### PR TITLE
fix: ensure NSFW verification uses consistent data directory path

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -8,6 +8,7 @@
 const AuthManager = require('./core/authentication');
 const logger = require('./logger');
 const { botConfig } = require('../config');
+const { getDataDirectory } = require('./dataStorage');
 
 // Create singleton instance
 let authManager = null;
@@ -99,6 +100,7 @@ async function initAuth() {
       serviceApiBaseUrl: `${process.env.SERVICE_API_BASE_URL}/v1`,
       ownerId: process.env.OWNER_ID,
       isDevelopment: botConfig.isDevelopment,
+      dataDir: getDataDirectory(), // Use the same data directory as dataStorage.js
     });
 
     try {

--- a/src/dataStorage.js
+++ b/src/dataStorage.js
@@ -19,12 +19,20 @@ const path = require('path');
 const logger = require('./logger');
 
 /**
+ * Get the appropriate data directory path for the current environment
+ * @returns {string} The data directory path
+ */
+function getDataDirectory() {
+  return process.env.RAILWAY_ENVIRONMENT
+    ? '/app/data' // Use Railway persistent volume when deployed
+    : path.join(__dirname, '..', 'data'); // Use local data directory in development
+}
+
+/**
  * Path to the data storage directory
  * @constant {string}
  */
-const DATA_DIR = process.env.RAILWAY_ENVIRONMENT
-  ? '/app/data' // Use Railway persistent volume when deployed
-  : path.join(__dirname, '..', 'data'); // Use local data directory in development
+const DATA_DIR = getDataDirectory();
 
 /**
  * Initialize the data storage
@@ -133,4 +141,5 @@ module.exports = {
   initStorage,
   saveData,
   loadData,
+  getDataDirectory,
 };


### PR DESCRIPTION
## Summary

Fixes NSFW verification persistence issue on Railway by ensuring AuthManager uses the same data directory path as the main dataStorage module.

**Problem**: NSFW verification files weren't persisting on Railway because:
- `dataStorage.js` correctly used `/app/data` for Railway environment
- `AuthPersistence.js` defaulted to `process.cwd() + '/data'` which resolves differently

**Solution**: Extract shared data directory logic to prevent path inconsistencies.

## Changes

- Extract `getDataDirectory()` function from dataStorage.js for reusability
- Update AuthManager initialization to use shared data directory logic  
- Prevents Railway environment from using wrong path for NSFW verification
- Eliminates code duplication and ensures path consistency across modules

## Impact

- ✅ NSFW verification will now persist correctly on Railway
- ✅ Eliminates "copy-paste then diverge" anti-pattern
- ✅ Single source of truth for data directory path logic
- ✅ Improved maintainability for future environment changes

## Test Plan

- [x] Local tests pass (auth.test.js)
- [x] Pre-commit checks pass
- [x] ESLint warnings are pre-existing (not introduced by this change)
- [x] Deploy to Railway and verify NSFW verification persistence
- [x] Check logs show both "Loaded X user tokens" and "Loaded X NSFW verification records"

## Related Issues

Resolves the Railway deployment issue where user tokens persisted correctly but NSFW verification always showed "No NSFW verification file found, starting with empty store".

🤖 Generated with [Claude Code](https://claude.ai/code)