### PR TITLE
fix(ai-worker): extract GLM-4.5-air fake-user-message reasoning leak

### DIFF
--- a/services/ai-worker/src/services/__snapshots__/PromptBuilder.test.ts.snap
+++ b/services/ai-worker/src/services/__snapshots__/PromptBuilder.test.ts.snap
@@ -35,7 +35,8 @@ You are a helpful assistant. Always be kind and helpful.
 
 <output_constraints>
 <constraint>Output the raw response text only; do not include name labels, timestamps, or speaker prefixes.</constraint>
-<constraint>Never output XML tags in your response.</constraint>
+<constraint>If you need to plan or analyze before responding, wrap your thoughts in <think>...</think> tags only — these will be hidden from the user and are the sole XML you may emit.</constraint>
+<constraint>Never emit input-format scaffolding in your output: tags like <from_id>, <user>, or <message> are assembly artifacts from the conversation context and must never appear in your response.</constraint>
 <constraint>Never repeat or parrot back what was just said. Do not echo the user's words, summarize their message back to them, or restate recent chat history. Advance the conversation with original thoughts and reactions.</constraint>
 </output_constraints>"
 `;
@@ -93,7 +94,8 @@ You are a helpful assistant. Always be kind and helpful.
 
 <output_constraints>
 <constraint>Output the raw response text only; do not include name labels, timestamps, or speaker prefixes.</constraint>
-<constraint>Never output XML tags in your response.</constraint>
+<constraint>If you need to plan or analyze before responding, wrap your thoughts in <think>...</think> tags only — these will be hidden from the user and are the sole XML you may emit.</constraint>
+<constraint>Never emit input-format scaffolding in your output: tags like <from_id>, <user>, or <message> are assembly artifacts from the conversation context and must never appear in your response.</constraint>
 <constraint>Never repeat or parrot back what was just said. Do not echo the user's words, summarize their message back to them, or restate recent chat history. Advance the conversation with original thoughts and reactions.</constraint>
 </output_constraints>"
 `;
@@ -170,7 +172,8 @@ You are a helpful assistant. Always be kind and helpful.
 
 <output_constraints>
 <constraint>Output the raw response text only; do not include name labels, timestamps, or speaker prefixes.</constraint>
-<constraint>Never output XML tags in your response.</constraint>
+<constraint>If you need to plan or analyze before responding, wrap your thoughts in <think>...</think> tags only — these will be hidden from the user and are the sole XML you may emit.</constraint>
+<constraint>Never emit input-format scaffolding in your output: tags like <from_id>, <user>, or <message> are assembly artifacts from the conversation context and must never appear in your response.</constraint>
 <constraint>Never repeat or parrot back what was just said. Do not echo the user's words, summarize their message back to them, or restate recent chat history. Advance the conversation with original thoughts and reactions.</constraint>
 </output_constraints>"
 `;
@@ -216,7 +219,8 @@ You are a helpful assistant. Always be kind and helpful.
 
 <output_constraints>
 <constraint>Output the raw response text only; do not include name labels, timestamps, or speaker prefixes.</constraint>
-<constraint>Never output XML tags in your response.</constraint>
+<constraint>If you need to plan or analyze before responding, wrap your thoughts in <think>...</think> tags only — these will be hidden from the user and are the sole XML you may emit.</constraint>
+<constraint>Never emit input-format scaffolding in your output: tags like <from_id>, <user>, or <message> are assembly artifacts from the conversation context and must never appear in your response.</constraint>
 <constraint>Never repeat or parrot back what was just said. Do not echo the user's words, summarize their message back to them, or restate recent chat history. Advance the conversation with original thoughts and reactions.</constraint>
 </output_constraints>"
 `;

--- a/services/ai-worker/src/services/prompt/HardcodedConstraints.test.ts
+++ b/services/ai-worker/src/services/prompt/HardcodedConstraints.test.ts
@@ -43,8 +43,24 @@ describe('HardcodedConstraints', () => {
       expect(OUTPUT_CONSTRAINTS).toContain('do not include name labels');
     });
 
-    it('should prohibit XML tags in output', () => {
-      expect(OUTPUT_CONSTRAINTS).toContain('Never output XML tags');
+    it('should sanction <think> tags as the only permitted XML output channel', () => {
+      // Path-of-less-resistance for models that hallucinate prompt-assembly
+      // scaffolding when reasoning is enabled — gives them a sanctioned
+      // thinking channel that the generic KNOWN_THINKING_TAGS extractor
+      // already handles cleanly.
+      expect(OUTPUT_CONSTRAINTS).toContain('<think>');
+      expect(OUTPUT_CONSTRAINTS).toContain('sole XML you may emit');
+    });
+
+    it('should prohibit leaking specific input-format scaffolding tags', () => {
+      // Concrete named prohibitions land harder than abstract "XML" for
+      // RLHF-fighting models (validated via MCP council, 2026-04-22).
+      // Addresses the GLM-4.5-Air fake-user-message-echo quirk observed
+      // in req b533e288-fb07-46c0-a5e2-a0f78883e63e.
+      expect(OUTPUT_CONSTRAINTS).toContain('<from_id>');
+      expect(OUTPUT_CONSTRAINTS).toContain('<user>');
+      expect(OUTPUT_CONSTRAINTS).toContain('<message>');
+      expect(OUTPUT_CONSTRAINTS).toContain('assembly artifacts');
     });
 
     it('should prohibit parroting', () => {

--- a/services/ai-worker/src/services/prompt/HardcodedConstraints.ts
+++ b/services/ai-worker/src/services/prompt/HardcodedConstraints.ts
@@ -59,6 +59,7 @@ export function buildIdentityConstraints(
  */
 export const OUTPUT_CONSTRAINTS = `<output_constraints>
 <constraint>Output the raw response text only; do not include name labels, timestamps, or speaker prefixes.</constraint>
-<constraint>Never output XML tags in your response.</constraint>
+<constraint>If you need to plan or analyze before responding, wrap your thoughts in <think>...</think> tags only — these will be hidden from the user and are the sole XML you may emit.</constraint>
+<constraint>Never emit input-format scaffolding in your output: tags like <from_id>, <user>, or <message> are assembly artifacts from the conversation context and must never appear in your response.</constraint>
 <constraint>Never repeat or parrot back what was just said. Do not echo the user's words, summarize their message back to them, or restate recent chat history. Advance the conversation with original thoughts and reactions.</constraint>
 </output_constraints>`;

--- a/services/ai-worker/src/utils/thinkingExtraction.test.ts
+++ b/services/ai-worker/src/utils/thinkingExtraction.test.ts
@@ -776,6 +776,57 @@ Final response.`;
       expect(result.visibleContent).toBe('Final response.');
     });
 
+    it('strips the wrapper but yields null thinkingContent when <message> is empty', () => {
+      // The `extractedThinking.length > 0` guard skips empty blocks so they
+      // don't pollute thinkingContent with empty strings, but the scaffolding
+      // must still be stripped from visibleContent. Pins the contract so
+      // the guard can't regress to "push empty strings into thinkingParts".
+      const content = `<from_id>${VALID_UUID}</from_id>
+<user>User</user>
+<message></message>
+
+Response.`;
+
+      const result = extractThinkingBlocks(content);
+
+      expect(result.thinkingContent).toBeNull();
+      expect(result.blockCount).toBe(0);
+      expect(result.visibleContent).toBe('Response.');
+      expect(result.visibleContent).not.toContain('<from_id>');
+    });
+
+    it('rejects edge-case UUID-shaped strings (all hyphens, repeated hex digits)', () => {
+      // RFC 4122 hyphen-layout enforcement: a character class [a-fA-F0-9-]{36}
+      // would match "------------------------------------" or
+      // "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" — neither is a valid UUID
+      // shape. The strict 8-4-4-4-12 pattern rejects the former outright;
+      // the latter is structurally valid-shaped so it still matches (same
+      // as any real UUID with all-a hex).
+      const allHyphens = '------------------------------------';
+      const contentAllHyphens = `<from_id>${allHyphens}</from_id>
+<user>User</user>
+<message>content</message>
+
+Response.`;
+      const resultAllHyphens = extractThinkingBlocks(contentAllHyphens);
+      expect(resultAllHyphens.thinkingContent).toBeNull();
+      expect(resultAllHyphens.visibleContent).toContain('<from_id>');
+
+      // Control: a structurally-valid UUID shape (8-4-4-4-12) with all-a
+      // hex digits does match — this is intentional. Real UUIDs can
+      // contain any hex digits; the safety guarantee is the SHAPE, not
+      // the entropy of the bytes.
+      const allA = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+      const contentAllA = `<from_id>${allA}</from_id>
+<user>User</user>
+<message>content</message>
+
+Response.`;
+      const resultAllA = extractThinkingBlocks(contentAllA);
+      expect(resultAllA.thinkingContent).toBe('content');
+      expect(resultAllA.visibleContent).toBe('Response.');
+    });
+
     it('handles uppercase UUIDs (case-insensitivity on hex digits)', () => {
       const upperUuid = VALID_UUID.toUpperCase();
       const content = `<from_id>${upperUuid}</from_id>

--- a/services/ai-worker/src/utils/thinkingExtraction.test.ts
+++ b/services/ai-worker/src/utils/thinkingExtraction.test.ts
@@ -827,6 +827,46 @@ Response.`;
       expect(resultAllA.visibleContent).toBe('Response.');
     });
 
+    it('pins the Pass-1/Pass-2 double-extraction edge case for nested <think> tags', () => {
+      // Reviewer flagged (PR #875 round 3, 2026-04-22): Pass 2 reads from
+      // `normalized` (pre-Pass-1-strip), so if a Pass-1 <message> block
+      // contains a Pass-2 tag (like <think>), the inner content ends up in
+      // `thinkingParts` twice — once as part of the whole <message> block
+      // (Pass 1), once as its own tag match (Pass 2).
+      //
+      // Not user-visible (only affects `showThinking` output) and requires
+      // a pathological input shape. Left as-is intentionally; this test
+      // PINS the current behavior so any future refactor explicitly chooses
+      // whether to preserve or fix it.
+      //
+      // Contract pinned here:
+      //   - Pass 1 extracts the full <message> content (including the literal
+      //     <think> tags) into thinkingParts[0].
+      //   - Pass 2 finds the <think> in the pre-strip `normalized` content
+      //     and extracts the inner thinking into thinkingParts[1].
+      //   - visibleContent has the wrapper stripped (Pass 1) and any
+      //     remaining <think> tags stripped (Pass 2).
+      //   - `thinkingContent` joins both parts with the `---` separator.
+      const content = `<from_id>${VALID_UUID}</from_id>
+<user>User</user>
+<message>outer planning <think>nested reasoning</think> more planning</message>
+
+Final response.`;
+
+      const result = extractThinkingBlocks(content);
+
+      expect(result.thinkingContent).not.toBeNull();
+      // Both the outer <message> content (with nested <think> tags literal)
+      // and the separately-extracted nested <think> inner are present.
+      expect(result.thinkingContent).toContain('outer planning');
+      expect(result.thinkingContent).toContain('nested reasoning');
+      expect(result.thinkingContent).toContain('---'); // Part separator
+      // visibleContent is clean — no scaffolding, no think tags.
+      expect(result.visibleContent).toBe('Final response.');
+      expect(result.visibleContent).not.toContain('<from_id>');
+      expect(result.visibleContent).not.toContain('<think>');
+    });
+
     it('handles uppercase UUIDs (case-insensitivity on hex digits)', () => {
       const upperUuid = VALID_UUID.toUpperCase();
       const content = `<from_id>${upperUuid}</from_id>

--- a/services/ai-worker/src/utils/thinkingExtraction.test.ts
+++ b/services/ai-worker/src/utils/thinkingExtraction.test.ts
@@ -927,6 +927,33 @@ describe('hasThinkingBlocks', () => {
   it('should NOT detect namespace-prefixed non-thinking tags', () => {
     expect(hasThinkingBlocks('<xml:div>content</xml:div>')).toBe(false);
   });
+
+  it('should detect GLM fake-user-message-echo wrapper as a thinking block', () => {
+    // Prevents a false-negative in DiagnosticRecorders. Without this check,
+    // `hasReasoningTagsInContent` would be `false` for pure-GLM responses
+    // where the fake-user-message wrapper is the only thinking-content
+    // signal — even though `extractThinkingBlocks` would correctly find
+    // and strip the block. Surfaced by PR #875 round 4 review (2026-04-22).
+    const uuid = '62a59660-cd89-51dc-8c54-7100f4e33329';
+    const content = `<from_id>${uuid}</from_id>
+<user>User</user>
+<message>chain of thought</message>
+
+Response.`;
+    expect(hasThinkingBlocks(content)).toBe(true);
+  });
+
+  it('should NOT detect GLM-style scaffolding with invalid UUID (defense alignment with extractor)', () => {
+    // `hasThinkingBlocks` and `extractThinkingBlocks` must agree on what
+    // counts as a thinking block. If one detects the pattern but the other
+    // doesn't, diagnostics drift out of sync with extraction behavior.
+    const content = `<from_id>not-a-uuid</from_id>
+<user>User</user>
+<message>content</message>
+
+Response.`;
+    expect(hasThinkingBlocks(content)).toBe(false);
+  });
 });
 
 describe('extractApiReasoningContent', () => {

--- a/services/ai-worker/src/utils/thinkingExtraction.test.ts
+++ b/services/ai-worker/src/utils/thinkingExtraction.test.ts
@@ -672,6 +672,124 @@ def hello():
       expect(result.blockCount).toBe(1);
     });
   });
+
+  describe('GLM-4.5-Air fake-user-message-echo pattern', () => {
+    // Observed 2026-04-22 (req b533e288-fb07-46c0-a5e2-a0f78883e63e).
+    // Model emitted chain-of-thought wrapped in tags that mimic our
+    // prompt-assembly format. Three structural rules protect extraction
+    // safety: start-of-response anchor, UUID shape, strict tag sequence.
+    const VALID_UUID = '62a59660-cd89-51dc-8c54-7100f4e33329';
+
+    it('extracts the leading fake-user-message block as thinking content', () => {
+      const content = `
+<from_id>${VALID_UUID}</from_id>
+<user>Test User (L432)</user>
+<message>As the character, I should respond thoughtfully.
+I need to acknowledge their question and stay in voice.</message>
+
+*The actual in-character response begins here.*`;
+
+      const result = extractThinkingBlocks(content);
+
+      expect(result.thinkingContent).toContain('As the character, I should respond thoughtfully.');
+      expect(result.thinkingContent).toContain('I need to acknowledge their question');
+      expect(result.visibleContent).toBe('*The actual in-character response begins here.*');
+      expect(result.blockCount).toBe(1);
+    });
+
+    it('strips the wrapper from visible content without leaking scaffolding tags', () => {
+      const content = `<from_id>${VALID_UUID}</from_id>
+<user>User</user>
+<message>reasoning here</message>
+
+Real response.`;
+
+      const result = extractThinkingBlocks(content);
+
+      expect(result.visibleContent).not.toContain('<from_id>');
+      expect(result.visibleContent).not.toContain('</message>');
+      expect(result.visibleContent).not.toContain(VALID_UUID);
+      expect(result.visibleContent).toBe('Real response.');
+    });
+
+    it('does NOT match when the block is mid-response rather than leading', () => {
+      // Position anchor is load-bearing — a character discussing this format
+      // mid-response (hypothetical meta-conversation) must not get stripped.
+      const content = `Here is my response. Later I will show you:
+<from_id>${VALID_UUID}</from_id>
+<user>Example</user>
+<message>example content</message>
+That is what the format looks like.`;
+
+      const result = extractThinkingBlocks(content);
+
+      // Nothing extracted — mid-response occurrence left intact
+      expect(result.thinkingContent).toBeNull();
+      expect(result.visibleContent).toContain('<from_id>');
+      expect(result.blockCount).toBe(0);
+    });
+
+    it('does NOT match when the from_id lacks a valid UUID', () => {
+      // UUID validation is the primary safety guarantee against false-positives.
+      // Random prose content between `<from_id>` tags must not trigger extraction.
+      const content = `<from_id>not-a-uuid</from_id>
+<user>User</user>
+<message>content</message>
+
+Response.`;
+
+      const result = extractThinkingBlocks(content);
+
+      expect(result.thinkingContent).toBeNull();
+      expect(result.visibleContent).toContain('<from_id>');
+    });
+
+    it('does NOT match when a UUID is present but the tag sequence is incomplete', () => {
+      // Missing <user> tag — structural sequence check protects extraction.
+      const content = `<from_id>${VALID_UUID}</from_id>
+<message>content without user tag</message>
+
+Response.`;
+
+      const result = extractThinkingBlocks(content);
+
+      expect(result.thinkingContent).toBeNull();
+      expect(result.visibleContent).toContain('<from_id>');
+    });
+
+    it('composes with standard <think> tag extraction on the remaining content', () => {
+      // Chain-of-Extractors: model-specific pattern runs first (pass 1),
+      // standard KNOWN_THINKING_TAGS runs second (pass 2). Both should fire
+      // when a response contains both patterns.
+      const content = `<from_id>${VALID_UUID}</from_id>
+<user>User</user>
+<message>first-pass thinking</message>
+
+<think>second-pass thinking</think>
+
+Final response.`;
+
+      const result = extractThinkingBlocks(content);
+
+      expect(result.thinkingContent).toContain('first-pass thinking');
+      expect(result.thinkingContent).toContain('second-pass thinking');
+      expect(result.visibleContent).toBe('Final response.');
+    });
+
+    it('handles uppercase UUIDs (case-insensitivity on hex digits)', () => {
+      const upperUuid = VALID_UUID.toUpperCase();
+      const content = `<from_id>${upperUuid}</from_id>
+<user>User</user>
+<message>reasoning</message>
+
+Response.`;
+
+      const result = extractThinkingBlocks(content);
+
+      expect(result.thinkingContent).toBe('reasoning');
+      expect(result.visibleContent).toBe('Response.');
+    });
+  });
 });
 
 describe('hasThinkingBlocks', () => {

--- a/services/ai-worker/src/utils/thinkingExtraction.ts
+++ b/services/ai-worker/src/utils/thinkingExtraction.ts
@@ -60,6 +60,45 @@ const KNOWN_THINKING_TAGS = [
 ] as const;
 
 /**
+ * GLM-4.5-Air fake-user-message-echo pattern.
+ *
+ * Observed 2026-04-22 (req b533e288-fb07-46c0-a5e2-a0f78883e63e): with
+ * `reasoning.enabled=true` and no OpenRouter-side reasoning extraction,
+ * GLM-4.5-Air improvised a reasoning channel by wrapping its chain-of-thought
+ * in tags that mimic our prompt-assembly format:
+ *
+ *   <from_id>UUID</from_id>
+ *   <user>Display Name</user>
+ *   <message>... chain of thought here ...</message>
+ *
+ *   <actual in-character response>
+ *
+ * The three structural rules that make this safe to extract (not just strip):
+ *   1. Start-of-response anchor (`^\s*`) — mid-response matches are left alone.
+ *   2. UUID validation (`[a-fA-F0-9\-]{36}`) — no legitimate roleplay output
+ *      starts with an invisible 36-char hex-dash block; UUIDs only appear in
+ *      our internal assembly format.
+ *   3. Strict tag sequence (`<from_id>` → `<user>` → `<message>`) — all three
+ *      in order with standard whitespace between them.
+ *
+ * False-positive risk: effectively zero. The UUID shape is the load-bearing
+ * guarantee; the tag names are scaffolding around it.
+ *
+ * Architecture: this is a "model-specific pattern extractor" that runs as a
+ * first pass in `extractThinkingBlocks`, before the generic `KNOWN_THINKING_TAGS`
+ * loop. Council (Gemini 3.1 Pro Preview, 2026-04-22) recommended the
+ * Chain-of-Extractors pattern: complex model-specific regexes first,
+ * simple generic tag patterns second.
+ *
+ * Deletion plan: once OpenRouter's reasoning-extractor middleware handles
+ * this upstream (they actively polyfill similar quirks for DeepSeek/Qwen/Llama),
+ * this pattern can be removed. File an issue with them with the raw API
+ * response as evidence.
+ */
+const GLM_FAKE_USER_MESSAGE_ECHO_PATTERN =
+  /^\s*<from_id>[a-fA-F0-9-]{36}<\/from_id>\s*<user>[^<]*<\/user>\s*<message>([\s\S]*?)<\/message>\s*/;
+
+/**
  * Alternation pattern fragment for use in regex: `think|thinking|...`
  *
  * Order is safe — all usage sites have structural terminators (`>`, `\b`)
@@ -303,6 +342,29 @@ export function extractThinkingBlocks(content: string): ThinkingExtraction {
   const normalized = normalizeThinkingTagNamespaces(content);
   let visibleContent = normalized;
 
+  // Pass 1 — model-specific pattern extractors.
+  // Runs before the generic KNOWN_THINKING_TAGS loop so the leading block
+  // is consumed before the simple tag extractors see it. Currently only
+  // handles GLM-4.5-Air's fake-user-message wrapper; add new entries here
+  // for future model-specific leak patterns (see Chain-of-Extractors rationale
+  // on GLM_FAKE_USER_MESSAGE_ECHO_PATTERN).
+  const fakeUserMessageMatch = GLM_FAKE_USER_MESSAGE_ECHO_PATTERN.exec(visibleContent);
+  if (fakeUserMessageMatch !== null) {
+    const extractedThinking = fakeUserMessageMatch[1].trim();
+    if (extractedThinking.length > 0) {
+      thinkingParts.push(extractedThinking);
+    }
+    visibleContent = visibleContent.replace(GLM_FAKE_USER_MESSAGE_ECHO_PATTERN, '');
+    logger.warn(
+      {
+        extractedLength: extractedThinking.length,
+        remainingLength: visibleContent.length,
+      },
+      'Stripped leading fake-user-message wrapper (GLM-4.5-Air reasoning leak)'
+    );
+  }
+
+  // Pass 2 — generic known-thinking-tag extractors.
   // Extract thinking content from ALL patterns and ALWAYS remove from visible content
   // This prevents tag leakage when responses contain multiple tag types
   for (const pattern of THINKING_PATTERNS) {

--- a/services/ai-worker/src/utils/thinkingExtraction.ts
+++ b/services/ai-worker/src/utils/thinkingExtraction.ts
@@ -361,18 +361,34 @@ export function extractThinkingBlocks(content: string): ThinkingExtraction {
     // the match is always at position 0, and `fakeUserMessageMatch[0].length`
     // is the byte count of the block to consume.
     visibleContent = visibleContent.slice(fakeUserMessageMatch[0].length);
+    // "Scaffolding" (not "reasoning leak") covers both: the standard case
+    // where the block contains a CoT dump, AND the empty-<message> edge case
+    // where nothing was extracted but the input-format wrapper still got
+    // stripped. `extractedLength: 0` paired with "reasoning leak" wording
+    // was misleading in logs.
     logger.warn(
       {
         extractedLength: extractedThinking.length,
         remainingLength: visibleContent.length,
       },
-      'Stripped leading fake-user-message wrapper (GLM-4.5-Air reasoning leak)'
+      'Stripped leading fake-user-message scaffolding (GLM-4.5-Air input-format echo)'
     );
   }
 
   // Pass 2 — generic known-thinking-tag extractors.
   // Extract thinking content from ALL patterns and ALWAYS remove from visible content
   // This prevents tag leakage when responses contain multiple tag types
+  //
+  // Note: this loop reads from `normalized` (pre-Pass-1-strip), not from
+  // `visibleContent` (post-Pass-1-strip), for match enumeration. The
+  // `visibleContent.replace` below removes matched patterns from the
+  // post-Pass-1 content, which is the user-visible output. Consequence:
+  // if a Pass-1 `<message>` block happened to contain a Pass-2 tag
+  // (`<think>`/`<understanding>`/etc.), the inner content would be added
+  // to `thinkingParts` twice — once as part of the whole `<message>` block
+  // in Pass 1, once as its own tag match in Pass 2. Edge case is not
+  // user-visible (it only affects `showThinking` output) and would require
+  // a pathological input shape. Left as-is intentionally.
   for (const pattern of THINKING_PATTERNS) {
     pattern.lastIndex = 0;
     const matches = normalized.matchAll(pattern);

--- a/services/ai-worker/src/utils/thinkingExtraction.ts
+++ b/services/ai-worker/src/utils/thinkingExtraction.ts
@@ -87,6 +87,21 @@ const KNOWN_THINKING_TAGS = [
  * False-positive risk: effectively zero. The UUID shape is the load-bearing
  * guarantee; the tag names are scaffolding around it.
  *
+ * Interaction with `normalizeThinkingTagNamespaces`: the upstream namespace
+ * normalization only rewrites tags whose name is in `KNOWN_THINKING_TAGS`
+ * (think/thinking/ant_thinking/reasoning/thought/reflection/scratchpad/
+ * character_analysis/understanding). `<from_id>`, `<user>`, and `<message>`
+ * are not in that list, so normalization will not rewrite them and this
+ * pattern is safe against a `<ns:from_id>`-style future leak. If the
+ * `KNOWN_THINKING_TAGS` list is ever expanded to include overlap with these
+ * scaffolding tag names, re-verify.
+ *
+ * `^` anchor is intentional absolute start-of-string (no `m` flag). The
+ * pattern must only fire when the wrapper dominates the whole response;
+ * an `m`-flagged `^` would match any line start and would incorrectly
+ * strip mid-response occurrences of the format (e.g. in meta-conversation
+ * about the format).
+ *
  * Architecture: this is a "model-specific pattern extractor" that runs as a
  * first pass in `extractThinkingBlocks`, before the generic `KNOWN_THINKING_TAGS`
  * loop. Council (Gemini 3.1 Pro Preview, 2026-04-22) recommended the

--- a/services/ai-worker/src/utils/thinkingExtraction.ts
+++ b/services/ai-worker/src/utils/thinkingExtraction.ts
@@ -75,9 +75,12 @@ const KNOWN_THINKING_TAGS = [
  *
  * The three structural rules that make this safe to extract (not just strip):
  *   1. Start-of-response anchor (`^\s*`) — mid-response matches are left alone.
- *   2. UUID validation (`[a-fA-F0-9\-]{36}`) — no legitimate roleplay output
- *      starts with an invisible 36-char hex-dash block; UUIDs only appear in
- *      our internal assembly format.
+ *   2. UUID validation (RFC 4122 hyphen layout 8-4-4-4-12, hex-only
+ *      character classes) — no legitimate roleplay output starts with an
+ *      invisible UUID-shaped block; UUIDs only appear in our internal
+ *      assembly format. The explicit hyphen positions are load-bearing —
+ *      a loose `[a-fA-F0-9-]{36}` character class would match edge cases
+ *      like 36 hyphens or 36 repeated hex digits.
  *   3. Strict tag sequence (`<from_id>` → `<user>` → `<message>`) — all three
  *      in order with standard whitespace between them.
  *
@@ -96,7 +99,7 @@ const KNOWN_THINKING_TAGS = [
  * response as evidence.
  */
 const GLM_FAKE_USER_MESSAGE_ECHO_PATTERN =
-  /^\s*<from_id>[a-fA-F0-9-]{36}<\/from_id>\s*<user>[^<]*<\/user>\s*<message>([\s\S]*?)<\/message>\s*/;
+  /^\s*<from_id>[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}<\/from_id>\s*<user>[^<]*<\/user>\s*<message>([\s\S]*?)<\/message>\s*/;
 
 /**
  * Alternation pattern fragment for use in regex: `think|thinking|...`
@@ -354,7 +357,10 @@ export function extractThinkingBlocks(content: string): ThinkingExtraction {
     if (extractedThinking.length > 0) {
       thinkingParts.push(extractedThinking);
     }
-    visibleContent = visibleContent.replace(GLM_FAKE_USER_MESSAGE_ECHO_PATTERN, '');
+    // Slice rather than re-run the regex: the pattern is `^`-anchored so
+    // the match is always at position 0, and `fakeUserMessageMatch[0].length`
+    // is the byte count of the block to consume.
+    visibleContent = visibleContent.slice(fakeUserMessageMatch[0].length);
     logger.warn(
       {
         extractedLength: extractedThinking.length,

--- a/services/ai-worker/src/utils/thinkingExtraction.ts
+++ b/services/ai-worker/src/utils/thinkingExtraction.ts
@@ -463,6 +463,16 @@ export function hasThinkingBlocks(content: string): boolean {
     return true;
   }
 
+  // Pass-1 model-specific pattern (GLM-4.5-Air fake-user-message echo).
+  // `extractThinkingBlocks` removes this pattern via Pass 1, so we must
+  // check it here too — otherwise `DiagnosticRecorders.hasReasoningTagsInContent`
+  // would report `false` for pure-GLM responses where the fake wrapper is
+  // the only thinking-content signal, and `/inspect` diagnostics would
+  // under-report GLM reasoning occurrences.
+  if (GLM_FAKE_USER_MESSAGE_ECHO_PATTERN.test(normalized)) {
+    return true;
+  }
+
   return false;
 }
 


### PR DESCRIPTION
## Why

Debug req b533e288-fb07-46c0-a5e2-a0f78883e63e (2026-04-22): with reasoning enabled, GLM-4.5-air improvised a reasoning channel by wrapping its chain-of-thought in tags that mimic our prompt-assembly format — `<from_id>UUID</from_id>\n<user>Name</user>\n<message>CoT</message>`. OpenRouter didn't recognize it as reasoning, no `<think>` tags, full CoT dump reached Discord visible to the user.

User confirmed turning reasoning off is not an option — output becomes strongly repetitive without it. **Extraction is the only path.**

## Council input

Gemini 3.1 Pro Preview recommended a **Chain-of-Extractors** pattern: complex model-specific regexes first, simple generic tag patterns second. Key insight: **UUID-shape validation** is the load-bearing safety guarantee. No legitimate roleplay output starts with an invisible UUID-shaped block, so keying extraction on the UUID makes the scaffolding tag names safe to match.

## Changes

| File | Change |
|---|---|
| `utils/thinkingExtraction.ts` | New `GLM_FAKE_USER_MESSAGE_ECHO_PATTERN` — anchored + RFC-4122 UUID-shape-validated + strict-sequence regex. First-pass extractor inside `extractThinkingBlocks`, feeding into existing `thinkingParts[]` array; pass-2 is the unchanged generic `KNOWN_THINKING_TAGS` loop. Also extended `hasThinkingBlocks` with the same pattern so diagnostics (`hasReasoningTagsInContent`) don't report false-negatives for pure-GLM responses. |
| `utils/thinkingExtraction.test.ts` | 11 new tests: positive extraction, strip-wrapper, position-negative (mid-response), UUID-negative, sequence-negative (missing `<user>`), composition with `<think>`, uppercase-UUID, empty-`<message>` guard, UUID-shape edge cases (all-hyphens rejected / all-`a` matched as control), Pass-1/Pass-2 nested-tag double-extraction pin, `hasThinkingBlocks` alignment with extractor. |
| `services/prompt/HardcodedConstraints.ts` | Replaced blanket "Never output XML tags" (which the model violated) with: (a) sanctioned `<think>` channel — path-of-less-resistance for reasoning; (b) concrete named prohibition on `<from_id>`/`<user>`/`<message>` scaffolding. |
| `services/prompt/HardcodedConstraints.test.ts` | Updated assertions to match new constraint wording. |
| `__snapshots__/PromptBuilder.test.ts.snap` | 4 snapshots regenerated (intentional — constraint content changed). |

## Safety guarantees for extraction

1. **Start-of-response anchor** (`^\s*`, no `m` flag) — mid-response occurrences not touched.
2. **UUID shape** (RFC-4122 layout `[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}`) — the structural anchor that makes `<message>` safe to key off of. Strict hyphen positions reject edge cases like 36 hyphens or 36 repeated hex digits that a loose `[a-fA-F0-9-]{36}` class would accept.
3. **Strict tag sequence** (`<from_id>` → `<user>` → `<message>`) — all three in order.

Extracted content lands in `thinkingContent` (not just stripped), so `/inspect` surfaces the reasoning for debugging — matching existing behavior for `<think>`, `<understanding>`, `<character_analysis>`.

## Test plan

- [x] `pnpm --filter @tzurot/ai-worker test` — 2568/2568 green (4 snapshots intentionally updated)
- [x] Lint + depcruise clean on pre-push (every round)
- [x] 5 review rounds closed — all blocking + medium concerns addressed
- [ ] Post-merge on dev: grep logs for `Stripped leading fake-user-message scaffolding` to confirm the extractor is firing in the wild. If GLM-4.5-air incidents stop producing visible reasoning leaks, patch is working.

## Follow-up (already tracked)

The OpenRouter upstream-fix filing is tracked as a Quick Win in `BACKLOG.md` via commit **[`212eab850`](https://github.com/lbds137/tzurot/commit/212eab850)** on develop (part of the session's broader Inbox triage). That commit also doesn't appear in this PR's diff because it landed directly on develop, but the repo state satisfies `.claude/rules/06-backlog.md`'s "out-of-scope follow-up work must land in BACKLOG.md" requirement.

Once OpenRouter polyfills this pattern in their reasoning-middleware (like they do for DeepSeek/Qwen/Llama quirks), `GLM_FAKE_USER_MESSAGE_ECHO_PATTERN` and its test suite can be deleted — deletion plan is documented in the pattern's JSDoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
