### PR TITLE
fix(bot-client): handle SIGTERM gracefully + add DM raw-gateway diagnostic

### DIFF
--- a/services/bot-client/src/index.ts
+++ b/services/bot-client/src/index.ts
@@ -438,13 +438,51 @@ client.on(Events.Error, error => {
   logger.error({ err: error }, 'Discord client error');
 });
 
+// Optional raw-gateway diagnostic — gated by env var so it can be enabled per
+// deploy without code changes. Set DM_RAW_GATEWAY_DIAGNOSTIC=true to log every
+// DM-shaped MESSAGE_CREATE packet received from the gateway. Used to confirm
+// whether post-deploy DM silence is "Discord didn't deliver the packet" (no log
+// line for the test DM) vs "Discord.js dropped it after delivery" (log line
+// present but no MessageCreate handler invocation).
+if (process.env.DM_RAW_GATEWAY_DIAGNOSTIC === 'true') {
+  logger.warn(
+    'DM_RAW_GATEWAY_DIAGNOSTIC enabled — raw gateway packets will be logged. ' +
+      'Disable for production once diagnosis is complete.'
+  );
+  client.on(
+    'raw',
+    (packet: { t?: string; d?: { id?: string; channel_id?: string; guild_id?: string } }) => {
+      if (packet.t === 'MESSAGE_CREATE' && packet.d !== undefined) {
+        const isDm = packet.d.channel_id !== undefined && packet.d.guild_id === undefined;
+        if (isDm) {
+          logger.info(
+            { messageId: packet.d.id, channelId: packet.d.channel_id },
+            '[RAW GATEWAY] DM MESSAGE_CREATE packet received'
+          );
+        }
+      }
+    }
+  );
+}
+
 process.on('unhandledRejection', error => {
   logger.error({ err: error }, 'Unhandled rejection');
 });
 
-// Graceful shutdown
-process.on('SIGINT', () => {
-  logger.info('Shutting down...');
+// Graceful shutdown — register for BOTH SIGTERM (Railway/orchestrator) and
+// SIGINT (Ctrl+C in dev). Without SIGTERM handling, Railway's deploy lifecycle
+// hard-kills the process before client.destroy() can close the Discord gateway
+// session, leaving an orphaned shard that competes with the new instance until
+// Discord's session timeout — observed as DMs being silent for ~minutes after
+// every deploy (Hypothesis A under investigation, see DM_RAW_GATEWAY_DIAGNOSTIC).
+let shutdownInitiated = false;
+function handleShutdownSignal(signal: NodeJS.Signals): void {
+  if (shutdownInitiated) {
+    logger.warn({ signal }, 'Shutdown signal received again — already shutting down');
+    return;
+  }
+  shutdownInitiated = true;
+  logger.info({ signal }, 'Shutting down...');
 
   // Stop accepting new results first to prevent race condition during shutdown
   void services.resultsListener.stop();
@@ -476,7 +514,9 @@ process.on('SIGINT', () => {
       void disconnectPrisma();
       process.exit(0);
     });
-});
+}
+process.on('SIGTERM', handleShutdownSignal);
+process.on('SIGINT', handleShutdownSignal);
 
 /**
  * Verify database connection and log personality count


### PR DESCRIPTION
## Summary

Two-part fix for the post-deploy DM-silence pattern observed across multiple releases.

### Problem

After every Railway deploy, plain-text DMs to the bot are silently dropped on Discord's side until the user fires a slash command in the DM. Slash commands work; guild messages work; only plain-text \`MESSAGE_CREATE\` in DMs is dropped. Pattern is per-user-per-restart reproducible. Originally believed to require a userland DM-subscription warmer (~300+ LOC). Council consultation (\`google/gemini-3.1-pro-preview\`) and config investigation revealed a simpler structural cause.

### Root cause hypothesis

Two compounding issues:

1. **Missing SIGTERM handler.** Railway sends SIGTERM (not SIGINT) to terminate processes during deploys. Previously only SIGINT was handled, so V1 hard-exited on every Railway deploy without calling \`client.destroy()\` — leaving an orphaned Discord gateway session for Shard 0 that competed with V2's freshly-connected session for ~minutes until Discord's server-side session timeout.

2. **Railway's deploy overlap window.** \`railway status --json\` confirms \`overlapSeconds: null\` (default zero-downtime overlap), \`healthcheckPath: null\` (no readiness signal), \`drainingSeconds: null\` (no graceful drain). Result: V2 connects to gateway while V1 is still alive; both claim Shard 0 concurrently for the overlap window. Without the SIGTERM handler, V1's gateway session is never cleanly closed, leaving its DM channel subscriptions stuck on a dead session.

The orphaned-shard hypothesis explains every observed symptom — slash commands work because they have explicit interaction routing through a different code path; the slash command's implicit \`POST /users/@me/channels\` is what unsticks DMs because it forces V2 to establish a fresh subscription on its own session.

## Changes

### 1. Graceful SIGTERM handling

Refactored the existing SIGINT handler into a shared \`handleShutdownSignal\` function and registered it for both signals. Idempotent via \`shutdownInitiated\` guard (a SIGINT-then-SIGTERM sequence won't run shutdown twice).

This is the **actual fix** for the orphaned-shard hypothesis. \`client.destroy()\` now runs on Railway-initiated shutdown, closing the gateway WebSocket cleanly and releasing the shard claim before V2 finishes warming up.

### 2. Raw-gateway diagnostic (env-gated)

Added an opt-in \`client.on('raw')\` listener gated by \`DM_RAW_GATEWAY_DIAGNOSTIC=true\`. When enabled, it logs every DM-shaped \`MESSAGE_CREATE\` packet received from the gateway. Used to **verify the fix** rather than build it speculatively.

The binary signal — log line present vs absent for a known test DM — distinguishes:
- **Discord didn't route the packet to this process** (consistent with shard-overlap orphan session) → SIGTERM fix should resolve it
- **Discord.js received it and dropped it** (would point at cache/Partials issues despite \`Partials.Channel\` being configured) → different fix needed

Disabled by default; opt in via Railway env var per deploy. Logs are structured so they don't pollute production-typical traffic when enabled.

## Why this PR shape

Council recommended diagnostic-first before designing any fix. We have strong code-level evidence for the SIGTERM hypothesis, but shipping the fix bundled with the diagnostic gives us evidence-of-fix on the next deploy without a second PR cycle. If the diagnostic fires on test DMs after deploy → SIGTERM fix worked. If it doesn't → we have a clean signal to pivot.

## Test plan

- [x] \`pnpm --filter @tzurot/bot-client typecheck\` clean
- [x] \`pnpm --filter @tzurot/bot-client lint\` clean
- [x] \`pnpm test\` — all 4591 bot-client tests + workspace tests green
- [ ] **Post-merge / post-deploy**: enable \`DM_RAW_GATEWAY_DIAGNOSTIC=true\` on dev (or prod) for one release cycle. Send a test plain-text DM. Read logs:
  - Log line present + handler fires → fix worked, DMs route correctly post-deploy
  - Log line present + handler doesn't fire → Discord.js side issue, file new investigation
  - Log line absent → either still shard-overlap (less likely with SIGTERM handler) OR something else, file new investigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)