### PR TITLE
feat(tooling): add release:finalize command

### DIFF
--- a/.claude/skills/tzurot-git-workflow/SKILL.md
+++ b/.claude/skills/tzurot-git-workflow/SKILL.md
@@ -201,6 +201,20 @@ Skip this step if the release contains no migration. Verify with `git log v<prev
 
 ### 6. After Merge to Main
 
+Rebase develop onto main so their SHAs stay aligned. Skipping this step causes the next release PR to show apparent "conflicts with main" that aren't real (content is identical, just different SHAs).
+
+**Preferred — automated:**
+
+```bash
+pnpm ops release:finalize           # Interactive: prompts before force-push
+pnpm ops release:finalize --yes     # Skip the prompt (non-TTY safe)
+pnpm ops release:finalize --dry-run # Preview the steps without executing
+```
+
+The command runs the full `fetch → checkout main → pull → checkout develop → pull → rebase origin/main → push --force-with-lease` sequence with safety rails: refuses on dirty working tree, no-op exit when already aligned, aborts rebase cleanly on conflicts.
+
+**Manual fallback (if the tool is broken or you need step-by-step debugging):**
+
 ```bash
 git fetch --all
 git checkout main && git pull origin main

--- a/docs/reference/tooling/OPS_CLI_REFERENCE.md
+++ b/docs/reference/tooling/OPS_CLI_REFERENCE.md
@@ -126,14 +126,25 @@ Fetch and analyze Railway service logs:
 
 ## Release Commands
 
-Version management:
+Cover the full release lifecycle: bump versions before the release PR, draft and verify release notes, and finalize develop-vs-main alignment after the release merges.
 
-| Command                                 | Description                 |
-| --------------------------------------- | --------------------------- |
-| `pnpm ops release:bump 3.0.0-beta.49`   | Bump all package.json files |
-| `pnpm ops release:bump 3.0.0 --dry-run` | Preview without changes     |
+| Command                                               | Description                                                                                                       |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `pnpm ops release:bump 3.0.0-beta.49`                 | Bump version in all package.json files                                                                            |
+| `pnpm ops release:bump 3.0.0 --dry-run`               | Preview bump without writing                                                                                      |
+| `pnpm ops release:draft-notes`                        | Draft release-notes skeleton from PRs merged since the previous tag                                               |
+| `pnpm ops release:draft-notes --from v3.0.0-beta.103` | Draft starting from a specific tag (else auto-discovered via `git describe`)                                      |
+| `cat /tmp/notes.md \| pnpm ops release:verify-notes`  | Verify a notes draft references every merged PR in range exactly once (exits 1 on missing/extra/duplicate refs)   |
+| `pnpm ops release:finalize`                           | Rebase develop onto main after a release PR merges (step 6 of the git-workflow release flow). Interactive prompt. |
+| `pnpm ops release:finalize --yes`                     | Skip the force-push confirmation prompt (required on non-TTY stdin)                                               |
+| `pnpm ops release:finalize --dry-run`                 | Preview the finalize steps without executing                                                                      |
 
-**Use case:** Bump version across monorepo before release.
+**Use cases:**
+
+- `release:bump` — before cutting the release PR, bump the monorepo version so it ships tagged correctly.
+- `release:draft-notes` — generate the skeleton for the release PR body; edit as needed before submitting.
+- `release:verify-notes` — CI/pre-publish gate: confirms every merged PR in the tag-to-HEAD range appears in the notes exactly once.
+- `release:finalize` — run after the release PR merges to main. Keeps develop's SHAs aligned with main's so the next release PR doesn't show phantom "conflicts with main."
 
 ## GitHub Commands
 

--- a/packages/tooling/src/commands/release.ts
+++ b/packages/tooling/src/commands/release.ts
@@ -50,10 +50,8 @@ export function registerReleaseCommands(cli: CAC): void {
       await verifyNotes(options);
     });
 
-  // Rebase develop onto main after a release PR merges (final step of
-  // the release flow). Previously manual + sometimes skipped; automation
-  // prevents the develop-vs-main SHA drift that surfaces as apparent
-  // "conflicts with main" on the next release PR.
+  // Rebase develop onto main after a release PR merges. Full rationale
+  // + safety details in `finalize.ts` module-level JSDoc.
   cli
     .command(
       'release:finalize',

--- a/packages/tooling/src/commands/release.ts
+++ b/packages/tooling/src/commands/release.ts
@@ -49,4 +49,23 @@ export function registerReleaseCommands(cli: CAC): void {
       const { verifyNotes } = await import('../release/verify-notes.js');
       await verifyNotes(options);
     });
+
+  // Rebase develop onto main after a release PR merges (final step of
+  // the release flow). Previously manual + sometimes skipped; automation
+  // prevents the develop-vs-main SHA drift that surfaces as apparent
+  // "conflicts with main" on the next release PR.
+  cli
+    .command(
+      'release:finalize',
+      'Rebase develop onto main after a release PR merges (step 5 of the release flow)'
+    )
+    .option('--dry-run', 'Preview the planned steps without executing')
+    .option('--yes', 'Skip the force-push confirmation prompt (required on non-TTY stdin)')
+    .example('pnpm ops release:finalize')
+    .example('pnpm ops release:finalize --dry-run')
+    .example('pnpm ops release:finalize --yes')
+    .action(async (options: { dryRun?: boolean; yes?: boolean }) => {
+      const { finalizeRelease } = await import('../release/finalize.js');
+      await finalizeRelease(options);
+    });
 }

--- a/packages/tooling/src/commands/release.ts
+++ b/packages/tooling/src/commands/release.ts
@@ -57,7 +57,7 @@ export function registerReleaseCommands(cli: CAC): void {
   cli
     .command(
       'release:finalize',
-      'Rebase develop onto main after a release PR merges (step 5 of the release flow)'
+      'Rebase develop onto main after a release PR merges (step 6 of the release flow)'
     )
     .option('--dry-run', 'Preview the planned steps without executing')
     .option('--yes', 'Skip the force-push confirmation prompt (required on non-TTY stdin)')

--- a/packages/tooling/src/release/finalize.test.ts
+++ b/packages/tooling/src/release/finalize.test.ts
@@ -296,6 +296,44 @@ describe('finalizeRelease', () => {
     });
   });
 
+  describe('detached HEAD', () => {
+    it('treats rev-parse returning "HEAD" as no branch info (detached state)', async () => {
+      // `git rev-parse --abbrev-ref HEAD` outputs the literal string
+      // "HEAD" in detached HEAD state — it does NOT throw. Without the
+      // HEAD→'' translation in captureCurrentBranch, the drift message
+      // would read "you started on 'HEAD' but are now on 'main'. Run
+      // `git checkout HEAD` to return." — which is misleading at best.
+      // This test pins the translation so detached HEAD falls into the
+      // "no drift hint" branch.
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      mockGit({
+        'rev-list --count': '3\n',
+        'rev-parse': 'HEAD\n', // Simulate detached HEAD
+        pull: () => {
+          throw new Error('fatal: Not possible to fast-forward');
+        },
+      });
+
+      await expect(finalizeRelease({ yes: true })).rejects.toThrow(/Not possible to fast-forward/);
+
+      // No "you started on" drift message — startBranch was '' (detached)
+      // so reportBranchDrift early-exits.
+      const driftMessage = errorSpy.mock.calls.map(c => String(c[0])).join('\n');
+      expect(driftMessage).not.toContain('you started on');
+      expect(driftMessage).not.toContain('checkout HEAD');
+    });
+  });
+
+  // Interactive-abort path (TTY + user types 'n') is not directly
+  // tested: mocking readline reliably requires either module-level
+  // `vi.mock` (affecting every test in the file) or `vi.resetModules` +
+  // dynamic import (brittle against module-cache state). The two
+  // endpoints of the confirmation-gate branching ARE pinned — `--yes`
+  // → skip prompt (happy path), non-TTY no-yes → throw (non-TTY safety).
+  // The middle path is a straightforward readline round-trip between
+  // those two and doesn't meaningfully exercise finalize.ts logic.
+
   describe('edge cases', () => {
     it('throws a descriptive error on malformed rev-list output', async () => {
       // If git's rev-list returns something un-parseable as an integer

--- a/packages/tooling/src/release/finalize.test.ts
+++ b/packages/tooling/src/release/finalize.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+}));
+
+const mockedExec = vi.mocked(execFileSync);
+
+// Import AFTER the mock so the module binding captures the vi.mock version.
+import { finalizeRelease } from './finalize.js';
+
+/**
+ * Lookup table helper: match on the first git subcommand argument and
+ * return canned stdout. `git status --porcelain` → clean working tree,
+ * `git rev-list --count ...` → number of commits, everything else → ''.
+ *
+ * Individual tests override specific subcommands via a nested map.
+ */
+function mockGit(overrides: Record<string, string | (() => string)> = {}): void {
+  mockedExec.mockImplementation(((_cmd: string, args: readonly string[]) => {
+    // The first arg after 'git' identifies the subcommand (e.g. 'status',
+    // 'rev-list', 'rebase'); the second arg disambiguates for subcommands
+    // that share a name across cases.
+    const key = args.slice(0, 2).join(' ');
+    const subKey = args[0];
+    if (key in overrides) {
+      const v = overrides[key];
+      return typeof v === 'function' ? v() : v;
+    }
+    if (subKey in overrides) {
+      const v = overrides[subKey];
+      return typeof v === 'function' ? v() : v;
+    }
+    // Defaults: clean working tree, zero-commit rev-list output.
+    if (key === 'status --porcelain') return '';
+    if (key === 'rev-list --count') return '0\n';
+    return '';
+  }) as unknown as typeof execFileSync);
+}
+
+describe('finalizeRelease', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Silence console output unless a test explicitly checks it.
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  describe('no-op path', () => {
+    it('exits early when develop already contains every main commit', async () => {
+      mockGit({ 'rev-list --count': '0\n' });
+
+      await finalizeRelease({ yes: true });
+
+      // Should fetch and check ahead-count, but NOT checkout, pull, rebase, push.
+      const invocations = mockedExec.mock.calls.map(c => (c[1] as string[]).join(' '));
+      expect(invocations).toContain('fetch --all');
+      expect(invocations).toContain('rev-list --count origin/develop..origin/main');
+      expect(invocations.some(cmd => cmd.startsWith('checkout'))).toBe(false);
+      expect(invocations.some(cmd => cmd.startsWith('rebase'))).toBe(false);
+      expect(invocations.some(cmd => cmd.startsWith('push'))).toBe(false);
+    });
+  });
+
+  describe('happy path', () => {
+    it('runs the full finalize sequence when main is ahead of develop', async () => {
+      mockGit({ 'rev-list --count': '3\n' });
+
+      await finalizeRelease({ yes: true });
+
+      const invocations = mockedExec.mock.calls.map(c => (c[1] as string[]).join(' '));
+      // Sequence is load-bearing — the rebase MUST come after both
+      // checkouts and MUST precede the push.
+      const fetchIdx = invocations.indexOf('fetch --all');
+      const checkoutMainIdx = invocations.indexOf('checkout main');
+      const pullMainIdx = invocations.indexOf('pull --ff-only');
+      const checkoutDevIdx = invocations.indexOf('checkout develop');
+      const rebaseIdx = invocations.indexOf('rebase origin/main');
+      const pushIdx = invocations.indexOf('push --force-with-lease');
+
+      expect(fetchIdx).toBeGreaterThanOrEqual(0);
+      expect(checkoutMainIdx).toBeGreaterThan(fetchIdx);
+      expect(pullMainIdx).toBeGreaterThan(checkoutMainIdx);
+      expect(checkoutDevIdx).toBeGreaterThan(pullMainIdx);
+      expect(rebaseIdx).toBeGreaterThan(checkoutDevIdx);
+      expect(pushIdx).toBeGreaterThan(rebaseIdx);
+    });
+  });
+
+  describe('dirty working tree', () => {
+    it('refuses to run if git status shows uncommitted changes', async () => {
+      mockGit({ 'status --porcelain': 'M some-file.ts\n' });
+
+      await expect(finalizeRelease({ yes: true })).rejects.toThrow(/Working tree is not clean/);
+
+      // Should have bailed before fetch.
+      const invocations = mockedExec.mock.calls.map(c => (c[1] as string[]).join(' '));
+      expect(invocations).not.toContain('fetch --all');
+    });
+
+    it('skips the clean-tree check in dry-run mode', async () => {
+      // Dry-run is preview-only — inspecting state while mid-work should
+      // be allowed. Zero commits to rebase so we exit on the no-op path.
+      mockGit({ 'status --porcelain': 'M some-file.ts\n', 'rev-list --count': '0\n' });
+
+      await expect(finalizeRelease({ dryRun: true, yes: true })).resolves.toBeUndefined();
+    });
+  });
+
+  describe('rebase conflict handling', () => {
+    it('aborts the rebase and re-throws when rebase fails', async () => {
+      let rebaseAttempted = false;
+      let abortCalled = false;
+      mockGit({
+        'rev-list --count': '3\n',
+        rebase: () => {
+          // First call is the rebase attempt; second (via --abort) would
+          // be the cleanup. Only the first is a conflict.
+          if (!rebaseAttempted) {
+            rebaseAttempted = true;
+            throw new Error('CONFLICT: merge conflict in foo.ts');
+          }
+          abortCalled = true;
+          return '';
+        },
+      });
+
+      await expect(finalizeRelease({ yes: true })).rejects.toThrow(/CONFLICT/);
+      expect(rebaseAttempted).toBe(true);
+      // Verify --abort was attempted — leaving the user in a rebase-in-progress
+      // state would be worse than the original conflict.
+      expect(abortCalled).toBe(true);
+    });
+
+    it('swallows a secondary --abort failure to surface the original error', async () => {
+      // If `rebase --abort` itself fails (e.g., no rebase in progress),
+      // the primary conflict error is still what the user needs to see.
+      mockGit({
+        'rev-list --count': '3\n',
+        rebase: () => {
+          throw new Error('CONFLICT: original error');
+        },
+      });
+
+      // Override: the abort path also throws. The test asserts we see
+      // the ORIGINAL error, not the secondary one.
+      await expect(finalizeRelease({ yes: true })).rejects.toThrow(/CONFLICT: original error/);
+    });
+  });
+
+  describe('dry-run mode', () => {
+    it('never executes checkout/rebase/push in dry-run', async () => {
+      mockGit({ 'rev-list --count': '3\n' });
+
+      await finalizeRelease({ dryRun: true, yes: true });
+
+      // Dry-run still needs to read state (status, rev-list via fetch
+      // wouldn't run in dry-run, rev-list itself is a read). Writes must
+      // never fire.
+      const invocations = mockedExec.mock.calls.map(c => (c[1] as string[]).join(' '));
+      // rev-list is the only read allowed post-fetch; fetch itself is
+      // printed, not executed, in dry-run.
+      expect(invocations).not.toContain('fetch --all');
+      expect(invocations).not.toContain('checkout main');
+      expect(invocations).not.toContain('checkout develop');
+      expect(invocations).not.toContain('rebase origin/main');
+      expect(invocations).not.toContain('push --force-with-lease');
+    });
+  });
+
+  describe('non-TTY safety', () => {
+    it('requires --yes when stdin is non-TTY to run the force-push path', async () => {
+      // Simulate non-TTY by stubbing isTTY. In practice vitest's stdin
+      // is already non-TTY, but asserting explicitly keeps the test
+      // robust against future vitest changes.
+      const originalIsTTY = process.stdin.isTTY;
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: false,
+        configurable: true,
+      });
+
+      try {
+        mockGit({ 'rev-list --count': '3\n' });
+
+        // No --yes — should bail before force-push.
+        await finalizeRelease({});
+
+        const invocations = mockedExec.mock.calls.map(c => (c[1] as string[]).join(' '));
+        expect(invocations).not.toContain('push --force-with-lease');
+      } finally {
+        Object.defineProperty(process.stdin, 'isTTY', {
+          value: originalIsTTY,
+          configurable: true,
+        });
+      }
+    });
+  });
+});

--- a/packages/tooling/src/release/finalize.test.ts
+++ b/packages/tooling/src/release/finalize.test.ts
@@ -70,12 +70,14 @@ describe('finalizeRelease', () => {
       await finalizeRelease({ yes: true });
 
       const invocations = mockedExec.mock.calls.map(c => (c[1] as string[]).join(' '));
-      // Sequence is load-bearing — the rebase MUST come after both
-      // checkouts and MUST precede the push.
+      // Sequence is load-bearing — both pulls must happen between their
+      // checkouts and the rebase, and the rebase must precede the push.
+      // Asserting every adjacent pair pins the full sequence.
       const fetchIdx = invocations.indexOf('fetch --all');
       const checkoutMainIdx = invocations.indexOf('checkout main');
       const pullMainIdx = invocations.indexOf('pull --ff-only origin main');
       const checkoutDevIdx = invocations.indexOf('checkout develop');
+      const pullDevIdx = invocations.indexOf('pull --ff-only origin develop');
       const rebaseIdx = invocations.indexOf('rebase origin/main');
       const pushIdx = invocations.indexOf('push --force-with-lease origin develop');
 
@@ -83,7 +85,8 @@ describe('finalizeRelease', () => {
       expect(checkoutMainIdx).toBeGreaterThan(fetchIdx);
       expect(pullMainIdx).toBeGreaterThan(checkoutMainIdx);
       expect(checkoutDevIdx).toBeGreaterThan(pullMainIdx);
-      expect(rebaseIdx).toBeGreaterThan(checkoutDevIdx);
+      expect(pullDevIdx).toBeGreaterThan(checkoutDevIdx);
+      expect(rebaseIdx).toBeGreaterThan(pullDevIdx);
       expect(pushIdx).toBeGreaterThan(rebaseIdx);
     });
   });

--- a/packages/tooling/src/release/finalize.test.ts
+++ b/packages/tooling/src/release/finalize.test.ts
@@ -205,10 +205,11 @@ describe('finalizeRelease', () => {
   });
 
   describe('non-TTY safety', () => {
-    it('requires --yes when stdin is non-TTY to run the force-push path', async () => {
-      // Simulate non-TTY by stubbing isTTY. In practice vitest's stdin
-      // is already non-TTY, but asserting explicitly keeps the test
-      // robust against future vitest changes.
+    it('throws when stdin is non-TTY and --yes is omitted', async () => {
+      // A CI pipeline that forgets --yes must fail LOUDLY (non-zero exit)
+      // rather than silently "abort" and exit 0 — otherwise a missing
+      // flag looks indistinguishable from a successful run. Throwing
+      // surfaces the misuse so the pipeline step fails.
       const originalIsTTY = process.stdin.isTTY;
       Object.defineProperty(process.stdin, 'isTTY', {
         value: false,
@@ -218,10 +219,11 @@ describe('finalizeRelease', () => {
       try {
         mockGit({ 'rev-list --count': '3\n' });
 
-        // No --yes — should bail before force-push.
-        await finalizeRelease({});
+        await expect(finalizeRelease({})).rejects.toThrow(/Non-TTY stdin requires --yes/);
 
+        // Neither the rebase nor the force-push should have run.
         const invocations = mockedExec.mock.calls.map(c => (c[1] as string[]).join(' '));
+        expect(invocations).not.toContain('rebase origin/main');
         expect(invocations).not.toContain('push --force-with-lease origin develop');
       } finally {
         Object.defineProperty(process.stdin, 'isTTY', {

--- a/packages/tooling/src/release/finalize.test.ts
+++ b/packages/tooling/src/release/finalize.test.ts
@@ -32,8 +32,8 @@ function mockGit(overrides: Record<string, string | (() => string)> = {}): void 
       const v = overrides[subKey];
       return typeof v === 'function' ? v() : v;
     }
-    // Defaults: clean working tree, zero-commit rev-list output.
-    if (key === 'status --porcelain') return '';
+    // Defaults: clean working tree (tracked-only check), zero-commit rev-list.
+    if (subKey === 'status') return '';
     if (key === 'rev-list --count') return '0\n';
     return '';
   }) as unknown as typeof execFileSync);
@@ -74,10 +74,10 @@ describe('finalizeRelease', () => {
       // checkouts and MUST precede the push.
       const fetchIdx = invocations.indexOf('fetch --all');
       const checkoutMainIdx = invocations.indexOf('checkout main');
-      const pullMainIdx = invocations.indexOf('pull --ff-only');
+      const pullMainIdx = invocations.indexOf('pull --ff-only origin main');
       const checkoutDevIdx = invocations.indexOf('checkout develop');
       const rebaseIdx = invocations.indexOf('rebase origin/main');
-      const pushIdx = invocations.indexOf('push --force-with-lease');
+      const pushIdx = invocations.indexOf('push --force-with-lease origin develop');
 
       expect(fetchIdx).toBeGreaterThanOrEqual(0);
       expect(checkoutMainIdx).toBeGreaterThan(fetchIdx);
@@ -89,20 +89,38 @@ describe('finalizeRelease', () => {
   });
 
   describe('dirty working tree', () => {
-    it('refuses to run if git status shows uncommitted changes', async () => {
-      mockGit({ 'status --porcelain': 'M some-file.ts\n' });
+    it('refuses to run if git status shows uncommitted tracked changes', async () => {
+      mockGit({ status: 'M some-file.ts\n' });
 
-      await expect(finalizeRelease({ yes: true })).rejects.toThrow(/Working tree is not clean/);
+      await expect(finalizeRelease({ yes: true })).rejects.toThrow(
+        /tracked changes.*Commit or stash/
+      );
 
       // Should have bailed before fetch.
       const invocations = mockedExec.mock.calls.map(c => (c[1] as string[]).join(' '));
       expect(invocations).not.toContain('fetch --all');
     });
 
+    it('uses --untracked-files=no so stray untracked files do not block', async () => {
+      // The default mock returns '' from `status`, so this test locks
+      // in the flag shape rather than the behavior. `git status
+      // --porcelain --untracked-files=no` excludes ??-prefixed lines,
+      // meaning a stray notes.txt or .env.local is ignored — matches
+      // the actual risk surface (git checkout tolerates untracked files
+      // in the 99% case).
+      mockGit({ status: '' });
+
+      await finalizeRelease({ yes: true });
+
+      const statusCall = mockedExec.mock.calls.find(c => (c[1] as string[])[0] === 'status');
+      expect(statusCall).toBeDefined();
+      expect(statusCall![1]).toEqual(['status', '--porcelain', '--untracked-files=no']);
+    });
+
     it('skips the clean-tree check in dry-run mode', async () => {
       // Dry-run is preview-only — inspecting state while mid-work should
       // be allowed. Zero commits to rebase so we exit on the no-op path.
-      mockGit({ 'status --porcelain': 'M some-file.ts\n', 'rev-list --count': '0\n' });
+      mockGit({ status: 'M some-file.ts\n', 'rev-list --count': '0\n' });
 
       await expect(finalizeRelease({ dryRun: true, yes: true })).resolves.toBeUndefined();
     });
@@ -165,7 +183,7 @@ describe('finalizeRelease', () => {
       expect(invocations).not.toContain('checkout main');
       expect(invocations).not.toContain('checkout develop');
       expect(invocations).not.toContain('rebase origin/main');
-      expect(invocations).not.toContain('push --force-with-lease');
+      expect(invocations).not.toContain('push --force-with-lease origin develop');
     });
   });
 
@@ -187,7 +205,7 @@ describe('finalizeRelease', () => {
         await finalizeRelease({});
 
         const invocations = mockedExec.mock.calls.map(c => (c[1] as string[]).join(' '));
-        expect(invocations).not.toContain('push --force-with-lease');
+        expect(invocations).not.toContain('push --force-with-lease origin develop');
       } finally {
         Object.defineProperty(process.stdin, 'isTTY', {
           value: originalIsTTY,

--- a/packages/tooling/src/release/finalize.test.ts
+++ b/packages/tooling/src/release/finalize.test.ts
@@ -155,18 +155,29 @@ describe('finalizeRelease', () => {
     });
 
     it('swallows a secondary --abort failure to surface the original error', async () => {
-      // If `rebase --abort` itself fails (e.g., no rebase in progress),
-      // the primary conflict error is still what the user needs to see.
+      // Scenario: the initial rebase throws a CONFLICT, and the subsequent
+      // `rebase --abort` cleanup ALSO throws (e.g., no rebase in progress
+      // because the conflict was reported but rebase state wasn't left
+      // behind). The primary CONFLICT is what the user needs to see —
+      // the secondary abort failure should not shadow it.
+      let rebaseCallCount = 0;
       mockGit({
         'rev-list --count': '3\n',
         rebase: () => {
-          throw new Error('CONFLICT: original error');
+          rebaseCallCount += 1;
+          // Distinguish the scenarios: first call is the real rebase, second
+          // is the --abort cleanup. Both throw, but with different messages
+          // so the test proves we surface the ORIGINAL error, not the
+          // cleanup error.
+          if (rebaseCallCount === 1) {
+            throw new Error('CONFLICT: original error');
+          }
+          throw new Error('SECONDARY: abort failed');
         },
       });
 
-      // Override: the abort path also throws. The test asserts we see
-      // the ORIGINAL error, not the secondary one.
       await expect(finalizeRelease({ yes: true })).rejects.toThrow(/CONFLICT: original error/);
+      expect(rebaseCallCount).toBe(2); // Both calls happened; original won.
     });
   });
 
@@ -215,6 +226,68 @@ describe('finalizeRelease', () => {
           configurable: true,
         });
       }
+    });
+  });
+
+  describe('branch drift reporting', () => {
+    it('reports drift to stderr when a mid-sequence failure leaves the user on a different branch', async () => {
+      // User starts on 'develop'; pull-main succeeds, checkout-develop
+      // succeeds, then pull-develop fails leaving them on 'develop'
+      // (no drift) — so instead simulate: starting branch is a
+      // feature branch, checkout-main succeeds, pull-main fails.
+      // The helper should log the drift from 'my-feature' to 'main'.
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      let pullCallCount = 0;
+      let revParseCallCount = 0;
+      mockGit({
+        'rev-list --count': '3\n',
+        'rev-parse': () => {
+          revParseCallCount += 1;
+          // First call: capture starting branch (function entry).
+          // Second call: inside reportBranchDrift (catch path).
+          return revParseCallCount === 1 ? 'my-feature\n' : 'main\n';
+        },
+        pull: () => {
+          pullCallCount += 1;
+          throw new Error('fatal: Not possible to fast-forward, aborting.');
+        },
+      });
+
+      await expect(finalizeRelease({ yes: true })).rejects.toThrow(/Not possible to fast-forward/);
+
+      // Sanity: we did try the pull, and we did check branch twice.
+      expect(pullCallCount).toBe(1);
+      expect(revParseCallCount).toBe(2);
+
+      // The drift hint mentions both branches + the recovery command.
+      const driftMessage = errorSpy.mock.calls.map(c => String(c[0])).join('\n');
+      expect(driftMessage).toContain("'my-feature'");
+      expect(driftMessage).toContain("'main'");
+      expect(driftMessage).toContain('git checkout my-feature');
+    });
+
+    it('does not report drift when starting branch matches current branch', async () => {
+      // User starts on develop, rebase conflicts. By the time we reach
+      // the catch, rebaseOrAbortCleanly has already called --abort, so
+      // we're back on develop — no drift to report.
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      mockGit({
+        'rev-list --count': '3\n',
+        'rev-parse': 'develop\n',
+        rebase: () => {
+          throw new Error('CONFLICT');
+        },
+      });
+
+      await expect(finalizeRelease({ yes: true })).rejects.toThrow(/CONFLICT/);
+
+      // The "Rebase failed" red line IS logged (from rebaseOrAbortCleanly),
+      // but the drift hint should NOT fire since current === starting.
+      const errorLines = errorSpy.mock.calls.map(c => String(c[0]));
+      const driftLines = errorLines.filter(line => line.includes('you started on'));
+      expect(driftLines).toHaveLength(0);
     });
   });
 

--- a/packages/tooling/src/release/finalize.test.ts
+++ b/packages/tooling/src/release/finalize.test.ts
@@ -117,10 +117,13 @@ describe('finalizeRelease', () => {
       expect(statusCall![1]).toEqual(['status', '--porcelain', '--untracked-files=no']);
     });
 
-    it('skips the clean-tree check in dry-run mode', async () => {
+    it('skips the clean-tree check in dry-run mode even when rebase is needed', async () => {
       // Dry-run is preview-only — inspecting state while mid-work should
-      // be allowed. Zero commits to rebase so we exit on the no-op path.
-      mockGit({ status: 'M some-file.ts\n', 'rev-list --count': '0\n' });
+      // be allowed. Use count = 3 so dry-run actually traverses the
+      // full preview path (not just the no-op exit); this proves the
+      // clean-tree check is truly bypassed, not just sidestepped by
+      // the no-op early-return.
+      mockGit({ status: 'M some-file.ts\n', 'rev-list --count': '3\n' });
 
       await expect(finalizeRelease({ dryRun: true, yes: true })).resolves.toBeUndefined();
     });
@@ -212,6 +215,43 @@ describe('finalizeRelease', () => {
           configurable: true,
         });
       }
+    });
+  });
+
+  describe('edge cases', () => {
+    it('throws a descriptive error on malformed rev-list output', async () => {
+      // If git's rev-list returns something un-parseable as an integer
+      // (shouldn't happen in practice, but a helpful error beats a silent
+      // NaN propagating through the rest of the flow).
+      mockGit({ 'rev-list --count': 'not-a-number\n' });
+
+      await expect(finalizeRelease({ yes: true })).rejects.toThrow(/Unexpected rev-list output/);
+    });
+
+    it('propagates pull errors without attempting recovery (intentional)', async () => {
+      // If `pull --ff-only origin main` fails (e.g., local main has
+      // diverged from origin/main), the error surfaces as-is. The user
+      // may be left on `main` rather than their starting branch. This
+      // is intentional: attempting rollback for every pre-rebase step
+      // adds complexity for an edge case where git's own error message
+      // is already clear. This test pins the behavior so any future
+      // refactor that adds rollback logic breaks it on purpose.
+      mockGit({
+        'rev-list --count': '3\n',
+        pull: () => {
+          throw new Error('fatal: Not possible to fast-forward, aborting.');
+        },
+      });
+
+      await expect(finalizeRelease({ yes: true })).rejects.toThrow(/Not possible to fast-forward/);
+
+      // Document what DID run: fetch, status, rev-list, checkout main,
+      // pull main (threw). Did NOT reach: checkout develop, rebase, push.
+      const invocations = mockedExec.mock.calls.map(c => (c[1] as string[]).join(' '));
+      expect(invocations).toContain('checkout main');
+      expect(invocations).not.toContain('checkout develop');
+      expect(invocations).not.toContain('rebase origin/main');
+      expect(invocations).not.toContain('push --force-with-lease origin develop');
     });
   });
 });

--- a/packages/tooling/src/release/finalize.ts
+++ b/packages/tooling/src/release/finalize.ts
@@ -120,6 +120,19 @@ async function shouldProceedWithForcePush(yes: boolean): Promise<boolean> {
 }
 
 /**
+ * Return the current branch name, or `''` if git can't resolve it
+ * (detached HEAD, missing upstream, etc.). Best-effort — callers treat
+ * `''` as "no branch info available" and silently skip downstream uses.
+ */
+function captureCurrentBranch(): string {
+  try {
+    return git(['rev-parse', '--abbrev-ref', 'HEAD']);
+  } catch {
+    return '';
+  }
+}
+
+/**
  * If an error left us on a different branch than we started on, log a
  * hint so the user can orient themselves quickly. Git's own error
  * messages say nothing about HEAD position, and `git status` after an
@@ -127,19 +140,14 @@ async function shouldProceedWithForcePush(yes: boolean): Promise<boolean> {
  * are swallowed so this helper never shadows the primary error.
  */
 function reportBranchDrift(startBranch: string): void {
-  try {
-    const currentBranch = git(['rev-parse', '--abbrev-ref', 'HEAD']);
-    if (currentBranch !== startBranch) {
-      console.error(
-        chalk.yellow(
-          `Note: you started on '${startBranch}' but are now on '${currentBranch}'. ` +
-            `Run \`git checkout ${startBranch}\` to return.`
-        )
-      );
-    }
-  } catch {
-    // Weird git state — don't clobber the primary error with a secondary
-    // rev-parse failure. The user's own `git status` will still work.
+  const currentBranch = captureCurrentBranch();
+  if (currentBranch !== '' && currentBranch !== startBranch) {
+    console.error(
+      chalk.yellow(
+        `Note: you started on '${startBranch}' but are now on '${currentBranch}'. ` +
+          `Run \`git checkout ${startBranch}\` to return.`
+      )
+    );
   }
 }
 
@@ -196,19 +204,9 @@ export async function finalizeRelease(options: FinalizeOptions): Promise<void> {
   }
 
   // Capture the starting branch so we can emit a "you're now on X" hint
-  // if any of the checkout/pull steps fail mid-sequence. In dry-run we
-  // skip this since no writes happen. Best-effort: if rev-parse fails
-  // (detached HEAD with no upstream, etc.) we fall back to an empty
-  // string and the drift hint simply won't fire.
-  const startBranch = dryRun
-    ? ''
-    : (() => {
-        try {
-          return git(['rev-parse', '--abbrev-ref', 'HEAD']);
-        } catch {
-          return '';
-        }
-      })();
+  // if any of the checkout/pull steps fail mid-sequence. Skipped in
+  // dry-run since no writes happen there.
+  const startBranch = dryRun ? '' : captureCurrentBranch();
 
   console.log(chalk.cyan(dryRun ? '[dry-run] Finalizing release' : 'Finalizing release'));
 

--- a/packages/tooling/src/release/finalize.ts
+++ b/packages/tooling/src/release/finalize.ts
@@ -1,32 +1,8 @@
 /**
- * Release Finalize
- *
- * Automates step 5 of the release flow: rebase develop onto main after a
- * release PR merges.
- *
- * The problem: the git-workflow skill documents "rebase develop onto main"
- * as the final step of a release, but nothing enforced it. Skipping it
- * left develop with the pre-rebase SHAs of the release commits while main
- * had the post-rebase versions — surfacing ~24 hours later as apparent
- * "conflicts with main" on the next release PR. The content was identical
- * (git auto-skips via `--reapply-cherry-picks`), but the diff looked
- * frightening until diagnosed.
- *
- * This command runs the full sequence:
- *   1. `git fetch --all`
- *   2. Checkout main, pull
- *   3. Checkout develop, pull
- *   4. `git rebase origin/main`
- *   5. `git push --force-with-lease`
- *
- * Safety:
- *   - Refuses to run with a dirty working tree
- *   - Skips the whole thing when main and develop already share the same
- *     tip (no-op path — "already finalized")
- *   - Requires `--yes` (or an interactive TTY) before the force-push step
- *   - On rebase conflicts, aborts cleanly and exits non-zero (leaves the
- *     user on develop at the original tip, nothing lost)
- *   - `--dry-run` prints the planned steps without executing
+ * Automates step 6 of the release flow (rebase develop onto main after a
+ * release PR merges). See `.claude/skills/tzurot-git-workflow/SKILL.md`
+ * for the release flow context and why skipping this step causes phantom
+ * "conflicts with main" on the next release PR.
  */
 
 import { execFileSync } from 'node:child_process';
@@ -83,15 +59,19 @@ async function confirmOrAbort(prompt: string): Promise<boolean> {
 }
 
 /**
- * Assert the working tree is clean. `git status --porcelain` is empty
- * when clean; any output means there are uncommitted/unstaged changes or
- * untracked files we'd risk losing during the checkout dance.
+ * Assert tracked files are clean. Uses `--untracked-files=no` so stray
+ * untracked files (scratch notes, build artifacts, `.env.local`) don't
+ * block the command — git checkout only fails on untracked files when
+ * one would collide with a tracked file in the target branch, which is
+ * rare and git will refuse loudly if it happens anyway. The 99% case is
+ * "untracked file sits there harmlessly," so scoping to tracked-only
+ * makes the check match the actual risk surface.
  */
 function assertCleanWorkingTree(): void {
-  const status = git(['status', '--porcelain']);
+  const status = git(['status', '--porcelain', '--untracked-files=no']);
   if (status.length > 0) {
     throw new Error(
-      'Working tree is not clean. Commit or stash changes before running release:finalize.'
+      'Working tree has uncommitted or unstaged tracked changes. Commit or stash them before running release:finalize.'
     );
   }
 }
@@ -174,7 +154,11 @@ export async function finalizeRelease(options: FinalizeOptions): Promise<void> {
       );
       return;
     }
-    console.log(chalk.yellow(`(preview) main ahead of develop by ${ahead} commit(s)`));
+    console.log(
+      chalk.yellow(
+        `(preview, local refs — may be stale) main ahead of develop by ${ahead} commit(s)`
+      )
+    );
   } else {
     console.log(chalk.yellow(`main ahead of develop — rebase needed`));
   }
@@ -188,17 +172,19 @@ export async function finalizeRelease(options: FinalizeOptions): Promise<void> {
 
   // Step 4: sync main locally. Nice-to-have: keeps local main pointer
   // matching origin/main; not strictly required since rebase uses the
-  // remote-tracking ref.
+  // remote-tracking ref. Explicit `origin main` avoids depending on
+  // upstream tracking being configured (it usually is, but a fresh
+  // clone or a manually-reset branch can be missing the link).
   console.log(chalk.dim('Syncing main...'));
   planStep(['checkout', 'main'], dryRun);
-  planStep(['pull', '--ff-only'], dryRun);
+  planStep(['pull', '--ff-only', 'origin', 'main'], dryRun);
 
   // Step 5: switch back to develop, pull, rebase. The ff-only pull fails
   // loudly if the local tip has diverged from origin/develop — better
   // than a surprise mid-rebase.
   console.log(chalk.dim('Syncing develop and rebasing onto main...'));
   planStep(['checkout', 'develop'], dryRun);
-  planStep(['pull', '--ff-only'], dryRun);
+  planStep(['pull', '--ff-only', 'origin', 'develop'], dryRun);
   if (dryRun) {
     console.log(chalk.dim('  [dry-run] git rebase origin/main'));
   } else {
@@ -207,8 +193,11 @@ export async function finalizeRelease(options: FinalizeOptions): Promise<void> {
 
   // Step 6: force-push. --force-with-lease (never raw --force) so a
   // concurrent push from someone else refuses instead of clobbering it.
+  // Explicit `origin develop` refspec guards against the unlikely case
+  // where `checkout develop` landed on an unexpected branch — the push
+  // refuses rather than silently pushing the wrong tracking branch.
   console.log(chalk.dim('Force-pushing develop...'));
-  planStep(['push', '--force-with-lease'], dryRun);
+  planStep(['push', '--force-with-lease', 'origin', 'develop'], dryRun);
 
   console.log(
     chalk.green(

--- a/packages/tooling/src/release/finalize.ts
+++ b/packages/tooling/src/release/finalize.ts
@@ -18,6 +18,13 @@ export interface FinalizeOptions {
  * Run a git subcommand with array args (no shell interpolation — see
  * `.claude/rules/00-critical.md` § "Shell Command Safety"). Returns
  * trimmed stdout; throws on non-zero exit.
+ *
+ * `execFileSync` defaults to `stdio: 'pipe'` for both streams, so git's
+ * own progress output (`Fetching origin...`, `Successfully rebased...`)
+ * is captured rather than shown to the user. Deliberate — our own
+ * `console.log` status lines cover the same ground with consistent
+ * formatting. On non-zero exit, the captured stderr is included in the
+ * thrown `Error.message` so the user still sees git's diagnostic text.
  */
 function git(args: string[]): string {
   return execFileSync('git', args, { encoding: 'utf-8' }).trim();
@@ -264,6 +271,12 @@ export async function finalizeRelease(options: FinalizeOptions): Promise<void> {
   try {
     runCheckoutRebasePushSequence(dryRun);
   } catch (err) {
+    // Outer guard handles "no useful startBranch" (detached HEAD, or
+    // rev-parse failed entirely); inner guard inside `reportBranchDrift`
+    // handles "we can't discover currentBranch post-failure." Both are
+    // load-bearing — without the outer guard, a detached-HEAD start
+    // followed by ending on a real branch would emit a misleading
+    // "you started on '' but are now on 'main'" message.
     if (startBranch !== '') {
       reportBranchDrift(startBranch);
     }

--- a/packages/tooling/src/release/finalize.ts
+++ b/packages/tooling/src/release/finalize.ts
@@ -120,6 +120,70 @@ async function shouldProceedWithForcePush(yes: boolean): Promise<boolean> {
 }
 
 /**
+ * If an error left us on a different branch than we started on, log a
+ * hint so the user can orient themselves quickly. Git's own error
+ * messages say nothing about HEAD position, and `git status` after an
+ * unexpected failure is easy to miss. Best-effort: rev-parse failures
+ * are swallowed so this helper never shadows the primary error.
+ */
+function reportBranchDrift(startBranch: string): void {
+  try {
+    const currentBranch = git(['rev-parse', '--abbrev-ref', 'HEAD']);
+    if (currentBranch !== startBranch) {
+      console.error(
+        chalk.yellow(
+          `Note: you started on '${startBranch}' but are now on '${currentBranch}'. ` +
+            `Run \`git checkout ${startBranch}\` to return.`
+        )
+      );
+    }
+  } catch {
+    // Weird git state — don't clobber the primary error with a secondary
+    // rev-parse failure. The user's own `git status` will still work.
+  }
+}
+
+/**
+ * The sequence of writes that the finalize runs (or previews, in dry-run):
+ * sync main locally, switch to develop, pull, rebase onto main, force-push.
+ *
+ * Explicit `origin <branch>` refspecs on pulls avoid depending on upstream
+ * tracking being configured (usually is, but a fresh clone or manually-reset
+ * branch can be missing the link). Explicit `origin develop` on push guards
+ * against the unlikely case where `checkout develop` landed on an unexpected
+ * branch — push refuses rather than silently pushing the wrong tracking ref.
+ */
+function runCheckoutRebasePushSequence(dryRun: boolean): void {
+  // Sync main locally. Nice-to-have: keeps the local main pointer matching
+  // origin/main; not strictly required since rebase uses the remote-tracking
+  // ref directly.
+  console.log(chalk.dim('Syncing main...'));
+  planStep(['checkout', 'main'], dryRun);
+  planStep(['pull', '--ff-only', 'origin', 'main'], dryRun);
+
+  // Switch back to develop and pull. The ff-only pull fails loudly if the
+  // local tip has diverged from origin/develop — better than a surprise
+  // mid-rebase.
+  console.log(chalk.dim('Syncing develop and rebasing onto main...'));
+  planStep(['checkout', 'develop'], dryRun);
+  planStep(['pull', '--ff-only', 'origin', 'develop'], dryRun);
+
+  // Can't use planStep for rebase: it needs try/catch for --abort teardown
+  // on conflicts. Dry-run branch mirrors planStep's output format manually
+  // to keep the preview consistent.
+  if (dryRun) {
+    console.log(chalk.dim('  [dry-run] git rebase origin/main'));
+  } else {
+    rebaseOrAbortCleanly();
+  }
+
+  // Force-push with --force-with-lease (never raw --force) so a concurrent
+  // push from someone else refuses instead of clobbering it.
+  console.log(chalk.dim('Force-pushing develop...'));
+  planStep(['push', '--force-with-lease', 'origin', 'develop'], dryRun);
+}
+
+/**
  * Execute or preview the finalize sequence. When `dryRun` is true, all
  * git commands are printed instead of executed — useful for reviewing
  * what the command will do before committing to the force-push.
@@ -130,6 +194,21 @@ export async function finalizeRelease(options: FinalizeOptions): Promise<void> {
   if (!dryRun) {
     assertCleanWorkingTree();
   }
+
+  // Capture the starting branch so we can emit a "you're now on X" hint
+  // if any of the checkout/pull steps fail mid-sequence. In dry-run we
+  // skip this since no writes happen. Best-effort: if rev-parse fails
+  // (detached HEAD with no upstream, etc.) we fall back to an empty
+  // string and the drift hint simply won't fire.
+  const startBranch = dryRun
+    ? ''
+    : (() => {
+        try {
+          return git(['rev-parse', '--abbrev-ref', 'HEAD']);
+        } catch {
+          return '';
+        }
+      })();
 
   console.log(chalk.cyan(dryRun ? '[dry-run] Finalizing release' : 'Finalizing release'));
 
@@ -170,37 +249,19 @@ export async function finalizeRelease(options: FinalizeOptions): Promise<void> {
     return;
   }
 
-  // Step 4: sync main locally. Nice-to-have: keeps local main pointer
-  // matching origin/main; not strictly required since rebase uses the
-  // remote-tracking ref. Explicit `origin main` avoids depending on
-  // upstream tracking being configured (it usually is, but a fresh
-  // clone or a manually-reset branch can be missing the link).
-  console.log(chalk.dim('Syncing main...'));
-  planStep(['checkout', 'main'], dryRun);
-  planStep(['pull', '--ff-only', 'origin', 'main'], dryRun);
-
-  // Step 5: switch back to develop, pull, rebase. The ff-only pull fails
-  // loudly if the local tip has diverged from origin/develop — better
-  // than a surprise mid-rebase.
-  console.log(chalk.dim('Syncing develop and rebasing onto main...'));
-  planStep(['checkout', 'develop'], dryRun);
-  planStep(['pull', '--ff-only', 'origin', 'develop'], dryRun);
-  // Can't use planStep here: rebase needs try/catch for --abort teardown
-  // on conflicts. The dry-run branch mirrors planStep's output format
-  // manually to keep the preview consistent.
-  if (dryRun) {
-    console.log(chalk.dim('  [dry-run] git rebase origin/main'));
-  } else {
-    rebaseOrAbortCleanly();
+  // Any failure in the checkout/pull/rebase/push dance may have left
+  // the user on a different branch than they started on. Log the drift
+  // (git's own error says nothing about HEAD) then re-throw to preserve
+  // the non-zero exit code. `startBranch` is empty in dry-run, so the
+  // hint is skipped there.
+  try {
+    runCheckoutRebasePushSequence(dryRun);
+  } catch (err) {
+    if (startBranch !== '') {
+      reportBranchDrift(startBranch);
+    }
+    throw err;
   }
-
-  // Step 6: force-push. --force-with-lease (never raw --force) so a
-  // concurrent push from someone else refuses instead of clobbering it.
-  // Explicit `origin develop` refspec guards against the unlikely case
-  // where `checkout develop` landed on an unexpected branch — the push
-  // refuses rather than silently pushing the wrong tracking branch.
-  console.log(chalk.dim('Force-pushing develop...'));
-  planStep(['push', '--force-with-lease', 'origin', 'develop'], dryRun);
 
   console.log(
     chalk.green(

--- a/packages/tooling/src/release/finalize.ts
+++ b/packages/tooling/src/release/finalize.ts
@@ -37,18 +37,12 @@ function planStep(args: string[], dryRun: boolean): void {
 }
 
 /**
- * Prompt for y/N confirmation. Returns false on non-TTY stdin so
- * automated callers without `--yes` fail safe rather than hanging.
+ * Prompt for y/N confirmation interactively. Caller must guarantee a
+ * TTY stdin — the non-TTY safety check lives in `shouldProceedWithForcePush`
+ * so the error surfaces as a thrown Error (non-zero exit) rather than a
+ * silent "returned false → Aborted" that looks like success in CI.
  */
-async function confirmOrAbort(prompt: string): Promise<boolean> {
-  if (!process.stdin.isTTY) {
-    console.error(
-      chalk.red(
-        'Refusing to force-push on non-TTY stdin without --yes. Re-run with --yes to confirm.'
-      )
-    );
-    return false;
-  }
+async function confirmInteractively(prompt: string): Promise<boolean> {
   const rl = createInterface({ input: process.stdin, output: process.stdout });
   try {
     const answer = await rl.question(`${prompt} [y/N] `);
@@ -71,7 +65,7 @@ function assertCleanWorkingTree(): void {
   const status = git(['status', '--porcelain', '--untracked-files=no']);
   if (status.length > 0) {
     throw new Error(
-      'Working tree has uncommitted or unstaged tracked changes. Commit or stash them before running release:finalize.'
+      'Working tree has uncommitted tracked changes (staged or unstaged). Commit or stash them before running release:finalize.'
     );
   }
 }
@@ -111,12 +105,19 @@ function rebaseOrAbortCleanly(): void {
 }
 
 /**
- * Decide whether to proceed with the force-push. Returns true if the
- * user confirmed interactively or passed `--yes`, false otherwise.
+ * Decide whether to proceed with the force-push. Three paths:
+ *   - `--yes` passed → return true (skip prompt).
+ *   - Non-TTY stdin without `--yes` → throw. A caller in CI that forgot
+ *     `--yes` must fail loudly (non-zero exit); silently "aborting" would
+ *     look like success and mask the missing flag.
+ *   - Interactive TTY → prompt for y/N, return the user's answer.
  */
 async function shouldProceedWithForcePush(yes: boolean): Promise<boolean> {
   if (yes) return true;
-  return confirmOrAbort('This will rebase develop onto main and force-push. Proceed?');
+  if (!process.stdin.isTTY) {
+    throw new Error('Non-TTY stdin requires --yes. Re-run with --yes to confirm the force-push.');
+  }
+  return confirmInteractively('This will rebase develop onto main and force-push. Proceed?');
 }
 
 /**

--- a/packages/tooling/src/release/finalize.ts
+++ b/packages/tooling/src/release/finalize.ts
@@ -1,0 +1,220 @@
+/**
+ * Release Finalize
+ *
+ * Automates step 5 of the release flow: rebase develop onto main after a
+ * release PR merges.
+ *
+ * The problem: the git-workflow skill documents "rebase develop onto main"
+ * as the final step of a release, but nothing enforced it. Skipping it
+ * left develop with the pre-rebase SHAs of the release commits while main
+ * had the post-rebase versions — surfacing ~24 hours later as apparent
+ * "conflicts with main" on the next release PR. The content was identical
+ * (git auto-skips via `--reapply-cherry-picks`), but the diff looked
+ * frightening until diagnosed.
+ *
+ * This command runs the full sequence:
+ *   1. `git fetch --all`
+ *   2. Checkout main, pull
+ *   3. Checkout develop, pull
+ *   4. `git rebase origin/main`
+ *   5. `git push --force-with-lease`
+ *
+ * Safety:
+ *   - Refuses to run with a dirty working tree
+ *   - Skips the whole thing when main and develop already share the same
+ *     tip (no-op path — "already finalized")
+ *   - Requires `--yes` (or an interactive TTY) before the force-push step
+ *   - On rebase conflicts, aborts cleanly and exits non-zero (leaves the
+ *     user on develop at the original tip, nothing lost)
+ *   - `--dry-run` prints the planned steps without executing
+ */
+
+import { execFileSync } from 'node:child_process';
+import { createInterface } from 'node:readline/promises';
+import chalk from 'chalk';
+
+export interface FinalizeOptions {
+  dryRun?: boolean;
+  yes?: boolean;
+}
+
+/**
+ * Run a git subcommand with array args (no shell interpolation — see
+ * `.claude/rules/00-critical.md` § "Shell Command Safety"). Returns
+ * trimmed stdout; throws on non-zero exit.
+ */
+function git(args: string[]): string {
+  return execFileSync('git', args, { encoding: 'utf-8' }).trim();
+}
+
+/**
+ * Execute a git step, or in dry-run mode print what would be executed.
+ * Keeps the dry-run branching out of the orchestrator so `finalizeRelease`
+ * reads as a linear sequence of steps.
+ */
+function planStep(args: string[], dryRun: boolean): void {
+  if (dryRun) {
+    console.log(chalk.dim(`  [dry-run] git ${args.join(' ')}`));
+    return;
+  }
+  git(args);
+}
+
+/**
+ * Prompt for y/N confirmation. Returns false on non-TTY stdin so
+ * automated callers without `--yes` fail safe rather than hanging.
+ */
+async function confirmOrAbort(prompt: string): Promise<boolean> {
+  if (!process.stdin.isTTY) {
+    console.error(
+      chalk.red(
+        'Refusing to force-push on non-TTY stdin without --yes. Re-run with --yes to confirm.'
+      )
+    );
+    return false;
+  }
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await rl.question(`${prompt} [y/N] `);
+    return answer.trim().toLowerCase() === 'y';
+  } finally {
+    rl.close();
+  }
+}
+
+/**
+ * Assert the working tree is clean. `git status --porcelain` is empty
+ * when clean; any output means there are uncommitted/unstaged changes or
+ * untracked files we'd risk losing during the checkout dance.
+ */
+function assertCleanWorkingTree(): void {
+  const status = git(['status', '--porcelain']);
+  if (status.length > 0) {
+    throw new Error(
+      'Working tree is not clean. Commit or stash changes before running release:finalize.'
+    );
+  }
+}
+
+/**
+ * Count commits that are on `origin/main` but not on `origin/develop`.
+ * Zero means develop already contains every main commit — the finalize
+ * is a no-op and we can exit early.
+ */
+function commitsMainAheadOfDevelop(): number {
+  const out = git(['rev-list', '--count', 'origin/develop..origin/main']);
+  const n = parseInt(out, 10);
+  if (Number.isNaN(n)) {
+    throw new Error(`Unexpected rev-list output: ${out}`);
+  }
+  return n;
+}
+
+/**
+ * Run the rebase step with conflict-safe teardown: if rebase throws, try
+ * to `--abort` so the user lands back on develop at the pre-rebase tip,
+ * then re-throw the original error. A secondary abort failure is
+ * swallowed to avoid clobbering the primary error message.
+ */
+function rebaseOrAbortCleanly(): void {
+  try {
+    git(['rebase', 'origin/main']);
+  } catch (err) {
+    console.error(chalk.red('Rebase failed — aborting to leave develop at original tip.'));
+    try {
+      git(['rebase', '--abort']);
+    } catch {
+      // Secondary failure — original error is what matters.
+    }
+    throw err instanceof Error ? err : new Error(String(err));
+  }
+}
+
+/**
+ * Decide whether to proceed with the force-push. Returns true if the
+ * user confirmed interactively or passed `--yes`, false otherwise.
+ */
+async function shouldProceedWithForcePush(yes: boolean): Promise<boolean> {
+  if (yes) return true;
+  return confirmOrAbort('This will rebase develop onto main and force-push. Proceed?');
+}
+
+/**
+ * Execute or preview the finalize sequence. When `dryRun` is true, all
+ * git commands are printed instead of executed — useful for reviewing
+ * what the command will do before committing to the force-push.
+ */
+export async function finalizeRelease(options: FinalizeOptions): Promise<void> {
+  const { dryRun = false, yes = false } = options;
+
+  if (!dryRun) {
+    assertCleanWorkingTree();
+  }
+
+  console.log(chalk.cyan(dryRun ? '[dry-run] Finalizing release' : 'Finalizing release'));
+
+  // Step 1: fetch. Dry-run prints; real run actually fetches (we need
+  // the current remote state for the ahead-count check that follows).
+  console.log(chalk.dim('Fetching remote refs...'));
+  planStep(['fetch', '--all'], dryRun);
+
+  // Step 2: detect no-op. In dry-run this also runs so users see real state.
+  // In real mode we already fetched so the ref is current.
+  if (!dryRun && commitsMainAheadOfDevelop() === 0) {
+    console.log(chalk.green('✓ develop already contains every main commit — nothing to finalize'));
+    return;
+  }
+  if (dryRun) {
+    // In dry-run we need the count without having fetched first; check with
+    // whatever refs we have locally so the preview is still informative.
+    const ahead = commitsMainAheadOfDevelop();
+    if (ahead === 0) {
+      console.log(
+        chalk.green('✓ develop already contains every main commit — nothing to finalize')
+      );
+      return;
+    }
+    console.log(chalk.yellow(`(preview) main ahead of develop by ${ahead} commit(s)`));
+  } else {
+    console.log(chalk.yellow(`main ahead of develop — rebase needed`));
+  }
+
+  // Step 3: confirm the force-push branch. Rebase itself is safe (local
+  // only, reversible via --abort); the force-push needs explicit sign-off.
+  if (!dryRun && !(await shouldProceedWithForcePush(yes))) {
+    console.log(chalk.dim('Aborted by user.'));
+    return;
+  }
+
+  // Step 4: sync main locally. Nice-to-have: keeps local main pointer
+  // matching origin/main; not strictly required since rebase uses the
+  // remote-tracking ref.
+  console.log(chalk.dim('Syncing main...'));
+  planStep(['checkout', 'main'], dryRun);
+  planStep(['pull', '--ff-only'], dryRun);
+
+  // Step 5: switch back to develop, pull, rebase. The ff-only pull fails
+  // loudly if the local tip has diverged from origin/develop — better
+  // than a surprise mid-rebase.
+  console.log(chalk.dim('Syncing develop and rebasing onto main...'));
+  planStep(['checkout', 'develop'], dryRun);
+  planStep(['pull', '--ff-only'], dryRun);
+  if (dryRun) {
+    console.log(chalk.dim('  [dry-run] git rebase origin/main'));
+  } else {
+    rebaseOrAbortCleanly();
+  }
+
+  // Step 6: force-push. --force-with-lease (never raw --force) so a
+  // concurrent push from someone else refuses instead of clobbering it.
+  console.log(chalk.dim('Force-pushing develop...'));
+  planStep(['push', '--force-with-lease'], dryRun);
+
+  console.log(
+    chalk.green(
+      dryRun
+        ? '✓ Dry run complete — re-run without --dry-run to apply'
+        : '✓ Finalize complete — develop is now SHA-aligned with main'
+    )
+  );
+}

--- a/packages/tooling/src/release/finalize.ts
+++ b/packages/tooling/src/release/finalize.ts
@@ -124,10 +124,16 @@ async function shouldProceedWithForcePush(yes: boolean): Promise<boolean> {
  * Return the current branch name, or `''` if git can't resolve it
  * (detached HEAD, missing upstream, etc.). Best-effort — callers treat
  * `''` as "no branch info available" and silently skip downstream uses.
+ *
+ * Note: `git rev-parse --abbrev-ref HEAD` does NOT throw in detached
+ * HEAD state — it outputs the literal string `HEAD`. Translate that to
+ * `''` so downstream drift messages don't recommend `git checkout HEAD`
+ * (which means something different from "return to your previous branch").
  */
 function captureCurrentBranch(): string {
   try {
-    return git(['rev-parse', '--abbrev-ref', 'HEAD']);
+    const branch = git(['rev-parse', '--abbrev-ref', 'HEAD']);
+    return branch === 'HEAD' ? '' : branch;
   } catch {
     return '';
   }
@@ -150,6 +156,26 @@ function reportBranchDrift(startBranch: string): void {
       )
     );
   }
+}
+
+/**
+ * Check whether main has commits ahead of develop. Returns `'noop'` when
+ * develop already contains every main commit (exit early) or `'proceed'`
+ * when a rebase is needed. Logs the appropriate status message in both
+ * cases — dry-run gets a "(preview, local refs — may be stale)" prefix
+ * since `fetch --all` was only printed, not executed.
+ */
+function checkAheadCount(dryRun: boolean): 'noop' | 'proceed' {
+  const ahead = commitsMainAheadOfDevelop();
+  if (ahead === 0) {
+    console.log(chalk.green('✓ develop already contains every main commit — nothing to finalize'));
+    return 'noop';
+  }
+  const note = dryRun
+    ? `(preview, local refs — may be stale) main ahead of develop by ${ahead} commit(s)`
+    : `main ahead of develop — rebase needed`;
+  console.log(chalk.yellow(note));
+  return 'proceed';
 }
 
 /**
@@ -216,29 +242,11 @@ export async function finalizeRelease(options: FinalizeOptions): Promise<void> {
   console.log(chalk.dim('Fetching remote refs...'));
   planStep(['fetch', '--all'], dryRun);
 
-  // Step 2: detect no-op. In dry-run this also runs so users see real state.
-  // In real mode we already fetched so the ref is current.
-  if (!dryRun && commitsMainAheadOfDevelop() === 0) {
-    console.log(chalk.green('✓ develop already contains every main commit — nothing to finalize'));
+  // Step 2: detect no-op. In dry-run we're reading local refs (fetch
+  // was printed, not executed) so the count may be stale — the helper
+  // flags that in the status message.
+  if (checkAheadCount(dryRun) === 'noop') {
     return;
-  }
-  if (dryRun) {
-    // In dry-run we need the count without having fetched first; check with
-    // whatever refs we have locally so the preview is still informative.
-    const ahead = commitsMainAheadOfDevelop();
-    if (ahead === 0) {
-      console.log(
-        chalk.green('✓ develop already contains every main commit — nothing to finalize')
-      );
-      return;
-    }
-    console.log(
-      chalk.yellow(
-        `(preview, local refs — may be stale) main ahead of develop by ${ahead} commit(s)`
-      )
-    );
-  } else {
-    console.log(chalk.yellow(`main ahead of develop — rebase needed`));
   }
 
   // Step 3: confirm the force-push branch. Rebase itself is safe (local

--- a/packages/tooling/src/release/finalize.ts
+++ b/packages/tooling/src/release/finalize.ts
@@ -185,6 +185,9 @@ export async function finalizeRelease(options: FinalizeOptions): Promise<void> {
   console.log(chalk.dim('Syncing develop and rebasing onto main...'));
   planStep(['checkout', 'develop'], dryRun);
   planStep(['pull', '--ff-only', 'origin', 'develop'], dryRun);
+  // Can't use planStep here: rebase needs try/catch for --abort teardown
+  // on conflicts. The dry-run branch mirrors planStep's output format
+  // manually to keep the preview consistent.
   if (dryRun) {
     console.log(chalk.dim('  [dry-run] git rebase origin/main'));
   } else {


### PR DESCRIPTION
## Why

Quick Win #4 from the 2026-04-22 triage. The git-workflow skill documents "rebase develop onto main" as the final step of a release, but nothing enforced it. Got skipped after beta.98 shipped; showed up ~24 hours later as apparent "conflicts with main" on the beta.99 release PR. The content was identical (git auto-skipped via `--reapply-cherry-picks`), but the diff looked frightening until diagnosed.

## What

New `pnpm ops release:finalize` command that runs the full step-5 sequence atomically:

```
git fetch --all
git checkout main && git pull --ff-only
git checkout develop && git pull --ff-only
git rebase origin/main
git push --force-with-lease
```

## Safety rails

| Rail | Why |
|---|---|
| Refuse dirty working tree | Checkout dance would risk losing uncommitted work. Exception: `--dry-run` bypasses the check so you can preview from any state |
| No-op exit when develop already contains every main commit | Rebase would be a no-op; saves the force-push round-trip |
| Require `--yes` on non-TTY stdin, prompt interactively otherwise, before force-push | Rebase itself is safe (local, reversible via `--abort`); the force-push is the part needing sign-off |
| On rebase conflicts → abort + re-throw | User lands back on develop at pre-rebase tip, nothing lost |
| `--force-with-lease` never raw `--force` | Concurrent pushes from others refuse instead of getting clobbered |
| `--dry-run` previews without executing | Review planned sequence before committing |

## Files

| File | Change |
|---|---|
| `release/finalize.ts` (new) | Core logic — orchestrator + 4 small helpers (`planStep`, `rebaseOrAbortCleanly`, `shouldProceedWithForcePush`, `confirmOrAbort`) |
| `release/finalize.test.ts` (new) | 8 tests: no-op, happy path sequence ordering, dirty-tree refusal, dry-run permissiveness, rebase-conflict abort + re-throw, secondary --abort swallowed, non-TTY safety, dry-run write skipping |
| `commands/release.ts` | Registered `release:finalize` alongside the existing `release:bump`, `release:draft-notes`, `release:verify-notes` |

## CLI shape

```
$ pnpm ops release:finalize --help
Usage:
  $ ops release:finalize

Options:
  --dry-run   Preview the planned steps without executing
  --yes       Skip the force-push confirmation prompt (required on non-TTY stdin)
  -h, --help  Display this message
```

## Test plan

- [x] 8/8 finalize.test.ts green
- [x] Full tooling suite 595/595 green (no regressions in the adjacent release commands)
- [x] CLI help output verified via `pnpm ops release:finalize --help`
- [x] `pnpm typecheck` clean across all 11 packages
- [ ] Real run on the next release (whenever `v3.0.0-beta.104` ships) — this command IS the test, in effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)