### PR TITLE
fix: multi-word tag parsing by updating max alias word count after loading personalities

### DIFF
--- a/docs/development/KNOWN_BUGS.md
+++ b/docs/development/KNOWN_BUGS.md
@@ -110,7 +110,7 @@ When reporting a new bug, include:
 
 ## Recently Fixed
 
-- **Multi-word Tag Parsing** (Jan 2025): Fixed max alias word count calculation timing issue
+- **Multi-word Tag Parsing** (Aug 2025): Fixed max alias word count calculation timing issue
 
 ## Related Documents
 

--- a/docs/development/KNOWN_BUGS.md
+++ b/docs/development/KNOWN_BUGS.md
@@ -1,0 +1,119 @@
+# Known Bugs and Issues
+
+This document tracks known bugs and issues in the Tzurot Discord bot. For feature requests and improvements, see [Feature Ideas](../improvements/post-ddd/FEATURE_IDEAS.md).
+
+## Bug Priority Classification
+
+- **🔴 Critical**: Security issues, data loss, or features completely broken
+- **🟡 High**: Core functionality impaired but has workarounds  
+- **🟢 Medium**: Non-critical issues affecting user experience
+- **⚪ Low**: Minor issues or edge cases
+
+## Active Bugs
+
+### 🔴 Critical Issues
+
+#### 1. NSFW/Authentication Bypass Bug
+**Status**: Open  
+**Branch**: `fix/nsfw-channel-bypass`  
+**Description**: Replies in SFW channels seem to bypass NSFW check. Verified users allowed to interact in any channel regardless of NSFW settings.  
+**Details**:
+- Security/content filtering issue
+- Need to check authentication flow in personalityHandler.js
+- May involve checkPersonalityAuth function
+**Affected Files**: `src/handlers/personalityHandler.js`
+
+### 🟡 High Priority
+
+#### 2. Autorespond Default State Bug
+**Status**: Open  
+**Branch**: `fix/autorespond-default-state`  
+**Description**: Autorespond turns on by itself for unknown reasons. Should be OFF by default.  
+**Details**:
+- Check ConversationManager initialization
+- Verify default settings in conversation domain
+- May need to check persistence layer
+**Affected Files**: `src/core/conversation/ConversationManager.js`
+
+#### 3. DM Reply Quote Bug
+**Status**: Open  
+**Branch**: `fix/dm-reply-quotes`  
+**Description**: Replying to a DM personality message always includes the quoted message instead of matching channel behavior.  
+**Details**:
+- Check dmHandler.js for reply logic
+- Should match channel behavior for quote inclusion
+**Affected Files**: `src/handlers/dmHandler.js`
+
+### 🟢 Medium Priority
+
+#### 4. ~~Multi-word Tag Parsing Bug~~ ✅ FIXED
+**Status**: Fixed in PR #[pending]  
+**Branch**: `fix/multi-word-tag-parsing`  
+**Description**: Multi-word tags like `@cash money` were broken.  
+**Solution**: Updated max alias word count calculation to happen after personalities are loaded from disk.
+
+#### 5. Image Re-upload Handling Bug
+**Status**: Open  
+**Branch**: `fix/image-reupload-handling`  
+**Description**: Links being completely stripped out can look odd in the middle of a message when images are re-uploaded.  
+**Details**:
+- Check media attachment handling in messageHandler.js
+- May need to preserve placeholder text when Discord re-uploads images
+**Affected Files**: `src/handlers/messageHandler.js`
+
+#### 6. Embed Field Parsing Bug
+**Status**: Open  
+**Branch**: `fix/embed-field-parsing`  
+**Description**: Not all embed fields are parsed correctly for links/referenced messages.  
+**Details**:
+- Check referenceHandler.js for embed parsing logic
+- Some embed types may be missing or incorrectly parsed
+**Affected Files**: `src/handlers/referenceHandler.js`
+
+### ⚪ Low Priority
+
+#### 7. Purgbot Command Limit Bug
+**Status**: Open  
+**Branch**: `fix/purgbot-message-limit`  
+**Description**: Purgbot command stops after 99 messages even if there are more.  
+**Details**:
+- Check purgbot personality handler
+- May be Discord API limit that needs pagination
+**Affected Files**: Command implementation in purgbot handler
+
+#### 8. Verify Command Timing Bug
+**Status**: Open  
+**Branch**: `fix/verify-command-timing`  
+**Description**: `!tz verify` doesn't work properly if auth isn't finished.  
+**Details**:
+- Race condition or missing state check
+- Check VerifyCommand.js implementation
+**Affected Files**: `src/application/commands/authentication/VerifyCommand.js`
+
+## Bug Reporting Guidelines
+
+When reporting a new bug, include:
+1. **Description**: Clear, concise description of the issue
+2. **Steps to Reproduce**: Exact steps to trigger the bug
+3. **Expected Behavior**: What should happen
+4. **Actual Behavior**: What actually happens
+5. **Environment**: Discord server type, bot version, etc.
+6. **Screenshots/Logs**: If applicable
+
+## Fix Workflow
+
+1. Create branch from `develop`: `fix/descriptive-name`
+2. Implement fix with tests
+3. Update this document to mark as fixed
+4. Create PR to `develop` branch
+5. After merge, remove from active bugs list
+
+## Recently Fixed
+
+- **Multi-word Tag Parsing** (Jan 2025): Fixed max alias word count calculation timing issue
+
+## Related Documents
+
+- [Feature Ideas](../improvements/post-ddd/FEATURE_IDEAS.md) - New feature requests
+- [Issue Resolutions](ISSUE_RESOLUTIONS.md) - Historical fixes and resolutions
+- [Git Workflow](GIT_AND_PR_WORKFLOW.md) - Branch and PR guidelines

--- a/docs/improvements/post-ddd/FEATURE_IDEAS.md
+++ b/docs/improvements/post-ddd/FEATURE_IDEAS.md
@@ -109,7 +109,7 @@
 
 ---
 
-## Additional Feature Ideas (January 2025)
+## Additional Feature Ideas (August 2025)
 
 ### 4. User Preferences System with Voice Toggle
 **Feature**: User-specific preferences command system

--- a/docs/improvements/post-ddd/FEATURE_IDEAS.md
+++ b/docs/improvements/post-ddd/FEATURE_IDEAS.md
@@ -105,4 +105,130 @@
 ## Next Steps
 - Discuss preferred approach for personality storage with team
 - Create detailed technical specifications for each feature
-- Implement features in priority order- **Express.js HTTP Framework Migration** - Consider migrating from custom HTTP server to Express.js for better routing, middleware support, and ecosystem
+- Implement features in priority order
+
+---
+
+## Additional Feature Ideas (January 2025)
+
+### 4. User Preferences System with Voice Toggle
+**Feature**: User-specific preferences command system
+- **Command**: `!tz preferences` or `!tz prefs`
+- **Primary Use Case**: Toggle !voice prefix for personalities
+- **Behavior**:
+  - Store per-user preferences including voice message generation
+  - Default: voice prefix ON (prepends !voice to personality messages)
+  - Users can toggle this off if they don't want voice messages
+  - Could expand to include timezone preferences, notification settings, etc.
+- **Implementation Notes**:
+  - Need persistence layer for user preferences
+  - Hook into message generation to conditionally add !voice prefix
+  - Consider using existing user auth infrastructure
+
+### 5. Emoji Reaction Actions
+**Feature**: Use emoji reactions on personality messages to trigger actions
+- **Behavior**:
+  - ℹ️ or ❓ emoji: Display stats/details about the personality
+  - 🔄 emoji: Regenerate the response
+  - ❌ emoji: Delete the personality message (if user has permission)
+  - 📊 emoji: Show usage statistics
+- **Implementation**:
+  - Listen for reaction add/remove events
+  - Map emojis to specific actions
+  - Check permissions before executing actions
+  - Store message-to-personality mapping for context
+
+### 6. Multiple Personality Tags
+**Feature**: Tag multiple personalities in one message for group responses
+- **Behavior**:
+  - Parse multiple @mentions in a single message
+  - Queue responses from each tagged personality
+  - Personalities respond in order mentioned
+  - Handle rate limiting appropriately
+- **Example**: "@alice @bob What do you think?" generates responses from both
+- **Considerations**:
+  - Rate limit handling for multiple API calls
+  - Message ordering and threading
+  - Cost implications of multiple AI calls
+
+### 7. Disable Replies for Disabled Tags
+**Feature**: Respect Discord's ping notification settings
+- **Behavior**:
+  - Check if user has notifications enabled for personality mentions
+  - If ping is disabled in Discord UI, optionally skip reply
+  - Could be a per-personality or global setting
+- **Implementation**:
+  - Hook into Discord's notification API
+  - Store user preference for this behavior
+
+### 8. Forwarded Message Support
+**Feature**: Parse and handle Discord's forwarded message format
+- **Behavior**:
+  - Detect forwarded message structure
+  - Include forwarded content in personality context
+  - Properly attribute original sender
+- **Implementation**:
+  - Update message parsing in messageHandler.js
+  - Handle forwarded embeds appropriately
+
+### 9. Smart Reference Inclusion
+**Feature**: Intelligent handling of webhook content references
+- **Behavior**:
+  - Track which user an AI message was replying to
+  - If different user, always include reference (bypass time check)
+  - Maintains conversation context across user switches
+- **Implementation**:
+  - Enhance conversation tracking with reply chain data
+  - Store user context in message mapping
+
+### 10. Personality Mention Stripping
+**Feature**: Smart handling of @mentions in personality messages
+- **Behavior**:
+  - Strip @mentions at beginning/end of messages
+  - Preserve @mentions in middle of sentences
+  - Prevents awkward "Hi @user" at start of responses
+- **Example**: "@alice hi there" → "hi there" sent to AI
+- **Implementation**:
+  - Regex pattern to detect position of mentions
+  - Clean message before sending to AI service
+
+### 11. Command Ordering for AI Service
+**Feature**: Ensure AI service commands appear before context metadata
+- **Behavior**:
+  - Commands like !voice, !wack, !sleep, !reset, !web must appear first
+  - Only one command per message allowed
+  - Enhanced context metadata comes after command
+- **Implementation**:
+  - Reorder message construction in aiService.js
+  - Validate command presence and position
+
+### 12. Discord Sticker Support
+**Feature**: Convert Discord stickers to images for AI processing
+- **Behavior**:
+  - Detect sticker attachments in messages
+  - Convert static stickers to images
+  - Handle animated stickers (convert to static or describe)
+  - Send to AI as image content
+- **Implementation**:
+  - Add sticker detection in messageHandler.js
+  - Implement sticker-to-image conversion
+  - Update media handling pipeline
+
+## Feature Priority Matrix
+
+### High Impact, Low Effort
+- Personality Mention Stripping (#10)
+- Command Ordering (#11)
+- User Preferences with Voice Toggle (#4)
+
+### High Impact, High Effort
+- Multiple Personality Tags (#6)
+- Emoji Reaction Actions (#5)
+- Smart Reference Inclusion (#9)
+
+### Low Impact, Low Effort
+- Forwarded Message Support (#8)
+- Disable Replies for Disabled Tags (#7)
+
+### Low Impact, High Effort
+- Discord Sticker Support (#12)

--- a/src/application/bootstrap/ApplicationBootstrap.js
+++ b/src/application/bootstrap/ApplicationBootstrap.js
@@ -212,6 +212,16 @@ class ApplicationBootstrap {
       await authenticationRepository.initialize();
       await blacklistRepository.initialize();
 
+      // Step 9.5: Update max alias word count after personalities are loaded from disk
+      try {
+        const updatedMaxWordCount = await personalityApplicationService.getMaxAliasWordCount();
+        messageHandlerConfig.setMaxAliasWordCount(updatedMaxWordCount);
+        logger.info(`[ApplicationBootstrap] Updated max alias word count after loading personalities: ${updatedMaxWordCount}`);
+      } catch (configError) {
+        logger.error('[ApplicationBootstrap] Failed to update max alias word count:', configError);
+        // Continue with existing config value
+      }
+
       // Step 10: Schedule owner personality seeding in background (don't block initialization)
       this.initialized = true;
       logger.info('[ApplicationBootstrap] ✅ DDD application layer initialization complete');

--- a/src/application/services/PersonalityApplicationService.js
+++ b/src/application/services/PersonalityApplicationService.js
@@ -669,12 +669,12 @@ class PersonalityApplicationService {
 
   /**
    * Get the maximum word count among all aliases
-   * @returns {Promise<number>} The maximum word count (minimum 1)
+   * @returns {Promise<number>} The maximum word count (minimum 2)
    */
   async getMaxAliasWordCount() {
     try {
       const personalities = await this.personalityRepository.findAll();
-      let maxWordCount = 1; // Default to 1 if no aliases exist
+      let maxWordCount = 2; // Default to 2 to always support multi-word aliases like "@cash money"
 
       for (const personality of personalities) {
         for (const alias of personality.aliases) {

--- a/src/config/MessageHandlerConfig.js
+++ b/src/config/MessageHandlerConfig.js
@@ -7,7 +7,7 @@
  */
 class MessageHandlerConfig {
   constructor() {
-    this._maxAliasWordCount = 5; // Safe default
+    this._maxAliasWordCount = 2; // Default to support multi-word aliases like "@cash money"
     this._initialized = false;
   }
 
@@ -27,8 +27,8 @@ class MessageHandlerConfig {
   getMaxAliasWordCount() {
     if (!this._initialized) {
       // Return a safe default if not initialized yet
-      // This prevents startup issues
-      return 5;
+      // This prevents startup issues and ensures multi-word aliases work
+      return 2;
     }
     return this._maxAliasWordCount;
   }

--- a/tests/unit/config/MessageHandlerConfig.test.js
+++ b/tests/unit/config/MessageHandlerConfig.test.js
@@ -38,14 +38,14 @@ describe('MessageHandlerConfig', () => {
 
   describe('constructor and initialization', () => {
     it('should initialize with safe defaults', () => {
-      expect(config.getMaxAliasWordCount()).toBe(5);
+      expect(config.getMaxAliasWordCount()).toBe(2);
       expect(config.isInitialized()).toBe(false);
     });
 
     it('should return safe default when not initialized', () => {
       // Fresh instance should not be initialized
       expect(config.isInitialized()).toBe(false);
-      expect(config.getMaxAliasWordCount()).toBe(5);
+      expect(config.getMaxAliasWordCount()).toBe(2);
     });
   });
 
@@ -93,7 +93,7 @@ describe('MessageHandlerConfig', () => {
   describe('getMaxAliasWordCount', () => {
     it('should return safe default before initialization', () => {
       expect(config.isInitialized()).toBe(false);
-      expect(config.getMaxAliasWordCount()).toBe(5);
+      expect(config.getMaxAliasWordCount()).toBe(2);
     });
 
     it('should return configured value after initialization', () => {
@@ -187,14 +187,14 @@ describe('MessageHandlerConfig', () => {
       
       const value = config.getMaxAliasWordCount();
       
-      expect(value).toBe(5);
+      expect(value).toBe(2);
       expect(config.isInitialized()).toBe(false); // Should remain false
     });
 
     it('should return safe default consistently before initialization', () => {
-      expect(config.getMaxAliasWordCount()).toBe(5);
-      expect(config.getMaxAliasWordCount()).toBe(5);
-      expect(config.getMaxAliasWordCount()).toBe(5);
+      expect(config.getMaxAliasWordCount()).toBe(2);
+      expect(config.getMaxAliasWordCount()).toBe(2);
+      expect(config.getMaxAliasWordCount()).toBe(2);
       expect(config.isInitialized()).toBe(false);
     });
   });
@@ -216,7 +216,7 @@ describe('MessageHandlerConfig', () => {
     it('should handle early access before configuration gracefully', () => {
       // Component tries to get value before app initialization
       const earlyValue = config.getMaxAliasWordCount();
-      expect(earlyValue).toBe(5); // Safe default
+      expect(earlyValue).toBe(2); // Safe default
       expect(config.isInitialized()).toBe(false);
       
       // Later, app initializes


### PR DESCRIPTION
## Summary
Fixes the multi-word tag parsing bug where aliases like `@cash money` weren't being recognized.

## Root Cause
The max alias word count was being calculated and set before personalities were loaded from disk, resulting in a value of 1 that broke the regex pattern for multi-word matching.

## Solution
1. Set a safe minimum default of 2 words to always support multi-word aliases
2. Recalculate and update the MessageHandlerConfig after personalities are loaded from disk
3. This ensures the regex pattern `{0,${maxWords - 1}}` never becomes `{0,0}` which would break multi-word matching

## Changes
- Updated `ApplicationBootstrap.js` to recalculate max word count after loading personalities
- Set minimum default to 2 in both `PersonalityApplicationService.js` and `MessageHandlerConfig.js`
- Updated tests to reflect the new default value

## Testing
- All tests pass ✅
- Verified max word count is correctly set to 2 after initialization
- Multi-word aliases like `@cash money` should now work correctly

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

Fixes #3 from the known bugs list

🤖 Generated with [Claude Code](https://claude.ai/code)