### PR TITLE
chore: bundle three small Quick Wins (defense-in-depth + test coverage)

### DIFF
--- a/services/ai-worker/src/jobs/handlers/LLMGenerationHandler.test.ts
+++ b/services/ai-worker/src/jobs/handlers/LLMGenerationHandler.test.ts
@@ -14,11 +14,13 @@ import {
   JobType,
   JobStatus,
   AIProvider,
+  ApiErrorCategory,
   type LLMGenerationJobData,
   type LoadedPersonality,
   REDIS_KEY_PREFIXES,
 } from '@tzurot/common-types';
 import { LLMGenerationHandler } from './LLMGenerationHandler.js';
+import { DownloadAttachmentsStep } from './pipeline/steps/DownloadAttachmentsStep.js';
 import type { ApiKeyResolver, ApiKeyResolutionResult } from '../../services/ApiKeyResolver.js';
 
 // Mock the redis module (dynamic import)
@@ -781,6 +783,35 @@ describe('LLMGenerationHandler', () => {
         expect(result.metadata?.isGuestMode).toBe(false);
       });
 
+      it('should classify DownloadAttachments throwing as MEDIA_NOT_FOUND on errorInfo.category', async () => {
+        // Pins path (2) from the broader-coverage test below: when the
+        // DownloadAttachments pipeline step throws, the handler's outer catch
+        // populates errorInfo with the MEDIA_NOT_FOUND category. Without this
+        // assertion at the handler level, a future refactor of the
+        // currentStepName → category mapping (LLMGenerationHandler.ts:207-210)
+        // could silently break the classification — the unit-level coverage
+        // in DownloadAttachmentsStep.test.ts only exercises the step's own
+        // throw, not the handler's classification of it.
+        const jobData = createValidJobData();
+        const job = { id: 'job-attachment-fail', data: jobData } as Job<LLMGenerationJobData>;
+
+        const stepError = new Error('Failed to download attachment');
+        const stepSpy = vi
+          .spyOn(DownloadAttachmentsStep.prototype, 'process')
+          .mockRejectedValue(stepError);
+
+        try {
+          const result = await handler.processJob(job);
+
+          expect(result.success).toBe(false);
+          expect(result.errorInfo).toBeDefined();
+          expect(result.errorInfo?.category).toBe(ApiErrorCategory.MEDIA_NOT_FOUND);
+          expect(result.errorInfo?.technicalMessage).toContain('Failed to download attachment');
+        } finally {
+          stepSpy.mockRestore();
+        }
+      });
+
       it('should always include errorInfo on failure results so bot-client can render spoiler-tag details', async () => {
         // Two paths populate errorInfo on a failed pipeline:
         // (1) GenerationStep failures (e.g. RAG rejection) — GenerationStep
@@ -790,12 +821,9 @@ describe('LLMGenerationHandler', () => {
         //     step-classified category (DownloadAttachments → MEDIA_NOT_FOUND).
         //
         // This test pins path (1) — that GenerationStep failures still produce
-        // a result the bot-client can use. Path (2) is pinned at the unit
-        // level by DownloadAttachmentsStep.test.ts (the THROWS-when-no-text
-        // case) plus visual inspection of the small mapping if-branch — the
-        // existing pipeline test harness mocks RAGService but uses real
-        // pipeline steps, so triggering DownloadAttachments to throw here
-        // would require non-trivial setup that adds no marginal coverage.
+        // a result the bot-client can use. Path (2) — DownloadAttachmentsStep
+        // throwing → MEDIA_NOT_FOUND classification — is pinned by the test
+        // immediately above this one.
         //
         // Without errorInfo, bot-client falls through to the generic "Sorry,
         // I encountered an error" with no diagnostic content — observed

--- a/services/ai-worker/src/utils/safeExternalFetch.test.ts
+++ b/services/ai-worker/src/utils/safeExternalFetch.test.ts
@@ -123,6 +123,10 @@ describe('isPrivateOrInternalIp', () => {
   it('rejects IPv6 loopback (::1) and unspecified (::)', () => {
     expect(isPrivateOrInternalIp('::1')).toBe(true);
     expect(isPrivateOrInternalIp('::')).toBe(true);
+    // Uncompressed forms — same addresses, different syntactic representation.
+    // dns.lookup returns canonical (::1, ::) but the helper may receive arbitrary input.
+    expect(isPrivateOrInternalIp('0:0:0:0:0:0:0:1')).toBe(true);
+    expect(isPrivateOrInternalIp('0:0:0:0:0:0:0:0')).toBe(true);
   });
 
   it('rejects IPv6 unique local addresses (fc00::/7)', () => {

--- a/services/ai-worker/src/utils/safeExternalFetch.ts
+++ b/services/ai-worker/src/utils/safeExternalFetch.ts
@@ -140,10 +140,19 @@ function isPrivateOrInternalIpv6Tunneled6to4(lower: string): boolean {
  * Covers loopback, ULA, link-local, multicast, deprecated site-local,
  * IPv4-mapped recursion, 6to4 tunneling recursion, and Teredo tunneling.
  */
+// Loopback / unspecified IPv6 addresses, in the forms `dns.lookup` actually
+// produces: canonical (RFC 5952) `::`, `::1` plus the uncompressed-zeros
+// representation. Fully-padded forms (`0000:...:0001`) and mixed-compression
+// variants are not covered — `dns.lookup` does not emit them, and the only
+// other caller (`isPrivateOrInternalIp` exposed for defense-in-depth) is
+// expected to canonicalise its input first. Set lookup keeps the guard tight
+// while keeping function complexity below the lint cap.
+const LOOPBACK_OR_UNSPECIFIED_IPV6 = new Set(['::', '::1', '0:0:0:0:0:0:0:0', '0:0:0:0:0:0:0:1']);
+
 function isPrivateOrInternalIpv6(ip: string): boolean {
   const lower = ip.toLowerCase();
-  if (lower === '::' || lower === '::1') {
-    return true; // unspecified or loopback
+  if (LOOPBACK_OR_UNSPECIFIED_IPV6.has(lower)) {
+    return true;
   }
   // IPv4-mapped IPv6 (::ffff:a.b.c.d) — extract embedded IPv4 and recurse so
   // a private IPv4 wrapped in IPv6 syntax doesn't slip through.

--- a/services/bot-client/src/commands/character/avatar.test.ts
+++ b/services/bot-client/src/commands/character/avatar.test.ts
@@ -51,7 +51,7 @@ describe('Character Avatar Handler', () => {
 
   const createMockAttachment = (overrides: Partial<Attachment> = {}): Attachment =>
     ({
-      url: 'https://cdn.discord.com/attachments/123/456/image.png',
+      url: 'https://cdn.discordapp.com/attachments/123/456/image.png',
       contentType: 'image/png',
       size: 1024 * 1024, // 1MB
       ...overrides,
@@ -144,6 +144,18 @@ describe('Character Avatar Handler', () => {
 
       expect(mockContext.editReply).toHaveBeenCalledWith(expect.stringContaining('too large'));
       expect(api.fetchCharacter).not.toHaveBeenCalled();
+    });
+
+    it('should reject non-Discord CDN URLs', async () => {
+      const attachment = createMockAttachment({ url: 'https://evil.example.com/malicious.png' });
+      const mockContext = createMockContext('my-char', attachment);
+      vi.mocked(api.fetchCharacter).mockResolvedValue(createMockCharacter({ slug: 'my-char' }));
+
+      await handleAvatar(mockContext, mockConfig);
+
+      expect(mockContext.editReply).toHaveBeenCalledWith('❌ Invalid attachment URL.');
+      expect(api.updateCharacter).not.toHaveBeenCalled();
+      expect(mockFetch).not.toHaveBeenCalled();
     });
 
     it('should return error when character not found', async () => {

--- a/services/bot-client/src/commands/character/avatar.ts
+++ b/services/bot-client/src/commands/character/avatar.ts
@@ -8,6 +8,7 @@
 import { createLogger, type EnvConfig, characterAvatarOptions } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import { toGatewayUser } from '../../utils/userGatewayClient.js';
+import { validateDiscordCdnUrl } from '../../utils/discordCdnGuard.js';
 import { fetchCharacter, updateCharacter } from './api.js';
 import {
   VALID_IMAGE_TYPES,
@@ -64,6 +65,15 @@ export async function handleAvatar(
         `❌ You don't have permission to edit \`${slug}\`.\n` +
           'You can only edit characters you own.'
       );
+      return;
+    }
+
+    // SSRF defense-in-depth: validate the attachment URL points at a Discord
+    // CDN host before fetching. Discord interactions only ever supply CDN URLs,
+    // so this is a guard rather than expected reject path.
+    const cdnGuard = validateDiscordCdnUrl(attachment.url, logger);
+    if (!cdnGuard.ok) {
+      await context.editReply('❌ Invalid attachment URL.');
       return;
     }
 

--- a/services/bot-client/src/commands/character/import.test.ts
+++ b/services/bot-client/src/commands/character/import.test.ts
@@ -286,6 +286,38 @@ describe('handleImport', () => {
     });
   });
 
+  describe('CDN URL validation', () => {
+    it('should reject character file URLs not on the Discord CDN', async () => {
+      const context = createMockContext({
+        url: 'https://evil.example.com/malicious.json',
+      });
+
+      await handleImport(context, mockConfig);
+
+      const editReplyArg = (context.editReply as Mock).mock.calls[0][0];
+      expect(editReplyArg).toContain('❌ Invalid file URL.');
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(callGatewayApi).not.toHaveBeenCalled();
+    });
+
+    it('should reject avatar URLs not on the Discord CDN', async () => {
+      // File URL passes the guard; avatar URL fails — pins the second guard inside processAvatarDownload.
+      const context = createMockContext(undefined, {
+        url: 'https://evil.example.com/malicious.png',
+      });
+      mockFetch.mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify(createValidCharacterData())),
+      });
+      mockCreateScenario({ ok: true, data: { id: 'new-id' } });
+
+      await handleImport(context, mockConfig);
+
+      const editReplyArg = (context.editReply as Mock).mock.calls[0][0];
+      expect(editReplyArg).toContain('❌ Invalid avatar URL.');
+    });
+  });
+
   describe('file size validation', () => {
     it('should reject files larger than AVATAR_SIZE limit', async () => {
       const context = createMockContext({

--- a/services/bot-client/src/commands/character/import.ts
+++ b/services/bot-client/src/commands/character/import.ts
@@ -15,6 +15,7 @@ import {
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import { callGatewayApi, toGatewayUser, type GatewayUser } from '../../utils/userGatewayClient.js';
 import { validateJsonFile, downloadAndParseJson } from '../../utils/jsonFileUtils.js';
+import { validateDiscordCdnUrl } from '../../utils/discordCdnGuard.js';
 import {
   VALID_IMAGE_TYPES,
   MAX_INPUT_SIZE_MB,
@@ -148,7 +149,7 @@ async function validateAndParseCharacterJsonFile(
     return { error: validationResult.error + '\n\n' + buildTemplateMessage() };
   }
 
-  // Download and parse using shared utility
+  // Download and parse using shared utility (CDN guard runs inside downloadAndParseJson)
   const jsonResult = await downloadAndParseJson(file.url, file.name);
   if ('error' in jsonResult) {
     return { error: jsonResult.error + '\n\n' + buildTemplateMessage() };
@@ -185,6 +186,11 @@ function validateAvatarAttachment(avatar: AttachmentOption): string | null {
 async function processAvatarDownload(
   avatar: AttachmentOption
 ): Promise<AvatarProcessingResult | { error: string }> {
+  // SSRF defense-in-depth: reject non-Discord-CDN URLs before fetching.
+  const cdnGuard = validateDiscordCdnUrl(avatar.url, logger);
+  if (!cdnGuard.ok) {
+    return { error: '❌ Invalid avatar URL.' };
+  }
   try {
     const response = await fetch(avatar.url);
     if (!response.ok) {

--- a/services/bot-client/src/commands/character/voice.ts
+++ b/services/bot-client/src/commands/character/voice.ts
@@ -16,6 +16,7 @@ import {
   isAutocompleteErrorSentinel,
 } from '../../utils/apiCheck.js';
 import { toGatewayUser, type GatewayUser } from '../../utils/userGatewayClient.js';
+import { validateDiscordCdnUrl } from '../../utils/discordCdnGuard.js';
 import { fetchCharacter, updateCharacter, type FetchedCharacter } from './api.js';
 
 const logger = createLogger('character-voice');
@@ -28,9 +29,6 @@ const VALID_AUDIO_PREFIX = 'audio/';
 /** Max upload size accepted client-side (same as server limit) */
 const MAX_UPLOAD_BYTES = VOICE_REFERENCE_LIMITS.MAX_SIZE;
 const MAX_UPLOAD_MB = MAX_UPLOAD_BYTES / (1024 * 1024);
-
-/** Allowed Discord CDN hostnames for SSRF defense-in-depth */
-const DISCORD_CDN_HOSTS = ['cdn.discordapp.com', 'media.discordapp.net'];
 
 /**
  * Fetch a character and verify the user has edit permission.
@@ -95,15 +93,8 @@ async function handleVoiceUpload(
   }
 
   // Validate attachment URL is from Discord CDN (SSRF defense-in-depth)
-  let attachmentHost: string;
-  try {
-    attachmentHost = new URL(attachment.url).hostname;
-  } catch {
-    await context.editReply('❌ Invalid attachment URL.');
-    return;
-  }
-  if (!DISCORD_CDN_HOSTS.includes(attachmentHost)) {
-    logger.warn({ url: attachment.url, host: attachmentHost }, 'Unexpected attachment URL host');
+  const cdnGuard = validateDiscordCdnUrl(attachment.url, logger);
+  if (!cdnGuard.ok) {
     await context.editReply('❌ Invalid attachment URL.');
     return;
   }

--- a/services/bot-client/src/utils/discordCdnGuard.test.ts
+++ b/services/bot-client/src/utils/discordCdnGuard.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Logger } from 'pino';
+import { validateDiscordCdnUrl } from './discordCdnGuard.js';
+
+function mockLogger(): Logger {
+  return { warn: vi.fn() } as unknown as Logger;
+}
+
+describe('validateDiscordCdnUrl', () => {
+  it('accepts cdn.discordapp.com URLs', () => {
+    const result = validateDiscordCdnUrl('https://cdn.discordapp.com/attachments/1/2/file.png');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.hostname).toBe('cdn.discordapp.com');
+    }
+  });
+
+  it('accepts media.discordapp.net URLs', () => {
+    const result = validateDiscordCdnUrl('https://media.discordapp.net/external/abc/image.jpg');
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects URLs with unexpected hosts', () => {
+    const result = validateDiscordCdnUrl('https://evil.example.com/file.png');
+    expect(result.ok).toBe(false);
+    if (!result.ok && result.reason === 'unexpected-host') {
+      expect(result.rawHost).toBe('evil.example.com');
+    } else {
+      throw new Error('expected unexpected-host failure variant');
+    }
+  });
+
+  it('rejects malformed URLs', () => {
+    const result = validateDiscordCdnUrl('not-a-url');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('invalid-url');
+    }
+  });
+
+  it('rejects non-https protocols even with allowed host', () => {
+    const result = validateDiscordCdnUrl('http://cdn.discordapp.com/attachments/1/2/file.png');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('invalid-url');
+    }
+  });
+
+  it('logs a warning when host is unexpected and logger is provided', () => {
+    const logger = mockLogger();
+    validateDiscordCdnUrl('https://evil.example.com/file.png', logger);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ host: 'evil.example.com' }),
+      expect.stringMatching(/Unexpected attachment URL host/)
+    );
+  });
+
+  it('does not log when host is valid', () => {
+    const logger = mockLogger();
+    validateDiscordCdnUrl('https://cdn.discordapp.com/x.png', logger);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});

--- a/services/bot-client/src/utils/discordCdnGuard.ts
+++ b/services/bot-client/src/utils/discordCdnGuard.ts
@@ -1,0 +1,46 @@
+// SSRF defense-in-depth helper. Discord interactions only ever supply
+// CDN URLs from `cdn.discordapp.com` or `media.discordapp.net`, but a malicious
+// or compromised Discord client could in principle inject a different host
+// into an attachment payload. This helper validates the URL before any
+// outbound fetch, providing an explicit guard at every fetch site rather
+// than implicit trust in the Discord interaction object.
+
+import type { Logger } from 'pino';
+
+/** Allowed Discord CDN hostnames. */
+const DISCORD_CDN_HOSTS = ['cdn.discordapp.com', 'media.discordapp.net'];
+
+export type DiscordCdnGuardResult =
+  | { ok: true; hostname: string }
+  | { ok: false; reason: 'invalid-url' }
+  | { ok: false; reason: 'unexpected-host'; rawHost: string };
+
+/**
+ * Validate that an attachment URL points at a Discord CDN host. Returns a
+ * tagged result rather than throwing so callers can control their own
+ * error-reply flow (some need to send to Discord, some to a webhook, etc.).
+ *
+ * @param url The attachment URL (typically `attachment.url` from a Discord
+ *   interaction option).
+ * @param logger Optional logger; when provided, an `unexpected-host` rejection
+ *   logs a warn-level entry with the URL+host for incident triage.
+ */
+export function validateDiscordCdnUrl(url: string, logger?: Logger): DiscordCdnGuardResult {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { ok: false, reason: 'invalid-url' };
+  }
+  if (parsed.protocol !== 'https:') {
+    return { ok: false, reason: 'invalid-url' };
+  }
+  const hostname = parsed.hostname;
+  if (!DISCORD_CDN_HOSTS.includes(hostname)) {
+    if (logger !== undefined) {
+      logger.warn({ url, host: hostname }, 'Unexpected attachment URL host');
+    }
+    return { ok: false, reason: 'unexpected-host', rawHost: hostname };
+  }
+  return { ok: true, hostname };
+}

--- a/services/bot-client/src/utils/jsonFileUtils.test.ts
+++ b/services/bot-client/src/utils/jsonFileUtils.test.ts
@@ -52,7 +52,7 @@ describe('jsonFileUtils', () => {
         contentType: 'application/json',
         name: 'test.json',
         size: 1000,
-        url: 'https://example.com/test.json',
+        url: 'https://cdn.discordapp.com/attachments/1/2/test.json',
         ...overrides,
       }) as Attachment;
 
@@ -110,7 +110,10 @@ describe('jsonFileUtils', () => {
         text: () => Promise.resolve(JSON.stringify(testData)),
       });
 
-      const result = await downloadAndParseJson('https://example.com/test.json', 'test.json');
+      const result = await downloadAndParseJson(
+        'https://cdn.discordapp.com/attachments/1/2/test.json',
+        'test.json'
+      );
 
       expect(result).toHaveProperty('data');
       expect((result as { data: unknown }).data).toEqual(testData);
@@ -122,7 +125,10 @@ describe('jsonFileUtils', () => {
         status: 404,
       });
 
-      const result = await downloadAndParseJson('https://example.com/test.json', 'test.json');
+      const result = await downloadAndParseJson(
+        'https://cdn.discordapp.com/attachments/1/2/test.json',
+        'test.json'
+      );
 
       expect(result).toHaveProperty('error');
       expect((result as { error: string }).error).toContain('Failed to parse');
@@ -134,7 +140,10 @@ describe('jsonFileUtils', () => {
         text: () => Promise.resolve('not valid json {'),
       });
 
-      const result = await downloadAndParseJson('https://example.com/test.json', 'test.json');
+      const result = await downloadAndParseJson(
+        'https://cdn.discordapp.com/attachments/1/2/test.json',
+        'test.json'
+      );
 
       expect(result).toHaveProperty('error');
       expect((result as { error: string }).error).toContain('Failed to parse');
@@ -143,9 +152,23 @@ describe('jsonFileUtils', () => {
     it('should return error for network failure', async () => {
       mockFetch.mockRejectedValue(new Error('Network error'));
 
-      const result = await downloadAndParseJson('https://example.com/test.json', 'test.json');
+      const result = await downloadAndParseJson(
+        'https://cdn.discordapp.com/attachments/1/2/test.json',
+        'test.json'
+      );
 
       expect(result).toHaveProperty('error');
+    });
+
+    it('should reject non-Discord-CDN URLs without fetching', async () => {
+      const result = await downloadAndParseJson(
+        'https://evil.example.com/malicious.json',
+        'evil.json'
+      );
+
+      expect(result).toHaveProperty('error');
+      expect((result as { error: string }).error).toContain('Invalid file URL');
+      expect(mockFetch).not.toHaveBeenCalled();
     });
   });
 
@@ -155,7 +178,7 @@ describe('jsonFileUtils', () => {
         contentType: 'application/json',
         name: 'test.json',
         size: 1000,
-        url: 'https://example.com/test.json',
+        url: 'https://cdn.discordapp.com/attachments/1/2/test.json',
         ...overrides,
       }) as Attachment;
 

--- a/services/bot-client/src/utils/jsonFileUtils.ts
+++ b/services/bot-client/src/utils/jsonFileUtils.ts
@@ -8,6 +8,7 @@
 import { AttachmentBuilder } from 'discord.js';
 import { createLogger, DISCORD_LIMITS } from '@tzurot/common-types';
 import type { Attachment } from 'discord.js';
+import { validateDiscordCdnUrl } from './discordCdnGuard.js';
 
 const logger = createLogger('json-file-utils');
 
@@ -72,6 +73,14 @@ export async function downloadAndParseJson<T = Record<string, unknown>>(
   url: string,
   filename: string
 ): Promise<JsonDownloadResult<T> | JsonErrorResult> {
+  // SSRF defense-in-depth: reject non-Discord-CDN URLs before fetching.
+  // Discord-supplied attachment URLs always come from the CDN; anything else
+  // is suspect. Guarding here protects every caller (character import, preset
+  // import, future ones) without requiring per-site discipline.
+  const cdnGuard = validateDiscordCdnUrl(url, logger);
+  if (!cdnGuard.ok) {
+    return { error: '❌ Invalid file URL.' };
+  }
   try {
     const response = await fetch(url);
     if (!response.ok) {


### PR DESCRIPTION
## Summary

Three independent Quick Wins surfaced from prior PR reviews. Bundled because each is sub-30-line, defense-in-depth or test-coverage themed, and they share a coherent review surface.

## Items

### 1. IPv6 loopback gap — `safeExternalFetch.ts`

`isPrivateOrInternalIpv6` accepted the uncompressed RFC form `0:0:0:0:0:0:0:1` as public when the canonical `::1` was correctly rejected. Not exploitable through current call path (dns.lookup canonicalizes), but the helper is defense-in-depth and may be reused with arbitrary input.

- Refactored the loopback check into a `LOOPBACK_OR_UNSPECIFIED_IPV6` Set lookup
- Keeps function complexity under the 20 cap (was at 21 with linear `||` chain)
- Test added in `safeExternalFetch.test.ts`

Surfaced 2026-04-25 by claude-bot review on release PR #894.

### 2. MEDIA_NOT_FOUND classification handler test — `LLMGenerationHandler.test.ts`

Tests pinned the GenerationStep error path but not the DownloadAttachments → MEDIA_NOT_FOUND mapping. Added a test that spies on `DownloadAttachmentsStep.prototype.process` to throw, and asserts `result.errorInfo.category === ApiErrorCategory.MEDIA_NOT_FOUND`.

Surfaced 2026-04-25 by claude-bot review on PR #893 round 7.

### 3. Bot-client direct-fetch hostname validation — `discordCdnGuard.ts`

`avatar.ts` and `import.ts` used `fetch(attachment.url)` after only a MIME-type check; `voice.ts` had a Discord CDN allowlist guard. Extracted the allowlist logic into a shared helper.

- New file: `bot-client/src/utils/discordCdnGuard.ts` (`validateDiscordCdnUrl`)
- Applied at all three fetch sites: `avatar.ts`, `voice.ts`, `import.ts`
- Tests in `discordCdnGuard.test.ts` (6 tests covering all paths)
- Existing `avatar.test.ts` mock URL fixed (was the typo `cdn.discord.com` instead of canonical `cdn.discordapp.com`)

Surfaced 2026-04-25 during beta.106 hotfix audit.

## Test plan

- [x] `pnpm test` — 14/14 tasks pass (4586 bot-client tests, all packages)
- [x] `pnpm quality` — green locally
- [ ] Verify CI green on PR
- [ ] No regression in upload paths (avatar/voice/import) — backstopped by existing tests + new helper test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)