### PR TITLE
fix: handle null buffer errors in audio attachments after undici upgrade

### DIFF
--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -10,7 +10,7 @@ const MessageTracker = require('./utils/messageTracker');
 const { botPrefix } = require('../../config');
 
 // Create a shared message tracker instance
-let messageTracker = new MessageTracker();
+const messageTracker = new MessageTracker();
 
 // Default command context that can be overridden for testing
 let commandContext = {

--- a/src/utils/media/audioHandler.js
+++ b/src/utils/media/audioHandler.js
@@ -8,7 +8,7 @@
  */
 
 const nodeFetch = require('node-fetch');
-const { Readable } = require('stream');
+const { AttachmentBuilder } = require('discord.js');
 const logger = require('../../logger');
 const urlValidator = require('../urlValidator');
 
@@ -220,7 +220,28 @@ async function downloadAudioFile(url) {
     }
 
     // Read the response as an array buffer
-    const buffer = await response.arrayBuffer();
+    let buffer;
+    try {
+      buffer = await response.arrayBuffer();
+    } catch (error) {
+      logger.error(`[AudioHandler] Failed to read response as array buffer: ${error.message}`);
+      throw new Error(`Failed to read audio data: ${error.message}`);
+    }
+
+    // Validate buffer
+    if (!buffer) {
+      logger.error('[AudioHandler] Response returned null or undefined buffer');
+      throw new Error('Audio download returned empty data');
+    }
+
+    // Check buffer size
+    const bufferSize = buffer.byteLength;
+    if (bufferSize === 0) {
+      logger.error('[AudioHandler] Downloaded audio file is empty');
+      throw new Error('Downloaded audio file is empty');
+    }
+
+    logger.info(`[AudioHandler] Successfully downloaded audio file: ${filename} (${bufferSize} bytes)`);
 
     return {
       buffer,
@@ -239,16 +260,36 @@ async function downloadAudioFile(url) {
  * @returns {Object} - Discord.js compatible attachment object
  */
 function createDiscordAttachment(audioFile) {
+  // Validate input
+  if (!audioFile || !audioFile.buffer) {
+    logger.error('[AudioHandler] Invalid audio file object - missing buffer');
+    throw new Error('Cannot create attachment from invalid audio file');
+  }
+
   // Convert ArrayBuffer to Buffer
-  const nodeBuffer = Buffer.from(audioFile.buffer);
+  let nodeBuffer;
+  try {
+    nodeBuffer = Buffer.from(audioFile.buffer);
+  } catch (error) {
+    logger.error(`[AudioHandler] Failed to convert ArrayBuffer to Buffer: ${error.message}`);
+    throw new Error('Failed to create buffer from audio data');
+  }
 
-  // Create a readable stream from the buffer
-  const stream = new Readable();
-  stream.push(nodeBuffer);
-  stream.push(null);
+  // Validate buffer is not empty
+  if (!nodeBuffer || nodeBuffer.length === 0) {
+    logger.error('[AudioHandler] Buffer is empty or invalid');
+    throw new Error('Audio buffer is empty');
+  }
 
+  // Discord.js v14 requires AttachmentBuilder for files
+  const attachmentBuilder = new AttachmentBuilder(nodeBuffer, {
+    name: audioFile.filename,
+    description: `Audio file: ${audioFile.filename}`
+  });
+
+  // Return in the format expected by our webhook system
   return {
-    attachment: stream,
+    attachment: attachmentBuilder,
     name: audioFile.filename,
     contentType: audioFile.contentType,
   };

--- a/src/utils/media/imageHandler.js
+++ b/src/utils/media/imageHandler.js
@@ -8,7 +8,7 @@
  */
 
 const nodeFetch = require('node-fetch');
-const { Readable } = require('stream');
+const { AttachmentBuilder } = require('discord.js');
 const logger = require('../../logger');
 const urlValidator = require('../urlValidator');
 
@@ -244,13 +244,15 @@ function createDiscordAttachment(imageFile) {
   // Convert ArrayBuffer to Buffer
   const nodeBuffer = Buffer.from(imageFile.buffer);
 
-  // Create a readable stream from the buffer
-  const stream = new Readable();
-  stream.push(nodeBuffer);
-  stream.push(null);
+  // Discord.js v14 requires AttachmentBuilder for files
+  const attachmentBuilder = new AttachmentBuilder(nodeBuffer, {
+    name: imageFile.filename,
+    description: `Image file: ${imageFile.filename}`
+  });
 
+  // Return in the format expected by our webhook system
   return {
-    attachment: stream,
+    attachment: attachmentBuilder,
     name: imageFile.filename,
     contentType: imageFile.contentType,
   };

--- a/src/utils/media/mediaHandler.js
+++ b/src/utils/media/mediaHandler.js
@@ -339,12 +339,22 @@ function prepareAttachmentOptions(attachments) {
     return {};
   }
 
+  // For Discord.js v14, if attachment is already an AttachmentBuilder, use it directly
   return {
-    files: attachments.map(attachment => ({
-      attachment: attachment.attachment,
-      name: attachment.name,
-      contentType: attachment.contentType,
-    })),
+    files: attachments.map(attachment => {
+      // If it's already an AttachmentBuilder instance, return it directly
+      if (attachment.attachment && attachment.attachment.constructor && 
+          attachment.attachment.constructor.name === 'AttachmentBuilder') {
+        return attachment.attachment;
+      }
+      
+      // Otherwise, maintain backward compatibility with the old format
+      return {
+        attachment: attachment.attachment,
+        name: attachment.name,
+        contentType: attachment.contentType,
+      };
+    }),
   };
 }
 

--- a/tests/unit/utils/media/audioHandler.test.js
+++ b/tests/unit/utils/media/audioHandler.test.js
@@ -4,12 +4,20 @@
 
 const audioHandler = require('../../../../src/utils/media/audioHandler');
 const nodeFetch = require('node-fetch');
-const { Readable } = require('stream');
 const logger = require('../../../../src/logger');
 const urlValidator = require('../../../../src/utils/urlValidator');
+const { AttachmentBuilder } = require('discord.js');
 
 // Mock the dependencies
 jest.mock('node-fetch');
+jest.mock('discord.js', () => ({
+  AttachmentBuilder: jest.fn().mockImplementation((buffer, options) => ({
+    constructor: { name: 'AttachmentBuilder' },
+    attachment: buffer,
+    name: options?.name,
+    description: options?.description,
+  })),
+}));
 jest.mock('../../../../src/logger', () => ({
   debug: jest.fn(),
   info: jest.fn(),
@@ -437,9 +445,19 @@ describe('audioHandler', () => {
       const result = audioHandler.createDiscordAttachment(audioFile);
       
       expect(result).toHaveProperty('attachment');
-      expect(result.attachment).toBeInstanceOf(Readable);
+      expect(result.attachment).toHaveProperty('constructor');
+      expect(result.attachment.constructor.name).toBe('AttachmentBuilder');
       expect(result).toHaveProperty('name', 'audio.mp3');
       expect(result).toHaveProperty('contentType', 'audio/mpeg');
+      
+      // Verify AttachmentBuilder was called correctly
+      expect(AttachmentBuilder).toHaveBeenCalledWith(
+        expect.any(Buffer),
+        expect.objectContaining({
+          name: 'audio.mp3',
+          description: 'Audio file: audio.mp3'
+        })
+      );
     });
   });
 

--- a/tests/unit/utils/media/imageHandler.test.js
+++ b/tests/unit/utils/media/imageHandler.test.js
@@ -7,6 +7,16 @@ const imageHandler = require('../../../../src/utils/media/imageHandler');
 jest.mock('node-fetch');
 const nodeFetch = require('node-fetch');
 
+// Mock Discord.js
+jest.mock('discord.js', () => ({
+  AttachmentBuilder: jest.fn().mockImplementation((buffer, options) => ({
+    constructor: { name: 'AttachmentBuilder' },
+    attachment: buffer,
+    name: options?.name,
+    description: options?.description,
+  })),
+}));
+
 // Mock the logger
 jest.mock('../../../../src/logger');
 const logger = require('../../../../src/logger');


### PR DESCRIPTION
After upgrading undici, audio attachments started failing with "Cannot read properties of null (reading 'byteLength')" errors. This was due to stricter stream handling in newer versions and Discord.js v14 requirements.

Changes:
- Add null/undefined buffer validation in downloadAudioFile
- Check buffer size to ensure non-empty downloads
- Add proper error handling in createDiscordAttachment
- Use AttachmentBuilder for Discord.js v14 compatibility
- Update prepareAttachmentOptions to handle AttachmentBuilder instances
- Apply same fix to imageHandler for consistency
- Update tests to expect AttachmentBuilder instead of Buffer
- Convert messageTracker from let to const in commands/index.js

The key fix is using Discord.js v14's AttachmentBuilder class instead of passing raw Buffers or streams, which resolves the undici compatibility issues.

🤖 Generated with [Claude Code](https://claude.ai/code)