### PR TITLE
fix(bot-client): warn before truncating over-length character fields

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -144,20 +144,6 @@ _New items go here. Triage to appropriate section weekly._
 
   **Start**: `pnpm ops logs --env prod --filter "@tzurot/ai-worker" --since 48h | grep -iE "tts|voice|elevenlabs"` to enumerate recent failures; `services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts` `performElevenLabsTTSWithFallback` for the current fallback sequencing; the existing `ElevenLabsClient` + `VoiceEngineClient` error classifiers as the natural differentiation points.
 
-- 🐛 `[FIX]` **Character truncation warning → Edit button silent-failure when interaction times out** — `handleEditTruncatedButton` in `services/bot-client/src/commands/character/truncationWarning.ts` cannot `deferUpdate` before the async work because Discord requires `showModal` to be the _first_ response to the interaction (deferring poisons the modal path). The handler therefore calls `resolveCharacterSectionContext` — which hits Redis and may fall through to a gateway `fetchCharacter` call — _before_ the ack. In the common case the session is Redis-cached from the preceding select-menu interaction and the async work fits inside Discord's 3-second window. But users can leave the warning embed on screen indefinitely, and a session TTL expiry + slow gateway response can blow the budget. When `showModal` then throws `10062 Unknown interaction`, `CommandHandler.handleComponentInteraction:350` catches the throw and calls `sendErrorReply`, but `reply()` on a dead interaction also throws 10062 — the inner try/catch at line 358 logs to debug and the user sees a silent no-op. Surfaced during PR #825 R3 review (2026-04-17).
-
-  **Fix options** (not yet chosen — need UX + engineering input):
-  - **(a)** Pre-fetch + session-warm on the select-menu interaction so the cache miss path is effectively dead (wastes work when the user picks View Full or Cancel).
-  - **(b)** Swap the Edit-with-Truncation flow to use `update` + a follow-up "click here to open the editor" link, moving the modal behind a second interaction where a defer _is_ legal. Extra click, but eliminates the 3-second risk entirely.
-  - **(c)** Replace the warning with a fresh interaction on click (Discord returns a new token), re-resolving context via `deferReply`. Simplest but slowest — user waits through the defer ack twice.
-
-  **Why it's latent**: the 3-second window is only blown on cache miss + slow gateway. In the common case users click within seconds and the session is hot. Not reproduced in production yet, but the failure mode is known.
-
-  **Start**:
-  - Timeout site: `services/bot-client/src/commands/character/truncationWarning.ts` `handleEditTruncatedButton`
-  - Error-handling chain that swallows the 10062: `services/bot-client/src/handlers/CommandHandler.ts:350-360`
-  - sendErrorReply (the swallower): `services/bot-client/src/handlers/CommandHandler.ts:53-66`
-
 - 🧹 `[CHORE]` **Add lint/test assertion that dashboard section fields declare `maxLength`** — `detectOverLengthFields` in `services/bot-client/src/commands/character/truncationWarning.ts` (and by extension the character field silent-truncation warning) intentionally skips fields where `field.maxLength === undefined`, because `ModalFactory` applies default caps only at modal-show time and we don't want to warn about defaults users can't configure. The tradeoff: if a new section field is ever added to `services/bot-client/src/commands/character/config.ts` without an explicit `maxLength`, the silent-truncate path for that field silently re-opens and users lose data with no warning — same bug the PR #825 fix was designed to prevent, just scoped to new fields. Currently nothing enforces `maxLength` presence; the protection is "discipline + code review." Flagged in PR #825 R3 (2026-04-17).
 
   **Fix options**:

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -13,6 +13,55 @@ Single source of truth for all work. Tech debt competes for the same time as fea
 
 _Active bugs observed in production. Fix before new features._
 
+- 🐛 `[FIX]` **🚫 BETA.100 BLOCKER — `/admin db-sync` fails with NOT NULL violation on `users.default_persona_id`** — Observed 2026-04-17 19:52 UTC by bot owner. Command fails with HTTP 500:
+
+  ```
+  INTERNAL_ERROR: Invalid `prisma.$executeRawUnsafe()` invocation:
+  Raw query failed. Code: `23502`. Message: `null value in column "default_persona_id"
+  of relation "users" violates not-null constraint`
+  ```
+
+  **Root cause — schema/sync drift**: migration `20260416215546_identity_epic_phase_5b_default_persona_not_null` (applied 2026-04-16) made `users.default_persona_id` NOT NULL. `prisma/schema.prisma:27` declares it `defaultPersonaId String` (non-nullable). But `services/api-gateway/src/services/sync/config/syncTables.ts:104` lists `default_persona_id` in `deferredFkColumns`, which means pass 1 of the two-pass sync inserts users with this column NULL (to break the users↔personas circular FK), and pass 2 backfills from prod after personas sync. Pass 1 now violates the constraint and the whole sync aborts.
+
+  **Fix options**:
+  - **(a)** Remove `default_persona_id` from `deferredFkColumns` and reorder the sync so personas sync before users. Requires untangling the circular FK (users.default_persona_id → personas.id and personas.owner_id → users.id) in a different direction.
+  - **(b)** Sync personas for the user first, insert users with a real `default_persona_id` (e.g., synthesize a provisional persona per synced user if one doesn't exist yet, then overwrite in pass 2). Keeps the two-pass shape but breaks the circular insert.
+  - **(c)** Do the sync inside a session where `SET CONSTRAINTS ALL DEFERRED` is active and the FK is `DEFERRABLE INITIALLY DEFERRED`. Requires a migration to mark the FK deferrable. Preserves current logic with minimal code churn.
+
+  Option (c) is likely the smallest change but is a separate migration. Option (b) is the most correct long-term. Blocker because dev→prod syncing is a common dev-loop need.
+
+  **Start**:
+  - Error site: `services/api-gateway/src/services/sync/` — `DatabaseSyncService.ts` entry point
+  - Sync config: `services/api-gateway/src/services/sync/config/syncTables.ts:104` (`deferredFkColumns`)
+  - Schema state: `prisma/schema.prisma:27` (defaultPersonaId NOT NULL)
+  - Migration that introduced the mismatch: `prisma/migrations/20260416215546_identity_epic_phase_5b_default_persona_not_null/migration.sql`
+  - Related sync-order documentation: `syncTables.ts:213-218` (dependency graph)
+
+- 🐛 `[FIX]` **🚫 BETA.100 BLOCKER — `/settings preset default` rejects valid-looking configId as "Invalid configId format"** — Observed 2026-04-17 19:54 UTC by bot owner. Command fails with user-visible: `❌ Failed to set default: configId: Invalid configId format`. This is produced by `SetDefaultConfigSchema` in `packages/common-types/src/schemas/api/model-override.ts:103` — `z.string().uuid(...)`.
+
+  **Investigation pointers — what is and isn't known**:
+  - Command flow: bot-client `settings/preset/default.ts` → reads `options.preset()` → `PUT /user/model-override/default { configId }` → api-gateway validates with `SetDefaultConfigSchema` → rejects non-UUID.
+  - Autocomplete at `settings/preset/autocomplete.ts:140` sets `value: c.id`, where `c.id` comes from `/user/llm-config` → `LlmConfigSummarySchema.id = z.string()` (NOT `.uuid()`). The response schema is wider than the input schema — if any config has a non-UUID id, autocomplete would accept it and the downstream write would reject it.
+  - Prisma schema declares `LlmConfig.id` as `@db.Uuid`, so all database-backed configs have UUID ids. But this means either (a) a newly-provisioned config is slipping in with a non-UUID id via some code path, or (b) the user manually typed a value instead of picking from autocomplete (which Discord allows for string-option inputs).
+
+  **First investigation step**: have the user confirm whether they picked from autocomplete or typed. If typed, this is a UX gap (need to tighten the bot-side validation before calling the API, or switch to a choice-only option). If picked, something is wrong with autocomplete's value population or the configs list includes a non-UUID id.
+
+  **Fix options** (pending triage):
+  - **(a)** Tighten `LlmConfigSummarySchema.id` to `z.string().uuid()` — forces the gateway to reject non-UUID configs from its own response, catches the class of bug at the response boundary.
+  - **(b)** Bot-side pre-validation: `settings/preset/default.ts` checks the configId is a UUID before calling the API and shows a friendlier error if it's not.
+  - **(c)** Switch the `preset` option from free-text string to `addChoices` (if the config count is reasonable) so users cannot type arbitrary strings.
+  - Probably want both (a) and either (b) or (c).
+
+  Blocker because `/settings preset default` is a core user flow and the error message is opaque ("Invalid configId format" looks like a dev error, not a user-actionable one).
+
+  **Start**:
+  - User-visible error assembly: `services/bot-client/src/commands/settings/preset/default.ts:48` (echoes `result.error` verbatim)
+  - Schema that rejects: `packages/common-types/src/schemas/api/model-override.ts:103` (`SetDefaultConfigSchema`)
+  - Schema that over-permits: `packages/common-types/src/schemas/api/llm-config.ts:204` (`LlmConfigSummarySchema.id` — should tighten to `.uuid()`)
+  - Autocomplete value source: `services/bot-client/src/commands/settings/preset/autocomplete.ts:140`
+  - Gateway handler: `services/api-gateway/src/routes/user/model-override.ts` (PUT `/user/model-override/default`)
+  - Underlying service: `services/api-gateway/src/services/LlmConfigService.ts:333` (`setDefault`)
+
 - 🐛 `[FIX]` **Character field length caps cause silent data loss in dashboard edit + block API updates** — `PersonalityCharacterFieldsSchema` enforces length caps (1000/100/4000 chars per field, matching Discord modal input limits) at the Zod validation layer. Characters with legacy fields exceeding those caps (likely from shapes.inc imports or pre-cap data) exhibit two failure modes:
 
   **1. Silent data loss via dashboard edit** (CRITICAL): When a user clicks a character dashboard section that contains an over-long field (e.g., Biography → Appearance), `ModalFactory.buildSectionModal` silently truncates the pre-fill to `maxLength` chars at `services/bot-client/src/utils/dashboard/ModalFactory.ts:108` (`currentValue.slice(0, maxLength)`). The user sees no warning. If they submit, the trailing content is irrecoverably lost. The truncation is justified at line 107 as "Discord modals require value to be within length constraints" — a genuine API constraint — but the destructive behavior is hidden from the user.
@@ -63,6 +112,24 @@ _Active bugs observed in production. Fix before new features._
 ## 📥 Inbox
 
 _New items go here. Triage to appropriate section weekly._
+
+- 🐛 `[FIX]` **Deleting from dashboard-after-browse loses the browse context — no back-to-browse affordance** — When a user browses to a character/persona/preset via `/... browse` and then clicks Delete in the resulting dashboard, the post-delete screen is just an `editReply` with "✅ Character has been deleted." + stats. There's no button to return to the browse list they came from, even though the session has `browseContext` populated when the dashboard was opened from browse. User has to re-run the browse command to keep going through their collection. Surfaced in conversation 2026-04-17.
+
+  **Scope — affects multiple commands**: `browseContext` is used by `character`, `deny`, `persona`, and `preset` dashboards. All four share the same pattern: dashboard sessions carry a `browseContext: { source: 'browse', page, filter, sort? | query? }` field; back-from-edit preserves it via `handleBackButton`; **delete discards it**. So this is a cross-cutting UX gap, not a single-command bug.
+
+  **Proposed fix** (shape; each command implements independently since their browse flows are not shared yet):
+  - On successful delete, if `session.data.browseContext !== undefined`, render the post-delete confirmation with a "Back to Browse" button whose `customId` encodes the original browse-context (page, filter, sort/query).
+  - The button's handler is already wired — each command's `handleBackButton` consumes the same shape and re-renders the browse list.
+  - If no `browseContext` exists (dashboard opened via direct slash command), render today's post-delete state unchanged.
+  - Tests: one per command asserting that post-delete components include the back-button when browseContext was present, and omit it when absent.
+
+  **Known complication**: the entity no longer exists after delete, so the session lookup by entity slug will be stale by the time the Back-to-Browse button is clicked. The browse list handler needs to re-query the list from scratch (it already does). Just don't try to re-hydrate the session for the deleted entity.
+
+  **Start**:
+  - Delete handlers (per command): `services/bot-client/src/commands/character/dashboardDeleteHandlers.ts`, `services/bot-client/src/commands/preset/dashboardButtons.ts` (`handleDeleteButton`), equivalents in `persona/`, `deny/`
+  - Existing back handler that consumes browseContext: `services/bot-client/src/commands/character/dashboardButtons.ts` `handleBackButton` and equivalents
+  - Session shape: each command's `types.ts` — look for `browseContext?: BrowseContext`
+  - Cross-cut candidate: the pattern may be shared-utility worthy once 3+ commands implement it; follow rule-of-three (do it in the first command, confirm shape with the second, extract on the third).
 
 - 🧹 `[CHORE]` **Normalize logger-message prefixes across bot-client (Pino convention)** — Most log calls in `services/bot-client/src/services/JobTracker.ts` (and likely other bot-client modules) hardcode a module-name prefix into the message string, e.g. `logger.warn({ jobId }, '[JobTracker] Completed job after Xs')`. Per Pino conventions, the `createLogger('JobTracker')` call already tags every message with the module name in the serialized output — the prefix string is redundant and couples the message to the module name (rename → search/replace hazard). Surfaced during PR #820 round 5: I stripped the prefix from one new log in round 2 thinking it was cleaner, then R5 reviewer correctly flagged that leaving 1 without + 10+ with creates ambiguity for future authors. Restored the prefix in that PR to preserve consistency; this backlog item is to do the broader normalization as a dedicated pass. **Fix shape**: grep for `'\[\w+\]` in log-message strings across `services/bot-client/src/`, remove them, verify logs still carry the module name via the `createLogger` tag, update any regex-based log grep/dashboard queries that depend on the bracket prefix. Low risk; touches many lines but no behavior change. **Start**: `grep -rn "'\[" services/bot-client/src/ | grep logger` to enumerate, then tackle one module at a time. Possibly extend scope to api-gateway/ai-worker once bot-client is clean.
 - 🐛 `[FIX]` **Voice generation intermittently fails — investigate** — User has observed TTS/voice-generation failures "every now and again" on 2026-04-17, not yet reproduced deterministically or correlated to a specific cause. Unknown whether the failures originate at ElevenLabs (rate limit / 429, quota, transient network), the voice-engine fallback (cold start timeout, ONNX model load, Pocket TTS failure), the handoff between them, or somewhere further upstream (job failure, audio attachment validation). Existing TTS-adjacent backlog items (ElevenLabs timeout reduction, voice-engine warmup parallelism, STT+voice-engine retry-count audit) cover _known_ tuning opportunities; this item covers the open question of which failure modes are actually occurring in production.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -152,6 +152,22 @@ _New items go here. Triage to appropriate section weekly._
 
   **Start**: `pnpm ops logs --env prod --filter "@tzurot/ai-worker" --since 48h | grep -iE "tts|voice|elevenlabs"` to enumerate recent failures; `services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts` `performElevenLabsTTSWithFallback` for the current fallback sequencing; the existing `ElevenLabsClient` + `VoiceEngineClient` error classifiers as the natural differentiation points.
 
+- 🐛 `[FIX]` **Character `Open Editor` can still blow the 3-second window on cold cache + slow gateway** — The two-click Edit-with-Truncation flow (PR #825 option b) materially narrowed but did not fully eliminate the 3-second risk. `handleOpenEditorButton` in `services/bot-client/src/commands/character/truncationWarning.ts` still calls `resolveCharacterSectionContext` before `interaction.showModal` — because Discord requires `showModal` to be the first response to an interaction, we can't `deferReply` before the resolve. In the common case the session is hot from step 1's warm and this is a sub-ms Redis hit. But a cold-cache fallthrough (Redis eviction, pod cold start, TTL past the step-1 warm window) routes through the gateway's `fetchCharacter`, which can take hundreds of ms to multi-seconds under load. When that blows the window, the handler's 10062 catch surfaces a visible retry message — not silent, but the user is already one click deep into a consent flow and the retry ask is confusing. Surfaced by PR #825 R8 (2026-04-17).
+
+  **Why tracked now (low priority)**: the 10062 fallback is user-actionable (clicks "Open Editor" again, fresh 3-sec window, very likely succeeds on second try), so the bug is not silent. But the retry UX could be improved.
+
+  **Fix options** (none urgent):
+  - **(a)** Pre-resolve the full `CharacterSectionContext` during step 1's warm and stash it in an in-memory cache keyed by the `open_editor` button's customId. Step 2 retrieves synchronously, builds modal, `showModal` with zero async work. Works for single-replica bot-client; breaks on multi-replica unless the cache is Redis-backed (which reintroduces the async). Tzurot is currently single-replica for bot-client (Discord gateway requirement).
+  - **(b)** Pre-build the modal (not just the context) during step 1 and stash the modal JSON. Same trade-offs as (a).
+  - **(c)** Just raise the gateway timeout on `fetchCharacter` when called from the session-helpers path so the cold-cache fetch reliably fits in 3 sec. Smallest change but doesn't defend against the raw Redis latency spike.
+  - Do nothing: the 10062 retry path is user-actionable. Accept the residual and rely on the warn log for frequency monitoring.
+
+  **Start**:
+  - Handler with the residual race: `services/bot-client/src/commands/character/truncationWarning.ts` `handleOpenEditorButton`
+  - 10062 catch: same file, immediately after `await interaction.showModal(modal)`
+  - Session-warm origin: same file, `handleEditTruncatedButton` step 2
+  - Session layer with the gateway fallback: `services/bot-client/src/utils/dashboard/sessionHelpers.ts` `fetchOrCreateSession`
+
 - 🧹 `[CHORE]` **Add lint/test assertion that dashboard section fields declare `maxLength`** — `detectOverLengthFields` in `services/bot-client/src/commands/character/truncationWarning.ts` (and by extension the character field silent-truncation warning) intentionally skips fields where `field.maxLength === undefined`, because `ModalFactory` applies default caps only at modal-show time and we don't want to warn about defaults users can't configure. The tradeoff: if a new section field is ever added to `services/bot-client/src/commands/character/config.ts` without an explicit `maxLength`, the silent-truncate path for that field silently re-opens and users lose data with no warning — same bug the PR #825 fix was designed to prevent, just scoped to new fields. Currently nothing enforces `maxLength` presence; the protection is "discipline + code review." Flagged in PR #825 R3 (2026-04-17).
 
   **Fix options**:

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -37,30 +37,38 @@ _Active bugs observed in production. Fix before new features._
   - Migration that introduced the mismatch: `prisma/migrations/20260416215546_identity_epic_phase_5b_default_persona_not_null/migration.sql`
   - Related sync-order documentation: `syncTables.ts:213-218` (dependency graph)
 
-- 🐛 `[FIX]` **🚫 BETA.100 BLOCKER — `/settings preset default` rejects valid-looking configId as "Invalid configId format"** — Observed 2026-04-17 19:54 UTC by bot owner. Command fails with user-visible: `❌ Failed to set default: configId: Invalid configId format`. This is produced by `SetDefaultConfigSchema` in `packages/common-types/src/schemas/api/model-override.ts:103` — `z.string().uuid(...)`.
+- 🐛 `[FIX]` **🚫 BETA.100 BLOCKER — preset-option autocomplete produces configIds that the gateway rejects as "Invalid configId format"** — First observed via `/settings preset default` on 2026-04-17 19:54 UTC by bot owner, who confirmed the value was **picked from autocomplete** (not typed manually). Failing request produced: `❌ Failed to set default: configId: Invalid configId format`, from `SetDefaultConfigSchema.configId = z.string().uuid(...)` at `packages/common-types/src/schemas/api/model-override.ts:103`.
+
+  **Scope — this is a cross-command pattern, not a single-command bug**: every command that feeds preset-autocomplete values into a gateway endpoint with a `.uuid()` configId schema is on the same failure path. Enumerated consumers (grep for autocomplete files + `.uuid()` schemas):
+  - `/settings preset default` — `settings/preset/default.ts` → PUT `/user/model-override/default` → `SetDefaultConfigSchema`
+  - `/settings preset set` — `settings/preset/set.ts` (if it exists) → PUT `/user/model-override` → `SetModelOverrideSchema` (configId + personalityId, both `.uuid()`)
+  - `/preset edit <preset>` — top-level `/preset` autocomplete in `services/bot-client/src/commands/preset/autocomplete.ts` — same `c.id` shape, hits `LlmConfigService` detail/update endpoints
+  - Any other command whose autocomplete uses the `value: c.id` pattern and whose downstream API validates with `.uuid()`. Grep target when fixing: `grep -rn "value: c\.id" services/bot-client/src/commands/` + cross-reference against `packages/common-types/src/schemas/api/` for matching `.uuid()` schemas.
+  - **Personality autocomplete may share the class**: `handlePersonalityAutocomplete` with `valueField: 'id'` feeds `personalityId: z.string().uuid()` in several schemas. Same failure mode is possible if a non-UUID personality id ever reaches the list response.
 
   **Investigation pointers — what is and isn't known**:
-  - Command flow: bot-client `settings/preset/default.ts` → reads `options.preset()` → `PUT /user/model-override/default { configId }` → api-gateway validates with `SetDefaultConfigSchema` → rejects non-UUID.
-  - Autocomplete at `settings/preset/autocomplete.ts:140` sets `value: c.id`, where `c.id` comes from `/user/llm-config` → `LlmConfigSummarySchema.id = z.string()` (NOT `.uuid()`). The response schema is wider than the input schema — if any config has a non-UUID id, autocomplete would accept it and the downstream write would reject it.
-  - Prisma schema declares `LlmConfig.id` as `@db.Uuid`, so all database-backed configs have UUID ids. But this means either (a) a newly-provisioned config is slipping in with a non-UUID id via some code path, or (b) the user manually typed a value instead of picking from autocomplete (which Discord allows for string-option inputs).
+  - Bot owner picked from autocomplete, so the user-typed hypothesis is ruled out.
+  - Autocomplete at `settings/preset/autocomplete.ts:140` sets `value: c.id`, where `c.id` comes from `/user/llm-config` → `LlmConfigSummarySchema.id = z.string()` (NOT `.uuid()`). The response schema is wider than the input schema — if any config has a non-UUID id, autocomplete accepts it and the downstream write rejects it.
+  - Prisma schema declares `LlmConfig.id` as `@db.Uuid`, so DB-backed configs should all have UUID ids. So either (a) a code path is creating/surfacing a config with a non-UUID id (bug), or (b) autocomplete is submitting something subtly different from what was selected (encoding/race condition), or (c) the list response is picking up a synthesized-but-non-UUID id somewhere (e.g., a virtual "free default" or upsell-style entry that wasn't fully caught).
+  - `UNLOCK_MODELS_VALUE = '__unlock_all_models__'` is handled upstream by `handleUnlockModelsUpsell`, so that's not the culprit.
 
-  **First investigation step**: have the user confirm whether they picked from autocomplete or typed. If typed, this is a UX gap (need to tighten the bot-side validation before calling the API, or switch to a choice-only option). If picked, something is wrong with autocomplete's value population or the configs list includes a non-UUID id.
+  **First investigation step**: add temporary log at `settings/preset/default.ts:28` capturing the raw `configId` that came off the interaction, then reproduce. Compare against the `/user/llm-config` response to see whether a specific config entry has a malformed id or whether the autocomplete mechanism is mangling the value.
 
-  **Fix options** (pending triage):
-  - **(a)** Tighten `LlmConfigSummarySchema.id` to `z.string().uuid()` — forces the gateway to reject non-UUID configs from its own response, catches the class of bug at the response boundary.
-  - **(b)** Bot-side pre-validation: `settings/preset/default.ts` checks the configId is a UUID before calling the API and shows a friendlier error if it's not.
-  - **(c)** Switch the `preset` option from free-text string to `addChoices` (if the config count is reasonable) so users cannot type arbitrary strings.
-  - Probably want both (a) and either (b) or (c).
+  **Fix options** (pending triage + root-cause confirmation):
+  - **(a)** Tighten `LlmConfigSummarySchema.id` to `z.string().uuid()` — forces the gateway to reject non-UUID configs at the response boundary. Does nothing about the pre-existing data that might already be broken, but it catches the next recurrence at the source.
+  - **(b)** Bot-side pre-validation in every preset consumer: check the configId is a UUID before calling the API; show a friendlier error ("This preset can't be used — please pick another, or report this to the admin if it keeps happening").
+  - **(c)** Audit database for any LlmConfig rows with non-UUID ids: `SELECT id FROM llm_configs WHERE id !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$';` If found, either migrate or delete.
+  - Probably want all three, and the fix should sweep every preset-consuming command as a single pass.
 
-  Blocker because `/settings preset default` is a core user flow and the error message is opaque ("Invalid configId format" looks like a dev error, not a user-actionable one).
+  Blocker because preset configuration is a core user flow; the error is opaque ("Invalid configId format" looks like a dev error, not user-actionable); and failing silently across multiple commands is worse than failing noisily in one.
 
-  **Start**:
-  - User-visible error assembly: `services/bot-client/src/commands/settings/preset/default.ts:48` (echoes `result.error` verbatim)
-  - Schema that rejects: `packages/common-types/src/schemas/api/model-override.ts:103` (`SetDefaultConfigSchema`)
-  - Schema that over-permits: `packages/common-types/src/schemas/api/llm-config.ts:204` (`LlmConfigSummarySchema.id` — should tighten to `.uuid()`)
-  - Autocomplete value source: `services/bot-client/src/commands/settings/preset/autocomplete.ts:140`
-  - Gateway handler: `services/api-gateway/src/routes/user/model-override.ts` (PUT `/user/model-override/default`)
-  - Underlying service: `services/api-gateway/src/services/LlmConfigService.ts:333` (`setDefault`)
+  **Start** (cast wide):
+  - Enumerate all preset consumers: `grep -rn "autocomplete\|preset" services/bot-client/src/commands/ | grep -v test`
+  - Enumerate all schemas with `configId: z.string().uuid(...)`: `grep -rn "configId.*uuid" packages/common-types/src/schemas/`
+  - Check the response schema: `packages/common-types/src/schemas/api/llm-config.ts:204` (`LlmConfigSummarySchema.id` — tighten to `.uuid()`)
+  - Initial observed failure: `services/bot-client/src/commands/settings/preset/default.ts:48` (echoes `result.error` verbatim)
+  - Top-level preset command autocomplete (second likely victim): `services/bot-client/src/commands/preset/autocomplete.ts`
+  - Prod DB audit query (see fix option c above) run via `pnpm ops run --env prod psql` or equivalent
 
 - 🐛 `[FIX]` **Character field length caps cause silent data loss in dashboard edit + block API updates** — `PersonalityCharacterFieldsSchema` enforces length caps (1000/100/4000 chars per field, matching Discord modal input limits) at the Zod validation layer. Characters with legacy fields exceeding those caps (likely from shapes.inc imports or pre-cap data) exhibit two failure modes:
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -77,6 +77,34 @@ _New items go here. Triage to appropriate section weekly._
 
   **Start**: `pnpm ops logs --env prod --filter "@tzurot/ai-worker" --since 48h | grep -iE "tts|voice|elevenlabs"` to enumerate recent failures; `services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts` `performElevenLabsTTSWithFallback` for the current fallback sequencing; the existing `ElevenLabsClient` + `VoiceEngineClient` error classifiers as the natural differentiation points.
 
+- 🐛 `[FIX]` **Character truncation warning → Edit button silent-failure when interaction times out** — `handleEditTruncatedButton` in `services/bot-client/src/commands/character/truncationWarning.ts` cannot `deferUpdate` before the async work because Discord requires `showModal` to be the _first_ response to the interaction (deferring poisons the modal path). The handler therefore calls `resolveCharacterSectionContext` — which hits Redis and may fall through to a gateway `fetchCharacter` call — _before_ the ack. In the common case the session is Redis-cached from the preceding select-menu interaction and the async work fits inside Discord's 3-second window. But users can leave the warning embed on screen indefinitely, and a session TTL expiry + slow gateway response can blow the budget. When `showModal` then throws `10062 Unknown interaction`, `CommandHandler.handleComponentInteraction:350` catches the throw and calls `sendErrorReply`, but `reply()` on a dead interaction also throws 10062 — the inner try/catch at line 358 logs to debug and the user sees a silent no-op. Surfaced during PR #825 R3 review (2026-04-17).
+
+  **Fix options** (not yet chosen — need UX + engineering input):
+  - **(a)** Pre-fetch + session-warm on the select-menu interaction so the cache miss path is effectively dead (wastes work when the user picks View Full or Cancel).
+  - **(b)** Swap the Edit-with-Truncation flow to use `update` + a follow-up "click here to open the editor" link, moving the modal behind a second interaction where a defer _is_ legal. Extra click, but eliminates the 3-second risk entirely.
+  - **(c)** Replace the warning with a fresh interaction on click (Discord returns a new token), re-resolving context via `deferReply`. Simplest but slowest — user waits through the defer ack twice.
+
+  **Why it's latent**: the 3-second window is only blown on cache miss + slow gateway. In the common case users click within seconds and the session is hot. Not reproduced in production yet, but the failure mode is known.
+
+  **Start**:
+  - Timeout site: `services/bot-client/src/commands/character/truncationWarning.ts` `handleEditTruncatedButton`
+  - Error-handling chain that swallows the 10062: `services/bot-client/src/handlers/CommandHandler.ts:350-360`
+  - sendErrorReply (the swallower): `services/bot-client/src/handlers/CommandHandler.ts:53-66`
+
+- 🧹 `[CHORE]` **Add lint/test assertion that dashboard section fields declare `maxLength`** — `detectOverLengthFields` in `services/bot-client/src/commands/character/truncationWarning.ts` (and by extension the character field silent-truncation warning) intentionally skips fields where `field.maxLength === undefined`, because `ModalFactory` applies default caps only at modal-show time and we don't want to warn about defaults users can't configure. The tradeoff: if a new section field is ever added to `services/bot-client/src/commands/character/config.ts` without an explicit `maxLength`, the silent-truncate path for that field silently re-opens and users lose data with no warning — same bug the PR #825 fix was designed to prevent, just scoped to new fields. Currently nothing enforces `maxLength` presence; the protection is "discipline + code review." Flagged in PR #825 R3 (2026-04-17).
+
+  **Fix options**:
+  - **(a)** Narrow the `FieldDefinition` type: make `maxLength` required on text/paragraph input types. Catches the bug at compile time; may require minor churn at each call site that currently omits it.
+  - **(b)** Add a structure.test.ts-style assertion that walks the dashboard config and fails CI if any field has input `TextInputStyle.Paragraph` / `Short` without `maxLength`. Runtime check, same signal, weaker — runs only in CI.
+  - **(c)** Doc-only: add a JSDoc note on `FieldDefinition.maxLength` documenting the invariant, relying on code review. Weakest, not recommended.
+
+  Option (a) is the cleanest long-term. (b) is the cheaper short-term.
+
+  **Start**:
+  - Current skip logic: `services/bot-client/src/commands/character/truncationWarning.ts` `detectOverLengthFields`
+  - Field definitions: `services/bot-client/src/utils/dashboard/types.ts` (look for `FieldDefinition`)
+  - Consumer config: `services/bot-client/src/commands/character/config.ts`
+
 - 🐛 `[FIX]` **Typing indicator intermittently stops during long AI responses — investigate** — User has observed the "bot is typing…" indicator disappearing before the AI response actually lands, multiple times, not yet reproduced deterministically. Unclear whether this is a bot-side bug (failed `sendTyping` refresh not recovering) or a Discord client-side display glitch (indicator sent but not rendered).
 
   **Current implementation — two independent typing loops**:

--- a/services/bot-client/src/commands/character/dashboard.test.ts
+++ b/services/bot-client/src/commands/character/dashboard.test.ts
@@ -13,6 +13,7 @@ import { handleDashboardClose } from '../../utils/dashboard/closeHandler.js';
 import * as api from './api.js';
 import * as createModule from './create.js';
 import * as viewModule from './view.js';
+import * as truncationWarning from './truncationWarning.js';
 import * as dashboardUtils from '../../utils/dashboard/index.js';
 import * as customIds from '../../utils/customIds.js';
 import type { EnvConfig } from '@tzurot/common-types';
@@ -44,6 +45,17 @@ vi.mock('./create.js', () => ({
 vi.mock('./view.js', () => ({
   handleViewPagination: vi.fn(),
   handleExpandField: vi.fn(),
+}));
+
+vi.mock('./truncationWarning.js', () => ({
+  handleEditTruncatedButton: vi.fn(),
+  handleViewFullButton: vi.fn(),
+  handleCancelEditButton: vi.fn(),
+  // These are only referenced via handleSelectMenu's overlap-detect +
+  // warning-display path; stubbing them keeps the button-routing tests
+  // isolated from that branch.
+  detectOverLengthFields: vi.fn().mockReturnValue([]),
+  showTruncationWarning: vi.fn(),
 }));
 
 vi.mock('../../utils/dashboard/index.js', async () => {
@@ -589,6 +601,94 @@ describe('Character Dashboard', () => {
         components: [],
       });
     });
+
+    // Truncation-warning button dispatch — verifies the router in
+    // `handleButton` maps the three underscore-delimited action names to
+    // the correct downstream handlers in truncationWarning.ts. A typo in
+    // any of these action strings would otherwise be invisible because
+    // the handlers are tested separately in truncationWarning.test.ts.
+    it('should route edit_truncated to handleEditTruncatedButton', async () => {
+      vi.mocked(customIds.CharacterCustomIds.parse).mockReturnValue(null);
+      vi.mocked(dashboardUtils.parseDashboardCustomId).mockReturnValue({
+        entityType: 'character',
+        action: 'edit_truncated',
+        entityId: 'test-char',
+        sectionId: 'identity',
+      });
+
+      const mockInteraction = createMockButtonInteraction(
+        'character::edit_truncated::test-char::identity'
+      );
+
+      await handleButton(mockInteraction);
+
+      expect(truncationWarning.handleEditTruncatedButton).toHaveBeenCalledWith(
+        mockInteraction,
+        'test-char',
+        'identity',
+        expect.any(Object)
+      );
+    });
+
+    it('should route view_full to handleViewFullButton', async () => {
+      vi.mocked(customIds.CharacterCustomIds.parse).mockReturnValue(null);
+      vi.mocked(dashboardUtils.parseDashboardCustomId).mockReturnValue({
+        entityType: 'character',
+        action: 'view_full',
+        entityId: 'test-char',
+        sectionId: 'identity',
+      });
+
+      const mockInteraction = createMockButtonInteraction(
+        'character::view_full::test-char::identity'
+      );
+
+      await handleButton(mockInteraction);
+
+      expect(truncationWarning.handleViewFullButton).toHaveBeenCalledWith(
+        mockInteraction,
+        'test-char',
+        'identity',
+        expect.any(Object)
+      );
+    });
+
+    it('should route cancel_edit to handleCancelEditButton', async () => {
+      vi.mocked(customIds.CharacterCustomIds.parse).mockReturnValue(null);
+      vi.mocked(dashboardUtils.parseDashboardCustomId).mockReturnValue({
+        entityType: 'character',
+        action: 'cancel_edit',
+        entityId: 'test-char',
+        sectionId: 'identity',
+      });
+
+      const mockInteraction = createMockButtonInteraction(
+        'character::cancel_edit::test-char::identity'
+      );
+
+      await handleButton(mockInteraction);
+
+      expect(truncationWarning.handleCancelEditButton).toHaveBeenCalledWith(mockInteraction);
+    });
+
+    it('should NOT call edit_truncated handler when sectionId is missing', async () => {
+      // The router guards with `sectionId !== undefined`. Without a sectionId
+      // the handler would crash trying to build the modal, so the branch
+      // falls through silently.
+      vi.mocked(customIds.CharacterCustomIds.parse).mockReturnValue(null);
+      vi.mocked(dashboardUtils.parseDashboardCustomId).mockReturnValue({
+        entityType: 'character',
+        action: 'edit_truncated',
+        entityId: 'test-char',
+        sectionId: undefined,
+      });
+
+      const mockInteraction = createMockButtonInteraction('character::edit_truncated::test-char');
+
+      await handleButton(mockInteraction);
+
+      expect(truncationWarning.handleEditTruncatedButton).not.toHaveBeenCalled();
+    });
   });
 
   describe('isCharacterDashboardInteraction', () => {
@@ -605,6 +705,9 @@ describe('Character Dashboard', () => {
         'delete',
         'delete_confirm',
         'delete_cancel',
+        'edit_truncated',
+        'view_full',
+        'cancel_edit',
       ];
 
       for (const action of dashboardActions) {

--- a/services/bot-client/src/commands/character/dashboard.test.ts
+++ b/services/bot-client/src/commands/character/dashboard.test.ts
@@ -717,6 +717,46 @@ describe('Character Dashboard', () => {
 
       expect(truncationWarning.handleEditTruncatedButton).not.toHaveBeenCalled();
     });
+
+    it('should NOT call view_full handler when sectionId is missing', async () => {
+      // Parallel guard: same `sectionId !== undefined` check as edit_truncated.
+      // A typo that drops the guard or rewrites the action key would pass CI
+      // without this test because the downstream handler tolerates missing
+      // section context via sectionContext's ephemeral error path.
+      vi.mocked(customIds.CharacterCustomIds.parse).mockReturnValue(null);
+      vi.mocked(dashboardUtils.parseDashboardCustomId).mockReturnValue({
+        entityType: 'character',
+        action: 'view_full',
+        entityId: 'test-char',
+        sectionId: undefined,
+      });
+
+      const mockInteraction = createMockButtonInteraction('character::view_full::test-char');
+
+      await handleButton(mockInteraction);
+
+      expect(truncationWarning.handleViewFullButton).not.toHaveBeenCalled();
+    });
+
+    it('should NOT call open_editor handler when sectionId is missing', async () => {
+      // Parallel guard for the two-click flow's step 2. Missing sectionId
+      // here means the button customId was malformed, which the router
+      // handles by falling through silently rather than invoking showModal
+      // on undefined section context (which would throw).
+      vi.mocked(customIds.CharacterCustomIds.parse).mockReturnValue(null);
+      vi.mocked(dashboardUtils.parseDashboardCustomId).mockReturnValue({
+        entityType: 'character',
+        action: 'open_editor',
+        entityId: 'test-char',
+        sectionId: undefined,
+      });
+
+      const mockInteraction = createMockButtonInteraction('character::open_editor::test-char');
+
+      await handleButton(mockInteraction);
+
+      expect(truncationWarning.handleOpenEditorButton).not.toHaveBeenCalled();
+    });
   });
 
   describe('isCharacterDashboardInteraction', () => {

--- a/services/bot-client/src/commands/character/dashboard.test.ts
+++ b/services/bot-client/src/commands/character/dashboard.test.ts
@@ -49,6 +49,7 @@ vi.mock('./view.js', () => ({
 
 vi.mock('./truncationWarning.js', () => ({
   handleEditTruncatedButton: vi.fn(),
+  handleOpenEditorButton: vi.fn(),
   handleViewFullButton: vi.fn(),
   handleCancelEditButton: vi.fn(),
   // These are only referenced via handleSelectMenu's overlap-detect +
@@ -653,6 +654,33 @@ describe('Character Dashboard', () => {
       );
     });
 
+    it('should route open_editor to handleOpenEditorButton', async () => {
+      // Step 2 of the two-click Edit-with-Truncation flow. The button's
+      // customId carries entity + section so the handler can build the
+      // modal with zero preamble — session is warmed by the preceding
+      // edit_truncated click.
+      vi.mocked(customIds.CharacterCustomIds.parse).mockReturnValue(null);
+      vi.mocked(dashboardUtils.parseDashboardCustomId).mockReturnValue({
+        entityType: 'character',
+        action: 'open_editor',
+        entityId: 'test-char',
+        sectionId: 'identity',
+      });
+
+      const mockInteraction = createMockButtonInteraction(
+        'character::open_editor::test-char::identity'
+      );
+
+      await handleButton(mockInteraction);
+
+      expect(truncationWarning.handleOpenEditorButton).toHaveBeenCalledWith(
+        mockInteraction,
+        'test-char',
+        'identity',
+        expect.any(Object)
+      );
+    });
+
     it('should route cancel_edit to handleCancelEditButton', async () => {
       vi.mocked(customIds.CharacterCustomIds.parse).mockReturnValue(null);
       vi.mocked(dashboardUtils.parseDashboardCustomId).mockReturnValue({
@@ -707,6 +735,7 @@ describe('Character Dashboard', () => {
         'delete_cancel',
         'edit_truncated',
         'view_full',
+        'open_editor',
         'cancel_edit',
       ];
 

--- a/services/bot-client/src/commands/character/dashboard.ts
+++ b/services/bot-client/src/commands/character/dashboard.ts
@@ -21,20 +21,16 @@ import {
   buildSectionModal,
   extractAndMergeSectionValues,
   getSessionManager,
-  fetchOrCreateSession,
   parseDashboardCustomId,
   isDashboardInteraction,
-  type DashboardContext,
 } from '../../utils/dashboard/index.js';
-import { DASHBOARD_MESSAGES } from '../../utils/dashboard/messages.js';
 import { CharacterCustomIds } from '../../utils/customIds.js';
 import {
   getCharacterDashboardConfig,
   buildCharacterDashboardOptions,
-  type CharacterData,
   type CharacterSessionData,
 } from './config.js';
-import { fetchCharacter, updateCharacter } from './api.js';
+import { updateCharacter } from './api.js';
 import { handleAction } from './dashboardActions.js';
 import { handleSeedModalSubmit } from './create.js';
 import { handleDeleteAction, handleDeleteButton } from './dashboardDeleteHandlers.js';
@@ -48,6 +44,7 @@ import {
   handleViewFullButton,
   showTruncationWarning,
 } from './truncationWarning.js';
+import { resolveCharacterSectionContext } from './sectionContext.js';
 
 const logger = createLogger('character-dashboard');
 
@@ -195,12 +192,11 @@ export async function handleSelectMenu(interaction: StringSelectMenuInteraction)
   const value = interaction.values[0];
   const entityId = parsed.entityId;
 
-  // Determine admin status for context-aware features.
-  // hasVoiceReference=false is fine here — config is only used for section
-  // lookup and modal building, not action rendering.
+  // isAdmin is needed for the admin-section security check below. The
+  // rest of the section context (dashboardConfig, data, DashboardContext)
+  // is resolved inside resolveCharacterSectionContext so the select-menu
+  // path shares its preamble with the truncation-warning button handlers.
   const isAdmin = isBotOwner(interaction.user.id);
-  const dashboardConfig = getCharacterDashboardConfig(isAdmin, false);
-  const context: DashboardContext = { isAdmin, userId: interaction.user.id };
 
   // Handle section edit selection
   if (value.startsWith('edit-')) {
@@ -219,45 +215,31 @@ export async function handleSelectMenu(interaction: StringSelectMenuInteraction)
       return;
     }
 
-    const section = dashboardConfig.sections.find(s => s.id === sectionId);
-    if (!section) {
-      await interaction.reply({
-        content: '❌ Unknown section.',
-        flags: MessageFlags.Ephemeral,
-      });
-      return;
-    }
-
-    // Get current data from session or fetch from API
-    const result = await fetchOrCreateSession<CharacterSessionData, CharacterData>({
-      userId: interaction.user.id,
-      entityType: 'character',
-      entityId,
-      fetchFn: () => fetchCharacter(entityId, config, interaction.user.id),
-      transformFn: (character: CharacterData) => ({ ...character, _isAdmin: isAdmin }),
-      interaction,
-    });
-    if (!result.success) {
-      await interaction.reply({
-        content: DASHBOARD_MESSAGES.NOT_FOUND('Character'),
-        flags: MessageFlags.Ephemeral,
-      });
-      return;
-    }
+    // Section lookup + data fetch are shared with the truncation-warning
+    // button handlers; see sectionContext.ts. Helper sends its own
+    // ephemeral error reply and returns null on failure.
+    const ctx = await resolveCharacterSectionContext(interaction, entityId, sectionId, config);
+    if (ctx === null) {return;}
 
     // Gate the modal on an informed consent when any field in the section
     // currently holds a value longer than its modal maxLength. The silent
     // truncation would otherwise happen in ModalFactory without user
     // awareness — see BACKLOG Production Issue on character field
     // silent data loss.
-    const overLength = detectOverLengthFields(section, result.data);
+    const overLength = detectOverLengthFields(ctx.section, ctx.data);
     if (overLength.length > 0) {
-      await showTruncationWarning(interaction, section, entityId, overLength);
+      await showTruncationWarning(interaction, ctx.section, entityId, overLength);
       return;
     }
 
     // Build and show section modal (with context for field visibility)
-    const modal = buildSectionModal(dashboardConfig, section, entityId, result.data, context);
+    const modal = buildSectionModal(
+      ctx.dashboardConfig,
+      ctx.section,
+      entityId,
+      ctx.data,
+      ctx.context
+    );
     await interaction.showModal(modal);
     return;
   }

--- a/services/bot-client/src/commands/character/dashboard.ts
+++ b/services/bot-client/src/commands/character/dashboard.ts
@@ -219,7 +219,9 @@ export async function handleSelectMenu(interaction: StringSelectMenuInteraction)
     // button handlers; see sectionContext.ts. Helper sends its own
     // ephemeral error reply and returns null on failure.
     const ctx = await resolveCharacterSectionContext(interaction, entityId, sectionId, config);
-    if (ctx === null) {return;}
+    if (ctx === null) {
+      return;
+    }
 
     // Gate the modal on an informed consent when any field in the section
     // currently holds a value longer than its modal maxLength. The silent
@@ -356,20 +358,25 @@ export async function handleButton(interaction: ButtonInteraction): Promise<void
 
   // Truncation-warning flow: three buttons rendered after the user picks
   // a section containing values longer than the modal maxLength. See
-  // truncationWarning.ts for the producer side.
+  // truncationWarning.ts for the producer side. Underscored action names
+  // match the existing `delete_confirm` / `delete_cancel` convention.
   const sectionId = parsed.sectionId;
-  if (action === 'edit-truncated' && sectionId !== undefined) {
+  if (action === 'edit_truncated' && sectionId !== undefined) {
     await handleEditTruncatedButton(interaction, entityId, sectionId, config);
     return;
   }
 
-  if (action === 'view-full' && sectionId !== undefined) {
+  if (action === 'view_full' && sectionId !== undefined) {
     await handleViewFullButton(interaction, entityId, sectionId, config);
     return;
   }
 
-  if (action === 'cancel-edit') {
+  if (action === 'cancel_edit') {
     await handleCancelEditButton(interaction);
+    // Matches the per-branch early-return pattern above; dropping the return
+    // would silently fall through when a future action is appended here.
+    // eslint-disable-next-line sonarjs/no-redundant-jump -- explained above
+    return;
   }
 }
 
@@ -383,9 +390,9 @@ const DASHBOARD_ACTIONS = new Set([
   'delete',
   'delete_confirm',
   'delete_cancel',
-  'edit-truncated',
-  'view-full',
-  'cancel-edit',
+  'edit_truncated',
+  'view_full',
+  'cancel_edit',
 ]);
 
 /**

--- a/services/bot-client/src/commands/character/dashboard.ts
+++ b/services/bot-client/src/commands/character/dashboard.ts
@@ -41,6 +41,7 @@ import {
   detectOverLengthFields,
   handleCancelEditButton,
   handleEditTruncatedButton,
+  handleOpenEditorButton,
   handleViewFullButton,
   showTruncationWarning,
 } from './truncationWarning.js';
@@ -371,6 +372,14 @@ export async function handleButton(interaction: ButtonInteraction): Promise<void
     return;
   }
 
+  // `open_editor` is step 2 of the Edit-with-Truncation two-click flow.
+  // The customId carries entity + section so the handler can build the
+  // modal with zero pre-work (session warmed by step 1's handler).
+  if (action === 'open_editor' && sectionId !== undefined) {
+    await handleOpenEditorButton(interaction, entityId, sectionId, config);
+    return;
+  }
+
   if (action === 'cancel_edit') {
     await handleCancelEditButton(interaction);
     // eslint-disable-next-line sonarjs/no-redundant-jump -- future-proofing: keeps the per-branch early-return pattern so appending a new action below this block can't silently fall through into the wrong handler
@@ -390,6 +399,7 @@ const DASHBOARD_ACTIONS = new Set([
   'delete_cancel',
   'edit_truncated',
   'view_full',
+  'open_editor',
   'cancel_edit',
 ]);
 

--- a/services/bot-client/src/commands/character/dashboard.ts
+++ b/services/bot-client/src/commands/character/dashboard.ts
@@ -41,6 +41,13 @@ import { handleDeleteAction, handleDeleteButton } from './dashboardDeleteHandler
 // Note: Browse pagination is handled in index.ts via handleBrowsePagination
 import { handleViewPagination, handleExpandField } from './view.js';
 import { handleBackButton, handleRefreshButton, handleCloseButton } from './dashboardButtons.js';
+import {
+  detectOverLengthFields,
+  handleCancelEditButton,
+  handleEditTruncatedButton,
+  handleViewFullButton,
+  showTruncationWarning,
+} from './truncationWarning.js';
 
 const logger = createLogger('character-dashboard');
 
@@ -238,6 +245,17 @@ export async function handleSelectMenu(interaction: StringSelectMenuInteraction)
       return;
     }
 
+    // Gate the modal on an informed consent when any field in the section
+    // currently holds a value longer than its modal maxLength. The silent
+    // truncation would otherwise happen in ModalFactory without user
+    // awareness — see BACKLOG Production Issue on character field
+    // silent data loss.
+    const overLength = detectOverLengthFields(section, result.data);
+    if (overLength.length > 0) {
+      await showTruncationWarning(interaction, section, entityId, overLength);
+      return;
+    }
+
     // Build and show section modal (with context for field visibility)
     const modal = buildSectionModal(dashboardConfig, section, entityId, result.data, context);
     await interaction.showModal(modal);
@@ -351,6 +369,25 @@ export async function handleButton(interaction: ButtonInteraction): Promise<void
 
   if (action === 'delete') {
     await handleDeleteAction(interaction, entityId, config);
+    return;
+  }
+
+  // Truncation-warning flow: three buttons rendered after the user picks
+  // a section containing values longer than the modal maxLength. See
+  // truncationWarning.ts for the producer side.
+  const sectionId = parsed.sectionId;
+  if (action === 'edit-truncated' && sectionId !== undefined) {
+    await handleEditTruncatedButton(interaction, entityId, sectionId, config);
+    return;
+  }
+
+  if (action === 'view-full' && sectionId !== undefined) {
+    await handleViewFullButton(interaction, entityId, sectionId, config);
+    return;
+  }
+
+  if (action === 'cancel-edit') {
+    await handleCancelEditButton(interaction);
   }
 }
 
@@ -364,6 +401,9 @@ const DASHBOARD_ACTIONS = new Set([
   'delete',
   'delete_confirm',
   'delete_cancel',
+  'edit-truncated',
+  'view-full',
+  'cancel-edit',
 ]);
 
 /**

--- a/services/bot-client/src/commands/character/dashboard.ts
+++ b/services/bot-client/src/commands/character/dashboard.ts
@@ -373,9 +373,7 @@ export async function handleButton(interaction: ButtonInteraction): Promise<void
 
   if (action === 'cancel_edit') {
     await handleCancelEditButton(interaction);
-    // Matches the per-branch early-return pattern above; dropping the return
-    // would silently fall through when a future action is appended here.
-    // eslint-disable-next-line sonarjs/no-redundant-jump -- explained above
+    // eslint-disable-next-line sonarjs/no-redundant-jump -- future-proofing: keeps the per-branch early-return pattern so appending a new action below this block can't silently fall through into the wrong handler
     return;
   }
 }

--- a/services/bot-client/src/commands/character/sectionContext.test.ts
+++ b/services/bot-client/src/commands/character/sectionContext.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for resolveCharacterSectionContext
+ *
+ * Targets the shared preamble: admin resolution, section lookup, data
+ * fetch, and the null-returning error paths for unknown sections and
+ * missing characters. The downstream handlers (truncation warning,
+ * section modal) have their own test files; here we isolate the
+ * resolver's contract.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MessageFlags } from 'discord.js';
+import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
+
+// Mock common-types logger + isBotOwner.
+const mockIsBotOwner = vi.fn().mockReturnValue(false);
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+    isBotOwner: (...args: unknown[]) => mockIsBotOwner(...args),
+    getConfig: vi.fn().mockReturnValue({}),
+  };
+});
+
+const mockFetchCharacter = vi.fn();
+vi.mock('./api.js', () => ({
+  fetchCharacter: (...args: unknown[]) => mockFetchCharacter(...args),
+}));
+
+const mockFetchOrCreateSession = vi.fn();
+vi.mock('../../utils/dashboard/index.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../utils/dashboard/index.js')>();
+  return {
+    ...actual,
+    fetchOrCreateSession: (...args: unknown[]) => mockFetchOrCreateSession(...args),
+  };
+});
+
+const { resolveCharacterSectionContext } = await import('./sectionContext.js');
+
+describe('resolveCharacterSectionContext', () => {
+  beforeEach(() => {
+    mockFetchOrCreateSession.mockReset();
+    mockIsBotOwner.mockReturnValue(false);
+  });
+
+  it('returns the full bundle on success', async () => {
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { slug: 'hero', name: 'Hero', _isAdmin: false },
+    });
+    const mockReply = vi.fn();
+    const interaction = {
+      user: { id: 'user-1' },
+      reply: mockReply,
+    } as unknown as ButtonInteraction;
+
+    const result = await resolveCharacterSectionContext(
+      interaction,
+      'hero',
+      'identity',
+      {} as never
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.section.id).toBe('identity');
+    expect(result?.isAdmin).toBe(false);
+    expect(result?.data.name).toBe('Hero');
+    expect(result?.context).toEqual({ isAdmin: false, userId: 'user-1' });
+    expect(mockReply).not.toHaveBeenCalled();
+  });
+
+  it('propagates admin status from isBotOwner into context + transform', async () => {
+    mockIsBotOwner.mockReturnValue(true);
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { slug: 'hero', name: 'Hero', _isAdmin: true },
+    });
+    const interaction = {
+      user: { id: 'admin-1' },
+      reply: vi.fn(),
+    } as unknown as ButtonInteraction;
+
+    const result = await resolveCharacterSectionContext(
+      interaction,
+      'hero',
+      'identity',
+      {} as never
+    );
+
+    expect(result?.isAdmin).toBe(true);
+    expect(result?.context.isAdmin).toBe(true);
+    // Verify fetchOrCreateSession was invoked with the admin-tagged transform
+    const invokeArgs = mockFetchOrCreateSession.mock.calls[0][0];
+    const transformed = invokeArgs.transformFn({ slug: 'hero', name: 'Hero' });
+    expect(transformed._isAdmin).toBe(true);
+  });
+
+  it('replies with "Unknown section" and returns null for a missing section id', async () => {
+    const mockReply = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      user: { id: 'user-1' },
+      reply: mockReply,
+    } as unknown as StringSelectMenuInteraction;
+
+    const result = await resolveCharacterSectionContext(
+      interaction,
+      'hero',
+      'nonexistent-section-id',
+      {} as never
+    );
+
+    expect(result).toBeNull();
+    expect(mockReply).toHaveBeenCalledWith({
+      content: '❌ Unknown section.',
+      flags: MessageFlags.Ephemeral,
+    });
+    // Must NOT attempt to fetch the character when the section is unknown
+    expect(mockFetchOrCreateSession).not.toHaveBeenCalled();
+  });
+
+  it('replies with "Character not found" and returns null when the fetch fails', async () => {
+    mockFetchOrCreateSession.mockResolvedValue({ success: false });
+    const mockReply = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      user: { id: 'user-1' },
+      reply: mockReply,
+    } as unknown as ButtonInteraction;
+
+    const result = await resolveCharacterSectionContext(
+      interaction,
+      'hero',
+      'identity',
+      {} as never
+    );
+
+    expect(result).toBeNull();
+    expect(mockReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('not found'),
+        flags: MessageFlags.Ephemeral,
+      })
+    );
+  });
+});

--- a/services/bot-client/src/commands/character/sectionContext.test.ts
+++ b/services/bot-client/src/commands/character/sectionContext.test.ts
@@ -149,4 +149,36 @@ describe('resolveCharacterSectionContext', () => {
       })
     );
   });
+
+  it('routes error replies through followUp when the caller already deferred', async () => {
+    // Simulates `handleViewFullButton`, which `deferReply`s before calling
+    // this helper. The helper must detect `interaction.deferred` and use
+    // `followUp` — `reply()` on a deferred interaction throws.
+    mockFetchOrCreateSession.mockResolvedValue({ success: false });
+    const mockFollowUp = vi.fn().mockResolvedValue(undefined);
+    const mockReply = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      user: { id: 'user-1' },
+      deferred: true,
+      replied: false,
+      followUp: mockFollowUp,
+      reply: mockReply,
+    } as unknown as ButtonInteraction;
+
+    const result = await resolveCharacterSectionContext(
+      interaction,
+      'hero',
+      'identity',
+      {} as never
+    );
+
+    expect(result).toBeNull();
+    expect(mockReply).not.toHaveBeenCalled();
+    expect(mockFollowUp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('not found'),
+        flags: MessageFlags.Ephemeral,
+      })
+    );
+  });
 });

--- a/services/bot-client/src/commands/character/sectionContext.test.ts
+++ b/services/bot-client/src/commands/character/sectionContext.test.ts
@@ -34,9 +34,12 @@ vi.mock('./api.js', () => ({
   fetchCharacter: (...args: unknown[]) => mockFetchCharacter(...args),
 }));
 
+// Mock path is the SOURCE module, not the index re-export — vitest mocks
+// the exact module path, and sectionContext.ts imports directly from
+// sessionHelpers.js (per 02-code-standards.md on "no index-import indirection").
 const mockFetchOrCreateSession = vi.fn();
-vi.mock('../../utils/dashboard/index.js', async importOriginal => {
-  const actual = await importOriginal<typeof import('../../utils/dashboard/index.js')>();
+vi.mock('../../utils/dashboard/sessionHelpers.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../utils/dashboard/sessionHelpers.js')>();
   return {
     ...actual,
     fetchOrCreateSession: (...args: unknown[]) => mockFetchOrCreateSession(...args),

--- a/services/bot-client/src/commands/character/sectionContext.test.ts
+++ b/services/bot-client/src/commands/character/sectionContext.test.ts
@@ -46,7 +46,8 @@ vi.mock('../../utils/dashboard/sessionHelpers.js', async importOriginal => {
   };
 });
 
-const { resolveCharacterSectionContext } = await import('./sectionContext.js');
+const { resolveCharacterSectionContext, findCharacterSection, loadCharacterSectionData } =
+  await import('./sectionContext.js');
 
 describe('resolveCharacterSectionContext', () => {
   beforeEach(() => {
@@ -182,6 +183,88 @@ describe('resolveCharacterSectionContext', () => {
         content: expect.stringContaining('not found'),
         flags: MessageFlags.Ephemeral,
       })
+    );
+  });
+});
+
+describe('findCharacterSection (sync helper)', () => {
+  beforeEach(() => {
+    mockIsBotOwner.mockReturnValue(false);
+  });
+
+  it('returns the full sync bundle for a known section', () => {
+    const result = findCharacterSection('identity', 'user-1');
+    expect(result).not.toBeNull();
+    expect(result?.section.id).toBe('identity');
+    expect(result?.isAdmin).toBe(false);
+    expect(result?.context).toEqual({ isAdmin: false, userId: 'user-1' });
+  });
+
+  it('returns null for unknown section id (no side effects)', () => {
+    // Sync helper must not touch the interaction — callers decide what
+    // to do about the null. This is what lets step 1 of the edit flow
+    // call it pre-update without blowing the 3-sec budget on an
+    // error reply.
+    const result = findCharacterSection('nonexistent-section', 'user-1');
+    expect(result).toBeNull();
+  });
+
+  it('propagates admin status from isBotOwner', () => {
+    mockIsBotOwner.mockReturnValue(true);
+    const result = findCharacterSection('identity', 'admin-1');
+    expect(result?.isAdmin).toBe(true);
+    expect(result?.context.isAdmin).toBe(true);
+  });
+});
+
+describe('loadCharacterSectionData (async helper with pre-resolved sync bundle)', () => {
+  beforeEach(() => {
+    mockFetchOrCreateSession.mockReset();
+    mockIsBotOwner.mockReturnValue(false);
+  });
+
+  it('fetches data and returns the full context bundle on success', async () => {
+    // Regression pin for PR #825 R9: the split exists to let callers
+    // do the sync resolution once and reuse it, avoiding a second
+    // getCharacterDashboardConfig build. This test confirms the async
+    // path accepts a pre-built sync bundle and returns the merged
+    // context without re-deriving the config.
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { slug: 'hero', name: 'Hero', _isAdmin: false },
+    });
+    const sync = findCharacterSection('identity', 'user-1');
+    expect(sync).not.toBeNull();
+    if (sync === null) return;
+
+    const interaction = {
+      user: { id: 'user-1' },
+      reply: vi.fn(),
+    } as unknown as ButtonInteraction;
+
+    const result = await loadCharacterSectionData(interaction, 'hero', {} as never, sync);
+    expect(result).not.toBeNull();
+    expect(result?.data.name).toBe('Hero');
+    // Same bundle fields — no second dashboardConfig build.
+    expect(result?.dashboardConfig).toBe(sync.dashboardConfig);
+    expect(result?.section).toBe(sync.section);
+  });
+
+  it('sends "Character not found" on fetch failure and returns null', async () => {
+    mockFetchOrCreateSession.mockResolvedValue({ success: false });
+    const sync = findCharacterSection('identity', 'user-1');
+    if (sync === null) throw new Error('sync resolution should not fail');
+
+    const mockReply = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      user: { id: 'user-1' },
+      reply: mockReply,
+    } as unknown as ButtonInteraction;
+
+    const result = await loadCharacterSectionData(interaction, 'hero', {} as never, sync);
+    expect(result).toBeNull();
+    expect(mockReply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining('not found') })
     );
   });
 });

--- a/services/bot-client/src/commands/character/sectionContext.ts
+++ b/services/bot-client/src/commands/character/sectionContext.ts
@@ -27,12 +27,12 @@ import { MessageFlags } from 'discord.js';
 import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
 import { isBotOwner, type EnvConfig } from '@tzurot/common-types';
 import {
-  fetchOrCreateSession,
-  DASHBOARD_MESSAGES,
   type DashboardConfig,
   type DashboardContext,
   type SectionDefinition,
-} from '../../utils/dashboard/index.js';
+} from '../../utils/dashboard/types.js';
+import { fetchOrCreateSession } from '../../utils/dashboard/sessionHelpers.js';
+import { DASHBOARD_MESSAGES } from '../../utils/dashboard/messages.js';
 import {
   getCharacterDashboardConfig,
   type CharacterData,

--- a/services/bot-client/src/commands/character/sectionContext.ts
+++ b/services/bot-client/src/commands/character/sectionContext.ts
@@ -73,10 +73,7 @@ export async function resolveCharacterSectionContext(
   const dashboardConfig = getCharacterDashboardConfig(isAdmin, false);
   const section = dashboardConfig.sections.find(s => s.id === sectionId);
   if (!section) {
-    await interaction.reply({
-      content: '❌ Unknown section.',
-      flags: MessageFlags.Ephemeral,
-    });
+    await replyError(interaction, '❌ Unknown section.');
     return null;
   }
 
@@ -89,13 +86,28 @@ export async function resolveCharacterSectionContext(
     interaction,
   });
   if (!result.success) {
-    await interaction.reply({
-      content: DASHBOARD_MESSAGES.NOT_FOUND('Character'),
-      flags: MessageFlags.Ephemeral,
-    });
+    await replyError(interaction, DASHBOARD_MESSAGES.NOT_FOUND('Character'));
     return null;
   }
 
   const context: DashboardContext = { isAdmin, userId: interaction.user.id };
   return { isAdmin, dashboardConfig, section, data: result.data, context };
+}
+
+/**
+ * Reply with an ephemeral error, adapting to whether the caller has
+ * already acked the interaction. Callers that `deferReply`-ed before
+ * invoking this helper need `followUp`; fresh callers need `reply`.
+ * Checking `interaction.deferred || interaction.replied` lets the helper
+ * work transparently under both call shapes.
+ */
+async function replyError(
+  interaction: ButtonInteraction | StringSelectMenuInteraction,
+  content: string
+): Promise<void> {
+  if (interaction.deferred || interaction.replied) {
+    await interaction.followUp({ content, flags: MessageFlags.Ephemeral });
+  } else {
+    await interaction.reply({ content, flags: MessageFlags.Ephemeral });
+  }
 }

--- a/services/bot-client/src/commands/character/sectionContext.ts
+++ b/services/bot-client/src/commands/character/sectionContext.ts
@@ -41,15 +41,84 @@ import {
 import { fetchCharacter } from './api.js';
 
 /**
- * Bundle returned by {@link resolveCharacterSectionContext} on success.
- * Holds everything a downstream section handler typically needs.
+ * Pure-sync portion of the section resolution. Split out so callers that
+ * need the section label _before_ they can await (e.g., the two-click
+ * Edit-with-Truncation flow's step 1, which must `interaction.update`
+ * within the 3-second budget) can get the section without paying for a
+ * redundant dashboard-config build later.
  */
-export interface CharacterSectionContext {
+export interface CharacterSectionSync {
   isAdmin: boolean;
   dashboardConfig: DashboardConfig<CharacterData>;
   section: SectionDefinition<CharacterData>;
-  data: CharacterData;
   context: DashboardContext;
+}
+
+/**
+ * Bundle returned by {@link resolveCharacterSectionContext} on success.
+ * Holds everything a downstream section handler typically needs.
+ */
+export interface CharacterSectionContext extends CharacterSectionSync {
+  data: CharacterData;
+}
+
+/**
+ * Sync helper: resolve `isAdmin` + dashboard config + section lookup from
+ * static inputs. No Redis, no gateway — safe to call before any
+ * `interaction.update` / `deferReply` ack.
+ *
+ * Returns `null` if the section id is unknown. Callers are expected to
+ * handle the null case themselves (send an ephemeral error, etc.) — this
+ * helper does not touch the interaction so it can be called in contexts
+ * that are post-ack and post-response.
+ *
+ * `hasVoiceReference` is pinned to `false` because the output is used
+ * for section field lookup / modal building, never for voice-gated
+ * action rendering. See the matching note in `dashboard.ts`
+ * `handleSelectMenu`.
+ */
+export function findCharacterSection(
+  sectionId: string,
+  userId: string
+): CharacterSectionSync | null {
+  const isAdmin = isBotOwner(userId);
+  const dashboardConfig = getCharacterDashboardConfig(isAdmin, false);
+  const section = dashboardConfig.sections.find(s => s.id === sectionId);
+  if (!section) {
+    return null;
+  }
+  const context: DashboardContext = { isAdmin, userId };
+  return { isAdmin, dashboardConfig, section, context };
+}
+
+/**
+ * Given an already-resolved sync bundle, fetch the character data (Redis
+ * session cache → gateway fallback) and assemble the full context.
+ *
+ * Extracted so callers that already did the sync resolution (to render a
+ * label before an `update` ack) can avoid rebuilding the dashboard config
+ * when they later need the data. On character-fetch miss, sends an
+ * ephemeral error and returns `null`.
+ */
+export async function loadCharacterSectionData(
+  interaction: ButtonInteraction | StringSelectMenuInteraction,
+  entityId: string,
+  config: EnvConfig,
+  sync: CharacterSectionSync
+): Promise<CharacterSectionContext | null> {
+  const result = await fetchOrCreateSession<CharacterSessionData, CharacterData>({
+    userId: interaction.user.id,
+    entityType: 'character',
+    entityId,
+    fetchFn: () => fetchCharacter(entityId, config, interaction.user.id),
+    transformFn: (character: CharacterData) => ({ ...character, _isAdmin: sync.isAdmin }),
+    interaction,
+  });
+  if (!result.success) {
+    await replyError(interaction, DASHBOARD_MESSAGES.NOT_FOUND('Character'));
+    return null;
+  }
+  return { ...sync, data: result.data };
 }
 
 /**
@@ -58,10 +127,10 @@ export interface CharacterSectionContext {
  * On failure (unknown section / missing character), sends an ephemeral
  * error reply to `interaction` and returns `null` — caller should return.
  *
- * `hasVoiceReference` is pinned to `false` because this helper's output
- * is used for section field lookup and modal building, never for the
- * voice-gated dashboard action rendering. See the matching note in
- * `dashboard.ts` `handleSelectMenu`.
+ * This is the combined-path helper most callers want. Callers that need
+ * the section label _before_ an async ack (two-click edit flow, step 1)
+ * should call {@link findCharacterSection} + {@link loadCharacterSectionData}
+ * separately so the dashboard-config build happens only once per request.
  */
 export async function resolveCharacterSectionContext(
   interaction: ButtonInteraction | StringSelectMenuInteraction,
@@ -69,29 +138,12 @@ export async function resolveCharacterSectionContext(
   sectionId: string,
   config: EnvConfig
 ): Promise<CharacterSectionContext | null> {
-  const isAdmin = isBotOwner(interaction.user.id);
-  const dashboardConfig = getCharacterDashboardConfig(isAdmin, false);
-  const section = dashboardConfig.sections.find(s => s.id === sectionId);
-  if (!section) {
+  const sync = findCharacterSection(sectionId, interaction.user.id);
+  if (sync === null) {
     await replyError(interaction, '❌ Unknown section.');
     return null;
   }
-
-  const result = await fetchOrCreateSession<CharacterSessionData, CharacterData>({
-    userId: interaction.user.id,
-    entityType: 'character',
-    entityId,
-    fetchFn: () => fetchCharacter(entityId, config, interaction.user.id),
-    transformFn: (character: CharacterData) => ({ ...character, _isAdmin: isAdmin }),
-    interaction,
-  });
-  if (!result.success) {
-    await replyError(interaction, DASHBOARD_MESSAGES.NOT_FOUND('Character'));
-    return null;
-  }
-
-  const context: DashboardContext = { isAdmin, userId: interaction.user.id };
-  return { isAdmin, dashboardConfig, section, data: result.data, context };
+  return loadCharacterSectionData(interaction, entityId, config, sync);
 }
 
 /**

--- a/services/bot-client/src/commands/character/sectionContext.ts
+++ b/services/bot-client/src/commands/character/sectionContext.ts
@@ -1,0 +1,101 @@
+/**
+ * Character Section Context Resolver
+ *
+ * Shared preamble for handlers that need to act on a specific section of
+ * a specific character: resolve admin status, build the dashboard config,
+ * locate the section, and fetch (or session-cache) the current data.
+ *
+ * Three consumers at extraction time (rule-of-three trigger):
+ * - `dashboard.ts` `handleSelectMenu` — when a user picks a section to edit
+ * - `truncationWarning.ts` `handleEditTruncatedButton` — the opt-in edit path
+ *   after a destructive-action warning
+ * - `truncationWarning.ts` `handleViewFullButton` — the read-only inspection
+ *   path for over-length legacy content
+ *
+ * On any failure (unknown section, character fetch miss), the helper
+ * replies to the interaction with an ephemeral error and returns `null`.
+ * Callers just check for null and return; no further error handling.
+ *
+ * Scope-limited to character. Persona/preset dashboards use the same
+ * SessionManager + DashboardConfig abstractions but have their own
+ * entity types / fetch functions — lifting this across entities would
+ * need the kind of entity-agnostic parameterization that violates the
+ * rule-of-three until those dashboards actually hit the same pattern.
+ */
+
+import { MessageFlags } from 'discord.js';
+import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
+import { isBotOwner, type EnvConfig } from '@tzurot/common-types';
+import {
+  fetchOrCreateSession,
+  DASHBOARD_MESSAGES,
+  type DashboardConfig,
+  type DashboardContext,
+  type SectionDefinition,
+} from '../../utils/dashboard/index.js';
+import {
+  getCharacterDashboardConfig,
+  type CharacterData,
+  type CharacterSessionData,
+} from './config.js';
+import { fetchCharacter } from './api.js';
+
+/**
+ * Bundle returned by {@link resolveCharacterSectionContext} on success.
+ * Holds everything a downstream section handler typically needs.
+ */
+export interface CharacterSectionContext {
+  isAdmin: boolean;
+  dashboardConfig: DashboardConfig<CharacterData>;
+  section: SectionDefinition<CharacterData>;
+  data: CharacterData;
+  context: DashboardContext;
+}
+
+/**
+ * Resolve the full context needed by a character section handler.
+ *
+ * On failure (unknown section / missing character), sends an ephemeral
+ * error reply to `interaction` and returns `null` — caller should return.
+ *
+ * `hasVoiceReference` is pinned to `false` because this helper's output
+ * is used for section field lookup and modal building, never for the
+ * voice-gated dashboard action rendering. See the matching note in
+ * `dashboard.ts` `handleSelectMenu`.
+ */
+export async function resolveCharacterSectionContext(
+  interaction: ButtonInteraction | StringSelectMenuInteraction,
+  entityId: string,
+  sectionId: string,
+  config: EnvConfig
+): Promise<CharacterSectionContext | null> {
+  const isAdmin = isBotOwner(interaction.user.id);
+  const dashboardConfig = getCharacterDashboardConfig(isAdmin, false);
+  const section = dashboardConfig.sections.find(s => s.id === sectionId);
+  if (!section) {
+    await interaction.reply({
+      content: '❌ Unknown section.',
+      flags: MessageFlags.Ephemeral,
+    });
+    return null;
+  }
+
+  const result = await fetchOrCreateSession<CharacterSessionData, CharacterData>({
+    userId: interaction.user.id,
+    entityType: 'character',
+    entityId,
+    fetchFn: () => fetchCharacter(entityId, config, interaction.user.id),
+    transformFn: (character: CharacterData) => ({ ...character, _isAdmin: isAdmin }),
+    interaction,
+  });
+  if (!result.success) {
+    await interaction.reply({
+      content: DASHBOARD_MESSAGES.NOT_FOUND('Character'),
+      flags: MessageFlags.Ephemeral,
+    });
+    return null;
+  }
+
+  const context: DashboardContext = { isAdmin, userId: interaction.user.id };
+  return { isAdmin, dashboardConfig, section, data: result.data, context };
+}

--- a/services/bot-client/src/commands/character/truncationWarning.test.ts
+++ b/services/bot-client/src/commands/character/truncationWarning.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Tests for character truncation-warning flow
+ *
+ * Covers the three user-visible branches:
+ * - detection picks up over-length fields per their modal maxLength
+ * - the warning embed surfaces char counts + truncation amount
+ * - the three buttons (Edit with Truncation / View Full / Cancel) route
+ *   to handlers that each produce the expected Discord response shape
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MessageFlags } from 'discord.js';
+import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
+
+// Mock common-types — logger, DISCORD_COLORS, isBotOwner, getConfig.
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+    isBotOwner: vi.fn().mockReturnValue(false),
+    getConfig: vi.fn().mockReturnValue({}),
+  };
+});
+
+// Mock the character API to avoid gateway calls in tests.
+const mockFetchCharacter = vi.fn();
+vi.mock('./api.js', () => ({
+  fetchCharacter: (...args: unknown[]) => mockFetchCharacter(...args),
+}));
+
+// Mock fetchOrCreateSession so the handlers see a stable data fixture.
+const mockFetchOrCreateSession = vi.fn();
+vi.mock('../../utils/dashboard/index.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../utils/dashboard/index.js')>();
+  return {
+    ...actual,
+    fetchOrCreateSession: (...args: unknown[]) => mockFetchOrCreateSession(...args),
+    // The real buildSectionModal returns a ModalBuilder; stub it so the
+    // handler tests don't depend on Discord.js modal internals.
+    buildSectionModal: vi.fn().mockReturnValue({ __modal: true }),
+  };
+});
+
+// Import after mocks so the factory resolves before module load.
+const {
+  detectOverLengthFields,
+  buildTruncationWarningEmbed,
+  buildTruncationButtons,
+  showTruncationWarning,
+  handleEditTruncatedButton,
+  handleViewFullButton,
+  handleCancelEditButton,
+} = await import('./truncationWarning.js');
+
+// A realistic character-identity section stub with two fields that have
+// explicit maxLength values.
+const identitySectionStub = {
+  id: 'identity',
+  label: '🏷️ Identity & Basics',
+  description: 'test',
+  fieldIds: ['personalityAge', 'personalityTraits'],
+  fields: [
+    { id: 'personalityAge', label: 'Age', maxLength: 100, style: 'short' as const },
+    {
+      id: 'personalityTraits',
+      label: 'Traits',
+      maxLength: 1000,
+      style: 'paragraph' as const,
+    },
+  ],
+  getStatus: () => 0,
+  getPreview: () => '',
+};
+
+describe('detectOverLengthFields', () => {
+  it('returns empty when no field exceeds its maxLength', () => {
+    const data = {
+      personalityAge: 'a short age',
+      personalityTraits: 'short traits',
+    } as unknown as Parameters<typeof detectOverLengthFields>[1];
+
+    const result = detectOverLengthFields(identitySectionStub, data);
+    expect(result).toEqual([]);
+  });
+
+  it('flags a field whose value exceeds the cap', () => {
+    const data = {
+      personalityAge: 'x'.repeat(150), // over the 100 cap
+      personalityTraits: 'ok',
+    } as unknown as Parameters<typeof detectOverLengthFields>[1];
+
+    const result = detectOverLengthFields(identitySectionStub, data);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      fieldId: 'personalityAge',
+      label: 'Age',
+      current: 150,
+      max: 100,
+    });
+  });
+
+  it('flags multiple over-cap fields independently', () => {
+    const data = {
+      personalityAge: 'x'.repeat(150),
+      personalityTraits: 'y'.repeat(1500),
+    } as unknown as Parameters<typeof detectOverLengthFields>[1];
+
+    const result = detectOverLengthFields(identitySectionStub, data);
+    expect(result).toHaveLength(2);
+    expect(result.map(r => r.fieldId).sort()).toEqual(['personalityAge', 'personalityTraits']);
+  });
+
+  it('ignores non-string values and missing fields', () => {
+    const data = {
+      personalityAge: null,
+      personalityTraits: undefined,
+      unrelated: 'x'.repeat(5000),
+    } as unknown as Parameters<typeof detectOverLengthFields>[1];
+
+    const result = detectOverLengthFields(identitySectionStub, data);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('buildTruncationWarningEmbed', () => {
+  it('includes per-field char counts and the total truncation amount', () => {
+    const embed = buildTruncationWarningEmbed(
+      [
+        { fieldId: 'personalityAge', label: 'Age', current: 150, max: 100 },
+        {
+          fieldId: 'personalityTraits',
+          label: 'Traits',
+          current: 1500,
+          max: 1000,
+        },
+      ],
+      '🏷️ Identity & Basics'
+    );
+
+    const json = embed.toJSON();
+    expect(json.title).toContain('"Identity & Basics"');
+    expect(json.description).toContain('Age');
+    expect(json.description).toContain('150');
+    expect(json.description).toContain('100');
+    expect(json.description).toContain('Traits');
+    expect(json.description).toContain('1,500');
+    // Footer lists total truncation across all fields: (150-100)+(1500-1000)=550
+    expect(json.footer?.text).toContain('550');
+    expect(json.footer?.text).toContain('2 field');
+  });
+});
+
+describe('buildTruncationButtons', () => {
+  it('emits three buttons with character dashboard customId shape', () => {
+    const row = buildTruncationButtons('char-1', 'identity');
+    const json = row.toJSON();
+    expect(json.components).toHaveLength(3);
+    const customIds = json.components.map(c => (c as { custom_id: string }).custom_id);
+    expect(customIds).toEqual([
+      'character::edit-truncated::char-1::identity',
+      'character::view-full::char-1::identity',
+      'character::cancel-edit::char-1::identity',
+    ]);
+  });
+});
+
+describe('showTruncationWarning', () => {
+  it('replies ephemerally with the warning embed and button row', async () => {
+    const mockReply = vi.fn().mockResolvedValue(undefined);
+    const interaction = { reply: mockReply } as unknown as StringSelectMenuInteraction;
+
+    await showTruncationWarning(interaction, identitySectionStub, 'char-1', [
+      { fieldId: 'personalityAge', label: 'Age', current: 150, max: 100 },
+    ]);
+
+    expect(mockReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flags: MessageFlags.Ephemeral,
+        embeds: expect.arrayContaining([expect.any(Object)]),
+        components: expect.arrayContaining([expect.any(Object)]),
+      })
+    );
+  });
+});
+
+describe('handleEditTruncatedButton', () => {
+  beforeEach(() => {
+    mockFetchOrCreateSession.mockReset();
+  });
+
+  it('fetches the character and shows the section modal', async () => {
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { name: 'Hero', _isAdmin: false },
+    });
+    const mockShowModal = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      user: { id: 'user-1' },
+      showModal: mockShowModal,
+    } as unknown as ButtonInteraction;
+
+    await handleEditTruncatedButton(interaction, 'char-1', 'identity');
+
+    expect(mockShowModal).toHaveBeenCalledWith({ __modal: true });
+  });
+
+  it('replies with an error when the character cannot be fetched', async () => {
+    mockFetchOrCreateSession.mockResolvedValue({ success: false });
+    const mockReply = vi.fn().mockResolvedValue(undefined);
+    const mockShowModal = vi.fn();
+    const interaction = {
+      user: { id: 'user-1' },
+      reply: mockReply,
+      showModal: mockShowModal,
+    } as unknown as ButtonInteraction;
+
+    await handleEditTruncatedButton(interaction, 'char-1', 'identity');
+
+    expect(mockShowModal).not.toHaveBeenCalled();
+    expect(mockReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('Character not found'),
+        flags: MessageFlags.Ephemeral,
+      })
+    );
+  });
+
+  it('replies with an error when the section id is unknown', async () => {
+    const mockReply = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      user: { id: 'user-1' },
+      reply: mockReply,
+    } as unknown as ButtonInteraction;
+
+    await handleEditTruncatedButton(interaction, 'char-1', 'nonexistent-section');
+
+    expect(mockReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('Unknown section'),
+      })
+    );
+  });
+});
+
+describe('handleViewFullButton', () => {
+  beforeEach(() => {
+    mockFetchOrCreateSession.mockReset();
+  });
+
+  it('replies with txt attachments for each over-length field', async () => {
+    const longValue = 'x'.repeat(150);
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { personalityAge: longValue, _isAdmin: false },
+    });
+    const mockReply = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      user: { id: 'user-1' },
+      reply: mockReply,
+    } as unknown as ButtonInteraction;
+
+    await handleViewFullButton(interaction, 'char-1', 'identity');
+
+    expect(mockReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flags: MessageFlags.Ephemeral,
+        files: expect.arrayContaining([expect.any(Object)]),
+        content: expect.stringContaining('Full content'),
+      })
+    );
+    const callArg = mockReply.mock.calls[0][0] as { files: unknown[] };
+    expect(callArg.files).toHaveLength(1);
+  });
+
+  it('reports no-op when content no longer exceeds cap', async () => {
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { personalityAge: 'short', _isAdmin: false },
+    });
+    const mockReply = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      user: { id: 'user-1' },
+      reply: mockReply,
+    } as unknown as ButtonInteraction;
+
+    await handleViewFullButton(interaction, 'char-1', 'identity');
+
+    expect(mockReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('No fields'),
+        flags: MessageFlags.Ephemeral,
+      })
+    );
+    expect(mockReply.mock.calls[0][0].files).toBeUndefined();
+  });
+
+  it('replies with an error when the character cannot be fetched', async () => {
+    mockFetchOrCreateSession.mockResolvedValue({ success: false });
+    const mockReply = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      user: { id: 'user-1' },
+      reply: mockReply,
+    } as unknown as ButtonInteraction;
+
+    await handleViewFullButton(interaction, 'char-1', 'identity');
+
+    expect(mockReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('Character not found'),
+      })
+    );
+  });
+});
+
+describe('handleCancelEditButton', () => {
+  it('updates the ephemeral message to a cancellation notice', async () => {
+    const mockUpdate = vi.fn().mockResolvedValue(undefined);
+    const interaction = { update: mockUpdate } as unknown as ButtonInteraction;
+
+    await handleCancelEditButton(interaction);
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      content: '✅ Edit cancelled.',
+      embeds: [],
+      components: [],
+    });
+  });
+});

--- a/services/bot-client/src/commands/character/truncationWarning.test.ts
+++ b/services/bot-client/src/commands/character/truncationWarning.test.ts
@@ -188,6 +188,18 @@ describe('buildTruncationButtons', () => {
       'character::cancel_edit::char-1::identity',
     ]);
   });
+
+  it('sets an emoji on every button per 04-discord.md consistency rule', () => {
+    // The rule (`.claude/rules/04-discord.md`) requires `.setEmoji()` on
+    // every button for visual sizing consistency. All three warning
+    // buttons must have an emoji set.
+    const row = buildTruncationButtons('char-1', 'identity');
+    const json = row.toJSON();
+    for (const component of json.components) {
+      const button = component as { emoji?: { name: string } };
+      expect(button.emoji?.name, `button ${JSON.stringify(component)} missing emoji`).toBeDefined();
+    }
+  });
 });
 
 describe('showTruncationWarning', () => {
@@ -504,6 +516,31 @@ describe('handleViewFullButton', () => {
     );
     const callArg = editReply.mock.calls[0][0] as { files: unknown[] };
     expect(callArg.files).toHaveLength(1);
+  });
+
+  it('names attachments from user-facing labels, not internal field ids', async () => {
+    // Regression guard for PR #825 R5 #2: filenames were exposing internal
+    // field ids like `personalityAge.txt` to users. The safe-filename
+    // conversion should produce `age.txt` from the "Age" label, and the
+    // summary content should reference the same filename so users can
+    // cross-reference the embed bullet list with the downloaded file.
+    const longValue = 'x'.repeat(150);
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { personalityAge: longValue, _isAdmin: false },
+    });
+    const { interaction, editReply } = makeDeferrableInteraction();
+
+    await handleViewFullButton(interaction, 'char-1', 'identity');
+
+    const callArg = editReply.mock.calls[0][0] as {
+      files: { name: string }[];
+      content: string;
+    };
+    expect(callArg.files[0].name).toBe('age.txt');
+    expect(callArg.files[0].name).not.toContain('personalityAge');
+    // Summary text must reference the same filename
+    expect(callArg.content).toContain('age.txt');
   });
 
   it('reports no-op via editReply when content no longer exceeds cap', async () => {

--- a/services/bot-client/src/commands/character/truncationWarning.test.ts
+++ b/services/bot-client/src/commands/character/truncationWarning.test.ts
@@ -57,6 +57,7 @@ const {
   handleViewFullButton,
   handleCancelEditButton,
 } = await import('./truncationWarning.js');
+const { SectionStatus } = await import('../../utils/dashboard/index.js');
 
 // A realistic character-identity section stub with two fields that have
 // explicit maxLength values.
@@ -74,7 +75,7 @@ const identitySectionStub = {
       style: 'paragraph' as const,
     },
   ],
-  getStatus: () => 0,
+  getStatus: () => SectionStatus.DEFAULT,
   getPreview: () => '',
 };
 

--- a/services/bot-client/src/commands/character/truncationWarning.test.ts
+++ b/services/bot-client/src/commands/character/truncationWarning.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { MessageFlags } from 'discord.js';
+import { ButtonStyle, MessageFlags } from 'discord.js';
 import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
 
 // Mock common-types — logger, DISCORD_COLORS, isBotOwner, getConfig.
@@ -193,11 +193,23 @@ describe('buildTruncationButtons', () => {
     const json = row.toJSON();
     expect(json.components).toHaveLength(3);
     const customIds = json.components.map(c => (c as { custom_id: string }).custom_id);
+    // Ordered per `04-discord.md` Standard Button Order: Primary (View Full)
+    // first, Secondary (Cancel) middle, Destructive (Edit with Truncation)
+    // last. A regression that reverts to destructive-first would break
+    // consistency with delete-confirmation dialogs across the codebase.
     expect(customIds).toEqual([
-      'character::edit_truncated::char-1::identity',
       'character::view_full::char-1::identity',
       'character::cancel_edit::char-1::identity',
+      'character::edit_truncated::char-1::identity',
     ]);
+  });
+
+  it('places the Danger-styled button last per destructive-last rule', () => {
+    const row = buildTruncationButtons('char-1', 'identity');
+    const json = row.toJSON();
+    const styles = json.components.map(c => (c as { style: number }).style);
+    // ButtonStyle.Danger = 4; verify it's the last button's style.
+    expect(styles[styles.length - 1]).toBe(ButtonStyle.Danger);
   });
 
   it('sets an emoji on every button per 04-discord.md consistency rule', () => {

--- a/services/bot-client/src/commands/character/truncationWarning.test.ts
+++ b/services/bot-client/src/commands/character/truncationWarning.test.ts
@@ -35,14 +35,25 @@ vi.mock('./api.js', () => ({
 }));
 
 // Mock fetchOrCreateSession so the handlers see a stable data fixture.
+// Mocks target the SOURCE modules, not the index re-export — vitest mocks
+// the exact module path, and the source files import directly from their
+// sources (per 02-code-standards.md on "no index-import indirection"),
+// so mocking the index here would silently miss.
 const mockFetchOrCreateSession = vi.fn();
-vi.mock('../../utils/dashboard/index.js', async importOriginal => {
-  const actual = await importOriginal<typeof import('../../utils/dashboard/index.js')>();
+vi.mock('../../utils/dashboard/sessionHelpers.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../utils/dashboard/sessionHelpers.js')>();
   return {
     ...actual,
     fetchOrCreateSession: (...args: unknown[]) => mockFetchOrCreateSession(...args),
-    // The real buildSectionModal returns a ModalBuilder; stub it so the
-    // handler tests don't depend on Discord.js modal internals.
+  };
+});
+
+// The real buildSectionModal returns a ModalBuilder; stub it so the
+// handler tests don't depend on Discord.js modal internals.
+vi.mock('../../utils/dashboard/ModalFactory.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../utils/dashboard/ModalFactory.js')>();
+  return {
+    ...actual,
     buildSectionModal: vi.fn().mockReturnValue({ __modal: true }),
   };
 });

--- a/services/bot-client/src/commands/character/truncationWarning.test.ts
+++ b/services/bot-client/src/commands/character/truncationWarning.test.ts
@@ -153,7 +153,23 @@ describe('buildTruncationWarningEmbed', () => {
     expect(json.description).toContain('1,500');
     // Footer lists total truncation across all fields: (150-100)+(1500-1000)=550
     expect(json.footer?.text).toContain('550');
-    expect(json.footer?.text).toContain('2 field');
+    // Plural form — two fields should read "2 fields", never "2 field(s)"
+    expect(json.footer?.text).toContain('2 fields');
+    expect(json.footer?.text).not.toContain('field(s)');
+  });
+
+  it('uses singular "field" in the footer when only one field is over-length', () => {
+    // Guards against the "1 field(s)" pluralization regression flagged in PR
+    // review. The single-field path is the common case for short legacy
+    // fields (e.g. a stray overgrown "Age" value) and needs to read cleanly.
+    const embed = buildTruncationWarningEmbed(
+      [{ fieldId: 'personalityAge', label: 'Age', current: 150, max: 100 }],
+      '🏷️ Identity & Basics'
+    );
+    const json = embed.toJSON();
+    expect(json.footer?.text).toContain('1 field');
+    expect(json.footer?.text).not.toContain('1 fields');
+    expect(json.footer?.text).not.toContain('field(s)');
   });
 });
 

--- a/services/bot-client/src/commands/character/truncationWarning.test.ts
+++ b/services/bot-client/src/commands/character/truncationWarning.test.ts
@@ -52,8 +52,11 @@ const {
   detectOverLengthFields,
   buildTruncationWarningEmbed,
   buildTruncationButtons,
+  buildOpenEditorButtonRow,
+  buildReadyToEditEmbed,
   showTruncationWarning,
   handleEditTruncatedButton,
+  handleOpenEditorButton,
   handleViewFullButton,
   handleCancelEditButton,
 } = await import('./truncationWarning.js');
@@ -206,12 +209,103 @@ describe('showTruncationWarning', () => {
   });
 });
 
+describe('buildReadyToEditEmbed', () => {
+  it('strips the leading emoji and names the section in the title', () => {
+    const embed = buildReadyToEditEmbed('🏷️ Identity & Basics');
+    const json = embed.toJSON();
+    expect(json.title).toContain('Identity & Basics');
+    expect(json.title).not.toContain('🏷️');
+  });
+});
+
+describe('buildOpenEditorButtonRow', () => {
+  it('emits a single Open Editor button with the expected customId shape', () => {
+    const row = buildOpenEditorButtonRow('char-1', 'identity');
+    const json = row.toJSON();
+    expect(json.components).toHaveLength(1);
+    const button = json.components[0] as { custom_id: string; label?: string };
+    expect(button.custom_id).toBe('character::open_editor::char-1::identity');
+    expect(button.label).toBe('Open Editor');
+  });
+});
+
 describe('handleEditTruncatedButton', () => {
   beforeEach(() => {
     mockFetchOrCreateSession.mockReset();
   });
 
-  it('fetches the character and shows the section modal', async () => {
+  it('updates the interaction to the Ready-to-Edit state with an Open Editor button', async () => {
+    // Step 1 of the two-click flow must `update` first (no showModal) so
+    // the 3-second budget is never blown by the subsequent session warm.
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { name: 'Hero', _isAdmin: false },
+    });
+    const mockUpdate = vi.fn().mockResolvedValue(undefined);
+    const mockShowModal = vi.fn();
+    const interaction = {
+      user: { id: 'user-1' },
+      update: mockUpdate,
+      showModal: mockShowModal,
+    } as unknown as ButtonInteraction;
+
+    await handleEditTruncatedButton(interaction, 'char-1', 'identity');
+
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockShowModal).not.toHaveBeenCalled();
+    const updateArgs = mockUpdate.mock.calls[0][0];
+    expect(updateArgs.embeds).toHaveLength(1);
+    expect(updateArgs.components).toHaveLength(1);
+  });
+
+  it('warms the session AFTER the update ack, not before', async () => {
+    // The update must precede the async resolveContext work. If this order
+    // flips, we're back to the PR #825 R1 3-sec bug.
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { name: 'Hero', _isAdmin: false },
+    });
+    const mockUpdate = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      user: { id: 'user-1' },
+      update: mockUpdate,
+      showModal: vi.fn(),
+    } as unknown as ButtonInteraction;
+
+    await handleEditTruncatedButton(interaction, 'char-1', 'identity');
+
+    expect(mockUpdate).toHaveBeenCalled();
+    expect(mockFetchOrCreateSession).toHaveBeenCalled();
+    const updateOrder = mockUpdate.mock.invocationCallOrder[0];
+    const fetchOrder = mockFetchOrCreateSession.mock.invocationCallOrder[0];
+    expect(updateOrder).toBeLessThan(fetchOrder);
+  });
+
+  it('swallows session-warm failures so the open_editor click can retry', async () => {
+    // A failed warm shouldn't propagate to the user — step 2 has its own
+    // resolveContext + 10062 fallback. Swallowing also prevents the
+    // CommandHandler catch from surfacing a scary error on a successful update.
+    mockFetchOrCreateSession.mockRejectedValue(new Error('Redis connection refused'));
+    const mockUpdate = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      user: { id: 'user-1' },
+      update: mockUpdate,
+      showModal: vi.fn(),
+    } as unknown as ButtonInteraction;
+
+    await expect(
+      handleEditTruncatedButton(interaction, 'char-1', 'identity')
+    ).resolves.toBeUndefined();
+    expect(mockUpdate).toHaveBeenCalled();
+  });
+});
+
+describe('handleOpenEditorButton', () => {
+  beforeEach(() => {
+    mockFetchOrCreateSession.mockReset();
+  });
+
+  it('fetches the character and shows the section modal on success', async () => {
     mockFetchOrCreateSession.mockResolvedValue({
       success: true,
       data: { name: 'Hero', _isAdmin: false },
@@ -222,7 +316,7 @@ describe('handleEditTruncatedButton', () => {
       showModal: mockShowModal,
     } as unknown as ButtonInteraction;
 
-    await handleEditTruncatedButton(interaction, 'char-1', 'identity');
+    await handleOpenEditorButton(interaction, 'char-1', 'identity');
 
     expect(mockShowModal).toHaveBeenCalledWith({ __modal: true });
   });
@@ -237,31 +331,97 @@ describe('handleEditTruncatedButton', () => {
       showModal: mockShowModal,
     } as unknown as ButtonInteraction;
 
-    await handleEditTruncatedButton(interaction, 'char-1', 'identity');
+    await handleOpenEditorButton(interaction, 'char-1', 'identity');
 
     expect(mockShowModal).not.toHaveBeenCalled();
     expect(mockReply).toHaveBeenCalledWith(
       expect.objectContaining({
         content: expect.stringContaining('Character not found'),
+      })
+    );
+  });
+
+  it('catches 10062 and surfaces a retry-visible followUp when the 3-sec window blows', async () => {
+    // Residual failure mode: session warmed but Redis latency spike pushes
+    // the open_editor ack past 3 sec. Discord returns 10062. The handler
+    // must not silently die — it must attempt a user-visible followUp.
+    const { DiscordAPIError } = await import('discord.js');
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { name: 'Hero', _isAdmin: false },
+    });
+    const timeoutError = new DiscordAPIError(
+      { code: 10062, message: 'Unknown interaction' },
+      10062,
+      404,
+      'POST',
+      '/interactions/x/y/callback',
+      {}
+    );
+    const mockShowModal = vi.fn().mockRejectedValue(timeoutError);
+    const mockFollowUp = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      user: { id: 'user-1' },
+      showModal: mockShowModal,
+      followUp: mockFollowUp,
+    } as unknown as ButtonInteraction;
+
+    await handleOpenEditorButton(interaction, 'char-1', 'identity');
+
+    expect(mockShowModal).toHaveBeenCalled();
+    expect(mockFollowUp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('Took too long'),
         flags: MessageFlags.Ephemeral,
       })
     );
   });
 
-  it('replies with an error when the section id is unknown', async () => {
-    const mockReply = vi.fn().mockResolvedValue(undefined);
+  it('rethrows non-10062 showModal errors so the global catch can handle them', async () => {
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { name: 'Hero', _isAdmin: false },
+    });
+    const unexpected = new Error('boom');
+    const mockShowModal = vi.fn().mockRejectedValue(unexpected);
     const interaction = {
       user: { id: 'user-1' },
-      reply: mockReply,
+      showModal: mockShowModal,
+      followUp: vi.fn(),
     } as unknown as ButtonInteraction;
 
-    await handleEditTruncatedButton(interaction, 'char-1', 'nonexistent-section');
+    await expect(handleOpenEditorButton(interaction, 'char-1', 'identity')).rejects.toThrow('boom');
+  });
 
-    expect(mockReply).toHaveBeenCalledWith(
-      expect.objectContaining({
-        content: expect.stringContaining('Unknown section'),
-      })
+  it('swallows secondary followUp failures after a 10062', async () => {
+    // On a fully-dead interaction token, followUp also throws 10062. The
+    // handler must not propagate that secondary failure to the outer
+    // CommandHandler catch (which would re-log and re-attempt a send).
+    const { DiscordAPIError } = await import('discord.js');
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { name: 'Hero', _isAdmin: false },
+    });
+    const timeoutError = new DiscordAPIError(
+      { code: 10062, message: 'Unknown interaction' },
+      10062,
+      404,
+      'POST',
+      '/interactions/x/y/callback',
+      {}
     );
+    const mockShowModal = vi.fn().mockRejectedValue(timeoutError);
+    const mockFollowUp = vi.fn().mockRejectedValue(timeoutError);
+    const interaction = {
+      user: { id: 'user-1' },
+      showModal: mockShowModal,
+      followUp: mockFollowUp,
+    } as unknown as ButtonInteraction;
+
+    await expect(
+      handleOpenEditorButton(interaction, 'char-1', 'identity')
+    ).resolves.toBeUndefined();
+    expect(mockFollowUp).toHaveBeenCalled();
   });
 });
 

--- a/services/bot-client/src/commands/character/truncationWarning.test.ts
+++ b/services/bot-client/src/commands/character/truncationWarning.test.ts
@@ -321,6 +321,38 @@ describe('handleEditTruncatedButton', () => {
     ).resolves.toBeUndefined();
     expect(mockUpdate).toHaveBeenCalled();
   });
+
+  it('handles session-warm null returns without propagating (character-deleted race)', async () => {
+    // Regression pin for PR #825 R8 #3: when resolveCharacterSectionContext
+    // returns null (non-throwing failure path, e.g., character-deleted
+    // between warning display and opt-in click), the handler must neither
+    // throw, propagate the null, nor double-send a followUp. The "Ready
+    // to edit" embed + sectionContext's internal followUp error is the
+    // acceptable UX (strictly better than a silent 10062).
+    mockFetchOrCreateSession.mockResolvedValue({ success: false });
+    const mockUpdate = vi.fn().mockResolvedValue(undefined);
+    const mockFollowUp = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      user: { id: 'user-1' },
+      update: mockUpdate,
+      showModal: vi.fn(),
+      followUp: mockFollowUp,
+      get deferred() {
+        return false;
+      },
+      get replied() {
+        return true; // interaction.update sets replied=true
+      },
+    } as unknown as ButtonInteraction;
+
+    await expect(
+      handleEditTruncatedButton(interaction, 'char-1', 'identity')
+    ).resolves.toBeUndefined();
+    expect(mockUpdate).toHaveBeenCalled();
+    // sectionContext's replyError sends the followUp; we don't double-send
+    // from handleEditTruncatedButton's own logic.
+    expect(mockFollowUp).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('handleOpenEditorButton', () => {

--- a/services/bot-client/src/commands/character/truncationWarning.test.ts
+++ b/services/bot-client/src/commands/character/truncationWarning.test.ts
@@ -164,9 +164,9 @@ describe('buildTruncationButtons', () => {
     expect(json.components).toHaveLength(3);
     const customIds = json.components.map(c => (c as { custom_id: string }).custom_id);
     expect(customIds).toEqual([
-      'character::edit-truncated::char-1::identity',
-      'character::view-full::char-1::identity',
-      'character::cancel-edit::char-1::identity',
+      'character::edit_truncated::char-1::identity',
+      'character::view_full::char-1::identity',
+      'character::cancel_edit::char-1::identity',
     ]);
   });
 });
@@ -254,66 +254,109 @@ describe('handleViewFullButton', () => {
     mockFetchOrCreateSession.mockReset();
   });
 
-  it('replies with txt attachments for each over-length field', async () => {
+  /**
+   * Build an interaction stub that models the deferReply → editReply
+   * lifecycle: once deferReply is called, `deferred` flips true so
+   * sectionContext's replyError predicate correctly routes errors to
+   * followUp instead of reply.
+   */
+  function makeDeferrableInteraction(): {
+    interaction: ButtonInteraction;
+    deferReply: ReturnType<typeof vi.fn>;
+    editReply: ReturnType<typeof vi.fn>;
+    followUp: ReturnType<typeof vi.fn>;
+    reply: ReturnType<typeof vi.fn>;
+  } {
+    const state = { deferred: false, replied: false };
+    const deferReply = vi.fn().mockImplementation(async () => {
+      state.deferred = true;
+    });
+    const editReply = vi.fn().mockResolvedValue(undefined);
+    const followUp = vi.fn().mockResolvedValue(undefined);
+    const reply = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      user: { id: 'user-1' },
+      deferReply,
+      editReply,
+      followUp,
+      reply,
+      get deferred() {
+        return state.deferred;
+      },
+      get replied() {
+        return state.replied;
+      },
+    } as unknown as ButtonInteraction;
+    return { interaction, deferReply, editReply, followUp, reply };
+  }
+
+  it('defers within the 3-second window before any async work', async () => {
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { personalityAge: 'x'.repeat(150), _isAdmin: false },
+    });
+    const { interaction, deferReply } = makeDeferrableInteraction();
+
+    await handleViewFullButton(interaction, 'char-1', 'identity');
+
+    expect(deferReply).toHaveBeenCalledWith(
+      expect.objectContaining({ flags: MessageFlags.Ephemeral })
+    );
+    // deferReply must fire before fetchOrCreateSession (the async work)
+    expect(deferReply.mock.invocationCallOrder[0]).toBeLessThan(
+      mockFetchOrCreateSession.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('editReplies with txt attachments for each over-length field', async () => {
     const longValue = 'x'.repeat(150);
     mockFetchOrCreateSession.mockResolvedValue({
       success: true,
       data: { personalityAge: longValue, _isAdmin: false },
     });
-    const mockReply = vi.fn().mockResolvedValue(undefined);
-    const interaction = {
-      user: { id: 'user-1' },
-      reply: mockReply,
-    } as unknown as ButtonInteraction;
+    const { interaction, editReply, reply } = makeDeferrableInteraction();
 
     await handleViewFullButton(interaction, 'char-1', 'identity');
 
-    expect(mockReply).toHaveBeenCalledWith(
+    // Must use editReply, never reply — the interaction was deferred
+    expect(reply).not.toHaveBeenCalled();
+    expect(editReply).toHaveBeenCalledWith(
       expect.objectContaining({
-        flags: MessageFlags.Ephemeral,
         files: expect.arrayContaining([expect.any(Object)]),
         content: expect.stringContaining('Full content'),
       })
     );
-    const callArg = mockReply.mock.calls[0][0] as { files: unknown[] };
+    const callArg = editReply.mock.calls[0][0] as { files: unknown[] };
     expect(callArg.files).toHaveLength(1);
   });
 
-  it('reports no-op when content no longer exceeds cap', async () => {
+  it('reports no-op via editReply when content no longer exceeds cap', async () => {
     mockFetchOrCreateSession.mockResolvedValue({
       success: true,
       data: { personalityAge: 'short', _isAdmin: false },
     });
-    const mockReply = vi.fn().mockResolvedValue(undefined);
-    const interaction = {
-      user: { id: 'user-1' },
-      reply: mockReply,
-    } as unknown as ButtonInteraction;
+    const { interaction, editReply } = makeDeferrableInteraction();
 
     await handleViewFullButton(interaction, 'char-1', 'identity');
 
-    expect(mockReply).toHaveBeenCalledWith(
-      expect.objectContaining({
-        content: expect.stringContaining('No fields'),
-        flags: MessageFlags.Ephemeral,
-      })
+    expect(editReply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining('No fields') })
     );
-    expect(mockReply.mock.calls[0][0].files).toBeUndefined();
+    expect(editReply.mock.calls[0][0].files).toBeUndefined();
   });
 
-  it('replies with an error when the character cannot be fetched', async () => {
+  it('surfaces fetch-failure via followUp (sectionContext detects defer)', async () => {
     mockFetchOrCreateSession.mockResolvedValue({ success: false });
-    const mockReply = vi.fn().mockResolvedValue(undefined);
-    const interaction = {
-      user: { id: 'user-1' },
-      reply: mockReply,
-    } as unknown as ButtonInteraction;
+    const { interaction, followUp, reply } = makeDeferrableInteraction();
 
     await handleViewFullButton(interaction, 'char-1', 'identity');
 
-    expect(mockReply).toHaveBeenCalledWith(
+    // After deferReply, sectionContext must use followUp, not reply
+    expect(reply).not.toHaveBeenCalled();
+    expect(followUp).toHaveBeenCalledWith(
       expect.objectContaining({
-        content: expect.stringContaining('Character not found'),
+        content: expect.stringContaining('not found'),
+        flags: MessageFlags.Ephemeral,
       })
     );
   });

--- a/services/bot-client/src/commands/character/truncationWarning.ts
+++ b/services/bot-client/src/commands/character/truncationWarning.ts
@@ -1,0 +1,322 @@
+/**
+ * Character Truncation Warning
+ *
+ * Detects over-length legacy field values in a character section before a
+ * user opens the edit modal, and shows a destructive-action warning with
+ * explicit opt-in. Ports the pattern from `memory/detailModals.ts`
+ * (buildTruncationWarningEmbed / handleEditTruncatedButton) to the
+ * character dashboard's many-field modals.
+ *
+ * The silent-truncate site in `utils/dashboard/ModalFactory.ts:108`
+ * still runs after user consent — this module's job is gating the
+ * modal on an informed decision, plus offering a View Full read path
+ * so users can see the content they'd be about to truncate before
+ * committing.
+ */
+
+import {
+  EmbedBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ActionRowBuilder,
+  AttachmentBuilder,
+  MessageFlags,
+} from 'discord.js';
+import type {
+  ButtonInteraction,
+  StringSelectMenuInteraction,
+  InteractionReplyOptions,
+} from 'discord.js';
+import {
+  createLogger,
+  DISCORD_COLORS,
+  getConfig,
+  isBotOwner,
+  type EnvConfig,
+} from '@tzurot/common-types';
+import {
+  buildDashboardCustomId,
+  buildSectionModal,
+  fetchOrCreateSession,
+  type SectionDefinition,
+  type DashboardContext,
+} from '../../utils/dashboard/index.js';
+import {
+  getCharacterDashboardConfig,
+  type CharacterData,
+  type CharacterSessionData,
+} from './config.js';
+import { fetchCharacter } from './api.js';
+
+const logger = createLogger('character-truncation-warning');
+
+/**
+ * A field whose current value exceeds its modal maxLength.
+ */
+export interface OverLengthField {
+  /** The field id (matches CharacterData key) */
+  fieldId: string;
+  /** The user-facing label */
+  label: string;
+  /** Current character count */
+  current: number;
+  /** Configured maxLength — what the edit modal will truncate down to */
+  max: number;
+}
+
+/**
+ * Scan a section's fields and report any whose current value exceeds
+ * the modal's maxLength constraint.
+ *
+ * Fields with `field.maxLength === undefined` are treated as unconstrained —
+ * the ModalFactory applies default caps only when showing the modal, but
+ * for warning purposes we only flag explicit user-visible caps. If a
+ * field intentionally uses the default cap without declaring it, the
+ * silent-truncate path for that field remains unchanged by this module.
+ */
+export function detectOverLengthFields(
+  section: SectionDefinition<CharacterData>,
+  data: CharacterData
+): OverLengthField[] {
+  const over: OverLengthField[] = [];
+  for (const field of section.fields) {
+    if (field.maxLength === undefined) {continue;}
+    const raw = (data as Record<string, unknown>)[field.id];
+    if (typeof raw !== 'string') {continue;}
+    if (raw.length > field.maxLength) {
+      over.push({
+        fieldId: field.id,
+        label: field.label,
+        current: raw.length,
+        max: field.maxLength,
+      });
+    }
+  }
+  return over;
+}
+
+/**
+ * Build the destructive-action warning embed listing the over-length
+ * fields, their current lengths, and the per-field truncation amount.
+ */
+export function buildTruncationWarningEmbed(
+  overLength: OverLengthField[],
+  sectionLabel: string
+): EmbedBuilder {
+  // Strip a leading emoji + whitespace from the section label the same
+  // way ModalFactory does for modal titles.
+  const plainLabel = sectionLabel.replace(/^[^\w\s]+\s*/, '');
+
+  const fieldLines = overLength
+    .map(f => {
+      const loss = f.current - f.max;
+      return (
+        `• **${f.label}** — ${f.current.toLocaleString()} / ${f.max.toLocaleString()} chars ` +
+        `(${loss.toLocaleString()} will be truncated)`
+      );
+    })
+    .join('\n');
+
+  const totalLoss = overLength.reduce((sum, f) => sum + (f.current - f.max), 0);
+
+  return new EmbedBuilder()
+    .setTitle(`⚠️ "${plainLabel}" contains content longer than Discord modals allow`)
+    .setColor(DISCORD_COLORS.WARNING)
+    .setDescription(
+      `One or more fields in this section hold values that exceed the edit modal's limit:\n\n` +
+        `${fieldLines}\n\n` +
+        `⚠️ **Opening the edit modal will pre-fill the fields with truncated values.** ` +
+        `If you save the modal, the trailing content will be lost permanently.\n\n` +
+        `Choose **View Full** to inspect the current full content before deciding. ` +
+        `Choose **Edit with Truncation** only if you're OK losing the trailing text.`
+    )
+    .setFooter({
+      text: `${totalLoss.toLocaleString()} total characters would be truncated across ${overLength.length} field(s)`,
+    });
+}
+
+/**
+ * Build the three-button row for the warning:
+ * - Edit with Truncation (danger, opt-in to destructive edit)
+ * - View Full (primary, safe read-only inspection)
+ * - Cancel (secondary, dismiss)
+ */
+export function buildTruncationButtons(
+  entityId: string,
+  sectionId: string
+): ActionRowBuilder<ButtonBuilder> {
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(buildDashboardCustomId('character', 'edit-truncated', entityId, sectionId))
+      .setLabel('Edit with Truncation')
+      .setEmoji('✂️')
+      .setStyle(ButtonStyle.Danger),
+    new ButtonBuilder()
+      .setCustomId(buildDashboardCustomId('character', 'view-full', entityId, sectionId))
+      .setLabel('View Full')
+      .setEmoji('📖')
+      .setStyle(ButtonStyle.Primary),
+    new ButtonBuilder()
+      .setCustomId(buildDashboardCustomId('character', 'cancel-edit', entityId, sectionId))
+      .setLabel('Cancel')
+      .setStyle(ButtonStyle.Secondary)
+  );
+}
+
+/**
+ * Show the truncation warning as an ephemeral reply to the select-menu
+ * interaction. Extracted so the dashboard handler stays compact.
+ */
+export async function showTruncationWarning(
+  interaction: StringSelectMenuInteraction,
+  section: SectionDefinition<CharacterData>,
+  entityId: string,
+  overLength: OverLengthField[]
+): Promise<void> {
+  await interaction.reply({
+    embeds: [buildTruncationWarningEmbed(overLength, section.label)],
+    components: [buildTruncationButtons(entityId, section.id)],
+    flags: MessageFlags.Ephemeral,
+  });
+}
+
+/**
+ * "Edit with Truncation" handler — user has acknowledged the warning
+ * and wants to proceed. Fetch fresh data, resolve the section, and show
+ * the modal. The actual truncation happens inside ModalFactory.
+ */
+export async function handleEditTruncatedButton(
+  interaction: ButtonInteraction,
+  entityId: string,
+  sectionId: string,
+  config: EnvConfig = getConfig()
+): Promise<void> {
+  const isAdmin = isBotOwner(interaction.user.id);
+  // hasVoiceReference=false is fine here — this config is only used for
+  // section field lookup, not action rendering (same pattern used in
+  // handleSectionModalSubmit in dashboard.ts).
+  const dashboardConfig = getCharacterDashboardConfig(isAdmin, false);
+  const section = dashboardConfig.sections.find(s => s.id === sectionId);
+  if (!section) {
+    await interaction.reply({
+      content: '❌ Unknown section.',
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const result = await fetchOrCreateSession<CharacterSessionData, CharacterData>({
+    userId: interaction.user.id,
+    entityType: 'character',
+    entityId,
+    fetchFn: () => fetchCharacter(entityId, config, interaction.user.id),
+    transformFn: (character: CharacterData) => ({ ...character, _isAdmin: isAdmin }),
+    interaction,
+  });
+  if (!result.success) {
+    await interaction.reply({
+      content: '❌ Character not found.',
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const context: DashboardContext = { isAdmin, userId: interaction.user.id };
+  const modal = buildSectionModal(dashboardConfig, section, entityId, result.data, context);
+  await interaction.showModal(modal);
+}
+
+/**
+ * "View Full" handler — render the over-length field values as attached
+ * `.txt` files so the user can inspect their content without triggering
+ * the destructive edit path. Attachments handle arbitrary sizes uniformly
+ * (no Discord embed-limit gymnastics) and let users save/search the
+ * content locally.
+ */
+export async function handleViewFullButton(
+  interaction: ButtonInteraction,
+  entityId: string,
+  sectionId: string,
+  config: EnvConfig = getConfig()
+): Promise<void> {
+  const isAdmin = isBotOwner(interaction.user.id);
+  // hasVoiceReference=false is fine here — this config is only used for
+  // section field lookup, not action rendering (same pattern used in
+  // handleSectionModalSubmit in dashboard.ts).
+  const dashboardConfig = getCharacterDashboardConfig(isAdmin, false);
+  const section = dashboardConfig.sections.find(s => s.id === sectionId);
+  if (!section) {
+    await interaction.reply({
+      content: '❌ Unknown section.',
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const result = await fetchOrCreateSession<CharacterSessionData, CharacterData>({
+    userId: interaction.user.id,
+    entityType: 'character',
+    entityId,
+    fetchFn: () => fetchCharacter(entityId, config, interaction.user.id),
+    transformFn: (character: CharacterData) => ({ ...character, _isAdmin: isAdmin }),
+    interaction,
+  });
+  if (!result.success) {
+    await interaction.reply({
+      content: '❌ Character not found.',
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const overLength = detectOverLengthFields(section, result.data);
+  if (overLength.length === 0) {
+    // Edge case: data changed between warning and View Full click (e.g.,
+    // a concurrent save trimmed fields). Let the user know there's
+    // nothing to view specially.
+    await interaction.reply({
+      content: '✅ No fields in this section exceed the edit limit. Nothing to display.',
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
+
+  const attachments = overLength.map(f => {
+    const content = (result.data as Record<string, unknown>)[f.fieldId];
+    const textContent = typeof content === 'string' ? content : '';
+    return new AttachmentBuilder(Buffer.from(textContent, 'utf-8'), {
+      name: `${f.fieldId}.txt`,
+    });
+  });
+
+  const plainLabel = section.label.replace(/^[^\w\s]+\s*/, '');
+  const summary = overLength
+    .map(f => `• \`${f.fieldId}.txt\` — ${f.current.toLocaleString()} chars`)
+    .join('\n');
+
+  const payload: InteractionReplyOptions = {
+    content:
+      `**Full content for "${plainLabel}"** (read-only):\n${summary}\n\n` +
+      `These files hold the current, untruncated values. Editing this section ` +
+      `via the dashboard would cut each field to its modal cap.`,
+    files: attachments,
+    flags: MessageFlags.Ephemeral,
+  };
+
+  await interaction.reply(payload);
+  logger.info(
+    { userId: interaction.user.id, entityId, sectionId, fields: overLength.length },
+    'View Full served over-length field content'
+  );
+}
+
+/**
+ * "Cancel" handler — dismiss the warning and leave the dashboard as-is.
+ */
+export async function handleCancelEditButton(interaction: ButtonInteraction): Promise<void> {
+  await interaction.update({
+    content: '✅ Edit cancelled.',
+    embeds: [],
+    components: [],
+  });
+}

--- a/services/bot-client/src/commands/character/truncationWarning.ts
+++ b/services/bot-client/src/commands/character/truncationWarning.ts
@@ -53,6 +53,20 @@ function stripLeadingEmoji(label: string): string {
 }
 
 /**
+ * Convert a user-facing field label into a safe filename slug. Lowercased,
+ * whitespace collapsed to underscores, non-alphanumeric chars removed so
+ * the resulting name works across OSes. Used for View Full attachments so
+ * the user sees `age.txt` instead of the internal `personalityAge.txt`.
+ */
+function toSafeFilename(label: string): string {
+  return label
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, '_')
+    .replace(/[^a-z0-9_]/g, '');
+}
+
+/**
  * A field whose current value exceeds its modal maxLength.
  */
 export interface OverLengthField {
@@ -163,6 +177,7 @@ export function buildTruncationButtons(
     new ButtonBuilder()
       .setCustomId(buildDashboardCustomId('character', 'cancel_edit', entityId, sectionId))
       .setLabel('Cancel')
+      .setEmoji('✖️')
       .setStyle(ButtonStyle.Secondary)
   );
 }
@@ -260,6 +275,18 @@ export async function handleEditTruncatedButton(
   // hit. If this fails we swallow the error: the Open Editor handler has
   // its own resolveContext + 10062 fallback, so a failed warm here just
   // means it retries there. Logged for visibility into cache-miss rates.
+  //
+  // Subtle contract note: on a `null` (non-throwing) return from
+  // resolveCharacterSectionContext, sectionContext's replyError helper
+  // has already `followUp`-ed an error like "❌ Unknown section." — which
+  // would visually collide with our just-sent "Ready to edit" embed. We
+  // accept this collision because null returns are unreachable in
+  // practice here: the section lookup is a sync walk of a static dashboard
+  // config (no Redis, no gateway), and the customId we're acting on was
+  // emitted from that same config in step 0, so the section always exists.
+  // The character-not-found branch is the only realistic null path, and
+  // even then the "Ready to edit" embed + "Character not found" followUp
+  // is a strict improvement over the pre-option-(b) silent 10062.
   try {
     await resolveCharacterSectionContext(interaction, entityId, sectionId, config);
   } catch (error) {
@@ -288,11 +315,20 @@ function getSectionLabelSync(sectionId: string, userId: string): string {
  * edit modal.
  *
  * Discord requires `showModal` as the first response — we call it with
- * minimum pre-work: one Redis-hot session read (warmed by the preceding
- * edit_truncated click). On the narrow residual failure where the 3-sec
- * window still blows (e.g., Redis latency spike), we catch 10062 and
+ * minimum pre-work: one `resolveCharacterSectionContext` call. In the
+ * common case (session warmed by step 1), that's a Redis hit in the low
+ * single-digit ms. But `fetchOrCreateSession` has a gateway API fallback
+ * for the cold-cache case (Redis eviction, pod cold start, TTL past the
+ * step-1 warm window). That fallback routes through the gateway's
+ * fetchCharacter — typically 100-300ms locally, potentially multi-second
+ * under load. This is the residual 3-second-budget risk that option (b)
+ * narrowed but did not eliminate.
+ *
+ * On the narrow residual failure where the 3-sec window still blows
+ * (cold cache + slow gateway), we catch `10062 Unknown interaction` and
  * surface an explicit retry message via `followUp` instead of silently
- * dying in the CommandHandler catch chain.
+ * dying in the CommandHandler catch chain. The BACKLOG doesn't track
+ * this residual since the visible error path is user-actionable.
  */
 export async function handleOpenEditorButton(
   interaction: ButtonInteraction,
@@ -381,13 +417,13 @@ export async function handleViewFullButton(
     const content = (ctx.data as Record<string, unknown>)[f.fieldId];
     const textContent = typeof content === 'string' ? content : '';
     return new AttachmentBuilder(Buffer.from(textContent, 'utf-8'), {
-      name: `${f.fieldId}.txt`,
+      name: `${toSafeFilename(f.label)}.txt`,
     });
   });
 
   const plainLabel = stripLeadingEmoji(ctx.section.label);
   const summary = overLength
-    .map(f => `• \`${f.fieldId}.txt\` — ${f.current.toLocaleString()} chars`)
+    .map(f => `• \`${toSafeFilename(f.label)}.txt\` — ${f.current.toLocaleString()} chars`)
     .join('\n');
 
   await interaction.editReply({

--- a/services/bot-client/src/commands/character/truncationWarning.ts
+++ b/services/bot-client/src/commands/character/truncationWarning.ts
@@ -24,17 +24,15 @@ import {
   MessageFlags,
 } from 'discord.js';
 import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
-import {
-  createLogger,
-  DISCORD_COLORS,
-  getConfig,
-  isBotOwner,
-  type EnvConfig,
-} from '@tzurot/common-types';
+import { createLogger, DISCORD_COLORS, getConfig, type EnvConfig } from '@tzurot/common-types';
 import { buildDashboardCustomId, type SectionDefinition } from '../../utils/dashboard/types.js';
 import { buildSectionModal } from '../../utils/dashboard/ModalFactory.js';
-import { getCharacterDashboardConfig, type CharacterData } from './config.js';
-import { resolveCharacterSectionContext } from './sectionContext.js';
+import { type CharacterData } from './config.js';
+import {
+  findCharacterSection,
+  loadCharacterSectionData,
+  resolveCharacterSectionContext,
+} from './sectionContext.js';
 
 const logger = createLogger('character-truncation-warning');
 
@@ -151,21 +149,21 @@ export function buildTruncationWarningEmbed(
 }
 
 /**
- * Build the three-button row for the warning:
- * - Edit with Truncation (danger, opt-in to destructive edit)
+ * Build the three-button row for the warning, ordered per `04-discord.md`
+ * Standard Button Order (Primary first, Destructive last):
  * - View Full (primary, safe read-only inspection)
  * - Cancel (secondary, dismiss)
+ * - Edit with Truncation (danger, opt-in to destructive edit)
+ *
+ * The destructive-last convention matches the memory detail flow and the
+ * delete-confirmation dialogs across the codebase; consistency outranks
+ * the "lead with the warning" instinct for this UX.
  */
 export function buildTruncationButtons(
   entityId: string,
   sectionId: string
 ): ActionRowBuilder<ButtonBuilder> {
   return new ActionRowBuilder<ButtonBuilder>().addComponents(
-    new ButtonBuilder()
-      .setCustomId(buildDashboardCustomId('character', 'edit_truncated', entityId, sectionId))
-      .setLabel('Edit with Truncation')
-      .setEmoji('✂️')
-      .setStyle(ButtonStyle.Danger),
     new ButtonBuilder()
       .setCustomId(buildDashboardCustomId('character', 'view_full', entityId, sectionId))
       .setLabel('View Full')
@@ -175,7 +173,12 @@ export function buildTruncationButtons(
       .setCustomId(buildDashboardCustomId('character', 'cancel_edit', entityId, sectionId))
       .setLabel('Cancel')
       .setEmoji('✖️')
-      .setStyle(ButtonStyle.Secondary)
+      .setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder()
+      .setCustomId(buildDashboardCustomId('character', 'edit_truncated', entityId, sectionId))
+      .setLabel('Edit with Truncation')
+      .setEmoji('✂️')
+      .setStyle(ButtonStyle.Danger)
   );
 }
 
@@ -258,9 +261,13 @@ export async function handleEditTruncatedButton(
   sectionId: string,
   config: EnvConfig = getConfig()
 ): Promise<void> {
-  // Resolve the section label for the embed copy — this is a sync lookup
-  // on the dashboard config (no Redis, no gateway), safe before `update`.
-  const sectionLabel = getSectionLabelSync(sectionId, interaction.user.id);
+  // Sync-resolve the section ONCE — label for the embed copy plus the
+  // dashboard bundle we reuse in step 2's warm. This avoids the double
+  // getCharacterDashboardConfig call that the naive shape (label-sync +
+  // full resolveCharacterSectionContext) would perform. Surfaced in PR
+  // #825 R9 review.
+  const sync = findCharacterSection(sectionId, interaction.user.id);
+  const sectionLabel = sync?.section.label ?? sectionId;
 
   // Step 1 — ack within the 3-sec budget via `update`. No async before this.
   await interaction.update({
@@ -269,36 +276,25 @@ export async function handleEditTruncatedButton(
   });
 
   // Step 2 — warm the session so the Open Editor click gets a hot cache
-  // hit. If this fails we swallow the error: the Open Editor handler has
-  // its own resolveContext + 10062 fallback, so a failed warm here just
-  // means it retries there. Logged for visibility into cache-miss rates.
-  //
-  // Subtle contract note: on a `null` (non-throwing) return from
-  // resolveCharacterSectionContext, sectionContext's replyError helper
-  // has already `followUp`-ed an error like "❌ Unknown section." — which
-  // would visually collide with our just-sent "Ready to edit" embed. We
-  // accept this collision because null returns are unreachable in
-  // practice here: the section lookup is a sync walk of a static dashboard
-  // config (no Redis, no gateway), and the customId we're acting on was
-  // emitted from that same config in step 0, so the section always exists.
-  // The character-not-found branch is the only realistic null path, and
-  // even then the "Ready to edit" embed + "Character not found" followUp
-  // is a strict improvement over the pre-option-(b) silent 10062.
-  try {
-    const warmResult = await resolveCharacterSectionContext(
-      interaction,
-      entityId,
-      sectionId,
-      config
+  // hit. If the sync section lookup failed (unknown sectionId), we
+  // can't warm and there's nothing to do — the open_editor click will
+  // hit its own resolveContext + error path. Swallow quietly.
+  if (sync === null) {
+    logger.warn(
+      { userId: interaction.user.id, entityId, sectionId },
+      'Unknown sectionId in edit_truncated opt-in; open_editor click will surface the error'
     );
+    return;
+  }
+
+  // If the data fetch fails (character-deleted race between warning and
+  // opt-in click), loadCharacterSectionData already sent a followUp via
+  // replyError. The user now sees "Ready to edit" + error followUp —
+  // strictly better than pre-option-(b) silent 10062; log so the
+  // frequency is trackable.
+  try {
+    const warmResult = await loadCharacterSectionData(interaction, entityId, config, sync);
     if (warmResult === null) {
-      // sectionContext already sent a followUp via replyError — the user
-      // now sees the "Ready to edit" embed + an error followUp. Per the
-      // comment above this is strictly better than the pre-option-(b)
-      // silent 10062, but we log it so the frequency is trackable. A
-      // null here is realistically only the character-deleted race
-      // (warning → opt-in click gap); the unknown-section path is dead
-      // per the static-config argument.
       logger.warn(
         { userId: interaction.user.id, entityId, sectionId },
         'Session warm returned null after edit_truncated opt-in (likely character-deleted race); user saw Ready-to-Edit + followUp error'
@@ -310,19 +306,6 @@ export async function handleEditTruncatedButton(
       'Session warm failed after edit_truncated opt-in; open_editor will retry'
     );
   }
-}
-
-/**
- * Sync lookup of a section's display label for use in the "Ready to edit"
- * embed. Walks the statically-built dashboard config — no Redis, no gateway,
- * safe to call before the 3-sec `interaction.update` ack. Falls back to
- * the raw sectionId on unknown sections so the embed still renders.
- */
-function getSectionLabelSync(sectionId: string, userId: string): string {
-  const isAdmin = isBotOwner(userId);
-  const config = getCharacterDashboardConfig(isAdmin, false);
-  const section = config.sections.find(s => s.id === sectionId);
-  return section?.label ?? sectionId;
 }
 
 /**

--- a/services/bot-client/src/commands/character/truncationWarning.ts
+++ b/services/bot-client/src/commands/character/truncationWarning.ts
@@ -285,7 +285,25 @@ export async function handleEditTruncatedButton(
   // even then the "Ready to edit" embed + "Character not found" followUp
   // is a strict improvement over the pre-option-(b) silent 10062.
   try {
-    await resolveCharacterSectionContext(interaction, entityId, sectionId, config);
+    const warmResult = await resolveCharacterSectionContext(
+      interaction,
+      entityId,
+      sectionId,
+      config
+    );
+    if (warmResult === null) {
+      // sectionContext already sent a followUp via replyError — the user
+      // now sees the "Ready to edit" embed + an error followUp. Per the
+      // comment above this is strictly better than the pre-option-(b)
+      // silent 10062, but we log it so the frequency is trackable. A
+      // null here is realistically only the character-deleted race
+      // (warning → opt-in click gap); the unknown-section path is dead
+      // per the static-config argument.
+      logger.warn(
+        { userId: interaction.user.id, entityId, sectionId },
+        'Session warm returned null after edit_truncated opt-in (likely character-deleted race); user saw Ready-to-Edit + followUp error'
+      );
+    }
   } catch (error) {
     logger.warn(
       { err: error, userId: interaction.user.id, entityId, sectionId },
@@ -324,8 +342,11 @@ function getSectionLabelSync(sectionId: string, userId: string): string {
  * On the narrow residual failure where the 3-sec window still blows
  * (cold cache + slow gateway), we catch `10062 Unknown interaction` and
  * surface an explicit retry message via `followUp` instead of silently
- * dying in the CommandHandler catch chain. The BACKLOG doesn't track
- * this residual since the visible error path is user-actionable.
+ * dying in the CommandHandler catch chain. The residual is tracked in
+ * BACKLOG ("Character Open Editor can still blow the 3-second window")
+ * for future UX improvement — the retry message is user-actionable but
+ * mid-flow retries are confusing, and the eventual fix is stashing
+ * either the resolved context or pre-built modal during step 1.
  */
 export async function handleOpenEditorButton(
   interaction: ButtonInteraction,

--- a/services/bot-client/src/commands/character/truncationWarning.ts
+++ b/services/bot-client/src/commands/character/truncationWarning.ts
@@ -22,11 +22,7 @@ import {
   AttachmentBuilder,
   MessageFlags,
 } from 'discord.js';
-import type {
-  ButtonInteraction,
-  StringSelectMenuInteraction,
-  InteractionReplyOptions,
-} from 'discord.js';
+import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
 import { createLogger, DISCORD_COLORS, getConfig, type EnvConfig } from '@tzurot/common-types';
 import {
   buildDashboardCustomId,
@@ -37,6 +33,17 @@ import type { CharacterData } from './config.js';
 import { resolveCharacterSectionContext } from './sectionContext.js';
 
 const logger = createLogger('character-truncation-warning');
+
+/**
+ * Strip a leading emoji + whitespace from a section label so modal titles
+ * / embed titles / attachment copy read cleanly. Mirrors the inline regex
+ * in `ModalFactory.ts:51` (modal title derivation) — kept in sync by
+ * convention until a section-label shortener becomes a third consumer
+ * that warrants a shared helper.
+ */
+function stripLeadingEmoji(label: string): string {
+  return label.replace(/^[^\w\s]+\s*/, '');
+}
 
 /**
  * A field whose current value exceeds its modal maxLength.
@@ -95,9 +102,7 @@ export function buildTruncationWarningEmbed(
   overLength: OverLengthField[],
   sectionLabel: string
 ): EmbedBuilder {
-  // Strip a leading emoji + whitespace from the section label the same
-  // way ModalFactory does for modal titles.
-  const plainLabel = sectionLabel.replace(/^[^\w\s]+\s*/, '');
+  const plainLabel = stripLeadingEmoji(sectionLabel);
 
   const fieldLines = overLength
     .map(f => {
@@ -139,17 +144,17 @@ export function buildTruncationButtons(
 ): ActionRowBuilder<ButtonBuilder> {
   return new ActionRowBuilder<ButtonBuilder>().addComponents(
     new ButtonBuilder()
-      .setCustomId(buildDashboardCustomId('character', 'edit-truncated', entityId, sectionId))
+      .setCustomId(buildDashboardCustomId('character', 'edit_truncated', entityId, sectionId))
       .setLabel('Edit with Truncation')
       .setEmoji('✂️')
       .setStyle(ButtonStyle.Danger),
     new ButtonBuilder()
-      .setCustomId(buildDashboardCustomId('character', 'view-full', entityId, sectionId))
+      .setCustomId(buildDashboardCustomId('character', 'view_full', entityId, sectionId))
       .setLabel('View Full')
       .setEmoji('📖')
       .setStyle(ButtonStyle.Primary),
     new ButtonBuilder()
-      .setCustomId(buildDashboardCustomId('character', 'cancel-edit', entityId, sectionId))
+      .setCustomId(buildDashboardCustomId('character', 'cancel_edit', entityId, sectionId))
       .setLabel('Cancel')
       .setStyle(ButtonStyle.Secondary)
   );
@@ -176,6 +181,14 @@ export async function showTruncationWarning(
  * "Edit with Truncation" handler — user has acknowledged the warning
  * and wants to proceed. Fetch fresh data, resolve the section, and show
  * the modal. The actual truncation happens inside ModalFactory.
+ *
+ * No `deferReply`/`deferUpdate` before the async work here: Discord
+ * requires `showModal` to be the first response to the interaction
+ * (you can't defer then modal). In practice the session is almost always
+ * cached from the preceding select-menu interaction, so the async work
+ * is a cheap Redis hit that fits inside the 3-second window. If a cache
+ * miss is observed in production the right fix is a different UX shape
+ * (e.g. instruct the user to retry), not deferring here.
  */
 export async function handleEditTruncatedButton(
   interaction: ButtonInteraction,
@@ -184,7 +197,9 @@ export async function handleEditTruncatedButton(
   config: EnvConfig = getConfig()
 ): Promise<void> {
   const ctx = await resolveCharacterSectionContext(interaction, entityId, sectionId, config);
-  if (ctx === null) {return;}
+  if (ctx === null) {
+    return;
+  }
 
   const modal = buildSectionModal(
     ctx.dashboardConfig,
@@ -209,17 +224,25 @@ export async function handleViewFullButton(
   sectionId: string,
   config: EnvConfig = getConfig()
 ): Promise<void> {
+  // Ack within 3 seconds before any async work — `resolveCharacterSectionContext`
+  // hits Redis (and may fall through to a gateway API call on session miss),
+  // which could blow the 3-second window under load. `deferReply({ ephemeral })`
+  // establishes the response now; `editReply` / `followUp` fill it in later.
+  await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
   const ctx = await resolveCharacterSectionContext(interaction, entityId, sectionId, config);
-  if (ctx === null) {return;}
+  if (ctx === null) {
+    // sectionContext already `followUp`-ed the error (it detects the defer).
+    return;
+  }
 
   const overLength = detectOverLengthFields(ctx.section, ctx.data);
   if (overLength.length === 0) {
     // Edge case: data changed between warning and View Full click (e.g.,
     // a concurrent save trimmed fields). Let the user know there's
     // nothing to view specially.
-    await interaction.reply({
+    await interaction.editReply({
       content: '✅ No fields in this section exceed the edit limit. Nothing to display.',
-      flags: MessageFlags.Ephemeral,
     });
     return;
   }
@@ -232,21 +255,18 @@ export async function handleViewFullButton(
     });
   });
 
-  const plainLabel = ctx.section.label.replace(/^[^\w\s]+\s*/, '');
+  const plainLabel = stripLeadingEmoji(ctx.section.label);
   const summary = overLength
     .map(f => `• \`${f.fieldId}.txt\` — ${f.current.toLocaleString()} chars`)
     .join('\n');
 
-  const payload: InteractionReplyOptions = {
+  await interaction.editReply({
     content:
       `**Full content for "${plainLabel}"** (read-only):\n${summary}\n\n` +
       `These files hold the current, untruncated values. Editing this section ` +
       `via the dashboard would cut each field to its modal cap.`,
     files: attachments,
-    flags: MessageFlags.Ephemeral,
-  };
-
-  await interaction.reply(payload);
+  });
   logger.info(
     { userId: interaction.user.id, entityId, sectionId, fields: overLength.length },
     'View Full served over-length field content'

--- a/services/bot-client/src/commands/character/truncationWarning.ts
+++ b/services/bot-client/src/commands/character/truncationWarning.ts
@@ -128,7 +128,7 @@ export function buildTruncationWarningEmbed(
         `Choose **Edit with Truncation** only if you're OK losing the trailing text.`
     )
     .setFooter({
-      text: `${totalLoss.toLocaleString()} total characters would be truncated across ${overLength.length} field(s)`,
+      text: `${totalLoss.toLocaleString()} total characters would be truncated across ${overLength.length} field${overLength.length === 1 ? '' : 's'}`,
     });
 }
 

--- a/services/bot-client/src/commands/character/truncationWarning.ts
+++ b/services/bot-client/src/commands/character/truncationWarning.ts
@@ -20,16 +20,23 @@ import {
   ButtonStyle,
   ActionRowBuilder,
   AttachmentBuilder,
+  DiscordAPIError,
   MessageFlags,
 } from 'discord.js';
 import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
-import { createLogger, DISCORD_COLORS, getConfig, type EnvConfig } from '@tzurot/common-types';
+import {
+  createLogger,
+  DISCORD_COLORS,
+  getConfig,
+  isBotOwner,
+  type EnvConfig,
+} from '@tzurot/common-types';
 import {
   buildDashboardCustomId,
   buildSectionModal,
   type SectionDefinition,
 } from '../../utils/dashboard/index.js';
-import type { CharacterData } from './config.js';
+import { getCharacterDashboardConfig, type CharacterData } from './config.js';
 import { resolveCharacterSectionContext } from './sectionContext.js';
 
 const logger = createLogger('character-truncation-warning');
@@ -178,19 +185,116 @@ export async function showTruncationWarning(
 }
 
 /**
- * "Edit with Truncation" handler — user has acknowledged the warning
- * and wants to proceed. Fetch fresh data, resolve the section, and show
- * the modal. The actual truncation happens inside ModalFactory.
+ * Build the "Open Editor" button shown after the user opts into the
+ * truncating edit. Splitting the opt-in confirmation from the modal-open
+ * click lets us satisfy Discord's "showModal must be the first response"
+ * constraint without doing any async work before the showModal call.
+ */
+export function buildOpenEditorButtonRow(
+  entityId: string,
+  sectionId: string
+): ActionRowBuilder<ButtonBuilder> {
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(buildDashboardCustomId('character', 'open_editor', entityId, sectionId))
+      .setLabel('Open Editor')
+      .setEmoji('✏️')
+      .setStyle(ButtonStyle.Primary)
+  );
+}
+
+/**
+ * Build the embed shown between the Edit-with-Truncation opt-in and the
+ * actual modal. It reassures the user that their consent was recorded
+ * and directs them to the single click that opens the modal.
+ */
+export function buildReadyToEditEmbed(sectionLabel: string): EmbedBuilder {
+  const plainLabel = stripLeadingEmoji(sectionLabel);
+  return new EmbedBuilder()
+    .setTitle(`✅ Ready to edit "${plainLabel}"`)
+    .setColor(DISCORD_COLORS.SUCCESS)
+    .setDescription(
+      `Your opt-in to truncate over-length fields has been recorded. ` +
+        `Click **Open Editor** below to open the edit modal. ` +
+        `The modal will open with the current values truncated to the edit limit.`
+    );
+}
+
+/**
+ * "Edit with Truncation" handler — step 1 of a two-click flow.
  *
- * No `deferReply`/`deferUpdate` before the async work here: Discord
- * requires `showModal` to be the first response to the interaction
- * (you can't defer then modal). In practice the session is almost always
- * cached from the preceding select-menu interaction, so the async work
- * is a cheap Redis hit that fits inside the 3-second window. If a cache
- * miss is observed in production the right fix is a different UX shape
- * (e.g. instruct the user to retry), not deferring here.
+ * Why two clicks instead of one showModal:
+ * Discord requires `showModal` to be the first response to an interaction
+ * (you can't `deferReply`/`deferUpdate` then `showModal`). That made the
+ * single-click flow vulnerable to 10062 Unknown interaction if any async
+ * work (session resolution, gateway fallback) ate the 3-second response
+ * budget. See PR #825 R4 — the reviewer's option (b).
+ *
+ * New flow:
+ * - Step 1 (this handler): `interaction.update` immediately to morph the
+ *   warning embed into a "Ready to edit" state with a single Open Editor
+ *   button. The update call has no async work before it, so the 3-second
+ *   budget is never at risk. After the update we warm the session in the
+ *   background so the Open Editor click hits a hot cache.
+ * - Step 2 (`handleOpenEditorButton`): shows the modal with no pre-work
+ *   beyond a Redis-hot session read. Residual risk is logged + surfaced
+ *   if 10062 still fires.
  */
 export async function handleEditTruncatedButton(
+  interaction: ButtonInteraction,
+  entityId: string,
+  sectionId: string,
+  config: EnvConfig = getConfig()
+): Promise<void> {
+  // Resolve the section label for the embed copy — this is a sync lookup
+  // on the dashboard config (no Redis, no gateway), safe before `update`.
+  const sectionLabel = getSectionLabelSync(sectionId, interaction.user.id);
+
+  // Step 1 — ack within the 3-sec budget via `update`. No async before this.
+  await interaction.update({
+    embeds: [buildReadyToEditEmbed(sectionLabel)],
+    components: [buildOpenEditorButtonRow(entityId, sectionId)],
+  });
+
+  // Step 2 — warm the session so the Open Editor click gets a hot cache
+  // hit. If this fails we swallow the error: the Open Editor handler has
+  // its own resolveContext + 10062 fallback, so a failed warm here just
+  // means it retries there. Logged for visibility into cache-miss rates.
+  try {
+    await resolveCharacterSectionContext(interaction, entityId, sectionId, config);
+  } catch (error) {
+    logger.warn(
+      { err: error, userId: interaction.user.id, entityId, sectionId },
+      'Session warm failed after edit_truncated opt-in; open_editor will retry'
+    );
+  }
+}
+
+/**
+ * Sync lookup of a section's display label for use in the "Ready to edit"
+ * embed. Walks the statically-built dashboard config — no Redis, no gateway,
+ * safe to call before the 3-sec `interaction.update` ack. Falls back to
+ * the raw sectionId on unknown sections so the embed still renders.
+ */
+function getSectionLabelSync(sectionId: string, userId: string): string {
+  const isAdmin = isBotOwner(userId);
+  const config = getCharacterDashboardConfig(isAdmin, false);
+  const section = config.sections.find(s => s.id === sectionId);
+  return section?.label ?? sectionId;
+}
+
+/**
+ * "Open Editor" handler — step 2 of the two-click flow. Shows the section
+ * edit modal.
+ *
+ * Discord requires `showModal` as the first response — we call it with
+ * minimum pre-work: one Redis-hot session read (warmed by the preceding
+ * edit_truncated click). On the narrow residual failure where the 3-sec
+ * window still blows (e.g., Redis latency spike), we catch 10062 and
+ * surface an explicit retry message via `followUp` instead of silently
+ * dying in the CommandHandler catch chain.
+ */
+export async function handleOpenEditorButton(
   interaction: ButtonInteraction,
   entityId: string,
   sectionId: string,
@@ -208,7 +312,33 @@ export async function handleEditTruncatedButton(
     ctx.data,
     ctx.context
   );
-  await interaction.showModal(modal);
+  try {
+    await interaction.showModal(modal);
+  } catch (error) {
+    if (error instanceof DiscordAPIError && error.code === 10062) {
+      // 3-sec window blew despite the session warm (e.g., Redis latency
+      // spike). Log with enough context to track frequency. The interaction
+      // token is dead so followUp also fails — we try once anyway for the
+      // rare race where Discord still accepts it, and swallow the inner
+      // failure so the outer CommandHandler catch doesn't log twice.
+      logger.warn(
+        { userId: interaction.user.id, entityId, sectionId },
+        'Open Editor showModal exceeded 3-second window (10062)'
+      );
+      try {
+        await interaction.followUp({
+          content:
+            '⏰ Took too long to open the editor. Please click **Open Editor** again, ' +
+            'or re-open the dashboard if the button is gone.',
+          flags: MessageFlags.Ephemeral,
+        });
+      } catch {
+        // Expected on a fully-dead interaction token. Nothing else to do.
+      }
+      return;
+    }
+    throw error;
+  }
 }
 
 /**

--- a/services/bot-client/src/commands/character/truncationWarning.ts
+++ b/services/bot-client/src/commands/character/truncationWarning.ts
@@ -31,11 +31,8 @@ import {
   isBotOwner,
   type EnvConfig,
 } from '@tzurot/common-types';
-import {
-  buildDashboardCustomId,
-  buildSectionModal,
-  type SectionDefinition,
-} from '../../utils/dashboard/index.js';
+import { buildDashboardCustomId, type SectionDefinition } from '../../utils/dashboard/types.js';
+import { buildSectionModal } from '../../utils/dashboard/ModalFactory.js';
 import { getCharacterDashboardConfig, type CharacterData } from './config.js';
 import { resolveCharacterSectionContext } from './sectionContext.js';
 

--- a/services/bot-client/src/commands/character/truncationWarning.ts
+++ b/services/bot-client/src/commands/character/truncationWarning.ts
@@ -27,26 +27,14 @@ import type {
   StringSelectMenuInteraction,
   InteractionReplyOptions,
 } from 'discord.js';
-import {
-  createLogger,
-  DISCORD_COLORS,
-  getConfig,
-  isBotOwner,
-  type EnvConfig,
-} from '@tzurot/common-types';
+import { createLogger, DISCORD_COLORS, getConfig, type EnvConfig } from '@tzurot/common-types';
 import {
   buildDashboardCustomId,
   buildSectionModal,
-  fetchOrCreateSession,
   type SectionDefinition,
-  type DashboardContext,
 } from '../../utils/dashboard/index.js';
-import {
-  getCharacterDashboardConfig,
-  type CharacterData,
-  type CharacterSessionData,
-} from './config.js';
-import { fetchCharacter } from './api.js';
+import type { CharacterData } from './config.js';
+import { resolveCharacterSectionContext } from './sectionContext.js';
 
 const logger = createLogger('character-truncation-warning');
 
@@ -80,9 +68,13 @@ export function detectOverLengthFields(
 ): OverLengthField[] {
   const over: OverLengthField[] = [];
   for (const field of section.fields) {
-    if (field.maxLength === undefined) {continue;}
+    if (field.maxLength === undefined) {
+      continue;
+    }
     const raw = (data as Record<string, unknown>)[field.id];
-    if (typeof raw !== 'string') {continue;}
+    if (typeof raw !== 'string') {
+      continue;
+    }
     if (raw.length > field.maxLength) {
       over.push({
         fieldId: field.id,
@@ -191,38 +183,16 @@ export async function handleEditTruncatedButton(
   sectionId: string,
   config: EnvConfig = getConfig()
 ): Promise<void> {
-  const isAdmin = isBotOwner(interaction.user.id);
-  // hasVoiceReference=false is fine here — this config is only used for
-  // section field lookup, not action rendering (same pattern used in
-  // handleSectionModalSubmit in dashboard.ts).
-  const dashboardConfig = getCharacterDashboardConfig(isAdmin, false);
-  const section = dashboardConfig.sections.find(s => s.id === sectionId);
-  if (!section) {
-    await interaction.reply({
-      content: '❌ Unknown section.',
-      flags: MessageFlags.Ephemeral,
-    });
-    return;
-  }
+  const ctx = await resolveCharacterSectionContext(interaction, entityId, sectionId, config);
+  if (ctx === null) {return;}
 
-  const result = await fetchOrCreateSession<CharacterSessionData, CharacterData>({
-    userId: interaction.user.id,
-    entityType: 'character',
+  const modal = buildSectionModal(
+    ctx.dashboardConfig,
+    ctx.section,
     entityId,
-    fetchFn: () => fetchCharacter(entityId, config, interaction.user.id),
-    transformFn: (character: CharacterData) => ({ ...character, _isAdmin: isAdmin }),
-    interaction,
-  });
-  if (!result.success) {
-    await interaction.reply({
-      content: '❌ Character not found.',
-      flags: MessageFlags.Ephemeral,
-    });
-    return;
-  }
-
-  const context: DashboardContext = { isAdmin, userId: interaction.user.id };
-  const modal = buildSectionModal(dashboardConfig, section, entityId, result.data, context);
+    ctx.data,
+    ctx.context
+  );
   await interaction.showModal(modal);
 }
 
@@ -239,37 +209,10 @@ export async function handleViewFullButton(
   sectionId: string,
   config: EnvConfig = getConfig()
 ): Promise<void> {
-  const isAdmin = isBotOwner(interaction.user.id);
-  // hasVoiceReference=false is fine here — this config is only used for
-  // section field lookup, not action rendering (same pattern used in
-  // handleSectionModalSubmit in dashboard.ts).
-  const dashboardConfig = getCharacterDashboardConfig(isAdmin, false);
-  const section = dashboardConfig.sections.find(s => s.id === sectionId);
-  if (!section) {
-    await interaction.reply({
-      content: '❌ Unknown section.',
-      flags: MessageFlags.Ephemeral,
-    });
-    return;
-  }
+  const ctx = await resolveCharacterSectionContext(interaction, entityId, sectionId, config);
+  if (ctx === null) {return;}
 
-  const result = await fetchOrCreateSession<CharacterSessionData, CharacterData>({
-    userId: interaction.user.id,
-    entityType: 'character',
-    entityId,
-    fetchFn: () => fetchCharacter(entityId, config, interaction.user.id),
-    transformFn: (character: CharacterData) => ({ ...character, _isAdmin: isAdmin }),
-    interaction,
-  });
-  if (!result.success) {
-    await interaction.reply({
-      content: '❌ Character not found.',
-      flags: MessageFlags.Ephemeral,
-    });
-    return;
-  }
-
-  const overLength = detectOverLengthFields(section, result.data);
+  const overLength = detectOverLengthFields(ctx.section, ctx.data);
   if (overLength.length === 0) {
     // Edge case: data changed between warning and View Full click (e.g.,
     // a concurrent save trimmed fields). Let the user know there's
@@ -282,14 +225,14 @@ export async function handleViewFullButton(
   }
 
   const attachments = overLength.map(f => {
-    const content = (result.data as Record<string, unknown>)[f.fieldId];
+    const content = (ctx.data as Record<string, unknown>)[f.fieldId];
     const textContent = typeof content === 'string' ? content : '';
     return new AttachmentBuilder(Buffer.from(textContent, 'utf-8'), {
       name: `${f.fieldId}.txt`,
     });
   });
 
-  const plainLabel = section.label.replace(/^[^\w\s]+\s*/, '');
+  const plainLabel = ctx.section.label.replace(/^[^\w\s]+\s*/, '');
   const summary = overLength
     .map(f => `• \`${f.fieldId}.txt\` — ${f.current.toLocaleString()} chars`)
     .join('\n');


### PR DESCRIPTION
## Summary

Closes the silent-data-loss Production Issue on the character edit dashboard (documented in BACKLOG since 2026-04-11; 23.8% of personalities in prod affected at least once).

When a user opened a section containing a legacy value longer than a field's modal `maxLength`, `ModalFactory.buildSectionModal` silently pre-filled the modal with `currentValue.slice(0, maxLength)`. Saving the modal committed the truncated value with no warning to the user. Ports the `/memory` command's destructive-action pattern to the character dashboard's many-field sections.

## Changes

### New module: `services/bot-client/src/commands/character/truncationWarning.ts`
- `detectOverLengthFields(section, data)` — scans a section's fields against current data and reports any whose string value exceeds the declared `maxLength`
- `buildTruncationWarningEmbed` — warning embed listing per-field chars/cap + total truncation amount
- `buildTruncationButtons` — three-button row: **Edit with Truncation** (Danger, opt-in), **View Full** (Primary, read-only inspection), **Cancel** (Secondary)
- `showTruncationWarning` — ephemeral reply rendering the warning + buttons
- `handleEditTruncatedButton` — proceeds through the existing modal path (ModalFactory truncates after explicit consent)
- `handleViewFullButton` — attaches one `.txt` file per over-length field so the user can inspect their current full values without triggering the destructive edit path
- `handleCancelEditButton` — dismisses the warning

### Modified: `services/bot-client/src/commands/character/dashboard.ts`
- Before opening the section modal (line 242 area), detection runs. If any field is over-length → warning embed. Else → modal as today.
- `handleButton` router wires the three new button actions (`edit-truncated`, `view-full`, `cancel-edit`). `DASHBOARD_ACTIONS` set updated so the dispatcher recognizes them.

### No changes to `ModalFactory.ts`
The silent-truncate site at line 108 still runs, but only after user consent. Scope-limited to character per the BACKLOG's rule-of-three guidance — shared-utility extraction is deferred until persona/preset dashboards hit the same class of bug.

## UX

```
[User clicks edit → picks "🏷️ Identity & Basics" section]

⚠️ "Identity & Basics" contains content longer than Discord modals allow

One or more fields in this section hold values that exceed the edit modal's limit:

• Traits — 1,500 / 1,000 chars (500 will be truncated)
• Age — 150 / 100 chars (50 will be truncated)

⚠️ Opening the edit modal will pre-fill the fields with truncated values.
If you save the modal, the trailing content will be lost permanently.

Choose View Full to inspect the current full content before deciding.
Choose Edit with Truncation only if you're OK losing the trailing text.

[✂️ Edit with Truncation] [📖 View Full] [Cancel]
```

**View Full** produces one `.txt` attachment per over-length field so users can inspect and locally save their content before any destructive action.

## Test plan

- [ ] `pnpm --filter @tzurot/bot-client test` — 4271 tests pass (14 new in `truncationWarning.test.ts`)
- [ ] `pnpm typecheck` + `typecheck:spec` — clean
- [ ] Pre-push hook passed (build + lint + cpd + depcruise)
- [ ] Manual (post-merge): open a character with over-length fields → confirm warning appears; click each button → confirm correct flow

## Deferred follow-ups (not blocking this PR)

- Extracting the pattern to a shared `utils/dashboard/overLongFieldWarning.ts` helper — waiting for rule-of-three trigger (persona/preset dashboards hit the same bug)
- Dashboard-level pre-emptive "View Full" affordance (before any edit attempt) — current design requires the user to click edit to discover the warning + View Full path

🤖 Generated with [Claude Code](https://claude.com/claude-code)