### PR TITLE
fix(bot-client): match personality names with abbreviation periods

### DIFF
--- a/services/bot-client/src/utils/personalityMentionParser.test.ts
+++ b/services/bot-client/src/utils/personalityMentionParser.test.ts
@@ -29,6 +29,8 @@ describe('personalityMentionParser', () => {
       { name: 'Administrator', displayName: 'Administrator', systemPrompt: 'Test prompt' },
       { name: 'Angel Dust', displayName: 'Angel Dust', systemPrompt: 'Test prompt' },
       { name: "O'Reilly", displayName: "O'Reilly", systemPrompt: 'Test prompt' },
+      { name: 'Dr. Gregory House', displayName: 'Dr. Gregory House', systemPrompt: 'Test prompt' },
+      { name: 'J.R.R. Tolkien', displayName: 'J.R.R. Tolkien', systemPrompt: 'Test prompt' },
     ]);
   });
 
@@ -146,6 +148,97 @@ describe('personalityMentionParser', () => {
       expect(result).not.toBeNull();
       expect(result?.personalityName).toBe('Bambi Prime');
       expect(result?.cleanContent).toBe('strategy is interesting');
+    });
+  });
+
+  describe('Names with periods (abbreviations)', () => {
+    // User-reported bug (beta.97): "Dr. Gregory House" couldn't be matched
+    // because the per-word trailing-punctuation strip removed the period
+    // from "Dr." before generating candidates, so only "Dr Gregory House"
+    // (no period) was tried — which didn't match any personality.
+    // Fix: two-pass per-word punctuation strip (full vs. period-preserving),
+    // so both "Dr. Gregory House" and "Dr Gregory House" become candidates.
+
+    it('should match personality names containing abbreviation periods', async () => {
+      const result = await findPersonalityMention(
+        '@Dr. Gregory House how are you?',
+        '@',
+        mockPersonalityService,
+        TEST_USER_ID
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.personalityName).toBe('Dr. Gregory House');
+      expect(result?.cleanContent).toBe('how are you?');
+    });
+
+    it('should match period-name followed by sentence-ending period', async () => {
+      // Trailing period here is sentence-ending, not part of "House"
+      const result = await findPersonalityMention(
+        '@Dr. Gregory House.',
+        '@',
+        mockPersonalityService,
+        TEST_USER_ID
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.personalityName).toBe('Dr. Gregory House');
+      expect(result?.cleanContent).toBe('');
+    });
+
+    it('should match period-name followed by other punctuation', async () => {
+      const result = await findPersonalityMention(
+        '@Dr. Gregory House, what do you think?',
+        '@',
+        mockPersonalityService,
+        TEST_USER_ID
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.personalityName).toBe('Dr. Gregory House');
+      expect(result?.cleanContent).toBe('what do you think?');
+    });
+
+    it('should match personality names with multiple abbreviation periods', async () => {
+      const result = await findPersonalityMention(
+        '@J.R.R. Tolkien wrote fantasy novels',
+        '@',
+        mockPersonalityService,
+        TEST_USER_ID
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.personalityName).toBe('J.R.R. Tolkien');
+      expect(result?.cleanContent).toBe('wrote fantasy novels');
+    });
+
+    it('should match possessive form of period-containing name', async () => {
+      const result = await findPersonalityMention(
+        "@Dr. Gregory House's diagnosis was correct",
+        '@',
+        mockPersonalityService,
+        TEST_USER_ID
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.personalityName).toBe('Dr. Gregory House');
+      expect(result?.cleanContent).toBe('diagnosis was correct');
+    });
+
+    it('should still match simple names without periods (no regression)', async () => {
+      // Regression guard: the new period-preserving pass MUST NOT break the
+      // common case of a name without periods followed by sentence-ending
+      // punctuation.
+      const result = await findPersonalityMention(
+        '@Lilith.',
+        '@',
+        mockPersonalityService,
+        TEST_USER_ID
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.personalityName).toBe('Lilith');
+      expect(result?.cleanContent).toBe('');
     });
   });
 

--- a/services/bot-client/src/utils/personalityMentionParser.ts
+++ b/services/bot-client/src/utils/personalityMentionParser.ts
@@ -20,10 +20,12 @@ const MAX_POTENTIAL_MENTIONS = 10; // Security: Prevent resource exhaustion from
 const POSSESSIVE_SUFFIX = /'s$/i;
 
 /**
- * Strip trailing punctuation from a word — full-strip variant.
- * Matches `trailingPunctuationRegex` used at the message level; used when
- * we assume the trailing period etc. is sentence-ending punctuation, not
- * part of the name ("Hey @Lilith." → "Lilith").
+ * Strip trailing punctuation from a word — full-strip variant. Strips sentence
+ * punctuation (".", "!", "?"), list punctuation (",", ";", ":"), quotes, and
+ * Discord markdown chars (`*_~|`). Used when the trailing period is treated
+ * as sentence-ending punctuation, not part of the name ("Hey @Lilith." →
+ * "Lilith"). Also the regex passed to {@link extractPotentialMentions} for
+ * cleaning the full matched text at the message-spanning level.
  */
 const WORD_PUNCTUATION_STRIP_ALL = /[.,!?;:)"'*_~|]+$/;
 
@@ -101,15 +103,13 @@ export async function findPersonalityMention(
 
   const escapedChar = mentionChar.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const mentionCharRegex = new RegExp(`^${escapedChar}`);
-  // Discord markdown chars (*_~|) plus standard punctuation - used to strip after extraction
-  const trailingPunctuationRegex = /[.,!?;:)"'*_~|]+$/; // No 'g' flag needed - replace() doesn't use lastIndex
 
   // Step 1: Extract all potential personality names from the message
   const potentialMentions = extractPotentialMentions(
     content,
     escapedChar,
     mentionCharRegex,
-    trailingPunctuationRegex
+    WORD_PUNCTUATION_STRIP_ALL
   );
 
   if (potentialMentions.length === 0) {
@@ -187,6 +187,37 @@ export async function findPersonalityMention(
 }
 
 /**
+ * Add name candidates to the deduplication map, including the possessive-stripped
+ * variant. Extracted to flatten nesting depth in the multi-word extraction loop
+ * (multi-word match × word-count × candidate × possessive = 4 levels deep
+ * inline). Accepts both the full-strip and period-preserving candidate forms
+ * for the two-pass approach.
+ */
+function addMultiWordCandidates(
+  map: Map<string, number>,
+  stripped: string,
+  withPeriod: string,
+  wordCount: number
+): void {
+  // Deduplicate the two variants before storage (often identical for
+  // period-free names like "Bambi Prime").
+  const candidates = stripped === withPeriod ? [stripped] : [stripped, withPeriod];
+
+  for (const name of candidates) {
+    if (!name) {
+      continue;
+    }
+    if (!map.has(name)) {
+      map.set(name, wordCount);
+    }
+    const withoutPossessive = name.replace(POSSESSIVE_SUFFIX, '');
+    if (withoutPossessive !== name && !map.has(withoutPossessive)) {
+      map.set(withoutPossessive, wordCount);
+    }
+  }
+}
+
+/**
  * Extract all potential personality mentions from message content
  *
  * This function performs a two-pass extraction to find both multi-word and single-word
@@ -218,37 +249,6 @@ export async function findPersonalityMention(
  * @param trailingPunctuationRegex - Regex to remove trailing punctuation
  * @returns Array of unique potential mentions with their word counts
  */
-/**
- * Add name candidates to the deduplication map, including the possessive-stripped
- * variant. Extracted to flatten nesting depth in the multi-word extraction loop
- * (multi-word match × word-count × candidate × possessive = 4 levels deep
- * inline). Accepts both the full-strip and period-preserving candidate forms
- * for the two-pass approach.
- */
-function addMultiWordCandidates(
-  map: Map<string, number>,
-  stripped: string,
-  withPeriod: string,
-  wordCount: number
-): void {
-  // Deduplicate the two variants before storage (often identical for
-  // period-free names like "Bambi Prime").
-  const candidates = stripped === withPeriod ? [stripped] : [stripped, withPeriod];
-
-  for (const name of candidates) {
-    if (!name) {
-      continue;
-    }
-    if (!map.has(name)) {
-      map.set(name, wordCount);
-    }
-    const withoutPossessive = name.replace(POSSESSIVE_SUFFIX, '');
-    if (withoutPossessive !== name && !map.has(withoutPossessive)) {
-      map.set(withoutPossessive, wordCount);
-    }
-  }
-}
-
 // eslint-disable-next-line sonarjs/cognitive-complexity -- Extracts multi-word and single-word mentions with deduplication, escape handling, and punctuation stripping
 function extractPotentialMentions(
   content: string,

--- a/services/bot-client/src/utils/personalityMentionParser.ts
+++ b/services/bot-client/src/utils/personalityMentionParser.ts
@@ -19,6 +19,26 @@ const MAX_POTENTIAL_MENTIONS = 10; // Security: Prevent resource exhaustion from
 /** Strip possessive suffix ('s) from a name candidate to also try the base form */
 const POSSESSIVE_SUFFIX = /'s$/i;
 
+/**
+ * Strip trailing punctuation from a word — full-strip variant.
+ * Matches `trailingPunctuationRegex` used at the message level; used when
+ * we assume the trailing period etc. is sentence-ending punctuation, not
+ * part of the name ("Hey @Lilith." → "Lilith").
+ */
+const WORD_PUNCTUATION_STRIP_ALL = /[.,!?;:)"'*_~|]+$/;
+
+/**
+ * Strip trailing punctuation from a word — period-preserving variant.
+ * Used to generate alternate candidates when the trailing period might be
+ * semantically part of the name ("@Dr. Gregory House" → "Dr." is preserved
+ * as a candidate prefix, so "Dr. Gregory House" can match). Personalities
+ * with abbreviation-style names ("Dr.", "J.R.R. Tolkien") can't be matched
+ * without this variant. Two-pass approach: try with period → on miss,
+ * fall back to the full-strip version. Both variants feed into the Map,
+ * so lookups resolve whichever actually exists.
+ */
+const WORD_PUNCTUATION_STRIP_NON_PERIOD = /[,!?;:)"'*_~|]+$/;
+
 interface PersonalityMentionResult {
   personalityName: string;
   cleanContent: string;
@@ -198,6 +218,37 @@ export async function findPersonalityMention(
  * @param trailingPunctuationRegex - Regex to remove trailing punctuation
  * @returns Array of unique potential mentions with their word counts
  */
+/**
+ * Add name candidates to the deduplication map, including the possessive-stripped
+ * variant. Extracted to flatten nesting depth in the multi-word extraction loop
+ * (multi-word match × word-count × candidate × possessive = 4 levels deep
+ * inline). Accepts both the full-strip and period-preserving candidate forms
+ * for the two-pass approach.
+ */
+function addMultiWordCandidates(
+  map: Map<string, number>,
+  stripped: string,
+  withPeriod: string,
+  wordCount: number
+): void {
+  // Deduplicate the two variants before storage (often identical for
+  // period-free names like "Bambi Prime").
+  const candidates = stripped === withPeriod ? [stripped] : [stripped, withPeriod];
+
+  for (const name of candidates) {
+    if (!name) {
+      continue;
+    }
+    if (!map.has(name)) {
+      map.set(name, wordCount);
+    }
+    const withoutPossessive = name.replace(POSSESSIVE_SUFFIX, '');
+    if (withoutPossessive !== name && !map.has(withoutPossessive)) {
+      map.set(withoutPossessive, wordCount);
+    }
+  }
+}
+
 // eslint-disable-next-line sonarjs/cognitive-complexity -- Extracts multi-word and single-word mentions with deduplication, escape handling, and punctuation stripping
 function extractPotentialMentions(
   content: string,
@@ -222,29 +273,30 @@ function extractPotentialMentions(
         .replace(mentionCharRegex, '') // Remove mention char
         .replace(trailingPunctuationRegex, ''); // Remove trailing punctuation
 
-      // Split into words and remove punctuation from each
-      const words = capturedText
-        .split(/\s+/)
-        .map(word => word.replace(trailingPunctuationRegex, ''));
+      // Split into words and produce TWO variants per word (two-pass approach):
+      // - `words`: full strip — handles "Hey @Lilith." sentence-ending periods
+      // - `wordsWithPeriods`: preserves trailing periods — handles abbreviation
+      //   names like "Dr." in "@Dr. Gregory House". User-reported: "Dr. Gregory
+      //   House" couldn't be matched because the per-word strip removed the
+      //   period from "Dr." before generating candidates, so only
+      //   "Dr Gregory House" (no period) was tried. Both variants feed into
+      //   the Map and the lookup succeeds for whichever matches an actual
+      //   personality name; deduplication prevents candidate explosion.
+      const rawWords = capturedText.split(/\s+/);
+      const words = rawWords.map(word => word.replace(WORD_PUNCTUATION_STRIP_ALL, ''));
+      const wordsWithPeriods = rawWords.map(word =>
+        word.replace(WORD_PUNCTUATION_STRIP_NON_PERIOD, '')
+      );
 
-      // Try combinations from longest to shortest for this match
+      // Try combinations from longest to shortest for this match, using both
+      // per-word variants so abbreviation-style names are discoverable.
       for (let wordCount = Math.min(MAX_MENTION_WORDS, words.length); wordCount >= 1; wordCount--) {
-        const potentialName = words.slice(0, wordCount).join(' ').trim();
-
-        if (!potentialName) {
-          continue;
-        }
-
-        // Store if we haven't seen this name yet
-        if (!potentialMentions.has(potentialName)) {
-          potentialMentions.set(potentialName, wordCount);
-        }
-
-        // Also try without possessive suffix: @Bambi Prime's → Bambi Prime
-        const withoutPossessive = potentialName.replace(POSSESSIVE_SUFFIX, '');
-        if (withoutPossessive !== potentialName && !potentialMentions.has(withoutPossessive)) {
-          potentialMentions.set(withoutPossessive, wordCount);
-        }
+        addMultiWordCandidates(
+          potentialMentions,
+          words.slice(0, wordCount).join(' ').trim(),
+          wordsWithPeriods.slice(0, wordCount).join(' ').trim(),
+          wordCount
+        );
       }
     }
   }


### PR DESCRIPTION
## Summary

**Item C of the beta.98 bundle** — the cool-down dopamine-hit task. User-reported bug: personalities with abbreviation-style names like \"Dr. Gregory House\" couldn't be matched via @mention. User worked around by renaming the character.

## The bug

\`extractPotentialMentions\` in \`personalityMentionParser.ts\` applied the per-word trailing-punctuation regex \`/[.,!?;:)\"'*_~|]+$/\` to strip punctuation from each word during multi-word candidate generation. For \"@Dr. Gregory House\":

- `rawWords = [\"Dr.\", \"Gregory\", \"House\"]`
- After strip: `[\"Dr\", \"Gregory\", \"House\"]` ← period lost
- Candidate generated: `\"Dr Gregory House\"` ← didn't match stored \"Dr. Gregory House\"

Apostrophes were fixed in PR #797 via a two-pass approach. Periods got missed.

## The fix

Split the per-word punctuation strip into two variants and generate candidates from both:

| Constant | Pattern | Use |
|---|---|---|
| `WORD_PUNCTUATION_STRIP_ALL` (existing) | `/[.,!?;:)\"'*_~|]+$/` | Sentence-ending periods (\"Hey @Lilith.\") |
| `WORD_PUNCTUATION_STRIP_NON_PERIOD` (new) | `/[,!?;:)\"'*_~|]+$/` | Preserve trailing periods in abbreviation names |

Both feed into the deduplication Map, so whichever actually matches a stored personality name wins. Dedup prevents candidate explosion (stripped and preserved are identical for period-free names).

Extracted \`addMultiWordCandidates\` helper to flatten nesting — the added candidate-variants loop would otherwise exceed the max-depth=4 lint limit.

## Tests

6 new cases:
- Abbreviation-period name with trailing text: \"@Dr. Gregory House how are you?\"
- Same + trailing sentence period: \"@Dr. Gregory House.\"
- Same + trailing comma: \"@Dr. Gregory House, what do you think?\"
- Multi-period name: \"@J.R.R. Tolkien wrote fantasy novels\"
- Possessive form: \"@Dr. Gregory House's diagnosis was correct\"
- Regression guard: simple name + sentence-ending period (\"@Lilith.\") still matches \"Lilith\"

## Test plan

- [x] +6 new test cases covering the bug and adjacent cases
- [x] All 37 personalityMentionParser tests pass (was 31)
- [x] \`pnpm test\` — full suite green
- [x] \`pnpm quality\` — lint + typecheck + depcruise green
- [ ] Railway CI green
- [ ] Post-merge: user can restore \"Dr. Gregory House\" as the character name and the mention will work

## Bundle status

With this merged, all three items of the beta.98 bundle are done:
- ✅ **A**: cross-channel permission leak (PR #809)
- ✅ **B**: MEDIA_NOT_FOUND regex fix (PR #810)
- ✅ **C**: periods in @mentions (this PR)

Ready to cut beta.98 release once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)