### PR TITLE
test(tooling): fix flaky xray suppression test

### DIFF
--- a/packages/tooling/src/xray/analyzer.test.ts
+++ b/packages/tooling/src/xray/analyzer.test.ts
@@ -126,6 +126,11 @@ describe('analyzeMonorepo', () => {
     const health = report.summary.byPackage['test-pkg']?.health;
     expect(health?.totalSuppressions).toBe(1);
     expect(report.summary.totalSuppressions).toBe(1);
+    // Belt-and-suspenders: confirm suppressions also reach the per-file
+    // FileInfo through the full pipeline, not just the aggregated health
+    // summary. Catches a hypothetical regression where FileInfo gets cloned
+    // without spreading `suppressions`.
+    expect(report.packages[0].files[0].suppressions.length).toBe(1);
   });
 
   it('should report zero suppressions for clean code', () => {
@@ -190,9 +195,9 @@ describe('analyzeMonorepo', () => {
   it('should include suppressions in file data', () => {
     const content = `// @ts-expect-error -- test\nexport const x = 1;\n// eslint-disable-next-line no-unused-vars\nconst y = 2;\n`;
 
-    const file = parseFile('/root/packages/test-pkg/src/index.ts', content, {
-      includePrivate: true,
-    });
+    // No `includePrivate: true` — suppression extraction is independent of
+    // declaration visibility, so the option is incidental noise here.
+    const file = parseFile('/root/packages/test-pkg/src/index.ts', content);
 
     expect(file.suppressions).toHaveLength(2);
     expect(file.suppressions[0].kind).toBe('ts-expect-error');

--- a/packages/tooling/src/xray/analyzer.test.ts
+++ b/packages/tooling/src/xray/analyzer.test.ts
@@ -23,6 +23,7 @@ vi.mock('node:fs', () => ({
 
 import { readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
 import { analyzeMonorepo, runXray } from './analyzer.js';
+import { parseFile } from './file-parser.js';
 
 function setupMockPackage(
   packageName: string,
@@ -179,15 +180,20 @@ describe('analyzeMonorepo', () => {
     consoleWarnSpy.mockRestore();
   });
 
-  // ts-morph Project initialization is CPU-intensive; CI runners need extra time
-  it('should include suppressions in file data', { timeout: 30_000 }, () => {
-    setupMockPackage('test-pkg', 'packages', {
-      'index.ts': `// @ts-expect-error -- test\nexport const x = 1;\n// eslint-disable-next-line no-unused-vars\nconst y = 2;\n`,
+  // Call parseFile directly rather than routing through analyzeMonorepo +
+  // the file-discovery mock. The assertion only needs to confirm that
+  // suppressions land on FileInfo — the full pipeline was flaky on
+  // resource-constrained CI runners (timed out at 15s, then 30s) because
+  // ts-morph cold-start compounded with discovery/readFileSync mock overhead.
+  // The deeper correctness of suppression parsing is covered directly in
+  // file-parser.test.ts's `extractSuppressions` suite.
+  it('should include suppressions in file data', () => {
+    const content = `// @ts-expect-error -- test\nexport const x = 1;\n// eslint-disable-next-line no-unused-vars\nconst y = 2;\n`;
+
+    const file = parseFile('/root/packages/test-pkg/src/index.ts', content, {
+      includePrivate: true,
     });
 
-    const report = analyzeMonorepo('/root', { includePrivate: true });
-
-    const file = report.packages[0].files[0];
     expect(file.suppressions).toHaveLength(2);
     expect(file.suppressions[0].kind).toBe('ts-expect-error');
     expect(file.suppressions[1].kind).toBe('eslint-disable-next-line');

--- a/packages/tooling/src/xray/analyzer.test.ts
+++ b/packages/tooling/src/xray/analyzer.test.ts
@@ -116,7 +116,7 @@ describe('analyzeMonorepo', () => {
     expect(file.imports).toHaveLength(0);
   });
 
-  it('should count suppressions in package health', () => {
+  it('should count suppressions in package health and propagate to FileInfo', () => {
     setupMockPackage('test-pkg', 'packages', {
       'index.ts': `// eslint-disable-next-line no-console\nconsole.log('hi');\nexport const x = 1;\n`,
     });


### PR DESCRIPTION
## Summary

Bundle C from the Quick Wins sweep. The pnpm/action-setup v6 investigation (originally also in Bundle C) concluded "defer" — findings went to BACKLOG on develop at 01f3def7c, so this PR is single-commit.

- **`test(tooling)` — flaky xray suppression test.** The `analyzer.test.ts` "should include suppressions in file data" test routed through the full `analyzeMonorepo` + file-discovery mock + ts-morph pipeline just to check that suppressions propagate onto `FileInfo`. It timed out at 15s, then 30s, on resource-constrained CI runners. Replaced with a direct `parseFile` call — same plumbing assertion, no file-discovery overhead. The deeper correctness of `extractSuppressions` is already unit-tested in `file-parser.test.ts`.

## Context on the deferred item

Investigation of `pnpm/action-setup` v5→v6 showed v6.0.0's only feature is pnpm 11 support. We run pnpm 10.30.3 (`packageManager` in package.json), so the upgrade has zero benefit. The v5→v6 diff replaces the bundled pnpm binary with a runtime bootstrap installer — the likely cause of the `ERR_PNPM_BROKEN_LOCKFILE` we hit in PR #798. Moved to the Deferred table in BACKLOG with revisit triggers (we adopt pnpm 11, v5 is deprecated, or a v6.x patch lands).

## Test plan

- [ ] `pnpm --filter @tzurot/tooling test` — 532 tests pass locally in 5s (dropped from 30s range)
- [ ] Pre-push hook passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)