### PR TITLE
Release v1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Tzurot Discord bot will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.2] - 2025-06-06
+
+### Fixed
+- **Release Notification Categorization** - Fixed incorrect categorization of changelog sections
+  - "Changed" sections no longer appear as "Breaking Changes" in notifications
+  - Changed sections now correctly display under "Other Changes" with a wrench icon
+  - Prevents confusion when patch releases show breaking changes warnings
+
 ## [1.3.1] - 2025-06-06
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tzurot",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "A Discord bot that uses webhooks to represent multiple AI personalities",
   "main": "index.js",
   "scripts": {

--- a/src/core/notifications/GitHubReleaseClient.js
+++ b/src/core/notifications/GitHubReleaseClient.js
@@ -224,9 +224,9 @@ class GitHubReleaseClient {
         currentSection = 'features';
       } else if (trimmed.match(/^#+\s*(fixes?|fixed|bug\s*fixes?)/i)) {
         currentSection = 'fixes';
-      } else if (trimmed.match(/^#+\s*(breaking|changed)/i)) {
+      } else if (trimmed.match(/^#+\s*(breaking)/i)) {
         currentSection = 'breaking';
-      } else if (trimmed.match(/^#+\s*(other|misc|chore)/i)) {
+      } else if (trimmed.match(/^#+\s*(changed|other|misc|chore|removed)/i)) {
         currentSection = 'other';
       }
 

--- a/src/core/notifications/ReleaseNotificationManager.js
+++ b/src/core/notifications/ReleaseNotificationManager.js
@@ -353,6 +353,14 @@ class ReleaseNotificationManager {
       });
     }
 
+    if (aggregatedChanges.other.length > 0) {
+      embed.addFields({
+        name: '🔧 Other Changes',
+        value: this.formatChangesList(aggregatedChanges.other, 5),
+        inline: false,
+      });
+    }
+
     // Add link to full release
     const releaseLinks =
       releases.length > 1

--- a/tests/unit/core/notifications/GitHubReleaseClient.test.js
+++ b/tests/unit/core/notifications/GitHubReleaseClient.test.js
@@ -231,9 +231,8 @@ describe('GitHubReleaseClient', () => {
       expect(formatted).not.toContain('**Release Notes:**');
       expect(formatted).not.toContain('## New Features');
     });
-  });
 
-  describe('getReleasesBetween', () => {
+    // Additional getReleasesBetween tests
     const mockReleases = [
       {
         tag_name: 'v1.3.0',

--- a/tests/unit/core/notifications/GitHubReleaseClient.test.js
+++ b/tests/unit/core/notifications/GitHubReleaseClient.test.js
@@ -499,6 +499,25 @@ Some other text that's not in a section`,
         'Another dash bullet',
       ]);
     });
+
+    it('should categorize Changed section as other, not breaking', () => {
+      const release = {
+        body: `## Changed
+- Environment Variable Standardization
+- Updated configuration
+
+## Breaking
+- Actual breaking change`,
+      };
+
+      const changes = client.parseReleaseChanges(release);
+
+      expect(changes.breaking).toEqual(['Actual breaking change']);
+      expect(changes.other).toEqual([
+        'Environment Variable Standardization',
+        'Updated configuration',
+      ]);
+    });
   });
 
   describe('clearCache', () => {


### PR DESCRIPTION
## Release v1.3.2

This patch release fixes the notification system's changelog parsing.

### 🐛 Bug Fix
- **Release Notification Categorization** - Fixed incorrect categorization of changelog sections
  - "Changed" sections no longer appear as "Breaking Changes" in notifications
  - Changed sections now correctly display under "Other Changes" with a wrench icon
  - Prevents confusion when patch releases show breaking changes warnings

### Impact
Users will no longer see scary "⚠️ Breaking Changes" warnings for simple patch releases that only contain internal changes or improvements.

### Checklist
- [x] Version bumped to 1.3.2
- [x] CHANGELOG.md updated
- [ ] Tests passing
- [ ] Deploy to production after merge
- [ ] Create GitHub release after merge
- [ ] Sync develop branch with main after merge

### Release Process Reminder
1. Merge this PR to main
2. Deploy to production
3. Run `./scripts/create-release.sh v1.3.2` to create GitHub release
4. Run `git sync-develop` to sync develop with main