### PR TITLE
fix: preset UX error surfacing (clone auto-number + context window wording)

### DIFF
--- a/services/api-gateway/src/utils/modelValidation.test.ts
+++ b/services/api-gateway/src/utils/modelValidation.test.ts
@@ -71,9 +71,10 @@ describe('validateModelAndContextWindow', () => {
     const model = createMockModel({ contextLength: 200000 });
     const cache = createMockModelCache(model);
     const result = await validateModelAndContextWindow(cache, 'anthropic/claude-sonnet-4', 150000);
-    expect(result.error).toContain("exceeds 50% of the model's");
+    expect(result.error).toContain("exceeds the safe limit for 'anthropic/claude-sonnet-4'");
     expect(result.error).toContain('200K');
     expect(result.error).toContain('100K');
+    expect(result.error).toContain('Reduce the Context Window value');
     expect(result.contextWindowCap).toBe(100000);
   });
 
@@ -112,7 +113,8 @@ describe('validateModelAndContextWindow', () => {
     const model = createMockModel({ contextLength: 32768 });
     const cache = createMockModelCache(model);
     const result = await validateModelAndContextWindow(cache, 'test/small-model', 40000);
-    expect(result.error).toContain("exceeds the model's full");
+    expect(result.error).toContain("exceeds the full limit for 'test/small-model'");
+    expect(result.error).toContain('Reduce the Context Window value');
     expect(result.contextWindowCap).toBe(32768);
   });
 

--- a/services/api-gateway/src/utils/modelValidation.ts
+++ b/services/api-gateway/src/utils/modelValidation.ts
@@ -67,11 +67,14 @@ export async function validateModelAndContextWindow(
   if (contextWindowTokens !== undefined && contextWindowTokens > cap) {
     const contextK = Math.round(model.contextLength / 1000);
     const capK = Math.round(cap / 1000);
-    const limit = cap === model.contextLength ? "the model's full" : "50% of the model's";
+    // "full" when the cap equals contextLength (small model, no halving applied),
+    // "safe" when we're holding back 50% for generation room.
+    const scope = cap === model.contextLength ? 'full' : 'safe';
     return {
       error:
-        `contextWindowTokens (${contextWindowTokens}) exceeds ${limit} context window. ` +
-        `Model '${modelId}' supports ${contextK}K tokens; maximum allowed is ${capK}K (${cap} tokens).`,
+        `Context window setting (${contextWindowTokens} tokens) exceeds the ${scope} limit for '${modelId}'. ` +
+        `Model supports ${contextK}K tokens; maximum allowed for this preset is ${capK}K (${cap} tokens). ` +
+        `Reduce the Context Window value before saving.`,
       contextWindowCap: cap,
     };
   }

--- a/services/api-gateway/src/utils/modelValidation.ts
+++ b/services/api-gateway/src/utils/modelValidation.ts
@@ -73,7 +73,7 @@ export async function validateModelAndContextWindow(
     return {
       error:
         `Context window setting (${contextWindowTokens} tokens) exceeds the ${scope} limit for '${modelId}'. ` +
-        `Model supports ${contextK}K tokens; maximum allowed for this preset is ${capK}K (${cap} tokens). ` +
+        `Model supports ${contextK}K tokens; maximum allowed for this model is ${capK}K (${cap} tokens). ` +
         `Reduce the Context Window value before saving.`,
       contextWindowCap: cap,
     };

--- a/services/bot-client/src/commands/preset/dashboard.test.ts
+++ b/services/bot-client/src/commands/preset/dashboard.test.ts
@@ -1058,5 +1058,54 @@ describe('handleButton', () => {
         flags: MessageFlags.Ephemeral,
       });
     });
+
+    it('should auto-number past a first-attempt name collision', async () => {
+      mockParseDashboardCustomId.mockReturnValue({
+        entityType: 'preset',
+        entityId: 'preset-123',
+        action: 'clone',
+      });
+      mockSessionManagerGet.mockResolvedValue({
+        data: {
+          id: 'preset-123',
+          name: 'Test Preset',
+          model: 'anthropic/claude-sonnet-4',
+          provider: 'openrouter',
+          isGlobal: false,
+          isOwned: true,
+        },
+      });
+
+      const clonedPreset = { ...mockPresetData, id: 'preset-456', name: 'Test Preset (Copy 2)' };
+      // First attempt collides (user already has "Test Preset (Copy)"); second
+      // attempt with the bumped name succeeds.
+      mockCreatePreset
+        .mockRejectedValueOnce(
+          new Error(
+            'Failed to create preset: 400 - You already have a config named "Test Preset (Copy)"'
+          )
+        )
+        .mockResolvedValueOnce(clonedPreset);
+      mockFetchPreset.mockResolvedValue(clonedPreset);
+
+      await handleButton(createCloneButtonInteraction('preset::clone::preset-123'));
+
+      expect(mockCreatePreset).toHaveBeenCalledTimes(2);
+      // First attempt used the plain "(Copy)" suffix
+      expect(mockCreatePreset).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ name: 'Test Preset (Copy)' }),
+        'user-456'
+      );
+      // Retry bumped the suffix to "(Copy 2)" and succeeded
+      expect(mockCreatePreset).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ name: 'Test Preset (Copy 2)' }),
+        'user-456'
+      );
+      // User sees the success path, not an error
+      expect(mockFollowUp).not.toHaveBeenCalled();
+      expect(mockEditReply).toHaveBeenCalled();
+    });
   });
 });

--- a/services/bot-client/src/commands/preset/dashboard.test.ts
+++ b/services/bot-client/src/commands/preset/dashboard.test.ts
@@ -1107,5 +1107,79 @@ describe('handleButton', () => {
       expect(mockFollowUp).not.toHaveBeenCalled();
       expect(mockEditReply).toHaveBeenCalled();
     });
+
+    it('should pass non-collision errors through immediately without retrying', async () => {
+      mockParseDashboardCustomId.mockReturnValue({
+        entityType: 'preset',
+        entityId: 'preset-123',
+        action: 'clone',
+      });
+      mockSessionManagerGet.mockResolvedValue({
+        data: {
+          id: 'preset-123',
+          name: 'Test Preset',
+          model: 'nonexistent/model',
+          provider: 'openrouter',
+          isGlobal: false,
+          isOwned: true,
+        },
+      });
+
+      // A 400 that is NOT a name collision (e.g., invalid model) must not
+      // trigger the retry loop — we want the first attempt's error to
+      // reach the user immediately.
+      mockCreatePreset.mockRejectedValue(
+        new Error(
+          "Failed to create preset: 400 - Model 'nonexistent/model' not found in the available models list."
+        )
+      );
+
+      await handleButton(createCloneButtonInteraction('preset::clone::preset-123'));
+
+      // Called exactly once — no retry
+      expect(mockCreatePreset).toHaveBeenCalledTimes(1);
+      // User sees the underlying API error, not the generic "Failed to clone"
+      expect(mockFollowUp).toHaveBeenCalledWith({
+        content: expect.stringContaining("Model 'nonexistent/model' not found"),
+        flags: MessageFlags.Ephemeral,
+      });
+    });
+
+    it('should rethrow the last collision error after exhausting retries', async () => {
+      mockParseDashboardCustomId.mockReturnValue({
+        entityType: 'preset',
+        entityId: 'preset-123',
+        action: 'clone',
+      });
+      mockSessionManagerGet.mockResolvedValue({
+        data: {
+          id: 'preset-123',
+          name: 'Test Preset',
+          model: 'anthropic/claude-sonnet-4',
+          provider: 'openrouter',
+          isGlobal: false,
+          isOwned: true,
+        },
+      });
+
+      // Every attempt collides — the retry loop reaches MAX_CLONE_NAME_RETRIES
+      // (10) and rethrows the last collision error so the user sees which
+      // name finally couldn't be placed.
+      mockCreatePreset.mockRejectedValue(
+        new Error(
+          'Failed to create preset: 400 - You already have a config named "Test Preset (Copy 10)"'
+        )
+      );
+
+      await handleButton(createCloneButtonInteraction('preset::clone::preset-123'));
+
+      // Attempted the max number of times
+      expect(mockCreatePreset).toHaveBeenCalledTimes(10);
+      // Final user-visible error surfaces the collision
+      expect(mockFollowUp).toHaveBeenCalledWith({
+        content: expect.stringContaining('You already have a config named'),
+        flags: MessageFlags.Ephemeral,
+      });
+    });
   });
 });

--- a/services/bot-client/src/commands/preset/dashboardButtons.ts
+++ b/services/bot-client/src/commands/preset/dashboardButtons.ts
@@ -57,6 +57,13 @@ const MAX_CLONE_NAME_RETRIES = 10;
  * from `ErrorResponses.validationError` in `user/llm-config.ts` and reaches
  * bot-client wrapped as `Failed to create preset: 400 - You already have a
  * config named "..."` via `createPreset`.
+ *
+ * **Coupling risk**: this regex matches the gateway's natural-language
+ * message text. If the wording in `user/llm-config.ts` ever changes
+ * (localization, copy editing, restructure), the retry loop silently
+ * degrades to single-attempt. Hardening tracked in BACKLOG as a typed
+ * error-code refactor ("Harden preset clone collision detection against
+ * error-message drift").
  */
 const NAME_COLLISION_PATTERN = /already have a config named/i;
 

--- a/services/bot-client/src/commands/preset/dashboardButtons.ts
+++ b/services/bot-client/src/commands/preset/dashboardButtons.ts
@@ -420,6 +420,12 @@ async function createClonedPreset(
     }
   }
 
+  // `lastError` is always set when we reach here: the loop can only exit
+  // via this `throw` (vs. the `return` inside the try) if at least one
+  // iteration caught a collision and assigned `lastError`. The `??`
+  // fallback is unreachable unless `MAX_CLONE_NAME_RETRIES` is set to 0,
+  // in which case the loop body never runs — keeping the fallback defends
+  // against that degenerate config.
   throw lastError ?? new Error('Failed to generate a unique clone name');
 }
 

--- a/services/bot-client/src/commands/preset/dashboardButtons.ts
+++ b/services/bot-client/src/commands/preset/dashboardButtons.ts
@@ -407,9 +407,9 @@ async function createClonedPreset(
       if (err instanceof Error && NAME_COLLISION_PATTERN.test(err.message)) {
         lastError = err;
         clonedName = generateClonedName(clonedName);
-        continue;
+      } else {
+        throw err;
       }
-      throw err;
     }
   }
 

--- a/services/bot-client/src/commands/preset/dashboardButtons.ts
+++ b/services/bot-client/src/commands/preset/dashboardButtons.ts
@@ -37,6 +37,7 @@ import {
   createPreset,
   extractApiErrorMessage,
 } from './api.js';
+import type { PresetData } from './types.js';
 import { buildBrowseResponse, type PresetBrowseFilter } from './browse.js';
 
 // Re-export for backward compatibility
@@ -46,6 +47,18 @@ const logger = createLogger('preset-dashboard-buttons');
 
 /** Recovery command shown in expired session messages */
 const PRESET_RECOVERY_CMD = '/preset browse';
+
+/** Max retry attempts when a generated clone name collides with an existing preset. */
+const MAX_CLONE_NAME_RETRIES = 10;
+
+/**
+ * Detect the api-gateway's "name already used" validation error so the clone
+ * flow can bump the suffix and retry instead of giving up. The message comes
+ * from `ErrorResponses.validationError` in `user/llm-config.ts` and reaches
+ * bot-client wrapped as `Failed to create preset: 400 - You already have a
+ * config named "..."` via `createPreset`.
+ */
+const NAME_COLLISION_PATTERN = /already have a config named/i;
 
 /**
  * Pattern to match a trailing (Copy) or (Copy N) suffix.
@@ -359,6 +372,51 @@ export async function handleCancelDeleteButton(
 }
 
 /**
+ * Create a cloned preset with auto-numbered naming. If the initial candidate
+ * collides with an existing preset, feed the candidate back through
+ * `generateClonedName` to bump the suffix and retry. Any non-collision error
+ * propagates immediately. After `MAX_CLONE_NAME_RETRIES` attempts the last
+ * collision error is rethrown so the user sees the actual collision name.
+ */
+async function createClonedPreset(
+  sourceData: FlattenedPresetData,
+  userId: string
+): Promise<PresetData> {
+  let clonedName = generateClonedName(sourceData.name);
+  let lastError: Error | null = null;
+
+  for (let attempt = 0; attempt < MAX_CLONE_NAME_RETRIES; attempt++) {
+    try {
+      return await createPreset(
+        {
+          name: clonedName,
+          model: sourceData.model,
+          provider: sourceData.provider,
+          description:
+            sourceData.description !== undefined && sourceData.description.length > 0
+              ? sourceData.description
+              : undefined,
+          visionModel:
+            sourceData.visionModel !== undefined && sourceData.visionModel.length > 0
+              ? sourceData.visionModel
+              : undefined,
+        },
+        userId
+      );
+    } catch (err) {
+      if (err instanceof Error && NAME_COLLISION_PATTERN.test(err.message)) {
+        lastError = err;
+        clonedName = generateClonedName(clonedName);
+        continue;
+      }
+      throw err;
+    }
+  }
+
+  throw lastError ?? new Error('Failed to generate a unique clone name');
+}
+
+/**
  * Handle clone button - create a copy of the preset owned by the user.
  */
 export async function handleCloneButton(
@@ -379,25 +437,12 @@ export async function handleCloneButton(
     const sourceData = session.data;
     const sessionManager = getSessionManager();
 
-    const clonedName = generateClonedName(sourceData.name);
-
-    // Create the cloned preset with basic fields
-    const newPreset = await createPreset(
-      {
-        name: clonedName,
-        model: sourceData.model,
-        provider: sourceData.provider,
-        description:
-          sourceData.description !== undefined && sourceData.description.length > 0
-            ? sourceData.description
-            : undefined,
-        visionModel:
-          sourceData.visionModel !== undefined && sourceData.visionModel.length > 0
-            ? sourceData.visionModel
-            : undefined,
-      },
-      interaction.user.id
-    );
+    // Auto-number past any existing collisions. generateClonedName picks a
+    // candidate based on the source name alone — it can't know what already
+    // exists in the user's library, so cloning the original twice produces
+    // the same "(Copy)" candidate both times. Retry with a bumped suffix on
+    // the gateway's name-collision validation error; surface anything else.
+    const newPreset = await createClonedPreset(sourceData, interaction.user.id);
 
     // Build update payload with all non-basic fields from source
     const updatePayload = unflattenPresetData(sourceData);


### PR DESCRIPTION
## Summary

Two preset-command UX papercuts where the system had the information to help the user but surfaced it poorly.

- **`fix(bot-client)` — clone auto-numbers past collisions.** `generateClonedName` is deterministic on the source name alone, so cloning the original preset twice produced the same `"(Copy)"` candidate both times and failed on the second attempt with a generic "You already have a config named …" error. Now the clone handler retries with a bumped suffix on the gateway's name-collision validation error (up to 10 attempts), so the second clone becomes `"(Copy 2)"`, the third `"(Copy 3)"`, etc. Non-collision errors still propagate immediately.
- **`fix(api-gateway)` — context-window validation wording.** Saving a preset whose `contextWindowTokens` exceeded the model's current supported range surfaced the JSON field name in the user-facing error (`"contextWindowTokens (100000) exceeds 50% of the model's context window…"`). Rewritten to use Discord UI terminology and include an actionable next step (`"Context window setting (100000 tokens) exceeds the safe limit for '<model>'. … Reduce the Context Window value before saving."`). Triggered by vendors reducing a model's context after a preset was saved (e.g., z.ai dropping GLM context limits to 40K–80K), where the user previously had to read Railway logs to find out why a save failed.

No council review on these — both are self-contained wording/logic changes with obvious shape.

## Test plan

- [ ] `pnpm --filter @tzurot/bot-client test` — 4235 tests pass locally (1 new auto-number test)
- [ ] `pnpm --filter @tzurot/api-gateway test` — 1706 tests pass locally (2 updated validator assertions)
- [ ] `pnpm typecheck` — clean across both packages
- [ ] Pre-push hook passed
- [ ] Manual: verify Discord UX on clone-of-clone + context-overflow save (both need a real user interaction session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)