### PR TITLE
refactor(bot-client): extract BrowseActionRow type + trim duplicate guard tests

### DIFF
--- a/services/bot-client/src/commands/admin/servers.ts
+++ b/services/bot-client/src/commands/admin/servers.ts
@@ -17,7 +17,6 @@ import {
   ButtonBuilder,
   ButtonStyle,
   ActionRowBuilder,
-  StringSelectMenuBuilder,
 } from 'discord.js';
 import type { ButtonInteraction, StringSelectMenuInteraction, Guild } from 'discord.js';
 import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
@@ -30,6 +29,7 @@ import {
   formatSortNatural,
   formatSortVerbatim,
   type BrowseSortToggle,
+  type BrowseActionRow,
 } from '../../utils/browse/index.js';
 
 const logger = createLogger('admin-servers');
@@ -170,9 +170,6 @@ const SERVERS_SORT_TOGGLE: BrowseSortToggle<ServerBrowseSortType> = {
       ? { label: 'Sort A-Z', emoji: '🔤' }
       : { label: 'Sort by Members', emoji: '👥' },
 };
-
-/** Union type for action rows */
-type BrowseActionRow = ActionRowBuilder<ButtonBuilder> | ActionRowBuilder<StringSelectMenuBuilder>;
 
 /**
  * Build the browse embed and components

--- a/services/bot-client/src/commands/channel/settings.test.ts
+++ b/services/bot-client/src/commands/channel/settings.test.ts
@@ -11,12 +11,11 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
+import type { ButtonInteraction } from 'discord.js';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import {
   handleChannelSettings,
   handleChannelSettingsButton,
-  handleChannelSettingsSelectMenu,
   handleChannelSettingsModal,
   isChannelSettingsInteraction,
 } from './settings.js';
@@ -117,50 +116,6 @@ describe('Channel Settings Dashboard', () => {
       followUp: vi.fn(),
       deleteReply: vi.fn(),
     } as unknown as DeferredCommandContext;
-  };
-
-  const createMockButtonInteraction = (
-    customId: string
-  ): ButtonInteraction & {
-    deferUpdate: ReturnType<typeof vi.fn>;
-    editReply: ReturnType<typeof vi.fn>;
-    message: { id: string };
-  } => {
-    return {
-      customId,
-      user: { id: 'user-456' },
-      deferUpdate: vi.fn().mockResolvedValue(undefined),
-      editReply: vi.fn().mockResolvedValue(undefined),
-      message: { id: 'message-123' },
-    } as unknown as ButtonInteraction & {
-      deferUpdate: ReturnType<typeof vi.fn>;
-      editReply: ReturnType<typeof vi.fn>;
-      message: { id: string };
-    };
-  };
-
-  const createMockSelectMenuInteraction = (
-    customId: string,
-    value: string
-  ): StringSelectMenuInteraction & {
-    deferUpdate: ReturnType<typeof vi.fn>;
-    editReply: ReturnType<typeof vi.fn>;
-    message: { id: string };
-    values: string[];
-  } => {
-    return {
-      customId,
-      user: { id: 'user-456' },
-      deferUpdate: vi.fn().mockResolvedValue(undefined),
-      editReply: vi.fn().mockResolvedValue(undefined),
-      message: { id: 'message-123' },
-      values: [value],
-    } as unknown as StringSelectMenuInteraction & {
-      deferUpdate: ReturnType<typeof vi.fn>;
-      editReply: ReturnType<typeof vi.fn>;
-      message: { id: string };
-      values: string[];
-    };
   };
 
   beforeEach(() => {
@@ -421,14 +376,6 @@ describe('Channel Settings Dashboard', () => {
   });
 
   describe('handleChannelSettingsButton', () => {
-    it('should ignore non-channel-settings interactions', async () => {
-      const interaction = createMockButtonInteraction('admin-settings::set::global::enabled:true');
-
-      await handleChannelSettingsButton(interaction);
-
-      expect(interaction.deferUpdate).not.toHaveBeenCalled();
-    });
-
     it('should handle API failure gracefully', async () => {
       const interaction = {
         customId: 'channel-settings::set::channel-123::maxMessages:auto',
@@ -464,19 +411,6 @@ describe('Channel Settings Dashboard', () => {
     });
   });
 
-  describe('handleChannelSettingsSelectMenu', () => {
-    it('should ignore non-channel-settings interactions', async () => {
-      const interaction = createMockSelectMenuInteraction(
-        'admin-settings::select::global',
-        'enabled'
-      );
-
-      await handleChannelSettingsSelectMenu(interaction);
-
-      expect(interaction.deferUpdate).not.toHaveBeenCalled();
-    });
-  });
-
   describe('handleChannelSettingsModal', () => {
     const createMockModalInteraction = (customId: string, inputValue: string) => ({
       customId,
@@ -502,17 +436,6 @@ describe('Channel Settings Dashboard', () => {
         view: 'setting',
         activeSetting: settingId,
       },
-    });
-
-    it('should ignore non-channel-settings modal interactions', async () => {
-      const interaction = createMockModalInteraction(
-        'admin-settings::modal::global::enabled',
-        '50'
-      );
-
-      await handleChannelSettingsModal(interaction as never);
-
-      expect(interaction.reply).not.toHaveBeenCalled();
     });
 
     it('should update maxMessages setting via config-overrides endpoint', async () => {

--- a/services/bot-client/src/commands/character/browse.ts
+++ b/services/bot-client/src/commands/character/browse.ts
@@ -9,7 +9,7 @@
  * - Groups characters by owner for better organization
  */
 
-import { ButtonBuilder, EmbedBuilder, ActionRowBuilder, StringSelectMenuBuilder } from 'discord.js';
+import { EmbedBuilder } from 'discord.js';
 import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
 import {
   createLogger,
@@ -45,6 +45,7 @@ import {
   formatFilterLabeled,
   formatSortNatural,
   formatSortVerbatim,
+  type BrowseActionRow,
 } from '../../utils/browse/index.js';
 import {
   type ListItem,
@@ -130,9 +131,6 @@ function buildBrowseButtons(
     buildInfoId: browseHelpers.buildInfo,
   });
 }
-
-/** Union type for action rows that can contain buttons or select menus */
-type BrowseActionRow = ActionRowBuilder<ButtonBuilder> | ActionRowBuilder<StringSelectMenuBuilder>;
 
 /** Options for buildBrowsePage */
 interface BuildBrowsePageOptions {

--- a/services/bot-client/src/commands/character/overrides.test.ts
+++ b/services/bot-client/src/commands/character/overrides.test.ts
@@ -6,11 +6,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
+import type { ButtonInteraction } from 'discord.js';
 import {
   handleOverrides,
   handleCharacterOverridesButton,
-  handleCharacterOverridesSelectMenu,
   handleCharacterOverridesModal,
   isCharacterOverridesInteraction,
 } from './overrides.js';
@@ -126,50 +125,6 @@ describe('Character Overrides Dashboard', () => {
           getString: ReturnType<typeof vi.fn>;
         };
       };
-    };
-  };
-
-  const createMockButtonInteraction = (
-    customId: string
-  ): ButtonInteraction & {
-    deferUpdate: ReturnType<typeof vi.fn>;
-    editReply: ReturnType<typeof vi.fn>;
-    message: { id: string };
-  } => {
-    return {
-      customId,
-      user: { id: 'user-456' },
-      deferUpdate: vi.fn().mockResolvedValue(undefined),
-      editReply: vi.fn().mockResolvedValue(undefined),
-      message: { id: 'message-123' },
-    } as unknown as ButtonInteraction & {
-      deferUpdate: ReturnType<typeof vi.fn>;
-      editReply: ReturnType<typeof vi.fn>;
-      message: { id: string };
-    };
-  };
-
-  const createMockSelectMenuInteraction = (
-    customId: string,
-    value: string
-  ): StringSelectMenuInteraction & {
-    deferUpdate: ReturnType<typeof vi.fn>;
-    editReply: ReturnType<typeof vi.fn>;
-    message: { id: string };
-    values: string[];
-  } => {
-    return {
-      customId,
-      user: { id: 'user-456' },
-      deferUpdate: vi.fn().mockResolvedValue(undefined),
-      editReply: vi.fn().mockResolvedValue(undefined),
-      message: { id: 'message-123' },
-      values: [value],
-    } as unknown as StringSelectMenuInteraction & {
-      deferUpdate: ReturnType<typeof vi.fn>;
-      editReply: ReturnType<typeof vi.fn>;
-      message: { id: string };
-      values: string[];
     };
   };
 
@@ -337,25 +292,6 @@ describe('Character Overrides Dashboard', () => {
   });
 
   describe('handleCharacterOverridesButton', () => {
-    it('should ignore non-character-overrides interactions', async () => {
-      const interaction = createMockButtonInteraction(
-        'character-settings::set::personality-123::enabled:true'
-      );
-
-      await handleCharacterOverridesButton(interaction);
-
-      expect(interaction.deferUpdate).not.toHaveBeenCalled();
-    });
-
-    it('should return early when entityId is missing from custom ID', async () => {
-      // A custom ID that passes isSettingsInteraction but parseSettingsCustomId returns no entityId
-      const interaction = createMockButtonInteraction('character-overrides::set');
-
-      await handleCharacterOverridesButton(interaction);
-
-      expect(mockCallGatewayApi).not.toHaveBeenCalled();
-    });
-
     it('should update setting via user-personality cascade endpoint', async () => {
       const interaction = {
         customId: 'character-overrides::set::personality-123::crossChannelHistoryEnabled:true',
@@ -406,30 +342,6 @@ describe('Character Overrides Dashboard', () => {
     });
   });
 
-  describe('handleCharacterOverridesSelectMenu', () => {
-    it('should ignore non-character-overrides interactions', async () => {
-      const interaction = createMockSelectMenuInteraction(
-        'character-settings::select::aurora',
-        'maxMessages'
-      );
-
-      await handleCharacterOverridesSelectMenu(interaction);
-
-      expect(interaction.deferUpdate).not.toHaveBeenCalled();
-    });
-
-    it('should return early when entityId is missing from custom ID', async () => {
-      const interaction = createMockSelectMenuInteraction(
-        'character-overrides::select',
-        'maxMessages'
-      );
-
-      await handleCharacterOverridesSelectMenu(interaction);
-
-      expect(mockCallGatewayApi).not.toHaveBeenCalled();
-    });
-  });
-
   describe('handleCharacterOverridesModal', () => {
     const createMockModalInteraction = (customId: string, inputValue: string) => ({
       customId,
@@ -455,25 +367,6 @@ describe('Character Overrides Dashboard', () => {
         view: 'setting',
         activeSetting: settingId,
       },
-    });
-
-    it('should ignore non-character-overrides modal interactions', async () => {
-      const interaction = createMockModalInteraction(
-        'character-settings::modal::personality-123::maxMessages',
-        '50'
-      );
-
-      await handleCharacterOverridesModal(interaction as never);
-
-      expect(interaction.reply).not.toHaveBeenCalled();
-    });
-
-    it('should return early when entityId is missing from custom ID', async () => {
-      const interaction = createMockModalInteraction('character-overrides::modal', '50');
-
-      await handleCharacterOverridesModal(interaction as never);
-
-      expect(mockCallGatewayApi).not.toHaveBeenCalled();
     });
 
     it('should update maxMessages setting via user-personality cascade endpoint', async () => {

--- a/services/bot-client/src/commands/character/settings.test.ts
+++ b/services/bot-client/src/commands/character/settings.test.ts
@@ -6,11 +6,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
+import type { ButtonInteraction } from 'discord.js';
 import {
   handleSettings,
   handleCharacterSettingsButton,
-  handleCharacterSettingsSelectMenu,
   handleCharacterSettingsModal,
   isCharacterSettingsInteraction,
 } from './settings.js';
@@ -126,50 +125,6 @@ describe('Character Settings Dashboard', () => {
           getString: ReturnType<typeof vi.fn>;
         };
       };
-    };
-  };
-
-  const createMockButtonInteraction = (
-    customId: string
-  ): ButtonInteraction & {
-    deferUpdate: ReturnType<typeof vi.fn>;
-    editReply: ReturnType<typeof vi.fn>;
-    message: { id: string };
-  } => {
-    return {
-      customId,
-      user: { id: 'user-456' },
-      deferUpdate: vi.fn().mockResolvedValue(undefined),
-      editReply: vi.fn().mockResolvedValue(undefined),
-      message: { id: 'message-123' },
-    } as unknown as ButtonInteraction & {
-      deferUpdate: ReturnType<typeof vi.fn>;
-      editReply: ReturnType<typeof vi.fn>;
-      message: { id: string };
-    };
-  };
-
-  const createMockSelectMenuInteraction = (
-    customId: string,
-    value: string
-  ): StringSelectMenuInteraction & {
-    deferUpdate: ReturnType<typeof vi.fn>;
-    editReply: ReturnType<typeof vi.fn>;
-    message: { id: string };
-    values: string[];
-  } => {
-    return {
-      customId,
-      user: { id: 'user-456' },
-      deferUpdate: vi.fn().mockResolvedValue(undefined),
-      editReply: vi.fn().mockResolvedValue(undefined),
-      message: { id: 'message-123' },
-      values: [value],
-    } as unknown as StringSelectMenuInteraction & {
-      deferUpdate: ReturnType<typeof vi.fn>;
-      editReply: ReturnType<typeof vi.fn>;
-      message: { id: string };
-      values: string[];
     };
   };
 
@@ -363,16 +318,6 @@ describe('Character Settings Dashboard', () => {
   });
 
   describe('handleCharacterSettingsButton', () => {
-    it('should ignore non-character-settings interactions', async () => {
-      const interaction = createMockButtonInteraction(
-        'channel-settings::set::chan-123::enabled:true'
-      );
-
-      await handleCharacterSettingsButton(interaction);
-
-      expect(interaction.deferUpdate).not.toHaveBeenCalled();
-    });
-
     it('should update crossChannelHistoryEnabled via set button', async () => {
       const interaction = {
         customId: 'character-settings::set::personality-123::crossChannelHistoryEnabled:true',
@@ -549,19 +494,6 @@ describe('Character Settings Dashboard', () => {
     });
   });
 
-  describe('handleCharacterSettingsSelectMenu', () => {
-    it('should ignore non-character-settings interactions', async () => {
-      const interaction = createMockSelectMenuInteraction(
-        'channel-settings::select::chan-123',
-        'enabled'
-      );
-
-      await handleCharacterSettingsSelectMenu(interaction);
-
-      expect(interaction.deferUpdate).not.toHaveBeenCalled();
-    });
-  });
-
   describe('handleCharacterSettingsModal', () => {
     const createMockModalInteraction = (customId: string, inputValue: string) => ({
       customId,
@@ -588,17 +520,6 @@ describe('Character Settings Dashboard', () => {
         view: 'setting',
         activeSetting: settingId,
       },
-    });
-
-    it('should ignore non-character-settings modal interactions', async () => {
-      const interaction = createMockModalInteraction(
-        'admin-settings::modal::global::enabled',
-        '50'
-      );
-
-      await handleCharacterSettingsModal(interaction as never);
-
-      expect(interaction.reply).not.toHaveBeenCalled();
     });
 
     it('should update maxMessages setting via cascade endpoint', async () => {

--- a/services/bot-client/src/commands/deny/browse.ts
+++ b/services/bot-client/src/commands/deny/browse.ts
@@ -7,12 +7,7 @@
  */
 
 import { EmbedBuilder, escapeMarkdown } from 'discord.js';
-import type {
-  ButtonInteraction,
-  StringSelectMenuInteraction,
-  ActionRowBuilder as ActionRowBuilderType,
-  ButtonBuilder,
-} from 'discord.js';
+import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
 import { createLogger, isBotOwner, DISCORD_COLORS, formatDateShort } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import { requireBotOwnerContext } from '../../utils/commandContext/index.js';
@@ -29,6 +24,7 @@ import {
   formatFilterParens,
   formatSortNatural,
   type BrowseSortType,
+  type BrowseActionRow,
 } from '../../utils/browse/index.js';
 
 const logger = createLogger('deny-browse');
@@ -125,7 +121,7 @@ function buildBrowsePage(
   page: number,
   filter: DenyBrowseFilter,
   sort: BrowseSortType
-): { embed: EmbedBuilder; components: ActionRowBuilderType<ButtonBuilder>[] } {
+): { embed: EmbedBuilder; components: BrowseActionRow[] } {
   const { safePage, totalPages, startIndex, endIndex } = calculatePaginationState(
     entries.length,
     ITEMS_PER_PAGE,
@@ -154,7 +150,7 @@ function buildBrowsePage(
     ),
   });
 
-  const components: ActionRowBuilderType<ButtonBuilder>[] = [];
+  const components: BrowseActionRow[] = [];
   if (entries.length > 0) {
     components.push(
       buildBrowseButtons({
@@ -189,12 +185,7 @@ function buildBrowsePage(
     }),
   });
   if (selectRow !== null) {
-    // Cast preserved from pre-migration code: deny's components array is
-    // typed as ActionRowBuilderType<ButtonBuilder>[] for editReply compat,
-    // and the select row needs to be widened to that type. Out of scope
-    // for this migration; revisit if deny adopts the BrowseActionRow
-    // union pattern that admin/servers and others use.
-    components.push(selectRow as unknown as ActionRowBuilderType<ButtonBuilder>);
+    components.push(selectRow);
   }
 
   return { embed, components };
@@ -224,7 +215,7 @@ export function buildBrowseResponse(
   page: number,
   filter: DenyBrowseFilter,
   sort: BrowseSortType
-): { embed: EmbedBuilder; components: ActionRowBuilderType<ButtonBuilder>[] } {
+): { embed: EmbedBuilder; components: BrowseActionRow[] } {
   const filtered = filterByType(entries, filter);
   const sorted = sortEntries(filtered, sort);
   return buildBrowsePage(sorted, page, filter, sort);

--- a/services/bot-client/src/commands/memory/browse.ts
+++ b/services/bot-client/src/commands/memory/browse.ts
@@ -15,13 +15,7 @@
  * because UUIDs can't fit in the filter enum slot.
  */
 
-import type {
-  ActionRowBuilder,
-  ButtonBuilder,
-  ButtonInteraction,
-  StringSelectMenuBuilder,
-  StringSelectMenuInteraction,
-} from 'discord.js';
+import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
 import { EmbedBuilder, escapeMarkdown, MessageFlags } from 'discord.js';
 import {
   createLogger,
@@ -40,6 +34,7 @@ import {
   pluralize,
   formatSortVerbatim,
   formatPageIndicator,
+  type BrowseActionRow,
 } from '../../utils/browse/index.js';
 import { resolveOptionalPersonality } from './resolveHelpers.js';
 import { buildMemoryActionId, handleMemorySelect } from './detail.js';
@@ -53,9 +48,6 @@ import {
   fetchPageWithEmptyFallback,
   MEMORY_BROWSE_ENTITY_TYPE,
 } from './browseSession.js';
-
-/** Union type for action rows containing buttons or select menus */
-type BrowseActionRow = ActionRowBuilder<ButtonBuilder> | ActionRowBuilder<StringSelectMenuBuilder>;
 
 const logger = createLogger('memory-browse');
 

--- a/services/bot-client/src/commands/persona/browse.ts
+++ b/services/bot-client/src/commands/persona/browse.ts
@@ -5,7 +5,7 @@
  * Shows a paginated list of user's personas with select menu to edit
  */
 
-import { ButtonBuilder, EmbedBuilder, ActionRowBuilder, StringSelectMenuBuilder } from 'discord.js';
+import { EmbedBuilder } from 'discord.js';
 import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
 import { createLogger, DISCORD_COLORS, type ListPersonasResponse } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
@@ -25,6 +25,7 @@ import {
   formatSortNatural,
   formatSortVerbatim,
   type BrowseSortType,
+  type BrowseActionRow,
 } from '../../utils/browse/index.js';
 import { createListComparator } from '../../utils/listSorting.js';
 
@@ -100,9 +101,6 @@ function buildBrowseButtons(
     buildInfoId: browseHelpers.buildInfo,
   });
 }
-
-/** Union type for action rows */
-type BrowseActionRow = ActionRowBuilder<ButtonBuilder> | ActionRowBuilder<StringSelectMenuBuilder>;
 
 /**
  * Build the browse embed and components

--- a/services/bot-client/src/commands/preset/browse.ts
+++ b/services/bot-client/src/commands/preset/browse.ts
@@ -8,13 +8,7 @@
  * - Pagination support for larger lists
  */
 
-import {
-  EmbedBuilder,
-  escapeMarkdown,
-  ActionRowBuilder,
-  ButtonBuilder,
-  StringSelectMenuBuilder,
-} from 'discord.js';
+import { EmbedBuilder, escapeMarkdown } from 'discord.js';
 import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
 import {
   createLogger,
@@ -39,6 +33,7 @@ import {
   joinFooter,
   pluralize,
   formatFilterLabeled,
+  type BrowseActionRow,
 } from '../../utils/browse/index.js';
 import {
   PRESET_DASHBOARD_CONFIG,
@@ -216,9 +211,6 @@ function buildBrowseButtons(
     showSortToggle: false, // Presets don't have sort toggle
   });
 }
-
-/** Union type for action rows that can contain buttons or select menus */
-type BrowseActionRow = ActionRowBuilder<ButtonBuilder> | ActionRowBuilder<StringSelectMenuBuilder>;
 
 /**
  * Build the browse embed and components

--- a/services/bot-client/src/utils/browse/index.ts
+++ b/services/bot-client/src/utils/browse/index.ts
@@ -28,7 +28,7 @@ export {
 export { truncateForSelect, truncateForDescription } from './truncation.js';
 
 // Types
-export { calculatePaginationState } from './types.js';
+export { calculatePaginationState, type BrowseActionRow } from './types.js';
 
 // CustomId factory
 export { createBrowseCustomIdHelpers } from './customIdFactory.js';

--- a/services/bot-client/src/utils/browse/types.ts
+++ b/services/bot-client/src/utils/browse/types.ts
@@ -5,7 +5,13 @@
  * and browse context for back navigation.
  */
 
+import type { ActionRowBuilder, ButtonBuilder, StringSelectMenuBuilder } from 'discord.js';
 import type { BrowseSortType } from './constants.js';
+
+/** Union type for action rows that can contain buttons or select menus */
+export type BrowseActionRow =
+  | ActionRowBuilder<ButtonBuilder>
+  | ActionRowBuilder<StringSelectMenuBuilder>;
 
 /**
  * Pagination state for browse lists


### PR DESCRIPTION
## Summary

- Extract shared `BrowseActionRow` type alias from 5 duplicate definitions into `browse/types.ts`, fixing the deny/browse `as unknown as` cast that existed because it didn't use the union type
- Remove 12 duplicate guard/parse test blocks from 3 settings test files now covered by the `createSettingsCommandHandlers` factory tests, along with dead mock helpers and unused imports

## Changes

- **New shared type**: `BrowseActionRow` in `services/bot-client/src/utils/browse/types.ts`
- **6 browse files**: Import from shared type instead of local definition
- **3 test files**: Removed duplicate `it()` blocks, empty `describe()` blocks, dead mock helpers, unused imports
- **Net**: +25 / -314 lines

## Test plan

- [ ] `pnpm typecheck` passes (all 11 packages)
- [ ] `pnpm --filter bot-client test` passes (261 files, 4198 tests)
- [ ] Verify deny browse still renders select menu correctly (no cast = correct typing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)