### PR TITLE
chore(ai-worker): PR #924 review polish — 3 commits bundled

### DIFF
--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.test.ts
@@ -290,6 +290,43 @@ describe('AuthStep', () => {
       });
     });
 
+    describe('ProviderRouter injection', () => {
+      it('should use the injected ProviderRouter instead of auto-constructing one', async () => {
+        // Constructor seam test: when a ProviderRouter is passed explicitly,
+        // AuthStep must use it. Future tests can leverage this to isolate
+        // AuthStep behavior from real ProviderRouter logic. We prove the seam
+        // works by injecting a stub that returns a fixture only this stub
+        // would produce (a sentinel apiKey + provider) and asserting AuthStep
+        // surfaces those values — if AuthStep had auto-constructed its own
+        // router, the result would reflect the apiKeyResolver mock instead.
+        const injectedRouter = {
+          resolveRoute: vi.fn().mockResolvedValue({
+            effectiveProvider: AIProvider.OpenRouter,
+            effectiveModel: 'injected/model',
+            apiKey: 'injected-router-sentinel-key',
+            isGuestMode: false,
+            fallthroughTriggered: false,
+          }),
+        } as unknown as import('../../../../services/ProviderRouter.js').ProviderRouter;
+
+        step = new AuthStep(mockApiKeyResolver, mockConfigResolver, injectedRouter);
+        const result = await step.process({
+          job: createMockJob(),
+          startTime: Date.now(),
+          config: { effectivePersonality: TEST_PERSONALITY, configSource: 'personality' },
+        });
+
+        expect(injectedRouter.resolveRoute).toHaveBeenCalledTimes(1);
+        expect(result.auth?.apiKey).toBe('injected-router-sentinel-key');
+        // apiKeyResolver.resolveApiKey was NOT called for the LLM path because
+        // the injected router short-circuited the resolution.
+        const orCalls = vi
+          .mocked(mockApiKeyResolver.resolveApiKey)
+          .mock.calls.filter(c => c[1] === AIProvider.OpenRouter);
+        expect(orCalls).toHaveLength(0);
+      });
+    });
+
     it('should not override model if already free in guest mode', async () => {
       const freePersonality: LoadedPersonality = {
         ...TEST_PERSONALITY,

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.ts
@@ -19,15 +19,19 @@ export class AuthStep implements IPipelineStep {
 
   constructor(
     private readonly apiKeyResolver?: ApiKeyResolver,
-    private readonly configResolver?: LlmConfigResolver
+    private readonly configResolver?: LlmConfigResolver,
+    providerRouter?: ProviderRouter
   ) {
     // ProviderRouter wraps ApiKeyResolver to encode the auto-fallthrough
     // routing rule for `zai-coding` (and any future provider that needs it).
-    // We construct it inline so AuthStep's existing constructor signature
-    // stays backward compatible — injectable ProviderRouter constructor
-    // parameter is deferred; tests mock at the `apiKeyResolver` level instead.
+    // The optional `providerRouter` parameter lets tests inject a mock to
+    // isolate AuthStep behavior from ProviderRouter — without it, AuthStep
+    // tests exercise both layers and a ProviderRouter bug manifests as an
+    // AuthStep test failure. Production callers omit the parameter and get
+    // the inline-constructed router.
     this.providerRouter =
-      apiKeyResolver !== undefined ? new ProviderRouter(apiKeyResolver) : undefined;
+      providerRouter ??
+      (apiKeyResolver !== undefined ? new ProviderRouter(apiKeyResolver) : undefined);
   }
 
   async process(context: GenerationContext): Promise<GenerationContext> {

--- a/services/ai-worker/src/services/ApiKeyResolver.test.ts
+++ b/services/ai-worker/src/services/ApiKeyResolver.test.ts
@@ -419,6 +419,24 @@ describe('ApiKeyResolver', () => {
       expect(secondCall).toBe('zai-user-key');
       expect(mockPrisma.userApiKey.findFirst).not.toHaveBeenCalled();
     });
+
+    it('should NOT cache the null path — re-reads DB on every call (accepted overhead)', async () => {
+      // The auto-fallthrough majority path: user has no key for the requested
+      // provider. ApiKeyResolver intentionally does NOT write a "no key"
+      // sentinel here (would muddy resolveApiKey's source: 'system' semantics
+      // for providers like zai-coding that have no system fallback). This test
+      // locks in that invariant — if a future refactor adds caching here, the
+      // second-call DB-call assertion catches it.
+      mockPrisma.userApiKey.findFirst.mockResolvedValue(null);
+
+      const result = await resolver.tryResolveUserKey('user-123', AIProvider.ZaiCoding);
+      expect(result).toBeNull();
+      expect(mockPrisma.userApiKey.findFirst).toHaveBeenCalledTimes(1);
+
+      const secondResult = await resolver.tryResolveUserKey('user-123', AIProvider.ZaiCoding);
+      expect(secondResult).toBeNull();
+      expect(mockPrisma.userApiKey.findFirst).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('encryption key not configured', () => {

--- a/services/ai-worker/src/services/multimodal/VisionProcessor.test.ts
+++ b/services/ai-worker/src/services/multimodal/VisionProcessor.test.ts
@@ -144,7 +144,6 @@ describe('VisionProcessor', () => {
       it('should use personality visionModel when specified', async () => {
         const personality = createMockPersonality({
           model: 'gpt-4',
-          provider: 'openrouter',
           visionModel: 'gpt-4-vision-preview',
         });
 
@@ -164,7 +163,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -184,7 +182,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -198,7 +195,6 @@ describe('VisionProcessor', () => {
       it('should prefer visionModel over main model even if main has vision', async () => {
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: 'claude-3-opus',
         });
 
@@ -220,7 +216,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -238,7 +233,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -256,7 +250,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -276,7 +269,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
           systemPrompt: 'You are a helpful assistant',
         });
@@ -294,7 +286,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
           systemPrompt: '',
         });
@@ -309,7 +300,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
           systemPrompt: undefined as any,
         });
@@ -326,7 +316,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -342,7 +331,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -358,7 +346,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -379,7 +366,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -397,7 +383,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -419,7 +404,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -442,7 +426,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -467,7 +450,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -494,7 +476,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -513,7 +494,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -530,7 +510,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -547,7 +526,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -564,7 +542,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -581,7 +558,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -606,7 +582,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -639,7 +614,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -670,7 +644,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -703,7 +676,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -736,7 +708,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -757,7 +728,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -778,7 +748,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -801,7 +770,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -822,7 +790,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -838,7 +805,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -858,7 +824,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -873,7 +838,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -888,7 +852,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -903,7 +866,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -919,7 +881,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -934,7 +895,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -955,7 +915,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -975,7 +934,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -998,7 +956,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -1015,7 +972,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -1031,7 +987,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -1048,7 +1003,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -1077,7 +1031,6 @@ describe('VisionProcessor', () => {
 
           const personality = createMockPersonality({
             model: 'gpt-4o',
-            provider: 'openrouter',
             visionModel: undefined,
           });
 
@@ -1096,7 +1049,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -1119,7 +1071,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 
@@ -1142,7 +1093,6 @@ describe('VisionProcessor', () => {
 
         const personality = createMockPersonality({
           model: 'gpt-4o',
-          provider: 'openrouter',
           visionModel: undefined,
         });
 


### PR DESCRIPTION
## Summary

Three small follow-ups from PR #924's 8 review rounds, bundled like PR #920:

1. **`test(ai-worker): add tryResolveUserKey no-key invariant test`** — locks in the documented "do NOT cache the null path" invariant from PR #924. A future refactor that accidentally cached the fallthrough path would break resolveApiKey's source: 'system' semantics for providers like zai-coding that have no system fallback. Reviewer-provided test body asserts both the null result AND the absence of caching (second call re-reads DB).
2. **`refactor(ai-worker): optional ProviderRouter constructor injection in AuthStep`** — adds an optional `providerRouter?` constructor parameter so future tests can inject a mock and isolate AuthStep behavior from ProviderRouter logic. Existing callers unchanged. Includes 1 test that proves the seam works.
3. **`test(ai-worker): drop redundant provider:'openrouter' overrides in VisionProcessor.test.ts`** — PR #924 added `provider: 'openrouter'` to the local `createMockPersonality` factory default; the 50 inline overrides are now mechanically redundant. Pure noise reduction (-50 lines), all 53 existing tests pass unchanged.

Discovered during planning that 4 other items in the "z.ai integration — remaining follow-ups" backlog entry were already done (addressed inline during PR #921's review rounds 5-6 but never struck through in the backlog). Those will be cleaned up as a doc commit on develop after this PR merges.

## Test plan

- [x] `pnpm --filter @tzurot/ai-worker test` — 2787 tests pass (was 2785; +2 new tests)
- [x] `pnpm quality` — all 11 tasks green (lint, cpd, depcruise, typecheck, typecheck:spec across packages)
- [ ] CI green (claude-review, codecov/patch, integration-tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)