### PR TITLE
refactor(bot-client): redesign /inspect embed for post-PR-#895 diagnostic shape

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -86,6 +86,24 @@ The Identity & Provisioning Hardening Epic shipped end-to-end as of 2026-04-23 (
 
 Promoted from Inbox 2026-04-22.
 
+### Inspect UX Hardening (mini-epic)
+
+_Focus: bring `/inspect` up to par after PR #895 changed the diagnostic shape, plus close the long-standing character-card privacy issue while we're touching the code. 5 PRs, smallest-first._
+
+**Sequence:**
+
+1. **Embed redesign** (Tier 1 + 2 + L) — drop the now-misleading "Interception: `<reasoning>` tags not found ❌" line; surface `upstreamProvider`; show API→Pipeline extraction chain; clarify `Provider:z-ai` (model namespace ≠ upstream OpenRouter provider); color/emoji-code `finishReason`; show memory score range; "(none triggered)" indicator on stop-sequence; remove duplicate completion-tokens display; better select-menu placeholder; reasoning button shows byte-size hint. ~50 line surface.
+
+2. **Privacy redaction for non-owners** _(closes long-standing backlog item — supersedes the prior "Inspect command privacy toggle" entry)_ — gateway endpoint joins `LlmDiagnosticLog` ↔ `Personality` and surfaces `ownerId` in admin-diagnostic responses. Bot-client threads `canViewCharacter` through view builders. **Redact for non-owners**: System Prompt (XML), Full JSON's `assembledPrompt.messages[0].content`, Compact JSON's memory previews, Memory Inspector previews. **Keep visible** for non-owners: reasoning content (model thinking is genuinely interesting; user already saw the response anyway). **Admin sees everything** (bot owner has DB access regardless). `isPublic` flag is irrelevant — public means "available to chat with," not "internals visible." Replace redacted views with explicit `🔒 Character card hidden (owned by another user)` so users know it's deliberate. ~200 line surface.
+
+3. **New diagnostic views** (Tier 3 J + M) — Pipeline Health view (single-screen success/failure for `thinking_extraction`, `artifact_strip`, deduplication, memory budget) and Quick-copy summary (one-line text affordance for sharing in incident threads, e.g. `glm-4.7 via DekaLLM • 9.6s • 47 tok • thinking 1063 chars`). ~100 line surface.
+
+4. **Memory Inspector filtering** (Tier 3 K) — stateful filter buttons (Included / Dropped / Top-N) on the Memory Inspector view. State encoded in customId (no closures, restart-safe per `04-discord.md`). ~150 line surface.
+
+5. **Cleanup** — `git rm scripts/src/glm47-failure-segmentation.ts` (purpose served by `upstreamProvider` field in `/inspect`) + remove the corresponding Quick Wins entry. ~5 line surface.
+
+Surfaced 2026-04-25 by user dev-deploy validation of PR #895.
+
 ### Other in-flight
 
 _None beyond the above. TTS Engine Upgrade is Active Epic._
@@ -945,7 +963,7 @@ _Items moved from Inbox during backlog-shrink pass. Full prose preserved — imp
 
 - 🏗️ `[LIFT]` **Dynamic free model selection from OpenRouter** — Replace hardcoded `FREE_MODELS` / `VISION_FALLBACK_FREE` with a query layer on `OpenRouterModelCache`. Models go stale when sunset. **Start**: `services/api-gateway/src/services/OpenRouterModelCache.ts`.
 
-- ✨ `[FEAT]` **Inspect command privacy toggle** — Per-personality toggle to hide character card details from `/inspect`.
+<!-- "Inspect command privacy toggle" entry superseded 2026-04-25 by the Inspect UX Hardening mini-epic in Current Focus, which implements default-on redaction for non-owners (no per-personality toggle needed). -->
 
 - ✨ `[FEAT]` **Character import — optional voice file support** — Accept optional voice reference audio alongside character data import.
 

--- a/packages/common-types/src/types/diagnostic.ts
+++ b/packages/common-types/src/types/diagnostic.ts
@@ -218,10 +218,16 @@ export interface DiagnosticLlmResponse {
     responseMetadataKeys: string[];
     /** Whether reasoning_details array exists in response_metadata */
     hasReasoningDetails: boolean;
-    /** Whether <reasoning> tags were found in raw content (proves interception worked) */
+    /** Whether <reasoning> tags were found in raw content. Always false post-PR-#895 (reasoning extraction moved from transport-layer tag injection to consumer-layer kwargs population) — kept for backward compatibility with old logs. */
     hasReasoningTagsInContent: boolean;
     /** First ~200 chars of raw content for quick visual inspection */
     rawContentPreview: string;
+    /** Actual upstream OpenRouter provider that handled the request (e.g. "Parasail", "Chutes", "DekaLLM"). Distinct from LangChain's hardcoded `response_metadata.model_provider = "openai"`. Populated by extractAndPopulateOpenRouterReasoning post-PR-#895. */
+    upstreamProvider?: string;
+    /** Keys present on raw API response `choices[0].message`. Distinguishes "model returned structured reasoning" (includes `reasoning`/`reasoning_details`) from "model embedded planning into content directly" (just `role`/`content`). Populated post-PR-#895. */
+    apiMessageKeys?: string[];
+    /** Length of `message.reasoning` from the raw OpenRouter response, captured BEFORE the consumer-layer extractor runs. Compared with reasoningKwargsLength to detect leak class: zero = model emitted no structured reasoning; mismatch = pipeline lost data. Populated post-PR-#895. */
+    apiReasoningLength?: number;
   };
 }
 

--- a/services/bot-client/src/commands/inspect/browse.ts
+++ b/services/bot-client/src/commands/inspect/browse.ts
@@ -312,7 +312,10 @@ export async function handleBrowseLogSelection(
     }
 
     const embed = buildDiagnosticEmbed(result.log.data);
-    const inspectComponents = buildInspectComponents(result.log.requestId);
+    const inspectComponents = buildInspectComponents(
+      result.log.requestId,
+      result.log.data.postProcessing.thinkingContent?.length ?? 0
+    );
     const backRow = buildBackToListRow(parsed.page);
 
     await interaction.editReply({

--- a/services/bot-client/src/commands/inspect/components.test.ts
+++ b/services/bot-client/src/commands/inspect/components.test.ts
@@ -31,4 +31,34 @@ describe('buildInspectComponents', () => {
     const button = buttonRow.components[0].toJSON();
     expect('custom_id' in button && button.custom_id).toContain('inspect::');
   });
+
+  it('omits byte hint on View Reasoning button when thinking length is 0 / not passed', () => {
+    const rows = buildInspectComponents('test-req');
+    const reasoningButton = rows[0].components[0].toJSON();
+    expect('label' in reasoningButton && reasoningButton.label).toBe('View Reasoning');
+  });
+
+  it('shows raw count when thinking content is under 1k chars', () => {
+    const rows = buildInspectComponents('test-req', 250);
+    const reasoningButton = rows[0].components[0].toJSON();
+    expect('label' in reasoningButton && reasoningButton.label).toBe('View Reasoning (250)');
+  });
+
+  it('shows X.Xk format for 1k-99k char range', () => {
+    const rows = buildInspectComponents('test-req', 1063);
+    const reasoningButton = rows[0].components[0].toJSON();
+    expect('label' in reasoningButton && reasoningButton.label).toBe('View Reasoning (1.1k)');
+  });
+
+  it('shows integer Xk format for 100k+ chars', () => {
+    const rows = buildInspectComponents('test-req', 145_300);
+    const reasoningButton = rows[0].components[0].toJSON();
+    expect('label' in reasoningButton && reasoningButton.label).toBe('View Reasoning (145k)');
+  });
+
+  it('uses the more-descriptive select-menu placeholder', () => {
+    const rows = buildInspectComponents('test-req');
+    const selectMenu = rows[1].components[0].toJSON();
+    expect('placeholder' in selectMenu && selectMenu.placeholder).toBe('More diagnostic views…');
+  });
 });

--- a/services/bot-client/src/commands/inspect/components.ts
+++ b/services/bot-client/src/commands/inspect/components.ts
@@ -13,51 +13,80 @@ import { DebugViewType } from './types.js';
 import { InspectCustomIds } from './customIds.js';
 
 /**
- * Build the button row and select menu row for the diagnostic summary embed
+ * Format a byte count for compact display in a button label.
+ * 0 → null (caller should hide the hint)
+ * 1-999 → "(N)"
+ * 1k-99k → "(X.Xk)"
+ * 100k+ → "(XXk)"
+ */
+function formatByteHint(chars: number): string | null {
+  if (chars <= 0) {
+    return null;
+  }
+  if (chars < 1000) {
+    return `(${chars})`;
+  }
+  if (chars < 100_000) {
+    return `(${(chars / 1000).toFixed(1)}k)`;
+  }
+  return `(${Math.round(chars / 1000)}k)`;
+}
+
+/**
+ * Build the button row and select menu row for the diagnostic summary embed.
+ *
+ * @param requestId - Diagnostic request UUID for routing button/select clicks back
+ * @param thinkingContentLength - Length of extracted reasoning content; surfaced
+ *   as a byte hint on the "View Reasoning" button label so users can tell at a
+ *   glance whether reasoning is a 200-char preview or a 50KB monster before clicking
  */
 export function buildInspectComponents(
-  requestId: string
+  requestId: string,
+  thinkingContentLength = 0
 ): ActionRowBuilder<MessageActionRowComponentBuilder>[] {
+  const byteHint = formatByteHint(thinkingContentLength);
+  const reasoningLabel = byteHint !== null ? `View Reasoning ${byteHint}` : 'View Reasoning';
+
   const buttonRow = new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(
     new ButtonBuilder()
       .setCustomId(InspectCustomIds.button(requestId, DebugViewType.Reasoning))
-      .setLabel('View Reasoning')
-      .setEmoji('\ud83d\udcad')
+      .setLabel(reasoningLabel)
+      .setEmoji('💭')
       .setStyle(ButtonStyle.Primary),
     new ButtonBuilder()
       .setCustomId(InspectCustomIds.button(requestId, DebugViewType.FullJson))
       .setLabel('Full JSON')
-      .setEmoji('\ud83d\udcc4')
+      .setEmoji('📄')
       .setStyle(ButtonStyle.Secondary)
   );
 
   const selectMenu = new StringSelectMenuBuilder()
     .setCustomId(InspectCustomIds.selectMenu(requestId))
-    .setPlaceholder('More views...')
+    .setPlaceholder('More diagnostic views…')
     .addOptions(
       {
         label: 'Compact JSON',
         description: 'JSON with system prompt summarized',
         value: DebugViewType.CompactJson,
-        emoji: '\ud83d\udccb',
+        emoji: '📋',
       },
       {
         label: 'System Prompt (XML)',
         description: 'Extracted system prompt in XML wrapper',
         value: DebugViewType.SystemPrompt,
-        emoji: '\ud83d\udcc3',
+        emoji: '📃',
       },
       {
         label: 'Memory Inspector',
         description: 'Search query, scored memories, inclusion status',
         value: DebugViewType.MemoryInspector,
-        emoji: '\ud83e\udde0',
+        emoji: '🧠',
       },
       {
         label: 'Token Budget',
         description: 'ASCII breakdown of context window allocation',
         value: DebugViewType.TokenBudget,
-        emoji: '\ud83d\udcca',
+        emoji: '📊',
       }
     );
 

--- a/services/bot-client/src/commands/inspect/embed.test.ts
+++ b/services/bot-client/src/commands/inspect/embed.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import { DISCORD_COLORS } from '@tzurot/common-types';
 import type { DiagnosticPayload } from '@tzurot/common-types';
-import { getEmbedColor, buildReasoningField, buildDiagnosticEmbed } from './embed.js';
+import {
+  getEmbedColor,
+  buildReasoningField,
+  buildDiagnosticEmbed,
+  formatFinishReason,
+  formatExtractionStatus,
+  formatMemoryFoundLine,
+} from './embed.js';
 
 function createMockPayload(overrides?: Partial<DiagnosticPayload>): DiagnosticPayload {
   return {
@@ -95,43 +102,218 @@ describe('getEmbedColor', () => {
   });
 });
 
+describe('formatFinishReason', () => {
+  it('decorates natural-completion finish reasons with ✅', () => {
+    expect(formatFinishReason('stop')).toBe('stop ✅');
+    expect(formatFinishReason('end_turn')).toBe('end_turn ✅');
+    expect(formatFinishReason('STOP')).toBe('STOP ✅');
+    expect(formatFinishReason('stop_sequence')).toBe('stop_sequence ✅');
+  });
+
+  it('decorates length truncation with ⚠️', () => {
+    expect(formatFinishReason('length')).toBe('length ⚠️');
+  });
+
+  it('decorates content_filter with ⛔', () => {
+    expect(formatFinishReason('content_filter')).toBe('content_filter ⛔');
+  });
+
+  it('decorates unknown sentinel with ❔', () => {
+    expect(formatFinishReason('unknown')).toBe('unknown ❔');
+  });
+
+  it('passes through unrecognized reasons unchanged', () => {
+    expect(formatFinishReason('weird_provider_specific_reason')).toBe(
+      'weird_provider_specific_reason'
+    );
+  });
+});
+
+describe('formatExtractionStatus', () => {
+  it('returns null when reasoningDebug is undefined (pre-PR-#895 logs)', () => {
+    expect(formatExtractionStatus(undefined)).toBeNull();
+  });
+
+  it('returns null when apiReasoningLength is undefined (legacy reasoningDebug shape)', () => {
+    expect(
+      formatExtractionStatus({
+        additionalKwargsKeys: [],
+        hasReasoningInKwargs: false,
+        reasoningKwargsLength: 0,
+        responseMetadataKeys: [],
+        hasReasoningDetails: false,
+        hasReasoningTagsInContent: false,
+        rawContentPreview: '',
+      })
+    ).toBeNull();
+  });
+
+  it('shows healthy extraction when API and pipeline lengths match', () => {
+    const result = formatExtractionStatus({
+      additionalKwargsKeys: ['reasoning'],
+      hasReasoningInKwargs: true,
+      reasoningKwargsLength: 1063,
+      responseMetadataKeys: [],
+      hasReasoningDetails: false,
+      hasReasoningTagsInContent: false,
+      rawContentPreview: '',
+      apiReasoningLength: 1063,
+    });
+    expect(result).toContain('✅');
+    expect(result).toContain('1,063');
+    expect(result).toContain('1,063 chars (extracted)');
+  });
+
+  it('shows ❌ LEAK when API has reasoning but pipeline shows zero', () => {
+    const result = formatExtractionStatus({
+      additionalKwargsKeys: [],
+      hasReasoningInKwargs: false,
+      reasoningKwargsLength: 0,
+      responseMetadataKeys: [],
+      hasReasoningDetails: false,
+      hasReasoningTagsInContent: false,
+      rawContentPreview: '',
+      apiReasoningLength: 1063,
+    });
+    expect(result).toContain('❌');
+    expect(result).toContain('LEAK');
+  });
+
+  it('shows ⚠️ "no structured reasoning" when both API and pipeline are zero', () => {
+    const result = formatExtractionStatus({
+      additionalKwargsKeys: [],
+      hasReasoningInKwargs: false,
+      reasoningKwargsLength: 0,
+      responseMetadataKeys: [],
+      hasReasoningDetails: false,
+      hasReasoningTagsInContent: false,
+      rawContentPreview: '',
+      apiReasoningLength: 0,
+    });
+    expect(result).toContain('⚠️');
+    expect(result).toContain('no structured reasoning');
+  });
+
+  it('shows ⚠️ partial when API and pipeline lengths differ but both are non-zero', () => {
+    const result = formatExtractionStatus({
+      additionalKwargsKeys: ['reasoning'],
+      hasReasoningInKwargs: true,
+      reasoningKwargsLength: 500,
+      responseMetadataKeys: [],
+      hasReasoningDetails: false,
+      hasReasoningTagsInContent: false,
+      rawContentPreview: '',
+      apiReasoningLength: 1063,
+    });
+    expect(result).toContain('⚠️');
+    expect(result).toContain('500');
+    expect(result).toContain('1,063');
+  });
+});
+
+describe('formatMemoryFoundLine', () => {
+  it('returns Found: 0 for empty memories', () => {
+    expect(formatMemoryFoundLine([])).toBe('**Found:** 0');
+  });
+
+  it('shows score range when memories exist', () => {
+    const memories = [
+      { id: 'a', score: 0.55, preview: 'p', includedInPrompt: true },
+      { id: 'b', score: 0.84, preview: 'p', includedInPrompt: true },
+      { id: 'c', score: 0.71, preview: 'p', includedInPrompt: false },
+    ];
+    expect(formatMemoryFoundLine(memories)).toBe('**Found:** 3 (scores 0.55–0.84)');
+  });
+
+  it('shows identical min and max when only one memory', () => {
+    const memories = [{ id: 'a', score: 0.7, preview: 'p', includedInPrompt: true }];
+    expect(formatMemoryFoundLine(memories)).toBe('**Found:** 1 (scores 0.70–0.70)');
+  });
+});
+
 describe('buildReasoningField', () => {
   it('should return null when no reasoning config', () => {
     const payload = createMockPayload();
     expect(buildReasoningField(payload)).toBeNull();
   });
 
-  it('should include reasoning config details', () => {
+  it('shows config + upstream + extraction lines when reasoningDebug is populated', () => {
     const payload = createMockPayload();
     payload.llmConfig.allParams = {
       reasoning: { effort: 'medium', enabled: true },
     };
+    payload.llmResponse.reasoningDebug = {
+      additionalKwargsKeys: ['reasoning'],
+      hasReasoningInKwargs: true,
+      reasoningKwargsLength: 1063,
+      responseMetadataKeys: ['openrouter'],
+      hasReasoningDetails: true,
+      hasReasoningTagsInContent: false,
+      rawContentPreview: 'response',
+      apiReasoningLength: 1063,
+      upstreamProvider: 'DekaLLM',
+      apiMessageKeys: ['role', 'content', 'reasoning'],
+    };
+
+    const field = buildReasoningField(payload);
+    expect(field).not.toBeNull();
+    expect(field!.value).toContain('effort=medium');
+    expect(field!.value).toContain('Upstream:** DekaLLM');
+    expect(field!.value).toContain('Extraction:');
+    expect(field!.value).toContain('1,063 chars');
+  });
+
+  it('does NOT include the legacy "Interception" line that read hasReasoningTagsInContent', () => {
+    // Regression guard: post-PR-#895 hasReasoningTagsInContent is always false
+    // (the success path no longer injects tags into content), so the line was
+    // misleading users with a permanent ❌. Confirm it's gone.
+    const payload = createMockPayload();
+    payload.llmConfig.allParams = { reasoning: { effort: 'medium', enabled: true } };
     payload.llmResponse.reasoningDebug = {
       additionalKwargsKeys: [],
       hasReasoningInKwargs: false,
       reasoningKwargsLength: 0,
       responseMetadataKeys: [],
       hasReasoningDetails: false,
-      hasReasoningTagsInContent: true,
-      rawContentPreview: '<reasoning>thinking...</reasoning>Response',
+      hasReasoningTagsInContent: false,
+      rawContentPreview: '',
     };
-    payload.postProcessing.thinkingContent = 'thinking...';
 
     const field = buildReasoningField(payload);
     expect(field).not.toBeNull();
-    expect(field!.value).toContain('effort=medium');
-    expect(field!.value).toContain('found');
-    expect(field!.value).toContain('Yes (11 chars)');
+    expect(field!.value).not.toContain('Interception');
+    expect(field!.value).not.toContain('not found');
+    expect(field!.value).not.toContain('tags');
   });
 
-  it('should show LOW warning for low completion tokens', () => {
+  it('omits Upstream line when upstreamProvider is undefined (pre-PR-#895 logs)', () => {
+    const payload = createMockPayload();
+    payload.llmConfig.allParams = { reasoning: { effort: 'high', enabled: true } };
+    payload.llmResponse.reasoningDebug = {
+      additionalKwargsKeys: [],
+      hasReasoningInKwargs: false,
+      reasoningKwargsLength: 0,
+      responseMetadataKeys: [],
+      hasReasoningDetails: false,
+      hasReasoningTagsInContent: false,
+      rawContentPreview: '',
+      // No upstreamProvider, no apiReasoningLength
+    };
+
+    const field = buildReasoningField(payload);
+    expect(field!.value).not.toContain('Upstream:');
+    expect(field!.value).not.toContain('Extraction:');
+  });
+
+  it('does NOT show LOW completion-tokens warning in the Reasoning field (moved to Response field)', () => {
     const payload = createMockPayload();
     payload.llmConfig.allParams = { reasoning: { effort: 'high', enabled: true } };
     payload.llmResponse.completionTokens = 35;
 
     const field = buildReasoningField(payload);
     expect(field).not.toBeNull();
-    expect(field!.value).toContain('LOW');
+    expect(field!.value).not.toContain('LOW');
+    expect(field!.value).not.toContain('Completion Tokens');
   });
 });
 
@@ -179,5 +361,74 @@ describe('buildDiagnosticEmbed', () => {
     const fields = embed.toJSON().fields ?? [];
     const reasoningField = fields.find(f => f.name.includes('Reasoning'));
     expect(reasoningField).toBeDefined();
+  });
+
+  it('relabels Provider to Family and surfaces Upstream when reasoningDebug.upstreamProvider exists', () => {
+    const payload = createMockPayload();
+    payload.llmConfig.provider = 'z-ai';
+    payload.llmResponse.reasoningDebug = {
+      additionalKwargsKeys: [],
+      hasReasoningInKwargs: false,
+      reasoningKwargsLength: 0,
+      responseMetadataKeys: [],
+      hasReasoningDetails: false,
+      hasReasoningTagsInContent: false,
+      rawContentPreview: '',
+      upstreamProvider: 'DekaLLM',
+    };
+
+    const embed = buildDiagnosticEmbed(payload);
+    const modelField = embed.toJSON().fields?.find(f => f.name.includes('Model'));
+    expect(modelField?.value).toContain('Family:** z-ai');
+    expect(modelField?.value).toContain('Upstream:** DekaLLM');
+    expect(modelField?.value).not.toContain('Provider:** z-ai');
+  });
+
+  it('shows finish reason with emoji decoration in Response field', () => {
+    const payload = createMockPayload();
+    payload.llmResponse.finishReason = 'length';
+
+    const embed = buildDiagnosticEmbed(payload);
+    const responseField = embed.toJSON().fields?.find(f => f.name.includes('Response'));
+    expect(responseField?.value).toContain('length ⚠️');
+  });
+
+  it('shows LOW warning on Completion Tokens line when low + non-zero', () => {
+    const payload = createMockPayload();
+    payload.llmResponse.completionTokens = 47;
+
+    const embed = buildDiagnosticEmbed(payload);
+    const responseField = embed.toJSON().fields?.find(f => f.name.includes('Response'));
+    expect(responseField?.value).toContain('Completion Tokens:** 47 ⚠️ LOW');
+  });
+
+  it('shows — for stop sequence when none triggered (instead of hiding the line)', () => {
+    const payload = createMockPayload();
+    payload.llmResponse.stopSequenceTriggered = null;
+
+    const embed = buildDiagnosticEmbed(payload);
+    const responseField = embed.toJSON().fields?.find(f => f.name.includes('Response'));
+    expect(responseField?.value).toContain('Stop Sequence:** —');
+  });
+
+  it('shows the actual stop sequence in code formatting when one triggered', () => {
+    const payload = createMockPayload();
+    payload.llmResponse.stopSequenceTriggered = '</message>';
+
+    const embed = buildDiagnosticEmbed(payload);
+    const responseField = embed.toJSON().fields?.find(f => f.name.includes('Response'));
+    expect(responseField?.value).toContain('Stop Sequence:** `</message>`');
+  });
+
+  it('shows memory score range in Memory field when memories exist', () => {
+    const payload = createMockPayload();
+    payload.memoryRetrieval.memoriesFound = [
+      { id: 'a', score: 0.55, preview: 'p', includedInPrompt: true },
+      { id: 'b', score: 0.84, preview: 'p', includedInPrompt: true },
+    ];
+
+    const embed = buildDiagnosticEmbed(payload);
+    const memoryField = embed.toJSON().fields?.find(f => f.name.includes('Memory'));
+    expect(memoryField?.value).toContain('Found:** 2 (scores 0.55–0.84)');
   });
 });

--- a/services/bot-client/src/commands/inspect/embed.ts
+++ b/services/bot-client/src/commands/inspect/embed.ts
@@ -19,7 +19,90 @@ export function getEmbedColor(payload: DiagnosticPayload): number {
 }
 
 /**
- * Build the reasoning diagnostics field for the embed
+ * Format a finish reason with a status emoji prefix.
+ * Natural completion (stop / end_turn / STOP / stop_sequence) → ✅
+ * Length truncation → ⚠️
+ * Content filter blocked → ⛔
+ * Unknown sentinel → ❓
+ * Anything else → no decoration
+ */
+export function formatFinishReason(reason: string): string {
+  switch (reason) {
+    case FINISH_REASONS.STOP:
+    case FINISH_REASONS.END_TURN:
+    case FINISH_REASONS.STOP_GOOGLE:
+    case FINISH_REASONS.STOP_SEQUENCE:
+      return `${reason} ✅`;
+    case FINISH_REASONS.LENGTH:
+      return `${reason} ⚠️`;
+    case FINISH_REASONS.CONTENT_FILTER:
+      return `${reason} ⛔`;
+    case FINISH_REASONS.UNKNOWN:
+      return `${reason} ❔`;
+    default:
+      return reason;
+  }
+}
+
+/**
+ * Format the API → Pipeline reasoning extraction chain. Surfaces the leak class
+ * by comparing what the OpenRouter API emitted (`apiReasoningLength`) against
+ * what our pipeline ended up with (`reasoningKwargsLength`).
+ *
+ * - Both > 0 and equal → ✅ healthy extraction
+ * - API > 0 but pipeline === 0 → ❌ pipeline leak (would fire if the LangChain
+ *   __includeRawResponse contract breaks despite passing CI)
+ * - Both === 0 → ⚠️ model emitted no structured reasoning (the known model-
+ *   behavior leak class — model embedded planning into content directly)
+ * - API > 0 and pipeline > 0 but mismatched → ⚠️ partial
+ *
+ * Returns null when reasoningDebug is absent (pre-PR-#895 logs).
+ */
+export function formatExtractionStatus(
+  reasoningDebug: NonNullable<DiagnosticPayload['llmResponse']['reasoningDebug']> | undefined
+): string | null {
+  if (reasoningDebug === undefined) {
+    return null;
+  }
+  const apiLen = reasoningDebug.apiReasoningLength;
+  const pipelineLen = reasoningDebug.reasoningKwargsLength;
+  // Pre-PR-#895 log fallback: apiReasoningLength is undefined
+  if (apiLen === undefined) {
+    return null;
+  }
+  if (apiLen === 0 && pipelineLen === 0) {
+    return '⚠️ Model emitted no structured reasoning (may be embedded in content)';
+  }
+  if (apiLen > 0 && pipelineLen === 0) {
+    return `❌ LEAK: ${apiLen.toLocaleString()} chars (API) → 0 chars (extracted)`;
+  }
+  if (apiLen === pipelineLen) {
+    return `✅ ${apiLen.toLocaleString()} chars (API) → ${pipelineLen.toLocaleString()} chars (extracted)`;
+  }
+  return `⚠️ ${apiLen.toLocaleString()} chars (API) → ${pipelineLen.toLocaleString()} chars (extracted)`;
+}
+
+/**
+ * Format the Memory section's "Found" line with a score range when memories exist.
+ */
+export function formatMemoryFoundLine(
+  memories: DiagnosticPayload['memoryRetrieval']['memoriesFound']
+): string {
+  if (memories.length === 0) {
+    return '**Found:** 0';
+  }
+  const scores = memories.map(m => m.score);
+  const min = Math.min(...scores);
+  const max = Math.max(...scores);
+  return `**Found:** ${memories.length} (scores ${min.toFixed(2)}–${max.toFixed(2)})`;
+}
+
+/**
+ * Build the reasoning diagnostics field for the embed.
+ *
+ * Post-PR-#895: shows upstream provider + extraction-chain health rather than
+ * the now-stale "<reasoning> tag interception" check (which always reads false
+ * after the consumer-layer refactor).
  */
 export function buildReasoningField(
   payload: DiagnosticPayload
@@ -31,23 +114,69 @@ export function buildReasoningField(
     return null;
   }
 
-  const { postProcessing, llmResponse } = payload;
+  const { llmResponse } = payload;
   const reasoningDebug = llmResponse.reasoningDebug;
-  const hasInterceptionTags = reasoningDebug?.hasReasoningTagsInContent === true;
-  const thinkingLen = postProcessing.thinkingContent?.length ?? 0;
-  const lowTokenWarning =
-    llmResponse.completionTokens < 100 && llmResponse.completionTokens > 0
-      ? ' \u26a0\ufe0f LOW'
-      : '';
+  const lines: string[] = [
+    `**Config:** effort=${reasoningConfig.effort ?? 'default'}, enabled=${String(reasoningConfig.enabled ?? true)}`,
+  ];
+
+  if (reasoningDebug?.upstreamProvider !== undefined) {
+    lines.push(`**Upstream:** ${reasoningDebug.upstreamProvider}`);
+  }
+
+  const extractionStatus = formatExtractionStatus(reasoningDebug);
+  if (extractionStatus !== null) {
+    lines.push(`**Extraction:** ${extractionStatus}`);
+  }
 
   return {
-    name: '\ud83d\udcad Reasoning',
+    name: '💭 Reasoning',
+    value: lines.join('\n'),
+  };
+}
+
+/**
+ * Build the Model field. "Family" is the namespace prefix from the model name
+ * (e.g. "z-ai" from "z-ai/glm-4.7") — this is NOT the actual upstream OpenRouter
+ * provider that handled the request. The real upstream lives in
+ * reasoningDebug.upstreamProvider and is shown as a separate "Upstream" line
+ * when available.
+ */
+function buildModelField(
+  llmConfig: DiagnosticPayload['llmConfig'],
+  llmResponse: DiagnosticPayload['llmResponse']
+): { name: string; value: string; inline: boolean } {
+  const lines: string[] = [`**Model:** ${llmConfig.model}`, `**Family:** ${llmConfig.provider}`];
+  const upstreamProvider = llmResponse.reasoningDebug?.upstreamProvider;
+  if (upstreamProvider !== undefined) {
+    lines.push(`**Upstream:** ${upstreamProvider}`);
+  }
+  lines.push(`**Temperature:** ${llmConfig.temperature ?? 'default'}`);
+  return { name: '🤖 Model', value: lines.join('\n'), inline: true };
+}
+
+/**
+ * Build the Response field with finish-reason emoji decoration, LOW completion-
+ * tokens warning, and always-show stop-sequence (— when none triggered).
+ */
+function buildResponseField(llmResponse: DiagnosticPayload['llmResponse']): {
+  name: string;
+  value: string;
+  inline: boolean;
+} {
+  const lowTokenWarning =
+    llmResponse.completionTokens < 100 && llmResponse.completionTokens > 0 ? ' ⚠️ LOW' : '';
+  const stopSequenceDisplay =
+    llmResponse.stopSequenceTriggered !== null ? `\`${llmResponse.stopSequenceTriggered}\`` : '—';
+  return {
+    name: '📤 Response',
     value: [
-      `**Config:** effort=${reasoningConfig.effort ?? 'default'}, enabled=${String(reasoningConfig.enabled ?? true)}`,
-      `**Interception:** <reasoning> tags ${hasInterceptionTags ? 'found \u2705' : 'not found \u274c'}`,
-      `**Thinking Extracted:** ${thinkingLen > 0 ? `Yes (${thinkingLen.toLocaleString()} chars)` : 'No'}`,
+      `**Finish Reason:** ${formatFinishReason(llmResponse.finishReason)}`,
+      `**Prompt Tokens:** ${llmResponse.promptTokens}`,
       `**Completion Tokens:** ${llmResponse.completionTokens}${lowTokenWarning}`,
+      `**Stop Sequence:** ${stopSequenceDisplay}`,
     ].join('\n'),
+    inline: true,
   };
 }
 
@@ -63,17 +192,16 @@ export function buildDiagnosticEmbed(payload: DiagnosticPayload): EmbedBuilder {
   const systemPercent = Math.round((tokenBudget.systemPromptTokens / totalTokens) * 100);
 
   const tokenBar = `System: ${systemPercent}% | Memory: ${memoryPercent}% | History: ${historyPercent}%`;
-  const dangerWarning =
-    historyPercent > 70 ? '\n\u26a0\ufe0f **History > 70%** - Sycophancy risk!' : '';
+  const dangerWarning = historyPercent > 70 ? '\n⚠️ **History > 70%** - Sycophancy risk!' : '';
 
-  const title = error ? '\u274c LLM Diagnostic (FAILED)' : '\ud83d\udd0d LLM Diagnostic Summary';
+  const title = error ? '❌ LLM Diagnostic (FAILED)' : '🔍 LLM Diagnostic Summary';
 
   const embed = new EmbedBuilder()
     .setTitle(title)
     .setColor(getEmbedColor(payload))
     .addFields(
       {
-        name: '\ud83d\udcdd Request',
+        name: '📝 Request',
         value: [
           `**ID:** \`${meta.requestId}\``,
           `**Personality:** ${meta.personalityName}`,
@@ -82,19 +210,11 @@ export function buildDiagnosticEmbed(payload: DiagnosticPayload): EmbedBuilder {
         ].join('\n'),
         inline: true,
       },
+      buildModelField(llmConfig, llmResponse),
       {
-        name: '\ud83e\udd16 Model',
+        name: '🧠 Memory',
         value: [
-          `**Model:** ${llmConfig.model}`,
-          `**Provider:** ${llmConfig.provider}`,
-          `**Temperature:** ${llmConfig.temperature ?? 'default'}`,
-        ].join('\n'),
-        inline: true,
-      },
-      {
-        name: '\ud83e\udde0 Memory',
-        value: [
-          `**Found:** ${memoryRetrieval.memoriesFound.length}`,
+          formatMemoryFoundLine(memoryRetrieval.memoriesFound),
           `**Included:** ${memoryRetrieval.memoriesFound.filter(m => m.includedInPrompt).length}`,
           `**Focus Mode:** ${memoryRetrieval.focusModeEnabled ? 'Yes' : 'No'}`,
         ].join('\n'),
@@ -104,7 +224,7 @@ export function buildDiagnosticEmbed(payload: DiagnosticPayload): EmbedBuilder {
 
   if (error) {
     embed.addFields({
-      name: '\ud83d\udea8 Error',
+      name: '🚨 Error',
       value: [
         `**Category:** ${error.category}`,
         `**Message:** ${error.message.substring(0, 200)}${error.message.length > 200 ? '...' : ''}`,
@@ -119,26 +239,13 @@ export function buildDiagnosticEmbed(payload: DiagnosticPayload): EmbedBuilder {
 
   embed.addFields(
     {
-      name: '\ud83d\udcca Token Budget',
+      name: '📊 Token Budget',
       value: `\`${tokenBar}\`${dangerWarning}`,
       inline: false,
     },
+    buildResponseField(llmResponse),
     {
-      name: '\ud83d\udce4 Response',
-      value: [
-        `**Finish Reason:** ${llmResponse.finishReason}`,
-        `**Prompt Tokens:** ${llmResponse.promptTokens}`,
-        `**Completion Tokens:** ${llmResponse.completionTokens}`,
-        llmResponse.stopSequenceTriggered !== null
-          ? `**Stop Sequence:** \`${llmResponse.stopSequenceTriggered}\``
-          : '',
-      ]
-        .filter(Boolean)
-        .join('\n'),
-      inline: true,
-    },
-    {
-      name: '\u23f1\ufe0f Timing',
+      name: '⏱️ Timing',
       value: [
         `**Total:** ${timing.totalDurationMs}ms`,
         timing.memoryRetrievalMs !== undefined ? `**Memory:** ${timing.memoryRetrievalMs}ms` : '',

--- a/services/bot-client/src/commands/inspect/index.ts
+++ b/services/bot-client/src/commands/inspect/index.ts
@@ -85,7 +85,10 @@ async function execute(ctx: SafeCommandContext): Promise<void> {
 
     const { log } = result;
     const embed = buildDiagnosticEmbed(log.data);
-    const components = buildInspectComponents(log.requestId);
+    const components = buildInspectComponents(
+      log.requestId,
+      log.data.postProcessing.thinkingContent?.length ?? 0
+    );
 
     await context.editReply({
       embeds: [embed],


### PR DESCRIPTION
## Summary

PR 1 of 5 in the **Inspect UX Hardening mini-epic** (see [BACKLOG.md Current Focus](BACKLOG.md)). Foundation work — bring the embed up to par after PR #895 changed the diagnostic shape, plus polish UX rough edges that surfaced during the audit. Smallest, no auth changes, lowest risk.

Net change: 8 files, **+515/-68**.

## Why now

[PR #895](https://github.com/lbds137/tzurot/pull/895) moved reasoning extraction from a transport-layer fetch interceptor to a consumer-layer helper. The embed kept showing pre-refactor indicators, most prominently:

> **Interception:** `<reasoning>` tags not found ❌

This became the **permanent** state for every successful request, because the new pipeline doesn't inject `<reasoning>` tags into content anymore — it populates `additional_kwargs.reasoning` directly. Every successful request was displaying a red ❌ for reasoning extraction. This PR replaces stale indicators with new ones that reflect post-refactor reality.

## What changed

### Tier 1 — Post-PR-#895 alignment

| Before | After |
|---|---|
| ❌ "Interception: `<reasoning>` tags not found" (always misleading) | New "Extraction" line shows API → Pipeline chain with leak-class detection |
| `Provider: z-ai` (the model namespace prefix, easy to misread as upstream) | `Family: z-ai` + `Upstream: DekaLLM` (when available) |
| Upstream provider invisible to user | Surfaced in both Model and Reasoning sections |

The new **Extraction** line surfaces all four health states:

- ✅ `1063 chars (API) → 1063 chars (extracted)` — healthy
- ❌ `LEAK: 1063 chars (API) → 0 chars (extracted)` — pipeline broken (canary regression)
- ⚠️ `Model emitted no structured reasoning (may be embedded in content)` — known model-behavior leak class
- ⚠️ partial mismatch — would surface if extraction breaks partially

### Tier 2 — UX polish

- Color/emoji-code finish reasons: `stop ✅`, `length ⚠️`, `content_filter ⛔`, `unknown ❔`
- Memory section shows score range: `Found: 20 (scores 0.55–0.84)` instead of just count
- Always show Stop Sequence row (`—` when none triggered) instead of hiding it (silent absence was confusing)
- Move LOW completion-tokens warning from Reasoning section to Response section (no longer duplicated in two places)
- Better select-menu placeholder: `More diagnostic views…`

### Tier 3 L — Reasoning button byte hint (folded in since touching `components.ts`)

Button label now includes a compact size hint so users know upfront whether reasoning is a 200-char preview vs a 50KB monster:

- `View Reasoning` (no reasoning content)
- `View Reasoning (250)` (under 1k chars)
- `View Reasoning (1.0k)` (1k-99k range)
- `View Reasoning (145k)` (100k+)

### Type sync

- Adds optional `upstreamProvider` / `apiMessageKeys` / `apiReasoningLength` to `packages/common-types/src/types/diagnostic.ts` ReasoningDebug type. These fields were defined in `services/ai-worker/src/services/diagnostics/DiagnosticTypes.ts` in PR #895 but the common-types view consumed by bot-client was missed in the original sync.

### BACKLOG

- Adds **Inspect UX Hardening mini-epic** to Current Focus, documenting all 5 PRs in the sequence
- Removes the superseded *"Inspect command privacy toggle"* entry (PR 2 of this mini-epic implements default-on redaction for non-owners — no per-personality toggle needed)

## What's NEXT in the mini-epic (separate PRs)

- **PR 2** — Privacy redaction for non-owners (closes the longstanding backlog item)
- **PR 3** — Pipeline Health view + Quick-copy summary
- **PR 4** — Memory Inspector filtering
- **PR 5** — `glm47-failure-segmentation.ts` deletion (its purpose served by `upstreamProvider` field that this PR surfaces)

## Test plan

- [x] `pnpm --filter bot-client test` — 4513 green (+27 net new tests)
- [x] `pnpm quality` — 11/11 tasks green
- [ ] Post-deploy: spot-check `/inspect` on a recent reasoning request and confirm the new fields render correctly (Family/Upstream/Extraction lines visible; LEAK detection works on edge cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)