### PR TITLE
fix: personality reply crash due to undefined service reference

### DIFF
--- a/src/application/bootstrap/ApplicationBootstrap.js
+++ b/src/application/bootstrap/ApplicationBootstrap.js
@@ -302,7 +302,7 @@ class ApplicationBootstrap {
     if (!this.initialized) {
       throw new Error('ApplicationBootstrap not initialized');
     }
-    return this.personalityApplicationService;
+    return this.applicationServices.personalityApplicationService;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Fixed critical bug where replying to personality messages caused crashes
- The getPersonalityApplicationService() method was returning wrong property path

## Problem
When users replied to personality messages, the bot crashed with:
```
Cannot read properties of undefined (reading 'getPersonality')
```

## Root Cause
The `getPersonalityApplicationService()` method in ApplicationBootstrap was returning `this.personalityApplicationService` instead of `this.applicationServices.personalityApplicationService`.

## Solution
Fixed the property path to return the correct service instance.

## Testing
- Verified all existing ApplicationBootstrap tests pass
- Verified MessageHistory tests pass (which use this service)
- The fix is a simple one-line property path correction

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change  
- [ ] Documentation update