### PR TITLE
fix: prevent false alias collision detection when display name alread…

### DIFF
--- a/src/core/personality/PersonalityManager.js
+++ b/src/core/personality/PersonalityManager.js
@@ -397,11 +397,12 @@ class PersonalityManager {
       }
       
       // Set the alternate alias
-      this.registry.setAlias(alternateAlias, fullName);
+      this.registry.setAlias(alternateAlias.toLowerCase(), fullName);
       logger.info(`[PersonalityManager] Created alternate alias ${alternateAlias} for ${fullName} (${displayName} was taken)`);
     } else {
       // Alias is available, use it directly
-      this.registry.setAlias(displayName, fullName);
+      this.registry.setAlias(lowerAlias, fullName);
+      logger.info(`[PersonalityManager] Set display name alias '${lowerAlias}' for ${fullName}`);
     }
   }
 

--- a/src/personalityManager.js
+++ b/src/personalityManager.js
@@ -71,7 +71,19 @@ function getPersonality(fullName) {
  * Set a personality alias (backward compatibility wrapper)
  */
 async function setPersonalityAlias(alias, fullName, skipSave = false, isDisplayName = false) {
-  // If isDisplayName is true and alias already exists, create alternate aliases
+  // Trim the alias to remove any leading/trailing spaces
+  alias = alias.trim();
+  
+  
+  // Check if the alias already exists
+  const existingPersonality = personalityManager.getPersonalityByAlias(alias.toLowerCase());
+  if (existingPersonality && existingPersonality.fullName === fullName) {
+    // Alias already points to this personality, no need to set it again
+    logger.info(`Alias ${alias} already points to ${fullName} - no changes needed`);
+    return { success: true };
+  }
+  
+  // If isDisplayName is true and alias already exists for a different personality, create alternate aliases
   if (isDisplayName && personalityManager.personalityAliases.has(alias.toLowerCase())) {
     const alternateAliases = [];
     let alternateAlias = alias;


### PR DESCRIPTION
…y set

When a personality is registered, the display name is automatically set as an alias. The add command then tries to set the same alias again, which was incorrectly detected as a collision, causing a random suffix to be generated.

- Check if alias already points to same personality before creating alternates
- Trim aliases to remove any leading/trailing spaces
- Return early if alias is already correctly set

This fixes the issue where personalities were getting aliases like "spiderman-abc123" when "spiderman" wasn't actually taken by another personality.

🤖 Generated with [Claude Code](https://claude.ai/code)