### PR TITLE
fix(hooks): clear depcruise cache before pre-push

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -128,7 +128,12 @@ else
 fi
 
 # 9. Run dependency boundary checks (BLOCKING)
+# Clear the depcruise cache first — content-strategy caching has missed
+# circular-dependency violations across renamed/moved files at least once
+# (PR #901, 2026-04-25). The full analysis takes ~5s, so the cost of always
+# starting cold is negligible compared to the cost of a stale "no violations".
 echo "Running dependency boundary checks..."
+rm -rf node_modules/.cache/dependency-cruiser
 if ! pnpm depcruise; then
     echo "${RED}Dependency boundary check failed!${NC}"
     echo "Run 'pnpm depcruise' for details"


### PR DESCRIPTION
## Summary

Fixes a false-negative class where pre-push's `depcruise` step reported "no violations" while CI caught a circular dependency on the same commit.

## Why this matters

Hit during PR #901 (memory-inspector filter buttons): the new file `memoryInspectorState.ts` imported `InspectCustomIds` from `customIds.ts`, while `customIds.ts` imported types/arrays from `memoryInspectorState.ts` — a circular dependency. CI's fresh `depcruise` run flagged it immediately. Pre-push's run output `✔ no dependency violations found`.

Looking at the cache file in `node_modules/.cache/dependency-cruiser/`: it was 4 days stale, predating the new file's existence. With `cache.strategy: 'content'`, depcruise *should* invalidate on content changes, but evidently doesn't catch newly-introduced cycles across files that were modified vs. files that were created. (The exact failure mode is in dependency-cruiser internals; this PR is the pragmatic fix.)

## What this changes

`.husky/pre-push` step 9 now clears `node_modules/.cache/dependency-cruiser` before running `pnpm depcruise`. Adds ~5s to push time. Doesn't affect:

- **CI** — no cache to invalidate; runs fresh anyway
- **Other local invocations** (`pnpm depcruise` ad-hoc) — they just rebuild the cache once
- **`pnpm quality`** in regular use — still uses the cache

## Test plan

- [x] Modified `.husky/pre-push` runs cleanly on push (this very push verified it)
- [x] Pre-push hook still triggers on code-file changes (depcruise step is gated by changed files; doc-only pushes skip)
- [ ] Manually verify: revert this PR, introduce a known cycle, observe pre-push catches it (out of scope for this PR — diagnostic confirmation)