### PR TITLE
feat: invalidate profile cache when removing personality

### DIFF
--- a/src/commands/handlers/remove.js
+++ b/src/commands/handlers/remove.js
@@ -11,6 +11,7 @@ const {
   removePersonality,
 } = require('../../personalityManager');
 const { botPrefix } = require('../../../config');
+const { deleteFromCache } = require('../../profileInfoFetcher');
 
 /**
  * Command metadata
@@ -88,6 +89,10 @@ async function execute(message, args, context = {}) {
         `Failed to remove the personality. It may not exist or you may not have permission.`
       );
     }
+
+    // Clear the profile info cache for this personality
+    deleteFromCache(personality.fullName);
+    logger.info(`[RemoveCommand] Cleared profile cache for: ${personality.fullName}`);
 
     // Clear the completed add command tracking to allow immediate re-adding
     tracker.removeCompletedAddCommand(message.author.id, personalityName);

--- a/src/core/api/ProfileInfoCache.js
+++ b/src/core/api/ProfileInfoCache.js
@@ -84,6 +84,19 @@ class ProfileInfoCache {
   }
 
   /**
+   * Delete a specific profile from cache
+   * @param {string} profileName - The profile name to delete
+   * @returns {boolean} True if the profile was deleted, false if it didn't exist
+   */
+  delete(profileName) {
+    const deleted = this.cache.delete(profileName);
+    if (deleted) {
+      logger.debug(`${this.logPrefix} Deleted profile from cache: ${profileName}`);
+    }
+    return deleted;
+  }
+
+  /**
    * Get the current cache size
    * @returns {number} Number of cached entries
    */

--- a/src/core/api/ProfileInfoFetcher.js
+++ b/src/core/api/ProfileInfoFetcher.js
@@ -190,6 +190,15 @@ class ProfileInfoFetcher {
   }
 
   /**
+   * Delete a specific profile from cache
+   * @param {string} profileName - The profile name to delete
+   * @returns {boolean} True if the profile was deleted
+   */
+  deleteFromCache(profileName) {
+    return this.cache.delete(profileName);
+  }
+
+  /**
    * Get cache instance (for testing)
    */
   getCache() {

--- a/src/profileInfoFetcher.js
+++ b/src/profileInfoFetcher.js
@@ -119,11 +119,21 @@ function clearCache() {
   getFetcher().clearCache();
 }
 
+/**
+ * Delete a specific profile from the cache
+ * @param {string} profileName - The profile name to delete
+ * @returns {boolean} True if the profile was deleted
+ */
+function deleteFromCache(profileName) {
+  return getFetcher().deleteFromCache(profileName);
+}
+
 // Export the module
 module.exports = {
   fetchProfileInfo,
   getProfileAvatarUrl,
   getProfileDisplayName,
+  deleteFromCache,
   // For testing
   _testing: {
     clearCache,

--- a/tests/unit/commands/handlers/remove.test.js
+++ b/tests/unit/commands/handlers/remove.test.js
@@ -8,6 +8,23 @@ jest.mock('discord.js');
 jest.mock('../../../../src/logger');
 jest.mock('../../../../config', () => ({
   botPrefix: '!tz',
+  isDevelopment: false,
+  APP_ID: 'test-app-id',
+  API_KEY: 'test-api-key'
+}));
+jest.mock('../../../../src/profileInfoFetcher', () => ({
+  fetchProfileInfo: jest.fn(),
+  getProfileAvatarUrl: jest.fn(),
+  getProfileDisplayName: jest.fn(),
+  deleteFromCache: jest.fn(),
+  _testing: {
+    clearCache: jest.fn(),
+    getCache: jest.fn(),
+    setFetchImplementation: jest.fn(),
+    getRateLimiter: jest.fn(),
+    getFetcher: jest.fn(),
+    resetFetcher: jest.fn()
+  }
 }));
 
 // Import enhanced test helpers
@@ -129,6 +146,9 @@ describe('Remove Command', () => {
   });
   
   it('should remove a personality by name', async () => {
+    // Import the mocked profileInfoFetcher after other mocks are set up
+    const profileInfoFetcher = require('../../../../src/profileInfoFetcher');
+    
     await removeCommand.execute(mockMessage, ['test-personality']);
     
     // Verify personality lookups
@@ -144,6 +164,9 @@ describe('Remove Command', () => {
       'test-personality'
     );
     
+    // Verify profile cache was invalidated
+    expect(profileInfoFetcher.deleteFromCache).toHaveBeenCalledWith('test-personality');
+    
     // Verify embed was created correctly
     expect(mockEmbed.setTitle).toHaveBeenCalledWith('Personality Removed');
     expect(mockEmbed.setDescription).toHaveBeenCalledWith(
@@ -156,6 +179,9 @@ describe('Remove Command', () => {
   });
   
   it('should remove a personality by alias', async () => {
+    // Import the mocked profileInfoFetcher after other mocks are set up
+    const profileInfoFetcher = require('../../../../src/profileInfoFetcher');
+    
     // Set up mock for alias lookup
     const mockPersonality = {
       fullName: 'full-personality-name',
@@ -180,6 +206,9 @@ describe('Remove Command', () => {
       mockMessage.author.id,
       'full-personality-name'
     );
+    
+    // Verify profile cache was invalidated with the full name
+    expect(profileInfoFetcher.deleteFromCache).toHaveBeenCalledWith('full-personality-name');
     
     // Verify embed was created correctly
     expect(mockEmbed.setTitle).toHaveBeenCalledWith('Personality Removed');


### PR DESCRIPTION
- Add delete method to ProfileInfoCache for removing specific entries
- Add deleteFromCache method to ProfileInfoFetcher
- Export deleteFromCache from profileInfoFetcher module
- Update remove command to invalidate cache after successful removal
- Add tests to verify cache invalidation on personality removal

This ensures that when a personality is removed and re-added with a new profile picture, the old cached avatar URL won't be used.

🤖 Generated with [Claude Code](https://claude.ai/code)