### PR TITLE
fix: migrate existing authenticated users to notification system

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,11 @@ async function init() {
     
     // Initialize release notification manager and check for updates
     try {
-      await releaseNotificationManager.initialize(client);
+      // Get authManager to migrate existing authenticated users
+      const { getAuthManager } = require('./src/auth');
+      const authManager = getAuthManager();
+      
+      await releaseNotificationManager.initialize(client, authManager);
       logger.info('Release notification manager initialized');
       
       // Check for new version and send notifications in the background

--- a/src/core/notifications/VersionTracker.js
+++ b/src/core/notifications/VersionTracker.js
@@ -108,9 +108,20 @@ class VersionTracker {
     const lastVersion = await this.getLastNotifiedVersion();
 
     if (!lastVersion) {
-      // First run, don't notify but save current version
-      await this.saveNotifiedVersion(currentVersion);
-      return { hasNewVersion: false, currentVersion, lastVersion: null, changeType: null };
+      // First run - we should notify about the current version
+      // Don't save yet - let the notification manager handle that after sending
+      logger.info(`[VersionTracker] First run detected, will notify about current version ${currentVersion}`);
+      
+      // Determine change type based on current version
+      const current = this.parseVersion(currentVersion);
+      let changeType = 'minor'; // Default to minor for first notification
+      
+      // If it's a major version (x.0.0), treat as major
+      if (current.minor === 0 && current.patch === 0) {
+        changeType = 'major';
+      }
+      
+      return { hasNewVersion: true, currentVersion, lastVersion: null, changeType };
     }
 
     const comparison = this.compareVersions(currentVersion, lastVersion);


### PR DESCRIPTION
## Summary
Fixes the issue where existing authenticated users were not receiving release notifications.

## Problem
The notification system was only aware of users who had explicitly used the `\!tz notifications` command. Existing authenticated users were not being migrated to the notification system, so they wouldn't receive any notifications despite being opted-in by default.

## Solution
1. **Migration of Authenticated Users**
   - Added `migrateAuthenticatedUsers()` method to ReleaseNotificationManager
   - Automatically adds all authenticated users to the notification system with default preferences
   - Users are opted-in with 'minor' notification level by default

2. **First-Run Notification Fix**
   - Modified VersionTracker to treat first run as a new version event
   - On first run, fetches up to 5 recent releases to show version history
   - Ensures users see comprehensive release information on initial notification

## Changes
- Modified `ReleaseNotificationManager.initialize()` to accept authManager and migrate users
- Updated `VersionTracker.checkForNewVersion()` to return `hasNewVersion: true` on first run
- Changed first-run behavior to fetch recent release history instead of just current version
- Updated index.js to pass authManager during notification system initialization

## Impact
- All authenticated users will now receive notifications
- First notification will include recent version history (up to 5 releases)
- No user action required - automatic migration preserves opt-in by default behavior

## Testing
After deploying this fix:
1. The bot will automatically migrate all authenticated users
2. Users will receive a notification about v1.2.0 with recent release history
3. Future releases will notify all opted-in users as expected

🤖 Generated with [Claude Code](https://claude.ai/code)