### PR TITLE
chore: remove vestigial setAsDefault + collector sanity check

### DIFF
--- a/packages/common-types/src/factories/persona.ts
+++ b/packages/common-types/src/factories/persona.ts
@@ -147,7 +147,6 @@ export function mockCreatePersonaResponse(
   const base: CreatePersonaResponse = {
     success: true,
     persona: createBasePersonaDetails(),
-    setAsDefault: false,
   };
   return CreatePersonaResponseSchema.parse(deepMerge(base, overrides));
 }

--- a/packages/common-types/src/schemas/api/persona.test.ts
+++ b/packages/common-types/src/schemas/api/persona.test.ts
@@ -150,17 +150,6 @@ describe('Persona API Contract Tests', () => {
       const data = {
         success: true as const,
         persona: createValidPersonaDetails(),
-        setAsDefault: true,
-      };
-      const result = CreatePersonaResponseSchema.safeParse(data);
-      expect(result.success).toBe(true);
-    });
-
-    it('should accept create response with setAsDefault=false', () => {
-      const data = {
-        success: true as const,
-        persona: createValidPersonaDetails({ isDefault: false }),
-        setAsDefault: false,
       };
       const result = CreatePersonaResponseSchema.safeParse(data);
       expect(result.success).toBe(true);
@@ -170,7 +159,6 @@ describe('Persona API Contract Tests', () => {
       const data = {
         success: false,
         persona: createValidPersonaDetails(),
-        setAsDefault: true,
       };
       const result = CreatePersonaResponseSchema.safeParse(data);
       expect(result.success).toBe(false);

--- a/packages/common-types/src/schemas/api/persona.ts
+++ b/packages/common-types/src/schemas/api/persona.ts
@@ -89,7 +89,6 @@ export type GetPersonaResponse = z.infer<typeof GetPersonaResponseSchema>;
 export const CreatePersonaResponseSchema = z.object({
   success: z.literal(true),
   persona: PersonaDetailsSchema,
-  setAsDefault: z.boolean(),
 });
 export type CreatePersonaResponse = z.infer<typeof CreatePersonaResponseSchema>;
 

--- a/services/ai-worker/src/services/diagnostics/personalityOwnerResolver.test.ts
+++ b/services/ai-worker/src/services/diagnostics/personalityOwnerResolver.test.ts
@@ -196,9 +196,12 @@ describe('DiagnosticCollector construction is funneled through the owner resolve
           '\n'
         )}\nAll production code must construct DiagnosticCollector via createDiagnosticCollectorForRequest so the owner resolver is invoked.`
     ).toEqual([]);
-    // Sanity: the resolver callsite still exists. Catches accidental rename
-    // of the helper that would silently make this test trivially pass.
+    // Sanity: each allowlist entry still maps to a real construction site.
+    // Catches accidental rename of either file that would silently make this
+    // test trivially pass.
     const resolverPath = path.normalize('services/diagnostics/personalityOwnerResolver.ts');
     expect(offenders.some(o => o.file.endsWith(resolverPath))).toBe(true);
+    const collectorPath = path.normalize('services/DiagnosticCollector.ts');
+    expect(offenders.some(o => o.file.endsWith(collectorPath))).toBe(true);
   });
 });

--- a/services/api-gateway/src/routes/user/persona/crud.ts
+++ b/services/api-gateway/src/routes/user/persona/crud.ts
@@ -162,10 +162,6 @@ function createCreateHandler(prisma: PrismaClient) {
       select: PERSONA_SELECT,
     });
 
-    // The provisioning middleware always supplies a non-null defaultPersonaId
-    // on req, so this newly-created persona is never the first one. The
-    // shell-path-era branch that auto-set a "first" persona as the default
-    // was deleted alongside getOrCreateUserShell.
     logger.info({ userId: user.id, personaId: persona.id }, 'Created new persona');
 
     sendCustomSuccess(
@@ -173,7 +169,6 @@ function createCreateHandler(prisma: PrismaClient) {
       {
         success: true,
         persona: toPersonaDetails(persona, false),
-        setAsDefault: false,
       },
       StatusCodes.CREATED
     );

--- a/services/bot-client/src/commands/persona/create.test.ts
+++ b/services/bot-client/src/commands/persona/create.test.ts
@@ -97,7 +97,6 @@ describe('handleCreateModalSubmit', () => {
           pronouns: 'she/her',
           content: 'I am professional',
         },
-        setAsDefault: false,
       }),
     });
 
@@ -133,37 +132,6 @@ describe('handleCreateModalSubmit', () => {
     });
   });
 
-  it('should indicate when set as default', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: mockCreatePersonaResponse({
-        persona: {
-          name: 'First Persona',
-          description: null,
-          preferredName: null,
-          pronouns: null,
-          content: null,
-        },
-        setAsDefault: true,
-      }),
-    });
-
-    await handleCreateModalSubmit(
-      createMockModalInteraction({
-        personaName: 'First Persona',
-        description: '',
-        preferredName: '',
-        pronouns: '',
-        content: '',
-      })
-    );
-
-    expect(mockReply).toHaveBeenCalledWith({
-      content: expect.stringContaining('set as your default'),
-      flags: MessageFlags.Ephemeral,
-    });
-  });
-
   it('should require persona name', async () => {
     await handleCreateModalSubmit(
       createMockModalInteraction({
@@ -193,7 +161,6 @@ describe('handleCreateModalSubmit', () => {
           pronouns: null,
           content: '',
         },
-        setAsDefault: false,
       }),
     });
 
@@ -236,7 +203,6 @@ describe('handleCreateModalSubmit', () => {
           pronouns: 'she/her',
           content: 'content',
         },
-        setAsDefault: false,
       }),
     });
 

--- a/services/bot-client/src/commands/persona/create.ts
+++ b/services/bot-client/src/commands/persona/create.ts
@@ -32,7 +32,6 @@ interface CreatePersonaResponse {
     pronouns: string | null;
     content: string | null;
   };
-  setAsDefault: boolean;
 }
 
 /**
@@ -111,13 +110,9 @@ export async function handleCreateModalSubmit(interaction: ModalSubmitInteractio
       return;
     }
 
-    const { persona, setAsDefault } = result.data;
+    const { persona } = result.data;
 
     logger.info({ userId: discordId, personaId: persona.id, personaName }, 'Created new persona');
-
-    if (setAsDefault) {
-      logger.info({ userId: discordId, personaId: persona.id }, 'Set as default (first persona)');
-    }
 
     // Build response
     const details: string[] = [];
@@ -139,9 +134,6 @@ export async function handleCreateModalSubmit(interaction: ModalSubmitInteractio
     let response = `✅ **Persona "${personaName}" created!**`;
     if (details.length > 0) {
       response += `\n\n${details.join('\n')}`;
-    }
-    if (setAsDefault) {
-      response += '\n\n⭐ This persona has been set as your default.';
     }
     response += '\n\nUse `/persona browse` to see all your personas.';
 

--- a/services/bot-client/src/commands/persona/types.ts
+++ b/services/bot-client/src/commands/persona/types.ts
@@ -61,5 +61,4 @@ export interface FlattenedPersonaData {
 export interface SavePersonaResponse {
   success: boolean;
   persona: PersonaDetails;
-  setAsDefault?: boolean;
 }


### PR DESCRIPTION
## Summary

Two small follow-ups from PR #911 / PR #908 reviews, bundled because each is tiny.

### Item 1 — Remove vestigial \`setAsDefault\` field

Post-Identity-Hardening, the \`setAsDefault\` field on \`CreatePersonaResponse\` is structurally always \`false\` because the provisioning middleware always supplies a non-null \`defaultPersonaId\` on \`req\` (the \`isFirstPersona\` branch in \`crud.ts\` was unreachable and was deleted in #911).

Bot-client *did* read the flag (\`services/bot-client/src/commands/persona/create.ts\` line 35, 114, 118-120, 143-145), but only into branches that can no longer fire — a log line and a "⭐ This persona has been set as your default." response message. Removing the field cleans up both ends symmetrically.

Audit confirmed bot-client is the sole consumer; no other services or tests assert against the field.

### Item 2 — DiagnosticCollector sanity check

The structural guard test at \`services/ai-worker/src/services/diagnostics/personalityOwnerResolver.test.ts\` had an asymmetry: it asserted that one of two allowlist entries (\`personalityOwnerResolver.ts\`) still mapped to a real \`new DiagnosticCollector(...)\` callsite, but didn't have the same assertion for the other allowlist entry (\`DiagnosticCollector.ts\` itself). Symmetric assertion added.

If \`DiagnosticCollector.ts\` is renamed in the future, the test now fails instead of silently passing — same silent-rot guard the existing resolver assertion provides.

## Test plan
- [x] \`pnpm test\` — all 4591 bot-client tests + api-gateway + common-types green
- [x] \`pnpm quality\` — lint, typecheck, depcruise, cpd all clean
- [x] Audit confirmed no \`setAsDefault\` consumer in src trees beyond \`persona/create.ts\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)