### PR TITLE
test(ai-worker): assert createdAt mapping in queryMemories result

### DIFF
--- a/services/ai-worker/src/services/PgvectorMemoryAdapter.test.ts
+++ b/services/ai-worker/src/services/PgvectorMemoryAdapter.test.ts
@@ -313,6 +313,10 @@ describe('PgvectorMemoryAdapter', () => {
       // `score = 1 - distance` per `mapQueryResultToDocument`, locking in
       // the storage-layer normalization that downstream RAG context relies on.
       expect(result[0].metadata?.score).toBeCloseTo(0.95);
+      // `createdAt` is normalized from the row's `created_at` Date/string into
+      // a number-of-ms-since-epoch — `MemoryFormatter` reads this field for
+      // timestamp display, so the contract matters at the storage→RAG seam.
+      expect(result[0].metadata?.createdAt).toBe(new Date('2026-04-30T12:00:00Z').getTime());
       expect(result[1].pageContent).toBe('Second memory');
       expect(result[1].metadata?.score).toBeCloseTo(0.8);
     });


### PR DESCRIPTION
## Summary

Closes obs-#2 from PR #948's squashed-commit review. The \`mapQueryResultToDocument\` test was asserting \`id\` and \`score\` from the normalized metadata but not \`createdAt\` — yet that field is part of the contract \`MemoryFormatter\` consumes for timestamp display in the RAG layer.

Single assertion addition (~3 LOC including comment). Locks in the row's \`created_at\` Date → epoch-ms normalization.

## Inbox closed

- ⚡️ Add \`createdAt\` mapping assertion to \`queryMemories\` test (PR #948 review obs #2)

## Test plan

- [x] \`pnpm --filter @tzurot/ai-worker test\` — 2934/2934 pass
- [ ] CI: structure tests + integration tests + claude-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)