### PR TITLE
chore: post-beta-108 cleanup bundle (chunker truncation + shutdown await + persona type import)

### DIFF
--- a/services/ai-worker/src/services/voice/ttsSynthesizer.test.ts
+++ b/services/ai-worker/src/services/voice/ttsSynthesizer.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   splitTextIntoChunks,
+  enforceChunkLengthCap,
   extractPcmData,
   buildWavHeader,
   inferSampleRate,
@@ -127,6 +128,63 @@ describe('splitTextIntoChunks', () => {
 
     expect(chunks).toHaveLength(1);
     expect(chunks[0]).toBe('');
+  });
+});
+
+describe('enforceChunkLengthCap', () => {
+  beforeEach(() => {
+    mockLogger.warn.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should pass through chunks within the cap unchanged', () => {
+    const input = ['short', 'A'.repeat(1500), 'A'.repeat(2000)];
+    const result = enforceChunkLengthCap(input);
+
+    expect(result).toEqual(input);
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it('should truncate any chunk exceeding the cap to MAX_CHUNK_LENGTH', () => {
+    // Synthetic over-cap input — the production-failing shape was 2006 chars
+    // against the 2000 cap (Lilith observation 2026-04-27).
+    const oversized = 'A'.repeat(2006);
+    const result = enforceChunkLengthCap([oversized]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].length).toBe(2000);
+    expect(result[0]).toBe('A'.repeat(2000));
+  });
+
+  it('should log a warning with chunk-length context when truncation triggers', () => {
+    enforceChunkLengthCap(['A'.repeat(2050)]);
+
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      { chunkLength: 2050, maxLength: 2000 },
+      expect.stringContaining('TTS chunk exceeded MAX_CHUNK_LENGTH')
+    );
+  });
+
+  it('should truncate only the offending chunks in a mixed array', () => {
+    const input = ['A'.repeat(1500), 'B'.repeat(2200), 'C'.repeat(800), 'D'.repeat(2001)];
+    const result = enforceChunkLengthCap(input);
+
+    expect(result[0]).toBe('A'.repeat(1500));
+    expect(result[1]).toBe('B'.repeat(2000));
+    expect(result[2]).toBe('C'.repeat(800));
+    expect(result[3]).toBe('D'.repeat(2000));
+    expect(mockLogger.warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('should return an empty array unchanged', () => {
+    const result = enforceChunkLengthCap([]);
+
+    expect(result).toEqual([]);
+    expect(mockLogger.warn).not.toHaveBeenCalled();
   });
 });
 

--- a/services/ai-worker/src/services/voice/ttsSynthesizer.ts
+++ b/services/ai-worker/src/services/voice/ttsSynthesizer.ts
@@ -62,12 +62,40 @@ function accumulateSentence(chunks: string[], currentChunk: string, sentence: st
 }
 
 /**
+ * Defensive cap: if any chunk exceeds MAX_CHUNK_LENGTH despite the splitting
+ * logic, truncate to the cap and warn. Safety net against edge cases the
+ * static analysis of accumulateSentence/forceSplitLongSentence misses, plus
+ * any upstream preprocessing or measurement-mismatch that could inflate
+ * chunk length post-split.
+ *
+ * Lossy by design (last few chars dropped from an offending chunk) — strictly
+ * better than the alternative, which is voice-engine returning 400 and the
+ * user losing ALL TTS audio for the response.
+ *
+ * @internal Exported for testing
+ */
+export function enforceChunkLengthCap(chunks: string[]): string[] {
+  return chunks.map(chunk => {
+    if (chunk.length > MAX_CHUNK_LENGTH) {
+      logger.warn(
+        { chunkLength: chunk.length, maxLength: MAX_CHUNK_LENGTH },
+        'TTS chunk exceeded MAX_CHUNK_LENGTH after splitting — truncating to defensive cap'
+      );
+      return chunk.slice(0, MAX_CHUNK_LENGTH);
+    }
+    return chunk;
+  });
+}
+
+/**
  * Split text into chunks that fit within the TTS character limit.
  * Splits at sentence boundaries to maintain natural speech flow.
  *
  * @internal Exported for testing
  */
 export function splitTextIntoChunks(text: string): string[] {
+  // Fast path: bypasses enforceChunkLengthCap because the condition itself
+  // guarantees output is already at or below MAX_CHUNK_LENGTH.
   if (text.length <= MAX_CHUNK_LENGTH) {
     return [text];
   }
@@ -94,7 +122,7 @@ export function splitTextIntoChunks(text: string): string[] {
     chunks.push(currentChunk.trim());
   }
 
-  return chunks;
+  return enforceChunkLengthCap(chunks);
 }
 
 /**

--- a/services/bot-client/src/commands/persona/create.ts
+++ b/services/bot-client/src/commands/persona/create.ts
@@ -14,25 +14,13 @@
 import { MessageFlags, ModalBuilder } from 'discord.js';
 import type { ModalSubmitInteraction } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
+import type { CreatePersonaResponse } from '@tzurot/common-types';
 import type { ModalCommandContext } from '../../utils/commandContext/types.js';
 import { buildPersonaModalFields } from './utils/modalBuilder.js';
 import { PersonaCustomIds } from '../../utils/customIds.js';
 import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
 
 const logger = createLogger('persona-create');
-
-/** Response type for creating a persona */
-interface CreatePersonaResponse {
-  success: boolean;
-  persona: {
-    id: string;
-    name: string;
-    preferredName: string | null;
-    description: string | null;
-    pronouns: string | null;
-    content: string | null;
-  };
-}
 
 /**
  * Handle /persona create command - shows modal

--- a/services/bot-client/src/index.ts
+++ b/services/bot-client/src/index.ts
@@ -558,21 +558,46 @@ function handleShutdownSignal(signal: NodeJS.Signals): void {
         logger.error({ err: error, jobId }, 'Error delivering buffered result on shutdown');
       }
     })
-    .finally(() => {
+    .finally(async () => {
       services.jobTracker.cleanup();
       services.responseOrderingService.stopCleanup();
       services.webhookManager.destroy();
       stopNotificationCacheCleanup();
       stopVerificationCleanupScheduler();
-      void services.cacheInvalidationService.unsubscribe();
-      void services.personaCacheInvalidationService.unsubscribe();
-      void services.channelActivationCacheInvalidationService.unsubscribe();
-      void services.denylistCacheInvalidationService.unsubscribe();
       services.personaResolver.stopCleanup();
+      // ioredis Redis#disconnect is synchronous (returns void) — kept outside
+      // the awaited Promise.all because there's no Promise to await.
       services.cacheRedis.disconnect();
-      void closeRedis();
-      void client.destroy();
-      void disconnectPrisma();
+
+      // Await async cleanup with a bounded timeout so a hung resource can't
+      // block shutdown. Railway will SIGKILL after its grace window anyway;
+      // better to exit cleanly when we can. Without the await, voided promises
+      // returned ~immediately and process.exit ran before Discord WebSocket
+      // close handshake / Redis disconnect / Prisma cleanup completed.
+      const SHUTDOWN_TIMEOUT_MS = 5000;
+      try {
+        await Promise.race([
+          Promise.all([
+            services.cacheInvalidationService.unsubscribe(),
+            services.personaCacheInvalidationService.unsubscribe(),
+            services.channelActivationCacheInvalidationService.unsubscribe(),
+            services.denylistCacheInvalidationService.unsubscribe(),
+            closeRedis(),
+            client.destroy(),
+            disconnectPrisma(),
+          ]),
+          new Promise<never>((_resolve, reject) =>
+            setTimeout(
+              () => reject(new Error(`Shutdown cleanup exceeded ${SHUTDOWN_TIMEOUT_MS}ms`)),
+              SHUTDOWN_TIMEOUT_MS
+            )
+          ),
+        ]);
+        logger.info('Shutdown cleanup completed cleanly');
+      } catch (error) {
+        logger.warn({ err: error }, 'Shutdown cleanup did not complete cleanly');
+      }
+
       process.exit(0);
     });
 }


### PR DESCRIPTION
## Summary

Three independent small items folded into one PR. Each lives in its own commit and can be evaluated in isolation.

### 1. Chunker defensive truncation (`fix(ai-worker)`, commit d2f2c9426)

**Problem**: Production observed a 2006-char chunk reaching voice-engine against the 2000-char cap (Lilith observation 2026-04-27, beta.107 deploy `433bbeb5` logs). Voice-engine returned 400 *Text too long (2006 chars). Maximum: 2000* — non-retryable, so the user lost ALL TTS audio for the response. Static analysis of `accumulateSentence` and `forceSplitLongSentence` *appears* to constrain output to ≤ `MAX_CHUNK_LENGTH`, but reality disagreed. Reproduction against the user-pasted text produced safe chunks (1991 + 982), so the production-failing input differs from what's reconstructable post-hoc by ~15-25 chars (suspected: copy-paste whitespace loss, hidden characters, or upstream preprocessing inflation).

**Fix**: New `enforceChunkLengthCap` helper applied at chunker output. Any chunk exceeding the cap is sliced to the cap and a warn is logged. Lossy by design (last few chars of an offending chunk dropped) — strictly better than losing all TTS audio. Helper exported for direct testing; root-cause investigation deferred to a separate icebox item for chunker harmonization.

**Tests**: Pass-through, truncation behavior, warn logging, mixed-array cherry-pick, empty input. Covered by 5 new test cases.

### 2. Await async cleanup before `process.exit` (`fix(bot-client)`, commit 898e6a155)

**Problem**: `handleShutdownSignal` launched 7 async cleanup operations (`cacheInvalidationService.unsubscribe` x4, `closeRedis`, `client.destroy`, `disconnectPrisma`) as voided promises and then synchronously called `process.exit(0)`. The Discord WebSocket close handshake, Redis disconnect, and Prisma cleanup did not reliably complete before exit. Surfaced 2026-04-26 by claude-bot review on PR #913 as the natural follow-up to the SIGTERM handler shipped there.

**Fix**: Convert `.finally()` callback to async; `await Promise.all([...])` of the seven async cleanup operations, bounded by a 5s `Promise.race` timeout so a hung resource cannot prevent shutdown. Railway will SIGKILL after its grace window regardless; clean exit before that is strictly better. ~30 LOC change.

**Tests**: None — `index.ts` is the entry-point file with structure-test exclusion. The `Promise.race` timeout pattern is straightforward enough to review on diff. If reviewers want coverage, the natural extraction is `services/bot-client/src/shutdown.ts` with its own colocated test — flagging as a follow-up rather than expanding scope here.

### 3. `CreatePersonaResponse` type import (`refactor(bot-client)`, commit 8f79f24c7)

**Problem**: `services/bot-client/src/commands/persona/create.ts` declared a local `CreatePersonaResponse` interface duplicating the Zod-validated schema in `packages/common-types/src/schemas/api/persona.ts`. Drift between local interface and canonical schema was not a compile-time error — exactly what happened in PR #912 with the `setAsDefault` field (removed from schema, local interface had to be hand-edited separately).

**Fix**: Replace local interface with `import type { CreatePersonaResponse } from '@tzurot/common-types'` (the schema-inferred type). Drift is now a typecheck failure. Surfaced 2026-04-26 by claude-bot review on PR #912.

**Tests**: None added; existing `create.test.ts` coverage exercises the consumption pattern and continues to pass (typecheck-only swap).

## Test plan

- [x] `pnpm test` — 4611 tests across 277 test files, all green
- [x] `pnpm quality` — lint + cpd + depcruise + typecheck + typecheck:spec, exit 0 (11/11 cached after first run)
- [ ] Reviewer eyes on each commit independently
- [ ] CI green (typecheck-spec on bot-client + ai-worker; depcruise on full graph)
- [ ] Post-merge: monitor production logs for the new `TTS chunk exceeded MAX_CHUNK_LENGTH` warn after next deploy — its presence/absence on the same input class will tell us whether the original symptom recurs through the new safety net

🤖 Generated with [Claude Code](https://claude.com/claude-code)