### PR TITLE
fix: resolve HTTP server 502 errors on Railway deployment

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,15 +114,24 @@ async function init() {
       const { createHTTPServer } = require('./src/httpServer');
       const httpPort = process.env.PORT || process.env.HTTP_PORT || 3000;
       
+      logger.info(`[Init] Starting HTTP server on port ${httpPort} (PORT env: ${process.env.PORT || 'not set'})`);
+      
       // Create context with Discord client and other shared resources
       const serverContext = {
         discordClient: global.tzurotClient || client,
       };
       
       httpServer = createHTTPServer(httpPort, serverContext);
-      logger.info(`HTTP server started on port ${httpPort}`);
+      logger.info(`[Init] HTTP server started successfully on port ${httpPort}`);
+      
+      // Log Railway-specific environment info
+      if (process.env.RAILWAY_ENVIRONMENT) {
+        logger.info(`[Init] Railway environment: ${process.env.RAILWAY_ENVIRONMENT}`);
+        logger.info(`[Init] Railway public domain: ${process.env.RAILWAY_PUBLIC_DOMAIN || 'not set'}`);
+      }
     } catch (httpError) {
-      logger.error('Failed to start HTTP server:', httpError);
+      logger.error('[Init] Failed to start HTTP server:', httpError);
+      logger.error('[Init] HTTP server error details:', httpError.stack);
       // Continue initialization despite HTTP server failure
       // The bot can still function without it
     }

--- a/src/httpServer.js
+++ b/src/httpServer.js
@@ -127,9 +127,10 @@ function createHTTPServer(port = 3000, context = {}) {
     logger.error(`[HTTPServer] Server error: ${error.message}`, error);
   });
 
-  server.listen(port, () => {
-    logger.info(`[HTTPServer] Server running on port ${port}`);
+  server.listen(port, '0.0.0.0', () => {
+    logger.info(`[HTTPServer] Server running on 0.0.0.0:${port}`);
     logger.info(`[HTTPServer] Available routes: ${Array.from(routes.keys()).join(', ')}`);
+    logger.info(`[HTTPServer] Railway deployment URL expected: ${process.env.RAILWAY_STATIC_URL || 'not set'}`);
   });
 
   return server;

--- a/src/routes/health.js
+++ b/src/routes/health.js
@@ -153,8 +153,27 @@ async function healthHandler(req, res) {
   }
 }
 
+/**
+ * Root path handler
+ * @param {http.IncomingMessage} req - The request object
+ * @param {http.ServerResponse} res - The response object
+ */
+async function rootHandler(req, res) {
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({
+    status: 'ok',
+    service: 'Tzurot Discord Bot',
+    endpoints: {
+      health: '/health',
+      avatars: '/avatars',
+      webhooks: '/webhooks'
+    }
+  }));
+}
+
 module.exports = {
   routes: [
+    { method: 'GET', path: '/', handler: rootHandler },
     { method: 'GET', path: '/health', handler: healthHandler },
     { method: 'GET', path: '/health/', handler: healthHandler },
   ],


### PR DESCRIPTION
## Summary
Fix 502 errors preventing external access to HTTP endpoints on Railway deployment.

## Changes Made
- **Root Path Handler**: Added `/` endpoint in health.js to provide service information and available endpoints
- **Explicit IP Binding**: Changed server binding from default to explicit `0.0.0.0:PORT` for external connectivity
- **Enhanced Logging**: Added diagnostic logging for Railway environment variables and startup process

## Railway Deployment Fix
This addresses the specific issue where:
- Railway health checks expect a root endpoint response (now returns service info)
- External connectivity requires explicit IP binding to 0.0.0.0 (previously used default)
- Diagnostic logging helps troubleshoot deployment-specific issues

## Test Plan
- [x] All existing tests pass
- [x] HTTP server starts successfully in development
- [ ] Verify external accessibility resolves 502 errors on Railway
- [ ] Confirm root endpoint returns proper service information

This is a clean fix that only includes HTTP server changes, built from the current develop branch.

🤖 Generated with [Claude Code](https://claude.ai/code)