### PR TITLE
feat: add personality-specific error messages

### DIFF
--- a/docs/improvements/PROFILE_DATA_ENHANCEMENT.md
+++ b/docs/improvements/PROFILE_DATA_ENHANCEMENT.md
@@ -237,10 +237,16 @@ const embed = new EmbedBuilder()
 
 ## Quick Wins (Can do immediately)
 
-1. **Error Messages** (2 hours)
-   - Extract error_message field
-   - Use in error handlers
-   - Immediate UX improvement
+1. **Error Messages** (2 hours) ✅ COMPLETED
+   - Extract error_message field ✅
+   - Use in error handlers ✅
+   - Immediate UX improvement ✅
+   - Implementation Notes:
+     - Added `getProfileErrorMessage()` to profileInfoFetcher
+     - Updated PersonalityManager to fetch and store errorMessage field
+     - Modified aiErrorHandler to use personality-specific messages
+     - Properly handles reference ID insertion into existing error patterns
+     - Falls back to default messages when personality has no error_message
 
 2. **Status in Info** (1 hour)
    - Extract status field

--- a/src/commands/handlers/debug.js
+++ b/src/commands/handlers/debug.js
@@ -58,10 +58,12 @@ async function execute(message, args) {
     case 'unverify': {
       const nsfwManager = getNsfwVerificationManager();
       const cleared = nsfwManager.clearVerification(message.author.id);
-      
+
       if (cleared) {
         logger.info(`[Debug] NSFW verification cleared for ${message.author.tag}`);
-        return await directSend('✅ Your NSFW verification has been cleared. You are now unverified.');
+        return await directSend(
+          '✅ Your NSFW verification has been cleared. You are now unverified.'
+        );
       } else {
         return await directSend('❌ You were not verified, so nothing was cleared.');
       }
@@ -71,7 +73,9 @@ async function execute(message, args) {
       try {
         // Clear conversation for all personalities in current channel
         clearConversation(message.author.id, message.channel.id);
-        logger.info(`[Debug] Conversation history cleared for ${message.author.tag} in channel ${message.channel.id}`);
+        logger.info(
+          `[Debug] Conversation history cleared for ${message.author.tag} in channel ${message.channel.id}`
+        );
         return await directSend('✅ Cleared your conversation history in this channel.');
       } catch (error) {
         logger.error(`[Debug] Error clearing conversation: ${error.message}`);
@@ -84,7 +88,9 @@ async function execute(message, args) {
         // Clean up expired auth tokens
         await auth.cleanupExpiredTokens();
         logger.info(`[Debug] Authentication tokens cleaned up for ${message.author.tag}`);
-        return await directSend('✅ Cleaned up authentication tokens. You may need to re-authenticate.');
+        return await directSend(
+          '✅ Cleaned up authentication tokens. You may need to re-authenticate.'
+        );
       } catch (error) {
         logger.error(`[Debug] Error clearing auth: ${error.message}`);
         return await directSend('❌ Failed to clear authentication.');
@@ -107,16 +113,16 @@ async function execute(message, args) {
         // Gather various statistics
         const stats = {
           webhooks: {
-            tracked: 'Not available' // webhookUserTracker doesn't expose a count method
+            tracked: 'Not available', // webhookUserTracker doesn't expose a count method
           },
           messages: {
-            tracked: messageTracker.size
+            tracked: messageTracker.size,
           },
           auth: {
-            hasManager: !!auth.getAuthManager()
-          }
+            hasManager: !!auth.getAuthManager(),
+          },
         };
-        
+
         const statsText = `📊 **Debug Statistics**\n\`\`\`json\n${JSON.stringify(stats, null, 2)}\n\`\`\``;
         return await directSend(statsText);
       } catch (error) {

--- a/src/core/authentication/AuthPersistence.js
+++ b/src/core/authentication/AuthPersistence.js
@@ -183,7 +183,6 @@ class AuthPersistence {
         modified: tokenStats.mtime,
       };
     } catch (_error) {
-       
       stats.files.authTokens = { exists: false };
     }
 
@@ -195,7 +194,6 @@ class AuthPersistence {
         modified: nsfwStats.mtime,
       };
     } catch (_error) {
-       
       stats.files.nsfwVerified = { exists: false };
     }
 

--- a/src/core/authentication/NsfwVerificationManager.js
+++ b/src/core/authentication/NsfwVerificationManager.js
@@ -164,7 +164,7 @@ class NsfwVerificationManager {
           systemType: proxySystemType,
         };
       }
-      
+
       // For guild channels, only NSFW channels are allowed
       if (channel.nsfw === true) {
         return {
@@ -192,15 +192,19 @@ class NsfwVerificationManager {
       // Auto-verify the user since they're already in an NSFW channel
       // This applies to both direct users and proxy users
       if (isProxy) {
-        logger.info(`[NsfwVerificationManager] Auto-verifying proxy user ${effectiveUserId} in NSFW channel ${channel.id}`);
+        logger.info(
+          `[NsfwVerificationManager] Auto-verifying proxy user ${effectiveUserId} in NSFW channel ${channel.id}`
+        );
       } else {
-        logger.info(`[NsfwVerificationManager] Auto-verifying user ${effectiveUserId} in NSFW channel ${channel.id}`);
+        logger.info(
+          `[NsfwVerificationManager] Auto-verifying user ${effectiveUserId} in NSFW channel ${channel.id}`
+        );
       }
       this.storeNsfwVerification(effectiveUserId, true);
-      
+
       return {
         isAllowed: true,
-        reason: isProxy 
+        reason: isProxy
           ? `Proxy user ${effectiveUserId} auto-verified in NSFW channel`
           : 'User auto-verified in NSFW channel',
         autoVerified: true,

--- a/src/core/personality/PersonalityManager.js
+++ b/src/core/personality/PersonalityManager.js
@@ -1,7 +1,11 @@
 const PersonalityRegistry = require('./PersonalityRegistry');
 const PersonalityPersistence = require('./PersonalityPersistence');
 const PersonalityValidator = require('./PersonalityValidator');
-const { getProfileAvatarUrl, getProfileDisplayName } = require('../../profileInfoFetcher');
+const {
+  getProfileAvatarUrl,
+  getProfileDisplayName,
+  getProfileErrorMessage,
+} = require('../../profileInfoFetcher');
 const logger = require('../../logger');
 
 /**
@@ -105,13 +109,15 @@ class PersonalityManager {
       // Fetch profile info if requested (default true unless fetchInfo is explicitly false)
       if (additionalData.fetchInfo !== false) {
         try {
-          const [avatarUrl, displayName] = await Promise.all([
+          const [avatarUrl, displayName, errorMessage] = await Promise.all([
             getProfileAvatarUrl(fullName),
             getProfileDisplayName(fullName),
+            getProfileErrorMessage(fullName),
           ]);
 
           if (avatarUrl) sanitized.avatarUrl = avatarUrl;
           if (displayName) sanitized.displayName = displayName;
+          if (errorMessage) sanitized.errorMessage = errorMessage;
         } catch (profileError) {
           logger.warn(
             `[PersonalityManager] Could not fetch profile info for ${fullName}: ${profileError.message}`
@@ -281,7 +287,6 @@ class PersonalityManager {
           ownerId = constants.USER_CONFIG.OWNER_ID;
         }
       } catch (_error) {
-         
         // Constants not available
       }
     }
@@ -302,7 +307,6 @@ class PersonalityManager {
         );
       }
     } catch (_error) {
-       
       // If constants not available, use default list
       expectedPersonalities = ['assistant', 'claude-3-opus', 'claude-3-sonnet', 'claude-3-haiku'];
     }

--- a/src/core/personality/PersonalityRegistry.js
+++ b/src/core/personality/PersonalityRegistry.js
@@ -24,7 +24,9 @@ class PersonalityRegistry {
       this.updateMaxWordCount();
     }
     const result = this._maxAliasWordCount || 1;
-    logger.debug(`[PersonalityRegistry] maxAliasWordCount getter returning: ${result} (internal value: ${this._maxAliasWordCount})`);
+    logger.debug(
+      `[PersonalityRegistry] maxAliasWordCount getter returning: ${result} (internal value: ${this._maxAliasWordCount})`
+    );
     return result;
   }
 
@@ -77,7 +79,7 @@ class PersonalityRegistry {
 
     // Check if any aliases being removed have the max word count
     let needsMaxUpdate = false;
-    
+
     // Remove all aliases pointing to this personality
     const aliasesToRemove = [];
     for (const [alias, targetName] of this.aliases.entries()) {
@@ -132,7 +134,10 @@ class PersonalityRegistry {
    * @returns {number} The number of words in the alias
    */
   getWordCount(alias) {
-    return alias.trim().split(/\s+/).filter(word => word.length > 0).length;
+    return alias
+      .trim()
+      .split(/\s+/)
+      .filter(word => word.length > 0).length;
   }
 
   /**
@@ -142,7 +147,7 @@ class PersonalityRegistry {
   updateMaxWordCount() {
     let max = 1;
     const multiWordAliases = [];
-    
+
     for (const alias of this.aliases.keys()) {
       const wordCount = this.getWordCount(alias);
       if (wordCount > 1) {
@@ -152,12 +157,14 @@ class PersonalityRegistry {
         max = wordCount;
       }
     }
-    
+
     this._maxAliasWordCount = max;
     logger.debug(`[PersonalityRegistry] Updated max alias word count to: ${max}`);
-    
+
     if (multiWordAliases.length > 0) {
-      logger.debug(`[PersonalityRegistry] Multi-word aliases found: ${multiWordAliases.join(', ')}`);
+      logger.debug(
+        `[PersonalityRegistry] Multi-word aliases found: ${multiWordAliases.join(', ')}`
+      );
     } else {
       logger.debug('[PersonalityRegistry] No multi-word aliases found in the system');
     }
@@ -172,12 +179,10 @@ class PersonalityRegistry {
   setAlias(alias, fullName) {
     // Handle null or invalid alias
     if (!alias || typeof alias !== 'string') {
-      logger.warn(
-        `[PersonalityRegistry] Invalid alias provided: ${alias}`
-      );
+      logger.warn(`[PersonalityRegistry] Invalid alias provided: ${alias}`);
       return false;
     }
-    
+
     if (!this.personalities.has(fullName)) {
       logger.warn(
         `[PersonalityRegistry] Cannot set alias for non-existent personality: ${fullName}`
@@ -203,17 +208,21 @@ class PersonalityRegistry {
 
     // Store in lowercase for case-insensitive matching
     this.aliases.set(lowerAlias, fullName);
-    
+
     // Update max word count if this alias has more words
     const wordCount = this.getWordCount(alias);
     const currentMax = this._maxAliasWordCount || 0;
-    logger.debug(`[PersonalityRegistry] Alias "${alias}" has ${wordCount} words, current max: ${currentMax}`);
-    
+    logger.debug(
+      `[PersonalityRegistry] Alias "${alias}" has ${wordCount} words, current max: ${currentMax}`
+    );
+
     if (wordCount > currentMax) {
       this._maxAliasWordCount = wordCount;
-      logger.info(`[PersonalityRegistry] New max alias word count: ${wordCount} (from alias: ${alias})`);
+      logger.info(
+        `[PersonalityRegistry] New max alias word count: ${wordCount} (from alias: ${alias})`
+      );
     }
-    
+
     logger.debug(`[PersonalityRegistry] Set alias ${alias} -> ${fullName}`);
     return true;
   }
@@ -228,7 +237,7 @@ class PersonalityRegistry {
     if (!alias) {
       return null;
     }
-    
+
     // Always do case-insensitive lookup
     const fullName = this.aliases.get(alias.toLowerCase());
     if (!fullName) {
@@ -245,7 +254,7 @@ class PersonalityRegistry {
   removeAlias(alias) {
     const lowerAlias = alias.toLowerCase();
     const removed = this.aliases.delete(lowerAlias);
-    
+
     if (removed) {
       // Check if we removed an alias with the max word count
       const removedWordCount = this.getWordCount(alias);
@@ -254,7 +263,7 @@ class PersonalityRegistry {
         this.updateMaxWordCount();
       }
     }
-    
+
     return removed;
   }
 
@@ -345,7 +354,7 @@ class PersonalityRegistry {
         }
       }
     }
-    
+
     // Set the max word count
     this._maxAliasWordCount = maxWords;
 

--- a/src/core/personality/PersonalityValidator.js
+++ b/src/core/personality/PersonalityValidator.js
@@ -227,7 +227,6 @@ class PersonalityValidator {
         return true;
       }
     } catch (_error) {
-       
       // Constants might not be available in all contexts
     }
 

--- a/src/handlers/personalityHandler.js
+++ b/src/handlers/personalityHandler.js
@@ -822,7 +822,7 @@ async function handlePersonalityInteraction(
     if (typingInterval) {
       timerFunctions.clearInterval(typingInterval);
     }
-    
+
     // CRITICAL: Always remove the request from tracking, even on error
     // This allows users to retry after failures (e.g., 500 errors from AI service)
     if (requestKey) {

--- a/src/handlers/referenceHandler.js
+++ b/src/handlers/referenceHandler.js
@@ -100,16 +100,22 @@ async function handleMessageReference(message, handlePersonalityInteraction, cli
 
         // First try to get personality directly as it could be a full name
         let personality = getPersonality(personalityName);
-        logger.debug(`Direct personality lookup for "${personalityName}": ${personality ? 'found' : 'not found'}`);
+        logger.debug(
+          `Direct personality lookup for "${personalityName}": ${personality ? 'found' : 'not found'}`
+        );
 
         // If not found as direct name, try it as an alias
         if (!personality) {
-          logger.debug(`Attempting alias lookup with userId: ${message.author.id} and name: ${personalityName}`);
+          logger.debug(
+            `Attempting alias lookup with userId: ${message.author.id} and name: ${personalityName}`
+          );
           personality = getPersonalityByAlias(personalityName);
           logger.debug(`Alias lookup result: ${personality ? 'found' : 'not found'}`);
         }
 
-        logger.debug(`Final personality lookup result: ${personality ? personality.fullName : 'null'}`);
+        logger.debug(
+          `Final personality lookup result: ${personality ? personality.fullName : 'null'}`
+        );
 
         if (personality) {
           // Process the message with this personality

--- a/src/logger.js
+++ b/src/logger.js
@@ -95,6 +95,8 @@ if (!isTest) {
 }
 
 // Log the active log level on startup
-logger.info(`Logger initialized with level: ${logger.level} (${botConfig.isDevelopment ? 'development' : 'production'} mode)`);
+logger.info(
+  `Logger initialized with level: ${logger.level} (${botConfig.isDevelopment ? 'development' : 'production'} mode)`
+);
 
 module.exports = logger;

--- a/src/profileInfoFetcher.js
+++ b/src/profileInfoFetcher.js
@@ -120,6 +120,40 @@ function clearCache() {
 }
 
 /**
+ * Get the error message for a profile
+ * @param {string} profileName - The profile's username
+ * @param {string} [userId] - Optional user ID for authentication
+ * @returns {Promise<string|null>} The error message or null if not found
+ */
+async function getProfileErrorMessage(profileName, userId = null) {
+  logger.info(`[ProfileInfoFetcher] Getting error message for: ${profileName}`);
+
+  try {
+    const profileInfo = await fetchProfileInfo(profileName, userId);
+
+    if (!profileInfo) {
+      logger.warn(`[ProfileInfoFetcher] No profile info found for error message: ${profileName}`);
+      return null;
+    }
+
+    // Check for error_message field in the response
+    if (profileInfo.error_message) {
+      logger.debug(
+        `[ProfileInfoFetcher] Found error message for ${profileName}: ${profileInfo.error_message.substring(0, 100)}...`
+      );
+      return profileInfo.error_message;
+    }
+
+    // No error message found in profile info
+    logger.debug(`[ProfileInfoFetcher] No error_message found for profile: ${profileName}`);
+    return null;
+  } catch (error) {
+    logger.error(`[ProfileInfoFetcher] Error getting error message: ${error.message}`);
+    return null;
+  }
+}
+
+/**
  * Delete a specific profile from the cache
  * @param {string} profileName - The profile name to delete
  * @returns {boolean} True if the profile was deleted
@@ -133,6 +167,7 @@ module.exports = {
   fetchProfileInfo,
   getProfileAvatarUrl,
   getProfileDisplayName,
+  getProfileErrorMessage,
   deleteFromCache,
   // For testing
   _testing: {

--- a/tests/unit/aiErrorHandler.personality.test.js
+++ b/tests/unit/aiErrorHandler.personality.test.js
@@ -1,0 +1,229 @@
+/**
+ * Tests for personality-specific error messages in aiErrorHandler
+ */
+
+// Mock dependencies
+jest.mock('../../src/logger');
+jest.mock('../../src/utils/errorTracker', () => ({
+  ErrorCategory: {
+    API_CONTENT: 'API_CONTENT',
+  },
+  trackError: jest.fn(),
+}));
+
+jest.mock('../../src/core/personality', () => ({
+  getPersonality: jest.fn(),
+}));
+
+const logger = require('../../src/logger');
+const { getPersonality } = require('../../src/core/personality');
+const { analyzeErrorAndGenerateMessage } = require('../../src/utils/aiErrorHandler');
+
+describe('AI Error Handler - Personality-Specific Messages', () => {
+  const mockAddToBlackoutList = jest.fn();
+  const mockContext = { userId: 'test-user-123', channelId: 'test-channel-123' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Set up logger mock
+    logger.info = jest.fn();
+    logger.debug = jest.fn();
+    logger.error = jest.fn();
+  });
+
+  describe('Personality error messages', () => {
+    it('should use personality error message when available', () => {
+      // Mock personality with error message
+      getPersonality.mockReturnValue({
+        fullName: 'test-personality',
+        errorMessage: '*sighs dramatically* Something went wrong! ||*(an error has occurred)*||',
+      });
+
+      const result = analyzeErrorAndGenerateMessage(
+        'NoneType object has no attribute',
+        'test-personality',
+        mockContext,
+        mockAddToBlackoutList
+      );
+
+      // Should replace the marker with reference ID
+      expect(result).toMatch(/\*sighs dramatically\* Something went wrong! \|\|\*\(an error has occurred; reference: \w+\)\*\|\|/);
+      expect(logger.info).toHaveBeenCalledWith(
+        '[AIErrorHandler] Using personality-specific error message for test-personality'
+      );
+    });
+
+    it('should append error marker if personality message does not have one', () => {
+      // Mock personality with error message without marker
+      getPersonality.mockReturnValue({
+        fullName: 'test-personality',
+        errorMessage: 'Oops! My circuits are fried!',
+      });
+
+      const result = analyzeErrorAndGenerateMessage(
+        'NoneType object has no attribute',
+        'test-personality',
+        mockContext,
+        mockAddToBlackoutList
+      );
+
+      // Should append the marker with reference ID
+      expect(result).toMatch(/Oops! My circuits are fried! \|\|\*\(an error has occurred; reference: \w+\)\*\|\|/);
+    });
+
+    it('should handle personality error messages with different spoiler patterns', () => {
+      // Mock personality with different spoiler pattern
+      getPersonality.mockReturnValue({
+        fullName: 'test-personality',
+        errorMessage: 'Error detected! ||*(system malfunction)*||',
+      });
+
+      const result = analyzeErrorAndGenerateMessage(
+        'NoneType object has no attribute',
+        'test-personality',
+        mockContext,
+        mockAddToBlackoutList
+      );
+
+      // Should update the existing spoiler pattern with reference
+      expect(result).toMatch(/Error detected! \|\|\*\(system malfunction; reference: \w+\)\*\|\|/);
+    });
+
+    it('should fall back to default messages when personality has no error message', () => {
+      // Mock personality without error message
+      getPersonality.mockReturnValue({
+        fullName: 'test-personality',
+        displayName: 'Test',
+      });
+
+      const result = analyzeErrorAndGenerateMessage(
+        'NoneType object has no attribute',
+        'test-personality',
+        mockContext,
+        mockAddToBlackoutList
+      );
+
+      // Should use default message
+      expect(result).toMatch(/I encountered a processing error.*\|\|\(Reference: \w+\)\|\|/);
+    });
+
+    it('should fall back to default messages when personality is not found', () => {
+      // Mock no personality found
+      getPersonality.mockReturnValue(null);
+
+      const result = analyzeErrorAndGenerateMessage(
+        '',
+        'unknown-personality',
+        mockContext,
+        mockAddToBlackoutList
+      );
+
+      // Should use default empty response message
+      expect(result).toMatch(/Hmm, I couldn't generate a response.*\|\|\(Reference: \w+\)\|\|/);
+    });
+
+    it('should handle errors when fetching personality data', () => {
+      // Mock error when getting personality
+      getPersonality.mockImplementation(() => {
+        throw new Error('Database error');
+      });
+
+      const result = analyzeErrorAndGenerateMessage(
+        'rate limit',
+        'test-personality',
+        mockContext,
+        mockAddToBlackoutList
+      );
+
+      // Should fall back to default message
+      expect(result).toMatch(/I'm getting too many requests.*\|\|\(Reference: \w+\)\|\|/);
+      expect(logger.debug).toHaveBeenCalledWith(
+        '[AIErrorHandler] Could not fetch personality data: Database error'
+      );
+    });
+
+    it('should generate unique reference IDs for each error', () => {
+      getPersonality.mockReturnValue({
+        fullName: 'test-personality',
+        errorMessage: 'Error! ||*(an error has occurred)*||',
+      });
+
+      const result1 = analyzeErrorAndGenerateMessage(
+        'error',
+        'test-personality',
+        mockContext,
+        mockAddToBlackoutList
+      );
+      const result2 = analyzeErrorAndGenerateMessage(
+        'error',
+        'test-personality',
+        mockContext,
+        mockAddToBlackoutList
+      );
+
+      // Extract reference IDs
+      const ref1 = result1.match(/reference: (\w+)/)[1];
+      const ref2 = result2.match(/reference: (\w+)/)[1];
+
+      expect(ref1).not.toBe(ref2);
+    });
+  });
+
+  describe('Error type detection with personality messages', () => {
+    beforeEach(() => {
+      // Set up personality with error message
+      getPersonality.mockReturnValue({
+        fullName: 'test-personality',
+        errorMessage: 'Oops! Something broke! ||*(an error has occurred)*||',
+      });
+    });
+
+    it('should use personality message for attribute errors', () => {
+      const result = analyzeErrorAndGenerateMessage(
+        "AttributeError: 'NoneType' object has no attribute 'text'",
+        'test-personality',
+        mockContext,
+        mockAddToBlackoutList
+      );
+
+      expect(result).toMatch(/Oops! Something broke!/);
+      expect(mockAddToBlackoutList).toHaveBeenCalledWith(
+        'test-personality',
+        mockContext,
+        5 * 60 * 1000 // Technical errors get 5 minutes
+      );
+    });
+
+    it('should use personality message for empty responses', () => {
+      const result = analyzeErrorAndGenerateMessage(
+        '',
+        'test-personality',
+        mockContext,
+        mockAddToBlackoutList
+      );
+
+      expect(result).toMatch(/Oops! Something broke!/);
+      expect(mockAddToBlackoutList).toHaveBeenCalledWith(
+        'test-personality',
+        mockContext,
+        30 * 1000 // User-friendly errors get 30 seconds
+      );
+    });
+
+    it('should use personality message for rate limit errors', () => {
+      const result = analyzeErrorAndGenerateMessage(
+        'Too many requests. Rate limit exceeded.',
+        'test-personality',
+        mockContext,
+        mockAddToBlackoutList
+      );
+
+      expect(result).toMatch(/Oops! Something broke!/);
+      expect(mockAddToBlackoutList).toHaveBeenCalledWith(
+        'test-personality',
+        mockContext,
+        30 * 1000
+      );
+    });
+  });
+});

--- a/tests/unit/core/personality/PersonalityManager.test.js
+++ b/tests/unit/core/personality/PersonalityManager.test.js
@@ -15,7 +15,8 @@ jest.mock('../../../../src/logger', () => ({
 
 jest.mock('../../../../src/profileInfoFetcher', () => ({
   getProfileAvatarUrl: jest.fn(),
-  getProfileDisplayName: jest.fn()
+  getProfileDisplayName: jest.fn(),
+  getProfileErrorMessage: jest.fn()
 }));
 
 jest.mock('../../../../src/dataStorage', () => ({
@@ -34,7 +35,7 @@ jest.mock('../../../../src/constants', () => ({
 // Import after mocking external deps
 const PersonalityManager = require('../../../../src/core/personality/PersonalityManager');
 const logger = require('../../../../src/logger');
-const { getProfileAvatarUrl, getProfileDisplayName } = require('../../../../src/profileInfoFetcher');
+const { getProfileAvatarUrl, getProfileDisplayName, getProfileErrorMessage } = require('../../../../src/profileInfoFetcher');
 const { loadData, saveData } = require('../../../../src/dataStorage');
 
 describe('PersonalityManager Integration Tests', () => {
@@ -71,6 +72,7 @@ describe('PersonalityManager Integration Tests', () => {
     saveData.mockResolvedValue(true);
     getProfileAvatarUrl.mockResolvedValue('https://example.com/avatar.png');
     getProfileDisplayName.mockResolvedValue('Test Display');
+    getProfileErrorMessage.mockResolvedValue(null); // Default to no error message
   });
 
   afterEach(() => {
@@ -185,6 +187,7 @@ describe('PersonalityManager Integration Tests', () => {
     it('should fetch and set profile info', async () => {
       getProfileAvatarUrl.mockResolvedValue('https://custom.com/avatar.png');
       getProfileDisplayName.mockResolvedValue('Custom Display');
+      getProfileErrorMessage.mockResolvedValue('*sighs* Something went wrong! ||*(an error has occurred)*||');
 
       const result = await personalityManager.registerPersonality('test-personality', 'user123');
 
@@ -214,6 +217,7 @@ describe('PersonalityManager Integration Tests', () => {
     it('should handle profile fetch errors gracefully', async () => {
       getProfileAvatarUrl.mockRejectedValue(new Error('Fetch failed'));
       getProfileDisplayName.mockRejectedValue(new Error('Fetch failed'));
+      getProfileErrorMessage.mockRejectedValue(new Error('Fetch failed'));
 
       const result = await personalityManager.registerPersonality('test-personality', 'user123');
 
@@ -228,6 +232,7 @@ describe('PersonalityManager Integration Tests', () => {
     it('should set display name alias with smart collision handling', async () => {
       // Register first personality with display name "lilith"
       getProfileDisplayName.mockResolvedValue('lilith');
+      getProfileErrorMessage.mockResolvedValue(null); // Reset to default
       await personalityManager.registerPersonality('lilith-first', 'user123');
       
       // Register second personality with same display name
@@ -403,6 +408,7 @@ describe('PersonalityManager Integration Tests', () => {
       // Mock profile fetching to avoid external calls
       getProfileAvatarUrl.mockResolvedValue(null);
       getProfileDisplayName.mockResolvedValue(null);
+      getProfileErrorMessage.mockResolvedValue(null);
 
       await personalityManager.seedOwnerPersonalities({ skipDelays: true });
 

--- a/tests/unit/profileInfoFetcher.errorMessage.test.js
+++ b/tests/unit/profileInfoFetcher.errorMessage.test.js
@@ -1,0 +1,143 @@
+/**
+ * Tests for getProfileErrorMessage function in profileInfoFetcher
+ */
+
+// Mock dependencies
+jest.mock('../../src/logger');
+jest.mock('../../src/core/api', () => ({
+  ProfileInfoFetcher: jest.fn().mockImplementation(() => ({
+    fetchProfileInfo: jest.fn(),
+    clearCache: jest.fn(),
+    deleteFromCache: jest.fn(),
+    getCache: jest.fn().mockReturnValue(new Map()),
+  })),
+}));
+
+const logger = require('../../src/logger');
+const { ProfileInfoFetcher } = require('../../src/core/api');
+const { getProfileErrorMessage, _testing } = require('../../src/profileInfoFetcher');
+
+describe('Profile Info Fetcher - Error Messages', () => {
+  let mockFetcher;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    // Reset the fetcher
+    _testing.resetFetcher();
+    
+    // Get the mock fetcher instance
+    mockFetcher = new ProfileInfoFetcher();
+    ProfileInfoFetcher.mockReturnValue(mockFetcher);
+    
+    // Set up logger mocks
+    logger.info = jest.fn();
+    logger.debug = jest.fn();
+    logger.warn = jest.fn();
+    logger.error = jest.fn();
+  });
+
+  describe('getProfileErrorMessage', () => {
+    it('should return error message when profile has one', async () => {
+      const mockProfileData = {
+        name: 'Test Personality',
+        avatar: 'https://example.com/avatar.png',
+        error_message: '*laughs darkly* The mysteries of existence sometimes exceed even my grasp... ||*(an error has occurred)*||',
+      };
+
+      mockFetcher.fetchProfileInfo.mockResolvedValue(mockProfileData);
+
+      const result = await getProfileErrorMessage('test-personality', 'user-123');
+
+      expect(result).toBe(mockProfileData.error_message);
+      expect(mockFetcher.fetchProfileInfo).toHaveBeenCalledWith('test-personality', 'user-123');
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('[ProfileInfoFetcher] Found error message for test-personality:')
+      );
+    });
+
+    it('should return null when profile has no error message', async () => {
+      const mockProfileData = {
+        name: 'Test Personality',
+        avatar: 'https://example.com/avatar.png',
+        // No error_message field
+      };
+
+      mockFetcher.fetchProfileInfo.mockResolvedValue(mockProfileData);
+
+      const result = await getProfileErrorMessage('test-personality');
+
+      expect(result).toBeNull();
+      expect(logger.debug).toHaveBeenCalledWith(
+        '[ProfileInfoFetcher] No error_message found for profile: test-personality'
+      );
+    });
+
+    it('should return null when profile is not found', async () => {
+      mockFetcher.fetchProfileInfo.mockResolvedValue(null);
+
+      const result = await getProfileErrorMessage('unknown-personality');
+
+      expect(result).toBeNull();
+      expect(logger.warn).toHaveBeenCalledWith(
+        '[ProfileInfoFetcher] No profile info found for error message: unknown-personality'
+      );
+    });
+
+    it('should handle errors gracefully', async () => {
+      mockFetcher.fetchProfileInfo.mockRejectedValue(new Error('Network error'));
+
+      const result = await getProfileErrorMessage('test-personality');
+
+      expect(result).toBeNull();
+      expect(logger.error).toHaveBeenCalledWith(
+        '[ProfileInfoFetcher] Error getting error message: Network error'
+      );
+    });
+
+    it('should handle empty error messages', async () => {
+      const mockProfileData = {
+        name: 'Test Personality',
+        error_message: '', // Empty string
+      };
+
+      mockFetcher.fetchProfileInfo.mockResolvedValue(mockProfileData);
+
+      const result = await getProfileErrorMessage('test-personality');
+
+      // Empty string is falsy, so it should return null
+      expect(result).toBeNull();
+      expect(logger.debug).toHaveBeenCalledWith(
+        '[ProfileInfoFetcher] No error_message found for profile: test-personality'
+      );
+    });
+
+    it('should log the first 100 characters of error message', async () => {
+      const longErrorMessage = 'A'.repeat(150) + ' ||*(an error has occurred)*||';
+      const mockProfileData = {
+        name: 'Test Personality',
+        error_message: longErrorMessage,
+      };
+
+      mockFetcher.fetchProfileInfo.mockResolvedValue(mockProfileData);
+
+      await getProfileErrorMessage('test-personality');
+
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('[ProfileInfoFetcher] Found error message for test-personality: ' + 'A'.repeat(100) + '...')
+      );
+    });
+
+    it('should pass userId when provided', async () => {
+      const mockProfileData = {
+        error_message: 'Error occurred!',
+      };
+
+      mockFetcher.fetchProfileInfo.mockResolvedValue(mockProfileData);
+
+      await getProfileErrorMessage('test-personality', 'user-456');
+
+      expect(mockFetcher.fetchProfileInfo).toHaveBeenCalledWith('test-personality', 'user-456');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implement personality-specific error messages for user-visible errors
- Use the `error_message` field from personality profile API data
- Replace generic error messages with character-appropriate ones that maintain the reference ID pattern

## Changes
- Added `getProfileErrorMessage()` function to profileInfoFetcher.js to fetch error messages from profile API
- Updated PersonalityManager to fetch and store error messages during personality registration  
- Modified aiErrorHandler to use personality-specific error messages with proper reference ID insertion
- Added comprehensive tests for personality error message functionality

## Implementation Details
The error message pattern replacement handles three cases:
1. Exact match: `||*(an error has occurred)*||` → `||*(an error has occurred; reference: <id>)*||`
2. Other parenthetical patterns: `||*(system malfunction)*||` → `||*(system malfunction; reference: <id>)*||`
3. No pattern: append ` ||*(an error has occurred; reference: <id>)*||`

The implementation maintains backward compatibility by falling back to default messages when personality-specific ones aren't available.

## Test plan
- [x] Run all tests: `npm test` (all passing)
- [x] Run quality checks: `npm run quality` (all passing)
- [x] Test personality error messages work correctly
- [x] Verify backward compatibility with personalities without error messages
- [x] Confirm reference IDs are properly inserted

🤖 Generated with [Claude Code](https://claude.ai/code)