### PR TITLE
fix: PR #819 review follow-ups — PersonaResolver + JobTracker

### DIFF
--- a/packages/common-types/src/services/resolvers/PersonaResolver.test.ts
+++ b/packages/common-types/src/services/resolvers/PersonaResolver.test.ts
@@ -358,7 +358,7 @@ describe('PersonaResolver', () => {
       });
     });
 
-    it('should default focusModeEnabled to false when no config exists', async () => {
+    it('should default focusModeEnabled to false when no config exists (or user missing)', async () => {
       mockPrismaClient.user.findUnique.mockResolvedValueOnce({
         id: 'user-uuid',
         defaultPersonaId: 'persona-123',

--- a/packages/common-types/src/services/resolvers/PersonaResolver.test.ts
+++ b/packages/common-types/src/services/resolvers/PersonaResolver.test.ts
@@ -417,8 +417,8 @@ describe('PersonaResolver', () => {
       });
 
       mockPrismaClient.userPersonalityConfig.findFirst
-        .mockResolvedValueOnce(null) // persona override
-        .mockRejectedValueOnce(new Error('DB error')); // focus mode check fails
+        .mockResolvedValueOnce(null) // persona override lookup
+        .mockRejectedValueOnce(new Error('DB error')); // focus mode findFirst fails
 
       const result = await resolver.resolveForMemory('discord-123', 'personality-456');
 

--- a/packages/common-types/src/services/resolvers/PersonaResolver.test.ts
+++ b/packages/common-types/src/services/resolvers/PersonaResolver.test.ts
@@ -309,20 +309,17 @@ describe('PersonaResolver', () => {
 
   describe('resolveForMemory', () => {
     it('should return lightweight memory info when persona exists', async () => {
-      mockPrismaClient.user.findUnique
-        .mockResolvedValueOnce({
-          id: 'user-uuid',
-          defaultPersonaId: 'persona-123',
-          defaultPersona: {
-            id: 'persona-123',
-            preferredName: 'Name',
-            pronouns: 'they/them',
-            content: 'Content',
-          },
-          ownedPersonas: [],
-        })
-        // Second call for focus mode check
-        .mockResolvedValueOnce({ id: 'user-uuid' });
+      mockPrismaClient.user.findUnique.mockResolvedValueOnce({
+        id: 'user-uuid',
+        defaultPersonaId: 'persona-123',
+        defaultPersona: {
+          id: 'persona-123',
+          preferredName: 'Name',
+          pronouns: 'they/them',
+          content: 'Content',
+        },
+        ownedPersonas: [],
+      });
 
       mockPrismaClient.userPersonalityConfig.findFirst
         .mockResolvedValueOnce(null) // persona override check
@@ -337,19 +334,17 @@ describe('PersonaResolver', () => {
     });
 
     it('should return focusModeEnabled true when focus mode is enabled', async () => {
-      mockPrismaClient.user.findUnique
-        .mockResolvedValueOnce({
-          id: 'user-uuid',
-          defaultPersonaId: 'persona-123',
-          defaultPersona: {
-            id: 'persona-123',
-            preferredName: 'Name',
-            pronouns: 'they/them',
-            content: 'Content',
-          },
-          ownedPersonas: [],
-        })
-        .mockResolvedValueOnce({ id: 'user-uuid' });
+      mockPrismaClient.user.findUnique.mockResolvedValueOnce({
+        id: 'user-uuid',
+        defaultPersonaId: 'persona-123',
+        defaultPersona: {
+          id: 'persona-123',
+          preferredName: 'Name',
+          pronouns: 'they/them',
+          content: 'Content',
+        },
+        ownedPersonas: [],
+      });
 
       mockPrismaClient.userPersonalityConfig.findFirst
         .mockResolvedValueOnce(null) // persona override
@@ -364,45 +359,21 @@ describe('PersonaResolver', () => {
     });
 
     it('should default focusModeEnabled to false when no config exists', async () => {
-      mockPrismaClient.user.findUnique
-        .mockResolvedValueOnce({
-          id: 'user-uuid',
-          defaultPersonaId: 'persona-123',
-          defaultPersona: {
-            id: 'persona-123',
-            preferredName: 'Name',
-            pronouns: null,
-            content: 'Content',
-          },
-          ownedPersonas: [],
-        })
-        .mockResolvedValueOnce({ id: 'user-uuid' });
+      mockPrismaClient.user.findUnique.mockResolvedValueOnce({
+        id: 'user-uuid',
+        defaultPersonaId: 'persona-123',
+        defaultPersona: {
+          id: 'persona-123',
+          preferredName: 'Name',
+          pronouns: null,
+          content: 'Content',
+        },
+        ownedPersonas: [],
+      });
 
       mockPrismaClient.userPersonalityConfig.findFirst
         .mockResolvedValueOnce(null) // persona override
-        .mockResolvedValueOnce(null); // no config for focus mode
-
-      const result = await resolver.resolveForMemory('discord-123', 'personality-456');
-
-      expect(result?.focusModeEnabled).toBe(false);
-    });
-
-    it('should default focusModeEnabled to false when user not found in focus mode check', async () => {
-      mockPrismaClient.user.findUnique
-        .mockResolvedValueOnce({
-          id: 'user-uuid',
-          defaultPersonaId: 'persona-123',
-          defaultPersona: {
-            id: 'persona-123',
-            preferredName: 'Name',
-            pronouns: null,
-            content: 'Content',
-          },
-          ownedPersonas: [],
-        })
-        .mockResolvedValueOnce(null); // user not found in focus mode check
-
-      mockPrismaClient.userPersonalityConfig.findFirst.mockResolvedValueOnce(null);
+        .mockResolvedValueOnce(null); // no config for focus mode (covers both "user missing" and "user exists but no config" — single JOIN query)
 
       const result = await resolver.resolveForMemory('discord-123', 'personality-456');
 
@@ -433,21 +404,21 @@ describe('PersonaResolver', () => {
     });
 
     it('should handle focus mode check errors gracefully', async () => {
-      mockPrismaClient.user.findUnique
-        .mockResolvedValueOnce({
-          id: 'user-uuid',
-          defaultPersonaId: 'persona-123',
-          defaultPersona: {
-            id: 'persona-123',
-            preferredName: 'Name',
-            pronouns: null,
-            content: 'Content',
-          },
-          ownedPersonas: [],
-        })
-        .mockRejectedValueOnce(new Error('DB error')); // focus mode check fails
+      mockPrismaClient.user.findUnique.mockResolvedValueOnce({
+        id: 'user-uuid',
+        defaultPersonaId: 'persona-123',
+        defaultPersona: {
+          id: 'persona-123',
+          preferredName: 'Name',
+          pronouns: null,
+          content: 'Content',
+        },
+        ownedPersonas: [],
+      });
 
-      mockPrismaClient.userPersonalityConfig.findFirst.mockResolvedValueOnce(null);
+      mockPrismaClient.userPersonalityConfig.findFirst
+        .mockResolvedValueOnce(null) // persona override
+        .mockRejectedValueOnce(new Error('DB error')); // focus mode check fails
 
       const result = await resolver.resolveForMemory('discord-123', 'personality-456');
 

--- a/packages/common-types/src/services/resolvers/PersonaResolver.ts
+++ b/packages/common-types/src/services/resolvers/PersonaResolver.ts
@@ -137,20 +137,12 @@ export class PersonaResolver extends BaseConfigResolver<ResolvedPersona> {
    */
   private async getFocusModeStatus(discordUserId: string, personalityId: string): Promise<boolean> {
     try {
-      // Get user's internal ID
-      const user = await this.prisma.user.findUnique({
-        where: { discordId: discordUserId },
-        select: { id: true },
-      });
-
-      if (user === null) {
-        return false; // Default to disabled if user not found
-      }
-
-      // Check UserPersonalityConfig for focus mode (stored in configOverrides JSONB)
+      // findFirst (not findUnique) because Prisma doesn't allow nested
+      // relation filters (`user: { discordId }`) on findUnique — even though
+      // (userId, personalityId) is composite-unique, findFirst is required here.
       const config = await this.prisma.userPersonalityConfig.findFirst({
         where: {
-          userId: user.id,
+          user: { discordId: discordUserId },
           personalityId,
         },
         select: { configOverrides: true },

--- a/services/bot-client/src/services/JobTracker.test.ts
+++ b/services/bot-client/src/services/JobTracker.test.ts
@@ -325,6 +325,8 @@ describe('JobTracker', () => {
       jobTracker.trackJob('job-123', mockChannel, createMockContext());
 
       // Advance just past the typing cutoff — orphan sweep is armed here.
+      // +16s = 2 typing-interval (8s) ticks past the 10-min cutoff so the
+      // interval callback actually fires and runs the cutoff branch.
       await vi.advanceTimersByTimeAsync(10 * 60 * 1000 + 16 * 1000);
       expect(jobTracker.isTracking('job-123')).toBe(true);
 

--- a/services/bot-client/src/services/JobTracker.test.ts
+++ b/services/bot-client/src/services/JobTracker.test.ts
@@ -314,12 +314,16 @@ describe('JobTracker', () => {
 
   describe('Orphan sweep (grace period past typing cutoff)', () => {
     it('should release the tracker if the result never arrives past grace period', async () => {
+      // Capture the notification-delete mock so we can assert that the full
+      // cleanup chain fires when the orphan sweep closes the tracker:
+      // 5 min → taking-longer notification sent
+      // 10 min + 16s → typing cutoff, orphan sweep armed
+      // 40 min + 16s → sweep fires → completeJob → notification.delete()
+      const deleteMock = vi.fn().mockResolvedValue(undefined);
       const mockChannel = {
         id: 'channel-123',
         sendTyping: vi.fn().mockResolvedValue(undefined),
-        send: vi
-          .fn()
-          .mockResolvedValue({ id: 'notif-1', delete: vi.fn().mockResolvedValue(undefined) }),
+        send: vi.fn().mockResolvedValue({ id: 'notif-1', delete: deleteMock }),
       } as any;
 
       jobTracker.trackJob('job-123', mockChannel, createMockContext());
@@ -329,14 +333,18 @@ describe('JobTracker', () => {
       // interval callback actually fires and runs the cutoff branch.
       await vi.advanceTimersByTimeAsync(10 * 60 * 1000 + 16 * 1000);
       expect(jobTracker.isTracking('job-123')).toBe(true);
+      // Taking-longer notification sent at the 5-min tick (before cutoff)
+      expect(mockChannel.send).toHaveBeenCalledTimes(1);
 
       // Advance another 29 min — still inside grace period, job still tracked.
       await vi.advanceTimersByTimeAsync(29 * 60 * 1000);
       expect(jobTracker.isTracking('job-123')).toBe(true);
 
-      // Advance past the 30-min grace period — sweep fires, tracker released.
+      // Advance past the 30-min grace period — sweep fires, tracker released,
+      // and the taking-longer notification is cleaned up as part of completeJob.
       await vi.advanceTimersByTimeAsync(2 * 60 * 1000);
       expect(jobTracker.isTracking('job-123')).toBe(false);
+      expect(deleteMock).toHaveBeenCalledTimes(1);
     });
 
     it('should not fire if the job completes normally before grace period', async () => {

--- a/services/bot-client/src/services/JobTracker.test.ts
+++ b/services/bot-client/src/services/JobTracker.test.ts
@@ -312,6 +312,86 @@ describe('JobTracker', () => {
     });
   });
 
+  describe('Orphan sweep (grace period past typing cutoff)', () => {
+    it('should release the tracker if the result never arrives past grace period', async () => {
+      const mockChannel = {
+        id: 'channel-123',
+        sendTyping: vi.fn().mockResolvedValue(undefined),
+        send: vi
+          .fn()
+          .mockResolvedValue({ id: 'notif-1', delete: vi.fn().mockResolvedValue(undefined) }),
+      } as any;
+
+      jobTracker.trackJob('job-123', mockChannel, createMockContext());
+
+      // Advance just past the typing cutoff — orphan sweep is armed here.
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000 + 16 * 1000);
+      expect(jobTracker.isTracking('job-123')).toBe(true);
+
+      // Advance another 29 min — still inside grace period, job still tracked.
+      await vi.advanceTimersByTimeAsync(29 * 60 * 1000);
+      expect(jobTracker.isTracking('job-123')).toBe(true);
+
+      // Advance past the 30-min grace period — sweep fires, tracker released.
+      await vi.advanceTimersByTimeAsync(2 * 60 * 1000);
+      expect(jobTracker.isTracking('job-123')).toBe(false);
+    });
+
+    it('should not fire if the job completes normally before grace period', async () => {
+      const mockChannel = {
+        id: 'channel-123',
+        sendTyping: vi.fn().mockResolvedValue(undefined),
+        send: vi
+          .fn()
+          .mockResolvedValue({ id: 'notif-1', delete: vi.fn().mockResolvedValue(undefined) }),
+      } as any;
+
+      jobTracker.trackJob('job-123', mockChannel, createMockContext());
+
+      // Advance past typing cutoff so the sweep is armed.
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000 + 16 * 1000);
+      expect(jobTracker.isTracking('job-123')).toBe(true);
+
+      // Result lands 15 min later (inside grace period).
+      await vi.advanceTimersByTimeAsync(15 * 60 * 1000);
+      const channel = jobTracker.completeJob('job-123');
+      expect(channel).toBe(mockChannel);
+      expect(jobTracker.isTracking('job-123')).toBe(false);
+
+      // Advance past when the sweep would have fired — must not re-invoke
+      // completeJob or warn. Re-completing an unknown job would return null,
+      // so this primarily guards against the sweep timer firing with stale
+      // closure state.
+      await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+      expect(jobTracker.isTracking('job-123')).toBe(false);
+    });
+
+    it('should clear pending orphan sweeps on cleanup()', async () => {
+      const mockChannel = {
+        id: 'channel-123',
+        sendTyping: vi.fn().mockResolvedValue(undefined),
+        send: vi
+          .fn()
+          .mockResolvedValue({ id: 'notif-1', delete: vi.fn().mockResolvedValue(undefined) }),
+      } as any;
+
+      jobTracker.trackJob('job-123', mockChannel, createMockContext());
+
+      // Arm the sweep by passing typing cutoff.
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000 + 16 * 1000);
+      expect(jobTracker.isTracking('job-123')).toBe(true);
+
+      // Shutdown clears everything, including the pending sweep.
+      jobTracker.cleanup();
+      expect(jobTracker.isTracking('job-123')).toBe(false);
+
+      // Advancing past the sweep's scheduled fire time must not re-invoke
+      // any side effects — the timer was cleared.
+      await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+      expect(jobTracker.isTracking('job-123')).toBe(false);
+    });
+  });
+
   describe('isTracking', () => {
     it('should return true for tracked jobs', () => {
       const mockChannel = {

--- a/services/bot-client/src/services/JobTracker.ts
+++ b/services/bot-client/src/services/JobTracker.ts
@@ -29,6 +29,13 @@ const TAKING_LONGER_NOTIFY_MS = 5 * 60 * 1000; // 5 minutes
 // Discord typing lasts ~10s, refresh every 8s
 const TYPING_INDICATOR_INTERVAL_MS = 8000;
 
+// How long past TYPING_INDICATOR_TIMEOUT_MS to wait before force-releasing
+// the tracker slot if no result has arrived. Generous by design: legitimate
+// late results should still land, but a genuine orphan (worker crashed,
+// Redis partition never recovered, BullMQ lost the job) shouldn't sit in
+// memory forever. Total ceiling: 10 min typing + 30 min grace = 40 min.
+const ORPHAN_SWEEP_GRACE_MS = 30 * 60 * 1000;
+
 /**
  * Context needed to handle async job results
  * Stored here instead of in MessageHandler for statelessness
@@ -54,6 +61,12 @@ interface TrackedJob {
   takingLongerMessage?: Message;
   /** Prevents re-sending the notification on every typing-interval tick. */
   notificationSent?: boolean;
+  /**
+   * Grace-period sweep timer scheduled when the typing cutoff fires. If the
+   * real result arrives first, completeJob clears this. If it never arrives,
+   * the sweep releases the tracker slot so activeJobs doesn't leak.
+   */
+  orphanSweep?: NodeJS.Timeout;
 }
 
 export class JobTracker {
@@ -135,6 +148,9 @@ export class JobTracker {
           // Clear the typing interval to avoid rate limits, but DON'T remove the job
           // The job context must remain so we can deliver the result when it arrives
           clearInterval(typingInterval);
+          // Arm an orphan sweep: if the result never arrives within the
+          // grace period, release the tracker slot instead of leaking.
+          this.scheduleOrphanSweep(jobId, startTime);
           return;
         }
 
@@ -187,6 +203,12 @@ export class JobTracker {
 
     // Clear typing interval
     clearInterval(tracked.typingInterval);
+
+    // Clear the orphan sweep timer if one was armed (job completed before
+    // the grace period elapsed — the sweep is no longer needed).
+    if (tracked.orphanSweep) {
+      clearTimeout(tracked.orphanSweep);
+    }
 
     // Clean up the "taking longer" notification if it was sent. The real
     // response is about to arrive, so leaving the notification in the channel
@@ -256,8 +278,31 @@ export class JobTracker {
 
     for (const job of this.activeJobs.values()) {
       clearInterval(job.typingInterval);
+      if (job.orphanSweep) {
+        clearTimeout(job.orphanSweep);
+      }
     }
 
     this.activeJobs.clear();
+  }
+
+  /**
+   * Schedule a grace-period sweep that force-completes the job if the result
+   * never arrives. Called when the typing indicator cutoff fires. The sweep
+   * checks `activeJobs.has(jobId)` at fire time — if the real result landed
+   * first, the entry is already gone and the sweep is a no-op.
+   */
+  private scheduleOrphanSweep(jobId: string, startTime: number): void {
+    const tracked = this.activeJobs.get(jobId);
+    if (!tracked) {return;}
+    tracked.orphanSweep = setTimeout(() => {
+      if (this.activeJobs.has(jobId)) {
+        logger.warn(
+          { jobId, ageMs: Date.now() - startTime },
+          '[JobTracker] Orphan sweep — job never completed past grace period, releasing tracker'
+        );
+        this.completeJob(jobId);
+      }
+    }, ORPHAN_SWEEP_GRACE_MS);
   }
 }

--- a/services/bot-client/src/services/JobTracker.ts
+++ b/services/bot-client/src/services/JobTracker.ts
@@ -308,7 +308,7 @@ export class JobTracker {
       if (this.activeJobs.has(jobId)) {
         logger.warn(
           { jobId, ageMs: Date.now() - startTime },
-          'Orphan sweep — job never completed past grace period, releasing tracker'
+          '[JobTracker] Orphan sweep — job never completed past grace period, releasing tracker'
         );
         this.completeJob(jobId);
       }

--- a/services/bot-client/src/services/JobTracker.ts
+++ b/services/bot-client/src/services/JobTracker.ts
@@ -294,12 +294,14 @@ export class JobTracker {
    */
   private scheduleOrphanSweep(jobId: string, startTime: number): void {
     const tracked = this.activeJobs.get(jobId);
-    if (!tracked) {return;}
+    if (!tracked) {
+      return;
+    }
     tracked.orphanSweep = setTimeout(() => {
       if (this.activeJobs.has(jobId)) {
         logger.warn(
           { jobId, ageMs: Date.now() - startTime },
-          '[JobTracker] Orphan sweep — job never completed past grace period, releasing tracker'
+          'Orphan sweep — job never completed past grace period, releasing tracker'
         );
         this.completeJob(jobId);
       }

--- a/services/bot-client/src/services/JobTracker.ts
+++ b/services/bot-client/src/services/JobTracker.ts
@@ -297,6 +297,13 @@ export class JobTracker {
     if (!tracked) {
       return;
     }
+    // Guard against double-arming. The cutoff branch clearInterval()s
+    // synchronously before calling this, so a second fire is unreachable
+    // today — but if that ordering ever changes, overwriting `orphanSweep`
+    // would leak the first timer. Cheap invariant to hold explicit.
+    if (tracked.orphanSweep !== undefined) {
+      return;
+    }
     tracked.orphanSweep = setTimeout(() => {
       if (this.activeJobs.has(jobId)) {
         logger.warn(

--- a/services/bot-client/src/services/JobTracker.ts
+++ b/services/bot-client/src/services/JobTracker.ts
@@ -150,7 +150,7 @@ export class JobTracker {
           clearInterval(typingInterval);
           // Arm an orphan sweep: if the result never arrives within the
           // grace period, release the tracker slot instead of leaking.
-          this.scheduleOrphanSweep(jobId, startTime);
+          this.scheduleOrphanSweep(jobId);
           return;
         }
 
@@ -292,7 +292,7 @@ export class JobTracker {
    * checks `activeJobs.has(jobId)` at fire time — if the real result landed
    * first, the entry is already gone and the sweep is a no-op.
    */
-  private scheduleOrphanSweep(jobId: string, startTime: number): void {
+  private scheduleOrphanSweep(jobId: string): void {
     const tracked = this.activeJobs.get(jobId);
     if (!tracked) {
       return;
@@ -304,6 +304,7 @@ export class JobTracker {
     if (tracked.orphanSweep !== undefined) {
       return;
     }
+    const { startTime } = tracked;
     tracked.orphanSweep = setTimeout(() => {
       if (this.activeJobs.has(jobId)) {
         logger.warn(


### PR DESCRIPTION
## Summary

Closes two stability issues flagged in the claude-bot review of PR #819 (beta.99 release) that were acknowledged but not fixed in-flight.

- **`perf(common-types)` — PersonaResolver focus-mode two-query hop → one.** `getFocusModeStatus` previously ran `user.findUnique` by `discordId` then `userPersonalityConfig.findFirst` by internal `userId`. Collapsed to a single `findFirst` using a nested relation filter (`user: { discordId }`). One DB round-trip on the memory-retrieval hot path instead of two, and eliminates a latent race window where the user could be deleted between the two queries.
- **`fix(bot-client)` — JobTracker orphan sweep.** Jobs that exceed `TYPING_INDICATOR_TIMEOUT_MS` (10 min) intentionally stay tracked so late results still deliver. But if the result never arrives (worker crash, Redis partition, BullMQ lost the job), the entry sat in `activeJobs` forever — slow memory leak on a long-lived process. Schedules a grace-period `setTimeout` (30 min past cutoff = 40 min total ceiling) that releases the tracker slot if the job is still stuck. Idempotent — normal completion clears the timer so the sweep is a no-op.

Council (gemini-3.1-pro-preview) reviewed the PersonaResolver change and confirmed behavior preservation + caught a free race-condition fix as a bonus. JobTracker change is a standard timer-cleanup pattern, shipped without council review.

## Test plan

- [ ] `pnpm --filter @tzurot/common-types test` — 2078 tests pass locally
- [ ] `pnpm --filter @tzurot/bot-client test` — 4237 tests pass locally (3 new orphan-sweep tests added)
- [ ] `pnpm typecheck` — clean across both packages
- [ ] Pre-push hook (build + lint + cpd + depcruise) — passed
- [ ] Manual: confirm no behavioral regression on focus-mode toggle for long-term memory (Discord smoke test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)