### PR TITLE
feat: voice engine phase 4.5 — BYOK hardening, Whisper removal, voice management UX

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,13 +56,9 @@ AI_PROVIDER=openrouter
 OPENROUTER_API_KEY=your_openrouter_api_key
 OPENROUTER_APP_TITLE=Tzurot  # Shown in OpenRouter dashboard logs
 
-# OpenAI (for Whisper transcription only)
-OPENAI_API_KEY=your_openai_api_key
-
 # Model Configuration
 # Note: These defaults are also defined in packages/common-types/src/constants/ai.ts
 DEFAULT_AI_MODEL=anthropic/claude-haiku-4.5  # Main generation model
-WHISPER_MODEL=whisper-1  # For voice transcription
 VISION_FALLBACK_MODEL=qwen/qwen3.5-397b-a17b  # For image analysis fallback (paid, multimodal)
 # Note: Embeddings are local (Xenova/bge-small-en-v1.5) - no API key needed
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -25,7 +25,7 @@ _New items go here. Triage to appropriate section weekly._
 - 🐛 `[FIX]` **Log warning on `voiceReferenceType` WAV fallback** — `voiceReferences.ts` falls back to `audio/wav` if stored MIME type is missing/invalid. Add a log warning before the fallback to aid debugging if it ever fires.
 - 🧹 `[CHORE]` **Add comment on `shouldRunTTS` default** — `voiceResponseMode ?? 'never'` silently defaults to never when `configOverrides` is absent. One-line comment clarifying the safe default.
 - 🧹 `[CHORE]` **Expand `mypy --strict` to test files** — CI currently only checks `server.py`. Add `tests/` to catch type issues as the Python test suite grows.
-- 🧹 `[CHORE]` **Clean up completed voice-engine proposal** — `docs/proposals/active/voice-engine-implementation-guide.md` is fully implemented. Per lifecycle rules: verify reference docs exist, then delete.
+- 🧹 `[CHORE]` **Update voice-engine proposal** — `docs/proposals/active/voice-engine-implementation-guide.md` Phases 1-4.5 complete. Phase 5 (shapes.inc voice import) remains. Update status table.
 
 ## 🎯 Current Focus
 
@@ -437,8 +437,18 @@ BYOK ElevenLabs support for users who want premium voice quality.
 - [x] TTS routing: ElevenLabs BYOK → voice-engine → fallback chain
 - [x] STT routing: ElevenLabs → voice-engine → Whisper fallback chain
 - [x] Content type threading: MP3 (ElevenLabs) vs WAV (voice-engine) → correct Discord file extension
-- [ ] Thread ElevenLabs key through `AudioTranscriptionJob` + inline STT callers (`ConversationInputProcessor`, `ConversationalRAGService`)
-- [ ] Voice slot management UX — `/settings apikey voices` list/clear cloned voices
+- [x] Thread ElevenLabs key through `AudioTranscriptionJob` + inline STT callers — Phase 4.5
+- [x] Voice slot management UX — `/settings voices browse|delete|clear` — Phase 4.5
+
+#### Phase 4.5: BYOK Hardening + Whisper Removal
+
+Tighten ElevenLabs BYOK from PR #727 follow-ups and simplify the STT fallback chain by removing the OpenAI Whisper code path. Two-tier STT: ElevenLabs (BYOK) → voice-engine (free). No third fallback.
+
+- [x] Thread `elevenlabsApiKey` through `AudioTranscriptionJob` payload + handler
+- [x] Thread `elevenlabsApiKey` through inline STT callers (`ConversationInputProcessor`, `ConversationalRAGService`)
+- [x] Remove OpenAI Whisper STT fallback (simplify to: ElevenLabs BYOK → voice-engine, no third tier)
+- [x] Clean up Whisper-related code, config, and `OPENAI_API_KEY` env var
+- [x] Voice slot management UX — `/settings voices browse|delete|clear` commands
 
 #### Phase 5: Shapes.inc Voice Field Import
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -450,6 +450,16 @@ Tighten ElevenLabs BYOK from PR #727 follow-ups and simplify the STT fallback ch
 - [x] Clean up Whisper-related code, config, and `OPENAI_API_KEY` env var
 - [x] Voice slot management UX — `/settings voices browse|delete|clear` commands
 
+#### Phase 4.6: Configurable ElevenLabs TTS Model
+
+Users should choose their preferred ElevenLabs TTS model — shapes.inc had a dropdown for this. Currently hardcoded to `eleven_multilingual_v2` in `ElevenLabsClient.ts:141`. The `ElevenLabsTTSOptions` interface already accepts an optional `modelId` but no caller passes it.
+
+- [ ] Call `GET /v1/models` on ElevenLabs API to discover available TTS models
+- [ ] Add `/settings voices model` subcommand with autocomplete dropdown of available models
+- [ ] Store user's preferred model in DB (per-user setting, not per-character)
+- [ ] Thread selected `modelId` through `TTSStep` → `ElevenLabsClient.textToSpeech()`
+- [ ] STT model (`scribe_v1`) stays pinned — fewer options, less user value
+
 #### Phase 5: Shapes.inc Voice Field Import
 
 Import voice configuration from shapes.inc character data.

--- a/docs/proposals/active/voice-engine-implementation-guide.md
+++ b/docs/proposals/active/voice-engine-implementation-guide.md
@@ -2,14 +2,15 @@
 
 ## Status
 
-| Phase    | Scope                                         | Status          |
-| -------- | --------------------------------------------- | --------------- |
-| Phase 1  | Python service + voice reference blob storage | COMPLETE        |
-| Phase 2  | Python hardening + ai-worker STT integration  | COMPLETE        |
-| Phase 3a | TTS pipeline + config cascade (ai-worker)     | COMPLETE (#710) |
-| Phase 3b | Voice commands + cascade wiring (bot-client)  | COMPLETE        |
-| Phase 4  | ElevenLabs Premium Tier                       | Not started     |
-| Phase 5  | Shapes.inc Voice Field Import                 | Not started     |
+| Phase     | Scope                                         | Status          |
+| --------- | --------------------------------------------- | --------------- |
+| Phase 1   | Python service + voice reference blob storage | COMPLETE        |
+| Phase 2   | Python hardening + ai-worker STT integration  | COMPLETE        |
+| Phase 3a  | TTS pipeline + config cascade (ai-worker)     | COMPLETE (#710) |
+| Phase 3b  | Voice commands + cascade wiring (bot-client)  | COMPLETE        |
+| Phase 4   | ElevenLabs Premium Tier                       | COMPLETE (#727) |
+| Phase 4.5 | BYOK Hardening + Whisper Removal + Voice UX   | COMPLETE        |
+| Phase 5   | Shapes.inc Voice Field Import                 | Not started     |
 
 ### Phase 1 Checklist
 
@@ -123,14 +124,14 @@ See Part 6 for full details. Quick checklist:
 
 ### Deployment Gotchas (Lessons Learned)
 
-| Issue                              | Symptom                                          | Fix                                                                         |
-| ---------------------------------- | ------------------------------------------------ | --------------------------------------------------------------------------- |
-| Missing `GATEWAY_URL` on ai-worker | `ECONNREFUSED` in VoiceRegistrationService       | Set `GATEWAY_URL` to api-gateway private domain                             |
-| Missing `HF_TOKEN` on voice-engine | `VOICE_CLONING_UNSUPPORTED` error                | Set `HF_TOKEN` with gated repo access                                       |
-| Volume permissions                 | `PermissionError` writing to `/app/voices`       | Dockerfile runs as root (no `USER` directive) — matches api-gateway pattern |
-| First TTS timeout                  | `TTS completed after timeout (result discarded)` | One-time model download; retry and it works                                 |
-| Negative cache after failure       | Voice registration skipped for 5 min after error | Wait for `VoiceRegistrationService` negative cache (5 min TTL) to expire    |
-| First cold-start TTS timeout       | Long responses may timeout on first request       | 90s budget: health retries (12s) + voice registration (15s) + synthesis (~63s). Multi-chunk TTS on first cold-start may still exceed budget. Falls back to text-only gracefully. |
+| Issue                              | Symptom                                          | Fix                                                                                                                                                                              |
+| ---------------------------------- | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Missing `GATEWAY_URL` on ai-worker | `ECONNREFUSED` in VoiceRegistrationService       | Set `GATEWAY_URL` to api-gateway private domain                                                                                                                                  |
+| Missing `HF_TOKEN` on voice-engine | `VOICE_CLONING_UNSUPPORTED` error                | Set `HF_TOKEN` with gated repo access                                                                                                                                            |
+| Volume permissions                 | `PermissionError` writing to `/app/voices`       | Dockerfile runs as root (no `USER` directive) — matches api-gateway pattern                                                                                                      |
+| First TTS timeout                  | `TTS completed after timeout (result discarded)` | One-time model download; retry and it works                                                                                                                                      |
+| Negative cache after failure       | Voice registration skipped for 5 min after error | Wait for `VoiceRegistrationService` negative cache (5 min TTL) to expire                                                                                                         |
+| First cold-start TTS timeout       | Long responses may timeout on first request      | 90s budget: health retries (12s) + voice registration (15s) + synthesis (~63s). Multi-chunk TTS on first cold-start may still exceed budget. Falls back to text-only gracefully. |
 
 ### Phase 2 Implementation Notes
 

--- a/docs/reference/deployment/RAILWAY_OPERATIONS.md
+++ b/docs/reference/deployment/RAILWAY_OPERATIONS.md
@@ -120,9 +120,7 @@ The script reads from your `.env` file and sets variables in Railway.
 | `REDIS_URL`             | Redis connection                          |
 | `AI_PROVIDER`           | AI provider (e.g., `openrouter`)          |
 | `OPENROUTER_API_KEY`    | OpenRouter API key                        |
-| `OPENAI_API_KEY`        | OpenAI key (for Whisper transcription)    |
 | `DEFAULT_AI_MODEL`      | Default model                             |
-| `WHISPER_MODEL`         | Audio transcription (`whisper-1`)         |
 | `VISION_FALLBACK_MODEL` | Image analysis model                      |
 | `NODE_ENV`              | Environment (`production`/`development`)  |
 | `LOG_LEVEL`             | Logging verbosity                         |

--- a/docs/reference/guides/DEVELOPMENT.md
+++ b/docs/reference/guides/DEVELOPMENT.md
@@ -239,7 +239,6 @@ See `.env.example` for all available environment variables.
 
 - `DISCORD_TOKEN` - Your Discord bot token
 - `OPENROUTER_API_KEY` - For LLM completions
-- `OPENAI_API_KEY` - For embeddings
 - `REDIS_URL` / `REDIS_HOST` - Redis connection
 
 # No QDRANT_URL needed - pgvector uses DATABASE_URL
@@ -298,7 +297,7 @@ pnpm --filter @tzurot/ai-worker dev  # Logs to stdout
 
 **"No API key available"**
 
-- Set OPENROUTER_API_KEY or OPENAI_API_KEY in .env
+- Set OPENROUTER_API_KEY in .env
 - For BYOK, user must provide their own key
 
 **"Worker not processing jobs"**

--- a/packages/common-types/src/config/config.ts
+++ b/packages/common-types/src/config/config.ts
@@ -67,11 +67,9 @@ export const envSchema = z.object({
   OPENROUTER_API_KEY: optionalNonEmptyString(),
   OPENROUTER_APP_TITLE: optionalNonEmptyString(),
   OPENROUTER_APP_URL: optionalNonEmptyString(),
-  OPENAI_API_KEY: optionalNonEmptyString(),
   DEFAULT_AI_MODEL: optionalNonEmptyString().transform(val => val ?? MODEL_DEFAULTS.DEFAULT_MODEL),
 
   // AI Model Defaults
-  WHISPER_MODEL: z.string().default(MODEL_DEFAULTS.WHISPER),
   VISION_FALLBACK_MODEL: z.string().default(MODEL_DEFAULTS.VISION_FALLBACK),
   // Note: Embeddings are local (Xenova/bge-small-en-v1.5) - no env config needed
 
@@ -225,11 +223,9 @@ export function createTestConfig(overrides: Partial<EnvConfig> = {}): EnvConfig 
     OPENROUTER_API_KEY: undefined,
     OPENROUTER_APP_TITLE: undefined,
     OPENROUTER_APP_URL: undefined,
-    OPENAI_API_KEY: undefined,
     DEFAULT_AI_MODEL: MODEL_DEFAULTS.DEFAULT_MODEL,
 
     // AI Model Defaults
-    WHISPER_MODEL: MODEL_DEFAULTS.WHISPER,
     VISION_FALLBACK_MODEL: MODEL_DEFAULTS.VISION_FALLBACK,
 
     // Redis

--- a/packages/common-types/src/constants/ai.ts
+++ b/packages/common-types/src/constants/ai.ts
@@ -172,6 +172,15 @@ export const MODEL_DEFAULTS = {
 } as const;
 
 /**
+ * ElevenLabs voice cloning constants
+ *
+ * Cross-service contract: both ai-worker (clone creation) and api-gateway
+ * (voice management routes) must agree on the prefix used to identify
+ * Tzurot-cloned voices in a user's ElevenLabs account.
+ */
+export const ELEVENLABS_VOICE_NAME_PREFIX = 'tzurot-';
+
+/**
  * AI provider identifiers
  *
  * OpenRouter: LLM chat/generation (BYOK for model access)

--- a/packages/common-types/src/constants/ai.ts
+++ b/packages/common-types/src/constants/ai.ts
@@ -47,8 +47,6 @@ export const AI_DEFAULTS = {
   } as const,
   /** Temperature for vision models (lower = more deterministic) */
   VISION_TEMPERATURE: 0.3,
-  /** Default language for Whisper transcription */
-  WHISPER_LANGUAGE: 'en',
   /** Default memory score threshold for retrieval (0.0-1.0, higher = stricter matching) */
   MEMORY_SCORE_THRESHOLD: 0.5,
   /** Default number of memories to retrieve */
@@ -161,7 +159,6 @@ export const MODEL_DEFAULTS = {
   DEFAULT_MODEL: 'anthropic/claude-haiku-4.5',
 
   // Specialized models
-  WHISPER: 'whisper-1',
   /** Vision fallback for BYOK users (paid) — natively multimodal */
   VISION_FALLBACK: 'qwen/qwen3.5-397b-a17b',
   /** Vision fallback for free tier users (no BYOK) — 128k context, multimodal, less censored */
@@ -180,8 +177,8 @@ export const MODEL_DEFAULTS = {
  * OpenRouter: LLM chat/generation (BYOK for model access)
  * ElevenLabs: Voice synthesis and cloning (BYOK for premium TTS/STT)
  *
- * Note: The system still uses OPENAI_API_KEY internally for embeddings and
- * Whisper transcription, but users cannot select OpenAI as a provider.
+ * OpenRouter: LLM chat/generation (BYOK for model access)
+ * ElevenLabs: Voice synthesis, cloning, and STT (BYOK for premium features)
  */
 export enum AIProvider {
   OpenRouter = 'openrouter',

--- a/packages/common-types/src/constants/ai.ts
+++ b/packages/common-types/src/constants/ai.ts
@@ -175,9 +175,6 @@ export const MODEL_DEFAULTS = {
  * AI provider identifiers
  *
  * OpenRouter: LLM chat/generation (BYOK for model access)
- * ElevenLabs: Voice synthesis and cloning (BYOK for premium TTS/STT)
- *
- * OpenRouter: LLM chat/generation (BYOK for model access)
  * ElevenLabs: Voice synthesis, cloning, and STT (BYOK for premium features)
  */
 export enum AIProvider {

--- a/packages/common-types/src/constants/discord.ts
+++ b/packages/common-types/src/constants/discord.ts
@@ -88,6 +88,9 @@ export const GATEWAY_TIMEOUTS = {
    *  10s is generous for warmed DB connections — the api-gateway now calls
    *  prisma.$connect() at startup to eliminate cold-start latency. */
   DEFERRED: 10000,
+  /** Extended timeout for bulk operations (e.g., clearing all cloned voices).
+   *  These involve multiple sequential/batched external API calls. */
+  BULK_OPERATION: 30_000,
 } as const;
 
 /**

--- a/packages/common-types/src/constants/index.ts
+++ b/packages/common-types/src/constants/index.ts
@@ -9,6 +9,7 @@ export {
   AI_DEFAULTS,
   AI_ENDPOINTS,
   MODEL_DEFAULTS,
+  ELEVENLABS_VOICE_NAME_PREFIX,
   AIProvider,
   GUEST_MODE,
   isFreeModel,

--- a/packages/common-types/src/constants/timing.ts
+++ b/packages/common-types/src/constants/timing.ts
@@ -22,8 +22,8 @@ export const TIMEOUTS = {
   // Individual component timeouts (PER ATTEMPT - with 3 retries via job chain)
   /** Vision model invocation timeout per attempt (90 seconds - handles slow models and high-res images) */
   VISION_MODEL: 90000,
-  /** Whisper transcription timeout per attempt (180 seconds - handles long voice messages up to ~15 min) */
-  WHISPER_API: 180000,
+  /** Voice engine / STT transcription timeout per attempt (180 seconds - handles long voice messages up to ~15 min) */
+  VOICE_ENGINE_API: 180000,
   /** Audio file download timeout (30 seconds - Discord CDN is fast) */
   AUDIO_FETCH: 30000,
   /** LLM invocation timeout for all retry attempts combined (8 minutes) */

--- a/packages/common-types/src/constants/timing.ts
+++ b/packages/common-types/src/constants/timing.ts
@@ -190,11 +190,13 @@ export const SYNC_LIMITS = {
 } as const;
 
 /**
- * External API validation timeouts
+ * External API timeouts for ElevenLabs operations
  */
 export const VALIDATION_TIMEOUTS = {
   /** Timeout for API key validation requests (30 seconds - allows for slow networks and provider load) */
-  API_KEY_VALIDATION: 30000,
+  API_KEY_VALIDATION: 30_000,
+  /** Timeout for general ElevenLabs API calls: voice list, single-voice fetch, delete (30 seconds) */
+  ELEVENLABS_API_CALL: 30_000,
 } as const;
 
 /**

--- a/packages/common-types/src/utils/timeout.test.ts
+++ b/packages/common-types/src/utils/timeout.test.ts
@@ -3,7 +3,7 @@
  *
  * NEW ARCHITECTURE: Independent component budgets WITH RETRY SUPPORT
  * - Preprocessing jobs retry up to 3 times with exponential backoff
- * - Each component gets full timeout budget regardless of other components
+ * - Each component gets its full timeout budget regardless of other components
  */
 
 import { describe, it, expect } from 'vitest';
@@ -48,7 +48,7 @@ describe('calculateJobTimeout - Independent Component Budgets with Retries', () 
   describe('Audio attachments (with retries)', () => {
     it('should calculate timeout for 1 audio with retries + independent LLM budget', () => {
       // SYSTEM_OVERHEAD: 15s
-      // AUDIO_FETCH + WHISPER_API with retries: 210s × 3 attempts + 3s delays = 633s
+      // AUDIO_FETCH + VOICE_ENGINE_API with retries: 210s × 3 attempts + 3s delays = 633s
       // LLM_INVOCATION: 480s
       // Total: 15s + 633s + 480s = 1128s
       const timeout = calculateJobTimeout(0, 1);

--- a/packages/common-types/src/utils/timeout.ts
+++ b/packages/common-types/src/utils/timeout.ts
@@ -16,7 +16,7 @@ import { TIMEOUTS, RETRY_CONFIG } from '../constants/index.js';
  *
  * @example
  * // Audio: 210s per attempt × 3 attempts + delays (1s + 2s)
- * calculateTimeoutWithRetries(210000, 3) // 633000ms (633s)
+ * calculateTimeoutWithRetries(210_000, 3) // 633000ms (633s)
  *
  * @example
  * // Vision: 90s per attempt × 3 attempts + delays (1s + 2s)
@@ -52,7 +52,7 @@ function calculateTimeoutWithRetries(
  * preprocessing jobs retry up to 3 times with exponential backoff.
  *
  * Component breakdown (all independent, WITH RETRIES):
- * - Audio processing: (30s fetch + 180s whisper) × 3 attempts + delays = 633s
+ * - Audio processing: (30s fetch + 180s STT) × 3 attempts + delays = 633s
  * - Image processing: 90s × 3 attempts + delays = 273s
  * - LLM invocation: 480s total (already includes retry budget)
  * - System overhead: 15s for DB, queue, network operations
@@ -89,9 +89,11 @@ export function calculateJobTimeout(imageCount: number, audioCount = 0): number 
   const imageProcessingTime =
     imageCount > 0 ? calculateTimeoutWithRetries(TIMEOUTS.VISION_MODEL) : 0;
 
-  // Audio: (30s fetch + 180s whisper) per attempt × 3 attempts + backoff delays = 633s
+  // Audio: (30s fetch + 180s STT) per attempt × 3 attempts + backoff delays = 633s
   const audioProcessingTime =
-    audioCount > 0 ? calculateTimeoutWithRetries(TIMEOUTS.AUDIO_FETCH + TIMEOUTS.WHISPER_API) : 0;
+    audioCount > 0
+      ? calculateTimeoutWithRetries(TIMEOUTS.AUDIO_FETCH + TIMEOUTS.VOICE_ENGINE_API)
+      : 0;
 
   const attachmentTime = Math.max(imageProcessingTime, audioProcessingTime);
 

--- a/packages/tooling/src/deployment/setup-railway-variables.test.ts
+++ b/packages/tooling/src/deployment/setup-railway-variables.test.ts
@@ -80,7 +80,6 @@ describe('setupRailwayVariables', () => {
     mockReadFileSync.mockReturnValue(`
 AI_PROVIDER=openrouter
 OPENROUTER_API_KEY=sk-test-key
-OPENAI_API_KEY=sk-openai-key
 DISCORD_TOKEN=test-discord-token
 DISCORD_CLIENT_ID=123456789
 BOT_OWNER_ID=987654321
@@ -169,8 +168,7 @@ DISCORD_CLIENT_ID=123456789
 
       const output = consoleLogs.join('\n');
       // Should use defaults
-      expect(output).toContain('WHISPER_MODEL: whisper-1');
-      // Note: EMBEDDING_MODEL removed - local embeddings don't need env config
+      expect(output).toContain('VISION_FALLBACK_MODEL: qwen/qwen3.5-397b-a17b');
     });
 
     it('should report 0 variables when .env file is missing', async () => {

--- a/packages/tooling/src/deployment/setup-railway-variables.ts
+++ b/packages/tooling/src/deployment/setup-railway-variables.ts
@@ -45,24 +45,11 @@ const SHARED_VARIABLES: VariableConfig[] = [
   },
   { key: 'OPENROUTER_API_KEY', description: 'OpenRouter API key', isSecret: true, required: true },
   {
-    key: 'OPENAI_API_KEY',
-    description: 'OpenAI API key (embeddings/Whisper)',
-    isSecret: true,
-    required: false,
-  },
-  {
     key: 'DEFAULT_AI_MODEL',
     description: 'Default AI model',
     isSecret: false,
     required: true,
     defaultValue: 'anthropic/claude-haiku-4.5',
-  },
-  {
-    key: 'WHISPER_MODEL',
-    description: 'Audio transcription model',
-    isSecret: false,
-    required: true,
-    defaultValue: 'whisper-1',
   },
   {
     key: 'VISION_FALLBACK_MODEL',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,6 @@ overrides:
   tar@<=7.5.9: '>=7.5.10'
 
 importers:
-
   .:
     dependencies:
       openai:
@@ -313,9 +312,6 @@ importers:
       onnxruntime-node:
         specifier: ^1.24.3
         version: 1.24.3
-      openai:
-        specifier: ^6.27.0
-        version: 6.27.0(ws@8.19.0)(zod@4.3.6)
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -463,439 +459,741 @@ importers:
         version: 4.0.18(@types/node@25.3.5)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
-
   '@azu/format-text@1.0.2':
-    resolution: {integrity: sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==}
+    resolution:
+      {
+        integrity: sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==,
+      }
 
   '@azu/style-format@1.0.1':
-    resolution: {integrity: sha512-AHcTojlNBdD/3/KxIKlg8sxIWHfOtQszLvOpagLTO+bjC3u7SAszu1lf//u7JJC50aUSH+BVWDD/KvaA6Gfn5g==}
+    resolution:
+      {
+        integrity: sha512-AHcTojlNBdD/3/KxIKlg8sxIWHfOtQszLvOpagLTO+bjC3u7SAszu1lf//u7JJC50aUSH+BVWDD/KvaA6Gfn5g==,
+      }
 
   '@babel/code-frame@7.29.0':
-    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
-    engines: {node: '>=6.9.0'}
+    resolution:
+      {
+        integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==,
+      }
+    engines: { node: '>=6.9.0' }
 
   '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
+    resolution:
+      {
+        integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==,
+      }
+    engines: { node: '>=6.9.0' }
 
   '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
-    engines: {node: '>=6.9.0'}
+    resolution:
+      {
+        integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==,
+      }
+    engines: { node: '>=6.9.0' }
 
   '@babel/parser@7.29.0':
-    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
-    engines: {node: '>=6.0.0'}
+    resolution:
+      {
+        integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==,
+      }
+    engines: { node: '>=6.0.0' }
     hasBin: true
 
   '@babel/runtime@7.28.6':
-    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
-    engines: {node: '>=6.9.0'}
+    resolution:
+      {
+        integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==,
+      }
+    engines: { node: '>=6.9.0' }
 
   '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
-    engines: {node: '>=6.9.0'}
+    resolution:
+      {
+        integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==,
+      }
+    engines: { node: '>=6.9.0' }
 
   '@bcoe/v8-coverage@1.0.2':
-    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==,
+      }
+    engines: { node: '>=18' }
 
   '@cfworker/json-schema@4.1.1':
-    resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
+    resolution:
+      {
+        integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==,
+      }
 
   '@changesets/apply-release-plan@7.1.0':
-    resolution: {integrity: sha512-yq8ML3YS7koKQ/9bk1PqO0HMzApIFNwjlwCnwFEXMzNe8NpzeeYYKCmnhWJGkN8g7E51MnWaSbqRcTcdIxUgnQ==}
+    resolution:
+      {
+        integrity: sha512-yq8ML3YS7koKQ/9bk1PqO0HMzApIFNwjlwCnwFEXMzNe8NpzeeYYKCmnhWJGkN8g7E51MnWaSbqRcTcdIxUgnQ==,
+      }
 
   '@changesets/assemble-release-plan@6.0.9':
-    resolution: {integrity: sha512-tPgeeqCHIwNo8sypKlS3gOPmsS3wP0zHt67JDuL20P4QcXiw/O4Hl7oXiuLnP9yg+rXLQ2sScdV1Kkzde61iSQ==}
+    resolution:
+      {
+        integrity: sha512-tPgeeqCHIwNo8sypKlS3gOPmsS3wP0zHt67JDuL20P4QcXiw/O4Hl7oXiuLnP9yg+rXLQ2sScdV1Kkzde61iSQ==,
+      }
 
   '@changesets/changelog-git@0.2.1':
-    resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
+    resolution:
+      {
+        integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==,
+      }
 
   '@changesets/changelog-github@0.6.0':
-    resolution: {integrity: sha512-wA2/y4hR/A1K411cCT75rz0d46Iezxp1WYRFoFJDIUpkQ6oDBAIUiU7BZkDCmYgz0NBl94X1lgcZO+mHoiHnFg==}
+    resolution:
+      {
+        integrity: sha512-wA2/y4hR/A1K411cCT75rz0d46Iezxp1WYRFoFJDIUpkQ6oDBAIUiU7BZkDCmYgz0NBl94X1lgcZO+mHoiHnFg==,
+      }
 
   '@changesets/cli@2.30.0':
-    resolution: {integrity: sha512-5D3Nk2JPqMI1wK25pEymeWRSlSMdo5QOGlyfrKg0AOufrUcjEE3RQgaCpHoBiM31CSNrtSgdJ0U6zL1rLDDfBA==}
+    resolution:
+      {
+        integrity: sha512-5D3Nk2JPqMI1wK25pEymeWRSlSMdo5QOGlyfrKg0AOufrUcjEE3RQgaCpHoBiM31CSNrtSgdJ0U6zL1rLDDfBA==,
+      }
     hasBin: true
 
   '@changesets/config@3.1.3':
-    resolution: {integrity: sha512-vnXjcey8YgBn2L1OPWd3ORs0bGC4LoYcK/ubpgvzNVr53JXV5GiTVj7fWdMRsoKUH7hhhMAQnsJUqLr21EncNw==}
+    resolution:
+      {
+        integrity: sha512-vnXjcey8YgBn2L1OPWd3ORs0bGC4LoYcK/ubpgvzNVr53JXV5GiTVj7fWdMRsoKUH7hhhMAQnsJUqLr21EncNw==,
+      }
 
   '@changesets/errors@0.2.0':
-    resolution: {integrity: sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==}
+    resolution:
+      {
+        integrity: sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==,
+      }
 
   '@changesets/get-dependents-graph@2.1.3':
-    resolution: {integrity: sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==}
+    resolution:
+      {
+        integrity: sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==,
+      }
 
   '@changesets/get-github-info@0.8.0':
-    resolution: {integrity: sha512-cRnC+xdF0JIik7coko3iUP9qbnfi1iJQ3sAa6dE+Tx3+ET8bjFEm63PA4WEohgjYcmsOikPHWzPsMWWiZmntOQ==}
+    resolution:
+      {
+        integrity: sha512-cRnC+xdF0JIik7coko3iUP9qbnfi1iJQ3sAa6dE+Tx3+ET8bjFEm63PA4WEohgjYcmsOikPHWzPsMWWiZmntOQ==,
+      }
 
   '@changesets/get-release-plan@4.0.15':
-    resolution: {integrity: sha512-Q04ZaRPuEVZtA+auOYgFaVQQSA98dXiVe/yFaZfY7hoSmQICHGvP0TF4u3EDNHWmmCS4ekA/XSpKlSM2PyTS2g==}
+    resolution:
+      {
+        integrity: sha512-Q04ZaRPuEVZtA+auOYgFaVQQSA98dXiVe/yFaZfY7hoSmQICHGvP0TF4u3EDNHWmmCS4ekA/XSpKlSM2PyTS2g==,
+      }
 
   '@changesets/get-version-range-type@0.4.0':
-    resolution: {integrity: sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==}
+    resolution:
+      {
+        integrity: sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==,
+      }
 
   '@changesets/git@3.0.4':
-    resolution: {integrity: sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw==}
+    resolution:
+      {
+        integrity: sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw==,
+      }
 
   '@changesets/logger@0.1.1':
-    resolution: {integrity: sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==}
+    resolution:
+      {
+        integrity: sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==,
+      }
 
   '@changesets/parse@0.4.3':
-    resolution: {integrity: sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==}
+    resolution:
+      {
+        integrity: sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==,
+      }
 
   '@changesets/pre@2.0.2':
-    resolution: {integrity: sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==}
+    resolution:
+      {
+        integrity: sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==,
+      }
 
   '@changesets/read@0.6.7':
-    resolution: {integrity: sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA==}
+    resolution:
+      {
+        integrity: sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA==,
+      }
 
   '@changesets/should-skip-package@0.1.2':
-    resolution: {integrity: sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==}
+    resolution:
+      {
+        integrity: sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==,
+      }
 
   '@changesets/types@4.1.0':
-    resolution: {integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==}
+    resolution:
+      {
+        integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==,
+      }
 
   '@changesets/types@6.1.0':
-    resolution: {integrity: sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==}
+    resolution:
+      {
+        integrity: sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==,
+      }
 
   '@changesets/write@0.4.0':
-    resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+    resolution:
+      {
+        integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==,
+      }
 
   '@chevrotain/cst-dts-gen@10.5.0':
-    resolution: {integrity: sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==}
+    resolution:
+      {
+        integrity: sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==,
+      }
 
   '@chevrotain/gast@10.5.0':
-    resolution: {integrity: sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A==}
+    resolution:
+      {
+        integrity: sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A==,
+      }
 
   '@chevrotain/types@10.5.0':
-    resolution: {integrity: sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A==}
+    resolution:
+      {
+        integrity: sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A==,
+      }
 
   '@chevrotain/utils@10.5.0':
-    resolution: {integrity: sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==}
+    resolution:
+      {
+        integrity: sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==,
+      }
 
   '@colors/colors@1.5.0':
-    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
-    engines: {node: '>=0.1.90'}
+    resolution:
+      {
+        integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==,
+      }
+    engines: { node: '>=0.1.90' }
 
   '@commitlint/cli@20.4.3':
-    resolution: {integrity: sha512-Z37EMoDT7+Upg500vlr/vZrgRsb6Xc5JAA3Tv7BYbobnN/ZpqUeZnSLggBg2+1O+NptRDtyujr2DD1CPV2qwhA==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-Z37EMoDT7+Upg500vlr/vZrgRsb6Xc5JAA3Tv7BYbobnN/ZpqUeZnSLggBg2+1O+NptRDtyujr2DD1CPV2qwhA==,
+      }
+    engines: { node: '>=v18' }
     hasBin: true
 
   '@commitlint/config-conventional@20.4.3':
-    resolution: {integrity: sha512-9RtLySbYQAs8yEqWEqhSZo9nYhbm57jx7qHXtgRmv/nmeQIjjMcwf6Dl+y5UZcGWgWx435TAYBURONaJIuCjWg==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-9RtLySbYQAs8yEqWEqhSZo9nYhbm57jx7qHXtgRmv/nmeQIjjMcwf6Dl+y5UZcGWgWx435TAYBURONaJIuCjWg==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/config-validator@20.4.3':
-    resolution: {integrity: sha512-jCZpZFkcSL3ZEdL5zgUzFRdytv3xPo8iukTe9VA+QGus/BGhpp1xXSVu2B006GLLb2gYUAEGEqv64kTlpZNgmA==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-jCZpZFkcSL3ZEdL5zgUzFRdytv3xPo8iukTe9VA+QGus/BGhpp1xXSVu2B006GLLb2gYUAEGEqv64kTlpZNgmA==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/ensure@20.4.3':
-    resolution: {integrity: sha512-WcXGKBNn0wBKpX8VlXgxqedyrLxedIlLBCMvdamLnJFEbUGJ9JZmBVx4vhLV3ZyA8uONGOb+CzW0Y9HDbQ+ONQ==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-WcXGKBNn0wBKpX8VlXgxqedyrLxedIlLBCMvdamLnJFEbUGJ9JZmBVx4vhLV3ZyA8uONGOb+CzW0Y9HDbQ+ONQ==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/execute-rule@20.0.0':
-    resolution: {integrity: sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/format@20.4.3':
-    resolution: {integrity: sha512-UDJVErjLbNghop6j111rsHJYGw6MjCKAi95K0GT2yf4eeiDHy3JDRLWYWEjIaFgO+r+dQSkuqgJ1CdMTtrvHsA==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-UDJVErjLbNghop6j111rsHJYGw6MjCKAi95K0GT2yf4eeiDHy3JDRLWYWEjIaFgO+r+dQSkuqgJ1CdMTtrvHsA==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/is-ignored@20.4.3':
-    resolution: {integrity: sha512-W5VQKZ7fdJ1X3Tko+h87YZaqRMGN1KvQKXyCM8xFdxzMIf1KCZgN4uLz3osLB1zsFcVS4ZswHY64LI26/9ACag==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-W5VQKZ7fdJ1X3Tko+h87YZaqRMGN1KvQKXyCM8xFdxzMIf1KCZgN4uLz3osLB1zsFcVS4ZswHY64LI26/9ACag==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/lint@20.4.3':
-    resolution: {integrity: sha512-CYOXL23e+nRKij81+d0+dymtIi7Owl9QzvblJYbEfInON/4MaETNSLFDI74LDu+YJ0ML5HZyw9Vhp9QpckwQ0A==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-CYOXL23e+nRKij81+d0+dymtIi7Owl9QzvblJYbEfInON/4MaETNSLFDI74LDu+YJ0ML5HZyw9Vhp9QpckwQ0A==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/load@20.4.3':
-    resolution: {integrity: sha512-3cdJOUVP+VcgHa7bhJoWS+Z8mBNXB5aLWMBu7Q7uX8PSeWDzdbrBlR33J1MGGf7r1PZDp+mPPiFktk031PgdRw==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-3cdJOUVP+VcgHa7bhJoWS+Z8mBNXB5aLWMBu7Q7uX8PSeWDzdbrBlR33J1MGGf7r1PZDp+mPPiFktk031PgdRw==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/message@20.4.3':
-    resolution: {integrity: sha512-6akwCYrzcrFcTYz9GyUaWlhisY4lmQ3KvrnabmhoeAV8nRH4dXJAh4+EUQ3uArtxxKQkvxJS78hNX2EU3USgxQ==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-6akwCYrzcrFcTYz9GyUaWlhisY4lmQ3KvrnabmhoeAV8nRH4dXJAh4+EUQ3uArtxxKQkvxJS78hNX2EU3USgxQ==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/parse@20.4.3':
-    resolution: {integrity: sha512-hzC3JCo3zs3VkQ833KnGVuWjWIzR72BWZWjQM7tY/7dfKreKAm7fEsy71tIFCRtxf2RtMP2d3RLF1U9yhFSccA==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-hzC3JCo3zs3VkQ833KnGVuWjWIzR72BWZWjQM7tY/7dfKreKAm7fEsy71tIFCRtxf2RtMP2d3RLF1U9yhFSccA==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/read@20.4.3':
-    resolution: {integrity: sha512-j42OWv3L31WfnP8WquVjHZRt03w50Y/gEE8FAyih7GQTrIv2+pZ6VZ6pWLD/ml/3PO+RV2SPtRtTp/MvlTb8rQ==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-j42OWv3L31WfnP8WquVjHZRt03w50Y/gEE8FAyih7GQTrIv2+pZ6VZ6pWLD/ml/3PO+RV2SPtRtTp/MvlTb8rQ==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/resolve-extends@20.4.3':
-    resolution: {integrity: sha512-QucxcOy+00FhS9s4Uy0OyS5HeUV+hbC6OLqkTSIm6fwMdKva+OEavaCDuLtgd9akZZlsUo//XzSmPP3sLKBPog==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-QucxcOy+00FhS9s4Uy0OyS5HeUV+hbC6OLqkTSIm6fwMdKva+OEavaCDuLtgd9akZZlsUo//XzSmPP3sLKBPog==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/rules@20.4.3':
-    resolution: {integrity: sha512-Yuosd7Grn5qiT7FovngXLyRXTMUbj9PYiSkvUgWK1B5a7+ZvrbWDS7epeUapYNYatCy/KTpPFPbgLUdE+MUrBg==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-Yuosd7Grn5qiT7FovngXLyRXTMUbj9PYiSkvUgWK1B5a7+ZvrbWDS7epeUapYNYatCy/KTpPFPbgLUdE+MUrBg==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/to-lines@20.0.0':
-    resolution: {integrity: sha512-2l9gmwiCRqZNWgV+pX1X7z4yP0b3ex/86UmUFgoRt672Ez6cAM2lOQeHFRUTuE6sPpi8XBCGnd8Kh3bMoyHwJw==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-2l9gmwiCRqZNWgV+pX1X7z4yP0b3ex/86UmUFgoRt672Ez6cAM2lOQeHFRUTuE6sPpi8XBCGnd8Kh3bMoyHwJw==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/top-level@20.4.3':
-    resolution: {integrity: sha512-qD9xfP6dFg5jQ3NMrOhG0/w5y3bBUsVGyJvXxdWEwBm8hyx4WOk3kKXw28T5czBYvyeCVJgJJ6aoJZUWDpaacQ==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-qD9xfP6dFg5jQ3NMrOhG0/w5y3bBUsVGyJvXxdWEwBm8hyx4WOk3kKXw28T5czBYvyeCVJgJJ6aoJZUWDpaacQ==,
+      }
+    engines: { node: '>=v18' }
 
   '@commitlint/types@20.4.3':
-    resolution: {integrity: sha512-51OWa1Gi6ODOasPmfJPq6js4pZoomima4XLZZCrkldaH2V5Nb3bVhNXPeT6XV0gubbainSpTw4zi68NqAeCNCg==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-51OWa1Gi6ODOasPmfJPq6js4pZoomima4XLZZCrkldaH2V5Nb3bVhNXPeT6XV0gubbainSpTw4zi68NqAeCNCg==,
+      }
+    engines: { node: '>=v18' }
 
   '@discordjs/builders@1.13.1':
-    resolution: {integrity: sha512-cOU0UDHc3lp/5nKByDxkmRiNZBpdp0kx55aarbiAfakfKJHlxv/yFW1zmIqCAmwH5CRlrH9iMFKJMpvW4DPB+w==}
-    engines: {node: '>=16.11.0'}
+    resolution:
+      {
+        integrity: sha512-cOU0UDHc3lp/5nKByDxkmRiNZBpdp0kx55aarbiAfakfKJHlxv/yFW1zmIqCAmwH5CRlrH9iMFKJMpvW4DPB+w==,
+      }
+    engines: { node: '>=16.11.0' }
 
   '@discordjs/collection@1.5.3':
-    resolution: {integrity: sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==}
-    engines: {node: '>=16.11.0'}
+    resolution:
+      {
+        integrity: sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==,
+      }
+    engines: { node: '>=16.11.0' }
 
   '@discordjs/collection@2.1.1':
-    resolution: {integrity: sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==,
+      }
+    engines: { node: '>=18' }
 
   '@discordjs/formatters@0.6.2':
-    resolution: {integrity: sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==}
-    engines: {node: '>=16.11.0'}
+    resolution:
+      {
+        integrity: sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==,
+      }
+    engines: { node: '>=16.11.0' }
 
   '@discordjs/rest@2.6.0':
-    resolution: {integrity: sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==,
+      }
+    engines: { node: '>=18' }
 
   '@discordjs/util@1.2.0':
-    resolution: {integrity: sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==,
+      }
+    engines: { node: '>=18' }
 
   '@discordjs/ws@1.2.3':
-    resolution: {integrity: sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==}
-    engines: {node: '>=16.11.0'}
+    resolution:
+      {
+        integrity: sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==,
+      }
+    engines: { node: '>=16.11.0' }
 
   '@electric-sql/pglite-socket@0.0.20':
-    resolution: {integrity: sha512-J5nLGsicnD9wJHnno9r+DGxfcZWh+YJMCe0q/aCgtG6XOm9Z7fKeite8IZSNXgZeGltSigM9U/vAWZQWdgcSFg==}
+    resolution:
+      {
+        integrity: sha512-J5nLGsicnD9wJHnno9r+DGxfcZWh+YJMCe0q/aCgtG6XOm9Z7fKeite8IZSNXgZeGltSigM9U/vAWZQWdgcSFg==,
+      }
     hasBin: true
     peerDependencies:
       '@electric-sql/pglite': 0.3.15
 
   '@electric-sql/pglite-tools@0.2.20':
-    resolution: {integrity: sha512-BK50ZnYa3IG7ztXhtgYf0Q7zijV32Iw1cYS8C+ThdQlwx12V5VZ9KRJ42y82Hyb4PkTxZQklVQA9JHyUlex33A==}
+    resolution:
+      {
+        integrity: sha512-BK50ZnYa3IG7ztXhtgYf0Q7zijV32Iw1cYS8C+ThdQlwx12V5VZ9KRJ42y82Hyb4PkTxZQklVQA9JHyUlex33A==,
+      }
     peerDependencies:
       '@electric-sql/pglite': 0.3.15
 
   '@electric-sql/pglite@0.3.15':
-    resolution: {integrity: sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==}
+    resolution:
+      {
+        integrity: sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==,
+      }
 
   '@emnapi/core@1.8.1':
-    resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
+    resolution:
+      {
+        integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==,
+      }
 
   '@emnapi/runtime@1.8.1':
-    resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
+    resolution:
+      {
+        integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==,
+      }
 
   '@emnapi/wasi-threads@1.1.0':
-    resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+    resolution:
+      {
+        integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==,
+      }
 
   '@esbuild/aix-ppc64@0.27.2':
-    resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==,
+      }
+    engines: { node: '>=18' }
     cpu: [ppc64]
     os: [aix]
 
   '@esbuild/android-arm64@0.27.2':
-    resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==,
+      }
+    engines: { node: '>=18' }
     cpu: [arm64]
     os: [android]
 
   '@esbuild/android-arm@0.27.2':
-    resolution: {integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==,
+      }
+    engines: { node: '>=18' }
     cpu: [arm]
     os: [android]
 
   '@esbuild/android-x64@0.27.2':
-    resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==,
+      }
+    engines: { node: '>=18' }
     cpu: [x64]
     os: [android]
 
   '@esbuild/darwin-arm64@0.27.2':
-    resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==,
+      }
+    engines: { node: '>=18' }
     cpu: [arm64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.2':
-    resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==,
+      }
+    engines: { node: '>=18' }
     cpu: [x64]
     os: [darwin]
 
   '@esbuild/freebsd-arm64@0.27.2':
-    resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==,
+      }
+    engines: { node: '>=18' }
     cpu: [arm64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.2':
-    resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==,
+      }
+    engines: { node: '>=18' }
     cpu: [x64]
     os: [freebsd]
 
   '@esbuild/linux-arm64@0.27.2':
-    resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==,
+      }
+    engines: { node: '>=18' }
     cpu: [arm64]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.2':
-    resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==,
+      }
+    engines: { node: '>=18' }
     cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-ia32@0.27.2':
-    resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==,
+      }
+    engines: { node: '>=18' }
     cpu: [ia32]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.2':
-    resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==,
+      }
+    engines: { node: '>=18' }
     cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-mips64el@0.27.2':
-    resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==,
+      }
+    engines: { node: '>=18' }
     cpu: [mips64el]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.2':
-    resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==,
+      }
+    engines: { node: '>=18' }
     cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-riscv64@0.27.2':
-    resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==,
+      }
+    engines: { node: '>=18' }
     cpu: [riscv64]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.2':
-    resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==,
+      }
+    engines: { node: '>=18' }
     cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-x64@0.27.2':
-    resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==,
+      }
+    engines: { node: '>=18' }
     cpu: [x64]
     os: [linux]
 
   '@esbuild/netbsd-arm64@0.27.2':
-    resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==,
+      }
+    engines: { node: '>=18' }
     cpu: [arm64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.2':
-    resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==,
+      }
+    engines: { node: '>=18' }
     cpu: [x64]
     os: [netbsd]
 
   '@esbuild/openbsd-arm64@0.27.2':
-    resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==,
+      }
+    engines: { node: '>=18' }
     cpu: [arm64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.2':
-    resolution: {integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==,
+      }
+    engines: { node: '>=18' }
     cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openharmony-arm64@0.27.2':
-    resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==,
+      }
+    engines: { node: '>=18' }
     cpu: [arm64]
     os: [openharmony]
 
   '@esbuild/sunos-x64@0.27.2':
-    resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==,
+      }
+    engines: { node: '>=18' }
     cpu: [x64]
     os: [sunos]
 
   '@esbuild/win32-arm64@0.27.2':
-    resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==,
+      }
+    engines: { node: '>=18' }
     cpu: [arm64]
     os: [win32]
 
   '@esbuild/win32-ia32@0.27.2':
-    resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==,
+      }
+    engines: { node: '>=18' }
     cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.2':
-    resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==,
+      }
+    engines: { node: '>=18' }
     cpu: [x64]
     os: [win32]
 
   '@eslint-community/eslint-utils@4.9.1':
-    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    resolution:
+      {
+        integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==,
+      }
+    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
   '@eslint-community/regexpp@4.12.2':
-    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
-    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+    resolution:
+      {
+        integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==,
+      }
+    engines: { node: ^12.0.0 || ^14.0.0 || >=16.0.0 }
 
   '@eslint/config-array@0.21.1':
-    resolution: {integrity: sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   '@eslint/config-array@0.23.3':
-    resolution: {integrity: sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    resolution:
+      {
+        integrity: sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==,
+      }
+    engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
   '@eslint/config-helpers@0.4.2':
-    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   '@eslint/config-helpers@0.5.3':
-    resolution: {integrity: sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    resolution:
+      {
+        integrity: sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==,
+      }
+    engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
   '@eslint/core@0.17.0':
-    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   '@eslint/core@1.1.1':
-    resolution: {integrity: sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    resolution:
+      {
+        integrity: sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==,
+      }
+    engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
   '@eslint/eslintrc@3.3.3':
-    resolution: {integrity: sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   '@eslint/js@10.0.1':
-    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    resolution:
+      {
+        integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==,
+      }
+    engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
     peerDependencies:
       eslint: ^10.0.0
     peerDependenciesMeta:
@@ -903,210 +1201,324 @@ packages:
         optional: true
 
   '@eslint/js@9.39.2':
-    resolution: {integrity: sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   '@eslint/object-schema@2.1.7':
-    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   '@eslint/object-schema@3.0.3':
-    resolution: {integrity: sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    resolution:
+      {
+        integrity: sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==,
+      }
+    engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
   '@eslint/plugin-kit@0.4.1':
-    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   '@eslint/plugin-kit@0.6.1':
-    resolution: {integrity: sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    resolution:
+      {
+        integrity: sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==,
+      }
+    engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
   '@hono/node-server@1.19.10':
-    resolution: {integrity: sha512-hZ7nOssGqRgyV3FVVQdfi+U4q02uB23bpnYpdvNXkYTRRyWx84b7yf1ans+dnJ/7h41sGL3CeQTfO+ZGxuO+Iw==}
-    engines: {node: '>=18.14.1'}
+    resolution:
+      {
+        integrity: sha512-hZ7nOssGqRgyV3FVVQdfi+U4q02uB23bpnYpdvNXkYTRRyWx84b7yf1ans+dnJ/7h41sGL3CeQTfO+ZGxuO+Iw==,
+      }
+    engines: { node: '>=18.14.1' }
     peerDependencies:
       hono: '>=4.12.4'
 
   '@huggingface/jinja@0.5.3':
-    resolution: {integrity: sha512-asqfZ4GQS0hD876Uw4qiUb7Tr/V5Q+JZuo2L+BtdrD4U40QU58nIRq3ZSgAzJgT874VLjhGVacaYfrdpXtEvtA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-asqfZ4GQS0hD876Uw4qiUb7Tr/V5Q+JZuo2L+BtdrD4U40QU58nIRq3ZSgAzJgT874VLjhGVacaYfrdpXtEvtA==,
+      }
+    engines: { node: '>=18' }
 
   '@huggingface/transformers@3.8.1':
-    resolution: {integrity: sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==}
+    resolution:
+      {
+        integrity: sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==,
+      }
 
   '@humanfs/core@0.19.1':
-    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
-    engines: {node: '>=18.18.0'}
+    resolution:
+      {
+        integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==,
+      }
+    engines: { node: '>=18.18.0' }
 
   '@humanfs/node@0.16.7':
-    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
-    engines: {node: '>=18.18.0'}
+    resolution:
+      {
+        integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==,
+      }
+    engines: { node: '>=18.18.0' }
 
   '@humanwhocodes/module-importer@1.0.1':
-    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
-    engines: {node: '>=12.22'}
+    resolution:
+      {
+        integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==,
+      }
+    engines: { node: '>=12.22' }
 
   '@humanwhocodes/retry@0.4.3':
-    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
-    engines: {node: '>=18.18'}
+    resolution:
+      {
+        integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==,
+      }
+    engines: { node: '>=18.18' }
 
   '@img/colour@1.0.0':
-    resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==,
+      }
+    engines: { node: '>=18' }
 
   '@img/sharp-darwin-arm64@0.34.5':
-    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    resolution:
+      {
+        integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm64]
     os: [darwin]
 
   '@img/sharp-darwin-x64@0.34.5':
-    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    resolution:
+      {
+        integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [x64]
     os: [darwin]
 
   '@img/sharp-libvips-darwin-arm64@1.2.4':
-    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    resolution:
+      {
+        integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==,
+      }
     cpu: [arm64]
     os: [darwin]
 
   '@img/sharp-libvips-darwin-x64@1.2.4':
-    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    resolution:
+      {
+        integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==,
+      }
     cpu: [x64]
     os: [darwin]
 
   '@img/sharp-libvips-linux-arm64@1.2.4':
-    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    resolution:
+      {
+        integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==,
+      }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
-    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    resolution:
+      {
+        integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==,
+      }
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
-    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    resolution:
+      {
+        integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==,
+      }
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
-    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    resolution:
+      {
+        integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==,
+      }
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
-    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    resolution:
+      {
+        integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==,
+      }
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
-    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    resolution:
+      {
+        integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==,
+      }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    resolution:
+      {
+        integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==,
+      }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    resolution:
+      {
+        integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==,
+      }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
-    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    resolution:
+      {
+        integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
-    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    resolution:
+      {
+        integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
-    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    resolution:
+      {
+        integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
-    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    resolution:
+      {
+        integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
-    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    resolution:
+      {
+        integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
-    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    resolution:
+      {
+        integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
-    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    resolution:
+      {
+        integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
-    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    resolution:
+      {
+        integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
-    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    resolution:
+      {
+        integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [wasm32]
 
   '@img/sharp-win32-arm64@0.34.5':
-    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    resolution:
+      {
+        integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm64]
     os: [win32]
 
   '@img/sharp-win32-ia32@0.34.5':
-    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    resolution:
+      {
+        integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [ia32]
     os: [win32]
 
   '@img/sharp-win32-x64@0.34.5':
-    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    resolution:
+      {
+        integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [x64]
     os: [win32]
 
   '@inquirer/external-editor@1.0.3':
-    resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==,
+      }
+    engines: { node: '>=18' }
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -1114,169 +1526,268 @@ packages:
         optional: true
 
   '@ioredis/commands@1.5.1':
-    resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
+    resolution:
+      {
+        integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==,
+      }
 
   '@isaacs/fs-minipass@4.0.1':
-    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
-    engines: {node: '>=18.0.0'}
+    resolution:
+      {
+        integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==,
+      }
+    engines: { node: '>=18.0.0' }
 
   '@jridgewell/resolve-uri@3.1.2':
-    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
-    engines: {node: '>=6.0.0'}
+    resolution:
+      {
+        integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==,
+      }
+    engines: { node: '>=6.0.0' }
 
   '@jridgewell/sourcemap-codec@1.5.5':
-    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+    resolution:
+      {
+        integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==,
+      }
 
   '@jridgewell/trace-mapping@0.3.31':
-    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+    resolution:
+      {
+        integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==,
+      }
 
   '@jscpd/badge-reporter@4.0.4':
-    resolution: {integrity: sha512-I9b4MmLXPM2vo0SxSUWnNGKcA4PjQlD3GzXvFK60z43cN/EIdLbOq3FVwCL+dg2obUqGXKIzAm7EsDFTg0D+mQ==}
+    resolution:
+      {
+        integrity: sha512-I9b4MmLXPM2vo0SxSUWnNGKcA4PjQlD3GzXvFK60z43cN/EIdLbOq3FVwCL+dg2obUqGXKIzAm7EsDFTg0D+mQ==,
+      }
 
   '@jscpd/core@4.0.4':
-    resolution: {integrity: sha512-QGMT3iXEX1fI6lgjPH+x8eyJwhwr2KkpSF5uBpjC0Z5Xloj0yFTFLtwJT+RhxP/Ob4WYrtx2jvpKB269oIwgMQ==}
+    resolution:
+      {
+        integrity: sha512-QGMT3iXEX1fI6lgjPH+x8eyJwhwr2KkpSF5uBpjC0Z5Xloj0yFTFLtwJT+RhxP/Ob4WYrtx2jvpKB269oIwgMQ==,
+      }
 
   '@jscpd/finder@4.0.4':
-    resolution: {integrity: sha512-qVUWY7Nzuvfd5OIk+n7/5CM98LmFroLqblRXAI2gDABwZrc7qS+WH2SNr0qoUq0f4OqwM+piiwKvwL/VDNn/Cg==}
+    resolution:
+      {
+        integrity: sha512-qVUWY7Nzuvfd5OIk+n7/5CM98LmFroLqblRXAI2gDABwZrc7qS+WH2SNr0qoUq0f4OqwM+piiwKvwL/VDNn/Cg==,
+      }
 
   '@jscpd/html-reporter@4.0.4':
-    resolution: {integrity: sha512-YiepyeYkeH74Kx59PJRdUdonznct0wHPFkf6FLQN+mCBoy6leAWCcOfHtcexnp+UsBFDlItG5nRdKrDSxSH+Kg==}
+    resolution:
+      {
+        integrity: sha512-YiepyeYkeH74Kx59PJRdUdonznct0wHPFkf6FLQN+mCBoy6leAWCcOfHtcexnp+UsBFDlItG5nRdKrDSxSH+Kg==,
+      }
 
   '@jscpd/tokenizer@4.0.4':
-    resolution: {integrity: sha512-xxYYY/qaLah/FlwogEbGIxx9CjDO+G9E6qawcy26WwrflzJb6wsnhjwdneN6Wb0RNCDsqvzY+bzG453jsin4UQ==}
+    resolution:
+      {
+        integrity: sha512-xxYYY/qaLah/FlwogEbGIxx9CjDO+G9E6qawcy26WwrflzJb6wsnhjwdneN6Wb0RNCDsqvzY+bzG453jsin4UQ==,
+      }
 
   '@jsonjoy.com/base64@1.1.2':
-    resolution: {integrity: sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==}
-    engines: {node: '>=10.0'}
+    resolution:
+      {
+        integrity: sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==,
+      }
+    engines: { node: '>=10.0' }
     peerDependencies:
       tslib: '2'
 
   '@jsonjoy.com/base64@17.67.0':
-    resolution: {integrity: sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==}
-    engines: {node: '>=10.0'}
+    resolution:
+      {
+        integrity: sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==,
+      }
+    engines: { node: '>=10.0' }
     peerDependencies:
       tslib: '2'
 
   '@jsonjoy.com/buffers@1.2.1':
-    resolution: {integrity: sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==}
-    engines: {node: '>=10.0'}
+    resolution:
+      {
+        integrity: sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==,
+      }
+    engines: { node: '>=10.0' }
     peerDependencies:
       tslib: '2'
 
   '@jsonjoy.com/buffers@17.67.0':
-    resolution: {integrity: sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==}
-    engines: {node: '>=10.0'}
+    resolution:
+      {
+        integrity: sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==,
+      }
+    engines: { node: '>=10.0' }
     peerDependencies:
       tslib: '2'
 
   '@jsonjoy.com/codegen@1.0.0':
-    resolution: {integrity: sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==}
-    engines: {node: '>=10.0'}
+    resolution:
+      {
+        integrity: sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==,
+      }
+    engines: { node: '>=10.0' }
     peerDependencies:
       tslib: '2'
 
   '@jsonjoy.com/codegen@17.67.0':
-    resolution: {integrity: sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==}
-    engines: {node: '>=10.0'}
+    resolution:
+      {
+        integrity: sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==,
+      }
+    engines: { node: '>=10.0' }
     peerDependencies:
       tslib: '2'
 
   '@jsonjoy.com/fs-core@4.56.11':
-    resolution: {integrity: sha512-wThHjzUp01ImIjfCwhs+UnFkeGPFAymwLEkOtenHewaKe2pTP12p6r1UuwikA9NEvNf9Vlck92r8fb8n/MWM5w==}
-    engines: {node: '>=10.0'}
+    resolution:
+      {
+        integrity: sha512-wThHjzUp01ImIjfCwhs+UnFkeGPFAymwLEkOtenHewaKe2pTP12p6r1UuwikA9NEvNf9Vlck92r8fb8n/MWM5w==,
+      }
+    engines: { node: '>=10.0' }
     peerDependencies:
       tslib: '2'
 
   '@jsonjoy.com/fs-fsa@4.56.11':
-    resolution: {integrity: sha512-ZYlF3XbMayyp97xEN8ZvYutU99PCHjM64mMZvnCseXkCJXJDVLAwlF8Q/7q/xiWQRsv3pQBj1WXHd9eEyYcaCQ==}
-    engines: {node: '>=10.0'}
+    resolution:
+      {
+        integrity: sha512-ZYlF3XbMayyp97xEN8ZvYutU99PCHjM64mMZvnCseXkCJXJDVLAwlF8Q/7q/xiWQRsv3pQBj1WXHd9eEyYcaCQ==,
+      }
+    engines: { node: '>=10.0' }
     peerDependencies:
       tslib: '2'
 
   '@jsonjoy.com/fs-node-builtins@4.56.11':
-    resolution: {integrity: sha512-CNmt3a0zMCIhniFLXtzPWuUxXFU+U+2VyQiIrgt/rRVeEJNrMQUABaRbVxR0Ouw1LyR9RjaEkPM6nYpED+y43A==}
-    engines: {node: '>=10.0'}
+    resolution:
+      {
+        integrity: sha512-CNmt3a0zMCIhniFLXtzPWuUxXFU+U+2VyQiIrgt/rRVeEJNrMQUABaRbVxR0Ouw1LyR9RjaEkPM6nYpED+y43A==,
+      }
+    engines: { node: '>=10.0' }
     peerDependencies:
       tslib: '2'
 
   '@jsonjoy.com/fs-node-to-fsa@4.56.11':
-    resolution: {integrity: sha512-5OzGdvJDgZVo+xXWEYo72u81zpOWlxlbG4d4nL+hSiW+LKlua/dldNgPrpWxtvhgyntmdFQad2UTxFyGjJAGhA==}
-    engines: {node: '>=10.0'}
+    resolution:
+      {
+        integrity: sha512-5OzGdvJDgZVo+xXWEYo72u81zpOWlxlbG4d4nL+hSiW+LKlua/dldNgPrpWxtvhgyntmdFQad2UTxFyGjJAGhA==,
+      }
+    engines: { node: '>=10.0' }
     peerDependencies:
       tslib: '2'
 
   '@jsonjoy.com/fs-node-utils@4.56.11':
-    resolution: {integrity: sha512-JADOZFDA3wRfsuxkT0+MYc4F9hJO2PYDaY66kRTG6NqGX3+bqmKu66YFYAbII/tEmQWPZeHoClUB23rtQM9UPg==}
-    engines: {node: '>=10.0'}
+    resolution:
+      {
+        integrity: sha512-JADOZFDA3wRfsuxkT0+MYc4F9hJO2PYDaY66kRTG6NqGX3+bqmKu66YFYAbII/tEmQWPZeHoClUB23rtQM9UPg==,
+      }
+    engines: { node: '>=10.0' }
     peerDependencies:
       tslib: '2'
 
   '@jsonjoy.com/fs-node@4.56.11':
-    resolution: {integrity: sha512-D65YrnP6wRuZyEWoSFnBJSr5zARVpVBGctnhie4rCsMuGXNzX7IHKaOt85/Aj7SSoG1N2+/xlNjWmkLvZ2H3Tg==}
-    engines: {node: '>=10.0'}
+    resolution:
+      {
+        integrity: sha512-D65YrnP6wRuZyEWoSFnBJSr5zARVpVBGctnhie4rCsMuGXNzX7IHKaOt85/Aj7SSoG1N2+/xlNjWmkLvZ2H3Tg==,
+      }
+    engines: { node: '>=10.0' }
     peerDependencies:
       tslib: '2'
 
   '@jsonjoy.com/fs-print@4.56.11':
-    resolution: {integrity: sha512-rnaKRgCRIn8JGTjxhS0JPE38YM3Pj/H7SW4/tglhIPbfKEkky7dpPayNKV2qy25SZSL15oFVgH/62dMZ/z7cyA==}
-    engines: {node: '>=10.0'}
+    resolution:
+      {
+        integrity: sha512-rnaKRgCRIn8JGTjxhS0JPE38YM3Pj/H7SW4/tglhIPbfKEkky7dpPayNKV2qy25SZSL15oFVgH/62dMZ/z7cyA==,
+      }
+    engines: { node: '>=10.0' }
     peerDependencies:
       tslib: '2'
 
   '@jsonjoy.com/fs-snapshot@4.56.11':
-    resolution: {integrity: sha512-IIldPX+cIRQuUol9fQzSS3hqyECxVpYMJQMqdU3dCKZFRzEl1rkIkw4P6y7Oh493sI7YdxZlKr/yWdzEWZ1wGQ==}
-    engines: {node: '>=10.0'}
+    resolution:
+      {
+        integrity: sha512-IIldPX+cIRQuUol9fQzSS3hqyECxVpYMJQMqdU3dCKZFRzEl1rkIkw4P6y7Oh493sI7YdxZlKr/yWdzEWZ1wGQ==,
+      }
+    engines: { node: '>=10.0' }
     peerDependencies:
       tslib: '2'
 
   '@jsonjoy.com/json-pack@1.21.0':
-    resolution: {integrity: sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==}
-    engines: {node: '>=10.0'}
+    resolution:
+      {
+        integrity: sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==,
+      }
+    engines: { node: '>=10.0' }
     peerDependencies:
       tslib: '2'
 
   '@jsonjoy.com/json-pack@17.67.0':
-    resolution: {integrity: sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==}
-    engines: {node: '>=10.0'}
+    resolution:
+      {
+        integrity: sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==,
+      }
+    engines: { node: '>=10.0' }
     peerDependencies:
       tslib: '2'
 
   '@jsonjoy.com/json-pointer@1.0.2':
-    resolution: {integrity: sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==}
-    engines: {node: '>=10.0'}
+    resolution:
+      {
+        integrity: sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==,
+      }
+    engines: { node: '>=10.0' }
     peerDependencies:
       tslib: '2'
 
   '@jsonjoy.com/json-pointer@17.67.0':
-    resolution: {integrity: sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==}
-    engines: {node: '>=10.0'}
+    resolution:
+      {
+        integrity: sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==,
+      }
+    engines: { node: '>=10.0' }
     peerDependencies:
       tslib: '2'
 
   '@jsonjoy.com/util@1.9.0':
-    resolution: {integrity: sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==}
-    engines: {node: '>=10.0'}
+    resolution:
+      {
+        integrity: sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==,
+      }
+    engines: { node: '>=10.0' }
     peerDependencies:
       tslib: '2'
 
   '@jsonjoy.com/util@17.67.0':
-    resolution: {integrity: sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==}
-    engines: {node: '>=10.0'}
+    resolution:
+      {
+        integrity: sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==,
+      }
+    engines: { node: '>=10.0' }
     peerDependencies:
       tslib: '2'
 
   '@langchain/core@1.1.31':
-    resolution: {integrity: sha512-FxsgIUONjKaRpjx59sISgmb0OMCbAetPGyhzjGa2kX0y1f8LZ5xm9VB2db7W9HYWyLvzRWcMA51Uu4OSTJmtZQ==}
-    engines: {node: '>=20'}
+    resolution:
+      {
+        integrity: sha512-FxsgIUONjKaRpjx59sISgmb0OMCbAetPGyhzjGa2kX0y1f8LZ5xm9VB2db7W9HYWyLvzRWcMA51Uu4OSTJmtZQ==,
+      }
+    engines: { node: '>=20' }
 
   '@langchain/langgraph-checkpoint@1.0.0':
-    resolution: {integrity: sha512-xrclBGvNCXDmi0Nz28t3vjpxSH6UYx6w5XAXSiiB1WEdc2xD2iY/a913I3x3a31XpInUW/GGfXXfePfaghV54A==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-xrclBGvNCXDmi0Nz28t3vjpxSH6UYx6w5XAXSiiB1WEdc2xD2iY/a913I3x3a31XpInUW/GGfXXfePfaghV54A==,
+      }
+    engines: { node: '>=18' }
     peerDependencies:
       '@langchain/core': ^1.0.1
 
   '@langchain/langgraph-sdk@1.6.5':
-    resolution: {integrity: sha512-JjprmbhgCnoNJ9DUKcvrEU+C9FfKsNGyT3ooqWxAY5Cx2qofhXmDJOpTCqqbxfDHPKG0RjTs5HgVK3WW5M6Big==}
+    resolution:
+      {
+        integrity: sha512-JjprmbhgCnoNJ9DUKcvrEU+C9FfKsNGyT3ooqWxAY5Cx2qofhXmDJOpTCqqbxfDHPKG0RjTs5HgVK3WW5M6Big==,
+      }
     peerDependencies:
       '@langchain/core': ^1.1.16
       react: ^18 || ^19
@@ -1290,8 +1801,11 @@ packages:
         optional: true
 
   '@langchain/langgraph@1.2.1':
-    resolution: {integrity: sha512-OeLMejye1DZeZBPnurus2bqvjRi+pyrqfAXX77hYdUqKeQ3hAG7pLG04xdrvMs0pl/F57ZtwywqoE2oVqcI6JA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-OeLMejye1DZeZBPnurus2bqvjRi+pyrqfAXX77hYdUqKeQ3hAG7pLG04xdrvMs0pl/F57ZtwywqoE2oVqcI6JA==,
+      }
+    engines: { node: '>=18' }
     peerDependencies:
       '@langchain/core': ^1.1.16
       zod: ^3.25.32 || ^4.2.0
@@ -1301,193 +1815,313 @@ packages:
         optional: true
 
   '@langchain/openai@1.2.12':
-    resolution: {integrity: sha512-Im6PPNujrfkZk4vpc9JAjbeERg+RbNtWRe3KSFOP7aNGa/yZ+XD69lxXwbsZGaZkbiUN/hwe9RYeisUfThb5wg==}
-    engines: {node: '>=20'}
+    resolution:
+      {
+        integrity: sha512-Im6PPNujrfkZk4vpc9JAjbeERg+RbNtWRe3KSFOP7aNGa/yZ+XD69lxXwbsZGaZkbiUN/hwe9RYeisUfThb5wg==,
+      }
+    engines: { node: '>=20' }
     peerDependencies:
       '@langchain/core': ^1.1.30
 
   '@manypkg/find-root@1.1.0':
-    resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
+    resolution:
+      {
+        integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==,
+      }
 
   '@manypkg/get-packages@1.1.3':
-    resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+    resolution:
+      {
+        integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==,
+      }
 
   '@mrleebo/prisma-ast@0.13.1':
-    resolution: {integrity: sha512-XyroGQXcHrZdvmrGJvsA9KNeOOgGMg1Vg9OlheUsBOSKznLMDl+YChxbkboRHvtFYJEMRYmlV3uoo/njCw05iw==}
-    engines: {node: '>=16'}
+    resolution:
+      {
+        integrity: sha512-XyroGQXcHrZdvmrGJvsA9KNeOOgGMg1Vg9OlheUsBOSKznLMDl+YChxbkboRHvtFYJEMRYmlV3uoo/njCw05iw==,
+      }
+    engines: { node: '>=16' }
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
-    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
+    resolution:
+      {
+        integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==,
+      }
     cpu: [arm64]
     os: [darwin]
 
   '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
-    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
+    resolution:
+      {
+        integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==,
+      }
     cpu: [x64]
     os: [darwin]
 
   '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
-    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
+    resolution:
+      {
+        integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==,
+      }
     cpu: [arm64]
     os: [linux]
 
   '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
-    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
+    resolution:
+      {
+        integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==,
+      }
     cpu: [arm]
     os: [linux]
 
   '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
-    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
+    resolution:
+      {
+        integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==,
+      }
     cpu: [x64]
     os: [linux]
 
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
-    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
+    resolution:
+      {
+        integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==,
+      }
     cpu: [x64]
     os: [win32]
 
   '@napi-rs/wasm-runtime@1.1.1':
-    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+    resolution:
+      {
+        integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==,
+      }
 
   '@noble/hashes@1.8.0':
-    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
-    engines: {node: ^14.21.3 || >=16}
+    resolution:
+      {
+        integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==,
+      }
+    engines: { node: ^14.21.3 || >=16 }
 
   '@nodelib/fs.scandir@2.1.5':
-    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==,
+      }
+    engines: { node: '>= 8' }
 
   '@nodelib/fs.stat@2.0.5':
-    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==,
+      }
+    engines: { node: '>= 8' }
 
   '@nodelib/fs.walk@1.2.8':
-    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==,
+      }
+    engines: { node: '>= 8' }
 
   '@oxc-resolver/binding-android-arm-eabi@11.19.1':
-    resolution: {integrity: sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg==}
+    resolution:
+      {
+        integrity: sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg==,
+      }
     cpu: [arm]
     os: [android]
 
   '@oxc-resolver/binding-android-arm64@11.19.1':
-    resolution: {integrity: sha512-oolbkRX+m7Pq2LNjr/kKgYeC7bRDMVTWPgxBGMjSpZi/+UskVo4jsMU3MLheZV55jL6c3rNelPl4oD60ggYmqA==}
+    resolution:
+      {
+        integrity: sha512-oolbkRX+m7Pq2LNjr/kKgYeC7bRDMVTWPgxBGMjSpZi/+UskVo4jsMU3MLheZV55jL6c3rNelPl4oD60ggYmqA==,
+      }
     cpu: [arm64]
     os: [android]
 
   '@oxc-resolver/binding-darwin-arm64@11.19.1':
-    resolution: {integrity: sha512-nUC6d2i3R5B12sUW4O646qD5cnMXf2oBGPLIIeaRfU9doJRORAbE2SGv4eW6rMqhD+G7nf2Y8TTJTLiiO3Q/dQ==}
+    resolution:
+      {
+        integrity: sha512-nUC6d2i3R5B12sUW4O646qD5cnMXf2oBGPLIIeaRfU9doJRORAbE2SGv4eW6rMqhD+G7nf2Y8TTJTLiiO3Q/dQ==,
+      }
     cpu: [arm64]
     os: [darwin]
 
   '@oxc-resolver/binding-darwin-x64@11.19.1':
-    resolution: {integrity: sha512-cV50vE5+uAgNcFa3QY1JOeKDSkM/9ReIcc/9wn4TavhW/itkDGrXhw9jaKnkQnGbjJ198Yh5nbX/Gr2mr4Z5jQ==}
+    resolution:
+      {
+        integrity: sha512-cV50vE5+uAgNcFa3QY1JOeKDSkM/9ReIcc/9wn4TavhW/itkDGrXhw9jaKnkQnGbjJ198Yh5nbX/Gr2mr4Z5jQ==,
+      }
     cpu: [x64]
     os: [darwin]
 
   '@oxc-resolver/binding-freebsd-x64@11.19.1':
-    resolution: {integrity: sha512-xZOQiYGFxtk48PBKff+Zwoym7ScPAIVp4c14lfLxizO2LTTTJe5sx9vQNGrBymrf/vatSPNMD4FgsaaRigPkqw==}
+    resolution:
+      {
+        integrity: sha512-xZOQiYGFxtk48PBKff+Zwoym7ScPAIVp4c14lfLxizO2LTTTJe5sx9vQNGrBymrf/vatSPNMD4FgsaaRigPkqw==,
+      }
     cpu: [x64]
     os: [freebsd]
 
   '@oxc-resolver/binding-linux-arm-gnueabihf@11.19.1':
-    resolution: {integrity: sha512-lXZYWAC6kaGe/ky2su94e9jN9t6M0/6c+GrSlCqL//XO1cxi5lpAhnJYdyrKfm0ZEr/c7RNyAx3P7FSBcBd5+A==}
+    resolution:
+      {
+        integrity: sha512-lXZYWAC6kaGe/ky2su94e9jN9t6M0/6c+GrSlCqL//XO1cxi5lpAhnJYdyrKfm0ZEr/c7RNyAx3P7FSBcBd5+A==,
+      }
     cpu: [arm]
     os: [linux]
 
   '@oxc-resolver/binding-linux-arm-musleabihf@11.19.1':
-    resolution: {integrity: sha512-veG1kKsuK5+t2IsO9q0DErYVSw2azvCVvWHnfTOS73WE0STdLLB7Q1bB9WR+yHPQM76ASkFyRbogWo1GR1+WbQ==}
+    resolution:
+      {
+        integrity: sha512-veG1kKsuK5+t2IsO9q0DErYVSw2azvCVvWHnfTOS73WE0STdLLB7Q1bB9WR+yHPQM76ASkFyRbogWo1GR1+WbQ==,
+      }
     cpu: [arm]
     os: [linux]
 
   '@oxc-resolver/binding-linux-arm64-gnu@11.19.1':
-    resolution: {integrity: sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==}
+    resolution:
+      {
+        integrity: sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==,
+      }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
-    resolution: {integrity: sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==}
+    resolution:
+      {
+        integrity: sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==,
+      }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
-    resolution: {integrity: sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==}
+    resolution:
+      {
+        integrity: sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==,
+      }
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
-    resolution: {integrity: sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==}
+    resolution:
+      {
+        integrity: sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==,
+      }
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
-    resolution: {integrity: sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==}
+    resolution:
+      {
+        integrity: sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==,
+      }
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
-    resolution: {integrity: sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==}
+    resolution:
+      {
+        integrity: sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==,
+      }
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
-    resolution: {integrity: sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==}
+    resolution:
+      {
+        integrity: sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==,
+      }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.19.1':
-    resolution: {integrity: sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==}
+    resolution:
+      {
+        integrity: sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==,
+      }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
-    resolution: {integrity: sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==}
+    resolution:
+      {
+        integrity: sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==,
+      }
     cpu: [arm64]
     os: [openharmony]
 
   '@oxc-resolver/binding-wasm32-wasi@11.19.1':
-    resolution: {integrity: sha512-w8UCKhX826cP/ZLokXDS6+milN8y4X7zidsAttEdWlVoamTNf6lhBJldaWr3ukTDiye7s4HRcuPEPOXNC432Vg==}
-    engines: {node: '>=14.0.0'}
+    resolution:
+      {
+        integrity: sha512-w8UCKhX826cP/ZLokXDS6+milN8y4X7zidsAttEdWlVoamTNf6lhBJldaWr3ukTDiye7s4HRcuPEPOXNC432Vg==,
+      }
+    engines: { node: '>=14.0.0' }
     cpu: [wasm32]
 
   '@oxc-resolver/binding-win32-arm64-msvc@11.19.1':
-    resolution: {integrity: sha512-nJ4AsUVZrVKwnU/QRdzPCCrO0TrabBqgJ8pJhXITdZGYOV28TIYystV1VFLbQ7DtAcaBHpocT5/ZJnF78YJPtQ==}
+    resolution:
+      {
+        integrity: sha512-nJ4AsUVZrVKwnU/QRdzPCCrO0TrabBqgJ8pJhXITdZGYOV28TIYystV1VFLbQ7DtAcaBHpocT5/ZJnF78YJPtQ==,
+      }
     cpu: [arm64]
     os: [win32]
 
   '@oxc-resolver/binding-win32-ia32-msvc@11.19.1':
-    resolution: {integrity: sha512-EW+ND5q2Tl+a3pH81l1QbfgbF3HmqgwLfDfVithRFheac8OTcnbXt/JxqD2GbDkb7xYEqy1zNaVFRr3oeG8npA==}
+    resolution:
+      {
+        integrity: sha512-EW+ND5q2Tl+a3pH81l1QbfgbF3HmqgwLfDfVithRFheac8OTcnbXt/JxqD2GbDkb7xYEqy1zNaVFRr3oeG8npA==,
+      }
     cpu: [ia32]
     os: [win32]
 
   '@oxc-resolver/binding-win32-x64-msvc@11.19.1':
-    resolution: {integrity: sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw==}
+    resolution:
+      {
+        integrity: sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw==,
+      }
     cpu: [x64]
     os: [win32]
 
   '@paralleldrive/cuid2@2.3.1':
-    resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
+    resolution:
+      {
+        integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==,
+      }
 
   '@pinojs/redact@0.4.0':
-    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+    resolution:
+      {
+        integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==,
+      }
 
   '@prisma/adapter-pg@7.4.2':
-    resolution: {integrity: sha512-oUo2Zhe9Tf6YwVL8kLPuOLTK1Z2pwi/Ua77t2PuGyBan2w7shRKqHvYK+3XXmRH9RWhPJ4SMtHZKpNo6Ax/4bQ==}
+    resolution:
+      {
+        integrity: sha512-oUo2Zhe9Tf6YwVL8kLPuOLTK1Z2pwi/Ua77t2PuGyBan2w7shRKqHvYK+3XXmRH9RWhPJ4SMtHZKpNo6Ax/4bQ==,
+      }
 
   '@prisma/client-runtime-utils@7.4.2':
-    resolution: {integrity: sha512-cID+rzOEb38VyMsx5LwJMEY4NGIrWCNpKu/0ImbeooQ2Px7TI+kOt7cm0NelxUzF2V41UVVXAmYjANZQtCu1/Q==}
+    resolution:
+      {
+        integrity: sha512-cID+rzOEb38VyMsx5LwJMEY4NGIrWCNpKu/0ImbeooQ2Px7TI+kOt7cm0NelxUzF2V41UVVXAmYjANZQtCu1/Q==,
+      }
 
   '@prisma/client@7.4.2':
-    resolution: {integrity: sha512-ts2mu+cQHriAhSxngO3StcYubBGTWDtu/4juZhXCUKOwgh26l+s4KD3vT2kMUzFyrYnll9u/3qWrtzRv9CGWzA==}
-    engines: {node: ^20.19 || ^22.12 || >=24.0}
+    resolution:
+      {
+        integrity: sha512-ts2mu+cQHriAhSxngO3StcYubBGTWDtu/4juZhXCUKOwgh26l+s4KD3vT2kMUzFyrYnll9u/3qWrtzRv9CGWzA==,
+      }
+    engines: { node: ^20.19 || ^22.12 || >=24.0 }
     peerDependencies:
       prisma: '*'
       typescript: '>=5.4.0'
@@ -1498,87 +2132,162 @@ packages:
         optional: true
 
   '@prisma/config@7.4.2':
-    resolution: {integrity: sha512-CftBjWxav99lzY1Z4oDgomdb1gh9BJFAOmWF6P2v1xRfXqQb56DfBub+QKcERRdNoAzCb3HXy3Zii8Vb4AsXhg==}
+    resolution:
+      {
+        integrity: sha512-CftBjWxav99lzY1Z4oDgomdb1gh9BJFAOmWF6P2v1xRfXqQb56DfBub+QKcERRdNoAzCb3HXy3Zii8Vb4AsXhg==,
+      }
 
   '@prisma/debug@7.2.0':
-    resolution: {integrity: sha512-YSGTiSlBAVJPzX4ONZmMotL+ozJwQjRmZweQNIq/ER0tQJKJynNkRB3kyvt37eOfsbMCXk3gnLF6J9OJ4QWftw==}
+    resolution:
+      {
+        integrity: sha512-YSGTiSlBAVJPzX4ONZmMotL+ozJwQjRmZweQNIq/ER0tQJKJynNkRB3kyvt37eOfsbMCXk3gnLF6J9OJ4QWftw==,
+      }
 
   '@prisma/debug@7.4.2':
-    resolution: {integrity: sha512-aP7qzu+g/JnbF6U69LMwHoUkELiserKmWsE2shYuEpNUJ4GrtxBCvZwCyCBHFSH2kLTF2l1goBlBh4wuvRq62w==}
+    resolution:
+      {
+        integrity: sha512-aP7qzu+g/JnbF6U69LMwHoUkELiserKmWsE2shYuEpNUJ4GrtxBCvZwCyCBHFSH2kLTF2l1goBlBh4wuvRq62w==,
+      }
 
   '@prisma/dev@0.20.0':
-    resolution: {integrity: sha512-ovlBYwWor0OzG+yH4J3Ot+AneD818BttLA+Ii7wjbcLHUrnC4tbUPVGyNd3c/+71KETPKZfjhkTSpdS15dmXNQ==}
+    resolution:
+      {
+        integrity: sha512-ovlBYwWor0OzG+yH4J3Ot+AneD818BttLA+Ii7wjbcLHUrnC4tbUPVGyNd3c/+71KETPKZfjhkTSpdS15dmXNQ==,
+      }
 
   '@prisma/driver-adapter-utils@7.2.0':
-    resolution: {integrity: sha512-gzrUcbI9VmHS24Uf+0+7DNzdIw7keglJsD5m/MHxQOU68OhGVzlphQRobLiDMn8CHNA2XN8uugwKjudVtnfMVQ==}
+    resolution:
+      {
+        integrity: sha512-gzrUcbI9VmHS24Uf+0+7DNzdIw7keglJsD5m/MHxQOU68OhGVzlphQRobLiDMn8CHNA2XN8uugwKjudVtnfMVQ==,
+      }
 
   '@prisma/driver-adapter-utils@7.4.2':
-    resolution: {integrity: sha512-REdjFpT/ye9KdDs+CXAXPIbMQkVLhne9G5Pe97sNY4Ovx4r2DAbWM9hOFvvB1Oq8H8bOCdu0Ri3AoGALquQqVw==}
+    resolution:
+      {
+        integrity: sha512-REdjFpT/ye9KdDs+CXAXPIbMQkVLhne9G5Pe97sNY4Ovx4r2DAbWM9hOFvvB1Oq8H8bOCdu0Ri3AoGALquQqVw==,
+      }
 
   '@prisma/engines-version@7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919':
-    resolution: {integrity: sha512-5FIKY3KoYQlBuZC2yc16EXfVRQ8HY+fLqgxkYfWCtKhRb3ajCRzP/rPeoSx11+NueJDANdh4hjY36mdmrTcGSg==}
+    resolution:
+      {
+        integrity: sha512-5FIKY3KoYQlBuZC2yc16EXfVRQ8HY+fLqgxkYfWCtKhRb3ajCRzP/rPeoSx11+NueJDANdh4hjY36mdmrTcGSg==,
+      }
 
   '@prisma/engines@7.4.2':
-    resolution: {integrity: sha512-B+ZZhI4rXlzjVqRw/93AothEKOU5/x4oVyJFGo9RpHPnBwaPwk4Pi0Q4iGXipKxeXPs/dqljgNBjK0m8nocOJA==}
+    resolution:
+      {
+        integrity: sha512-B+ZZhI4rXlzjVqRw/93AothEKOU5/x4oVyJFGo9RpHPnBwaPwk4Pi0Q4iGXipKxeXPs/dqljgNBjK0m8nocOJA==,
+      }
 
   '@prisma/fetch-engine@7.4.2':
-    resolution: {integrity: sha512-f/c/MwYpdJO7taLETU8rahEstLeXfYgQGlz5fycG7Fbmva3iPdzGmjiSWHeSWIgNnlXnelUdCJqyZnFocurZuA==}
+    resolution:
+      {
+        integrity: sha512-f/c/MwYpdJO7taLETU8rahEstLeXfYgQGlz5fycG7Fbmva3iPdzGmjiSWHeSWIgNnlXnelUdCJqyZnFocurZuA==,
+      }
 
   '@prisma/get-platform@7.2.0':
-    resolution: {integrity: sha512-k1V0l0Td1732EHpAfi2eySTezyllok9dXb6UQanajkJQzPUGi3vO2z7jdkz67SypFTdmbnyGYxvEvYZdZsMAVA==}
+    resolution:
+      {
+        integrity: sha512-k1V0l0Td1732EHpAfi2eySTezyllok9dXb6UQanajkJQzPUGi3vO2z7jdkz67SypFTdmbnyGYxvEvYZdZsMAVA==,
+      }
 
   '@prisma/get-platform@7.4.2':
-    resolution: {integrity: sha512-UTnChXRwiauzl/8wT4hhe7Xmixja9WE28oCnGpBtRejaHhvekx5kudr3R4Y9mLSA0kqGnAMeyTiKwDVMjaEVsw==}
+    resolution:
+      {
+        integrity: sha512-UTnChXRwiauzl/8wT4hhe7Xmixja9WE28oCnGpBtRejaHhvekx5kudr3R4Y9mLSA0kqGnAMeyTiKwDVMjaEVsw==,
+      }
 
   '@prisma/query-plan-executor@7.2.0':
-    resolution: {integrity: sha512-EOZmNzcV8uJ0mae3DhTsiHgoNCuu1J9mULQpGCh62zN3PxPTd+qI9tJvk5jOst8WHKQNwJWR3b39t0XvfBB0WQ==}
+    resolution:
+      {
+        integrity: sha512-EOZmNzcV8uJ0mae3DhTsiHgoNCuu1J9mULQpGCh62zN3PxPTd+qI9tJvk5jOst8WHKQNwJWR3b39t0XvfBB0WQ==,
+      }
 
   '@prisma/studio-core@0.13.1':
-    resolution: {integrity: sha512-agdqaPEePRHcQ7CexEfkX1RvSH9uWDb6pXrZnhCRykhDFAV0/0P3d07WtfiY8hZWb7oRU4v+NkT4cGFHkQJIPg==}
+    resolution:
+      {
+        integrity: sha512-agdqaPEePRHcQ7CexEfkX1RvSH9uWDb6pXrZnhCRykhDFAV0/0P3d07WtfiY8hZWb7oRU4v+NkT4cGFHkQJIPg==,
+      }
     peerDependencies:
       '@types/react': ^18.0.0 || ^19.0.0
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
   '@protobufjs/aspromise@1.1.2':
-    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+    resolution:
+      {
+        integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==,
+      }
 
   '@protobufjs/base64@1.1.2':
-    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+    resolution:
+      {
+        integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==,
+      }
 
   '@protobufjs/codegen@2.0.4':
-    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+    resolution:
+      {
+        integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==,
+      }
 
   '@protobufjs/eventemitter@1.1.0':
-    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+    resolution:
+      {
+        integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==,
+      }
 
   '@protobufjs/fetch@1.1.0':
-    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+    resolution:
+      {
+        integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==,
+      }
 
   '@protobufjs/float@1.0.2':
-    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+    resolution:
+      {
+        integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==,
+      }
 
   '@protobufjs/inquire@1.1.0':
-    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+    resolution:
+      {
+        integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==,
+      }
 
   '@protobufjs/path@1.1.2':
-    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+    resolution:
+      {
+        integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==,
+      }
 
   '@protobufjs/pool@1.1.0':
-    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+    resolution:
+      {
+        integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==,
+      }
 
   '@protobufjs/utf8@1.1.0':
-    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+    resolution:
+      {
+        integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==,
+      }
 
   '@redis/bloom@5.11.0':
-    resolution: {integrity: sha512-KYiVilAhAFN3057afUb/tfYJpsEyTkQB+tQcn5gVVA7DgcNOAj8lLxe4j8ov8BF6I9C1Fe/kwlbuAICcTMX8Lw==}
-    engines: {node: '>= 18'}
+    resolution:
+      {
+        integrity: sha512-KYiVilAhAFN3057afUb/tfYJpsEyTkQB+tQcn5gVVA7DgcNOAj8lLxe4j8ov8BF6I9C1Fe/kwlbuAICcTMX8Lw==,
+      }
+    engines: { node: '>= 18' }
     peerDependencies:
       '@redis/client': ^5.11.0
 
   '@redis/client@5.11.0':
-    resolution: {integrity: sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==}
-    engines: {node: '>= 18'}
+    resolution:
+      {
+        integrity: sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==,
+      }
+    engines: { node: '>= 18' }
     peerDependencies:
       '@node-rs/xxhash': ^1.1.0
     peerDependenciesMeta:
@@ -1586,385 +2295,652 @@ packages:
         optional: true
 
   '@redis/json@5.11.0':
-    resolution: {integrity: sha512-1iAy9kAtcD0quB21RbPTbUqqy+T2Uu2JxucwE+B4A+VaDbIRvpZR6DMqV8Iqaws2YxJYB3GC5JVNzPYio2ErUg==}
-    engines: {node: '>= 18'}
+    resolution:
+      {
+        integrity: sha512-1iAy9kAtcD0quB21RbPTbUqqy+T2Uu2JxucwE+B4A+VaDbIRvpZR6DMqV8Iqaws2YxJYB3GC5JVNzPYio2ErUg==,
+      }
+    engines: { node: '>= 18' }
     peerDependencies:
       '@redis/client': ^5.11.0
 
   '@redis/search@5.11.0':
-    resolution: {integrity: sha512-g1l7f3Rnyk/xI99oGHIgWHSKFl45Re5YTIcO8j/JE8olz389yUFyz2+A6nqVy/Zi031VgPDWscbbgOk8hlhZ3g==}
-    engines: {node: '>= 18'}
+    resolution:
+      {
+        integrity: sha512-g1l7f3Rnyk/xI99oGHIgWHSKFl45Re5YTIcO8j/JE8olz389yUFyz2+A6nqVy/Zi031VgPDWscbbgOk8hlhZ3g==,
+      }
+    engines: { node: '>= 18' }
     peerDependencies:
       '@redis/client': ^5.11.0
 
   '@redis/time-series@5.11.0':
-    resolution: {integrity: sha512-TWFeOcU4xkj0DkndnOyhtxvX1KWD+78UHT3XX3x3XRBUGWeQrKo3jqzDsZwxbggUgf9yLJr/akFHXru66X5UQA==}
-    engines: {node: '>= 18'}
+    resolution:
+      {
+        integrity: sha512-TWFeOcU4xkj0DkndnOyhtxvX1KWD+78UHT3XX3x3XRBUGWeQrKo3jqzDsZwxbggUgf9yLJr/akFHXru66X5UQA==,
+      }
+    engines: { node: '>= 18' }
     peerDependencies:
       '@redis/client': ^5.11.0
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
-    resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
+    resolution:
+      {
+        integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==,
+      }
     cpu: [arm]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.59.0':
-    resolution: {integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==}
+    resolution:
+      {
+        integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==,
+      }
     cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-darwin-arm64@4.59.0':
-    resolution: {integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==}
+    resolution:
+      {
+        integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==,
+      }
     cpu: [arm64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.59.0':
-    resolution: {integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==}
+    resolution:
+      {
+        integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==,
+      }
     cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-freebsd-arm64@4.59.0':
-    resolution: {integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==}
+    resolution:
+      {
+        integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==,
+      }
     cpu: [arm64]
     os: [freebsd]
 
   '@rollup/rollup-freebsd-x64@4.59.0':
-    resolution: {integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==}
+    resolution:
+      {
+        integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==,
+      }
     cpu: [x64]
     os: [freebsd]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
-    resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
+    resolution:
+      {
+        integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==,
+      }
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
-    resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
+    resolution:
+      {
+        integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==,
+      }
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
-    resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
+    resolution:
+      {
+        integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==,
+      }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
-    resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
+    resolution:
+      {
+        integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==,
+      }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
-    resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
+    resolution:
+      {
+        integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==,
+      }
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
-    resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
+    resolution:
+      {
+        integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==,
+      }
     cpu: [loong64]
     os: [linux]
     libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
-    resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
+    resolution:
+      {
+        integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==,
+      }
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
-    resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
+    resolution:
+      {
+        integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==,
+      }
     cpu: [ppc64]
     os: [linux]
     libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
-    resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
+    resolution:
+      {
+        integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==,
+      }
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
-    resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
+    resolution:
+      {
+        integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==,
+      }
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
-    resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
+    resolution:
+      {
+        integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==,
+      }
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
-    resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
+    resolution:
+      {
+        integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==,
+      }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
-    resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
+    resolution:
+      {
+        integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==,
+      }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
-    resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
+    resolution:
+      {
+        integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==,
+      }
     cpu: [x64]
     os: [openbsd]
 
   '@rollup/rollup-openharmony-arm64@4.59.0':
-    resolution: {integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==}
+    resolution:
+      {
+        integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==,
+      }
     cpu: [arm64]
     os: [openharmony]
 
   '@rollup/rollup-win32-arm64-msvc@4.59.0':
-    resolution: {integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==}
+    resolution:
+      {
+        integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==,
+      }
     cpu: [arm64]
     os: [win32]
 
   '@rollup/rollup-win32-ia32-msvc@4.59.0':
-    resolution: {integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==}
+    resolution:
+      {
+        integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==,
+      }
     cpu: [ia32]
     os: [win32]
 
   '@rollup/rollup-win32-x64-gnu@4.59.0':
-    resolution: {integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==}
+    resolution:
+      {
+        integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==,
+      }
     cpu: [x64]
     os: [win32]
 
   '@rollup/rollup-win32-x64-msvc@4.59.0':
-    resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
+    resolution:
+      {
+        integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==,
+      }
     cpu: [x64]
     os: [win32]
 
   '@sapphire/async-queue@1.5.5':
-    resolution: {integrity: sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==}
-    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+    resolution:
+      {
+        integrity: sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==,
+      }
+    engines: { node: '>=v14.0.0', npm: '>=7.0.0' }
 
   '@sapphire/shapeshift@4.0.0':
-    resolution: {integrity: sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==}
-    engines: {node: '>=v16'}
+    resolution:
+      {
+        integrity: sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==,
+      }
+    engines: { node: '>=v16' }
 
   '@sapphire/snowflake@3.5.3':
-    resolution: {integrity: sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==}
-    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+    resolution:
+      {
+        integrity: sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==,
+      }
+    engines: { node: '>=v14.0.0', npm: '>=7.0.0' }
 
   '@secretlint/config-creator@11.3.1':
-    resolution: {integrity: sha512-CwMipj6jAVbyMF6OIzABlFcmJNcVB3RNUq3df5LGf9442T0p2f07sTNbGR8a3PfLww73/0rgPTw6lZjmHFpQLA==}
-    engines: {node: '>=20.0.0'}
+    resolution:
+      {
+        integrity: sha512-CwMipj6jAVbyMF6OIzABlFcmJNcVB3RNUq3df5LGf9442T0p2f07sTNbGR8a3PfLww73/0rgPTw6lZjmHFpQLA==,
+      }
+    engines: { node: '>=20.0.0' }
 
   '@secretlint/config-loader@11.3.1':
-    resolution: {integrity: sha512-WPB3tLebNjd6nkRwWf9l6DHc7gr74J9wAneLxsg1bYZrcAsw/gU0D3SeLtqgHwQUyyvt3vLRKKrTHe1mw7i4YQ==}
-    engines: {node: '>=20.0.0'}
+    resolution:
+      {
+        integrity: sha512-WPB3tLebNjd6nkRwWf9l6DHc7gr74J9wAneLxsg1bYZrcAsw/gU0D3SeLtqgHwQUyyvt3vLRKKrTHe1mw7i4YQ==,
+      }
+    engines: { node: '>=20.0.0' }
 
   '@secretlint/core@11.3.1':
-    resolution: {integrity: sha512-iGPtWlBI0J17Exe92JztsxyvjYroMg89B6Qw8Rf2fhRb2CBlo6BO1V32Y6TDMCXpqwof9NkBXEiOIIeSgCRLKw==}
-    engines: {node: '>=20.0.0'}
+    resolution:
+      {
+        integrity: sha512-iGPtWlBI0J17Exe92JztsxyvjYroMg89B6Qw8Rf2fhRb2CBlo6BO1V32Y6TDMCXpqwof9NkBXEiOIIeSgCRLKw==,
+      }
+    engines: { node: '>=20.0.0' }
 
   '@secretlint/formatter@11.3.1':
-    resolution: {integrity: sha512-dHFHXHkTSfWYCQx2Q2+DJPMl6zZemny5mKRApy/zebzI9fKV3E2rgzry1rZxQnSx7vng5l9/kRNVLAnKT3RWrA==}
-    engines: {node: '>=20.0.0'}
+    resolution:
+      {
+        integrity: sha512-dHFHXHkTSfWYCQx2Q2+DJPMl6zZemny5mKRApy/zebzI9fKV3E2rgzry1rZxQnSx7vng5l9/kRNVLAnKT3RWrA==,
+      }
+    engines: { node: '>=20.0.0' }
 
   '@secretlint/node@11.3.1':
-    resolution: {integrity: sha512-BMP7XlfPjp85pYf9r2uBd21ZfVmCK4PFaRsfIun6XjkbbCRgksV4yb9HV424oVkL5D4RgImPDZANOdH1TniA8g==}
-    engines: {node: '>=20.0.0'}
+    resolution:
+      {
+        integrity: sha512-BMP7XlfPjp85pYf9r2uBd21ZfVmCK4PFaRsfIun6XjkbbCRgksV4yb9HV424oVkL5D4RgImPDZANOdH1TniA8g==,
+      }
+    engines: { node: '>=20.0.0' }
 
   '@secretlint/profiler@11.3.1':
-    resolution: {integrity: sha512-V7Qyzs++M9Z2Ox1wCMaYMGmdGpZxQcie0FjnFIS8y68sKK1n7LmJJ+uGNegWobx1KZOYnRxhefOm9gbq1Td+GQ==}
+    resolution:
+      {
+        integrity: sha512-V7Qyzs++M9Z2Ox1wCMaYMGmdGpZxQcie0FjnFIS8y68sKK1n7LmJJ+uGNegWobx1KZOYnRxhefOm9gbq1Td+GQ==,
+      }
 
   '@secretlint/resolver@11.3.1':
-    resolution: {integrity: sha512-+bGKntF0wXyPyhFe4wxPk3mxKLHE0sQVeF4FwOH2uFKUzXZJxF9NwISYWAmCzyzAxZbjBDjcpJAEtB2492ohbg==}
+    resolution:
+      {
+        integrity: sha512-+bGKntF0wXyPyhFe4wxPk3mxKLHE0sQVeF4FwOH2uFKUzXZJxF9NwISYWAmCzyzAxZbjBDjcpJAEtB2492ohbg==,
+      }
 
   '@secretlint/secretlint-rule-preset-recommend@11.3.1':
-    resolution: {integrity: sha512-zRkESw8Mhuh4J65+biFKkpTW8Gjpse+D4BZhznASCtge38ervYcuG3IgHvFLf1AbTM+YQdH5wRVNdU0+btaEBw==}
-    engines: {node: '>=20.0.0'}
+    resolution:
+      {
+        integrity: sha512-zRkESw8Mhuh4J65+biFKkpTW8Gjpse+D4BZhznASCtge38ervYcuG3IgHvFLf1AbTM+YQdH5wRVNdU0+btaEBw==,
+      }
+    engines: { node: '>=20.0.0' }
 
   '@secretlint/source-creator@11.3.1':
-    resolution: {integrity: sha512-Y0AAUawmoP+94ot3lZmXyHOmw1FJvgcCV9Yvy/9ynjsvwVEojea4in4zA06V8uZtBtTaNXqFZ7v+rt3ytoa07A==}
-    engines: {node: '>=20.0.0'}
+    resolution:
+      {
+        integrity: sha512-Y0AAUawmoP+94ot3lZmXyHOmw1FJvgcCV9Yvy/9ynjsvwVEojea4in4zA06V8uZtBtTaNXqFZ7v+rt3ytoa07A==,
+      }
+    engines: { node: '>=20.0.0' }
 
   '@secretlint/types@11.3.1':
-    resolution: {integrity: sha512-6PU7JLivE6Swavrw1TxiPVbvk1Nafihm+v6hNpsEAt7raLlazoFXFK/O8YeSEK15u+4oofSBqwipy81HAbLnlg==}
-    engines: {node: '>=20.0.0'}
+    resolution:
+      {
+        integrity: sha512-6PU7JLivE6Swavrw1TxiPVbvk1Nafihm+v6hNpsEAt7raLlazoFXFK/O8YeSEK15u+4oofSBqwipy81HAbLnlg==,
+      }
+    engines: { node: '>=20.0.0' }
 
   '@simple-libs/stream-utils@1.2.0':
-    resolution: {integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==,
+      }
+    engines: { node: '>=18' }
 
   '@sindresorhus/merge-streams@2.3.0':
-    resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==,
+      }
+    engines: { node: '>=18' }
 
   '@standard-schema/spec@1.1.0':
-    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+    resolution:
+      {
+        integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
+      }
 
   '@textlint/ast-node-types@15.5.1':
-    resolution: {integrity: sha512-2ABQSaQoM9u9fycXLJKcCv4XQulJWTUSwjo6F0i/ujjqOH8/AZ2A0RDKKbAddqxDhuabVB20lYoEsZZgzehccg==}
+    resolution:
+      {
+        integrity: sha512-2ABQSaQoM9u9fycXLJKcCv4XQulJWTUSwjo6F0i/ujjqOH8/AZ2A0RDKKbAddqxDhuabVB20lYoEsZZgzehccg==,
+      }
 
   '@textlint/linter-formatter@15.5.1':
-    resolution: {integrity: sha512-7wfzpcQtk7TZ3UJO2deTI71mJCm4VvPGUmSwE4iuH6FoaxpdWpwSBiMLcZtjYrt/oIFOtNz0uf5rI+xJiHTFww==}
+    resolution:
+      {
+        integrity: sha512-7wfzpcQtk7TZ3UJO2deTI71mJCm4VvPGUmSwE4iuH6FoaxpdWpwSBiMLcZtjYrt/oIFOtNz0uf5rI+xJiHTFww==,
+      }
 
   '@textlint/module-interop@15.5.1':
-    resolution: {integrity: sha512-Y1jcFGCKNSmHxwsLO3mshOfLYX4Wavq2+w5BG6x5lGgZv0XrF1xxURRhbnhns4LzCu0fAcx6W+3V8/1bkyTZCw==}
+    resolution:
+      {
+        integrity: sha512-Y1jcFGCKNSmHxwsLO3mshOfLYX4Wavq2+w5BG6x5lGgZv0XrF1xxURRhbnhns4LzCu0fAcx6W+3V8/1bkyTZCw==,
+      }
 
   '@textlint/resolver@15.5.1':
-    resolution: {integrity: sha512-CVHxMIm8iNGccqM12CQ/ycvh+HjJId4RyC6as5ynCcp2E1Uy1TCe0jBWOpmLsbT4Nx15Ke29BmspyByawuIRyA==}
+    resolution:
+      {
+        integrity: sha512-CVHxMIm8iNGccqM12CQ/ycvh+HjJId4RyC6as5ynCcp2E1Uy1TCe0jBWOpmLsbT4Nx15Ke29BmspyByawuIRyA==,
+      }
 
   '@textlint/types@15.5.1':
-    resolution: {integrity: sha512-IY1OVZZk8LOOrbapYCsaeH7XSJT89HVukixDT8CoiWMrKGCTCZ3/Kzoa3DtMMbY8jtY777QmPOVCNnR+8fF6YQ==}
+    resolution:
+      {
+        integrity: sha512-IY1OVZZk8LOOrbapYCsaeH7XSJT89HVukixDT8CoiWMrKGCTCZ3/Kzoa3DtMMbY8jtY777QmPOVCNnR+8fF6YQ==,
+      }
 
   '@ts-morph/common@0.28.1':
-    resolution: {integrity: sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==}
+    resolution:
+      {
+        integrity: sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==,
+      }
 
   '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+    resolution:
+      {
+        integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==,
+      }
 
   '@types/body-parser@1.19.6':
-    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+    resolution:
+      {
+        integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==,
+      }
 
   '@types/chai@5.2.3':
-    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+    resolution:
+      {
+        integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==,
+      }
 
   '@types/connect@3.4.38':
-    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+    resolution:
+      {
+        integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==,
+      }
 
   '@types/cookiejar@2.1.5':
-    resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
+    resolution:
+      {
+        integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==,
+      }
 
   '@types/deep-eql@4.0.2':
-    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+    resolution:
+      {
+        integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==,
+      }
 
   '@types/eslint@9.6.1':
-    resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
+    resolution:
+      {
+        integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==,
+      }
 
   '@types/esrecurse@4.3.1':
-    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+    resolution:
+      {
+        integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==,
+      }
 
   '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+    resolution:
+      {
+        integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
+      }
 
   '@types/express-serve-static-core@5.1.1':
-    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+    resolution:
+      {
+        integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==,
+      }
 
   '@types/express@5.0.6':
-    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+    resolution:
+      {
+        integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==,
+      }
 
   '@types/http-errors@2.0.5':
-    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+    resolution:
+      {
+        integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==,
+      }
 
   '@types/json-schema@7.0.15':
-    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+    resolution:
+      {
+        integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==,
+      }
 
   '@types/methods@1.1.4':
-    resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
+    resolution:
+      {
+        integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==,
+      }
 
   '@types/node@12.20.55':
-    resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+    resolution:
+      {
+        integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==,
+      }
 
   '@types/node@25.3.5':
-    resolution: {integrity: sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==}
+    resolution:
+      {
+        integrity: sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==,
+      }
 
   '@types/normalize-package-data@2.4.4':
-    resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+    resolution:
+      {
+        integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==,
+      }
 
   '@types/pg@8.18.0':
-    resolution: {integrity: sha512-gT+oueVQkqnj6ajGJXblFR4iavIXWsGAFCk3dP4Kki5+a9R4NMt0JARdk6s8cUKcfUoqP5dAtDSLU8xYUTFV+Q==}
+    resolution:
+      {
+        integrity: sha512-gT+oueVQkqnj6ajGJXblFR4iavIXWsGAFCk3dP4Kki5+a9R4NMt0JARdk6s8cUKcfUoqP5dAtDSLU8xYUTFV+Q==,
+      }
 
   '@types/qs@6.14.0':
-    resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
+    resolution:
+      {
+        integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==,
+      }
 
   '@types/range-parser@1.2.7':
-    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+    resolution:
+      {
+        integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==,
+      }
 
   '@types/react@19.2.7':
-    resolution: {integrity: sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==}
+    resolution:
+      {
+        integrity: sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==,
+      }
 
   '@types/sarif@2.1.7':
-    resolution: {integrity: sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==}
+    resolution:
+      {
+        integrity: sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==,
+      }
 
   '@types/send@1.2.1':
-    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+    resolution:
+      {
+        integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==,
+      }
 
   '@types/serve-static@2.2.0':
-    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+    resolution:
+      {
+        integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==,
+      }
 
   '@types/superagent@8.1.9':
-    resolution: {integrity: sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==}
+    resolution:
+      {
+        integrity: sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==,
+      }
 
   '@types/supertest@7.2.0':
-    resolution: {integrity: sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==}
+    resolution:
+      {
+        integrity: sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==,
+      }
 
   '@types/uuid@10.0.0':
-    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
+    resolution:
+      {
+        integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==,
+      }
 
   '@types/ws@8.18.1':
-    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+    resolution:
+      {
+        integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==,
+      }
 
   '@typescript-eslint/eslint-plugin@8.57.0':
-    resolution: {integrity: sha512-qeu4rTHR3/IaFORbD16gmjq9+rEs9fGKdX0kF6BKSfi+gCuG3RCKLlSBYzn/bGsY9Tj7KE/DAQStbp8AHJGHEQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-qeu4rTHR3/IaFORbD16gmjq9+rEs9fGKdX0kF6BKSfi+gCuG3RCKLlSBYzn/bGsY9Tj7KE/DAQStbp8AHJGHEQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       '@typescript-eslint/parser': ^8.57.0
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/parser@8.57.0':
-    resolution: {integrity: sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/project-service@8.57.0':
-    resolution: {integrity: sha512-pR+dK0BlxCLxtWfaKQWtYr7MhKmzqZxuii+ZjuFlZlIGRZm22HnXFqa2eY+90MUz8/i80YJmzFGDUsi8dMOV5w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-pR+dK0BlxCLxtWfaKQWtYr7MhKmzqZxuii+ZjuFlZlIGRZm22HnXFqa2eY+90MUz8/i80YJmzFGDUsi8dMOV5w==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/scope-manager@8.57.0':
-    resolution: {integrity: sha512-nvExQqAHF01lUM66MskSaZulpPL5pgy5hI5RfrxviLgzZVffB5yYzw27uK/ft8QnKXI2X0LBrHJFr1TaZtAibw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-nvExQqAHF01lUM66MskSaZulpPL5pgy5hI5RfrxviLgzZVffB5yYzw27uK/ft8QnKXI2X0LBrHJFr1TaZtAibw==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   '@typescript-eslint/tsconfig-utils@8.57.0':
-    resolution: {integrity: sha512-LtXRihc5ytjJIQEH+xqjB0+YgsV4/tW35XKX3GTZHpWtcC8SPkT/d4tqdf1cKtesryHm2bgp6l555NYcT2NLvA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-LtXRihc5ytjJIQEH+xqjB0+YgsV4/tW35XKX3GTZHpWtcC8SPkT/d4tqdf1cKtesryHm2bgp6l555NYcT2NLvA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/type-utils@8.57.0':
-    resolution: {integrity: sha512-yjgh7gmDcJ1+TcEg8x3uWQmn8ifvSupnPfjP21twPKrDP/pTHlEQgmKcitzF/rzPSmv7QjJ90vRpN4U+zoUjwQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-yjgh7gmDcJ1+TcEg8x3uWQmn8ifvSupnPfjP21twPKrDP/pTHlEQgmKcitzF/rzPSmv7QjJ90vRpN4U+zoUjwQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/types@8.57.0':
-    resolution: {integrity: sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   '@typescript-eslint/typescript-estree@8.57.0':
-    resolution: {integrity: sha512-m7faHcyVg0BT3VdYTlX8GdJEM7COexXxS6KqGopxdtkQRvBanK377QDHr4W/vIPAR+ah9+B/RclSW5ldVniO1Q==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-m7faHcyVg0BT3VdYTlX8GdJEM7COexXxS6KqGopxdtkQRvBanK377QDHr4W/vIPAR+ah9+B/RclSW5ldVniO1Q==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/utils@8.57.0':
-    resolution: {integrity: sha512-5iIHvpD3CZe06riAsbNxxreP+MuYgVUsV0n4bwLH//VJmgtt54sQeY2GszntJ4BjYCpMzrfVh2SBnUQTtys2lQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-5iIHvpD3CZe06riAsbNxxreP+MuYgVUsV0n4bwLH//VJmgtt54sQeY2GszntJ4BjYCpMzrfVh2SBnUQTtys2lQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/visitor-keys@8.57.0':
-    resolution: {integrity: sha512-zm6xx8UT/Xy2oSr2ZXD0pZo7Jx2XsCoID2IUh9YSTFRu7z+WdwYTRk6LhUftm1crwqbuoF6I8zAFeCMw0YjwDg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-zm6xx8UT/Xy2oSr2ZXD0pZo7Jx2XsCoID2IUh9YSTFRu7z+WdwYTRk6LhUftm1crwqbuoF6I8zAFeCMw0YjwDg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   '@vitest/coverage-v8@4.0.18':
-    resolution: {integrity: sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==}
+    resolution:
+      {
+        integrity: sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==,
+      }
     peerDependencies:
       '@vitest/browser': 4.0.18
       vitest: 4.0.18
@@ -1973,10 +2949,16 @@ packages:
         optional: true
 
   '@vitest/expect@4.0.18':
-    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+    resolution:
+      {
+        integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==,
+      }
 
   '@vitest/mocker@4.0.18':
-    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
+    resolution:
+      {
+        integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==,
+      }
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0-0
@@ -1987,200 +2969,359 @@ packages:
         optional: true
 
   '@vitest/pretty-format@4.0.18':
-    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+    resolution:
+      {
+        integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==,
+      }
 
   '@vitest/runner@4.0.18':
-    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
+    resolution:
+      {
+        integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==,
+      }
 
   '@vitest/snapshot@4.0.18':
-    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
+    resolution:
+      {
+        integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==,
+      }
 
   '@vitest/spy@4.0.18':
-    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+    resolution:
+      {
+        integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==,
+      }
 
   '@vitest/utils@4.0.18':
-    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+    resolution:
+      {
+        integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==,
+      }
 
   '@vladfrangu/async_event_emitter@2.4.7':
-    resolution: {integrity: sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==}
-    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+    resolution:
+      {
+        integrity: sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==,
+      }
+    engines: { node: '>=v14.0.0', npm: '>=7.0.0' }
 
   accepts@2.0.0:
-    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==,
+      }
+    engines: { node: '>= 0.6' }
 
   acorn-jsx-walk@2.0.0:
-    resolution: {integrity: sha512-uuo6iJj4D4ygkdzd6jPtcxs8vZgDX9YFIkqczGImoypX2fQ4dVImmu3UzA4ynixCIMTrEOWW+95M2HuBaCEOVA==}
+    resolution:
+      {
+        integrity: sha512-uuo6iJj4D4ygkdzd6jPtcxs8vZgDX9YFIkqczGImoypX2fQ4dVImmu3UzA4ynixCIMTrEOWW+95M2HuBaCEOVA==,
+      }
 
   acorn-jsx@5.3.2:
-    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    resolution:
+      {
+        integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==,
+      }
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
   acorn-loose@8.5.2:
-    resolution: {integrity: sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==}
-    engines: {node: '>=0.4.0'}
+    resolution:
+      {
+        integrity: sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==,
+      }
+    engines: { node: '>=0.4.0' }
 
   acorn-walk@8.3.4:
-    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
-    engines: {node: '>=0.4.0'}
+    resolution:
+      {
+        integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==,
+      }
+    engines: { node: '>=0.4.0' }
 
   acorn@7.4.1:
-    resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
-    engines: {node: '>=0.4.0'}
+    resolution:
+      {
+        integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==,
+      }
+    engines: { node: '>=0.4.0' }
     hasBin: true
 
   acorn@8.15.0:
-    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
-    engines: {node: '>=0.4.0'}
+    resolution:
+      {
+        integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==,
+      }
+    engines: { node: '>=0.4.0' }
     hasBin: true
 
   acorn@8.16.0:
-    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
-    engines: {node: '>=0.4.0'}
+    resolution:
+      {
+        integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==,
+      }
+    engines: { node: '>=0.4.0' }
     hasBin: true
 
   adm-zip@0.5.16:
-    resolution: {integrity: sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==}
-    engines: {node: '>=12.0'}
+    resolution:
+      {
+        integrity: sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==,
+      }
+    engines: { node: '>=12.0' }
 
   ajv@6.14.0:
-    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+    resolution:
+      {
+        integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==,
+      }
 
   ajv@8.18.0:
-    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+    resolution:
+      {
+        integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==,
+      }
 
   ansi-colors@4.1.3:
-    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==,
+      }
+    engines: { node: '>=6' }
 
   ansi-escapes@7.2.0:
-    resolution: {integrity: sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==,
+      }
+    engines: { node: '>=18' }
 
   ansi-escapes@7.3.0:
-    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==,
+      }
+    engines: { node: '>=18' }
 
   ansi-regex@5.0.1:
-    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==,
+      }
+    engines: { node: '>=8' }
 
   ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==,
+      }
+    engines: { node: '>=12' }
 
   ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==,
+      }
+    engines: { node: '>=8' }
 
   ansi-styles@5.2.0:
-    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==,
+      }
+    engines: { node: '>=10' }
 
   ansi-styles@6.2.3:
-    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==,
+      }
+    engines: { node: '>=12' }
 
   argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+    resolution:
+      {
+        integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==,
+      }
 
   argparse@2.0.1:
-    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+    resolution:
+      {
+        integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==,
+      }
 
   array-ify@1.0.0:
-    resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
+    resolution:
+      {
+        integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==,
+      }
 
   array-union@2.1.0:
-    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==,
+      }
+    engines: { node: '>=8' }
 
   asap@2.0.6:
-    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+    resolution:
+      {
+        integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==,
+      }
 
   assert-never@1.4.0:
-    resolution: {integrity: sha512-5oJg84os6NMQNl27T9LnZkvvqzvAnHu03ShCnoj6bsJwS7L8AO4lf+C/XjK/nvzEqQB744moC6V128RucQd1jA==}
+    resolution:
+      {
+        integrity: sha512-5oJg84os6NMQNl27T9LnZkvvqzvAnHu03ShCnoj6bsJwS7L8AO4lf+C/XjK/nvzEqQB744moC6V128RucQd1jA==,
+      }
 
   assertion-error@2.0.1:
-    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==,
+      }
+    engines: { node: '>=12' }
 
   ast-v8-to-istanbul@0.3.11:
-    resolution: {integrity: sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==}
+    resolution:
+      {
+        integrity: sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==,
+      }
 
   astral-regex@2.0.0:
-    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==,
+      }
+    engines: { node: '>=8' }
 
   asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+    resolution:
+      {
+        integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==,
+      }
 
   atomic-sleep@1.0.0:
-    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
-    engines: {node: '>=8.0.0'}
+    resolution:
+      {
+        integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==,
+      }
+    engines: { node: '>=8.0.0' }
 
   aws-ssl-profiles@1.1.2:
-    resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
-    engines: {node: '>= 6.0.0'}
+    resolution:
+      {
+        integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==,
+      }
+    engines: { node: '>= 6.0.0' }
 
   babel-walk@3.0.0-canary-5:
-    resolution: {integrity: sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==}
-    engines: {node: '>= 10.0.0'}
+    resolution:
+      {
+        integrity: sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==,
+      }
+    engines: { node: '>= 10.0.0' }
 
   badgen@3.2.3:
-    resolution: {integrity: sha512-svDuwkc63E/z0ky3drpUppB83s/nlgDciH9m+STwwQoWyq7yCgew1qEfJ+9axkKdNq7MskByptWUN9j1PGMwFA==}
+    resolution:
+      {
+        integrity: sha512-svDuwkc63E/z0ky3drpUppB83s/nlgDciH9m+STwwQoWyq7yCgew1qEfJ+9axkKdNq7MskByptWUN9j1PGMwFA==,
+      }
 
   balanced-match@4.0.4:
-    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
-    engines: {node: 18 || 20 || >=22}
+    resolution:
+      {
+        integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==,
+      }
+    engines: { node: 18 || 20 || >=22 }
 
   base64-js@1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    resolution:
+      {
+        integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==,
+      }
 
   better-path-resolve@1.0.0:
-    resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==,
+      }
+    engines: { node: '>=4' }
 
   binaryextensions@6.11.0:
-    resolution: {integrity: sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==,
+      }
+    engines: { node: '>=4' }
 
   blamer@1.0.7:
-    resolution: {integrity: sha512-GbBStl/EVlSWkiJQBZps3H1iARBrC7vt++Jb/TTmCNu/jZ04VW7tSN1nScbFXBUy1AN+jzeL7Zep9sbQxLhXKA==}
-    engines: {node: '>=8.9'}
+    resolution:
+      {
+        integrity: sha512-GbBStl/EVlSWkiJQBZps3H1iARBrC7vt++Jb/TTmCNu/jZ04VW7tSN1nScbFXBUy1AN+jzeL7Zep9sbQxLhXKA==,
+      }
+    engines: { node: '>=8.9' }
 
   body-parser@2.2.2:
-    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==,
+      }
+    engines: { node: '>=18' }
 
   boolean@3.2.0:
-    resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
+    resolution:
+      {
+        integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==,
+      }
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   boundary@2.0.0:
-    resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
+    resolution:
+      {
+        integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==,
+      }
 
   brace-expansion@5.0.4:
-    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
-    engines: {node: 18 || 20 || >=22}
+    resolution:
+      {
+        integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==,
+      }
+    engines: { node: 18 || 20 || >=22 }
 
   braces@3.0.3:
-    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==,
+      }
+    engines: { node: '>=8' }
 
   builtin-modules@3.3.0:
-    resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==,
+      }
+    engines: { node: '>=6' }
 
   bullmq@5.70.4:
-    resolution: {integrity: sha512-S58YT/tGdhc4pEPcIahtZRBR1TcTLpss1UKiXimF+Vy4yZwF38pW2IvhHqs4j4dEbZqDt8oi0jGGN/WYQHbPDg==}
+    resolution:
+      {
+        integrity: sha512-S58YT/tGdhc4pEPcIahtZRBR1TcTLpss1UKiXimF+Vy4yZwF38pW2IvhHqs4j4dEbZqDt8oi0jGGN/WYQHbPDg==,
+      }
 
   bytes@3.1.2:
-    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==,
+      }
+    engines: { node: '>= 0.8' }
 
   c12@3.1.0:
-    resolution: {integrity: sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==}
+    resolution:
+      {
+        integrity: sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==,
+      }
     peerDependencies:
       magicast: ^0.3.5
     peerDependenciesMeta:
@@ -2188,171 +3329,303 @@ packages:
         optional: true
 
   cac@7.0.0:
-    resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
-    engines: {node: '>=20.19.0'}
+    resolution:
+      {
+        integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==,
+      }
+    engines: { node: '>=20.19.0' }
 
   call-bind-apply-helpers@1.0.2:
-    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==,
+      }
+    engines: { node: '>= 0.4' }
 
   call-bound@1.0.4:
-    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==,
+      }
+    engines: { node: '>= 0.4' }
 
   callsites@3.1.0:
-    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==,
+      }
+    engines: { node: '>=6' }
 
   camelcase@6.3.0:
-    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==,
+      }
+    engines: { node: '>=10' }
 
   chai@6.2.2:
-    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==,
+      }
+    engines: { node: '>=18' }
 
   chalk@4.1.2:
-    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==,
+      }
+    engines: { node: '>=10' }
 
   chalk@5.6.2:
-    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+    resolution:
+      {
+        integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==,
+      }
+    engines: { node: ^12.17.0 || ^14.13 || >=16.0.0 }
 
   character-parser@2.2.0:
-    resolution: {integrity: sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw==}
+    resolution:
+      {
+        integrity: sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw==,
+      }
 
   chardet@2.1.1:
-    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+    resolution:
+      {
+        integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==,
+      }
 
   chevrotain@10.5.0:
-    resolution: {integrity: sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==}
+    resolution:
+      {
+        integrity: sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==,
+      }
 
   chokidar@4.0.3:
-    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
-    engines: {node: '>= 14.16.0'}
+    resolution:
+      {
+        integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==,
+      }
+    engines: { node: '>= 14.16.0' }
 
   chownr@3.0.0:
-    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==,
+      }
+    engines: { node: '>=18' }
 
   citty@0.1.6:
-    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+    resolution:
+      {
+        integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==,
+      }
 
   citty@0.2.1:
-    resolution: {integrity: sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==}
+    resolution:
+      {
+        integrity: sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==,
+      }
 
   cli-cursor@5.0.0:
-    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==,
+      }
+    engines: { node: '>=18' }
 
   cli-table3@0.6.5:
-    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
-    engines: {node: 10.* || >= 12.*}
+    resolution:
+      {
+        integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==,
+      }
+    engines: { node: 10.* || >= 12.* }
 
   cli-truncate@5.2.0:
-    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
-    engines: {node: '>=20'}
+    resolution:
+      {
+        integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==,
+      }
+    engines: { node: '>=20' }
 
   cliui@8.0.1:
-    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==,
+      }
+    engines: { node: '>=12' }
 
   cluster-key-slot@1.1.2:
-    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==,
+      }
+    engines: { node: '>=0.10.0' }
 
   code-block-writer@13.0.3:
-    resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
+    resolution:
+      {
+        integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==,
+      }
 
   color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
+    resolution:
+      {
+        integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
+      }
+    engines: { node: '>=7.0.0' }
 
   color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+    resolution:
+      {
+        integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
+      }
 
   colorette@2.0.20:
-    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+    resolution:
+      {
+        integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==,
+      }
 
   colors@1.4.0:
-    resolution: {integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==}
-    engines: {node: '>=0.1.90'}
+    resolution:
+      {
+        integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==,
+      }
+    engines: { node: '>=0.1.90' }
 
   combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==,
+      }
+    engines: { node: '>= 0.8' }
 
   commander@14.0.3:
-    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
-    engines: {node: '>=20'}
+    resolution:
+      {
+        integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==,
+      }
+    engines: { node: '>=20' }
 
   commander@5.1.0:
-    resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==,
+      }
+    engines: { node: '>= 6' }
 
   compare-func@2.0.0:
-    resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
+    resolution:
+      {
+        integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==,
+      }
 
   component-emitter@1.3.1:
-    resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
+    resolution:
+      {
+        integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==,
+      }
 
   confbox@0.2.4:
-    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
+    resolution:
+      {
+        integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==,
+      }
 
   consola@3.4.2:
-    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
-    engines: {node: ^14.18.0 || >=16.10.0}
+    resolution:
+      {
+        integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==,
+      }
+    engines: { node: ^14.18.0 || >=16.10.0 }
 
   console-table-printer@2.15.0:
-    resolution: {integrity: sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==}
+    resolution:
+      {
+        integrity: sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==,
+      }
 
   constantinople@4.0.1:
-    resolution: {integrity: sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==}
+    resolution:
+      {
+        integrity: sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==,
+      }
 
   content-disposition@1.0.1:
-    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==,
+      }
+    engines: { node: '>=18' }
 
   content-type@1.0.5:
-    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==,
+      }
+    engines: { node: '>= 0.6' }
 
   conventional-changelog-angular@8.3.0:
-    resolution: {integrity: sha512-DOuBwYSqWzfwuRByY9O4oOIvDlkUCTDzfbOgcSbkY+imXXj+4tmrEFao3K+FxemClYfYnZzsvudbwrhje9VHDA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-DOuBwYSqWzfwuRByY9O4oOIvDlkUCTDzfbOgcSbkY+imXXj+4tmrEFao3K+FxemClYfYnZzsvudbwrhje9VHDA==,
+      }
+    engines: { node: '>=18' }
 
   conventional-changelog-conventionalcommits@9.3.0:
-    resolution: {integrity: sha512-kYFx6gAyjSIMwNtASkI3ZE99U1fuVDJr0yTYgVy+I2QG46zNZfl2her+0+eoviG82c5WQvW1jMt1eOQTeJLodA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-kYFx6gAyjSIMwNtASkI3ZE99U1fuVDJr0yTYgVy+I2QG46zNZfl2her+0+eoviG82c5WQvW1jMt1eOQTeJLodA==,
+      }
+    engines: { node: '>=18' }
 
   conventional-commits-parser@6.3.0:
-    resolution: {integrity: sha512-RfOq/Cqy9xV9bOA8N+ZH6DlrDR+5S3Mi0B5kACEjESpE+AviIpAptx9a9cFpWCCvgRtWT+0BbUw+e1BZfts9jg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-RfOq/Cqy9xV9bOA8N+ZH6DlrDR+5S3Mi0B5kACEjESpE+AviIpAptx9a9cFpWCCvgRtWT+0BbUw+e1BZfts9jg==,
+      }
+    engines: { node: '>=18' }
     hasBin: true
 
   cookie-signature@1.2.2:
-    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
-    engines: {node: '>=6.6.0'}
+    resolution:
+      {
+        integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==,
+      }
+    engines: { node: '>=6.6.0' }
 
   cookie@0.7.2:
-    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==,
+      }
+    engines: { node: '>= 0.6' }
 
   cookiejar@2.1.4:
-    resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
+    resolution:
+      {
+        integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==,
+      }
 
   cosmiconfig-typescript-loader@6.2.0:
-    resolution: {integrity: sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==}
-    engines: {node: '>=v18'}
+    resolution:
+      {
+        integrity: sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==,
+      }
+    engines: { node: '>=v18' }
     peerDependencies:
       '@types/node': '*'
       cosmiconfig: '>=9'
       typescript: '>=5'
 
   cosmiconfig@9.0.1:
-    resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
-    engines: {node: '>=14'}
+    resolution:
+      {
+        integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==,
+      }
+    engines: { node: '>=14' }
     peerDependencies:
       typescript: '>=4.9.5'
     peerDependenciesMeta:
@@ -2360,29 +3633,50 @@ packages:
         optional: true
 
   cron-parser@4.9.0:
-    resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
-    engines: {node: '>=12.0.0'}
+    resolution:
+      {
+        integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==,
+      }
+    engines: { node: '>=12.0.0' }
 
   cross-spawn@7.0.6:
-    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==,
+      }
+    engines: { node: '>= 8' }
 
   csstype@3.2.3:
-    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+    resolution:
+      {
+        integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==,
+      }
 
   dargs@8.1.0:
-    resolution: {integrity: sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==,
+      }
+    engines: { node: '>=12' }
 
   dataloader@1.4.0:
-    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
+    resolution:
+      {
+        integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==,
+      }
 
   dateformat@4.6.3:
-    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
+    resolution:
+      {
+        integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==,
+      }
 
   debug@4.4.3:
-    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
-    engines: {node: '>=6.0'}
+    resolution:
+      {
+        integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==,
+      }
+    engines: { node: '>=6.0' }
     peerDependencies:
       supports-color: '*'
     peerDependenciesMeta:
@@ -2390,214 +3684,382 @@ packages:
         optional: true
 
   decamelize@1.2.0:
-    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==,
+      }
+    engines: { node: '>=0.10.0' }
 
   deep-is@0.1.4:
-    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+    resolution:
+      {
+        integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==,
+      }
 
   deepmerge-ts@7.1.5:
-    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
-    engines: {node: '>=16.0.0'}
+    resolution:
+      {
+        integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==,
+      }
+    engines: { node: '>=16.0.0' }
 
   define-data-property@1.1.4:
-    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==,
+      }
+    engines: { node: '>= 0.4' }
 
   define-properties@1.2.1:
-    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==,
+      }
+    engines: { node: '>= 0.4' }
 
   defu@6.1.4:
-    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+    resolution:
+      {
+        integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==,
+      }
 
   delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
+    resolution:
+      {
+        integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==,
+      }
+    engines: { node: '>=0.4.0' }
 
   denque@2.1.0:
-    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
-    engines: {node: '>=0.10'}
+    resolution:
+      {
+        integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==,
+      }
+    engines: { node: '>=0.10' }
 
   depd@2.0.0:
-    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==,
+      }
+    engines: { node: '>= 0.8' }
 
   dependency-cruiser@17.3.8:
-    resolution: {integrity: sha512-ziP2ziP7D6MVFK/mFTOQAAb7t2VAD6mhBMjD1Pu9CWDMzozssDN49RprKn8u85mTuK/W6kyiRg9WOyr1Y7lNqg==}
-    engines: {node: ^20.12||^22||>=24}
+    resolution:
+      {
+        integrity: sha512-ziP2ziP7D6MVFK/mFTOQAAb7t2VAD6mhBMjD1Pu9CWDMzozssDN49RprKn8u85mTuK/W6kyiRg9WOyr1Y7lNqg==,
+      }
+    engines: { node: ^20.12||^22||>=24 }
     hasBin: true
 
   destr@2.0.5:
-    resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
+    resolution:
+      {
+        integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==,
+      }
 
   detect-indent@6.1.0:
-    resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==,
+      }
+    engines: { node: '>=8' }
 
   detect-libc@2.1.2:
-    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==,
+      }
+    engines: { node: '>=8' }
 
   detect-node@2.1.0:
-    resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
+    resolution:
+      {
+        integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==,
+      }
 
   dezalgo@1.0.4:
-    resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
+    resolution:
+      {
+        integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==,
+      }
 
   dir-glob@3.0.1:
-    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==,
+      }
+    engines: { node: '>=8' }
 
   discord-api-types@0.38.41:
-    resolution: {integrity: sha512-yMECyR8j9c2fVTvCQ+Qc24pweYFIZk/XoxDOmt1UvPeSw5tK6gXBd/2hhP+FEAe9Y6ny8pRMaf618XDK4U53OQ==}
+    resolution:
+      {
+        integrity: sha512-yMECyR8j9c2fVTvCQ+Qc24pweYFIZk/XoxDOmt1UvPeSw5tK6gXBd/2hhP+FEAe9Y6ny8pRMaf618XDK4U53OQ==,
+      }
 
   discord.js@14.25.1:
-    resolution: {integrity: sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==,
+      }
+    engines: { node: '>=18' }
 
   doctypes@1.1.0:
-    resolution: {integrity: sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ==}
+    resolution:
+      {
+        integrity: sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ==,
+      }
 
   dot-prop@5.3.0:
-    resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==,
+      }
+    engines: { node: '>=8' }
 
   dotenv@16.6.1:
-    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==,
+      }
+    engines: { node: '>=12' }
 
   dotenv@17.3.1:
-    resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==,
+      }
+    engines: { node: '>=12' }
 
   dotenv@8.6.0:
-    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==,
+      }
+    engines: { node: '>=10' }
 
   dunder-proto@1.0.1:
-    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==,
+      }
+    engines: { node: '>= 0.4' }
 
   editions@6.22.0:
-    resolution: {integrity: sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ==}
-    engines: {ecmascript: '>= es5', node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ==,
+      }
+    engines: { ecmascript: '>= es5', node: '>=4' }
 
   ee-first@1.1.1:
-    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    resolution:
+      {
+        integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==,
+      }
 
   effect@3.18.4:
-    resolution: {integrity: sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==}
+    resolution:
+      {
+        integrity: sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==,
+      }
 
   emoji-regex@10.6.0:
-    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+    resolution:
+      {
+        integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==,
+      }
 
   emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+    resolution:
+      {
+        integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==,
+      }
 
   empathic@2.0.0:
-    resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
-    engines: {node: '>=14'}
+    resolution:
+      {
+        integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==,
+      }
+    engines: { node: '>=14' }
 
   encodeurl@2.0.0:
-    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==,
+      }
+    engines: { node: '>= 0.8' }
 
   end-of-stream@1.4.5:
-    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+    resolution:
+      {
+        integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==,
+      }
 
   enhanced-resolve@5.19.0:
-    resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
-    engines: {node: '>=10.13.0'}
+    resolution:
+      {
+        integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==,
+      }
+    engines: { node: '>=10.13.0' }
 
   enquirer@2.4.1:
-    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
-    engines: {node: '>=8.6'}
+    resolution:
+      {
+        integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==,
+      }
+    engines: { node: '>=8.6' }
 
   env-paths@2.2.1:
-    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==,
+      }
+    engines: { node: '>=6' }
 
   environment@1.1.0:
-    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==,
+      }
+    engines: { node: '>=18' }
 
   error-ex@1.3.4:
-    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+    resolution:
+      {
+        integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==,
+      }
 
   es-define-property@1.0.1:
-    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==,
+      }
+    engines: { node: '>= 0.4' }
 
   es-errors@1.3.0:
-    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==,
+      }
+    engines: { node: '>= 0.4' }
 
   es-module-lexer@1.7.0:
-    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+    resolution:
+      {
+        integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==,
+      }
 
   es-object-atoms@1.1.1:
-    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==,
+      }
+    engines: { node: '>= 0.4' }
 
   es-set-tostringtag@2.1.0:
-    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==,
+      }
+    engines: { node: '>= 0.4' }
 
   es6-error@4.1.1:
-    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
+    resolution:
+      {
+        integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==,
+      }
 
   esbuild@0.27.2:
-    resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==,
+      }
+    engines: { node: '>=18' }
     hasBin: true
 
   escalade@3.2.0:
-    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==,
+      }
+    engines: { node: '>=6' }
 
   escape-html@1.0.3:
-    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+    resolution:
+      {
+        integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==,
+      }
 
   escape-string-regexp@4.0.0:
-    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==,
+      }
+    engines: { node: '>=10' }
 
   eslint-formatter-pretty@7.0.0:
-    resolution: {integrity: sha512-1CaE7Pnce8Csy+tlTEbFC2q5qgT5cJo2a0UkEOds+Y5+mI1nX3DApIhcBP8EPwV8TgTpLlzOfw8mcBJBAs3Y9Q==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-1CaE7Pnce8Csy+tlTEbFC2q5qgT5cJo2a0UkEOds+Y5+mI1nX3DApIhcBP8EPwV8TgTpLlzOfw8mcBJBAs3Y9Q==,
+      }
+    engines: { node: '>=18' }
 
   eslint-plugin-sonarjs@4.0.1:
-    resolution: {integrity: sha512-lmqzFTrw0/zpHQMRmwdgdEEw50s3md0c8RE23JqNom9ovsGQxC/azZ9H00aGKVDkxIXywfcxwzyFJ9Sm3bp2ng==}
+    resolution:
+      {
+        integrity: sha512-lmqzFTrw0/zpHQMRmwdgdEEw50s3md0c8RE23JqNom9ovsGQxC/azZ9H00aGKVDkxIXywfcxwzyFJ9Sm3bp2ng==,
+      }
     peerDependencies:
       eslint: ^8.0.0 || ^9.0.0 || ^10.0.0
 
   eslint-rule-docs@1.1.235:
-    resolution: {integrity: sha512-+TQ+x4JdTnDoFEXXb3fDvfGOwnyNV7duH8fXWTPD1ieaBmB8omj7Gw/pMBBu4uI2uJCCU8APDaQJzWuXnTsH4A==}
+    resolution:
+      {
+        integrity: sha512-+TQ+x4JdTnDoFEXXb3fDvfGOwnyNV7duH8fXWTPD1ieaBmB8omj7Gw/pMBBu4uI2uJCCU8APDaQJzWuXnTsH4A==,
+      }
 
   eslint-scope@8.4.0:
-    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   eslint-scope@9.1.2:
-    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    resolution:
+      {
+        integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==,
+      }
+    engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
   eslint-visitor-keys@3.4.3:
-    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    resolution:
+      {
+        integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==,
+      }
+    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
 
   eslint-visitor-keys@4.2.1:
-    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   eslint-visitor-keys@5.0.1:
-    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    resolution:
+      {
+        integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==,
+      }
+    engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
   eslint@10.0.3:
-    resolution: {integrity: sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    resolution:
+      {
+        integrity: sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==,
+      }
+    engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -2606,8 +4068,11 @@ packages:
         optional: true
 
   eslint@9.39.2:
-    resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -2616,107 +4081,194 @@ packages:
         optional: true
 
   espree@10.4.0:
-    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   espree@11.2.0:
-    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    resolution:
+      {
+        integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==,
+      }
+    engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
   esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==,
+      }
+    engines: { node: '>=4' }
     hasBin: true
 
   esquery@1.7.0:
-    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
-    engines: {node: '>=0.10'}
+    resolution:
+      {
+        integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==,
+      }
+    engines: { node: '>=0.10' }
 
   esrecurse@4.3.0:
-    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
-    engines: {node: '>=4.0'}
+    resolution:
+      {
+        integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==,
+      }
+    engines: { node: '>=4.0' }
 
   estraverse@5.3.0:
-    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
-    engines: {node: '>=4.0'}
+    resolution:
+      {
+        integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==,
+      }
+    engines: { node: '>=4.0' }
 
   estree-walker@3.0.3:
-    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+    resolution:
+      {
+        integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==,
+      }
 
   esutils@2.0.3:
-    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==,
+      }
+    engines: { node: '>=0.10.0' }
 
   etag@1.8.1:
-    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==,
+      }
+    engines: { node: '>= 0.6' }
 
   eventemitter3@4.0.7:
-    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+    resolution:
+      {
+        integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==,
+      }
 
   eventemitter3@5.0.4:
-    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+    resolution:
+      {
+        integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==,
+      }
 
   execa@4.1.0:
-    resolution: {integrity: sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==,
+      }
+    engines: { node: '>=10' }
 
   expect-type@1.3.0:
-    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
-    engines: {node: '>=12.0.0'}
+    resolution:
+      {
+        integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==,
+      }
+    engines: { node: '>=12.0.0' }
 
   express@5.2.1:
-    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
-    engines: {node: '>= 18'}
+    resolution:
+      {
+        integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==,
+      }
+    engines: { node: '>= 18' }
 
   exsolve@1.0.8:
-    resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
+    resolution:
+      {
+        integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==,
+      }
 
   extendable-error@0.1.7:
-    resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
+    resolution:
+      {
+        integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==,
+      }
 
   fast-check@3.23.2:
-    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
-    engines: {node: '>=8.0.0'}
+    resolution:
+      {
+        integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==,
+      }
+    engines: { node: '>=8.0.0' }
 
   fast-copy@4.0.2:
-    resolution: {integrity: sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==}
+    resolution:
+      {
+        integrity: sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==,
+      }
 
   fast-deep-equal@3.1.3:
-    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    resolution:
+      {
+        integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==,
+      }
 
   fast-glob@3.3.3:
-    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
-    engines: {node: '>=8.6.0'}
+    resolution:
+      {
+        integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==,
+      }
+    engines: { node: '>=8.6.0' }
 
   fast-json-stable-stringify@2.1.0:
-    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+    resolution:
+      {
+        integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==,
+      }
 
   fast-levenshtein@2.0.6:
-    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+    resolution:
+      {
+        integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==,
+      }
 
   fast-safe-stringify@2.1.1:
-    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+    resolution:
+      {
+        integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==,
+      }
 
   fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+    resolution:
+      {
+        integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==,
+      }
 
   fast-xml-builder@1.0.0:
-    resolution: {integrity: sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==}
+    resolution:
+      {
+        integrity: sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==,
+      }
 
   fast-xml-parser@5.4.2:
-    resolution: {integrity: sha512-pw/6pIl4k0CSpElPEJhDppLzaixDEuWui2CUQQBH/ECDf7+y6YwA4Gf7Tyb0Rfe4DIMuZipYj4AEL0nACKglvQ==}
+    resolution:
+      {
+        integrity: sha512-pw/6pIl4k0CSpElPEJhDppLzaixDEuWui2CUQQBH/ECDf7+y6YwA4Gf7Tyb0Rfe4DIMuZipYj4AEL0nACKglvQ==,
+      }
     hasBin: true
 
   fastq@1.20.1:
-    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+    resolution:
+      {
+        integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==,
+      }
 
   fd-package-json@2.0.0:
-    resolution: {integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==}
+    resolution:
+      {
+        integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==,
+      }
 
   fdir@6.5.0:
-    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
-    engines: {node: '>=12.0.0'}
+    resolution:
+      {
+        integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==,
+      }
+    engines: { node: '>=12.0.0' }
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -2724,491 +4276,875 @@ packages:
         optional: true
 
   file-entry-cache@8.0.0:
-    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
-    engines: {node: '>=16.0.0'}
+    resolution:
+      {
+        integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==,
+      }
+    engines: { node: '>=16.0.0' }
 
   fill-range@7.1.1:
-    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==,
+      }
+    engines: { node: '>=8' }
 
   finalhandler@2.1.1:
-    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
-    engines: {node: '>= 18.0.0'}
+    resolution:
+      {
+        integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==,
+      }
+    engines: { node: '>= 18.0.0' }
 
   find-up@4.1.0:
-    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==,
+      }
+    engines: { node: '>=8' }
 
   find-up@5.0.0:
-    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==,
+      }
+    engines: { node: '>=10' }
 
   flat-cache@4.0.1:
-    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
-    engines: {node: '>=16'}
+    resolution:
+      {
+        integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==,
+      }
+    engines: { node: '>=16' }
 
   flatbuffers@25.9.23:
-    resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
+    resolution:
+      {
+        integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==,
+      }
 
   flatted@3.4.1:
-    resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
+    resolution:
+      {
+        integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==,
+      }
 
   foreground-child@3.3.1:
-    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
-    engines: {node: '>=14'}
+    resolution:
+      {
+        integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==,
+      }
+    engines: { node: '>=14' }
 
   form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==,
+      }
+    engines: { node: '>= 6' }
 
   formatly@0.3.0:
-    resolution: {integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==}
-    engines: {node: '>=18.3.0'}
+    resolution:
+      {
+        integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==,
+      }
+    engines: { node: '>=18.3.0' }
     hasBin: true
 
   formidable@3.5.4:
-    resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
-    engines: {node: '>=14.0.0'}
+    resolution:
+      {
+        integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==,
+      }
+    engines: { node: '>=14.0.0' }
 
   forwarded@0.2.0:
-    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==,
+      }
+    engines: { node: '>= 0.6' }
 
   fresh@2.0.0:
-    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==,
+      }
+    engines: { node: '>= 0.8' }
 
   fs-extra@11.3.3:
-    resolution: {integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==}
-    engines: {node: '>=14.14'}
+    resolution:
+      {
+        integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==,
+      }
+    engines: { node: '>=14.14' }
 
   fs-extra@7.0.1:
-    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
-    engines: {node: '>=6 <7 || >=8'}
+    resolution:
+      {
+        integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==,
+      }
+    engines: { node: '>=6 <7 || >=8' }
 
   fs-extra@8.1.0:
-    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
-    engines: {node: '>=6 <7 || >=8'}
+    resolution:
+      {
+        integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==,
+      }
+    engines: { node: '>=6 <7 || >=8' }
 
   fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    resolution:
+      {
+        integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==,
+      }
+    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
     os: [darwin]
 
   function-bind@1.1.2:
-    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+    resolution:
+      {
+        integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==,
+      }
 
   functional-red-black-tree@1.0.1:
-    resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
+    resolution:
+      {
+        integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==,
+      }
 
   generate-function@2.3.1:
-    resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
+    resolution:
+      {
+        integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==,
+      }
 
   get-caller-file@2.0.5:
-    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
-    engines: {node: 6.* || 8.* || >= 10.*}
+    resolution:
+      {
+        integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==,
+      }
+    engines: { node: 6.* || 8.* || >= 10.* }
 
   get-east-asian-width@1.4.0:
-    resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==,
+      }
+    engines: { node: '>=18' }
 
   get-east-asian-width@1.5.0:
-    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==,
+      }
+    engines: { node: '>=18' }
 
   get-intrinsic@1.3.0:
-    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==,
+      }
+    engines: { node: '>= 0.4' }
 
   get-port-please@3.2.0:
-    resolution: {integrity: sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==}
+    resolution:
+      {
+        integrity: sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==,
+      }
 
   get-proto@1.0.1:
-    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==,
+      }
+    engines: { node: '>= 0.4' }
 
   get-stream@5.2.0:
-    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==,
+      }
+    engines: { node: '>=8' }
 
   get-tsconfig@4.13.1:
-    resolution: {integrity: sha512-EoY1N2xCn44xU6750Sx7OjOIT59FkmstNc3X6y5xpz7D5cBtZRe/3pSlTkDJgqsOk3WwZPkWfonhhUJfttQo3w==}
+    resolution:
+      {
+        integrity: sha512-EoY1N2xCn44xU6750Sx7OjOIT59FkmstNc3X6y5xpz7D5cBtZRe/3pSlTkDJgqsOk3WwZPkWfonhhUJfttQo3w==,
+      }
 
   giget@2.0.0:
-    resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
+    resolution:
+      {
+        integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==,
+      }
     hasBin: true
 
   git-raw-commits@4.0.0:
-    resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
-    engines: {node: '>=16'}
+    resolution:
+      {
+        integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==,
+      }
+    engines: { node: '>=16' }
     deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   gitignore-to-glob@0.3.0:
-    resolution: {integrity: sha512-mk74BdnK7lIwDHnotHddx1wsjMOFIThpLY3cPNniJ/2fA/tlLzHnFxIdR+4sLOu5KGgQJdij4kjJ2RoUNnCNMA==}
-    engines: {node: '>=4.4 <5 || >=6.9'}
+    resolution:
+      {
+        integrity: sha512-mk74BdnK7lIwDHnotHddx1wsjMOFIThpLY3cPNniJ/2fA/tlLzHnFxIdR+4sLOu5KGgQJdij4kjJ2RoUNnCNMA==,
+      }
+    engines: { node: '>=4.4 <5 || >=6.9' }
 
   glob-parent@5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==,
+      }
+    engines: { node: '>= 6' }
 
   glob-parent@6.0.2:
-    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
-    engines: {node: '>=10.13.0'}
+    resolution:
+      {
+        integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==,
+      }
+    engines: { node: '>=10.13.0' }
 
   glob-to-regex.js@1.2.0:
-    resolution: {integrity: sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==}
-    engines: {node: '>=10.0'}
+    resolution:
+      {
+        integrity: sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==,
+      }
+    engines: { node: '>=10.0' }
     peerDependencies:
       tslib: '2'
 
   global-agent@3.0.0:
-    resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
-    engines: {node: '>=10.0'}
+    resolution:
+      {
+        integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==,
+      }
+    engines: { node: '>=10.0' }
 
   global-directory@4.0.1:
-    resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==,
+      }
+    engines: { node: '>=18' }
 
   globals@14.0.0:
-    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==,
+      }
+    engines: { node: '>=18' }
 
   globals@17.4.0:
-    resolution: {integrity: sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==,
+      }
+    engines: { node: '>=18' }
 
   globalthis@1.0.4:
-    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==,
+      }
+    engines: { node: '>= 0.4' }
 
   globby@11.1.0:
-    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==,
+      }
+    engines: { node: '>=10' }
 
   globby@14.1.0:
-    resolution: {integrity: sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==,
+      }
+    engines: { node: '>=18' }
 
   gopd@1.2.0:
-    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==,
+      }
+    engines: { node: '>= 0.4' }
 
   graceful-fs@4.2.11:
-    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+    resolution:
+      {
+        integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
+      }
 
   grammex@3.1.12:
-    resolution: {integrity: sha512-6ufJOsSA7LcQehIJNCO7HIBykfM7DXQual0Ny780/DEcJIpBlHRvcqEBWGPYd7hrXL2GJ3oJI1MIhaXjWmLQOQ==}
+    resolution:
+      {
+        integrity: sha512-6ufJOsSA7LcQehIJNCO7HIBykfM7DXQual0Ny780/DEcJIpBlHRvcqEBWGPYd7hrXL2GJ3oJI1MIhaXjWmLQOQ==,
+      }
 
   graphmatch@1.1.1:
-    resolution: {integrity: sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==}
+    resolution:
+      {
+        integrity: sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==,
+      }
 
   guid-typescript@1.0.9:
-    resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
+    resolution:
+      {
+        integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==,
+      }
 
   has-flag@4.0.0:
-    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
+      }
+    engines: { node: '>=8' }
 
   has-flag@5.0.1:
-    resolution: {integrity: sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==,
+      }
+    engines: { node: '>=12' }
 
   has-property-descriptors@1.0.2:
-    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+    resolution:
+      {
+        integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==,
+      }
 
   has-symbols@1.1.0:
-    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==,
+      }
+    engines: { node: '>= 0.4' }
 
   has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==,
+      }
+    engines: { node: '>= 0.4' }
 
   hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==,
+      }
+    engines: { node: '>= 0.4' }
 
   help-me@5.0.0:
-    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
+    resolution:
+      {
+        integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==,
+      }
 
   hono@4.12.5:
-    resolution: {integrity: sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==}
-    engines: {node: '>=16.9.0'}
+    resolution:
+      {
+        integrity: sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==,
+      }
+    engines: { node: '>=16.9.0' }
 
   hosted-git-info@7.0.2:
-    resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
-    engines: {node: ^16.14.0 || >=18.0.0}
+    resolution:
+      {
+        integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==,
+      }
+    engines: { node: ^16.14.0 || >=18.0.0 }
 
   html-escaper@2.0.2:
-    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+    resolution:
+      {
+        integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==,
+      }
 
   http-errors@2.0.1:
-    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==,
+      }
+    engines: { node: '>= 0.8' }
 
   http-status-codes@2.3.0:
-    resolution: {integrity: sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==}
+    resolution:
+      {
+        integrity: sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==,
+      }
 
   human-id@4.1.3:
-    resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
+    resolution:
+      {
+        integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==,
+      }
     hasBin: true
 
   human-signals@1.1.1:
-    resolution: {integrity: sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==}
-    engines: {node: '>=8.12.0'}
+    resolution:
+      {
+        integrity: sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==,
+      }
+    engines: { node: '>=8.12.0' }
 
   husky@9.1.7:
-    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==,
+      }
+    engines: { node: '>=18' }
     hasBin: true
 
   hyperdyperid@1.2.0:
-    resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
-    engines: {node: '>=10.18'}
+    resolution:
+      {
+        integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==,
+      }
+    engines: { node: '>=10.18' }
 
   iconv-lite@0.7.2:
-    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==,
+      }
+    engines: { node: '>=0.10.0' }
 
   ignore@5.3.2:
-    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
-    engines: {node: '>= 4'}
+    resolution:
+      {
+        integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==,
+      }
+    engines: { node: '>= 4' }
 
   ignore@7.0.5:
-    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
-    engines: {node: '>= 4'}
+    resolution:
+      {
+        integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==,
+      }
+    engines: { node: '>= 4' }
 
   import-fresh@3.3.1:
-    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==,
+      }
+    engines: { node: '>=6' }
 
   import-meta-resolve@4.2.0:
-    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+    resolution:
+      {
+        integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==,
+      }
 
   imurmurhash@0.1.4:
-    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
-    engines: {node: '>=0.8.19'}
+    resolution:
+      {
+        integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==,
+      }
+    engines: { node: '>=0.8.19' }
 
   index-to-position@1.2.0:
-    resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==,
+      }
+    engines: { node: '>=18' }
 
   inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    resolution:
+      {
+        integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
+      }
 
   ini@4.1.1:
-    resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    resolution:
+      {
+        integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==,
+      }
+    engines: { node: ^14.17.0 || ^16.13.0 || >=18.0.0 }
 
   interpret@3.1.1:
-    resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
-    engines: {node: '>=10.13.0'}
+    resolution:
+      {
+        integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==,
+      }
+    engines: { node: '>=10.13.0' }
 
   ioredis@5.10.0:
-    resolution: {integrity: sha512-HVBe9OFuqs+Z6n64q09PQvP1/R4Bm+30PAyyD4wIEqssh3v9L21QjCVk4kRLucMBcDokJTcLjsGeVRlq/nH6DA==}
-    engines: {node: '>=12.22.0'}
+    resolution:
+      {
+        integrity: sha512-HVBe9OFuqs+Z6n64q09PQvP1/R4Bm+30PAyyD4wIEqssh3v9L21QjCVk4kRLucMBcDokJTcLjsGeVRlq/nH6DA==,
+      }
+    engines: { node: '>=12.22.0' }
 
   ipaddr.js@1.9.1:
-    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
-    engines: {node: '>= 0.10'}
+    resolution:
+      {
+        integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==,
+      }
+    engines: { node: '>= 0.10' }
 
   irregular-plurals@3.5.0:
-    resolution: {integrity: sha512-1ANGLZ+Nkv1ptFb2pa8oG8Lem4krflKuX/gINiHJHjJUKaJHk/SXk5x6K3J+39/p0h1RQ2saROclJJ+QLvETCQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-1ANGLZ+Nkv1ptFb2pa8oG8Lem4krflKuX/gINiHJHjJUKaJHk/SXk5x6K3J+39/p0h1RQ2saROclJJ+QLvETCQ==,
+      }
+    engines: { node: '>=8' }
 
   is-arrayish@0.2.1:
-    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+    resolution:
+      {
+        integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==,
+      }
 
   is-core-module@2.16.1:
-    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==,
+      }
+    engines: { node: '>= 0.4' }
 
   is-expression@4.0.0:
-    resolution: {integrity: sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A==}
+    resolution:
+      {
+        integrity: sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A==,
+      }
 
   is-extglob@2.1.1:
-    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==,
+      }
+    engines: { node: '>=0.10.0' }
 
   is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==,
+      }
+    engines: { node: '>=8' }
 
   is-fullwidth-code-point@5.1.0:
-    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==,
+      }
+    engines: { node: '>=18' }
 
   is-glob@4.0.3:
-    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==,
+      }
+    engines: { node: '>=0.10.0' }
 
   is-installed-globally@1.0.0:
-    resolution: {integrity: sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==,
+      }
+    engines: { node: '>=18' }
 
   is-network-error@1.3.1:
-    resolution: {integrity: sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==}
-    engines: {node: '>=16'}
+    resolution:
+      {
+        integrity: sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==,
+      }
+    engines: { node: '>=16' }
 
   is-number@7.0.0:
-    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
-    engines: {node: '>=0.12.0'}
+    resolution:
+      {
+        integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==,
+      }
+    engines: { node: '>=0.12.0' }
 
   is-obj@2.0.0:
-    resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==,
+      }
+    engines: { node: '>=8' }
 
   is-path-inside@4.0.0:
-    resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==,
+      }
+    engines: { node: '>=12' }
 
   is-plain-obj@4.1.0:
-    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==,
+      }
+    engines: { node: '>=12' }
 
   is-promise@2.2.2:
-    resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
+    resolution:
+      {
+        integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==,
+      }
 
   is-promise@4.0.0:
-    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+    resolution:
+      {
+        integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==,
+      }
 
   is-property@1.0.2:
-    resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
+    resolution:
+      {
+        integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==,
+      }
 
   is-regex@1.2.1:
-    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==,
+      }
+    engines: { node: '>= 0.4' }
 
   is-stream@2.0.1:
-    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==,
+      }
+    engines: { node: '>=8' }
 
   is-subdir@1.2.0:
-    resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==,
+      }
+    engines: { node: '>=4' }
 
   is-unicode-supported@2.1.0:
-    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==,
+      }
+    engines: { node: '>=18' }
 
   is-windows@1.0.2:
-    resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==,
+      }
+    engines: { node: '>=0.10.0' }
 
   isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+    resolution:
+      {
+        integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
+      }
 
   istanbul-lib-coverage@3.2.2:
-    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==,
+      }
+    engines: { node: '>=8' }
 
   istanbul-lib-report@3.0.1:
-    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==,
+      }
+    engines: { node: '>=10' }
 
   istanbul-reports@3.2.0:
-    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==,
+      }
+    engines: { node: '>=8' }
 
   istextorbinary@9.5.0:
-    resolution: {integrity: sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==,
+      }
+    engines: { node: '>=4' }
 
   jiti@2.6.1:
-    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    resolution:
+      {
+        integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==,
+      }
     hasBin: true
 
   joycon@3.1.1:
-    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==,
+      }
+    engines: { node: '>=10' }
 
   js-stringify@1.0.2:
-    resolution: {integrity: sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g==}
+    resolution:
+      {
+        integrity: sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g==,
+      }
 
   js-tiktoken@1.0.21:
-    resolution: {integrity: sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==}
+    resolution:
+      {
+        integrity: sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==,
+      }
 
   js-tokens@10.0.0:
-    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+    resolution:
+      {
+        integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==,
+      }
 
   js-tokens@4.0.0:
-    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+    resolution:
+      {
+        integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
+      }
 
   js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    resolution:
+      {
+        integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==,
+      }
     hasBin: true
 
   js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    resolution:
+      {
+        integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==,
+      }
     hasBin: true
 
   jscpd-sarif-reporter@4.0.6:
-    resolution: {integrity: sha512-b9Sm3IPZ3+m8Lwa4gZa+4/LhDhlc/ZLEsLXKSOy1DANQ6kx0ueqZT+fUHWEdQ6m0o3+RIVIa7DmvLSojQD05ng==}
+    resolution:
+      {
+        integrity: sha512-b9Sm3IPZ3+m8Lwa4gZa+4/LhDhlc/ZLEsLXKSOy1DANQ6kx0ueqZT+fUHWEdQ6m0o3+RIVIa7DmvLSojQD05ng==,
+      }
 
   jscpd@4.0.8:
-    resolution: {integrity: sha512-d2VNT/2Hv4dxT2/59He8Lyda4DYOxPRyRG9zBaOpTZAqJCVf2xLrBlZkT8Va6Lo9u3X2qz8Bpq4HrDi4JsrQhA==}
+    resolution:
+      {
+        integrity: sha512-d2VNT/2Hv4dxT2/59He8Lyda4DYOxPRyRG9zBaOpTZAqJCVf2xLrBlZkT8Va6Lo9u3X2qz8Bpq4HrDi4JsrQhA==,
+      }
     hasBin: true
 
   json-buffer@3.0.1:
-    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+    resolution:
+      {
+        integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==,
+      }
 
   json-parse-even-better-errors@2.3.1:
-    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+    resolution:
+      {
+        integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==,
+      }
 
   json-schema-traverse@0.4.1:
-    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+    resolution:
+      {
+        integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==,
+      }
 
   json-schema-traverse@1.0.0:
-    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+    resolution:
+      {
+        integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==,
+      }
 
   json-stable-stringify-without-jsonify@1.0.1:
-    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+    resolution:
+      {
+        integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==,
+      }
 
   json-stringify-safe@5.0.1:
-    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+    resolution:
+      {
+        integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==,
+      }
 
   json5@2.2.3:
-    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==,
+      }
+    engines: { node: '>=6' }
     hasBin: true
 
   jsonfile@4.0.0:
-    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+    resolution:
+      {
+        integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==,
+      }
 
   jsonfile@6.2.0:
-    resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+    resolution:
+      {
+        integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==,
+      }
 
   jstransformer@1.0.0:
-    resolution: {integrity: sha512-C9YK3Rf8q6VAPDCCU9fnqo3mAfOH6vUGnMcP4AQAYIEpWtfGLpwOTmZ+igtdK5y+VvI2n3CyYSzy4Qh34eq24A==}
+    resolution:
+      {
+        integrity: sha512-C9YK3Rf8q6VAPDCCU9fnqo3mAfOH6vUGnMcP4AQAYIEpWtfGLpwOTmZ+igtdK5y+VvI2n3CyYSzy4Qh34eq24A==,
+      }
 
   jsx-ast-utils-x@0.1.0:
-    resolution: {integrity: sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
   keyv@4.5.4:
-    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+    resolution:
+      {
+        integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==,
+      }
 
   kleur@3.0.3:
-    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==,
+      }
+    engines: { node: '>=6' }
 
   knip@5.86.0:
-    resolution: {integrity: sha512-tGpRCbP+L+VysXnAp1bHTLQ0k/SdC3M3oX18+Cpiqax1qdS25iuCPzpK8LVmAKARZv0Ijri81Wq09Rzk0JTl+Q==}
-    engines: {node: '>=18.18.0'}
+    resolution:
+      {
+        integrity: sha512-tGpRCbP+L+VysXnAp1bHTLQ0k/SdC3M3oX18+Cpiqax1qdS25iuCPzpK8LVmAKARZv0Ijri81Wq09Rzk0JTl+Q==,
+      }
+    engines: { node: '>=18.18.0' }
     hasBin: true
     peerDependencies:
       '@types/node': '>=18'
       typescript: '>=5.0.4 <7'
 
   langchain@1.2.30:
-    resolution: {integrity: sha512-Ofsk7LTGvIkyy3uesv7hpyerpTghdjNpYFJfIxJRGGLjd+4JgTVkT/Ax6Cjg0F6doEuO7VRID0NK2QwmT3A/bg==}
-    engines: {node: '>=20'}
+    resolution:
+      {
+        integrity: sha512-Ofsk7LTGvIkyy3uesv7hpyerpTghdjNpYFJfIxJRGGLjd+4JgTVkT/Ax6Cjg0F6doEuO7VRID0NK2QwmT3A/bg==,
+      }
+    engines: { node: '>=20' }
     peerDependencies:
       '@langchain/core': ^1.1.31
 
   langsmith@0.5.8:
-    resolution: {integrity: sha512-AsdwxazXXLwbEzVTXB5uo7Fva5MhGhSvIJ9FjBbkWOkgwqC28E9Gmah5SGbPM3CPjN0FdxB6nKzX5GRkkkXDjQ==}
+    resolution:
+      {
+        integrity: sha512-AsdwxazXXLwbEzVTXB5uo7Fva5MhGhSvIJ9FjBbkWOkgwqC28E9Gmah5SGbPM3CPjN0FdxB6nKzX5GRkkkXDjQ==,
+      }
     peerDependencies:
       '@opentelemetry/api': '*'
       '@opentelemetry/exporter-trace-otlp-proto': '*'
@@ -3225,246 +5161,444 @@ packages:
         optional: true
 
   levn@0.4.1:
-    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
-    engines: {node: '>= 0.8.0'}
+    resolution:
+      {
+        integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==,
+      }
+    engines: { node: '>= 0.8.0' }
 
   lilconfig@2.1.0:
-    resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==,
+      }
+    engines: { node: '>=10' }
 
   lines-and-columns@1.2.4:
-    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+    resolution:
+      {
+        integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==,
+      }
 
   lint-staged@16.3.2:
-    resolution: {integrity: sha512-xKqhC2AeXLwiAHXguxBjuChoTTWFC6Pees0SHPwOpwlvI3BH7ZADFPddAdN3pgo3aiKgPUx/bxE78JfUnxQnlg==}
-    engines: {node: '>=20.17'}
+    resolution:
+      {
+        integrity: sha512-xKqhC2AeXLwiAHXguxBjuChoTTWFC6Pees0SHPwOpwlvI3BH7ZADFPddAdN3pgo3aiKgPUx/bxE78JfUnxQnlg==,
+      }
+    engines: { node: '>=20.17' }
     hasBin: true
 
   listr2@9.0.5:
-    resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
-    engines: {node: '>=20.0.0'}
+    resolution:
+      {
+        integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==,
+      }
+    engines: { node: '>=20.0.0' }
 
   locate-path@5.0.0:
-    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==,
+      }
+    engines: { node: '>=8' }
 
   locate-path@6.0.0:
-    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==,
+      }
+    engines: { node: '>=10' }
 
   lodash.camelcase@4.3.0:
-    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+    resolution:
+      {
+        integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==,
+      }
 
   lodash.defaults@4.2.0:
-    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+    resolution:
+      {
+        integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==,
+      }
 
   lodash.isarguments@3.1.0:
-    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
+    resolution:
+      {
+        integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==,
+      }
 
   lodash.kebabcase@4.1.1:
-    resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==}
+    resolution:
+      {
+        integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==,
+      }
 
   lodash.merge@4.6.2:
-    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+    resolution:
+      {
+        integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==,
+      }
 
   lodash.mergewith@4.6.2:
-    resolution: {integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==}
+    resolution:
+      {
+        integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==,
+      }
 
   lodash.snakecase@4.1.1:
-    resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
+    resolution:
+      {
+        integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==,
+      }
 
   lodash.startcase@4.4.0:
-    resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
+    resolution:
+      {
+        integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==,
+      }
 
   lodash.truncate@4.4.2:
-    resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
+    resolution:
+      {
+        integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==,
+      }
 
   lodash.upperfirst@4.3.1:
-    resolution: {integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==}
+    resolution:
+      {
+        integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==,
+      }
 
   lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+    resolution:
+      {
+        integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==,
+      }
 
   log-symbols@7.0.1:
-    resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==,
+      }
+    engines: { node: '>=18' }
 
   log-update@6.1.0:
-    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==,
+      }
+    engines: { node: '>=18' }
 
   long@5.3.2:
-    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+    resolution:
+      {
+        integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==,
+      }
 
   lru-cache@10.4.3:
-    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+    resolution:
+      {
+        integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==,
+      }
 
   lru-cache@11.2.6:
-    resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
-    engines: {node: 20 || >=22}
+    resolution:
+      {
+        integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==,
+      }
+    engines: { node: 20 || >=22 }
 
   lru.min@1.1.4:
-    resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
-    engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
+    resolution:
+      {
+        integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==,
+      }
+    engines: { bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0' }
 
   luxon@3.7.2:
-    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==,
+      }
+    engines: { node: '>=12' }
 
   magic-bytes.js@1.13.0:
-    resolution: {integrity: sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==}
+    resolution:
+      {
+        integrity: sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==,
+      }
 
   magic-string@0.30.21:
-    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+    resolution:
+      {
+        integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
+      }
 
   magicast@0.3.5:
-    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+    resolution:
+      {
+        integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==,
+      }
 
   magicast@0.5.1:
-    resolution: {integrity: sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==}
+    resolution:
+      {
+        integrity: sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==,
+      }
 
   make-dir@4.0.0:
-    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==,
+      }
+    engines: { node: '>=10' }
 
   markdown-table@2.0.0:
-    resolution: {integrity: sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==}
+    resolution:
+      {
+        integrity: sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==,
+      }
 
   matcher@3.0.0:
-    resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==,
+      }
+    engines: { node: '>=10' }
 
   math-intrinsics@1.1.0:
-    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==,
+      }
+    engines: { node: '>= 0.4' }
 
   media-typer@1.1.0:
-    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==,
+      }
+    engines: { node: '>= 0.8' }
 
   memfs@4.56.11:
-    resolution: {integrity: sha512-/GodtwVeKVIHZKLUSr2ZdOxKBC5hHki4JNCU22DoCGPEHr5o2PD5U721zvESKyWwCfTfavFl9WZYgA13OAYK0g==}
+    resolution:
+      {
+        integrity: sha512-/GodtwVeKVIHZKLUSr2ZdOxKBC5hHki4JNCU22DoCGPEHr5o2PD5U721zvESKyWwCfTfavFl9WZYgA13OAYK0g==,
+      }
     peerDependencies:
       tslib: '2'
 
   meow@12.1.1:
-    resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
-    engines: {node: '>=16.10'}
+    resolution:
+      {
+        integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==,
+      }
+    engines: { node: '>=16.10' }
 
   meow@13.2.0:
-    resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==,
+      }
+    engines: { node: '>=18' }
 
   merge-descriptors@2.0.0:
-    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==,
+      }
+    engines: { node: '>=18' }
 
   merge-stream@2.0.0:
-    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+    resolution:
+      {
+        integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==,
+      }
 
   merge2@1.4.1:
-    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==,
+      }
+    engines: { node: '>= 8' }
 
   methods@1.1.2:
-    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==,
+      }
+    engines: { node: '>= 0.6' }
 
   micromatch@4.0.8:
-    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
-    engines: {node: '>=8.6'}
+    resolution:
+      {
+        integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==,
+      }
+    engines: { node: '>=8.6' }
 
   mime-db@1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==,
+      }
+    engines: { node: '>= 0.6' }
 
   mime-db@1.54.0:
-    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==,
+      }
+    engines: { node: '>= 0.6' }
 
   mime-types@2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==,
+      }
+    engines: { node: '>= 0.6' }
 
   mime-types@3.0.2:
-    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==,
+      }
+    engines: { node: '>=18' }
 
   mime@2.6.0:
-    resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
-    engines: {node: '>=4.0.0'}
+    resolution:
+      {
+        integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==,
+      }
+    engines: { node: '>=4.0.0' }
     hasBin: true
 
   mimic-fn@2.1.0:
-    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==,
+      }
+    engines: { node: '>=6' }
 
   mimic-function@5.0.1:
-    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==,
+      }
+    engines: { node: '>=18' }
 
   minimatch@10.2.4:
-    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
-    engines: {node: 18 || 20 || >=22}
+    resolution:
+      {
+        integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==,
+      }
+    engines: { node: 18 || 20 || >=22 }
 
   minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+    resolution:
+      {
+        integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==,
+      }
 
   minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
-    engines: {node: '>=16 || 14 >=14.17'}
+    resolution:
+      {
+        integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==,
+      }
+    engines: { node: '>=16 || 14 >=14.17' }
 
   minizlib@3.1.0:
-    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
-    engines: {node: '>= 18'}
+    resolution:
+      {
+        integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==,
+      }
+    engines: { node: '>= 18' }
 
   mri@1.2.0:
-    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==,
+      }
+    engines: { node: '>=4' }
 
   ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+    resolution:
+      {
+        integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
+      }
 
   msgpackr-extract@3.0.3:
-    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
+    resolution:
+      {
+        integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==,
+      }
     hasBin: true
 
   msgpackr@1.11.5:
-    resolution: {integrity: sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA==}
+    resolution:
+      {
+        integrity: sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA==,
+      }
 
   mustache@4.2.0:
-    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    resolution:
+      {
+        integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==,
+      }
     hasBin: true
 
   mysql2@3.15.3:
-    resolution: {integrity: sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==}
-    engines: {node: '>= 8.0'}
+    resolution:
+      {
+        integrity: sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==,
+      }
+    engines: { node: '>= 8.0' }
 
   named-placeholders@1.1.6:
-    resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
-    engines: {node: '>=8.0.0'}
+    resolution:
+      {
+        integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==,
+      }
+    engines: { node: '>=8.0.0' }
 
   nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    resolution:
+      {
+        integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==,
+      }
+    engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
 
   natural-compare@1.4.0:
-    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+    resolution:
+      {
+        integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==,
+      }
 
   negotiator@1.0.0:
-    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==,
+      }
+    engines: { node: '>= 0.6' }
 
   node-abort-controller@3.1.1:
-    resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
+    resolution:
+      {
+        integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==,
+      }
 
   node-fetch-native@1.6.7:
-    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+    resolution:
+      {
+        integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==,
+      }
 
   node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
+    resolution:
+      {
+        integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==,
+      }
+    engines: { node: 4.x || >=6.0.0 }
     peerDependencies:
       encoding: ^0.1.0
     peerDependenciesMeta:
@@ -3472,85 +5606,151 @@ packages:
         optional: true
 
   node-gyp-build-optional-packages@5.2.2:
-    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    resolution:
+      {
+        integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==,
+      }
     hasBin: true
 
   node-sarif-builder@3.4.0:
-    resolution: {integrity: sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg==}
-    engines: {node: '>=20'}
+    resolution:
+      {
+        integrity: sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg==,
+      }
+    engines: { node: '>=20' }
 
   normalize-package-data@6.0.2:
-    resolution: {integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==}
-    engines: {node: ^16.14.0 || >=18.0.0}
+    resolution:
+      {
+        integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==,
+      }
+    engines: { node: ^16.14.0 || >=18.0.0 }
 
   npm-run-path@4.0.1:
-    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==,
+      }
+    engines: { node: '>=8' }
 
   nypm@0.6.5:
-    resolution: {integrity: sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==,
+      }
+    engines: { node: '>=18' }
     hasBin: true
 
   object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==,
+      }
+    engines: { node: '>=0.10.0' }
 
   object-inspect@1.13.4:
-    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==,
+      }
+    engines: { node: '>= 0.4' }
 
   object-keys@1.1.1:
-    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==,
+      }
+    engines: { node: '>= 0.4' }
 
   obug@2.1.1:
-    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+    resolution:
+      {
+        integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==,
+      }
 
   ohash@2.0.11:
-    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+    resolution:
+      {
+        integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==,
+      }
 
   on-exit-leak-free@2.1.2:
-    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
-    engines: {node: '>=14.0.0'}
+    resolution:
+      {
+        integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==,
+      }
+    engines: { node: '>=14.0.0' }
 
   on-finished@2.4.1:
-    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==,
+      }
+    engines: { node: '>= 0.8' }
 
   once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+    resolution:
+      {
+        integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==,
+      }
 
   onetime@5.1.2:
-    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==,
+      }
+    engines: { node: '>=6' }
 
   onetime@7.0.0:
-    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==,
+      }
+    engines: { node: '>=18' }
 
   onnxruntime-common@1.21.0:
-    resolution: {integrity: sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==}
+    resolution:
+      {
+        integrity: sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==,
+      }
 
   onnxruntime-common@1.22.0-dev.20250409-89f8206ba4:
-    resolution: {integrity: sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==}
+    resolution:
+      {
+        integrity: sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==,
+      }
 
   onnxruntime-common@1.24.3:
-    resolution: {integrity: sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==}
+    resolution:
+      {
+        integrity: sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==,
+      }
 
   onnxruntime-node@1.21.0:
-    resolution: {integrity: sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==}
+    resolution:
+      {
+        integrity: sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==,
+      }
     os: [win32, darwin, linux]
 
   onnxruntime-node@1.24.3:
-    resolution: {integrity: sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==}
+    resolution:
+      {
+        integrity: sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==,
+      }
     os: [win32, darwin, linux]
 
   onnxruntime-web@1.22.0-dev.20250409-89f8206ba4:
-    resolution: {integrity: sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==}
+    resolution:
+      {
+        integrity: sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==,
+      }
 
   openai@6.27.0:
-    resolution: {integrity: sha512-osTKySlrdYrLYTt0zjhY8yp0JUBmWDCN+Q+QxsV4xMQnnoVFpylgKGgxwN8sSdTNw0G4y+WUXs4eCMWpyDNWZQ==}
+    resolution:
+      {
+        integrity: sha512-osTKySlrdYrLYTt0zjhY8yp0JUBmWDCN+Q+QxsV4xMQnnoVFpylgKGgxwN8sSdTNw0G4y+WUXs4eCMWpyDNWZQ==,
+      }
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -3562,152 +5762,272 @@ packages:
         optional: true
 
   optionator@0.9.4:
-    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
-    engines: {node: '>= 0.8.0'}
+    resolution:
+      {
+        integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==,
+      }
+    engines: { node: '>= 0.8.0' }
 
   outdent@0.5.0:
-    resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
+    resolution:
+      {
+        integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==,
+      }
 
   oxc-resolver@11.19.1:
-    resolution: {integrity: sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg==}
+    resolution:
+      {
+        integrity: sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg==,
+      }
 
   p-filter@2.1.0:
-    resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==,
+      }
+    engines: { node: '>=8' }
 
   p-finally@1.0.0:
-    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==,
+      }
+    engines: { node: '>=4' }
 
   p-limit@2.3.0:
-    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==,
+      }
+    engines: { node: '>=6' }
 
   p-limit@3.1.0:
-    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==,
+      }
+    engines: { node: '>=10' }
 
   p-locate@4.1.0:
-    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==,
+      }
+    engines: { node: '>=8' }
 
   p-locate@5.0.0:
-    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==,
+      }
+    engines: { node: '>=10' }
 
   p-map@2.1.0:
-    resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==,
+      }
+    engines: { node: '>=6' }
 
   p-map@7.0.4:
-    resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==,
+      }
+    engines: { node: '>=18' }
 
   p-queue@6.6.2:
-    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==,
+      }
+    engines: { node: '>=8' }
 
   p-queue@9.1.0:
-    resolution: {integrity: sha512-O/ZPaXuQV29uSLbxWBGGZO1mCQXV2BLIwUr59JUU9SoH76mnYvtms7aafH/isNSNGwuEfP6W/4xD0/TJXxrizw==}
-    engines: {node: '>=20'}
+    resolution:
+      {
+        integrity: sha512-O/ZPaXuQV29uSLbxWBGGZO1mCQXV2BLIwUr59JUU9SoH76mnYvtms7aafH/isNSNGwuEfP6W/4xD0/TJXxrizw==,
+      }
+    engines: { node: '>=20' }
 
   p-retry@7.1.1:
-    resolution: {integrity: sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==}
-    engines: {node: '>=20'}
+    resolution:
+      {
+        integrity: sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==,
+      }
+    engines: { node: '>=20' }
 
   p-timeout@3.2.0:
-    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==,
+      }
+    engines: { node: '>=8' }
 
   p-timeout@7.0.1:
-    resolution: {integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==}
-    engines: {node: '>=20'}
+    resolution:
+      {
+        integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==,
+      }
+    engines: { node: '>=20' }
 
   p-try@2.2.0:
-    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==,
+      }
+    engines: { node: '>=6' }
 
   package-manager-detector@0.2.11:
-    resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
+    resolution:
+      {
+        integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==,
+      }
 
   parent-module@1.0.1:
-    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==,
+      }
+    engines: { node: '>=6' }
 
   parse-duration@2.1.5:
-    resolution: {integrity: sha512-/IX1KRw6zHDOOJrgIz++gvFASbFl7nc8GEXaLdD7d1t1x/GnrK6hh5Fgk8G3RLpkIEi4tsGj9pupGLWNg0EiJA==}
+    resolution:
+      {
+        integrity: sha512-/IX1KRw6zHDOOJrgIz++gvFASbFl7nc8GEXaLdD7d1t1x/GnrK6hh5Fgk8G3RLpkIEi4tsGj9pupGLWNg0EiJA==,
+      }
 
   parse-json@5.2.0:
-    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==,
+      }
+    engines: { node: '>=8' }
 
   parse-json@8.3.0:
-    resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==,
+      }
+    engines: { node: '>=18' }
 
   parseurl@1.3.3:
-    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==,
+      }
+    engines: { node: '>= 0.8' }
 
   path-browserify@1.0.1:
-    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+    resolution:
+      {
+        integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==,
+      }
 
   path-exists@4.0.0:
-    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==,
+      }
+    engines: { node: '>=8' }
 
   path-key@3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==,
+      }
+    engines: { node: '>=8' }
 
   path-parse@1.0.7:
-    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+    resolution:
+      {
+        integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==,
+      }
 
   path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+    resolution:
+      {
+        integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==,
+      }
 
   path-type@4.0.0:
-    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==,
+      }
+    engines: { node: '>=8' }
 
   path-type@6.0.0:
-    resolution: {integrity: sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==,
+      }
+    engines: { node: '>=18' }
 
   pathe@2.0.3:
-    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+    resolution:
+      {
+        integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
+      }
 
   perfect-debounce@1.0.0:
-    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+    resolution:
+      {
+        integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==,
+      }
 
   pg-cloudflare@1.3.0:
-    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+    resolution:
+      {
+        integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==,
+      }
 
   pg-connection-string@2.12.0:
-    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+    resolution:
+      {
+        integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==,
+      }
 
   pg-int8@1.0.1:
-    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
-    engines: {node: '>=4.0.0'}
+    resolution:
+      {
+        integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==,
+      }
+    engines: { node: '>=4.0.0' }
 
   pg-pool@3.13.0:
-    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
+    resolution:
+      {
+        integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==,
+      }
     peerDependencies:
       pg: '>=8.0'
 
   pg-protocol@1.11.0:
-    resolution: {integrity: sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==}
+    resolution:
+      {
+        integrity: sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==,
+      }
 
   pg-protocol@1.13.0:
-    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+    resolution:
+      {
+        integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==,
+      }
 
   pg-types@2.2.0:
-    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==,
+      }
+    engines: { node: '>=4' }
 
   pg@8.20.0:
-    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
-    engines: {node: '>= 16.0.0'}
+    resolution:
+      {
+        integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==,
+      }
+    engines: { node: '>= 16.0.0' }
     peerDependencies:
       pg-native: '>=3.0.1'
     peerDependenciesMeta:
@@ -3715,108 +6035,189 @@ packages:
         optional: true
 
   pglite-prisma-adapter@0.7.2:
-    resolution: {integrity: sha512-NqLXIUguFbgEHpIoyCvAbpEurbK+AUukiv96gIogVnNYWBdhAU0idfTXcJrsS7OdWenYa8QxEQM2ND1cTQrU4g==}
+    resolution:
+      {
+        integrity: sha512-NqLXIUguFbgEHpIoyCvAbpEurbK+AUukiv96gIogVnNYWBdhAU0idfTXcJrsS7OdWenYa8QxEQM2ND1cTQrU4g==,
+      }
     peerDependencies:
       '@electric-sql/pglite': '>=0.2.0'
       '@prisma/client': '>= 7.1.0'
 
   pgpass@1.0.5:
-    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+    resolution:
+      {
+        integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==,
+      }
 
   picocolors@1.1.1:
-    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+    resolution:
+      {
+        integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
+      }
 
   picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
-    engines: {node: '>=8.6'}
+    resolution:
+      {
+        integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==,
+      }
+    engines: { node: '>=8.6' }
 
   picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==,
+      }
+    engines: { node: '>=12' }
 
   pify@4.0.1:
-    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==,
+      }
+    engines: { node: '>=6' }
 
   pino-abstract-transport@3.0.0:
-    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+    resolution:
+      {
+        integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==,
+      }
 
   pino-http@11.0.0:
-    resolution: {integrity: sha512-wqg5XIAGRRIWtTk8qPGxkbrfiwEWz1lgedVLvhLALudKXvg1/L2lTFgTGPJ4Z2e3qcRmxoFxDuSdMdMGNM6I1g==}
+    resolution:
+      {
+        integrity: sha512-wqg5XIAGRRIWtTk8qPGxkbrfiwEWz1lgedVLvhLALudKXvg1/L2lTFgTGPJ4Z2e3qcRmxoFxDuSdMdMGNM6I1g==,
+      }
 
   pino-pretty@13.1.3:
-    resolution: {integrity: sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==}
+    resolution:
+      {
+        integrity: sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==,
+      }
     hasBin: true
 
   pino-std-serializers@7.1.0:
-    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+    resolution:
+      {
+        integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==,
+      }
 
   pino@10.3.1:
-    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    resolution:
+      {
+        integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==,
+      }
     hasBin: true
 
   pkg-types@2.3.0:
-    resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+    resolution:
+      {
+        integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==,
+      }
 
   platform@1.3.6:
-    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
+    resolution:
+      {
+        integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==,
+      }
 
   plur@5.1.0:
-    resolution: {integrity: sha512-VP/72JeXqak2KiOzjgKtQen5y3IZHn+9GOuLDafPv0eXa47xq0At93XahYBs26MsifCQ4enGKwbjBTKgb9QJXg==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    resolution:
+      {
+        integrity: sha512-VP/72JeXqak2KiOzjgKtQen5y3IZHn+9GOuLDafPv0eXa47xq0At93XahYBs26MsifCQ4enGKwbjBTKgb9QJXg==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
 
   pluralize@2.0.0:
-    resolution: {integrity: sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw==}
+    resolution:
+      {
+        integrity: sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw==,
+      }
 
   pluralize@8.0.0:
-    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==,
+      }
+    engines: { node: '>=4' }
 
   postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
-    engines: {node: ^10 || ^12 || >=14}
+    resolution:
+      {
+        integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==,
+      }
+    engines: { node: ^10 || ^12 || >=14 }
 
   postgres-array@2.0.0:
-    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==,
+      }
+    engines: { node: '>=4' }
 
   postgres-array@3.0.4:
-    resolution: {integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==,
+      }
+    engines: { node: '>=12' }
 
   postgres-bytea@1.0.1:
-    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==,
+      }
+    engines: { node: '>=0.10.0' }
 
   postgres-date@1.0.7:
-    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==,
+      }
+    engines: { node: '>=0.10.0' }
 
   postgres-interval@1.2.0:
-    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==,
+      }
+    engines: { node: '>=0.10.0' }
 
   postgres@3.4.7:
-    resolution: {integrity: sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==,
+      }
+    engines: { node: '>=12' }
 
   prelude-ls@1.2.1:
-    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
-    engines: {node: '>= 0.8.0'}
+    resolution:
+      {
+        integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==,
+      }
+    engines: { node: '>= 0.8.0' }
 
   prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
-    engines: {node: '>=10.13.0'}
+    resolution:
+      {
+        integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==,
+      }
+    engines: { node: '>=10.13.0' }
     hasBin: true
 
   prettier@3.8.1:
-    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
-    engines: {node: '>=14'}
+    resolution:
+      {
+        integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==,
+      }
+    engines: { node: '>=14' }
     hasBin: true
 
   prisma@7.4.2:
-    resolution: {integrity: sha512-2bP8Ruww3Q95Z2eH4Yqh4KAENRsj/SxbdknIVBfd6DmjPwmpsC4OVFMLOeHt6tM3Amh8ebjvstrUz3V/hOe1dA==}
-    engines: {node: ^20.19 || ^22.12 || >=24.0}
+    resolution:
+      {
+        integrity: sha512-2bP8Ruww3Q95Z2eH4Yqh4KAENRsj/SxbdknIVBfd6DmjPwmpsC4OVFMLOeHt6tM3Amh8ebjvstrUz3V/hOe1dA==,
+      }
+    engines: { node: ^20.19 || ^22.12 || >=24.0 }
     hasBin: true
     peerDependencies:
       better-sqlite3: '>=9.0.0'
@@ -3828,687 +6229,1230 @@ packages:
         optional: true
 
   process-warning@5.0.0:
-    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+    resolution:
+      {
+        integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==,
+      }
 
   promise@7.3.1:
-    resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
+    resolution:
+      {
+        integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==,
+      }
 
   prompts@2.4.2:
-    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
-    engines: {node: '>= 6'}
+    resolution:
+      {
+        integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==,
+      }
+    engines: { node: '>= 6' }
 
   proper-lockfile@4.1.2:
-    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+    resolution:
+      {
+        integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==,
+      }
 
   protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
-    engines: {node: '>=12.0.0'}
+    resolution:
+      {
+        integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==,
+      }
+    engines: { node: '>=12.0.0' }
 
   proxy-addr@2.0.7:
-    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
-    engines: {node: '>= 0.10'}
+    resolution:
+      {
+        integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==,
+      }
+    engines: { node: '>= 0.10' }
 
   pug-attrs@3.0.0:
-    resolution: {integrity: sha512-azINV9dUtzPMFQktvTXciNAfAuVh/L/JCl0vtPCwvOA21uZrC08K/UnmrL+SXGEVc1FwzjW62+xw5S/uaLj6cA==}
+    resolution:
+      {
+        integrity: sha512-azINV9dUtzPMFQktvTXciNAfAuVh/L/JCl0vtPCwvOA21uZrC08K/UnmrL+SXGEVc1FwzjW62+xw5S/uaLj6cA==,
+      }
 
   pug-code-gen@3.0.3:
-    resolution: {integrity: sha512-cYQg0JW0w32Ux+XTeZnBEeuWrAY7/HNE6TWnhiHGnnRYlCgyAUPoyh9KzCMa9WhcJlJ1AtQqpEYHc+vbCzA+Aw==}
+    resolution:
+      {
+        integrity: sha512-cYQg0JW0w32Ux+XTeZnBEeuWrAY7/HNE6TWnhiHGnnRYlCgyAUPoyh9KzCMa9WhcJlJ1AtQqpEYHc+vbCzA+Aw==,
+      }
 
   pug-error@2.1.0:
-    resolution: {integrity: sha512-lv7sU9e5Jk8IeUheHata6/UThZ7RK2jnaaNztxfPYUY+VxZyk/ePVaNZ/vwmH8WqGvDz3LrNYt/+gA55NDg6Pg==}
+    resolution:
+      {
+        integrity: sha512-lv7sU9e5Jk8IeUheHata6/UThZ7RK2jnaaNztxfPYUY+VxZyk/ePVaNZ/vwmH8WqGvDz3LrNYt/+gA55NDg6Pg==,
+      }
 
   pug-filters@4.0.0:
-    resolution: {integrity: sha512-yeNFtq5Yxmfz0f9z2rMXGw/8/4i1cCFecw/Q7+D0V2DdtII5UvqE12VaZ2AY7ri6o5RNXiweGH79OCq+2RQU4A==}
+    resolution:
+      {
+        integrity: sha512-yeNFtq5Yxmfz0f9z2rMXGw/8/4i1cCFecw/Q7+D0V2DdtII5UvqE12VaZ2AY7ri6o5RNXiweGH79OCq+2RQU4A==,
+      }
 
   pug-lexer@5.0.1:
-    resolution: {integrity: sha512-0I6C62+keXlZPZkOJeVam9aBLVP2EnbeDw3An+k0/QlqdwH6rv8284nko14Na7c0TtqtogfWXcRoFE4O4Ff20w==}
+    resolution:
+      {
+        integrity: sha512-0I6C62+keXlZPZkOJeVam9aBLVP2EnbeDw3An+k0/QlqdwH6rv8284nko14Na7c0TtqtogfWXcRoFE4O4Ff20w==,
+      }
 
   pug-linker@4.0.0:
-    resolution: {integrity: sha512-gjD1yzp0yxbQqnzBAdlhbgoJL5qIFJw78juN1NpTLt/mfPJ5VgC4BvkoD3G23qKzJtIIXBbcCt6FioLSFLOHdw==}
+    resolution:
+      {
+        integrity: sha512-gjD1yzp0yxbQqnzBAdlhbgoJL5qIFJw78juN1NpTLt/mfPJ5VgC4BvkoD3G23qKzJtIIXBbcCt6FioLSFLOHdw==,
+      }
 
   pug-load@3.0.0:
-    resolution: {integrity: sha512-OCjTEnhLWZBvS4zni/WUMjH2YSUosnsmjGBB1An7CsKQarYSWQ0GCVyd4eQPMFJqZ8w9xgs01QdiZXKVjk92EQ==}
+    resolution:
+      {
+        integrity: sha512-OCjTEnhLWZBvS4zni/WUMjH2YSUosnsmjGBB1An7CsKQarYSWQ0GCVyd4eQPMFJqZ8w9xgs01QdiZXKVjk92EQ==,
+      }
 
   pug-parser@6.0.0:
-    resolution: {integrity: sha512-ukiYM/9cH6Cml+AOl5kETtM9NR3WulyVP2y4HOU45DyMim1IeP/OOiyEWRr6qk5I5klpsBnbuHpwKmTx6WURnw==}
+    resolution:
+      {
+        integrity: sha512-ukiYM/9cH6Cml+AOl5kETtM9NR3WulyVP2y4HOU45DyMim1IeP/OOiyEWRr6qk5I5klpsBnbuHpwKmTx6WURnw==,
+      }
 
   pug-runtime@3.0.1:
-    resolution: {integrity: sha512-L50zbvrQ35TkpHwv0G6aLSuueDRwc/97XdY8kL3tOT0FmhgG7UypU3VztfV/LATAvmUfYi4wNxSajhSAeNN+Kg==}
+    resolution:
+      {
+        integrity: sha512-L50zbvrQ35TkpHwv0G6aLSuueDRwc/97XdY8kL3tOT0FmhgG7UypU3VztfV/LATAvmUfYi4wNxSajhSAeNN+Kg==,
+      }
 
   pug-strip-comments@2.0.0:
-    resolution: {integrity: sha512-zo8DsDpH7eTkPHCXFeAk1xZXJbyoTfdPlNR0bK7rpOMuhBYb0f5qUVCO1xlsitYd3w5FQTK7zpNVKb3rZoUrrQ==}
+    resolution:
+      {
+        integrity: sha512-zo8DsDpH7eTkPHCXFeAk1xZXJbyoTfdPlNR0bK7rpOMuhBYb0f5qUVCO1xlsitYd3w5FQTK7zpNVKb3rZoUrrQ==,
+      }
 
   pug-walk@2.0.0:
-    resolution: {integrity: sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ==}
+    resolution:
+      {
+        integrity: sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ==,
+      }
 
   pug@3.0.3:
-    resolution: {integrity: sha512-uBi6kmc9f3SZ3PXxqcHiUZLmIXgfgWooKWXcwSGwQd2Zi5Rb0bT14+8CJjJgI8AB+nndLaNgHGrcc6bPIB665g==}
+    resolution:
+      {
+        integrity: sha512-uBi6kmc9f3SZ3PXxqcHiUZLmIXgfgWooKWXcwSGwQd2Zi5Rb0bT14+8CJjJgI8AB+nndLaNgHGrcc6bPIB665g==,
+      }
 
   pump@3.0.3:
-    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
+    resolution:
+      {
+        integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==,
+      }
 
   punycode@2.3.1:
-    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==,
+      }
+    engines: { node: '>=6' }
 
   pure-rand@6.1.0:
-    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+    resolution:
+      {
+        integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==,
+      }
 
   qs@6.15.0:
-    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
-    engines: {node: '>=0.6'}
+    resolution:
+      {
+        integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==,
+      }
+    engines: { node: '>=0.6' }
 
   quansync@0.2.11:
-    resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
+    resolution:
+      {
+        integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==,
+      }
 
   queue-microtask@1.2.3:
-    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+    resolution:
+      {
+        integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==,
+      }
 
   quick-format-unescaped@4.0.4:
-    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+    resolution:
+      {
+        integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==,
+      }
 
   range-parser@1.2.1:
-    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==,
+      }
+    engines: { node: '>= 0.6' }
 
   raw-body@3.0.2:
-    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
-    engines: {node: '>= 0.10'}
+    resolution:
+      {
+        integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==,
+      }
+    engines: { node: '>= 0.10' }
 
   rc-config-loader@4.1.3:
-    resolution: {integrity: sha512-kD7FqML7l800i6pS6pvLyIE2ncbk9Du8Q0gp/4hMPhJU6ZxApkoLcGD8ZeqgiAlfwZ6BlETq6qqe+12DUL207w==}
+    resolution:
+      {
+        integrity: sha512-kD7FqML7l800i6pS6pvLyIE2ncbk9Du8Q0gp/4hMPhJU6ZxApkoLcGD8ZeqgiAlfwZ6BlETq6qqe+12DUL207w==,
+      }
 
   rc9@2.1.2:
-    resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
+    resolution:
+      {
+        integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==,
+      }
 
   react-dom@19.2.0:
-    resolution: {integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==}
+    resolution:
+      {
+        integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==,
+      }
     peerDependencies:
       react: ^19.2.0
 
   react@19.2.0:
-    resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==,
+      }
+    engines: { node: '>=0.10.0' }
 
   read-pkg@9.0.1:
-    resolution: {integrity: sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==,
+      }
+    engines: { node: '>=18' }
 
   read-yaml-file@1.1.0:
-    resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==,
+      }
+    engines: { node: '>=6' }
 
   readdirp@4.1.2:
-    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
-    engines: {node: '>= 14.18.0'}
+    resolution:
+      {
+        integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==,
+      }
+    engines: { node: '>= 14.18.0' }
 
   real-require@0.2.0:
-    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
-    engines: {node: '>= 12.13.0'}
+    resolution:
+      {
+        integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==,
+      }
+    engines: { node: '>= 12.13.0' }
 
   rechoir@0.8.0:
-    resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
-    engines: {node: '>= 10.13.0'}
+    resolution:
+      {
+        integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==,
+      }
+    engines: { node: '>= 10.13.0' }
 
   redis-errors@1.2.0:
-    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==,
+      }
+    engines: { node: '>=4' }
 
   redis-parser@3.0.0:
-    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==,
+      }
+    engines: { node: '>=4' }
 
   redis@5.11.0:
-    resolution: {integrity: sha512-YwXjATVDT+AuxcyfOwZn046aml9jMlQPvU1VXIlLDVAExe0u93aTfPYSeRgG4p9Q/Jlkj+LXJ1XEoFV+j2JKcQ==}
-    engines: {node: '>= 18'}
+    resolution:
+      {
+        integrity: sha512-YwXjATVDT+AuxcyfOwZn046aml9jMlQPvU1VXIlLDVAExe0u93aTfPYSeRgG4p9Q/Jlkj+LXJ1XEoFV+j2JKcQ==,
+      }
+    engines: { node: '>= 18' }
 
   refa@0.12.1:
-    resolution: {integrity: sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==}
-    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+    resolution:
+      {
+        integrity: sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==,
+      }
+    engines: { node: ^12.0.0 || ^14.0.0 || >=16.0.0 }
 
   regexp-ast-analysis@0.7.1:
-    resolution: {integrity: sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==}
-    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+    resolution:
+      {
+        integrity: sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==,
+      }
+    engines: { node: ^12.0.0 || ^14.0.0 || >=16.0.0 }
 
   regexp-to-ast@0.5.0:
-    resolution: {integrity: sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==}
+    resolution:
+      {
+        integrity: sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==,
+      }
 
   regexp-tree@0.1.27:
-    resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
+    resolution:
+      {
+        integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==,
+      }
     hasBin: true
 
   remeda@2.33.4:
-    resolution: {integrity: sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ==}
+    resolution:
+      {
+        integrity: sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ==,
+      }
 
   repeat-string@1.6.1:
-    resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
-    engines: {node: '>=0.10'}
+    resolution:
+      {
+        integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==,
+      }
+    engines: { node: '>=0.10' }
 
   reprism@0.0.11:
-    resolution: {integrity: sha512-VsxDR5QxZo08M/3nRypNlScw5r3rKeSOPdU/QhDmu3Ai3BJxHn/qgfXGWQp/tAxUtzwYNo9W6997JZR0tPLZsA==}
+    resolution:
+      {
+        integrity: sha512-VsxDR5QxZo08M/3nRypNlScw5r3rKeSOPdU/QhDmu3Ai3BJxHn/qgfXGWQp/tAxUtzwYNo9W6997JZR0tPLZsA==,
+      }
 
   require-directory@2.1.1:
-    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==,
+      }
+    engines: { node: '>=0.10.0' }
 
   require-from-string@2.0.2:
-    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==,
+      }
+    engines: { node: '>=0.10.0' }
 
   resolve-from@4.0.0:
-    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==,
+      }
+    engines: { node: '>=4' }
 
   resolve-from@5.0.0:
-    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==,
+      }
+    engines: { node: '>=8' }
 
   resolve-pkg-maps@1.0.0:
-    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+    resolution:
+      {
+        integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==,
+      }
 
   resolve@1.22.11:
-    resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==,
+      }
+    engines: { node: '>= 0.4' }
     hasBin: true
 
   restore-cursor@5.1.0:
-    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==,
+      }
+    engines: { node: '>=18' }
 
   retry@0.12.0:
-    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
-    engines: {node: '>= 4'}
+    resolution:
+      {
+        integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==,
+      }
+    engines: { node: '>= 4' }
 
   reusify@1.1.0:
-    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
-    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==,
+      }
+    engines: { iojs: '>=1.0.0', node: '>=0.10.0' }
 
   rfdc@1.4.1:
-    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+    resolution:
+      {
+        integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==,
+      }
 
   roarr@2.15.4:
-    resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
-    engines: {node: '>=8.0'}
+    resolution:
+      {
+        integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==,
+      }
+    engines: { node: '>=8.0' }
 
   rollup@4.59.0:
-    resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    resolution:
+      {
+        integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==,
+      }
+    engines: { node: '>=18.0.0', npm: '>=8.0.0' }
     hasBin: true
 
   router@2.2.0:
-    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
-    engines: {node: '>= 18'}
+    resolution:
+      {
+        integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==,
+      }
+    engines: { node: '>= 18' }
 
   run-parallel@1.2.0:
-    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+    resolution:
+      {
+        integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==,
+      }
 
   safe-regex@2.1.1:
-    resolution: {integrity: sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==}
+    resolution:
+      {
+        integrity: sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==,
+      }
 
   safe-stable-stringify@2.5.0:
-    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==,
+      }
+    engines: { node: '>=10' }
 
   safer-buffer@2.1.2:
-    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+    resolution:
+      {
+        integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
+      }
 
   scheduler@0.27.0:
-    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+    resolution:
+      {
+        integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==,
+      }
 
   scslre@0.3.0:
-    resolution: {integrity: sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==}
-    engines: {node: ^14.0.0 || >=16.0.0}
+    resolution:
+      {
+        integrity: sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==,
+      }
+    engines: { node: ^14.0.0 || >=16.0.0 }
 
   secretlint@11.3.1:
-    resolution: {integrity: sha512-CThioOhzkK/D7CdwYw2WgNaIAS4pTjUMb9aN296zNVxQV02aJIjzjfRS5Bih/auHXd0mHSfypGYLj5mmjUleNw==}
-    engines: {node: '>=20.0.0'}
+    resolution:
+      {
+        integrity: sha512-CThioOhzkK/D7CdwYw2WgNaIAS4pTjUMb9aN296zNVxQV02aJIjzjfRS5Bih/auHXd0mHSfypGYLj5mmjUleNw==,
+      }
+    engines: { node: '>=20.0.0' }
     hasBin: true
 
   secure-json-parse@4.1.0:
-    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
+    resolution:
+      {
+        integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==,
+      }
 
   semver-compare@1.0.0:
-    resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
+    resolution:
+      {
+        integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==,
+      }
 
   semver@7.7.3:
-    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==,
+      }
+    engines: { node: '>=10' }
     hasBin: true
 
   semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==,
+      }
+    engines: { node: '>=10' }
     hasBin: true
 
   send@1.2.1:
-    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
-    engines: {node: '>= 18'}
+    resolution:
+      {
+        integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==,
+      }
+    engines: { node: '>= 18' }
 
   seq-queue@0.0.5:
-    resolution: {integrity: sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==}
+    resolution:
+      {
+        integrity: sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==,
+      }
 
   serialize-error@7.0.1:
-    resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==,
+      }
+    engines: { node: '>=10' }
 
   serve-static@2.2.1:
-    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
-    engines: {node: '>= 18'}
+    resolution:
+      {
+        integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==,
+      }
+    engines: { node: '>= 18' }
 
   setprototypeof@1.2.0:
-    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+    resolution:
+      {
+        integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==,
+      }
 
   sharp@0.34.5:
-    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    resolution:
+      {
+        integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
 
   shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==,
+      }
+    engines: { node: '>=8' }
 
   shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
+      }
+    engines: { node: '>=8' }
 
   side-channel-list@1.0.0:
-    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==,
+      }
+    engines: { node: '>= 0.4' }
 
   side-channel-map@1.0.1:
-    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==,
+      }
+    engines: { node: '>= 0.4' }
 
   side-channel-weakmap@1.0.2:
-    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==,
+      }
+    engines: { node: '>= 0.4' }
 
   side-channel@1.1.0:
-    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==,
+      }
+    engines: { node: '>= 0.4' }
 
   siginfo@2.0.0:
-    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+    resolution:
+      {
+        integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==,
+      }
 
   signal-exit@3.0.7:
-    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+    resolution:
+      {
+        integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==,
+      }
 
   signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
+    resolution:
+      {
+        integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==,
+      }
+    engines: { node: '>=14' }
 
   simple-wcswidth@1.1.2:
-    resolution: {integrity: sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==}
+    resolution:
+      {
+        integrity: sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==,
+      }
 
   sisteransi@1.0.5:
-    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+    resolution:
+      {
+        integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==,
+      }
 
   slash@3.0.0:
-    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==,
+      }
+    engines: { node: '>=8' }
 
   slash@5.1.0:
-    resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
-    engines: {node: '>=14.16'}
+    resolution:
+      {
+        integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==,
+      }
+    engines: { node: '>=14.16' }
 
   slice-ansi@4.0.0:
-    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==,
+      }
+    engines: { node: '>=10' }
 
   slice-ansi@7.1.2:
-    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==,
+      }
+    engines: { node: '>=18' }
 
   slice-ansi@8.0.0:
-    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
-    engines: {node: '>=20'}
+    resolution:
+      {
+        integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==,
+      }
+    engines: { node: '>=20' }
 
   smol-toml@1.6.0:
-    resolution: {integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==}
-    engines: {node: '>= 18'}
+    resolution:
+      {
+        integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==,
+      }
+    engines: { node: '>= 18' }
 
   sonic-boom@4.2.0:
-    resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
+    resolution:
+      {
+        integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==,
+      }
 
   source-map-js@1.2.1:
-    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==,
+      }
+    engines: { node: '>=0.10.0' }
 
   spark-md5@3.0.2:
-    resolution: {integrity: sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==}
+    resolution:
+      {
+        integrity: sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==,
+      }
 
   spawndamnit@3.0.1:
-    resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
+    resolution:
+      {
+        integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==,
+      }
 
   spdx-correct@3.2.0:
-    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
+    resolution:
+      {
+        integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==,
+      }
 
   spdx-exceptions@2.5.0:
-    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+    resolution:
+      {
+        integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==,
+      }
 
   spdx-expression-parse@3.0.1:
-    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+    resolution:
+      {
+        integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==,
+      }
 
   spdx-license-ids@3.0.22:
-    resolution: {integrity: sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==}
+    resolution:
+      {
+        integrity: sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==,
+      }
 
   split2@4.2.0:
-    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
-    engines: {node: '>= 10.x'}
+    resolution:
+      {
+        integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==,
+      }
+    engines: { node: '>= 10.x' }
 
   sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+    resolution:
+      {
+        integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==,
+      }
 
   sprintf-js@1.1.3:
-    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+    resolution:
+      {
+        integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==,
+      }
 
   sqlstring@2.3.3:
-    resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==,
+      }
+    engines: { node: '>= 0.6' }
 
   stackback@0.0.2:
-    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+    resolution:
+      {
+        integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==,
+      }
 
   standard-as-callback@2.1.0:
-    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+    resolution:
+      {
+        integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==,
+      }
 
   statuses@2.0.2:
-    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==,
+      }
+    engines: { node: '>= 0.8' }
 
   std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+    resolution:
+      {
+        integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==,
+      }
 
   string-argv@0.3.2:
-    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
-    engines: {node: '>=0.6.19'}
+    resolution:
+      {
+        integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==,
+      }
+    engines: { node: '>=0.6.19' }
 
   string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==,
+      }
+    engines: { node: '>=8' }
 
   string-width@7.2.0:
-    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==,
+      }
+    engines: { node: '>=18' }
 
   string-width@8.1.1:
-    resolution: {integrity: sha512-KpqHIdDL9KwYk22wEOg/VIqYbrnLeSApsKT/bSj6Ez7pn3CftUiLAv2Lccpq1ALcpLV9UX1Ppn92npZWu2w/aw==}
-    engines: {node: '>=20'}
+    resolution:
+      {
+        integrity: sha512-KpqHIdDL9KwYk22wEOg/VIqYbrnLeSApsKT/bSj6Ez7pn3CftUiLAv2Lccpq1ALcpLV9UX1Ppn92npZWu2w/aw==,
+      }
+    engines: { node: '>=20' }
 
   string-width@8.2.0:
-    resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
-    engines: {node: '>=20'}
+    resolution:
+      {
+        integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==,
+      }
+    engines: { node: '>=20' }
 
   strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==,
+      }
+    engines: { node: '>=8' }
 
   strip-ansi@7.2.0:
-    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==,
+      }
+    engines: { node: '>=12' }
 
   strip-bom@3.0.0:
-    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==,
+      }
+    engines: { node: '>=4' }
 
   strip-final-newline@2.0.0:
-    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==,
+      }
+    engines: { node: '>=6' }
 
   strip-json-comments@3.1.1:
-    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==,
+      }
+    engines: { node: '>=8' }
 
   strip-json-comments@5.0.3:
-    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
-    engines: {node: '>=14.16'}
+    resolution:
+      {
+        integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==,
+      }
+    engines: { node: '>=14.16' }
 
   strnum@2.2.0:
-    resolution: {integrity: sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==}
+    resolution:
+      {
+        integrity: sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==,
+      }
 
   structured-source@4.0.0:
-    resolution: {integrity: sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==}
+    resolution:
+      {
+        integrity: sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==,
+      }
 
   superagent@10.3.0:
-    resolution: {integrity: sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==}
-    engines: {node: '>=14.18.0'}
+    resolution:
+      {
+        integrity: sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==,
+      }
+    engines: { node: '>=14.18.0' }
 
   supertest@7.2.2:
-    resolution: {integrity: sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==}
-    engines: {node: '>=14.18.0'}
+    resolution:
+      {
+        integrity: sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==,
+      }
+    engines: { node: '>=14.18.0' }
 
   supports-color@10.2.2:
-    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==,
+      }
+    engines: { node: '>=18' }
 
   supports-color@7.2.0:
-    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==,
+      }
+    engines: { node: '>=8' }
 
   supports-hyperlinks@3.2.0:
-    resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
-    engines: {node: '>=14.18'}
+    resolution:
+      {
+        integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==,
+      }
+    engines: { node: '>=14.18' }
 
   supports-hyperlinks@4.4.0:
-    resolution: {integrity: sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==}
-    engines: {node: '>=20'}
+    resolution:
+      {
+        integrity: sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==,
+      }
+    engines: { node: '>=20' }
 
   supports-preserve-symlinks-flag@1.0.0:
-    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==,
+      }
+    engines: { node: '>= 0.4' }
 
   table@6.9.0:
-    resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
-    engines: {node: '>=10.0.0'}
+    resolution:
+      {
+        integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==,
+      }
+    engines: { node: '>=10.0.0' }
 
   tapable@2.3.0:
-    resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==,
+      }
+    engines: { node: '>=6' }
 
   tar@7.5.10:
-    resolution: {integrity: sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==,
+      }
+    engines: { node: '>=18' }
 
   term-size@2.2.1:
-    resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==,
+      }
+    engines: { node: '>=8' }
 
   terminal-link@4.0.0:
-    resolution: {integrity: sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA==,
+      }
+    engines: { node: '>=18' }
 
   text-table@0.2.0:
-    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+    resolution:
+      {
+        integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==,
+      }
 
   textextensions@6.11.0:
-    resolution: {integrity: sha512-tXJwSr9355kFJI3lbCkPpUH5cP8/M0GGy2xLO34aZCjMXBaK3SoPnZwr/oWmo1FdCnELcs4npdCIOFtq9W3ruQ==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-tXJwSr9355kFJI3lbCkPpUH5cP8/M0GGy2xLO34aZCjMXBaK3SoPnZwr/oWmo1FdCnELcs4npdCIOFtq9W3ruQ==,
+      }
+    engines: { node: '>=4' }
 
   thingies@2.5.0:
-    resolution: {integrity: sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw==}
-    engines: {node: '>=10.18'}
+    resolution:
+      {
+        integrity: sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw==,
+      }
+    engines: { node: '>=10.18' }
     peerDependencies:
       tslib: ^2
 
   thread-stream@4.0.0:
-    resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
-    engines: {node: '>=20'}
+    resolution:
+      {
+        integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==,
+      }
+    engines: { node: '>=20' }
 
   tiktoken@1.0.22:
-    resolution: {integrity: sha512-PKvy1rVF1RibfF3JlXBSP0Jrcw2uq3yXdgcEXtKTYn3QJ/cBRBHDnrJ5jHky+MENZ6DIPwNUGWpkVx+7joCpNA==}
+    resolution:
+      {
+        integrity: sha512-PKvy1rVF1RibfF3JlXBSP0Jrcw2uq3yXdgcEXtKTYn3QJ/cBRBHDnrJ5jHky+MENZ6DIPwNUGWpkVx+7joCpNA==,
+      }
 
   tinybench@2.9.0:
-    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+    resolution:
+      {
+        integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==,
+      }
 
   tinyexec@1.0.2:
-    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==,
+      }
+    engines: { node: '>=18' }
 
   tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
+    resolution:
+      {
+        integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==,
+      }
+    engines: { node: '>=12.0.0' }
 
   tinyrainbow@3.0.3:
-    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
-    engines: {node: '>=14.0.0'}
+    resolution:
+      {
+        integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==,
+      }
+    engines: { node: '>=14.0.0' }
 
   to-regex-range@5.0.1:
-    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
-    engines: {node: '>=8.0'}
+    resolution:
+      {
+        integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==,
+      }
+    engines: { node: '>=8.0' }
 
   toidentifier@1.0.1:
-    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
-    engines: {node: '>=0.6'}
+    resolution:
+      {
+        integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==,
+      }
+    engines: { node: '>=0.6' }
 
   token-stream@1.0.0:
-    resolution: {integrity: sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==}
+    resolution:
+      {
+        integrity: sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==,
+      }
 
   tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+    resolution:
+      {
+        integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==,
+      }
 
   tree-dump@1.1.0:
-    resolution: {integrity: sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==}
-    engines: {node: '>=10.0'}
+    resolution:
+      {
+        integrity: sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==,
+      }
+    engines: { node: '>=10.0' }
     peerDependencies:
       tslib: '2'
 
   ts-api-utils@2.4.0:
-    resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
-    engines: {node: '>=18.12'}
+    resolution:
+      {
+        integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==,
+      }
+    engines: { node: '>=18.12' }
     peerDependencies:
       typescript: '>=4.8.4'
 
   ts-mixer@6.0.4:
-    resolution: {integrity: sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==}
+    resolution:
+      {
+        integrity: sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==,
+      }
 
   ts-morph@27.0.2:
-    resolution: {integrity: sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w==}
+    resolution:
+      {
+        integrity: sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w==,
+      }
 
   tsconfig-paths-webpack-plugin@4.2.0:
-    resolution: {integrity: sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==}
-    engines: {node: '>=10.13.0'}
+    resolution:
+      {
+        integrity: sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==,
+      }
+    engines: { node: '>=10.13.0' }
 
   tsconfig-paths@4.2.0:
-    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
-    engines: {node: '>=6'}
+    resolution:
+      {
+        integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==,
+      }
+    engines: { node: '>=6' }
 
   tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+    resolution:
+      {
+        integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
+      }
 
   tsx@4.21.0:
-    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
-    engines: {node: '>=18.0.0'}
+    resolution:
+      {
+        integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==,
+      }
+    engines: { node: '>=18.0.0' }
     hasBin: true
 
   turbo-darwin-64@2.8.14:
-    resolution: {integrity: sha512-9sFi7n2lLfEsGWi5OEoA/eTtQU2BPKtzSYKqufMtDeRmqMT9vKjbv9gJCRkllSVE9BOXA0qXC3diyX8V8rKIKw==}
+    resolution:
+      {
+        integrity: sha512-9sFi7n2lLfEsGWi5OEoA/eTtQU2BPKtzSYKqufMtDeRmqMT9vKjbv9gJCRkllSVE9BOXA0qXC3diyX8V8rKIKw==,
+      }
     cpu: [x64]
     os: [darwin]
 
   turbo-darwin-arm64@2.8.14:
-    resolution: {integrity: sha512-aS4yJuy6A1PCLws+PJpZP0qCURG8Y5iVx13z/WAbKyeDTY6W6PiGgcEllSaeLGxyn++382ztN/EZH85n2zZ6VQ==}
+    resolution:
+      {
+        integrity: sha512-aS4yJuy6A1PCLws+PJpZP0qCURG8Y5iVx13z/WAbKyeDTY6W6PiGgcEllSaeLGxyn++382ztN/EZH85n2zZ6VQ==,
+      }
     cpu: [arm64]
     os: [darwin]
 
   turbo-linux-64@2.8.14:
-    resolution: {integrity: sha512-XC6wPUDJkakjhNLaS0NrHDMiujRVjH+naEAwvKLArgqRaFkNxjmyNDRM4eu3soMMFmjym6NTxYaF74rvET+Orw==}
+    resolution:
+      {
+        integrity: sha512-XC6wPUDJkakjhNLaS0NrHDMiujRVjH+naEAwvKLArgqRaFkNxjmyNDRM4eu3soMMFmjym6NTxYaF74rvET+Orw==,
+      }
     cpu: [x64]
     os: [linux]
 
   turbo-linux-arm64@2.8.14:
-    resolution: {integrity: sha512-ChfE7isyVNjZrVSPDwcfqcHLG/FuIBbOFxnt1FM8vSuBGzHAs8AlTdwFNIxlEMJfZ8Ad9mdMxdmsCUPIWiQ6cg==}
+    resolution:
+      {
+        integrity: sha512-ChfE7isyVNjZrVSPDwcfqcHLG/FuIBbOFxnt1FM8vSuBGzHAs8AlTdwFNIxlEMJfZ8Ad9mdMxdmsCUPIWiQ6cg==,
+      }
     cpu: [arm64]
     os: [linux]
 
   turbo-windows-64@2.8.14:
-    resolution: {integrity: sha512-FTbIeQL1ycLFW2t9uQNMy+bRSzi3Xhwun/e7ZhFBdM+U0VZxxrtfYEBM9CHOejlfqomk6Jh7aRz0sJoqYn39Hg==}
+    resolution:
+      {
+        integrity: sha512-FTbIeQL1ycLFW2t9uQNMy+bRSzi3Xhwun/e7ZhFBdM+U0VZxxrtfYEBM9CHOejlfqomk6Jh7aRz0sJoqYn39Hg==,
+      }
     cpu: [x64]
     os: [win32]
 
   turbo-windows-arm64@2.8.14:
-    resolution: {integrity: sha512-KgZX12cTyhY030qS7ieT8zRkhZZE2VWJasDFVUSVVn17nR7IShpv68/7j5UqJNeRLIGF1XPK0phsP5V5yw3how==}
+    resolution:
+      {
+        integrity: sha512-KgZX12cTyhY030qS7ieT8zRkhZZE2VWJasDFVUSVVn17nR7IShpv68/7j5UqJNeRLIGF1XPK0phsP5V5yw3how==,
+      }
     cpu: [arm64]
     os: [win32]
 
   turbo@2.8.14:
-    resolution: {integrity: sha512-UCTxeMNYT1cKaHiIFdLCQ7ulI+jw5i5uOnJOrRXsgUD7G3+OjlUjwVd7JfeVt2McWSVGjYA3EVW/v1FSsJ5DtA==}
+    resolution:
+      {
+        integrity: sha512-UCTxeMNYT1cKaHiIFdLCQ7ulI+jw5i5uOnJOrRXsgUD7G3+OjlUjwVd7JfeVt2McWSVGjYA3EVW/v1FSsJ5DtA==,
+      }
     hasBin: true
 
   type-check@0.4.0:
-    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
-    engines: {node: '>= 0.8.0'}
+    resolution:
+      {
+        integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==,
+      }
+    engines: { node: '>= 0.8.0' }
 
   type-fest@0.13.1:
-    resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==,
+      }
+    engines: { node: '>=10' }
 
   type-fest@4.41.0:
-    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
-    engines: {node: '>=16'}
+    resolution:
+      {
+        integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==,
+      }
+    engines: { node: '>=16' }
 
   type-is@2.0.1:
-    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
-    engines: {node: '>= 0.6'}
+    resolution:
+      {
+        integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==,
+      }
+    engines: { node: '>= 0.6' }
 
   typescript-eslint@8.57.0:
-    resolution: {integrity: sha512-W8GcigEMEeB07xEZol8oJ26rigm3+bfPHxHvwbYUlu1fUDsGuQ7Hiskx5xGW/xM4USc9Ephe3jtv7ZYPQntHeA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    resolution:
+      {
+        integrity: sha512-W8GcigEMEeB07xEZol8oJ26rigm3+bfPHxHvwbYUlu1fUDsGuQ7Hiskx5xGW/xM4USc9Ephe3jtv7ZYPQntHeA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
   typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
+    resolution:
+      {
+        integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==,
+      }
+    engines: { node: '>=14.17' }
     hasBin: true
 
   unbash@2.2.0:
-    resolution: {integrity: sha512-X2wH19RAPZE3+ldGicOkoj/SIA83OIxcJ6Cuaw23hf8Xc6fQpvZXY0SftE2JgS0QhYLUG4uwodSI3R53keyh7w==}
-    engines: {node: '>=14'}
+    resolution:
+      {
+        integrity: sha512-X2wH19RAPZE3+ldGicOkoj/SIA83OIxcJ6Cuaw23hf8Xc6fQpvZXY0SftE2JgS0QhYLUG4uwodSI3R53keyh7w==,
+      }
+    engines: { node: '>=14' }
 
   undici-types@7.18.2:
-    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+    resolution:
+      {
+        integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==,
+      }
 
   undici@6.23.0:
-    resolution: {integrity: sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==}
-    engines: {node: '>=18.17'}
+    resolution:
+      {
+        integrity: sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==,
+      }
+    engines: { node: '>=18.17' }
 
   unicorn-magic@0.1.0:
-    resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==,
+      }
+    engines: { node: '>=18' }
 
   unicorn-magic@0.3.0:
-    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==,
+      }
+    engines: { node: '>=18' }
 
   universalify@0.1.2:
-    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
-    engines: {node: '>= 4.0.0'}
+    resolution:
+      {
+        integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==,
+      }
+    engines: { node: '>= 4.0.0' }
 
   universalify@2.0.1:
-    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
-    engines: {node: '>= 10.0.0'}
+    resolution:
+      {
+        integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==,
+      }
+    engines: { node: '>= 10.0.0' }
 
   unpipe@1.0.0:
-    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==,
+      }
+    engines: { node: '>= 0.8' }
 
   uri-js@4.4.1:
-    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+    resolution:
+      {
+        integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==,
+      }
 
   uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    resolution:
+      {
+        integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==,
+      }
     hasBin: true
 
   uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    resolution:
+      {
+        integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==,
+      }
     hasBin: true
 
   uuid@13.0.0:
-    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+    resolution:
+      {
+        integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==,
+      }
     hasBin: true
 
   valibot@1.2.0:
-    resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
+    resolution:
+      {
+        integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==,
+      }
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -4516,19 +7460,31 @@ packages:
         optional: true
 
   validate-npm-package-license@3.0.4:
-    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+    resolution:
+      {
+        integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==,
+      }
 
   vary@1.1.2:
-    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
-    engines: {node: '>= 0.8'}
+    resolution:
+      {
+        integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==,
+      }
+    engines: { node: '>= 0.8' }
 
   version-range@4.15.0:
-    resolution: {integrity: sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==,
+      }
+    engines: { node: '>=4' }
 
   vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+    resolution:
+      {
+        integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
@@ -4567,8 +7523,11 @@ packages:
         optional: true
 
   vitest@4.0.18:
-    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
-    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    resolution:
+      {
+        integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==,
+      }
+    engines: { node: ^20.0.0 || ^22.0.0 || >=24.0.0 }
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
@@ -4601,56 +7560,95 @@ packages:
         optional: true
 
   void-elements@3.1.0:
-    resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==,
+      }
+    engines: { node: '>=0.10.0' }
 
   walk-up-path@4.0.0:
-    resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
-    engines: {node: 20 || >=22}
+    resolution:
+      {
+        integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==,
+      }
+    engines: { node: 20 || >=22 }
 
   watskeburt@5.0.2:
-    resolution: {integrity: sha512-8xIz2RALjwTA7kYeRtkiQ2uaFyr327T1GXJnVcGOoPuzQX2axpUXqeJPcgOEVemCWB2YveZjhWCcW/eZ3uTkZA==}
-    engines: {node: ^20.12||^22.13||>=24.0}
+    resolution:
+      {
+        integrity: sha512-8xIz2RALjwTA7kYeRtkiQ2uaFyr327T1GXJnVcGOoPuzQX2axpUXqeJPcgOEVemCWB2YveZjhWCcW/eZ3uTkZA==,
+      }
+    engines: { node: ^20.12||^22.13||>=24.0 }
     hasBin: true
 
   webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+    resolution:
+      {
+        integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==,
+      }
 
   whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+    resolution:
+      {
+        integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==,
+      }
 
   which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
+    resolution:
+      {
+        integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==,
+      }
+    engines: { node: '>= 8' }
     hasBin: true
 
   why-is-node-running@2.3.0:
-    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
-    engines: {node: '>=8'}
+    resolution:
+      {
+        integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==,
+      }
+    engines: { node: '>=8' }
     hasBin: true
 
   with@7.0.2:
-    resolution: {integrity: sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==}
-    engines: {node: '>= 10.0.0'}
+    resolution:
+      {
+        integrity: sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==,
+      }
+    engines: { node: '>= 10.0.0' }
 
   word-wrap@1.2.5:
-    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==,
+      }
+    engines: { node: '>=0.10.0' }
 
   wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==,
+      }
+    engines: { node: '>=10' }
 
   wrap-ansi@9.0.2:
-    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==,
+      }
+    engines: { node: '>=18' }
 
   wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+    resolution:
+      {
+        integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==,
+      }
 
   ws@8.19.0:
-    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
-    engines: {node: '>=10.0.0'}
+    resolution:
+      {
+        integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==,
+      }
+    engines: { node: '>=10.0.0' }
     peerDependencies:
       bufferutil: ^4.0.1
       utf-8-validate: '>=5.0.2'
@@ -4661,46 +7659,75 @@ packages:
         optional: true
 
   xtend@4.0.2:
-    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
-    engines: {node: '>=0.4'}
+    resolution:
+      {
+        integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==,
+      }
+    engines: { node: '>=0.4' }
 
   y18n@5.0.8:
-    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==,
+      }
+    engines: { node: '>=10' }
 
   yallist@5.0.0:
-    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==,
+      }
+    engines: { node: '>=18' }
 
   yaml@2.8.2:
-    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
-    engines: {node: '>= 14.6'}
+    resolution:
+      {
+        integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==,
+      }
+    engines: { node: '>= 14.6' }
     hasBin: true
 
   yargs-parser@21.1.1:
-    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==,
+      }
+    engines: { node: '>=12' }
 
   yargs@17.7.2:
-    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
-    engines: {node: '>=12'}
+    resolution:
+      {
+        integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==,
+      }
+    engines: { node: '>=12' }
 
   yocto-queue@0.1.0:
-    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
-    engines: {node: '>=10'}
+    resolution:
+      {
+        integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==,
+      }
+    engines: { node: '>=10' }
 
   yoctocolors@2.1.2:
-    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
-    engines: {node: '>=18'}
+    resolution:
+      {
+        integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==,
+      }
+    engines: { node: '>=18' }
 
   zeptomatch@2.1.0:
-    resolution: {integrity: sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==}
+    resolution:
+      {
+        integrity: sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==,
+      }
 
   zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+    resolution:
+      {
+        integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==,
+      }
 
 snapshots:
-
   '@azu/format-text@1.0.2': {}
 
   '@azu/style-format@1.0.1':

--- a/services/ai-worker/.env.test
+++ b/services/ai-worker/.env.test
@@ -12,8 +12,6 @@ PROD_DATABASE_URL="postgresql://testuser:testpass@localhost:5432/testdb"
 # AI Providers (dummy values for testing)
 AI_PROVIDER="openrouter"
 OPENROUTER_API_KEY="test-openrouter-key-dummy"
-GEMINI_API_KEY="test-gemini-key-dummy"
-OPENAI_API_KEY="test-openai-key-dummy"
 
 # Node Environment
 NODE_ENV="test"

--- a/services/ai-worker/package.json
+++ b/services/ai-worker/package.json
@@ -30,7 +30,6 @@
     "ioredis": "^5.10.0",
     "langchain": "^1.2.30",
     "onnxruntime-node": "^1.24.3",
-    "openai": "^6.27.0",
     "pino": "^10.3.1",
     "redis": "^5.11.0",
     "sharp": "^0.34.5",

--- a/services/ai-worker/src/index.ts
+++ b/services/ai-worker/src/index.ts
@@ -32,12 +32,7 @@ import {
   type PrismaClient,
   type AnyJobData,
 } from '@tzurot/common-types';
-import {
-  validateRequiredEnvVars,
-  validateAIConfig,
-  buildHealthResponse,
-  checkVoiceEngineHealth,
-} from './startup.js';
+import { validateRequiredEnvVars, buildHealthResponse, checkVoiceEngineHealth } from './startup.js';
 import { setupCacheInvalidation } from './cacheInvalidation.js';
 import { initStopSequenceRedis } from './services/StopSequenceTracker.js';
 
@@ -311,7 +306,6 @@ async function setupScheduledJobs(
  */
 async function main(): Promise<void> {
   logger.info('[AIWorker] Starting AI Worker service...');
-  validateAIConfig();
 
   logger.info(
     {

--- a/services/ai-worker/src/jobs/AIJobProcessor.test.ts
+++ b/services/ai-worker/src/jobs/AIJobProcessor.test.ts
@@ -13,7 +13,9 @@ import { AIJobProcessor } from './AIJobProcessor.js';
 import type { Job } from 'bullmq';
 import type { PrismaClient } from '@tzurot/common-types';
 import type { ConversationalRAGService } from '../services/ConversationalRAGService.js';
+import type { ApiKeyResolver } from '../services/ApiKeyResolver.js';
 import {
+  AIProvider,
   JobType,
   CONTENT_TYPES,
   type AudioTranscriptionJobData,
@@ -94,6 +96,29 @@ function createMockRAGService(): ConversationalRAGService {
       modelUsed: 'test-model',
     }),
   } as unknown as ConversationalRAGService;
+}
+
+function createMockApiKeyResolver(elevenlabsApiKey?: string): ApiKeyResolver {
+  return {
+    resolveApiKey: vi.fn().mockImplementation((_userId: string, provider: AIProvider) => {
+      if (provider === AIProvider.ElevenLabs && elevenlabsApiKey !== undefined) {
+        return Promise.resolve({
+          apiKey: elevenlabsApiKey,
+          source: 'user',
+          provider: AIProvider.ElevenLabs,
+          isGuestMode: false,
+        });
+      }
+      // Default: guest mode (no key)
+      return Promise.resolve({
+        apiKey: 'system-key',
+        source: 'system',
+        provider: provider ?? AIProvider.OpenRouter,
+        isGuestMode: true,
+      });
+    }),
+    invalidateCacheForUser: vi.fn(),
+  } as unknown as ApiKeyResolver;
 }
 
 function createMockJob<T>(data: T, id = 'job-123'): Job<T> {
@@ -188,7 +213,7 @@ describe('AIJobProcessor', () => {
 
         const result = await processor.processJob(job);
 
-        expect(processAudioTranscriptionJob).toHaveBeenCalledWith(job);
+        expect(processAudioTranscriptionJob).toHaveBeenCalledWith(job, undefined);
         expect(result).toEqual(audioResult);
       });
 
@@ -252,6 +277,58 @@ describe('AIJobProcessor', () => {
           'unknown:audio-job-123',
           audioResult
         );
+      });
+
+      it('should resolve and pass ElevenLabs API key to audio transcription job', async () => {
+        const elApiKey = 'el-test-key-abc';
+        const mockResolver = createMockApiKeyResolver(elApiKey);
+        const processorWithResolver = new AIJobProcessor({
+          prisma: mockPrisma,
+          ragService: mockRAGService,
+          apiKeyResolver: mockResolver,
+        });
+
+        vi.mocked(processAudioTranscriptionJob).mockResolvedValue(audioResult);
+        const job = createMockJob(audioJobData, 'audio-job-123');
+
+        await processorWithResolver.processJob(job);
+
+        expect(mockResolver.resolveApiKey).toHaveBeenCalledWith('user-123', AIProvider.ElevenLabs);
+        expect(processAudioTranscriptionJob).toHaveBeenCalledWith(job, elApiKey);
+      });
+
+      it('should pass undefined ElevenLabs key when user is in guest mode', async () => {
+        const mockResolver = createMockApiKeyResolver(); // No ElevenLabs key
+        const processorWithResolver = new AIJobProcessor({
+          prisma: mockPrisma,
+          ragService: mockRAGService,
+          apiKeyResolver: mockResolver,
+        });
+
+        vi.mocked(processAudioTranscriptionJob).mockResolvedValue(audioResult);
+        const job = createMockJob(audioJobData, 'audio-job-123');
+
+        await processorWithResolver.processJob(job);
+
+        expect(processAudioTranscriptionJob).toHaveBeenCalledWith(job, undefined);
+      });
+
+      it('should pass undefined ElevenLabs key when resolver throws', async () => {
+        const mockResolver = createMockApiKeyResolver();
+        vi.mocked(mockResolver.resolveApiKey).mockRejectedValue(new Error('DB error'));
+        const processorWithResolver = new AIJobProcessor({
+          prisma: mockPrisma,
+          ragService: mockRAGService,
+          apiKeyResolver: mockResolver,
+        });
+
+        vi.mocked(processAudioTranscriptionJob).mockResolvedValue(audioResult);
+        const job = createMockJob(audioJobData, 'audio-job-123');
+
+        await processorWithResolver.processJob(job);
+
+        // Should gracefully fall back to no ElevenLabs key
+        expect(processAudioTranscriptionJob).toHaveBeenCalledWith(job, undefined);
       });
     });
 

--- a/services/ai-worker/src/jobs/AIJobProcessor.ts
+++ b/services/ai-worker/src/jobs/AIJobProcessor.ts
@@ -163,8 +163,11 @@ export class AIJobProcessor {
       if (!elResult.isGuestMode && elResult.apiKey !== undefined) {
         elevenlabsApiKey = elResult.apiKey;
       }
-    } catch {
-      // No-op — fall back to voice-engine STT
+    } catch (error) {
+      logger.warn(
+        { err: error, userId: job.data.context.userId },
+        '[AIJobProcessor] Failed to resolve ElevenLabs key — falling back to voice-engine STT'
+      );
     }
 
     const result = await processAudioTranscriptionJob(job, elevenlabsApiKey);

--- a/services/ai-worker/src/jobs/AIJobProcessor.ts
+++ b/services/ai-worker/src/jobs/AIJobProcessor.ts
@@ -15,6 +15,7 @@ import { LlmConfigResolver, type ConfigCascadeResolver } from '@tzurot/common-ty
 import { PersonaResolver } from '../services/resolvers/index.js';
 import {
   createLogger,
+  AIProvider,
   type AnyJobData,
   type AnyJobResult,
   type AudioTranscriptionJobData,
@@ -152,7 +153,21 @@ export class AIJobProcessor {
   private async processAudioTranscriptionJobWrapper(
     job: Job<AudioTranscriptionJobData>
   ): Promise<AudioTranscriptionResult> {
-    const result = await processAudioTranscriptionJob(job);
+    // Resolve ElevenLabs BYOK key for premium STT (if user has one configured)
+    let elevenlabsApiKey: string | undefined;
+    try {
+      const elResult = await this.apiKeyResolver.resolveApiKey(
+        job.data.context.userId,
+        AIProvider.ElevenLabs
+      );
+      if (!elResult.isGuestMode && elResult.apiKey !== undefined) {
+        elevenlabsApiKey = elResult.apiKey;
+      }
+    } catch {
+      // No-op — fall back to voice-engine STT
+    }
+
+    const result = await processAudioTranscriptionJob(job, elevenlabsApiKey);
 
     // Store result in Redis for dependent jobs (with userId namespacing)
     const jobId = job.id ?? job.data.requestId;

--- a/services/ai-worker/src/jobs/AudioTranscriptionJob.test.ts
+++ b/services/ai-worker/src/jobs/AudioTranscriptionJob.test.ts
@@ -254,6 +254,77 @@ describe('AudioTranscriptionJob', () => {
       expect(mockWithRetry).toHaveBeenCalled();
     });
 
+    it('should pass elevenlabsApiKey to transcribeAudio when provided', async () => {
+      const jobData: AudioTranscriptionJobData = {
+        requestId: 'test-req-audio-key',
+        jobType: JobType.AudioTranscription,
+        attachment: {
+          url: 'https://example.com/audio.ogg',
+          name: 'audio.ogg',
+          contentType: CONTENT_TYPES.AUDIO_OGG,
+          size: 2048,
+          duration: 10,
+        },
+        context: {
+          userId: 'user-123',
+          channelId: 'channel-456',
+        },
+        responseDestination: {
+          type: 'discord',
+          channelId: 'channel-456',
+        },
+      };
+
+      const job = {
+        id: 'audio-test-key',
+        data: jobData,
+      } as Job<AudioTranscriptionJobData>;
+
+      const testApiKey = 'el-test-key-123';
+      await processAudioTranscriptionJob(job, testApiKey);
+
+      // Verify withRetry was called with a function that passes the key
+      expect(mockWithRetry).toHaveBeenCalledTimes(1);
+      const retryFn = mockWithRetry.mock.calls[0][0];
+      await retryFn();
+      expect(mockTranscribeAudio).toHaveBeenCalledWith(jobData.attachment, testApiKey);
+    });
+
+    it('should not pass elevenlabsApiKey when not provided', async () => {
+      const jobData: AudioTranscriptionJobData = {
+        requestId: 'test-req-audio-nokey',
+        jobType: JobType.AudioTranscription,
+        attachment: {
+          url: 'https://example.com/audio.ogg',
+          name: 'audio.ogg',
+          contentType: CONTENT_TYPES.AUDIO_OGG,
+          size: 2048,
+          duration: 10,
+        },
+        context: {
+          userId: 'user-123',
+          channelId: 'channel-456',
+        },
+        responseDestination: {
+          type: 'discord',
+          channelId: 'channel-456',
+        },
+      };
+
+      const job = {
+        id: 'audio-test-nokey',
+        data: jobData,
+      } as Job<AudioTranscriptionJobData>;
+
+      await processAudioTranscriptionJob(job);
+
+      // Verify withRetry was called with a function that does NOT pass a key
+      expect(mockWithRetry).toHaveBeenCalledTimes(1);
+      const retryFn = mockWithRetry.mock.calls[0][0];
+      await retryFn();
+      expect(mockTranscribeAudio).toHaveBeenCalledWith(jobData.attachment, undefined);
+    });
+
     it('should include retry metadata in result', async () => {
       const jobData: AudioTranscriptionJobData = {
         requestId: 'test-req-audio-5',

--- a/services/ai-worker/src/jobs/AudioTranscriptionJob.test.ts
+++ b/services/ai-worker/src/jobs/AudioTranscriptionJob.test.ts
@@ -167,14 +167,14 @@ describe('AudioTranscriptionJob', () => {
       } as Job<AudioTranscriptionJobData>;
 
       // Simulate withRetry failing after all attempts
-      mockWithRetry.mockRejectedValue(new Error('Whisper API timeout after 3 attempts'));
+      mockWithRetry.mockRejectedValue(new Error('STT API timeout after 3 attempts'));
 
       const result = await processAudioTranscriptionJob(job);
 
       expect(result).toMatchObject({
         requestId: 'test-req-audio-2',
         success: false,
-        error: 'Whisper API timeout after 3 attempts',
+        error: 'STT API timeout after 3 attempts',
         metadata: {
           processingTimeMs: expect.any(Number),
           duration: undefined,

--- a/services/ai-worker/src/jobs/AudioTranscriptionJob.test.ts
+++ b/services/ai-worker/src/jobs/AudioTranscriptionJob.test.ts
@@ -9,7 +9,7 @@ import type { AudioTranscriptionJobData } from '@tzurot/common-types';
 import { JobType, CONTENT_TYPES } from '@tzurot/common-types';
 
 // Mock transcribeAudio and withRetry
-vi.mock('../services/MultimodalProcessor.js', () => ({
+vi.mock('../services/multimodal/AudioProcessor.js', () => ({
   transcribeAudio: vi.fn(),
 }));
 
@@ -18,7 +18,7 @@ vi.mock('../utils/retry.js', () => ({
 }));
 
 // Import the mocked modules
-import { transcribeAudio } from '../services/MultimodalProcessor.js';
+import { transcribeAudio } from '../services/multimodal/AudioProcessor.js';
 import { withRetry } from '../utils/retry.js';
 
 // Get mocked functions

--- a/services/ai-worker/src/jobs/AudioTranscriptionJob.test.ts
+++ b/services/ai-worker/src/jobs/AudioTranscriptionJob.test.ts
@@ -367,6 +367,25 @@ describe('AudioTranscriptionJob', () => {
       expect(mockTranscribeAudio).toHaveBeenCalledWith(jobData.attachment, undefined);
     });
 
+    it('should throw on invalid job data (Zod validation failure)', async () => {
+      const invalidJobData = {
+        requestId: 'test-req-invalid',
+        // Missing jobType, attachment, context, responseDestination
+      };
+
+      const job = {
+        id: 'audio-test-invalid',
+        data: invalidJobData,
+      } as Job<AudioTranscriptionJobData>;
+
+      await expect(processAudioTranscriptionJob(job)).rejects.toThrow(
+        'Audio transcription job validation failed'
+      );
+
+      // Should NOT attempt transcription for invalid payloads
+      expect(mockWithRetry).not.toHaveBeenCalled();
+    });
+
     it('should include retry metadata in result', async () => {
       const jobData: AudioTranscriptionJobData = {
         requestId: 'test-req-audio-5',

--- a/services/ai-worker/src/jobs/AudioTranscriptionJob.test.ts
+++ b/services/ai-worker/src/jobs/AudioTranscriptionJob.test.ts
@@ -92,9 +92,51 @@ describe('AudioTranscriptionJob', () => {
         expect.any(Function),
         expect.objectContaining({
           maxAttempts: 3,
+          shouldRetry: expect.any(Function),
           operationName: 'Audio transcription (audio.ogg)',
         })
       );
+    });
+
+    it('should not retry permanent config errors (no STT provider)', async () => {
+      const jobData: AudioTranscriptionJobData = {
+        requestId: 'test-req-config-error',
+        jobType: JobType.AudioTranscription,
+        attachment: {
+          url: 'https://example.com/audio.ogg',
+          name: 'audio.ogg',
+          contentType: CONTENT_TYPES.AUDIO_OGG,
+          size: 2048,
+          duration: 10,
+        },
+        context: {
+          userId: 'user-123',
+          channelId: 'channel-456',
+        },
+        responseDestination: {
+          type: 'discord',
+          channelId: 'channel-456',
+        },
+      };
+
+      const job = {
+        id: 'audio-config-error',
+        data: jobData,
+      } as Job<AudioTranscriptionJobData>;
+
+      mockWithRetry.mockImplementation(async fn => {
+        const value = await fn();
+        return { value, attempts: 1, totalTimeMs: 100 };
+      });
+
+      await processAudioTranscriptionJob(job);
+
+      // Verify shouldRetry callback rejects config errors
+      const retryOpts = mockWithRetry.mock.calls[0][1];
+      const shouldRetry = retryOpts!.shouldRetry!;
+      expect(shouldRetry(new Error('No STT provider available: configure...'))).toBe(false);
+      expect(shouldRetry(new Error('fetch failed'))).toBe(true);
+      expect(shouldRetry(new Error('Voice engine request timed out'))).toBe(true);
     });
 
     it('should use withRetry wrapper for transcription', async () => {

--- a/services/ai-worker/src/jobs/AudioTranscriptionJob.ts
+++ b/services/ai-worker/src/jobs/AudioTranscriptionJob.ts
@@ -66,9 +66,13 @@ export async function processAudioTranscriptionJob(
       throw new Error(`Invalid attachment type: ${attachment.contentType}. Expected audio.`);
     }
 
-    // Transcribe the audio with retry logic (3 attempts)
+    // Transcribe the audio with retry logic (3 attempts).
+    // Config errors ("No STT provider available") are non-retryable — fast-fail
+    // instead of wasting ~30s on guaranteed-identical failures.
     const result = await withRetry(() => transcribeAudio(attachment, elevenlabsApiKey), {
       maxAttempts: RETRY_CONFIG.MAX_ATTEMPTS,
+      shouldRetry: err =>
+        !(err instanceof Error && err.message.startsWith('No STT provider available')),
       logger,
       operationName: `Audio transcription (${attachment.name})`,
     });

--- a/services/ai-worker/src/jobs/AudioTranscriptionJob.ts
+++ b/services/ai-worker/src/jobs/AudioTranscriptionJob.ts
@@ -45,7 +45,7 @@ export async function processAudioTranscriptionJob(
     throw new Error(`Audio transcription job validation failed: ${validation.error.message}`);
   }
 
-  const { requestId, attachment, sourceReferenceNumber } = job.data;
+  const { requestId, attachment, sourceReferenceNumber } = validation.data;
 
   logger.info(
     {

--- a/services/ai-worker/src/jobs/AudioTranscriptionJob.ts
+++ b/services/ai-worker/src/jobs/AudioTranscriptionJob.ts
@@ -15,7 +15,7 @@ import {
   type AudioTranscriptionResult,
   audioTranscriptionJobDataSchema,
 } from '@tzurot/common-types';
-import { transcribeAudio } from '../services/MultimodalProcessor.js';
+import { transcribeAudio } from '../services/multimodal/AudioProcessor.js';
 import { withRetry } from '../utils/retry.js';
 
 const logger = createLogger('AudioTranscriptionJob');

--- a/services/ai-worker/src/jobs/AudioTranscriptionJob.ts
+++ b/services/ai-worker/src/jobs/AudioTranscriptionJob.ts
@@ -2,7 +2,7 @@
  * Audio Transcription Job Processor
  *
  * Handles audio transcription preprocessing jobs.
- * Extracts audio attachments and transcribes them using Whisper.
+ * Extracts audio attachments and transcribes them using available STT providers.
  * Results are stored in Redis for dependent jobs to consume.
  */
 
@@ -22,9 +22,13 @@ const logger = createLogger('AudioTranscriptionJob');
 
 /**
  * Process audio transcription job
+ *
+ * @param job - BullMQ job with audio transcription data
+ * @param elevenlabsApiKey - Optional ElevenLabs BYOK key for premium STT
  */
 export async function processAudioTranscriptionJob(
-  job: Job<AudioTranscriptionJobData>
+  job: Job<AudioTranscriptionJobData>,
+  elevenlabsApiKey?: string
 ): Promise<AudioTranscriptionResult> {
   const startTime = Date.now();
 
@@ -63,8 +67,7 @@ export async function processAudioTranscriptionJob(
     }
 
     // Transcribe the audio with retry logic (3 attempts)
-    // Note: Personality is optional for transcription (not currently used by Whisper API)
-    const result = await withRetry(() => transcribeAudio(attachment), {
+    const result = await withRetry(() => transcribeAudio(attachment, elevenlabsApiKey), {
       maxAttempts: RETRY_CONFIG.MAX_ATTEMPTS,
       logger,
       operationName: `Audio transcription (${attachment.name})`,

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/DependencyStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/DependencyStep.test.ts
@@ -406,6 +406,7 @@ describe('DependencyStep', () => {
         [expect.objectContaining({ url: 'https://example.com/cat.jpg' })],
         TEST_PERSONALITY,
         false,
+        undefined,
         undefined
       );
       expect(result.preprocessing?.extendedContextAttachments).toHaveLength(1);
@@ -466,7 +467,8 @@ describe('DependencyStep', () => {
         [expect.objectContaining({ url: 'https://example.com/dog.jpg' })],
         TEST_PERSONALITY,
         false, // isGuestMode from auth context
-        'user-test-key-12345' // userApiKey from auth context (BYOK)
+        'user-test-key-12345', // userApiKey from auth context (BYOK)
+        undefined // elevenlabsApiKey (not set in this test)
       );
       expect(result.preprocessing?.extendedContextAttachments).toHaveLength(1);
     });
@@ -525,7 +527,8 @@ describe('DependencyStep', () => {
         [expect.objectContaining({ url: 'https://example.com/bird.jpg' })],
         GUEST_EFFECTIVE_PERSONALITY, // Uses resolved config with free visionModel
         true, // isGuestMode = true for guest users
-        'system-openrouter-key' // System key (guests don't have BYOK)
+        'system-openrouter-key', // System key (guests don't have BYOK)
+        undefined // elevenlabsApiKey (guests don't have ElevenLabs key)
       );
       expect(result.preprocessing?.extendedContextAttachments).toHaveLength(1);
 
@@ -672,7 +675,8 @@ describe('DependencyStep', () => {
         [expect.objectContaining({ url: 'https://example.com/noauth.jpg' })],
         TEST_PERSONALITY,
         false, // isGuestMode defaults to false when auth missing
-        undefined // userApiKey is undefined (system key fallback)
+        undefined, // userApiKey is undefined (system key fallback)
+        undefined // elevenlabsApiKey (no auth context)
       );
       expect(result.preprocessing?.extendedContextAttachments).toHaveLength(1);
     });
@@ -722,7 +726,8 @@ describe('DependencyStep', () => {
         [expect.objectContaining({ url: 'https://example.com/fallback.jpg' })],
         TEST_PERSONALITY, // Falls back to job.data.personality
         false,
-        undefined
+        undefined,
+        undefined // elevenlabsApiKey (no config context)
       );
       expect(result.preprocessing?.extendedContextAttachments).toHaveLength(1);
     });

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/DependencyStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/DependencyStep.ts
@@ -97,8 +97,11 @@ export class DependencyStep implements IPipelineStep {
         jobContext.extendedContextAttachments,
         personality,
         job.id,
-        auth?.isGuestMode ?? false,
-        auth?.apiKey
+        {
+          isGuestMode: auth?.isGuestMode ?? false,
+          userApiKey: auth?.apiKey,
+          elevenlabsApiKey: auth?.elevenlabsApiKey,
+        }
       );
       preprocessing.extendedContextAttachments = extendedContextAttachments;
     }
@@ -193,14 +196,15 @@ export class DependencyStep implements IPipelineStep {
    * @param jobId - Job ID for logging
    * @param isGuestMode - Whether user is in guest mode (uses free models)
    * @param userApiKey - User's BYOK API key (for BYOK users)
+   * @param elevenlabsApiKey - Optional ElevenLabs BYOK key for premium STT
    */
   private async processExtendedContextAttachments(
     attachments: AttachmentMetadata[],
     personality: GenerationContext['job']['data']['personality'],
     jobId: string | undefined,
-    isGuestMode: boolean,
-    userApiKey?: string
+    authOptions: { isGuestMode: boolean; userApiKey?: string; elevenlabsApiKey?: string }
   ): Promise<ProcessedAttachment[]> {
+    const { isGuestMode, userApiKey, elevenlabsApiKey } = authOptions;
     // Filter to only images
     const imageAttachments = attachments.filter(a => a.contentType?.startsWith('image/'));
     if (imageAttachments.length === 0) {
@@ -227,7 +231,8 @@ export class DependencyStep implements IPipelineStep {
         imageAttachments,
         personality,
         isGuestMode,
-        userApiKey
+        userApiKey,
+        elevenlabsApiKey
       );
 
       logger.info(

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/GenerationStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/GenerationStep.ts
@@ -93,6 +93,7 @@ export class GenerationStep implements IPipelineStep {
     conversationContext: ConversationContext;
     recentAssistantMessages: string[];
     apiKey: string | undefined;
+    elevenlabsApiKey: string | undefined;
     isGuestMode: boolean;
     jobId: string | undefined;
     diagnosticCollector?: DiagnosticCollector;
@@ -145,6 +146,7 @@ export class GenerationStep implements IPipelineStep {
       try {
         response = await this.ragService.generateResponse(personality, message, attemptContext, {
           userApiKey: apiKey,
+          elevenlabsApiKey: opts.elevenlabsApiKey,
           isGuestMode,
           retryConfig: { attempt, ...retryConfig },
           skipMemoryStorage: true,
@@ -318,6 +320,7 @@ export class GenerationStep implements IPipelineStep {
           conversationContext,
           recentAssistantMessages,
           apiKey,
+          elevenlabsApiKey: auth.elevenlabsApiKey,
           isGuestMode,
           jobId: job.id,
           diagnosticCollector,

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts
@@ -16,6 +16,7 @@ import type { IPipelineStep, GenerationContext } from '../types.js';
 import { getVoiceEngineClient } from '../../../../services/voice/VoiceEngineClient.js';
 import { VoiceRegistrationService } from '../../../../services/voice/VoiceRegistrationService.js';
 import { synthesizeWithChunking } from '../../../../services/voice/ttsSynthesizer.js';
+import { waitForVoiceEngine } from '../../../../services/voice/voiceEngineWarmup.js';
 import { ElevenLabsVoiceService } from '../../../../services/voice/ElevenLabsVoiceService.js';
 import { elevenLabsTTS } from '../../../../services/voice/ElevenLabsClient.js';
 import { redisService } from '../../../../redis.js';
@@ -26,14 +27,6 @@ const logger = createLogger('TTSStep');
  * Budget: health wait (75s) + voice registration (15s) + synthesis (~45s) + margin (15s).
  * 150s accommodates the full ~56s cold start plus multi-chunk TTS. */
 const TTS_TIMEOUT_MS = 150_000;
-
-/** Total time budget for health polling during voice engine cold start (ms).
- * Railway Serverless cold boot measured at ~56s — 75s gives comfortable margin.
- * Note: effective poll count varies — ECONNREFUSED resolves instantly (~25 polls),
- * but once Railway's LB is up the 5s health timeout may reduce it to ~10 polls. */
-const HEALTH_WAIT_BUDGET_MS = 75_000;
-/** Interval between health check polls (ms) */
-const HEALTH_POLL_INTERVAL_MS = 3_000;
 
 /**
  * Lazy singleton for voice registration (shares VoiceEngineClient lifecycle).
@@ -228,8 +221,9 @@ export class TTSStep implements IPipelineStep {
     // Pre-warm: ping /health to wake voice engine from Railway Serverless sleep.
     // Voice engine cold boot takes ~56s (model loading from disk). The first ping's
     // TCP connection triggers Railway to start the container; subsequent polls wait
-    // for model readiness.
-    await this.waitForVoiceEngine(registrationService, slug);
+    // for model readiness. Proceeds even if budget exhausted — synthesis will fail
+    // with a clear error if the engine truly isn't available.
+    await waitForVoiceEngine(registrationService.client, 'tts');
 
     // Ensure voice is registered
     await registrationService.ensureVoiceRegistered(slug);
@@ -250,45 +244,5 @@ export class TTSStep implements IPipelineStep {
     const key = await redisService.storeTTSAudio(jobId, audioBuffer);
 
     return { key, audioSize: audioBuffer.length, contentType };
-  }
-
-  /**
-   * Wait for the voice engine to become ready, polling health checks on a time budget.
-   * The first ping wakes Railway Serverless; subsequent polls wait for model loading (~56s).
-   * Proceeds after budget exhausted — registration/synthesis will fail with a clear error
-   * if the engine truly isn't available.
-   */
-  private async waitForVoiceEngine(
-    registrationService: VoiceRegistrationService,
-    slug: string
-  ): Promise<void> {
-    const deadline = Date.now() + HEALTH_WAIT_BUDGET_MS;
-    let attempt = 0;
-
-    while (Date.now() < deadline) {
-      attempt++;
-      // getHealth() is error-safe — wraps all errors (ECONNREFUSED, 502, etc.)
-      // and returns { asr: false, tts: false }. It never throws, so the loop
-      // is resilient to transient network failures during the full boot window.
-      const health = await registrationService.client.getHealth();
-      if (health.tts) {
-        return;
-      }
-      const remaining = deadline - Date.now();
-      if (remaining <= 0) {
-        break;
-      }
-      logger.info(
-        { slug, attempt, remainingMs: remaining },
-        'Voice engine TTS not ready — waiting for cold start'
-      );
-      await new Promise(resolve =>
-        setTimeout(resolve, Math.min(HEALTH_POLL_INTERVAL_MS, remaining))
-      );
-    }
-    logger.warn(
-      { slug, attempts: attempt },
-      'Voice engine TTS still not ready after health budget — proceeding anyway'
-    );
   }
 }

--- a/services/ai-worker/src/services/AttachmentProcessor.test.ts
+++ b/services/ai-worker/src/services/AttachmentProcessor.test.ts
@@ -204,7 +204,7 @@ describe('AttachmentProcessor', () => {
     });
 
     it('should handle voice transcription failures gracefully', async () => {
-      mockTranscribeAudio.mockRejectedValue(new Error('Whisper failed'));
+      mockTranscribeAudio.mockRejectedValue(new Error('STT failed'));
 
       const result = await processAttachmentsParallel({
         attachments: [

--- a/services/ai-worker/src/services/AttachmentProcessor.ts
+++ b/services/ai-worker/src/services/AttachmentProcessor.ts
@@ -46,6 +46,8 @@ interface ProcessSingleAttachmentOptions {
   preprocessedAttachments?: ProcessedAttachment[];
   /** User's BYOK API key (for BYOK users) */
   userApiKey?: string;
+  /** ElevenLabs BYOK API key for premium STT */
+  elevenlabsApiKey?: string;
 }
 
 /**
@@ -72,6 +74,8 @@ export interface ProcessAttachmentsOptions {
   isGuestMode: boolean;
   preprocessedAttachments?: ProcessedAttachment[];
   userApiKey?: string;
+  /** ElevenLabs BYOK API key for premium STT */
+  elevenlabsApiKey?: string;
 }
 
 /**
@@ -91,6 +95,7 @@ export async function processAttachmentsParallel(
     isGuestMode,
     preprocessedAttachments,
     userApiKey,
+    elevenlabsApiKey,
   } = options;
   if (!attachments || attachments.length === 0) {
     return [];
@@ -105,6 +110,7 @@ export async function processAttachmentsParallel(
       isGuestMode,
       preprocessedAttachments,
       userApiKey,
+      elevenlabsApiKey,
     })
   );
 
@@ -143,7 +149,8 @@ async function processVoiceAttachment(
   attachment: ProcessSingleAttachmentOptions['attachment'],
   index: number,
   referenceNumber: number,
-  preprocessed?: ProcessedAttachment
+  preprocessed?: ProcessedAttachment,
+  elevenlabsApiKey?: string
 ): Promise<ProcessedAttachmentResult> {
   if (preprocessed?.description !== undefined && preprocessed.description !== '') {
     logger.debug(
@@ -161,7 +168,7 @@ async function processVoiceAttachment(
       { referenceNumber, url: attachment.url, duration: attachment.duration },
       '[AttachmentProcessor] Transcribing voice message'
     );
-    const result = await withRetry(() => transcribeAudio(attachment), {
+    const result = await withRetry(() => transcribeAudio(attachment, elevenlabsApiKey), {
       maxAttempts: RETRY_CONFIG.MAX_ATTEMPTS,
       logger,
       operationName: `Voice transcription (reference ${referenceNumber})`,
@@ -236,11 +243,18 @@ async function processSingleAttachment(
     isGuestMode,
     preprocessedAttachments,
     userApiKey,
+    elevenlabsApiKey,
   } = options;
   const preprocessed = findPreprocessedByUrl(attachment.url, preprocessedAttachments);
 
   if (attachment.isVoiceMessage === true) {
-    return processVoiceAttachment(attachment, index, referenceNumber, preprocessed);
+    return processVoiceAttachment(
+      attachment,
+      index,
+      referenceNumber,
+      preprocessed,
+      elevenlabsApiKey
+    );
   }
 
   if (attachment.contentType?.startsWith(CONTENT_TYPES.IMAGE_PREFIX)) {

--- a/services/ai-worker/src/services/ConversationInputProcessor.test.ts
+++ b/services/ai-worker/src/services/ConversationInputProcessor.test.ts
@@ -155,7 +155,9 @@ describe('ConversationInputProcessor', () => {
       ];
       const context = createMockContext({ preprocessedAttachments });
 
-      const result = await processor.processInputs(mockPersonality, mockMessage, context, false);
+      const result = await processor.processInputs(mockPersonality, mockMessage, context, {
+        isGuestMode: false,
+      });
 
       expect(result.processedAttachments).toEqual(preprocessedAttachments);
       expect(mockProcessAttachments).not.toHaveBeenCalled();
@@ -175,27 +177,25 @@ describe('ConversationInputProcessor', () => {
 
       const context = createMockContext({ attachments });
 
-      const result = await processor.processInputs(
-        mockPersonality,
-        mockMessage,
-        context,
-        false,
-        'user-api-key'
-      );
+      const result = await processor.processInputs(mockPersonality, mockMessage, context, {
+        isGuestMode: false,
+        userApiKey: 'user-api-key',
+      });
 
       expect(result.processedAttachments).toEqual(processedResult);
       expect(mockProcessAttachments).toHaveBeenCalledWith(
         attachments,
         mockPersonality,
         false,
-        'user-api-key'
+        'user-api-key',
+        undefined // elevenlabsApiKey
       );
     });
 
     it('should format user message via PromptBuilder', async () => {
       const context = createMockContext();
 
-      await processor.processInputs(mockPersonality, mockMessage, context, false);
+      await processor.processInputs(mockPersonality, mockMessage, context, { isGuestMode: false });
 
       expect(mockPromptBuilder.formatUserMessage).toHaveBeenCalledWith(mockMessage, context);
     });
@@ -220,7 +220,7 @@ describe('ConversationInputProcessor', () => {
         rawConversationHistory: rawHistory,
       });
 
-      await processor.processInputs(mockPersonality, mockMessage, context, false);
+      await processor.processInputs(mockPersonality, mockMessage, context, { isGuestMode: false });
 
       expect(mockResponsePostProcessor.filterDuplicateReferences).toHaveBeenCalledWith(
         referencedMessages,
@@ -244,19 +244,16 @@ describe('ConversationInputProcessor', () => {
       ];
       const context = createMockContext({ referencedMessages });
 
-      const result = await processor.processInputs(
-        mockPersonality,
-        mockMessage,
-        context,
-        true // guest mode
-      );
+      const result = await processor.processInputs(mockPersonality, mockMessage, context, {
+        isGuestMode: true,
+      });
 
       expect(mockReferencedMessageFormatter.formatReferencedMessages).toHaveBeenCalledWith(
         referencedMessages,
         mockPersonality,
         true,
         undefined,
-        undefined
+        { userApiKey: undefined, elevenlabsApiKey: undefined }
       );
       expect(result.referencedMessagesDescriptions).toBe('<references>formatted</references>');
     });
@@ -264,7 +261,9 @@ describe('ConversationInputProcessor', () => {
     it('should not format references when none present', async () => {
       const context = createMockContext({ referencedMessages: [] });
 
-      const result = await processor.processInputs(mockPersonality, mockMessage, context, false);
+      const result = await processor.processInputs(mockPersonality, mockMessage, context, {
+        isGuestMode: false,
+      });
 
       expect(mockReferencedMessageFormatter.formatReferencedMessages).not.toHaveBeenCalled();
       expect(result.referencedMessagesDescriptions).toBeUndefined();
@@ -286,7 +285,9 @@ describe('ConversationInputProcessor', () => {
       ];
       const context = createMockContext({ referencedMessages });
 
-      const result = await processor.processInputs(mockPersonality, mockMessage, context, false);
+      const result = await processor.processInputs(mockPersonality, mockMessage, context, {
+        isGuestMode: false,
+      });
 
       expect(mockReferencedMessageFormatter.extractTextForSearch).toHaveBeenCalledWith(
         '<references>formatted</references>'
@@ -298,7 +299,7 @@ describe('ConversationInputProcessor', () => {
       const rawHistory = [{ id: 'msg1', content: 'previous' }];
       const context = createMockContext({ rawConversationHistory: rawHistory });
 
-      await processor.processInputs(mockPersonality, mockMessage, context, false);
+      await processor.processInputs(mockPersonality, mockMessage, context, { isGuestMode: false });
 
       expect(mockExtractRecentHistoryWindow).toHaveBeenCalledWith(rawHistory);
     });
@@ -331,7 +332,9 @@ describe('ConversationInputProcessor', () => {
         rawConversationHistory: [{ id: 'history1' }],
       });
 
-      const result = await processor.processInputs(mockPersonality, mockMessage, context, false);
+      const result = await processor.processInputs(mockPersonality, mockMessage, context, {
+        isGuestMode: false,
+      });
 
       expect(mockPromptBuilder.buildSearchQuery).toHaveBeenCalledWith(
         'formatted user message',
@@ -369,21 +372,26 @@ describe('ConversationInputProcessor', () => {
         preprocessedReferenceAttachments,
       });
 
-      await processor.processInputs(mockPersonality, mockMessage, context, false, 'api-key');
+      await processor.processInputs(mockPersonality, mockMessage, context, {
+        isGuestMode: false,
+        userApiKey: 'api-key',
+      });
 
       expect(mockReferencedMessageFormatter.formatReferencedMessages).toHaveBeenCalledWith(
         referencedMessages,
         mockPersonality,
         false,
         preprocessedReferenceAttachments,
-        'api-key'
+        { userApiKey: 'api-key', elevenlabsApiKey: undefined }
       );
     });
 
     it('should return complete ProcessedInputs structure', async () => {
       const context = createMockContext();
 
-      const result = await processor.processInputs(mockPersonality, mockMessage, context, false);
+      const result = await processor.processInputs(mockPersonality, mockMessage, context, {
+        isGuestMode: false,
+      });
 
       expect(result).toHaveProperty('processedAttachments');
       expect(result).toHaveProperty('userMessage');

--- a/services/ai-worker/src/services/ConversationInputProcessor.ts
+++ b/services/ai-worker/src/services/ConversationInputProcessor.ts
@@ -48,16 +48,19 @@ export class ConversationInputProcessor {
    * @param personality - Personality configuration
    * @param message - User's message content
    * @param context - Conversation context
-   * @param isGuestMode - Whether user is in guest mode (uses free models)
-   * @param userApiKey - User's BYOK API key (for BYOK users)
+   * @param authOptions - Authentication options (guest mode, API keys)
    */
   async processInputs(
     personality: LoadedPersonality,
     message: MessageContent,
     context: ConversationContext,
-    isGuestMode: boolean,
-    userApiKey?: string
+    authOptions: {
+      isGuestMode: boolean;
+      userApiKey?: string;
+      elevenlabsApiKey?: string;
+    }
   ): Promise<ProcessedInputs> {
+    const { isGuestMode, userApiKey, elevenlabsApiKey } = authOptions;
     // Use pre-processed attachments from dependency jobs if available
     let processedAttachments: ProcessedAttachment[] = [];
     if (context.preprocessedAttachments && context.preprocessedAttachments.length > 0) {
@@ -67,15 +70,13 @@ export class ConversationInputProcessor {
         'Using pre-processed attachments from dependency jobs'
       );
     } else if (context.attachments && context.attachments.length > 0) {
-      // Fallback: process attachments inline (shouldn't happen with job chain, but defensive).
-      // ElevenLabs STT key not threaded here — this path uses voice-engine/Whisper.
-      // The primary STT path (AudioTranscriptionJob) threads elevenlabsApiKey; this
-      // inline fallback is a rare safety net. See AudioProcessor.transcribeAudio().
+      // Fallback: process attachments inline (shouldn't happen with job chain, but defensive)
       processedAttachments = await processAttachments(
         context.attachments,
         personality,
         isGuestMode,
-        userApiKey
+        userApiKey,
+        elevenlabsApiKey
       );
       logger.info(
         { count: processedAttachments.length },
@@ -100,7 +101,7 @@ export class ConversationInputProcessor {
             personality,
             isGuestMode,
             context.preprocessedReferenceAttachments,
-            userApiKey
+            { userApiKey, elevenlabsApiKey }
           )
         : undefined;
 

--- a/services/ai-worker/src/services/ConversationalRAGService.test.ts
+++ b/services/ai-worker/src/services/ConversationalRAGService.test.ts
@@ -490,13 +490,13 @@ describe('ConversationalRAGService', () => {
 
       await service.generateResponse(personality, 'Reply to this', context);
 
-      // Includes preprocessedAttachments (undefined) and userApiKey (undefined) for BYOK support
+      // Includes preprocessedAttachments (undefined) and apiKeys for BYOK support
       expect(getReferencedMessageFormatterMock().formatReferencedMessages).toHaveBeenCalledWith(
         referencedMessages,
         personality,
         false,
         undefined,
-        undefined
+        { userApiKey: undefined, elevenlabsApiKey: undefined }
       );
     });
 
@@ -614,11 +614,12 @@ describe('ConversationalRAGService', () => {
 
       await service.generateResponse(personality, 'What is this?', context);
 
-      // Includes isGuestMode (false) and userApiKey (undefined) for BYOK support
+      // Includes isGuestMode (false), userApiKey (undefined), and elevenlabsApiKey (undefined) for BYOK support
       expect(mockProcessAttachments).toHaveBeenCalledWith(
         attachments,
         personality,
         false,
+        undefined,
         undefined
       );
     });
@@ -639,11 +640,12 @@ describe('ConversationalRAGService', () => {
 
       await service.generateResponse(personality, '', context);
 
-      // Includes isGuestMode (false) and userApiKey (undefined) for BYOK support
+      // Includes isGuestMode (false), userApiKey (undefined), and elevenlabsApiKey (undefined) for BYOK support
       expect(mockProcessAttachments).toHaveBeenCalledWith(
         attachments,
         personality,
         false,
+        undefined,
         undefined
       );
     });

--- a/services/ai-worker/src/services/ConversationalRAGService.ts
+++ b/services/ai-worker/src/services/ConversationalRAGService.ts
@@ -331,6 +331,7 @@ export class ConversationalRAGService {
   ): Promise<RAGResponse> {
     const {
       userApiKey,
+      elevenlabsApiKey,
       isGuestMode = false,
       retryConfig,
       diagnosticCollector: diagnosticCollectorRef,
@@ -340,13 +341,11 @@ export class ConversationalRAGService {
 
     try {
       // Step 1: Process inputs (attachments, messages, search query)
-      const inputs = await this.inputProcessor.processInputs(
-        personality,
-        message,
-        context,
+      const inputs = await this.inputProcessor.processInputs(personality, message, context, {
         isGuestMode,
-        userApiKey
-      );
+        userApiKey,
+        elevenlabsApiKey,
+      });
 
       // Record input processing for diagnostics
       if (diagnosticCollector) {
@@ -367,9 +366,7 @@ export class ConversationalRAGService {
         context.preprocessedExtendedContextAttachments,
         getPrismaClient(),
         visionDescriptionCache,
-        // ElevenLabs STT key not threaded here — history enrichment uses
-        // voice-engine/Whisper. See AudioProcessor.transcribeAudio() for BYOK STT.
-        atts => processAttachments(atts, personality, isGuestMode, userApiKey)
+        atts => processAttachments(atts, personality, isGuestMode, userApiKey, elevenlabsApiKey)
       );
 
       // Step 2: Load personas and resolve user references

--- a/services/ai-worker/src/services/ConversationalRAGTypes.ts
+++ b/services/ai-worker/src/services/ConversationalRAGTypes.ts
@@ -308,6 +308,8 @@ export interface DuplicateRetryConfig {
 export interface GenerateResponseOptions {
   /** User's BYOK API key (for BYOK users) */
   userApiKey?: string;
+  /** ElevenLabs BYOK API key for premium STT (voice transcription) */
+  elevenlabsApiKey?: string;
   /** Whether user is in guest mode (uses free models). Default: false */
   isGuestMode?: boolean;
   /** Retry configuration for duplicate detection retries */

--- a/services/ai-worker/src/services/ModelFactory.ts
+++ b/services/ai-worker/src/services/ModelFactory.ts
@@ -4,8 +4,8 @@
  * Supports:
  * - OpenRouter - via AI_PROVIDER=openrouter or OPENROUTER_API_KEY
  *
- * Note: OpenAI API key is used internally for embeddings/whisper, but not for chat models.
  * All chat/generation goes through OpenRouter which can route to any provider including OpenAI models.
+ * Embeddings are local (Xenova/bge-small-en-v1.5). STT uses ElevenLabs (BYOK) or voice-engine.
  */
 
 import { ChatOpenAI } from '@langchain/openai';

--- a/services/ai-worker/src/services/MultimodalProcessor.test.ts
+++ b/services/ai-worker/src/services/MultimodalProcessor.test.ts
@@ -11,8 +11,7 @@ import { AttachmentType, CONTENT_TYPES } from '@tzurot/common-types';
 const {
   mockModelInvoke,
   mockCreateChatModel,
-  mockWhisperCreate,
-  mockGetVoiceTranscript,
+  mockTranscribeAudio,
   mockCheckModelVisionSupport,
   mockVisionCacheGet,
   mockVisionCacheStore,
@@ -21,8 +20,7 @@ const {
 } = vi.hoisted(() => ({
   mockModelInvoke: vi.fn(),
   mockCreateChatModel: vi.fn(),
-  mockWhisperCreate: vi.fn(),
-  mockGetVoiceTranscript: vi.fn(),
+  mockTranscribeAudio: vi.fn(),
   mockCheckModelVisionSupport: vi.fn(),
   mockVisionCacheGet: vi.fn(),
   mockVisionCacheStore: vi.fn(),
@@ -49,22 +47,13 @@ vi.mock('../utils/apiErrorParser.js', () => ({
   shouldRetryError: () => true,
 }));
 
-vi.mock('openai', () => ({
-  default: class MockOpenAI {
-    audio = {
-      transcriptions: {
-        create: mockWhisperCreate,
-      },
-    };
-  },
+// Mock AudioProcessor — orchestrator tests shouldn't test STT internals
+vi.mock('./multimodal/AudioProcessor.js', () => ({
+  transcribeAudio: (...args: unknown[]) => mockTranscribeAudio(...args),
 }));
 
-// Mock fetch for audio downloads
-global.fetch = vi.fn();
-
-// Mock redis module (transcribeAudio tries to import it, VisionProcessor uses checkModelVisionSupport and visionDescriptionCache)
+// Mock redis module (VisionProcessor uses checkModelVisionSupport and visionDescriptionCache)
 vi.mock('../redis.js', () => ({
-  getVoiceTranscript: mockGetVoiceTranscript,
   checkModelVisionSupport: mockCheckModelVisionSupport,
   visionDescriptionCache: {
     get: mockVisionCacheGet,
@@ -104,11 +93,10 @@ describe('MultimodalProcessor', () => {
       modelName: 'test-model',
     });
 
-    // Whisper with response_format:'text' returns string directly, not {text: string}
-    mockWhisperCreate.mockResolvedValue('Mocked transcription');
+    // Mock transcribeAudio to return transcription text
+    mockTranscribeAudio.mockResolvedValue('Mocked transcription');
 
     // Reset redis mocks to default
-    mockGetVoiceTranscript.mockResolvedValue(null); // Return null to skip cache
     mockCheckModelVisionSupport.mockResolvedValue(false); // Default to no vision support
     mockVisionCacheGet.mockResolvedValue(null); // Default: cache miss
     mockVisionCacheStore.mockResolvedValue(undefined);
@@ -165,19 +153,13 @@ describe('MultimodalProcessor', () => {
         size: 1024,
       };
 
-      // Mock successful fetch
-      (global.fetch as any).mockResolvedValue({
-        ok: true,
-        arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(1024)),
-      });
-
       const result = await transcribeAudio(attachment);
 
       expect(result).toBe('Mocked transcription');
-      expect(global.fetch).toHaveBeenCalledWith(attachment.url, expect.any(Object));
+      expect(mockTranscribeAudio).toHaveBeenCalledWith(attachment);
     });
 
-    it('should handle fetch errors', async () => {
+    it('should handle transcription errors', async () => {
       const attachment: AttachmentMetadata = {
         url: 'https://example.com/audio.ogg',
         name: 'audio.ogg',
@@ -185,27 +167,9 @@ describe('MultimodalProcessor', () => {
         size: 1024,
       };
 
-      (global.fetch as any).mockRejectedValue(new Error('Network error'));
+      mockTranscribeAudio.mockRejectedValue(new Error('No STT provider available'));
 
-      await expect(transcribeAudio(attachment)).rejects.toThrow('Network error');
-    });
-
-    it('should handle Whisper API errors', async () => {
-      const attachment: AttachmentMetadata = {
-        url: 'https://example.com/audio.ogg',
-        name: 'audio.ogg',
-        contentType: CONTENT_TYPES.AUDIO_OGG,
-        size: 1024,
-      };
-
-      (global.fetch as any).mockResolvedValue({
-        ok: true,
-        arrayBuffer: () => Promise.resolve(new ArrayBuffer(1024)),
-      });
-
-      mockWhisperCreate.mockRejectedValue(new Error('Whisper API error'));
-
-      await expect(transcribeAudio(attachment)).rejects.toThrow('Whisper API error');
+      await expect(transcribeAudio(attachment)).rejects.toThrow('No STT provider available');
     });
   });
 
@@ -256,12 +220,6 @@ describe('MultimodalProcessor', () => {
         },
       ];
 
-      // Ensure fetch is properly mocked
-      (global.fetch as any).mockResolvedValue({
-        ok: true,
-        arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(2048)),
-      });
-
       const results = await processAttachments(attachments, mockPersonality);
 
       expect(results).toHaveLength(1);
@@ -296,11 +254,6 @@ describe('MultimodalProcessor', () => {
           size: 2048,
         },
       ];
-
-      (global.fetch as any).mockResolvedValue({
-        ok: true,
-        arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(2048)),
-      });
 
       const results = await processAttachments(attachments, mockPersonality);
 
@@ -423,7 +376,7 @@ describe('MultimodalProcessor', () => {
         },
       ];
 
-      (global.fetch as any).mockRejectedValue(new Error('Network error'));
+      mockTranscribeAudio.mockRejectedValue(new Error('Network error'));
 
       const promise = processAttachments(attachments, mockPersonality);
 

--- a/services/ai-worker/src/services/MultimodalProcessor.ts
+++ b/services/ai-worker/src/services/MultimodalProcessor.ts
@@ -4,7 +4,7 @@
  * Coordinates processing of images and audio to extract text descriptions/transcriptions.
  * Delegates to specialized processors:
  * - VisionProcessor: Image descriptions using vision models
- * - AudioProcessor: Audio transcriptions using Whisper
+ * - AudioProcessor: Audio transcriptions via ElevenLabs STT or voice-engine
  *
  * This allows multimodal content to be:
  * 1. Stored as text in conversation history (for long-term context)

--- a/services/ai-worker/src/services/ReferencedMessageFormatter.test.ts
+++ b/services/ai-worker/src/services/ReferencedMessageFormatter.test.ts
@@ -581,7 +581,7 @@ describe('ReferencedMessageFormatter', () => {
 
     it('should handle voice transcription failures gracefully', async () => {
       // Use hoisted mock directly
-      mockTranscribeAudio.mockRejectedValue(new Error('Whisper API failed'));
+      mockTranscribeAudio.mockRejectedValue(new Error('STT failed'));
 
       const references: ReferencedMessage[] = [
         {
@@ -905,7 +905,7 @@ describe('ReferencedMessageFormatter', () => {
       expect(mockDescribeImage).not.toHaveBeenCalled();
     });
 
-    it('should use preprocessed voice transcriptions instead of calling Whisper API', async () => {
+    it('should use preprocessed voice transcriptions instead of calling STT API', async () => {
       // Uses hoisted mockTranscribeAudio - verify it's NOT called when preprocessed data exists
 
       const references: ReferencedMessage[] = [
@@ -964,7 +964,7 @@ describe('ReferencedMessageFormatter', () => {
         '- Voice Message (10s): "Preprocessed: Hello, this is a test message"'
       );
 
-      // Should NOT call Whisper API
+      // Should NOT call STT API
       expect(mockTranscribeAudio).not.toHaveBeenCalled();
     });
 

--- a/services/ai-worker/src/services/ReferencedMessageFormatter.ts
+++ b/services/ai-worker/src/services/ReferencedMessageFormatter.ts
@@ -55,6 +55,7 @@ export class ReferencedMessageFormatter {
    * @param isGuestMode - Whether the user is in guest mode (no BYOK API key)
    * @param preprocessedAttachments - Pre-processed attachments keyed by reference number (avoids inline API calls)
    * @param userApiKey - User's BYOK API key (for BYOK users)
+   * @param elevenlabsApiKey - Optional ElevenLabs BYOK key for premium STT
    * @returns Formatted string ready for prompt
    */
   async formatReferencedMessages(
@@ -62,8 +63,10 @@ export class ReferencedMessageFormatter {
     personality: LoadedPersonality,
     isGuestMode = false,
     preprocessedAttachments?: Record<number, ProcessedAttachment[]>,
-    userApiKey?: string
+    apiKeys?: { userApiKey?: string; elevenlabsApiKey?: string }
   ): Promise<string> {
+    const userApiKey = apiKeys?.userApiKey;
+    const elevenlabsApiKey = apiKeys?.elevenlabsApiKey;
     const referenceElements: string[] = [];
 
     // Process each reference into XML
@@ -91,7 +94,7 @@ export class ReferencedMessageFormatter {
           personality,
           isGuestMode,
           preprocessedAttachments?.[ref.referenceNumber],
-          userApiKey
+          { userApiKey, elevenlabsApiKey }
         );
         referenceElements.push(forwardedElement);
         continue;
@@ -103,7 +106,7 @@ export class ReferencedMessageFormatter {
         personality,
         isGuestMode,
         preprocessedAttachments?.[ref.referenceNumber],
-        userApiKey
+        { userApiKey, elevenlabsApiKey }
       );
       referenceElements.push(standardElement);
     }
@@ -135,8 +138,9 @@ export class ReferencedMessageFormatter {
     personality: LoadedPersonality,
     isGuestMode: boolean,
     preprocessedForRef?: ProcessedAttachment[],
-    userApiKey?: string
+    apiKeys?: { userApiKey?: string; elevenlabsApiKey?: string }
   ): Promise<string> {
+    const { userApiKey, elevenlabsApiKey } = apiKeys ?? {};
     const { absolute, relative } = formatTimestampWithDelta(ref.timestamp);
 
     let attachmentLines: string[] = [];
@@ -148,6 +152,7 @@ export class ReferencedMessageFormatter {
         isGuestMode,
         preprocessedAttachments: preprocessedForRef,
         userApiKey,
+        elevenlabsApiKey,
       });
     }
 
@@ -172,8 +177,9 @@ export class ReferencedMessageFormatter {
     personality: LoadedPersonality,
     isGuestMode: boolean,
     preprocessedForRef?: ProcessedAttachment[],
-    userApiKey?: string
+    apiKeys?: { userApiKey?: string; elevenlabsApiKey?: string }
   ): Promise<string> {
+    const { userApiKey, elevenlabsApiKey } = apiKeys ?? {};
     const { absolute, relative } = formatTimestampWithDelta(ref.timestamp);
 
     const forwardedContent: ForwardedMessageContent = {
@@ -191,6 +197,7 @@ export class ReferencedMessageFormatter {
         isGuestMode,
         preprocessedAttachments: preprocessedForRef,
         userApiKey,
+        elevenlabsApiKey,
       });
 
       if (attachmentLines.length > 0) {

--- a/services/ai-worker/src/services/multimodal/AudioProcessor.test.ts
+++ b/services/ai-worker/src/services/multimodal/AudioProcessor.test.ts
@@ -8,21 +8,9 @@ import type { AttachmentMetadata } from '@tzurot/common-types';
 import { CONTENT_TYPES } from '@tzurot/common-types';
 
 // Create mock functions
-const mockWhisperCreate = vi.fn().mockResolvedValue('Mocked transcription');
 const mockVoiceTranscriptCacheGet = vi.fn().mockResolvedValue(null);
 const mockVoiceEngineTranscribe = vi.fn();
 let mockVoiceEngineClient: { transcribe: typeof mockVoiceEngineTranscribe } | null = null;
-
-// Mock dependencies
-vi.mock('openai', () => ({
-  default: class MockOpenAI {
-    audio = {
-      transcriptions: {
-        create: mockWhisperCreate,
-      },
-    };
-  },
-}));
 
 vi.mock('../../redis.js', () => ({
   voiceTranscriptCache: {
@@ -55,7 +43,6 @@ global.fetch = vi.fn();
 describe('AudioProcessor', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockWhisperCreate.mockResolvedValue('Mocked transcription');
     mockVoiceTranscriptCacheGet.mockResolvedValue(null);
     mockVoiceEngineClient = null;
     mockVoiceEngineTranscribe.mockReset();
@@ -84,17 +71,18 @@ describe('AudioProcessor', () => {
         expect(result).toBe('Cached transcription from Redis');
         expect(mockVoiceTranscriptCacheGet).toHaveBeenCalledWith(attachment.originalUrl);
         expect(global.fetch).not.toHaveBeenCalled();
-        expect(mockWhisperCreate).not.toHaveBeenCalled();
       });
 
       it('should skip cache when originalUrl is not provided', async () => {
         const attachment: AttachmentMetadata = {
           url: 'https://example.com/audio.ogg',
-          // No originalUrl
           name: 'audio.ogg',
           contentType: CONTENT_TYPES.AUDIO_OGG,
           size: 1024,
         };
+
+        mockVoiceEngineTranscribe.mockResolvedValue({ text: 'transcribed' });
+        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe };
 
         (global.fetch as any).mockResolvedValue({
           ok: true,
@@ -115,6 +103,9 @@ describe('AudioProcessor', () => {
           contentType: CONTENT_TYPES.AUDIO_OGG,
           size: 1024,
         };
+
+        mockVoiceEngineTranscribe.mockResolvedValue({ text: 'transcribed' });
+        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe };
 
         (global.fetch as any).mockResolvedValue({
           ok: true,
@@ -138,6 +129,9 @@ describe('AudioProcessor', () => {
 
         mockVoiceTranscriptCacheGet.mockRejectedValue(new Error('Redis connection failed'));
 
+        mockVoiceEngineTranscribe.mockResolvedValue({ text: 'Fallback result' });
+        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe };
+
         (global.fetch as any).mockResolvedValue({
           ok: true,
           arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(1024)),
@@ -145,9 +139,8 @@ describe('AudioProcessor', () => {
 
         const result = await transcribeAudio(attachment);
 
-        expect(result).toBe('Mocked transcription');
+        expect(result).toBe('Fallback result');
         expect(global.fetch).toHaveBeenCalled();
-        expect(mockWhisperCreate).toHaveBeenCalled();
       });
 
       it('should skip cache when cached value is null', async () => {
@@ -161,6 +154,9 @@ describe('AudioProcessor', () => {
 
         mockVoiceTranscriptCacheGet.mockResolvedValue(null);
 
+        mockVoiceEngineTranscribe.mockResolvedValue({ text: 'transcribed' });
+        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe };
+
         (global.fetch as any).mockResolvedValue({
           ok: true,
           arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(1024)),
@@ -169,7 +165,6 @@ describe('AudioProcessor', () => {
         await transcribeAudio(attachment);
 
         expect(global.fetch).toHaveBeenCalled();
-        expect(mockWhisperCreate).toHaveBeenCalled();
       });
 
       it('should skip cache when cached value is empty string', async () => {
@@ -183,6 +178,9 @@ describe('AudioProcessor', () => {
 
         mockVoiceTranscriptCacheGet.mockResolvedValue('');
 
+        mockVoiceEngineTranscribe.mockResolvedValue({ text: 'transcribed' });
+        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe };
+
         (global.fetch as any).mockResolvedValue({
           ok: true,
           arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(1024)),
@@ -191,7 +189,6 @@ describe('AudioProcessor', () => {
         await transcribeAudio(attachment);
 
         expect(global.fetch).toHaveBeenCalled();
-        expect(mockWhisperCreate).toHaveBeenCalled();
       });
     });
 
@@ -216,10 +213,9 @@ describe('AudioProcessor', () => {
 
         expect(result).toBe('Voice engine transcription');
         expect(mockVoiceEngineTranscribe).toHaveBeenCalled();
-        expect(mockWhisperCreate).not.toHaveBeenCalled();
       });
 
-      it('should return empty string from voice-engine without falling back to Whisper', async () => {
+      it('should return empty string from voice-engine without falling back', async () => {
         const attachment: AttachmentMetadata = {
           url: 'https://example.com/audio.ogg',
           name: 'audio.ogg',
@@ -239,10 +235,9 @@ describe('AudioProcessor', () => {
 
         expect(result).toBe('');
         expect(mockVoiceEngineTranscribe).toHaveBeenCalled();
-        expect(mockWhisperCreate).not.toHaveBeenCalled();
       });
 
-      it('should fall back to Whisper when voice-engine fails', async () => {
+      it('should throw when voice-engine fails and no other provider available', async () => {
         const attachment: AttachmentMetadata = {
           url: 'https://example.com/audio.ogg',
           name: 'audio.ogg',
@@ -258,14 +253,10 @@ describe('AudioProcessor', () => {
           arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(1024)),
         });
 
-        const result = await transcribeAudio(attachment);
-
-        expect(result).toBe('Mocked transcription');
-        expect(mockVoiceEngineTranscribe).toHaveBeenCalled();
-        expect(mockWhisperCreate).toHaveBeenCalled();
+        await expect(transcribeAudio(attachment)).rejects.toThrow('No STT provider available');
       });
 
-      it('should use Whisper directly when voice-engine not configured', async () => {
+      it('should throw when no STT provider is configured', async () => {
         const attachment: AttachmentMetadata = {
           url: 'https://example.com/audio.ogg',
           name: 'audio.ogg',
@@ -273,17 +264,14 @@ describe('AudioProcessor', () => {
           size: 1024,
         };
 
-        // mockVoiceEngineClient is null by default (no VOICE_ENGINE_URL)
+        // No voice engine, no ElevenLabs key
 
         (global.fetch as any).mockResolvedValue({
           ok: true,
           arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(1024)),
         });
 
-        const result = await transcribeAudio(attachment);
-
-        expect(result).toBe('Mocked transcription');
-        expect(mockWhisperCreate).toHaveBeenCalled();
+        await expect(transcribeAudio(attachment)).rejects.toThrow('No STT provider available');
       });
     });
 
@@ -296,6 +284,9 @@ describe('AudioProcessor', () => {
           size: 2048,
         };
 
+        mockVoiceEngineTranscribe.mockResolvedValue({ text: 'transcribed' });
+        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe };
+
         (global.fetch as any).mockResolvedValue({
           ok: true,
           arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(2048)),
@@ -303,7 +294,7 @@ describe('AudioProcessor', () => {
 
         const result = await transcribeAudio(attachment);
 
-        expect(result).toBe('Mocked transcription');
+        expect(result).toBe('transcribed');
         expect(global.fetch).toHaveBeenCalledWith(
           attachment.url,
           expect.objectContaining({
@@ -359,143 +350,6 @@ describe('AudioProcessor', () => {
       });
     });
 
-    describe('Whisper transcription', () => {
-      it('should transcribe audio successfully', async () => {
-        const attachment: AttachmentMetadata = {
-          url: 'https://example.com/audio.ogg',
-          name: 'test-audio.ogg',
-          contentType: CONTENT_TYPES.AUDIO_OGG,
-          size: 4096,
-          duration: 30,
-        };
-
-        (global.fetch as any).mockResolvedValue({
-          ok: true,
-          arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(4096)),
-        });
-
-        mockWhisperCreate.mockResolvedValue('This is a transcribed message');
-
-        const result = await transcribeAudio(attachment);
-
-        expect(result).toBe('This is a transcribed message');
-        expect(mockWhisperCreate).toHaveBeenCalledWith(
-          expect.objectContaining({
-            file: expect.any(File),
-            model: expect.any(String),
-            language: expect.any(String),
-            response_format: 'text',
-          })
-        );
-      });
-
-      it('should create File object with correct name', async () => {
-        const attachment: AttachmentMetadata = {
-          url: 'https://example.com/audio.ogg',
-          name: 'my-recording.ogg',
-          contentType: CONTENT_TYPES.AUDIO_OGG,
-          size: 1024,
-        };
-
-        (global.fetch as any).mockResolvedValue({
-          ok: true,
-          arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(1024)),
-        });
-
-        await transcribeAudio(attachment);
-
-        const fileArg = mockWhisperCreate.mock.calls[0][0].file;
-        expect(fileArg.name).toBe('my-recording.ogg');
-      });
-
-      it('should use default name when attachment name is missing', async () => {
-        const attachment: AttachmentMetadata = {
-          url: 'https://example.com/audio.ogg',
-          // No name
-          contentType: CONTENT_TYPES.AUDIO_OGG,
-          size: 1024,
-        };
-
-        (global.fetch as any).mockResolvedValue({
-          ok: true,
-          arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(1024)),
-        });
-
-        await transcribeAudio(attachment);
-
-        const fileArg = mockWhisperCreate.mock.calls[0][0].file;
-        expect(fileArg.name).toBe('audio.ogg');
-      });
-
-      it('should use default name when attachment name is empty', async () => {
-        const attachment: AttachmentMetadata = {
-          url: 'https://example.com/audio.ogg',
-          name: '',
-          contentType: CONTENT_TYPES.AUDIO_OGG,
-          size: 1024,
-        };
-
-        (global.fetch as any).mockResolvedValue({
-          ok: true,
-          arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(1024)),
-        });
-
-        await transcribeAudio(attachment);
-
-        const fileArg = mockWhisperCreate.mock.calls[0][0].file;
-        expect(fileArg.name).toBe('audio.ogg');
-      });
-
-      it('should handle Whisper API errors', async () => {
-        const attachment: AttachmentMetadata = {
-          url: 'https://example.com/audio.ogg',
-          name: 'audio.ogg',
-          contentType: CONTENT_TYPES.AUDIO_OGG,
-          size: 1024,
-        };
-
-        (global.fetch as any).mockResolvedValue({
-          ok: true,
-          arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(1024)),
-        });
-
-        mockWhisperCreate.mockRejectedValue(new Error('Whisper API error'));
-
-        await expect(transcribeAudio(attachment)).rejects.toThrow('Whisper API error');
-      });
-    });
-
-    describe('different audio formats', () => {
-      const testFormats = [
-        { contentType: CONTENT_TYPES.AUDIO_OGG, name: 'OGG format' },
-        { contentType: 'audio/mpeg', name: 'MP3 format' },
-        { contentType: 'audio/wav', name: 'WAV format' },
-        { contentType: 'audio/webm', name: 'WebM format' },
-      ];
-
-      testFormats.forEach(({ contentType, name }) => {
-        it(`should handle ${name}`, async () => {
-          const attachment: AttachmentMetadata = {
-            url: 'https://example.com/audio',
-            name: 'audio',
-            contentType,
-            size: 1024,
-          };
-
-          (global.fetch as any).mockResolvedValue({
-            ok: true,
-            arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(1024)),
-          });
-
-          const result = await transcribeAudio(attachment);
-
-          expect(result).toBe('Mocked transcription');
-          const fileArg = mockWhisperCreate.mock.calls[0][0].file;
-          expect(fileArg.type).toBe(contentType);
-        });
-      });
-    });
-
     describe('voice message handling', () => {
       it('should handle voice messages with duration', async () => {
         const attachment: AttachmentMetadata = {
@@ -503,9 +357,12 @@ describe('AudioProcessor', () => {
           name: 'voice.ogg',
           contentType: CONTENT_TYPES.AUDIO_OGG,
           size: 8192,
-          duration: 120, // 2 minutes
+          duration: 120,
           isVoiceMessage: true,
         };
+
+        mockVoiceEngineTranscribe.mockResolvedValue({ text: 'Voice message text' });
+        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe };
 
         (global.fetch as any).mockResolvedValue({
           ok: true,
@@ -514,30 +371,8 @@ describe('AudioProcessor', () => {
 
         const result = await transcribeAudio(attachment);
 
-        expect(result).toBe('Mocked transcription');
-        expect(mockWhisperCreate).toHaveBeenCalled();
-      });
-
-      it('should handle very long voice messages', async () => {
-        const attachment: AttachmentMetadata = {
-          url: 'https://example.com/long-voice.ogg',
-          name: 'long-voice.ogg',
-          contentType: CONTENT_TYPES.AUDIO_OGG,
-          size: 32768,
-          duration: 900, // 15 minutes
-          isVoiceMessage: true,
-        };
-
-        (global.fetch as any).mockResolvedValue({
-          ok: true,
-          arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(32768)),
-        });
-
-        mockWhisperCreate.mockResolvedValue('Very long transcription...');
-
-        const result = await transcribeAudio(attachment);
-
-        expect(result).toBe('Very long transcription...');
+        expect(result).toBe('Voice message text');
+        expect(mockVoiceEngineTranscribe).toHaveBeenCalled();
       });
     });
 
@@ -569,7 +404,6 @@ describe('AudioProcessor', () => {
             contentType: CONTENT_TYPES.AUDIO_OGG,
           })
         );
-        expect(mockWhisperCreate).not.toHaveBeenCalled();
       });
 
       it('should fall back to voice-engine when ElevenLabs fails', async () => {
@@ -584,22 +418,23 @@ describe('AudioProcessor', () => {
         expect(mockVoiceEngineTranscribe).toHaveBeenCalled();
       });
 
-      it('should fall back to Whisper when both ElevenLabs and voice-engine fail', async () => {
+      it('should throw when both ElevenLabs and voice-engine fail', async () => {
         mockElevenLabsSTT.mockRejectedValue(new Error('ElevenLabs down'));
         // No voice engine configured
 
-        const result = await transcribeAudio(audioAttachment, 'sk_el_test');
-
-        expect(result).toBe('Mocked transcription');
-        expect(mockElevenLabsSTT).toHaveBeenCalled();
-        expect(mockWhisperCreate).toHaveBeenCalled();
+        await expect(transcribeAudio(audioAttachment, 'sk_el_test')).rejects.toThrow(
+          'No STT provider available'
+        );
       });
 
       it('should skip ElevenLabs when no apiKey provided', async () => {
+        mockVoiceEngineTranscribe.mockResolvedValue({ text: 'voice engine result' });
+        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe };
+
         const result = await transcribeAudio(audioAttachment);
 
         expect(mockElevenLabsSTT).not.toHaveBeenCalled();
-        expect(result).toBe('Mocked transcription');
+        expect(result).toBe('voice engine result');
       });
     });
   });

--- a/services/ai-worker/src/services/multimodal/AudioProcessor.test.ts
+++ b/services/ai-worker/src/services/multimodal/AudioProcessor.test.ts
@@ -462,6 +462,8 @@ describe('AudioProcessor', () => {
             contentType: CONTENT_TYPES.AUDIO_OGG,
           })
         );
+        // Voice-engine should NOT be called when ElevenLabs succeeds (early return)
+        expect(mockVoiceEngineTranscribe).not.toHaveBeenCalled();
       });
 
       it('should fall back to voice-engine when ElevenLabs fails', async () => {

--- a/services/ai-worker/src/services/multimodal/AudioProcessor.test.ts
+++ b/services/ai-worker/src/services/multimodal/AudioProcessor.test.ts
@@ -10,7 +10,16 @@ import { CONTENT_TYPES } from '@tzurot/common-types';
 // Create mock functions
 const mockVoiceTranscriptCacheGet = vi.fn().mockResolvedValue(null);
 const mockVoiceEngineTranscribe = vi.fn();
-let mockVoiceEngineClient: { transcribe: typeof mockVoiceEngineTranscribe } | null = null;
+const mockGetHealth = vi.fn().mockResolvedValue({ asr: true, tts: true });
+let mockVoiceEngineClient: {
+  transcribe: typeof mockVoiceEngineTranscribe;
+  getHealth: typeof mockGetHealth;
+} | null = null;
+
+const mockWaitForVoiceEngine = vi.fn().mockResolvedValue(true);
+vi.mock('../voice/voiceEngineWarmup.js', () => ({
+  waitForVoiceEngine: (...args: unknown[]) => mockWaitForVoiceEngine(...args),
+}));
 
 vi.mock('../../redis.js', () => ({
   voiceTranscriptCache: {
@@ -46,6 +55,8 @@ describe('AudioProcessor', () => {
     mockVoiceTranscriptCacheGet.mockResolvedValue(null);
     mockVoiceEngineClient = null;
     mockVoiceEngineTranscribe.mockReset();
+    mockGetHealth.mockReset().mockResolvedValue({ asr: true, tts: true });
+    mockWaitForVoiceEngine.mockReset().mockResolvedValue(true);
     mockElevenLabsSTT.mockReset();
   });
 
@@ -82,7 +93,7 @@ describe('AudioProcessor', () => {
         };
 
         mockVoiceEngineTranscribe.mockResolvedValue({ text: 'transcribed' });
-        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe };
+        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe, getHealth: mockGetHealth };
 
         (global.fetch as any).mockResolvedValue({
           ok: true,
@@ -105,7 +116,7 @@ describe('AudioProcessor', () => {
         };
 
         mockVoiceEngineTranscribe.mockResolvedValue({ text: 'transcribed' });
-        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe };
+        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe, getHealth: mockGetHealth };
 
         (global.fetch as any).mockResolvedValue({
           ok: true,
@@ -130,7 +141,7 @@ describe('AudioProcessor', () => {
         mockVoiceTranscriptCacheGet.mockRejectedValue(new Error('Redis connection failed'));
 
         mockVoiceEngineTranscribe.mockResolvedValue({ text: 'Fallback result' });
-        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe };
+        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe, getHealth: mockGetHealth };
 
         (global.fetch as any).mockResolvedValue({
           ok: true,
@@ -155,7 +166,7 @@ describe('AudioProcessor', () => {
         mockVoiceTranscriptCacheGet.mockResolvedValue(null);
 
         mockVoiceEngineTranscribe.mockResolvedValue({ text: 'transcribed' });
-        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe };
+        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe, getHealth: mockGetHealth };
 
         (global.fetch as any).mockResolvedValue({
           ok: true,
@@ -179,7 +190,7 @@ describe('AudioProcessor', () => {
         mockVoiceTranscriptCacheGet.mockResolvedValue('');
 
         mockVoiceEngineTranscribe.mockResolvedValue({ text: 'transcribed' });
-        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe };
+        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe, getHealth: mockGetHealth };
 
         (global.fetch as any).mockResolvedValue({
           ok: true,
@@ -202,7 +213,7 @@ describe('AudioProcessor', () => {
         };
 
         mockVoiceEngineTranscribe.mockResolvedValue({ text: 'Voice engine transcription' });
-        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe };
+        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe, getHealth: mockGetHealth };
 
         (global.fetch as any).mockResolvedValue({
           ok: true,
@@ -224,7 +235,7 @@ describe('AudioProcessor', () => {
         };
 
         mockVoiceEngineTranscribe.mockResolvedValue({ text: '' });
-        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe };
+        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe, getHealth: mockGetHealth };
 
         (global.fetch as any).mockResolvedValue({
           ok: true,
@@ -246,7 +257,7 @@ describe('AudioProcessor', () => {
         };
 
         mockVoiceEngineTranscribe.mockRejectedValue(new Error('Voice engine down'));
-        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe };
+        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe, getHealth: mockGetHealth };
 
         (global.fetch as any).mockResolvedValue({
           ok: true,
@@ -275,6 +286,53 @@ describe('AudioProcessor', () => {
       });
     });
 
+    describe('voice-engine warm-up', () => {
+      const warmupAttachment: AttachmentMetadata = {
+        url: 'https://example.com/audio.ogg',
+        name: 'audio.ogg',
+        contentType: CONTENT_TYPES.AUDIO_OGG,
+        size: 1024,
+      };
+
+      beforeEach(() => {
+        (global.fetch as any).mockResolvedValue({
+          ok: true,
+          arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(1024)),
+        });
+      });
+
+      it('calls waitForVoiceEngine with asr capability before transcription', async () => {
+        mockVoiceEngineTranscribe.mockResolvedValue({ text: 'warm result' });
+        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe, getHealth: mockGetHealth };
+
+        await transcribeAudio(warmupAttachment);
+
+        expect(mockWaitForVoiceEngine).toHaveBeenCalledWith(mockVoiceEngineClient, 'asr');
+        expect(mockWaitForVoiceEngine).toHaveBeenCalledTimes(1);
+        expect(mockVoiceEngineTranscribe).toHaveBeenCalled();
+      });
+
+      it('proceeds with transcription even when warm-up returns false (budget exhausted)', async () => {
+        mockWaitForVoiceEngine.mockResolvedValue(false);
+        mockVoiceEngineTranscribe.mockResolvedValue({ text: 'still works' });
+        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe, getHealth: mockGetHealth };
+
+        const result = await transcribeAudio(warmupAttachment);
+
+        expect(result).toBe('still works');
+        expect(mockWaitForVoiceEngine).toHaveBeenCalledWith(mockVoiceEngineClient, 'asr');
+        expect(mockVoiceEngineTranscribe).toHaveBeenCalled();
+      });
+
+      it('does not call warm-up when voice engine client is null', async () => {
+        // No voice engine configured — should throw "No STT provider"
+        await expect(transcribeAudio(warmupAttachment)).rejects.toThrow(
+          'No STT provider available'
+        );
+        expect(mockWaitForVoiceEngine).not.toHaveBeenCalled();
+      });
+    });
+
     describe('audio fetching', () => {
       it('should fetch audio successfully', async () => {
         const attachment: AttachmentMetadata = {
@@ -285,7 +343,7 @@ describe('AudioProcessor', () => {
         };
 
         mockVoiceEngineTranscribe.mockResolvedValue({ text: 'transcribed' });
-        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe };
+        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe, getHealth: mockGetHealth };
 
         (global.fetch as any).mockResolvedValue({
           ok: true,
@@ -362,7 +420,7 @@ describe('AudioProcessor', () => {
         };
 
         mockVoiceEngineTranscribe.mockResolvedValue({ text: 'Voice message text' });
-        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe };
+        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe, getHealth: mockGetHealth };
 
         (global.fetch as any).mockResolvedValue({
           ok: true,
@@ -408,7 +466,7 @@ describe('AudioProcessor', () => {
 
       it('should fall back to voice-engine when ElevenLabs fails', async () => {
         mockElevenLabsSTT.mockRejectedValue(new Error('ElevenLabs down'));
-        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe };
+        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe, getHealth: mockGetHealth };
         mockVoiceEngineTranscribe.mockResolvedValue({ text: 'Voice engine result' });
 
         const result = await transcribeAudio(audioAttachment, 'sk_el_test');
@@ -429,7 +487,7 @@ describe('AudioProcessor', () => {
 
       it('should skip ElevenLabs when no apiKey provided', async () => {
         mockVoiceEngineTranscribe.mockResolvedValue({ text: 'voice engine result' });
-        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe };
+        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe, getHealth: mockGetHealth };
 
         const result = await transcribeAudio(audioAttachment);
 

--- a/services/ai-worker/src/services/multimodal/AudioProcessor.ts
+++ b/services/ai-worker/src/services/multimodal/AudioProcessor.ts
@@ -9,6 +9,7 @@
 
 import { createLogger, TIMEOUTS, type AttachmentMetadata } from '@tzurot/common-types';
 import { VoiceEngineError, getVoiceEngineClient } from '../voice/VoiceEngineClient.js';
+import { waitForVoiceEngine } from '../voice/voiceEngineWarmup.js';
 import { elevenLabsSTT, ElevenLabsApiError } from '../voice/ElevenLabsClient.js';
 
 const logger = createLogger('AudioProcessor');
@@ -54,6 +55,11 @@ async function transcribeWithVoiceEngine(
   if (voiceEngineClient === null) {
     return null;
   }
+
+  // Wake voice-engine from Railway Serverless sleep before attempting STT.
+  // Without this, ECONNREFUSED wastes the first retry attempt (~7s backoff)
+  // while the engine cold-starts for ~56s.
+  await waitForVoiceEngine(voiceEngineClient, 'asr');
 
   try {
     const filename =

--- a/services/ai-worker/src/services/multimodal/AudioProcessor.ts
+++ b/services/ai-worker/src/services/multimodal/AudioProcessor.ts
@@ -3,47 +3,19 @@
  *
  * Processes audio (voice messages, audio files) to extract text transcriptions.
  * Primary path: ElevenLabs STT (when BYOK key available).
- * Secondary: self-hosted voice-engine (Parakeet TDT) when VOICE_ENGINE_URL is set.
- * Fallback: OpenAI Whisper when neither is available.
+ * Fallback: self-hosted voice-engine (Parakeet TDT) when VOICE_ENGINE_URL is set.
  * Includes Redis caching for faster repeated access.
  */
 
-import {
-  createLogger,
-  getConfig,
-  TIMEOUTS,
-  AI_DEFAULTS,
-  TEXT_LIMITS,
-  type AttachmentMetadata,
-} from '@tzurot/common-types';
-import OpenAI from 'openai';
+import { createLogger, TIMEOUTS, type AttachmentMetadata } from '@tzurot/common-types';
 import { VoiceEngineError, getVoiceEngineClient } from '../voice/VoiceEngineClient.js';
 import { elevenLabsSTT, ElevenLabsApiError } from '../voice/ElevenLabsClient.js';
 
 const logger = createLogger('AudioProcessor');
 
-// ---------------------------------------------------------------------------
-// Lazy OpenAI singleton — avoids creating a new client per transcription
-// ---------------------------------------------------------------------------
-let _openaiClient: OpenAI | null = null;
-
-function getOpenAIClient(): OpenAI {
-  if (_openaiClient !== null) {
-    return _openaiClient;
-  }
-  const config = getConfig();
-  _openaiClient = new OpenAI({ apiKey: config.OPENAI_API_KEY, timeout: TIMEOUTS.WHISPER_API });
-  return _openaiClient;
-}
-
-/** Reset singleton for testing. */
-export function resetOpenAIClient(): void {
-  _openaiClient = null;
-}
-
 /**
  * Fetch audio from a URL with timeout, returning a Buffer.
- * Shared by both voice-engine and Whisper paths.
+ * Shared by both ElevenLabs and voice-engine paths.
  */
 async function fetchAudioBuffer(url: string): Promise<ArrayBuffer> {
   const controller = new AbortController();
@@ -108,80 +80,16 @@ async function transcribeWithVoiceEngine(
       );
     }
 
-    // Empty string is a valid result (silent/inaudible audio) — don't fall back to Whisper
+    // Empty string is a valid result (silent/inaudible audio)
     return result.text;
   } catch (error) {
-    // Auth errors (401/403) are persistent config issues — log at error level.
-    // We still fall back to Whisper (intentional "always succeed" trade-off:
-    // user gets a transcription even with misconfigured voice-engine, at the
-    // cost of silent OpenAI API usage visible only in error logs).
     if (error instanceof VoiceEngineError && error.isAuthError) {
-      logger.error(
-        { err: error, voiceEngineFallback: true },
-        'Voice engine auth error — check VOICE_ENGINE_API_KEY config'
-      );
+      logger.error({ err: error }, 'Voice engine auth error — check VOICE_ENGINE_API_KEY config');
     } else {
-      logger.warn(
-        { err: error, voiceEngineFallback: true },
-        '[FALLBACK] Voice engine unavailable — transcribing via Whisper'
-      );
+      logger.warn({ err: error }, 'Voice engine transcription failed');
     }
     return null;
   }
-}
-
-/**
- * Transcribe audio using OpenAI Whisper (fallback path).
- */
-async function transcribeWithWhisper(
-  attachment: AttachmentMetadata,
-  audioBuffer: ArrayBuffer
-): Promise<string> {
-  const config = getConfig();
-
-  logger.info(
-    {
-      url: attachment.url,
-      originalUrl: attachment.originalUrl,
-      duration: attachment.duration,
-      contentType: attachment.contentType,
-    },
-    'Transcribing audio with Whisper'
-  );
-
-  const openai = getOpenAIClient();
-
-  const blob = new Blob([audioBuffer], { type: attachment.contentType });
-  const audioFile = new File(
-    [blob],
-    attachment.name !== undefined && attachment.name.length > 0 ? attachment.name : 'audio.ogg',
-    { type: attachment.contentType }
-  );
-
-  logger.info(
-    { fileSize: audioFile.size, duration: attachment.duration },
-    'Starting Whisper transcription...'
-  );
-
-  const transcription = await openai.audio.transcriptions.create({
-    file: audioFile,
-    model: config.WHISPER_MODEL,
-    language: AI_DEFAULTS.WHISPER_LANGUAGE,
-    response_format: 'text',
-  });
-
-  logger.info(
-    {
-      duration: attachment.duration,
-      transcriptionLength: transcription.length,
-      transcriptionPreview:
-        transcription.substring(0, TEXT_LIMITS.PERSONALITY_PREVIEW) +
-        (transcription.length > TEXT_LIMITS.PERSONALITY_PREVIEW ? '...' : ''),
-    },
-    'Audio transcribed successfully via Whisper'
-  );
-
-  return transcription;
 }
 
 /**
@@ -229,10 +137,8 @@ async function transcribeWithElevenLabs(
 
 /**
  * Transcribe audio (voice message or audio file).
- * Tries ElevenLabs STT first (if BYOK key), then voice-engine, falls back to Whisper.
- * Empty string from voice-engine is returned as-is (silent/inaudible audio) —
- * only null (unconfigured or failed) triggers the Whisper fallback.
- * Throws errors to allow retry logic to handle them.
+ * Tries ElevenLabs STT first (if BYOK key), then voice-engine.
+ * Throws when no STT provider is available — surfaces config issues.
  *
  * @param attachment - Audio attachment to transcribe
  * @param elevenlabsApiKey - Optional ElevenLabs BYOK key for premium STT
@@ -288,6 +194,8 @@ export async function transcribeAudio(
     return voiceEngineResult;
   }
 
-  // Fallback to Whisper
-  return transcribeWithWhisper(attachment, audioBuffer);
+  // No STT provider available — fail with clear error
+  throw new Error(
+    'No STT provider available: configure an ElevenLabs API key (BYOK) or VOICE_ENGINE_URL'
+  );
 }

--- a/services/ai-worker/src/services/voice/ElevenLabsVoiceService.ts
+++ b/services/ai-worker/src/services/voice/ElevenLabsVoiceService.ts
@@ -15,7 +15,12 @@
  * Voice naming: "tzurot-{slug}" — identifiable in ElevenLabs dashboard.
  */
 
-import { createLogger, TTLCache, getConfig } from '@tzurot/common-types';
+import {
+  createLogger,
+  TTLCache,
+  getConfig,
+  ELEVENLABS_VOICE_NAME_PREFIX,
+} from '@tzurot/common-types';
 import {
   elevenLabsCloneVoice,
   elevenLabsListVoices,
@@ -30,8 +35,6 @@ const CLONE_CACHE_TTL_MS = 30 * 60 * 1000;
 const NEGATIVE_CACHE_TTL_MS = 5 * 60 * 1000;
 /** Max cached entries */
 const CACHE_MAX_SIZE = 200;
-/** Voice name prefix for identification in user's ElevenLabs dashboard */
-const VOICE_NAME_PREFIX = 'tzurot-';
 
 interface CachedVoice {
   voiceId: string;
@@ -101,7 +104,7 @@ export class ElevenLabsVoiceService {
   }
 
   private async doEnsureCloned(slug: string, apiKey: string, cacheKey: string): Promise<string> {
-    const voiceName = `${VOICE_NAME_PREFIX}${slug}`;
+    const voiceName = `${ELEVENLABS_VOICE_NAME_PREFIX}${slug}`;
 
     // Check if voice already exists in user's account (avoids re-cloning).
     // Note: matches by name only — a manually-created voice with the same

--- a/services/ai-worker/src/services/voice/VoiceEngineClient.ts
+++ b/services/ai-worker/src/services/voice/VoiceEngineClient.ts
@@ -42,9 +42,9 @@ export class VoiceEngineClient {
     // Strip trailing slash for consistent URL construction
     this.baseUrl = baseUrl.replace(/\/+$/, '');
     this.apiKey = apiKey;
-    // Reuses WHISPER_API timeout (3min) intentionally — Railway Serverless cold starts
+    // Uses VOICE_ENGINE_API timeout (3min) — Railway Serverless cold starts
     // take 30-120s for model loading, so a shorter timeout would cause false failures.
-    this.timeoutMs = timeoutMs ?? TIMEOUTS.WHISPER_API;
+    this.timeoutMs = timeoutMs ?? TIMEOUTS.VOICE_ENGINE_API;
   }
 
   /** Transcribe audio via POST /v1/transcribe (native endpoint). */

--- a/services/ai-worker/src/services/voice/voiceEngineWarmup.test.ts
+++ b/services/ai-worker/src/services/voice/voiceEngineWarmup.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for Voice Engine Warm-Up
+ *
+ * Verifies the shared health-polling loop used by both TTS and STT paths
+ * to handle Railway Serverless cold starts (~56s).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    }),
+  };
+});
+
+const { waitForVoiceEngine } = await import('./voiceEngineWarmup.js');
+
+function createMockClient(getHealthImpl: () => Promise<{ asr: boolean; tts: boolean }>) {
+  return { getHealth: vi.fn(getHealthImpl) } as unknown as Parameters<typeof waitForVoiceEngine>[0];
+}
+
+describe('waitForVoiceEngine', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns true immediately when capability is ready on first poll', async () => {
+    const client = createMockClient(async () => ({ asr: true, tts: true }));
+
+    const promise = waitForVoiceEngine(client, 'tts');
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe(true);
+    expect(client.getHealth).toHaveBeenCalledTimes(1);
+  });
+
+  it('polls until ready (simulates cold start)', async () => {
+    const client = createMockClient(
+      vi
+        .fn<() => Promise<{ asr: boolean; tts: boolean }>>()
+        .mockResolvedValueOnce({ asr: false, tts: false })
+        .mockResolvedValueOnce({ asr: false, tts: false })
+        .mockResolvedValueOnce({ asr: true, tts: true })
+    );
+
+    const promise = waitForVoiceEngine(client, 'tts');
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe(true);
+    expect(client.getHealth).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns false when budget exhausted (all polls unhealthy)', async () => {
+    const client = createMockClient(async () => ({ asr: false, tts: false }));
+
+    const promise = waitForVoiceEngine(client, 'tts', {
+      budgetMs: 9_000,
+      pollIntervalMs: 3_000,
+    });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe(false);
+    // 9_000 / 3_000 = 3 polls (each followed by 3s sleep)
+    expect(client.getHealth).toHaveBeenCalledTimes(3);
+  });
+
+  it('respects custom budgetMs and pollIntervalMs', async () => {
+    const client = createMockClient(async () => ({ asr: false, tts: false }));
+
+    const promise = waitForVoiceEngine(client, 'asr', {
+      budgetMs: 5_000,
+      pollIntervalMs: 1_000,
+    });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe(false);
+    // 5_000 / 1_000 = 5 polls
+    expect(client.getHealth).toHaveBeenCalledTimes(5);
+  });
+
+  it('checks correct capability field — asr', async () => {
+    // TTS ready but ASR not — should keep polling for ASR
+    const client = createMockClient(
+      vi
+        .fn<() => Promise<{ asr: boolean; tts: boolean }>>()
+        .mockResolvedValueOnce({ asr: false, tts: true })
+        .mockResolvedValueOnce({ asr: true, tts: true })
+    );
+
+    const promise = waitForVoiceEngine(client, 'asr');
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe(true);
+    expect(client.getHealth).toHaveBeenCalledTimes(2);
+  });
+
+  it('checks correct capability field — tts', async () => {
+    // ASR ready but TTS not — should keep polling for TTS
+    const client = createMockClient(
+      vi
+        .fn<() => Promise<{ asr: boolean; tts: boolean }>>()
+        .mockResolvedValueOnce({ asr: true, tts: false })
+        .mockResolvedValueOnce({ asr: true, tts: true })
+    );
+
+    const promise = waitForVoiceEngine(client, 'tts');
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe(true);
+    expect(client.getHealth).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses default budget and interval when no options provided', async () => {
+    const client = createMockClient(async () => ({ asr: false, tts: false }));
+
+    const promise = waitForVoiceEngine(client, 'tts');
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe(false);
+    // Default: 75_000 / 3_000 = 25 polls
+    expect(client.getHealth).toHaveBeenCalledTimes(25);
+  });
+});

--- a/services/ai-worker/src/services/voice/voiceEngineWarmup.ts
+++ b/services/ai-worker/src/services/voice/voiceEngineWarmup.ts
@@ -1,0 +1,73 @@
+/**
+ * Voice Engine Warm-Up
+ *
+ * Shared utility for waking voice-engine from Railway Serverless sleep.
+ * First ping triggers Railway to start the container; subsequent polls
+ * wait for model loading (~56s measured cold boot).
+ *
+ * Used by both TTS (TTSStep) and STT (AudioProcessor) paths.
+ */
+
+import { createLogger } from '@tzurot/common-types';
+import type { VoiceEngineClient } from './VoiceEngineClient.js';
+
+const logger = createLogger('VoiceEngineWarmup');
+
+/** Total time budget for health polling during voice engine cold start (ms).
+ * Railway Serverless cold boot measured at ~56s — 75s gives comfortable margin.
+ * Note: effective poll count varies — ECONNREFUSED resolves instantly (~25 polls),
+ * but once Railway's LB is up the 5s health timeout may reduce it to ~10 polls. */
+const DEFAULT_BUDGET_MS = 75_000;
+
+/** Interval between health check polls (ms) */
+const DEFAULT_POLL_INTERVAL_MS = 3_000;
+
+export interface WarmupOptions {
+  budgetMs?: number;
+  pollIntervalMs?: number;
+}
+
+/**
+ * Wait for voice-engine to become ready by polling /health.
+ * First ping wakes Railway Serverless; subsequent polls wait for model loading (~56s).
+ * Returns true if the requested capability is ready, false if budget exhausted.
+ *
+ * Callers should proceed even on `false` — registration/synthesis will fail with
+ * a clear error if the engine truly isn't available.
+ */
+export async function waitForVoiceEngine(
+  client: VoiceEngineClient,
+  capability: 'asr' | 'tts',
+  options?: WarmupOptions
+): Promise<boolean> {
+  const budgetMs = options?.budgetMs ?? DEFAULT_BUDGET_MS;
+  const pollIntervalMs = options?.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const deadline = Date.now() + budgetMs;
+  let attempt = 0;
+
+  while (Date.now() < deadline) {
+    attempt++;
+    // getHealth() is error-safe — wraps all errors (ECONNREFUSED, 502, etc.)
+    // and returns { asr: false, tts: false }. It never throws, so the loop
+    // is resilient to transient network failures during the full boot window.
+    const health = await client.getHealth();
+    if (health[capability]) {
+      return true;
+    }
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      break;
+    }
+    logger.info(
+      { capability, attempt, remainingMs: remaining },
+      `Voice engine ${capability.toUpperCase()} not ready — waiting for cold start`
+    );
+    await new Promise(resolve => setTimeout(resolve, Math.min(pollIntervalMs, remaining)));
+  }
+
+  logger.warn(
+    { capability, attempts: attempt, budgetMs },
+    `Voice engine ${capability.toUpperCase()} still not ready after health budget`
+  );
+  return false;
+}

--- a/services/ai-worker/src/startup.test.ts
+++ b/services/ai-worker/src/startup.test.ts
@@ -20,7 +20,6 @@ vi.mock('@tzurot/common-types', async importOriginal => {
     }),
     getConfig: vi.fn(() => ({
       REDIS_URL: 'redis://localhost:6379',
-      OPENAI_API_KEY: 'test-openai-key',
     })),
     HealthStatus: actual.HealthStatus,
   };
@@ -32,12 +31,7 @@ vi.mock('./services/voice/VoiceEngineClient.js', () => ({
 
 import { HealthStatus } from '@tzurot/common-types';
 import { getVoiceEngineClient } from './services/voice/VoiceEngineClient.js';
-import {
-  validateRequiredEnvVars,
-  validateAIConfig,
-  buildHealthResponse,
-  checkVoiceEngineHealth,
-} from './startup.js';
+import { validateRequiredEnvVars, buildHealthResponse, checkVoiceEngineHealth } from './startup.js';
 
 describe('Startup Utilities', () => {
   beforeEach(() => {
@@ -76,35 +70,6 @@ describe('Startup Utilities', () => {
           config as ReturnType<typeof import('@tzurot/common-types').getConfig>
         )
       ).toThrow('REDIS_URL environment variable is required');
-    });
-  });
-
-  describe('validateAIConfig', () => {
-    it('should not throw when OPENAI_API_KEY is set', () => {
-      const config = {
-        OPENAI_API_KEY: 'test-key',
-      };
-      expect(() =>
-        validateAIConfig(config as ReturnType<typeof import('@tzurot/common-types').getConfig>)
-      ).not.toThrow();
-    });
-
-    it('should throw when OPENAI_API_KEY is undefined', () => {
-      const config = {
-        OPENAI_API_KEY: undefined,
-      };
-      expect(() =>
-        validateAIConfig(config as ReturnType<typeof import('@tzurot/common-types').getConfig>)
-      ).toThrow('OPENAI_API_KEY environment variable is required for memory embeddings');
-    });
-
-    it('should throw when OPENAI_API_KEY is empty', () => {
-      const config = {
-        OPENAI_API_KEY: '',
-      };
-      expect(() =>
-        validateAIConfig(config as ReturnType<typeof import('@tzurot/common-types').getConfig>)
-      ).toThrow('OPENAI_API_KEY environment variable is required for memory embeddings');
     });
   });
 

--- a/services/ai-worker/src/startup.ts
+++ b/services/ai-worker/src/startup.ts
@@ -20,17 +20,6 @@ export function validateRequiredEnvVars(config = getConfig()): void {
 }
 
 /**
- * Validate AI-specific configuration
- * @throws Error if AI-specific environment variables are missing
- */
-export function validateAIConfig(config = getConfig()): void {
-  if (config.OPENAI_API_KEY === undefined || config.OPENAI_API_KEY.length === 0) {
-    logger.fatal('OPENAI_API_KEY environment variable is required for memory embeddings');
-    throw new Error('OPENAI_API_KEY environment variable is required for memory embeddings');
-  }
-}
-
-/**
  * One-shot voice engine health check at startup.
  * Logs whether the voice engine is configured and reachable.
  * Never throws — wrapped in try/catch for resilience.

--- a/services/api-gateway/src/routes/ai/transcribe.ts
+++ b/services/api-gateway/src/routes/ai/transcribe.ts
@@ -1,6 +1,6 @@
 /**
  * POST /ai/transcribe
- * Transcribe audio attachments using Whisper
+ * Transcribe audio attachments via ElevenLabs STT (BYOK) or voice-engine
  */
 
 import { Router, type Request, type Response } from 'express';
@@ -34,7 +34,7 @@ export function createTranscribeRoute(
   /**
    * POST /transcribe
    *
-   * Transcribe audio attachments using Whisper.
+   * Transcribe audio attachments via ElevenLabs STT (BYOK) or voice-engine.
    * Creates an AudioTranscriptionJob for each audio attachment.
    *
    * Query parameters:

--- a/services/api-gateway/src/routes/ai/transcribe.ts
+++ b/services/api-gateway/src/routes/ai/transcribe.ts
@@ -59,6 +59,10 @@ export function createTranscribeRoute(
       // Download attachments to local storage
       const localAttachments = await attachmentStorage.downloadAndStore(requestId, attachments);
 
+      if (localAttachments.length === 0) {
+        return sendError(res, ErrorResponses.internalError('Failed to download audio attachment'));
+      }
+
       // Use first audio attachment (transcribe endpoint expects single audio file)
       const audioAttachment = localAttachments[0];
 

--- a/services/api-gateway/src/routes/user/index.ts
+++ b/services/api-gateway/src/routes/user/index.ts
@@ -46,6 +46,9 @@
  * - GET /user/nsfw - Get NSFW verification status
  * - POST /user/nsfw/verify - Mark user as NSFW verified
  * - GET /user/conversation/message-personality - Get personality from Discord message ID (internal)
+ * - GET /user/voices - List ElevenLabs cloned voices (tzurot-prefixed)
+ * - DELETE /user/voices/:voiceId - Delete a single cloned voice
+ * - POST /user/voices/clear - Delete ALL tzurot-prefixed voices
  */
 
 import { Router } from 'express';
@@ -72,6 +75,7 @@ import { createConversationLookupRoutes } from './conversationLookup.js';
 import { createConfigOverrideRoutes } from './config-overrides.js';
 import { createPersonalityConfigOverrideRoutes } from './personality-config-overrides.js';
 import { createShapesRoutes } from './shapes/index.js';
+import { createVoicesRoutes } from './voices.js';
 
 /** Dependencies for creating the user router */
 interface UserRouterOptions {
@@ -144,6 +148,9 @@ export function createUserRouter(opts: UserRouterOptions): Router {
 
   // Shapes.inc import routes (credential management, import jobs)
   router.use('/shapes', createShapesRoutes(prisma, aiQueue));
+
+  // Voice management routes (ElevenLabs cloned voice CRUD)
+  router.use('/voices', createVoicesRoutes(prisma));
 
   return router;
 }

--- a/services/api-gateway/src/routes/user/voices.test.ts
+++ b/services/api-gateway/src/routes/user/voices.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Tests for Voice Management Routes
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { createVoicesRoutes } from './voices.js';
+import type { PrismaClient } from '@tzurot/common-types';
+
+// Mock common-types
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    }),
+    decryptApiKey: vi.fn().mockReturnValue('test-elevenlabs-key'),
+  };
+});
+
+// Mock auth middleware
+vi.mock('../../services/AuthMiddleware.js', () => ({
+  requireUserAuth: () => (req: any, _res: any, next: any) => {
+    req.userId = 'discord-user-123';
+    next();
+  },
+}));
+
+// Mock fetch
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+import { decryptApiKey } from '@tzurot/common-types';
+
+describe('Voice Management Routes', () => {
+  let app: express.Express;
+
+  const mockPrisma = {
+    user: {
+      findFirst: vi.fn(),
+    },
+    userApiKey: {
+      findFirst: vi.fn(),
+    },
+  } as unknown as PrismaClient;
+
+  const mockVoicesResponse = {
+    voices: [
+      { voice_id: 'voice-1', name: 'tzurot-alice', category: 'cloned' },
+      { voice_id: 'voice-2', name: 'tzurot-bob', category: 'cloned' },
+      { voice_id: 'voice-3', name: 'my-custom-voice', category: 'cloned' },
+      { voice_id: 'voice-4', name: 'premade-voice', category: 'premade' },
+    ],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    app = express();
+    app.use(express.json());
+    app.use('/voices', createVoicesRoutes(mockPrisma));
+
+    // Default: user exists and has encrypted key
+    (mockPrisma.user.findFirst as any).mockResolvedValue({ id: 'user-uuid-123' });
+    (mockPrisma.userApiKey.findFirst as any).mockResolvedValue({
+      iv: 'mock-iv',
+      content: 'mock-content',
+      tag: 'mock-tag',
+    });
+
+    // Default: decryptApiKey returns test key (must re-apply after restoreAllMocks)
+    vi.mocked(decryptApiKey).mockReturnValue('test-elevenlabs-key');
+
+    // Default: ElevenLabs returns voices
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockVoicesResponse),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('GET / - List voices', () => {
+    it('should return tzurot-prefixed voices only', async () => {
+      const res = await request(app).get('/voices');
+
+      expect(res.status).toBe(200);
+      expect(res.body.voices).toHaveLength(2);
+      expect(res.body.voices[0]).toEqual({
+        voiceId: 'voice-1',
+        name: 'tzurot-alice',
+        slug: 'alice',
+      });
+      expect(res.body.voices[1]).toEqual({
+        voiceId: 'voice-2',
+        name: 'tzurot-bob',
+        slug: 'bob',
+      });
+      expect(res.body.totalSlots).toBe(4);
+      expect(res.body.tzurotCount).toBe(2);
+    });
+
+    it('should return 404 when user has no ElevenLabs key', async () => {
+      (mockPrisma.userApiKey.findFirst as any).mockResolvedValue(null);
+
+      const res = await request(app).get('/voices');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('NOT_FOUND');
+      expect(res.body.message).toContain('ElevenLabs API key');
+    });
+
+    it('should return 404 when user does not exist', async () => {
+      (mockPrisma.user.findFirst as any).mockResolvedValue(null);
+
+      const res = await request(app).get('/voices');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('NOT_FOUND');
+    });
+
+    it('should return 500 when decryption fails', async () => {
+      vi.mocked(decryptApiKey).mockImplementation(() => {
+        throw new Error('Decryption failed');
+      });
+
+      const res = await request(app).get('/voices');
+
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe('INTERNAL_ERROR');
+    });
+
+    it('should handle ElevenLabs API errors', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+      });
+
+      const res = await request(app).get('/voices');
+
+      expect(res.status).toBe(500);
+    });
+  });
+
+  describe('DELETE /:voiceId - Delete a voice', () => {
+    it('should delete a tzurot-prefixed voice', async () => {
+      // First call: fetch voices to verify; Second call: delete
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockVoicesResponse),
+        })
+        .mockResolvedValueOnce({ ok: true });
+
+      const res = await request(app).delete('/voices/voice-1');
+
+      expect(res.status).toBe(200);
+      expect(res.body.deleted).toBe(true);
+      expect(res.body.voiceId).toBe('voice-1');
+      expect(res.body.slug).toBe('alice');
+    });
+
+    it('should reject deleting a non-tzurot voice', async () => {
+      const res = await request(app).delete('/voices/voice-3');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('NOT_FOUND');
+    });
+
+    it('should reject deleting a nonexistent voice', async () => {
+      const res = await request(app).delete('/voices/nonexistent');
+
+      expect(res.status).toBe(404);
+    });
+
+    it('should handle ElevenLabs delete failure', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockVoicesResponse),
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 500,
+          statusText: 'Internal Server Error',
+        });
+
+      const res = await request(app).delete('/voices/voice-1');
+
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe('INTERNAL_ERROR');
+    });
+  });
+
+  describe('POST /clear - Clear all tzurot voices', () => {
+    it('should delete all tzurot-prefixed voices', async () => {
+      // First call: fetch voices; subsequent calls: delete each
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockVoicesResponse),
+        })
+        .mockResolvedValue({ ok: true });
+
+      const res = await request(app).post('/voices/clear');
+
+      expect(res.status).toBe(200);
+      expect(res.body.deleted).toBe(2);
+      expect(res.body.total).toBe(2);
+      expect(res.body.errors).toBeUndefined();
+    });
+
+    it('should report when no voices to clear', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            voices: [{ voice_id: 'v1', name: 'non-tzurot', category: 'premade' }],
+          }),
+      });
+
+      const res = await request(app).post('/voices/clear');
+
+      expect(res.status).toBe(200);
+      expect(res.body.deleted).toBe(0);
+      expect(res.body.message).toContain('No Tzurot voices');
+    });
+
+    it('should report partial failures', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockVoicesResponse),
+        })
+        .mockResolvedValueOnce({ ok: true }) // voice-1 succeeds
+        .mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Error' }); // voice-2 fails
+
+      const res = await request(app).post('/voices/clear');
+
+      expect(res.status).toBe(200);
+      expect(res.body.deleted).toBe(1);
+      expect(res.body.total).toBe(2);
+      expect(res.body.errors).toHaveLength(1);
+    });
+  });
+});

--- a/services/api-gateway/src/routes/user/voices.test.ts
+++ b/services/api-gateway/src/routes/user/voices.test.ts
@@ -167,11 +167,12 @@ describe('Voice Management Routes', () => {
 
   describe('DELETE /:voiceId - Delete a voice', () => {
     it('should delete a tzurot-prefixed voice', async () => {
-      // First call: fetch voices to verify; Second call: delete
+      // First call: fetch single voice to verify; Second call: delete
       mockFetch
         .mockResolvedValueOnce({
           ok: true,
-          json: () => Promise.resolve(mockVoicesResponse),
+          json: () =>
+            Promise.resolve({ voice_id: 'voice-1', name: 'tzurot-alice', category: 'cloned' }),
         })
         .mockResolvedValueOnce({ ok: true });
 
@@ -185,6 +186,12 @@ describe('Voice Management Routes', () => {
 
     it('should reject deleting a non-tzurot voice (IDOR guard)', async () => {
       // voice-3 is 'my-custom-voice' — not tzurot-prefixed, so ownership check rejects
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({ voice_id: 'voice-3', name: 'my-custom-voice', category: 'cloned' }),
+      });
+
       const res = await request(app).delete('/voices/voice-3');
 
       expect(res.status).toBe(404);
@@ -193,6 +200,12 @@ describe('Voice Management Routes', () => {
     });
 
     it('should reject deleting a nonexistent voice', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      });
+
       const res = await request(app).delete('/voices/nonexistent');
 
       expect(res.status).toBe(404);
@@ -216,7 +229,8 @@ describe('Voice Management Routes', () => {
       mockFetch
         .mockResolvedValueOnce({
           ok: true,
-          json: () => Promise.resolve(mockVoicesResponse),
+          json: () =>
+            Promise.resolve({ voice_id: 'voice-1', name: 'tzurot-alice', category: 'cloned' }),
         })
         .mockResolvedValueOnce({
           ok: false,

--- a/services/api-gateway/src/routes/user/voices.test.ts
+++ b/services/api-gateway/src/routes/user/voices.test.ts
@@ -194,7 +194,7 @@ describe('Voice Management Routes', () => {
 
       expect(res.status).toBe(404);
       expect(res.body.error).toBe('NOT_FOUND');
-      expect(res.body.message).toContain('not a Tzurot-cloned voice');
+      expect(res.body.message).toBe('Tzurot-cloned voice not found');
     });
 
     it('should reject malformed voiceId without calling ElevenLabs', async () => {

--- a/services/api-gateway/src/routes/user/voices.test.ts
+++ b/services/api-gateway/src/routes/user/voices.test.ts
@@ -44,9 +44,6 @@ describe('Voice Management Routes', () => {
     user: {
       findFirst: vi.fn(),
     },
-    userApiKey: {
-      findFirst: vi.fn(),
-    },
   } as unknown as PrismaClient;
 
   const mockVoicesResponse = {
@@ -65,12 +62,10 @@ describe('Voice Management Routes', () => {
     app.use(express.json());
     app.use('/voices', createVoicesRoutes(mockPrisma));
 
-    // Default: user exists and has encrypted key
-    (mockPrisma.user.findFirst as any).mockResolvedValue({ id: 'user-uuid-123' });
-    (mockPrisma.userApiKey.findFirst as any).mockResolvedValue({
-      iv: 'mock-iv',
-      content: 'mock-content',
-      tag: 'mock-tag',
+    // Default: user exists and has encrypted ElevenLabs key (single query with include)
+    (mockPrisma.user.findFirst as any).mockResolvedValue({
+      id: 'user-uuid-123',
+      apiKeys: [{ iv: 'mock-iv', content: 'mock-content', tag: 'mock-tag' }],
     });
 
     // Default: decryptApiKey returns test key (must re-apply after restoreAllMocks)
@@ -108,7 +103,10 @@ describe('Voice Management Routes', () => {
     });
 
     it('should return 404 when user has no ElevenLabs key', async () => {
-      (mockPrisma.userApiKey.findFirst as any).mockResolvedValue(null);
+      (mockPrisma.user.findFirst as any).mockResolvedValue({
+        id: 'user-uuid-123',
+        apiKeys: [],
+      });
 
       const res = await request(app).get('/voices');
 
@@ -197,6 +195,17 @@ describe('Voice Management Routes', () => {
       expect(res.status).toBe(404);
       expect(res.body.error).toBe('NOT_FOUND');
       expect(res.body.message).toContain('not a Tzurot-cloned voice');
+    });
+
+    it('should reject malformed voiceId without calling ElevenLabs', async () => {
+      // URL-encode to ensure the full string reaches the route param
+      const badId = 'invalid%20voice%21%23id';
+      const res = await request(app).delete(`/voices/${badId}`);
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('NOT_FOUND');
+      // Should not make any ElevenLabs API calls for obviously invalid IDs
+      expect(mockFetch).not.toHaveBeenCalled();
     });
 
     it('should reject deleting a nonexistent voice', async () => {

--- a/services/api-gateway/src/routes/user/voices.test.ts
+++ b/services/api-gateway/src/routes/user/voices.test.ts
@@ -181,6 +181,18 @@ describe('Voice Management Routes', () => {
       expect(res.status).toBe(404);
     });
 
+    it('should handle ElevenLabs API error during ownership check', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+      });
+
+      const res = await request(app).delete('/voices/voice-1');
+
+      expect(res.status).toBe(500);
+    });
+
     it('should handle ElevenLabs delete failure', async () => {
       mockFetch
         .mockResolvedValueOnce({
@@ -232,7 +244,20 @@ describe('Voice Management Routes', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.deleted).toBe(0);
+      expect(res.body.total).toBe(0);
       expect(res.body.message).toContain('No Tzurot voices');
+    });
+
+    it('should handle ElevenLabs API error during voice listing', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+      });
+
+      const res = await request(app).post('/voices/clear');
+
+      expect(res.status).toBe(500);
     });
 
     it('should report partial failures', async () => {

--- a/services/api-gateway/src/routes/user/voices.test.ts
+++ b/services/api-gateway/src/routes/user/voices.test.ts
@@ -137,7 +137,7 @@ describe('Voice Management Routes', () => {
       expect(res.body.error).toBe('INTERNAL_ERROR');
     });
 
-    it('should handle ElevenLabs API errors', async () => {
+    it('should return 403 when ElevenLabs rejects the API key', async () => {
       mockFetch.mockResolvedValue({
         ok: false,
         status: 401,
@@ -146,7 +146,22 @@ describe('Voice Management Routes', () => {
 
       const res = await request(app).get('/voices');
 
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe('UNAUTHORIZED');
+      expect(res.body.message).toContain('invalid or expired');
+    });
+
+    it('should return 500 for non-auth ElevenLabs API errors', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 502,
+        statusText: 'Bad Gateway',
+      });
+
+      const res = await request(app).get('/voices');
+
       expect(res.status).toBe(500);
+      expect(res.body.error).toBe('INTERNAL_ERROR');
     });
   });
 
@@ -183,16 +198,18 @@ describe('Voice Management Routes', () => {
       expect(res.status).toBe(404);
     });
 
-    it('should handle ElevenLabs API error during ownership check', async () => {
+    it('should return 403 when ElevenLabs rejects key during ownership check', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,
-        status: 401,
-        statusText: 'Unauthorized',
+        status: 403,
+        statusText: 'Forbidden',
       });
 
       const res = await request(app).delete('/voices/voice-1');
 
-      expect(res.status).toBe(500);
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe('UNAUTHORIZED');
+      expect(res.body.message).toContain('invalid or expired');
     });
 
     it('should handle ElevenLabs delete failure', async () => {
@@ -250,7 +267,7 @@ describe('Voice Management Routes', () => {
       expect(res.body.message).toContain('No Tzurot voices');
     });
 
-    it('should handle ElevenLabs API error during voice listing', async () => {
+    it('should return 403 when ElevenLabs rejects key during voice listing', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 401,
@@ -259,7 +276,9 @@ describe('Voice Management Routes', () => {
 
       const res = await request(app).post('/voices/clear');
 
-      expect(res.status).toBe(500);
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe('UNAUTHORIZED');
+      expect(res.body.message).toContain('invalid or expired');
     });
 
     it('should report partial failures', async () => {

--- a/services/api-gateway/src/routes/user/voices.test.ts
+++ b/services/api-gateway/src/routes/user/voices.test.ts
@@ -197,6 +197,7 @@ describe('Voice Management Routes', () => {
 
       expect(res.status).toBe(500);
       expect(res.body.error).toBe('INTERNAL_ERROR');
+      expect(res.body.message).toBe('Failed to delete voice');
     });
   });
 

--- a/services/api-gateway/src/routes/user/voices.test.ts
+++ b/services/api-gateway/src/routes/user/voices.test.ts
@@ -320,5 +320,23 @@ describe('Voice Management Routes', () => {
       expect(res.body.total).toBe(2);
       expect(res.body.errors).toHaveLength(1);
     });
+
+    it('should show actionable message for rate-limited deletions', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockVoicesResponse),
+        })
+        .mockResolvedValueOnce({ ok: true }) // voice-1 succeeds
+        .mockResolvedValueOnce({ ok: false, status: 429, statusText: 'Too Many Requests' }); // voice-2 rate limited
+
+      const res = await request(app).post('/voices/clear');
+
+      expect(res.status).toBe(200);
+      expect(res.body.deleted).toBe(1);
+      expect(res.body.errors).toHaveLength(1);
+      expect(res.body.errors[0]).toContain('rate limited');
+      expect(res.body.errors[0]).toContain('try again shortly');
+    });
   });
 });

--- a/services/api-gateway/src/routes/user/voices.test.ts
+++ b/services/api-gateway/src/routes/user/voices.test.ts
@@ -202,8 +202,9 @@ describe('Voice Management Routes', () => {
       const badId = 'invalid%20voice%21%23id';
       const res = await request(app).delete(`/voices/${badId}`);
 
-      expect(res.status).toBe(404);
-      expect(res.body.error).toBe('NOT_FOUND');
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('VALIDATION_ERROR');
+      expect(res.body.message).toBe('Invalid voice ID format');
       // Should not make any ElevenLabs API calls for obviously invalid IDs
       expect(mockFetch).not.toHaveBeenCalled();
     });

--- a/services/api-gateway/src/routes/user/voices.test.ts
+++ b/services/api-gateway/src/routes/user/voices.test.ts
@@ -161,6 +161,19 @@ describe('Voice Management Routes', () => {
       expect(res.status).toBe(500);
       expect(res.body.error).toBe('INTERNAL_ERROR');
     });
+
+    it('should return 500 when ElevenLabs returns malformed response', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ unexpected: 'format' }),
+      });
+
+      const res = await request(app).get('/voices');
+
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe('INTERNAL_ERROR');
+      expect(res.body.message).toContain('Unexpected response');
+    });
   });
 
   describe('DELETE /:voiceId - Delete a voice', () => {

--- a/services/api-gateway/src/routes/user/voices.test.ts
+++ b/services/api-gateway/src/routes/user/voices.test.ts
@@ -168,11 +168,13 @@ describe('Voice Management Routes', () => {
       expect(res.body.slug).toBe('alice');
     });
 
-    it('should reject deleting a non-tzurot voice', async () => {
+    it('should reject deleting a non-tzurot voice (IDOR guard)', async () => {
+      // voice-3 is 'my-custom-voice' — not tzurot-prefixed, so ownership check rejects
       const res = await request(app).delete('/voices/voice-3');
 
       expect(res.status).toBe(404);
       expect(res.body.error).toBe('NOT_FOUND');
+      expect(res.body.message).toContain('not a Tzurot-cloned voice');
     });
 
     it('should reject deleting a nonexistent voice', async () => {

--- a/services/api-gateway/src/routes/user/voices.test.ts
+++ b/services/api-gateway/src/routes/user/voices.test.ts
@@ -98,7 +98,7 @@ describe('Voice Management Routes', () => {
         name: 'tzurot-bob',
         slug: 'bob',
       });
-      expect(res.body.totalSlots).toBe(4);
+      expect(res.body.totalVoices).toBe(4);
       expect(res.body.tzurotCount).toBe(2);
     });
 

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -31,6 +31,9 @@ const logger = createLogger('VoicesRoute');
 /** Prefix used by ElevenLabsVoiceService when cloning voices */
 const VOICE_NAME_PREFIX = 'tzurot-';
 
+/** Max concurrent ElevenLabs delete calls per batch in bulk clear */
+const DELETE_BATCH_SIZE = 5;
+
 /** Shape of a voice entry from ElevenLabs GET /v1/voices */
 interface ElevenLabsVoice {
   voice_id: string;
@@ -127,6 +130,47 @@ async function fetchTzurotVoices(
   return { voices: tzurotVoices, totalSlots: allVoices.length };
 }
 
+/**
+ * Fetch a single voice by ID from ElevenLabs.
+ * Used by the delete handler for O(1) IDOR verification instead of listing all voices.
+ */
+async function fetchSingleVoice(
+  apiKey: string,
+  voiceId: string
+): Promise<{ voice: ElevenLabsVoice } | { errorResponse: ErrorResponse }> {
+  const response = await fetch(
+    `${AI_ENDPOINTS.ELEVENLABS_BASE_URL}/voices/${encodeURIComponent(voiceId)}`,
+    {
+      headers: { 'xi-api-key': apiKey },
+      signal: AbortSignal.timeout(VALIDATION_TIMEOUTS.API_KEY_VALIDATION),
+    }
+  );
+
+  if (!response.ok) {
+    if (response.status === 401 || response.status === 403) {
+      logger.warn({ status: response.status }, '[Voices] ElevenLabs rejected API key');
+      return {
+        errorResponse: ErrorResponses.unauthorized(
+          'ElevenLabs API key is invalid or expired. Update it with /settings apikey set'
+        ),
+      };
+    }
+    if (response.status === 404) {
+      return { errorResponse: ErrorResponses.notFound('Voice') };
+    }
+    logger.error(
+      { status: response.status, statusText: response.statusText, voiceId },
+      '[Voices] ElevenLabs API error fetching voice'
+    );
+    return {
+      errorResponse: ErrorResponses.internalError('Failed to fetch voice from ElevenLabs'),
+    };
+  }
+
+  const voice = (await response.json()) as ElevenLabsVoice;
+  return { voice };
+}
+
 /** Delete a single ElevenLabs voice via the API */
 async function deleteElevenLabsVoice(
   apiKey: string,
@@ -193,17 +237,17 @@ async function handleDeleteVoice(
     return;
   }
 
-  // Verify voiceId belongs to a tzurot-prefixed clone before deleting.
-  // Prevents deleting the user's own non-Tzurot voices by guessing IDs.
-  const voicesResult = await fetchTzurotVoices(keyResult.apiKey);
-  if ('errorResponse' in voicesResult) {
-    sendError(res, voicesResult.errorResponse);
+  // Fetch the single voice to verify it exists and is tzurot-prefixed (IDOR guard).
+  // Uses GET /v1/voices/:voiceId — O(1) instead of listing all voices.
+  const voiceResult = await fetchSingleVoice(keyResult.apiKey, voiceId);
+  if ('errorResponse' in voiceResult) {
+    sendError(res, voiceResult.errorResponse);
     return;
   }
 
-  const voice = voicesResult.voices.find(v => v.voice_id === voiceId);
+  const { voice } = voiceResult;
 
-  if (voice === undefined) {
+  if (!voice.name.startsWith(VOICE_NAME_PREFIX)) {
     sendError(res, ErrorResponses.notFound('Voice not found or not a Tzurot-cloned voice'));
     return;
   }
@@ -263,12 +307,11 @@ async function handleClearVoices(
 
   // Delete in small batches to balance speed vs ElevenLabs rate limits.
   // Bot-client uses GATEWAY_TIMEOUTS.BULK_OPERATION (30s) for this call.
-  const BATCH_SIZE = 5;
   let deleted = 0;
   const errors: string[] = [];
 
-  for (let i = 0; i < voices.length; i += BATCH_SIZE) {
-    const batch = voices.slice(i, i + BATCH_SIZE);
+  for (let i = 0; i < voices.length; i += DELETE_BATCH_SIZE) {
+    const batch = voices.slice(i, i + DELETE_BATCH_SIZE);
     const results = await Promise.allSettled(
       batch.map(async voice => {
         const deleteResponse = await deleteElevenLabsVoice(keyResult.apiKey, voice.voice_id);

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -88,17 +88,33 @@ async function resolveElevenLabsKey(
 
 /**
  * Fetch all voices from ElevenLabs, filtered to tzurot-prefixed clones.
+ * Returns an ErrorResponse for auth failures (401/403) so callers can surface
+ * user-actionable messages instead of a generic 500.
  */
 async function fetchTzurotVoices(
   apiKey: string
-): Promise<{ voices: ElevenLabsVoice[]; totalSlots: number }> {
+): Promise<{ voices: ElevenLabsVoice[]; totalSlots: number } | { errorResponse: ErrorResponse }> {
   const response = await fetch(`${AI_ENDPOINTS.ELEVENLABS_BASE_URL}/voices`, {
     headers: { 'xi-api-key': apiKey },
     signal: AbortSignal.timeout(VALIDATION_TIMEOUTS.API_KEY_VALIDATION),
   });
 
   if (!response.ok) {
-    throw new Error(`ElevenLabs API error: ${response.status} ${response.statusText}`);
+    if (response.status === 401 || response.status === 403) {
+      logger.warn({ status: response.status }, '[Voices] ElevenLabs rejected API key');
+      return {
+        errorResponse: ErrorResponses.unauthorized(
+          'ElevenLabs API key is invalid or expired. Update it with /settings apikey set'
+        ),
+      };
+    }
+    logger.error(
+      { status: response.status, statusText: response.statusText },
+      '[Voices] ElevenLabs API error'
+    );
+    return {
+      errorResponse: ErrorResponses.internalError('Failed to fetch voices from ElevenLabs'),
+    };
   }
 
   const data = (await response.json()) as ElevenLabsVoicesResponse;
@@ -134,7 +150,13 @@ async function handleListVoices(
     return;
   }
 
-  const { voices, totalSlots } = await fetchTzurotVoices(keyResult.apiKey);
+  const voicesResult = await fetchTzurotVoices(keyResult.apiKey);
+  if ('errorResponse' in voicesResult) {
+    sendError(res, voicesResult.errorResponse);
+    return;
+  }
+
+  const { voices, totalSlots } = voicesResult;
 
   logger.info(
     { discordUserId, tzurotCount: voices.length, totalSlots },
@@ -159,6 +181,7 @@ async function handleDeleteVoice(
   res: ExpressResponse
 ): Promise<void> {
   const discordUserId = req.userId;
+  // Express types req.params values as string | string[] — cast is needed
   const voiceId = req.params.voiceId as string;
 
   const keyResult = await resolveElevenLabsKey(prisma, discordUserId);
@@ -169,8 +192,13 @@ async function handleDeleteVoice(
 
   // Verify voiceId belongs to a tzurot-prefixed clone before deleting.
   // Prevents deleting the user's own non-Tzurot voices by guessing IDs.
-  const { voices } = await fetchTzurotVoices(keyResult.apiKey);
-  const voice = voices.find(v => v.voice_id === voiceId);
+  const voicesResult = await fetchTzurotVoices(keyResult.apiKey);
+  if ('errorResponse' in voicesResult) {
+    sendError(res, voicesResult.errorResponse);
+    return;
+  }
+
+  const voice = voicesResult.voices.find(v => v.voice_id === voiceId);
 
   if (voice === undefined) {
     sendError(res, ErrorResponses.notFound('Voice not found or not a Tzurot-cloned voice'));
@@ -217,30 +245,32 @@ async function handleClearVoices(
     return;
   }
 
-  const { voices } = await fetchTzurotVoices(keyResult.apiKey);
+  const voicesResult = await fetchTzurotVoices(keyResult.apiKey);
+  if ('errorResponse' in voicesResult) {
+    sendError(res, voicesResult.errorResponse);
+    return;
+  }
+
+  const { voices } = voicesResult;
 
   if (voices.length === 0) {
     sendCustomSuccess(res, { deleted: 0, total: 0, message: 'No Tzurot voices to clear' });
     return;
   }
 
-  const results = await Promise.allSettled(
-    voices.map(async voice => {
-      const deleteResponse = await deleteElevenLabsVoice(keyResult.apiKey, voice.voice_id);
-      if (!deleteResponse.ok) {
-        throw new Error(`${voice.name}: ${deleteResponse.status}`);
-      }
-      return voice;
-    })
-  );
-
+  // Delete sequentially to avoid hitting ElevenLabs rate limits
   let deleted = 0;
   const errors: string[] = [];
-  for (const result of results) {
-    if (result.status === 'fulfilled') {
-      deleted++;
-    } else {
-      errors.push(result.reason instanceof Error ? result.reason.message : 'Unknown error');
+  for (const voice of voices) {
+    try {
+      const deleteResponse = await deleteElevenLabsVoice(keyResult.apiKey, voice.voice_id);
+      if (!deleteResponse.ok) {
+        errors.push(`${voice.name}: ${deleteResponse.status}`);
+      } else {
+        deleted++;
+      }
+    } catch (error) {
+      errors.push(`${voice.name}: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   }
 

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -145,7 +145,7 @@ async function handleListVoices(
     voices: voices.map(v => ({
       voiceId: v.voice_id,
       name: v.name,
-      slug: v.name.replace(VOICE_NAME_PREFIX, ''),
+      slug: v.name.slice(VOICE_NAME_PREFIX.length),
     })),
     totalSlots,
     tzurotCount: voices.length,
@@ -179,15 +179,15 @@ async function handleDeleteVoice(
 
   if (!deleteResponse.ok) {
     logger.error(
-      { discordUserId, voiceId, status: deleteResponse.status },
-      '[Voices] Failed to delete voice'
+      {
+        discordUserId,
+        voiceId,
+        status: deleteResponse.status,
+        statusText: deleteResponse.statusText,
+      },
+      '[Voices] Failed to delete voice from ElevenLabs'
     );
-    sendError(
-      res,
-      ErrorResponses.internalError(
-        `Failed to delete voice: ${deleteResponse.status} ${deleteResponse.statusText}`
-      )
-    );
+    sendError(res, ErrorResponses.internalError('Failed to delete voice'));
     return;
   }
 
@@ -197,7 +197,7 @@ async function handleDeleteVoice(
     deleted: true,
     voiceId,
     name: voice.name,
-    slug: voice.name.replace(VOICE_NAME_PREFIX, ''),
+    slug: voice.name.slice(VOICE_NAME_PREFIX.length),
   });
 }
 
@@ -222,20 +222,23 @@ async function handleClearVoices(
     return;
   }
 
+  const results = await Promise.allSettled(
+    voices.map(async voice => {
+      const deleteResponse = await deleteElevenLabsVoice(keyResult.apiKey, voice.voice_id);
+      if (!deleteResponse.ok) {
+        throw new Error(`${voice.name}: ${deleteResponse.status}`);
+      }
+      return voice;
+    })
+  );
+
   let deleted = 0;
   const errors: string[] = [];
-
-  for (const voice of voices) {
-    try {
-      const deleteResponse = await deleteElevenLabsVoice(keyResult.apiKey, voice.voice_id);
-
-      if (deleteResponse.ok) {
-        deleted++;
-      } else {
-        errors.push(`${voice.name}: ${deleteResponse.status}`);
-      }
-    } catch (error) {
-      errors.push(`${voice.name}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  for (const result of results) {
+    if (result.status === 'fulfilled') {
+      deleted++;
+    } else {
+      errors.push(result.reason instanceof Error ? result.reason.message : 'Unknown error');
     }
   }
 

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -54,7 +54,7 @@ interface ElevenLabsVoicesResponse {
  */
 async function fetchTzurotVoices(
   apiKey: string
-): Promise<{ voices: ElevenLabsVoice[]; totalSlots: number } | { errorResponse: ErrorResponse }> {
+): Promise<{ voices: ElevenLabsVoice[]; totalVoices: number } | { errorResponse: ErrorResponse }> {
   const response = await fetch(`${AI_ENDPOINTS.ELEVENLABS_BASE_URL}/voices`, {
     headers: { 'xi-api-key': apiKey },
     signal: AbortSignal.timeout(VALIDATION_TIMEOUTS.ELEVENLABS_API_CALL),
@@ -84,7 +84,7 @@ async function fetchTzurotVoices(
     v => typeof v.name === 'string' && v.name.startsWith(ELEVENLABS_VOICE_NAME_PREFIX)
   );
 
-  return { voices: tzurotVoices, totalSlots: allVoices.length };
+  return { voices: tzurotVoices, totalVoices: allVoices.length };
 }
 
 /**
@@ -165,10 +165,10 @@ async function handleListVoices(
     return;
   }
 
-  const { voices, totalSlots } = voicesResult;
+  const { voices, totalVoices } = voicesResult;
 
   logger.info(
-    { discordUserId, tzurotCount: voices.length, totalSlots },
+    { discordUserId, tzurotCount: voices.length, totalVoices },
     '[Voices] Listed cloned voices'
   );
 
@@ -178,7 +178,7 @@ async function handleListVoices(
       name: v.name,
       slug: v.name.slice(ELEVENLABS_VOICE_NAME_PREFIX.length),
     })),
-    totalSlots,
+    totalVoices,
     tzurotCount: voices.length,
   });
 }
@@ -296,7 +296,9 @@ async function handleClearVoices(
       batch.map(async voice => {
         const deleteResponse = await deleteElevenLabsVoice(keyResult.apiKey, voice.voice_id);
         if (!deleteResponse.ok) {
-          // Surface actionable messages — "429" alone is meaningless to end users
+          // Surface actionable messages — "429" alone is meaningless to end users.
+          // voice.name is safe to embed directly in Discord: it's always tzurot-* prefixed
+          // (filtered by fetchTzurotVoices), so no user-controlled injection risk.
           const detail =
             deleteResponse.status === 429
               ? `${voice.name}: rate limited — try again shortly`

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -94,15 +94,13 @@ async function resolveElevenLabsKey(
  * Returns an ErrorResponse for auth failures (401/403) so callers can surface
  * user-actionable messages instead of a generic 500.
  *
- * Note: Reuses VALIDATION_TIMEOUTS.API_KEY_VALIDATION (30s) for the per-call
- * timeout — the value is appropriate for any single ElevenLabs API call.
  */
 async function fetchTzurotVoices(
   apiKey: string
 ): Promise<{ voices: ElevenLabsVoice[]; totalSlots: number } | { errorResponse: ErrorResponse }> {
   const response = await fetch(`${AI_ENDPOINTS.ELEVENLABS_BASE_URL}/voices`, {
     headers: { 'xi-api-key': apiKey },
-    signal: AbortSignal.timeout(VALIDATION_TIMEOUTS.API_KEY_VALIDATION),
+    signal: AbortSignal.timeout(VALIDATION_TIMEOUTS.ELEVENLABS_API_CALL),
   });
 
   if (!response.ok) {
@@ -124,7 +122,7 @@ async function fetchTzurotVoices(
   }
 
   const data = (await response.json()) as ElevenLabsVoicesResponse;
-  const allVoices = data.voices;
+  const allVoices = Array.isArray(data.voices) ? data.voices : [];
   const tzurotVoices = allVoices.filter(v => v.name.startsWith(VOICE_NAME_PREFIX));
 
   return { voices: tzurotVoices, totalSlots: allVoices.length };
@@ -142,7 +140,7 @@ async function fetchSingleVoice(
     `${AI_ENDPOINTS.ELEVENLABS_BASE_URL}/voices/${encodeURIComponent(voiceId)}`,
     {
       headers: { 'xi-api-key': apiKey },
-      signal: AbortSignal.timeout(VALIDATION_TIMEOUTS.API_KEY_VALIDATION),
+      signal: AbortSignal.timeout(VALIDATION_TIMEOUTS.ELEVENLABS_API_CALL),
     }
   );
 
@@ -168,6 +166,11 @@ async function fetchSingleVoice(
   }
 
   const voice = (await response.json()) as ElevenLabsVoice;
+  if (typeof voice.voice_id !== 'string' || typeof voice.name !== 'string') {
+    return {
+      errorResponse: ErrorResponses.internalError('Unexpected voice response from ElevenLabs'),
+    };
+  }
   return { voice };
 }
 
@@ -179,7 +182,7 @@ async function deleteElevenLabsVoice(
   return fetch(`${AI_ENDPOINTS.ELEVENLABS_BASE_URL}/voices/${encodeURIComponent(voiceId)}`, {
     method: 'DELETE',
     headers: { 'xi-api-key': apiKey },
-    signal: AbortSignal.timeout(VALIDATION_TIMEOUTS.API_KEY_VALIDATION),
+    signal: AbortSignal.timeout(VALIDATION_TIMEOUTS.ELEVENLABS_API_CALL),
   });
 }
 
@@ -307,6 +310,8 @@ async function handleClearVoices(
 
   // Delete in small batches to balance speed vs ElevenLabs rate limits.
   // Bot-client uses GATEWAY_TIMEOUTS.BULK_OPERATION (30s) for this call.
+  // If the gateway exceeds that, the bot-client aborts but deletions continue
+  // server-side — no data is lost, voices are eventually removed.
   let deleted = 0;
   const errors: string[] = [];
 

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -16,6 +16,7 @@ import {
   decryptApiKey,
   AIProvider,
   AI_ENDPOINTS,
+  ELEVENLABS_VOICE_NAME_PREFIX,
   VALIDATION_TIMEOUTS,
   type PrismaClient,
 } from '@tzurot/common-types';
@@ -28,8 +29,8 @@ import type { AuthenticatedRequest } from '../../types.js';
 
 const logger = createLogger('VoicesRoute');
 
-/** Prefix used by ElevenLabsVoiceService when cloning voices */
-const VOICE_NAME_PREFIX = 'tzurot-';
+/** Validates ElevenLabs voice IDs — prevents unnecessary API round-trips for garbage input */
+const VOICE_ID_RE = /^[A-Za-z0-9_-]{1,64}$/;
 
 /** Max concurrent ElevenLabs delete calls per batch in bulk clear */
 const DELETE_BATCH_SIZE = 5;
@@ -56,19 +57,22 @@ async function resolveElevenLabsKey(
 ): Promise<{ apiKey: string } | { errorResponse: ErrorResponse }> {
   const user = await prisma.user.findFirst({
     where: { discordId: discordUserId },
-    select: { id: true },
+    select: {
+      id: true,
+      apiKeys: {
+        where: { provider: AIProvider.ElevenLabs },
+        select: { iv: true, content: true, tag: true },
+        take: 1,
+      },
+    },
   });
 
   if (user === null) {
     return { errorResponse: ErrorResponses.notFound('User') };
   }
 
-  const storedKey = await prisma.userApiKey.findFirst({
-    where: { userId: user.id, provider: AIProvider.ElevenLabs },
-    select: { iv: true, content: true, tag: true },
-  });
-
-  if (storedKey === null) {
+  const storedKey = user.apiKeys[0];
+  if (storedKey === undefined) {
     return {
       errorResponse: ErrorResponses.notFound(
         'ElevenLabs API key. Set one with /settings apikey set'
@@ -124,7 +128,7 @@ async function fetchTzurotVoices(
   const data = (await response.json()) as ElevenLabsVoicesResponse;
   const allVoices = Array.isArray(data.voices) ? data.voices : [];
   const tzurotVoices = allVoices.filter(
-    v => typeof v.name === 'string' && v.name.startsWith(VOICE_NAME_PREFIX)
+    v => typeof v.name === 'string' && v.name.startsWith(ELEVENLABS_VOICE_NAME_PREFIX)
   );
 
   return { voices: tzurotVoices, totalSlots: allVoices.length };
@@ -219,7 +223,7 @@ async function handleListVoices(
     voices: voices.map(v => ({
       voiceId: v.voice_id,
       name: v.name,
-      slug: v.name.slice(VOICE_NAME_PREFIX.length),
+      slug: v.name.slice(ELEVENLABS_VOICE_NAME_PREFIX.length),
     })),
     totalSlots,
     tzurotCount: voices.length,
@@ -237,6 +241,11 @@ async function handleDeleteVoice(
   // Named route params (`:voiceId`) are always string, but the index signature is wider
   const voiceId = req.params.voiceId as string;
 
+  if (!VOICE_ID_RE.test(voiceId)) {
+    sendError(res, ErrorResponses.notFound('Voice'));
+    return;
+  }
+
   const keyResult = await resolveElevenLabsKey(prisma, discordUserId);
   if ('errorResponse' in keyResult) {
     sendError(res, keyResult.errorResponse);
@@ -253,7 +262,7 @@ async function handleDeleteVoice(
 
   const { voice } = voiceResult;
 
-  if (!voice.name.startsWith(VOICE_NAME_PREFIX)) {
+  if (!voice.name.startsWith(ELEVENLABS_VOICE_NAME_PREFIX)) {
     sendError(res, ErrorResponses.notFound('Voice not found or not a Tzurot-cloned voice'));
     return;
   }
@@ -280,11 +289,18 @@ async function handleDeleteVoice(
     deleted: true,
     voiceId,
     name: voice.name,
-    slug: voice.name.slice(VOICE_NAME_PREFIX.length),
+    slug: voice.name.slice(ELEVENLABS_VOICE_NAME_PREFIX.length),
   });
 }
 
-/** POST /clear handler — delete ALL tzurot-prefixed voices */
+/**
+ * POST /clear handler — delete ALL tzurot-prefixed voices.
+ *
+ * Always returns 200 OK, even on partial failure. Callers must inspect the
+ * response body: `{ deleted, total, errors? }`. When `errors` is present,
+ * some deletions failed but others succeeded. This mirrors the bot-client's
+ * expectation — it shows a warning embed for partial failures.
+ */
 async function handleClearVoices(
   prisma: PrismaClient,
   req: AuthenticatedRequest,

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -233,7 +233,8 @@ async function handleDeleteVoice(
   res: ExpressResponse
 ): Promise<void> {
   const discordUserId = req.userId;
-  // ParamsDictionary types values as string | string[] — cast needed for named params
+  // @types/express-serve-static-core ParamsDictionary: [key: string]: string | string[]
+  // Named route params (`:voiceId`) are always string, but the index signature is wider
   const voiceId = req.params.voiceId as string;
 
   const keyResult = await resolveElevenLabsKey(prisma, discordUserId);

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -267,19 +267,20 @@ export function createVoicesRoutes(prisma: PrismaClient): Router {
     })
   );
 
-  router.delete(
-    '/:voiceId',
-    requireUserAuth(),
-    asyncHandler(async (req: AuthenticatedRequest, res: ExpressResponse) => {
-      await handleDeleteVoice(prisma, req, res);
-    })
-  );
-
+  // Register /clear before /:voiceId so the wildcard doesn't shadow it
   router.post(
     '/clear',
     requireUserAuth(),
     asyncHandler(async (req: AuthenticatedRequest, res: ExpressResponse) => {
       await handleClearVoices(prisma, req, res);
+    })
+  );
+
+  router.delete(
+    '/:voiceId',
+    requireUserAuth(),
+    asyncHandler(async (req: AuthenticatedRequest, res: ExpressResponse) => {
+      await handleDeleteVoice(prisma, req, res);
     })
   );
 

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -13,8 +13,6 @@
 import { Router, type Response as ExpressResponse } from 'express';
 import {
   createLogger,
-  decryptApiKey,
-  AIProvider,
   AI_ENDPOINTS,
   ELEVENLABS_VOICE_NAME_PREFIX,
   VALIDATION_TIMEOUTS,
@@ -25,6 +23,7 @@ import { requireUserAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendCustomSuccess, sendError } from '../../utils/responseHelpers.js';
 import { ErrorResponses, createErrorResponse, ErrorCode } from '../../utils/errorResponses.js';
+import { resolveElevenLabsKey } from '../../utils/elevenLabsKeyResolver.js';
 import type { AuthenticatedRequest } from '../../types.js';
 
 const logger = createLogger('VoicesRoute');
@@ -45,52 +44,6 @@ interface ElevenLabsVoice {
 /** Response from ElevenLabs GET /v1/voices */
 interface ElevenLabsVoicesResponse {
   voices: ElevenLabsVoice[];
-}
-
-/**
- * Resolve and decrypt the user's ElevenLabs API key.
- * Returns the decrypted key or an ErrorResponse for the caller to send.
- */
-async function resolveElevenLabsKey(
-  prisma: PrismaClient,
-  discordUserId: string
-): Promise<{ apiKey: string } | { errorResponse: ErrorResponse }> {
-  const user = await prisma.user.findFirst({
-    where: { discordId: discordUserId },
-    select: {
-      id: true,
-      apiKeys: {
-        where: { provider: AIProvider.ElevenLabs },
-        select: { iv: true, content: true, tag: true },
-        take: 1,
-      },
-    },
-  });
-
-  if (user === null) {
-    return { errorResponse: ErrorResponses.notFound('User') };
-  }
-
-  const storedKey = user.apiKeys[0];
-  if (storedKey === undefined) {
-    return {
-      errorResponse: ErrorResponses.notFound(
-        'ElevenLabs API key. Set one with /settings apikey set'
-      ),
-    };
-  }
-
-  try {
-    const apiKey = decryptApiKey({
-      iv: storedKey.iv,
-      content: storedKey.content,
-      tag: storedKey.tag,
-    });
-    return { apiKey };
-  } catch (error) {
-    logger.error({ err: error, discordUserId }, '[Voices] Failed to decrypt ElevenLabs key');
-    return { errorResponse: ErrorResponses.internalError('Failed to decrypt stored API key') };
-  }
 }
 
 /**

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -22,7 +22,7 @@ import type { ErrorResponse } from '../../utils/errorResponses.js';
 import { requireUserAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendCustomSuccess, sendError } from '../../utils/responseHelpers.js';
-import { ErrorResponses, createErrorResponse, ErrorCode } from '../../utils/errorResponses.js';
+import { ErrorResponses } from '../../utils/errorResponses.js';
 import { resolveElevenLabsKey } from '../../utils/elevenLabsKeyResolver.js';
 import type { AuthenticatedRequest } from '../../types.js';
 
@@ -50,7 +50,6 @@ interface ElevenLabsVoicesResponse {
  * Fetch all voices from ElevenLabs, filtered to tzurot-prefixed clones.
  * Returns an ErrorResponse for auth failures (401/403) so callers can surface
  * user-actionable messages instead of a generic 500.
- *
  */
 async function fetchTzurotVoices(
   apiKey: string
@@ -216,10 +215,7 @@ async function handleDeleteVoice(
   const { voice } = voiceResult;
 
   if (!voice.name.startsWith(ELEVENLABS_VOICE_NAME_PREFIX)) {
-    sendError(
-      res,
-      createErrorResponse(ErrorCode.NOT_FOUND, 'Voice not found or not a Tzurot-cloned voice')
-    );
+    sendError(res, ErrorResponses.notFound('Tzurot-cloned voice'));
     return;
   }
 

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -123,7 +123,9 @@ async function fetchTzurotVoices(
 
   const data = (await response.json()) as ElevenLabsVoicesResponse;
   const allVoices = Array.isArray(data.voices) ? data.voices : [];
-  const tzurotVoices = allVoices.filter(v => v.name.startsWith(VOICE_NAME_PREFIX));
+  const tzurotVoices = allVoices.filter(
+    v => typeof v.name === 'string' && v.name.startsWith(VOICE_NAME_PREFIX)
+  );
 
   return { voices: tzurotVoices, totalSlots: allVoices.length };
 }

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -11,6 +11,7 @@
  */
 
 import { Router, type Response as ExpressResponse } from 'express';
+import { z } from 'zod';
 import {
   createLogger,
   AI_ENDPOINTS,
@@ -34,17 +35,18 @@ const VOICE_ID_RE = /^[A-Za-z0-9_-]{1,64}$/;
 /** Max concurrent ElevenLabs delete calls per batch in bulk clear */
 const DELETE_BATCH_SIZE = 5;
 
-/** Shape of a voice entry from ElevenLabs GET /v1/voices */
-interface ElevenLabsVoice {
-  voice_id: string;
-  name: string;
-  category?: string;
-}
+/** Zod schemas for ElevenLabs API responses — validates at the external service boundary */
+const ElevenLabsVoiceSchema = z.object({
+  voice_id: z.string(),
+  name: z.string(),
+  category: z.string().optional(),
+});
 
-/** Response from ElevenLabs GET /v1/voices */
-interface ElevenLabsVoicesResponse {
-  voices: ElevenLabsVoice[];
-}
+const ElevenLabsVoicesResponseSchema = z.object({
+  voices: z.array(ElevenLabsVoiceSchema),
+});
+
+type ElevenLabsVoice = z.infer<typeof ElevenLabsVoiceSchema>;
 
 /**
  * Fetch all voices from ElevenLabs, filtered to tzurot-prefixed clones.
@@ -77,11 +79,18 @@ async function fetchTzurotVoices(
     };
   }
 
-  const data = (await response.json()) as ElevenLabsVoicesResponse;
-  const allVoices = Array.isArray(data.voices) ? data.voices : [];
-  const tzurotVoices = allVoices.filter(
-    v => typeof v.name === 'string' && v.name.startsWith(ELEVENLABS_VOICE_NAME_PREFIX)
-  );
+  const parseResult = ElevenLabsVoicesResponseSchema.safeParse(await response.json());
+  if (!parseResult.success) {
+    logger.error(
+      { errors: parseResult.error.format() },
+      '[Voices] Unexpected response format from ElevenLabs'
+    );
+    return {
+      errorResponse: ErrorResponses.internalError('Unexpected response from ElevenLabs API'),
+    };
+  }
+  const allVoices = parseResult.data.voices;
+  const tzurotVoices = allVoices.filter(v => v.name.startsWith(ELEVENLABS_VOICE_NAME_PREFIX));
 
   return { voices: tzurotVoices, totalVoices: allVoices.length };
 }
@@ -123,13 +132,17 @@ async function fetchSingleVoice(
     };
   }
 
-  const voice = (await response.json()) as ElevenLabsVoice;
-  if (typeof voice.voice_id !== 'string' || typeof voice.name !== 'string') {
+  const parseResult = ElevenLabsVoiceSchema.safeParse(await response.json());
+  if (!parseResult.success) {
+    logger.error(
+      { errors: parseResult.error.format(), voiceId },
+      '[Voices] Unexpected voice response format from ElevenLabs'
+    );
     return {
       errorResponse: ErrorResponses.internalError('Unexpected voice response from ElevenLabs'),
     };
   }
-  return { voice };
+  return { voice: parseResult.data };
 }
 
 /** Delete a single ElevenLabs voice via the API */

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -1,0 +1,282 @@
+/**
+ * Voice Management Routes
+ *
+ * Manages ElevenLabs cloned voices (tzurot-prefixed) for BYOK users.
+ * Proxies to ElevenLabs API after decrypting the user's stored key.
+ *
+ * Endpoints:
+ * - GET /    - List cloned voices (filtered to tzurot-* prefix)
+ * - DELETE /:voiceId - Delete a single voice
+ * - POST /clear     - Delete ALL tzurot-prefixed voices
+ */
+
+import { Router, type Response as ExpressResponse } from 'express';
+import {
+  createLogger,
+  decryptApiKey,
+  AIProvider,
+  AI_ENDPOINTS,
+  VALIDATION_TIMEOUTS,
+  type PrismaClient,
+} from '@tzurot/common-types';
+import type { ErrorResponse } from '../../utils/errorResponses.js';
+import { requireUserAuth } from '../../services/AuthMiddleware.js';
+import { asyncHandler } from '../../utils/asyncHandler.js';
+import { sendCustomSuccess, sendError } from '../../utils/responseHelpers.js';
+import { ErrorResponses } from '../../utils/errorResponses.js';
+import type { AuthenticatedRequest } from '../../types.js';
+
+const logger = createLogger('VoicesRoute');
+
+/** Prefix used by ElevenLabsVoiceService when cloning voices */
+const VOICE_NAME_PREFIX = 'tzurot-';
+
+/** Shape of a voice entry from ElevenLabs GET /v1/voices */
+interface ElevenLabsVoice {
+  voice_id: string;
+  name: string;
+  category?: string;
+}
+
+/** Response from ElevenLabs GET /v1/voices */
+interface ElevenLabsVoicesResponse {
+  voices: ElevenLabsVoice[];
+}
+
+/**
+ * Resolve and decrypt the user's ElevenLabs API key.
+ * Returns the decrypted key or an ErrorResponse for the caller to send.
+ */
+async function resolveElevenLabsKey(
+  prisma: PrismaClient,
+  discordUserId: string
+): Promise<{ apiKey: string } | { errorResponse: ErrorResponse }> {
+  const user = await prisma.user.findFirst({
+    where: { discordId: discordUserId },
+    select: { id: true },
+  });
+
+  if (user === null) {
+    return { errorResponse: ErrorResponses.notFound('User') };
+  }
+
+  const storedKey = await prisma.userApiKey.findFirst({
+    where: { userId: user.id, provider: AIProvider.ElevenLabs },
+    select: { iv: true, content: true, tag: true },
+  });
+
+  if (storedKey === null) {
+    return {
+      errorResponse: ErrorResponses.notFound(
+        'ElevenLabs API key. Set one with /settings apikey set'
+      ),
+    };
+  }
+
+  try {
+    const apiKey = decryptApiKey({
+      iv: storedKey.iv,
+      content: storedKey.content,
+      tag: storedKey.tag,
+    });
+    return { apiKey };
+  } catch (error) {
+    logger.error({ err: error, discordUserId }, '[Voices] Failed to decrypt ElevenLabs key');
+    return { errorResponse: ErrorResponses.internalError('Failed to decrypt stored API key') };
+  }
+}
+
+/**
+ * Fetch all voices from ElevenLabs, filtered to tzurot-prefixed clones.
+ */
+async function fetchTzurotVoices(
+  apiKey: string
+): Promise<{ voices: ElevenLabsVoice[]; totalSlots: number }> {
+  const response = await fetch(`${AI_ENDPOINTS.ELEVENLABS_BASE_URL}/voices`, {
+    headers: { 'xi-api-key': apiKey },
+    signal: AbortSignal.timeout(VALIDATION_TIMEOUTS.API_KEY_VALIDATION),
+  });
+
+  if (!response.ok) {
+    throw new Error(`ElevenLabs API error: ${response.status} ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as ElevenLabsVoicesResponse;
+  const allVoices = data.voices;
+  const tzurotVoices = allVoices.filter(v => v.name.startsWith(VOICE_NAME_PREFIX));
+
+  return { voices: tzurotVoices, totalSlots: allVoices.length };
+}
+
+/** Delete a single ElevenLabs voice via the API */
+async function deleteElevenLabsVoice(
+  apiKey: string,
+  voiceId: string
+): Promise<globalThis.Response> {
+  return fetch(`${AI_ENDPOINTS.ELEVENLABS_BASE_URL}/voices/${encodeURIComponent(voiceId)}`, {
+    method: 'DELETE',
+    headers: { 'xi-api-key': apiKey },
+    signal: AbortSignal.timeout(VALIDATION_TIMEOUTS.API_KEY_VALIDATION),
+  });
+}
+
+/** GET / handler — list cloned voices with slot summary */
+async function handleListVoices(
+  prisma: PrismaClient,
+  req: AuthenticatedRequest,
+  res: ExpressResponse
+): Promise<void> {
+  const discordUserId = req.userId;
+
+  const keyResult = await resolveElevenLabsKey(prisma, discordUserId);
+  if ('errorResponse' in keyResult) {
+    sendError(res, keyResult.errorResponse);
+    return;
+  }
+
+  const { voices, totalSlots } = await fetchTzurotVoices(keyResult.apiKey);
+
+  logger.info(
+    { discordUserId, tzurotCount: voices.length, totalSlots },
+    '[Voices] Listed cloned voices'
+  );
+
+  sendCustomSuccess(res, {
+    voices: voices.map(v => ({
+      voiceId: v.voice_id,
+      name: v.name,
+      slug: v.name.replace(VOICE_NAME_PREFIX, ''),
+    })),
+    totalSlots,
+    tzurotCount: voices.length,
+  });
+}
+
+/** DELETE /:voiceId handler — delete a single tzurot-prefixed voice */
+async function handleDeleteVoice(
+  prisma: PrismaClient,
+  req: AuthenticatedRequest,
+  res: ExpressResponse
+): Promise<void> {
+  const discordUserId = req.userId;
+  const { voiceId } = req.params;
+
+  const keyResult = await resolveElevenLabsKey(prisma, discordUserId);
+  if ('errorResponse' in keyResult) {
+    sendError(res, keyResult.errorResponse);
+    return;
+  }
+
+  const { voices } = await fetchTzurotVoices(keyResult.apiKey);
+  const voice = voices.find(v => v.voice_id === voiceId);
+
+  if (voice === undefined) {
+    sendError(res, ErrorResponses.notFound('Voice not found or not a Tzurot-cloned voice'));
+    return;
+  }
+
+  const deleteResponse = await deleteElevenLabsVoice(keyResult.apiKey, voiceId);
+
+  if (!deleteResponse.ok) {
+    logger.error(
+      { discordUserId, voiceId, status: deleteResponse.status },
+      '[Voices] Failed to delete voice'
+    );
+    sendError(
+      res,
+      ErrorResponses.internalError(
+        `Failed to delete voice: ${deleteResponse.status} ${deleteResponse.statusText}`
+      )
+    );
+    return;
+  }
+
+  logger.info({ discordUserId, voiceId, voiceName: voice.name }, '[Voices] Deleted voice');
+
+  sendCustomSuccess(res, {
+    deleted: true,
+    voiceId,
+    name: voice.name,
+    slug: voice.name.replace(VOICE_NAME_PREFIX, ''),
+  });
+}
+
+/** POST /clear handler — delete ALL tzurot-prefixed voices */
+async function handleClearVoices(
+  prisma: PrismaClient,
+  req: AuthenticatedRequest,
+  res: ExpressResponse
+): Promise<void> {
+  const discordUserId = req.userId;
+
+  const keyResult = await resolveElevenLabsKey(prisma, discordUserId);
+  if ('errorResponse' in keyResult) {
+    sendError(res, keyResult.errorResponse);
+    return;
+  }
+
+  const { voices } = await fetchTzurotVoices(keyResult.apiKey);
+
+  if (voices.length === 0) {
+    sendCustomSuccess(res, { deleted: 0, message: 'No Tzurot voices to clear' });
+    return;
+  }
+
+  let deleted = 0;
+  const errors: string[] = [];
+
+  for (const voice of voices) {
+    try {
+      const deleteResponse = await deleteElevenLabsVoice(keyResult.apiKey, voice.voice_id);
+
+      if (deleteResponse.ok) {
+        deleted++;
+      } else {
+        errors.push(`${voice.name}: ${deleteResponse.status}`);
+      }
+    } catch (error) {
+      errors.push(`${voice.name}: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+  }
+
+  logger.info(
+    { discordUserId, deleted, total: voices.length, errors: errors.length },
+    '[Voices] Cleared cloned voices'
+  );
+
+  sendCustomSuccess(res, {
+    deleted,
+    total: voices.length,
+    errors: errors.length > 0 ? errors : undefined,
+  });
+}
+
+export function createVoicesRoutes(prisma: PrismaClient): Router {
+  const router = Router();
+
+  router.get(
+    '/',
+    requireUserAuth(),
+    asyncHandler(async (req: AuthenticatedRequest, res: ExpressResponse) => {
+      await handleListVoices(prisma, req, res);
+    })
+  );
+
+  router.delete(
+    '/:voiceId',
+    requireUserAuth(),
+    asyncHandler(async (req: AuthenticatedRequest, res: ExpressResponse) => {
+      await handleDeleteVoice(prisma, req, res);
+    })
+  );
+
+  router.post(
+    '/clear',
+    requireUserAuth(),
+    asyncHandler(async (req: AuthenticatedRequest, res: ExpressResponse) => {
+      await handleClearVoices(prisma, req, res);
+    })
+  );
+
+  return router;
+}

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -90,6 +90,9 @@ async function resolveElevenLabsKey(
  * Fetch all voices from ElevenLabs, filtered to tzurot-prefixed clones.
  * Returns an ErrorResponse for auth failures (401/403) so callers can surface
  * user-actionable messages instead of a generic 500.
+ *
+ * Note: Reuses VALIDATION_TIMEOUTS.API_KEY_VALIDATION (30s) for the per-call
+ * timeout — the value is appropriate for any single ElevenLabs API call.
  */
 async function fetchTzurotVoices(
   apiKey: string
@@ -181,7 +184,7 @@ async function handleDeleteVoice(
   res: ExpressResponse
 ): Promise<void> {
   const discordUserId = req.userId;
-  // Express types req.params values as string | string[] — cast is needed
+  // ParamsDictionary types values as string | string[] — cast needed for named params
   const voiceId = req.params.voiceId as string;
 
   const keyResult = await resolveElevenLabsKey(prisma, discordUserId);
@@ -258,19 +261,29 @@ async function handleClearVoices(
     return;
   }
 
-  // Delete sequentially to avoid hitting ElevenLabs rate limits
+  // Delete in small batches to balance speed vs ElevenLabs rate limits.
+  // Bot-client uses GATEWAY_TIMEOUTS.BULK_OPERATION (30s) for this call.
+  const BATCH_SIZE = 5;
   let deleted = 0;
   const errors: string[] = [];
-  for (const voice of voices) {
-    try {
-      const deleteResponse = await deleteElevenLabsVoice(keyResult.apiKey, voice.voice_id);
-      if (!deleteResponse.ok) {
-        errors.push(`${voice.name}: ${deleteResponse.status}`);
-      } else {
+
+  for (let i = 0; i < voices.length; i += BATCH_SIZE) {
+    const batch = voices.slice(i, i + BATCH_SIZE);
+    const results = await Promise.allSettled(
+      batch.map(async voice => {
+        const deleteResponse = await deleteElevenLabsVoice(keyResult.apiKey, voice.voice_id);
+        if (!deleteResponse.ok) {
+          throw new Error(`${voice.name}: ${deleteResponse.status}`);
+        }
+      })
+    );
+
+    for (const result of results) {
+      if (result.status === 'fulfilled') {
         deleted++;
+      } else {
+        errors.push(result.reason instanceof Error ? result.reason.message : 'Unknown error');
       }
-    } catch (error) {
-      errors.push(`${voice.name}: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   }
 

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -167,6 +167,8 @@ async function handleDeleteVoice(
     return;
   }
 
+  // Verify voiceId belongs to a tzurot-prefixed clone before deleting.
+  // Prevents deleting the user's own non-Tzurot voices by guessing IDs.
   const { voices } = await fetchTzurotVoices(keyResult.apiKey);
   const voice = voices.find(v => v.voice_id === voiceId);
 
@@ -218,7 +220,7 @@ async function handleClearVoices(
   const { voices } = await fetchTzurotVoices(keyResult.apiKey);
 
   if (voices.length === 0) {
-    sendCustomSuccess(res, { deleted: 0, message: 'No Tzurot voices to clear' });
+    sendCustomSuccess(res, { deleted: 0, total: 0, message: 'No Tzurot voices to clear' });
     return;
   }
 

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -159,7 +159,7 @@ async function handleDeleteVoice(
   res: ExpressResponse
 ): Promise<void> {
   const discordUserId = req.userId;
-  const { voiceId } = req.params;
+  const voiceId = req.params.voiceId as string;
 
   const keyResult = await resolveElevenLabsKey(prisma, discordUserId);
   if ('errorResponse' in keyResult) {

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -29,7 +29,8 @@ import type { AuthenticatedRequest } from '../../types.js';
 
 const logger = createLogger('VoicesRoute');
 
-/** Validates ElevenLabs voice IDs — prevents unnecessary API round-trips for garbage input */
+/** Validates ElevenLabs voice IDs — prevents unnecessary API round-trips for garbage input.
+ * See also: voice-engine's `_VOICE_ID_RE` in server.py (authoritative pattern). */
 const VOICE_ID_RE = /^[A-Za-z0-9_-]{1,64}$/;
 
 /** Max concurrent ElevenLabs delete calls per batch in bulk clear */

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -194,7 +194,7 @@ async function handleDeleteVoice(
   const voiceId = req.params.voiceId as string;
 
   if (!VOICE_ID_RE.test(voiceId)) {
-    sendError(res, ErrorResponses.notFound('Voice'));
+    sendError(res, ErrorResponses.validationError('Invalid voice ID format'));
     return;
   }
 

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -24,7 +24,7 @@ import type { ErrorResponse } from '../../utils/errorResponses.js';
 import { requireUserAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendCustomSuccess, sendError } from '../../utils/responseHelpers.js';
-import { ErrorResponses } from '../../utils/errorResponses.js';
+import { ErrorResponses, createErrorResponse, ErrorCode } from '../../utils/errorResponses.js';
 import type { AuthenticatedRequest } from '../../types.js';
 
 const logger = createLogger('VoicesRoute');
@@ -263,7 +263,10 @@ async function handleDeleteVoice(
   const { voice } = voiceResult;
 
   if (!voice.name.startsWith(ELEVENLABS_VOICE_NAME_PREFIX)) {
-    sendError(res, ErrorResponses.notFound('Voice not found or not a Tzurot-cloned voice'));
+    sendError(
+      res,
+      createErrorResponse(ErrorCode.NOT_FOUND, 'Voice not found or not a Tzurot-cloned voice')
+    );
     return;
   }
 

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -340,7 +340,12 @@ async function handleClearVoices(
       batch.map(async voice => {
         const deleteResponse = await deleteElevenLabsVoice(keyResult.apiKey, voice.voice_id);
         if (!deleteResponse.ok) {
-          throw new Error(`${voice.name}: ${deleteResponse.status}`);
+          // Surface actionable messages — "429" alone is meaningless to end users
+          const detail =
+            deleteResponse.status === 429
+              ? `${voice.name}: rate limited — try again shortly`
+              : `${voice.name}: ${deleteResponse.status}`;
+          throw new Error(detail);
         }
       })
     );

--- a/services/api-gateway/src/utils/elevenLabsKeyResolver.test.ts
+++ b/services/api-gateway/src/utils/elevenLabsKeyResolver.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for ElevenLabs API Key Resolver
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolveElevenLabsKey } from './elevenLabsKeyResolver.js';
+import type { PrismaClient } from '@tzurot/common-types';
+
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    }),
+    decryptApiKey: vi.fn().mockReturnValue('decrypted-elevenlabs-key'),
+  };
+});
+
+import { decryptApiKey } from '@tzurot/common-types';
+
+describe('resolveElevenLabsKey', () => {
+  const mockPrisma = {
+    user: {
+      findFirst: vi.fn(),
+    },
+  } as unknown as PrismaClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(decryptApiKey).mockReturnValue('decrypted-elevenlabs-key');
+  });
+
+  it('should return decrypted API key when user has an ElevenLabs key', async () => {
+    (mockPrisma.user.findFirst as any).mockResolvedValue({
+      id: 'user-uuid',
+      apiKeys: [{ iv: 'test-iv', content: 'test-content', tag: 'test-tag' }],
+    });
+
+    const result = await resolveElevenLabsKey(mockPrisma, 'discord-123');
+
+    expect(result).toEqual({ apiKey: 'decrypted-elevenlabs-key' });
+    expect(decryptApiKey).toHaveBeenCalledWith({
+      iv: 'test-iv',
+      content: 'test-content',
+      tag: 'test-tag',
+    });
+  });
+
+  it('should return NOT_FOUND when user does not exist', async () => {
+    (mockPrisma.user.findFirst as any).mockResolvedValue(null);
+
+    const result = await resolveElevenLabsKey(mockPrisma, 'discord-unknown');
+
+    expect(result).toHaveProperty('errorResponse');
+    if ('errorResponse' in result) {
+      expect(result.errorResponse.error).toBe('NOT_FOUND');
+    }
+  });
+
+  it('should return NOT_FOUND when user has no ElevenLabs key', async () => {
+    (mockPrisma.user.findFirst as any).mockResolvedValue({
+      id: 'user-uuid',
+      apiKeys: [],
+    });
+
+    const result = await resolveElevenLabsKey(mockPrisma, 'discord-123');
+
+    expect(result).toHaveProperty('errorResponse');
+    if ('errorResponse' in result) {
+      expect(result.errorResponse.error).toBe('NOT_FOUND');
+      expect(result.errorResponse.message).toContain('ElevenLabs API key');
+    }
+  });
+
+  it('should return INTERNAL_ERROR when decryption fails', async () => {
+    (mockPrisma.user.findFirst as any).mockResolvedValue({
+      id: 'user-uuid',
+      apiKeys: [{ iv: 'bad-iv', content: 'bad-content', tag: 'bad-tag' }],
+    });
+    vi.mocked(decryptApiKey).mockImplementation(() => {
+      throw new Error('Decryption failed');
+    });
+
+    const result = await resolveElevenLabsKey(mockPrisma, 'discord-123');
+
+    expect(result).toHaveProperty('errorResponse');
+    if ('errorResponse' in result) {
+      expect(result.errorResponse.error).toBe('INTERNAL_ERROR');
+    }
+  });
+});

--- a/services/api-gateway/src/utils/elevenLabsKeyResolver.ts
+++ b/services/api-gateway/src/utils/elevenLabsKeyResolver.ts
@@ -1,0 +1,61 @@
+/**
+ * ElevenLabs API Key Resolver
+ *
+ * Resolves and decrypts a user's stored ElevenLabs API key from the database.
+ * Extracted from voice routes for reuse by any route that needs the user's
+ * ElevenLabs key (voice management, future TTS endpoints, etc.).
+ */
+
+import { createLogger, decryptApiKey, AIProvider, type PrismaClient } from '@tzurot/common-types';
+import type { ErrorResponse } from './errorResponses.js';
+import { ErrorResponses } from './errorResponses.js';
+
+const logger = createLogger('ElevenLabsKeyResolver');
+
+/**
+ * Resolve and decrypt the user's ElevenLabs API key.
+ *
+ * Looks up the user by Discord ID, finds their ElevenLabs key, and decrypts it.
+ * Returns the decrypted key or an ErrorResponse for the caller to send.
+ */
+export async function resolveElevenLabsKey(
+  prisma: PrismaClient,
+  discordUserId: string
+): Promise<{ apiKey: string } | { errorResponse: ErrorResponse }> {
+  const user = await prisma.user.findFirst({
+    where: { discordId: discordUserId },
+    select: {
+      id: true,
+      apiKeys: {
+        where: { provider: AIProvider.ElevenLabs },
+        select: { iv: true, content: true, tag: true },
+        take: 1,
+      },
+    },
+  });
+
+  if (user === null) {
+    return { errorResponse: ErrorResponses.notFound('User') };
+  }
+
+  const storedKey = user.apiKeys[0];
+  if (storedKey === undefined) {
+    return {
+      errorResponse: ErrorResponses.notFound(
+        'ElevenLabs API key. Set one with /settings apikey set'
+      ),
+    };
+  }
+
+  try {
+    const apiKey = decryptApiKey({
+      iv: storedKey.iv,
+      content: storedKey.content,
+      tag: storedKey.tag,
+    });
+    return { apiKey };
+  } catch (error) {
+    logger.error({ err: error, discordUserId }, '[ElevenLabsKey] Failed to decrypt key');
+    return { errorResponse: ErrorResponses.internalError('Failed to decrypt stored API key') };
+  }
+}

--- a/services/bot-client/src/commands/settings/index.test.ts
+++ b/services/bot-client/src/commands/settings/index.test.ts
@@ -71,6 +71,10 @@ vi.mock('./preset/autocomplete.js', () => ({
 // Mock voice handlers
 vi.mock('./voices/browse.js', () => ({
   handleBrowseVoices: vi.fn().mockResolvedValue(undefined),
+  handleVoiceBrowsePagination: vi.fn().mockResolvedValue(undefined),
+  isVoiceBrowseInteraction: vi.fn((customId: string) =>
+    customId.startsWith('settings-voices::browse')
+  ),
 }));
 
 vi.mock('./voices/delete.js', () => ({
@@ -216,8 +220,11 @@ describe('Settings Command Index', () => {
       expect(subcommands).toContain('clear');
     });
 
-    it('should have componentPrefixes for user-defaults-settings', () => {
-      expect(settingsCommand.componentPrefixes).toEqual(['user-defaults-settings']);
+    it('should have componentPrefixes for user-defaults and voice browse', () => {
+      expect(settingsCommand.componentPrefixes).toEqual([
+        'user-defaults-settings',
+        'settings-voices',
+      ]);
     });
 
     it('should have correct deferral modes', () => {
@@ -448,6 +455,18 @@ describe('Settings Command Index', () => {
       await handleButton(interaction);
 
       expect(handleUserDefaultsButton).toHaveBeenCalledWith(interaction);
+    });
+
+    it('should route voice browse pagination buttons to browse handler', async () => {
+      const { handleVoiceBrowsePagination } = await import('./voices/browse.js');
+
+      const interaction = {
+        customId: 'settings-voices::browse::1::all::',
+      } as any;
+
+      await handleButton(interaction);
+
+      expect(handleVoiceBrowsePagination).toHaveBeenCalledWith(interaction);
     });
 
     it('should route voice-clear destructive buttons to voice handler', async () => {

--- a/services/bot-client/src/commands/settings/index.test.ts
+++ b/services/bot-client/src/commands/settings/index.test.ts
@@ -68,6 +68,32 @@ vi.mock('./preset/autocomplete.js', () => ({
   handleAutocomplete: vi.fn().mockResolvedValue(undefined),
 }));
 
+// Mock voice handlers
+vi.mock('./voices/browse.js', () => ({
+  handleBrowseVoices: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('./voices/delete.js', () => ({
+  handleDeleteVoice: vi.fn().mockResolvedValue(undefined),
+  handleVoiceAutocomplete: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('./voices/clear.js', () => ({
+  handleClearVoices: vi.fn().mockResolvedValue(undefined),
+  handleVoiceClearButton: vi.fn().mockResolvedValue(undefined),
+  handleVoiceClearModal: vi.fn().mockResolvedValue(undefined),
+  VOICE_CLEAR_OPERATION: 'voice-clear',
+}));
+
+// Mock destructive confirmation utilities
+vi.mock('../../utils/destructiveConfirmation.js', () => ({
+  buildDestructiveWarning: vi.fn(),
+  createHardDeleteConfig: vi.fn(),
+  handleDestructiveConfirmButton: vi.fn(),
+  handleDestructiveCancel: vi.fn(),
+  handleDestructiveModalSubmit: vi.fn(),
+}));
+
 // Mock defaults handlers
 vi.mock('./defaults/edit.js', () => ({
   handleDefaultsEdit: vi.fn().mockResolvedValue(undefined),
@@ -171,6 +197,23 @@ describe('Settings Command Index', () => {
         (defaultsGroup as { options?: Array<{ name: string }> })?.options ?? []
       ).map(s => s.name);
       expect(subcommands).toContain('edit');
+    });
+
+    it('should have voices subcommand group with browse, delete, clear', () => {
+      const json = data.toJSON();
+      const options = json.options ?? [];
+
+      const groups = options.filter((opt: { type: number }) => opt.type === 2);
+      const voicesGroup = groups.find((g: { name: string }) => g.name === 'voices');
+
+      expect(voicesGroup).toBeDefined();
+
+      const subcommands = (
+        (voicesGroup as { options?: Array<{ name: string }> })?.options ?? []
+      ).map(s => s.name);
+      expect(subcommands).toContain('browse');
+      expect(subcommands).toContain('delete');
+      expect(subcommands).toContain('clear');
     });
 
     it('should have componentPrefixes for user-defaults-settings', () => {
@@ -328,6 +371,35 @@ describe('Settings Command Index', () => {
       });
     });
 
+    describe('voices group', () => {
+      it('should route to voices browse handler', async () => {
+        const { handleBrowseVoices } = await import('./voices/browse.js');
+        const context = createMockContext('voices', 'browse');
+
+        await execute(context);
+
+        expect(handleBrowseVoices).toHaveBeenCalledWith(context);
+      });
+
+      it('should route to voices delete handler', async () => {
+        const { handleDeleteVoice } = await import('./voices/delete.js');
+        const context = createMockContext('voices', 'delete');
+
+        await execute(context);
+
+        expect(handleDeleteVoice).toHaveBeenCalledWith(context);
+      });
+
+      it('should route to voices clear handler', async () => {
+        const { handleClearVoices } = await import('./voices/clear.js');
+        const context = createMockContext('voices', 'clear');
+
+        await execute(context);
+
+        expect(handleClearVoices).toHaveBeenCalledWith(context);
+      });
+    });
+
     it('should handle unknown group gracefully', async () => {
       const context = createMockContext('unknown', 'test');
 
@@ -378,6 +450,18 @@ describe('Settings Command Index', () => {
       expect(handleUserDefaultsButton).toHaveBeenCalledWith(interaction);
     });
 
+    it('should route voice-clear destructive buttons to voice handler', async () => {
+      const { handleVoiceClearButton } = await import('./voices/clear.js');
+
+      const interaction = {
+        customId: 'settings::destructive::confirm_button::voice-clear::all',
+      } as any;
+
+      await handleButton(interaction);
+
+      expect(handleVoiceClearButton).toHaveBeenCalledWith(interaction);
+    });
+
     it('should log warning for unknown button custom ID', async () => {
       const interaction = {
         customId: 'unknown-entity::action::id',
@@ -408,6 +492,20 @@ describe('Settings Command Index', () => {
 
       // Should not throw
       await handleSelectMenu(interaction);
+    });
+  });
+
+  describe('handleModal - voice-clear routing', () => {
+    it('should route voice-clear destructive modals to voice handler', async () => {
+      const { handleVoiceClearModal } = await import('./voices/clear.js');
+
+      const interaction = {
+        customId: 'settings::destructive::modal_submit::voice-clear::all',
+      } as any;
+
+      await handleModal(interaction);
+
+      expect(handleVoiceClearModal).toHaveBeenCalledWith(interaction);
     });
   });
 
@@ -443,6 +541,21 @@ describe('Settings Command Index', () => {
       await autocomplete(interaction);
 
       expect(handlePresetAutocomplete).toHaveBeenCalledWith(interaction);
+    });
+
+    it('should route voice autocomplete to voice handler', async () => {
+      const { handleVoiceAutocomplete } = await import('./voices/delete.js');
+
+      const interaction = {
+        options: {
+          getFocused: () => ({ name: 'voice', value: 'ali' }),
+          getSubcommandGroup: () => 'voices',
+        },
+      } as any;
+
+      await autocomplete(interaction);
+
+      expect(handleVoiceAutocomplete).toHaveBeenCalledWith(interaction);
     });
 
     it('should return empty array for unknown options', async () => {

--- a/services/bot-client/src/commands/settings/index.ts
+++ b/services/bot-client/src/commands/settings/index.ts
@@ -55,7 +55,11 @@ import { handleClearDefault as handlePresetClearDefault } from './preset/clear-d
 import { handleAutocomplete as handlePresetAutocomplete } from './preset/autocomplete.js';
 
 // Voice management handlers
-import { handleBrowseVoices } from './voices/browse.js';
+import {
+  handleBrowseVoices,
+  handleVoiceBrowsePagination,
+  isVoiceBrowseInteraction,
+} from './voices/browse.js';
 import { handleDeleteVoice, handleVoiceAutocomplete } from './voices/delete.js';
 import {
   handleClearVoices,
@@ -187,6 +191,12 @@ async function handleModal(interaction: ModalSubmitInteraction): Promise<void> {
 async function handleButton(interaction: ButtonInteraction): Promise<void> {
   if (isUserDefaultsInteraction(interaction.customId)) {
     await handleUserDefaultsButton(interaction);
+    return;
+  }
+
+  // Voice browse pagination buttons
+  if (isVoiceBrowseInteraction(interaction.customId)) {
+    await handleVoiceBrowsePagination(interaction);
     return;
   }
 
@@ -419,5 +429,5 @@ export default defineCommand({
   handleModal,
   handleButton,
   handleSelectMenu,
-  componentPrefixes: ['user-defaults-settings'],
+  componentPrefixes: ['user-defaults-settings', 'settings-voices'],
 });

--- a/services/bot-client/src/commands/settings/index.ts
+++ b/services/bot-client/src/commands/settings/index.ts
@@ -7,6 +7,7 @@
  * - /settings apikey set|browse|remove|test - Manage API keys (BYOK)
  * - /settings preset browse|set|reset|default|clear-default - Manage preset overrides
  * - /settings defaults edit - Manage global default settings (config cascade)
+ * - /settings voices browse|delete|clear - Manage ElevenLabs cloned voices
  *
  * HISTORY:
  * - Consolidated from former /me timezone, /wallet, and /me preset commands
@@ -43,7 +44,7 @@ import { handleBrowse as handleWalletBrowse } from './apikey/browse.js';
 import { handleRemoveKey } from './apikey/remove.js';
 import { handleTestKey } from './apikey/test.js';
 import { handleApikeyModalSubmit } from './apikey/modal.js';
-import { ApikeyCustomIds } from '../../utils/customIds.js';
+import { ApikeyCustomIds, DestructiveCustomIds } from '../../utils/customIds.js';
 
 // Preset handlers
 import { handleBrowseOverrides } from './preset/browse.js';
@@ -52,6 +53,16 @@ import { handleReset as handlePresetReset } from './preset/reset.js';
 import { handleDefault as handlePresetDefault } from './preset/default.js';
 import { handleClearDefault as handlePresetClearDefault } from './preset/clear-default.js';
 import { handleAutocomplete as handlePresetAutocomplete } from './preset/autocomplete.js';
+
+// Voice management handlers
+import { handleBrowseVoices } from './voices/browse.js';
+import { handleDeleteVoice, handleVoiceAutocomplete } from './voices/delete.js';
+import {
+  handleClearVoices,
+  handleVoiceClearButton,
+  handleVoiceClearModal,
+  VOICE_CLEAR_OPERATION,
+} from './voices/clear.js';
 
 // Defaults handlers (user-default config cascade settings)
 import {
@@ -107,6 +118,18 @@ const presetRouter = createTypedSubcommandRouter(
 );
 
 /**
+ * Voices subcommand group router (all deferred)
+ */
+const voicesRouter = createTypedSubcommandRouter(
+  {
+    browse: handleBrowseVoices,
+    delete: handleDeleteVoice,
+    clear: handleClearVoices,
+  },
+  { logger, logPrefix: '[Settings/Voices]' }
+);
+
+/**
  * Command execution router
  */
 async function execute(context: SafeCommandContext): Promise<void> {
@@ -120,6 +143,8 @@ async function execute(context: SafeCommandContext): Promise<void> {
     await presetRouter(context as DeferredCommandContext);
   } else if (group === 'defaults') {
     await handleDefaultsEdit(context as DeferredCommandContext);
+  } else if (group === 'voices') {
+    await voicesRouter(context as DeferredCommandContext);
   } else {
     logger.warn({ group }, '[Settings] Unknown subcommand group');
     await (context as DeferredCommandContext).editReply({
@@ -144,6 +169,15 @@ async function handleModal(interaction: ModalSubmitInteraction): Promise<void> {
     return;
   }
 
+  // Check if this is a voice-clear destructive confirmation modal
+  if (DestructiveCustomIds.isDestructive(interaction.customId)) {
+    const parsed = DestructiveCustomIds.parse(interaction.customId);
+    if (parsed?.operation === VOICE_CLEAR_OPERATION) {
+      await handleVoiceClearModal(interaction);
+      return;
+    }
+  }
+
   logger.warn({ customId: interaction.customId }, '[Settings] Unknown modal customId');
 }
 
@@ -154,6 +188,15 @@ async function handleButton(interaction: ButtonInteraction): Promise<void> {
   if (isUserDefaultsInteraction(interaction.customId)) {
     await handleUserDefaultsButton(interaction);
     return;
+  }
+
+  // Voice-clear destructive confirmation buttons
+  if (DestructiveCustomIds.isDestructive(interaction.customId)) {
+    const parsed = DestructiveCustomIds.parse(interaction.customId);
+    if (parsed?.operation === VOICE_CLEAR_OPERATION) {
+      await handleVoiceClearButton(interaction);
+      return;
+    }
   }
 
   logger.warn({ customId: interaction.customId }, '[Settings] Unknown button customId');
@@ -199,6 +242,8 @@ async function autocomplete(interaction: AutocompleteInteraction): Promise<void>
     // Personality and preset autocomplete for preset commands
     // The handlePresetAutocomplete handles both 'personality' and 'preset' options
     await handlePresetAutocomplete(interaction);
+  } else if (subcommandGroup === 'voices' && focusedOption.name === 'voice') {
+    await handleVoiceAutocomplete(interaction);
   } else {
     await interaction.respond([]);
   }
@@ -343,6 +388,30 @@ export default defineCommand({
         .setDescription('Manage your global default settings')
         .addSubcommand(subcommand =>
           subcommand.setName('edit').setDescription('Open your default settings dashboard')
+        )
+    )
+    // Voices subcommand group (ElevenLabs cloned voice management)
+    .addSubcommandGroup(group =>
+      group
+        .setName('voices')
+        .setDescription('Manage your ElevenLabs cloned voices')
+        .addSubcommand(subcommand =>
+          subcommand.setName('browse').setDescription('Browse your cloned voices')
+        )
+        .addSubcommand(subcommand =>
+          subcommand
+            .setName('delete')
+            .setDescription('Delete a single cloned voice')
+            .addStringOption(option =>
+              option
+                .setName('voice')
+                .setDescription('The voice to delete')
+                .setRequired(true)
+                .setAutocomplete(true)
+            )
+        )
+        .addSubcommand(subcommand =>
+          subcommand.setName('clear').setDescription('Delete all Tzurot cloned voices')
         )
     ),
   execute,

--- a/services/bot-client/src/commands/settings/voices/browse.test.ts
+++ b/services/bot-client/src/commands/settings/voices/browse.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for Voice Browse Handler
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ChatInputCommandInteraction } from 'discord.js';
+import { handleBrowseVoices } from './browse.js';
+import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
+
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+const mockCallGatewayApi = vi.fn();
+vi.mock('../../../utils/userGatewayClient.js', () => ({
+  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
+}));
+
+describe('handleBrowseVoices', () => {
+  const mockEditReply = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function createMockContext(): DeferredCommandContext {
+    const mockInteraction = {
+      user: { id: 'user-123' },
+      editReply: mockEditReply,
+    } as unknown as ChatInputCommandInteraction;
+
+    return {
+      interaction: mockInteraction,
+      user: mockInteraction.user,
+      guild: null,
+      member: null,
+      channel: null,
+      channelId: 'channel-123',
+      guildId: null,
+      commandName: 'settings',
+      isEphemeral: true,
+      editReply: mockEditReply,
+      followUp: vi.fn(),
+      deleteReply: vi.fn(),
+      getOption: vi.fn(),
+      getRequiredOption: vi.fn(),
+      getSubcommand: vi.fn().mockReturnValue('browse'),
+      getSubcommandGroup: vi.fn().mockReturnValue('voices'),
+    } as unknown as DeferredCommandContext;
+  }
+
+  it('should list voices successfully', async () => {
+    mockCallGatewayApi.mockResolvedValue({
+      ok: true,
+      data: {
+        voices: [
+          { voiceId: 'v1', name: 'tzurot-alice', slug: 'alice' },
+          { voiceId: 'v2', name: 'tzurot-bob', slug: 'bob' },
+        ],
+        totalSlots: 10,
+        tzurotCount: 2,
+      },
+    });
+
+    await handleBrowseVoices(createMockContext());
+
+    expect(mockCallGatewayApi).toHaveBeenCalledWith(
+      '/user/voices',
+      expect.objectContaining({ userId: 'user-123' })
+    );
+    expect(mockEditReply).toHaveBeenCalledWith({
+      embeds: [
+        expect.objectContaining({
+          data: expect.objectContaining({
+            title: '🎤 Cloned Voices',
+            description: expect.stringContaining('alice'),
+          }),
+        }),
+      ],
+    });
+  });
+
+  it('should show empty state when no voices', async () => {
+    mockCallGatewayApi.mockResolvedValue({
+      ok: true,
+      data: {
+        voices: [],
+        totalSlots: 5,
+        tzurotCount: 0,
+      },
+    });
+
+    await handleBrowseVoices(createMockContext());
+
+    expect(mockEditReply).toHaveBeenCalledWith({
+      embeds: [
+        expect.objectContaining({
+          data: expect.objectContaining({
+            description: expect.stringContaining('No Tzurot-cloned voices'),
+          }),
+        }),
+      ],
+    });
+  });
+
+  it('should handle API error', async () => {
+    mockCallGatewayApi.mockResolvedValue({
+      ok: false,
+      status: 404,
+      error: 'ElevenLabs API key not found',
+    });
+
+    await handleBrowseVoices(createMockContext());
+
+    expect(mockEditReply).toHaveBeenCalledWith({
+      content: '❌ ElevenLabs API key not found',
+    });
+  });
+
+  it('should handle exceptions', async () => {
+    mockCallGatewayApi.mockRejectedValue(new Error('Network error'));
+
+    await handleBrowseVoices(createMockContext());
+
+    expect(mockEditReply).toHaveBeenCalledWith({
+      content: '❌ An unexpected error occurred. Please try again.',
+    });
+  });
+});

--- a/services/bot-client/src/commands/settings/voices/browse.test.ts
+++ b/services/bot-client/src/commands/settings/voices/browse.test.ts
@@ -81,7 +81,7 @@ describe('handleBrowseVoices', () => {
           { voiceId: 'v1', name: 'tzurot-alice', slug: 'alice' },
           { voiceId: 'v2', name: 'tzurot-bob', slug: 'bob' },
         ],
-        totalSlots: 10,
+        totalVoices: 10,
         tzurotCount: 2,
       },
     });
@@ -112,7 +112,7 @@ describe('handleBrowseVoices', () => {
       ok: true,
       data: {
         voices,
-        totalSlots: 30,
+        totalVoices: 30,
         tzurotCount: 12,
       },
     });
@@ -143,7 +143,7 @@ describe('handleBrowseVoices', () => {
       ok: true,
       data: {
         voices: [{ voiceId: 'v1', name: 'tzurot-alice', slug: 'alice' }],
-        totalSlots: 5,
+        totalVoices: 5,
         tzurotCount: 1,
       },
     });
@@ -166,7 +166,7 @@ describe('handleBrowseVoices', () => {
       ok: true,
       data: {
         voices: [],
-        totalSlots: 5,
+        totalVoices: 5,
         tzurotCount: 0,
       },
     });
@@ -247,7 +247,7 @@ describe('handleVoiceBrowsePagination', () => {
 
     mockCallGatewayApi.mockResolvedValue({
       ok: true,
-      data: { voices, totalSlots: 30, tzurotCount: 12 },
+      data: { voices, totalVoices: 30, tzurotCount: 12 },
     });
 
     // Click "next" to go to page 1

--- a/services/bot-client/src/commands/settings/voices/browse.test.ts
+++ b/services/bot-client/src/commands/settings/voices/browse.test.ts
@@ -3,9 +3,14 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { ChatInputCommandInteraction } from 'discord.js';
-import { handleBrowseVoices } from './browse.js';
+import type { ChatInputCommandInteraction, ButtonInteraction } from 'discord.js';
+import {
+  handleBrowseVoices,
+  handleVoiceBrowsePagination,
+  isVoiceBrowseInteraction,
+} from './browse.js';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
+import type { VoiceEntry } from './types.js';
 
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal<typeof import('@tzurot/common-types')>();
@@ -25,6 +30,15 @@ vi.mock('../../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
   GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
 }));
+
+/** Generate N voice entries for pagination tests */
+function generateVoices(count: number): VoiceEntry[] {
+  return Array.from({ length: count }, (_, i) => ({
+    voiceId: `v${i + 1}`,
+    name: `tzurot-voice-${i + 1}`,
+    slug: `voice-${i + 1}`,
+  }));
+}
 
 describe('handleBrowseVoices', () => {
   const mockEditReply = vi.fn();
@@ -59,7 +73,7 @@ describe('handleBrowseVoices', () => {
     } as unknown as DeferredCommandContext;
   }
 
-  it('should list voices successfully', async () => {
+  it('should list voices successfully with no pagination buttons for small lists', async () => {
     mockCallGatewayApi.mockResolvedValue({
       ok: true,
       data: {
@@ -87,7 +101,64 @@ describe('handleBrowseVoices', () => {
           }),
         }),
       ],
+      components: [], // No pagination needed for 2 voices
     });
+  });
+
+  it('should show pagination buttons when voices exceed page size', async () => {
+    const voices = generateVoices(12); // 12 voices = 2 pages at 10/page
+
+    mockCallGatewayApi.mockResolvedValue({
+      ok: true,
+      data: {
+        voices,
+        totalSlots: 30,
+        tzurotCount: 12,
+      },
+    });
+
+    await handleBrowseVoices(createMockContext());
+
+    expect(mockEditReply).toHaveBeenCalledWith({
+      embeds: [
+        expect.objectContaining({
+          data: expect.objectContaining({
+            title: '🎤 Cloned Voices',
+            // First page shows voices 1-10
+            description: expect.stringContaining('voice-1'),
+          }),
+        }),
+      ],
+      components: [expect.any(Object)], // Pagination button row
+    });
+
+    // Verify first page only shows 10 voices
+    const embedDescription = mockEditReply.mock.calls[0][0].embeds[0].data.description;
+    expect(embedDescription).toContain('voice-10');
+    expect(embedDescription).not.toContain('voice-11');
+  });
+
+  it('should show management hints on first page only', async () => {
+    mockCallGatewayApi.mockResolvedValue({
+      ok: true,
+      data: {
+        voices: [{ voiceId: 'v1', name: 'tzurot-alice', slug: 'alice' }],
+        totalSlots: 5,
+        tzurotCount: 1,
+      },
+    });
+
+    await handleBrowseVoices(createMockContext());
+
+    const embed = mockEditReply.mock.calls[0][0].embeds[0];
+    expect(embed.data.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: '💡 Management',
+          value: expect.stringContaining('/settings voices delete'),
+        }),
+      ])
+    );
   });
 
   it('should show empty state when no voices', async () => {
@@ -110,6 +181,7 @@ describe('handleBrowseVoices', () => {
           }),
         }),
       ],
+      components: [],
     });
   });
 
@@ -135,5 +207,106 @@ describe('handleBrowseVoices', () => {
     expect(mockEditReply).toHaveBeenCalledWith({
       content: '❌ An unexpected error occurred. Please try again.',
     });
+  });
+});
+
+describe('isVoiceBrowseInteraction', () => {
+  it('should match voice browse pagination custom IDs', () => {
+    expect(isVoiceBrowseInteraction('settings-voices::browse::0::all::')).toBe(true);
+    expect(isVoiceBrowseInteraction('settings-voices::browse::1::all::')).toBe(true);
+  });
+
+  it('should not match unrelated custom IDs', () => {
+    expect(isVoiceBrowseInteraction('character::browse::0::all::date::')).toBe(false);
+    expect(
+      isVoiceBrowseInteraction('settings::destructive::confirm_button::voice-clear::all')
+    ).toBe(false);
+    expect(isVoiceBrowseInteraction('user-defaults-settings::voice::edit')).toBe(false);
+  });
+});
+
+describe('handleVoiceBrowsePagination', () => {
+  const mockDeferUpdate = vi.fn();
+  const mockEditReply = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function createMockButtonInteraction(customId: string): ButtonInteraction {
+    return {
+      customId,
+      user: { id: 'user-123' },
+      deferUpdate: mockDeferUpdate,
+      editReply: mockEditReply,
+    } as unknown as ButtonInteraction;
+  }
+
+  it('should navigate to requested page', async () => {
+    const voices = generateVoices(12);
+
+    mockCallGatewayApi.mockResolvedValue({
+      ok: true,
+      data: { voices, totalSlots: 30, tzurotCount: 12 },
+    });
+
+    // Click "next" to go to page 1
+    await handleVoiceBrowsePagination(
+      createMockButtonInteraction('settings-voices::browse::1::all::')
+    );
+
+    expect(mockDeferUpdate).toHaveBeenCalled();
+    expect(mockEditReply).toHaveBeenCalledWith({
+      embeds: [
+        expect.objectContaining({
+          data: expect.objectContaining({
+            // Page 2 should show voices 11-12
+            description: expect.stringContaining('voice-11'),
+          }),
+        }),
+      ],
+      components: [expect.any(Object)],
+    });
+
+    // Page 2 should NOT show management hints
+    const embed = mockEditReply.mock.calls[0][0].embeds[0];
+    expect(embed.data.fields).toBeUndefined();
+  });
+
+  it('should ignore unparseable custom IDs', async () => {
+    await handleVoiceBrowsePagination(createMockButtonInteraction('garbage-custom-id'));
+
+    expect(mockDeferUpdate).not.toHaveBeenCalled();
+    expect(mockCallGatewayApi).not.toHaveBeenCalled();
+  });
+
+  it('should handle API error during pagination', async () => {
+    mockCallGatewayApi.mockResolvedValue({
+      ok: false,
+      error: 'ElevenLabs key expired',
+    });
+
+    await handleVoiceBrowsePagination(
+      createMockButtonInteraction('settings-voices::browse::1::all::')
+    );
+
+    expect(mockDeferUpdate).toHaveBeenCalled();
+    expect(mockEditReply).toHaveBeenCalledWith({
+      content: '❌ ElevenLabs key expired',
+      embeds: [],
+      components: [],
+    });
+  });
+
+  it('should keep existing content on fetch exception', async () => {
+    mockCallGatewayApi.mockRejectedValue(new Error('Network error'));
+
+    await handleVoiceBrowsePagination(
+      createMockButtonInteraction('settings-voices::browse::1::all::')
+    );
+
+    expect(mockDeferUpdate).toHaveBeenCalled();
+    // Should NOT call editReply — keeps existing content visible
+    expect(mockEditReply).not.toHaveBeenCalled();
   });
 });

--- a/services/bot-client/src/commands/settings/voices/browse.ts
+++ b/services/bot-client/src/commands/settings/voices/browse.ts
@@ -1,0 +1,90 @@
+/**
+ * Voice Browse Handler
+ * Lists ElevenLabs cloned voices (tzurot-prefixed) with slot summary
+ */
+
+import { EmbedBuilder } from 'discord.js';
+import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
+import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
+import { callGatewayApi, GATEWAY_TIMEOUTS } from '../../../utils/userGatewayClient.js';
+
+const logger = createLogger('settings-voices-browse');
+
+interface VoiceEntry {
+  voiceId: string;
+  name: string;
+  slug: string;
+}
+
+interface VoicesListResponse {
+  voices: VoiceEntry[];
+  totalSlots: number;
+  tzurotCount: number;
+}
+
+/**
+ * Build the browse embed for voice listing
+ */
+function buildVoiceBrowseEmbed(data: VoicesListResponse): EmbedBuilder {
+  const { voices, totalSlots, tzurotCount } = data;
+
+  const embed = new EmbedBuilder()
+    .setTitle('🎤 Cloned Voices')
+    .setColor(voices.length > 0 ? DISCORD_COLORS.SUCCESS : DISCORD_COLORS.BLURPLE)
+    .setTimestamp();
+
+  if (voices.length === 0) {
+    embed.setDescription(
+      'No Tzurot-cloned voices found.\n\n' +
+        'Voices are auto-cloned when you talk to a character with voice enabled.\n' +
+        `Your ElevenLabs account has **${totalSlots}** total voice slots.`
+    );
+    return embed;
+  }
+
+  const voiceLines = voices.map((v, i) => `**${i + 1}.** \`${v.slug}\` — \`${v.voiceId}\``);
+
+  embed.setDescription(voiceLines.join('\n'));
+  embed.setFooter({
+    text: `${tzurotCount} Tzurot voice${tzurotCount !== 1 ? 's' : ''} / ${totalSlots} total ElevenLabs slots`,
+  });
+
+  embed.addFields({
+    name: '💡 Management',
+    value: [
+      '`/settings voices delete <voice>` - Remove a single voice',
+      '`/settings voices clear` - Remove all Tzurot voices',
+    ].join('\n'),
+    inline: false,
+  });
+
+  return embed;
+}
+
+/**
+ * Handle /settings voices browse
+ * Lists all tzurot-prefixed cloned voices from ElevenLabs
+ */
+export async function handleBrowseVoices(context: DeferredCommandContext): Promise<void> {
+  const userId = context.user.id;
+
+  try {
+    const result = await callGatewayApi<VoicesListResponse>('/user/voices', {
+      userId,
+      timeout: GATEWAY_TIMEOUTS.DEFERRED,
+    });
+
+    if (!result.ok) {
+      await context.editReply({ content: `❌ ${result.error}` });
+      return;
+    }
+
+    const embed = buildVoiceBrowseEmbed(result.data);
+    await context.editReply({ embeds: [embed] });
+
+    logger.info({ userId, voiceCount: result.data.voices.length }, '[Voices Browse] Listed voices');
+  } catch (error) {
+    logger.error({ err: error, userId }, '[Voices Browse] Unexpected error');
+    await context.editReply({ content: '❌ An unexpected error occurred. Please try again.' });
+  }
+}

--- a/services/bot-client/src/commands/settings/voices/browse.ts
+++ b/services/bot-client/src/commands/settings/voices/browse.ts
@@ -52,7 +52,11 @@ function buildVoiceBrowseEmbed(data: VoicesListResponse): EmbedBuilder {
 
 /**
  * Handle /settings voices browse
- * Lists all tzurot-prefixed cloned voices from ElevenLabs
+ * Lists all tzurot-prefixed cloned voices from ElevenLabs.
+ *
+ * Intentionally does NOT use the voiceCache (autocomplete cache) — browse
+ * should always show fresh data since users invoke it to verify state after
+ * mutations. The cache is designed for autocomplete keystroke dedup only.
  */
 export async function handleBrowseVoices(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;

--- a/services/bot-client/src/commands/settings/voices/browse.ts
+++ b/services/bot-client/src/commands/settings/voices/browse.ts
@@ -7,20 +7,9 @@ import { EmbedBuilder } from 'discord.js';
 import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
 import { callGatewayApi, GATEWAY_TIMEOUTS } from '../../../utils/userGatewayClient.js';
+import type { VoicesListResponse } from './types.js';
 
 const logger = createLogger('settings-voices-browse');
-
-interface VoiceEntry {
-  voiceId: string;
-  name: string;
-  slug: string;
-}
-
-interface VoicesListResponse {
-  voices: VoiceEntry[];
-  totalSlots: number;
-  tzurotCount: number;
-}
 
 /**
  * Build the browse embed for voice listing

--- a/services/bot-client/src/commands/settings/voices/browse.ts
+++ b/services/bot-client/src/commands/settings/voices/browse.ts
@@ -1,20 +1,45 @@
 /**
  * Voice Browse Handler
- * Lists ElevenLabs cloned voices (tzurot-prefixed) with slot summary
+ * Lists ElevenLabs cloned voices (tzurot-prefixed) with paginated slot summary
  */
 
 import { EmbedBuilder } from 'discord.js';
+import type { ButtonInteraction, ActionRowBuilder, ButtonBuilder } from 'discord.js';
 import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
 import { callGatewayApi, GATEWAY_TIMEOUTS } from '../../../utils/userGatewayClient.js';
+import {
+  ITEMS_PER_PAGE,
+  createBrowseCustomIdHelpers,
+  buildBrowseButtons,
+} from '../../../utils/browse/index.js';
 import type { VoicesListResponse } from './types.js';
 
 const logger = createLogger('settings-voices-browse');
 
+type VoiceBrowseFilter = 'all';
+
+const browseHelpers = createBrowseCustomIdHelpers<VoiceBrowseFilter>({
+  prefix: 'settings-voices',
+  validFilters: ['all'] as const,
+  includeSort: false,
+});
+
+/** Check if a custom ID is a voice browse pagination button */
+export function isVoiceBrowseInteraction(customId: string): boolean {
+  return browseHelpers.isBrowse(customId);
+}
+
 /**
- * Build the browse embed for voice listing
+ * Build the paginated browse response for voice listing.
+ *
+ * Paginates client-side since the gateway returns all voices at once
+ * (max ~30 for ElevenLabs Creator plan — no server-side pagination needed).
  */
-function buildVoiceBrowseEmbed(data: VoicesListResponse): EmbedBuilder {
+function buildVoiceBrowsePage(
+  data: VoicesListResponse,
+  page: number
+): { embed: EmbedBuilder; components: ActionRowBuilder<ButtonBuilder>[] } {
   const { voices, totalSlots, tzurotCount } = data;
 
   const embed = new EmbedBuilder()
@@ -28,26 +53,52 @@ function buildVoiceBrowseEmbed(data: VoicesListResponse): EmbedBuilder {
         'Voices are auto-cloned when you talk to a character with voice enabled.\n' +
         `Your ElevenLabs account has **${totalSlots}** total voice slots.`
     );
-    return embed;
+    return { embed, components: [] };
   }
 
-  const voiceLines = voices.map((v, i) => `**${i + 1}.** \`${v.slug}\` — \`${v.voiceId}\``);
+  const totalPages = Math.max(1, Math.ceil(voices.length / ITEMS_PER_PAGE));
+  const safePage = Math.max(0, Math.min(page, totalPages - 1));
+  const startIdx = safePage * ITEMS_PER_PAGE;
+  const pageVoices = voices.slice(startIdx, startIdx + ITEMS_PER_PAGE);
+
+  const voiceLines = pageVoices.map(
+    (v, i) => `**${startIdx + i + 1}.** \`${v.slug}\` — \`${v.voiceId}\``
+  );
 
   embed.setDescription(voiceLines.join('\n'));
   embed.setFooter({
     text: `${tzurotCount} Tzurot voice${tzurotCount !== 1 ? 's' : ''} / ${totalSlots} total ElevenLabs slots`,
   });
 
-  embed.addFields({
-    name: '💡 Management',
-    value: [
-      '`/settings voices delete <voice>` - Remove a single voice',
-      '`/settings voices clear` - Remove all Tzurot voices',
-    ].join('\n'),
-    inline: false,
-  });
+  // Show management hints only on first page to avoid clutter
+  if (safePage === 0) {
+    embed.addFields({
+      name: '💡 Management',
+      value: [
+        '`/settings voices delete <voice>` - Remove a single voice',
+        '`/settings voices clear` - Remove all Tzurot voices',
+      ].join('\n'),
+      inline: false,
+    });
+  }
 
-  return embed;
+  const components: ActionRowBuilder<ButtonBuilder>[] = [];
+  if (totalPages > 1) {
+    components.push(
+      buildBrowseButtons<VoiceBrowseFilter>({
+        currentPage: safePage,
+        totalPages,
+        filter: 'all',
+        currentSort: 'name', // Unused — sort toggle disabled
+        query: null,
+        buildCustomId: browseHelpers.build,
+        buildInfoId: browseHelpers.buildInfo,
+        showSortToggle: false,
+      })
+    );
+  }
+
+  return { embed, components };
 }
 
 /**
@@ -72,12 +123,51 @@ export async function handleBrowseVoices(context: DeferredCommandContext): Promi
       return;
     }
 
-    const embed = buildVoiceBrowseEmbed(result.data);
-    await context.editReply({ embeds: [embed] });
+    const { embed, components } = buildVoiceBrowsePage(result.data, 0);
+    await context.editReply({ embeds: [embed], components });
 
     logger.info({ userId, voiceCount: result.data.voices.length }, '[Voices Browse] Listed voices');
   } catch (error) {
     logger.error({ err: error, userId }, '[Voices Browse] Unexpected error');
     await context.editReply({ content: '❌ An unexpected error occurred. Please try again.' });
+  }
+}
+
+/**
+ * Handle pagination button clicks for voice browse.
+ *
+ * Re-fetches from gateway on each page turn — browse intentionally shows
+ * fresh data (not the autocomplete cache) so users can verify state after
+ * voice mutations.
+ */
+export async function handleVoiceBrowsePagination(interaction: ButtonInteraction): Promise<void> {
+  const parsed = browseHelpers.parse(interaction.customId);
+  if (parsed === null) {
+    return;
+  }
+
+  await interaction.deferUpdate();
+
+  const userId = interaction.user.id;
+
+  try {
+    const result = await callGatewayApi<VoicesListResponse>('/user/voices', {
+      userId,
+      timeout: GATEWAY_TIMEOUTS.DEFERRED,
+    });
+
+    if (!result.ok) {
+      await interaction.editReply({ content: `❌ ${result.error}`, embeds: [], components: [] });
+      return;
+    }
+
+    const { embed, components } = buildVoiceBrowsePage(result.data, parsed.page);
+    await interaction.editReply({ embeds: [embed], components });
+  } catch (error) {
+    logger.error(
+      { err: error, userId, page: parsed.page },
+      '[Voices Browse] Failed to load browse page'
+    );
+    // Keep existing content on error (same pattern as character browse)
   }
 }

--- a/services/bot-client/src/commands/settings/voices/browse.ts
+++ b/services/bot-client/src/commands/settings/voices/browse.ts
@@ -40,7 +40,7 @@ function buildVoiceBrowsePage(
   data: VoicesListResponse,
   page: number
 ): { embed: EmbedBuilder; components: ActionRowBuilder<ButtonBuilder>[] } {
-  const { voices, totalSlots, tzurotCount } = data;
+  const { voices, totalVoices, tzurotCount } = data;
 
   const embed = new EmbedBuilder()
     .setTitle('🎤 Cloned Voices')
@@ -51,7 +51,7 @@ function buildVoiceBrowsePage(
     embed.setDescription(
       'No Tzurot-cloned voices found.\n\n' +
         'Voices are auto-cloned when you talk to a character with voice enabled.\n' +
-        `Your ElevenLabs account has **${totalSlots}** total voice slots.`
+        `Your ElevenLabs account has **${totalVoices}** voices.`
     );
     return { embed, components: [] };
   }
@@ -67,7 +67,7 @@ function buildVoiceBrowsePage(
 
   embed.setDescription(voiceLines.join('\n'));
   embed.setFooter({
-    text: `${tzurotCount} Tzurot voice${tzurotCount !== 1 ? 's' : ''} / ${totalSlots} total ElevenLabs slots`,
+    text: `${tzurotCount} Tzurot voice${tzurotCount !== 1 ? 's' : ''} / ${totalVoices} total in ElevenLabs account`,
   });
 
   // Show management hints only on first page to avoid clutter

--- a/services/bot-client/src/commands/settings/voices/clear.test.ts
+++ b/services/bot-client/src/commands/settings/voices/clear.test.ts
@@ -104,7 +104,7 @@ describe('handleClearVoices', () => {
           { voiceId: 'v1', name: 'tzurot-alice', slug: 'alice' },
           { voiceId: 'v2', name: 'tzurot-bob', slug: 'bob' },
         ],
-        totalSlots: 10,
+        totalVoices: 10,
         tzurotCount: 2,
       },
     });
@@ -123,7 +123,7 @@ describe('handleClearVoices', () => {
   it('should show message when no voices to clear', async () => {
     mockCallGatewayApi.mockResolvedValue({
       ok: true,
-      data: { voices: [], totalSlots: 5, tzurotCount: 0 },
+      data: { voices: [], totalVoices: 5, tzurotCount: 0 },
     });
 
     await handleClearVoices(createMockContext());

--- a/services/bot-client/src/commands/settings/voices/clear.test.ts
+++ b/services/bot-client/src/commands/settings/voices/clear.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Tests for Voice Clear Handler
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type {
+  ChatInputCommandInteraction,
+  ButtonInteraction,
+  ModalSubmitInteraction,
+} from 'discord.js';
+import {
+  handleClearVoices,
+  handleVoiceClearButton,
+  handleVoiceClearModal,
+  VOICE_CLEAR_OPERATION,
+} from './clear.js';
+import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
+
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+const mockCallGatewayApi = vi.fn();
+vi.mock('../../../utils/userGatewayClient.js', () => ({
+  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
+}));
+
+const mockBuildDestructiveWarning = vi.fn().mockReturnValue({ embeds: [], components: [] });
+const mockHandleDestructiveConfirmButton = vi.fn();
+const mockHandleDestructiveCancel = vi.fn();
+const mockHandleDestructiveModalSubmit = vi.fn();
+vi.mock('../../../utils/destructiveConfirmation.js', () => ({
+  buildDestructiveWarning: (...args: unknown[]) => mockBuildDestructiveWarning(...args),
+  createHardDeleteConfig: (opts: Record<string, unknown>) => opts,
+  handleDestructiveConfirmButton: (...args: unknown[]) =>
+    mockHandleDestructiveConfirmButton(...args),
+  handleDestructiveCancel: (...args: unknown[]) => mockHandleDestructiveCancel(...args),
+  handleDestructiveModalSubmit: (...args: unknown[]) => mockHandleDestructiveModalSubmit(...args),
+}));
+
+vi.mock('../../../utils/customIds.js', () => ({
+  DestructiveCustomIds: {
+    parse: (customId: string) => {
+      const parts = customId.split('::');
+      if (parts[1] !== 'destructive') return null;
+      return {
+        source: parts[0],
+        action: parts[2],
+        operation: parts[3],
+        entityId: parts[4],
+      };
+    },
+  },
+}));
+
+describe('handleClearVoices', () => {
+  const mockEditReply = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function createMockContext(): DeferredCommandContext {
+    const mockInteraction = {
+      user: { id: 'user-123' },
+      editReply: mockEditReply,
+    } as unknown as ChatInputCommandInteraction;
+
+    return {
+      interaction: mockInteraction,
+      user: mockInteraction.user,
+      guild: null,
+      member: null,
+      channel: null,
+      channelId: 'channel-123',
+      guildId: null,
+      commandName: 'settings',
+      isEphemeral: true,
+      editReply: mockEditReply,
+      followUp: vi.fn(),
+      deleteReply: vi.fn(),
+      getOption: vi.fn(),
+      getRequiredOption: vi.fn(),
+      getSubcommand: vi.fn().mockReturnValue('clear'),
+      getSubcommandGroup: vi.fn().mockReturnValue('voices'),
+    } as unknown as DeferredCommandContext;
+  }
+
+  it('should show destructive warning when voices exist', async () => {
+    mockCallGatewayApi.mockResolvedValue({
+      ok: true,
+      data: {
+        voices: [
+          { voiceId: 'v1', name: 'tzurot-alice', slug: 'alice' },
+          { voiceId: 'v2', name: 'tzurot-bob', slug: 'bob' },
+        ],
+        totalSlots: 10,
+        tzurotCount: 2,
+      },
+    });
+
+    await handleClearVoices(createMockContext());
+
+    expect(mockBuildDestructiveWarning).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityType: 'cloned voices',
+        operation: VOICE_CLEAR_OPERATION,
+      })
+    );
+    expect(mockEditReply).toHaveBeenCalled();
+  });
+
+  it('should show message when no voices to clear', async () => {
+    mockCallGatewayApi.mockResolvedValue({
+      ok: true,
+      data: { voices: [], totalSlots: 5, tzurotCount: 0 },
+    });
+
+    await handleClearVoices(createMockContext());
+
+    expect(mockEditReply).toHaveBeenCalledWith({
+      content: 'No Tzurot voices to clear.',
+    });
+    expect(mockBuildDestructiveWarning).not.toHaveBeenCalled();
+  });
+
+  it('should handle API error', async () => {
+    mockCallGatewayApi.mockResolvedValue({
+      ok: false,
+      status: 404,
+      error: 'ElevenLabs API key not found',
+    });
+
+    await handleClearVoices(createMockContext());
+
+    expect(mockEditReply).toHaveBeenCalledWith({
+      content: '❌ ElevenLabs API key not found',
+    });
+  });
+
+  it('should handle exceptions', async () => {
+    mockCallGatewayApi.mockRejectedValue(new Error('Network error'));
+
+    await handleClearVoices(createMockContext());
+
+    expect(mockEditReply).toHaveBeenCalledWith({
+      content: '❌ An unexpected error occurred. Please try again.',
+    });
+  });
+});
+
+describe('handleVoiceClearButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should handle cancel button', async () => {
+    const interaction = {
+      customId: `settings::destructive::cancel_button::${VOICE_CLEAR_OPERATION}::all`,
+    } as unknown as ButtonInteraction;
+
+    await handleVoiceClearButton(interaction);
+
+    expect(mockHandleDestructiveCancel).toHaveBeenCalledWith(interaction, 'Voice clear cancelled.');
+  });
+
+  it('should handle confirm button', async () => {
+    const interaction = {
+      customId: `settings::destructive::confirm_button::${VOICE_CLEAR_OPERATION}::all`,
+    } as unknown as ButtonInteraction;
+
+    await handleVoiceClearButton(interaction);
+
+    expect(mockHandleDestructiveConfirmButton).toHaveBeenCalled();
+  });
+});
+
+describe('handleVoiceClearModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should handle modal submit', async () => {
+    const interaction = {
+      customId: `settings::destructive::modal_submit::${VOICE_CLEAR_OPERATION}::all`,
+      user: { id: 'user-123' },
+    } as unknown as ModalSubmitInteraction;
+
+    await handleVoiceClearModal(interaction);
+
+    expect(mockHandleDestructiveModalSubmit).toHaveBeenCalled();
+  });
+});

--- a/services/bot-client/src/commands/settings/voices/clear.test.ts
+++ b/services/bot-client/src/commands/settings/voices/clear.test.ts
@@ -32,7 +32,7 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 const mockCallGatewayApi = vi.fn();
 vi.mock('../../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
+  GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000, BULK_OPERATION: 30000 },
 }));
 
 const mockBuildDestructiveWarning = vi.fn().mockReturnValue({ embeds: [], components: [] });

--- a/services/bot-client/src/commands/settings/voices/clear.ts
+++ b/services/bot-client/src/commands/settings/voices/clear.ts
@@ -103,7 +103,7 @@ export async function handleVoiceClearModalSubmit(
     const result = await callGatewayApi<VoiceClearResponse>('/user/voices/clear', {
       method: 'POST',
       userId,
-      timeout: GATEWAY_TIMEOUTS.DEFERRED,
+      timeout: GATEWAY_TIMEOUTS.BULK_OPERATION,
     });
 
     if (!result.ok) {

--- a/services/bot-client/src/commands/settings/voices/clear.ts
+++ b/services/bot-client/src/commands/settings/voices/clear.ts
@@ -16,23 +16,12 @@ import {
   handleDestructiveModalSubmit,
 } from '../../../utils/destructiveConfirmation.js';
 import { DestructiveCustomIds } from '../../../utils/customIds.js';
+import type { VoicesListResponse } from './types.js';
 
 const logger = createLogger('settings-voices-clear');
 
 /** Operation name for destructive confirmation custom IDs */
 export const VOICE_CLEAR_OPERATION = 'voice-clear';
-
-interface VoiceEntry {
-  voiceId: string;
-  name: string;
-  slug: string;
-}
-
-interface VoicesListResponse {
-  voices: VoiceEntry[];
-  totalSlots: number;
-  tzurotCount: number;
-}
 
 interface VoiceClearResponse {
   deleted: number;
@@ -149,7 +138,9 @@ export async function handleVoiceClearModalSubmit(
  */
 export async function handleVoiceClearButton(interaction: ButtonInteraction): Promise<void> {
   const parsed = DestructiveCustomIds.parse(interaction.customId);
-  if (parsed === null) {return;}
+  if (parsed === null) {
+    return;
+  }
 
   if (parsed.action === 'cancel_button') {
     await handleDestructiveCancel(interaction, 'Voice clear cancelled.');
@@ -166,7 +157,9 @@ export async function handleVoiceClearButton(interaction: ButtonInteraction): Pr
  */
 export async function handleVoiceClearModal(interaction: ModalSubmitInteraction): Promise<void> {
   const parsed = DestructiveCustomIds.parse(interaction.customId);
-  if (parsed === null) {return;}
+  if (parsed === null) {
+    return;
+  }
 
   if (parsed.action === 'modal_submit') {
     await handleVoiceClearModalSubmit(interaction);

--- a/services/bot-client/src/commands/settings/voices/clear.ts
+++ b/services/bot-client/src/commands/settings/voices/clear.ts
@@ -26,7 +26,7 @@ export const VOICE_CLEAR_OPERATION = 'voice-clear';
 
 interface VoiceClearResponse {
   deleted: number;
-  total?: number;
+  total: number;
   message?: string;
   errors?: string[];
 }

--- a/services/bot-client/src/commands/settings/voices/clear.ts
+++ b/services/bot-client/src/commands/settings/voices/clear.ts
@@ -119,9 +119,16 @@ export async function handleVoiceClearModalSubmit(
       .setTimestamp();
 
     if (errors !== undefined && errors.length > 0) {
+      // Truncate error list to avoid exceeding Discord's 2048-char embed description limit.
+      // With ~50 voices and verbose error messages, the full list can easily overflow.
+      const MAX_ERRORS_SHOWN = 5;
+      const shownErrors = errors.slice(0, MAX_ERRORS_SHOWN);
+      const overflow =
+        errors.length > MAX_ERRORS_SHOWN ? `\n…and ${errors.length - MAX_ERRORS_SHOWN} more` : '';
       embed.setDescription(
         `Deleted **${deleted}/${total}** voices. ${errors.length} failed:\n` +
-          errors.map(e => `• ${e}`).join('\n')
+          shownErrors.map(e => `• ${e}`).join('\n') +
+          overflow
       );
       embed.setColor(DISCORD_COLORS.WARNING);
     } else {

--- a/services/bot-client/src/commands/settings/voices/clear.ts
+++ b/services/bot-client/src/commands/settings/voices/clear.ts
@@ -1,0 +1,174 @@
+/**
+ * Voice Clear Handler
+ * Deletes ALL tzurot-prefixed voices with destructive confirmation
+ */
+
+import { EmbedBuilder } from 'discord.js';
+import type { ButtonInteraction, ModalSubmitInteraction } from 'discord.js';
+import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
+import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
+import { callGatewayApi, GATEWAY_TIMEOUTS } from '../../../utils/userGatewayClient.js';
+import {
+  buildDestructiveWarning,
+  createHardDeleteConfig,
+  handleDestructiveConfirmButton,
+  handleDestructiveCancel,
+  handleDestructiveModalSubmit,
+} from '../../../utils/destructiveConfirmation.js';
+import { DestructiveCustomIds } from '../../../utils/customIds.js';
+
+const logger = createLogger('settings-voices-clear');
+
+/** Operation name for destructive confirmation custom IDs */
+export const VOICE_CLEAR_OPERATION = 'voice-clear';
+
+interface VoiceEntry {
+  voiceId: string;
+  name: string;
+  slug: string;
+}
+
+interface VoicesListResponse {
+  voices: VoiceEntry[];
+  totalSlots: number;
+  tzurotCount: number;
+}
+
+interface VoiceClearResponse {
+  deleted: number;
+  total?: number;
+  message?: string;
+  errors?: string[];
+}
+
+/**
+ * Handle /settings voices clear
+ * Shows destructive confirmation before clearing all tzurot voices
+ */
+export async function handleClearVoices(context: DeferredCommandContext): Promise<void> {
+  const userId = context.user.id;
+
+  try {
+    const result = await callGatewayApi<VoicesListResponse>('/user/voices', {
+      userId,
+      timeout: GATEWAY_TIMEOUTS.DEFERRED,
+    });
+
+    if (!result.ok) {
+      await context.editReply({ content: `❌ ${result.error}` });
+      return;
+    }
+
+    if (result.data.voices.length === 0) {
+      await context.editReply({ content: 'No Tzurot voices to clear.' });
+      return;
+    }
+
+    const count = result.data.voices.length;
+    const config = createHardDeleteConfig({
+      entityType: 'cloned voices',
+      entityName: `${count} Tzurot voice${count !== 1 ? 's' : ''}`,
+      additionalWarning:
+        'This will remove all auto-cloned voices from your ElevenLabs account.\n' +
+        'They will be re-cloned automatically when needed.',
+      source: 'settings',
+      operation: VOICE_CLEAR_OPERATION,
+      entityId: 'all',
+    });
+
+    const warning = buildDestructiveWarning(config);
+    await context.editReply(warning);
+
+    logger.info({ userId, voiceCount: count }, '[Voices Clear] Showing confirmation');
+  } catch (error) {
+    logger.error({ err: error, userId }, '[Voices Clear] Unexpected error');
+    await context.editReply({ content: '❌ An unexpected error occurred. Please try again.' });
+  }
+}
+
+/**
+ * Handle confirm button for voice-clear operation
+ */
+export async function handleVoiceClearConfirmButton(interaction: ButtonInteraction): Promise<void> {
+  const config = createHardDeleteConfig({
+    entityType: 'cloned voices',
+    entityName: 'all Tzurot voices',
+    additionalWarning: 'This will remove all auto-cloned voices from your ElevenLabs account.',
+    source: 'settings',
+    operation: VOICE_CLEAR_OPERATION,
+    entityId: 'all',
+  });
+
+  await handleDestructiveConfirmButton(interaction, config);
+}
+
+/**
+ * Handle modal submit for voice-clear operation
+ */
+export async function handleVoiceClearModalSubmit(
+  interaction: ModalSubmitInteraction
+): Promise<void> {
+  const userId = interaction.user.id;
+
+  await handleDestructiveModalSubmit(interaction, 'DELETE', async () => {
+    const result = await callGatewayApi<VoiceClearResponse>('/user/voices/clear', {
+      method: 'POST',
+      userId,
+      timeout: GATEWAY_TIMEOUTS.DEFERRED,
+    });
+
+    if (!result.ok) {
+      return { success: false, errorMessage: `❌ ${result.error}` };
+    }
+
+    const { deleted, total, errors } = result.data;
+
+    const embed = new EmbedBuilder()
+      .setTitle('🗑️ Voices Cleared')
+      .setColor(DISCORD_COLORS.SUCCESS)
+      .setTimestamp();
+
+    if (errors !== undefined && errors.length > 0) {
+      embed.setDescription(
+        `Deleted **${deleted}/${total}** voices. ${errors.length} failed:\n` +
+          errors.map(e => `• ${e}`).join('\n')
+      );
+      embed.setColor(DISCORD_COLORS.WARNING);
+    } else {
+      embed.setDescription(`Deleted **${deleted}** cloned voice${deleted !== 1 ? 's' : ''}.`);
+    }
+
+    logger.info({ userId, deleted, total }, '[Voices Clear] Cleared voices');
+
+    return { success: true, successEmbed: embed };
+  });
+}
+
+/**
+ * Route button interactions for voice-clear destructive confirmation
+ */
+export async function handleVoiceClearButton(interaction: ButtonInteraction): Promise<void> {
+  const parsed = DestructiveCustomIds.parse(interaction.customId);
+  if (parsed === null) {return;}
+
+  if (parsed.action === 'cancel_button') {
+    await handleDestructiveCancel(interaction, 'Voice clear cancelled.');
+    return;
+  }
+
+  if (parsed.action === 'confirm_button') {
+    await handleVoiceClearConfirmButton(interaction);
+  }
+}
+
+/**
+ * Route modal interactions for voice-clear destructive confirmation
+ */
+export async function handleVoiceClearModal(interaction: ModalSubmitInteraction): Promise<void> {
+  const parsed = DestructiveCustomIds.parse(interaction.customId);
+  if (parsed === null) {return;}
+
+  if (parsed.action === 'modal_submit') {
+    await handleVoiceClearModalSubmit(interaction);
+  }
+}

--- a/services/bot-client/src/commands/settings/voices/clear.ts
+++ b/services/bot-client/src/commands/settings/voices/clear.ts
@@ -17,7 +17,7 @@ import {
 } from '../../../utils/destructiveConfirmation.js';
 import { DestructiveCustomIds } from '../../../utils/customIds.js';
 import type { VoicesListResponse } from './types.js';
-import { clearVoiceCacheForUser } from './delete.js';
+import { invalidateVoiceCache } from './voiceCache.js';
 
 const logger = createLogger('settings-voices-clear');
 
@@ -129,7 +129,7 @@ export async function handleVoiceClearModalSubmit(
     }
 
     // Invalidate autocomplete cache so deleted voices don't appear in /settings voices delete
-    clearVoiceCacheForUser(userId);
+    invalidateVoiceCache(userId);
 
     logger.info({ userId, deleted, total }, '[Voices Clear] Cleared voices');
 

--- a/services/bot-client/src/commands/settings/voices/clear.ts
+++ b/services/bot-client/src/commands/settings/voices/clear.ts
@@ -17,6 +17,7 @@ import {
 } from '../../../utils/destructiveConfirmation.js';
 import { DestructiveCustomIds } from '../../../utils/customIds.js';
 import type { VoicesListResponse } from './types.js';
+import { clearVoiceCacheForUser } from './delete.js';
 
 const logger = createLogger('settings-voices-clear');
 
@@ -126,6 +127,9 @@ export async function handleVoiceClearModalSubmit(
     } else {
       embed.setDescription(`Deleted **${deleted}** cloned voice${deleted !== 1 ? 's' : ''}.`);
     }
+
+    // Invalidate autocomplete cache so deleted voices don't appear in /settings voices delete
+    clearVoiceCacheForUser(userId);
 
     logger.info({ userId, deleted, total }, '[Voices Clear] Cleared voices');
 

--- a/services/bot-client/src/commands/settings/voices/delete.test.ts
+++ b/services/bot-client/src/commands/settings/voices/delete.test.ts
@@ -137,7 +137,7 @@ describe('handleVoiceAutocomplete', () => {
           { voiceId: 'v1', name: 'tzurot-alice', slug: 'alice' },
           { voiceId: 'v2', name: 'tzurot-bob', slug: 'bob' },
         ],
-        totalSlots: 10,
+        totalVoices: 10,
         tzurotCount: 2,
       },
     });
@@ -158,7 +158,7 @@ describe('handleVoiceAutocomplete', () => {
           { voiceId: 'v1', name: 'tzurot-alice', slug: 'alice' },
           { voiceId: 'v2', name: 'tzurot-bob', slug: 'bob' },
         ],
-        totalSlots: 10,
+        totalVoices: 10,
         tzurotCount: 2,
       },
     });
@@ -173,7 +173,7 @@ describe('handleVoiceAutocomplete', () => {
       ok: true,
       data: {
         voices: [{ voiceId: 'v1', name: 'tzurot-alice', slug: 'alice' }],
-        totalSlots: 10,
+        totalVoices: 10,
         tzurotCount: 1,
       },
     });
@@ -193,7 +193,7 @@ describe('handleVoiceAutocomplete', () => {
       ok: true,
       data: {
         voices: [{ voiceId: 'voice-1', name: 'tzurot-alice', slug: 'alice' }],
-        totalSlots: 10,
+        totalVoices: 10,
         tzurotCount: 1,
       },
     });
@@ -229,7 +229,7 @@ describe('handleVoiceAutocomplete', () => {
     // Autocomplete should re-fetch (cache was invalidated)
     mockCallGatewayApi.mockResolvedValue({
       ok: true,
-      data: { voices: [], totalSlots: 10, tzurotCount: 0 },
+      data: { voices: [], totalVoices: 10, tzurotCount: 0 },
     });
     await handleVoiceAutocomplete(createMockAutocomplete());
     expect(mockCallGatewayApi).toHaveBeenCalledTimes(3);

--- a/services/bot-client/src/commands/settings/voices/delete.test.ts
+++ b/services/bot-client/src/commands/settings/voices/delete.test.ts
@@ -4,7 +4,11 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ChatInputCommandInteraction, AutocompleteInteraction } from 'discord.js';
-import { handleDeleteVoice, handleVoiceAutocomplete } from './delete.js';
+import {
+  handleDeleteVoice,
+  handleVoiceAutocomplete,
+  _clearVoiceCacheForTesting,
+} from './delete.js';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
 
 vi.mock('@tzurot/common-types', async importOriginal => {
@@ -113,6 +117,7 @@ describe('handleVoiceAutocomplete', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    _clearVoiceCacheForTesting();
   });
 
   function createMockAutocomplete(query = ''): AutocompleteInteraction {
@@ -164,6 +169,25 @@ describe('handleVoiceAutocomplete', () => {
     await handleVoiceAutocomplete(createMockAutocomplete('ali'));
 
     expect(mockRespond).toHaveBeenCalledWith([{ name: 'alice', value: 'v1' }]);
+  });
+
+  it('should use cached voices on subsequent calls', async () => {
+    mockCallGatewayApi.mockResolvedValue({
+      ok: true,
+      data: {
+        voices: [{ voiceId: 'v1', name: 'tzurot-alice', slug: 'alice' }],
+        totalSlots: 10,
+        tzurotCount: 1,
+      },
+    });
+
+    // First call populates cache
+    await handleVoiceAutocomplete(createMockAutocomplete());
+    // Second call should use cache (no additional API call)
+    await handleVoiceAutocomplete(createMockAutocomplete('ali'));
+
+    expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
+    expect(mockRespond).toHaveBeenCalledTimes(2);
   });
 
   it('should return empty on API error', async () => {

--- a/services/bot-client/src/commands/settings/voices/delete.test.ts
+++ b/services/bot-client/src/commands/settings/voices/delete.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for Voice Delete Handler and Autocomplete
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ChatInputCommandInteraction, AutocompleteInteraction } from 'discord.js';
+import { handleDeleteVoice, handleVoiceAutocomplete } from './delete.js';
+import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
+
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+const mockCallGatewayApi = vi.fn();
+vi.mock('../../../utils/userGatewayClient.js', () => ({
+  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
+}));
+
+describe('handleDeleteVoice', () => {
+  const mockEditReply = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function createMockContext(voiceId = 'voice-1'): DeferredCommandContext {
+    const mockInteraction = {
+      user: { id: 'user-123' },
+      editReply: mockEditReply,
+    } as unknown as ChatInputCommandInteraction;
+
+    return {
+      interaction: mockInteraction,
+      user: mockInteraction.user,
+      guild: null,
+      member: null,
+      channel: null,
+      channelId: 'channel-123',
+      guildId: null,
+      commandName: 'settings',
+      isEphemeral: true,
+      editReply: mockEditReply,
+      followUp: vi.fn(),
+      deleteReply: vi.fn(),
+      getOption: vi.fn(),
+      getRequiredOption: vi.fn().mockReturnValue(voiceId),
+      getSubcommand: vi.fn().mockReturnValue('delete'),
+      getSubcommandGroup: vi.fn().mockReturnValue('voices'),
+    } as unknown as DeferredCommandContext;
+  }
+
+  it('should delete a voice successfully', async () => {
+    mockCallGatewayApi.mockResolvedValue({
+      ok: true,
+      data: { deleted: true, voiceId: 'voice-1', name: 'tzurot-alice', slug: 'alice' },
+    });
+
+    await handleDeleteVoice(createMockContext());
+
+    expect(mockCallGatewayApi).toHaveBeenCalledWith(
+      '/user/voices/voice-1',
+      expect.objectContaining({ method: 'DELETE', userId: 'user-123' })
+    );
+    expect(mockEditReply).toHaveBeenCalledWith({
+      embeds: [
+        expect.objectContaining({
+          data: expect.objectContaining({
+            title: '🗑️ Voice Deleted',
+            description: expect.stringContaining('alice'),
+          }),
+        }),
+      ],
+    });
+  });
+
+  it('should handle not found error', async () => {
+    mockCallGatewayApi.mockResolvedValue({
+      ok: false,
+      status: 404,
+      error: 'Voice not found',
+    });
+
+    await handleDeleteVoice(createMockContext('nonexistent'));
+
+    expect(mockEditReply).toHaveBeenCalledWith({
+      content: '❌ Voice not found',
+    });
+  });
+
+  it('should handle exceptions', async () => {
+    mockCallGatewayApi.mockRejectedValue(new Error('Network error'));
+
+    await handleDeleteVoice(createMockContext());
+
+    expect(mockEditReply).toHaveBeenCalledWith({
+      content: '❌ An unexpected error occurred. Please try again.',
+    });
+  });
+});
+
+describe('handleVoiceAutocomplete', () => {
+  const mockRespond = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function createMockAutocomplete(query = ''): AutocompleteInteraction {
+    return {
+      user: { id: 'user-123' },
+      options: {
+        getFocused: vi.fn().mockReturnValue(query),
+        getSubcommandGroup: vi.fn().mockReturnValue('voices'),
+        getSubcommand: vi.fn().mockReturnValue('delete'),
+      },
+      respond: mockRespond,
+    } as unknown as AutocompleteInteraction;
+  }
+
+  it('should return voice choices', async () => {
+    mockCallGatewayApi.mockResolvedValue({
+      ok: true,
+      data: {
+        voices: [
+          { voiceId: 'v1', name: 'tzurot-alice', slug: 'alice' },
+          { voiceId: 'v2', name: 'tzurot-bob', slug: 'bob' },
+        ],
+        totalSlots: 10,
+        tzurotCount: 2,
+      },
+    });
+
+    await handleVoiceAutocomplete(createMockAutocomplete());
+
+    expect(mockRespond).toHaveBeenCalledWith([
+      { name: 'alice', value: 'v1' },
+      { name: 'bob', value: 'v2' },
+    ]);
+  });
+
+  it('should filter by query', async () => {
+    mockCallGatewayApi.mockResolvedValue({
+      ok: true,
+      data: {
+        voices: [
+          { voiceId: 'v1', name: 'tzurot-alice', slug: 'alice' },
+          { voiceId: 'v2', name: 'tzurot-bob', slug: 'bob' },
+        ],
+        totalSlots: 10,
+        tzurotCount: 2,
+      },
+    });
+
+    await handleVoiceAutocomplete(createMockAutocomplete('ali'));
+
+    expect(mockRespond).toHaveBeenCalledWith([{ name: 'alice', value: 'v1' }]);
+  });
+
+  it('should return empty on API error', async () => {
+    mockCallGatewayApi.mockResolvedValue({ ok: false, status: 404, error: 'Not found' });
+
+    await handleVoiceAutocomplete(createMockAutocomplete());
+
+    expect(mockRespond).toHaveBeenCalledWith([]);
+  });
+
+  it('should return empty on exception', async () => {
+    mockCallGatewayApi.mockRejectedValue(new Error('timeout'));
+
+    await handleVoiceAutocomplete(createMockAutocomplete());
+
+    expect(mockRespond).toHaveBeenCalledWith([]);
+  });
+});

--- a/services/bot-client/src/commands/settings/voices/delete.test.ts
+++ b/services/bot-client/src/commands/settings/voices/delete.test.ts
@@ -4,11 +4,8 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ChatInputCommandInteraction, AutocompleteInteraction } from 'discord.js';
-import {
-  handleDeleteVoice,
-  handleVoiceAutocomplete,
-  _clearVoiceCacheForTesting,
-} from './delete.js';
+import { handleDeleteVoice, handleVoiceAutocomplete } from './delete.js';
+import { _clearVoiceCacheForTesting } from './voiceCache.js';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
 
 vi.mock('@tzurot/common-types', async importOriginal => {

--- a/services/bot-client/src/commands/settings/voices/delete.test.ts
+++ b/services/bot-client/src/commands/settings/voices/delete.test.ts
@@ -190,6 +190,54 @@ describe('handleVoiceAutocomplete', () => {
     expect(mockRespond).toHaveBeenCalledTimes(2);
   });
 
+  it('should invalidate cache after successful delete', async () => {
+    // Pre-populate cache via autocomplete
+    mockCallGatewayApi.mockResolvedValue({
+      ok: true,
+      data: {
+        voices: [{ voiceId: 'voice-1', name: 'tzurot-alice', slug: 'alice' }],
+        totalSlots: 10,
+        tzurotCount: 1,
+      },
+    });
+    await handleVoiceAutocomplete(createMockAutocomplete());
+    expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
+
+    // Delete the voice — should invalidate cache
+    mockCallGatewayApi.mockResolvedValue({
+      ok: true,
+      data: { deleted: true, voiceId: 'voice-1', name: 'tzurot-alice', slug: 'alice' },
+    });
+    const mockEditReply = vi.fn();
+    const mockContext = {
+      interaction: { user: { id: 'user-123' }, editReply: mockEditReply },
+      user: { id: 'user-123' },
+      guild: null,
+      member: null,
+      channel: null,
+      channelId: 'ch',
+      guildId: null,
+      commandName: 'settings',
+      isEphemeral: true,
+      editReply: mockEditReply,
+      followUp: vi.fn(),
+      deleteReply: vi.fn(),
+      getOption: vi.fn(),
+      getRequiredOption: vi.fn().mockReturnValue('voice-1'),
+      getSubcommand: vi.fn().mockReturnValue('delete'),
+      getSubcommandGroup: vi.fn().mockReturnValue('voices'),
+    } as unknown as DeferredCommandContext;
+    await handleDeleteVoice(mockContext);
+
+    // Autocomplete should re-fetch (cache was invalidated)
+    mockCallGatewayApi.mockResolvedValue({
+      ok: true,
+      data: { voices: [], totalSlots: 10, tzurotCount: 0 },
+    });
+    await handleVoiceAutocomplete(createMockAutocomplete());
+    expect(mockCallGatewayApi).toHaveBeenCalledTimes(3);
+  });
+
   it('should return empty on API error', async () => {
     mockCallGatewayApi.mockResolvedValue({ ok: false, status: 404, error: 'Not found' });
 

--- a/services/bot-client/src/commands/settings/voices/delete.ts
+++ b/services/bot-client/src/commands/settings/voices/delete.ts
@@ -45,6 +45,9 @@ export async function handleDeleteVoice(context: DeferredCommandContext): Promis
       return;
     }
 
+    // Invalidate cached voice list so autocomplete reflects the deletion
+    voiceCache.delete(userId);
+
     const embed = new EmbedBuilder()
       .setTitle('🗑️ Voice Deleted')
       .setDescription(`Removed cloned voice **${result.data.slug}** (\`${result.data.voiceId}\`)`)

--- a/services/bot-client/src/commands/settings/voices/delete.ts
+++ b/services/bot-client/src/commands/settings/voices/delete.ts
@@ -5,15 +5,13 @@
 
 import { EmbedBuilder } from 'discord.js';
 import type { AutocompleteInteraction } from 'discord.js';
-import { createLogger, DISCORD_COLORS, DISCORD_LIMITS, TTLCache } from '@tzurot/common-types';
+import { createLogger, DISCORD_COLORS, DISCORD_LIMITS } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
 import { callGatewayApi, GATEWAY_TIMEOUTS } from '../../../utils/userGatewayClient.js';
-import type { VoiceEntry, VoicesListResponse } from './types.js';
+import type { VoicesListResponse } from './types.js';
+import { getCachedVoices, setCachedVoices, invalidateVoiceCache } from './voiceCache.js';
 
 const logger = createLogger('settings-voices-delete');
-
-/** Cache voice lists per user to avoid hitting ElevenLabs API on every autocomplete keystroke */
-const voiceCache = new TTLCache<VoiceEntry[]>({ ttl: 30_000, maxSize: 100 });
 
 interface VoiceDeleteResponse {
   deleted: boolean;
@@ -46,7 +44,7 @@ export async function handleDeleteVoice(context: DeferredCommandContext): Promis
     }
 
     // Invalidate cached voice list so autocomplete reflects the deletion
-    voiceCache.delete(userId);
+    invalidateVoiceCache(userId);
 
     const embed = new EmbedBuilder()
       .setTitle('🗑️ Voice Deleted')
@@ -73,7 +71,7 @@ export async function handleVoiceAutocomplete(interaction: AutocompleteInteracti
   const query = focused.toLowerCase();
 
   try {
-    let voices = voiceCache.get(userId);
+    let voices = getCachedVoices(userId);
 
     if (voices === null) {
       const result = await callGatewayApi<VoicesListResponse>('/user/voices', {
@@ -87,7 +85,7 @@ export async function handleVoiceAutocomplete(interaction: AutocompleteInteracti
       }
 
       voices = result.data.voices;
-      voiceCache.set(userId, voices);
+      setCachedVoices(userId, voices);
     }
 
     const filtered = voices
@@ -104,20 +102,4 @@ export async function handleVoiceAutocomplete(interaction: AutocompleteInteracti
     logger.error({ err: error, userId }, '[Voices Autocomplete] Error');
     await interaction.respond([]);
   }
-}
-
-/**
- * Invalidate a user's cached voice list (e.g., after bulk clear).
- * Called from clear.ts after a successful /user/voices/clear response.
- */
-export function clearVoiceCacheForUser(userId: string): void {
-  voiceCache.delete(userId);
-}
-
-/**
- * Clear the entire voice autocomplete cache.
- * @internal For testing only
- */
-export function _clearVoiceCacheForTesting(): void {
-  voiceCache.clear();
 }

--- a/services/bot-client/src/commands/settings/voices/delete.ts
+++ b/services/bot-client/src/commands/settings/voices/delete.ts
@@ -1,0 +1,105 @@
+/**
+ * Voice Delete Handler
+ * Deletes a single ElevenLabs cloned voice with autocomplete
+ */
+
+import { EmbedBuilder } from 'discord.js';
+import type { AutocompleteInteraction } from 'discord.js';
+import { createLogger, DISCORD_COLORS, DISCORD_LIMITS } from '@tzurot/common-types';
+import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
+import { callGatewayApi, GATEWAY_TIMEOUTS } from '../../../utils/userGatewayClient.js';
+
+const logger = createLogger('settings-voices-delete');
+
+interface VoiceEntry {
+  voiceId: string;
+  name: string;
+  slug: string;
+}
+
+interface VoicesListResponse {
+  voices: VoiceEntry[];
+  totalSlots: number;
+  tzurotCount: number;
+}
+
+interface VoiceDeleteResponse {
+  deleted: boolean;
+  voiceId: string;
+  name: string;
+  slug: string;
+}
+
+/**
+ * Handle /settings voices delete <voice>
+ * Deletes a single tzurot-prefixed voice from ElevenLabs
+ */
+export async function handleDeleteVoice(context: DeferredCommandContext): Promise<void> {
+  const userId = context.user.id;
+  const voiceId = context.getRequiredOption<string>('voice');
+
+  try {
+    const result = await callGatewayApi<VoiceDeleteResponse>(
+      `/user/voices/${encodeURIComponent(voiceId)}`,
+      {
+        method: 'DELETE',
+        userId,
+        timeout: GATEWAY_TIMEOUTS.DEFERRED,
+      }
+    );
+
+    if (!result.ok) {
+      await context.editReply({ content: `❌ ${result.error}` });
+      return;
+    }
+
+    const embed = new EmbedBuilder()
+      .setTitle('🗑️ Voice Deleted')
+      .setDescription(`Removed cloned voice **${result.data.slug}** (\`${result.data.voiceId}\`)`)
+      .setColor(DISCORD_COLORS.SUCCESS)
+      .setTimestamp();
+
+    await context.editReply({ embeds: [embed] });
+
+    logger.info({ userId, voiceId, slug: result.data.slug }, '[Voices Delete] Deleted voice');
+  } catch (error) {
+    logger.error({ err: error, userId }, '[Voices Delete] Unexpected error');
+    await context.editReply({ content: '❌ An unexpected error occurred. Please try again.' });
+  }
+}
+
+/**
+ * Autocomplete handler for voice selection
+ * Fetches voice list from gateway and filters by user input
+ */
+export async function handleVoiceAutocomplete(interaction: AutocompleteInteraction): Promise<void> {
+  const userId = interaction.user.id;
+  const focused = interaction.options.getFocused();
+  const query = focused.toLowerCase();
+
+  try {
+    const result = await callGatewayApi<VoicesListResponse>('/user/voices', {
+      userId,
+      timeout: GATEWAY_TIMEOUTS.AUTOCOMPLETE,
+    });
+
+    if (!result.ok) {
+      await interaction.respond([]);
+      return;
+    }
+
+    const filtered = result.data.voices
+      .filter(v => v.slug.toLowerCase().includes(query) || v.voiceId.toLowerCase().includes(query))
+      .slice(0, DISCORD_LIMITS.AUTOCOMPLETE_MAX_CHOICES);
+
+    const choices = filtered.map(v => ({
+      name: v.slug,
+      value: v.voiceId,
+    }));
+
+    await interaction.respond(choices);
+  } catch (error) {
+    logger.error({ err: error, userId }, '[Voices Autocomplete] Error');
+    await interaction.respond([]);
+  }
+}

--- a/services/bot-client/src/commands/settings/voices/delete.ts
+++ b/services/bot-client/src/commands/settings/voices/delete.ts
@@ -107,7 +107,15 @@ export async function handleVoiceAutocomplete(interaction: AutocompleteInteracti
 }
 
 /**
- * Clear the voice autocomplete cache.
+ * Invalidate a user's cached voice list (e.g., after bulk clear).
+ * Called from clear.ts after a successful /user/voices/clear response.
+ */
+export function clearVoiceCacheForUser(userId: string): void {
+  voiceCache.delete(userId);
+}
+
+/**
+ * Clear the entire voice autocomplete cache.
  * @internal For testing only
  */
 export function _clearVoiceCacheForTesting(): void {

--- a/services/bot-client/src/commands/settings/voices/delete.ts
+++ b/services/bot-client/src/commands/settings/voices/delete.ts
@@ -5,23 +5,15 @@
 
 import { EmbedBuilder } from 'discord.js';
 import type { AutocompleteInteraction } from 'discord.js';
-import { createLogger, DISCORD_COLORS, DISCORD_LIMITS } from '@tzurot/common-types';
+import { createLogger, DISCORD_COLORS, DISCORD_LIMITS, TTLCache } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
 import { callGatewayApi, GATEWAY_TIMEOUTS } from '../../../utils/userGatewayClient.js';
+import type { VoiceEntry, VoicesListResponse } from './types.js';
 
 const logger = createLogger('settings-voices-delete');
 
-interface VoiceEntry {
-  voiceId: string;
-  name: string;
-  slug: string;
-}
-
-interface VoicesListResponse {
-  voices: VoiceEntry[];
-  totalSlots: number;
-  tzurotCount: number;
-}
+/** Cache voice lists per user to avoid hitting ElevenLabs API on every autocomplete keystroke */
+const voiceCache = new TTLCache<VoiceEntry[]>({ ttl: 30_000, maxSize: 100 });
 
 interface VoiceDeleteResponse {
   deleted: boolean;
@@ -78,17 +70,24 @@ export async function handleVoiceAutocomplete(interaction: AutocompleteInteracti
   const query = focused.toLowerCase();
 
   try {
-    const result = await callGatewayApi<VoicesListResponse>('/user/voices', {
-      userId,
-      timeout: GATEWAY_TIMEOUTS.AUTOCOMPLETE,
-    });
+    let voices = voiceCache.get(userId);
 
-    if (!result.ok) {
-      await interaction.respond([]);
-      return;
+    if (voices === null) {
+      const result = await callGatewayApi<VoicesListResponse>('/user/voices', {
+        userId,
+        timeout: GATEWAY_TIMEOUTS.AUTOCOMPLETE,
+      });
+
+      if (!result.ok) {
+        await interaction.respond([]);
+        return;
+      }
+
+      voices = result.data.voices;
+      voiceCache.set(userId, voices);
     }
 
-    const filtered = result.data.voices
+    const filtered = voices
       .filter(v => v.slug.toLowerCase().includes(query) || v.voiceId.toLowerCase().includes(query))
       .slice(0, DISCORD_LIMITS.AUTOCOMPLETE_MAX_CHOICES);
 
@@ -102,4 +101,12 @@ export async function handleVoiceAutocomplete(interaction: AutocompleteInteracti
     logger.error({ err: error, userId }, '[Voices Autocomplete] Error');
     await interaction.respond([]);
   }
+}
+
+/**
+ * Clear the voice autocomplete cache.
+ * @internal For testing only
+ */
+export function _clearVoiceCacheForTesting(): void {
+  voiceCache.clear();
 }

--- a/services/bot-client/src/commands/settings/voices/types.ts
+++ b/services/bot-client/src/commands/settings/voices/types.ts
@@ -11,6 +11,6 @@ export interface VoiceEntry {
 
 export interface VoicesListResponse {
   voices: VoiceEntry[];
-  totalSlots: number;
+  totalVoices: number;
   tzurotCount: number;
 }

--- a/services/bot-client/src/commands/settings/voices/types.ts
+++ b/services/bot-client/src/commands/settings/voices/types.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared types for voice management commands.
+ * Matches the response shape from GET /user/voices gateway route.
+ */
+
+export interface VoiceEntry {
+  voiceId: string;
+  name: string;
+  slug: string;
+}
+
+export interface VoicesListResponse {
+  voices: VoiceEntry[];
+  totalSlots: number;
+  tzurotCount: number;
+}

--- a/services/bot-client/src/commands/settings/voices/voiceCache.test.ts
+++ b/services/bot-client/src/commands/settings/voices/voiceCache.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Tests for Voice Autocomplete Cache
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getCachedVoices,
+  setCachedVoices,
+  invalidateVoiceCache,
+  _clearVoiceCacheForTesting,
+} from './voiceCache.js';
+import type { VoiceEntry } from './types.js';
+
+describe('voiceCache', () => {
+  const voices: VoiceEntry[] = [
+    { voiceId: 'v1', name: 'tzurot-alice', slug: 'alice' },
+    { voiceId: 'v2', name: 'tzurot-bob', slug: 'bob' },
+  ];
+
+  beforeEach(() => {
+    _clearVoiceCacheForTesting();
+  });
+
+  it('should return null on cache miss', () => {
+    expect(getCachedVoices('user-123')).toBeNull();
+  });
+
+  it('should return cached voices after set', () => {
+    setCachedVoices('user-123', voices);
+    expect(getCachedVoices('user-123')).toEqual(voices);
+  });
+
+  it('should invalidate cache for a specific user', () => {
+    setCachedVoices('user-123', voices);
+    setCachedVoices('user-456', voices);
+
+    invalidateVoiceCache('user-123');
+
+    expect(getCachedVoices('user-123')).toBeNull();
+    expect(getCachedVoices('user-456')).toEqual(voices);
+  });
+
+  it('should clear all cached entries', () => {
+    setCachedVoices('user-123', voices);
+    setCachedVoices('user-456', voices);
+
+    _clearVoiceCacheForTesting();
+
+    expect(getCachedVoices('user-123')).toBeNull();
+    expect(getCachedVoices('user-456')).toBeNull();
+  });
+});

--- a/services/bot-client/src/commands/settings/voices/voiceCache.ts
+++ b/services/bot-client/src/commands/settings/voices/voiceCache.ts
@@ -1,0 +1,36 @@
+/**
+ * Voice Autocomplete Cache
+ *
+ * Shared TTLCache for voice autocomplete data. Both delete.ts (primary consumer)
+ * and clear.ts (invalidation after bulk delete) use this module, avoiding
+ * sibling coupling between the two command handlers.
+ */
+
+import { TTLCache } from '@tzurot/common-types';
+import type { VoiceEntry } from './types.js';
+
+/** Cache voice lists per user to avoid hitting ElevenLabs API on every autocomplete keystroke */
+const voiceCache = new TTLCache<VoiceEntry[]>({ ttl: 30_000, maxSize: 100 });
+
+/** Get cached voice list for a user. Returns null on cache miss. */
+export function getCachedVoices(userId: string): VoiceEntry[] | null {
+  return voiceCache.get(userId);
+}
+
+/** Cache a voice list for a user. */
+export function setCachedVoices(userId: string, voices: VoiceEntry[]): void {
+  voiceCache.set(userId, voices);
+}
+
+/** Invalidate a user's cached voice list (e.g., after delete or bulk clear). */
+export function invalidateVoiceCache(userId: string): void {
+  voiceCache.delete(userId);
+}
+
+/**
+ * Clear the entire voice autocomplete cache.
+ * @internal For testing only
+ */
+export function _clearVoiceCacheForTesting(): void {
+  voiceCache.clear();
+}

--- a/services/bot-client/src/handlers/__snapshots__/CommandHandler.int.test.ts.snap
+++ b/services/bot-client/src/handlers/__snapshots__/CommandHandler.int.test.ts.snap
@@ -949,6 +949,52 @@ exports[`CommandHandler (component) > command structure snapshots > should have 
     ],
     "type": 2,
   },
+  {
+    "description": "Manage your ElevenLabs cloned voices",
+    "description_localizations": undefined,
+    "name": "voices",
+    "name_localizations": undefined,
+    "options": [
+      {
+        "description": "Browse your cloned voices",
+        "description_localizations": undefined,
+        "name": "browse",
+        "name_localizations": undefined,
+        "options": [],
+        "type": 1,
+      },
+      {
+        "description": "Delete a single cloned voice",
+        "description_localizations": undefined,
+        "name": "delete",
+        "name_localizations": undefined,
+        "options": [
+          {
+            "autocomplete": true,
+            "choices": undefined,
+            "description": "The voice to delete",
+            "description_localizations": undefined,
+            "max_length": undefined,
+            "min_length": undefined,
+            "name": "voice",
+            "name_localizations": undefined,
+            "required": true,
+            "type": 3,
+          },
+        ],
+        "type": 1,
+      },
+      {
+        "description": "Delete all Tzurot cloned voices",
+        "description_localizations": undefined,
+        "name": "clear",
+        "name_localizations": undefined,
+        "options": [],
+        "type": 1,
+      },
+    ],
+    "type": 2,
+  },
 ]
 `;
 

--- a/services/bot-client/src/utils/userGatewayClient.test.ts
+++ b/services/bot-client/src/utils/userGatewayClient.test.ts
@@ -289,5 +289,13 @@ describe('userGatewayClient', () => {
     it('should have DEFERRED longer than AUTOCOMPLETE', () => {
       expect(GATEWAY_TIMEOUTS.DEFERRED).toBeGreaterThan(GATEWAY_TIMEOUTS.AUTOCOMPLETE);
     });
+
+    it('should have BULK_OPERATION timeout of 30000ms', () => {
+      expect(GATEWAY_TIMEOUTS.BULK_OPERATION).toBe(30000);
+    });
+
+    it('should have BULK_OPERATION longer than DEFERRED', () => {
+      expect(GATEWAY_TIMEOUTS.BULK_OPERATION).toBeGreaterThan(GATEWAY_TIMEOUTS.DEFERRED);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- **Thread `elevenlabsApiKey` through all STT callers** — `AudioTranscriptionJob`, `ConversationInputProcessor`, `ConversationalRAGService`, `AttachmentProcessor`, `ReferencedMessageFormatter`, `DependencyStep`, and `GenerationStep` now pass the user's ElevenLabs BYOK key through the entire transcription pipeline
- **Remove OpenAI Whisper fallback** — STT simplified to two tiers: ElevenLabs (BYOK) → voice-engine (free). Removes `OPENAI_API_KEY` env var entirely (only consumer was Whisper; embeddings are local). Removes `openai` dependency from ai-worker
- **Voice slot management UX** — New `/settings voices browse|delete|clear` commands for users to manage auto-cloned ElevenLabs voices. Gateway routes proxy ElevenLabs voice API with BYOK key decryption. `clear` uses destructive confirmation flow (button → modal → typed phrase)

## Commits

1. `feat(ai-worker): thread elevenlabsApiKey through AudioTranscriptionJob`
2. `feat(ai-worker): thread elevenlabsApiKey through inline STT callers`
3. `refactor(ai-worker): remove OpenAI Whisper fallback from AudioProcessor`
4. `chore: remove Whisper config, OPENAI_API_KEY, and stale references`
5. `feat(api-gateway): add voice management routes (/user/voices)`
6. `feat(bot-client): add /settings voices subcommand group`
7. `docs: update integration test snapshot, backlog, and proposal for Phase 4.5`
8. `fix(api-gateway): fix req.params type narrowing in voice delete route`

## Test plan

- [x] `pnpm test` — all unit tests pass (4118 bot-client + all other packages)
- [x] `pnpm quality` — lint, typecheck, depcruise, cpd all pass
- [x] `pnpm test:int` — integration test snapshots updated for new `voices` subcommand group (246 tests pass)
- [x] Pre-push hooks pass (20/20 tasks, 0 dependency violations)
- [ ] Grep confirms no remaining `OPENAI_API_KEY` references in source
- [ ] Grep confirms no remaining Whisper code (only benign test fixture strings)
- [ ] Manual test: `/settings voices browse` shows voice list
- [ ] Manual test: `/settings voices delete` with autocomplete
- [ ] Manual test: `/settings voices clear` destructive confirmation flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)