### PR TITLE
feat: voice pipeline hardening

### DIFF
--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.test.ts
@@ -66,10 +66,14 @@ vi.mock('../../../../services/voice/ElevenLabsVoiceService.js', () => ({
 
 const mockElevenLabsTTS = vi.fn();
 
+// Import the real TimeoutError — withRetry/RetryError use the real module (no mock),
+// so the mock subclass must extend the real base for instanceof checks to work.
+const { TimeoutError: RealTimeoutError } = await import('../../../../utils/retry.js');
+
 /** Typed sentinel for ElevenLabs timeout errors (instanceof check in retry logic) */
-class MockElevenLabsTimeoutError extends Error {
+class MockElevenLabsTimeoutError extends RealTimeoutError {
   constructor(timeoutMs: number) {
-    super(`ElevenLabs request timed out after ${timeoutMs}ms`);
+    super(timeoutMs, 'ElevenLabs API request');
     this.name = 'ElevenLabsTimeoutError';
   }
 }

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts
@@ -23,7 +23,7 @@ import {
   ElevenLabsApiError,
   ElevenLabsTimeoutError,
 } from '../../../../services/voice/ElevenLabsClient.js';
-import { withRetry, RetryError } from '../../../../utils/retry.js';
+import { withRetry, RetryError, TimeoutError } from '../../../../utils/retry.js';
 import { redisService } from '../../../../redis.js';
 
 const logger = createLogger('TTSStep');
@@ -165,7 +165,7 @@ export class TTSStep implements IPipelineStep {
         new Promise<null>((_, reject) => {
           timeoutId = setTimeout(() => {
             timedOut = true;
-            reject(new Error(`TTS timed out after ${TTS_TIMEOUT_MS}ms`));
+            reject(new TimeoutError(TTS_TIMEOUT_MS, 'TTS processing'));
           }, TTS_TIMEOUT_MS);
         }),
       ]);

--- a/services/ai-worker/src/services/multimodal/AudioProcessor.test.ts
+++ b/services/ai-worker/src/services/multimodal/AudioProcessor.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { transcribeAudio } from './AudioProcessor.js';
 import type { AttachmentMetadata } from '@tzurot/common-types';
 import { CONTENT_TYPES } from '@tzurot/common-types';
+import { TimeoutError } from '../../utils/retry.js';
 
 // Create mock functions
 const mockVoiceTranscriptCacheGet = vi.fn().mockResolvedValue(null);
@@ -392,7 +393,7 @@ describe('AudioProcessor', () => {
         );
       });
 
-      it('should handle fetch timeout with AbortError', async () => {
+      it('should throw TimeoutError on fetch abort', async () => {
         const attachment: AttachmentMetadata = {
           url: 'https://example.com/audio.ogg',
           name: 'audio.ogg',
@@ -404,7 +405,10 @@ describe('AudioProcessor', () => {
         abortError.name = 'AbortError';
         (global.fetch as any).mockRejectedValue(abortError);
 
-        await expect(transcribeAudio(attachment)).rejects.toThrow('Audio file download timed out');
+        const error = await transcribeAudio(attachment).catch(e => e);
+        expect(error).toBeInstanceOf(TimeoutError);
+        expect(error.operationName).toBe('audio file download');
+        expect(error.timeoutMs).toBe(30_000);
       });
     });
 

--- a/services/ai-worker/src/services/multimodal/AudioProcessor.ts
+++ b/services/ai-worker/src/services/multimodal/AudioProcessor.ts
@@ -8,6 +8,7 @@
  */
 
 import { createLogger, TIMEOUTS, type AttachmentMetadata } from '@tzurot/common-types';
+import { TimeoutError } from '../../utils/retry.js';
 import { VoiceEngineError, getVoiceEngineClient } from '../voice/VoiceEngineClient.js';
 import { waitForVoiceEngine } from '../voice/voiceEngineWarmup.js';
 import { elevenLabsSTT, ElevenLabsApiError } from '../voice/ElevenLabsClient.js';
@@ -33,9 +34,7 @@ async function fetchAudioBuffer(url: string): Promise<ArrayBuffer> {
     return await response.arrayBuffer();
   } catch (error) {
     if (error instanceof Error && error.name === 'AbortError') {
-      throw new Error(`Audio file download timed out after ${TIMEOUTS.AUDIO_FETCH}ms`, {
-        cause: error,
-      });
+      throw new TimeoutError(TIMEOUTS.AUDIO_FETCH, 'audio file download', error);
     }
     throw error;
   } finally {

--- a/services/ai-worker/src/services/voice/ElevenLabsClient.test.ts
+++ b/services/ai-worker/src/services/voice/ElevenLabsClient.test.ts
@@ -16,6 +16,7 @@ import {
   ElevenLabsApiError,
   ElevenLabsTimeoutError,
 } from './ElevenLabsClient.js';
+import { TimeoutError } from '../../utils/retry.js';
 
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal<typeof import('@tzurot/common-types')>();
@@ -131,6 +132,23 @@ describe('ElevenLabsClient', () => {
       await expect(
         elevenLabsTTS({ text: 'test', voiceId: 'v1', apiKey: 'sk_test' })
       ).rejects.toThrow(ElevenLabsTimeoutError);
+    });
+
+    it('should throw error that is also instanceof TimeoutError (base class)', async () => {
+      const abortError = new Error('Aborted');
+      abortError.name = 'AbortError';
+      mockFetch.mockRejectedValue(abortError);
+
+      const error = await elevenLabsTTS({
+        text: 'test',
+        voiceId: 'v1',
+        apiKey: 'sk_test',
+      }).catch(e => e);
+
+      expect(error).toBeInstanceOf(ElevenLabsTimeoutError);
+      expect(error).toBeInstanceOf(TimeoutError);
+      expect(error.timeoutMs).toBe(60_000);
+      expect(error.operationName).toBe('ElevenLabs API request');
     });
   });
 

--- a/services/ai-worker/src/services/voice/ElevenLabsClient.ts
+++ b/services/ai-worker/src/services/voice/ElevenLabsClient.ts
@@ -281,7 +281,9 @@ export async function elevenLabsListVoices(apiKey: string): Promise<ElevenLabsVo
  *
  * NOTE: api-gateway has a parallel implementation in routes/user/voiceModels.ts that
  * fetches and filters models the same way (can_do_text_to_speech === true). If the
- * filter logic changes, update both places.
+ * filter logic changes, update both places. Validation differs by design: this path
+ * uses manual Array.isArray() and returns [] on unexpected shapes (silent degradation),
+ * while api-gateway uses Zod and surfaces parse failures as 500 errors to the caller.
  */
 export async function elevenLabsListModels(apiKey: string): Promise<ElevenLabsModelInfo[]> {
   const response = await elevenLabsFetch(

--- a/services/ai-worker/src/services/voice/ElevenLabsClient.ts
+++ b/services/ai-worker/src/services/voice/ElevenLabsClient.ts
@@ -14,6 +14,7 @@
  */
 
 import { createLogger, AI_ENDPOINTS } from '@tzurot/common-types';
+import { TimeoutError } from '../../utils/retry.js';
 
 const logger = createLogger('ElevenLabsClient');
 
@@ -69,9 +70,9 @@ export interface ElevenLabsModelInfo {
 
 /** Error thrown when an ElevenLabs API call times out (AbortController fires).
  * Typed sentinel replaces fragile message-string matching in retry logic. */
-export class ElevenLabsTimeoutError extends Error {
+export class ElevenLabsTimeoutError extends TimeoutError {
   constructor(timeoutMs: number, cause: Error) {
-    super(`ElevenLabs request timed out after ${timeoutMs}ms`, { cause });
+    super(timeoutMs, 'ElevenLabs API request', cause);
     this.name = 'ElevenLabsTimeoutError';
   }
 }

--- a/services/ai-worker/src/services/voice/VoiceEngineClient.test.ts
+++ b/services/ai-worker/src/services/voice/VoiceEngineClient.test.ts
@@ -10,6 +10,7 @@ import {
 } from './VoiceEngineClient.js';
 import * as commonTypes from '@tzurot/common-types';
 import type { EnvConfig } from '@tzurot/common-types';
+import { TimeoutError } from '../../utils/retry.js';
 
 // Mock global fetch
 const mockFetch = vi.fn();
@@ -216,16 +217,19 @@ describe('VoiceEngineClient', () => {
       vi.useRealTimers();
     });
 
-    it('should throw descriptive error on timeout', async () => {
+    it('should throw TimeoutError on abort', async () => {
       const shortTimeoutClient = new VoiceEngineClient('http://voice-engine:8000', 'test-key', 100);
 
       const abortError = new Error('The operation was aborted');
       abortError.name = 'AbortError';
       mockFetch.mockRejectedValue(abortError);
 
-      await expect(
-        shortTimeoutClient.transcribe(Buffer.from('fake-audio'), 'test.wav', 'audio/wav')
-      ).rejects.toThrow('Voice engine request timed out');
+      const error = await shortTimeoutClient
+        .transcribe(Buffer.from('fake-audio'), 'test.wav', 'audio/wav')
+        .catch(e => e);
+      expect(error).toBeInstanceOf(TimeoutError);
+      expect(error.timeoutMs).toBe(100);
+      expect(error.operationName).toBe('voice engine request');
     });
 
     it('should abort request after configured timeout delay', async () => {
@@ -248,7 +252,7 @@ describe('VoiceEngineClient', () => {
       );
 
       const promise = shortTimeoutClient.transcribe(Buffer.from('audio'), 'test.wav', 'audio/wav');
-      const assertion = expect(promise).rejects.toThrow('Voice engine request timed out');
+      const assertion = expect(promise).rejects.toThrow(TimeoutError);
       await vi.advanceTimersByTimeAsync(1001);
       await assertion;
     });

--- a/services/ai-worker/src/services/voice/VoiceEngineClient.ts
+++ b/services/ai-worker/src/services/voice/VoiceEngineClient.ts
@@ -6,6 +6,7 @@
  */
 
 import { createLogger, getConfig, TIMEOUTS } from '@tzurot/common-types';
+import { TimeoutError } from '../../utils/retry.js';
 
 const logger = createLogger('VoiceEngineClient');
 
@@ -191,9 +192,7 @@ export class VoiceEngineClient {
       });
     } catch (error) {
       if (error instanceof Error && error.name === 'AbortError') {
-        throw new Error(`Voice engine request timed out after ${effectiveTimeout}ms`, {
-          cause: error,
-        });
+        throw new TimeoutError(effectiveTimeout, 'voice engine request', error);
       }
       throw error;
     } finally {

--- a/services/api-gateway/src/routes/user/voiceModels.test.ts
+++ b/services/api-gateway/src/routes/user/voiceModels.test.ts
@@ -33,7 +33,7 @@ const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
 import { decryptApiKey } from '@tzurot/common-types';
-import { handleListModels } from './voiceModels.js';
+import { handleListModels, resetModelCache } from './voiceModels.js';
 import { requireUserAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import type { AuthenticatedRequest } from '../../types.js';
@@ -53,6 +53,7 @@ describe('Voice Models Route', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    resetModelCache();
 
     app = express();
     app.get(
@@ -139,5 +140,60 @@ describe('Voice Models Route', () => {
     const response = await request(app).get('/models');
 
     expect(response.status).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
+  });
+
+  it('should return cached models on second call without re-fetching', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          {
+            model_id: 'eleven_multilingual_v2',
+            name: 'Multilingual v2',
+            can_do_text_to_speech: true,
+          },
+        ]),
+    });
+
+    // First call — cache miss, fetches from ElevenLabs
+    const first = await request(app).get('/models');
+    expect(first.status).toBe(StatusCodes.OK);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Second call — cache hit, no new fetch
+    const second = await request(app).get('/models');
+    expect(second.status).toBe(StatusCodes.OK);
+    expect(second.body.models).toEqual([
+      { modelId: 'eleven_multilingual_v2', name: 'Multilingual v2' },
+    ]);
+    expect(mockFetch).toHaveBeenCalledTimes(1); // still 1 — served from cache
+  });
+
+  it('should re-fetch after cache is cleared (simulates expiry)', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          {
+            model_id: 'eleven_multilingual_v2',
+            name: 'Multilingual v2',
+            can_do_text_to_speech: true,
+          },
+        ]),
+    });
+
+    // First call — fills cache
+    const first = await request(app).get('/models');
+    expect(first.status).toBe(StatusCodes.OK);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Simulate cache expiry (lru-cache caches performance.now at load time,
+    // so vi.useFakeTimers doesn't advance its internal clock)
+    resetModelCache();
+
+    // Next call — cache cleared, re-fetches
+    const second = await request(app).get('/models');
+    expect(second.status).toBe(StatusCodes.OK);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/services/api-gateway/src/routes/user/voiceModels.test.ts
+++ b/services/api-gateway/src/routes/user/voiceModels.test.ts
@@ -32,7 +32,6 @@ vi.mock('../../services/AuthMiddleware.js', () => ({
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
-import { decryptApiKey } from '@tzurot/common-types';
 import { handleListModels, resetModelCache } from './voiceModels.js';
 import { requireUserAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
@@ -68,8 +67,6 @@ describe('Voice Models Route', () => {
       id: 'user-uuid-123',
       apiKeys: [{ iv: 'mock-iv', content: 'mock-content', tag: 'mock-tag' }],
     });
-
-    vi.mocked(decryptApiKey).mockReturnValue('test-elevenlabs-key');
   });
 
   it('should return TTS-capable models', async () => {

--- a/services/api-gateway/src/routes/user/voiceModels.ts
+++ b/services/api-gateway/src/routes/user/voiceModels.ts
@@ -9,7 +9,7 @@
  */
 
 import { z } from 'zod';
-import { createLogger, type PrismaClient } from '@tzurot/common-types';
+import { createLogger, TTLCache, type PrismaClient } from '@tzurot/common-types';
 import type { Response as ExpressResponse } from 'express';
 import { resolveElevenLabsKey } from '../../utils/elevenLabsKeyResolver.js';
 import { fetchFromElevenLabs } from '../../utils/elevenLabsFetch.js';
@@ -17,6 +17,23 @@ import { sendCustomSuccess, sendError } from '../../utils/responseHelpers.js';
 import type { AuthenticatedRequest } from '../../types.js';
 
 const logger = createLogger('VoiceModelsRoute');
+
+interface CachedModelList {
+  models: { modelId: string; name: string }[];
+}
+
+const MODEL_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+const MODEL_CACHE_MAX_SIZE = 50; // max user entries
+
+const modelCache = new TTLCache<CachedModelList>({
+  ttl: MODEL_CACHE_TTL,
+  maxSize: MODEL_CACHE_MAX_SIZE,
+});
+
+/** Reset cache — exported for tests */
+export function resetModelCache(): void {
+  modelCache.clear();
+}
 
 /** Zod schema for ElevenLabs model list response */
 const ElevenLabsModelSchema = z.object({
@@ -47,6 +64,14 @@ export async function handleListModels(
     return;
   }
 
+  // Check cache before making external API call
+  const cached = modelCache.get(discordUserId);
+  if (cached !== null) {
+    logger.debug({ discordUserId }, '[Models] Cache hit for ElevenLabs models');
+    sendCustomSuccess(res, cached);
+    return;
+  }
+
   const result = await fetchFromElevenLabs({
     endpoint: '/models',
     apiKey: keyResult.apiKey,
@@ -68,5 +93,7 @@ export async function handleListModels(
     '[Models] Listed ElevenLabs TTS models'
   );
 
-  sendCustomSuccess(res, { models: ttsModels });
+  const modelResult = { models: ttsModels };
+  modelCache.set(discordUserId, modelResult);
+  sendCustomSuccess(res, modelResult);
 }

--- a/services/api-gateway/src/routes/user/voiceModels.ts
+++ b/services/api-gateway/src/routes/user/voiceModels.ts
@@ -58,17 +58,19 @@ export async function handleListModels(
 ): Promise<void> {
   const discordUserId = req.userId;
 
-  const keyResult = await resolveElevenLabsKey(prisma, discordUserId);
-  if ('errorResponse' in keyResult) {
-    sendError(res, keyResult.errorResponse);
-    return;
-  }
-
-  // Check cache before making external API call
+  // Check cache before DB + external API calls. The 5-min TTL means a revoked
+  // key could serve stale (but benign) model list data briefly — acceptable
+  // tradeoff for skipping a DB round-trip on every cache hit.
   const cached = modelCache.get(discordUserId);
   if (cached !== null) {
     logger.debug({ discordUserId }, '[Models] Cache hit for ElevenLabs models');
     sendCustomSuccess(res, cached);
+    return;
+  }
+
+  const keyResult = await resolveElevenLabsKey(prisma, discordUserId);
+  if ('errorResponse' in keyResult) {
+    sendError(res, keyResult.errorResponse);
     return;
   }
 

--- a/services/api-gateway/src/routes/user/voiceModels.ts
+++ b/services/api-gateway/src/routes/user/voiceModels.ts
@@ -49,7 +49,9 @@ const ElevenLabsModelsResponseSchema = z.array(ElevenLabsModelSchema);
  *
  * NOTE: ai-worker has a parallel implementation in services/voice/ElevenLabsClient.ts
  * (elevenLabsListModels) that filters models the same way (can_do_text_to_speech === true).
- * If the filter logic changes, update both places.
+ * If the filter logic changes, update both places. Validation differs by design: this
+ * path uses Zod and surfaces parse failures as 500 errors, while ai-worker uses manual
+ * Array.isArray() and returns [] on unexpected shapes (silent degradation for job context).
  */
 export async function handleListModels(
   prisma: PrismaClient,


### PR DESCRIPTION
## Summary

- **TimeoutError type safety**: Convert 4 remaining manual timeout throws in ai-worker to use the typed `TimeoutError` sentinel from `retry.ts`. `ElevenLabsTimeoutError` now extends `TimeoutError` (instanceof both). Eliminates fragile message-string matching for timeout detection across `AudioProcessor`, `VoiceEngineClient`, and `TTSStep`.
- **Model list caching**: Add 5-minute `TTLCache` to `GET /voice/models` endpoint in api-gateway, keyed by user ID. Avoids redundant ElevenLabs API calls when the model list rarely changes.

## Test plan

- [x] `ElevenLabsClient` — new test verifies `instanceof TimeoutError` on the subclass
- [x] `AudioProcessor` — timeout test updated to assert `TimeoutError` with property checks
- [x] `VoiceEngineClient` — timeout tests updated to assert `TimeoutError` with property checks
- [x] `TTSStep` — mock `ElevenLabsTimeoutError` updated to extend real `TimeoutError`
- [x] `voiceModels` — cache hit test (no re-fetch on 2nd call), cache clear re-fetch test
- [x] Full suite: 2414 tests pass, `pnpm quality` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)