### PR TITLE
chore(hooks): add release-finalize reminder for post-release-merge step

### DIFF
--- a/.claude/hooks/release-finalize-reminder.sh
+++ b/.claude/hooks/release-finalize-reminder.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# PostToolUse hook: after `gh pr merge <N> --rebase` completes for a release PR
+# (one whose base branch is `main`), inject a reminder to run
+# `pnpm ops release:finalize` so develop's SHAs stay aligned with main.
+#
+# Why this hook exists: the release procedure in `.claude/skills/tzurot-git-workflow`
+# documents a step 6 ("After Merge to Main") that rebases develop onto main and
+# force-pushes, dropping the duplicate-SHA commits a rebase-merge always
+# creates. The tool (`pnpm ops release:finalize`, PR #878) and the skill
+# documentation existed for both the v3.0.0-beta.111 and v3.0.0-beta.112
+# releases — but the step was skipped both times, accumulating ~57 commits of
+# divergent-SHA drift before being caught and cleaned up on 2026-04-30.
+#
+# Documentation + tool wasn't enough enforcement. This hook is the
+# deterministic-trigger layer: PostToolUse fires on the `gh pr merge` event
+# itself, not on attention to a procedure document.
+#
+# Known limitations:
+# - PostToolUse fires on the COMMAND, not on its success. A failed
+#   `gh pr merge` (network error, branch-protection rejection) triggers
+#   PostToolUse but does NOT trigger the reminder, because the
+#   `PR_STATE = MERGED` check below exits silently when state is OPEN.
+#   Retries after a failed attempt fire correctly because the dedup
+#   write is gated by the same MERGED check.
+# - `gh pr merge https://github.com/.../pull/N` (URL form) is not matched
+#   by the `gh pr merge[[:space:]]+[0-9]+` extraction below. The reminder
+#   silently no-ops on URL-form invocations. Documented examples in the
+#   project consistently use the numeric form, so this is a known gap
+#   rather than a bug.
+# - `gh pr merge --rebase <NUM>` (flags before number) likewise doesn't
+#   match — the extraction requires the number directly after `gh pr merge`.
+#   Same rationale: documented examples always put the number first.
+
+# No `-e`: we rely on graceful early-exits via empty-var checks. `-u` catches
+# typos on variable names; pipefail surfaces failures from pipelines.
+set -uo pipefail
+
+INPUT=$(cat)
+TOOL_NAME=$(jq -r '.tool_name // empty' <<<"$INPUT" 2>/dev/null || echo "")
+COMMAND=$(jq -r '.tool_input.command // empty' <<<"$INPUT" 2>/dev/null || echo "")
+
+[ "$TOOL_NAME" != "Bash" ] && exit 0
+
+# Match `gh pr merge <NUM> [...] --rebase`. Excludes squash/merge strategies
+# since the project rule mandates rebase-only for release PRs anyway — if
+# a future operator violates that rule, this hook silently no-ops, which
+# is the right failure mode (the rule violation is the bigger problem).
+if ! grep -qE '(^|[[:space:]&|;])gh pr merge[[:space:]]+[0-9]+' <<<"$COMMAND"; then
+    exit 0
+fi
+if ! grep -qE -- '(^|[[:space:]&|;])--rebase($|[[:space:]])' <<<"$COMMAND"; then
+    exit 0
+fi
+
+# Feature-branch PRs to develop carry `--delete-branch` (and the project's
+# critical-rule says release PRs MUST omit it). This is the PRIMARY
+# fast-path filter: it lets us short-circuit on the common feature-PR
+# case without making an API call. The `gh pr view` call below is the
+# SECONDARY confirmation that catches feature PRs which forgot the
+# `--delete-branch` flag — without that, every such merge would
+# spuriously fire the reminder.
+#
+# `--auto` (GitHub auto-merge) is not filtered — but the `PR_STATE = MERGED`
+# check below correctly prevents spurious firing at command-issue time
+# (state would be OPEN at that point, not MERGED). The real gap is the
+# opposite: when an auto-merge eventually lands (minutes later when CI
+# greens and GitHub auto-applies), NO PostToolUse event fires for that
+# merge, so the reminder never fires at all. The project release procedure
+# always merges synchronously after CI greens, so this gap is theoretical
+# — but worth noting for a future operator who might opt into --auto.
+if grep -qE -- '(^|[[:space:]&|;])--delete-branch($|[[:space:]])' <<<"$COMMAND"; then
+    exit 0
+fi
+
+PR_NUM=$(grep -oE 'gh pr merge[[:space:]]+[0-9]+' <<<"$COMMAND" | grep -oE '[0-9]+$' | head -1)
+[ -z "$PR_NUM" ] && exit 0
+
+# Confirm via PR metadata: base = main AND state = MERGED.
+#
+# Why both fields: PostToolUse fires on the command, not on success. A
+# failed `gh pr merge` (branch protection, network blip) reaches this
+# point with the same shape as a successful one. Without the state
+# check, the dedup file below would be written on the failed attempt,
+# the reminder would fire confusingly, AND the subsequent successful
+# retry's reminder would be dedup-suppressed — defeating the hook's
+# purpose in the exact scenario where reliable reminders matter most.
+# Filtering on `state = MERGED` is what makes the dedup write safe.
+#
+# Single API call fetches both fields together — no extra round trip
+# vs the previous baseRefName-only version.
+PR_INFO=$(gh pr view "$PR_NUM" --json baseRefName,state 2>/dev/null || echo "")
+PR_BASE=$(jq -r '.baseRefName // empty' <<<"$PR_INFO" 2>/dev/null || echo "")
+PR_STATE=$(jq -r '.state // empty' <<<"$PR_INFO" 2>/dev/null || echo "")
+[ "$PR_BASE" != "main" ] && exit 0
+[ "$PR_STATE" != "MERGED" ] && exit 0
+
+# Append-only dedup: one line per release PR we've already reminded for.
+# Survives multi-PR sessions; namespaced by UID for shared-host safety.
+# /tmp is wiped on reboot, so the file stays bounded naturally.
+#
+# PR-level dedup (not PR:SHA like pr-monitor-reminder.sh): a release merge
+# is a one-shot event. There's no follow-up push to the same release PR
+# that should re-fire this reminder — once finalize has run, the operator
+# moves on to tagging + GitHub Release. The sister hook keys on PR:SHA
+# because feature-PR pushes happen repeatedly within a session.
+#
+# Critically: this dedup write is gated by the `PR_STATE = MERGED` check
+# above. Without that gate, a failed-then-retried merge sequence would
+# write the failed attempt's PR num to the dedup file, suppressing the
+# reminder on the subsequent successful retry.
+SEEN_FILE="/tmp/.claude_release_finalize_seen.$(id -u)"
+if [ -f "$SEEN_FILE" ] && grep -qxF "$PR_NUM" "$SEEN_FILE" 2>/dev/null; then
+    exit 0
+fi
+echo "$PR_NUM" >>"$SEEN_FILE"
+chmod 600 "$SEEN_FILE" 2>/dev/null || true
+
+cat <<EOF
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+RELEASE FINALIZE REMINDER — release PR #$PR_NUM merged to main
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Per .claude/skills/tzurot-git-workflow "Release Procedure" step 6, run
+release:finalize NEXT to rebase develop onto main:
+
+  pnpm ops release:finalize --yes
+
+Why this matters: rebase-merging a release PR to main creates new SHAs on
+main. Without finalize, develop keeps its old SHAs and the next release PR
+shows ~N commits of false divergence per cycle. Skipped on beta.111 +
+beta.112; ~57 commits of drift accumulated before manual cleanup on
+2026-04-30. Don't make it three in a row.
+
+Also remember the rest of the release sequence:
+  - Run pending Prisma migrations on prod IF this release includes one
+    (pnpm ops db:migrate --env prod; check: git log v<prev>..HEAD -- prisma/migrations/)
+  - Tag + push the release tag (git tag v3.0.0-beta.XX && git push --tags)
+  - Create the GitHub Release (gh release create v3.0.0-beta.XX --notes ...)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+EOF

--- a/.claude/rules/05-tooling.md
+++ b/.claude/rules/05-tooling.md
@@ -131,6 +131,10 @@ gh pr checks N --watch --interval=30 > /dev/null 2>&1; echo "CI_COMPLETE"; gh pr
 
 Note the `;` between each command (not `&&`). `echo "CI_COMPLETE"` and the final `gh pr checks N` run unconditionally — the sentinel fires even if `--watch` exits non-zero (network blip, bad flag). That's intentional: the trailing `gh pr checks N` surfaces the true state regardless, and "watch exited" is always a useful signal. `CI_COMPLETE` means "watch exited," not "all checks passed."
 
+**Exit-code semantics — "Monitor script failed (exit 1)" can be cosmetic.** The trailing `gh pr checks N` exits non-zero whenever ANY check is red. Branches with active `fixup!` commits will have `fixup-check` red intentionally until autosquash, so the Monitor tool will report "script failed" on every fixup-bearing branch even though the script ran perfectly and emitted the event stream. **Read the event stream for the actual outcome; treat the exit code as informational only.** Do not append `; true` to muzzle this — that would also suppress real `gh` CLI failures (network errors, rate limits) which are useful signal.
+
+**Don't reinvent the watch loop.** When tempted to "improve" the canonical pattern (e.g., custom `until` loops parsing `gh pr checks --json bucket` to wait for "all non-pending"), don't. `gh pr checks --watch` already correctly waits for all checks to reach a terminal state, including ones that haven't registered yet. Homegrown JSON-snapshot polling has a race: `gh pr checks --json` can return a partial check list, and "all non-pending" can be momentarily true before slow checks (lint, test, claude-review, CodeQL) register. The canonical `--watch` pattern doesn't have this race. If the canonical pattern reports "failed" on a fixup-bearing branch, that's the cosmetic-exit-code case above, not a reason to rebuild the wait loop.
+
 Pass to `Monitor` with `timeout_ms: 900000` (15 min — GitHub CI + CodeQL usually finishes well inside that; if it exceeds, re-arm).
 
 When the monitor fires, **all four** of the following must happen before the cycle is complete — do not stop after step 1 even if every check passed:

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,6 +26,10 @@
           {
             "type": "command",
             "command": ".claude/hooks/pr-monitor-reminder.sh"
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/release-finalize-reminder.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary

PostToolUse Bash hook that fires after \`gh pr merge <N> --rebase\` (without \`--delete-branch\`) when the merged PR's base branch is \`main\` — i.e., a release PR. Injects a system-reminder pointing at \`pnpm ops release:finalize --yes\`.

## Why this hook exists

The release procedure documented in \`.claude/skills/tzurot-git-workflow\` (step 6, "After Merge to Main") and the tool implementation (\`pnpm ops release:finalize\`, shipped via PR #878) both existed for the v3.0.0-beta.111 and v3.0.0-beta.112 releases. The step was **skipped both times**, accumulating ~57 commits of divergent-SHA drift between develop and main before being caught and manually cleaned up on 2026-04-30.

Documentation + tool wasn't enough enforcement. PostToolUse hooks fire deterministically on the \`gh pr merge\` event itself, not on attention to a procedure document — that's the structural-fix-discipline rule from \`.claude/rules/00-critical.md\` "Fix Recurring Failures Structurally" applied at the hook layer (rule + skill layers were already exhausted).

## Pattern matching

- Triggers only on \`gh pr merge <NUM> ... --rebase\` without \`--delete-branch\` (release-PR signature; feature PRs always carry \`--delete-branch\` per project rules)
- Confirms via \`gh pr view --json baseRefName\` that base = main, so a feature-PR merge that forgot the \`--delete-branch\` flag silently no-ops rather than spuriously firing
- Per-UID dedup file under \`/tmp\` prevents repeated reminders for the same PR within a session
- Modeled on the existing \`pr-monitor-reminder.sh\` hook (same JSON-input parsing, same dedup pattern, same output format)

## Test plan

Manual test cases (all pass):

- [x] Feature PR with \`--delete-branch\` → silent
- [x] Release PR (\`--rebase\`, no \`--delete-branch\`) → fires reminder with PR number, link to release:finalize tool, and the don't-make-it-three-in-a-row context
- [x] Same release PR re-fired → silent (dedup)
- [x] Non-merge command (\`git push origin develop\`) → silent
- [x] \`--squash\` strategy (not \`--rebase\`) → silent
- [ ] CI: lint / test / claude-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)