### PR TITLE
chore: phase 2 identity hardening follow-ups (review nits)

### DIFF
--- a/docs/reference/architecture/epic-identity-hardening.md
+++ b/docs/reference/architecture/epic-identity-hardening.md
@@ -232,6 +232,27 @@ DB admins" for fixture setup, and gating test fixtures through UserService
 would force integration tests to go through a cache layer and race-
 protection logic they don't need.
 
+**Known limitation — aliasing bypass**: the syntactic AST pattern does
+NOT catch variable aliasing:
+
+```ts
+const userTable = prisma.user;
+await userTable.create({ ... });              // NOT flagged
+
+const { user } = prisma;
+await user.create({ ... });                   // NOT flagged
+```
+
+Full type-flow analysis would be needed for exhaustive coverage. In
+practice nobody destructures `prisma.user` or aliases it in this
+codebase, so the syntactic rule is a strong first line of defense. If
+the pattern ever appears in a PR, catch it in review; if it becomes
+common, extend with a dependency-cruiser rule that looks at the
+import-level pattern (e.g., banning indirect access through local
+aliases of Prisma client substructures). The ESLint rule's inline
+comment in `eslint.config.js` documents this gap so grep-auditors
+don't assume it's comprehensive.
+
 ## Related backlog items
 
 See `BACKLOG.md` Icebox/Inbox for:

--- a/packages/common-types/src/services/UserService.int.test.ts
+++ b/packages/common-types/src/services/UserService.int.test.ts
@@ -18,6 +18,7 @@ import { PGlite } from '@electric-sql/pglite';
 import { vector } from '@electric-sql/pglite/vector';
 import { PrismaPGlite } from 'pglite-prisma-adapter';
 import { UserService } from './UserService.js';
+import { generatePersonaUuid } from '../utils/deterministicUuid.js';
 import { loadPGliteSchema } from '@tzurot/test-utils';
 
 // Mock isBotOwner - will be configured per test
@@ -222,8 +223,12 @@ describe('UserService', () => {
         testDisplayName
       );
 
+      // Persona UUID is deterministic (generatePersonaUuid(username, userId)),
+      // so we can assert the exact expected value rather than a weaker
+      // .not.toBeNull() check.
+      const expectedPersonaId = generatePersonaUuid(testUsername, userId);
       expect(provisioned?.userId).toBe(userId);
-      expect(provisioned?.defaultPersonaId).not.toBeNull();
+      expect(provisioned?.defaultPersonaId).toBe(expectedPersonaId);
 
       // Verify persona was backfilled
       const user = await prisma.user.findUnique({


### PR DESCRIPTION
## Summary

Post-merge follow-ups from [PR #807](https://github.com/lbds137/tzurot/pull/807) review. Both items were flagged as non-blockers during the second review pass — handled on a new branch rather than reopening the merged PR.

## Changes

### 1. Tighten backfill assertion to deterministic UUID equality

`UserService.int.test.ts`: changed from `expect(provisioned?.defaultPersonaId).not.toBeNull()` to `expect(provisioned?.defaultPersonaId).toBe(expectedPersonaId)` where `expectedPersonaId = generatePersonaUuid(testUsername, userId)`. The persona UUID is deterministic, so a non-null-but-wrong ID was a semantic gap in the original check.

### 2. Document ESLint aliasing bypass under D5

`epic-identity-hardening.md` D5: the rule's AST selector matches `X.user.create(...)` but not:
```ts
const u = prisma.user; u.create(...)         // NOT flagged
const { user } = prisma; user.create(...)    // NOT flagged
```
Already noted in `eslint.config.js` inline. The epic-doc entry is for grep-auditors searching decisions, who wouldn't think to cross-reference the config file. Decision log now includes the limitation + catch-in-review + dep-cruiser escalation path if the pattern ever appears.

## Test plan

- [x] `pnpm test` — all 4218 unit tests pass
- [x] `pnpm test:int` — all 246 integration tests pass (including the tightened backfill assertion)
- [x] `pnpm quality` — lint + typecheck + depcruise green

🤖 Generated with [Claude Code](https://claude.com/claude-code)