### PR TITLE
feat(api-gateway): shapes.inc cookie-submit hardening — preflight + stricter validation

### DIFF
--- a/packages/common-types/src/types/shapes-import.test.ts
+++ b/packages/common-types/src/types/shapes-import.test.ts
@@ -50,6 +50,18 @@ describe('isPlausibleShapesTokenValue', () => {
     expect(isPlausibleShapesTokenValue('a'.repeat(31))).toBe(false);
   });
 
+  it('accepts a 512-char value (exact upper boundary)', () => {
+    expect(isPlausibleShapesTokenValue('a'.repeat(512))).toBe(true);
+  });
+
+  it('rejects a 513-char value (just over the maximum)', () => {
+    expect(isPlausibleShapesTokenValue('a'.repeat(513))).toBe(false);
+  });
+
+  it('rejects a 10,000-char pathological oversize value', () => {
+    expect(isPlausibleShapesTokenValue('a'.repeat(10_000))).toBe(false);
+  });
+
   it('rejects an empty string', () => {
     expect(isPlausibleShapesTokenValue('')).toBe(false);
   });

--- a/packages/common-types/src/types/shapes-import.test.ts
+++ b/packages/common-types/src/types/shapes-import.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   SHAPES_SESSION_COOKIE_NAME,
   isShapesAllowedCookieName,
+  isPlausibleShapesTokenValue,
   buildSessionCookie,
   parseShapesSessionCookieInput,
 } from './shapes-import.js';
@@ -33,6 +34,33 @@ describe('isShapesAllowedCookieName', () => {
 describe('buildSessionCookie', () => {
   it('prepends the cookie name to a raw token value', () => {
     expect(buildSessionCookie('abc123')).toBe(`${SHAPES_SESSION_COOKIE_NAME}=abc123`);
+  });
+});
+
+describe('isPlausibleShapesTokenValue', () => {
+  it('accepts a 32-char alphanumeric value (exact boundary)', () => {
+    expect(isPlausibleShapesTokenValue('a'.repeat(32))).toBe(true);
+  });
+
+  it('accepts a value mixing allowed characters (letters, digits, dot, underscore, hyphen)', () => {
+    expect(isPlausibleShapesTokenValue('ABC-def_123.xyz-0123456789abcdef')).toBe(true);
+  });
+
+  it('rejects a 31-char value (just under the minimum)', () => {
+    expect(isPlausibleShapesTokenValue('a'.repeat(31))).toBe(false);
+  });
+
+  it('rejects an empty string', () => {
+    expect(isPlausibleShapesTokenValue('')).toBe(false);
+  });
+
+  it('rejects values containing spaces', () => {
+    expect(isPlausibleShapesTokenValue(`${'a'.repeat(20)} ${'b'.repeat(20)}`)).toBe(false);
+  });
+
+  it('rejects values containing special characters outside the allowed set', () => {
+    expect(isPlausibleShapesTokenValue(`${'a'.repeat(30)}!@`)).toBe(false);
+    expect(isPlausibleShapesTokenValue(`${'a'.repeat(30)}==`)).toBe(false);
   });
 });
 

--- a/packages/common-types/src/types/shapes-import.ts
+++ b/packages/common-types/src/types/shapes-import.ts
@@ -373,6 +373,16 @@ const SHAPES_TOKEN_SHAPE = /^[A-Za-z0-9._-]+$/;
 export const SHAPES_TOKEN_MIN_LENGTH = 32;
 
 /**
+ * Upper bound for a plausible Better Auth session token value. Typical
+ * tokens are 32–128 characters; 512 is well above any realistic length
+ * while blocking pathological oversize inputs (a malicious or
+ * misconfigured caller could otherwise submit a multi-KB value that
+ * would pass shape validation and balloon the stored ciphertext + the
+ * preflight `Cookie:` header).
+ */
+export const SHAPES_TOKEN_MAX_LENGTH = 512;
+
+/**
  * Parse the user-supplied modal input into a normalized cookie string.
  *
  * Accepts three input shapes, in order of preference:
@@ -437,5 +447,9 @@ export function parseShapesSessionCookieInput(rawInput: string): ShapesSessionIn
  * re-routing through the full three-shape parser.
  */
 export function isPlausibleShapesTokenValue(value: string): boolean {
-  return value.length >= SHAPES_TOKEN_MIN_LENGTH && SHAPES_TOKEN_SHAPE.test(value);
+  return (
+    value.length >= SHAPES_TOKEN_MIN_LENGTH &&
+    value.length <= SHAPES_TOKEN_MAX_LENGTH &&
+    SHAPES_TOKEN_SHAPE.test(value)
+  );
 }

--- a/packages/common-types/src/types/shapes-import.ts
+++ b/packages/common-types/src/types/shapes-import.ts
@@ -409,7 +409,7 @@ export function parseShapesSessionCookieInput(rawInput: string): ShapesSessionIn
       const name = trimmed.substring(0, eqIdx);
       const value = trimmed.substring(eqIdx + 1);
       if (name === SHAPES_SESSION_COOKIE_NAME) {
-        if (!isPlausibleTokenValue(value)) {
+        if (!isPlausibleShapesTokenValue(value)) {
           return { ok: false, reason: 'malformed-value' };
         }
         return { ok: true, cookie: buildSessionCookie(value) };
@@ -419,7 +419,7 @@ export function parseShapesSessionCookieInput(rawInput: string): ShapesSessionIn
   }
 
   // Bare token value path — sanity-check shape and length.
-  if (!isPlausibleTokenValue(input)) {
+  if (!isPlausibleShapesTokenValue(input)) {
     return { ok: false, reason: 'malformed-value' };
   }
   return { ok: true, cookie: buildSessionCookie(input) };
@@ -430,7 +430,12 @@ export function parseShapesSessionCookieInput(rawInput: string): ShapesSessionIn
  * `parseShapesSessionCookieInput` so a 16-char bare value and a 16-char
  * `name=value` value both fail the same way — no surprise where a format
  * is permissive in one path and strict in another.
+ *
+ * Also usable directly at trust boundaries (e.g., api-gateway validation)
+ * where callers have already extracted the raw token value from a
+ * `name=value` string and want to apply the same shape gate without
+ * re-routing through the full three-shape parser.
  */
-function isPlausibleTokenValue(value: string): boolean {
+export function isPlausibleShapesTokenValue(value: string): boolean {
   return value.length >= SHAPES_TOKEN_MIN_LENGTH && SHAPES_TOKEN_SHAPE.test(value);
 }

--- a/services/api-gateway/src/routes/user/shapes/auth.test.ts
+++ b/services/api-gateway/src/routes/user/shapes/auth.test.ts
@@ -37,6 +37,13 @@ vi.mock('../../../utils/asyncHandler.js', () => ({
   asyncHandler: vi.fn(fn => fn),
 }));
 
+// Mock the preflight so tests don't hit shapes.inc. Default to 'valid' so the
+// happy-path tests don't need per-case wiring; error-path tests override per call.
+const mockProbeShapesSession = vi.fn().mockResolvedValue('valid');
+vi.mock('../../../services/ShapesPreflight.js', () => ({
+  probeShapesSession: (...args: unknown[]) => mockProbeShapesSession(...args),
+}));
+
 import { createShapesAuthRoutes } from './auth.js';
 import type { PrismaClient } from '@tzurot/common-types';
 import { findRoute, getRouteHandler } from '../../../test/expressRouterUtils.js';
@@ -92,6 +99,8 @@ function createMockReqRes(body: Record<string, unknown> = {}) {
 describe('Shapes Auth Routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset preflight mock default after clearAllMocks wipes the implementation.
+    mockProbeShapesSession.mockResolvedValue('valid');
   });
 
   describe('route factory', () => {
@@ -215,6 +224,51 @@ describe('Shapes Auth Routes', () => {
       );
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+    });
+
+    describe('preflight outcomes', () => {
+      const VALID_COOKIE =
+        '__Secure-better-auth.session_token=opaque-better-auth-token-value-12345';
+
+      it('persists the cookie when preflight returns "valid"', async () => {
+        mockProbeShapesSession.mockResolvedValueOnce('valid');
+        const { res } = await callStoreHandler({ sessionCookie: VALID_COOKIE });
+
+        expect(mockProbeShapesSession).toHaveBeenCalledWith(VALID_COOKIE);
+        expect(mockPrisma.userCredential.upsert).toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(200);
+      });
+
+      it('rejects the cookie and does NOT persist when preflight returns "invalid"', async () => {
+        mockProbeShapesSession.mockResolvedValueOnce('invalid');
+        const { res } = await callStoreHandler({ sessionCookie: VALID_COOKIE });
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: expect.stringContaining('shapes.inc rejected this session cookie'),
+          })
+        );
+        expect(mockPrisma.userCredential.upsert).not.toHaveBeenCalled();
+      });
+
+      it('persists the cookie when preflight returns "inconclusive" (graceful degradation)', async () => {
+        // Transient shapes.inc failures must not block saving valid credentials.
+        mockProbeShapesSession.mockResolvedValueOnce('inconclusive');
+        const { res } = await callStoreHandler({ sessionCookie: VALID_COOKIE });
+
+        expect(mockPrisma.userCredential.upsert).toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(200);
+      });
+
+      it('does NOT run the preflight when format validation already rejects', async () => {
+        // tooShort fails the shape check before the preflight would be called.
+        await callStoreHandler({
+          sessionCookie: '__Secure-better-auth.session_token=tooShort',
+        });
+
+        expect(mockProbeShapesSession).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/services/api-gateway/src/routes/user/shapes/auth.test.ts
+++ b/services/api-gateway/src/routes/user/shapes/auth.test.ts
@@ -172,6 +172,31 @@ describe('Shapes Auth Routes', () => {
       expect(res.status).toHaveBeenCalledWith(400);
     });
 
+    it('should reject a value shorter than the minimum length', async () => {
+      // 8-char value; the min is 32. Matches bot-client modal's parse-time
+      // check so there's no gate that accepts what the other rejects.
+      const { res } = await callStoreHandler({
+        sessionCookie: '__Secure-better-auth.session_token=tooShort',
+      });
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('32 characters') })
+      );
+    });
+
+    it('should reject a value containing disallowed characters', async () => {
+      // Spaces fail the token-shape regex even though the length is fine.
+      const { res } = await callStoreHandler({
+        sessionCookie: '__Secure-better-auth.session_token=val with spaces and padding xxx',
+      });
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('alphanumeric') })
+      );
+    });
+
     it('should encrypt and upsert a valid Better Auth session cookie', async () => {
       const { res } = await callStoreHandler({
         sessionCookie: '__Secure-better-auth.session_token=opaque-better-auth-token-value-12345',

--- a/services/api-gateway/src/routes/user/shapes/auth.test.ts
+++ b/services/api-gateway/src/routes/user/shapes/auth.test.ts
@@ -39,9 +39,14 @@ vi.mock('../../../utils/asyncHandler.js', () => ({
 
 // Mock the preflight so tests don't hit shapes.inc. Default to 'valid' so the
 // happy-path tests don't need per-case wiring; error-path tests override per call.
-const mockProbeShapesSession = vi.fn().mockResolvedValue('valid');
+// Strictly typed so a typo in a mockResolvedValueOnce call (e.g., 'inconclusve')
+// would fail type-check rather than silently misdirect the test.
+import type { PreflightOutcome } from '../../../services/ShapesPreflight.js';
+const mockProbeShapesSession = vi
+  .fn<(sessionCookie: string) => Promise<PreflightOutcome>>()
+  .mockResolvedValue('valid');
 vi.mock('../../../services/ShapesPreflight.js', () => ({
-  probeShapesSession: (...args: unknown[]) => mockProbeShapesSession(...args),
+  probeShapesSession: (cookie: string) => mockProbeShapesSession(cookie),
 }));
 
 import { createShapesAuthRoutes } from './auth.js';
@@ -190,7 +195,7 @@ describe('Shapes Auth Routes', () => {
 
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith(
-        expect.objectContaining({ message: expect.stringContaining('32 characters') })
+        expect.objectContaining({ message: expect.stringContaining('32-512 characters') })
       );
     });
 
@@ -204,6 +209,17 @@ describe('Shapes Auth Routes', () => {
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({ message: expect.stringContaining('alphanumeric') })
       );
+    });
+
+    it('should reject a value longer than the maximum length', async () => {
+      // Pathological oversize input — 10 KB of alphanumeric passes the shape
+      // regex but must be rejected by the length ceiling so it can't reach
+      // the preflight fetch with a multi-KB Cookie header.
+      const { res } = await callStoreHandler({
+        sessionCookie: `__Secure-better-auth.session_token=${'a'.repeat(10000)}`,
+      });
+
+      expect(res.status).toHaveBeenCalledWith(400);
     });
 
     it('should encrypt and upsert a valid Better Auth session cookie', async () => {

--- a/services/api-gateway/src/routes/user/shapes/auth.ts
+++ b/services/api-gateway/src/routes/user/shapes/auth.ts
@@ -21,6 +21,8 @@ import {
   CREDENTIAL_SERVICES,
   CREDENTIAL_TYPES,
   SHAPES_SESSION_COOKIE_NAME,
+  SHAPES_TOKEN_MIN_LENGTH,
+  isPlausibleShapesTokenValue,
 } from '@tzurot/common-types';
 import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
@@ -51,17 +53,26 @@ function createStoreHandler(prisma: PrismaClient, userService: UserService) {
 
     // Bot-client's auth modal normalizes input to `name=value` form via
     // parseShapesSessionCookieInput before POSTing here. We accept only that
-    // strict shape: the string must start with the expected cookie name and
-    // have a non-empty value following the `=`.
+    // strict shape: the string must start with the expected cookie name, and
+    // the value portion must pass the same shape gate the parser applies.
+    // Defense-in-depth against direct API callers that skip the bot-client
+    // modal and would otherwise persist a 1-char or obviously-malformed
+    // value that shapes.inc will reject on the next request anyway.
     const expectedPrefix = `${SHAPES_SESSION_COOKIE_NAME}=`;
-    if (
-      !sessionCookie.startsWith(expectedPrefix) ||
-      sessionCookie.length <= expectedPrefix.length
-    ) {
+    if (!sessionCookie.startsWith(expectedPrefix)) {
       return sendError(
         res,
         ErrorResponses.validationError(
           `Session cookie must be in the form '${SHAPES_SESSION_COOKIE_NAME}=<value>'`
+        )
+      );
+    }
+    const tokenValue = sessionCookie.substring(expectedPrefix.length);
+    if (!isPlausibleShapesTokenValue(tokenValue)) {
+      return sendError(
+        res,
+        ErrorResponses.validationError(
+          `Session cookie value must be at least ${SHAPES_TOKEN_MIN_LENGTH} characters and contain only alphanumeric, dot, underscore, or hyphen characters`
         )
       );
     }

--- a/services/api-gateway/src/routes/user/shapes/auth.ts
+++ b/services/api-gateway/src/routes/user/shapes/auth.ts
@@ -29,6 +29,7 @@ import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { resolveProvisionedUserId } from '../../../utils/resolveProvisionedUserId.js';
 import { sendError, sendCustomSuccess } from '../../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
+import { probeShapesSession } from '../../../services/ShapesPreflight.js';
 import type { AuthenticatedRequest, ProvisionedRequest } from '../../../types.js';
 
 const logger = createLogger('shapes-auth');
@@ -73,6 +74,22 @@ function createStoreHandler(prisma: PrismaClient, userService: UserService) {
         res,
         ErrorResponses.validationError(
           `Session cookie value must be at least ${SHAPES_TOKEN_MIN_LENGTH} characters and contain only alphanumeric, dot, underscore, or hyphen characters`
+        )
+      );
+    }
+
+    // Preflight the cookie against shapes.inc before persisting. Catches
+    // already-expired cookies at submit time rather than on the user's first
+    // `/shapes import` attempt minutes later. Transient upstream failures
+    // (5xx, network, timeout) produce `inconclusive` and we proceed anyway —
+    // a shapes.inc outage must not block users from saving valid credentials.
+    const preflight = await probeShapesSession(sessionCookie);
+    if (preflight === 'invalid') {
+      logger.info({ discordUserId }, 'Preflight rejected cookie; not persisting');
+      return sendError(
+        res,
+        ErrorResponses.validationError(
+          'shapes.inc rejected this session cookie. It may be expired or from the wrong domain — harvest a fresh cookie from https://shapes.inc/dashboard and try again.'
         )
       );
     }

--- a/services/api-gateway/src/routes/user/shapes/auth.ts
+++ b/services/api-gateway/src/routes/user/shapes/auth.ts
@@ -22,6 +22,7 @@ import {
   CREDENTIAL_TYPES,
   SHAPES_SESSION_COOKIE_NAME,
   SHAPES_TOKEN_MIN_LENGTH,
+  SHAPES_TOKEN_MAX_LENGTH,
   isPlausibleShapesTokenValue,
 } from '@tzurot/common-types';
 import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthMiddleware.js';
@@ -73,7 +74,7 @@ function createStoreHandler(prisma: PrismaClient, userService: UserService) {
       return sendError(
         res,
         ErrorResponses.validationError(
-          `Session cookie value must be at least ${SHAPES_TOKEN_MIN_LENGTH} characters and contain only alphanumeric, dot, underscore, or hyphen characters`
+          `Session cookie value must be ${SHAPES_TOKEN_MIN_LENGTH}-${SHAPES_TOKEN_MAX_LENGTH} characters and contain only alphanumeric, dot, underscore, or hyphen characters`
         )
       );
     }
@@ -92,6 +93,9 @@ function createStoreHandler(prisma: PrismaClient, userService: UserService) {
           'shapes.inc rejected this session cookie. It may be expired or from the wrong domain — harvest a fresh cookie from https://shapes.inc/dashboard and try again.'
         )
       );
+    }
+    if (preflight === 'inconclusive') {
+      logger.warn({ discordUserId }, 'Preflight inconclusive; proceeding with persistence');
     }
 
     const userId = await resolveProvisionedUserId(req, userService);

--- a/services/api-gateway/src/services/ShapesPreflight.test.ts
+++ b/services/api-gateway/src/services/ShapesPreflight.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+import { probeShapesSession } from './ShapesPreflight.js';
+
+const SESSION_COOKIE = '__Secure-better-auth.session_token=abcdef0123456789abcdef0123456789';
+
+function mockResponse(status: number): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+  } as unknown as Response;
+}
+
+describe('probeShapesSession', () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    global.fetch = mockFetch as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns "valid" when shapes.inc returns 2xx', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse(200));
+    await expect(probeShapesSession(SESSION_COOKIE)).resolves.toBe('valid');
+  });
+
+  it('returns "valid" for non-200 2xx codes (e.g., 204)', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse(204));
+    await expect(probeShapesSession(SESSION_COOKIE)).resolves.toBe('valid');
+  });
+
+  it('returns "invalid" on 401 Unauthorized', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse(401));
+    await expect(probeShapesSession(SESSION_COOKIE)).resolves.toBe('invalid');
+  });
+
+  it('returns "invalid" on 403 Forbidden', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse(403));
+    await expect(probeShapesSession(SESSION_COOKIE)).resolves.toBe('invalid');
+  });
+
+  it('returns "inconclusive" on 404 (endpoint moved/missing)', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse(404));
+    await expect(probeShapesSession(SESSION_COOKIE)).resolves.toBe('inconclusive');
+  });
+
+  it('returns "inconclusive" on 500 server error', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse(500));
+    await expect(probeShapesSession(SESSION_COOKIE)).resolves.toBe('inconclusive');
+  });
+
+  it('returns "inconclusive" on 503 service unavailable', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse(503));
+    await expect(probeShapesSession(SESSION_COOKIE)).resolves.toBe('inconclusive');
+  });
+
+  it('returns "inconclusive" on network error (TypeError from undici)', async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError('fetch failed'));
+    await expect(probeShapesSession(SESSION_COOKIE)).resolves.toBe('inconclusive');
+  });
+
+  it('returns "inconclusive" when the fetch is aborted (AbortError)', async () => {
+    const abortError = new DOMException('The user aborted a request.', 'AbortError');
+    mockFetch.mockRejectedValueOnce(abortError);
+    await expect(probeShapesSession(SESSION_COOKIE)).resolves.toBe('inconclusive');
+  });
+
+  it('sends the submitted cookie and a Chrome-style User-Agent', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse(200));
+    await probeShapesSession(SESSION_COOKIE);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/auth/session'),
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Cookie: SESSION_COOKIE,
+          'User-Agent': expect.stringContaining('Mozilla/5.0'),
+          Accept: 'application/json',
+        }),
+      })
+    );
+  });
+
+  it('hits shapes.inc on the HTTPS origin', async () => {
+    mockFetch.mockResolvedValueOnce(mockResponse(200));
+    await probeShapesSession(SESSION_COOKIE);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringMatching(/^https:\/\/shapes\.inc\//),
+      expect.anything()
+    );
+  });
+});

--- a/services/api-gateway/src/services/ShapesPreflight.test.ts
+++ b/services/api-gateway/src/services/ShapesPreflight.test.ts
@@ -28,12 +28,14 @@ describe('probeShapesSession', () => {
   let mockFetch: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
+    vi.useFakeTimers();
     mockFetch = vi.fn();
     global.fetch = mockFetch as unknown as typeof fetch;
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it('returns "valid" when shapes.inc returns 2xx', async () => {
@@ -80,6 +82,27 @@ describe('probeShapesSession', () => {
     const abortError = new DOMException('The user aborted a request.', 'AbortError');
     mockFetch.mockRejectedValueOnce(abortError);
     await expect(probeShapesSession(SESSION_COOKIE)).resolves.toBe('inconclusive');
+  });
+
+  it('returns "inconclusive" when the preflight times out (setTimeout → abort)', async () => {
+    // Simulate shapes.inc hanging: fetch receives the abort signal and rejects
+    // with AbortError once `controller.abort()` fires via the internal timer.
+    mockFetch.mockImplementationOnce(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          const signal = init.signal;
+          if (signal !== undefined && signal !== null) {
+            signal.addEventListener('abort', () => {
+              reject(new DOMException('The user aborted a request.', 'AbortError'));
+            });
+          }
+        })
+    );
+
+    const promise = probeShapesSession(SESSION_COOKIE);
+    // Advance past the 5s internal timeout so the AbortController fires.
+    await vi.advanceTimersByTimeAsync(6000);
+    await expect(promise).resolves.toBe('inconclusive');
   });
 
   it('sends the submitted cookie and a Chrome-style User-Agent', async () => {

--- a/services/api-gateway/src/services/ShapesPreflight.ts
+++ b/services/api-gateway/src/services/ShapesPreflight.ts
@@ -1,0 +1,90 @@
+/**
+ * Shapes.inc Session Preflight
+ *
+ * When a user submits a shapes.inc session cookie via `/shapes auth`, validate
+ * it against shapes.inc *before* encrypting and persisting. Without this check,
+ * an already-expired cookie would land in the credential store successfully
+ * and only surface its invalidity on the user's first `/shapes import` attempt
+ * minutes later.
+ *
+ * Graceful degradation: a 5xx, a 404, or any network/timeout error produces an
+ * `inconclusive` outcome — the caller still persists the cookie. A shapes.inc
+ * outage must not block users from saving otherwise-valid credentials.
+ *
+ * Only an explicit 401/403 from shapes.inc is treated as "invalid".
+ */
+
+import { createLogger, SHAPES_BASE_URL, SHAPES_USER_AGENT } from '@tzurot/common-types';
+
+const logger = createLogger('ShapesPreflight');
+
+/**
+ * Timeout for the preflight request. Generous enough for a slow round-trip
+ * but short enough that a shapes.inc outage doesn't stall the user's auth flow
+ * for the full gateway-deferred-reply budget.
+ */
+const PREFLIGHT_TIMEOUT_MS = 5000;
+
+/**
+ * The Better Auth convention is to expose a session-introspection endpoint at
+ * `/api/auth/session` that returns the decoded session on valid, or a 401 on
+ * invalid/expired. If shapes.inc ever moves it, update this constant — the
+ * `inconclusive` outcome on 404 keeps the auth flow working in the meantime.
+ */
+const PREFLIGHT_ENDPOINT = '/api/auth/session';
+
+export type PreflightOutcome = 'valid' | 'invalid' | 'inconclusive';
+
+/**
+ * Probe shapes.inc with the submitted session cookie and return the outcome.
+ * Never throws — network/timeout errors return `'inconclusive'` so the caller
+ * can decide whether to proceed.
+ */
+export async function probeShapesSession(sessionCookie: string): Promise<PreflightOutcome> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), PREFLIGHT_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(`${SHAPES_BASE_URL}${PREFLIGHT_ENDPOINT}`, {
+      method: 'GET',
+      headers: {
+        Cookie: sessionCookie,
+        'User-Agent': SHAPES_USER_AGENT,
+        Accept: 'application/json',
+      },
+      signal: controller.signal,
+    });
+
+    if (response.ok) {
+      return 'valid';
+    }
+
+    if (response.status === 401 || response.status === 403) {
+      logger.info(
+        { status: response.status },
+        '[ShapesPreflight] shapes.inc rejected submitted cookie'
+      );
+      return 'invalid';
+    }
+
+    // 404 (endpoint moved/missing), 5xx (server error), other 4xx (unexpected)
+    // → inconclusive. Log loudly so we notice if the endpoint ever changes
+    // and always-inconclusive becomes the norm.
+    logger.warn(
+      { status: response.status, endpoint: PREFLIGHT_ENDPOINT },
+      '[ShapesPreflight] Inconclusive preflight — persisting cookie anyway'
+    );
+    return 'inconclusive';
+  } catch (error) {
+    // AbortError (timeout), network errors (ENOTFOUND, ECONNRESET, etc.) all
+    // collapse to inconclusive — we don't want a shapes.inc outage to block
+    // users from saving valid credentials.
+    logger.warn(
+      { err: error instanceof Error ? error : new Error(String(error)) },
+      '[ShapesPreflight] Preflight fetch failed — persisting cookie anyway'
+    );
+    return 'inconclusive';
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/services/api-gateway/src/services/ShapesPreflight.ts
+++ b/services/api-gateway/src/services/ShapesPreflight.ts
@@ -60,10 +60,7 @@ export async function probeShapesSession(sessionCookie: string): Promise<Preflig
     }
 
     if (response.status === 401 || response.status === 403) {
-      logger.info(
-        { status: response.status },
-        '[ShapesPreflight] shapes.inc rejected submitted cookie'
-      );
+      logger.info({ status: response.status }, 'shapes.inc rejected submitted cookie');
       return 'invalid';
     }
 
@@ -72,7 +69,7 @@ export async function probeShapesSession(sessionCookie: string): Promise<Preflig
     // and always-inconclusive becomes the norm.
     logger.warn(
       { status: response.status, endpoint: PREFLIGHT_ENDPOINT },
-      '[ShapesPreflight] Inconclusive preflight — persisting cookie anyway'
+      'Inconclusive preflight — persisting cookie anyway'
     );
     return 'inconclusive';
   } catch (error) {
@@ -81,7 +78,7 @@ export async function probeShapesSession(sessionCookie: string): Promise<Preflig
     // users from saving valid credentials.
     logger.warn(
       { err: error instanceof Error ? error : new Error(String(error)) },
-      '[ShapesPreflight] Preflight fetch failed — persisting cookie anyway'
+      'Preflight fetch failed — persisting cookie anyway'
     );
     return 'inconclusive';
   } finally {


### PR DESCRIPTION
## Summary

Two-commit gateway hardening follow-up to PR #869, bundled because both commits touch the same handler (`services/api-gateway/src/routes/user/shapes/auth.ts`). Sequenced per the Inbox entry: stricter format validation first (preamble), then the live preflight that builds on that foundation.

## Commit 1 — `refactor(api-gateway): share token-shape check between bot-client and gateway` (`09be1555d`)

- Promotes `isPlausibleTokenValue` from a private helper inside `parseShapesSessionCookieInput` to an exported `isPlausibleShapesTokenValue(value: string): boolean` predicate.
- Gateway's `createStoreHandler` now runs the extracted token value through `isPlausibleShapesTokenValue` before persisting — same shape + length gate the bot-client modal applies.
- Closes the divergence flagged in PR #869 review: previously the gateway accepted any non-empty value (including 1-char tokens). Direct API calls that bypass the bot-client modal can no longer persist structurally-invalid tokens.
- 6 new tests: direct predicate tests in common-types (boundary at 31/32 chars, regex rejection), gateway-level rejection tests for short value and disallowed-character value.

## Commit 2 — `feat(api-gateway): add shapes.inc session preflight on cookie submit` (`54f2c3140`)

- New `services/api-gateway/src/services/ShapesPreflight.ts` with `probeShapesSession(cookie) → 'valid' | 'invalid' | 'inconclusive'`.
- Probes `GET https://shapes.inc/api/auth/session` (Better Auth's conventional introspection path) with a 5-second timeout.
- Outcome mapping:
  - **2xx** → `valid` → proceed with persistence
  - **401 / 403** → `invalid` → reject with user-facing error pointing at re-harvest flow; cookie NOT persisted
  - **404, 5xx, network error, timeout** → `inconclusive` → warn-log + proceed with persistence
- The `inconclusive` path is intentional per council design: a shapes.inc outage must not block users from saving otherwise-valid credentials.
- Runs AFTER format validation so malformed inputs never reach shapes.inc — cheap local rejection takes precedence over a 5-second network round-trip.

## Council context

Design reviewed during PR #869 (council: Gemini 3.1 Pro Preview, 2026-04-22). The preflight recommendation came from "catches already-expired cookies at submit time rather than discovering them during the first `/shapes import` attempt minutes later." Graceful-degradation-on-transient-failure was also their call — avoid the "block valid cookies on shapes.inc 5xx" trap.

## Open question (not blocking)

**Is `/api/auth/session` the right preflight endpoint?** Based on Better Auth's convention but not verified against shapes.inc directly. If the endpoint is wrong (e.g., returns 404), the `inconclusive` path keeps the auth flow working — but we lose the validity check. Manual verification on dev after deploy:

```
pnpm ops logs --env dev --filter "@api-gateway" | grep "ShapesPreflight"
```

If the logs show consistent `inconclusive` after real submit attempts, the endpoint choice needs revisiting.

## Test plan

- [x] `pnpm typecheck` clean (11/11 tasks)
- [x] `pnpm test` green across all 14 tasks (api-gateway 109 test files, ai-worker 106, bot-client 270)
- [x] `pnpm quality` 11/11
- [x] Pre-push hook full build + lint + test + depcruise + typecheck:spec all green
- [x] New tests for every preflight outcome (11 tests in `ShapesPreflight.test.ts`)
- [x] Handler tests for all three outcomes in `auth.test.ts` including "preflight not run when format validation rejects"
- [ ] Manual verification on dev: `/shapes auth` with (a) a real valid cookie → should persist with `preflight=valid` log; (b) a tampered cookie → should reject with the re-harvest error

## Out of scope (intentional)

- The "schema-drift canary" and "raw JSON persistence" items from `docs/proposals/backlog/shapes-inc-fetcher-hardening.md` — those are fetcher-side hardening, separate PR(s).
- Telemetry for preflight outcome rates — basic warn-log is enough for the dev observability window; structured metrics can come in a follow-on if the outcome distribution is interesting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)