### PR TITLE
test(api-gateway): consolidate per-domain test-utils onto shared provisioned helper

### DIFF
--- a/services/api-gateway/src/routes/user/channel/activate.test.ts
+++ b/services/api-gateway/src/routes/user/channel/activate.test.ts
@@ -245,36 +245,4 @@ describe('POST /user/channel/activate', () => {
 
     expect(res.status).toHaveBeenCalledWith(201);
   });
-
-  it('should create user if they do not exist', async () => {
-    const personality = createMockPersonality({ isPublic: true });
-    const settings = createMockActivation();
-
-    // Override default mock so the shell path sees "user missing"
-    mockPrisma.user.findUnique
-      .mockResolvedValueOnce(null) // getOrCreateUserShell initial lookup
-      .mockResolvedValueOnce({ id: MOCK_USER_UUID, defaultPersonaId: null }); // post-create lookup in userHelpers
-    mockPrisma.user.create.mockResolvedValueOnce({ id: MOCK_USER_UUID });
-    mockPrisma.user.findFirst.mockResolvedValue(null);
-    mockPrisma.personality.findUnique.mockResolvedValue(personality);
-    mockPrisma.channelSettings.upsert.mockResolvedValue(settings);
-
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
-    const handler = getHandler(router, 'post', '/activate');
-    const { req, res } = createMockReqRes({
-      channelId: MOCK_DISCORD_USER_ID,
-      personalitySlug: 'test-character',
-      guildId: '987654321098765432',
-    });
-
-    await handler(req, res);
-
-    // Shell creation — api-gateway routes don't have username context, so
-    // UserService.getOrCreateUserShell runs a single $executeRaw CTE that
-    // atomically creates the user plus a placeholder persona named
-    // `"User {discordId}"`. The placeholder is renamed to the real
-    // username on the first bot-client interaction.
-    expect(mockPrisma.$executeRaw).toHaveBeenCalled();
-    expect(res.status).toHaveBeenCalledWith(201);
-  });
 });

--- a/services/api-gateway/src/routes/user/channel/test-utils.ts
+++ b/services/api-gateway/src/routes/user/channel/test-utils.ts
@@ -6,13 +6,10 @@ import { vi } from 'vitest';
 import {
   createMockIsBotOwner,
   createMockCreatedAt,
-  createMockReqRes,
+  createProvisionedMockReqRes,
   getHandler,
   type RouteHandler,
 } from '../../../test/shared-route-test-utils.js';
-
-// Re-export shared utilities used by test files
-export { createMockReqRes, getHandler, createMockCreatedAt, type RouteHandler };
 
 // Mock isBotOwner - must be before vi.mock to be hoisted
 export const mockIsBotOwner = createMockIsBotOwner();
@@ -22,6 +19,27 @@ export const MOCK_USER_UUID = '550e8400-e29b-41d4-a716-446655440000';
 export const MOCK_PERSONALITY_UUID = '550e8400-e29b-41d4-a716-446655440001';
 export const MOCK_ACTIVATION_UUID = '550e8400-e29b-41d4-a716-446655440002';
 export const MOCK_DISCORD_USER_ID = '123456789012345678';
+/** Sentinel default-persona id shared by channel-domain mocks. */
+const MOCK_DEFAULT_PERSONA_ID = 'test-persona-uuid';
+
+/**
+ * Channel-domain wrapper around the shared mock helper. Sets
+ * `provisionedUserId` to MOCK_USER_UUID so route handlers see the same id
+ * as `setupStandardMocks` returns from `mockPrisma.user.findUnique`.
+ */
+export function createMockReqRes(
+  body: Record<string, unknown> = {},
+  params: Record<string, string> = {},
+  query: Record<string, string> = {}
+): ReturnType<typeof createProvisionedMockReqRes> {
+  return createProvisionedMockReqRes(body, params, query, {
+    provisionedUserId: MOCK_USER_UUID,
+    provisionedDefaultPersonaId: MOCK_DEFAULT_PERSONA_ID,
+  });
+}
+
+// Re-export shared utilities used by test files
+export { getHandler, createMockCreatedAt, type RouteHandler };
 
 // Mock Prisma client with tables needed for channel settings tests + UserService dependencies
 export function createMockPrisma(): {
@@ -50,7 +68,6 @@ export function createMockPrisma(): {
     delete: ReturnType<typeof vi.fn>;
     updateMany: ReturnType<typeof vi.fn>;
   };
-  $executeRaw: ReturnType<typeof vi.fn>;
 } {
   return {
     user: {
@@ -60,14 +77,14 @@ export function createMockPrisma(): {
       findUnique: vi.fn().mockResolvedValue({
         id: MOCK_USER_UUID,
         username: 'test-user',
-        defaultPersonaId: 'test-persona-uuid',
+        defaultPersonaId: MOCK_DEFAULT_PERSONA_ID,
         isSuperuser: false,
       }),
       create: vi.fn(),
       update: vi.fn(),
     },
     persona: {
-      create: vi.fn().mockResolvedValue({ id: 'test-persona-uuid' }),
+      create: vi.fn().mockResolvedValue({ id: MOCK_DEFAULT_PERSONA_ID }),
     },
     personality: {
       findUnique: vi.fn(),
@@ -85,8 +102,6 @@ export function createMockPrisma(): {
       delete: vi.fn(),
       updateMany: vi.fn(),
     },
-    // UserService's create-user CTE; plain happy-path resolve by default.
-    $executeRaw: vi.fn().mockResolvedValue(1),
   };
 }
 

--- a/services/api-gateway/src/routes/user/persona/crud.test.ts
+++ b/services/api-gateway/src/routes/user/persona/crud.test.ts
@@ -18,6 +18,7 @@ import {
   mockPersona,
   MOCK_USER_ID,
   MOCK_PERSONA_ID,
+  MOCK_PERSONA_ID_2,
   NONEXISTENT_UUID,
 } from './test-utils.js';
 
@@ -113,25 +114,6 @@ describe('persona CRUD routes', () => {
         // This provides helpful error messages if the schema validation fails
         console.error('Schema validation failed:', parseResult.error.format());
       }
-    });
-
-    it('should create user if they do not exist', async () => {
-      // First call returns null (user doesn't exist), second returns created shell user
-      mockPrisma.user.findUnique
-        .mockResolvedValueOnce(null) // getOrCreateUserShell lookup
-        .mockResolvedValueOnce({ id: MOCK_USER_ID, defaultPersonaId: null }); // After shell creation
-      mockPrisma.user.create.mockResolvedValueOnce({ id: MOCK_USER_ID });
-      mockPrisma.persona.findMany.mockResolvedValue([]);
-
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
-      const handler = getHandler(router, 'get', '/');
-
-      const { req, res } = createMockReqRes();
-      await handler(req, res);
-
-      // Shell creation — api-gateway routes don't have username context.
-      // See UserService.getOrCreateUserShell — creates a User-only record.
-      expect(mockPrisma.$executeRaw).toHaveBeenCalled();
     });
 
     it('should handle personas with null content and pronouns', async () => {
@@ -294,36 +276,25 @@ describe('persona CRUD routes', () => {
       );
     });
 
-    it('should set first persona as default', async () => {
-      // User has no default persona
-      mockPrisma.user.findUnique.mockResolvedValue({
-        id: MOCK_USER_ID,
-        defaultPersonaId: null,
-      });
-      mockPrisma.persona.create.mockResolvedValue({
-        ...mockPersona,
-        id: 'new-persona-id',
-      });
-      mockPrisma.user.update.mockResolvedValue({});
-
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
-      const handler = getHandler(router, 'post', '/');
-
-      const { req, res } = createMockReqRes({
-        name: 'First Persona',
-        content: 'My first persona',
-      });
-      await handler(req, res);
-
-      expect(mockPrisma.user.update).toHaveBeenCalledWith({
-        where: { id: MOCK_USER_ID },
-        data: { defaultPersonaId: 'new-persona-id' },
-      });
-      expect(res.json).toHaveBeenCalledWith(
-        expect.objectContaining({
-          setAsDefault: true,
-        })
-      );
+    // Test skipped: "should set first persona as default" verified the
+    // `defaultPersonaId === null` branch in POST /user/persona. Post Identity
+    // Hardening, the provisioning middleware always supplies a non-null
+    // defaultPersonaId on req, so the branch is unreachable from the
+    // provisioned path. The route's `if (isFirstPersona)` block remains as
+    // defense-in-depth but isn't exercised by tests.
+    //
+    // TODO(identity-hardening-cleanup-PR): when the cleanup PR removes the
+    // `isFirstPersona` branch from crud.ts, delete this skipped test in the
+    // same commit so the suite doesn't carry a permanently-dead `it.skip`.
+    it.skip('should set first persona as default (UNREACHABLE post-Identity-Hardening)', () => {
+      // The pre-migration test body verified that POST /user/persona sets
+      // user.defaultPersonaId to the new persona's id when user.defaultPersonaId
+      // was null. After the test-utils consolidation, createMockReqRes always
+      // sets req.provisionedDefaultPersonaId = MOCK_PERSONA_ID, so the
+      // isFirstPersona branch (crud.ts:165-170) is unreachable from this test
+      // shape. Don't un-skip and "fix" the old body — the branch is what's
+      // unreachable, not the test setup. Delete this block in the same commit
+      // that removes isFirstPersona from the route.
     });
   });
 
@@ -470,18 +441,19 @@ describe('persona CRUD routes', () => {
 
   describe('DELETE /user/persona/:id', () => {
     it('should delete persona', async () => {
-      // UserService uses findUnique, not findFirst - set defaultPersonaId to null to allow delete
-      mockPrisma.user.findUnique.mockResolvedValue({ id: MOCK_USER_ID, defaultPersonaId: null });
-      mockPrisma.persona.findFirst.mockResolvedValue({ id: MOCK_PERSONA_ID });
+      // Delete a non-default persona (MOCK_PERSONA_ID_2) — provisioning
+      // middleware sets req.provisionedDefaultPersonaId = MOCK_PERSONA_ID,
+      // so deleting that id would trip the "can't delete default" guard.
+      mockPrisma.persona.findFirst.mockResolvedValue({ id: MOCK_PERSONA_ID_2 });
       mockPrisma.persona.delete.mockResolvedValue({});
 
       const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
       const handler = getHandler(router, 'delete', '/:id');
 
-      const { req, res } = createMockReqRes({}, { id: MOCK_PERSONA_ID });
+      const { req, res } = createMockReqRes({}, { id: MOCK_PERSONA_ID_2 });
       await handler(req, res);
 
-      expect(mockPrisma.persona.delete).toHaveBeenCalledWith({ where: { id: MOCK_PERSONA_ID } });
+      expect(mockPrisma.persona.delete).toHaveBeenCalledWith({ where: { id: MOCK_PERSONA_ID_2 } });
       expect(res.json).toHaveBeenCalledWith({ message: 'Persona deleted' });
     });
 

--- a/services/api-gateway/src/routes/user/persona/test-utils.ts
+++ b/services/api-gateway/src/routes/user/persona/test-utils.ts
@@ -4,14 +4,10 @@
 
 import { vi } from 'vitest';
 import {
-  createMockReqRes,
+  createProvisionedMockReqRes,
   getHandler,
-  createUserServiceExecuteRawMock,
   type RouteHandler,
 } from '../../../test/shared-route-test-utils.js';
-
-// Re-export shared utilities used by test files
-export { createMockReqRes, getHandler, type RouteHandler };
 
 // Valid UUIDs for testing (required by route validation)
 export const MOCK_USER_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
@@ -19,6 +15,27 @@ export const MOCK_PERSONA_ID = 'b2c3d4e5-f6a7-8901-bcde-f12345678901';
 export const MOCK_PERSONA_ID_2 = 'f6a7b8c9-d0e1-4345-a012-456789012345';
 export const MOCK_PERSONALITY_ID = 'c3d4e5f6-a7b8-9012-cdef-123456789012';
 export const NONEXISTENT_UUID = 'd4e5f6a7-b8c9-4123-9ef0-234567890123';
+
+/**
+ * Persona-domain wrapper around the shared mock helper. Sets
+ * `provisionedUserId` and `provisionedDefaultPersonaId` to the file's MOCK_*
+ * constants so route handlers see the same IDs as the rest of the test's
+ * Prisma mocks (which all use MOCK_USER_ID for user.id and MOCK_PERSONA_ID
+ * for default persona).
+ */
+export function createMockReqRes(
+  body: Record<string, unknown> = {},
+  params: Record<string, string> = {},
+  query: Record<string, string> = {}
+): ReturnType<typeof createProvisionedMockReqRes> {
+  return createProvisionedMockReqRes(body, params, query, {
+    provisionedUserId: MOCK_USER_ID,
+    provisionedDefaultPersonaId: MOCK_PERSONA_ID,
+  });
+}
+
+// Re-export shared utilities used by test files
+export { getHandler, type RouteHandler };
 
 export const mockUser = {
   id: MOCK_USER_ID,
@@ -65,7 +82,6 @@ interface MockPrismaClient {
     update: ReturnType<typeof vi.fn>;
     delete: ReturnType<typeof vi.fn>;
   };
-  $executeRaw: ReturnType<typeof vi.fn>;
 }
 
 /** Create mock Prisma client for testing - includes UserService dependencies */
@@ -100,6 +116,5 @@ export function createMockPrisma(): MockPrismaClient {
       update: vi.fn(),
       delete: vi.fn(),
     },
-    $executeRaw: createUserServiceExecuteRawMock(),
   };
 }

--- a/services/api-gateway/src/routes/user/personality/create.test.ts
+++ b/services/api-gateway/src/routes/user/personality/create.test.ts
@@ -197,31 +197,6 @@ describe('POST /user/personality (create)', () => {
     );
   });
 
-  it('should create user if not exists', async () => {
-    // First findUnique returns null (user doesn't exist), second returns created shell user
-    mockPrisma.user.findUnique
-      .mockResolvedValueOnce(null) // getOrCreateUserShell lookup
-      .mockResolvedValueOnce({ id: 'user-uuid-123', defaultPersonaId: null }); // After shell creation
-    mockPrisma.user.create.mockResolvedValueOnce({ id: 'user-uuid-123' });
-    mockPrisma.personality.create.mockResolvedValue(createMockPersonality());
-
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
-    const handler = getHandler(router, 'post', '/');
-    const { req, res } = createMockReqRes({
-      name: 'New Character',
-      slug: 'new-char',
-      characterInfo: 'Info',
-      personalityTraits: 'Traits',
-    });
-
-    await handler(req, res);
-
-    // Shell creation — api-gateway routes don't have username context.
-    // See UserService.getOrCreateUserShell.
-    expect(mockPrisma.$executeRaw).toHaveBeenCalled();
-    expect(res.status).toHaveBeenCalledWith(201);
-  });
-
   it('does not create a personality_default_configs row on personality create', async () => {
     // New personalities cascade to the current global default at request time
     // via PersonalityService.loadPersonality. Auto-pinning was removed after

--- a/services/api-gateway/src/routes/user/personality/test-utils.ts
+++ b/services/api-gateway/src/routes/user/personality/test-utils.ts
@@ -7,14 +7,39 @@ import {
   createMockIsBotOwner,
   createMockCreatedAt,
   createMockUpdatedAt,
-  createMockReqRes,
+  createProvisionedMockReqRes,
   getHandler,
-  createUserServiceExecuteRawMock,
   type RouteHandler,
 } from '../../../test/shared-route-test-utils.js';
 
+/**
+ * Internal user identifier used by every personality-route test mock. The
+ * value is a free-form string rather than a UUID; routes don't validate the
+ * format here, but consumers checking by exact equality (Prisma mocks,
+ * `provisionedUserId` comparison) all agree on this string.
+ */
+export const MOCK_USER_ID = 'user-uuid-123';
+
+/**
+ * Personality-domain wrapper around the shared mock helper. Sets
+ * `provisionedUserId` to MOCK_USER_ID so route handlers see the same id
+ * as `setupStandardMocks` returns from `mockPrisma.user.findUnique`.
+ */
+export function createMockReqRes(
+  body: Record<string, unknown> = {},
+  params: Record<string, string> = {},
+  query: Record<string, string> = {}
+): ReturnType<typeof createProvisionedMockReqRes> {
+  return createProvisionedMockReqRes(body, params, query, {
+    provisionedUserId: MOCK_USER_ID,
+    // provisionedDefaultPersonaId intentionally omitted — personality routes
+    // don't read user.defaultPersonaId, so the sentinel default from the shared
+    // helper is fine. Contrast with persona/test-utils, which does set it.
+  });
+}
+
 // Re-export shared utilities used by test files
-export { createMockReqRes, getHandler, type RouteHandler };
+export { getHandler, type RouteHandler };
 
 // Mock isBotOwner - must be before vi.mock to be hoisted
 export const mockIsBotOwner = createMockIsBotOwner();
@@ -45,7 +70,6 @@ export function createMockPrisma(): {
   systemPrompt: { findFirst: ReturnType<typeof vi.fn> };
   llmConfig: { findFirst: ReturnType<typeof vi.fn> };
   personalityDefaultConfig: { create: ReturnType<typeof vi.fn> };
-  $executeRaw: ReturnType<typeof vi.fn>;
 } {
   return {
     user: {
@@ -81,7 +105,6 @@ export function createMockPrisma(): {
     personalityDefaultConfig: {
       create: vi.fn(),
     },
-    $executeRaw: createUserServiceExecuteRawMock(),
   };
 }
 
@@ -110,8 +133,7 @@ export function createMockPersonality(
     isPublic: false,
     voiceEnabled: false,
     imageEnabled: false,
-    // eslint-disable-next-line sonarjs/no-duplicate-string -- Test fixture UUID shared across mock factory functions
-    ownerId: 'user-uuid-123',
+    ownerId: MOCK_USER_ID,
     avatarData: null,
     voiceReferenceType: null,
     customFields: null,
@@ -128,10 +150,10 @@ export function createMockPersonality(
 export function setupStandardMocks(mockPrisma: ReturnType<typeof createMockPrisma>): void {
   mockIsBotOwner.mockReturnValue(false);
   // Old findFirst for legacy code paths
-  mockPrisma.user.findFirst.mockResolvedValue({ id: 'user-uuid-123' });
+  mockPrisma.user.findFirst.mockResolvedValue({ id: MOCK_USER_ID });
   // UserService uses findUnique to look up users
   mockPrisma.user.findUnique.mockResolvedValue({
-    id: 'user-uuid-123',
+    id: MOCK_USER_ID,
     username: 'test-user',
     defaultPersonaId: null,
     isSuperuser: false,

--- a/services/api-gateway/src/test/shared-route-test-utils.ts
+++ b/services/api-gateway/src/test/shared-route-test-utils.ts
@@ -117,13 +117,3 @@ export function getHandler(
 ): RouteHandler {
   return getRouteHandler(router, method, path) as RouteHandler;
 }
-
-/**
- * Create a mock `$executeRaw` implementation for UserService's
- * CTE-based user creation (Phase 5b). UserService uses a single
- * `$executeRaw` call to atomically create the user + default persona,
- * so mocks need only resolve successfully.
- */
-export function createUserServiceExecuteRawMock(): ReturnType<typeof vi.fn> {
-  return vi.fn().mockResolvedValue(1);
-}


### PR DESCRIPTION
## Summary

Preparatory PR for the Identity Hardening final cleanup. Consolidates the three per-domain `test-utils.ts` files (persona, personality, channel) onto the shared `createProvisionedMockReqRes` helper, so route-test fixtures stop exercising the shadow-mode shell path.

After this lands, the upcoming Identity cleanup PR can flip the middleware to strict 400 + delete `getOrCreateUserShell` without simultaneously battling test-side dependencies on shell-path behavior.

### What changed

**3 test-utils.ts files migrated**:
- `routes/user/persona/test-utils.ts`
- `routes/user/personality/test-utils.ts`
- `routes/user/channel/test-utils.ts`

Each now wraps the shared `createProvisionedMockReqRes` and sets `provisionedUserId` to the same UUID the file's `mockPrisma.user.findUnique` returns.

**4 obsolete tests cleaned up**:
- `persona/crud.test.ts`: removed `should create user if they do not exist`; skipped `should set first persona as default` with rationale (branch unreachable from provisioned path); updated `should delete persona` to use `MOCK_PERSONA_ID_2` since the default-id check now reads from `req.provisionedDefaultPersonaId`
- `personality/create.test.ts`: removed `should create user if not exists`
- `channel/activate.test.ts`: removed `should create user if they do not exist`

### Out of scope

~20 user/wallet route test files still define their own local `createMockReqRes` helpers that bypass the shared one. Those are not migrated here because they currently pass via shadow-mode fallback. They'll need migration when the strict-middleware flip lands; that work is intentionally bundled with the actual cleanup PR (or a focused follow-up) so the test changes track the production-code changes.

## Test plan

- [x] `pnpm --filter @tzurot/api-gateway test` — 1696 passing, 1 skipped, 0 failing
- [x] `pnpm --filter @tzurot/api-gateway typecheck` — clean
- [x] `pnpm --filter @tzurot/api-gateway lint` — clean
- [x] Pre-push hook all green: depcruise (1478 modules), build, test, typecheck:spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)