### PR TITLE
feat: layer 1 startup DM cache pre-warm

### DIFF
--- a/packages/common-types/src/schemas/api/index.ts
+++ b/packages/common-types/src/schemas/api/index.ts
@@ -52,3 +52,6 @@ export * from './history.js';
 
 // Transcribe input schemas
 export * from './transcribe.js';
+
+// Internal service-to-service endpoints
+export * from './internal.js';

--- a/packages/common-types/src/schemas/api/internal.test.ts
+++ b/packages/common-types/src/schemas/api/internal.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { RecentUsersResponseSchema } from './internal.js';
+
+describe('RecentUsersResponseSchema', () => {
+  it('accepts a valid response with snowflake IDs', () => {
+    const data = {
+      discordIds: ['111111111111111111', '222222222222222222'],
+      sinceDays: 30,
+    };
+    const result = RecentUsersResponseSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts empty discordIds', () => {
+    const data = { discordIds: [], sinceDays: 30 };
+    const result = RecentUsersResponseSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts the snowflake length range (17 and 20 digits)', () => {
+    const data = {
+      discordIds: ['12345678901234567', '12345678901234567890'], // 17 and 20 digits
+      sinceDays: 30,
+    };
+    const result = RecentUsersResponseSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects negative sinceDays', () => {
+    const data = { discordIds: [], sinceDays: -1 };
+    const result = RecentUsersResponseSchema.safeParse(data);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects zero sinceDays', () => {
+    const data = { discordIds: [], sinceDays: 0 };
+    const result = RecentUsersResponseSchema.safeParse(data);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-string discordIds', () => {
+    const data = { discordIds: [123], sinceDays: 30 };
+    const result = RecentUsersResponseSchema.safeParse(data);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty discordId strings', () => {
+    const data = { discordIds: [''], sinceDays: 30 };
+    const result = RecentUsersResponseSchema.safeParse(data);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-numeric discordId strings', () => {
+    const data = { discordIds: ['not-a-snowflake'], sinceDays: 30 };
+    const result = RecentUsersResponseSchema.safeParse(data);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects discordId strings shorter than 17 digits', () => {
+    const data = { discordIds: ['1234567890123456'], sinceDays: 30 }; // 16 digits
+    const result = RecentUsersResponseSchema.safeParse(data);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects discordId strings longer than 20 digits', () => {
+    const data = { discordIds: ['123456789012345678901'], sinceDays: 30 }; // 21 digits
+    const result = RecentUsersResponseSchema.safeParse(data);
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/common-types/src/schemas/api/internal.ts
+++ b/packages/common-types/src/schemas/api/internal.ts
@@ -1,0 +1,28 @@
+/**
+ * Internal API endpoints
+ *
+ * Service-to-service endpoints under /internal/. Not for user-scoped traffic.
+ * Service-auth protected by the global middleware in api-gateway/src/index.ts.
+ */
+
+import { z } from 'zod';
+
+// ============================================================================
+// GET /internal/users/recent
+// Returns Discord IDs of users with usage_logs activity in the last N days.
+// Used by bot-client at startup to pre-populate the Discord.js DM channel
+// cache (Layer 1 of the post-deploy DM-silence fix).
+// ============================================================================
+
+/**
+ * Discord snowflake IDs are 17–20 digit strings per Discord's ID format spec.
+ * Validating the format here catches DB corruption or test-data drift early
+ * rather than letting bad IDs propagate to `client.users.fetch()` calls.
+ */
+const DiscordSnowflakeSchema = z.string().regex(/^\d{17,20}$/);
+
+export const RecentUsersResponseSchema = z.object({
+  discordIds: z.array(DiscordSnowflakeSchema),
+  sinceDays: z.number().int().positive(),
+});
+export type RecentUsersResponse = z.infer<typeof RecentUsersResponseSchema>;

--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -35,6 +35,7 @@ import { createAIRouter } from './routes/ai/index.js';
 import { createAdminRouter } from './routes/admin/index.js';
 import { createWalletRouter } from './routes/wallet/index.js';
 import { createUserRouter } from './routes/user/index.js';
+import { createInternalRouter } from './routes/internal/index.js';
 import { createModelsRouter } from './routes/models/index.js';
 import {
   createHealthRouter,
@@ -246,6 +247,9 @@ function registerRoutes(app: Express, prisma: PrismaClient, services: ServicesCo
 
   app.use('/models', createModelsRouter(modelCache));
   logger.info('Models routes registered');
+
+  app.use('/internal', createInternalRouter(prisma));
+  logger.info('Internal routes registered');
 
   app.use(
     '/admin',

--- a/services/api-gateway/src/routes/internal/index.test.ts
+++ b/services/api-gateway/src/routes/internal/index.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import type { PrismaClient } from '@tzurot/common-types';
+import { createInternalRouter } from './index.js';
+
+vi.mock('@tzurot/common-types', async () => {
+  const actual = await vi.importActual('@tzurot/common-types');
+  return {
+    ...actual,
+    createLogger: () => ({
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+/**
+ * Note: service-auth (`requireServiceAuth()`) is applied globally in
+ * `services/api-gateway/src/index.ts` before the `/internal` mount, not
+ * per-router. These tests construct a bare express app to verify routing
+ * structure only — auth gating is covered by AuthMiddleware.test.ts and
+ * the integration tests, not here.
+ */
+describe('createInternalRouter', () => {
+  let mockPrisma: { $queryRaw: ReturnType<typeof vi.fn> };
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma = { $queryRaw: vi.fn().mockResolvedValue([]) };
+    app = express();
+    app.use('/internal', createInternalRouter(mockPrisma as unknown as PrismaClient));
+  });
+
+  it('mounts GET /users/recent', async () => {
+    const response = await request(app).get('/internal/users/recent');
+    expect(response.status).toBe(200);
+    expect(mockPrisma.$queryRaw).toHaveBeenCalled();
+  });
+
+  it('returns 404 for unknown internal routes', async () => {
+    const response = await request(app).get('/internal/does-not-exist');
+    expect(response.status).toBe(404);
+  });
+});

--- a/services/api-gateway/src/routes/internal/index.ts
+++ b/services/api-gateway/src/routes/internal/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Internal Routes Router
+ *
+ * Service-to-service endpoints under /internal/. Already protected by the
+ * global requireServiceAuth() middleware in api-gateway/src/index.ts; no
+ * per-route auth wiring needed.
+ */
+
+import { Router } from 'express';
+import type { PrismaClient } from '@tzurot/common-types';
+import { createUsersRecentHandler } from './usersRecent.js';
+
+export function createInternalRouter(prisma: PrismaClient): Router {
+  const router = Router();
+  router.get('/users/recent', createUsersRecentHandler(prisma));
+  return router;
+}

--- a/services/api-gateway/src/routes/internal/usersRecent.test.ts
+++ b/services/api-gateway/src/routes/internal/usersRecent.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import type { PrismaClient } from '@tzurot/common-types';
+import { createUsersRecentHandler } from './usersRecent.js';
+
+vi.mock('@tzurot/common-types', async () => {
+  const actual = await vi.importActual('@tzurot/common-types');
+  return {
+    ...actual,
+    createLogger: () => ({
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+describe('GET /internal/users/recent', () => {
+  let mockPrisma: { $queryRaw: ReturnType<typeof vi.fn> };
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma = { $queryRaw: vi.fn() };
+    app = express();
+    app.get(
+      '/internal/users/recent',
+      createUsersRecentHandler(mockPrisma as unknown as PrismaClient)
+    );
+  });
+
+  it('returns the list of recently active Discord IDs with default sinceDays=30', async () => {
+    mockPrisma.$queryRaw.mockResolvedValue([
+      { discord_id: '111111111111111111' },
+      { discord_id: '222222222222222222' },
+    ]);
+
+    const response = await request(app).get('/internal/users/recent');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      discordIds: ['111111111111111111', '222222222222222222'],
+      sinceDays: 30,
+    });
+    // Tagged-template invocation: first arg is the static-strings array,
+    // bound parameters follow as positional rest args.
+    expect(mockPrisma.$queryRaw).toHaveBeenCalledWith(expect.any(Array), 30, 1000);
+  });
+
+  it('honors custom sinceDays query param', async () => {
+    mockPrisma.$queryRaw.mockResolvedValue([]);
+
+    const response = await request(app).get('/internal/users/recent?sinceDays=90');
+
+    expect(response.status).toBe(200);
+    expect(response.body.sinceDays).toBe(90);
+    expect(mockPrisma.$queryRaw).toHaveBeenCalledWith(expect.any(Array), 90, 1000);
+  });
+
+  it('returns empty list when no users match', async () => {
+    mockPrisma.$queryRaw.mockResolvedValue([]);
+
+    const response = await request(app).get('/internal/users/recent');
+
+    expect(response.status).toBe(200);
+    expect(response.body.discordIds).toEqual([]);
+    expect(response.body.total).toBeUndefined();
+  });
+
+  it('accepts sinceDays=365 (max allowed)', async () => {
+    mockPrisma.$queryRaw.mockResolvedValue([]);
+
+    const response = await request(app).get('/internal/users/recent?sinceDays=365');
+
+    expect(response.status).toBe(200);
+    expect(response.body.sinceDays).toBe(365);
+  });
+
+  it('rejects sinceDays=0 with 400', async () => {
+    const response = await request(app).get('/internal/users/recent?sinceDays=0');
+
+    expect(response.status).toBe(400);
+    expect(mockPrisma.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it('rejects negative sinceDays with 400', async () => {
+    const response = await request(app).get('/internal/users/recent?sinceDays=-5');
+
+    expect(response.status).toBe(400);
+  });
+
+  it('rejects non-numeric sinceDays with 400', async () => {
+    const response = await request(app).get('/internal/users/recent?sinceDays=abc');
+
+    expect(response.status).toBe(400);
+  });
+
+  it('rejects sinceDays > 365 with 400', async () => {
+    const response = await request(app).get('/internal/users/recent?sinceDays=999');
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/services/api-gateway/src/routes/internal/usersRecent.ts
+++ b/services/api-gateway/src/routes/internal/usersRecent.ts
@@ -1,0 +1,88 @@
+/**
+ * GET /internal/users/recent?sinceDays=30
+ *
+ * Returns Discord IDs of users with usage_logs activity in the last N days.
+ * Service-auth protected (global middleware in api-gateway/src/index.ts).
+ *
+ * Used by bot-client at startup to pre-populate the Discord.js DM channel
+ * cache so plain-text DMs route correctly without requiring the user to
+ * first interact via slash command. Layer 1 of the post-deploy DM-silence
+ * fix; Layer 2 (lazy-on-interaction) lives in bot-client/services/DMCacheWarmer.
+ */
+
+import { type Request, type Response, type RequestHandler } from 'express';
+import { StatusCodes } from 'http-status-codes';
+import { createLogger, type PrismaClient, RecentUsersResponseSchema } from '@tzurot/common-types';
+import { asyncHandler } from '../../utils/asyncHandler.js';
+import { sendCustomSuccess, sendError } from '../../utils/responseHelpers.js';
+import { ErrorResponses } from '../../utils/errorResponses.js';
+
+const logger = createLogger('internal-users-recent');
+
+/**
+ * Defensive cap on rows returned. Real-world usage for a personal-scale bot
+ * is well under this number; the LIMIT exists to prevent pathological cases
+ * (e.g., a usage_logs backfill bug producing millions of rows) from generating
+ * a runaway response that the bot would then try to warm one-by-one.
+ */
+const MAX_RESULTS = 1000;
+
+/** Default lookback window in days when no sinceDays query param provided. */
+const DEFAULT_SINCE_DAYS = 30;
+
+/** Hard cap on sinceDays to prevent abuse via crafted query params. */
+const MAX_SINCE_DAYS = 365;
+
+interface RawRow {
+  discord_id: string;
+}
+
+export function createUsersRecentHandler(prisma: PrismaClient): RequestHandler {
+  return asyncHandler(async (req: Request, res: Response) => {
+    // Parse and validate sinceDays query param. Number() + Number.isInteger()
+    // is strictly stricter than parseInt(): rejects partial-numeric strings
+    // like "30abc" (parseInt would silently accept as 30) and float values.
+    const rawSinceDays = req.query.sinceDays;
+    let sinceDays = DEFAULT_SINCE_DAYS;
+    if (typeof rawSinceDays === 'string') {
+      const parsed = Number(rawSinceDays);
+      if (!Number.isInteger(parsed) || parsed <= 0 || parsed > MAX_SINCE_DAYS) {
+        return sendError(
+          res,
+          ErrorResponses.validationError(`sinceDays must be a positive integer ≤ ${MAX_SINCE_DAYS}`)
+        );
+      }
+      sinceDays = parsed;
+    }
+
+    // INNER JOIN avoids a full usage_logs scan that the IN-subquery shape can
+    // produce on some query plans. GROUP BY collapses multi-request users.
+    // ORDER BY MAX(ul.created_at) DESC ensures that when LIMIT clips, we get
+    // the most-recently-active users (deterministic + meaningful order).
+    // LIMIT is a defensive cap (see MAX_RESULTS). Both `sinceDays` and
+    // `MAX_RESULTS` go through Prisma's parameterized binding via the tagged
+    // template — `MAX_RESULTS` is a compile-time constant so this is safe by
+    // shape, and using `$queryRaw` keeps the project's preference (per
+    // `03-database.md`) for the safer-by-default API.
+    const rows = await prisma.$queryRaw<RawRow[]>`
+      SELECT u.discord_id
+      FROM users u
+      INNER JOIN usage_logs ul ON ul.user_id = u.id
+      WHERE ul.created_at > NOW() - (${sinceDays} * INTERVAL '1 day')
+      GROUP BY u.discord_id
+      ORDER BY MAX(ul.created_at) DESC
+      LIMIT ${MAX_RESULTS}
+    `;
+
+    const discordIds = rows.map(r => r.discord_id);
+
+    const parsed = RecentUsersResponseSchema.parse({ discordIds, sinceDays });
+
+    logger.info(
+      { sinceDays, total: discordIds.length, capped: discordIds.length === MAX_RESULTS },
+      'Returning recent active users'
+    );
+
+    sendCustomSuccess(res, parsed, StatusCodes.OK);
+  });
+}

--- a/services/bot-client/src/index.ts
+++ b/services/bot-client/src/index.ts
@@ -45,6 +45,7 @@ import { PersonalityMessageHandler } from './services/PersonalityMessageHandler.
 import { PersonalityIdCache } from './services/PersonalityIdCache.js';
 import { DenylistCache } from './services/DenylistCache.js';
 import { DMCacheWarmer } from './services/DMCacheWarmer.js';
+import { StartupDMPrewarmer } from './services/StartupDMPrewarmer.js';
 import { registerServices } from './services/serviceRegistry.js';
 
 // Processors
@@ -446,6 +447,16 @@ client.once(Events.ClientReady, () => {
 
   // Restore saved bot presence from Redis
   void restoreBotPresence(client).catch(err => logger.warn({ err }, 'Failed to restore presence'));
+
+  // Layer 1 of the post-deploy DM-silence fix: pre-populate Discord.js's
+  // DM channel cache for recently active users. Fire-and-forget — bot is
+  // fully operational without this; pre-warming runs in the background.
+  // See StartupDMPrewarmer.ts and DMCacheWarmer.ts for the diagnosis chain.
+  const startupPrewarmer = new StartupDMPrewarmer({
+    client,
+    warmer: services.dmCacheWarmer,
+  });
+  void startupPrewarmer.run();
 
   // Auto-leave denied guilds when bot is added.
   // Registered inside ClientReady to make the dependency on denylistCache hydration explicit

--- a/services/bot-client/src/services/StartupDMPrewarmer.test.ts
+++ b/services/bot-client/src/services/StartupDMPrewarmer.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Client, User } from 'discord.js';
+import { StartupDMPrewarmer } from './StartupDMPrewarmer.js';
+import type { DMCacheWarmer } from './DMCacheWarmer.js';
+
+const mockAdminFetch = vi.fn();
+vi.mock('../utils/adminApiClient.js', () => ({
+  adminFetch: (...args: unknown[]) => mockAdminFetch(...args),
+}));
+
+vi.mock('@tzurot/common-types', async () => {
+  const actual = await vi.importActual('@tzurot/common-types');
+  return {
+    ...actual,
+    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  };
+});
+
+function mockJsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+function mockUser(id: string): User {
+  return { id, createDM: vi.fn().mockResolvedValue({}) } as unknown as User;
+}
+
+describe('StartupDMPrewarmer', () => {
+  let prewarmer: StartupDMPrewarmer;
+  let mockClient: { users: { fetch: ReturnType<typeof vi.fn> } };
+  let mockWarmer: { warm: ReturnType<typeof vi.fn> };
+  let mockSleep: ReturnType<typeof vi.fn<(ms: number) => Promise<void>>>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockAdminFetch.mockReset();
+    mockClient = { users: { fetch: vi.fn() } };
+    mockWarmer = { warm: vi.fn() };
+    mockSleep = vi.fn<(ms: number) => Promise<void>>().mockResolvedValue(undefined);
+    prewarmer = new StartupDMPrewarmer({
+      client: mockClient as unknown as Client,
+      warmer: mockWarmer as unknown as DMCacheWarmer,
+      sleep: mockSleep,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('warms each user returned by the recent-users endpoint', async () => {
+    mockAdminFetch.mockResolvedValue(
+      mockJsonResponse({
+        discordIds: ['111111111111111111', '222222222222222222'],
+        sinceDays: 30,
+      })
+    );
+    mockClient.users.fetch
+      .mockResolvedValueOnce(mockUser('111111111111111111'))
+      .mockResolvedValueOnce(mockUser('222222222222222222'));
+
+    await prewarmer.run();
+
+    expect(mockClient.users.fetch).toHaveBeenCalledTimes(2);
+    expect(mockClient.users.fetch).toHaveBeenCalledWith('111111111111111111');
+    expect(mockClient.users.fetch).toHaveBeenCalledWith('222222222222222222');
+    expect(mockWarmer.warm).toHaveBeenCalledTimes(2);
+    expect(mockSleep).toHaveBeenCalledWith(1000);
+  });
+
+  it('rate-limits with 1000ms sleep between fetches (N-1 sleeps for N users)', async () => {
+    mockAdminFetch.mockResolvedValue(
+      mockJsonResponse({
+        discordIds: ['111111111111111111', '222222222222222222', '333333333333333333'],
+        sinceDays: 30,
+      })
+    );
+    mockClient.users.fetch.mockImplementation((id: string) => Promise.resolve(mockUser(id)));
+
+    await prewarmer.run();
+
+    // 3 users → 2 sleeps (between requests, not after the last one)
+    expect(mockSleep).toHaveBeenCalledTimes(2);
+    expect(mockSleep).toHaveBeenCalledWith(1000);
+  });
+
+  it('does not sleep at all for a single-user list', async () => {
+    mockAdminFetch.mockResolvedValue(
+      mockJsonResponse({ discordIds: ['111111111111111111'], sinceDays: 30 })
+    );
+    mockClient.users.fetch.mockResolvedValue(mockUser('111111111111111111'));
+
+    await prewarmer.run();
+
+    expect(mockSleep).not.toHaveBeenCalled();
+    expect(mockWarmer.warm).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues when a single user fetch fails (e.g. deleted account)', async () => {
+    mockAdminFetch.mockResolvedValue(
+      mockJsonResponse({
+        discordIds: ['111111111111111111', '222222222222222222', '333333333333333333'],
+        sinceDays: 30,
+      })
+    );
+    mockClient.users.fetch
+      .mockResolvedValueOnce(mockUser('111111111111111111'))
+      .mockRejectedValueOnce(new Error('Unknown User'))
+      .mockResolvedValueOnce(mockUser('333333333333333333'));
+
+    await prewarmer.run();
+
+    expect(mockClient.users.fetch).toHaveBeenCalledTimes(3);
+    expect(mockWarmer.warm).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips warming entirely when api-gateway fetch fails', async () => {
+    mockAdminFetch.mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+    await prewarmer.run();
+
+    expect(mockClient.users.fetch).not.toHaveBeenCalled();
+    expect(mockWarmer.warm).not.toHaveBeenCalled();
+  });
+
+  it('skips warming when api-gateway returns non-2xx', async () => {
+    mockAdminFetch.mockResolvedValue(mockJsonResponse({}, false, 503));
+
+    await prewarmer.run();
+
+    expect(mockClient.users.fetch).not.toHaveBeenCalled();
+  });
+
+  it('skips warming when api-gateway returns malformed body', async () => {
+    mockAdminFetch.mockResolvedValue(mockJsonResponse({ wrong: 'shape' }));
+
+    await prewarmer.run();
+
+    expect(mockClient.users.fetch).not.toHaveBeenCalled();
+  });
+
+  it('returns silently when the recent-users list is empty', async () => {
+    mockAdminFetch.mockResolvedValue(mockJsonResponse({ discordIds: [], sinceDays: 30 }));
+
+    await prewarmer.run();
+
+    expect(mockClient.users.fetch).not.toHaveBeenCalled();
+    expect(mockSleep).not.toHaveBeenCalled();
+  });
+
+  it('calls the recent-users endpoint with sinceDays=30', async () => {
+    mockAdminFetch.mockResolvedValue(mockJsonResponse({ discordIds: [], sinceDays: 30 }));
+
+    await prewarmer.run();
+
+    expect(mockAdminFetch).toHaveBeenCalledWith('/internal/users/recent?sinceDays=30');
+  });
+});

--- a/services/bot-client/src/services/StartupDMPrewarmer.ts
+++ b/services/bot-client/src/services/StartupDMPrewarmer.ts
@@ -1,0 +1,126 @@
+/**
+ * StartupDMPrewarmer — Layer 1 of the post-deploy DM-silence fix.
+ *
+ * On bot startup, fetches the list of recently active Discord user IDs from
+ * api-gateway (`GET /internal/users/recent`), then walks the list at a slow
+ * rate-limited cadence calling `client.users.fetch(id).then(u => warmer.warm(u))`
+ * to pre-populate Discord.js's DM channel cache for those users.
+ *
+ * Why slow (1/sec): the Discord.js REST manager processes requests through
+ * a queue. Bursting createDM calls would compete with live user-traffic
+ * REST requests for that queue's bandwidth (head-of-line blocking risk
+ * flagged by council review). Pre-warming is background work with no
+ * urgency — speed isn't the right axis to optimize.
+ *
+ * Why fire-and-forget: the bot must come online and service guild traffic
+ * even if the gateway is slow or the recent-users list is unavailable.
+ * A failed pre-warm degrades to Layer 2 (DMCacheWarmer) which still covers
+ * users who interact via slash/button before DMing.
+ *
+ * Layer 1 closes the cold-start gap: a user whose first post-restart action
+ * is a plain-text DM (the bug-trigger case) gets pre-cached at startup so
+ * their DM dispatches correctly without prior interaction.
+ */
+
+import type { Client } from 'discord.js';
+import { createLogger, RecentUsersResponseSchema } from '@tzurot/common-types';
+import { adminFetch } from '../utils/adminApiClient.js';
+import type { DMCacheWarmer } from './DMCacheWarmer.js';
+
+const logger = createLogger('StartupDMPrewarmer');
+
+/** Lookback window for the recent-users query. */
+const SINCE_DAYS = 30;
+
+/** Delay between createDM attempts in ms. 1/sec keeps us well under Discord's
+ *  global rate limit and avoids head-of-line-blocking the REST queue with
+ *  non-urgent background work. */
+const RATE_LIMIT_DELAY_MS = 1000;
+
+export interface StartupDMPrewarmerDeps {
+  client: Client;
+  warmer: DMCacheWarmer;
+  /** Optional sleep override for testing with fake timers. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export class StartupDMPrewarmer {
+  private readonly client: Client;
+  private readonly warmer: DMCacheWarmer;
+  private readonly sleep: (ms: number) => Promise<void>;
+
+  constructor(deps: StartupDMPrewarmerDeps) {
+    this.client = deps.client;
+    this.warmer = deps.warmer;
+    this.sleep = deps.sleep ?? ((ms: number) => new Promise(resolve => setTimeout(resolve, ms)));
+  }
+
+  /**
+   * Fetch recently active users from api-gateway and pre-warm each one.
+   * Returns when the loop finishes or the fetch fails. Designed for
+   * fire-and-forget invocation from `ClientReady`.
+   */
+  async run(): Promise<void> {
+    const start = Date.now();
+    let discordIds: string[];
+    try {
+      discordIds = await this.fetchRecentUserIds();
+    } catch (err) {
+      logger.warn(
+        { err },
+        'Failed to fetch recent user list from api-gateway — skipping startup DM pre-warm; Layer 2 will handle live traffic'
+      );
+      return;
+    }
+
+    if (discordIds.length === 0) {
+      logger.info({ sinceDays: SINCE_DAYS }, 'No recent users to pre-warm');
+      return;
+    }
+
+    logger.info({ count: discordIds.length, sinceDays: SINCE_DAYS }, 'Starting DM cache pre-warm');
+
+    let warmed = 0;
+    let failed = 0;
+    for (let i = 0; i < discordIds.length; i++) {
+      const discordId = discordIds[i];
+      try {
+        const user = await this.client.users.fetch(discordId);
+        this.warmer.warm(user);
+        warmed += 1;
+      } catch (err) {
+        // Common: deleted accounts (10013), accounts the bot can't see, etc.
+        // Logging at debug to avoid noise from expected attrition over a
+        // 30-day lookback window.
+        logger.debug({ err, discordId }, 'Skipping pre-warm for user');
+        failed += 1;
+      }
+      // Sleep is a between-request rate limit, not a post-loop delay.
+      // Skipping after the last user avoids a gratuitous 1-sec stall before
+      // the completion log fires.
+      if (i < discordIds.length - 1) {
+        await this.sleep(RATE_LIMIT_DELAY_MS);
+      }
+    }
+
+    const elapsedSec = Math.round((Date.now() - start) / 1000);
+    // `warmed` = users.fetch() succeeded and warm() was invoked. createDM()
+    // inside warm() runs fire-and-forget, so this counts "warming attempted"
+    // not "DM channel definitively cached." `failed` counts users.fetch()
+    // errors only (deleted accounts, etc.).
+    logger.info({ warmed, failed, elapsedSec }, 'DM cache pre-warm complete');
+  }
+
+  private async fetchRecentUserIds(): Promise<string[]> {
+    const response = await adminFetch(`/internal/users/recent?sinceDays=${SINCE_DAYS}`);
+    if (!response.ok) {
+      throw new Error(`api-gateway returned ${response.status}`);
+    }
+    const json: unknown = await response.json();
+    const parsed = RecentUsersResponseSchema.safeParse(json);
+    if (!parsed.success) {
+      throw new Error(`Invalid recent-users response: ${parsed.error.message}`);
+    }
+    return parsed.data.discordIds;
+  }
+}


### PR DESCRIPTION
## Summary

Closes the cold-start gap left by PR #916 (Layer 2 lazy DM warmer). After bot restarts, plain-text DMs from users who haven't yet interacted with the bot in this process lifetime were still silent — empirically observed and reproduced after PR #916 deployed. Layer 1 pre-populates the DM channel cache for recently active users at startup, so their first plain-text DM post-restart routes correctly without prior interaction.

## Why a separate PR from #916

PR #916 (Layer 2) covers users who interact via guild messages or any \`InteractionCreate\` source before DMing. The cold-start gap — user's first post-restart action is a plain-text DM — wasn't covered. The bot owner hit this empirically via the diagnostic listener in PR #915: \`[RAW GATEWAY]\` log fired but \`[DJS DEBUG]\` continued to log \`Failed to find guild, or unknown type for channel\`, and MessageHandler never ran. Layer 1 closes that gap.

## Three components

**1. New api-gateway endpoint \`GET /internal/users/recent?sinceDays=30\`**

- Service-auth protected via the global \`requireServiceAuth()\` middleware applied to all routes past line 223 of \`services/api-gateway/src/index.ts\`.
- SQL: \`SELECT u.discord_id FROM users u INNER JOIN usage_logs ul ON ul.user_id = u.id WHERE ul.created_at > NOW() - (\${sinceDays} * INTERVAL '1 day') GROUP BY u.discord_id ORDER BY MAX(ul.created_at) DESC LIMIT 1000\` — \`INNER JOIN\` over \`IN (subquery)\` for better query plan, \`GROUP BY\` + \`ORDER BY MAX(created_at) DESC\` so when LIMIT clips we get the most-recently-active users (deterministic + meaningful), \`LIMIT 1000\` as defensive cap, \`sinceDays\` capped at 365 to prevent abuse via crafted query params.
- Returns \`{ discordIds, sinceDays }\` validated against \`RecentUsersResponseSchema\`.

**2. New \`RecentUsersResponseSchema\` in common-types**

\`packages/common-types/src/schemas/api/internal.ts\` — exported via the \`api/index\` barrel. \`discordIds\` validated as Discord snowflake regex (\`/^\\d{17,20}$/\`); schema test covers valid/empty/edge cases.

**3. New bot-client \`StartupDMPrewarmer\` service**

\`services/bot-client/src/services/StartupDMPrewarmer.ts\` — wired into \`Events.ClientReady\` as fire-and-forget background work. Walks the recent-users list at **1 req/sec** calling \`client.users.fetch(id).then(u => warmer.warm(u))\`. Per-user fetch failures (deleted accounts etc.) are debug-logged and skipped. Gateway-fetch failures degrade silently to Layer 2 — the bot stays operational and Layer 2 still covers users who interact via slash/button before DMing.

## Council review

Consulted google/gemini-3.1-pro-preview before building. Adjustments made from initial plan:

| Initial | Revised | Why |
|---|---|---|
| 10/sec rate limit | **1/sec** | Head-of-line blocking risk on discord.js REST queue — bursting createDM competes with live user-traffic REST requests |
| No SQL LIMIT | **\`LIMIT 1000\`** | Defensive cap; prevents pathological row counts |
| \`IN (subquery)\` SQL | **\`INNER JOIN\`** | Avoids full \`usage_logs\` scan that some query planners produce for IN-subquery |
| \`.catch()\` only on \`createDM()\` | **\`.catch()\` on both \`users.fetch()\` and \`createDM()\`** | Deleted accounts throw on fetch (DiscordAPIError 10013), would otherwise propagate |

## Test plan

- [x] \`pnpm test\` — all 4605 tests pass
- [x] \`pnpm quality\` — typecheck, lint, depcruise, cpd all clean
- [ ] **Post-merge**: dev auto-deploys; restart triggers \`StartupDMPrewarmer.run()\`; recent users get pre-cached. Send a plain-text DM as bot owner — diagnostic should now log BOTH \`[RAW GATEWAY]\` AND a \`MessageHandler\` "Processing message" entry for the same messageId, with NO \`[DJS DEBUG]\` "Failed to find guild" error. Once verified, disable \`DM_RAW_GATEWAY_DIAGNOSTIC\` env var on dev per the existing quick-wins backlog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)