### PR TITLE
fix(bot-client): character back-to-browse sweep via renderTerminalScreen

### DIFF
--- a/services/bot-client/src/commands/character/dashboard.test.ts
+++ b/services/bot-client/src/commands/character/dashboard.test.ts
@@ -65,6 +65,21 @@ vi.mock('./truncationWarning.js', () => ({
   showTruncationWarning: vi.fn(),
 }));
 
+// renderTerminalScreen imports getSessionManager directly from the source
+// module, so mocking the barrel below isn't enough — add a source-level stub
+// so handleRefreshButton's NOT_FOUND path doesn't blow up on an uninitialized
+// session manager.
+vi.mock('../../utils/dashboard/SessionManager.js', () => ({
+  getSessionManager: vi.fn().mockReturnValue({
+    get: vi.fn(),
+    set: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  }),
+  initSessionManager: vi.fn(),
+  shutdownSessionManager: vi.fn(),
+}));
+
 vi.mock('../../utils/dashboard/index.js', async () => {
   const actual = await vi.importActual('../../utils/dashboard/index.js');
   return {
@@ -605,6 +620,13 @@ describe('Character Dashboard', () => {
         entityId: 'nonexistent',
       });
 
+      // Explicitly null out the shared session-get mock. `vi.clearAllMocks` in
+      // beforeEach wipes call history but preserves implementations set by
+      // earlier tests in this suite (e.g. the modal-submit test seeds
+      // browseContext). Without this reset, renderTerminalScreen would see a
+      // leaked browseContext and render the Back-to-Browse button instead of
+      // the clean terminal expected here.
+      vi.mocked(dashboardUtils.getSessionManager().get).mockResolvedValue(null);
       vi.mocked(api.fetchCharacter).mockResolvedValue(null);
 
       const mockInteraction = createMockButtonInteraction('character::refresh::nonexistent');

--- a/services/bot-client/src/commands/character/dashboardButtons.test.ts
+++ b/services/bot-client/src/commands/character/dashboardButtons.test.ts
@@ -48,6 +48,16 @@ vi.mock('../../utils/dashboard/index.js', async () => {
   };
 });
 
+// renderTerminalScreen imports getSessionManager directly from
+// SessionManager.js (not via the index barrel), so the index.js mock above
+// doesn't intercept it. Mock SessionManager at the source so renderTerminalScreen
+// can run against the same mocked session manager during these tests.
+vi.mock('../../utils/dashboard/SessionManager.js', () => ({
+  getSessionManager: () => mockSessionManager,
+  initSessionManager: vi.fn(),
+  shutdownSessionManager: vi.fn(),
+}));
+
 vi.mock('../../utils/dashboard/closeHandler.js', () => ({
   handleDashboardClose: vi.fn().mockResolvedValue(undefined),
 }));

--- a/services/bot-client/src/commands/character/dashboardButtons.ts
+++ b/services/bot-client/src/commands/character/dashboardButtons.ts
@@ -15,6 +15,7 @@ import {
   handleDashboardClose,
   DASHBOARD_MESSAGES,
   formatSessionExpiredMessage,
+  renderTerminalScreen,
 } from '../../utils/dashboard/index.js';
 import {
   getCharacterDashboardConfig,
@@ -51,13 +52,23 @@ export async function handleBackButton(
     return;
   }
 
+  // All three error branches below render as terminal-with-no-back-button
+  // (re-adding the back-button would re-enter the failing path) and clean up
+  // the now-dead session. Share the session descriptor.
+  const noContextSession = {
+    userId: interaction.user.id,
+    entityType: 'character' as const,
+    entityId,
+    browseContext: undefined,
+  };
+
   const browseContext = session.data.browseContext;
   if (!browseContext) {
-    // Session exists but no browse context - shouldn't happen, show expired
-    await interaction.editReply({
+    // Session exists but no browse context - shouldn't happen; terminate cleanly.
+    await renderTerminalScreen({
+      interaction,
+      session: noContextSession,
       content: formatSessionExpiredMessage('/character browse'),
-      embeds: [],
-      components: [],
     });
     return;
   }
@@ -86,10 +97,10 @@ export async function handleBackButton(
     );
   } catch (error) {
     logger.error({ err: error, entityId }, '[Character] Failed to return to browse');
-    await interaction.editReply({
+    await renderTerminalScreen({
+      interaction,
+      session: noContextSession,
       content: '❌ Failed to load browse list. Please try again.',
-      embeds: [],
-      components: [],
     });
   }
 }
@@ -115,10 +126,18 @@ export async function handleRefreshButton(
 
   const character = await fetchCharacter(entityId, config, toGatewayUser(interaction.user));
   if (!character) {
-    await interaction.editReply({
+    // Character gone (deleted elsewhere). If the user came from /character
+    // browse, renderTerminalScreen preserves Back-to-Browse so they're not
+    // stranded.
+    await renderTerminalScreen({
+      interaction,
+      session: {
+        userId: interaction.user.id,
+        entityType: 'character' as const,
+        entityId,
+        browseContext: existingBrowseContext,
+      },
       content: DASHBOARD_MESSAGES.NOT_FOUND('Character'),
-      embeds: [],
-      components: [],
     });
     return;
   }

--- a/services/bot-client/src/commands/character/dashboardDeleteHandlers.test.ts
+++ b/services/bot-client/src/commands/character/dashboardDeleteHandlers.test.ts
@@ -46,6 +46,20 @@ vi.mock('../../utils/customIds.js', () => ({
   },
 }));
 
+const mockSessionGet = vi.fn();
+vi.mock('../../utils/dashboard/SessionManager.js', () => ({
+  getSessionManager: () => ({
+    get: mockSessionGet,
+    set: vi.fn(),
+    delete: vi.fn(),
+  }),
+}));
+
+const mockRenderTerminalScreen = vi.fn();
+vi.mock('../../utils/dashboard/terminalScreen.js', () => ({
+  renderTerminalScreen: (...args: unknown[]) => mockRenderTerminalScreen(...args),
+}));
+
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal();
   return {
@@ -98,6 +112,11 @@ describe('dashboardDeleteHandlers', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCallGatewayApi.mockReset();
+    mockSessionGet.mockReset();
+    mockRenderTerminalScreen.mockReset();
+    // Default: no session (simulates dashboard opened via /character view with
+    // no browseContext). Individual tests override when they need a session.
+    mockSessionGet.mockResolvedValue(null);
   });
 
   describe('handleDeleteAction', () => {
@@ -178,11 +197,8 @@ describe('dashboardDeleteHandlers', () => {
 
       await handleDeleteButton(interaction, 'test-char', true);
 
-      expect(interaction.update).toHaveBeenCalledWith({
-        content: expect.stringContaining('Deleting character'),
-        embeds: [],
-        components: [],
-      });
+      // Ack via deferUpdate (no intermediate progress message per preset pattern)
+      expect(interaction.deferUpdate).toHaveBeenCalled();
       expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/personality/test-char', {
         method: 'DELETE',
         user: {
@@ -191,11 +207,46 @@ describe('dashboardDeleteHandlers', () => {
           displayName: 'testuser',
         },
       });
-      expect(interaction.editReply).toHaveBeenCalledWith({
-        content: expect.stringContaining('deleted'),
-        embeds: [],
-        components: [],
+      // Success goes through renderTerminalScreen so dashboards opened from
+      // /character browse preserve the Back-to-Browse affordance.
+      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+        expect.objectContaining({
+          session: expect.objectContaining({
+            entityType: 'character',
+            entityId: 'test-char',
+            browseContext: undefined,
+          }),
+          content: expect.stringContaining('deleted'),
+        })
+      );
+    });
+
+    it('should carry browseContext from session into the terminal screen', async () => {
+      const browseContext = { page: 2, filter: 'all', sort: 'date' };
+      mockSessionGet.mockResolvedValue({ data: { browseContext } });
+      mockCallGatewayApi.mockResolvedValue({
+        ok: true,
+        data: {
+          deletedCounts: {
+            conversationHistory: 0,
+            memories: 0,
+            pendingMemories: 0,
+            channelSettings: 0,
+            aliases: 0,
+          },
+          deletedName: 'Test Character',
+          deletedSlug: 'test-char',
+        },
       });
+      const interaction = createMockButtonInteraction();
+
+      await handleDeleteButton(interaction, 'test-char', true);
+
+      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+        expect.objectContaining({
+          session: expect.objectContaining({ browseContext }),
+        })
+      );
     });
 
     it('should show error on API failure', async () => {
@@ -207,11 +258,11 @@ describe('dashboardDeleteHandlers', () => {
 
       await handleDeleteButton(interaction, 'test-char', true);
 
-      expect(interaction.editReply).toHaveBeenCalledWith({
-        content: expect.stringContaining('Failed to delete'),
-        embeds: [],
-        components: [],
-      });
+      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining('Failed to delete'),
+        })
+      );
     });
   });
 });

--- a/services/bot-client/src/commands/character/dashboardDeleteHandlers.ts
+++ b/services/bot-client/src/commands/character/dashboardDeleteHandlers.ts
@@ -15,9 +15,12 @@ import {
 } from '@tzurot/common-types';
 import { buildDeleteConfirmation } from '../../utils/dashboard/deleteConfirmation.js';
 import { DASHBOARD_MESSAGES } from '../../utils/dashboard/messages.js';
+import { getSessionManager } from '../../utils/dashboard/SessionManager.js';
+import { renderTerminalScreen } from '../../utils/dashboard/terminalScreen.js';
 import { CharacterCustomIds } from '../../utils/customIds.js';
 import { fetchCharacter } from './api.js';
 import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
+import type { CharacterData } from './config.js';
 
 const logger = createLogger('character-dashboard');
 
@@ -75,6 +78,11 @@ export async function handleDeleteAction(
 /**
  * Handle delete confirmation button click.
  * Called when user clicks "Delete Forever" or "Cancel" on the delete confirmation dialog.
+ *
+ * Terminal success/failure paths route through {@link renderTerminalScreen} so
+ * that dashboards opened from `/character browse` preserve the Back-to-Browse
+ * affordance. The cancel path is left non-terminal — see the `intentionally-raw`
+ * marker below for the follow-up-tracked limitation.
  */
 export async function handleDeleteButton(
   interaction: ButtonInteraction,
@@ -82,20 +90,38 @@ export async function handleDeleteButton(
   confirmed: boolean
 ): Promise<void> {
   if (!confirmed) {
+    // Cancel-delete is non-terminal — ideally it restores the dashboard (like
+    // preset's handleCancelDeleteButton via refreshDashboardUI), but
+    // character's dashboard renders its own embed without a shared refresh
+    // helper. Tracked as a follow-up backlog item ("character cancel-delete
+    // should restore dashboard").
     await interaction.update({
       content: '✅ Deletion cancelled.',
       embeds: [],
+      // intentionally-raw: non-terminal cancel path; see block comment above.
       components: [],
     });
     return;
   }
 
-  // User clicked confirm - proceed with deletion
-  await interaction.update({
-    content: '🔄 Deleting character...',
-    embeds: [],
-    components: [],
-  });
+  // User clicked confirm — ack the button and let renderTerminalScreen handle
+  // every terminal outcome. No intermediate "Deleting..." message (matches the
+  // preset pattern); the user sees the button's spinner while the DELETE API
+  // call resolves.
+  await interaction.deferUpdate();
+
+  // Fetch the session so browseContext (if any) can carry into the terminal
+  // screen. Users who opened this dashboard from /character browse get a
+  // Back-to-Browse button on the final message; users who opened it via
+  // /character view get a clean terminal state with no back button.
+  const sessionManager = getSessionManager();
+  const session = await sessionManager.get<CharacterData>(interaction.user.id, 'character', slug);
+  const terminalSession = {
+    userId: interaction.user.id,
+    entityType: 'character' as const,
+    entityId: slug,
+    browseContext: session?.data.browseContext,
+  };
 
   // Call the DELETE API
   const result = await callGatewayApi<unknown>(`/user/personality/${slug}`, {
@@ -105,10 +131,10 @@ export async function handleDeleteButton(
 
   if (!result.ok) {
     logger.error({ slug, error: result.error }, '[Character] Delete API failed');
-    await interaction.editReply({
+    await renderTerminalScreen({
+      interaction,
+      session: terminalSession,
       content: `❌ Failed to delete character: ${result.error}`,
-      embeds: [],
-      components: [],
     });
     return;
   }
@@ -121,10 +147,10 @@ export async function handleDeleteButton(
       '[Character] Response schema validation failed'
     );
     // Still consider it a success since the API returned 200
-    await interaction.editReply({
+    await renderTerminalScreen({
+      interaction,
+      session: terminalSession,
       content: `✅ Character has been deleted.`,
-      embeds: [],
-      components: [],
     });
     return;
   }
@@ -147,10 +173,10 @@ export async function handleDeleteButton(
     successMessage += '\n\n**Deleted data:**\n' + countLines.join('\n');
   }
 
-  await interaction.editReply({
+  await renderTerminalScreen({
+    interaction,
+    session: terminalSession,
     content: successMessage,
-    embeds: [],
-    components: [],
   });
 
   logger.info(

--- a/services/bot-client/src/utils/dashboard/terminalScreen.structure.test.ts
+++ b/services/bot-client/src/utils/dashboard/terminalScreen.structure.test.ts
@@ -5,7 +5,11 @@ import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 // Add a file here when you migrate its delete/archive/confirm handlers.
-const ENFORCED_FILES = ['services/bot-client/src/commands/preset/dashboardButtons.ts'];
+const ENFORCED_FILES = [
+  'services/bot-client/src/commands/preset/dashboardButtons.ts',
+  'services/bot-client/src/commands/character/dashboardButtons.ts',
+  'services/bot-client/src/commands/character/dashboardDeleteHandlers.ts',
+];
 
 const REPO_ROOT = resolve(__dirname, '../../../../..');
 


### PR DESCRIPTION
## Summary

Applies the preset-pattern from PR #836 to `/character` so dashboards opened from `/character browse` preserve the Back-to-Browse affordance through terminal actions (delete, refresh-not-found, back-button errors). Rule-of-three sweep from the beta.101 review — character/persona/deny all dropped the affordance; preset shipped the fix in PR #836, character is #1 of the remaining three.

## Migrated terminal sites

**`dashboardButtons.ts`** (3 sites):
- `handleBackButton` no-context branch (session exists but no browseContext)
- `handleBackButton` exception path (browse fetch failure)
- `handleRefreshButton` character-not-found (entity deleted elsewhere)

**`dashboardDeleteHandlers.ts`** (3 sites):
- Delete API failure (`result.ok === false`)
- Schema-validation fallback (API returned 200 but response shape didn't parse)
- Success message with deletion counts

Dropped the intermediate `interaction.update({ content: '🔄 Deleting character...', ... })` progress message in favor of `deferUpdate()`. Matches the preset pattern — users see the button spinner while the DELETE resolves, no flash of intermediate text.

## Scope exception: cancel-delete

`handleDeleteButton` with `confirmed=false` (the Cancel branch) is left with a raw `components: []` + `// intentionally-raw:` marker. Ideally it restores the dashboard like preset's `handleCancelDeleteButton` does via `refreshDashboardUI`, but character's dashboard renders its own embed without a shared refresh helper — fixing that requires either introducing a shared character-refresh or duplicating the render logic inline, both bigger than this PR's scope.

**Tracked as a follow-up backlog entry** (cancel-delete should restore dashboard).

## Enforcement

Added both files to `ENFORCED_FILES` in `terminalScreen.structure.test.ts`:

```ts
const ENFORCED_FILES = [
  'services/bot-client/src/commands/preset/dashboardButtons.ts',
  'services/bot-client/src/commands/character/dashboardButtons.ts',
  'services/bot-client/src/commands/character/dashboardDeleteHandlers.ts',
];
```

Any future regression where someone drops a raw `components: []` into a terminal path in these files now fails the structural test.

## Test updates

**Non-obvious mocking gotcha worth documenting**: `renderTerminalScreen` imports `getSessionManager` directly from `./SessionManager.js`, not via the `dashboard/index.js` barrel. Existing tests mocked the barrel to stub `getSessionManager`, which didn't intercept the source-level import — `renderTerminalScreen` would then throw `Session manager not initialized`. Added source-level `vi.mock('../../utils/dashboard/SessionManager.js', ...)` stubs to `dashboardButtons.test.ts` and `dashboard.test.ts` so the real `renderTerminalScreen` runs against a mocked session manager.

`dashboardDeleteHandlers.test.ts` went further and mocks `renderTerminalScreen` directly — that decouples the unit tests from renderTerminalScreen internals and lets assertions target the `session` + `content` shape passed in.

Also: one test case needed an explicit `vi.mocked(getSessionManager().get).mockResolvedValue(null)` — `vi.clearAllMocks` in beforeEach wipes call history but preserves implementations set by earlier tests, and a prior test seeded `browseContext` that leaked into this one.

**New test**: `dashboardDeleteHandlers.test.ts` now covers the browseContext carry-through explicitly (\"should carry browseContext from session into the terminal screen\").

## Test plan

- [x] `pnpm test` — 4316/4316 pass
- [x] `pnpm quality` — lint + cpd + depcruise + typecheck + typecheck:spec all green
- [ ] Manual dev verification after auto-deploy: open a character dashboard from `/character browse`, delete it, verify the \"Deleted\" message has a Back-to-Browse button that returns you to the right browse page + filter

## Follow-ups (not in this PR)

- Cancel-delete should restore the dashboard (backlog entry to add on develop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)