### PR TITLE
refactor(bot-client): thread GatewayUser context to api-gateway via headers (Phase 5c PR A)

### DIFF
--- a/packages/common-types/src/index.ts
+++ b/packages/common-types/src/index.ts
@@ -14,6 +14,7 @@ export * from './schemas/index.js';
 export * from './types/api-types.js';
 export * from './types/discord.js';
 export * from './types/discord-types.js';
+export * from './types/gateway-context.js';
 export * from './types/jobs.js';
 export * from './types/shapes-import.js';
 export * from './types/schemas/index.js';

--- a/packages/common-types/src/types/gateway-context.ts
+++ b/packages/common-types/src/types/gateway-context.ts
@@ -1,0 +1,34 @@
+/**
+ * Gateway Context Types
+ *
+ * Cross-service contract for the Discord user context that bot-client
+ * attaches to every api-gateway HTTP request (as `X-User-Id`,
+ * `X-User-Username`, `X-User-DisplayName` headers).
+ *
+ * Consumers:
+ * - bot-client constructs `GatewayUser` from Discord interaction/message
+ *   objects via its local `toGatewayUser(DiscordUser)` helper.
+ * - api-gateway middleware reads the headers and reconstructs `GatewayUser`
+ *   for provisioning (Identity Epic Phase 5c PR B).
+ *
+ * Keeping the type in common-types means both sides agree on field names
+ * and semantics by compile-time contract, not convention.
+ */
+
+/**
+ * Discord user context carried on every bot-client → api-gateway request.
+ *
+ * - `discordId`: Discord snowflake (digits only). Safe to send raw as a
+ *   Latin-1 HTTP header value.
+ * - `username`: Discord username. MUST be URI-encoded on the wire; Node
+ *   `fetch` rejects non-Latin-1 header values synchronously.
+ * - `displayName`: `globalName ?? username`. Same encoding requirement.
+ *
+ * On the gateway side, decode `username` and `displayName` with
+ * `decodeURIComponent` before using them.
+ */
+export interface GatewayUser {
+  discordId: string;
+  username: string;
+  displayName: string;
+}

--- a/services/bot-client/src/commands/channel/activate.test.ts
+++ b/services/bot-client/src/commands/channel/activate.test.ts
@@ -12,14 +12,15 @@ import type { DeferredCommandContext } from '../../utils/commandContext/types.js
 import { handleActivate } from './activate.js';
 
 // Mock gateway client
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: vi.fn(),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: vi.fn(),
+  };
+});
 
 // Mock GatewayClient for cache invalidation
 vi.mock('../../utils/GatewayClient.js', () => ({
@@ -93,7 +94,7 @@ describe('/channel activate', () => {
           }),
         },
       },
-      user: { id: 'user-123' },
+      user: { id: 'user-123', username: 'testuser' },
       guild: guildId !== null ? { id: guildId } : null,
       member: guildId !== null ? mockMember : null,
       channel: null,

--- a/services/bot-client/src/commands/channel/activate.test.ts
+++ b/services/bot-client/src/commands/channel/activate.test.ts
@@ -14,6 +14,11 @@ import { handleActivate } from './activate.js';
 // Mock gateway client
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: vi.fn(),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock GatewayClient for cache invalidation
@@ -130,7 +135,11 @@ describe('/channel activate', () => {
     await handleActivate(context);
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/channel/activate', {
-      userId: 'user-123',
+      user: {
+        discordId: 'user-123',
+        username: 'testuser',
+        displayName: 'testuser',
+      },
       method: 'POST',
       body: {
         channelId: '123456789012345678',

--- a/services/bot-client/src/commands/channel/activate.ts
+++ b/services/bot-client/src/commands/channel/activate.ts
@@ -15,7 +15,7 @@ import {
   channelActivateOptions,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
 import { requireManageMessagesContext } from '../../utils/permissions.js';
 import { invalidateChannelSettingsCache } from '../../utils/GatewayClient.js';
 import { getChannelActivationCacheInvalidationService } from '../../services/serviceRegistry.js';
@@ -59,7 +59,7 @@ export async function handleActivate(context: DeferredCommandContext): Promise<v
 
   try {
     const result = await callGatewayApi<ActivateChannelResponse>('/user/channel/activate', {
-      userId: context.user.id,
+      user: toGatewayUser(context.user),
       method: 'POST',
       body: {
         channelId,

--- a/services/bot-client/src/commands/channel/browse.test.ts
+++ b/services/bot-client/src/commands/channel/browse.test.ts
@@ -23,14 +23,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 // Mock userGatewayClient
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Mock permissions
 const mockRequireManageMessagesContext = vi.fn().mockResolvedValue(true);
@@ -74,7 +75,7 @@ describe('handleBrowse', () => {
 
   function createMockContext(query: string | null = null, filter: string | null = null) {
     return {
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       guildId: 'guild-123',
       interaction: {
         client: {
@@ -294,7 +295,7 @@ describe('handleBrowsePagination', () => {
   function createMockButtonInteraction(customId: string) {
     return {
       customId,
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       client: {
         channels: { cache: new Map() },
         guilds: { cache: new Map() },
@@ -490,7 +491,7 @@ describe('backfillMissingGuildIds', () => {
 
   function createMockContextWithFetch(channelFetchFn: typeof mockChannelsFetch) {
     return {
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       guildId: 'guild-123',
       interaction: {
         client: {
@@ -665,7 +666,7 @@ describe('buildGuildPages (all-servers view)', () => {
 
   function createMockContext(filter: string | null = 'all') {
     return {
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       guildId: 'guild-123',
       interaction: {
         client: {

--- a/services/bot-client/src/commands/channel/browse.test.ts
+++ b/services/bot-client/src/commands/channel/browse.test.ts
@@ -25,6 +25,11 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock permissions
@@ -126,7 +131,11 @@ describe('handleBrowse', () => {
     expect(mockCallGatewayApi).toHaveBeenCalledWith(
       expect.stringContaining('/user/channel/list?guildId='),
       expect.objectContaining({
-        userId: '123456789',
+        user: {
+          discordId: '123456789',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         method: 'GET',
       })
     );
@@ -173,7 +182,11 @@ describe('handleBrowse', () => {
     expect(mockCallGatewayApi).toHaveBeenCalledWith(
       '/user/channel/list',
       expect.objectContaining({
-        userId: '123456789',
+        user: {
+          discordId: '123456789',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         method: 'GET',
       })
     );
@@ -321,7 +334,11 @@ describe('handleBrowsePagination', () => {
     expect(mockCallGatewayApi).toHaveBeenCalledWith(
       expect.stringContaining('/user/channel/list'),
       expect.objectContaining({
-        userId: '123456789',
+        user: {
+          discordId: '123456789',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         method: 'GET',
       })
     );
@@ -522,7 +539,11 @@ describe('backfillMissingGuildIds', () => {
     expect(mockCallGatewayApi).toHaveBeenCalledWith(
       '/user/channel/update-guild',
       expect.objectContaining({
-        userId: '123456789',
+        user: {
+          discordId: '123456789',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         method: 'PATCH',
         body: {
           channelId: 'channel-1',

--- a/services/bot-client/src/commands/channel/browse.ts
+++ b/services/bot-client/src/commands/channel/browse.ts
@@ -30,7 +30,7 @@ import {
   formatDateShort,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser, type GatewayUser } from '../../utils/userGatewayClient.js';
 import { requireManageMessagesContext } from '../../utils/permissions.js';
 import { createListComparator, type ListSortType } from '../../utils/listSorting.js';
 import { CHANNELS_PER_PAGE, CHANNELS_PER_PAGE_ALL_SERVERS, type GuildPage } from './listTypes.js';
@@ -351,7 +351,7 @@ function buildBrowsePage(options: BuildBrowsePageOptions): {
 async function backfillMissingGuildIds(
   activations: ChannelSettings[],
   client: Client,
-  userId: string
+  user: GatewayUser
 ): Promise<void> {
   const needsBackfill = activations.filter(a => a.guildId === null);
 
@@ -372,7 +372,7 @@ async function backfillMissingGuildIds(
       }
       if ('guild' in channel && channel.guild !== null) {
         await callGatewayApi('/user/channel/update-guild', {
-          userId,
+          user,
           method: 'PATCH',
           body: {
             channelId: activation.channelId,
@@ -417,7 +417,7 @@ export async function handleBrowse(context: DeferredCommandContext): Promise<voi
       filter === 'all' ? '/user/channel/list' : `/user/channel/list?guildId=${context.guildId}`;
 
     const result = await callGatewayApi<ListChannelSettingsResponse>(queryPath, {
-      userId: context.user.id,
+      user: toGatewayUser(context.user),
       method: 'GET',
     });
 
@@ -433,7 +433,7 @@ export async function handleBrowse(context: DeferredCommandContext): Promise<voi
     let { settings } = result.data;
 
     // Lazy backfill missing guildIds
-    await backfillMissingGuildIds(settings, interaction.client, context.user.id);
+    await backfillMissingGuildIds(settings, interaction.client, toGatewayUser(context.user));
 
     // For current server view, filter again after backfill
     if (filter === 'current' && context.guildId !== null) {
@@ -500,7 +500,7 @@ export async function handleBrowsePagination(
       filter === 'all' ? '/user/channel/list' : `/user/channel/list?guildId=${guildId}`;
 
     const result = await callGatewayApi<ListChannelSettingsResponse>(queryPath, {
-      userId,
+      user: toGatewayUser(interaction.user),
       method: 'GET',
     });
 

--- a/services/bot-client/src/commands/channel/deactivate.test.ts
+++ b/services/bot-client/src/commands/channel/deactivate.test.ts
@@ -12,14 +12,15 @@ import type { DeferredCommandContext } from '../../utils/commandContext/types.js
 import { handleDeactivate } from './deactivate.js';
 
 // Mock gateway client
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: vi.fn(),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: vi.fn(),
+  };
+});
 
 // Mock GatewayClient for cache invalidation
 vi.mock('../../utils/GatewayClient.js', () => ({
@@ -83,7 +84,7 @@ describe('/channel deactivate', () => {
 
     return {
       interaction: { editReply: mockEditReply },
-      user: { id: 'user-123' },
+      user: { id: 'user-123', username: 'testuser' },
       guild: guildId !== null ? { id: guildId } : null,
       member: guildId !== null ? mockMember : null,
       channel: null,

--- a/services/bot-client/src/commands/channel/deactivate.test.ts
+++ b/services/bot-client/src/commands/channel/deactivate.test.ts
@@ -14,6 +14,11 @@ import { handleDeactivate } from './deactivate.js';
 // Mock gateway client
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: vi.fn(),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock GatewayClient for cache invalidation
@@ -113,7 +118,11 @@ describe('/channel deactivate', () => {
     await handleDeactivate(context);
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/channel/deactivate', {
-      userId: 'user-123',
+      user: {
+        discordId: 'user-123',
+        username: 'testuser',
+        displayName: 'testuser',
+      },
       method: 'DELETE',
       body: {
         channelId: '123456789012345678',

--- a/services/bot-client/src/commands/channel/deactivate.ts
+++ b/services/bot-client/src/commands/channel/deactivate.ts
@@ -11,7 +11,7 @@
 
 import { createLogger, type DeactivateChannelResponse } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
 import { requireManageMessagesContext } from '../../utils/permissions.js';
 import { invalidateChannelSettingsCache } from '../../utils/GatewayClient.js';
 import { getChannelActivationCacheInvalidationService } from '../../services/serviceRegistry.js';
@@ -33,7 +33,7 @@ export async function handleDeactivate(context: DeferredCommandContext): Promise
 
   try {
     const result = await callGatewayApi<DeactivateChannelResponse>('/user/channel/deactivate', {
-      userId: context.user.id,
+      user: toGatewayUser(context.user),
       method: 'DELETE',
       body: {
         channelId,

--- a/services/bot-client/src/commands/channel/settings.test.ts
+++ b/services/bot-client/src/commands/channel/settings.test.ts
@@ -37,6 +37,11 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock GatewayClient - use vi.hoisted() for proper mock hoisting
@@ -387,7 +392,11 @@ describe('Channel Settings Dashboard', () => {
 
       mockSessionManager.get.mockReturnValue({
         data: {
-          userId: 'user-456',
+          user: {
+            discordId: 'user-456',
+            username: 'testuser',
+            displayName: 'testuser',
+          },
           entityId: 'channel-123',
           data: {
             maxMessages: { localValue: null, effectiveValue: 50, source: 'admin' },
@@ -426,7 +435,11 @@ describe('Channel Settings Dashboard', () => {
 
     const createSessionWithSetting = (settingId: string) => ({
       data: {
-        userId: 'user-456',
+        user: {
+          discordId: 'user-456',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         entityId: 'channel-123',
         data: {
           maxMessages: { localValue: null, effectiveValue: 50, source: 'admin' },

--- a/services/bot-client/src/commands/channel/settings.test.ts
+++ b/services/bot-client/src/commands/channel/settings.test.ts
@@ -35,14 +35,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 });
 
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Mock GatewayClient - use vi.hoisted() for proper mock hoisting
 const { mockGetChannelSettings, mockInvalidateChannelSettingsCache } = vi.hoisted(() => ({

--- a/services/bot-client/src/commands/channel/settings.ts
+++ b/services/bot-client/src/commands/channel/settings.ts
@@ -22,7 +22,7 @@ import {
   type ResolvedConfigOverrides,
   type ConfigOverrides,
 } from '@tzurot/common-types';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser, type GatewayUser } from '../../utils/userGatewayClient.js';
 import { GatewayClient, invalidateChannelSettingsCache } from '../../utils/GatewayClient.js';
 import {
   type SettingsDashboardConfig,
@@ -95,7 +95,11 @@ export async function handleChannelSettings(context: DeferredCommandContext): Pr
     const personalityId = channelSettings?.settings?.activatedPersonalityId ?? undefined;
 
     // Fetch resolved config with channel tier
-    const data = await fetchAndConvertSettingsData(userId, personalityId, channelId);
+    const data = await fetchAndConvertSettingsData(
+      toGatewayUser(context.user),
+      personalityId,
+      channelId
+    );
 
     // When no personality is activated, resolve-defaults is used as fallback,
     // so admin and user-default overrides are visible. Only personality-tier is missing.
@@ -165,7 +169,7 @@ export const isChannelSettingsInteraction = channelSettingsHandlers.isInteractio
  * admin → user-default) so admin overrides are still visible.
  */
 async function fetchAndConvertSettingsData(
-  userId: string,
+  user: GatewayUser,
   personalityId: string | undefined,
   channelId: string
 ): Promise<SettingsData> {
@@ -175,18 +179,18 @@ async function fetchAndConvertSettingsData(
     personalityId !== undefined
       ? callGatewayApi<ResolvedConfigOverrides>(
           `/user/config-overrides/resolve/${encodeURIComponent(personalityId)}?channelId=${encodeURIComponent(channelId)}`,
-          { method: 'GET', userId, timeout: GATEWAY_TIMEOUTS.DEFERRED }
+          { method: 'GET', user, timeout: GATEWAY_TIMEOUTS.DEFERRED }
         )
       : callGatewayApi<ResolveDefaultsResponse>('/user/config-overrides/resolve-defaults', {
           method: 'GET',
-          userId,
+          user,
           timeout: GATEWAY_TIMEOUTS.DEFERRED,
         });
 
   const [channelOverridesResult, resolvedResult] = await Promise.all([
     callGatewayApi<{ configOverrides: Record<string, unknown> | null }>(
       `/user/channel/${encodeURIComponent(channelId)}/config-overrides`,
-      { method: 'GET', userId, timeout: GATEWAY_TIMEOUTS.DEFERRED }
+      { method: 'GET', user, timeout: GATEWAY_TIMEOUTS.DEFERRED }
     ),
     resolvePromise,
   ]);
@@ -239,7 +243,12 @@ async function handleSettingUpdate(
     // Send update to channel config-overrides endpoint
     const result = await callGatewayApi(
       `/user/channel/${encodeURIComponent(channelId)}/config-overrides`,
-      { method: 'PATCH', body, userId, timeout: GATEWAY_TIMEOUTS.DEFERRED }
+      {
+        method: 'PATCH',
+        body,
+        user: toGatewayUser(interaction.user),
+        timeout: GATEWAY_TIMEOUTS.DEFERRED,
+      }
     );
 
     if (!result.ok) {
@@ -257,7 +266,11 @@ async function handleSettingUpdate(
     const gatewayClient = new GatewayClient();
     const channelSettings = await gatewayClient.getChannelSettings(channelId);
     const personalityId = channelSettings?.settings?.activatedPersonalityId ?? undefined;
-    const newData = await fetchAndConvertSettingsData(userId, personalityId, channelId);
+    const newData = await fetchAndConvertSettingsData(
+      toGatewayUser(interaction.user),
+      personalityId,
+      channelId
+    );
 
     logger.info({ settingId, newValue, channelId, userId }, '[Channel Settings] Setting updated');
 

--- a/services/bot-client/src/commands/character/api.test.ts
+++ b/services/bot-client/src/commands/character/api.test.ts
@@ -22,14 +22,15 @@ import * as userGatewayClient from '../../utils/userGatewayClient.js';
 import type { EnvConfig } from '@tzurot/common-types';
 
 // Mock the gateway client
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: vi.fn(),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: vi.fn(),
+  };
+});
 
 describe('Character API Client', () => {
   const mockConfig = {

--- a/services/bot-client/src/commands/character/api.test.ts
+++ b/services/bot-client/src/commands/character/api.test.ts
@@ -24,6 +24,11 @@ import type { EnvConfig } from '@tzurot/common-types';
 // Mock the gateway client
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: vi.fn(),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 describe('Character API Client', () => {
@@ -31,7 +36,7 @@ describe('Character API Client', () => {
     GATEWAY_URL: 'http://localhost:3000',
   } as EnvConfig;
 
-  const mockUserId = 'discord-user-123';
+  const mockUser = { discordId: 'discord-user-123', username: 'testuser', displayName: 'testuser' };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -60,11 +65,11 @@ describe('Character API Client', () => {
 
       vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue(mockResponse);
 
-      const result = await fetchCharacter('test-character', mockConfig, mockUserId);
+      const result = await fetchCharacter('test-character', mockConfig, mockUser);
 
       expect(userGatewayClient.callGatewayApi).toHaveBeenCalledWith(
         '/user/personality/test-character',
-        { userId: mockUserId }
+        { user: mockUser }
       );
 
       expect(result).not.toBeNull();
@@ -89,7 +94,7 @@ describe('Character API Client', () => {
 
       vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue(mockResponse);
 
-      const result = await fetchCharacter('other-character', mockConfig, mockUserId);
+      const result = await fetchCharacter('other-character', mockConfig, mockUser);
 
       expect(result!.canEdit).toBe(false);
     });
@@ -101,7 +106,7 @@ describe('Character API Client', () => {
         error: 'Not found',
       });
 
-      const result = await fetchCharacter('nonexistent', mockConfig, mockUserId);
+      const result = await fetchCharacter('nonexistent', mockConfig, mockUser);
 
       expect(result).toBeNull();
     });
@@ -113,7 +118,7 @@ describe('Character API Client', () => {
         error: 'Forbidden',
       });
 
-      const result = await fetchCharacter('private-char', mockConfig, mockUserId);
+      const result = await fetchCharacter('private-char', mockConfig, mockUser);
 
       expect(result).toBeNull();
     });
@@ -125,7 +130,7 @@ describe('Character API Client', () => {
         error: 'Internal server error',
       });
 
-      await expect(fetchCharacter('test', mockConfig, mockUserId)).rejects.toThrow(
+      await expect(fetchCharacter('test', mockConfig, mockUser)).rejects.toThrow(
         'Failed to fetch character: 500'
       );
     });
@@ -163,7 +168,7 @@ describe('Character API Client', () => {
 
       vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue(mockResponse);
 
-      const result = await fetchAllCharacters(mockUserId, mockConfig);
+      const result = await fetchAllCharacters(mockUser, mockConfig);
 
       expect(result.owned).toHaveLength(1);
       expect(result.owned[0].slug).toBe('my-char');
@@ -179,7 +184,7 @@ describe('Character API Client', () => {
         error: 'Server error',
       });
 
-      await expect(fetchAllCharacters(mockUserId, mockConfig)).rejects.toThrow(
+      await expect(fetchAllCharacters(mockUser, mockConfig)).rejects.toThrow(
         'Failed to fetch characters: 500'
       );
     });
@@ -217,7 +222,7 @@ describe('Character API Client', () => {
 
       vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue(mockResponse);
 
-      const result = await fetchUserCharacters(mockUserId, mockConfig);
+      const result = await fetchUserCharacters(mockUser, mockConfig);
 
       expect(result).toHaveLength(1);
       expect(result[0].slug).toBe('my-char');
@@ -256,7 +261,7 @@ describe('Character API Client', () => {
 
       vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue(mockResponse);
 
-      const result = await fetchPublicCharacters(mockUserId, mockConfig);
+      const result = await fetchPublicCharacters(mockUser, mockConfig);
 
       expect(result).toHaveLength(1);
       expect(result[0].slug).toBe('other-char');
@@ -289,13 +294,13 @@ describe('Character API Client', () => {
           characterInfo: 'Info',
           personalityTraits: 'Traits',
         },
-        mockUserId,
+        mockUser,
         mockConfig
       );
 
       expect(userGatewayClient.callGatewayApi).toHaveBeenCalledWith('/user/personality', {
         method: 'POST',
-        userId: mockUserId,
+        user: mockUser,
         body: {
           name: 'New Character',
           slug: 'new-character',
@@ -322,7 +327,7 @@ describe('Character API Client', () => {
             characterInfo: 'Info',
             personalityTraits: 'Traits',
           },
-          mockUserId,
+          mockUser,
           mockConfig
         )
       ).rejects.toThrow('Failed to create character: 409 - Slug already exists');
@@ -348,13 +353,13 @@ describe('Character API Client', () => {
       const result = await updateCharacter(
         'test-char',
         { name: 'Updated Name' },
-        mockUserId,
+        mockUser,
         mockConfig
       );
 
       expect(userGatewayClient.callGatewayApi).toHaveBeenCalledWith('/user/personality/test-char', {
         method: 'PUT',
-        userId: mockUserId,
+        user: mockUser,
         body: { name: 'Updated Name' },
       });
 
@@ -369,7 +374,7 @@ describe('Character API Client', () => {
       });
 
       await expect(
-        updateCharacter('test-char', { name: 'New Name' }, mockUserId, mockConfig)
+        updateCharacter('test-char', { name: 'New Name' }, mockUser, mockConfig)
       ).rejects.toThrow('Failed to update character: 403 - Not authorized');
     });
   });
@@ -390,13 +395,13 @@ describe('Character API Client', () => {
 
       vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue(mockResponse);
 
-      const result = await toggleVisibility('test-char', true, mockUserId, mockConfig);
+      const result = await toggleVisibility('test-char', true, mockUser, mockConfig);
 
       expect(userGatewayClient.callGatewayApi).toHaveBeenCalledWith(
         '/user/personality/test-char/visibility',
         {
           method: 'PATCH',
-          userId: mockUserId,
+          user: mockUser,
           body: { isPublic: true },
         }
       );

--- a/services/bot-client/src/commands/character/api.ts
+++ b/services/bot-client/src/commands/character/api.ts
@@ -7,7 +7,7 @@
 
 import type { ChatInputCommandInteraction } from 'discord.js';
 import type { EnvConfig } from '@tzurot/common-types';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, type GatewayUser } from '../../utils/userGatewayClient.js';
 import type { CharacterData } from './config.js';
 
 /**
@@ -53,10 +53,10 @@ interface PersonalityListResponse {
 export async function fetchCharacter(
   slugOrId: string,
   _config: EnvConfig,
-  userId: string
+  user: GatewayUser
 ): Promise<FetchedCharacter | null> {
   const result = await callGatewayApi<PersonalityResponse>(`/user/personality/${slugOrId}`, {
-    userId,
+    user,
   });
 
   if (!result.ok) {
@@ -78,11 +78,11 @@ export async function fetchCharacter(
  * Returns two arrays: user's owned characters and public characters from others
  */
 export async function fetchAllCharacters(
-  userId: string,
+  user: GatewayUser,
   _config: EnvConfig
 ): Promise<{ owned: CharacterData[]; publicOthers: CharacterData[] }> {
   const result = await callGatewayApi<PersonalityListResponse>('/user/personality', {
-    userId,
+    user,
   });
 
   if (!result.ok) {
@@ -142,10 +142,10 @@ export async function fetchAllCharacters(
  * Fetch characters owned by user (wrapper for fetchAllCharacters)
  */
 export async function fetchUserCharacters(
-  userId: string,
+  user: GatewayUser,
   config: EnvConfig
 ): Promise<CharacterData[]> {
-  const { owned } = await fetchAllCharacters(userId, config);
+  const { owned } = await fetchAllCharacters(user, config);
   return owned;
 }
 
@@ -153,10 +153,10 @@ export async function fetchUserCharacters(
  * Fetch public characters from others (wrapper for fetchAllCharacters)
  */
 export async function fetchPublicCharacters(
-  userId: string,
+  user: GatewayUser,
   config: EnvConfig
 ): Promise<CharacterData[]> {
-  const { publicOthers } = await fetchAllCharacters(userId, config);
+  const { publicOthers } = await fetchAllCharacters(user, config);
   return publicOthers;
 }
 
@@ -193,14 +193,14 @@ export async function createCharacter(
     characterInfo: string;
     personalityTraits: string;
   },
-  userId: string,
+  user: GatewayUser,
   _config: EnvConfig
 ): Promise<CharacterData> {
   const result = await callGatewayApi<{ success: boolean; personality: CharacterData }>(
     '/user/personality',
     {
       method: 'POST',
-      userId,
+      user,
       body: data,
     }
   );
@@ -218,14 +218,14 @@ export async function createCharacter(
 export async function updateCharacter(
   slug: string,
   data: Partial<CharacterData>,
-  userId: string,
+  user: GatewayUser,
   _config: EnvConfig
 ): Promise<CharacterData> {
   const result = await callGatewayApi<{ success: boolean; personality: CharacterData }>(
     `/user/personality/${slug}`,
     {
       method: 'PUT',
-      userId,
+      user,
       body: data,
     }
   );
@@ -243,7 +243,7 @@ export async function updateCharacter(
 export async function toggleVisibility(
   slug: string,
   isPublic: boolean,
-  userId: string,
+  user: GatewayUser,
   _config: EnvConfig
 ): Promise<{ id: string; slug: string; isPublic: boolean }> {
   const result = await callGatewayApi<{
@@ -251,7 +251,7 @@ export async function toggleVisibility(
     personality: { id: string; slug: string; isPublic: boolean };
   }>(`/user/personality/${slug}/visibility`, {
     method: 'PATCH',
-    userId,
+    user,
     body: { isPublic },
   });
 

--- a/services/bot-client/src/commands/character/avatar.test.ts
+++ b/services/bot-client/src/commands/character/avatar.test.ts
@@ -230,7 +230,7 @@ describe('Character Avatar Handler', () => {
       expect(api.updateCharacter).toHaveBeenCalledWith(
         'my-char',
         { avatarData: expect.any(String) },
-        'user-123',
+        expect.objectContaining({ discordId: 'user-123' }),
         mockConfig
       );
       expect(mockContext.editReply).toHaveBeenCalledWith(expect.stringContaining('Avatar updated'));

--- a/services/bot-client/src/commands/character/avatar.ts
+++ b/services/bot-client/src/commands/character/avatar.ts
@@ -7,6 +7,7 @@
 
 import { createLogger, type EnvConfig, characterAvatarOptions } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
+import { toGatewayUser } from '../../utils/userGatewayClient.js';
 import { fetchCharacter, updateCharacter } from './api.js';
 import {
   VALID_IMAGE_TYPES,
@@ -51,7 +52,7 @@ export async function handleAvatar(
 
   try {
     // Check if user can edit this character
-    const character = await fetchCharacter(slug, config, userId);
+    const character = await fetchCharacter(slug, config, toGatewayUser(context.user));
     if (!character) {
       await context.editReply(`❌ Character \`${slug}\` not found or not accessible.`);
       return;
@@ -102,7 +103,7 @@ export async function handleAvatar(
     const base64Image = result.buffer.toString('base64');
 
     // Update character with new avatar
-    await updateCharacter(slug, { avatarData: base64Image }, userId, config);
+    await updateCharacter(slug, { avatarData: base64Image }, toGatewayUser(context.user), config);
 
     await context.editReply(
       `✅ Avatar updated for **${character.displayName ?? character.name}**!`

--- a/services/bot-client/src/commands/character/browse.test.ts
+++ b/services/bot-client/src/commands/character/browse.test.ts
@@ -134,8 +134,14 @@ describe('handleBrowse', () => {
     const context = createMockContext();
     await handleBrowse(context, mockConfig);
 
-    expect(api.fetchUserCharacters).toHaveBeenCalledWith('123456789', mockConfig);
-    expect(api.fetchPublicCharacters).toHaveBeenCalledWith('123456789', mockConfig);
+    expect(api.fetchUserCharacters).toHaveBeenCalledWith(
+      expect.objectContaining({ discordId: '123456789' }),
+      mockConfig
+    );
+    expect(api.fetchPublicCharacters).toHaveBeenCalledWith(
+      expect.objectContaining({ discordId: '123456789' }),
+      mockConfig
+    );
     expect(mockEditReply).toHaveBeenCalledWith({
       embeds: [
         expect.objectContaining({
@@ -565,8 +571,14 @@ describe('handleBrowsePagination', () => {
     const mockInteraction = createMockButtonInteraction('character::browse::1::all::date::');
     await handleBrowsePagination(mockInteraction, mockConfig);
 
-    expect(api.fetchUserCharacters).toHaveBeenCalledWith('123456789', mockConfig);
-    expect(api.fetchPublicCharacters).toHaveBeenCalledWith('123456789', mockConfig);
+    expect(api.fetchUserCharacters).toHaveBeenCalledWith(
+      expect.objectContaining({ discordId: '123456789' }),
+      mockConfig
+    );
+    expect(api.fetchPublicCharacters).toHaveBeenCalledWith(
+      expect.objectContaining({ discordId: '123456789' }),
+      mockConfig
+    );
   });
 
   it('should handle errors gracefully without crashing', async () => {
@@ -825,7 +837,11 @@ describe('handleBrowseSelect', () => {
     await handleBrowseSelect(interaction, mockConfig);
 
     expect(interaction.deferUpdate).toHaveBeenCalled();
-    expect(api.fetchCharacter).toHaveBeenCalledWith('luna', mockConfig, '123456789');
+    expect(api.fetchCharacter).toHaveBeenCalledWith(
+      'luna',
+      mockConfig,
+      expect.objectContaining({ discordId: '123456789' })
+    );
   });
 
   it('should open dashboard when character is found', async () => {

--- a/services/bot-client/src/commands/character/browse.ts
+++ b/services/bot-client/src/commands/character/browse.ts
@@ -18,6 +18,7 @@ import {
   characterBrowseOptions,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
+import { toGatewayUser, type GatewayUser } from '../../utils/userGatewayClient.js';
 import {
   fetchUserCharacters,
   fetchPublicCharacters,
@@ -232,6 +233,7 @@ export async function handleBrowse(
   config: EnvConfig
 ): Promise<void> {
   const userId = context.user.id;
+  const user = toGatewayUser(context.user);
   const options = characterBrowseOptions(context.interaction);
   const query = options.query();
   const filter = (options.filter() ?? 'all') as CharacterBrowseFilter;
@@ -239,8 +241,8 @@ export async function handleBrowse(
   try {
     // Fetch user's own characters and all public characters
     const [ownCharacters, publicCharacters] = await Promise.all([
-      fetchUserCharacters(userId, config),
-      fetchPublicCharacters(userId, config),
+      fetchUserCharacters(user, config),
+      fetchPublicCharacters(user, config),
     ]);
 
     // Apply filter and query
@@ -286,7 +288,7 @@ export async function handleBrowse(
  * Reusable for pagination and back-from-dashboard navigation
  */
 export async function buildBrowseResponse(
-  userId: string,
+  user: GatewayUser,
   client: ButtonInteraction['client'],
   config: EnvConfig,
   browseContext: {
@@ -300,12 +302,18 @@ export async function buildBrowseResponse(
 
   // Re-fetch character data
   const [ownCharacters, publicCharacters] = await Promise.all([
-    fetchUserCharacters(userId, config),
-    fetchPublicCharacters(userId, config),
+    fetchUserCharacters(user, config),
+    fetchPublicCharacters(user, config),
   ]);
 
   // Apply filter and query
-  const { own, others } = filterCharacters(ownCharacters, publicCharacters, userId, filter, query);
+  const { own, others } = filterCharacters(
+    ownCharacters,
+    publicCharacters,
+    user.discordId,
+    filter,
+    query
+  );
 
   // Fetch creator usernames
   const creatorIds = [...new Set(others.map(c => c.ownerId).filter(Boolean))] as string[];
@@ -344,7 +352,7 @@ export async function handleBrowsePagination(
 
   try {
     const { embed, components } = await buildBrowseResponse(
-      interaction.user.id,
+      toGatewayUser(interaction.user),
       interaction.client,
       config,
       parsed
@@ -377,7 +385,7 @@ export async function handleBrowseSelect(
 
   try {
     // Fetch the character with full data
-    const character = await fetchCharacter(slug, config, userId);
+    const character = await fetchCharacter(slug, config, toGatewayUser(interaction.user));
 
     if (!character) {
       await interaction.editReply({

--- a/services/bot-client/src/commands/character/chat.test.ts
+++ b/services/bot-client/src/commands/character/chat.test.ts
@@ -216,7 +216,11 @@ describe('Character Chat Handler', () => {
     } = {}
   ) => ({
     context: {
-      userId: 'user-123',
+      user: {
+        discordId: 'user-123',
+        username: 'testuser',
+        displayName: 'testuser',
+      },
       userInternalId: 'internal-user-123',
       userName: 'TestUser',
       discordUsername: 'TestUser',
@@ -232,7 +236,11 @@ describe('Character Chat Handler', () => {
         channel: { id: 'channel-123', name: 'test-channel', type: 'text' },
       },
     },
-    userId: 'internal-user-123',
+    user: {
+      discordId: 'internal-user-123',
+      username: 'testuser',
+      displayName: 'testuser',
+    },
     personaId: 'persona-123',
     personaName: overrides.personaName ?? null,
     messageContent: 'Hello!',
@@ -370,7 +378,11 @@ describe('Character Chat Handler', () => {
         personality,
         expect.objectContaining({
           messageContent: 'Hello!',
-          userId: 'user-123',
+          user: {
+            discordId: 'user-123',
+            username: 'testuser',
+            displayName: 'testuser',
+          },
           userName: 'TestUser',
         })
       );

--- a/services/bot-client/src/commands/character/create.test.ts
+++ b/services/bot-client/src/commands/character/create.test.ts
@@ -270,7 +270,7 @@ describe('Character Create', () => {
           personalityTraits: 'Personality traits',
           isPublic: false,
         },
-        'user-123',
+        expect.objectContaining({ discordId: 'user-123' }),
         mockConfig
       );
     });

--- a/services/bot-client/src/commands/character/create.ts
+++ b/services/bot-client/src/commands/character/create.ts
@@ -36,6 +36,7 @@ import {
   characterSeedFields,
   buildCharacterDashboardOptions,
 } from './config.js';
+import { toGatewayUser } from '../../utils/userGatewayClient.js';
 import { createCharacter } from './api.js';
 
 const logger = createLogger('character-create');
@@ -107,7 +108,7 @@ export async function handleSeedModalSubmit(
         personalityTraits: values.personalityTraits,
         isPublic: false, // Default to private
       },
-      interaction.user.id,
+      toGatewayUser(interaction.user),
       config
     );
 

--- a/services/bot-client/src/commands/character/dashboard.test.ts
+++ b/services/bot-client/src/commands/character/dashboard.test.ts
@@ -34,6 +34,11 @@ vi.mock('./api.js', () => ({
 // Mock userGatewayClient (transitive dep via dashboardDeleteHandlers)
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: vi.fn(),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 vi.mock('./create.js', () => ({
@@ -337,7 +342,12 @@ describe('Character Dashboard', () => {
 
       await handleSelectMenu(mockInteraction);
 
-      expect(api.toggleVisibility).toHaveBeenCalledWith('test-char', true, 'user-123', mockConfig);
+      expect(api.toggleVisibility).toHaveBeenCalledWith(
+        'test-char',
+        true,
+        expect.objectContaining({ discordId: 'user-123' }),
+        mockConfig
+      );
     });
 
     it('should handle action-voice selection with prompt', async () => {
@@ -436,7 +446,7 @@ describe('Character Dashboard', () => {
       expect(api.updateCharacter).toHaveBeenCalledWith(
         'test-char',
         { voiceEnabled: false },
-        'user-123',
+        expect.objectContaining({ discordId: 'user-123' }),
         expect.any(Object)
       );
       // Dashboard should be rebuilt with updated state
@@ -578,7 +588,11 @@ describe('Character Dashboard', () => {
       await handleButton(mockInteraction);
 
       expect(mockInteraction.deferUpdate).toHaveBeenCalled();
-      expect(api.fetchCharacter).toHaveBeenCalledWith('test-char', expect.any(Object), 'user-123');
+      expect(api.fetchCharacter).toHaveBeenCalledWith(
+        'test-char',
+        expect.any(Object),
+        expect.objectContaining({ discordId: 'user-123' })
+      );
       expect(mockInteraction.editReply).toHaveBeenCalled();
     });
 

--- a/services/bot-client/src/commands/character/dashboard.test.ts
+++ b/services/bot-client/src/commands/character/dashboard.test.ts
@@ -32,14 +32,15 @@ vi.mock('./api.js', () => ({
 }));
 
 // Mock userGatewayClient (transitive dep via dashboardDeleteHandlers)
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: vi.fn(),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: vi.fn(),
+  };
+});
 
 vi.mock('./create.js', () => ({
   handleSeedModalSubmit: vi.fn(),

--- a/services/bot-client/src/commands/character/dashboard.ts
+++ b/services/bot-client/src/commands/character/dashboard.ts
@@ -30,6 +30,7 @@ import {
   buildCharacterDashboardOptions,
   type CharacterSessionData,
 } from './config.js';
+import { toGatewayUser } from '../../utils/userGatewayClient.js';
 import { updateCharacter } from './api.js';
 import { handleAction } from './dashboardActions.js';
 import { handleSeedModalSubmit } from './create.js';
@@ -138,7 +139,12 @@ async function handleSectionModalSubmit(
 
   try {
     // Update character via API (entityId is the slug)
-    const updated = await updateCharacter(entityId, extracted.merged, interaction.user.id, config);
+    const updated = await updateCharacter(
+      entityId,
+      extracted.merged,
+      toGatewayUser(interaction.user),
+      config
+    );
 
     // Build session data (preserve _isAdmin flag and browseContext)
     const sessionData: CharacterSessionData = {

--- a/services/bot-client/src/commands/character/dashboardActions.test.ts
+++ b/services/bot-client/src/commands/character/dashboardActions.test.ts
@@ -115,7 +115,12 @@ describe('Dashboard Actions', () => {
       await handleAction(mockInteraction, 'test-char', 'visibility', mockConfig);
 
       expect(mockInteraction.deferUpdate).toHaveBeenCalled();
-      expect(api.toggleVisibility).toHaveBeenCalledWith('test-char', true, 'user-123', mockConfig);
+      expect(api.toggleVisibility).toHaveBeenCalledWith(
+        'test-char',
+        true,
+        expect.objectContaining({ discordId: 'user-123' }),
+        mockConfig
+      );
       expect(mockInteraction.editReply).toHaveBeenCalled();
     });
 
@@ -182,7 +187,7 @@ describe('Dashboard Actions', () => {
       expect(api.updateCharacter).toHaveBeenCalledWith(
         'test-char',
         { voiceEnabled: false },
-        'user-123',
+        expect.objectContaining({ discordId: 'user-123' }),
         expect.any(Object)
       );
       expect(mockInteraction.editReply).toHaveBeenCalled();

--- a/services/bot-client/src/commands/character/dashboardActions.ts
+++ b/services/bot-client/src/commands/character/dashboardActions.ts
@@ -24,6 +24,7 @@ import {
   type CharacterData,
   type CharacterSessionData,
 } from './config.js';
+import { toGatewayUser } from '../../utils/userGatewayClient.js';
 import { fetchCharacter, updateCharacter, toggleVisibility } from './api.js';
 
 const logger = createLogger('character-dashboard-actions');
@@ -88,7 +89,7 @@ export async function handleAction(
     // the general update endpoint, since visibility changes may have additional side effects.
     await interaction.deferUpdate();
 
-    const character = await fetchCharacter(entityId, config, interaction.user.id);
+    const character = await fetchCharacter(entityId, config, toGatewayUser(interaction.user));
     if (!character) {
       return;
     }
@@ -96,7 +97,7 @@ export async function handleAction(
     const result = await toggleVisibility(
       entityId,
       !character.isPublic,
-      interaction.user.id,
+      toGatewayUser(interaction.user),
       config
     );
 
@@ -139,7 +140,7 @@ export async function handleAction(
     // just click again if the state looks wrong.
     await interaction.deferUpdate();
 
-    const character = await fetchCharacter(entityId, config, interaction.user.id);
+    const character = await fetchCharacter(entityId, config, toGatewayUser(interaction.user));
     if (!character) {
       return;
     }
@@ -156,7 +157,7 @@ export async function handleAction(
     const updated = await updateCharacter(
       entityId,
       { voiceEnabled: newVoiceEnabled },
-      interaction.user.id,
+      toGatewayUser(interaction.user),
       config
     );
 

--- a/services/bot-client/src/commands/character/dashboardButtons.test.ts
+++ b/services/bot-client/src/commands/character/dashboardButtons.test.ts
@@ -243,7 +243,7 @@ describe('Character Dashboard Buttons', () => {
 
       expect(mockInteraction.deferUpdate).toHaveBeenCalled();
       expect(mockBuildBrowseResponse).toHaveBeenCalledWith(
-        'user-123',
+        expect.objectContaining({ discordId: 'user-123' }),
         expect.anything(),
         expect.anything(),
         {
@@ -329,7 +329,7 @@ describe('Character Dashboard Buttons', () => {
       await handleBackButton(mockInteraction, 'test-character');
 
       expect(mockBuildBrowseResponse).toHaveBeenCalledWith(
-        'user-123',
+        expect.objectContaining({ discordId: 'user-123' }),
         expect.anything(),
         expect.anything(),
         {
@@ -361,7 +361,7 @@ describe('Character Dashboard Buttons', () => {
       await handleBackButton(mockInteraction, 'test-character');
 
       expect(mockBuildBrowseResponse).toHaveBeenCalledWith(
-        'user-123',
+        expect.objectContaining({ discordId: 'user-123' }),
         expect.anything(),
         expect.anything(),
         expect.objectContaining({

--- a/services/bot-client/src/commands/character/dashboardButtons.ts
+++ b/services/bot-client/src/commands/character/dashboardButtons.ts
@@ -24,6 +24,7 @@ import {
   type CharacterBrowseFilter,
   type CharacterBrowseSortType,
 } from './config.js';
+import { toGatewayUser } from '../../utils/userGatewayClient.js';
 import { fetchCharacter } from './api.js';
 import { buildBrowseResponse } from './browse.js';
 
@@ -63,7 +64,7 @@ export async function handleBackButton(
 
   try {
     const { embed, components } = await buildBrowseResponse(
-      interaction.user.id,
+      toGatewayUser(interaction.user),
       interaction.client,
       config,
       {
@@ -112,7 +113,7 @@ export async function handleRefreshButton(
   );
   const existingBrowseContext = existingSession?.data.browseContext;
 
-  const character = await fetchCharacter(entityId, config, interaction.user.id);
+  const character = await fetchCharacter(entityId, config, toGatewayUser(interaction.user));
   if (!character) {
     await interaction.editReply({
       content: DASHBOARD_MESSAGES.NOT_FOUND('Character'),

--- a/services/bot-client/src/commands/character/dashboardDeleteHandlers.test.ts
+++ b/services/bot-client/src/commands/character/dashboardDeleteHandlers.test.ts
@@ -15,14 +15,15 @@ vi.mock('./api.js', () => ({
 }));
 
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 vi.mock('../../utils/dashboard/deleteConfirmation.js', () => ({
   buildDeleteConfirmation: vi.fn().mockReturnValue({
@@ -80,7 +81,7 @@ import { handleDeleteAction, handleDeleteButton } from './dashboardDeleteHandler
 function createMockButtonInteraction(overrides?: Partial<ButtonInteraction>): ButtonInteraction {
   return {
     customId: 'character::delete::test-char',
-    user: { id: 'user-123' },
+    user: { id: 'user-123', username: 'testuser' },
     message: { id: 'msg-123' },
     channelId: 'channel-123',
     reply: vi.fn(),

--- a/services/bot-client/src/commands/character/dashboardDeleteHandlers.test.ts
+++ b/services/bot-client/src/commands/character/dashboardDeleteHandlers.test.ts
@@ -17,6 +17,11 @@ vi.mock('./api.js', () => ({
 const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 vi.mock('../../utils/dashboard/deleteConfirmation.js', () => ({
@@ -179,7 +184,11 @@ describe('dashboardDeleteHandlers', () => {
       });
       expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/personality/test-char', {
         method: 'DELETE',
-        userId: 'user-123',
+        user: {
+          discordId: 'user-123',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
       });
       expect(interaction.editReply).toHaveBeenCalledWith({
         content: expect.stringContaining('deleted'),

--- a/services/bot-client/src/commands/character/dashboardDeleteHandlers.ts
+++ b/services/bot-client/src/commands/character/dashboardDeleteHandlers.ts
@@ -17,7 +17,7 @@ import { buildDeleteConfirmation } from '../../utils/dashboard/deleteConfirmatio
 import { DASHBOARD_MESSAGES } from '../../utils/dashboard/messages.js';
 import { CharacterCustomIds } from '../../utils/customIds.js';
 import { fetchCharacter } from './api.js';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
 
 const logger = createLogger('character-dashboard');
 
@@ -30,7 +30,7 @@ export async function handleDeleteAction(
   config: EnvConfig
 ): Promise<void> {
   // Re-fetch to verify current state and permissions
-  const character = await fetchCharacter(slug, config, interaction.user.id);
+  const character = await fetchCharacter(slug, config, toGatewayUser(interaction.user));
   if (!character) {
     await interaction.reply({
       content: DASHBOARD_MESSAGES.NOT_FOUND('Character'),
@@ -100,7 +100,7 @@ export async function handleDeleteButton(
   // Call the DELETE API
   const result = await callGatewayApi<unknown>(`/user/personality/${slug}`, {
     method: 'DELETE',
-    userId: interaction.user.id,
+    user: toGatewayUser(interaction.user),
   });
 
   if (!result.ok) {

--- a/services/bot-client/src/commands/character/edit.ts
+++ b/services/bot-client/src/commands/character/edit.ts
@@ -21,6 +21,7 @@ import {
   buildCharacterDashboardOptions,
   type CharacterSessionData,
 } from './config.js';
+import { toGatewayUser } from '../../utils/userGatewayClient.js';
 import { fetchCharacter } from './api.js';
 
 const logger = createLogger('character-edit');
@@ -38,7 +39,7 @@ export async function handleEdit(
 
   try {
     // Fetch character data from API
-    const character = await fetchCharacter(slug, config, userId);
+    const character = await fetchCharacter(slug, config, toGatewayUser(context.user));
     if (!character) {
       await context.editReply({ content: `❌ Character \`${slug}\` not found or not accessible.` });
       return;

--- a/services/bot-client/src/commands/character/export.test.ts
+++ b/services/bot-client/src/commands/character/export.test.ts
@@ -17,6 +17,11 @@ import { AttachmentBuilder } from 'discord.js';
 // Mock dependencies
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: vi.fn(),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 vi.mock('@tzurot/common-types', async importOriginal => {
@@ -319,7 +324,7 @@ describe('Character Export', () => {
 
       expect(userGatewayClient.callGatewayApi).toHaveBeenCalledWith(
         '/user/personality/test-character',
-        { userId: 'user-123' }
+        { user: { discordId: 'user-123', username: 'testuser', displayName: 'testuser' } }
       );
     });
 

--- a/services/bot-client/src/commands/character/export.test.ts
+++ b/services/bot-client/src/commands/character/export.test.ts
@@ -15,14 +15,15 @@ import type { EnvConfig } from '@tzurot/common-types';
 import { AttachmentBuilder } from 'discord.js';
 
 // Mock dependencies
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: vi.fn(),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: vi.fn(),
+  };
+});
 
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal();
@@ -49,7 +50,7 @@ describe('Character Export', () => {
 
   const createMockContext = () =>
     ({
-      user: { id: 'user-123' },
+      user: { id: 'user-123', username: 'testuser' },
       interaction: {
         options: {
           getString: vi.fn().mockReturnValue('test-character'),

--- a/services/bot-client/src/commands/character/export.ts
+++ b/services/bot-client/src/commands/character/export.ts
@@ -13,7 +13,7 @@ import {
   characterExportOptions,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
 import type { CharacterData } from './config.js';
 
 const logger = createLogger('character-export');
@@ -132,7 +132,7 @@ export async function handleExport(
   try {
     // Fetch character data
     const result = await callGatewayApi<PersonalityResponse>(`/user/personality/${slug}`, {
-      userId,
+      user: toGatewayUser(context.user),
     });
 
     if (!result.ok) {

--- a/services/bot-client/src/commands/character/import.test.ts
+++ b/services/bot-client/src/commands/character/import.test.ts
@@ -30,6 +30,11 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: vi.fn(),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Import mocked modules
@@ -600,7 +605,11 @@ describe('handleImport', () => {
       await handleImport(context, mockConfig);
 
       expect(callGatewayApi).toHaveBeenCalledWith('/user/personality', {
-        userId: 'owner-123',
+        user: {
+          discordId: 'owner-123',
+          username: 'testowner',
+          displayName: 'testowner',
+        },
         method: 'POST',
         body: expect.objectContaining({
           name: 'Test Character',
@@ -623,7 +632,11 @@ describe('handleImport', () => {
       expect(callGatewayApi).toHaveBeenCalledWith(
         '/user/personality',
         expect.objectContaining({
-          userId: 'user-789',
+          user: {
+            discordId: 'user-789',
+            username: 'testowner',
+            displayName: 'testowner',
+          },
         })
       );
     });
@@ -850,7 +863,9 @@ describe('handleImport', () => {
       expect(callGatewayApi).toHaveBeenCalledWith(
         '/user/personality',
         expect.objectContaining({
-          userId: 'regular-user-456',
+          user: expect.objectContaining({
+            discordId: 'regular-user-456',
+          }),
           method: 'POST',
           body: expect.objectContaining({
             slug: 'test-character-cooluser', // Username appended
@@ -932,13 +947,21 @@ describe('handleImport', () => {
 
       // First call should be GET to check existence
       expect(callGatewayApi).toHaveBeenNthCalledWith(1, '/user/personality/test-character', {
-        userId: 'owner-123',
+        user: {
+          discordId: 'owner-123',
+          username: 'testowner',
+          displayName: 'testowner',
+        },
         method: 'GET',
       });
 
       // Second call should be PUT to update
       expect(callGatewayApi).toHaveBeenNthCalledWith(2, '/user/personality/test-character', {
-        userId: 'owner-123',
+        user: {
+          discordId: 'owner-123',
+          username: 'testowner',
+          displayName: 'testowner',
+        },
         method: 'PUT',
         body: expect.objectContaining({
           name: 'Test Character',

--- a/services/bot-client/src/commands/character/import.test.ts
+++ b/services/bot-client/src/commands/character/import.test.ts
@@ -28,14 +28,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: vi.fn(),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: vi.fn(),
+  };
+});
 
 // Import mocked modules
 import { callGatewayApi } from '../../utils/userGatewayClient.js';

--- a/services/bot-client/src/commands/character/import.ts
+++ b/services/bot-client/src/commands/character/import.ts
@@ -13,7 +13,7 @@ import {
   PersonalityCreateSchema,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser, type GatewayUser } from '../../utils/userGatewayClient.js';
 import { validateJsonFile, downloadAndParseJson } from '../../utils/jsonFileUtils.js';
 import {
   VALID_IMAGE_TYPES,
@@ -296,13 +296,13 @@ function buildImportPayload(
  */
 async function checkExistingCharacter(
   slug: string,
-  userId: string
+  user: GatewayUser
 ): Promise<{ exists: false } | { exists: true; canEdit: boolean }> {
   const result = await callGatewayApi<{
     personality: { id: string };
     canEdit: boolean;
   }>(`/user/personality/${slug}`, {
-    userId,
+    user,
     method: 'GET',
   });
 
@@ -317,14 +317,14 @@ async function checkExistingCharacter(
  */
 async function saveCharacter(
   slug: string,
-  userId: string,
+  user: GatewayUser,
   payload: Record<string, unknown>,
   isUpdate: boolean
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   const result = await callGatewayApi<{ id: string }>(
     isUpdate ? `/user/personality/${slug}` : '/user/personality',
     {
-      userId,
+      user,
       method: isUpdate ? 'PUT' : 'POST',
       body: payload,
     }
@@ -418,7 +418,7 @@ export async function handleImport(
     }
 
     // Step 6: Check if character already exists
-    const existingCheck = await checkExistingCharacter(slug, userId);
+    const existingCheck = await checkExistingCharacter(slug, toGatewayUser(context.user));
     if (existingCheck.exists && !existingCheck.canEdit) {
       await context.editReply(
         `❌ A character with the slug \`${slug}\` already exists and you don't own it.\n` +
@@ -428,7 +428,12 @@ export async function handleImport(
     }
 
     // Step 7: Create or update character
-    const saveResult = await saveCharacter(slug, userId, payload, existingCheck.exists);
+    const saveResult = await saveCharacter(
+      slug,
+      toGatewayUser(context.user),
+      payload,
+      existingCheck.exists
+    );
     if (!saveResult.ok) {
       await context.editReply(
         `❌ Failed to ${existingCheck.exists ? 'update' : 'import'} character:\n` +

--- a/services/bot-client/src/commands/character/overrides.test.ts
+++ b/services/bot-client/src/commands/character/overrides.test.ts
@@ -32,6 +32,11 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock the session manager
@@ -144,13 +149,21 @@ describe('Character Overrides Dashboard', () => {
       // First call: fetch personality
       expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/personality/aurora', {
         method: 'GET',
-        userId: 'user-456',
+        user: {
+          discordId: 'user-456',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         timeout: 10000,
       });
       // Second call: resolve full cascade overrides
       expect(mockCallGatewayApi).toHaveBeenCalledWith(
         '/user/config-overrides/resolve/personality-123',
-        { method: 'GET', userId: 'user-456', timeout: 10000 }
+        {
+          method: 'GET',
+          user: { discordId: 'user-456', username: 'testuser', displayName: 'testuser' },
+          timeout: 10000,
+        }
       );
       expect(context.editReply).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/services/bot-client/src/commands/character/overrides.test.ts
+++ b/services/bot-client/src/commands/character/overrides.test.ts
@@ -30,14 +30,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 });
 
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Mock the session manager
 const mockSessionManager = {
@@ -117,7 +118,7 @@ describe('Character Overrides Dashboard', () => {
         replied: false,
         editReply: mockEditReply,
       },
-      user: { id: 'user-456' },
+      user: { id: 'user-456', username: 'testuser' },
       editReply: mockEditReply,
     } as unknown as Parameters<typeof handleOverrides>[0] & {
       editReply: ReturnType<typeof vi.fn>;
@@ -308,7 +309,7 @@ describe('Character Overrides Dashboard', () => {
     it('should update setting via user-personality cascade endpoint', async () => {
       const interaction = {
         customId: 'character-overrides::set::personality-123::crossChannelHistoryEnabled:true',
-        user: { id: 'user-456' },
+        user: { id: 'user-456', username: 'testuser' },
         reply: vi.fn(),
         update: vi.fn(),
         showModal: vi.fn(),
@@ -358,7 +359,7 @@ describe('Character Overrides Dashboard', () => {
   describe('handleCharacterOverridesModal', () => {
     const createMockModalInteraction = (customId: string, inputValue: string) => ({
       customId,
-      user: { id: 'user-456' },
+      user: { id: 'user-456', username: 'testuser' },
       fields: {
         getTextInputValue: vi.fn().mockReturnValue(inputValue),
       },

--- a/services/bot-client/src/commands/character/overrides.ts
+++ b/services/bot-client/src/commands/character/overrides.ts
@@ -20,7 +20,7 @@ import {
   characterSettingsOptions,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
 import {
   type SettingsData,
   type SettingsDashboardConfig,
@@ -81,7 +81,7 @@ export async function handleOverrides(
     // Fetch current character data from API gateway
     const result = await callGatewayApi<PersonalityResponse>(`/user/personality/${characterSlug}`, {
       method: 'GET',
-      userId,
+      user: toGatewayUser(context.user),
       timeout: GATEWAY_TIMEOUTS.DEFERRED,
     });
 
@@ -104,7 +104,7 @@ export async function handleOverrides(
     // Resolve full cascade overrides for this user+personality
     const cascadeResult = await callGatewayApi<ResolvedConfigOverrides>(
       `/user/config-overrides/resolve/${encodeURIComponent(personality.id)}`,
-      { method: 'GET', userId, timeout: GATEWAY_TIMEOUTS.DEFERRED }
+      { method: 'GET', user: toGatewayUser(context.user), timeout: GATEWAY_TIMEOUTS.DEFERRED }
     );
 
     if (!cascadeResult.ok) {

--- a/services/bot-client/src/commands/character/sectionContext.ts
+++ b/services/bot-client/src/commands/character/sectionContext.ts
@@ -38,6 +38,7 @@ import {
   type CharacterData,
   type CharacterSessionData,
 } from './config.js';
+import { toGatewayUser } from '../../utils/userGatewayClient.js';
 import { fetchCharacter } from './api.js';
 
 /**
@@ -110,7 +111,7 @@ export async function loadCharacterSectionData(
     userId: interaction.user.id,
     entityType: 'character',
     entityId,
-    fetchFn: () => fetchCharacter(entityId, config, interaction.user.id),
+    fetchFn: () => fetchCharacter(entityId, config, toGatewayUser(interaction.user)),
     transformFn: (character: CharacterData) => ({ ...character, _isAdmin: sync.isAdmin }),
     interaction,
   });

--- a/services/bot-client/src/commands/character/settings.test.ts
+++ b/services/bot-client/src/commands/character/settings.test.ts
@@ -30,14 +30,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 });
 
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Mock the session manager
 const mockSessionManager = {
@@ -117,7 +118,7 @@ describe('Character Settings Dashboard', () => {
         replied: false,
         editReply: mockEditReply,
       },
-      user: { id: 'user-456' },
+      user: { id: 'user-456', username: 'testuser' },
       editReply: mockEditReply,
     } as unknown as Parameters<typeof handleSettings>[0] & {
       editReply: ReturnType<typeof vi.fn>;
@@ -334,7 +335,7 @@ describe('Character Settings Dashboard', () => {
     it('should update crossChannelHistoryEnabled via set button', async () => {
       const interaction = {
         customId: 'character-settings::set::personality-123::crossChannelHistoryEnabled:true',
-        user: { id: 'user-456' },
+        user: { id: 'user-456', username: 'testuser' },
         reply: vi.fn(),
         update: vi.fn(),
         showModal: vi.fn(),
@@ -382,7 +383,7 @@ describe('Character Settings Dashboard', () => {
     it('should update shareLtmAcrossPersonalities via set button', async () => {
       const interaction = {
         customId: 'character-settings::set::personality-123::shareLtmAcrossPersonalities:true',
-        user: { id: 'user-456' },
+        user: { id: 'user-456', username: 'testuser' },
         reply: vi.fn(),
         update: vi.fn(),
         showModal: vi.fn(),
@@ -431,7 +432,7 @@ describe('Character Settings Dashboard', () => {
       // Entity ID now uses slug::personalityId format
       const interaction = {
         customId: 'character-settings::set::personality-123::maxMessages:auto',
-        user: { id: 'user-456' },
+        user: { id: 'user-456', username: 'testuser' },
         reply: vi.fn(),
         update: vi.fn(),
         showModal: vi.fn(),
@@ -470,7 +471,7 @@ describe('Character Settings Dashboard', () => {
     it('should handle character not found (404) response', async () => {
       const interaction = {
         customId: 'character-settings::set::personality-123::maxMessages:auto',
-        user: { id: 'user-456' },
+        user: { id: 'user-456', username: 'testuser' },
         reply: vi.fn(),
         update: vi.fn(),
         showModal: vi.fn(),
@@ -510,7 +511,7 @@ describe('Character Settings Dashboard', () => {
   describe('handleCharacterSettingsModal', () => {
     const createMockModalInteraction = (customId: string, inputValue: string) => ({
       customId,
-      user: { id: 'user-456' },
+      user: { id: 'user-456', username: 'testuser' },
       fields: {
         getTextInputValue: vi.fn().mockReturnValue(inputValue),
       },

--- a/services/bot-client/src/commands/character/settings.test.ts
+++ b/services/bot-client/src/commands/character/settings.test.ts
@@ -32,6 +32,11 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock the session manager
@@ -144,13 +149,21 @@ describe('Character Settings Dashboard', () => {
       // First call: fetch personality
       expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/personality/aurora', {
         method: 'GET',
-        userId: 'user-456',
+        user: {
+          discordId: 'user-456',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         timeout: 10000,
       });
       // Second call: resolve 3-tier cascade (hardcoded → admin → personality)
       expect(mockCallGatewayApi).toHaveBeenCalledWith(
         '/user/config-overrides/resolve-personality/personality-123',
-        { method: 'GET', userId: 'user-456', timeout: 10000 }
+        {
+          method: 'GET',
+          user: { discordId: 'user-456', username: 'testuser', displayName: 'testuser' },
+          timeout: 10000,
+        }
       );
       expect(context.editReply).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/services/bot-client/src/commands/character/settings.ts
+++ b/services/bot-client/src/commands/character/settings.ts
@@ -20,7 +20,7 @@ import {
   characterSettingsOptions,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
 import {
   type SettingsData,
   type SettingsDashboardConfig,
@@ -80,7 +80,7 @@ export async function handleSettings(
     // Fetch current character data from API gateway
     const result = await callGatewayApi<PersonalityResponse>(`/user/personality/${characterSlug}`, {
       method: 'GET',
-      userId,
+      user: toGatewayUser(context.user),
       timeout: GATEWAY_TIMEOUTS.DEFERRED,
     });
 
@@ -103,7 +103,7 @@ export async function handleSettings(
     // Resolve 3-tier cascade (hardcoded → admin → personality) for creator view
     const cascadeResult = await callGatewayApi<ResolvedConfigOverrides>(
       `/user/config-overrides/resolve-personality/${encodeURIComponent(personality.id)}`,
-      { method: 'GET', userId, timeout: GATEWAY_TIMEOUTS.DEFERRED }
+      { method: 'GET', user: toGatewayUser(context.user), timeout: GATEWAY_TIMEOUTS.DEFERRED }
     );
 
     if (!cascadeResult.ok) {

--- a/services/bot-client/src/commands/character/view.ts
+++ b/services/bot-client/src/commands/character/view.ts
@@ -24,7 +24,7 @@ import {
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import type { CharacterData } from './config.js';
 import { CharacterCustomIds } from '../../utils/customIds.js';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser, type GatewayUser } from '../../utils/userGatewayClient.js';
 import { VIEW_TOTAL_PAGES, VIEW_PAGE_TITLES, EXPANDABLE_FIELDS } from './viewTypes.js';
 import { sendChunkedReply } from '../../utils/chunkedReply.js';
 
@@ -340,9 +340,9 @@ function buildViewComponents(
 /**
  * Fetch a character by slug
  */
-async function fetchCharacter(slug: string, userId: string): Promise<CharacterData | null> {
+async function fetchCharacter(slug: string, user: GatewayUser): Promise<CharacterData | null> {
   const result = await callGatewayApi<PersonalityResponse>(`/user/personality/${slug}`, {
-    userId,
+    user,
   });
 
   if (!result.ok) {
@@ -368,10 +368,9 @@ export async function handleView(
 ): Promise<void> {
   const options = characterViewOptions(context.interaction);
   const slug = options.character();
-  const userId = context.user.id;
 
   try {
-    const character = await fetchCharacter(slug, userId);
+    const character = await fetchCharacter(slug, toGatewayUser(context.user));
     if (!character) {
       await context.editReply(`❌ Character \`${slug}\` not found or not accessible.`);
       return;
@@ -400,7 +399,7 @@ export async function handleViewPagination(
   await interaction.deferUpdate();
 
   try {
-    const character = await fetchCharacter(slug, interaction.user.id);
+    const character = await fetchCharacter(slug, toGatewayUser(interaction.user));
     if (!character) {
       await interaction.editReply({
         content: '❌ Character not found.',
@@ -433,7 +432,7 @@ export async function handleExpandField(
   await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
   try {
-    const character = await fetchCharacter(slug, interaction.user.id);
+    const character = await fetchCharacter(slug, toGatewayUser(interaction.user));
     if (!character) {
       await interaction.editReply('❌ Character not found.');
       return;

--- a/services/bot-client/src/commands/character/voice.test.ts
+++ b/services/bot-client/src/commands/character/voice.test.ts
@@ -45,7 +45,7 @@ function createMockContext(
       },
       guildId: 'guild-123',
     },
-    user: { id: 'user-123' },
+    user: { id: 'user-123', username: 'testuser', globalName: 'testuser' },
     editReply: vi.fn(),
   } as unknown as DeferredCommandContext;
 }
@@ -147,7 +147,7 @@ describe('handleVoice', () => {
           voiceReferenceData: expect.stringContaining('data:audio/wav;base64,'),
           voiceEnabled: true,
         },
-        'user-123',
+        { discordId: 'user-123', username: 'testuser', displayName: 'testuser' },
         mockConfig
       );
       expect(context.editReply).toHaveBeenCalledWith(
@@ -266,7 +266,7 @@ describe('handleVoice', () => {
       expect(updateCharacter).toHaveBeenCalledWith(
         'test-char',
         { voiceReferenceData: null, voiceEnabled: false },
-        'user-123',
+        { discordId: 'user-123', username: 'testuser', displayName: 'testuser' },
         mockConfig
       );
       expect(context.editReply).toHaveBeenCalledWith(

--- a/services/bot-client/src/commands/character/voice.ts
+++ b/services/bot-client/src/commands/character/voice.ts
@@ -11,6 +11,7 @@
 import { escapeMarkdown } from 'discord.js';
 import { createLogger, type EnvConfig, VOICE_REFERENCE_LIMITS } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
+import { toGatewayUser, type GatewayUser } from '../../utils/userGatewayClient.js';
 import { fetchCharacter, updateCharacter, type FetchedCharacter } from './api.js';
 
 const logger = createLogger('character-voice');
@@ -34,10 +35,10 @@ const DISCORD_CDN_HOSTS = ['cdn.discordapp.com', 'media.discordapp.net'];
 async function fetchEditableCharacter(
   slug: string,
   config: EnvConfig,
-  userId: string,
+  user: GatewayUser,
   context: DeferredCommandContext
 ): Promise<FetchedCharacter | null> {
-  const character = await fetchCharacter(slug, config, userId);
+  const character = await fetchCharacter(slug, config, user);
   if (!character) {
     await context.editReply(
       `❌ Character \`${escapeMarkdown(slug)}\` not found or not accessible.`
@@ -101,7 +102,12 @@ async function handleVoiceUpload(
 
   try {
     // Check permissions
-    const character = await fetchEditableCharacter(slug, config, userId, context);
+    const character = await fetchEditableCharacter(
+      slug,
+      config,
+      toGatewayUser(context.user),
+      context
+    );
     if (!character) {
       return;
     }
@@ -127,7 +133,7 @@ async function handleVoiceUpload(
     await updateCharacter(
       slug,
       { voiceReferenceData: base64Audio, voiceEnabled: true },
-      userId,
+      toGatewayUser(context.user),
       config
     );
 
@@ -155,13 +161,23 @@ async function handleVoiceClear(context: DeferredCommandContext, config: EnvConf
 
   try {
     // Check permissions
-    const character = await fetchEditableCharacter(slug, config, userId, context);
+    const character = await fetchEditableCharacter(
+      slug,
+      config,
+      toGatewayUser(context.user),
+      context
+    );
     if (!character) {
       return;
     }
 
     // Clear voice reference and disable voice
-    await updateCharacter(slug, { voiceReferenceData: null, voiceEnabled: false }, userId, config);
+    await updateCharacter(
+      slug,
+      { voiceReferenceData: null, voiceEnabled: false },
+      toGatewayUser(context.user),
+      config
+    );
 
     await context.editReply(
       `✅ Voice reference removed for **${character.displayName ?? character.name}**. Voice is now disabled.`

--- a/services/bot-client/src/commands/deny/permissions.test.ts
+++ b/services/bot-client/src/commands/deny/permissions.test.ts
@@ -18,14 +18,15 @@ vi.mock('../../utils/permissions.js', () => ({
   requireManageMessagesContext: vi.fn(),
 }));
 
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: vi.fn(),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: vi.fn(),
+  };
+});
 
 import { isBotOwner } from '@tzurot/common-types';
 import { requireManageMessagesContext } from '../../utils/permissions.js';

--- a/services/bot-client/src/commands/deny/permissions.test.ts
+++ b/services/bot-client/src/commands/deny/permissions.test.ts
@@ -20,6 +20,11 @@ vi.mock('../../utils/permissions.js', () => ({
 
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: vi.fn(),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 import { isBotOwner } from '@tzurot/common-types';

--- a/services/bot-client/src/commands/deny/permissions.ts
+++ b/services/bot-client/src/commands/deny/permissions.ts
@@ -10,7 +10,7 @@
 import { isBotOwner, GATEWAY_TIMEOUTS } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import { requireManageMessagesContext } from '../../utils/permissions.js';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
 
 interface PermissionResult {
   allowed: boolean;
@@ -91,7 +91,7 @@ async function checkPersonalityPermission(
 
   const result = await callGatewayApi<{ personality: { id: string }; canEdit: boolean }>(
     `/user/personality/${encodeURIComponent(personalitySlug)}`,
-    { userId: context.user.id, timeout: GATEWAY_TIMEOUTS.DEFERRED }
+    { user: toGatewayUser(context.user), timeout: GATEWAY_TIMEOUTS.DEFERRED }
   );
 
   if (!result.ok) {

--- a/services/bot-client/src/commands/history/clear.test.ts
+++ b/services/bot-client/src/commands/history/clear.test.ts
@@ -27,6 +27,11 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock commandHelpers
@@ -100,7 +105,11 @@ describe('handleClear', () => {
     await handleClear(context);
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/history/clear', {
-      userId: '123456789',
+      user: {
+        discordId: '123456789',
+        username: 'testuser',
+        displayName: 'testuser',
+      },
       method: 'POST',
       body: { personalitySlug: 'lilith' },
     });

--- a/services/bot-client/src/commands/history/clear.test.ts
+++ b/services/bot-client/src/commands/history/clear.test.ts
@@ -25,14 +25,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 // Mock userGatewayClient
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Mock commandHelpers
 const mockCreateSuccessEmbed = vi.fn(() => ({
@@ -66,7 +67,7 @@ describe('handleClear', () => {
           getInteger: vi.fn(() => null),
         },
       },
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       guild: null,
       member: null,
       channel: null,

--- a/services/bot-client/src/commands/history/clear.ts
+++ b/services/bot-client/src/commands/history/clear.ts
@@ -8,7 +8,7 @@
 
 import { createLogger, historyClearOptions } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
 import { createSuccessEmbed } from '../../utils/commandHelpers.js';
 
 const logger = createLogger('history-clear');
@@ -38,7 +38,7 @@ export async function handleClear(context: DeferredCommandContext): Promise<void
     }
 
     const result = await callGatewayApi<ClearResponse>('/user/history/clear', {
-      userId,
+      user: toGatewayUser(context.user),
       method: 'POST',
       body,
     });

--- a/services/bot-client/src/commands/history/index.test.ts
+++ b/services/bot-client/src/commands/history/index.test.ts
@@ -102,6 +102,11 @@ vi.mock('../../utils/destructiveConfirmation.js', () => ({
 const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock commandHelpers

--- a/services/bot-client/src/commands/history/index.test.ts
+++ b/services/bot-client/src/commands/history/index.test.ts
@@ -100,14 +100,15 @@ vi.mock('../../utils/destructiveConfirmation.js', () => ({
 
 // Mock userGatewayClient
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Mock commandHelpers
 vi.mock('../../utils/commandHelpers.js', () => ({

--- a/services/bot-client/src/commands/history/index.ts
+++ b/services/bot-client/src/commands/history/index.ts
@@ -35,7 +35,7 @@ import {
   createHardDeleteConfig,
   type DestructiveOperationResult,
 } from '../../utils/destructiveConfirmation.js';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser, type GatewayUser } from '../../utils/userGatewayClient.js';
 import { createSuccessEmbed } from '../../utils/commandHelpers.js';
 
 const logger = createLogger('history-command');
@@ -70,7 +70,7 @@ async function execute(ctx: SafeCommandContext): Promise<void> {
  * Build the hard-delete execution callback for modal submission
  */
 function buildHardDeleteOperation(
-  userId: string,
+  user: GatewayUser,
   personalitySlug: string,
   channelId: string
 ): () => Promise<DestructiveOperationResult> {
@@ -82,14 +82,14 @@ function buildHardDeleteOperation(
     }
 
     const result = await callGatewayApi<HardDeleteResponse>('/user/history/hard-delete', {
-      userId,
+      user,
       method: 'DELETE',
       body: { personalitySlug, channelId },
     });
 
     if (!result.ok) {
       logger.error(
-        { userId, personalitySlug, channelId, error: result.error },
+        { userId: user.discordId, personalitySlug, channelId, error: result.error },
         '[History] Hard-delete API failed'
       );
       return {
@@ -104,7 +104,7 @@ function buildHardDeleteOperation(
     const { deletedCount } = result.data;
 
     logger.info(
-      { userId, personalitySlug, channelId, deletedCount },
+      { userId: user.discordId, personalitySlug, channelId, deletedCount },
       '[History] Hard-delete completed'
     );
 
@@ -147,7 +147,7 @@ async function handleModal(interaction: ModalSubmitInteraction): Promise<void> {
 
       const { personalitySlug, channelId } = entityInfo;
       const executeOperation = buildHardDeleteOperation(
-        interaction.user.id,
+        toGatewayUser(interaction.user),
         personalitySlug,
         channelId
       );

--- a/services/bot-client/src/commands/history/stats.test.ts
+++ b/services/bot-client/src/commands/history/stats.test.ts
@@ -27,6 +27,11 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock commandHelpers
@@ -115,7 +120,10 @@ describe('handleStats', () => {
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith(
       '/user/history/stats?personalitySlug=lilith&channelId=channel-123',
-      { userId: '123456789', method: 'GET' }
+      {
+        user: { discordId: '123456789', username: 'testuser', displayName: 'testuser' },
+        method: 'GET',
+      }
     );
     expect(mockCreateInfoEmbed).toHaveBeenCalledWith(
       'Conversation Statistics',

--- a/services/bot-client/src/commands/history/stats.test.ts
+++ b/services/bot-client/src/commands/history/stats.test.ts
@@ -25,14 +25,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 // Mock userGatewayClient
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Mock commandHelpers
 const mockCreateInfoEmbed = vi.fn(() => ({
@@ -69,7 +70,7 @@ describe('handleStats', () => {
           getInteger: vi.fn(() => null),
         },
       },
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       guild: null,
       member: null,
       channel: null,

--- a/services/bot-client/src/commands/history/stats.ts
+++ b/services/bot-client/src/commands/history/stats.ts
@@ -9,7 +9,7 @@
 import { escapeMarkdown } from 'discord.js';
 import { createLogger, historyStatsOptions, formatDateTimeCompact } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
 import { createInfoEmbed } from '../../utils/commandHelpers.js';
 
 const logger = createLogger('history-stats');
@@ -65,7 +65,7 @@ export async function handleStats(context: DeferredCommandContext): Promise<void
     }
 
     const result = await callGatewayApi<StatsResponse>(`/user/history/stats?${params.toString()}`, {
-      userId,
+      user: toGatewayUser(context.user),
       method: 'GET',
     });
 

--- a/services/bot-client/src/commands/history/undo.test.ts
+++ b/services/bot-client/src/commands/history/undo.test.ts
@@ -25,14 +25,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 // Mock userGatewayClient
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Mock commandHelpers
 const mockCreateSuccessEmbed = vi.fn(() => ({}));
@@ -64,7 +65,7 @@ describe('handleUndo', () => {
           getInteger: vi.fn(() => null),
         },
       },
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       guild: null,
       member: null,
       channel: null,

--- a/services/bot-client/src/commands/history/undo.test.ts
+++ b/services/bot-client/src/commands/history/undo.test.ts
@@ -27,6 +27,11 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock commandHelpers
@@ -97,7 +102,11 @@ describe('handleUndo', () => {
     await handleUndo(context);
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/history/undo', {
-      userId: '123456789',
+      user: {
+        discordId: '123456789',
+        username: 'testuser',
+        displayName: 'testuser',
+      },
       method: 'POST',
       body: { personalitySlug: 'lilith' },
     });

--- a/services/bot-client/src/commands/history/undo.ts
+++ b/services/bot-client/src/commands/history/undo.ts
@@ -8,7 +8,7 @@
 
 import { createLogger, historyUndoOptions } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
 import { createSuccessEmbed } from '../../utils/commandHelpers.js';
 
 const logger = createLogger('history-undo');
@@ -37,7 +37,7 @@ export async function handleUndo(context: DeferredCommandContext): Promise<void>
     }
 
     const result = await callGatewayApi<UndoResponse>('/user/history/undo', {
-      userId,
+      user: toGatewayUser(context.user),
       method: 'POST',
       body,
     });

--- a/services/bot-client/src/commands/memory/autocomplete.test.ts
+++ b/services/bot-client/src/commands/memory/autocomplete.test.ts
@@ -9,6 +9,11 @@ import {
   getPersonalityName,
 } from './autocomplete.js';
 import type { AutocompleteInteraction } from 'discord.js';
+import type { GatewayUser } from '../../utils/userGatewayClient.js';
+
+function mkUser(discordId = 'user-123'): GatewayUser {
+  return { discordId, username: 'test-user', displayName: 'Test User' };
+}
 
 // Mock shared autocomplete utility
 const mockSharedAutocomplete = vi.fn();
@@ -54,26 +59,27 @@ describe('Memory Autocomplete', () => {
     });
 
     it('should resolve personality by slug', async () => {
-      const result = await resolvePersonalityId('user-123', 'lilith');
+      const user = mkUser();
+      const result = await resolvePersonalityId(user, 'lilith');
 
       expect(result).toBe('uuid-1');
-      expect(mockGetCachedPersonalities).toHaveBeenCalledWith('user-123');
+      expect(mockGetCachedPersonalities).toHaveBeenCalledWith(user);
     });
 
     it('should resolve personality by ID', async () => {
-      const result = await resolvePersonalityId('user-123', 'uuid-2');
+      const result = await resolvePersonalityId(mkUser(), 'uuid-2');
 
       expect(result).toBe('uuid-2');
     });
 
     it('should resolve personality by name (case-insensitive)', async () => {
-      const result = await resolvePersonalityId('user-123', 'ZEPHYR');
+      const result = await resolvePersonalityId(mkUser(), 'ZEPHYR');
 
       expect(result).toBe('uuid-3');
     });
 
     it('should return null for unknown personality', async () => {
-      const result = await resolvePersonalityId('user-123', 'unknown');
+      const result = await resolvePersonalityId(mkUser(), 'unknown');
 
       expect(result).toBeNull();
     });
@@ -86,7 +92,7 @@ describe('Memory Autocomplete', () => {
       ]);
 
       // First match by slug wins
-      const result = await resolvePersonalityId('user-123', 'aria');
+      const result = await resolvePersonalityId(mkUser(), 'aria');
 
       // Should find the original 'aria' by slug first
       expect(result).toBe('uuid-2');
@@ -105,26 +111,27 @@ describe('Memory Autocomplete', () => {
     });
 
     it('should return displayName when available', async () => {
-      const result = await getPersonalityName('user-123', 'uuid-1');
+      const user = mkUser();
+      const result = await getPersonalityName(user, 'uuid-1');
 
       expect(result).toBe('Lilith the Dark');
-      expect(mockGetCachedPersonalities).toHaveBeenCalledWith('user-123');
+      expect(mockGetCachedPersonalities).toHaveBeenCalledWith(user);
     });
 
     it('should return name when displayName is null', async () => {
-      const result = await getPersonalityName('user-123', 'uuid-2');
+      const result = await getPersonalityName(mkUser(), 'uuid-2');
 
       expect(result).toBe('Aria');
     });
 
     it('should return name when displayName is undefined', async () => {
-      const result = await getPersonalityName('user-123', 'uuid-3');
+      const result = await getPersonalityName(mkUser(), 'uuid-3');
 
       expect(result).toBe('Zephyr');
     });
 
     it('should return null for unknown personality', async () => {
-      const result = await getPersonalityName('user-123', 'unknown-uuid');
+      const result = await getPersonalityName(mkUser(), 'unknown-uuid');
 
       expect(result).toBeNull();
     });

--- a/services/bot-client/src/commands/memory/autocomplete.ts
+++ b/services/bot-client/src/commands/memory/autocomplete.ts
@@ -7,6 +7,7 @@
 import type { AutocompleteInteraction } from 'discord.js';
 import { handlePersonalityAutocomplete as sharedPersonalityAutocomplete } from '../../utils/autocomplete/personalityAutocomplete.js';
 import { getCachedPersonalities } from '../../utils/autocomplete/autocompleteCache.js';
+import { type GatewayUser } from '../../utils/userGatewayClient.js';
 
 /**
  * Handle personality autocomplete for memory commands
@@ -32,10 +33,10 @@ export async function handlePersonalityAutocomplete(
  * @returns Personality UUID or null if not found
  */
 export async function resolvePersonalityId(
-  userId: string,
+  user: GatewayUser,
   slugOrId: string
 ): Promise<string | null> {
-  const personalities = await getCachedPersonalities(userId);
+  const personalities = await getCachedPersonalities(user);
 
   // Try to find by slug first (most common case from autocomplete)
   const bySlug = personalities.find(p => p.slug === slugOrId);
@@ -66,10 +67,10 @@ export async function resolvePersonalityId(
  * @returns Personality display name or null if not found
  */
 export async function getPersonalityName(
-  userId: string,
+  user: GatewayUser,
   personalityId: string
 ): Promise<string | null> {
-  const personalities = await getCachedPersonalities(userId);
+  const personalities = await getCachedPersonalities(user);
 
   const personality = personalities.find(p => p.id === personalityId);
   if (personality === undefined) {

--- a/services/bot-client/src/commands/memory/batchDelete.test.ts
+++ b/services/bot-client/src/commands/memory/batchDelete.test.ts
@@ -28,14 +28,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 // Mock userGatewayClient
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Mock commandHelpers
 const mockReplyWithError = vi.fn();

--- a/services/bot-client/src/commands/memory/batchDelete.test.ts
+++ b/services/bot-client/src/commands/memory/batchDelete.test.ts
@@ -30,6 +30,11 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock commandHelpers
@@ -66,7 +71,7 @@ describe('handleBatchDelete', () => {
 
   function createMockContext(personality = 'lilith', timeframe: string | null = null) {
     return {
-      user: { id: 'user-123' },
+      user: { id: 'user-123', username: 'testuser', globalName: 'testuser' },
       interaction: {
         options: {
           getString: (name: string, _required?: boolean) => {
@@ -122,7 +127,10 @@ describe('handleBatchDelete', () => {
       const context = createMockContext('lilith');
       await handleBatchDelete(context);
 
-      expect(mockResolvePersonalityId).toHaveBeenCalledWith('user-123', 'lilith');
+      expect(mockResolvePersonalityId).toHaveBeenCalledWith(
+        { discordId: 'user-123', username: 'testuser', displayName: 'testuser' },
+        'lilith'
+      );
       expect(mockCallGatewayApi).toHaveBeenCalledWith(
         expect.stringContaining('personalityId=personality-uuid-123'),
         expect.objectContaining({ method: 'GET' })

--- a/services/bot-client/src/commands/memory/batchDelete.ts
+++ b/services/bot-client/src/commands/memory/batchDelete.ts
@@ -19,7 +19,7 @@ import {
   memoryDeleteOptions,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
 import { createWarningEmbed, createSuccessEmbed } from '../../utils/commandHelpers.js';
 import { resolvePersonalityId } from './autocomplete.js';
 
@@ -69,13 +69,14 @@ function formatTimeframe(timeframe: string | null): string {
 // eslint-disable-next-line max-lines-per-function, max-statements -- Discord command handler with sequential UI flow
 export async function handleBatchDelete(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
+  const user = toGatewayUser(context.user);
   const options = memoryDeleteOptions(context.interaction);
   const personalityInput = options.personality();
   const timeframe = options.timeframe();
 
   try {
     // Resolve personality slug to ID
-    const personalityId = await resolvePersonalityId(userId, personalityInput);
+    const personalityId = await resolvePersonalityId(user, personalityInput);
 
     if (personalityId === null) {
       await context.editReply({
@@ -93,7 +94,7 @@ export async function handleBatchDelete(context: DeferredCommandContext): Promis
     const previewResult = await callGatewayApi<PreviewResponse>(
       `/user/memory/delete/preview?${queryParams.toString()}`,
       {
-        userId,
+        user,
         method: 'GET',
       }
     );
@@ -180,7 +181,7 @@ export async function handleBatchDelete(context: DeferredCommandContext): Promis
       await buttonInteraction.deferUpdate();
 
       const deleteResult = await callGatewayApi<DeleteResponse>('/user/memory/delete', {
-        userId,
+        user,
         method: 'POST',
         body: {
           personalityId,

--- a/services/bot-client/src/commands/memory/browse.test.ts
+++ b/services/bot-client/src/commands/memory/browse.test.ts
@@ -42,14 +42,15 @@ vi.mock('@tzurot/common-types', async () => {
   };
 });
 
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 vi.mock('./resolveHelpers.js', () => ({
   resolveOptionalPersonality: (...args: unknown[]) => mockResolveOptionalPersonality(...args),

--- a/services/bot-client/src/commands/memory/browse.test.ts
+++ b/services/bot-client/src/commands/memory/browse.test.ts
@@ -44,6 +44,11 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 vi.mock('./resolveHelpers.js', () => ({
@@ -187,7 +192,10 @@ describe('handleBrowse', () => {
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith(
       expect.stringContaining('/user/memory/list'),
-      expect.objectContaining({ method: 'GET', userId: TEST_USER_ID })
+      expect.objectContaining({
+        method: 'GET',
+        user: expect.objectContaining({ discordId: TEST_USER_ID }),
+      })
     );
     expect(context.editReply).toHaveBeenCalledWith(
       expect.objectContaining({ embeds: expect.any(Array), components: expect.any(Array) })

--- a/services/bot-client/src/commands/memory/browse.ts
+++ b/services/bot-client/src/commands/memory/browse.ts
@@ -24,7 +24,7 @@ import {
   formatDateShort,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser, type GatewayUser } from '../../utils/userGatewayClient.js';
 import {
   createBrowseCustomIdHelpers,
   buildBrowseButtons as buildSharedBrowseButtons,
@@ -184,7 +184,7 @@ function buildBrowseComponents(
  * Fetch memories from API
  */
 async function fetchMemories(
-  userId: string,
+  user: GatewayUser,
   personalityId: string | undefined,
   offset: number,
   limit: number
@@ -202,7 +202,7 @@ async function fetchMemories(
   const result = await callGatewayApi<BrowseResponse>(
     `/user/memory/list?${queryParams.toString()}`,
     {
-      userId,
+      user,
       method: 'GET',
     }
   );
@@ -219,6 +219,7 @@ async function fetchMemories(
  */
 export async function handleBrowse(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
+  const user = toGatewayUser(context.user);
   const options = memoryBrowseOptions(context.interaction);
   const personalityInput = options.personality();
 
@@ -226,13 +227,13 @@ export async function handleBrowse(context: DeferredCommandContext): Promise<voi
     // Resolve personality if provided. Contract: null means the helper
     // already sent an error reply via editReply, so we must return early
     // without sending another reply (Discord would reject the double-reply).
-    const personalityId = await resolveOptionalPersonality(context, userId, personalityInput);
+    const personalityId = await resolveOptionalPersonality(context, user, personalityInput);
     if (personalityId === null) {
       return;
     }
 
     // Fetch first page
-    const data = await fetchMemories(userId, personalityId, 0, MEMORIES_PER_PAGE);
+    const data = await fetchMemories(user, personalityId, 0, MEMORIES_PER_PAGE);
 
     if (data === null) {
       logger.warn({ userId }, '[Memory] Browse failed');
@@ -322,7 +323,7 @@ export async function handleBrowsePagination(interaction: ButtonInteraction): Pr
   const newPage = parsed.page;
 
   const data = await fetchMemories(
-    userId,
+    toGatewayUser(interaction.user),
     personalityId,
     newPage * MEMORIES_PER_PAGE,
     MEMORIES_PER_PAGE
@@ -386,12 +387,13 @@ export async function refreshBrowseList(interaction: ButtonInteraction): Promise
   }
 
   const userId = interaction.user.id;
+  const user = toGatewayUser(interaction.user);
   const { personalityId } = session.data;
 
   const result = await fetchPageWithEmptyFallback({
     currentPage: session.data.currentPage,
     fetchPage: page =>
-      fetchMemories(userId, personalityId, page * MEMORIES_PER_PAGE, MEMORIES_PER_PAGE),
+      fetchMemories(user, personalityId, page * MEMORIES_PER_PAGE, MEMORIES_PER_PAGE),
     isEmpty: d => d.memories.length === 0,
   });
   if (result === null) {

--- a/services/bot-client/src/commands/memory/detail.test.ts
+++ b/services/bot-client/src/commands/memory/detail.test.ts
@@ -43,6 +43,11 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock customIds

--- a/services/bot-client/src/commands/memory/detail.test.ts
+++ b/services/bot-client/src/commands/memory/detail.test.ts
@@ -41,14 +41,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 // Mock userGatewayClient
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Mock customIds
 vi.mock('../../utils/customIds.js', () => ({

--- a/services/bot-client/src/commands/memory/detail.ts
+++ b/services/bot-client/src/commands/memory/detail.ts
@@ -16,6 +16,7 @@ import {
 import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
 import { createLogger, DISCORD_COLORS, formatDateTimeCompact } from '@tzurot/common-types';
 import { CUSTOM_ID_DELIMITER } from '../../utils/customIds.js';
+import { toGatewayUser } from '../../utils/userGatewayClient.js';
 
 import { fetchMemory, toggleMemoryLock, deleteMemory } from './detailApi.js';
 import type { MemoryItem } from './detailApi.js';
@@ -210,12 +211,11 @@ export function buildDeleteConfirmButtons(memoryId: string): ActionRowBuilder<Bu
  * parameter.)
  */
 export async function handleMemorySelect(interaction: StringSelectMenuInteraction): Promise<void> {
-  const userId = interaction.user.id;
   const memoryId = interaction.values[0];
 
   await interaction.deferUpdate();
 
-  const memory = await fetchMemory(userId, memoryId);
+  const memory = await fetchMemory(toGatewayUser(interaction.user), memoryId);
   if (memory === null) {
     await interaction.followUp({
       content: '❌ Failed to load memory details. It may have been deleted.',
@@ -244,7 +244,7 @@ export async function handleLockButton(
 
   await interaction.deferUpdate();
 
-  const updatedMemory = await toggleMemoryLock(userId, memoryId);
+  const updatedMemory = await toggleMemoryLock(toGatewayUser(interaction.user), memoryId);
   if (updatedMemory === null) {
     await interaction.followUp({
       content: '❌ Failed to update lock status. Please try again.',
@@ -272,11 +272,9 @@ export async function handleDeleteButton(
   interaction: ButtonInteraction,
   memoryId: string
 ): Promise<void> {
-  const userId = interaction.user.id;
-
   await interaction.deferUpdate();
 
-  const memory = await fetchMemory(userId, memoryId);
+  const memory = await fetchMemory(toGatewayUser(interaction.user), memoryId);
   if (memory === null) {
     await interaction.followUp({
       content: '❌ Failed to load memory. It may have already been deleted.',
@@ -321,7 +319,7 @@ export async function handleDeleteConfirm(
     await interaction.deferUpdate();
   }
 
-  const success = await deleteMemory(userId, memoryId);
+  const success = await deleteMemory(toGatewayUser(interaction.user), memoryId);
   if (!success) {
     await interaction.followUp({
       content: '❌ Failed to delete memory. Please try again.',
@@ -345,7 +343,7 @@ export async function handleViewFullButton(
 
   await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
-  const memory = await fetchMemory(userId, memoryId);
+  const memory = await fetchMemory(toGatewayUser(interaction.user), memoryId);
   if (memory === null) {
     await interaction.editReply({
       content: '❌ Failed to load memory. It may have been deleted.',

--- a/services/bot-client/src/commands/memory/detailApi.test.ts
+++ b/services/bot-client/src/commands/memory/detailApi.test.ts
@@ -24,7 +24,18 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
+
+const TEST_USER = {
+  discordId: 'user-123',
+  username: 'testuser',
+  displayName: 'testuser',
+} as const;
 
 describe('Memory Detail API', () => {
   beforeEach(() => {
@@ -50,11 +61,15 @@ describe('Memory Detail API', () => {
         data: { memory },
       });
 
-      const result = await fetchMemory('user-123', 'memory-123');
+      const result = await fetchMemory(TEST_USER, 'memory-123');
 
       expect(result).toEqual(memory);
       expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/memory/memory-123', {
-        userId: 'user-123',
+        user: {
+          discordId: 'user-123',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         method: 'GET',
       });
     });
@@ -65,7 +80,7 @@ describe('Memory Detail API', () => {
         error: 'Not found',
       });
 
-      const result = await fetchMemory('user-123', 'memory-123');
+      const result = await fetchMemory(TEST_USER, 'memory-123');
 
       expect(result).toBeNull();
     });
@@ -79,11 +94,15 @@ describe('Memory Detail API', () => {
         data: { memory },
       });
 
-      const result = await updateMemory('user-123', 'memory-123', 'Updated content');
+      const result = await updateMemory(TEST_USER, 'memory-123', 'Updated content');
 
       expect(result).toEqual(memory);
       expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/memory/memory-123', {
-        userId: 'user-123',
+        user: {
+          discordId: 'user-123',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         method: 'PATCH',
         body: { content: 'Updated content' },
       });
@@ -95,7 +114,7 @@ describe('Memory Detail API', () => {
         error: 'Update failed',
       });
 
-      const result = await updateMemory('user-123', 'memory-123', 'New content');
+      const result = await updateMemory(TEST_USER, 'memory-123', 'New content');
 
       expect(result).toBeNull();
     });
@@ -109,11 +128,15 @@ describe('Memory Detail API', () => {
         data: { memory },
       });
 
-      const result = await toggleMemoryLock('user-123', 'memory-123');
+      const result = await toggleMemoryLock(TEST_USER, 'memory-123');
 
       expect(result).toEqual(memory);
       expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/memory/memory-123/lock', {
-        userId: 'user-123',
+        user: {
+          discordId: 'user-123',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         method: 'POST',
       });
     });
@@ -124,7 +147,7 @@ describe('Memory Detail API', () => {
         error: 'Lock failed',
       });
 
-      const result = await toggleMemoryLock('user-123', 'memory-123');
+      const result = await toggleMemoryLock(TEST_USER, 'memory-123');
 
       expect(result).toBeNull();
     });
@@ -137,11 +160,15 @@ describe('Memory Detail API', () => {
         data: { success: true },
       });
 
-      const result = await deleteMemory('user-123', 'memory-123');
+      const result = await deleteMemory(TEST_USER, 'memory-123');
 
       expect(result).toBe(true);
       expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/memory/memory-123', {
-        userId: 'user-123',
+        user: {
+          discordId: 'user-123',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         method: 'DELETE',
       });
     });
@@ -152,7 +179,7 @@ describe('Memory Detail API', () => {
         error: 'Delete failed',
       });
 
-      const result = await deleteMemory('user-123', 'memory-123');
+      const result = await deleteMemory(TEST_USER, 'memory-123');
 
       expect(result).toBe(false);
     });

--- a/services/bot-client/src/commands/memory/detailApi.test.ts
+++ b/services/bot-client/src/commands/memory/detailApi.test.ts
@@ -22,14 +22,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 // Mock userGatewayClient
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 const TEST_USER = {
   discordId: 'user-123',

--- a/services/bot-client/src/commands/memory/detailApi.ts
+++ b/services/bot-client/src/commands/memory/detailApi.ts
@@ -4,7 +4,7 @@
  */
 
 import { createLogger } from '@tzurot/common-types';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, type GatewayUser } from '../../utils/userGatewayClient.js';
 
 /**
  * Memory item structure from API
@@ -28,14 +28,17 @@ interface SingleMemoryResponse {
 /**
  * Fetch a single memory by ID
  */
-export async function fetchMemory(userId: string, memoryId: string): Promise<MemoryItem | null> {
+export async function fetchMemory(user: GatewayUser, memoryId: string): Promise<MemoryItem | null> {
   const result = await callGatewayApi<SingleMemoryResponse>(`/user/memory/${memoryId}`, {
-    userId,
+    user,
     method: 'GET',
   });
 
   if (!result.ok) {
-    logger.warn({ userId, memoryId, error: result.error }, '[Memory] Failed to fetch memory');
+    logger.warn(
+      { userId: user.discordId, memoryId, error: result.error },
+      '[Memory] Failed to fetch memory'
+    );
     return null;
   }
 
@@ -46,18 +49,21 @@ export async function fetchMemory(userId: string, memoryId: string): Promise<Mem
  * Update memory content
  */
 export async function updateMemory(
-  userId: string,
+  user: GatewayUser,
   memoryId: string,
   content: string
 ): Promise<MemoryItem | null> {
   const result = await callGatewayApi<SingleMemoryResponse>(`/user/memory/${memoryId}`, {
-    userId,
+    user,
     method: 'PATCH',
     body: { content },
   });
 
   if (!result.ok) {
-    logger.warn({ userId, memoryId, error: result.error }, '[Memory] Failed to update memory');
+    logger.warn(
+      { userId: user.discordId, memoryId, error: result.error },
+      '[Memory] Failed to update memory'
+    );
     return null;
   }
 
@@ -68,16 +74,19 @@ export async function updateMemory(
  * Toggle memory lock status
  */
 export async function toggleMemoryLock(
-  userId: string,
+  user: GatewayUser,
   memoryId: string
 ): Promise<MemoryItem | null> {
   const result = await callGatewayApi<SingleMemoryResponse>(`/user/memory/${memoryId}/lock`, {
-    userId,
+    user,
     method: 'POST',
   });
 
   if (!result.ok) {
-    logger.warn({ userId, memoryId, error: result.error }, '[Memory] Failed to toggle lock');
+    logger.warn(
+      { userId: user.discordId, memoryId, error: result.error },
+      '[Memory] Failed to toggle lock'
+    );
     return null;
   }
 
@@ -87,14 +96,17 @@ export async function toggleMemoryLock(
 /**
  * Delete a memory
  */
-export async function deleteMemory(userId: string, memoryId: string): Promise<boolean> {
+export async function deleteMemory(user: GatewayUser, memoryId: string): Promise<boolean> {
   const result = await callGatewayApi<{ success: boolean }>(`/user/memory/${memoryId}`, {
-    userId,
+    user,
     method: 'DELETE',
   });
 
   if (!result.ok) {
-    logger.warn({ userId, memoryId, error: result.error }, '[Memory] Failed to delete memory');
+    logger.warn(
+      { userId: user.discordId, memoryId, error: result.error },
+      '[Memory] Failed to delete memory'
+    );
     return false;
   }
 

--- a/services/bot-client/src/commands/memory/detailModals.test.ts
+++ b/services/bot-client/src/commands/memory/detailModals.test.ts
@@ -35,6 +35,11 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock customIds

--- a/services/bot-client/src/commands/memory/detailModals.test.ts
+++ b/services/bot-client/src/commands/memory/detailModals.test.ts
@@ -33,14 +33,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 // Mock userGatewayClient
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Mock customIds
 vi.mock('../../utils/customIds.js', () => ({

--- a/services/bot-client/src/commands/memory/detailModals.ts
+++ b/services/bot-client/src/commands/memory/detailModals.ts
@@ -16,6 +16,7 @@ import {
 import type { ButtonInteraction, ModalSubmitInteraction } from 'discord.js';
 import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
 import { buildMemoryActionId, buildDetailEmbed, buildDetailButtons } from './detail.js';
+import { toGatewayUser } from '../../utils/userGatewayClient.js';
 import { fetchMemory, updateMemory } from './detailApi.js';
 import type { MemoryItem } from './detailApi.js';
 
@@ -98,9 +99,7 @@ export async function handleEditButton(
   interaction: ButtonInteraction,
   memoryId: string
 ): Promise<void> {
-  const userId = interaction.user.id;
-
-  const memory = await fetchMemory(userId, memoryId);
+  const memory = await fetchMemory(toGatewayUser(interaction.user), memoryId);
   if (memory === null) {
     await interaction.reply({
       content: '❌ Failed to load memory. It may have been deleted.',
@@ -135,9 +134,7 @@ export async function handleEditTruncatedButton(
   interaction: ButtonInteraction,
   memoryId: string
 ): Promise<void> {
-  const userId = interaction.user.id;
-
-  const memory = await fetchMemory(userId, memoryId);
+  const memory = await fetchMemory(toGatewayUser(interaction.user), memoryId);
   if (memory === null) {
     await interaction.update({
       content: '❌ Failed to load memory. It may have been deleted.',
@@ -195,7 +192,7 @@ export async function handleEditModalSubmit(
     return;
   }
 
-  const updatedMemory = await updateMemory(userId, memoryId, newContent);
+  const updatedMemory = await updateMemory(toGatewayUser(interaction.user), memoryId, newContent);
   if (updatedMemory === null) {
     await interaction.followUp({
       content: '❌ Failed to update memory. Please try again.',

--- a/services/bot-client/src/commands/memory/focus.test.ts
+++ b/services/bot-client/src/commands/memory/focus.test.ts
@@ -21,14 +21,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 // Mock userGatewayClient
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Mock commandHelpers
 const mockCreateSuccessEmbed = vi.fn(() => ({}));
@@ -57,7 +58,7 @@ describe('Memory Focus Handlers', () => {
 
   function createMockContext(personalitySlug: string = 'lilith') {
     return {
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       interaction: {
         options: {
           getString: (name: string, _required?: boolean) => {

--- a/services/bot-client/src/commands/memory/focus.test.ts
+++ b/services/bot-client/src/commands/memory/focus.test.ts
@@ -23,6 +23,11 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock commandHelpers
@@ -81,7 +86,11 @@ describe('Memory Focus Handlers', () => {
       await handleFocusEnable(context);
 
       expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/memory/focus', {
-        userId: '123456789',
+        user: {
+          discordId: '123456789',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         method: 'POST',
         body: { personalityId: 'personality-uuid-123', enabled: true },
       });
@@ -148,7 +157,11 @@ describe('Memory Focus Handlers', () => {
       await handleFocusDisable(context);
 
       expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/memory/focus', {
-        userId: '123456789',
+        user: {
+          discordId: '123456789',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         method: 'POST',
         body: { personalityId: 'personality-uuid-123', enabled: false },
       });
@@ -188,7 +201,10 @@ describe('Memory Focus Handlers', () => {
 
       expect(mockCallGatewayApi).toHaveBeenCalledWith(
         '/user/memory/focus?personalityId=personality-uuid-123',
-        { userId: '123456789', method: 'GET' }
+        {
+          user: { discordId: '123456789', username: 'testuser', displayName: 'testuser' },
+          method: 'GET',
+        }
       );
       expect(mockCreateInfoEmbed).toHaveBeenCalledWith(
         'Focus Mode Status',

--- a/services/bot-client/src/commands/memory/focus.ts
+++ b/services/bot-client/src/commands/memory/focus.ts
@@ -14,7 +14,7 @@ import {
   memoryFocusStatusOptions,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
 import { createSuccessEmbed, createInfoEmbed } from '../../utils/commandHelpers.js';
 import { getPersonalityName } from './autocomplete.js';
 import { resolveRequiredPersonality } from './resolveHelpers.js';
@@ -47,12 +47,13 @@ export async function handleFocusDisable(context: DeferredCommandContext): Promi
  */
 export async function handleFocusStatus(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
+  const user = toGatewayUser(context.user);
   const options = memoryFocusStatusOptions(context.interaction);
   const personalityInput = options.personality();
 
   try {
     // Resolve personality slug to ID
-    const personalityId = await resolveRequiredPersonality(context, userId, personalityInput);
+    const personalityId = await resolveRequiredPersonality(context, user, personalityInput);
     if (personalityId === null) {
       return;
     }
@@ -60,7 +61,7 @@ export async function handleFocusStatus(context: DeferredCommandContext): Promis
     const result = await callGatewayApi<FocusResponse>(
       `/user/memory/focus?personalityId=${personalityId}`,
       {
-        userId,
+        user,
         method: 'GET',
       }
     );
@@ -77,7 +78,7 @@ export async function handleFocusStatus(context: DeferredCommandContext): Promis
     }
 
     const data = result.data;
-    const personalityName = await getPersonalityName(userId, personalityId);
+    const personalityName = await getPersonalityName(user, personalityId);
 
     const embed = createInfoEmbed(
       'Focus Mode Status',
@@ -103,6 +104,7 @@ export async function handleFocusStatus(context: DeferredCommandContext): Promis
  */
 async function setFocusMode(context: DeferredCommandContext, enabled: boolean): Promise<void> {
   const userId = context.user.id;
+  const user = toGatewayUser(context.user);
   // Both enable and disable use the same option schema
   const options = enabled
     ? memoryFocusEnableOptions(context.interaction)
@@ -111,13 +113,13 @@ async function setFocusMode(context: DeferredCommandContext, enabled: boolean): 
 
   try {
     // Resolve personality slug to ID
-    const personalityId = await resolveRequiredPersonality(context, userId, personalityInput);
+    const personalityId = await resolveRequiredPersonality(context, user, personalityInput);
     if (personalityId === null) {
       return;
     }
 
     const result = await callGatewayApi<FocusResponse>('/user/memory/focus', {
-      userId,
+      user,
       method: 'POST',
       body: { personalityId, enabled },
     });

--- a/services/bot-client/src/commands/memory/incognito.test.ts
+++ b/services/bot-client/src/commands/memory/incognito.test.ts
@@ -31,14 +31,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 // Mock userGatewayClient
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Mock commandHelpers - embeds return empty objects for test simplicity
 const mockCreateSuccessEmbed = vi.fn(() => ({ type: 'success' }));
@@ -75,7 +76,7 @@ describe('Memory Incognito Handlers', () => {
     timeframe?: string;
   }) {
     return {
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       interaction: {
         options: {
           getString: (name: string, _required?: boolean) => {

--- a/services/bot-client/src/commands/memory/incognito.test.ts
+++ b/services/bot-client/src/commands/memory/incognito.test.ts
@@ -33,6 +33,11 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock commandHelpers - embeds return empty objects for test simplicity
@@ -93,7 +98,11 @@ describe('Memory Incognito Handlers', () => {
         ok: true,
         data: {
           session: {
-            userId: '123456789',
+            user: {
+              discordId: '123456789',
+              username: 'testuser',
+              displayName: 'testuser',
+            },
             personalityId: 'personality-uuid-123',
             enabledAt: '2026-01-15T12:00:00Z',
             expiresAt: '2026-01-15T13:00:00Z',
@@ -109,7 +118,11 @@ describe('Memory Incognito Handlers', () => {
       await handleIncognitoEnable(context);
 
       expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/memory/incognito', {
-        userId: '123456789',
+        user: {
+          discordId: '123456789',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         method: 'POST',
         body: { personalityId: 'personality-uuid-123', duration: '1h' },
       });
@@ -126,7 +139,11 @@ describe('Memory Incognito Handlers', () => {
         ok: true,
         data: {
           session: {
-            userId: '123456789',
+            user: {
+              discordId: '123456789',
+              username: 'testuser',
+              displayName: 'testuser',
+            },
             personalityId: 'all',
             enabledAt: '2026-01-15T12:00:00Z',
             expiresAt: null,
@@ -143,7 +160,11 @@ describe('Memory Incognito Handlers', () => {
 
       expect(mockResolvePersonalityId).not.toHaveBeenCalled();
       expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/memory/incognito', {
-        userId: '123456789',
+        user: {
+          discordId: '123456789',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         method: 'POST',
         body: { personalityId: 'all', duration: 'forever' },
       });
@@ -157,7 +178,11 @@ describe('Memory Incognito Handlers', () => {
         ok: true,
         data: {
           session: {
-            userId: '123456789',
+            user: {
+              discordId: '123456789',
+              username: 'testuser',
+              displayName: 'testuser',
+            },
             personalityId: 'personality-uuid-123',
             enabledAt: '2026-01-15T11:00:00Z',
             expiresAt: '2026-01-15T12:00:00Z',
@@ -236,7 +261,11 @@ describe('Memory Incognito Handlers', () => {
       await handleIncognitoDisable(context);
 
       expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/memory/incognito', {
-        userId: '123456789',
+        user: {
+          discordId: '123456789',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         method: 'DELETE',
         body: { personalityId: 'personality-uuid-123' },
       });
@@ -260,7 +289,11 @@ describe('Memory Incognito Handlers', () => {
 
       expect(mockResolvePersonalityId).not.toHaveBeenCalled();
       expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/memory/incognito', {
-        userId: '123456789',
+        user: {
+          discordId: '123456789',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         method: 'DELETE',
         body: { personalityId: 'all' },
       });
@@ -353,7 +386,11 @@ describe('Memory Incognito Handlers', () => {
           active: true,
           sessions: [
             {
-              userId: '123456789',
+              user: {
+                discordId: '123456789',
+                username: 'testuser',
+                displayName: 'testuser',
+              },
               personalityId: 'personality-uuid-123',
               enabledAt: '2026-01-15T11:00:00Z',
               expiresAt: '2026-01-15T13:00:00Z',
@@ -381,7 +418,11 @@ describe('Memory Incognito Handlers', () => {
           active: true,
           sessions: [
             {
-              userId: '123456789',
+              user: {
+                discordId: '123456789',
+                username: 'testuser',
+                displayName: 'testuser',
+              },
               personalityId: 'personality-uuid-1',
               enabledAt: '2026-01-15T11:00:00Z',
               expiresAt: '2026-01-15T13:00:00Z',
@@ -389,7 +430,11 @@ describe('Memory Incognito Handlers', () => {
               timeRemaining: '1h remaining',
             },
             {
-              userId: '123456789',
+              user: {
+                discordId: '123456789',
+                username: 'testuser',
+                displayName: 'testuser',
+              },
               personalityId: 'personality-uuid-2',
               enabledAt: '2026-01-15T11:30:00Z',
               expiresAt: '2026-01-15T15:30:00Z',
@@ -414,7 +459,11 @@ describe('Memory Incognito Handlers', () => {
           active: true,
           sessions: [
             {
-              userId: '123456789',
+              user: {
+                discordId: '123456789',
+                username: 'testuser',
+                displayName: 'testuser',
+              },
               personalityId: 'all',
               enabledAt: '2026-01-15T11:00:00Z',
               expiresAt: null,
@@ -481,7 +530,11 @@ describe('Memory Incognito Handlers', () => {
       await handleIncognitoForget(context);
 
       expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/memory/incognito/forget', {
-        userId: '123456789',
+        user: {
+          discordId: '123456789',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         method: 'POST',
         body: { personalityId: 'personality-uuid-123', timeframe: '15m' },
       });
@@ -506,7 +559,11 @@ describe('Memory Incognito Handlers', () => {
 
       expect(mockResolvePersonalityId).not.toHaveBeenCalled();
       expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/memory/incognito/forget', {
-        userId: '123456789',
+        user: {
+          discordId: '123456789',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         method: 'POST',
         body: { personalityId: 'all', timeframe: '1h' },
       });

--- a/services/bot-client/src/commands/memory/incognito.ts
+++ b/services/bot-client/src/commands/memory/incognito.ts
@@ -21,7 +21,7 @@ import {
   type IncognitoDuration,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser, type GatewayUser } from '../../utils/userGatewayClient.js';
 import {
   createSuccessEmbed,
   createInfoEmbed,
@@ -76,19 +76,19 @@ function formatSessionInfo(session: SessionWithTime, personalityName?: string): 
  * @returns { id: personality UUID or 'all', name: display name or null }
  */
 async function resolvePersonalityOrAll(
-  userId: string,
+  user: GatewayUser,
   personalityInput: string
 ): Promise<{ id: string; name: string | null } | null> {
   if (personalityInput.toLowerCase() === 'all') {
     return { id: 'all', name: ALL_PERSONALITIES_LABEL };
   }
 
-  const personalityId = await resolvePersonalityId(userId, personalityInput);
+  const personalityId = await resolvePersonalityId(user, personalityInput);
   if (personalityId === null) {
     return null;
   }
 
-  const name = await getPersonalityName(userId, personalityId);
+  const name = await getPersonalityName(user, personalityId);
   return { id: personalityId, name };
 }
 
@@ -97,12 +97,13 @@ async function resolvePersonalityOrAll(
  */
 export async function handleIncognitoEnable(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
+  const user = toGatewayUser(context.user);
   const options = memoryIncognitoEnableOptions(context.interaction);
   const personalityInput = options.personality();
   const duration = options.duration() as IncognitoDuration;
 
   try {
-    const resolved = await resolvePersonalityOrAll(userId, personalityInput);
+    const resolved = await resolvePersonalityOrAll(user, personalityInput);
 
     if (resolved === null) {
       await context.editReply({
@@ -112,7 +113,7 @@ export async function handleIncognitoEnable(context: DeferredCommandContext): Pr
     }
 
     const result = await callGatewayApi<IncognitoEnableResponse>(INCOGNITO_API_PATH, {
-      userId,
+      user,
       method: 'POST',
       body: { personalityId: resolved.id, duration },
     });
@@ -155,11 +156,12 @@ export async function handleIncognitoEnable(context: DeferredCommandContext): Pr
  */
 export async function handleIncognitoDisable(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
+  const user = toGatewayUser(context.user);
   const options = memoryIncognitoDisableOptions(context.interaction);
   const personalityInput = options.personality();
 
   try {
-    const resolved = await resolvePersonalityOrAll(userId, personalityInput);
+    const resolved = await resolvePersonalityOrAll(user, personalityInput);
 
     if (resolved === null) {
       await context.editReply({
@@ -169,7 +171,7 @@ export async function handleIncognitoDisable(context: DeferredCommandContext): P
     }
 
     const result = await callGatewayApi<IncognitoDisableResponse>(INCOGNITO_API_PATH, {
-      userId,
+      user,
       method: 'DELETE',
       body: { personalityId: resolved.id },
     });
@@ -214,10 +216,11 @@ export async function handleIncognitoDisable(context: DeferredCommandContext): P
  */
 export async function handleIncognitoStatus(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
+  const user = toGatewayUser(context.user);
 
   try {
     const result = await callGatewayApi<IncognitoStatusResponse>(INCOGNITO_API_PATH, {
-      userId,
+      user,
       method: 'GET',
     });
 
@@ -246,7 +249,7 @@ export async function handleIncognitoStatus(context: DeferredCommandContext): Pr
         if (session.personalityId === 'all') {
           return formatSessionInfo(session, ALL_PERSONALITIES_LABEL);
         }
-        const name = await getPersonalityName(userId, session.personalityId);
+        const name = await getPersonalityName(user, session.personalityId);
         return formatSessionInfo(session, name ?? session.personalityId);
       })
     );
@@ -273,12 +276,13 @@ export async function handleIncognitoStatus(context: DeferredCommandContext): Pr
  */
 export async function handleIncognitoForget(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
+  const user = toGatewayUser(context.user);
   const options = memoryIncognitoForgetOptions(context.interaction);
   const personalityInput = options.personality();
   const timeframe = options.timeframe();
 
   try {
-    const resolved = await resolvePersonalityOrAll(userId, personalityInput);
+    const resolved = await resolvePersonalityOrAll(user, personalityInput);
 
     if (resolved === null) {
       await context.editReply({
@@ -288,7 +292,7 @@ export async function handleIncognitoForget(context: DeferredCommandContext): Pr
     }
 
     const result = await callGatewayApi<IncognitoForgetResponse>('/user/memory/incognito/forget', {
-      userId,
+      user,
       method: 'POST',
       body: { personalityId: resolved.id, timeframe },
     });

--- a/services/bot-client/src/commands/memory/purge.test.ts
+++ b/services/bot-client/src/commands/memory/purge.test.ts
@@ -28,14 +28,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 // Mock userGatewayClient
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Mock commandHelpers
 const mockReplyWithError = vi.fn();

--- a/services/bot-client/src/commands/memory/purge.test.ts
+++ b/services/bot-client/src/commands/memory/purge.test.ts
@@ -30,6 +30,11 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock commandHelpers
@@ -65,7 +70,7 @@ describe('handlePurge', () => {
 
   function createMockContext(personality = 'lilith') {
     return {
-      user: { id: 'user-123' },
+      user: { id: 'user-123', username: 'testuser', globalName: 'testuser' },
       interaction: {
         options: {
           getString: (name: string, _required?: boolean) => {
@@ -149,7 +154,10 @@ describe('handlePurge', () => {
       const context = createMockContext('lilith');
       await handlePurge(context);
 
-      expect(mockResolvePersonalityId).toHaveBeenCalledWith('user-123', 'lilith');
+      expect(mockResolvePersonalityId).toHaveBeenCalledWith(
+        { discordId: 'user-123', username: 'testuser', displayName: 'testuser' },
+        'lilith'
+      );
     });
   });
 

--- a/services/bot-client/src/commands/memory/purge.ts
+++ b/services/bot-client/src/commands/memory/purge.ts
@@ -18,7 +18,7 @@ import {
 } from 'discord.js';
 import { createLogger, memoryPurgeOptions } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
 import { createDangerEmbed, createSuccessEmbed } from '../../utils/commandHelpers.js';
 import { resolveRequiredPersonality } from './resolveHelpers.js';
 
@@ -63,12 +63,13 @@ function getConfirmationPhrase(personalityName: string): string {
 // eslint-disable-next-line max-lines-per-function, max-statements -- Discord command handler with multi-step confirmation flow
 export async function handlePurge(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
+  const user = toGatewayUser(context.user);
   const options = memoryPurgeOptions(context.interaction);
   const personalityInput = options.personality();
 
   try {
     // Resolve personality slug to ID
-    const personalityId = await resolveRequiredPersonality(context, userId, personalityInput);
+    const personalityId = await resolveRequiredPersonality(context, user, personalityInput);
     if (personalityId === null) {
       return;
     }
@@ -77,7 +78,7 @@ export async function handlePurge(context: DeferredCommandContext): Promise<void
     const statsResult = await callGatewayApi<StatsResponse>(
       `/user/memory/stats?personalityId=${personalityId}`,
       {
-        userId,
+        user,
         method: 'GET',
       }
     );
@@ -222,7 +223,7 @@ export async function handlePurge(context: DeferredCommandContext): Promise<void
     await modalInteraction.deferUpdate();
 
     const purgeResult = await callGatewayApi<PurgeResponse>('/user/memory/purge', {
-      userId,
+      user,
       method: 'POST',
       body: {
         personalityId,

--- a/services/bot-client/src/commands/memory/resolveHelpers.test.ts
+++ b/services/bot-client/src/commands/memory/resolveHelpers.test.ts
@@ -5,6 +5,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { resolveOptionalPersonality, resolveRequiredPersonality } from './resolveHelpers.js';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
+import type { GatewayUser } from '../../utils/userGatewayClient.js';
+
+function mkUser(discordId = 'user-123'): GatewayUser {
+  return { discordId, username: 'test-user', displayName: 'Test User' };
+}
 
 // Mock the autocomplete module
 vi.mock('./autocomplete.js', () => ({
@@ -36,13 +41,13 @@ describe('resolveOptionalPersonality', () => {
   });
 
   it('should return undefined when personalityInput is null', async () => {
-    const result = await resolveOptionalPersonality(context, 'user-123', null);
+    const result = await resolveOptionalPersonality(context, mkUser(), null);
     expect(result).toBeUndefined();
     expect(mockResolvePersonalityId).not.toHaveBeenCalled();
   });
 
   it('should return undefined when personalityInput is empty string', async () => {
-    const result = await resolveOptionalPersonality(context, 'user-123', '');
+    const result = await resolveOptionalPersonality(context, mkUser(), '');
     expect(result).toBeUndefined();
     expect(mockResolvePersonalityId).not.toHaveBeenCalled();
   });
@@ -50,15 +55,16 @@ describe('resolveOptionalPersonality', () => {
   it('should return resolved ID when personality is found', async () => {
     mockResolvePersonalityId.mockResolvedValue('personality-uuid');
 
-    const result = await resolveOptionalPersonality(context, 'user-123', 'my-persona');
+    const user = mkUser();
+    const result = await resolveOptionalPersonality(context, user, 'my-persona');
     expect(result).toBe('personality-uuid');
-    expect(mockResolvePersonalityId).toHaveBeenCalledWith('user-123', 'my-persona');
+    expect(mockResolvePersonalityId).toHaveBeenCalledWith(user, 'my-persona');
   });
 
   it('should return null and send error reply when personality is not found', async () => {
     mockResolvePersonalityId.mockResolvedValue(null);
 
-    const result = await resolveOptionalPersonality(context, 'user-123', 'unknown');
+    const result = await resolveOptionalPersonality(context, mkUser(), 'unknown');
     expect(result).toBeNull();
     expect(mockEditReply).toHaveBeenCalledWith({
       content:
@@ -82,15 +88,16 @@ describe('resolveRequiredPersonality', () => {
   it('should return resolved ID when personality is found', async () => {
     mockResolvePersonalityId.mockResolvedValue('personality-uuid');
 
-    const result = await resolveRequiredPersonality(context, 'user-123', 'my-persona');
+    const user = mkUser();
+    const result = await resolveRequiredPersonality(context, user, 'my-persona');
     expect(result).toBe('personality-uuid');
-    expect(mockResolvePersonalityId).toHaveBeenCalledWith('user-123', 'my-persona');
+    expect(mockResolvePersonalityId).toHaveBeenCalledWith(user, 'my-persona');
   });
 
   it('should return null and send error reply when personality is not found', async () => {
     mockResolvePersonalityId.mockResolvedValue(null);
 
-    const result = await resolveRequiredPersonality(context, 'user-123', 'unknown');
+    const result = await resolveRequiredPersonality(context, mkUser(), 'unknown');
     expect(result).toBeNull();
     expect(mockEditReply).toHaveBeenCalledWith({
       content:
@@ -101,7 +108,7 @@ describe('resolveRequiredPersonality', () => {
   it('should not send error reply on success', async () => {
     mockResolvePersonalityId.mockResolvedValue('personality-uuid');
 
-    await resolveRequiredPersonality(context, 'user-123', 'my-persona');
+    await resolveRequiredPersonality(context, mkUser(), 'my-persona');
     expect(mockEditReply).not.toHaveBeenCalled();
   });
 });

--- a/services/bot-client/src/commands/memory/resolveHelpers.ts
+++ b/services/bot-client/src/commands/memory/resolveHelpers.ts
@@ -6,6 +6,7 @@
  */
 
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
+import { type GatewayUser } from '../../utils/userGatewayClient.js';
 import { resolvePersonalityId } from './autocomplete.js';
 
 /**
@@ -28,14 +29,14 @@ import { resolvePersonalityId } from './autocomplete.js';
  */
 export async function resolveOptionalPersonality(
   context: DeferredCommandContext,
-  userId: string,
+  user: GatewayUser,
   personalityInput: string | null
 ): Promise<string | undefined | null> {
   if (personalityInput === null || personalityInput.length === 0) {
     return undefined;
   }
 
-  const resolved = await resolvePersonalityId(userId, personalityInput);
+  const resolved = await resolvePersonalityId(user, personalityInput);
   if (resolved === null) {
     await context.editReply({
       content: `❌ Personality "${personalityInput}" not found. Use autocomplete to select a valid personality.`,
@@ -59,10 +60,10 @@ export async function resolveOptionalPersonality(
  */
 export async function resolveRequiredPersonality(
   context: DeferredCommandContext,
-  userId: string,
+  user: GatewayUser,
   personalityInput: string
 ): Promise<string | null> {
-  const resolved = await resolvePersonalityId(userId, personalityInput);
+  const resolved = await resolvePersonalityId(user, personalityInput);
   if (resolved === null) {
     await context.editReply({
       content: `❌ Personality "${personalityInput}" not found. Use autocomplete to select a valid personality.`,

--- a/services/bot-client/src/commands/memory/search.test.ts
+++ b/services/bot-client/src/commands/memory/search.test.ts
@@ -52,6 +52,11 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 vi.mock('./resolveHelpers.js', () => ({

--- a/services/bot-client/src/commands/memory/search.test.ts
+++ b/services/bot-client/src/commands/memory/search.test.ts
@@ -50,14 +50,15 @@ vi.mock('@tzurot/common-types', async () => {
   };
 });
 
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 vi.mock('./resolveHelpers.js', () => ({
   resolveOptionalPersonality: (...args: unknown[]) => mockResolveOptionalPersonality(...args),

--- a/services/bot-client/src/commands/memory/search.ts
+++ b/services/bot-client/src/commands/memory/search.ts
@@ -26,7 +26,7 @@ import {
   formatDateShort,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser, type GatewayUser } from '../../utils/userGatewayClient.js';
 import {
   createBrowseCustomIdHelpers,
   buildBrowseButtons as buildSharedBrowseButtons,
@@ -224,7 +224,7 @@ function buildSearchView(opts: {
 }
 
 interface FetchSearchOptions {
-  userId: string;
+  user: GatewayUser;
   query: string;
   personalityId?: string;
   offset: number;
@@ -237,7 +237,7 @@ interface FetchSearchOptions {
  * Fetch search results from API
  */
 async function fetchSearchResults(options: FetchSearchOptions): Promise<SearchResponse | null> {
-  const { userId, query, personalityId, offset, limit, preferTextSearch } = options;
+  const { user, query, personalityId, offset, limit, preferTextSearch } = options;
 
   const requestBody: Record<string, unknown> = {
     query,
@@ -255,7 +255,7 @@ async function fetchSearchResults(options: FetchSearchOptions): Promise<SearchRe
   }
 
   const result = await callGatewayApi<SearchResponse>('/user/memory/search', {
-    userId,
+    user,
     method: 'POST',
     body: requestBody,
   });
@@ -272,6 +272,7 @@ async function fetchSearchResults(options: FetchSearchOptions): Promise<SearchRe
  */
 export async function handleSearch(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
+  const user = toGatewayUser(context.user);
   const options = memorySearchOptions(context.interaction);
   const query = options.query();
   const personalityInput = options.personality();
@@ -284,14 +285,14 @@ export async function handleSearch(context: DeferredCommandContext): Promise<voi
     // Resolve personality if provided. Contract: null means the helper
     // already sent an error reply via editReply, so we must return early
     // without sending another reply (Discord would reject the double-reply).
-    const personalityId = await resolveOptionalPersonality(context, userId, personalityInput);
+    const personalityId = await resolveOptionalPersonality(context, user, personalityInput);
     if (personalityId === null) {
       return;
     }
 
     // Fetch first page
     const data = await fetchSearchResults({
-      userId,
+      user,
       query,
       personalityId,
       offset: 0,
@@ -399,7 +400,7 @@ export async function handleSearchPagination(interaction: ButtonInteraction): Pr
   const newPage = parsed.page;
 
   const data = await fetchSearchResults({
-    userId,
+    user: toGatewayUser(interaction.user),
     query: searchQuery,
     personalityId,
     offset: newPage * pageSize,
@@ -471,12 +472,13 @@ export async function refreshSearchList(interaction: ButtonInteraction): Promise
   const { personalityId, searchQuery, pageSize, searchType } = session.data;
 
   const userId = interaction.user.id;
+  const user = toGatewayUser(interaction.user);
 
   const result = await fetchPageWithEmptyFallback({
     currentPage: session.data.currentPage,
     fetchPage: page =>
       fetchSearchResults({
-        userId,
+        user,
         query: searchQuery,
         personalityId,
         offset: page * pageSize,

--- a/services/bot-client/src/commands/memory/stats.test.ts
+++ b/services/bot-client/src/commands/memory/stats.test.ts
@@ -23,6 +23,11 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock commandHelpers
@@ -49,7 +54,7 @@ describe('handleStats', () => {
 
   function createMockContext(personalitySlug: string = 'lilith') {
     return {
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser', globalName: 'testuser' },
       interaction: {
         options: {
           getString: (name: string, _required?: boolean) => {
@@ -81,10 +86,16 @@ describe('handleStats', () => {
     const context = createMockContext();
     await handleStats(context);
 
-    expect(mockResolvePersonalityId).toHaveBeenCalledWith('123456789', 'lilith');
+    expect(mockResolvePersonalityId).toHaveBeenCalledWith(
+      { discordId: '123456789', username: 'testuser', displayName: 'testuser' },
+      'lilith'
+    );
     expect(mockCallGatewayApi).toHaveBeenCalledWith(
       '/user/memory/stats?personalityId=personality-uuid-123',
-      { userId: '123456789', method: 'GET' }
+      {
+        user: { discordId: '123456789', username: 'testuser', displayName: 'testuser' },
+        method: 'GET',
+      }
     );
     expect(mockCreateInfoEmbed).toHaveBeenCalledWith(
       'Memory Statistics',

--- a/services/bot-client/src/commands/memory/stats.test.ts
+++ b/services/bot-client/src/commands/memory/stats.test.ts
@@ -21,14 +21,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 // Mock userGatewayClient
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Mock commandHelpers
 const mockCreateInfoEmbed = vi.fn(() => ({

--- a/services/bot-client/src/commands/memory/stats.ts
+++ b/services/bot-client/src/commands/memory/stats.ts
@@ -6,7 +6,7 @@
 import { escapeMarkdown } from 'discord.js';
 import { createLogger, memoryStatsOptions, formatDateTimeCompact } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
 import { createInfoEmbed } from '../../utils/commandHelpers.js';
 import { resolveRequiredPersonality } from './resolveHelpers.js';
 
@@ -33,12 +33,13 @@ function formatDateOrNA(dateStr: string | null): string {
  */
 export async function handleStats(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
+  const user = toGatewayUser(context.user);
   const options = memoryStatsOptions(context.interaction);
   const personalityInput = options.personality();
 
   try {
     // Resolve personality slug to ID
-    const personalityId = await resolveRequiredPersonality(context, userId, personalityInput);
+    const personalityId = await resolveRequiredPersonality(context, user, personalityInput);
     if (personalityId === null) {
       return;
     }
@@ -46,7 +47,7 @@ export async function handleStats(context: DeferredCommandContext): Promise<void
     const result = await callGatewayApi<StatsResponse>(
       `/user/memory/stats?personalityId=${personalityId}`,
       {
-        userId,
+        user,
         method: 'GET',
       }
     );

--- a/services/bot-client/src/commands/persona/api.test.ts
+++ b/services/bot-client/src/commands/persona/api.test.ts
@@ -17,6 +17,7 @@ import { mockGetPersonaResponse, mockListPersonasResponse } from '@tzurot/common
 const TEST_PERSONA_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
 const OTHER_PERSONA_ID = 'b2c3d4e5-f6a7-8901-bcde-f12345678901';
 const TEST_USER_ID = '123456789';
+const TEST_USER = { discordId: TEST_USER_ID, username: 'testuser', displayName: 'testuser' };
 
 // Mock gateway client
 // Note: Tests use objectContaining for API call assertions to focus on the essential
@@ -25,6 +26,11 @@ const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
   GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 vi.mock('@tzurot/common-types', async () => {
@@ -53,11 +59,11 @@ describe('fetchPersona', () => {
       }),
     });
 
-    const result = await fetchPersona(TEST_PERSONA_ID, TEST_USER_ID);
+    const result = await fetchPersona(TEST_PERSONA_ID, TEST_USER);
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith(
       `/user/persona/${TEST_PERSONA_ID}`,
-      expect.objectContaining({ userId: TEST_USER_ID })
+      expect.objectContaining({ user: expect.objectContaining({ discordId: TEST_USER_ID }) })
     );
     expect(result).not.toBeNull();
     expect(result?.name).toBe('Test Persona');
@@ -69,7 +75,7 @@ describe('fetchPersona', () => {
       error: 'Persona not found',
     });
 
-    const result = await fetchPersona(TEST_PERSONA_ID, TEST_USER_ID);
+    const result = await fetchPersona(TEST_PERSONA_ID, TEST_USER);
 
     expect(result).toBeNull();
   });
@@ -97,11 +103,11 @@ describe('fetchDefaultPersona', () => {
       }),
     });
 
-    const result = await fetchDefaultPersona(TEST_USER_ID);
+    const result = await fetchDefaultPersona(TEST_USER);
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith(
       '/user/persona',
-      expect.objectContaining({ userId: TEST_USER_ID })
+      expect.objectContaining({ user: expect.objectContaining({ discordId: TEST_USER_ID }) })
     );
     expect(result).not.toBeNull();
     expect(result?.name).toBe('Default');
@@ -113,7 +119,7 @@ describe('fetchDefaultPersona', () => {
       data: mockListPersonasResponse([{ id: TEST_PERSONA_ID, name: 'Test', isDefault: false }]),
     });
 
-    const result = await fetchDefaultPersona(TEST_USER_ID);
+    const result = await fetchDefaultPersona(TEST_USER);
 
     expect(result).toBeNull();
   });
@@ -124,7 +130,7 @@ describe('fetchDefaultPersona', () => {
       error: 'Failed to fetch',
     });
 
-    const result = await fetchDefaultPersona(TEST_USER_ID);
+    const result = await fetchDefaultPersona(TEST_USER);
 
     expect(result).toBeNull();
   });
@@ -154,14 +160,14 @@ describe('updatePersona', () => {
     const result = await updatePersona(
       TEST_PERSONA_ID,
       { name: 'Updated Name', preferredName: 'Tester' },
-      TEST_USER_ID
+      TEST_USER
     );
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith(
       `/user/persona/${TEST_PERSONA_ID}`,
       expect.objectContaining({
         method: 'PUT',
-        userId: TEST_USER_ID,
+        user: expect.objectContaining({ discordId: TEST_USER_ID }),
         body: { name: 'Updated Name', preferredName: 'Tester' },
       })
     );
@@ -175,7 +181,7 @@ describe('updatePersona', () => {
       error: 'Update failed',
     });
 
-    const result = await updatePersona(TEST_PERSONA_ID, { name: 'Test' }, TEST_USER_ID);
+    const result = await updatePersona(TEST_PERSONA_ID, { name: 'Test' }, TEST_USER);
 
     expect(result).toBeNull();
   });
@@ -192,13 +198,13 @@ describe('deletePersona', () => {
       data: { message: 'Persona deleted' },
     });
 
-    const result = await deletePersona(TEST_PERSONA_ID, TEST_USER_ID);
+    const result = await deletePersona(TEST_PERSONA_ID, TEST_USER);
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith(
       `/user/persona/${TEST_PERSONA_ID}`,
       expect.objectContaining({
         method: 'DELETE',
-        userId: TEST_USER_ID,
+        user: expect.objectContaining({ discordId: TEST_USER_ID }),
       })
     );
     expect(result.success).toBe(true);
@@ -211,7 +217,7 @@ describe('deletePersona', () => {
       error: 'Cannot delete default persona',
     });
 
-    const result = await deletePersona(TEST_PERSONA_ID, TEST_USER_ID);
+    const result = await deletePersona(TEST_PERSONA_ID, TEST_USER);
 
     expect(result.success).toBe(false);
     expect(result.error).toBe('Cannot delete default persona');
@@ -232,7 +238,7 @@ describe('isDefaultPersona', () => {
       ]),
     });
 
-    const result = await isDefaultPersona(TEST_PERSONA_ID, TEST_USER_ID);
+    const result = await isDefaultPersona(TEST_PERSONA_ID, TEST_USER);
 
     expect(result).toBe(true);
   });
@@ -243,7 +249,7 @@ describe('isDefaultPersona', () => {
       data: mockListPersonasResponse([{ id: TEST_PERSONA_ID, name: 'Test', isDefault: false }]),
     });
 
-    const result = await isDefaultPersona(TEST_PERSONA_ID, TEST_USER_ID);
+    const result = await isDefaultPersona(TEST_PERSONA_ID, TEST_USER);
 
     expect(result).toBe(false);
   });
@@ -254,7 +260,7 @@ describe('isDefaultPersona', () => {
       data: mockListPersonasResponse([{ id: OTHER_PERSONA_ID, name: 'Other', isDefault: true }]),
     });
 
-    const result = await isDefaultPersona(TEST_PERSONA_ID, TEST_USER_ID);
+    const result = await isDefaultPersona(TEST_PERSONA_ID, TEST_USER);
 
     expect(result).toBe(false);
   });
@@ -265,7 +271,7 @@ describe('isDefaultPersona', () => {
       error: 'Failed',
     });
 
-    const result = await isDefaultPersona(TEST_PERSONA_ID, TEST_USER_ID);
+    const result = await isDefaultPersona(TEST_PERSONA_ID, TEST_USER);
 
     expect(result).toBe(false);
   });

--- a/services/bot-client/src/commands/persona/api.test.ts
+++ b/services/bot-client/src/commands/persona/api.test.ts
@@ -23,15 +23,15 @@ const TEST_USER = { discordId: TEST_USER_ID, username: 'testuser', displayName: 
 // Note: Tests use objectContaining for API call assertions to focus on the essential
 // userId parameter while ignoring implementation details like timeout values.
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 vi.mock('@tzurot/common-types', async () => {
   const actual = await vi.importActual('@tzurot/common-types');

--- a/services/bot-client/src/commands/persona/api.ts
+++ b/services/bot-client/src/commands/persona/api.ts
@@ -5,7 +5,11 @@
  */
 
 import { createLogger, type ListPersonasResponse } from '@tzurot/common-types';
-import { callGatewayApi, GATEWAY_TIMEOUTS } from '../../utils/userGatewayClient.js';
+import {
+  callGatewayApi,
+  GATEWAY_TIMEOUTS,
+  type GatewayUser,
+} from '../../utils/userGatewayClient.js';
 import type { PersonaDetails, PersonaSummary, SavePersonaResponse } from './types.js';
 
 const logger = createLogger('persona-api');
@@ -15,15 +19,18 @@ const logger = createLogger('persona-api');
  */
 export async function fetchPersona(
   personaId: string,
-  userId: string
+  user: GatewayUser
 ): Promise<PersonaDetails | null> {
   const result = await callGatewayApi<{ persona: PersonaDetails }>(`/user/persona/${personaId}`, {
-    userId,
+    user,
     timeout: GATEWAY_TIMEOUTS.DEFERRED,
   });
 
   if (!result.ok) {
-    logger.warn({ userId, personaId, error: result.error }, 'Failed to fetch persona');
+    logger.warn(
+      { userId: user.discordId, personaId, error: result.error },
+      'Failed to fetch persona'
+    );
     return null;
   }
 
@@ -33,11 +40,17 @@ export async function fetchPersona(
 /**
  * Fetch the user's default persona
  */
-export async function fetchDefaultPersona(userId: string): Promise<PersonaDetails | null> {
-  const listResult = await callGatewayApi<ListPersonasResponse>('/user/persona', { userId, timeout: GATEWAY_TIMEOUTS.DEFERRED });
+export async function fetchDefaultPersona(user: GatewayUser): Promise<PersonaDetails | null> {
+  const listResult = await callGatewayApi<ListPersonasResponse>('/user/persona', {
+    user,
+    timeout: GATEWAY_TIMEOUTS.DEFERRED,
+  });
 
   if (!listResult.ok) {
-    logger.warn({ userId, error: listResult.error }, 'Failed to fetch persona list');
+    logger.warn(
+      { userId: user.discordId, error: listResult.error },
+      'Failed to fetch persona list'
+    );
     return null;
   }
 
@@ -46,7 +59,7 @@ export async function fetchDefaultPersona(userId: string): Promise<PersonaDetail
     return null;
   }
 
-  return fetchPersona(defaultPersona.id, userId);
+  return fetchPersona(defaultPersona.id, user);
 }
 
 /**
@@ -55,17 +68,20 @@ export async function fetchDefaultPersona(userId: string): Promise<PersonaDetail
 export async function updatePersona(
   personaId: string,
   data: Record<string, unknown>,
-  userId: string
+  user: GatewayUser
 ): Promise<PersonaDetails | null> {
   const result = await callGatewayApi<SavePersonaResponse>(`/user/persona/${personaId}`, {
     method: 'PUT',
-    userId,
+    user,
     body: data,
     timeout: GATEWAY_TIMEOUTS.DEFERRED,
   });
 
   if (!result.ok) {
-    logger.warn({ userId, personaId, error: result.error }, 'Failed to update persona');
+    logger.warn(
+      { userId: user.discordId, personaId, error: result.error },
+      'Failed to update persona'
+    );
     return null;
   }
 
@@ -77,16 +93,19 @@ export async function updatePersona(
  */
 export async function deletePersona(
   personaId: string,
-  userId: string
+  user: GatewayUser
 ): Promise<{ success: boolean; error?: string }> {
   const result = await callGatewayApi<{ message: string }>(`/user/persona/${personaId}`, {
     method: 'DELETE',
-    userId,
+    user,
     timeout: GATEWAY_TIMEOUTS.DEFERRED,
   });
 
   if (!result.ok) {
-    logger.warn({ userId, personaId, error: result.error }, 'Failed to delete persona');
+    logger.warn(
+      { userId: user.discordId, personaId, error: result.error },
+      'Failed to delete persona'
+    );
     return { success: false, error: result.error };
   }
 
@@ -96,8 +115,11 @@ export async function deletePersona(
 /**
  * Check if a persona is the default persona
  */
-export async function isDefaultPersona(personaId: string, userId: string): Promise<boolean> {
-  const listResult = await callGatewayApi<ListPersonasResponse>('/user/persona', { userId, timeout: GATEWAY_TIMEOUTS.DEFERRED });
+export async function isDefaultPersona(personaId: string, user: GatewayUser): Promise<boolean> {
+  const listResult = await callGatewayApi<ListPersonasResponse>('/user/persona', {
+    user,
+    timeout: GATEWAY_TIMEOUTS.DEFERRED,
+  });
 
   if (!listResult.ok) {
     return false;

--- a/services/bot-client/src/commands/persona/browse.test.ts
+++ b/services/bot-client/src/commands/persona/browse.test.ts
@@ -25,6 +25,11 @@ const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
   GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock dashboard utilities
@@ -84,7 +89,9 @@ describe('handleBrowse', () => {
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith(
       '/user/persona',
-      expect.objectContaining({ userId: '123456789' })
+      expect.objectContaining({
+        user: { discordId: '123456789', username: 'testuser', displayName: 'testuser' },
+      })
     );
     expect(mockEditReply).toHaveBeenCalledWith({
       embeds: [expect.any(Object)],
@@ -159,7 +166,9 @@ describe('handleBrowsePagination', () => {
     expect(mockDeferUpdate).toHaveBeenCalled();
     expect(mockCallGatewayApi).toHaveBeenCalledWith(
       '/user/persona',
-      expect.objectContaining({ userId: '123456789' })
+      expect.objectContaining({
+        user: { discordId: '123456789', username: 'testuser', displayName: 'testuser' },
+      })
     );
     expect(mockEditReply).toHaveBeenCalled();
   });
@@ -215,7 +224,9 @@ describe('handleBrowseSelect', () => {
     expect(mockDeferUpdate).toHaveBeenCalled();
     expect(mockCallGatewayApi).toHaveBeenCalledWith(
       `/user/persona/${TEST_PERSONA_ID}`,
-      expect.objectContaining({ userId: '123456789' })
+      expect.objectContaining({
+        user: { discordId: '123456789', username: 'testuser', displayName: 'testuser' },
+      })
     );
     expect(mockBuildDashboardEmbed).toHaveBeenCalled();
     expect(mockSessionSet).toHaveBeenCalled();

--- a/services/bot-client/src/commands/persona/browse.test.ts
+++ b/services/bot-client/src/commands/persona/browse.test.ts
@@ -22,15 +22,15 @@ const TEST_PERSONA_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
 // Note: Tests use objectContaining for API call assertions to focus on the essential
 // userId parameter while ignoring implementation details like timeout values.
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Mock dashboard utilities
 const mockBuildDashboardEmbed = vi.fn();
@@ -71,7 +71,7 @@ describe('handleBrowse', () => {
 
   function createMockContext() {
     return {
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       editReply: mockEditReply,
     } as unknown as Parameters<typeof handleBrowse>[0];
   }
@@ -146,7 +146,7 @@ describe('handleBrowsePagination', () => {
   function createMockButtonInteraction(customId: string) {
     return {
       customId,
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       deferUpdate: mockDeferUpdate,
       editReply: mockEditReply,
     } as unknown as Parameters<typeof handleBrowsePagination>[0];
@@ -195,7 +195,7 @@ describe('handleBrowseSelect', () => {
     return {
       customId: 'persona::browse-select::0::all::name::',
       values: [personaId],
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       channelId: 'channel-123',
       message: { id: 'message-123' },
       deferUpdate: mockDeferUpdate,

--- a/services/bot-client/src/commands/persona/browse.ts
+++ b/services/bot-client/src/commands/persona/browse.ts
@@ -9,7 +9,12 @@ import { EmbedBuilder } from 'discord.js';
 import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
 import { createLogger, DISCORD_COLORS, type ListPersonasResponse } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi, GATEWAY_TIMEOUTS } from '../../utils/userGatewayClient.js';
+import {
+  callGatewayApi,
+  GATEWAY_TIMEOUTS,
+  toGatewayUser,
+  type GatewayUser,
+} from '../../utils/userGatewayClient.js';
 import {
   buildDashboardEmbed,
   buildDashboardComponents,
@@ -196,7 +201,7 @@ export async function handleBrowse(context: DeferredCommandContext): Promise<voi
   try {
     // Fetch user's personas via gateway API
     const result = await callGatewayApi<ListPersonasResponse>(PERSONA_LIST_ENDPOINT, {
-      userId,
+      user: toGatewayUser(context.user),
       timeout: GATEWAY_TIMEOUTS.DEFERRED,
     });
 
@@ -238,7 +243,7 @@ export async function handleBrowsePagination(interaction: ButtonInteraction): Pr
 
     // Fetch fresh data
     const result = await callGatewayApi<ListPersonasResponse>(PERSONA_LIST_ENDPOINT, {
-      userId,
+      user: toGatewayUser(interaction.user),
       timeout: GATEWAY_TIMEOUTS.DEFERRED,
     });
 
@@ -277,7 +282,7 @@ export async function handleBrowseSelect(interaction: StringSelectMenuInteractio
 
   try {
     // Fetch the persona with full data
-    const persona = await fetchPersona(personaId, userId);
+    const persona = await fetchPersona(personaId, toGatewayUser(interaction.user));
 
     if (!persona) {
       await interaction.editReply({
@@ -355,18 +360,18 @@ export function isPersonaBrowseSelectInteraction(customId: string): boolean {
  * Fetches personas and builds the embed/components for a given page/sort
  */
 export async function buildBrowseResponse(
-  userId: string,
+  user: GatewayUser,
   page: number,
   sort: BrowseSortType
 ): Promise<{ embed: EmbedBuilder; components: BrowseActionRow[] } | null> {
   const result = await callGatewayApi<ListPersonasResponse>(PERSONA_LIST_ENDPOINT, {
-    userId,
+    user,
     timeout: GATEWAY_TIMEOUTS.DEFERRED,
   });
 
   if (!result.ok) {
     logger.warn(
-      { userId, error: result.error },
+      { userId: user.discordId, error: result.error },
       '[Persona] Failed to fetch personas for back navigation'
     );
     return null;

--- a/services/bot-client/src/commands/persona/create.test.ts
+++ b/services/bot-client/src/commands/persona/create.test.ts
@@ -10,14 +10,15 @@ import { mockCreatePersonaResponse } from '@tzurot/common-types';
 
 // Mock gateway client
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 vi.mock('@tzurot/common-types', async () => {
   const actual = await vi.importActual('@tzurot/common-types');

--- a/services/bot-client/src/commands/persona/create.test.ts
+++ b/services/bot-client/src/commands/persona/create.test.ts
@@ -12,6 +12,11 @@ import { mockCreatePersonaResponse } from '@tzurot/common-types';
 const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 vi.mock('@tzurot/common-types', async () => {
@@ -106,7 +111,11 @@ describe('handleCreateModalSubmit', () => {
     );
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/persona', {
-      userId: '123456789',
+      user: {
+        discordId: '123456789',
+        username: 'testuser',
+        displayName: 'testuser',
+      },
       method: 'POST',
       body: {
         name: 'Work Persona',
@@ -198,7 +207,11 @@ describe('handleCreateModalSubmit', () => {
     );
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/persona', {
-      userId: '123456789',
+      user: {
+        discordId: '123456789',
+        username: 'testuser',
+        displayName: 'testuser',
+      },
       method: 'POST',
       body: {
         name: 'Minimal Persona',
@@ -237,7 +250,11 @@ describe('handleCreateModalSubmit', () => {
     );
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/persona', {
-      userId: '123456789',
+      user: {
+        discordId: '123456789',
+        username: 'testuser',
+        displayName: 'testuser',
+      },
       method: 'POST',
       body: {
         name: 'Work Persona',

--- a/services/bot-client/src/commands/persona/create.ts
+++ b/services/bot-client/src/commands/persona/create.ts
@@ -17,7 +17,7 @@ import { createLogger } from '@tzurot/common-types';
 import type { ModalCommandContext } from '../../utils/commandContext/types.js';
 import { buildPersonaModalFields } from './utils/modalBuilder.js';
 import { PersonaCustomIds } from '../../utils/customIds.js';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
 
 const logger = createLogger('persona-create');
 
@@ -86,7 +86,7 @@ export async function handleCreateModalSubmit(interaction: ModalSubmitInteractio
 
     // Create persona via gateway API
     const result = await callGatewayApi<CreatePersonaResponse>('/user/persona', {
-      userId: discordId,
+      user: toGatewayUser(interaction.user),
       method: 'POST',
       body: {
         name: personaName,

--- a/services/bot-client/src/commands/persona/dashboard.test.ts
+++ b/services/bot-client/src/commands/persona/dashboard.test.ts
@@ -20,15 +20,15 @@ const TEST_PERSONA_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
 
 // Mock gateway client
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Mock dashboard utilities
 const mockBuildDashboardEmbed = vi.fn();
@@ -271,7 +271,7 @@ describe('handleModalSubmit', () => {
   function createMockModalInteraction(customId: string, fields: Record<string, string> = {}) {
     return {
       customId,
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       fields: {
         getTextInputValue: (name: string) => fields[name] ?? '',
       },
@@ -371,7 +371,7 @@ describe('handleSelectMenu', () => {
     return {
       customId,
       values: [value],
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       message: { id: 'message-123' },
       channelId: 'channel-123',
       showModal: mockShowModal,
@@ -456,7 +456,7 @@ describe('handleButton', () => {
   function createMockButtonInteraction(customId: string) {
     return {
       customId,
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       message: { id: 'message-123' },
       channelId: 'channel-123',
       update: mockUpdate,

--- a/services/bot-client/src/commands/persona/dashboard.test.ts
+++ b/services/bot-client/src/commands/persona/dashboard.test.ts
@@ -23,6 +23,11 @@ const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
   GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock dashboard utilities
@@ -300,7 +305,11 @@ describe('handleModalSubmit', () => {
       `/user/persona/${TEST_PERSONA_ID}`,
       expect.objectContaining({
         method: 'PUT',
-        userId: '123456789',
+        user: {
+          discordId: '123456789',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
       })
     );
   });

--- a/services/bot-client/src/commands/persona/dashboard.ts
+++ b/services/bot-client/src/commands/persona/dashboard.ts
@@ -27,6 +27,7 @@ import {
   formatSessionExpiredMessage,
 } from '../../utils/dashboard/index.js';
 import { handleDashboardSectionSelect } from '../../utils/dashboard/genericSelectMenuHandler.js';
+import { toGatewayUser } from '../../utils/userGatewayClient.js';
 import {
   PERSONA_DASHBOARD_CONFIG,
   type FlattenedPersonaData,
@@ -105,7 +106,11 @@ async function handleSectionModalSubmit(
     const updatePayload = unflattenPersonaData(extracted.merged);
 
     // Update persona via API
-    const updatedPersona = await updatePersona(entityId, updatePayload, interaction.user.id);
+    const updatedPersona = await updatePersona(
+      entityId,
+      updatePayload,
+      toGatewayUser(interaction.user)
+    );
 
     if (!updatedPersona) {
       await interaction.followUp({
@@ -160,7 +165,7 @@ export async function handleSelectMenu(interaction: StringSelectMenuInteraction)
   await handleDashboardSectionSelect<FlattenedPersonaData, PersonaDetails>(interaction, {
     entityType: 'persona',
     dashboardConfig: PERSONA_DASHBOARD_CONFIG,
-    fetchFn: (entityId, userId) => fetchPersona(entityId, userId),
+    fetchFn: (entityId, user) => fetchPersona(entityId, user),
     transformFn: flattenPersonaData,
     entityName: 'Persona',
   });
@@ -195,7 +200,7 @@ async function handleDeleteButton(interaction: ButtonInteraction, entityId: stri
   }
 
   // Check if this is the default persona
-  const isDefault = await isDefaultPersona(entityId, interaction.user.id);
+  const isDefault = await isDefaultPersona(entityId, toGatewayUser(interaction.user));
   if (isDefault) {
     await interaction.reply({
       content:
@@ -236,7 +241,7 @@ async function handleConfirmDeleteButton(
 
   const personaName = session?.data.name ?? 'Persona';
 
-  const result = await deletePersona(entityId, interaction.user.id);
+  const result = await deletePersona(entityId, toGatewayUser(interaction.user));
 
   if (!result.success) {
     await interaction.editReply({
@@ -370,7 +375,7 @@ async function handleBackButton(interaction: ButtonInteraction, entityId: string
 
   try {
     const result = await buildBrowseResponse(
-      interaction.user.id,
+      toGatewayUser(interaction.user),
       browseContext.page,
       browseContext.sort as PersonaBrowseSortType
     );

--- a/services/bot-client/src/commands/persona/default.test.ts
+++ b/services/bot-client/src/commands/persona/default.test.ts
@@ -14,6 +14,11 @@ import { mockSetDefaultPersonaResponse } from '@tzurot/common-types';
 const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 vi.mock('@tzurot/common-types', async () => {
@@ -66,7 +71,11 @@ describe('handleSetDefaultPersona', () => {
     await handleSetDefaultPersona(createMockContext('persona-123'));
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/persona/persona-123/default', {
-      userId: '123456789',
+      user: {
+        discordId: '123456789',
+        username: 'testuser',
+        displayName: 'testuser',
+      },
       method: 'PATCH',
     });
     expect(mockEditReply).toHaveBeenCalledWith({

--- a/services/bot-client/src/commands/persona/default.test.ts
+++ b/services/bot-client/src/commands/persona/default.test.ts
@@ -12,14 +12,15 @@ import { mockSetDefaultPersonaResponse } from '@tzurot/common-types';
 
 // Mock gateway client
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 vi.mock('@tzurot/common-types', async () => {
   const actual = await vi.importActual('@tzurot/common-types');

--- a/services/bot-client/src/commands/persona/default.ts
+++ b/services/bot-client/src/commands/persona/default.ts
@@ -9,7 +9,7 @@
 
 import { createLogger, personaDefaultOptions } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
 
 const logger = createLogger('persona-default');
 
@@ -35,7 +35,7 @@ export async function handleSetDefaultPersona(context: DeferredCommandContext): 
   try {
     // Set default via gateway API
     const result = await callGatewayApi<SetDefaultResponse>(`/user/persona/${personaId}/default`, {
-      userId: discordId,
+      user: toGatewayUser(context.user),
       method: 'PATCH',
     });
 

--- a/services/bot-client/src/commands/persona/edit.test.ts
+++ b/services/bot-client/src/commands/persona/edit.test.ts
@@ -20,6 +20,11 @@ const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
   GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock dashboard utilities
@@ -85,7 +90,9 @@ describe('handleEditPersona', () => {
 
       expect(mockCallGatewayApi).toHaveBeenCalledWith(
         `/user/persona/${TEST_PERSONA_ID}`,
-        expect.objectContaining({ userId: '123456789' })
+        expect.objectContaining({
+          user: { discordId: '123456789', username: 'testuser', displayName: 'testuser' },
+        })
       );
       expect(mockBuildDashboardEmbed).toHaveBeenCalled();
       expect(mockBuildDashboardComponents).toHaveBeenCalled();
@@ -140,7 +147,9 @@ describe('handleEditPersona', () => {
 
       expect(mockCallGatewayApi).toHaveBeenCalledWith(
         '/user/persona',
-        expect.objectContaining({ userId: '123456789' })
+        expect.objectContaining({
+          user: { discordId: '123456789', username: 'testuser', displayName: 'testuser' },
+        })
       );
       expect(mockBuildDashboardEmbed).toHaveBeenCalled();
       expect(mockEditReply).toHaveBeenCalled();

--- a/services/bot-client/src/commands/persona/edit.test.ts
+++ b/services/bot-client/src/commands/persona/edit.test.ts
@@ -17,15 +17,15 @@ const DEFAULT_PERSONA_ID = 'b2c3d4e5-f6a7-8901-bcde-f12345678901';
 // Note: Tests use objectContaining for API call assertions to focus on the essential
 // userId parameter while ignoring implementation details like timeout values.
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Mock dashboard utilities
 const mockBuildDashboardEmbed = vi.fn();
@@ -64,7 +64,7 @@ describe('handleEditPersona', () => {
 
   function createMockContext() {
     return {
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       channelId: 'channel-123',
       editReply: mockEditReply,
     } as unknown as Parameters<typeof handleEditPersona>[0];

--- a/services/bot-client/src/commands/persona/edit.ts
+++ b/services/bot-client/src/commands/persona/edit.ts
@@ -23,6 +23,7 @@ import {
   buildPersonaDashboardOptions,
   type FlattenedPersonaData,
 } from './config.js';
+import { toGatewayUser } from '../../utils/userGatewayClient.js';
 import { fetchPersona, fetchDefaultPersona } from './api.js';
 
 const logger = createLogger('persona-edit');
@@ -45,7 +46,7 @@ export async function handleEditPersona(
 
     if (personaId !== null && personaId !== undefined) {
       // Fetch specific persona
-      persona = await fetchPersona(personaId, userId);
+      persona = await fetchPersona(personaId, toGatewayUser(context.user));
 
       if (!persona) {
         await context.editReply({
@@ -55,7 +56,7 @@ export async function handleEditPersona(
       }
     } else {
       // Fetch default persona
-      persona = await fetchDefaultPersona(userId);
+      persona = await fetchDefaultPersona(toGatewayUser(context.user));
 
       if (!persona) {
         await context.editReply({

--- a/services/bot-client/src/commands/persona/override/clear.test.ts
+++ b/services/bot-client/src/commands/persona/override/clear.test.ts
@@ -15,14 +15,15 @@ import { mockClearOverrideResponse } from '@tzurot/common-types';
 
 // Mock gateway client
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
+    '../../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 vi.mock('@tzurot/common-types', async () => {
   const actual = await vi.importActual('@tzurot/common-types');

--- a/services/bot-client/src/commands/persona/override/clear.test.ts
+++ b/services/bot-client/src/commands/persona/override/clear.test.ts
@@ -17,6 +17,11 @@ import { mockClearOverrideResponse } from '@tzurot/common-types';
 const mockCallGatewayApi = vi.fn();
 vi.mock('../../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 vi.mock('@tzurot/common-types', async () => {
@@ -67,7 +72,11 @@ describe('handleOverrideClear', () => {
     await handleOverrideClear(createMockContext('lilith'));
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/persona/override/lilith', {
-      userId: '123456789',
+      user: {
+        discordId: '123456789',
+        username: 'testuser',
+        displayName: 'testuser',
+      },
       method: 'DELETE',
     });
     expect(mockEditReply).toHaveBeenCalledWith({

--- a/services/bot-client/src/commands/persona/override/clear.ts
+++ b/services/bot-client/src/commands/persona/override/clear.ts
@@ -9,7 +9,7 @@
 
 import { createLogger, personaOverrideClearOptions } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
 
 const logger = createLogger('persona-override-clear');
 
@@ -37,7 +37,7 @@ export async function handleOverrideClear(context: DeferredCommandContext): Prom
     const result = await callGatewayApi<ClearOverrideResponse>(
       `/user/persona/override/${personalitySlug}`,
       {
-        userId: discordId,
+        user: toGatewayUser(context.user),
         method: 'DELETE',
       }
     );

--- a/services/bot-client/src/commands/persona/override/set.test.ts
+++ b/services/bot-client/src/commands/persona/override/set.test.ts
@@ -20,6 +20,11 @@ import {
 const mockCallGatewayApi = vi.fn();
 vi.mock('../../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 vi.mock('@tzurot/common-types', async () => {
@@ -80,7 +85,11 @@ describe('handleOverrideSet', () => {
     await handleOverrideSet(createMockContext('lilith', 'persona-123'));
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/persona/override/lilith', {
-      userId: '123456789',
+      user: {
+        discordId: '123456789',
+        username: 'testuser',
+        displayName: 'testuser',
+      },
       method: 'PUT',
       body: { personaId: 'persona-123' },
     });
@@ -102,7 +111,11 @@ describe('handleOverrideSet', () => {
     await handleOverrideSet(createMockContext('lilith', CREATE_NEW_PERSONA_VALUE));
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/persona/override/lilith', {
-      userId: '123456789',
+      user: {
+        discordId: '123456789',
+        username: 'testuser',
+        displayName: 'testuser',
+      },
     });
     expect(mockShowModal).toHaveBeenCalled();
     expect(mockReply).not.toHaveBeenCalled();
@@ -213,7 +226,11 @@ describe('handleOverrideCreateModalSubmit', () => {
     expect(mockCallGatewayApi).toHaveBeenCalledWith(
       '/user/persona/override/by-id/personality-uuid',
       {
-        userId: '123456789',
+        user: {
+          discordId: '123456789',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         method: 'POST',
         body: {
           name: 'Lilith Persona',

--- a/services/bot-client/src/commands/persona/override/set.test.ts
+++ b/services/bot-client/src/commands/persona/override/set.test.ts
@@ -18,14 +18,15 @@ import {
 
 // Mock gateway client
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
+    '../../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 vi.mock('@tzurot/common-types', async () => {
   const actual = await vi.importActual('@tzurot/common-types');

--- a/services/bot-client/src/commands/persona/override/set.ts
+++ b/services/bot-client/src/commands/persona/override/set.ts
@@ -24,7 +24,7 @@ import type { ModalCommandContext } from '../../../utils/commandContext/types.js
 import { CREATE_NEW_PERSONA_VALUE } from '../autocomplete.js';
 import { buildPersonaModalFields } from '../utils/modalBuilder.js';
 import { PersonaCustomIds } from '../../../utils/customIds.js';
-import { callGatewayApi } from '../../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
 
 const logger = createLogger('persona-override-set');
 
@@ -95,7 +95,7 @@ async function showCreateOverrideModal(
 ): Promise<void> {
   const infoResult = await callGatewayApi<OverrideInfoResponse>(
     `/user/persona/override/${personalitySlug}`,
-    { userId: discordId }
+    { user: toGatewayUser(context.user) }
   );
 
   if (!infoResult.ok) {
@@ -141,7 +141,7 @@ async function setExistingOverride(
 ): Promise<void> {
   const result = await callGatewayApi<SetOverrideResponse>(
     `/user/persona/override/${personalitySlug}`,
-    { userId: discordId, method: 'PUT', body: { personaId } }
+    { user: toGatewayUser(context.user), method: 'PUT', body: { personaId } }
   );
 
   if (!result.ok) {
@@ -231,7 +231,7 @@ export async function handleOverrideCreateModalSubmit(
     const result = await callGatewayApi<CreateOverrideResponse>(
       `/user/persona/override/by-id/${personalityId}`,
       {
-        userId: discordId,
+        user: toGatewayUser(interaction.user),
         method: 'POST',
         body: {
           name: personaName,

--- a/services/bot-client/src/commands/persona/view.test.ts
+++ b/services/bot-client/src/commands/persona/view.test.ts
@@ -13,14 +13,15 @@ import { mockListPersonasResponse, mockGetPersonaResponse } from '@tzurot/common
 
 // Mock gateway client
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 vi.mock('@tzurot/common-types', async () => {
   const actual = await vi.importActual('@tzurot/common-types');

--- a/services/bot-client/src/commands/persona/view.test.ts
+++ b/services/bot-client/src/commands/persona/view.test.ts
@@ -15,6 +15,11 @@ import { mockListPersonasResponse, mockGetPersonaResponse } from '@tzurot/common
 const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 vi.mock('@tzurot/common-types', async () => {

--- a/services/bot-client/src/commands/persona/view.ts
+++ b/services/bot-client/src/commands/persona/view.ts
@@ -22,7 +22,7 @@ import type { ButtonInteraction } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import { PersonaCustomIds } from '../../utils/customIds.js';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
 import { sendChunkedReply } from '../../utils/chunkedReply.js';
 
 const logger = createLogger('persona-view');
@@ -108,7 +108,7 @@ export async function handleViewPersona(context: DeferredCommandContext): Promis
 
   try {
     const result = await callGatewayApi<{ personas: PersonaSummary[] }>('/user/persona', {
-      userId: discordId,
+      user: toGatewayUser(context.user),
     });
 
     if (!result.ok) {
@@ -131,7 +131,7 @@ export async function handleViewPersona(context: DeferredCommandContext): Promis
 
     const detailsResult = await callGatewayApi<{ persona: PersonaDetails }>(
       `/user/persona/${persona.id}`,
-      { userId: discordId }
+      { user: toGatewayUser(context.user) }
     );
 
     if (!detailsResult.ok) {
@@ -171,7 +171,7 @@ export async function handleExpandContent(
   try {
     // Fetch persona details via gateway (also verifies ownership)
     const result = await callGatewayApi<{ persona: PersonaDetails }>(`/user/persona/${personaId}`, {
-      userId: discordId,
+      user: toGatewayUser(interaction.user),
     });
 
     if (!result.ok) {

--- a/services/bot-client/src/commands/preset/api.test.ts
+++ b/services/bot-client/src/commands/preset/api.test.ts
@@ -63,10 +63,18 @@ describe('fetchPreset', () => {
       data: { config: mockPresetData },
     });
 
-    const result = await fetchPreset('preset-123', 'user-456');
+    const result = await fetchPreset('preset-123', {
+      discordId: 'user-456',
+      username: 'testuser',
+      displayName: 'testuser',
+    });
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/llm-config/preset-123', {
-      userId: 'user-456',
+      user: {
+        discordId: 'user-456',
+        username: 'testuser',
+        displayName: 'testuser',
+      },
     });
     expect(result).toEqual(mockPresetData);
   });
@@ -77,7 +85,11 @@ describe('fetchPreset', () => {
       status: 404,
     });
 
-    const result = await fetchPreset('nonexistent', 'user-456');
+    const result = await fetchPreset('missing', {
+      discordId: 'user-456',
+      username: 'testuser',
+      displayName: 'testuser',
+    });
 
     expect(result).toBeNull();
   });
@@ -88,9 +100,13 @@ describe('fetchPreset', () => {
       status: 500,
     });
 
-    await expect(fetchPreset('preset-123', 'user-456')).rejects.toThrow(
-      'Failed to fetch preset: 500'
-    );
+    await expect(
+      fetchPreset('preset-123', {
+        discordId: 'user-456',
+        username: 'testuser',
+        displayName: 'testuser',
+      })
+    ).rejects.toThrow('Failed to fetch preset: 500');
   });
 });
 
@@ -159,11 +175,19 @@ describe('updatePreset', () => {
     });
 
     const updateData = { name: 'Updated Name' };
-    const result = await updatePreset('preset-123', updateData, 'user-456');
+    const result = await updatePreset('preset-123', updateData, {
+      discordId: 'user-456',
+      username: 'testuser',
+      displayName: 'testuser',
+    });
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/llm-config/preset-123', {
       method: 'PUT',
-      userId: 'user-456',
+      user: {
+        discordId: 'user-456',
+        username: 'testuser',
+        displayName: 'testuser',
+      },
       body: updateData,
     });
     expect(result).toEqual(mockPresetData);
@@ -176,9 +200,13 @@ describe('updatePreset', () => {
       error: 'Invalid data',
     });
 
-    await expect(updatePreset('preset-123', {}, 'user-456')).rejects.toThrow(
-      'Failed to update preset: 400 - Invalid data'
-    );
+    await expect(
+      updatePreset(
+        'preset-123',
+        {},
+        { discordId: 'user-456', username: 'testuser', displayName: 'testuser' }
+      )
+    ).rejects.toThrow('Failed to update preset: 400 - Invalid data');
   });
 
   it('should throw on error without message', async () => {
@@ -187,9 +215,13 @@ describe('updatePreset', () => {
       status: 500,
     });
 
-    await expect(updatePreset('preset-123', {}, 'user-456')).rejects.toThrow(
-      'Failed to update preset: 500 - Unknown'
-    );
+    await expect(
+      updatePreset(
+        'preset-123',
+        {},
+        { discordId: 'user-456', username: 'testuser', displayName: 'testuser' }
+      )
+    ).rejects.toThrow('Failed to update preset: 500 - Unknown');
   });
 });
 
@@ -313,12 +345,19 @@ describe('createPreset', () => {
       data: { config: mockPresetData },
     });
 
-    const result = await createPreset({ name: 'Foo', model: 'm', provider: 'p' }, 'user-1');
+    const result = await createPreset(
+      { name: 'Foo', model: 'm', provider: 'p' },
+      { discordId: 'user-1', username: 'testuser', displayName: 'testuser' }
+    );
 
     expect(result).toBe(mockPresetData);
     expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/llm-config', {
       method: 'POST',
-      userId: 'user-1',
+      user: {
+        discordId: 'user-1',
+        username: 'testuser',
+        displayName: 'testuser',
+      },
       body: { name: 'Foo', model: 'm', provider: 'p' },
     });
   });
@@ -333,9 +372,10 @@ describe('createPreset', () => {
 
     // Catch the rejection once so we can inspect class + shape without
     // re-invoking createPreset (which would re-consume the one-shot mock).
-    const err = await createPreset({ name: 'Foo', model: 'm', provider: 'p' }, 'user-1').catch(
-      e => e
-    );
+    const err = await createPreset(
+      { name: 'Foo', model: 'm', provider: 'p' },
+      { discordId: 'user-1', username: 'testuser', displayName: 'testuser' }
+    ).catch(e => e);
 
     expect(err).toBeInstanceOf(GatewayApiError);
     expect(err.status).toBe(400);
@@ -350,7 +390,10 @@ describe('createPreset', () => {
     });
 
     await expect(
-      createPreset({ name: 'Foo', model: 'm', provider: 'p' }, 'user-1')
+      createPreset(
+        { name: 'Foo', model: 'm', provider: 'p' },
+        { discordId: 'user-1', username: 'testuser', displayName: 'testuser' }
+      )
     ).rejects.toMatchObject({
       status: 500,
       code: undefined,

--- a/services/bot-client/src/commands/preset/api.ts
+++ b/services/bot-client/src/commands/preset/api.ts
@@ -5,7 +5,11 @@
  * Uses callGatewayApi for user endpoints and adminFetch for admin endpoints.
  */
 
-import { callGatewayApi, GatewayApiError } from '../../utils/userGatewayClient.js';
+import {
+  callGatewayApi,
+  GatewayApiError,
+  type GatewayUser,
+} from '../../utils/userGatewayClient.js';
 import { adminFetch, adminPutJson } from '../../utils/adminApiClient.js';
 import type { PresetData, PresetResponse } from './types.js';
 
@@ -35,9 +39,9 @@ export function extractApiErrorMessage(error: unknown): string | null {
 /**
  * Fetch a preset by ID (user endpoint)
  */
-export async function fetchPreset(presetId: string, userId: string): Promise<PresetData | null> {
+export async function fetchPreset(presetId: string, user: GatewayUser): Promise<PresetData | null> {
   const result = await callGatewayApi<PresetResponse>(`/user/llm-config/${presetId}`, {
-    userId,
+    user,
   });
 
   if (!result.ok) {
@@ -87,11 +91,11 @@ export async function fetchGlobalPreset(presetId: string): Promise<PresetData | 
 export async function updatePreset(
   presetId: string,
   data: Record<string, unknown>,
-  userId: string
+  user: GatewayUser
 ): Promise<PresetData> {
   const result = await callGatewayApi<PresetResponse>(`/user/llm-config/${presetId}`, {
     method: 'PUT',
-    userId,
+    user,
     body: data,
   });
 
@@ -153,11 +157,11 @@ export async function createPreset(
     description?: string;
     visionModel?: string;
   },
-  userId: string
+  user: GatewayUser
 ): Promise<PresetData> {
   const result = await callGatewayApi<PresetResponse>('/user/llm-config', {
     method: 'POST',
-    userId,
+    user,
     body: data,
   });
 

--- a/services/bot-client/src/commands/preset/autocomplete.test.ts
+++ b/services/bot-client/src/commands/preset/autocomplete.test.ts
@@ -24,6 +24,11 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 // Mock the gateway client
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: vi.fn(),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 import { callGatewayApi } from '../../utils/userGatewayClient.js';
@@ -84,7 +89,9 @@ describe('handleAutocomplete', () => {
 
       await handleAutocomplete(mockInteraction);
 
-      expect(callGatewayApi).toHaveBeenCalledWith('/user/llm-config', { userId: 'user-123' });
+      expect(callGatewayApi).toHaveBeenCalledWith('/user/llm-config', {
+        user: { discordId: 'user-123', username: 'testuser', displayName: 'testuser' },
+      });
       // Should only return owned presets
       expect(mockInteraction.respond).toHaveBeenCalledWith([
         { name: 'My Preset · claude-sonnet-4', value: '00000000-0000-4000-8000-0000000000c1' },

--- a/services/bot-client/src/commands/preset/autocomplete.test.ts
+++ b/services/bot-client/src/commands/preset/autocomplete.test.ts
@@ -22,14 +22,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 });
 
 // Mock the gateway client
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: vi.fn(),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: vi.fn(),
+  };
+});
 
 import { callGatewayApi } from '../../utils/userGatewayClient.js';
 
@@ -42,6 +43,7 @@ describe('handleAutocomplete', () => {
 
     mockUser = {
       id: 'user-123',
+      username: 'testuser',
     } as User;
 
     mockInteraction = {

--- a/services/bot-client/src/commands/preset/autocomplete.ts
+++ b/services/bot-client/src/commands/preset/autocomplete.ts
@@ -15,7 +15,7 @@ import {
   type LlmConfigSummary,
   type AutocompleteBadge,
 } from '@tzurot/common-types';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
 import { adminFetch } from '../../utils/adminApiClient.js';
 import {
   fetchTextModels,
@@ -159,7 +159,7 @@ async function handlePresetAutocomplete(
   const subcommand = interaction.options.getSubcommand(false);
 
   const result = await callGatewayApi<{ configs: LlmConfigSummary[] }>('/user/llm-config', {
-    userId,
+    user: toGatewayUser(interaction.user),
   });
 
   if (!result.ok) {

--- a/services/bot-client/src/commands/preset/browse.test.ts
+++ b/services/bot-client/src/commands/preset/browse.test.ts
@@ -36,6 +36,11 @@ vi.mock('../../utils/userGatewayClient.js', () => ({
     AUTOCOMPLETE: 2500,
     DEFERRED: 10000,
   },
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock dashboard utilities
@@ -139,7 +144,11 @@ describe('handleBrowse', () => {
     await handleBrowse(context);
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/llm-config', {
-      userId: '123456789',
+      user: {
+        discordId: '123456789',
+        username: 'testuser',
+        displayName: 'testuser',
+      },
       timeout: 10000,
     });
     expect(mockEditReply).toHaveBeenCalledWith({
@@ -411,7 +420,11 @@ describe('handleBrowsePagination', () => {
     await handleBrowsePagination(mockInteraction);
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/llm-config', {
-      userId: '123456789',
+      user: {
+        discordId: '123456789',
+        username: 'testuser',
+        displayName: 'testuser',
+      },
       timeout: 10000,
     });
     expect(mockEditReply).toHaveBeenCalledWith({
@@ -552,7 +565,11 @@ describe('handleBrowseSelect', () => {
     await handleBrowseSelect(mockInteraction);
 
     expect(mockDeferUpdate).toHaveBeenCalled();
-    expect(mockFetchPreset).toHaveBeenCalledWith('preset-123', '123456789');
+    expect(mockFetchPreset).toHaveBeenCalledWith('preset-123', {
+      discordId: '123456789',
+      username: 'testuser',
+      displayName: 'testuser',
+    });
     expect(mockBuildDashboardEmbed).toHaveBeenCalled();
     expect(mockBuildDashboardComponents).toHaveBeenCalled();
     expect(mockEditReply).toHaveBeenCalled();

--- a/services/bot-client/src/commands/preset/browse.test.ts
+++ b/services/bot-client/src/commands/preset/browse.test.ts
@@ -30,18 +30,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 // Mock userGatewayClient
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  GATEWAY_TIMEOUTS: {
-    AUTOCOMPLETE: 2500,
-    DEFERRED: 10000,
-  },
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Mock dashboard utilities
 const mockBuildDashboardEmbed = vi.fn(() => ({ toJSON: () => ({ title: 'Dashboard' }) }));
@@ -85,7 +82,7 @@ describe('handleBrowse', () => {
 
   function createMockContext(query: string | null = null, filter: string | null = null) {
     return {
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       interaction: {
         options: {
           getString: vi.fn((name: string) => {
@@ -355,7 +352,7 @@ describe('handleBrowsePagination', () => {
   function createMockButtonInteraction(customId: string) {
     return {
       customId,
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       deferUpdate: mockDeferUpdate,
       editReply: mockEditReply,
     } as unknown as ButtonInteraction;
@@ -544,7 +541,7 @@ describe('handleBrowseSelect', () => {
     return {
       customId: 'preset::browse-select',
       values: [presetId],
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       deferUpdate: mockDeferUpdate,
       editReply: mockEditReply,
       message: { id: 'message-123' },

--- a/services/bot-client/src/commands/preset/browse.ts
+++ b/services/bot-client/src/commands/preset/browse.ts
@@ -19,7 +19,12 @@ import {
   type AIProvider,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi, GATEWAY_TIMEOUTS } from '../../utils/userGatewayClient.js';
+import {
+  callGatewayApi,
+  GATEWAY_TIMEOUTS,
+  toGatewayUser,
+  type GatewayUser,
+} from '../../utils/userGatewayClient.js';
 import {
   buildDashboardEmbed,
   buildDashboardComponents,
@@ -319,13 +324,14 @@ export async function handleBrowse(context: DeferredCommandContext): Promise<voi
   try {
     // Fetch presets and wallet status in parallel
     // Use longer timeout since this is a deferred operation
+    const user = toGatewayUser(context.user);
     const [presetResult, walletResult] = await Promise.all([
       callGatewayApi<ListResponse>('/user/llm-config', {
-        userId,
+        user,
         timeout: GATEWAY_TIMEOUTS.DEFERRED,
       }),
       callGatewayApi<WalletListResponse>('/wallet/list', {
-        userId,
+        user,
         timeout: GATEWAY_TIMEOUTS.DEFERRED,
       }),
     ]);
@@ -372,7 +378,7 @@ export async function handleBrowse(context: DeferredCommandContext): Promise<voi
  * Reusable for pagination and back-from-dashboard navigation
  */
 export async function buildBrowseResponse(
-  userId: string,
+  user: GatewayUser,
   browseContext: {
     page: number;
     filter: PresetBrowseFilter;
@@ -384,11 +390,11 @@ export async function buildBrowseResponse(
   // Re-fetch data (use longer timeout since this is a deferred operation)
   const [presetResult, walletResult] = await Promise.all([
     callGatewayApi<ListResponse>('/user/llm-config', {
-      userId,
+      user,
       timeout: GATEWAY_TIMEOUTS.DEFERRED,
     }),
     callGatewayApi<WalletListResponse>('/wallet/list', {
-      userId,
+      user,
       timeout: GATEWAY_TIMEOUTS.DEFERRED,
     }),
   ]);
@@ -416,7 +422,7 @@ export async function handleBrowsePagination(interaction: ButtonInteraction): Pr
   await interaction.deferUpdate();
 
   try {
-    const result = await buildBrowseResponse(interaction.user.id, parsed);
+    const result = await buildBrowseResponse(toGatewayUser(interaction.user), parsed);
 
     if (result === null) {
       logger.warn(
@@ -450,7 +456,7 @@ export async function handleBrowseSelect(interaction: StringSelectMenuInteractio
 
   try {
     // Fetch the preset
-    const preset = await fetchPreset(presetId, userId);
+    const preset = await fetchPreset(presetId, toGatewayUser(interaction.user));
 
     if (!preset) {
       await interaction.editReply({

--- a/services/bot-client/src/commands/preset/cloneName.test.ts
+++ b/services/bot-client/src/commands/preset/cloneName.test.ts
@@ -9,7 +9,12 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GatewayApiError } from '../../utils/userGatewayClient.js';
+import type { GatewayUser } from '../../utils/userGatewayClient.js';
 import type { FlattenedPresetData } from './config.js';
+
+function mkUser(discordId = 'user-1'): GatewayUser {
+  return { discordId, username: 'test-user', displayName: 'Test User' };
+}
 
 const mockCreatePreset = vi.fn();
 vi.mock('./api.js', () => ({
@@ -71,13 +76,14 @@ describe('createClonedPreset', () => {
     const resultPreset = { id: 'new-id', name: 'My Preset (Copy)' };
     mockCreatePreset.mockResolvedValueOnce(resultPreset);
 
-    const result = await createClonedPreset(sourceData, 'user-1');
+    const user = mkUser();
+    const result = await createClonedPreset(sourceData, user);
 
     expect(result).toBe(resultPreset);
     expect(mockCreatePreset).toHaveBeenCalledTimes(1);
     expect(mockCreatePreset).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'My Preset (Copy)' }),
-      'user-1'
+      user
     );
   });
 
@@ -87,19 +93,20 @@ describe('createClonedPreset', () => {
       .mockRejectedValueOnce(new GatewayApiError('collision', 400, 'NAME_COLLISION'))
       .mockResolvedValueOnce(resultPreset);
 
-    const result = await createClonedPreset(sourceData, 'user-1');
+    const user = mkUser();
+    const result = await createClonedPreset(sourceData, user);
 
     expect(result).toBe(resultPreset);
     expect(mockCreatePreset).toHaveBeenCalledTimes(2);
     expect(mockCreatePreset).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({ name: 'My Preset (Copy)' }),
-      'user-1'
+      user
     );
     expect(mockCreatePreset).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({ name: 'My Preset (Copy 2)' }),
-      'user-1'
+      user
     );
   });
 
@@ -109,14 +116,14 @@ describe('createClonedPreset', () => {
     // propagate — don't retry.
     mockCreatePreset.mockRejectedValueOnce(new GatewayApiError('Bad request', 400));
 
-    await expect(createClonedPreset(sourceData, 'user-1')).rejects.toThrow('Bad request');
+    await expect(createClonedPreset(sourceData, mkUser())).rejects.toThrow('Bad request');
     expect(mockCreatePreset).toHaveBeenCalledTimes(1);
   });
 
   it('propagates plain Errors immediately (not GatewayApiError)', async () => {
     mockCreatePreset.mockRejectedValueOnce(new Error('network blip'));
 
-    await expect(createClonedPreset(sourceData, 'user-1')).rejects.toThrow('network blip');
+    await expect(createClonedPreset(sourceData, mkUser())).rejects.toThrow('network blip');
     expect(mockCreatePreset).toHaveBeenCalledTimes(1);
   });
 
@@ -124,7 +131,7 @@ describe('createClonedPreset', () => {
     const collision = new GatewayApiError('still colliding', 400, 'NAME_COLLISION');
     mockCreatePreset.mockRejectedValue(collision);
 
-    await expect(createClonedPreset(sourceData, 'user-1')).rejects.toBe(collision);
+    await expect(createClonedPreset(sourceData, mkUser())).rejects.toBe(collision);
     expect(mockCreatePreset).toHaveBeenCalledTimes(MAX_CLONE_NAME_RETRIES);
   });
 });

--- a/services/bot-client/src/commands/preset/cloneName.ts
+++ b/services/bot-client/src/commands/preset/cloneName.ts
@@ -8,7 +8,7 @@
  */
 
 import { API_ERROR_SUBCODE } from '@tzurot/common-types';
-import { GatewayApiError } from '../../utils/userGatewayClient.js';
+import { GatewayApiError, type GatewayUser } from '../../utils/userGatewayClient.js';
 import { createPreset } from './api.js';
 import type { FlattenedPresetData } from './config.js';
 import type { PresetData } from './types.js';
@@ -84,7 +84,7 @@ function isNameCollisionError(err: unknown): err is GatewayApiError {
  */
 export async function createClonedPreset(
   sourceData: FlattenedPresetData,
-  userId: string
+  user: GatewayUser
 ): Promise<PresetData> {
   let clonedName = generateClonedName(sourceData.name);
   // Tightened from `Error | null` to `GatewayApiError | null`: the only
@@ -109,7 +109,7 @@ export async function createClonedPreset(
               ? sourceData.visionModel
               : undefined,
         },
-        userId
+        user
       );
     } catch (err) {
       if (isNameCollisionError(err)) {

--- a/services/bot-client/src/commands/preset/create.test.ts
+++ b/services/bot-client/src/commands/preset/create.test.ts
@@ -198,7 +198,7 @@ describe('Preset Create', () => {
           model: 'anthropic/claude-sonnet-4',
           provider: 'openrouter',
         },
-        'user-123'
+        expect.objectContaining({ discordId: 'user-123' })
       );
 
       // Dashboard should be built

--- a/services/bot-client/src/commands/preset/create.ts
+++ b/services/bot-client/src/commands/preset/create.ts
@@ -31,6 +31,7 @@ import {
   presetSeedFields,
   buildPresetDashboardOptions,
 } from './config.js';
+import { toGatewayUser } from '../../utils/userGatewayClient.js';
 import { createPreset, extractApiErrorMessage } from './api.js';
 
 const logger = createLogger('preset-create');
@@ -92,7 +93,7 @@ export async function handleSeedModalSubmit(interaction: ModalSubmitInteraction)
         model: values.model.trim(),
         provider: 'openrouter', // Default provider
       },
-      interaction.user.id
+      toGatewayUser(interaction.user)
     );
 
     // Flatten the data for dashboard display

--- a/services/bot-client/src/commands/preset/dashboard.test.ts
+++ b/services/bot-client/src/commands/preset/dashboard.test.ts
@@ -14,6 +14,12 @@ import { handleDashboardClose } from '../../utils/dashboard/closeHandler.js';
 import type { PresetData } from './config.js';
 import { GatewayApiError } from '../../utils/userGatewayClient.js';
 
+const TEST_USER = {
+  discordId: 'user-456',
+  username: 'testuser',
+  displayName: 'testuser',
+} as const;
+
 // Mock common-types logger
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal<typeof import('@tzurot/common-types')>();
@@ -326,7 +332,7 @@ describe('handleModalSubmit', () => {
   function createMockModalInteraction(customId: string) {
     return {
       customId,
-      user: { id: 'user-456' },
+      user: { id: 'user-456', username: 'testuser', globalName: 'testuser' },
       deferUpdate: mockDeferUpdate,
       editReply: mockEditReply,
       reply: mockReply,
@@ -353,7 +359,7 @@ describe('handleModalSubmit', () => {
     await handleModalSubmit(createMockModalInteraction('preset::modal::preset-123::identity'));
 
     expect(mockDeferUpdate).toHaveBeenCalled();
-    expect(mockUpdatePreset).toHaveBeenCalledWith('preset-123', expect.any(Object), 'user-456');
+    expect(mockUpdatePreset).toHaveBeenCalledWith('preset-123', expect.any(Object), TEST_USER);
     expect(mockSessionManagerUpdate).toHaveBeenCalled();
     expect(mockEditReply).toHaveBeenCalledWith({
       embeds: [{ title: 'Test Embed' }],
@@ -471,7 +477,7 @@ describe('handleSelectMenu', () => {
     return {
       customId,
       values: [value],
-      user: { id: 'user-456' },
+      user: { id: 'user-456', username: 'testuser', globalName: 'testuser' },
       channelId: 'channel-999',
       message: { id: 'message-789' },
       showModal: mockShowModal,
@@ -514,7 +520,7 @@ describe('handleSelectMenu', () => {
       createMockSelectInteraction('preset::select::preset-123', 'edit-identity')
     );
 
-    expect(mockFetchPreset).toHaveBeenCalledWith('preset-123', 'user-456');
+    expect(mockFetchPreset).toHaveBeenCalledWith('preset-123', TEST_USER);
     expect(mockSessionManagerSet).toHaveBeenCalled();
     expect(mockShowModal).toHaveBeenCalled();
   });
@@ -601,7 +607,7 @@ describe('handleButton', () => {
   function createMockButtonInteraction(customId: string) {
     return {
       customId,
-      user: { id: 'user-456' },
+      user: { id: 'user-456', username: 'testuser', globalName: 'testuser' },
       channelId: 'channel-999',
       message: { id: 'message-789' },
       update: mockUpdate,
@@ -642,7 +648,7 @@ describe('handleButton', () => {
     await handleButton(createMockButtonInteraction('preset::refresh::preset-123'));
 
     expect(mockDeferUpdate).toHaveBeenCalled();
-    expect(mockFetchPreset).toHaveBeenCalledWith('preset-123', 'user-456');
+    expect(mockFetchPreset).toHaveBeenCalledWith('preset-123', TEST_USER);
     expect(mockSessionManagerSet).toHaveBeenCalled();
     expect(mockEditReply).toHaveBeenCalledWith({
       embeds: [{ title: 'Test Embed' }],
@@ -665,7 +671,7 @@ describe('handleButton', () => {
     await handleButton(createMockButtonInteraction('preset::refresh::preset-123'));
 
     // Should try user endpoint first (works for accessible global presets)
-    expect(mockFetchPreset).toHaveBeenCalledWith('preset-123', 'user-456');
+    expect(mockFetchPreset).toHaveBeenCalledWith('preset-123', TEST_USER);
     // Should not need to fall back to global endpoint
     expect(mockFetchGlobalPreset).not.toHaveBeenCalled();
   });
@@ -686,7 +692,7 @@ describe('handleButton', () => {
 
     await handleButton(createMockButtonInteraction('preset::refresh::preset-123'));
 
-    expect(mockFetchPreset).toHaveBeenCalledWith('preset-123', 'user-456');
+    expect(mockFetchPreset).toHaveBeenCalledWith('preset-123', TEST_USER);
     expect(mockFetchGlobalPreset).toHaveBeenCalledWith('preset-123');
   });
 
@@ -726,7 +732,7 @@ describe('handleButton', () => {
     function createToggleButtonInteraction(customId: string) {
       return {
         customId,
-        user: { id: 'user-456' },
+        user: { id: 'user-456', username: 'testuser', globalName: 'testuser' },
         channelId: 'channel-999',
         message: { id: 'message-789' },
         update: mockUpdate,
@@ -758,7 +764,7 @@ describe('handleButton', () => {
       await handleButton(createToggleButtonInteraction('preset::toggle-global::preset-123'));
 
       expect(mockDeferUpdate).toHaveBeenCalled();
-      expect(mockUpdatePreset).toHaveBeenCalledWith('preset-123', { isGlobal: true }, 'user-456');
+      expect(mockUpdatePreset).toHaveBeenCalledWith('preset-123', { isGlobal: true }, TEST_USER);
       expect(mockSessionManagerUpdate).toHaveBeenCalled();
       expect(mockEditReply).toHaveBeenCalled();
     });
@@ -778,7 +784,7 @@ describe('handleButton', () => {
 
       await handleButton(createToggleButtonInteraction('preset::toggle-global::preset-123'));
 
-      expect(mockUpdatePreset).toHaveBeenCalledWith('preset-123', { isGlobal: false }, 'user-456');
+      expect(mockUpdatePreset).toHaveBeenCalledWith('preset-123', { isGlobal: false }, TEST_USER);
     });
 
     it('should show error when session expired', async () => {
@@ -867,7 +873,7 @@ describe('handleButton', () => {
     function createCloneButtonInteraction(customId: string) {
       return {
         customId,
-        user: { id: 'user-456' },
+        user: { id: 'user-456', username: 'testuser', globalName: 'testuser' },
         channelId: 'channel-999',
         message: { id: 'message-789' },
         update: mockUpdate,
@@ -914,7 +920,7 @@ describe('handleButton', () => {
           model: 'anthropic/claude-sonnet-4',
           provider: 'openrouter',
         }),
-        'user-456'
+        TEST_USER
       );
       expect(mockSessionManagerSet).toHaveBeenCalled();
       expect(mockSessionManagerDelete).toHaveBeenCalledWith('user-456', 'preset', 'preset-123');
@@ -948,7 +954,7 @@ describe('handleButton', () => {
         expect.objectContaining({
           name: 'Test Preset (Copy 2)',
         }),
-        'user-456'
+        TEST_USER
       );
     });
 
@@ -986,7 +992,7 @@ describe('handleButton', () => {
             top_p: 0.9,
           }),
         }),
-        'user-456'
+        TEST_USER
       );
     });
 
@@ -1100,13 +1106,13 @@ describe('handleButton', () => {
       expect(mockCreatePreset).toHaveBeenNthCalledWith(
         1,
         expect.objectContaining({ name: 'Test Preset (Copy)' }),
-        'user-456'
+        TEST_USER
       );
       // Retry bumped the suffix to "(Copy 2)" and succeeded
       expect(mockCreatePreset).toHaveBeenNthCalledWith(
         2,
         expect.objectContaining({ name: 'Test Preset (Copy 2)' }),
-        'user-456'
+        TEST_USER
       );
       // User sees the success path, not an error
       expect(mockFollowUp).not.toHaveBeenCalled();

--- a/services/bot-client/src/commands/preset/dashboard.ts
+++ b/services/bot-client/src/commands/preset/dashboard.ts
@@ -24,6 +24,7 @@ import {
 } from '../../utils/dashboard/index.js';
 import { handleDashboardSectionSelect } from '../../utils/dashboard/genericSelectMenuHandler.js';
 import { refreshDashboardUI } from '../../utils/dashboard/refreshHandler.js';
+import { toGatewayUser } from '../../utils/userGatewayClient.js';
 import {
   PRESET_DASHBOARD_CONFIG,
   type FlattenedPresetData,
@@ -148,7 +149,7 @@ async function handleSectionModalSubmit(
     // Update preset via appropriate API
     const updatedPreset = isGlobal
       ? await updateGlobalPreset(entityId, updatePayload)
-      : await updatePreset(entityId, updatePayload, interaction.user.id);
+      : await updatePreset(entityId, updatePayload, toGatewayUser(interaction.user));
 
     // Flatten the response for dashboard display
     const flattenedData = flattenPresetData(updatedPreset);
@@ -207,7 +208,7 @@ export async function handleSelectMenu(interaction: StringSelectMenuInteraction)
   await handleDashboardSectionSelect<FlattenedPresetData, PresetData>(interaction, {
     entityType: 'preset',
     dashboardConfig: PRESET_DASHBOARD_CONFIG,
-    fetchFn: (entityId, userId) => fetchPreset(entityId, userId),
+    fetchFn: (entityId, user) => fetchPreset(entityId, user),
     transformFn: flattenPresetData,
     entityName: 'Preset',
     canEdit: data => data.canEdit === true,

--- a/services/bot-client/src/commands/preset/dashboardButtons.test.ts
+++ b/services/bot-client/src/commands/preset/dashboardButtons.test.ts
@@ -19,6 +19,12 @@ import { handleDashboardClose } from '../../utils/dashboard/closeHandler.js';
 import { refreshDashboardUI } from '../../utils/dashboard/refreshHandler.js';
 import type { FlattenedPresetData } from './config.js';
 
+const TEST_USER = {
+  discordId: 'user-123',
+  username: 'testuser',
+  displayName: 'testuser',
+} as const;
+
 // Mock dependencies
 const mockFetchPreset = vi.fn();
 const mockFetchGlobalPreset = vi.fn();
@@ -40,6 +46,11 @@ vi.mock('./browse.js', () => ({
 const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 const mockSessionManager = {
@@ -232,7 +243,7 @@ describe('Preset Dashboard Buttons', () => {
   const createMockButtonInteraction = (customId: string) =>
     ({
       customId,
-      user: { id: 'user-123' },
+      user: { id: 'user-123', username: 'testuser', globalName: 'testuser' },
       message: { id: 'msg-123' },
       channelId: 'channel-123',
       update: vi.fn(),
@@ -339,7 +350,7 @@ describe('Preset Dashboard Buttons', () => {
       await handleRefreshButton(mockInteraction, 'preset-123');
 
       expect(mockInteraction.deferUpdate).toHaveBeenCalled();
-      expect(mockFetchPreset).toHaveBeenCalledWith('preset-123', 'user-123');
+      expect(mockFetchPreset).toHaveBeenCalledWith('preset-123', TEST_USER);
       expect(mockSessionManager.set).toHaveBeenCalled();
     });
 
@@ -361,7 +372,7 @@ describe('Preset Dashboard Buttons', () => {
       await handleRefreshButton(mockInteraction, 'preset-123');
 
       // Should try user endpoint first (works for accessible global presets)
-      expect(mockFetchPreset).toHaveBeenCalledWith('preset-123', 'user-123');
+      expect(mockFetchPreset).toHaveBeenCalledWith('preset-123', TEST_USER);
       // Should not need to fall back to global endpoint
       expect(mockFetchGlobalPreset).not.toHaveBeenCalled();
     });
@@ -386,7 +397,7 @@ describe('Preset Dashboard Buttons', () => {
       await handleRefreshButton(mockInteraction, 'preset-123');
 
       // Should try user endpoint first
-      expect(mockFetchPreset).toHaveBeenCalledWith('preset-123', 'user-123');
+      expect(mockFetchPreset).toHaveBeenCalledWith('preset-123', TEST_USER);
       // Should fall back to global endpoint
       expect(mockFetchGlobalPreset).toHaveBeenCalledWith('preset-123');
     });
@@ -689,7 +700,7 @@ describe('Preset Dashboard Buttons', () => {
             temperature: 0.8,
           }),
         }),
-        'user-123'
+        TEST_USER
       );
     });
 
@@ -725,11 +736,14 @@ describe('Preset Dashboard Buttons', () => {
       await handleBackButton(mockInteraction, 'preset-123');
 
       expect(mockInteraction.deferUpdate).toHaveBeenCalled();
-      expect(mockBuildBrowseResponse).toHaveBeenCalledWith('user-123', {
-        page: 1,
-        filter: 'owned',
-        query: null,
-      });
+      expect(mockBuildBrowseResponse).toHaveBeenCalledWith(
+        expect.objectContaining({ discordId: 'user-123' }),
+        {
+          page: 1,
+          filter: 'owned',
+          query: null,
+        }
+      );
       expect(mockSessionManager.delete).toHaveBeenCalledWith('user-123', 'preset', 'preset-123');
     });
 
@@ -800,11 +814,14 @@ describe('Preset Dashboard Buttons', () => {
 
       await handleBackButton(mockInteraction, 'preset-123');
 
-      expect(mockBuildBrowseResponse).toHaveBeenCalledWith('user-123', {
-        page: 0,
-        filter: 'all',
-        query: 'gpt',
-      });
+      expect(mockBuildBrowseResponse).toHaveBeenCalledWith(
+        expect.objectContaining({ discordId: 'user-123' }),
+        {
+          page: 0,
+          filter: 'all',
+          query: 'gpt',
+        }
+      );
     });
   });
 });

--- a/services/bot-client/src/commands/preset/dashboardButtons.test.ts
+++ b/services/bot-client/src/commands/preset/dashboardButtons.test.ts
@@ -44,14 +44,15 @@ vi.mock('./browse.js', () => ({
 }));
 
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 const mockSessionManager = {
   get: vi.fn(),

--- a/services/bot-client/src/commands/preset/dashboardButtons.ts
+++ b/services/bot-client/src/commands/preset/dashboardButtons.ts
@@ -11,7 +11,7 @@
 import { MessageFlags } from 'discord.js';
 import type { ButtonInteraction } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
 import {
   buildDeleteConfirmation,
   handleDashboardClose,
@@ -79,7 +79,7 @@ export async function handleRefreshButton(
   const existingBrowseContext = existingSession?.data.browseContext;
 
   // Try user endpoint first (works for owned presets AND accessible global presets)
-  let preset = await fetchPreset(entityId, interaction.user.id);
+  let preset = await fetchPreset(entityId, toGatewayUser(interaction.user));
 
   // Fallback: if null and session indicated global, try admin endpoint
   // This handles edge case where preset is still global but user endpoint failed
@@ -151,7 +151,7 @@ export async function handleToggleGlobalButton(
 
   try {
     // Fetch fresh data to prevent race condition with stale session.data.isGlobal
-    const freshPreset = await fetchPreset(entityId, interaction.user.id);
+    const freshPreset = await fetchPreset(entityId, toGatewayUser(interaction.user));
     if (freshPreset === null) {
       await interaction.followUp({
         content: DASHBOARD_MESSAGES.NOT_FOUND('Preset'),
@@ -164,7 +164,7 @@ export async function handleToggleGlobalButton(
     const updatedPreset = await updatePreset(
       entityId,
       { isGlobal: newIsGlobal },
-      interaction.user.id
+      toGatewayUser(interaction.user)
     );
 
     const flattenedData = flattenPresetData(updatedPreset);
@@ -246,7 +246,7 @@ export async function handleConfirmDeleteButton(
   try {
     const result = await callGatewayApi<void>(`/user/llm-config/${entityId}`, {
       method: 'DELETE',
-      userId: interaction.user.id,
+      user: toGatewayUser(interaction.user),
     });
 
     if (!result.ok) {
@@ -333,7 +333,7 @@ export async function handleCloneButton(
     // exists in the user's library, so cloning the original twice produces
     // the same "(Copy)" candidate both times. Retry with a bumped suffix on
     // the gateway's name-collision validation error; surface anything else.
-    const newPreset = await createClonedPreset(sourceData, interaction.user.id);
+    const newPreset = await createClonedPreset(sourceData, toGatewayUser(interaction.user));
 
     // Build update payload with all non-basic fields from source
     const updatePayload = unflattenPresetData(sourceData);
@@ -352,11 +352,11 @@ export async function handleCloneButton(
 
     // Apply updates if needed
     if (Object.keys(updatePayload).length > 0) {
-      await updatePreset(newPreset.id, updatePayload, interaction.user.id);
+      await updatePreset(newPreset.id, updatePayload, toGatewayUser(interaction.user));
     }
 
     // Fetch the complete cloned preset to get all fields
-    const clonedPreset = await fetchPreset(newPreset.id, interaction.user.id);
+    const clonedPreset = await fetchPreset(newPreset.id, toGatewayUser(interaction.user));
     if (clonedPreset === null) {
       throw new Error('Failed to fetch cloned preset');
     }
@@ -428,7 +428,7 @@ export async function handleBackButton(
   }
 
   try {
-    const result = await buildBrowseResponse(interaction.user.id, {
+    const result = await buildBrowseResponse(toGatewayUser(interaction.user), {
       page: browseContext.page,
       filter: browseContext.filter as PresetBrowseFilter,
       query: browseContext.query ?? null,

--- a/services/bot-client/src/commands/preset/edit.test.ts
+++ b/services/bot-client/src/commands/preset/edit.test.ts
@@ -64,7 +64,7 @@ describe('handleEdit', () => {
 
   function createMockContext(presetId = 'preset-123') {
     return {
-      user: { id: 'user-456' },
+      user: { id: 'user-456', username: 'testuser', globalName: 'testuser' },
       channelId: 'channel-999',
       interaction: {
         options: {
@@ -90,7 +90,11 @@ describe('handleEdit', () => {
     await handleEdit(createMockContext());
 
     // Note: deferReply is now called at the framework level, not in the handler
-    expect(mockFetchPreset).toHaveBeenCalledWith('preset-123', 'user-456');
+    expect(mockFetchPreset).toHaveBeenCalledWith('preset-123', {
+      discordId: 'user-456',
+      username: 'testuser',
+      displayName: 'testuser',
+    });
     expect(mockBuildDashboardEmbed).toHaveBeenCalled();
     // Uses buildPresetDashboardOptions for consistent button configuration
     expect(mockBuildDashboardComponents).toHaveBeenCalledWith(

--- a/services/bot-client/src/commands/preset/edit.ts
+++ b/services/bot-client/src/commands/preset/edit.ts
@@ -19,6 +19,7 @@ import {
   flattenPresetData,
   buildPresetDashboardOptions,
 } from './config.js';
+import { toGatewayUser } from '../../utils/userGatewayClient.js';
 import { fetchPreset } from './api.js';
 
 const logger = createLogger('preset-edit');
@@ -34,7 +35,7 @@ export async function handleEdit(context: DeferredCommandContext): Promise<void>
 
   try {
     // Fetch the preset
-    const preset = await fetchPreset(presetId, userId);
+    const preset = await fetchPreset(presetId, toGatewayUser(context.user));
 
     if (!preset) {
       await context.editReply({ content: '❌ Preset not found.' });

--- a/services/bot-client/src/commands/preset/export.test.ts
+++ b/services/bot-client/src/commands/preset/export.test.ts
@@ -16,6 +16,11 @@ import type { DeferredCommandContext } from '../../utils/commandContext/types.js
 // Mock dependencies
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: vi.fn(),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 vi.mock('@tzurot/common-types', async importOriginal => {
@@ -279,7 +284,7 @@ describe('Preset Export', () => {
 
       expect(userGatewayClient.callGatewayApi).toHaveBeenCalledWith(
         '/user/llm-config/test-preset-id',
-        { userId: 'user-123' }
+        { user: { discordId: 'user-123', username: 'testuser', displayName: 'testuser' } }
       );
     });
 

--- a/services/bot-client/src/commands/preset/export.test.ts
+++ b/services/bot-client/src/commands/preset/export.test.ts
@@ -14,14 +14,15 @@ import * as userGatewayClient from '../../utils/userGatewayClient.js';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 
 // Mock dependencies
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: vi.fn(),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: vi.fn(),
+  };
+});
 
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal();
@@ -49,7 +50,7 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 describe('Preset Export', () => {
   const createMockContext = (userId = 'user-123') =>
     ({
-      user: { id: userId },
+      user: { id: userId, username: 'testuser' },
       interaction: {
         options: {
           getString: vi.fn().mockReturnValue('test-preset-id'),

--- a/services/bot-client/src/commands/preset/export.ts
+++ b/services/bot-client/src/commands/preset/export.ts
@@ -6,7 +6,7 @@
 import { escapeMarkdown } from 'discord.js';
 import { createLogger, isBotOwner, presetExportOptions } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
 import { createJsonAttachment } from '../../utils/jsonFileUtils.js';
 import type { PresetData, PresetResponse } from './types.js';
 
@@ -125,7 +125,7 @@ export async function handleExport(context: DeferredCommandContext): Promise<voi
   try {
     // Fetch preset data
     const result = await callGatewayApi<PresetResponse>(`/user/llm-config/${presetId}`, {
-      userId,
+      user: toGatewayUser(context.user),
     });
 
     if (!result.ok) {

--- a/services/bot-client/src/commands/preset/import.test.ts
+++ b/services/bot-client/src/commands/preset/import.test.ts
@@ -19,6 +19,11 @@ import type { Attachment } from 'discord.js';
 // Mock dependencies
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: vi.fn(),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 vi.mock('../../utils/jsonFileUtils.js', () => ({

--- a/services/bot-client/src/commands/preset/import.test.ts
+++ b/services/bot-client/src/commands/preset/import.test.ts
@@ -17,14 +17,15 @@ import type { DeferredCommandContext } from '../../utils/commandContext/types.js
 import type { Attachment } from 'discord.js';
 
 // Mock dependencies
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: vi.fn(),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: vi.fn(),
+  };
+});
 
 vi.mock('../../utils/jsonFileUtils.js', () => ({
   validateAndParseJsonFile: vi.fn(),

--- a/services/bot-client/src/commands/preset/import.ts
+++ b/services/bot-client/src/commands/preset/import.ts
@@ -6,7 +6,7 @@
 import { EmbedBuilder, escapeMarkdown } from 'discord.js';
 import { createLogger, DISCORD_COLORS, presetImportOptions } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser, type GatewayUser } from '../../utils/userGatewayClient.js';
 import { validateAndParseJsonFile } from '../../utils/jsonFileUtils.js';
 import {
   getImportedFieldsList,
@@ -173,12 +173,12 @@ function buildImportPayload(data: ImportedPresetData): Record<string, unknown> {
  * Create preset via API
  */
 async function createPresetFromImport(
-  userId: string,
+  user: GatewayUser,
   payload: Record<string, unknown>
 ): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
   // Create preset with all fields - API supports all fields in create endpoint
   const createResult = await callGatewayApi<{ id: string }>('/user/llm-config', {
-    userId,
+    user,
     method: 'POST',
     body: {
       name: payload.name,
@@ -248,7 +248,7 @@ export async function handleImport(context: DeferredCommandContext): Promise<voi
     const payload = buildImportPayload(parseResult.data);
 
     // Step 4: Create preset
-    const createResult = await createPresetFromImport(userId, payload);
+    const createResult = await createPresetFromImport(toGatewayUser(context.user), payload);
     if (!createResult.ok) {
       await context.editReply(
         `❌ Failed to import preset:\n\`\`\`\n${createResult.error.slice(0, 1500)}\n\`\`\``

--- a/services/bot-client/src/commands/settings/apikey/browse.test.ts
+++ b/services/bot-client/src/commands/settings/apikey/browse.test.ts
@@ -26,15 +26,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 // Note: Tests use objectContaining for API call assertions to focus on the essential
 // userId parameter while ignoring implementation details like timeout values.
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
+    '../../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Mock providers
 vi.mock('../../../utils/providers.js', () => ({
@@ -55,7 +55,7 @@ describe('handleBrowse', () => {
 
   function createMockContext(): DeferredCommandContext {
     const mockInteraction = {
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       editReply: mockEditReply,
     } as unknown as ChatInputCommandInteraction;
 

--- a/services/bot-client/src/commands/settings/apikey/browse.test.ts
+++ b/services/bot-client/src/commands/settings/apikey/browse.test.ts
@@ -29,6 +29,11 @@ const mockCallGatewayApi = vi.fn();
 vi.mock('../../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
   GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock providers
@@ -92,7 +97,9 @@ describe('handleBrowse', () => {
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith(
       '/wallet/list',
-      expect.objectContaining({ userId: '123456789' })
+      expect.objectContaining({
+        user: { discordId: '123456789', username: 'testuser', displayName: 'testuser' },
+      })
     );
     expect(mockEditReply).toHaveBeenCalledWith({
       embeds: [

--- a/services/bot-client/src/commands/settings/apikey/browse.ts
+++ b/services/bot-client/src/commands/settings/apikey/browse.ts
@@ -20,7 +20,11 @@ import {
   type AIProvider,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import { callGatewayApi, GATEWAY_TIMEOUTS } from '../../../utils/userGatewayClient.js';
+import {
+  callGatewayApi,
+  GATEWAY_TIMEOUTS,
+  toGatewayUser,
+} from '../../../utils/userGatewayClient.js';
 import { getProviderDisplayName } from '../../../utils/providers.js';
 
 const logger = createLogger('settings-apikey-browse');
@@ -109,7 +113,10 @@ export async function handleBrowse(context: DeferredCommandContext): Promise<voi
   const userId = context.user.id;
 
   try {
-    const result = await callGatewayApi<WalletListResponse>('/wallet/list', { userId, timeout: GATEWAY_TIMEOUTS.DEFERRED });
+    const result = await callGatewayApi<WalletListResponse>('/wallet/list', {
+      user: toGatewayUser(context.user),
+      timeout: GATEWAY_TIMEOUTS.DEFERRED,
+    });
 
     if (!result.ok) {
       await context.editReply({ content: `❌ Failed to retrieve wallet info: ${result.error}` });

--- a/services/bot-client/src/commands/settings/apikey/modal.ts
+++ b/services/bot-client/src/commands/settings/apikey/modal.ts
@@ -13,7 +13,7 @@ import type { ModalSubmitInteraction } from 'discord.js';
 import { MessageFlags, EmbedBuilder } from 'discord.js';
 import { createLogger, DISCORD_COLORS, AIProvider, API_KEY_FORMATS } from '@tzurot/common-types';
 import { getProviderDisplayName } from '../../../utils/providers.js';
-import { callGatewayApi } from '../../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
 import { ApikeyCustomIds } from '../../../utils/customIds.js';
 
 const logger = createLogger('settings-apikey-modal');
@@ -74,7 +74,7 @@ async function handleSetKeySubmit(
     // Send to api-gateway for validation and storage
     const result = await callGatewayApi<{ success: boolean }>('/wallet/set', {
       method: 'POST',
-      userId: interaction.user.id,
+      user: toGatewayUser(interaction.user),
       body: { provider, apiKey },
     });
 

--- a/services/bot-client/src/commands/settings/apikey/remove.test.ts
+++ b/services/bot-client/src/commands/settings/apikey/remove.test.ts
@@ -24,14 +24,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 // Mock userGatewayClient
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
+    '../../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Mock providers
 vi.mock('../../../utils/providers.js', () => ({
@@ -52,7 +53,7 @@ describe('handleRemoveKey', () => {
 
   function createMockContext(provider: string = 'openrouter'): DeferredCommandContext {
     const mockInteraction = {
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       options: {
         getString: (name: string, _required?: boolean) => {
           if (name === 'provider') return provider;

--- a/services/bot-client/src/commands/settings/apikey/remove.test.ts
+++ b/services/bot-client/src/commands/settings/apikey/remove.test.ts
@@ -26,6 +26,11 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 const mockCallGatewayApi = vi.fn();
 vi.mock('../../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock providers
@@ -90,7 +95,11 @@ describe('handleRemoveKey', () => {
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith('/wallet/openrouter', {
       method: 'DELETE',
-      userId: '123456789',
+      user: {
+        discordId: '123456789',
+        username: 'testuser',
+        displayName: 'testuser',
+      },
     });
     expect(mockEditReply).toHaveBeenCalledWith({
       embeds: [

--- a/services/bot-client/src/commands/settings/apikey/remove.ts
+++ b/services/bot-client/src/commands/settings/apikey/remove.ts
@@ -15,7 +15,7 @@ import {
   settingsApikeyRemoveOptions,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
 import { getProviderDisplayName } from '../../../utils/providers.js';
 
 const logger = createLogger('settings-apikey-remove');
@@ -35,7 +35,7 @@ export async function handleRemoveKey(context: DeferredCommandContext): Promise<
   try {
     const result = await callGatewayApi<void>(`/wallet/${provider}`, {
       method: 'DELETE',
-      userId,
+      user: toGatewayUser(context.user),
     });
 
     if (!result.ok) {

--- a/services/bot-client/src/commands/settings/apikey/test.test.ts
+++ b/services/bot-client/src/commands/settings/apikey/test.test.ts
@@ -24,14 +24,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 // Mock userGatewayClient
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
+    '../../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Mock providers
 vi.mock('../../../utils/providers.js', () => ({
@@ -52,7 +53,7 @@ describe('handleTestKey', () => {
 
   function createMockContext(provider: string = 'openrouter'): DeferredCommandContext {
     const mockInteraction = {
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       options: {
         getString: (name: string, _required?: boolean) => {
           if (name === 'provider') return provider;

--- a/services/bot-client/src/commands/settings/apikey/test.test.ts
+++ b/services/bot-client/src/commands/settings/apikey/test.test.ts
@@ -26,6 +26,11 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 const mockCallGatewayApi = vi.fn();
 vi.mock('../../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock providers
@@ -92,7 +97,11 @@ describe('handleTestKey', () => {
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith('/wallet/test', {
       method: 'POST',
-      userId: '123456789',
+      user: {
+        discordId: '123456789',
+        username: 'testuser',
+        displayName: 'testuser',
+      },
       body: { provider: 'openrouter' },
     });
     expect(mockEditReply).toHaveBeenCalledWith({

--- a/services/bot-client/src/commands/settings/apikey/test.ts
+++ b/services/bot-client/src/commands/settings/apikey/test.ts
@@ -15,7 +15,7 @@ import {
   settingsApikeyTestOptions,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
 import { getProviderDisplayName } from '../../../utils/providers.js';
 
 const logger = createLogger('settings-apikey-test');
@@ -43,7 +43,7 @@ export async function handleTestKey(context: DeferredCommandContext): Promise<vo
   try {
     const result = await callGatewayApi<WalletTestResponse>('/wallet/test', {
       method: 'POST',
-      userId,
+      user: toGatewayUser(context.user),
       body: { provider },
     });
 

--- a/services/bot-client/src/commands/settings/defaults/edit.test.ts
+++ b/services/bot-client/src/commands/settings/defaults/edit.test.ts
@@ -33,15 +33,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 });
 
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
+    '../../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Mock the session manager
 const mockSessionManager = {
@@ -100,7 +100,7 @@ describe('User Default Settings Dashboard', () => {
 
     return {
       interaction: mockInteraction,
-      user: { id: 'user-456' },
+      user: { id: 'user-456', username: 'testuser' },
       guild: null,
       member: null,
       channel: null,
@@ -130,7 +130,7 @@ describe('User Default Settings Dashboard', () => {
   } => {
     return {
       customId,
-      user: { id: 'user-456' },
+      user: { id: 'user-456', username: 'testuser' },
       deferUpdate: vi.fn().mockResolvedValue(undefined),
       editReply: vi.fn().mockResolvedValue(undefined),
       message: { id: 'message-123' },
@@ -152,7 +152,7 @@ describe('User Default Settings Dashboard', () => {
   } => {
     return {
       customId,
-      user: { id: 'user-456' },
+      user: { id: 'user-456', username: 'testuser' },
       deferUpdate: vi.fn().mockResolvedValue(undefined),
       editReply: vi.fn().mockResolvedValue(undefined),
       message: { id: 'message-123' },
@@ -372,7 +372,7 @@ describe('User Default Settings Dashboard', () => {
     it('should handle API failure gracefully', async () => {
       const interaction = {
         customId: 'user-defaults-settings::set::user-456::maxMessages:auto',
-        user: { id: 'user-456' },
+        user: { id: 'user-456', username: 'testuser' },
         reply: vi.fn(),
         update: vi.fn(),
         showModal: vi.fn(),
@@ -410,7 +410,7 @@ describe('User Default Settings Dashboard', () => {
     it('should handle unknown setting ID', async () => {
       const interaction = {
         customId: 'user-defaults-settings::set::user-456::unknownSetting:value',
-        user: { id: 'user-456' },
+        user: { id: 'user-456', username: 'testuser' },
         reply: vi.fn(),
         update: vi.fn(),
         showModal: vi.fn(),
@@ -454,7 +454,7 @@ describe('User Default Settings Dashboard', () => {
   describe('handleUserDefaultsModal', () => {
     const createMockModalInteraction = (customId: string, inputValue: string) => ({
       customId,
-      user: { id: 'user-456' },
+      user: { id: 'user-456', username: 'testuser' },
       fields: {
         getTextInputValue: vi.fn().mockReturnValue(inputValue),
       },

--- a/services/bot-client/src/commands/settings/defaults/edit.test.ts
+++ b/services/bot-client/src/commands/settings/defaults/edit.test.ts
@@ -36,6 +36,11 @@ const mockCallGatewayApi = vi.fn();
 vi.mock('../../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
   GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock the session manager
@@ -176,7 +181,11 @@ describe('User Default Settings Dashboard', () => {
 
       expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/config-overrides/resolve-defaults', {
         method: 'GET',
-        userId: 'user-456',
+        user: {
+          discordId: 'user-456',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         timeout: 10000,
       });
       expect(context.editReply).toHaveBeenCalledWith(
@@ -457,7 +466,11 @@ describe('User Default Settings Dashboard', () => {
 
     const createSessionWithSetting = (settingId: string) => ({
       data: {
-        userId: 'user-456',
+        user: {
+          discordId: 'user-456',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         entityId: 'user-456',
         data: {
           maxMessages: { localValue: 50, effectiveValue: 50, source: 'hardcoded' },
@@ -496,7 +509,11 @@ describe('User Default Settings Dashboard', () => {
       expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/config-overrides/defaults', {
         method: 'PATCH',
         body: { maxMessages: 30 },
-        userId: 'user-456',
+        user: {
+          discordId: 'user-456',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         timeout: 10000,
       });
     });
@@ -517,7 +534,11 @@ describe('User Default Settings Dashboard', () => {
       expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/config-overrides/defaults', {
         method: 'PATCH',
         body: { maxAge: 7200 },
-        userId: 'user-456',
+        user: {
+          discordId: 'user-456',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         timeout: 10000,
       });
     });
@@ -538,7 +559,11 @@ describe('User Default Settings Dashboard', () => {
       expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/config-overrides/defaults', {
         method: 'PATCH',
         body: { maxMessages: null },
-        userId: 'user-456',
+        user: {
+          discordId: 'user-456',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         timeout: 10000,
       });
     });

--- a/services/bot-client/src/commands/settings/defaults/edit.ts
+++ b/services/bot-client/src/commands/settings/defaults/edit.ts
@@ -19,7 +19,11 @@ import type {
 } from 'discord.js';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
 import { createLogger, DISCORD_COLORS, GATEWAY_TIMEOUTS } from '@tzurot/common-types';
-import { callGatewayApi } from '../../../utils/userGatewayClient.js';
+import {
+  callGatewayApi,
+  toGatewayUser,
+  type GatewayUser,
+} from '../../../utils/userGatewayClient.js';
 import {
   type SettingsDashboardConfig,
   type SettingsDashboardSession,
@@ -76,7 +80,7 @@ export async function handleDefaultsEdit(context: DeferredCommandContext): Promi
   logger.debug({ userId }, '[User Defaults] Opening dashboard');
 
   try {
-    const data = await fetchAndConvertSettingsData(userId);
+    const data = await fetchAndConvertSettingsData(toGatewayUser(context.user));
 
     await createSettingsDashboard(context.interaction, {
       config: USER_DEFAULTS_CONFIG,
@@ -144,10 +148,10 @@ export function isUserDefaultsInteraction(customId: string): boolean {
 /**
  * Fetch resolved config from API and convert to dashboard SettingsData format.
  */
-async function fetchAndConvertSettingsData(userId: string): Promise<SettingsData> {
+async function fetchAndConvertSettingsData(user: GatewayUser): Promise<SettingsData> {
   const result = await callGatewayApi<ResolveDefaultsResponse>(
     '/user/config-overrides/resolve-defaults',
-    { method: 'GET', userId, timeout: GATEWAY_TIMEOUTS.DEFERRED }
+    { method: 'GET', user, timeout: GATEWAY_TIMEOUTS.DEFERRED }
   );
 
   if (!result.ok) {
@@ -180,10 +184,11 @@ async function handleSettingUpdate(
       return { success: false, error: 'Unknown setting' };
     }
 
+    const user = toGatewayUser(interaction.user);
     const result = await callGatewayApi('/user/config-overrides/defaults', {
       method: 'PATCH',
       body,
-      userId,
+      user,
       timeout: GATEWAY_TIMEOUTS.DEFERRED,
     });
 
@@ -193,7 +198,7 @@ async function handleSettingUpdate(
     }
 
     // Re-fetch resolved data to get updated effective values and sources
-    const newData = await fetchAndConvertSettingsData(userId);
+    const newData = await fetchAndConvertSettingsData(user);
 
     logger.info({ settingId, newValue, userId }, '[User Defaults] Setting updated');
 

--- a/services/bot-client/src/commands/settings/preset/autocomplete.test.ts
+++ b/services/bot-client/src/commands/settings/preset/autocomplete.test.ts
@@ -24,6 +24,11 @@ vi.mock('@tzurot/common-types', async () => {
 // Mock the gateway client
 vi.mock('../../../utils/userGatewayClient.js', () => ({
   callGatewayApi: vi.fn(),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock the autocomplete cache
@@ -81,6 +86,8 @@ describe('handleAutocomplete', () => {
 
     mockUser = {
       id: 'user-123',
+      username: 'testuser',
+      globalName: 'testuser',
     } as User;
 
     mockInteraction = {
@@ -127,7 +134,11 @@ describe('handleAutocomplete', () => {
 
       await handleAutocomplete(mockInteraction);
 
-      expect(mockGetCachedPersonalities).toHaveBeenCalledWith('user-123');
+      expect(mockGetCachedPersonalities).toHaveBeenCalledWith({
+        discordId: 'user-123',
+        username: 'testuser',
+        displayName: 'testuser',
+      });
       // 🔒 = owned + private, includes slug in parentheses, value is id (model override API expects ID)
       expect(mockInteraction.respond).toHaveBeenCalledWith([
         { name: '🔒 Test Bot (testbot)', value: 'p1' },
@@ -281,7 +292,9 @@ describe('handleAutocomplete', () => {
 
       await handleAutocomplete(mockInteraction);
 
-      expect(callGatewayApi).toHaveBeenCalledWith('/user/llm-config', { userId: 'user-123' });
+      expect(callGatewayApi).toHaveBeenCalledWith('/user/llm-config', {
+        user: { discordId: 'user-123', username: 'testuser', displayName: 'testuser' },
+      });
       expect(mockInteraction.respond).toHaveBeenCalledWith([
         {
           name: '🌐⭐ Claude Config · claude-sonnet-4',

--- a/services/bot-client/src/commands/settings/preset/autocomplete.test.ts
+++ b/services/bot-client/src/commands/settings/preset/autocomplete.test.ts
@@ -22,14 +22,15 @@ vi.mock('@tzurot/common-types', async () => {
 });
 
 // Mock the gateway client
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: vi.fn(),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
+    '../../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: vi.fn(),
+  };
+});
 
 // Mock the autocomplete cache
 const mockGetCachedPersonalities = vi.fn();

--- a/services/bot-client/src/commands/settings/preset/autocomplete.ts
+++ b/services/bot-client/src/commands/settings/preset/autocomplete.ts
@@ -14,7 +14,7 @@ import {
   type AIProvider,
   type AutocompleteBadge,
 } from '@tzurot/common-types';
-import { callGatewayApi } from '../../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
 import { handlePersonalityAutocomplete } from '../../../utils/autocomplete/index.js';
 
 /**
@@ -80,9 +80,10 @@ async function handlePresetAutocomplete(
   userId: string
 ): Promise<void> {
   // Fetch configs and wallet status in parallel
+  const user = toGatewayUser(interaction.user);
   const [configResult, walletResult] = await Promise.all([
-    callGatewayApi<{ configs: LlmConfigSummary[] }>('/user/llm-config', { userId }),
-    callGatewayApi<WalletListResponse>('/wallet/list', { userId }),
+    callGatewayApi<{ configs: LlmConfigSummary[] }>('/user/llm-config', { user }),
+    callGatewayApi<WalletListResponse>('/wallet/list', { user }),
   ]);
 
   if (!configResult.ok) {

--- a/services/bot-client/src/commands/settings/preset/browse.test.ts
+++ b/services/bot-client/src/commands/settings/preset/browse.test.ts
@@ -13,6 +13,11 @@ import { EmbedBuilder } from 'discord.js';
 vi.mock('../../../utils/userGatewayClient.js', () => ({
   callGatewayApi: vi.fn(),
   GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 vi.mock('@tzurot/common-types', async importOriginal => {

--- a/services/bot-client/src/commands/settings/preset/browse.test.ts
+++ b/services/bot-client/src/commands/settings/preset/browse.test.ts
@@ -10,15 +10,15 @@ import { handleBrowseOverrides } from './browse.js';
 import { EmbedBuilder } from 'discord.js';
 
 // Mock dependencies
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: vi.fn(),
-  GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
+    '../../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: vi.fn(),
+  };
+});
 
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal();

--- a/services/bot-client/src/commands/settings/preset/browse.ts
+++ b/services/bot-client/src/commands/settings/preset/browse.ts
@@ -6,7 +6,11 @@
 import { EmbedBuilder, escapeMarkdown } from 'discord.js';
 import { createLogger, DISCORD_COLORS, type ModelOverrideSummary } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import { callGatewayApi, GATEWAY_TIMEOUTS } from '../../../utils/userGatewayClient.js';
+import {
+  callGatewayApi,
+  GATEWAY_TIMEOUTS,
+  toGatewayUser,
+} from '../../../utils/userGatewayClient.js';
 
 const logger = createLogger('settings-preset-browse');
 
@@ -21,7 +25,10 @@ export async function handleBrowseOverrides(context: DeferredCommandContext): Pr
   const userId = context.user.id;
 
   try {
-    const result = await callGatewayApi<ListResponse>('/user/model-override', { userId, timeout: GATEWAY_TIMEOUTS.DEFERRED });
+    const result = await callGatewayApi<ListResponse>('/user/model-override', {
+      user: toGatewayUser(context.user),
+      timeout: GATEWAY_TIMEOUTS.DEFERRED,
+    });
 
     if (!result.ok) {
       logger.warn({ userId, status: result.status }, '[Me/Preset] Failed to list overrides');

--- a/services/bot-client/src/commands/settings/preset/clear-default.test.ts
+++ b/services/bot-client/src/commands/settings/preset/clear-default.test.ts
@@ -12,6 +12,11 @@ import { mockClearDefaultConfigResponse } from '@tzurot/common-types';
 // Mock userGatewayClient
 vi.mock('../../../utils/userGatewayClient.js', () => ({
   callGatewayApi: vi.fn(),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 import { callGatewayApi } from '../../../utils/userGatewayClient.js';
@@ -55,7 +60,11 @@ describe('handleClearDefault', () => {
 
     expect(callGatewayApi).toHaveBeenCalledWith('/user/model-override/default', {
       method: 'DELETE',
-      userId: '123456789',
+      user: {
+        discordId: '123456789',
+        username: 'testuser',
+        displayName: 'testuser',
+      },
     });
   });
 

--- a/services/bot-client/src/commands/settings/preset/clear-default.test.ts
+++ b/services/bot-client/src/commands/settings/preset/clear-default.test.ts
@@ -10,14 +10,15 @@ import { handleClearDefault } from './clear-default.js';
 import { mockClearDefaultConfigResponse } from '@tzurot/common-types';
 
 // Mock userGatewayClient
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: vi.fn(),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
+    '../../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: vi.fn(),
+  };
+});
 
 import { callGatewayApi } from '../../../utils/userGatewayClient.js';
 
@@ -45,7 +46,7 @@ describe('handleClearDefault', () => {
 
   function createMockContext() {
     return {
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       editReply: mockEditReply,
     } as unknown as Parameters<typeof handleClearDefault>[0];
   }

--- a/services/bot-client/src/commands/settings/preset/clear-default.ts
+++ b/services/bot-client/src/commands/settings/preset/clear-default.ts
@@ -7,7 +7,7 @@
 import { EmbedBuilder } from 'discord.js';
 import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
 
 const logger = createLogger('settings-preset-clear-default');
 
@@ -20,7 +20,7 @@ export async function handleClearDefault(context: DeferredCommandContext): Promi
   try {
     const result = await callGatewayApi<{ deleted: boolean }>('/user/model-override/default', {
       method: 'DELETE',
-      userId,
+      user: toGatewayUser(context.user),
     });
 
     if (!result.ok) {

--- a/services/bot-client/src/commands/settings/preset/default.test.ts
+++ b/services/bot-client/src/commands/settings/preset/default.test.ts
@@ -31,6 +31,11 @@ vi.mock('@tzurot/common-types', async () => {
 vi.mock('../../../utils/userGatewayClient.js', () => ({
   callGatewayApi: vi.fn(),
   GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 import { callGatewayApi } from '../../../utils/userGatewayClient.js';
@@ -91,7 +96,11 @@ describe('handleDefault', () => {
 
     expect(callGatewayApi).toHaveBeenCalledWith('/user/model-override/default', {
       method: 'PUT',
-      userId: 'user-123',
+      user: {
+        discordId: 'user-123',
+        username: 'testuser',
+        displayName: 'testuser',
+      },
       body: { configId: '00000000-0000-4000-8000-000000000456' },
     });
   });
@@ -243,7 +252,11 @@ describe('handleDefault', () => {
     // Should call the set-default API
     expect(callGatewayApi).toHaveBeenCalledWith('/user/model-override/default', {
       method: 'PUT',
-      userId: 'user-123',
+      user: {
+        discordId: 'user-123',
+        username: 'testuser',
+        displayName: 'testuser',
+      },
       body: { configId: '00000000-0000-4000-8000-000000000f00' },
     });
 

--- a/services/bot-client/src/commands/settings/preset/default.test.ts
+++ b/services/bot-client/src/commands/settings/preset/default.test.ts
@@ -28,15 +28,15 @@ vi.mock('@tzurot/common-types', async () => {
 });
 
 // Mock the gateway client
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: vi.fn(),
-  GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
+    '../../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: vi.fn(),
+  };
+});
 
 import { callGatewayApi } from '../../../utils/userGatewayClient.js';
 
@@ -50,7 +50,7 @@ describe('handleDefault', () => {
 
   function createMockContext(configId: string) {
     return {
-      user: { id: 'user-123' },
+      user: { id: 'user-123', username: 'testuser' },
       interaction: {
         options: {
           getString: (_name: string, _required?: boolean) => configId,

--- a/services/bot-client/src/commands/settings/preset/default.ts
+++ b/services/bot-client/src/commands/settings/preset/default.ts
@@ -7,7 +7,7 @@
 import { EmbedBuilder } from 'discord.js';
 import { createLogger, DISCORD_COLORS, settingsPresetDefaultOptions } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
 import { handleUnlockModelsUpsell, checkGuestModePremiumAccess } from './guestModeValidation.js';
 
 const logger = createLogger('settings-preset-default');
@@ -32,14 +32,18 @@ export async function handleDefault(context: DeferredCommandContext): Promise<vo
   }
 
   try {
-    const { blocked } = await checkGuestModePremiumAccess(context, configId, userId);
+    const { blocked } = await checkGuestModePremiumAccess(
+      context,
+      configId,
+      toGatewayUser(context.user)
+    );
     if (blocked) {
       return;
     }
 
     const result = await callGatewayApi<SetDefaultResponse>('/user/model-override/default', {
       method: 'PUT',
-      userId,
+      user: toGatewayUser(context.user),
       body: { configId },
     });
 

--- a/services/bot-client/src/commands/settings/preset/guestModeValidation.test.ts
+++ b/services/bot-client/src/commands/settings/preset/guestModeValidation.test.ts
@@ -2,10 +2,20 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as gatewayClient from '../../../utils/userGatewayClient.js';
 import { handleUnlockModelsUpsell, checkGuestModePremiumAccess } from './guestModeValidation.js';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
+import type { GatewayUser } from '../../../utils/userGatewayClient.js';
+
+function mkUser(discordId = 'user-1'): GatewayUser {
+  return { discordId, username: 'test-user', displayName: 'Test User' };
+}
 
 vi.mock('../../../utils/userGatewayClient.js', () => ({
   callGatewayApi: vi.fn(),
   GATEWAY_TIMEOUTS: { DEFERRED: 10000 },
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 vi.mock('./autocomplete.js', () => ({
@@ -67,7 +77,7 @@ describe('guestModeValidation', () => {
         } as never)
         .mockResolvedValueOnce({ ok: true, data: { configs: [] } } as never);
 
-      const result = await checkGuestModePremiumAccess(createMockContext(), 'config-1', 'user-1');
+      const result = await checkGuestModePremiumAccess(createMockContext(), 'config-1', mkUser());
       expect(result.isGuestMode).toBe(false);
       expect(result.blocked).toBe(false);
     });
@@ -80,7 +90,7 @@ describe('guestModeValidation', () => {
           data: { configs: [{ id: 'config-1', name: 'Free Config', model: 'free-gpt' }] },
         } as never);
 
-      const result = await checkGuestModePremiumAccess(createMockContext(), 'config-1', 'user-1');
+      const result = await checkGuestModePremiumAccess(createMockContext(), 'config-1', mkUser());
       expect(result.isGuestMode).toBe(true);
       expect(result.blocked).toBe(false);
     });
@@ -95,7 +105,7 @@ describe('guestModeValidation', () => {
           },
         } as never);
 
-      const result = await checkGuestModePremiumAccess(createMockContext(), 'config-1', 'user-1');
+      const result = await checkGuestModePremiumAccess(createMockContext(), 'config-1', mkUser());
       expect(result.isGuestMode).toBe(true);
       expect(result.blocked).toBe(true);
       expect(mockEditReply).toHaveBeenCalled();
@@ -112,7 +122,7 @@ describe('guestModeValidation', () => {
       const result = await checkGuestModePremiumAccess(
         createMockContext(),
         'config-not-found',
-        'user-1'
+        mkUser()
       );
       expect(result.isGuestMode).toBe(true);
       expect(result.blocked).toBe(false);

--- a/services/bot-client/src/commands/settings/preset/guestModeValidation.test.ts
+++ b/services/bot-client/src/commands/settings/preset/guestModeValidation.test.ts
@@ -8,15 +8,15 @@ function mkUser(discordId = 'user-1'): GatewayUser {
   return { discordId, username: 'test-user', displayName: 'Test User' };
 }
 
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: vi.fn(),
-  GATEWAY_TIMEOUTS: { DEFERRED: 10000 },
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
+    '../../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: vi.fn(),
+  };
+});
 
 vi.mock('./autocomplete.js', () => ({
   UNLOCK_MODELS_VALUE: '__UNLOCK_ALL_MODELS__',

--- a/services/bot-client/src/commands/settings/preset/guestModeValidation.ts
+++ b/services/bot-client/src/commands/settings/preset/guestModeValidation.ts
@@ -15,7 +15,11 @@ import {
   type LlmConfigSummary,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import { callGatewayApi, GATEWAY_TIMEOUTS } from '../../../utils/userGatewayClient.js';
+import {
+  callGatewayApi,
+  GATEWAY_TIMEOUTS,
+  type GatewayUser,
+} from '../../../utils/userGatewayClient.js';
 import { UNLOCK_MODELS_VALUE } from './autocomplete.js';
 
 const logger = createLogger('settings-preset-guest-mode');
@@ -77,15 +81,15 @@ export interface GuestModeCheckResult {
 export async function checkGuestModePremiumAccess(
   context: DeferredCommandContext,
   configId: string,
-  userId: string
+  user: GatewayUser
 ): Promise<GuestModeCheckResult & { blocked: boolean }> {
   const [walletResult, configsResult] = await Promise.all([
     callGatewayApi<WalletListResponse>('/wallet/list', {
-      userId,
+      user,
       timeout: GATEWAY_TIMEOUTS.DEFERRED,
     }),
     callGatewayApi<ConfigListResponse>('/user/llm-config', {
-      userId,
+      user,
       timeout: GATEWAY_TIMEOUTS.DEFERRED,
     }),
   ]);
@@ -109,7 +113,7 @@ export async function checkGuestModePremiumAccess(
 
       await context.editReply({ embeds: [embed] });
       logger.info(
-        { userId, configId, configName: selectedConfig.name, isGuestMode },
+        { userId: user.discordId, configId, configName: selectedConfig.name, isGuestMode },
         '[Me/Preset] Guest mode user tried to select premium model'
       );
       return { isGuestMode, blocked: true };

--- a/services/bot-client/src/commands/settings/preset/handlers.test.ts
+++ b/services/bot-client/src/commands/settings/preset/handlers.test.ts
@@ -44,6 +44,11 @@ const mockCallGatewayApi = vi.fn();
 vi.mock('../../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
   GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock commandHelpers (only used by reset for createSuccessEmbed/createInfoEmbed)
@@ -92,7 +97,9 @@ describe('Preset Command Handlers', () => {
 
       expect(mockCallGatewayApi).toHaveBeenCalledWith(
         '/user/model-override',
-        expect.objectContaining({ userId: '123456789' })
+        expect.objectContaining({
+          user: { discordId: '123456789', username: 'testuser', displayName: 'testuser' },
+        })
       );
       expect(mockEditReply).toHaveBeenCalledWith({
         embeds: [
@@ -192,7 +199,11 @@ describe('Preset Command Handlers', () => {
         '/user/model-override',
         expect.objectContaining({
           method: 'PUT',
-          userId: '123456789',
+          user: {
+            discordId: '123456789',
+            username: 'testuser',
+            displayName: 'testuser',
+          },
           body: { personalityId: PERSONALITY_ID_1, configId: CONFIG_ID_1 },
         })
       );
@@ -250,7 +261,11 @@ describe('Preset Command Handlers', () => {
         `/user/model-override/${PERSONALITY_ID_1}`,
         expect.objectContaining({
           method: 'DELETE',
-          userId: '123456789',
+          user: {
+            discordId: '123456789',
+            username: 'testuser',
+            displayName: 'testuser',
+          },
         })
       );
       expect(mockCreateSuccessEmbed).toHaveBeenCalledWith(

--- a/services/bot-client/src/commands/settings/preset/handlers.test.ts
+++ b/services/bot-client/src/commands/settings/preset/handlers.test.ts
@@ -41,15 +41,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 // Note: Tests use objectContaining for API call assertions to focus on the essential
 // userId parameter while ignoring implementation details like timeout values.
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
+    '../../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Mock commandHelpers (only used by reset for createSuccessEmbed/createInfoEmbed)
 const mockCreateSuccessEmbed = vi.fn().mockReturnValue({ data: { title: 'Success' } });
@@ -69,7 +69,7 @@ describe('Preset Command Handlers', () => {
   describe('handleBrowseOverrides', () => {
     function createMockContext() {
       return {
-        user: { id: '123456789' },
+        user: { id: '123456789', username: 'testuser' },
         editReply: mockEditReply,
       } as unknown as Parameters<typeof handleBrowseOverrides>[0];
     }
@@ -146,7 +146,7 @@ describe('Preset Command Handlers', () => {
   describe('handleSet', () => {
     function createMockContext(personalityId = PERSONALITY_ID_1, configId = CONFIG_ID_1) {
       return {
-        user: { id: '123456789' },
+        user: { id: '123456789', username: 'testuser' },
         interaction: {
           options: {
             getString: (name: string) => {
@@ -236,7 +236,7 @@ describe('Preset Command Handlers', () => {
   describe('handleReset', () => {
     function createMockContext(personalityId = PERSONALITY_ID_1) {
       return {
-        user: { id: '123456789' },
+        user: { id: '123456789', username: 'testuser' },
         interaction: {
           options: {
             getString: (name: string) => {

--- a/services/bot-client/src/commands/settings/preset/reset.test.ts
+++ b/services/bot-client/src/commands/settings/preset/reset.test.ts
@@ -9,14 +9,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { handleReset } from './reset.js';
 
 // Mock dependencies
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: vi.fn(),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
+    '../../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: vi.fn(),
+  };
+});
 
 // Create mock EmbedBuilder-like objects
 function createMockEmbed(title: string, description?: string) {
@@ -69,7 +70,7 @@ describe('Me Preset Reset Handler', () => {
 
   function createMockContext(personalityId: string) {
     return {
-      user: { id: 'user-123' },
+      user: { id: 'user-123', username: 'testuser' },
       interaction: {
         options: {
           getString: (_name: string, _required?: boolean) => personalityId,

--- a/services/bot-client/src/commands/settings/preset/reset.test.ts
+++ b/services/bot-client/src/commands/settings/preset/reset.test.ts
@@ -11,6 +11,11 @@ import { handleReset } from './reset.js';
 // Mock dependencies
 vi.mock('../../../utils/userGatewayClient.js', () => ({
   callGatewayApi: vi.fn(),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Create mock EmbedBuilder-like objects
@@ -85,7 +90,11 @@ describe('Me Preset Reset Handler', () => {
 
       expect(callGatewayApi).toHaveBeenCalledWith('/user/model-override/personality-123', {
         method: 'DELETE',
-        userId: 'user-123',
+        user: {
+          discordId: 'user-123',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
       });
 
       expect(mockCreateSuccessEmbed).toHaveBeenCalledWith(

--- a/services/bot-client/src/commands/settings/preset/reset.ts
+++ b/services/bot-client/src/commands/settings/preset/reset.ts
@@ -5,7 +5,7 @@
 
 import { createLogger, settingsPresetResetOptions } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
 import { createSuccessEmbed, createInfoEmbed } from '../../../utils/commandHelpers.js';
 
 const logger = createLogger('settings-preset-reset');
@@ -26,7 +26,7 @@ export async function handleReset(context: DeferredCommandContext): Promise<void
   try {
     const result = await callGatewayApi<ResetResponse>(`/user/model-override/${personalityId}`, {
       method: 'DELETE',
-      userId,
+      user: toGatewayUser(context.user),
     });
 
     if (!result.ok) {

--- a/services/bot-client/src/commands/settings/preset/set.test.ts
+++ b/services/bot-client/src/commands/settings/preset/set.test.ts
@@ -13,6 +13,11 @@ import { EmbedBuilder } from 'discord.js';
 vi.mock('../../../utils/userGatewayClient.js', () => ({
   callGatewayApi: vi.fn(),
   GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 vi.mock('@tzurot/common-types', async importOriginal => {
@@ -97,7 +102,11 @@ describe('Me Preset Set Handler', () => {
       // Verify set override API call
       expect(callGatewayApi).toHaveBeenCalledWith('/user/model-override', {
         method: 'PUT',
-        userId: 'user-123',
+        user: {
+          discordId: 'user-123',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         body: { personalityId: 'personality-1', configId: 'config-1' },
       });
 
@@ -174,7 +183,11 @@ describe('Me Preset Set Handler', () => {
       // Should call the set override API
       expect(callGatewayApi).toHaveBeenCalledWith('/user/model-override', {
         method: 'PUT',
-        userId: 'user-123',
+        user: {
+          discordId: 'user-123',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         body: { personalityId: 'personality-1', configId: 'free-config' },
       });
     });

--- a/services/bot-client/src/commands/settings/preset/set.test.ts
+++ b/services/bot-client/src/commands/settings/preset/set.test.ts
@@ -10,15 +10,15 @@ import { handleSet } from './set.js';
 import { EmbedBuilder } from 'discord.js';
 
 // Mock dependencies
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: vi.fn(),
-  GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
+    '../../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: vi.fn(),
+  };
+});
 
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal();
@@ -44,7 +44,7 @@ describe('Me Preset Set Handler', () => {
 
   function createMockContext(personalityId: string, presetId: string) {
     return {
-      user: { id: 'user-123' },
+      user: { id: 'user-123', username: 'testuser' },
       interaction: {
         options: {
           getString: (name: string, _required?: boolean) => {

--- a/services/bot-client/src/commands/settings/preset/set.ts
+++ b/services/bot-client/src/commands/settings/preset/set.ts
@@ -6,7 +6,7 @@
 import { EmbedBuilder } from 'discord.js';
 import { createLogger, DISCORD_COLORS, settingsPresetSetOptions } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
 import { handleUnlockModelsUpsell, checkGuestModePremiumAccess } from './guestModeValidation.js';
 
 const logger = createLogger('settings-preset-set');
@@ -34,14 +34,15 @@ export async function handleSet(context: DeferredCommandContext): Promise<void> 
   }
 
   try {
-    const { isGuestMode, blocked } = await checkGuestModePremiumAccess(context, configId, userId);
+    const user = toGatewayUser(context.user);
+    const { isGuestMode, blocked } = await checkGuestModePremiumAccess(context, configId, user);
     if (blocked) {
       return;
     }
 
     const result = await callGatewayApi<SetResponse>('/user/model-override', {
       method: 'PUT',
-      userId,
+      user,
       body: { personalityId, configId },
     });
 

--- a/services/bot-client/src/commands/settings/timezone/get.test.ts
+++ b/services/bot-client/src/commands/settings/timezone/get.test.ts
@@ -27,15 +27,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 // Note: Tests use objectContaining for API call assertions to focus on the essential
 // userId parameter while ignoring implementation details like timeout values.
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
+    '../../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Create mock EmbedBuilder-like objects
 function createMockEmbed(title: string, description?: string) {
@@ -81,7 +81,7 @@ describe('handleTimezoneGet', () => {
 
   function createMockContext() {
     return {
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       editReply: mockEditReply,
     } as unknown as Parameters<typeof handleTimezoneGet>[0];
   }

--- a/services/bot-client/src/commands/settings/timezone/get.test.ts
+++ b/services/bot-client/src/commands/settings/timezone/get.test.ts
@@ -30,6 +30,11 @@ const mockCallGatewayApi = vi.fn();
 vi.mock('../../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
   GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Create mock EmbedBuilder-like objects
@@ -91,7 +96,9 @@ describe('handleTimezoneGet', () => {
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith(
       '/user/timezone',
-      expect.objectContaining({ userId: '123456789' })
+      expect.objectContaining({
+        user: { discordId: '123456789', username: 'testuser', displayName: 'testuser' },
+      })
     );
     expect(mockEditReply).toHaveBeenCalledWith({
       embeds: [

--- a/services/bot-client/src/commands/settings/timezone/get.ts
+++ b/services/bot-client/src/commands/settings/timezone/get.ts
@@ -5,7 +5,11 @@
 
 import { createLogger, TIMEZONE_DISCORD_CHOICES } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import { callGatewayApi, GATEWAY_TIMEOUTS } from '../../../utils/userGatewayClient.js';
+import {
+  callGatewayApi,
+  GATEWAY_TIMEOUTS,
+  toGatewayUser,
+} from '../../../utils/userGatewayClient.js';
 import { createInfoEmbed } from '../../../utils/commandHelpers.js';
 import { getCurrentTimeInTimezone, type TimezoneResponse } from './utils.js';
 
@@ -19,7 +23,7 @@ export async function handleTimezoneGet(context: DeferredCommandContext): Promis
 
   try {
     const result = await callGatewayApi<TimezoneResponse>('/user/timezone', {
-      userId,
+      user: toGatewayUser(context.user),
       timeout: GATEWAY_TIMEOUTS.DEFERRED,
     });
 

--- a/services/bot-client/src/commands/settings/timezone/set.test.ts
+++ b/services/bot-client/src/commands/settings/timezone/set.test.ts
@@ -27,6 +27,11 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 const mockCallGatewayApi = vi.fn();
 vi.mock('../../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Create mock EmbedBuilder-like objects
@@ -95,7 +100,11 @@ describe('handleTimezoneSet', () => {
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/timezone', {
       method: 'PUT',
-      userId: '123456789',
+      user: {
+        discordId: '123456789',
+        username: 'testuser',
+        displayName: 'testuser',
+      },
       body: { timezone: 'America/New_York' },
     });
     expect(mockEditReply).toHaveBeenCalledWith({

--- a/services/bot-client/src/commands/settings/timezone/set.test.ts
+++ b/services/bot-client/src/commands/settings/timezone/set.test.ts
@@ -25,14 +25,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 // Mock userGatewayClient
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
+    '../../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Create mock EmbedBuilder-like objects
 function createMockEmbed(title: string, description?: string) {
@@ -77,7 +78,7 @@ describe('handleTimezoneSet', () => {
 
   function createMockContext(options: { timezone?: string } = {}) {
     return {
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       interaction: {
         options: {
           getString: (name: string, _required?: boolean) => {

--- a/services/bot-client/src/commands/settings/timezone/set.ts
+++ b/services/bot-client/src/commands/settings/timezone/set.ts
@@ -9,7 +9,7 @@ import {
   settingsTimezoneSetOptions,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import { callGatewayApi } from '../../../utils/userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
 import { createSuccessEmbed } from '../../../utils/commandHelpers.js';
 import { getCurrentTimeInTimezone, type TimezoneResponse } from './utils.js';
 
@@ -26,7 +26,7 @@ export async function handleTimezoneSet(context: DeferredCommandContext): Promis
   try {
     const result = await callGatewayApi<TimezoneResponse>('/user/timezone', {
       method: 'PUT',
-      userId,
+      user: toGatewayUser(context.user),
       body: { timezone },
     });
 

--- a/services/bot-client/src/commands/settings/voices/browse.test.ts
+++ b/services/bot-client/src/commands/settings/voices/browse.test.ts
@@ -26,15 +26,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 });
 
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
+    '../../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 /** Generate N voice entries for pagination tests */
 function generateVoices(count: number): VoiceEntry[] {
@@ -54,7 +54,7 @@ describe('handleBrowseVoices', () => {
 
   function createMockContext(): DeferredCommandContext {
     const mockInteraction = {
-      user: { id: 'user-123' },
+      user: { id: 'user-123' , username: 'testuser' },
       editReply: mockEditReply,
     } as unknown as ChatInputCommandInteraction;
 
@@ -241,7 +241,7 @@ describe('handleVoiceBrowsePagination', () => {
   function createMockButtonInteraction(customId: string): ButtonInteraction {
     return {
       customId,
-      user: { id: 'user-123' },
+      user: { id: 'user-123' , username: 'testuser' },
       deferUpdate: mockDeferUpdate,
       editReply: mockEditReply,
     } as unknown as ButtonInteraction;

--- a/services/bot-client/src/commands/settings/voices/browse.test.ts
+++ b/services/bot-client/src/commands/settings/voices/browse.test.ts
@@ -29,6 +29,11 @@ const mockCallGatewayApi = vi.fn();
 vi.mock('../../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
   GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 /** Generate N voice entries for pagination tests */
@@ -90,7 +95,7 @@ describe('handleBrowseVoices', () => {
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith(
       '/user/voices',
-      expect.objectContaining({ userId: 'user-123' })
+      expect.objectContaining({ user: { discordId: 'user-123', username: 'testuser', displayName: 'testuser' } })
     );
     expect(mockEditReply).toHaveBeenCalledWith({
       embeds: [

--- a/services/bot-client/src/commands/settings/voices/browse.ts
+++ b/services/bot-client/src/commands/settings/voices/browse.ts
@@ -7,7 +7,7 @@ import { EmbedBuilder } from 'discord.js';
 import type { ButtonInteraction, ActionRowBuilder, ButtonBuilder } from 'discord.js';
 import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import { callGatewayApi, GATEWAY_TIMEOUTS } from '../../../utils/userGatewayClient.js';
+import { callGatewayApi, GATEWAY_TIMEOUTS, toGatewayUser } from '../../../utils/userGatewayClient.js';
 import {
   ITEMS_PER_PAGE,
   createBrowseCustomIdHelpers,
@@ -115,7 +115,7 @@ export async function handleBrowseVoices(context: DeferredCommandContext): Promi
 
   try {
     const result = await callGatewayApi<VoicesListResponse>('/user/voices', {
-      userId,
+      user: toGatewayUser(context.user),
       timeout: GATEWAY_TIMEOUTS.DEFERRED,
     });
 
@@ -153,7 +153,7 @@ export async function handleVoiceBrowsePagination(interaction: ButtonInteraction
 
   try {
     const result = await callGatewayApi<VoicesListResponse>('/user/voices', {
-      userId,
+      user: toGatewayUser(interaction.user),
       timeout: GATEWAY_TIMEOUTS.DEFERRED,
     });
 

--- a/services/bot-client/src/commands/settings/voices/clear.test.ts
+++ b/services/bot-client/src/commands/settings/voices/clear.test.ts
@@ -30,15 +30,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 });
 
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000, BULK_OPERATION: 30000 },
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
+    '../../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 const mockBuildDestructiveWarning = vi.fn().mockReturnValue({ embeds: [], components: [] });
 const mockHandleDestructiveConfirmButton = vi.fn();

--- a/services/bot-client/src/commands/settings/voices/clear.test.ts
+++ b/services/bot-client/src/commands/settings/voices/clear.test.ts
@@ -33,6 +33,11 @@ const mockCallGatewayApi = vi.fn();
 vi.mock('../../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
   GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000, BULK_OPERATION: 30000 },
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 const mockBuildDestructiveWarning = vi.fn().mockReturnValue({ embeds: [], components: [] });

--- a/services/bot-client/src/commands/settings/voices/clear.ts
+++ b/services/bot-client/src/commands/settings/voices/clear.ts
@@ -7,7 +7,7 @@ import { EmbedBuilder } from 'discord.js';
 import type { ButtonInteraction, ModalSubmitInteraction } from 'discord.js';
 import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import { callGatewayApi, GATEWAY_TIMEOUTS } from '../../../utils/userGatewayClient.js';
+import { callGatewayApi, GATEWAY_TIMEOUTS, toGatewayUser } from '../../../utils/userGatewayClient.js';
 import {
   buildDestructiveWarning,
   createHardDeleteConfig,
@@ -40,7 +40,7 @@ export async function handleClearVoices(context: DeferredCommandContext): Promis
 
   try {
     const result = await callGatewayApi<VoicesListResponse>('/user/voices', {
-      userId,
+      user: toGatewayUser(context.user),
       timeout: GATEWAY_TIMEOUTS.DEFERRED,
     });
 
@@ -103,7 +103,7 @@ export async function handleVoiceClearModalSubmit(
   await handleDestructiveModalSubmit(interaction, 'DELETE', async () => {
     const result = await callGatewayApi<VoiceClearResponse>('/user/voices/clear', {
       method: 'POST',
-      userId,
+      user: toGatewayUser(interaction.user),
       timeout: GATEWAY_TIMEOUTS.BULK_OPERATION,
     });
 

--- a/services/bot-client/src/commands/settings/voices/delete.test.ts
+++ b/services/bot-client/src/commands/settings/voices/delete.test.ts
@@ -25,6 +25,11 @@ const mockCallGatewayApi = vi.fn();
 vi.mock('../../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
   GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 describe('handleDeleteVoice', () => {
@@ -70,7 +75,7 @@ describe('handleDeleteVoice', () => {
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith(
       '/user/voices/voice-1',
-      expect.objectContaining({ method: 'DELETE', userId: 'user-123' })
+      expect.objectContaining({ method: 'DELETE', user: { discordId: 'user-123', username: 'testuser', displayName: 'testuser' } })
     );
     expect(mockEditReply).toHaveBeenCalledWith({
       embeds: [

--- a/services/bot-client/src/commands/settings/voices/delete.test.ts
+++ b/services/bot-client/src/commands/settings/voices/delete.test.ts
@@ -22,15 +22,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 });
 
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
+    '../../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 describe('handleDeleteVoice', () => {
   const mockEditReply = vi.fn();
@@ -41,7 +41,7 @@ describe('handleDeleteVoice', () => {
 
   function createMockContext(voiceId = 'voice-1'): DeferredCommandContext {
     const mockInteraction = {
-      user: { id: 'user-123' },
+      user: { id: 'user-123' , username: 'testuser' },
       editReply: mockEditReply,
     } as unknown as ChatInputCommandInteraction;
 
@@ -124,7 +124,7 @@ describe('handleVoiceAutocomplete', () => {
 
   function createMockAutocomplete(query = ''): AutocompleteInteraction {
     return {
-      user: { id: 'user-123' },
+      user: { id: 'user-123' , username: 'testuser' },
       options: {
         getFocused: vi.fn().mockReturnValue(query),
         getSubcommandGroup: vi.fn().mockReturnValue('voices'),
@@ -212,8 +212,8 @@ describe('handleVoiceAutocomplete', () => {
     });
     const mockEditReply = vi.fn();
     const mockContext = {
-      interaction: { user: { id: 'user-123' }, editReply: mockEditReply },
-      user: { id: 'user-123' },
+      interaction: { user: { id: 'user-123' , username: 'testuser' }, editReply: mockEditReply },
+      user: { id: 'user-123' , username: 'testuser' },
       guild: null,
       member: null,
       channel: null,

--- a/services/bot-client/src/commands/settings/voices/delete.ts
+++ b/services/bot-client/src/commands/settings/voices/delete.ts
@@ -7,7 +7,7 @@ import { EmbedBuilder } from 'discord.js';
 import type { AutocompleteInteraction } from 'discord.js';
 import { createLogger, DISCORD_COLORS, DISCORD_LIMITS } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import { callGatewayApi, GATEWAY_TIMEOUTS } from '../../../utils/userGatewayClient.js';
+import { callGatewayApi, GATEWAY_TIMEOUTS, toGatewayUser } from '../../../utils/userGatewayClient.js';
 import type { VoicesListResponse } from './types.js';
 import { getCachedVoices, setCachedVoices, invalidateVoiceCache } from './voiceCache.js';
 
@@ -33,7 +33,7 @@ export async function handleDeleteVoice(context: DeferredCommandContext): Promis
       `/user/voices/${encodeURIComponent(voiceId)}`,
       {
         method: 'DELETE',
-        userId,
+        user: toGatewayUser(context.user),
         timeout: GATEWAY_TIMEOUTS.DEFERRED,
       }
     );
@@ -75,7 +75,7 @@ export async function handleVoiceAutocomplete(interaction: AutocompleteInteracti
 
     if (voices === null) {
       const result = await callGatewayApi<VoicesListResponse>('/user/voices', {
-        userId,
+        user: toGatewayUser(interaction.user),
         timeout: GATEWAY_TIMEOUTS.AUTOCOMPLETE,
       });
 

--- a/services/bot-client/src/commands/settings/voices/model.test.ts
+++ b/services/bot-client/src/commands/settings/voices/model.test.ts
@@ -24,6 +24,11 @@ const mockCallGatewayApi = vi.fn();
 vi.mock('../../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
   GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 describe('handleModelSet', () => {
@@ -72,7 +77,11 @@ describe('handleModelSet', () => {
       '/user/config-overrides/defaults',
       expect.objectContaining({
         method: 'PATCH',
-        userId: 'user-123',
+        user: {
+          discordId: 'user-123',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         body: { elevenlabsTtsModel: 'eleven_turbo_v2_5' },
       })
     );

--- a/services/bot-client/src/commands/settings/voices/model.test.ts
+++ b/services/bot-client/src/commands/settings/voices/model.test.ts
@@ -21,15 +21,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 });
 
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
+    '../../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 describe('handleModelSet', () => {
   const mockEditReply = vi.fn();
@@ -44,7 +44,7 @@ describe('handleModelSet', () => {
 
   function createMockContext(modelId = 'eleven_turbo_v2_5'): DeferredCommandContext {
     const mockInteraction = {
-      user: { id: 'user-123' },
+      user: { id: 'user-123' , username: 'testuser' },
       editReply: mockEditReply,
     } as unknown as ChatInputCommandInteraction;
 
@@ -135,7 +135,7 @@ describe('handleModelAutocomplete', () => {
 
   function createMockAutocomplete(query = ''): AutocompleteInteraction {
     return {
-      user: { id: 'user-123' },
+      user: { id: 'user-123' , username: 'testuser' },
       options: {
         getFocused: vi.fn().mockReturnValue(query),
         getSubcommandGroup: vi.fn().mockReturnValue('voices'),

--- a/services/bot-client/src/commands/settings/voices/model.ts
+++ b/services/bot-client/src/commands/settings/voices/model.ts
@@ -9,7 +9,7 @@ import { EmbedBuilder } from 'discord.js';
 import type { AutocompleteInteraction } from 'discord.js';
 import { createLogger, DISCORD_COLORS, DISCORD_LIMITS } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import { callGatewayApi, GATEWAY_TIMEOUTS } from '../../../utils/userGatewayClient.js';
+import { callGatewayApi, GATEWAY_TIMEOUTS, toGatewayUser } from '../../../utils/userGatewayClient.js';
 
 const logger = createLogger('settings-voices-model');
 
@@ -36,7 +36,7 @@ export async function handleModelSet(context: DeferredCommandContext): Promise<v
       '/user/config-overrides/defaults',
       {
         method: 'PATCH',
-        userId,
+        user: toGatewayUser(context.user),
         body: { elevenlabsTtsModel: modelId },
         timeout: GATEWAY_TIMEOUTS.DEFERRED,
       }
@@ -73,7 +73,7 @@ export async function handleModelAutocomplete(interaction: AutocompleteInteracti
 
   try {
     const result = await callGatewayApi<ModelsListResponse>('/user/voices/models', {
-      userId,
+      user: toGatewayUser(interaction.user),
       timeout: GATEWAY_TIMEOUTS.AUTOCOMPLETE,
     });
 

--- a/services/bot-client/src/commands/shapes/autocomplete.ts
+++ b/services/bot-client/src/commands/shapes/autocomplete.ts
@@ -10,6 +10,7 @@
 import type { AutocompleteInteraction } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
 import { getCachedShapes } from '../../utils/autocomplete/autocompleteCache.js';
+import { toGatewayUser } from '../../utils/userGatewayClient.js';
 import { truncateForSelect } from '../../utils/browse/truncation.js';
 
 const logger = createLogger('shapes-autocomplete');
@@ -27,7 +28,7 @@ export async function handleShapesSlugAutocomplete(
   const userId = interaction.user.id;
 
   try {
-    const shapes = await getCachedShapes(userId);
+    const shapes = await getCachedShapes(toGatewayUser(interaction.user));
 
     const filtered = shapes
       .filter(s => s.name.toLowerCase().includes(query) || s.username.toLowerCase().includes(query))

--- a/services/bot-client/src/commands/shapes/browse.test.ts
+++ b/services/bot-client/src/commands/shapes/browse.test.ts
@@ -30,15 +30,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 // Mock gateway client
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  GATEWAY_TIMEOUTS: { DEFERRED: 15000 },
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 function makeShape(i: number): ShapeItem {
   return {
@@ -59,7 +59,7 @@ describe('handleBrowse', () => {
 
   function createMockContext(): DeferredCommandContext {
     return {
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       editReply: mockEditReply,
       guild: null,
       member: null,

--- a/services/bot-client/src/commands/shapes/browse.test.ts
+++ b/services/bot-client/src/commands/shapes/browse.test.ts
@@ -8,6 +8,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { handleBrowse, buildBrowsePage, fetchShapesList, type ShapeItem } from './browse.js';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
+import type { GatewayUser } from '../../utils/userGatewayClient.js';
+
+function mkUser(discordId = 'user-123'): GatewayUser {
+  return { discordId, username: 'test-user', displayName: 'Test User' };
+}
 
 // Mock common-types
 vi.mock('@tzurot/common-types', async importOriginal => {
@@ -28,6 +33,11 @@ const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
   GATEWAY_TIMEOUTS: { DEFERRED: 15000 },
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 function makeShape(i: number): ShapeItem {
@@ -78,7 +88,9 @@ describe('handleBrowse', () => {
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith(
       '/user/shapes/list',
-      expect.objectContaining({ userId: '123456789' })
+      expect.objectContaining({
+        user: { discordId: '123456789', username: 'testuser', displayName: 'testuser' },
+      })
     );
   });
 
@@ -234,7 +246,7 @@ describe('fetchShapesList', () => {
       data: { shapes: mockShapes, total: 1 },
     });
 
-    const result = await fetchShapesList('user-123');
+    const result = await fetchShapesList(mkUser());
 
     expect(result).toEqual({ ok: true, shapes: mockShapes });
   });
@@ -246,7 +258,7 @@ describe('fetchShapesList', () => {
       error: 'No credentials',
     });
 
-    const result = await fetchShapesList('user-123');
+    const result = await fetchShapesList(mkUser());
 
     expect(result).toEqual({ ok: false, status: 401, error: 'No credentials' });
   });

--- a/services/bot-client/src/commands/shapes/browse.ts
+++ b/services/bot-client/src/commands/shapes/browse.ts
@@ -11,7 +11,12 @@
 import { EmbedBuilder, ActionRowBuilder, type ButtonBuilder } from 'discord.js';
 import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi, GATEWAY_TIMEOUTS } from '../../utils/userGatewayClient.js';
+import {
+  callGatewayApi,
+  GATEWAY_TIMEOUTS,
+  toGatewayUser,
+  type GatewayUser,
+} from '../../utils/userGatewayClient.js';
 import {
   createBrowseCustomIdHelpers,
   buildBrowseButtons,
@@ -148,10 +153,10 @@ export function buildBrowsePage(
  * Exported for reuse by interactionHandlers (stateless pagination)
  */
 export async function fetchShapesList(
-  userId: string
+  user: GatewayUser
 ): Promise<{ ok: true; shapes: ShapeItem[] } | { ok: false; status: number; error: string }> {
   const result = await callGatewayApi<ShapesListResponse>('/user/shapes/list', {
-    userId,
+    user,
     timeout: GATEWAY_TIMEOUTS.DEFERRED,
   });
 
@@ -171,7 +176,7 @@ export async function handleBrowse(context: DeferredCommandContext): Promise<voi
   const userId = context.user.id;
 
   try {
-    const result = await fetchShapesList(userId);
+    const result = await fetchShapesList(toGatewayUser(context.user));
 
     if (!result.ok) {
       if (result.status === 401) {

--- a/services/bot-client/src/commands/shapes/detail.test.ts
+++ b/services/bot-client/src/commands/shapes/detail.test.ts
@@ -4,6 +4,11 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { buildShapeDetailEmbed } from './detail.js';
+import type { GatewayUser } from '../../utils/userGatewayClient.js';
+
+function mkUser(discordId = 'user-123'): GatewayUser {
+  return { discordId, username: 'test-user', displayName: 'Test User' };
+}
 
 // Mock common-types
 vi.mock('@tzurot/common-types', async importOriginal => {
@@ -24,6 +29,11 @@ const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
   GATEWAY_TIMEOUTS: { DEFERRED: 15000 },
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 describe('buildShapeDetailEmbed', () => {
@@ -34,7 +44,7 @@ describe('buildShapeDetailEmbed', () => {
   it('should show slug in title and footer', async () => {
     mockCallGatewayApi.mockResolvedValue({ ok: true, data: { jobs: [] } });
 
-    const { embed } = await buildShapeDetailEmbed('user-123', 'my-shape');
+    const { embed } = await buildShapeDetailEmbed(mkUser(), 'my-shape');
 
     expect(embed.data.title).toContain('my-shape');
     expect(embed.data.footer?.text).toBe('slug:my-shape|sort:name');
@@ -43,7 +53,7 @@ describe('buildShapeDetailEmbed', () => {
   it('should show "No imports yet" when no import jobs exist', async () => {
     mockCallGatewayApi.mockResolvedValue({ ok: true, data: { jobs: [] } });
 
-    const { embed } = await buildShapeDetailEmbed('user-123', 'my-shape');
+    const { embed } = await buildShapeDetailEmbed(mkUser(), 'my-shape');
 
     expect(embed.data.description).toContain('No imports yet');
   });
@@ -51,7 +61,7 @@ describe('buildShapeDetailEmbed', () => {
   it('should show "No exports yet" when no export jobs exist', async () => {
     mockCallGatewayApi.mockResolvedValue({ ok: true, data: { jobs: [] } });
 
-    const { embed } = await buildShapeDetailEmbed('user-123', 'my-shape');
+    const { embed } = await buildShapeDetailEmbed(mkUser(), 'my-shape');
 
     expect(embed.data.description).toContain('No exports yet');
   });
@@ -79,7 +89,7 @@ describe('buildShapeDetailEmbed', () => {
       })
       .mockResolvedValueOnce({ ok: true, data: { jobs: [] } });
 
-    const { embed } = await buildShapeDetailEmbed('user-123', 'my-shape');
+    const { embed } = await buildShapeDetailEmbed(mkUser(), 'my-shape');
 
     expect(embed.data.description).toContain('42 memories imported');
   });
@@ -87,7 +97,7 @@ describe('buildShapeDetailEmbed', () => {
   it('should pass slug query param to gateway for server-side filtering', async () => {
     mockCallGatewayApi.mockResolvedValue({ ok: true, data: { jobs: [] } });
 
-    await buildShapeDetailEmbed('user-123', 'my-shape');
+    await buildShapeDetailEmbed(mkUser(), 'my-shape');
 
     // Verify slug is passed as query parameter (server-side filtering)
     expect(mockCallGatewayApi).toHaveBeenCalledWith(
@@ -103,7 +113,7 @@ describe('buildShapeDetailEmbed', () => {
   it('should include action buttons in two rows', async () => {
     mockCallGatewayApi.mockResolvedValue({ ok: true, data: { jobs: [] } });
 
-    const { components } = await buildShapeDetailEmbed('user-123', 'my-shape');
+    const { components } = await buildShapeDetailEmbed(mkUser(), 'my-shape');
 
     expect(components).toHaveLength(2);
 
@@ -125,7 +135,7 @@ describe('buildShapeDetailEmbed', () => {
   it('should handle API errors gracefully', async () => {
     mockCallGatewayApi.mockRejectedValue(new Error('Network error'));
 
-    const { embed } = await buildShapeDetailEmbed('user-123', 'my-shape');
+    const { embed } = await buildShapeDetailEmbed(mkUser(), 'my-shape');
 
     // Should still build the embed with "no jobs" status
     expect(embed.data.title).toContain('my-shape');

--- a/services/bot-client/src/commands/shapes/detail.test.ts
+++ b/services/bot-client/src/commands/shapes/detail.test.ts
@@ -26,15 +26,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 // Mock gateway client
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  GATEWAY_TIMEOUTS: { DEFERRED: 15000 },
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 describe('buildShapeDetailEmbed', () => {
   beforeEach(() => {

--- a/services/bot-client/src/commands/shapes/detail.ts
+++ b/services/bot-client/src/commands/shapes/detail.ts
@@ -8,7 +8,11 @@
 
 import { EmbedBuilder, ButtonBuilder, ButtonStyle, ActionRowBuilder } from 'discord.js';
 import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
-import { callGatewayApi, GATEWAY_TIMEOUTS } from '../../utils/userGatewayClient.js';
+import {
+  callGatewayApi,
+  GATEWAY_TIMEOUTS,
+  type GatewayUser,
+} from '../../utils/userGatewayClient.js';
 import { ShapesCustomIds } from '../../utils/customIds.js';
 import type { BrowseSortType } from '../../utils/browse/constants.js';
 import {
@@ -28,15 +32,15 @@ interface JobStatus {
 }
 
 /** Fetch the latest import and export job for a specific slug (server-side filtered). */
-async function fetchJobStatusForSlug(userId: string, slug: string): Promise<JobStatus> {
+async function fetchJobStatusForSlug(user: GatewayUser, slug: string): Promise<JobStatus> {
   const slugParam = encodeURIComponent(slug);
   const [importResult, exportResult] = await Promise.all([
     callGatewayApi<ImportJobsResponse>(`/user/shapes/import/jobs?slug=${slugParam}`, {
-      userId,
+      user,
       timeout: GATEWAY_TIMEOUTS.DEFERRED,
     }),
     callGatewayApi<ExportJobsResponse>(`/user/shapes/export/jobs?slug=${slugParam}`, {
-      userId,
+      user,
       timeout: GATEWAY_TIMEOUTS.DEFERRED,
     }),
   ]);
@@ -107,15 +111,18 @@ function buildDetailButtons(): ActionRowBuilder<ButtonBuilder>[] {
  * @returns Embed and component rows ready for interaction.update() or editReply()
  */
 export async function buildShapeDetailEmbed(
-  userId: string,
+  user: GatewayUser,
   slug: string,
   sort: BrowseSortType = 'name'
 ): Promise<{ embed: EmbedBuilder; components: ActionRowBuilder<ButtonBuilder>[] }> {
   let jobStatus: JobStatus;
   try {
-    jobStatus = await fetchJobStatusForSlug(userId, slug);
+    jobStatus = await fetchJobStatusForSlug(user, slug);
   } catch (error) {
-    logger.error({ err: error, userId, slug }, '[Shapes] Failed to fetch job status');
+    logger.error(
+      { err: error, userId: user.discordId, slug },
+      '[Shapes] Failed to fetch job status'
+    );
     jobStatus = { latestImport: null, latestExport: null };
   }
 

--- a/services/bot-client/src/commands/shapes/detailHandlers.test.ts
+++ b/services/bot-client/src/commands/shapes/detailHandlers.test.ts
@@ -33,15 +33,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 // Mock gateway client
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  GATEWAY_TIMEOUTS: { DEFERRED: 15000 },
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Mock error sanitization
 vi.mock('../../utils/errorSanitization.js', () => ({

--- a/services/bot-client/src/commands/shapes/detailHandlers.test.ts
+++ b/services/bot-client/src/commands/shapes/detailHandlers.test.ts
@@ -36,6 +36,11 @@ const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
   GATEWAY_TIMEOUTS: { DEFERRED: 15000 },
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock error sanitization

--- a/services/bot-client/src/commands/shapes/detailHandlers.ts
+++ b/services/bot-client/src/commands/shapes/detailHandlers.ts
@@ -15,6 +15,7 @@ import { ShapesCustomIds } from '../../utils/customIds.js';
 import type { BrowseSortType } from '../../utils/browse/constants.js';
 import { startImport } from './import.js';
 import { startExport } from './export.js';
+import { toGatewayUser } from '../../utils/userGatewayClient.js';
 import { buildShapeDetailEmbed } from './detail.js';
 
 const logger = createLogger('shapes-detail-handlers');
@@ -62,8 +63,11 @@ export async function showDetailView(
   slug: string,
   sort: BrowseSortType = 'name'
 ): Promise<void> {
-  const userId = interaction.user.id;
-  const { embed, components } = await buildShapeDetailEmbed(userId, slug, sort);
+  const { embed, components } = await buildShapeDetailEmbed(
+    toGatewayUser(interaction.user),
+    slug,
+    sort
+  );
   await interaction.update({
     content: '',
     embeds: [embed],
@@ -153,7 +157,11 @@ export async function handleDetailExport(
   if (success) {
     // Show detail view with updated job status
     try {
-      const { embed, components } = await buildShapeDetailEmbed(userId, slug, sort);
+      const { embed, components } = await buildShapeDetailEmbed(
+        toGatewayUser(interaction.user),
+        slug,
+        sort
+      );
       await interaction.editReply({
         embeds: [embed],
         components,
@@ -232,7 +240,11 @@ export async function handleImportConfirm(
   // If triggered from detail view and import succeeded, show detail view with job status
   if (isFromDetail && success) {
     try {
-      const { embed, components } = await buildShapeDetailEmbed(userId, slug, sort);
+      const { embed, components } = await buildShapeDetailEmbed(
+        toGatewayUser(interaction.user),
+        slug,
+        sort
+      );
       await interaction.editReply({
         embeds: [embed],
         components,

--- a/services/bot-client/src/commands/shapes/export.test.ts
+++ b/services/bot-client/src/commands/shapes/export.test.ts
@@ -25,6 +25,11 @@ const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
   GATEWAY_TIMEOUTS: { DEFERRED: 15000 },
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 describe('handleExport', () => {
@@ -78,7 +83,11 @@ describe('handleExport', () => {
       '/user/shapes/export',
       expect.objectContaining({
         method: 'POST',
-        userId: '123456789',
+        user: {
+          discordId: '123456789',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         body: { slug: 'test-character', format: 'json' },
       })
     );

--- a/services/bot-client/src/commands/shapes/export.test.ts
+++ b/services/bot-client/src/commands/shapes/export.test.ts
@@ -22,15 +22,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 // Mock gateway client
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  GATEWAY_TIMEOUTS: { DEFERRED: 15000 },
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 describe('handleExport', () => {
   const mockEditReply = vi.fn();
@@ -44,7 +44,7 @@ describe('handleExport', () => {
 
   function createMockContext(): DeferredCommandContext {
     return {
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       editReply: mockEditReply,
       guild: null,
       member: null,

--- a/services/bot-client/src/commands/shapes/export.ts
+++ b/services/bot-client/src/commands/shapes/export.ts
@@ -12,7 +12,7 @@
 import { EmbedBuilder, type MessageComponentInteraction } from 'discord.js';
 import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi, GATEWAY_TIMEOUTS } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, GATEWAY_TIMEOUTS, toGatewayUser } from '../../utils/userGatewayClient.js';
 import { sanitizeErrorForDiscord } from '../../utils/errorSanitization.js';
 import { buildBackToBrowseRow } from './errorRecovery.js';
 
@@ -58,7 +58,7 @@ export async function startExport(
 
   const result = await callGatewayApi<ExportJobResponse>('/user/shapes/export', {
     method: 'POST',
-    userId,
+    user: toGatewayUser(interaction.user),
     body: { slug, format },
     timeout: GATEWAY_TIMEOUTS.DEFERRED,
   });
@@ -97,7 +97,7 @@ export async function handleExport(context: DeferredCommandContext): Promise<voi
   try {
     const result = await callGatewayApi<ExportJobResponse>('/user/shapes/export', {
       method: 'POST',
-      userId,
+      user: toGatewayUser(context.user),
       body: { slug, format },
       timeout: GATEWAY_TIMEOUTS.DEFERRED,
     });

--- a/services/bot-client/src/commands/shapes/import.test.ts
+++ b/services/bot-client/src/commands/shapes/import.test.ts
@@ -29,6 +29,11 @@ const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
   GATEWAY_TIMEOUTS: { DEFERRED: 15000 },
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 describe('handleImport', () => {
@@ -77,7 +82,9 @@ describe('handleImport', () => {
 
     expect(mockCallGatewayApi).toHaveBeenCalledWith(
       '/user/shapes/auth/status',
-      expect.objectContaining({ userId: '123456789' })
+      expect.objectContaining({
+        user: { discordId: '123456789', username: 'testuser', displayName: 'testuser' },
+      })
     );
   });
 
@@ -205,7 +212,11 @@ describe('startImport', () => {
       '/user/shapes/import',
       expect.objectContaining({
         method: 'POST',
-        userId: '123456789',
+        user: {
+          discordId: '123456789',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         body: { sourceSlug: 'test-shape', importType: 'full' },
       })
     );

--- a/services/bot-client/src/commands/shapes/import.test.ts
+++ b/services/bot-client/src/commands/shapes/import.test.ts
@@ -26,15 +26,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 // Mock gateway client
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  GATEWAY_TIMEOUTS: { DEFERRED: 15000 },
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 describe('handleImport', () => {
   const mockEditReply = vi.fn();
@@ -52,7 +52,7 @@ describe('handleImport', () => {
 
   function createMockContext(): DeferredCommandContext {
     return {
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       editReply: mockEditReply,
       guild: null,
       member: null,
@@ -190,7 +190,7 @@ describe('startImport', () => {
 
   function createMockButtonInteraction() {
     return {
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       update: mockUpdate,
       editReply: mockEditReply,
     } as unknown as MessageComponentInteraction;

--- a/services/bot-client/src/commands/shapes/import.ts
+++ b/services/bot-client/src/commands/shapes/import.ts
@@ -15,7 +15,7 @@ import {
 } from 'discord.js';
 import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi, GATEWAY_TIMEOUTS } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, GATEWAY_TIMEOUTS, toGatewayUser } from '../../utils/userGatewayClient.js';
 import { ShapesCustomIds } from '../../utils/customIds.js';
 import { sanitizeErrorForDiscord } from '../../utils/errorSanitization.js';
 import { buildBackToBrowseRow } from './errorRecovery.js';
@@ -64,7 +64,7 @@ export async function startImport(
 
   const importResult = await callGatewayApi<ImportResponse>('/user/shapes/import', {
     method: 'POST',
-    userId,
+    user: toGatewayUser(buttonInteraction.user),
     body: { sourceSlug: slug, importType },
     timeout: GATEWAY_TIMEOUTS.DEFERRED,
   });
@@ -128,7 +128,7 @@ export async function handleImport(context: DeferredCommandContext): Promise<voi
   try {
     // 1. Check credentials exist
     const authResult = await callGatewayApi<AuthStatusResponse>('/user/shapes/auth/status', {
-      userId,
+      user: toGatewayUser(context.user),
       timeout: GATEWAY_TIMEOUTS.DEFERRED,
     });
 

--- a/services/bot-client/src/commands/shapes/interactionHandlers.test.ts
+++ b/services/bot-client/src/commands/shapes/interactionHandlers.test.ts
@@ -25,15 +25,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 // Mock gateway client
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  GATEWAY_TIMEOUTS: { DEFERRED: 15000 },
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 // Mock error sanitization
 vi.mock('../../utils/errorSanitization.js', () => ({
@@ -52,7 +52,7 @@ describe('handleShapesButton', () => {
   function createMockButtonInteraction(customId: string, embedFooter?: string): ButtonInteraction {
     return {
       customId,
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       update: mockUpdate,
       editReply: mockEditReply,
       showModal: mockShowModal,
@@ -461,7 +461,7 @@ describe('handleShapesSelectMenu', () => {
     return {
       customId,
       values,
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       update: mockUpdate,
     } as unknown as StringSelectMenuInteraction;
   }

--- a/services/bot-client/src/commands/shapes/interactionHandlers.test.ts
+++ b/services/bot-client/src/commands/shapes/interactionHandlers.test.ts
@@ -28,6 +28,11 @@ const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
   GATEWAY_TIMEOUTS: { DEFERRED: 15000 },
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Mock error sanitization
@@ -399,7 +404,9 @@ describe('handleShapesButton', () => {
 
       expect(mockCallGatewayApi).toHaveBeenCalledWith(
         '/user/shapes/list',
-        expect.objectContaining({ userId: '123456789' })
+        expect.objectContaining({
+          user: { discordId: '123456789', username: 'testuser', displayName: 'testuser' },
+        })
       );
       expect(mockUpdate).toHaveBeenCalledTimes(1);
       const updateArgs = mockUpdate.mock.calls[0][0];

--- a/services/bot-client/src/commands/shapes/interactionHandlers.ts
+++ b/services/bot-client/src/commands/shapes/interactionHandlers.ts
@@ -20,6 +20,7 @@ import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js'
 import { ButtonBuilder, ActionRowBuilder } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
 import { ShapesCustomIds } from '../../utils/customIds.js';
+import { toGatewayUser } from '../../utils/userGatewayClient.js';
 import { buildBrowsePage, fetchShapesList, shapesBrowseIds } from './browse.js';
 import type { BrowseSortType } from '../../utils/browse/constants.js';
 import { buildAuthModal } from './auth.js';
@@ -204,8 +205,7 @@ async function handleBrowsePage(
   page: number,
   sort: BrowseSortType
 ): Promise<void> {
-  const userId = interaction.user.id;
-  const result = await fetchShapesList(userId);
+  const result = await fetchShapesList(toGatewayUser(interaction.user));
 
   if (!result.ok) {
     await interaction.update({

--- a/services/bot-client/src/commands/shapes/logout.test.ts
+++ b/services/bot-client/src/commands/shapes/logout.test.ts
@@ -25,6 +25,11 @@ const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
   GATEWAY_TIMEOUTS: { DEFERRED: 15000 },
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 describe('handleLogout', () => {
@@ -61,7 +66,11 @@ describe('handleLogout', () => {
       '/user/shapes/auth',
       expect.objectContaining({
         method: 'DELETE',
-        userId: '123456789',
+        user: {
+          discordId: '123456789',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
       })
     );
   });

--- a/services/bot-client/src/commands/shapes/logout.test.ts
+++ b/services/bot-client/src/commands/shapes/logout.test.ts
@@ -22,15 +22,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 // Mock gateway client
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  GATEWAY_TIMEOUTS: { DEFERRED: 15000 },
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 describe('handleLogout', () => {
   const mockEditReply = vi.fn();
@@ -41,7 +41,7 @@ describe('handleLogout', () => {
 
   function createMockContext(): DeferredCommandContext {
     return {
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       editReply: mockEditReply,
       guild: null,
       member: null,

--- a/services/bot-client/src/commands/shapes/logout.ts
+++ b/services/bot-client/src/commands/shapes/logout.ts
@@ -7,7 +7,7 @@
 import { EmbedBuilder } from 'discord.js';
 import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi, GATEWAY_TIMEOUTS } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, GATEWAY_TIMEOUTS, toGatewayUser } from '../../utils/userGatewayClient.js';
 
 const logger = createLogger('shapes-logout');
 
@@ -21,7 +21,7 @@ export async function handleLogout(context: DeferredCommandContext): Promise<voi
   try {
     const result = await callGatewayApi<void>('/user/shapes/auth', {
       method: 'DELETE',
-      userId,
+      user: toGatewayUser(context.user),
       timeout: GATEWAY_TIMEOUTS.DEFERRED,
     });
 

--- a/services/bot-client/src/commands/shapes/modal.test.ts
+++ b/services/bot-client/src/commands/shapes/modal.test.ts
@@ -22,15 +22,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 // Mock gateway client
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  GATEWAY_TIMEOUTS: { DEFERRED: 15000 },
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 describe('handleShapesModalSubmit', () => {
   const mockReply = vi.fn();
@@ -48,7 +48,7 @@ describe('handleShapesModalSubmit', () => {
   ) {
     return {
       customId,
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       fields: {
         getTextInputValue: (fieldId: string) => {
           if (fieldId === 'cookiePart0') return cookiePart0;

--- a/services/bot-client/src/commands/shapes/modal.test.ts
+++ b/services/bot-client/src/commands/shapes/modal.test.ts
@@ -25,6 +25,11 @@ const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
   GATEWAY_TIMEOUTS: { DEFERRED: 15000 },
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 describe('handleShapesModalSubmit', () => {
@@ -100,7 +105,11 @@ describe('handleShapesModalSubmit', () => {
         '/user/shapes/auth',
         expect.objectContaining({
           method: 'POST',
-          userId: '123456789',
+          user: {
+            discordId: '123456789',
+            username: 'testuser',
+            displayName: 'testuser',
+          },
           body: {
             sessionCookie: 'appSession.0=part0-value; appSession.1=part1-value',
           },

--- a/services/bot-client/src/commands/shapes/modal.ts
+++ b/services/bot-client/src/commands/shapes/modal.ts
@@ -13,7 +13,7 @@
 import type { ModalSubmitInteraction } from 'discord.js';
 import { MessageFlags, EmbedBuilder } from 'discord.js';
 import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
-import { callGatewayApi, GATEWAY_TIMEOUTS } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, GATEWAY_TIMEOUTS, toGatewayUser } from '../../utils/userGatewayClient.js';
 import { ShapesCustomIds } from '../../utils/customIds.js';
 
 const logger = createLogger('shapes-modal');
@@ -65,7 +65,7 @@ async function handleAuthSubmit(interaction: ModalSubmitInteraction): Promise<vo
   try {
     const result = await callGatewayApi<{ success: boolean }>('/user/shapes/auth', {
       method: 'POST',
-      userId: interaction.user.id,
+      user: toGatewayUser(interaction.user),
       body: { sessionCookie },
       timeout: GATEWAY_TIMEOUTS.DEFERRED,
     });

--- a/services/bot-client/src/commands/shapes/status.test.ts
+++ b/services/bot-client/src/commands/shapes/status.test.ts
@@ -25,6 +25,11 @@ const mockCallGatewayApi = vi.fn();
 vi.mock('../../utils/userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
   GATEWAY_TIMEOUTS: { DEFERRED: 15000 },
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 describe('handleStatus', () => {
@@ -73,15 +78,21 @@ describe('handleStatus', () => {
     expect(mockCallGatewayApi).toHaveBeenCalledTimes(3);
     expect(mockCallGatewayApi).toHaveBeenCalledWith(
       '/user/shapes/auth/status',
-      expect.objectContaining({ userId: '123456789' })
+      expect.objectContaining({
+        user: { discordId: '123456789', username: 'testuser', displayName: 'testuser' },
+      })
     );
     expect(mockCallGatewayApi).toHaveBeenCalledWith(
       '/user/shapes/import/jobs',
-      expect.objectContaining({ userId: '123456789' })
+      expect.objectContaining({
+        user: { discordId: '123456789', username: 'testuser', displayName: 'testuser' },
+      })
     );
     expect(mockCallGatewayApi).toHaveBeenCalledWith(
       '/user/shapes/export/jobs',
-      expect.objectContaining({ userId: '123456789' })
+      expect.objectContaining({
+        user: { discordId: '123456789', username: 'testuser', displayName: 'testuser' },
+      })
     );
   });
 

--- a/services/bot-client/src/commands/shapes/status.test.ts
+++ b/services/bot-client/src/commands/shapes/status.test.ts
@@ -22,15 +22,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 // Mock gateway client
 const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  GATEWAY_TIMEOUTS: { DEFERRED: 15000 },
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
+    '../../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 describe('handleStatus', () => {
   const mockEditReply = vi.fn();
@@ -41,7 +41,7 @@ describe('handleStatus', () => {
 
   function createMockContext(): DeferredCommandContext {
     return {
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser' },
       editReply: mockEditReply,
       guild: null,
       member: null,

--- a/services/bot-client/src/commands/shapes/status.ts
+++ b/services/bot-client/src/commands/shapes/status.ts
@@ -7,7 +7,7 @@
 import { EmbedBuilder } from 'discord.js';
 import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi, GATEWAY_TIMEOUTS } from '../../utils/userGatewayClient.js';
+import { callGatewayApi, GATEWAY_TIMEOUTS, toGatewayUser } from '../../utils/userGatewayClient.js';
 import {
   formatImportJobStatus,
   formatExportJobStatus,
@@ -33,17 +33,18 @@ export async function handleStatus(context: DeferredCommandContext): Promise<voi
 
   try {
     // Fetch auth status, import history, and export history in parallel
+    const user = toGatewayUser(context.user);
     const [authResult, importJobsResult, exportJobsResult] = await Promise.all([
       callGatewayApi<AuthStatusResponse>('/user/shapes/auth/status', {
-        userId,
+        user,
         timeout: GATEWAY_TIMEOUTS.DEFERRED,
       }),
       callGatewayApi<ImportJobsResponse>('/user/shapes/import/jobs', {
-        userId,
+        user,
         timeout: GATEWAY_TIMEOUTS.DEFERRED,
       }),
       callGatewayApi<ExportJobsResponse>('/user/shapes/export/jobs', {
-        userId,
+        user,
         timeout: GATEWAY_TIMEOUTS.DEFERRED,
       }),
     ]);

--- a/services/bot-client/src/processors/DMSessionProcessor.ts
+++ b/services/bot-client/src/processors/DMSessionProcessor.ts
@@ -24,6 +24,7 @@ import {
   sendNsfwVerificationMessage,
   checkNsfwVerification,
 } from '../utils/nsfwVerification.js';
+import { toGatewayUser } from '../utils/userGatewayClient.js';
 import { getEffectiveContent } from '../utils/messageTypeUtils.js';
 import { findPersonalityMention } from '../utils/personalityMentionParser.js';
 
@@ -65,7 +66,7 @@ export class DMSessionProcessor implements IMessageProcessor {
     logger.debug({ userId }, '[DMSessionProcessor] Processing DM message');
 
     // 2. Check NSFW verification first (higher priority than help message)
-    const nsfwStatus = await checkNsfwVerification(userId);
+    const nsfwStatus = await checkNsfwVerification(toGatewayUser(message.author));
     if (!nsfwStatus.nsfwVerified) {
       logger.info({ userId }, '[DMSessionProcessor] DM blocked - user not NSFW verified');
       await sendNsfwVerificationMessage(message, 'DMSessionProcessor');

--- a/services/bot-client/src/services/PersonalityMessageHandler.test.ts
+++ b/services/bot-client/src/services/PersonalityMessageHandler.test.ts
@@ -43,6 +43,11 @@ vi.mock('../utils/userGatewayClient.js', () => ({
     },
   }),
   GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 // Import for per-test mock manipulation

--- a/services/bot-client/src/services/PersonalityMessageHandler.test.ts
+++ b/services/bot-client/src/services/PersonalityMessageHandler.test.ts
@@ -29,26 +29,26 @@ vi.mock('../utils/nsfwVerification.js', () => ({
 
 // Mock gateway client for config resolution
 // Default returns LlmConfig defaults (no personality overrides)
-vi.mock('../utils/userGatewayClient.js', () => ({
-  callGatewayApi: vi.fn().mockResolvedValue({
-    ok: true,
-    data: {
-      config: {
-        model: 'test-model',
-        maxMessages: 50,
-        maxAge: null,
-        maxImages: 10,
+vi.mock('../utils/userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../utils/userGatewayClient.js')>(
+    '../utils/userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: vi.fn().mockResolvedValue({
+      ok: true,
+      data: {
+        config: {
+          model: 'test-model',
+          maxMessages: 50,
+          maxAge: null,
+          maxImages: 10,
+        },
+        source: 'personality',
       },
-      source: 'personality',
-    },
-  }),
-  GATEWAY_TIMEOUTS: { AUTOCOMPLETE: 2500, DEFERRED: 10000 },
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+    }),
+  };
+});
 
 // Import for per-test mock manipulation
 import { callGatewayApi } from '../utils/userGatewayClient.js';
@@ -518,6 +518,46 @@ describe('PersonalityMessageHandler', () => {
       );
     });
 
+    it('should pass full Discord user context (discordId + username + displayName) on the message-event path', async () => {
+      // Guards the message-event provisioning path (PR A of Phase 5c). A
+      // regression in toGatewayUser(message.author) — e.g. dropping
+      // displayName, swapping message.author for interaction.user, or losing
+      // the globalName fallback — would pass typecheck but break real users
+      // whose prompts depend on their Discord username in <participants>.
+      const mockMessage = createMockMessage();
+      const mockPersonality = createMockPersonality();
+
+      const mockBuildResult = {
+        context: {
+          userMessage: 'hi',
+          conversationHistory: [],
+          attachments: [],
+          referencedMessages: [],
+          environment: {},
+        },
+        personaId: 'persona-123',
+        messageContent: 'hi',
+        referencedMessages: [],
+        conversationHistory: [],
+      };
+
+      mockContextBuilder.buildContext.mockResolvedValue(mockBuildResult);
+      mockGatewayClient.generate.mockResolvedValue({ jobId: 'job-123' });
+
+      await handler.handleMessage(mockMessage, mockPersonality, 'hi');
+
+      expect(callGatewayApi).toHaveBeenCalledWith(
+        '/user/llm-config/resolve',
+        expect.objectContaining({
+          user: {
+            discordId: 'user-123',
+            username: 'testuser',
+            displayName: 'Test User',
+          },
+        })
+      );
+    });
+
     it('should handle voice transcript content', async () => {
       const mockMessage = createMockMessage();
       const mockPersonality = createMockPersonality();
@@ -845,6 +885,8 @@ function createMockMessage(): Message {
     id: 'message-123',
     author: {
       id: 'user-123',
+      username: 'testuser',
+      globalName: 'Test User',
       bot: false,
     },
     channel: {

--- a/services/bot-client/src/services/PersonalityMessageHandler.ts
+++ b/services/bot-client/src/services/PersonalityMessageHandler.ts
@@ -14,7 +14,12 @@ import type {
 } from '@tzurot/common-types';
 import { createLogger, isBotOwner, isTypingChannel, MESSAGE_LIMITS } from '@tzurot/common-types';
 import { GatewayClient } from '../utils/GatewayClient.js';
-import { callGatewayApi, GATEWAY_TIMEOUTS } from '../utils/userGatewayClient.js';
+import {
+  callGatewayApi,
+  GATEWAY_TIMEOUTS,
+  toGatewayUser,
+  type GatewayUser,
+} from '../utils/userGatewayClient.js';
 import { JobTracker } from './JobTracker.js';
 import { MessageContextBuilder } from './MessageContextBuilder.js';
 import { ConversationPersistence } from './ConversationPersistence.js';
@@ -59,13 +64,13 @@ export class PersonalityMessageHandler {
    * Falls back to personality defaults on error.
    */
   private async resolveConfig(
-    userId: string,
+    user: GatewayUser,
     personality: LoadedPersonality,
     channelId?: string
   ): Promise<ConfigResolutionResult> {
     const result = await callGatewayApi<ConfigResolutionResult>('/user/llm-config/resolve', {
       method: 'POST',
-      userId,
+      user,
       body: {
         personalityId: personality.id,
         personalityConfig: personality,
@@ -76,7 +81,7 @@ export class PersonalityMessageHandler {
 
     if (!result.ok) {
       logger.warn(
-        { userId, personalityId: personality.id, error: result.error },
+        { userId: user.discordId, personalityId: personality.id, error: result.error },
         '[PersonalityMessageHandler] Failed to resolve config, using personality defaults'
       );
       // Fall back to personality defaults with hardcoded fallbacks for safety
@@ -188,7 +193,7 @@ export class PersonalityMessageHandler {
 
       // Resolve LLM config from gateway (applies user overrides for context settings)
       const resolvedConfig = await this.resolveConfig(
-        message.author.id,
+        toGatewayUser(message.author),
         personality,
         message.channel.id
       );

--- a/services/bot-client/src/utils/GatewayClient.test.ts
+++ b/services/bot-client/src/utils/GatewayClient.test.ts
@@ -133,7 +133,11 @@ describe('GatewayClient', () => {
       const personality = { name: 'test-personality', model: 'gpt-4' };
       const context = {
         messageContent: 'Hello world',
-        userId: 'user-123',
+        user: {
+          discordId: 'user-123',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
         conversationHistory: [{ role: 'user', content: 'Previous' }],
       };
 

--- a/services/bot-client/src/utils/api/gatewayFetcher.test.ts
+++ b/services/bot-client/src/utils/api/gatewayFetcher.test.ts
@@ -15,14 +15,14 @@ import {
 import * as userGatewayClientModule from '../userGatewayClient.js';
 
 // Mock the gateway client
-vi.mock('../userGatewayClient.js', () => ({
-  callGatewayApi: vi.fn(),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../userGatewayClient.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('../userGatewayClient.js')>('../userGatewayClient.js');
+  return {
+    ...actual,
+    callGatewayApi: vi.fn(),
+  };
+});
 
 const TEST_USER = {
   discordId: 'user-456',

--- a/services/bot-client/src/utils/api/gatewayFetcher.test.ts
+++ b/services/bot-client/src/utils/api/gatewayFetcher.test.ts
@@ -17,7 +17,18 @@ import * as userGatewayClientModule from '../userGatewayClient.js';
 // Mock the gateway client
 vi.mock('../userGatewayClient.js', () => ({
   callGatewayApi: vi.fn(),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
+
+const TEST_USER = {
+  discordId: 'user-456',
+  username: 'testuser',
+  displayName: 'testuser',
+} as const;
 
 describe('gatewayFetcher', () => {
   beforeEach(() => {
@@ -46,11 +57,11 @@ describe('gatewayFetcher', () => {
         data: { entity: mockEntity },
       });
 
-      const result = await fetcher('/user/entity', '123', 'user-456');
+      const result = await fetcher('/user/entity', '123', TEST_USER);
 
       expect(result).toEqual(mockEntity);
       expect(userGatewayClientModule.callGatewayApi).toHaveBeenCalledWith('/user/entity/123', {
-        userId: 'user-456',
+        user: TEST_USER,
       });
     });
 
@@ -61,7 +72,7 @@ describe('gatewayFetcher', () => {
         status: 404,
       });
 
-      const result = await fetcher('/user/entity', '123', 'user-456');
+      const result = await fetcher('/user/entity', '123', TEST_USER);
 
       expect(result).toBeNull();
     });
@@ -89,12 +100,12 @@ describe('gatewayFetcher', () => {
         data: { entity: mockEntity },
       });
 
-      const result = await updater('/user/entity', '123', { name: 'Updated' }, 'user-456');
+      const result = await updater('/user/entity', '123', { name: 'Updated' }, TEST_USER);
 
       expect(result).toEqual(mockEntity);
       expect(userGatewayClientModule.callGatewayApi).toHaveBeenCalledWith('/user/entity/123', {
         method: 'PUT',
-        userId: 'user-456',
+        user: TEST_USER,
         body: { name: 'Updated' },
       });
     });
@@ -112,7 +123,7 @@ describe('gatewayFetcher', () => {
         status: 500,
       });
 
-      const result = await updater('/user/entity', '123', {}, 'user-456');
+      const result = await updater('/user/entity', '123', {}, TEST_USER);
 
       expect(result).toBeNull();
     });
@@ -131,7 +142,7 @@ describe('gatewayFetcher', () => {
         status: 500,
       });
 
-      await expect(updater('/user/entity', '123', {}, 'user-456')).rejects.toThrow(
+      await expect(updater('/user/entity', '123', {}, TEST_USER)).rejects.toThrow(
         'Failed to update entity: 500 - Server error'
       );
     });
@@ -149,12 +160,12 @@ describe('gatewayFetcher', () => {
         data: { message: 'Deleted' },
       });
 
-      const result = await deleter('/user/entity', '123', 'user-456');
+      const result = await deleter('/user/entity', '123', TEST_USER);
 
       expect(result).toEqual({ success: true });
       expect(userGatewayClientModule.callGatewayApi).toHaveBeenCalledWith('/user/entity/123', {
         method: 'DELETE',
-        userId: 'user-456',
+        user: TEST_USER,
       });
     });
 
@@ -165,7 +176,7 @@ describe('gatewayFetcher', () => {
         status: 403,
       });
 
-      const result = await deleter('/user/entity', '123', 'user-456');
+      const result = await deleter('/user/entity', '123', TEST_USER);
 
       expect(result).toEqual({ success: false, error: 'Cannot delete' });
     });
@@ -189,11 +200,11 @@ describe('gatewayFetcher', () => {
         data: { items },
       });
 
-      const result = await fetcher('/user/items', 'user-456');
+      const result = await fetcher('/user/items', TEST_USER);
 
       expect(result).toEqual(items);
       expect(userGatewayClientModule.callGatewayApi).toHaveBeenCalledWith('/user/items', {
-        userId: 'user-456',
+        user: TEST_USER,
       });
     });
 
@@ -204,7 +215,7 @@ describe('gatewayFetcher', () => {
         status: 500,
       });
 
-      const result = await fetcher('/user/items', 'user-456');
+      const result = await fetcher('/user/items', TEST_USER);
 
       expect(result).toBeNull();
     });

--- a/services/bot-client/src/utils/api/gatewayFetcher.ts
+++ b/services/bot-client/src/utils/api/gatewayFetcher.ts
@@ -6,7 +6,7 @@
  */
 
 import { createLogger } from '@tzurot/common-types';
-import { callGatewayApi } from '../userGatewayClient.js';
+import { callGatewayApi, type GatewayUser } from '../userGatewayClient.js';
 
 /**
  * Result type that matches callGatewayApi return
@@ -40,19 +40,22 @@ interface FetcherOptions<TResponse, TResult> {
  *   actionName: 'fetch persona',
  * });
  *
- * const persona = await fetchPersona('/user/persona', personaId, userId);
+ * const persona = await fetchPersona('/user/persona', personaId, user);
  * ```
  */
 export function createEntityFetcher<TResponse, TResult>(
   options: FetcherOptions<TResponse, TResult>
-): (endpoint: string, entityId: string, userId: string) => Promise<TResult | null> {
+): (endpoint: string, entityId: string, user: GatewayUser) => Promise<TResult | null> {
   const logger = createLogger(options.loggerName);
 
-  return async (endpoint: string, entityId: string, userId: string): Promise<TResult | null> => {
-    const result = await callGatewayApi<TResponse>(`${endpoint}/${entityId}`, { userId });
+  return async (endpoint: string, entityId: string, user: GatewayUser): Promise<TResult | null> => {
+    const result = await callGatewayApi<TResponse>(`${endpoint}/${entityId}`, { user });
 
     if (!result.ok) {
-      logger.warn({ userId, entityId, error: result.error }, `Failed to ${options.actionName}`);
+      logger.warn(
+        { userId: user.discordId, entityId, error: result.error },
+        `Failed to ${options.actionName}`
+      );
       return null;
     }
 
@@ -87,7 +90,7 @@ interface UpdaterOptions<TResponse, TResult> {
  *   actionName: 'update persona',
  * });
  *
- * const updated = await updatePersona('/user/persona', personaId, data, userId);
+ * const updated = await updatePersona('/user/persona', personaId, data, user);
  * ```
  */
 export function createEntityUpdater<TResponse, TResult>(
@@ -96,7 +99,7 @@ export function createEntityUpdater<TResponse, TResult>(
   endpoint: string,
   entityId: string,
   data: Record<string, unknown>,
-  userId: string
+  user: GatewayUser
 ) => Promise<TResult | null> {
   const logger = createLogger(options.loggerName);
 
@@ -104,16 +107,19 @@ export function createEntityUpdater<TResponse, TResult>(
     endpoint: string,
     entityId: string,
     data: Record<string, unknown>,
-    userId: string
+    user: GatewayUser
   ): Promise<TResult | null> => {
     const result = await callGatewayApi<TResponse>(`${endpoint}/${entityId}`, {
       method: 'PUT',
-      userId,
+      user,
       body: data,
     });
 
     if (!result.ok) {
-      logger.warn({ userId, entityId, error: result.error }, `Failed to ${options.actionName}`);
+      logger.warn(
+        { userId: user.discordId, entityId, error: result.error },
+        `Failed to ${options.actionName}`
+      );
       if (options.throwOnError === true) {
         throw new Error(`Failed to ${options.actionName}: ${result.status} - ${result.error}`);
       }
@@ -154,7 +160,7 @@ interface DeleterOptions {
  *   actionName: 'delete persona',
  * });
  *
- * const result = await deletePersona('/user/persona', personaId, userId);
+ * const result = await deletePersona('/user/persona', personaId, user);
  * if (!result.success) {
  *   console.log('Failed:', result.error);
  * }
@@ -162,17 +168,20 @@ interface DeleterOptions {
  */
 export function createEntityDeleter(
   options: DeleterOptions
-): (endpoint: string, entityId: string, userId: string) => Promise<DeleteResult> {
+): (endpoint: string, entityId: string, user: GatewayUser) => Promise<DeleteResult> {
   const logger = createLogger(options.loggerName);
 
-  return async (endpoint: string, entityId: string, userId: string): Promise<DeleteResult> => {
+  return async (endpoint: string, entityId: string, user: GatewayUser): Promise<DeleteResult> => {
     const result = await callGatewayApi<{ message: string }>(`${endpoint}/${entityId}`, {
       method: 'DELETE',
-      userId,
+      user,
     });
 
     if (!result.ok) {
-      logger.warn({ userId, entityId, error: result.error }, `Failed to ${options.actionName}`);
+      logger.warn(
+        { userId: user.discordId, entityId, error: result.error },
+        `Failed to ${options.actionName}`
+      );
       return { success: false, error: result.error };
     }
 
@@ -205,19 +214,22 @@ interface ListFetcherOptions<TResponse, TResult> {
  *   actionName: 'list personas',
  * });
  *
- * const personas = await listPersonas('/user/persona', userId);
+ * const personas = await listPersonas('/user/persona', user);
  * ```
  */
 export function createListFetcher<TResponse, TResult>(
   options: ListFetcherOptions<TResponse, TResult>
-): (endpoint: string, userId: string) => Promise<TResult[] | null> {
+): (endpoint: string, user: GatewayUser) => Promise<TResult[] | null> {
   const logger = createLogger(options.loggerName);
 
-  return async (endpoint: string, userId: string): Promise<TResult[] | null> => {
-    const result = await callGatewayApi<TResponse>(endpoint, { userId });
+  return async (endpoint: string, user: GatewayUser): Promise<TResult[] | null> => {
+    const result = await callGatewayApi<TResponse>(endpoint, { user });
 
     if (!result.ok) {
-      logger.warn({ userId, error: result.error }, `Failed to ${options.actionName}`);
+      logger.warn(
+        { userId: user.discordId, error: result.error },
+        `Failed to ${options.actionName}`
+      );
       return null;
     }
 
@@ -234,7 +246,7 @@ export function createListFetcher<TResponse, TResult>(
  *
  * @example
  * ```typescript
- * const result = await callGatewayApi<Response>('/user/preset/123', { userId });
+ * const result = await callGatewayApi<Response>('/user/preset/123', { user });
  * const data = unwrapOrThrow(result, 'preset');
  * // Returns data on success, throws NotFoundError for 404, throws Error otherwise
  * ```

--- a/services/bot-client/src/utils/autocomplete/autocompleteCache.test.ts
+++ b/services/bot-client/src/utils/autocomplete/autocompleteCache.test.ts
@@ -17,14 +17,14 @@ import type { PersonaSummary, ShapesSummary } from './autocompleteCache.js';
 
 // Mock the gateway client
 const mockCallGatewayApi = vi.fn();
-vi.mock('../userGatewayClient.js', () => ({
-  callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../userGatewayClient.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('../userGatewayClient.js')>('../userGatewayClient.js');
+  return {
+    ...actual,
+    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  };
+});
 
 vi.mock('@tzurot/common-types', async () => {
   const actual = await vi.importActual('@tzurot/common-types');

--- a/services/bot-client/src/utils/autocomplete/autocompleteCache.test.ts
+++ b/services/bot-client/src/utils/autocomplete/autocompleteCache.test.ts
@@ -19,6 +19,11 @@ import type { PersonaSummary, ShapesSummary } from './autocompleteCache.js';
 const mockCallGatewayApi = vi.fn();
 vi.mock('../userGatewayClient.js', () => ({
   callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 vi.mock('@tzurot/common-types', async () => {
@@ -36,6 +41,15 @@ vi.mock('@tzurot/common-types', async () => {
 
 describe('autocompleteCache', () => {
   const testUserId = 'user-123';
+  const testUser = {
+    discordId: 'user-123',
+    username: 'testuser',
+    displayName: 'testuser',
+  } as const;
+
+  function mkUser(id: string) {
+    return { discordId: id, username: 'testuser', displayName: 'testuser' } as const;
+  }
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -78,9 +92,9 @@ describe('autocompleteCache', () => {
         data: { personalities: mockPersonalities },
       });
 
-      const result = await getCachedPersonalities(testUserId);
+      const result = await getCachedPersonalities(testUser);
 
-      expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/personality', { userId: testUserId });
+      expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/personality', { user: testUser });
       expect(result).toEqual(mockPersonalities);
     });
 
@@ -91,11 +105,11 @@ describe('autocompleteCache', () => {
       });
 
       // First call - cache miss
-      await getCachedPersonalities(testUserId);
+      await getCachedPersonalities(testUser);
       expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
 
       // Second call - cache hit
-      const result = await getCachedPersonalities(testUserId);
+      const result = await getCachedPersonalities(testUser);
       expect(mockCallGatewayApi).toHaveBeenCalledTimes(1); // Still only 1 call
       expect(result).toEqual(mockPersonalities);
     });
@@ -107,11 +121,11 @@ describe('autocompleteCache', () => {
       });
 
       // First call - cache miss
-      await getCachedPersonalities(testUserId);
+      await getCachedPersonalities(testUser);
       expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
 
       // Second call - should be cache hit even with empty list
-      const result = await getCachedPersonalities(testUserId);
+      const result = await getCachedPersonalities(testUser);
       expect(mockCallGatewayApi).toHaveBeenCalledTimes(1); // Still only 1 call
       expect(result).toEqual([]);
     });
@@ -122,7 +136,7 @@ describe('autocompleteCache', () => {
         error: 'Gateway error',
       });
 
-      const result = await getCachedPersonalities(testUserId);
+      const result = await getCachedPersonalities(testUser);
 
       expect(result).toEqual([]);
     });
@@ -130,7 +144,7 @@ describe('autocompleteCache', () => {
     it('should return empty array on exception', async () => {
       mockCallGatewayApi.mockRejectedValue(new Error('Network error'));
 
-      const result = await getCachedPersonalities(testUserId);
+      const result = await getCachedPersonalities(testUser);
 
       expect(result).toEqual([]);
     });
@@ -141,8 +155,8 @@ describe('autocompleteCache', () => {
         data: { personalities: mockPersonalities },
       });
 
-      await getCachedPersonalities('user-1');
-      await getCachedPersonalities('user-2');
+      await getCachedPersonalities(mkUser('user-1'));
+      await getCachedPersonalities(mkUser('user-2'));
 
       expect(mockCallGatewayApi).toHaveBeenCalledTimes(2);
       expect(_getCacheSizeForTesting()).toBe(2);
@@ -171,9 +185,9 @@ describe('autocompleteCache', () => {
         data: { personas: mockPersonas },
       });
 
-      const result = await getCachedPersonas(testUserId);
+      const result = await getCachedPersonas(testUser);
 
-      expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/persona', { userId: testUserId });
+      expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/persona', { user: testUser });
       expect(result).toEqual(mockPersonas);
     });
 
@@ -184,11 +198,11 @@ describe('autocompleteCache', () => {
       });
 
       // First call - cache miss
-      await getCachedPersonas(testUserId);
+      await getCachedPersonas(testUser);
       expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
 
       // Second call - cache hit
-      const result = await getCachedPersonas(testUserId);
+      const result = await getCachedPersonas(testUser);
       expect(mockCallGatewayApi).toHaveBeenCalledTimes(1); // Still only 1 call
       expect(result).toEqual(mockPersonas);
     });
@@ -205,11 +219,11 @@ describe('autocompleteCache', () => {
       });
 
       // First call - cache miss
-      await getCachedPersonas(testUserId);
+      await getCachedPersonas(testUser);
       expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
 
       // Second call - should be cache hit even with empty list
-      const result = await getCachedPersonas(testUserId);
+      const result = await getCachedPersonas(testUser);
       expect(mockCallGatewayApi).toHaveBeenCalledTimes(1); // Still only 1 call!
       expect(result).toEqual([]);
     });
@@ -220,7 +234,7 @@ describe('autocompleteCache', () => {
         error: 'Gateway error',
       });
 
-      const result = await getCachedPersonas(testUserId);
+      const result = await getCachedPersonas(testUser);
 
       expect(result).toEqual([]);
     });
@@ -228,7 +242,7 @@ describe('autocompleteCache', () => {
     it('should return empty array on exception', async () => {
       mockCallGatewayApi.mockRejectedValue(new Error('Network error'));
 
-      const result = await getCachedPersonas(testUserId);
+      const result = await getCachedPersonas(testUser);
 
       expect(result).toEqual([]);
     });
@@ -246,10 +260,10 @@ describe('autocompleteCache', () => {
         data: { shapes: mockShapes },
       });
 
-      const result = await getCachedShapes(testUserId);
+      const result = await getCachedShapes(testUser);
 
       expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/shapes/list', {
-        userId: testUserId,
+        user: testUser,
       });
       expect(result).toEqual(mockShapes);
     });
@@ -260,10 +274,10 @@ describe('autocompleteCache', () => {
         data: { shapes: mockShapes },
       });
 
-      await getCachedShapes(testUserId);
+      await getCachedShapes(testUser);
       expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
 
-      const result = await getCachedShapes(testUserId);
+      const result = await getCachedShapes(testUser);
       expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
       expect(result).toEqual(mockShapes);
     });
@@ -274,10 +288,10 @@ describe('autocompleteCache', () => {
         data: { shapes: [] },
       });
 
-      await getCachedShapes(testUserId);
+      await getCachedShapes(testUser);
       expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
 
-      const result = await getCachedShapes(testUserId);
+      const result = await getCachedShapes(testUser);
       expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
       expect(result).toEqual([]);
     });
@@ -288,7 +302,7 @@ describe('autocompleteCache', () => {
         error: 'Gateway error',
       });
 
-      const result = await getCachedShapes(testUserId);
+      const result = await getCachedShapes(testUser);
 
       expect(result).toEqual([]);
     });
@@ -296,7 +310,7 @@ describe('autocompleteCache', () => {
     it('should return empty array on exception', async () => {
       mockCallGatewayApi.mockRejectedValue(new Error('Network error'));
 
-      const result = await getCachedShapes(testUserId);
+      const result = await getCachedShapes(testUser);
 
       expect(result).toEqual([]);
     });
@@ -310,7 +324,7 @@ describe('autocompleteCache', () => {
       });
 
       // Populate cache
-      await getCachedPersonalities(testUserId);
+      await getCachedPersonalities(testUser);
       expect(_getCacheSizeForTesting()).toBe(1);
 
       // Invalidate
@@ -325,14 +339,14 @@ describe('autocompleteCache', () => {
       });
 
       // First call - cache miss
-      await getCachedPersonalities(testUserId);
+      await getCachedPersonalities(testUser);
       expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
 
       // Invalidate
       invalidateUserCache(testUserId);
 
       // Next call - cache miss again
-      await getCachedPersonalities(testUserId);
+      await getCachedPersonalities(testUser);
       expect(mockCallGatewayApi).toHaveBeenCalledTimes(2);
     });
   });
@@ -361,19 +375,19 @@ describe('autocompleteCache', () => {
         ok: true,
         data: { personalities: mockPersonalities },
       });
-      await getCachedPersonalities(testUserId);
+      await getCachedPersonalities(testUser);
 
       // Then fetch personas (should preserve personalities)
       mockCallGatewayApi.mockResolvedValue({
         ok: true,
         data: { personas: mockPersonas },
       });
-      await getCachedPersonas(testUserId);
+      await getCachedPersonas(testUser);
 
       // Verify both are cached
       mockCallGatewayApi.mockClear();
-      const personalities = await getCachedPersonalities(testUserId);
-      const personas = await getCachedPersonas(testUserId);
+      const personalities = await getCachedPersonalities(testUser);
+      const personas = await getCachedPersonas(testUser);
 
       expect(mockCallGatewayApi).not.toHaveBeenCalled();
       expect(personalities).toEqual(mockPersonalities);
@@ -401,19 +415,19 @@ describe('autocompleteCache', () => {
         ok: true,
         data: { personalities: mockPersonalities },
       });
-      await getCachedPersonalities(testUserId);
+      await getCachedPersonalities(testUser);
 
       // Then fetch shapes (should preserve personalities)
       mockCallGatewayApi.mockResolvedValue({
         ok: true,
         data: { shapes: mockShapes },
       });
-      await getCachedShapes(testUserId);
+      await getCachedShapes(testUser);
 
       // Verify both are cached
       mockCallGatewayApi.mockClear();
-      const personalities = await getCachedPersonalities(testUserId);
-      const shapes = await getCachedShapes(testUserId);
+      const personalities = await getCachedPersonalities(testUser);
+      const shapes = await getCachedShapes(testUser);
 
       expect(mockCallGatewayApi).not.toHaveBeenCalled();
       expect(personalities).toEqual(mockPersonalities);

--- a/services/bot-client/src/utils/autocomplete/autocompleteCache.ts
+++ b/services/bot-client/src/utils/autocomplete/autocompleteCache.ts
@@ -10,7 +10,7 @@
  */
 
 import { createLogger, TTLCache, type PersonalitySummary } from '@tzurot/common-types';
-import { callGatewayApi } from '../userGatewayClient.js';
+import { callGatewayApi, type GatewayUser } from '../userGatewayClient.js';
 
 const logger = createLogger('autocomplete-cache');
 
@@ -67,7 +67,8 @@ const userCache = new TTLCache<UserAutocompleteData>({
  * @param userId - Discord user ID
  * @returns Array of personality summaries, or empty array on error
  */
-export async function getCachedPersonalities(userId: string): Promise<PersonalitySummary[]> {
+export async function getCachedPersonalities(user: GatewayUser): Promise<PersonalitySummary[]> {
+  const userId = user.discordId;
   // Check cache first - undefined means "not fetched yet"
   const cached = userCache.get(userId);
   if (cached?.personalities !== undefined) {
@@ -81,7 +82,7 @@ export async function getCachedPersonalities(userId: string): Promise<Personalit
   try {
     const result = await callGatewayApi<{ personalities: PersonalitySummary[] }>(
       '/user/personality',
-      { userId }
+      { user }
     );
 
     if (!result.ok) {
@@ -120,7 +121,8 @@ export async function getCachedPersonalities(userId: string): Promise<Personalit
  * @param userId - Discord user ID
  * @returns Array of persona summaries, or empty array on error
  */
-export async function getCachedPersonas(userId: string): Promise<PersonaSummary[]> {
+export async function getCachedPersonas(user: GatewayUser): Promise<PersonaSummary[]> {
+  const userId = user.discordId;
   // Check cache first - undefined means "not fetched yet"
   const cached = userCache.get(userId);
   if (cached?.personas !== undefined) {
@@ -133,7 +135,7 @@ export async function getCachedPersonas(userId: string): Promise<PersonaSummary[
 
   try {
     const result = await callGatewayApi<{ personas: PersonaSummary[] }>('/user/persona', {
-      userId,
+      user,
     });
 
     if (!result.ok) {
@@ -169,7 +171,8 @@ export async function getCachedPersonas(userId: string): Promise<PersonaSummary[
  * @param userId - Discord user ID
  * @returns Array of shape summaries, or empty array on error
  */
-export async function getCachedShapes(userId: string): Promise<ShapesSummary[]> {
+export async function getCachedShapes(user: GatewayUser): Promise<ShapesSummary[]> {
+  const userId = user.discordId;
   // Check cache first - undefined means "not fetched yet"
   const cached = userCache.get(userId);
   if (cached?.shapes !== undefined) {
@@ -182,7 +185,7 @@ export async function getCachedShapes(userId: string): Promise<ShapesSummary[]> 
 
   try {
     const result = await callGatewayApi<{ shapes: ShapesSummary[] }>('/user/shapes/list', {
-      userId,
+      user,
       // Explicit: default is AUTOCOMPLETE (2500ms), fits Discord's 3s autocomplete window
     });
 

--- a/services/bot-client/src/utils/autocomplete/personaAutocomplete.test.ts
+++ b/services/bot-client/src/utils/autocomplete/personaAutocomplete.test.ts
@@ -51,7 +51,7 @@ describe('handlePersonaAutocomplete', () => {
 
   function createMockInteraction(focusedName: string, focusedValue: string) {
     return {
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser', globalName: 'Test User' },
       options: {
         getFocused: vi.fn().mockReturnValue({
           name: focusedName,
@@ -112,7 +112,11 @@ describe('handlePersonaAutocomplete', () => {
       const interaction = createMockInteraction('profile', '');
       await handlePersonaAutocomplete(interaction);
 
-      expect(mockGetCachedPersonas).toHaveBeenCalledWith('123456789');
+      expect(mockGetCachedPersonas).toHaveBeenCalledWith({
+        discordId: '123456789',
+        username: 'testuser',
+        displayName: 'Test User',
+      });
     });
 
     it('should return empty array when cache returns empty', async () => {

--- a/services/bot-client/src/utils/autocomplete/personaAutocomplete.ts
+++ b/services/bot-client/src/utils/autocomplete/personaAutocomplete.ts
@@ -13,6 +13,7 @@ import {
   formatAutocompleteOption,
 } from '@tzurot/common-types';
 import { getCachedPersonas } from './autocompleteCache.js';
+import { toGatewayUser } from '../userGatewayClient.js';
 
 const logger = createLogger('persona-autocomplete');
 
@@ -60,7 +61,7 @@ export async function handlePersonaAutocomplete(
 
   try {
     // Use cached data to avoid HTTP requests on every keystroke
-    const personas = await getCachedPersonas(userId);
+    const personas = await getCachedPersonas(toGatewayUser(interaction.user));
 
     // Filter by query
     const filtered = personas

--- a/services/bot-client/src/utils/autocomplete/personalityAutocomplete.test.ts
+++ b/services/bot-client/src/utils/autocomplete/personalityAutocomplete.test.ts
@@ -36,7 +36,7 @@ describe('handlePersonalityAutocomplete', () => {
 
   function createMockInteraction(focusedName: string, focusedValue: string) {
     return {
-      user: { id: '123456789' },
+      user: { id: '123456789', username: 'testuser', globalName: 'Test User' },
       guildId: 'guild-123',
       options: {
         getFocused: vi.fn().mockReturnValue({
@@ -135,7 +135,11 @@ describe('handlePersonalityAutocomplete', () => {
       const interaction = createMockInteraction('personality', '');
       await handlePersonalityAutocomplete(interaction);
 
-      expect(mockGetCachedPersonalities).toHaveBeenCalledWith('123456789');
+      expect(mockGetCachedPersonalities).toHaveBeenCalledWith({
+        discordId: '123456789',
+        username: 'testuser',
+        displayName: 'Test User',
+      });
     });
 
     it('should return empty array when cache returns empty', async () => {

--- a/services/bot-client/src/utils/autocomplete/personalityAutocomplete.ts
+++ b/services/bot-client/src/utils/autocomplete/personalityAutocomplete.ts
@@ -18,6 +18,7 @@ import {
   formatAutocompleteOption,
 } from '@tzurot/common-types';
 import { getCachedPersonalities } from './autocompleteCache.js';
+import { toGatewayUser } from '../userGatewayClient.js';
 
 const logger = createLogger('personality-autocomplete');
 
@@ -74,7 +75,7 @@ export async function handlePersonalityAutocomplete(
 
   try {
     // Use cached data to avoid HTTP requests on every keystroke
-    const personalities = await getCachedPersonalities(userId);
+    const personalities = await getCachedPersonalities(toGatewayUser(interaction.user));
 
     if (personalities.length === 0) {
       await interaction.respond([]);

--- a/services/bot-client/src/utils/commandHelpers.test.ts
+++ b/services/bot-client/src/utils/commandHelpers.test.ts
@@ -25,14 +25,14 @@ vi.mock('@tzurot/common-types', async () => {
   };
 });
 
-vi.mock('./userGatewayClient.js', () => ({
-  isGatewayConfigured: vi.fn().mockReturnValue(true),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('./userGatewayClient.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('./userGatewayClient.js')>('./userGatewayClient.js');
+  return {
+    ...actual,
+    isGatewayConfigured: vi.fn().mockReturnValue(true),
+  };
+});
 
 import {
   replyWithError,

--- a/services/bot-client/src/utils/commandHelpers.test.ts
+++ b/services/bot-client/src/utils/commandHelpers.test.ts
@@ -27,6 +27,11 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('./userGatewayClient.js', () => ({
   isGatewayConfigured: vi.fn().mockReturnValue(true),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 import {

--- a/services/bot-client/src/utils/dashboard/genericSelectMenuHandler.ts
+++ b/services/bot-client/src/utils/dashboard/genericSelectMenuHandler.ts
@@ -15,6 +15,7 @@
 
 import type { StringSelectMenuInteraction } from 'discord.js';
 import { MessageFlags } from 'discord.js';
+import { toGatewayUser, type GatewayUser } from '../userGatewayClient.js';
 import { parseDashboardCustomId, type DashboardConfig } from './types.js';
 import { fetchOrCreateSession } from './sessionHelpers.js';
 import { buildSectionModal } from './ModalFactory.js';
@@ -27,7 +28,7 @@ export interface GenericSelectMenuConfig<TFlat extends Record<string, unknown>, 
   /** Dashboard config defining the sections and modal fields */
   dashboardConfig: DashboardConfig<TFlat>;
   /** Fetch the raw entity data from the API */
-  fetchFn: (entityId: string, userId: string) => Promise<TRaw | null>;
+  fetchFn: (entityId: string, user: GatewayUser) => Promise<TRaw | null>;
   /** Transform raw API data to the flattened session format */
   transformFn: (raw: TRaw) => TFlat;
   /** Entity name used in user-facing error messages (e.g., 'Persona', 'Preset') */
@@ -78,7 +79,7 @@ export async function handleDashboardSectionSelect<TFlat extends Record<string, 
     userId: interaction.user.id,
     entityType: config.entityType,
     entityId,
-    fetchFn: () => config.fetchFn(entityId, interaction.user.id),
+    fetchFn: () => config.fetchFn(entityId, toGatewayUser(interaction.user)),
     transformFn: config.transformFn,
     interaction,
   });

--- a/services/bot-client/src/utils/dashboard/refreshHandler.test.ts
+++ b/services/bot-client/src/utils/dashboard/refreshHandler.test.ts
@@ -60,7 +60,7 @@ describe('refreshHandler', () => {
       });
 
       const interaction = {
-        user: { id: 'user-123' },
+        user: { id: 'user-123', username: 'testuser', globalName: 'Test User' },
         message: { id: 'msg-456' },
         channelId: 'channel-789',
         deferUpdate: vi.fn(),
@@ -70,7 +70,11 @@ describe('refreshHandler', () => {
       await handler(interaction, 'entity-abc');
 
       expect(interaction.deferUpdate).toHaveBeenCalled();
-      expect(fetchFn).toHaveBeenCalledWith('entity-abc', 'user-123');
+      expect(fetchFn).toHaveBeenCalledWith('entity-abc', {
+        discordId: 'user-123',
+        username: 'testuser',
+        displayName: 'Test User',
+      });
       expect(transformFn).toHaveBeenCalledWith(rawData);
       expect(mockSessionManager.set).toHaveBeenCalledWith({
         userId: 'user-123',

--- a/services/bot-client/src/utils/dashboard/refreshHandler.ts
+++ b/services/bot-client/src/utils/dashboard/refreshHandler.ts
@@ -6,6 +6,7 @@
 
 import type { ButtonInteraction, ModalSubmitInteraction } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
+import { toGatewayUser, type GatewayUser } from '../userGatewayClient.js';
 import { getSessionManager } from './SessionManager.js';
 import {
   buildDashboardEmbed,
@@ -26,7 +27,7 @@ interface RefreshHandlerOptions<TData, TRaw = TData> {
   /** Dashboard configuration */
   dashboardConfig: DashboardConfig<TData>;
   /** Function to fetch fresh data */
-  fetchFn: (entityId: string, userId: string) => Promise<TRaw | null>;
+  fetchFn: (entityId: string, user: GatewayUser) => Promise<TRaw | null>;
   /** Function to transform raw data to dashboard format (optional if same) */
   transformFn?: (raw: TRaw) => TData;
   /** Function to build action button options from data (optional) */
@@ -69,7 +70,7 @@ export function createRefreshHandler<TData, TRaw = TData>(
   return async (interaction: ButtonInteraction, entityId: string): Promise<void> => {
     await interaction.deferUpdate();
 
-    const rawData = await fetchFn(entityId, interaction.user.id);
+    const rawData = await fetchFn(entityId, toGatewayUser(interaction.user));
 
     if (rawData === null) {
       await interaction.editReply({

--- a/services/bot-client/src/utils/dashboard/settings/settingsUpdateFactory.test.ts
+++ b/services/bot-client/src/utils/dashboard/settings/settingsUpdateFactory.test.ts
@@ -7,6 +7,11 @@ const { mockCallGatewayApi, mockMapSettingToApiUpdate } = vi.hoisted(() => ({
 
 vi.mock('../../userGatewayClient.js', () => ({
   callGatewayApi: mockCallGatewayApi,
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 vi.mock('./settingsUpdate.js', () => ({

--- a/services/bot-client/src/utils/dashboard/settings/settingsUpdateFactory.test.ts
+++ b/services/bot-client/src/utils/dashboard/settings/settingsUpdateFactory.test.ts
@@ -5,14 +5,15 @@ const { mockCallGatewayApi, mockMapSettingToApiUpdate } = vi.hoisted(() => ({
   mockMapSettingToApiUpdate: vi.fn(),
 }));
 
-vi.mock('../../userGatewayClient.js', () => ({
-  callGatewayApi: mockCallGatewayApi,
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('../../userGatewayClient.js', async () => {
+  const actual = await vi.importActual<typeof import('../../userGatewayClient.js')>(
+    '../../userGatewayClient.js'
+  );
+  return {
+    ...actual,
+    callGatewayApi: mockCallGatewayApi,
+  };
+});
 
 vi.mock('./settingsUpdate.js', () => ({
   mapSettingToApiUpdate: mockMapSettingToApiUpdate,

--- a/services/bot-client/src/utils/dashboard/settings/settingsUpdateFactory.ts
+++ b/services/bot-client/src/utils/dashboard/settings/settingsUpdateFactory.ts
@@ -21,7 +21,7 @@ import {
   type ConfigOverrideSource,
   type ResolvedConfigOverrides,
 } from '@tzurot/common-types';
-import { callGatewayApi } from '../../userGatewayClient.js';
+import { callGatewayApi, toGatewayUser } from '../../userGatewayClient.js';
 import type {
   SettingsData,
   SettingsDashboardSession,
@@ -86,6 +86,7 @@ export function createSettingsUpdateHandler(
     newValue: unknown
   ): Promise<SettingUpdateResult> => {
     const userId = interaction.user.id;
+    const user = toGatewayUser(interaction.user);
 
     logger.debug(
       { settingId, newValue, entityId, userId },
@@ -103,7 +104,7 @@ export function createSettingsUpdateHandler(
       const result = await callGatewayApi(config.patchEndpoint(entityId), {
         method: 'PATCH',
         body,
-        userId,
+        user,
         timeout: GATEWAY_TIMEOUTS.DEFERRED,
       });
 
@@ -118,7 +119,7 @@ export function createSettingsUpdateHandler(
       // Re-resolve cascade to get updated effective values
       const cascadeResult = await callGatewayApi<ResolvedConfigOverrides>(
         config.resolveEndpoint(entityId),
-        { method: 'GET', userId, timeout: GATEWAY_TIMEOUTS.DEFERRED }
+        { method: 'GET', user, timeout: GATEWAY_TIMEOUTS.DEFERRED }
       );
 
       if (!cascadeResult.ok) {

--- a/services/bot-client/src/utils/nsfwVerification.test.ts
+++ b/services/bot-client/src/utils/nsfwVerification.test.ts
@@ -19,6 +19,11 @@ import * as userGatewayClient from './userGatewayClient.js';
 // Mock the gateway client
 vi.mock('./userGatewayClient.js', () => ({
   callGatewayApi: vi.fn(),
+  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
+    discordId: user.id ?? 'test-user-id',
+    username: user.username ?? 'testuser',
+    displayName: user.globalName ?? user.username ?? 'testuser',
+  }),
 }));
 
 describe('NSFW Verification Utilities', () => {
@@ -40,7 +45,11 @@ describe('NSFW Verification Utilities', () => {
         },
       });
 
-      const result = await checkNsfwVerification('user123');
+      const result = await checkNsfwVerification({
+        discordId: 'user123',
+        username: 'testuser',
+        displayName: 'testuser',
+      });
 
       expect(result).toEqual({
         nsfwVerified: true,
@@ -48,7 +57,11 @@ describe('NSFW Verification Utilities', () => {
       });
       expect(userGatewayClient.callGatewayApi).toHaveBeenCalledWith('/user/nsfw', {
         method: 'GET',
-        userId: 'user123',
+        user: {
+          discordId: 'user123',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
       });
     });
 
@@ -59,7 +72,11 @@ describe('NSFW Verification Utilities', () => {
         status: 500,
       });
 
-      const result = await checkNsfwVerification('user123');
+      const result = await checkNsfwVerification({
+        discordId: 'user123',
+        username: 'testuser',
+        displayName: 'testuser',
+      });
 
       expect(result).toEqual({
         nsfwVerified: false,
@@ -79,7 +96,11 @@ describe('NSFW Verification Utilities', () => {
         },
       });
 
-      const result = await verifyNsfwUser('user123');
+      const result = await verifyNsfwUser({
+        discordId: 'user123',
+        username: 'testuser',
+        displayName: 'testuser',
+      });
 
       expect(result).toEqual({
         nsfwVerified: true,
@@ -88,7 +109,11 @@ describe('NSFW Verification Utilities', () => {
       });
       expect(userGatewayClient.callGatewayApi).toHaveBeenCalledWith('/user/nsfw/verify', {
         method: 'POST',
-        userId: 'user123',
+        user: {
+          discordId: 'user123',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
       });
     });
 
@@ -99,7 +124,11 @@ describe('NSFW Verification Utilities', () => {
         status: 500,
       });
 
-      const result = await verifyNsfwUser('user123');
+      const result = await verifyNsfwUser({
+        discordId: 'user123',
+        username: 'testuser',
+        displayName: 'testuser',
+      });
 
       expect(result).toBeNull();
     });
@@ -384,7 +413,11 @@ describe('NSFW Verification Utilities', () => {
       expect(result).toEqual({ allowed: true, wasNewVerification: true });
       expect(userGatewayClient.callGatewayApi).toHaveBeenCalledWith('/user/nsfw/verify', {
         method: 'POST',
-        userId: 'user-123',
+        user: {
+          discordId: 'user-123',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
       });
     });
 
@@ -435,7 +468,11 @@ describe('NSFW Verification Utilities', () => {
       expect(result).toEqual({ allowed: true, wasNewVerification: false });
       expect(userGatewayClient.callGatewayApi).toHaveBeenCalledWith('/user/nsfw', {
         method: 'GET',
-        userId: 'user-123',
+        user: {
+          discordId: 'user-123',
+          username: 'testuser',
+          displayName: 'testuser',
+        },
       });
     });
 

--- a/services/bot-client/src/utils/nsfwVerification.test.ts
+++ b/services/bot-client/src/utils/nsfwVerification.test.ts
@@ -17,14 +17,14 @@ import {
 import * as userGatewayClient from './userGatewayClient.js';
 
 // Mock the gateway client
-vi.mock('./userGatewayClient.js', () => ({
-  callGatewayApi: vi.fn(),
-  toGatewayUser: (user: { id?: string; username?: string; globalName?: string | null }) => ({
-    discordId: user.id ?? 'test-user-id',
-    username: user.username ?? 'testuser',
-    displayName: user.globalName ?? user.username ?? 'testuser',
-  }),
-}));
+vi.mock('./userGatewayClient.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('./userGatewayClient.js')>('./userGatewayClient.js');
+  return {
+    ...actual,
+    callGatewayApi: vi.fn(),
+  };
+});
 
 describe('NSFW Verification Utilities', () => {
   beforeEach(() => {
@@ -365,7 +365,7 @@ describe('NSFW Verification Utilities', () => {
       const mockReply = { id: 'reply-123', channelId: 'channel-456' };
       const mockMessage = {
         id: 'msg-789',
-        author: { id: 'user-123' },
+        author: { id: 'user-123', username: 'testuser' },
         reply: vi.fn().mockResolvedValue(mockReply),
       } as any;
 
@@ -377,7 +377,7 @@ describe('NSFW Verification Utilities', () => {
     it('should handle reply failure gracefully', async () => {
       const mockMessage = {
         id: 'msg-789',
-        author: { id: 'user-123' },
+        author: { id: 'user-123', username: 'testuser' },
         reply: vi.fn().mockRejectedValue(new Error('Cannot send message')),
       } as any;
 
@@ -400,7 +400,7 @@ describe('NSFW Verification Utilities', () => {
       });
 
       const mockMessage = {
-        author: { id: 'user-123' },
+        author: { id: 'user-123', username: 'testuser' },
         channel: {
           type: ChannelType.GuildText,
           nsfw: true,
@@ -432,7 +432,7 @@ describe('NSFW Verification Utilities', () => {
       });
 
       const mockMessage = {
-        author: { id: 'user-123' },
+        author: { id: 'user-123', username: 'testuser' },
         channel: {
           type: ChannelType.GuildText,
           nsfw: true,
@@ -455,7 +455,7 @@ describe('NSFW Verification Utilities', () => {
       });
 
       const mockMessage = {
-        author: { id: 'user-123' },
+        author: { id: 'user-123', username: 'testuser' },
         channel: {
           type: ChannelType.GuildText,
           nsfw: false,
@@ -488,7 +488,7 @@ describe('NSFW Verification Utilities', () => {
       const mockReply = { id: 'reply-123', channelId: 'channel-456' };
       const mockMessage = {
         id: 'msg-789',
-        author: { id: 'user-123' },
+        author: { id: 'user-123', username: 'testuser' },
         channel: {
           type: ChannelType.DM,
         },
@@ -512,7 +512,7 @@ describe('NSFW Verification Utilities', () => {
       });
 
       const mockMessage = {
-        author: { id: 'user-123' },
+        author: { id: 'user-123', username: 'testuser' },
         channel: {
           type: ChannelType.PublicThread,
           parent: {

--- a/services/bot-client/src/utils/nsfwVerification.ts
+++ b/services/bot-client/src/utils/nsfwVerification.ts
@@ -58,12 +58,12 @@ export async function checkNsfwVerification(user: GatewayUser): Promise<NsfwStat
  * Called when user interacts with the bot in an NSFW Discord channel
  */
 export async function verifyNsfwUser(user: GatewayUser): Promise<NsfwVerifyResponse | null> {
+  const userId = user.discordId;
   const result = await callGatewayApi<NsfwVerifyResponse>('/user/nsfw/verify', {
     method: 'POST',
     user,
   });
 
-  const userId = user.discordId;
   if (!result.ok) {
     logger.warn({ userId, error: result.error }, '[NSFW] Failed to verify user');
     return null;

--- a/services/bot-client/src/utils/nsfwVerification.ts
+++ b/services/bot-client/src/utils/nsfwVerification.ts
@@ -14,7 +14,7 @@ import {
   type SendableChannels,
 } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
-import { callGatewayApi } from './userGatewayClient.js';
+import { callGatewayApi, toGatewayUser, type GatewayUser } from './userGatewayClient.js';
 import { redis } from '../redis.js';
 import { storePendingVerificationMessage } from './pendingVerificationMessages.js';
 import { cleanupVerificationMessagesForUser } from '../services/VerificationCleanupService.js';
@@ -36,14 +36,17 @@ interface NsfwVerifyResponse {
 /**
  * Check if a user is NSFW verified
  */
-export async function checkNsfwVerification(userId: string): Promise<NsfwStatus> {
+export async function checkNsfwVerification(user: GatewayUser): Promise<NsfwStatus> {
   const result = await callGatewayApi<NsfwStatus>('/user/nsfw', {
     method: 'GET',
-    userId,
+    user,
   });
 
   if (!result.ok) {
-    logger.warn({ userId, error: result.error }, '[NSFW] Failed to check verification status');
+    logger.warn(
+      { userId: user.discordId, error: result.error },
+      '[NSFW] Failed to check verification status'
+    );
     return { nsfwVerified: false, nsfwVerifiedAt: null };
   }
 
@@ -54,12 +57,13 @@ export async function checkNsfwVerification(userId: string): Promise<NsfwStatus>
  * Mark a user as NSFW verified
  * Called when user interacts with the bot in an NSFW Discord channel
  */
-export async function verifyNsfwUser(userId: string): Promise<NsfwVerifyResponse | null> {
+export async function verifyNsfwUser(user: GatewayUser): Promise<NsfwVerifyResponse | null> {
   const result = await callGatewayApi<NsfwVerifyResponse>('/user/nsfw/verify', {
     method: 'POST',
-    userId,
+    user,
   });
 
+  const userId = user.discordId;
   if (!result.ok) {
     logger.warn({ userId, error: result.error }, '[NSFW] Failed to verify user');
     return null;
@@ -220,18 +224,19 @@ export async function handleNsfwVerification(
   logPrefix: string
 ): Promise<NsfwVerificationResult> {
   const userId = message.author.id;
+  const user = toGatewayUser(message.author);
   const { channel } = message;
 
   // If in NSFW channel, auto-verify and continue
   if (isNsfwChannel(channel)) {
-    const verifyResult = await verifyNsfwUser(userId);
+    const verifyResult = await verifyNsfwUser(user);
     // wasNewVerification is true if verify succeeded AND user wasn't already verified
     const wasNewVerification = verifyResult !== null && !verifyResult.alreadyVerified;
     return { allowed: true, wasNewVerification };
   }
 
   // For all other channels (DMs and non-NSFW guild channels), check verification
-  const nsfwStatus = await checkNsfwVerification(userId);
+  const nsfwStatus = await checkNsfwVerification(user);
   if (!nsfwStatus.nsfwVerified) {
     logger.info(
       { userId, channelType: channel.type },

--- a/services/bot-client/src/utils/userGatewayClient.test.ts
+++ b/services/bot-client/src/utils/userGatewayClient.test.ts
@@ -38,8 +38,15 @@ import {
   isGatewayConfigured,
   parseErrorResponse,
   callGatewayApi,
+  toGatewayUser,
   GATEWAY_TIMEOUTS,
+  type GatewayUser,
 } from './userGatewayClient.js';
+import type { User as DiscordUser } from 'discord.js';
+
+function mkUser(discordId = 'user-123'): GatewayUser {
+  return { discordId, username: 'test-user', displayName: 'Test User' };
+}
 
 // Helper to create mock config with defaults
 function createMockConfig(overrides: Record<string, unknown> = {}) {
@@ -172,7 +179,7 @@ describe('userGatewayClient', () => {
       });
 
       const result = await callGatewayApi<{ data: string }>('/test', {
-        userId: 'user-123',
+        user: mkUser(),
       });
 
       expect(result.ok).toBe(true);
@@ -187,6 +194,8 @@ describe('userGatewayClient', () => {
           headers: {
             'X-Service-Auth': 'test-service-secret',
             'X-User-Id': 'user-123',
+            'X-User-Username': 'test-user',
+            'X-User-DisplayName': 'Test%20User',
           },
         })
       );
@@ -200,7 +209,7 @@ describe('userGatewayClient', () => {
 
       await callGatewayApi('/test', {
         method: 'POST',
-        userId: 'user-123',
+        user: mkUser(),
         body: { key: 'value' },
       });
 
@@ -211,6 +220,8 @@ describe('userGatewayClient', () => {
           headers: {
             'X-Service-Auth': 'test-service-secret',
             'X-User-Id': 'user-123',
+            'X-User-Username': 'test-user',
+            'X-User-DisplayName': 'Test%20User',
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({ key: 'value' }),
@@ -225,7 +236,7 @@ describe('userGatewayClient', () => {
         json: vi.fn().mockResolvedValue({ error: 'Not found' }),
       });
 
-      const result = await callGatewayApi('/test', { userId: 'user-123' });
+      const result = await callGatewayApi('/test', { user: mkUser() });
 
       expect(result.ok).toBe(false);
       if (!result.ok) {
@@ -248,7 +259,7 @@ describe('userGatewayClient', () => {
         }),
       });
 
-      const result = await callGatewayApi('/test', { userId: 'user-123' });
+      const result = await callGatewayApi('/test', { user: mkUser() });
 
       expect(result.ok).toBe(false);
       if (!result.ok) {
@@ -265,7 +276,7 @@ describe('userGatewayClient', () => {
         json: vi.fn().mockResolvedValue({ error: 'Internal error' }),
       });
 
-      const result = await callGatewayApi('/test', { userId: 'user-123' });
+      const result = await callGatewayApi('/test', { user: mkUser() });
 
       expect(result.ok).toBe(false);
       if (!result.ok) {
@@ -276,7 +287,7 @@ describe('userGatewayClient', () => {
     it('should handle fetch errors', async () => {
       mockFetch.mockRejectedValue(new Error('Network error'));
 
-      const result = await callGatewayApi('/test', { userId: 'user-123' });
+      const result = await callGatewayApi('/test', { user: mkUser() });
 
       expect(result.ok).toBe(false);
       if (!result.ok) {
@@ -291,7 +302,7 @@ describe('userGatewayClient', () => {
         json: vi.fn().mockResolvedValue({ data: 'test' }),
       });
 
-      await callGatewayApi('/test', { userId: 'user-123' });
+      await callGatewayApi('/test', { user: mkUser() });
 
       // Verify AbortSignal.timeout was called with default (2500ms)
       expect(mockFetch).toHaveBeenCalledWith(
@@ -309,7 +320,7 @@ describe('userGatewayClient', () => {
       });
 
       await callGatewayApi('/test', {
-        userId: 'user-123',
+        user: mkUser(),
         timeout: GATEWAY_TIMEOUTS.DEFERRED,
       });
 
@@ -326,13 +337,71 @@ describe('userGatewayClient', () => {
       const timeoutError = new DOMException('Signal timed out', 'TimeoutError');
       mockFetch.mockRejectedValue(timeoutError);
 
-      const result = await callGatewayApi('/test', { userId: 'user-123' });
+      const result = await callGatewayApi('/test', { user: mkUser() });
 
       expect(result.ok).toBe(false);
       if (!result.ok) {
         expect(result.error).toBe('Request timeout (gateway slow or unavailable)');
         expect(result.status).toBe(0);
       }
+    });
+
+    it('should URI-encode username and displayName for non-Latin-1 values', async () => {
+      // Node fetch rejects non-Latin-1 chars (emoji) in header values with a
+      // synchronous throw. Encoding on the way out is the only safe path;
+      // PR B's gateway middleware decodes on arrival.
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({}),
+      });
+
+      await callGatewayApi('/test', {
+        user: {
+          discordId: 'user-123',
+          username: 'alice_🌸',
+          displayName: '👋 Alice',
+        },
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'X-User-Username': encodeURIComponent('alice_🌸'),
+            'X-User-DisplayName': encodeURIComponent('👋 Alice'),
+          }),
+        })
+      );
+    });
+  });
+
+  describe('toGatewayUser', () => {
+    it('should use globalName as displayName when present', () => {
+      const user = {
+        id: 'user-123',
+        username: 'alice',
+        globalName: 'Alice Cooper',
+      } as DiscordUser;
+
+      expect(toGatewayUser(user)).toEqual({
+        discordId: 'user-123',
+        username: 'alice',
+        displayName: 'Alice Cooper',
+      });
+    });
+
+    it('should fall back to username when globalName is null', () => {
+      const user = {
+        id: 'user-123',
+        username: 'alice',
+        globalName: null,
+      } as DiscordUser;
+
+      expect(toGatewayUser(user)).toEqual({
+        discordId: 'user-123',
+        username: 'alice',
+        displayName: 'alice',
+      });
     });
   });
 

--- a/services/bot-client/src/utils/userGatewayClient.ts
+++ b/services/bot-client/src/utils/userGatewayClient.ts
@@ -16,12 +16,18 @@ import {
   CONTENT_TYPES,
   GATEWAY_TIMEOUTS,
   type ApiErrorSubcode,
+  type GatewayUser,
 } from '@tzurot/common-types';
 
 const logger = createLogger('gateway-client');
 
 // Re-export GATEWAY_TIMEOUTS for existing consumers
 export { GATEWAY_TIMEOUTS };
+
+// Re-export GatewayUser so bot-client callers have a single import site.
+// The interface itself lives in common-types — PR B's gateway middleware
+// will import from the same source, giving both sides one contract.
+export type { GatewayUser };
 
 /**
  * Gateway API response wrapper
@@ -63,20 +69,6 @@ export class GatewayApiError extends Error {
     this.status = status;
     this.code = code;
   }
-}
-
-/**
- * Discord user context passed to every gateway API call.
- *
- * Identity Epic Phase 5c: the gateway middleware uses `username` +
- * `displayName` to provision users with real Discord context instead of
- * the placeholder shell path. `discordId` matches `interaction.user.id`
- * (the Discord snowflake), NOT the internal UUID.
- */
-export interface GatewayUser {
-  discordId: string;
-  username: string;
-  displayName: string;
 }
 
 /**
@@ -189,7 +181,8 @@ export async function callGatewayApi<T>(
     // URI-encode `username` and `displayName` because Node's `fetch` encodes
     // HTTP header values as Latin-1; any non-Latin-1 char (emoji in display
     // names are very common) throws synchronously. Gateway middleware in
-    // PR B decodes these on arrival.
+    // PR B decodes these on arrival. `X-User-Id` is safe raw: Discord
+    // snowflakes are digits only, always Latin-1.
     const headers: Record<string, string> = {
       'X-Service-Auth': config.INTERNAL_SERVICE_SECRET ?? '',
       'X-User-Id': user.discordId,

--- a/services/bot-client/src/utils/userGatewayClient.ts
+++ b/services/bot-client/src/utils/userGatewayClient.ts
@@ -4,11 +4,12 @@
  *
  * Provides:
  * - Service-to-service authentication (X-Service-Auth header)
- * - User identification (X-User-Id header)
+ * - User identification context (X-User-Id, X-User-Username, X-User-DisplayName)
  * - Standardized error handling
  * - Gateway URL validation
  */
 
+import type { User as DiscordUser } from 'discord.js';
 import {
   getConfig,
   createLogger,
@@ -65,11 +66,38 @@ export class GatewayApiError extends Error {
 }
 
 /**
+ * Discord user context passed to every gateway API call.
+ *
+ * Identity Epic Phase 5c: the gateway middleware uses `username` +
+ * `displayName` to provision users with real Discord context instead of
+ * the placeholder shell path. `discordId` matches `interaction.user.id`
+ * (the Discord snowflake), NOT the internal UUID.
+ */
+export interface GatewayUser {
+  discordId: string;
+  username: string;
+  displayName: string;
+}
+
+/**
+ * Build a `GatewayUser` from a Discord.js `User` object. Centralizes the
+ * `globalName ?? username` fallback — callers never decide locally.
+ * Works for both `interaction.user` and `message.author` (both are `User`).
+ */
+export function toGatewayUser(user: DiscordUser): GatewayUser {
+  return {
+    discordId: user.id,
+    username: user.username,
+    displayName: user.globalName ?? user.username,
+  };
+}
+
+/**
  * Options for gateway API calls
  */
 interface GatewayCallOptions {
   method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
-  userId: string;
+  user: GatewayUser;
   body?: unknown;
   /**
    * Request timeout in milliseconds.
@@ -145,22 +173,28 @@ export async function parseErrorResponse(response: Response): Promise<ParsedErro
  * Call the gateway API with consistent auth and error handling
  *
  * @param path - API path (e.g., '/user/llm-config')
- * @param options - Request options including userId for auth
+ * @param options - Request options including `user` context for auth + provisioning
  * @returns GatewayResult with typed data or error
  */
 export async function callGatewayApi<T>(
   path: string,
   options: GatewayCallOptions
 ): Promise<GatewayResult<T>> {
-  const { method = 'GET', userId, body, timeout = GATEWAY_TIMEOUTS.AUTOCOMPLETE } = options;
+  const { method = 'GET', user, body, timeout = GATEWAY_TIMEOUTS.AUTOCOMPLETE } = options;
 
   try {
     const gatewayUrl = getGatewayUrl();
     const config = getConfig();
 
+    // URI-encode `username` and `displayName` because Node's `fetch` encodes
+    // HTTP header values as Latin-1; any non-Latin-1 char (emoji in display
+    // names are very common) throws synchronously. Gateway middleware in
+    // PR B decodes these on arrival.
     const headers: Record<string, string> = {
       'X-Service-Auth': config.INTERNAL_SERVICE_SECRET ?? '',
-      'X-User-Id': userId,
+      'X-User-Id': user.discordId,
+      'X-User-Username': encodeURIComponent(user.username),
+      'X-User-DisplayName': encodeURIComponent(user.displayName),
     };
 
     if (body !== undefined) {
@@ -176,7 +210,10 @@ export async function callGatewayApi<T>(
 
     if (!response.ok) {
       const parsed = await parseErrorResponse(response);
-      logger.warn({ path, method, status: response.status, userId }, '[Gateway] Request failed');
+      logger.warn(
+        { path, method, status: response.status, userId: user.discordId },
+        '[Gateway] Request failed'
+      );
       return {
         ok: false,
         error: parsed.message,
@@ -197,7 +234,7 @@ export async function callGatewayApi<T>(
         : 'Unknown error';
 
     logger.warn(
-      { path, method, userId, errorMessage, isTimeout: isAbortError },
+      { path, method, userId: user.discordId, errorMessage, isTimeout: isAbortError },
       '[Gateway] Request error'
     );
     return { ok: false, error: errorMessage, status: 0 };


### PR DESCRIPTION
## Summary

PR A of **Phase 5c** in the Identity & Provisioning Hardening epic. bot-client now attaches `X-User-Username` and `X-User-DisplayName` headers alongside `X-User-Id` on every api-gateway request.

**Purely additive**: headers go out, nothing on the gateway consumes them yet. PR B (gateway shadow-mode middleware) and Phase 6 (integration tests) follow in this release.

## Approach

Introduces a `GatewayUser` type (`{ discordId, username, displayName }`) and threads it through the bot-client's HTTP wrapper, factories, per-entity API modules, and callsites — replacing the bare `userId: string` parameter pattern. The `toGatewayUser(user: DiscordUser)` helper centralizes the `globalName ?? username` fallback.

**Why a type object, not two string parameters**: PR B and likely follow-ons (guild id for activation caching, locale for errors) will want to extend the context. An object type extends without churning every call signature; two parameters becomes four, becomes six. One-time rename cost now, zero callsite churn later.

**Critical: URI-encoded header values**. Node `fetch` encodes HTTP header values as Latin-1; emoji in Discord display names (very common) would cause a synchronous `fetch` throw without encoding. Mitigation: `encodeURIComponent` on the way out. PR B will `decodeURIComponent` on arrival. One dedicated test for emoji in `displayName`.

## Scope

- 187 files, +1980 / −740 (includes prettier reformatting applied at commit-time)
- Almost entirely mechanical signature propagation driven by TypeScript's cascading compile errors
- No changes to production business logic
- No new `as any` / `as unknown as` casts
- Log fields preserved as `userId: user.discordId` for Railway log-query compatibility
- `adminFetch` and admin endpoints explicitly out of scope — covered by PR B's middleware design

## Out of scope (planned follow-ups)

- Gateway middleware that consumes the new headers — **PR B**
- Deletion of the shell-creation path — **PR C** (separate release)
- Integration test coverage for the refactor-regression class — **Phase 6**, bundled into this release
- `adminFetch` threading — PR B
- Username drift-sync — PR C (async fire-and-forget)

## Rollback safety

- Headers are sent but not consumed on the gateway yet — PR A can be reverted as a single commit with zero user-visible impact
- URI-encoding eliminates the non-Latin-1 failure mode by construction
- 4304 bot-client tests cover the new header + encoding paths

## Test plan

- [x] `pnpm --filter @tzurot/bot-client typecheck` — 0 errors
- [x] `pnpm --filter @tzurot/bot-client typecheck:spec` — 0 errors
- [x] `pnpm --filter @tzurot/bot-client test` — 4304/4304 passing
- [x] `pnpm --filter @tzurot/bot-client lint` — clean
- [x] `pnpm quality` (full repo, 11 tasks) — 11/11 passing
- [x] New dedicated tests: URI-encoding for emoji in `displayName`, `toGatewayUser` with/without `globalName`
- [ ] Local smoke: spot-check `X-User-Username` + `X-User-DisplayName` appear on gateway incoming requests in dev Railway logs (optional before merge; PR B verifies end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)