### PR TITLE
fix(ai-worker): increase voice engine cold-start health retry budget

### DIFF
--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.test.ts
@@ -313,8 +313,9 @@ describe('TTSStep', () => {
       const result = await promise;
 
       // With fake timers, Date.now() only advances on setTimeout fires, so the
-      // poll count is deterministic: 75_000 / 3_000 = 25 polls + 1 final check = 26.
-      expect(mockVoiceEngineClient.getHealth.mock.calls.length).toBeGreaterThanOrEqual(20);
+      // poll count is deterministic: 75_000 / 3_000 = 25 polls (each followed by
+      // a 3s sleep; after the 25th sleep Date.now() == deadline, loop exits).
+      expect(mockVoiceEngineClient.getHealth).toHaveBeenCalledTimes(25);
       expect(mockEnsureVoiceRegistered).toHaveBeenCalledWith('testbot');
       expect(result.result?.metadata?.ttsAudioKey).toBe('tts:retry-job');
     });

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.test.ts
@@ -297,8 +297,8 @@ describe('TTSStep', () => {
       expect(result.result?.metadata?.ttsAudioKey).toBe('tts:cold-job');
     });
 
-    it('proceeds with TTS after max health retries exhausted', async () => {
-      // Engine never reports ready within retry window
+    it('proceeds with TTS after health budget exhausted', async () => {
+      // Engine never reports ready within the 75s time budget
       mockVoiceEngineClient.getHealth.mockResolvedValue({ asr: false, tts: false });
       mockStoreTTSAudio.mockResolvedValue('tts:retry-job');
       mockSynthesizeWithChunking.mockResolvedValue({
@@ -312,8 +312,10 @@ describe('TTSStep', () => {
       await vi.runAllTimersAsync();
       const result = await promise;
 
-      // Should exhaust all 5 attempts then proceed anyway
-      expect(mockVoiceEngineClient.getHealth).toHaveBeenCalledTimes(5);
+      // Time-based budget: 75s / 3s poll interval = ~25 polls, but exact count
+      // depends on timing. Verify it polled multiple times and still proceeded.
+      expect(mockVoiceEngineClient.getHealth).toHaveBeenCalled();
+      expect(mockVoiceEngineClient.getHealth.mock.calls.length).toBeGreaterThan(5);
       expect(mockEnsureVoiceRegistered).toHaveBeenCalledWith('testbot');
       expect(result.result?.metadata?.ttsAudioKey).toBe('tts:retry-job');
     });
@@ -376,8 +378,8 @@ describe('TTSStep', () => {
       const ctx = createContext();
 
       const promise = step.process(ctx);
-      // Advance past the 90s timeout
-      await vi.advanceTimersByTimeAsync(90_000);
+      // Advance past the 150s timeout
+      await vi.advanceTimersByTimeAsync(150_000);
       const result = await promise;
 
       expect(result).toBe(ctx);

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.test.ts
@@ -312,10 +312,9 @@ describe('TTSStep', () => {
       await vi.runAllTimersAsync();
       const result = await promise;
 
-      // Time-based budget: 75s / 3s poll interval = ~25 polls, but exact count
-      // depends on timing. Verify it polled multiple times and still proceeded.
-      expect(mockVoiceEngineClient.getHealth).toHaveBeenCalled();
-      expect(mockVoiceEngineClient.getHealth.mock.calls.length).toBeGreaterThan(5);
+      // With fake timers, Date.now() only advances on setTimeout fires, so the
+      // poll count is deterministic: 75_000 / 3_000 = 25 polls + 1 final check = 26.
+      expect(mockVoiceEngineClient.getHealth.mock.calls.length).toBeGreaterThanOrEqual(20);
       expect(mockEnsureVoiceRegistered).toHaveBeenCalledWith('testbot');
       expect(result.result?.metadata?.ttsAudioKey).toBe('tts:retry-job');
     });

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts
@@ -214,6 +214,9 @@ export class TTSStep implements IPipelineStep {
 
     while (Date.now() < deadline) {
       attempt++;
+      // getHealth() is error-safe — wraps all errors (ECONNREFUSED, 502, etc.)
+      // and returns { asr: false, tts: false }. It never throws, so the loop
+      // is resilient to transient network failures during the full boot window.
       const health = await registrationService.client.getHealth();
       if (health.tts) {
         return;

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts
@@ -21,14 +21,15 @@ import { redisService } from '../../../../redis.js';
 const logger = createLogger('TTSStep');
 
 /** TTS timeout — includes voice-engine cold start time on Railway Serverless.
- * Budget: health retries (12s) + voice registration (15s) + synthesis (~63s).
- * 90s accommodates multi-chunk TTS on first cold-start without unnecessary wait on true failures. */
-const TTS_TIMEOUT_MS = 90_000;
+ * Budget: health wait (75s) + voice registration (15s) + synthesis (~45s) + margin (15s).
+ * 150s accommodates the full ~56s cold start plus multi-chunk TTS. */
+const TTS_TIMEOUT_MS = 150_000;
 
-/** Delay between health check retries when waiting for voice engine cold start */
-const HEALTH_RETRY_DELAY_MS = 3_000;
-/** Max health check attempts before proceeding anyway */
-const HEALTH_RETRY_MAX_ATTEMPTS = 5;
+/** Total time budget for health polling during voice engine cold start (ms).
+ * Railway Serverless cold boot measured at ~56s — 75s gives comfortable margin. */
+const HEALTH_WAIT_BUDGET_MS = 75_000;
+/** Interval between health check polls (ms) */
+const HEALTH_POLL_INTERVAL_MS = 3_000;
 
 /**
  * Lazy singleton for voice registration (shares VoiceEngineClient lifecycle).
@@ -146,7 +147,8 @@ export class TTSStep implements IPipelineStep {
       return false;
     }
 
-    // Check config cascade for voice response mode
+    // Check config cascade for voice response mode.
+    // Defaults to 'never' when configOverrides is absent (e.g., guest mode, missing cascade).
     const voiceResponseMode = context.configOverrides?.voiceResponseMode ?? 'never';
 
     if (voiceResponseMode === 'never') {
@@ -173,9 +175,9 @@ export class TTSStep implements IPipelineStep {
     context: GenerationContext
   ): Promise<{ key: string; audioSize: number } | null> {
     // Pre-warm: ping /health to wake voice engine from Railway Serverless sleep.
-    // Voice engine cold boot takes ~7s (models cached on disk), so retry a few
-    // times with short delays. The first ping's TCP connection triggers Railway
-    // to start the container.
+    // Voice engine cold boot takes ~56s (model loading from disk). The first ping's
+    // TCP connection triggers Railway to start the container; subsequent polls wait
+    // for model readiness.
     await this.waitForVoiceEngine(registrationService, slug);
 
     // Ensure voice is registered
@@ -196,28 +198,38 @@ export class TTSStep implements IPipelineStep {
   }
 
   /**
-   * Wait for the voice engine to become ready, retrying health checks with delays.
-   * The first ping wakes Railway Serverless; subsequent pings wait for model loading (~7s).
-   * Proceeds after max attempts regardless — registration/synthesis will fail with a
-   * clear error if the engine truly isn't available.
+   * Wait for the voice engine to become ready, polling health checks on a time budget.
+   * The first ping wakes Railway Serverless; subsequent polls wait for model loading (~56s).
+   * Proceeds after budget exhausted — registration/synthesis will fail with a clear error
+   * if the engine truly isn't available.
    */
   private async waitForVoiceEngine(
     registrationService: VoiceRegistrationService,
     slug: string
   ): Promise<void> {
-    for (let attempt = 1; attempt <= HEALTH_RETRY_MAX_ATTEMPTS; attempt++) {
+    const deadline = Date.now() + HEALTH_WAIT_BUDGET_MS;
+    let attempt = 0;
+
+    while (Date.now() < deadline) {
+      attempt++;
       const health = await registrationService.client.getHealth();
       if (health.tts) {
         return;
       }
-      if (attempt < HEALTH_RETRY_MAX_ATTEMPTS) {
+      // Don't sleep if we've already exhausted the budget
+      if (Date.now() + HEALTH_POLL_INTERVAL_MS < deadline) {
         logger.info(
-          { slug, attempt, maxAttempts: HEALTH_RETRY_MAX_ATTEMPTS },
+          { slug, attempt, remainingMs: deadline - Date.now() },
           'Voice engine TTS not ready — waiting for cold start'
         );
-        await new Promise(resolve => setTimeout(resolve, HEALTH_RETRY_DELAY_MS));
+        await new Promise(resolve => setTimeout(resolve, HEALTH_POLL_INTERVAL_MS));
+      } else {
+        break;
       }
     }
-    logger.warn({ slug }, 'Voice engine TTS still not ready after retries — proceeding anyway');
+    logger.warn(
+      { slug, attempts: attempt },
+      'Voice engine TTS still not ready after health budget — proceeding anyway'
+    );
   }
 }

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts
@@ -216,16 +216,17 @@ export class TTSStep implements IPipelineStep {
       if (health.tts) {
         return;
       }
-      // Don't sleep if we've already exhausted the budget
-      if (Date.now() + HEALTH_POLL_INTERVAL_MS < deadline) {
-        logger.info(
-          { slug, attempt, remainingMs: deadline - Date.now() },
-          'Voice engine TTS not ready — waiting for cold start'
-        );
-        await new Promise(resolve => setTimeout(resolve, HEALTH_POLL_INTERVAL_MS));
-      } else {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
         break;
       }
+      logger.info(
+        { slug, attempt, remainingMs: remaining },
+        'Voice engine TTS not ready — waiting for cold start'
+      );
+      await new Promise(resolve =>
+        setTimeout(resolve, Math.min(HEALTH_POLL_INTERVAL_MS, remaining))
+      );
     }
     logger.warn(
       { slug, attempts: attempt },

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts
@@ -26,7 +26,9 @@ const logger = createLogger('TTSStep');
 const TTS_TIMEOUT_MS = 150_000;
 
 /** Total time budget for health polling during voice engine cold start (ms).
- * Railway Serverless cold boot measured at ~56s — 75s gives comfortable margin. */
+ * Railway Serverless cold boot measured at ~56s — 75s gives comfortable margin.
+ * Note: effective poll count varies — ECONNREFUSED resolves instantly (~25 polls),
+ * but once Railway's LB is up the 5s health timeout may reduce it to ~10 polls. */
 const HEALTH_WAIT_BUDGET_MS = 75_000;
 /** Interval between health check polls (ms) */
 const HEALTH_POLL_INTERVAL_MS = 3_000;

--- a/services/ai-worker/src/services/voice/VoiceRegistrationService.test.ts
+++ b/services/ai-worker/src/services/voice/VoiceRegistrationService.test.ts
@@ -285,86 +285,40 @@ describe('VoiceRegistrationService', () => {
     expect(mockVoiceEngineClient.listVoices).toHaveBeenCalledTimes(2);
   });
 
-  it('should NOT negatively cache 503 VoiceEngineError (partial cold start)', async () => {
-    // Realistic path: listVoices returns empty, gateway fetch succeeds,
-    // but registerVoice throws 503 (voice-engine models still loading)
-    mockVoiceEngineClient.listVoices.mockResolvedValue([]);
-    mockFetch.mockResolvedValue({
-      ok: true,
-      arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(100)),
-      headers: { get: vi.fn().mockReturnValue('audio/wav') },
-    });
-    mockVoiceEngineClient.registerVoice.mockRejectedValue(
-      new VoiceEngineError(503, 'TTS model not loaded')
-    );
+  it.each([
+    [502, 'Bad Gateway', 'Railway LB up, app not yet ready'],
+    [503, 'TTS model not loaded', 'voice-engine models still loading'],
+    [504, 'Gateway Timeout', 'Railway LB timeout during boot'],
+  ] as const)(
+    'should NOT negatively cache %i VoiceEngineError (%s)',
+    async (status, detail, _scenario) => {
+      // Realistic path: listVoices returns empty, gateway fetch succeeds,
+      // but registerVoice throws transient HTTP error during cold start
+      mockVoiceEngineClient.listVoices.mockResolvedValue([]);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(100)),
+        headers: { get: vi.fn().mockReturnValue('audio/wav') },
+      });
+      mockVoiceEngineClient.registerVoice.mockRejectedValue(new VoiceEngineError(status, detail));
 
-    await expect(service.ensureVoiceRegistered('cold-voice')).rejects.toThrow(
-      'Voice engine request failed (503)'
-    );
+      const slug = `transient-${status}`;
+      await expect(service.ensureVoiceRegistered(slug)).rejects.toThrow(
+        `Voice engine request failed (${status})`
+      );
 
-    // Second call: should retry (NOT hit negative cache)
-    mockVoiceEngineClient.listVoices.mockClear();
-    mockVoiceEngineClient.registerVoice.mockClear();
+      // Second call: should retry (NOT hit negative cache)
+      mockVoiceEngineClient.listVoices.mockClear();
+      mockVoiceEngineClient.registerVoice.mockClear();
 
-    // Second attempt: engine is now ready and voice was registered between calls
-    mockVoiceEngineClient.listVoices.mockResolvedValue(['cold-voice']);
+      // Engine is now ready and voice was registered between calls
+      mockVoiceEngineClient.listVoices.mockResolvedValue([slug]);
 
-    await service.ensureVoiceRegistered('cold-voice');
+      await service.ensureVoiceRegistered(slug);
 
-    // Should have called listVoices again (not blocked by negative cache)
-    expect(mockVoiceEngineClient.listVoices).toHaveBeenCalledOnce();
-  });
-
-  it('should NOT negatively cache 502 VoiceEngineError (Railway load balancer during boot)', async () => {
-    // Realistic path: listVoices returns empty, gateway fetch succeeds,
-    // but registerVoice throws 502 (Railway LB up, app not yet ready)
-    mockVoiceEngineClient.listVoices.mockResolvedValue([]);
-    mockFetch.mockResolvedValue({
-      ok: true,
-      arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(100)),
-      headers: { get: vi.fn().mockReturnValue('audio/wav') },
-    });
-    mockVoiceEngineClient.registerVoice.mockRejectedValue(new VoiceEngineError(502, 'Bad Gateway'));
-
-    await expect(service.ensureVoiceRegistered('boot-voice')).rejects.toThrow(
-      'Voice engine request failed (502)'
-    );
-
-    // Second call: should retry (NOT hit negative cache)
-    mockVoiceEngineClient.listVoices.mockClear();
-    mockVoiceEngineClient.registerVoice.mockClear();
-
-    mockVoiceEngineClient.listVoices.mockResolvedValue(['boot-voice']);
-
-    await service.ensureVoiceRegistered('boot-voice');
-
-    expect(mockVoiceEngineClient.listVoices).toHaveBeenCalledOnce();
-  });
-
-  it('should NOT negatively cache 504 VoiceEngineError (Railway LB timeout during boot)', async () => {
-    mockVoiceEngineClient.listVoices.mockResolvedValue([]);
-    mockFetch.mockResolvedValue({
-      ok: true,
-      arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(100)),
-      headers: { get: vi.fn().mockReturnValue('audio/wav') },
-    });
-    mockVoiceEngineClient.registerVoice.mockRejectedValue(
-      new VoiceEngineError(504, 'Gateway Timeout')
-    );
-
-    await expect(service.ensureVoiceRegistered('timeout-voice')).rejects.toThrow(
-      'Voice engine request failed (504)'
-    );
-
-    mockVoiceEngineClient.listVoices.mockClear();
-    mockVoiceEngineClient.registerVoice.mockClear();
-
-    mockVoiceEngineClient.listVoices.mockResolvedValue(['timeout-voice']);
-
-    await service.ensureVoiceRegistered('timeout-voice');
-
-    expect(mockVoiceEngineClient.listVoices).toHaveBeenCalledOnce();
-  });
+      expect(mockVoiceEngineClient.listVoices).toHaveBeenCalledOnce();
+    }
+  );
 
   it('should negatively cache non-transient VoiceEngineError (e.g., 400)', async () => {
     // Realistic path: listVoices returns empty, gateway fetch succeeds,

--- a/services/ai-worker/src/services/voice/VoiceRegistrationService.test.ts
+++ b/services/ai-worker/src/services/voice/VoiceRegistrationService.test.ts
@@ -290,7 +290,7 @@ describe('VoiceRegistrationService', () => {
     [503, 'TTS model not loaded', 'voice-engine models still loading'],
     [504, 'Gateway Timeout', 'Railway LB timeout during boot'],
   ] as const)(
-    'should NOT negatively cache %i VoiceEngineError (%s)',
+    'should NOT negatively cache %i VoiceEngineError (%s — %s)',
     async (status, detail, _scenario) => {
       // Realistic path: listVoices returns empty, gateway fetch succeeds,
       // but registerVoice throws transient HTTP error during cold start

--- a/services/ai-worker/src/services/voice/VoiceRegistrationService.test.ts
+++ b/services/ai-worker/src/services/voice/VoiceRegistrationService.test.ts
@@ -308,6 +308,27 @@ describe('VoiceRegistrationService', () => {
     expect(mockVoiceEngineClient.listVoices).toHaveBeenCalledOnce();
   });
 
+  it('should NOT negatively cache 502 VoiceEngineError (Railway load balancer during boot)', async () => {
+    mockVoiceEngineClient.listVoices.mockResolvedValue([]);
+
+    // Railway LB returns 502 when app hasn't bound its port yet
+    mockFetch.mockRejectedValue(new VoiceEngineError(502, 'Bad Gateway'));
+
+    await expect(service.ensureVoiceRegistered('boot-voice')).rejects.toThrow(
+      'Voice engine request failed (502)'
+    );
+
+    // Second call: should retry (NOT hit negative cache)
+    mockFetch.mockClear();
+    mockVoiceEngineClient.listVoices.mockClear();
+
+    mockVoiceEngineClient.listVoices.mockResolvedValue(['boot-voice']);
+
+    await service.ensureVoiceRegistered('boot-voice');
+
+    expect(mockVoiceEngineClient.listVoices).toHaveBeenCalledOnce();
+  });
+
   it('should negatively cache non-503 VoiceEngineError (e.g., 400)', async () => {
     mockVoiceEngineClient.listVoices.mockResolvedValue([]);
 

--- a/services/ai-worker/src/services/voice/VoiceRegistrationService.test.ts
+++ b/services/ai-worker/src/services/voice/VoiceRegistrationService.test.ts
@@ -286,20 +286,27 @@ describe('VoiceRegistrationService', () => {
   });
 
   it('should NOT negatively cache 503 VoiceEngineError (partial cold start)', async () => {
+    // Realistic path: listVoices returns empty, gateway fetch succeeds,
+    // but registerVoice throws 503 (voice-engine models still loading)
     mockVoiceEngineClient.listVoices.mockResolvedValue([]);
-
-    // Voice engine HTTP server is up but models still loading → 503
-    mockFetch.mockRejectedValue(new VoiceEngineError(503, 'TTS model not loaded'));
+    mockFetch.mockResolvedValue({
+      ok: true,
+      arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(100)),
+      headers: { get: vi.fn().mockReturnValue('audio/wav') },
+    });
+    mockVoiceEngineClient.registerVoice.mockRejectedValue(
+      new VoiceEngineError(503, 'TTS model not loaded')
+    );
 
     await expect(service.ensureVoiceRegistered('cold-voice')).rejects.toThrow(
       'Voice engine request failed (503)'
     );
 
     // Second call: should retry (NOT hit negative cache)
-    mockFetch.mockClear();
     mockVoiceEngineClient.listVoices.mockClear();
+    mockVoiceEngineClient.registerVoice.mockClear();
 
-    // Voice engine is now fully ready
+    // Voice engine is now fully ready — voice already registered from first attempt
     mockVoiceEngineClient.listVoices.mockResolvedValue(['cold-voice']);
 
     await service.ensureVoiceRegistered('cold-voice');
@@ -309,18 +316,23 @@ describe('VoiceRegistrationService', () => {
   });
 
   it('should NOT negatively cache 502 VoiceEngineError (Railway load balancer during boot)', async () => {
+    // Realistic path: listVoices returns empty, gateway fetch succeeds,
+    // but registerVoice throws 502 (Railway LB up, app not yet ready)
     mockVoiceEngineClient.listVoices.mockResolvedValue([]);
-
-    // Railway LB returns 502 when app hasn't bound its port yet
-    mockFetch.mockRejectedValue(new VoiceEngineError(502, 'Bad Gateway'));
+    mockFetch.mockResolvedValue({
+      ok: true,
+      arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(100)),
+      headers: { get: vi.fn().mockReturnValue('audio/wav') },
+    });
+    mockVoiceEngineClient.registerVoice.mockRejectedValue(new VoiceEngineError(502, 'Bad Gateway'));
 
     await expect(service.ensureVoiceRegistered('boot-voice')).rejects.toThrow(
       'Voice engine request failed (502)'
     );
 
     // Second call: should retry (NOT hit negative cache)
-    mockFetch.mockClear();
     mockVoiceEngineClient.listVoices.mockClear();
+    mockVoiceEngineClient.registerVoice.mockClear();
 
     mockVoiceEngineClient.listVoices.mockResolvedValue(['boot-voice']);
 
@@ -329,19 +341,26 @@ describe('VoiceRegistrationService', () => {
     expect(mockVoiceEngineClient.listVoices).toHaveBeenCalledOnce();
   });
 
-  it('should negatively cache non-503 VoiceEngineError (e.g., 400)', async () => {
+  it('should negatively cache non-transient VoiceEngineError (e.g., 400)', async () => {
+    // Realistic path: listVoices returns empty, gateway fetch succeeds,
+    // but registerVoice throws 400 (bad audio format — permanent error)
     mockVoiceEngineClient.listVoices.mockResolvedValue([]);
-
-    // Voice engine returns 400 (bad request) — this IS a permanent error
-    mockFetch.mockRejectedValue(new VoiceEngineError(400, 'Invalid audio format'));
+    mockFetch.mockResolvedValue({
+      ok: true,
+      arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(100)),
+      headers: { get: vi.fn().mockReturnValue('audio/wav') },
+    });
+    mockVoiceEngineClient.registerVoice.mockRejectedValue(
+      new VoiceEngineError(400, 'Invalid audio format')
+    );
 
     await expect(service.ensureVoiceRegistered('bad-audio')).rejects.toThrow(
       'Voice engine request failed (400)'
     );
 
     // Second call: should be negatively cached
-    mockFetch.mockClear();
     mockVoiceEngineClient.listVoices.mockClear();
+    mockVoiceEngineClient.registerVoice.mockClear();
 
     await expect(service.ensureVoiceRegistered('bad-audio')).rejects.toThrow(
       'Voice registration for "bad-audio" recently failed'

--- a/services/ai-worker/src/services/voice/VoiceRegistrationService.test.ts
+++ b/services/ai-worker/src/services/voice/VoiceRegistrationService.test.ts
@@ -341,6 +341,31 @@ describe('VoiceRegistrationService', () => {
     expect(mockVoiceEngineClient.listVoices).toHaveBeenCalledOnce();
   });
 
+  it('should NOT negatively cache 504 VoiceEngineError (Railway LB timeout during boot)', async () => {
+    mockVoiceEngineClient.listVoices.mockResolvedValue([]);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(100)),
+      headers: { get: vi.fn().mockReturnValue('audio/wav') },
+    });
+    mockVoiceEngineClient.registerVoice.mockRejectedValue(
+      new VoiceEngineError(504, 'Gateway Timeout')
+    );
+
+    await expect(service.ensureVoiceRegistered('timeout-voice')).rejects.toThrow(
+      'Voice engine request failed (504)'
+    );
+
+    mockVoiceEngineClient.listVoices.mockClear();
+    mockVoiceEngineClient.registerVoice.mockClear();
+
+    mockVoiceEngineClient.listVoices.mockResolvedValue(['timeout-voice']);
+
+    await service.ensureVoiceRegistered('timeout-voice');
+
+    expect(mockVoiceEngineClient.listVoices).toHaveBeenCalledOnce();
+  });
+
   it('should negatively cache non-transient VoiceEngineError (e.g., 400)', async () => {
     // Realistic path: listVoices returns empty, gateway fetch succeeds,
     // but registerVoice throws 400 (bad audio format — permanent error)

--- a/services/ai-worker/src/services/voice/VoiceRegistrationService.test.ts
+++ b/services/ai-worker/src/services/voice/VoiceRegistrationService.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { VoiceRegistrationService } from './VoiceRegistrationService.js';
+import { VoiceEngineError } from './VoiceEngineClient.js';
 import type { VoiceEngineClient } from './VoiceEngineClient.js';
 import type { EnvConfig } from '@tzurot/common-types';
 import * as commonTypes from '@tzurot/common-types';
@@ -282,6 +283,49 @@ describe('VoiceRegistrationService', () => {
     mockVoiceEngineClient.listVoices.mockResolvedValue(['undici-voice']);
     await service.ensureVoiceRegistered('undici-voice');
     expect(mockVoiceEngineClient.listVoices).toHaveBeenCalledTimes(2);
+  });
+
+  it('should NOT negatively cache 503 VoiceEngineError (partial cold start)', async () => {
+    mockVoiceEngineClient.listVoices.mockResolvedValue([]);
+
+    // Voice engine HTTP server is up but models still loading → 503
+    mockFetch.mockRejectedValue(new VoiceEngineError(503, 'TTS model not loaded'));
+
+    await expect(service.ensureVoiceRegistered('cold-voice')).rejects.toThrow(
+      'Voice engine request failed (503)'
+    );
+
+    // Second call: should retry (NOT hit negative cache)
+    mockFetch.mockClear();
+    mockVoiceEngineClient.listVoices.mockClear();
+
+    // Voice engine is now fully ready
+    mockVoiceEngineClient.listVoices.mockResolvedValue(['cold-voice']);
+
+    await service.ensureVoiceRegistered('cold-voice');
+
+    // Should have called listVoices again (not blocked by negative cache)
+    expect(mockVoiceEngineClient.listVoices).toHaveBeenCalledOnce();
+  });
+
+  it('should negatively cache non-503 VoiceEngineError (e.g., 400)', async () => {
+    mockVoiceEngineClient.listVoices.mockResolvedValue([]);
+
+    // Voice engine returns 400 (bad request) — this IS a permanent error
+    mockFetch.mockRejectedValue(new VoiceEngineError(400, 'Invalid audio format'));
+
+    await expect(service.ensureVoiceRegistered('bad-audio')).rejects.toThrow(
+      'Voice engine request failed (400)'
+    );
+
+    // Second call: should be negatively cached
+    mockFetch.mockClear();
+    mockVoiceEngineClient.listVoices.mockClear();
+
+    await expect(service.ensureVoiceRegistered('bad-audio')).rejects.toThrow(
+      'Voice registration for "bad-audio" recently failed'
+    );
+    expect(mockVoiceEngineClient.listVoices).not.toHaveBeenCalled();
   });
 
   it('should negatively cache errors with "fetch failed" substring in longer message', async () => {

--- a/services/ai-worker/src/services/voice/VoiceRegistrationService.test.ts
+++ b/services/ai-worker/src/services/voice/VoiceRegistrationService.test.ts
@@ -306,7 +306,7 @@ describe('VoiceRegistrationService', () => {
     mockVoiceEngineClient.listVoices.mockClear();
     mockVoiceEngineClient.registerVoice.mockClear();
 
-    // Voice engine is now fully ready — voice already registered from first attempt
+    // Second attempt: engine is now ready and voice was registered between calls
     mockVoiceEngineClient.listVoices.mockResolvedValue(['cold-voice']);
 
     await service.ensureVoiceRegistered('cold-voice');

--- a/services/ai-worker/src/services/voice/VoiceRegistrationService.ts
+++ b/services/ai-worker/src/services/voice/VoiceRegistrationService.ts
@@ -8,6 +8,7 @@
  */
 
 import { createLogger, TTLCache, getConfig } from '@tzurot/common-types';
+import { VoiceEngineError } from './VoiceEngineClient.js';
 import type { VoiceEngineClient } from './VoiceEngineClient.js';
 
 const logger = createLogger('VoiceRegistrationService');
@@ -85,7 +86,7 @@ export class VoiceRegistrationService {
 
         // Connection errors are transient (cold start, sleeping service) — don't
         // negatively cache them so the next request retries immediately.
-        if (isConnectionError(error)) {
+        if (isConnectionError(error) || isTransientServiceError(error)) {
           logger.warn(
             { slug, reason },
             'Voice registration failed (connection error — not cached)'
@@ -127,8 +128,8 @@ export class VoiceRegistrationService {
     const voiceUrl = `${gatewayUrl}/voice-references/${encodeURIComponent(slug)}`;
     logger.info({ slug }, 'Fetching voice reference from gateway');
 
-    // 15s timeout — tighter than TTSStep's 60s outer timeout so the failure
-    // surfaces as a gateway fetch error rather than a generic TTS timeout.
+    // 15s timeout — tighter than TTSStep's TTS_TIMEOUT_MS outer timeout so the
+    // failure surfaces as a gateway fetch error rather than a generic TTS timeout.
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), 15_000);
     let response: globalThis.Response;
@@ -165,6 +166,15 @@ export class VoiceRegistrationService {
     this.registrationCache.clear();
     this.negativeCache.clear();
   }
+}
+
+/**
+ * Check if an error is a transient HTTP service error (e.g., 503 Service Unavailable).
+ * Voice engine returns 503 during cold start when the HTTP server is up but models
+ * haven't finished loading — this should NOT be negatively cached.
+ */
+function isTransientServiceError(error: unknown): boolean {
+  return error instanceof VoiceEngineError && error.status === 503;
 }
 
 /**

--- a/services/ai-worker/src/services/voice/VoiceRegistrationService.ts
+++ b/services/ai-worker/src/services/voice/VoiceRegistrationService.ts
@@ -166,13 +166,17 @@ export class VoiceRegistrationService {
 }
 
 /**
- * Check if an error is a transient HTTP service error (502/503).
- * - 503: Voice engine HTTP server is up but models haven't finished loading
+ * Check if an error is a transient HTTP service error (502/503/504).
  * - 502: Railway load balancer is up but the app hasn't bound its port yet
- * Neither should be negatively cached — the next request should retry immediately.
+ * - 503: Voice engine HTTP server is up but models haven't finished loading
+ * - 504: Railway load balancer timeout during slow boot
+ * None should be negatively cached — the next request should retry immediately.
  */
 function isTransientServiceError(error: unknown): boolean {
-  return error instanceof VoiceEngineError && (error.status === 502 || error.status === 503);
+  if (!(error instanceof VoiceEngineError)) {
+    return false;
+  }
+  return error.status === 502 || error.status === 503 || error.status === 504;
 }
 
 /**

--- a/services/ai-worker/src/services/voice/VoiceRegistrationService.ts
+++ b/services/ai-worker/src/services/voice/VoiceRegistrationService.ts
@@ -84,13 +84,10 @@ export class VoiceRegistrationService {
       .catch(error => {
         const reason = error instanceof Error ? error.message : String(error);
 
-        // Connection errors are transient (cold start, sleeping service) — don't
-        // negatively cache them so the next request retries immediately.
+        // Transient errors (connection failures, 502/503) indicate cold start or
+        // sleeping service — don't negatively cache so the next request retries immediately.
         if (isConnectionError(error) || isTransientServiceError(error)) {
-          logger.warn(
-            { slug, reason },
-            'Voice registration failed (connection error — not cached)'
-          );
+          logger.warn({ slug, reason }, 'Voice registration failed (transient error — not cached)');
         } else {
           this.negativeCache.set(slug, reason);
           logger.warn({ slug, reason }, 'Voice registration failed — cached for 5 min');
@@ -169,12 +166,13 @@ export class VoiceRegistrationService {
 }
 
 /**
- * Check if an error is a transient HTTP service error (e.g., 503 Service Unavailable).
- * Voice engine returns 503 during cold start when the HTTP server is up but models
- * haven't finished loading — this should NOT be negatively cached.
+ * Check if an error is a transient HTTP service error (502/503).
+ * - 503: Voice engine HTTP server is up but models haven't finished loading
+ * - 502: Railway load balancer is up but the app hasn't bound its port yet
+ * Neither should be negatively cached — the next request should retry immediately.
  */
 function isTransientServiceError(error: unknown): boolean {
-  return error instanceof VoiceEngineError && error.status === 503;
+  return error instanceof VoiceEngineError && (error.status === 502 || error.status === 503);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Switch TTSStep health polling from fixed 5-attempt count (15s max) to time-based budget (75s), covering the measured ~56s Railway Serverless cold boot
- Increase TTS_TIMEOUT_MS from 90s to 150s to accommodate health wait + registration + synthesis
- Treat HTTP 502/503/504 from voice-engine as transient in VoiceRegistrationService (not negatively cached for 5 min)
- Fix stale comments referencing old timing values

## Test plan

- [x] TTSStep unit tests updated for time-based health budget and new timeout value
- [x] VoiceRegistrationService tests: parameterized 502/503/504 transient handling (not cached) and 400 permanent errors (cached)
- [x] pnpm test — all 14 packages pass
- [x] pnpm quality — lint, typecheck, depcruise all green
- [ ] Deploy to dev, trigger TTS after voice-engine sleeps >5 min, verify first request succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)