### PR TITLE
ci: skip claude-review on dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,13 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip claude-review on dependabot PRs. The claude-code-action structurally
+    # rejects bot actors (`Action failed: Workflow initiated by non-human actor`),
+    # so without this guard every dependabot PR shows a red claude-review check
+    # that's pure infra noise — a version-bump diff in package.json wouldn't
+    # produce useful review output anyway. Job-level `if:` cleanly skips for
+    # bot-authored PRs without producing a fail.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

Add job-level `if:` guard to skip `claude-review` on dependabot-authored PRs. Eliminates the false-red infra check that fires on every dependabot PR (the action structurally rejects bot actors with "Workflow initiated by non-human actor").

## Release-coupled timing

Per `backlog/quick-wins.md`: this is intentionally scheduled as the **LAST commit on develop before the next release-merge PR opens**. The `claude-code-action` self-validates that the workflow file on the PR branch matches `main`; until develop merges to main, claude-review will fail on every subsequent develop PR because this file now diverges between branches. The dark window is minimized by sequencing this merge → immediate release-merge PR.

## Test plan

- [x] YAML syntax valid (just adds a single `if:` line at job level)
- [ ] CI: this PR's own claude-review will likely fail on the merge-base check — that's the "dark window" itself; merging through it intentionally per the documented timing constraint
- [ ] Once merged + release-merged to main, future dependabot PRs will show claude-review as "skipped" rather than "failed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)