### PR TITLE
chore: release v2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.2] - 2025-01-18
+
+### Changed
+- **Model Indicator Terminology** - Updated model indicator text for consistency
+  - Changed "Main Model Used (Premium)" to "Primary Model Used (Premium)"
+  - Changed "Main Model Used (Free)" to "Primary Model Used (Free)"
+  - Provides clearer and more consistent terminology across the bot
+
 ## [2.2.1] - 2025-01-18
 
 ### Fixed
@@ -21,8 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Fallback Engine Indicators** - Messages now display model usage information
-  - "Main Model Used (Premium)" when using premium model with `is_premium: true`
-  - "Main Model Used (Free)" when using standard model with `is_premium: false`
+  - "Primary Model Used (Premium)" when using premium model with `is_premium: true`
+  - "Primary Model Used (Free)" when using standard model with `is_premium: false`
   - "Fallback Model Used" when using fallback engine with `fallback_model_used: true`
   - Indicators appear as small Discord text (using `-#` formatting) at the end of personality messages
   - Works across all message types: DMs, regular channels, and threads

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tzurot",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tzurot",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "dependencies": {
         "discord.js": "14.19.3",
         "dotenv": "16.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tzurot",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "A Discord bot that uses webhooks to represent multiple AI personalities",
   "main": "index.js",
   "scripts": {

--- a/src/handlers/personalityHandler.js
+++ b/src/handlers/personalityHandler.js
@@ -229,9 +229,9 @@ function generateModelIndicator(metadata) {
   if (metadata.fallback_model_used === true) {
     indicator = 'Fallback Model Used';
   } else if (metadata.is_premium === true) {
-    indicator = 'Main Model Used (Premium)';
+    indicator = 'Primary Model Used (Premium)';
   } else if (metadata.is_premium === false) {
-    indicator = 'Main Model Used (Free)';
+    indicator = 'Primary Model Used (Free)';
   }
 
   return indicator ? `\n-# ${indicator}` : '';

--- a/tests/unit/personalityHandler.metadata.test.js
+++ b/tests/unit/personalityHandler.metadata.test.js
@@ -127,7 +127,7 @@ describe('Personality Handler - Model Metadata Indicator', () => {
       };
 
       const indicator = personalityHandler.generateModelIndicator(metadata);
-      expect(indicator).toBe('\n-# Main Model Used (Premium)');
+      expect(indicator).toBe('\n-# Primary Model Used (Premium)');
     });
 
     it('should generate indicator for free main model', () => {
@@ -138,7 +138,7 @@ describe('Personality Handler - Model Metadata Indicator', () => {
       };
 
       const indicator = personalityHandler.generateModelIndicator(metadata);
-      expect(indicator).toBe('\n-# Main Model Used (Free)');
+      expect(indicator).toBe('\n-# Primary Model Used (Free)');
     });
 
     it('should return empty string for null metadata', () => {
@@ -165,12 +165,12 @@ describe('Personality Handler - Model Metadata Indicator', () => {
         },
         {
           metadata: { fallback_model_used: false, is_premium: true },
-          expected: '\n-# Main Model Used (Premium)',
+          expected: '\n-# Primary Model Used (Premium)',
           description: 'premium model',
         },
         {
           metadata: { fallback_model_used: false, is_premium: false },
-          expected: '\n-# Main Model Used (Free)',
+          expected: '\n-# Primary Model Used (Free)',
           description: 'free model',
         },
         {


### PR DESCRIPTION
## Summary
- Updated model indicator terminology from "Main Model Used" to "Primary Model Used" for consistency

## Changes
- Changed "Main Model Used (Premium)" to "Primary Model Used (Premium)"
- Changed "Main Model Used (Free)" to "Primary Model Used (Free)"
- Updated tests to match new terminology

This is a minor text change that improves consistency in the bot's terminology.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Minor improvement
- [ ] Documentation update

## Testing
- [x] Tests pass locally
- [x] No breaking changes

## Checklist
- [x] PR targets `main` branch (release PR)
- [x] Version bumped to 2.2.2
- [x] CHANGELOG.md updated
- [x] All tests passing