### PR TITLE
fix: make getPersonality async to properly load error messages

### DIFF
--- a/src/commands/handlers/activate.js
+++ b/src/commands/handlers/activate.js
@@ -67,7 +67,7 @@ async function execute(message, args) {
     let personality = getPersonalityByAlias(personalityInput);
 
     if (!personality) {
-      personality = getPersonality(personalityInput);
+      personality = await getPersonality(personalityInput);
     }
 
     if (!personality) {

--- a/src/commands/handlers/add.js
+++ b/src/commands/handlers/add.js
@@ -130,7 +130,7 @@ async function execute(message, args, context = {}) {
     logger.debug(`[AddCommand] Generated command ID: ${commandId}`);
 
     // Check if this personality already exists globally first
-    const existingPersonality = getPersonality(personalityName);
+    const existingPersonality = await getPersonality(personalityName);
     if (existingPersonality) {
       logger.info(`[AddCommand] Personality ${personalityName} already exists globally`);
 
@@ -228,7 +228,7 @@ async function execute(message, args, context = {}) {
     }
 
     // Registration successful, now fetch the personality
-    const personality = getPersonality(personalityName);
+    const personality = await getPersonality(personalityName);
     if (!personality) {
       logger.error(
         `[AddCommand ${commandId}] Personality registered but could not be retrieved: ${personalityName}`

--- a/src/commands/handlers/alias.js
+++ b/src/commands/handlers/alias.js
@@ -42,7 +42,7 @@ async function execute(message, args) {
 
   try {
     // Find the personality first
-    const personality = getPersonality(personalityName);
+    const personality = await getPersonality(personalityName);
 
     if (!personality) {
       return await directSend(

--- a/src/commands/handlers/info.js
+++ b/src/commands/handlers/info.js
@@ -44,7 +44,7 @@ async function execute(message, args) {
     let personality = getPersonalityByAlias(personalityInput);
 
     if (!personality) {
-      personality = getPersonality(personalityInput);
+      personality = await getPersonality(personalityInput);
     }
 
     if (!personality) {

--- a/src/commands/handlers/remove.js
+++ b/src/commands/handlers/remove.js
@@ -62,7 +62,7 @@ async function execute(message, args, context = {}) {
 
     // If not found by alias, try the direct name
     if (!personality) {
-      personality = getPersonality(personalityName);
+      personality = await getPersonality(personalityName);
     }
 
     if (!personality) {

--- a/src/commands/handlers/reset.js
+++ b/src/commands/handlers/reset.js
@@ -43,7 +43,7 @@ async function execute(message, args) {
     let personality = personalityManager.getPersonalityByAlias(personalityInput);
 
     if (!personality) {
-      personality = personalityManager.getPersonality(personalityInput);
+      personality = await personalityManager.getPersonality(personalityInput);
     }
 
     if (!personality) {

--- a/src/handlers/dmHandler.js
+++ b/src/handlers/dmHandler.js
@@ -134,7 +134,7 @@ async function handleDmReply(message, client) {
 
         // If still not found, try by direct personality name
         if (!personality) {
-          personality = getPersonality(displayName);
+          personality = await getPersonality(displayName);
 
           if (personality) {
             logger.info(`[DmHandler] Found personality directly by name: ${personality.fullName}`);
@@ -296,7 +296,7 @@ async function handleDirectMessage(message, client) {
     logger.info(`[DmHandler] Using sticky personality in DM: ${activePersonalityName}`);
 
     // Get the personality data
-    let personality = getPersonality(activePersonalityName);
+    let personality = await getPersonality(activePersonalityName);
     if (!personality) {
       personality = getPersonalityByAlias(activePersonalityName);
     }

--- a/src/handlers/messageHandler.js
+++ b/src/handlers/messageHandler.js
@@ -28,9 +28,9 @@ const pluralkitMessageStore = require('../utils/pluralkitMessageStore').instance
 /**
  * Check if a message contains any personality mentions (without processing them)
  * @param {Object} message - Discord message object
- * @returns {boolean} - Whether the message contains personality mentions
+ * @returns {Promise<boolean>} - Whether the message contains personality mentions
  */
-function checkForPersonalityMentions(message) {
+async function checkForPersonalityMentions(message) {
   if (!message.content) return false;
 
   logger.debug(`[checkForPersonalityMentions] Checking message: "${message.content}"`);
@@ -52,7 +52,7 @@ function checkForPersonalityMentions(message) {
       const cleanedName = match[1].trim().replace(/[.,!?;:)"']+$/, '');
 
       // Check if this is a valid personality (directly or as an alias)
-      let personality = getPersonality(cleanedName);
+      let personality = await getPersonality(cleanedName);
       if (!personality) {
         personality = getPersonalityByAlias(cleanedName);
       }
@@ -279,7 +279,7 @@ async function handleMessage(message, client) {
       logger.info(`[MessageHandler] Has activated personality: ${hasActivatedPersonality}`);
 
       // Check if the message contains a personality mention
-      const hasMention = checkForPersonalityMentions(message);
+      const hasMention = await checkForPersonalityMentions(message);
       logger.info(`[MessageHandler] Has mention: ${hasMention}`);
 
       // Only skip processing if there are no mentions AND no Discord links
@@ -406,7 +406,7 @@ async function handleMentions(message, client) {
       );
 
       // Check if this is a valid personality (directly or as an alias)
-      let personality = getPersonality(mentionName);
+      let personality = await getPersonality(mentionName);
       if (!personality) {
         personality = getPersonalityByAlias(mentionName);
       }
@@ -575,7 +575,7 @@ async function handleActiveConversation(message, client) {
   logger.info(`[MessageHandler] Found active conversation with: ${activePersonalityName}`);
 
   // First try to get personality directly by full name
-  let personality = getPersonality(activePersonalityName);
+  let personality = await getPersonality(activePersonalityName);
 
   // If not found as direct name, try it as an alias
   if (!personality) {
@@ -662,7 +662,7 @@ async function handleActivatedChannel(message, client) {
   }
 
   // First try to get personality directly by full name
-  let personality = getPersonality(activatedPersonalityName);
+  let personality = await getPersonality(activatedPersonalityName);
 
   // If not found as direct name, try it as an alias
   if (!personality) {

--- a/src/handlers/referenceHandler.js
+++ b/src/handlers/referenceHandler.js
@@ -99,7 +99,7 @@ async function handleMessageReference(message, handlePersonalityInteraction, cli
         logger.debug(`Found personality name: ${personalityName}, looking up personality details`);
 
         // First try to get personality directly as it could be a full name
-        let personality = getPersonality(personalityName);
+        let personality = await getPersonality(personalityName);
         logger.debug(
           `Direct personality lookup for "${personalityName}": ${personality ? 'found' : 'not found'}`
         );

--- a/src/httpServer.js
+++ b/src/httpServer.js
@@ -46,7 +46,7 @@ async function handleRequest(req, res) {
   // Log all incoming requests for debugging Railway connectivity
   const clientIP = req.headers['x-forwarded-for'] || req.socket?.remoteAddress || 'unknown';
   logger.info(`[HTTPServer] Incoming request: ${req.method} ${req.url} from ${clientIP}`);
-  
+
   const routeKey = `${req.method}:${req.url}`;
   let handler = routes.get(routeKey);
 
@@ -139,7 +139,9 @@ function createHTTPServer(port = 3000, context = {}) {
   server.listen(port, '0.0.0.0', () => {
     logger.info(`[HTTPServer] Server running on 0.0.0.0:${port}`);
     logger.info(`[HTTPServer] Available routes: ${Array.from(routes.keys()).join(', ')}`);
-    logger.info(`[HTTPServer] Railway deployment URL expected: ${process.env.RAILWAY_STATIC_URL || 'not set'}`);
+    logger.info(
+      `[HTTPServer] Railway deployment URL expected: ${process.env.RAILWAY_STATIC_URL || 'not set'}`
+    );
   });
 
   return server;

--- a/src/routes/health.js
+++ b/src/routes/health.js
@@ -161,20 +161,22 @@ async function healthHandler(req, res) {
 async function rootHandler(req, res) {
   const clientIP = req.headers['x-forwarded-for'] || req.socket?.remoteAddress || 'unknown';
   logger.info(`[Health] Root endpoint accessed from ${clientIP}`);
-  
+
   res.writeHead(200, { 'Content-Type': 'application/json' });
-  res.end(JSON.stringify({
-    status: 'ok',
-    service: 'Tzurot Discord Bot',
-    version: '1.2.1',
-    environment: process.env.RAILWAY_ENVIRONMENT || 'local',
-    port: process.env.PORT || '3000',
-    endpoints: {
-      health: '/health',
-      avatars: '/avatars',
-      webhooks: '/webhooks'
-    }
-  }));
+  res.end(
+    JSON.stringify({
+      status: 'ok',
+      service: 'Tzurot Discord Bot',
+      version: '1.2.1',
+      environment: process.env.RAILWAY_ENVIRONMENT || 'local',
+      port: process.env.PORT || '3000',
+      endpoints: {
+        health: '/health',
+        avatars: '/avatars',
+        webhooks: '/webhooks',
+      },
+    })
+  );
 }
 
 module.exports = {

--- a/src/utils/aiErrorHandler.js
+++ b/src/utils/aiErrorHandler.js
@@ -82,9 +82,14 @@ function isErrorResponse(content) {
  * @param {string} personalityName - The personality that generated the error
  * @param {Object} context - Request context for logging
  * @param {Function} addToBlackoutList - Function to add to blackout tracking
- * @returns {string} - User-friendly error message
+ * @returns {Promise<string>} - User-friendly error message
  */
-function analyzeErrorAndGenerateMessage(content, personalityName, context, addToBlackoutList) {
+async function analyzeErrorAndGenerateMessage(
+  content,
+  personalityName,
+  context,
+  addToBlackoutList
+) {
   // Analyze error content to provide more detailed information
   let errorType = 'error_in_content';
   let errorDetails = 'Unknown error format';
@@ -228,7 +233,7 @@ function analyzeErrorAndGenerateMessage(content, personalityName, context, addTo
   // Try to get personality-specific error message first
   let personality = null;
   try {
-    personality = getPersonality(personalityName);
+    personality = await getPersonality(personalityName);
     if (personality && personality.errorMessage) {
       logger.info(
         `[AIErrorHandler] Using personality-specific error message for ${personalityName}`

--- a/src/utils/aiMessageFormatter.js
+++ b/src/utils/aiMessageFormatter.js
@@ -13,9 +13,14 @@ const { getPersonality } = require('../core/personality');
  * @param {string} personalityName - The name of the personality to use in media prompts
  * @param {string} [userName] - The user's formatted name (displayName + username)
  * @param {boolean} [isProxyMessage] - Whether this is a proxy system message (PluralKit, etc)
- * @returns {Array} Formatted messages array for API request
+ * @returns {Promise<Array>} Formatted messages array for API request
  */
-function formatApiMessages(content, personalityName, userName = 'a user', isProxyMessage = false) {
+async function formatApiMessages(
+  content,
+  personalityName,
+  userName = 'a user',
+  isProxyMessage = false
+) {
   try {
     // Check if the content is an object with a special reference format
     if (
@@ -161,7 +166,7 @@ function formatApiMessages(content, personalityName, userName = 'a user', isProx
             let displayName;
 
             // Try to get the personality from the personality manager
-            const personalityObject = fullName ? getPersonality(fullName) : null;
+            const personalityObject = fullName ? await getPersonality(fullName) : null;
             if (personalityObject && personalityObject.displayName) {
               // Use display name from personality manager if available
               displayName = personalityObject.displayName;

--- a/src/webhook/messageUtils.js
+++ b/src/webhook/messageUtils.js
@@ -238,7 +238,7 @@ async function sendMessageChunk(webhook, messageData, chunkIndex, totalChunks) {
 
     // Extract personality and prepare final message data
     const { _personality, ...baseMessageData } = messageData;
-    
+
     // Resolve avatar URL if personality is provided
     let avatarUrl = null;
     if (_personality && _personality.avatarUrl) {
@@ -253,7 +253,7 @@ async function sendMessageChunk(webhook, messageData, chunkIndex, totalChunks) {
         avatarUrl = _personality.avatarUrl; // Fallback to original
       }
     }
-    
+
     // Prepare final message data with resolved avatar URL
     const finalMessageData = {
       ...baseMessageData,

--- a/tests/unit/aiService.embedMedia.test.js
+++ b/tests/unit/aiService.embedMedia.test.js
@@ -13,7 +13,7 @@ describe('AIService - Embed Media Extraction', () => {
     jest.clearAllMocks();
   });
 
-  test('should include embed thumbnail as image attachment when referenced', () => {
+  test('should include embed thumbnail as image attachment when referenced', async () => {
     const input = {
       messageContent: "@TestPersonality is this accurate?",
       userName: "testuser",
@@ -27,7 +27,7 @@ describe('AIService - Embed Media Extraction', () => {
       }
     };
 
-    const result = formatApiMessages(input);
+    const result = await formatApiMessages(input);
     
     expect(result).toHaveLength(1);
     expect(result[0].role).toBe('user');
@@ -47,7 +47,7 @@ describe('AIService - Embed Media Extraction', () => {
     expect(imageContent.image_url.url).toBe("https://example.com/thumbnail.jpg");
   });
 
-  test('should include embed image as image attachment when referenced', () => {
+  test('should include embed image as image attachment when referenced', async () => {
     const input = {
       messageContent: "What do you think of this?",
       userName: "testuser",
@@ -61,7 +61,7 @@ describe('AIService - Embed Media Extraction', () => {
       }
     };
 
-    const result = formatApiMessages(input);
+    const result = await formatApiMessages(input);
     
     expect(result).toHaveLength(1);
     const imageContent = result[0].content.find(item => item.type === 'image_url');
@@ -70,7 +70,7 @@ describe('AIService - Embed Media Extraction', () => {
     expect(imageContent.image_url.url).toBe("https://example.com/art.jpg");
   });
 
-  test('should prioritize audio over image from embeds', () => {
+  test('should prioritize audio over image from embeds', async () => {
     const input = {
       messageContent: "Listen to this!",
       userName: "testuser",
@@ -85,7 +85,7 @@ describe('AIService - Embed Media Extraction', () => {
       }
     };
 
-    const result = formatApiMessages(input);
+    const result = await formatApiMessages(input);
     
     expect(result).toHaveLength(1);
     const audioContent = result[0].content.find(item => item.type === 'audio_url');
@@ -97,7 +97,7 @@ describe('AIService - Embed Media Extraction', () => {
     expect(imageContent).toBeUndefined();
   });
 
-  test('should fall back to text extraction if media URLs not provided', () => {
+  test('should fall back to text extraction if media URLs not provided', async () => {
     const input = {
       messageContent: "Check this out",
       userName: "testuser",
@@ -111,7 +111,7 @@ describe('AIService - Embed Media Extraction', () => {
       }
     };
 
-    const result = formatApiMessages(input);
+    const result = await formatApiMessages(input);
     
     expect(result).toHaveLength(1);
     const imageContent = result[0].content.find(item => item.type === 'image_url');
@@ -120,7 +120,7 @@ describe('AIService - Embed Media Extraction', () => {
     expect(imageContent.image_url.url).toBe("https://example.com/oldformat.jpg");
   });
 
-  test('should clean embed references from text when media is included', () => {
+  test('should clean embed references from text when media is included', async () => {
     const input = {
       messageContent: "What's this?",
       userName: "testuser",
@@ -134,7 +134,7 @@ describe('AIService - Embed Media Extraction', () => {
       }
     };
 
-    const result = formatApiMessages(input);
+    const result = await formatApiMessages(input);
     
     const textContent = result[0].content.find(item => item.type === 'text');
     

--- a/tests/unit/aiService.error.test.js
+++ b/tests/unit/aiService.error.test.js
@@ -399,7 +399,7 @@ describe('aiService Error Handling', () => {
     test('getAiResponse should use personality error message for empty responses', async () => {
       // Configure personality with custom error message
       const { getPersonality } = require('../../src/core/personality');
-      getPersonality.mockReturnValue({
+      getPersonality.mockResolvedValue({
         fullName: 'test-personality',
         errorMessage: 'My circuits are fried! ||*(an error has occurred)*||'
       });

--- a/tests/unit/aiService.reference.test.js
+++ b/tests/unit/aiService.reference.test.js
@@ -35,7 +35,7 @@ describe('AI Service Reference Message Handling', () => {
   });
 
   describe('formatApiMessages with referenced messages', () => {
-    it('should properly format text-only referenced messages from users', () => {
+    it('should properly format text-only referenced messages from users', async () => {
       const input = {
         messageContent: "What do you think about this?",
         referencedMessage: {
@@ -45,7 +45,7 @@ describe('AI Service Reference Message Handling', () => {
         }
       };
       
-      const result = formatApiMessages(input);
+      const result = await formatApiMessages(input);
       
       // Should have one combined message with all content
       expect(result.length).toBe(1);
@@ -62,7 +62,7 @@ describe('AI Service Reference Message Handling', () => {
       expect(textContent.text).toContain('I believe AI has both benefits and risks');
     });
     
-    it('should properly format text-only referenced messages from the bot', () => {
+    it('should properly format text-only referenced messages from the bot', async () => {
       const input = {
         messageContent: "Please elaborate on that.",
         referencedMessage: {
@@ -72,7 +72,7 @@ describe('AI Service Reference Message Handling', () => {
         }
       };
       
-      const result = formatApiMessages(input);
+      const result = await formatApiMessages(input);
       
       // Should have one combined message with all content
       expect(result.length).toBe(1);
@@ -89,7 +89,7 @@ describe('AI Service Reference Message Handling', () => {
       expect(textContent.text).toContain('The concept of artificial intelligence raises profound philosophical questions');
     });
     
-    it('should handle problematic content in referenced messages', () => {
+    it('should handle problematic content in referenced messages', async () => {
       const input = {
         messageContent: "What's wrong with this message?",
         referencedMessage: {
@@ -99,7 +99,7 @@ describe('AI Service Reference Message Handling', () => {
         }
       };
       
-      const result = formatApiMessages(input);
+      const result = await formatApiMessages(input);
       
       // Should have one combined message with all content
       expect(result.length).toBe(1);
@@ -130,7 +130,7 @@ describe('AI Service Reference Message Handling', () => {
       // Removed as it's now tested above
     });
     
-    it('should handle image references', () => {
+    it('should handle image references', async () => {
       const input = {
         messageContent: "Tell me about this image",
         referencedMessage: {
@@ -140,7 +140,7 @@ describe('AI Service Reference Message Handling', () => {
         }
       };
       
-      const result = formatApiMessages(input);
+      const result = await formatApiMessages(input);
       
       // Should have one combined message with all content
       expect(result.length).toBe(1);
@@ -161,7 +161,7 @@ describe('AI Service Reference Message Handling', () => {
       expect(imageItem.image_url.url).toBe('https://example.com/image.jpg');
     });
     
-    it('should handle audio references', () => {
+    it('should handle audio references', async () => {
       const input = {
         messageContent: "What's in this recording?",
         referencedMessage: {
@@ -171,7 +171,7 @@ describe('AI Service Reference Message Handling', () => {
         }
       };
       
-      const result = formatApiMessages(input);
+      const result = await formatApiMessages(input);
       
       // Should have one combined message with all content
       expect(result.length).toBe(1);
@@ -192,7 +192,7 @@ describe('AI Service Reference Message Handling', () => {
       expect(audioItem.audio_url.url).toBe('https://example.com/audio.mp3');
     });
     
-    it('should handle references to the same personality', () => {
+    it('should handle references to the same personality', async () => {
       const input = {
         messageContent: "Tell me more about that",
         referencedMessage: {
@@ -205,7 +205,7 @@ describe('AI Service Reference Message Handling', () => {
       };
       
       // Use the same personality name in the formatApiMessages call
-      const result = formatApiMessages(input, "albert-einstein");
+      const result = await formatApiMessages(input, "albert-einstein");
       
       // Should have one combined message with all content
       expect(result.length).toBe(1);
@@ -222,7 +222,7 @@ describe('AI Service Reference Message Handling', () => {
       expect(textContent.text).toContain("I am an AI assistant with many capabilities");
     });
     
-    it('should handle references to different personalities', () => {
+    it('should handle references to different personalities', async () => {
       const input = {
         messageContent: "What do you think about that?",
         referencedMessage: {
@@ -235,7 +235,7 @@ describe('AI Service Reference Message Handling', () => {
       };
       
       // Use a different personality name in the formatApiMessages call
-      const result = formatApiMessages(input, "sigmund-freud");
+      const result = await formatApiMessages(input, "sigmund-freud");
       
       // Should have one combined message with all content
       expect(result.length).toBe(1);
@@ -252,7 +252,7 @@ describe('AI Service Reference Message Handling', () => {
       expect(textContent.text).toContain("Time is relative to the observer");
     });
 
-    it('should handle user self-references with first person format', () => {
+    it('should handle user self-references with first person format', async () => {
       const input = {
         messageContent: "Actually, let me clarify that point",
         referencedMessage: {
@@ -263,7 +263,7 @@ describe('AI Service Reference Message Handling', () => {
         userName: "CurrentUser"
       };
       
-      const result = formatApiMessages(input);
+      const result = await formatApiMessages(input);
       
       // Should have one combined message with all content
       expect(result.length).toBe(1);
@@ -281,7 +281,7 @@ describe('AI Service Reference Message Handling', () => {
       expect(textContent.text).not.toContain("CurrentUser said:");
     });
 
-    it('should handle user self-references with audio (scenario 3.2)', () => {
+    it('should handle user self-references with audio (scenario 3.2)', async () => {
       const input = {
         messageContent: "Let me try this again with better context:",
         referencedMessage: {
@@ -292,7 +292,7 @@ describe('AI Service Reference Message Handling', () => {
         userName: "CurrentUser"
       };
       
-      const result = formatApiMessages(input);
+      const result = await formatApiMessages(input);
       
       // Should have one combined message with all content
       expect(result.length).toBe(1);
@@ -316,7 +316,7 @@ describe('AI Service Reference Message Handling', () => {
       expect(audioContent.audio_url.url).toBe("https://example.com/my-audio.mp3");
     });
 
-    it('should handle user self-references with audio (scenario 5.2)', () => {
+    it('should handle user self-references with audio (scenario 5.2)', async () => {
       const input = {
         messageContent: "Let me add more context to this audio",
         referencedMessage: {
@@ -327,7 +327,7 @@ describe('AI Service Reference Message Handling', () => {
         userName: "CurrentUser"
       };
       
-      const result = formatApiMessages(input);
+      const result = await formatApiMessages(input);
       
       // Should have one combined message with all content
       expect(result.length).toBe(1);
@@ -351,7 +351,7 @@ describe('AI Service Reference Message Handling', () => {
       expect(audioContent.audio_url.url).toBe("https://example.com/my-recording.mp3");
     });
 
-    it('should handle user self-references using user IDs', () => {
+    it('should handle user self-references using user IDs', async () => {
       const input = {
         messageContent: "What did I mean by that?",
         userId: "user123", // Current user ID
@@ -364,7 +364,7 @@ describe('AI Service Reference Message Handling', () => {
         }
       };
       
-      const result = formatApiMessages(input);
+      const result = await formatApiMessages(input);
       
       // Should have one combined message
       expect(result.length).toBe(1);
@@ -379,7 +379,7 @@ describe('AI Service Reference Message Handling', () => {
       expect(textContent.text).not.toContain("JohnDoe said:");
     });
 
-    it('should not treat as self-reference when user IDs differ', () => {
+    it('should not treat as self-reference when user IDs differ', async () => {
       const input = {
         messageContent: "What does John think?",
         userId: "user456", // Current user ID
@@ -392,7 +392,7 @@ describe('AI Service Reference Message Handling', () => {
         }
       };
       
-      const result = formatApiMessages(input);
+      const result = await formatApiMessages(input);
       
       // Should have one combined message
       expect(result.length).toBe(1);
@@ -407,7 +407,7 @@ describe('AI Service Reference Message Handling', () => {
       expect(textContent.text).not.toContain("I said:");
     });
 
-    it('should fall back to username comparison when user IDs are not available', () => {
+    it('should fall back to username comparison when user IDs are not available', async () => {
       const input = {
         messageContent: "Let me clarify",
         userName: "TestUser",
@@ -420,7 +420,7 @@ describe('AI Service Reference Message Handling', () => {
         }
       };
       
-      const result = formatApiMessages(input);
+      const result = await formatApiMessages(input);
       
       // Should still detect self-reference by username
       const textContent = result[0].content.find(item => item.type === 'text');
@@ -430,7 +430,7 @@ describe('AI Service Reference Message Handling', () => {
       expect(textContent.text).toContain("This needs more explanation");
     });
 
-    it('should use personalityDisplayName when displayName is not available', () => {
+    it('should use personalityDisplayName when displayName is not available', async () => {
       const input = {
         messageContent: "Can you elaborate on that?",
         referencedMessage: {
@@ -443,7 +443,7 @@ describe('AI Service Reference Message Handling', () => {
         }
       };
       
-      const result = formatApiMessages(input, "sigmund-freud");
+      const result = await formatApiMessages(input, "sigmund-freud");
       
       // Should have one combined message
       expect(result.length).toBe(1);
@@ -457,7 +457,7 @@ describe('AI Service Reference Message Handling', () => {
       expect(textContent.text).toContain("I believe in the power of the unconscious mind");
     });
 
-    it('should handle DM personality format references correctly', () => {
+    it('should handle DM personality format references correctly', async () => {
       const input = {
         messageContent: "Tell me more about that theory",
         referencedMessage: {
@@ -469,7 +469,7 @@ describe('AI Service Reference Message Handling', () => {
         }
       };
       
-      const result = formatApiMessages(input, "albert-einstein");
+      const result = await formatApiMessages(input, "albert-einstein");
       
       // Should have one combined message
       expect(result.length).toBe(1);
@@ -485,7 +485,7 @@ describe('AI Service Reference Message Handling', () => {
       expect(textContent.text).toContain("The theory of relativity shows us that time and space are interconnected");
     });
 
-    it('should not include reference when replying to same personality recently', () => {
+    it('should not include reference when replying to same personality recently', async () => {
       // This test verifies that the personality handler's logic for skipping
       // same-personality references is working correctly
       const input = {
@@ -502,7 +502,7 @@ describe('AI Service Reference Message Handling', () => {
       // In the actual implementation, personalityHandler.js checks if it's the same
       // personality and skips adding the reference. We can test that formatApiMessages
       // handles the case where no reference is provided (simulating the skip)
-      const resultWithoutReference = formatApiMessages("Continue that thought", "sigmund-freud");
+      const resultWithoutReference = await formatApiMessages("Continue that thought", "sigmund-freud");
       
       // Should have simple message without reference
       expect(resultWithoutReference.length).toBe(1);

--- a/tests/unit/aiService.test.js
+++ b/tests/unit/aiService.test.js
@@ -165,7 +165,7 @@ describe('AI Service', () => {
   
   // Unit test for isErrorResponse function
   describe('isErrorResponse', () => {
-    it('should return true for high confidence error patterns', () => {
+    it('should return true for high confidence error patterns', async () => {
       const highConfidenceErrors = [
         'NoneType object has no attribute',
         'AttributeError occurred in processing',
@@ -183,7 +183,7 @@ describe('AI Service', () => {
       }
     });
     
-    it('should return true for low confidence patterns with sufficient context', () => {
+    it('should return true for low confidence patterns with sufficient context', async () => {
       const contextualErrors = [
         'Error: something went wrong with the connection',
         'Traceback (most recent call last):\n  File "app.py", line 42',
@@ -197,7 +197,7 @@ describe('AI Service', () => {
       }
     });
     
-    it('should return false for normal responses even with error-like terms', () => {
+    it('should return false for normal responses even with error-like terms', async () => {
       const normalResponses = [
         'Hello, how can I help you today?',
         'That\'s an interesting question about philosophy.',
@@ -215,7 +215,7 @@ describe('AI Service', () => {
       }
     });
     
-    it('should return true for empty or null content', () => {
+    it('should return true for empty or null content', async () => {
       expect(isErrorResponse('')).toBe(true);
       expect(isErrorResponse(null)).toBe(true);
       expect(isErrorResponse(undefined)).toBe(true);
@@ -225,7 +225,7 @@ describe('AI Service', () => {
   
   // Unit test for createBlackoutKey and blackout period functions
   describe('Blackout Period Management', () => {
-    it('should create a unique blackout key for a personality-user-channel combination', () => {
+    it('should create a unique blackout key for a personality-user-channel combination', async () => {
       const personalityName = 'test-personality';
       const context = { userId: 'user-123', channelId: 'channel-456' };
       
@@ -233,7 +233,7 @@ describe('AI Service', () => {
       expect(key).toBe('test-personality_user-123_channel-456');
     });
     
-    it('should handle missing userId or channelId in context', () => {
+    it('should handle missing userId or channelId in context', async () => {
       const personalityName = 'test-personality';
       
       // Missing both
@@ -249,7 +249,7 @@ describe('AI Service', () => {
       expect(key).toBe('test-personality_anon_channel-456');
     });
     
-    it('should add a personality to the blackout list', () => {
+    it('should add a personality to the blackout list', async () => {
       const personalityName = 'test-personality';
       const context = { userId: 'user-123', channelId: 'channel-456' };
       
@@ -262,7 +262,7 @@ describe('AI Service', () => {
       expect(expirationTime).toBeGreaterThan(Date.now());
     });
     
-    it('should accept a custom duration when adding to blackout list', () => {
+    it('should accept a custom duration when adding to blackout list', async () => {
       const personalityName = 'test-personality';
       const context = { userId: 'user-123', channelId: 'channel-456' };
       const customDuration = 60000; // 1 minute
@@ -277,7 +277,7 @@ describe('AI Service', () => {
       expect(expirationTime).toBeGreaterThanOrEqual(expectedMinTime);
     });
     
-    it('should detect when a personality is in a blackout period', () => {
+    it('should detect when a personality is in a blackout period', async () => {
       const personalityName = 'test-personality';
       const context = { userId: 'user-123', channelId: 'channel-456' };
       const key = createBlackoutKey(personalityName, context);
@@ -287,7 +287,7 @@ describe('AI Service', () => {
       expect(isInBlackoutPeriod(personalityName, context)).toBe(true);
     });
     
-    it('should detect when a personality is not in a blackout period', () => {
+    it('should detect when a personality is not in a blackout period', async () => {
       const personalityName = 'test-personality';
       const context = { userId: 'user-123', channelId: 'channel-456' };
       
@@ -308,16 +308,16 @@ describe('AI Service', () => {
   describe('formatApiMessages', () => {
     const { formatApiMessages } = require('../../src/aiService');
     
-    it('should format a simple string message correctly', () => {
+    it('should format a simple string message correctly', async () => {
       const message = 'Hello, how are you?';
-      const formattedMessages = formatApiMessages(message);
+      const formattedMessages = await formatApiMessages(message);
       
       expect(formattedMessages).toEqual([
         { role: 'user', content: message }
       ]);
     });
     
-    it('should handle multimodal content array with image', () => {
+    it('should handle multimodal content array with image', async () => {
       const multimodalContent = [
         {
           type: 'text',
@@ -331,14 +331,14 @@ describe('AI Service', () => {
         }
       ];
       
-      const formattedMessages = formatApiMessages(multimodalContent);
+      const formattedMessages = await formatApiMessages(multimodalContent);
       
       expect(formattedMessages).toEqual([
         { role: 'user', content: multimodalContent }
       ]);
     });
     
-    it('should handle multimodal content array with audio', () => {
+    it('should handle multimodal content array with audio', async () => {
       const multimodalContent = [
         {
           type: 'text',
@@ -352,20 +352,20 @@ describe('AI Service', () => {
         }
       ];
       
-      const formattedMessages = formatApiMessages(multimodalContent);
+      const formattedMessages = await formatApiMessages(multimodalContent);
       
       expect(formattedMessages).toEqual([
         { role: 'user', content: multimodalContent }
       ]);
     });
     
-    it('should not modify content array structure', () => {
+    it('should not modify content array structure', async () => {
       const multimodalContent = [
         { type: 'text', text: 'Text content' },
         { type: 'image_url', image_url: { url: 'https://example.com/image.png' } }
       ];
       
-      const formattedMessages = formatApiMessages(multimodalContent);
+      const formattedMessages = await formatApiMessages(multimodalContent);
       
       // Verify that the content array structure is preserved
       expect(formattedMessages[0].content).toBe(multimodalContent);
@@ -373,13 +373,13 @@ describe('AI Service', () => {
       expect(formattedMessages[0].content[1].type).toBe('image_url');
     });
     
-    it('should preserve audio content in multimodal array', () => {
+    it('should preserve audio content in multimodal array', async () => {
       const multimodalContent = [
         { type: 'text', text: 'Transcribe this' },
         { type: 'audio_url', audio_url: { url: 'https://example.com/audio.mp3' } }
       ];
       
-      const formattedMessages = formatApiMessages(multimodalContent);
+      const formattedMessages = await formatApiMessages(multimodalContent);
       
       // Verify that the audio content structure is preserved
       expect(formattedMessages[0].content).toBe(multimodalContent);
@@ -389,33 +389,33 @@ describe('AI Service', () => {
     });
 
     // PluralKit speaker identification tests
-    it('should add speaker identification for PluralKit messages', () => {
+    it('should add speaker identification for PluralKit messages', async () => {
       const message = 'Hello from PluralKit!';
       const personalityName = 'test-personality';
       const userName = 'Alice | Wonderland System';
       const isProxyMessage = true;
       
-      const formattedMessages = formatApiMessages(message, personalityName, userName, isProxyMessage);
+      const formattedMessages = await formatApiMessages(message, personalityName, userName, isProxyMessage);
       
       expect(formattedMessages).toEqual([
         { role: 'user', content: '[Alice | Wonderland System]: Hello from PluralKit!' }
       ]);
     });
 
-    it('should NOT add speaker identification for regular users', () => {
+    it('should NOT add speaker identification for regular users', async () => {
       const message = 'Hello from regular user!';
       const personalityName = 'test-personality';
       const userName = 'Bob (bob123)';
       const isProxyMessage = false;
       
-      const formattedMessages = formatApiMessages(message, personalityName, userName, isProxyMessage);
+      const formattedMessages = await formatApiMessages(message, personalityName, userName, isProxyMessage);
       
       expect(formattedMessages).toEqual([
         { role: 'user', content: 'Hello from regular user!' }
       ]);
     });
 
-    it('should add speaker identification to multimodal PluralKit messages', () => {
+    it('should add speaker identification to multimodal PluralKit messages', async () => {
       const multimodalContent = [
         { type: 'text', text: 'What is this?' },
         { type: 'image_url', image_url: { url: 'https://example.com/image.jpg' } }
@@ -424,7 +424,7 @@ describe('AI Service', () => {
       const userName = 'Charlie | Rainbow System';
       const isProxyMessage = true;
       
-      const formattedMessages = formatApiMessages(multimodalContent, personalityName, userName, isProxyMessage);
+      const formattedMessages = await formatApiMessages(multimodalContent, personalityName, userName, isProxyMessage);
       
       expect(formattedMessages).toEqual([
         { 
@@ -437,7 +437,7 @@ describe('AI Service', () => {
       ]);
     });
 
-    it('should NOT add speaker identification to multimodal regular user messages', () => {
+    it('should NOT add speaker identification to multimodal regular user messages', async () => {
       const multimodalContent = [
         { type: 'text', text: 'What is this?' },
         { type: 'image_url', image_url: { url: 'https://example.com/image.jpg' } }
@@ -446,19 +446,19 @@ describe('AI Service', () => {
       const userName = 'Dave (dave123)';
       const isProxyMessage = false;
       
-      const formattedMessages = formatApiMessages(multimodalContent, personalityName, userName, isProxyMessage);
+      const formattedMessages = await formatApiMessages(multimodalContent, personalityName, userName, isProxyMessage);
       
       expect(formattedMessages).toEqual([
         { role: 'user', content: multimodalContent }
       ]);
     });
 
-    it('should handle default userName parameter correctly', () => {
+    it('should handle default userName parameter correctly', async () => {
       const message = 'Test message';
       const personalityName = 'test-personality';
       // Not passing userName, should default to 'a user'
       
-      const formattedMessages = formatApiMessages(message, personalityName);
+      const formattedMessages = await formatApiMessages(message, personalityName);
       
       expect(formattedMessages).toEqual([
         { role: 'user', content: 'Test message' }
@@ -468,7 +468,7 @@ describe('AI Service', () => {
 
   // Unit test for createRequestId function
   describe('createRequestId', () => {
-    it('should create a unique request ID for tracking API requests', () => {
+    it('should create a unique request ID for tracking API requests', async () => {
       const personalityName = 'test-personality';
       const message = 'This is a test message';
       const context = { userId: 'user-123', channelId: 'channel-456' };
@@ -478,7 +478,7 @@ describe('AI Service', () => {
       expect(requestId).toMatch(/^test-personality_user-123_channel-456_Thisisatestmessage_h\d+$/);
     });
     
-    it('should handle long messages by truncating to 50 characters', () => {
+    it('should handle long messages by truncating to 50 characters', async () => {
       const personalityName = 'test-personality';
       const message = 'This is a very long message that should be truncated to only 50 characters now';
       const context = { userId: 'user-123', channelId: 'channel-456' };
@@ -488,7 +488,7 @@ describe('AI Service', () => {
       expect(requestId).toMatch(/^test-personality_user-123_channel-456_Thisisaverylongmessagethatshouldbetruncat_h\d+$/);
     });
     
-    it('should handle missing context values', () => {
+    it('should handle missing context values', async () => {
       const personalityName = 'test-personality';
       const message = 'Test message';
       
@@ -505,7 +505,7 @@ describe('AI Service', () => {
       expect(requestId).toMatch(/^test-personality_anon_channel-456_Testmessage_h\d+$/);
     });
     
-    it('should handle multimodal content arrays with images', () => {
+    it('should handle multimodal content arrays with images', async () => {
       const personalityName = 'test-personality';
       const multimodalContent = [
         {
@@ -536,7 +536,7 @@ describe('AI Service', () => {
       expect(requestId).toBe(requestId2);
     });
     
-    it('should handle multimodal content arrays with audio', () => {
+    it('should handle multimodal content arrays with audio', async () => {
       const personalityName = 'test-personality';
       const multimodalContent = [
         {
@@ -802,7 +802,7 @@ describe('AI Service', () => {
       webhookUserTracker.shouldBypassNsfwVerification.mockReturnValue(false);
     });
     
-    it('should delegate initAiClient to aiAuth module', () => {
+    it('should delegate initAiClient to aiAuth module', async () => {
       const { initAiClient } = require('../../src/aiService');
       const aiAuth = require('../../src/utils/aiAuth');
       

--- a/tests/unit/bot.message.reference.test.js
+++ b/tests/unit/bot.message.reference.test.js
@@ -16,7 +16,7 @@ describe('Message Reference Handling', () => {
     jest.clearAllMocks();
   });
   
-  it('should correctly format referenced messages for the API', () => {
+  it('should correctly format referenced messages for the API', async () => {
     // Test with text-only referenced message from another user
     const textRefMsg = {
       messageContent: "What do you think about this?",
@@ -27,7 +27,7 @@ describe('Message Reference Handling', () => {
       }
     };
     
-    const formattedTextRef = formatApiMessages(textRefMsg);
+    const formattedTextRef = await formatApiMessages(textRefMsg);
     
     // Should have one combined message
     expect(formattedTextRef).toHaveLength(1);
@@ -44,7 +44,7 @@ describe('Message Reference Handling', () => {
     expect(textItem.text).toContain('I believe AI will transform society');
   });
   
-  it('should correctly format referenced messages from bot/assistant', () => {
+  it('should correctly format referenced messages from bot/assistant', async () => {
     // Test with text-only referenced message from the bot
     const botRefMsg = {
       messageContent: "Can you elaborate on that?",
@@ -55,7 +55,7 @@ describe('Message Reference Handling', () => {
       }
     };
     
-    const formattedBotRef = formatApiMessages(botRefMsg);
+    const formattedBotRef = await formatApiMessages(botRefMsg);
     
     // Should have one combined message
     expect(formattedBotRef).toHaveLength(1);
@@ -71,7 +71,7 @@ describe('Message Reference Handling', () => {
     expect(textItem.text).toContain("The concept of emergence is fascinating in complex systems.");
   });
   
-  it('should correctly handle referenced messages with image content', () => {
+  it('should correctly handle referenced messages with image content', async () => {
     // Test with referenced message containing an image
     const imageRefMsg = {
       messageContent: "What can you tell me about this image?",
@@ -82,7 +82,7 @@ describe('Message Reference Handling', () => {
       }
     };
     
-    const formattedImageRef = formatApiMessages(imageRefMsg);
+    const formattedImageRef = await formatApiMessages(imageRefMsg);
     
     // Should have one combined message
     expect(formattedImageRef).toHaveLength(1);
@@ -107,7 +107,7 @@ describe('Message Reference Handling', () => {
     expect(imageItem).toBeDefined();
   });
   
-  it('should handle multimodal content in the user message with references', () => {
+  it('should handle multimodal content in the user message with references', async () => {
     // Test with multimodal user message and a reference
     const multimodalMsg = {
       messageContent: [
@@ -121,7 +121,7 @@ describe('Message Reference Handling', () => {
       }
     };
     
-    const formattedMultimodalRef = formatApiMessages(multimodalMsg);
+    const formattedMultimodalRef = await formatApiMessages(multimodalMsg);
     
     // Should have one combined message
     expect(formattedMultimodalRef).toHaveLength(1);
@@ -152,10 +152,10 @@ describe('Message Reference Handling', () => {
     expect(refImageItem).toBeDefined();
   });
   
-  it('should handle regular user messages without references', () => {
+  it('should handle regular user messages without references', async () => {
     // Test with regular text message
     const textMsg = "Hello, how are you?";
-    const formattedText = formatApiMessages(textMsg);
+    const formattedText = await formatApiMessages(textMsg);
     
     // Should have one message
     expect(formattedText).toHaveLength(1);
@@ -168,7 +168,7 @@ describe('Message Reference Handling', () => {
       { type: 'image_url', image_url: { url: 'https://example.com/image.jpg' } }
     ];
     
-    const formattedMultimodal = formatApiMessages(multimodalArray);
+    const formattedMultimodal = await formatApiMessages(multimodalArray);
     
     // Should have one message with multimodal content
     expect(formattedMultimodal).toHaveLength(1);

--- a/tests/unit/bot.referenced.media.test.js
+++ b/tests/unit/bot.referenced.media.test.js
@@ -181,7 +181,7 @@ describe('Referenced Message Media Tests', () => {
     };
     
     // Test the formatApiMessages function directly
-    const formattedMessages = formatApiMessages(message);
+    const formattedMessages = await formatApiMessages(message);
     
     // Verify we get a single combined message
     expect(formattedMessages.length).toBe(1);
@@ -234,7 +234,7 @@ describe('Referenced Message Media Tests', () => {
     };
     
     // Test the formatApiMessages function directly
-    const formattedMessages = formatApiMessages(message);
+    const formattedMessages = await formatApiMessages(message);
     
     // Verify we get a single combined message
     expect(formattedMessages.length).toBe(1);
@@ -298,7 +298,7 @@ describe('Referenced Message Media Tests', () => {
     };
     
     // Test the formatApiMessages function directly
-    const formattedMessages = formatApiMessages(message);
+    const formattedMessages = await formatApiMessages(message);
     
     // Verify we get a single combined message
     expect(formattedMessages.length).toBe(1);
@@ -372,7 +372,7 @@ describe('Referenced Message Media Tests', () => {
     };
     
     // Test the formatApiMessages function directly
-    const formattedMessages = formatApiMessages(message);
+    const formattedMessages = await formatApiMessages(message);
     
     // Verify we get a single combined message
     expect(formattedMessages.length).toBe(1);

--- a/tests/unit/handlers/messageHandler.mentions.test.js
+++ b/tests/unit/handlers/messageHandler.mentions.test.js
@@ -21,44 +21,44 @@ describe('checkForPersonalityMentions', () => {
   });
 
   describe('single word mentions', () => {
-    it('should detect valid single-word personality mention', () => {
+    it('should detect valid single-word personality mention', async () => {
       const message = { content: '@TestBot hello', author: { id: 'user123' } };
-      getPersonality.mockReturnValue(null);
+      getPersonality.mockResolvedValue(null);
       getPersonalityByAlias.mockReturnValue({ fullName: 'test-bot' });
 
-      const result = checkForPersonalityMentions(message);
+      const result = await checkForPersonalityMentions(message);
 
       expect(result).toBe(true);
       expect(getPersonalityByAlias).toHaveBeenCalledWith('TestBot');
     });
 
-    it('should handle mention at end of message', () => {
+    it('should handle mention at end of message', async () => {
       const message = { content: 'hello @TestBot', author: { id: 'user123' } };
-      getPersonality.mockReturnValue(null);
+      getPersonality.mockResolvedValue(null);
       getPersonalityByAlias.mockReturnValue({ fullName: 'test-bot' });
 
-      const result = checkForPersonalityMentions(message);
+      const result = await checkForPersonalityMentions(message);
 
       expect(result).toBe(true);
     });
 
-    it('should handle mention with punctuation', () => {
+    it('should handle mention with punctuation', async () => {
       const message = { content: 'hello @TestBot!', author: { id: 'user123' } };
-      getPersonality.mockReturnValue(null);
+      getPersonality.mockResolvedValue(null);
       getPersonalityByAlias.mockReturnValue({ fullName: 'test-bot' });
 
-      const result = checkForPersonalityMentions(message);
+      const result = await checkForPersonalityMentions(message);
 
       expect(result).toBe(true);
       expect(getPersonalityByAlias).toHaveBeenCalledWith('TestBot');
     });
 
-    it('should return false for invalid mention', () => {
+    it('should return false for invalid mention', async () => {
       const message = { content: '@NonExistent hello', author: { id: 'user123' } };
-      getPersonality.mockReturnValue(null);
+      getPersonality.mockResolvedValue(null);
       getPersonalityByAlias.mockReturnValue(null);
 
-      const result = checkForPersonalityMentions(message);
+      const result = await checkForPersonalityMentions(message);
 
       expect(result).toBe(false);
     });
@@ -69,62 +69,62 @@ describe('checkForPersonalityMentions', () => {
       getMaxAliasWordCount.mockReturnValue(2); // Allow 2-word aliases
     });
 
-    it('should detect valid two-word personality mention', () => {
+    it('should detect valid two-word personality mention', async () => {
       const message = { content: '@angel dust hello', author: { id: 'user123' } };
-      getPersonality.mockReturnValue(null);
+      getPersonality.mockResolvedValue(null);
       getPersonalityByAlias.mockReturnValueOnce(null) // First check for "angel"
         .mockReturnValueOnce({ fullName: 'angel-dust-hazbin' }); // Second check for "angel dust"
 
-      const result = checkForPersonalityMentions(message);
+      const result = await checkForPersonalityMentions(message);
 
       expect(result).toBe(true);
       expect(getPersonalityByAlias).toHaveBeenCalledWith('angel dust');
     });
 
-    it('should handle multi-word mention at end of message', () => {
+    it('should handle multi-word mention at end of message', async () => {
       const message = { content: 'hello @angel dust', author: { id: 'user123' } };
-      getPersonality.mockReturnValue(null);
+      getPersonality.mockResolvedValue(null);
       getPersonalityByAlias.mockReturnValueOnce(null)
         .mockReturnValueOnce({ fullName: 'angel-dust-hazbin' });
 
-      const result = checkForPersonalityMentions(message);
+      const result = await checkForPersonalityMentions(message);
 
       expect(result).toBe(true);
     });
 
-    it('should handle multi-word mention with punctuation', () => {
+    it('should handle multi-word mention with punctuation', async () => {
       const message = { content: '@angel dust, how are you?', author: { id: 'user123' } };
-      getPersonality.mockReturnValue(null);
+      getPersonality.mockResolvedValue(null);
       getPersonalityByAlias.mockReturnValueOnce(null)
         .mockReturnValueOnce({ fullName: 'angel-dust-hazbin' });
 
-      const result = checkForPersonalityMentions(message);
+      const result = await checkForPersonalityMentions(message);
 
       expect(result).toBe(true);
       expect(getPersonalityByAlias).toHaveBeenCalledWith('angel dust');
     });
 
-    it('should handle three-word aliases when max is 3', () => {
+    it('should handle three-word aliases when max is 3', async () => {
       getMaxAliasWordCount.mockReturnValue(3);
       const message = { content: '@the dark lord speaks', author: { id: 'user123' } };
-      getPersonality.mockReturnValue(null);
+      getPersonality.mockResolvedValue(null);
       getPersonalityByAlias.mockReturnValueOnce(null) // "the"
         .mockReturnValueOnce(null) // "the dark"
         .mockReturnValueOnce({ fullName: 'the-dark-lord' }); // "the dark lord"
 
-      const result = checkForPersonalityMentions(message);
+      const result = await checkForPersonalityMentions(message);
 
       expect(result).toBe(true);
       expect(getPersonalityByAlias).toHaveBeenCalledWith('the dark lord');
     });
 
-    it('should not check beyond max word count', () => {
+    it('should not check beyond max word count', async () => {
       getMaxAliasWordCount.mockReturnValue(2); // Max 2 words
       const message = { content: '@one two three four', author: { id: 'user123' } };
-      getPersonality.mockReturnValue(null);
+      getPersonality.mockResolvedValue(null);
       getPersonalityByAlias.mockReturnValue(null);
 
-      checkForPersonalityMentions(message);
+      await checkForPersonalityMentions(message);
 
       // Should only check up to 2 words
       expect(getPersonalityByAlias).not.toHaveBeenCalledWith('one two three');
@@ -133,42 +133,42 @@ describe('checkForPersonalityMentions', () => {
   });
 
   describe('edge cases', () => {
-    it('should handle empty message content', () => {
+    it('should handle empty message content', async () => {
       const message = { content: '', author: { id: 'user123' } };
 
-      const result = checkForPersonalityMentions(message);
+      const result = await checkForPersonalityMentions(message);
 
       expect(result).toBe(false);
       expect(getPersonalityByAlias).not.toHaveBeenCalled();
     });
 
-    it('should handle null message content', () => {
+    it('should handle null message content', async () => {
       const message = { content: null, author: { id: 'user123' } };
 
-      const result = checkForPersonalityMentions(message);
+      const result = await checkForPersonalityMentions(message);
 
       expect(result).toBe(false);
     });
 
-    it('should handle multiple mentions and return true on first match', () => {
+    it('should handle multiple mentions and return true on first match', async () => {
       const message = { content: '@bot1 @bot2 hello', author: { id: 'user123' } };
-      getPersonality.mockReturnValue(null);
+      getPersonality.mockResolvedValue(null);
       getPersonalityByAlias.mockReturnValueOnce({ fullName: 'bot-1' }); // First mention matches
 
-      const result = checkForPersonalityMentions(message);
+      const result = await checkForPersonalityMentions(message);
 
       expect(result).toBe(true);
       expect(getPersonalityByAlias).toHaveBeenCalledTimes(1); // Stops after first match
     });
 
-    it('should handle mentions with multiple spaces', () => {
+    it('should handle mentions with multiple spaces', async () => {
       getMaxAliasWordCount.mockReturnValue(2);
       const message = { content: '@angel   dust hello', author: { id: 'user123' } };
-      getPersonality.mockReturnValue(null);
+      getPersonality.mockResolvedValue(null);
       getPersonalityByAlias.mockReturnValueOnce(null)
         .mockReturnValueOnce({ fullName: 'angel-dust-hazbin' });
 
-      const result = checkForPersonalityMentions(message);
+      const result = await checkForPersonalityMentions(message);
 
       expect(result).toBe(true);
       // Should normalize spaces
@@ -181,26 +181,26 @@ describe('checkForPersonalityMentions', () => {
   });
 
   describe('regex generation based on max word count', () => {
-    it('should generate correct regex for 1 word max', () => {
+    it('should generate correct regex for 1 word max', async () => {
       getMaxAliasWordCount.mockReturnValue(1);
       const message = { content: '@test mention', author: { id: 'user123' } };
-      getPersonality.mockReturnValue(null);
+      getPersonality.mockResolvedValue(null);
       getPersonalityByAlias.mockReturnValue(null);
 
-      checkForPersonalityMentions(message);
+      await checkForPersonalityMentions(message);
 
       // With max 1 word, should only check single words
       expect(getPersonalityByAlias).toHaveBeenCalledWith('test');
       expect(getPersonalityByAlias).not.toHaveBeenCalledWith('test mention');
     });
 
-    it('should generate correct regex for 5 word max', () => {
+    it('should generate correct regex for 5 word max', async () => {
       getMaxAliasWordCount.mockReturnValue(5);
       const message = { content: '@one two three four five six', author: { id: 'user123' } };
-      getPersonality.mockReturnValue(null);
+      getPersonality.mockResolvedValue(null);
       getPersonalityByAlias.mockReturnValue(null);
 
-      checkForPersonalityMentions(message);
+      await checkForPersonalityMentions(message);
 
       // Should check up to 5 words
       expect(getPersonalityByAlias).toHaveBeenCalledWith('one two three four five');

--- a/tests/unit/utils/aiMessageFormatter.webhook.test.js
+++ b/tests/unit/utils/aiMessageFormatter.webhook.test.js
@@ -27,8 +27,8 @@ describe('aiMessageFormatter - Webhook Name Handling', () => {
   });
 
   describe('formatApiMessages with webhook references', () => {
-    it('should use webhook name when personality info is not available', () => {
-      getPersonality.mockReturnValue(null); // No personality found
+    it('should use webhook name when personality info is not available', async () => {
+      getPersonality.mockResolvedValue(null); // No personality found
       
       const content = {
         messageContent: 'Hello',
@@ -43,7 +43,7 @@ describe('aiMessageFormatter - Webhook Name Handling', () => {
         }
       };
 
-      const result = formatApiMessages(content, 'test-personality');
+      const result = await formatApiMessages(content, 'test-personality');
       
       // The content is returned as an array with text objects
       expect(result).toBeDefined();
@@ -55,8 +55,8 @@ describe('aiMessageFormatter - Webhook Name Handling', () => {
       expect(textContent).not.toContain('the bot said');
     });
 
-    it('should use author name as fallback when webhook name is not available', () => {
-      getPersonality.mockReturnValue(null);
+    it('should use author name as fallback when webhook name is not available', async () => {
+      getPersonality.mockResolvedValue(null);
       
       const content = {
         messageContent: 'Hello',
@@ -71,15 +71,15 @@ describe('aiMessageFormatter - Webhook Name Handling', () => {
         }
       };
 
-      const result = formatApiMessages(content, 'test-personality');
+      const result = await formatApiMessages(content, 'test-personality');
       
       const textContent = result[0].content[0].text;
       expect(textContent).toContain('AuthorName said');
       expect(textContent).not.toContain('the bot said');
     });
 
-    it('should only use "the bot" as last resort', () => {
-      getPersonality.mockReturnValue(null);
+    it('should only use "the bot" as last resort', async () => {
+      getPersonality.mockResolvedValue(null);
       
       const content = {
         messageContent: 'Hello',
@@ -94,19 +94,19 @@ describe('aiMessageFormatter - Webhook Name Handling', () => {
         }
       };
 
-      const result = formatApiMessages(content, 'test-personality');
+      const result = await formatApiMessages(content, 'test-personality');
       
       // Only use 'the bot' when all other options are null
       const textContent = result[0].content[0].text;
       expect(textContent).toContain('the bot said');
     });
 
-    it('should prefer personality display name when available', () => {
+    it('should prefer personality display name when available', async () => {
       const mockPersonality = {
         fullName: 'test-personality-full',
         displayName: 'Test Display'
       };
-      getPersonality.mockReturnValue(mockPersonality);
+      getPersonality.mockResolvedValue(mockPersonality);
       
       const content = {
         messageContent: 'Hello',
@@ -121,15 +121,15 @@ describe('aiMessageFormatter - Webhook Name Handling', () => {
         }
       };
 
-      const result = formatApiMessages(content, 'other-personality');
+      const result = await formatApiMessages(content, 'other-personality');
       
       // Should use personality display name when available
       const textContent = result[0].content[0].text;
       expect(textContent).toContain('Test Display (test-personality-full) said');
     });
 
-    it('should handle proxy system webhooks with proper names', () => {
-      getPersonality.mockReturnValue(null);
+    it('should handle proxy system webhooks with proper names', async () => {
+      getPersonality.mockResolvedValue(null);
       
       const content = {
         messageContent: 'Response to proxy',
@@ -144,15 +144,15 @@ describe('aiMessageFormatter - Webhook Name Handling', () => {
         }
       };
 
-      const result = formatApiMessages(content, 'test-personality');
+      const result = await formatApiMessages(content, 'test-personality');
       
       const textContent = result[0].content[0].text;
       expect(textContent).toContain('ProxyMember said');
       expect(textContent).toContain('Message from proxy system');
     });
 
-    it('should handle media references with webhook names', () => {
-      getPersonality.mockReturnValue(null);
+    it('should handle media references with webhook names', async () => {
+      getPersonality.mockResolvedValue(null);
       
       const content = {
         messageContent: 'Nice image!',
@@ -168,15 +168,15 @@ describe('aiMessageFormatter - Webhook Name Handling', () => {
         }
       };
 
-      const result = formatApiMessages(content, 'test-personality');
+      const result = await formatApiMessages(content, 'test-personality');
       
       const textContent = result[0].content[0].text;
       expect(textContent).toContain('CustomWebhook said (with an image)');
       expect(textContent).toContain('Check this out');
     });
 
-    it('should handle self-references correctly', () => {
-      getPersonality.mockReturnValue(null);
+    it('should handle self-references correctly', async () => {
+      getPersonality.mockResolvedValue(null);
       
       const content = {
         messageContent: 'Correction',
@@ -193,7 +193,7 @@ describe('aiMessageFormatter - Webhook Name Handling', () => {
         }
       };
 
-      const result = formatApiMessages(content, 'test-personality');
+      const result = await formatApiMessages(content, 'test-personality');
       
       // Should use "I said" for self-references
       const textContent = result[0].content[0].text;
@@ -203,8 +203,8 @@ describe('aiMessageFormatter - Webhook Name Handling', () => {
   });
 
   describe('Edge cases', () => {
-    it('should handle missing reference data gracefully', () => {
-      getPersonality.mockReturnValue(null);
+    it('should handle missing reference data gracefully', async () => {
+      getPersonality.mockResolvedValue(null);
       
       const content = {
         messageContent: 'Hello',
@@ -220,7 +220,7 @@ describe('aiMessageFormatter - Webhook Name Handling', () => {
         }
       };
 
-      const result = formatApiMessages(content, 'test-personality');
+      const result = await formatApiMessages(content, 'test-personality');
       
       // Should still work with fallback
       expect(result).toBeDefined();
@@ -228,8 +228,8 @@ describe('aiMessageFormatter - Webhook Name Handling', () => {
       expect(textContent).toContain('the bot said');
     });
 
-    it('should handle empty webhook names', () => {
-      getPersonality.mockReturnValue(null);
+    it('should handle empty webhook names', async () => {
+      getPersonality.mockResolvedValue(null);
       
       const content = {
         messageContent: 'Hello',
@@ -244,7 +244,7 @@ describe('aiMessageFormatter - Webhook Name Handling', () => {
         }
       };
 
-      const result = formatApiMessages(content, 'test-personality');
+      const result = await formatApiMessages(content, 'test-personality');
       
       // Should fall back to author
       const textContent = result[0].content[0].text;


### PR DESCRIPTION
## Summary
- Fixed personality loading to be async so error messages are properly displayed
- Applied linting and formatting fixes

## Context
When getPersonality was synchronous, it couldn't properly load personality-specific error messages from disk. This PR makes it async to ensure error messages load correctly before being used.

## Test plan
- [x] Existing tests pass
- [x] Error messages now display correctly when personality loading fails
- [x] No regressions in personality functionality

🤖 Generated with [Claude Code](https://claude.ai/code)