### PR TITLE
fix(ai-worker,voice-engine): harden voice engine cold start + fix ElevenLabs abort leak

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -45,11 +45,12 @@ fi
 # 3. Check if only docs/config changed
 # Include package.json and pnpm-lock.yaml as they can affect builds (dependencies, scripts)
 CODE_FILES=$(echo "$CHANGED_FILES" | grep -E '\.(ts|tsx|js|jsx|mjs|cjs|d\.ts)$|package\.json$|pnpm-lock\.yaml$' || true)
+PYTHON_FILES=$(echo "$CHANGED_FILES" | grep -E '\.py$' || true)
 
 if [ -z "$CHANGED_FILES" ]; then
     echo "${YELLOW}No files detected in push - skipping checks${NC}"
     exit 0
-elif [ -z "$CODE_FILES" ]; then
+elif [ -z "$CODE_FILES" ] && [ -z "$PYTHON_FILES" ]; then
     echo "${GREEN}Only documentation/config files changed - skipping build and tests${NC}"
     exit 0
 fi
@@ -132,6 +133,19 @@ if ! pnpm depcruise; then
     echo "${RED}Dependency boundary check failed!${NC}"
     echo "Run 'pnpm depcruise' for details"
     exit 1
+fi
+
+# 10. Run Python quality checks if Python files changed
+if [ -n "$PYTHON_FILES" ]; then
+    echo "Running Python quality checks (ruff + mypy)..."
+    if ! (cd services/voice-engine && ruff check .); then
+        echo "${RED}Python linting (ruff) failed!${NC}"
+        exit 1
+    fi
+    if ! (cd services/voice-engine && mypy --strict server.py tests/); then
+        echo "${RED}Python type checking (mypy) failed!${NC}"
+        exit 1
+    fi
 fi
 
 echo "${GREEN}All pre-push checks passed!${NC}"

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,6 @@
 {
   "*.{ts,tsx}": ["prettier --write", "eslint --fix --max-warnings=0 --no-warn-ignored"],
+  "*.py": ["ruff check --fix", "ruff format"],
   "*.{md,json,yml,yaml}": ["prettier --write"],
   "*.{ts,tsx,js,jsx,json}": ["secretlint"]
 }

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.test.ts
@@ -349,9 +349,9 @@ describe('TTSStep', () => {
       const result = await promise;
 
       // With fake timers, Date.now() only advances on setTimeout fires, so the
-      // poll count is deterministic: 75_000 / 3_000 = 25 polls (each followed by
-      // a 3s sleep; after the 25th sleep Date.now() == deadline, loop exits).
-      expect(mockVoiceEngineClient.getHealth).toHaveBeenCalledTimes(25);
+      // poll count is deterministic: 120_000 / 3_000 = 40 polls (each followed by
+      // a 3s sleep; after the 40th sleep Date.now() == deadline, loop exits).
+      expect(mockVoiceEngineClient.getHealth).toHaveBeenCalledTimes(40);
       expect(mockEnsureVoiceRegistered).toHaveBeenCalledWith('testbot');
       expect(result.result?.metadata?.ttsAudioKey).toBe('tts:retry-job');
     });

--- a/services/ai-worker/src/services/voice/ElevenLabsClient.test.ts
+++ b/services/ai-worker/src/services/voice/ElevenLabsClient.test.ts
@@ -150,6 +150,20 @@ describe('ElevenLabsClient', () => {
       expect(error.timeoutMs).toBe(60_000);
       expect(error.operationName).toBe('ElevenLabs /text-to-speech/v1');
     });
+
+    it('should throw ElevenLabsTimeoutError when abort fires during response.arrayBuffer()', async () => {
+      const abortError = new Error('The operation was aborted');
+      abortError.name = 'AbortError';
+      mockFetch.mockResolvedValue({
+        ok: true,
+        headers: new Headers({ 'content-type': 'audio/mpeg' }),
+        arrayBuffer: vi.fn().mockRejectedValue(abortError),
+      });
+
+      await expect(
+        elevenLabsTTS({ text: 'test', voiceId: 'v1', apiKey: 'sk_test' })
+      ).rejects.toThrow(ElevenLabsTimeoutError);
+    });
   });
 
   describe('elevenLabsSTT', () => {
@@ -187,6 +201,24 @@ describe('ElevenLabsClient', () => {
       });
 
       expect(result.text).toBe('');
+    });
+
+    it('should throw ElevenLabsTimeoutError when abort fires during response.json()', async () => {
+      const abortError = new Error('The operation was aborted');
+      abortError.name = 'AbortError';
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockRejectedValue(abortError),
+      });
+
+      await expect(
+        elevenLabsSTT({
+          audioBuffer: Buffer.from('audio'),
+          filename: 'test.wav',
+          contentType: 'audio/wav',
+          apiKey: 'sk_test',
+        })
+      ).rejects.toThrow(ElevenLabsTimeoutError);
     });
   });
 

--- a/services/ai-worker/src/services/voice/ElevenLabsClient.test.ts
+++ b/services/ai-worker/src/services/voice/ElevenLabsClient.test.ts
@@ -276,6 +276,24 @@ describe('ElevenLabsClient', () => {
         })
       ).rejects.toThrow(ElevenLabsApiError);
     });
+
+    it('should throw ElevenLabsTimeoutError when abort fires during response.json()', async () => {
+      const abortError = new Error('The operation was aborted');
+      abortError.name = 'AbortError';
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockRejectedValue(abortError),
+      });
+
+      await expect(
+        elevenLabsCloneVoice({
+          name: 'test',
+          audioBuffer: Buffer.from('audio'),
+          contentType: 'audio/wav',
+          apiKey: 'sk_test',
+        })
+      ).rejects.toThrow(ElevenLabsTimeoutError);
+    });
   });
 
   describe('elevenLabsListVoices', () => {
@@ -322,6 +340,17 @@ describe('ElevenLabsClient', () => {
           headers: expect.objectContaining({ 'xi-api-key': 'sk_my_key' }),
         })
       );
+    });
+
+    it('should throw ElevenLabsTimeoutError when abort fires during response.json()', async () => {
+      const abortError = new Error('The operation was aborted');
+      abortError.name = 'AbortError';
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockRejectedValue(abortError),
+      });
+
+      await expect(elevenLabsListVoices('sk_test')).rejects.toThrow(ElevenLabsTimeoutError);
     });
   });
 
@@ -406,6 +435,17 @@ describe('ElevenLabsClient', () => {
       });
 
       await expect(elevenLabsListModels('bad_key')).rejects.toThrow(ElevenLabsApiError);
+    });
+
+    it('should throw ElevenLabsTimeoutError when abort fires during response.json()', async () => {
+      const abortError = new Error('The operation was aborted');
+      abortError.name = 'AbortError';
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockRejectedValue(abortError),
+      });
+
+      await expect(elevenLabsListModels('sk_test')).rejects.toThrow(ElevenLabsTimeoutError);
     });
   });
 

--- a/services/ai-worker/src/services/voice/ElevenLabsClient.ts
+++ b/services/ai-worker/src/services/voice/ElevenLabsClient.ts
@@ -172,6 +172,30 @@ async function extractErrorDetail(response: globalThis.Response): Promise<string
 }
 
 /**
+ * Read response body with AbortError → ElevenLabsTimeoutError conversion.
+ *
+ * The fetch signal remains attached to the response stream, so an abort
+ * during body consumption (arrayBuffer, json) throws a raw AbortError.
+ * This wrapper catches it and converts to the same typed timeout error
+ * that elevenLabsFetch uses for fetch-phase aborts.
+ */
+async function readBody<T>(
+  response: globalThis.Response,
+  reader: (r: globalThis.Response) => Promise<T>,
+  timeoutMs: number,
+  path: string
+): Promise<T> {
+  try {
+    return await reader(response);
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new ElevenLabsTimeoutError(timeoutMs, path, error);
+    }
+    throw error;
+  }
+}
+
+/**
  * Synthesize speech via ElevenLabs TTS.
  *
  * Returns MP3 audio (~10x smaller than WAV from voice-engine).
@@ -183,7 +207,8 @@ export async function elevenLabsTTS(options: ElevenLabsTTSOptions): Promise<Elev
   const { text, voiceId, apiKey, modelId = 'eleven_multilingual_v2' } = options;
 
   // SSRF prevention: encode voiceId in URL path
-  const response = await elevenLabsFetch(`/text-to-speech/${encodeURIComponent(voiceId)}`, apiKey, {
+  const path = `/text-to-speech/${encodeURIComponent(voiceId)}`;
+  const response = await elevenLabsFetch(path, apiKey, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -197,7 +222,7 @@ export async function elevenLabsTTS(options: ElevenLabsTTSOptions): Promise<Elev
     throw new ElevenLabsApiError(response.status, detail);
   }
 
-  const arrayBuffer = await response.arrayBuffer();
+  const arrayBuffer = await readBody(response, r => r.arrayBuffer(), ELEVENLABS_TIMEOUT_MS, path);
   return {
     audioBuffer: Buffer.from(arrayBuffer),
     contentType: response.headers.get('content-type') ?? 'audio/mpeg',
@@ -217,7 +242,8 @@ export async function elevenLabsSTT(options: ElevenLabsSTTOptions): Promise<Elev
   // Upgrade to 'scribe_v2' when audio event tags ([laughter], [sigh]) support is added.
   formData.append('model_id', 'scribe_v1');
 
-  const response = await elevenLabsFetch('/speech-to-text', apiKey, {
+  const path = '/speech-to-text';
+  const response = await elevenLabsFetch(path, apiKey, {
     method: 'POST',
     body: formData,
   });
@@ -227,7 +253,12 @@ export async function elevenLabsSTT(options: ElevenLabsSTTOptions): Promise<Elev
     throw new ElevenLabsApiError(response.status, detail);
   }
 
-  const data = (await response.json()) as { text?: string };
+  const data = await readBody(
+    response,
+    async r => (await r.json()) as { text?: string },
+    ELEVENLABS_TIMEOUT_MS,
+    path
+  );
   return { text: data.text ?? '' };
 }
 
@@ -255,7 +286,8 @@ export async function elevenLabsCloneVoice(
     formData.append('description', description);
   }
 
-  const response = await elevenLabsFetch('/voices/add', apiKey, {
+  const path = '/voices/add';
+  const response = await elevenLabsFetch(path, apiKey, {
     method: 'POST',
     body: formData,
   });
@@ -265,7 +297,12 @@ export async function elevenLabsCloneVoice(
     throw new ElevenLabsApiError(response.status, detail);
   }
 
-  const data = (await response.json()) as { voice_id?: string };
+  const data = await readBody(
+    response,
+    async r => (await r.json()) as { voice_id?: string },
+    ELEVENLABS_TIMEOUT_MS,
+    path
+  );
   if (data.voice_id === undefined) {
     throw new Error('ElevenLabs voice clone response missing voice_id');
   }
@@ -278,8 +315,9 @@ export async function elevenLabsCloneVoice(
  * List voices in the user's ElevenLabs account.
  */
 export async function elevenLabsListVoices(apiKey: string): Promise<ElevenLabsVoiceInfo[]> {
+  const path = '/voices';
   const response = await elevenLabsFetch(
-    '/voices',
+    path,
     apiKey,
     { method: 'GET' },
     ELEVENLABS_FAST_TIMEOUT_MS
@@ -290,7 +328,12 @@ export async function elevenLabsListVoices(apiKey: string): Promise<ElevenLabsVo
     throw new ElevenLabsApiError(response.status, detail);
   }
 
-  const data = (await response.json()) as { voices?: { voice_id: string; name: string }[] };
+  const data = await readBody(
+    response,
+    async r => (await r.json()) as { voices?: { voice_id: string; name: string }[] },
+    ELEVENLABS_FAST_TIMEOUT_MS,
+    path
+  );
   return (data.voices ?? []).map(v => ({ voiceId: v.voice_id, name: v.name }));
 }
 
@@ -304,8 +347,9 @@ export async function elevenLabsListVoices(apiKey: string): Promise<ElevenLabsVo
  * while api-gateway uses Zod and surfaces parse failures as 500 errors to the caller.
  */
 export async function elevenLabsListModels(apiKey: string): Promise<ElevenLabsModelInfo[]> {
+  const path = '/models';
   const response = await elevenLabsFetch(
-    '/models',
+    path,
     apiKey,
     { method: 'GET' },
     ELEVENLABS_FAST_TIMEOUT_MS
@@ -316,11 +360,13 @@ export async function elevenLabsListModels(apiKey: string): Promise<ElevenLabsMo
     throw new ElevenLabsApiError(response.status, detail);
   }
 
-  const data = (await response.json()) as {
-    model_id?: string;
-    name?: string;
-    can_do_text_to_speech?: boolean;
-  }[];
+  const data = await readBody(
+    response,
+    async r =>
+      (await r.json()) as { model_id?: string; name?: string; can_do_text_to_speech?: boolean }[],
+    ELEVENLABS_FAST_TIMEOUT_MS,
+    path
+  );
 
   // ElevenLabs /v1/models returns a top-level array of model objects
   return (Array.isArray(data) ? data : [])

--- a/services/ai-worker/src/services/voice/voiceEngineWarmup.test.ts
+++ b/services/ai-worker/src/services/voice/voiceEngineWarmup.test.ts
@@ -2,7 +2,7 @@
  * Tests for Voice Engine Warm-Up
  *
  * Verifies the shared health-polling loop used by both TTS and STT paths
- * to handle Railway Serverless cold starts (~56s).
+ * to handle Railway Serverless cold starts (~25s model loading).
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -135,7 +135,7 @@ describe('waitForVoiceEngine', () => {
     const result = await promise;
 
     expect(result).toEqual({ ready: false, elapsedMs: expect.any(Number) });
-    // Default: 75_000 / 3_000 = 25 polls
-    expect(client.getHealth).toHaveBeenCalledTimes(25);
+    // Default: 120_000 / 3_000 = 40 polls
+    expect(client.getHealth).toHaveBeenCalledTimes(40);
   });
 });

--- a/services/ai-worker/src/services/voice/voiceEngineWarmup.ts
+++ b/services/ai-worker/src/services/voice/voiceEngineWarmup.ts
@@ -14,10 +14,11 @@ import type { VoiceEngineClient } from './VoiceEngineClient.js';
 const logger = createLogger('VoiceEngineWarmup');
 
 /** Total time budget for health polling during voice engine cold start (ms).
- * Railway Serverless cold boot measured at ~56s — 75s gives comfortable margin.
- * Note: effective poll count varies — ECONNREFUSED resolves instantly (~25 polls),
- * but once Railway's LB is up the 5s health timeout may reduce it to ~10 polls. */
-const DEFAULT_BUDGET_MS = 75_000;
+ * Railway Serverless model loading takes ~25s (voices are lazy-loaded, not
+ * pre-loaded). 120s gives ample margin for variable Railway container startup.
+ * Note: effective poll count varies — ECONNREFUSED resolves instantly (~40 polls),
+ * but once Railway's LB is up the 5s health timeout may reduce it to ~15 polls. */
+const DEFAULT_BUDGET_MS = 120_000;
 
 /** Interval between health check polls (ms) */
 const DEFAULT_POLL_INTERVAL_MS = 3_000;

--- a/services/voice-engine/server.py
+++ b/services/voice-engine/server.py
@@ -158,6 +158,14 @@ def _safe_voice_path(voices_dir: str, filename: str) -> str:
 models: dict[str, Any] = {}
 voice_cache: dict[str, Any] = {}
 
+# Per-voice locks — prevents duplicate computation when concurrent TTS requests
+# hit a cache miss for the same voice. Without this, both requests would redundantly
+# call get_state_for_audio_prompt (~2.5s each), wasting a semaphore slot.
+_voice_locks: dict[str, asyncio.Lock] = {}
+
+# Audio file extensions recognized when scanning the voices/ directory for lazy loading.
+_VOICE_FILE_EXTENSIONS: tuple[str, ...] = (".wav", ".mp3", ".flac", ".ogg")
+
 # Concurrency cap for model inference — prevents OOM on Railway's 4GB ceiling.
 # Two concurrent Parakeet TDT passes on 1-min WAV ≈ 480MB audio + 1.2GB model.
 try:
@@ -183,6 +191,61 @@ def _cache_voice(voice_id: str, voice_state: Any) -> None:
         })
 
 
+def _find_voice_on_disk(voice_id: str) -> str | None:
+    """Find a registered voice file in the voices/ directory.
+
+    Returns the full file path if found, None otherwise.
+    Used for lazy loading: voices registered via /v1/voices/register are
+    persisted to disk but only loaded into memory on first TTS request.
+    """
+    voices_dir = os.environ.get("VOICES_DIR", "./voices")
+    if not os.path.isdir(voices_dir):
+        return None
+    for filename in os.listdir(voices_dir):
+        name, ext = os.path.splitext(filename)
+        if name == voice_id and ext in _VOICE_FILE_EXTENSIONS:
+            return os.path.join(voices_dir, filename)
+    return None
+
+
+async def _load_voice(
+    voice_id: str, tts_model: Any, loop: asyncio.AbstractEventLoop
+) -> Any:
+    """Load a voice state from disk or preset, caching the result.
+
+    Resolution order:
+    1. voices/ directory (registered custom voices persisted to disk)
+    2. Pocket TTS preset name or HuggingFace path
+    3. HTTPException 404 if nothing found
+
+    Caller must hold the per-voice lock (_voice_locks[voice_id]) to prevent
+    duplicate computation from concurrent requests.
+    """
+    # Try loading from voices/ directory first (registered custom voices)
+    disk_path = _find_voice_on_disk(voice_id)
+    if disk_path is not None:
+        voice_state: Any = await loop.run_in_executor(
+            None, tts_model.get_state_for_audio_prompt, disk_path
+        )
+        _cache_voice(voice_id, voice_state)
+        logger.info("Lazy-loaded voice from disk", extra={"voice_id": voice_id})
+        return voice_state
+
+    # Fallback: try as a Pocket TTS preset name or HuggingFace path
+    try:
+        voice_state = await loop.run_in_executor(
+            None, tts_model.get_state_for_audio_prompt, voice_id
+        )
+        _cache_voice(voice_id, voice_state)
+        return voice_state
+    except Exception:
+        logger.warning("Voice not found", extra={"voice_id": voice_id})
+        raise HTTPException(
+            status_code=404,
+            detail=f"Voice '{voice_id}' not found",
+        ) from None
+
+
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     """Load models on startup, clean up on shutdown."""
@@ -204,50 +267,20 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     models["tts"] = tts_model
     logger.info("Pocket TTS loaded", extra={"sample_rate": tts_model.sample_rate})
 
-    # --- Pre-load default voices ---
-    default_voices = os.environ.get("DEFAULT_VOICES", "alba,bria").split(",")
-    for voice_name in default_voices:
-        voice_name = voice_name.strip()
-        if not voice_name:
-            continue
-        if not _is_valid_voice_id(voice_name):
-            logger.warning("Skipping invalid preset voice name", extra={"voice_id": voice_name})
-            continue
-        try:
-            _cache_voice(
-                voice_name,
-                tts_model.get_state_for_audio_prompt(voice_name),
-            )
-            logger.info("Pre-loaded voice", extra={"voice_id": voice_name})
-        except Exception:
-            logger.warning("Failed to pre-load voice", exc_info=True, extra={"voice_id": voice_name})
+    # Voices are loaded lazily on first TTS request — no pre-loading.
+    # This keeps startup fast (~25s for models only) which is critical for
+    # Railway Serverless where containers sleep after 10 min idle.
+    # Custom voices persist in the voices/ directory and are loaded into
+    # voice_cache on demand when a TTS request references them.
 
-    # --- Pre-load any custom voices from the voices/ directory ---
-    voices_dir = os.environ.get("VOICES_DIR", "./voices")
-    if os.path.isdir(voices_dir):
-        for filename in os.listdir(voices_dir):
-            if filename.endswith((".wav", ".mp3", ".flac", ".ogg")):
-                voice_id = os.path.splitext(filename)[0]
-                if not _is_valid_voice_id(voice_id):
-                    logger.warning("Skipping voice file with invalid ID", extra={"filename": filename})
-                    continue
-                filepath = os.path.join(voices_dir, filename)
-                try:
-                    _cache_voice(
-                        voice_id,
-                        tts_model.get_state_for_audio_prompt(filepath),
-                    )
-                    logger.info("Pre-loaded custom voice", extra={"voice_id": voice_id})
-                except Exception:
-                    logger.warning("Failed to pre-load custom voice", exc_info=True, extra={"voice_id": voice_id})
-
-    logger.info("Voice Engine ready", extra={"voices_loaded": len(voice_cache)})
+    logger.info("Voice Engine ready")
 
     yield
 
     # Shutdown cleanup
     models.clear()
     voice_cache.clear()
+    _voice_locks.clear()
     gc.collect()
     logger.info("Voice Engine shut down")
 
@@ -461,18 +494,20 @@ async def text_to_speech(
                     _cache_voice(voice_id, voice_state)
 
                 else:
-                    # Try loading as a preset name or HF path
-                    try:
-                        voice_state = await loop.run_in_executor(
-                            None, tts_model.get_state_for_audio_prompt, voice_id
-                        )
-                        _cache_voice(voice_id, voice_state)
-                    except Exception:
-                        logger.warning("Voice not found", extra={"voice_id": voice_id})
-                        raise HTTPException(
-                            status_code=404,
-                            detail=f"Voice '{voice_id}' not found",
-                        ) from None
+                    # Cache miss — acquire per-voice lock to prevent duplicate
+                    # computation when concurrent requests hit the same voice.
+                    if voice_id not in _voice_locks:
+                        _voice_locks[voice_id] = asyncio.Lock()
+                    async with _voice_locks[voice_id]:
+                        # Double-check: another request may have loaded it while
+                        # we waited for the lock.
+                        if voice_id in voice_cache:
+                            voice_state = voice_cache[voice_id]
+                            _cache_voice(voice_id, voice_state)
+                        else:
+                            voice_state = await _load_voice(
+                                voice_id, tts_model, loop
+                            )
 
                 # Generate audio
                 audio_tensor: Any = await loop.run_in_executor(
@@ -593,14 +628,24 @@ async def register_voice(
         # Write and process — clean up on any failure (disk full, model error).
         # File write is offloaded to executor to avoid blocking the event loop
         # for large uploads (up to MAX_AUDIO_UPLOAD_BYTES = 50MB).
+        # Atomic write (temp + rename) prevents corrupted reads if a TTS request
+        # tries to lazy-load this voice file mid-write.
         loop = asyncio.get_running_loop()
 
-        def _write_file(path: str, data: bytes) -> None:
-            with open(path, "wb") as f:
-                f.write(data)
+        def _write_file_atomic(final_path: str, data: bytes) -> None:
+            dir_name = os.path.dirname(final_path)
+            fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+            try:
+                with os.fdopen(fd, "wb") as f:
+                    f.write(data)
+                os.rename(tmp_path, final_path)
+            except BaseException:
+                with suppress(OSError):
+                    os.unlink(tmp_path)
+                raise
 
         try:
-            await loop.run_in_executor(None, _write_file, voice_path, audio_bytes)
+            await loop.run_in_executor(None, _write_file_atomic, voice_path, audio_bytes)
             async with _inference_semaphore:
                 voice_state: Any = await loop.run_in_executor(
                     None, tts_model.get_state_for_audio_prompt, voice_path

--- a/services/voice-engine/server.py
+++ b/services/voice-engine/server.py
@@ -477,8 +477,8 @@ async def text_to_speech(
             # avoids wasting a concurrency slot while waiting on a lock.
             voice_state: Any
             if ref_tmp_path is not None:
-                # Zero-shot cloning — state extraction inside semaphore
-                # because uploaded reference audio can be large.
+                # Zero-shot cloning — voice_state set in Phase 2 (inside
+                # semaphore) because uploaded reference audio can be large.
                 pass
             elif voice_id in voice_cache:
                 # Refresh LRU position via _cache_voice (pop-and-reinsert)

--- a/services/voice-engine/server.py
+++ b/services/voice-engine/server.py
@@ -228,6 +228,9 @@ async def _load_voice(voice_id: str, tts_model: Any, loop: asyncio.AbstractEvent
     # executor to avoid stalling the event loop.
     disk_path = await loop.run_in_executor(None, _find_voice_on_disk, voice_id)
     if disk_path is not None:
+        # No error handling here — if the file exists but is corrupted,
+        # the resulting 500 is the correct signal (server-side data error,
+        # not a missing-voice user error). Re-registering the voice fixes it.
         voice_state: Any = await loop.run_in_executor(None, tts_model.get_state_for_audio_prompt, disk_path)
         _cache_voice(voice_id, voice_state)
         logger.info("Lazy-loaded voice from disk", extra={"voice_id": voice_id})
@@ -278,7 +281,10 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     # Custom voices persist in the voices/ directory and are loaded into
     # voice_cache on demand when a TTS request references them.
     if os.environ.get("DEFAULT_VOICES"):
-        logger.warning("DEFAULT_VOICES is set but no longer used — voices are lazy-loaded")
+        logger.warning(
+            "DEFAULT_VOICES is set but no longer used — remove it from your environment. "
+            "Voices load automatically on first TTS request."
+        )
 
     logger.info("Voice Engine ready", extra={"mode": "lazy"})
 

--- a/services/voice-engine/server.py
+++ b/services/voice-engine/server.py
@@ -161,6 +161,8 @@ voice_cache: dict[str, Any] = {}
 # Per-voice locks — prevents duplicate computation when concurrent TTS requests
 # hit a cache miss for the same voice. Without this, both requests would redundantly
 # call get_state_for_audio_prompt (~2.5s each), wasting a semaphore slot.
+# Grows without bound but bounded by total voice count (~60-100 in practice).
+# Entries are cheap (asyncio.Lock is ~100 bytes) and cleared on shutdown.
 _voice_locks: dict[str, asyncio.Lock] = {}
 
 # Audio file extensions recognized when scanning the voices/ directory for lazy loading.
@@ -231,14 +233,17 @@ async def _load_voice(
         logger.info("Lazy-loaded voice from disk", extra={"voice_id": voice_id})
         return voice_state
 
-    # Fallback: try as a Pocket TTS preset name or HuggingFace path
+    # Fallback: try as a Pocket TTS preset name or HuggingFace path.
+    # FileNotFoundError is the specific exception Pocket TTS raises for unknown
+    # preset names — catch it for the 404 path. Any other exception (OOM, model
+    # crash, I/O failure) propagates as 500 via the outer handler.
     try:
         voice_state = await loop.run_in_executor(
             None, tts_model.get_state_for_audio_prompt, voice_id
         )
         _cache_voice(voice_id, voice_state)
         return voice_state
-    except Exception:
+    except (FileNotFoundError, ValueError, OSError):
         logger.warning("Voice not found", extra={"voice_id": voice_id})
         raise HTTPException(
             status_code=404,
@@ -500,10 +505,10 @@ async def text_to_speech(
                         _voice_locks[voice_id] = asyncio.Lock()
                     async with _voice_locks[voice_id]:
                         # Double-check: another request may have loaded it while
-                        # we waited for the lock.
+                        # we waited for the lock. No LRU refresh needed — the
+                        # concurrent request just cached it, so it's already newest.
                         if voice_id in voice_cache:
                             voice_state = voice_cache[voice_id]
-                            _cache_voice(voice_id, voice_state)
                         else:
                             voice_state = await _load_voice(
                                 voice_id, tts_model, loop

--- a/services/voice-engine/server.py
+++ b/services/voice-engine/server.py
@@ -40,9 +40,7 @@ class _JsonFormatter(logging.Formatter):
     # Standard LogRecord attributes to exclude from extra-field merging.
     # Derived from a dummy LogRecord's __dict__ — common pattern in logging libraries.
     # If CPython adds new internal attrs in future versions, they'll be auto-excluded.
-    _STANDARD_ATTRS: frozenset[str] = frozenset(
-        logging.LogRecord("", 0, "", 0, "", (), None).__dict__
-    )
+    _STANDARD_ATTRS: frozenset[str] = frozenset(logging.LogRecord("", 0, "", 0, "", (), None).__dict__)
 
     def format(self, record: logging.LogRecord) -> str:
         # Intentionally does NOT call super().format() — that would set record.message
@@ -188,9 +186,13 @@ def _cache_voice(voice_id: str, voice_state: Any) -> None:
     if len(voice_cache) > MAX_VOICE_CACHE_SIZE:
         oldest = next(iter(voice_cache))
         del voice_cache[oldest]
-        logger.warning("Voice cache full, evicted oldest entry", extra={
-            "voice_id": oldest, "voice_count": MAX_VOICE_CACHE_SIZE,
-        })
+        logger.warning(
+            "Voice cache full, evicted oldest entry",
+            extra={
+                "voice_id": oldest,
+                "voice_count": MAX_VOICE_CACHE_SIZE,
+            },
+        )
 
 
 def _find_voice_on_disk(voice_id: str) -> str | None:
@@ -210,9 +212,7 @@ def _find_voice_on_disk(voice_id: str) -> str | None:
     return None
 
 
-async def _load_voice(
-    voice_id: str, tts_model: Any, loop: asyncio.AbstractEventLoop
-) -> Any:
+async def _load_voice(voice_id: str, tts_model: Any, loop: asyncio.AbstractEventLoop) -> Any:
     """Load a voice state from disk or preset, caching the result.
 
     Resolution order:
@@ -228,9 +228,7 @@ async def _load_voice(
     # executor to avoid stalling the event loop.
     disk_path = await loop.run_in_executor(None, _find_voice_on_disk, voice_id)
     if disk_path is not None:
-        voice_state: Any = await loop.run_in_executor(
-            None, tts_model.get_state_for_audio_prompt, disk_path
-        )
+        voice_state: Any = await loop.run_in_executor(None, tts_model.get_state_for_audio_prompt, disk_path)
         _cache_voice(voice_id, voice_state)
         logger.info("Lazy-loaded voice from disk", extra={"voice_id": voice_id})
         return voice_state
@@ -240,17 +238,19 @@ async def _load_voice(
     # names, ValueError for invalid formats. Any other exception (OOM, model
     # crash) propagates as 500 via the outer handler.
     try:
-        voice_state = await loop.run_in_executor(
-            None, tts_model.get_state_for_audio_prompt, voice_id
-        )
+        voice_state = await loop.run_in_executor(None, tts_model.get_state_for_audio_prompt, voice_id)
         _cache_voice(voice_id, voice_state)
         return voice_state
-    except (ValueError, OSError):
-        logger.warning("Voice not found", extra={"voice_id": voice_id})
+    except (ValueError, OSError) as exc:
+        logger.warning(
+            "Voice not found",
+            exc_info=True,
+            extra={"voice_id": voice_id},
+        )
         raise HTTPException(
             status_code=404,
             detail=f"Voice '{voice_id}' not found",
-        ) from None
+        ) from exc
 
 
 @asynccontextmanager
@@ -260,9 +260,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 
     # --- Load STT model ---
     logger.info("Loading Parakeet TDT 0.6B v3")
-    asr_model = nemo_asr.models.ASRModel.from_pretrained(
-        model_name="nvidia/parakeet-tdt-0.6b-v3"
-    )
+    asr_model = nemo_asr.models.ASRModel.from_pretrained(model_name="nvidia/parakeet-tdt-0.6b-v3")
     asr_model = asr_model.cpu()
     asr_model.eval()
     models["asr"] = asr_model
@@ -279,8 +277,10 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     # Railway Serverless where containers sleep after 10 min idle.
     # Custom voices persist in the voices/ directory and are loaded into
     # voice_cache on demand when a TTS request references them.
+    if os.environ.get("DEFAULT_VOICES"):
+        logger.warning("DEFAULT_VOICES is set but no longer used — voices are lazy-loaded")
 
-    logger.info("Voice Engine ready")
+    logger.info("Voice Engine ready", extra={"mode": "lazy"})
 
     yield
 
@@ -306,9 +306,7 @@ if _API_KEY is not None and not _API_KEY.strip():
 
 
 @app.middleware("http")
-async def check_api_key(
-    request: Request, call_next: Callable[[Request], Awaitable[Response]]
-) -> Response:
+async def check_api_key(request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
     if _API_KEY is not None and request.url.path != "/health":
         provided = request.headers.get("x-api-key", "")
         if not provided:
@@ -316,9 +314,7 @@ async def check_api_key(
             if auth.startswith("Bearer "):
                 provided = auth[7:]
         if not provided or not secrets.compare_digest(provided, _API_KEY):
-            return JSONResponse(
-                status_code=401, content={"detail": "Invalid or missing API key"}
-            )
+            return JSONResponse(status_code=401, content={"detail": "Invalid or missing API key"})
     return await call_next(request)
 
 
@@ -375,9 +371,7 @@ async def transcribe(file: UploadFile = File(...)) -> dict[str, str]:
                 )
 
             # Transcribe — NeMo returns objects with .text attribute
-            transcriptions: list[Any] = await loop.run_in_executor(
-                None, asr_model.transcribe, [audio_array]
-            )
+            transcriptions: list[Any] = await loop.run_in_executor(None, asr_model.transcribe, [audio_array])
             text: str = transcriptions[0].text if transcriptions else ""
 
         # Cleanup
@@ -414,6 +408,7 @@ async def transcribe_openai_compat(
 # ---------------------------------------------------------------------------
 # TTS Endpoints
 # ---------------------------------------------------------------------------
+
 
 @app.post("/v1/tts")
 async def text_to_speech(
@@ -463,73 +458,65 @@ async def text_to_speech(
             if reference_audio:
                 ref_audio_bytes = await reference_audio.read()
                 if len(ref_audio_bytes) > MAX_AUDIO_UPLOAD_BYTES:
-                    raise HTTPException(
-                        status_code=413, detail="Reference audio file too large"
-                    )
-                if (
-                    reference_audio.content_type
-                    and reference_audio.content_type not in _AUDIO_EXTENSIONS
-                ):
+                    raise HTTPException(status_code=413, detail="Reference audio file too large")
+                if reference_audio.content_type and reference_audio.content_type not in _AUDIO_EXTENSIONS:
                     raise HTTPException(
                         status_code=400,
                         detail=f"Unsupported audio type: {reference_audio.content_type}. "
                         f"Allowed: {', '.join(sorted(_AUDIO_EXTENSIONS))}",
                     )
-                ext = _AUDIO_EXTENSIONS.get(
-                    reference_audio.content_type or "", _DEFAULT_AUDIO_EXT
-                )
-                with tempfile.NamedTemporaryFile(
-                    suffix=ext, delete=False
-                ) as tmp:
+                ext = _AUDIO_EXTENSIONS.get(reference_audio.content_type or "", _DEFAULT_AUDIO_EXT)
+                with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as tmp:
                     ref_tmp_path = tmp.name
                     tmp.write(ref_audio_bytes)
                 del ref_audio_bytes
 
+            # --- Phase 1: Resolve voice state (outside semaphore) ---
+            # Voice resolution uses per-voice locks to prevent duplicate
+            # computation. Keeping this outside the inference semaphore
+            # avoids wasting a concurrency slot while waiting on a lock.
+            voice_state: Any
+            if ref_tmp_path is not None:
+                # Zero-shot cloning — state extraction inside semaphore
+                # because uploaded reference audio can be large.
+                pass
+            elif voice_id in voice_cache:
+                # Refresh LRU position via _cache_voice (pop-and-reinsert)
+                voice_state = voice_cache[voice_id]
+                _cache_voice(voice_id, voice_state)
+            else:
+                # Cache miss — acquire per-voice lock to prevent duplicate
+                # computation when concurrent requests hit the same voice.
+                # Lock dict growth is bounded: only authenticated ai-worker
+                # calls reach here (VOICE_ENGINE_API_KEY + Railway private
+                # networking), and voice_id is format-validated by
+                # _is_valid_voice_id. Practical max = registered voice count.
+                lock = _voice_locks.setdefault(voice_id, asyncio.Lock())
+                async with lock:
+                    # Double-check: another request may have loaded it while
+                    # we waited for the lock. No LRU refresh needed — the
+                    # concurrent request just cached it, so it's already newest.
+                    if voice_id in voice_cache:
+                        voice_state = voice_cache[voice_id]
+                    else:
+                        voice_state = await _load_voice(voice_id, tts_model, loop)
+
+            # --- Phase 2: Model inference (semaphore) ---
             # Semaphore caps concurrency to prevent OOM on Railway 4GB ceiling.
             async with _inference_semaphore:
-                # Get or create voice state
                 if ref_tmp_path is not None:
-                    # Zero-shot cloning from uploaded audio
-                    voice_state: Any = await loop.run_in_executor(
-                        None, tts_model.get_state_for_audio_prompt, ref_tmp_path
-                    )
+                    voice_state = await loop.run_in_executor(None, tts_model.get_state_for_audio_prompt, ref_tmp_path)
                     _cache_voice(voice_id, voice_state)
-
-                elif voice_id in voice_cache:
-                    # Refresh LRU position via _cache_voice (pop-and-reinsert)
-                    voice_state = voice_cache[voice_id]
-                    _cache_voice(voice_id, voice_state)
-
-                else:
-                    # Cache miss — acquire per-voice lock to prevent duplicate
-                    # computation when concurrent requests hit the same voice.
-                    # Lock dict growth is bounded: only authenticated ai-worker
-                    # calls reach here (VOICE_ENGINE_API_KEY + Railway private
-                    # networking), and voice_id is format-validated by
-                    # _is_valid_voice_id. Practical max = registered voice count.
-                    lock = _voice_locks.setdefault(voice_id, asyncio.Lock())
-                    async with lock:
-                        # Double-check: another request may have loaded it while
-                        # we waited for the lock. No LRU refresh needed — the
-                        # concurrent request just cached it, so it's already newest.
-                        if voice_id in voice_cache:
-                            voice_state = voice_cache[voice_id]
-                        else:
-                            voice_state = await _load_voice(
-                                voice_id, tts_model, loop
-                            )
 
                 # Generate audio
-                audio_tensor: Any = await loop.run_in_executor(
-                    None, tts_model.generate_audio, voice_state, clean_text
-                )
+                audio_tensor: Any = await loop.run_in_executor(None, tts_model.generate_audio, voice_state, clean_text)
         finally:
             # Clean up temp file regardless of semaphore/model errors
             if ref_tmp_path is not None and os.path.exists(ref_tmp_path):
                 os.unlink(ref_tmp_path)
-        audio_np: np.ndarray[Any, np.dtype[np.int16]] = np.clip(
-            audio_tensor.numpy() * 32767, -32768, 32767
-        ).astype(np.int16)
+        audio_np: np.ndarray[Any, np.dtype[np.int16]] = np.clip(audio_tensor.numpy() * 32767, -32768, 32767).astype(
+            np.int16
+        )
 
         # Convert to WAV bytes
         wav_buffer = io.BytesIO()
@@ -575,11 +562,7 @@ async def tts_openai_compat(
 @app.get("/v1/voices")
 def list_voices() -> dict[str, list[dict[str, str]]]:
     """List all available voices."""
-    return {
-        "voices": [
-            {"id": voice_id, "type": "cached"} for voice_id in voice_cache
-        ]
-    }
+    return {"voices": [{"id": voice_id, "type": "cached"} for voice_id in voice_cache]}
 
 
 @app.post("/v1/voices/register")
@@ -611,8 +594,7 @@ async def register_voice(
         if audio.content_type and audio.content_type not in _AUDIO_EXTENSIONS:
             raise HTTPException(
                 status_code=400,
-                detail=f"Unsupported audio type: {audio.content_type}. "
-                f"Allowed: {', '.join(sorted(_AUDIO_EXTENSIONS))}",
+                detail=f"Unsupported audio type: {audio.content_type}. Allowed: {', '.join(sorted(_AUDIO_EXTENSIONS))}",
             )
 
         # Save to voices directory for persistence across restarts.
@@ -657,9 +639,7 @@ async def register_voice(
         try:
             await loop.run_in_executor(None, _write_file_atomic, voice_path, audio_bytes)
             async with _inference_semaphore:
-                voice_state: Any = await loop.run_in_executor(
-                    None, tts_model.get_state_for_audio_prompt, voice_path
-                )
+                voice_state: Any = await loop.run_in_executor(None, tts_model.get_state_for_audio_prompt, voice_path)
             _cache_voice(voice_id, voice_state)
         except Exception:
             # Inline containment check for cleanup (CodeQL py/path-injection #63/#64).

--- a/services/voice-engine/server.py
+++ b/services/voice-engine/server.py
@@ -223,8 +223,10 @@ async def _load_voice(
     Caller must hold the per-voice lock (_voice_locks[voice_id]) to prevent
     duplicate computation from concurrent requests.
     """
-    # Try loading from voices/ directory first (registered custom voices)
-    disk_path = _find_voice_on_disk(voice_id)
+    # Try loading from voices/ directory first (registered custom voices).
+    # os.listdir() inside _find_voice_on_disk is blocking I/O — offload to
+    # executor to avoid stalling the event loop.
+    disk_path = await loop.run_in_executor(None, _find_voice_on_disk, voice_id)
     if disk_path is not None:
         voice_state: Any = await loop.run_in_executor(
             None, tts_model.get_state_for_audio_prompt, disk_path
@@ -501,9 +503,8 @@ async def text_to_speech(
                 else:
                     # Cache miss — acquire per-voice lock to prevent duplicate
                     # computation when concurrent requests hit the same voice.
-                    if voice_id not in _voice_locks:
-                        _voice_locks[voice_id] = asyncio.Lock()
-                    async with _voice_locks[voice_id]:
+                    lock = _voice_locks.setdefault(voice_id, asyncio.Lock())
+                    async with lock:
                         # Double-check: another request may have loaded it while
                         # we waited for the lock. No LRU refresh needed — the
                         # concurrent request just cached it, so it's already newest.

--- a/services/voice-engine/server.py
+++ b/services/voice-engine/server.py
@@ -236,16 +236,16 @@ async def _load_voice(
         return voice_state
 
     # Fallback: try as a Pocket TTS preset name or HuggingFace path.
-    # FileNotFoundError is the specific exception Pocket TTS raises for unknown
-    # preset names — catch it for the 404 path. Any other exception (OOM, model
-    # crash, I/O failure) propagates as 500 via the outer handler.
+    # Pocket TTS raises OSError (including FileNotFoundError) for unknown preset
+    # names, ValueError for invalid formats. Any other exception (OOM, model
+    # crash) propagates as 500 via the outer handler.
     try:
         voice_state = await loop.run_in_executor(
             None, tts_model.get_state_for_audio_prompt, voice_id
         )
         _cache_voice(voice_id, voice_state)
         return voice_state
-    except (FileNotFoundError, ValueError, OSError):
+    except (ValueError, OSError):
         logger.warning("Voice not found", extra={"voice_id": voice_id})
         raise HTTPException(
             status_code=404,
@@ -503,6 +503,10 @@ async def text_to_speech(
                 else:
                     # Cache miss — acquire per-voice lock to prevent duplicate
                     # computation when concurrent requests hit the same voice.
+                    # Lock dict growth is bounded: only authenticated ai-worker
+                    # calls reach here (VOICE_ENGINE_API_KEY + Railway private
+                    # networking), and voice_id is format-validated by
+                    # _is_valid_voice_id. Practical max = registered voice count.
                     lock = _voice_locks.setdefault(voice_id, asyncio.Lock())
                     async with lock:
                         # Double-check: another request may have loaded it while

--- a/services/voice-engine/tests/conftest.py
+++ b/services/voice-engine/tests/conftest.py
@@ -28,18 +28,20 @@ for _mod_name in (
     if _mod_name not in sys.modules:
         sys.modules[_mod_name] = MagicMock()
 
-from server import app, models, voice_cache  # noqa: E402 -- must import after sys.modules mocking above
+from server import app, models, voice_cache, _voice_locks  # noqa: E402 -- must import after sys.modules mocking above
 from tests.helpers import FakeTranscription  # noqa: E402 -- must import after sys.modules mocking above
 
 
 @pytest.fixture(autouse=True)
 def _reset_state() -> Generator[None, None, None]:
-    """Clear models and voice_cache before each test to prevent leaks."""
+    """Clear models, voice_cache, and voice_locks before each test to prevent leaks."""
     models.clear()
     voice_cache.clear()
+    _voice_locks.clear()
     yield
     models.clear()
     voice_cache.clear()
+    _voice_locks.clear()
 
 
 @pytest.fixture()

--- a/services/voice-engine/tests/conftest.py
+++ b/services/voice-engine/tests/conftest.py
@@ -28,7 +28,7 @@ for _mod_name in (
     if _mod_name not in sys.modules:
         sys.modules[_mod_name] = MagicMock()
 
-from server import app, models, voice_cache, _voice_locks  # noqa: E402 -- must import after sys.modules mocking above
+from server import _voice_locks, app, models, voice_cache  # noqa: E402 -- must import after sys.modules mocking above
 from tests.helpers import FakeTranscription  # noqa: E402 -- must import after sys.modules mocking above
 
 

--- a/services/voice-engine/tests/test_tts.py
+++ b/services/voice-engine/tests/test_tts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -87,9 +88,7 @@ async def test_tts_rejects_invalid_voice_id(client: httpx.AsyncClient, mock_tts:
     assert "voice_id" in response.json()["detail"]
 
 
-async def test_tts_rejects_empty_text_after_tag_stripping(
-    client: httpx.AsyncClient, mock_tts: MagicMock
-) -> None:
+async def test_tts_rejects_empty_text_after_tag_stripping(client: httpx.AsyncClient, mock_tts: MagicMock) -> None:
     voice_cache["alba"] = {"state": "mock"}
 
     response = await client.post(
@@ -101,9 +100,7 @@ async def test_tts_rejects_empty_text_after_tag_stripping(
     assert "No text to synthesize" in response.json()["detail"]
 
 
-async def test_tts_requires_auth_when_key_set(
-    client: httpx.AsyncClient, mock_tts: MagicMock, api_key: str
-) -> None:
+async def test_tts_requires_auth_when_key_set(client: httpx.AsyncClient, mock_tts: MagicMock, api_key: str) -> None:
     response = await client.post(
         "/v1/tts",
         data={"text": "Hello", "voice_id": "alba"},
@@ -112,9 +109,7 @@ async def test_tts_requires_auth_when_key_set(
     assert response.status_code == 401
 
 
-async def test_tts_lazy_loads_voice_from_disk(
-    client: httpx.AsyncClient, mock_tts: MagicMock
-) -> None:
+async def test_tts_lazy_loads_voice_from_disk(client: httpx.AsyncClient, mock_tts: MagicMock) -> None:
     """Voice not in cache but file exists on disk — should lazy-load from disk path."""
     # _find_voice_on_disk returns a disk path; get_state_for_audio_prompt is called with it
     fake_path = "/app/voices/my-custom-voice.wav"
@@ -131,17 +126,16 @@ async def test_tts_lazy_loads_voice_from_disk(
     assert "my-custom-voice" in voice_cache
 
 
-async def test_tts_concurrent_requests_compute_voice_state_once(
-    client: httpx.AsyncClient, mock_tts: MagicMock
-) -> None:
+async def test_tts_concurrent_requests_compute_voice_state_once(client: httpx.AsyncClient, mock_tts: MagicMock) -> None:
     """Two concurrent TTS requests for the same uncached voice should only compute state once."""
     fake_path = "/app/voices/shared-voice.wav"
 
     # Simulate slow voice state computation (~0.1s) to expose concurrency
     original_return = mock_tts.get_state_for_audio_prompt.return_value
 
-    def slow_load(path: str) -> dict[str, str]:
+    def slow_load(path: str) -> Any:
         import time
+
         time.sleep(0.05)
         return original_return
 

--- a/services/voice-engine/tests/test_tts.py
+++ b/services/voice-engine/tests/test_tts.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+import asyncio
+from unittest.mock import MagicMock, patch
 
 import httpx
 
@@ -109,3 +110,50 @@ async def test_tts_requires_auth_when_key_set(
     )
 
     assert response.status_code == 401
+
+
+async def test_tts_lazy_loads_voice_from_disk(
+    client: httpx.AsyncClient, mock_tts: MagicMock
+) -> None:
+    """Voice not in cache but file exists on disk — should lazy-load from disk path."""
+    # _find_voice_on_disk returns a disk path; get_state_for_audio_prompt is called with it
+    fake_path = "/app/voices/my-custom-voice.wav"
+    with patch("server._find_voice_on_disk", return_value=fake_path):
+        response = await client.post(
+            "/v1/tts",
+            data={"text": "Hello", "voice_id": "my-custom-voice"},
+        )
+
+    assert response.status_code == 200
+    # Verify get_state_for_audio_prompt was called with the disk path, not the bare voice_id
+    mock_tts.get_state_for_audio_prompt.assert_called_once_with(fake_path)
+    # Voice should now be cached
+    assert "my-custom-voice" in voice_cache
+
+
+async def test_tts_concurrent_requests_compute_voice_state_once(
+    client: httpx.AsyncClient, mock_tts: MagicMock
+) -> None:
+    """Two concurrent TTS requests for the same uncached voice should only compute state once."""
+    fake_path = "/app/voices/shared-voice.wav"
+
+    # Simulate slow voice state computation (~0.1s) to expose concurrency
+    original_return = mock_tts.get_state_for_audio_prompt.return_value
+
+    def slow_load(path: str) -> dict[str, str]:
+        import time
+        time.sleep(0.05)
+        return original_return
+
+    mock_tts.get_state_for_audio_prompt.side_effect = slow_load
+
+    with patch("server._find_voice_on_disk", return_value=fake_path):
+        results = await asyncio.gather(
+            client.post("/v1/tts", data={"text": "Hello 1", "voice_id": "shared-voice"}),
+            client.post("/v1/tts", data={"text": "Hello 2", "voice_id": "shared-voice"}),
+        )
+
+    assert results[0].status_code == 200
+    assert results[1].status_code == 200
+    # Per-voice lock should deduplicate: state computed once, second request uses cache
+    assert mock_tts.get_state_for_audio_prompt.call_count == 1


### PR DESCRIPTION
## Summary

- **Python voice-engine**: Remove voice pre-loading from startup (70s → 25s cold start). Voices lazy-load from `voices/` directory on first TTS request with per-voice `asyncio.Lock` to prevent thundering herd. Atomic file writes in `/register` endpoint.
- **TypeScript warmup**: Increase health-poll budget from 75s to 120s — massive headroom with the faster startup.
- **ElevenLabs abort fix**: Wrap `response.arrayBuffer()` / `response.json()` with AbortError → ElevenLabsTimeoutError conversion via new `readBody()` helper. Prevents raw "aborted" surfacing to users when timeout fires during response body parsing.

## Test plan

- [x] Python tests: 53/53 passed (2 new: lazy disk loading, concurrent deduplication)
- [x] TypeScript tests: 2476/2476 passed (2 new: AbortError during body parsing)
- [x] Quality: lint + cpd + depcruise + typecheck all clean
- [ ] Post-deploy: verify Railway logs show ~25s startup (no "Pre-loaded" lines)
- [ ] Post-deploy: first TTS request for a registered voice lazy-loads from disk
- [ ] Post-deploy: ElevenLabs timeout errors show proper message instead of "aborted"

🤖 Generated with [Claude Code](https://claude.com/claude-code)