### PR TITLE
fix(ai-worker): voice-engine retry resilience for cold starts

### DIFF
--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.test.ts
@@ -46,9 +46,16 @@ vi.mock('../../../../services/voice/VoiceRegistrationService.js', () => ({
 }));
 
 const mockGetVoiceEngineClient = vi.fn();
-vi.mock('../../../../services/voice/VoiceEngineClient.js', () => ({
-  getVoiceEngineClient: (...args: unknown[]) => mockGetVoiceEngineClient(...args),
-}));
+// Use importOriginal to preserve real exports (isTransientVoiceEngineError, VOICE_ENGINE_RETRY,
+// VoiceEngineError) — only getVoiceEngineClient needs to be mocked for singleton control.
+vi.mock('../../../../services/voice/VoiceEngineClient.js', async importOriginal => {
+  const actual =
+    await importOriginal<typeof import('../../../../services/voice/VoiceEngineClient.js')>();
+  return {
+    ...actual,
+    getVoiceEngineClient: (...args: unknown[]) => mockGetVoiceEngineClient(...args),
+  };
+});
 
 const mockSynthesizeWithChunking = vi.fn();
 vi.mock('../../../../services/voice/ttsSynthesizer.js', () => ({
@@ -890,6 +897,69 @@ describe('TTSStep', () => {
       expect(mockSynthesizeWithChunking).toHaveBeenCalled();
       expect(result.result?.metadata?.ttsAudioKey).toBeUndefined();
       expect(result.result?.content).toBe('Hello world');
+    });
+  });
+
+  describe('voice-engine retry on transient errors', () => {
+    it('retries on ECONNREFUSED and succeeds on second attempt', async () => {
+      const econnrefusedCause = new Error('connect ECONNREFUSED') as NodeJS.ErrnoException;
+      econnrefusedCause.code = 'ECONNREFUSED';
+      const fetchError = new TypeError('fetch failed', { cause: econnrefusedCause });
+
+      mockSynthesizeWithChunking.mockRejectedValueOnce(fetchError).mockResolvedValueOnce({
+        audioBuffer: Buffer.from('retry-audio'),
+        contentType: 'audio/wav',
+      });
+      mockStoreTTSAudio.mockResolvedValue('tts:retry-job');
+
+      const ctx = createContext();
+
+      const promise = step.process(ctx);
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result.result?.metadata?.ttsAudioKey).toBe('tts:retry-job');
+      // First call fails, second succeeds
+      expect(mockSynthesizeWithChunking).toHaveBeenCalledTimes(2);
+      // Registration called twice (once per retry attempt — cache prevents duplicate work)
+      expect(mockEnsureVoiceRegistered).toHaveBeenCalledTimes(2);
+    });
+
+    it('gives up after max retry attempts and degrades gracefully', async () => {
+      const fetchError = new TypeError('fetch failed');
+
+      mockSynthesizeWithChunking.mockRejectedValue(fetchError);
+
+      const ctx = createContext();
+
+      const promise = step.process(ctx);
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      // Graceful degradation — text still delivered
+      expect(result).toBe(ctx);
+      expect(result.result?.metadata?.ttsAudioKey).toBeUndefined();
+      expect(result.result?.content).toBe('Hello world');
+      // 2 attempts (MAX_ATTEMPTS = 2)
+      expect(mockSynthesizeWithChunking).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not retry non-transient errors (fast-fail)', async () => {
+      // VoiceEngineError 401 is not transient — should fast-fail
+      const { VoiceEngineError } = await import('../../../../services/voice/VoiceEngineClient.js');
+      mockEnsureVoiceRegistered.mockRejectedValue(new VoiceEngineError(401, 'Unauthorized'));
+
+      const ctx = createContext();
+
+      const promise = step.process(ctx);
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      // Graceful degradation
+      expect(result.result?.metadata?.ttsAudioKey).toBeUndefined();
+      // Only 1 attempt — shouldRetry returned false
+      expect(mockEnsureVoiceRegistered).toHaveBeenCalledTimes(1);
+      expect(mockSynthesizeWithChunking).not.toHaveBeenCalled();
     });
   });
 

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.test.ts
@@ -940,8 +940,9 @@ describe('TTSStep', () => {
       expect(result).toBe(ctx);
       expect(result.result?.metadata?.ttsAudioKey).toBeUndefined();
       expect(result.result?.content).toBe('Hello world');
-      // 2 attempts (MAX_ATTEMPTS = 2)
+      // 2 attempts (MAX_ATTEMPTS = 2) — both registration and synthesis retry together
       expect(mockSynthesizeWithChunking).toHaveBeenCalledTimes(2);
+      expect(mockEnsureVoiceRegistered).toHaveBeenCalledTimes(2);
     });
 
     it('does not retry non-transient errors (fast-fail)', async () => {

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts
@@ -13,7 +13,11 @@
 
 import { createLogger, isVoiceEnabled } from '@tzurot/common-types';
 import type { IPipelineStep, GenerationContext } from '../types.js';
-import { getVoiceEngineClient } from '../../../../services/voice/VoiceEngineClient.js';
+import {
+  getVoiceEngineClient,
+  isTransientVoiceEngineError,
+  VOICE_ENGINE_RETRY,
+} from '../../../../services/voice/VoiceEngineClient.js';
 import { VoiceRegistrationService } from '../../../../services/voice/VoiceRegistrationService.js';
 import { synthesizeWithChunking } from '../../../../services/voice/ttsSynthesizer.js';
 import { waitForVoiceEngine } from '../../../../services/voice/voiceEngineWarmup.js';
@@ -353,17 +357,30 @@ export class TTSStep implements IPipelineStep {
       'Voice engine warmup complete for TTS'
     );
 
-    // Ensure voice is registered
-    await registrationService.ensureVoiceRegistered(slug);
-
-    // Synthesize (with chunking for long text)
-    const { audioBuffer, contentType } = await synthesizeWithChunking(
-      registrationService.client,
-      text,
-      slug
+    // Register + synthesize with retry for transient errors (ECONNREFUSED, 502/503/504).
+    // Warmup stays outside retry (it has its own polling loop). Registration positive cache
+    // prevents duplicate work on retry; transient errors aren't negatively cached so re-attempt
+    // succeeds once the engine stabilizes. Outer Promise.race (240s) still enforces total budget.
+    const { value: synthesisResult } = await withRetry(
+      async () => {
+        await registrationService.ensureVoiceRegistered(slug);
+        return synthesizeWithChunking(registrationService.client, text, slug);
+      },
+      {
+        maxAttempts: VOICE_ENGINE_RETRY.MAX_ATTEMPTS,
+        initialDelayMs: VOICE_ENGINE_RETRY.INITIAL_DELAY_MS,
+        shouldRetry: isTransientVoiceEngineError,
+        operationName: 'Voice Engine TTS',
+        logger,
+      }
     );
 
-    return this.storeTTSResult(context, audioBuffer, contentType, slug);
+    return this.storeTTSResult(
+      context,
+      synthesisResult.audioBuffer,
+      synthesisResult.contentType,
+      slug
+    );
   }
 
   private async storeTTSResult(

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts
@@ -360,7 +360,10 @@ export class TTSStep implements IPipelineStep {
     // Register + synthesize with retry for transient errors (ECONNREFUSED, 502/503/504).
     // Warmup stays outside retry (it has its own polling loop). Registration positive cache
     // prevents duplicate work on retry; transient errors aren't negatively cached so re-attempt
-    // succeeds once the engine stabilizes. Outer Promise.race (240s) still enforces total budget.
+    // succeeds once the engine stabilizes.
+    // No globalTimeoutMs — intentionally omitted (unlike ElevenLabs retry which uses 90s).
+    // The outer Promise.race (TTS_MAX_TOTAL_MS = 240s) already enforces the total budget,
+    // and with maxAttempts=2 + 3s delay the worst-case retry overhead is ~6s.
     const { value: synthesisResult } = await withRetry(
       async () => {
         await registrationService.ensureVoiceRegistered(slug);

--- a/services/ai-worker/src/services/multimodal/AudioProcessor.test.ts
+++ b/services/ai-worker/src/services/multimodal/AudioProcessor.test.ts
@@ -438,6 +438,57 @@ describe('AudioProcessor', () => {
       });
     });
 
+    describe('voice-engine retry on transient errors', () => {
+      const retryAttachment: AttachmentMetadata = {
+        url: 'https://example.com/audio.ogg',
+        name: 'audio.ogg',
+        contentType: CONTENT_TYPES.AUDIO_OGG,
+        size: 1024,
+      };
+
+      beforeEach(() => {
+        (global.fetch as any).mockResolvedValue({
+          ok: true,
+          arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(1024)),
+        });
+        mockVoiceEngineClient = { transcribe: mockVoiceEngineTranscribe, getHealth: mockGetHealth };
+      });
+
+      it('should retry on ECONNREFUSED and succeed on second attempt', async () => {
+        const econnrefusedCause = new Error('connect ECONNREFUSED') as NodeJS.ErrnoException;
+        econnrefusedCause.code = 'ECONNREFUSED';
+        const fetchError = new TypeError('fetch failed', { cause: econnrefusedCause });
+
+        mockVoiceEngineTranscribe
+          .mockRejectedValueOnce(fetchError)
+          .mockResolvedValueOnce({ text: 'Transcribed after retry' });
+
+        const result = await transcribeAudio(retryAttachment);
+
+        expect(result).toBe('Transcribed after retry');
+        expect(mockVoiceEngineTranscribe).toHaveBeenCalledTimes(2);
+      });
+
+      it('should return null after all retry attempts fail with transient errors', async () => {
+        const fetchError = new TypeError('fetch failed');
+
+        mockVoiceEngineTranscribe.mockRejectedValue(fetchError);
+
+        await expect(transcribeAudio(retryAttachment)).rejects.toThrow('No STT provider available');
+        // 2 attempts (MAX_ATTEMPTS = 2)
+        expect(mockVoiceEngineTranscribe).toHaveBeenCalledTimes(2);
+      });
+
+      it('should not retry on non-transient errors (fast-fail)', async () => {
+        const { VoiceEngineError } = await import('../voice/VoiceEngineClient.js');
+        mockVoiceEngineTranscribe.mockRejectedValue(new VoiceEngineError(401, 'Unauthorized'));
+
+        await expect(transcribeAudio(retryAttachment)).rejects.toThrow('No STT provider available');
+        // Only 1 attempt — shouldRetry returned false for 401
+        expect(mockVoiceEngineTranscribe).toHaveBeenCalledTimes(1);
+      });
+    });
+
     describe('ElevenLabs STT integration', () => {
       const audioAttachment: AttachmentMetadata = {
         url: 'https://example.com/audio.ogg',

--- a/services/ai-worker/src/services/multimodal/AudioProcessor.ts
+++ b/services/ai-worker/src/services/multimodal/AudioProcessor.ts
@@ -8,8 +8,13 @@
  */
 
 import { createLogger, TIMEOUTS, type AttachmentMetadata } from '@tzurot/common-types';
-import { TimeoutError } from '../../utils/retry.js';
-import { VoiceEngineError, getVoiceEngineClient } from '../voice/VoiceEngineClient.js';
+import { withRetry, RetryError, TimeoutError } from '../../utils/retry.js';
+import {
+  VoiceEngineError,
+  getVoiceEngineClient,
+  isTransientVoiceEngineError,
+  VOICE_ENGINE_RETRY,
+} from '../voice/VoiceEngineClient.js';
 import { waitForVoiceEngine } from '../voice/voiceEngineWarmup.js';
 import { elevenLabsSTT, ElevenLabsApiError } from '../voice/ElevenLabsClient.js';
 
@@ -68,10 +73,19 @@ async function transcribeWithVoiceEngine(
     const filename =
       attachment.name !== undefined && attachment.name.length > 0 ? attachment.name : 'audio.ogg';
 
-    const result = await voiceEngineClient.transcribe(
-      Buffer.from(audioBuffer),
-      filename,
-      attachment.contentType
+    // Retry transient errors (ECONNREFUSED, 502/503/504) — the engine may still be
+    // stabilizing after warmup polling returned. Auth errors and other permanent
+    // failures fast-fail via shouldRetry returning false.
+    const { value: result } = await withRetry(
+      () =>
+        voiceEngineClient.transcribe(Buffer.from(audioBuffer), filename, attachment.contentType),
+      {
+        maxAttempts: VOICE_ENGINE_RETRY.MAX_ATTEMPTS,
+        initialDelayMs: VOICE_ENGINE_RETRY.INITIAL_DELAY_MS,
+        shouldRetry: isTransientVoiceEngineError,
+        operationName: 'Voice Engine STT',
+        logger,
+      }
     );
 
     if (result.text.length === 0) {
@@ -92,10 +106,16 @@ async function transcribeWithVoiceEngine(
     // Empty string is a valid result (silent/inaudible audio)
     return result.text;
   } catch (error) {
-    if (error instanceof VoiceEngineError && error.isAuthError) {
-      logger.error({ err: error }, 'Voice engine auth error — check VOICE_ENGINE_API_KEY config');
+    // Unwrap RetryError to get the original error for classification.
+    // Pino won't auto-unwrap RetryError.lastError, so log the original directly.
+    const originalError = error instanceof RetryError ? error.lastError : error;
+    if (originalError instanceof VoiceEngineError && originalError.isAuthError) {
+      logger.error(
+        { err: originalError },
+        'Voice engine auth error — check VOICE_ENGINE_API_KEY config'
+      );
     } else {
-      logger.warn({ err: error }, 'Voice engine transcription failed');
+      logger.warn({ err: error }, 'Voice engine transcription failed after retries');
     }
     return null;
   }

--- a/services/ai-worker/src/services/multimodal/AudioProcessor.ts
+++ b/services/ai-worker/src/services/multimodal/AudioProcessor.ts
@@ -76,6 +76,8 @@ async function transcribeWithVoiceEngine(
     // Retry transient errors (ECONNREFUSED, 502/503/504) — the engine may still be
     // stabilizing after warmup polling returned. Auth errors and other permanent
     // failures fast-fail via shouldRetry returning false.
+    // No globalTimeoutMs — the per-call VOICE_ENGINE_API timeout (180s) bounds each
+    // attempt, and with maxAttempts=2 the worst-case retry overhead is ~3s (delay only).
     const { value: result } = await withRetry(
       () =>
         voiceEngineClient.transcribe(Buffer.from(audioBuffer), filename, attachment.contentType),
@@ -106,8 +108,10 @@ async function transcribeWithVoiceEngine(
     // Empty string is a valid result (silent/inaudible audio)
     return result.text;
   } catch (error) {
-    // Unwrap RetryError to get the original error for classification.
-    // Pino won't auto-unwrap RetryError.lastError, so log the original directly.
+    // Unwrap RetryError to classify the root cause (auth vs transient).
+    // Auth branch logs originalError (the VoiceEngineError with status code).
+    // Else branch logs the full `error` (RetryError wrapper) — its message includes
+    // attempt count and timing, which is more useful for diagnosing transient failures.
     const originalError = error instanceof RetryError ? error.lastError : error;
     if (originalError instanceof VoiceEngineError && originalError.isAuthError) {
       logger.error(

--- a/services/ai-worker/src/services/voice/VoiceEngineClient.test.ts
+++ b/services/ai-worker/src/services/voice/VoiceEngineClient.test.ts
@@ -5,8 +5,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   VoiceEngineClient,
+  VoiceEngineError,
   getVoiceEngineClient,
   resetVoiceEngineClient,
+  isTransientVoiceEngineError,
 } from './VoiceEngineClient.js';
 import * as commonTypes from '@tzurot/common-types';
 import type { EnvConfig } from '@tzurot/common-types';
@@ -450,5 +452,72 @@ describe('getVoiceEngineClient', () => {
     const first = getVoiceEngineClient();
     const second = getVoiceEngineClient();
     expect(first).toBe(second);
+  });
+});
+
+describe('isTransientVoiceEngineError', () => {
+  it('should return true for TimeoutError', () => {
+    expect(isTransientVoiceEngineError(new TimeoutError(5000, 'test'))).toBe(true);
+  });
+
+  it('should return true for VoiceEngineError 502', () => {
+    expect(isTransientVoiceEngineError(new VoiceEngineError(502, 'Bad Gateway'))).toBe(true);
+  });
+
+  it('should return true for VoiceEngineError 503', () => {
+    expect(isTransientVoiceEngineError(new VoiceEngineError(503, 'Service Unavailable'))).toBe(
+      true
+    );
+  });
+
+  it('should return true for VoiceEngineError 504', () => {
+    expect(isTransientVoiceEngineError(new VoiceEngineError(504, 'Gateway Timeout'))).toBe(true);
+  });
+
+  it('should return false for VoiceEngineError 400', () => {
+    expect(isTransientVoiceEngineError(new VoiceEngineError(400, 'Bad Request'))).toBe(false);
+  });
+
+  it('should return false for VoiceEngineError 401', () => {
+    expect(isTransientVoiceEngineError(new VoiceEngineError(401, 'Unauthorized'))).toBe(false);
+  });
+
+  it('should return false for VoiceEngineError 404', () => {
+    expect(isTransientVoiceEngineError(new VoiceEngineError(404, 'Not Found'))).toBe(false);
+  });
+
+  it('should return true for TypeError("fetch failed")', () => {
+    expect(isTransientVoiceEngineError(new TypeError('fetch failed'))).toBe(true);
+  });
+
+  it('should return true for TypeError with ECONNREFUSED cause', () => {
+    const cause = new Error('connect ECONNREFUSED') as NodeJS.ErrnoException;
+    cause.code = 'ECONNREFUSED';
+    const error = new TypeError('other message', { cause });
+    expect(isTransientVoiceEngineError(error)).toBe(true);
+  });
+
+  it('should return true for TypeError with ECONNRESET cause', () => {
+    const cause = new Error('connection reset') as NodeJS.ErrnoException;
+    cause.code = 'ECONNRESET';
+    const error = new TypeError('other message', { cause });
+    expect(isTransientVoiceEngineError(error)).toBe(true);
+  });
+
+  it('should return true for TypeError with ETIMEDOUT cause', () => {
+    const cause = new Error('connection timed out') as NodeJS.ErrnoException;
+    cause.code = 'ETIMEDOUT';
+    const error = new TypeError('other message', { cause });
+    expect(isTransientVoiceEngineError(error)).toBe(true);
+  });
+
+  it('should return false for generic Error', () => {
+    expect(isTransientVoiceEngineError(new Error('something went wrong'))).toBe(false);
+  });
+
+  it('should return false for non-error values', () => {
+    expect(isTransientVoiceEngineError(null)).toBe(false);
+    expect(isTransientVoiceEngineError(undefined)).toBe(false);
+    expect(isTransientVoiceEngineError('string error')).toBe(false);
   });
 });

--- a/services/ai-worker/src/services/voice/VoiceEngineClient.ts
+++ b/services/ai-worker/src/services/voice/VoiceEngineClient.ts
@@ -211,6 +211,52 @@ export class VoiceEngineClient {
 }
 
 // ---------------------------------------------------------------------------
+// Transient error classification — used by callers to decide retry eligibility
+// ---------------------------------------------------------------------------
+
+/** Retry configuration for voice-engine operations (shared by TTS + STT callers). */
+export const VOICE_ENGINE_RETRY = {
+  /** 1 initial + 1 retry — matches ElevenLabs retry budget */
+  MAX_ATTEMPTS: 2,
+  /** Delay before retry — matches warmup poll interval so engine has time to stabilize */
+  INITIAL_DELAY_MS: 3_000,
+} as const;
+
+/** Classify errors as transient (worth retrying) for voice-engine operations.
+ * Covers: ECONNREFUSED/ECONNRESET/ETIMEDOUT (cold start), 502/503/504 (Railway LB),
+ * and TimeoutError (slow response during model loading).
+ *
+ * Mirrors `isTransientElevenLabsError` in TTSStep.ts — same structure, different
+ * error types because VoiceEngineClient uses VoiceEngineError instead of ElevenLabsApiError. */
+export function isTransientVoiceEngineError(error: unknown): boolean {
+  // Typed sentinel — AbortController timeout or withTimeout wrapper
+  if (error instanceof TimeoutError) {
+    return true;
+  }
+  // HTTP-level transient errors from voice-engine responses:
+  // - 502: Railway load balancer is up but the app hasn't bound its port yet
+  // - 503: Voice engine HTTP server is up but models haven't finished loading
+  // - 504: Railway load balancer timeout during slow boot
+  if (error instanceof VoiceEngineError) {
+    return error.status === 502 || error.status === 503 || error.status === 504;
+  }
+  // Network-level connection failures: Node undici throws TypeError("fetch failed")
+  // with a cause carrying a POSIX error code (ECONNREFUSED, ECONNRESET, ETIMEDOUT).
+  // Check both the known message string and the cause code for robustness across
+  // Node versions — the message is an undici implementation detail that may change.
+  if (error instanceof TypeError) {
+    if (error.message === 'fetch failed') {
+      return true;
+    }
+    const causeCode = (error.cause as NodeJS.ErrnoException | undefined)?.code;
+    if (causeCode === 'ECONNREFUSED' || causeCode === 'ECONNRESET' || causeCode === 'ETIMEDOUT') {
+      return true;
+    }
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
 // Lazy singleton — created from config on first access
 // ---------------------------------------------------------------------------
 let _instance: VoiceEngineClient | null = null;


### PR DESCRIPTION
## Summary

- Add `isTransientVoiceEngineError()` classifier to `VoiceEngineClient.ts` — handles ECONNREFUSED, ECONNRESET, ETIMEDOUT, 502/503/504, and TimeoutError
- Wrap voice-engine TTS path (registration + synthesis) with `withRetry` in `TTSStep.ts`
- Wrap voice-engine STT path (transcription) with `withRetry` in `AudioProcessor.ts`
- Shared retry config: 2 attempts, 3s initial delay (matches warmup poll interval)

Follow-up to PR #757. The warmup polling loop handles ECONNREFUSED silently (`getHealth()` catches all errors), but the actual `transcribe()` / `synthesize()` calls let ECONNREFUSED propagate as raw errors with no retry — unlike the ElevenLabs path which has `withRetry` + `isTransientElevenLabsError`.

## Test plan

- [x] `isTransientVoiceEngineError` classifier tests (13 cases: TimeoutError, VoiceEngineError 502/503/504, 400/401/404, TypeError variants, generic Error, non-error values)
- [x] TTSStep retry tests (ECONNREFUSED retry + success, exhaustion + graceful degradation, non-transient fast-fail)
- [x] AudioProcessor retry tests (ECONNREFUSED retry + success, exhaustion + fallthrough, non-transient fast-fail)
- [x] All 2464 existing ai-worker tests pass
- [x] `pnpm quality` clean (lint, cpd, depcruise, typecheck)
- [ ] Manual: deploy and verify voice transcription during cold start

🤖 Generated with [Claude Code](https://claude.com/claude-code)