### PR TITLE
fix(bot-client): pre-warm DM channel cache on every user encounter

### DIFF
--- a/services/bot-client/src/index.ts
+++ b/services/bot-client/src/index.ts
@@ -44,6 +44,7 @@ import { ReplyResolutionService } from './services/ReplyResolutionService.js';
 import { PersonalityMessageHandler } from './services/PersonalityMessageHandler.js';
 import { PersonalityIdCache } from './services/PersonalityIdCache.js';
 import { DenylistCache } from './services/DenylistCache.js';
+import { DMCacheWarmer } from './services/DMCacheWarmer.js';
 import { registerServices } from './services/serviceRegistry.js';
 
 // Processors
@@ -136,6 +137,7 @@ interface Services {
   channelActivationCacheInvalidationService: ChannelActivationCacheInvalidationService;
   denylistCache: DenylistCache;
   denylistCacheInvalidationService: DenylistCacheInvalidationService;
+  dmCacheWarmer: DMCacheWarmer;
 }
 
 /**
@@ -184,6 +186,12 @@ function createServices(): Services {
   // Denylist cache and invalidation service
   const denylistCache = new DenylistCache();
   const denylistCacheInvalidationService = new DenylistCacheInvalidationService(cacheRedis);
+
+  // DM channel cache warmer — pre-establishes Discord.js's internal channel
+  // cache for any user we encounter, so subsequent plain-text DMs can be
+  // resolved by MessageCreateAction.getChannel(). See DMCacheWarmer.ts for
+  // the full diagnosis narrative.
+  const dmCacheWarmer = new DMCacheWarmer();
 
   // Message handling services
   const responseSender = new DiscordResponseSender(webhookManager);
@@ -257,6 +265,7 @@ function createServices(): Services {
     channelActivationCacheInvalidationService,
     denylistCache,
     denylistCacheInvalidationService,
+    dmCacheWarmer,
   };
 }
 
@@ -266,6 +275,10 @@ let commandHandler: CommandHandler;
 
 // Message handler - wrapped to handle async properly
 client.on(Events.MessageCreate, message => {
+  // Warm the DM channel cache for this user; see DMCacheWarmer.ts for why.
+  if (!message.author.bot) {
+    services.dmCacheWarmer.warm(message.author);
+  }
   void (async () => {
     try {
       await services.messageHandler.handleMessage(message);
@@ -277,6 +290,8 @@ client.on(Events.MessageCreate, message => {
 
 // Interaction handler for slash commands, modals, autocomplete, and component interactions
 client.on(Events.InteractionCreate, interaction => {
+  // Warm the DM channel cache for this user; see DMCacheWarmer.ts for why.
+  services.dmCacheWarmer.warm(interaction.user);
   void (async () => {
     try {
       // Denylist check — applies to ALL interaction types (silent deny)

--- a/services/bot-client/src/services/DMCacheWarmer.test.ts
+++ b/services/bot-client/src/services/DMCacheWarmer.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { User } from 'discord.js';
+import { DMCacheWarmer } from './DMCacheWarmer.js';
+
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  };
+});
+
+function mockUser(id: string, createDM = vi.fn().mockResolvedValue({})): User {
+  return { id, createDM } as unknown as User;
+}
+
+describe('DMCacheWarmer', () => {
+  let warmer: DMCacheWarmer;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    warmer = new DMCacheWarmer();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls user.createDM() on first warm', () => {
+    const createDM = vi.fn().mockResolvedValue({});
+    const user = mockUser('user-1', createDM);
+
+    warmer.warm(user);
+
+    expect(createDM).toHaveBeenCalledTimes(1);
+    expect(warmer.has('user-1')).toBe(true);
+  });
+
+  it('skips createDM() on second warm of the same user', () => {
+    const createDM = vi.fn().mockResolvedValue({});
+    const user = mockUser('user-1', createDM);
+
+    warmer.warm(user);
+    warmer.warm(user);
+    warmer.warm(user);
+
+    expect(createDM).toHaveBeenCalledTimes(1);
+  });
+
+  it('warms different users independently', () => {
+    const createDM1 = vi.fn().mockResolvedValue({});
+    const createDM2 = vi.fn().mockResolvedValue({});
+
+    warmer.warm(mockUser('user-1', createDM1));
+    warmer.warm(mockUser('user-2', createDM2));
+
+    expect(createDM1).toHaveBeenCalledTimes(1);
+    expect(createDM2).toHaveBeenCalledTimes(1);
+    expect(warmer.size).toBe(2);
+  });
+
+  it('does not throw or reject when createDM fails', async () => {
+    const createDM = vi.fn().mockRejectedValue(new Error('DMs disabled'));
+    const user = mockUser('user-1', createDM);
+
+    // Synchronous warm() must not throw
+    expect(() => warmer.warm(user)).not.toThrow();
+
+    // The Set entry was added even though createDM failed — this is intentional
+    // (we don't want to retry repeatedly for users who have DMs blocked).
+    expect(warmer.has('user-1')).toBe(true);
+
+    // Flush microtasks so the rejected promise settles before assertions
+    await vi.runAllTimersAsync();
+  });
+
+  it('clear() empties the memo', () => {
+    warmer.warm(mockUser('user-1'));
+    warmer.warm(mockUser('user-2'));
+    expect(warmer.size).toBe(2);
+
+    warmer.clear();
+
+    expect(warmer.size).toBe(0);
+    expect(warmer.has('user-1')).toBe(false);
+  });
+
+  it('post-clear, the same user can be warmed again', () => {
+    const createDM = vi.fn().mockResolvedValue({});
+    const user = mockUser('user-1', createDM);
+
+    warmer.warm(user);
+    expect(createDM).toHaveBeenCalledTimes(1);
+
+    warmer.clear();
+    warmer.warm(user);
+
+    expect(createDM).toHaveBeenCalledTimes(2);
+  });
+});

--- a/services/bot-client/src/services/DMCacheWarmer.ts
+++ b/services/bot-client/src/services/DMCacheWarmer.ts
@@ -1,0 +1,64 @@
+/**
+ * DMCacheWarmer — pre-establishes Discord DM channels in the Discord.js cache.
+ *
+ * Why this exists: Discord.js v14+ MessageCreateAction silently drops DM
+ * MESSAGE_CREATE events when the channel isn't already cached, because the
+ * payload lacks the `recipients` field needed to construct a partial channel
+ * (even with Partials.Channel set). The channel must be in cache *before*
+ * the MESSAGE_CREATE event arrives.
+ *
+ * Empirically diagnosed via the [DJS DEBUG] listener in PR #915, which
+ * captured `"Failed to find guild, or unknown type for channel <id> undefined"`
+ * on every plain-text DM until a slash-command interaction populated the
+ * cache for that user. This service replicates the cache-population side
+ * effect by calling `user.createDM()` proactively whenever we encounter a
+ * user via any event channel.
+ *
+ * The Set memo bounds calls to once-per-user-per-process-lifetime. Set growth
+ * is bounded by the number of unique users who interact with the bot during
+ * a single process — typically well under 10k for this scale of bot. Process
+ * restart clears the memo, matching Discord-side cache lifecycle.
+ */
+
+import { createLogger } from '@tzurot/common-types';
+import type { User } from 'discord.js';
+
+const logger = createLogger('DMCacheWarmer');
+
+export class DMCacheWarmer {
+  private warmedUserIds = new Set<string>();
+
+  /**
+   * Idempotently ensure the DM channel for `user` is cached in Discord.js.
+   * Fire-and-forget: failures are logged but don't propagate.
+   */
+  warm(user: User): void {
+    if (this.warmedUserIds.has(user.id)) {
+      return;
+    }
+
+    this.warmedUserIds.add(user.id);
+    void user.createDM().catch((err: unknown) => {
+      // DM creation can fail for users with privacy DMs blocked, deleted
+      // accounts, etc. We just lose the warming optimization for this user;
+      // their DMs would fail dispatch the same way, but slash-command-based
+      // recovery still works as a fallback path.
+      logger.debug({ err, userId: user.id }, 'createDM failed during warming');
+    });
+  }
+
+  /** Number of users currently in the warmed-set memo. */
+  get size(): number {
+    return this.warmedUserIds.size;
+  }
+
+  /** Test hook: clear the warmed-set memo. */
+  clear(): void {
+    this.warmedUserIds.clear();
+  }
+
+  /** Test hook: check whether a user has been warmed. */
+  has(userId: string): boolean {
+    return this.warmedUserIds.has(userId);
+  }
+}


### PR DESCRIPTION
## Summary

Definitive fix for the post-deploy DM-silence bug. New \`DMCacheWarmer\` service that pre-establishes Discord.js's internal DM channel cache for every user the bot encounters via any event, so subsequent plain-text DMs can be resolved at dispatch.

## Empirical evidence (the smoking gun)

PR #915's \`[DJS DEBUG]\` listener captured this on dev:

\`\`\`
[DJS DEBUG] djsDebug="Failed to find guild, or unknown type for channel 1377516962480914584 undefined"
\`\`\`

This is emitted by Discord.js's \`MessageCreateAction.getChannel()\` when it can't resolve the channel from the cache *and* can't construct a partial from the payload. \`MESSAGE_CREATE\` payloads don't include the \`recipients\` field that DM partial-channel construction requires (even with \`Partials.Channel\` set), so Discord.js silently drops the event.

## Why this explains every symptom

| Observation | Now explained by |
|---|---|
| DMs silent immediately post-deploy | Cache empty after restart, no payload field to construct DM partial from |
| Slash commands work | Interaction payloads include channel data with type info that DJS does cache |
| Slash command in DM unsticks DMs | That interaction populates the cache for that channel; subsequent MESSAGE_CREATE events find it via \`client.channels.resolve()\` |
| Per-user, per-restart reproducible | Cache state is per-user-per-channel and cleared on process restart |

## What this PR does

New \`DMCacheWarmer\` service (\`services/bot-client/src/services/DMCacheWarmer.ts\`):

- \`warm(user)\` method: idempotently calls \`user.createDM()\` to populate the channel cache. Fire-and-forget — failures (DMs blocked, deleted accounts) are debug-logged, not propagated.
- \`Set<string>\` memo bounds calls to once-per-user-per-process-lifetime. Bounded by per-process unique-user count (typically <10k for this bot's scale); cleared on restart, matching Discord-side cache lifecycle.

Wired into both \`MessageCreate\` (guild messages — caches the user's DM ahead of any future DM) and \`InteractionCreate\` (slash, button, modal, autocomplete, etc.) handlers in \`index.ts\`.

## Relationship to prior PRs

- **PR #913** (SIGTERM handler) — still correct. Railway sends SIGTERM, the bot was hard-exiting without graceful gateway shutdown. Fixed a real latent bug; just wasn't this one.
- **PR #914** (Partials.Message + User) — still correct. Canonical Discord.js v14+ "DM-receiving bot" config. Necessary but not sufficient; doesn't help when the channel itself isn't cached.
- **PR #915** (diagnostic listeners) — produced the empirical evidence that made this fix possible. Will be retired once this fix is verified.
- **This PR** (DMCacheWarmer) — addresses the actual cache-resolution gap.

## What this PR does *not* do

- **Layer 1 startup pre-warm** of recently-active users from a database query is deferred. Layer 2 alone covers anyone who interacts with the bot at all post-restart, which is most active users. Layer 1 would only help users whose first post-restart interaction is a plain-text DM (true cold-start with no prior signal). Worth adding later if the residual case is observed.

## Test plan

- [x] \`pnpm --filter @tzurot/bot-client test\` — all 4597 tests pass (6 new from \`DMCacheWarmer.test.ts\`)
- [x] \`pnpm --filter @tzurot/bot-client typecheck\` clean
- [x] \`pnpm --filter @tzurot/bot-client lint\` clean
- [ ] **Post-merge**: dev auto-deploys; send plain-text DM; verify BOTH \`[RAW GATEWAY]\` log AND \`MessageHandler\` entry log fire for the same messageId. If both fire → bug resolved → disable \`DM_RAW_GATEWAY_DIAGNOSTIC\` env var on dev (per existing \`backlog/quick-wins.md\` entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)