### PR TITLE
debug: add Railway connectivity diagnostic logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,6 +128,10 @@ async function init() {
       if (process.env.RAILWAY_ENVIRONMENT) {
         logger.info(`[Init] Railway environment: ${process.env.RAILWAY_ENVIRONMENT}`);
         logger.info(`[Init] Railway public domain: ${process.env.RAILWAY_PUBLIC_DOMAIN || 'not set'}`);
+        logger.info(`[Init] Railway static URL: ${process.env.RAILWAY_STATIC_URL || 'not set'}`);
+        logger.info(`[Init] Railway service URL: ${process.env.RAILWAY_SERVICE_URL || 'not set'}`);
+      } else {
+        logger.info(`[Init] Not running on Railway (RAILWAY_ENVIRONMENT not set)`);
       }
     } catch (httpError) {
       logger.error('[Init] Failed to start HTTP server:', httpError);

--- a/src/httpServer.js
+++ b/src/httpServer.js
@@ -43,6 +43,9 @@ function registerRoutes(routeModule) {
  * @param {http.ServerResponse} res - The response object
  */
 async function handleRequest(req, res) {
+  // Log all incoming requests for debugging Railway connectivity
+  logger.info(`[HTTPServer] Incoming request: ${req.method} ${req.url} from ${req.headers['x-forwarded-for'] || req.socket.remoteAddress}`);
+  
   const routeKey = `${req.method}:${req.url}`;
   let handler = routes.get(routeKey);
 

--- a/src/routes/health.js
+++ b/src/routes/health.js
@@ -159,10 +159,15 @@ async function healthHandler(req, res) {
  * @param {http.ServerResponse} res - The response object
  */
 async function rootHandler(req, res) {
+  logger.info(`[Health] Root endpoint accessed from ${req.headers['x-forwarded-for'] || req.socket.remoteAddress}`);
+  
   res.writeHead(200, { 'Content-Type': 'application/json' });
   res.end(JSON.stringify({
     status: 'ok',
     service: 'Tzurot Discord Bot',
+    version: '1.2.1',
+    environment: process.env.RAILWAY_ENVIRONMENT || 'local',
+    port: process.env.PORT || '3000',
     endpoints: {
       health: '/health',
       avatars: '/avatars',


### PR DESCRIPTION
## Summary
Add comprehensive logging to diagnose Railway 502 connectivity issues.

## Debugging Features Added
- **Request Logging**: Log all incoming HTTP requests with source IP and headers
- **Railway Environment Details**: Log all Railway-specific environment variables
- **Enhanced Root Endpoint**: Include version, environment, and port information
- **Connection Source Tracking**: Track where requests are coming from

## Why This Helps
The server appears to be running correctly on 0.0.0.0:8080 but Railway is still returning 502 errors. This logging will help us understand:
- Are requests actually reaching our server?
- What Railway environment variables are available?
- Is Railway routing traffic correctly?
- Are there any specific headers or routing issues?

## Expected Logs
Once deployed, we should see:
```
[HTTPServer] Incoming request: GET / from x.x.x.x
[Health] Root endpoint accessed from x.x.x.x
[Init] Railway environment: development
[Init] Railway public domain: ...
[Init] Railway static URL: ...
```

If we don't see these logs when curling the endpoint, it means Railway isn't routing traffic to our server.

🤖 Generated with [Claude Code](https://claude.ai/code)