### PR TITLE
chore: three quick wins from Inbox/Quick-Wins triage

### DIFF
--- a/services/ai-worker/src/utils/thinkingExtraction.ts
+++ b/services/ai-worker/src/utils/thinkingExtraction.ts
@@ -529,7 +529,7 @@ export function extractApiReasoningContent(reasoningDetails: unknown): string | 
     }
 
     const typedDetail = detail as ReasoningDetail;
-    const extracted = processReasoningDetail(typedDetail, parts);
+    const extracted = processReasoningDetail(typedDetail);
     if (extracted !== null) {
       parts.push(extracted);
     }
@@ -556,7 +556,7 @@ export function extractApiReasoningContent(reasoningDetails: unknown): string | 
 /**
  * Process a single reasoning detail and return extracted content.
  */
-function processReasoningDetail(detail: ReasoningDetail, _parts: string[]): string | null {
+function processReasoningDetail(detail: ReasoningDetail): string | null {
   switch (detail.type) {
     case 'reasoning.text':
     case 'reasoning.summary':

--- a/services/api-gateway/src/routes/user/shapes/auth.test.ts
+++ b/services/api-gateway/src/routes/user/shapes/auth.test.ts
@@ -319,15 +319,7 @@ describe('Shapes Auth Routes', () => {
       return { req, res };
     }
 
-    it('should return 404 when user not found', async () => {
-      mockPrisma.user.findFirst.mockResolvedValue(null);
-      const { res } = await callDeleteHandler();
-
-      expect(res.status).toHaveBeenCalledWith(404);
-    });
-
     it('should return 404 when credential not found', async () => {
-      mockPrisma.user.findFirst.mockResolvedValue({ id: 'user-uuid-123' });
       mockPrisma.userCredential.findFirst.mockResolvedValue(null);
       const { res } = await callDeleteHandler();
 
@@ -335,7 +327,6 @@ describe('Shapes Auth Routes', () => {
     });
 
     it('should delete credential and return success', async () => {
-      mockPrisma.user.findFirst.mockResolvedValue({ id: 'user-uuid-123' });
       mockPrisma.userCredential.findFirst.mockResolvedValue({ id: 'cred-uuid-123' });
 
       const { res } = await callDeleteHandler();
@@ -359,25 +350,16 @@ describe('Shapes Auth Routes', () => {
       return { req, res };
     }
 
-    it('should return hasCredentials: false when user not found', async () => {
-      mockPrisma.user.findFirst.mockResolvedValue(null);
+    it('should return hasCredentials: false when credential not found', async () => {
+      mockPrisma.userCredential.findFirst.mockResolvedValue(null);
       const { res } = await callStatusHandler();
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ hasCredentials: false }));
     });
 
-    it('should return hasCredentials: false when credential not found', async () => {
-      mockPrisma.user.findFirst.mockResolvedValue({ id: 'user-uuid-123' });
-      mockPrisma.userCredential.findFirst.mockResolvedValue(null);
-      const { res } = await callStatusHandler();
-
-      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ hasCredentials: false }));
-    });
-
     it('should return hasCredentials: true with timestamps', async () => {
       const now = new Date('2026-02-16T12:00:00Z');
-      mockPrisma.user.findFirst.mockResolvedValue({ id: 'user-uuid-123' });
       mockPrisma.userCredential.findFirst.mockResolvedValue({
         createdAt: now,
         lastUsedAt: null,

--- a/services/api-gateway/src/routes/user/shapes/auth.ts
+++ b/services/api-gateway/src/routes/user/shapes/auth.ts
@@ -31,7 +31,7 @@ import { resolveProvisionedUserId } from '../../../utils/resolveProvisionedUserI
 import { sendError, sendCustomSuccess } from '../../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
 import { probeShapesSession } from '../../../services/ShapesPreflight.js';
-import type { AuthenticatedRequest, ProvisionedRequest } from '../../../types.js';
+import type { ProvisionedRequest } from '../../../types.js';
 
 const logger = createLogger('shapes-auth');
 
@@ -131,21 +131,13 @@ function createStoreHandler(prisma: PrismaClient, userService: UserService) {
   };
 }
 
-function createDeleteHandler(prisma: PrismaClient) {
-  return async (req: AuthenticatedRequest, res: Response) => {
+function createDeleteHandler(prisma: PrismaClient, userService: UserService) {
+  return async (req: ProvisionedRequest, res: Response) => {
     const discordUserId = req.userId;
-
-    const user = await prisma.user.findFirst({
-      where: { discordId: discordUserId },
-      select: { id: true },
-    });
-
-    if (user === null) {
-      return sendError(res, ErrorResponses.notFound('Shapes.inc credentials'));
-    }
+    const userId = await resolveProvisionedUserId(req, userService);
 
     const existing = await prisma.userCredential.findFirst({
-      where: { userId: user.id, ...SHAPES_CREDENTIAL_WHERE },
+      where: { userId, ...SHAPES_CREDENTIAL_WHERE },
     });
 
     if (existing === null) {
@@ -163,22 +155,12 @@ function createDeleteHandler(prisma: PrismaClient) {
   };
 }
 
-function createStatusHandler(prisma: PrismaClient) {
-  return async (req: AuthenticatedRequest, res: Response) => {
-    const discordUserId = req.userId;
-
-    const user = await prisma.user.findFirst({
-      where: { discordId: discordUserId },
-      select: { id: true },
-    });
-
-    if (user === null) {
-      sendCustomSuccess(res, { hasCredentials: false, service: CREDENTIAL_SERVICES.SHAPES_INC });
-      return;
-    }
+function createStatusHandler(prisma: PrismaClient, userService: UserService) {
+  return async (req: ProvisionedRequest, res: Response) => {
+    const userId = await resolveProvisionedUserId(req, userService);
 
     const credential = await prisma.userCredential.findFirst({
-      where: { userId: user.id, ...SHAPES_CREDENTIAL_WHERE },
+      where: { userId, ...SHAPES_CREDENTIAL_WHERE },
       select: { createdAt: true, lastUsedAt: true, expiresAt: true },
     });
 
@@ -211,13 +193,13 @@ export function createShapesAuthRoutes(prisma: PrismaClient): Router {
     '/',
     requireUserAuth(),
     requireProvisionedUser(prisma),
-    asyncHandler(createDeleteHandler(prisma))
+    asyncHandler(createDeleteHandler(prisma, userService))
   );
   router.get(
     '/status',
     requireUserAuth(),
     requireProvisionedUser(prisma),
-    asyncHandler(createStatusHandler(prisma))
+    asyncHandler(createStatusHandler(prisma, userService))
   );
 
   return router;

--- a/services/bot-client/src/commands/character/dashboardButtons.test.ts
+++ b/services/bot-client/src/commands/character/dashboardButtons.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ButtonInteraction, Client } from 'discord.js';
 import { handleRefreshButton, handleCloseButton } from './dashboardButtons.js';
 import { handleDashboardClose } from '../../utils/dashboard/closeHandler.js';
+import { formatSessionExpiredMessage } from '../../utils/dashboard/messages.js';
 
 // Mock dependencies
 const mockFetchCharacter = vi.fn();
@@ -31,7 +32,7 @@ const mockGetSessionOrExpired = vi
     const session = await mockSessionManager.get(interaction.user.id, entityType, entityId);
     if (session === null) {
       await interaction.editReply({
-        content: 'Session expired. Please run /character browse to try again.',
+        content: formatSessionExpiredMessage('/character browse'),
         embeds: [],
         components: [],
       });
@@ -89,7 +90,7 @@ describe('Character Dashboard Buttons', () => {
         const session = await mockSessionManager.get(interaction.user.id, entityType, entityId);
         if (session === null) {
           await interaction.editReply({
-            content: 'Session expired. Please run /character browse to try again.',
+            content: formatSessionExpiredMessage('/character browse'),
             embeds: [],
             components: [],
           });

--- a/services/bot-client/src/commands/deny/detailEdit.ts
+++ b/services/bot-client/src/commands/deny/detailEdit.ts
@@ -6,7 +6,13 @@
  * scope changes, and persisting edits via the gateway API.
  */
 
-import { ModalBuilder, TextInputBuilder, TextInputStyle, ActionRowBuilder } from 'discord.js';
+import {
+  ModalBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+  ActionRowBuilder,
+  MessageFlags,
+} from 'discord.js';
 import type { ButtonInteraction, ModalSubmitInteraction } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
 import { getSessionManager } from '../../utils/dashboard/SessionManager.js';
@@ -28,7 +34,10 @@ export async function handleEdit(interaction: ButtonInteraction, entryId: string
   );
 
   if (session === null) {
-    await interaction.followUp({ content: DASHBOARD_MESSAGES.SESSION_EXPIRED, flags: 64 });
+    await interaction.followUp({
+      content: DASHBOARD_MESSAGES.SESSION_EXPIRED,
+      flags: MessageFlags.Ephemeral,
+    });
     return;
   }
 
@@ -99,7 +108,10 @@ export async function handleEditModal(
   );
 
   if (session === null) {
-    await interaction.reply({ content: DASHBOARD_MESSAGES.SESSION_EXPIRED, flags: 64 });
+    await interaction.reply({
+      content: DASHBOARD_MESSAGES.SESSION_EXPIRED,
+      flags: MessageFlags.Ephemeral,
+    });
     return;
   }
 

--- a/services/bot-client/src/commands/persona/dashboard.test.ts
+++ b/services/bot-client/src/commands/persona/dashboard.test.ts
@@ -13,6 +13,7 @@ import {
 } from './dashboard.js';
 import { handleDashboardClose } from '../../utils/dashboard/closeHandler.js';
 import { buildDeleteConfirmation } from '../../utils/dashboard/deleteConfirmation.js';
+import { DASHBOARD_MESSAGES, formatSessionExpiredMessage } from '../../utils/dashboard/messages.js';
 import { mockGetPersonaResponse, mockListPersonasResponse } from '@tzurot/common-types';
 
 // Valid UUIDs for tests
@@ -47,7 +48,7 @@ const mockGetSessionOrExpired = vi
     const session = await mockSessionGet(interaction.user.id, entityType, entityId);
     if (session === null) {
       await interaction.editReply({
-        content: 'Session expired. Please run /persona browse to try again.',
+        content: formatSessionExpiredMessage('/persona browse'),
         embeds: [],
         components: [],
       });
@@ -80,8 +81,8 @@ const mockGetSessionDataOrReply = vi
     const session = await mockSessionGet(interaction.user.id, entityType, entityId);
     if (session === null) {
       await interaction.reply({
-        content: 'Session expired. Please try again.',
-        flags: 64,
+        content: DASHBOARD_MESSAGES.SESSION_EXPIRED,
+        flags: MessageFlags.Ephemeral,
       });
       return null;
     }
@@ -472,7 +473,7 @@ describe('handleButton', () => {
       const session = await mockSessionGet(interaction.user.id, entityType, entityId);
       if (session === null) {
         await interaction.editReply({
-          content: 'Session expired. Please run /persona browse to try again.',
+          content: formatSessionExpiredMessage('/persona browse'),
           embeds: [],
           components: [],
         });
@@ -483,8 +484,8 @@ describe('handleButton', () => {
       const session = await mockSessionGet(interaction.user.id, entityType, entityId);
       if (session === null) {
         await interaction.reply({
-          content: 'Session expired. Please try again.',
-          flags: 64,
+          content: DASHBOARD_MESSAGES.SESSION_EXPIRED,
+          flags: MessageFlags.Ephemeral,
         });
         return null;
       }

--- a/services/bot-client/src/commands/preset/dashboard.test.ts
+++ b/services/bot-client/src/commands/preset/dashboard.test.ts
@@ -11,6 +11,7 @@ import {
   isPresetDashboardInteraction,
 } from './dashboard.js';
 import { handleDashboardClose } from '../../utils/dashboard/closeHandler.js';
+import { DASHBOARD_MESSAGES, formatSessionExpiredMessage } from '../../utils/dashboard/messages.js';
 import type { PresetData } from './config.js';
 import { GatewayApiError } from '../../utils/userGatewayClient.js';
 
@@ -89,7 +90,7 @@ const mockGetSessionOrExpired = vi
     if (session === null) {
       // Mimic real behavior: call editReply with expired message
       await interaction.editReply({
-        content: 'Session expired. Please run /preset browse to try again.',
+        content: formatSessionExpiredMessage('/preset browse'),
         embeds: [],
         components: [],
       });
@@ -110,8 +111,8 @@ const mockGetSessionDataOrReply = vi
     if (session === null) {
       // Mimic real behavior: call reply with expired message
       await interaction.reply({
-        content: 'Session expired. Please try again.',
-        flags: 64, // MessageFlags.Ephemeral
+        content: DASHBOARD_MESSAGES.SESSION_EXPIRED,
+        flags: MessageFlags.Ephemeral,
       });
       return null;
     }

--- a/services/bot-client/src/commands/preset/dashboardButtons.test.ts
+++ b/services/bot-client/src/commands/preset/dashboardButtons.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MessageFlags } from 'discord.js';
 import type { ButtonInteraction } from 'discord.js';
 import {
   buildPresetDashboardOptions,
@@ -16,6 +17,7 @@ import {
 import { generateClonedName } from './cloneName.js';
 import { handleDashboardClose } from '../../utils/dashboard/closeHandler.js';
 import { refreshDashboardUI } from '../../utils/dashboard/refreshHandler.js';
+import { DASHBOARD_MESSAGES, formatSessionExpiredMessage } from '../../utils/dashboard/messages.js';
 import type { FlattenedPresetData } from './config.js';
 
 const TEST_USER = {
@@ -68,7 +70,7 @@ const mockGetSessionOrExpired = vi
     if (session === null) {
       // Mimic real behavior: call editReply with expired message
       await interaction.editReply({
-        content: 'Session expired. Please run /preset browse to try again.',
+        content: formatSessionExpiredMessage('/preset browse'),
         embeds: [],
         components: [],
       });
@@ -82,8 +84,8 @@ const mockGetSessionDataOrReply = vi
     if (session === null) {
       // Mimic real behavior: call reply with expired message
       await interaction.reply({
-        content: 'Session expired. Please try again.',
-        flags: 64, // MessageFlags.Ephemeral
+        content: DASHBOARD_MESSAGES.SESSION_EXPIRED,
+        flags: MessageFlags.Ephemeral,
       });
       return null;
     }
@@ -97,8 +99,8 @@ const mockGetSessionDataOrFollowUp = vi
     const session = await mockSessionManager.get(interaction.user.id, entityType, entityId);
     if (session === null) {
       await interaction.followUp({
-        content: 'Session expired. Please try again.',
-        flags: 64, // MessageFlags.Ephemeral
+        content: DASHBOARD_MESSAGES.SESSION_EXPIRED,
+        flags: MessageFlags.Ephemeral,
       });
       return null;
     }

--- a/services/bot-client/src/utils/safeInteraction.test.ts
+++ b/services/bot-client/src/utils/safeInteraction.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MessageFlags } from 'discord.js';
 import type { ChatInputCommandInteraction, Message } from 'discord.js';
 
 // Mock the logger using vi.hoisted to ensure proper initialization order
@@ -75,7 +76,7 @@ describe('wrapDeferredInteraction', () => {
 
     it('should pass through ephemeral flag (already set by deferReply)', async () => {
       const wrapped = wrapDeferredInteraction(mockInteraction);
-      const options = { content: 'Secret', flags: 64 }; // Ephemeral flag
+      const options = { content: 'Secret', flags: MessageFlags.Ephemeral } as const;
 
       await wrapped.reply(options);
 


### PR DESCRIPTION
## Summary

Three small, independent cleanups bundled as one PR. Each commit is self-contained and could theoretically land separately, but they're cheap enough together that splitting would be churn.

### 1. `refactor(ai-worker)`: drop unused `_parts` param from `processReasoningDetail`

`thinkingExtraction.ts:559` had a `_parts: string[]` parameter that was never read. Per `02-code-standards.md`, the `_` prefix escape hatch is reserved for signatures we don't control (callbacks, interface impls); internal helpers should just drop the param. 2-line fix.

Surfaced on PR #879 review.

### 2. `refactor(api-gateway)`: use `resolveProvisionedUserId` in shapes auth delete/status handlers

`createDeleteHandler` and `createStatusHandler` in `routes/user/shapes/auth.ts` were typed as `AuthenticatedRequest` and re-queried the DB with `prisma.user.findFirst({ where: { discordId } })` to re-derive the same internal UUID that `requireProvisionedUser` middleware already found. The sibling `createStoreHandler` in the same file does it correctly. This is the Phase 5c invariant applied inconsistently within one file.

Switched both to `ProvisionedRequest` + `resolveProvisionedUserId`. Removes one DB round-trip per call. The "user not found" test branches become unreachable (middleware guarantees the user exists, or shadow-mode fallback creates one via `getOrCreateUserShell`) — deleted.

Surfaced on PR #879 review rounds 1+2.

### 3. `chore(bot-client)`: adopt `MessageFlags.Ephemeral` + `DASHBOARD_MESSAGES` in tests

Two production sites in `deny/detailEdit.ts` used the magic `flags: 64` instead of `MessageFlags.Ephemeral`. Several test-mock implementations (preset/persona/character dashboards) mirrored outdated production text (`'Session expired. Please try again.'`) instead of the real `DASHBOARD_MESSAGES.SESSION_EXPIRED` / `formatSessionExpiredMessage()` constants. Tests passed via loose `stringContaining()` assertions, but the mocks would drift further apart over time.

Unified: production uses `MessageFlags.Ephemeral`; mocks consume the same constants they're simulating, so future text changes in `messages.ts` flow through automatically.

Surfaced 2026-04-22 from claude-bot review on PR #876.

## Stats

9 files changed, +52/-70. Net reduction from deleting redundant shell-path defensive code in `auth.ts`.

## Test plan

- [x] `pnpm --filter ai-worker test thinkingExtraction` — 102/102 pass
- [x] `pnpm --filter api-gateway test auth.test.ts` — 21/21 pass (down from 23 after deleting dead-branch tests)
- [x] `pnpm --filter bot-client test` — 4398/4398 pass
- [x] `pnpm --filter bot-client typecheck:spec` — clean (after `as const` fix for `MessageFlags.Ephemeral` widening)
- [x] `pnpm depcruise` — 1433 modules, 0 violations (pre-push gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)