### PR TITLE
chore(prisma): explicit onDelete on UserPersonalityConfig FKs

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -343,9 +343,9 @@ model UserPersonalityConfig {
   createdAt        DateTime @default(now()) @map("created_at")
   updatedAt        DateTime @updatedAt @map("updated_at")
 
-  llmConfig   LlmConfig?  @relation(fields: [llmConfigId], references: [id])
-  ttsConfig   TtsConfig?  @relation("UserPersonalityTtsConfig", fields: [ttsConfigId], references: [id])
-  persona     Persona?    @relation(fields: [personaId], references: [id])
+  llmConfig   LlmConfig?  @relation(fields: [llmConfigId], references: [id], onDelete: SetNull)
+  ttsConfig   TtsConfig?  @relation("UserPersonalityTtsConfig", fields: [ttsConfigId], references: [id], onDelete: SetNull)
+  persona     Persona?    @relation(fields: [personaId], references: [id], onDelete: SetNull)
   personality Personality @relation(fields: [personalityId], references: [id], onDelete: Cascade)
   user        User        @relation(fields: [userId], references: [id], onDelete: Cascade)
 


### PR DESCRIPTION
## Summary

Schema-documentation fix: makes the implicit DB-level `ON DELETE SET NULL` explicit in the Prisma schema on `UserPersonalityConfig.{llmConfigId, ttsConfigId, personaId}`.

## Why

The DB-level FK constraints for these fields have always been `ON DELETE SET NULL` — the init migration set them up that way, and the TTS cascade migration too. The Prisma schema was missing the explicit annotation, so:

1. Future readers had to look up migration history to understand the FK behavior
2. The asymmetry with the parallel `User.defaultLlmConfigId` / `User.defaultTtsConfigId` fields (which DO use explicit `onDelete: SetNull`) was confusing

## Why SetNull (not Restrict)

Matches the existing DB state and the `User.default*ConfigId` precedent. `checkDeleteConstraints` in `LlmConfigService` / `TtsConfigService` already short-circuits the delete path when references exist, so the DB constraint only fires if the app guard is bypassed. SetNull is the graceful fallback in that edge case (user's per-personality override drops back to the cascade default rather than the deletion failing at the DB).

## No migration needed

`pnpm ops db:check-drift` confirmed no DB changes — the schema annotation was the only diff. The empty migration directory was deleted; `pglite-schema.sql` was auto-regenerated by husky to match.

## Closes

Inbox entry filed in PR #961 round 5: "Add explicit `onDelete` annotation to `UserPersonalityConfig.{ttsConfigId,llmConfigId}` (cross-cutting)" — also extended to cover `personaId` while in-scope.

## Test plan

- [x] `pnpm test` (4674 + 1836 + 2304 + others = 14/14 packages green)
- [x] `pnpm quality` (11/11 tasks green)
- [x] `pnpm ops db:check-drift` confirms no DB drift
- [ ] CI green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)