### PR TITLE
fix(repo): repair 4 non-rfc-4122 uuids in llm_configs (beta.100 blocker)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -13,39 +13,6 @@ Single source of truth for all work. Tech debt competes for the same time as fea
 
 _Active bugs observed in production. Fix before new features._
 
-- 🐛 `[FIX]` **🚫 BETA.100 BLOCKER — preset-option autocomplete produces configIds that the gateway rejects as "Invalid configId format"** — First observed via `/settings preset default` on 2026-04-17 19:54 UTC by bot owner, who confirmed the value was **picked from autocomplete** (not typed manually). Failing request produced: `❌ Failed to set default: configId: Invalid configId format`, from `SetDefaultConfigSchema.configId = z.string().uuid(...)` at `packages/common-types/src/schemas/api/model-override.ts:103`.
-
-  **Scope — this is a cross-command pattern, not a single-command bug**: every command that feeds preset-autocomplete values into a gateway endpoint with a `.uuid()` configId schema is on the same failure path. Enumerated consumers (grep for autocomplete files + `.uuid()` schemas):
-  - `/settings preset default` — `settings/preset/default.ts` → PUT `/user/model-override/default` → `SetDefaultConfigSchema`
-  - `/settings preset set` — `settings/preset/set.ts` (if it exists) → PUT `/user/model-override` → `SetModelOverrideSchema` (configId + personalityId, both `.uuid()`)
-  - `/preset edit <preset>` — top-level `/preset` autocomplete in `services/bot-client/src/commands/preset/autocomplete.ts` — same `c.id` shape, hits `LlmConfigService` detail/update endpoints
-  - Any other command whose autocomplete uses the `value: c.id` pattern and whose downstream API validates with `.uuid()`. Grep target when fixing: `grep -rn "value: c\.id" services/bot-client/src/commands/` + cross-reference against `packages/common-types/src/schemas/api/` for matching `.uuid()` schemas.
-  - **Personality autocomplete may share the class**: `handlePersonalityAutocomplete` with `valueField: 'id'` feeds `personalityId: z.string().uuid()` in several schemas. Same failure mode is possible if a non-UUID personality id ever reaches the list response.
-
-  **Investigation pointers — what is and isn't known**:
-  - Bot owner picked from autocomplete, so the user-typed hypothesis is ruled out.
-  - Autocomplete at `settings/preset/autocomplete.ts:140` sets `value: c.id`, where `c.id` comes from `/user/llm-config` → `LlmConfigSummarySchema.id = z.string()` (NOT `.uuid()`). The response schema is wider than the input schema — if any config has a non-UUID id, autocomplete accepts it and the downstream write rejects it.
-  - Prisma schema declares `LlmConfig.id` as `@db.Uuid`, so DB-backed configs should all have UUID ids. So either (a) a code path is creating/surfacing a config with a non-UUID id (bug), or (b) autocomplete is submitting something subtly different from what was selected (encoding/race condition), or (c) the list response is picking up a synthesized-but-non-UUID id somewhere (e.g., a virtual "free default" or upsell-style entry that wasn't fully caught).
-  - `UNLOCK_MODELS_VALUE = '__unlock_all_models__'` is handled upstream by `handleUnlockModelsUpsell`, so that's not the culprit.
-
-  **First investigation step**: add temporary log at `settings/preset/default.ts:28` capturing the raw `configId` that came off the interaction, then reproduce. Compare against the `/user/llm-config` response to see whether a specific config entry has a malformed id or whether the autocomplete mechanism is mangling the value.
-
-  **Fix options** (pending triage + root-cause confirmation):
-  - **(a)** Tighten `LlmConfigSummarySchema.id` to `z.string().uuid()` — forces the gateway to reject non-UUID configs at the response boundary. Does nothing about the pre-existing data that might already be broken, but it catches the next recurrence at the source.
-  - **(b)** Bot-side pre-validation in every preset consumer: check the configId is a UUID before calling the API; show a friendlier error ("This preset can't be used — please pick another, or report this to the admin if it keeps happening").
-  - **(c)** Audit database for any LlmConfig rows with non-UUID ids: `SELECT id FROM llm_configs WHERE id !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$';` If found, either migrate or delete.
-  - Probably want all three, and the fix should sweep every preset-consuming command as a single pass.
-
-  Blocker because preset configuration is a core user flow; the error is opaque ("Invalid configId format" looks like a dev error, not user-actionable); and failing silently across multiple commands is worse than failing noisily in one.
-
-  **Start** (cast wide):
-  - Enumerate all preset consumers: `grep -rn "autocomplete\|preset" services/bot-client/src/commands/ | grep -v test`
-  - Enumerate all schemas with `configId: z.string().uuid(...)`: `grep -rn "configId.*uuid" packages/common-types/src/schemas/`
-  - Check the response schema: `packages/common-types/src/schemas/api/llm-config.ts:204` (`LlmConfigSummarySchema.id` — tighten to `.uuid()`)
-  - Initial observed failure: `services/bot-client/src/commands/settings/preset/default.ts:48` (echoes `result.error` verbatim)
-  - Top-level preset command autocomplete (second likely victim): `services/bot-client/src/commands/preset/autocomplete.ts`
-  - Prod DB audit query (see fix option c above) run via `pnpm ops run --env prod psql` or equivalent
-
 - 🐛 `[FIX]` **Character field length caps cause silent data loss in dashboard edit + block API updates** — `PersonalityCharacterFieldsSchema` enforces length caps (1000/100/4000 chars per field, matching Discord modal input limits) at the Zod validation layer. Characters with legacy fields exceeding those caps (likely from shapes.inc imports or pre-cap data) exhibit two failure modes:
 
   **1. Silent data loss via dashboard edit** (CRITICAL): When a user clicks a character dashboard section that contains an over-long field (e.g., Biography → Appearance), `ModalFactory.buildSectionModal` silently truncates the pre-fill to `maxLength` chars at `services/bot-client/src/utils/dashboard/ModalFactory.ts:108` (`currentValue.slice(0, maxLength)`). The user sees no warning. If they submit, the trailing content is irrecoverably lost. The truncation is justified at line 107 as "Discord modals require value to be within length constraints" — a genuine API constraint — but the destructive behavior is hidden from the user.

--- a/scripts/migrations/repair-llm-config-rfc-uuids.ts
+++ b/scripts/migrations/repair-llm-config-rfc-uuids.ts
@@ -1,0 +1,157 @@
+#!/usr/bin/env tsx
+/**
+ * Data Migration: Repair non-RFC-4122 `llm_configs.id` values
+ *
+ * Symptom this repair fixes:
+ *   /settings preset default → "❌ Failed to set default: configId: Invalid configId format"
+ *
+ * Background:
+ *   Four llm_configs rows in production have `id` values that Postgres accepts
+ *   (the `uuid` column type validates format only) but that fail Zod's
+ *   `.uuid()` check (which enforces RFC 4122's variant-bit rule — the 17th
+ *   hex digit must be 8/9/a/b). When one of these ids is submitted as a
+ *   config override, SetDefaultConfigSchema.configId rejects it.
+ *
+ *   The full audit across 65 uuid columns × 202K rows showed exactly 8
+ *   violations, all originating from these 4 rows (+ 4 FK references in
+ *   users.default_llm_config_id that CASCADE-update when the config id
+ *   changes). No code path in the current codebase produces non-RFC UUIDs
+ *   — all app inserts route through `generateLlmConfigUuid` (v5) or
+ *   Prisma's built-in UUID default (v4), both RFC-compliant. These 4
+ *   rows were inserted via some out-of-band path (manual, one-off script,
+ *   Prisma Studio) on 2025-11-28 and the history is not recoverable.
+ *
+ * Fix shape:
+ *   For each row, compute the canonical id via `generateLlmConfigUuid(name)`
+ *   and UPDATE the row's id to that value. The users↔llm_configs FK has
+ *   ON UPDATE CASCADE, so the 4 dependent users.default_llm_config_id
+ *   references auto-repair.
+ *
+ * Run:
+ *   DRY_RUN=1 pnpm tsx scripts/migrations/repair-llm-config-rfc-uuids.ts
+ *   pnpm tsx scripts/migrations/repair-llm-config-rfc-uuids.ts
+ *
+ * Against prod:
+ *   DRY_RUN=1 pnpm ops run --env prod pnpm tsx scripts/migrations/repair-llm-config-rfc-uuids.ts
+ *   pnpm ops run --env prod pnpm tsx scripts/migrations/repair-llm-config-rfc-uuids.ts
+ *
+ * (Env var instead of --dry-run because `pnpm ops run` parses arg flags
+ * as its own options and swallows them before they reach this script.)
+ */
+
+/* eslint-disable no-console -- this is a CLI migration script */
+
+import { generateLlmConfigUuid, getPrismaClient } from '@tzurot/common-types';
+
+// RFC 4122 variant bits: the 17th hex digit (index 19 in the dashed form)
+// must be 8, 9, a, or b. Anything else is non-RFC.
+const RFC_VARIANT_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+interface Mapping {
+  oldId: string;
+  newId: string;
+  name: string;
+  collision: boolean;
+}
+
+async function main(): Promise<void> {
+  // Env var instead of flag because `pnpm ops run` consumes positional
+  // `--` options as its own flags. See the file header for invocation.
+  const dryRun = process.env.DRY_RUN === '1' || process.env.DRY_RUN === 'true';
+  const prisma = getPrismaClient();
+
+  console.log(`\n🚀 Repairing non-RFC-4122 llm_configs ids${dryRun ? ' (DRY RUN)' : ''}\n`);
+
+  // Find offenders. Uses the same variant-bit heuristic as the Zod schema
+  // they were failing against.
+  const all = await prisma.llmConfig.findMany({
+    select: { id: true, name: true },
+  });
+  const offenders = all.filter(c => !RFC_VARIANT_RE.test(c.id));
+  console.log(`📊 Scanned ${all.length} configs; ${offenders.length} offenders\n`);
+
+  if (offenders.length === 0) {
+    console.log('✅ Nothing to repair.');
+    await prisma.$disconnect();
+    return;
+  }
+
+  // Compute the canonical id for each. Check for collision: if a DIFFERENT
+  // existing row already has the canonical id, we cannot repair this one
+  // without further data work (it would imply two rows with the same name).
+  // Expected: no collisions, because the offenders are the only rows with
+  // these names.
+  const existingIds = new Set(all.map(c => c.id));
+  const mappings: Mapping[] = offenders.map(c => {
+    const newId = generateLlmConfigUuid(c.name);
+    return {
+      oldId: c.id,
+      newId,
+      name: c.name,
+      // Collision is only real if the canonical id exists on a *different*
+      // row. If the offender somehow already has the canonical id (can't
+      // happen here — they'd have RFC variant bits then — but defense in
+      // depth), skip it.
+      collision: existingIds.has(newId) && newId !== c.id,
+    };
+  });
+
+  console.log('📝 Planned repairs:\n');
+  for (const m of mappings) {
+    const marker = m.collision ? '⚠️  COLLISION' : '  ';
+    console.log(`${marker}  ${m.name}`);
+    console.log(`      old: ${m.oldId}`);
+    console.log(`      new: ${m.newId}`);
+  }
+  console.log('');
+
+  const collisions = mappings.filter(m => m.collision);
+  if (collisions.length > 0) {
+    console.error(
+      `❌ ${collisions.length} collision(s) detected. Aborting. ` +
+        `Another row already holds the canonical id for these names. ` +
+        `This probably means two configs share a name — resolve by hand first.`
+    );
+    await prisma.$disconnect();
+    process.exit(1);
+  }
+
+  if (dryRun) {
+    console.log('🔍 Dry run — no changes made. Re-run without DRY_RUN to apply.');
+    await prisma.$disconnect();
+    return;
+  }
+
+  // Apply in one transaction so all 4 updates commit atomically (or none do).
+  // The users.default_llm_config_id FK has ON UPDATE CASCADE, so Postgres
+  // propagates the new id to dependent rows within the same transaction.
+  console.log('✏️  Applying...\n');
+  await prisma.$transaction(async tx => {
+    for (const m of mappings) {
+      await tx.$executeRawUnsafe(
+        `UPDATE "llm_configs" SET "id" = $1::uuid WHERE "id" = $2::uuid`,
+        m.newId,
+        m.oldId
+      );
+      console.log(`  ✓ ${m.name}`);
+    }
+  });
+
+  // Verify post-repair.
+  const after = await prisma.llmConfig.findMany({ select: { id: true } });
+  const stillBad = after.filter(c => !RFC_VARIANT_RE.test(c.id));
+  console.log(`\n🔎 Post-repair audit: ${after.length} configs, ${stillBad.length} offenders`);
+  if (stillBad.length > 0) {
+    console.error(`❌ Repair incomplete — ${stillBad.length} offenders remain.`);
+    process.exitCode = 1;
+  } else {
+    console.log('✅ All llm_configs ids are now RFC 4122 compliant.');
+  }
+
+  await prisma.$disconnect();
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Fixes the **beta.100 blocker** where `/settings preset default` (and `/settings preset set`) failed with `❌ Failed to set default: configId: Invalid configId format` for 4 specific presets. Already applied to prod this session.

## Root cause (evidence-based)

4 of 29 rows in prod `llm_configs` had `id` values where the 17th hex digit (the RFC 4122 variant bit) was outside `8/9/a/b`. Postgres's `uuid` type accepts any hex-formatted 36-char string; Zod's `.uuid()` enforces RFC 4122 strictly. So the gateway rejected these ids even though the DB happily stored them.

**Confirmed by**:
- Two live reproductions from mobile (tapping the autocomplete chip, not typing) both failed on configId `2cf9a6ea-7b1d-2fc3-f4de-0a9c2f3b7e1f` → "Gemma 4 31B (Free)"
- Full audit across 65 uuid columns × 202,071 rows: exactly 8 violations, all localized to `llm_configs.id` (4) and their downstream `users.default_llm_config_id` FK references (4)
- No active code path can produce non-RFC UUIDs: all inserts route through `generateLlmConfigUuid` (v5) or the original Prisma `@default(uuid())` (v4), both RFC-compliant
- None of the 4 bad ids appear literally anywhere in tracked files
- All 4 have round `createdAt` timestamps (second-level precision; app-code creates have ms precision), indicating out-of-band manual insertion on 2025-11-28 that isn't in git history

## Fix

New data-migration script `scripts/migrations/repair-llm-config-rfc-uuids.ts`:

1. Scans `llm_configs` for rows whose `id` fails RFC 4122 variant check
2. Computes canonical id via `generateLlmConfigUuid(name)` — same deterministic v5 generator used everywhere else, so re-creating a config with the same name maps back to the same id
3. Collision guard: refuses if any canonical id already exists on a *different* row (would mean two configs share a name)
4. `UPDATE` in one transaction; FK `ON UPDATE CASCADE` auto-propagates to `users.default_llm_config_id`
5. Post-repair audit asserts 0 remaining violations

**Applied to prod in this session** (29 configs scanned, 4 repaired, post-audit clean). Dev has 0 configs — no-op there.

## Intentionally NOT done

- **No CHECK constraint** on `llm_configs.id`: would be inconsistent with 64 other uuid columns, and the failure mode only materializes via manual inserts the constraint can't catch at a different layer.
- **No bot-client pre-validation**: root cause is data, not code. The gateway's `.uuid()` schema is correct; the data was wrong. Adding client-side pre-validation would mask the gateway's correct rejection rather than fix it.

## Bonus: new rule in `.claude/rules/00-critical.md`

Already landed on develop in `54e807c6d`. "Don't Present Speculation as Fact" — surfaces when my hypotheses don't match evidence, which happened repeatedly during this investigation before the prod data actually got checked.

## Test plan

- [ ] CI: `pnpm test` + `pnpm quality` pass
- [ ] Script `--dry-run` equivalent (`DRY_RUN=1`) tested against prod: identified 4 offenders, produced 4 canonical v5 UUIDs with no collisions
- [ ] Script applied to prod: all 4 updated, post-audit confirms 0 offenders
- [ ] Manual: try `/settings preset default` with each of the 4 previously-broken configs (Gemma 4 31B Free, Nous Hermes 3 405B Free, GLM 4.5 Air Free, GPT-OSS 120B Free) → should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)