### PR TITLE
fix(bot-client,ai-worker): voice pipeline resilience for cold starts

### DIFF
--- a/packages/common-types/src/constants/timing.ts
+++ b/packages/common-types/src/constants/timing.ts
@@ -35,6 +35,10 @@ export const TIMEOUTS = {
   SYSTEM_OVERHEAD: 15000,
   /** Job wait timeout in gateway (10 minutes - Railway safety buffer) */
   JOB_WAIT: 600000,
+  /** Client-side timeout for STT transcription gateway requests (2 minutes).
+   * Shorter than JOB_WAIT to provide timely user feedback on failure.
+   * Covers: cold start warmup (~75s) + audio fetch (~30s) + transcription (~15s). */
+  STT_GATEWAY: 120_000,
   /** BullMQ worker lock duration - maximum time a job can run before being considered stalled (20 minutes - safety net for hung jobs) */
   WORKER_LOCK_DURATION: 20 * 60 * 1000,
 } as const;

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.test.ts
@@ -929,7 +929,7 @@ describe('TTSStep', () => {
       expect(result.result?.metadata?.ttsAudioKey).toBeUndefined();
     });
 
-    it('returns context unchanged when TTS times out (voice-engine path)', async () => {
+    it('returns context unchanged when TTS times out (voice-engine path, 240s)', async () => {
       // Synthesis never resolves — will be beaten by the timeout
       mockSynthesizeWithChunking.mockImplementation(
         () => new Promise(() => {}) // never resolves
@@ -944,7 +944,25 @@ describe('TTSStep', () => {
 
       expect(result).toBe(ctx);
       expect(result.result?.metadata?.ttsAudioKey).toBeUndefined();
-      // Text content is preserved
+      expect(result.result?.content).toBe('Hello world');
+    });
+
+    it('returns context unchanged when TTS times out (ElevenLabs path, 150s)', async () => {
+      // ElevenLabs TTS never resolves — will be beaten by the 150s timeout
+      mockEnsureVoiceCloned.mockResolvedValue('el-voice-timeout');
+      mockElevenLabsTTS.mockImplementation(
+        () => new Promise(() => {}) // never resolves
+      );
+
+      const ctx = createElevenLabsContext();
+
+      const promise = step.process(ctx);
+      // Advance past the 150s ElevenLabs synthesis budget
+      await vi.advanceTimersByTimeAsync(150_000);
+      const result = await promise;
+
+      expect(result).toBe(ctx);
+      expect(result.result?.metadata?.ttsAudioKey).toBeUndefined();
       expect(result.result?.content).toBe('Hello world');
     });
   });

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.test.ts
@@ -929,7 +929,7 @@ describe('TTSStep', () => {
       expect(result.result?.metadata?.ttsAudioKey).toBeUndefined();
     });
 
-    it('returns context unchanged when TTS times out', async () => {
+    it('returns context unchanged when TTS times out (voice-engine path)', async () => {
       // Synthesis never resolves — will be beaten by the timeout
       mockSynthesizeWithChunking.mockImplementation(
         () => new Promise(() => {}) // never resolves
@@ -938,8 +938,8 @@ describe('TTSStep', () => {
       const ctx = createContext();
 
       const promise = step.process(ctx);
-      // Advance past the 150s timeout
-      await vi.advanceTimersByTimeAsync(150_000);
+      // Advance past the 240s voice-engine timeout (includes cold start budget)
+      await vi.advanceTimersByTimeAsync(240_000);
       const result = await promise;
 
       expect(result).toBe(ctx);

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts
@@ -24,15 +24,16 @@ import { redisService } from '../../../../redis.js';
 
 const logger = createLogger('TTSStep');
 
-/** TTS timeout — includes voice-engine cold start time on Railway Serverless.
- * Budget: health wait (75s) + voice registration (15s) + synthesis (~45s) + margin (15s).
- * 150s accommodates the full ~56s cold start plus multi-chunk TTS.
- *
- * Intentionally not widened further: 150s is already a long Discord user wait
- * for a non-critical feature. If cold-start fallbacks time out in production,
- * reduce ELEVENLABS_MAX_ATTEMPTS to 1 (recovering ~65s) rather than extending
- * this cap. Monitor elapsedMs in fallback log messages. */
-const TTS_TIMEOUT_MS = 150_000;
+/** TTS synthesis budget (no cold start) — used for ElevenLabs path.
+ * Budget: voice cloning (cached ~1s) + synthesis (60s per attempt × 2) + margin (30s).
+ * ElevenLabs is a cloud service with no cold start, so this is generous. */
+const TTS_SYNTHESIS_BUDGET_MS = 150_000;
+
+/** TTS total budget including cold start — used for voice-engine path.
+ * Budget: cold start warmup (75s) + registration (15s) + multi-chunk synthesis (~120s) + margin (30s).
+ * Text is always delivered regardless — this only affects whether audio is attached.
+ * Wider than the ElevenLabs budget because Railway Serverless cold starts are unavoidable. */
+const TTS_MAX_TOTAL_MS = 240_000;
 
 /** Max ElevenLabs TTS outer retry attempts (1 initial + 1 retry).
  * Each attempt may make 1 extra elevenLabsTTS call if 404 triggers re-clone.
@@ -145,10 +146,13 @@ export class TTSStep implements IPipelineStep {
       // is discarded (ttsAudioKey never written), and the audio expires via Redis TTL.
       let timedOut = false;
       let timeoutId: NodeJS.Timeout | undefined;
-      const ttsPromise =
-        elevenlabsApiKey !== undefined
-          ? this.performElevenLabsTTSWithFallback(text, slug, elevenlabsApiKey, context)
-          : this.performVoiceEngineTTS(text, slug, context);
+      // Select timeout based on path: ElevenLabs has no cold start, voice-engine does
+      const isElevenLabs = elevenlabsApiKey !== undefined;
+      const effectiveTimeout = isElevenLabs ? TTS_SYNTHESIS_BUDGET_MS : TTS_MAX_TOTAL_MS;
+
+      const ttsPromise = isElevenLabs
+        ? this.performElevenLabsTTSWithFallback(text, slug, elevenlabsApiKey, context)
+        : this.performVoiceEngineTTS(text, slug, context);
 
       // Observe dangling completion/rejection after timeout (makes background work visible in logs).
       void ttsPromise.then(
@@ -176,8 +180,8 @@ export class TTSStep implements IPipelineStep {
         new Promise<null>((_, reject) => {
           timeoutId = setTimeout(() => {
             timedOut = true;
-            reject(new TimeoutError(TTS_TIMEOUT_MS, 'TTS processing'));
-          }, TTS_TIMEOUT_MS);
+            reject(new TimeoutError(effectiveTimeout, 'TTS processing'));
+          }, effectiveTimeout);
         }),
       ]);
 
@@ -343,7 +347,11 @@ export class TTSStep implements IPipelineStep {
     // TCP connection triggers Railway to start the container; subsequent polls wait
     // for model readiness. Proceeds even if budget exhausted — synthesis will fail
     // with a clear error if the engine truly isn't available.
-    await waitForVoiceEngine(registrationService.client, 'tts');
+    const warmup = await waitForVoiceEngine(registrationService.client, 'tts');
+    logger.info(
+      { slug, warmupElapsedMs: warmup.elapsedMs, ready: warmup.ready },
+      'Voice engine warmup complete for TTS'
+    );
 
     // Ensure voice is registered
     await registrationService.ensureVoiceRegistered(slug);

--- a/services/ai-worker/src/services/multimodal/AudioProcessor.test.ts
+++ b/services/ai-worker/src/services/multimodal/AudioProcessor.test.ts
@@ -17,7 +17,7 @@ let mockVoiceEngineClient: {
   getHealth: typeof mockGetHealth;
 } | null = null;
 
-const mockWaitForVoiceEngine = vi.fn().mockResolvedValue(true);
+const mockWaitForVoiceEngine = vi.fn().mockResolvedValue({ ready: true, elapsedMs: 0 });
 vi.mock('../voice/voiceEngineWarmup.js', () => ({
   waitForVoiceEngine: (...args: unknown[]) => mockWaitForVoiceEngine(...args),
 }));
@@ -57,7 +57,7 @@ describe('AudioProcessor', () => {
     mockVoiceEngineClient = null;
     mockVoiceEngineTranscribe.mockReset();
     mockGetHealth.mockReset().mockResolvedValue({ asr: true, tts: true });
-    mockWaitForVoiceEngine.mockReset().mockResolvedValue(true);
+    mockWaitForVoiceEngine.mockReset().mockResolvedValue({ ready: true, elapsedMs: 0 });
     mockElevenLabsSTT.mockReset();
   });
 

--- a/services/ai-worker/src/services/multimodal/AudioProcessor.ts
+++ b/services/ai-worker/src/services/multimodal/AudioProcessor.ts
@@ -58,7 +58,11 @@ async function transcribeWithVoiceEngine(
   // Wake voice-engine from Railway Serverless sleep before attempting STT.
   // Without this, ECONNREFUSED wastes the first retry attempt (~7s backoff)
   // while the engine cold-starts for ~56s.
-  await waitForVoiceEngine(voiceEngineClient, 'asr');
+  const warmup = await waitForVoiceEngine(voiceEngineClient, 'asr');
+  logger.debug(
+    { warmupElapsedMs: warmup.elapsedMs, ready: warmup.ready },
+    'Voice engine warmup complete for STT'
+  );
 
   try {
     const filename =

--- a/services/ai-worker/src/services/multimodal/AudioProcessor.ts
+++ b/services/ai-worker/src/services/multimodal/AudioProcessor.ts
@@ -59,7 +59,7 @@ async function transcribeWithVoiceEngine(
   // Without this, ECONNREFUSED wastes the first retry attempt (~7s backoff)
   // while the engine cold-starts for ~56s.
   const warmup = await waitForVoiceEngine(voiceEngineClient, 'asr');
-  logger.debug(
+  logger.info(
     { warmupElapsedMs: warmup.elapsedMs, ready: warmup.ready },
     'Voice engine warmup complete for STT'
   );

--- a/services/ai-worker/src/services/voice/voiceEngineWarmup.test.ts
+++ b/services/ai-worker/src/services/voice/voiceEngineWarmup.test.ts
@@ -42,7 +42,7 @@ describe('waitForVoiceEngine', () => {
     await vi.runAllTimersAsync();
     const result = await promise;
 
-    expect(result).toBe(true);
+    expect(result).toEqual({ ready: true, elapsedMs: expect.any(Number) });
     expect(client.getHealth).toHaveBeenCalledTimes(1);
   });
 
@@ -59,7 +59,7 @@ describe('waitForVoiceEngine', () => {
     await vi.runAllTimersAsync();
     const result = await promise;
 
-    expect(result).toBe(true);
+    expect(result).toEqual({ ready: true, elapsedMs: expect.any(Number) });
     expect(client.getHealth).toHaveBeenCalledTimes(3);
   });
 
@@ -73,7 +73,7 @@ describe('waitForVoiceEngine', () => {
     await vi.runAllTimersAsync();
     const result = await promise;
 
-    expect(result).toBe(false);
+    expect(result).toEqual({ ready: false, elapsedMs: expect.any(Number) });
     // 9_000 / 3_000 = 3 polls (each followed by 3s sleep)
     expect(client.getHealth).toHaveBeenCalledTimes(3);
   });
@@ -88,7 +88,7 @@ describe('waitForVoiceEngine', () => {
     await vi.runAllTimersAsync();
     const result = await promise;
 
-    expect(result).toBe(false);
+    expect(result).toEqual({ ready: false, elapsedMs: expect.any(Number) });
     // 5_000 / 1_000 = 5 polls
     expect(client.getHealth).toHaveBeenCalledTimes(5);
   });
@@ -106,7 +106,7 @@ describe('waitForVoiceEngine', () => {
     await vi.runAllTimersAsync();
     const result = await promise;
 
-    expect(result).toBe(true);
+    expect(result).toEqual({ ready: true, elapsedMs: expect.any(Number) });
     expect(client.getHealth).toHaveBeenCalledTimes(2);
   });
 
@@ -123,7 +123,7 @@ describe('waitForVoiceEngine', () => {
     await vi.runAllTimersAsync();
     const result = await promise;
 
-    expect(result).toBe(true);
+    expect(result).toEqual({ ready: true, elapsedMs: expect.any(Number) });
     expect(client.getHealth).toHaveBeenCalledTimes(2);
   });
 
@@ -134,7 +134,7 @@ describe('waitForVoiceEngine', () => {
     await vi.runAllTimersAsync();
     const result = await promise;
 
-    expect(result).toBe(false);
+    expect(result).toEqual({ ready: false, elapsedMs: expect.any(Number) });
     // Default: 75_000 / 3_000 = 25 polls
     expect(client.getHealth).toHaveBeenCalledTimes(25);
   });

--- a/services/ai-worker/src/services/voice/voiceEngineWarmup.ts
+++ b/services/ai-worker/src/services/voice/voiceEngineWarmup.ts
@@ -27,10 +27,17 @@ export interface WarmupOptions {
   pollIntervalMs?: number;
 }
 
+export interface WarmupResult {
+  /** Whether the requested capability is ready */
+  ready: boolean;
+  /** Time spent waiting for warmup (milliseconds) */
+  elapsedMs: number;
+}
+
 /**
  * Wait for voice-engine to become ready by polling /health.
  * First ping wakes Railway Serverless; subsequent polls wait for model loading (~56s).
- * Returns true if the requested capability is ready, false if budget exhausted.
+ * Returns ready status and elapsed time so callers can adapt timeout budgets.
  *
  * Callers should proceed even on `false` — registration/synthesis will fail with
  * a clear error if the engine truly isn't available.
@@ -39,10 +46,11 @@ export async function waitForVoiceEngine(
   client: VoiceEngineClient,
   capability: 'asr' | 'tts',
   options?: WarmupOptions
-): Promise<boolean> {
+): Promise<WarmupResult> {
   const budgetMs = options?.budgetMs ?? DEFAULT_BUDGET_MS;
   const pollIntervalMs = options?.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
-  const deadline = Date.now() + budgetMs;
+  const startTime = Date.now();
+  const deadline = startTime + budgetMs;
   let attempt = 0;
 
   while (Date.now() < deadline) {
@@ -52,7 +60,7 @@ export async function waitForVoiceEngine(
     // is resilient to transient network failures during the full boot window.
     const health = await client.getHealth();
     if (health[capability]) {
-      return true;
+      return { ready: true, elapsedMs: Date.now() - startTime };
     }
     const remaining = deadline - Date.now();
     if (remaining <= 0) {
@@ -69,5 +77,5 @@ export async function waitForVoiceEngine(
     { capability, attempts: attempt, budgetMs },
     `Voice engine ${capability.toUpperCase()} still not ready after health budget`
   );
-  return false;
+  return { ready: false, elapsedMs: Date.now() - startTime };
 }

--- a/services/bot-client/src/services/VoiceTranscriptionService.test.ts
+++ b/services/bot-client/src/services/VoiceTranscriptionService.test.ts
@@ -393,6 +393,35 @@ describe('VoiceTranscriptionService', () => {
       });
     });
 
+    it('should send timeout-specific error when transcription times out', async () => {
+      const message = createMockMessage({
+        attachments: [
+          {
+            url: 'https://cdn.discord.com/voice/123.ogg',
+            contentType: 'audio/ogg',
+            name: 'voice.ogg',
+            size: 50000,
+            duration: 5.2,
+          },
+        ],
+      });
+
+      // AbortSignal.timeout() throws DOMException with name 'TimeoutError'
+      const timeoutError = new DOMException(
+        'The operation was aborted due to timeout',
+        'TimeoutError'
+      );
+      mockGatewayClient.transcribe.mockRejectedValue(timeoutError);
+
+      const result = await service.transcribe(message, false, false);
+
+      expect(result).toBeNull();
+      expect(message.reply).toHaveBeenCalledWith({
+        content: expect.stringContaining('taking too long'),
+        allowedMentions: { parse: [], repliedUser: false },
+      });
+    });
+
     it('should return null when gateway returns empty response', async () => {
       const message = createMockMessage({
         attachments: [

--- a/services/bot-client/src/services/VoiceTranscriptionService.ts
+++ b/services/bot-client/src/services/VoiceTranscriptionService.ts
@@ -16,9 +16,9 @@ const logger = createLogger('VoiceTranscriptionService');
 /** Interval for refreshing the typing indicator (Discord expires at ~10s, matches JobTracker.ts) */
 const TYPING_INDICATOR_INTERVAL_MS = 8000;
 
-/** Check if an error is a timeout (AbortSignal.timeout throws DOMException with name 'TimeoutError') */
+/** Check if an error is a timeout. AbortSignal.timeout() throws DOMException with name 'TimeoutError'. */
 function isTimeoutError(error: unknown): boolean {
-  return error instanceof Error && (error.name === 'TimeoutError' || error.name === 'AbortError');
+  return error instanceof Error && error.name === 'TimeoutError';
 }
 
 /** Attachment info for transcription */

--- a/services/bot-client/src/services/VoiceTranscriptionService.ts
+++ b/services/bot-client/src/services/VoiceTranscriptionService.ts
@@ -16,6 +16,11 @@ const logger = createLogger('VoiceTranscriptionService');
 /** Interval for refreshing the typing indicator (Discord expires at ~10s, matches JobTracker.ts) */
 const TYPING_INDICATOR_INTERVAL_MS = 8000;
 
+/** Check if an error is a timeout (AbortSignal.timeout throws DOMException with name 'TimeoutError') */
+function isTimeoutError(error: unknown): boolean {
+  return error instanceof Error && (error.name === 'TimeoutError' || error.name === 'AbortError');
+}
+
 /** Attachment info for transcription */
 interface TranscriptionAttachment {
   url: string;
@@ -254,9 +259,14 @@ export class VoiceTranscriptionService {
       };
     } catch (error) {
       logger.error({ err: error }, '[VoiceTranscriptionService] Error transcribing voice message');
+
+      const userMessage = isTimeoutError(error)
+        ? 'Sorry, transcription is taking too long \u2014 the voice service may be starting up. Please try again in a moment.'
+        : "Sorry, I couldn't transcribe that voice message.";
+
       await message
         .reply({
-          content: "Sorry, I couldn't transcribe that voice message.",
+          content: userMessage,
           allowedMentions: { parse: [], repliedUser: false },
         })
         .catch(replyError => {

--- a/services/bot-client/src/utils/GatewayClient.test.ts
+++ b/services/bot-client/src/utils/GatewayClient.test.ts
@@ -286,6 +286,24 @@ describe('GatewayClient', () => {
       const body = JSON.parse(fetchCall[1].body as string);
       expect(body.userId).toBeUndefined();
     });
+
+    it('should include AbortSignal timeout on transcribe requests', async () => {
+      const client = new GatewayClient('http://test.gateway');
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            jobId: 'job-1',
+            status: JobStatus.Completed,
+            result: { content: 'text' },
+          }),
+      });
+
+      await client.transcribe([{ url: 'http://test/audio.ogg', contentType: 'audio/ogg' }]);
+
+      const fetchOptions = mockFetch.mock.calls[0][1];
+      expect(fetchOptions.signal).toBeDefined();
+    });
   });
 
   describe('confirmDelivery()', () => {

--- a/services/bot-client/src/utils/GatewayClient.test.ts
+++ b/services/bot-client/src/utils/GatewayClient.test.ts
@@ -302,7 +302,7 @@ describe('GatewayClient', () => {
       await client.transcribe([{ url: 'http://test/audio.ogg', contentType: 'audio/ogg' }]);
 
       const fetchOptions = mockFetch.mock.calls[0][1];
-      expect(fetchOptions.signal).toBeDefined();
+      expect(fetchOptions.signal).toBeInstanceOf(AbortSignal);
     });
   });
 

--- a/services/bot-client/src/utils/GatewayClient.ts
+++ b/services/bot-client/src/utils/GatewayClient.ts
@@ -167,6 +167,7 @@ export class GatewayClient {
           attachments,
           ...(userId !== undefined && { userId }),
         }),
+        signal: AbortSignal.timeout(TIMEOUTS.STT_GATEWAY),
       });
 
       if (!response.ok) {


### PR DESCRIPTION
## Summary

Voice pipeline timeout architecture overhaul to handle Railway Serverless cold starts (~56s) without silently dropping audio or hanging indefinitely.

- **STT gateway timeout** — Add missing `AbortSignal.timeout(120s)` to `GatewayClient.transcribe()` — was the only gateway fetch call without a timeout (8 others had it)
- **Timeout-aware error messages** — Users now see "voice service may be starting up, try again" instead of generic "Sorry" on transcription timeouts
- **Warmup timing observability** — `waitForVoiceEngine()` returns `{ ready, elapsedMs }` instead of just `boolean`, enabling adaptive timeout budgets and production monitoring
- **Adaptive TTS timeout** — ElevenLabs path: 150s (no cold start). Voice-engine path: 240s (accommodates 75s cold start + multi-chunk synthesis). Previously a fixed 150s silently dropped audio on every cold start.

## Test plan

- [x] `pnpm test` — all 14 packages pass
- [x] `pnpm quality` — lint, CPD, depcruise, typecheck all green
- [x] Pre-push hooks pass
- [ ] Verify STT transcription completes on cold start (Railway Serverless)
- [ ] Verify TTS audio attaches after cold start (previously dropped silently)
- [ ] Verify timeout error message appears when STT exceeds 120s

🤖 Generated with [Claude Code](https://claude.com/claude-code)