### PR TITLE
feat(bot-client): stateful filter / sort / Top-N buttons on Memory Inspector

### DIFF
--- a/services/bot-client/src/commands/inspect/constants.ts
+++ b/services/bot-client/src/commands/inspect/constants.ts
@@ -1,0 +1,7 @@
+// Shared constants for inspect customId encoding. Lives in its own file so
+// both customIds.ts and memoryInspectorState.ts can import without creating a
+// cycle (memoryInspectorState.ts holds memoryButton, which is also exposed
+// via customIds.ts's InspectCustomIds for API symmetry).
+
+export const INSPECT_PREFIX = 'inspect';
+export const INSPECT_DELIMITER = '::';

--- a/services/bot-client/src/commands/inspect/customIds.test.ts
+++ b/services/bot-client/src/commands/inspect/customIds.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect } from 'vitest';
 import { InspectCustomIds } from './customIds.js';
 import { DebugViewType } from './types.js';
+import { MEMORY_FILTERS, TOP_N_VALUES, SORT_MODES } from './memoryInspectorState.js';
 
 describe('InspectCustomIds', () => {
   describe('button', () => {
@@ -75,6 +76,100 @@ describe('InspectCustomIds', () => {
 
       const selectId = InspectCustomIds.selectMenu(longRequestId);
       expect(selectId.length).toBeLessThan(100);
+
+      // Memory-state button uses the longest combination
+      const memoryId = InspectCustomIds.memoryButton(
+        longRequestId,
+        'included',
+        20,
+        'included-first'
+      );
+      expect(memoryId.length).toBeLessThan(100);
+    });
+  });
+
+  describe('memoryButton', () => {
+    it('builds a 7-segment button with state', () => {
+      const id = InspectCustomIds.memoryButton('req-1', 'all', 0, 'score-desc');
+      expect(id).toBe('inspect::btn::req-1::memory-inspector::all::0::sd');
+    });
+
+    it('uses short-form sort tokens on the wire', () => {
+      expect(InspectCustomIds.memoryButton('r', 'all', 0, 'score-desc')).toContain('::sd');
+      expect(InspectCustomIds.memoryButton('r', 'all', 0, 'score-asc')).toContain('::sa');
+      expect(InspectCustomIds.memoryButton('r', 'all', 0, 'included-first')).toContain('::if');
+    });
+  });
+
+  describe('parseButton — memory state', () => {
+    it('round-trips all 36 (filter × topN × sort) combinations', () => {
+      for (const filter of MEMORY_FILTERS) {
+        for (const topN of TOP_N_VALUES) {
+          for (const sort of SORT_MODES) {
+            const built = InspectCustomIds.memoryButton('req-1', filter, topN, sort);
+            const parsed = InspectCustomIds.parseButton(built);
+            expect(parsed).toEqual({
+              requestId: 'req-1',
+              viewType: DebugViewType.MemoryInspector,
+              memoryState: { filter, topN, sort },
+            });
+          }
+        }
+      }
+    });
+
+    it('legacy 4-segment memory-inspector button parses without memoryState', () => {
+      const result = InspectCustomIds.parseButton('inspect::btn::req-1::memory-inspector');
+      expect(result).toEqual({
+        requestId: 'req-1',
+        viewType: DebugViewType.MemoryInspector,
+      });
+      expect(result?.memoryState).toBeUndefined();
+    });
+
+    it('rejects bad filter token', () => {
+      expect(
+        InspectCustomIds.parseButton('inspect::btn::req::memory-inspector::bogus::5::sd')
+      ).toBeNull();
+    });
+
+    it('rejects bad topN token', () => {
+      expect(
+        InspectCustomIds.parseButton('inspect::btn::req::memory-inspector::all::7::sd')
+      ).toBeNull();
+    });
+
+    it('rejects non-numeric topN', () => {
+      expect(
+        InspectCustomIds.parseButton('inspect::btn::req::memory-inspector::all::abc::sd')
+      ).toBeNull();
+    });
+
+    it('rejects bad sort token', () => {
+      expect(
+        InspectCustomIds.parseButton('inspect::btn::req::memory-inspector::all::0::xx')
+      ).toBeNull();
+    });
+
+    it('rejects 7-segment customIds for non-memory view types', () => {
+      // Even with valid-looking state segments, only memory-inspector accepts the 7-segment form
+      expect(InspectCustomIds.parseButton('inspect::btn::req::full-json::all::0::sd')).toBeNull();
+    });
+
+    it('still rejects 5- and 6-segment customIds', () => {
+      expect(InspectCustomIds.parseButton('inspect::btn::req::memory-inspector::all')).toBeNull();
+      expect(
+        InspectCustomIds.parseButton('inspect::btn::req::memory-inspector::all::0')
+      ).toBeNull();
+    });
+
+    it('regression: 4-segment buttons for other view types still parse', () => {
+      // Sanity check that the relaxation didn't break the legacy path
+      const result = InspectCustomIds.parseButton('inspect::btn::req::full-json');
+      expect(result).toEqual({
+        requestId: 'req',
+        viewType: DebugViewType.FullJson,
+      });
     });
   });
 });

--- a/services/bot-client/src/commands/inspect/customIds.ts
+++ b/services/bot-client/src/commands/inspect/customIds.ts
@@ -2,16 +2,24 @@
  * Custom ID builders and parsers for inspect interactive components
  *
  * Custom ID scheme:
- *   Buttons:     inspect::btn::{requestId}::{viewType}
- *   Select menu: inspect::select::{requestId}
+ *   Buttons (legacy):       inspect::btn::{requestId}::{viewType}
+ *   Buttons (memory state): inspect::btn::{requestId}::memory-inspector::{filter}::{topN}::{sortWire}
+ *   Select menu:            inspect::select::{requestId}
  */
 
 import { DebugViewType } from './types.js';
+import { INSPECT_PREFIX as PREFIX, INSPECT_DELIMITER as DELIMITER } from './constants.js';
+import {
+  MEMORY_FILTERS,
+  TOP_N_VALUES,
+  SORT_FROM_WIRE,
+  memoryButton,
+  type MemoryFilter,
+  type TopN,
+  type MemoryInspectorState,
+} from './memoryInspectorState.js';
 
-const PREFIX = 'inspect';
-const DELIMITER = '::';
-
-/** Build a button custom ID for a specific view */
+/** Build a button custom ID for a specific view (no state). */
 function button(requestId: string, viewType: DebugViewType): string {
   return [PREFIX, 'btn', requestId, viewType].join(DELIMITER);
 }
@@ -21,17 +29,66 @@ function selectMenu(requestId: string): string {
   return [PREFIX, 'select', requestId].join(DELIMITER);
 }
 
-/** Parse a button custom ID. Returns null if not an inspect button. */
-function parseButton(customId: string): { requestId: string; viewType: DebugViewType } | null {
+/**
+ * Parse a button custom ID. Returns null if not an inspect button.
+ *
+ * Accepts two shapes:
+ *   - 4 segments (legacy / non-memory views): `inspect::btn::{req}::{viewType}`
+ *   - 7 segments (memory-inspector with state): adds `::{filter}::{topN}::{sortWire}`
+ *
+ * Memory-inspector legacy buttons (4 segments) parse with `memoryState: undefined`;
+ * dispatch supplies the default state.
+ */
+function parseButton(
+  customId: string
+): { requestId: string; viewType: DebugViewType; memoryState?: MemoryInspectorState } | null {
   const parts = customId.split(DELIMITER);
-  if (parts.length !== 4 || parts[0] !== PREFIX || parts[1] !== 'btn') {
+  if (parts.length !== 4 && parts.length !== 7) {
+    return null;
+  }
+  if (parts[0] !== PREFIX || parts[1] !== 'btn') {
     return null;
   }
   const viewType = parts[3] as DebugViewType;
   if (!Object.values(DebugViewType).includes(viewType)) {
     return null;
   }
-  return { requestId: parts[2], viewType };
+
+  if (parts.length === 4) {
+    return { requestId: parts[2], viewType };
+  }
+
+  // 7-segment form is only valid for memory-inspector
+  if (viewType !== DebugViewType.MemoryInspector) {
+    return null;
+  }
+
+  const filterRaw = parts[4];
+  const topNRaw = Number(parts[5]);
+  const sortRaw = parts[6];
+
+  if (!(MEMORY_FILTERS as readonly string[]).includes(filterRaw)) {
+    return null;
+  }
+  if (!Number.isInteger(topNRaw) || !(TOP_N_VALUES as readonly number[]).includes(topNRaw)) {
+    return null;
+  }
+  // SORT_FROM_WIRE is the inverse of SORT_WIRE, so any defined value is
+  // by construction a valid SortMode — the undefined check is sufficient.
+  const sort = SORT_FROM_WIRE[sortRaw];
+  if (sort === undefined) {
+    return null;
+  }
+
+  return {
+    requestId: parts[2],
+    viewType,
+    memoryState: {
+      filter: filterRaw as MemoryFilter,
+      topN: topNRaw as TopN,
+      sort,
+    },
+  };
 }
 
 /** Parse a select menu custom ID. Returns null if not an inspect select. */
@@ -51,6 +108,7 @@ function isInspect(customId: string): boolean {
 export const InspectCustomIds = {
   PREFIX,
   button,
+  memoryButton,
   selectMenu,
   parseButton,
   parseSelectMenu,

--- a/services/bot-client/src/commands/inspect/index.test.ts
+++ b/services/bot-client/src/commands/inspect/index.test.ts
@@ -269,6 +269,18 @@ describe('handleButton', () => {
       customId: InspectCustomIds.button(requestId, viewType),
       user: { id: userId },
       deferReply: vi.fn().mockResolvedValue(undefined),
+      deferUpdate: vi.fn().mockResolvedValue(undefined),
+      editReply: vi.fn().mockResolvedValue(undefined),
+    } as unknown as import('discord.js').ButtonInteraction;
+  }
+
+  function createMockMemoryButtonInteraction(userId = 'owner-123') {
+    const requestId = 'test-req-123';
+    return {
+      customId: InspectCustomIds.memoryButton(requestId, 'included', 5, 'score-asc'),
+      user: { id: userId },
+      deferReply: vi.fn().mockResolvedValue(undefined),
+      deferUpdate: vi.fn().mockResolvedValue(undefined),
       editReply: vi.fn().mockResolvedValue(undefined),
     } as unknown as import('discord.js').ButtonInteraction;
   }
@@ -311,6 +323,30 @@ describe('handleButton', () => {
 
     expect(interaction.deferReply).not.toHaveBeenCalled();
     expect(interaction.editReply).not.toHaveBeenCalled();
+  });
+
+  it('uses deferUpdate (not deferReply) for memory-state filter buttons', async () => {
+    // deferUpdate edits the existing ephemeral message in place, so successive
+    // filter clicks don't accumulate as separate messages in the user's view.
+    const mockPayload = createMockDiagnosticPayload();
+    vi.mocked(fetch).mockResolvedValue(createSuccessResponse('test-req-123', mockPayload));
+
+    const interaction = createMockMemoryButtonInteraction();
+    await inspectCommand.handleButton!(interaction);
+
+    expect(interaction.deferUpdate).toHaveBeenCalledTimes(1);
+    expect(interaction.deferReply).not.toHaveBeenCalled();
+  });
+
+  it('uses deferReply for non-memory view-navigation buttons', async () => {
+    const mockPayload = createMockDiagnosticPayload();
+    vi.mocked(fetch).mockResolvedValue(createSuccessResponse('test-req-123', mockPayload));
+
+    const interaction = createMockButtonInteraction(DebugViewType.FullJson);
+    await inspectCommand.handleButton!(interaction);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    expect(interaction.deferUpdate).not.toHaveBeenCalled();
   });
 });
 

--- a/services/bot-client/src/commands/inspect/index.ts
+++ b/services/bot-client/src/commands/inspect/index.ts
@@ -151,10 +151,16 @@ async function handleSelectMenu(interaction: StringSelectMenuInteraction): Promi
     // original /inspect invoker. Ephemeral replies already prevent other users
     // from seeing the buttons, but each click revalidates.
     const ctx = computeViewContext(result.log, interaction.user.id);
+    // Picking MemoryInspector from the select menu always starts at DEFAULT_MEMORY_STATE.
+    // Filter / sort / Top-N state is only preserved when navigating between memory-inspector
+    // buttons (handleButton below threads parsed.memoryState through).
     const viewResult = VIEW_BUILDERS[viewType](result.log.data, parsed.requestId, ctx);
     await interaction.editReply({
       content: viewResult.content,
       files: viewResult.files,
+      // Pass [] for views without components so any prior component row is cleared
+      // when the user picks a different view from the same select menu.
+      components: viewResult.components ?? [],
     });
   } catch (error) {
     logger.error(
@@ -186,7 +192,15 @@ async function handleButton(interaction: ButtonInteraction): Promise<void> {
     return;
   }
 
-  await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+  // Memory-state filter buttons mutate the existing view in place — use deferUpdate
+  // so editReply edits the message that owns the button rather than spawning a new
+  // ephemeral per click. View-navigation buttons (Reasoning, FullJson, etc.) keep
+  // deferReply because they semantically open a new view as a separate ephemeral.
+  if (parsed.memoryState !== undefined) {
+    await interaction.deferUpdate();
+  } else {
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+  }
 
   try {
     const filterUserId = getFilterUserId(interaction.user.id);
@@ -198,10 +212,14 @@ async function handleButton(interaction: ButtonInteraction): Promise<void> {
 
     // See handleSelectMenu — same defense-in-depth re-evaluation.
     const ctx = computeViewContext(result.log, interaction.user.id);
-    const viewResult = VIEW_BUILDERS[parsed.viewType](result.log.data, parsed.requestId, ctx);
+    const viewResult =
+      parsed.viewType === DebugViewType.MemoryInspector
+        ? buildMemoryInspectorView(result.log.data, parsed.requestId, ctx, parsed.memoryState)
+        : VIEW_BUILDERS[parsed.viewType](result.log.data, parsed.requestId, ctx);
     await interaction.editReply({
       content: viewResult.content,
       files: viewResult.files,
+      components: viewResult.components ?? [],
     });
   } catch (error) {
     logger.error(

--- a/services/bot-client/src/commands/inspect/memoryInspectorState.test.ts
+++ b/services/bot-client/src/commands/inspect/memoryInspectorState.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import { ButtonStyle, type APIButtonComponentWithCustomId } from 'discord.js';
+import type { DiagnosticMemoryEntry } from '@tzurot/common-types';
+import {
+  applyMemoryFilter,
+  applySort,
+  applyTopN,
+  nextTopN,
+  nextSort,
+  buildMemoryFilterButtons,
+  DEFAULT_MEMORY_STATE,
+  type MemoryInspectorState,
+} from './memoryInspectorState.js';
+
+function mem(id: string, score: number, includedInPrompt: boolean): DiagnosticMemoryEntry {
+  return { id, score, preview: `preview-${id}`, includedInPrompt };
+}
+
+const SAMPLE: DiagnosticMemoryEntry[] = [
+  mem('a', 0.9, true),
+  mem('b', 0.7, false),
+  mem('c', 0.5, true),
+  mem('d', 0.3, false),
+  mem('e', 0.1, true),
+];
+
+describe('applyMemoryFilter', () => {
+  it('all returns every memory', () => {
+    expect(applyMemoryFilter(SAMPLE, 'all')).toHaveLength(5);
+  });
+  it('included returns only included rows', () => {
+    const result = applyMemoryFilter(SAMPLE, 'included');
+    expect(result.map(m => m.id)).toEqual(['a', 'c', 'e']);
+  });
+  it('dropped returns only dropped rows', () => {
+    const result = applyMemoryFilter(SAMPLE, 'dropped');
+    expect(result.map(m => m.id)).toEqual(['b', 'd']);
+  });
+});
+
+describe('applySort', () => {
+  it('score-desc sorts highest first', () => {
+    const result = applySort(SAMPLE, 'score-desc');
+    expect(result.map(m => m.id)).toEqual(['a', 'b', 'c', 'd', 'e']);
+  });
+  it('score-asc sorts lowest first', () => {
+    const result = applySort(SAMPLE, 'score-asc');
+    expect(result.map(m => m.id)).toEqual(['e', 'd', 'c', 'b', 'a']);
+  });
+  it('included-first groups included rows above dropped, score-desc within each', () => {
+    const result = applySort(SAMPLE, 'included-first');
+    expect(result.map(m => m.id)).toEqual(['a', 'c', 'e', 'b', 'd']);
+  });
+});
+
+describe('applyTopN', () => {
+  it('topN=0 returns all', () => {
+    expect(applyTopN(SAMPLE, 0)).toHaveLength(5);
+  });
+  it('topN=5 returns up to 5 rows (all when total <= 5)', () => {
+    expect(applyTopN(SAMPLE, 5).map(m => m.id)).toEqual(['a', 'b', 'c', 'd', 'e']);
+    expect(applyTopN(SAMPLE.slice(0, 3), 5)).toHaveLength(3); // > total returns all
+  });
+  it('topN=20 returns all when total < 20', () => {
+    expect(applyTopN(SAMPLE, 20)).toHaveLength(5);
+  });
+});
+
+describe('nextTopN', () => {
+  it('cycles 0 → 5 → 10 → 20 → 0', () => {
+    expect(nextTopN(0)).toBe(5);
+    expect(nextTopN(5)).toBe(10);
+    expect(nextTopN(10)).toBe(20);
+    expect(nextTopN(20)).toBe(0);
+  });
+});
+
+describe('nextSort', () => {
+  it('cycles score-desc → score-asc → included-first → score-desc', () => {
+    expect(nextSort('score-desc')).toBe('score-asc');
+    expect(nextSort('score-asc')).toBe('included-first');
+    expect(nextSort('included-first')).toBe('score-desc');
+  });
+});
+
+describe('buildMemoryFilterButtons', () => {
+  const state: MemoryInspectorState = DEFAULT_MEMORY_STATE;
+
+  it('returns one ActionRow with 5 buttons', () => {
+    const row = buildMemoryFilterButtons('req-1', state);
+    expect(row.components).toHaveLength(5);
+  });
+
+  it('marks the active filter button as Primary, others as Secondary', () => {
+    const row = buildMemoryFilterButtons('req-1', { ...state, filter: 'included' });
+    const buttons = row.components.map(b => b.toJSON() as APIButtonComponentWithCustomId);
+    expect(buttons[0].style).toBe(ButtonStyle.Secondary); // All
+    expect(buttons[1].style).toBe(ButtonStyle.Primary); // Included
+    expect(buttons[2].style).toBe(ButtonStyle.Secondary); // Dropped
+  });
+
+  it('Top-N button is Secondary when topN=0, Primary otherwise', () => {
+    const noLimit = buildMemoryFilterButtons('req-1', { ...state, topN: 0 });
+    const withLimit = buildMemoryFilterButtons('req-1', { ...state, topN: 10 });
+    expect((noLimit.components[3].toJSON() as APIButtonComponentWithCustomId).style).toBe(
+      ButtonStyle.Secondary
+    );
+    expect((withLimit.components[3].toJSON() as APIButtonComponentWithCustomId).style).toBe(
+      ButtonStyle.Primary
+    );
+  });
+
+  it('Top-N button label reflects current value', () => {
+    const noLimit = buildMemoryFilterButtons('req-1', { ...state, topN: 0 });
+    const withLimit = buildMemoryFilterButtons('req-1', { ...state, topN: 5 });
+    expect((noLimit.components[3].toJSON() as APIButtonComponentWithCustomId).label).toBe('Top N');
+    expect((withLimit.components[3].toJSON() as APIButtonComponentWithCustomId).label).toBe(
+      'Top 5'
+    );
+  });
+
+  it('Sort button is Secondary on default sort, Primary on non-default', () => {
+    const sortDesc = buildMemoryFilterButtons('req-1', { ...state, sort: 'score-desc' });
+    const sortAsc = buildMemoryFilterButtons('req-1', { ...state, sort: 'score-asc' });
+    const includedFirst = buildMemoryFilterButtons('req-1', { ...state, sort: 'included-first' });
+    expect((sortDesc.components[4].toJSON() as APIButtonComponentWithCustomId).style).toBe(
+      ButtonStyle.Secondary
+    );
+    expect((sortAsc.components[4].toJSON() as APIButtonComponentWithCustomId).style).toBe(
+      ButtonStyle.Primary
+    );
+    expect((includedFirst.components[4].toJSON() as APIButtonComponentWithCustomId).style).toBe(
+      ButtonStyle.Primary
+    );
+  });
+
+  it('Sort button label reflects current sort mode', () => {
+    const sortDesc = buildMemoryFilterButtons('req-1', { ...state, sort: 'score-desc' });
+    const sortAsc = buildMemoryFilterButtons('req-1', { ...state, sort: 'score-asc' });
+    const includedFirst = buildMemoryFilterButtons('req-1', { ...state, sort: 'included-first' });
+    expect((sortDesc.components[4].toJSON() as APIButtonComponentWithCustomId).label).toBe(
+      '↓ Score'
+    );
+    expect((sortAsc.components[4].toJSON() as APIButtonComponentWithCustomId).label).toBe(
+      '↑ Score'
+    );
+    expect((includedFirst.components[4].toJSON() as APIButtonComponentWithCustomId).label).toBe(
+      'Included ⊳'
+    );
+  });
+});

--- a/services/bot-client/src/commands/inspect/memoryInspectorState.ts
+++ b/services/bot-client/src/commands/inspect/memoryInspectorState.ts
@@ -1,0 +1,159 @@
+// Stateful filter / sort / Top-N controls for the /inspect Memory Inspector view.
+// State is encoded into button customIds so it survives bot restarts and
+// multi-replica deployments (per .claude/rules/04-discord.md).
+
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  type MessageActionRowComponentBuilder,
+} from 'discord.js';
+import type { DiagnosticMemoryEntry } from '@tzurot/common-types';
+import { DebugViewType } from './types.js';
+import { INSPECT_PREFIX as PREFIX, INSPECT_DELIMITER as DELIMITER } from './constants.js';
+
+export const MEMORY_FILTERS = ['all', 'included', 'dropped'] as const;
+export type MemoryFilter = (typeof MEMORY_FILTERS)[number];
+
+export const TOP_N_VALUES = [0, 5, 10, 20] as const;
+export type TopN = (typeof TOP_N_VALUES)[number];
+
+/** Sort modes mapped to their short-form wire tokens (kept under Discord's 100-char customId limit). */
+export const SORT_WIRE = {
+  'score-desc': 'sd',
+  'score-asc': 'sa',
+  'included-first': 'if',
+} as const;
+
+export type SortMode = keyof typeof SORT_WIRE;
+export const SORT_MODES: readonly SortMode[] = Object.keys(SORT_WIRE) as SortMode[];
+
+/** Reverse map: short wire token → full SortMode. The `| undefined` in the cast
+ *  is intentional — it forces parseButton to null-check on unknown tokens; the
+ *  map itself only stores the three valid SortMode values. */
+export const SORT_FROM_WIRE = Object.fromEntries(
+  Object.entries(SORT_WIRE).map(([k, v]) => [v, k])
+) as Record<string, SortMode | undefined>;
+
+export interface MemoryInspectorState {
+  filter: MemoryFilter;
+  topN: TopN;
+  sort: SortMode;
+}
+
+export const DEFAULT_MEMORY_STATE: MemoryInspectorState = {
+  filter: 'all',
+  topN: 0,
+  sort: 'score-desc',
+};
+
+export function applyMemoryFilter(
+  memories: readonly DiagnosticMemoryEntry[],
+  filter: MemoryFilter
+): DiagnosticMemoryEntry[] {
+  if (filter === 'included') {
+    return memories.filter(m => m.includedInPrompt);
+  }
+  if (filter === 'dropped') {
+    return memories.filter(m => !m.includedInPrompt);
+  }
+  return [...memories];
+}
+
+export function applySort(
+  memories: readonly DiagnosticMemoryEntry[],
+  sort: SortMode
+): DiagnosticMemoryEntry[] {
+  if (sort === 'score-asc') {
+    return [...memories].sort((a, b) => a.score - b.score);
+  }
+  if (sort === 'included-first') {
+    const included = memories.filter(m => m.includedInPrompt).sort((a, b) => b.score - a.score);
+    const dropped = memories.filter(m => !m.includedInPrompt).sort((a, b) => b.score - a.score);
+    return [...included, ...dropped];
+  }
+  // score-desc: explicit fallthrough. If a new SortMode is added to SORT_WIRE
+  // without a corresponding branch here, TypeScript prevents the silent regression
+  // because `sort` is a `SortMode` union — an unhandled variant produces a type
+  // error at the parse boundary.
+  return [...memories].sort((a, b) => b.score - a.score);
+}
+
+export function applyTopN(
+  memories: readonly DiagnosticMemoryEntry[],
+  topN: TopN
+): DiagnosticMemoryEntry[] {
+  if (topN === 0) {
+    return [...memories];
+  }
+  return memories.slice(0, topN);
+}
+
+export function nextTopN(current: TopN): TopN {
+  const idx = TOP_N_VALUES.indexOf(current);
+  return TOP_N_VALUES[(idx + 1) % TOP_N_VALUES.length];
+}
+
+export function nextSort(current: SortMode): SortMode {
+  const idx = SORT_MODES.indexOf(current);
+  return SORT_MODES[(idx + 1) % SORT_MODES.length];
+}
+
+/** Build a memory-inspector button custom ID with filter/topN/sort state encoded.
+ *  Defined here (not in customIds.ts) to break the circular import:
+ *  customIds.ts → memoryInspectorState.ts → customIds.ts. */
+export function memoryButton(
+  requestId: string,
+  filter: MemoryFilter,
+  topN: TopN,
+  sort: SortMode
+): string {
+  return [
+    PREFIX,
+    'btn',
+    requestId,
+    DebugViewType.MemoryInspector,
+    filter,
+    String(topN),
+    SORT_WIRE[sort],
+  ].join(DELIMITER);
+}
+
+const SORT_BUTTON_LABEL: Record<SortMode, string> = {
+  'score-desc': '↓ Score',
+  'score-asc': '↑ Score',
+  'included-first': 'Included ⊳',
+};
+
+export function buildMemoryFilterButtons(
+  requestId: string,
+  state: MemoryInspectorState
+): ActionRowBuilder<MessageActionRowComponentBuilder> {
+  const filterButton = (label: string, emoji: string, target: MemoryFilter): ButtonBuilder =>
+    new ButtonBuilder()
+      .setCustomId(memoryButton(requestId, target, state.topN, state.sort))
+      .setLabel(label)
+      .setEmoji(emoji)
+      .setStyle(state.filter === target ? ButtonStyle.Primary : ButtonStyle.Secondary);
+
+  const topNLabel = state.topN === 0 ? 'Top N' : `Top ${state.topN}`;
+  const topNButton = new ButtonBuilder()
+    .setCustomId(memoryButton(requestId, state.filter, nextTopN(state.topN), state.sort))
+    .setLabel(topNLabel)
+    .setEmoji('🔢')
+    .setStyle(state.topN === 0 ? ButtonStyle.Secondary : ButtonStyle.Primary);
+
+  const sortButton = new ButtonBuilder()
+    .setCustomId(memoryButton(requestId, state.filter, state.topN, nextSort(state.sort)))
+    .setLabel(SORT_BUTTON_LABEL[state.sort])
+    .setEmoji('↕️')
+    .setStyle(state.sort === 'score-desc' ? ButtonStyle.Secondary : ButtonStyle.Primary);
+
+  return new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(
+    filterButton('All', '📚', 'all'),
+    filterButton('Included', '✅', 'included'),
+    filterButton('Dropped', '🗑️', 'dropped'),
+    topNButton,
+    sortButton
+  );
+}

--- a/services/bot-client/src/commands/inspect/views.test.ts
+++ b/services/bot-client/src/commands/inspect/views.test.ts
@@ -280,6 +280,146 @@ describe('buildMemoryInspectorView', () => {
     const content = result.files![0].attachment.toString();
     expect(content).toContain('_none_');
   });
+
+  describe('filter / sort / Top-N state', () => {
+    function memoryPayload() {
+      const payload = createMockPayload();
+      payload.memoryRetrieval.memoriesFound = [
+        { id: 'm1', score: 0.9, preview: 'p1', includedInPrompt: true },
+        { id: 'm2', score: 0.8, preview: 'p2', includedInPrompt: false },
+        { id: 'm3', score: 0.7, preview: 'p3', includedInPrompt: true },
+        { id: 'm4', score: 0.6, preview: 'p4', includedInPrompt: false },
+        { id: 'm5', score: 0.5, preview: 'p5', includedInPrompt: true },
+      ];
+      return payload;
+    }
+
+    it('default state matches existing behavior (regression)', () => {
+      const result = buildMemoryInspectorView(memoryPayload(), 'req-1', OWNER_CTX);
+      const text = result.files![0].attachment.toString();
+      // All 5 rows shown
+      expect(text).toContain('p1');
+      expect(text).toContain('p5');
+      expect(text).toContain('5 total');
+      expect(text).toContain('showing 5');
+    });
+
+    it('returns 5-button component row', () => {
+      const result = buildMemoryInspectorView(memoryPayload(), 'req-1', OWNER_CTX);
+      expect(result.components).toHaveLength(1);
+      expect(result.components![0].components).toHaveLength(5);
+    });
+
+    it('filter=included shows only included rows', () => {
+      const result = buildMemoryInspectorView(memoryPayload(), 'req-1', OWNER_CTX, {
+        filter: 'included',
+        topN: 0,
+        sort: 'score-desc',
+      });
+      const text = result.files![0].attachment.toString();
+      expect(text).toContain('p1');
+      expect(text).not.toContain('p2');
+      expect(text).toContain('p3');
+      expect(text).not.toContain('p4');
+      expect(text).toContain('p5');
+    });
+
+    it('filter=dropped shows only dropped rows', () => {
+      const result = buildMemoryInspectorView(memoryPayload(), 'req-1', OWNER_CTX, {
+        filter: 'dropped',
+        topN: 0,
+        sort: 'score-desc',
+      });
+      const text = result.files![0].attachment.toString();
+      expect(text).not.toContain('p1');
+      expect(text).toContain('p2');
+      expect(text).not.toContain('p3');
+      expect(text).toContain('p4');
+      expect(text).not.toContain('p5');
+    });
+
+    it('topN=5 covers all 5 fixture rows', () => {
+      const result = buildMemoryInspectorView(memoryPayload(), 'req-1', OWNER_CTX, {
+        filter: 'all',
+        topN: 5,
+        sort: 'score-desc',
+      });
+      const text = result.files![0].attachment.toString();
+      expect(text).toContain('showing 5');
+    });
+
+    it('sort=score-asc puts lowest score first', () => {
+      const result = buildMemoryInspectorView(memoryPayload(), 'req-1', OWNER_CTX, {
+        filter: 'all',
+        topN: 0,
+        sort: 'score-asc',
+      });
+      const text = result.files![0].attachment.toString();
+      // First row index is 1, lowest-scored memory (p5 with 0.50) should be there
+      const firstRowMatch = text.match(/\| 1 \| (\d+\.\d+) \|/);
+      expect(firstRowMatch?.[1]).toBe('0.50');
+    });
+
+    it('sort=included-first groups included rows above dropped', () => {
+      const result = buildMemoryInspectorView(memoryPayload(), 'req-1', OWNER_CTX, {
+        filter: 'all',
+        topN: 0,
+        sort: 'included-first',
+      });
+      const text = result.files![0].attachment.toString();
+      const p1Idx = text.indexOf('p1'); // included
+      const p3Idx = text.indexOf('p3'); // included
+      const p5Idx = text.indexOf('p5'); // included
+      const p2Idx = text.indexOf('p2'); // dropped
+      const p4Idx = text.indexOf('p4'); // dropped
+      // All included rows appear before any dropped row
+      expect(Math.max(p1Idx, p3Idx, p5Idx)).toBeLessThan(Math.min(p2Idx, p4Idx));
+    });
+
+    it('combined filter + topN + sort: included + topN=5 + score-asc', () => {
+      const result = buildMemoryInspectorView(memoryPayload(), 'req-1', OWNER_CTX, {
+        filter: 'included',
+        topN: 5,
+        sort: 'score-asc',
+      });
+      const text = result.files![0].attachment.toString();
+      // Included memories sorted by ascending score: p5 (0.5), p3 (0.7), p1 (0.9)
+      // topN=5 covers all 3
+      const p5Idx = text.indexOf('p5');
+      const p3Idx = text.indexOf('p3');
+      const p1Idx = text.indexOf('p1');
+      expect(p5Idx).toBeLessThan(p3Idx);
+      expect(p3Idx).toBeLessThan(p1Idx);
+    });
+
+    it('empty result after filtering shows "no memories match" message', () => {
+      const payload = memoryPayload();
+      // All memories are included, so filter=dropped → empty
+      payload.memoryRetrieval.memoriesFound = payload.memoryRetrieval.memoriesFound.map(m => ({
+        ...m,
+        includedInPrompt: true,
+      }));
+      const result = buildMemoryInspectorView(payload, 'req-1', OWNER_CTX, {
+        filter: 'dropped',
+        topN: 0,
+        sort: 'score-desc',
+      });
+      const text = result.files![0].attachment.toString();
+      expect(text).toContain('No memories match filter');
+    });
+
+    it('non-owner with filter applied still redacts previews', () => {
+      const result = buildMemoryInspectorView(memoryPayload(), 'req-1', NON_OWNER_CTX, {
+        filter: 'included',
+        topN: 0,
+        sort: 'score-desc',
+      });
+      const text = result.files![0].attachment.toString();
+      expect(text).toContain('[REDACTED]');
+      expect(text).not.toContain('p1');
+      expect(text).not.toContain('p3');
+    });
+  });
 });
 
 describe('buildTokenBudgetView', () => {

--- a/services/bot-client/src/commands/inspect/views.ts
+++ b/services/bot-client/src/commands/inspect/views.ts
@@ -9,15 +9,29 @@
  * `viewContext.ts` for the ownership-resolution logic.
  */
 
-import { AttachmentBuilder, MessageFlags } from 'discord.js';
-import type { DiagnosticPayload } from '@tzurot/common-types';
+import {
+  ActionRowBuilder,
+  AttachmentBuilder,
+  MessageFlags,
+  type MessageActionRowComponentBuilder,
+} from 'discord.js';
+import type { DiagnosticPayload, DiagnosticMemoryEntry } from '@tzurot/common-types';
 import type { ViewContext } from './viewContext.js';
+import {
+  DEFAULT_MEMORY_STATE,
+  applyMemoryFilter,
+  applySort,
+  applyTopN,
+  buildMemoryFilterButtons,
+  type MemoryInspectorState,
+} from './memoryInspectorState.js';
 
-/** Return type for view builders — either a content string or file attachments */
+/** Return type for view builders — content string, file attachments, and optional component rows. */
 export interface DebugViewResult {
   content?: string;
   files?: AttachmentBuilder[];
   flags?: MessageFlags;
+  components?: ActionRowBuilder<MessageActionRowComponentBuilder>[];
 }
 
 /** Sentinel string used in JSON views to redact a system-prompt message body */
@@ -224,51 +238,75 @@ export function buildReasoningView(
 // Memory Inspector
 // ---------------------------------------------------------------------------
 
-/** Scored memories table with inclusion status */
+function formatMemoryRow(
+  m: DiagnosticMemoryEntry,
+  index: number,
+  canViewCharacter: boolean
+): string {
+  const status = m.includedInPrompt ? 'Included' : 'Dropped (budget)';
+  const preview = canViewCharacter
+    ? m.preview.replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/\n/g, ' ')
+    : REDACTED_MEMORY_PREVIEW;
+  return `| ${index + 1} | ${m.score.toFixed(2)} | ${status} | ${preview} |`;
+}
+
+function renderMemoryTable(
+  memories: readonly DiagnosticMemoryEntry[],
+  allMemories: readonly DiagnosticMemoryEntry[],
+  tokenBudget: { memoryTokensUsed: number },
+  canViewCharacter: boolean
+): string[] {
+  const includedTotal = allMemories.filter(m => m.includedInPrompt).length;
+  // Budget drops happened over the full unfiltered retrieval, not the filtered view —
+  // hence allMemories rather than memories. Variable name is explicit to avoid
+  // confusion with filter-induced row exclusion.
+  const budgetDropped = allMemories.length - includedTotal;
+  const lines = [
+    `## Retrieved Memories (${allMemories.length} total, ${includedTotal} included, showing ${memories.length})`,
+  ];
+  if (!canViewCharacter) {
+    lines.push('');
+    lines.push('🔒 _Memory previews redacted — this personality is owned by another user._');
+  }
+  lines.push('', '| # | Score | Status | Preview |', '|---|-------|--------|---------|');
+  for (let i = 0; i < memories.length; i++) {
+    lines.push(formatMemoryRow(memories[i], i, canViewCharacter));
+  }
+  lines.push('');
+  lines.push(
+    `**Token Budget:** ${tokenBudget.memoryTokensUsed} tokens allocated, ${budgetDropped} memories dropped for budget`
+  );
+  return lines;
+}
+
+/** Scored memories table with inclusion status. Applies filter → sort → Top-N. */
 export function buildMemoryInspectorView(
   payload: DiagnosticPayload,
   requestId: string,
-  ctx: ViewContext
+  ctx: ViewContext,
+  state: MemoryInspectorState = DEFAULT_MEMORY_STATE
 ): DebugViewResult {
   const { memoryRetrieval, inputProcessing, tokenBudget } = payload;
-  const memories = memoryRetrieval.memoriesFound;
+  const allMemories = memoryRetrieval.memoriesFound;
+  const filtered = applyMemoryFilter(allMemories, state.filter);
+  const sorted = applySort(filtered, state.sort);
+  const memories = applyTopN(sorted, state.topN);
 
   const lines: string[] = [
     '# Memory Inspector',
     '',
     `**Search Query:** ${inputProcessing.searchQuery !== null ? `"${inputProcessing.searchQuery}"` : '_none_'}`,
     `**Focus Mode:** ${memoryRetrieval.focusModeEnabled ? 'Enabled' : 'Disabled'}`,
+    `**Filter:** ${state.filter} · **Sort:** ${state.sort} · **Top-N:** ${state.topN === 0 ? 'all' : state.topN}`,
     '',
   ];
 
-  if (memories.length === 0) {
+  if (allMemories.length === 0) {
     lines.push('_No memories retrieved for this request._');
+  } else if (memories.length === 0) {
+    lines.push(`_No memories match filter "${state.filter}"._`);
   } else {
-    const included = memories.filter(m => m.includedInPrompt).length;
-    const dropped = memories.length - included;
-
-    lines.push(`## Retrieved Memories (${memories.length} found, ${included} included)`);
-    if (!ctx.canViewCharacter) {
-      lines.push('');
-      lines.push('🔒 _Memory previews redacted — this personality is owned by another user._');
-    }
-    lines.push('');
-    lines.push('| # | Score | Status | Preview |');
-    lines.push('|---|-------|--------|---------|');
-
-    for (let i = 0; i < memories.length; i++) {
-      const m = memories[i];
-      const status = m.includedInPrompt ? 'Included' : 'Dropped (budget)';
-      const preview = ctx.canViewCharacter
-        ? m.preview.replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/\n/g, ' ')
-        : REDACTED_MEMORY_PREVIEW;
-      lines.push(`| ${i + 1} | ${m.score.toFixed(2)} | ${status} | ${preview} |`);
-    }
-
-    lines.push('');
-    lines.push(
-      `**Token Budget:** ${tokenBudget.memoryTokensUsed} tokens allocated, ${dropped} memories dropped for budget`
-    );
+    lines.push(...renderMemoryTable(memories, allMemories, tokenBudget, ctx.canViewCharacter));
   }
 
   const content = lines.join('\n');
@@ -279,6 +317,7 @@ export function buildMemoryInspectorView(
         description: 'Memory retrieval details',
       }),
     ],
+    components: [buildMemoryFilterButtons(requestId, state)],
     flags: MessageFlags.Ephemeral,
   };
 }


### PR DESCRIPTION
## Summary

Mini-epic PR 4/5: adds an interactive control row to the `/inspect` Memory Inspector view so operators can narrow the memory table without re-running `/inspect`. Five buttons in one ActionRow:

- **3 filter buttons (radio)**: All / Included / Dropped — active filter highlighted in Primary
- **Top-N cycler**: 0 → 5 → 10 → 20 → 0 — Primary when capped, Secondary at 0
- **Sort cycler**: ↓ Score → ↑ Score → Included ⊳ → ↓ Score

State is encoded in the customId, so buttons survive bot restarts and multi-replica deployments per `04-discord.md`. The Sort wire format uses short tokens (`sd`/`sa`/`if`) to keep customIds well under Discord's 100-char limit.

## Architecture notes

- **Application order: filter → sort → Top-N.** "Top 5 by score-asc on Included" = the 5 lowest-scored included memories. Useful for the "why did this dropped memory rank so low?" debugging question.
- **`DebugViewResult` gains optional `components`** field. The other 7 view builders need zero changes (omit the field → identical to today). Dispatch in `handleSelectMenu` and `handleButton` passes `components: viewResult.components ?? []` so non-memory views explicitly clear any prior button row.
- **`parseButton` accepts both 4-segment legacy customIds** (default state on render) **and 7-segment state-bearing customIds** (memory-inspector only). Other view types still reject 7-segment form. Round-trip property test covers all 36 (3 filter × 4 topN × 3 sort) combinations.
- **`SORT_WIRE` is the single source of truth** — `SORT_MODES` and `SORT_FROM_WIRE` are derived from it via `Object.keys` / `Object.fromEntries`. Adding a new sort mode means one edit, not three.

## Files

- `services/bot-client/src/commands/inspect/memoryInspectorState.ts` — NEW: state types, filter/sort/topN helpers, button builder
- `services/bot-client/src/commands/inspect/views.ts` — `DebugViewResult.components` extension; `buildMemoryInspectorView` now takes optional state, applies filter/sort/Top-N, returns components
- `services/bot-client/src/commands/inspect/customIds.ts` — `memoryButton` builder; relaxed `parseButton` for 7-segment state form
- `services/bot-client/src/commands/inspect/index.ts` — dispatch threads `memoryState` through to `buildMemoryInspectorView`; both `handleSelectMenu` and `handleButton` pass `components` to `editReply`
- Tests for all of the above

## Test plan

- [x] `pnpm --filter @tzurot/bot-client test` — 4576 passed (+39 new across `memoryInspectorState.test.ts`, `customIds.test.ts`, `views.test.ts`)
- [x] `pnpm quality` — clean
- [ ] Manual smoke after deploy:
  1. `/inspect <msgId>` → Memory Inspector → 5 filter buttons appear
  2. Click All / Included / Dropped — table re-renders, active button is Primary
  3. Click Top N — label cycles through 5/10/20 and back to "Top N"
  4. Click Sort — label cycles ↓ Score / ↑ Score / Included ⊳
  5. Combine: Included + Top 5 + ↑ Score → 5 lowest-scored included memories

## Mini-epic context

- ✅ PR #897 — Embed redesign
- ✅ PR #898 — Privacy redaction
- ✅ PR #899 — Pipeline Health + Quick Copy
- 👉 PR 4 (this) — Memory Inspector filtering
- ⏳ PR 5 — Cleanup (delete glm47-failure-segmentation.ts + add `.claude/hooks/` to doc-commit rule's "still requires PR" column)