### PR TITLE
refactor(bot-client): defer-first in preset handleDeleteButton

### DIFF
--- a/services/bot-client/src/commands/preset/dashboardButtons.test.ts
+++ b/services/bot-client/src/commands/preset/dashboardButtons.test.ts
@@ -89,6 +89,21 @@ const mockGetSessionDataOrReply = vi
     }
     return session.data;
   });
+// Sibling of getSessionDataOrReply for already-deferred interactions.
+// Uses followUp because reply would throw on an acked interaction.
+const mockGetSessionDataOrFollowUp = vi
+  .fn()
+  .mockImplementation(async (interaction, entityType, entityId) => {
+    const session = await mockSessionManager.get(interaction.user.id, entityType, entityId);
+    if (session === null) {
+      await interaction.followUp({
+        content: 'Session expired. Please try again.',
+        flags: 64, // MessageFlags.Ephemeral
+      });
+      return null;
+    }
+    return session.data;
+  });
 // Mock requireDeferredSession: deferUpdate + getSessionOrExpired
 const mockRequireDeferredSession = vi
   .fn()
@@ -117,6 +132,7 @@ vi.mock('../../utils/dashboard/index.js', async () => {
     requireDeferredSession: (...args: unknown[]) => mockRequireDeferredSession(...args),
     getSessionOrExpired: (...args: unknown[]) => mockGetSessionOrExpired(...args),
     getSessionDataOrReply: (...args: unknown[]) => mockGetSessionDataOrReply(...args),
+    getSessionDataOrFollowUp: (...args: unknown[]) => mockGetSessionDataOrFollowUp(...args),
     checkOwnership: (...args: unknown[]) => mockCheckOwnership(...args),
     renderTerminalScreen: (...args: unknown[]) => mockRenderTerminalScreen(...args),
     renderPostActionScreen: (...args: unknown[]) => mockRenderPostActionScreen(...args),
@@ -485,7 +501,32 @@ describe('Preset Dashboard Buttons', () => {
   });
 
   describe('handleDeleteButton', () => {
-    it('should show confirmation dialog when canDelete is true', async () => {
+    it('should defer the interaction before touching Redis session lookup', async () => {
+      // Regression guard for the defer-first refactor (BACKLOG 2026-04-22):
+      // deferUpdate MUST fire before the session lookup so Discord's 3-second
+      // interaction budget is protected even under a slow Redis round-trip.
+      const mockInteraction = createMockButtonInteraction('preset::delete::preset-123');
+      let deferCallOrder = -1;
+      let sessionLookupCallOrder = -1;
+      let counter = 0;
+      mockInteraction.deferUpdate = vi.fn().mockImplementation(() => {
+        deferCallOrder = ++counter;
+        return Promise.resolve();
+      });
+      mockSessionManager.get.mockImplementation(() => {
+        sessionLookupCallOrder = ++counter;
+        return Promise.resolve({
+          data: createMockFlattenedPreset({ isOwned: true, canDelete: true }),
+        });
+      });
+
+      await handleDeleteButton(mockInteraction, 'preset-123');
+
+      expect(deferCallOrder).toBeGreaterThan(0);
+      expect(sessionLookupCallOrder).toBeGreaterThan(deferCallOrder);
+    });
+
+    it('should show confirmation dialog via editReply when canDelete is true', async () => {
       const mockInteraction = createMockButtonInteraction('preset::delete::preset-123');
 
       mockSessionManager.get.mockResolvedValue({
@@ -494,7 +535,9 @@ describe('Preset Dashboard Buttons', () => {
 
       await handleDeleteButton(mockInteraction, 'preset-123');
 
-      expect(mockInteraction.update).toHaveBeenCalledWith({
+      // Uses editReply because deferUpdate was called first — calling
+      // interaction.update on an acked interaction would throw.
+      expect(mockInteraction.editReply).toHaveBeenCalledWith({
         embeds: expect.arrayContaining([
           expect.objectContaining({
             data: expect.objectContaining({
@@ -504,6 +547,7 @@ describe('Preset Dashboard Buttons', () => {
         ]),
         components: expect.any(Array),
       });
+      expect(mockInteraction.update).not.toHaveBeenCalled();
     });
 
     it('should show confirmation dialog for admin deleting a non-owned preset', async () => {
@@ -517,11 +561,11 @@ describe('Preset Dashboard Buttons', () => {
 
       await handleDeleteButton(mockInteraction, 'preset-123');
 
-      expect(mockInteraction.update).toHaveBeenCalled();
+      expect(mockInteraction.editReply).toHaveBeenCalled();
       expect(mockInteraction.reply).not.toHaveBeenCalled();
     });
 
-    it('should reject when canDelete is false', async () => {
+    it('should follow up with no-permission error when canDelete is false', async () => {
       const mockInteraction = createMockButtonInteraction('preset::delete::preset-123');
 
       mockSessionManager.get.mockResolvedValue({
@@ -530,27 +574,30 @@ describe('Preset Dashboard Buttons', () => {
 
       await handleDeleteButton(mockInteraction, 'preset-123');
 
-      // Direct canDelete guard replies with the NO_PERMISSION message; the
-      // confirmation dialog update must not fire.
-      expect(mockInteraction.update).not.toHaveBeenCalled();
-      expect(mockInteraction.reply).toHaveBeenCalledWith({
+      // Interaction is already deferred, so we followUp (not reply) and the
+      // confirmation dialog editReply must not fire.
+      expect(mockInteraction.editReply).not.toHaveBeenCalled();
+      expect(mockInteraction.reply).not.toHaveBeenCalled();
+      expect(mockInteraction.followUp).toHaveBeenCalledWith({
         content: expect.stringContaining('delete presets'),
         flags: expect.any(Number),
       });
     });
 
-    it('should show error if session expired', async () => {
+    it('should follow up with session-expired error if session is null', async () => {
       const mockInteraction = createMockButtonInteraction('preset::delete::preset-123');
 
       mockSessionManager.get.mockResolvedValue(null);
 
       await handleDeleteButton(mockInteraction, 'preset-123');
 
-      // getSessionDataOrReply handles the error reply
-      expect(mockInteraction.reply).toHaveBeenCalledWith({
+      // getSessionDataOrFollowUp handles the expired branch via followUp
+      // (reply would throw on the deferred interaction).
+      expect(mockInteraction.followUp).toHaveBeenCalledWith({
         content: expect.stringContaining('Session expired'),
         flags: expect.any(Number),
       });
+      expect(mockInteraction.reply).not.toHaveBeenCalled();
     });
   });
 

--- a/services/bot-client/src/commands/preset/dashboardButtons.ts
+++ b/services/bot-client/src/commands/preset/dashboardButtons.ts
@@ -17,7 +17,7 @@ import {
   handleDashboardClose,
   getSessionManager,
   requireDeferredSession,
-  getSessionDataOrReply,
+  getSessionDataOrFollowUp,
   checkOwnership,
   DASHBOARD_MESSAGES,
   formatSuccessBanner,
@@ -206,13 +206,20 @@ export async function handleToggleGlobalButton(
 
 /**
  * Handle delete button - show confirmation dialog.
+ *
+ * Defers first (`deferUpdate`) to protect Discord's 3-second interaction
+ * budget against a slow Redis session lookup. Subsequent responses use
+ * `editReply` / `followUp` since the interaction is already acked.
+ * See `.claude/rules/04-discord.md` § "defer first, then process."
  */
 export async function handleDeleteButton(
   interaction: ButtonInteraction,
   entityId: string
 ): Promise<void> {
-  // Get session data or reply with expired message (non-deferred)
-  const data = await getSessionDataOrReply<FlattenedPresetData>(interaction, 'preset', entityId);
+  await interaction.deferUpdate();
+
+  // Get session data or follow up with expired message (interaction already deferred)
+  const data = await getSessionDataOrFollowUp<FlattenedPresetData>(interaction, 'preset', entityId);
   if (data === null) {
     return;
   }
@@ -222,7 +229,7 @@ export async function handleDeleteButton(
   // was UI-only and wouldn't honor the admin override from
   // computeLlmConfigPermissions.
   if (!data.canDelete) {
-    await interaction.reply({
+    await interaction.followUp({
       content: DASHBOARD_MESSAGES.NO_PERMISSION('delete presets'),
       flags: MessageFlags.Ephemeral,
     });
@@ -237,7 +244,10 @@ export async function handleDeleteButton(
     cancelCustomId: `preset::cancel-delete::${entityId}`,
   });
 
-  await interaction.update({ embeds: [embed], components });
+  // `editReply` replaces the dashboard message in place — same visual effect
+  // as the prior `interaction.update`, but the interaction has already been
+  // acked via `deferUpdate` above so `update` would throw.
+  await interaction.editReply({ embeds: [embed], components });
 }
 
 /**

--- a/services/bot-client/src/utils/dashboard/index.ts
+++ b/services/bot-client/src/utils/dashboard/index.ts
@@ -91,6 +91,7 @@ export {
   requireDeferredSession,
   getSessionOrExpired,
   getSessionDataOrReply,
+  getSessionDataOrFollowUp,
 } from './sessionHelpers.js';
 
 // Modal Helpers

--- a/services/bot-client/src/utils/dashboard/sessionHelpers.test.ts
+++ b/services/bot-client/src/utils/dashboard/sessionHelpers.test.ts
@@ -10,6 +10,7 @@ import {
   requireDeferredSession,
   getSessionOrExpired,
   getSessionDataOrReply,
+  getSessionDataOrFollowUp,
 } from './sessionHelpers.js';
 import * as SessionManagerModule from './SessionManager.js';
 
@@ -244,6 +245,59 @@ describe('sessionHelpers', () => {
         content: '⏰ Session expired. Please run the command again.',
         flags: MessageFlags.Ephemeral,
       });
+    });
+  });
+
+  describe('getSessionDataOrFollowUp', () => {
+    // Sibling of getSessionDataOrReply for already-deferred interactions.
+    // Mirrors the test pair above: the two helpers must behave identically
+    // on the happy path and only differ on the expired branch (reply vs
+    // followUp). Any drift between them would produce silent runtime errors
+    // (InteractionAlreadyReplied on the wrong call shape).
+    it('should return session data when it exists', async () => {
+      const sessionData = { name: 'Test' };
+      mockSessionManager.get.mockResolvedValue({ data: sessionData });
+      const interaction = {
+        user: { id: 'user-123' },
+        followUp: vi.fn(),
+      } as unknown as ButtonInteraction;
+
+      const result = await getSessionDataOrFollowUp(interaction, 'preset', 'preset-123');
+
+      expect(result).toEqual(sessionData);
+      expect(interaction.followUp).not.toHaveBeenCalled();
+    });
+
+    it('should follow up with error and return null when session is missing', async () => {
+      mockSessionManager.get.mockResolvedValue(null);
+      const interaction = {
+        user: { id: 'user-123' },
+        followUp: vi.fn(),
+      } as unknown as ButtonInteraction;
+
+      const result = await getSessionDataOrFollowUp(interaction, 'preset', 'preset-123');
+
+      expect(result).toBeNull();
+      expect(interaction.followUp).toHaveBeenCalledWith({
+        content: '⏰ Session expired. Please run the command again.',
+        flags: MessageFlags.Ephemeral,
+      });
+    });
+
+    it('should NOT call reply (would throw on already-deferred interactions)', async () => {
+      // Pins the whole purpose of this sibling helper. If someone later
+      // mistakenly changes followUp → reply, this test breaks and surfaces
+      // the regression before it hits prod as InteractionAlreadyReplied.
+      mockSessionManager.get.mockResolvedValue(null);
+      const interaction = {
+        user: { id: 'user-123' },
+        followUp: vi.fn(),
+        reply: vi.fn(),
+      } as unknown as ButtonInteraction;
+
+      await getSessionDataOrFollowUp(interaction, 'preset', 'preset-123');
+
+      expect(interaction.reply).not.toHaveBeenCalled();
     });
   });
 });

--- a/services/bot-client/src/utils/dashboard/sessionHelpers.ts
+++ b/services/bot-client/src/utils/dashboard/sessionHelpers.ts
@@ -187,6 +187,10 @@ export async function getSessionOrExpired<T>(
  * Simpler version that just needs the data, not full session.
  * Uses interaction.reply() for non-deferred interactions.
  *
+ * For handlers that have already called `deferUpdate` / `deferReply` (and
+ * therefore can't `reply` again without Discord throwing), use
+ * {@link getSessionDataOrFollowUp} instead.
+ *
  * @returns Session data or null if expired
  */
 export async function getSessionDataOrReply<T>(
@@ -199,6 +203,43 @@ export async function getSessionDataOrReply<T>(
 
   if (session === null) {
     await interaction.reply({
+      content: DASHBOARD_MESSAGES.SESSION_EXPIRED,
+      flags: MessageFlags.Ephemeral,
+    });
+    return null;
+  }
+
+  return session.data;
+}
+
+/**
+ * Get session data or follow up with error, for already-deferred interactions.
+ *
+ * Mirror of {@link getSessionDataOrReply} for handlers that called
+ * `interaction.deferUpdate()` (or `deferReply()`) before the session lookup.
+ * Uses `interaction.followUp` for the expired branch because `reply` would
+ * throw on an already-acked interaction.
+ *
+ * **When to use this over `getSessionDataOrReply`**: when Discord's 3-second
+ * interaction budget matters and you've deferred eagerly to protect it. The
+ * Redis session lookup is sub-ms on the hot path but can spike under load,
+ * and the old "reply or fail" pattern gave us no defer-first option because
+ * the fallback branch would race the ack. See
+ * `.claude/rules/04-discord.md` § "defer first, then process" for the
+ * broader rule.
+ *
+ * @returns Session data or null if expired
+ */
+export async function getSessionDataOrFollowUp<T>(
+  interaction: ButtonInteraction | StringSelectMenuInteraction,
+  entityType: string,
+  entityId: string
+): Promise<T | null> {
+  const sessionManager = getSessionManager();
+  const session = await sessionManager.get<T>(interaction.user.id, entityType, entityId);
+
+  if (session === null) {
+    await interaction.followUp({
       content: DASHBOARD_MESSAGES.SESSION_EXPIRED,
       flags: MessageFlags.Ephemeral,
     });


### PR DESCRIPTION
## Why

Surfaced during PR #836 r4 review (2026-04-19), promoted to Quick Wins during 2026-04-22 triage, actioned now.

`preset/dashboardButtons.ts handleDeleteButton` was doing a Redis session lookup **before** any Discord ack, meaning a slow Redis round-trip could consume the 3-second interaction budget. Under load or transient latency spikes this surfaces as 10062 "Unknown interaction" errors. Today's hot-path is sub-ms, but the pattern violates `.claude/rules/04-discord.md` § "defer first, then process" and replicates across dashboard button handlers.

Character's equivalent handler (`dashboardDeleteHandlers.ts handleDeleteAction`) already defers-first. This brings preset in line.

## Blocker on the simple fix

The obvious "just `deferUpdate` first" move fails because `getSessionDataOrReply` uses `interaction.reply()` on the session-expired branch — and `reply` throws `InteractionAlreadyReplied` on an already-acked interaction.

## Fix shape

1. **New sibling helper** `getSessionDataOrFollowUp` in `sessionHelpers.ts` — mirror of `getSessionDataOrReply` but uses `interaction.followUp` for the expired branch. Correct call shape for already-deferred interactions.
2. **Updated `handleDeleteButton`** to:
   - `await interaction.deferUpdate()` as the first statement
   - Call `getSessionDataOrFollowUp` instead of `getSessionDataOrReply`
   - Use `interaction.followUp` for the NO_PERMISSION branch
   - Use `interaction.editReply` (not `interaction.update`) for the confirmation dialog — required since `deferUpdate` already acked

## Scope discipline

- **No behavior change for `persona/dashboard.ts`** — the other `getSessionDataOrReply` caller. It doesn't have the defer-first problem and keeps the existing helper.
- **No touching of `handleDeleteButton` downstream handlers** (`handleConfirmDeleteButton`, `handleCancelDeleteButton`) — they already defer correctly.

## Tests

| Test | What it pins |
|---|---|
| Defer-before-session-lookup ordering | Regression guard using a shared counter — deferUpdate must fire before the session lookup |
| confirmation-dialog shows via editReply (not update) | New response shape after the refactor |
| NO_PERMISSION follows up (doesn't reply) | Already-acked path correctness |
| Session-expired follows up (doesn't reply) | `getSessionDataOrFollowUp` integration |
| Admin-canDelete path uses editReply | Bot-owner/admin override still works |

43/43 dashboardButtons tests, 635/635 dashboard tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)