### PR TITLE
chore: release v2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.3] - 2025-01-18
+
+### Fixed
+- **Personality Error Messages** - Fixed personality-specific error messages not displaying
+  - PersonalityRouter was returning raw Personality aggregate objects
+  - Added `toJSON()` serialization to access error message property
+  - Personalities now correctly show their custom error messages (e.g., "*sighs dramatically* Something went wrong!")
+  - Includes enhanced debug logging for troubleshooting
+
 ## [2.2.2] - 2025-01-18
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tzurot",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tzurot",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "dependencies": {
         "discord.js": "14.19.3",
         "dotenv": "16.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tzurot",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "A Discord bot that uses webhooks to represent multiple AI personalities",
   "main": "index.js",
   "scripts": {

--- a/src/adapters/persistence/FilePersonalityRepository.js
+++ b/src/adapters/persistence/FilePersonalityRepository.js
@@ -462,21 +462,33 @@ class FilePersonalityRepository {
     // Create profile from stored data
     let profile;
     if (data.profile) {
-      // Use object constructor to preserve all fields
-      profile = new PersonalityProfile({
-        mode: data.profile.mode || 'local',
+      const profileMode = data.profile.mode || 'local';
+      
+      // Build profile data based on mode
+      const profileData = {
+        mode: profileMode,
         name: data.profile.name || data.id,
         displayName: data.profile.displayName || data.profile.name || data.id,
-        prompt: data.profile.prompt || `You are ${data.profile.name || data.id}`,
-        modelPath: data.profile.modelPath || '/default',
-        maxWordCount: data.profile.maxWordCount || 1000,
         avatarUrl: data.profile.avatarUrl,
-        bio: data.profile.bio,
-        systemPrompt: data.profile.systemPrompt,
-        temperature: data.profile.temperature,
-        maxTokens: data.profile.maxTokens,
         errorMessage: data.profile.errorMessage,
-      });
+      };
+      
+      // Only add local-mode fields if not external
+      if (profileMode !== 'external') {
+        profileData.prompt = data.profile.prompt || `You are ${data.profile.name || data.id}`;
+        profileData.modelPath = data.profile.modelPath || '/default';
+        profileData.maxWordCount = data.profile.maxWordCount || 1000;
+        profileData.bio = data.profile.bio;
+        profileData.systemPrompt = data.profile.systemPrompt;
+        profileData.temperature = data.profile.temperature;
+        profileData.maxTokens = data.profile.maxTokens;
+      } else {
+        // For external mode, include lastFetched if available
+        profileData.lastFetched = data.profile.lastFetched;
+      }
+      
+      // Use object constructor to preserve all fields
+      profile = new PersonalityProfile(profileData);
     } else {
       // No profile data - create default using object constructor
       profile = new PersonalityProfile({

--- a/src/application/services/PersonalityApplicationService.js
+++ b/src/application/services/PersonalityApplicationService.js
@@ -240,10 +240,12 @@ class PersonalityApplicationService {
           const apiData = await this.profileFetcher.fetchProfileInfo(personalityName, userId);
           if (apiData) {
             // Update profile with API data
-            personality.profile = PersonalityProfile.fromApiResponse(apiData);
+            const updatedProfile = PersonalityProfile.fromApiResponse(apiData);
+            personality.updateProfile({ externalProfile: updatedProfile });
 
             // Save updated profile
             await this.personalityRepository.save(personality);
+            await this._publishEvents(personality);
 
             // Pre-download avatar if URL changed
             if (personality.profile.avatarUrl) {


### PR DESCRIPTION
## Summary
Release v2.2.3 - Fixes personality-specific error messages not displaying

## Changes
- Fixed PersonalityRouter returning raw Personality aggregate objects
- Added `toJSON()` serialization to properly access error message property
- Personalities now correctly show their custom error messages

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Tests pass locally
- [x] Manual testing completed
- [x] Error messages now display correctly

## Release Checklist
- [x] Version bumped to 2.2.3
- [x] CHANGELOG.md updated
- [x] All tests passing
- [ ] Ready to merge
- [ ] Create GitHub release after merge
- [ ] Sync develop with main after merge

🤖 Generated with [Claude Code](https://claude.ai/code)