### PR TITLE
fix(bot-client): prevent cross-channel data leak in message-link expansion

### DIFF
--- a/services/bot-client/src/handlers/references/LinkExtractor.test.ts
+++ b/services/bot-client/src/handlers/references/LinkExtractor.test.ts
@@ -954,6 +954,72 @@ describe('LinkExtractor', () => {
       expect(mockChannel.messages.fetch).not.toHaveBeenCalled();
     });
 
+    it('allows expansion when invoker IS a member of the source guild (cross-guild happy path)', async () => {
+      // Critical correctness test: ensures the access check targets the
+      // SOURCE guild (the guild that owns the linked channel) and NOT the
+      // invoker's current guild. A naive refactor using `sourceMessage.guild`
+      // instead of `channel.guild` would still pass the same-guild tests
+      // above but would silently break cross-guild access control — this
+      // test catches that regression by giving the two guilds DIFFERENT
+      // members.fetch mocks and asserting the SOURCE guild's was called.
+      const mockMessage = createMockMessage();
+      const invokerCurrentGuild = mockMessage.guild!;
+
+      // Distinct source guild with its own members.fetch. Invoker IS a
+      // member of this foreign guild → fetch resolves → expansion allowed.
+      const sourceGuildFetch = vi.fn().mockResolvedValue({ id: 'user-123' });
+      const sourceGuild = {
+        id: 'other-guild-999',
+        name: 'Other Guild',
+        members: { fetch: sourceGuildFetch },
+      } as unknown as Guild;
+
+      // Point the test link at the OTHER guild, and swap the mocked channel
+      // onto that guild's resolution path.
+      vi.mocked(MessageLinkParser.parseMessageLinks).mockReturnValue([
+        {
+          fullUrl: 'https://discord.com/channels/other-guild-999/channel-456/ref-msg-456',
+          guildId: 'other-guild-999',
+          channelId: 'channel-456',
+          messageId: 'ref-msg-456',
+        },
+      ]);
+
+      const foreignChannel = {
+        id: 'channel-456',
+        isTextBased: vi.fn(() => true),
+        isThread: vi.fn(() => false),
+        isDMBased: vi.fn(() => false),
+        permissionsFor: vi.fn(() => ({ has: vi.fn(() => true) })),
+        guild: sourceGuild,
+        messages: {
+          fetch: vi.fn().mockResolvedValue(createMockMessage({ id: 'ref-msg-456' })),
+        },
+      } as unknown as TextChannel;
+
+      // Client-level resolution: the link parser hits guilds.fetch → returns
+      // the source guild; guild.channels.cache lookup misses → falls to
+      // client.channels.fetch → returns the foreign channel.
+      vi.mocked(mockMessage.client.guilds.fetch).mockResolvedValue(sourceGuild as any);
+      vi.mocked(mockMessage.client.channels.fetch).mockResolvedValue(foreignChannel as any);
+      (sourceGuild as any).channels = { cache: new Map() };
+
+      const [references] = await linkExtractor.extractLinkReferences(
+        mockMessage,
+        new Set(),
+        new Set(),
+        [],
+        1
+      );
+
+      expect(references).toHaveLength(1);
+      // CRITICAL assertions: the SOURCE guild's fetch was called, NOT the
+      // invoker's current guild's fetch. A bug here would pass the denial
+      // test (same-guild-lookup-fails) but fail this one (wrong guild queried).
+      expect(sourceGuildFetch).toHaveBeenCalledWith('user-123');
+      expect(invokerCurrentGuild.members.fetch).not.toHaveBeenCalled();
+    });
+
     it('denies expansion when invoker is not a member of the source guild (cross-guild leak)', async () => {
       // Classic exploit: bot is in private guild Y, attacker in guild X pastes
       // a guild-Y link into a guild-X channel. Invoker isn't in guild Y →

--- a/services/bot-client/src/handlers/references/LinkExtractor.test.ts
+++ b/services/bot-client/src/handlers/references/LinkExtractor.test.ts
@@ -920,6 +920,40 @@ describe('LinkExtractor', () => {
       expect(mockChannel.messages.fetch).not.toHaveBeenCalled();
     });
 
+    it('denies expansion when invoker has ViewChannel but not ReadMessageHistory', async () => {
+      // Documents the AND-semantics of the permission check. The production
+      // code asserts BOTH flags via `permissions.has([ViewChannel, ReadMessageHistory])`.
+      // An accidental refactor to `has(ViewChannel)` only would silently
+      // weaken the check — this test would catch that regression.
+      const mockMessage = createMockMessage();
+      const mockChannel = mockMessage.channel as TextChannel;
+
+      // Mock `has()` to return true for ViewChannel alone but false when
+      // both flags are required as an array. This simulates the real
+      // PermissionsBitField.has() behavior: `has(single)` vs `has([a, b])`.
+      (mockChannel as any).permissionsFor = vi.fn(() => ({
+        has: vi.fn((flags: unknown) => {
+          // The production call passes an array of both flags → must return false
+          if (Array.isArray(flags)) {
+            return false;
+          }
+          // A single-flag call (what a weakened refactor might use) → would be true
+          return true;
+        }),
+      }));
+
+      const [references] = await linkExtractor.extractLinkReferences(
+        mockMessage,
+        new Set(),
+        new Set(),
+        [],
+        1
+      );
+
+      expect(references).toHaveLength(0);
+      expect(mockChannel.messages.fetch).not.toHaveBeenCalled();
+    });
+
     it('denies expansion when invoker is not a member of the source guild (cross-guild leak)', async () => {
       // Classic exploit: bot is in private guild Y, attacker in guild X pastes
       // a guild-Y link into a guild-X channel. Invoker isn't in guild Y →

--- a/services/bot-client/src/handlers/references/LinkExtractor.test.ts
+++ b/services/bot-client/src/handlers/references/LinkExtractor.test.ts
@@ -7,7 +7,7 @@ import { LinkExtractor } from './LinkExtractor.js';
 import { MessageFormatter } from './MessageFormatter.js';
 import { SnapshotFormatter } from './SnapshotFormatter.js';
 import { MessageLinkParser } from '../../utils/MessageLinkParser.js';
-import { MessageReferenceType, Collection } from 'discord.js';
+import { ChannelType, MessageReferenceType, Collection } from 'discord.js';
 import { INTERVALS } from '@tzurot/common-types';
 import type { Message, Guild, Channel, TextChannel, Client, MessageSnapshot } from 'discord.js';
 import type { ReferencedMessage } from '@tzurot/common-types';
@@ -996,7 +996,7 @@ describe('LinkExtractor', () => {
       const mockChannel = mockMessage.channel as TextChannel;
 
       (mockChannel as any).isThread = vi.fn(() => true);
-      (mockChannel as any).type = 12; // PrivateThread
+      (mockChannel as any).type = ChannelType.PrivateThread;
       (mockChannel as any).members = {
         fetch: vi.fn().mockRejectedValue(new Error('Unknown Member')),
       };
@@ -1018,7 +1018,7 @@ describe('LinkExtractor', () => {
       const mockChannel = mockMessage.channel as TextChannel;
 
       (mockChannel as any).isThread = vi.fn(() => true);
-      (mockChannel as any).type = 12; // PrivateThread
+      (mockChannel as any).type = ChannelType.PrivateThread;
       (mockChannel as any).members = {
         fetch: vi.fn().mockResolvedValue({ id: 'user-123' }),
       };
@@ -1044,7 +1044,7 @@ describe('LinkExtractor', () => {
       const mockChannel = mockMessage.channel as TextChannel;
 
       (mockChannel as any).isThread = vi.fn(() => true);
-      (mockChannel as any).type = 11; // PublicThread — NOT private
+      (mockChannel as any).type = ChannelType.PublicThread;
       vi.mocked(mockChannel.messages.fetch).mockResolvedValue(
         createMockMessage({ id: 'ref-msg-123' }) as any
       );
@@ -1068,6 +1068,30 @@ describe('LinkExtractor', () => {
       const mockChannel = mockMessage.channel as TextChannel;
 
       (mockChannel as any).permissionsFor = vi.fn(() => null);
+
+      const [references] = await linkExtractor.extractLinkReferences(
+        mockMessage,
+        new Set(),
+        new Set(),
+        [],
+        1
+      );
+
+      expect(references).toHaveLength(0);
+      expect(mockChannel.messages.fetch).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when a non-DM channel has no guild reference (malformed state)', async () => {
+      // Defensive guard: a text-based, non-DM channel should always have a
+      // guild. If Discord.js produces a channel without one (malformed state,
+      // edge-case fetch race), we refuse to proceed rather than assuming it's
+      // safe to expand.
+      const mockMessage = createMockMessage();
+      const mockChannel = mockMessage.channel as TextChannel;
+
+      // Non-DM channel, but guild property is missing (`guild` is still in the
+      // object shape because TextChannel requires it, but we explicitly null it)
+      (mockChannel as any).guild = null;
 
       const [references] = await linkExtractor.extractLinkReferences(
         mockMessage,

--- a/services/bot-client/src/handlers/references/LinkExtractor.test.ts
+++ b/services/bot-client/src/handlers/references/LinkExtractor.test.ts
@@ -22,8 +22,26 @@ vi.mock('../../utils/MessageLinkParser.js', () => ({
 // Type for mock input - allows any properties to be overridden
 type MockMessageInput = Record<string, unknown>;
 
-// Helper to create mock Discord message
+// Helper to create mock Discord message.
+// Security-check defaults: channel returns a permissive `permissionsFor` result
+// and the guild returns a valid member on `members.fetch`, so existing tests
+// (which don't exercise the access-check path) continue to pass. Security-
+// specific tests in the "access control" describe block override these.
 function createMockMessage(overrides: MockMessageInput = {}): Message {
+  const permissiveChannelMethods = {
+    isDMBased: vi.fn(() => false),
+    isThread: vi.fn(() => false),
+    permissionsFor: vi.fn(() => ({ has: vi.fn(() => true) })),
+  };
+
+  const mockGuild = {
+    id: 'guild-123',
+    name: 'Test Guild',
+    members: {
+      fetch: vi.fn().mockResolvedValue({ id: 'user-123' }),
+    },
+  } as unknown as Guild;
+
   const mockChannel = {
     id: 'channel-123',
     type: 0, // GUILD_TEXT
@@ -31,16 +49,15 @@ function createMockMessage(overrides: MockMessageInput = {}): Message {
     messages: {
       fetch: vi.fn(),
     },
+    guild: mockGuild,
+    ...permissiveChannelMethods,
   } as unknown as TextChannel;
 
-  const mockGuild = {
-    id: 'guild-123',
-    name: 'Test Guild',
-    channels: {
-      cache: new Map([[mockChannel.id, mockChannel as Channel]]),
-      fetch: vi.fn(),
-    },
-  } as unknown as Guild;
+  // Attach the channel into the guild's channel cache now that both exist
+  (mockGuild as any).channels = {
+    cache: new Map([[mockChannel.id, mockChannel as Channel]]),
+    fetch: vi.fn(),
+  };
 
   const mockClient: Partial<Client> = {
     guilds: {
@@ -347,11 +364,18 @@ describe('LinkExtractor', () => {
         channels: {
           cache: new Map(),
         },
+        members: {
+          fetch: vi.fn().mockResolvedValue({ id: 'user-123' }),
+        },
       } as unknown as Guild;
 
       const mockChannel = {
         id: 'channel-456',
         isTextBased: vi.fn(() => true),
+        isThread: vi.fn(() => false),
+        isDMBased: vi.fn(() => false),
+        permissionsFor: vi.fn(() => ({ has: vi.fn(() => true) })),
+        guild: mockGuild,
         messages: {
           fetch: vi.fn().mockResolvedValue(createMockMessage({ id: 'ref-msg-456' })),
         },
@@ -434,6 +458,9 @@ describe('LinkExtractor', () => {
         type: 11, // PUBLIC_THREAD
         isTextBased: vi.fn(() => true),
         isThread: vi.fn(() => true),
+        isDMBased: vi.fn(() => false),
+        permissionsFor: vi.fn(() => ({ has: vi.fn(() => true) })),
+        guild: mockGuild,
         messages: {
           fetch: vi.fn().mockResolvedValue(createMockMessage({ id: 'thread-msg-789' })),
         },
@@ -822,6 +849,236 @@ describe('LinkExtractor', () => {
       // Should NOT be deduplicated (user message, not bot/webhook)
       expect(references).toHaveLength(1);
       expect(linkMap.size).toBe(1);
+    });
+  });
+
+  // ============================================================================
+  // SECURITY: invoking-user access check on message-link expansion.
+  //
+  // The bot has cross-channel credentials that the invoking user may not share.
+  // Without the invoker-access check, pasting a link to a private #staff channel
+  // in a public channel would let the bot expand the private content into the
+  // AI's context, potentially surfacing in the AI reply the victim user reads.
+  //
+  // These tests cover the access-check decision tree in
+  // `LinkExtractor.verifyInvokerCanAccessSource`:
+  //   - DM source: only DM participant can expand
+  //   - Guild source: invoker must be a guild member AND have ViewChannel +
+  //     ReadMessageHistory on the source channel
+  //   - Private thread: additionally requires thread membership
+  //   - Fail closed: any null/undefined check result denies access
+  // ============================================================================
+  describe('access control (verifyInvokerCanAccessSource)', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      // Default: every link parses to the same test link
+      vi.mocked(MessageLinkParser.parseMessageLinks).mockReturnValue([
+        {
+          fullUrl: 'https://discord.com/channels/guild-123/channel-123/ref-msg-123',
+          guildId: 'guild-123',
+          channelId: 'channel-123',
+          messageId: 'ref-msg-123',
+        },
+      ]);
+    });
+
+    it('allows expansion when invoker has ViewChannel + ReadMessageHistory in same-guild source', async () => {
+      const mockMessage = createMockMessage();
+      const mockChannel = mockMessage.channel as TextChannel;
+      vi.mocked(mockChannel.messages.fetch).mockResolvedValue(
+        createMockMessage({ id: 'ref-msg-123' }) as any
+      );
+
+      const [references] = await linkExtractor.extractLinkReferences(
+        mockMessage,
+        new Set(),
+        new Set(),
+        [],
+        1
+      );
+
+      expect(references).toHaveLength(1);
+      expect(mockChannel.messages.fetch).toHaveBeenCalledWith('ref-msg-123');
+    });
+
+    it('denies expansion when invoker lacks ViewChannel on source channel', async () => {
+      const mockMessage = createMockMessage();
+      const mockChannel = mockMessage.channel as TextChannel;
+
+      // Override permissionsFor to deny
+      (mockChannel as any).permissionsFor = vi.fn(() => ({ has: vi.fn(() => false) }));
+
+      const [references] = await linkExtractor.extractLinkReferences(
+        mockMessage,
+        new Set(),
+        new Set(),
+        [],
+        1
+      );
+
+      expect(references).toHaveLength(0);
+      expect(mockChannel.messages.fetch).not.toHaveBeenCalled();
+    });
+
+    it('denies expansion when invoker is not a member of the source guild (cross-guild leak)', async () => {
+      // Classic exploit: bot is in private guild Y, attacker in guild X pastes
+      // a guild-Y link into a guild-X channel. Invoker isn't in guild Y →
+      // members.fetch rejects → deny.
+      const mockMessage = createMockMessage();
+      const mockGuild = mockMessage.guild!;
+      const mockChannel = mockMessage.channel as TextChannel;
+
+      // members.fetch rejects (user not in source guild)
+      vi.mocked(mockGuild.members.fetch).mockRejectedValue(new Error('Unknown Member') as never);
+
+      const [references] = await linkExtractor.extractLinkReferences(
+        mockMessage,
+        new Set(),
+        new Set(),
+        [],
+        1
+      );
+
+      expect(references).toHaveLength(0);
+      expect(mockChannel.messages.fetch).not.toHaveBeenCalled();
+    });
+
+    it('allows expansion when invoker is a DM participant (self-reference to own DM)', async () => {
+      // The legitimate case: you're in a DM with the bot and you paste a link
+      // to your own DM message in another conversation. You have access.
+      const mockMessage = createMockMessage();
+      const mockChannel = mockMessage.channel as TextChannel;
+
+      // Override channel to be a DM where invoker (user-123) is the recipient
+      (mockChannel as any).isDMBased = vi.fn(() => true);
+      (mockChannel as any).recipientId = 'user-123';
+      vi.mocked(mockChannel.messages.fetch).mockResolvedValue(
+        createMockMessage({ id: 'ref-msg-123' }) as any
+      );
+
+      const [references] = await linkExtractor.extractLinkReferences(
+        mockMessage,
+        new Set(),
+        new Set(),
+        [],
+        1
+      );
+
+      expect(references).toHaveLength(1);
+    });
+
+    it('denies expansion when invoker is NOT a DM participant (third-party DM leak)', async () => {
+      // The exploit case: someone else pastes a link to a DM they're not part
+      // of, trying to get the bot to expand it. Deny.
+      const mockMessage = createMockMessage();
+      const mockChannel = mockMessage.channel as TextChannel;
+
+      // DM exists but invoker (user-123) is NOT the recipient
+      (mockChannel as any).isDMBased = vi.fn(() => true);
+      (mockChannel as any).recipientId = 'some-other-user-999';
+
+      const [references] = await linkExtractor.extractLinkReferences(
+        mockMessage,
+        new Set(),
+        new Set(),
+        [],
+        1
+      );
+
+      expect(references).toHaveLength(0);
+      expect(mockChannel.messages.fetch).not.toHaveBeenCalled();
+    });
+
+    it('denies expansion for private thread when invoker is not a thread member', async () => {
+      // Private threads (type 12) have an explicit member list. Parent-channel
+      // ViewChannel isn't enough — you must be in the thread's member list.
+      const mockMessage = createMockMessage();
+      const mockChannel = mockMessage.channel as TextChannel;
+
+      (mockChannel as any).isThread = vi.fn(() => true);
+      (mockChannel as any).type = 12; // PrivateThread
+      (mockChannel as any).members = {
+        fetch: vi.fn().mockRejectedValue(new Error('Unknown Member')),
+      };
+
+      const [references] = await linkExtractor.extractLinkReferences(
+        mockMessage,
+        new Set(),
+        new Set(),
+        [],
+        1
+      );
+
+      expect(references).toHaveLength(0);
+      expect(mockChannel.messages.fetch).not.toHaveBeenCalled();
+    });
+
+    it('allows expansion for private thread when invoker IS a thread member', async () => {
+      const mockMessage = createMockMessage();
+      const mockChannel = mockMessage.channel as TextChannel;
+
+      (mockChannel as any).isThread = vi.fn(() => true);
+      (mockChannel as any).type = 12; // PrivateThread
+      (mockChannel as any).members = {
+        fetch: vi.fn().mockResolvedValue({ id: 'user-123' }),
+      };
+      vi.mocked(mockChannel.messages.fetch).mockResolvedValue(
+        createMockMessage({ id: 'ref-msg-123' }) as any
+      );
+
+      const [references] = await linkExtractor.extractLinkReferences(
+        mockMessage,
+        new Set(),
+        new Set(),
+        [],
+        1
+      );
+
+      expect(references).toHaveLength(1);
+    });
+
+    it('allows expansion for PUBLIC thread (inherits parent permissions, no extra check)', async () => {
+      // Public threads don't have a per-thread member list for access control.
+      // Parent ViewChannel + ReadMessageHistory is sufficient.
+      const mockMessage = createMockMessage();
+      const mockChannel = mockMessage.channel as TextChannel;
+
+      (mockChannel as any).isThread = vi.fn(() => true);
+      (mockChannel as any).type = 11; // PublicThread — NOT private
+      vi.mocked(mockChannel.messages.fetch).mockResolvedValue(
+        createMockMessage({ id: 'ref-msg-123' }) as any
+      );
+
+      const [references] = await linkExtractor.extractLinkReferences(
+        mockMessage,
+        new Set(),
+        new Set(),
+        [],
+        1
+      );
+
+      expect(references).toHaveLength(1);
+    });
+
+    it('fails closed when permissionsFor returns null (unexpected Discord.js state)', async () => {
+      // Defense in depth: if Discord.js returns null from permissionsFor for
+      // any reason (malformed member, edge-case channel type), deny rather
+      // than default-allow.
+      const mockMessage = createMockMessage();
+      const mockChannel = mockMessage.channel as TextChannel;
+
+      (mockChannel as any).permissionsFor = vi.fn(() => null);
+
+      const [references] = await linkExtractor.extractLinkReferences(
+        mockMessage,
+        new Set(),
+        new Set(),
+        [],
+        1
+      );
+
+      expect(references).toHaveLength(0);
+      expect(mockChannel.messages.fetch).not.toHaveBeenCalled();
     });
   });
 });

--- a/services/bot-client/src/handlers/references/LinkExtractor.ts
+++ b/services/bot-client/src/handlers/references/LinkExtractor.ts
@@ -4,7 +4,14 @@
  * Extracts referenced messages from Discord message links
  */
 
-import type { Message, Channel, TextChannel, ThreadChannel, DMChannel } from 'discord.js';
+import type {
+  Message,
+  Channel,
+  TextChannel,
+  ThreadChannel,
+  DMChannel,
+  GuildMember,
+} from 'discord.js';
 import { ChannelType, PermissionsBitField } from 'discord.js';
 import { createLogger, INTERVALS } from '@tzurot/common-types';
 import type { ReferencedMessage } from '@tzurot/common-types';
@@ -334,7 +341,11 @@ export class LinkExtractor {
       }
 
       const sourceGuild = channel.guild;
-      let sourceMember;
+      // Explicit type: `members.fetch(id)` returns `Promise<GuildMember>`, but
+      // the no-args overload returns `Promise<Collection<string, GuildMember>>`.
+      // Annotating prevents a future refactor of the fetch call from silently
+      // widening the type through either overload.
+      let sourceMember: GuildMember | undefined;
       try {
         // `fetch` with cache preference — returns cached member or falls back
         // to API call. Throws if the user isn't in the guild.

--- a/services/bot-client/src/handlers/references/LinkExtractor.ts
+++ b/services/bot-client/src/handlers/references/LinkExtractor.ts
@@ -120,18 +120,20 @@ export class LinkExtractor {
 
   /**
    * Fetch a message from a parsed Discord link
-   * @param link - Parsed message link
-   * @param sourceMessage - Original message (for guild access)
+   * @param link - Parsed message link (the link being expanded)
+   * @param invokingMessage - Message that contains the link (its author is
+   *   the user whose access is being verified). Named to disambiguate from
+   *   the linked-to message, which is what this method FETCHES.
    * @returns Discord message or null if not accessible
    */
   // eslint-disable-next-line complexity, max-lines-per-function -- Discord API requires nested try-catch for guild→channel→message fetch chain with different error codes (10008, 50001, 50013). Extracting would obscure the sequential fetch flow and error handling context.
   async fetchMessageFromLink(
     link: ParsedMessageLink,
-    sourceMessage: Message
+    invokingMessage: Message
   ): Promise<Message | null> {
     try {
       // Try to get guild from cache first
-      let guild = sourceMessage.client.guilds.cache.get(link.guildId);
+      let guild = invokingMessage.client.guilds.cache.get(link.guildId);
 
       // If not in cache, try to fetch it (bot might be in the guild but it's not cached)
       if (!guild) {
@@ -144,7 +146,7 @@ export class LinkExtractor {
             '[LinkExtractor] Guild not in cache, attempting fetch...'
           );
 
-          guild = await sourceMessage.client.guilds.fetch(link.guildId);
+          guild = await invokingMessage.client.guilds.fetch(link.guildId);
 
           logger.info(
             {
@@ -180,7 +182,7 @@ export class LinkExtractor {
             '[LinkExtractor] Channel not in cache, fetching...'
           );
 
-          channel = await sourceMessage.client.channels.fetch(link.channelId);
+          channel = await invokingMessage.client.channels.fetch(link.channelId);
 
           logger.debug(
             {
@@ -222,14 +224,14 @@ export class LinkExtractor {
       // leaking private content into the AI reply via context assembly.
       // Phase 2 of the Identity & Provisioning Hardening epic — see
       // docs/reference/architecture/epic-identity-hardening.md.
-      const invokerCanAccess = await this.verifyInvokerCanAccessSource(channel, sourceMessage);
+      const invokerCanAccess = await this.verifyInvokerCanAccessSource(channel, invokingMessage);
       if (!invokerCanAccess) {
         logger.debug(
           {
             messageId: link.messageId,
             channelId: link.channelId,
             guildId: link.guildId,
-            invokerId: sourceMessage.author.id,
+            invokerId: invokingMessage.author.id,
           },
           '[LinkExtractor] Invoking user lacks access to source channel — skipping expansion'
         );
@@ -289,39 +291,42 @@ export class LinkExtractor {
   }
 
   /**
-   * Verify the invoking user (author of sourceMessage) has access to the
-   * source channel of a message link, not just the bot.
+   * Verify the invoking user (author of `invokingMessage`) has access to
+   * the channel that the link points at, not just the bot.
    *
    * Without this check, the bot's credentials would let anyone expand a
    * message link from a channel they cannot see, leaking private content
    * into the AI reply via conversation-context assembly.
    *
    * Decision tree:
-   * - **DM source**: allowed iff the invoker is one of the DM participants.
+   * - **DM link target**: allowed iff the invoker is the DM participant.
    *   DMs have no roles/permissions; the participant set is the access set.
    *   Covers the legitimate "I want to reference my own DM with the bot
    *   somewhere else" case.
-   * - **Guild source**: fetch the invoker's member record for the SOURCE
-   *   guild (which may differ from where they're invoking from). If the
-   *   invoker isn't a member of the source guild, deny. If they are, check
-   *   `permissionsFor(sourceMember).has(ViewChannel | ReadMessageHistory)`.
-   * - **Thread source**: threads inherit permissions from their parent, BUT
-   *   private threads require explicit access that `ViewChannel` on parent
-   *   does not imply. For private threads we additionally verify the user
-   *   can view the thread itself via `threadMembers.fetch()` presence (a
-   *   private thread has an explicit member list).
+   * - **Guild link target**: fetch the invoker's member record for the
+   *   TARGET guild (which may differ from where they're invoking from —
+   *   cross-guild link case). If the invoker isn't a member of the target
+   *   guild, deny. If they are, check `permissionsFor(member).has(ViewChannel,
+   *   ReadMessageHistory)` on the target channel.
+   * - **Thread target**: threads inherit permissions from their parent,
+   *   BUT private threads require explicit membership that `ViewChannel`
+   *   on the parent does not imply. For private threads we additionally
+   *   verify the user is in the thread's member list via `thread.members.fetch()`.
    *
-   * **Fail closed**: if any lookup returns null/undefined unexpectedly (e.g.,
-   * member fetch rejects, thread membership fetch throws), deny access.
+   * **Fail closed**: if any lookup returns null/undefined unexpectedly
+   * (e.g., member fetch rejects, thread membership fetch throws), deny.
    *
-   * @returns true if the invoker can access the source channel
+   * @param channel - The channel the link points at (NOT the invoking channel)
+   * @param invokingMessage - The message containing the link. Its author is
+   *   the user whose access is being verified.
+   * @returns true if the invoker can access the channel the link points at
    */
   private async verifyInvokerCanAccessSource(
     channel: Channel,
-    sourceMessage: Message
+    invokingMessage: Message
   ): Promise<boolean> {
     try {
-      const invokerId = sourceMessage.author.id;
+      const invokerId = invokingMessage.author.id;
 
       // DM case — check DM participant.
       // Bots cannot participate in Group DMs (Discord restriction), so a bot's
@@ -333,8 +338,11 @@ export class LinkExtractor {
         return dmChannel.recipientId === invokerId;
       }
 
-      // Guild case — invoker must be a member of the SOURCE guild (which may
-      // differ from sourceMessage.guild if this is a cross-guild link)
+      // Guild case — invoker must be a member of the TARGET guild (which may
+      // differ from invokingMessage.guild if this is a cross-guild link).
+      // The `'guild' in channel` + null checks also serve to narrow `channel`
+      // from the broad `Channel` type to a guild-channel variant so that
+      // `channel.permissionsFor()` below is type-safe to call.
       if (!('guild' in channel) || channel.guild === null || channel.guild === undefined) {
         // Text-based but not a DM and no guild — unexpected. Fail closed.
         return false;
@@ -396,7 +404,7 @@ export class LinkExtractor {
     } catch (error) {
       // Catch-all: any unexpected error during permission checks fails closed.
       logger.warn(
-        { err: error, invokerId: sourceMessage.author.id, channelId: channel.id },
+        { err: error, invokerId: invokingMessage.author.id, channelId: channel.id },
         '[LinkExtractor] Unexpected error during access check — failing closed'
       );
       return false;

--- a/services/bot-client/src/handlers/references/LinkExtractor.ts
+++ b/services/bot-client/src/handlers/references/LinkExtractor.ts
@@ -4,7 +4,8 @@
  * Extracts referenced messages from Discord message links
  */
 
-import type { Message, Channel, TextChannel, ThreadChannel } from 'discord.js';
+import type { Message, Channel, TextChannel, ThreadChannel, DMChannel } from 'discord.js';
+import { ChannelType, PermissionsBitField } from 'discord.js';
 import { createLogger, INTERVALS } from '@tzurot/common-types';
 import type { ReferencedMessage } from '@tzurot/common-types';
 import { MessageLinkParser, type ParsedMessageLink } from '../../utils/MessageLinkParser.js';
@@ -208,6 +209,26 @@ export class LinkExtractor {
         return null;
       }
 
+      // SECURITY: verify the invoking user (not just the bot) has access to the
+      // source channel before fetching. Without this check, the bot's credentials
+      // would let anyone expand a message link from a channel they cannot see,
+      // leaking private content into the AI reply via context assembly.
+      // Phase 2 of the Identity & Provisioning Hardening epic — see
+      // docs/reference/architecture/epic-identity-hardening.md.
+      const invokerCanAccess = await this.verifyInvokerCanAccessSource(channel, sourceMessage);
+      if (!invokerCanAccess) {
+        logger.debug(
+          {
+            messageId: link.messageId,
+            channelId: link.channelId,
+            guildId: link.guildId,
+            invokerId: sourceMessage.author.id,
+          },
+          '[LinkExtractor] Invoking user lacks access to source channel — skipping expansion'
+        );
+        return null;
+      }
+
       const fetchedMessage = await (channel as TextChannel | ThreadChannel).messages.fetch(
         link.messageId
       );
@@ -258,6 +279,113 @@ export class LinkExtractor {
    */
   private isTextBasedChannel(channel: Channel | null): boolean {
     return channel !== null && channel.isTextBased() && 'messages' in channel;
+  }
+
+  /**
+   * Verify the invoking user (author of sourceMessage) has access to the
+   * source channel of a message link, not just the bot.
+   *
+   * Without this check, the bot's credentials would let anyone expand a
+   * message link from a channel they cannot see, leaking private content
+   * into the AI reply via conversation-context assembly.
+   *
+   * Decision tree:
+   * - **DM source**: allowed iff the invoker is one of the DM participants.
+   *   DMs have no roles/permissions; the participant set is the access set.
+   *   Covers the legitimate "I want to reference my own DM with the bot
+   *   somewhere else" case.
+   * - **Guild source**: fetch the invoker's member record for the SOURCE
+   *   guild (which may differ from where they're invoking from). If the
+   *   invoker isn't a member of the source guild, deny. If they are, check
+   *   `permissionsFor(sourceMember).has(ViewChannel | ReadMessageHistory)`.
+   * - **Thread source**: threads inherit permissions from their parent, BUT
+   *   private threads require explicit access that `ViewChannel` on parent
+   *   does not imply. For private threads we additionally verify the user
+   *   can view the thread itself via `threadMembers.fetch()` presence (a
+   *   private thread has an explicit member list).
+   *
+   * **Fail closed**: if any lookup returns null/undefined unexpectedly (e.g.,
+   * member fetch rejects, thread membership fetch throws), deny access.
+   *
+   * @returns true if the invoker can access the source channel
+   */
+  private async verifyInvokerCanAccessSource(
+    channel: Channel,
+    sourceMessage: Message
+  ): Promise<boolean> {
+    try {
+      const invokerId = sourceMessage.author.id;
+
+      // DM case — check DM participant.
+      // Bots cannot participate in Group DMs (Discord restriction), so a bot's
+      // DM channel is always 1-on-1 (`DMChannel` with a single `recipientId`,
+      // never a `PartialGroupDMChannel`). The invoker is either THE recipient
+      // or not — there's no third option we need to worry about.
+      if (channel.isDMBased()) {
+        const dmChannel = channel as DMChannel;
+        return dmChannel.recipientId === invokerId;
+      }
+
+      // Guild case — invoker must be a member of the SOURCE guild (which may
+      // differ from sourceMessage.guild if this is a cross-guild link)
+      if (!('guild' in channel) || channel.guild === null || channel.guild === undefined) {
+        // Text-based but not a DM and no guild — unexpected. Fail closed.
+        return false;
+      }
+
+      const sourceGuild = channel.guild;
+      let sourceMember;
+      try {
+        // `fetch` with cache preference — returns cached member or falls back
+        // to API call. Throws if the user isn't in the guild.
+        sourceMember = await sourceGuild.members.fetch(invokerId);
+      } catch {
+        // Invoker isn't a member of the source guild. Deny.
+        return false;
+      }
+
+      // Check base channel permissions
+      const permissions = channel.permissionsFor(sourceMember);
+      if (permissions === null) {
+        // Rare: permission calculation failed. Fail closed.
+        return false;
+      }
+      const hasBaseAccess = permissions.has([
+        PermissionsBitField.Flags.ViewChannel,
+        PermissionsBitField.Flags.ReadMessageHistory,
+      ]);
+      if (!hasBaseAccess) {
+        return false;
+      }
+
+      // Thread case — additionally verify private-thread membership.
+      // Public threads inherit parent perms; private threads have an explicit
+      // member list that `ViewChannel` on parent does NOT imply.
+      if (channel.isThread()) {
+        const thread = channel as ThreadChannel;
+        // Private threads have an explicit member list; public and announcement
+        // threads inherit parent-channel access.
+        const isPrivateThread = thread.type === ChannelType.PrivateThread;
+        if (isPrivateThread) {
+          try {
+            const threadMember = await thread.members.fetch(invokerId);
+            return threadMember !== null && threadMember !== undefined;
+          } catch {
+            // Not a thread member. Deny.
+            return false;
+          }
+        }
+      }
+
+      return true;
+    } catch (error) {
+      // Catch-all: any unexpected error during permission checks fails closed.
+      logger.warn(
+        { err: error, invokerId: sourceMessage.author.id, channelId: channel.id },
+        '[LinkExtractor] Unexpected error during access check — failing closed'
+      );
+      return false;
+    }
   }
 
   /**

--- a/services/bot-client/src/handlers/references/LinkExtractor.ts
+++ b/services/bot-client/src/handlers/references/LinkExtractor.ts
@@ -226,7 +226,10 @@ export class LinkExtractor {
       // docs/reference/architecture/epic-identity-hardening.md.
       const invokerCanAccess = await this.verifyInvokerCanAccessSource(channel, invokingMessage);
       if (!invokerCanAccess) {
-        logger.debug(
+        // Access denial is a security event — log at info so it surfaces in
+        // production logs for probe/abuse detection (e.g., "is someone
+        // pasting staff-channel links hoping the bot will expand them?").
+        logger.info(
           {
             messageId: link.messageId,
             channelId: link.channelId,
@@ -333,6 +336,13 @@ export class LinkExtractor {
       // DM channel is always 1-on-1 (`DMChannel` with a single `recipientId`,
       // never a `PartialGroupDMChannel`). The invoker is either THE recipient
       // or not — there's no third option we need to worry about.
+      //
+      // Note: `MessageLinkParser.MESSAGE_LINK_REGEX` requires `\d+` for the
+      // guild segment, so DM-format links (`/channels/@me/...`) are pre-
+      // filtered and never reach this method through normal user input. This
+      // branch is defensive for edge cases where a DM channel could be
+      // resolved via `client.channels.fetch()` fallback on a guild-format
+      // link that happens to reference a DM channel ID.
       if (channel.isDMBased()) {
         const dmChannel = channel as DMChannel;
         return dmChannel.recipientId === invokerId;
@@ -356,8 +366,14 @@ export class LinkExtractor {
       // lets CFA narrow out the uninitialized case — no `| undefined` needed.
       let sourceMember: GuildMember;
       try {
-        // `fetch` with cache preference — returns cached member or falls back
-        // to API call. Throws if the user isn't in the guild.
+        // Discord.js's single-ID `members.fetch(id)` is cache-first: it
+        // returns the cached member without an API call when available, and
+        // only falls back to `GET /guilds/{id}/members/{id}` on a miss.
+        // With the `GuildMembers` intent enabled (see services/bot-client/src/index.ts),
+        // `MESSAGE_CREATE` payloads auto-cache the message author on receipt,
+        // so the invoker is typically cached for same-guild lookups. Cross-
+        // guild lookups may incur one API call on first access, then cached.
+        // Throws if the user isn't in the guild (caught → deny below).
         sourceMember = await sourceGuild.members.fetch(invokerId);
       } catch {
         // Invoker isn't a member of the source guild. Deny.
@@ -383,8 +399,11 @@ export class LinkExtractor {
       // member list that `ViewChannel` on parent does NOT imply.
       if (channel.isThread()) {
         const thread = channel as ThreadChannel;
-        // Private threads have an explicit member list; public and announcement
-        // threads inherit parent-channel access.
+        // Private threads (type 12) have an explicit member list that
+        // `ViewChannel` on the parent does NOT imply — they need the extra
+        // check below. Public threads (type 11) and announcement threads
+        // (type 10) inherit parent-channel access, so the base permission
+        // check is sufficient and we skip the thread-membership lookup.
         const isPrivateThread = thread.type === ChannelType.PrivateThread;
         if (isPrivateThread) {
           try {

--- a/services/bot-client/src/handlers/references/LinkExtractor.ts
+++ b/services/bot-client/src/handlers/references/LinkExtractor.ts
@@ -344,8 +344,9 @@ export class LinkExtractor {
       // Explicit type: `members.fetch(id)` returns `Promise<GuildMember>`, but
       // the no-args overload returns `Promise<Collection<string, GuildMember>>`.
       // Annotating prevents a future refactor of the fetch call from silently
-      // widening the type through either overload.
-      let sourceMember: GuildMember | undefined;
+      // widening the type through either overload. The diverging catch below
+      // lets CFA narrow out the uninitialized case — no `| undefined` needed.
+      let sourceMember: GuildMember;
       try {
         // `fetch` with cache preference — returns cached member or falls back
         // to API call. Throws if the user isn't in the guild.
@@ -379,8 +380,11 @@ export class LinkExtractor {
         const isPrivateThread = thread.type === ChannelType.PrivateThread;
         if (isPrivateThread) {
           try {
-            const threadMember = await thread.members.fetch(invokerId);
-            return threadMember !== null && threadMember !== undefined;
+            // `thread.members.fetch(id)` throws if the user isn't a thread
+            // member — it never returns null/undefined — so reaching the
+            // line after the await is itself proof of membership.
+            await thread.members.fetch(invokerId);
+            return true;
           } catch {
             // Not a thread member. Deny.
             return false;

--- a/services/bot-client/src/test/mocks/Discord.mock.ts
+++ b/services/bot-client/src/test/mocks/Discord.mock.ts
@@ -129,6 +129,12 @@ export function createMockGuild(overrides: MockInput<Guild> = EMPTY_OVERRIDES): 
     name: 'Test Server',
     ownerId: '111111111111111111',
     memberCount: 100,
+    // Security-check default: members.fetch resolves to a valid member so that
+    // LinkExtractor.verifyInvokerCanAccessSource passes by default. Security-
+    // specific tests override this to reject.
+    members: {
+      fetch: vi.fn().mockResolvedValue({ id: '111111111111111111' }),
+    } as unknown as Guild['members'],
     // Plain arrow function - we don't need to spy on valueOf()
     valueOf: () => id,
   };
@@ -175,6 +181,14 @@ export function createMockTextChannel(
     isThread: vi.fn(() => false),
     // @ts-expect-error - Type predicates cannot be replicated by vi.fn(). Runtime behavior is correct.
     isTextBased: vi.fn(() => true),
+    // @ts-expect-error - Type predicates cannot be replicated by vi.fn(). Runtime behavior is correct.
+    isDMBased: vi.fn(() => false),
+    // Security-check default: permissionsFor returns a permissive stub so that
+    // LinkExtractor.verifyInvokerCanAccessSource passes by default. Security-
+    // specific tests override this to deny.
+    permissionsFor: vi.fn(() => ({
+      has: vi.fn(() => true),
+    })) as unknown as TextChannel['permissionsFor'],
     send: vi.fn().mockResolvedValue(null),
     // Plain arrow functions - we don't need to spy on these
     toString: () => `<#${id}>`,


### PR DESCRIPTION
## Summary

**Item A of the beta.98 bundle.** Live production data-leak vector flagged during Phase 2 of the Identity & Provisioning Hardening epic, triaged by MCP council (Gemini 3.1 Pro Preview) as highest-priority for the beta.98 release.

## The bug

\`LinkExtractor.fetchMessageFromLink()\` used the bot's own Discord credentials to fetch messages referenced by users. It verified the BOT had access but never checked the invoking USER had access. A user could paste a link to a private channel the bot is in (e.g., \`#staff\`) into a public conversation, and the bot would expand the private content into the AI reply the victim user then reads.

## The fix

\`verifyInvokerCanAccessSource\` performs a full decision tree before \`messages.fetch\`:

| Source channel type | Check | Rationale |
|---|---|---|
| DM | Invoker is the DM recipient | Bots can't be in Group DMs (Discord restriction), so 1-on-1 is the only shape. Preserves the legitimate "reference my own DM with the bot elsewhere" case. |
| Guild | Fetch invoker's member record for SOURCE guild (may differ from where they're invoking from). Check \`permissionsFor(member).has(ViewChannel, ReadMessageHistory)\`. | Prevents the classic exploit: bot in private guild Y, attacker pastes guild-Y link in guild X where they lack guild-Y membership. |
| Private thread (type 12) | Additionally verify thread membership via \`thread.members.fetch(invokerId)\` | Parent \`ViewChannel\` is not enough for private threads; access is a distinct member list. |
| Fail closed | Any null/undefined return, any fetch rejection, any uncaught error | Defense in depth: never default-allow. |

## Traps avoided (council-flagged)

1. **Cross-guild trap**: \`invokingMember\` is guild-scoped. A naive \`channel.permissionsFor(invokingMember)\` where channel is in a different guild would throw or return null. Fix: fetch member for SOURCE guild.
2. **DM trap**: \`permissionsFor()\` has different semantics for DM channels (no roles). Fix: \`channel.isDMBased()\` early-return with a participant check.
3. **Thread trap**: private thread membership is orthogonal to parent \`ViewChannel\`. Fix: dedicated thread-member fetch after the base check.
4. **Fail closed**: any defensive path defaults to deny. Never default-allow on null/undefined.

## Preserves legitimate use cases

- You DM the bot → reference that DM message elsewhere (your own conversation). ✅ Still works.
- You're in a public server, paste a link to another public channel you can see. ✅ Still works.
- You're in a public thread you can access. ✅ Still works.

## Test plan

- [x] 9 new test cases covering the full decision tree
- [x] 3 existing tests updated with permissive mock defaults
- [x] Shared \`createMockGuild\` / \`createMockTextChannel\` factories gain permissive defaults so unrelated tests don't break
- [x] \`pnpm test\` — all 4227 bot-client tests pass
- [x] \`pnpm quality\` — lint, typecheck, depcruise all green
- [ ] Railway CI green

## Follow-up

Items B (AbortError retry amplifier) and C (periods in @mentions) shipping as separate PRs in the beta.98 bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)