### PR TITLE
fix(ai-worker): preserve original 429 category in cache + strip standalone <from_id> tags

### DIFF
--- a/services/ai-worker/src/services/LLMInvoker.test.ts
+++ b/services/ai-worker/src/services/LLMInvoker.test.ts
@@ -1515,11 +1515,21 @@ describe('LLMInvoker', () => {
       await vi.runAllTimersAsync();
       await assertion;
 
-      expect(mockMarkRateLimited).toHaveBeenCalledWith({
-        cacheKeyId: 'user:111111111111111111',
-        model: 'z-ai/glm-4.5-air:free',
-        resetTimestampMs: resetMs,
-      });
+      // Cache write now persists the original error context (category +
+      // user message + technical message) so synthetic short-circuits at
+      // read time can replay the exact context the user would have seen
+      // on a real upstream 429. expect.objectContaining lets future
+      // additions to the persisted context not break this assertion.
+      expect(mockMarkRateLimited).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cacheKeyId: 'user:111111111111111111',
+          model: 'z-ai/glm-4.5-air:free',
+          resetTimestampMs: resetMs,
+          category: ApiErrorCategory.RATE_LIMIT,
+          userMessage: expect.any(String),
+          technicalMessage: expect.any(String),
+        })
+      );
 
       vi.useRealTimers();
     });

--- a/services/ai-worker/src/services/LLMInvoker.ts
+++ b/services/ai-worker/src/services/LLMInvoker.ts
@@ -317,40 +317,39 @@ export class LLMInvoker {
       {
         cacheKeyId,
         model: modelName,
+        category: result.category,
         ttlSeconds: result.ttlSeconds,
         resetIso: new Date(result.resetMs).toISOString(),
       },
       'Skipped LLM call — rate-limit cache hit'
     );
-    // Round-trip through parseApiError to inherit the RATE_LIMIT category +
-    // user message without duplicating the category-to-message mapping. The
-    // override below replaces only `shouldRetry` and `type` (which classify
-    // wrongly for a synthetic short-circuit) while keeping the inherited
-    // fields stable.
-    const errorInfo = parseApiError(
-      Object.assign(new Error(`Rate limit cached: model is rate-limited until ${result.resetMs}`), {
-        status: 429,
-      })
-    );
-    // Override `shouldRetry` and `type` from `parseApiError`'s default
-    // RATE_LIMIT classification: a synthetic short-circuit represents a
-    // KNOWN rate-limit window with a reset time, not a transient error
-    // worth retrying. Without this override, a future caller using
+    // Use the cached category + userMessage + technicalMessage directly
+    // instead of re-parsing through a stub message. This preserves the
+    // user-facing distinction between RATE_LIMIT and QUOTA_EXCEEDED that
+    // the original 429 had — pre-cache, the user saw a category-specific
+    // message; collapsing everything to a generic "too many requests"
+    // string at synthetic-error construction would silently drop the
+    // QUOTA_EXCEEDED routing (which carries actionable wording about
+    // credits + the limit-reset window).
+    //
+    // `shouldRetry: false` + `type: PERMANENT`: a synthetic short-circuit
+    // represents a KNOWN rate-limit window with a reset time, not a
+    // transient error worth retrying. Without these, a future caller using
     // `shouldRetryError()` on the thrown error would re-enter
     // `invokeWithRetry` → cache hits → throws → loops until exhausted.
     //
-    // Override `referenceId` to a stable sentinel: `parseApiError` calls
-    // `generateReferenceId()` for every error it sees, but for a synthetic
-    // short-circuit the generated ID points to a fake error object — there
-    // is no real provider call to trace if the ID surfaces in a user-facing
-    // message or support ticket. The sentinel makes it unambiguous in logs
-    // and UX that the reference traces to cache logic, not an upstream call.
+    // `referenceId: 'rate-limit-cache-hit'`: stable sentinel since there's
+    // no real upstream call to trace. Makes it unambiguous in logs/UX
+    // that the reference traces to cache logic, not an upstream call.
     throw new ApiError('Rate limit cached', {
-      ...errorInfo,
-      rateLimitResetMs: result.resetMs,
-      shouldRetry: false,
       type: ApiErrorType.PERMANENT,
+      category: result.category,
+      statusCode: 429,
+      userMessage: result.userMessage,
+      technicalMessage: result.technicalMessage,
       referenceId: 'rate-limit-cache-hit',
+      shouldRetry: false,
+      rateLimitResetMs: result.resetMs,
     });
   }
 
@@ -381,6 +380,20 @@ export class LLMInvoker {
       cacheKeyId,
       model: modelName,
       resetTimestampMs: errorInfo.rateLimitResetMs,
+      // Persist category + messages so the synthetic short-circuit at read
+      // time can replay the same user-facing message the user would have
+      // seen on a real upstream call. Without these, every cache hit
+      // collapsed to the generic RATE_LIMIT message even when the original
+      // 429 routed to QUOTA_EXCEEDED (different actionable wording about
+      // credits + limit-reset windows).
+      //
+      // `technicalMessage` is optional on `errorInfo` (parseApiError's
+      // post-truncation `?.substring` can produce undefined); fall back to
+      // empty string rather than persist `undefined` (which would JSON-
+      // serialize to absent and trip the read-side schema check).
+      category: errorInfo.category,
+      userMessage: errorInfo.userMessage,
+      technicalMessage: errorInfo.technicalMessage ?? '',
     });
   }
 

--- a/services/ai-worker/src/services/RateLimitCache.test.ts
+++ b/services/ai-worker/src/services/RateLimitCache.test.ts
@@ -1,9 +1,24 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Redis } from 'ioredis';
+import { ApiErrorCategory } from '@tzurot/common-types';
 import { RateLimitCache, deriveCacheKeyId, assertValidCacheKeyId } from './RateLimitCache.js';
 
 // Frozen "now" for deterministic TTL math in clamping tests
 const FIXED_NOW_MS = 1_777_500_000_000;
+
+/**
+ * Default error context for tests that don't care about the cached
+ * category/message replay path. Tests focusing on key shape, TTL math,
+ * isolation, etc. can spread this into their `markRateLimited` calls
+ * to avoid repeating the boilerplate. Tests that DO care about the
+ * preserved category (e.g., the QUOTA_EXCEEDED replay path) override
+ * these fields explicitly.
+ */
+const DEFAULT_ERROR_CTX = {
+  category: ApiErrorCategory.RATE_LIMIT,
+  userMessage: "I'm receiving too many requests right now. Please wait a moment and try again.",
+  technicalMessage: 'Rate limit exceeded',
+};
 
 describe('RateLimitCache', () => {
   let mockRedis: {
@@ -36,6 +51,7 @@ describe('RateLimitCache', () => {
         cacheKeyId: 'user:278863839632818186',
         model: 'z-ai/glm-4.5-air:free',
         resetTimestampMs: resetMs,
+        ...DEFAULT_ERROR_CTX,
       });
 
       expect(mockRedis.setex).toHaveBeenCalledTimes(1);
@@ -43,7 +59,15 @@ describe('RateLimitCache', () => {
       // Cache key is opaque scope ID + model, no hashing layer.
       expect(key).toBe('ratelimit:openrouter:user:278863839632818186:z-ai/glm-4.5-air:free');
       expect(ttl).toBe(3600);
-      expect(value).toBe(String(resetMs));
+      // Value is JSON-encoded since the cache schema migration. Preserves
+      // category + userMessage + technicalMessage for synthetic-error replay
+      // at read time.
+      expect(JSON.parse(value)).toEqual({
+        resetMs,
+        category: ApiErrorCategory.RATE_LIMIT,
+        userMessage: DEFAULT_ERROR_CTX.userMessage,
+        technicalMessage: DEFAULT_ERROR_CTX.technicalMessage,
+      });
     });
 
     it('uses literal "system" for guest-mode / system-key fallback bucket', async () => {
@@ -52,6 +76,7 @@ describe('RateLimitCache', () => {
         cacheKeyId: 'system',
         model: 'z-ai/glm-4.5-air:free',
         resetTimestampMs: resetMs,
+        ...DEFAULT_ERROR_CTX,
       });
       const [key] = mockRedis.setex.mock.calls[0];
       expect(key).toBe('ratelimit:openrouter:system:z-ai/glm-4.5-air:free');
@@ -63,6 +88,7 @@ describe('RateLimitCache', () => {
         cacheKeyId: 'system',
         model: 'z-ai/glm-4.5-air:free',
         resetTimestampMs: resetMs,
+        ...DEFAULT_ERROR_CTX,
       });
       expect(mockRedis.setex).not.toHaveBeenCalled();
     });
@@ -73,6 +99,7 @@ describe('RateLimitCache', () => {
         cacheKeyId: 'system',
         model: 'z-ai/glm-4.5-air:free',
         resetTimestampMs: resetMs,
+        ...DEFAULT_ERROR_CTX,
       });
       const [, ttl] = mockRedis.setex.mock.calls[0];
       expect(ttl).toBe(60);
@@ -84,6 +111,7 @@ describe('RateLimitCache', () => {
         cacheKeyId: 'system',
         model: 'z-ai/glm-4.5-air:free',
         resetTimestampMs: resetMs,
+        ...DEFAULT_ERROR_CTX,
       });
       const [, ttl] = mockRedis.setex.mock.calls[0];
       expect(ttl).toBe(86400);
@@ -97,6 +125,7 @@ describe('RateLimitCache', () => {
           cacheKeyId: 'system',
           model: 'z-ai/glm-4.5-air:free',
           resetTimestampMs: resetMs,
+          ...DEFAULT_ERROR_CTX,
         })
       ).resolves.toBeUndefined();
     });
@@ -112,21 +141,93 @@ describe('RateLimitCache', () => {
       expect(result).toEqual({ rateLimited: false });
     });
 
-    it('returns rateLimited result with reset + inferred ttl for present key', async () => {
+    it('returns rateLimited result with full context for present JSON-shaped key', async () => {
       const resetMs = FIXED_NOW_MS + 3600 * 1000;
-      mockRedis.get.mockResolvedValue(String(resetMs));
+      mockRedis.get.mockResolvedValue(
+        JSON.stringify({
+          resetMs,
+          category: ApiErrorCategory.QUOTA_EXCEEDED,
+          userMessage:
+            "You've reached your API usage limit. Please add credits to your OpenRouter account or wait until your limit resets.",
+          technicalMessage: 'Rate limit exceeded: free-models-per-day-high-balance',
+        })
+      );
       const result = await cache.isRateLimited({
         cacheKeyId: 'system',
         model: 'z-ai/glm-4.5-air:free',
       });
       // ttlSeconds is computed from (resetMs - now), not queried from Redis —
       // saves a round-trip on every cache hit and avoids a GET/TTL race window.
+      // Category + userMessage + technicalMessage are preserved across the
+      // cache so the synthetic short-circuit at read time can replay the
+      // exact context from the original 429 (e.g., QUOTA_EXCEEDED's
+      // credits-and-reset-window message instead of the generic
+      // RATE_LIMIT "too many requests" string).
       expect(result).toEqual({
         rateLimited: true,
         resetMs,
         ttlSeconds: 3600,
+        category: ApiErrorCategory.QUOTA_EXCEEDED,
+        userMessage:
+          "You've reached your API usage limit. Please add credits to your OpenRouter account or wait until your limit resets.",
+        technicalMessage: 'Rate limit exceeded: free-models-per-day-high-balance',
       });
       expect(mockRedis.ttl).not.toHaveBeenCalled();
+    });
+
+    it('falls back to RATE_LIMIT category for legacy numeric-only cache entries', async () => {
+      // Legacy entries (pre-JSON-migration cache writes still in flight)
+      // stored just `String(resetMs)`. Read-path compat preserves the prior
+      // user-facing behavior: RATE_LIMIT category + generic message.
+      // Existing prod entries naturally expire within 24h via TTL clamp,
+      // so this branch is bounded transitional.
+      const resetMs = FIXED_NOW_MS + 3600 * 1000;
+      mockRedis.get.mockResolvedValue(String(resetMs));
+      const result = await cache.isRateLimited({
+        cacheKeyId: 'system',
+        model: 'z-ai/glm-4.5-air:free',
+      });
+      expect(result).toEqual({
+        rateLimited: true,
+        resetMs,
+        ttlSeconds: 3600,
+        category: ApiErrorCategory.RATE_LIMIT,
+        userMessage:
+          "I'm receiving too many requests right now. Please wait a moment and try again.",
+        technicalMessage: `Rate limit cached: model is rate-limited until ${resetMs}`,
+      });
+    });
+
+    it('falls back to RATE_LIMIT category when persisted category is unknown (forward-deploy + rollback safety)', async () => {
+      // Guards the forward/backward deployment skew scenario: a future
+      // ai-worker adds a new ApiErrorCategory, writes it into the cache,
+      // then rollback reads the unknown string. Without the runtime
+      // membership check, the unknown value flows unchecked through
+      // ApiError and into downstream consumers that switch on category.
+      // The fallback uses RATE_LIMIT since we know the entry was written
+      // for a 429-class event; the persisted user/technical messages are
+      // still used verbatim so the user sees the original wording.
+      const resetMs = FIXED_NOW_MS + 3600 * 1000;
+      mockRedis.get.mockResolvedValue(
+        JSON.stringify({
+          resetMs,
+          category: 'category_from_the_future',
+          userMessage: "Future version's user message — preserved verbatim.",
+          technicalMessage: 'Future version technical detail',
+        })
+      );
+      const result = await cache.isRateLimited({
+        cacheKeyId: 'system',
+        model: 'z-ai/glm-4.5-air:free',
+      });
+      expect(result).toEqual({
+        rateLimited: true,
+        resetMs,
+        ttlSeconds: 3600,
+        category: ApiErrorCategory.RATE_LIMIT,
+        userMessage: "Future version's user message — preserved verbatim.",
+        technicalMessage: 'Future version technical detail',
+      });
     });
 
     it('returns false for malformed cache value (non-numeric)', async () => {
@@ -169,11 +270,13 @@ describe('RateLimitCache', () => {
         cacheKeyId: 'user:111111111111111111',
         model: 'z-ai/glm-4.5-air:free',
         resetTimestampMs: resetMs,
+        ...DEFAULT_ERROR_CTX,
       });
       await cache.markRateLimited({
         cacheKeyId: 'user:222222222222222222',
         model: 'z-ai/glm-4.5-air:free',
         resetTimestampMs: resetMs,
+        ...DEFAULT_ERROR_CTX,
       });
       const keyA = mockRedis.setex.mock.calls[0][0];
       const keyB = mockRedis.setex.mock.calls[1][0];
@@ -186,11 +289,13 @@ describe('RateLimitCache', () => {
         cacheKeyId: 'user:111111111111111111',
         model: 'z-ai/glm-4.5-air:free',
         resetTimestampMs: resetMs,
+        ...DEFAULT_ERROR_CTX,
       });
       await cache.markRateLimited({
         cacheKeyId: 'system',
         model: 'z-ai/glm-4.5-air:free',
         resetTimestampMs: resetMs,
+        ...DEFAULT_ERROR_CTX,
       });
       const keyUser = mockRedis.setex.mock.calls[0][0];
       const keySystem = mockRedis.setex.mock.calls[1][0];
@@ -203,11 +308,13 @@ describe('RateLimitCache', () => {
         cacheKeyId: 'system',
         model: 'z-ai/glm-4.5-air:free',
         resetTimestampMs: resetMs,
+        ...DEFAULT_ERROR_CTX,
       });
       await cache.markRateLimited({
         cacheKeyId: 'system',
         model: 'google/gemma-4-31b-it:free',
         resetTimestampMs: resetMs,
+        ...DEFAULT_ERROR_CTX,
       });
       const key1 = mockRedis.setex.mock.calls[0][0];
       const key2 = mockRedis.setex.mock.calls[1][0];

--- a/services/ai-worker/src/services/RateLimitCache.ts
+++ b/services/ai-worker/src/services/RateLimitCache.ts
@@ -39,13 +39,51 @@
  */
 
 import type { Redis } from 'ioredis';
-import { CACHE_KEY_PREFIXES, createLogger } from '@tzurot/common-types';
+import { ApiErrorCategory, CACHE_KEY_PREFIXES, createLogger } from '@tzurot/common-types';
 
 const logger = createLogger('RateLimitCache');
 
 const KEY_PREFIX = CACHE_KEY_PREFIXES.RATE_LIMIT_OPENROUTER;
 const MIN_TTL_SECONDS = 60;
 const MAX_TTL_SECONDS = 24 * 60 * 60;
+
+/**
+ * Cached value shape, persisted as JSON in Redis.
+ *
+ * Stores the full user-facing context from the original 429 — not just the
+ * reset timestamp — so the synthetic short-circuit at read time can replay
+ * the exact category + message the user would have seen on a real upstream
+ * call. Without this, every cache hit collapsed to the generic
+ * `RATE_LIMIT` user message, losing the `QUOTA_EXCEEDED` distinction
+ * (which carries actionable wording about credits + limit-reset windows).
+ *
+ * Schema migration: prior versions of this cache stored only
+ * `String(resetTimestampMs)` as the value. The read path
+ * (`parseStoredValue` below) handles both shapes — legacy numeric values
+ * fall back to `RATE_LIMIT` category with the generic user message
+ * (preserving prior behavior for in-flight cache entries). Existing prod
+ * entries naturally expire within 24h via TTL clamping, so the migration
+ * self-completes within a deployment cycle.
+ */
+interface StoredValue {
+  /** Unix-ms timestamp when the rate-limit window resets. */
+  resetMs: number;
+  /**
+   * Original ApiErrorCategory from the upstream 429. Persisted as a
+   * string for forward-compat with new categories; the read path falls
+   * back to RATE_LIMIT on unknown values.
+   */
+  category: ApiErrorCategory;
+  /** User-facing message corresponding to `category` (verbatim from `USER_ERROR_MESSAGES`). */
+  userMessage: string;
+  /**
+   * Original upstream technical message text (e.g.,
+   * "Rate limit exceeded: free-models-per-day-high-balance"). Bounded
+   * length is the caller's responsibility — `parseApiError` already
+   * applies `MAX_ERROR_MESSAGE_LENGTH` truncation.
+   */
+  technicalMessage: string;
+}
 
 /**
  * Format invariant for `cacheKeyId` — the dynamic segment of the cache key.
@@ -66,6 +104,16 @@ interface MarkOptions {
   cacheKeyId: string;
   model: string;
   resetTimestampMs: number;
+  /**
+   * Original error category from `parseApiError` — preserved so the
+   * synthetic short-circuit at read time can replay the same user
+   * message the user would have seen on a real upstream 429.
+   */
+  category: ApiErrorCategory;
+  /** User-facing message corresponding to `category`. */
+  userMessage: string;
+  /** Original upstream error text. */
+  technicalMessage: string;
 }
 
 interface CheckOptions {
@@ -77,6 +125,16 @@ interface RateLimitedResult {
   rateLimited: true;
   resetMs: number;
   ttlSeconds: number;
+  /**
+   * Original error category preserved across the cache. Falls back to
+   * `RATE_LIMIT` for legacy entries that were written before the JSON
+   * schema migration (those entries had only a numeric resetMs).
+   */
+  category: ApiErrorCategory;
+  /** User-facing message preserved across the cache. */
+  userMessage: string;
+  /** Original upstream error text preserved across the cache. */
+  technicalMessage: string;
 }
 
 interface NotLimitedResult {
@@ -94,7 +152,8 @@ export class RateLimitCache {
    * or evaporate immediately.
    */
   async markRateLimited(options: MarkOptions): Promise<void> {
-    const { cacheKeyId, model, resetTimestampMs } = options;
+    const { cacheKeyId, model, resetTimestampMs, category, userMessage, technicalMessage } =
+      options;
     const rawTtlSeconds = Math.floor((resetTimestampMs - Date.now()) / 1000);
     if (rawTtlSeconds <= 0) {
       logger.warn(
@@ -105,12 +164,19 @@ export class RateLimitCache {
     }
     const ttlSeconds = clampTtl(rawTtlSeconds);
     const key = buildKey(cacheKeyId, model);
+    const value: StoredValue = {
+      resetMs: resetTimestampMs,
+      category,
+      userMessage,
+      technicalMessage,
+    };
     try {
-      await this.redis.setex(key, ttlSeconds, String(resetTimestampMs));
+      await this.redis.setex(key, ttlSeconds, JSON.stringify(value));
       logger.info(
         {
           cacheKeyId,
           model,
+          category,
           ttlSeconds,
           resetIso: new Date(resetTimestampMs).toISOString(),
         },
@@ -144,8 +210,8 @@ export class RateLimitCache {
       if (stored === null) {
         return { rateLimited: false };
       }
-      const resetMs = Number(stored);
-      if (Number.isNaN(resetMs)) {
+      const parsed = parseStoredValue(stored);
+      if (parsed === null) {
         return { rateLimited: false };
       }
       // Treat the cached resetMs as the canonical truth. If the reset has
@@ -154,11 +220,18 @@ export class RateLimitCache {
       // short-circuiting on a stale cached value would block a request that
       // should succeed.
       const nowMs = Date.now();
-      if (resetMs < nowMs) {
+      if (parsed.resetMs < nowMs) {
         return { rateLimited: false };
       }
-      const ttlSeconds = Math.floor((resetMs - nowMs) / 1000);
-      return { rateLimited: true, resetMs, ttlSeconds };
+      const ttlSeconds = Math.floor((parsed.resetMs - nowMs) / 1000);
+      return {
+        rateLimited: true,
+        resetMs: parsed.resetMs,
+        ttlSeconds,
+        category: parsed.category,
+        userMessage: parsed.userMessage,
+        technicalMessage: parsed.technicalMessage,
+      };
     } catch (err) {
       logger.warn({ err, model }, 'Rate-limit cache read failed — degrading to retry path');
       return { rateLimited: false };
@@ -188,6 +261,101 @@ function buildKey(cacheKeyId: string, model: string): string {
 
 function clampTtl(seconds: number): number {
   return Math.min(MAX_TTL_SECONDS, Math.max(MIN_TTL_SECONDS, seconds));
+}
+
+/**
+ * Generic fallback user message for the legacy-cache-entry case (when the
+ * stored value is a bare numeric `resetMs` from the pre-JSON-migration cache
+ * shape). Identical to `USER_ERROR_MESSAGES[ApiErrorCategory.RATE_LIMIT]`
+ * but inlined here to avoid a circular dependency between the cache layer
+ * and the user-message constants. If `USER_ERROR_MESSAGES[RATE_LIMIT]`
+ * changes upstream, this string should be kept in sync — the cache fallback
+ * is a transitional safety net, not a permanent state.
+ */
+const LEGACY_FALLBACK_USER_MESSAGE =
+  "I'm receiving too many requests right now. Please wait a moment and try again.";
+
+/**
+ * Parse a Redis cache value into the structured shape, with backward-compat
+ * for the legacy numeric-only format. Returns null for malformed values
+ * (cache read fails closed, callers fall through to the retry path).
+ *
+ * Schema migration handling:
+ * - **New JSON shape** (`{ resetMs, category, userMessage, technicalMessage }`):
+ *   parsed faithfully, all fields preserved.
+ * - **Legacy numeric shape** (just `String(resetMs)` from pre-JSON cache
+ *   entries still in flight): returns the resetMs with `RATE_LIMIT` category
+ *   and the generic user message. This preserves the user-facing behavior
+ *   exactly as it was before the JSON migration for entries that haven't
+ *   expired yet. New writes always use JSON.
+ *
+ * Existing prod entries naturally expire within 24h via the TTL clamp, so
+ * the legacy-fallback branch can be removed in a follow-up PR after one
+ * deployment cycle.
+ */
+function parseStoredValue(raw: string): StoredValue | null {
+  // Legacy numeric path: pre-JSON cache entries persisted just `resetMs`
+  // as a stringified number. The first-character check distinguishes:
+  // JSON values always start with `{`, numeric values always start with
+  // a digit.
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  if (trimmed.startsWith('{')) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      return null;
+    }
+    if (parsed === null || typeof parsed !== 'object') {
+      return null;
+    }
+    const candidate = parsed as Record<string, unknown>;
+    if (
+      typeof candidate.resetMs !== 'number' ||
+      Number.isNaN(candidate.resetMs) ||
+      typeof candidate.category !== 'string' ||
+      typeof candidate.userMessage !== 'string' ||
+      typeof candidate.technicalMessage !== 'string'
+    ) {
+      return null;
+    }
+    // Validate the persisted category against the known enum values. The
+    // primary failure mode this guards against is a forward/backward
+    // deployment skew: a future version of ai-worker adds a new
+    // `ApiErrorCategory`, writes it into the cache, then a rollback to the
+    // current code reads the unknown string. Without this check, the
+    // unknown value would flow unchecked through `ApiError` and into
+    // downstream consumers that switch on `category` (e.g., the bot-client
+    // error renderer). On unknown values, fall back to `RATE_LIMIT` —
+    // safe since we know the entry was written for a 429-class event,
+    // and the persisted `userMessage`/`technicalMessage` are still used
+    // verbatim so the user sees the original wording.
+    const isKnownCategory = (Object.values(ApiErrorCategory) as string[]).includes(
+      candidate.category
+    );
+    return {
+      resetMs: candidate.resetMs,
+      category: isKnownCategory
+        ? (candidate.category as ApiErrorCategory)
+        : ApiErrorCategory.RATE_LIMIT,
+      userMessage: candidate.userMessage,
+      technicalMessage: candidate.technicalMessage,
+    };
+  }
+  // Legacy numeric path.
+  const resetMs = Number(trimmed);
+  if (Number.isNaN(resetMs)) {
+    return null;
+  }
+  return {
+    resetMs,
+    category: ApiErrorCategory.RATE_LIMIT,
+    userMessage: LEGACY_FALLBACK_USER_MESSAGE,
+    technicalMessage: `Rate limit cached: model is rate-limited until ${resetMs}`,
+  };
 }
 
 /**

--- a/services/ai-worker/src/utils/thinkingExtraction.test.ts
+++ b/services/ai-worker/src/utils/thinkingExtraction.test.ts
@@ -744,8 +744,13 @@ Response.`;
       expect(result.visibleContent).toContain('<from_id>');
     });
 
-    it('does NOT match when a UUID is present but the tag sequence is incomplete', () => {
-      // Missing <user> tag — structural sequence check protects extraction.
+    it('does NOT extract reasoning from an incomplete sequence; standalone <from_id> strips bare', () => {
+      // Missing <user> tag — the 4.5-Air full-sequence pattern won't match,
+      // so no <message> body is captured as reasoning. The bare <from_id>
+      // falls through to the standalone extractor (added 2026-04-30 for
+      // GLM-4.7's bare-from-id leak) and gets stripped. The <message> tag
+      // without preceding <user> isn't recognized as scaffolding and stays
+      // in visibleContent.
       const content = `<from_id>${VALID_UUID}</from_id>
 <message>content without user tag</message>
 
@@ -753,8 +758,14 @@ Response.`;
 
       const result = extractThinkingBlocks(content);
 
+      // No reasoning extracted (the <message> body wasn't claimed by either
+      // extractor — the 4.5-Air pattern needed <user> first; the standalone
+      // pattern doesn't capture body content).
       expect(result.thinkingContent).toBeNull();
-      expect(result.visibleContent).toContain('<from_id>');
+      // The bare <from_id> got stripped by the standalone extractor.
+      expect(result.visibleContent).not.toContain('<from_id>');
+      // The orphaned <message> tag without scaffolding context is preserved.
+      expect(result.visibleContent).toContain('<message>content without user tag</message>');
     });
 
     it('composes with standard <think> tag extraction on the remaining content', () => {
@@ -879,6 +890,93 @@ Response.`;
 
       expect(result.thinkingContent).toBe('reasoning');
       expect(result.visibleContent).toBe('Response.');
+    });
+  });
+
+  describe('Standalone <from_id> echo pattern (GLM-4.7 bare-from-id leak)', () => {
+    // Observed 2026-04-30 in production. GLM-4.7 emitted just
+    // <from_id>UUID</from_id> followed by the response, without the rest of
+    // the 4.5-Air vocabulary (<user>, <message>). The 4.5-Air full-sequence
+    // pattern requires all three tags and silently passes through this bare
+    // variant, leaking the <from_id>UUID</from_id> tag into the user-facing
+    // output. The standalone extractor catches this case.
+    const VALID_UUID = '62a59660-cd89-51dc-8c54-7100f4e33329';
+
+    it('strips the bare <from_id>UUID</from_id> when it stands alone', () => {
+      const content = `<from_id>${VALID_UUID}</from_id>
+
+The darkness shifts around me as I take in this image.`;
+
+      const result = extractThinkingBlocks(content);
+
+      // Bare from_id carries no reasoning content — strip silently without
+      // contributing to thinkingParts.
+      expect(result.thinkingContent).toBeNull();
+      expect(result.visibleContent).toBe('The darkness shifts around me as I take in this image.');
+      expect(result.visibleContent).not.toContain('<from_id>');
+    });
+
+    it('does NOT match when the from_id lacks a valid UUID', () => {
+      // Same UUID-format strictness as the 4.5-Air pattern. Random text
+      // between <from_id> tags must not trigger extraction.
+      const content = `<from_id>not-a-uuid</from_id>
+
+Response with garbage tag preserved.`;
+
+      const result = extractThinkingBlocks(content);
+
+      // Tag is preserved as-is — we only strip recognized leak shapes.
+      expect(result.visibleContent).toContain('<from_id>');
+    });
+
+    it('does NOT fire when the 4.5-Air full sequence is present (4.5-Air extractor wins)', () => {
+      // The full-sequence extractor is more specific (captures <message>
+      // body as reasoning); it must consume the leading <from_id> as part
+      // of its block. The standalone extractor only catches residual bare
+      // <from_id> tags that the full-sequence pattern didn't match.
+      const content = `<from_id>${VALID_UUID}</from_id>
+<user>User</user>
+<message>full reasoning block</message>
+
+Response.`;
+
+      const result = extractThinkingBlocks(content);
+
+      // Reasoning came from the <message> body via the 4.5-Air extractor;
+      // the visibleContent has the whole leading scaffolding stripped.
+      expect(result.thinkingContent).toBe('full reasoning block');
+      expect(result.visibleContent).toBe('Response.');
+    });
+
+    it('handles uppercase UUIDs (case-insensitivity on hex digits)', () => {
+      const upperUuid = VALID_UUID.toUpperCase();
+      const content = `<from_id>${upperUuid}</from_id>
+
+Response.`;
+
+      const result = extractThinkingBlocks(content);
+
+      expect(result.visibleContent).toBe('Response.');
+      expect(result.visibleContent).not.toContain('<from_id>');
+    });
+
+    it('does NOT match a <from_id> appearing mid-response (start-of-response anchor)', () => {
+      const content = `Some prose first. <from_id>${VALID_UUID}</from_id> then more prose.`;
+
+      const result = extractThinkingBlocks(content);
+
+      // Mid-response from_id (e.g., model quoting an attribute name in a
+      // meta-discussion about its own input format) must be preserved.
+      expect(result.visibleContent).toContain('<from_id>');
+    });
+
+    it('hasThinkingBlocks reports true on bare from_id (Pass-2 secondary check)', () => {
+      // DiagnosticRecorders.hasReasoningTagsInContent uses hasThinkingBlocks
+      // to count GLM scaffolding occurrences in /inspect output. Without
+      // this guard, bare-from_id leaks would be reported as zero
+      // reasoning-content occurrences, under-reporting the GLM quirk rate.
+      const content = `<from_id>${VALID_UUID}</from_id>\n\nResponse.`;
+      expect(hasThinkingBlocks(content)).toBe(true);
     });
   });
 

--- a/services/ai-worker/src/utils/thinkingExtraction.ts
+++ b/services/ai-worker/src/utils/thinkingExtraction.ts
@@ -117,6 +117,47 @@ const GLM_FAKE_USER_MESSAGE_ECHO_PATTERN =
   /^\s*<from_id>[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}<\/from_id>\s*<user>[^<]*<\/user>\s*<message>([\s\S]*?)<\/message>\s*/;
 
 /**
+ * Standalone `<from_id>` echo — bare variant of the 4.5-Air leak.
+ *
+ * Observed 2026-04-30 in production (Lilith persona, image-vision context,
+ * `z-ai/glm-4.7 • 📍 auto`). GLM-4.7 emitted just
+ * `<from_id>UUID</from_id>` followed by the in-character response, without
+ * the rest of the GLM-4.5-Air vocabulary (`<user>`, `<message>`). The
+ * `GLM_FAKE_USER_MESSAGE_ECHO_PATTERN` above requires the full sequence to
+ * match and silently passes through this bare variant — leaking the
+ * `<from_id>UUID</from_id>` tag into the user-facing Discord output.
+ *
+ * Source of the leak: prompt scaffolding includes `<message from="..."
+ * from_id="UUID" role="..."...>...</message>`. The model treats `from_id`
+ * as a standalone element rather than an attribute and echoes it as
+ * leading scaffolding. `HardcodedConstraints.ts` already tells the model
+ * not to do this; GLM-4.7 ignores the constraint inconsistently.
+ *
+ * Safety: same UUID-format anchor as the 4.5-Air pattern. A real response
+ * won't statistically start with `<from_id>UUID-shaped-text</from_id>`
+ * because UUIDs are not natural prose. Strip without side effects.
+ *
+ * Order in Pass 1: must run AFTER `GLM_FAKE_USER_MESSAGE_ECHO_PATTERN`. If
+ * the 4.5-Air full-sequence is present, the leading `<from_id>` is part of
+ * that block and should be consumed by the more-specific extractor (which
+ * also captures the `<message>` body as reasoning). Only when the
+ * 4.5-Air pattern doesn't match (because `<user>`/`<message>` follow-up is
+ * absent) does this fallback fire on the residual bare `<from_id>`.
+ *
+ * No reasoning content — `from_id` is just a UUID, not a CoT block. Strip
+ * silently without contributing to `thinkingParts`.
+ *
+ * Deletion plan: same as the other GLM patterns — once OpenRouter's
+ * reasoning middleware polyfills this leak shape upstream, remove this
+ * extractor. Removal trigger: a production log sample showing GLM-4.7
+ * responses NO LONGER include a leading `<from_id>UUID</from_id>` block
+ * for several days running. File with the raw API response as evidence
+ * before removing.
+ */
+const STANDALONE_FROM_ID_ECHO_PATTERN =
+  /^\s*<from_id>[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}<\/from_id>\s*/;
+
+/**
  * GLM-4.7 meta-preamble pattern.
  *
  * Observed 2026-04-24 (req 9b2aa0f3-d659-4f00-95f4-36da3a9b40f3): with
@@ -193,6 +234,25 @@ const GLM_FAKE_USER_MESSAGE_ECHO_PATTERN =
  */
 const GLM_47_META_PREAMBLE_PATTERN =
   /^\s*(?:<(user|character)>[^<]*<\/\1>\s*){0,2}(?:<analysis>([\s\S]*?)(?:<\/analysis>|$))\s*/i;
+
+/**
+ * Pass-1 strip helper for the standalone `<from_id>` echo. Extracted from
+ * `extractThinkingBlocks` to keep that function under the cognitive-complexity
+ * limit — a Pass-1 entry that doesn't capture content (the bare `<from_id>`
+ * carries no reasoning) is cleaner as a separate one-liner caller.
+ */
+function stripStandaloneFromId(content: string): string {
+  const match = STANDALONE_FROM_ID_ECHO_PATTERN.exec(content);
+  if (match === null) {
+    return content;
+  }
+  const stripped = content.slice(match[0].length);
+  logger.warn(
+    { remainingLength: stripped.length },
+    'Stripped leading standalone <from_id> scaffolding (GLM-4.7 bare-from-id echo)'
+  );
+  return stripped;
+}
 
 /**
  * Alternation pattern fragment for use in regex: `think|thinking|...`
@@ -468,6 +528,8 @@ export function extractThinkingBlocks(content: string): ThinkingExtraction {
     );
   }
 
+  visibleContent = stripStandaloneFromId(visibleContent);
+
   const glm47MetaMatch = GLM_47_META_PREAMBLE_PATTERN.exec(visibleContent);
   if (glm47MetaMatch !== null) {
     // Group 2 is the <analysis> body (group 1 is the preamble tag name used
@@ -570,6 +632,9 @@ export function hasThinkingBlocks(content: string): boolean {
   // pure-GLM responses where the scaffolding is the only thinking-content
   // signal, and `/inspect` diagnostics would under-report GLM reasoning
   // occurrences.
+  if (STANDALONE_FROM_ID_ECHO_PATTERN.test(normalized)) {
+    return true;
+  }
   if (GLM_FAKE_USER_MESSAGE_ECHO_PATTERN.test(normalized)) {
     return true;
   }


### PR DESCRIPTION
## Summary

Two related user-facing-context fixes for GLM-4.7 + the rate-limit cache, bundled into one PR because both share the theme of "preserve user-facing context that's currently being silently dropped."

## Part 1 — Preserve original 429 category across rate-limit cache

The rate-limit cache shipped in PR #943 (beta.112) was storing only \`String(resetMs)\` as its Redis value. Synthetic short-circuits at read time re-parsed through a stub message ("Rate limit cached: model is rate-limited until X"), which always pattern-matched into the generic \`RATE_LIMIT\` category — losing the \`QUOTA_EXCEEDED\` routing for daily-quota 429s, which carries actionable wording about credits + the limit-reset window.

User-observable regression: pre-cache, daily-quota 429s showed "You've reached your API usage limit. Please add credits to your OpenRouter account or wait until your limit resets." Post-cache, every cache hit collapsed to the generic "I'm receiving too many requests right now. Please wait a moment and try again."

**Fix**: cache value is now JSON \`{ resetMs, category, userMessage, technicalMessage }\`. \`shortCircuitOnCachedRateLimit\` uses the cached fields directly instead of re-parsing through a stub. \`cacheRateLimitOnFailure\` extracts those fields from the original \`errorInfo\` and threads them through.

**Schema migration**: legacy entries (numeric-only) handled gracefully by \`parseStoredValue\` — fall back to \`RATE_LIMIT\` category + generic message (preserving prior behavior). Existing prod entries naturally expire within 24h via TTL clamping; legacy branch can be removed in a follow-up after one deployment cycle.

## Part 2 — Strip standalone \`<from_id>\` tags from GLM-4.7 output

Observed 2026-04-30 in production: GLM-4.7 emitted just \`<from_id>UUID</from_id>\` followed by the in-character response, without the rest of the GLM-4.5-Air vocabulary (\`<user>\`, \`<message>\`). The existing \`GLM_FAKE_USER_MESSAGE_ECHO_PATTERN\` requires the full sequence to match and silently passed through this bare variant — leaking the literal \`<from_id>UUID</from_id>\` tag into the user-facing Discord output.

**Fix**: new \`STANDALONE_FROM_ID_ECHO_PATTERN\` extractor with the same UUID-format strictness as the 4.5-Air pattern. Runs in Pass 1 between the 4.5-Air full-sequence extractor and the 4.7 meta-preamble extractor — only catches the residual bare \`<from_id>\` case after the more-specific full-sequence pattern has had a chance to consume the leading scaffolding. Wired into the Pass-2 secondary check so \`hasThinkingBlocks\` correctly reports true on bare-from_id leaks.

The bare \`<from_id>\` carries no reasoning content (it's just a UUID, an attribute name echoed as an element); strip silently without contributing to \`thinkingParts\`.

Extracted into \`stripStandaloneFromId\` helper to keep \`extractThinkingBlocks\` under cognitive-complexity limit.

## Test plan

- [x] \`pnpm test\` — full suite green (2941 tests, +7 new for the standalone-from_id extractor + 1 for the legacy-cache-fallback path)
- [x] \`pnpm quality\` — lint + cpd + depcruise + typecheck + typecheck:spec all green
- [x] Reproducer for Part 2: literal screenshot from production captured 2026-04-30 with Lilith persona on z-ai/glm-4.7
- [ ] CI: structure tests + integration tests + claude-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)