### PR TITLE
release: v2.0.8 - Fix webhook profile pictures after DDD migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.8] - 2025-07-08
+
+### Fixed
+- **Webhook Profile Pictures** - Fixed avatars not showing in Discord webhooks after DDD migration
+  - Added avatarStorage initialization to ApplicationBootstrap (was only in legacy PersonalityManager)
+  - Added avatar pre-downloading when registering personalities in DDD system
+  - Added avatar pre-downloading when refreshing profiles from API
+  - Ensures avatars are downloaded and served locally to bypass Discord/shapes.inc blocking
+
 ## [2.0.7] - 2025-07-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added avatarStorage initialization to ApplicationBootstrap (was only in legacy PersonalityManager)
   - Added avatar pre-downloading when registering personalities in DDD system
   - Added avatar pre-downloading when refreshing profiles from API
-  - Ensures avatars are downloaded and served locally to bypass Discord/shapes.inc blocking
+  - Ensures avatars are downloaded and served locally for better reliability
 
 ## [2.0.7] - 2025-07-08
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tzurot",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tzurot",
-      "version": "2.0.7",
+      "version": "2.0.8",
       "dependencies": {
         "discord.js": "14.19.3",
         "dotenv": "16.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tzurot",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "A Discord bot that uses webhooks to represent multiple AI personalities",
   "main": "index.js",
   "scripts": {

--- a/src/application/bootstrap/ApplicationBootstrap.js
+++ b/src/application/bootstrap/ApplicationBootstrap.js
@@ -75,8 +75,9 @@ class ApplicationBootstrap {
       logger.info('[ApplicationBootstrap] Starting DDD application layer initialization...');
 
       // Initialize avatar storage system (needed for webhook profile pictures)
+      logger.info('[ApplicationBootstrap] Initializing avatar storage system...');
       await avatarStorage.initialize();
-      logger.info('[ApplicationBootstrap] Avatar storage initialized');
+      logger.info('[ApplicationBootstrap] Avatar storage initialized successfully');
 
       // Step 1: Create shared infrastructure
       this.eventBus = new DomainEventBus();

--- a/src/application/bootstrap/ApplicationBootstrap.js
+++ b/src/application/bootstrap/ApplicationBootstrap.js
@@ -23,6 +23,7 @@ const { getCommandIntegrationAdapter } = require('../../adapters/CommandIntegrat
 const profileInfoFetcher = require('../../profileInfoFetcher');
 const { messageTracker } = require('../../messageTracker');
 const { getInstance: getConversationManager } = require('../../core/conversation');
+const avatarStorage = require('../../utils/avatarStorage');
 
 /**
  * ApplicationBootstrap
@@ -72,6 +73,10 @@ class ApplicationBootstrap {
 
     try {
       logger.info('[ApplicationBootstrap] Starting DDD application layer initialization...');
+
+      // Initialize avatar storage system (needed for webhook profile pictures)
+      await avatarStorage.initialize();
+      logger.info('[ApplicationBootstrap] Avatar storage initialized');
 
       // Step 1: Create shared infrastructure
       this.eventBus = new DomainEventBus();

--- a/src/webhook/messageUtils.js
+++ b/src/webhook/messageUtils.js
@@ -262,9 +262,11 @@ async function sendMessageChunk(webhook, messageData, chunkIndex, totalChunks) {
           personalityAvatarUrl
         );
         avatarUrl = localAvatarUrl || personalityAvatarUrl;
+        logger.info(`[MessageUtils] Avatar URL for ${_personality.fullName}: ${avatarUrl} (original: ${personalityAvatarUrl})`);
       } catch (error) {
         logger.error(`[MessageUtils] Failed to get local avatar URL: ${error.message}`);
         avatarUrl = personalityAvatarUrl; // Fallback to original
+        logger.info(`[MessageUtils] Using fallback avatar URL: ${avatarUrl}`);
       }
     }
 


### PR DESCRIPTION
## Summary
Fixed webhook profile pictures not showing after DDD migration by implementing avatar pre-downloading in the DDD system.

## Changes
- Added avatarStorage initialization to ApplicationBootstrap (was only initialized in legacy PersonalityManager)
- Added avatar pre-downloading when registering personalities in DDD PersonalityApplicationService
- Added avatar pre-downloading when refreshing profiles from API
- Matches the exact behavior of the legacy system to ensure avatars are downloaded and served locally

## Why This Fixes The Issue
The avatar storage system downloads avatars from shapes.inc and serves them locally from the bot's domain. This is necessary because Discord and shapes.inc had a falling out, so Discord won't display avatars from shapes.inc domains directly. The DDD migration missed this critical functionality.

## Test plan
- [x] All tests passing
- [ ] Deploy and verify avatars show in webhooks
- [ ] Check logs for avatar download confirmations

🤖 Generated with [Claude Code](https://claude.ai/code)