### PR TITLE
fix: update sync scripts to use rebase for linear history

### DIFF
--- a/docs/development/WORKFLOW_SUMMARY.md
+++ b/docs/development/WORKFLOW_SUMMARY.md
@@ -42,6 +42,7 @@ git push origin feat/my-feature
 git sync-develop
 
 # That's it! One command and you're synced.
+# Note: This uses rebase + force push to maintain linear history
 ```
 
 ## The Entire Workflow

--- a/scripts/sync-develop.sh
+++ b/scripts/sync-develop.sh
@@ -16,20 +16,21 @@ echo "🌿 Switching to develop branch..."
 git checkout develop
 git pull origin develop
 
-# Merge main into develop
-echo "🔀 Merging main into develop..."
-if git merge origin/main -m "chore: sync develop with main after release [skip ci]"; then
-    echo "✅ Merge successful!"
+# Rebase develop onto main
+echo "🔀 Rebasing develop onto main..."
+if git rebase origin/main; then
+    echo "✅ Rebase successful!"
     
-    # Push to origin
-    echo "📤 Pushing to origin..."
-    git push origin develop
+    # Push to origin (force needed after rebase)
+    echo "📤 Pushing to origin (with force-with-lease for safety)..."
+    git push origin develop --force-with-lease
     
     echo "✨ Develop is now synced with main!"
 else
-    echo "❌ Merge failed - there might be conflicts"
+    echo "❌ Rebase failed - there might be conflicts"
     echo "Resolve conflicts manually, then run:"
-    echo "  git push origin develop"
+    echo "  git rebase --continue  # After fixing conflicts"
+    echo "  git push origin develop --force-with-lease"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
Updates the sync scripts to use rebase instead of merge, maintaining linear git history.

## Problem
- The sync scripts were using `git merge`, which would create merge commits
- This conflicts with the repository's rebase-only policy
- Would cause the 'X commits behind, Y ahead' issue to reoccur

## Solution
- Updated `sync-develop.sh` to use `git rebase origin/main`
- Updated git alias `sync-develop` to use rebase
- Both now use `--force-with-lease` for safe force pushing
- Updated documentation to note the force push requirement

## Testing
After merging this PR, we'll test the sync script to ensure it works correctly with the rebase workflow.