### PR TITLE
feat(api-gateway): shadow-mode provisioning middleware + shell-path canary (Phase 5c PR B)

### DIFF
--- a/.claude/rules/01-architecture.md
+++ b/.claude/rules/01-architecture.md
@@ -40,6 +40,21 @@ Discord User → bot-client (Discord.js) → api-gateway (Express + BullMQ) → 
 | api-gateway | Clean JSON, NO emojis | `{ "error": "NOT_FOUND", "message": "Persona not found" }` |
 | bot-client  | ADD emojis for users  | `'❌ Profile not found.'`                                  |
 
+## Request Enrichment (api-gateway middleware)
+
+User-scoped routes run two auth-adjacent middlewares. Handlers read from `req` depending on which field they need:
+
+| Middleware                 | Attaches                                                   | Field type               | When to use                                             |
+| -------------------------- | ---------------------------------------------------------- | ------------------------ | ------------------------------------------------------- |
+| `requireUserAuth()`        | `req.userId`                                               | Discord snowflake string | When you need the Discord ID (e.g., for `isBotOwner()`) |
+| `requireProvisionedUser()` | `req.provisionedUserId`, `req.provisionedDefaultPersonaId` | Internal UUIDs           | When you need the internal user row (Phase 5c PR B on)  |
+
+Mount order matters: `requireProvisionedUser` runs AFTER `requireUserAuth` and reads the Discord ID set by the first middleware. Both attach fields via local casting (`(req as ProvisionedRequest).provisionedUserId = ...`) — no global Express augmentation.
+
+During the shadow-mode window (PR B → PR C), `provisionedUserId` is **optional** on the request type because the middleware degrades gracefully on missing headers or malformed URI encoding. PR C tightens the invariant once bot-client has been fully rolled out.
+
+Handlers that need the internal UUID should prefer `req.provisionedUserId` over calling `getOrCreateUserShell(req.userId)` going forward.
+
 ## Design Principles
 
 1. **Simple, clean classes** - No DDD over-engineering

--- a/packages/common-types/src/services/UserService.ts
+++ b/packages/common-types/src/services/UserService.ts
@@ -202,8 +202,16 @@ export class UserService {
     // caller. Target: zero hits in prod for 48-72h, which unlocks PR C's
     // shell-path deletion. Kept at warn level so a misconfigured route shows
     // up in normal log-search without spamming debug noise.
+    //
+    // Stack is capped to the top 6 frames: enough to see the caller chain
+    // (middleware / handler / route-helper) without paying for a full 30+
+    // frame string allocation on every shell-path hit during the deploy-
+    // transition window.
     logger.warn(
-      { discordId, stack: new Error().stack },
+      {
+        discordId,
+        stack: new Error().stack?.split('\n').slice(0, 6).join('\n'),
+      },
       '[Identity] Shell path executed — PR B shadow-mode canary (should trend to zero before PR C)'
     );
 

--- a/packages/common-types/src/services/UserService.ts
+++ b/packages/common-types/src/services/UserService.ts
@@ -195,6 +195,18 @@ export class UserService {
    * @returns The user's UUID
    */
   async getOrCreateUserShell(discordId: string): Promise<string> {
+    // Phase 5c PR B shadow-mode canary. Any call here means a route bypassed
+    // the provisioning middleware — either the middleware isn't mounted on
+    // that route, or bot-client didn't send the X-User-Username/-DisplayName
+    // headers (deploy transition). The stack trace identifies the offending
+    // caller. Target: zero hits in prod for 48-72h, which unlocks PR C's
+    // shell-path deletion. Kept at warn level so a misconfigured route shows
+    // up in normal log-search without spamming debug noise.
+    logger.warn(
+      { discordId, stack: new Error().stack },
+      '[Identity] Shell path executed — PR B shadow-mode canary (should trend to zero before PR C)'
+    );
+
     const cached = this.userCache.get(discordId);
     if (cached !== null) {
       return cached.userId;

--- a/services/api-gateway/src/routes/user/channel/activate.test.ts
+++ b/services/api-gateway/src/routes/user/channel/activate.test.ts
@@ -38,6 +38,9 @@ vi.mock('../../../services/AuthMiddleware.js', () => ({
   requireServiceAuth: vi.fn(() =>
     vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
   ),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/channel/activate.ts
+++ b/services/api-gateway/src/routes/user/channel/activate.ts
@@ -15,7 +15,7 @@ import {
   ActivateChannelRequestSchema,
   ActivateChannelResponseSchema,
 } from '@tzurot/common-types';
-import { requireUserAuth } from '../../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendCustomSuccess, sendError } from '../../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
@@ -165,5 +165,5 @@ export function createActivateHandler(prisma: PrismaClient): RequestHandler[] {
     sendCustomSuccess(res, buildActivationResponse(settings, wasReplaced), StatusCodes.CREATED);
   });
 
-  return [requireUserAuth(), handler];
+  return [requireUserAuth(), requireProvisionedUser(prisma), handler];
 }

--- a/services/api-gateway/src/routes/user/channel/configOverrides.test.ts
+++ b/services/api-gateway/src/routes/user/channel/configOverrides.test.ts
@@ -20,6 +20,9 @@ vi.mock('../../../services/AuthMiddleware.js', () => ({
     req.userId = 'service';
     next();
   },
+  requireProvisionedUser: () => (_req: unknown, _res: unknown, next: () => void) => {
+    next();
+  },
 }));
 
 // Mock isBotOwner

--- a/services/api-gateway/src/routes/user/channel/configOverrides.ts
+++ b/services/api-gateway/src/routes/user/channel/configOverrides.ts
@@ -25,7 +25,7 @@ import {
   type PrismaClient,
   type ConfigCascadeCacheInvalidationService,
 } from '@tzurot/common-types';
-import { requireUserAuth } from '../../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import {
   tryInvalidateCache,
@@ -54,6 +54,7 @@ function validateChannelId(channelId: string, res: Response): boolean {
 export function createGetConfigOverridesHandler(prisma: PrismaClient): RequestHandler[] {
   return [
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
       const channelId = getRequiredParam(req.params.channelId, 'channelId');
       if (!validateChannelId(channelId, res)) {
@@ -87,6 +88,7 @@ export function createPatchConfigOverridesHandler(
 ): RequestHandler[] {
   return [
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
       const channelId = getRequiredParam(req.params.channelId, 'channelId');
       if (!validateChannelId(channelId, res)) {
@@ -144,6 +146,7 @@ export function createDeleteConfigOverridesHandler(
 ): RequestHandler[] {
   return [
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
       const channelId = getRequiredParam(req.params.channelId, 'channelId');
       if (!validateChannelId(channelId, res)) {

--- a/services/api-gateway/src/routes/user/channel/deactivate.test.ts
+++ b/services/api-gateway/src/routes/user/channel/deactivate.test.ts
@@ -33,6 +33,9 @@ vi.mock('../../../services/AuthMiddleware.js', () => ({
   requireServiceAuth: vi.fn(() =>
     vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
   ),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/channel/deactivate.ts
+++ b/services/api-gateway/src/routes/user/channel/deactivate.ts
@@ -14,7 +14,7 @@ import {
   DeactivateChannelRequestSchema,
   DeactivateChannelResponseSchema,
 } from '@tzurot/common-types';
-import { requireUserAuth } from '../../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendCustomSuccess } from '../../../utils/responseHelpers.js';
 import { sendZodError } from '../../../utils/zodHelpers.js';
@@ -90,5 +90,5 @@ export function createDeactivateHandler(prisma: PrismaClient): RequestHandler[] 
     sendCustomSuccess(res, response, StatusCodes.OK);
   });
 
-  return [requireUserAuth(), handler];
+  return [requireUserAuth(), requireProvisionedUser(prisma), handler];
 }

--- a/services/api-gateway/src/routes/user/channel/get.test.ts
+++ b/services/api-gateway/src/routes/user/channel/get.test.ts
@@ -34,6 +34,9 @@ vi.mock('../../../services/AuthMiddleware.js', () => ({
   requireServiceAuth: vi.fn(() =>
     vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
   ),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/channel/list.test.ts
+++ b/services/api-gateway/src/routes/user/channel/list.test.ts
@@ -37,6 +37,9 @@ vi.mock('../../../services/AuthMiddleware.js', () => ({
   requireServiceAuth: vi.fn(() =>
     vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
   ),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/channel/list.ts
+++ b/services/api-gateway/src/routes/user/channel/list.ts
@@ -13,7 +13,7 @@ import {
   type PrismaClient,
   ListChannelSettingsResponseSchema,
 } from '@tzurot/common-types';
-import { requireUserAuth } from '../../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendCustomSuccess, sendError } from '../../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
@@ -95,5 +95,5 @@ export function createListHandler(prisma: PrismaClient): RequestHandler[] {
     sendCustomSuccess(res, response, StatusCodes.OK);
   });
 
-  return [requireUserAuth(), handler];
+  return [requireUserAuth(), requireProvisionedUser(prisma), handler];
 }

--- a/services/api-gateway/src/routes/user/channel/updateGuild.test.ts
+++ b/services/api-gateway/src/routes/user/channel/updateGuild.test.ts
@@ -32,6 +32,9 @@ vi.mock('../../../services/AuthMiddleware.js', () => ({
   requireServiceAuth: vi.fn(() =>
     vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
   ),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/channel/updateGuild.ts
+++ b/services/api-gateway/src/routes/user/channel/updateGuild.ts
@@ -14,7 +14,7 @@ import {
   UpdateChannelGuildRequestSchema,
   UpdateChannelGuildResponseSchema,
 } from '@tzurot/common-types';
-import { requireUserAuth } from '../../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendCustomSuccess } from '../../../utils/responseHelpers.js';
 import { sendZodError } from '../../../utils/zodHelpers.js';
@@ -64,5 +64,5 @@ export function createUpdateGuildHandler(prisma: PrismaClient): RequestHandler[]
     sendCustomSuccess(res, response, StatusCodes.OK);
   });
 
-  return [requireUserAuth(), handler];
+  return [requireUserAuth(), requireProvisionedUser(prisma), handler];
 }

--- a/services/api-gateway/src/routes/user/config-overrides.test.ts
+++ b/services/api-gateway/src/routes/user/config-overrides.test.ts
@@ -73,6 +73,9 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/config-overrides.ts
+++ b/services/api-gateway/src/routes/user/config-overrides.ts
@@ -29,7 +29,7 @@ import {
   type ConfigCascadeCacheInvalidationService,
   type ConfigOverrideSource,
 } from '@tzurot/common-types';
-import { requireUserAuth } from '../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import {
   tryInvalidateCache,
@@ -71,6 +71,7 @@ export function createConfigOverrideRoutes(
 
   // All routes require authentication
   router.use(requireUserAuth());
+  router.use(requireProvisionedUser(prisma));
 
   /**
    * GET /user/config-overrides/resolve-defaults

--- a/services/api-gateway/src/routes/user/history.test.ts
+++ b/services/api-gateway/src/routes/user/history.test.ts
@@ -52,6 +52,9 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/history.ts
+++ b/services/api-gateway/src/routes/user/history.ts
@@ -23,7 +23,7 @@ import {
   HardDeleteHistorySchema,
   HistoryStatsQuerySchema,
 } from '@tzurot/common-types';
-import { requireUserAuth } from '../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
@@ -364,16 +364,26 @@ export function createHistoryRoutes(prisma: PrismaClient): Router {
   };
 
   // POST /user/history/clear - Set context epoch (soft reset)
-  router.post('/clear', requireUserAuth(), createClearHandler(deps));
+  router.post(
+    '/clear',
+    requireUserAuth(),
+    requireProvisionedUser(prisma),
+    createClearHandler(deps)
+  );
 
   // POST /user/history/undo - Restore previous epoch
-  router.post('/undo', requireUserAuth(), createUndoHandler(deps));
+  router.post('/undo', requireUserAuth(), requireProvisionedUser(prisma), createUndoHandler(deps));
 
   // GET /user/history/stats - Get history statistics
-  router.get('/stats', requireUserAuth(), createStatsHandler(deps));
+  router.get('/stats', requireUserAuth(), requireProvisionedUser(prisma), createStatsHandler(deps));
 
   // DELETE /user/history/hard-delete - Permanently delete history
-  router.delete('/hard-delete', requireUserAuth(), createHardDeleteHandler(deps));
+  router.delete(
+    '/hard-delete',
+    requireUserAuth(),
+    requireProvisionedUser(prisma),
+    createHardDeleteHandler(deps)
+  );
 
   return router;
 }

--- a/services/api-gateway/src/routes/user/llm-config.int.test.ts
+++ b/services/api-gateway/src/routes/user/llm-config.int.test.ts
@@ -43,6 +43,9 @@ vi.mock('../../services/AuthMiddleware.js', () => ({
     (req as Request & { userId: string }).userId = TEST_DISCORD_ID;
     next();
   }),
+  requireProvisionedUser: vi.fn(
+    () => (_req: Request, _res: Response, next: NextFunction) => next()
+  ),
 }));
 
 // Import after mocking

--- a/services/api-gateway/src/routes/user/llm-config.test.ts
+++ b/services/api-gateway/src/routes/user/llm-config.test.ts
@@ -65,6 +65,9 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 vi.mock('../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/llm-config.ts
+++ b/services/api-gateway/src/routes/user/llm-config.ts
@@ -25,7 +25,7 @@ import {
   LlmConfigCreateSchema,
   LlmConfigUpdateSchema,
 } from '@tzurot/common-types';
-import { requireUserAuth } from '../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
@@ -339,28 +339,42 @@ export function createLlmConfigRoutes(
   const service = new LlmConfigService(prisma, llmConfigCacheInvalidation);
   const userService = new UserService(prisma);
 
-  router.get('/', requireUserAuth(), asyncHandler(createListHandler(service, prisma)));
+  router.get(
+    '/',
+    requireUserAuth(),
+    requireProvisionedUser(prisma),
+    asyncHandler(createListHandler(service, prisma))
+  );
   router.get(
     '/:id',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(createGetHandler(service, prisma, modelCache))
   );
   router.post(
     '/',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(createCreateHandler(service, userService, modelCache))
   );
   router.post(
     '/resolve',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(createResolveHandler(prisma, cascadeResolver))
   );
   router.put(
     '/:id',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(createUpdateHandler(service, prisma, modelCache))
   );
-  router.delete('/:id', requireUserAuth(), asyncHandler(createDeleteHandler(service, prisma)));
+  router.delete(
+    '/:id',
+    requireUserAuth(),
+    requireProvisionedUser(prisma),
+    asyncHandler(createDeleteHandler(service, prisma))
+  );
 
   return router;
 }

--- a/services/api-gateway/src/routes/user/memory.test.ts
+++ b/services/api-gateway/src/routes/user/memory.test.ts
@@ -43,6 +43,9 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/memory.ts
+++ b/services/api-gateway/src/routes/user/memory.ts
@@ -32,7 +32,7 @@ import {
   generateUserPersonalityConfigUuid,
   FocusModeSchema,
 } from '@tzurot/common-types';
-import { requireUserAuth } from '../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
@@ -276,30 +276,35 @@ export function createMemoryRoutes(prisma: PrismaClient, redis?: Redis): Router 
   router.get(
     '/stats',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler((req: AuthenticatedRequest, res: Response) => handleGetStats(prisma, req, res))
   );
 
   router.get(
     '/list',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler((req: AuthenticatedRequest, res: Response) => handleList(prisma, req, res))
   );
 
   router.get(
     '/focus',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler((req: AuthenticatedRequest, res: Response) => handleGetFocus(prisma, req, res))
   );
 
   router.post(
     '/focus',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler((req: AuthenticatedRequest, res: Response) => handleSetFocus(prisma, req, res))
   );
 
   router.post(
     '/search',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler((req: AuthenticatedRequest, res: Response) => handleSearch(prisma, req, res))
   );
 
@@ -307,6 +312,7 @@ export function createMemoryRoutes(prisma: PrismaClient, redis?: Redis): Router 
   router.get(
     '/delete/preview',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler((req: AuthenticatedRequest, res: Response) =>
       handleBatchDeletePreview(prisma, req, res)
     )
@@ -315,12 +321,14 @@ export function createMemoryRoutes(prisma: PrismaClient, redis?: Redis): Router 
   router.post(
     '/delete',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler((req: AuthenticatedRequest, res: Response) => handleBatchDelete(prisma, req, res))
   );
 
   router.post(
     '/purge',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler((req: AuthenticatedRequest, res: Response) => handlePurge(prisma, req, res))
   );
 
@@ -328,24 +336,28 @@ export function createMemoryRoutes(prisma: PrismaClient, redis?: Redis): Router 
   router.get(
     '/:id',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler((req: AuthenticatedRequest, res: Response) => handleGetMemory(prisma, req, res))
   );
 
   router.patch(
     '/:id',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler((req: AuthenticatedRequest, res: Response) => handleUpdateMemory(prisma, req, res))
   );
 
   router.delete(
     '/:id',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler((req: AuthenticatedRequest, res: Response) => handleDeleteMemory(prisma, req, res))
   );
 
   router.post(
     '/:id/lock',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler((req: AuthenticatedRequest, res: Response) => handleToggleLock(prisma, req, res))
   );
 

--- a/services/api-gateway/src/routes/user/memoryIncognito.test.ts
+++ b/services/api-gateway/src/routes/user/memoryIncognito.test.ts
@@ -27,6 +27,9 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/memoryIncognito.ts
+++ b/services/api-gateway/src/routes/user/memoryIncognito.ts
@@ -19,7 +19,7 @@ import {
   DisableIncognitoRequestSchema,
   IncognitoForgetRequestSchema,
 } from '@tzurot/common-types';
-import { requireUserAuth } from '../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
@@ -317,6 +317,7 @@ export function createIncognitoRoutes(prisma: PrismaClient, redis: Redis): Route
   router.get(
     '/',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler((req: AuthenticatedRequest, res: Response) => handleGetStatus(manager, req, res))
   );
 
@@ -324,6 +325,7 @@ export function createIncognitoRoutes(prisma: PrismaClient, redis: Redis): Route
   router.post(
     '/',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler((req: AuthenticatedRequest, res: Response) =>
       handleEnable(prisma, manager, req, res)
     )
@@ -333,6 +335,7 @@ export function createIncognitoRoutes(prisma: PrismaClient, redis: Redis): Route
   router.delete(
     '/',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler((req: AuthenticatedRequest, res: Response) =>
       handleDisable(prisma, manager, req, res)
     )
@@ -342,6 +345,7 @@ export function createIncognitoRoutes(prisma: PrismaClient, redis: Redis): Route
   router.post(
     '/forget',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler((req: AuthenticatedRequest, res: Response) => handleForget(prisma, req, res))
   );
 

--- a/services/api-gateway/src/routes/user/model-override.test.ts
+++ b/services/api-gateway/src/routes/user/model-override.test.ts
@@ -23,6 +23,9 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/model-override.ts
+++ b/services/api-gateway/src/routes/user/model-override.ts
@@ -24,7 +24,7 @@ import {
   SetModelOverrideSchema,
   SetDefaultConfigSchema,
 } from '@tzurot/common-types';
-import { requireUserAuth } from '../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { tryInvalidateCache } from '../../utils/configOverrideHelpers.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
@@ -68,6 +68,7 @@ export function createModelOverrideRoutes(
   router.get(
     '/',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
       const discordUserId = req.userId;
 
@@ -116,6 +117,7 @@ export function createModelOverrideRoutes(
   router.put(
     '/',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
       const discordUserId = req.userId;
 
@@ -205,6 +207,7 @@ export function createModelOverrideRoutes(
   router.get(
     '/default',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
       const discordUserId = req.userId;
 
@@ -237,6 +240,7 @@ export function createModelOverrideRoutes(
   router.put(
     '/default',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
       const discordUserId = req.userId;
 
@@ -292,6 +296,7 @@ export function createModelOverrideRoutes(
   router.delete(
     '/default',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
       const discordUserId = req.userId;
 
@@ -345,6 +350,7 @@ export function createModelOverrideRoutes(
   router.delete(
     '/:personalityId',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
       const discordUserId = req.userId;
       const personalityId = getParam(req.params.personalityId);

--- a/services/api-gateway/src/routes/user/nsfw.test.ts
+++ b/services/api-gateway/src/routes/user/nsfw.test.ts
@@ -51,6 +51,9 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 vi.mock('../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/nsfw.ts
+++ b/services/api-gateway/src/routes/user/nsfw.ts
@@ -7,7 +7,7 @@
 import { Router, type Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { createLogger, UserService, type PrismaClient } from '@tzurot/common-types';
-import { requireUserAuth } from '../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendCustomSuccess } from '../../utils/responseHelpers.js';
 import type { AuthenticatedRequest } from '../../types.js';
@@ -25,6 +25,7 @@ export function createNsfwRoutes(prisma: PrismaClient): Router {
   router.get(
     '/',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
       const discordUserId = req.userId;
 
@@ -64,6 +65,7 @@ export function createNsfwRoutes(prisma: PrismaClient): Router {
   router.post(
     '/verify',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
       const discordUserId = req.userId;
 

--- a/services/api-gateway/src/routes/user/persona/crud.test.ts
+++ b/services/api-gateway/src/routes/user/persona/crud.test.ts
@@ -37,6 +37,9 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/persona/crud.ts
+++ b/services/api-gateway/src/routes/user/persona/crud.ts
@@ -19,7 +19,7 @@ import {
   type PersonaSummary,
   type PersonaDetails,
 } from '@tzurot/common-types';
-import { requireUserAuth } from '../../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendCustomSuccess, sendError } from '../../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
@@ -270,9 +270,34 @@ function createDeleteHandler(prisma: PrismaClient) {
 // --- Main Route Setup ---
 
 export function addCrudRoutes(router: Router, prisma: PrismaClient): void {
-  router.get('/', requireUserAuth(), asyncHandler(createListHandler(prisma)));
-  router.get('/:id', requireUserAuth(), asyncHandler(createGetHandler(prisma)));
-  router.post('/', requireUserAuth(), asyncHandler(createCreateHandler(prisma)));
-  router.put('/:id', requireUserAuth(), asyncHandler(createUpdateHandler(prisma)));
-  router.delete('/:id', requireUserAuth(), asyncHandler(createDeleteHandler(prisma)));
+  router.get(
+    '/',
+    requireUserAuth(),
+    requireProvisionedUser(prisma),
+    asyncHandler(createListHandler(prisma))
+  );
+  router.get(
+    '/:id',
+    requireUserAuth(),
+    requireProvisionedUser(prisma),
+    asyncHandler(createGetHandler(prisma))
+  );
+  router.post(
+    '/',
+    requireUserAuth(),
+    requireProvisionedUser(prisma),
+    asyncHandler(createCreateHandler(prisma))
+  );
+  router.put(
+    '/:id',
+    requireUserAuth(),
+    requireProvisionedUser(prisma),
+    asyncHandler(createUpdateHandler(prisma))
+  );
+  router.delete(
+    '/:id',
+    requireUserAuth(),
+    requireProvisionedUser(prisma),
+    asyncHandler(createDeleteHandler(prisma))
+  );
 }

--- a/services/api-gateway/src/routes/user/persona/default.test.ts
+++ b/services/api-gateway/src/routes/user/persona/default.test.ts
@@ -31,6 +31,9 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/persona/default.ts
+++ b/services/api-gateway/src/routes/user/persona/default.ts
@@ -5,7 +5,7 @@
 
 import { Router, type Response } from 'express';
 import { createLogger, type PrismaClient } from '@tzurot/common-types';
-import { requireUserAuth } from '../../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendCustomSuccess, sendError } from '../../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
@@ -24,6 +24,7 @@ export function addDefaultRoutes(router: Router, prisma: PrismaClient): void {
   router.patch(
     '/:id/default',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
       const discordUserId = req.userId;
       const id = getParam(req.params.id);

--- a/services/api-gateway/src/routes/user/persona/index.test.ts
+++ b/services/api-gateway/src/routes/user/persona/index.test.ts
@@ -22,6 +22,9 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/persona/override.test.ts
+++ b/services/api-gateway/src/routes/user/persona/override.test.ts
@@ -36,6 +36,9 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/persona/override.ts
+++ b/services/api-gateway/src/routes/user/persona/override.ts
@@ -13,7 +13,7 @@ import {
   type PrismaClient,
   SetPersonaOverrideSchema,
 } from '@tzurot/common-types';
-import { requireUserAuth } from '../../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendCustomSuccess, sendError } from '../../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
@@ -229,8 +229,28 @@ function createClearHandler(prisma: PrismaClient) {
 const OVERRIDE_BY_SLUG = '/override/:personalitySlug';
 
 export function addOverrideRoutes(router: Router, prisma: PrismaClient): void {
-  router.get('/override', requireUserAuth(), asyncHandler(createListHandler(prisma)));
-  router.get(OVERRIDE_BY_SLUG, requireUserAuth(), asyncHandler(createGetHandler(prisma)));
-  router.put(OVERRIDE_BY_SLUG, requireUserAuth(), asyncHandler(createSetHandler(prisma)));
-  router.delete(OVERRIDE_BY_SLUG, requireUserAuth(), asyncHandler(createClearHandler(prisma)));
+  router.get(
+    '/override',
+    requireUserAuth(),
+    requireProvisionedUser(prisma),
+    asyncHandler(createListHandler(prisma))
+  );
+  router.get(
+    OVERRIDE_BY_SLUG,
+    requireUserAuth(),
+    requireProvisionedUser(prisma),
+    asyncHandler(createGetHandler(prisma))
+  );
+  router.put(
+    OVERRIDE_BY_SLUG,
+    requireUserAuth(),
+    requireProvisionedUser(prisma),
+    asyncHandler(createSetHandler(prisma))
+  );
+  router.delete(
+    OVERRIDE_BY_SLUG,
+    requireUserAuth(),
+    requireProvisionedUser(prisma),
+    asyncHandler(createClearHandler(prisma))
+  );
 }

--- a/services/api-gateway/src/routes/user/personality-config-overrides.test.ts
+++ b/services/api-gateway/src/routes/user/personality-config-overrides.test.ts
@@ -64,6 +64,9 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/personality-config-overrides.ts
+++ b/services/api-gateway/src/routes/user/personality-config-overrides.ts
@@ -16,7 +16,7 @@ import {
   type PrismaClient,
   type ConfigCascadeCacheInvalidationService,
 } from '@tzurot/common-types';
-import { requireUserAuth } from '../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import {
   tryInvalidateCache,
@@ -38,6 +38,7 @@ export function createPersonalityConfigOverrideRoutes(
   const cascadeResolver = new ConfigCascadeResolver(prisma, { enableCleanup: false });
 
   router.use(requireUserAuth());
+  router.use(requireProvisionedUser(prisma));
 
   /**
    * GET /resolve-personality/:personalityId

--- a/services/api-gateway/src/routes/user/personality/create.test.ts
+++ b/services/api-gateway/src/routes/user/personality/create.test.ts
@@ -33,6 +33,9 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/personality/create.ts
+++ b/services/api-gateway/src/routes/user/personality/create.ts
@@ -14,7 +14,7 @@ import {
   type PersonalityCreateInput,
   PERSONALITY_DETAIL_SELECT,
 } from '@tzurot/common-types';
-import { requireUserAuth } from '../../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendCustomSuccess, sendError } from '../../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
@@ -148,5 +148,5 @@ export function createCreateHandler(prisma: PrismaClient): RequestHandler[] {
     );
   });
 
-  return [requireUserAuth(), handler];
+  return [requireUserAuth(), requireProvisionedUser(prisma), handler];
 }

--- a/services/api-gateway/src/routes/user/personality/delete.test.ts
+++ b/services/api-gateway/src/routes/user/personality/delete.test.ts
@@ -30,6 +30,9 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/personality/delete.ts
+++ b/services/api-gateway/src/routes/user/personality/delete.ts
@@ -11,7 +11,7 @@ import {
   type CacheInvalidationService,
   DeletePersonalityResponseSchema,
 } from '@tzurot/common-types';
-import { requireUserAuth } from '../../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendCustomSuccess, sendError } from '../../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
@@ -135,5 +135,9 @@ export function createDeleteHandler(
   prisma: PrismaClient,
   cacheInvalidationService?: CacheInvalidationService
 ): RequestHandler[] {
-  return [requireUserAuth(), asyncHandler(createHandler(prisma, cacheInvalidationService))];
+  return [
+    requireUserAuth(),
+    requireProvisionedUser(prisma),
+    asyncHandler(createHandler(prisma, cacheInvalidationService)),
+  ];
 }

--- a/services/api-gateway/src/routes/user/personality/get.test.ts
+++ b/services/api-gateway/src/routes/user/personality/get.test.ts
@@ -27,6 +27,9 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/personality/get.ts
+++ b/services/api-gateway/src/routes/user/personality/get.ts
@@ -11,7 +11,7 @@ import {
   isBotOwner,
   PERSONALITY_DETAIL_SELECT,
 } from '@tzurot/common-types';
-import { requireUserAuth } from '../../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendCustomSuccess, sendError } from '../../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
@@ -98,5 +98,5 @@ function createHandler(prisma: PrismaClient) {
 // --- Route Factory ---
 
 export function createGetHandler(prisma: PrismaClient): RequestHandler[] {
-  return [requireUserAuth(), asyncHandler(createHandler(prisma))];
+  return [requireUserAuth(), requireProvisionedUser(prisma), asyncHandler(createHandler(prisma))];
 }

--- a/services/api-gateway/src/routes/user/personality/index.test.ts
+++ b/services/api-gateway/src/routes/user/personality/index.test.ts
@@ -25,6 +25,9 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/personality/list.test.ts
+++ b/services/api-gateway/src/routes/user/personality/list.test.ts
@@ -49,6 +49,9 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/personality/list.ts
+++ b/services/api-gateway/src/routes/user/personality/list.ts
@@ -13,7 +13,7 @@ import {
   computePersonalityPermissions,
   PERSONALITY_LIST_SELECT,
 } from '@tzurot/common-types';
-import { requireUserAuth } from '../../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendCustomSuccess } from '../../../utils/responseHelpers.js';
 import type { AuthenticatedRequest } from '../../../types.js';
@@ -161,5 +161,5 @@ export function createListHandler(prisma: PrismaClient): RequestHandler[] {
     sendCustomSuccess(res, { personalities }, StatusCodes.OK);
   });
 
-  return [requireUserAuth(), handler];
+  return [requireUserAuth(), requireProvisionedUser(prisma), handler];
 }

--- a/services/api-gateway/src/routes/user/personality/update.test.ts
+++ b/services/api-gateway/src/routes/user/personality/update.test.ts
@@ -31,6 +31,9 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/personality/update.ts
+++ b/services/api-gateway/src/routes/user/personality/update.ts
@@ -15,7 +15,7 @@ import {
   PERSONALITY_DETAIL_SELECT,
 } from '@tzurot/common-types';
 import { Prisma } from '@tzurot/common-types';
-import { requireUserAuth } from '../../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendCustomSuccess, sendError } from '../../../utils/responseHelpers.js';
 import { ErrorResponses, type ErrorResponse } from '../../../utils/errorResponses.js';
@@ -281,5 +281,9 @@ export function createUpdateHandler(
   prisma: PrismaClient,
   cacheInvalidationService?: CacheInvalidationService
 ): RequestHandler[] {
-  return [requireUserAuth(), asyncHandler(createHandler(prisma, cacheInvalidationService))];
+  return [
+    requireUserAuth(),
+    requireProvisionedUser(prisma),
+    asyncHandler(createHandler(prisma, cacheInvalidationService)),
+  ];
 }

--- a/services/api-gateway/src/routes/user/personality/visibility.test.ts
+++ b/services/api-gateway/src/routes/user/personality/visibility.test.ts
@@ -27,6 +27,9 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/personality/visibility.ts
+++ b/services/api-gateway/src/routes/user/personality/visibility.ts
@@ -6,7 +6,7 @@
 import { type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { createLogger, type PrismaClient, SetVisibilitySchema } from '@tzurot/common-types';
-import { requireUserAuth } from '../../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendCustomSuccess, sendError } from '../../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
@@ -75,5 +75,5 @@ export function createVisibilityHandler(prisma: PrismaClient): RequestHandler[] 
     );
   });
 
-  return [requireUserAuth(), handler];
+  return [requireUserAuth(), requireProvisionedUser(prisma), handler];
 }

--- a/services/api-gateway/src/routes/user/shapes/auth.test.ts
+++ b/services/api-gateway/src/routes/user/shapes/auth.test.ts
@@ -28,6 +28,9 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/shapes/auth.ts
+++ b/services/api-gateway/src/routes/user/shapes/auth.ts
@@ -21,7 +21,7 @@ import {
   CREDENTIAL_SERVICES,
   CREDENTIAL_TYPES,
 } from '@tzurot/common-types';
-import { requireUserAuth } from '../../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
@@ -163,9 +163,24 @@ export function createShapesAuthRoutes(prisma: PrismaClient): Router {
   const router = Router();
   const userService = new UserService(prisma);
 
-  router.post('/', requireUserAuth(), asyncHandler(createStoreHandler(prisma, userService)));
-  router.delete('/', requireUserAuth(), asyncHandler(createDeleteHandler(prisma)));
-  router.get('/status', requireUserAuth(), asyncHandler(createStatusHandler(prisma)));
+  router.post(
+    '/',
+    requireUserAuth(),
+    requireProvisionedUser(prisma),
+    asyncHandler(createStoreHandler(prisma, userService))
+  );
+  router.delete(
+    '/',
+    requireUserAuth(),
+    requireProvisionedUser(prisma),
+    asyncHandler(createDeleteHandler(prisma))
+  );
+  router.get(
+    '/status',
+    requireUserAuth(),
+    requireProvisionedUser(prisma),
+    asyncHandler(createStatusHandler(prisma))
+  );
 
   return router;
 }

--- a/services/api-gateway/src/routes/user/shapes/export.test.ts
+++ b/services/api-gateway/src/routes/user/shapes/export.test.ts
@@ -21,6 +21,9 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/shapes/export.ts
+++ b/services/api-gateway/src/routes/user/shapes/export.ts
@@ -25,7 +25,7 @@ import {
   getConfig,
   Prisma,
 } from '@tzurot/common-types';
-import { requireUserAuth } from '../../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
@@ -286,11 +286,13 @@ export function createShapesExportRoutes(prisma: PrismaClient, queue: Queue): Ro
   router.post(
     '/',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(createExportHandler(prisma, queue, userService, baseUrl))
   );
   router.get(
     '/jobs',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(createListExportJobsHandler(prisma, baseUrl))
   );
 

--- a/services/api-gateway/src/routes/user/shapes/import.test.ts
+++ b/services/api-gateway/src/routes/user/shapes/import.test.ts
@@ -21,6 +21,9 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/shapes/import.ts
+++ b/services/api-gateway/src/routes/user/shapes/import.ts
@@ -18,7 +18,7 @@ import {
   JOB_PREFIXES,
   type ShapesImportJobData,
 } from '@tzurot/common-types';
-import { requireUserAuth } from '../../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
@@ -231,9 +231,15 @@ export function createShapesImportRoutes(prisma: PrismaClient, queue: Queue): Ro
   router.post(
     '/',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(createImportHandler(prisma, queue, userService))
   );
-  router.get('/jobs', requireUserAuth(), asyncHandler(createListImportJobsHandler(prisma)));
+  router.get(
+    '/jobs',
+    requireUserAuth(),
+    requireProvisionedUser(prisma),
+    asyncHandler(createListImportJobsHandler(prisma))
+  );
 
   return router;
 }

--- a/services/api-gateway/src/routes/user/shapes/list.test.ts
+++ b/services/api-gateway/src/routes/user/shapes/list.test.ts
@@ -22,6 +22,9 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/shapes/list.ts
+++ b/services/api-gateway/src/routes/user/shapes/list.ts
@@ -17,7 +17,7 @@ import {
   SHAPES_BASE_URL,
   SHAPES_USER_AGENT,
 } from '@tzurot/common-types';
-import { requireUserAuth } from '../../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
@@ -148,7 +148,12 @@ function createListHandler(prisma: PrismaClient) {
 export function createShapesListRoutes(prisma: PrismaClient): Router {
   const router = Router();
 
-  router.get('/', requireUserAuth(), asyncHandler(createListHandler(prisma)));
+  router.get(
+    '/',
+    requireUserAuth(),
+    requireProvisionedUser(prisma),
+    asyncHandler(createListHandler(prisma))
+  );
 
   return router;
 }

--- a/services/api-gateway/src/routes/user/timezone.test.ts
+++ b/services/api-gateway/src/routes/user/timezone.test.ts
@@ -26,6 +26,9 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/timezone.ts
+++ b/services/api-gateway/src/routes/user/timezone.ts
@@ -14,7 +14,7 @@ import {
   getTimezoneInfo,
   SetTimezoneInputSchema,
 } from '@tzurot/common-types';
-import { requireUserAuth } from '../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
@@ -34,6 +34,7 @@ export function createTimezoneRoutes(prisma: PrismaClient): Router {
   router.get(
     '/',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
       const discordUserId = req.userId;
 
@@ -72,6 +73,7 @@ export function createTimezoneRoutes(prisma: PrismaClient): Router {
   router.put(
     '/',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
       const discordUserId = req.userId;
 

--- a/services/api-gateway/src/routes/user/usage.test.ts
+++ b/services/api-gateway/src/routes/user/usage.test.ts
@@ -24,6 +24,9 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/user/usage.ts
+++ b/services/api-gateway/src/routes/user/usage.ts
@@ -11,7 +11,7 @@ import {
   type UsagePeriod,
   type UsageStats,
 } from '@tzurot/common-types';
-import { requireUserAuth } from '../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
@@ -60,6 +60,7 @@ export function createUsageRoutes(prisma: PrismaClient): Router {
   router.get(
     '/',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
       const discordUserId = req.userId;
       const period = (req.query.period as UsagePeriod) ?? 'month';

--- a/services/api-gateway/src/routes/user/voices.test.ts
+++ b/services/api-gateway/src/routes/user/voices.test.ts
@@ -29,6 +29,9 @@ vi.mock('../../services/AuthMiddleware.js', () => ({
     req.userId = 'discord-user-123';
     next();
   },
+  requireProvisionedUser: () => (_req: any, _res: any, next: any) => {
+    next();
+  },
 }));
 
 // Mock fetch

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -20,7 +20,7 @@ import {
   type PrismaClient,
 } from '@tzurot/common-types';
 import type { ErrorResponse } from '../../utils/errorResponses.js';
-import { requireUserAuth } from '../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendCustomSuccess, sendError } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
@@ -325,6 +325,7 @@ export function createVoicesRoutes(prisma: PrismaClient): Router {
   router.get(
     '/',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(async (req: AuthenticatedRequest, res: ExpressResponse) => {
       await handleListVoices(prisma, req, res);
     })
@@ -334,6 +335,7 @@ export function createVoicesRoutes(prisma: PrismaClient): Router {
   router.get(
     '/models',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(async (req: AuthenticatedRequest, res: ExpressResponse) => {
       await handleListModels(prisma, req, res);
     })
@@ -343,6 +345,7 @@ export function createVoicesRoutes(prisma: PrismaClient): Router {
   router.post(
     '/clear',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(async (req: AuthenticatedRequest, res: ExpressResponse) => {
       await handleClearVoices(prisma, req, res);
     })
@@ -351,6 +354,7 @@ export function createVoicesRoutes(prisma: PrismaClient): Router {
   router.delete(
     '/:voiceId',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(async (req: AuthenticatedRequest, res: ExpressResponse) => {
       await handleDeleteVoice(prisma, req, res);
     })

--- a/services/api-gateway/src/routes/wallet/listKeys.test.ts
+++ b/services/api-gateway/src/routes/wallet/listKeys.test.ts
@@ -24,6 +24,9 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/wallet/listKeys.ts
+++ b/services/api-gateway/src/routes/wallet/listKeys.ts
@@ -9,7 +9,7 @@
 
 import { Router, type Response } from 'express';
 import { createLogger, type PrismaClient } from '@tzurot/common-types';
-import { requireUserAuth } from '../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendCustomSuccess } from '../../utils/responseHelpers.js';
 import type { AuthenticatedRequest } from '../../types.js';
@@ -22,6 +22,7 @@ export function createListKeysRoute(prisma: PrismaClient): Router {
   router.get(
     '/',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
       const discordUserId = req.userId;
 

--- a/services/api-gateway/src/routes/wallet/removeKey.test.ts
+++ b/services/api-gateway/src/routes/wallet/removeKey.test.ts
@@ -24,6 +24,9 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../utils/asyncHandler.js', () => ({
@@ -66,8 +69,10 @@ async function callHandler(
   res: Response
 ): Promise<void> {
   const handlers = createRemoveKeyRoute(prisma as PrismaClient);
-  // handlers[0] is auth middleware, handlers[1] is the actual handler
-  const handler = handlers[1] as (req: Request, res: Response) => Promise<void>;
+  // handlers[0] is requireUserAuth, handlers[1] is requireProvisionedUser,
+  // handlers[2] is the actual handler (Phase 5c PR B added the provisioning
+  // middleware in position 1).
+  const handler = handlers[2] as (req: Request, res: Response) => Promise<void>;
   await handler(req, res);
 }
 
@@ -85,19 +90,25 @@ describe('DELETE /wallet/:provider', () => {
 
       expect(handlers).toBeDefined();
       expect(Array.isArray(handlers)).toBe(true);
-      expect(handlers.length).toBe(2); // [auth middleware, handler]
+      expect(handlers.length).toBe(3); // [requireUserAuth, requireProvisionedUser, handler]
     });
 
-    it('should have auth middleware as first handler', () => {
+    it('should have requireUserAuth as first handler', () => {
       const handlers = createRemoveKeyRoute(mockPrisma as unknown as PrismaClient);
 
       expect(typeof handlers[0]).toBe('function');
     });
 
-    it('should have request handler as second handler', () => {
+    it('should have requireProvisionedUser as second handler', () => {
       const handlers = createRemoveKeyRoute(mockPrisma as unknown as PrismaClient);
 
       expect(typeof handlers[1]).toBe('function');
+    });
+
+    it('should have request handler as third handler', () => {
+      const handlers = createRemoveKeyRoute(mockPrisma as unknown as PrismaClient);
+
+      expect(typeof handlers[2]).toBe('function');
     });
   });
 

--- a/services/api-gateway/src/routes/wallet/removeKey.test.ts
+++ b/services/api-gateway/src/routes/wallet/removeKey.test.ts
@@ -69,9 +69,7 @@ async function callHandler(
   res: Response
 ): Promise<void> {
   const handlers = createRemoveKeyRoute(prisma as PrismaClient);
-  // handlers[0] is requireUserAuth, handlers[1] is requireProvisionedUser,
-  // handlers[2] is the actual handler (Phase 5c PR B added the provisioning
-  // middleware in position 1).
+  // handlers layout: [auth, provision, handler]
   const handler = handlers[2] as (req: Request, res: Response) => Promise<void>;
   await handler(req, res);
 }

--- a/services/api-gateway/src/routes/wallet/removeKey.ts
+++ b/services/api-gateway/src/routes/wallet/removeKey.ts
@@ -10,7 +10,7 @@ import {
   type PrismaClient,
   type ApiKeyCacheInvalidationService,
 } from '@tzurot/common-types';
-import { requireUserAuth } from '../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendCustomSuccess, sendError } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
@@ -80,5 +80,5 @@ export function createRemoveKeyRoute(
     });
   });
 
-  return [requireUserAuth(), handler];
+  return [requireUserAuth(), requireProvisionedUser(prisma), handler];
 }

--- a/services/api-gateway/src/routes/wallet/setKey.test.ts
+++ b/services/api-gateway/src/routes/wallet/setKey.test.ts
@@ -50,6 +50,9 @@ vi.mock('@tzurot/common-types', async () => {
 
 vi.mock('../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/wallet/setKey.ts
+++ b/services/api-gateway/src/routes/wallet/setKey.ts
@@ -20,7 +20,7 @@ import {
   generateUserApiKeyUuid,
   SetWalletKeySchema,
 } from '@tzurot/common-types';
-import { requireUserAuth } from '../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses, type ErrorResponse } from '../../utils/errorResponses.js';
@@ -64,6 +64,7 @@ export function createSetKeyRoute(
   router.post(
     '/',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
       const parseResult = SetWalletKeySchema.safeParse(req.body);
       if (!parseResult.success) {

--- a/services/api-gateway/src/routes/wallet/testKey.test.ts
+++ b/services/api-gateway/src/routes/wallet/testKey.test.ts
@@ -36,6 +36,9 @@ const mockDecryptApiKey = vi.mocked(decryptApiKey);
 
 vi.mock('../../services/AuthMiddleware.js', () => ({
   requireUserAuth: vi.fn(() => vi.fn((_req: unknown, _res: unknown, next: () => void) => next())),
+  requireProvisionedUser: vi.fn(() =>
+    vi.fn((_req: unknown, _res: unknown, next: () => void) => next())
+  ),
 }));
 
 vi.mock('../../utils/asyncHandler.js', () => ({

--- a/services/api-gateway/src/routes/wallet/testKey.ts
+++ b/services/api-gateway/src/routes/wallet/testKey.ts
@@ -13,7 +13,7 @@ import {
   type PrismaClient,
   TestWalletKeySchema,
 } from '@tzurot/common-types';
-import { requireUserAuth } from '../../services/AuthMiddleware.js';
+import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendCustomSuccess, sendError } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
@@ -29,6 +29,7 @@ export function createTestKeyRoute(prisma: PrismaClient): Router {
   router.post(
     '/',
     requireUserAuth(),
+    requireProvisionedUser(prisma),
     asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
       const parseResult = TestWalletKeySchema.safeParse(req.body);
       if (!parseResult.success) {

--- a/services/api-gateway/src/services/AuthMiddleware.test.ts
+++ b/services/api-gateway/src/services/AuthMiddleware.test.ts
@@ -12,6 +12,7 @@ import {
   requireOwnerAuth,
   extractUserId,
   requireUserAuth,
+  requireProvisionedUser,
   extractServiceSecret,
   isValidServiceSecret,
   requireServiceAuth,
@@ -22,12 +23,20 @@ import * as commonTypes from '@tzurot/common-types';
 
 // Mock getConfig and isBotOwner
 const mockIsBotOwnerFn = vi.fn();
+const mockGetOrCreateUser = vi.fn();
 vi.mock('@tzurot/common-types', async () => {
   const actual = await vi.importActual('@tzurot/common-types');
   return {
     ...actual,
     getConfig: vi.fn(),
     isBotOwner: (userId: string) => mockIsBotOwnerFn(userId),
+    // UserService used by requireProvisionedUser. Class shape just needs
+    // `getOrCreateUser`; the middleware never calls other methods.
+    // Using a class (not an arrow-function mockImplementation) so `new
+    // UserService(...)` is a valid constructor call.
+    UserService: class MockUserService {
+      getOrCreateUser = mockGetOrCreateUser;
+    },
   };
 });
 
@@ -442,6 +451,158 @@ describe('authMiddleware', () => {
           timestamp: expect.any(String),
         })
       );
+    });
+  });
+
+  describe('requireProvisionedUser middleware', () => {
+    // Cast to `any` for test fixtures — PrismaClient is never actually used
+    // because UserService is mocked at the module level.
+    const fakePrisma = {} as never;
+
+    // Each test gets a fresh mock response + next + req. The middleware
+    // never calls res.* in the graceful-degradation paths; tests confirm
+    // that by asserting res.status / res.json were NOT called.
+    let mockReq: Partial<Request> & { userId?: string };
+    let mockRes: Partial<Response>;
+    let mockNext: NextFunction;
+
+    beforeEach(() => {
+      mockGetOrCreateUser.mockReset();
+      mockReq = {
+        // requireUserAuth already ran and set this — the new middleware
+        // reads req.userId as the Discord snowflake.
+        userId: '123456789012345678',
+        path: '/user/test',
+        method: 'GET',
+        headers: {
+          'x-user-username': 'alice',
+          'x-user-displayname': 'Alice%20Cooper',
+        },
+      };
+      mockRes = {
+        status: vi.fn().mockReturnThis(),
+        json: vi.fn().mockReturnThis(),
+      };
+      mockNext = vi.fn();
+    });
+
+    it('should attach provisioned fields on the happy path', async () => {
+      mockGetOrCreateUser.mockResolvedValue({
+        userId: 'internal-uuid-123',
+        defaultPersonaId: 'persona-uuid-456',
+      });
+
+      const middleware = requireProvisionedUser(fakePrisma);
+      await middleware(mockReq as Request, mockRes as Response, mockNext);
+
+      expect(mockGetOrCreateUser).toHaveBeenCalledWith(
+        '123456789012345678',
+        'alice',
+        'Alice Cooper' // decoded from 'Alice%20Cooper'
+      );
+      expect((mockReq as { provisionedUserId?: string }).provisionedUserId).toBe(
+        'internal-uuid-123'
+      );
+      expect(
+        (mockReq as { provisionedDefaultPersonaId?: string }).provisionedDefaultPersonaId
+      ).toBe('persona-uuid-456');
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext).toHaveBeenCalledWith(); // no error argument
+      expect(mockRes.status).not.toHaveBeenCalled();
+    });
+
+    it('should URI-decode non-Latin-1 values (emoji in displayName)', async () => {
+      mockReq.headers = {
+        'x-user-username': 'alice_%F0%9F%8C%B8', // 🌸
+        'x-user-displayname': '%F0%9F%91%8B%20Alice', // 👋 Alice
+      };
+      mockGetOrCreateUser.mockResolvedValue({
+        userId: 'internal-uuid-123',
+        defaultPersonaId: 'persona-uuid-456',
+      });
+
+      const middleware = requireProvisionedUser(fakePrisma);
+      await middleware(mockReq as Request, mockRes as Response, mockNext);
+
+      expect(mockGetOrCreateUser).toHaveBeenCalledWith(
+        '123456789012345678',
+        'alice_🌸',
+        '👋 Alice'
+      );
+      expect(mockNext).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fall through without attaching when X-User-Username is missing', async () => {
+      mockReq.headers = { 'x-user-displayname': 'Alice' };
+
+      const middleware = requireProvisionedUser(fakePrisma);
+      await middleware(mockReq as Request, mockRes as Response, mockNext);
+
+      expect(mockGetOrCreateUser).not.toHaveBeenCalled();
+      expect((mockReq as { provisionedUserId?: string }).provisionedUserId).toBeUndefined();
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext).toHaveBeenCalledWith();
+      expect(mockRes.status).not.toHaveBeenCalled();
+    });
+
+    it('should fall through without attaching when X-User-DisplayName is missing', async () => {
+      mockReq.headers = { 'x-user-username': 'alice' };
+
+      const middleware = requireProvisionedUser(fakePrisma);
+      await middleware(mockReq as Request, mockRes as Response, mockNext);
+
+      expect(mockGetOrCreateUser).not.toHaveBeenCalled();
+      expect((mockReq as { provisionedUserId?: string }).provisionedUserId).toBeUndefined();
+      expect(mockNext).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fall through on malformed URI encoding (invalid % sequence)', async () => {
+      mockReq.headers = {
+        'x-user-username': '%ZZ', // invalid hex after %
+        'x-user-displayname': 'Alice',
+      };
+
+      const middleware = requireProvisionedUser(fakePrisma);
+      await middleware(mockReq as Request, mockRes as Response, mockNext);
+
+      expect(mockGetOrCreateUser).not.toHaveBeenCalled();
+      expect((mockReq as { provisionedUserId?: string }).provisionedUserId).toBeUndefined();
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockRes.status).not.toHaveBeenCalled();
+    });
+
+    it('should fall through when getOrCreateUser throws', async () => {
+      mockGetOrCreateUser.mockRejectedValue(new Error('DB down'));
+
+      const middleware = requireProvisionedUser(fakePrisma);
+      await middleware(mockReq as Request, mockRes as Response, mockNext);
+
+      expect(mockGetOrCreateUser).toHaveBeenCalled();
+      expect((mockReq as { provisionedUserId?: string }).provisionedUserId).toBeUndefined();
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext).toHaveBeenCalledWith(); // no error argument — graceful degradation
+    });
+
+    it('should fall through when getOrCreateUser returns null (bot user case)', async () => {
+      mockGetOrCreateUser.mockResolvedValue(null);
+
+      const middleware = requireProvisionedUser(fakePrisma);
+      await middleware(mockReq as Request, mockRes as Response, mockNext);
+
+      expect((mockReq as { provisionedUserId?: string }).provisionedUserId).toBeUndefined();
+      expect(mockNext).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fall through when req.userId is missing (defense in depth)', async () => {
+      // In practice requireUserAuth runs first and 401s on missing userId —
+      // this test just guards against a future refactor removing that chain.
+      mockReq.userId = undefined;
+
+      const middleware = requireProvisionedUser(fakePrisma);
+      await middleware(mockReq as Request, mockRes as Response, mockNext);
+
+      expect(mockGetOrCreateUser).not.toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/services/api-gateway/src/services/AuthMiddleware.ts
+++ b/services/api-gateway/src/services/AuthMiddleware.ts
@@ -211,11 +211,29 @@ function readEncodedHeader(req: Request, headerName: string): string | undefined
  * @param prisma - PrismaClient used to construct a cached UserService
  * @returns Express middleware function
  */
+// Cache UserService instances by PrismaClient reference so multiple factory
+// calls with the same client share ONE UserService (and its TTLCache). Each
+// route file mounts `requireProvisionedUser(prisma)` per-endpoint, so
+// `memory.ts` (12 endpoints) would otherwise create 12 independent
+// UserServices with 12 independent caches — cache hits would never carry
+// across endpoints for the same user. WeakMap lets the instance be GC'd
+// if/when the PrismaClient it was built against is released (not expected
+// in prod, but correct for test fixtures that spin up short-lived clients).
+const userServiceByPrisma = new WeakMap<PrismaClient, UserService>();
+
+function getOrCreateUserService(prisma: PrismaClient): UserService {
+  let service = userServiceByPrisma.get(prisma);
+  if (service === undefined) {
+    service = new UserService(prisma);
+    userServiceByPrisma.set(prisma, service);
+  }
+  return service;
+}
+
 export function requireProvisionedUser(prisma: PrismaClient) {
-  // Construct UserService once per factory call (typically app-startup).
-  // UserService just stores the prisma reference — cheap to reuse across
-  // every request that hits this router mount.
-  const userService = new UserService(prisma);
+  // Shared UserService across all factory calls with the same prisma
+  // reference — see `userServiceByPrisma` comment above for why.
+  const userService = getOrCreateUserService(prisma);
 
   return async (req: Request, _res: Response, next: NextFunction): Promise<void> => {
     const discordId = (req as AuthenticatedRequest).userId;

--- a/services/api-gateway/src/services/AuthMiddleware.ts
+++ b/services/api-gateway/src/services/AuthMiddleware.ts
@@ -6,9 +6,15 @@
  */
 
 import type { Request, Response, NextFunction } from 'express';
-import { getConfig, createLogger, isBotOwner } from '@tzurot/common-types';
+import {
+  getConfig,
+  createLogger,
+  isBotOwner,
+  UserService,
+  type PrismaClient,
+} from '@tzurot/common-types';
 import { ErrorResponses, getStatusCode } from '../utils/errorResponses.js';
-import type { AuthenticatedRequest } from '../types.js';
+import type { AuthenticatedRequest, ProvisionedRequest } from '../types.js';
 
 const logger = createLogger('auth-middleware');
 
@@ -150,6 +156,132 @@ export function requireUserAuth(customMessage?: string) {
 
     // Attach userId to request for downstream handlers
     (req as AuthenticatedRequest).userId = userId;
+
+    next();
+  };
+}
+
+/**
+ * Safely read + URI-decode a header value. Returns `undefined` when the
+ * header is missing/empty and `null` when present-but-malformed (i.e.
+ * `decodeURIComponent` threw on an invalid `%` sequence). Callers
+ * distinguish these cases because missing is normal during deploy
+ * transition whereas malformed is a bot-client bug worth surfacing.
+ */
+function readEncodedHeader(req: Request, headerName: string): string | undefined | null {
+  const raw = req.headers[headerName];
+  if (typeof raw !== 'string' || raw.length === 0) {
+    return undefined;
+  }
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Express middleware to provision the authenticated user via the full
+ * context path (Phase 5c PR B shadow mode).
+ *
+ * Runs AFTER `requireUserAuth()`. Reads the `X-User-Username` and
+ * `X-User-DisplayName` headers set by bot-client in PR A, URI-decodes
+ * them, and calls `UserService.getOrCreateUser(discordId, username,
+ * displayName)` — the full provisioning path that avoids the
+ * placeholder-name shell-user class of bug. Attaches
+ * `req.provisionedUserId` + `req.provisionedDefaultPersonaId` on success.
+ *
+ * **Shadow mode**: degrades gracefully on every failure mode. Missing
+ * headers, malformed URI encoding, or a thrown `getOrCreateUser` all
+ * log at warn and call `next()` without attaching the provisioned
+ * fields — the existing handler's shell-path call still runs. PR C
+ * tightens this to 400 Bad Request once every prod bot-client is on
+ * the new code path and the canary log in `getOrCreateUserShell` has
+ * trended to zero.
+ *
+ * Usage:
+ * ```ts
+ * router.get('/override',
+ *   requireUserAuth(),
+ *   requireProvisionedUser(prisma),
+ *   asyncHandler(handler)
+ * );
+ * ```
+ *
+ * @param prisma - PrismaClient used to construct a cached UserService
+ * @returns Express middleware function
+ */
+export function requireProvisionedUser(prisma: PrismaClient) {
+  // Construct UserService once per factory call (typically app-startup).
+  // UserService just stores the prisma reference — cheap to reuse across
+  // every request that hits this router mount.
+  const userService = new UserService(prisma);
+
+  return async (req: Request, _res: Response, next: NextFunction): Promise<void> => {
+    const discordId = (req as AuthenticatedRequest).userId;
+    // Shouldn't happen — requireUserAuth runs first and would 401 on
+    // missing userId — but defense in depth.
+    if (discordId === undefined || discordId.length === 0) {
+      next();
+      return;
+    }
+
+    const username = readEncodedHeader(req, 'x-user-username');
+    const displayName = readEncodedHeader(req, 'x-user-displayname');
+
+    // Missing either header → deploy-transition case, warn and fall through.
+    if (username === undefined || displayName === undefined) {
+      logger.warn(
+        {
+          discordId,
+          path: req.path,
+          method: req.method,
+          hasUsername: username !== undefined,
+          hasDisplayName: displayName !== undefined,
+        },
+        '[Identity] Missing user-context headers — shadow middleware falling through'
+      );
+      next();
+      return;
+    }
+
+    // Malformed URI → bot-client bug, warn louder and fall through.
+    if (username === null || displayName === null) {
+      logger.warn(
+        {
+          discordId,
+          path: req.path,
+          usernameMalformed: username === null,
+          displayNameMalformed: displayName === null,
+        },
+        '[Identity] Malformed URI in user-context header — shadow middleware falling through'
+      );
+      next();
+      return;
+    }
+
+    // Full provisioning path. getOrCreateUser handles P2002 races internally.
+    try {
+      const provisioned = await userService.getOrCreateUser(discordId, username, displayName);
+      if (provisioned === null) {
+        // getOrCreateUser returns null for bot accounts; HTTP routes
+        // shouldn't receive bot traffic in practice, but if it happens
+        // we fall through rather than block the request.
+        logger.warn(
+          { discordId, path: req.path },
+          '[Identity] getOrCreateUser returned null (bot user?) — shadow middleware falling through'
+        );
+        next();
+        return;
+      }
+      (req as ProvisionedRequest).provisionedUserId = provisioned.userId;
+      (req as ProvisionedRequest).provisionedDefaultPersonaId = provisioned.defaultPersonaId;
+    } catch (err) {
+      logger.warn(
+        { err, discordId, path: req.path },
+        '[Identity] getOrCreateUser threw — shadow middleware falling through'
+      );
+    }
 
     next();
   };

--- a/services/api-gateway/src/types.ts
+++ b/services/api-gateway/src/types.ts
@@ -39,6 +39,25 @@ export interface AuthenticatedRequest extends Request {
 }
 
 /**
+ * Request after `requireProvisionedUser` middleware has run.
+ *
+ * `provisionedUserId` is the internal UUID (not the Discord snowflake) for
+ * the user, obtained via `UserService.getOrCreateUser()` — the full
+ * provisioning path that uses the real Discord username/displayName from
+ * headers set by bot-client in Phase 5c PR A.
+ *
+ * Both fields are optional because the middleware degrades gracefully
+ * (doesn't fail the request) when the headers are absent or malformed.
+ * Handlers that want to consume them must narrow the optional first — or
+ * wait for PR C to tighten the invariant once prod bot-client is fully
+ * on the new code path.
+ */
+export interface ProvisionedRequest extends AuthenticatedRequest {
+  provisionedUserId?: string; // Internal user UUID, from getOrCreateUser
+  provisionedDefaultPersonaId?: string; // Internal persona UUID
+}
+
+/**
  * Health check response
  */
 export interface HealthResponse {


### PR DESCRIPTION
## Summary

PR B of **Phase 5c** in the Identity & Provisioning Hardening epic. Adds gateway-side middleware that consumes the `X-User-Username` + `X-User-DisplayName` headers from PR A, provisions users via the full `getOrCreateUser` path, and attaches `req.provisionedUserId` + `req.provisionedDefaultPersonaId`. Adds a canary log inside `UserService.getOrCreateUserShell` that warn-logs every call with `discordId` + stack trace — the empirical signal for when PR C is ready.

**Purely additive, shadow-mode**: existing handlers still call `getOrCreateUserShell`. No behavior change until PR C flips them over.

## Changes

- **`packages/common-types/src/services/UserService.ts`** — canary `logger.warn` at `getOrCreateUserShell` function entry. Target: zero hits in prod for 48-72h.
- **`services/api-gateway/src/services/AuthMiddleware.ts`** — new `requireProvisionedUser(prisma)` middleware (URI-decodes headers in try-catch, full graceful degradation on every failure mode, never blocks a request).
- **`services/api-gateway/src/types.ts`** — new `ProvisionedRequest` interface (optional fields during shadow mode).
- **33 route files** — mount `requireProvisionedUser(prisma)` immediately after `requireUserAuth()` on every user-scoped endpoint.
- **37 test files** — pass-through mock for the new middleware (36 route tests + 1 integration test).
- **`.claude/rules/01-architecture.md`** — new "Request Enrichment" section documenting `req.userId` vs `req.provisionedUserId` invariants.

## Design decisions

- **Graceful degradation on every failure mode**: missing headers → warn + `next()`, malformed URI → warn + `next()`, `getOrCreateUser` throws → warn + `next()`, `getOrCreateUser` returns `null` (bot user) → warn + `next()`. Never 4xx/5xx. PR C tightens to strict rejection once every bot-client version in production is on the new code path.
- **UserService construction**: factory constructs `new UserService(prisma)` once in the closure, not per-request. Cheap reuse.
- **Local type casting**: matches existing `AuthenticatedRequest` pattern — no global Express augmentation.
- **Mount order matters**: `requireProvisionedUser` runs AFTER `requireUserAuth` and reads `req.userId` for the Discord snowflake.

## Shadow-mode verification plan

After deploy to dev Railway:

1. Tail api-gateway logs for `'[Identity] Shell path executed'`. 
2. Expect non-zero during deploy-transition window (old bot-client clients without the PR A headers still hit the shell path).
3. Once all bot-client instances are on PR A, canary should trend toward zero.
4. Zero hits for 48-72h → PR C is unblocked.
5. If the canary stays non-zero after the bot-client rollout, the stack trace in each log line identifies the route that still reaches the shell path — either a missing middleware mount or a handler that short-circuits around it.

## Test coverage

- **`AuthMiddleware.test.ts`**: 8 new unit tests for `requireProvisionedUser` (happy path, emoji URI-decode, missing headers × 2, malformed URI, `getOrCreateUser` throws, `getOrCreateUser` returns null, `req.userId` missing defense-in-depth).
- **No new knownGaps**. Coverage audit passes.

## Rollback safety

Single-commit revert. If reverted: canary stops firing, middleware stops running, shell path still works (it always did). Zero user impact. No DB migration. No config change. No gateway deployment dependencies.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm typecheck:spec` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — api-gateway 1706/1706 + bot-client 4305/4305 + all other packages passing
- [x] `pnpm test:int` — 257/257 passing (including the `llm-config.int.test.ts` mock update)
- [x] `pnpm quality` — 11/11 tasks
- [ ] Post-deploy dev smoke: tail Railway api-gateway logs for `'[Identity] Shell path executed'` — observe the canary working

## Out of scope

- Handler cutover from `getOrCreateUserShell` → `req.provisionedUserId` — **PR C**
- Deleting `getOrCreateUserShell`, `createShellUserWithRaceProtection`, placeholder-rename block — **PR C**
- Username drift-sync on existing user hits — **PR C** (async fire-and-forget per council review)
- Tightening graceful-degradation to 400 Bad Request — **PR C**
- `adminFetch` / `requireOwnerAuth` provisioning — separate scope, deferred to PR C or later
- Integration test coverage for the refactor-regression class — **Phase 6**

75 files changed, +674/-71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)