### PR TITLE
chore(common-types): centralize cache KEY_PREFIX + cacheKeyId invariant + opt-out log

### DIFF
--- a/packages/common-types/src/constants/index.ts
+++ b/packages/common-types/src/constants/index.ts
@@ -130,3 +130,6 @@ export { WALLET_ERROR_MESSAGES, API_KEY_FORMATS } from './wallet.js';
 
 // Persona constants
 export { DEFAULT_PERSONA_DESCRIPTION } from './persona.js';
+
+// Redis cache-key prefixes (shared by services and ops tooling)
+export { CACHE_KEY_PREFIXES } from './redis-keys.js';

--- a/packages/common-types/src/constants/redis-keys.test.ts
+++ b/packages/common-types/src/constants/redis-keys.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+
+import { CACHE_KEY_PREFIXES } from './redis-keys.js';
+
+describe('CACHE_KEY_PREFIXES', () => {
+  it('exposes the OpenRouter rate-limit prefix matching ai-worker RateLimitCache', () => {
+    expect(CACHE_KEY_PREFIXES.RATE_LIMIT_OPENROUTER).toBe('ratelimit:openrouter:');
+  });
+
+  it('exposes the OpenRouter credit-exhaustion prefix matching ai-worker CreditExhaustionCache + ops tooling', () => {
+    expect(CACHE_KEY_PREFIXES.CREDIT_EXHAUSTION_OPENROUTER).toBe('nocredits:openrouter:');
+  });
+
+  it('every prefix ends with a colon (concatenation invariant)', () => {
+    for (const prefix of Object.values(CACHE_KEY_PREFIXES)) {
+      expect(prefix.endsWith(':')).toBe(true);
+    }
+  });
+});

--- a/packages/common-types/src/constants/redis-keys.ts
+++ b/packages/common-types/src/constants/redis-keys.ts
@@ -1,0 +1,24 @@
+/**
+ * Redis cache-key prefixes shared by services and ops tooling. Centralised
+ * here so a rename can't silently desync the runtime cache writer from the
+ * operator `DEL` tooling — the previous duplication had no compile-time
+ * signal that the two literals had to match.
+ *
+ * Every prefix ends with `:` so callers concatenate the dynamic identifier
+ * directly. The `cacheKeyId` segment follows its producer's no-colon
+ * invariant — see `RateLimitCache.assertValidCacheKeyId` for the
+ * runtime-enforced grammar. List every reader/writer in a `<consumer>` doc
+ * line when adding a prefix.
+ */
+export const CACHE_KEY_PREFIXES = {
+  /**
+   * Per-(account, model) rate-limit window cache for OpenRouter 429s.
+   * Consumers: `ai-worker/RateLimitCache`.
+   */
+  RATE_LIMIT_OPENROUTER: 'ratelimit:openrouter:',
+  /**
+   * Per-account credit-exhaustion cache for OpenRouter 402s.
+   * Consumers: `ai-worker/CreditExhaustionCache`, `tooling/cache/clear-credit-exhaustion`.
+   */
+  CREDIT_EXHAUSTION_OPENROUTER: 'nocredits:openrouter:',
+} as const;

--- a/packages/tooling/src/cache/clear-credit-exhaustion.ts
+++ b/packages/tooling/src/cache/clear-credit-exhaustion.ts
@@ -12,11 +12,12 @@
 
 import { Redis } from 'ioredis';
 import chalk from 'chalk';
+import { CACHE_KEY_PREFIXES } from '@tzurot/common-types';
 
 import { getRailwayRedisUrl } from '../inspect/bullmqConnection.js';
 import type { Environment } from '../utils/env-runner.js';
 
-const KEY_PREFIX = 'nocredits:openrouter:';
+const KEY_PREFIX = CACHE_KEY_PREFIXES.CREDIT_EXHAUSTION_OPENROUTER;
 
 export interface ClearOptions {
   env: Environment;

--- a/services/ai-worker/src/services/CreditExhaustionCache.ts
+++ b/services/ai-worker/src/services/CreditExhaustionCache.ts
@@ -32,11 +32,11 @@
  */
 
 import type { Redis } from 'ioredis';
-import { createLogger } from '@tzurot/common-types';
+import { CACHE_KEY_PREFIXES, createLogger } from '@tzurot/common-types';
 
 const logger = createLogger('CreditExhaustionCache');
 
-const KEY_PREFIX = 'nocredits:openrouter:';
+const KEY_PREFIX = CACHE_KEY_PREFIXES.CREDIT_EXHAUSTION_OPENROUTER;
 const MIN_TTL_SECONDS = 60;
 const MAX_TTL_SECONDS = 24 * 60 * 60;
 const DEFAULT_TTL_SECONDS = 60 * 60; // 1 hour

--- a/services/ai-worker/src/services/LLMInvoker.test.ts
+++ b/services/ai-worker/src/services/LLMInvoker.test.ts
@@ -1759,6 +1759,65 @@ describe('LLMInvoker', () => {
       expect(mockIsRateLimited).not.toHaveBeenCalled();
     });
   });
+
+  describe('cacheKeyId invariant validation at invokeWithRetry call site', () => {
+    // The producer-side `assertValidCacheKeyId` inside `deriveCacheKeyId` is
+    // dormant against current outputs by construction, so it doesn't catch
+    // callers that bypass the producer and pass arbitrary strings into
+    // `InvokeWithRetryOptions.cacheKeyId`. The consumer-side guard inside
+    // `invokeWithRetry`'s else branch closes that gap.
+    it('does not throw on an invalid `cacheKeyId` shape — warn-only contract', async () => {
+      // Cache reports no active block so the call proceeds past the
+      // short-circuit guards and exercises the full validation + cache path.
+      mockIsCreditExhausted.mockResolvedValueOnce({ exhausted: false });
+      mockIsRateLimited.mockResolvedValueOnce({ rateLimited: false });
+
+      const messages: BaseMessage[] = [new HumanMessage('test')];
+      const mockInvoke = vi.fn().mockResolvedValue({ content: 'ok' });
+      const mockModel = { invoke: mockInvoke } as unknown as BaseChatModel;
+
+      await expect(
+        invoker.invokeWithRetry({
+          model: mockModel,
+          messages,
+          modelName: 'z-ai/glm-4.5-air:free',
+          // Colon-bearing scope that violates the format invariant — this
+          // is exactly the future-misuse case the consumer-side guard exists
+          // to detect.
+          cacheKeyId: 'org:my-team:special',
+        })
+      ).resolves.toBeDefined();
+
+      // Cache calls still execute — the validator is a non-blocking sentinel,
+      // not a control-flow guard. If a future refactor escalates the
+      // assertion to a throw, this expectation surfaces the regression.
+      expect(mockIsCreditExhausted).toHaveBeenCalledTimes(1);
+      expect(mockIsRateLimited).toHaveBeenCalledTimes(1);
+      expect(mockInvoke).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not invoke the validator when cacheKeyId is empty (cache opt-out path)', async () => {
+      // The empty-string branch goes through the debug-log path, not the
+      // else branch — so the consumer-side `assertValidCacheKeyId` call
+      // does not fire. Verified by exercising the empty path and
+      // confirming the cache calls don't happen (which would imply the
+      // else branch wasn't taken).
+      const messages: BaseMessage[] = [new HumanMessage('test')];
+      const mockInvoke = vi.fn().mockResolvedValue({ content: 'ok' });
+      const mockModel = { invoke: mockInvoke } as unknown as BaseChatModel;
+
+      await invoker.invokeWithRetry({
+        model: mockModel,
+        messages,
+        modelName: 'z-ai/glm-4.5-air:free',
+        cacheKeyId: '',
+      });
+
+      expect(mockIsCreditExhausted).not.toHaveBeenCalled();
+      expect(mockIsRateLimited).not.toHaveBeenCalled();
+      expect(mockInvoke).toHaveBeenCalledTimes(1);
+    });
+  });
 });
 
 describe('supportsStopSequences', () => {

--- a/services/ai-worker/src/services/LLMInvoker.ts
+++ b/services/ai-worker/src/services/LLMInvoker.ts
@@ -41,6 +41,7 @@ import {
 } from '../utils/apiErrorParser.js';
 import { recordStopSequenceActivation, inferNonXmlStop } from './StopSequenceTracker.js';
 import type { RateLimitCache } from './RateLimitCache.js';
+import { assertValidCacheKeyId } from './RateLimitCache.js';
 import type { CreditExhaustionCache } from './CreditExhaustionCache.js';
 import { rateLimitCache, creditExhaustionCache } from '../redis.js';
 import {
@@ -170,20 +171,37 @@ export class LLMInvoker {
       stopSequences,
     } = options;
 
-    // Credit-exhaustion cache short-circuit runs FIRST: a 402 is a permanent
-    // account state until top-up, while a 429 is a time-bounded transient
-    // block. If both cache hits exist, surface the worse one — credit
-    // exhaustion blocks all OpenRouter calls regardless of model, so a
-    // CREDIT_EXHAUSTION error is more informative than a per-model RATE_LIMIT.
-    if (cacheKeyId.length > 0) {
+    if (cacheKeyId.length === 0) {
+      // An empty `cacheKeyId` skips both caches entirely — currently used by
+      // legacy test fixtures and any production caller that forgets to thread
+      // the value through. Surface it as a debug log so the silent opt-out is
+      // at least visible in local dev when wiring up a new caller. (Promoting
+      // the field to required in the type is tracked in `backlog/inbox.md`.)
+      logger.debug(
+        { modelName },
+        'Empty cacheKeyId — rate-limit + credit-exhaustion caches skipped'
+      );
+    } else {
+      // Validate the caller-supplied `cacheKeyId` shape before it flows into
+      // Redis key construction. The check is also applied inside
+      // `deriveCacheKeyId` (the canonical producer), but `cacheKeyId` is typed
+      // as optional on `InvokeWithRetryOptions` and callers can pass any
+      // string without going through `deriveCacheKeyId`. This second guard
+      // catches future callers that bypass the producer — without it a
+      // colon-bearing scope (e.g., `org:my-team:special`) would silently
+      // corrupt the `<prefix>:<id>:<model>` key shape with no log signal.
+      // Warn-only contract: assertion never throws, so cache short-circuit
+      // continues unchanged for currently-valid shapes.
+      assertValidCacheKeyId(cacheKeyId);
+      // Credit-exhaustion cache short-circuit runs FIRST: a 402 is a permanent
+      // account state until top-up, while a 429 is a time-bounded transient
+      // block. If both cache hits exist, surface the worse one — credit
+      // exhaustion blocks all OpenRouter calls regardless of model, so a
+      // CREDIT_EXHAUSTION error is more informative than a per-model RATE_LIMIT.
       await this.shortCircuitOnCreditExhaustion(creditExhaustionCache, cacheKeyId);
-    }
-
-    // Rate-limit cache short-circuit — when a previous 429 told us the
-    // (cacheKeyId, model) pair is in a known rate-limit window, fail fast
-    // instead of burning ~80s × 3 retry attempts to land on the same
-    // result. Skip when cacheKeyId is empty (legacy test path).
-    if (cacheKeyId.length > 0) {
+      // Rate-limit cache short-circuit — when a previous 429 told us the
+      // (cacheKeyId, model) pair is in a known rate-limit window, fail fast
+      // instead of burning ~80s × 3 retry attempts to land on the same result.
       await this.shortCircuitOnCachedRateLimit(rateLimitCache, cacheKeyId, modelName);
     }
 

--- a/services/ai-worker/src/services/RateLimitCache.test.ts
+++ b/services/ai-worker/src/services/RateLimitCache.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Redis } from 'ioredis';
-import { RateLimitCache, deriveCacheKeyId } from './RateLimitCache.js';
+import { RateLimitCache, deriveCacheKeyId, assertValidCacheKeyId } from './RateLimitCache.js';
 
 // Frozen "now" for deterministic TTL math in clamping tests
 const FIXED_NOW_MS = 1_777_500_000_000;
@@ -243,5 +243,43 @@ describe('deriveCacheKeyId', () => {
     // bucket — the system key is shared across all guest-mode callers
     // anyway, so there's no cross-account leakage.
     expect(deriveCacheKeyId(undefined, '')).toBe('system');
+  });
+});
+
+describe('assertValidCacheKeyId', () => {
+  // The assertion is a runtime sentinel against future scope-extensions silently
+  // breaking the `<prefix>:<id>:<model>` key shape via colon-collision in the
+  // dynamic segment. It logs `warn` rather than throwing (cache is never a
+  // correctness gate), so the contract being tested here is "never throws"
+  // for either valid or invalid shapes — a future regression that escalates
+  // to a throw would surface immediately in the bad-shape cases below.
+
+  it('passes for the literal "system" scope', () => {
+    expect(() => assertValidCacheKeyId('system')).not.toThrow();
+  });
+
+  it('passes for "user:<digits>" with a Discord snowflake', () => {
+    expect(() => assertValidCacheKeyId('user:278863839632818186')).not.toThrow();
+  });
+
+  it('passes for the empty-string skip-cache sentinel', () => {
+    expect(() => assertValidCacheKeyId('')).not.toThrow();
+  });
+
+  it('does not throw on a non-numeric user ID (warn-only contract — signals grammar drift)', () => {
+    // A future contributor expanding the grammar to alphanumeric IDs without
+    // updating VALID_CACHE_KEY_ID lands here.
+    expect(() => assertValidCacheKeyId('user:alice')).not.toThrow();
+  });
+
+  it('does not throw on a colon in the dynamic segment (warn-only contract — the collision case this guards against)', () => {
+    // `org:my-team:special` would corrupt the `<prefix>:<id>:<model>` key
+    // shape — operator queries on `<prefix>:org:my-team:*` would clash with
+    // legitimate `<prefix>:org:my-team:<model>` writes.
+    expect(() => assertValidCacheKeyId('org:my-team:special')).not.toThrow();
+  });
+
+  it('does not throw on an unknown scope prefix entirely (warn-only contract)', () => {
+    expect(() => assertValidCacheKeyId('account:12345')).not.toThrow();
   });
 });

--- a/services/ai-worker/src/services/RateLimitCache.ts
+++ b/services/ai-worker/src/services/RateLimitCache.ts
@@ -39,13 +39,23 @@
  */
 
 import type { Redis } from 'ioredis';
-import { createLogger } from '@tzurot/common-types';
+import { CACHE_KEY_PREFIXES, createLogger } from '@tzurot/common-types';
 
 const logger = createLogger('RateLimitCache');
 
-const KEY_PREFIX = 'ratelimit:openrouter:';
+const KEY_PREFIX = CACHE_KEY_PREFIXES.RATE_LIMIT_OPENROUTER;
 const MIN_TTL_SECONDS = 60;
 const MAX_TTL_SECONDS = 24 * 60 * 60;
+
+/**
+ * Format invariant for `cacheKeyId` — the dynamic segment of the cache key.
+ * Either the literal string `system`, `user:<digits>`, or empty (cache opt-out).
+ * Critically excludes any colon in the dynamic segment after `user:` so the
+ * `<prefix>:<id>:<model>` key shape stays unambiguous. Future scope extensions
+ * (e.g., `org:<name>`) MUST update this regex AND audit all callers to confirm
+ * the new dynamic segment cannot itself contain a colon.
+ */
+const VALID_CACHE_KEY_ID = /^(?:system|user:\d+|)$/;
 
 interface MarkOptions {
   /**
@@ -198,8 +208,38 @@ function clampTtl(seconds: number): number {
  */
 export function deriveCacheKeyId(userApiKey: string | undefined, userId: string): string {
   const hasByokKey = userApiKey !== undefined && userApiKey.length > 0;
+  let result: string;
   if (hasByokKey) {
-    return userId.length > 0 ? `user:${userId}` : '';
+    result = userId.length > 0 ? `user:${userId}` : '';
+  } else {
+    result = 'system';
   }
-  return 'system';
+  assertValidCacheKeyId(result);
+  return result;
+}
+
+/**
+ * Runtime belt for the documented `cacheKeyId` format invariant. Logs `warn`
+ * on violation rather than throwing — the cache is a performance optimisation,
+ * never a correctness gate, so a degraded read is preferable to a hard
+ * failure mid-request.
+ *
+ * Dormant against the current `deriveCacheKeyId` outputs, which all match
+ * `VALID_CACHE_KEY_ID` by construction. The check is a sentinel for future
+ * extensions: a contributor adding a new scope (e.g., `org:<name>`) must
+ * update both `deriveCacheKeyId` and `VALID_CACHE_KEY_ID`, or this assertion
+ * will fire and surface the gap.
+ *
+ * Exported for direct unit testing of the invariant — callers that route
+ * through `deriveCacheKeyId` get the check for free.
+ */
+export function assertValidCacheKeyId(cacheKeyId: string): void {
+  if (!VALID_CACHE_KEY_ID.test(cacheKeyId)) {
+    logger.warn(
+      { cacheKeyId },
+      'Cache key ID violates expected shape — Redis key lookups may collide. ' +
+        'Expected: "system" | "user:<digits>" | "". ' +
+        'Update VALID_CACHE_KEY_ID + deriveCacheKeyId together when adding a new scope.'
+    );
+  }
 }


### PR DESCRIPTION
## Summary

Three opportunistic cleanups from the PR #943/#946 review-cycle inboxes that share a file surface:

1. **Centralize `CACHE_KEY_PREFIXES`** to \`@tzurot/common-types/constants/redis-keys\`. The \`nocredits:openrouter:\` prefix was duplicated across \`CreditExhaustionCache\` (ai-worker) and \`clear-credit-exhaustion\` (ops tooling). A future rename in one would silently break the other — operator \`DEL\` would target a stale key while live writes go to the renamed one. Both consumers now import the single source of truth.

2. **Add \`assertValidCacheKeyId\` runtime invariant** in \`RateLimitCache\`. The Redis key shape \`<prefix>:<id>:<model>\` is unambiguous only because \`cacheKeyId\` is always \`system\`, \`user:<digits>\`, or empty (no colons in the dynamic segment). The invariant was documented in \`buildKey\`'s JSDoc but unenforced. Now logs \`warn\` on violation. Dormant against current outputs by construction — fires only when a future scope-extension (e.g. \`org:<name>\` with a colon-bearing name) violates the contract without updating the regex.

3. **Add \`logger.debug\` opt-out log** in \`LLMInvoker.invokeWithRetry\` when \`cacheKeyId\` is empty. Empty-string silently skips both caches — surface it in dev so a new caller forgetting to thread the value is at least visible. (Promoting the field to required in the type stays tracked in \`backlog/inbox.md\`.)

Net complexity neutral: the two existing \`if (cacheKeyId.length > 0)\` short-circuit guards collapse into a single \`if/else\` so the new debug branch doesn't bump \`invokeWithRetry\`'s cyclomatic count.

## Inbox items closed

- ⚡️ Cache \`KEY_PREFIX\` constants duplicated across services and tooling (PR #946 review)
- ⚡️ Enforce \`buildKey\` no-colon invariant in \`deriveCacheKeyId\` at runtime (PR #943 rounds 12 + 16)
- ⚡️ Make \`cacheKeyId\` required in \`InvokeWithRetryOptions\` (or add debug-log on empty opt-out) — option (b) shipped, option (a) stays tracked

## Test plan

- [x] \`pnpm test\` — full suite green (4624 + 2186 + others; total 14/14 packages pass)
- [x] \`pnpm quality\` — lint + cpd + depcruise + typecheck + typecheck:spec all green
- [x] New tests: 3 cases in \`redis-keys.test.ts\` (prefix values + invariant), 6 cases in \`assertValidCacheKeyId\` describe block
- [ ] CI: structure tests + integration tests + claude-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)