### PR TITLE
feat: standardize DDD commands to use Discord embeds consistently

### DIFF
--- a/src/application/commands/conversation/ActivateCommand.js
+++ b/src/application/commands/conversation/ActivateCommand.js
@@ -47,31 +47,49 @@ function createExecutor(_dependencies) {
     try {
       // Validate this is a guild channel
       if (!context.getGuildId()) {
-        return await context.respond(
-          '❌ The activate command can only be used in server channels, not DMs.'
-        );
+        const errorEmbed = {
+          title: '❌ Server Channels Only',
+          description: 'The activate command can only be used in server channels, not DMs.',
+          color: 0xf44336,
+          timestamp: new Date().toISOString(),
+        };
+        return await context.respond({ embeds: [errorEmbed] });
       }
 
       // Check if user has required permissions
       const hasPermission = await context.hasPermission('ManageMessages');
       if (!hasPermission) {
-        return await context.respond(
-          '❌ You need the "Manage Messages" permission to activate personalities in this channel.'
-        );
+        const errorEmbed = {
+          title: '❌ Insufficient Permissions',
+          description: 'You need the "Manage Messages" permission to activate personalities in this channel.',
+          color: 0xf44336,
+          timestamp: new Date().toISOString(),
+        };
+        return await context.respond({ embeds: [errorEmbed] });
       }
 
       // Check if channel is NSFW
       const isNSFW = await context.isChannelNSFW();
       if (!isNSFW) {
-        return await context.respond(
-          '⚠️ For safety and compliance reasons, personalities can only be activated in channels marked as NSFW.'
-        );
+        const errorEmbed = {
+          title: '⚠️ NSFW Channel Required',
+          description: 'For safety and compliance reasons, personalities can only be activated in channels marked as NSFW.',
+          color: 0xff9800,
+          timestamp: new Date().toISOString(),
+        };
+        return await context.respond({ embeds: [errorEmbed] });
       }
 
       // Get personality name from args or options
       const personalityInput = options.personality || args.join(' ');
       if (!personalityInput) {
-        return await context.respond('❌ Please specify a personality to activate.');
+        const errorEmbed = {
+          title: '❌ Missing Personality',
+          description: 'Please specify a personality to activate.',
+          color: 0xf44336,
+          timestamp: new Date().toISOString(),
+        };
+        return await context.respond({ embeds: [errorEmbed] });
       }
 
       logger.debug(`[ActivateCommand] Looking up personality: "${personalityInput}"`);
@@ -88,13 +106,30 @@ function createExecutor(_dependencies) {
         }
       } catch (error) {
         logger.error('[ActivateCommand] Error looking up personality:', error);
-        return await context.respond('❌ Error looking up personality. Please try again.');
+        const errorEmbed = {
+          title: '❌ Lookup Error',
+          description: 'Error looking up personality. Please try again.',
+          color: 0xf44336,
+          timestamp: new Date().toISOString(),
+        };
+        return await context.respond({ embeds: [errorEmbed] });
       }
 
       if (!personality) {
-        return await context.respond(
-          `❌ Personality "${personalityInput}" not found. Use \`${context.dependencies.botPrefix} list\` to see available personalities.`
-        );
+        const errorEmbed = {
+          title: '❌ Personality Not Found',
+          description: `Personality "${personalityInput}" not found.`,
+          color: 0xf44336,
+          fields: [
+            {
+              name: 'Need help?',
+              value: `Use \`${context.dependencies.botPrefix} list\` to see available personalities.`,
+              inline: false,
+            },
+          ],
+          timestamp: new Date().toISOString(),
+        };
+        return await context.respond({ embeds: [errorEmbed] });
       }
 
       // Activate the personality in this channel

--- a/src/application/commands/conversation/DeactivateCommand.js
+++ b/src/application/commands/conversation/DeactivateCommand.js
@@ -43,15 +43,25 @@ function createExecutor(_dependencies) {
       // Check if user has required permissions
       const hasPermission = await context.hasPermission('ManageMessages');
       if (!hasPermission) {
-        return await context.respond(
-          '❌ You need the "Manage Messages" permission to deactivate personalities in this channel.'
-        );
+        const errorEmbed = {
+          title: '❌ Insufficient Permissions',
+          description: 'You need the "Manage Messages" permission to deactivate personalities in this channel.',
+          color: 0xf44336,
+          timestamp: new Date().toISOString(),
+        };
+        return await context.respond({ embeds: [errorEmbed] });
       }
 
       // Check if there's an active personality
       const activePersonality = conversationManager.getActivatedPersonality(context.getChannelId());
       if (!activePersonality) {
-        return await context.respond('❌ There is no active personality in this channel.');
+        const errorEmbed = {
+          title: '❌ No Active Personality',
+          description: 'There is no active personality in this channel.',
+          color: 0xf44336,
+          timestamp: new Date().toISOString(),
+        };
+        return await context.respond({ embeds: [errorEmbed] });
       }
 
       // Deactivate the personality
@@ -62,7 +72,13 @@ function createExecutor(_dependencies) {
         );
       } catch (error) {
         logger.error('[DeactivateCommand] Error deactivating personality:', error);
-        return await context.respond('❌ Failed to deactivate personality. Please try again.');
+        const errorEmbed = {
+          title: '❌ Deactivation Failed',
+          description: 'Failed to deactivate personality. Please try again.',
+          color: 0xf44336,
+          timestamp: new Date().toISOString(),
+        };
+        return await context.respond({ embeds: [errorEmbed] });
       }
 
       // Send success response with embed

--- a/src/application/commands/utility/DebugCommand.js
+++ b/src/application/commands/utility/DebugCommand.js
@@ -18,7 +18,13 @@ function createExecutor(dependencies = {}) {
     try {
       // Admin check
       if (!context.isAdmin) {
-        await context.respond('This command requires administrator permissions.');
+        const errorEmbed = {
+          title: '❌ Access Denied',
+          description: 'This command requires administrator permissions.',
+          color: 0xf44336,
+          timestamp: new Date().toISOString(),
+        };
+        await context.respond({ embeds: [errorEmbed] });
         return;
       }
 
@@ -60,36 +66,74 @@ function createExecutor(dependencies = {}) {
             authManager,
           });
 
-        default:
-          await context.respond(
-            `Unknown debug subcommand: \`${subcommand}\`. Use \`${context.commandPrefix}debug\` to see available subcommands.`
-          );
+        default: {
+          const errorEmbed = {
+            title: '❌ Unknown Subcommand',
+            description: `Unknown debug subcommand: \`${subcommand}\`.`,
+            color: 0xf44336,
+            fields: [
+              {
+                name: 'Help',
+                value: `Use \`${context.commandPrefix}debug\` to see available subcommands.`,
+                inline: false,
+              },
+            ],
+            timestamp: new Date().toISOString(),
+          };
+          await context.respond({ embeds: [errorEmbed] });
+        }
       }
     } catch (error) {
       logger.error('[DebugCommand] Execution failed:', error);
-      await context.respond('An error occurred while executing the debug command.');
+      const errorEmbed = {
+        title: '❌ Command Error',
+        description: 'An error occurred while executing the debug command.',
+        color: 0xf44336,
+        timestamp: new Date().toISOString(),
+      };
+      await context.respond({ embeds: [errorEmbed] });
     }
   };
 }
 
 async function showHelp(context) {
-  const helpText = `You need to provide a subcommand. Usage: \`${context.commandPrefix}debug <subcommand>\`
+  const helpEmbed = {
+    title: '🛠️ Debug Command Help',
+    description: `Usage: \`${context.commandPrefix}debug <subcommand>\``,
+    color: 0x2196f3,
+    fields: [
+      {
+        name: 'Available Subcommands',
+        value: [
+          '• `clearwebhooks` - Clear cached webhook identifications',
+          '• `unverify` - Clear your NSFW verification status',
+          '• `clearconversation` - Clear your conversation history',
+          '• `clearauth` - Clear your authentication tokens',
+          '• `clearmessages` - Clear message tracking history',
+          '• `stats` - Show debug statistics',
+        ].join('\n'),
+        inline: false,
+      },
+    ],
+    footer: {
+      text: 'Administrator permissions required',
+    },
+    timestamp: new Date().toISOString(),
+  };
 
-Available subcommands:
-• \`clearwebhooks\` - Clear cached webhook identifications
-• \`unverify\` - Clear your NSFW verification status
-• \`clearconversation\` - Clear your conversation history
-• \`clearauth\` - Clear your authentication tokens
-• \`clearmessages\` - Clear message tracking history
-• \`stats\` - Show debug statistics`;
-
-  await context.respond(helpText);
+  await context.respond({ embeds: [helpEmbed] });
 }
 
 async function clearWebhooks(context, webhookUserTracker) {
   webhookUserTracker.clearAllCachedWebhooks();
   logger.info(`[Debug] Webhook cache cleared by ${context.userTag}`);
-  await context.respond('✅ Cleared all cached webhook identifications.');
+  const successEmbed = {
+    title: '✅ Webhooks Cleared',
+    description: 'Cleared all cached webhook identifications.',
+    color: 0x4caf50,
+    timestamp: new Date().toISOString(),
+  };
+  await context.respond({ embeds: [successEmbed] });
 }
 
 async function unverify(context, nsfwVerificationManager) {
@@ -97,9 +141,21 @@ async function unverify(context, nsfwVerificationManager) {
 
   if (cleared) {
     logger.info(`[Debug] NSFW verification cleared for ${context.userTag}`);
-    await context.respond('✅ Your NSFW verification has been cleared. You are now unverified.');
+    const successEmbed = {
+      title: '✅ Verification Cleared',
+      description: 'Your NSFW verification has been cleared. You are now unverified.',
+      color: 0x4caf50,
+      timestamp: new Date().toISOString(),
+    };
+    await context.respond({ embeds: [successEmbed] });
   } else {
-    await context.respond('❌ You were not verified, so nothing was cleared.');
+    const infoEmbed = {
+      title: 'ℹ️ No Change',
+      description: 'You were not verified, so nothing was cleared.',
+      color: 0x2196f3,
+      timestamp: new Date().toISOString(),
+    };
+    await context.respond({ embeds: [infoEmbed] });
   }
 }
 
@@ -110,10 +166,22 @@ async function clearConversation(context, conversationManager) {
     logger.info(
       `[Debug] Conversation history cleared for ${context.userTag} in channel ${context.channelId}`
     );
-    await context.respond('✅ Cleared your conversation history in this channel.');
+    const successEmbed = {
+      title: '✅ Conversation Cleared',
+      description: 'Cleared your conversation history in this channel.',
+      color: 0x4caf50,
+      timestamp: new Date().toISOString(),
+    };
+    await context.respond({ embeds: [successEmbed] });
   } catch (error) {
     logger.error(`[Debug] Error clearing conversation: ${error.message}`);
-    await context.respond('❌ Failed to clear conversation history.');
+    const errorEmbed = {
+      title: '❌ Clear Failed',
+      description: 'Failed to clear conversation history.',
+      color: 0xf44336,
+      timestamp: new Date().toISOString(),
+    };
+    await context.respond({ embeds: [errorEmbed] });
   }
 }
 
@@ -122,10 +190,22 @@ async function clearAuth(context, authManager) {
     // Clean up expired auth tokens
     await authManager.cleanupExpiredTokens();
     logger.info(`[Debug] Authentication tokens cleaned up for ${context.userTag}`);
-    await context.respond('✅ Cleaned up authentication tokens. You may need to re-authenticate.');
+    const successEmbed = {
+      title: '✅ Authentication Cleared',
+      description: 'Cleaned up authentication tokens. You may need to re-authenticate.',
+      color: 0x4caf50,
+      timestamp: new Date().toISOString(),
+    };
+    await context.respond({ embeds: [successEmbed] });
   } catch (error) {
     logger.error(`[Debug] Error clearing auth: ${error.message}`);
-    await context.respond('❌ Failed to clear authentication.');
+    const errorEmbed = {
+      title: '❌ Clear Failed',
+      description: 'Failed to clear authentication.',
+      color: 0xf44336,
+      timestamp: new Date().toISOString(),
+    };
+    await context.respond({ embeds: [errorEmbed] });
   }
 }
 
@@ -133,10 +213,22 @@ async function clearMessages(context, messageTracker) {
   try {
     messageTracker.clear();
     logger.info(`[Debug] Message tracking history cleared by ${context.userTag}`);
-    await context.respond('✅ Cleared message tracking history.');
+    const successEmbed = {
+      title: '✅ Messages Cleared',
+      description: 'Cleared message tracking history.',
+      color: 0x4caf50,
+      timestamp: new Date().toISOString(),
+    };
+    await context.respond({ embeds: [successEmbed] });
   } catch (error) {
     logger.error(`[Debug] Error clearing message tracker: ${error.message}`);
-    await context.respond('❌ Failed to clear message tracking.');
+    const errorEmbed = {
+      title: '❌ Clear Failed',
+      description: 'Failed to clear message tracking.',
+      color: 0xf44336,
+      timestamp: new Date().toISOString(),
+    };
+    await context.respond({ embeds: [errorEmbed] });
   }
 }
 
@@ -157,15 +249,44 @@ async function showStats(context, dependencies) {
       },
     };
 
-    const statsText = `📊 **Debug Statistics**\n\`\`\`json\n${JSON.stringify(
-      stats,
-      null,
-      2
-    )}\n\`\`\``;
-    await context.respond(statsText);
+    const statsEmbed = {
+      title: '📊 Debug Statistics',
+      description: 'Current system debug information',
+      color: 0x2196f3,
+      fields: [
+        {
+          name: 'Webhooks',
+          value: `Tracked: ${stats.webhooks.tracked}`,
+          inline: true,
+        },
+        {
+          name: 'Messages',
+          value: `Tracked: ${stats.messages.tracked}`,
+          inline: true,
+        },
+        {
+          name: 'Authentication',
+          value: `Manager: ${stats.auth.hasManager ? '✅' : '❌'}`,
+          inline: true,
+        },
+        {
+          name: 'Raw Data',
+          value: `\`\`\`json\n${JSON.stringify(stats, null, 2)}\n\`\`\``,
+          inline: false,
+        },
+      ],
+      timestamp: new Date().toISOString(),
+    };
+    await context.respond({ embeds: [statsEmbed] });
   } catch (error) {
     logger.error(`[Debug] Error gathering stats: ${error.message}`);
-    await context.respond('❌ Failed to gather statistics.');
+    const errorEmbed = {
+      title: '❌ Stats Failed',
+      description: 'Failed to gather statistics.',
+      color: 0xf44336,
+      timestamp: new Date().toISOString(),
+    };
+    await context.respond({ embeds: [errorEmbed] });
   }
 }
 

--- a/src/application/commands/utility/PingCommand.js
+++ b/src/application/commands/utility/PingCommand.js
@@ -17,12 +17,38 @@ function createExecutor(dependencies = {}) {
   return async function execute(context) {
     try {
       const { botConfig = require('../../../../config').botConfig } = dependencies;
+      const startTime = Date.now();
 
-      // Simply respond with pong and bot name
-      await context.respond(`Pong! ${botConfig.name} is operational.`);
+      // Create ping response embed
+      const pingEmbed = {
+        title: '🏓 Pong!',
+        description: `${botConfig.name} is operational.`,
+        color: 0x4caf50,
+        fields: [
+          {
+            name: 'Status',
+            value: '✅ Online',
+            inline: true,
+          },
+          {
+            name: 'Response Time',
+            value: `${Date.now() - startTime}ms`,
+            inline: true,
+          },
+        ],
+        timestamp: new Date().toISOString(),
+      };
+
+      await context.respond({ embeds: [pingEmbed] });
     } catch (error) {
       logger.error('[PingCommand] Execution failed:', error);
-      await context.respond('An error occurred while checking bot status.');
+      const errorEmbed = {
+        title: '❌ Ping Failed',
+        description: 'An error occurred while checking bot status.',
+        color: 0xf44336,
+        timestamp: new Date().toISOString(),
+      };
+      await context.respond({ embeds: [errorEmbed] });
     }
   };
 }

--- a/tests/unit/application/commands/conversation/ActivateCommand.test.js
+++ b/tests/unit/application/commands/conversation/ActivateCommand.test.js
@@ -188,9 +188,13 @@ describe('ActivateCommand', () => {
       await command.execute(mockContext);
 
       // Assert
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        '❌ The activate command can only be used in server channels, not DMs.'
-      );
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '❌ Server Channels Only',
+          description: 'The activate command can only be used in server channels, not DMs.',
+          color: 0xf44336
+        })]
+      });
       expect(mockConversationManager.activatePersonality).not.toHaveBeenCalled();
     });
 
@@ -203,9 +207,13 @@ describe('ActivateCommand', () => {
       await command.execute(mockContext);
 
       // Assert
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        '❌ You need the "Manage Messages" permission to activate personalities in this channel.'
-      );
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '❌ Insufficient Permissions',
+          description: 'You need the "Manage Messages" permission to activate personalities in this channel.',
+          color: 0xf44336
+        })]
+      });
       expect(mockConversationManager.activatePersonality).not.toHaveBeenCalled();
     });
 
@@ -219,9 +227,13 @@ describe('ActivateCommand', () => {
       await command.execute(mockContext);
 
       // Assert
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        '⚠️ For safety and compliance reasons, personalities can only be activated in channels marked as NSFW.'
-      );
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '⚠️ NSFW Channel Required',
+          description: 'For safety and compliance reasons, personalities can only be activated in channels marked as NSFW.',
+          color: 0xff9800
+        })]
+      });
       expect(mockConversationManager.activatePersonality).not.toHaveBeenCalled();
     });
 
@@ -235,9 +247,13 @@ describe('ActivateCommand', () => {
       await command.execute(mockContext);
 
       // Assert
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        '❌ Please specify a personality to activate.'
-      );
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '❌ Missing Personality',
+          description: 'Please specify a personality to activate.',
+          color: 0xf44336
+        })]
+      });
       expect(mockConversationManager.activatePersonality).not.toHaveBeenCalled();
     });
 
@@ -253,9 +269,19 @@ describe('ActivateCommand', () => {
       await command.execute(mockContext);
 
       // Assert
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        '❌ Personality "NonExistent" not found. Use `!tz list` to see available personalities.'
-      );
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '❌ Personality Not Found',
+          description: 'Personality "NonExistent" not found.',
+          color: 0xf44336,
+          fields: expect.arrayContaining([
+            expect.objectContaining({
+              name: 'Need help?',
+              value: expect.stringContaining('!tz list')
+            })
+          ])
+        })]
+      });
       expect(mockConversationManager.activatePersonality).not.toHaveBeenCalled();
     });
 
@@ -270,9 +296,13 @@ describe('ActivateCommand', () => {
       await command.execute(mockContext);
 
       // Assert
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        '❌ Error looking up personality. Please try again.'
-      );
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '❌ Lookup Error',
+          description: 'Error looking up personality. Please try again.',
+          color: 0xf44336
+        })]
+      });
       expect(logger.error).toHaveBeenCalledWith(
         '[ActivateCommand] Error looking up personality:',
         expect.any(Error)

--- a/tests/unit/application/commands/conversation/DeactivateCommand.test.js
+++ b/tests/unit/application/commands/conversation/DeactivateCommand.test.js
@@ -120,9 +120,13 @@ describe('DeactivateCommand', () => {
       await command.execute(mockContext);
 
       // Assert
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        '❌ You need the "Manage Messages" permission to deactivate personalities in this channel.'
-      );
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '❌ Insufficient Permissions',
+          description: 'You need the "Manage Messages" permission to deactivate personalities in this channel.',
+          color: 0xf44336
+        })]
+      });
       expect(mockConversationManager.deactivatePersonality).not.toHaveBeenCalled();
     });
 
@@ -135,9 +139,13 @@ describe('DeactivateCommand', () => {
       await command.execute(mockContext);
 
       // Assert
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        '❌ There is no active personality in this channel.'
-      );
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '❌ No Active Personality',
+          description: 'There is no active personality in this channel.',
+          color: 0xf44336
+        })]
+      });
       expect(mockConversationManager.deactivatePersonality).not.toHaveBeenCalled();
     });
 
@@ -153,9 +161,13 @@ describe('DeactivateCommand', () => {
       await command.execute(mockContext);
 
       // Assert
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        '❌ Failed to deactivate personality. Please try again.'
-      );
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '❌ Deactivation Failed',
+          description: 'Failed to deactivate personality. Please try again.',
+          color: 0xf44336
+        })]
+      });
       expect(logger.error).toHaveBeenCalledWith(
         '[DeactivateCommand] Error deactivating personality:',
         expect.any(Error)

--- a/tests/unit/application/commands/utility/DebugCommand.test.js
+++ b/tests/unit/application/commands/utility/DebugCommand.test.js
@@ -92,9 +92,13 @@ describe('DebugCommand', () => {
 
       await debugCommand.execute(mockContext);
 
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        'This command requires administrator permissions.'
-      );
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '❌ Access Denied',
+          description: 'This command requires administrator permissions.',
+          color: 0xf44336
+        })]
+      });
       expect(mockWebhookUserTracker.clearAllCachedWebhooks).not.toHaveBeenCalled();
     });
   });
@@ -103,12 +107,19 @@ describe('DebugCommand', () => {
     it('should show help when no subcommand provided', async () => {
       await debugCommand.execute(mockContext);
 
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        expect.stringContaining('You need to provide a subcommand')
-      );
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        expect.stringContaining('Available subcommands:')
-      );
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '🛠️ Debug Command Help',
+          description: expect.stringContaining('Usage:'),
+          color: 0x2196f3,
+          fields: expect.arrayContaining([
+            expect.objectContaining({
+              name: 'Available Subcommands',
+              value: expect.stringContaining('clearwebhooks')
+            })
+          ])
+        })]
+      });
     });
   });
 
@@ -122,9 +133,13 @@ describe('DebugCommand', () => {
       expect(logger.info).toHaveBeenCalledWith(
         '[Debug] Webhook cache cleared by TestUser#1234'
       );
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        '✅ Cleared all cached webhook identifications.'
-      );
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '✅ Webhooks Cleared',
+          description: 'Cleared all cached webhook identifications.',
+          color: 0x4caf50
+        })]
+      });
     });
 
     it('should work with options instead of args', async () => {
@@ -146,9 +161,13 @@ describe('DebugCommand', () => {
       expect(logger.info).toHaveBeenCalledWith(
         '[Debug] NSFW verification cleared for TestUser#1234'
       );
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        '✅ Your NSFW verification has been cleared. You are now unverified.'
-      );
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '✅ Verification Cleared',
+          description: 'Your NSFW verification has been cleared. You are now unverified.',
+          color: 0x4caf50
+        })]
+      });
     });
 
     it('should handle when user was not verified', async () => {
@@ -157,9 +176,13 @@ describe('DebugCommand', () => {
 
       await debugCommand.execute(mockContext);
 
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        '❌ You were not verified, so nothing was cleared.'
-      );
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: 'ℹ️ No Change',
+          description: 'You were not verified, so nothing was cleared.',
+          color: 0x2196f3
+        })]
+      });
     });
   });
 
@@ -176,9 +199,13 @@ describe('DebugCommand', () => {
       expect(logger.info).toHaveBeenCalledWith(
         '[Debug] Conversation history cleared for TestUser#1234 in channel channel123'
       );
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        '✅ Cleared your conversation history in this channel.'
-      );
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '✅ Conversation Cleared',
+          description: 'Cleared your conversation history in this channel.',
+          color: 0x4caf50
+        })]
+      });
     });
 
     it('should handle conversation clear errors', async () => {
@@ -192,9 +219,13 @@ describe('DebugCommand', () => {
       expect(logger.error).toHaveBeenCalledWith(
         '[Debug] Error clearing conversation: Database error'
       );
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        '❌ Failed to clear conversation history.'
-      );
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '❌ Clear Failed',
+          description: 'Failed to clear conversation history.',
+          color: 0xf44336
+        })]
+      });
     });
   });
 
@@ -208,9 +239,13 @@ describe('DebugCommand', () => {
       expect(logger.info).toHaveBeenCalledWith(
         '[Debug] Authentication tokens cleaned up for TestUser#1234'
       );
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        '✅ Cleaned up authentication tokens. You may need to re-authenticate.'
-      );
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '✅ Authentication Cleared',
+          description: 'Cleaned up authentication tokens. You may need to re-authenticate.',
+          color: 0x4caf50
+        })]
+      });
     });
 
     it('should handle auth cleanup errors', async () => {
@@ -222,9 +257,13 @@ describe('DebugCommand', () => {
       expect(logger.error).toHaveBeenCalledWith(
         '[Debug] Error clearing auth: Auth error'
       );
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        '❌ Failed to clear authentication.'
-      );
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '❌ Clear Failed',
+          description: 'Failed to clear authentication.',
+          color: 0xf44336
+        })]
+      });
     });
   });
 
@@ -238,9 +277,13 @@ describe('DebugCommand', () => {
       expect(logger.info).toHaveBeenCalledWith(
         '[Debug] Message tracking history cleared by TestUser#1234'
       );
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        '✅ Cleared message tracking history.'
-      );
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '✅ Messages Cleared',
+          description: 'Cleared message tracking history.',
+          color: 0x4caf50
+        })]
+      });
     });
 
     it('should handle message tracker errors', async () => {
@@ -254,9 +297,13 @@ describe('DebugCommand', () => {
       expect(logger.error).toHaveBeenCalledWith(
         '[Debug] Error clearing message tracker: Tracker error'
       );
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        '❌ Failed to clear message tracking.'
-      );
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '❌ Clear Failed',
+          description: 'Failed to clear message tracking.',
+          color: 0xf44336
+        })]
+      });
     });
   });
 
@@ -266,12 +313,23 @@ describe('DebugCommand', () => {
 
       await debugCommand.execute(mockContext);
 
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        expect.stringContaining('📊 **Debug Statistics**')
-      );
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        expect.stringContaining('"tracked": 42')
-      );
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '📊 Debug Statistics',
+          description: 'Current system debug information',
+          color: 0x2196f3,
+          fields: expect.arrayContaining([
+            expect.objectContaining({
+              name: 'Messages',
+              value: 'Tracked: 42'
+            }),
+            expect.objectContaining({
+              name: 'Raw Data',
+              value: expect.stringContaining('"tracked": 42')
+            })
+          ])
+        })]
+      });
     });
 
     it('should handle stats gathering errors', async () => {
@@ -288,9 +346,13 @@ describe('DebugCommand', () => {
       expect(logger.error).toHaveBeenCalledWith(
         '[Debug] Error gathering stats: Property access error'
       );
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        '❌ Failed to gather statistics.'
-      );
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '❌ Stats Failed',
+          description: 'Failed to gather statistics.',
+          color: 0xf44336
+        })]
+      });
     });
 
     it('should handle missing size property', async () => {
@@ -299,9 +361,17 @@ describe('DebugCommand', () => {
 
       await debugCommand.execute(mockContext);
 
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        expect.stringContaining('"tracked": 0')
-      );
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '📊 Debug Statistics',
+          fields: expect.arrayContaining([
+            expect.objectContaining({
+              name: 'Raw Data',
+              value: expect.stringContaining('"tracked": 0')
+            })
+          ])
+        })]
+      });
     });
   });
 
@@ -311,9 +381,13 @@ describe('DebugCommand', () => {
 
       await debugCommand.execute(mockContext);
 
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        expect.stringContaining('Unknown debug subcommand: `invalid`')
-      );
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '❌ Unknown Subcommand',
+          description: 'Unknown debug subcommand: `invalid`.',
+          color: 0xf44336
+        })]
+      });
     });
   });
 
@@ -331,9 +405,13 @@ describe('DebugCommand', () => {
         '[DebugCommand] Execution failed:',
         expect.any(Error)
       );
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        'An error occurred while executing the debug command.'
-      );
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '❌ Command Error',
+          description: 'An error occurred while executing the debug command.',
+          color: 0xf44336
+        })]
+      });
     });
   });
 

--- a/tests/unit/application/commands/utility/PingCommand.test.js
+++ b/tests/unit/application/commands/utility/PingCommand.test.js
@@ -52,7 +52,17 @@ describe('PingCommand', () => {
     it('should respond with pong message', async () => {
       await pingCommand.execute(mockContext);
 
-      expect(mockContext.respond).toHaveBeenCalledWith('Pong! TestBot is operational.');
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '🏓 Pong!',
+          description: 'TestBot is operational.',
+          color: 0x4caf50,
+          fields: expect.arrayContaining([
+            expect.objectContaining({ name: 'Status', value: '✅ Online' }),
+            expect.objectContaining({ name: 'Response Time', value: expect.stringMatching(/\d+ms/) })
+          ])
+        })]
+      });
       expect(mockContext.respond).toHaveBeenCalledTimes(1);
     });
 
@@ -61,7 +71,17 @@ describe('PingCommand', () => {
 
       await pingCommand.execute(mockContext);
 
-      expect(mockContext.respond).toHaveBeenCalledWith('Pong! TestBot is operational.');
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '🏓 Pong!',
+          description: 'TestBot is operational.',
+          color: 0x4caf50,
+          fields: expect.arrayContaining([
+            expect.objectContaining({ name: 'Status', value: '✅ Online' }),
+            expect.objectContaining({ name: 'Response Time', value: expect.stringMatching(/\d+ms/) })
+          ])
+        })]
+      });
     });
 
     it('should work in guild channels', async () => {
@@ -69,7 +89,17 @@ describe('PingCommand', () => {
 
       await pingCommand.execute(mockContext);
 
-      expect(mockContext.respond).toHaveBeenCalledWith('Pong! TestBot is operational.');
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '🏓 Pong!',
+          description: 'TestBot is operational.',
+          color: 0x4caf50,
+          fields: expect.arrayContaining([
+            expect.objectContaining({ name: 'Status', value: '✅ Online' }),
+            expect.objectContaining({ name: 'Response Time', value: expect.stringMatching(/\d+ms/) })
+          ])
+        })]
+      });
     });
 
     it('should handle missing bot config gracefully', async () => {
@@ -79,9 +109,12 @@ describe('PingCommand', () => {
       // Should fall back to require statement
       await commandWithoutConfig.execute(mockContext);
 
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        expect.stringContaining('Pong!')
-      );
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: expect.stringContaining('Pong!'),
+          description: expect.stringContaining('operational')
+        })]
+      });
     });
 
     it('should handle errors gracefully', async () => {
@@ -94,9 +127,13 @@ describe('PingCommand', () => {
         expect.any(Error)
       );
       expect(mockContext.respond).toHaveBeenCalledTimes(2);
-      expect(mockContext.respond).toHaveBeenLastCalledWith(
-        'An error occurred while checking bot status.'
-      );
+      expect(mockContext.respond).toHaveBeenLastCalledWith({
+        embeds: [expect.objectContaining({
+          title: '❌ Ping Failed',
+          description: 'An error occurred while checking bot status.',
+          color: 0xf44336
+        })]
+      });
     });
 
     it('should handle unexpected errors', async () => {
@@ -111,9 +148,13 @@ describe('PingCommand', () => {
         '[PingCommand] Execution failed:',
         expect.any(Error)
       );
-      expect(mockContext.respond).toHaveBeenCalledWith(
-        'An error occurred while checking bot status.'
-      );
+      expect(mockContext.respond).toHaveBeenCalledWith({
+        embeds: [expect.objectContaining({
+          title: '❌ Ping Failed',
+          description: 'An error occurred while checking bot status.',
+          color: 0xf44336
+        })]
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

This PR standardizes all DDD commands to use Discord embeds consistently, providing a much better user experience with proper visual formatting and color coding.

## Changes Made

### Commands Updated
- ✅ **ActivateCommand** - All error messages now use embeds
- ✅ **DeactivateCommand** - All error messages now use embeds  
- ✅ **DebugCommand** - Complete conversion to embeds with enhanced help
- ✅ **PingCommand** - Enhanced with response time and status indicators

### Embed Standards Implemented
- 🟢 **Success**: `color: 0x4caf50` (green) with `✅` titles
- 🔴 **Error**: `color: 0xf44336` (red) with `❌` titles
- 🔵 **Info**: `color: 0x2196f3` (blue) with `ℹ️` titles
- 🟠 **Warning**: `color: 0xff9800` (orange) with `⚠️` titles

### Enhanced User Experience
- **Consistent Visual Design** - All commands now have the same professional look
- **Better Error Messaging** - Clear, structured error information
- **Improved Debug Help** - Structured subcommand listing with descriptions
- **Enhanced Ping Response** - Shows response time and operational status

### Test Updates
- Updated all test files to expect embed objects instead of plain text
- Maintained comprehensive test coverage (54 tests passing)
- Fixed ESLint issues including lexical declaration in case block

## Before/After Examples

### Before (Plain Text)
```
❌ The activate command can only be used in server channels, not DMs.
```

### After (Rich Embed)
```json
{
  "title": "❌ Server Channels Only",
  "description": "The activate command can only be used in server channels, not DMs.",
  "color": 16007990,
  "timestamp": "2025-06-19T11:06:11.071Z"
}
```

## Test Results
- ✅ All 54 command tests passing
- ✅ Pre-commit hooks passing
- ✅ ESLint clean (0 errors, warnings only for function length)
- ✅ Timer patterns validated
- ✅ Test anti-patterns clean

## Next Steps

This establishes the foundation for:
1. Converting remaining DDD commands to embeds
2. Porting legacy commands to DDD with embed support
3. Enhanced user experience across the entire bot

🤖 Generated with [Claude Code](https://claude.ai/code)