### PR TITLE
fix(bot-client): deny back-to-browse enforcement (via intentionally-raw markers)

### DIFF
--- a/services/bot-client/src/commands/deny/detail.ts
+++ b/services/bot-client/src/commands/deny/detail.ts
@@ -7,6 +7,16 @@
  *
  * UI builders and types are in detailTypes.ts.
  * Edit modal handlers are in detailEdit.ts.
+ *
+ * Back-to-Browse UX note: unlike `/preset`, `/character`, and `/persona`, the
+ * deny detail view does NOT use `renderTerminalScreen`'s Back-to-Browse
+ * button pattern. `handleConfirmDelete` (success path) and `handleBack`
+ * manually re-fetch entries and re-render the browse list directly, which
+ * saves a click versus the Back-to-Browse + click + re-render flow the other
+ * commands use. Terminal error paths in this file are intentionally plain
+ * `editReply({ components: [] })` — see each site's `intentionally-raw:`
+ * marker for the per-site reason. This file is in ENFORCED_FILES so any NEW
+ * terminal path must either use `renderTerminalScreen` or add its own marker.
  */
 
 import type { ButtonInteraction, ModalSubmitInteraction } from 'discord.js';
@@ -27,10 +37,13 @@ const logger = createLogger('deny-detail');
 async function replyExpired(interaction: {
   editReply: ButtonInteraction['editReply'];
 }): Promise<void> {
+  // intentionally-raw: session-expired helper has no access to browseContext
+  // (it's a generic utility called from multiple sites where the caller
+  // couldn't even load the session). Recovery path is in the content text.
   await interaction.editReply({
     content: `${DASHBOARD_MESSAGES.SESSION_EXPIRED} Use \`/deny browse\` to view entries again.`,
     embeds: [],
-    components: [],
+    components: [], // intentionally-raw: see file-top UX note.
   });
 }
 
@@ -121,10 +134,12 @@ async function handleModeToggle(interaction: ButtonInteraction, entryId: string)
     );
 
     if (!response.ok) {
+      // intentionally-raw: deny uses manual re-render for back-to-browse (see
+      // file-top comment); terminal error path, session remains for retry.
       await interaction.editReply({
         content: DASHBOARD_MESSAGES.OPERATION_FAILED('toggle mode'),
         embeds: [],
-        components: [],
+        components: [], // intentionally-raw: see file-top UX note.
       });
       return;
     }
@@ -140,10 +155,12 @@ async function handleModeToggle(interaction: ButtonInteraction, entryId: string)
     });
   } catch (error) {
     logger.error({ err: error }, '[Deny] Failed to toggle mode');
+    // intentionally-raw: terminal exception path; see file-top comment for
+    // why deny doesn't use renderTerminalScreen's Back-to-Browse pattern.
     await interaction.editReply({
       content: DASHBOARD_MESSAGES.OPERATION_FAILED('toggle mode'),
       embeds: [],
-      components: [],
+      components: [], // intentionally-raw: see file-top UX note.
     });
   }
 }
@@ -180,10 +197,12 @@ async function handleConfirmDelete(interaction: ButtonInteraction, entryId: stri
     });
 
     if (!response.ok && response.status !== 404) {
+      // intentionally-raw: delete-API-failure terminal path; session still
+      // valid so user can retry. Deny doesn't use Back-to-Browse button.
       await interaction.editReply({
         content: DASHBOARD_MESSAGES.OPERATION_FAILED('delete entry'),
         embeds: [],
-        components: [],
+        components: [], // intentionally-raw: see file-top UX note.
       });
       return;
     }
@@ -209,17 +228,21 @@ async function handleConfirmDelete(interaction: ButtonInteraction, entryId: stri
       return;
     }
 
+    // intentionally-raw: delete succeeded + browse list is now empty — no
+    // meaningful browse to go back to, clean terminal is correct.
     await interaction.editReply({
       content: `\u2705 Denylist entry for ${data.type} \`${data.discordId}\` has been deleted. No entries remaining.`,
       embeds: [],
-      components: [],
+      components: [], // intentionally-raw: see file-top UX note.
     });
   } catch (error) {
     logger.error({ err: error }, '[Deny] Failed to delete entry');
+    // intentionally-raw: delete-exception terminal path; session already
+    // cleaned up so no retry possible. Clean terminal per file-top UX note.
     await interaction.editReply({
       content: DASHBOARD_MESSAGES.OPERATION_FAILED('delete entry'),
       embeds: [],
-      components: [],
+      components: [], // intentionally-raw: see file-top UX note.
     });
   }
 }
@@ -249,10 +272,12 @@ async function handleBack(interaction: ButtonInteraction, entryId: string): Prom
   const { fetchEntries, buildBrowseResponse } = await import('./browse.js');
   const entries = await fetchEntries(interaction.user.id);
   if (entries === null) {
+    // intentionally-raw: back-to-browse itself failed; adding a Back-to-Browse
+    // button would just loop into the same failing fetch. Clean terminal.
     await interaction.editReply({
       content: '\u274C Failed to fetch denylist entries.',
       embeds: [],
-      components: [],
+      components: [], // intentionally-raw: see file-top UX note.
     });
     return;
   }

--- a/services/bot-client/src/commands/deny/detailEdit.ts
+++ b/services/bot-client/src/commands/deny/detailEdit.ts
@@ -112,6 +112,9 @@ export async function handleEditModal(
 
   const validationError = validateEditInput(newScope, newScopeId, newReason);
   if (validationError !== null) {
+    // intentionally-raw: deny uses manual re-render for back-to-browse (see
+    // detail.ts file-top comment). Validation error is terminal; session
+    // remains so user can re-edit.
     await interaction.editReply({ content: validationError, embeds: [], components: [] });
     return;
   }
@@ -134,9 +137,12 @@ export async function handleEditModal(
 
     if (!upsertResponse.ok) {
       const body = (await upsertResponse.json()) as { message?: string };
+      // Edit-API-failure terminal path; deny doesn't use the Back-to-Browse
+      // button pattern (see detail.ts file-top comment).
       await interaction.editReply({
         content: `\u274C Failed to update: ${body.message ?? 'Unknown error'}`,
         embeds: [],
+        // intentionally-raw: see block comment above.
         components: [],
       });
       return;
@@ -186,9 +192,12 @@ export async function handleEditModal(
     await interaction.editReply({ embeds: [embed], components });
   } catch (error) {
     logger.error({ err: error }, '[Deny] Failed to edit entry');
+    // Edit-exception terminal path; deny doesn't use the Back-to-Browse
+    // button pattern (see detail.ts file-top comment).
     await interaction.editReply({
       content: DASHBOARD_MESSAGES.OPERATION_FAILED('update entry'),
       embeds: [],
+      // intentionally-raw: see block comment above.
       components: [],
     });
   }

--- a/services/bot-client/src/utils/dashboard/terminalScreen.structure.test.ts
+++ b/services/bot-client/src/utils/dashboard/terminalScreen.structure.test.ts
@@ -11,6 +11,8 @@ const ENFORCED_FILES = [
   'services/bot-client/src/commands/character/dashboardDeleteHandlers.ts',
   'services/bot-client/src/commands/persona/dashboard.ts',
   'services/bot-client/src/utils/dashboard/refreshHandler.ts',
+  'services/bot-client/src/commands/deny/detail.ts',
+  'services/bot-client/src/commands/deny/detailEdit.ts',
 ];
 
 const REPO_ROOT = resolve(__dirname, '../../../../..');


### PR DESCRIPTION
## Summary

Completes the rule-of-three back-to-browse sweep (preset PR #836, character PR #842, persona PR #843, deny = this PR).

**Deny is different on purpose** — no renderTerminalScreen migration here. Instead, formal enforcement via `intentionally-raw:` markers + ENFORCED_FILES entry.

## Why deny's UX diverges from the other three

`handleConfirmDelete` (success path, `detail.ts:193-210`) and `handleBack` (`detail.ts:246-267`) both manually re-fetch entries and re-render the browse list directly. That saves a click versus the preset/character/persona pattern (terminal screen → Back-to-Browse button → click → re-render). For deny it's **better UX to leave as-is**.

Because the divergence is deliberate, force-migrating the terminal error paths to `renderTerminalScreen` would either:
- Downgrade the success path (insert a Back-to-Browse button where direct re-render was already doing the job), or
- Require plumbing `BrowseCapableEntityType` to accept `'deny-detail'` (the session storage type) + adjusting the button customId convention (`deny::back::...` is what the existing router expects) — structural changes out of scope here.

## What this PR does

**Enforcement**: adds `deny/detail.ts` and `deny/detailEdit.ts` to `ENFORCED_FILES` in `terminalScreen.structure.test.ts`.

**Documentation**: new file-top block comment on `detail.ts` explaining the UX divergence — pointer for future contributors.

**Opt-outs**: marks each existing raw `components: []` terminal site with `intentionally-raw:` + per-site reason. Two layers:
1. A block comment above each site with the specific justification (e.g., \"session-expired helper has no access to browseContext\", \"delete-API-failure terminal path\", \"back-to-browse itself failed — would loop\").
2. A same-line trailing marker on the `components: []` line itself (the structural test's 3-line opt-out window requires the marker be close to the offending line; block comments at function-top were outside the window).

## Files touched

- `services/bot-client/src/commands/deny/detail.ts` — file-top UX note + 7 opt-out markers
- `services/bot-client/src/commands/deny/detailEdit.ts` — 3 opt-out markers
- `services/bot-client/src/utils/dashboard/terminalScreen.structure.test.ts` — extends `ENFORCED_FILES`

## What this protects against

A future contributor adding a new terminal path to deny must either:
- Use `renderTerminalScreen` (if the UX should drift back toward the convention), or
- Add an explicit `intentionally-raw:` marker with justification.

Silent regressions where someone drops `components: []` into a terminal path without thinking about back-to-browse now fail the structural test.

## Test plan

- [x] `pnpm test` — 4316/4316 pass (no behavior changes)
- [x] `pnpm quality` — lint + cpd + depcruise + typecheck all green

## Sweep complete

With this PR, all four browse-capable commands have their terminal paths structurally guarded:

| Command   | Pattern                                 | PR      |
| --------- | --------------------------------------- | ------- |
| preset    | `renderTerminalScreen` + Back-to-Browse | #836    |
| character | `renderTerminalScreen` + Back-to-Browse | #842    |
| persona   | `renderTerminalScreen` + Back-to-Browse | #843    |
| deny      | Manual re-render + `intentionally-raw:` | this    |

🤖 Generated with [Claude Code](https://claude.com/claude-code)