### PR TITLE
refactor(ai-worker): rename storage-layer MemoryDocument to PgvectorMemoryDocument

### DIFF
--- a/services/ai-worker/src/services/MemoryRetriever.ts
+++ b/services/ai-worker/src/services/MemoryRetriever.ts
@@ -208,7 +208,13 @@ export class MemoryRetriever {
       );
     }
 
-    // Query memories only if memory manager is available
+    // Query memories only if memory manager is available.
+    //
+    // Storage→RAG boundary: `queryMemories*` returns `PgvectorMemoryDocument[]`
+    // (wider `metadata?: Record<string, unknown>`), assigned here into the
+    // RAG-layer `MemoryDocument[]` shape (narrower typed metadata). The two
+    // are structurally compatible because all RAG-layer metadata fields are
+    // optional — see `PgvectorTypes.ts` for the change-together invariant.
     const relevantMemories =
       this.memoryManager !== undefined
         ? memoryQueryOptions.channelIds !== undefined && memoryQueryOptions.channelIds.length > 0

--- a/services/ai-worker/src/services/PgvectorChannelScoping.test.ts
+++ b/services/ai-worker/src/services/PgvectorChannelScoping.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { waterfallMemoryQuery, type QueryMemoriesFn } from './PgvectorChannelScoping.js';
-import type { MemoryDocument, MemoryQueryOptions } from './PgvectorTypes.js';
+import type { PgvectorMemoryDocument, MemoryQueryOptions } from './PgvectorTypes.js';
 
 // Valid Discord snowflake IDs for testing (17-19 digit numeric strings)
 const VALID_CHANNEL_ID_1 = '123456789012345678';
@@ -41,7 +41,7 @@ describe('waterfallMemoryQuery', () => {
   });
 
   it('should fall back to normal query when no channelIds provided', async () => {
-    const mockResults: MemoryDocument[] = [
+    const mockResults: PgvectorMemoryDocument[] = [
       { pageContent: 'memory 1', metadata: { id: 'mem-1' } },
       { pageContent: 'memory 2', metadata: { id: 'mem-2' } },
     ];
@@ -55,7 +55,9 @@ describe('waterfallMemoryQuery', () => {
   });
 
   it('should fall back to normal query when channelIds is empty array', async () => {
-    const mockResults: MemoryDocument[] = [{ pageContent: 'memory 1', metadata: { id: 'mem-1' } }];
+    const mockResults: PgvectorMemoryDocument[] = [
+      { pageContent: 'memory 1', metadata: { id: 'mem-1' } },
+    ];
     mockQueryFn.mockResolvedValue(mockResults);
 
     const options = { ...baseOptions, channelIds: [] };
@@ -67,13 +69,13 @@ describe('waterfallMemoryQuery', () => {
 
   it('should perform waterfall query with default 50% budget ratio', async () => {
     // Channel-scoped results (5 memories - 50% of 10)
-    const channelResults: MemoryDocument[] = [
+    const channelResults: PgvectorMemoryDocument[] = [
       { pageContent: 'channel memory 1', metadata: { id: 'ch-1' } },
       { pageContent: 'channel memory 2', metadata: { id: 'ch-2' } },
       { pageContent: 'channel memory 3', metadata: { id: 'ch-3' } },
     ];
     // Global backfill results (remaining budget: 10 - 3 = 7)
-    const globalResults: MemoryDocument[] = [
+    const globalResults: PgvectorMemoryDocument[] = [
       { pageContent: 'global memory 1', metadata: { id: 'gl-1' } },
       { pageContent: 'global memory 2', metadata: { id: 'gl-2' } },
     ];
@@ -112,10 +114,10 @@ describe('waterfallMemoryQuery', () => {
   });
 
   it('should respect custom channelBudgetRatio', async () => {
-    const channelResults: MemoryDocument[] = [
+    const channelResults: PgvectorMemoryDocument[] = [
       { pageContent: 'channel memory', metadata: { id: 'ch-1' } },
     ];
-    const globalResults: MemoryDocument[] = [
+    const globalResults: PgvectorMemoryDocument[] = [
       { pageContent: 'global memory', metadata: { id: 'gl-1' } },
     ];
 
@@ -150,7 +152,7 @@ describe('waterfallMemoryQuery', () => {
 
   it('should skip global backfill when channel results fill the budget', async () => {
     // Channel-scoped returns exactly the full limit worth
-    const channelResults: MemoryDocument[] = Array.from({ length: 10 }, (_, i) => ({
+    const channelResults: PgvectorMemoryDocument[] = Array.from({ length: 10 }, (_, i) => ({
       pageContent: `channel memory ${i}`,
       metadata: { id: `ch-${i}` },
     }));
@@ -173,7 +175,7 @@ describe('waterfallMemoryQuery', () => {
   });
 
   it('should handle empty channel results and only return global results', async () => {
-    const globalResults: MemoryDocument[] = [
+    const globalResults: PgvectorMemoryDocument[] = [
       { pageContent: 'global memory 1', metadata: { id: 'gl-1' } },
       { pageContent: 'global memory 2', metadata: { id: 'gl-2' } },
     ];
@@ -201,12 +203,12 @@ describe('waterfallMemoryQuery', () => {
   });
 
   it('should handle memories without IDs in metadata', async () => {
-    const channelResults: MemoryDocument[] = [
+    const channelResults: PgvectorMemoryDocument[] = [
       { pageContent: 'channel memory 1', metadata: { score: 0.9 } }, // No id
       { pageContent: 'channel memory 2', metadata: { id: 'ch-2' } },
       { pageContent: 'channel memory 3' }, // No metadata at all
     ];
-    const globalResults: MemoryDocument[] = [
+    const globalResults: PgvectorMemoryDocument[] = [
       { pageContent: 'global memory', metadata: { id: 'gl-1' } },
     ];
 
@@ -230,8 +232,8 @@ describe('waterfallMemoryQuery', () => {
   });
 
   it('should use default limit of 10 when not specified', async () => {
-    const channelResults: MemoryDocument[] = [];
-    const globalResults: MemoryDocument[] = [];
+    const channelResults: PgvectorMemoryDocument[] = [];
+    const globalResults: PgvectorMemoryDocument[] = [];
 
     mockQueryFn.mockResolvedValueOnce(channelResults).mockResolvedValueOnce(globalResults);
 
@@ -303,7 +305,7 @@ describe('waterfallMemoryQuery', () => {
 
   it('should ensure minimum channel budget of 1 even with small limit', async () => {
     // Edge case: totalLimit=1, ratio=0.5 → should still get channelBudget=1, not 0
-    const channelResults: MemoryDocument[] = [
+    const channelResults: PgvectorMemoryDocument[] = [
       { pageContent: 'channel memory', metadata: { id: 'ch-1' } },
     ];
 
@@ -375,7 +377,7 @@ describe('waterfallMemoryQuery', () => {
   });
 
   it('should return channel results even when global query fails', async () => {
-    const channelResults: MemoryDocument[] = [
+    const channelResults: PgvectorMemoryDocument[] = [
       { pageContent: 'channel memory 1', metadata: { id: 'ch-1' } },
       { pageContent: 'channel memory 2', metadata: { id: 'ch-2' } },
     ];
@@ -397,10 +399,10 @@ describe('waterfallMemoryQuery', () => {
   });
 
   it('should filter invalid channel IDs and proceed with valid ones in waterfall', async () => {
-    const channelResults: MemoryDocument[] = [
+    const channelResults: PgvectorMemoryDocument[] = [
       { pageContent: 'channel memory', metadata: { id: 'ch-1' } },
     ];
-    const globalResults: MemoryDocument[] = [
+    const globalResults: PgvectorMemoryDocument[] = [
       { pageContent: 'global memory', metadata: { id: 'gl-1' } },
     ];
 
@@ -425,13 +427,13 @@ describe('waterfallMemoryQuery', () => {
   describe('null value handling', () => {
     it('should handle channel results with null ids when building excludeIds', async () => {
       // Channel results include documents with null/undefined ids
-      const channelResults: MemoryDocument[] = [
+      const channelResults: PgvectorMemoryDocument[] = [
         { pageContent: 'memory 1', metadata: { id: null as unknown as string } }, // null id
         { pageContent: 'memory 2', metadata: { id: 'ch-2' } }, // valid id
         { pageContent: 'memory 3', metadata: { id: undefined as unknown as string } }, // undefined
         { pageContent: 'memory 4' }, // no metadata
       ];
-      const globalResults: MemoryDocument[] = [
+      const globalResults: PgvectorMemoryDocument[] = [
         { pageContent: 'global memory', metadata: { id: 'gl-1' } },
       ];
 

--- a/services/ai-worker/src/services/PgvectorChannelScoping.ts
+++ b/services/ai-worker/src/services/PgvectorChannelScoping.ts
@@ -4,7 +4,7 @@
  */
 
 import { AI_DEFAULTS, filterValidDiscordIds, createLogger } from '@tzurot/common-types';
-import type { MemoryQueryOptions, MemoryDocument } from './PgvectorTypes.js';
+import type { MemoryQueryOptions, PgvectorMemoryDocument } from './PgvectorTypes.js';
 
 const logger = createLogger('PgvectorChannelScoping');
 
@@ -12,7 +12,7 @@ const logger = createLogger('PgvectorChannelScoping');
 export type QueryMemoriesFn = (
   query: string,
   options: MemoryQueryOptions
-) => Promise<MemoryDocument[]>;
+) => Promise<PgvectorMemoryDocument[]>;
 
 /**
  * Query memories with channel scoping using the "waterfall" method
@@ -35,7 +35,7 @@ export async function waterfallMemoryQuery(
   queryFn: QueryMemoriesFn,
   query: string,
   options: MemoryQueryOptions
-): Promise<MemoryDocument[]> {
+): Promise<PgvectorMemoryDocument[]> {
   const totalLimit = options.limit ?? 10;
   // Clamp channelBudgetRatio to valid 0-1 range to prevent invalid budget calculations
   const rawRatio = options.channelBudgetRatio ?? AI_DEFAULTS.CHANNEL_MEMORY_BUDGET_RATIO;
@@ -82,7 +82,7 @@ export async function waterfallMemoryQuery(
   );
 
   // Step 1: Query channel-scoped memories first
-  let channelResults: MemoryDocument[] = [];
+  let channelResults: PgvectorMemoryDocument[] = [];
   try {
     channelResults = await queryFn(query, {
       ...options,
@@ -109,7 +109,7 @@ export async function waterfallMemoryQuery(
     .filter((id): id is string => id !== undefined && id !== null);
 
   // Step 3: Global semantic query with exclusion (no channel filter)
-  let globalResults: MemoryDocument[] = [];
+  let globalResults: PgvectorMemoryDocument[] = [];
   if (remainingBudget > 0) {
     try {
       globalResults = await queryFn(query, {

--- a/services/ai-worker/src/services/PgvectorMemoryAdapter.test.ts
+++ b/services/ai-worker/src/services/PgvectorMemoryAdapter.test.ts
@@ -56,6 +56,10 @@ vi.mock('@tzurot/common-types', async () => {
     deterministicMemoryUuid: actual.deterministicMemoryUuid,
     // Mock countTextTokens for defensive validation check
     countTextTokens: () => 100, // Return safe value under limit
+    // Pass through the real `Prisma` namespace — `PgvectorQueryBuilder` calls
+    // `Prisma.sql` / `Prisma.join` to construct similarity-search SQL, and a
+    // missing entry here makes those calls throw and the catch path return [].
+    Prisma: actual.Prisma,
   };
 });
 
@@ -206,6 +210,158 @@ describe('PgvectorMemoryAdapter', () => {
       // All 4 should be the same chunkGroupId
       const uniqueGroupIds = new Set(chunkGroupIds);
       expect(uniqueGroupIds.size).toBe(1); // All have same group ID (deterministic)
+    });
+  });
+
+  describe('queryMemories', () => {
+    // Covers the read path: validation short-circuit, storage→RAG mapping,
+    // and graceful DB-failure degradation. PgvectorChannelScoping.test.ts and
+    // PgvectorSiblingExpander.test.ts own the helper-level assertions.
+
+    /**
+     * Build a `MemoryQueryResult` row matching the shape `prisma.$queryRaw`
+     * returns. Overrides are typed against the snake_case row shape so a
+     * typo like `persona_idd` fails the type check rather than silently
+     * overwriting nothing.
+     */
+    interface MemoryQueryResultRowOverrides {
+      id?: string;
+      content?: string;
+      persona_id?: string;
+      persona_name?: string;
+      owner_username?: string;
+      personality_id?: string;
+      personality_name?: string;
+      session_id?: string | null;
+      canon_scope?: string;
+      summary_type?: string | null;
+      channel_id?: string | null;
+      guild_id?: string | null;
+      message_ids?: string[] | null;
+      senders?: string[] | null;
+      created_at?: Date | string;
+      distance?: number;
+      chunk_group_id?: string | null;
+      chunk_index?: number | null;
+      total_chunks?: number | null;
+    }
+    function buildQueryResultRow(overrides: MemoryQueryResultRowOverrides = {}): unknown {
+      return {
+        id: 'mem-1',
+        content: 'Test memory content',
+        persona_id: 'persona-123',
+        persona_name: 'Test Persona',
+        owner_username: 'testuser',
+        personality_id: 'personality-456',
+        personality_name: 'Test Personality',
+        session_id: null,
+        canon_scope: 'personal',
+        summary_type: null,
+        channel_id: null,
+        guild_id: null,
+        message_ids: null,
+        senders: null,
+        created_at: new Date('2026-04-30T12:00:00Z'),
+        distance: 0.1,
+        chunk_group_id: null,
+        chunk_index: null,
+        total_chunks: null,
+        ...overrides,
+      };
+    }
+
+    it('returns empty array for an empty query string (validation short-circuit)', async () => {
+      const mockPrisma = {
+        $queryRaw: vi.fn(),
+      };
+
+      const adapter = new PgvectorMemoryAdapter(mockPrisma as never, createMockEmbeddingService());
+
+      const result = await adapter.queryMemories('', {
+        personaId: 'persona-123',
+      });
+
+      expect(result).toEqual([]);
+      // The validation gate runs before any DB call — confirms we never
+      // burn an embedding-API request on a known-bad input.
+      expect(mockPrisma.$queryRaw).not.toHaveBeenCalled();
+    });
+
+    it('maps prisma rows into PgvectorMemoryDocument[] with normalized metadata', async () => {
+      const mockPrisma = {
+        $queryRaw: vi
+          .fn()
+          .mockResolvedValue([
+            buildQueryResultRow({ id: 'mem-1', content: 'First memory', distance: 0.05 }),
+            buildQueryResultRow({ id: 'mem-2', content: 'Second memory', distance: 0.2 }),
+          ]),
+      };
+
+      const adapter = new PgvectorMemoryAdapter(mockPrisma as never, createMockEmbeddingService());
+
+      const result = await adapter.queryMemories('what did we discuss yesterday', {
+        personaId: 'persona-123',
+        // Disable sibling expansion to keep the test scope tight to
+        // queryMemories itself; PgvectorSiblingExpander.test.ts owns
+        // the expansion-path assertions.
+        includeSiblings: false,
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result[0].pageContent).toBe('First memory');
+      expect(result[0].metadata?.id).toBe('mem-1');
+      // `score = 1 - distance` per `mapQueryResultToDocument`, locking in
+      // the storage-layer normalization that downstream RAG context relies on.
+      expect(result[0].metadata?.score).toBeCloseTo(0.95);
+      expect(result[1].pageContent).toBe('Second memory');
+      expect(result[1].metadata?.score).toBeCloseTo(0.8);
+    });
+
+    it('returns empty array when prisma query throws (graceful degradation)', async () => {
+      const mockPrisma = {
+        $queryRaw: vi.fn().mockRejectedValue(new Error('Connection refused')),
+      };
+
+      const adapter = new PgvectorMemoryAdapter(mockPrisma as never, createMockEmbeddingService());
+
+      const result = await adapter.queryMemories('any query', {
+        personaId: 'persona-123',
+        includeSiblings: false,
+      });
+
+      // The catch path returns [] rather than propagating — DB unavailability
+      // should never block the LLM response, just result in no retrieved
+      // memories for that turn.
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('queryMemoriesWithChannelScoping', () => {
+    // Pins delegation wiring — confirms this method routes through the
+    // adapter's own queryMemories rather than a separate code path.
+
+    it('delegates to waterfallMemoryQuery using its own queryMemories', async () => {
+      const mockPrisma = {
+        $queryRaw: vi.fn().mockResolvedValue([]),
+      };
+
+      const adapter = new PgvectorMemoryAdapter(mockPrisma as never, createMockEmbeddingService());
+      // Spy on `queryMemories` so we can confirm the delegator routes
+      // through it rather than skipping the adapter's own validation
+      // and mapping logic.
+      const queryMemoriesSpy = vi.spyOn(adapter, 'queryMemories');
+
+      const result = await adapter.queryMemoriesWithChannelScoping('test query', {
+        personaId: 'persona-123',
+        // No channelIds → waterfall falls back to a single normal query
+        // through the delegated function (kept simple for this unit test;
+        // the full waterfall behavior is covered in
+        // PgvectorChannelScoping.test.ts).
+        includeSiblings: false,
+      });
+
+      expect(result).toEqual([]);
+      expect(queryMemoriesSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/services/ai-worker/src/services/PgvectorMemoryAdapter.ts
+++ b/services/ai-worker/src/services/PgvectorMemoryAdapter.ts
@@ -32,7 +32,7 @@ export { MemoryQueryOptions, MemoryMetadata, MemoryMetadataSchema } from './Pgve
 
 import type {
   MemoryQueryOptions,
-  MemoryDocument,
+  PgvectorMemoryDocument,
   MemoryMetadata,
   MemoryQueryResult,
 } from './PgvectorTypes.js';
@@ -58,7 +58,10 @@ export class PgvectorMemoryAdapter {
   /**
    * Query memories using vector similarity search
    */
-  async queryMemories(query: string, options: MemoryQueryOptions): Promise<MemoryDocument[]> {
+  async queryMemories(
+    query: string,
+    options: MemoryQueryOptions
+  ): Promise<PgvectorMemoryDocument[]> {
     try {
       // Validate query input before calling OpenAI API
       if (!isValidId(query)) {
@@ -97,7 +100,7 @@ export class PgvectorMemoryAdapter {
       );
 
       const memories = await this.prisma.$queryRaw<MemoryQueryResult[]>(sqlQuery);
-      let documents: MemoryDocument[] = memories.map(mapQueryResultToDocument);
+      let documents: PgvectorMemoryDocument[] = memories.map(mapQueryResultToDocument);
 
       // Expand results with sibling chunks (default: true for complete memory retrieval)
       if (options.includeSiblings !== false && documents.length > 0) {
@@ -312,7 +315,7 @@ export class PgvectorMemoryAdapter {
   async queryMemoriesWithChannelScoping(
     query: string,
     options: MemoryQueryOptions
-  ): Promise<MemoryDocument[]> {
+  ): Promise<PgvectorMemoryDocument[]> {
     return waterfallMemoryQuery((q, o) => this.queryMemories(q, o), query, options);
   }
 

--- a/services/ai-worker/src/services/PgvectorSiblingExpander.test.ts
+++ b/services/ai-worker/src/services/PgvectorSiblingExpander.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fetchChunkSiblings, expandWithSiblings } from './PgvectorSiblingExpander.js';
-import type { MemoryDocument } from './PgvectorTypes.js';
+import type { PgvectorMemoryDocument } from './PgvectorTypes.js';
 
 vi.mock('@tzurot/common-types', () => ({
   createLogger: () => ({
@@ -105,7 +105,7 @@ describe('PgvectorSiblingExpander', () => {
   describe('expandWithSiblings', () => {
     it('should return documents with sibling chunks when chunk groups exist', async () => {
       // Mock the initial query result (chunk 1 of 3)
-      const initialResult: MemoryDocument[] = [
+      const initialResult: PgvectorMemoryDocument[] = [
         {
           pageContent: 'Chunk 1 content',
           metadata: {
@@ -199,7 +199,7 @@ describe('PgvectorSiblingExpander', () => {
 
     it('should not duplicate chunks when multiple chunks from same group match', async () => {
       // Initial results include 2 chunks from same group
-      const initialResults: MemoryDocument[] = [
+      const initialResults: PgvectorMemoryDocument[] = [
         {
           pageContent: 'Chunk 1 content',
           metadata: {
@@ -301,7 +301,7 @@ describe('PgvectorSiblingExpander', () => {
 
     it('should return original documents when no chunk groups exist', async () => {
       // Documents without chunk metadata
-      const documents: MemoryDocument[] = [
+      const documents: PgvectorMemoryDocument[] = [
         { pageContent: 'Regular memory 1', metadata: { id: 'mem-1' } },
         { pageContent: 'Regular memory 2', metadata: { id: 'mem-2' } },
       ];
@@ -316,7 +316,7 @@ describe('PgvectorSiblingExpander', () => {
 
     it('should handle null chunkGroupId from database (PostgreSQL null vs undefined)', async () => {
       // Documents with explicit null chunkGroupId (as PostgreSQL would return)
-      const documents: MemoryDocument[] = [
+      const documents: PgvectorMemoryDocument[] = [
         {
           pageContent: 'Memory with null chunkGroupId',
           metadata: {
@@ -343,7 +343,7 @@ describe('PgvectorSiblingExpander', () => {
 
     it('should handle null id in metadata from database', async () => {
       // Documents with null id (edge case from database)
-      const documents: MemoryDocument[] = [
+      const documents: PgvectorMemoryDocument[] = [
         {
           pageContent: 'Memory with null id',
           metadata: {
@@ -409,7 +409,7 @@ describe('PgvectorSiblingExpander', () => {
 
     it('should handle empty string chunkGroupId', async () => {
       // Document with empty string chunkGroupId
-      const documents: MemoryDocument[] = [
+      const documents: PgvectorMemoryDocument[] = [
         {
           pageContent: 'Memory with empty chunkGroupId',
           metadata: {

--- a/services/ai-worker/src/services/PgvectorSiblingExpander.ts
+++ b/services/ai-worker/src/services/PgvectorSiblingExpander.ts
@@ -9,7 +9,7 @@ import {
   extractChunkGroups,
   mergeSiblings,
 } from '../utils/memoryUtils.js';
-import type { MemoryQueryResult, MemoryDocument } from './PgvectorTypes.js';
+import type { MemoryQueryResult, PgvectorMemoryDocument } from './PgvectorTypes.js';
 
 const logger = createLogger('PgvectorSiblingExpander');
 
@@ -21,7 +21,7 @@ export async function fetchChunkSiblings(
   prisma: PrismaClient,
   chunkGroupId: string,
   personaId: string
-): Promise<MemoryDocument[]> {
+): Promise<PgvectorMemoryDocument[]> {
   const memories = await prisma.$queryRaw<MemoryQueryResult[]>`
     SELECT m.id, m.content, m.persona_id, m.personality_id, m.session_id,
            m.canon_scope, m.summary_type, m.channel_id, m.guild_id,
@@ -52,9 +52,9 @@ export async function fetchChunkSiblings(
  */
 export async function expandWithSiblings(
   prisma: PrismaClient,
-  documents: MemoryDocument[],
+  documents: PgvectorMemoryDocument[],
   personaId: string
-): Promise<MemoryDocument[]> {
+): Promise<PgvectorMemoryDocument[]> {
   const { chunkGroups, seenIds } = extractChunkGroups(documents);
   if (chunkGroups.size === 0) {
     return documents;

--- a/services/ai-worker/src/services/PgvectorTypes.ts
+++ b/services/ai-worker/src/services/PgvectorTypes.ts
@@ -68,7 +68,22 @@ export interface MemoryQueryOptions {
   includeSiblings?: boolean;
 }
 
-export interface MemoryDocument {
+/**
+ * Storage-layer memory document — what the pgvector adapter returns from raw
+ * similarity queries. Distinct from the RAG-layer `MemoryDocument` defined in
+ * `ConversationalRAGTypes.ts` (which has typed `metadata` fields like `score`
+ * and `createdAt`). Both shapes share `pageContent` + optional `metadata`, but
+ * the storage layer's metadata is wider (`Record<string, unknown>`) because
+ * downstream stages may add fields the storage layer doesn't know about.
+ *
+ * The two interfaces remain structurally compatible at the boundary where
+ * storage flows into RAG context — if you change either shape, verify the
+ * other still narrows correctly at the consumption site
+ * (`MemoryRetriever.retrieveMemoriesAndDecideFocus`).
+ *
+ * @see ./ConversationalRAGTypes.ts for the RAG-layer `MemoryDocument`
+ */
+export interface PgvectorMemoryDocument {
   pageContent: string;
   metadata?: Record<string, unknown>;
 }

--- a/services/ai-worker/src/utils/memoryUtils.test.ts
+++ b/services/ai-worker/src/utils/memoryUtils.test.ts
@@ -209,7 +209,7 @@ describe('memoryUtils', () => {
   });
 
   describe('mapQueryResultToDocument', () => {
-    it('transforms database result to MemoryDocument', () => {
+    it('transforms database result to PgvectorMemoryDocument', () => {
       const queryResult: MemoryQueryResult = {
         id: 'mem-123',
         content: 'Test memory content',

--- a/services/ai-worker/src/utils/memoryUtils.ts
+++ b/services/ai-worker/src/utils/memoryUtils.ts
@@ -7,7 +7,7 @@ import type {
   MemoryMetadata,
   NormalizedMetadata,
   MemoryQueryResult,
-  MemoryDocument,
+  PgvectorMemoryDocument,
 } from '../services/PgvectorTypes.js';
 import { replacePromptPlaceholders } from './promptPlaceholders.js';
 
@@ -55,10 +55,10 @@ export function normalizeMetadata(metadata: MemoryMetadata): NormalizedMetadata 
 }
 
 /**
- * Transform a raw database query result into a MemoryDocument
+ * Transform a raw database query result into a PgvectorMemoryDocument
  * Handles placeholder replacement and metadata normalization
  */
-export function mapQueryResultToDocument(memory: MemoryQueryResult): MemoryDocument {
+export function mapQueryResultToDocument(memory: MemoryQueryResult): PgvectorMemoryDocument {
   // Replace {user} and {assistant} tokens with actual names
   // Pass owner_username for disambiguation when persona name matches personality name
   const content = replacePromptPlaceholders(
@@ -96,7 +96,7 @@ export function mapQueryResultToDocument(memory: MemoryQueryResult): MemoryDocum
  * Extract unique chunk group IDs and seen document IDs from a list of documents
  * Used for sibling chunk expansion
  */
-export function extractChunkGroups(documents: MemoryDocument[]): {
+export function extractChunkGroups(documents: PgvectorMemoryDocument[]): {
   chunkGroups: Set<string>;
   seenIds: Set<string>;
 } {
@@ -121,10 +121,10 @@ export function extractChunkGroups(documents: MemoryDocument[]): {
  * Merge sibling documents into the main document list, avoiding duplicates
  */
 export function mergeSiblings(
-  documents: MemoryDocument[],
-  siblings: MemoryDocument[],
+  documents: PgvectorMemoryDocument[],
+  siblings: PgvectorMemoryDocument[],
   seenIds: Set<string>
-): MemoryDocument[] {
+): PgvectorMemoryDocument[] {
   const result = [...documents];
   for (const sibling of siblings) {
     const sibId = sibling.metadata?.id as string | null | undefined;


### PR DESCRIPTION
## Summary

The ai-worker service had two different \`MemoryDocument\` interfaces sharing a name:

- **Storage layer** (\`PgvectorTypes.ts\`): \`{ pageContent: string; metadata?: Record<string, unknown> }\` — wider metadata, returned from raw pgvector queries.
- **RAG context layer** (\`ConversationalRAGTypes.ts\`): \`{ pageContent: string; metadata?: { id?, createdAt?, score? } }\` — narrower metadata, consumed by prompt building and budget management.

Structurally compatible at the storage→RAG boundary, but ambiguous at import sites — a reader hitting \`MemoryDocument\` had to check the import path to know which one was in scope.

This PR renames the storage-layer interface to \`PgvectorMemoryDocument\`. The RAG-layer \`MemoryDocument\` keeps its name. No shape changes, no behavior changes, just disambiguation across all 8 consumers.

## Why option (b)

The Inbox entry from PR #944's review surfaced three options:
- (a) unify into one with the wider metadata, accepting looser RAG-layer typing
- **(b) rename the storage-layer one to \`PgvectorMemoryDocument\`** — lowest-risk pure rename
- (c) add an explicit narrowing-conversion at the adapter boundary

(b) was identified as the lowest-risk pure rename in the original entry. It preserves both layers' typing strictness without restructuring the data flow.

## Inbox items closed

- ⚡️ Reconcile triple \`MemoryDocument\` definition across the ai-worker service (PR #944 round 1, after that PR's \`PromptContext.ts\` deletion eliminated the third copy — this resolves the remaining duality)

## Test plan

- [x] \`pnpm test\` — full suite green (4624 + 2186 + others; 14/14 packages pass)
- [x] \`pnpm quality\` — lint + cpd + depcruise + typecheck + typecheck:spec all green
- [x] Pgvector + memoryUtils focused tests: 85 pass (5 files)
- [ ] CI: structure tests + integration tests + claude-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)