### PR TITLE
refactor(bot-client): consolidate dashboard handlers (settings + select menu)

### DIFF
--- a/services/bot-client/src/commands/character/overrides.ts
+++ b/services/bot-client/src/commands/character/overrides.ts
@@ -21,7 +21,6 @@ import {
   DISCORD_COLORS,
   GATEWAY_TIMEOUTS,
   type EnvConfig,
-  type ConfigOverrides,
   type ResolvedConfigOverrides,
   characterSettingsOptions,
 } from '@tzurot/common-types';
@@ -30,8 +29,7 @@ import { callGatewayApi } from '../../utils/userGatewayClient.js';
 import {
   type SettingsData,
   type SettingsDashboardConfig,
-  type SettingsDashboardSession,
-  type SettingUpdateResult,
+  type SettingUpdateHandler,
   type PersonalityResponse,
   createSettingsDashboard,
   handleSettingsSelectMenu,
@@ -43,9 +41,11 @@ import {
   MEMORY_SETTINGS,
   DISPLAY_SETTINGS,
   VOICE_CASCADE_SETTINGS,
-  mapSettingToApiUpdate,
-  buildCascadeSettingsData,
 } from '../../utils/dashboard/settings/index.js';
+import {
+  createSettingsUpdateHandler,
+  convertCascadeToSettingsData,
+} from '../../utils/dashboard/settings/settingsUpdateFactory.js';
 
 const logger = createLogger('character-overrides');
 
@@ -222,110 +222,18 @@ export function isCharacterOverridesInteraction(customId: string): boolean {
   return isSettingsInteraction(customId, ENTITY_TYPE);
 }
 
-/**
- * Convert cascade-resolved overrides to dashboard SettingsData format.
- * Extracts local overrides by checking which fields the user-personality tier set.
- */
+/** Config for the character overrides update handler (full user-personality cascade) */
+const CHARACTER_OVERRIDES_UPDATE_CONFIG = {
+  patchEndpoint: (id: string) => `/user/config-overrides/${encodeURIComponent(id)}`,
+  resolveEndpoint: (id: string) => `/user/config-overrides/resolve/${encodeURIComponent(id)}`,
+  sourceTier: 'user-personality' as const,
+  logContext: '[Character Overrides]',
+};
+
+function createUpdateHandler(personalityId: string): SettingUpdateHandler {
+  return createSettingsUpdateHandler(personalityId, CHARACTER_OVERRIDES_UPDATE_CONFIG);
+}
+
 function convertToSettingsData(resolved: ResolvedConfigOverrides): SettingsData {
-  const localOverrides: Partial<ConfigOverrides> = {};
-  for (const [field, source] of Object.entries(resolved.sources)) {
-    if (source === 'user-personality') {
-      // Safe: we only iterate config field keys from resolved.sources, never the
-      // `sources` key itself, so the indexed value is always a config primitive.
-      // `as never` satisfies the union type that includes Record<string, string>.
-      localOverrides[field as keyof ConfigOverrides] = resolved[
-        field as keyof ResolvedConfigOverrides
-      ] as never;
-    }
-  }
-  return buildCascadeSettingsData(
-    resolved,
-    Object.keys(localOverrides).length > 0 ? localOverrides : null,
-    'user-personality'
-  );
-}
-
-/**
- * Create a settings update handler bound to a specific personality.
- * Returns a 4-param handler matching the SettingsUpdateHandler signature.
- */
-function createUpdateHandler(personalityId: string) {
-  return (
-    interaction: ButtonInteraction | ModalSubmitInteraction,
-    _session: SettingsDashboardSession,
-    settingId: string,
-    newValue: unknown
-  ): Promise<SettingUpdateResult> =>
-    handleSettingUpdate(interaction, settingId, newValue, personalityId);
-}
-
-/**
- * Handle setting updates from the dashboard
- * Writes to user's per-personality config overrides via cascade endpoint
- */
-async function handleSettingUpdate(
-  interaction: ButtonInteraction | ModalSubmitInteraction,
-  settingId: string,
-  newValue: unknown,
-  personalityId: string
-): Promise<SettingUpdateResult> {
-  const userId = interaction.user.id;
-
-  logger.debug(
-    { settingId, newValue, personalityId, userId },
-    '[Character Overrides] Updating setting'
-  );
-
-  try {
-    // Map setting ID to cascade field
-    const body = mapSettingToApiUpdate(settingId, newValue);
-
-    if (body === null) {
-      return { success: false, error: 'Unknown setting' };
-    }
-
-    // Write to per-personality config overrides
-    const result = await callGatewayApi(
-      `/user/config-overrides/${encodeURIComponent(personalityId)}`,
-      {
-        method: 'PATCH',
-        body,
-        userId,
-        timeout: GATEWAY_TIMEOUTS.DEFERRED,
-      }
-    );
-
-    if (!result.ok) {
-      logger.warn(
-        { settingId, error: result.error, personalityId },
-        '[Character Overrides] Update failed'
-      );
-      return { success: false, error: result.error };
-    }
-
-    // Re-resolve cascade to get updated effective values
-    const cascadeResult = await callGatewayApi<ResolvedConfigOverrides>(
-      `/user/config-overrides/resolve/${encodeURIComponent(personalityId)}`,
-      { method: 'GET', userId, timeout: GATEWAY_TIMEOUTS.DEFERRED }
-    );
-
-    if (!cascadeResult.ok) {
-      return { success: false, error: 'Failed to fetch updated settings' };
-    }
-
-    const newData = convertToSettingsData(cascadeResult.data);
-
-    logger.info(
-      { settingId, newValue, personalityId, userId },
-      '[Character Overrides] Setting updated'
-    );
-
-    return { success: true, newData };
-  } catch (error) {
-    logger.error(
-      { err: error, settingId, personalityId },
-      '[Character Overrides] Error updating setting'
-    );
-    return { success: false, error: 'Failed to update setting' };
-  }
+  return convertCascadeToSettingsData(resolved, 'user-personality');
 }

--- a/services/bot-client/src/commands/character/settings.ts
+++ b/services/bot-client/src/commands/character/settings.ts
@@ -21,7 +21,6 @@ import {
   DISCORD_COLORS,
   GATEWAY_TIMEOUTS,
   type EnvConfig,
-  type ConfigOverrides,
   type ResolvedConfigOverrides,
   characterSettingsOptions,
 } from '@tzurot/common-types';
@@ -30,8 +29,7 @@ import { callGatewayApi } from '../../utils/userGatewayClient.js';
 import {
   type SettingsData,
   type SettingsDashboardConfig,
-  type SettingsDashboardSession,
-  type SettingUpdateResult,
+  type SettingUpdateHandler,
   type PersonalityResponse,
   createSettingsDashboard,
   handleSettingsSelectMenu,
@@ -43,9 +41,11 @@ import {
   MEMORY_SETTINGS,
   DISPLAY_SETTINGS,
   VOICE_CASCADE_SETTINGS,
-  mapSettingToApiUpdate,
-  buildCascadeSettingsData,
 } from '../../utils/dashboard/settings/index.js';
+import {
+  createSettingsUpdateHandler,
+  convertCascadeToSettingsData,
+} from '../../utils/dashboard/settings/settingsUpdateFactory.js';
 
 const logger = createLogger('character-settings');
 
@@ -219,110 +219,19 @@ export function isCharacterSettingsInteraction(customId: string): boolean {
   return isSettingsInteraction(customId, ENTITY_TYPE);
 }
 
-/**
- * Convert cascade-resolved overrides to dashboard SettingsData format.
- * Extracts local overrides by checking which fields the personality tier set.
- */
+/** Config for the character settings update handler (3-tier cascade, creator-only) */
+const CHARACTER_SETTINGS_UPDATE_CONFIG = {
+  patchEndpoint: (id: string) => `/user/config-overrides/personality/${encodeURIComponent(id)}`,
+  resolveEndpoint: (id: string) =>
+    `/user/config-overrides/resolve-personality/${encodeURIComponent(id)}`,
+  sourceTier: 'personality' as const,
+  logContext: '[Character Settings]',
+};
+
+function createUpdateHandler(personalityId: string): SettingUpdateHandler {
+  return createSettingsUpdateHandler(personalityId, CHARACTER_SETTINGS_UPDATE_CONFIG);
+}
+
 function convertToSettingsData(resolved: ResolvedConfigOverrides): SettingsData {
-  const localOverrides: Partial<ConfigOverrides> = {};
-  for (const [field, source] of Object.entries(resolved.sources)) {
-    if (source === 'personality') {
-      // Safe: we only iterate config field keys from resolved.sources, never the
-      // `sources` key itself, so the indexed value is always a config primitive.
-      // `as never` satisfies the union type that includes Record<string, string>.
-      localOverrides[field as keyof ConfigOverrides] = resolved[
-        field as keyof ResolvedConfigOverrides
-      ] as never;
-    }
-  }
-  return buildCascadeSettingsData(
-    resolved,
-    Object.keys(localOverrides).length > 0 ? localOverrides : null,
-    'personality'
-  );
-}
-
-/**
- * Create a settings update handler bound to a specific personality.
- * Returns a 4-param handler matching the SettingsUpdateHandler signature.
- */
-function createUpdateHandler(personalityId: string) {
-  return (
-    interaction: ButtonInteraction | ModalSubmitInteraction,
-    _session: SettingsDashboardSession,
-    settingId: string,
-    newValue: unknown
-  ): Promise<SettingUpdateResult> =>
-    handleSettingUpdate(interaction, settingId, newValue, personalityId);
-}
-
-/**
- * Handle setting updates from the dashboard
- * Writes to personality-level config defaults via cascade endpoint (creator-only)
- */
-async function handleSettingUpdate(
-  interaction: ButtonInteraction | ModalSubmitInteraction,
-  settingId: string,
-  newValue: unknown,
-  personalityId: string
-): Promise<SettingUpdateResult> {
-  const userId = interaction.user.id;
-
-  logger.debug(
-    { settingId, newValue, personalityId, userId },
-    '[Character Settings] Updating setting'
-  );
-
-  try {
-    // Map setting ID to cascade field
-    const body = mapSettingToApiUpdate(settingId, newValue);
-
-    if (body === null) {
-      return { success: false, error: 'Unknown setting' };
-    }
-
-    // Write to personality-level config defaults (creator-only)
-    const result = await callGatewayApi(
-      `/user/config-overrides/personality/${encodeURIComponent(personalityId)}`,
-      {
-        method: 'PATCH',
-        body,
-        userId,
-        timeout: GATEWAY_TIMEOUTS.DEFERRED,
-      }
-    );
-
-    if (!result.ok) {
-      logger.warn(
-        { settingId, error: result.error, personalityId },
-        '[Character Settings] Update failed'
-      );
-      return { success: false, error: result.error };
-    }
-
-    // Re-resolve 3-tier cascade to get updated effective values
-    const cascadeResult = await callGatewayApi<ResolvedConfigOverrides>(
-      `/user/config-overrides/resolve-personality/${encodeURIComponent(personalityId)}`,
-      { method: 'GET', userId, timeout: GATEWAY_TIMEOUTS.DEFERRED }
-    );
-
-    if (!cascadeResult.ok) {
-      return { success: false, error: 'Failed to fetch updated settings' };
-    }
-
-    const newData = convertToSettingsData(cascadeResult.data);
-
-    logger.info(
-      { settingId, newValue, personalityId, userId },
-      '[Character Settings] Setting updated'
-    );
-
-    return { success: true, newData };
-  } catch (error) {
-    logger.error(
-      { err: error, settingId, personalityId },
-      '[Character Settings] Error updating setting'
-    );
-    return { success: false, error: 'Failed to update setting' };
-  }
+  return convertCascadeToSettingsData(resolved, 'personality');
 }

--- a/services/bot-client/src/commands/persona/dashboard.test.ts
+++ b/services/bot-client/src/commands/persona/dashboard.test.ts
@@ -152,6 +152,62 @@ vi.mock('../../utils/dashboard/index.js', async () => {
   };
 });
 
+// The generic select menu handler imports these from source modules directly,
+// so mocks on the barrel file don't apply. Mirror the barrel mocks here.
+vi.mock('../../utils/dashboard/sessionHelpers.js', () => ({
+  fetchOrCreateSession: vi
+    .fn()
+    .mockImplementation(
+      async (opts: {
+        userId: string;
+        entityType: string;
+        entityId: string;
+        fetchFn: () => Promise<unknown>;
+        transformFn: (d: unknown) => unknown;
+      }) => {
+        const session = await mockSessionGet(opts.userId, opts.entityType, opts.entityId);
+        if (session !== null) {
+          return { success: true, data: session.data, fromCache: true };
+        }
+        const raw = await opts.fetchFn();
+        if (raw === null) {
+          return { success: false, error: 'not_found' };
+        }
+        const data = opts.transformFn(raw);
+        await mockSessionSet({
+          userId: opts.userId,
+          entityType: opts.entityType,
+          entityId: opts.entityId,
+          data,
+          messageId: 'message-123',
+          channelId: 'channel-123',
+        });
+        return { success: true, data, fromCache: false };
+      }
+    ),
+}));
+
+vi.mock('../../utils/dashboard/ModalFactory.js', () => ({
+  buildSectionModal: (...args: unknown[]) => mockBuildSectionModal(...args),
+}));
+
+vi.mock('../../utils/dashboard/types.js', async () => {
+  const actual = await vi.importActual('../../utils/dashboard/types.js');
+  return {
+    ...actual,
+    parseDashboardCustomId: vi.fn((customId: string) => {
+      const parts = customId.split('::');
+      if (parts[0] !== 'persona') return null;
+      return {
+        entityType: 'persona',
+        action: parts[1],
+        entityId: parts[2],
+        sectionId: parts[3],
+      };
+    }),
+  };
+});
+
 vi.mock('../../utils/dashboard/closeHandler.js', () => ({
   handleDashboardClose: vi.fn().mockResolvedValue(undefined),
 }));

--- a/services/bot-client/src/commands/persona/dashboard.ts
+++ b/services/bot-client/src/commands/persona/dashboard.ts
@@ -18,17 +18,15 @@ import { buildDeleteConfirmation } from '../../utils/dashboard/deleteConfirmatio
 import { handleDashboardClose } from '../../utils/dashboard/closeHandler.js';
 import { createRefreshHandler, refreshDashboardUI } from '../../utils/dashboard/refreshHandler.js';
 import {
-  buildSectionModal,
   extractAndMergeSectionValues,
   getSessionManager,
-  fetchOrCreateSession,
   requireDeferredSession,
   getSessionDataOrReply,
   parseDashboardCustomId,
   isDashboardInteraction,
-  DASHBOARD_MESSAGES,
   formatSessionExpiredMessage,
 } from '../../utils/dashboard/index.js';
+import { handleDashboardSectionSelect } from '../../utils/dashboard/genericSelectMenuHandler.js';
 import {
   PERSONA_DASHBOARD_CONFIG,
   type FlattenedPersonaData,
@@ -159,52 +157,13 @@ async function handleSectionModalSubmit(
  * Handle select menu interactions for dashboard
  */
 export async function handleSelectMenu(interaction: StringSelectMenuInteraction): Promise<void> {
-  const parsed = parseDashboardCustomId(interaction.customId);
-  if (parsed?.entityType !== 'persona' || parsed.entityId === undefined) {
-    return;
-  }
-
-  const value = interaction.values[0];
-  const entityId = parsed.entityId;
-
-  // Handle section edit selection
-  if (value.startsWith('edit-')) {
-    const sectionId = value.replace('edit-', '');
-    const section = PERSONA_DASHBOARD_CONFIG.sections.find(s => s.id === sectionId);
-    if (!section) {
-      await interaction.reply({
-        content: '❌ Unknown section.',
-        flags: MessageFlags.Ephemeral,
-      });
-      return;
-    }
-
-    // Get current data from session or fetch from API
-    const result = await fetchOrCreateSession<FlattenedPersonaData, PersonaDetails>({
-      userId: interaction.user.id,
-      entityType: 'persona',
-      entityId,
-      fetchFn: () => fetchPersona(entityId, interaction.user.id),
-      transformFn: flattenPersonaData,
-      interaction,
-    });
-    if (!result.success) {
-      await interaction.reply({
-        content: DASHBOARD_MESSAGES.NOT_FOUND('Persona'),
-        flags: MessageFlags.Ephemeral,
-      });
-      return;
-    }
-
-    // Build and show section modal
-    const modal = buildSectionModal<FlattenedPersonaData>(
-      PERSONA_DASHBOARD_CONFIG,
-      section,
-      entityId,
-      result.data
-    );
-    await interaction.showModal(modal);
-  }
+  await handleDashboardSectionSelect<FlattenedPersonaData, PersonaDetails>(interaction, {
+    entityType: 'persona',
+    dashboardConfig: PERSONA_DASHBOARD_CONFIG,
+    fetchFn: (entityId, userId) => fetchPersona(entityId, userId),
+    transformFn: flattenPersonaData,
+    entityName: 'Persona',
+  });
 }
 
 /**

--- a/services/bot-client/src/commands/preset/dashboard.test.ts
+++ b/services/bot-client/src/commands/preset/dashboard.test.ts
@@ -170,6 +170,53 @@ vi.mock('../../utils/dashboard/index.js', async () => {
   };
 });
 
+// The generic select menu handler imports these from source modules directly,
+// so mocks on the barrel file don't apply. Mirror the barrel mocks here.
+vi.mock('../../utils/dashboard/sessionHelpers.js', () => ({
+  fetchOrCreateSession: vi
+    .fn()
+    .mockImplementation(
+      async (opts: {
+        userId: string;
+        entityType: string;
+        entityId: string;
+        fetchFn: () => Promise<unknown>;
+        transformFn: (d: unknown) => unknown;
+      }) => {
+        const session = await mockSessionManagerGet(opts.userId, opts.entityType, opts.entityId);
+        if (session !== null) {
+          return { success: true, data: session.data, fromCache: true };
+        }
+        const raw = await opts.fetchFn();
+        if (raw === null) {
+          return { success: false, error: 'not_found' };
+        }
+        const data = opts.transformFn(raw);
+        await mockSessionManagerSet({
+          userId: opts.userId,
+          entityType: opts.entityType,
+          entityId: opts.entityId,
+          data,
+          messageId: 'message-789',
+          channelId: 'channel-999',
+        });
+        return { success: true, data, fromCache: false };
+      }
+    ),
+}));
+
+vi.mock('../../utils/dashboard/ModalFactory.js', () => ({
+  buildSectionModal: (...args: unknown[]) => mockBuildSectionModal(...args),
+}));
+
+vi.mock('../../utils/dashboard/types.js', async () => {
+  const actual = await vi.importActual('../../utils/dashboard/types.js');
+  return {
+    ...actual,
+    parseDashboardCustomId: (...args: unknown[]) => mockParseDashboardCustomId(...args),
+  };
+});
+
 vi.mock('../../utils/dashboard/closeHandler.js', () => ({
   handleDashboardClose: vi.fn().mockResolvedValue(undefined),
 }));

--- a/services/bot-client/src/commands/preset/dashboard.ts
+++ b/services/bot-client/src/commands/preset/dashboard.ts
@@ -17,14 +17,12 @@ import type {
 } from 'discord.js';
 import { createLogger, getConfig } from '@tzurot/common-types';
 import {
-  buildSectionModal,
   extractAndMergeSectionValues,
   getSessionManager,
-  fetchOrCreateSession,
   parseDashboardCustomId,
   isDashboardInteraction,
 } from '../../utils/dashboard/index.js';
-import { DASHBOARD_MESSAGES } from '../../utils/dashboard/messages.js';
+import { handleDashboardSectionSelect } from '../../utils/dashboard/genericSelectMenuHandler.js';
 import { refreshDashboardUI } from '../../utils/dashboard/refreshHandler.js';
 import {
   PRESET_DASHBOARD_CONFIG,
@@ -206,56 +204,14 @@ async function handleSectionModalSubmit(
  * Handle select menu interactions for dashboard
  */
 export async function handleSelectMenu(interaction: StringSelectMenuInteraction): Promise<void> {
-  const parsed = parseDashboardCustomId(interaction.customId);
-  if (parsed?.entityType !== 'preset' || parsed.entityId === undefined) {
-    return;
-  }
-
-  const value = interaction.values[0];
-  const entityId = parsed.entityId;
-
-  // Handle section edit selection
-  if (value.startsWith('edit-')) {
-    const sectionId = value.replace('edit-', '');
-    const section = PRESET_DASHBOARD_CONFIG.sections.find(s => s.id === sectionId);
-    if (section === undefined) {
-      await interaction.reply({
-        content: '❌ Unknown section.',
-        flags: MessageFlags.Ephemeral,
-      });
-      return;
-    }
-
-    // Get current data from session or fetch from API
-    const result = await fetchOrCreateSession<FlattenedPresetData, PresetData>({
-      userId: interaction.user.id,
-      entityType: 'preset',
-      entityId,
-      fetchFn: () => fetchPreset(entityId, interaction.user.id),
-      transformFn: flattenPresetData,
-      interaction,
-    });
-    if (!result.success) {
-      await interaction.reply({
-        content: DASHBOARD_MESSAGES.NOT_FOUND('Preset'),
-        flags: MessageFlags.Ephemeral,
-      });
-      return;
-    }
-
-    // Check if user can edit this preset (uses canEdit for admin support)
-    if (!result.data.canEdit) {
-      await interaction.reply({
-        content: DASHBOARD_MESSAGES.NO_PERMISSION('edit this preset'),
-        flags: MessageFlags.Ephemeral,
-      });
-      return;
-    }
-
-    // Build and show section modal
-    const modal = buildSectionModal(PRESET_DASHBOARD_CONFIG, section, entityId, result.data);
-    await interaction.showModal(modal);
-  }
+  await handleDashboardSectionSelect<FlattenedPresetData, PresetData>(interaction, {
+    entityType: 'preset',
+    dashboardConfig: PRESET_DASHBOARD_CONFIG,
+    fetchFn: (entityId, userId) => fetchPreset(entityId, userId),
+    transformFn: flattenPresetData,
+    entityName: 'Preset',
+    canEdit: data => data.canEdit === true,
+  });
 }
 
 /**

--- a/services/bot-client/src/utils/dashboard/genericSelectMenuHandler.test.ts
+++ b/services/bot-client/src/utils/dashboard/genericSelectMenuHandler.test.ts
@@ -58,14 +58,22 @@ const TEST_CONFIG: DashboardConfig<TestData> = {
   // Other required fields filled with minimal stubs
 } as never;
 
-function createInteraction(customId: string, value: string): never {
+interface MockInteraction {
+  customId: string;
+  values: string[];
+  user: { id: string };
+  reply: ReturnType<typeof vi.fn>;
+  showModal: ReturnType<typeof vi.fn>;
+}
+
+function createInteraction(customId: string, value: string): MockInteraction {
   return {
     customId,
     values: [value],
     user: { id: 'user-123' },
     reply: vi.fn().mockResolvedValue(undefined),
     showModal: vi.fn().mockResolvedValue(undefined),
-  } as never;
+  };
 }
 
 function createConfig(canEdit?: (data: TestData) => boolean): never {
@@ -91,7 +99,7 @@ describe('handleDashboardSectionSelect', () => {
     });
     const interaction = createInteraction('other::select::e1', 'edit-section-a');
 
-    await handleDashboardSectionSelect(interaction, createConfig());
+    await handleDashboardSectionSelect(interaction as never, createConfig());
 
     expect(mockFetchOrCreateSession).not.toHaveBeenCalled();
     expect(interaction.showModal).not.toHaveBeenCalled();
@@ -104,7 +112,7 @@ describe('handleDashboardSectionSelect', () => {
     });
     const interaction = createInteraction('test::select::', 'edit-section-a');
 
-    await handleDashboardSectionSelect(interaction, createConfig());
+    await handleDashboardSectionSelect(interaction as never, createConfig());
 
     expect(mockFetchOrCreateSession).not.toHaveBeenCalled();
   });
@@ -116,7 +124,7 @@ describe('handleDashboardSectionSelect', () => {
     });
     const interaction = createInteraction('test::select::e1', 'other-action');
 
-    await handleDashboardSectionSelect(interaction, createConfig());
+    await handleDashboardSectionSelect(interaction as never, createConfig());
 
     expect(mockFetchOrCreateSession).not.toHaveBeenCalled();
   });
@@ -128,7 +136,7 @@ describe('handleDashboardSectionSelect', () => {
     });
     const interaction = createInteraction('test::select::e1', 'edit-bogus-section');
 
-    await handleDashboardSectionSelect(interaction, createConfig());
+    await handleDashboardSectionSelect(interaction as never, createConfig());
 
     expect(interaction.reply).toHaveBeenCalledWith(
       expect.objectContaining({ content: '❌ Unknown section.' })
@@ -144,7 +152,7 @@ describe('handleDashboardSectionSelect', () => {
     mockFetchOrCreateSession.mockResolvedValue({ success: false, error: 'not_found' });
     const interaction = createInteraction('test::select::e1', 'edit-section-a');
 
-    await handleDashboardSectionSelect(interaction, createConfig());
+    await handleDashboardSectionSelect(interaction as never, createConfig());
 
     expect(interaction.reply).toHaveBeenCalledWith(
       expect.objectContaining({ content: '❌ Test not found.' })
@@ -165,7 +173,7 @@ describe('handleDashboardSectionSelect', () => {
     const interaction = createInteraction('test::select::e1', 'edit-section-a');
 
     await handleDashboardSectionSelect(
-      interaction,
+      interaction as never,
       createConfig(data => data.canEdit === true)
     );
 
@@ -188,7 +196,7 @@ describe('handleDashboardSectionSelect', () => {
     mockBuildSectionModal.mockReturnValue({ customId: 'modal-1' });
     const interaction = createInteraction('test::select::e1', 'edit-section-a');
 
-    await handleDashboardSectionSelect(interaction, createConfig());
+    await handleDashboardSectionSelect(interaction as never, createConfig());
 
     expect(mockBuildSectionModal).toHaveBeenCalled();
     expect(interaction.showModal).toHaveBeenCalledWith({ customId: 'modal-1' });
@@ -208,7 +216,7 @@ describe('handleDashboardSectionSelect', () => {
     const interaction = createInteraction('test::select::e1', 'edit-section-a');
 
     // No canEdit in config — should proceed regardless of data.canEdit
-    await handleDashboardSectionSelect(interaction, createConfig());
+    await handleDashboardSectionSelect(interaction as never, createConfig());
 
     expect(interaction.showModal).toHaveBeenCalled();
   });

--- a/services/bot-client/src/utils/dashboard/genericSelectMenuHandler.test.ts
+++ b/services/bot-client/src/utils/dashboard/genericSelectMenuHandler.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockFetchOrCreateSession, mockBuildSectionModal, mockParseDashboardCustomId } = vi.hoisted(
+  () => ({
+    mockFetchOrCreateSession: vi.fn(),
+    mockBuildSectionModal: vi.fn(),
+    mockParseDashboardCustomId: vi.fn(),
+  })
+);
+
+vi.mock('./sessionHelpers.js', () => ({
+  fetchOrCreateSession: mockFetchOrCreateSession,
+}));
+
+vi.mock('./ModalFactory.js', () => ({
+  buildSectionModal: mockBuildSectionModal,
+}));
+
+vi.mock('./types.js', async () => {
+  const actual = await vi.importActual('./types.js');
+  return {
+    ...actual,
+    parseDashboardCustomId: mockParseDashboardCustomId,
+  };
+});
+
+vi.mock('./messages.js', () => ({
+  DASHBOARD_MESSAGES: {
+    NOT_FOUND: (name: string) => `❌ ${name} not found.`,
+    NO_PERMISSION: (action: string) => `❌ You don't have permission to ${action}.`,
+  },
+}));
+
+import { handleDashboardSectionSelect } from './genericSelectMenuHandler.js';
+import type { DashboardConfig } from './types.js';
+
+interface TestData extends Record<string, unknown> {
+  name: string;
+  canEdit?: boolean;
+}
+
+interface TestRaw {
+  id: string;
+  rawName: string;
+  rawCanEdit?: boolean;
+}
+
+const TEST_CONFIG: DashboardConfig<TestData> = {
+  entityType: 'test',
+  title: 'Test Dashboard',
+  sections: [
+    {
+      id: 'section-a',
+      title: 'Section A',
+      fields: [{ id: 'name', label: 'Name', style: 1, required: true }],
+    },
+  ],
+  // Other required fields filled with minimal stubs
+} as never;
+
+function createInteraction(customId: string, value: string): never {
+  return {
+    customId,
+    values: [value],
+    user: { id: 'user-123' },
+    reply: vi.fn().mockResolvedValue(undefined),
+    showModal: vi.fn().mockResolvedValue(undefined),
+  } as never;
+}
+
+function createConfig(canEdit?: (data: TestData) => boolean): never {
+  return {
+    entityType: 'test',
+    dashboardConfig: TEST_CONFIG,
+    fetchFn: vi.fn().mockResolvedValue({ id: 'e1', rawName: 'Test', rawCanEdit: true }),
+    transformFn: (raw: TestRaw): TestData => ({ name: raw.rawName, canEdit: raw.rawCanEdit }),
+    entityName: 'Test',
+    canEdit,
+  } as never;
+}
+
+describe('handleDashboardSectionSelect', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns early when entityType does not match', async () => {
+    mockParseDashboardCustomId.mockReturnValue({
+      entityType: 'other',
+      entityId: 'e1',
+    });
+    const interaction = createInteraction('other::select::e1', 'edit-section-a');
+
+    await handleDashboardSectionSelect(interaction, createConfig());
+
+    expect(mockFetchOrCreateSession).not.toHaveBeenCalled();
+    expect(interaction.showModal).not.toHaveBeenCalled();
+  });
+
+  it('returns early when entityId is missing', async () => {
+    mockParseDashboardCustomId.mockReturnValue({
+      entityType: 'test',
+      entityId: undefined,
+    });
+    const interaction = createInteraction('test::select::', 'edit-section-a');
+
+    await handleDashboardSectionSelect(interaction, createConfig());
+
+    expect(mockFetchOrCreateSession).not.toHaveBeenCalled();
+  });
+
+  it('ignores values that do not start with "edit-"', async () => {
+    mockParseDashboardCustomId.mockReturnValue({
+      entityType: 'test',
+      entityId: 'e1',
+    });
+    const interaction = createInteraction('test::select::e1', 'other-action');
+
+    await handleDashboardSectionSelect(interaction, createConfig());
+
+    expect(mockFetchOrCreateSession).not.toHaveBeenCalled();
+  });
+
+  it('shows error for unknown section', async () => {
+    mockParseDashboardCustomId.mockReturnValue({
+      entityType: 'test',
+      entityId: 'e1',
+    });
+    const interaction = createInteraction('test::select::e1', 'edit-bogus-section');
+
+    await handleDashboardSectionSelect(interaction, createConfig());
+
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: '❌ Unknown section.' })
+    );
+    expect(mockFetchOrCreateSession).not.toHaveBeenCalled();
+  });
+
+  it('shows not-found error when session fetch fails', async () => {
+    mockParseDashboardCustomId.mockReturnValue({
+      entityType: 'test',
+      entityId: 'e1',
+    });
+    mockFetchOrCreateSession.mockResolvedValue({ success: false, error: 'not_found' });
+    const interaction = createInteraction('test::select::e1', 'edit-section-a');
+
+    await handleDashboardSectionSelect(interaction, createConfig());
+
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: '❌ Test not found.' })
+    );
+    expect(interaction.showModal).not.toHaveBeenCalled();
+  });
+
+  it('shows no-permission error when canEdit returns false', async () => {
+    mockParseDashboardCustomId.mockReturnValue({
+      entityType: 'test',
+      entityId: 'e1',
+    });
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { name: 'Test', canEdit: false },
+      fromCache: false,
+    });
+    const interaction = createInteraction('test::select::e1', 'edit-section-a');
+
+    await handleDashboardSectionSelect(
+      interaction,
+      createConfig(data => data.canEdit === true)
+    );
+
+    expect(interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: "❌ You don't have permission to edit this test." })
+    );
+    expect(interaction.showModal).not.toHaveBeenCalled();
+  });
+
+  it('builds and shows modal on successful flow', async () => {
+    mockParseDashboardCustomId.mockReturnValue({
+      entityType: 'test',
+      entityId: 'e1',
+    });
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { name: 'Test', canEdit: true },
+      fromCache: false,
+    });
+    mockBuildSectionModal.mockReturnValue({ customId: 'modal-1' });
+    const interaction = createInteraction('test::select::e1', 'edit-section-a');
+
+    await handleDashboardSectionSelect(interaction, createConfig());
+
+    expect(mockBuildSectionModal).toHaveBeenCalled();
+    expect(interaction.showModal).toHaveBeenCalledWith({ customId: 'modal-1' });
+  });
+
+  it('skips canEdit check when not provided', async () => {
+    mockParseDashboardCustomId.mockReturnValue({
+      entityType: 'test',
+      entityId: 'e1',
+    });
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { name: 'Test', canEdit: false }, // canEdit false but no check configured
+      fromCache: false,
+    });
+    mockBuildSectionModal.mockReturnValue({ customId: 'modal-1' });
+    const interaction = createInteraction('test::select::e1', 'edit-section-a');
+
+    // No canEdit in config — should proceed regardless of data.canEdit
+    await handleDashboardSectionSelect(interaction, createConfig());
+
+    expect(interaction.showModal).toHaveBeenCalled();
+  });
+});

--- a/services/bot-client/src/utils/dashboard/genericSelectMenuHandler.ts
+++ b/services/bot-client/src/utils/dashboard/genericSelectMenuHandler.ts
@@ -1,0 +1,105 @@
+/**
+ * Generic Dashboard Select Menu Handler
+ *
+ * Handles the "edit section" select menu flow shared by persona and preset
+ * dashboards. Both flows follow the same pattern:
+ * 1. Parse the custom ID and guard on entity type
+ * 2. Look up the section config
+ * 3. Fetch or create the session
+ * 4. Optionally verify edit permission
+ * 5. Build and show the section modal
+ *
+ * Extracted from persona/dashboard.ts and preset/dashboard.ts which had
+ * nearly-identical 47-line handleSelectMenu functions.
+ */
+
+import type { StringSelectMenuInteraction } from 'discord.js';
+import { MessageFlags } from 'discord.js';
+import { parseDashboardCustomId, type DashboardConfig } from './types.js';
+import { fetchOrCreateSession } from './sessionHelpers.js';
+import { buildSectionModal } from './ModalFactory.js';
+import { DASHBOARD_MESSAGES } from './messages.js';
+
+/** Configuration for a generic dashboard select menu handler */
+export interface GenericSelectMenuConfig<TFlat extends Record<string, unknown>, TRaw> {
+  /** Entity type string used for custom ID routing (e.g., 'persona', 'preset') */
+  entityType: string;
+  /** Dashboard config defining the sections and modal fields */
+  dashboardConfig: DashboardConfig<TFlat>;
+  /** Fetch the raw entity data from the API */
+  fetchFn: (entityId: string, userId: string) => Promise<TRaw | null>;
+  /** Transform raw API data to the flattened session format */
+  transformFn: (raw: TRaw) => TFlat;
+  /** Entity name used in user-facing error messages (e.g., 'Persona', 'Preset') */
+  entityName: string;
+  /**
+   * Optional permission check. Called after session data is fetched.
+   * If it returns false, sends a "no permission" error and aborts.
+   * Receives the flattened data, so it can inspect fields like `canEdit`.
+   */
+  canEdit?: (data: TFlat) => boolean;
+}
+
+/**
+ * Handle a dashboard select menu interaction for the "edit section" flow.
+ * Parses the custom ID, looks up the section, fetches the session, and
+ * shows the section modal. Silently returns if the interaction doesn't
+ * match the configured entity type.
+ */
+export async function handleDashboardSectionSelect<TFlat extends Record<string, unknown>, TRaw>(
+  interaction: StringSelectMenuInteraction,
+  config: GenericSelectMenuConfig<TFlat, TRaw>
+): Promise<void> {
+  const parsed = parseDashboardCustomId(interaction.customId);
+  if (parsed?.entityType !== config.entityType || parsed.entityId === undefined) {
+    return;
+  }
+
+  const value = interaction.values[0];
+  const entityId = parsed.entityId;
+
+  // Only handle 'edit-<sectionId>' values; caller's handler is responsible for other values
+  if (!value.startsWith('edit-')) {
+    return;
+  }
+
+  const sectionId = value.replace('edit-', '');
+  const section = config.dashboardConfig.sections.find(s => s.id === sectionId);
+  if (!section) {
+    await interaction.reply({
+      content: '❌ Unknown section.',
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  // Fetch or create the session
+  const result = await fetchOrCreateSession<TFlat, TRaw>({
+    userId: interaction.user.id,
+    entityType: config.entityType,
+    entityId,
+    fetchFn: () => config.fetchFn(entityId, interaction.user.id),
+    transformFn: config.transformFn,
+    interaction,
+  });
+  if (!result.success) {
+    await interaction.reply({
+      content: DASHBOARD_MESSAGES.NOT_FOUND(config.entityName),
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  // Optional permission check
+  if (config.canEdit && !config.canEdit(result.data)) {
+    await interaction.reply({
+      content: DASHBOARD_MESSAGES.NO_PERMISSION(`edit this ${config.entityName.toLowerCase()}`),
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  // Build and show the section modal
+  const modal = buildSectionModal<TFlat>(config.dashboardConfig, section, entityId, result.data);
+  await interaction.showModal(modal);
+}

--- a/services/bot-client/src/utils/dashboard/settings/index.ts
+++ b/services/bot-client/src/utils/dashboard/settings/index.ts
@@ -11,6 +11,7 @@ export {
   type SettingsDashboardSession,
   type SettingsDashboardConfig,
   type SettingSource,
+  type SettingUpdateHandler,
   type SettingUpdateResult,
   type SettingValue,
   type PersonalityResponse,

--- a/services/bot-client/src/utils/dashboard/settings/settingsUpdateFactory.test.ts
+++ b/services/bot-client/src/utils/dashboard/settings/settingsUpdateFactory.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockCallGatewayApi, mockMapSettingToApiUpdate } = vi.hoisted(() => ({
+  mockCallGatewayApi: vi.fn(),
+  mockMapSettingToApiUpdate: vi.fn(),
+}));
+
+vi.mock('../../userGatewayClient.js', () => ({
+  callGatewayApi: mockCallGatewayApi,
+}));
+
+vi.mock('./settingsUpdate.js', () => ({
+  mapSettingToApiUpdate: mockMapSettingToApiUpdate,
+}));
+
+import {
+  createSettingsUpdateHandler,
+  convertCascadeToSettingsData,
+  type SettingUpdateConfig,
+} from './settingsUpdateFactory.js';
+
+const TEST_CONFIG: SettingUpdateConfig = {
+  patchEndpoint: id => `/test/patch/${id}`,
+  resolveEndpoint: id => `/test/resolve/${id}`,
+  sourceTier: 'personality',
+  logContext: '[Test]',
+};
+
+const TEST_ENTITY_ID = '00000000-0000-0000-0000-000000000001';
+const TEST_USER_ID = 'discord-user-123';
+
+const mockSession = {} as never;
+const mockInteraction = {
+  user: { id: TEST_USER_ID },
+} as never;
+
+const fullResolvedCascade = {
+  maxMessages: 25,
+  maxAge: 86400,
+  maxImages: 5,
+  focusModeEnabled: false,
+  crossChannelHistoryEnabled: false,
+  shareLtmAcrossPersonalities: false,
+  memoryScoreThreshold: 0.7,
+  memoryLimit: 10,
+  showModelFooter: true,
+  voiceResponseMode: 'never',
+  voiceTranscriptionEnabled: false,
+  elevenlabsTtsModel: 'eleven_turbo_v2_5',
+  sources: {
+    maxMessages: 'personality',
+    maxAge: 'admin',
+    maxImages: 'hardcoded',
+    focusModeEnabled: 'hardcoded',
+    crossChannelHistoryEnabled: 'hardcoded',
+    shareLtmAcrossPersonalities: 'hardcoded',
+    memoryScoreThreshold: 'hardcoded',
+    memoryLimit: 'hardcoded',
+    showModelFooter: 'hardcoded',
+    voiceResponseMode: 'hardcoded',
+    voiceTranscriptionEnabled: 'hardcoded',
+    elevenlabsTtsModel: 'hardcoded',
+  },
+} as never;
+
+describe('convertCascadeToSettingsData', () => {
+  it('extracts fields matching the source tier as local overrides', () => {
+    const result = convertCascadeToSettingsData(fullResolvedCascade, 'personality');
+    expect(result.maxMessages.localValue).toBe(25);
+    expect(result.maxMessages.source).toBe('personality');
+  });
+
+  it('treats non-matching source tiers as non-local', () => {
+    const result = convertCascadeToSettingsData(fullResolvedCascade, 'user-personality');
+    // maxMessages is 'personality', not 'user-personality', so it should NOT be a local override
+    expect(result.maxMessages.localValue).toBeNull();
+  });
+});
+
+describe('createSettingsUpdateHandler', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockMapSettingToApiUpdate.mockReturnValue({ maxMessages: 50 });
+  });
+
+  it('uses the configured patch endpoint', async () => {
+    mockCallGatewayApi
+      .mockResolvedValueOnce({ ok: true, status: 200, data: {} })
+      .mockResolvedValueOnce({ ok: true, status: 200, data: fullResolvedCascade });
+
+    const handler = createSettingsUpdateHandler(TEST_ENTITY_ID, TEST_CONFIG);
+    const result = await handler(mockInteraction, mockSession, 'maxMessages', 50);
+
+    expect(result.success).toBe(true);
+    expect(mockCallGatewayApi).toHaveBeenNthCalledWith(
+      1,
+      `/test/patch/${TEST_ENTITY_ID}`,
+      expect.objectContaining({ method: 'PATCH', body: { maxMessages: 50 } })
+    );
+  });
+
+  it('uses the configured resolve endpoint on success', async () => {
+    mockCallGatewayApi
+      .mockResolvedValueOnce({ ok: true, status: 200, data: {} })
+      .mockResolvedValueOnce({ ok: true, status: 200, data: fullResolvedCascade });
+
+    const handler = createSettingsUpdateHandler(TEST_ENTITY_ID, TEST_CONFIG);
+    await handler(mockInteraction, mockSession, 'maxMessages', 50);
+
+    expect(mockCallGatewayApi).toHaveBeenNthCalledWith(
+      2,
+      `/test/resolve/${TEST_ENTITY_ID}`,
+      expect.objectContaining({ method: 'GET' })
+    );
+  });
+
+  it('returns error when mapSettingToApiUpdate returns null (unknown setting)', async () => {
+    mockMapSettingToApiUpdate.mockReturnValueOnce(null);
+
+    const handler = createSettingsUpdateHandler(TEST_ENTITY_ID, TEST_CONFIG);
+    const result = await handler(mockInteraction, mockSession, 'bogus-setting', 'value');
+
+    expect(result).toEqual({ success: false, error: 'Unknown setting' });
+    expect(mockCallGatewayApi).not.toHaveBeenCalled();
+  });
+
+  it('returns error when PATCH call fails', async () => {
+    mockCallGatewayApi.mockResolvedValueOnce({ ok: false, status: 500, error: 'Server error' });
+
+    const handler = createSettingsUpdateHandler(TEST_ENTITY_ID, TEST_CONFIG);
+    const result = await handler(mockInteraction, mockSession, 'maxMessages', 50);
+
+    expect(result).toEqual({ success: false, error: 'Server error' });
+    // Should not have called resolve endpoint
+    expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns error when resolve call fails after successful PATCH', async () => {
+    mockCallGatewayApi
+      .mockResolvedValueOnce({ ok: true, status: 200, data: {} })
+      .mockResolvedValueOnce({ ok: false, status: 500, error: 'Resolve error' });
+
+    const handler = createSettingsUpdateHandler(TEST_ENTITY_ID, TEST_CONFIG);
+    const result = await handler(mockInteraction, mockSession, 'maxMessages', 50);
+
+    expect(result.success).toBe(false);
+    expect(result).toMatchObject({ error: 'Failed to fetch updated settings' });
+  });
+
+  it('handles unexpected exceptions', async () => {
+    mockCallGatewayApi.mockRejectedValueOnce(new Error('Network down'));
+
+    const handler = createSettingsUpdateHandler(TEST_ENTITY_ID, TEST_CONFIG);
+    const result = await handler(mockInteraction, mockSession, 'maxMessages', 50);
+
+    expect(result).toEqual({ success: false, error: 'Failed to update setting' });
+  });
+
+  it('returns newData derived from the configured sourceTier', async () => {
+    mockCallGatewayApi
+      .mockResolvedValueOnce({ ok: true, status: 200, data: {} })
+      .mockResolvedValueOnce({ ok: true, status: 200, data: fullResolvedCascade });
+
+    const handler = createSettingsUpdateHandler(TEST_ENTITY_ID, TEST_CONFIG);
+    const result = await handler(mockInteraction, mockSession, 'maxMessages', 50);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // sourceTier was 'personality', so maxMessages (source: 'personality') should be local
+      expect(result.newData.maxMessages.localValue).toBe(25);
+    }
+  });
+});

--- a/services/bot-client/src/utils/dashboard/settings/settingsUpdateFactory.test.ts
+++ b/services/bot-client/src/utils/dashboard/settings/settingsUpdateFactory.test.ts
@@ -165,9 +165,7 @@ describe('createSettingsUpdateHandler', () => {
     const result = await handler(mockInteraction, mockSession, 'maxMessages', 50);
 
     expect(result.success).toBe(true);
-    if (result.success) {
-      // sourceTier was 'personality', so maxMessages (source: 'personality') should be local
-      expect(result.newData.maxMessages.localValue).toBe(25);
-    }
+    // sourceTier was 'personality', so maxMessages (source: 'personality') should be local
+    expect(result.newData?.maxMessages.localValue).toBe(25);
   });
 });

--- a/services/bot-client/src/utils/dashboard/settings/settingsUpdateFactory.ts
+++ b/services/bot-client/src/utils/dashboard/settings/settingsUpdateFactory.ts
@@ -1,0 +1,144 @@
+/**
+ * Settings Update Handler Factory
+ *
+ * Creates a SettingUpdateHandler for a settings dashboard. Extracted from
+ * character/settings.ts and character/overrides.ts, which had nearly-identical
+ * 80-line handleSettingUpdate implementations differing only in endpoints,
+ * source tier, and log context.
+ *
+ * Flow:
+ * 1. Map setting ID to API patch body via mapSettingToApiUpdate
+ * 2. PATCH to the configured endpoint
+ * 3. Re-resolve the cascade via the configured resolve endpoint
+ * 4. Convert resolved cascade back to SettingsData (filtering by source tier)
+ */
+
+import type { ButtonInteraction, ModalSubmitInteraction } from 'discord.js';
+import {
+  createLogger,
+  GATEWAY_TIMEOUTS,
+  type ConfigOverrides,
+  type ConfigOverrideSource,
+  type ResolvedConfigOverrides,
+} from '@tzurot/common-types';
+import { callGatewayApi } from '../../userGatewayClient.js';
+import type {
+  SettingsData,
+  SettingsDashboardSession,
+  SettingUpdateHandler,
+  SettingUpdateResult,
+} from './types.js';
+import { mapSettingToApiUpdate } from './settingsUpdate.js';
+import { buildCascadeSettingsData } from './settingsDataBuilder.js';
+
+const logger = createLogger('settingsUpdateFactory');
+
+/** Configuration for a settings update handler */
+export interface SettingUpdateConfig {
+  /** Function to build the PATCH endpoint from entityId (e.g., personalityId) */
+  patchEndpoint: (entityId: string) => string;
+  /** Function to build the GET resolve endpoint from entityId */
+  resolveEndpoint: (entityId: string) => string;
+  /** Source tier to treat as "local" when converting the resolved cascade */
+  sourceTier: ConfigOverrideSource;
+  /** Log context prefix (e.g., '[Character Settings]') */
+  logContext: string;
+}
+
+/**
+ * Convert a resolved cascade back to dashboard SettingsData, extracting the
+ * local-tier overrides by matching the configured source.
+ */
+export function convertCascadeToSettingsData(
+  resolved: ResolvedConfigOverrides,
+  sourceTier: ConfigOverrideSource
+): SettingsData {
+  const localOverrides: Partial<ConfigOverrides> = {};
+  for (const [field, source] of Object.entries(resolved.sources)) {
+    if (source === sourceTier) {
+      // Safe: we only iterate config field keys from resolved.sources, never the
+      // `sources` key itself, so the indexed value is always a config primitive.
+      localOverrides[field as keyof ConfigOverrides] = resolved[
+        field as keyof ResolvedConfigOverrides
+      ] as never;
+    }
+  }
+  return buildCascadeSettingsData(
+    resolved,
+    Object.keys(localOverrides).length > 0 ? localOverrides : null,
+    sourceTier
+  );
+}
+
+/**
+ * Create a settings update handler bound to a specific entity ID.
+ * The returned handler matches the SettingUpdateHandler signature and can be
+ * passed directly to handleSettingsSelectMenu/Button/Modal.
+ */
+export function createSettingsUpdateHandler(
+  entityId: string,
+  config: SettingUpdateConfig
+): SettingUpdateHandler {
+  return async (
+    interaction: ButtonInteraction | ModalSubmitInteraction,
+    _session: SettingsDashboardSession,
+    settingId: string,
+    newValue: unknown
+  ): Promise<SettingUpdateResult> => {
+    const userId = interaction.user.id;
+
+    logger.debug(
+      { settingId, newValue, entityId, userId },
+      `${config.logContext} Updating setting`
+    );
+
+    try {
+      // Map setting ID to cascade field
+      const body = mapSettingToApiUpdate(settingId, newValue);
+      if (body === null) {
+        return { success: false, error: 'Unknown setting' };
+      }
+
+      // Write the patch to the configured endpoint
+      const result = await callGatewayApi(config.patchEndpoint(entityId), {
+        method: 'PATCH',
+        body,
+        userId,
+        timeout: GATEWAY_TIMEOUTS.DEFERRED,
+      });
+
+      if (!result.ok) {
+        logger.warn(
+          { settingId, error: result.error, entityId },
+          `${config.logContext} Update failed`
+        );
+        return { success: false, error: result.error };
+      }
+
+      // Re-resolve cascade to get updated effective values
+      const cascadeResult = await callGatewayApi<ResolvedConfigOverrides>(
+        config.resolveEndpoint(entityId),
+        { method: 'GET', userId, timeout: GATEWAY_TIMEOUTS.DEFERRED }
+      );
+
+      if (!cascadeResult.ok) {
+        return { success: false, error: 'Failed to fetch updated settings' };
+      }
+
+      const newData = convertCascadeToSettingsData(cascadeResult.data, config.sourceTier);
+
+      logger.info(
+        { settingId, newValue, entityId, userId },
+        `${config.logContext} Setting updated`
+      );
+
+      return { success: true, newData };
+    } catch (error) {
+      logger.error(
+        { err: error, settingId, entityId },
+        `${config.logContext} Error updating setting`
+      );
+      return { success: false, error: 'Failed to update setting' };
+    }
+  };
+}


### PR DESCRIPTION
## Summary

Two shared abstractions extracted from near-identical dashboard code across 4 files:

### 1. Settings Update Handler Factory (~160 lines eliminated)

Both `character/settings.ts` and `character/overrides.ts` had 80-line `handleSettingUpdate` + wrapper implementations differing only in:
- PATCH endpoint (personality tier vs user-personality tier)
- Resolve endpoint (resolve-personality vs resolve)
- Source tier in the cascade-to-settings conversion
- Log context

New `createSettingsUpdateHandler(entityId, config)` factory + `convertCascadeToSettingsData()` helper.

- `character/settings.ts`: 329 → 234 lines
- `character/overrides.ts`: 332 → 237 lines
- New `settingsUpdateFactory.ts`: 144 lines (+ 9 tests)

### 2. Generic Dashboard Section Select Handler (~94 lines eliminated)

Both `persona/dashboard.ts` and `preset/dashboard.ts` had 47-line `handleSelectMenu` functions parsing custom IDs → looking up sections → fetching sessions → building modals. Only entity type, config, fetch/transform functions, and an optional permission check differed.

New `handleDashboardSectionSelect()` with typed `GenericSelectMenuConfig<TFlat, TRaw>`. Preset uses the `canEdit` hook for admin-aware permission checks.

- `persona/dashboard.ts`: 485 → 437 lines
- `preset/dashboard.ts`: 338 → 290 lines
- New `genericSelectMenuHandler.ts`: 108 lines (+ 8 tests)

## Impact

- **Duplication eliminated**: ~254 lines
- **CPD**: 137 → 132 (-5 clones)
- **Tests**: 4166 passing (17 new) — full bot-client suite green
- **Maintainability**: Adding a new dashboard variant now requires ~10 lines instead of ~200

## Test plan

- [x] 17 new tests for both helpers cover happy path, error paths, and edge cases
- [x] All existing dashboard tests pass (character/settings, character/overrides, persona/dashboard, preset/dashboard)
- [x] Full bot-client suite: 4166 tests passing
- [x] `pnpm quality` clean (lint, cpd, depcruise, typecheck, typecheck:spec)
- [ ] CI passes

## Notes

Dashboard tests had to add mocks for source modules (`sessionHelpers.js`, `ModalFactory.js`, `types.js`) because the new generic handler imports from source per project rule 02-code-standards ("Import from source modules, not index files").

🤖 Generated with [Claude Code](https://claude.com/claude-code)