### PR TITLE
fix(ai-worker): typed TimeoutError sentinel for withTimeout

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -514,9 +514,11 @@ Auto-inject `[ServiceName]` prefix in logs instead of hardcoding in every log ca
 - [ ] Remove manual `[ServiceName]` prefixes from log messages
 - [ ] Consider structured `service` field instead of string prefix
 
-#### 🏗️ Typed Sentinel Error for `withTimeout`
+#### 🏗️ ~~Typed Sentinel Error for `withTimeout`~~ ✅ Done (#732)
 
-`KeyValidationService` detects timeouts via `error.message.includes('timed out')` — fragile if the message text changes. Replace with a typed `TimeoutError` class thrown by `withTimeout()` so callers can use `instanceof` checks. Affects both OpenRouter and ElevenLabs validation paths. Discovered during PR #727 review.
+#### 🏗️ Audit Manual Timeout Throws for Typed Sentinels
+
+Several places construct raw `Error`s for timeouts outside of `withTimeout`: `LocalEmbeddingService.ts:182`, `TTSStep.ts:168`, `AudioProcessor.ts:36`, `VoiceEngineClient.ts:194`. Audit these for the same `instanceof`-friendly treatment. Discovered during PR #732 review.
 
 #### 🏗️ Audit Error Sanitization in Log Pipeline
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -518,7 +518,7 @@ Auto-inject `[ServiceName]` prefix in logs instead of hardcoding in every log ca
 
 #### 🏗️ Audit Manual Timeout Throws for Typed Sentinels
 
-Several places construct raw `Error`s for timeouts outside of `withTimeout`: `LocalEmbeddingService.ts:182`, `TTSStep.ts:168`, `AudioProcessor.ts:36`, `VoiceEngineClient.ts:194`. Audit these for the same `instanceof`-friendly treatment. Discovered during PR #732 review.
+Several places construct raw `Error`s for timeouts outside of `withTimeout`: `LocalEmbeddingService.ts:182`, `TTSStep.ts:168`, `AudioProcessor.ts:36`, `VoiceEngineClient.ts:194`. Audit these for the same `instanceof`-friendly treatment. Also consider making `ElevenLabsTimeoutError extends TimeoutError` so callers can `instanceof TimeoutError` as a catch-all across both ElevenLabs and general timeout paths. Discovered during PR #732 review.
 
 #### 🏗️ Audit Error Sanitization in Log Pipeline
 

--- a/services/ai-worker/src/services/KeyValidationService.test.ts
+++ b/services/ai-worker/src/services/KeyValidationService.test.ts
@@ -29,6 +29,10 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
+/** Sentinel message thrown by tests to trigger the mock's timeout path.
+ * Only used in this test file — not a real error from any production code. */
+const MOCK_TIMEOUT_SIGNAL = 'MOCK_TIMEOUT_SIGNAL';
+
 // Mock withTimeout while preserving real TimeoutError class for instanceof checks
 vi.mock('../utils/retry.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../utils/retry.js')>();
@@ -43,7 +47,7 @@ vi.mock('../utils/retry.js', async importOriginal => {
       try {
         return await fn(controller.signal);
       } catch (error) {
-        if (error instanceof Error && error.message === 'TIMEOUT') {
+        if (error instanceof Error && error.message === MOCK_TIMEOUT_SIGNAL) {
           throw new actual.TimeoutError(timeout, operation, error);
         }
         throw error;
@@ -162,7 +166,7 @@ describe('KeyValidationService', () => {
       });
 
       it('should handle timeout errors', async () => {
-        mockFetch.mockRejectedValue(new Error('TIMEOUT'));
+        mockFetch.mockRejectedValue(new Error(MOCK_TIMEOUT_SIGNAL));
 
         const result = await service.validateKey('sk-or-slow', AIProvider.OpenRouter);
 
@@ -237,7 +241,7 @@ describe('KeyValidationService', () => {
       });
 
       it('should handle timeout errors', async () => {
-        mockFetch.mockRejectedValue(new Error('TIMEOUT'));
+        mockFetch.mockRejectedValue(new Error(MOCK_TIMEOUT_SIGNAL));
 
         const result = await service.validateKey('sk_slow', AIProvider.ElevenLabs);
 

--- a/services/ai-worker/src/services/KeyValidationService.test.ts
+++ b/services/ai-worker/src/services/KeyValidationService.test.ts
@@ -29,12 +29,14 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
-// Mock the retry withTimeout function
-vi.mock('../utils/retry.js', async () => {
+// Mock withTimeout while preserving real TimeoutError class for instanceof checks
+vi.mock('../utils/retry.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../utils/retry.js')>();
   return {
+    ...actual,
     withTimeout: async <T>(
       fn: (signal: AbortSignal) => Promise<T>,
-      _timeout: number,
+      timeout: number,
       operation: string
     ): Promise<T> => {
       const controller = new AbortController();
@@ -42,7 +44,7 @@ vi.mock('../utils/retry.js', async () => {
         return await fn(controller.signal);
       } catch (error) {
         if (error instanceof Error && error.message === 'TIMEOUT') {
-          throw new Error(`${operation} timed out`);
+          throw new actual.TimeoutError(timeout, operation, error);
         }
         throw error;
       }

--- a/services/ai-worker/src/services/KeyValidationService.ts
+++ b/services/ai-worker/src/services/KeyValidationService.ts
@@ -11,7 +11,7 @@
  */
 
 import { createLogger, AIProvider, AI_ENDPOINTS, VALIDATION_TIMEOUTS } from '@tzurot/common-types';
-import { withTimeout } from '../utils/retry.js';
+import { withTimeout, TimeoutError } from '../utils/retry.js';
 
 const logger = createLogger('KeyValidationService');
 
@@ -242,7 +242,7 @@ export class KeyValidationService {
         metadata: { creditBalance: calculateCreditBalance(data?.data) },
       };
     } catch (error) {
-      if (error instanceof Error && error.message.includes('timed out')) {
+      if (error instanceof TimeoutError) {
         throw new ValidationTimeoutError(provider);
       }
       throw error;
@@ -309,7 +309,7 @@ export class KeyValidationService {
         metadata: { creditBalance: remaining },
       };
     } catch (error) {
-      if (error instanceof Error && error.message.includes('timed out')) {
+      if (error instanceof TimeoutError) {
         throw new ValidationTimeoutError(provider);
       }
       throw error;

--- a/services/ai-worker/src/services/voice/VoiceRegistrationService.test.ts
+++ b/services/ai-worker/src/services/voice/VoiceRegistrationService.test.ts
@@ -8,6 +8,7 @@ import { VoiceEngineError } from './VoiceEngineClient.js';
 import type { VoiceEngineClient } from './VoiceEngineClient.js';
 import type { EnvConfig } from '@tzurot/common-types';
 import * as commonTypes from '@tzurot/common-types';
+import { TimeoutError } from '../../utils/retry.js';
 
 // Mock global fetch
 const mockFetch = vi.fn();
@@ -161,15 +162,17 @@ describe('VoiceRegistrationService', () => {
     );
   });
 
-  it('should throw descriptive error when gateway fetch times out', async () => {
+  it('should throw typed TimeoutError when gateway fetch times out', async () => {
     mockVoiceEngineClient.listVoices.mockResolvedValue([]);
 
     const timeoutError = new DOMException('The operation timed out', 'TimeoutError');
     mockFetch.mockRejectedValue(timeoutError);
 
-    await expect(service.ensureVoiceRegistered('slow-voice')).rejects.toThrow(
-      'Gateway fetch timed out for voice reference "slow-voice"'
-    );
+    const error = await service.ensureVoiceRegistered('slow-voice').catch(e => e);
+
+    expect(error).toBeInstanceOf(TimeoutError);
+    expect((error as TimeoutError).operationName).toBe('voice reference fetch for "slow-voice"');
+    expect((error as TimeoutError).timeoutMs).toBe(15_000);
   });
 
   it('should cache failure and reject immediately on retry (negative caching)', async () => {

--- a/services/ai-worker/src/services/voice/voiceReferenceHelper.test.ts
+++ b/services/ai-worker/src/services/voice/voiceReferenceHelper.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TimeoutError } from '../../utils/retry.js';
 
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal<typeof import('@tzurot/common-types')>();
@@ -62,13 +63,17 @@ describe('fetchVoiceReference', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it('throws timeout error on TimeoutError', async () => {
+  it('throws typed TimeoutError on AbortSignal timeout', async () => {
+    // AbortSignal.timeout() throws a DOMException with name 'TimeoutError'
     const timeoutError = new DOMException('The operation timed out', 'TimeoutError');
     mockFetch.mockRejectedValue(timeoutError);
 
-    await expect(fetchVoiceReference('test-slug')).rejects.toThrow(
-      'Gateway fetch timed out for voice reference "test-slug"'
-    );
+    const error = await fetchVoiceReference('test-slug').catch(e => e);
+
+    expect(error).toBeInstanceOf(TimeoutError);
+    expect((error as TimeoutError).timeoutMs).toBe(15_000);
+    expect((error as TimeoutError).operationName).toBe('voice reference fetch for "test-slug"');
+    expect((error as TimeoutError).cause).toBe(timeoutError);
   });
 
   it('re-throws non-abort fetch errors', async () => {

--- a/services/ai-worker/src/services/voice/voiceReferenceHelper.ts
+++ b/services/ai-worker/src/services/voice/voiceReferenceHelper.ts
@@ -7,6 +7,7 @@
  */
 
 import { createLogger, getConfig } from '@tzurot/common-types';
+import { TimeoutError } from '../../utils/retry.js';
 
 const logger = createLogger('VoiceReferenceHelper');
 
@@ -35,8 +36,15 @@ export async function fetchVoiceReference(slug: string): Promise<VoiceReferenceR
       signal: AbortSignal.timeout(VOICE_REFERENCE_TIMEOUT_MS),
     });
   } catch (error) {
+    // AbortSignal.timeout() throws a DOMException with name 'TimeoutError' — that's
+    // the Web API sentinel, not our custom TimeoutError. Detect by name string, then
+    // re-throw as our typed sentinel so callers can use instanceof.
     if (error instanceof Error && error.name === 'TimeoutError') {
-      throw new Error(`Gateway fetch timed out for voice reference "${slug}"`, { cause: error });
+      throw new TimeoutError(
+        VOICE_REFERENCE_TIMEOUT_MS,
+        `voice reference fetch for "${slug}"`,
+        error
+      );
     }
     throw error;
   }

--- a/services/ai-worker/src/utils/retry.test.ts
+++ b/services/ai-worker/src/utils/retry.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Logger } from 'pino';
-import { withRetry, withTimeout, RetryError } from './retry.js';
+import { withRetry, withTimeout, RetryError, TimeoutError } from './retry.js';
 
 describe('retryService', () => {
   let mockLogger: Logger;
@@ -399,7 +399,7 @@ describe('retryService', () => {
       expect(fn).toHaveBeenCalledWith(expect.any(AbortSignal));
     });
 
-    it('should throw timeout error if operation exceeds timeout', async () => {
+    it('should throw TimeoutError if operation exceeds timeout', async () => {
       const timeoutMs = 50;
 
       // A function that never resolves, simulating a long-running operation
@@ -417,14 +417,19 @@ describe('retryService', () => {
       const promise = withTimeout(fn, timeoutMs, 'test-operation');
 
       // Attach handler before advancing timers
-      const assertionPromise = expect(promise).rejects.toThrow(
-        'test-operation timed out after 50ms'
-      );
+      const assertionPromise = expect(promise).rejects.toThrow(TimeoutError);
 
       // Advance timers to trigger the timeout
       await vi.advanceTimersByTimeAsync(timeoutMs);
 
       await assertionPromise;
+
+      // Verify TimeoutError properties (reuse the caught error from the same promise)
+      await expect(promise).rejects.toMatchObject({
+        timeoutMs: 50,
+        message: 'test-operation timed out after 50ms',
+        name: 'TimeoutError',
+      });
     });
 
     it('should propagate non-timeout errors', async () => {

--- a/services/ai-worker/src/utils/retry.test.ts
+++ b/services/ai-worker/src/utils/retry.test.ts
@@ -416,20 +416,24 @@ describe('retryService', () => {
 
       const promise = withTimeout(fn, timeoutMs, 'test-operation');
 
-      // Attach handler before advancing timers
-      const assertionPromise = expect(promise).rejects.toThrow(TimeoutError);
+      // Attach rejection handler before advancing timers to avoid unhandled rejection
+      let caught: unknown;
+      const catcher = promise.catch(e => {
+        caught = e;
+      });
 
       // Advance timers to trigger the timeout
       await vi.advanceTimersByTimeAsync(timeoutMs);
+      await catcher;
 
-      await assertionPromise;
-
-      // Verify TimeoutError properties (reuse the caught error from the same promise)
-      await expect(promise).rejects.toMatchObject({
-        timeoutMs: 50,
-        message: 'test-operation timed out after 50ms',
-        name: 'TimeoutError',
-      });
+      // Verify typed sentinel and all properties in one place
+      expect(caught).toBeInstanceOf(TimeoutError);
+      const err = caught as TimeoutError;
+      expect(err.timeoutMs).toBe(50);
+      expect(err.operationName).toBe('test-operation');
+      expect(err.message).toBe('test-operation timed out after 50ms');
+      expect(err.name).toBe('TimeoutError');
+      expect(err.cause).toBeDefined();
     });
 
     it('should propagate non-timeout errors', async () => {

--- a/services/ai-worker/src/utils/retry.ts
+++ b/services/ai-worker/src/utils/retry.ts
@@ -79,7 +79,7 @@ export class RetryError extends Error {
 export class TimeoutError extends Error {
   constructor(
     public readonly timeoutMs: number,
-    operationName: string,
+    public readonly operationName: string,
     cause: Error
   ) {
     super(`${operationName} timed out after ${timeoutMs}ms`, { cause });

--- a/services/ai-worker/src/utils/retry.ts
+++ b/services/ai-worker/src/utils/retry.ts
@@ -82,10 +82,8 @@ export class TimeoutError extends Error {
     public readonly operationName: string,
     cause?: Error
   ) {
-    super(
-      `${operationName} timed out after ${timeoutMs}ms`,
-      ...(cause !== undefined ? [{ cause }] : [])
-    );
+    // Error superclass ignores undefined cause, so passing { cause } is safe either way
+    super(`${operationName} timed out after ${timeoutMs}ms`, { cause });
     this.name = 'TimeoutError';
   }
 }
@@ -380,8 +378,8 @@ export async function withTimeout<T>(
     return result;
   } catch (error) {
     clearTimeout(timeoutId);
-    if ((error as Error).name === 'AbortError') {
-      throw new TimeoutError(timeoutMs, operationName, error as Error);
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new TimeoutError(timeoutMs, operationName, error);
     }
     throw error;
   }

--- a/services/ai-worker/src/utils/retry.ts
+++ b/services/ai-worker/src/utils/retry.ts
@@ -75,14 +75,17 @@ export class RetryError extends Error {
 
 /** Typed sentinel for {@link withTimeout} — replaces fragile message-string
  * matching (`error.message.includes('timed out')`) with `instanceof` checks.
- * Preserves the original `AbortError` as `cause` for debugging. */
+ * Preserves the original `AbortError` as `cause` for debugging when available. */
 export class TimeoutError extends Error {
   constructor(
     public readonly timeoutMs: number,
     public readonly operationName: string,
-    cause: Error
+    cause?: Error
   ) {
-    super(`${operationName} timed out after ${timeoutMs}ms`, { cause });
+    super(
+      `${operationName} timed out after ${timeoutMs}ms`,
+      ...(cause !== undefined ? [{ cause }] : [])
+    );
     this.name = 'TimeoutError';
   }
 }

--- a/services/ai-worker/src/utils/retry.ts
+++ b/services/ai-worker/src/utils/retry.ts
@@ -73,6 +73,20 @@ export class RetryError extends Error {
   }
 }
 
+/** Typed sentinel for {@link withTimeout} — replaces fragile message-string
+ * matching (`error.message.includes('timed out')`) with `instanceof` checks.
+ * Preserves the original `AbortError` as `cause` for debugging. */
+export class TimeoutError extends Error {
+  constructor(
+    public readonly timeoutMs: number,
+    operationName: string,
+    cause: Error
+  ) {
+    super(`${operationName} timed out after ${timeoutMs}ms`, { cause });
+    this.name = 'TimeoutError';
+  }
+}
+
 /**
  * Normalize a caught error for Pino logging.
  *
@@ -364,7 +378,7 @@ export async function withTimeout<T>(
   } catch (error) {
     clearTimeout(timeoutId);
     if ((error as Error).name === 'AbortError') {
-      throw new Error(`${operationName} timed out after ${timeoutMs}ms`, { cause: error });
+      throw new TimeoutError(timeoutMs, operationName, error as Error);
     }
     throw error;
   }


### PR DESCRIPTION
## Summary

- Add `TimeoutError` class to `retry.ts` — `withTimeout()` now throws a typed sentinel instead of a generic `Error` with "timed out" in the message
- Update `KeyValidationService.ts` to use `instanceof TimeoutError` instead of `error.message.includes('timed out')` for both OpenRouter and ElevenLabs validation paths
- Follows the same pattern as `ElevenLabsTimeoutError` from PR #731

## Test plan

- [x] `retry.test.ts` updated — asserts `instanceof TimeoutError` + verifies `timeoutMs` and `message` properties
- [x] `KeyValidationService.test.ts` updated — mock uses real `TimeoutError` via `importOriginal` so `instanceof` works under test
- [x] All 2413 unit tests pass
- [x] Quality suite clean (lint, CPD, depcruise, typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)