### PR TITLE
fix(ai-worker): widen cross-turn duplicate detection to catch history regurgitation

### DIFF
--- a/services/ai-worker/src/utils/conversationHistoryUtils.test.ts
+++ b/services/ai-worker/src/utils/conversationHistoryUtils.test.ts
@@ -93,13 +93,16 @@ describe('getRecentAssistantMessages', () => {
       { role: 'user', content: 'User' },
       { role: 'assistant', content: 'Message 6' },
     ];
-    // Default is 5
+    // Default is 25 (widened from 5 to catch history regurgitation on
+    // glm-4.5-air:free — see conversationHistoryUtils.ts). Fixture has only
+    // 6 assistant messages so all are returned.
     expect(getRecentAssistantMessages(history)).toEqual([
       'Message 6',
       'Message 5',
       'Message 4',
       'Message 3',
       'Message 2',
+      'Message 1',
     ]);
     // Custom limit
     expect(getRecentAssistantMessages(history, 2)).toEqual(['Message 6', 'Message 5']);

--- a/services/ai-worker/src/utils/conversationHistoryUtils.ts
+++ b/services/ai-worker/src/utils/conversationHistoryUtils.ts
@@ -34,11 +34,25 @@ function isAssistantRole(role: string): boolean {
 }
 
 /**
- * Number of recent assistant messages to extract by default.
- * Set to 5 based on production observations showing API-level caching
- * can return responses from 3-4 turns back.
+ * Number of recent assistant messages to extract for cross-turn duplicate detection.
+ *
+ * The window must cover every assistant turn the model could potentially
+ * regurgitate. Two failure modes inform the size:
+ *
+ * 1. API-level caching — classic "cached response from 3-4 turns back"
+ *    pattern. Narrow (≤5).
+ * 2. Model-level history regurgitation — observed on `z-ai/glm-4.5-air:free`.
+ *    The model occasionally emits a past assistant turn from anywhere in
+ *    the conversation-history slice, verbatim. Confirmed incident on
+ *    2026-04-20 surfaced a message far beyond the previous 5-turn window.
+ *
+ * Sized at 25 to match the realistic assistant-turn count within the default
+ * context (`MESSAGE_LIMITS.DEFAULT_MAX_MESSAGES = 50` total, typically
+ * alternating user/assistant → ~25 assistant turns). Still bounded by
+ * `MAX_SCAN_DEPTH` below. Callers with larger context windows can override
+ * via the `maxMessages` parameter.
  */
-const DEFAULT_MAX_ASSISTANT_MESSAGES = 5;
+const DEFAULT_MAX_ASSISTANT_MESSAGES = 25;
 
 /**
  * Maximum number of messages to scan when searching for assistant messages.

--- a/services/ai-worker/src/utils/duplicateDetection.test.ts
+++ b/services/ai-worker/src/utils/duplicateDetection.test.ts
@@ -578,8 +578,11 @@ Now sit there, be quiet, and try to learn something about how a real professiona
     it('should extract assistant messages from production-format history', () => {
       const recentMessages = getRecentAssistantMessages(PRODUCTION_HISTORY_FORMAT);
 
-      // Should find 5 assistant messages (the max)
-      expect(recentMessages.length).toBe(5);
+      // With the widened default (25 assistant messages, up from 5), all 6
+      // assistant messages in the fixture are returned — the old cap truncated
+      // to 5, causing a 13-day-old regurgitated message on `glm-4.5-air:free`
+      // to slip past detection.
+      expect(recentMessages.length).toBe(6);
 
       // Most recent should be the ORIGINAL duplicate response
       expect(recentMessages[0]).toBe(DUPLICATE_RESPONSE);
@@ -615,6 +618,36 @@ Now sit there, be quiet, and try to learn something about how a real professiona
       const newResponseWithExtraSpace = DUPLICATE_RESPONSE + ' ';
       const result = isRecentDuplicate(newResponseWithExtraSpace, recentAssistantMessages);
 
+      expect(result.isDuplicate).toBe(true);
+    });
+
+    it('should detect a verbatim regurgitation from far back in history', () => {
+      // Regression for the `glm-4.5-air:free` 13-day-old regurgitation
+      // incident (2026-04-20). The old 5-message cap silently dropped any
+      // assistant turn beyond the 5th most recent, so a model that
+      // regurgitated a 10-turn-old response would pass detection.
+      const OLD_REGURGITATED_RESPONSE =
+        'This is a specific response from deep in the conversation history that ' +
+        'the model decided to emit verbatim instead of generating a new reply.';
+
+      // Build a history of 20 alternating user/assistant turns. Plant the
+      // "old" response at turn index 0 (the 10th most recent assistant
+      // message, well outside the old 5-message window).
+      const history: { role: string; content: string }[] = [
+        { role: 'assistant', content: OLD_REGURGITATED_RESPONSE },
+        { role: 'user', content: 'follow-up 1' },
+      ];
+      // Pad with 9 more assistant/user pairs so the OLD one is turn 10 back.
+      for (let i = 1; i <= 9; i++) {
+        history.push({ role: 'assistant', content: `recent response ${i}` });
+        history.push({ role: 'user', content: `recent prompt ${i}` });
+      }
+
+      const recentAssistantMessages = getRecentAssistantMessages(history);
+      expect(recentAssistantMessages.length).toBe(10);
+      expect(recentAssistantMessages).toContain(OLD_REGURGITATED_RESPONSE);
+
+      const result = isRecentDuplicate(OLD_REGURGITATED_RESPONSE, recentAssistantMessages);
       expect(result.isDuplicate).toBe(true);
     });
   });


### PR DESCRIPTION
## Summary

Fixes a recurring duplicate-reply failure mode on `z-ai/glm-4.5-air:free`: the model occasionally emits a past assistant turn from the conversation-history slice verbatim, and `CrossTurnDetection` was silently passing because its comparison window was capped at 5 recent messages.

## Context

The 2026-04-20 prod incident exposed a **13-day-old** assistant turn being regurgitated verbatim. The current duplicate-detection window (`DEFAULT_MAX_ASSISTANT_MESSAGES = 5`) was sized for a narrower bug class (provider-level response caching returning responses from 3-4 turns back). The actual failure mode is wider: the model can latch onto any assistant turn that's in the context it receives, regardless of age.

User's earlier "duplicate consecutive replies" incidents are the same failure mode with a proximate message picked instead of a distant one.

## Change

Bump `DEFAULT_MAX_ASSISTANT_MESSAGES` from 5 → 25 in `services/ai-worker/src/utils/conversationHistoryUtils.ts`. That matches the realistic assistant-turn count within the default context (`LlmConfig.maxMessages = 50`, typically alternating user/assistant → ~25 assistant turns). Still bounded upward by `MAX_SCAN_DEPTH = 100`; callers with larger contexts can override via the `maxMessages` parameter.

Widening at the extraction layer is O(1) for the caller — every detection layer (hash, jaccard, bigram, semantic) benefits without touching their loops. For the pathological case where layer 4 (embedding cosine) fires and the array is 25-long, that's 25 embedding calls per retry — still cheap, and only happens when layers 1-3 all miss.

## Not in scope

- **Model-level mitigation** (suppressing the model, routing around it, etc.) — user confirmed GLM-4.5-air:free stays. This change patches the symptom-detection layer instead.
- **Vector-memory retrieval regurgitation** (the `MemoryRetriever` pipeline that surfaces long-term embedded messages). Different code path, separate investigation if it surfaces.
- **Larger cap for custom LlmConfig.maxMessages > 50** — callers can pass their own `maxMessages` today.

## Test plan

- [x] Updated `getRecentAssistantMessages > should respect maxMessages parameter` — fixture has 6 assistant messages, old cap returned 5, new cap returns all 6.
- [x] Updated `getRecentAssistantMessages with production data format > should extract assistant messages from production-format history` — fixture has 6 assistant messages, old cap returned 5, new cap returns all 6.
- [x] Added regression test: `should detect a verbatim regurgitation from far back in history` — plants a response 10 turns back in a 20-turn history, verifies detection fires. Would have silently passed under the old 5-cap.
- [x] `pnpm test` — full monorepo green.
- [x] `pnpm quality` — all 11 quality tasks green.

## Observability for post-merge

Once deployed, the next occurrence of this bug should:
- Trigger CrossTurnDetection's `comparisonReport` for the retrieval-regurgitation case
- Show a high Jaccard/bigram score against a distant assistant message (not the previous one)
- Be caught by the retry loop before shipping

If a future incident still slips past the widened window, escalation is to raise the cap further or thread the LlmConfig maxMessages into the extraction call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)