### PR TITLE
fix(bot-client): encode dynamic url segments in admin-side helpers

### DIFF
--- a/services/bot-client/src/commands/admin/usage.ts
+++ b/services/bot-client/src/commands/admin/usage.ts
@@ -22,7 +22,7 @@ export async function handleUsage(context: DeferredCommandContext): Promise<void
       : '7d';
 
   try {
-    const response = await adminFetch(`/admin/usage?timeframe=${timeframe}`);
+    const response = await adminFetch(`/admin/usage?timeframe=${encodeURIComponent(timeframe)}`);
 
     if (!response.ok) {
       const errorText = await response.text();

--- a/services/bot-client/src/commands/preset/api.ts
+++ b/services/bot-client/src/commands/preset/api.ts
@@ -69,7 +69,7 @@ export async function fetchPreset(presetId: string, user: GatewayUser): Promise<
  * for dashboard compatibility.
  */
 export async function fetchGlobalPreset(presetId: string): Promise<PresetData | null> {
-  const response = await adminFetch(`/admin/llm-config/${presetId}`);
+  const response = await adminFetch(`/admin/llm-config/${encodeURIComponent(presetId)}`);
 
   if (!response.ok) {
     if (response.status === 404) {
@@ -122,7 +122,7 @@ export async function updateGlobalPreset(
   presetId: string,
   data: Record<string, unknown>
 ): Promise<PresetData> {
-  const response = await adminPutJson(`/admin/llm-config/${presetId}`, data);
+  const response = await adminPutJson(`/admin/llm-config/${encodeURIComponent(presetId)}`, data);
 
   if (!response.ok) {
     // Read body once, then try parsing as JSON (structured API error).


### PR DESCRIPTION
## Summary

Follow-up to PR #859 (callGatewayApi sweep). Applies `encodeURIComponent` to three admin-side HTTP helper calls that were intentionally excluded from that sweep as a distinct cleanup pass.

**Three sites fixed:**
- `bot-client/src/commands/preset/api.ts:72` — `fetchGlobalPreset` (`presetId` path segment)
- `bot-client/src/commands/preset/api.ts:125` — `updateGlobalPreset` (`presetId` path segment)
- `bot-client/src/commands/admin/usage.ts:25` — `handleUsage` (`timeframe` query param)

**Low real-world risk** — `presetId` is a gateway-returned UUID, `timeframe` is a slash-command enum. But `.claude/rules/00-critical.md` mandates encoding as defense in depth, including for trusted API-response values. CodeQL would flag these eventually.

**Broader grep verification**: confirmed no other `admin*` template-literal URLs with interpolation need fixing — `inspect/lookup.ts`, `deny/detail.ts`, `deny/detailEdit.ts` all already encode per-segment.

## Test plan

- [x] `pnpm test` — 4380 tests pass, including unchanged `preset/api.test.ts` (23) and `admin/usage.test.ts` (10)
- [x] `pnpm quality` clean (lint, typecheck, typecheck:spec, depcruise, cpd, knip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)