### PR TITLE
Release v2.1.1: Critical webhook URL corruption fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1] - 2025-07-10
+
+### Fixed
+- **Webhook URL Corruption in Thread Messages** - Fixed critical production issue causing thread message failures
+  - Root cause: Inconsistent webhook client construction between threadHandler and webhookCache
+  - threadHandler was using `new WebhookClient({ url: webhook.url })` while webhookCache used `{ id, token }`
+  - This inconsistency corrupted webhook URLs for specific threads (e.g., thread ID 1377848847119679508)
+  - Now threadHandler uses webhookCache.getOrCreateWebhook() for consistent webhook construction
+  - Fixes "The provided webhook URL is not valid" errors in production
+  - Emergency fallback now works properly for both short and long messages
+  - Tested successfully on regular threads and forum threads
+
 ## [2.1.0] - 2025-07-10
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tzurot",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tzurot",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
         "discord.js": "14.19.3",
         "dotenv": "16.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tzurot",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A Discord bot that uses webhooks to represent multiple AI personalities",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Release v2.1.1 - Critical Hotfix

This release contains a critical production fix for webhook URL corruption affecting thread messages.

### 🚨 Critical Fix
- **Webhook URL Corruption in Thread Messages** - Fixed production issue causing thread message failures
  - Inconsistent webhook client construction between threadHandler and webhookCache
  - Affected specific threads with "The provided webhook URL is not valid" errors
  - Emergency fallback working for short but failing for long messages due to Discord's 2000 char limit

### 🔧 Technical Details
- **Root Cause**: threadHandler used `new WebhookClient({ url: webhook.url })` while webhookCache used `{ id, token }`
- **Solution**: threadHandler now uses webhookCache.getOrCreateWebhook() for consistency
- **Impact**: High impact fix with low risk - uses existing proven webhook cache system
- **Testing**: Verified on regular threads and forum threads

### ✅ Quality Assurance
- All tests pass (including updated threadHandler tests)
- No breaking changes or API modifications
- Maintains all existing webhook functionality
- Pre-commit checks and quality gates passed

### 📋 Release Checklist
- [x] Version bumped: 2.1.0 → 2.1.1
- [x] CHANGELOG.md updated with detailed fix description
- [x] package-lock.json updated
- [x] All tests passing
- [x] Production issue verified as resolved

### 🚀 Deployment Impact
- **Risk Level**: Low (internal consistency fix)
- **Urgency**: High (fixes critical production webhook failures)
- **Rollback**: Safe (no schema or API changes)

This hotfix resolves the immediate production webhook issues reported in thread ID 1377848847119679508 and ensures consistent webhook behavior across all thread types.

🤖 Generated with [Claude Code](https://claude.ai/code)