### PR TITLE
feat(tooling): preserve CHECK constraints in pglite-schema generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,22 +68,23 @@ jobs:
           # Verify schema file exists
           if [ ! -f "packages/test-utils/schema/pglite-schema.sql" ]; then
             echo "❌ ERROR: packages/test-utils/schema/pglite-schema.sql not found"
-            echo "Run: ./scripts/testing/regenerate-pglite-schema.sh"
+            echo "Run: pnpm ops test:generate-schema"
             exit 1
           fi
 
-          # Generate fresh schema from Prisma (no DB connection needed)
-          npx prisma migrate diff \
-            --from-empty \
-            --to-schema ./prisma/schema.prisma \
-            --script > /tmp/fresh-pglite-schema.sql
+          # Use the ops generator so CI matches what developers run locally.
+          # The generator appends CHECK constraints harvested from migration SQL
+          # (Prisma's schema-diff has no CHECK representation), so a raw
+          # `prisma migrate diff` would produce a different file and always
+          # flag drift.
+          pnpm ops test:generate-schema --output /tmp/fresh-pglite-schema.sql > /dev/null
 
           # Compare with committed schema
           if ! diff -q packages/test-utils/schema/pglite-schema.sql /tmp/fresh-pglite-schema.sql > /dev/null 2>&1; then
             echo "❌ ERROR: pglite-schema.sql is out of sync with prisma/schema.prisma"
             echo ""
             echo "The integration test schema must match the Prisma schema."
-            echo "Run: ./scripts/testing/regenerate-pglite-schema.sh"
+            echo "Run: pnpm ops test:generate-schema"
             echo ""
             echo "Diff:"
             diff packages/test-utils/schema/pglite-schema.sql /tmp/fresh-pglite-schema.sql || true

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -90,6 +90,8 @@ _Small tasks that can be done between major features. Good for momentum._
 
 _Empty — both entries shipped (CHECK extractor in this PR, typing-error classifier in PR #886)._
 
+- 🧹 `[CHORE]` **Handle `DROP CONSTRAINT` in pglite CHECK extractor** — Surfaced 2026-04-24 by PR #887 review. `extractCheckConstraints` in `packages/tooling/src/test/generate-schema.ts` tracks ADD statements in a `Map<name, statement>` but ignores `DROP CONSTRAINT` entirely. The drop-and-re-add case works (second ADD overwrites first), but a future migration that drops a CHECK **without re-adding it** would leave the original ADD in the extracted output — PGLite would then enforce a constraint prod Postgres no longer has, causing integration-test false-positives with confusing symptoms. **Fix shape**: extend `extractCheckStatementsFromFile` to emit a tagged union `{ kind: 'add' | 'drop'; name: string; statement?: string }`, and have the outer loop in `extractCheckConstraints` call `byName.delete(name)` on DROP entries. Add a test with `migration_A: ADD "c1"` + `migration_B: DROP "c1"` (no re-add) asserting "c1" is absent from output. **Not a current regression**: all 5 emitted constraints are active in prod. Would bite once confusingly when the first CHECK is eventually retired.
+
 ### 🐛 Detect and Retry Inadequate LLM Responses
 
 LLMs occasionally return a 200 OK with garbage content — e.g., glm-5 returned just `"N" (1 token, finishReason: "unknown"`, 160s duration). Needs compound scoring heuristic + timing data threading through RAGResponse. ~4-6hr feature, not a quick win — moved details to Logging & Error Observability theme.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -88,7 +88,7 @@ _None beyond the above. TTS Engine Upgrade is Active Epic._
 
 _Small tasks that can be done between major features. Good for momentum._
 
-- 🧹 `[CHORE]` **Extend `pnpm ops test:generate-schema` to preserve CHECK constraints** — The PGLite schema file at `packages/test-utils/schema/pglite-schema.sql` has zero `CHECK` constraint DDL despite Phase 5 adding two (`personas_name_non_empty`, `personas_name_not_snowflake`). Root cause: the schema generator builds from Prisma introspection, which has no CHECK-constraint representation, so those DDL lines don't round-trip. Consequence: integration tests against PGLite can't exercise CHECK-constraint rejection behavior — the test harness silently permits values prod Postgres would reject. **Fix shape**: extend the generator to parse `prisma/migrations/**/migration.sql` for `ADD CONSTRAINT "..." CHECK (...)` patterns and append them to the generated schema. One-shot sweep + regeneration. **Once fixed**: `schemaInvariants.int.test.ts` can upgrade from structural (greps migration SQL) to behavioral (inserts bad values and asserts rejection). **Start**: `packages/tooling/src/commands/test.ts` or wherever `test:generate-schema` lives. Surfaced 2026-04-23.
+_Empty — both entries shipped (CHECK extractor in this PR, typing-error classifier in PR #886)._
 
 ### 🐛 Detect and Retry Inadequate LLM Responses
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -88,8 +88,6 @@ _None beyond the above. TTS Engine Upgrade is Active Epic._
 
 _Small tasks that can be done between major features. Good for momentum._
 
-_Empty — both entries shipped (CHECK extractor in this PR, typing-error classifier in PR #886)._
-
 - 🧹 `[CHORE]` **Handle `DROP CONSTRAINT` in pglite CHECK extractor** — Surfaced 2026-04-24 by PR #887 review. `extractCheckConstraints` in `packages/tooling/src/test/generate-schema.ts` tracks ADD statements in a `Map<name, statement>` but ignores `DROP CONSTRAINT` entirely. The drop-and-re-add case works (second ADD overwrites first), but a future migration that drops a CHECK **without re-adding it** would leave the original ADD in the extracted output — PGLite would then enforce a constraint prod Postgres no longer has, causing integration-test false-positives with confusing symptoms. **Fix shape**: extend `extractCheckStatementsFromFile` to emit a tagged union `{ kind: 'add' | 'drop'; name: string; statement?: string }`, and have the outer loop in `extractCheckConstraints` call `byName.delete(name)` on DROP entries. Add a test with `migration_A: ADD "c1"` + `migration_B: DROP "c1"` (no re-add) asserting "c1" is absent from output. **Not a current regression**: all 5 emitted constraints are active in prod. Would bite once confusingly when the first CHECK is eventually retired.
 
 ### 🐛 Detect and Retry Inadequate LLM Responses

--- a/packages/test-utils/schema/pglite-schema.sql
+++ b/packages/test-utils/schema/pglite-schema.sql
@@ -799,3 +799,11 @@ ALTER TABLE "import_jobs" ADD CONSTRAINT "import_jobs_personality_id_fkey" FOREI
 -- AddForeignKey
 ALTER TABLE "export_jobs" ADD CONSTRAINT "export_jobs_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
+-- CHECK constraints harvested from prisma/migrations/**/migration.sql
+-- (Prisma's schema-diff generator has no CHECK-constraint representation,
+-- so they're merged back in here at schema-generation time.)
+ALTER TABLE "personalities" ADD CONSTRAINT "valid_birth_month" CHECK ("birth_month" IS NULL OR ("birth_month" >= 1 AND "birth_month" <= 12));
+ALTER TABLE "personalities" ADD CONSTRAINT "valid_birth_day" CHECK ("birth_day" IS NULL OR ("birth_day" >= 1 AND "birth_day" <= 31));
+ALTER TABLE "personalities" ADD CONSTRAINT "valid_birth_year" CHECK ("birth_year" IS NULL OR ("birth_year" >= 1 AND "birth_year" <= 9999));
+ALTER TABLE "personas" ADD CONSTRAINT "personas_name_non_empty" CHECK (LENGTH(TRIM("name")) > 0);
+ALTER TABLE "personas" ADD CONSTRAINT "personas_name_not_snowflake" CHECK ("name" !~ '^\d{17,19}$');

--- a/packages/tooling/src/test/generate-schema.test.ts
+++ b/packages/tooling/src/test/generate-schema.test.ts
@@ -246,6 +246,47 @@ describe('generateSchema', () => {
       expect(content).toContain('ALTER TABLE "real" ADD CONSTRAINT "real_check" CHECK ("n" > 0);');
     });
 
+    // Block comments matter because `/* foo; bar */` contains a raw `;` that
+    // would split the surrounding statement in half. Without the block-comment
+    // strip, the CHECK after a block-commented prologue would be silently
+    // dropped — the exact failure mode this PR was built to prevent.
+    it('strips /* */ block comments before splitting on ;', async () => {
+      mockMigrations({
+        '20251127110000_block_commented': `
+          /* Drops the old check;
+             a new one follows. */
+          ALTER TABLE "t" ADD CONSTRAINT "c" CHECK ("n" > 0);
+        `,
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
+      expect(content).toContain('ALTER TABLE "t" ADD CONSTRAINT "c" CHECK ("n" > 0);');
+    });
+
+    // If a CHECK constraint name appears in two migrations (e.g., dropped and
+    // re-added), both would land in the output and PGLite would reject the
+    // duplicate `ADD CONSTRAINT` at setup time. First occurrence wins —
+    // chronological ordering above means this matches Postgres's "last write
+    // wins" semantics for the prod database.
+    it('deduplicates CHECK constraints by name across migrations', async () => {
+      mockMigrations({
+        '20251127110000_first': 'ALTER TABLE "t" ADD CONSTRAINT "dup_name" CHECK ("n" > 0);',
+        '20260501000000_second': 'ALTER TABLE "t" ADD CONSTRAINT "dup_name" CHECK ("n" > 100);',
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
+      // First occurrence is kept; later duplicate is silently skipped.
+      const matches = content.match(/ADD CONSTRAINT "dup_name"/g) ?? [];
+      expect(matches).toHaveLength(1);
+      expect(content).toContain('ALTER TABLE "t" ADD CONSTRAINT "dup_name" CHECK ("n" > 0);');
+    });
+
     it('processes migration folders in chronological order', async () => {
       // Later migrations may override/refine earlier ones. Deterministic
       // ordering (by folder name, which carries the YYYYMMDDHHMMSS prefix)

--- a/packages/tooling/src/test/generate-schema.test.ts
+++ b/packages/tooling/src/test/generate-schema.test.ts
@@ -266,25 +266,35 @@ describe('generateSchema', () => {
       expect(content).toContain('ALTER TABLE "t" ADD CONSTRAINT "c" CHECK ("n" > 0);');
     });
 
-    // If a CHECK constraint name appears in two migrations (e.g., dropped and
-    // re-added), both would land in the output and PGLite would reject the
-    // duplicate `ADD CONSTRAINT` at setup time. First occurrence wins —
-    // chronological ordering above means this matches Postgres's "last write
-    // wins" semantics for the prod database.
-    it('deduplicates CHECK constraints by name across migrations', async () => {
+    // Realistic "same name appears twice" shape: migration B drops the
+    // constraint, then re-adds it with a different expression. Without the
+    // dedup, both ADDs would land in the output and PGLite would reject the
+    // second. With dedup, the **last** migration's version must win — that's
+    // what prod Postgres enforces after applying both migrations.
+    //
+    // Two ADDs with no intervening DROP would fail `prisma migrate deploy`
+    // in real Postgres ("constraint already exists"), so we don't test that
+    // shape — it can't appear in a valid migration history.
+    it('keeps the last migration definition when a CHECK is dropped and re-added', async () => {
       mockMigrations({
-        '20251127110000_first': 'ALTER TABLE "t" ADD CONSTRAINT "dup_name" CHECK ("n" > 0);',
-        '20260501000000_second': 'ALTER TABLE "t" ADD CONSTRAINT "dup_name" CHECK ("n" > 100);',
+        '20251127110000_first': 'ALTER TABLE "t" ADD CONSTRAINT "c1" CHECK ("n" > 0);',
+        '20260501000000_second': `
+          ALTER TABLE "t" DROP CONSTRAINT "c1";
+          ALTER TABLE "t" ADD CONSTRAINT "c1" CHECK ("n" > 100);
+        `,
       });
 
       const { generateSchema } = await import('./generate-schema.js');
       await generateSchema();
 
       const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
-      // First occurrence is kept; later duplicate is silently skipped.
-      const matches = content.match(/ADD CONSTRAINT "dup_name"/g) ?? [];
+      // Only one definition of c1 in the output.
+      const matches = content.match(/ADD CONSTRAINT "c1"/g) ?? [];
       expect(matches).toHaveLength(1);
-      expect(content).toContain('ALTER TABLE "t" ADD CONSTRAINT "dup_name" CHECK ("n" > 0);');
+      // The winning definition is the later one (n > 100), matching the
+      // state prod Postgres is in after applying both migrations.
+      expect(content).toContain('ALTER TABLE "t" ADD CONSTRAINT "c1" CHECK ("n" > 100);');
+      expect(content).not.toContain('CHECK ("n" > 0)');
     });
 
     it('processes migration folders in chronological order', async () => {

--- a/packages/tooling/src/test/generate-schema.test.ts
+++ b/packages/tooling/src/test/generate-schema.test.ts
@@ -17,9 +17,16 @@ vi.mock('node:child_process', () => ({
   execFileSync: execFileSyncMock,
 }));
 
-// Mock fs
+// Mock fs — include the new CHECK-constraint extraction surface. Each fn is
+// typed to match the real signature so tests can install `mockImplementation`
+// that reads the path argument without tripping TS strict-mode overload checks.
 const fsMock = {
-  writeFileSync: vi.fn(),
+  writeFileSync: vi.fn<(path: string, content: string) => void>(),
+  existsSync: vi.fn<(path: string) => boolean>(() => false),
+  readdirSync: vi.fn<
+    (path: string, opts?: unknown) => Array<{ name: string; isDirectory: () => boolean }>
+  >(() => []),
+  readFileSync: vi.fn<(path: string, encoding?: string) => string>(() => ''),
 };
 vi.mock('node:fs', () => fsMock);
 
@@ -37,6 +44,13 @@ describe('generateSchema', () => {
 
     // Default: successful prisma migrate diff
     execFileSyncMock.mockReturnValue('CREATE TABLE users (id INT);');
+
+    // Reset fs mock defaults — `vi.clearAllMocks()` only clears call history,
+    // not implementations, so CHECK-constraint tests that install their own
+    // `mockImplementation` would otherwise leak into later tests.
+    fsMock.existsSync.mockReturnValue(false);
+    fsMock.readdirSync.mockReturnValue([]);
+    fsMock.readFileSync.mockReturnValue('');
   });
 
   afterEach(() => {
@@ -107,6 +121,185 @@ describe('generateSchema', () => {
       const output = consoleLogSpy.mock.calls.flat().join(' ');
       expect(output).toContain('Generated');
       expect(output).toContain('3 lines');
+    });
+  });
+
+  describe('CHECK-constraint preservation', () => {
+    /**
+     * Build a mock-fs layout for a set of migrations. Each entry becomes a
+     * directory under prisma/migrations/ with the provided SQL inside.
+     */
+    function mockMigrations(migrations: Record<string, string>): void {
+      fsMock.existsSync.mockImplementation((path: string) => {
+        // migrations dir always exists in this test
+        if (path.endsWith('prisma/migrations')) return true;
+        // migration.sql exists only for entries in the map
+        for (const name of Object.keys(migrations)) {
+          if (path.endsWith(`${name}/migration.sql`)) return true;
+        }
+        return false;
+      });
+      fsMock.readdirSync.mockImplementation(() =>
+        Object.keys(migrations).map(name => ({
+          name,
+          isDirectory: () => true,
+        }))
+      );
+      fsMock.readFileSync.mockImplementation((path: string) => {
+        for (const [name, sql] of Object.entries(migrations)) {
+          if (path.endsWith(`${name}/migration.sql`)) return sql;
+        }
+        return '';
+      });
+    }
+
+    it('extracts a single-line ADD CONSTRAINT CHECK statement', async () => {
+      mockMigrations({
+        '20251127110000_add_checks':
+          'ALTER TABLE "users" ADD CONSTRAINT "valid_month" CHECK ("m" >= 1 AND "m" <= 12);',
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
+      expect(content).toContain(
+        'ALTER TABLE "users" ADD CONSTRAINT "valid_month" CHECK ("m" >= 1 AND "m" <= 12);'
+      );
+    });
+
+    it('extracts multi-line ADD CONSTRAINT CHECK statements, normalizing whitespace', async () => {
+      mockMigrations({
+        '20260416164756_phase_5': `
+          ALTER TABLE "personas"
+            ADD CONSTRAINT "personas_name_non_empty" CHECK (LENGTH(TRIM("name")) > 0);
+
+          ALTER TABLE "personas"
+            ADD CONSTRAINT "personas_name_not_snowflake" CHECK ("name" !~ '^\\d{17,19}$');
+        `,
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
+      expect(content).toContain(
+        'ALTER TABLE "personas" ADD CONSTRAINT "personas_name_non_empty" CHECK (LENGTH(TRIM("name")) > 0);'
+      );
+      expect(content).toContain(
+        `ALTER TABLE "personas" ADD CONSTRAINT "personas_name_not_snowflake" CHECK ("name" !~ '^\\d{17,19}$');`
+      );
+    });
+
+    it('preserves CHECK expressions with nested parentheses', async () => {
+      // Parens inside the CHECK expression would confuse any regex that tries
+      // to balance them; the split-on-; approach handles this cleanly.
+      mockMigrations({
+        '20251127110000_nested':
+          'ALTER TABLE "t" ADD CONSTRAINT "c" CHECK ("x" IS NULL OR ("x" >= 1 AND "x" <= 12));',
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
+      expect(content).toContain(
+        'ALTER TABLE "t" ADD CONSTRAINT "c" CHECK ("x" IS NULL OR ("x" >= 1 AND "x" <= 12));'
+      );
+    });
+
+    it('ignores non-CHECK constraints (foreign keys, unique)', async () => {
+      // A foreign-key add-constraint is NOT a CHECK. The extractor must leave
+      // those to Prisma's own generator — otherwise we'd double-add FKs.
+      mockMigrations({
+        '20251127110000_mixed': `
+          ALTER TABLE "a" ADD CONSTRAINT "a_b_fkey" FOREIGN KEY ("b") REFERENCES "b"("id");
+          ALTER TABLE "c" ADD CONSTRAINT "c_unique" UNIQUE ("name");
+          ALTER TABLE "d" ADD CONSTRAINT "d_check" CHECK ("n" > 0);
+        `,
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
+      expect(content).toContain('ALTER TABLE "d" ADD CONSTRAINT "d_check" CHECK ("n" > 0);');
+      expect(content).not.toContain('a_b_fkey');
+      expect(content).not.toContain('c_unique');
+    });
+
+    it('strips -- single-line comments before splitting on ;', async () => {
+      // If comments were preserved, splitting on `;` would leave comment text
+      // attached to the next statement and the CHECK-detection regex would
+      // fail to anchor on ALTER TABLE.
+      mockMigrations({
+        '20251127110000_commented': `
+          -- This comment mentions ADD CONSTRAINT CHECK and contains fake SQL;
+          ALTER TABLE "real" ADD CONSTRAINT "real_check" CHECK ("n" > 0);
+        `,
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
+      expect(content).toContain('ALTER TABLE "real" ADD CONSTRAINT "real_check" CHECK ("n" > 0);');
+    });
+
+    it('processes migration folders in chronological order', async () => {
+      // Later migrations may override/refine earlier ones. Deterministic
+      // ordering (by folder name, which carries the YYYYMMDDHHMMSS prefix)
+      // means the output is reproducible across machines and over time.
+      mockMigrations({
+        '20260501000000_later': 'ALTER TABLE "t" ADD CONSTRAINT "second" CHECK ("n" > 100);',
+        '20251127110000_earlier': 'ALTER TABLE "t" ADD CONSTRAINT "first" CHECK ("n" > 0);',
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
+      const firstPos = content.indexOf('"first"');
+      const secondPos = content.indexOf('"second"');
+      expect(firstPos).toBeGreaterThan(-1);
+      expect(secondPos).toBeGreaterThan(firstPos);
+    });
+
+    it('reports the CHECK count in the success message', async () => {
+      mockMigrations({
+        '20251127110000_two': `
+          ALTER TABLE "t" ADD CONSTRAINT "a" CHECK ("x" > 0);
+          ALTER TABLE "t" ADD CONSTRAINT "b" CHECK ("y" > 0);
+        `,
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const output = consoleLogSpy.mock.calls.flat().join(' ');
+      expect(output).toContain('2 CHECK constraints preserved');
+    });
+
+    it('does not add the CHECK-constraint banner when no CHECKs exist', async () => {
+      mockMigrations({
+        '20251127110000_none':
+          'ALTER TABLE "t" ADD CONSTRAINT "fk" FOREIGN KEY ("b") REFERENCES "b"("id");',
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
+      expect(content).not.toContain('CHECK constraints harvested from');
+    });
+
+    it('handles missing migrations directory gracefully', async () => {
+      // Fresh clones / CI cache-miss scenarios may not have migrations yet.
+      // The extractor should noop rather than throw.
+      fsMock.existsSync.mockReturnValue(false);
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await expect(generateSchema()).resolves.not.toThrow();
     });
   });
 

--- a/packages/tooling/src/test/generate-schema.ts
+++ b/packages/tooling/src/test/generate-schema.ts
@@ -19,6 +19,18 @@ import chalk from 'chalk';
  */
 const DUMMY_DATABASE_URL = 'postgres://x:x@x/x';
 
+/**
+ * Header preceding appended CHECK statements in the generated schema. Spelled
+ * out as a constant (rather than inlined into the template literal) so a
+ * reader scanning `generateSchema()` sees the intent immediately instead of
+ * parsing an escaped-newline blob.
+ */
+const CHECK_CONSTRAINT_BANNER = [
+  '-- CHECK constraints harvested from prisma/migrations/**/migration.sql',
+  "-- (Prisma's schema-diff generator has no CHECK-constraint representation,",
+  "-- so they're merged back in here at schema-generation time.)",
+].join('\n');
+
 interface GenerateSchemaOptions {
   output?: string;
 }
@@ -37,17 +49,16 @@ interface GenerateSchemaOptions {
  * tokens (some migrations wrap after `ALTER TABLE`, others are single-line).
  * Case-insensitive to match either SQL convention.
  */
-const CHECK_CONSTRAINT_REGEX = /^ALTER\s+TABLE\s+"[^"]+"\s+ADD\s+CONSTRAINT\s+"[^"]+"\s+CHECK\b/i;
-
 /**
- * Extract all `ADD CONSTRAINT ... CHECK (...)` statements from every
- * `migration.sql` under `migrationsDir`, returned in chronological order
- * (sorted by directory name — Prisma's YYYYMMDDHHMMSS_ prefix sorts correctly).
- * Statements are returned normalized to single-line form, each terminated
- * with a semicolon.
+ * Matches an `ALTER TABLE ... ADD CONSTRAINT "<name>" CHECK (...)` statement
+ * and captures the constraint name. Because `"[^"]+"` requires at least one
+ * character inside the quotes, a successful match guarantees group 1 is a
+ * non-empty string — see type narrowing in `extractCheckStatementsFromFile`.
  */
+const CHECK_CONSTRAINT_REGEX = /^ALTER\s+TABLE\s+"[^"]+"\s+ADD\s+CONSTRAINT\s+"([^"]+)"\s+CHECK\b/i;
+
 interface ExtractedCheck {
-  name: string | undefined;
+  name: string;
   statement: string;
 }
 
@@ -70,17 +81,32 @@ function extractCheckStatementsFromFile(sqlPath: string): ExtractedCheck[] {
   for (const stmt of uncommented.split(';')) {
     const trimmed = stmt.trim();
     if (trimmed.length === 0) continue;
-    if (!CHECK_CONSTRAINT_REGEX.test(trimmed)) continue;
+    const match = CHECK_CONSTRAINT_REGEX.exec(trimmed);
+    if (match === null) continue;
+    const name = match[1];
+    // Unreachable per regex (`"[^"]+"` requires the capture), but TS sees
+    // match[1] as string | undefined.
+    if (name === undefined) continue;
 
-    const nameMatch = /ADD\s+CONSTRAINT\s+"([^"]+)"/i.exec(trimmed);
     results.push({
-      name: nameMatch?.[1],
+      name,
       statement: normalizeStatement(trimmed) + ';',
     });
   }
   return results;
 }
 
+/**
+ * Extract all `ADD CONSTRAINT ... CHECK (...)` statements from every
+ * `migration.sql` under `migrationsDir`. When the same constraint name
+ * appears in multiple migrations (drop + re-add across two files), the
+ * **last** migration's definition wins — this matches Postgres's own
+ * semantics: after migration B drops and re-adds `c1`, prod enforces
+ * migration B's CHECK expression, not migration A's. First-wins would
+ * silently ship migration A's (stale) definition into PGLite while prod
+ * runs migration B's, re-introducing the fidelity gap this extractor
+ * was built to eliminate.
+ */
 export function extractCheckConstraints(migrationsDir: string): string[] {
   if (!existsSync(migrationsDir)) {
     return [];
@@ -91,27 +117,21 @@ export function extractCheckConstraints(migrationsDir: string): string[] {
     .map(d => d.name)
     .sort();
 
-  const checkStatements: string[] = [];
-  // Dedup by constraint name: same name appearing in two migrations (unlikely
-  // with Prisma's workflow, but possible if a CHECK is dropped and re-added)
-  // would produce duplicate `ADD CONSTRAINT` statements, which PGLite rejects
-  // with a confusing runtime error. First occurrence wins — chronological
-  // sort above ensures this matches Postgres's own "last write wins" (the
-  // later migration has already overwritten the earlier one in prod).
-  const seenNames = new Set<string>();
+  // Map.set overwrites existing entries while preserving insertion order.
+  // Iterating chronologically means later migrations replace earlier ones
+  // by name while the overall emission order stays deterministic.
+  const byName = new Map<string, string>();
 
   for (const folder of migrationFolders) {
     const sqlPath = join(migrationsDir, folder, 'migration.sql');
     if (!existsSync(sqlPath)) continue;
 
     for (const { name, statement } of extractCheckStatementsFromFile(sqlPath)) {
-      if (name !== undefined && seenNames.has(name)) continue;
-      if (name !== undefined) seenNames.add(name);
-      checkStatements.push(statement);
+      byName.set(name, statement);
     }
   }
 
-  return checkStatements;
+  return Array.from(byName.values());
 }
 
 /** Collapse internal whitespace so each statement ends up on one line. */
@@ -157,7 +177,7 @@ export async function generateSchema(options: GenerateSchemaOptions = {}): Promi
     const checkStatements = extractCheckConstraints(migrationsDir);
     const sql =
       checkStatements.length > 0
-        ? `${baseSql.trimEnd()}\n\n-- CHECK constraints harvested from prisma/migrations/**/migration.sql\n-- (Prisma's schema-diff generator has no CHECK-constraint representation,\n-- so they're merged back in here at schema-generation time.)\n${checkStatements.join('\n')}\n`
+        ? `${baseSql.trimEnd()}\n\n${CHECK_CONSTRAINT_BANNER}\n${checkStatements.join('\n')}\n`
         : baseSql;
 
     // Write output

--- a/packages/tooling/src/test/generate-schema.ts
+++ b/packages/tooling/src/test/generate-schema.ts
@@ -113,6 +113,8 @@ export function extractCheckConstraints(migrationsDir: string): string[] {
   const migrationFolders = readdirSync(migrationsDir, { withFileTypes: true })
     .filter(d => d.isDirectory())
     .map(d => d.name)
+    // Prisma prefixes folders with `YYYYMMDDHHMMSS_`, so lexicographic sort
+    // matches chronological sort — essential for the last-wins dedup below.
     .sort();
 
   // Map.set overwrites existing entries while preserving insertion order.

--- a/packages/tooling/src/test/generate-schema.ts
+++ b/packages/tooling/src/test/generate-schema.ts
@@ -46,6 +46,41 @@ const CHECK_CONSTRAINT_REGEX = /^ALTER\s+TABLE\s+"[^"]+"\s+ADD\s+CONSTRAINT\s+"[
  * Statements are returned normalized to single-line form, each terminated
  * with a semicolon.
  */
+interface ExtractedCheck {
+  name: string | undefined;
+  statement: string;
+}
+
+/**
+ * Parse one migration.sql file and return its CHECK-constraint statements.
+ * Strips both line-comments and block-comments before splitting on `;` —
+ * block comments matter because a block-comment body can contain a raw `;`
+ * that would split the surrounding statement in half and silently drop the
+ * CHECK that followed.
+ */
+function extractCheckStatementsFromFile(sqlPath: string): ExtractedCheck[] {
+  const raw = readFileSync(sqlPath, 'utf-8');
+  const uncommented = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/--[^\n]*/g, '');
+  const results: ExtractedCheck[] = [];
+
+  // Prisma migrations use ; as the unambiguous statement terminator even
+  // across line breaks. CHECK expressions can contain nested parens but never
+  // a raw ;. Splitting here is safer than a multi-line regex that has to
+  // balance parens.
+  for (const stmt of uncommented.split(';')) {
+    const trimmed = stmt.trim();
+    if (trimmed.length === 0) continue;
+    if (!CHECK_CONSTRAINT_REGEX.test(trimmed)) continue;
+
+    const nameMatch = /ADD\s+CONSTRAINT\s+"([^"]+)"/i.exec(trimmed);
+    results.push({
+      name: nameMatch?.[1],
+      statement: normalizeStatement(trimmed) + ';',
+    });
+  }
+  return results;
+}
+
 export function extractCheckConstraints(migrationsDir: string): string[] {
   if (!existsSync(migrationsDir)) {
     return [];
@@ -57,29 +92,22 @@ export function extractCheckConstraints(migrationsDir: string): string[] {
     .sort();
 
   const checkStatements: string[] = [];
+  // Dedup by constraint name: same name appearing in two migrations (unlikely
+  // with Prisma's workflow, but possible if a CHECK is dropped and re-added)
+  // would produce duplicate `ADD CONSTRAINT` statements, which PGLite rejects
+  // with a confusing runtime error. First occurrence wins — chronological
+  // sort above ensures this matches Postgres's own "last write wins" (the
+  // later migration has already overwritten the earlier one in prod).
+  const seenNames = new Set<string>();
 
   for (const folder of migrationFolders) {
     const sqlPath = join(migrationsDir, folder, 'migration.sql');
-    if (!existsSync(sqlPath)) {
-      continue;
-    }
+    if (!existsSync(sqlPath)) continue;
 
-    const raw = readFileSync(sqlPath, 'utf-8');
-    // Strip single-line -- comments before splitting on ; so a commented-out
-    // statement doesn't leak into extraction and the following real statement
-    // doesn't get prefixed with comment text.
-    const uncommented = raw.replace(/--[^\n]*/g, '');
-
-    // Prisma migrations use ; as the unambiguous statement terminator even
-    // across line breaks. CHECK expressions can contain nested parens but never
-    // a raw ;. Splitting here is safer than a multi-line regex that has to
-    // balance parens.
-    for (const stmt of uncommented.split(';')) {
-      const trimmed = stmt.trim();
-      if (trimmed.length === 0) continue;
-      if (CHECK_CONSTRAINT_REGEX.test(trimmed)) {
-        checkStatements.push(normalizeStatement(trimmed) + ';');
-      }
+    for (const { name, statement } of extractCheckStatementsFromFile(sqlPath)) {
+      if (name !== undefined && seenNames.has(name)) continue;
+      if (name !== undefined) seenNames.add(name);
+      checkStatements.push(statement);
     }
   }
 

--- a/packages/tooling/src/test/generate-schema.ts
+++ b/packages/tooling/src/test/generate-schema.ts
@@ -8,7 +8,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { writeFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import chalk from 'chalk';
 
@@ -24,12 +24,81 @@ interface GenerateSchemaOptions {
 }
 
 /**
+ * Match an ALTER TABLE … ADD CONSTRAINT … CHECK (…) statement.
+ *
+ * Prisma's `migrate diff --from-empty` is based on schema introspection, which
+ * has no representation for CHECK constraints — so any CHECK added via a
+ * hand-written migration is silently dropped from the generated SQL. Without
+ * this extractor, integration tests against PGLite would permit values prod
+ * Postgres rejects (empty persona names, snowflake-shaped names, etc.). We
+ * sweep migrations for CHECK statements and append them to the output.
+ *
+ * The regex is intentionally permissive about whitespace/newlines between
+ * tokens (some migrations wrap after `ALTER TABLE`, others are single-line).
+ * Case-insensitive to match either SQL convention.
+ */
+const CHECK_CONSTRAINT_REGEX = /^ALTER\s+TABLE\s+"[^"]+"\s+ADD\s+CONSTRAINT\s+"[^"]+"\s+CHECK\b/i;
+
+/**
+ * Extract all `ADD CONSTRAINT ... CHECK (...)` statements from every
+ * `migration.sql` under `migrationsDir`, returned in chronological order
+ * (sorted by directory name — Prisma's YYYYMMDDHHMMSS_ prefix sorts correctly).
+ * Statements are returned normalized to single-line form, each terminated
+ * with a semicolon.
+ */
+export function extractCheckConstraints(migrationsDir: string): string[] {
+  if (!existsSync(migrationsDir)) {
+    return [];
+  }
+
+  const migrationFolders = readdirSync(migrationsDir, { withFileTypes: true })
+    .filter(d => d.isDirectory())
+    .map(d => d.name)
+    .sort();
+
+  const checkStatements: string[] = [];
+
+  for (const folder of migrationFolders) {
+    const sqlPath = join(migrationsDir, folder, 'migration.sql');
+    if (!existsSync(sqlPath)) {
+      continue;
+    }
+
+    const raw = readFileSync(sqlPath, 'utf-8');
+    // Strip single-line -- comments before splitting on ; so a commented-out
+    // statement doesn't leak into extraction and the following real statement
+    // doesn't get prefixed with comment text.
+    const uncommented = raw.replace(/--[^\n]*/g, '');
+
+    // Prisma migrations use ; as the unambiguous statement terminator even
+    // across line breaks. CHECK expressions can contain nested parens but never
+    // a raw ;. Splitting here is safer than a multi-line regex that has to
+    // balance parens.
+    for (const stmt of uncommented.split(';')) {
+      const trimmed = stmt.trim();
+      if (trimmed.length === 0) continue;
+      if (CHECK_CONSTRAINT_REGEX.test(trimmed)) {
+        checkStatements.push(normalizeStatement(trimmed) + ';');
+      }
+    }
+  }
+
+  return checkStatements;
+}
+
+/** Collapse internal whitespace so each statement ends up on one line. */
+function normalizeStatement(stmt: string): string {
+  return stmt.replace(/\s+/g, ' ').trim();
+}
+
+/**
  * Generate PGLite-compatible SQL schema from Prisma
  */
 export async function generateSchema(options: GenerateSchemaOptions = {}): Promise<void> {
   const rootDir = process.cwd();
   const outputPath =
     options.output ?? join(rootDir, 'packages', 'test-utils', 'schema', 'pglite-schema.sql');
+  const migrationsDir = join(rootDir, 'prisma', 'migrations');
 
   console.log(chalk.cyan('Generating PGLite schema from Prisma...'));
 
@@ -42,7 +111,7 @@ export async function generateSchema(options: GenerateSchemaOptions = {}): Promi
 
     // Run prisma migrate diff using execFileSync (no shell injection)
     const schemaPath = join(rootDir, 'prisma', 'schema.prisma');
-    const sql = execFileSync(
+    const baseSql = execFileSync(
       'npx',
       ['prisma', 'migrate', 'diff', '--from-empty', '--to-schema', schemaPath, '--script'],
       {
@@ -53,13 +122,27 @@ export async function generateSchema(options: GenerateSchemaOptions = {}): Promi
       }
     );
 
+    // Append CHECK constraints harvested from migration SQL. Prisma's schema-
+    // level diff doesn't represent CHECK constraints, so they must be merged
+    // in post-hoc or PGLite-backed tests silently accept values Postgres would
+    // reject.
+    const checkStatements = extractCheckConstraints(migrationsDir);
+    const sql =
+      checkStatements.length > 0
+        ? `${baseSql.trimEnd()}\n\n-- CHECK constraints harvested from prisma/migrations/**/migration.sql\n-- (Prisma's schema-diff generator has no CHECK-constraint representation,\n-- so they're merged back in here at schema-generation time.)\n${checkStatements.join('\n')}\n`
+        : baseSql;
+
     // Write output
     writeFileSync(outputPath, sql);
 
     // Count lines
     const lines = sql.split('\n').length;
 
-    console.log(chalk.green(`Generated ${outputPath} (${lines} lines)`));
+    console.log(
+      chalk.green(
+        `Generated ${outputPath} (${lines} lines, ${checkStatements.length} CHECK constraints preserved)`
+      )
+    );
     console.log(chalk.dim('Remember to commit the updated schema file.'));
   } catch (error) {
     console.error(chalk.red('Failed to generate schema'));

--- a/packages/tooling/src/test/generate-schema.ts
+++ b/packages/tooling/src/test/generate-schema.ts
@@ -36,24 +36,22 @@ interface GenerateSchemaOptions {
 }
 
 /**
- * Match an ALTER TABLE … ADD CONSTRAINT … CHECK (…) statement.
+ * Matches an `ALTER TABLE ... ADD CONSTRAINT "<name>" CHECK (...)` statement
+ * and captures the constraint name.
  *
- * Prisma's `migrate diff --from-empty` is based on schema introspection, which
- * has no representation for CHECK constraints — so any CHECK added via a
- * hand-written migration is silently dropped from the generated SQL. Without
- * this extractor, integration tests against PGLite would permit values prod
- * Postgres rejects (empty persona names, snowflake-shaped names, etc.). We
- * sweep migrations for CHECK statements and append them to the output.
+ * Why this extractor exists: Prisma's `migrate diff --from-empty` is
+ * introspection-based and has no representation for CHECK constraints — so
+ * any CHECK added via a hand-written migration is silently dropped from the
+ * generated SQL. Without this harvest, integration tests against PGLite
+ * would permit values prod Postgres rejects (empty persona names,
+ * snowflake-shaped names, birthday out-of-range, etc.).
  *
  * The regex is intentionally permissive about whitespace/newlines between
  * tokens (some migrations wrap after `ALTER TABLE`, others are single-line).
- * Case-insensitive to match either SQL convention.
- */
-/**
- * Matches an `ALTER TABLE ... ADD CONSTRAINT "<name>" CHECK (...)` statement
- * and captures the constraint name. Because `"[^"]+"` requires at least one
- * character inside the quotes, a successful match guarantees group 1 is a
- * non-empty string — see type narrowing in `extractCheckStatementsFromFile`.
+ * Case-insensitive to match either SQL convention. `"[^"]+"` requires at
+ * least one character inside the quotes, so a successful match guarantees
+ * group 1 is a non-empty string (see narrowing in
+ * `extractCheckStatementsFromFile`).
  */
 const CHECK_CONSTRAINT_REGEX = /^ALTER\s+TABLE\s+"[^"]+"\s+ADD\s+CONSTRAINT\s+"([^"]+)"\s+CHECK\b/i;
 


### PR DESCRIPTION
## Summary

\`pnpm ops test:generate-schema\` runs \`prisma migrate diff --from-empty\`, which is schema-introspection-based and has no representation for CHECK constraints. Result: any CHECK added via a hand-written migration (birthday range checks, persona name non-empty, persona name not snowflake) was silently dropped from \`packages/test-utils/schema/pglite-schema.sql\` — PGLite-backed integration tests permitted values prod Postgres would reject.

This PR adds a post-hoc extraction step that sweeps \`prisma/migrations/**/migration.sql\` for \`ADD CONSTRAINT ... CHECK (...)\` statements and appends them to the generated schema.

## What changed

- **New**: \`extractCheckConstraints(migrationsDir)\` helper in \`generate-schema.ts\`. Scans every \`migration.sql\` in chronological order (by folder name — Prisma's YYYYMMDDHHMMSS prefix sorts correctly), strips \`--\` line comments, splits on \`;\`, filters for \`ALTER TABLE \"...\" ADD CONSTRAINT \"...\" CHECK\` shape, normalizes whitespace to single-line form.
- **Updated**: \`generateSchema()\` appends extracted CHECKs under a banner comment explaining why they had to be harvested out-of-band.
- **Regenerated**: \`pglite-schema.sql\` now contains the 5 existing constraints:
  - \`valid_birth_month\`, \`valid_birth_day\`, \`valid_birth_year\` (Phase 5 personalities)
  - \`personas_name_non_empty\`, \`personas_name_not_snowflake\` (Identity Epic Phase 5)

## Design choices

- **Split on \`;\` rather than regex-match the full statement** — CHECK expressions contain nested parens (e.g., \`CHECK (\"x\" IS NULL OR (\"x\" >= 1 AND \"x\" <= 12))\`). Balancing parens inside a regex is fragile; splitting on the unambiguous \`;\` terminator is simpler and covers every observed migration shape.
- **Strip \`--\` comments before splitting** — prevents commented-out fake statements in docstrings from leaking into extraction, and prevents comment text from attaching to the following real statement.
- **Normalize whitespace to single-line** — generated schema stays readable; multi-line formatting in the source migration was for human commenting, not DDL semantics.

## Tests

- **New**: 9 tests in \`generate-schema.test.ts\` covering single-line extraction, multi-line extraction with whitespace normalization, nested parens, FK/UNIQUE filtering (non-CHECK statements must pass through untouched), comment stripping, chronological ordering, empty case, missing-migrations-dir noop.
- Regenerated schema verified locally: 810 lines, 5 CHECK constraints preserved.

## Follow-up (not this PR)

Unlocks upgrading \`schemaInvariants.int.test.ts\` from structural (greps migration SQL) to behavioral (inserts bad values and asserts rejection). Tracked separately; not in scope for this Quick Win.

## Test plan

- [ ] CI green
- [ ] Verify \`pnpm ops test:generate-schema\` locally produces identical output to the committed \`pglite-schema.sql\`
- [ ] Spot-check the regenerated schema ends with the 5 CHECK statements

🤖 Generated with [Claude Code](https://claude.com/claude-code)