### PR TITLE
fix(ai-worker): media-not-found regex matches actual prod error variants

### DIFF
--- a/services/ai-worker/src/utils/apiErrorParser.test.ts
+++ b/services/ai-worker/src/utils/apiErrorParser.test.ts
@@ -241,6 +241,52 @@ describe('parseApiError', () => {
       expect(result.category).toBe(ApiErrorCategory.MEDIA_NOT_FOUND);
       expect(result.shouldRetry).toBe(false);
     });
+
+    it('should classify the actual prod OpenRouter variant "400 Received 404 status code when fetching image from URL"', () => {
+      // Verified prod log sample (Railway 2026-04-14). Google AI Studio via
+      // OpenRouter wraps media-fetch 404s with extra phrasing ("status code",
+      // "image from") that the original minimal regex failed to match —
+      // this test locks in the fix for that prod miss.
+      const error = new Error(
+        '400 Received 404 status code when fetching image from URL: https://i.redd.it/ks0yn4k5ed6f1.jpeg'
+      );
+      const result = parseApiError(error);
+      expect(result.category).toBe(ApiErrorCategory.MEDIA_NOT_FOUND);
+      expect(result.type).toBe(ApiErrorType.PERMANENT);
+      expect(result.shouldRetry).toBe(false);
+    });
+
+    it('should classify OpenRouter variant with "status code" but without "image from"', () => {
+      const error = new Error(
+        '400 Received 404 status code when fetching URL: https://cdn.discordapp.com/attachments/123/456/image.png'
+      );
+      const result = parseApiError(error);
+      expect(result.category).toBe(ApiErrorCategory.MEDIA_NOT_FOUND);
+      expect(result.shouldRetry).toBe(false);
+    });
+
+    it('should classify variant with "image from" but without "status code"', () => {
+      const error = new Error(
+        'Received 404 when fetching image from URL https://example.com/photo.jpg'
+      );
+      const result = parseApiError(error);
+      expect(result.category).toBe(ApiErrorCategory.MEDIA_NOT_FOUND);
+      expect(result.shouldRetry).toBe(false);
+    });
+
+    it('should NOT match loosely-related "404" and "fetching URL" across distant parts of a message', () => {
+      // Defensive: the regex limits distance between anchors to prevent
+      // false positives on longer messages that mention both "404" and
+      // "fetching URL" in unrelated contexts. The bounded .{0,40}? / .{0,30}?
+      // quantifiers restrict matching to a single error-message span.
+      const error = new Error(
+        'Received 404 from upstream validation service. Separately, a retry fetching the secondary URL succeeded eventually after many attempts and some other long explanation.'
+      );
+      const result = parseApiError(error);
+      // Should NOT classify as MEDIA_NOT_FOUND — the 404 is about validation,
+      // not about fetching a URL.
+      expect(result.category).not.toBe(ApiErrorCategory.MEDIA_NOT_FOUND);
+    });
   });
 
   describe('network error detection', () => {

--- a/services/ai-worker/src/utils/apiErrorParser.ts
+++ b/services/ai-worker/src/utils/apiErrorParser.ts
@@ -207,10 +207,22 @@ function detectSpecialCases(error: unknown): ApiErrorCategory | null {
     if (error.name === 'AbortError' || /request was aborted/i.test(error.message)) {
       return ApiErrorCategory.TIMEOUT;
     }
-    // OpenRouter/vision API wrap media-fetch 404s inside a 400 response body
-    // (e.g., "400 Received 404 when fetching URL"). Must catch before status
-    // extraction so the wrapping 400 doesn't classify this as retryable BAD_REQUEST.
-    if (/received 404 when fetching url/i.test(error.message)) {
+    // OpenRouter/vision API wrap media-fetch 404s inside a 400 response body.
+    // Must catch before status extraction so the wrapping 400 doesn't classify
+    // this as retryable BAD_REQUEST.
+    //
+    // Observed prod variants (verified from Railway logs 2026-04-14+):
+    //   "400 Received 404 when fetching URL"                        ← minimal
+    //   "400 Received 404 status code when fetching URL"            ← OpenRouter variant
+    //   "400 Received 404 status code when fetching image from URL" ← Google AI Studio variant
+    //   "400 Received 404 when fetching image from URL"             ← plausible variant
+    //
+    // The regex allows up to ~40 chars between "received 404" and "fetching",
+    // and up to ~30 chars between "fetching" and "url", using non-greedy
+    // matching to restrict to a single error-message span. This covers every
+    // observed variant without matching loosely-related content across
+    // different parts of a longer error message.
+    if (/received 404.{0,40}?fetching.{0,30}?url/i.test(error.message)) {
       return ApiErrorCategory.MEDIA_NOT_FOUND;
     }
   }


### PR DESCRIPTION
## Summary

**Item B of the beta.98 bundle** — reframed from "AbortError retry amplifier" to a targeted regex fix after verifying that PR #802 (beta.97) already shipped the bulk of Item B's original scope.

## What PR #802 already shipped (verified via commit `a1e2825f1`)

- ✅ AbortError → `TIMEOUT` classification (`apiErrorParser.ts:207`)
- ✅ Vision retry cap 3 → 2 (`VISION_MAX_ATTEMPTS = 2`)
- ✅ Per-attempt success telemetry (`retry.ts:304-310`)
- ✅ `MEDIA_NOT_FOUND` category + `permanent` negative-cache flag

## The remaining bug — MEDIA_NOT_FOUND regex too strict

`detectSpecialCases` used `/received 404 when fetching url/i`. That regex matches the minimal form but fails on actual prod variants observed in Railway logs 2026-04-14:

| Variant | Source | Regex before | After |
|---|---|---|---|
| `"Received 404 when fetching URL"` | Minimal/test | ✓ match | ✓ match |
| `"400 Received 404 status code when fetching URL"` | OpenRouter | ✗ miss | ✓ match |
| `"400 Received 404 status code when fetching image from URL"` | Google AI Studio | ✗ miss | ✓ match |
| `"Received 404 when fetching image from URL"` | Plausible | ✗ miss | ✓ match |

Extra words (`status code`, `image from`) between the regex's literal anchor points broke matching. The actual prod 7% of vision failures falling through to retryable BAD_REQUEST were the variants the regex missed — they kept hitting retry cycles despite being permanent 404s.

## Fix

Relaxed to `/received 404.{0,40}?fetching.{0,30}?url/i` — non-greedy bounded quantifiers cover every observed variant while restricting matches to a single error-message span. Added a defensive negative test (400 mentioning "404" in one clause and "fetching URL" in a distant clause) to verify the bounds prevent false positives.

## Test plan

- [x] +4 new test cases (3 positive variants + 1 negative regex-bounds test)
- [x] All 56 apiErrorParser tests pass (was 52)
- [x] `pnpm test` — full suite green
- [x] `pnpm quality` — lint + typecheck + depcruise green
- [ ] Railway CI green
- [ ] Post-deploy: validate in prod logs that `MEDIA_NOT_FOUND` classification rate increases (`pnpm ops logs --service ai-worker --env prod --filter "@level:info errorCategory:media_not_found"`) and that the 7% 400-on-dead-URL class drops proportionally

## Reframe note on Item B scope

The BACKLOG entry for Item B was authored 2026-04-13 (pre-PR #802) and assumed the AbortError classification was still missing. Verifying actual code state (per the `feedback_verify_reviewer_claims` memory saved earlier this session) showed most of the original scope was already shipped. Item B reduces to this single regex bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)