### PR TITLE
feat: add backup support for knowledge, training, and user personalization data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,12 +19,7 @@ SERVICE_ID=your_service_id
 SERVICE_APP_ID=your_service_app_id
 SERVICE_API_KEY=your_service_api_key
 SERVICE_WEBSITE=https://app.example.com
-
-# Profile information paths
-# Public profile path (no auth required)
-PROFILE_INFO_PUBLIC_PATH=public/personalities
-# Private profile path (requires auth)
-PROFILE_INFO_PRIVATE_PATH=personalities/username
+PERSONALITY_JARGON_TERM=personalities
 
 # Owner's personalities (comma-separated)
 BOT_OWNER_PERSONALITIES=albert-einstein,sigmund-freud,carl-jung,marie-curie

--- a/config.js
+++ b/config.js
@@ -2,7 +2,6 @@
 require('dotenv').config();
 
 // Environment detection
-// eslint-disable-next-line no-restricted-syntax -- Config file needs to check environment
 const isDevelopment = process.env.NODE_ENV === 'development';
 
 // Bot configuration - all values come from environment variables
@@ -31,14 +30,26 @@ function getServiceId() {
   return process.env.SERVICE_ID;
 }
 
+// Function to get the personality jargon term (e.g., "personalities", "agents", "characters")
+function getPersonalityJargonTerm() {
+  return process.env.PERSONALITY_JARGON_TERM;
+}
+
 // Function to get the complete model path for a personality
 function getModelPath(personalityName) {
   return `${getServiceId()}/${personalityName}`;
 }
 
-// Function to get the profile info endpoint for a personality
+// Function to get the profile info endpoint for a personality (public)
 function getProfileInfoEndpoint(personalityName) {
-  return `${process.env.SERVICE_WEBSITE}/api/${process.env.PROFILE_INFO_PUBLIC_PATH}/${personalityName}`;
+  const jargonTerm = getPersonalityJargonTerm();
+  return `${process.env.SERVICE_WEBSITE}/api/public/${jargonTerm}/${personalityName}`;
+}
+
+// Function to get the private profile info path for backup operations
+function getPrivateProfileInfoPath() {
+  const jargonTerm = getPersonalityJargonTerm();
+  return `${jargonTerm}/username`;
 }
 
 // Public server configuration
@@ -70,6 +81,8 @@ module.exports = {
   getApiEndpoint,
   getModelPath,
   getProfileInfoEndpoint,
+  getPrivateProfileInfoPath,
+  getPersonalityJargonTerm,
   botPrefix,
   botConfig,
   avatarConfig,

--- a/docs/ddd/DDD_PHASE_2_ADAPTER_COMPLETION.md
+++ b/docs/ddd/DDD_PHASE_2_ADAPTER_COMPLETION.md
@@ -40,7 +40,7 @@ The adapter layer implementation for DDD Phase 2 has been successfully completed
 ## Key Design Decisions
 
 ### 1. Provider-Agnostic AI Adapters
-Per user request, the AI adapter implementation avoids any hardcoded references to specific providers (e.g., shapes.inc). Configuration is handled through:
+Per user request, the AI adapter implementation avoids any hardcoded references to specific providers. Configuration is handled through:
 - Environment variables for base URLs
 - Factory pattern for provider-specific configurations
 - Transformation functions for request/response mapping

--- a/scripts/README_BACKUP_SCRIPT.md
+++ b/scripts/README_BACKUP_SCRIPT.md
@@ -1,0 +1,88 @@
+# Personality Service Data Backup Script
+
+A standalone Node.js script to backup your personality data from external personality services, including memories, knowledge, training data, and user personalization settings.
+
+## Prerequisites
+
+- Node.js installed on your computer
+- An active account on the personality service
+- Your personality usernames
+
+## Quick Start
+
+1. **Download the script**: Save `backup-personalities-data.js` to your computer
+
+2. **Get your session cookie**:
+
+   - Log into the personality service in your browser
+   - Open Developer Tools (F12)
+   - Go to Application/Storage → Cookies (Chrome/Edge) or Storage → Cookies (Firefox)
+   - Find the `appSession` cookie (or similar session cookie)
+   - Copy its VALUE (the long string, not the whole cookie)
+
+3. **Run the backup**:
+   ```bash
+   SERVICE_COOKIE="your-cookie-value" \
+   SERVICE_WEBSITE="https://service.example.com" \
+   PERSONALITY_JARGON_TERM="personalities" \
+   node backup-personalities-data.js personality1 personality2
+   ```
+
+## What Gets Backed Up
+
+For each personality, the script saves:
+
+- **Profile data** - Basic personality information
+- **Memories** - All conversation memories (paginated)
+- **Knowledge/Story** - Knowledge base entries
+- **Training data** - Training examples
+- **User personalization** - Your specific settings and customizations
+
+## Output Structure
+
+```
+data/service-backup/
+└── personality-name/
+    ├── personality-name.json                    # Profile data
+    ├── personality-name_memories.json           # All memories
+    ├── personality-name_knowledge.json          # Knowledge/story data
+    ├── personality-name_training.json           # Training data
+    └── personality-name_user_personalization.json # User settings
+```
+
+## Environment Variables
+
+- `SERVICE_COOKIE` (required) - Your session cookie value
+- `SERVICE_WEBSITE` (required) - The service URL (e.g., https://service.example.com)
+- `PERSONALITY_JARGON_TERM` (required) - The service's term for personalities (e.g., "personalities", "agents", "characters")
+
+## Tips
+
+- The script is respectful of the API with 1-second delays between requests
+- Memories are automatically sorted chronologically (oldest first)
+- You can run the script multiple times - it will update existing backups
+- The script creates the output directory automatically
+
+## Privacy & Security
+
+- Your session cookie is only used locally by the script
+- All data is saved to your local machine
+- No data is sent anywhere except to the personality service to retrieve your information
+
+## Troubleshooting
+
+**"SERVICE_COOKIE environment variable required"**
+
+- Make sure you're providing the cookie value when running the script
+
+**"HTTP 401" errors**
+
+- Your session cookie may have expired. Get a fresh one from your browser
+
+**"No personalities specified"**
+
+- Add the personality usernames at the end of the command
+
+## License
+
+This script is provided as-is for personal backup purposes.

--- a/scripts/backup-personalities-data.js
+++ b/scripts/backup-personalities-data.js
@@ -1,22 +1,24 @@
 #!/usr/bin/env node
 
 /**
- * External Service Data Backup Script
- * 
- * Pulls complete personality data including memories from the external service
- * 
+ * Standalone Personality Data Backup Script
+ *
+ * This script is completely self-contained with no external dependencies.
+ * It backs up complete personality data including memories, knowledge, training,
+ * and user personalization from external personality services.
+ *
  * Usage:
  * 1. Log into the external service in your browser
  * 2. Open Developer Tools (F12)
  * 3. Go to Application/Storage → Cookies (Chrome/Edge) or Storage → Cookies (Firefox)
  * 4. Find the `appSession` cookie
  * 5. Copy its VALUE (the long string, not the whole cookie)
- * 6. Run: SERVICE_COOKIE="your-cookie-value" SERVICE_WEBSITE="https://service.example.com" PROFILE_INFO_PRIVATE_PATH="personalities/username" node scripts/backup-personalities-data.js personality1 personality2
- * 
+ * 6. Run: SERVICE_COOKIE="your-cookie-value" SERVICE_WEBSITE="https://service.example.com" PERSONALITY_JARGON_TERM="personalities" node scripts/backup-personalities-data.js personality1 personality2
+ *
  * Alternative method (from Network tab):
  * 1. Open Network tab in DevTools
- * 2. Visit any personality page  
- * 3. Find request to /api/personalities/username/ (or your configured PROFILE_INFO_PRIVATE_PATH)
+ * 2. Visit any personality page
+ * 3. Find request to /api/{jargon_term}/username/ (e.g., /api/personalities/username/)
  * 4. Look at Request Headers → Cookie header
  * 5. Copy only the appSession=xxx part
  */
@@ -29,7 +31,7 @@ const https = require('https');
 const OUTPUT_DIR = path.join(__dirname, '..', 'data', 'service-backup');
 const SERVICE_COOKIE = process.env.SERVICE_COOKIE;
 const SERVICE_WEBSITE = process.env.SERVICE_WEBSITE;
-const PROFILE_INFO_PRIVATE_PATH = process.env.PROFILE_INFO_PRIVATE_PATH;
+const PERSONALITY_JARGON_TERM = process.env.PERSONALITY_JARGON_TERM;
 const DELAY_BETWEEN_REQUESTS = 1000; // Be respectful, 1 second between requests
 
 if (!SERVICE_COOKIE) {
@@ -41,7 +43,9 @@ if (!SERVICE_COOKIE) {
   console.error('4. Find the `appSession` cookie');
   console.error('5. Copy its VALUE (the long string)\n');
   console.error('Example:');
-  console.error('SERVICE_COOKIE="abc123..." SERVICE_WEBSITE="https://service.com" node scripts/backup-personalities-data.js personality1\n');
+  console.error(
+    'SERVICE_COOKIE="abc123..." SERVICE_WEBSITE="https://service.example.com" PERSONALITY_JARGON_TERM="personalities" node backup-personalities-data.js personality1\n'
+  );
   process.exit(1);
 }
 
@@ -51,9 +55,14 @@ if (!SERVICE_WEBSITE) {
   process.exit(1);
 }
 
-if (!PROFILE_INFO_PRIVATE_PATH) {
-  console.error('\n❌ ERROR: PROFILE_INFO_PRIVATE_PATH environment variable required\n');
-  console.error('This is usually "personalities/username" or similar\n');
+// Profile paths are now constructed dynamically using the jargon term
+
+if (!PERSONALITY_JARGON_TERM) {
+  console.error('\n❌ ERROR: PERSONALITY_JARGON_TERM environment variable required\n');
+  console.error(
+    'This should be the personality service jargon term (e.g., "personalities", "agents", "characters")\n'
+  );
+  console.error('Example: PERSONALITY_JARGON_TERM="personalities"\n');
   process.exit(1);
 }
 
@@ -62,31 +71,36 @@ function httpsGet(url) {
   return new Promise((resolve, reject) => {
     const options = {
       headers: {
-        'Cookie': SERVICE_COOKIE.includes('appSession=') ? SERVICE_COOKIE : `appSession=${SERVICE_COOKIE}`,
+        Cookie: SERVICE_COOKIE.includes('appSession=')
+          ? SERVICE_COOKIE
+          : `appSession=${SERVICE_COOKIE}`,
         'User-Agent': 'Mozilla/5.0 (compatible; PersonalityBackup/1.0)',
-        'Accept': 'application/json'
-      }
+        Accept: 'application/json',
+      },
     };
 
-    https.get(url, options, (res) => {
-      let data = '';
-      res.on('data', chunk => data += chunk);
-      res.on('end', () => {
-        if (res.statusCode === 200) {
-          try {
-            resolve(JSON.parse(data));
-          } catch (e) {
-            reject(new Error(`Failed to parse JSON from ${url}: ${e.message}`));
+    https
+      .get(url, options, res => {
+        let data = '';
+        res.on('data', chunk => (data += chunk));
+        res.on('end', () => {
+          if (res.statusCode === 200) {
+            try {
+              resolve(JSON.parse(data));
+            } catch (e) {
+              reject(new Error(`Failed to parse JSON from ${url}: ${e.message}`));
+            }
+          } else {
+            reject(new Error(`HTTP ${res.statusCode} from ${url}: ${data}`));
           }
-        } else {
-          reject(new Error(`HTTP ${res.statusCode} from ${url}: ${data}`));
-        }
-      });
-    }).on('error', reject);
+        });
+      })
+      .on('error', reject);
   });
 }
 
-// Delay helper
+// Delay helper - simple implementation for standalone script
+// eslint-disable-next-line no-restricted-globals, no-restricted-syntax
 const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 // Ensure output directory exists
@@ -98,7 +112,7 @@ async function ensureOutputDir() {
 async function savePersonalityData(username, data) {
   const personalityDir = path.join(OUTPUT_DIR, username);
   await fs.mkdir(personalityDir, { recursive: true });
-  
+
   const filePath = path.join(personalityDir, `${username}.json`);
   await fs.writeFile(filePath, JSON.stringify(data, null, 2));
   console.log(`✓ Saved profile: ${username}`);
@@ -108,91 +122,222 @@ async function savePersonalityData(username, data) {
 async function saveMemoryData(username, memories) {
   const personalityDir = path.join(OUTPUT_DIR, username);
   await fs.mkdir(personalityDir, { recursive: true });
-  
+
   const filePath = path.join(personalityDir, `${username}_memories.json`);
   await fs.writeFile(filePath, JSON.stringify(memories, null, 2));
   console.log(`  ✓ Saved ${memories.length} memories for ${username}`);
 }
 
+// Save knowledge/story data to a single file
+async function saveKnowledgeData(username, knowledge) {
+  const personalityDir = path.join(OUTPUT_DIR, username);
+  await fs.mkdir(personalityDir, { recursive: true });
+
+  const filePath = path.join(personalityDir, `${username}_knowledge.json`);
+  await fs.writeFile(filePath, JSON.stringify(knowledge, null, 2));
+  console.log(`  ✓ Saved knowledge/story data for ${username}`);
+}
+
+// Save training data to a single file
+async function saveTrainingData(username, training) {
+  const personalityDir = path.join(OUTPUT_DIR, username);
+  await fs.mkdir(personalityDir, { recursive: true });
+
+  const filePath = path.join(personalityDir, `${username}_training.json`);
+  await fs.writeFile(filePath, JSON.stringify(training, null, 2));
+  console.log(`  ✓ Saved training data for ${username}`);
+}
+
+// Save user personalization data to a single file
+async function saveUserPersonalizationData(username, userPersonalization) {
+  const personalityDir = path.join(OUTPUT_DIR, username);
+  await fs.mkdir(personalityDir, { recursive: true });
+
+  const filePath = path.join(personalityDir, `${username}_user_personalization.json`);
+  await fs.writeFile(filePath, JSON.stringify(userPersonalization, null, 2));
+  console.log(`  ✓ Saved user personalization data for ${username}`);
+}
+
 // Fetch all memories for a personality
 async function fetchAllMemories(personalityId, username) {
   console.log(`\nFetching memories for ${username}...`);
-  
+
   try {
     const allMemories = [];
     let page = 1;
     let totalPages = 1;
-    
+
     // Fetch all pages
     while (page <= totalPages) {
       const url = `${SERVICE_WEBSITE}/api/memory/${personalityId}?page=${page}`;
       console.log(`  Fetching page ${page}...`);
       const response = await httpsGet(url);
-      
+
       // Handle different response formats
       const memories = response.items || response.memories || [];
       if (memories.length === 0 && page === 1) {
         console.log(`  No memories found for ${username}`);
         return;
       }
-      
+
       // Add memories to our collection
       allMemories.push(...memories);
-      
+
       // Update total pages from pagination
       const pagination = response.pagination || response.meta?.pagination;
       if (pagination) {
         totalPages = pagination.total_pages || pagination.totalPages || 1;
       }
-      
+
       if (page === 1) {
         console.log(`  Total memory pages: ${totalPages}`);
       }
-      
+
       page++;
       if (page <= totalPages) {
         await delay(DELAY_BETWEEN_REQUESTS);
       }
     }
-    
+
     // Sort memories by created_at timestamp (oldest first)
     allMemories.sort((a, b) => {
       // Handle both timestamp formats: Unix timestamp (number) and ISO string
-      const timeA = typeof a.created_at === 'number' ? a.created_at : new Date(a.created_at || a.timestamp || 0).getTime() / 1000;
-      const timeB = typeof b.created_at === 'number' ? b.created_at : new Date(b.created_at || b.timestamp || 0).getTime() / 1000;
+      const timeA =
+        typeof a.created_at === 'number'
+          ? a.created_at
+          : new Date(a.created_at || a.timestamp || 0).getTime() / 1000;
+      const timeB =
+        typeof b.created_at === 'number'
+          ? b.created_at
+          : new Date(b.created_at || b.timestamp || 0).getTime() / 1000;
       return timeA - timeB;
     });
-    
+
     // Save all memories to a single file
     await saveMemoryData(username, allMemories);
-    
   } catch (error) {
     console.error(`  ERROR fetching memories for ${username}: ${error.message}`);
   }
 }
 
+// Fetch knowledge/story data for a personality
+async function fetchKnowledgeData(personalityId, username) {
+  console.log(`\nFetching knowledge/story data for ${username}...`);
+
+  try {
+    const url = `${SERVICE_WEBSITE}/api/${PERSONALITY_JARGON_TERM}/${personalityId}/story`;
+    console.log(`  Fetching from: ${url}`);
+    const response = await httpsGet(url);
+
+    // The knowledge/story endpoint might return different formats
+    // Handle both array and object responses
+    let knowledge = [];
+    if (Array.isArray(response)) {
+      knowledge = response;
+    } else if (response.items) {
+      knowledge = response.items;
+    } else if (response.story || response.knowledge) {
+      knowledge = response.story || response.knowledge;
+    } else if (response && Object.keys(response).length > 0) {
+      // If it's a single object, wrap it in an array
+      knowledge = [response];
+    }
+
+    if (knowledge.length === 0) {
+      console.log(`  No knowledge/story data found for ${username}`);
+      return;
+    }
+
+    // Save knowledge data
+    await saveKnowledgeData(username, knowledge);
+  } catch (error) {
+    console.error(`  ERROR fetching knowledge for ${username}: ${error.message}`);
+  }
+}
+
+// Fetch training data for a personality
+async function fetchTrainingData(personalityId, username) {
+  console.log(`\nFetching training data for ${username}...`);
+
+  try {
+    const url = `${SERVICE_WEBSITE}/api/${PERSONALITY_JARGON_TERM}/${personalityId}/training`;
+    console.log(`  Fetching from: ${url}`);
+    const response = await httpsGet(url);
+
+    // The training endpoint should return an array similar to story
+    let training = [];
+    if (Array.isArray(response)) {
+      training = response;
+    } else if (response.items) {
+      training = response.items;
+    } else if (response.training) {
+      training = response.training;
+    } else if (response && Object.keys(response).length > 0) {
+      // If it's a single object, wrap it in an array
+      training = [response];
+    }
+
+    if (training.length === 0) {
+      console.log(`  No training data found for ${username}`);
+      return;
+    }
+
+    // Save training data
+    await saveTrainingData(username, training);
+  } catch (error) {
+    console.error(`  ERROR fetching training data for ${username}: ${error.message}`);
+  }
+}
+
+// Fetch user personalization data for a personality
+async function fetchUserPersonalizationData(personalityId, username) {
+  console.log(`\nFetching user personalization data for ${username}...`);
+
+  try {
+    const url = `${SERVICE_WEBSITE}/api/${PERSONALITY_JARGON_TERM}/${personalityId}/user`;
+    console.log(`  Fetching from: ${url}`);
+    const response = await httpsGet(url);
+
+    // The user personalization endpoint returns a single object
+    if (response && Object.keys(response).length > 0) {
+      // Save user personalization data
+      await saveUserPersonalizationData(username, response);
+    } else {
+      console.log(`  No user personalization data found for ${username}`);
+    }
+  } catch (error) {
+    console.error(`  ERROR fetching user personalization for ${username}: ${error.message}`);
+  }
+}
+
 // Fetch complete data for a personality
 async function fetchPersonalityData(username) {
-  try {
-    console.log(`\nFetching data for ${username}...`);
-    
-    // Get full personality data from authenticated API
-    const profileUrl = `${SERVICE_WEBSITE}/api/${PROFILE_INFO_PRIVATE_PATH}/${username}`;
-    const profileData = await httpsGet(profileUrl);
-    
-    // Save profile data
-    await savePersonalityData(username, profileData);
-    
-    // Get personality ID for memory fetching
-    if (profileData.id) {
-      await delay(DELAY_BETWEEN_REQUESTS);
-      await fetchAllMemories(profileData.id, username);
-    } else {
-      console.log(`  WARNING: No ID found for ${username}, skipping memories`);
-    }
-    
-  } catch (error) {
-    console.error(`ERROR: Failed to fetch ${username}: ${error.message}`);
+  console.log(`\nFetching data for ${username}...`);
+
+  // Get full personality data from authenticated API
+  const profileUrl = `${SERVICE_WEBSITE}/api/${PERSONALITY_JARGON_TERM}/username/${username}`;
+  const profileData = await httpsGet(profileUrl);
+
+  // Save profile data
+  await savePersonalityData(username, profileData);
+
+  // Get personality ID for memory, knowledge, training, and user personalization fetching
+  if (profileData.id) {
+    await delay(DELAY_BETWEEN_REQUESTS);
+    await fetchAllMemories(profileData.id, username);
+
+    await delay(DELAY_BETWEEN_REQUESTS);
+    await fetchKnowledgeData(profileData.id, username);
+
+    await delay(DELAY_BETWEEN_REQUESTS);
+    await fetchTrainingData(profileData.id, username);
+
+    await delay(DELAY_BETWEEN_REQUESTS);
+    await fetchUserPersonalizationData(profileData.id, username);
+  } else {
+    console.log(
+      `  WARNING: No ID found for ${username}, skipping memories, knowledge, training, and user personalization`
+    );
   }
 }
 
@@ -200,38 +345,68 @@ async function fetchPersonalityData(username) {
 async function main() {
   console.log('External Service Data Backup Script');
   console.log('===================================\n');
-  
+
   // Show configuration
   console.log('Configuration:');
   console.log(`  Service URL: ${SERVICE_WEBSITE}`);
-  console.log(`  Profile Path: ${PROFILE_INFO_PRIVATE_PATH}`);
+  console.log(`  Jargon Term: ${PERSONALITY_JARGON_TERM}`);
+  console.log(`  Profile Path: ${PERSONALITY_JARGON_TERM}/username`);
   console.log(`  Cookie: ${SERVICE_COOKIE ? SERVICE_COOKIE.substring(0, 20) + '...' : 'NOT SET'}`);
   console.log(`  Output Directory: ${OUTPUT_DIR}\n`);
-  
+
   await ensureOutputDir();
-  
+
   // Get list of personalities to backup
   // You'll need to provide this list - either from your existing data
   // or by manually listing them
   const personalities = process.argv.slice(2);
-  
+
   if (personalities.length === 0) {
     console.log('\n❌ ERROR: No personalities specified\n');
     console.log('Usage:');
-    console.log('SERVICE_COOKIE="your-cookie" SERVICE_WEBSITE="https://service.com" PROFILE_INFO_PRIVATE_PATH="personalities/username" node scripts/backup-personalities-data.js personality1 personality2 ...');
+    console.log(
+      'SERVICE_COOKIE="your-cookie" SERVICE_WEBSITE="https://service.example.com" PERSONALITY_JARGON_TERM="personalities" node backup-personalities-data.js personality1 personality2 ...'
+    );
     process.exit(1);
   }
-  
+
   console.log(`Backing up ${personalities.length} personalities...`);
-  
+
+  let successCount = 0;
+  let shouldContinue = true;
+
   // Process each personality
-  for (const username of personalities) {
-    await fetchPersonalityData(username);
-    await delay(DELAY_BETWEEN_REQUESTS * 2); // Extra delay between personalities
+  for (let i = 0; i < personalities.length; i++) {
+    if (!shouldContinue) break;
+    
+    const username = personalities[i];
+    try {
+      await fetchPersonalityData(username);
+      successCount++;
+      
+      if (i < personalities.length - 1) {
+        await delay(DELAY_BETWEEN_REQUESTS * 2); // Extra delay between personalities
+      }
+    } catch (error) {
+      // Check if it's a 401 Unauthorized error
+      if (error.message.includes('401')) {
+        console.error(`\n❌ Authentication failed! Your session cookie may have expired.`);
+        console.error(`Successfully backed up ${successCount} of ${personalities.length} personalities before failure.\n`);
+        console.error(`Please get a fresh session cookie from your browser and try again.`);
+        shouldContinue = false;
+      } else {
+        console.error(`ERROR: Failed to fetch ${username}: ${error.message}`);
+        // Continue with next personality for non-auth errors
+      }
+    }
   }
-  
-  console.log('\n✅ Backup complete!');
-  console.log(`Data saved to: ${OUTPUT_DIR}`);
+
+  if (shouldContinue) {
+    console.log('\n✅ Backup complete!');
+    console.log(`Data saved to: ${OUTPUT_DIR}`);
+  } else {
+    process.exit(1);
+  }
 }
 
 // Run the script

--- a/src/domain/personality/PersonalityProfile.js
+++ b/src/domain/personality/PersonalityProfile.js
@@ -18,7 +18,7 @@ class PersonalityProfile extends ValueObject {
     if (typeof nameOrConfig === 'object' && nameOrConfig !== null) {
       // Mode detection based on properties
       if (nameOrConfig.mode === 'external') {
-        // External API mode - data from shapes.inc API
+        // External API mode - data from external API
         this.mode = 'external';
         this.name = nameOrConfig.name || nameOrConfig.displayName;
         this.displayName = nameOrConfig.displayName || null;

--- a/tests/unit/domain/personality/PersonalityProfile.test.js
+++ b/tests/unit/domain/personality/PersonalityProfile.test.js
@@ -61,7 +61,7 @@ describe('PersonalityProfile', () => {
     });
     
     describe('local mode (self-managed)', () => {
-      it('should create local profile with shapes.inc data', () => {
+      it('should create local profile with external API data', () => {
         const profile = new PersonalityProfile({
           mode: 'local',
           username: 'angel-dust',
@@ -470,7 +470,7 @@ describe('PersonalityProfile', () => {
         jailbreak: 'I express myself...',
         engine_model: 'google/gemini-2.5-pro',
         engine_temperature: 1.0,
-        avatar: 'https://files.shapes.inc/avatar.png',
+        avatar: 'https://files.example.com/avatar.png',
         voice_id: 'XFS4iF5WnOwpgzpJCvuM',
         voice_model: 'eleven_multilingual_v2',
         voice_stability: 0.53
@@ -485,7 +485,7 @@ describe('PersonalityProfile', () => {
       expect(profile.jailbreak).toBe('I express myself...');
       expect(profile.modelPath).toBe('google/gemini-2.5-pro');
       expect(profile.temperature).toBe(1.0);
-      expect(profile.avatarUrl).toBe('https://files.shapes.inc/avatar.png');
+      expect(profile.avatarUrl).toBe('https://files.example.com/avatar.png');
       expect(profile.voiceConfig).toEqual({
         id: 'XFS4iF5WnOwpgzpJCvuM',
         model: 'eleven_multilingual_v2',


### PR DESCRIPTION
## Summary
- Add three new API endpoints to backup functionality for comprehensive personality data backup
- Genericize all service references for security and flexibility
- Improve authentication handling with proper 401 error detection

## What's Changed

### New Backup Endpoints
- `/api/{jargon_term}/{personalityId}/story` - Knowledge/story data backup
- `/api/{jargon_term}/{personalityId}/training` - Training examples backup  
- `/api/{jargon_term}/{personalityId}/user` - User personalization settings backup

### Service Genericization
- Add `PERSONALITY_JARGON_TERM` environment variable (required, no default)
- Remove all hardcoded service references throughout codebase
- Update examples to use generic "personalities" and "service.example.com"
- Simplify configuration by constructing paths dynamically

### Authentication Improvements
- Remove token auth fallback (doesn't work for these APIs)
- Require session cookie for all backup operations
- Add proper 401 error handling to stop bulk backups on auth failure
- Show clear progress when auth fails (X of Y personalities backed up)

### Standalone Script
- Make backup script completely independent with no config dependencies
- Add comprehensive README for sharing with others
- Remove all service-specific references for security

## Test Plan
- [x] Test backup command with single personality
- [x] Test backup command with --all flag
- [x] Test 401 error handling (expired cookie)
- [x] Test standalone script functionality
- [x] Verify all service references removed
- [x] Test dynamic path construction

🤖 Generated with [Claude Code](https://claude.ai/code)