### PR TITLE
fix: prevent duplicate CI runs on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,14 @@ name: CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
   pull_request:
     branches: [ main, develop ]
+
+# Cancel in-progress runs for the same workflow and branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:


### PR DESCRIPTION
## Problem
CI was running twice on pull requests:
1. Once for the push to the feature branch
2. Once for the pull_request event

This caused duplicate checks and wasted CI resources.

## Solution
- Only trigger push builds on main branch
- Pull request builds still run for PRs targeting main or develop
- Added concurrency group to cancel old runs when new commits are pushed

## Result
- Single CI run per PR instead of duplicate runs
- Faster feedback on PR status
- Reduced CI resource usage