### PR TITLE
fix: correct parameter order in add command registerPersonality call

### DIFF
--- a/src/commands/handlers/add.js
+++ b/src/commands/handlers/add.js
@@ -192,7 +192,7 @@ async function execute(message, args, context = {}) {
     // Pass an empty object for data, and let the personality manager fetch the info
     let personality;
     try {
-      personality = await registerPersonality(message.author.id, personalityName, {
+      personality = await registerPersonality(personalityName, message.author.id, {
         description: `Added by ${message.author.tag}`,
       });
     } catch (registerError) {

--- a/tests/unit/commands/handlers/add.test.js
+++ b/tests/unit/commands/handlers/add.test.js
@@ -147,7 +147,7 @@ describe('Add Command', () => {
     // Assert
     // Verify the registration call with description
     expect(personalityManager.registerPersonality).toHaveBeenCalledWith(
-      mockMessage.author.id, 'test-personality', {
+      'test-personality', mockMessage.author.id, {
         description: 'Added by User#1234',
       }
     );
@@ -333,7 +333,7 @@ describe('Add Command', () => {
     // Assert
     // Verify personality was registered with empty data object
     expect(personalityManager.registerPersonality).toHaveBeenCalledWith(
-      mockMessage.author.id, 'test-personality', {
+      'test-personality', mockMessage.author.id, {
         description: 'Added by User#1234',
       }
     );
@@ -383,7 +383,7 @@ describe('Add Command', () => {
     // Assert
     // Verify personality was registered
     expect(personalityManager.registerPersonality).toHaveBeenCalledWith(
-      mockMessage.author.id, 'test-personality', {
+      'test-personality', mockMessage.author.id, {
         description: 'Added by User#1234',
       }
     );
@@ -413,7 +413,7 @@ describe('Add Command', () => {
     // Assert
     // Verify personality was registered
     expect(personalityManager.registerPersonality).toHaveBeenCalledWith(
-      mockMessage.author.id, 'test-personality', {
+      'test-personality', mockMessage.author.id, {
         description: 'Added by User#1234',
       }
     );
@@ -441,7 +441,7 @@ describe('Add Command', () => {
     // Assert
     // Verify personality was registered
     expect(personalityManager.registerPersonality).toHaveBeenCalledWith(
-      mockMessage.author.id, 'test-personality', {
+      'test-personality', mockMessage.author.id, {
         description: 'Added by User#1234',
       }
     );
@@ -579,7 +579,7 @@ describe('Add Command', () => {
     // Assert - Core functionality
     // 1. Verify personality was registered
     expect(personalityManager.registerPersonality).toHaveBeenCalledWith(
-      mockMessage.author.id, 'vesselofazazel', {
+      'vesselofazazel', mockMessage.author.id, {
         description: 'Added by User#1234',
       }
     );


### PR DESCRIPTION
## Summary
Fixes a critical production bug where the add command was passing parameters in the wrong order to `registerPersonality()`.

## The Bug
The `registerPersonality` function expects:
1. `fullName` (the personality name)
2. `addedBy` (the user ID)
3. `additionalData` (optional)

But the add command was calling it with:
1. `message.author.id` (user ID)
2. `personalityName` (personality name)
3. Additional data

This caused the user's Discord ID to be sent to the profile API instead of the personality name, resulting in 404 errors.

## Production Impact
From the logs:
```
[ProfileInfoFetcher] Using endpoint: https://shapes.inc/api/public/shapes/278863839632818186
[ProfileInfoClient] API response error: 404 Not Found
```

The system was trying to fetch profile info using the user's Discord ID (278863839632818186) instead of the personality name (desidara-b3id).

## Changes
- Fixed parameter order in `src/commands/handlers/add.js` line 195
- Updated all test assertions in `tests/unit/commands/handlers/add.test.js` to expect the correct parameter order

## Test plan
- [x] All existing tests pass
- [x] Manually verified the parameter order matches the function signature
- [x] Pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.ai/code)