### PR TITLE
revert: restore original stream-based media handlers

### DIFF
--- a/src/utils/media/mediaHandler.js
+++ b/src/utils/media/mediaHandler.js
@@ -13,11 +13,10 @@
  * 3. Media attachment creation (converting URLs to Discord attachments)
  */
 
-const { AttachmentBuilder } = require('discord.js');
 const logger = require('../../logger');
 const audioHandler = require('./audioHandler');
 const imageHandler = require('./imageHandler');
-const _urlValidator = require('../urlValidator');
+const urlValidator = require('../urlValidator');
 
 /**
  * Detect and process media in a Discord message
@@ -161,8 +160,8 @@ async function detectMedia(message, messageContent, options = {}) {
 
   // Referenced media should be handled separately by aiService, not included in current message
   const useReferencedMedia = false;
-  const _referencedAudioUrl = options.referencedAudioUrl;
-  const _referencedImageUrl = options.referencedImageUrl;
+  const referencedAudioUrl = options.referencedAudioUrl;
+  const referencedImageUrl = options.referencedImageUrl;
 
   // Note: We no longer automatically include referenced media in the current message
   // Referenced media is handled separately in the aiService formatApiMessages function
@@ -340,25 +339,12 @@ function prepareAttachmentOptions(attachments) {
     return {};
   }
 
-  // For Discord.js v14, if attachment is already an AttachmentBuilder, use it directly
   return {
-    files: attachments.map(attachment => {
-      // If it's already an AttachmentBuilder instance, return it directly
-      if (attachment.attachment instanceof AttachmentBuilder) {
-        logger.debug('[MediaHandler] Using AttachmentBuilder directly for Discord.js v14');
-        return attachment.attachment;
-      }
-      
-      // Log what we're getting if it's not an AttachmentBuilder
-      logger.debug(`[MediaHandler] Attachment is not AttachmentBuilder, type: ${typeof attachment.attachment}, constructor: ${attachment.attachment?.constructor?.name}`);
-      
-      // Otherwise, maintain backward compatibility with the old format
-      return {
-        attachment: attachment.attachment,
-        name: attachment.name,
-        contentType: attachment.contentType,
-      };
-    }),
+    files: attachments.map(attachment => ({
+      attachment: attachment.attachment,
+      name: attachment.name,
+      contentType: attachment.contentType,
+    })),
   };
 }
 

--- a/tests/unit/utils/media/audioHandler.test.js
+++ b/tests/unit/utils/media/audioHandler.test.js
@@ -6,18 +6,10 @@ const audioHandler = require('../../../../src/utils/media/audioHandler');
 const nodeFetch = require('node-fetch');
 const logger = require('../../../../src/logger');
 const urlValidator = require('../../../../src/utils/urlValidator');
-const { AttachmentBuilder } = require('discord.js');
+const { Readable } = require('stream');
 
 // Mock the dependencies
 jest.mock('node-fetch');
-jest.mock('discord.js', () => ({
-  AttachmentBuilder: jest.fn().mockImplementation((buffer, options) => ({
-    constructor: { name: 'AttachmentBuilder' },
-    attachment: buffer,
-    name: options?.name,
-    description: options?.description,
-  })),
-}));
 jest.mock('../../../../src/logger', () => ({
   debug: jest.fn(),
   info: jest.fn(),
@@ -48,309 +40,256 @@ describe('audioHandler', () => {
       },
       arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(1024)),
       body: {
-        getReader: jest.fn().mockReturnValue({
-          read: jest.fn().mockResolvedValue({ done: false, value: new Uint8Array(10) }),
-          cancel: jest.fn()
-        })
+        on: jest.fn(),
+        pipe: jest.fn()
       }
     };
     
-    // Reset mock behavior
-    nodeFetch.mockReset();
-    
-    // Set default mock implementation
+    // Setup node-fetch mock
     nodeFetch.mockResolvedValue(mockResponse);
   });
-
+  
   describe('hasAudioExtension', () => {
+    it('should return true for valid audio extensions', () => {
+      expect(audioHandler.hasAudioExtension('song.mp3')).toBe(true);
+      expect(audioHandler.hasAudioExtension('audio.wav')).toBe(true);
+      expect(audioHandler.hasAudioExtension('track.ogg')).toBe(true);
+      expect(audioHandler.hasAudioExtension('music.m4a')).toBe(true);
+      expect(audioHandler.hasAudioExtension('audio.flac')).toBe(true);
+      expect(audioHandler.hasAudioExtension('SONG.MP3')).toBe(true); // Case insensitive
+    });
+    
     it('should return true for URLs with audio extensions', () => {
-      expect(audioHandler.hasAudioExtension('https://example.com/audio.mp3')).toBe(true);
-      expect(audioHandler.hasAudioExtension('https://example.com/audio.wav')).toBe(true);
-      expect(audioHandler.hasAudioExtension('https://example.com/audio.ogg')).toBe(true);
-      expect(audioHandler.hasAudioExtension('https://example.com/audio.m4a')).toBe(true);
-      expect(audioHandler.hasAudioExtension('https://example.com/audio.flac')).toBe(true);
-      
-      // With query parameters
-      expect(audioHandler.hasAudioExtension('https://example.com/audio.mp3?param=value')).toBe(true);
+      expect(audioHandler.hasAudioExtension('https://example.com/song.mp3')).toBe(true);
+      expect(audioHandler.hasAudioExtension('http://example.com/path/to/audio.wav')).toBe(true);
+      expect(audioHandler.hasAudioExtension('https://example.com/file.mp3?query=123')).toBe(true);
     });
-
-    it('should return false for URLs without audio extensions', () => {
-      expect(audioHandler.hasAudioExtension('https://example.com/audio.txt')).toBe(false);
-      expect(audioHandler.hasAudioExtension('https://example.com/audio')).toBe(false);
-      expect(audioHandler.hasAudioExtension('https://example.com/audio.pdf')).toBe(false);
+    
+    it('should return false for non-audio extensions', () => {
+      expect(audioHandler.hasAudioExtension('document.pdf')).toBe(false);
+      expect(audioHandler.hasAudioExtension('image.jpg')).toBe(false);
+      expect(audioHandler.hasAudioExtension('video.mp4')).toBe(false);
+      expect(audioHandler.hasAudioExtension('archive.zip')).toBe(false);
     });
-
-    it('should return false for invalid URLs', () => {
-      // Non-URL strings without audio extensions should return false
-      expect(audioHandler.hasAudioExtension('not-a-url')).toBe(false);
+    
+    it('should return false for empty or invalid input', () => {
       expect(audioHandler.hasAudioExtension('')).toBe(false);
       expect(audioHandler.hasAudioExtension(null)).toBe(false);
       expect(audioHandler.hasAudioExtension(undefined)).toBe(false);
     });
-
-    it('should handle the specific problematic case from logs', () => {
-      // This test verifies the fix for the specific issue in the logs
-      const urlFromLogs = 'https://example.com/audio.mp3';
-      const filenameFromLogs = 'audio.mp3';
-
-      // Both the full URL and just the filename should return true
-      expect(audioHandler.hasAudioExtension(urlFromLogs)).toBe(true);
-      expect(audioHandler.hasAudioExtension(filenameFromLogs)).toBe(true);
-    });
-
-    it('should handle invalid URL formats', () => {
-      // Mock URL validator to return false for invalid URLs
-      urlValidator.isValidUrlFormat
-        .mockReturnValueOnce(false) // for 'http://[invalid url].mp3'
-        .mockReturnValueOnce(false); // for 'https://.mp3'
-      
-      // Invalid URL should return false even with .mp3 extension
-      expect(audioHandler.hasAudioExtension('http://[invalid url].mp3')).toBe(false);
-      expect(audioHandler.hasAudioExtension('https://.mp3')).toBe(false);
-    });
-
-    it('should be case-insensitive for extensions', () => {
-      expect(audioHandler.hasAudioExtension('audio.MP3')).toBe(true);
-      expect(audioHandler.hasAudioExtension('audio.WaV')).toBe(true);
-      expect(audioHandler.hasAudioExtension('audio.OGG')).toBe(true);
+    
+    it('should return false for invalid URLs with audio extensions', () => {
+      urlValidator.isValidUrlFormat.mockReturnValue(false);
+      expect(audioHandler.hasAudioExtension('https://invalid url.mp3')).toBe(false);
     });
   });
-
+  
   describe('isAudioUrl', () => {
-    it('should return true for valid audio URLs with proper content-type', async () => {
-      const result = await audioHandler.isAudioUrl('https://example.com/audio.mp3');
+    beforeEach(() => {
+      urlValidator.isValidUrlFormat.mockReturnValue(true);
+    });
+    
+    it('should return true for URLs with audio extensions when trustExtensions is true', async () => {
+      const result = await audioHandler.isAudioUrl('https://example.com/song.mp3', { trustExtensions: true });
       expect(result).toBe(true);
+      expect(nodeFetch).not.toHaveBeenCalled(); // Should trust extension without fetching
     });
-
-    it('should return true for URLs with audio extensions even if fetch fails', async () => {
-      // Mock a failed fetch
-      nodeFetch.mockRejectedValueOnce(new Error('Network error'));
-      
-      const result = await audioHandler.isAudioUrl('https://example.com/audio.mp3');
-      expect(result).toBe(true);
-    });
-
-    it('should return false for invalid URLs', async () => {
-      // Mock URL validator to return false for invalid URL
-      urlValidator.isValidUrlFormat.mockReturnValueOnce(false);
-      
-      const result = await audioHandler.isAudioUrl('not-a-url');
-      expect(result).toBe(false);
-    });
-
-    it('should trust URLs with audio extensions when trustExtensions is true', async () => {
-      const result = await audioHandler.isAudioUrl('https://example.com/audio.mp3', { trustExtensions: true });
-      expect(result).toBe(true);
-      // Should not make a fetch call
-      expect(nodeFetch).not.toHaveBeenCalled();
-    });
-
-    it('should validate URLs without extensions when trustExtensions is false', async () => {
-      nodeFetch.mockResolvedValueOnce({
+    
+    it('should validate URL by fetching when trustExtensions is false', async () => {
+      const mockResponse = {
         ok: true,
         headers: {
           get: jest.fn().mockReturnValue('audio/mpeg')
         }
-      });
+      };
+      nodeFetch.mockResolvedValue(mockResponse);
       
-      const result = await audioHandler.isAudioUrl('https://example.com/audio', { trustExtensions: false });
+      const result = await audioHandler.isAudioUrl('https://example.com/song.mp3', { trustExtensions: false });
+      
       expect(result).toBe(true);
-      expect(nodeFetch).toHaveBeenCalled();
+      expect(nodeFetch).toHaveBeenCalledWith(
+        'https://example.com/song.mp3',
+        expect.objectContaining({
+          method: 'HEAD'
+        })
+      );
     });
-
-    it('should handle non-OK response status', async () => {
-      nodeFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 404,
-        headers: {
-          get: jest.fn().mockReturnValue('text/html')
-        }
-      });
+    
+    it('should return false for invalid URL format', async () => {
+      urlValidator.isValidUrlFormat.mockReturnValue(false);
       
-      // With default trustExtensions=true and .mp3 extension, it should return true
-      const result = await audioHandler.isAudioUrl('https://example.com/notfound.mp3');
-      expect(result).toBe(true); // Because it has .mp3 extension and trustExtensions is true
+      const result = await audioHandler.isAudioUrl('not a valid url');
+      expect(result).toBe(false);
+      expect(nodeFetch).not.toHaveBeenCalled();
     });
-
-    it('should accept application/octet-stream content type', async () => {
-      nodeFetch.mockResolvedValueOnce({
+    
+    it('should return false when server returns non-OK status', async () => {
+      const mockResponse = {
+        ok: false,
+        status: 404
+      };
+      nodeFetch.mockResolvedValue(mockResponse);
+      urlValidator.isValidUrlFormat.mockReturnValue(true);
+      
+      const result = await audioHandler.isAudioUrl('https://example.com/notfound.mp3', { trustExtensions: false });
+      expect(result).toBe(false);
+    });
+    
+    it('should handle octet-stream content type', async () => {
+      const mockResponse = {
         ok: true,
         headers: {
           get: jest.fn().mockReturnValue('application/octet-stream')
         }
-      });
+      };
+      nodeFetch.mockResolvedValue(mockResponse);
       
-      const result = await audioHandler.isAudioUrl('https://example.com/audio.bin');
+      const result = await audioHandler.isAudioUrl('https://example.com/audio', { trustExtensions: false });
       expect(result).toBe(true);
-    });
-
-    it('should handle missing content-type header with audio extension', async () => {
-      nodeFetch.mockResolvedValueOnce({
-        ok: true,
-        headers: {
-          get: jest.fn().mockReturnValue(null)
-        }
-      });
-      
-      const result = await audioHandler.isAudioUrl('https://example.com/audio.mp3');
-      expect(result).toBe(true);
-    });
-
-    it('should reject non-audio content types', async () => {
-      nodeFetch.mockResolvedValueOnce({
-        ok: true,
-        headers: {
-          get: jest.fn().mockReturnValue('text/html')
-        }
-      });
-      
-      const result = await audioHandler.isAudioUrl('https://example.com/page');
-      expect(result).toBe(false);
-    });
-
-    it('should handle timeout with AbortController', async () => {
-      // Mock a slow response that will trigger timeout
-      nodeFetch.mockImplementationOnce(() => 
-        new Promise((resolve) => {
-          setTimeout(() => resolve({
-            ok: true,
-            headers: { get: jest.fn().mockReturnValue('audio/mpeg') }
-          }), 10000);
-        })
-      );
-      
-      const result = await audioHandler.isAudioUrl('https://example.com/slow.mp3', { timeout: 100 });
-      expect(result).toBe(true); // Should trust extension on timeout
-    });
-  });
-
-  describe('extractAudioUrls', () => {
-    it('should extract audio URLs from files domain', () => {
-      const content = 'Check out this audio file: https://files.example.org/ha-shem-keev-ima-rxk-2025-05-18-16-48-24.mp3 it sounds great!';
-      const result = audioHandler.extractAudioUrls(content);
-      
-      expect(result).toHaveLength(1);
-      expect(result[0].url).toBe('https://files.example.org/ha-shem-keev-ima-rxk-2025-05-18-16-48-24.mp3');
-      expect(result[0].filename).toBe('ha-shem-keev-ima-rxk-2025-05-18-16-48-24.mp3');
-      expect(result[0].matchedPattern).toBe('files');
-    });
-
-    it('should extract multiple audio URLs', () => {
-      const content = `Here are two audio files:
-      https://files.example.org/ha-shem-keev-ima-rxk-2025-05-18-16-48-24.mp3
-      and another one:
-      https://files.example.org/ba-et-zelda-nya-bol-2025-05-19-12-30-45.mp3`;
-      
-      const result = audioHandler.extractAudioUrls(content);
-      
-      expect(result).toHaveLength(2);
-      expect(result[0].url).toBe('https://files.example.org/ha-shem-keev-ima-rxk-2025-05-18-16-48-24.mp3');
-      expect(result[1].url).toBe('https://files.example.org/ba-et-zelda-nya-bol-2025-05-19-12-30-45.mp3');
     });
     
-    it('should extract audio URLs from generic domains', () => {
-      const content = 'Check these out: https://example.com/audio/mysong.mp3 and https://audio-site.org/files/podcast.ogg?size=large';
+    it('should return true for audio extension even with fetch error when trustExtensions is true', async () => {
+      nodeFetch.mockRejectedValue(new Error('Network error'));
+      
+      const result = await audioHandler.isAudioUrl('https://example.com/song.mp3');
+      expect(result).toBe(true); // Should trust extension despite error
+    });
+    
+    it('should use injected timers for timeout', async () => {
+      jest.useFakeTimers();
+      const mockSetTimeout = jest.fn(globalThis.setTimeout);
+      const mockClearTimeout = jest.fn(globalThis.clearTimeout);
+      
+      audioHandler.configureTimers({
+        setTimeout: mockSetTimeout,
+        clearTimeout: mockClearTimeout
+      });
+      
+      const mockResponse = {
+        ok: true,
+        headers: {
+          get: jest.fn().mockReturnValue('audio/mpeg')
+        }
+      };
+      nodeFetch.mockResolvedValue(mockResponse);
+      
+      await audioHandler.isAudioUrl('https://example.com/test.mp3', { trustExtensions: false });
+      
+      expect(mockSetTimeout).toHaveBeenCalled();
+      expect(mockClearTimeout).toHaveBeenCalled();
+      
+      jest.useRealTimers();
+    });
+  });
+  
+  describe('extractAudioUrls', () => {
+    it('should extract audio URLs from text', () => {
+      const content = 'Check out this song: https://example.com/song.mp3 and this one https://example.com/track.wav';
       const result = audioHandler.extractAudioUrls(content);
       
       expect(result).toHaveLength(2);
-      expect(result[0].url).toBe('https://example.com/audio/mysong.mp3');
-      expect(result[0].filename).toBe('mysong.mp3');
-      expect(result[0].matchedPattern).toBe('generic');
-      
-      expect(result[1].url).toBe('https://audio-site.org/files/podcast.ogg?size=large');
-      expect(result[1].filename).toBe('podcast.ogg');
-      expect(result[1].matchedPattern).toBe('generic');
+      expect(result[0]).toEqual({
+        url: 'https://example.com/song.mp3',
+        filename: 'song.mp3',
+        matchedPattern: 'generic'
+      });
+      expect(result[1]).toEqual({
+        url: 'https://example.com/track.wav',
+        filename: 'track.wav',
+        matchedPattern: 'generic'
+      });
     });
     
     it('should handle URLs with query parameters', () => {
-      const content = 'Listen to this: https://example.com/download.mp3?user=123&token=abc';
+      const content = 'Listen to https://example.com/audio.mp3?id=123&token=abc';
       const result = audioHandler.extractAudioUrls(content);
       
       expect(result).toHaveLength(1);
-      expect(result[0].url).toBe('https://example.com/download.mp3?user=123&token=abc');
-      expect(result[0].filename).toBe('download.mp3');
-      expect(result[0].matchedPattern).toBe('generic');
+      expect(result[0]).toEqual({
+        url: 'https://example.com/audio.mp3?id=123&token=abc',
+        filename: 'audio.mp3',
+        matchedPattern: 'generic'
+      });
     });
-
-    it('should return an empty array for content without audio URLs', () => {
-      const content = 'This is a message without any audio URLs.';
+    
+    it('should categorize Discord CDN URLs', () => {
+      const content = 'Audio: https://cdn.discordapp.com/attachments/123/456/voice.mp3';
+      const result = audioHandler.extractAudioUrls(content);
+      
+      expect(result).toHaveLength(1);
+      expect(result[0].matchedPattern).toBe('discord');
+    });
+    
+    it('should categorize files domain URLs', () => {
+      const content = 'Download: https://files.example.com/audio.mp3';
+      const result = audioHandler.extractAudioUrls(content);
+      
+      expect(result).toHaveLength(1);
+      expect(result[0].matchedPattern).toBe('files');
+    });
+    
+    it('should return empty array for no audio URLs', () => {
+      const content = 'This text has no audio URLs, just some regular text.';
       const result = audioHandler.extractAudioUrls(content);
       
       expect(result).toHaveLength(0);
     });
-
-    it('should return an empty array for null or invalid input', () => {
-      expect(audioHandler.extractAudioUrls(null)).toHaveLength(0);
-      expect(audioHandler.extractAudioUrls(undefined)).toHaveLength(0);
-      expect(audioHandler.extractAudioUrls(123)).toHaveLength(0);
-      expect(audioHandler.extractAudioUrls({})).toHaveLength(0);
+    
+    it('should handle empty or invalid input', () => {
+      expect(audioHandler.extractAudioUrls('')).toEqual([]);
+      expect(audioHandler.extractAudioUrls(null)).toEqual([]);
+      expect(audioHandler.extractAudioUrls(undefined)).toEqual([]);
+      expect(audioHandler.extractAudioUrls(123)).toEqual([]);
     });
   });
-
+  
   describe('downloadAudioFile', () => {
-    it('should download an audio file and return buffer, filename and contentType', async () => {
-      // Reset mocks to ensure clean state after previous test
-      jest.clearAllMocks();
-      
-      // Create a custom mock implementation for this specific test
-      const originalDownloadAudioFile = audioHandler.downloadAudioFile;
-      
-      // Replace with our mock implementation that returns consistent values
-      audioHandler.downloadAudioFile = jest.fn().mockImplementation(async (url) => {
-        // Mock fetch call to ensure it was called with the URL
-        nodeFetch(url, expect.any(Object));
-        
-        // Return a predictable result
-        return {
-          buffer: new ArrayBuffer(1024),
-          filename: 'audio.mp3',
-          contentType: 'audio/mpeg'
-        };
-      });
-      
-      const result = await audioHandler.downloadAudioFile('https://example.com/audio.mp3');
-      
-      expect(nodeFetch).toHaveBeenCalledWith('https://example.com/audio.mp3', expect.any(Object));
-      expect(result).toHaveProperty('buffer');
-      expect(result).toHaveProperty('filename', 'audio.mp3');
-      expect(result).toHaveProperty('contentType', 'audio/mpeg');
-      
-      // Restore original implementation
-      audioHandler.downloadAudioFile = originalDownloadAudioFile;
-    });
-
-    it('should throw an error if the download fails', async () => {
-      // Clear all mocks
-      jest.clearAllMocks();
-      
-      // Mock a failed fetch
-      nodeFetch.mockReset(); // Reset all implementations
-      nodeFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 404,
-        statusText: 'Not Found',
-        // Mock other methods that might be called
-        arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(0)),
+    beforeEach(() => {
+      const mockResponse = {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
         headers: {
-          get: jest.fn().mockReturnValue('audio/mpeg')
-        }
-      });
-      
-      // Replace the implementation to make it throw the expected error
-      const originalDownloadAudioFile = audioHandler.downloadAudioFile;
-      audioHandler.downloadAudioFile = jest.fn().mockImplementation(async (url) => {
-        throw new Error('Failed to download audio file: 404 Not Found');
-      });
-      
-      await expect(audioHandler.downloadAudioFile('https://example.com/audio.mp3'))
-        .rejects.toThrow('Failed to download audio file: 404 Not Found');
-        
-      // Restore original function
-      audioHandler.downloadAudioFile = originalDownloadAudioFile;
+          get: jest.fn().mockImplementation(header => {
+            if (header === 'content-type') return 'audio/mpeg';
+            return null;
+          })
+        },
+        arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(1024))
+      };
+      nodeFetch.mockResolvedValue(mockResponse);
     });
-
-    it('should handle URLs without extensions and generate filename', async () => {
-      nodeFetch.mockResolvedValueOnce({
+    
+    it('should download audio file successfully', async () => {
+      const url = 'https://example.com/song.mp3';
+      const result = await audioHandler.downloadAudioFile(url);
+      
+      expect(result).toHaveProperty('buffer');
+      expect(result).toHaveProperty('filename', 'song.mp3');
+      expect(result).toHaveProperty('contentType', 'audio/mpeg');
+      expect(result.buffer).toBeInstanceOf(ArrayBuffer);
+      
+      expect(nodeFetch).toHaveBeenCalledWith(
+        url,
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.objectContaining({
+            'User-Agent': expect.any(String),
+            Accept: expect.stringContaining('audio/')
+          })
+        })
+      );
+    });
+    
+    it('should generate filename when URL has no extension', async () => {
+      const url = 'https://example.com/audio';
+      const result = await audioHandler.downloadAudioFile(url);
+      
+      expect(result.filename).toMatch(/^audio_\d+\.mp3$/);
+    });
+    
+    it('should use appropriate extension based on content type', async () => {
+      const mockResponse = {
         ok: true,
         headers: {
           get: jest.fn().mockImplementation(header => {
@@ -359,81 +298,70 @@ describe('audioHandler', () => {
           })
         },
         arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(1024))
-      });
+      };
+      nodeFetch.mockResolvedValue(mockResponse);
       
-      const result = await audioHandler.downloadAudioFile('https://example.com/stream');
+      const url = 'https://example.com/audio';
+      const result = await audioHandler.downloadAudioFile(url);
       
       expect(result.filename).toMatch(/^audio_\d+\.ogg$/);
       expect(result.contentType).toBe('audio/ogg');
     });
-
-    it('should extract filename from URL path', async () => {
-      nodeFetch.mockResolvedValueOnce({
+    
+    it('should handle download errors', async () => {
+      const mockResponse = {
+        ok: false,
+        status: 404,
+        statusText: 'Not Found'
+      };
+      nodeFetch.mockResolvedValue(mockResponse);
+      
+      await expect(audioHandler.downloadAudioFile('https://example.com/notfound.mp3'))
+        .rejects.toThrow('Failed to download audio file: 404 Not Found');
+    });
+    
+    it('should handle network errors', async () => {
+      nodeFetch.mockRejectedValue(new Error('Network error'));
+      
+      await expect(audioHandler.downloadAudioFile('https://example.com/song.mp3'))
+        .rejects.toThrow('Network error');
+    });
+    
+    it('should clean filename from query parameters', async () => {
+      const url = 'https://example.com/song.mp3?token=abc123';
+      const result = await audioHandler.downloadAudioFile(url);
+      
+      expect(result.filename).toBe('song.mp3');
+    });
+    
+    it('should use injected timers for timeout', async () => {
+      jest.useFakeTimers();
+      const mockSetTimeout = jest.fn(globalThis.setTimeout);
+      const mockClearTimeout = jest.fn(globalThis.clearTimeout);
+      
+      audioHandler.configureTimers({
+        setTimeout: mockSetTimeout,
+        clearTimeout: mockClearTimeout
+      });
+      
+      const mockResponse = {
         ok: true,
         headers: {
           get: jest.fn().mockReturnValue('audio/mpeg')
         },
         arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(1024))
-      });
+      };
+      nodeFetch.mockResolvedValue(mockResponse);
       
-      const result = await audioHandler.downloadAudioFile('https://example.com/path/to/song.mp3?token=123');
+      await audioHandler.downloadAudioFile('https://example.com/test.mp3');
       
-      expect(result.filename).toBe('song.mp3');
-    });
-
-    it('should handle different audio content types', async () => {
-      const contentTypes = [
-        { contentType: 'audio/wav', extension: 'wav' },
-        { contentType: 'audio/ogg', extension: 'ogg' },
-        { contentType: 'audio/mpeg', extension: 'mp3' },
-        { contentType: 'audio/unknown', extension: 'mp3' } // default
-      ];
+      expect(mockSetTimeout).toHaveBeenCalledWith(expect.any(Function), 30000);
+      expect(mockClearTimeout).toHaveBeenCalled();
       
-      for (const { contentType, extension } of contentTypes) {
-        nodeFetch.mockResolvedValueOnce({
-          ok: true,
-          headers: {
-            get: jest.fn().mockReturnValue(contentType)
-          },
-          arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(1024))
-        });
-        
-        const result = await audioHandler.downloadAudioFile('https://example.com/audio');
-        expect(result.filename).toMatch(new RegExp(`\\.${extension}$`));
-      }
-    });
-
-    it('should handle timeout during download', async () => {
-      // Use fake timers for this test
-      jest.useFakeTimers();
-      
-      // Create an abort error that will be thrown when timeout occurs
-      const abortError = new Error('The operation was aborted');
-      abortError.name = 'AbortError';
-      
-      // Mock fetch to reject after a delay
-      let rejectFn;
-      nodeFetch.mockImplementationOnce(() => new Promise((resolve, reject) => {
-        rejectFn = reject;
-      }));
-      
-      // Start the download
-      const downloadPromise = audioHandler.downloadAudioFile('https://example.com/slow.mp3');
-      
-      // Advance timers to trigger the timeout (30 seconds)
-      jest.advanceTimersByTime(30000);
-      
-      // Manually reject the promise to simulate abort
-      if (rejectFn) rejectFn(abortError);
-      
-      // The download should reject
-      await expect(downloadPromise).rejects.toThrow();
-      
-      // Restore real timers
       jest.useRealTimers();
     });
   });
-
+  
   describe('createDiscordAttachment', () => {
     it('should create a Discord attachment from an audio file', () => {
       const audioFile = {
@@ -444,38 +372,47 @@ describe('audioHandler', () => {
       
       const result = audioHandler.createDiscordAttachment(audioFile);
       
-      // createDiscordAttachment returns AttachmentBuilder directly
+      // createDiscordAttachment returns an object with stream, name, and contentType
       expect(result).toBeDefined();
-      expect(result.attachment).toBeDefined(); // The mock has an attachment property
+      expect(result.attachment).toBeInstanceOf(Readable);
       expect(result.name).toBe('audio.mp3');
-      expect(result.description).toBe('Audio file: audio.mp3');
+      expect(result.contentType).toBe('audio/mpeg');
+    });
+    
+    it('should convert ArrayBuffer to Buffer correctly', () => {
+      const testData = new Uint8Array([1, 2, 3, 4, 5]);
+      const audioFile = {
+        buffer: testData.buffer,
+        filename: 'test.mp3',
+        contentType: 'audio/mpeg'
+      };
       
-      // Verify AttachmentBuilder was called correctly
-      expect(AttachmentBuilder).toHaveBeenCalledWith(
-        expect.any(Buffer),
-        expect.objectContaining({
-          name: 'audio.mp3',
-          description: 'Audio file: audio.mp3'
-        })
-      );
+      const result = audioHandler.createDiscordAttachment(audioFile);
+      
+      // Check that the stream contains the correct data
+      const chunks = [];
+      result.attachment.on('data', chunk => chunks.push(chunk));
+      result.attachment.on('end', () => {
+        const buffer = Buffer.concat(chunks);
+        expect(buffer).toEqual(Buffer.from(testData));
+      });
     });
   });
-
+  
   describe('processAudioUrls', () => {
-    it('should process audio URLs and return updated content with attachments', async () => {
-      // Clean mocks and set up specific behavior for this test
-      jest.clearAllMocks();
-      
-      // Set up successful download mock
-      nodeFetch.mockResolvedValueOnce({
+    beforeEach(() => {
+      const mockResponse = {
         ok: true,
         headers: {
           get: jest.fn().mockReturnValue('audio/mpeg')
         },
         arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(1024))
-      });
-      
-      const content = 'Check out this audio file: https://files.example.org/ha-shem-keev-ima-rxk-2025-05-18-16-48-24.mp3 it sounds great!';
+      };
+      nodeFetch.mockResolvedValue(mockResponse);
+    });
+    
+    it('should process audio URLs and return updated content with attachments', async () => {
+      const content = 'Check out this audio file: https://cdn.discordapp.com/attachments/956701187273338941/1252372899048448020/ha-shem-keev-ima-rxk-2025-05-18-16-48-24.mp3 it sounds great!';
       
       const result = await audioHandler.processAudioUrls(content);
       
@@ -490,76 +427,48 @@ describe('audioHandler', () => {
       expect(result.attachments[0]).toHaveProperty('name', 'ha-shem-keev-ima-rxk-2025-05-18-16-48-24.mp3');
       expect(result.attachments[0]).toHaveProperty('contentType', 'audio/mpeg');
       
-      // The attachment should be an AttachmentBuilder instance (from our mock)
-      const attachmentBuilder = result.attachments[0].attachment;
-      expect(attachmentBuilder).toBeDefined();
-      expect(attachmentBuilder.name).toBe('ha-shem-keev-ima-rxk-2025-05-18-16-48-24.mp3');
+      // The attachment should be a Readable stream
+      const attachment = result.attachments[0];
+      expect(attachment.attachment).toBeInstanceOf(Readable);
+      expect(attachment.name).toBe('ha-shem-keev-ima-rxk-2025-05-18-16-48-24.mp3');
+      expect(attachment.contentType).toBe('audio/mpeg');
     });
-
+    
     it('should return original content and empty attachments if no audio URLs found', async () => {
-      const content = 'This is a message without any audio URLs.';
+      const content = 'This is just plain text without any audio URLs.';
       
       const result = await audioHandler.processAudioUrls(content);
       
-      expect(result).toHaveProperty('content', content);
-      expect(result).toHaveProperty('attachments');
-      expect(result.attachments).toHaveLength(0);
+      expect(result.content).toBe(content);
+      expect(result.attachments).toEqual([]);
     });
-
-    it('should return original content and empty attachments if download fails', async () => {
-      const content = 'Check out this audio file: https://files.example.org/ha-shem-keev-ima-rxk-2025-05-18-16-48-24.mp3 it sounds great!';
+    
+    it('should handle download errors gracefully', async () => {
+      nodeFetch.mockRejectedValue(new Error('Download failed'));
       
-      // Mock a failed download
-      nodeFetch.mockRejectedValueOnce(new Error('Download failed'));
-      
+      const content = 'Audio here: https://example.com/song.mp3';
       const result = await audioHandler.processAudioUrls(content);
       
-      expect(result).toHaveProperty('content', content);
-      expect(result).toHaveProperty('attachments');
-      expect(result.attachments).toHaveLength(0);
+      expect(result.content).toBe(content); // Original content preserved
+      expect(result.attachments).toEqual([]);
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to process audio URL'));
     });
-
-    it('should process first audio URL when multiple are present', async () => {
-      const content = 'Audio 1: https://example.com/first.mp3 and Audio 2: https://example.com/second.mp3';
-      
-      nodeFetch.mockResolvedValueOnce({
-        ok: true,
-        headers: {
-          get: jest.fn().mockReturnValue('audio/mpeg')
-        },
-        arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(1024))
-      });
+    
+    it('should process only the first audio URL', async () => {
+      const content = 'First: https://example.com/song1.mp3 Second: https://example.com/song2.wav';
       
       const result = await audioHandler.processAudioUrls(content);
       
-      // Should only process the first URL
-      expect(result.content).toBe('Audio 1:  and Audio 2: https://example.com/second.mp3');
+      expect(result.content).toBe('First:  Second: https://example.com/song2.wav');
       expect(result.attachments).toHaveLength(1);
-      expect(result.attachments[0].name).toBe('first.mp3');
+      expect(result.attachments[0].name).toBe('song1.mp3');
     });
-
-    it('should handle Discord CDN URLs', async () => {
-      const content = 'Discord audio: https://cdn.discordapp.com/attachments/123/456/audio.mp3';
-      
-      nodeFetch.mockResolvedValueOnce({
-        ok: true,
-        headers: {
-          get: jest.fn().mockReturnValue('audio/mpeg')
-        },
-        arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(1024))
-      });
-      
-      const result = await audioHandler.processAudioUrls(content);
-      
-      expect(result.content).toBe('Discord audio: ');
-      expect(result.attachments).toHaveLength(1);
-    });
-
-    it('should handle null or invalid input', async () => {
+    
+    it('should handle invalid input gracefully', async () => {
       expect(await audioHandler.processAudioUrls(null)).toEqual({ content: null, attachments: [] });
       expect(await audioHandler.processAudioUrls(undefined)).toEqual({ content: undefined, attachments: [] });
+      expect(await audioHandler.processAudioUrls('')).toEqual({ content: '', attachments: [] });
       expect(await audioHandler.processAudioUrls(123)).toEqual({ content: 123, attachments: [] });
-      expect(await audioHandler.processAudioUrls({})).toEqual({ content: {}, attachments: [] });
     });
   });
 });

--- a/tests/unit/utils/media/mediaHandler.test.js
+++ b/tests/unit/utils/media/mediaHandler.test.js
@@ -5,26 +5,6 @@
 jest.mock('../../../../src/logger');
 jest.mock('node-fetch');
 
-// Mock Discord.js
-jest.mock('discord.js', () => {
-  const mockInstances = [];
-  
-  class MockAttachmentBuilder {
-    constructor(buffer, options) {
-      this.attachment = buffer;
-      this.name = options?.name;
-      this.description = options?.description;
-      mockInstances.push(this);
-    }
-  }
-  
-  MockAttachmentBuilder._instances = mockInstances;
-  
-  return {
-    AttachmentBuilder: MockAttachmentBuilder
-  };
-});
-
 // Mock the audio and image handlers
 jest.mock('../../../../src/utils/media/audioHandler', () => ({
   processAudioUrls: jest.fn(),
@@ -181,26 +161,6 @@ describe('Media Handler', () => {
           { attachment: 'buffer2', name: 'file2.jpg', contentType: 'image/jpeg' }
         ]
       });
-    });
-    
-    it('should return AttachmentBuilder instances directly when present', () => {
-      const { AttachmentBuilder } = require('discord.js');
-      
-      // Create mock AttachmentBuilder instances
-      const mockAttachmentBuilder1 = new AttachmentBuilder(Buffer.from('test1'), { name: 'file1.mp3' });
-      const mockAttachmentBuilder2 = new AttachmentBuilder(Buffer.from('test2'), { name: 'file2.jpg' });
-      
-      const attachments = [
-        { attachment: mockAttachmentBuilder1, name: 'file1.mp3', contentType: 'audio/mpeg' },
-        { attachment: mockAttachmentBuilder2, name: 'file2.jpg', contentType: 'image/jpeg' }
-      ];
-      
-      const result = mediaHandler.prepareAttachmentOptions(attachments);
-      
-      expect(result).toHaveProperty('files');
-      expect(result.files).toHaveLength(2);
-      expect(result.files[0]).toBe(mockAttachmentBuilder1);
-      expect(result.files[1]).toBe(mockAttachmentBuilder2);
     });
   });
   


### PR DESCRIPTION
Reverted all media handlers to their original stream-based implementations that work correctly with undici 6.x.

Key changes:
- audioHandler.js: Restored Readable stream usage, removed AttachmentBuilder
- imageHandler.js: Restored Readable stream usage, removed AttachmentBuilder
- mediaHandler.js: Removed AttachmentBuilder checking and Discord.js import
- Fixed all test expectations to match stream-based behavior
- Maintained injectable timer patterns for testability

The handlers now return stream-based attachments instead of AttachmentBuilder instances, which is compatible with the undici 6.x that Discord.js 14.19.3 expects.

This completes the rollback to the working state before attempting to fix the undici v7 compatibility issue.

🤖 Generated with [Claude Code](https://claude.ai/code)