### PR TITLE
fix(bot-client): rename stale /character list + /channel list references to browse

### DIFF
--- a/docs/reference/features/CHANNEL_ACTIVATION.md
+++ b/docs/reference/features/CHANNEL_ACTIVATION.md
@@ -53,7 +53,7 @@ Deactivates the personality in the current channel.
 /channel deactivate
 ```
 
-### `/channel list`
+### `/channel browse`
 
 Lists all channel activations visible to you.
 

--- a/docs/reference/standards/SLASH_COMMAND_IMPLEMENTATION.md
+++ b/docs/reference/standards/SLASH_COMMAND_IMPLEMENTATION.md
@@ -488,7 +488,7 @@ export async function handleButton(interaction: ButtonInteraction): Promise<void
 ```typescript
 // User-friendly error with guidance
 await interaction.reply({
-  content: `❌ Character not found.\n\nUse \`/character list\` to see available characters.`,
+  content: `❌ Character not found.\n\nUse \`/character browse\` to see available characters.`,
   flags: MessageFlags.Ephemeral,
 });
 ```

--- a/docs/reference/standards/SLASH_COMMAND_UX.md
+++ b/docs/reference/standards/SLASH_COMMAND_UX.md
@@ -321,7 +321,7 @@ await interaction.reply({ content: '❌ Error', flags: MessageFlags.Ephemeral })
 
 // ✅ Good
 await interaction.reply({
-  content: '❌ Character not found.\n\nUse `/character list` to see available characters.',
+  content: '❌ Character not found.\n\nUse `/character browse` to see available characters.',
   flags: MessageFlags.Ephemeral,
 });
 ```

--- a/services/bot-client/src/processors/BotMentionProcessor.test.ts
+++ b/services/bot-client/src/processors/BotMentionProcessor.test.ts
@@ -101,7 +101,7 @@ describe('BotMentionProcessor', () => {
       const replyArg = vi.mocked(message.reply).mock.calls[0][0] as { content: string };
       expect(replyArg.content).toContain('multiple AI personalities');
       expect(replyArg.content).toContain('@personality');
-      expect(replyArg.content).toContain('/character list');
+      expect(replyArg.content).toContain('/character browse');
       expect(replyArg.content).toContain('/character chat');
     });
 

--- a/services/bot-client/src/processors/BotMentionProcessor.ts
+++ b/services/bot-client/src/processors/BotMentionProcessor.ts
@@ -67,7 +67,7 @@ export class BotMentionProcessor implements IMessageProcessor {
         `• Reply to a personality's message to continue the conversation`,
         `• Use \`/character chat\` to start a conversation via slash command`,
         ``,
-        `Use \`/character list\` to see available personalities.`,
+        `Use \`/character browse\` to see available personalities.`,
       ].join('\n'),
     });
 

--- a/services/bot-client/src/utils/customIds.test.ts
+++ b/services/bot-client/src/utils/customIds.test.ts
@@ -403,7 +403,7 @@ describe('customIds', () => {
   });
 
   describe('round-trip tests (build then parse)', () => {
-    it('should round-trip character list page', () => {
+    it('should round-trip character browse page', () => {
       const customId = CharacterCustomIds.listPage(5, 'date');
       const parsed = CharacterCustomIds.parse(customId);
       expect(parsed?.page).toBe(5);

--- a/services/bot-client/src/utils/customIds.ts
+++ b/services/bot-client/src/utils/customIds.ts
@@ -23,7 +23,7 @@ export const CUSTOM_ID_DELIMITER = '::';
 // CHARACTER COMMAND
 // ============================================================================
 
-/** Sort options for character list */
+/** Sort options for `/character browse` */
 type CharacterListSortType = 'date' | 'name';
 
 /** Result type for CharacterCustomIds.parse */
@@ -320,7 +320,7 @@ export const DestructiveCustomIds = {
 // CHANNEL COMMAND
 // ============================================================================
 
-/** Sort options for channel list */
+/** Sort options for `/channel browse` */
 type ChannelListSortType = 'date' | 'name';
 
 /** Result type for ChannelCustomIds.parse */

--- a/services/bot-client/src/utils/listSorting.ts
+++ b/services/bot-client/src/utils/listSorting.ts
@@ -2,7 +2,8 @@
  * Shared Sorting Utilities for List Commands
  *
  * Provides reusable comparator functions for sorting lists by name or date.
- * Used by both /channel list and /character list commands.
+ * Used by `/channel browse` and `/character browse` (both previously
+ * named `list` — renamed to `browse` before the current release cycle).
  */
 
 /** Sort options for list commands */


### PR DESCRIPTION
## Summary

Both `/character list` and `/channel list` were renamed to `/browse` before the current release cycle, but a handful of user-facing and internal references still pointed users at the old names. The most impactful instance is the bot's mention-response help reply — a new user who mentions the bot and follows the instructions would run `/character list` and get a command-not-found error.

## Fixed

- `BotMentionProcessor.ts:70` — user-facing help reply (`Use /character list to see available personalities.` → `/character browse`). Its test assertion updated.
- `utils/listSorting.ts:5` — internal file header comment now names the current command forms and notes the historical rename (`/channel list` + `/character list` both became `/browse`).
- `docs/reference/features/CHANNEL_ACTIVATION.md` — `### /channel list` section heading updated.
- `docs/reference/standards/SLASH_COMMAND_UX.md` — pattern example pointing at `/character list`.
- `docs/reference/standards/SLASH_COMMAND_IMPLEMENTATION.md` — same.

## Intentionally left alone (correct historical references)

- `channel/browse.ts` and `character/browse.ts` file headers that document *"Replaces the old /character list"* — those explain the rename and removing them would be confusing.
- `docs/proposals/backlog/MEMORY_MANAGEMENT_COMMANDS.md` — completed backlog item about the refactor, historical fact.

## Test plan

- [x] `BotMentionProcessor.test.ts` — 12 tests pass (assertion updated for new reply content)
- [x] `pnpm quality` — all 11 tasks green

## Release context

This is the last small fix before `v3.0.0-beta.101` release prep. Sequence after merge: version bump → release notes from `git log v3.0.0-beta.100..HEAD --no-merges` → PR develop → main → tag → GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)