### PR TITLE
feat(bot-client): migrate 4 commands to hybrid post-action UX (PR 2 of 2)

### DIFF
--- a/services/bot-client/src/commands/character/browse.test.ts
+++ b/services/bot-client/src/commands/character/browse.test.ts
@@ -10,6 +10,7 @@ import {
   isCharacterBrowseInteraction,
   isCharacterBrowseSelectInteraction,
 } from './browse.js';
+import { registerBrowseRebuilder } from '../../utils/dashboard/index.js';
 import * as api from './api.js';
 import type { EnvConfig } from '@tzurot/common-types';
 import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
@@ -901,5 +902,56 @@ describe('handleBrowseSelect', () => {
       embeds: [],
       components: [],
     });
+  });
+});
+
+// Capture the rebuilder callback registered at module-load BEFORE any
+// `vi.clearAllMocks()` wipes the call history.
+const characterRebuilderCall = vi
+  .mocked(registerBrowseRebuilder)
+  .mock.calls.find(c => c[0] === 'character');
+if (characterRebuilderCall === undefined) {
+  throw new Error('character rebuilder was not registered at module load');
+}
+const characterRebuilder = characterRebuilderCall[1];
+
+describe('registered browse rebuilder', () => {
+  function createMockInteraction() {
+    return {
+      user: { id: '123456789', username: 'testuser' },
+      client: { users: { fetch: vi.fn() } },
+    } as unknown as Parameters<typeof characterRebuilder>[0];
+  }
+
+  it('returns rebuilt view with banner on success', async () => {
+    vi.mocked(api.fetchUserCharacters).mockResolvedValue([]);
+    vi.mocked(api.fetchPublicCharacters).mockResolvedValue([]);
+    vi.mocked(api.fetchUsernames).mockResolvedValue(new Map());
+
+    const result = await characterRebuilder(
+      createMockInteraction(),
+      { source: 'browse', page: 0, filter: 'all', sort: 'date', query: null },
+      '✅ Banner'
+    );
+
+    expect(result).not.toBeNull();
+    expect(result).toEqual({
+      content: '✅ Banner',
+      embeds: expect.any(Array),
+      components: expect.any(Array),
+    });
+  });
+
+  it('returns null when underlying build throws', async () => {
+    vi.mocked(api.fetchUserCharacters).mockRejectedValue(new Error('API down'));
+    vi.mocked(api.fetchPublicCharacters).mockRejectedValue(new Error('API down'));
+
+    const result = await characterRebuilder(
+      createMockInteraction(),
+      { source: 'browse', page: 0, filter: 'all', sort: 'date', query: null },
+      '✅ Banner'
+    );
+
+    expect(result).toBeNull();
   });
 });

--- a/services/bot-client/src/commands/character/browse.test.ts
+++ b/services/bot-client/src/commands/character/browse.test.ts
@@ -48,6 +48,7 @@ vi.mock('../../utils/dashboard/index.js', () => ({
     get: vi.fn(),
     delete: vi.fn(),
   }),
+  registerBrowseRebuilder: vi.fn(),
 }));
 
 // Mock config module

--- a/services/bot-client/src/commands/character/browse.ts
+++ b/services/bot-client/src/commands/character/browse.ts
@@ -16,6 +16,7 @@ import {
   type EnvConfig,
   DISCORD_COLORS,
   characterBrowseOptions,
+  getConfig,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import { toGatewayUser, type GatewayUser } from '../../utils/userGatewayClient.js';
@@ -36,6 +37,7 @@ import {
   buildDashboardEmbed,
   buildDashboardComponents,
   getSessionManager,
+  registerBrowseRebuilder,
 } from '../../utils/dashboard/index.js';
 import {
   buildBrowseButtons as buildSharedBrowseButtons,
@@ -335,6 +337,38 @@ export async function buildBrowseResponse(
     query,
   });
 }
+
+// Register the character browse rebuilder with the shared registry at module
+// load time. Consumed by `renderPostActionScreen` (destructive-action success
+// → direct re-render) and `handleSharedBackButton` (Back-to-Browse click).
+//
+// Character's rebuilder is unique among the four commands in that
+// buildBrowseResponse needs `client` (for fetchUsernames) and `config` (for
+// REST endpoint URLs). The adapter captures both from the live interaction
+// and the static getConfig() — neither is stored in the session.
+registerBrowseRebuilder('character', async (interaction, browseContext, successBanner) => {
+  try {
+    const result = await buildBrowseResponse(
+      toGatewayUser(interaction.user),
+      interaction.client,
+      getConfig(),
+      {
+        page: browseContext.page,
+        filter: browseContext.filter as CharacterBrowseFilter,
+        sort: (browseContext.sort ?? 'date') as CharacterBrowseSortType,
+        query: browseContext.query ?? null,
+      }
+    );
+    return {
+      content: successBanner,
+      embeds: [result.embed],
+      components: result.components,
+    };
+  } catch (error) {
+    logger.error({ err: error, userId: interaction.user.id }, '[Character] Browse rebuilder threw');
+    return null;
+  }
+});
 
 /**
  * Handle browse pagination button clicks

--- a/services/bot-client/src/commands/character/dashboard.ts
+++ b/services/bot-client/src/commands/character/dashboard.ts
@@ -37,7 +37,11 @@ import { handleSeedModalSubmit } from './create.js';
 import { handleDeleteAction, handleDeleteButton } from './dashboardDeleteHandlers.js';
 // Note: Browse pagination is handled in index.ts via handleBrowsePagination
 import { handleViewPagination, handleExpandField } from './view.js';
-import { handleBackButton, handleRefreshButton, handleCloseButton } from './dashboardButtons.js';
+import { handleRefreshButton, handleCloseButton } from './dashboardButtons.js';
+import { handleSharedBackButton } from '../../utils/dashboard/index.js';
+// Side-effect import: registers the character browse rebuilder used by
+// renderPostActionScreen + handleSharedBackButton.
+import './browse.js';
 import {
   detectOverLengthFields,
   handleCancelEditButton,
@@ -349,7 +353,8 @@ export async function handleButton(interaction: ButtonInteraction): Promise<void
   }
 
   if (action === 'back') {
-    await handleBackButton(interaction, entityId);
+    await interaction.deferUpdate();
+    await handleSharedBackButton(interaction, 'character', entityId);
     return;
   }
 

--- a/services/bot-client/src/commands/character/dashboardButtons.test.ts
+++ b/services/bot-client/src/commands/character/dashboardButtons.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ButtonInteraction, Client } from 'discord.js';
-import { handleBackButton, handleRefreshButton, handleCloseButton } from './dashboardButtons.js';
+import { handleRefreshButton, handleCloseButton } from './dashboardButtons.js';
 import { handleDashboardClose } from '../../utils/dashboard/closeHandler.js';
 
 // Mock dependencies
@@ -231,153 +231,9 @@ describe('Character Dashboard Buttons', () => {
     });
   });
 
-  describe('handleBackButton', () => {
-    it('should return to browse list with saved context', async () => {
-      const mockInteraction = createMockButtonInteraction('character::back::test-character');
-      const browseContext = {
-        source: 'browse' as const,
-        page: 1,
-        filter: 'owned',
-        sort: 'date',
-      };
-
-      mockSessionManager.get.mockResolvedValue({
-        data: createMockCharacterData({ browseContext }),
-      });
-      mockBuildBrowseResponse.mockResolvedValue({
-        embed: { data: { title: 'Browse Characters' } },
-        components: [],
-      });
-
-      await handleBackButton(mockInteraction, 'test-character');
-
-      expect(mockInteraction.deferUpdate).toHaveBeenCalled();
-      expect(mockBuildBrowseResponse).toHaveBeenCalledWith(
-        expect.objectContaining({ discordId: 'user-123' }),
-        expect.anything(),
-        expect.anything(),
-        {
-          page: 1,
-          filter: 'owned',
-          sort: 'date',
-          query: null,
-        }
-      );
-      expect(mockSessionManager.delete).toHaveBeenCalledWith(
-        'user-123',
-        'character',
-        'test-character'
-      );
-    });
-
-    it('should show expired message when no browseContext', async () => {
-      const mockInteraction = createMockButtonInteraction('character::back::test-character');
-
-      mockSessionManager.get.mockResolvedValue({
-        data: createMockCharacterData({ browseContext: undefined }),
-      });
-
-      await handleBackButton(mockInteraction, 'test-character');
-
-      expect(mockInteraction.editReply).toHaveBeenCalledWith({
-        content: expect.stringContaining('Session expired'),
-        embeds: [],
-        components: [],
-      });
-    });
-
-    it('should show expired message when session is null', async () => {
-      const mockInteraction = createMockButtonInteraction('character::back::test-character');
-
-      mockSessionManager.get.mockResolvedValue(null);
-
-      await handleBackButton(mockInteraction, 'test-character');
-
-      expect(mockInteraction.editReply).toHaveBeenCalledWith({
-        content: expect.stringContaining('Session expired'),
-        embeds: [],
-        components: [],
-      });
-    });
-
-    it('should show error when buildBrowseResponse throws', async () => {
-      const mockInteraction = createMockButtonInteraction('character::back::test-character');
-      const browseContext = { source: 'browse' as const, page: 1, filter: 'all', sort: 'date' };
-
-      mockSessionManager.get.mockResolvedValue({
-        data: createMockCharacterData({ browseContext }),
-      });
-      mockBuildBrowseResponse.mockRejectedValue(new Error('API error'));
-
-      await handleBackButton(mockInteraction, 'test-character');
-
-      expect(mockInteraction.editReply).toHaveBeenCalledWith({
-        content: expect.stringContaining('Failed to load browse list'),
-        embeds: [],
-        components: [],
-      });
-    });
-
-    it('should include query from browseContext', async () => {
-      const mockInteraction = createMockButtonInteraction('character::back::test-character');
-      const browseContext = {
-        source: 'browse' as const,
-        page: 0,
-        filter: 'all',
-        sort: 'name',
-        query: 'luna',
-      };
-
-      mockSessionManager.get.mockResolvedValue({
-        data: createMockCharacterData({ browseContext }),
-      });
-      mockBuildBrowseResponse.mockResolvedValue({
-        embed: { data: { title: 'Browse Characters' } },
-        components: [],
-      });
-
-      await handleBackButton(mockInteraction, 'test-character');
-
-      expect(mockBuildBrowseResponse).toHaveBeenCalledWith(
-        expect.objectContaining({ discordId: 'user-123' }),
-        expect.anything(),
-        expect.anything(),
-        {
-          page: 0,
-          filter: 'all',
-          sort: 'name',
-          query: 'luna',
-        }
-      );
-    });
-
-    it('should default sort to date when not specified', async () => {
-      const mockInteraction = createMockButtonInteraction('character::back::test-character');
-      const browseContext = {
-        source: 'browse' as const,
-        page: 0,
-        filter: 'all',
-        // No sort specified
-      };
-
-      mockSessionManager.get.mockResolvedValue({
-        data: createMockCharacterData({ browseContext }),
-      });
-      mockBuildBrowseResponse.mockResolvedValue({
-        embed: { data: { title: 'Browse Characters' } },
-        components: [],
-      });
-
-      await handleBackButton(mockInteraction, 'test-character');
-
-      expect(mockBuildBrowseResponse).toHaveBeenCalledWith(
-        expect.objectContaining({ discordId: 'user-123' }),
-        expect.anything(),
-        expect.anything(),
-        expect.objectContaining({
-          sort: 'date', // Should default to 'date'
-        })
-      );
-    });
-  });
+  // handleBackButton was deleted from this module in favor of the shared
+  // handleSharedBackButton (utils/dashboard/sharedBackButtonHandler.ts),
+  // which `dashboard.ts` routes `::back::` customIds to. Its behavioral
+  // coverage lives in sharedBackButtonHandler.test.ts, parameterized across
+  // every BrowseCapableEntityType.
 });

--- a/services/bot-client/src/commands/character/dashboardButtons.ts
+++ b/services/bot-client/src/commands/character/dashboardButtons.ts
@@ -6,15 +6,13 @@
  */
 
 import type { ButtonInteraction } from 'discord.js';
-import { createLogger, getConfig, isBotOwner } from '@tzurot/common-types';
+import { getConfig, isBotOwner } from '@tzurot/common-types';
 import {
   buildDashboardEmbed,
   buildDashboardComponents,
   getSessionManager,
-  getSessionOrExpired,
   handleDashboardClose,
   DASHBOARD_MESSAGES,
-  formatSessionExpiredMessage,
   renderTerminalScreen,
 } from '../../utils/dashboard/index.js';
 import {
@@ -22,88 +20,9 @@ import {
   buildCharacterDashboardOptions,
   type CharacterData,
   type CharacterSessionData,
-  type CharacterBrowseFilter,
-  type CharacterBrowseSortType,
 } from './config.js';
 import { toGatewayUser } from '../../utils/userGatewayClient.js';
 import { fetchCharacter } from './api.js';
-import { buildBrowseResponse } from './browse.js';
-
-const logger = createLogger('character-dashboard-buttons');
-
-/**
- * Handle back button - return to browse list
- */
-export async function handleBackButton(
-  interaction: ButtonInteraction,
-  entityId: string
-): Promise<void> {
-  const config = getConfig();
-  await interaction.deferUpdate();
-
-  // Get session or show expired message
-  const session = await getSessionOrExpired<CharacterData>(
-    interaction,
-    'character',
-    entityId,
-    '/character browse'
-  );
-  if (session === null) {
-    return;
-  }
-
-  // All three error branches below render as terminal-with-no-back-button
-  // (re-adding the back-button would re-enter the failing path) and clean up
-  // the now-dead session. Share the session descriptor.
-  const noContextSession = {
-    userId: interaction.user.id,
-    entityType: 'character' as const,
-    entityId,
-    browseContext: undefined,
-  };
-
-  const browseContext = session.data.browseContext;
-  if (!browseContext) {
-    // Session exists but no browse context - shouldn't happen; terminate cleanly.
-    await renderTerminalScreen({
-      interaction,
-      session: noContextSession,
-      content: formatSessionExpiredMessage('/character browse'),
-    });
-    return;
-  }
-
-  try {
-    const { embed, components } = await buildBrowseResponse(
-      toGatewayUser(interaction.user),
-      interaction.client,
-      config,
-      {
-        page: browseContext.page,
-        filter: browseContext.filter as CharacterBrowseFilter,
-        sort: (browseContext.sort ?? 'date') as CharacterBrowseSortType,
-        query: browseContext.query ?? null,
-      }
-    );
-
-    // Clear the session since we're leaving the dashboard
-    const sessionManager = getSessionManager();
-    await sessionManager.delete(interaction.user.id, 'character', entityId);
-    await interaction.editReply({ embeds: [embed], components });
-
-    logger.info(
-      { userId: interaction.user.id, entityId, page: browseContext.page },
-      '[Character] Returned to browse from dashboard'
-    );
-  } catch (error) {
-    logger.error({ err: error, entityId }, '[Character] Failed to return to browse');
-    await renderTerminalScreen({
-      interaction,
-      session: noContextSession,
-      content: '❌ Failed to load browse list. Please try again.',
-    });
-  }
-}
 
 /**
  * Handle refresh button - reload character data while preserving browseContext

--- a/services/bot-client/src/commands/character/dashboardDeleteHandlers.test.ts
+++ b/services/bot-client/src/commands/character/dashboardDeleteHandlers.test.ts
@@ -37,6 +37,7 @@ vi.mock('../../utils/dashboard/messages.js', () => ({
     NOT_FOUND: (type: string) => `${type} not found`,
     NO_PERMISSION: (action: string) => `No permission to ${action}`,
   },
+  formatSuccessBanner: (verb: string, name: string) => `✅ **${verb}** · ${name}`,
 }));
 
 vi.mock('../../utils/customIds.js', () => ({
@@ -55,9 +56,9 @@ vi.mock('../../utils/dashboard/SessionManager.js', () => ({
   }),
 }));
 
-const mockRenderTerminalScreen = vi.fn();
-vi.mock('../../utils/dashboard/terminalScreen.js', () => ({
-  renderTerminalScreen: (...args: unknown[]) => mockRenderTerminalScreen(...args),
+const mockRenderPostActionScreen = vi.fn();
+vi.mock('../../utils/dashboard/postActionScreen.js', () => ({
+  renderPostActionScreen: (...args: unknown[]) => mockRenderPostActionScreen(...args),
 }));
 
 vi.mock('@tzurot/common-types', async importOriginal => {
@@ -113,7 +114,7 @@ describe('dashboardDeleteHandlers', () => {
     vi.clearAllMocks();
     mockCallGatewayApi.mockReset();
     mockSessionGet.mockReset();
-    mockRenderTerminalScreen.mockReset();
+    mockRenderPostActionScreen.mockReset();
     // Default: no session (simulates dashboard opened via /character view with
     // no browseContext). Individual tests override when they need a session.
     mockSessionGet.mockResolvedValue(null);
@@ -197,7 +198,7 @@ describe('dashboardDeleteHandlers', () => {
 
       await handleDeleteButton(interaction, 'test-char', true);
 
-      // Ack via deferUpdate (no intermediate progress message per preset pattern)
+      // Ack via deferUpdate (no intermediate progress message).
       expect(interaction.deferUpdate).toHaveBeenCalled();
       expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/personality/test-char', {
         method: 'DELETE',
@@ -207,21 +208,24 @@ describe('dashboardDeleteHandlers', () => {
           displayName: 'testuser',
         },
       });
-      // Success goes through renderTerminalScreen so dashboards opened from
-      // /character browse preserve the Back-to-Browse affordance.
-      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+      // Success goes through renderPostActionScreen — the helper decides
+      // success-with-rebuild vs clean-terminal based on browseContext.
+      expect(mockRenderPostActionScreen).toHaveBeenCalledWith(
         expect.objectContaining({
           session: expect.objectContaining({
             entityType: 'character',
             entityId: 'test-char',
             browseContext: undefined,
           }),
-          content: expect.stringContaining('deleted'),
+          outcome: expect.objectContaining({
+            kind: 'success',
+            banner: expect.stringContaining('Test Character'),
+          }),
         })
       );
     });
 
-    it('should carry browseContext from session into the terminal screen', async () => {
+    it('should carry browseContext from session into the post-action screen', async () => {
       const browseContext = { page: 2, filter: 'all', sort: 'date' };
       mockSessionGet.mockResolvedValue({ data: { browseContext } });
       mockCallGatewayApi.mockResolvedValue({
@@ -242,7 +246,7 @@ describe('dashboardDeleteHandlers', () => {
 
       await handleDeleteButton(interaction, 'test-char', true);
 
-      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+      expect(mockRenderPostActionScreen).toHaveBeenCalledWith(
         expect.objectContaining({
           session: expect.objectContaining({ browseContext }),
         })
@@ -258,9 +262,59 @@ describe('dashboardDeleteHandlers', () => {
 
       await handleDeleteButton(interaction, 'test-char', true);
 
-      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+      expect(mockRenderPostActionScreen).toHaveBeenCalledWith(
         expect.objectContaining({
-          content: expect.stringContaining('Failed to delete'),
+          outcome: expect.objectContaining({
+            kind: 'error',
+            content: expect.stringContaining('Failed to delete'),
+          }),
+        })
+      );
+    });
+
+    // Covers the review gap from PR #842 — the schema-validation fallback
+    // branch (safeParse returns { success: false }) had no explicit test.
+    // Imports `DeletePersonalityResponseSchema` from the mocked module-level
+    // object so we can override safeParse for this single case.
+    it('should render success via fallback banner when schema validation fails', async () => {
+      const { DeletePersonalityResponseSchema } = await import('@tzurot/common-types');
+      vi.mocked(DeletePersonalityResponseSchema.safeParse).mockReturnValueOnce({
+        success: false,
+        error: { message: 'schema drift' } as never,
+      } as never);
+
+      mockCallGatewayApi.mockResolvedValue({ ok: true, data: { unexpected: 'shape' } });
+      const interaction = createMockButtonInteraction();
+
+      await handleDeleteButton(interaction, 'test-char', true);
+
+      expect(mockRenderPostActionScreen).toHaveBeenCalledWith(
+        expect.objectContaining({
+          outcome: expect.objectContaining({
+            kind: 'success',
+            // Fallback banner uses the slug since deletedName isn't
+            // available from the malformed response.
+            banner: expect.stringContaining('test-char'),
+          }),
+        })
+      );
+    });
+
+    // Covers the try/catch review note — when callGatewayApi throws
+    // (network-level failure), the handler should render a graceful error
+    // rather than propagating to CommandHandler's generic reply.
+    it('should render graceful error when callGatewayApi throws', async () => {
+      mockCallGatewayApi.mockRejectedValueOnce(new Error('network down'));
+      const interaction = createMockButtonInteraction();
+
+      await handleDeleteButton(interaction, 'test-char', true);
+
+      expect(mockRenderPostActionScreen).toHaveBeenCalledWith(
+        expect.objectContaining({
+          outcome: expect.objectContaining({
+            kind: 'error',
+            content: expect.stringContaining('error occurred'),
+          }),
         })
       );
     });

--- a/services/bot-client/src/commands/character/dashboardDeleteHandlers.ts
+++ b/services/bot-client/src/commands/character/dashboardDeleteHandlers.ts
@@ -14,9 +14,9 @@ import {
   type EnvConfig,
 } from '@tzurot/common-types';
 import { buildDeleteConfirmation } from '../../utils/dashboard/deleteConfirmation.js';
-import { DASHBOARD_MESSAGES } from '../../utils/dashboard/messages.js';
+import { DASHBOARD_MESSAGES, formatSuccessBanner } from '../../utils/dashboard/messages.js';
 import { getSessionManager } from '../../utils/dashboard/SessionManager.js';
-import { renderTerminalScreen } from '../../utils/dashboard/terminalScreen.js';
+import { renderPostActionScreen } from '../../utils/dashboard/postActionScreen.js';
 import { CharacterCustomIds } from '../../utils/customIds.js';
 import { fetchCharacter } from './api.js';
 import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
@@ -79,10 +79,15 @@ export async function handleDeleteAction(
  * Handle delete confirmation button click.
  * Called when user clicks "Delete Forever" or "Cancel" on the delete confirmation dialog.
  *
- * Terminal success/failure paths route through {@link renderTerminalScreen} so
- * that dashboards opened from `/character browse` preserve the Back-to-Browse
- * affordance. The cancel path is left non-terminal — see the `intentionally-raw`
- * marker below for the follow-up-tracked limitation.
+ * Success routes through {@link renderPostActionScreen} — direct re-render of
+ * the browse list with a banner in `content` when the user came from
+ * `/character browse`, or a clean terminal otherwise. Error paths render as a
+ * terminal with Back-to-Browse where applicable.
+ *
+ * The cancel path is left non-terminal (plain empty-components reply +
+ * `intentionally-raw:` marker) — ideally it would restore the dashboard,
+ * but character's dashboard renders its own embed without a shared refresh
+ * helper. Tracked as a follow-up.
  */
 export async function handleDeleteButton(
   interaction: ButtonInteraction,
@@ -104,83 +109,96 @@ export async function handleDeleteButton(
     return;
   }
 
-  // User clicked confirm — ack the button and let renderTerminalScreen handle
-  // every terminal outcome. No intermediate "Deleting..." message (matches the
-  // preset pattern); the user sees the button's spinner while the DELETE API
-  // call resolves.
+  // User clicked confirm — ack the button. No intermediate "Deleting..."
+  // message; the user sees the button's spinner while the DELETE resolves.
   await interaction.deferUpdate();
 
-  // Fetch the session so browseContext (if any) can carry into the terminal
-  // screen. Users who opened this dashboard from /character browse get a
-  // Back-to-Browse button on the final message; users who opened it via
-  // /character view get a clean terminal state with no back button.
+  // Fetch the session so browseContext (if any) can carry into the post-action
+  // screen. Users who opened this dashboard from /character browse get the
+  // refreshed browse list with a success banner; users who opened it via
+  // /character view get a clean terminal state.
   const sessionManager = getSessionManager();
   const session = await sessionManager.get<CharacterData>(interaction.user.id, 'character', slug);
-  const terminalSession = {
+  const postActionSession = {
     userId: interaction.user.id,
     entityType: 'character' as const,
     entityId: slug,
     browseContext: session?.data.browseContext,
   };
 
-  // Call the DELETE API
-  const result = await callGatewayApi<unknown>(`/user/personality/${slug}`, {
-    method: 'DELETE',
-    user: toGatewayUser(interaction.user),
-  });
-
-  if (!result.ok) {
-    logger.error({ slug, error: result.error }, '[Character] Delete API failed');
-    await renderTerminalScreen({
-      interaction,
-      session: terminalSession,
-      content: `❌ Failed to delete character: ${result.error}`,
+  // Wrap the API call + response handling in try/catch so network errors
+  // (fetch throws, timeout, DNS failure) don't propagate up to CommandHandler's
+  // generic error reply. Matches the preset pattern.
+  try {
+    const result = await callGatewayApi<unknown>(`/user/personality/${slug}`, {
+      method: 'DELETE',
+      user: toGatewayUser(interaction.user),
     });
-    return;
-  }
 
-  // Validate response against schema (contract validation)
-  const parseResult = DeletePersonalityResponseSchema.safeParse(result.data);
-  if (!parseResult.success) {
-    logger.error(
-      { slug, parseError: parseResult.error.message },
-      '[Character] Response schema validation failed'
+    if (!result.ok) {
+      logger.error({ slug, error: result.error }, '[Character] Delete API failed');
+      await renderPostActionScreen({
+        interaction,
+        session: postActionSession,
+        outcome: { kind: 'error', content: `❌ Failed to delete character: ${result.error}` },
+      });
+      return;
+    }
+
+    // Validate response against schema (contract validation)
+    const parseResult = DeletePersonalityResponseSchema.safeParse(result.data);
+    if (!parseResult.success) {
+      logger.error(
+        { slug, parseError: parseResult.error.message },
+        '[Character] Response schema validation failed'
+      );
+      // Still consider it a success since the API returned 200
+      await renderPostActionScreen({
+        interaction,
+        session: postActionSession,
+        outcome: { kind: 'success', banner: formatSuccessBanner('Deleted character', slug) },
+      });
+      return;
+    }
+
+    const { deletedCounts: counts, deletedName, deletedSlug } = parseResult.data;
+
+    // Build the secondary detail block (deletion counts) shown below the
+    // banner in the success content. Filter out zero counts for terseness.
+    const countLines = [
+      counts.conversationHistory > 0 && `• ${counts.conversationHistory} conversation message(s)`,
+      counts.memories > 0 &&
+        `• ${counts.memories} long-term memor${counts.memories === 1 ? 'y' : 'ies'}`,
+      counts.pendingMemories > 0 &&
+        `• ${counts.pendingMemories} pending memor${counts.pendingMemories === 1 ? 'y' : 'ies'}`,
+      counts.channelSettings > 0 && `• ${counts.channelSettings} channel setting(s)`,
+      counts.aliases > 0 && `• ${counts.aliases} alias(es)`,
+    ].filter((line): line is string => typeof line === 'string');
+
+    let banner = formatSuccessBanner('Deleted character', deletedName);
+    if (countLines.length > 0) {
+      banner += '\n**Deleted data:**\n' + countLines.join('\n');
+    }
+
+    await renderPostActionScreen({
+      interaction,
+      session: postActionSession,
+      outcome: { kind: 'success', banner },
+    });
+
+    logger.info(
+      { userId: interaction.user.id, slug: deletedSlug, counts },
+      '[Character] Successfully deleted character'
     );
-    // Still consider it a success since the API returned 200
-    await renderTerminalScreen({
+  } catch (error) {
+    logger.error({ err: error, slug }, '[Character] Failed to delete character');
+    await renderPostActionScreen({
       interaction,
-      session: terminalSession,
-      content: `✅ Character has been deleted.`,
+      session: postActionSession,
+      outcome: {
+        kind: 'error',
+        content: '❌ An error occurred while deleting the character. Please try again.',
+      },
     });
-    return;
   }
-
-  const { deletedCounts: counts, deletedName, deletedSlug } = parseResult.data;
-
-  // Build success message with deletion counts (filter out zero counts)
-  const countLines = [
-    counts.conversationHistory > 0 && `• ${counts.conversationHistory} conversation message(s)`,
-    counts.memories > 0 &&
-      `• ${counts.memories} long-term memor${counts.memories === 1 ? 'y' : 'ies'}`,
-    counts.pendingMemories > 0 &&
-      `• ${counts.pendingMemories} pending memor${counts.pendingMemories === 1 ? 'y' : 'ies'}`,
-    counts.channelSettings > 0 && `• ${counts.channelSettings} channel setting(s)`,
-    counts.aliases > 0 && `• ${counts.aliases} alias(es)`,
-  ].filter((line): line is string => typeof line === 'string');
-
-  let successMessage = `✅ Character \`${deletedName}\` has been permanently deleted.`;
-  if (countLines.length > 0) {
-    successMessage += '\n\n**Deleted data:**\n' + countLines.join('\n');
-  }
-
-  await renderTerminalScreen({
-    interaction,
-    session: terminalSession,
-    content: successMessage,
-  });
-
-  logger.info(
-    { userId: interaction.user.id, slug: deletedSlug, counts },
-    '[Character] Successfully deleted character'
-  );
 }

--- a/services/bot-client/src/commands/deny/browse.test.ts
+++ b/services/bot-client/src/commands/deny/browse.test.ts
@@ -134,10 +134,17 @@ vi.mock('./detail.js', () => ({
   showDetailView: vi.fn(),
 }));
 
+// Mock the dashboard index so module-load registration is observable and
+// doesn't pollute the real browse-rebuilder registry across test files.
+vi.mock('../../utils/dashboard/index.js', () => ({
+  registerBrowseRebuilder: vi.fn(),
+}));
+
 import { isBotOwner } from '@tzurot/common-types';
 import { adminFetch } from '../../utils/adminApiClient.js';
 import { requireBotOwnerContext } from '../../utils/commandContext/index.js';
 import { showDetailView } from './detail.js';
+import { registerBrowseRebuilder } from '../../utils/dashboard/index.js';
 
 function createMockContext(options: Record<string, unknown> = {}): DeferredCommandContext {
   const optionMap = new Map(Object.entries(options));
@@ -537,6 +544,7 @@ describe('handleBrowseSelect', () => {
 
     expect(interaction.deferUpdate).toHaveBeenCalled();
     expect(showDetailView).toHaveBeenCalledWith(interaction, sampleEntries[0], {
+      source: 'browse',
       page: 0,
       filter: 'all',
       sort: 'date',
@@ -607,5 +615,52 @@ describe('buildBrowseResponse', () => {
 
     expect(result.embed.data.footer?.text).toContain('all types');
     expect(result.embed.data.footer?.text).toContain('by target ID');
+  });
+});
+
+// Capture the rebuilder callback registered at module-load BEFORE any
+// `vi.clearAllMocks()` wipes the call history.
+const denyRebuilderCall = vi.mocked(registerBrowseRebuilder).mock.calls.find(c => c[0] === 'deny');
+if (denyRebuilderCall === undefined) {
+  throw new Error('deny rebuilder was not registered at module load');
+}
+const denyRebuilder = denyRebuilderCall[1];
+
+describe('registered browse rebuilder', () => {
+  function createMockInteraction() {
+    return { user: { id: 'user-123' } } as unknown as Parameters<typeof denyRebuilder>[0];
+  }
+
+  it('returns rebuilt view with banner on success', async () => {
+    vi.mocked(adminFetch).mockResolvedValue(mockOkResponse({ entries: sampleEntries }));
+
+    const result = await denyRebuilder(
+      createMockInteraction(),
+      { source: 'browse', page: 0, filter: 'all', sort: 'date' },
+      '✅ Banner'
+    );
+
+    expect(result).not.toBeNull();
+    expect(result).toEqual({
+      content: '✅ Banner',
+      embeds: expect.any(Array),
+      components: expect.any(Array),
+    });
+  });
+
+  it('returns null when fetchEntries returns null (admin API fails)', async () => {
+    vi.mocked(adminFetch).mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({}),
+    } as Response);
+
+    const result = await denyRebuilder(
+      createMockInteraction(),
+      { source: 'browse', page: 0, filter: 'all', sort: 'date' },
+      '✅ Banner'
+    );
+
+    expect(result).toBeNull();
   });
 });

--- a/services/bot-client/src/commands/deny/browse.ts
+++ b/services/bot-client/src/commands/deny/browse.ts
@@ -12,6 +12,7 @@ import { createLogger, isBotOwner, DISCORD_COLORS, formatDateShort } from '@tzur
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import { requireBotOwnerContext } from '../../utils/commandContext/index.js';
 import { adminFetch } from '../../utils/adminApiClient.js';
+import { registerBrowseRebuilder } from '../../utils/dashboard/index.js';
 import {
   buildBrowseButtons,
   buildBrowseSelectMenu,
@@ -220,6 +221,34 @@ export function buildBrowseResponse(
   const sorted = sortEntries(filtered, sort);
   return buildBrowsePage(sorted, page, filter, sort);
 }
+
+// Register the deny browse rebuilder with the shared registry at module load
+// time. Consumed by `renderPostActionScreen` (destructive-action success →
+// direct re-render) and `handleSharedBackButton` (Back-to-Browse click).
+//
+// Deny is unique among the four commands in that its buildBrowseResponse
+// takes pre-fetched entries (synchronous), so the adapter first does
+// `fetchEntries(userId)` and then passes the result into the shared builder.
+// fetchEntries returns `null` on API failure — the adapter propagates that
+// as its own null return, and the shared helper falls through to the error
+// terminal.
+registerBrowseRebuilder('deny', async (interaction, browseContext, successBanner) => {
+  const entries = await fetchEntries(interaction.user.id);
+  if (entries === null) {
+    return null;
+  }
+  const result = buildBrowseResponse(
+    entries,
+    browseContext.page,
+    browseContext.filter as DenyBrowseFilter,
+    (browseContext.sort ?? 'date') as BrowseSortType
+  );
+  return {
+    content: successBanner,
+    embeds: [result.embed],
+    components: result.components,
+  };
+});
 
 /** Handle /deny browse [filter?] */
 export async function handleBrowse(context: DeferredCommandContext): Promise<void> {

--- a/services/bot-client/src/commands/deny/browse.ts
+++ b/services/bot-client/src/commands/deny/browse.ts
@@ -335,6 +335,7 @@ export async function handleBrowseSelect(interaction: StringSelectMenuInteractio
   // Import detail handler lazily to avoid circular dependency
   const { showDetailView } = await import('./detail.js');
   await showDetailView(interaction, entry, {
+    source: 'browse',
     page: parsed.page,
     filter: parsed.filter,
     sort: parsed.sort ?? 'date',

--- a/services/bot-client/src/commands/deny/detail.test.ts
+++ b/services/bot-client/src/commands/deny/detail.test.ts
@@ -111,7 +111,7 @@ const sampleEntry = {
 const sampleSession = {
   data: {
     ...sampleEntry,
-    browseContext: { page: 0, filter: 'all', sort: 'date' },
+    browseContext: { source: 'browse' as const, page: 0, filter: 'all', sort: 'date' },
     guildId: 'guild-456',
   },
   userId: 'user-123',
@@ -154,7 +154,12 @@ describe('showDetailView', () => {
   it('should create session and show detail embed', async () => {
     const interaction = createMockButtonInteraction('deny::browse-select::0::all::date::');
 
-    await showDetailView(interaction, sampleEntry, { page: 0, filter: 'all', sort: 'date' });
+    await showDetailView(interaction, sampleEntry, {
+      source: 'browse',
+      page: 0,
+      filter: 'all',
+      sort: 'date',
+    });
 
     expect(mockSessionManager.set).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/services/bot-client/src/commands/deny/detail.test.ts
+++ b/services/bot-client/src/commands/deny/detail.test.ts
@@ -37,6 +37,20 @@ vi.mock('../../utils/dashboard/messages.js', () => ({
     SESSION_EXPIRED: '⏰ Session expired.',
     OPERATION_FAILED: (action: string) => `❌ Failed to ${action}.`,
   },
+  formatSessionExpiredMessage: (cmd: string) => `⏰ Session expired — use ${cmd}.`,
+  formatSuccessBanner: (verb: string, name: string) => `✅ **${verb}** · ${name}`,
+}));
+
+// Stub the post-action helpers at their source so the deny tests can assert
+// on handler-level dispatch without exercising their internals (which have
+// their own test coverage).
+const mockRenderPostActionScreen = vi.fn();
+vi.mock('../../utils/dashboard/postActionScreen.js', () => ({
+  renderPostActionScreen: (...args: unknown[]) => mockRenderPostActionScreen(...args),
+}));
+const mockHandleSharedBackButton = vi.fn();
+vi.mock('../../utils/dashboard/sharedBackButtonHandler.js', () => ({
+  handleSharedBackButton: (...args: unknown[]) => mockHandleSharedBackButton(...args),
 }));
 
 vi.mock('../../utils/dashboard/types.js', () => ({
@@ -67,7 +81,7 @@ vi.mock('./browse.js', () => ({
 
 // Mock detailTypes so we don't construct Discord.js builders
 vi.mock('./detailTypes.js', () => ({
-  ENTITY_TYPE: 'deny-detail',
+  ENTITY_TYPE: 'deny',
   buildDetailEmbed: vi.fn(() => ({ data: { title: 'Detail' } })),
   buildDetailButtons: vi.fn(() => [{ type: 'action-row' }]),
 }));
@@ -80,7 +94,6 @@ vi.mock('./detailEdit.js', () => ({
 import { isBotOwner } from '@tzurot/common-types';
 import { adminPostJson, adminFetch } from '../../utils/adminApiClient.js';
 import { buildDeleteConfirmation } from '../../utils/dashboard/deleteConfirmation.js';
-import { fetchEntries, buildBrowseResponse } from './browse.js';
 import { handleEdit, handleEditModal } from './detailEdit.js';
 
 const sampleEntry = {
@@ -102,7 +115,7 @@ const sampleSession = {
     guildId: 'guild-456',
   },
   userId: 'user-123',
-  entityType: 'deny-detail',
+  entityType: 'deny',
   entityId: 'entry-uuid-1234',
   messageId: 'msg-1',
   channelId: 'chan-1',
@@ -146,7 +159,7 @@ describe('showDetailView', () => {
     expect(mockSessionManager.set).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: 'user-123',
-        entityType: 'deny-detail',
+        entityType: 'deny',
         entityId: 'entry-uuid-1234',
         data: expect.objectContaining({
           id: 'entry-uuid-1234',
@@ -196,7 +209,7 @@ describe('handleDetailButton', () => {
       );
       expect(mockSessionManager.update).toHaveBeenCalledWith(
         'user-123',
-        'deny-detail',
+        'deny',
         'entry-uuid-1234',
         { mode: 'MUTE' }
       );
@@ -272,11 +285,9 @@ describe('handleDetailButton', () => {
       );
     });
 
-    it('should delete entry and return to browse when entries remain', async () => {
+    it('should route delete success through renderPostActionScreen', async () => {
       mockSessionManager.get.mockResolvedValue(sampleSession);
-      mockSessionManager.delete.mockResolvedValue(true);
       vi.mocked(adminFetch).mockResolvedValue(mockOkResponse({ success: true }));
-      vi.mocked(fetchEntries).mockResolvedValue([sampleEntry]);
       const interaction = createMockButtonInteraction('deny::confirm-del::entry-uuid-1234');
 
       await handleDetailButton(interaction);
@@ -285,36 +296,27 @@ describe('handleDetailButton', () => {
         method: 'DELETE',
         userId: 'user-123',
       });
-      expect(mockSessionManager.delete).toHaveBeenCalledWith(
-        'user-123',
-        'deny-detail',
-        'entry-uuid-1234'
-      );
-      expect(fetchEntries).toHaveBeenCalledWith('user-123');
-      expect(buildBrowseResponse).toHaveBeenCalledWith([sampleEntry], 0, 'all', 'date');
-      expect(interaction.editReply).toHaveBeenCalledWith(
+      // Delete + browse rebuild + session cleanup are owned by the shared
+      // renderPostActionScreen helper + the browse rebuilder registered in
+      // browse.ts. Assert the handler routes correctly with the right shape.
+      expect(mockRenderPostActionScreen).toHaveBeenCalledWith(
         expect.objectContaining({
-          content: expect.stringContaining('has been deleted'),
-          embeds: expect.any(Array),
-          components: expect.any(Array),
+          session: expect.objectContaining({
+            entityType: 'deny',
+            entityId: 'entry-uuid-1234',
+            browseContext: expect.objectContaining({
+              source: 'browse',
+              page: 0,
+              filter: 'all',
+              sort: 'date',
+            }),
+          }),
+          outcome: expect.objectContaining({
+            kind: 'success',
+            banner: expect.stringContaining('USER'),
+          }),
         })
       );
-    });
-
-    it('should delete entry and show empty message when no entries remain', async () => {
-      mockSessionManager.get.mockResolvedValue(sampleSession);
-      mockSessionManager.delete.mockResolvedValue(true);
-      vi.mocked(adminFetch).mockResolvedValue(mockOkResponse({ success: true }));
-      vi.mocked(fetchEntries).mockResolvedValue([]);
-      const interaction = createMockButtonInteraction('deny::confirm-del::entry-uuid-1234');
-
-      await handleDetailButton(interaction);
-
-      expect(interaction.editReply).toHaveBeenCalledWith({
-        content: expect.stringContaining('No entries remaining'),
-        embeds: [],
-        components: [],
-      });
     });
 
     it('should return to detail view on cancel', async () => {
@@ -329,58 +331,34 @@ describe('handleDetailButton', () => {
       });
     });
 
-    it('should handle delete API error', async () => {
+    it('should route delete API errors through renderPostActionScreen as an error outcome', async () => {
       mockSessionManager.get.mockResolvedValue(sampleSession);
       vi.mocked(adminFetch).mockResolvedValue(mockErrorResponse(500, { message: 'Error' }));
       const interaction = createMockButtonInteraction('deny::confirm-del::entry-uuid-1234');
 
       await handleDetailButton(interaction);
 
-      expect(interaction.editReply).toHaveBeenCalledWith(
-        expect.objectContaining({ content: expect.stringContaining('Failed to delete') })
+      expect(mockRenderPostActionScreen).toHaveBeenCalledWith(
+        expect.objectContaining({
+          outcome: expect.objectContaining({
+            kind: 'error',
+            content: expect.stringContaining('Failed to delete'),
+          }),
+        })
       );
     });
   });
 
   describe('back navigation', () => {
-    it('should return to browse view', async () => {
-      mockSessionManager.get.mockResolvedValue(sampleSession);
-      mockSessionManager.delete.mockResolvedValue(true);
-      vi.mocked(fetchEntries).mockResolvedValue([sampleEntry]);
+    it('should route back button through handleSharedBackButton', async () => {
       const interaction = createMockButtonInteraction('deny::back::entry-uuid-1234');
 
       await handleDetailButton(interaction);
 
-      expect(mockSessionManager.delete).toHaveBeenCalledWith(
-        'user-123',
-        'deny-detail',
+      expect(mockHandleSharedBackButton).toHaveBeenCalledWith(
+        interaction,
+        'deny',
         'entry-uuid-1234'
-      );
-      expect(fetchEntries).toHaveBeenCalledWith('user-123');
-      expect(buildBrowseResponse).toHaveBeenCalledWith([sampleEntry], 0, 'all', 'date');
-    });
-
-    it('should handle fetch failure on back', async () => {
-      mockSessionManager.get.mockResolvedValue(sampleSession);
-      mockSessionManager.delete.mockResolvedValue(true);
-      vi.mocked(fetchEntries).mockResolvedValue(null);
-      const interaction = createMockButtonInteraction('deny::back::entry-uuid-1234');
-
-      await handleDetailButton(interaction);
-
-      expect(interaction.editReply).toHaveBeenCalledWith(
-        expect.objectContaining({ content: expect.stringContaining('Failed to fetch') })
-      );
-    });
-
-    it('should handle session expiry on back', async () => {
-      mockSessionManager.get.mockResolvedValue(null);
-      const interaction = createMockButtonInteraction('deny::back::entry-uuid-1234');
-
-      await handleDetailButton(interaction);
-
-      expect(interaction.editReply).toHaveBeenCalledWith(
-        expect.objectContaining({ content: expect.stringContaining('Session expired') })
       );
     });
   });

--- a/services/bot-client/src/commands/deny/detail.ts
+++ b/services/bot-client/src/commands/deny/detail.ts
@@ -31,6 +31,7 @@ import { parseDashboardCustomId } from '../../utils/dashboard/types.js';
 import { renderPostActionScreen } from '../../utils/dashboard/postActionScreen.js';
 import { handleSharedBackButton } from '../../utils/dashboard/sharedBackButtonHandler.js';
 import { adminPostJson, adminFetch } from '../../utils/adminApiClient.js';
+import type { BrowseContext } from '../../utils/dashboard/types.js';
 import type { DenylistEntryResponse } from './browse.js';
 import type { DenyDetailSession } from './detailTypes.js';
 import { ENTITY_TYPE, buildDetailEmbed, buildDetailButtons } from './detailTypes.js';
@@ -85,7 +86,7 @@ export async function showDetailView(
     guildId: string | null;
   },
   entry: DenylistEntryResponse,
-  browseContext: { page: number; filter: string; sort: string },
+  browseContext: BrowseContext,
   content?: string
 ): Promise<void> {
   const sessionData: DenyDetailSession = {
@@ -201,12 +202,7 @@ async function handleConfirmDelete(interaction: ButtonInteraction, entryId: stri
     userId: interaction.user.id,
     entityType: 'deny' as const,
     entityId: entryId,
-    // `data.browseContext` is shaped as a plain `{ page, filter, sort }` in
-    // deny's session data. The shared helper expects a `BrowseContext` with
-    // `source: 'browse'` — add it here. The entire DenyDetailSession is
-    // seeded from showDetailView which always has a valid browse context,
-    // so the shape is guaranteed at this point.
-    browseContext: { source: 'browse' as const, ...data.browseContext },
+    browseContext: data.browseContext,
   };
 
   try {
@@ -299,6 +295,9 @@ export async function handleDetailButton(interaction: ButtonInteraction): Promis
       await handleCancelDelete(interaction, entityId);
       break;
     case 'back':
+      // handleDetailButton calls deferUpdate above — handleSharedBackButton
+      // intentionally does NOT re-defer. Calling deferUpdate twice throws
+      // InteractionAlreadyReplied, so the shared helper trusts its callers.
       await handleSharedBackButton(interaction, 'deny', entityId);
       break;
     default:

--- a/services/bot-client/src/commands/deny/detail.ts
+++ b/services/bot-client/src/commands/deny/detail.ts
@@ -8,28 +8,36 @@
  * UI builders and types are in detailTypes.ts.
  * Edit modal handlers are in detailEdit.ts.
  *
- * Back-to-Browse UX note: unlike `/preset`, `/character`, and `/persona`, the
- * deny detail view does NOT use `renderTerminalScreen`'s Back-to-Browse
- * button pattern. `handleConfirmDelete` (success path) and `handleBack`
- * manually re-fetch entries and re-render the browse list directly, which
- * saves a click versus the Back-to-Browse + click + re-render flow the other
- * commands use. Terminal error paths in this file are intentionally plain
- * `editReply({ components: [] })` — see each site's `intentionally-raw:`
- * marker for the per-site reason. This file is in ENFORCED_FILES so any NEW
- * terminal path must either use `renderTerminalScreen` or add its own marker.
+ * Destructive-action flow: `handleConfirmDelete` routes success/failure
+ * through `renderPostActionScreen` (shared with preset/character/persona).
+ * Success re-renders the browse list with a banner in `content`; failure
+ * renders a terminal with Back-to-Browse. The browse rebuilder is
+ * registered in `browse.ts` — it does `fetchEntries` + `buildBrowseResponse`
+ * internally so the unified helper works the same across all four commands.
+ *
+ * `handleModeToggle` keeps plain empty-components replies on its error
+ * paths — those are recoverable in-place errors (session still alive, user
+ * can retry), not terminal post-actions. Marked `intentionally-raw:` so
+ * the structural test catches new terminal paths without false positives
+ * on these legitimate non-terminal error renders.
  */
 
 import type { ButtonInteraction, ModalSubmitInteraction } from 'discord.js';
 import { createLogger, isBotOwner } from '@tzurot/common-types';
 import { getSessionManager } from '../../utils/dashboard/SessionManager.js';
 import { buildDeleteConfirmation } from '../../utils/dashboard/deleteConfirmation.js';
-import { DASHBOARD_MESSAGES } from '../../utils/dashboard/messages.js';
+import { DASHBOARD_MESSAGES, formatSuccessBanner } from '../../utils/dashboard/messages.js';
 import { parseDashboardCustomId } from '../../utils/dashboard/types.js';
+import { renderPostActionScreen } from '../../utils/dashboard/postActionScreen.js';
+import { handleSharedBackButton } from '../../utils/dashboard/sharedBackButtonHandler.js';
 import { adminPostJson, adminFetch } from '../../utils/adminApiClient.js';
-import type { DenylistEntryResponse, DenyBrowseFilter } from './browse.js';
+import type { DenylistEntryResponse } from './browse.js';
 import type { DenyDetailSession } from './detailTypes.js';
 import { ENTITY_TYPE, buildDetailEmbed, buildDetailButtons } from './detailTypes.js';
 import { handleEdit, handleEditModal } from './detailEdit.js';
+// Side-effect import: registers the deny browse rebuilder used by
+// renderPostActionScreen + handleSharedBackButton.
+import './browse.js';
 
 const logger = createLogger('deny-detail');
 
@@ -189,6 +197,18 @@ async function handleConfirmDelete(interaction: ButtonInteraction, entryId: stri
     return;
   }
 
+  const postActionSession = {
+    userId: interaction.user.id,
+    entityType: 'deny' as const,
+    entityId: entryId,
+    // `data.browseContext` is shaped as a plain `{ page, filter, sort }` in
+    // deny's session data. The shared helper expects a `BrowseContext` with
+    // `source: 'browse'` — add it here. The entire DenyDetailSession is
+    // seeded from showDetailView which always has a valid browse context,
+    // so the shape is guaranteed at this point.
+    browseContext: { source: 'browse' as const, ...data.browseContext },
+  };
+
   try {
     const segments = [data.type, data.discordId, data.scope, data.scopeId].map(encodeURIComponent);
     const response = await adminFetch(`/admin/denylist/${segments.join('/')}`, {
@@ -197,52 +217,28 @@ async function handleConfirmDelete(interaction: ButtonInteraction, entryId: stri
     });
 
     if (!response.ok && response.status !== 404) {
-      // intentionally-raw: delete-API-failure terminal path; session still
-      // valid so user can retry. Deny doesn't use Back-to-Browse button.
-      await interaction.editReply({
-        content: DASHBOARD_MESSAGES.OPERATION_FAILED('delete entry'),
-        embeds: [],
-        components: [], // intentionally-raw: see file-top UX note.
+      await renderPostActionScreen({
+        interaction,
+        session: postActionSession,
+        outcome: { kind: 'error', content: DASHBOARD_MESSAGES.OPERATION_FAILED('delete entry') },
       });
       return;
     }
 
-    await getSessionManager().delete(interaction.user.id, ENTITY_TYPE, entryId);
-
-    // Try to return to browse list instead of dead-ending
-    const { fetchEntries, buildBrowseResponse } = await import('./browse.js');
-    const entries = await fetchEntries(interaction.user.id);
-    if (entries !== null && entries.length > 0) {
-      const ctx = data.browseContext;
-      const { embed, components } = buildBrowseResponse(
-        entries,
-        ctx.page,
-        ctx.filter as DenyBrowseFilter,
-        ctx.sort as 'name' | 'date'
-      );
-      await interaction.editReply({
-        content: `\u2705 Denylist entry for ${data.type} \`${data.discordId}\` has been deleted.`,
-        embeds: [embed],
-        components,
-      });
-      return;
-    }
-
-    // intentionally-raw: delete succeeded + browse list is now empty — no
-    // meaningful browse to go back to, clean terminal is correct.
-    await interaction.editReply({
-      content: `\u2705 Denylist entry for ${data.type} \`${data.discordId}\` has been deleted. No entries remaining.`,
-      embeds: [],
-      components: [], // intentionally-raw: see file-top UX note.
+    await renderPostActionScreen({
+      interaction,
+      session: postActionSession,
+      outcome: {
+        kind: 'success',
+        banner: formatSuccessBanner('Deleted denylist entry', `${data.type} \`${data.discordId}\``),
+      },
     });
   } catch (error) {
     logger.error({ err: error }, '[Deny] Failed to delete entry');
-    // intentionally-raw: delete-exception terminal path; session already
-    // cleaned up so no retry possible. Clean terminal per file-top UX note.
-    await interaction.editReply({
-      content: DASHBOARD_MESSAGES.OPERATION_FAILED('delete entry'),
-      embeds: [],
-      components: [], // intentionally-raw: see file-top UX note.
+    await renderPostActionScreen({
+      interaction,
+      session: postActionSession,
+      outcome: { kind: 'error', content: DASHBOARD_MESSAGES.OPERATION_FAILED('delete entry') },
     });
   }
 }
@@ -260,37 +256,10 @@ async function handleCancelDelete(interaction: ButtonInteraction, entryId: strin
   });
 }
 
-/** Handle back button — return to browse list */
-async function handleBack(interaction: ButtonInteraction, entryId: string): Promise<void> {
-  const data = await getSessionOrExpired(interaction, entryId);
-  if (data === null) {
-    return;
-  }
-
-  await getSessionManager().delete(interaction.user.id, ENTITY_TYPE, entryId);
-
-  const { fetchEntries, buildBrowseResponse } = await import('./browse.js');
-  const entries = await fetchEntries(interaction.user.id);
-  if (entries === null) {
-    // intentionally-raw: back-to-browse itself failed; adding a Back-to-Browse
-    // button would just loop into the same failing fetch. Clean terminal.
-    await interaction.editReply({
-      content: '\u274C Failed to fetch denylist entries.',
-      embeds: [],
-      components: [], // intentionally-raw: see file-top UX note.
-    });
-    return;
-  }
-
-  const ctx = data.browseContext;
-  const { embed, components } = buildBrowseResponse(
-    entries,
-    ctx.page,
-    ctx.filter as DenyBrowseFilter,
-    ctx.sort as 'name' | 'date'
-  );
-  await interaction.editReply({ embeds: [embed], components });
-}
+// handleBack was deleted in favor of the shared `handleSharedBackButton`
+// (utils/dashboard/sharedBackButtonHandler.ts) — routed to from the switch
+// in handleDetailButton below. The browse rebuilder registered in
+// `./browse.js` owns the fetchEntries + buildBrowseResponse path.
 
 /** Route detail button interactions */
 export async function handleDetailButton(interaction: ButtonInteraction): Promise<void> {
@@ -330,7 +299,7 @@ export async function handleDetailButton(interaction: ButtonInteraction): Promis
       await handleCancelDelete(interaction, entityId);
       break;
     case 'back':
-      await handleBack(interaction, entityId);
+      await handleSharedBackButton(interaction, 'deny', entityId);
       break;
     default:
       logger.warn({ action, entityId }, '[Deny] Unknown detail action');

--- a/services/bot-client/src/commands/deny/detailEdit.test.ts
+++ b/services/bot-client/src/commands/deny/detailEdit.test.ts
@@ -60,7 +60,7 @@ const sampleEntry = {
 const sampleSession = {
   data: {
     ...sampleEntry,
-    browseContext: { page: 0, filter: 'all', sort: 'date' },
+    browseContext: { source: 'browse' as const, page: 0, filter: 'all', sort: 'date' },
     guildId: 'guild-456',
   },
   userId: 'user-123',

--- a/services/bot-client/src/commands/deny/detailEdit.test.ts
+++ b/services/bot-client/src/commands/deny/detailEdit.test.ts
@@ -37,7 +37,7 @@ vi.mock('../../utils/adminApiClient.js', () => ({
 
 // Mock detailTypes so we don't construct Discord.js builders
 vi.mock('./detailTypes.js', () => ({
-  ENTITY_TYPE: 'deny-detail',
+  ENTITY_TYPE: 'deny',
   VALID_SCOPES: ['BOT', 'GUILD', 'CHANNEL', 'PERSONALITY'],
   buildDetailEmbed: vi.fn(() => ({ data: { title: 'Detail' } })),
   buildDetailButtons: vi.fn(() => [{ type: 'action-row' }]),
@@ -64,7 +64,7 @@ const sampleSession = {
     guildId: 'guild-456',
   },
   userId: 'user-123',
-  entityType: 'deny-detail',
+  entityType: 'deny',
   entityId: 'entry-uuid-1234',
   messageId: 'msg-1',
   channelId: 'chan-1',

--- a/services/bot-client/src/commands/deny/detailTypes.test.ts
+++ b/services/bot-client/src/commands/deny/detailTypes.test.ts
@@ -24,7 +24,7 @@ const sampleEntry = {
 
 describe('constants', () => {
   it('should export entity type', () => {
-    expect(ENTITY_TYPE).toBe('deny-detail');
+    expect(ENTITY_TYPE).toBe('deny');
   });
 
   it('should export valid scopes', () => {

--- a/services/bot-client/src/commands/deny/detailTypes.ts
+++ b/services/bot-client/src/commands/deny/detailTypes.ts
@@ -10,7 +10,7 @@ import { DISCORD_COLORS, formatDateShort } from '@tzurot/common-types';
 import type { DenylistEntryResponse } from './browse.js';
 
 /** Entity type key for Redis session storage */
-export const ENTITY_TYPE = 'deny-detail';
+export const ENTITY_TYPE = 'deny';
 
 /** Valid scope values for denylist entries */
 export const VALID_SCOPES = ['BOT', 'GUILD', 'CHANNEL', 'PERSONALITY'] as const;

--- a/services/bot-client/src/commands/deny/detailTypes.ts
+++ b/services/bot-client/src/commands/deny/detailTypes.ts
@@ -7,6 +7,7 @@
 
 import { EmbedBuilder, ButtonBuilder, ButtonStyle, ActionRowBuilder } from 'discord.js';
 import { DISCORD_COLORS, formatDateShort } from '@tzurot/common-types';
+import type { BrowseContext } from '../../utils/dashboard/types.js';
 import type { DenylistEntryResponse } from './browse.js';
 
 /** Entity type key for Redis session storage */
@@ -26,7 +27,7 @@ export interface DenyDetailSession {
   reason: string | null;
   addedAt: string;
   addedBy: string;
-  browseContext: { page: number; filter: string; sort: string };
+  browseContext: BrowseContext;
   guildId: string | null;
 }
 

--- a/services/bot-client/src/commands/deny/view.test.ts
+++ b/services/bot-client/src/commands/deny/view.test.ts
@@ -134,6 +134,7 @@ describe('handleView', () => {
     await handleView(context);
 
     expect(showDetailView).toHaveBeenCalledWith(context.interaction, ENTRY_USER, {
+      source: 'browse',
       page: 0,
       filter: 'all',
       sort: 'date',
@@ -149,7 +150,7 @@ describe('handleView', () => {
     expect(showDetailView).toHaveBeenCalledWith(
       context.interaction,
       ENTRY_USER,
-      { page: 0, filter: 'all', sort: 'date' },
+      { source: 'browse', page: 0, filter: 'all', sort: 'date' },
       expect.stringContaining('Found 2 entries')
     );
   });
@@ -161,6 +162,7 @@ describe('handleView', () => {
     await handleView(context);
 
     expect(showDetailView).toHaveBeenCalledWith(context.interaction, ENTRY_GUILD, {
+      source: 'browse',
       page: 0,
       filter: 'all',
       sort: 'date',

--- a/services/bot-client/src/commands/deny/view.ts
+++ b/services/bot-client/src/commands/deny/view.ts
@@ -50,6 +50,7 @@ export async function handleView(context: DeferredCommandContext): Promise<void>
   if (matches.length === 1) {
     // Single match — show detail view directly
     await showDetailView(context.interaction, matches[0], {
+      source: 'browse',
       page: 0,
       filter: 'all',
       sort: 'date',
@@ -66,7 +67,7 @@ export async function handleView(context: DeferredCommandContext): Promise<void>
   await showDetailView(
     context.interaction,
     matches[0],
-    { page: 0, filter: 'all', sort: 'date' },
+    { source: 'browse', page: 0, filter: 'all', sort: 'date' },
     `Found ${matches.length} entries for \`${target.trim()}\`. Showing first match — use the type filter for a specific entry.`
   );
 }

--- a/services/bot-client/src/commands/persona/browse.test.ts
+++ b/services/bot-client/src/commands/persona/browse.test.ts
@@ -42,6 +42,7 @@ vi.mock('../../utils/dashboard/index.js', () => ({
   getSessionManager: () => ({
     set: mockSessionSet,
   }),
+  registerBrowseRebuilder: vi.fn(),
 }));
 
 vi.mock('@tzurot/common-types', async () => {

--- a/services/bot-client/src/commands/persona/browse.test.ts
+++ b/services/bot-client/src/commands/persona/browse.test.ts
@@ -13,6 +13,7 @@ import {
   isPersonaBrowseInteraction,
   isPersonaBrowseSelectInteraction,
 } from './browse.js';
+import { registerBrowseRebuilder } from '../../utils/dashboard/index.js';
 import { mockListPersonasResponse, mockGetPersonaResponse } from '@tzurot/common-types';
 
 // Valid UUIDs for tests
@@ -269,5 +270,57 @@ describe('isPersonaBrowseSelectInteraction', () => {
   it('should return false for non-browse-select interactions', () => {
     expect(isPersonaBrowseSelectInteraction('persona::browse::0::all::name::')).toBe(false);
     expect(isPersonaBrowseSelectInteraction('persona::other::action')).toBe(false);
+  });
+});
+
+// Capture the rebuilder callback registered at module-load BEFORE any
+// `vi.clearAllMocks()` in sibling describes wipes the call history. This
+// reference is what the adapter-body tests invoke directly (codecov/patch
+// coverage).
+const personaRebuilderCall = vi
+  .mocked(registerBrowseRebuilder)
+  .mock.calls.find(c => c[0] === 'persona');
+if (personaRebuilderCall === undefined) {
+  throw new Error('persona rebuilder was not registered at module load');
+}
+const personaRebuilder = personaRebuilderCall[1];
+
+describe('registered browse rebuilder', () => {
+  function createMockInteraction() {
+    return { user: { id: '123456789', username: 'testuser' } } as unknown as Parameters<
+      typeof personaRebuilder
+    >[0];
+  }
+
+  it('returns rebuilt view with banner on success', async () => {
+    mockCallGatewayApi.mockResolvedValueOnce({
+      ok: true,
+      data: mockListPersonasResponse([{ name: 'Persona A', isDefault: true }]),
+    });
+
+    const result = await personaRebuilder(
+      createMockInteraction(),
+      { source: 'browse', page: 0, filter: 'all', sort: 'name' },
+      '✅ Banner'
+    );
+
+    expect(result).not.toBeNull();
+    expect(result).toEqual({
+      content: '✅ Banner',
+      embeds: expect.any(Array),
+      components: expect.any(Array),
+    });
+  });
+
+  it('returns null when gateway fetch fails', async () => {
+    mockCallGatewayApi.mockResolvedValueOnce({ ok: false, error: 'Network' });
+
+    const result = await personaRebuilder(
+      createMockInteraction(),
+      { source: 'browse', page: 0, filter: 'all', sort: 'name' },
+      '✅ Banner'
+    );
+
+    expect(result).toBeNull();
   });
 });

--- a/services/bot-client/src/commands/persona/browse.ts
+++ b/services/bot-client/src/commands/persona/browse.ts
@@ -19,6 +19,7 @@ import {
   buildDashboardEmbed,
   buildDashboardComponents,
   getSessionManager,
+  registerBrowseRebuilder,
 } from '../../utils/dashboard/index.js';
 import {
   ITEMS_PER_PAGE,
@@ -379,3 +380,24 @@ export async function buildBrowseResponse(
 
   return buildBrowsePage(result.data.personas, page, sort);
 }
+
+// Register the persona browse rebuilder with the shared registry at module
+// load time. Consumed by `renderPostActionScreen` (destructive-action success
+// → direct re-render) and `handleSharedBackButton` (Back-to-Browse click).
+// See `utils/dashboard/browseRebuilderRegistry.ts` for why the registry lives
+// in module memory rather than on the session.
+registerBrowseRebuilder('persona', async (interaction, browseContext, successBanner) => {
+  const result = await buildBrowseResponse(
+    toGatewayUser(interaction.user),
+    browseContext.page,
+    (browseContext.sort ?? DEFAULT_SORT) as BrowseSortType
+  );
+  if (result === null) {
+    return null;
+  }
+  return {
+    content: successBanner,
+    embeds: [result.embed],
+    components: result.components,
+  };
+});

--- a/services/bot-client/src/commands/persona/dashboard.test.ts
+++ b/services/bot-client/src/commands/persona/dashboard.test.ts
@@ -63,11 +63,15 @@ const mockRequireDeferredSession = vi
     return mockGetSessionOrExpired(interaction, entityType, entityId, command);
   });
 
-// renderTerminalScreen is imported via the dashboard index barrel, but it
-// ALSO calls getSessionManager from SessionManager.js directly (bypassing the
-// barrel). Mock the source module + spy on renderTerminalScreen so test
-// assertions can target its call shape directly.
+// renderTerminalScreen, renderPostActionScreen, and handleSharedBackButton
+// are all exported from the dashboard barrel. They also import from other
+// dashboard source modules directly (SessionManager.js, terminalScreen.js)
+// which would bypass the barrel mock, so each one is stubbed at its source
+// module below. Assertions target the post-action screen (success + error
+// paths) and the shared back-button handler for routing.
 const mockRenderTerminalScreen = vi.fn();
+const mockRenderPostActionScreen = vi.fn();
+const mockHandleSharedBackButton = vi.fn();
 
 // Mock getSessionDataOrReply to delegate to mockSessionGet
 const mockGetSessionDataOrReply = vi
@@ -98,6 +102,19 @@ vi.mock('../../utils/dashboard/SessionManager.js', () => ({
 vi.mock('../../utils/dashboard/terminalScreen.js', () => ({
   renderTerminalScreen: (...args: unknown[]) => mockRenderTerminalScreen(...args),
 }));
+
+vi.mock('../../utils/dashboard/postActionScreen.js', () => ({
+  renderPostActionScreen: (...args: unknown[]) => mockRenderPostActionScreen(...args),
+}));
+
+vi.mock('../../utils/dashboard/sharedBackButtonHandler.js', () => ({
+  handleSharedBackButton: (...args: unknown[]) => mockHandleSharedBackButton(...args),
+}));
+
+// Intercept the browse.ts side-effect import (which calls
+// registerBrowseRebuilder at module load). The test doesn't exercise the
+// rebuilder path; a no-op module keeps the import graph valid.
+vi.mock('./browse.js', () => ({}));
 
 vi.mock('../../utils/dashboard/index.js', async () => {
   const actual = await vi.importActual('../../utils/dashboard/index.js');
@@ -558,7 +575,7 @@ describe('handleButton', () => {
     });
   });
 
-  it('should delete persona on confirm-delete button', async () => {
+  it('should route confirm-delete success through renderPostActionScreen', async () => {
     mockSessionGet.mockResolvedValue({
       data: { name: 'Test Persona' },
     });
@@ -574,23 +591,25 @@ describe('handleButton', () => {
       `/user/persona/${TEST_PERSONA_ID}`,
       expect.objectContaining({ method: 'DELETE' })
     );
-    // Success goes through renderTerminalScreen — dashboards opened from
-    // /persona browse keep Back-to-Browse; others get a clean terminal.
-    // renderTerminalScreen handles the session cleanup internally, so the
-    // handler no longer calls sessionManager.delete directly.
-    expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+    // Success routes through renderPostActionScreen with a formatted banner.
+    // The helper decides success-with-rebuild vs clean-terminal based on
+    // the session's browseContext; tested independently.
+    expect(mockRenderPostActionScreen).toHaveBeenCalledWith(
       expect.objectContaining({
         session: expect.objectContaining({
           entityType: 'persona',
           entityId: TEST_PERSONA_ID,
         }),
-        content: expect.stringContaining('has been deleted'),
+        outcome: expect.objectContaining({
+          kind: 'success',
+          banner: expect.stringContaining('Test Persona'),
+        }),
       })
     );
   });
 
-  it('should carry browseContext from session into the terminal screen on confirm-delete', async () => {
-    const browseContext = { page: 1, filter: 'all', sort: 'name' };
+  it('should carry browseContext from session into the post-action screen on confirm-delete', async () => {
+    const browseContext = { source: 'browse', page: 1, filter: 'all', sort: 'name' };
     mockSessionGet.mockResolvedValue({
       data: { name: 'Test Persona', browseContext },
     });
@@ -601,14 +620,14 @@ describe('handleButton', () => {
 
     await handleButton(createMockButtonInteraction(`persona::confirm-delete::${TEST_PERSONA_ID}`));
 
-    expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+    expect(mockRenderPostActionScreen).toHaveBeenCalledWith(
       expect.objectContaining({
         session: expect.objectContaining({ browseContext }),
       })
     );
   });
 
-  it('should show error on confirm-delete when delete fails', async () => {
+  it('should route confirm-delete failure through renderPostActionScreen as an error outcome', async () => {
     mockSessionGet.mockResolvedValue({
       data: { name: 'Test Persona' },
     });
@@ -619,10 +638,24 @@ describe('handleButton', () => {
 
     await handleButton(createMockButtonInteraction(`persona::confirm-delete::${TEST_PERSONA_ID}`));
 
-    expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+    expect(mockRenderPostActionScreen).toHaveBeenCalledWith(
       expect.objectContaining({
-        content: expect.stringContaining('Failed to delete'),
+        outcome: expect.objectContaining({
+          kind: 'error',
+          content: expect.stringContaining('Failed to delete'),
+        }),
       })
+    );
+  });
+
+  it('should route back button through handleSharedBackButton', async () => {
+    await handleButton(createMockButtonInteraction(`persona::back::${TEST_PERSONA_ID}`));
+
+    expect(mockDeferUpdate).toHaveBeenCalled();
+    expect(mockHandleSharedBackButton).toHaveBeenCalledWith(
+      expect.anything(),
+      'persona',
+      TEST_PERSONA_ID
     );
   });
 

--- a/services/bot-client/src/commands/persona/dashboard.ts
+++ b/services/bot-client/src/commands/persona/dashboard.ts
@@ -19,13 +19,14 @@ import { handleDashboardClose } from '../../utils/dashboard/closeHandler.js';
 import { createRefreshHandler, refreshDashboardUI } from '../../utils/dashboard/refreshHandler.js';
 import {
   extractAndMergeSectionValues,
+  formatSuccessBanner,
   getSessionManager,
   requireDeferredSession,
   getSessionDataOrReply,
   parseDashboardCustomId,
   isDashboardInteraction,
-  formatSessionExpiredMessage,
-  renderTerminalScreen,
+  renderPostActionScreen,
+  handleSharedBackButton,
 } from '../../utils/dashboard/index.js';
 import { handleDashboardSectionSelect } from '../../utils/dashboard/genericSelectMenuHandler.js';
 import { toGatewayUser } from '../../utils/userGatewayClient.js';
@@ -38,8 +39,11 @@ import {
 } from './config.js';
 import type { PersonaDetails } from './types.js';
 import { fetchPersona, updatePersona, deletePersona, isDefaultPersona } from './api.js';
-import { PersonaCustomIds, type PersonaBrowseSortType } from '../../utils/customIds.js';
-import { buildBrowseResponse } from './browse.js';
+import { PersonaCustomIds } from '../../utils/customIds.js';
+// Registers the persona browse rebuilder for renderPostActionScreen +
+// handleSharedBackButton. Importing the module is enough — the
+// registerBrowseRebuilder call at the bottom of browse.ts runs on load.
+import './browse.js';
 
 const logger = createLogger('persona-dashboard');
 const BROWSE_COMMAND = '/persona browse';
@@ -226,6 +230,11 @@ async function handleDeleteButton(interaction: ButtonInteraction, entityId: stri
 
 /**
  * Handle confirm-delete button - actually delete the persona.
+ *
+ * Routes success through `renderPostActionScreen` so the dashboard is
+ * replaced with the refreshed browse list (banner in `content`) when the
+ * user came from `/persona browse`, or a clean terminal otherwise. Error
+ * paths render as a terminal screen with Back-to-Browse where applicable.
  */
 async function handleConfirmDeleteButton(
   interaction: ButtonInteraction,
@@ -242,10 +251,7 @@ async function handleConfirmDeleteButton(
 
   const personaName = session?.data.name ?? 'Persona';
 
-  // Helper reads browseContext to decide: Back-to-Browse button + keep session,
-  // or cleanup. No explicit sessionManager.delete here — renderTerminalScreen
-  // handles the cleanup path internally when browseContext is absent.
-  const terminalSession = {
+  const postActionSession = {
     userId: interaction.user.id,
     entityType: 'persona' as const,
     entityId,
@@ -255,18 +261,18 @@ async function handleConfirmDeleteButton(
   const result = await deletePersona(entityId, toGatewayUser(interaction.user));
 
   if (!result.success) {
-    await renderTerminalScreen({
+    await renderPostActionScreen({
       interaction,
-      session: terminalSession,
-      content: `❌ Failed to delete persona: ${result.error}`,
+      session: postActionSession,
+      outcome: { kind: 'error', content: `❌ Failed to delete persona: ${result.error}` },
     });
     return;
   }
 
-  await renderTerminalScreen({
+  await renderPostActionScreen({
     interaction,
-    session: terminalSession,
-    content: `✅ **${personaName}** has been deleted.`,
+    session: postActionSession,
+    outcome: { kind: 'success', banner: formatSuccessBanner('Deleted persona', personaName) },
   });
 
   logger.info({ userId: interaction.user.id, entityId, personaName }, 'Persona deleted');
@@ -338,7 +344,8 @@ export async function handleButton(interaction: ButtonInteraction): Promise<void
       await handleCloseButton(interaction, entityId);
       break;
     case 'back':
-      await handleBackButton(interaction, entityId);
+      await interaction.deferUpdate();
+      await handleSharedBackButton(interaction, 'persona', entityId);
       break;
     case 'refresh':
       await handleRefreshButton(interaction, entityId);
@@ -352,77 +359,6 @@ export async function handleButton(interaction: ButtonInteraction): Promise<void
     case 'cancel-delete':
       await handleCancelDeleteButton(interaction, entityId);
       break;
-  }
-}
-
-/**
- * Handle back button - return to browse list
- */
-async function handleBackButton(interaction: ButtonInteraction, entityId: string): Promise<void> {
-  const session = await requireDeferredSession<FlattenedPersonaData>(
-    interaction,
-    'persona',
-    entityId,
-    BROWSE_COMMAND
-  );
-  if (session === null) {
-    return;
-  }
-
-  // All three error branches below render as terminal-with-no-back-button
-  // (re-adding the back-button would re-enter the failing path) and clean up
-  // the now-dead session. Share the session descriptor.
-  const noContextSession = {
-    userId: interaction.user.id,
-    entityType: 'persona' as const,
-    entityId,
-    browseContext: undefined,
-  };
-
-  const browseContext = session.data.browseContext;
-  if (!browseContext) {
-    // Session exists but no browse context — terminate cleanly.
-    await renderTerminalScreen({
-      interaction,
-      session: noContextSession,
-      content: formatSessionExpiredMessage(BROWSE_COMMAND),
-    });
-    return;
-  }
-
-  try {
-    const result = await buildBrowseResponse(
-      toGatewayUser(interaction.user),
-      browseContext.page,
-      browseContext.sort as PersonaBrowseSortType
-    );
-
-    if (result === null) {
-      await renderTerminalScreen({
-        interaction,
-        session: noContextSession,
-        content: '❌ Failed to load browse list. Please try again.',
-      });
-      return;
-    }
-
-    // Clean up the dashboard session since we're leaving it for the browse list.
-    const sessionManager = getSessionManager();
-    await sessionManager.delete(interaction.user.id, 'persona', entityId);
-
-    await interaction.editReply({
-      embeds: [result.embed],
-      components: result.components,
-    });
-
-    logger.info({ userId: interaction.user.id }, '[Persona] Returned to browse from dashboard');
-  } catch (error) {
-    logger.error({ err: error }, '[Persona] Failed to return to browse');
-    await renderTerminalScreen({
-      interaction,
-      session: noContextSession,
-      content: '❌ Failed to load browse list. Please try again.',
-    });
   }
 }
 

--- a/services/bot-client/src/commands/preset/browse.test.ts
+++ b/services/bot-client/src/commands/preset/browse.test.ts
@@ -11,6 +11,7 @@ import {
   isPresetBrowseInteraction,
   isPresetBrowseSelectInteraction,
 } from './browse.js';
+import { registerBrowseRebuilder } from '../../utils/dashboard/index.js';
 import type { StringSelectMenuInteraction } from 'discord.js';
 import { mockListLlmConfigsResponse, mockListWalletKeysResponse } from '@tzurot/common-types';
 
@@ -606,5 +607,74 @@ describe('handleBrowseSelect', () => {
       embeds: [],
       components: [],
     });
+  });
+});
+
+// Capture the rebuilder callback registered at module-load BEFORE any
+// `vi.clearAllMocks()` wipes the call history.
+const presetRebuilderCall = vi
+  .mocked(registerBrowseRebuilder)
+  .mock.calls.find(c => c[0] === 'preset');
+if (presetRebuilderCall === undefined) {
+  throw new Error('preset rebuilder was not registered at module load');
+}
+const presetRebuilder = presetRebuilderCall[1];
+
+describe('registered browse rebuilder', () => {
+  function createMockInteraction() {
+    return { user: { id: '123456789', username: 'testuser' } } as unknown as Parameters<
+      typeof presetRebuilder
+    >[0];
+  }
+
+  it('returns rebuilt view with banner on success', async () => {
+    mockCallGatewayApi.mockImplementation((path: string) => {
+      if (path === '/user/llm-config') {
+        return Promise.resolve({
+          ok: true,
+          data: mockListLlmConfigsResponse([
+            {
+              id: '00000000-0000-4000-8000-000000000001',
+              name: 'Default',
+              model: 'anthropic/claude-sonnet-4',
+              isGlobal: true,
+              isOwned: false,
+            },
+          ]),
+        });
+      }
+      if (path === '/wallet/list') {
+        return Promise.resolve({
+          ok: true,
+          data: mockListWalletKeysResponse([{ isActive: true }]),
+        });
+      }
+      return Promise.resolve({ ok: false, error: 'Unknown' });
+    });
+
+    const result = await presetRebuilder(
+      createMockInteraction(),
+      { source: 'browse', page: 0, filter: 'all', query: null },
+      '✅ Banner'
+    );
+
+    expect(result).not.toBeNull();
+    expect(result).toEqual({
+      content: '✅ Banner',
+      embeds: expect.any(Array),
+      components: expect.any(Array),
+    });
+  });
+
+  it('returns null when gateway fetch fails', async () => {
+    mockCallGatewayApi.mockResolvedValue({ ok: false, error: 'Server error' });
+
+    const result = await presetRebuilder(
+      createMockInteraction(),
+      { source: 'browse', page: 0, filter: 'all', query: null },
+      '✅ Banner'
+    );
+
+    expect(result).toBeNull();
   });
 });

--- a/services/bot-client/src/commands/preset/browse.test.ts
+++ b/services/bot-client/src/commands/preset/browse.test.ts
@@ -52,6 +52,7 @@ vi.mock('../../utils/dashboard/index.js', () => ({
   getSessionManager: () => ({
     set: mockSessionManagerSet,
   }),
+  registerBrowseRebuilder: vi.fn(),
 }));
 
 // Mock preset api

--- a/services/bot-client/src/commands/preset/browse.ts
+++ b/services/bot-client/src/commands/preset/browse.ts
@@ -29,6 +29,7 @@ import {
   buildDashboardEmbed,
   buildDashboardComponents,
   getSessionManager,
+  registerBrowseRebuilder,
 } from '../../utils/dashboard/index.js';
 import {
   ITEMS_PER_PAGE,
@@ -409,6 +410,25 @@ export async function buildBrowseResponse(
 
   return buildBrowsePage(presetResult.data.configs, filter, query, page, isGuestMode);
 }
+
+// Register the preset browse rebuilder with the shared registry at module
+// load time. Consumed by `renderPostActionScreen` (destructive-action success
+// → direct re-render) and `handleSharedBackButton` (Back-to-Browse click).
+registerBrowseRebuilder('preset', async (interaction, browseContext, successBanner) => {
+  const result = await buildBrowseResponse(toGatewayUser(interaction.user), {
+    page: browseContext.page,
+    filter: browseContext.filter as PresetBrowseFilter,
+    query: browseContext.query ?? null,
+  });
+  if (result === null) {
+    return null;
+  }
+  return {
+    content: successBanner,
+    embeds: [result.embed],
+    components: result.components,
+  };
+});
 
 /**
  * Handle browse pagination button clicks

--- a/services/bot-client/src/commands/preset/dashboard.ts
+++ b/services/bot-client/src/commands/preset/dashboard.ts
@@ -48,8 +48,11 @@ import {
   handleConfirmDeleteButton,
   handleCancelDeleteButton,
   handleCloneButton,
-  handleBackButton,
 } from './dashboardButtons.js';
+import { handleSharedBackButton } from '../../utils/dashboard/index.js';
+// Side-effect import: registers the preset browse rebuilder used by
+// renderPostActionScreen + handleSharedBackButton.
+import './browse.js';
 
 const logger = createLogger('preset-dashboard');
 
@@ -232,7 +235,8 @@ export async function handleButton(interaction: ButtonInteraction): Promise<void
       await handleCloseButton(interaction, entityId);
       break;
     case 'back':
-      await handleBackButton(interaction, entityId);
+      await interaction.deferUpdate();
+      await handleSharedBackButton(interaction, 'preset', entityId);
       break;
     case 'refresh':
       await handleRefreshButton(interaction, entityId);

--- a/services/bot-client/src/commands/preset/dashboardButtons.test.ts
+++ b/services/bot-client/src/commands/preset/dashboardButtons.test.ts
@@ -12,7 +12,6 @@ import {
   handleConfirmDeleteButton,
   handleCancelDeleteButton,
   handleCloneButton,
-  handleBackButton,
 } from './dashboardButtons.js';
 import { generateClonedName } from './cloneName.js';
 import { handleDashboardClose } from '../../utils/dashboard/closeHandler.js';
@@ -108,6 +107,8 @@ const mockCheckOwnership = vi
 
 const mockRenderTerminalScreen = vi.fn().mockResolvedValue(undefined);
 
+const mockRenderPostActionScreen = vi.fn().mockResolvedValue(undefined);
+
 vi.mock('../../utils/dashboard/index.js', async () => {
   const actual = await vi.importActual('../../utils/dashboard/index.js');
   return {
@@ -118,6 +119,7 @@ vi.mock('../../utils/dashboard/index.js', async () => {
     getSessionDataOrReply: (...args: unknown[]) => mockGetSessionDataOrReply(...args),
     checkOwnership: (...args: unknown[]) => mockCheckOwnership(...args),
     renderTerminalScreen: (...args: unknown[]) => mockRenderTerminalScreen(...args),
+    renderPostActionScreen: (...args: unknown[]) => mockRenderPostActionScreen(...args),
   };
 });
 
@@ -554,10 +556,10 @@ describe('Preset Dashboard Buttons', () => {
 
   describe('handleConfirmDeleteButton', () => {
     beforeEach(() => {
-      mockRenderTerminalScreen.mockClear();
+      mockRenderPostActionScreen.mockClear();
     });
 
-    it('delegates post-delete rendering to renderTerminalScreen', async () => {
+    it('routes delete success through renderPostActionScreen with a formatted banner', async () => {
       const mockInteraction = createMockButtonInteraction('preset::confirm-delete::preset-123');
 
       mockSessionManager.get.mockResolvedValue({
@@ -572,23 +574,25 @@ describe('Preset Dashboard Buttons', () => {
         '/user/llm-config/preset-123',
         expect.objectContaining({ method: 'DELETE' })
       );
-      // The helper owns the editReply + session cleanup behaviour — this
-      // suite just verifies the handler routes through it with the correct
-      // session shape (including browseContext, which drives back-button
-      // rendering inside the helper).
-      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+      // The helper decides success-with-rebuild vs clean-terminal based on
+      // the session's browseContext; this suite verifies the handler routes
+      // through it with the right outcome shape.
+      expect(mockRenderPostActionScreen).toHaveBeenCalledWith(
         expect.objectContaining({
           interaction: mockInteraction,
           session: expect.objectContaining({
             entityType: 'preset',
             entityId: 'preset-123',
           }),
-          content: expect.stringContaining('has been deleted'),
+          outcome: expect.objectContaining({
+            kind: 'success',
+            banner: expect.stringContaining('Preset To Delete'),
+          }),
         })
       );
     });
 
-    it('forwards browseContext into the terminal session so back-button renders', async () => {
+    it('forwards browseContext into the post-action session so re-render finds context', async () => {
       const mockInteraction = createMockButtonInteraction('preset::confirm-delete::preset-123');
 
       const browseCtx = { source: 'browse' as const, page: 1, filter: 'all' };
@@ -599,14 +603,14 @@ describe('Preset Dashboard Buttons', () => {
 
       await handleConfirmDeleteButton(mockInteraction, 'preset-123');
 
-      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+      expect(mockRenderPostActionScreen).toHaveBeenCalledWith(
         expect.objectContaining({
           session: expect.objectContaining({ browseContext: browseCtx }),
         })
       );
     });
 
-    it('routes the delete-failure path through renderTerminalScreen too', async () => {
+    it('routes the delete-failure path through renderPostActionScreen with an error outcome', async () => {
       const mockInteraction = createMockButtonInteraction('preset::confirm-delete::preset-123');
 
       mockSessionManager.get.mockResolvedValue({
@@ -616,9 +620,12 @@ describe('Preset Dashboard Buttons', () => {
 
       await handleConfirmDeleteButton(mockInteraction, 'preset-123');
 
-      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
+      expect(mockRenderPostActionScreen).toHaveBeenCalledWith(
         expect.objectContaining({
-          content: expect.stringContaining('Failed to delete'),
+          outcome: expect.objectContaining({
+            kind: 'error',
+            content: expect.stringContaining('Failed to delete'),
+          }),
         })
       );
     });
@@ -849,113 +856,9 @@ describe('Preset Dashboard Buttons', () => {
     });
   });
 
-  describe('handleBackButton', () => {
-    it('should return to browse list with saved context', async () => {
-      const mockInteraction = createMockButtonInteraction('preset::back::preset-123');
-      const browseContext = { source: 'browse' as const, page: 1, filter: 'owned' };
-
-      mockSessionManager.get.mockResolvedValue({
-        data: createMockFlattenedPreset({ browseContext }),
-      });
-      mockBuildBrowseResponse.mockResolvedValue({
-        embed: { data: { title: 'Browse Presets' } },
-        components: [],
-      });
-
-      await handleBackButton(mockInteraction, 'preset-123');
-
-      expect(mockInteraction.deferUpdate).toHaveBeenCalled();
-      expect(mockBuildBrowseResponse).toHaveBeenCalledWith(
-        expect.objectContaining({ discordId: 'user-123' }),
-        {
-          page: 1,
-          filter: 'owned',
-          query: null,
-        }
-      );
-      expect(mockSessionManager.delete).toHaveBeenCalledWith('user-123', 'preset', 'preset-123');
-    });
-
-    it('routes "no browseContext" through renderTerminalScreen with cleanup', async () => {
-      const mockInteraction = createMockButtonInteraction('preset::back::preset-123');
-
-      mockSessionManager.get.mockResolvedValue({
-        data: createMockFlattenedPreset({ browseContext: undefined }),
-      });
-
-      await handleBackButton(mockInteraction, 'preset-123');
-
-      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
-        expect.objectContaining({
-          content: expect.stringContaining('Session expired'),
-          // browseContext forced to undefined so the helper skips the back
-          // button (re-adding it would re-enter this failing path) and
-          // cleans up the session.
-          session: expect.objectContaining({ browseContext: undefined }),
-        })
-      );
-    });
-
-    it('should show expired message when session is null', async () => {
-      const mockInteraction = createMockButtonInteraction('preset::back::preset-123');
-
-      mockSessionManager.get.mockResolvedValue(null);
-
-      await handleBackButton(mockInteraction, 'preset-123');
-
-      expect(mockInteraction.editReply).toHaveBeenCalledWith({
-        content: expect.stringContaining('Session expired'),
-        embeds: [],
-        components: [],
-      });
-    });
-
-    it('routes buildBrowseResponse failure through renderTerminalScreen with no-button cleanup', async () => {
-      const mockInteraction = createMockButtonInteraction('preset::back::preset-123');
-      const browseContext = { source: 'browse' as const, page: 1, filter: 'all' };
-
-      mockSessionManager.get.mockResolvedValue({
-        data: createMockFlattenedPreset({ browseContext }),
-      });
-      mockBuildBrowseResponse.mockResolvedValue(null);
-
-      await handleBackButton(mockInteraction, 'preset-123');
-
-      expect(mockRenderTerminalScreen).toHaveBeenCalledWith(
-        expect.objectContaining({
-          content: expect.stringContaining('Failed to load browse list'),
-          session: expect.objectContaining({ browseContext: undefined }),
-        })
-      );
-    });
-
-    it('should include query from browseContext', async () => {
-      const mockInteraction = createMockButtonInteraction('preset::back::preset-123');
-      const browseContext = {
-        source: 'browse' as const,
-        page: 0,
-        filter: 'all',
-        query: 'gpt',
-      };
-
-      mockSessionManager.get.mockResolvedValue({
-        data: createMockFlattenedPreset({ browseContext }),
-      });
-      mockBuildBrowseResponse.mockResolvedValue({
-        embed: { data: { title: 'Browse Presets' } },
-        components: [],
-      });
-
-      await handleBackButton(mockInteraction, 'preset-123');
-
-      expect(mockBuildBrowseResponse).toHaveBeenCalledWith(
-        expect.objectContaining({ discordId: 'user-123' }),
-        {
-          page: 0,
-          filter: 'all',
-          query: 'gpt',
-        }
-      );
-    });
-  });
+  // handleBackButton was deleted from this module in favor of the shared
+  // handleSharedBackButton (utils/dashboard/sharedBackButtonHandler.ts),
+  // which is routed to from preset/dashboard.ts. Its behavioral coverage
+  // lives in sharedBackButtonHandler.test.ts, parameterized across every
+  // BrowseCapableEntityType.
 });

--- a/services/bot-client/src/commands/preset/dashboardButtons.ts
+++ b/services/bot-client/src/commands/preset/dashboardButtons.ts
@@ -20,8 +20,9 @@ import {
   getSessionDataOrReply,
   checkOwnership,
   DASHBOARD_MESSAGES,
-  formatSessionExpiredMessage,
+  formatSuccessBanner,
   renderTerminalScreen,
+  renderPostActionScreen,
 } from '../../utils/dashboard/index.js';
 import { refreshDashboardUI } from '../../utils/dashboard/refreshHandler.js';
 import {
@@ -33,7 +34,6 @@ import {
 } from './config.js';
 import { fetchPreset, updatePreset, fetchGlobalPreset, extractApiErrorMessage } from './api.js';
 import { createClonedPreset } from './cloneName.js';
-import { buildBrowseResponse, type PresetBrowseFilter } from './browse.js';
 
 // Re-export for backward compatibility
 export { buildPresetDashboardOptions } from './config.js';
@@ -242,6 +242,10 @@ export async function handleDeleteButton(
 
 /**
  * Handle confirm-delete button - actually delete the preset.
+ *
+ * Success routes through `renderPostActionScreen` → direct re-render of the
+ * browse list with a banner in `content` when the dashboard was opened from
+ * `/preset browse`. Failure paths render as a terminal with Back-to-Browse.
  */
 export async function handleConfirmDeleteButton(
   interaction: ButtonInteraction,
@@ -258,8 +262,7 @@ export async function handleConfirmDeleteButton(
 
   const presetName = session?.data.name ?? 'Preset';
 
-  // Helper reads browseContext to decide: Back-to-Browse button + keep session, or cleanup.
-  const terminalSession = {
+  const postActionSession = {
     userId: interaction.user.id,
     entityType: 'preset' as const,
     entityId,
@@ -277,27 +280,30 @@ export async function handleConfirmDeleteButton(
         { userId: interaction.user.id, status: result.status, entityId },
         '[Preset] Failed to delete preset'
       );
-      await renderTerminalScreen({
+      await renderPostActionScreen({
         interaction,
-        session: terminalSession,
-        content: `❌ Failed to delete preset: ${result.error}`,
+        session: postActionSession,
+        outcome: { kind: 'error', content: `❌ Failed to delete preset: ${result.error}` },
       });
       return;
     }
 
-    await renderTerminalScreen({
+    await renderPostActionScreen({
       interaction,
-      session: terminalSession,
-      content: `✅ **${presetName}** has been deleted.`,
+      session: postActionSession,
+      outcome: { kind: 'success', banner: formatSuccessBanner('Deleted preset', presetName) },
     });
 
     logger.info({ userId: interaction.user.id, entityId, presetName }, '[Preset] Deleted preset');
   } catch (error) {
     logger.error({ err: error, entityId }, 'Failed to delete preset');
-    await renderTerminalScreen({
+    await renderPostActionScreen({
       interaction,
-      session: terminalSession,
-      content: '❌ An error occurred while deleting the preset. Please try again.',
+      session: postActionSession,
+      outcome: {
+        kind: 'error',
+        content: '❌ An error occurred while deleting the preset. Please try again.',
+      },
     });
   }
 }
@@ -423,81 +429,6 @@ export async function handleCloneButton(
     await interaction.followUp({
       content: `❌ ${extractApiErrorMessage(error) ?? 'Failed to clone preset. Please try again.'}`,
       flags: MessageFlags.Ephemeral,
-    });
-  }
-}
-
-/**
- * Handle back button - return to browse list using saved context.
- */
-export async function handleBackButton(
-  interaction: ButtonInteraction,
-  entityId: string
-): Promise<void> {
-  const session = await requireDeferredSession<FlattenedPresetData>(
-    interaction,
-    'preset',
-    entityId,
-    PRESET_RECOVERY_CMD
-  );
-  if (session === null) {
-    return;
-  }
-
-  // All three error branches below render as terminal-with-no-back-button
-  // (re-adding the back-button would re-enter the failing path) and clean up
-  // the now-dead session. Share the session descriptor.
-  const noContextSession = {
-    userId: interaction.user.id,
-    entityType: 'preset' as const,
-    entityId,
-    browseContext: undefined,
-  };
-
-  const browseContext = session.data.browseContext;
-  if (!browseContext) {
-    // Session exists but no browse context — back-button shouldn't have been
-    // rendered in the first place.
-    await renderTerminalScreen({
-      interaction,
-      session: noContextSession,
-      content: formatSessionExpiredMessage(PRESET_RECOVERY_CMD),
-    });
-    return;
-  }
-
-  try {
-    const result = await buildBrowseResponse(toGatewayUser(interaction.user), {
-      page: browseContext.page,
-      filter: browseContext.filter as PresetBrowseFilter,
-      query: browseContext.query ?? null,
-    });
-
-    if (result === null) {
-      await renderTerminalScreen({
-        interaction,
-        session: noContextSession,
-        content: '❌ Failed to load browse list. Please try again.',
-      });
-      return;
-    }
-
-    // Clear the session since we're leaving the dashboard
-    const sessionManager = getSessionManager();
-    await sessionManager.delete(interaction.user.id, 'preset', entityId);
-
-    await interaction.editReply({ embeds: [result.embed], components: result.components });
-
-    logger.info(
-      { userId: interaction.user.id, entityId, page: browseContext.page },
-      '[Preset] Returned to browse from dashboard'
-    );
-  } catch (error) {
-    logger.error({ err: error, entityId }, '[Preset] Failed to return to browse');
-    await renderTerminalScreen({
-      interaction,
-      session: noContextSession,
-      content: '❌ Failed to load browse list. Please try again.',
     });
   }
 }

--- a/services/bot-client/src/utils/dashboard/refreshHandler.ts
+++ b/services/bot-client/src/utils/dashboard/refreshHandler.ts
@@ -23,8 +23,13 @@ const logger = createLogger('dashboard-refresh');
  * Options for creating a refresh handler
  */
 interface RefreshHandlerOptions<TData, TRaw = TData> {
-  /** Entity type (e.g., 'persona', 'character', 'preset') */
-  entityType: string;
+  /**
+   * Entity type — must match one of the browse-capable commands. Narrowed
+   * from `string` so the NOT_FOUND path can pass `entityType` into
+   * `renderTerminalScreen` (which requires `BrowseCapableEntityType`)
+   * without an unsafe cast.
+   */
+  entityType: BrowseCapableEntityType;
   /** Dashboard configuration */
   dashboardConfig: DashboardConfig<TData>;
   /** Function to fetch fresh data */
@@ -98,7 +103,7 @@ export function createRefreshHandler<TData, TRaw = TData>(
         interaction,
         session: {
           userId: interaction.user.id,
-          entityType: entityType as BrowseCapableEntityType,
+          entityType,
           entityId,
           browseContext: existingBrowseContext,
         },

--- a/services/bot-client/src/utils/dashboard/terminalScreen.structure.test.ts
+++ b/services/bot-client/src/utils/dashboard/terminalScreen.structure.test.ts
@@ -1,10 +1,23 @@
-// Enforces renderTerminalScreen usage in files listed in ENFORCED_FILES — add a file to migrate it; opt out per-line with `// intentionally-raw: <reason>`.
+// Two structural invariants for post-action rendering:
+//
+// 1. `ENFORCED_FILES` (raw-components check): files listed here must route any
+//    `components: []` through the shared helpers (`renderTerminalScreen` or
+//    `renderPostActionScreen`). Opt out per-line with `// intentionally-raw:
+//    <reason>` when the empty-components render is genuinely non-terminal
+//    (e.g., recoverable error paths, cancel flows).
+//
+// 2. `POST_ACTION_ENFORCED_FILES`: files listed here must additionally
+//    **mention** `renderPostActionScreen` somewhere — the signal that
+//    destructive-action terminal handlers have been migrated to the hybrid
+//    pattern. Catches silent regressions where someone replaces
+//    `renderPostActionScreen` with a raw `editReply` that still carries
+//    components (and thus slips past the #1 check).
 
 import { describe, it, expect } from 'vitest';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-// Add a file here when you migrate its delete/archive/confirm handlers.
+// Files that may not have unguarded `components: []` (raw terminal renders).
 const ENFORCED_FILES = [
   'services/bot-client/src/commands/preset/dashboardButtons.ts',
   'services/bot-client/src/commands/character/dashboardButtons.ts',
@@ -13,6 +26,17 @@ const ENFORCED_FILES = [
   'services/bot-client/src/utils/dashboard/refreshHandler.ts',
   'services/bot-client/src/commands/deny/detail.ts',
   'services/bot-client/src/commands/deny/detailEdit.ts',
+];
+
+// Files that must route destructive-action outcomes through
+// `renderPostActionScreen`. If someone deletes the call, this test fires
+// even when no raw `components: []` is introduced — the failure mode we
+// saw in the early `renderTerminalScreen` migration.
+const POST_ACTION_ENFORCED_FILES = [
+  'services/bot-client/src/commands/preset/dashboardButtons.ts',
+  'services/bot-client/src/commands/character/dashboardDeleteHandlers.ts',
+  'services/bot-client/src/commands/persona/dashboard.ts',
+  'services/bot-client/src/commands/deny/detail.ts',
 ];
 
 const REPO_ROOT = resolve(__dirname, '../../../../..');
@@ -50,5 +74,20 @@ describe('dashboard terminal screen discipline', () => {
       violations,
       `${file}: ${hint}\nOffenders:\n${JSON.stringify(violations, null, 2)}`
     ).toEqual([]);
+  });
+
+  it.each(POST_ACTION_ENFORCED_FILES)('%s uses renderPostActionScreen', file => {
+    const abs = resolve(REPO_ROOT, file);
+    expect(existsSync(abs), `POST_ACTION_ENFORCED_FILES entry not found at ${abs}`).toBe(true);
+    const source = readFileSync(abs, 'utf8');
+
+    const hint =
+      `Expected \`${file}\` to reference \`renderPostActionScreen\` — destructive-action ` +
+      `handlers should route through the shared helper so success → direct re-render of the ` +
+      `browse list and error → terminal with Back-to-Browse both work uniformly across commands. ` +
+      `If this file has legitimately moved off the post-action pattern, remove it from ` +
+      `POST_ACTION_ENFORCED_FILES in terminalScreen.structure.test.ts.`;
+
+    expect(source.includes('renderPostActionScreen'), hint).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

PR 2 of 2 for the hybrid post-action UX refactor. Flips preset, character, persona, and deny onto the shared infrastructure landed in PR #851.

After this PR lands, all four browse-capable commands share one codepath:
- **Success** → `renderPostActionScreen` → direct re-render of the refreshed browse list with a banner in `editReply.content` (one less click than the prior terminal-screen + Back-to-Browse flow).
- **Error** → terminal screen with Back-to-Browse button when `browseContext` is present.
- **Back button** → shared `handleSharedBackButton` replaces per-command implementations.

**Net diff: 550 insertions / 792 deletions** across 24 files. Net-negative LOC because the four per-command `handleBackButton` implementations collapse into one shared dispatcher.

## Migrations

### Rebuilder registration (per-command `browse.ts`, at module-bottom)

| Command | Signature captured | Notes |
|---|---|---|
| persona | `(user, page, sort)` | straightforward adapter |
| preset | `(user, { page, filter, query })` | straightforward adapter |
| character | captures `interaction.client` + `getConfig()` | satisfies 4-arg `buildBrowseResponse` |
| deny | `fetchEntries(userId)` + `buildBrowseResponse(entries, ...)` | adapter does the fetch since deny's builder is synchronous-over-entries |

### Per-command handler flips

Each command's `handleConfirmDelete` (or equivalent) now routes success/failure through `renderPostActionScreen`. Each command's `case 'back':` routes to `handleSharedBackButton`. Per-command `handleBackButton` implementations **deleted**.

### Deny-specific: ENTITY_TYPE normalization

`ENTITY_TYPE` changed from `'deny-detail'` to `'deny'`. Session-key mismatch against the `deny::back::...` button customId would have prevented the shared back-button lookup from finding the session. The `'deny-detail'` literal was only referenced internally within deny's own handlers; aligning with the `BrowseCapableEntityType` union unlocks the unified dispatch.

### refreshHandler.ts type tightening

`RefreshHandlerOptions.entityType` narrowed from `string` → `BrowseCapableEntityType`. Eliminates the `as BrowseCapableEntityType` cast that was called out in PR #843 review. All current callers already pass valid values.

## Review-tally fold-ins (from PRs #842/#843)

| # | Item | Addressed by |
|---|---|---|
| 1 | try/catch around `callGatewayApi` in character | Added in `handleDeleteButton` — network errors render graceful terminal instead of propagating |
| 2 | Schema-fallback test for character | New test: overrides `safeParse` to `{ success: false }`, asserts fallback banner fires |
| 3 | `session?.data.browseContext` null-guard | Centralized in `renderPostActionScreen`'s session-access code |
| 4 | `entityType: string` → `BrowseCapableEntityType` | refreshHandler.ts tightening |
| 5 | Three missing persona `handleBackButton` error-branch tests | Obviated — handler deleted; coverage lives in parameterized `sharedBackButtonHandler.test.ts` |
| 6 | `noContextSession` naming nit | Obviated — variable gone with handler consolidation |
| 7 | Deny `intentionally-raw` comment wording | Obviated — markers removed from terminal paths |
| 8 | Deny `intentionally-raw` marker self-containedness | Obviated — markers removed |

## Structural test extension

`terminalScreen.structure.test.ts` now has two invariant lists:

- `ENFORCED_FILES` (existing): forbids unguarded `components: []` in terminal-handler files.
- `POST_ACTION_ENFORCED_FILES` (**new**): files listed here must mention `renderPostActionScreen` explicitly. Catches the silent-regression class where someone replaces the post-action call with a raw `editReply` that still carries components (and thus slips past the existing check).

## Pagination-clamp audit

Verified both persona and deny already clamp `page` to `[0, totalPages-1]` — persona at `browse.ts:126`, deny via `calculatePaginationState`. No code changes needed. After a destructive action drops `totalPages`, the rebuilder's clamp fires and the view lands on the last populated page.

## Non-goals / deliberate choices

- **Deny's `handleModeToggle` error markers stay.** Those are recoverable in-place errors (session still alive, user can retry), not terminal post-actions. The markers communicate that distinction to future contributors.
- **Character's cancel-delete marker stays.** Still flagged in BACKLOG — would ideally restore the dashboard, but requires introducing a shared refresh helper to character's dashboard (out of scope).

## Test plan

- [x] `pnpm test` — 4360 tests pass across 14 packages
- [x] `pnpm quality` — lint + cpd + depcruise + typecheck + typecheck:spec all green
- [x] 11 structural tests (7 raw-components, 4 post-action-enforced) pass
- [ ] Manual Discord verification after auto-deploy: for each of the 4 commands, open dashboard from `/<command> browse`, delete an item, verify success banner renders above the refreshed browse list; delete an item from `/<command> view` (no browseContext), verify clean terminal

## Risks

- **Mobile content-field blindness**: post-deploy observation — success banner uses bright emoji + bold per council, but if users miss it on mobile, the fallback is embed-title prefix. Watch user feedback.
- **Interaction token expiry during rebuild**: character's browse rebuild does parallel fetches + username lookups. 15-min interaction window is generous; watch error rates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)