### PR TITLE
test(api-gateway): normalize personality MOCK_USER_ID to real UUID format

### DIFF
--- a/services/api-gateway/src/routes/user/personality/create.test.ts
+++ b/services/api-gateway/src/routes/user/personality/create.test.ts
@@ -10,6 +10,7 @@ import {
   createMockReqRes,
   getHandler,
   setupStandardMocks,
+  MOCK_USER_ID,
 } from './test-utils.js';
 
 // Mock dependencies before imports
@@ -175,7 +176,7 @@ describe('POST /user/personality (create)', () => {
           slug: 'new-char',
           characterInfo: 'A new character',
           personalityTraits: 'Friendly, kind',
-          ownerId: 'user-uuid-123',
+          ownerId: MOCK_USER_ID,
           isPublic: false,
         }),
         select: expect.objectContaining({

--- a/services/api-gateway/src/routes/user/personality/delete.test.ts
+++ b/services/api-gateway/src/routes/user/personality/delete.test.ts
@@ -10,6 +10,7 @@ import {
   getHandler,
   mockIsBotOwner,
   setupStandardMocks,
+  MOCK_USER_ID,
 } from './test-utils.js';
 
 // Mock dependencies before imports
@@ -113,7 +114,7 @@ describe('DELETE /user/personality/:slug', () => {
     mockPrisma.personality.findUnique.mockResolvedValue({
       id: 'personality-owned',
       name: 'My Character',
-      ownerId: 'user-uuid-123',
+      ownerId: MOCK_USER_ID,
       _count: {
         conversationHistory: 10,
         memories: 5,
@@ -142,7 +143,7 @@ describe('DELETE /user/personality/:slug', () => {
     mockPrisma.personality.findUnique.mockResolvedValue({
       id: 'personality-counts',
       name: 'Count Test',
-      ownerId: 'user-uuid-123',
+      ownerId: MOCK_USER_ID,
       _count: {
         conversationHistory: 50,
         memories: 25,
@@ -178,7 +179,7 @@ describe('DELETE /user/personality/:slug', () => {
     mockPrisma.personality.findUnique.mockResolvedValue({
       id: 'personality-schema',
       name: 'Schema Test',
-      ownerId: 'user-uuid-123',
+      ownerId: MOCK_USER_ID,
       _count: {
         conversationHistory: 5,
         memories: 3,
@@ -206,7 +207,7 @@ describe('DELETE /user/personality/:slug', () => {
     mockPrisma.personality.findUnique.mockResolvedValue({
       id: 'personality-no-pending',
       name: 'No Pending',
-      ownerId: 'user-uuid-123',
+      ownerId: MOCK_USER_ID,
       _count: {
         conversationHistory: 5,
         memories: 3,
@@ -274,7 +275,7 @@ describe('DELETE /user/personality/:slug', () => {
     });
     // User has co-ownership entry in PersonalityOwner table
     mockPrisma.personalityOwner.findUnique.mockResolvedValue({
-      userId: 'user-uuid-123',
+      userId: MOCK_USER_ID,
       personalityId: 'personality-coowned',
     });
     mockPrisma.pendingMemory.count.mockResolvedValue(0);
@@ -294,7 +295,7 @@ describe('DELETE /user/personality/:slug', () => {
       mockPrisma.personality.findUnique.mockResolvedValue({
         id: 'personality-avatar-delete',
         name: 'Avatar Test',
-        ownerId: 'user-uuid-123',
+        ownerId: MOCK_USER_ID,
         _count: {
           conversationHistory: 0,
           memories: 0,
@@ -396,7 +397,7 @@ describe('DELETE /user/personality/:slug', () => {
       mockPrisma.personality.findUnique.mockResolvedValue({
         id: 'personality-cache-test',
         name: 'Cache Test',
-        ownerId: 'user-uuid-123',
+        ownerId: MOCK_USER_ID,
         _count: {
           conversationHistory: 0,
           memories: 0,

--- a/services/api-gateway/src/routes/user/personality/get.test.ts
+++ b/services/api-gateway/src/routes/user/personality/get.test.ts
@@ -9,6 +9,7 @@ import {
   createMockReqRes,
   getHandler,
   setupStandardMocks,
+  MOCK_USER_ID,
 } from './test-utils.js';
 
 // Mock dependencies before imports
@@ -150,7 +151,7 @@ describe('GET /user/personality/:slug', () => {
       isPublic: false,
       voiceEnabled: false,
       imageEnabled: false,
-      ownerId: 'user-uuid-123',
+      ownerId: MOCK_USER_ID,
       avatarData: Buffer.from('test'),
       voiceReferenceType: null,
       createdAt: new Date('2024-01-01'),

--- a/services/api-gateway/src/routes/user/personality/list.test.ts
+++ b/services/api-gateway/src/routes/user/personality/list.test.ts
@@ -10,6 +10,7 @@ import {
   getHandler,
   mockIsBotOwner,
   setupStandardMocks,
+  MOCK_USER_ID,
 } from './test-utils.js';
 
 // Mock dependencies before imports
@@ -109,7 +110,7 @@ describe('GET /user/personality (list)', () => {
       name: 'My Character',
       displayName: 'Mine',
       slug: 'my-character',
-      ownerId: 'user-uuid-123',
+      ownerId: MOCK_USER_ID,
       isPublic: false,
       owner: { discordId: 'discord-123456789' },
     };
@@ -187,7 +188,7 @@ describe('GET /user/personality (list)', () => {
           name: 'Admin Character',
           displayName: 'Admin',
           slug: 'admin-char',
-          ownerId: 'user-uuid-123', // Owned by bot owner
+          ownerId: MOCK_USER_ID, // Owned by bot owner
           isPublic: false,
           owner: { discordId: 'test-user-id' },
         },

--- a/services/api-gateway/src/routes/user/personality/test-utils.ts
+++ b/services/api-gateway/src/routes/user/personality/test-utils.ts
@@ -13,12 +13,12 @@ import {
 } from '../../../test/shared-route-test-utils.js';
 
 /**
- * Internal user identifier used by every personality-route test mock. The
- * value is a free-form string rather than a UUID; routes don't validate the
- * format here, but consumers checking by exact equality (Prisma mocks,
- * `provisionedUserId` comparison) all agree on this string.
+ * Internal user UUID used by every personality-route test mock. RFC-4122
+ * format matches the convention in `persona/test-utils.ts` and
+ * `channel/test-utils.ts` — protects against future middleware-side UUID
+ * validation that would reject the legacy `'user-uuid-123'` placeholder.
  */
-export const MOCK_USER_ID = 'user-uuid-123';
+export const MOCK_USER_ID = 'b9c8d7e6-f5a4-4321-b8c7-d6e5f4a3b2c1';
 
 /**
  * Personality-domain wrapper around the shared mock helper. Sets

--- a/services/api-gateway/src/routes/user/personality/update.test.ts
+++ b/services/api-gateway/src/routes/user/personality/update.test.ts
@@ -11,6 +11,7 @@ import {
   getHandler,
   setupStandardMocks,
   mockIsBotOwner,
+  MOCK_USER_ID,
 } from './test-utils.js';
 
 // Mock dependencies before imports
@@ -115,7 +116,7 @@ describe('PUT /user/personality/:slug (update)', () => {
   it('should update owned personality', async () => {
     mockPrisma.personality.findUnique.mockResolvedValue({
       id: 'personality-7',
-      ownerId: 'user-uuid-123',
+      ownerId: MOCK_USER_ID,
     });
     mockPrisma.personality.update.mockResolvedValue(
       createMockPersonality({
@@ -168,7 +169,7 @@ describe('PUT /user/personality/:slug (update)', () => {
     });
     // User has co-ownership entry in PersonalityOwner table
     mockPrisma.personalityOwner.findUnique.mockResolvedValue({
-      userId: 'user-uuid-123',
+      userId: MOCK_USER_ID,
       personalityId: 'personality-8',
     });
     mockPrisma.personality.update.mockResolvedValue(
@@ -195,7 +196,7 @@ describe('PUT /user/personality/:slug (update)', () => {
     beforeEach(() => {
       mockPrisma.personality.findUnique.mockResolvedValue({
         id: 'personality-unicode',
-        ownerId: 'user-uuid-123',
+        ownerId: MOCK_USER_ID,
         name: 'persephone', // Plain ASCII name
       });
     });
@@ -328,7 +329,7 @@ describe('PUT /user/personality/:slug (update)', () => {
       // Standard setup: user exists, owns the personality
       mockPrisma.personality.findUnique.mockResolvedValue({
         id: 'personality-avatar',
-        ownerId: 'user-uuid-123',
+        ownerId: MOCK_USER_ID,
         name: 'Test',
         avatarData: null,
       });
@@ -434,7 +435,7 @@ describe('PUT /user/personality/:slug (update)', () => {
       // Invalid slugs should not trigger glob at all
       mockPrisma.personality.findUnique.mockResolvedValue({
         id: 'personality-avatar',
-        ownerId: 'user-uuid-123',
+        ownerId: MOCK_USER_ID,
         slug: '../../../etc/passwd', // Malicious slug
         avatarData: null,
       });
@@ -459,7 +460,7 @@ describe('PUT /user/personality/:slug (update)', () => {
     beforeEach(() => {
       mockPrisma.personality.findUnique.mockResolvedValue({
         id: 'personality-cache',
-        ownerId: 'user-uuid-123',
+        ownerId: MOCK_USER_ID,
         name: 'Test',
         avatarData: null,
       });
@@ -546,7 +547,7 @@ describe('PUT /user/personality/:slug (update)', () => {
     beforeEach(() => {
       mockPrisma.personality.findUnique.mockResolvedValue({
         id: 'personality-voice',
-        ownerId: 'user-uuid-123',
+        ownerId: MOCK_USER_ID,
         name: 'Test',
       });
       mockPrisma.personality.update.mockResolvedValue(
@@ -697,7 +698,7 @@ describe('PUT /user/personality/:slug (update)', () => {
       // Setup: user exists and owns the personality
       mockPrisma.personality.findUnique.mockResolvedValue({
         id: 'personality-slug-test',
-        ownerId: 'user-uuid-123',
+        ownerId: MOCK_USER_ID,
         name: 'Test Character',
       });
     });
@@ -730,7 +731,7 @@ describe('PUT /user/personality/:slug (update)', () => {
       mockPrisma.personality.findUnique
         .mockResolvedValueOnce({
           id: 'personality-slug-test',
-          ownerId: 'user-uuid-123',
+          ownerId: MOCK_USER_ID,
           name: 'Test Character',
         })
         .mockResolvedValueOnce(null); // Uniqueness check
@@ -777,7 +778,7 @@ describe('PUT /user/personality/:slug (update)', () => {
       mockPrisma.personality.findUnique
         .mockResolvedValueOnce({
           id: 'personality-slug-test',
-          ownerId: 'user-uuid-123',
+          ownerId: MOCK_USER_ID,
           name: 'Test Character',
         })
         .mockResolvedValueOnce(null); // Uniqueness check
@@ -843,7 +844,7 @@ describe('PUT /user/personality/:slug (update)', () => {
       mockPrisma.personality.findUnique
         .mockResolvedValueOnce({
           id: 'personality-slug-test',
-          ownerId: 'user-uuid-123',
+          ownerId: MOCK_USER_ID,
           name: 'Test Character',
         })
         .mockResolvedValueOnce({ id: 'other-personality' }); // Another personality has this slug

--- a/services/api-gateway/src/routes/user/personality/visibility.test.ts
+++ b/services/api-gateway/src/routes/user/personality/visibility.test.ts
@@ -9,6 +9,7 @@ import {
   createMockReqRes,
   getHandler,
   setupStandardMocks,
+  MOCK_USER_ID,
 } from './test-utils.js';
 
 // Mock dependencies before imports
@@ -86,7 +87,7 @@ describe('PATCH /user/personality/:slug/visibility', () => {
   it('should toggle visibility to public', async () => {
     mockPrisma.personality.findUnique.mockResolvedValue({
       id: 'personality-10',
-      ownerId: 'user-uuid-123',
+      ownerId: MOCK_USER_ID,
       isPublic: false,
     });
     mockPrisma.personality.update.mockResolvedValue({
@@ -120,7 +121,7 @@ describe('PATCH /user/personality/:slug/visibility', () => {
   it('should toggle visibility to private', async () => {
     mockPrisma.personality.findUnique.mockResolvedValue({
       id: 'personality-11',
-      ownerId: 'user-uuid-123',
+      ownerId: MOCK_USER_ID,
       isPublic: true,
     });
     mockPrisma.personality.update.mockResolvedValue({


### PR DESCRIPTION
## Summary

Two-part nit cleanup deferred from PR #909 round 4 review.

1. **Sweep 24 inline `'user-uuid-123'` literals** across 6 personality test files (`create.test.ts`, `delete.test.ts`, `get.test.ts`, `list.test.ts`, `update.test.ts`, `visibility.test.ts`) onto the `MOCK_USER_ID` constant exported from `test-utils.ts`. Each file gains a one-line import addition.

2. **Change `MOCK_USER_ID`'s value** from the free-form `'user-uuid-123'` to a proper RFC-4122 UUID (`b9c8d7e6-f5a4-4321-b8c7-d6e5f4a3b2c1`). Matches the convention in `persona/test-utils.ts` and `channel/test-utils.ts`. Defensive against future middleware-side UUID validation that would reject the legacy placeholder.

Reviewer flagged both items in PR #909 round 4 as "minor" / "could land as fixups." Handling as a focused follow-up rather than backlog per user direction ("no reason to backlog something that minor").

## Test plan

- [x] `pnpm --filter @tzurot/api-gateway test` — 1696 passing, 1 skipped (pre-existing `it.skip` from PR #909), 0 failing
- [x] `pnpm --filter @tzurot/api-gateway typecheck` — clean
- [x] `pnpm --filter @tzurot/api-gateway lint` — clean
- [x] Pre-push hook all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)