### PR TITLE
feat(bot-client): hybrid post-action UX infrastructure (PR 1 of 2)

### DIFF
--- a/services/bot-client/src/utils/dashboard/SessionManager.test.ts
+++ b/services/bot-client/src/utils/dashboard/SessionManager.test.ts
@@ -133,6 +133,50 @@ describe('DashboardSessionManager', () => {
     vi.useRealTimers();
   });
 
+  describe('set: serialization assertion (dev-mode)', () => {
+    // Callbacks stored in session data silently become `undefined` on
+    // Redis rehydration. The assertion should catch this class of bug
+    // at write time, with a clear error pointing at the offending key.
+    it('throws when session.data contains a top-level function', async () => {
+      await expect(
+        manager.set({
+          userId: 'user1',
+          entityType: 'preset',
+          entityId: 'e1',
+          data: { rebuildBrowse: () => undefined } as unknown,
+          messageId: 'msg1',
+          channelId: 'ch1',
+        })
+      ).rejects.toThrow(/function at key "rebuildBrowse"/);
+    });
+
+    it('throws when session.data contains a nested function', async () => {
+      await expect(
+        manager.set({
+          userId: 'user1',
+          entityType: 'preset',
+          entityId: 'e1',
+          data: { browseContext: { page: 0, rebuild: () => 1 } } as unknown,
+          messageId: 'msg1',
+          channelId: 'ch1',
+        })
+      ).rejects.toThrow(/function at key "rebuild"/);
+    });
+
+    it('allows plain JSON-safe data', async () => {
+      await expect(
+        manager.set({
+          userId: 'user1',
+          entityType: 'preset',
+          entityId: 'e1',
+          data: { name: 'foo', nested: { n: 1, s: 'bar', arr: [1, 2, 3] } },
+          messageId: 'msg1',
+          channelId: 'ch1',
+        })
+      ).resolves.toBeDefined();
+    });
+  });
+
   describe('set and get', () => {
     it('should create a new session', async () => {
       const data: TestData = { name: 'test', value: 42 };

--- a/services/bot-client/src/utils/dashboard/SessionManager.ts
+++ b/services/bot-client/src/utils/dashboard/SessionManager.ts
@@ -67,22 +67,19 @@ function assertSessionDataIsSerializable(data: unknown): void {
   if (process.env.NODE_ENV === 'production') {
     return;
   }
-  try {
-    JSON.stringify(data, (key: string, value: unknown) => {
-      if (typeof value === 'function') {
-        throw new Error(
-          `SessionManager: session.data contains a function at key "${key}". ` +
-            `Sessions are Redis-backed JSON; functions cannot be persisted. ` +
-            `Use a module-level registry (e.g., browseRebuilderRegistry) instead.`
-        );
-      }
-      return value;
-    });
-  } catch (err) {
-    // Re-throw with our own message preserved; swallowing hides the class
-    // of bug we're trying to surface.
-    throw err instanceof Error ? err : new Error(String(err));
-  }
+  // Any throw inside the replacer propagates out of JSON.stringify as-is,
+  // so no try/catch wrapper is needed — the replacer only ever throws the
+  // Error instance constructed below.
+  JSON.stringify(data, (key: string, value: unknown) => {
+    if (typeof value === 'function') {
+      throw new Error(
+        `SessionManager: session.data contains a function at key "${key}". ` +
+          `Sessions are Redis-backed JSON; functions cannot be persisted. ` +
+          `Use a module-level registry (e.g., browseRebuilderRegistry) instead.`
+      );
+    }
+    return value;
+  });
 }
 
 /**

--- a/services/bot-client/src/utils/dashboard/SessionManager.ts
+++ b/services/bot-client/src/utils/dashboard/SessionManager.ts
@@ -50,6 +50,42 @@ interface SetSessionOptions<T> {
 const DEFAULT_SESSION_TTL_SECONDS = 15 * 60;
 
 /**
+ * Dev-mode guard against stashing functions in session data. Sessions are
+ * Redis-backed JSON; functions silently become `undefined` on rehydration,
+ * which is the kind of bug that's nearly impossible to debug from the
+ * symptom (e.g., `session.data.rebuildBrowse is not a function` after
+ * rehydration with no obvious cause).
+ *
+ * This runs on every `set()` call in non-production builds. It uses the
+ * `JSON.stringify` replacer callback to throw at the exact key where the
+ * function lives — precise and cheap.
+ *
+ * The rule: session data is a pure JSON document. Keep callbacks in module
+ * registries (see `browseRebuilderRegistry.ts`), not in session state.
+ */
+function assertSessionDataIsSerializable(data: unknown): void {
+  if (process.env.NODE_ENV === 'production') {
+    return;
+  }
+  try {
+    JSON.stringify(data, (key: string, value: unknown) => {
+      if (typeof value === 'function') {
+        throw new Error(
+          `SessionManager: session.data contains a function at key "${key}". ` +
+            `Sessions are Redis-backed JSON; functions cannot be persisted. ` +
+            `Use a module-level registry (e.g., browseRebuilderRegistry) instead.`
+        );
+      }
+      return value;
+    });
+  } catch (err) {
+    // Re-throw with our own message preserved; swallowing hides the class
+    // of bug we're trying to surface.
+    throw err instanceof Error ? err : new Error(String(err));
+  }
+}
+
+/**
  * Maximum sessions per user (bounded query protection)
  */
 const MAX_SESSIONS_PER_USER = 100;
@@ -147,6 +183,12 @@ export class DashboardSessionManager {
    */
   async set<T>(options: SetSessionOptions<T>): Promise<DashboardSession<T>> {
     const { userId, entityType, entityId, data, messageId, channelId } = options;
+
+    // Dev-only: catch attempts to stash non-serializable values (functions,
+    // class methods) in session data before they silently become undefined
+    // on rehydration. See `assertSessionDataIsSerializable` for rationale.
+    assertSessionDataIsSerializable(data);
+
     const sessionKey = buildSessionKey(userId, entityType, entityId);
     const msgIndexKey = buildMessageIndexKey(messageId);
     const now = new Date();

--- a/services/bot-client/src/utils/dashboard/browseRebuilderRegistry.test.ts
+++ b/services/bot-client/src/utils/dashboard/browseRebuilderRegistry.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { ButtonInteraction } from 'discord.js';
+import type { BrowseContext } from './types.js';
+import {
+  registerBrowseRebuilder,
+  getBrowseRebuilder,
+  clearBrowseRegistry,
+  type BrowseRebuilder,
+} from './browseRebuilderRegistry.js';
+
+const noopInteraction = {} as ButtonInteraction;
+const noopContext: BrowseContext = { source: 'browse', page: 0, filter: 'all' };
+
+function makeRebuilder(): BrowseRebuilder {
+  return vi.fn(async () => ({ content: 'banner', embeds: [], components: [] }));
+}
+
+describe('browseRebuilderRegistry', () => {
+  beforeEach(() => {
+    clearBrowseRegistry();
+  });
+
+  it('returns undefined for unregistered entity types', () => {
+    expect(getBrowseRebuilder('preset')).toBeUndefined();
+  });
+
+  it('registers and retrieves a rebuilder', async () => {
+    const rebuilder = makeRebuilder();
+    registerBrowseRebuilder('preset', rebuilder);
+
+    const looked = getBrowseRebuilder('preset');
+    expect(looked).toBe(rebuilder);
+
+    // Sanity: the registered function is actually callable.
+    await looked?.(noopInteraction, noopContext, 'banner');
+    expect(rebuilder).toHaveBeenCalledWith(noopInteraction, noopContext, 'banner');
+  });
+
+  it('is idempotent for the same function reference', () => {
+    const rebuilder = makeRebuilder();
+    registerBrowseRebuilder('character', rebuilder);
+    expect(() => registerBrowseRebuilder('character', rebuilder)).not.toThrow();
+    expect(getBrowseRebuilder('character')).toBe(rebuilder);
+  });
+
+  it('throws when registering a different function for the same entity type', () => {
+    registerBrowseRebuilder('persona', makeRebuilder());
+    expect(() => registerBrowseRebuilder('persona', makeRebuilder())).toThrow(
+      /BrowseRebuilder conflict for entity type "persona"/
+    );
+  });
+
+  it('supports independent registration for each entity type', () => {
+    const preset = makeRebuilder();
+    const character = makeRebuilder();
+    const persona = makeRebuilder();
+    const deny = makeRebuilder();
+
+    registerBrowseRebuilder('preset', preset);
+    registerBrowseRebuilder('character', character);
+    registerBrowseRebuilder('persona', persona);
+    registerBrowseRebuilder('deny', deny);
+
+    expect(getBrowseRebuilder('preset')).toBe(preset);
+    expect(getBrowseRebuilder('character')).toBe(character);
+    expect(getBrowseRebuilder('persona')).toBe(persona);
+    expect(getBrowseRebuilder('deny')).toBe(deny);
+  });
+
+  it('clearBrowseRegistry removes all registered rebuilders', () => {
+    registerBrowseRebuilder('preset', makeRebuilder());
+    registerBrowseRebuilder('deny', makeRebuilder());
+    clearBrowseRegistry();
+    expect(getBrowseRebuilder('preset')).toBeUndefined();
+    expect(getBrowseRebuilder('deny')).toBeUndefined();
+  });
+});

--- a/services/bot-client/src/utils/dashboard/browseRebuilderRegistry.ts
+++ b/services/bot-client/src/utils/dashboard/browseRebuilderRegistry.ts
@@ -1,0 +1,80 @@
+// Module-level registry mapping each browse-capable command to an adapter that
+// rebuilds its browse view from a preserved BrowseContext. Keyed by the closed
+// `BrowseCapableEntityType` union (NOT `string`) so typos fail at compile time
+// rather than silently returning undefined at runtime.
+//
+// Why a registry instead of a callback on BrowseContext: DashboardSession data
+// is Redis-backed JSON. Functions don't serialize, so storing the adapter on
+// the session would become `undefined` on rehydration. The registry lives in
+// process memory and is populated at module-load time via
+// `registerBrowseRebuilder` calls at the bottom of each command's browse.ts.
+
+import type { ButtonInteraction, MessageEditOptions } from 'discord.js';
+import type { BrowseCapableEntityType } from './terminalScreen.js';
+import type { BrowseContext } from './types.js';
+
+/**
+ * The shape of a rebuilt browse view, narrow-matched to what
+ * `interaction.editReply` accepts. Each command's adapter assembles this from
+ * its own `buildBrowseResponse` + any required pre-fetch (deny fetches entries
+ * first, character needs the `client` + config, etc.).
+ *
+ * Returning `null` signals "rebuild failed" — caller (postActionScreen /
+ * sharedBackButtonHandler) falls through to the error terminal.
+ */
+export type BrowseRebuildResult = Pick<MessageEditOptions, 'content' | 'embeds' | 'components'>;
+
+/**
+ * Command-specific adapter. Takes the live interaction (for `client`,
+ * `user.id`, and access to `interaction.editReply` context if needed), the
+ * preserved browse coordinates, and an optional success banner to render as
+ * the `content` field above the rebuilt browse embed. Returns the message
+ * payload for `editReply`, or `null` if the rebuild itself failed.
+ */
+export type BrowseRebuilder = (
+  interaction: ButtonInteraction,
+  browseContext: BrowseContext,
+  successBanner?: string
+) => Promise<BrowseRebuildResult | null>;
+
+const registry = new Map<BrowseCapableEntityType, BrowseRebuilder>();
+
+/**
+ * Register a browse-rebuilder for an entity type. Idempotent for the same
+ * function reference (tolerates module re-import in tests), but throws on
+ * registering a different function for a type that's already registered —
+ * that usually indicates two commands claiming the same key, which would
+ * produce silent dispatch errors at runtime.
+ */
+export function registerBrowseRebuilder(
+  entityType: BrowseCapableEntityType,
+  rebuilder: BrowseRebuilder
+): void {
+  const existing = registry.get(entityType);
+  if (existing !== undefined && existing !== rebuilder) {
+    throw new Error(
+      `BrowseRebuilder conflict for entity type "${entityType}": a different rebuilder is already registered. ` +
+        `This usually indicates two commands claiming the same BrowseCapableEntityType key.`
+    );
+  }
+  registry.set(entityType, rebuilder);
+}
+
+/**
+ * Look up the registered rebuilder for an entity type. Returns `undefined`
+ * when nothing is registered — callers must handle this case explicitly
+ * (postActionScreen logs a warning and falls through to error terminal).
+ */
+export function getBrowseRebuilder(
+  entityType: BrowseCapableEntityType
+): BrowseRebuilder | undefined {
+  return registry.get(entityType);
+}
+
+/**
+ * Test-only helper to reset the registry between test cases. Production code
+ * never calls this.
+ */
+export function clearBrowseRegistry(): void {
+  registry.clear();
+}

--- a/services/bot-client/src/utils/dashboard/index.ts
+++ b/services/bot-client/src/utils/dashboard/index.ts
@@ -45,7 +45,11 @@ export { buildSectionModal, extractModalValues } from './ModalFactory.js';
 export { initSessionManager, getSessionManager, shutdownSessionManager } from './SessionManager.js';
 
 // Messages
-export { DASHBOARD_MESSAGES, formatSessionExpiredMessage } from './messages.js';
+export {
+  DASHBOARD_MESSAGES,
+  formatSessionExpiredMessage,
+  formatSuccessBanner,
+} from './messages.js';
 
 // Close Handler
 export { handleDashboardClose } from './closeHandler.js';
@@ -57,6 +61,29 @@ export {
   type TerminalScreenOptions,
   type TerminalScreenSession,
 } from './terminalScreen.js';
+
+// Post-Action Screen (hybrid success=rebuild / error=terminal dispatcher)
+export {
+  renderPostActionScreen,
+  type PostActionOutcome,
+  type PostActionScreenOptions,
+} from './postActionScreen.js';
+
+// Shared Back-to-Browse button handler (used by renderTerminalScreen's back
+// button + renderPostActionScreen's error fallback). PR 2 wires per-command
+// back-button routers to this.
+export { handleSharedBackButton } from './sharedBackButtonHandler.js';
+
+// Browse-rebuilder registry — command browse modules call
+// `registerBrowseRebuilder` at module-load time; helpers above look up by
+// entity type.
+export {
+  registerBrowseRebuilder,
+  getBrowseRebuilder,
+  clearBrowseRegistry,
+  type BrowseRebuilder,
+  type BrowseRebuildResult,
+} from './browseRebuilderRegistry.js';
 
 // Session Helpers
 export {

--- a/services/bot-client/src/utils/dashboard/index.ts
+++ b/services/bot-client/src/utils/dashboard/index.ts
@@ -76,11 +76,11 @@ export { handleSharedBackButton } from './sharedBackButtonHandler.js';
 
 // Browse-rebuilder registry — command browse modules call
 // `registerBrowseRebuilder` at module-load time; helpers above look up by
-// entity type.
+// entity type. `clearBrowseRegistry` is intentionally NOT re-exported here:
+// it's a test-only helper and tests import from the source module directly.
 export {
   registerBrowseRebuilder,
   getBrowseRebuilder,
-  clearBrowseRegistry,
   type BrowseRebuilder,
   type BrowseRebuildResult,
 } from './browseRebuilderRegistry.js';

--- a/services/bot-client/src/utils/dashboard/messages.test.ts
+++ b/services/bot-client/src/utils/dashboard/messages.test.ts
@@ -7,6 +7,7 @@ import {
   DASHBOARD_MESSAGES,
   formatSessionExpiredMessage,
   formatNotFoundMessage,
+  formatSuccessBanner,
 } from './messages.js';
 
 describe('DASHBOARD_MESSAGES', () => {
@@ -64,5 +65,24 @@ describe('formatNotFoundMessage', () => {
 
   it('should handle undefined entity name', () => {
     expect(formatNotFoundMessage('Persona', undefined)).toBe('❌ Persona not found.');
+  });
+});
+
+describe('formatSuccessBanner', () => {
+  // Snapshot-test the exact shape — banner format is load-bearing for mobile
+  // visibility (bright emoji + bold). Any change should be deliberate.
+  it('renders a success banner with bright emoji and bolded verb', () => {
+    expect(formatSuccessBanner('Deleted', 'MyPreset')).toBe('✅ **Deleted** · MyPreset');
+  });
+
+  it('handles special characters in the entity name', () => {
+    expect(formatSuccessBanner('Updated', 'Preset with "quotes" & stuff')).toBe(
+      '✅ **Updated** · Preset with "quotes" & stuff'
+    );
+  });
+
+  it('supports different verbs', () => {
+    expect(formatSuccessBanner('Archived', 'X')).toBe('✅ **Archived** · X');
+    expect(formatSuccessBanner('Cloned', 'Y')).toBe('✅ **Cloned** · Y');
   });
 });

--- a/services/bot-client/src/utils/dashboard/messages.ts
+++ b/services/bot-client/src/utils/dashboard/messages.ts
@@ -74,3 +74,18 @@ export function formatNotFoundMessage(entityType: string, entityName?: string): 
   }
   return `❌ ${entityType} not found.`;
 }
+
+/**
+ * Format a post-action success banner for Pattern B (direct re-render with a
+ * short banner in `editReply.content`). Used by the hybrid post-action flow.
+ *
+ * Bright emoji + bold verb is deliberate: Discord's mobile client
+ * de-emphasizes the `content` field when a large embed sits directly below,
+ * so the banner has to be visually distinctive to remain scannable.
+ *
+ * @example
+ *   formatSuccessBanner('Deleted', 'MyPreset') // '✅ **Deleted** · MyPreset'
+ */
+export function formatSuccessBanner(verb: string, entityName: string): string {
+  return `✅ **${verb}** · ${entityName}`;
+}

--- a/services/bot-client/src/utils/dashboard/postActionScreen.test.ts
+++ b/services/bot-client/src/utils/dashboard/postActionScreen.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { ButtonInteraction } from 'discord.js';
+import type { BrowseContext } from './types.js';
+import type { TerminalScreenSession } from './terminalScreen.js';
+
+// Mock renderTerminalScreen so we can assert how the post-action helper
+// delegates to it without exercising its internals (tested separately).
+const mockRenderTerminalScreen = vi.fn();
+vi.mock('./terminalScreen.js', () => ({
+  renderTerminalScreen: (...args: unknown[]) => mockRenderTerminalScreen(...args),
+}));
+
+// Mock session manager so we can assert session deletion on the success path.
+const mockSessionDelete = vi.fn();
+vi.mock('./SessionManager.js', () => ({
+  getSessionManager: () => ({ delete: mockSessionDelete }),
+}));
+
+import { renderPostActionScreen } from './postActionScreen.js';
+import {
+  registerBrowseRebuilder,
+  clearBrowseRegistry,
+  type BrowseRebuilder,
+} from './browseRebuilderRegistry.js';
+
+const browseContext: BrowseContext = {
+  source: 'browse',
+  page: 1,
+  filter: 'all',
+  sort: 'name',
+};
+
+function makeInteraction(): ButtonInteraction {
+  return { editReply: vi.fn() } as unknown as ButtonInteraction;
+}
+
+function makeSession(overrides: Partial<TerminalScreenSession> = {}): TerminalScreenSession {
+  return {
+    userId: 'user-1',
+    entityType: 'preset',
+    entityId: 'entity-1',
+    browseContext,
+    ...overrides,
+  };
+}
+
+describe('renderPostActionScreen', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearBrowseRegistry();
+  });
+
+  describe('success path with browseContext', () => {
+    it('calls the registered rebuilder, deletes the session, and editReplies the rebuilt view', async () => {
+      const rebuilt = { content: 'banner', embeds: [], components: [] };
+      const rebuilder: BrowseRebuilder = vi.fn(async () => rebuilt);
+      registerBrowseRebuilder('preset', rebuilder);
+
+      const interaction = makeInteraction();
+      const session = makeSession();
+
+      await renderPostActionScreen({
+        interaction,
+        session,
+        outcome: { kind: 'success', banner: '✅ **Deleted** · MyPreset' },
+      });
+
+      expect(rebuilder).toHaveBeenCalledWith(
+        interaction,
+        browseContext,
+        '✅ **Deleted** · MyPreset'
+      );
+      expect(mockSessionDelete).toHaveBeenCalledWith('user-1', 'preset', 'entity-1');
+      expect(interaction.editReply).toHaveBeenCalledWith(rebuilt);
+      expect(mockRenderTerminalScreen).not.toHaveBeenCalled();
+    });
+
+    it('falls through to error terminal when no rebuilder is registered for the entity type', async () => {
+      // Deliberately DO NOT register a rebuilder
+      const interaction = makeInteraction();
+      const session = makeSession();
+
+      await renderPostActionScreen({
+        interaction,
+        session,
+        outcome: { kind: 'success', banner: '✅ **Deleted** · MyPreset' },
+      });
+
+      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+        expect.objectContaining({
+          interaction,
+          session,
+          content: expect.stringContaining('✅ **Deleted** · MyPreset'),
+        })
+      );
+      // Banner preserved + error note appended
+      expect(mockRenderTerminalScreen.mock.calls[0]?.[0].content).toMatch(
+        /Could not reload the browse list/
+      );
+      expect(mockSessionDelete).not.toHaveBeenCalled();
+    });
+
+    it('falls through to error terminal when rebuilder returns null (rebuild failed)', async () => {
+      const rebuilder: BrowseRebuilder = vi.fn(async () => null);
+      registerBrowseRebuilder('preset', rebuilder);
+
+      const interaction = makeInteraction();
+      const session = makeSession();
+
+      await renderPostActionScreen({
+        interaction,
+        session,
+        outcome: { kind: 'success', banner: '✅ **Deleted** · MyPreset' },
+      });
+
+      expect(rebuilder).toHaveBeenCalled();
+      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining('Could not reload the browse list'),
+        })
+      );
+      // Session NOT deleted on fallback path — terminal screen handles cleanup
+      expect(mockSessionDelete).not.toHaveBeenCalled();
+    });
+
+    it('falls through to error terminal when rebuilder throws', async () => {
+      const rebuilder: BrowseRebuilder = vi.fn(async () => {
+        throw new Error('network down');
+      });
+      registerBrowseRebuilder('preset', rebuilder);
+
+      const interaction = makeInteraction();
+      const session = makeSession();
+
+      await renderPostActionScreen({
+        interaction,
+        session,
+        outcome: { kind: 'success', banner: '✅ **Deleted** · MyPreset' },
+      });
+
+      expect(rebuilder).toHaveBeenCalled();
+      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining('Could not reload the browse list'),
+        })
+      );
+    });
+  });
+
+  describe('success path without browseContext', () => {
+    it('renders a clean terminal with the banner as content', async () => {
+      const interaction = makeInteraction();
+      const session = makeSession({ browseContext: undefined });
+
+      await renderPostActionScreen({
+        interaction,
+        session,
+        outcome: { kind: 'success', banner: '✅ **Deleted** · MyPreset' },
+      });
+
+      // No rebuilder call, no session-delete from us (renderTerminalScreen handles it)
+      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+        expect.objectContaining({
+          interaction,
+          session,
+          content: '✅ **Deleted** · MyPreset',
+        })
+      );
+    });
+
+    it('handles a null session (no session was ever created)', async () => {
+      const interaction = makeInteraction();
+
+      await renderPostActionScreen({
+        interaction,
+        session: null,
+        outcome: { kind: 'success', banner: '✅ Done' },
+      });
+
+      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+        expect.objectContaining({ session: null, content: '✅ Done' })
+      );
+    });
+  });
+
+  describe('error path', () => {
+    it('delegates to renderTerminalScreen with context for the Back-to-Browse button', async () => {
+      const interaction = makeInteraction();
+      const session = makeSession();
+
+      await renderPostActionScreen({
+        interaction,
+        session,
+        outcome: { kind: 'error', content: '❌ Failed to delete preset.' },
+      });
+
+      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+        expect.objectContaining({
+          interaction,
+          session,
+          content: '❌ Failed to delete preset.',
+        })
+      );
+      // Error path does NOT call the rebuilder, even when one is registered
+      // and browseContext is present.
+    });
+
+    it('delegates to renderTerminalScreen without context for a clean terminal', async () => {
+      const interaction = makeInteraction();
+      const session = makeSession({ browseContext: undefined });
+
+      await renderPostActionScreen({
+        interaction,
+        session,
+        outcome: { kind: 'error', content: '❌ Failed.' },
+      });
+
+      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+        expect.objectContaining({ session, content: '❌ Failed.' })
+      );
+    });
+  });
+});

--- a/services/bot-client/src/utils/dashboard/postActionScreen.ts
+++ b/services/bot-client/src/utils/dashboard/postActionScreen.ts
@@ -1,0 +1,135 @@
+// Hybrid post-action screen: success = direct re-render of browse list with a
+// banner in `content` (saves a click); error = terminal screen with
+// Back-to-Browse button (forces acknowledgement). Routes to the command's
+// registered browse-rebuilder by `session.entityType`.
+//
+// Callers: destructive-action handlers (delete-confirm, etc.) across the four
+// browse-capable commands. Each command's terminal handler invokes this with
+// `outcome: { kind: 'success', banner: ... }` on success and
+// `{ kind: 'error', content: ... }` on failure.
+
+import type { ButtonInteraction } from 'discord.js';
+import { createLogger } from '@tzurot/common-types';
+import { renderTerminalScreen, type TerminalScreenSession } from './terminalScreen.js';
+import { getBrowseRebuilder } from './browseRebuilderRegistry.js';
+
+const logger = createLogger('postActionScreen');
+
+/**
+ * Outcome of a post-action flow.
+ *
+ * - `success`: destructive action completed. `banner` is the short,
+ *   visually distinct message to render in `editReply.content` above the
+ *   refreshed browse list (e.g. `✅ **Deleted** · MyPreset`). Mobile
+ *   Discord clients can de-emphasize the `content` field when a large
+ *   embed sits below it — keep banners bold + emoji so they remain
+ *   scannable. Use `formatSuccessBanner` from `messages.ts` for consistent
+ *   shape.
+ * - `error`: destructive action failed. `content` is the full error
+ *   message to render as the terminal screen body.
+ */
+export type PostActionOutcome =
+  | { kind: 'success'; banner: string }
+  | { kind: 'error'; content: string };
+
+export interface PostActionScreenOptions {
+  /** Already-deferred button interaction. */
+  interaction: ButtonInteraction;
+  /**
+   * The session descriptor. May be `null` for unusual flows where no session
+   * was ever created — in that case only the terminal-cleanup path is
+   * meaningful (no Back-to-Browse button, no rebuild).
+   */
+  session: TerminalScreenSession | null;
+  outcome: PostActionOutcome;
+}
+
+/**
+ * Route a post-action outcome through the unified helper.
+ *
+ * Branching:
+ * - `success` + `browseContext` + registered rebuilder → call the rebuilder;
+ *   on non-null result, delete the session and `editReply` the rebuilt view
+ *   with the banner in `content`.
+ * - `success` + `browseContext` + **no rebuilder** → log a warning and fall
+ *   through to the error-terminal path. This should never happen in
+ *   production (all four commands register rebuilders at module load); the
+ *   warn makes the misconfiguration loud without crashing the interaction.
+ * - `success` + `browseContext` + rebuilder returns `null` → same fall-
+ *   through (the rebuild itself failed, e.g., fetch error on re-query).
+ * - `success` **without** `browseContext` → terminal cleanup path. The
+ *   banner is rendered as `content`; no back button. Session is deleted.
+ * - `error` path → delegate to `renderTerminalScreen`, which renders the
+ *   error content with a Back-to-Browse button if `browseContext` is
+ *   present, or without if not.
+ */
+export async function renderPostActionScreen(opts: PostActionScreenOptions): Promise<void> {
+  const { interaction, session, outcome } = opts;
+
+  if (outcome.kind === 'success' && session?.browseContext !== undefined && session !== null) {
+    const rebuilder = getBrowseRebuilder(session.entityType);
+    if (rebuilder === undefined) {
+      logger.warn(
+        { entityType: session.entityType, entityId: session.entityId },
+        'No BrowseRebuilder registered for entity type; falling through to error terminal'
+      );
+      await renderTerminalScreen({
+        interaction,
+        session,
+        content: `${outcome.banner}\n\n\u274C Could not reload the browse list.`,
+      });
+      return;
+    }
+
+    try {
+      const rebuilt = await rebuilder(interaction, session.browseContext, outcome.banner);
+      if (rebuilt === null) {
+        // Rebuild itself failed — e.g. the re-fetch returned null.
+        // Preserve the success banner in the terminal fallback so the user
+        // sees that the destructive action *did* succeed.
+        await renderTerminalScreen({
+          interaction,
+          session,
+          content: `${outcome.banner}\n\n\u274C Could not reload the browse list.`,
+        });
+        return;
+      }
+
+      // Success path: clean up session (user is leaving the dashboard for the
+      // browse list) and render the rebuilt view.
+      const { getSessionManager } = await import('./SessionManager.js');
+      await getSessionManager().delete(session.userId, session.entityType, session.entityId);
+      await interaction.editReply(rebuilt);
+      return;
+    } catch (error) {
+      logger.error(
+        { err: error, entityType: session.entityType, entityId: session.entityId },
+        'BrowseRebuilder threw; falling through to error terminal'
+      );
+      await renderTerminalScreen({
+        interaction,
+        session,
+        content: `${outcome.banner}\n\n\u274C Could not reload the browse list.`,
+      });
+      return;
+    }
+  }
+
+  if (outcome.kind === 'success') {
+    // No browseContext — dashboard opened without /browse (e.g. /preset view).
+    // Render the banner as a clean terminal; no back button needed.
+    await renderTerminalScreen({
+      interaction,
+      session,
+      content: outcome.banner,
+    });
+    return;
+  }
+
+  // Error path.
+  await renderTerminalScreen({
+    interaction,
+    session,
+    content: outcome.content,
+  });
+}

--- a/services/bot-client/src/utils/dashboard/postActionScreen.ts
+++ b/services/bot-client/src/utils/dashboard/postActionScreen.ts
@@ -12,6 +12,7 @@ import type { ButtonInteraction } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
 import { renderTerminalScreen, type TerminalScreenSession } from './terminalScreen.js';
 import { getBrowseRebuilder } from './browseRebuilderRegistry.js';
+import { getSessionManager } from './SessionManager.js';
 
 const logger = createLogger('postActionScreen');
 
@@ -66,7 +67,7 @@ export interface PostActionScreenOptions {
 export async function renderPostActionScreen(opts: PostActionScreenOptions): Promise<void> {
   const { interaction, session, outcome } = opts;
 
-  if (outcome.kind === 'success' && session?.browseContext !== undefined && session !== null) {
+  if (outcome.kind === 'success' && session?.browseContext !== undefined) {
     const rebuilder = getBrowseRebuilder(session.entityType);
     if (rebuilder === undefined) {
       logger.warn(
@@ -76,7 +77,7 @@ export async function renderPostActionScreen(opts: PostActionScreenOptions): Pro
       await renderTerminalScreen({
         interaction,
         session,
-        content: `${outcome.banner}\n\n\u274C Could not reload the browse list.`,
+        content: `${outcome.banner}\n\n❌ Could not reload the browse list.`,
       });
       return;
     }
@@ -90,14 +91,13 @@ export async function renderPostActionScreen(opts: PostActionScreenOptions): Pro
         await renderTerminalScreen({
           interaction,
           session,
-          content: `${outcome.banner}\n\n\u274C Could not reload the browse list.`,
+          content: `${outcome.banner}\n\n❌ Could not reload the browse list.`,
         });
         return;
       }
 
       // Success path: clean up session (user is leaving the dashboard for the
       // browse list) and render the rebuilt view.
-      const { getSessionManager } = await import('./SessionManager.js');
       await getSessionManager().delete(session.userId, session.entityType, session.entityId);
       await interaction.editReply(rebuilt);
       return;
@@ -109,7 +109,7 @@ export async function renderPostActionScreen(opts: PostActionScreenOptions): Pro
       await renderTerminalScreen({
         interaction,
         session,
-        content: `${outcome.banner}\n\n\u274C Could not reload the browse list.`,
+        content: `${outcome.banner}\n\n❌ Could not reload the browse list.`,
       });
       return;
     }

--- a/services/bot-client/src/utils/dashboard/sharedBackButtonHandler.test.ts
+++ b/services/bot-client/src/utils/dashboard/sharedBackButtonHandler.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { ButtonInteraction } from 'discord.js';
+import type { BrowseCapableEntityType } from './terminalScreen.js';
+import type { BrowseContext } from './types.js';
+
+// Mocks — renderTerminalScreen + SessionManager are collaborators; assert on
+// the call shape rather than their internals.
+const mockRenderTerminalScreen = vi.fn();
+vi.mock('./terminalScreen.js', () => ({
+  renderTerminalScreen: (...args: unknown[]) => mockRenderTerminalScreen(...args),
+}));
+
+const mockSessionGet = vi.fn();
+const mockSessionDelete = vi.fn();
+vi.mock('./SessionManager.js', () => ({
+  getSessionManager: () => ({ get: mockSessionGet, delete: mockSessionDelete }),
+}));
+
+import { handleSharedBackButton } from './sharedBackButtonHandler.js';
+import {
+  registerBrowseRebuilder,
+  clearBrowseRegistry,
+  type BrowseRebuilder,
+} from './browseRebuilderRegistry.js';
+
+const validContext: BrowseContext = {
+  source: 'browse',
+  page: 2,
+  filter: 'all',
+  sort: 'name',
+};
+
+function makeInteraction(userId = 'user-1'): ButtonInteraction {
+  return { user: { id: userId }, editReply: vi.fn() } as unknown as ButtonInteraction;
+}
+
+describe('handleSharedBackButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearBrowseRegistry();
+    mockSessionGet.mockResolvedValue(null);
+  });
+
+  // Parameterize the happy path + error branches across every
+  // BrowseCapableEntityType — catches any keyed-lookup regression where the
+  // registry key or the session key drifts from the entity type literal.
+  const entityTypes: BrowseCapableEntityType[] = ['preset', 'character', 'persona', 'deny'];
+
+  describe.each(entityTypes)('for entityType=%s', entityType => {
+    it('fetches session, reads browseContext, invokes rebuilder, deletes session, and editReplies', async () => {
+      mockSessionGet.mockResolvedValue({ data: { browseContext: validContext } });
+      const rebuilt = { content: undefined, embeds: [], components: [] };
+      const rebuilder: BrowseRebuilder = vi.fn(async () => rebuilt);
+      registerBrowseRebuilder(entityType, rebuilder);
+
+      const interaction = makeInteraction();
+      await handleSharedBackButton(interaction, entityType, 'entity-1');
+
+      expect(mockSessionGet).toHaveBeenCalledWith('user-1', entityType, 'entity-1');
+      // No successBanner argument — back navigation, not a post-action
+      expect(rebuilder).toHaveBeenCalledWith(interaction, validContext);
+      expect(mockSessionDelete).toHaveBeenCalledWith('user-1', entityType, 'entity-1');
+      expect(interaction.editReply).toHaveBeenCalledWith(rebuilt);
+      expect(mockRenderTerminalScreen).not.toHaveBeenCalled();
+    });
+
+    it('renders session-expired terminal (no back button) when session is missing', async () => {
+      mockSessionGet.mockResolvedValue(null);
+      const interaction = makeInteraction();
+
+      await handleSharedBackButton(interaction, entityType, 'entity-1');
+
+      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+        expect.objectContaining({
+          interaction,
+          session: expect.objectContaining({ browseContext: undefined, entityType }),
+          content: expect.stringContaining('expired'),
+        })
+      );
+      expect(mockSessionDelete).not.toHaveBeenCalled();
+    });
+
+    it('renders expired terminal when session has no browseContext', async () => {
+      mockSessionGet.mockResolvedValue({ data: { name: 'Something' } });
+      const interaction = makeInteraction();
+
+      await handleSharedBackButton(interaction, entityType, 'entity-1');
+
+      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('expired') })
+      );
+    });
+
+    it('renders error terminal when no rebuilder is registered', async () => {
+      mockSessionGet.mockResolvedValue({ data: { browseContext: validContext } });
+      // Deliberately no register call
+
+      const interaction = makeInteraction();
+      await handleSharedBackButton(interaction, entityType, 'entity-1');
+
+      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('load browse list') })
+      );
+    });
+
+    it('renders error terminal when rebuilder returns null', async () => {
+      mockSessionGet.mockResolvedValue({ data: { browseContext: validContext } });
+      const rebuilder: BrowseRebuilder = vi.fn(async () => null);
+      registerBrowseRebuilder(entityType, rebuilder);
+
+      const interaction = makeInteraction();
+      await handleSharedBackButton(interaction, entityType, 'entity-1');
+
+      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('load browse list') })
+      );
+      expect(mockSessionDelete).not.toHaveBeenCalled();
+    });
+
+    it('renders error terminal when rebuilder throws', async () => {
+      mockSessionGet.mockResolvedValue({ data: { browseContext: validContext } });
+      const rebuilder: BrowseRebuilder = vi.fn(async () => {
+        throw new Error('boom');
+      });
+      registerBrowseRebuilder(entityType, rebuilder);
+
+      const interaction = makeInteraction();
+      await handleSharedBackButton(interaction, entityType, 'entity-1');
+
+      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('load browse list') })
+      );
+    });
+  });
+
+  it('treats malformed browseContext as missing (guards against bad shape in session data)', async () => {
+    mockSessionGet.mockResolvedValue({
+      data: { browseContext: { source: 'browse', page: 'not-a-number', filter: 'all' } },
+    });
+    const interaction = makeInteraction();
+
+    await handleSharedBackButton(interaction, 'preset', 'entity-1');
+
+    expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining('expired') })
+    );
+  });
+});

--- a/services/bot-client/src/utils/dashboard/sharedBackButtonHandler.test.ts
+++ b/services/bot-client/src/utils/dashboard/sharedBackButtonHandler.test.ts
@@ -133,16 +133,61 @@ describe('handleSharedBackButton', () => {
     });
   });
 
-  it('treats malformed browseContext as missing (guards against bad shape in session data)', async () => {
-    mockSessionGet.mockResolvedValue({
-      data: { browseContext: { source: 'browse', page: 'not-a-number', filter: 'all' } },
+  // Each branch of the extractBrowseContext guard gets its own test — the
+  // coverage report pinpointed each malformation path as uncovered. Grouping
+  // them here keeps the guard's every-field-matters contract explicit.
+  describe('extractBrowseContext guard', () => {
+    it('treats browseContext with non-numeric page as missing', async () => {
+      mockSessionGet.mockResolvedValue({
+        data: { browseContext: { source: 'browse', page: 'not-a-number', filter: 'all' } },
+      });
+
+      await handleSharedBackButton(makeInteraction(), 'preset', 'entity-1');
+      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('expired') })
+      );
     });
-    const interaction = makeInteraction();
 
-    await handleSharedBackButton(interaction, 'preset', 'entity-1');
+    it('treats browseContext with non-string filter as missing', async () => {
+      mockSessionGet.mockResolvedValue({
+        data: { browseContext: { source: 'browse', page: 1, filter: 42 } },
+      });
 
-    expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
-      expect.objectContaining({ content: expect.stringContaining('expired') })
-    );
+      await handleSharedBackButton(makeInteraction(), 'preset', 'entity-1');
+      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('expired') })
+      );
+    });
+
+    it('treats browseContext with wrong source literal as missing', async () => {
+      mockSessionGet.mockResolvedValue({
+        data: { browseContext: { source: 'other', page: 1, filter: 'all' } },
+      });
+
+      await handleSharedBackButton(makeInteraction(), 'preset', 'entity-1');
+      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('expired') })
+      );
+    });
+
+    it('treats non-object browseContext as missing', async () => {
+      mockSessionGet.mockResolvedValue({
+        data: { browseContext: 'string-not-object' },
+      });
+
+      await handleSharedBackButton(makeInteraction(), 'preset', 'entity-1');
+      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('expired') })
+      );
+    });
+
+    it('treats non-object session data as missing', async () => {
+      mockSessionGet.mockResolvedValue({ data: 'not-an-object' });
+
+      await handleSharedBackButton(makeInteraction(), 'preset', 'entity-1');
+      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('expired') })
+      );
+    });
   });
 });

--- a/services/bot-client/src/utils/dashboard/sharedBackButtonHandler.ts
+++ b/services/bot-client/src/utils/dashboard/sharedBackButtonHandler.ts
@@ -1,0 +1,158 @@
+// Shared handler for the Back-to-Browse button rendered by
+// `renderTerminalScreen` and `renderPostActionScreen`. Replaces the four
+// near-identical per-command `handleBackButton` implementations.
+//
+// Each of /preset, /character, /persona, /deny used to carry its own
+// handleBackButton that did the same five-step flow:
+//   1. fetch session → 2. read browseContext → 3. call buildBrowseResponse
+//   → 4. sessionManager.delete + editReply → 5. error fallbacks.
+// Step 3 was the only variable — solved centrally by the browse-rebuilder
+// registry — so the flow collapses into this single handler.
+//
+// All error branches render the error-terminal with NO back button:
+// re-rendering the back button on a back-button failure would just loop
+// the user into the same failure.
+
+import type { ButtonInteraction } from 'discord.js';
+import { createLogger } from '@tzurot/common-types';
+import { getSessionManager } from './SessionManager.js';
+import { renderTerminalScreen, type BrowseCapableEntityType } from './terminalScreen.js';
+import { getBrowseRebuilder } from './browseRebuilderRegistry.js';
+import { formatSessionExpiredMessage, DASHBOARD_MESSAGES } from './messages.js';
+import type { BrowseContext } from './types.js';
+
+const logger = createLogger('sharedBackButtonHandler');
+
+/** Action-suffix used in all three error-terminal "couldn't go back" branches. */
+const BROWSE_LOAD_ACTION = 'load browse list';
+
+/**
+ * Map each browse-capable entity type to the recovery slash-command shown in
+ * session-expired messages. Keyed by the closed union so adding a new entry
+ * to `BrowseCapableEntityType` without updating this table is a compile
+ * error.
+ */
+const RECOVERY_COMMAND: Record<BrowseCapableEntityType, string> = {
+  preset: '/preset browse',
+  character: '/character browse',
+  persona: '/persona browse',
+  deny: '/deny browse',
+};
+
+/**
+ * Extract `browseContext` from a session's data field in a type-safe way.
+ * Session data shape varies per command, but all four commands serialize a
+ * `BrowseContext`-shaped object at `data.browseContext` when the dashboard
+ * was opened from `/browse`. Returns `undefined` when missing or malformed.
+ */
+function extractBrowseContext(sessionData: unknown): BrowseContext | undefined {
+  if (sessionData === null || typeof sessionData !== 'object') {
+    return undefined;
+  }
+  const candidate = (sessionData as { browseContext?: unknown }).browseContext;
+  if (candidate === null || typeof candidate !== 'object') {
+    return undefined;
+  }
+  const ctx = candidate as Partial<BrowseContext>;
+  if (ctx.source !== 'browse') {
+    return undefined;
+  }
+  if (typeof ctx.page !== 'number') {
+    return undefined;
+  }
+  if (typeof ctx.filter !== 'string') {
+    return undefined;
+  }
+  return ctx as BrowseContext;
+}
+
+/**
+ * Handle a Back-to-Browse button click for any browse-capable command.
+ *
+ * Expects the interaction to be already deferred (caller `deferUpdate`s).
+ *
+ * On success: clears the session and re-renders the browse list in place.
+ * On any error branch (expired session, missing browseContext, rebuilder
+ * missing/null/throws): renders a clean error terminal with no back button.
+ */
+export async function handleSharedBackButton(
+  interaction: ButtonInteraction,
+  entityType: BrowseCapableEntityType,
+  entityId: string
+): Promise<void> {
+  const sessionManager = getSessionManager();
+  const session = await sessionManager.get(interaction.user.id, entityType, entityId);
+
+  // The terminal-screen descriptor we'll use for ALL error branches — never
+  // carries browseContext (re-rendering the back button would loop). Built
+  // once, shared across branches.
+  const errorSession = {
+    userId: interaction.user.id,
+    entityType,
+    entityId,
+    browseContext: undefined,
+  };
+
+  if (session === null) {
+    await renderTerminalScreen({
+      interaction,
+      session: errorSession,
+      content: formatSessionExpiredMessage(RECOVERY_COMMAND[entityType]),
+    });
+    return;
+  }
+
+  const browseContext = extractBrowseContext(session.data);
+  if (browseContext === undefined) {
+    // Session exists but no (or malformed) browseContext — the back button
+    // shouldn't have been rendered in the first place. Treat as expired.
+    logger.warn(
+      { entityType, entityId },
+      '[back] Session had no browseContext; rendering expired terminal'
+    );
+    await renderTerminalScreen({
+      interaction,
+      session: errorSession,
+      content: formatSessionExpiredMessage(RECOVERY_COMMAND[entityType]),
+    });
+    return;
+  }
+
+  const rebuilder = getBrowseRebuilder(entityType);
+  if (rebuilder === undefined) {
+    logger.error({ entityType, entityId }, '[back] No BrowseRebuilder registered for entity type');
+    await renderTerminalScreen({
+      interaction,
+      session: errorSession,
+      content: DASHBOARD_MESSAGES.OPERATION_FAILED(BROWSE_LOAD_ACTION),
+    });
+    return;
+  }
+
+  let rebuilt;
+  try {
+    rebuilt = await rebuilder(interaction, browseContext);
+  } catch (error) {
+    logger.error({ err: error, entityType, entityId }, '[back] BrowseRebuilder threw');
+    await renderTerminalScreen({
+      interaction,
+      session: errorSession,
+      content: DASHBOARD_MESSAGES.OPERATION_FAILED(BROWSE_LOAD_ACTION),
+    });
+    return;
+  }
+
+  if (rebuilt === null) {
+    await renderTerminalScreen({
+      interaction,
+      session: errorSession,
+      content: DASHBOARD_MESSAGES.OPERATION_FAILED(BROWSE_LOAD_ACTION),
+    });
+    return;
+  }
+
+  // Happy path — leaving the dashboard for the browse list.
+  await sessionManager.delete(interaction.user.id, entityType, entityId);
+  await interaction.editReply(rebuilt);
+  logger.info({ userId: interaction.user.id, entityType, entityId }, '[back] Returned to browse');
+}

--- a/services/bot-client/src/utils/dashboard/sharedBackButtonHandler.ts
+++ b/services/bot-client/src/utils/dashboard/sharedBackButtonHandler.ts
@@ -44,6 +44,12 @@ const RECOVERY_COMMAND: Record<BrowseCapableEntityType, string> = {
  * Session data shape varies per command, but all four commands serialize a
  * `BrowseContext`-shaped object at `data.browseContext` when the dashboard
  * was opened from `/browse`. Returns `undefined` when missing or malformed.
+ *
+ * Intentionally a subset check: validates the three fields that all browse
+ * variants require (`source`, `page`, `filter`) and accepts optional fields
+ * (`sort`, `query`) as-is. A future required field on `BrowseContext` will
+ * slip through this guard — if `BrowseContext` grows load-bearing fields,
+ * migrate this to a Zod `safeParse` so the guard stays self-maintaining.
  */
 function extractBrowseContext(sessionData: unknown): BrowseContext | undefined {
   if (sessionData === null || typeof sessionData !== 'object') {


### PR DESCRIPTION
## Summary

PR 1 of 2 for the hybrid post-action UX refactor. Adds the shared primitives; **no commands migrate in this PR** — callers land in PR 2.

Full design in `~/.claude/plans/tranquil-marinating-metcalfe.md` (plan-mode approved). Council consultation from 2026-04-21 landed on hybrid: success = direct re-render with a banner (one less click), error = terminal + Back-to-Browse button (forces acknowledgement). All four browse-capable commands will converge on this shape in PR 2.

## What's new

**Architecture — registry keyed by `BrowseCapableEntityType`, not a callback on `BrowseContext`**: council's literal suggestion (store `rebuildBrowse` callback in the session-persisted BrowseContext) cannot be implemented as-is — sessions are Redis-backed JSON and functions don't serialize. The registry lives in process memory and is populated at module-load time by each command's `browse.ts`. See the new `browseRebuilderRegistry.ts` and the file-top docstring on why this is the right shape.

New primitives (all in `services/bot-client/src/utils/dashboard/`):

- **`browseRebuilderRegistry.ts`** — typed `register`/`get`/`clearBrowseRegistry` keyed by the closed `BrowseCapableEntityType` union. Double-register of a *different* function throws (prevents two commands claiming the same key); idempotent for the same function ref.
- **`postActionScreen.ts`** — `renderPostActionScreen({ interaction, session, outcome })` with `outcome: { kind: 'success'; banner } | { kind: 'error'; content }`. Success + browseContext + registered rebuilder → delete session + editReply the rebuilt view. All other branches (no context, no rebuilder, rebuilder returns null, rebuilder throws, error path) delegate to existing `renderTerminalScreen`.
- **`sharedBackButtonHandler.ts`** — replaces the four near-identical per-command `handleBackButton` implementations (consumed in PR 2). Error branches render a terminal *without* a back button — adding one would loop into the same failure.

Supporting:

- **`messages.ts`** — `formatSuccessBanner(verb, entityName)` → `'✅ **Deleted** · MyPreset'`. Bright emoji + bold is deliberate: mobile Discord de-emphasizes `content` when a large embed sits below, so the banner has to remain scannable.
- **`SessionManager.set`** — dev-only assertion that session.data is JSON-serializable. Catches callback-in-session bugs at the *write* site with a clear error pointing to the offending key. Prod-gated via `NODE_ENV`.
- **`dashboard/index.ts`** — re-exports for the new API surface.

## Test coverage

| File | Tests | Notes |
|---|---|---|
| `browseRebuilderRegistry.test.ts` | 6 | Register/get, idempotency, conflict-throws, per-type isolation, clear |
| `postActionScreen.test.ts` | 8 | All outcome × context × rebuilder-state combos (null return, throw, missing) |
| `sharedBackButtonHandler.test.ts` | 25 | Parameterized across all four `BrowseCapableEntityType` values × every error branch |
| `messages.test.ts` | +3 | `formatSuccessBanner` shape + special chars |
| `SessionManager.test.ts` | +3 | Serialization-assertion: top-level function rejected, nested function rejected, plain JSON passes |

All existing tests unchanged and passing.

## Deliberate non-goals for this PR

- No existing caller of `renderTerminalScreen` migrates. PR 1 is purely additive.
- No `intentionally-raw` markers are cleared (they disappear with deny's migration in PR 2).
- No `ENFORCED_FILES` changes to `terminalScreen.structure.test.ts` — we'll revisit the structural test after callers migrate (PR 2 will add a parallel `POST_ACTION_ENFORCED_FILES` list so silent regressions of the new API get caught too).

## PR 2 outline

1. **persona** — register rebuilder, swap confirm-delete handler, delete per-command back-button, add the three missing error-branch tests (PR #843 review item).
2. **preset** — same shape, simpler.
3. **character** — register rebuilder (adapter captures `client` + `config` for character's unique 4-arg `buildBrowseResponse`), fold in try/catch around `callGatewayApi` + schema-fallback test (PR #842 review items).
4. **deny** — register rebuilder (adapter does `fetchEntries` + `buildBrowseResponse`), migrate confirm-delete + back-button, remove four `intentionally-raw:` markers (keeping the two on `handleModeToggle` which are recoverable in-place errors, not terminal post-actions).
5. **`refreshHandler.ts`** — tighten `entityType: string` → `BrowseCapableEntityType` (PR #843 review item — eliminates the `as BrowseCapableEntityType` cast).
6. **Structural test** — add `POST_ACTION_ENFORCED_FILES` list.
7. **Pagination-clamp audit** for persona + deny.

## Test plan

- [x] `pnpm test` — 14/14 packages pass
- [x] `pnpm quality` — lint + cpd + depcruise + typecheck + typecheck:spec all green
- [ ] No manual verification needed for PR 1 (nothing user-visible changes)
- [ ] Manual verification queued for PR 2

## Risks flagged

See the plan file for full list. Highlights:
- **Registration race in tests** — mitigated via `clearBrowseRegistry()` helper.
- **Mobile content-field blindness** — mitigated via bright-emoji + bold banner format; watch post-deploy after PR 2 ships.
- **Interaction token expiry during rebuild** — no regression from current; watch error rates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)