### PR TITLE
refactor(common-types): Phase 3 — make PersonaResolver read-only

### DIFF
--- a/packages/common-types/src/services/resolvers/PersonaResolver.test.ts
+++ b/packages/common-types/src/services/resolvers/PersonaResolver.test.ts
@@ -3,8 +3,9 @@
  *
  * Tests the cascading configuration pattern for persona resolution:
  * 1. Per-personality override (UserPersonalityConfig.personaId)
- * 2. User's default persona (User.defaultPersonaId)
- * 3. Auto-default to first owned persona (lazy initialization)
+ * 2. User's explicit default (User.defaultPersonaId)
+ * 3. Transient first-owned-persona fallback (warns, no persist)
+ * 4. System default (errors, user has no personas at all)
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -24,13 +25,19 @@ const mockPrismaClient = {
   },
 };
 
-vi.mock('../../utils/logger.js', () => ({
-  createLogger: () => ({
+// Shared logger mock — hoisted so `vi.mock` factory (hoisted too) can close over
+// it and tests can still assert on which level fired.
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: {
     debug: vi.fn(),
     info: vi.fn(),
     warn: vi.fn(),
     error: vi.fn(),
-  }),
+  },
+}));
+
+vi.mock('../../utils/logger.js', () => ({
+  createLogger: () => mockLogger,
 }));
 
 describe('PersonaResolver', () => {
@@ -118,7 +125,11 @@ describe('PersonaResolver', () => {
       expect(result.config.preferredName).toBe('Default Name');
     });
 
-    it('should auto-default to first owned persona and persist it', async () => {
+    it('should return first owned persona as transient resolution without persisting', async () => {
+      // Phase 3 regression guard: resolution is strictly read-only. When a user
+      // has owned personas but no defaultPersonaId, we pick the first-owned
+      // persona for this request only. Persistence is UserService's job (via
+      // runMaintenanceTasks → backfillDefaultPersona on the next interaction).
       mockPrismaClient.user.findUnique.mockResolvedValue({
         id: 'user-uuid',
         defaultPersonaId: null,
@@ -134,22 +145,65 @@ describe('PersonaResolver', () => {
       });
 
       mockPrismaClient.userPersonalityConfig.findFirst.mockResolvedValue(null);
-      mockPrismaClient.user.update.mockResolvedValue({});
 
       const result = await resolver.resolve('discord-123', 'personality-456');
 
       expect(result.source).toBe('user-default');
-      expect(result.sourceName).toBe('auto-default');
+      expect(result.sourceName).toBe('transient-first-owned');
       expect(result.config.personaId).toBe('first-owned-persona');
 
-      // Should persist the auto-default
-      expect(mockPrismaClient.user.update).toHaveBeenCalledWith({
-        where: { id: 'user-uuid' },
-        data: { defaultPersonaId: 'first-owned-persona' },
-      });
+      // Must NOT persist. No Prisma writes from the read path.
+      expect(mockPrismaClient.user.update).not.toHaveBeenCalled();
+
+      // Must warn so the transient state is visible in production logs.
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          discordUserId: 'discord-123',
+          userId: 'user-uuid',
+          selectedPersonaId: 'first-owned-persona',
+          ownedPersonaCount: 1,
+        }),
+        expect.stringContaining('Transient resolution')
+      );
     });
 
-    it('should return system default when user has no personas at all', async () => {
+    it('should log error and fall through when defaultPersonaId is dangling', async () => {
+      // Schema has onDelete: SetNull, so this shouldn't happen — but we guard
+      // defensively as a precursor signal for Phase 5's NOT NULL FK upgrade.
+      mockPrismaClient.user.findUnique.mockResolvedValue({
+        id: 'user-uuid',
+        defaultPersonaId: 'persona-that-was-deleted',
+        defaultPersona: null, // relation returns null when referenced row is gone
+        ownedPersonas: [
+          {
+            id: 'fallback-persona',
+            preferredName: 'Fallback',
+            pronouns: null,
+            content: 'Fallback content',
+          },
+        ],
+      });
+
+      mockPrismaClient.userPersonalityConfig.findFirst.mockResolvedValue(null);
+
+      const result = await resolver.resolve('discord-123', 'personality-456');
+
+      // Falls through to owned-persona resolution so the request succeeds.
+      expect(result.config.personaId).toBe('fallback-persona');
+      expect(result.sourceName).toBe('transient-first-owned');
+
+      // Dangling reference must be error-logged as a data-integrity signal.
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          discordUserId: 'discord-123',
+          userId: 'user-uuid',
+          defaultPersonaId: 'persona-that-was-deleted',
+        }),
+        expect.stringContaining('Dangling defaultPersonaId')
+      );
+    });
+
+    it('should return system default and log error when user has no personas at all', async () => {
       mockPrismaClient.user.findUnique.mockResolvedValue({
         id: 'user-uuid',
         defaultPersonaId: null,
@@ -163,6 +217,16 @@ describe('PersonaResolver', () => {
 
       expect(result.source).toBe('system-default');
       expect(result.config.personaId).toBe('');
+
+      // Post-Phase-2, every user should have at least one persona. Log at error
+      // level so provisioning bugs surface loudly in logs.
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          discordUserId: 'discord-123',
+          userId: 'user-uuid',
+        }),
+        expect.stringContaining('User has no personas')
+      );
     });
 
     it('should resolve without personalityId (default persona only)', async () => {
@@ -564,32 +628,11 @@ describe('PersonaResolver', () => {
     });
   });
 
-  describe('auto-default persistence error handling', () => {
-    it('should still return persona even if persist fails', async () => {
-      mockPrismaClient.user.findUnique.mockResolvedValue({
-        id: 'user-uuid',
-        defaultPersonaId: null,
-        defaultPersona: null,
-        ownedPersonas: [
-          {
-            id: 'first-owned-persona',
-            preferredName: 'First',
-            pronouns: null,
-            content: '',
-          },
-        ],
-      });
-
-      mockPrismaClient.userPersonalityConfig.findFirst.mockResolvedValue(null);
-      mockPrismaClient.user.update.mockRejectedValue(new Error('Update failed'));
-
-      const result = await resolver.resolve('discord-123', 'personality-456');
-
-      // Should still return the persona even if persist failed
-      expect(result.config.personaId).toBe('first-owned-persona');
-      expect(result.source).toBe('user-default');
-    });
-  });
+  // Note: the "auto-default persistence error handling" describe block was
+  // removed in the Phase 3 refactor. Persistence is no longer part of the
+  // resolve() path, so there's no write-failure mode to test here. Provisioning
+  // tests live in UserService.test.ts (createUserWithDefaultPersona +
+  // backfillDefaultPersona).
 
   describe('cache management', () => {
     it('should clear all cache entries', async () => {

--- a/packages/common-types/src/services/resolvers/PersonaResolver.ts
+++ b/packages/common-types/src/services/resolvers/PersonaResolver.ts
@@ -4,14 +4,26 @@
  * Implements the "Switch" strategy: returns the entire persona object,
  * no field-level merging with defaults.
  *
+ * Resolution is strictly READ-ONLY. Provisioning is the exclusive responsibility
+ * of `UserService.getOrCreateUser` → `runMaintenanceTasks` → `backfillDefaultPersona`.
+ * This resolver never writes; it picks the best persona it can for the current
+ * request and returns it.
+ *
  * Resolution hierarchy:
  * 1. Per-personality override (UserPersonalityConfig.personaId)
- * 2. User's default persona (User.defaultPersonaId)
- * 3. Auto-default: First owned persona (lazy initialization - persists the default)
+ * 2. User's explicit default (User.defaultPersonaId)
+ * 3. Transient first-owned-persona fallback (warns, does NOT persist)
+ * 4. System default (errors, user has no personas at all)
  *
- * The auto-default feature ensures users always have a persona without
- * requiring explicit setup. On first resolution, if no default is set,
- * the user's first owned persona becomes their default.
+ * Prior to the Identity Epic Phase 3 (2026-04-16), the Priority 3 branch
+ * lazily persisted the first owned persona as the user's default. That lazy
+ * mutation was dropped because: (a) it made a "read" path mutate state,
+ * (b) errors were swallowed as "best-effort optimization" and became
+ * invisible, (c) UserService already provisions `defaultPersonaId` atomically
+ * at creation time (Phase 2), so the lazy-init code path is a transitional
+ * compatibility shim rather than load-bearing logic. Transient resolution
+ * warns loudly so persistent orphaned users are visible in logs; the next
+ * `getOrCreateUser` call heals them via `backfillDefaultPersona`.
  */
 
 import { createLogger } from '../../utils/logger.js';
@@ -196,37 +208,9 @@ export class PersonaResolver extends BaseConfigResolver<ResolvedPersona> {
     }
 
     // Priority 1: Per-personality override (separate query for cleaner typing)
-    if (personalityId !== undefined && personalityId !== '') {
-      const personaOverride = await this.prisma.userPersonalityConfig.findFirst({
-        where: {
-          userId: user.id,
-          personalityId,
-          personaId: { not: null },
-        },
-        select: {
-          persona: {
-            select: {
-              id: true,
-              name: true,
-              preferredName: true,
-              pronouns: true,
-              content: true,
-            },
-          },
-        },
-      });
-
-      if (personaOverride?.persona) {
-        logger.debug(
-          { discordUserId, personalityId, personaId: personaOverride.persona.id },
-          'Using personality-specific persona override'
-        );
-        return {
-          config: this.mapToResolvedPersona(personaOverride.persona),
-          source: 'context-override',
-          sourceName: `override:${personalityId}`,
-        };
-      }
+    const override = await this.loadPersonalityOverride(user.id, discordUserId, personalityId);
+    if (override !== null) {
+      return override;
     }
 
     // Priority 2: User's explicit default
@@ -238,46 +222,93 @@ export class PersonaResolver extends BaseConfigResolver<ResolvedPersona> {
       };
     }
 
-    // Priority 3: Auto-default - use first owned persona and persist it
+    // Data-integrity check: defaultPersonaId is set but the persona row is missing.
+    // Schema has onDelete: SetNull on User.defaultPersona, so this *shouldn't* happen —
+    // log an error as a precursor signal for Phase 5's NOT NULL FK upgrade. We still
+    // fall through to owned-persona resolution so the request succeeds.
+    if (user.defaultPersonaId !== null) {
+      logger.error(
+        { discordUserId, userId: user.id, defaultPersonaId: user.defaultPersonaId },
+        'Dangling defaultPersonaId — references a non-existent persona. Falling through to owned-persona resolution.'
+      );
+    }
+
+    // Priority 3: User has owned personas but no usable defaultPersona.
+    // Transient resolution — pick the first owned persona without persisting.
+    // Provisioning is UserService's job; the next getOrCreateUser call will
+    // run runMaintenanceTasks → backfillDefaultPersona and heal the user row.
     if (user.ownedPersonas.length > 0) {
       const firstPersona = user.ownedPersonas[0];
-
-      // Persist as default for future lookups (lazy initialization)
-      await this.setUserDefault(user.id, firstPersona.id);
-
-      logger.debug(
-        { discordUserId, personaId: firstPersona.id },
-        'Auto-defaulted to first owned persona'
+      logger.warn(
+        {
+          discordUserId,
+          userId: user.id,
+          selectedPersonaId: firstPersona.id,
+          ownedPersonaCount: user.ownedPersonas.length,
+        },
+        'Transient resolution — user has owned personas but no defaultPersonaId. Will be healed on next UserService.getOrCreateUser call.'
       );
-
       return {
         config: this.mapToResolvedPersona(firstPersona),
-        source: SOURCE_USER_DEFAULT, // Treat as user-default since we just set it
-        sourceName: 'auto-default',
+        source: SOURCE_USER_DEFAULT,
+        sourceName: 'transient-first-owned',
       };
     }
 
-    // No persona at all
-    logger.warn({ discordUserId }, 'User has no personas');
+    // No persona at all — genuine data-integrity violation post-Phase-2.
+    logger.error(
+      { discordUserId, userId: user.id },
+      'User has no personas — provisioning is incomplete. Check UserService.createUserWithDefaultPersona flow.'
+    );
     return { config: this.getSystemDefault(), source: SOURCE_SYSTEM_DEFAULT };
   }
 
   /**
-   * Set user's default persona (for auto-default and explicit setting)
+   * Look up the per-personality persona override. Returns null when the user
+   * has no override for this personality (or no personalityId was provided).
+   * Extracted to keep resolveFresh under the per-function line limit.
    */
-  private async setUserDefault(internalUserId: string, personaId: string): Promise<void> {
-    try {
-      await this.prisma.user.update({
-        where: { id: internalUserId },
-        data: { defaultPersonaId: personaId },
-      });
-    } catch (error) {
-      logger.error(
-        { err: error, userId: internalUserId, personaId },
-        'Failed to set default persona'
-      );
-      // Don't throw - this is a best-effort optimization
+  private async loadPersonalityOverride(
+    userId: string,
+    discordUserId: string,
+    personalityId: string | undefined
+  ): Promise<ResolutionResult<ResolvedPersona> | null> {
+    if (personalityId === undefined || personalityId === '') {
+      return null;
     }
+
+    const personaOverride = await this.prisma.userPersonalityConfig.findFirst({
+      where: {
+        userId,
+        personalityId,
+        personaId: { not: null },
+      },
+      select: {
+        persona: {
+          select: {
+            id: true,
+            name: true,
+            preferredName: true,
+            pronouns: true,
+            content: true,
+          },
+        },
+      },
+    });
+
+    if (!personaOverride?.persona) {
+      return null;
+    }
+
+    logger.debug(
+      { discordUserId, personalityId, personaId: personaOverride.persona.id },
+      'Using personality-specific persona override'
+    );
+    return {
+      config: this.mapToResolvedPersona(personaOverride.persona),
+      source: 'context-override',
+      sourceName: `override:${personalityId}`,
+    };
   }
 
   /**

--- a/services/bot-client/src/services/contextBuilder/UserContextResolver.ts
+++ b/services/bot-client/src/services/contextBuilder/UserContextResolver.ts
@@ -89,10 +89,11 @@ export async function resolveUserContext(
   // Get internal user ID for database operations.
   //
   // `provisioned.defaultPersonaId` is available here but currently unused —
-  // PersonaResolver below re-resolves per (user, personality) combination.
-  // Phase 3 of the identity epic will eliminate `PersonaResolver.setUserDefault`'s
-  // lazy mutation side effect, at which point this caller can short-circuit
-  // the persona lookup for the user-default case using `provisioned.defaultPersonaId`.
+  // PersonaResolver below re-resolves because Priority 1 (per-personality
+  // override in UserPersonalityConfig) can't be short-circuited from the
+  // provisioned value. If we ever split "resolve override vs fall back to
+  // default" into separate calls, this is the point where the default side
+  // could skip a query.
   const provisioned = await userService.getOrCreateUser(
     user.id,
     user.username,


### PR DESCRIPTION
## Summary

Identity Epic **Phase 3** — eliminates the lazy mutation side effect in `PersonaResolver.resolveFresh`.

- Remove `await setUserDefault(...)` write from the "read" path (was on line 246)
- Replace with transient first-owned-persona resolution + `warn` log (no persist)
- Add dangling-`defaultPersonaId` error log (precursor signal for Phase 5's NOT NULL FK)
- Upgrade "no personas at all" log `warn` → `error` (genuine data-integrity violation post-Phase 2)
- Delete the unused private `setUserDefault` method
- Extract `loadPersonalityOverride` helper to keep `resolveFresh` under the 100-line limit
- Expand top-of-file JSDoc to document the read-only contract explicitly

## Why

Before this change, `PersonaResolver.resolveFresh` silently mutated state mid-resolution when a user had owned personas but no `defaultPersonaId`. It called `setUserDefault` with errors swallowed as "best-effort optimization" — making failures invisible, enabling concurrent-request write races, and conflating resolution semantics with provisioning semantics. Phase 2 already gave us a clean provisioning path (`UserService.getOrCreateUser` → atomic transaction + `runMaintenanceTasks` → `backfillDefaultPersona`); Phase 3 stops the resolver from duplicating it.

## Council pressure-test (2026-04-16)

Scope initially estimated ~3 days in the epic doc. Council reframed the problem (**"you're conflating resolution with provisioning; they should be separate operations"**) and right-sized it to ~20–60 LOC. Recommended **Option A-prime** over the originally-planned "extract `ensureDefaultPersona`":

- A-prime (this PR): delete the write entirely, return transient resolution, let UserService own provisioning
- Alternative (rejected): new `ensureDefaultPersona` on PersonaResolver — would duplicate `backfillDefaultPersona` and preserve the wrong mental model

## Empirical data

Pre-change SQL survey (dev + prod):

| Metric | Dev (before #813) | Dev (after #813) | Prod |
|---|---|---|---|
| `totalUsers` | 227 | 227 | 227 |
| `unprovisioned_hasOwnedPersonas` | 117 | 0 | 0 |
| `empty_noPersonas` | 0 | 0 | 0 |
| `dangling_defaultPersonaId` | 0 | 0 | 0 |

With dev at 0 orphans and prod at 0, the new `warn` log will fire **~0 times in steady state** — any firing after this ships is a real signal (either a new-user race or a test fixture that bypasses `UserService`).

## Observability added

Three levels of visibility for failure modes that were previously invisible:

| Log level | Condition | Interpretation |
|---|---|---|
| `warn` | `ownedPersonas > 0 && defaultPersonaId === null` | Transient — user will be healed on next `getOrCreateUser` call |
| `error` | `defaultPersonaId != null && defaultPersona === null` | Dangling FK (shouldn't happen — schema has `onDelete: SetNull`) |
| `error` | `ownedPersonas === 0 && defaultPersonaId === null` | Provisioning incomplete (`createUserWithDefaultPersona` flow broken) |

## Test plan

- [x] `pnpm test` — 4236 bot-client + 2090 common-types + all others green
- [x] `pnpm quality` — 11/11 tasks pass
- [x] New tests: transient-no-mutation, dangling-defaultPersonaId, no-personas-with-error-log
- [x] Obsolete "auto-default persistence error handling" describe block removed
- [ ] Post-merge deploy + production log check: no new `warn`/`error` firings from normal traffic

## Files

- `packages/common-types/src/services/resolvers/PersonaResolver.ts` — core change + helper extraction
- `packages/common-types/src/services/resolvers/PersonaResolver.test.ts` — three new tests, obsolete block removed, logger mock made inspectable via `vi.hoisted`
- `services/bot-client/src/services/contextBuilder/UserContextResolver.ts` — remove stale Phase-3 reference comment

## Remaining Identity Epic phases

- Phase 4 (~3 days): kill `discord:XXXX` dual-tier personaId format
- Phase 5 (~1 day + migration): DB-level FK constraint `User.defaultPersonaId → Persona.id` NOT NULL + unique `(ownerId, name)` on Persona
- Phase 6 (~2 days): integration test coverage for the refactor-regression class that caused the original bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)