### PR TITLE
chore(repo): add 'rules' to commitlint scope-enum

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -6,8 +6,10 @@ const staticScopes = [
   'ci', // CI/CD configuration (.github/)
   'deps', // Dependency updates
   'docs', // General documentation
-  'hooks', // Git hooks (.husky/)
+  'hooks', // Claude Code hooks (.claude/hooks/)
+  'husky', // Git workflow hooks (.husky/)
   'repo', // General repo maintenance
+  'rules', // Claude Code rules (.claude/rules/)
   'skills', // Claude Code skills (.claude/skills/)
 ];
 


### PR DESCRIPTION
## Summary

Adds `rules` to the static-scope list in `commitlint.config.cjs`, paralleling the existing `skills` scope.

Rule edits under `.claude/rules/` are common (this session alone produced two — relaxing the develop direct-commit rule, and a future try/catch rule for pipeline steps) and architecturally distinct from skills. Forcing them under `repo` loses scope-enum search value in `git log`.

## Also splits `hooks` from `husky`

While in this file, the `hooks` scope was clarified and split. Investigation surfaced that **all 15 historical uses** of the `hooks` scope were for `.claude/hooks/` work (PR #837 line). The comment `// Git hooks (.husky/)` was historically inaccurate — `.husky/` work has fallen under `repo` or `ci`, not `hooks`. The split aligns scope semantics with actual git history:

- `hooks` → now correctly comments `.claude/hooks/` (Claude Code automation hooks)
- `husky` → new dedicated scope for `.husky/` (git workflow hooks)

This is not a behavior change — no historical commit gets retroactively miscategorised.

## Why now

Hit during 2026-04-25 session: `docs(rules): allow direct doc commits to develop...` got rejected by commitlint. Used `docs(repo)` as the workaround. This PR makes the natural scope available going forward.

## Test plan

- [x] `commitlint.config.cjs` parses without error
- [ ] Verify `git commit -m "docs(rules): test"` succeeds after merge (manual)
- [ ] Verify `git commit -m "fix(husky): test"` succeeds after merge (manual)