### PR TITLE
release: v2.0.7 - Fix webhook display names for DDD personalities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.7] - 2025-07-08
+
+### Fixed
+- **Webhook Display Names** - Fixed warning "displayName missing for personality" in webhook manager
+  - Updated `getStandardizedUsername` to correctly access `personality.profile.displayName` in DDD structure
+  - Fixed avatar URL resolution to use `personality.profile.avatarUrl` for proper webhook profile pictures
+  - Removed legacy personality structure support as all data has been migrated to DDD
+  - Updated all webhook-related tests to use correct DDD personality structure
+
 ## [2.0.6] - 2025-07-08
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tzurot",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tzurot",
-      "version": "2.0.6",
+      "version": "2.0.7",
       "dependencies": {
         "discord.js": "14.19.3",
         "dotenv": "16.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tzurot",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "A Discord bot that uses webhooks to represent multiple AI personalities",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/webhook/messageUtils.test.js
+++ b/tests/unit/webhook/messageUtils.test.js
@@ -41,14 +41,18 @@ describe('messageUtils', () => {
     it('should prioritize displayName when available', () => {
       const personality = {
         fullName: 'test-personality',
-        displayName: 'Test Display',
+        profile: {
+          displayName: 'Test Display',
+        },
       };
       expect(getStandardizedUsername(personality)).toBe('Test Display');
     });
 
     it('should trim whitespace from displayName', () => {
       const personality = {
-        displayName: '  Test Display  ',
+        profile: {
+          displayName: '  Test Display  ',
+        },
       };
       expect(getStandardizedUsername(personality)).toBe('Test Display');
     });
@@ -56,7 +60,9 @@ describe('messageUtils', () => {
     it('should handle empty displayName', () => {
       const personality = {
         fullName: 'test-personality',
-        displayName: '',
+        profile: {
+          displayName: '',
+        },
       };
       expect(getStandardizedUsername(personality)).toBe('Test');
     });
@@ -69,7 +75,9 @@ describe('messageUtils', () => {
       };
 
       const personality = {
-        displayName: 'Test',
+        profile: {
+          displayName: 'Test',
+        },
       };
 
       expect(getStandardizedUsername(personality)).toBe('Test | Dev');
@@ -83,7 +91,9 @@ describe('messageUtils', () => {
       };
 
       const personality = {
-        displayName: 'Test',
+        profile: {
+          displayName: 'Test',
+        },
       };
 
       expect(getStandardizedUsername(personality)).toBe('Test');
@@ -97,7 +107,9 @@ describe('messageUtils', () => {
       };
 
       const personality = {
-        displayName: 'Test',
+        profile: {
+          displayName: 'Test',
+        },
       };
 
       expect(getStandardizedUsername(personality)).toBe('Test | Production');
@@ -105,7 +117,9 @@ describe('messageUtils', () => {
 
     it('should truncate long names to fit 32 character limit', () => {
       const personality = {
-        displayName: 'This Is A Very Long Display Name That Exceeds Limit',
+        profile: {
+          displayName: 'This Is A Very Long Display Name That Exceeds Limit',
+        },
       };
 
       const result = getStandardizedUsername(personality);
@@ -121,7 +135,9 @@ describe('messageUtils', () => {
       };
 
       const personality = {
-        displayName: 'This Is A Very Long Display Name',
+        profile: {
+          displayName: 'This Is A Very Long Display Name',
+        },
       };
 
       const result = getStandardizedUsername(personality);
@@ -138,7 +154,9 @@ describe('messageUtils', () => {
       };
 
       const personality = {
-        displayName: 'Test',
+        profile: {
+          displayName: 'Test',
+        },
       };
 
       const result = getStandardizedUsername(personality);
@@ -189,7 +207,9 @@ describe('messageUtils', () => {
       global.tzurotClient = undefined;
 
       const personality = {
-        displayName: 'Test',
+        profile: {
+          displayName: 'Test',
+        },
       };
 
       expect(getStandardizedUsername(personality)).toBe('Test');
@@ -201,7 +221,9 @@ describe('messageUtils', () => {
       };
 
       const personality = {
-        displayName: 'Test',
+        profile: {
+          displayName: 'Test',
+        },
       };
 
       expect(getStandardizedUsername(personality)).toBe('Test');
@@ -215,7 +237,9 @@ describe('messageUtils', () => {
       };
 
       const personality = {
-        displayName: 'Test',
+        profile: {
+          displayName: 'Test',
+        },
       };
 
       expect(getStandardizedUsername(personality)).toBe('Test');
@@ -260,7 +284,9 @@ describe('messageUtils', () => {
       };
 
       const personality = {
-        displayName: 'Test',
+        profile: {
+          displayName: 'Test',
+        },
       };
 
       expect(getStandardizedUsername(personality)).toBe('Test | Dev');
@@ -407,7 +433,9 @@ describe('messageUtils', () => {
     it('should create virtual result with personality', () => {
       const personality = {
         fullName: 'test-personality',
-        displayName: 'Test',
+        profile: {
+          displayName: 'Test',
+        },
       };
 
       const result = createVirtualResult(personality, 'channel-123');
@@ -454,7 +482,9 @@ describe('messageUtils', () => {
 
       const personality = {
         fullName: 'test-personality',
-        displayName: 'Test Display',
+        profile: {
+          displayName: 'Test Display',
+        },
       };
 
       const result = createVirtualResult(personality, 'channel-123');
@@ -498,7 +528,9 @@ describe('messageUtils', () => {
         username: 'TestUser',
         _personality: {
           fullName: 'test-bot',
-          avatarUrl: 'https://example.com/avatar.png',
+          profile: {
+            avatarUrl: 'https://example.com/avatar.png',
+          },
         },
       };
 

--- a/tests/unit/webhookManager.exports.test.js
+++ b/tests/unit/webhookManager.exports.test.js
@@ -92,7 +92,9 @@ describe('WebhookManager - Exported Functions', () => {
     it('should prioritize displayName if available', () => {
       const personality = {
         fullName: 'test-personality',
-        displayName: 'Test Display Name',
+        profile: {
+          displayName: 'Test Display Name',
+        },
       };
 
       const result = webhookManager.getStandardizedUsername(personality);
@@ -101,8 +103,10 @@ describe('WebhookManager - Exported Functions', () => {
 
     it('should truncate display names longer than 32 characters', () => {
       const personality = {
-        displayName:
-          "This is a very long display name that exceeds Discord's limit of 32 characters",
+        profile: {
+          displayName:
+            "This is a very long display name that exceeds Discord's limit of 32 characters",
+        },
       };
 
       const result = webhookManager.getStandardizedUsername(personality);

--- a/tests/unit/webhookManager.media.test.js
+++ b/tests/unit/webhookManager.media.test.js
@@ -60,7 +60,9 @@ describe('Webhook Manager - Media Handling', () => {
       'Check out this content',
       {
         fullName: 'test-personality',
-        displayName: 'Test Personality',
+        profile: {
+          displayName: 'Test Personality',
+        },
       },
       {
         files: [
@@ -86,7 +88,9 @@ describe('Webhook Manager - Media Handling', () => {
       'Multiple files',
       {
         fullName: 'test-personality',
-        displayName: 'Test Personality',
+        profile: {
+          displayName: 'Test Personality',
+        },
       },
       {
         files: [{ attachment: 'https://example.com/image1.png', name: 'image1.png' }],
@@ -114,7 +118,9 @@ describe('Webhook Manager - Media Handling', () => {
       'DM with file',
       {
         fullName: 'test-personality',
-        displayName: 'Test Personality',
+        profile: {
+          displayName: 'Test Personality',
+        },
       },
       {
         files: [
@@ -137,7 +143,9 @@ describe('Webhook Manager - Media Handling', () => {
       '',
       {
         fullName: 'test-personality',
-        displayName: 'Test Personality',
+        profile: {
+          displayName: 'Test Personality',
+        },
       },
       {
         files: [
@@ -167,7 +175,9 @@ describe('Webhook Manager - Media Handling', () => {
   test('should send simple message without options', async () => {
     const promise = webhookManager.sendWebhookMessage(mockChannel, 'Message with embed', {
       fullName: 'test-personality',
-      displayName: 'Test Personality',
+      profile: {
+          displayName: 'Test Personality',
+        },
     });
 
     // Advance timers to resolve any pending timers
@@ -186,15 +196,17 @@ describe('Webhook Manager - Media Handling', () => {
   test('should handle errors gracefully', async () => {
     mockWebhook.send.mockRejectedValue(new Error('Webhook error'));
 
-    const promise = expect(
-      webhookManager.sendWebhookMessage(mockChannel, 'This will fail', {
-        fullName: 'test-personality',
+    const promise = webhookManager.sendWebhookMessage(mockChannel, 'This will fail', {
+      fullName: 'test-personality',
+      profile: {
         displayName: 'Test Personality',
-      })
-    ).rejects.toThrow();
+      },
+    });
 
+    // Advance timers to resolve any pending timers
     jest.runAllTimers();
-    await promise;
+
+    await expect(promise).rejects.toThrow();
 
     expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Error'));
   });

--- a/tests/unit/webhookManager.test.js
+++ b/tests/unit/webhookManager.test.js
@@ -164,7 +164,9 @@ describe('WebhookManager', () => {
     it('should prioritize displayName if available', () => {
       const personality = {
         fullName: 'full-name-personality',
-        displayName: 'Display Name',
+        profile: {
+          displayName: 'Display Name',
+        },
       };
 
       expect(webhookManager.getStandardizedUsername(personality)).toBe('Display Name');
@@ -190,7 +192,9 @@ describe('WebhookManager', () => {
 
     it('should truncate names longer than 32 characters', () => {
       const personality = {
-        displayName: 'This is a very long display name that exceeds discord limits',
+        profile: {
+          displayName: 'This is a very long display name that exceeds discord limits',
+        },
       };
 
       const result = webhookManager.getStandardizedUsername(personality);

--- a/tests/unit/webhookManager.username.suffix.test.js
+++ b/tests/unit/webhookManager.username.suffix.test.js
@@ -22,7 +22,9 @@ describe('Webhook Username Suffix', () => {
   it('should append bot suffix to display name', () => {
     const personality = {
       fullName: 'albert-einstein',
-      displayName: 'Albert Einstein',
+      profile: {
+        displayName: 'Albert Einstein',
+      },
       avatarUrl: 'https://example.com/avatar.png',
     };
 
@@ -43,7 +45,9 @@ describe('Webhook Username Suffix', () => {
   it('should handle long display names and truncate properly', () => {
     const personality = {
       fullName: 'long-name',
-      displayName: 'This is a very very very long display name that exceeds limit',
+      profile: {
+        displayName: 'This is a very very very long display name that exceeds limit',
+      },
       avatarUrl: 'https://example.com/avatar.png',
     };
 
@@ -52,7 +56,7 @@ describe('Webhook Username Suffix', () => {
     const maxNameLength = 29 - expectedSuffix.length;
 
     expect(username).toBe(
-      `${personality.displayName.substring(0, maxNameLength)}...${expectedSuffix}`
+      `${personality.profile.displayName.substring(0, maxNameLength)}...${expectedSuffix}`
     );
     expect(username.length).toBeLessThanOrEqual(32);
   });
@@ -79,7 +83,9 @@ describe('Webhook Username Suffix', () => {
 
     const personality = {
       fullName: 'sigmund-freud',
-      displayName: 'Sigmund Freud',
+      profile: {
+        displayName: 'Sigmund Freud',
+      },
       avatarUrl: 'https://example.com/avatar.png',
     };
 
@@ -97,7 +103,9 @@ describe('Webhook Username Suffix', () => {
 
     const personality = {
       fullName: 'carl-jung',
-      displayName: 'Carl Jung',
+      profile: {
+        displayName: 'Carl Jung',
+      },
       avatarUrl: 'https://example.com/avatar.png',
     };
 
@@ -122,7 +130,9 @@ describe('Webhook Username Suffix', () => {
 
     const personality = {
       fullName: 'carl-jung',
-      displayName: 'Carl Jung',
+      profile: {
+        displayName: 'Carl Jung',
+      },
       avatarUrl: 'https://example.com/avatar.png',
     };
 


### PR DESCRIPTION
## Summary
Fixed warning messages about missing displayName for DDD personalities in webhook manager.

## Changes
- Updated `getStandardizedUsername` to correctly access `personality.profile.displayName` in DDD structure
- Fixed avatar URL resolution to use `personality.profile.avatarUrl` for proper webhook profile pictures
- Removed legacy personality structure support as all data has been migrated to DDD
- Updated all webhook-related tests to use correct DDD personality structure

## Test plan
- [x] All tests passing
- [x] Manual testing shows no more displayName warnings
- [x] Webhook profile pictures should work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)