### PR TITLE
fix(bot-client): preset autocomplete fails open on wallet check error

### DIFF
--- a/services/bot-client/src/commands/settings/preset/autocomplete.test.ts
+++ b/services/bot-client/src/commands/settings/preset/autocomplete.test.ts
@@ -502,6 +502,57 @@ describe('handleAutocomplete', () => {
       expect(choices.some(c => c.value === UNLOCK_MODELS_VALUE)).toBe(false);
     });
 
+    it('should fail open when wallet API errors — show all models, no upsell', async () => {
+      // Pre-fix bug: walletResult.ok && ... collapsed to false on API failure,
+      // forcing isGuestMode = true and hiding paid models for users who
+      // actually have active keys. ai-worker enforces the gate authoritatively
+      // at generation time, so failing open here is safe.
+      vi.mocked(mockInteraction.options.getFocused).mockReturnValue({
+        name: 'preset',
+        value: '',
+      } as unknown as string);
+      vi.mocked(callGatewayApi).mockImplementation((path: string) => {
+        if (path === '/user/llm-config') {
+          return Promise.resolve({
+            ok: true,
+            data: {
+              configs: [
+                mockLlmConfigSummary({
+                  id: '00000000-0000-4000-8000-0000000000c1',
+                  name: 'Claude Pro',
+                  model: 'anthropic/claude-sonnet-4',
+                  isGlobal: true,
+                  isOwned: false,
+                }),
+                mockLlmConfigSummary({
+                  id: '00000000-0000-4000-8000-0000000000c2',
+                  name: 'Grok Free',
+                  model: 'x-ai/grok-4.1-fast:free',
+                  isGlobal: true,
+                  isOwned: false,
+                }),
+              ],
+            },
+          });
+        }
+        if (path === '/wallet/list') {
+          return Promise.resolve({ ok: false, error: 'Gateway timeout', status: 504 });
+        }
+        return Promise.resolve({ ok: false, error: 'Unknown path', status: 404 });
+      });
+
+      await handleAutocomplete(mockInteraction);
+
+      const choices = vi.mocked(mockInteraction.respond).mock.calls[0][0] as {
+        name: string;
+        value: string;
+      }[];
+      // Both models should be present (no guest-mode filter applied)
+      expect(choices).toHaveLength(2);
+      // Upsell should NOT appear — we treated the user as paid
+      expect(choices.some(c => c.value === UNLOCK_MODELS_VALUE)).toBe(false);
+    });
+
     it('should add 🆓 badge to free models', async () => {
       vi.mocked(mockInteraction.options.getFocused).mockReturnValue({
         name: 'preset',

--- a/services/bot-client/src/commands/settings/preset/autocomplete.ts
+++ b/services/bot-client/src/commands/settings/preset/autocomplete.ts
@@ -92,9 +92,25 @@ async function handlePresetAutocomplete(
     return;
   }
 
-  // Check if user is in guest mode (no active wallet keys)
-  const hasActiveWallet = walletResult.ok && walletResult.data.keys.some(k => k.isActive === true);
-  const isGuestMode = !hasActiveWallet;
+  // Check if user is in guest mode (no active wallet keys).
+  //
+  // Fails OPEN on wallet-API failure: a transient `/wallet/list` error
+  // would otherwise collapse with `!hasActiveWallet` to force `isGuestMode
+  // = true`, hiding paid models from users who actually have active keys.
+  // Mirrors the pattern in guestModeValidation.checkGuestModePremiumAccess —
+  // the ai-worker's ApiKeyResolver + AuthStep enforce the gate
+  // authoritatively at generation time, so showing extra options here can't
+  // bypass the real check.
+  let isGuestMode: boolean;
+  if (walletResult.ok) {
+    isGuestMode = !walletResult.data.keys.some(k => k.isActive === true);
+  } else {
+    logger.warn(
+      { userId, error: walletResult.error },
+      'Wallet check failed in preset autocomplete — failing open, treating as paid'
+    );
+    isGuestMode = false;
+  }
 
   const queryLower = query.toLowerCase();
 


### PR DESCRIPTION
## Summary

The preset autocomplete handler had a guest-mode logic bug: a transient `/wallet/list` API failure would force `isGuestMode = true` and hide every paid model from users who actually had active API keys. Caused intermittent "where did all the models go?" reports.

## Root cause

```typescript
// services/bot-client/src/commands/settings/preset/autocomplete.ts (pre-fix)
const hasActiveWallet = walletResult.ok && walletResult.data.keys.some(k => k.isActive === true);
const isGuestMode = !hasActiveWallet;
```

The `walletResult.ok && ...` collapses to `false` on **any** wallet-API failure (timeout, 5xx, network blip). Combined with `!hasActiveWallet`, this forces `isGuestMode = true` regardless of whether the user actually has paid keys. There was no log to surface when this happened in prod.

## Fix

Mirror the canonical fail-open pattern from `guestModeValidation.checkGuestModePremiumAccess`:

```typescript
let isGuestMode: boolean;
if (walletResult.ok) {
  isGuestMode = !walletResult.data.keys.some(k => k.isActive === true);
} else {
  logger.warn(
    { userId, error: walletResult.error },
    'Wallet check failed in preset autocomplete — failing open, treating as paid'
  );
  isGuestMode = false;
}
```

The ai-worker's `ApiKeyResolver` + `AuthStep` enforce the gate authoritatively at generation time, so showing extra options in autocomplete cannot bypass the real check. Worst case is a clearer error at submit time, not a security hole.

## Test added

Added `'should fail open when wallet API errors — show all models, no upsell'` to `autocomplete.test.ts`. Mocks `/wallet/list` returning `{ ok: false, status: 504 }`; asserts both paid and free models appear in the response and the upsell is NOT added.

## Test plan

- [x] `pnpm test` for the affected file (17/17 pass — was 16)
- [x] Lint clean
- [ ] Verify CI green
- [ ] Manual smoke after merge: `/settings preset` while wallet endpoint is healthy → see all models. (Reproducing the failure path requires gateway/wallet downtime — covered by the unit test.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)