### PR TITLE
fix/conversation tracking logging

### DIFF
--- a/src/core/conversation/ConversationTracker.js
+++ b/src/core/conversation/ConversationTracker.js
@@ -69,7 +69,7 @@ class ConversationTracker {
       });
     });
     
-    logger.debug(`[ConversationTracker] Recorded conversation for ${key} with personality ${personalityName}, isDM: ${isDM}, isMentionOnly: ${isMentionOnly}`);
+    logger.info(`[ConversationTracker] Recorded conversation for ${key} with personality ${personalityName}, isDM: ${isDM}, isMentionOnly: ${isMentionOnly}, messageIds: ${messageIdArray.join(', ')}`);
   }
 
   /**
@@ -85,10 +85,11 @@ class ConversationTracker {
     const conversation = this.activeConversations.get(key);
     
     if (!conversation) {
+      logger.debug(`[ConversationTracker] No active conversation found for ${key}`);
       return null;
     }
     
-    logger.debug(`[ConversationTracker] Checking active conversation for ${key}: isMentionOnly=${conversation.isMentionOnly}, isDM=${isDM}, autoResponseEnabled=${autoResponseEnabled}`);
+    logger.info(`[ConversationTracker] Checking active conversation for ${key}: isMentionOnly=${conversation.isMentionOnly}, isDM=${isDM}, autoResponseEnabled=${autoResponseEnabled}, personalityName=${conversation.personalityName}`);
     
     // If this was a mention-only conversation in a guild channel, don't continue it
     if (!isDM && conversation.isMentionOnly) {

--- a/src/handlers/messageHandler.js
+++ b/src/handlers/messageHandler.js
@@ -503,6 +503,12 @@ async function handleActiveConversation(message, client) {
   // Check if auto-response is enabled for this user
   const autoResponseEnabled = isAutoResponseEnabled(message.author.id);
   
+  logger.info(
+    `[MessageHandler] Checking for active conversation - User: ${message.author.id}, ` +
+    `Channel: ${message.channel.id}, isDM: ${message.channel.isDMBased()}, ` +
+    `autoResponseEnabled: ${autoResponseEnabled}`
+  );
+  
   // Check for active conversation
   const activePersonalityName = getActivePersonality(
     message.author.id, 
@@ -514,7 +520,7 @@ async function handleActiveConversation(message, client) {
     return false; // No active conversation
   }
 
-  logger.debug(`Found active conversation with: ${activePersonalityName}`);
+  logger.info(`[MessageHandler] Found active conversation with: ${activePersonalityName}`);
 
   // First try to get personality directly by full name
   let personality = getPersonality(activePersonalityName);

--- a/src/handlers/personalityHandler.js
+++ b/src/handlers/personalityHandler.js
@@ -22,11 +22,17 @@ const personalityAuth = require('../utils/personalityAuth');
 const threadHandler = require('../utils/threadHandler');
 
 // Injectable timer functions for testability
+// Using the injectable pattern as documented in docs/core/TIMER_PATTERNS.md
+const globalSetTimeout = setTimeout;
+const globalClearTimeout = clearTimeout;
+const globalSetInterval = setInterval;
+const globalClearInterval = clearInterval;
+
 let timerFunctions = {
-  setTimeout: (callback, delay, ...args) => setTimeout(callback, delay, ...args),
-  clearTimeout: (id) => clearTimeout(id),
-  setInterval: (callback, delay, ...args) => setInterval(callback, delay, ...args),
-  clearInterval: (id) => clearInterval(id)
+  setTimeout: (callback, delay, ...args) => globalSetTimeout(callback, delay, ...args),
+  clearTimeout: (id) => globalClearTimeout(id),
+  setInterval: (callback, delay, ...args) => globalSetInterval(callback, delay, ...args),
+  clearInterval: (id) => globalClearInterval(id)
 };
 
 /**
@@ -739,6 +745,13 @@ async function handlePersonalityInteraction(
     // 3. A reply to another user's message
     // Only DMs or autoresponse-enabled channels should have continuous conversations
     const isMentionOnly = !message.channel.isDMBased() && !autoResponseEnabled;
+    
+    logger.info(
+      `[PersonalityHandler] Recording conversation - User: ${conversationUserId}, Channel: ${message.channel.id}, ` +
+      `Personality: ${personality.fullName}, isDM: ${message.channel.isDMBased()}, ` +
+      `autoResponseEnabled: ${autoResponseEnabled}, isMentionOnly: ${isMentionOnly}, ` +
+      `triggeringMention: ${triggeringMention}`
+    );
     
     recordConversationData(
       conversationUserId,


### PR DESCRIPTION
Added comprehensive logging to track down autoresponse issue:
- Log when conversations are recorded with all parameters
- Log when checking for active conversations
- Log the full state including isMentionOnly flag

This will help diagnose why conversations continue after replies in guild channels without autoresponse enabled.

🤖 Generated with [Claude Code](https://claude.ai/code)