### PR TITLE
refactor(api-gateway): split routeHelpers from configOverrideHelpers + tighten configId

### DIFF
--- a/services/api-gateway/src/routes/admin/llm-config.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.ts
@@ -26,7 +26,7 @@ import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
 import { sendZodError } from '../../utils/zodHelpers.js';
-import { getParam } from '../../utils/requestParams.js';
+import { getRequiredParam } from '../../utils/requestParams.js';
 import type { AuthenticatedRequest } from '../../types.js';
 import { LlmConfigService } from '../../services/LlmConfigService.js';
 import type { OpenRouterModelCache } from '../../services/OpenRouterModelCache.js';
@@ -51,9 +51,9 @@ function createListHandler(service: LlmConfigService) {
 
 function createGetHandler(service: LlmConfigService, modelCache?: OpenRouterModelCache) {
   return async (req: Request, res: Response) => {
-    const configId = getParam(req.params.id);
+    const configId = getRequiredParam(req.params.id, 'id');
 
-    const config = await service.getById(configId ?? '');
+    const config = await service.getById(configId);
     if (config === null) {
       return sendError(res, ErrorResponses.notFound(CONFIG_RESOURCE));
     }
@@ -123,7 +123,7 @@ function createEditConfigHandler(
   modelCache?: OpenRouterModelCache
 ) {
   return async (req: Request, res: Response) => {
-    const configId = getParam(req.params.id);
+    const configId = getRequiredParam(req.params.id, 'id');
 
     // Validate request body with shared Zod schema from common-types
     const parseResult = LlmConfigUpdateSchema.safeParse(req.body);
@@ -137,7 +137,7 @@ function createEditConfigHandler(
         res,
         modelCache,
         body,
-        fallback: { service, configId: configId ?? '' },
+        fallback: { service, configId: configId },
       }))
     ) {
       return;
@@ -170,7 +170,7 @@ function createEditConfigHandler(
       return sendError(res, ErrorResponses.validationError('No fields to update'));
     }
 
-    const config = await service.update(configId ?? '', body);
+    const config = await service.update(configId, body);
     const formatted = service.formatConfigDetail(config);
     await enrichWithModelContext(formatted, config.model, modelCache);
 
@@ -184,7 +184,7 @@ function createEditConfigHandler(
 
 function createSetDefaultHandler(service: LlmConfigService, prisma: PrismaClient) {
   return async (req: Request, res: Response) => {
-    const configId = getParam(req.params.id);
+    const configId = getRequiredParam(req.params.id, 'id');
 
     const config = await prisma.llmConfig.findUnique({
       where: { id: configId },
@@ -201,7 +201,7 @@ function createSetDefaultHandler(service: LlmConfigService, prisma: PrismaClient
       );
     }
 
-    await service.setAsDefault(configId ?? '');
+    await service.setAsDefault(configId);
 
     logger.info({ configId, name: config.name }, '[AdminLlmConfig] Set as system default');
     sendCustomSuccess(res, { success: true, configName: config.name }, StatusCodes.OK);
@@ -210,7 +210,7 @@ function createSetDefaultHandler(service: LlmConfigService, prisma: PrismaClient
 
 function createSetFreeDefaultHandler(service: LlmConfigService, prisma: PrismaClient) {
   return async (req: Request, res: Response) => {
-    const configId = getParam(req.params.id);
+    const configId = getRequiredParam(req.params.id, 'id');
 
     const config = await prisma.llmConfig.findUnique({
       where: { id: configId },
@@ -235,7 +235,7 @@ function createSetFreeDefaultHandler(service: LlmConfigService, prisma: PrismaCl
       );
     }
 
-    await service.setAsFreeDefault(configId ?? '');
+    await service.setAsFreeDefault(configId);
 
     logger.info({ configId, name: config.name }, '[AdminLlmConfig] Set as free tier default');
     sendCustomSuccess(res, { success: true, configName: config.name }, StatusCodes.OK);
@@ -244,7 +244,7 @@ function createSetFreeDefaultHandler(service: LlmConfigService, prisma: PrismaCl
 
 function createDeleteConfigHandler(service: LlmConfigService, prisma: PrismaClient) {
   return async (req: Request, res: Response) => {
-    const configId = getParam(req.params.id);
+    const configId = getRequiredParam(req.params.id, 'id');
 
     const config = await prisma.llmConfig.findUnique({
       where: { id: configId },
@@ -265,12 +265,12 @@ function createDeleteConfigHandler(service: LlmConfigService, prisma: PrismaClie
     }
 
     // Check delete constraints
-    const constraintError = await service.checkDeleteConstraints(configId ?? '');
+    const constraintError = await service.checkDeleteConstraints(configId);
     if (constraintError !== null) {
       return sendError(res, ErrorResponses.validationError(constraintError));
     }
 
-    await service.delete(configId ?? '');
+    await service.delete(configId);
 
     logger.info({ configId, name: config.name }, '[AdminLlmConfig] Deleted global config');
     sendCustomSuccess(res, { deleted: true }, StatusCodes.OK);

--- a/services/api-gateway/src/routes/user/config-overrides.ts
+++ b/services/api-gateway/src/routes/user/config-overrides.ts
@@ -34,8 +34,8 @@ import { asyncHandler } from '../../utils/asyncHandler.js';
 import {
   tryInvalidateCache,
   mergeAndValidateOverrides,
-  resolveUserIdOrSendError,
 } from '../../utils/configOverrideHelpers.js';
+import { resolveUserIdOrSendError } from '../../utils/routeHelpers.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
 import { getRequiredParam } from '../../utils/requestParams.js';

--- a/services/api-gateway/src/routes/user/llm-config.ts
+++ b/services/api-gateway/src/routes/user/llm-config.ts
@@ -29,9 +29,9 @@ import { requireUserAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
-import { resolveUserIdOrSendError } from '../../utils/configOverrideHelpers.js';
+import { resolveUserIdOrSendError } from '../../utils/routeHelpers.js';
 import { sendZodError } from '../../utils/zodHelpers.js';
-import { getParam } from '../../utils/requestParams.js';
+import { getRequiredParam } from '../../utils/requestParams.js';
 import type { AuthenticatedRequest } from '../../types.js';
 import { LlmConfigService, type LlmConfigScope } from '../../services/LlmConfigService.js';
 import type { OpenRouterModelCache } from '../../services/OpenRouterModelCache.js';
@@ -92,10 +92,10 @@ function createGetHandler(
 ) {
   return async (req: AuthenticatedRequest, res: Response) => {
     const discordUserId = req.userId;
-    const configId = getParam(req.params.id);
+    const configId = getRequiredParam(req.params.id, 'id');
 
     // Use service to get config
-    const config = await service.getById(configId ?? '');
+    const config = await service.getById(configId);
     if (config === null) {
       return sendError(res, ErrorResponses.notFound(CONFIG_RESOURCE));
     }
@@ -200,7 +200,7 @@ function createUpdateHandler(
 ) {
   return async (req: AuthenticatedRequest, res: Response) => {
     const discordUserId = req.userId;
-    const configId = getParam(req.params.id);
+    const configId = getRequiredParam(req.params.id, 'id');
 
     // Validate request body with shared Zod schema from common-types
     const parseResult = LlmConfigUpdateSchema.safeParse(req.body);
@@ -214,7 +214,7 @@ function createUpdateHandler(
         res,
         modelCache,
         body,
-        fallback: { service, configId: configId ?? '' },
+        fallback: { service, configId: configId },
       }))
     ) {
       return;
@@ -230,7 +230,7 @@ function createUpdateHandler(
     }
 
     // Get existing config using service
-    const config = await service.getById(configId ?? '');
+    const config = await service.getById(configId);
     if (config === null) {
       return sendError(res, ErrorResponses.notFound(CONFIG_RESOURCE));
     }
@@ -245,7 +245,7 @@ function createUpdateHandler(
       const nameCheck = await service.checkNameExists(
         body.name,
         { type: 'USER', userId: user.id, discordId: discordUserId },
-        configId ?? ''
+        configId
       );
       if (nameCheck.exists) {
         return sendError(
@@ -260,7 +260,7 @@ function createUpdateHandler(
     }
 
     // Update using service (handles cache invalidation)
-    const updated = await service.update(configId ?? '', body);
+    const updated = await service.update(configId, body);
 
     // User always owns their own updated config (we already checked ownership above)
     const permissions = computeLlmConfigPermissions(
@@ -289,7 +289,7 @@ function createUpdateHandler(
 function createDeleteHandler(service: LlmConfigService, prisma: PrismaClient) {
   return async (req: AuthenticatedRequest, res: Response) => {
     const discordUserId = req.userId;
-    const configId = getParam(req.params.id);
+    const configId = getRequiredParam(req.params.id, 'id');
 
     const user = await prisma.user.findFirst({
       where: { discordId: discordUserId },
@@ -301,7 +301,7 @@ function createDeleteHandler(service: LlmConfigService, prisma: PrismaClient) {
     }
 
     // Get config using service
-    const config = await service.getById(configId ?? '');
+    const config = await service.getById(configId);
     if (config === null) {
       return sendError(res, ErrorResponses.notFound(CONFIG_RESOURCE));
     }
@@ -317,13 +317,13 @@ function createDeleteHandler(service: LlmConfigService, prisma: PrismaClient) {
     }
 
     // Check delete constraints using service
-    const constraintError = await service.checkDeleteConstraints(configId ?? '');
+    const constraintError = await service.checkDeleteConstraints(configId);
     if (constraintError !== null) {
       return sendError(res, ErrorResponses.validationError(constraintError));
     }
 
     // Delete using service (handles cache invalidation)
-    await service.delete(configId ?? '');
+    await service.delete(configId);
 
     logger.info({ discordUserId, configId, name: config.name }, '[LlmConfig] Deleted config');
     sendCustomSuccess(res, { deleted: true }, StatusCodes.OK);

--- a/services/api-gateway/src/routes/user/model-override.ts
+++ b/services/api-gateway/src/routes/user/model-override.ts
@@ -26,7 +26,8 @@ import {
 } from '@tzurot/common-types';
 import { requireUserAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
-import { tryInvalidateCache, resolveUserIdOrSendError } from '../../utils/configOverrideHelpers.js';
+import { tryInvalidateCache } from '../../utils/configOverrideHelpers.js';
+import { resolveUserIdOrSendError } from '../../utils/routeHelpers.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
 import { sendZodError } from '../../utils/zodHelpers.js';

--- a/services/api-gateway/src/routes/user/nsfw.ts
+++ b/services/api-gateway/src/routes/user/nsfw.ts
@@ -72,7 +72,7 @@ export function createNsfwRoutes(prisma: PrismaClient): Router {
       // Ensure user exists via centralized UserService (creates shell user if needed).
       //
       // NOTE: Deliberately not migrated to `resolveUserIdOrSendError` from
-      // `configOverrideHelpers.ts` (PR #779). That helper sends a 400 validation-error
+      // `routeHelpers.ts` (PR #779). That helper sends a 400 validation-error
       // response on the bot-null case, which is wrong here: NSFW verification status
       // is advisory, and the correct bot-user response is a 200 with
       // `{ nsfwVerified: false }` — not an error. This route uses `sendCustomSuccess`

--- a/services/api-gateway/src/routes/user/personality-config-overrides.ts
+++ b/services/api-gateway/src/routes/user/personality-config-overrides.ts
@@ -21,8 +21,8 @@ import { asyncHandler } from '../../utils/asyncHandler.js';
 import {
   tryInvalidateCache,
   mergeAndValidateOverrides,
-  resolveUserIdOrSendError,
 } from '../../utils/configOverrideHelpers.js';
+import { resolveUserIdOrSendError } from '../../utils/routeHelpers.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
 import { getRequiredParam } from '../../utils/requestParams.js';

--- a/services/api-gateway/src/routes/user/shapes/auth.ts
+++ b/services/api-gateway/src/routes/user/shapes/auth.ts
@@ -25,7 +25,7 @@ import { requireUserAuth } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
-import { resolveUserIdOrSendError } from '../../../utils/configOverrideHelpers.js';
+import { resolveUserIdOrSendError } from '../../../utils/routeHelpers.js';
 import type { AuthenticatedRequest } from '../../../types.js';
 
 const logger = createLogger('shapes-auth');

--- a/services/api-gateway/src/routes/user/shapes/export.ts
+++ b/services/api-gateway/src/routes/user/shapes/export.ts
@@ -29,7 +29,7 @@ import { requireUserAuth } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
-import { resolveUserIdOrSendError } from '../../../utils/configOverrideHelpers.js';
+import { resolveUserIdOrSendError } from '../../../utils/routeHelpers.js';
 import { isPrismaUniqueConstraintError } from '../../../utils/prismaErrors.js';
 import type { AuthenticatedRequest } from '../../../types.js';
 

--- a/services/api-gateway/src/routes/user/shapes/import.ts
+++ b/services/api-gateway/src/routes/user/shapes/import.ts
@@ -22,7 +22,7 @@ import { requireUserAuth } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
-import { resolveUserIdOrSendError } from '../../../utils/configOverrideHelpers.js';
+import { resolveUserIdOrSendError } from '../../../utils/routeHelpers.js';
 import { isPrismaUniqueConstraintError } from '../../../utils/prismaErrors.js';
 import type { AuthenticatedRequest } from '../../../types.js';
 

--- a/services/api-gateway/src/routes/user/timezone.ts
+++ b/services/api-gateway/src/routes/user/timezone.ts
@@ -18,7 +18,7 @@ import { requireUserAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
-import { resolveUserIdOrSendError } from '../../utils/configOverrideHelpers.js';
+import { resolveUserIdOrSendError } from '../../utils/routeHelpers.js';
 import { sendZodError } from '../../utils/zodHelpers.js';
 import type { AuthenticatedRequest } from '../../types.js';
 

--- a/services/api-gateway/src/routes/wallet/setKey.ts
+++ b/services/api-gateway/src/routes/wallet/setKey.ts
@@ -24,7 +24,7 @@ import { requireUserAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses, type ErrorResponse } from '../../utils/errorResponses.js';
-import { resolveUserIdOrSendError } from '../../utils/configOverrideHelpers.js';
+import { resolveUserIdOrSendError } from '../../utils/routeHelpers.js';
 import { sendZodError } from '../../utils/zodHelpers.js';
 import { validateApiKey, type ApiKeyValidationResult } from '../../utils/apiKeyValidation.js';
 import type { AuthenticatedRequest } from '../../types.js';

--- a/services/api-gateway/src/utils/asyncHandler.test.ts
+++ b/services/api-gateway/src/utils/asyncHandler.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Request, Response } from 'express';
+
+vi.mock('@tzurot/common-types', async () => {
+  const actual = await vi.importActual('@tzurot/common-types');
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { asyncHandler } from './asyncHandler.js';
+import { ParameterError } from './requestParams.js';
+
+function createMockRes(): Response & {
+  status: ReturnType<typeof vi.fn>;
+  json: ReturnType<typeof vi.fn>;
+  headersSent: boolean;
+} {
+  const res = {
+    headersSent: false,
+    status: vi.fn(),
+    json: vi.fn(),
+  };
+  res.status.mockReturnValue(res);
+  return res as unknown as Response & {
+    status: ReturnType<typeof vi.fn>;
+    json: ReturnType<typeof vi.fn>;
+    headersSent: boolean;
+  };
+}
+
+describe('asyncHandler', () => {
+  const mockReq = {} as Request;
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it('should call the handler and not send error on success', async () => {
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const res = createMockRes();
+
+    const wrapped = asyncHandler(handler);
+    wrapped(mockReq, res);
+    await vi.waitFor(() => expect(handler).toHaveBeenCalled());
+
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('should send 400 for ParameterError', async () => {
+    const handler = vi.fn().mockRejectedValue(new ParameterError('id'));
+    const res = createMockRes();
+
+    const wrapped = asyncHandler(handler);
+    wrapped(mockReq, res);
+    await vi.waitFor(() => expect(res.status).toHaveBeenCalled());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'VALIDATION_ERROR' }));
+  });
+
+  it('should send 500 for generic errors', async () => {
+    const handler = vi.fn().mockRejectedValue(new Error('Something broke'));
+    const res = createMockRes();
+
+    const wrapped = asyncHandler(handler);
+    wrapped(mockReq, res);
+    await vi.waitFor(() => expect(res.status).toHaveBeenCalled());
+
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+
+  it('should not send error if headers already sent', async () => {
+    const handler = vi.fn().mockRejectedValue(new Error('Late error'));
+    const res = createMockRes();
+    res.headersSent = true;
+
+    const wrapped = asyncHandler(handler);
+    wrapped(mockReq, res);
+    await vi.waitFor(() => expect(handler).toHaveBeenCalled());
+
+    // Give the async handler time to process the error
+    await new Promise(resolve => setTimeout(resolve, 10));
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});

--- a/services/api-gateway/src/utils/asyncHandler.ts
+++ b/services/api-gateway/src/utils/asyncHandler.ts
@@ -7,6 +7,7 @@ import type { Request, Response } from 'express';
 import { createLogger } from '@tzurot/common-types';
 import { ErrorResponses } from './errorResponses.js';
 import { sendError } from './responseHelpers.js';
+import { ParameterError } from './requestParams.js';
 
 const logger = createLogger('asyncHandler');
 
@@ -55,13 +56,19 @@ export function asyncHandler<R extends Request = Request>(
       try {
         await handler(req as R, res);
       } catch (error) {
-        logger.error({ err: error }, 'Request handler error');
-
         // If response already sent, don't try to send error
         if (res.headersSent) {
-          logger.warn({}, 'Response already sent, cannot send error response');
+          logger.warn({ err: error }, 'Response already sent, cannot send error response');
           return;
         }
+
+        // Missing/invalid route parameters are client errors, not server errors
+        if (error instanceof ParameterError) {
+          sendError(res, ErrorResponses.validationError(error.message));
+          return;
+        }
+
+        logger.error({ err: error }, 'Request handler error');
 
         const errorResponse = ErrorResponses.internalError(
           error instanceof Error ? error.message : 'Internal server error'

--- a/services/api-gateway/src/utils/asyncHandler.ts
+++ b/services/api-gateway/src/utils/asyncHandler.ts
@@ -62,8 +62,10 @@ export function asyncHandler<R extends Request = Request>(
           return;
         }
 
-        // Missing/invalid route parameters are client errors, not server errors
+        // Missing/invalid route parameters are client errors, not server errors.
+        // Logged at warn since it could indicate a routing misconfiguration.
         if (error instanceof ParameterError) {
+          logger.warn({ err: error }, 'Missing required route parameter');
           sendError(res, ErrorResponses.validationError(error.message));
           return;
         }

--- a/services/api-gateway/src/utils/configOverrideHelpers.test.ts
+++ b/services/api-gateway/src/utils/configOverrideHelpers.test.ts
@@ -18,12 +18,7 @@ vi.mock('@tzurot/common-types', async () => {
   };
 });
 
-import {
-  tryInvalidateCache,
-  mergeAndValidateOverrides,
-  resolveUserIdOrSendError,
-} from './configOverrideHelpers.js';
-import type { UserService } from '@tzurot/common-types';
+import { tryInvalidateCache, mergeAndValidateOverrides } from './configOverrideHelpers.js';
 
 // Mock the merge function to control its return values
 const mockMerge = vi.fn();
@@ -114,53 +109,5 @@ describe('mergeAndValidateOverrides', () => {
     const result = mergeAndValidateOverrides({}, { bad: 'data' }, mockRes);
     expect(result.merged).toBeUndefined();
     expect(mockSendError).toHaveBeenCalledOnce();
-  });
-});
-
-describe('resolveUserIdOrSendError', () => {
-  const mockRes = {} as never;
-  const mockGetOrCreateUser = vi.fn();
-  const mockUserService = { getOrCreateUser: mockGetOrCreateUser } as unknown as UserService;
-
-  beforeEach(() => vi.resetAllMocks());
-
-  it('returns the internal user UUID on success', async () => {
-    mockGetOrCreateUser.mockResolvedValue('internal-uuid-abc');
-
-    const result = await resolveUserIdOrSendError(mockUserService, 'discord-123', mockRes);
-
-    expect(result).toBe('internal-uuid-abc');
-    expect(mockGetOrCreateUser).toHaveBeenCalledWith('discord-123', 'discord-123');
-    expect(mockSendError).not.toHaveBeenCalled();
-  });
-
-  it('returns null and sends validation error when user is a bot', async () => {
-    mockGetOrCreateUser.mockResolvedValue(null);
-
-    const result = await resolveUserIdOrSendError(mockUserService, 'bot-456', mockRes);
-
-    expect(result).toBeNull();
-    expect(mockSendError).toHaveBeenCalledOnce();
-  });
-
-  it('sends the unified error message "Cannot create user for bot"', async () => {
-    mockGetOrCreateUser.mockResolvedValue(null);
-
-    await resolveUserIdOrSendError(mockUserService, 'bot-456', mockRes);
-
-    expect(mockSendError).toHaveBeenCalledWith(
-      mockRes,
-      expect.objectContaining({ message: 'Cannot create user for bot' })
-    );
-  });
-
-  it('passes the same discord ID as both discordId and username args', async () => {
-    // Current call-site convention: username doubles as discordId since real username
-    // isn't available at the route layer. Preserved by the helper.
-    mockGetOrCreateUser.mockResolvedValue('uuid');
-
-    await resolveUserIdOrSendError(mockUserService, 'discord-xyz', mockRes);
-
-    expect(mockGetOrCreateUser).toHaveBeenCalledWith('discord-xyz', 'discord-xyz');
   });
 });

--- a/services/api-gateway/src/utils/configOverrideHelpers.ts
+++ b/services/api-gateway/src/utils/configOverrideHelpers.ts
@@ -7,57 +7,12 @@
  */
 
 import type { Response } from 'express';
-import { Prisma, createLogger, type UserService } from '@tzurot/common-types';
+import { Prisma, createLogger } from '@tzurot/common-types';
 import { mergeConfigOverrides } from './configOverrideMerge.js';
 import { sendError } from './responseHelpers.js';
 import { ErrorResponses } from './errorResponses.js';
 
 const logger = createLogger('configOverrideHelpers');
-
-// ============================================================================
-// User Resolution
-// ============================================================================
-
-/**
- * Resolve the internal user UUID for an incoming Discord user ID, sending a
- * validation error response and returning `null` if the lookup fails because
- * the Discord user is a bot.
- *
- * Collapses the repeated pattern:
- *
- * ```ts
- * const userId = await userService.getOrCreateUser(req.userId, req.userId);
- * if (userId === null) {
- *   return sendError(res, ErrorResponses.validationError('Cannot create user for bot'));
- * }
- * ```
- *
- * into:
- *
- * ```ts
- * const userId = await resolveUserIdOrSendError(userService, req.userId, res);
- * if (userId === null) return;
- * ```
- *
- * 15 call sites across 9 route files currently duplicate this pattern with
- * two minor error-text variants (`'Cannot create user for bot'` and
- * `'Cannot create user'`). This helper standardizes on the more specific
- * former message.
- *
- * @returns internal user UUID on success, or `null` if error was sent
- */
-export async function resolveUserIdOrSendError(
-  userService: UserService,
-  discordUserId: string,
-  res: Response
-): Promise<string | null> {
-  const userId = await userService.getOrCreateUser(discordUserId, discordUserId);
-  if (userId === null) {
-    sendError(res, ErrorResponses.validationError('Cannot create user for bot'));
-    return null;
-  }
-  return userId;
-}
 
 // ============================================================================
 // Cache Invalidation

--- a/services/api-gateway/src/utils/routeHelpers.test.ts
+++ b/services/api-gateway/src/utils/routeHelpers.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSendError = vi.fn();
+vi.mock('./responseHelpers.js', () => ({
+  sendError: (...args: unknown[]) => mockSendError(...args),
+}));
+
+vi.mock('./errorResponses.js', () => ({
+  ErrorResponses: {
+    validationError: (msg: string) => ({ error: 'VALIDATION', message: msg }),
+  },
+}));
+
+import { resolveUserIdOrSendError } from './routeHelpers.js';
+import type { UserService } from '@tzurot/common-types';
+
+describe('resolveUserIdOrSendError', () => {
+  const mockRes = {} as never;
+  const mockGetOrCreateUser = vi.fn();
+  const mockUserService = { getOrCreateUser: mockGetOrCreateUser } as unknown as UserService;
+
+  beforeEach(() => vi.resetAllMocks());
+
+  it('returns the internal user UUID on success', async () => {
+    mockGetOrCreateUser.mockResolvedValue('internal-uuid-abc');
+
+    const result = await resolveUserIdOrSendError(mockUserService, 'discord-123', mockRes);
+
+    expect(result).toBe('internal-uuid-abc');
+    expect(mockGetOrCreateUser).toHaveBeenCalledWith('discord-123', 'discord-123');
+    expect(mockSendError).not.toHaveBeenCalled();
+  });
+
+  it('returns null and sends validation error when user is a bot', async () => {
+    mockGetOrCreateUser.mockResolvedValue(null);
+
+    const result = await resolveUserIdOrSendError(mockUserService, 'bot-456', mockRes);
+
+    expect(result).toBeNull();
+    expect(mockSendError).toHaveBeenCalledOnce();
+  });
+
+  it('sends the unified error message "Cannot create user for bot"', async () => {
+    mockGetOrCreateUser.mockResolvedValue(null);
+
+    await resolveUserIdOrSendError(mockUserService, 'bot-456', mockRes);
+
+    expect(mockSendError).toHaveBeenCalledWith(
+      mockRes,
+      expect.objectContaining({ message: 'Cannot create user for bot' })
+    );
+  });
+
+  it('passes the same discord ID as both discordId and username args', async () => {
+    // Current call-site convention: username doubles as discordId since real username
+    // isn't available at the route layer. Preserved by the helper.
+    mockGetOrCreateUser.mockResolvedValue('uuid');
+
+    await resolveUserIdOrSendError(mockUserService, 'discord-xyz', mockRes);
+
+    expect(mockGetOrCreateUser).toHaveBeenCalledWith('discord-xyz', 'discord-xyz');
+  });
+});

--- a/services/api-gateway/src/utils/routeHelpers.ts
+++ b/services/api-gateway/src/utils/routeHelpers.ts
@@ -1,0 +1,47 @@
+/**
+ * Route Helpers
+ *
+ * Generic utilities shared across route handlers. For config-cascade-specific
+ * helpers (merge, invalidation), see configOverrideHelpers.ts.
+ */
+
+import type { Response } from 'express';
+import type { UserService } from '@tzurot/common-types';
+import { sendError } from './responseHelpers.js';
+import { ErrorResponses } from './errorResponses.js';
+
+/**
+ * Resolve the internal user UUID for an incoming Discord user ID, sending a
+ * validation error response and returning `null` if the lookup fails because
+ * the Discord user is a bot.
+ *
+ * Collapses the repeated pattern:
+ *
+ * ```ts
+ * const userId = await userService.getOrCreateUser(req.userId, req.userId);
+ * if (userId === null) {
+ *   return sendError(res, ErrorResponses.validationError('Cannot create user for bot'));
+ * }
+ * ```
+ *
+ * into:
+ *
+ * ```ts
+ * const userId = await resolveUserIdOrSendError(userService, req.userId, res);
+ * if (userId === null) return;
+ * ```
+ *
+ * @returns internal user UUID on success, or `null` if error was sent
+ */
+export async function resolveUserIdOrSendError(
+  userService: UserService,
+  discordUserId: string,
+  res: Response
+): Promise<string | null> {
+  const userId = await userService.getOrCreateUser(discordUserId, discordUserId);
+  if (userId === null) {
+    sendError(res, ErrorResponses.validationError('Cannot create user for bot'));
+    return null;
+  }
+  return userId;
+}

--- a/services/api-gateway/src/utils/routeHelpers.ts
+++ b/services/api-gateway/src/utils/routeHelpers.ts
@@ -31,6 +31,10 @@ import { ErrorResponses } from './errorResponses.js';
  * if (userId === null) return;
  * ```
  *
+ * Extracted because 15 call sites across 9 route files duplicated this
+ * pattern with two minor error-text variants. This helper standardizes
+ * on the more specific `'Cannot create user for bot'` message.
+ *
  * @returns internal user UUID on success, or `null` if error was sent
  */
 export async function resolveUserIdOrSendError(


### PR DESCRIPTION
## Summary

- Split `resolveUserIdOrSendError` into new `routeHelpers.ts` — it's a generic route utility used by 9 files, not config-cascade-specific
- Replace `getParam` with `getRequiredParam` for `configId` in both admin and user LLM config routes, eliminating all `?? ''` fallbacks that could silently mask bugs

## Changes

- **New file**: `services/api-gateway/src/utils/routeHelpers.ts` + colocated test
- **configOverrideHelpers.ts**: Removed `resolveUserIdOrSendError` and `UserService` import
- **9 route files**: Updated imports to point to `routeHelpers.ts`
- **2 LLM config routes**: `getParam` → `getRequiredParam`, removed 13 `?? ''` fallbacks
- **1 comment**: Updated `nsfw.ts` reference from old file name

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm --filter api-gateway test` passes (109 files, 1722 tests)
- [ ] Verify LLM config CRUD still works (create, edit, delete, set-default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)