### PR TITLE
refactor(api-gateway): extract config override helpers

### DIFF
--- a/services/api-gateway/src/routes/user/channel/configOverrides.ts
+++ b/services/api-gateway/src/routes/user/channel/configOverrides.ts
@@ -124,7 +124,8 @@ export function createPatchConfigOverridesHandler(
       });
 
       await tryInvalidateCache(
-        cascadeInvalidation?.invalidateChannel.bind(cascadeInvalidation, channelId)
+        cascadeInvalidation?.invalidateChannel.bind(cascadeInvalidation, channelId),
+        { channelId }
       );
 
       logger.info({ channelId, userId: req.userId }, 'Updated channel config overrides');
@@ -155,7 +156,8 @@ export function createDeleteConfigOverridesHandler(
       });
 
       await tryInvalidateCache(
-        cascadeInvalidation?.invalidateChannel.bind(cascadeInvalidation, channelId)
+        cascadeInvalidation?.invalidateChannel.bind(cascadeInvalidation, channelId),
+        { channelId }
       );
 
       logger.info({ channelId, userId: req.userId }, 'Cleared channel config overrides');

--- a/services/api-gateway/src/routes/user/channel/configOverrides.ts
+++ b/services/api-gateway/src/routes/user/channel/configOverrides.ts
@@ -19,15 +19,18 @@ import { type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import {
   createLogger,
-  Prisma,
   generateChannelSettingsUuid,
   isValidDiscordId,
+  Prisma,
   type PrismaClient,
   type ConfigCascadeCacheInvalidationService,
 } from '@tzurot/common-types';
 import { requireUserAuth } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
-import { mergeConfigOverrides } from '../../../utils/configOverrideMerge.js';
+import {
+  tryInvalidateCache,
+  mergeAndValidateOverrides,
+} from '../../../utils/configOverrideHelpers.js';
 import { sendError, sendCustomSuccess } from '../../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
 import { getRequiredParam } from '../../../utils/requestParams.js';
@@ -43,9 +46,6 @@ function validateChannelId(channelId: string, res: Response): boolean {
   }
   return true;
 }
-
-const CASCADE_INVALIDATION_WARN =
-  '[ChannelConfigOverrides] Failed to publish cascade cache invalidation';
 
 /**
  * Create GET handler for channel config overrides
@@ -101,14 +101,14 @@ export function createPatchConfigOverridesHandler(
         select: { configOverrides: true },
       });
 
-      const merged = mergeConfigOverrides(existing?.configOverrides, input);
-      if (merged === 'invalid') {
-        sendError(res, ErrorResponses.validationError('Invalid config format'));
+      const { merged, prismaValue } = mergeAndValidateOverrides(
+        existing?.configOverrides,
+        input,
+        res
+      );
+      if (merged === undefined) {
         return;
       }
-
-      const configOverridesValue =
-        merged === null ? Prisma.JsonNull : (merged as Prisma.InputJsonValue);
 
       // Upsert: create channel settings if they don't exist yet
       await prisma.channelSettings.upsert({
@@ -116,14 +116,16 @@ export function createPatchConfigOverridesHandler(
         create: {
           id: settingsId,
           channelId,
-          configOverrides: configOverridesValue,
+          configOverrides: prismaValue,
         },
         update: {
-          configOverrides: configOverridesValue,
+          configOverrides: prismaValue,
         },
       });
 
-      await tryInvalidateChannel(cascadeInvalidation, channelId);
+      await tryInvalidateCache(
+        cascadeInvalidation?.invalidateChannel.bind(cascadeInvalidation, channelId)
+      );
 
       logger.info({ channelId, userId: req.userId }, 'Updated channel config overrides');
       sendCustomSuccess(res, { configOverrides: merged }, StatusCodes.OK);
@@ -152,25 +154,12 @@ export function createDeleteConfigOverridesHandler(
         data: { configOverrides: Prisma.JsonNull },
       });
 
-      await tryInvalidateChannel(cascadeInvalidation, channelId);
+      await tryInvalidateCache(
+        cascadeInvalidation?.invalidateChannel.bind(cascadeInvalidation, channelId)
+      );
 
       logger.info({ channelId, userId: req.userId }, 'Cleared channel config overrides');
       sendCustomSuccess(res, { success: true }, StatusCodes.OK);
     }),
   ];
-}
-
-/** Publish cascade invalidation for a channel, swallowing errors. */
-async function tryInvalidateChannel(
-  cascadeInvalidation: ConfigCascadeCacheInvalidationService | undefined,
-  channelId: string
-): Promise<void> {
-  if (cascadeInvalidation === undefined) {
-    return;
-  }
-  try {
-    await cascadeInvalidation.invalidateChannel(channelId);
-  } catch (error) {
-    logger.warn({ err: error }, CASCADE_INVALIDATION_WARN);
-  }
 }

--- a/services/api-gateway/src/routes/user/config-overrides.ts
+++ b/services/api-gateway/src/routes/user/config-overrides.ts
@@ -193,7 +193,8 @@ export function createConfigOverrideRoutes(
       });
 
       await tryInvalidateCache(
-        cascadeInvalidation?.invalidateUser.bind(cascadeInvalidation, req.userId)
+        cascadeInvalidation?.invalidateUser.bind(cascadeInvalidation, req.userId),
+        { discordUserId: req.userId }
       );
 
       sendCustomSuccess(res, { configDefaults: merged }, StatusCodes.OK);
@@ -218,7 +219,8 @@ export function createConfigOverrideRoutes(
       });
 
       await tryInvalidateCache(
-        cascadeInvalidation?.invalidateUser.bind(cascadeInvalidation, req.userId)
+        cascadeInvalidation?.invalidateUser.bind(cascadeInvalidation, req.userId),
+        { discordUserId: req.userId }
       );
 
       sendCustomSuccess(res, { success: true }, StatusCodes.OK);
@@ -298,7 +300,8 @@ export function createConfigOverrideRoutes(
       });
 
       await tryInvalidateCache(
-        cascadeInvalidation?.invalidateUser.bind(cascadeInvalidation, req.userId)
+        cascadeInvalidation?.invalidateUser.bind(cascadeInvalidation, req.userId),
+        { discordUserId: req.userId }
       );
 
       sendCustomSuccess(res, { configOverrides: merged }, StatusCodes.OK);
@@ -337,7 +340,8 @@ export function createConfigOverrideRoutes(
       }
 
       await tryInvalidateCache(
-        cascadeInvalidation?.invalidateUser.bind(cascadeInvalidation, req.userId)
+        cascadeInvalidation?.invalidateUser.bind(cascadeInvalidation, req.userId),
+        { discordUserId: req.userId }
       );
 
       sendCustomSuccess(res, { success: true }, StatusCodes.OK);

--- a/services/api-gateway/src/routes/user/config-overrides.ts
+++ b/services/api-gateway/src/routes/user/config-overrides.ts
@@ -31,7 +31,10 @@ import {
 } from '@tzurot/common-types';
 import { requireUserAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
-import { mergeConfigOverrides } from '../../utils/configOverrideMerge.js';
+import {
+  tryInvalidateCache,
+  mergeAndValidateOverrides,
+} from '../../utils/configOverrideHelpers.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
 import { getRequiredParam } from '../../utils/requestParams.js';
@@ -40,7 +43,6 @@ import type { AuthenticatedRequest } from '../../types.js';
 const logger = createLogger('user-config-overrides');
 
 const BOT_USER_ERROR = 'Cannot create user for bot';
-const CASCADE_INVALIDATION_WARN = 'Failed to publish cascade invalidation';
 
 /** Parse and validate a config tier's JSONB value. Returns null if absent or invalid. */
 function parseConfigTier(raw: unknown): Record<string, unknown> | null {
@@ -68,19 +70,6 @@ export function createConfigOverrideRoutes(
   const router = Router();
   const userService = new UserService(prisma);
   const cascadeResolver = new ConfigCascadeResolver(prisma, { enableCleanup: false });
-
-  /** Publish cascade invalidation for a user, swallowing errors.
-   *  If pub/sub fails, caches expire via TTL (30s) for eventual consistency. */
-  async function tryInvalidateUser(discordUserId: string): Promise<void> {
-    if (cascadeInvalidation === undefined) {
-      return;
-    }
-    try {
-      await cascadeInvalidation.invalidateUser(discordUserId);
-    } catch (error) {
-      logger.warn({ err: error }, CASCADE_INVALIDATION_WARN);
-    }
-  }
 
   // All routes require authentication
   router.use(requireUserAuth());
@@ -184,30 +173,28 @@ export function createConfigOverrideRoutes(
         return sendError(res, ErrorResponses.validationError(BOT_USER_ERROR));
       }
 
-      if (typeof req.body !== 'object' || req.body === null || Array.isArray(req.body)) {
-        return sendError(res, ErrorResponses.validationError('Request body must be a JSON object'));
-      }
-      const input = req.body as Record<string, unknown>;
-
       const user = await prisma.user.findUnique({
         where: { id: userId },
         select: { configDefaults: true },
       });
 
-      const merged = mergeConfigOverrides(user?.configDefaults, input);
-      if (merged === 'invalid') {
-        sendError(res, ErrorResponses.validationError('Invalid config format'));
+      const { merged, prismaValue } = mergeAndValidateOverrides(
+        user?.configDefaults,
+        req.body,
+        res
+      );
+      if (merged === undefined) {
         return;
       }
 
       await prisma.user.update({
         where: { id: userId },
-        data: {
-          configDefaults: merged === null ? Prisma.JsonNull : (merged as Prisma.InputJsonValue),
-        },
+        data: { configDefaults: prismaValue },
       });
 
-      await tryInvalidateUser(req.userId);
+      await tryInvalidateCache(
+        cascadeInvalidation?.invalidateUser.bind(cascadeInvalidation, req.userId)
+      );
 
       sendCustomSuccess(res, { configDefaults: merged }, StatusCodes.OK);
     })
@@ -230,7 +217,9 @@ export function createConfigOverrideRoutes(
         data: { configDefaults: Prisma.JsonNull },
       });
 
-      await tryInvalidateUser(req.userId);
+      await tryInvalidateCache(
+        cascadeInvalidation?.invalidateUser.bind(cascadeInvalidation, req.userId)
+      );
 
       sendCustomSuccess(res, { success: true }, StatusCodes.OK);
     })
@@ -278,11 +267,6 @@ export function createConfigOverrideRoutes(
         return sendError(res, ErrorResponses.validationError(BOT_USER_ERROR));
       }
 
-      if (typeof req.body !== 'object' || req.body === null || Array.isArray(req.body)) {
-        return sendError(res, ErrorResponses.validationError('Request body must be a JSON object'));
-      }
-      const input = req.body as Record<string, unknown>;
-
       // Upsert UserPersonalityConfig with deterministic UUID
       const upcId = generateUserPersonalityConfigUuid(userId, personalityId);
 
@@ -291,9 +275,12 @@ export function createConfigOverrideRoutes(
         select: { configOverrides: true },
       });
 
-      const merged = mergeConfigOverrides(existing?.configOverrides, input);
-      if (merged === 'invalid') {
-        sendError(res, ErrorResponses.validationError('Invalid config format'));
+      const { merged, prismaValue } = mergeAndValidateOverrides(
+        existing?.configOverrides,
+        req.body,
+        res
+      );
+      if (merged === undefined) {
         return;
       }
 
@@ -303,14 +290,16 @@ export function createConfigOverrideRoutes(
           id: upcId,
           userId,
           personalityId,
-          configOverrides: merged === null ? Prisma.JsonNull : (merged as Prisma.InputJsonValue),
+          configOverrides: prismaValue,
         },
         update: {
-          configOverrides: merged === null ? Prisma.JsonNull : (merged as Prisma.InputJsonValue),
+          configOverrides: prismaValue,
         },
       });
 
-      await tryInvalidateUser(req.userId);
+      await tryInvalidateCache(
+        cascadeInvalidation?.invalidateUser.bind(cascadeInvalidation, req.userId)
+      );
 
       sendCustomSuccess(res, { configOverrides: merged }, StatusCodes.OK);
     })
@@ -347,7 +336,9 @@ export function createConfigOverrideRoutes(
         });
       }
 
-      await tryInvalidateUser(req.userId);
+      await tryInvalidateCache(
+        cascadeInvalidation?.invalidateUser.bind(cascadeInvalidation, req.userId)
+      );
 
       sendCustomSuccess(res, { success: true }, StatusCodes.OK);
     })

--- a/services/api-gateway/src/routes/user/memoryHelpers.ts
+++ b/services/api-gateway/src/routes/user/memoryHelpers.ts
@@ -49,6 +49,34 @@ export async function getDefaultPersonaId(
   return user?.defaultPersonaId ?? null;
 }
 
+/** Result of resolving user + persona for memory operations */
+export interface MemoryContext {
+  user: { id: string };
+  personaId: string;
+}
+
+/**
+ * Resolve user and default persona for memory operations.
+ * Combines getUserByDiscordId + getDefaultPersonaId into a single call.
+ * Sends appropriate error responses and returns null if resolution fails.
+ */
+export async function resolveMemoryContext(
+  prisma: PrismaClient,
+  discordUserId: string,
+  res: Response
+): Promise<MemoryContext | null> {
+  const user = await getUserByDiscordId(prisma, discordUserId, res);
+  if (!user) {return null;}
+
+  const personaId = await getDefaultPersonaId(prisma, user.id);
+  if (personaId === null) {
+    sendError(res, ErrorResponses.notFound('Memory'));
+    return null;
+  }
+
+  return { user, personaId };
+}
+
 /**
  * Validate and get personality by ID.
  * Sends 404 error response and returns null if personality not found.

--- a/services/api-gateway/src/routes/user/memoryHelpers.ts
+++ b/services/api-gateway/src/routes/user/memoryHelpers.ts
@@ -49,34 +49,6 @@ export async function getDefaultPersonaId(
   return user?.defaultPersonaId ?? null;
 }
 
-/** Result of resolving user + persona for memory operations */
-export interface MemoryContext {
-  user: { id: string };
-  personaId: string;
-}
-
-/**
- * Resolve user and default persona for memory operations.
- * Combines getUserByDiscordId + getDefaultPersonaId into a single call.
- * Sends appropriate error responses and returns null if resolution fails.
- */
-export async function resolveMemoryContext(
-  prisma: PrismaClient,
-  discordUserId: string,
-  res: Response
-): Promise<MemoryContext | null> {
-  const user = await getUserByDiscordId(prisma, discordUserId, res);
-  if (!user) {return null;}
-
-  const personaId = await getDefaultPersonaId(prisma, user.id);
-  if (personaId === null) {
-    sendError(res, ErrorResponses.notFound('Memory'));
-    return null;
-  }
-
-  return { user, personaId };
-}
-
 /**
  * Validate and get personality by ID.
  * Sends 404 error response and returns null if personality not found.

--- a/services/api-gateway/src/routes/user/model-override.ts
+++ b/services/api-gateway/src/routes/user/model-override.ts
@@ -26,6 +26,7 @@ import {
 } from '@tzurot/common-types';
 import { requireUserAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
+import { tryInvalidateCache } from '../../utils/configOverrideHelpers.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
 import { sendZodError } from '../../utils/zodHelpers.js';
@@ -50,26 +51,6 @@ async function verifyConfigAccess(
     },
     select: { id: true, name: true },
   });
-}
-
-/**
- * Attempt to invalidate user LLM config cache. Logs errors but does not throw.
- */
-async function tryInvalidateUserLlmConfigCache(
-  service: LlmConfigCacheInvalidationService | undefined,
-  discordUserId: string
-): Promise<void> {
-  if (!service) {
-    return;
-  }
-
-  try {
-    await service.invalidateUserLlmConfig(discordUserId);
-    logger.debug({ discordUserId }, '[ModelDefault] Invalidated user LLM config cache');
-  } catch (err) {
-    // Log but don't fail the request - cache will expire naturally
-    logger.error({ err, discordUserId }, '[ModelDefault] Failed to invalidate cache');
-  }
 }
 
 // eslint-disable-next-line max-lines-per-function -- Route factory with multiple endpoints
@@ -302,7 +283,12 @@ export function createModelOverrideRoutes(
       );
 
       // Invalidate user's LLM config cache so ai-worker picks up the change
-      await tryInvalidateUserLlmConfigCache(llmConfigCacheInvalidation, discordUserId);
+      await tryInvalidateCache(
+        llmConfigCacheInvalidation?.invalidateUserLlmConfig.bind(
+          llmConfigCacheInvalidation,
+          discordUserId
+        )
+      );
 
       sendCustomSuccess(res, { default: result }, StatusCodes.OK);
     })
@@ -344,7 +330,12 @@ export function createModelOverrideRoutes(
       logger.info({ discordUserId }, '[ModelDefault] Cleared default config');
 
       // Invalidate user's LLM config cache so ai-worker picks up the change
-      await tryInvalidateUserLlmConfigCache(llmConfigCacheInvalidation, discordUserId);
+      await tryInvalidateCache(
+        llmConfigCacheInvalidation?.invalidateUserLlmConfig.bind(
+          llmConfigCacheInvalidation,
+          discordUserId
+        )
+      );
 
       sendCustomSuccess(res, { deleted: true }, StatusCodes.OK);
     })

--- a/services/api-gateway/src/routes/user/model-override.ts
+++ b/services/api-gateway/src/routes/user/model-override.ts
@@ -287,7 +287,8 @@ export function createModelOverrideRoutes(
         llmConfigCacheInvalidation?.invalidateUserLlmConfig.bind(
           llmConfigCacheInvalidation,
           discordUserId
-        )
+        ),
+        { discordUserId }
       );
 
       sendCustomSuccess(res, { default: result }, StatusCodes.OK);
@@ -334,7 +335,8 @@ export function createModelOverrideRoutes(
         llmConfigCacheInvalidation?.invalidateUserLlmConfig.bind(
           llmConfigCacheInvalidation,
           discordUserId
-        )
+        ),
+        { discordUserId }
       );
 
       sendCustomSuccess(res, { deleted: true }, StatusCodes.OK);

--- a/services/api-gateway/src/routes/user/personality-config-overrides.ts
+++ b/services/api-gateway/src/routes/user/personality-config-overrides.ts
@@ -111,7 +111,8 @@ export function createPersonalityConfigOverrideRoutes(
       });
 
       await tryInvalidateCache(
-        cascadeInvalidation?.invalidatePersonality.bind(cascadeInvalidation, personalityId)
+        cascadeInvalidation?.invalidatePersonality.bind(cascadeInvalidation, personalityId),
+        { personalityId }
       );
 
       sendCustomSuccess(res, { configDefaults: merged }, StatusCodes.OK);

--- a/services/api-gateway/src/routes/user/personality-config-overrides.ts
+++ b/services/api-gateway/src/routes/user/personality-config-overrides.ts
@@ -11,22 +11,21 @@
 import { Router, type Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import {
-  createLogger,
   UserService,
   ConfigCascadeResolver,
-  Prisma,
   type PrismaClient,
   type ConfigCascadeCacheInvalidationService,
 } from '@tzurot/common-types';
 import { requireUserAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
-import { mergeConfigOverrides } from '../../utils/configOverrideMerge.js';
+import {
+  tryInvalidateCache,
+  mergeAndValidateOverrides,
+} from '../../utils/configOverrideHelpers.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
 import { getRequiredParam } from '../../utils/requestParams.js';
 import type { AuthenticatedRequest } from '../../types.js';
-
-const logger = createLogger('personality-config-overrides');
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -97,32 +96,23 @@ export function createPersonalityConfigOverrideRoutes(
         );
       }
 
-      if (typeof req.body !== 'object' || req.body === null || Array.isArray(req.body)) {
-        return sendError(res, ErrorResponses.validationError('Request body must be a JSON object'));
-      }
-
-      const merged = mergeConfigOverrides(
+      const { merged, prismaValue } = mergeAndValidateOverrides(
         personality.configDefaults,
-        req.body as Record<string, unknown>
+        req.body,
+        res
       );
-      if (merged === 'invalid') {
-        return sendError(res, ErrorResponses.validationError('Invalid config format'));
+      if (merged === undefined) {
+        return;
       }
 
       await prisma.personality.update({
         where: { id: personalityId },
-        data: {
-          configDefaults: merged === null ? Prisma.JsonNull : (merged as Prisma.InputJsonValue),
-        },
+        data: { configDefaults: prismaValue },
       });
 
-      if (cascadeInvalidation !== undefined) {
-        try {
-          await cascadeInvalidation.invalidatePersonality(personalityId);
-        } catch (error) {
-          logger.warn({ err: error }, 'Failed to publish cascade invalidation');
-        }
-      }
+      await tryInvalidateCache(
+        cascadeInvalidation?.invalidatePersonality.bind(cascadeInvalidation, personalityId)
+      );
 
       sendCustomSuccess(res, { configDefaults: merged }, StatusCodes.OK);
     })

--- a/services/api-gateway/src/utils/configOverrideHelpers.test.ts
+++ b/services/api-gateway/src/utils/configOverrideHelpers.test.ts
@@ -46,9 +46,9 @@ describe('tryInvalidateCache', () => {
     expect(fn).toHaveBeenCalledOnce();
   });
 
-  it('should skip when fn is undefined', async () => {
+  it('should skip silently when fn is undefined', async () => {
     await tryInvalidateCache(undefined);
-    // No error thrown — just returns
+    expect(mockLogger.warn).not.toHaveBeenCalled();
   });
 
   it('should swallow errors and log warning with context', async () => {

--- a/services/api-gateway/src/utils/configOverrideHelpers.test.ts
+++ b/services/api-gateway/src/utils/configOverrideHelpers.test.ts
@@ -1,18 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { tryInvalidateCache, mergeAndValidateOverrides } from './configOverrideHelpers.js';
+
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
 
 vi.mock('@tzurot/common-types', async () => {
   const actual = await vi.importActual('@tzurot/common-types');
   return {
     ...actual,
-    createLogger: () => ({
-      info: vi.fn(),
-      debug: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    }),
+    createLogger: () => mockLogger,
   };
 });
+
+import { tryInvalidateCache, mergeAndValidateOverrides } from './configOverrideHelpers.js';
 
 // Mock the merge function to control its return values
 const mockMerge = vi.fn();
@@ -45,11 +50,14 @@ describe('tryInvalidateCache', () => {
     // No error thrown — just returns
   });
 
-  it('should swallow errors from the invalidation function', async () => {
+  it('should swallow errors and log warning with context', async () => {
     const fn = vi.fn().mockRejectedValue(new Error('Redis down'));
-    await tryInvalidateCache(fn);
-    // Should not throw
+    await tryInvalidateCache(fn, { discordUserId: 'user-123' });
     expect(fn).toHaveBeenCalledOnce();
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.any(Error), discordUserId: 'user-123' }),
+      'Failed to publish cache invalidation'
+    );
   });
 });
 

--- a/services/api-gateway/src/utils/configOverrideHelpers.test.ts
+++ b/services/api-gateway/src/utils/configOverrideHelpers.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { tryInvalidateCache, mergeAndValidateOverrides } from './configOverrideHelpers.js';
+
+vi.mock('@tzurot/common-types', async () => {
+  const actual = await vi.importActual('@tzurot/common-types');
+  return {
+    ...actual,
+    createLogger: () => ({
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+// Mock the merge function to control its return values
+const mockMerge = vi.fn();
+vi.mock('./configOverrideMerge.js', () => ({
+  mergeConfigOverrides: (...args: unknown[]) => mockMerge(...args),
+}));
+
+const mockSendError = vi.fn();
+vi.mock('./responseHelpers.js', () => ({
+  sendError: (...args: unknown[]) => mockSendError(...args),
+}));
+
+vi.mock('./errorResponses.js', () => ({
+  ErrorResponses: {
+    validationError: (msg: string) => ({ error: 'VALIDATION', message: msg }),
+  },
+}));
+
+describe('tryInvalidateCache', () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it('should call the invalidation function when provided', async () => {
+    const fn = vi.fn().mockResolvedValue(undefined);
+    await tryInvalidateCache(fn);
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it('should skip when fn is undefined', async () => {
+    await tryInvalidateCache(undefined);
+    // No error thrown — just returns
+  });
+
+  it('should swallow errors from the invalidation function', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('Redis down'));
+    await tryInvalidateCache(fn);
+    // Should not throw
+    expect(fn).toHaveBeenCalledOnce();
+  });
+});
+
+describe('mergeAndValidateOverrides', () => {
+  const mockRes = {} as never;
+
+  beforeEach(() => vi.resetAllMocks());
+
+  it('should reject non-object body', () => {
+    const result = mergeAndValidateOverrides(null, 'not-an-object', mockRes);
+    expect(result.merged).toBeUndefined();
+    expect(mockSendError).toHaveBeenCalledOnce();
+  });
+
+  it('should reject null body', () => {
+    const result = mergeAndValidateOverrides(null, null, mockRes);
+    expect(result.merged).toBeUndefined();
+    expect(mockSendError).toHaveBeenCalledOnce();
+  });
+
+  it('should reject array body', () => {
+    const result = mergeAndValidateOverrides(null, [1, 2, 3], mockRes);
+    expect(result.merged).toBeUndefined();
+    expect(mockSendError).toHaveBeenCalledOnce();
+  });
+
+  it('should return merged value on success', () => {
+    const merged = { maxMessages: 50 };
+    mockMerge.mockReturnValue(merged);
+
+    const result = mergeAndValidateOverrides({ maxMessages: 25 }, { maxMessages: 50 }, mockRes);
+    expect(result.merged).toEqual(merged);
+    expect(result.prismaValue).toEqual(merged);
+    expect(mockSendError).not.toHaveBeenCalled();
+  });
+
+  it('should return null merged with Prisma.JsonNull when merge clears all', () => {
+    mockMerge.mockReturnValue(null);
+
+    const result = mergeAndValidateOverrides({ maxMessages: 25 }, { maxMessages: null }, mockRes);
+    expect(result.merged).toBeNull();
+    // prismaValue should be Prisma.JsonNull (a symbol)
+    expect(result.prismaValue).toBeDefined();
+  });
+
+  it('should send error on invalid merge result', () => {
+    mockMerge.mockReturnValue('invalid');
+
+    const result = mergeAndValidateOverrides({}, { bad: 'data' }, mockRes);
+    expect(result.merged).toBeUndefined();
+    expect(mockSendError).toHaveBeenCalledOnce();
+  });
+});

--- a/services/api-gateway/src/utils/configOverrideHelpers.test.ts
+++ b/services/api-gateway/src/utils/configOverrideHelpers.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Prisma } from '@tzurot/common-types';
 
 const { mockLogger } = vi.hoisted(() => ({
   mockLogger: {
@@ -99,8 +100,7 @@ describe('mergeAndValidateOverrides', () => {
 
     const result = mergeAndValidateOverrides({ maxMessages: 25 }, { maxMessages: null }, mockRes);
     expect(result.merged).toBeNull();
-    // prismaValue should be Prisma.JsonNull (a symbol)
-    expect(result.prismaValue).toBeDefined();
+    expect(result.prismaValue).toBe(Prisma.JsonNull);
   });
 
   it('should send error on invalid merge result', () => {

--- a/services/api-gateway/src/utils/configOverrideHelpers.ts
+++ b/services/api-gateway/src/utils/configOverrideHelpers.ts
@@ -1,0 +1,83 @@
+/**
+ * Config Override Helpers
+ *
+ * Shared utilities for config cascade override routes. These patterns are
+ * repeated across user config-overrides, personality config-overrides,
+ * channel config-overrides, and model-override routes.
+ */
+
+import type { Response } from 'express';
+import { Prisma, createLogger } from '@tzurot/common-types';
+import { mergeConfigOverrides } from './configOverrideMerge.js';
+import { sendError } from './responseHelpers.js';
+import { ErrorResponses } from './errorResponses.js';
+
+const logger = createLogger('configOverrideHelpers');
+
+// ============================================================================
+// Cache Invalidation
+// ============================================================================
+
+/**
+ * Publish a cache invalidation event, swallowing errors.
+ * If pub/sub fails, caches expire via TTL for eventual consistency.
+ *
+ * Replaces the duplicated tryInvalidateUser/tryInvalidateChannel/
+ * tryInvalidatePersonality/tryInvalidateUserLlmConfig patterns.
+ *
+ * @param fn - The invalidation function to call (e.g., service.invalidateUser)
+ *             Pass undefined to skip invalidation (service not available).
+ */
+export async function tryInvalidateCache(fn: (() => Promise<void>) | undefined): Promise<void> {
+  if (fn === undefined) {
+    return;
+  }
+  try {
+    await fn();
+  } catch (error) {
+    logger.warn({ err: error }, 'Failed to publish cache invalidation');
+  }
+}
+
+// ============================================================================
+// Config Override Merge
+// ============================================================================
+
+/** Result of merging config overrides. Either the merged JSON value or null if error was sent. */
+export interface MergeOverridesResult {
+  /** The merged value (null means "clear all overrides"), or undefined if validation failed. */
+  merged: Record<string, unknown> | null | undefined;
+  /** Prisma-safe JSON value. Only defined when merged is not undefined. */
+  prismaValue: Prisma.InputJsonValue | typeof Prisma.JsonNull | undefined;
+}
+
+/**
+ * Validate request body, merge config overrides, and convert to Prisma-safe value.
+ *
+ * Sends error response and returns `{ merged: undefined }` if:
+ * - Body is not a JSON object
+ * - Merged result is 'invalid' (schema validation failed)
+ *
+ * @returns merged value + Prisma-safe value, or undefined merged if error was sent
+ */
+export function mergeAndValidateOverrides(
+  currentConfig: unknown,
+  body: unknown,
+  res: Response
+): MergeOverridesResult {
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    sendError(res, ErrorResponses.validationError('Request body must be a JSON object'));
+    return { merged: undefined, prismaValue: undefined };
+  }
+
+  const input = body as Record<string, unknown>;
+  const merged = mergeConfigOverrides(currentConfig, input);
+
+  if (merged === 'invalid') {
+    sendError(res, ErrorResponses.validationError('Invalid config format'));
+    return { merged: undefined, prismaValue: undefined };
+  }
+
+  const prismaValue = merged === null ? Prisma.JsonNull : (merged as Prisma.InputJsonValue);
+  return { merged, prismaValue };
+}

--- a/services/api-gateway/src/utils/configOverrideHelpers.ts
+++ b/services/api-gateway/src/utils/configOverrideHelpers.ts
@@ -22,20 +22,24 @@ const logger = createLogger('configOverrideHelpers');
  * Publish a cache invalidation event, swallowing errors.
  * If pub/sub fails, caches expire via TTL for eventual consistency.
  *
- * Replaces the duplicated tryInvalidateUser/tryInvalidateChannel/
- * tryInvalidatePersonality/tryInvalidateUserLlmConfig patterns.
+ * Uses warn level (not error) because TTL provides the safety net — a failed
+ * pub/sub notification is a degraded-latency event, not a data correctness issue.
  *
  * @param fn - The invalidation function to call (e.g., service.invalidateUser)
  *             Pass undefined to skip invalidation (service not available).
+ * @param context - Optional structured context for the log entry (e.g., { discordUserId })
  */
-export async function tryInvalidateCache(fn: (() => Promise<void>) | undefined): Promise<void> {
+export async function tryInvalidateCache(
+  fn: (() => Promise<void>) | undefined,
+  context?: Record<string, unknown>
+): Promise<void> {
   if (fn === undefined) {
     return;
   }
   try {
     await fn();
   } catch (error) {
-    logger.warn({ err: error }, 'Failed to publish cache invalidation');
+    logger.warn({ err: error, ...context }, 'Failed to publish cache invalidation');
   }
 }
 


### PR DESCRIPTION
## Summary

- Extract `tryInvalidateCache()` — universal cache invalidation wrapper with structured context logging, replacing 4 duplicated `tryInvalidate*` functions across config-overrides, personality-config-overrides, channel/configOverrides, and model-override
- Extract `mergeAndValidateOverrides()` — combines body validation + merge + Prisma.JsonNull conversion, used by 3 config override PATCH handlers

**Intentional behavior change**: model-override invalidation failures now log at `warn` level (was `error`). All 4 routes now use consistent `warn` — TTL provides the safety net, so failed pub/sub is degraded-latency, not data loss.

**CPD**: 139 → 138 (modest — the helpers prevent future duplication more than they collapse existing clone fragments)

## Test plan

- [x] 9 new tests for configOverrideHelpers (tryInvalidateCache with context + mergeAndValidateOverrides)
- [x] All 82 existing route tests pass
- [x] `pnpm typecheck` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)