### PR TITLE
fix(bot-client): persona back-to-browse sweep + refreshHandler helper fix

### DIFF
--- a/services/bot-client/src/commands/persona/dashboard.test.ts
+++ b/services/bot-client/src/commands/persona/dashboard.test.ts
@@ -63,6 +63,12 @@ const mockRequireDeferredSession = vi
     return mockGetSessionOrExpired(interaction, entityType, entityId, command);
   });
 
+// renderTerminalScreen is imported via the dashboard index barrel, but it
+// ALSO calls getSessionManager from SessionManager.js directly (bypassing the
+// barrel). Mock the source module + spy on renderTerminalScreen so test
+// assertions can target its call shape directly.
+const mockRenderTerminalScreen = vi.fn();
+
 // Mock getSessionDataOrReply to delegate to mockSessionGet
 const mockGetSessionDataOrReply = vi
   .fn()
@@ -78,6 +84,21 @@ const mockGetSessionDataOrReply = vi
     return session.data;
   });
 
+vi.mock('../../utils/dashboard/SessionManager.js', () => ({
+  getSessionManager: () => ({
+    get: mockSessionGet,
+    set: mockSessionSet,
+    update: mockSessionUpdate,
+    delete: mockSessionDelete,
+  }),
+  initSessionManager: vi.fn(),
+  shutdownSessionManager: vi.fn(),
+}));
+
+vi.mock('../../utils/dashboard/terminalScreen.js', () => ({
+  renderTerminalScreen: (...args: unknown[]) => mockRenderTerminalScreen(...args),
+}));
+
 vi.mock('../../utils/dashboard/index.js', async () => {
   const actual = await vi.importActual('../../utils/dashboard/index.js');
   return {
@@ -86,6 +107,7 @@ vi.mock('../../utils/dashboard/index.js', async () => {
     buildDashboardComponents: (...args: unknown[]) => mockBuildDashboardComponents(...args),
     buildSectionModal: (...args: unknown[]) => mockBuildSectionModal(...args),
     extractModalValues: (...args: unknown[]) => mockExtractModalValues(...args),
+    renderTerminalScreen: (...args: unknown[]) => mockRenderTerminalScreen(...args),
     getSessionManager: () => ({
       get: mockSessionGet,
       set: mockSessionSet,
@@ -552,12 +574,38 @@ describe('handleButton', () => {
       `/user/persona/${TEST_PERSONA_ID}`,
       expect.objectContaining({ method: 'DELETE' })
     );
-    expect(mockSessionDelete).toHaveBeenCalled();
-    expect(mockEditReply).toHaveBeenCalledWith({
-      content: expect.stringContaining('has been deleted'),
-      embeds: [],
-      components: [],
+    // Success goes through renderTerminalScreen — dashboards opened from
+    // /persona browse keep Back-to-Browse; others get a clean terminal.
+    // renderTerminalScreen handles the session cleanup internally, so the
+    // handler no longer calls sessionManager.delete directly.
+    expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session: expect.objectContaining({
+          entityType: 'persona',
+          entityId: TEST_PERSONA_ID,
+        }),
+        content: expect.stringContaining('has been deleted'),
+      })
+    );
+  });
+
+  it('should carry browseContext from session into the terminal screen on confirm-delete', async () => {
+    const browseContext = { page: 1, filter: 'all', sort: 'name' };
+    mockSessionGet.mockResolvedValue({
+      data: { name: 'Test Persona', browseContext },
     });
+    mockCallGatewayApi.mockResolvedValue({
+      ok: true,
+      data: { message: 'Deleted' },
+    });
+
+    await handleButton(createMockButtonInteraction(`persona::confirm-delete::${TEST_PERSONA_ID}`));
+
+    expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session: expect.objectContaining({ browseContext }),
+      })
+    );
   });
 
   it('should show error on confirm-delete when delete fails', async () => {
@@ -571,11 +619,11 @@ describe('handleButton', () => {
 
     await handleButton(createMockButtonInteraction(`persona::confirm-delete::${TEST_PERSONA_ID}`));
 
-    expect(mockEditReply).toHaveBeenCalledWith({
-      content: expect.stringContaining('Failed to delete'),
-      embeds: [],
-      components: [],
-    });
+    expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('Failed to delete'),
+      })
+    );
   });
 
   it('should return to dashboard on cancel-delete button', async () => {

--- a/services/bot-client/src/commands/persona/dashboard.ts
+++ b/services/bot-client/src/commands/persona/dashboard.ts
@@ -25,6 +25,7 @@ import {
   parseDashboardCustomId,
   isDashboardInteraction,
   formatSessionExpiredMessage,
+  renderTerminalScreen,
 } from '../../utils/dashboard/index.js';
 import { handleDashboardSectionSelect } from '../../utils/dashboard/genericSelectMenuHandler.js';
 import { toGatewayUser } from '../../utils/userGatewayClient.js';
@@ -241,25 +242,31 @@ async function handleConfirmDeleteButton(
 
   const personaName = session?.data.name ?? 'Persona';
 
+  // Helper reads browseContext to decide: Back-to-Browse button + keep session,
+  // or cleanup. No explicit sessionManager.delete here — renderTerminalScreen
+  // handles the cleanup path internally when browseContext is absent.
+  const terminalSession = {
+    userId: interaction.user.id,
+    entityType: 'persona' as const,
+    entityId,
+    browseContext: session?.data.browseContext,
+  };
+
   const result = await deletePersona(entityId, toGatewayUser(interaction.user));
 
   if (!result.success) {
-    await interaction.editReply({
+    await renderTerminalScreen({
+      interaction,
+      session: terminalSession,
       content: `❌ Failed to delete persona: ${result.error}`,
-      embeds: [],
-      components: [],
     });
     return;
   }
 
-  // Clean up session
-  await sessionManager.delete(interaction.user.id, 'persona', entityId);
-
-  // Show success
-  await interaction.editReply({
+  await renderTerminalScreen({
+    interaction,
+    session: terminalSession,
     content: `✅ **${personaName}** has been deleted.`,
-    embeds: [],
-    components: [],
   });
 
   logger.info({ userId: interaction.user.id, entityId, personaName }, 'Persona deleted');
@@ -362,13 +369,23 @@ async function handleBackButton(interaction: ButtonInteraction, entityId: string
     return;
   }
 
+  // All three error branches below render as terminal-with-no-back-button
+  // (re-adding the back-button would re-enter the failing path) and clean up
+  // the now-dead session. Share the session descriptor.
+  const noContextSession = {
+    userId: interaction.user.id,
+    entityType: 'persona' as const,
+    entityId,
+    browseContext: undefined,
+  };
+
   const browseContext = session.data.browseContext;
   if (!browseContext) {
-    // Session exists but no browse context - shouldn't happen, show expired
-    await interaction.editReply({
+    // Session exists but no browse context — terminate cleanly.
+    await renderTerminalScreen({
+      interaction,
+      session: noContextSession,
       content: formatSessionExpiredMessage(BROWSE_COMMAND),
-      embeds: [],
-      components: [],
     });
     return;
   }
@@ -381,15 +398,15 @@ async function handleBackButton(interaction: ButtonInteraction, entityId: string
     );
 
     if (result === null) {
-      await interaction.editReply({
+      await renderTerminalScreen({
+        interaction,
+        session: noContextSession,
         content: '❌ Failed to load browse list. Please try again.',
-        embeds: [],
-        components: [],
       });
       return;
     }
 
-    // Clean up the dashboard session
+    // Clean up the dashboard session since we're leaving it for the browse list.
     const sessionManager = getSessionManager();
     await sessionManager.delete(interaction.user.id, 'persona', entityId);
 
@@ -401,10 +418,10 @@ async function handleBackButton(interaction: ButtonInteraction, entityId: string
     logger.info({ userId: interaction.user.id }, '[Persona] Returned to browse from dashboard');
   } catch (error) {
     logger.error({ err: error }, '[Persona] Failed to return to browse');
-    await interaction.editReply({
+    await renderTerminalScreen({
+      interaction,
+      session: noContextSession,
       content: '❌ Failed to load browse list. Please try again.',
-      embeds: [],
-      components: [],
     });
   }
 }

--- a/services/bot-client/src/utils/dashboard/refreshHandler.test.ts
+++ b/services/bot-client/src/utils/dashboard/refreshHandler.test.ts
@@ -19,6 +19,14 @@ vi.mock('./DashboardBuilder.js', () => ({
   buildDashboardComponents: vi.fn(),
 }));
 
+// Mock renderTerminalScreen so the NOT_FOUND branch can be asserted directly
+// on the call shape (session + content) rather than on the internal
+// editReply/sessionManager.delete calls it performs.
+const mockRenderTerminalScreen = vi.fn();
+vi.mock('./terminalScreen.js', () => ({
+  renderTerminalScreen: (...args: unknown[]) => mockRenderTerminalScreen(...args),
+}));
+
 describe('refreshHandler', () => {
   const mockSessionManager = {
     get: vi.fn(),
@@ -36,6 +44,11 @@ describe('refreshHandler', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockRenderTerminalScreen.mockReset();
+    mockSessionManager.get.mockReset();
+    // Default: no existing session. Individual tests override when they need
+    // an existing browseContext.
+    mockSessionManager.get.mockResolvedValue(null);
     vi.mocked(SessionManagerModule.getSessionManager).mockReturnValue(
       mockSessionManager as unknown as SessionManagerModule.DashboardSessionManager
     );
@@ -90,7 +103,7 @@ describe('refreshHandler', () => {
       });
     });
 
-    it('should show not found message when fetch returns null', async () => {
+    it('should route NOT_FOUND through renderTerminalScreen so Back-to-Browse is preserved', async () => {
       const fetchFn = vi.fn().mockResolvedValue(null);
 
       const handler = createRefreshHandler({
@@ -108,11 +121,45 @@ describe('refreshHandler', () => {
 
       await handler(interaction, 'entity-abc');
 
-      expect(interaction.editReply).toHaveBeenCalledWith({
-        content: '❌ Persona not found.',
-        embeds: [],
-        components: [],
+      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+        expect.objectContaining({
+          session: expect.objectContaining({
+            entityType: 'persona',
+            entityId: 'entity-abc',
+            browseContext: undefined,
+          }),
+          content: expect.stringContaining('Persona not found'),
+        })
+      );
+    });
+
+    it('should carry existing browseContext into the NOT_FOUND terminal screen', async () => {
+      const browseContext = { page: 2, filter: 'all', sort: 'name' };
+      mockSessionManager.get.mockResolvedValue({
+        data: { browseContext },
       });
+      const fetchFn = vi.fn().mockResolvedValue(null);
+
+      const handler = createRefreshHandler({
+        entityType: 'persona',
+        dashboardConfig: mockConfig,
+        fetchFn,
+        entityLabel: 'Persona',
+      });
+
+      const interaction = {
+        user: { id: 'user-123' },
+        deferUpdate: vi.fn(),
+        editReply: vi.fn(),
+      } as unknown as ButtonInteraction;
+
+      await handler(interaction, 'entity-abc');
+
+      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+        expect.objectContaining({
+          session: expect.objectContaining({ browseContext }),
+        })
+      );
     });
 
     it('should use buildOptions when provided', async () => {

--- a/services/bot-client/src/utils/dashboard/refreshHandler.ts
+++ b/services/bot-client/src/utils/dashboard/refreshHandler.ts
@@ -13,8 +13,9 @@ import {
   buildDashboardComponents,
   type ActionButtonOptions,
 } from './DashboardBuilder.js';
-import type { DashboardConfig } from './types.js';
+import type { BrowseContext, DashboardConfig } from './types.js';
 import { DASHBOARD_MESSAGES } from './messages.js';
+import { renderTerminalScreen, type BrowseCapableEntityType } from './terminalScreen.js';
 
 const logger = createLogger('dashboard-refresh');
 
@@ -70,13 +71,38 @@ export function createRefreshHandler<TData, TRaw = TData>(
   return async (interaction: ButtonInteraction, entityId: string): Promise<void> => {
     await interaction.deferUpdate();
 
+    // Fetch the existing session up-front so browseContext is available on
+    // both the happy path (preserved into the refreshed session) and the
+    // NOT_FOUND path (carried into the terminal screen so dashboards opened
+    // from /browse keep Back-to-Browse when the entity was deleted elsewhere).
+    const sessionManager = getSessionManager();
+    const existingSession = await sessionManager.get(interaction.user.id, entityType, entityId);
+    const existingData = existingSession?.data as Record<string, unknown> | undefined;
+    const existingBrowseContextRaw = existingData?.browseContext;
+    const hasBrowseContext =
+      existingBrowseContextRaw !== undefined &&
+      typeof existingBrowseContextRaw === 'object' &&
+      existingBrowseContextRaw !== null &&
+      'page' in existingBrowseContextRaw;
+    const existingBrowseContext = hasBrowseContext
+      ? (existingBrowseContextRaw as BrowseContext)
+      : undefined;
+
     const rawData = await fetchFn(entityId, toGatewayUser(interaction.user));
 
     if (rawData === null) {
-      await interaction.editReply({
+      // Entity gone (deleted elsewhere). If the user came from /browse,
+      // renderTerminalScreen preserves the Back-to-Browse affordance;
+      // otherwise it cleans up the session.
+      await renderTerminalScreen({
+        interaction,
+        session: {
+          userId: interaction.user.id,
+          entityType: entityType as BrowseCapableEntityType,
+          entityId,
+          browseContext: existingBrowseContext,
+        },
         content: DASHBOARD_MESSAGES.NOT_FOUND(entityLabel),
-        embeds: [],
-        components: [],
       });
       return;
     }
@@ -86,21 +112,9 @@ export function createRefreshHandler<TData, TRaw = TData>(
     // This cast is safe because the generic constraint requires callers to specify matching types.
     const data = transformFn !== undefined ? transformFn(rawData) : (rawData as unknown as TData);
 
-    // Get existing session to preserve browseContext (for back button navigation)
-    const sessionManager = getSessionManager();
-    const existingSession = await sessionManager.get(interaction.user.id, entityType, entityId);
-
-    // Preserve browseContext from existing session if present
-    // Type guard: browseContext is an object with page/filter/sort properties
-    const existingData = existingSession?.data as Record<string, unknown> | undefined;
-    const browseContext = existingData?.browseContext;
-    const hasBrowseContext =
-      browseContext !== undefined &&
-      typeof browseContext === 'object' &&
-      browseContext !== null &&
-      'page' in browseContext;
-
-    const dataWithContext = hasBrowseContext ? { ...data, browseContext } : data;
+    const dataWithContext = hasBrowseContext
+      ? { ...data, browseContext: existingBrowseContext }
+      : data;
 
     // Update session with preserved context
     await sessionManager.set({

--- a/services/bot-client/src/utils/dashboard/terminalScreen.structure.test.ts
+++ b/services/bot-client/src/utils/dashboard/terminalScreen.structure.test.ts
@@ -9,6 +9,8 @@ const ENFORCED_FILES = [
   'services/bot-client/src/commands/preset/dashboardButtons.ts',
   'services/bot-client/src/commands/character/dashboardButtons.ts',
   'services/bot-client/src/commands/character/dashboardDeleteHandlers.ts',
+  'services/bot-client/src/commands/persona/dashboard.ts',
+  'services/bot-client/src/utils/dashboard/refreshHandler.ts',
 ];
 
 const REPO_ROOT = resolve(__dirname, '../../../../..');


### PR DESCRIPTION
## Summary

- Migrates `/persona` dashboard terminal sites to `renderTerminalScreen` (sibling of PR #836 for preset, PR #842 for character).
- Also fixes the shared `createRefreshHandler` helper's NOT_FOUND branch — it was silently dropping Back-to-Browse when refresh found the entity deleted elsewhere. Persona uses this helper, so the fix benefits persona today and any future consumer tomorrow.

## Migrated terminal sites

**`persona/dashboard.ts`** (5 sites):
- `handleConfirmDeleteButton` — success + API-failure branches both route through `renderTerminalScreen` with browseContext from session. Explicit `sessionManager.delete` removed — `renderTerminalScreen` handles session cleanup internally when browseContext is absent.
- `handleBackButton` — no-context, browse-null-result, and exception branches all route through `renderTerminalScreen` with `browseContext: undefined` (re-adding the back-button would re-enter the failing path).

**`utils/dashboard/refreshHandler.ts`** (1 site + structural fix):
- NOT_FOUND branch now routes through `renderTerminalScreen`. Session fetch moved up-front so `browseContext` is available on **both** the happy path (preserved into the refreshed session) and the NOT_FOUND path (carried into the terminal screen).

## Why the shared-helper fix is worth doing here

The helper currently has one user (persona) but is the natural home for any future entity that needs the same refresh flow. Fixing it at the helper level means:
- Persona's refresh-not-found path is fixed without extra work in persona itself.
- Future commands using `createRefreshHandler` inherit the correct behavior by construction.
- One less instance of the rule-of-three pattern we've been migrating command-by-command.

Added to `ENFORCED_FILES` so future regressions on either file fail the structural test.

## Cancel-delete

Already correct in persona — `handleCancelDeleteButton` uses `refreshDashboardUI` to return to the dashboard. No `intentionally-raw` markers needed on persona/dashboard.ts (contrast with character, which doesn't have a shared refresh helper and left its cancel path with a marker).

## Test updates

**Same PGLite / mocking gotcha as PR #842**: `renderTerminalScreen` imports `getSessionManager` directly from `./SessionManager.js`, not via the barrel. Barrel-level mocks don't intercept. For this PR:
- `refreshHandler.test.ts` adds a source-level mock of `./terminalScreen.js` and asserts on the call shape directly.
- `persona/dashboard.test.ts` adds source-level mocks of both `./SessionManager.js` and `./terminalScreen.js`, plus a barrel mock that also points renderTerminalScreen at the same spy (so imports via either path hit the mock).

New tests exercise browseContext carry-through explicitly:
- `refreshHandler.test.ts`: \"should carry existing browseContext into the NOT_FOUND terminal screen\"
- `persona/dashboard.test.ts`: \"should carry browseContext from session into the terminal screen on confirm-delete\"

## Test plan

- [x] `pnpm test` — 4316/4316 pass (up from 4312 — three new tests)
- [x] `pnpm quality` — lint + cpd + depcruise + typecheck + typecheck:spec all green
- [ ] Manual dev verification after auto-deploy: open a persona dashboard from `/persona browse`, delete it, verify success message has Back-to-Browse button; delete a persona from `/persona view` (no browse context), verify clean terminal

## Related PRs

- PR #836 (shipped in beta.101) — preset
- PR #842 (open) — character
- This PR — persona
- Deny — next up

🤖 Generated with [Claude Code](https://claude.com/claude-code)