### PR TITLE
refactor(api-gateway): extract shared user-resolution and LLM config validation helpers (CPD Session 1b)

### DIFF
--- a/services/api-gateway/src/routes/admin/llm-config.test.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.test.ts
@@ -16,6 +16,16 @@ vi.mock('../../services/AuthMiddleware.js', () => ({
   },
 }));
 
+// Mock validateLlmConfigModelFields so tests can force early-return on
+// invalid-model paths without orchestrating a full model cache.
+const { mockValidateLlmConfigModelFields } = vi.hoisted(() => ({
+  mockValidateLlmConfigModelFields: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('../../utils/llmConfigValidation.js', () => ({
+  validateLlmConfigModelFields: mockValidateLlmConfigModelFields,
+}));
+
 const createMockCacheInvalidationService = () => ({
   invalidateAll: vi.fn().mockResolvedValue(undefined),
   invalidateUserLlmConfig: vi.fn().mockResolvedValue(undefined),
@@ -247,6 +257,25 @@ describe('Admin LLM Config Routes', () => {
   });
 
   describe('POST /admin/llm-config', () => {
+    it('should return 400 when model validation fails on create', async () => {
+      // Mock must write the error to res before returning false — matches the
+      // real helper's contract. Otherwise supertest hangs waiting for a response.
+      mockValidateLlmConfigModelFields.mockImplementationOnce(
+        async (opts: { res: { status: (n: number) => { json: (body: unknown) => unknown } } }) => {
+          opts.res.status(400).json({ error: 'VALIDATION_ERROR', message: 'Test: invalid model' });
+          return false;
+        }
+      );
+
+      const response = await request(app)
+        .post('/admin/llm-config')
+        .send({ name: 'Bad Config', model: 'invalid-model' });
+
+      expect(mockValidateLlmConfigModelFields).toHaveBeenCalled();
+      expect(prisma.llmConfig.create).not.toHaveBeenCalled();
+      expect(response.status).toBe(400);
+    });
+
     it('should create a global LLM config', async () => {
       prisma.llmConfig.findFirst.mockResolvedValue(null);
       prisma.llmConfig.create.mockResolvedValue({
@@ -360,6 +389,25 @@ describe('Admin LLM Config Routes', () => {
   });
 
   describe('PUT /admin/llm-config/:id', () => {
+    it('should return 400 when model validation fails on update', async () => {
+      mockValidateLlmConfigModelFields.mockImplementationOnce(
+        async (opts: { res: { status: (n: number) => { json: (body: unknown) => unknown } } }) => {
+          opts.res
+            .status(400)
+            .json({ error: 'VALIDATION_ERROR', message: 'Test: context too large' });
+          return false;
+        }
+      );
+
+      const response = await request(app)
+        .put('/admin/llm-config/config-id')
+        .send({ contextWindowTokens: 999999999 });
+
+      expect(mockValidateLlmConfigModelFields).toHaveBeenCalled();
+      expect(prisma.llmConfig.update).not.toHaveBeenCalled();
+      expect(response.status).toBe(400);
+    });
+
     it('should update a global config', async () => {
       prisma.llmConfig.findUnique.mockResolvedValue({
         id: 'config-id',

--- a/services/api-gateway/src/routes/admin/llm-config.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.ts
@@ -30,10 +30,8 @@ import { getParam } from '../../utils/requestParams.js';
 import type { AuthenticatedRequest } from '../../types.js';
 import { LlmConfigService } from '../../services/LlmConfigService.js';
 import type { OpenRouterModelCache } from '../../services/OpenRouterModelCache.js';
-import {
-  validateModelAndContextWindow,
-  enrichWithModelContext,
-} from '../../utils/modelValidation.js';
+import { enrichWithModelContext } from '../../utils/modelValidation.js';
+import { validateLlmConfigModelFields } from '../../utils/llmConfigValidation.js';
 
 const logger = createLogger('admin-llm-config');
 
@@ -83,14 +81,8 @@ function createCreateConfigHandler(
     }
     const body = parseResult.data;
 
-    // Validate model ID and context window cap
-    const modelValidation = await validateModelAndContextWindow(
-      modelCache,
-      body.model,
-      body.contextWindowTokens
-    );
-    if (modelValidation.error !== undefined) {
-      return sendError(res, ErrorResponses.validationError(modelValidation.error));
+    if (!(await validateLlmConfigModelFields({ res, modelCache, body }))) {
+      return;
     }
 
     // Get admin user's internal ID for ownership
@@ -140,21 +132,15 @@ function createEditConfigHandler(
     }
     const body = parseResult.data;
 
-    // Validate model ID and context window cap if either is being updated
-    if (body.model !== undefined || body.contextWindowTokens !== undefined) {
-      let effectiveModel = body.model;
-      if (effectiveModel === undefined) {
-        const current = await service.getById(configId ?? '');
-        effectiveModel = current?.model;
-      }
-      const modelValidation = await validateModelAndContextWindow(
+    if (
+      !(await validateLlmConfigModelFields({
+        res,
         modelCache,
-        effectiveModel,
-        body.contextWindowTokens
-      );
-      if (modelValidation.error !== undefined) {
-        return sendError(res, ErrorResponses.validationError(modelValidation.error));
-      }
+        body,
+        fallback: { service, configId: configId ?? '' },
+      }))
+    ) {
+      return;
     }
 
     const existing = await prisma.llmConfig.findUnique({

--- a/services/api-gateway/src/routes/user/config-overrides.test.ts
+++ b/services/api-gateway/src/routes/user/config-overrides.test.ts
@@ -282,6 +282,19 @@ describe('/user/config-overrides routes', () => {
   });
 
   describe('GET /defaults', () => {
+    it('should return 400 when user is a bot', async () => {
+      mockGetOrCreateUser.mockResolvedValueOnce(null);
+
+      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const handler = getHandler(router, 'get', '/defaults');
+      const { req, res } = createMockReqRes();
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'VALIDATION_ERROR' }));
+    });
+
     it('should return null when no config defaults set', async () => {
       const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
       const handler = getHandler(router, 'get', '/defaults');
@@ -314,6 +327,19 @@ describe('/user/config-overrides routes', () => {
   });
 
   describe('PATCH /defaults', () => {
+    it('should return 400 when user is a bot', async () => {
+      mockGetOrCreateUser.mockResolvedValueOnce(null);
+
+      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const handler = getHandler(router, 'patch', '/defaults');
+      const { req, res } = createMockReqRes({ maxImages: 5 });
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'VALIDATION_ERROR' }));
+    });
+
     it('should merge valid overrides with existing defaults', async () => {
       mockPrisma.user.findUnique.mockResolvedValue({
         configDefaults: { maxMessages: 30 },
@@ -369,6 +395,19 @@ describe('/user/config-overrides routes', () => {
   });
 
   describe('DELETE /defaults', () => {
+    it('should return 400 when user is a bot', async () => {
+      mockGetOrCreateUser.mockResolvedValueOnce(null);
+
+      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const handler = getHandler(router, 'delete', '/defaults');
+      const { req, res } = createMockReqRes();
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'VALIDATION_ERROR' }));
+    });
+
     it('should clear user config defaults', async () => {
       const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
       const handler = getHandler(router, 'delete', '/defaults');
@@ -454,6 +493,22 @@ describe('/user/config-overrides routes', () => {
   });
 
   describe('PATCH /:personalityId', () => {
+    it('should return 400 when user is a bot', async () => {
+      mockGetOrCreateUser.mockResolvedValueOnce(null);
+
+      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const handler = getHandler(router, 'patch', '/:personalityId');
+      const { req, res } = createMockReqRes(
+        { maxMessages: 25 },
+        { personalityId: TEST_PERSONALITY_ID }
+      );
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'VALIDATION_ERROR' }));
+    });
+
     it('should reject non-UUID personalityId', async () => {
       const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
       const handler = getHandler(router, 'patch', '/:personalityId');
@@ -555,6 +610,19 @@ describe('/user/config-overrides routes', () => {
   });
 
   describe('DELETE /:personalityId', () => {
+    it('should return 400 when user is a bot', async () => {
+      mockGetOrCreateUser.mockResolvedValueOnce(null);
+
+      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const handler = getHandler(router, 'delete', '/:personalityId');
+      const { req, res } = createMockReqRes({}, { personalityId: TEST_PERSONALITY_ID });
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'VALIDATION_ERROR' }));
+    });
+
     it('should reject non-UUID personalityId', async () => {
       const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
       const handler = getHandler(router, 'delete', '/:personalityId');

--- a/services/api-gateway/src/routes/user/config-overrides.ts
+++ b/services/api-gateway/src/routes/user/config-overrides.ts
@@ -34,6 +34,7 @@ import { asyncHandler } from '../../utils/asyncHandler.js';
 import {
   tryInvalidateCache,
   mergeAndValidateOverrides,
+  resolveUserIdOrSendError,
 } from '../../utils/configOverrideHelpers.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
@@ -41,8 +42,6 @@ import { getRequiredParam } from '../../utils/requestParams.js';
 import type { AuthenticatedRequest } from '../../types.js';
 
 const logger = createLogger('user-config-overrides');
-
-const BOT_USER_ERROR = 'Cannot create user for bot';
 
 /** Parse and validate a config tier's JSONB value. Returns null if absent or invalid. */
 function parseConfigTier(raw: unknown): Record<string, unknown> | null {
@@ -82,9 +81,9 @@ export function createConfigOverrideRoutes(
   router.get(
     '/resolve-defaults',
     asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
-      const userId = await userService.getOrCreateUser(req.userId, req.userId);
+      const userId = await resolveUserIdOrSendError(userService, req.userId, res);
       if (userId === null) {
-        return sendError(res, ErrorResponses.validationError(BOT_USER_ERROR));
+        return;
       }
 
       // Load admin and user tiers in parallel
@@ -142,9 +141,9 @@ export function createConfigOverrideRoutes(
   router.get(
     '/defaults',
     asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
-      const userId = await userService.getOrCreateUser(req.userId, req.userId);
+      const userId = await resolveUserIdOrSendError(userService, req.userId, res);
       if (userId === null) {
-        return sendError(res, ErrorResponses.validationError(BOT_USER_ERROR));
+        return;
       }
 
       const user = await prisma.user.findUnique({
@@ -168,9 +167,9 @@ export function createConfigOverrideRoutes(
   router.patch(
     '/defaults',
     asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
-      const userId = await userService.getOrCreateUser(req.userId, req.userId);
+      const userId = await resolveUserIdOrSendError(userService, req.userId, res);
       if (userId === null) {
-        return sendError(res, ErrorResponses.validationError(BOT_USER_ERROR));
+        return;
       }
 
       const user = await prisma.user.findUnique({
@@ -208,9 +207,9 @@ export function createConfigOverrideRoutes(
   router.delete(
     '/defaults',
     asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
-      const userId = await userService.getOrCreateUser(req.userId, req.userId);
+      const userId = await resolveUserIdOrSendError(userService, req.userId, res);
       if (userId === null) {
-        return sendError(res, ErrorResponses.validationError(BOT_USER_ERROR));
+        return;
       }
 
       await prisma.user.update({
@@ -264,9 +263,9 @@ export function createConfigOverrideRoutes(
         return sendError(res, ErrorResponses.validationError('Invalid personalityId format'));
       }
 
-      const userId = await userService.getOrCreateUser(req.userId, req.userId);
+      const userId = await resolveUserIdOrSendError(userService, req.userId, res);
       if (userId === null) {
-        return sendError(res, ErrorResponses.validationError(BOT_USER_ERROR));
+        return;
       }
 
       // Upsert UserPersonalityConfig with deterministic UUID
@@ -321,9 +320,9 @@ export function createConfigOverrideRoutes(
         return sendError(res, ErrorResponses.validationError('Invalid personalityId format'));
       }
 
-      const userId = await userService.getOrCreateUser(req.userId, req.userId);
+      const userId = await resolveUserIdOrSendError(userService, req.userId, res);
       if (userId === null) {
-        return sendError(res, ErrorResponses.validationError(BOT_USER_ERROR));
+        return;
       }
 
       const upcId = generateUserPersonalityConfigUuid(userId, personalityId);

--- a/services/api-gateway/src/routes/user/llm-config.test.ts
+++ b/services/api-gateway/src/routes/user/llm-config.test.ts
@@ -398,6 +398,10 @@ describe('/user/llm-config routes', () => {
     });
 
     it('should return 400 when model validation fails on create', async () => {
+      // Mock req/res approach — no real HTTP client, so returning `false` without
+      // calling res.status()/res.json() is safe. Contrast with admin/llm-config.test.ts
+      // which uses supertest and must have the mock write the error response to res
+      // (otherwise supertest hangs waiting for a response that never comes).
       mockValidateLlmConfigModelFields.mockResolvedValueOnce(false);
 
       const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);

--- a/services/api-gateway/src/routes/user/llm-config.test.ts
+++ b/services/api-gateway/src/routes/user/llm-config.test.ts
@@ -71,6 +71,19 @@ vi.mock('../../utils/asyncHandler.js', () => ({
   asyncHandler: vi.fn(fn => fn),
 }));
 
+// Mock validateLlmConfigModelFields so tests can force early-return on
+// invalid-model paths without orchestrating full model cache + Zod responses.
+// resolveUserIdOrSendError is NOT mocked here — tests that need the bot-user
+// early-return path spy on UserService.prototype.getOrCreateUser directly so
+// existing tests asserting on UserService.$transaction side effects still work.
+const { mockValidateLlmConfigModelFields } = vi.hoisted(() => ({
+  mockValidateLlmConfigModelFields: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('../../utils/llmConfigValidation.js', () => ({
+  validateLlmConfigModelFields: mockValidateLlmConfigModelFields,
+}));
+
 // Mock Prisma with UserService dependencies
 const mockPrisma = {
   user: {
@@ -126,7 +139,7 @@ const mockCacheInvalidation = {
 
 import { createLlmConfigRoutes } from './llm-config.js';
 import { getRouteHandler, findRoute } from '../../test/expressRouterUtils.js';
-import type { PrismaClient } from '@tzurot/common-types';
+import { UserService, type PrismaClient } from '@tzurot/common-types';
 
 // Helper to create mock request/response
 function createMockReqRes(body: Record<string, unknown> = {}, params: Record<string, string> = {}) {
@@ -365,6 +378,39 @@ describe('/user/llm-config routes', () => {
   });
 
   describe('POST /user/llm-config', () => {
+    it('should return 400 when user is a bot', async () => {
+      const getOrCreateUserSpy = vi
+        .spyOn(UserService.prototype, 'getOrCreateUser')
+        .mockResolvedValueOnce(null);
+
+      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const handler = getHandler(router, 'post', '/');
+      const { req, res } = createMockReqRes({ name: 'My Config', model: 'gpt-4' });
+
+      await handler(req, res);
+
+      expect(getOrCreateUserSpy).toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'VALIDATION_ERROR' }));
+      expect(mockPrisma.llmConfig.create).not.toHaveBeenCalled();
+
+      getOrCreateUserSpy.mockRestore();
+    });
+
+    it('should return 400 when model validation fails on create', async () => {
+      mockValidateLlmConfigModelFields.mockResolvedValueOnce(false);
+
+      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const handler = getHandler(router, 'post', '/');
+      const { req, res } = createMockReqRes({ name: 'My Config', model: 'bad-model' });
+
+      await handler(req, res);
+
+      // The mock returned false; route should have bailed before creating anything
+      expect(mockValidateLlmConfigModelFields).toHaveBeenCalled();
+      expect(mockPrisma.llmConfig.create).not.toHaveBeenCalled();
+    });
+
     it('should reject missing name', async () => {
       const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
       const handler = getHandler(router, 'post', '/');
@@ -562,6 +608,25 @@ describe('/user/llm-config routes', () => {
   });
 
   describe('PUT /user/llm-config/:id', () => {
+    it('should return 400 when model validation fails on update', async () => {
+      mockValidateLlmConfigModelFields.mockResolvedValueOnce(false);
+
+      const router = createLlmConfigRoutes(
+        mockPrisma as unknown as PrismaClient,
+        mockCacheInvalidation
+      );
+      const handler = getHandler(router, 'put', '/:id');
+      const { req, res } = createMockReqRes(
+        { contextWindowTokens: 999999999 },
+        { id: 'config-123' }
+      );
+
+      await handler(req, res);
+
+      expect(mockValidateLlmConfigModelFields).toHaveBeenCalled();
+      expect(mockPrisma.llmConfig.update).not.toHaveBeenCalled();
+    });
+
     it('should return 404 when user not found', async () => {
       mockPrisma.user.findFirst.mockResolvedValue(null);
 

--- a/services/api-gateway/src/routes/user/llm-config.ts
+++ b/services/api-gateway/src/routes/user/llm-config.ts
@@ -29,15 +29,14 @@ import { requireUserAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
+import { resolveUserIdOrSendError } from '../../utils/configOverrideHelpers.js';
 import { sendZodError } from '../../utils/zodHelpers.js';
 import { getParam } from '../../utils/requestParams.js';
 import type { AuthenticatedRequest } from '../../types.js';
 import { LlmConfigService, type LlmConfigScope } from '../../services/LlmConfigService.js';
 import type { OpenRouterModelCache } from '../../services/OpenRouterModelCache.js';
-import {
-  validateModelAndContextWindow,
-  enrichWithModelContext,
-} from '../../utils/modelValidation.js';
+import { enrichWithModelContext } from '../../utils/modelValidation.js';
+import { validateLlmConfigModelFields } from '../../utils/llmConfigValidation.js';
 import { createResolveHandler } from './llmConfigResolve.js';
 
 const logger = createLogger('user-llm-config');
@@ -141,20 +140,14 @@ function createCreateHandler(
     }
     const body = parseResult.data;
 
-    // Validate model ID and context window cap
-    const modelValidation = await validateModelAndContextWindow(
-      modelCache,
-      body.model,
-      body.contextWindowTokens
-    );
-    if (modelValidation.error !== undefined) {
-      return sendError(res, ErrorResponses.validationError(modelValidation.error));
+    if (!(await validateLlmConfigModelFields({ res, modelCache, body }))) {
+      return;
     }
 
     // Get or create user
-    const userId = await userService.getOrCreateUser(discordUserId, discordUserId);
+    const userId = await resolveUserIdOrSendError(userService, discordUserId, res);
     if (userId === null) {
-      return sendError(res, ErrorResponses.validationError('Cannot create user for bot'));
+      return;
     }
 
     // Check for duplicate name using service
@@ -216,23 +209,15 @@ function createUpdateHandler(
     }
     const body = parseResult.data;
 
-    // Validate model ID and context window cap if either is being updated
-    if (body.model !== undefined || body.contextWindowTokens !== undefined) {
-      // For context window validation, we need the effective model:
-      // use the new model if provided, otherwise look up the existing config's model
-      let effectiveModel = body.model;
-      if (effectiveModel === undefined) {
-        const existing = await service.getById(configId ?? '');
-        effectiveModel = existing?.model;
-      }
-      const modelValidation = await validateModelAndContextWindow(
+    if (
+      !(await validateLlmConfigModelFields({
+        res,
         modelCache,
-        effectiveModel,
-        body.contextWindowTokens
-      );
-      if (modelValidation.error !== undefined) {
-        return sendError(res, ErrorResponses.validationError(modelValidation.error));
-      }
+        body,
+        fallback: { service, configId: configId ?? '' },
+      }))
+    ) {
+      return;
     }
 
     const user = await prisma.user.findFirst({

--- a/services/api-gateway/src/routes/user/model-override.test.ts
+++ b/services/api-gateway/src/routes/user/model-override.test.ts
@@ -70,7 +70,7 @@ const mockPrisma = {
 
 import { createModelOverrideRoutes } from './model-override.js';
 import { getRouteHandler, findRoute } from '../../test/expressRouterUtils.js';
-import type { PrismaClient } from '@tzurot/common-types';
+import { UserService, type PrismaClient } from '@tzurot/common-types';
 
 // Helper to create mock request/response
 function createMockReqRes(body: Record<string, unknown> = {}, params: Record<string, string> = {}) {
@@ -218,6 +218,26 @@ describe('/user/model-override routes', () => {
   });
 
   describe('PUT /user/model-override', () => {
+    it('should return 400 when user is a bot', async () => {
+      const spy = vi.spyOn(UserService.prototype, 'getOrCreateUser').mockResolvedValueOnce(null);
+
+      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const handler = getHandler(router, 'put', '/');
+      const { req, res } = createMockReqRes({
+        personalityId: '11111111-1111-4111-a111-111111111111',
+        configId: '22222222-2222-4222-a222-222222222222',
+      });
+
+      await handler(req, res);
+
+      expect(spy).toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'VALIDATION_ERROR' }));
+      expect(mockPrisma.userPersonalityConfig.upsert).not.toHaveBeenCalled();
+
+      spy.mockRestore();
+    });
+
     it('should reject missing personalityId', async () => {
       const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
       const handler = getHandler(router, 'put', '/');
@@ -518,6 +538,24 @@ describe('/user/model-override routes', () => {
   });
 
   describe('PUT /user/model-override/default', () => {
+    it('should return 400 when user is a bot', async () => {
+      const spy = vi.spyOn(UserService.prototype, 'getOrCreateUser').mockResolvedValueOnce(null);
+
+      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const handler = getHandler(router, 'put', '/default');
+      const { req, res } = createMockReqRes({
+        configId: '22222222-2222-4222-a222-222222222222',
+      });
+
+      await handler(req, res);
+
+      expect(spy).toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'VALIDATION_ERROR' }));
+
+      spy.mockRestore();
+    });
+
     it('should reject missing configId', async () => {
       const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
       const handler = getHandler(router, 'put', '/default');

--- a/services/api-gateway/src/routes/user/model-override.ts
+++ b/services/api-gateway/src/routes/user/model-override.ts
@@ -26,7 +26,7 @@ import {
 } from '@tzurot/common-types';
 import { requireUserAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
-import { tryInvalidateCache } from '../../utils/configOverrideHelpers.js';
+import { tryInvalidateCache, resolveUserIdOrSendError } from '../../utils/configOverrideHelpers.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
 import { sendZodError } from '../../utils/zodHelpers.js';
@@ -127,11 +127,9 @@ export function createModelOverrideRoutes(
 
       const { personalityId, configId } = parseResult.data;
 
-      // Get or create user via centralized UserService
-      const userId = await userService.getOrCreateUser(discordUserId, discordUserId);
+      const userId = await resolveUserIdOrSendError(userService, discordUserId, res);
       if (userId === null) {
-        // Should not happen for slash commands (bots can't use them)
-        return sendError(res, ErrorResponses.validationError('Cannot create user for bot'));
+        return;
       }
 
       // Verify personality exists
@@ -253,11 +251,9 @@ export function createModelOverrideRoutes(
 
       const { configId } = parseResult.data;
 
-      // Get or create user via centralized UserService
-      const userId = await userService.getOrCreateUser(discordUserId, discordUserId);
+      const userId = await resolveUserIdOrSendError(userService, discordUserId, res);
       if (userId === null) {
-        // Should not happen for slash commands (bots can't use them)
-        return sendError(res, ErrorResponses.validationError('Cannot create user for bot'));
+        return;
       }
 
       // Verify config exists and user can access it (global or owned)

--- a/services/api-gateway/src/routes/user/nsfw.ts
+++ b/services/api-gateway/src/routes/user/nsfw.ts
@@ -69,7 +69,14 @@ export function createNsfwRoutes(prisma: PrismaClient): Router {
 
       logger.info({ discordUserId }, '[NSFW] Verifying user via NSFW channel interaction');
 
-      // Ensure user exists via centralized UserService (creates shell user if needed)
+      // Ensure user exists via centralized UserService (creates shell user if needed).
+      //
+      // NOTE: Deliberately not migrated to `resolveUserIdOrSendError` from
+      // `configOverrideHelpers.ts` (PR #779). That helper sends a 400 validation-error
+      // response on the bot-null case, which is wrong here: NSFW verification status
+      // is advisory, and the correct bot-user response is a 200 with
+      // `{ nsfwVerified: false }` — not an error. This route uses `sendCustomSuccess`
+      // with a clear advisory message instead of a rejection.
       const userId = await userService.getOrCreateUser(discordUserId, discordUserId);
       if (userId === null) {
         // Should not happen for slash commands (bots can't use them)

--- a/services/api-gateway/src/routes/user/personality-config-overrides.test.ts
+++ b/services/api-gateway/src/routes/user/personality-config-overrides.test.ts
@@ -148,6 +148,22 @@ describe('/user/config-overrides personality routes', () => {
   });
 
   describe('PATCH /personality/:personalityId', () => {
+    it('should return 400 when user is a bot', async () => {
+      mockGetOrCreateUser.mockResolvedValueOnce(null);
+
+      const router = createPersonalityConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const handler = getHandler(router, 'patch', '/personality/:personalityId');
+      const { req, res } = createMockReqRes(
+        { maxMessages: 25 },
+        { personalityId: TEST_PERSONALITY_ID }
+      );
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'VALIDATION_ERROR' }));
+    });
+
     it('should reject non-UUID personalityId', async () => {
       const router = createPersonalityConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
       const handler = getHandler(router, 'patch', '/personality/:personalityId');

--- a/services/api-gateway/src/routes/user/personality-config-overrides.ts
+++ b/services/api-gateway/src/routes/user/personality-config-overrides.ts
@@ -21,6 +21,7 @@ import { asyncHandler } from '../../utils/asyncHandler.js';
 import {
   tryInvalidateCache,
   mergeAndValidateOverrides,
+  resolveUserIdOrSendError,
 } from '../../utils/configOverrideHelpers.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
@@ -76,9 +77,9 @@ export function createPersonalityConfigOverrideRoutes(
         return sendError(res, ErrorResponses.validationError('Invalid personalityId format'));
       }
 
-      const userId = await userService.getOrCreateUser(req.userId, req.userId);
+      const userId = await resolveUserIdOrSendError(userService, req.userId, res);
       if (userId === null) {
-        return sendError(res, ErrorResponses.validationError('Cannot create user for bot'));
+        return;
       }
 
       // Verify creator ownership

--- a/services/api-gateway/src/routes/user/shapes/auth.test.ts
+++ b/services/api-gateway/src/routes/user/shapes/auth.test.ts
@@ -35,7 +35,7 @@ vi.mock('../../../utils/asyncHandler.js', () => ({
 }));
 
 import { createShapesAuthRoutes } from './auth.js';
-import type { PrismaClient } from '@tzurot/common-types';
+import { UserService, type PrismaClient } from '@tzurot/common-types';
 import { findRoute, getRouteHandler } from '../../../test/expressRouterUtils.js';
 
 // Mock Prisma
@@ -117,6 +117,18 @@ describe('Shapes Auth Routes', () => {
       await handler(req, res);
       return { req, res };
     }
+
+    it('should return 400 when user is a bot', async () => {
+      const spy = vi.spyOn(UserService.prototype, 'getOrCreateUser').mockResolvedValueOnce(null);
+
+      const { res } = await callStoreHandler({ sessionCookie: 'appSession=valid' });
+
+      expect(spy).toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'VALIDATION_ERROR' }));
+
+      spy.mockRestore();
+    });
 
     it('should reject missing sessionCookie', async () => {
       const { res } = await callStoreHandler({});

--- a/services/api-gateway/src/routes/user/shapes/auth.ts
+++ b/services/api-gateway/src/routes/user/shapes/auth.ts
@@ -25,6 +25,7 @@ import { requireUserAuth } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
+import { resolveUserIdOrSendError } from '../../../utils/configOverrideHelpers.js';
 import type { AuthenticatedRequest } from '../../../types.js';
 
 const logger = createLogger('shapes-auth');
@@ -60,9 +61,9 @@ function createStoreHandler(prisma: PrismaClient, userService: UserService) {
       );
     }
 
-    const userId = await userService.getOrCreateUser(discordUserId, discordUserId);
+    const userId = await resolveUserIdOrSendError(userService, discordUserId, res);
     if (userId === null) {
-      return sendError(res, ErrorResponses.validationError('Cannot create user'));
+      return;
     }
 
     const encrypted = encryptApiKey(sessionCookie);

--- a/services/api-gateway/src/routes/user/shapes/export.test.ts
+++ b/services/api-gateway/src/routes/user/shapes/export.test.ts
@@ -28,7 +28,7 @@ vi.mock('../../../utils/asyncHandler.js', () => ({
 }));
 
 import { createShapesExportRoutes } from './export.js';
-import type { PrismaClient } from '@tzurot/common-types';
+import { UserService, type PrismaClient } from '@tzurot/common-types';
 import { findRoute, getRouteHandler } from '../../../test/expressRouterUtils.js';
 
 /** Mocks for exportJob operations inside $transaction */
@@ -118,6 +118,18 @@ describe('Shapes Export Routes', () => {
       await handler(req, res);
       return { req, res };
     }
+
+    it('should return 400 when user is a bot', async () => {
+      const spy = vi.spyOn(UserService.prototype, 'getOrCreateUser').mockResolvedValueOnce(null);
+
+      const { res } = await callExportHandler({ slug: 'test-shape' });
+
+      expect(spy).toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'VALIDATION_ERROR' }));
+
+      spy.mockRestore();
+    });
 
     it('should reject missing slug', async () => {
       const { res } = await callExportHandler({});

--- a/services/api-gateway/src/routes/user/shapes/export.ts
+++ b/services/api-gateway/src/routes/user/shapes/export.ts
@@ -29,6 +29,7 @@ import { requireUserAuth } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
+import { resolveUserIdOrSendError } from '../../../utils/configOverrideHelpers.js';
 import { isPrismaUniqueConstraintError } from '../../../utils/prismaErrors.js';
 import type { AuthenticatedRequest } from '../../../types.js';
 
@@ -130,11 +131,9 @@ function createExportHandler(
     const normalizedSlug = slug.trim().toLowerCase();
     const format = formatRaw === 'markdown' ? 'markdown' : 'json';
 
-    // Get or create internal user (display name resolved later by bot-client;
-    // passing discordUserId as placeholder username matches the import flow)
-    const userId = await userService.getOrCreateUser(discordUserId, discordUserId);
+    const userId = await resolveUserIdOrSendError(userService, discordUserId, res);
     if (userId === null) {
-      return sendError(res, ErrorResponses.validationError('Cannot create user'));
+      return;
     }
 
     // Verify credentials exist (don't decrypt — ai-worker does that)

--- a/services/api-gateway/src/routes/user/shapes/import.test.ts
+++ b/services/api-gateway/src/routes/user/shapes/import.test.ts
@@ -28,7 +28,7 @@ vi.mock('../../../utils/asyncHandler.js', () => ({
 }));
 
 import { createShapesImportRoutes } from './import.js';
-import type { PrismaClient } from '@tzurot/common-types';
+import { UserService, type PrismaClient } from '@tzurot/common-types';
 import { findRoute, getRouteHandler } from '../../../test/expressRouterUtils.js';
 
 // Mock Prisma
@@ -108,6 +108,18 @@ describe('Shapes Import Routes', () => {
       await handler(req, res);
       return { req, res };
     }
+
+    it('should return 400 when user is a bot', async () => {
+      const spy = vi.spyOn(UserService.prototype, 'getOrCreateUser').mockResolvedValueOnce(null);
+
+      const { res } = await callImportHandler({ sourceSlug: 'test-shape' });
+
+      expect(spy).toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'VALIDATION_ERROR' }));
+
+      spy.mockRestore();
+    });
 
     it('should reject missing sourceSlug', async () => {
       const { res } = await callImportHandler({});

--- a/services/api-gateway/src/routes/user/shapes/import.ts
+++ b/services/api-gateway/src/routes/user/shapes/import.ts
@@ -22,6 +22,7 @@ import { requireUserAuth } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
+import { resolveUserIdOrSendError } from '../../../utils/configOverrideHelpers.js';
 import { isPrismaUniqueConstraintError } from '../../../utils/prismaErrors.js';
 import type { AuthenticatedRequest } from '../../../types.js';
 
@@ -106,10 +107,9 @@ function createImportHandler(prisma: PrismaClient, queue: Queue, userService: Us
 
     const validImportType = importType === 'memory_only' ? 'memory_only' : 'full';
 
-    // Get or create internal user
-    const userId = await userService.getOrCreateUser(discordUserId, discordUserId);
+    const userId = await resolveUserIdOrSendError(userService, discordUserId, res);
     if (userId === null) {
-      return sendError(res, ErrorResponses.validationError('Cannot create user'));
+      return;
     }
 
     // Atomically check for conflicts and create the import job

--- a/services/api-gateway/src/routes/user/timezone.test.ts
+++ b/services/api-gateway/src/routes/user/timezone.test.ts
@@ -61,7 +61,7 @@ const mockPrisma = {
 };
 
 import { createTimezoneRoutes } from './timezone.js';
-import type { PrismaClient } from '@tzurot/common-types';
+import { UserService, type PrismaClient } from '@tzurot/common-types';
 import { getRouteHandler, findRoute } from '../../test/expressRouterUtils.js';
 
 // Helper to create mock request/response
@@ -187,6 +187,23 @@ describe('/user/timezone routes', () => {
   });
 
   describe('PUT /user/timezone', () => {
+    it('should return 400 when user is a bot', async () => {
+      const spy = vi.spyOn(UserService.prototype, 'getOrCreateUser').mockResolvedValueOnce(null);
+
+      const router = createTimezoneRoutes(mockPrisma as unknown as PrismaClient);
+      const handler = getHandler(router, 'put', '/');
+      const { req, res } = createMockReqRes({ timezone: 'America/New_York' });
+
+      await handler(req, res);
+
+      expect(spy).toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'VALIDATION_ERROR' }));
+      expect(mockPrisma.user.update).not.toHaveBeenCalled();
+
+      spy.mockRestore();
+    });
+
     it('should reject missing timezone', async () => {
       const router = createTimezoneRoutes(mockPrisma as unknown as PrismaClient);
       const handler = getHandler(router, 'put', '/');

--- a/services/api-gateway/src/routes/user/timezone.ts
+++ b/services/api-gateway/src/routes/user/timezone.ts
@@ -18,6 +18,7 @@ import { requireUserAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
+import { resolveUserIdOrSendError } from '../../utils/configOverrideHelpers.js';
 import { sendZodError } from '../../utils/zodHelpers.js';
 import type { AuthenticatedRequest } from '../../types.js';
 
@@ -94,11 +95,9 @@ export function createTimezoneRoutes(prisma: PrismaClient): Router {
 
       logger.info({ discordUserId, timezone }, '[Timezone] Setting user timezone');
 
-      // Ensure user exists via centralized UserService (creates shell user if needed)
-      const userId = await userService.getOrCreateUser(discordUserId, discordUserId);
+      const userId = await resolveUserIdOrSendError(userService, discordUserId, res);
       if (userId === null) {
-        // Should not happen for slash commands (bots can't use them)
-        return sendError(res, ErrorResponses.validationError('Cannot create user for bot'));
+        return;
       }
 
       // Update the timezone

--- a/services/api-gateway/src/routes/wallet/setKey.test.ts
+++ b/services/api-gateway/src/routes/wallet/setKey.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Request, Response } from 'express';
-import { AIProvider } from '@tzurot/common-types';
+import { AIProvider, UserService } from '@tzurot/common-types';
 
 // Mock apiKeyValidation module
 vi.mock('../../utils/apiKeyValidation.js', () => ({
@@ -193,6 +193,24 @@ describe('POST /wallet/set', () => {
   });
 
   describe('API key validation', () => {
+    it('should return 400 when user is a bot', async () => {
+      const spy = vi.spyOn(UserService.prototype, 'getOrCreateUser').mockResolvedValueOnce(null);
+
+      const { req, res } = createMockReqRes({
+        provider: AIProvider.OpenRouter,
+        apiKey: 'sk-valid-key',
+      });
+
+      await callHandler(mockPrisma, req, res);
+
+      expect(spy).toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'VALIDATION_ERROR' }));
+      expect(mockPrisma.userApiKey.upsert).not.toHaveBeenCalled();
+
+      spy.mockRestore();
+    });
+
     it('should validate API key with provider', async () => {
       const { req, res } = createMockReqRes({
         provider: AIProvider.OpenRouter,

--- a/services/api-gateway/src/routes/wallet/setKey.ts
+++ b/services/api-gateway/src/routes/wallet/setKey.ts
@@ -24,6 +24,7 @@ import { requireUserAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses, type ErrorResponse } from '../../utils/errorResponses.js';
+import { resolveUserIdOrSendError } from '../../utils/configOverrideHelpers.js';
 import { sendZodError } from '../../utils/zodHelpers.js';
 import { validateApiKey, type ApiKeyValidationResult } from '../../utils/apiKeyValidation.js';
 import type { AuthenticatedRequest } from '../../types.js';
@@ -85,10 +86,9 @@ export function createSetKeyRoute(
         return sendError(res, mapValidationErrorToResponse(validation));
       }
 
-      // Ensure user exists and get internal user ID
-      const userId = await userService.getOrCreateUser(discordUserId, discordUserId);
+      const userId = await resolveUserIdOrSendError(userService, discordUserId, res);
       if (userId === null) {
-        return sendError(res, ErrorResponses.validationError('Cannot create user for bot'));
+        return;
       }
 
       // Encrypt and store the API key

--- a/services/api-gateway/src/utils/configOverrideHelpers.test.ts
+++ b/services/api-gateway/src/utils/configOverrideHelpers.test.ts
@@ -18,7 +18,12 @@ vi.mock('@tzurot/common-types', async () => {
   };
 });
 
-import { tryInvalidateCache, mergeAndValidateOverrides } from './configOverrideHelpers.js';
+import {
+  tryInvalidateCache,
+  mergeAndValidateOverrides,
+  resolveUserIdOrSendError,
+} from './configOverrideHelpers.js';
+import type { UserService } from '@tzurot/common-types';
 
 // Mock the merge function to control its return values
 const mockMerge = vi.fn();
@@ -109,5 +114,53 @@ describe('mergeAndValidateOverrides', () => {
     const result = mergeAndValidateOverrides({}, { bad: 'data' }, mockRes);
     expect(result.merged).toBeUndefined();
     expect(mockSendError).toHaveBeenCalledOnce();
+  });
+});
+
+describe('resolveUserIdOrSendError', () => {
+  const mockRes = {} as never;
+  const mockGetOrCreateUser = vi.fn();
+  const mockUserService = { getOrCreateUser: mockGetOrCreateUser } as unknown as UserService;
+
+  beforeEach(() => vi.resetAllMocks());
+
+  it('returns the internal user UUID on success', async () => {
+    mockGetOrCreateUser.mockResolvedValue('internal-uuid-abc');
+
+    const result = await resolveUserIdOrSendError(mockUserService, 'discord-123', mockRes);
+
+    expect(result).toBe('internal-uuid-abc');
+    expect(mockGetOrCreateUser).toHaveBeenCalledWith('discord-123', 'discord-123');
+    expect(mockSendError).not.toHaveBeenCalled();
+  });
+
+  it('returns null and sends validation error when user is a bot', async () => {
+    mockGetOrCreateUser.mockResolvedValue(null);
+
+    const result = await resolveUserIdOrSendError(mockUserService, 'bot-456', mockRes);
+
+    expect(result).toBeNull();
+    expect(mockSendError).toHaveBeenCalledOnce();
+  });
+
+  it('sends the unified error message "Cannot create user for bot"', async () => {
+    mockGetOrCreateUser.mockResolvedValue(null);
+
+    await resolveUserIdOrSendError(mockUserService, 'bot-456', mockRes);
+
+    expect(mockSendError).toHaveBeenCalledWith(
+      mockRes,
+      expect.objectContaining({ message: 'Cannot create user for bot' })
+    );
+  });
+
+  it('passes the same discord ID as both discordId and username args', async () => {
+    // Current call-site convention: username doubles as discordId since real username
+    // isn't available at the route layer. Preserved by the helper.
+    mockGetOrCreateUser.mockResolvedValue('uuid');
+
+    await resolveUserIdOrSendError(mockUserService, 'discord-xyz', mockRes);
+
+    expect(mockGetOrCreateUser).toHaveBeenCalledWith('discord-xyz', 'discord-xyz');
   });
 });

--- a/services/api-gateway/src/utils/configOverrideHelpers.ts
+++ b/services/api-gateway/src/utils/configOverrideHelpers.ts
@@ -7,12 +7,57 @@
  */
 
 import type { Response } from 'express';
-import { Prisma, createLogger } from '@tzurot/common-types';
+import { Prisma, createLogger, type UserService } from '@tzurot/common-types';
 import { mergeConfigOverrides } from './configOverrideMerge.js';
 import { sendError } from './responseHelpers.js';
 import { ErrorResponses } from './errorResponses.js';
 
 const logger = createLogger('configOverrideHelpers');
+
+// ============================================================================
+// User Resolution
+// ============================================================================
+
+/**
+ * Resolve the internal user UUID for an incoming Discord user ID, sending a
+ * validation error response and returning `null` if the lookup fails because
+ * the Discord user is a bot.
+ *
+ * Collapses the repeated pattern:
+ *
+ * ```ts
+ * const userId = await userService.getOrCreateUser(req.userId, req.userId);
+ * if (userId === null) {
+ *   return sendError(res, ErrorResponses.validationError('Cannot create user for bot'));
+ * }
+ * ```
+ *
+ * into:
+ *
+ * ```ts
+ * const userId = await resolveUserIdOrSendError(userService, req.userId, res);
+ * if (userId === null) return;
+ * ```
+ *
+ * 15 call sites across 9 route files currently duplicate this pattern with
+ * two minor error-text variants (`'Cannot create user for bot'` and
+ * `'Cannot create user'`). This helper standardizes on the more specific
+ * former message.
+ *
+ * @returns internal user UUID on success, or `null` if error was sent
+ */
+export async function resolveUserIdOrSendError(
+  userService: UserService,
+  discordUserId: string,
+  res: Response
+): Promise<string | null> {
+  const userId = await userService.getOrCreateUser(discordUserId, discordUserId);
+  if (userId === null) {
+    sendError(res, ErrorResponses.validationError('Cannot create user for bot'));
+    return null;
+  }
+  return userId;
+}
 
 // ============================================================================
 // Cache Invalidation

--- a/services/api-gateway/src/utils/llmConfigValidation.test.ts
+++ b/services/api-gateway/src/utils/llmConfigValidation.test.ts
@@ -79,6 +79,27 @@ describe('validateLlmConfigModelFields', () => {
 
       expect(mockGetById).not.toHaveBeenCalled();
     });
+
+    it('skips validation gracefully when body.model is absent on create', async () => {
+      // Reviewer-flagged edge case: create path with only contextWindowTokens (no model).
+      // validateModelAndContextWindow handles modelId === undefined by returning {} — the
+      // helper should forward that undefined model without throwing or pre-checking.
+      mockValidateModelAndContextWindow.mockResolvedValue({});
+
+      const result = await validateLlmConfigModelFields({
+        res: mockRes,
+        modelCache: mockModelCache,
+        body: { contextWindowTokens: 8000 },
+      });
+
+      expect(result).toBe(true);
+      expect(mockValidateModelAndContextWindow).toHaveBeenCalledWith(
+        mockModelCache,
+        undefined,
+        8000
+      );
+      expect(mockSendError).not.toHaveBeenCalled();
+    });
   });
 
   describe('update path (with fallback)', () => {

--- a/services/api-gateway/src/utils/llmConfigValidation.test.ts
+++ b/services/api-gateway/src/utils/llmConfigValidation.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for validateLlmConfigModelFields
+ *
+ * Covers both create (no fallback) and update (with fallback) paths, plus
+ * the subtle "neither field present on update" skip branch that's the main
+ * reason this helper earns its keep.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { validateLlmConfigModelFields } from './llmConfigValidation.js';
+import type { OpenRouterModelCache } from '../services/OpenRouterModelCache.js';
+import type { LlmConfigService } from '../services/LlmConfigService.js';
+
+const mockValidateModelAndContextWindow = vi.fn();
+vi.mock('./modelValidation.js', () => ({
+  validateModelAndContextWindow: (...args: unknown[]) => mockValidateModelAndContextWindow(...args),
+}));
+
+const mockSendError = vi.fn();
+vi.mock('./responseHelpers.js', () => ({
+  sendError: (...args: unknown[]) => mockSendError(...args),
+}));
+
+vi.mock('./errorResponses.js', () => ({
+  ErrorResponses: {
+    validationError: (msg: string) => ({ error: 'VALIDATION', message: msg }),
+  },
+}));
+
+describe('validateLlmConfigModelFields', () => {
+  const mockRes = {} as never;
+  const mockGetById = vi.fn();
+  const mockService = { getById: mockGetById } as unknown as LlmConfigService;
+  const mockModelCache = {} as unknown as OpenRouterModelCache;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('create path (no fallback)', () => {
+    it('returns true and calls validateModelAndContextWindow with body.model', async () => {
+      mockValidateModelAndContextWindow.mockResolvedValue({});
+
+      const result = await validateLlmConfigModelFields({
+        res: mockRes,
+        modelCache: mockModelCache,
+        body: { model: 'gpt-4', contextWindowTokens: 8000 },
+      });
+
+      expect(result).toBe(true);
+      expect(mockValidateModelAndContextWindow).toHaveBeenCalledWith(mockModelCache, 'gpt-4', 8000);
+      expect(mockSendError).not.toHaveBeenCalled();
+    });
+
+    it('returns false and sends error when validation fails', async () => {
+      mockValidateModelAndContextWindow.mockResolvedValue({ error: 'Model not found' });
+
+      const result = await validateLlmConfigModelFields({
+        res: mockRes,
+        modelCache: mockModelCache,
+        body: { model: 'invalid-model' },
+      });
+
+      expect(result).toBe(false);
+      expect(mockSendError).toHaveBeenCalledWith(
+        mockRes,
+        expect.objectContaining({ message: 'Model not found' })
+      );
+    });
+
+    it('does not fetch current model on create path (no fallback)', async () => {
+      mockValidateModelAndContextWindow.mockResolvedValue({});
+
+      await validateLlmConfigModelFields({
+        res: mockRes,
+        modelCache: mockModelCache,
+        body: { model: 'gpt-4' },
+      });
+
+      expect(mockGetById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('update path (with fallback)', () => {
+    it('skips validation entirely when neither model nor contextWindowTokens present', async () => {
+      const result = await validateLlmConfigModelFields({
+        res: mockRes,
+        modelCache: mockModelCache,
+        body: {},
+        fallback: { service: mockService, configId: 'cfg-1' },
+      });
+
+      expect(result).toBe(true);
+      expect(mockValidateModelAndContextWindow).not.toHaveBeenCalled();
+      expect(mockGetById).not.toHaveBeenCalled();
+    });
+
+    it('validates with body.model directly when provided', async () => {
+      mockValidateModelAndContextWindow.mockResolvedValue({});
+
+      const result = await validateLlmConfigModelFields({
+        res: mockRes,
+        modelCache: mockModelCache,
+        body: { model: 'claude-3-opus' },
+        fallback: { service: mockService, configId: 'cfg-1' },
+      });
+
+      expect(result).toBe(true);
+      expect(mockGetById).not.toHaveBeenCalled();
+      expect(mockValidateModelAndContextWindow).toHaveBeenCalledWith(
+        mockModelCache,
+        'claude-3-opus',
+        undefined
+      );
+    });
+
+    it('fetches current model when only contextWindowTokens is being updated', async () => {
+      mockGetById.mockResolvedValue({ model: 'existing-model' });
+      mockValidateModelAndContextWindow.mockResolvedValue({});
+
+      const result = await validateLlmConfigModelFields({
+        res: mockRes,
+        modelCache: mockModelCache,
+        body: { contextWindowTokens: 16000 },
+        fallback: { service: mockService, configId: 'cfg-1' },
+      });
+
+      expect(result).toBe(true);
+      expect(mockGetById).toHaveBeenCalledWith('cfg-1');
+      expect(mockValidateModelAndContextWindow).toHaveBeenCalledWith(
+        mockModelCache,
+        'existing-model',
+        16000
+      );
+    });
+
+    it('uses body.model when both model and contextWindowTokens are provided', async () => {
+      mockValidateModelAndContextWindow.mockResolvedValue({});
+
+      const result = await validateLlmConfigModelFields({
+        res: mockRes,
+        modelCache: mockModelCache,
+        body: { model: 'new-model', contextWindowTokens: 32000 },
+        fallback: { service: mockService, configId: 'cfg-1' },
+      });
+
+      expect(result).toBe(true);
+      // Should use body.model, not fetch current
+      expect(mockGetById).not.toHaveBeenCalled();
+      expect(mockValidateModelAndContextWindow).toHaveBeenCalledWith(
+        mockModelCache,
+        'new-model',
+        32000
+      );
+    });
+
+    it('returns false and sends error when validation fails on update', async () => {
+      mockValidateModelAndContextWindow.mockResolvedValue({
+        error: 'Context window exceeds 50% of model limit',
+      });
+
+      const result = await validateLlmConfigModelFields({
+        res: mockRes,
+        modelCache: mockModelCache,
+        body: { model: 'gpt-4', contextWindowTokens: 200000 },
+        fallback: { service: mockService, configId: 'cfg-1' },
+      });
+
+      expect(result).toBe(false);
+      expect(mockSendError).toHaveBeenCalledWith(
+        mockRes,
+        expect.objectContaining({ message: 'Context window exceeds 50% of model limit' })
+      );
+    });
+
+    it('handles current config being null (model becomes undefined)', async () => {
+      mockGetById.mockResolvedValue(null);
+      mockValidateModelAndContextWindow.mockResolvedValue({});
+
+      const result = await validateLlmConfigModelFields({
+        res: mockRes,
+        modelCache: mockModelCache,
+        body: { contextWindowTokens: 8000 },
+        fallback: { service: mockService, configId: 'missing-cfg' },
+      });
+
+      expect(result).toBe(true);
+      expect(mockValidateModelAndContextWindow).toHaveBeenCalledWith(
+        mockModelCache,
+        undefined,
+        8000
+      );
+    });
+  });
+});

--- a/services/api-gateway/src/utils/llmConfigValidation.ts
+++ b/services/api-gateway/src/utils/llmConfigValidation.ts
@@ -1,0 +1,101 @@
+/**
+ * LLM Config Validation Helpers
+ *
+ * Shared logic for the model-id + context-window validation step used by both
+ * admin and user LLM config create/update routes.
+ *
+ * Collapses four call sites across two files (admin/llm-config.ts,
+ * user/llm-config.ts) that previously duplicated the validate-and-error-respond
+ * pattern, including the subtle "fetch current model as fallback" logic used
+ * only on update paths.
+ *
+ * Deliberately scoped: does NOT bundle the preceding Zod `safeParse + sendZodError`
+ * step. The two routes use different schemas (`LlmConfigCreateSchema` vs
+ * `LlmConfigUpdateSchema`), and the parse idiom is a clean 3-liner that's better
+ * left at each call site.
+ */
+
+import type { Response } from 'express';
+import { sendError } from './responseHelpers.js';
+import { ErrorResponses } from './errorResponses.js';
+import { validateModelAndContextWindow } from './modelValidation.js';
+import type { OpenRouterModelCache } from '../services/OpenRouterModelCache.js';
+import type { LlmConfigService } from '../services/LlmConfigService.js';
+
+/**
+ * Options for validating the model/contextWindow fields of an LLM config body.
+ *
+ * The `fallback` property distinguishes create from update semantics:
+ *
+ * - **Create path**: omit `fallback`. Validation always runs, using `body.model`
+ *   directly. Absence of `body.model` is allowed only when `modelCache` is
+ *   undefined (graceful skip).
+ * - **Update path**: pass `fallback: { service, configId }`. Validation skips
+ *   entirely when neither `body.model` nor `body.contextWindowTokens` is present
+ *   (no-op edit). If only `body.contextWindowTokens` is provided, the helper
+ *   fetches the current config's model from `service` and validates the new
+ *   context window against it.
+ */
+export interface ValidateLlmConfigModelFieldsOptions {
+  res: Response;
+  modelCache: OpenRouterModelCache | undefined;
+  body: {
+    model?: string;
+    contextWindowTokens?: number;
+  };
+  /**
+   * Only present on update-path calls. Lets the helper fetch the current
+   * model if the update body omits `model` but changes `contextWindowTokens`.
+   */
+  fallback?: {
+    service: LlmConfigService;
+    configId: string;
+  };
+}
+
+/**
+ * Validate `body.model` + `body.contextWindowTokens` against the OpenRouter
+ * model cache, handling both create and update paths.
+ *
+ * On failure, sends a 400 validation error response and returns `false`. On
+ * success (or skipped validation), returns `true`.
+ *
+ * @returns `true` if validation passed or was skipped, `false` if error sent
+ */
+export async function validateLlmConfigModelFields(
+  opts: ValidateLlmConfigModelFieldsOptions
+): Promise<boolean> {
+  const { res, modelCache, body, fallback } = opts;
+
+  // Update path: skip entirely when neither model nor contextWindowTokens is present.
+  // A no-op update doesn't need model validation.
+  if (
+    fallback !== undefined &&
+    body.model === undefined &&
+    body.contextWindowTokens === undefined
+  ) {
+    return true;
+  }
+
+  // Resolve effective model. Update path with body.model absent falls back to
+  // the currently-stored model so contextWindowTokens can still be validated
+  // against a known model.
+  let effectiveModel = body.model;
+  if (effectiveModel === undefined && fallback !== undefined) {
+    const current = await fallback.service.getById(fallback.configId);
+    effectiveModel = current?.model;
+  }
+
+  const result = await validateModelAndContextWindow(
+    modelCache,
+    effectiveModel,
+    body.contextWindowTokens
+  );
+
+  if (result.error !== undefined) {
+    sendError(res, ErrorResponses.validationError(result.error));
+    return false;
+  }
+
+  return true;
+}

--- a/services/api-gateway/src/utils/llmConfigValidation.ts
+++ b/services/api-gateway/src/utils/llmConfigValidation.ts
@@ -38,6 +38,15 @@ import type { LlmConfigService } from '../services/LlmConfigService.js';
  */
 export interface ValidateLlmConfigModelFieldsOptions {
   res: Response;
+  /**
+   * OpenRouter model cache used to look up context-window caps.
+   *
+   * **Accepting `undefined` is intentional**: the underlying
+   * `validateModelAndContextWindow` gracefully skips all validation when the
+   * cache is absent (e.g., in local dev without an OpenRouter API key, or in
+   * tests that construct routes without a cache). Callers should pass through
+   * whatever cache reference they have without a pre-check.
+   */
   modelCache: OpenRouterModelCache | undefined;
   body: {
     model?: string;

--- a/services/api-gateway/src/utils/llmConfigValidation.ts
+++ b/services/api-gateway/src/utils/llmConfigValidation.ts
@@ -27,9 +27,11 @@ import type { LlmConfigService } from '../services/LlmConfigService.js';
  *
  * The `fallback` property distinguishes create from update semantics:
  *
- * - **Create path**: omit `fallback`. Validation always runs, using `body.model`
- *   directly. Absence of `body.model` is allowed only when `modelCache` is
- *   undefined (graceful skip).
+ * - **Create path**: omit `fallback`. The helper forwards `body.model` directly
+ *   to `validateModelAndContextWindow`, which handles an undefined model
+ *   gracefully (skips model-specific checks and returns no error). So a create
+ *   body without `model` is valid — validation simply has nothing to verify
+ *   about the model in that case. Same goes for `modelCache: undefined`.
  * - **Update path**: pass `fallback: { service, configId }`. Validation skips
  *   entirely when neither `body.model` nor `body.contextWindowTokens` is present
  *   (no-op edit). If only `body.contextWindowTokens` is provided, the helper


### PR DESCRIPTION
## Summary

Two related shared-helper extractions for api-gateway route handlers, part of CPD Zero Roadmap Session 1b:

- **`resolveUserIdOrSendError`** — collapses the `getOrCreateUser` + bot-null-check + error-send pattern duplicated across **15 call sites in 9 files** (grep rule revealed nearly double the plan's original estimate of 9 sites in 3 files)
- **`validateLlmConfigModelFields`** — collapses the model ID + context window validation across **4 call sites in 2 files**, including the subtle "fetch current model as fallback when only contextWindowTokens is updated" logic

**CPD impact**: 126 → 123 (-3 clones against develop baseline). Combined with PR #778 (merged, -5), Session 1 total is -8 clones (126 → 118).

## Helper 1: `resolveUserIdOrSendError`

Added to existing `services/api-gateway/src/utils/configOverrideHelpers.ts` (not a new file — keeps PR #769's shared-helpers module as the single home for route-level extractions).

### Before / after

```diff
- const userId = await userService.getOrCreateUser(req.userId, req.userId);
- if (userId === null) {
-   return sendError(res, ErrorResponses.validationError('Cannot create user for bot'));
- }
+ const userId = await resolveUserIdOrSendError(userService, req.userId, res);
+ if (userId === null) return;
```

### Call sites migrated (15 total)

| File | Sites | Pre-change error text |
|------|-------|----------------------|
| `routes/user/config-overrides.ts` | 6 | `BOT_USER_ERROR` constant — removed, now uses helper |
| `routes/user/personality-config-overrides.ts` | 1 | `'Cannot create user for bot'` |
| `routes/user/llm-config.ts` | 1 | `'Cannot create user for bot'` |
| `routes/user/model-override.ts` | 2 | `'Cannot create user for bot'` |
| `routes/user/timezone.ts` | 1 | `'Cannot create user for bot'` |
| `routes/wallet/setKey.ts` | 1 | `'Cannot create user for bot'` |
| `routes/user/shapes/auth.ts` | 1 | `'Cannot create user'` ← *minor user-facing change* |
| `routes/user/shapes/export.ts` | 1 | `'Cannot create user'` ← *minor user-facing change* |
| `routes/user/shapes/import.ts` | 1 | `'Cannot create user'` ← *minor user-facing change* |

### User-facing text change

The 3 shapes files previously returned `'Cannot create user'` (without the "for bot" suffix). This PR unifies on `'Cannot create user for bot'` for all 15 sites. **Minor user-facing improvement** — the unified message is more specific and accurate.

### Intentional exclusion

- `routes/user/nsfw.ts` uses `sendCustomSuccess` with a "not verified" advisory on the same bot-user null case. Semantically different pattern, doesn't fit this helper's shape. **Round 2** added an inline comment in `nsfw.ts` explaining this rationale so future readers don't wonder why the file diverges from the other 15 call sites.

## Helper 2: `validateLlmConfigModelFields`

New file: `services/api-gateway/src/utils/llmConfigValidation.ts` + colocated test.

### The tricky bit

The update path has subtle fallback logic: when `body.model` is omitted but `body.contextWindowTokens` is provided, the current config's model is fetched via the service so context window validation runs against a known model. When **neither** field is present on update (no-op edit), validation skips entirely. The helper encapsulates this logic so it lives in one place.

### Call sites migrated (4 total)

- `routes/admin/llm-config.ts` — POST create + PUT update
- `routes/user/llm-config.ts` — POST create + PUT update

### Deliberately NOT bundled

The preceding Zod `safeParse + sendZodError` step stays as a 3-liner at each call site. The two routes use different schemas (`LlmConfigCreateSchema` vs `LlmConfigUpdateSchema`), so bundling would brand the helper to the specific create/update use case and hide that difference.

## Review feedback addressed

### Round 1 (2026-04-11 13:58)
- ✅ Added missing test: create path with `body.model` undefined (only `contextWindowTokens` set)
- 🏗️ `resolveUserIdOrSendError` file placement — captured as Quick Wins backlog item in PR #780 (`routeHelpers.ts` rename)
- ℹ️ `vi.resetAllMocks()` vs. `vi.clearAllMocks()` — inherited from existing file patterns, noted as future alignment

### Round 2 (2026-04-11 15:13) — coverage + docs
- ✅ **Route-level null-path test coverage**: 19 new tests across 11 files covering every `resolveUserIdOrSendError` and `validateLlmConfigModelFields` early-return line in the migrated routes (closes codecov 80% patch gate)
- ✅ Added `// Mock req/res approach — no real HTTP client, so response can be left unsent` comment to `user/llm-config.test.ts` explaining the contrast with `admin/llm-config.test.ts`'s supertest-requires-res-write pattern
- ✅ Expanded JSDoc on `ValidateLlmConfigModelFieldsOptions.modelCache` documenting that `undefined` is intentional (graceful skip when cache is absent)
- ✅ Added rationale comment in `routes/user/nsfw.ts` explaining why it's not migrated to the helper

### Round 3 (2026-04-11 15:43) — JSDoc correction
- ✅ Fixed create-path JSDoc on `ValidateLlmConfigModelFieldsOptions` — old text said "Absence of `body.model` is allowed only when `modelCache` is undefined" but the round-1 test proved it's allowed regardless (both defined and undefined `modelCache` work fine because `validateModelAndContextWindow` handles undefined model gracefully). Updated to the reviewer's suggested framing.
- ℹ️ `GET /resolve-defaults` bot-check test — already present at `config-overrides.test.ts:161` from before this PR's round 2 work. My round-2 commit added bot-check tests for 5 endpoints; the 6th (`GET /resolve-defaults`) was pre-existing. Reviewer correctly identified 5 new tests in the diff but the file has all 6.

## Verification

- [x] `configOverrideHelpers.test.ts` — 13 tests (9 existing + 4 new for `resolveUserIdOrSendError`), all green
- [x] `llmConfigValidation.test.ts` — 10 tests (9 in round 1 + 1 in round 2 for create-path absent model), all green
- [x] `admin/llm-config.test.ts` — 45 tests (43 existing + 2 new validation-fails in round 2), all green
- [x] `user/llm-config.test.ts` — 47 tests (44 existing + 3 new in round 2: bot user + 2 validation-fails), all green
- [x] `user/config-overrides.test.ts` — 31 tests (26 existing + 5 new bot-check tests in round 2), all green
- [x] `personality-config-overrides.test.ts`, `model-override.test.ts`, `timezone.test.ts`, `setKey.test.ts`, `shapes/{auth,export,import}.test.ts` — each got 1-2 new bot-check tests in round 2
- [x] `pnpm --filter api-gateway test` — 1722 tests across 108 files, all green (was 1703 before round 2)
- [x] `pnpm quality` — lint + cpd + depcruise + typecheck + typecheck:spec, all green
- [x] `pnpm cpd` — 123 clones against develop baseline (delivered -3)
- [x] Codecov patch coverage gate: all new lines covered after round 2's null-path tests

## Relationship to PR #778

PR #778 is now **merged** into develop. This PR is independent of #778 — different service, no dependencies. PR #779's branch doesn't need rebasing against the post-merge develop (zero file overlap with #778's changes). Combined Session 1 delta: 126 → 118 (-8 clones).

## Related

- CPD Zero Roadmap: `~/.claude/plans/cpd-zero-roadmap.md` (Session 1b)
- Session 1 plan: `~/.claude/plans/humming-singing-barto.md`
- PR #769 (prior art): extracted `mergeAndValidateOverrides` and `tryInvalidateCache`; this PR extends the same file with the user-resolution extraction it left on the table.
- PR #780 (session wrap-up): tracks the `routeHelpers.ts` rename observation from this PR's round 1 review as a Quick Wins backlog item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
