### PR TITLE
Release v2.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.4] - 2025-06-21
+
+### Fixed
+- **DDD Personality Error Messages** - Fixed bug where personality-specific error messages weren't being used when DDD is enabled
+  - Updated `aiErrorHandler` to check DDD feature flag and use PersonalityRouter when enabled
+  - Fixed `PersonalityRouter._convertDDDToLegacyFormat` to include the `errorMessage` field
+  - Empty response errors now correctly use personality-specific error messages in DDD mode
+  - Added comprehensive tests for both legacy and DDD error handling paths
+
 ## [2.0.3] - 2025-06-20
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tzurot",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tzurot",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "dependencies": {
         "discord.js": "14.19.3",
         "dotenv": "16.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tzurot",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "A Discord bot that uses webhooks to represent multiple AI personalities",
   "main": "index.js",
   "scripts": {

--- a/src/adapters/CommandIntegrationAdapter.js
+++ b/src/adapters/CommandIntegrationAdapter.js
@@ -126,7 +126,6 @@ class CommandIntegrationAdapter {
     return true;
   }
 
-
   /**
    * Process command using new DDD system
    */

--- a/src/application/routers/PersonalityRouter.js
+++ b/src/application/routers/PersonalityRouter.js
@@ -304,6 +304,7 @@ class PersonalityRouter {
       owner: personality.ownerId?.toString ? personality.ownerId.toString() : personality.ownerId,
       aliases: personality.aliases?.map(a => a.value || a.alias || a) || [],
       avatarUrl: personality.profile?.avatarUrl,
+      errorMessage: personality.profile?.errorMessage,
       nsfwContent: personality.profile?.isNSFW,
       temperature: personality.profile?.temperature,
       maxWordCount: personality.profile?.maxWordCount,

--- a/tests/unit/aiErrorHandler.personality.test.js
+++ b/tests/unit/aiErrorHandler.personality.test.js
@@ -15,6 +15,18 @@ jest.mock('../../src/core/personality', () => ({
   getPersonality: jest.fn(),
 }));
 
+jest.mock('../../src/application/services/FeatureFlags', () => ({
+  getFeatureFlags: jest.fn().mockReturnValue({
+    isEnabled: jest.fn().mockReturnValue(false), // Default to legacy behavior
+  }),
+}));
+
+jest.mock('../../src/application/routers/PersonalityRouter', () => ({
+  getPersonalityRouter: jest.fn().mockReturnValue({
+    getPersonality: jest.fn(),
+  }),
+}));
+
 const logger = require('../../src/logger');
 const { getPersonality } = require('../../src/core/personality');
 const { analyzeErrorAndGenerateMessage } = require('../../src/utils/aiErrorHandler');


### PR DESCRIPTION
## Release v2.0.4

### Fixed
- **DDD Personality Error Messages** - Fixed bug where personality-specific error messages weren't being used when DDD is enabled
  - Updated `aiErrorHandler` to check DDD feature flag and use PersonalityRouter when enabled  
  - Fixed `PersonalityRouter._convertDDDToLegacyFormat` to include the `errorMessage` field
  - Empty response errors now correctly use personality-specific error messages in DDD mode
  - Added comprehensive tests for both legacy and DDD error handling paths

This is a patch release that fixes personality error message handling in the DDD system.

🤖 Generated with [Claude Code](https://claude.ai/code)