### PR TITLE
fix(ai-worker): vision classifier + retry cap + telemetry

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -669,6 +669,38 @@ Add supertest-style integration tests that boot the actual Express app with real
 
 Migrate stub commands to proper TypeScript implementations.
 
+### Theme: Observability & Analytics
+
+_Codebase-wide decisions on retry counts, timeouts, cache TTLs, rate limits, and feature adoption currently rely on guesswork because we don't systematically capture the data needed to answer them. Vision-pipeline telemetry landed 2026-04-14 as the first concrete step; treat the rest as epic-sized work._
+
+#### ✨ Observability & Telemetry Strategy
+
+**Problem**: System-health decisions (retry counts, timeouts, cache TTLs, queue concurrency) are made without quantitative data. Same pattern exists throughout ai-worker, api-gateway, bot-client — vision-pipeline fix on 2026-04-14 was just the first concrete instance.
+
+**Scope**:
+
+- Audit current logging across all services, identify gap events (hot-path successes with `durationMs`, cache hit/miss rates, job durations, queue depths, retry success rates per category)
+- Establish `{ durationMs, attempt, errorCategory, ...dimensionX }` structured-log conventions across the codebase (vision-pipeline retry logs are the prototype)
+- Document Railway query cookbook (builds on `pnpm ops logs --filter` DSL passthrough)
+- Define "decision-triggering metrics" — events that, when queried, answer a specific tuning question
+
+**Non-goal**: standing up Prometheus/Datadog/OTel. Pino + structured logs + Railway server-side query DSL is likely sufficient at one-person-project scale.
+
+#### ✨ User Analytics Strategy
+
+**Problem**: No systematic view of product usage. Questions unanswerable today: which personalities have active users? Are users adopting `/browse` or falling back to `/list`? Does voice-engine adoption correlate with specific personalities? What's retention look like by user cohort?
+
+**Scope**:
+
+- Event taxonomy: command invocations, personality switches, voice/vision/memory usage, user-facing errors (as product signals, not debug signals)
+- Privacy constraints: opaque user IDs only — never usernames, message content, or PII
+- **Build-vs-buy decision** (first real decision point for this epic):
+  - Off-the-shelf leading candidate: **PostHog self-hosted on Railway** (open-source, product-analytics-native, supports server-side event ingestion, self-hostable to avoid third-party data)
+  - Lighter alternatives: Plausible (too web-page-centric for a Discord bot), custom Postgres event table + query UI (most control, heaviest ops burden)
+- Integration surface: event emission as middleware/hooks in command handlers and job processors, decoupled from business logic
+
+**Non-goal**: anything requiring message-content inspection (privacy non-starter).
+
 ---
 
 ## 🧊 Icebox
@@ -772,6 +804,22 @@ Full audit of all slash command UI patterns. Review shared utilities usage, iden
 #### 🧹 Free-Tier Model Strategy
 
 Define free-tier model allowlist, usage quotas, upgrade prompts.
+
+#### 🐛 Revisit Vision `maxAttempts` After Telemetry Data
+
+**Problem**: Vision retry cap set to `maxAttempts: 2` (1 initial + 1 retry) on 2026-04-14 without empirical retry-success-rate data for AbortError-originated TIMEOUT errors. Council argued for 1 attempt (0 retries) on the assumption that 90s-budget AbortErrors are near-100% deterministic per URL. Kept 2 attempts until measurement proves otherwise.
+
+**Action**: After 1–2 weeks of prod telemetry from the vision-pipeline diagnostic bundle, grep ai-worker logs for `attempt=2` successes on operations where `attempt=1` failed with `errorCategory=timeout`. If retry success rate on TIMEOUT is <5%, cut `VISION_MAX_ATTEMPTS` in `services/ai-worker/src/jobs/ImageDescriptionJob.ts` to 1. If >20%, keep at 2. Between, reconsider with fresh eyes.
+
+**Why out of scope now**: Cannot decide empirically without the telemetry the diagnostic bundle installs.
+
+#### 🐛 Revisit `TIMEOUTS.VISION_MODEL` After Telemetry Data
+
+**Problem**: 90s vision-model timeout may be mis-calibrated. 63% hit rate in 2026-04-14 prod-log analysis suggests systemic (provider/CDN stall) rather than "almost-long-enough." If p95 successful response times are 25–35s, 90s is 2–3x overkill.
+
+**Action**: After 1–2 weeks of prod telemetry, analyze `durationMs` distribution from `[Retry] Image description succeeded on attempt` log entries. Tune `TIMEOUTS.VISION_MODEL` in `packages/common-types/src/constants/timing.ts` to p99 + small headroom.
+
+**Why out of scope now**: Cannot tune without the telemetry the diagnostic bundle installs.
 
 ---
 

--- a/packages/common-types/src/constants/error.test.ts
+++ b/packages/common-types/src/constants/error.test.ts
@@ -124,6 +124,7 @@ describe('isPermanentError', () => {
     expect(isPermanentError(ApiErrorCategory.QUOTA_EXCEEDED)).toBe(true);
     expect(isPermanentError(ApiErrorCategory.CONTENT_POLICY)).toBe(true);
     expect(isPermanentError(ApiErrorCategory.MODEL_NOT_FOUND)).toBe(true);
+    expect(isPermanentError(ApiErrorCategory.MEDIA_NOT_FOUND)).toBe(true);
   });
 
   it('should return false for transient categories', () => {
@@ -159,6 +160,7 @@ describe('isTransientError', () => {
     expect(isTransientError(ApiErrorCategory.QUOTA_EXCEEDED)).toBe(false);
     expect(isTransientError(ApiErrorCategory.CONTENT_POLICY)).toBe(false);
     expect(isTransientError(ApiErrorCategory.MODEL_NOT_FOUND)).toBe(false);
+    expect(isTransientError(ApiErrorCategory.MEDIA_NOT_FOUND)).toBe(false);
   });
 
   it('should return false for unknown category', () => {

--- a/packages/common-types/src/constants/error.ts
+++ b/packages/common-types/src/constants/error.ts
@@ -53,7 +53,9 @@ export function isTransientNetworkError(error: unknown): boolean {
 }
 
 function checkTransientNetwork(error: unknown, depth: number): boolean {
-  if (depth > 5) {return false;}
+  if (depth > 5) {
+    return false;
+  }
 
   if (!(error instanceof Error)) {
     // Handle plain objects with a `code` property in the cause chain
@@ -131,6 +133,8 @@ export enum ApiErrorCategory {
   BAD_REQUEST = 'bad_request',
   /** 404 - Model not found */
   MODEL_NOT_FOUND = 'model_not_found',
+  /** Media URL unavailable (e.g., Discord CDN link expired, upstream 404 fetching image). Permanent per-URL. */
+  MEDIA_NOT_FOUND = 'media_not_found',
   /** 429 - Rate limit (may be temporary or daily) */
   RATE_LIMIT = 'rate_limit',
   /** 500/502/503/504 - Server errors */
@@ -162,6 +166,8 @@ export const USER_ERROR_MESSAGES: Record<ApiErrorCategory, string> = {
     'The conversation has become too long. Please start a new conversation or try a shorter message.',
   [ApiErrorCategory.MODEL_NOT_FOUND]:
     'The requested AI model is not available. Please try again or use a different personality.',
+  [ApiErrorCategory.MEDIA_NOT_FOUND]:
+    'The media attachment could not be fetched — the link may have expired.',
   [ApiErrorCategory.RATE_LIMIT]:
     "I'm receiving too many requests right now. Please wait a moment and try again.",
   [ApiErrorCategory.SERVER_ERROR]:
@@ -204,6 +210,7 @@ export const PERMANENT_ERROR_CATEGORIES: ReadonlySet<ApiErrorCategory> = new Set
   ApiErrorCategory.QUOTA_EXCEEDED,
   ApiErrorCategory.CONTENT_POLICY,
   ApiErrorCategory.MODEL_NOT_FOUND,
+  ApiErrorCategory.MEDIA_NOT_FOUND,
 ]);
 
 /**

--- a/packages/tooling/src/deployment/logs.test.ts
+++ b/packages/tooling/src/deployment/logs.test.ts
@@ -114,31 +114,44 @@ describe('fetchLogs', () => {
     });
   });
 
-  describe('log filtering', () => {
-    it('should filter logs by keyword', async () => {
-      vi.mocked(execFileSync).mockReturnValue(
-        '2024-01-24 10:00:00 Request received\n' +
-          '2024-01-24 10:00:01 Database connection failed\n' +
-          '2024-01-24 10:00:02 Another message\n'
+  describe('--filter passthrough', () => {
+    it('should pass --filter through to Railway CLI args', async () => {
+      await fetchLogs({ env: 'dev', filter: '@level:error' });
+
+      expect(vi.mocked(execFileSync)).toHaveBeenCalledWith(
+        'railway',
+        expect.arrayContaining(['--filter', '@level:error']),
+        expect.anything()
       );
+    });
+
+    it('should pass complex Railway DSL queries unchanged', async () => {
+      await fetchLogs({ env: 'dev', filter: 'vision AND (404 OR 400)' });
+
+      expect(vi.mocked(execFileSync)).toHaveBeenCalledWith(
+        'railway',
+        expect.arrayContaining(['--filter', 'vision AND (404 OR 400)']),
+        expect.anything()
+      );
+    });
+
+    it('should omit --filter when not provided', async () => {
+      await fetchLogs({ env: 'dev' });
+
+      const callArgs = vi.mocked(execFileSync).mock.calls[0]?.[1] as string[];
+      expect(callArgs).not.toContain('--filter');
+    });
+
+    it('should not filter output client-side (Railway owns filtering)', async () => {
+      // Railway returns only matching lines when --filter is used. Our wrapper
+      // must print them verbatim — no client-side grep on top.
+      vi.mocked(execFileSync).mockReturnValue('Database connection failed\nAnother message\n');
 
       await fetchLogs({ env: 'dev', filter: 'database' });
 
       const output = consoleLogSpy.mock.calls.flat().join(' ');
       expect(output).toContain('Database connection failed');
-      expect(output).not.toContain('Request received');
-    });
-
-    it('should filter by log level (JSON format)', async () => {
-      vi.mocked(execFileSync).mockReturnValue(
-        '{"level":"info","message":"Info log"}\n{"level":"error","message":"Error log"}\n'
-      );
-
-      await fetchLogs({ env: 'dev', filter: 'error' });
-
-      const output = consoleLogSpy.mock.calls.flat().join(' ');
-      expect(output).toContain('Error log');
-      expect(output).not.toContain('Info log');
+      expect(output).toContain('Another message');
     });
   });
 

--- a/packages/tooling/src/deployment/logs.ts
+++ b/packages/tooling/src/deployment/logs.ts
@@ -39,35 +39,6 @@ function validateService(service: string | undefined): string | undefined {
 }
 
 /**
- * Filter log lines by keyword or log level
- */
-function filterLogs(logs: string, filter: string | undefined): string {
-  if (!filter) return logs;
-
-  const filterLower = filter.toLowerCase();
-  const lines = logs.split('\n');
-
-  // Check if filter is a log level
-  const logLevels = ['error', 'warn', 'info', 'debug'];
-  const isLevelFilter = logLevels.includes(filterLower);
-
-  return lines
-    .filter(line => {
-      const lineLower = line.toLowerCase();
-      if (isLevelFilter) {
-        // For level filters, match the level keyword
-        return (
-          lineLower.includes(`"level":"${filterLower}"`) ||
-          lineLower.includes(`level=${filterLower}`)
-        );
-      }
-      // For other filters, do a simple substring match
-      return lineLower.includes(filterLower);
-    })
-    .join('\n');
-}
-
-/**
  * Colorize log output based on log level
  */
 function colorizeLogs(logs: string): string {
@@ -117,9 +88,10 @@ function displayHeader(
 function displayFooter(): void {
   console.log('');
   console.log(chalk.cyan.bold('═══════════════════════════════════════════════════════'));
-  console.log(chalk.dim('💡 Tips:'));
+  console.log(chalk.dim('💡 Tips (--filter uses Railway query DSL):'));
   console.log(chalk.dim('   pnpm ops logs --env dev --service api-gateway'));
-  console.log(chalk.dim('   pnpm ops logs --env dev --filter error'));
+  console.log(chalk.dim('   pnpm ops logs --env dev --filter "@level:error"'));
+  console.log(chalk.dim('   pnpm ops logs --env dev --filter "vision AND 404"'));
   console.log(chalk.dim('   pnpm ops logs --env dev --follow'));
   console.log(chalk.cyan.bold('═══════════════════════════════════════════════════════'));
 }
@@ -127,7 +99,7 @@ function displayFooter(): void {
 /**
  * Stream logs in follow mode using spawn
  */
-async function streamLogsWithFollow(args: string[], filter: string | undefined): Promise<void> {
+async function streamLogsWithFollow(args: string[]): Promise<void> {
   const { spawn } = await import('node:child_process');
   const proc = spawn('railway', args, {
     stdio: ['inherit', 'pipe', 'pipe'],
@@ -135,10 +107,7 @@ async function streamLogsWithFollow(args: string[], filter: string | undefined):
   });
 
   proc.stdout?.on('data', (data: Buffer) => {
-    let output = data.toString();
-    if (filter) {
-      output = filterLogs(output, filter);
-    }
+    const output = data.toString();
     if (output.trim()) {
       process.stdout.write(colorizeLogs(output));
     }
@@ -164,20 +133,15 @@ async function streamLogsWithFollow(args: string[], filter: string | undefined):
 /**
  * Fetch logs synchronously (non-follow mode)
  */
-function fetchLogsSync(args: string[], filter: string | undefined): void {
+function fetchLogsSync(args: string[]): void {
   const result = execFileSync('railway', args, {
     encoding: 'utf-8',
     stdio: ['pipe', 'pipe', 'pipe'],
     maxBuffer: 10 * 1024 * 1024, // 10MB buffer for large log output
   });
 
-  let output = result;
-  if (filter) {
-    output = filterLogs(output, filter);
-  }
-
-  if (output.trim()) {
-    console.log(colorizeLogs(output));
+  if (result.trim()) {
+    console.log(colorizeLogs(result));
   } else {
     console.log(chalk.dim('No logs found matching the criteria.'));
   }
@@ -219,21 +183,26 @@ export async function fetchLogs(options: LogsOptions): Promise<void> {
 
   displayHeader(railwayEnv, validatedService, lines, filter);
 
-  // Build Railway logs command arguments
+  // Build Railway logs command arguments.
+  // --filter is passed through as a Railway 4.11.2 server-side query (attribute
+  // filters like `@level:error`, boolean operators like `"vision AND 404"`).
   const args = ['logs', '--environment', railwayEnv];
   if (validatedService) {
     args.push('--service', validatedService);
   }
   args.push('-n', String(lines));
+  if (filter !== undefined) {
+    args.push('--filter', filter);
+  }
   if (follow) {
     args.push('--follow');
   }
 
   try {
     if (follow) {
-      await streamLogsWithFollow(args, filter);
+      await streamLogsWithFollow(args);
     } else {
-      fetchLogsSync(args, filter);
+      fetchLogsSync(args);
     }
   } catch (error) {
     handleLogsError(error, validatedService);

--- a/services/ai-worker/src/jobs/ImageDescriptionJob.test.ts
+++ b/services/ai-worker/src/jobs/ImageDescriptionJob.test.ts
@@ -8,8 +8,9 @@ import type { Job } from 'bullmq';
 import type { ImageDescriptionJobData, LoadedPersonality } from '@tzurot/common-types';
 import { JobType, CONTENT_TYPES, AIProvider, TIMEOUTS } from '@tzurot/common-types';
 
-// Vision intentionally caps retries below the project-wide RETRY_CONFIG default —
-// see ImageDescriptionJob.ts for rationale.
+// Mirrors the module-level constant in ImageDescriptionJob.ts. Intentionally
+// kept as a copy so the test asserts the expected *contract* (vision uses 2
+// attempts) rather than coupling to the implementation's internal name.
 const VISION_MAX_ATTEMPTS = 2;
 import type { ApiKeyResolver } from '../services/ApiKeyResolver.js';
 
@@ -127,6 +128,9 @@ describe('ImageDescriptionJob', () => {
           globalTimeoutMs: TIMEOUTS.VISION_MODEL * VISION_MAX_ATTEMPTS,
           operationName: 'Image description (image1.png)',
           shouldRetry: expect.any(Function),
+          // Telemetry hook — guards against silent regression of errorCategory
+          // enrichment in failure logs.
+          getErrorContext: expect.any(Function),
         })
       );
     });

--- a/services/ai-worker/src/jobs/ImageDescriptionJob.test.ts
+++ b/services/ai-worker/src/jobs/ImageDescriptionJob.test.ts
@@ -6,7 +6,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { processImageDescriptionJob } from './ImageDescriptionJob.js';
 import type { Job } from 'bullmq';
 import type { ImageDescriptionJobData, LoadedPersonality } from '@tzurot/common-types';
-import { JobType, CONTENT_TYPES, AIProvider, TIMEOUTS, RETRY_CONFIG } from '@tzurot/common-types';
+import { JobType, CONTENT_TYPES, AIProvider, TIMEOUTS } from '@tzurot/common-types';
+
+// Vision intentionally caps retries below the project-wide RETRY_CONFIG default —
+// see ImageDescriptionJob.ts for rationale.
+const VISION_MAX_ATTEMPTS = 2;
 import type { ApiKeyResolver } from '../services/ApiKeyResolver.js';
 
 // Mock describeImage, withRetry, and shouldRetryError
@@ -20,6 +24,7 @@ vi.mock('../utils/retry.js', () => ({
 
 vi.mock('../utils/apiErrorParser.js', () => ({
   shouldRetryError: vi.fn((_error: unknown) => true),
+  getErrorLogContext: vi.fn((_error: unknown) => ({})),
 }));
 
 // Import the mocked modules
@@ -118,8 +123,8 @@ describe('ImageDescriptionJob', () => {
       expect(mockWithRetry).toHaveBeenCalledWith(
         expect.any(Function),
         expect.objectContaining({
-          maxAttempts: 3,
-          globalTimeoutMs: TIMEOUTS.VISION_MODEL * RETRY_CONFIG.MAX_ATTEMPTS,
+          maxAttempts: VISION_MAX_ATTEMPTS,
+          globalTimeoutMs: TIMEOUTS.VISION_MODEL * VISION_MAX_ATTEMPTS,
           operationName: 'Image description (image1.png)',
           shouldRetry: expect.any(Function),
         })
@@ -243,7 +248,7 @@ describe('ImageDescriptionJob', () => {
       expect(mockWithRetry).toHaveBeenCalledWith(
         expect.any(Function),
         expect.objectContaining({
-          maxAttempts: 3,
+          maxAttempts: VISION_MAX_ATTEMPTS,
         })
       );
     });
@@ -671,7 +676,7 @@ describe('ImageDescriptionJob', () => {
       expect(mockWithRetry).toHaveBeenCalledWith(
         expect.any(Function),
         expect.objectContaining({
-          globalTimeoutMs: TIMEOUTS.VISION_MODEL * RETRY_CONFIG.MAX_ATTEMPTS,
+          globalTimeoutMs: TIMEOUTS.VISION_MODEL * VISION_MAX_ATTEMPTS,
         })
       );
     });

--- a/services/ai-worker/src/jobs/ImageDescriptionJob.ts
+++ b/services/ai-worker/src/jobs/ImageDescriptionJob.ts
@@ -23,6 +23,14 @@ import type { ApiKeyResolver } from '../services/ApiKeyResolver.js';
 
 const logger = createLogger('ImageDescriptionJob');
 
+/**
+ * Vision retry cap: 2 attempts (1 initial + 1 retry). LangChain's 90s internal
+ * timeout fires deterministically on provider stalls; retrying beyond 2 attempts
+ * doubled wait time without measurable recovery.
+ * Revisit after telemetry confirms TIMEOUT retry-success-rate.
+ */
+const VISION_MAX_ATTEMPTS = 2;
+
 /** Result of processing a single image */
 interface ImageProcessResult {
   url: string;
@@ -85,11 +93,6 @@ async function processSingleImage(
   userApiKey?: string
 ): Promise<ImageProcessResult> {
   try {
-    // Vision cap: 2 attempts (1 initial + 1 retry). LangChain's 90s internal
-    // timeout fires deterministically on provider stalls; retrying beyond
-    // 2 attempts doubled wait time without measurable recovery.
-    // Revisit after telemetry confirms TIMEOUT retry-success-rate.
-    const VISION_MAX_ATTEMPTS = 2;
     const result = await withRetry(
       () =>
         describeImage(attachment, personality, isGuestMode, userApiKey, {

--- a/services/ai-worker/src/jobs/ImageDescriptionJob.ts
+++ b/services/ai-worker/src/jobs/ImageDescriptionJob.ts
@@ -10,7 +10,6 @@ import { Job } from 'bullmq';
 import {
   createLogger,
   CONTENT_TYPES,
-  RETRY_CONFIG,
   TIMEOUTS,
   AIProvider,
   type ImageDescriptionJobData,
@@ -19,7 +18,7 @@ import {
 } from '@tzurot/common-types';
 import { describeImage } from '../services/MultimodalProcessor.js';
 import { withRetry } from '../utils/retry.js';
-import { shouldRetryError } from '../utils/apiErrorParser.js';
+import { shouldRetryError, getErrorLogContext } from '../utils/apiErrorParser.js';
 import type { ApiKeyResolver } from '../services/ApiKeyResolver.js';
 
 const logger = createLogger('ImageDescriptionJob');
@@ -86,17 +85,25 @@ async function processSingleImage(
   userApiKey?: string
 ): Promise<ImageProcessResult> {
   try {
+    // Vision cap: 2 attempts (1 initial + 1 retry). LangChain's 90s internal
+    // timeout fires deterministically on provider stalls; retrying beyond
+    // 2 attempts doubled wait time without measurable recovery.
+    // Revisit after telemetry confirms TIMEOUT retry-success-rate.
+    const VISION_MAX_ATTEMPTS = 2;
     const result = await withRetry(
       () =>
         describeImage(attachment, personality, isGuestMode, userApiKey, {
           skipNegativeCache: true,
         }),
       {
-        maxAttempts: RETRY_CONFIG.MAX_ATTEMPTS,
-        globalTimeoutMs: TIMEOUTS.VISION_MODEL * RETRY_CONFIG.MAX_ATTEMPTS,
+        maxAttempts: VISION_MAX_ATTEMPTS,
+        globalTimeoutMs: TIMEOUTS.VISION_MODEL * VISION_MAX_ATTEMPTS,
         logger,
         operationName: `Image description (${attachment.name})`,
         shouldRetry: shouldRetryError,
+        // Enrich failure logs with errorCategory, statusCode, etc. so post-deploy
+        // telemetry can answer: "retry success rate per errorCategory".
+        getErrorContext: getErrorLogContext,
       }
     );
     return { url: attachment.url, description: result.value, success: true };

--- a/services/ai-worker/src/services/LLMInvoker.ts
+++ b/services/ai-worker/src/services/LLMInvoker.ts
@@ -212,11 +212,6 @@ export class LLMInvoker {
     // We do NOT strip tags here to avoid losing reasoning content before it can be
     // extracted and displayed to users (when showThinking is enabled).
 
-    logger.info(
-      { modelName, attempts: result.attempts, totalTimeMs: result.totalTimeMs },
-      '[LLMInvoker] LLM invocation completed'
-    );
-
     return result.value;
   }
 

--- a/services/ai-worker/src/services/multimodal/VisionProcessor.ts
+++ b/services/ai-worker/src/services/multimodal/VisionProcessor.ts
@@ -34,6 +34,7 @@ const FAILURE_LABELS: Record<string, string> = {
   content_policy: 'content filtered',
   bad_request: 'invalid request',
   model_not_found: 'model unavailable',
+  media_not_found: 'image unavailable',
   rate_limit: 'rate limited',
   server_error: 'server error',
   timeout: 'timed out',

--- a/services/ai-worker/src/utils/apiErrorParser.test.ts
+++ b/services/ai-worker/src/utils/apiErrorParser.test.ts
@@ -197,6 +197,52 @@ describe('parseApiError', () => {
     });
   });
 
+  describe('special-case detection (pre-status)', () => {
+    it('should classify AbortError by name as TIMEOUT', () => {
+      const error = new Error('Request was aborted');
+      error.name = 'AbortError';
+      const result = parseApiError(error);
+      expect(result.category).toBe(ApiErrorCategory.TIMEOUT);
+      expect(result.type).toBe(ApiErrorType.TRANSIENT);
+      expect(result.shouldRetry).toBe(true);
+    });
+
+    it('should classify error with "Request was aborted" message as TIMEOUT', () => {
+      const error = new Error('Request was aborted due to timeout');
+      const result = parseApiError(error);
+      expect(result.category).toBe(ApiErrorCategory.TIMEOUT);
+      expect(result.shouldRetry).toBe(true);
+    });
+
+    it('should classify AbortError even when wrapped with a status code', () => {
+      // Some LangChain wrappers attach a fake status to abort errors — special-case
+      // must still win over status-based classification.
+      const error = Object.assign(new Error('Request was aborted'), {
+        name: 'AbortError',
+        status: 500,
+      });
+      const result = parseApiError(error);
+      expect(result.category).toBe(ApiErrorCategory.TIMEOUT);
+    });
+
+    it('should classify "Received 404 when fetching URL" as permanent MEDIA_NOT_FOUND', () => {
+      // OpenRouter/vision APIs wrap media-fetch 404s inside a 400 response.
+      // Without the special case, the wrapping 400 would make this retryable BAD_REQUEST.
+      const error = new Error('400 Received 404 when fetching URL https://cdn.discord.com/foo.png');
+      const result = parseApiError(error);
+      expect(result.category).toBe(ApiErrorCategory.MEDIA_NOT_FOUND);
+      expect(result.type).toBe(ApiErrorType.PERMANENT);
+      expect(result.shouldRetry).toBe(false);
+    });
+
+    it('should classify MEDIA_NOT_FOUND even when error object carries status 400', () => {
+      const error = Object.assign(new Error('Received 404 when fetching URL'), { status: 400 });
+      const result = parseApiError(error);
+      expect(result.category).toBe(ApiErrorCategory.MEDIA_NOT_FOUND);
+      expect(result.shouldRetry).toBe(false);
+    });
+  });
+
   describe('network error detection', () => {
     it('should detect ECONNRESET as network error', () => {
       const error = { code: 'ECONNRESET', message: 'Connection reset' };

--- a/services/ai-worker/src/utils/apiErrorParser.ts
+++ b/services/ai-worker/src/utils/apiErrorParser.ts
@@ -191,6 +191,30 @@ function detectCategoryFromMessage(message: string): ApiErrorCategory | null {
 }
 
 /**
+ * Detect classifier special cases that must run before HTTP status extraction.
+ *
+ * AbortError: thrown by the OpenAI SDK when LangChain's internal `timeout`
+ * option fires. Has no HTTP status, and "Request was aborted" doesn't match
+ * the generic TIMEOUT regex patterns, so it would otherwise fall through to
+ * UNKNOWN (shouldRetry=true) and amplify into retry storms at the caller's
+ * maxAttempts × timeout budget.
+ */
+function detectSpecialCases(error: unknown): ApiErrorCategory | null {
+  if (error instanceof Error) {
+    if (error.name === 'AbortError' || /request was aborted/i.test(error.message)) {
+      return ApiErrorCategory.TIMEOUT;
+    }
+    // OpenRouter/vision API wrap media-fetch 404s inside a 400 response body
+    // (e.g., "400 Received 404 when fetching URL"). Must catch before status
+    // extraction so the wrapping 400 doesn't classify this as retryable BAD_REQUEST.
+    if (/received 404 when fetching url/i.test(error.message)) {
+      return ApiErrorCategory.MEDIA_NOT_FOUND;
+    }
+  }
+  return null;
+}
+
+/**
  * Check if error is a network error based on error code
  */
 function isNetworkError(error: unknown): boolean {
@@ -249,45 +273,61 @@ function detectContentError(error: unknown): ApiErrorCategory | null {
  *   // Use errorInfo.referenceId for support
  * }
  */
+/**
+ * Resolve category + type from error, running detection layers in priority order:
+ * 1. Special cases (AbortError, media-URL 404s) — must win over HTTP status
+ * 2. HTTP status classification (most reliable when no special case)
+ * 3. Message pattern matching (fallback for errors without status)
+ * 4. Content-specific detection (empty/censored response text)
+ * 5. Network error codes (ECONNRESET, etc.)
+ */
+function resolveCategoryAndType(
+  error: unknown,
+  statusCode: number | undefined,
+  errorMessage: string
+): { category: ApiErrorCategory; type: ApiErrorType } {
+  const specialCase = detectSpecialCases(error);
+  if (specialCase !== null) {
+    return {
+      category: specialCase,
+      type: isPermanentError(specialCase) ? ApiErrorType.PERMANENT : ApiErrorType.TRANSIENT,
+    };
+  }
+
+  if (statusCode !== undefined) {
+    const classification = classifyHttpStatus(statusCode);
+    if (classification.category !== ApiErrorCategory.UNKNOWN) {
+      return classification;
+    }
+  }
+
+  const messageCategory = detectCategoryFromMessage(errorMessage);
+  if (messageCategory !== null) {
+    return {
+      category: messageCategory,
+      type: isPermanentError(messageCategory) ? ApiErrorType.PERMANENT : ApiErrorType.TRANSIENT,
+    };
+  }
+
+  const contentCategory = detectContentError(error);
+  if (contentCategory !== null) {
+    return { category: contentCategory, type: ApiErrorType.TRANSIENT };
+  }
+
+  if (isNetworkError(error)) {
+    return { category: ApiErrorCategory.NETWORK, type: ApiErrorType.TRANSIENT };
+  }
+
+  return { category: ApiErrorCategory.UNKNOWN, type: ApiErrorType.UNKNOWN };
+}
+
 export function parseApiError(error: unknown): ApiErrorInfo {
   const referenceId = generateErrorReferenceId();
   const statusCode = extractStatusCode(error);
   const requestId = extractRequestId(error);
   const errorMessage = error instanceof Error ? error.message : String(error);
 
-  let category: ApiErrorCategory = ApiErrorCategory.UNKNOWN;
-  let type: ApiErrorType = ApiErrorType.UNKNOWN;
-
-  // First, try to classify by HTTP status code (most reliable)
-  if (statusCode !== undefined) {
-    const classification = classifyHttpStatus(statusCode);
-    category = classification.category;
-    type = classification.type;
-  }
-
-  // If status didn't give us a specific category, check error message patterns
-  if (category === ApiErrorCategory.UNKNOWN) {
-    const messageCategory = detectCategoryFromMessage(errorMessage);
-    if (messageCategory !== null) {
-      category = messageCategory;
-      type = isPermanentError(category) ? ApiErrorType.PERMANENT : ApiErrorType.TRANSIENT;
-    }
-  }
-
-  // Check for content errors (empty/censored response)
-  if (category === ApiErrorCategory.UNKNOWN) {
-    const contentCategory = detectContentError(error);
-    if (contentCategory !== null) {
-      category = contentCategory;
-      type = ApiErrorType.TRANSIENT; // These are retryable
-    }
-  }
-
-  // Check for network errors
-  if (category === ApiErrorCategory.UNKNOWN && isNetworkError(error)) {
-    category = ApiErrorCategory.NETWORK;
-    type = ApiErrorType.TRANSIENT;
-  }
+  const { category, type } = resolveCategoryAndType(error, statusCode, errorMessage);
 
   // Determine if we should retry
   const shouldRetry = type !== ApiErrorType.PERMANENT;

--- a/services/ai-worker/src/utils/apiErrorParser.ts
+++ b/services/ai-worker/src/utils/apiErrorParser.ts
@@ -256,24 +256,6 @@ function detectContentError(error: unknown): ApiErrorCategory | null {
 }
 
 /**
- * Parse an error from LangChain/OpenRouter and extract structured info
- *
- * @param error - The error to parse
- * @returns Structured error info for retry logic and user messaging
- *
- * @example
- * try {
- *   await model.invoke(messages);
- * } catch (error) {
- *   const errorInfo = parseApiError(error);
- *   if (!errorInfo.shouldRetry) {
- *     // Fast-fail, don't retry
- *   }
- *   // Use errorInfo.userMessage for user feedback
- *   // Use errorInfo.referenceId for support
- * }
- */
-/**
  * Resolve category + type from error, running detection layers in priority order:
  * 1. Special cases (AbortError, media-URL 404s) — must win over HTTP status
  * 2. HTTP status classification (most reliable when no special case)
@@ -321,6 +303,24 @@ function resolveCategoryAndType(
   return { category: ApiErrorCategory.UNKNOWN, type: ApiErrorType.UNKNOWN };
 }
 
+/**
+ * Parse an error from LangChain/OpenRouter and extract structured info
+ *
+ * @param error - The error to parse
+ * @returns Structured error info for retry logic and user messaging
+ *
+ * @example
+ * try {
+ *   await model.invoke(messages);
+ * } catch (error) {
+ *   const errorInfo = parseApiError(error);
+ *   if (!errorInfo.shouldRetry) {
+ *     // Fast-fail, don't retry
+ *   }
+ *   // Use errorInfo.userMessage for user feedback
+ *   // Use errorInfo.referenceId for support
+ * }
+ */
 export function parseApiError(error: unknown): ApiErrorInfo {
   const referenceId = generateErrorReferenceId();
   const statusCode = extractStatusCode(error);

--- a/services/ai-worker/src/utils/apiErrorParser.ts
+++ b/services/ai-worker/src/utils/apiErrorParser.ts
@@ -200,6 +200,9 @@ function detectCategoryFromMessage(message: string): ApiErrorCategory | null {
  * maxAttempts × timeout budget.
  */
 function detectSpecialCases(error: unknown): ApiErrorCategory | null {
+  // AbortError is always an Error subclass at the runtime level. If a future
+  // LangChain version ever wraps the abort in a plain object, this check falls
+  // through to UNKNOWN — acceptable safety behavior, but update this guard.
   if (error instanceof Error) {
     if (error.name === 'AbortError' || /request was aborted/i.test(error.message)) {
       return ApiErrorCategory.TIMEOUT;

--- a/services/ai-worker/src/utils/retry.test.ts
+++ b/services/ai-worker/src/utils/retry.test.ts
@@ -367,6 +367,94 @@ describe('retryService', () => {
       );
     });
 
+    it('should log success with attempt and durationMs on first-attempt success', async () => {
+      const fn = vi.fn().mockResolvedValue('ok');
+
+      const promise = withRetry(fn, {
+        logger: mockLogger,
+        operationName: 'fast-op',
+      });
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operationName: 'fast-op',
+          attempt: 1,
+          durationMs: expect.any(Number),
+          totalTimeMs: expect.any(Number),
+        }),
+        expect.stringContaining('succeeded on attempt 1')
+      );
+    });
+
+    it('should log success with attempt number reflecting retry index', async () => {
+      const fn = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('first try fails'))
+        .mockResolvedValue('ok');
+
+      const promise = withRetry(fn, {
+        maxAttempts: 2,
+        initialDelayMs: 10,
+        logger: mockLogger,
+        operationName: 'retry-op',
+      });
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ attempt: 2, durationMs: expect.any(Number) }),
+        expect.stringContaining('succeeded on attempt 2')
+      );
+    });
+
+    it('should include durationMs in per-attempt failure log', async () => {
+      const fn = vi.fn().mockRejectedValueOnce(new Error('transient')).mockResolvedValue('ok');
+
+      const promise = withRetry(fn, {
+        maxAttempts: 2,
+        initialDelayMs: 10,
+        logger: mockLogger,
+        operationName: 'fail-log-op',
+      });
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operationName: 'fail-log-op',
+          attempt: 1,
+          maxAttempts: 2,
+          durationMs: expect.any(Number),
+        }),
+        expect.stringContaining('failed (attempt 1/2)')
+      );
+    });
+
+    it('should include operationName in exhaustion log', async () => {
+      const fn = vi.fn().mockRejectedValue(new Error('permanent failure'));
+
+      const promise = withRetry(fn, {
+        maxAttempts: 2,
+        initialDelayMs: 10,
+        logger: mockLogger,
+        operationName: 'exhaust-op',
+      });
+      const assertion = expect(promise).rejects.toThrow(RetryError);
+      await vi.runAllTimersAsync();
+      await assertion;
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operationName: 'exhaust-op',
+          attempts: 2,
+          totalTimeMs: expect.any(Number),
+        }),
+        expect.stringContaining('exhausted all retry attempts')
+      );
+    });
+
     it('should include custom operation name in errors', async () => {
       const fn = vi.fn().mockRejectedValue(new Error('Fail'));
 

--- a/services/ai-worker/src/utils/retry.ts
+++ b/services/ai-worker/src/utils/retry.ts
@@ -287,21 +287,26 @@ export async function withRetry<T>(
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     checkGlobalTimeout({ globalTimeoutMs, startTime, attempt, operationName, lastError, logger });
+    const attemptStartTime = Date.now();
 
     try {
       const value = await fn();
-      const totalTimeMs = Date.now() - startTime;
+      const now = Date.now();
+      const durationMs = now - attemptStartTime;
+      const totalTimeMs = now - startTime;
 
-      if (attempt > 1) {
-        logger?.info(
-          { attempt, totalTimeMs },
-          `[Retry] ${operationName} succeeded after ${attempt} attempts`
-        );
-      }
+      // Log every successful attempt with per-attempt duration so post-deploy
+      // analysis can answer: attempt-1 success rate, p95 response time per
+      // attempt index, retry success rate.
+      logger?.info(
+        { operationName, attempt, durationMs, totalTimeMs },
+        `[Retry] ${operationName} succeeded on attempt ${attempt}`
+      );
 
       return { value, attempts: attempt, totalTimeMs };
     } catch (error) {
       lastError = error;
+      const durationMs = Date.now() - attemptStartTime;
       checkRetryableError({
         error,
         shouldRetry,
@@ -316,8 +321,10 @@ export async function withRetry<T>(
         {
           ...errorContext,
           err: normalizeErrorForLogging(error, operationName),
+          operationName,
           attempt,
           maxAttempts,
+          durationMs,
         },
         `[Retry] ${operationName} failed (attempt ${attempt}/${maxAttempts})`
       );
@@ -342,7 +349,7 @@ export async function withRetry<T>(
   );
   const exhaustionContext = safeGetErrorContext(getErrorContext, lastError, logger);
   logger?.error(
-    { ...exhaustionContext, err: error, attempts: maxAttempts, totalTimeMs },
+    { ...exhaustionContext, err: error, operationName, attempts: maxAttempts, totalTimeMs },
     `[Retry] ${operationName} exhausted all retry attempts`
   );
   throw error;


### PR DESCRIPTION
## Summary

Diagnostic bundle for vision-pipeline retry amplification. User-facing symptom: "AI sometimes takes a long time" — prod log analysis (2026-04-14) showed 63% of vision-model failures are raw `AbortError` at LangChain's 90s internal timeout, falling through our classifier to `UNKNOWN` (shouldRetry=true), amplifying into ~270s of wasted wall-time per hopeless image.

### Changes

- **Classifier correctness** (`services/ai-worker/src/utils/apiErrorParser.ts`)
  - `AbortError` (by name or `"Request was aborted"` message) now classifies as `TIMEOUT` via a new pre-status special-case check, winning over any HTTP status on the error object
  - `"400 Received 404 when fetching URL"` (dead Discord CDN links) now classifies as the new `MEDIA_NOT_FOUND` category, permanent — so the existing `visionDescriptionCache.storeFailure({ permanent })` layer marks it as permanent-failure and subsequent attempts skip the vision API entirely
  - Extracted classifier layers into `resolveCategoryAndType` helper to keep `parseApiError` under the cognitive-complexity limit

- **Retry cap for vision** (`services/ai-worker/src/jobs/ImageDescriptionJob.ts`)
  - `maxAttempts: 3 → 2` (1 initial + 1 retry). Max wait per hopeless image drops from ~270s to ~180s. Follow-up backlog item tracks the empirical revisit once we have retry-success-rate data from the new telemetry

- **Retry telemetry enrichment** (`services/ai-worker/src/utils/retry.ts`)
  - Success log now fires on **every** successful attempt (was previously silent on attempt-1 success), enriched with `{ operationName, attempt, durationMs, totalTimeMs }`
  - Per-attempt failure log enriched with `{ operationName, attempt, durationMs, maxAttempts }`
  - Exhaustion log gains `operationName` as structured field
  - `ImageDescriptionJob` now passes `getErrorContext: getErrorLogContext` so failure logs include `errorCategory`, `statusCode`, `shouldRetry`
  - **Log volume impact**: new info log per attempt-1 success for `AudioTranscriptionJob`, `TTSStep`, `ImageDescriptionJob` (previously silent on that path). `LLMInvoker` net neutral — its now-redundant "LLM invocation completed" log was deleted (`withRetry`'s enriched log supersedes it, `modelName` is embedded in `operationName` for queryability)

- **Railway `--filter` passthrough** (`packages/tooling/src/deployment/logs.ts`)
  - `pnpm ops logs --filter <query>` now passes through to Railway 4.11.2 server-side query DSL (attribute filters like `@level:error`, boolean operators like `"vision AND 404"`)
  - **Breaking change**: removed client-side substring/level-keyword grep. `--filter error` no longer matches `"level":"error"` — use `--filter "@level:error"` instead. Acceptable for a one-person internal dev tool

### Design decision validation

Choices stress-tested against MCP council (`gemini-3.1-pro-preview`) across two rounds:

1. **2 attempts vs 0 retries** — council argued for 0 (deterministic-stall assumption). Chose 2 to preserve recovery ceiling until we measure retry success rate. Follow-up revisit item filed.
2. **New `MEDIA_NOT_FOUND` category vs reusing `BAD_REQUEST`** — council argued for reuse. Kept new category because existing comment at `error.ts:198-199` documents that `BAD_REQUEST` is intentionally retryable (some AI APIs return 400 for transient issues).
3. **Per-attempt success log vs enrich existing** — council's "enrich" recommendation adopted as structured-field additions.
4. **Attempt-1 info log volume (2nd-round consult)** — council: keep info-level (debug-level would require manual ops toggle to measure retry success rate, which solo-dev workflow won't do reliably), but delete the redundant `LLMInvoker` completion log since `withRetry`'s enriched log now covers it. Both adopted.

## Test plan

- [x] `pnpm test` — 4218 passed across all services
- [x] `pnpm test:int` — 246 integration tests passed
- [x] `pnpm quality` — lint + cpd + depcruise + typecheck all pass
- [x] New unit tests: 3 AbortError classifier cases, 2 MEDIA_NOT_FOUND cases, 4 telemetry enrichment assertions, 4 Railway `--filter` passthrough cases
- [ ] **Post-deploy validation** (dev then prod): `pnpm ops logs --service ai-worker --filter "vision"` — expect AbortError retry clusters to shrink from 3-attempt pattern to 2-attempt pattern; new `attempt` + `durationMs` fields appear in success/failure logs
- [ ] **Post-deploy log volume check**: confirm `info`-level volume is within Railway retention/cost budgets after attempt-1 success logging kicks in for audio/TTS/vision (LLM path is net-neutral after the redundant-log deletion)
- [ ] **Follow-up empirical review** (1-2 weeks post-deploy): grep logs for `attempt=2` successes to measure retry success rate per `errorCategory`; tune `VISION_MAX_ATTEMPTS` and `TIMEOUTS.VISION_MODEL` accordingly. Both revisit items already filed in Icebox.

## Backlog additions

- 🧊 Icebox: Revisit `VISION_MAX_ATTEMPTS` after telemetry data
- 🧊 Icebox: Revisit `TIMEOUTS.VISION_MODEL` after telemetry data
- 📦 Future Themes: Observability & Telemetry Strategy (epic)
- 📦 Future Themes: User Analytics Strategy (epic, build-vs-buy decision required)

## Plan file

Full design rationale, alternatives considered, and step-by-step breakdown: `~/.claude/plans/majestic-drifting-lightning.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)