### PR TITLE
fix: handle missing errorMessage field for old personalities with lazy loading

### DIFF
--- a/src/aiService.js
+++ b/src/aiService.js
@@ -320,15 +320,15 @@ async function handleNormalPersonality(personalityName, message, context, modelP
   // Validate and sanitize response
   if (!response || !response.choices || !response.choices[0] || !response.choices[0].message) {
     logger.error(`[AIService] Invalid response structure from ${personalityName}`);
-
-    return 'I received an incomplete response. Please try again.';
+    // Use personality error handler for empty/invalid responses
+    return analyzeErrorAndGenerateMessage('', personalityName, context, addToBlackoutList);
   }
 
   let content = response.choices[0].message.content;
   if (typeof content !== 'string') {
     logger.error(`[AIService] Non-string content from ${personalityName}: ${typeof content}`);
-
-    return 'I received an unusual response format. Please try again.';
+    // Use personality error handler for non-string content
+    return analyzeErrorAndGenerateMessage(content, personalityName, context, addToBlackoutList);
   }
 
   // Check if the content appears to be an error before sanitization
@@ -352,16 +352,16 @@ async function handleNormalPersonality(personalityName, message, context, modelP
 
     if (sanitizedContent.length === 0) {
       logger.error(`[AIService] Empty content after sanitization from ${personalityName}`);
-
-      return 'I received an empty response. Please try again.';
+      // Use personality error handler for empty content after sanitization
+      return analyzeErrorAndGenerateMessage('', personalityName, context, addToBlackoutList);
     }
 
     // Replace the original content with the sanitized version
     content = sanitizedContent;
   } catch (sanitizeError) {
     logger.error(`[AIService] Sanitization error for ${personalityName}: ${sanitizeError.message}`);
-
-    return 'I encountered an issue processing my response. Please try again.';
+    // Use personality error handler for sanitization errors
+    return analyzeErrorAndGenerateMessage(sanitizeError.message, personalityName, context, addToBlackoutList);
   }
 
   logger.info(

--- a/src/utils/aiErrorHandler.js
+++ b/src/utils/aiErrorHandler.js
@@ -225,17 +225,15 @@ function analyzeErrorAndGenerateMessage(content, personalityName, context, addTo
   // IMPORTANT: ALL errors now show messages to users - no silent failures
   const errorId = Date.now().toString(36) + Math.random().toString(36).substring(2, 5);
 
-  // Try to get personality-specific error message
-  let userMessage = '';
+  // Try to get personality-specific error message first
   let personality = null;
-
   try {
     personality = getPersonality(personalityName);
     if (personality && personality.errorMessage) {
       logger.info(
         `[AIErrorHandler] Using personality-specific error message for ${personalityName}`
       );
-      userMessage = personality.errorMessage;
+      let userMessage = personality.errorMessage;
 
       // Check if the error message already has the error marker pattern
       if (userMessage.includes('||*(an error has occurred)*||')) {
@@ -261,7 +259,8 @@ function analyzeErrorAndGenerateMessage(content, personalityName, context, addTo
     logger.debug(`[AIErrorHandler] Could not fetch personality data: ${err.message}`);
   }
 
-  // Fall back to default error messages
+  // Fall back to default error messages if no personality error message
+  let userMessage = '';
   switch (errorType) {
     case 'empty_response':
       userMessage = `Hmm, I couldn't generate a response. Could you try rephrasing your message?`;

--- a/tests/unit/aiErrorHandler.personality.test.js
+++ b/tests/unit/aiErrorHandler.personality.test.js
@@ -210,6 +210,28 @@ describe('AI Error Handler - Personality-Specific Messages', () => {
       );
     });
 
+    it('should use personality message with existing error marker for empty responses', () => {
+      // This is the specific bug case - personality already has the error marker
+      getPersonality.mockReturnValue({
+        fullName: 'test-personality',
+        errorMessage: 'My circuits are fried! ||*(an error has occurred)*||',
+      });
+
+      const result = analyzeErrorAndGenerateMessage(
+        '', // empty response
+        'test-personality',
+        mockContext,
+        mockAddToBlackoutList
+      );
+
+      // Should use personality message and replace the marker with reference
+      expect(result).toMatch(/My circuits are fried! \|\|\*\(an error has occurred; reference: \w+\)\*\|\|/);
+      expect(result).not.toContain('Hmm, I couldn\'t generate a response'); // Should NOT use default
+      expect(logger.info).toHaveBeenCalledWith(
+        '[AIErrorHandler] Using personality-specific error message for test-personality'
+      );
+    });
+
     it('should use personality message for rate limit errors', () => {
       const result = analyzeErrorAndGenerateMessage(
         'Too many requests. Rate limit exceeded.',

--- a/tests/unit/aiService.test.js
+++ b/tests/unit/aiService.test.js
@@ -47,6 +47,11 @@ jest.mock('../../src/utils/contentSanitizer', () => ({
   }))
 }));
 
+// Mock personality module for error message handling
+jest.mock('../../src/core/personality', () => ({
+  getPersonality: jest.fn().mockReturnValue(null) // No personality found, use defaults
+}));
+
 // Mock OpenAI module
 jest.mock('openai', () => {
   // Create a mock AI client
@@ -985,7 +990,8 @@ describe('AI Service', () => {
       
       const response = await getAiResponse(personalityName, message, context);
       
-      expect(response).toBe('I received an empty response. Please try again.');
+      // Should use personality error handler for empty response
+      expect(response).toMatch(/Hmm, I couldn't generate a response.*\|\|\(Reference:.*\)\|\|/);
     });
 
     it('should handle sanitization errors', async () => {
@@ -1004,7 +1010,8 @@ describe('AI Service', () => {
       
       const response = await getAiResponse(personalityName, message, context);
       
-      expect(response).toBe('I encountered an issue processing my response. Please try again.');
+      // Should use personality error handler for sanitization errors
+      expect(response).toMatch(/I couldn't process that request.*\|\|\(Reference:.*\)\|\|/);
     });
     
     it('should handle invalid response structure', async () => {
@@ -1027,7 +1034,8 @@ describe('AI Service', () => {
       
       const response = await getAiResponse(personalityName, message, context);
       
-      expect(response).toBe('I received an incomplete response. Please try again.');
+      // Should use personality error handler for invalid response
+      expect(response).toMatch(/Hmm, I couldn't generate a response.*\|\|\(Reference:.*\)\|\|/);
     });
     
     it('should handle non-string content from AI', async () => {
@@ -1053,7 +1061,8 @@ describe('AI Service', () => {
       
       const response = await getAiResponse(personalityName, message, context);
       
-      expect(response).toBe('I received an unusual response format. Please try again.');
+      // Should use personality error handler for non-string content
+      expect(response).toMatch(/I couldn't process that request.*\|\|\(Reference:.*\)\|\|/);
     });
   });
 });

--- a/tests/unit/core/personality/PersonalityManager.lazyLoading.test.js
+++ b/tests/unit/core/personality/PersonalityManager.lazyLoading.test.js
@@ -1,0 +1,263 @@
+/**
+ * Tests for PersonalityManager lazy loading functionality
+ */
+
+// Mock dependencies
+jest.mock('../../../../src/profileInfoFetcher', () => ({
+  getProfileAvatarUrl: jest.fn(),
+  getProfileDisplayName: jest.fn(),
+  getProfileErrorMessage: jest.fn(),
+}));
+
+jest.mock('../../../../src/logger');
+
+const PersonalityManager = require('../../../../src/core/personality/PersonalityManager');
+const {
+  getProfileAvatarUrl,
+  getProfileDisplayName,
+  getProfileErrorMessage,
+} = require('../../../../src/profileInfoFetcher');
+const logger = require('../../../../src/logger');
+
+describe('PersonalityManager - Lazy Loading', () => {
+  let manager;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    
+    // Set up logger mock
+    logger.info = jest.fn();
+    logger.error = jest.fn();
+    logger.warn = jest.fn();
+    logger.debug = jest.fn();
+
+    // Create new manager instance
+    manager = PersonalityManager.create({
+      delay: () => Promise.resolve(), // No delays in tests
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('Error message lazy loading', () => {
+    it('should refresh stale personality data', async () => {
+      // Register a personality with old timestamp
+      const oldPersonalityData = {
+        fullName: 'test-personality',
+        addedBy: '123456789012345678',
+        displayName: 'Test',
+        avatarUrl: 'https://example.com/avatar.png',
+        errorMessage: 'Old error message',
+        lastUpdated: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(), // 2 hours ago
+      };
+
+      // Create manager with 1 hour staleness threshold
+      manager = PersonalityManager.create({
+        delay: () => Promise.resolve(),
+        staleDuration: 60 * 60 * 1000, // 1 hour
+      });
+
+      // Directly add to registry
+      manager.registry.personalities.set('test-personality', oldPersonalityData);
+
+      // Mock API responses
+      getProfileAvatarUrl.mockResolvedValue('https://example.com/new-avatar.png');
+      getProfileDisplayName.mockResolvedValue('Updated Test');
+      getProfileErrorMessage.mockResolvedValue('New error message!');
+
+      // Get the personality - should trigger refresh due to staleness
+      const personality = manager.getPersonality('test-personality');
+
+      // Should return the old data immediately
+      expect(personality).toEqual(oldPersonalityData);
+      expect(logger.info).toHaveBeenCalledWith(
+        '[PersonalityManager] Personality test-personality has stale data, refreshing...'
+      );
+
+      // Wait for async refresh
+      await jest.runAllTimersAsync();
+
+      // Check that data was refreshed
+      const updated = manager.getPersonality('test-personality');
+      expect(updated.errorMessage).toBe('New error message!');
+      expect(updated.displayName).toBe('Updated Test');
+      expect(new Date(updated.lastUpdated).getTime()).toBeGreaterThan(
+        new Date(oldPersonalityData.lastUpdated).getTime()
+      );
+    });
+    it('should refresh personality data when lastUpdated is missing', async () => {
+      // Register a personality without lastUpdated field (simulating very old data)
+      const oldPersonalityData = {
+        fullName: 'test-personality',
+        addedBy: '123456789012345678',
+        displayName: 'Test',
+        avatarUrl: 'https://example.com/avatar.png',
+        errorMessage: 'Error message exists',
+        // Note: no lastUpdated field at all
+      };
+
+      // Directly add to registry
+      manager.registry.personalities.set('test-personality', oldPersonalityData);
+
+      // Mock API responses
+      getProfileAvatarUrl.mockResolvedValue('https://example.com/new-avatar.png');
+      getProfileDisplayName.mockResolvedValue('Updated Test');
+      getProfileErrorMessage.mockResolvedValue('Updated error message!');
+
+      // Get the personality - should trigger refresh due to missing lastUpdated
+      const personality = manager.getPersonality('test-personality');
+
+      // Should return the old data immediately
+      expect(personality).toEqual(oldPersonalityData);
+      expect(logger.info).toHaveBeenCalledWith(
+        '[PersonalityManager] Personality test-personality has stale data, refreshing...'
+      );
+
+      // Wait for async refresh
+      await jest.runAllTimersAsync();
+
+      // Check that data was refreshed and lastUpdated was added
+      const updated = manager.getPersonality('test-personality');
+      expect(updated.lastUpdated).toBeDefined();
+      expect(updated.errorMessage).toBe('Updated error message!');
+    });
+
+    it('should refresh personality data when errorMessage is missing', async () => {
+      // Register a personality without errorMessage (simulating old data)
+      const oldPersonalityData = {
+        fullName: 'test-personality',
+        addedBy: '123456789012345678',
+        displayName: 'Test',
+        avatarUrl: 'https://example.com/avatar.png',
+        // Note: no errorMessage field
+      };
+
+      // Directly add to registry to simulate old data
+      manager.registry.personalities.set('test-personality', oldPersonalityData);
+
+      // Mock API responses for refresh
+      getProfileAvatarUrl.mockResolvedValue('https://example.com/new-avatar.png');
+      getProfileDisplayName.mockResolvedValue('Test Personality');
+      getProfileErrorMessage.mockResolvedValue('Oops! Something went wrong! ||*(an error has occurred)*||');
+
+      // Get the personality - should trigger lazy loading
+      const personality = manager.getPersonality('test-personality');
+
+      // Should return the old data immediately
+      expect(personality).toEqual(oldPersonalityData);
+      expect(logger.info).toHaveBeenCalledWith(
+        '[PersonalityManager] Personality test-personality missing errorMessage, refreshing...'
+      );
+
+      // Wait for async refresh to complete
+      await jest.runAllTimersAsync();
+
+      // Check that API calls were made
+      expect(getProfileAvatarUrl).toHaveBeenCalledWith('test-personality');
+      expect(getProfileDisplayName).toHaveBeenCalledWith('test-personality');
+      expect(getProfileErrorMessage).toHaveBeenCalledWith('test-personality');
+
+      // Get personality again - should have updated data
+      const updatedPersonality = manager.getPersonality('test-personality');
+      expect(updatedPersonality.errorMessage).toBe('Oops! Something went wrong! ||*(an error has occurred)*||');
+      expect(updatedPersonality.avatarUrl).toBe('https://example.com/new-avatar.png');
+      expect(updatedPersonality.displayName).toBe('Test Personality');
+    });
+
+    it('should not refresh if errorMessage already exists and data is fresh', async () => {
+      // Register a personality with errorMessage and recent timestamp
+      const personalityData = {
+        fullName: 'test-personality',
+        addedBy: '123456789012345678',
+        displayName: 'Test',
+        avatarUrl: 'https://example.com/avatar.png',
+        errorMessage: 'Existing error message',
+        lastUpdated: new Date().toISOString(), // Fresh timestamp
+      };
+
+      manager.registry.personalities.set('test-personality', personalityData);
+
+      // Get the personality
+      const personality = manager.getPersonality('test-personality');
+
+      // Should return the data without refreshing
+      expect(personality).toEqual(personalityData);
+      expect(logger.info).not.toHaveBeenCalledWith(
+        expect.stringContaining('refreshing')
+      );
+
+      // API should not be called
+      expect(getProfileAvatarUrl).not.toHaveBeenCalled();
+      expect(getProfileDisplayName).not.toHaveBeenCalled();
+      expect(getProfileErrorMessage).not.toHaveBeenCalled();
+    });
+
+    it('should handle refresh errors gracefully', async () => {
+      // Register a personality without errorMessage
+      const oldPersonalityData = {
+        fullName: 'test-personality',
+        addedBy: '123456789012345678',
+        displayName: 'Test',
+      };
+
+      manager.registry.personalities.set('test-personality', oldPersonalityData);
+
+      // Mock API error
+      getProfileErrorMessage.mockRejectedValue(new Error('API Error'));
+      getProfileAvatarUrl.mockRejectedValue(new Error('API Error'));
+      getProfileDisplayName.mockRejectedValue(new Error('API Error'));
+
+      // Get the personality
+      const personality = manager.getPersonality('test-personality');
+
+      // Should return the old data
+      expect(personality).toEqual(oldPersonalityData);
+
+      // Wait for async refresh to complete
+      await jest.runAllTimersAsync();
+
+      // Should log the warning from _fetchProfileData
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Could not fetch profile info for test-personality')
+      );
+
+      // Personality should have been updated with lastUpdated timestamp
+      const updated = manager.getPersonality('test-personality');
+      expect(updated.lastUpdated).toBeDefined();
+      expect(updated.fullName).toBe('test-personality');
+    });
+
+    it('should update all fields during refresh', async () => {
+      // Register a personality with outdated data
+      const oldPersonalityData = {
+        fullName: 'test-personality',
+        addedBy: '123456789012345678',
+        displayName: 'Old Name',
+        avatarUrl: 'https://example.com/old.png',
+        // No errorMessage
+      };
+
+      manager.registry.personalities.set('test-personality', oldPersonalityData);
+
+      // Mock API responses with all new data
+      getProfileAvatarUrl.mockResolvedValue('https://example.com/new.png');
+      getProfileDisplayName.mockResolvedValue('New Name');
+      getProfileErrorMessage.mockResolvedValue('New error message!');
+
+      // Trigger refresh
+      manager.getPersonality('test-personality');
+
+      // Wait for refresh
+      await jest.runAllTimersAsync();
+
+      // Check updated data
+      const updated = manager.getPersonality('test-personality');
+      expect(updated.avatarUrl).toBe('https://example.com/new.png');
+      expect(updated.displayName).toBe('New Name');
+      expect(updated.errorMessage).toBe('New error message!');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fix personalities with custom error messages showing generic errors instead
- Add lazy loading to refresh personality data when missing errorMessage field
- Implement freshness tracking to auto-refresh stale personality data

## Problem
When a personality has a custom error message (like Lilith's `"*laughs darkly* The mysteries of existence sometimes exceed even my grasp... ||*(an error has occurred)*||"`), empty_response errors were showing generic messages like "I received an empty response. Please try again." instead of the personality's custom message.

This happened because:
1. Several error paths in `aiService.js` had early returns that bypassed the personality error handler
2. Personalities registered before the errorMessage feature was added don't have that field

## Solution
1. **Modified aiService.js** to use `analyzeErrorAndGenerateMessage()` for all error paths instead of hardcoded messages
2. **Added lazy loading** in PersonalityManager that:
   - Detects when a personality is missing the errorMessage field
   - Detects when personality data is stale (>1 hour by default) 
   - Refreshes the personality data asynchronously without blocking the current request
   - Logs the refresh attempts for monitoring

## Changes
- `src/aiService.js`: Replace all hardcoded error returns with calls to personality error handler
- `src/core/personality/PersonalityManager.js`: Add lazy loading with freshness tracking
- `tests/unit/aiService.test.js` & `tests/unit/aiService.error.test.js`: Update test expectations
- `tests/unit/core/personality/PersonalityManager.lazyLoading.test.js`: New tests for lazy loading

## Test Plan
- [x] All existing tests pass
- [x] New tests for lazy loading functionality
- [x] Manually test with a personality missing errorMessage field
- [ ] Verify in production that Lilith's custom error message appears for empty responses

🤖 Generated with [Claude Code](https://claude.ai/code)