### PR TITLE
feat(ai-worker): migrate shapes.inc session cookie from Auth0 to Better Auth

### DIFF
--- a/packages/common-types/src/types/shapes-import.test.ts
+++ b/packages/common-types/src/types/shapes-import.test.ts
@@ -94,6 +94,24 @@ describe('parseShapesSessionCookieInput', () => {
         reason: 'malformed-value',
       });
     });
+
+    it('rejects name=value with a value shorter than the minimum length', () => {
+      // 'tooShort' is 8 chars; the min is 32. Same regex+length guard as the
+      // bare-token path must apply here so the parser's contract is uniform.
+      expect(parseShapesSessionCookieInput(`${SHAPES_SESSION_COOKIE_NAME}=tooShort`)).toEqual({
+        ok: false,
+        reason: 'malformed-value',
+      });
+    });
+
+    it('rejects name=value with a value containing disallowed characters', () => {
+      // Spaces fail the token-shape regex even though the length is fine.
+      expect(
+        parseShapesSessionCookieInput(
+          `${SHAPES_SESSION_COOKIE_NAME}=val with spaces and padding xxx`
+        )
+      ).toEqual({ ok: false, reason: 'malformed-value' });
+    });
   });
 
   describe('full Cookie: header paste defense', () => {
@@ -126,6 +144,17 @@ describe('parseShapesSessionCookieInput', () => {
       expect(parseShapesSessionCookieInput(legacy)).toEqual({
         ok: false,
         reason: 'wrong-cookie',
+      });
+    });
+
+    it('rejects a multi-cookie paste where the session cookie value itself is malformed', () => {
+      // Session cookie name is present but its value has disallowed characters
+      // and sub-minimum length. The multi-cookie path must apply the same
+      // shape/length guard as the bare-token and name=value paths.
+      const mixed = `_ga=GA1.1.12345; ${SHAPES_SESSION_COOKIE_NAME}=oops short; theme=dark`;
+      expect(parseShapesSessionCookieInput(mixed)).toEqual({
+        ok: false,
+        reason: 'malformed-value',
       });
     });
   });

--- a/packages/common-types/src/types/shapes-import.test.ts
+++ b/packages/common-types/src/types/shapes-import.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SHAPES_SESSION_COOKIE_NAME,
+  isShapesAllowedCookieName,
+  buildSessionCookie,
+  parseShapesSessionCookieInput,
+} from './shapes-import.js';
+
+describe('SHAPES_SESSION_COOKIE_NAME', () => {
+  it('is the Better Auth cookie name (case-sensitive, __Secure- prefix, dotted)', () => {
+    expect(SHAPES_SESSION_COOKIE_NAME).toBe('__Secure-better-auth.session_token');
+  });
+});
+
+describe('isShapesAllowedCookieName', () => {
+  it('accepts the session cookie name', () => {
+    expect(isShapesAllowedCookieName(SHAPES_SESSION_COOKIE_NAME)).toBe(true);
+  });
+
+  it('rejects legacy Auth0 cookie names', () => {
+    expect(isShapesAllowedCookieName('appSession')).toBe(false);
+    expect(isShapesAllowedCookieName('appSession.0')).toBe(false);
+    expect(isShapesAllowedCookieName('appSession.1')).toBe(false);
+  });
+
+  it('rejects arbitrary analytics / WAF cookie names', () => {
+    expect(isShapesAllowedCookieName('_ga')).toBe(false);
+    expect(isShapesAllowedCookieName('cf_clearance')).toBe(false);
+    expect(isShapesAllowedCookieName('x-datadome')).toBe(false);
+  });
+});
+
+describe('buildSessionCookie', () => {
+  it('prepends the cookie name to a raw token value', () => {
+    expect(buildSessionCookie('abc123')).toBe(`${SHAPES_SESSION_COOKIE_NAME}=abc123`);
+  });
+});
+
+describe('parseShapesSessionCookieInput', () => {
+  // A plausible Better Auth token value — 40 chars of allowed characters.
+  const validToken = 'a1b2c3d4e5f6g7h8.i9j0k1l2m3n4o5p6q7r8s9t0';
+  const expectedCookie = `${SHAPES_SESSION_COOKIE_NAME}=${validToken}`;
+
+  describe('bare token value path', () => {
+    it('normalizes a bare token value to name=value form', () => {
+      expect(parseShapesSessionCookieInput(validToken)).toEqual({
+        ok: true,
+        cookie: expectedCookie,
+      });
+    });
+
+    it('trims surrounding whitespace from bare tokens', () => {
+      expect(parseShapesSessionCookieInput(`   ${validToken}\n`)).toEqual({
+        ok: true,
+        cookie: expectedCookie,
+      });
+    });
+
+    it('rejects bare values shorter than the minimum length', () => {
+      expect(parseShapesSessionCookieInput('tooShort')).toEqual({
+        ok: false,
+        reason: 'malformed-value',
+      });
+    });
+
+    it('rejects bare values containing characters outside the allowed set', () => {
+      // 40 chars with a disallowed space embedded.
+      const badValue = 'a1b2c3d4e5f6g7h8 i9j0k1l2m3n4o5p6q7r8s9t0';
+      expect(parseShapesSessionCookieInput(badValue)).toEqual({
+        ok: false,
+        reason: 'malformed-value',
+      });
+    });
+  });
+
+  describe('single name=value pair path', () => {
+    it('accepts the expected name=value pair verbatim', () => {
+      expect(parseShapesSessionCookieInput(expectedCookie)).toEqual({
+        ok: true,
+        cookie: expectedCookie,
+      });
+    });
+
+    it('rejects a name=value pair with a different cookie name', () => {
+      expect(parseShapesSessionCookieInput(`appSession=${validToken}`)).toEqual({
+        ok: false,
+        reason: 'wrong-cookie',
+      });
+    });
+
+    it('rejects name=value with an empty value', () => {
+      expect(parseShapesSessionCookieInput(`${SHAPES_SESSION_COOKIE_NAME}=`)).toEqual({
+        ok: false,
+        reason: 'malformed-value',
+      });
+    });
+  });
+
+  describe('full Cookie: header paste defense', () => {
+    it('extracts the session cookie from a multi-cookie header string', () => {
+      const fullHeader = `_ga=GA1.1.12345; ${SHAPES_SESSION_COOKIE_NAME}=${validToken}; theme=dark`;
+      expect(parseShapesSessionCookieInput(fullHeader)).toEqual({
+        ok: true,
+        cookie: expectedCookie,
+      });
+    });
+
+    it('handles extra whitespace around semicolons in a header paste', () => {
+      const messy = `  _ga=GA1.1.12345  ;  ${SHAPES_SESSION_COOKIE_NAME}=${validToken}  ;  theme=dark `;
+      expect(parseShapesSessionCookieInput(messy)).toEqual({
+        ok: true,
+        cookie: expectedCookie,
+      });
+    });
+
+    it('rejects a multi-cookie header that lacks the session cookie name', () => {
+      const wrong = '_ga=GA1.1.12345; cf_clearance=abc123; theme=dark';
+      expect(parseShapesSessionCookieInput(wrong)).toEqual({
+        ok: false,
+        reason: 'wrong-cookie',
+      });
+    });
+
+    it('rejects a legacy Auth0 cookie paste (appSession.0 + appSession.1)', () => {
+      const legacy = 'appSession.0=part0value; appSession.1=part1value';
+      expect(parseShapesSessionCookieInput(legacy)).toEqual({
+        ok: false,
+        reason: 'wrong-cookie',
+      });
+    });
+  });
+
+  describe('empty input', () => {
+    it('rejects the empty string', () => {
+      expect(parseShapesSessionCookieInput('')).toEqual({ ok: false, reason: 'empty' });
+    });
+
+    it('rejects a whitespace-only string', () => {
+      expect(parseShapesSessionCookieInput('   \n\t ')).toEqual({ ok: false, reason: 'empty' });
+    });
+  });
+});

--- a/packages/common-types/src/types/shapes-import.ts
+++ b/packages/common-types/src/types/shapes-import.ts
@@ -363,7 +363,14 @@ export type ShapesSessionInputResult =
  * persisting (tracked separately).
  */
 const SHAPES_TOKEN_SHAPE = /^[A-Za-z0-9._-]+$/;
-const SHAPES_TOKEN_MIN_LENGTH = 32;
+
+/**
+ * Minimum length for a plausible Better Auth session token value.
+ * Exported so UI-layer gates (e.g., Discord modal `.setMinLength()`) can
+ * stay aligned with the parser — otherwise a user whose input passes the
+ * UI gate but fails the parser's check sees a confusing UX mismatch.
+ */
+export const SHAPES_TOKEN_MIN_LENGTH = 32;
 
 /**
  * Parse the user-supplied modal input into a normalized cookie string.
@@ -377,7 +384,8 @@ const SHAPES_TOKEN_MIN_LENGTH = 32;
  * Rejects (returns `{ ok: false }`):
  *  - Empty input
  *  - Any cookie-like input that doesn't include `SHAPES_SESSION_COOKIE_NAME` (user pasted wrong thing)
- *  - Bare values that fail the token-shape regex or minimum length
+ *  - A value (extracted from any of the three paths) that fails the token-shape
+ *    regex or minimum-length check
  *
  * The defense against shape (3) specifically catches the common failure mode
  * where users copy the `Cookie:` request header from the Network tab instead
@@ -401,7 +409,7 @@ export function parseShapesSessionCookieInput(rawInput: string): ShapesSessionIn
       const name = trimmed.substring(0, eqIdx);
       const value = trimmed.substring(eqIdx + 1);
       if (name === SHAPES_SESSION_COOKIE_NAME) {
-        if (value.length === 0) {
+        if (!isPlausibleTokenValue(value)) {
           return { ok: false, reason: 'malformed-value' };
         }
         return { ok: true, cookie: buildSessionCookie(value) };
@@ -411,8 +419,18 @@ export function parseShapesSessionCookieInput(rawInput: string): ShapesSessionIn
   }
 
   // Bare token value path — sanity-check shape and length.
-  if (input.length < SHAPES_TOKEN_MIN_LENGTH || !SHAPES_TOKEN_SHAPE.test(input)) {
+  if (!isPlausibleTokenValue(input)) {
     return { ok: false, reason: 'malformed-value' };
   }
   return { ok: true, cookie: buildSessionCookie(input) };
+}
+
+/**
+ * Apply the token shape + minimum-length check. Shared by every branch of
+ * `parseShapesSessionCookieInput` so a 16-char bare value and a 16-char
+ * `name=value` value both fail the same way — no surprise where a format
+ * is permissive in one path and strict in another.
+ */
+function isPlausibleTokenValue(value: string): boolean {
+  return value.length >= SHAPES_TOKEN_MIN_LENGTH && SHAPES_TOKEN_SHAPE.test(value);
 }

--- a/packages/common-types/src/types/shapes-import.ts
+++ b/packages/common-types/src/types/shapes-import.ts
@@ -303,3 +303,116 @@ export const SHAPES_BASE_URL = 'https://shapes.inc';
  */
 export const SHAPES_USER_AGENT =
   'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36';
+
+/**
+ * Name of the shapes.inc session cookie (Better Auth, as of 2026-04).
+ * The `__Secure-` prefix is a browser-enforced rule: the cookie is only set/sent
+ * over HTTPS, which matches our traffic since `SHAPES_BASE_URL` is HTTPS.
+ */
+export const SHAPES_SESSION_COOKIE_NAME = '__Secure-better-auth.session_token';
+
+/**
+ * Predicate: is `name` a cookie the shapes fetcher should accept in its jar?
+ *
+ * Scoped to just the Better Auth session cookie today. This prevents analytics
+ * (GA, Datadome) or bot-protection (Cloudflare `cf_clearance`) cookies served by
+ * shapes.inc from being echoed back on subsequent requests. If shapes.inc ever
+ * adds a required WAF-routing cookie, add the case here — do not broaden the
+ * fetcher to accept arbitrary names.
+ *
+ * Exposed as a predicate function rather than an exported Set so callers cannot
+ * accidentally mutate the allowlist at runtime.
+ */
+export function isShapesAllowedCookieName(name: string): boolean {
+  return name === SHAPES_SESSION_COOKIE_NAME;
+}
+
+/**
+ * Build a cookie string suitable for the `Cookie:` request header from a raw
+ * Better Auth session token value.
+ *
+ * Callers outside this module should not need to know the cookie-name format —
+ * they hand in the opaque token value, this returns `name=value`.
+ */
+export function buildSessionCookie(tokenValue: string): string {
+  return `${SHAPES_SESSION_COOKIE_NAME}=${tokenValue}`;
+}
+
+/**
+ * Outcome of parsing user-supplied cookie input at the auth modal boundary.
+ *
+ * - `ok: true, cookie` — normalized `name=value` string ready for the fetcher jar
+ * - `ok: false, reason: 'empty'` — input was blank after trimming
+ * - `ok: false, reason: 'wrong-cookie'` — input looked like a cookie string
+ *   (contained `=` or `;`) but did not include `SHAPES_SESSION_COOKIE_NAME`.
+ *   Classic "user pasted the whole Request Headers Cookie: line" mistake.
+ * - `ok: false, reason: 'malformed-value'` — input looked like a bare token
+ *   value but failed the basic shape check (regex/length).
+ */
+export type ShapesSessionInputResult =
+  | { ok: true; cookie: string }
+  | { ok: false; reason: 'empty' | 'wrong-cookie' | 'malformed-value' };
+
+/**
+ * Regex for a plausible Better Auth session token value. URL-safe base64 /
+ * hex / signed-value characters; minimum-length sanity check only.
+ *
+ * Intentionally permissive: Better Auth tokens are opaque and the format can
+ * change. This is a best-effort client-side sanity check, NOT authoritative
+ * validation — the gateway should live-preflight against shapes.inc before
+ * persisting (tracked separately).
+ */
+const SHAPES_TOKEN_SHAPE = /^[A-Za-z0-9._-]+$/;
+const SHAPES_TOKEN_MIN_LENGTH = 32;
+
+/**
+ * Parse the user-supplied modal input into a normalized cookie string.
+ *
+ * Accepts three input shapes, in order of preference:
+ *  1. Bare token value: `"abc123...xyz"` → prepended with the cookie name.
+ *  2. Single `name=value` pair: `"__Secure-better-auth.session_token=abc..."` → normalized to that form.
+ *  3. Full `Cookie:` header: `"_ga=1; __Secure-better-auth.session_token=abc; theme=dark"` →
+ *     extract just the expected cookie and discard the rest.
+ *
+ * Rejects (returns `{ ok: false }`):
+ *  - Empty input
+ *  - Any cookie-like input that doesn't include `SHAPES_SESSION_COOKIE_NAME` (user pasted wrong thing)
+ *  - Bare values that fail the token-shape regex or minimum length
+ *
+ * The defense against shape (3) specifically catches the common failure mode
+ * where users copy the `Cookie:` request header from the Network tab instead
+ * of a single cookie value from the Application tab.
+ */
+export function parseShapesSessionCookieInput(rawInput: string): ShapesSessionInputResult {
+  const input = rawInput.trim();
+  if (input.length === 0) {
+    return { ok: false, reason: 'empty' };
+  }
+
+  const looksLikeCookieString = input.includes('=') || input.includes(';');
+  if (looksLikeCookieString) {
+    // Parse as semicolon-delimited cookie pairs and extract the expected name.
+    for (const part of input.split(';')) {
+      const trimmed = part.trim();
+      const eqIdx = trimmed.indexOf('=');
+      if (eqIdx <= 0) {
+        continue;
+      }
+      const name = trimmed.substring(0, eqIdx);
+      const value = trimmed.substring(eqIdx + 1);
+      if (name === SHAPES_SESSION_COOKIE_NAME) {
+        if (value.length === 0) {
+          return { ok: false, reason: 'malformed-value' };
+        }
+        return { ok: true, cookie: buildSessionCookie(value) };
+      }
+    }
+    return { ok: false, reason: 'wrong-cookie' };
+  }
+
+  // Bare token value path — sanity-check shape and length.
+  if (input.length < SHAPES_TOKEN_MIN_LENGTH || !SHAPES_TOKEN_SHAPE.test(input)) {
+    return { ok: false, reason: 'malformed-value' };
+  }
+  return { ok: true, cookie: buildSessionCookie(input) };
+}

--- a/services/ai-worker/src/jobs/ShapesExportJob.test.ts
+++ b/services/ai-worker/src/jobs/ShapesExportJob.test.ts
@@ -18,7 +18,9 @@ vi.mock('@tzurot/common-types', async importOriginal => {
       warn: vi.fn(),
       error: vi.fn(),
     }),
-    decryptApiKey: vi.fn().mockReturnValue('appSession.0=abc'),
+    decryptApiKey: vi
+      .fn()
+      .mockReturnValue('__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq'),
     encryptApiKey: vi
       .fn()
       .mockReturnValue({ iv: 'new-iv', content: 'new-content', tag: 'new-tag' }),

--- a/services/ai-worker/src/jobs/ShapesExportJob.test.ts
+++ b/services/ai-worker/src/jobs/ShapesExportJob.test.ts
@@ -20,7 +20,9 @@ vi.mock('@tzurot/common-types', async importOriginal => {
     }),
     decryptApiKey: vi
       .fn()
-      .mockReturnValue('__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq'),
+      .mockReturnValue(
+        '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef'
+      ),
     encryptApiKey: vi
       .fn()
       .mockReturnValue({ iv: 'new-iv', content: 'new-content', tag: 'new-tag' }),

--- a/services/ai-worker/src/jobs/ShapesImportJob.test.ts
+++ b/services/ai-worker/src/jobs/ShapesImportJob.test.ts
@@ -21,7 +21,9 @@ vi.mock('@tzurot/common-types', async importOriginal => {
       warn: vi.fn(),
       error: vi.fn(),
     }),
-    decryptApiKey: vi.fn().mockReturnValue('appSession.0=abc; appSession.1=def'),
+    decryptApiKey: vi
+      .fn()
+      .mockReturnValue('__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq'),
     encryptApiKey: vi
       .fn()
       .mockReturnValue({ iv: 'new-iv', content: 'new-content', tag: 'new-tag' }),

--- a/services/ai-worker/src/jobs/ShapesImportJob.test.ts
+++ b/services/ai-worker/src/jobs/ShapesImportJob.test.ts
@@ -23,7 +23,9 @@ vi.mock('@tzurot/common-types', async importOriginal => {
     }),
     decryptApiKey: vi
       .fn()
-      .mockReturnValue('__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq'),
+      .mockReturnValue(
+        '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef'
+      ),
     encryptApiKey: vi
       .fn()
       .mockReturnValue({ iv: 'new-iv', content: 'new-content', tag: 'new-tag' }),

--- a/services/ai-worker/src/services/shapes/ShapesDataFetcher.test.ts
+++ b/services/ai-worker/src/services/shapes/ShapesDataFetcher.test.ts
@@ -130,7 +130,7 @@ describe('ShapesDataFetcher', () => {
       setupSuccessfulFetch();
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
       });
 
       // Advance timers for delays between requests
@@ -150,7 +150,7 @@ describe('ShapesDataFetcher', () => {
       setupSuccessfulFetch();
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
       });
       await vi.advanceTimersByTimeAsync(5000);
       await promise;
@@ -159,7 +159,7 @@ describe('ShapesDataFetcher', () => {
         expect.stringContaining('/api/shapes/username/test-shape'),
         expect.objectContaining({
           headers: expect.objectContaining({
-            Cookie: 'appSession.0=abc; appSession.1=def',
+            Cookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
           }),
         })
       );
@@ -178,7 +178,7 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(200, SAMPLE_USER_PERSONALIZATION));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
       });
       await vi.advanceTimersByTimeAsync(5000);
       const result = await promise;
@@ -197,7 +197,7 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(200, {}));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
       });
       await vi.advanceTimersByTimeAsync(5000);
       const result = await promise;
@@ -229,7 +229,7 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(200, {}));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
       });
       await vi.advanceTimersByTimeAsync(10000);
       const result = await promise;
@@ -244,7 +244,7 @@ describe('ShapesDataFetcher', () => {
       mockFetch.mockResolvedValueOnce(createMockResponse(401, { error: 'Unauthorized' }));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
       });
       const assertion = expect(promise).rejects.toThrow(ShapesAuthError);
       await vi.advanceTimersByTimeAsync(5000);
@@ -255,7 +255,7 @@ describe('ShapesDataFetcher', () => {
       mockFetch.mockResolvedValueOnce(createMockResponse(403, { error: 'Forbidden' }));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
       });
       const assertion = expect(promise).rejects.toThrow(ShapesAuthError);
       await vi.advanceTimersByTimeAsync(5000);
@@ -266,7 +266,7 @@ describe('ShapesDataFetcher', () => {
       mockFetch.mockResolvedValueOnce(createMockResponse(404, { error: 'Not found' }));
 
       const promise = fetcher.fetchShapeData('nonexistent', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
       });
       const assertion = expect(promise).rejects.toThrow(ShapesNotFoundError);
       await vi.advanceTimersByTimeAsync(5000);
@@ -281,7 +281,7 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(429, { error: 'Rate limited' }));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
       });
       const assertion = expect(promise).rejects.toThrow(ShapesRateLimitError);
       await vi.advanceTimersByTimeAsync(30000);
@@ -295,7 +295,7 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(500, { error: 'Server error' }));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
       });
       const assertion = expect(promise).rejects.toThrow(ShapesServerError);
       await vi.advanceTimersByTimeAsync(30000);
@@ -312,7 +312,7 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(502, { error: 'Bad Gateway' }));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
       });
       const assertion = expect(promise).rejects.toThrow(ShapesServerError);
       await vi.advanceTimersByTimeAsync(30000);
@@ -326,7 +326,7 @@ describe('ShapesDataFetcher', () => {
       mockFetch.mockResolvedValueOnce(createMockResponse(422, { error: 'Unprocessable' }));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
       });
       const assertion = expect(promise).rejects.toThrow(ShapesFetchError);
       await vi.advanceTimersByTimeAsync(5000);
@@ -341,7 +341,7 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(200, {}));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
       });
       await vi.advanceTimersByTimeAsync(5000);
       const result = await promise;
@@ -359,7 +359,7 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(200, SAMPLE_USER_PERSONALIZATION));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
       });
       await vi.advanceTimersByTimeAsync(5000);
       const result = await promise;
@@ -384,7 +384,7 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(200, {}));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
       });
       await vi.advanceTimersByTimeAsync(30000);
       const result = await promise;
@@ -408,7 +408,7 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(200, {}));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
       });
       await vi.advanceTimersByTimeAsync(30000);
       const result = await promise;
@@ -432,7 +432,7 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(200, {}));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
       });
       await vi.advanceTimersByTimeAsync(30000);
       const result = await promise;
@@ -444,7 +444,7 @@ describe('ShapesDataFetcher', () => {
       mockFetch.mockResolvedValueOnce(createMockResponse(401, { error: 'Unauthorized' }));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
       });
       const assertion = expect(promise).rejects.toThrow(ShapesAuthError);
       await vi.advanceTimersByTimeAsync(5000);
@@ -458,7 +458,7 @@ describe('ShapesDataFetcher', () => {
       mockFetch.mockResolvedValueOnce(createMockResponse(404, { error: 'Not found' }));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
       });
       const assertion = expect(promise).rejects.toThrow(ShapesNotFoundError);
       await vi.advanceTimersByTimeAsync(5000);
@@ -471,7 +471,7 @@ describe('ShapesDataFetcher', () => {
       mockFetch.mockResolvedValueOnce(createMockResponse(422, { error: 'Unprocessable' }));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
       });
       const assertion = expect(promise).rejects.toThrow(ShapesFetchError);
       await vi.advanceTimersByTimeAsync(5000);
@@ -495,7 +495,7 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(200, {}));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
       });
       await vi.advanceTimersByTimeAsync(30000);
       const result = await promise;
@@ -520,7 +520,7 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(200, {}));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
       });
       await vi.advanceTimersByTimeAsync(30000);
       const result = await promise;
@@ -533,7 +533,7 @@ describe('ShapesDataFetcher', () => {
       mockFetch.mockRejectedValueOnce(new TypeError('Cannot read properties of undefined'));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
       });
       const assertion = expect(promise).rejects.toThrow(TypeError);
       await vi.advanceTimersByTimeAsync(5000);
@@ -550,7 +550,7 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(429, { error: 'Rate limited' }));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
       });
       const assertion = expect(promise).rejects.toThrow(ShapesRateLimitError);
       await vi.advanceTimersByTimeAsync(30000);
@@ -567,7 +567,7 @@ describe('ShapesDataFetcher', () => {
       mockFetch.mockResolvedValueOnce(createMockResponse(500, { error: 'Server error' }));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
         signal: abortController.signal,
       });
       // Attach rejection handler FIRST to prevent unhandled rejection
@@ -591,7 +591,7 @@ describe('ShapesDataFetcher', () => {
       mockFetch.mockResolvedValueOnce(createMockResponse(500, { error: 'Server error' }));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
         signal: abortController.signal,
       });
       // Node.js auto-sets reason to DOMException('This operation was aborted', 'AbortError')
@@ -606,12 +606,11 @@ describe('ShapesDataFetcher', () => {
   });
 
   describe('cookie rotation', () => {
-    it('should update cookie from set-cookie response headers', async () => {
+    it('should update cookie from set-cookie response headers when Better Auth rotates', async () => {
       mockFetch
         .mockResolvedValueOnce(
           createMockResponse(200, SAMPLE_CONFIG, [
-            'appSession.0=new-value-0; Path=/; HttpOnly',
-            'appSession.1=new-value-1; Path=/; HttpOnly',
+            '__Secure-better-auth.session_token=rotated-value; Path=/; HttpOnly; Secure',
           ])
         )
         .mockResolvedValueOnce(
@@ -621,23 +620,24 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(200, {}));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=old-0; appSession.1=old-1',
+        sessionCookie: '__Secure-better-auth.session_token=old-value',
       });
       await vi.advanceTimersByTimeAsync(5000);
       await promise;
 
-      // Second request should use updated cookie
+      // Second request should use the rotated cookie value
       const secondCallHeaders = mockFetch.mock.calls[1][1].headers;
-      expect(secondCallHeaders.Cookie).toContain('appSession.0=new-value-0');
-      expect(secondCallHeaders.Cookie).toContain('appSession.1=new-value-1');
+      expect(secondCallHeaders.Cookie).toContain(
+        '__Secure-better-auth.session_token=rotated-value'
+      );
+      expect(secondCallHeaders.Cookie).not.toContain('old-value');
     });
 
     it('should expose updated cookie via getUpdatedCookie()', async () => {
       mockFetch
         .mockResolvedValueOnce(
           createMockResponse(200, SAMPLE_CONFIG, [
-            'appSession.0=rotated-0; Path=/; HttpOnly',
-            'appSession.1=rotated-1; Path=/; HttpOnly',
+            '__Secure-better-auth.session_token=rotated-token; Path=/; HttpOnly; Secure',
           ])
         )
         .mockResolvedValueOnce(
@@ -647,14 +647,41 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(200, {}));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=old-0; appSession.1=old-1',
+        sessionCookie: '__Secure-better-auth.session_token=old-token',
       });
       await vi.advanceTimersByTimeAsync(5000);
       await promise;
 
       const updatedCookie = fetcher.getUpdatedCookie();
-      expect(updatedCookie).toContain('appSession.0=rotated-0');
-      expect(updatedCookie).toContain('appSession.1=rotated-1');
+      expect(updatedCookie).toContain('__Secure-better-auth.session_token=rotated-token');
+      expect(updatedCookie).not.toContain('old-token');
+    });
+
+    it('should discard non-allowlisted cookies served alongside the session cookie', async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          createMockResponse(200, SAMPLE_CONFIG, [
+            '_ga=GA1.1.analytics; Path=/; Domain=.shapes.inc',
+            'cf_clearance=wafToken; Path=/; Secure',
+            '__Secure-better-auth.session_token=new-val; Path=/; HttpOnly; Secure',
+          ])
+        )
+        .mockResolvedValueOnce(
+          createMockResponse(200, { items: [], pagination: { has_next: false } })
+        )
+        .mockResolvedValueOnce(createMockResponse(200, []))
+        .mockResolvedValueOnce(createMockResponse(200, {}));
+
+      const promise = fetcher.fetchShapeData('test-shape', {
+        sessionCookie: '__Secure-better-auth.session_token=old-val',
+      });
+      await vi.advanceTimersByTimeAsync(5000);
+      await promise;
+
+      const secondCallHeaders = mockFetch.mock.calls[1][1].headers;
+      expect(secondCallHeaders.Cookie).toContain('__Secure-better-auth.session_token=new-val');
+      expect(secondCallHeaders.Cookie).not.toContain('_ga');
+      expect(secondCallHeaders.Cookie).not.toContain('cf_clearance');
     });
   });
 
@@ -669,7 +696,7 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(200, {}));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
       });
       await vi.advanceTimersByTimeAsync(5000);
       const result = await promise;
@@ -687,7 +714,7 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(200, {}));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: 'appSession.0=abc; appSession.1=def',
+        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
       });
       await vi.advanceTimersByTimeAsync(5000);
       const result = await promise;

--- a/services/ai-worker/src/services/shapes/ShapesDataFetcher.test.ts
+++ b/services/ai-worker/src/services/shapes/ShapesDataFetcher.test.ts
@@ -130,7 +130,8 @@ describe('ShapesDataFetcher', () => {
       setupSuccessfulFetch();
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
       });
 
       // Advance timers for delays between requests
@@ -150,7 +151,8 @@ describe('ShapesDataFetcher', () => {
       setupSuccessfulFetch();
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
       });
       await vi.advanceTimersByTimeAsync(5000);
       await promise;
@@ -159,7 +161,8 @@ describe('ShapesDataFetcher', () => {
         expect.stringContaining('/api/shapes/username/test-shape'),
         expect.objectContaining({
           headers: expect.objectContaining({
-            Cookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+            Cookie:
+              '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
           }),
         })
       );
@@ -178,7 +181,8 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(200, SAMPLE_USER_PERSONALIZATION));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
       });
       await vi.advanceTimersByTimeAsync(5000);
       const result = await promise;
@@ -197,7 +201,8 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(200, {}));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
       });
       await vi.advanceTimersByTimeAsync(5000);
       const result = await promise;
@@ -229,7 +234,8 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(200, {}));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
       });
       await vi.advanceTimersByTimeAsync(10000);
       const result = await promise;
@@ -244,7 +250,8 @@ describe('ShapesDataFetcher', () => {
       mockFetch.mockResolvedValueOnce(createMockResponse(401, { error: 'Unauthorized' }));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
       });
       const assertion = expect(promise).rejects.toThrow(ShapesAuthError);
       await vi.advanceTimersByTimeAsync(5000);
@@ -255,7 +262,8 @@ describe('ShapesDataFetcher', () => {
       mockFetch.mockResolvedValueOnce(createMockResponse(403, { error: 'Forbidden' }));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
       });
       const assertion = expect(promise).rejects.toThrow(ShapesAuthError);
       await vi.advanceTimersByTimeAsync(5000);
@@ -266,7 +274,8 @@ describe('ShapesDataFetcher', () => {
       mockFetch.mockResolvedValueOnce(createMockResponse(404, { error: 'Not found' }));
 
       const promise = fetcher.fetchShapeData('nonexistent', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
       });
       const assertion = expect(promise).rejects.toThrow(ShapesNotFoundError);
       await vi.advanceTimersByTimeAsync(5000);
@@ -281,7 +290,8 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(429, { error: 'Rate limited' }));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
       });
       const assertion = expect(promise).rejects.toThrow(ShapesRateLimitError);
       await vi.advanceTimersByTimeAsync(30000);
@@ -295,7 +305,8 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(500, { error: 'Server error' }));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
       });
       const assertion = expect(promise).rejects.toThrow(ShapesServerError);
       await vi.advanceTimersByTimeAsync(30000);
@@ -312,7 +323,8 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(502, { error: 'Bad Gateway' }));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
       });
       const assertion = expect(promise).rejects.toThrow(ShapesServerError);
       await vi.advanceTimersByTimeAsync(30000);
@@ -326,7 +338,8 @@ describe('ShapesDataFetcher', () => {
       mockFetch.mockResolvedValueOnce(createMockResponse(422, { error: 'Unprocessable' }));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
       });
       const assertion = expect(promise).rejects.toThrow(ShapesFetchError);
       await vi.advanceTimersByTimeAsync(5000);
@@ -341,7 +354,8 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(200, {}));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
       });
       await vi.advanceTimersByTimeAsync(5000);
       const result = await promise;
@@ -359,7 +373,8 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(200, SAMPLE_USER_PERSONALIZATION));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
       });
       await vi.advanceTimersByTimeAsync(5000);
       const result = await promise;
@@ -384,7 +399,8 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(200, {}));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
       });
       await vi.advanceTimersByTimeAsync(30000);
       const result = await promise;
@@ -408,7 +424,8 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(200, {}));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
       });
       await vi.advanceTimersByTimeAsync(30000);
       const result = await promise;
@@ -432,7 +449,8 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(200, {}));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
       });
       await vi.advanceTimersByTimeAsync(30000);
       const result = await promise;
@@ -444,7 +462,8 @@ describe('ShapesDataFetcher', () => {
       mockFetch.mockResolvedValueOnce(createMockResponse(401, { error: 'Unauthorized' }));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
       });
       const assertion = expect(promise).rejects.toThrow(ShapesAuthError);
       await vi.advanceTimersByTimeAsync(5000);
@@ -458,7 +477,8 @@ describe('ShapesDataFetcher', () => {
       mockFetch.mockResolvedValueOnce(createMockResponse(404, { error: 'Not found' }));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
       });
       const assertion = expect(promise).rejects.toThrow(ShapesNotFoundError);
       await vi.advanceTimersByTimeAsync(5000);
@@ -471,7 +491,8 @@ describe('ShapesDataFetcher', () => {
       mockFetch.mockResolvedValueOnce(createMockResponse(422, { error: 'Unprocessable' }));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
       });
       const assertion = expect(promise).rejects.toThrow(ShapesFetchError);
       await vi.advanceTimersByTimeAsync(5000);
@@ -495,7 +516,8 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(200, {}));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
       });
       await vi.advanceTimersByTimeAsync(30000);
       const result = await promise;
@@ -520,7 +542,8 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(200, {}));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
       });
       await vi.advanceTimersByTimeAsync(30000);
       const result = await promise;
@@ -533,7 +556,8 @@ describe('ShapesDataFetcher', () => {
       mockFetch.mockRejectedValueOnce(new TypeError('Cannot read properties of undefined'));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
       });
       const assertion = expect(promise).rejects.toThrow(TypeError);
       await vi.advanceTimersByTimeAsync(5000);
@@ -550,7 +574,8 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(429, { error: 'Rate limited' }));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
       });
       const assertion = expect(promise).rejects.toThrow(ShapesRateLimitError);
       await vi.advanceTimersByTimeAsync(30000);
@@ -567,7 +592,8 @@ describe('ShapesDataFetcher', () => {
       mockFetch.mockResolvedValueOnce(createMockResponse(500, { error: 'Server error' }));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
         signal: abortController.signal,
       });
       // Attach rejection handler FIRST to prevent unhandled rejection
@@ -591,7 +617,8 @@ describe('ShapesDataFetcher', () => {
       mockFetch.mockResolvedValueOnce(createMockResponse(500, { error: 'Server error' }));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
         signal: abortController.signal,
       });
       // Node.js auto-sets reason to DOMException('This operation was aborted', 'AbortError')
@@ -696,7 +723,8 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(200, {}));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
       });
       await vi.advanceTimersByTimeAsync(5000);
       const result = await promise;
@@ -714,7 +742,8 @@ describe('ShapesDataFetcher', () => {
         .mockResolvedValueOnce(createMockResponse(200, {}));
 
       const promise = fetcher.fetchShapeData('test-shape', {
-        sessionCookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+        sessionCookie:
+          '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
       });
       await vi.advanceTimersByTimeAsync(5000);
       const result = await promise;

--- a/services/ai-worker/src/services/shapes/ShapesDataFetcher.ts
+++ b/services/ai-worker/src/services/shapes/ShapesDataFetcher.ts
@@ -5,7 +5,9 @@
  * memories (paginated), stories/knowledge, and user personalization.
  *
  * Key behaviors:
- * - Stateful cookie management (shapes.inc rotates cookies on each request)
+ * - Stateful cookie management (shapes.inc occasionally rotates the Better Auth
+ *   session cookie within its updateAge window; the jar is refreshed when a
+ *   Set-Cookie header for an allowlisted name is present on a response)
  * - Rate-limited requests (1s delay between calls)
  * - Per-request retry with exponential backoff (429, 5xx, network errors)
  * - AbortController timeouts per request
@@ -47,7 +49,13 @@ const RETRY_BASE_DELAY_MS = 2000;
 // ============================================================================
 
 interface FetchOptions {
-  /** Initial session cookie (full cookie string with both appSession parts) */
+  /**
+   * Initial session cookie string in the form
+   * `__Secure-better-auth.session_token=<value>`. Harvest this from an
+   * authenticated browser session on https://shapes.inc/dashboard by
+   * copying the httpOnly cookie of that name from
+   * DevTools → Application → Cookies.
+   */
   sessionCookie: string;
   /** AbortSignal for external cancellation */
   signal?: AbortSignal;

--- a/services/ai-worker/src/services/shapes/shapesCookieParser.test.ts
+++ b/services/ai-worker/src/services/shapes/shapesCookieParser.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { SHAPES_SESSION_COOKIE_NAME } from '@tzurot/common-types';
 import { updateCookieFromResponse } from './shapesCookieParser.js';
 
 /**
@@ -12,50 +13,68 @@ function makeResponse(setCookieHeaders: string[]): Response {
   return { headers } as unknown as Response;
 }
 
+const VALID_TOKEN_A = 'token-value-a1b2c3d4e5f6g7h8i9j0';
+const VALID_TOKEN_B = 'token-value-z9y8x7w6v5u4t3s2r1q0';
+const INITIAL_COOKIE = `${SHAPES_SESSION_COOKIE_NAME}=${VALID_TOKEN_A}`;
+
 describe('updateCookieFromResponse', () => {
-  it('should return current cookie unchanged when no set-cookie headers', () => {
+  it('returns the current cookie unchanged when the response has no Set-Cookie headers', () => {
     const response = makeResponse([]);
-    const result = updateCookieFromResponse('appSession.0=abc; appSession.1=def', response);
-    expect(result).toBe('appSession.0=abc; appSession.1=def');
+    expect(updateCookieFromResponse(INITIAL_COOKIE, response)).toBe(INITIAL_COOKIE);
   });
 
-  it('should merge new cookie values into existing cookie string', () => {
+  it('replaces the allowlisted cookie when shapes.inc rotates it', () => {
     const response = makeResponse([
-      'appSession.0=new-value-0; Path=/; HttpOnly',
-      'appSession.1=new-value-1; Path=/; HttpOnly',
+      `${SHAPES_SESSION_COOKIE_NAME}=${VALID_TOKEN_B}; Path=/; HttpOnly; Secure; SameSite=Lax`,
     ]);
-    const result = updateCookieFromResponse('appSession.0=old-0; appSession.1=old-1', response);
-    expect(result).toContain('appSession.0=new-value-0');
-    expect(result).toContain('appSession.1=new-value-1');
-    expect(result).not.toContain('old-0');
-    expect(result).not.toContain('old-1');
+    const result = updateCookieFromResponse(INITIAL_COOKIE, response);
+    expect(result).toBe(`${SHAPES_SESSION_COOKIE_NAME}=${VALID_TOKEN_B}`);
+    expect(result).not.toContain(VALID_TOKEN_A);
   });
 
-  it('should preserve cookies not present in set-cookie headers', () => {
-    const response = makeResponse(['appSession.0=rotated; Path=/']);
-    const result = updateCookieFromResponse('appSession.0=old; otherCookie=keep-me', response);
-    expect(result).toContain('appSession.0=rotated');
-    expect(result).toContain('otherCookie=keep-me');
+  it('discards unrelated cookies served alongside the allowlisted one', () => {
+    const response = makeResponse([
+      '_ga=GA1.1.12345; Path=/; Domain=.shapes.inc',
+      'cf_clearance=someWafToken; Path=/; Secure',
+      `${SHAPES_SESSION_COOKIE_NAME}=${VALID_TOKEN_B}; Path=/; HttpOnly; Secure`,
+    ]);
+    const result = updateCookieFromResponse(INITIAL_COOKIE, response);
+    expect(result).toBe(`${SHAPES_SESSION_COOKIE_NAME}=${VALID_TOKEN_B}`);
+    expect(result).not.toContain('_ga');
+    expect(result).not.toContain('cf_clearance');
   });
 
-  it('should add new cookies not in the original string', () => {
-    const response = makeResponse(['newCookie=hello; Path=/']);
-    const result = updateCookieFromResponse('appSession.0=abc', response);
-    expect(result).toContain('appSession.0=abc');
-    expect(result).toContain('newCookie=hello');
+  it('discards a response that contains only unrelated cookies', () => {
+    const response = makeResponse(['_ga=GA1.1.12345; Path=/', 'x-datadome=ddToken; Path=/']);
+    const result = updateCookieFromResponse(INITIAL_COOKIE, response);
+    expect(result).toBe(INITIAL_COOKIE);
   });
 
-  it('should handle empty current cookie string', () => {
-    const response = makeResponse(['appSession.0=fresh; Path=/']);
+  it('accepts an empty initial jar and bootstraps from the response', () => {
+    const response = makeResponse([
+      `${SHAPES_SESSION_COOKIE_NAME}=${VALID_TOKEN_A}; Path=/; HttpOnly; Secure`,
+    ]);
+    expect(updateCookieFromResponse('', response)).toBe(
+      `${SHAPES_SESSION_COOKIE_NAME}=${VALID_TOKEN_A}`
+    );
+  });
+
+  it('strips cookie attributes (Path, HttpOnly, Expires, SameSite) from the jar', () => {
+    const response = makeResponse([
+      `${SHAPES_SESSION_COOKIE_NAME}=${VALID_TOKEN_A}; Path=/; Expires=Wed, 21 Oct 2026 07:28:00 GMT; HttpOnly; Secure; SameSite=Lax`,
+    ]);
     const result = updateCookieFromResponse('', response);
-    expect(result).toContain('appSession.0=fresh');
+    // Exact equality is the tightest check — the rebuilt jar contains ONLY `name=value`.
+    // Individual `.not.toContain()` checks for attribute names would produce false
+    // negatives here because the cookie name itself contains "Secure" as a substring.
+    expect(result).toBe(`${SHAPES_SESSION_COOKIE_NAME}=${VALID_TOKEN_A}`);
   });
 
-  it('should strip set-cookie attributes (Path, HttpOnly, etc.)', () => {
-    const response = makeResponse(['token=abc123; Path=/; HttpOnly; Secure; SameSite=Lax']);
-    const result = updateCookieFromResponse('', response);
-    expect(result).toBe('token=abc123');
-    expect(result).not.toContain('Path');
-    expect(result).not.toContain('HttpOnly');
+  it('drops non-allowlisted cookies that were somehow present in the initial jar', () => {
+    // Defense-in-depth: even if a stale jar has extraneous entries, the parser
+    // narrows them on merge rather than perpetuating them.
+    const pollutedInitial = `_ga=junk; ${SHAPES_SESSION_COOKIE_NAME}=${VALID_TOKEN_A}; theme=dark`;
+    const response = makeResponse([]);
+    expect(updateCookieFromResponse(pollutedInitial, response)).toBe(INITIAL_COOKIE);
   });
 });

--- a/services/ai-worker/src/services/shapes/shapesCookieParser.ts
+++ b/services/ai-worker/src/services/shapes/shapesCookieParser.ts
@@ -1,48 +1,61 @@
 /**
  * Cookie Parser for Shapes.inc API
  *
- * Shapes.inc rotates the appSession cookie on every API call. This module
- * parses set-cookie response headers and merges them into the existing
- * cookie string, keeping the cookie jar up to date across requests.
+ * Merges Set-Cookie response headers into the existing cookie jar, narrowed
+ * by `isShapesAllowedCookieName`. Cookies outside the allowlist (analytics,
+ * WAF routing, CSRF tokens, etc.) are discarded rather than retained in the
+ * jar — mixing unrelated cookies into subsequent requests adds risk without
+ * benefit.
+ *
+ * Under Better Auth, the session cookie rotates rarely (within a ~1-day
+ * `updateAge` window inside a 7-day session), so in the common case
+ * `updateCookieFromResponse` is a no-op and returns the existing cookie
+ * string unchanged.
  */
+
+import { isShapesAllowedCookieName } from '@tzurot/common-types';
 
 /**
- * Parse set-cookie headers and merge fresh session values into the existing
- * cookie string. Returns the updated cookie string.
+ * Parse Set-Cookie headers and merge allowlisted values into the existing
+ * cookie string. Returns the updated cookie string containing ONLY cookies
+ * that pass `isShapesAllowedCookieName`.
  *
- * @param currentCookie - The current cookie string (semicolon-delimited key=value pairs)
- * @param response - The HTTP response whose set-cookie headers should be merged
- * @returns The updated cookie string with any rotated values applied
+ * @param currentCookie - The current cookie string (semicolon-delimited name=value pairs)
+ * @param response - The HTTP response whose Set-Cookie headers should be merged
+ * @returns The updated cookie string, filtered to the allowlist
  */
 export function updateCookieFromResponse(currentCookie: string, response: Response): string {
-  const setCookieHeaders = response.headers.getSetCookie();
-  if (setCookieHeaders.length === 0) {
-    return currentCookie;
-  }
-
-  // Parse current cookies into a map
+  // Parse current jar, filtering to allowlisted names.
   const cookieMap = new Map<string, string>();
   for (const part of currentCookie.split(';')) {
     const trimmed = part.trim();
     const eqIdx = trimmed.indexOf('=');
-    if (eqIdx > 0) {
-      cookieMap.set(trimmed.substring(0, eqIdx), trimmed.substring(eqIdx + 1));
+    if (eqIdx <= 0) {
+      continue;
+    }
+    const name = trimmed.substring(0, eqIdx);
+    if (isShapesAllowedCookieName(name)) {
+      cookieMap.set(name, trimmed.substring(eqIdx + 1));
     }
   }
 
-  // Update with new cookies from response
+  // Merge allowlisted Set-Cookie entries from the response.
+  const setCookieHeaders = response.headers.getSetCookie();
   for (const header of setCookieHeaders) {
-    // set-cookie: name=value; Path=/; ...
-    const cookiePart = header.split(';')[0].trim();
-    const eqIdx = cookiePart.indexOf('=');
-    if (eqIdx > 0) {
-      const name = cookiePart.substring(0, eqIdx);
-      const value = cookiePart.substring(eqIdx + 1);
-      cookieMap.set(name, value);
+    // Set-Cookie: name=value; Path=/; HttpOnly; ...
+    const firstPart = header.split(';')[0].trim();
+    const eqIdx = firstPart.indexOf('=');
+    if (eqIdx <= 0) {
+      continue;
     }
+    const name = firstPart.substring(0, eqIdx);
+    if (!isShapesAllowedCookieName(name)) {
+      continue;
+    }
+    cookieMap.set(name, firstPart.substring(eqIdx + 1));
   }
 
-  // Rebuild cookie string
+  // Rebuild the cookie string from the filtered map.
   const parts: string[] = [];
   for (const [name, value] of cookieMap) {
     parts.push(`${name}=${value}`);

--- a/services/api-gateway/src/routes/user/shapes/auth.test.ts
+++ b/services/api-gateway/src/routes/user/shapes/auth.test.ts
@@ -135,7 +135,7 @@ describe('Shapes Auth Routes', () => {
       expect(res.status).toHaveBeenCalledWith(400);
     });
 
-    it('should reject cookie missing appSession prefix', async () => {
+    it('should reject a cookie with an unexpected name', async () => {
       const { res } = await callStoreHandler({
         sessionCookie: 'randomCookie=value',
       });
@@ -143,22 +143,38 @@ describe('Shapes Auth Routes', () => {
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
-          message: expect.stringContaining('appSession'),
+          message: expect.stringContaining('__Secure-better-auth.session_token'),
         })
       );
     });
 
-    it('should reject chunked cookie with only one part', async () => {
+    it('should reject a cookie whose name is embedded but not at the start (prefix defense)', async () => {
       const { res } = await callStoreHandler({
-        sessionCookie: 'appSession.0=value',
+        sessionCookie: 'fake-prefix__Secure-better-auth.session_token=value',
       });
 
       expect(res.status).toHaveBeenCalledWith(400);
     });
 
-    it('should encrypt and upsert valid chunked cookie', async () => {
+    it('should reject a legacy Auth0 cookie (appSession format)', async () => {
       const { res } = await callStoreHandler({
-        sessionCookie: 'appSession.0=part0; appSession.1=part1',
+        sessionCookie: 'appSession=legacy-value',
+      });
+
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it('should reject the expected cookie name with an empty value', async () => {
+      const { res } = await callStoreHandler({
+        sessionCookie: '__Secure-better-auth.session_token=',
+      });
+
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it('should encrypt and upsert a valid Better Auth session cookie', async () => {
+      const { res } = await callStoreHandler({
+        sessionCookie: '__Secure-better-auth.session_token=opaque-better-auth-token-value-12345',
       });
 
       expect(mockPrisma.userCredential.upsert).toHaveBeenCalledWith(
@@ -172,16 +188,6 @@ describe('Shapes Auth Routes', () => {
           }),
         })
       );
-      expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
-    });
-
-    it('should encrypt and upsert valid single cookie', async () => {
-      const { res } = await callStoreHandler({
-        sessionCookie: 'appSession=single-session-value',
-      });
-
-      expect(mockPrisma.userCredential.upsert).toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
     });

--- a/services/api-gateway/src/routes/user/shapes/auth.ts
+++ b/services/api-gateway/src/routes/user/shapes/auth.ts
@@ -20,6 +20,7 @@ import {
   generateUserCredentialUuid,
   CREDENTIAL_SERVICES,
   CREDENTIAL_TYPES,
+  SHAPES_SESSION_COOKIE_NAME,
 } from '@tzurot/common-types';
 import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
@@ -48,15 +49,19 @@ function createStoreHandler(prisma: PrismaClient, userService: UserService) {
       return sendError(res, ErrorResponses.validationError('sessionCookie is required'));
     }
 
-    const hasSingleCookie = sessionCookie.includes('appSession=');
-    const hasChunkedCookies =
-      sessionCookie.includes('appSession.0=') && sessionCookie.includes('appSession.1=');
-
-    if (!hasSingleCookie && !hasChunkedCookies) {
+    // Bot-client's auth modal normalizes input to `name=value` form via
+    // parseShapesSessionCookieInput before POSTing here. We accept only that
+    // strict shape: the string must start with the expected cookie name and
+    // have a non-empty value following the `=`.
+    const expectedPrefix = `${SHAPES_SESSION_COOKIE_NAME}=`;
+    if (
+      !sessionCookie.startsWith(expectedPrefix) ||
+      sessionCookie.length <= expectedPrefix.length
+    ) {
       return sendError(
         res,
         ErrorResponses.validationError(
-          'Session cookie must contain appSession or both appSession.0 and appSession.1 values'
+          `Session cookie must be in the form '${SHAPES_SESSION_COOKIE_NAME}=<value>'`
         )
       );
     }

--- a/services/api-gateway/src/routes/user/shapes/list.test.ts
+++ b/services/api-gateway/src/routes/user/shapes/list.test.ts
@@ -18,7 +18,9 @@ vi.mock('@tzurot/common-types', async () => {
     }),
     decryptApiKey: vi
       .fn()
-      .mockReturnValue('__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq'),
+      .mockReturnValue(
+        '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef'
+      ),
   };
 });
 
@@ -124,7 +126,8 @@ describe('Shapes List Routes', () => {
         expect.stringContaining('shapes.inc/api/shapes'),
         expect.objectContaining({
           headers: expect.objectContaining({
-            Cookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
+            Cookie:
+              '__Secure-better-auth.session_token=TEST-FIXTURE-not-a-real-session-token-abcdef',
           }),
         })
       );

--- a/services/api-gateway/src/routes/user/shapes/list.test.ts
+++ b/services/api-gateway/src/routes/user/shapes/list.test.ts
@@ -16,7 +16,9 @@ vi.mock('@tzurot/common-types', async () => {
       warn: vi.fn(),
       error: vi.fn(),
     }),
-    decryptApiKey: vi.fn().mockReturnValue('appSession.0=abc; appSession.1=def'),
+    decryptApiKey: vi
+      .fn()
+      .mockReturnValue('__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq'),
   };
 });
 
@@ -122,7 +124,7 @@ describe('Shapes List Routes', () => {
         expect.stringContaining('shapes.inc/api/shapes'),
         expect.objectContaining({
           headers: expect.objectContaining({
-            Cookie: 'appSession.0=abc; appSession.1=def',
+            Cookie: '__Secure-better-auth.session_token=abc123def456ghi789jkl012mno345pq',
           }),
         })
       );

--- a/services/bot-client/src/commands/shapes/auth.test.ts
+++ b/services/bot-client/src/commands/shapes/auth.test.ts
@@ -75,7 +75,10 @@ describe('handleAuth', () => {
     expect(embed.data.title).toBe('Shapes.inc Authentication');
     expect(embed.data.description).toContain('Developer Tools');
     expect(embed.data.description).toContain('Application');
-    expect(embed.data.description).toContain('appSession');
+    expect(embed.data.description).toContain('__Secure-better-auth.session_token');
+    // Domain distinction must remain in the instructions (talk.shapes.inc is
+    // a separate auth instance and cookies from it will not work)
+    expect(embed.data.description).toContain('talk.shapes.inc');
   });
 
   it('should use correct custom IDs for buttons', async () => {
@@ -108,24 +111,18 @@ describe('buildAuthModal', () => {
     expect(modal.data.title).toBe('Shapes.inc Authentication');
   });
 
-  it('should have two text inputs for cookie parts', () => {
+  it('should have a single required text input for the Better Auth cookie value', () => {
     const modal = buildAuthModal();
-    expect(modal.components).toHaveLength(2);
+    expect(modal.components).toHaveLength(1);
 
     // Cast to access nested components — union type includes LabelBuilder without .components
     const rows = modal.components as { components: { data: Record<string, unknown> }[] }[];
-    const part0 = rows[0].components[0];
-    const part1 = rows[1].components[0];
+    const input = rows[0].components[0];
 
-    expect(part0.data.custom_id).toBe('cookiePart0');
-    expect(part0.data.style).toBe(TextInputStyle.Paragraph);
-    expect(part0.data.required).toBe(true);
-    expect(part0.data.min_length).toBe(10);
-    expect(part0.data.max_length).toBe(4000);
-
-    expect(part1.data.custom_id).toBe('cookiePart1');
-    expect(part1.data.style).toBe(TextInputStyle.Paragraph);
-    expect(part1.data.required).toBe(false);
-    expect(part1.data.max_length).toBe(4000);
+    expect(input.data.custom_id).toBe('cookieValue');
+    expect(input.data.style).toBe(TextInputStyle.Paragraph);
+    expect(input.data.required).toBe(true);
+    expect(input.data.min_length).toBe(16);
+    expect(input.data.max_length).toBe(4000);
   });
 });

--- a/services/bot-client/src/commands/shapes/auth.test.ts
+++ b/services/bot-client/src/commands/shapes/auth.test.ts
@@ -122,7 +122,9 @@ describe('buildAuthModal', () => {
     expect(input.data.custom_id).toBe('cookieValue');
     expect(input.data.style).toBe(TextInputStyle.Paragraph);
     expect(input.data.required).toBe(true);
-    expect(input.data.min_length).toBe(16);
+    // Must align with parser's SHAPES_TOKEN_MIN_LENGTH so the UI gate
+    // and the parse-time check agree on the same minimum.
+    expect(input.data.min_length).toBe(32);
     expect(input.data.max_length).toBe(4000);
   });
 });

--- a/services/bot-client/src/commands/shapes/auth.ts
+++ b/services/bot-client/src/commands/shapes/auth.ts
@@ -27,33 +27,22 @@ import { DISCORD_COLORS } from '@tzurot/common-types';
 import type { ModalCommandContext } from '../../utils/commandContext/types.js';
 import { ShapesCustomIds } from '../../utils/customIds.js';
 
-/** Build the auth modal with cookie input fields */
+/** Build the auth modal with a single cookie input field (Better Auth, 2026-04+) */
 export function buildAuthModal(): ModalBuilder {
   const modal = new ModalBuilder()
     .setCustomId(ShapesCustomIds.auth())
     .setTitle('Shapes.inc Authentication');
 
-  const cookiePart0 = new TextInputBuilder()
-    .setCustomId('cookiePart0')
-    .setLabel('appSession (or appSession.0)')
+  const cookieValue = new TextInputBuilder()
+    .setCustomId('cookieValue')
+    .setLabel('Session cookie value')
     .setStyle(TextInputStyle.Paragraph)
-    .setPlaceholder('Paste your appSession cookie value (or appSession.0 if you have two)')
+    .setPlaceholder('Paste the value of __Secure-better-auth.session_token')
     .setRequired(true)
-    .setMinLength(10)
+    .setMinLength(16)
     .setMaxLength(4000);
 
-  const cookiePart1 = new TextInputBuilder()
-    .setCustomId('cookiePart1')
-    .setLabel('appSession.1 (only if you have two cookies)')
-    .setStyle(TextInputStyle.Paragraph)
-    .setPlaceholder('Leave empty if you only have one appSession cookie')
-    .setRequired(false)
-    .setMaxLength(4000);
-
-  modal.addComponents(
-    new ActionRowBuilder<TextInputBuilder>().addComponents(cookiePart0),
-    new ActionRowBuilder<TextInputBuilder>().addComponents(cookiePart1)
-  );
+  modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(cookieValue));
 
   return modal;
 }
@@ -73,14 +62,16 @@ export async function handleAuth(context: ModalCommandContext): Promise<void> {
       `To import characters from shapes.inc, ${botName} needs your session cookie.\n\n` +
         '**How to get it:**\n' +
         '1. Log in to [shapes.inc](https://shapes.inc) in your browser\n' +
-        '2. Navigate to [shapes.inc/dashboard](https://shapes.inc/dashboard) ' +
-        '(this avoids the chat UI which rotates your cookie frequently)\n' +
+        '2. Navigate to [shapes.inc/dashboard](https://shapes.inc/dashboard)\n' +
         '3. Press **F12** (or Ctrl+Shift+I) to open Developer Tools\n' +
         '4. Click the **Application** tab (Chrome) or **Storage** tab (Firefox)\n' +
         '5. In the left sidebar, expand **Cookies** → click `https://shapes.inc`\n' +
-        '6. Find `appSession` (or `appSession.0` and `appSession.1`)\n' +
-        '7. Double-click each **Value** cell to select it, then copy\n\n' +
-        `*Your cookie is encrypted and stored securely. ` +
+        '6. Find the cookie named `__Secure-better-auth.session_token` ' +
+        '(sort by the HttpOnly column to find it faster — it has that flag set)\n' +
+        '7. Double-click the **Value** cell to select it, then copy\n\n' +
+        '⚠️ **Must be from `shapes.inc`, not `talk.shapes.inc`.** ' +
+        "The chat subdomain is a separate app with its own auth and its cookie won't work here.\n\n" +
+        `*Your cookie is encrypted at rest with AES-256-GCM. ` +
         `${botName} never sees your shapes.inc password.*`
     );
 

--- a/services/bot-client/src/commands/shapes/auth.ts
+++ b/services/bot-client/src/commands/shapes/auth.ts
@@ -23,7 +23,7 @@ import {
   EmbedBuilder,
   MessageFlags,
 } from 'discord.js';
-import { DISCORD_COLORS } from '@tzurot/common-types';
+import { DISCORD_COLORS, SHAPES_TOKEN_MIN_LENGTH } from '@tzurot/common-types';
 import type { ModalCommandContext } from '../../utils/commandContext/types.js';
 import { ShapesCustomIds } from '../../utils/customIds.js';
 
@@ -39,7 +39,7 @@ export function buildAuthModal(): ModalBuilder {
     .setStyle(TextInputStyle.Paragraph)
     .setPlaceholder('Paste the value of __Secure-better-auth.session_token')
     .setRequired(true)
-    .setMinLength(16)
+    .setMinLength(SHAPES_TOKEN_MIN_LENGTH)
     .setMaxLength(4000);
 
   modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(cookieValue));

--- a/services/bot-client/src/commands/shapes/modal.test.ts
+++ b/services/bot-client/src/commands/shapes/modal.test.ts
@@ -6,7 +6,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MessageFlags } from 'discord.js';
 import { handleShapesModalSubmit } from './modal.js';
 
-// Mock common-types
+// Mock common-types — keep parseShapesSessionCookieInput real so we test the
+// integration between modal handler and parser.
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal<typeof import('@tzurot/common-types')>();
   return {
@@ -32,6 +33,11 @@ vi.mock('../../utils/userGatewayClient.js', async () => {
   };
 });
 
+// A long-enough alphanumeric token that passes the parser's shape + length check.
+const VALID_TOKEN = 'abcdefghijklmnopqrstuvwxyz0123456789.ABCDEF';
+const SESSION_COOKIE_NAME = '__Secure-better-auth.session_token';
+const NORMALIZED_COOKIE = `${SESSION_COOKIE_NAME}=${VALID_TOKEN}`;
+
 describe('handleShapesModalSubmit', () => {
   const mockReply = vi.fn();
   const mockDeferReply = vi.fn();
@@ -41,18 +47,13 @@ describe('handleShapesModalSubmit', () => {
     vi.clearAllMocks();
   });
 
-  function createMockInteraction(
-    customId: string,
-    cookiePart0: string = 'cookie-part-0-value',
-    cookiePart1: string = 'cookie-part-1-value'
-  ) {
+  function createMockInteraction(customId: string, cookieValue: string = VALID_TOKEN) {
     return {
       customId,
       user: { id: '123456789', username: 'testuser' },
       fields: {
         getTextInputValue: (fieldId: string) => {
-          if (fieldId === 'cookiePart0') return cookiePart0;
-          if (fieldId === 'cookiePart1') return cookiePart1;
+          if (fieldId === 'cookieValue') return cookieValue;
           return '';
         },
       },
@@ -84,21 +85,52 @@ describe('handleShapesModalSubmit', () => {
     });
   });
 
-  describe('Cookie validation', () => {
-    it('should reject empty cookie value', async () => {
-      const interaction = createMockInteraction('shapes::auth', '   ', '');
+  describe('Input parsing', () => {
+    it('should reject an empty cookie value', async () => {
+      const interaction = createMockInteraction('shapes::auth', '   ');
       await handleShapesModalSubmit(interaction);
 
       expect(mockDeferReply).toHaveBeenCalled();
       expect(mockEditReply).toHaveBeenCalledWith(expect.stringContaining('required'));
     });
+
+    it('should reject input that is a cookie string without the Better Auth name', async () => {
+      const interaction = createMockInteraction('shapes::auth', 'appSession=legacy-auth0-value');
+      await handleShapesModalSubmit(interaction);
+
+      expect(mockEditReply).toHaveBeenCalledWith(
+        expect.stringContaining("doesn't look like the right cookie")
+      );
+      expect(mockCallGatewayApi).not.toHaveBeenCalled();
+    });
+
+    it('should reject input that looks like a full Cookie: header paste without the expected cookie', async () => {
+      const interaction = createMockInteraction(
+        'shapes::auth',
+        '_ga=GA1.1.123; theme=dark; cf_clearance=abc'
+      );
+      await handleShapesModalSubmit(interaction);
+
+      expect(mockEditReply).toHaveBeenCalledWith(
+        expect.stringContaining("doesn't look like the right cookie")
+      );
+      expect(mockCallGatewayApi).not.toHaveBeenCalled();
+    });
+
+    it('should reject a bare token value that fails the shape/length check', async () => {
+      const interaction = createMockInteraction('shapes::auth', 'tooShort');
+      await handleShapesModalSubmit(interaction);
+
+      expect(mockEditReply).toHaveBeenCalledWith(expect.stringContaining('malformed'));
+      expect(mockCallGatewayApi).not.toHaveBeenCalled();
+    });
   });
 
   describe('Gateway API interaction', () => {
-    it('should send chunked cookie to gateway when both parts provided', async () => {
+    it('should send a normalized cookie to the gateway when given a bare token value', async () => {
       mockCallGatewayApi.mockResolvedValue({ ok: true, data: { success: true } });
 
-      const interaction = createMockInteraction('shapes::auth', 'part0-value', 'part1-value');
+      const interaction = createMockInteraction('shapes::auth', VALID_TOKEN);
       await handleShapesModalSubmit(interaction);
 
       expect(mockCallGatewayApi).toHaveBeenCalledWith(
@@ -110,25 +142,36 @@ describe('handleShapesModalSubmit', () => {
             username: 'testuser',
             displayName: 'testuser',
           },
-          body: {
-            sessionCookie: 'appSession.0=part0-value; appSession.1=part1-value',
-          },
+          body: { sessionCookie: NORMALIZED_COOKIE },
         })
       );
     });
 
-    it('should send single cookie to gateway when only first part provided', async () => {
+    it('should send a normalized cookie when the user pastes name=value form', async () => {
       mockCallGatewayApi.mockResolvedValue({ ok: true, data: { success: true } });
 
-      const interaction = createMockInteraction('shapes::auth', 'single-cookie-value', '');
+      const interaction = createMockInteraction('shapes::auth', NORMALIZED_COOKIE);
       await handleShapesModalSubmit(interaction);
 
       expect(mockCallGatewayApi).toHaveBeenCalledWith(
         '/user/shapes/auth',
         expect.objectContaining({
-          body: {
-            sessionCookie: 'appSession=single-cookie-value',
-          },
+          body: { sessionCookie: NORMALIZED_COOKIE },
+        })
+      );
+    });
+
+    it('should extract the session cookie from a full Cookie: header paste', async () => {
+      mockCallGatewayApi.mockResolvedValue({ ok: true, data: { success: true } });
+
+      const fullHeader = `_ga=GA1.1.123; ${NORMALIZED_COOKIE}; theme=dark`;
+      const interaction = createMockInteraction('shapes::auth', fullHeader);
+      await handleShapesModalSubmit(interaction);
+
+      expect(mockCallGatewayApi).toHaveBeenCalledWith(
+        '/user/shapes/auth',
+        expect.objectContaining({
+          body: { sessionCookie: NORMALIZED_COOKIE },
         })
       );
     });
@@ -150,7 +193,7 @@ describe('handleShapesModalSubmit', () => {
       });
     });
 
-    it('should handle 400 invalid cookie error', async () => {
+    it('should handle a 400 invalid-cookie error from the gateway', async () => {
       mockCallGatewayApi.mockResolvedValue({ ok: false, status: 400, error: 'Validation error' });
 
       const interaction = createMockInteraction('shapes::auth');
@@ -159,7 +202,7 @@ describe('handleShapesModalSubmit', () => {
       expect(mockEditReply).toHaveBeenCalledWith(expect.stringContaining('Invalid Cookie'));
     });
 
-    it('should handle 500 server error', async () => {
+    it('should handle a 500 server error from the gateway', async () => {
       mockCallGatewayApi.mockResolvedValue({ ok: false, status: 500, error: 'Internal error' });
 
       const interaction = createMockInteraction('shapes::auth');
@@ -168,7 +211,7 @@ describe('handleShapesModalSubmit', () => {
       expect(mockEditReply).toHaveBeenCalledWith(expect.stringContaining('Server Error'));
     });
 
-    it('should handle network errors gracefully', async () => {
+    it('should handle a network error gracefully', async () => {
       mockCallGatewayApi.mockRejectedValue(new Error('Network error'));
 
       const interaction = createMockInteraction('shapes::auth');

--- a/services/bot-client/src/commands/shapes/modal.ts
+++ b/services/bot-client/src/commands/shapes/modal.ts
@@ -12,7 +12,7 @@
 
 import type { ModalSubmitInteraction } from 'discord.js';
 import { MessageFlags, EmbedBuilder } from 'discord.js';
-import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
+import { createLogger, DISCORD_COLORS, parseShapesSessionCookieInput } from '@tzurot/common-types';
 import { callGatewayApi, GATEWAY_TIMEOUTS, toGatewayUser } from '../../utils/userGatewayClient.js';
 import { ShapesCustomIds } from '../../utils/customIds.js';
 
@@ -48,19 +48,15 @@ export async function handleShapesModalSubmit(interaction: ModalSubmitInteractio
 async function handleAuthSubmit(interaction: ModalSubmitInteraction): Promise<void> {
   await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
-  const cookiePart0 = interaction.fields.getTextInputValue('cookiePart0').trim();
-  const cookiePart1 = interaction.fields.getTextInputValue('cookiePart1').trim();
+  const rawInput = interaction.fields.getTextInputValue('cookieValue');
+  const parsed = parseShapesSessionCookieInput(rawInput);
 
-  if (cookiePart0.length === 0) {
-    await interaction.editReply('❌ Cookie value is required.');
+  if (!parsed.ok) {
+    await interaction.editReply(getInputValidationMessage(parsed.reason));
     return;
   }
 
-  // Build cookie string based on whether user has one or two cookies
-  const sessionCookie =
-    cookiePart1.length > 0
-      ? `appSession.0=${cookiePart0}; appSession.1=${cookiePart1}`
-      : `appSession=${cookiePart0}`;
+  const sessionCookie = parsed.cookie;
 
   try {
     const result = await callGatewayApi<{ success: boolean }>('/user/shapes/auth', {
@@ -112,12 +108,42 @@ async function handleAuthSubmit(interaction: ModalSubmitInteraction): Promise<vo
 function getAuthErrorMessage(status: number): string {
   switch (status) {
     case 400:
-      return '❌ **Invalid Cookie**\n\nThe session cookie format is invalid. Please check that you copied both parts correctly.';
+      return (
+        '❌ **Invalid Cookie**\n\n' +
+        'The session cookie format is invalid. Please re-run `/shapes auth` and paste the value ' +
+        'of `__Secure-better-auth.session_token` from your browser DevTools.'
+      );
     case 500:
     case 502:
     case 503:
       return '❌ **Server Error**\n\nThe server encountered an error. Please try again in a few minutes.';
     default:
       return '❌ **Unable to Save Credentials**\n\nAn unexpected error occurred. Please try again later.';
+  }
+}
+
+/**
+ * Map a parser rejection reason to a user-facing message.
+ * Each reason gets a distinct hint so users can self-diagnose the paste mistake.
+ */
+function getInputValidationMessage(reason: 'empty' | 'wrong-cookie' | 'malformed-value'): string {
+  switch (reason) {
+    case 'empty':
+      return '❌ Cookie value is required.';
+    case 'wrong-cookie':
+      return (
+        "❌ **That doesn't look like the right cookie.**\n\n" +
+        'The input contained cookies, but not `__Secure-better-auth.session_token`. ' +
+        'Common mistake: copying the whole `Cookie:` header from the Network tab instead ' +
+        'of a single cookie value from the Application tab. ' +
+        'Please re-run `/shapes auth` and follow steps 4–7.'
+      );
+    case 'malformed-value':
+      return (
+        '❌ **Cookie value looks malformed.**\n\n' +
+        'Better Auth tokens are opaque alphanumeric strings (typically 32+ characters). ' +
+        'Please re-run `/shapes auth` and copy the exact value of ' +
+        '`__Secure-better-auth.session_token` from DevTools.'
+      );
   }
 }


### PR DESCRIPTION
## Summary

shapes.inc has cut over from `@auth0/nextjs-auth0` (3-part `appSession` rolling pair) to Better Auth (single `__Secure-better-auth.session_token`). Our fetcher was silently broken against the new scheme, which affects `/shapes import` end-to-end (Phases 1-4 of the Character Portability work are shipped on develop).

- **Parser redesign**: allowlist pattern via `isShapesAllowedCookieName()` predicate. The fetcher filters incoming `Set-Cookie` headers to only the expected name, discarding analytics (GA), WAF routing (Cloudflare `cf_clearance`, Datadome), and CSRF cookies that would otherwise be echoed back on subsequent requests.
- **Modal UX**: single-field form (`cookieValue`) replacing the two-field chunked layout. `parseShapesSessionCookieInput()` normalizes three input shapes — bare token, `name=value`, or full `Cookie:` header paste — with a distinct user-facing hint for each rejection reason.
- **Gateway validation**: strict `startsWith(expectedPrefix)` check on already-normalized input; explicit rejection of the old `appSession*` formats and cookie-name prefix attacks.
- **Instruction embed**: reframed. Keeps the strict dashboard-vs-`talk.shapes.inc` distinction (domain scoping) but drops the now-obsolete "cookie rotates every request" framing.

## Council-reviewed design

Consulted `tzurot-council-mcp` (Gemini 3.1 Pro Preview) on the full design — allowlist vs generic parser, modal shape, validation, error messaging, full-header-paste defense. Relevant calls:

- **Allowlist hybrid** over either "narrow parser" or "keep generic" — constant-table defense without auth-lib specificity.
- **Unified auth-failure message** — one "re-run `/shapes auth`" message rather than three distinct 401 modes. Remediation is identical; state tracking is waste.
- **Full-header-paste defense** — users commonly copy the `Cookie:` request header from the Network tab instead of a single cookie value from the Application tab. The parser detects this class of mistake and surfaces a specific hint.

## Common-types additions (cross-service)

New exports from `@tzurot/common-types/types/shapes-import.ts`:

- `SHAPES_SESSION_COOKIE_NAME` constant
- `isShapesAllowedCookieName(name)` predicate (exposed as a function, not a Set, to prevent mutable-singleton export)
- `buildSessionCookie(tokenValue)` helper
- `parseShapesSessionCookieInput(rawInput): ShapesSessionInputResult` parser + discriminated-union result type

Used consistently across bot-client (modal), api-gateway (validation), and ai-worker (fetcher).

## Out of scope (deliberately deferred)

- **Gateway live preflight** against shapes.inc on cookie submit — next PR in the queue. Would catch already-expired cookies at submit time rather than at first import attempt.
- **Fetcher hardening follow-ons** (schema-drift canary, raw JSON persistence, bot-protection detection, etc.) — tracked in `docs/proposals/backlog/shapes-inc-fetcher-hardening.md`.
- No changes to OAuth/bearer-token/CSRF paths, browser automation, retry/backoff/timeout constants, or endpoint paths.

## Test plan

- [x] `pnpm typecheck` clean (11/11 tasks)
- [x] `pnpm quality` (lint + cpd + depcruise + typecheck + typecheck:spec) clean (11/11)
- [x] `pnpm test` green across all 14 tasks (api-gateway, ai-worker, bot-client all passing; 108 + 106 + 270 test files respectively)
- [x] `pnpm test:int` green (20 files, 264 tests, ~38s)
- [x] Pre-push hook full build + lint + test + depcruise all green
- [x] `grep -rn "appSession" services/ packages/` returns only intentional references (the legacy-rejection tests in common-types/gateway test files, plus mock fixture overrides for downstream consumers)
- [ ] Manual verification on dev after deploy: `/shapes auth` with a real Better Auth cookie, followed by `/shapes import` against a known-good shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)