### PR TITLE
fix(voice-engine): re-encode multi-chunk TTS to opus so long replies fit in 8 MiB

### DIFF
--- a/services/ai-worker/src/services/voice/VoiceEngineClient.test.ts
+++ b/services/ai-worker/src/services/voice/VoiceEngineClient.test.ts
@@ -364,6 +364,84 @@ describe('VoiceEngineClient', () => {
     });
   });
 
+  describe('transcode', () => {
+    it('should POST to /v1/audio/transcode and return audio buffer + content type', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        arrayBuffer: vi.fn().mockResolvedValue(new Uint8Array([0x4f, 0x67, 0x67, 0x53]).buffer),
+        headers: { get: vi.fn().mockReturnValue('audio/ogg') },
+      });
+
+      const result = await client.transcode(Buffer.from('RIFFfakewav'));
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://voice-engine:8000/v1/audio/transcode',
+        expect.objectContaining({ method: 'POST' })
+      );
+      expect(result.audioBuffer).toBeInstanceOf(Buffer);
+      expect(result.contentType).toBe('audio/ogg');
+    });
+
+    it('should surface audio/wav content type when voice-engine fell back', async () => {
+      // voice-engine returns the original WAV if ffmpeg fails — caller must
+      // treat contentType as authoritative, not assume audio/ogg.
+      mockFetch.mockResolvedValue({
+        ok: true,
+        arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(100)),
+        headers: { get: vi.fn().mockReturnValue('audio/wav') },
+      });
+
+      const result = await client.transcode(Buffer.from('RIFFfakewav'));
+
+      expect(result.contentType).toBe('audio/wav');
+    });
+
+    it('should throw VoiceEngineError on non-OK response', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 413,
+        statusText: 'Payload Too Large',
+        json: vi.fn().mockResolvedValue({ detail: 'Audio file too large' }),
+      });
+
+      await expect(client.transcode(Buffer.from('huge-wav'))).rejects.toMatchObject({
+        name: 'VoiceEngineError',
+        status: 413,
+        message: expect.stringContaining('Audio file too large'),
+      });
+    });
+
+    it('should send WAV buffer as multipart file field', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(10)),
+        headers: { get: vi.fn().mockReturnValue('audio/ogg') },
+      });
+
+      await client.transcode(Buffer.from('RIFF-wav-data'));
+
+      const [, init] = mockFetch.mock.calls[0];
+      const body = init.body as FormData;
+      // FormData blob size should match input buffer length — structural proof
+      // the buffer was attached under the 'file' field the server expects.
+      const fileField = body.get('file');
+      expect(fileField).toBeInstanceOf(Blob);
+      expect((fileField as Blob).size).toBe(13);
+    });
+
+    it('should fall back to audio/wav when content-type header is missing', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(50)),
+        headers: { get: vi.fn().mockReturnValue(null) },
+      });
+
+      const result = await client.transcode(Buffer.from('RIFFfake'));
+
+      expect(result.contentType).toBe('audio/wav');
+    });
+  });
+
   describe('registerVoice', () => {
     it('should succeed without throwing on 200', async () => {
       mockFetch.mockResolvedValue({ ok: true });

--- a/services/ai-worker/src/services/voice/VoiceEngineClient.ts
+++ b/services/ai-worker/src/services/voice/VoiceEngineClient.ts
@@ -145,6 +145,41 @@ export class VoiceEngineClient {
     };
   }
 
+  /**
+   * Transcode a WAV buffer to Opus-in-Ogg via POST /v1/audio/transcode.
+   *
+   * Used by the multi-chunk TTS path: chunks are synthesized as WAV (so raw
+   * PCM can be concatenated), then the combined WAV is posted through here
+   * for a single Opus encode — matching single-chunk behavior so Discord
+   * never receives raw WAV that trips its 8 MiB attachment limit.
+   *
+   * On voice-engine-side ffmpeg failure, the server returns the original WAV
+   * with content-type audio/wav (defensive fallback — see /v1/audio/transcode
+   * docstring). Callers should treat contentType as authoritative rather than
+   * assuming audio/ogg.
+   */
+  async transcode(wavBuffer: Buffer): Promise<SynthesisResult> {
+    const formData = new FormData();
+    const blob = new Blob([new Uint8Array(wavBuffer)], { type: 'audio/wav' });
+    formData.append('file', blob, 'combined.wav');
+
+    const response = await this.fetchWithTimeout('/v1/audio/transcode', {
+      method: 'POST',
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const detail = await this.extractErrorDetail(response);
+      throw new VoiceEngineError(response.status, detail);
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    return {
+      audioBuffer: Buffer.from(arrayBuffer),
+      contentType: response.headers.get('content-type') ?? 'audio/wav',
+    };
+  }
+
   /** Register a voice via POST /v1/voices/register. */
   async registerVoice(voiceId: string, audioBuffer: Buffer, contentType: string): Promise<void> {
     const formData = new FormData();

--- a/services/ai-worker/src/services/voice/ttsSynthesizer.test.ts
+++ b/services/ai-worker/src/services/voice/ttsSynthesizer.test.ts
@@ -350,6 +350,7 @@ describe('synthesizeWithChunking', () => {
     vi.useFakeTimers();
     mockClient = {
       synthesize: vi.fn(),
+      transcode: vi.fn(),
     } as unknown as VoiceEngineClient;
   });
 
@@ -373,7 +374,7 @@ describe('synthesizeWithChunking', () => {
     expect(result).toBe(expectedResult);
   });
 
-  it('should synthesize each chunk and concatenate PCM for multi-chunk text', async () => {
+  it('should synthesize each chunk and re-encode combined WAV to Opus', async () => {
     // Build text that requires multiple chunks
     const sentence = 'This is a moderately long sentence for testing purposes. ';
     const repetitions = Math.ceil(2100 / sentence.length);
@@ -394,31 +395,41 @@ describe('synthesizeWithChunking', () => {
       };
     });
 
+    const opusBuffer = Buffer.from('OggS\0fake-opus-payload', 'ascii');
+    vi.mocked(mockClient.transcode).mockResolvedValue({
+      audioBuffer: opusBuffer,
+      contentType: 'audio/ogg',
+    });
+
     const result = await synthesizeWithChunking(mockClient, longText, 'voice-1');
 
     // Should have called synthesize for each chunk
     expect(vi.mocked(mockClient.synthesize).mock.calls.length).toBeGreaterThanOrEqual(2);
 
-    // Each chunk must request WAV format — extractPcmData/buildWavHeader below operate
+    // Each chunk must request WAV format — extractPcmData/buildWavHeader operate
     // on raw PCM, and Opus-in-Ogg can't be losslessly concatenated at the byte level.
     for (const call of vi.mocked(mockClient.synthesize).mock.calls) {
       expect(call[2]).toEqual({ format: 'wav' });
     }
 
-    // Result should be a WAV with combined PCM
-    expect(result.contentType).toBe('audio/wav');
+    // Transcode should be called exactly once, with the combined WAV
+    expect(mockClient.transcode).toHaveBeenCalledTimes(1);
+    const transcodedInput = vi.mocked(mockClient.transcode).mock.calls[0][0];
 
-    // Verify the WAV header
-    const resultBuffer = result.audioBuffer;
-    expect(resultBuffer.toString('ascii', 0, 4)).toBe('RIFF');
-    expect(resultBuffer.toString('ascii', 8, 12)).toBe('WAVE');
-    expect(resultBuffer.toString('ascii', 36, 40)).toBe('data');
+    // The combined WAV passed to transcode should have a valid header and the
+    // combined PCM payload — this is the byte-identical substitute for what
+    // used to be the return value before the Opus re-encode was added.
+    expect(transcodedInput.toString('ascii', 0, 4)).toBe('RIFF');
+    expect(transcodedInput.toString('ascii', 8, 12)).toBe('WAVE');
+    expect(transcodedInput.toString('ascii', 36, 40)).toBe('data');
+    expect(transcodedInput.readUInt32LE(24)).toBe(sampleRate);
 
-    // Verify sample rate is preserved
-    expect(resultBuffer.readUInt32LE(24)).toBe(sampleRate);
+    // Final result is whatever transcode returned — Opus in the happy path
+    expect(result.contentType).toBe('audio/ogg');
+    expect(result.audioBuffer).toBe(opusBuffer);
   });
 
-  it('should produce combined WAV with correct total PCM length', async () => {
+  it('should produce combined WAV with correct total PCM length before transcoding', async () => {
     // Create text that will result in exactly 2 chunks
     // Use a clear sentence boundary to make splitting predictable
     const chunk1Text = 'A'.repeat(1500) + '.';
@@ -440,21 +451,54 @@ describe('synthesizeWithChunking', () => {
       };
     });
 
-    const result = await synthesizeWithChunking(mockClient, longText, 'voice-1');
+    vi.mocked(mockClient.transcode).mockResolvedValue({
+      audioBuffer: Buffer.from('OggS\0'),
+      contentType: 'audio/ogg',
+    });
+
+    await synthesizeWithChunking(mockClient, longText, 'voice-1');
+
+    // Inspect the combined WAV that was passed to transcode()
+    const transcodedInput = vi.mocked(mockClient.transcode).mock.calls[0][0];
 
     // Total PCM should be pcm1 + pcm2 = 300 bytes
     const expectedPcmLength = pcm1.length + pcm2.length;
 
     // PCM data length is written at offset 40 in the WAV header
-    expect(result.audioBuffer.readUInt32LE(40)).toBe(expectedPcmLength);
+    expect(transcodedInput.readUInt32LE(40)).toBe(expectedPcmLength);
 
     // Total buffer should be 44 (header) + 300 (PCM)
-    expect(result.audioBuffer.length).toBe(44 + expectedPcmLength);
+    expect(transcodedInput.length).toBe(44 + expectedPcmLength);
 
     // Verify the PCM data content is correct (first 100 bytes = 0xAA, next 200 = 0xBB)
-    const pcmData = extractPcmData(result.audioBuffer);
+    const pcmData = extractPcmData(transcodedInput);
     expect(pcmData.length).toBe(expectedPcmLength);
     expect(pcmData.subarray(0, 100).every(b => b === 0xaa)).toBe(true);
     expect(pcmData.subarray(100, 300).every(b => b === 0xbb)).toBe(true);
+  });
+
+  it('should fall back to combined WAV when transcode fails', async () => {
+    // Behavior contract: if the Opus re-encode errors (voice-engine unreachable,
+    // ffmpeg missing, 5xx), ship the combined WAV instead of failing the whole
+    // synthesis. DiscordResponseSender already has a size-limit fallback notice
+    // for the pathological case where the WAV exceeds 8 MiB.
+    const longText = 'A'.repeat(1500) + '. ' + 'B'.repeat(1500) + '.';
+    expect(longText.length).toBeGreaterThan(2000);
+
+    const sampleRate = 22050;
+    vi.mocked(mockClient.synthesize).mockImplementation(async () => ({
+      audioBuffer: createFakeWav(Buffer.alloc(50, 0xcc), sampleRate),
+      contentType: 'audio/wav',
+    }));
+
+    vi.mocked(mockClient.transcode).mockRejectedValue(new Error('voice-engine unreachable'));
+
+    const result = await synthesizeWithChunking(mockClient, longText, 'voice-1');
+
+    expect(result.contentType).toBe('audio/wav');
+    expect(result.audioBuffer.toString('ascii', 0, 4)).toBe('RIFF');
+    // Transcode was attempted exactly once (no retry loop in synthesizer — retry
+    // belongs in the client if we want it, not here)
+    expect(mockClient.transcode).toHaveBeenCalledTimes(1);
   });
 });

--- a/services/ai-worker/src/services/voice/ttsSynthesizer.ts
+++ b/services/ai-worker/src/services/voice/ttsSynthesizer.ts
@@ -272,10 +272,30 @@ export async function synthesizeWithChunking(
   const header = buildWavHeader(totalPcmLength, sampleRate);
   const combined = Buffer.concat([header, ...pcmBuffers]);
 
-  logger.info(
-    { voiceId, totalAudioSize: combined.length, chunkCount: chunks.length },
-    'Multi-chunk TTS synthesis complete'
-  );
-
-  return { audioBuffer: combined, contentType: 'audio/wav' };
+  // Re-encode combined WAV to Opus-in-Ogg so multi-chunk output matches the
+  // single-chunk path's ~10x size reduction. Without this, ~2 min of speech
+  // lands around 11-13 MB WAV and trips Discord's 8 MiB attachment limit.
+  // On transcode failure, fall back to WAV — better to deliver too-large
+  // audio that Discord's sender will replace with a fallback notice than to
+  // fail the whole synthesis.
+  try {
+    const transcoded = await client.transcode(combined);
+    logger.info(
+      {
+        voiceId,
+        wavSize: combined.length,
+        encodedSize: transcoded.audioBuffer.length,
+        contentType: transcoded.contentType,
+        chunkCount: chunks.length,
+      },
+      'Multi-chunk TTS synthesis complete'
+    );
+    return transcoded;
+  } catch (error) {
+    logger.warn(
+      { err: error, voiceId, wavSize: combined.length, chunkCount: chunks.length },
+      'Multi-chunk Opus transcode failed — falling back to combined WAV'
+    );
+    return { audioBuffer: combined, contentType: 'audio/wav' };
+  }
 }

--- a/services/voice-engine/server.py
+++ b/services/voice-engine/server.py
@@ -670,6 +670,51 @@ async def tts_openai_compat(
 
 
 # ---------------------------------------------------------------------------
+# Audio Transcode
+# ---------------------------------------------------------------------------
+@app.post("/v1/audio/transcode")
+async def transcode_wav_to_opus(file: UploadFile = File(...)) -> Response:
+    """Transcode WAV audio to Opus-in-Ogg (64 kbps VBR, speech-tuned).
+
+    Intended for the multi-chunk TTS path in ai-worker: chunks are synthesized
+    as WAV (so raw PCM can be concatenated), then the combined WAV is posted
+    here for a single Opus encode. Keeps encoding config (bitrate, VBR, voip
+    profile) centralized with _encode_opus so single-chunk and multi-chunk
+    produce byte-identical Opus output.
+
+    Accepts: audio/wav bodies up to MAX_AUDIO_UPLOAD_BYTES (50 MB — well above
+    the ~15 MB that ~5 min of 22.05 kHz 16-bit mono PCM produces).
+
+    Returns: audio/ogg (Opus) on success; falls back to audio/wav (the original
+    input) if ffmpeg is unavailable or fails — matches the /v1/tts fallback so
+    callers see one consistent contract.
+    """
+    audio_bytes = await file.read()
+    if len(audio_bytes) > MAX_AUDIO_UPLOAD_BYTES:
+        raise HTTPException(status_code=413, detail="Audio file too large")
+    if len(audio_bytes) == 0:
+        raise HTTPException(status_code=400, detail="Empty audio body")
+
+    try:
+        loop = asyncio.get_running_loop()
+        opus_bytes, media_type = await _encode_opus(audio_bytes, loop)
+        logger.info(
+            "Transcoded audio",
+            extra={
+                "in_bytes": len(audio_bytes),
+                "out_bytes": len(opus_bytes),
+                "media_type": media_type,
+            },
+        )
+        return Response(content=opus_bytes, media_type=media_type)
+    except HTTPException:
+        raise
+    except Exception:
+        logger.error("Transcode failed", exc_info=True)
+        raise HTTPException(status_code=500, detail="Transcode failed") from None
+
+
+# ---------------------------------------------------------------------------
 # Voice Management
 # ---------------------------------------------------------------------------
 @app.get("/v1/voices")

--- a/services/voice-engine/tests/test_transcode.py
+++ b/services/voice-engine/tests/test_transcode.py
@@ -1,0 +1,98 @@
+"""Tests for POST /v1/audio/transcode endpoint.
+
+Covers the multi-chunk TTS path's re-encode step: ai-worker concatenates PCM
+into a combined WAV, posts it here, and expects Opus-in-Ogg back. On ffmpeg
+failure, the endpoint returns the original WAV so callers still get playable
+audio — matching /v1/tts's defensive fallback.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from server import MAX_AUDIO_UPLOAD_BYTES
+
+
+async def test_transcode_returns_opus_on_happy_path(client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Posted WAV is transcoded to Opus-in-Ogg via _encode_opus."""
+    import server
+
+    async def fake_encode(_wav_bytes: bytes, _loop: Any) -> tuple[bytes, str]:
+        return b"OggS\x00fake-opus-payload", "audio/ogg"
+
+    monkeypatch.setattr(server, "_encode_opus", fake_encode)
+
+    response = await client.post(
+        "/v1/audio/transcode",
+        files={"file": ("combined.wav", b"RIFF\x24\x00\x00\x00WAVE-fake", "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "audio/ogg"
+    assert response.content == b"OggS\x00fake-opus-payload"
+
+
+async def test_transcode_falls_back_to_wav_when_ffmpeg_fails(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When _encode_opus falls back (returns WAV + audio/wav), endpoint passes it through."""
+    import server
+
+    async def fake_encode_fallback(wav_bytes: bytes, _loop: Any) -> tuple[bytes, str]:
+        return wav_bytes, "audio/wav"
+
+    monkeypatch.setattr(server, "_encode_opus", fake_encode_fallback)
+    wav_in = b"RIFF\x24\x00\x00\x00WAVE-fallback-data"
+
+    response = await client.post(
+        "/v1/audio/transcode",
+        files={"file": ("combined.wav", wav_in, "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "audio/wav"
+    assert response.content == wav_in
+
+
+async def test_transcode_rejects_oversize_upload(client: httpx.AsyncClient) -> None:
+    """Uploads larger than MAX_AUDIO_UPLOAD_BYTES (50 MB) are rejected with 413."""
+    oversize = b"\x00" * (MAX_AUDIO_UPLOAD_BYTES + 1)
+
+    response = await client.post(
+        "/v1/audio/transcode",
+        files={"file": ("huge.wav", oversize, "audio/wav")},
+    )
+
+    assert response.status_code == 413
+
+
+async def test_transcode_rejects_empty_body(client: httpx.AsyncClient) -> None:
+    """Empty uploads return 400 (not a silent encode of nothing)."""
+    response = await client.post(
+        "/v1/audio/transcode",
+        files={"file": ("empty.wav", b"", "audio/wav")},
+    )
+
+    assert response.status_code == 400
+
+
+async def test_transcode_surfaces_unexpected_exceptions_as_500(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unexpected errors inside _encode_opus become 500 with a generic detail."""
+    import server
+
+    async def fake_encode_raise(_wav_bytes: bytes, _loop: Any) -> tuple[bytes, str]:
+        raise RuntimeError("something internal went wrong")
+
+    monkeypatch.setattr(server, "_encode_opus", fake_encode_raise)
+
+    response = await client.post(
+        "/v1/audio/transcode",
+        files={"file": ("combined.wav", b"RIFFdata", "audio/wav")},
+    )
+
+    assert response.status_code == 500


### PR DESCRIPTION
## Summary

Multi-chunk TTS synthesis (text > 2000 chars) was returning uncompressed WAV because Opus-in-Ogg can't be losslessly byte-concatenated. That WAV went straight to Discord, which rejects attachments >8 MiB — ~2 minutes of speech landed around 11-13 MB and got replaced with the `voice_omitted_too_long.txt` fallback notice. Two real user samples: 11.66 MB and 13.16 MB.

Single-chunk path was fine because voice-engine's `/v1/tts` already Opus-encodes via ffmpeg at 64 kbps VBR (~10x smaller). This PR closes the asymmetry.

## Design — Option A (council-reviewed)

Considered three approaches:

- **A (chosen)**: New transcode endpoint in voice-engine reusing `_encode_opus`. ai-worker's multi-chunk path posts the combined WAV through it after PCM concat. Encoding config stays single-source-of-truth.
- **B**: Move chunking heuristic into voice-engine. Cleaner end state but larger refactor; moves logic across service boundary.
- **C**: Add ffmpeg to ai-worker container, shell out from Node. Operationally independent but duplicates ffmpeg dependency and encoding config.

Gemini 3.1 Pro council pushed on Option A citing HTTP payload limits, memory spikes, and voice-engine semaphore contention. Empirical check rebutted the payload concern (voice-engine already accepts 50 MB uploads via `/v1/transcribe`). Memory and semaphore impact bounded and acceptable — transcode is sub-second at 100x realtime. Single-source-of-truth encoding config won the tiebreaker.

## Changes

### voice-engine (Python)

- `POST /v1/audio/transcode` — accepts WAV up to 50 MB (`MAX_AUDIO_UPLOAD_BYTES`), returns Opus/Ogg via existing `_encode_opus` helper. Falls back to WAV with `audio/wav` content-type if ffmpeg fails (mirrors `/v1/tts` fallback).
- 5 new tests: happy path, ffmpeg fallback, 413 oversize, 400 empty body, 500 unexpected error.

### ai-worker (TypeScript)

- `VoiceEngineClient.transcode(wavBuffer)` — thin wrapper. Returns `SynthesisResult` with authoritative `contentType` (caller must not assume `audio/ogg` — server may have fallen back to WAV).
- `ttsSynthesizer.synthesizeWithChunking` — after concat, calls `transcode()`. On error, falls back to shipping the combined WAV so synthesis doesn't fail outright — `DiscordResponseSender` already has the too-large notice as a last resort.
- Existing PCM-concat tests now assert against the buffer passed to `transcode()` instead of the return value. 1 new fallback test.

## Test plan

- [x] `pnpm test` — 4380 bot-client + 81 voice tests pass
- [x] `pnpm quality` — lint, typecheck, typecheck:spec, depcruise, cpd, knip all clean
- [x] `python -m pytest` in voice-engine — 66/66 tests pass (5 new)
- [x] `ruff check` + `mypy --strict` clean on new Python code
- [ ] Dev deploy verification: ask user to send a long message that would produce ~2 min of TTS; confirm the response attaches as `.ogg` (not `.txt` fallback notice)

## Before/after for a typical multi-chunk reply

| | Before | After |
|---|--------|-------|
| Format | `audio/wav` | `audio/ogg` (Opus 64 kbps VBR) |
| Size (2 min speech) | ~13 MB | ~1 MB |
| Discord attachment | Omitted, replaced by `.txt` notice | Attached as `voice.ogg` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)