### PR TITLE
feat: TTS infrastructure cleanup (post-PR-3b bundle)

### DIFF
--- a/packages/common-types/src/services/tts/TtsProvider.test.ts
+++ b/packages/common-types/src/services/tts/TtsProvider.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   buildPreparedInlineAudio,
   buildPreparedVoiceId,
+  isSelfHostedTtsProvider,
   isTtsProviderId,
   type PreparedTts,
 } from './TtsProvider.js';
@@ -17,6 +18,23 @@ describe('isTtsProviderId', () => {
     expect(isTtsProviderId('openrouter')).toBe(false);
     expect(isTtsProviderId('')).toBe(false);
     expect(isTtsProviderId('Mistral')).toBe(false); // case-sensitive
+  });
+});
+
+describe('isSelfHostedTtsProvider', () => {
+  it('is true for self-hosted', () => {
+    expect(isSelfHostedTtsProvider('self-hosted')).toBe(true);
+  });
+
+  it('is false for BYOK providers', () => {
+    expect(isSelfHostedTtsProvider('elevenlabs')).toBe(false);
+    expect(isSelfHostedTtsProvider('mistral')).toBe(false);
+  });
+
+  it('is false for unknown strings (no narrowing prerequisite)', () => {
+    expect(isSelfHostedTtsProvider('openrouter')).toBe(false);
+    expect(isSelfHostedTtsProvider('')).toBe(false);
+    expect(isSelfHostedTtsProvider('Self-Hosted')).toBe(false); // case-sensitive
   });
 });
 

--- a/packages/common-types/src/services/tts/TtsProvider.ts
+++ b/packages/common-types/src/services/tts/TtsProvider.ts
@@ -50,6 +50,19 @@ export function isTtsProviderId(value: string): value is TtsProviderId {
 }
 
 /**
+ * True when the provider runs self-hosted (no per-user API key needed).
+ *
+ * Accepts arbitrary `string` so call sites can use it directly on DB-sourced
+ * values without a prior `isTtsProviderId` narrowing step. Use this at call
+ * sites instead of comparing to the literal `'self-hosted'` — semantic intent
+ * ("is this self-hosted?") survives if a second self-hosted variant is ever
+ * added; literal comparisons would silently fail on the new variant.
+ */
+export function isSelfHostedTtsProvider(value: string): boolean {
+  return value === 'self-hosted';
+}
+
+/**
  * Static introspection of what a provider supports.
  *
  * The dispatcher uses these to make routing decisions WITHOUT inspecting

--- a/services/api-gateway/src/routes/admin/tts-config.ts
+++ b/services/api-gateway/src/routes/admin/tts-config.ts
@@ -25,6 +25,7 @@ import { Router, type Response, type Request } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import {
   createLogger,
+  isSelfHostedTtsProvider,
   type PrismaClient,
   type TtsConfigCacheInvalidationService,
   TtsConfigCreateSchema,
@@ -219,10 +220,10 @@ function createSetFreeDefaultHandler(service: TtsConfigService, prisma: PrismaCl
         ErrorResponses.validationError('Only global TTS configs can be set as free tier default')
       );
     }
-    // TTS-shaped invariant: only `self-hosted` is free at the per-user level —
+    // TTS-shaped invariant: only self-hosted is free at the per-user level —
     // BYOK providers (elevenlabs, mistral) require user-supplied API keys,
     // so they can't serve guests as a fallback.
-    if (config.provider !== 'self-hosted') {
+    if (!isSelfHostedTtsProvider(config.provider)) {
       return sendError(
         res,
         ErrorResponses.validationError(

--- a/services/api-gateway/src/routes/user/voices.test.ts
+++ b/services/api-gateway/src/routes/user/voices.test.ts
@@ -9,7 +9,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import express from 'express';
 import request from 'supertest';
-import { createVoicesRoutes } from './voices.js';
+import { createVoicesRoutes, describeProviderError } from './voices.js';
+import { ErrorCode } from '../../types.js';
 import type { PrismaClient } from '@tzurot/common-types';
 
 // Mock common-types
@@ -222,7 +223,7 @@ describe('Voice Management Routes', () => {
       expect(res.body.error).toBe('NOT_FOUND');
     });
 
-    it('skips a provider gracefully when its API rejects the key (still serves working provider)', async () => {
+    it('skips a provider gracefully when its API rejects the key, surfacing a warning', async () => {
       userWithKeys(['elevenlabs', 'mistral']);
       setProviderFetchMocks({
         elevenlabsList: () => jsonOk(elevenLabsVoicesResponse),
@@ -232,10 +233,39 @@ describe('Voice Management Routes', () => {
 
       const res = await request(app).get('/voices');
 
-      // ElevenLabs voices still served; Mistral skipped silently
+      // ElevenLabs voices still served; Mistral surfaced as a warning
       expect(res.status).toBe(200);
       expect(res.body.voices.every((v: any) => v.provider === 'elevenlabs')).toBe(true);
+      expect(res.body.warnings).toEqual([
+        { provider: 'mistral', message: 'API key invalid or expired' },
+      ]);
     });
+
+    it('omits warnings field entirely when all providers loaded cleanly', async () => {
+      userWithKeys(['elevenlabs']);
+
+      const res = await request(app).get('/voices');
+
+      expect(res.status).toBe(200);
+      expect(res.body.warnings).toBeUndefined();
+    });
+
+    it('classifies INTERNAL_ERROR as "Provider temporarily unavailable"', async () => {
+      userWithKeys(['elevenlabs', 'mistral']);
+      setProviderFetchMocks({
+        elevenlabsList: () => jsonOk(elevenLabsVoicesResponse),
+        mistralList: () =>
+          ({ ok: false, status: 503, statusText: 'Service Unavailable' }) as unknown as Response,
+      });
+
+      const res = await request(app).get('/voices');
+
+      expect(res.status).toBe(200);
+      expect(res.body.warnings).toEqual([
+        { provider: 'mistral', message: 'Provider temporarily unavailable' },
+      ]);
+    });
+
   });
 
   // ===== DELETE /:provider/:voiceId =======================================
@@ -443,5 +473,41 @@ describe('Voice Management Routes', () => {
       expect(res.status).toBe(404);
       expect(res.body.message).toContain('audio provider API key');
     });
+  });
+});
+
+describe('describeProviderError', () => {
+  const baseStamp = '2026-05-03T17:00:00.000Z';
+
+  it('classifies UNAUTHORIZED as "API key invalid or expired"', () => {
+    expect(
+      describeProviderError({
+        error: ErrorCode.UNAUTHORIZED,
+        message: 'whatever',
+        timestamp: baseStamp,
+      })
+    ).toBe('API key invalid or expired');
+  });
+
+  it('classifies INTERNAL_ERROR as "Provider temporarily unavailable"', () => {
+    expect(
+      describeProviderError({
+        error: ErrorCode.INTERNAL_ERROR,
+        message: 'whatever',
+        timestamp: baseStamp,
+      })
+    ).toBe('Provider temporarily unavailable');
+  });
+
+  it('falls back to "Couldn\'t load voices" for unrecognized error codes', () => {
+    // NOT_FOUND isn't reachable through the current voice clients, but the
+    // fallback exists as defense-in-depth — exercises the branch directly.
+    expect(
+      describeProviderError({
+        error: ErrorCode.NOT_FOUND,
+        message: 'whatever',
+        timestamp: baseStamp,
+      })
+    ).toBe("Couldn't load voices");
   });
 });

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -63,6 +63,56 @@ interface TaggedVoice {
 // ===== Provider-fanout helpers =============================================
 
 /**
+ * Per-provider list dispatch. Exhaustive switch with `never`-typed default
+ * so adding a new `AudioProviderId` value surfaces a compile error here
+ * rather than silently being skipped on list/clear. Mirrors
+ * `deleteVoiceAtProvider`'s exhaustiveness pattern. Normalizes the per-API
+ * shape (ElevenLabs `voice_id`, Mistral `voiceId`) to the unified
+ * `TaggedVoice` shape at the source.
+ */
+async function listVoicesForProvider(
+  provider: AudioProviderId,
+  apiKey: string
+): Promise<{ voices: TaggedVoice[]; totalVoices: number } | { errorResponse: ErrorResponse }> {
+  switch (provider) {
+    case 'elevenlabs': {
+      const result = await listElevenLabsTzurotVoices(apiKey);
+      if ('errorResponse' in result) {
+        return result;
+      }
+      return {
+        voices: result.voices.map(v => ({
+          provider: 'elevenlabs',
+          voiceId: v.voice_id,
+          name: v.name,
+          slug: v.name.slice(TTS_VOICE_NAME_PREFIX.length),
+        })),
+        totalVoices: result.totalVoices,
+      };
+    }
+    case 'mistral': {
+      const result = await listMistralTzurotVoices(apiKey, TTS_VOICE_NAME_PREFIX);
+      if ('errorResponse' in result) {
+        return result;
+      }
+      return {
+        voices: result.voices.map(v => ({
+          provider: 'mistral',
+          voiceId: v.voiceId,
+          name: v.name,
+          slug: v.name.slice(TTS_VOICE_NAME_PREFIX.length),
+        })),
+        totalVoices: result.totalVoices,
+      };
+    }
+    default: {
+      const _exhaustive: never = provider;
+      throw new Error(`Unsupported audio provider: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+/**
  * Fetch tzurot-prefixed cloned voices from every provider the user has a
  * BYOK key for, tagging each voice with its provider. Used by both list and
  * clear handlers.
@@ -78,46 +128,17 @@ async function fetchAllTzurotVoices(
   const tagged: TaggedVoice[] = [];
   const totals = new Map<AudioProviderId, number>();
 
-  const elKey = keys.get('elevenlabs');
-  if (elKey !== undefined) {
-    const result = await listElevenLabsTzurotVoices(elKey);
+  for (const [provider, apiKey] of keys) {
+    const result = await listVoicesForProvider(provider, apiKey);
     if ('errorResponse' in result) {
       logger.warn(
-        { provider: 'elevenlabs', errorResponse: result.errorResponse },
+        { provider, errorResponse: result.errorResponse },
         'Skipping provider — fetch failed'
       );
-    } else {
-      totals.set('elevenlabs', result.totalVoices);
-      for (const v of result.voices) {
-        tagged.push({
-          provider: 'elevenlabs',
-          voiceId: v.voice_id,
-          name: v.name,
-          slug: v.name.slice(TTS_VOICE_NAME_PREFIX.length),
-        });
-      }
+      continue;
     }
-  }
-
-  const miKey = keys.get('mistral');
-  if (miKey !== undefined) {
-    const result = await listMistralTzurotVoices(miKey, TTS_VOICE_NAME_PREFIX);
-    if ('errorResponse' in result) {
-      logger.warn(
-        { provider: 'mistral', errorResponse: result.errorResponse },
-        'Skipping provider — fetch failed'
-      );
-    } else {
-      totals.set('mistral', result.totalVoices);
-      for (const v of result.voices) {
-        tagged.push({
-          provider: 'mistral',
-          voiceId: v.voiceId,
-          name: v.name,
-          slug: v.name.slice(TTS_VOICE_NAME_PREFIX.length),
-        });
-      }
-    }
+    totals.set(provider, result.totalVoices);
+    tagged.push(...result.voices);
   }
 
   return { voices: tagged, totalVoicesByProvider: totals };

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -19,6 +19,7 @@ import {
   type AudioProviderId,
   type PrismaClient,
 } from '@tzurot/common-types';
+import { ErrorCode } from '../../types.js';
 import type { ErrorResponse } from '../../utils/errorResponses.js';
 import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
@@ -58,6 +59,38 @@ interface TaggedVoice {
   voiceId: string;
   name: string;
   slug: string;
+}
+
+/**
+ * Per-provider warning surfaced to bot-client when one provider's fetch
+ * failed but the request as a whole succeeded (e.g., working ElevenLabs key
+ * + bad Mistral key returns ElevenLabs voices with a "Mistral unavailable"
+ * warning). Without this, a user with an expired key sees fewer voices and
+ * has no signal that something's wrong.
+ */
+interface ProviderWarning {
+  provider: AudioProviderId;
+  message: string;
+}
+
+/**
+ * Map a provider's error response to a clean user-facing warning message.
+ * The provider name is added by the consumer (`Mistral: ...`), so messages
+ * here describe only the failure shape, not which provider failed.
+ *
+ * Exported for direct unit-test coverage: the fallback ("Couldn't load
+ * voices") branch isn't reachable through the route tests because both
+ * voice clients only emit UNAUTHORIZED and INTERNAL_ERROR, but the branch
+ * remains as defensive code for future error codes.
+ */
+export function describeProviderError(errorResponse: ErrorResponse): string {
+  if (errorResponse.error === ErrorCode.UNAUTHORIZED) {
+    return 'API key invalid or expired';
+  }
+  if (errorResponse.error === ErrorCode.INTERNAL_ERROR) {
+    return 'Provider temporarily unavailable';
+  }
+  return "Couldn't load voices";
 }
 
 // ===== Provider-fanout helpers =============================================
@@ -122,11 +155,14 @@ async function listVoicesForProvider(
  * — a working ElevenLabs key + bad Mistral key shouldn't break the listing
  * the user's actual ElevenLabs voices).
  */
-async function fetchAllTzurotVoices(
-  keys: Map<AudioProviderId, string>
-): Promise<{ voices: TaggedVoice[]; totalVoicesByProvider: Map<AudioProviderId, number> }> {
+async function fetchAllTzurotVoices(keys: Map<AudioProviderId, string>): Promise<{
+  voices: TaggedVoice[];
+  totalVoicesByProvider: Map<AudioProviderId, number>;
+  warnings: ProviderWarning[];
+}> {
   const tagged: TaggedVoice[] = [];
   const totals = new Map<AudioProviderId, number>();
+  const warnings: ProviderWarning[] = [];
 
   for (const [provider, apiKey] of keys) {
     const result = await listVoicesForProvider(provider, apiKey);
@@ -135,13 +171,14 @@ async function fetchAllTzurotVoices(
         { provider, errorResponse: result.errorResponse },
         'Skipping provider — fetch failed'
       );
+      warnings.push({ provider, message: describeProviderError(result.errorResponse) });
       continue;
     }
     totals.set(provider, result.totalVoices);
     tagged.push(...result.voices);
   }
 
-  return { voices: tagged, totalVoicesByProvider: totals };
+  return { voices: tagged, totalVoicesByProvider: totals, warnings };
 }
 
 /** Per-provider single-voice lookup (for IDOR-style verification before delete). */
@@ -215,7 +252,7 @@ async function handleListVoices(
     return;
   }
 
-  const { voices, totalVoicesByProvider } = await fetchAllTzurotVoices(keysResult.keys);
+  const { voices, totalVoicesByProvider, warnings } = await fetchAllTzurotVoices(keysResult.keys);
   const totalVoices = Array.from(totalVoicesByProvider.values()).reduce((a, b) => a + b, 0);
 
   logger.info(
@@ -224,14 +261,19 @@ async function handleListVoices(
       tzurotCount: voices.length,
       totalVoices,
       providers: [...keysResult.keys.keys()],
+      warningCount: warnings.length,
     },
     'Listed cloned voices across providers'
   );
 
+  // Omit `warnings` field entirely when empty — keeps the success response
+  // shape clean and lets bot-client treat its presence as the signal to
+  // render. Mirror the contract on the bot-client side: optional field.
   sendCustomSuccess(res, {
     voices,
     totalVoices,
     tzurotCount: voices.length,
+    ...(warnings.length > 0 ? { warnings } : {}),
   });
 }
 

--- a/services/bot-client/src/commands/settings/tts/guestModeValidation.ts
+++ b/services/bot-client/src/commands/settings/tts/guestModeValidation.ts
@@ -18,6 +18,7 @@ import { EmbedBuilder } from 'discord.js';
 import {
   createLogger,
   DISCORD_COLORS,
+  isSelfHostedTtsProvider,
   type TtsConfigSummary,
   type ListTtsConfigsResponse,
 } from '@tzurot/common-types';
@@ -94,7 +95,7 @@ export async function checkTtsByokAccess(
   }
 
   // Self-hosted: no key required, always allowed
-  if (config.provider === 'self-hosted') {
+  if (isSelfHostedTtsProvider(config.provider)) {
     return { blocked: false, reason: 'self-hosted' };
   }
 

--- a/services/bot-client/src/commands/settings/voices/browse.test.ts
+++ b/services/bot-client/src/commands/settings/voices/browse.test.ts
@@ -191,6 +191,67 @@ describe('handleBrowseVoices', () => {
     });
   });
 
+  it('should render warnings field above voices when gateway surfaces provider failures', async () => {
+    mockCallGatewayApi.mockResolvedValue({
+      ok: true,
+      data: {
+        voices: generateVoices(2),
+        totalVoices: 2,
+        tzurotCount: 2,
+        warnings: [{ provider: 'mistral', message: 'API key invalid or expired' }],
+      },
+    });
+
+    await handleBrowseVoices(createMockContext());
+
+    expect(mockEditReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        embeds: [
+          expect.objectContaining({
+            data: expect.objectContaining({
+              fields: expect.arrayContaining([
+                expect.objectContaining({
+                  name: expect.stringContaining("Some providers couldn't be loaded"),
+                  value: expect.stringContaining('Mistral'),
+                }),
+              ]),
+            }),
+          }),
+        ],
+      })
+    );
+  });
+
+  it('uses correct display name for elevenlabs warnings (regression for ternary mislabeling)', async () => {
+    mockCallGatewayApi.mockResolvedValue({
+      ok: true,
+      data: {
+        voices: generateVoices(2),
+        totalVoices: 2,
+        tzurotCount: 2,
+        warnings: [{ provider: 'elevenlabs', message: 'Provider temporarily unavailable' }],
+      },
+    });
+
+    await handleBrowseVoices(createMockContext());
+
+    expect(mockEditReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        embeds: [
+          expect.objectContaining({
+            data: expect.objectContaining({
+              fields: expect.arrayContaining([
+                expect.objectContaining({
+                  value: expect.stringContaining('ElevenLabs'),
+                }),
+              ]),
+            }),
+          }),
+        ],
+      })
+    );
+  });
+
   it('should handle API error', async () => {
     mockCallGatewayApi.mockResolvedValue({
       ok: false,

--- a/services/bot-client/src/commands/settings/voices/browse.ts
+++ b/services/bot-client/src/commands/settings/voices/browse.ts
@@ -6,7 +6,7 @@
 
 import { EmbedBuilder } from 'discord.js';
 import type { ButtonInteraction, ActionRowBuilder, ButtonBuilder } from 'discord.js';
-import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
+import { createLogger, DISCORD_COLORS, type AudioProviderId } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
 import { callGatewayApi, GATEWAY_TIMEOUTS, toGatewayUser } from '../../../utils/userGatewayClient.js';
 import {
@@ -16,6 +16,17 @@ import {
   pluralize,
 } from '../../../utils/browse/index.js';
 import type { VoicesListResponse } from './types.js';
+
+/**
+ * Display names for audio providers in user-facing warning messages.
+ * Typed as `Record<AudioProviderId, …>` so adding a new provider value
+ * surfaces a TS error here — the `?? w.provider` fallback below is a
+ * cosmetic safety net; the real enforcement is the type error.
+ */
+const PROVIDER_DISPLAY_NAMES: Record<AudioProviderId, string> = {
+  elevenlabs: 'ElevenLabs',
+  mistral: 'Mistral',
+};
 
 const logger = createLogger('settings-voices-browse');
 
@@ -33,6 +44,26 @@ export function isVoiceBrowseInteraction(customId: string): boolean {
 }
 
 /**
+ * Render a per-provider warnings field. Omitted when no warnings — caller
+ * checks length before calling.
+ */
+function renderWarningsField(warnings: NonNullable<VoicesListResponse['warnings']>): {
+  name: string;
+  value: string;
+  inline: boolean;
+} {
+  const lines = warnings.map(w => {
+    const providerName = PROVIDER_DISPLAY_NAMES[w.provider] ?? w.provider;
+    return `• **${providerName}**: ${w.message}`;
+  });
+  return {
+    name: '⚠️ Some providers couldn\'t be loaded',
+    value: lines.join('\n'),
+    inline: false,
+  };
+}
+
+/**
  * Build the paginated browse response for voice listing.
  *
  * Paginates client-side since the gateway returns all voices at once
@@ -42,12 +73,25 @@ function buildVoiceBrowsePage(
   data: VoicesListResponse,
   page: number
 ): { embed: EmbedBuilder; components: ActionRowBuilder<ButtonBuilder>[] } {
-  const { voices, totalVoices, tzurotCount } = data;
+  const { voices, totalVoices, tzurotCount, warnings } = data;
+
+  // Color escalates to WARNING when any provider failed — visual signal
+  // beyond the inline field, in case the user only glances at the embed.
+  const hasWarnings = warnings !== undefined && warnings.length > 0;
+  const color = hasWarnings
+    ? DISCORD_COLORS.WARNING
+    : voices.length > 0
+      ? DISCORD_COLORS.SUCCESS
+      : DISCORD_COLORS.BLURPLE;
 
   const embed = new EmbedBuilder()
     .setTitle('🎤 Cloned Voices')
-    .setColor(voices.length > 0 ? DISCORD_COLORS.SUCCESS : DISCORD_COLORS.BLURPLE)
+    .setColor(color)
     .setTimestamp();
+
+  if (hasWarnings) {
+    embed.addFields(renderWarningsField(warnings));
+  }
 
   if (voices.length === 0) {
     embed.setDescription(

--- a/services/bot-client/src/commands/settings/voices/clear.test.ts
+++ b/services/bot-client/src/commands/settings/voices/clear.test.ts
@@ -125,6 +125,29 @@ describe('handleClearVoices', () => {
     expect(mockEditReply).toHaveBeenCalled();
   });
 
+  it('warning entityName does not include a numeric count (avoids snapshot drift)', async () => {
+    mockCallGatewayApi.mockResolvedValue({
+      ok: true,
+      data: {
+        voices: [
+          { voiceId: 'v1', name: 'tzurot-alice', slug: 'alice' },
+          { voiceId: 'v2', name: 'tzurot-bob', slug: 'bob' },
+        ],
+        totalVoices: 10,
+        tzurotCount: 2,
+      },
+    });
+
+    await handleClearVoices(createMockContext());
+
+    const callArg = mockBuildDestructiveWarning.mock.calls[0]?.[0] as
+      | { entityName?: string }
+      | undefined;
+    expect(callArg?.entityName).toBe('all your Tzurot voices');
+    // Specifically, no digits — defends against regression where the count returns
+    expect(callArg?.entityName).not.toMatch(/\d/);
+  });
+
   it('should show message when no voices to clear', async () => {
     mockCallGatewayApi.mockResolvedValue({
       ok: true,

--- a/services/bot-client/src/commands/settings/voices/clear.ts
+++ b/services/bot-client/src/commands/settings/voices/clear.ts
@@ -54,10 +54,17 @@ export async function handleClearVoices(context: DeferredCommandContext): Promis
       return;
     }
 
+    // Don't show a count in the warning. The warning fires on a snapshot
+    // from this GET; the actual delete happens server-side on a re-fetched
+    // snapshot in POST /user/voices/clear, which can drift if the user's
+    // voice slate changes between the two calls (concurrent clone from a
+    // parallel session). The result message reports the gateway's actual
+    // "deleted N/M" count from the same snapshot it deleted from, so the
+    // user gets accurate post-delete numbers without a misleading pre-count.
     const count = result.data.voices.length;
     const config = createHardDeleteConfig({
       entityType: 'cloned voices',
-      entityName: `${count} Tzurot voice${count !== 1 ? 's' : ''}`,
+      entityName: 'all your Tzurot voices',
       additionalWarning:
         'This will remove all auto-cloned voices from your audio provider accounts.\n' +
         'They will be re-cloned automatically when needed.',

--- a/services/bot-client/src/commands/settings/voices/types.ts
+++ b/services/bot-client/src/commands/settings/voices/types.ts
@@ -22,8 +22,19 @@ export interface VoiceEntry {
   slug: string;
 }
 
+/**
+ * Per-provider warning surfaced when one provider's fetch failed but the
+ * request as a whole succeeded. Absent (`undefined`) when all providers
+ * loaded cleanly. Bot-client renders these inline above the voice list.
+ */
+export interface VoiceWarning {
+  provider: AudioProviderId;
+  message: string;
+}
+
 export interface VoicesListResponse {
   voices: VoiceEntry[];
   totalVoices: number;
   tzurotCount: number;
+  warnings?: VoiceWarning[];
 }


### PR DESCRIPTION
## Summary

Bundles four small TTS-only follow-ups deferred from PR #961 (PR 3b) into one domain-cohesive PR. All four touch the same neighborhood (`/user/voices`, provider-string handling) and bundle naturally — single review cycle, single CI run, ~250 LOC total instead of four micro-PRs.

## Changes by commit

1. **`chore(common-types): add isSelfHostedTtsProvider predicate`** — Replaces hardcoded `'self-hosted'` string equality at two call sites with a typed predicate. Semantic intent ("is this self-hosted?") survives if a second self-hosted variant is added.
2. **`refactor(api-gateway): exhaustive listVoicesForProvider switch`** — Mirrors `deleteVoiceAtProvider`'s exhaustiveness pattern. Adding a new `AudioProviderId` value now surfaces a compile error in BOTH list and delete paths; previously the sequential if-chain would silently skip a new provider.
3. **`feat(api-gateway): /user/voices surfaces per-provider warnings`** — When a user has multiple BYOK keys configured but one is invalid, response now includes `warnings: Array<{ provider, message }>` instead of silently skipping. Field omitted when all providers loaded cleanly.
4. **`feat(bot-client): render voice-list warnings inline`** — Browse handler renders the warnings field above the voice list with embed color escalated to WARNING.
5. **`fix(bot-client): drop count from voice-clear warning`** — Eliminates snapshot drift between bot-client's pre-fetch count and gateway's actual delete count.

## Closes

Four `backlog/inbox.md` entries (will be removed in a follow-up doc commit on develop after merge):

- `'self-hosted'` predicate
- `fetchAllTzurotVoices` exhaustiveness asymmetry
- `/user/voices` warnings field
- `/user/voices/clear` snapshot drift

## Test plan

- [x] All unit tests green (4673 bot-client + 1836 api-gateway + 2304 common-types)
- [x] `pnpm quality` green (11/11 tasks)
- [ ] CI green on the squashed history before merge
- [ ] Manual verification in dev: deliberately invalid Mistral key → `/settings voices browse` shows the warning block

🤖 Generated with [Claude Code](https://claude.com/claude-code)