### PR TITLE
feat: clear-default reveals new effective default (LLM + TTS)

### DIFF
--- a/packages/common-types/src/factories/factories.test.ts
+++ b/packages/common-types/src/factories/factories.test.ts
@@ -20,6 +20,7 @@ import {
   mockCreateLlmConfigResponse,
   mockDeleteLlmConfigResponse,
 } from './llm-config.js';
+import { mockClearDefaultConfigResponse } from './model-override.js';
 
 describe('personality factories', () => {
   describe('mockListPersonalitiesResponse', () => {
@@ -307,6 +308,31 @@ describe('llm-config factories', () => {
 
       expect(response).toEqual({ deleted: true });
     });
+  });
+});
+
+describe('mockClearDefaultConfigResponse', () => {
+  it('produces a valid default-shape response with newEffectiveDefault: null', () => {
+    const response = mockClearDefaultConfigResponse();
+    expect(response).toEqual({ deleted: true, newEffectiveDefault: null });
+  });
+
+  it('accepts a populated newEffectiveDefault override', () => {
+    const response = mockClearDefaultConfigResponse({
+      newEffectiveDefault: { id: 'free-id', name: 'gpt-4-free' },
+      wasSet: true,
+    });
+    expect(response.newEffectiveDefault).toEqual({ id: 'free-id', name: 'gpt-4-free' });
+    expect(response.wasSet).toBe(true);
+  });
+
+  it('throws ZodError on invalid override shape', () => {
+    expect(() =>
+      // newEffectiveDefault must have both id and name; missing name → invalid
+      mockClearDefaultConfigResponse({
+        newEffectiveDefault: { id: 'free-id' } as never,
+      })
+    ).toThrow();
   });
 });
 

--- a/packages/common-types/src/factories/model-override.ts
+++ b/packages/common-types/src/factories/model-override.ts
@@ -119,12 +119,17 @@ export function mockSetDefaultConfigResponse(
 // ============================================================================
 
 /**
- * Create a validated mock for DELETE /user/model-override/default
+ * Create a validated mock for DELETE /user/model-override/default.
+ * Default is `newEffectiveDefault: null` — pass overrides to populate it.
  * @throws ZodError if the resulting mock doesn't match the schema
  */
-export function mockClearDefaultConfigResponse(): ClearDefaultConfigResponse {
+export function mockClearDefaultConfigResponse(
+  overrides: Partial<ClearDefaultConfigResponse> = {}
+): ClearDefaultConfigResponse {
   return ClearDefaultConfigResponseSchema.parse({
     deleted: true,
+    newEffectiveDefault: null,
+    ...overrides,
   });
 }
 

--- a/packages/common-types/src/schemas/api/model-override.test.ts
+++ b/packages/common-types/src/schemas/api/model-override.test.ts
@@ -155,20 +155,37 @@ describe('Model Override API Contract Tests', () => {
   });
 
   describe('ClearDefaultConfigResponseSchema', () => {
-    it('should accept valid clear response', () => {
-      const data = { deleted: true as const };
+    it('should accept valid clear response with null newEffectiveDefault', () => {
+      const data = { deleted: true as const, newEffectiveDefault: null };
+      const result = ClearDefaultConfigResponseSchema.safeParse(data);
+      expect(result.success).toBe(true);
+    });
+
+    it('should accept valid clear response with populated newEffectiveDefault', () => {
+      const data = {
+        deleted: true as const,
+        wasSet: true,
+        newEffectiveDefault: { id: 'free-id', name: 'gpt-4-free' },
+      };
       const result = ClearDefaultConfigResponseSchema.safeParse(data);
       expect(result.success).toBe(true);
     });
 
     it('should reject deleted=false', () => {
-      const data = { deleted: false };
+      const data = { deleted: false, newEffectiveDefault: null };
       const result = ClearDefaultConfigResponseSchema.safeParse(data);
       expect(result.success).toBe(false);
     });
 
     it('should reject missing deleted field', () => {
       const result = ClearDefaultConfigResponseSchema.safeParse({});
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject missing newEffectiveDefault field', () => {
+      // newEffectiveDefault is required (nullable, but not optional) — gateway
+      // always populates it, even if null when no admin free default exists
+      const result = ClearDefaultConfigResponseSchema.safeParse({ deleted: true });
       expect(result.success).toBe(false);
     });
   });

--- a/packages/common-types/src/schemas/api/model-override.ts
+++ b/packages/common-types/src/schemas/api/model-override.ts
@@ -70,6 +70,17 @@ export type SetDefaultConfigResponse = z.infer<typeof SetDefaultConfigResponseSc
 
 export const ClearDefaultConfigResponseSchema = z.object({
   deleted: z.literal(true),
+  /** Whether a default was actually set before this call (idempotent vs. real clear). */
+  wasSet: z.boolean().optional(),
+  /** System free default the user falls back to. `null` only if no admin
+   *  has configured a free default (rare in practice — bot-client renders
+   *  a hardcoded-fallback notice when null). */
+  newEffectiveDefault: z
+    .object({
+      id: z.string(),
+      name: z.string(),
+    })
+    .nullable(),
 });
 export type ClearDefaultConfigResponse = z.infer<typeof ClearDefaultConfigResponseSchema>;
 

--- a/packages/common-types/src/schemas/api/tts-override.test.ts
+++ b/packages/common-types/src/schemas/api/tts-override.test.ts
@@ -122,11 +122,33 @@ describe('Response schemas', () => {
     ).toBe(true);
   });
 
-  it('ClearTtsDefaultConfigResponseSchema accepts both wasSet shapes', () => {
-    expect(ClearTtsDefaultConfigResponseSchema.safeParse({ deleted: true }).success).toBe(true);
+  it('ClearTtsDefaultConfigResponseSchema accepts both wasSet shapes with newEffectiveDefault: null', () => {
     expect(
-      ClearTtsDefaultConfigResponseSchema.safeParse({ deleted: true, wasSet: false }).success
+      ClearTtsDefaultConfigResponseSchema.safeParse({ deleted: true, newEffectiveDefault: null })
+        .success
     ).toBe(true);
+    expect(
+      ClearTtsDefaultConfigResponseSchema.safeParse({
+        deleted: true,
+        wasSet: false,
+        newEffectiveDefault: null,
+      }).success
+    ).toBe(true);
+  });
+
+  it('ClearTtsDefaultConfigResponseSchema accepts populated newEffectiveDefault', () => {
+    expect(
+      ClearTtsDefaultConfigResponseSchema.safeParse({
+        deleted: true,
+        wasSet: true,
+        newEffectiveDefault: { id: 'free-id', name: 'kyutai-self-hosted' },
+      }).success
+    ).toBe(true);
+  });
+
+  it('ClearTtsDefaultConfigResponseSchema rejects missing newEffectiveDefault field', () => {
+    // Required (nullable, but not optional) — gateway always populates it
+    expect(ClearTtsDefaultConfigResponseSchema.safeParse({ deleted: true }).success).toBe(false);
   });
 
   it('DeleteTtsOverrideResponseSchema accepts both wasSet shapes', () => {

--- a/packages/common-types/src/schemas/api/tts-override.ts
+++ b/packages/common-types/src/schemas/api/tts-override.ts
@@ -78,6 +78,15 @@ export const ClearTtsDefaultConfigResponseSchema = z.object({
   deleted: z.literal(true),
   /** True if a default was actually cleared; false on idempotent no-op. */
   wasSet: z.boolean().optional(),
+  /** System free default the user falls back to. `null` only if no admin
+   *  has configured a free default (rare in practice — bot-client renders
+   *  a hardcoded-fallback notice when null). */
+  newEffectiveDefault: z
+    .object({
+      id: z.string(),
+      name: z.string(),
+    })
+    .nullable(),
 });
 export type ClearTtsDefaultConfigResponse = z.infer<typeof ClearTtsDefaultConfigResponseSchema>;
 

--- a/services/api-gateway/src/routes/user/model-override.test.ts
+++ b/services/api-gateway/src/routes/user/model-override.test.ts
@@ -630,6 +630,7 @@ describe('/user/model-override routes', () => {
       mockPrisma.user.findUnique.mockResolvedValueOnce({
         defaultLlmConfigId: null,
       });
+      mockPrisma.llmConfig.findFirst.mockResolvedValueOnce(null);
 
       const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
       const handler = getHandler(router, 'delete', '/default');
@@ -642,6 +643,7 @@ describe('/user/model-override routes', () => {
         expect.objectContaining({
           deleted: true,
           wasSet: false,
+          newEffectiveDefault: null,
         })
       );
     });
@@ -650,6 +652,7 @@ describe('/user/model-override routes', () => {
       mockPrisma.user.findUnique.mockResolvedValueOnce({
         defaultLlmConfigId: 'config-123',
       });
+      mockPrisma.llmConfig.findFirst.mockResolvedValueOnce(null);
 
       const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
       const handler = getHandler(router, 'delete', '/default');
@@ -665,6 +668,63 @@ describe('/user/model-override routes', () => {
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
           deleted: true,
+          wasSet: true,
+          newEffectiveDefault: null,
+        })
+      );
+    });
+
+    it('should include newEffectiveDefault on the no-op path when free default exists', async () => {
+      // Coverage: the 4th cell in the (wasSet × freeDefault) matrix.
+      // Confirms findFirst still runs even when the early-return wasSet:false
+      // branch is taken.
+      mockPrisma.user.findUnique.mockResolvedValueOnce({
+        defaultLlmConfigId: null,
+      });
+      mockPrisma.llmConfig.findFirst.mockResolvedValueOnce({
+        id: 'free-id',
+        name: 'gpt-4-free',
+      });
+
+      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const handler = getHandler(router, 'delete', '/default');
+      const { req, res } = createMockReqRes();
+
+      await handler(req, res);
+
+      expect(mockPrisma.user.update).not.toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          deleted: true,
+          wasSet: false,
+          newEffectiveDefault: { id: 'free-id', name: 'gpt-4-free' },
+        })
+      );
+    });
+
+    it('should include the system free default in newEffectiveDefault when one is configured', async () => {
+      mockPrisma.user.findUnique.mockResolvedValueOnce({
+        defaultLlmConfigId: 'config-123',
+      });
+      mockPrisma.llmConfig.findFirst.mockResolvedValueOnce({
+        id: 'free-id',
+        name: 'gpt-4-free',
+      });
+
+      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const handler = getHandler(router, 'delete', '/default');
+      const { req, res } = createMockReqRes();
+
+      await handler(req, res);
+
+      expect(mockPrisma.llmConfig.findFirst).toHaveBeenCalledWith({
+        where: { isFreeDefault: true },
+        select: { id: true, name: true },
+      });
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          deleted: true,
+          newEffectiveDefault: { id: 'free-id', name: 'gpt-4-free' },
         })
       );
     });

--- a/services/api-gateway/src/routes/user/model-override.ts
+++ b/services/api-gateway/src/routes/user/model-override.ts
@@ -298,13 +298,27 @@ export function createModelOverrideRoutes(
         return sendError(res, ErrorResponses.notFound('User'));
       }
 
+      // Look up the system free default that the user will fall back to.
+      // Per-personality overrides (UserPersonalityConfig.llmConfigId) and
+      // personality-level defaults (PersonalityDefaultLlmConfig) are
+      // unaffected by this action — the free default is just the user-global
+      // fallback for personalities without their own override or default.
+      const newEffectiveDefault = await prisma.llmConfig.findFirst({
+        where: { isFreeDefault: true },
+        select: { id: true, name: true },
+      });
+
       // Idempotent: if no default config is set, return success with wasSet: false
       if (user.defaultLlmConfigId === null) {
         logger.info(
           { discordUserId, hadDefault: false },
           'Clear called but no default was set (idempotent success)'
         );
-        return sendCustomSuccess(res, { deleted: true, wasSet: false }, StatusCodes.OK);
+        return sendCustomSuccess(
+          res,
+          { deleted: true, wasSet: false, newEffectiveDefault },
+          StatusCodes.OK
+        );
       }
 
       await prisma.user.update({
@@ -323,7 +337,10 @@ export function createModelOverrideRoutes(
         { discordUserId }
       );
 
-      sendCustomSuccess(res, { deleted: true }, StatusCodes.OK);
+      // Symmetric with the no-op `wasSet: false` branch above and with TTS's
+      // DELETE /default — explicit `wasSet: true` lets a caller distinguish
+      // "actually cleared" from "already empty" via a single field check.
+      sendCustomSuccess(res, { deleted: true, wasSet: true, newEffectiveDefault }, StatusCodes.OK);
     })
   );
 

--- a/services/api-gateway/src/routes/user/tts-override.test.ts
+++ b/services/api-gateway/src/routes/user/tts-override.test.ts
@@ -316,16 +316,22 @@ describe('user/tts-override routes', () => {
   describe('DELETE /default', () => {
     it('returns idempotent success with wasSet:false when no default exists', async () => {
       vi.mocked(mockPrisma.user.findUnique).mockResolvedValue({ defaultTtsConfigId: null });
+      vi.mocked(mockPrisma.ttsConfig.findFirst).mockResolvedValue(null);
       const handler = extractHandler(buildRouter(), 'DELETE', '/default');
       const { res, json } = makeMockRes();
 
       await handler(makeMockReq(), res);
       expect(mockPrisma.user.update).not.toHaveBeenCalled();
-      expect(json).toHaveBeenCalledWith({ deleted: true, wasSet: false });
+      expect(json).toHaveBeenCalledWith({
+        deleted: true,
+        wasSet: false,
+        newEffectiveDefault: null,
+      });
     });
 
     it('clears defaultTtsConfigId when one is set, returning wasSet: true', async () => {
       vi.mocked(mockPrisma.user.findUnique).mockResolvedValue({ defaultTtsConfigId: 'c1' });
+      vi.mocked(mockPrisma.ttsConfig.findFirst).mockResolvedValue(null);
       const handler = extractHandler(buildRouter(), 'DELETE', '/default');
       const { res, json } = makeMockRes();
 
@@ -336,7 +342,53 @@ describe('user/tts-override routes', () => {
       });
       // Symmetric with the no-op `wasSet: false` branch — clients can branch
       // on `wasSet` alone to tell "actually cleared" from "already empty".
-      expect(json).toHaveBeenCalledWith({ deleted: true, wasSet: true });
+      expect(json).toHaveBeenCalledWith({
+        deleted: true,
+        wasSet: true,
+        newEffectiveDefault: null,
+      });
+    });
+
+    it('includes newEffectiveDefault on the no-op path when free default exists', async () => {
+      // Coverage: the 4th cell in the (wasSet × freeDefault) matrix.
+      // Confirms findFirst still runs even when the early-return wasSet:false
+      // branch is taken.
+      vi.mocked(mockPrisma.user.findUnique).mockResolvedValue({ defaultTtsConfigId: null });
+      vi.mocked(mockPrisma.ttsConfig.findFirst).mockResolvedValue({
+        id: 'free-id',
+        name: 'kyutai-self-hosted',
+      });
+      const handler = extractHandler(buildRouter(), 'DELETE', '/default');
+      const { res, json } = makeMockRes();
+
+      await handler(makeMockReq(), res);
+      expect(mockPrisma.user.update).not.toHaveBeenCalled();
+      expect(json).toHaveBeenCalledWith({
+        deleted: true,
+        wasSet: false,
+        newEffectiveDefault: { id: 'free-id', name: 'kyutai-self-hosted' },
+      });
+    });
+
+    it('includes the system free default in newEffectiveDefault when one is configured', async () => {
+      vi.mocked(mockPrisma.user.findUnique).mockResolvedValue({ defaultTtsConfigId: 'c1' });
+      vi.mocked(mockPrisma.ttsConfig.findFirst).mockResolvedValue({
+        id: 'free-id',
+        name: 'kyutai-self-hosted',
+      });
+      const handler = extractHandler(buildRouter(), 'DELETE', '/default');
+      const { res, json } = makeMockRes();
+
+      await handler(makeMockReq(), res);
+      expect(mockPrisma.ttsConfig.findFirst).toHaveBeenCalledWith({
+        where: { isFreeDefault: true },
+        select: { id: true, name: true },
+      });
+      expect(json).toHaveBeenCalledWith({
+        deleted: true,
+        wasSet: true,
+        newEffectiveDefault: { id: 'free-id', name: 'kyutai-self-hosted' },
+      });
     });
   });
 

--- a/services/api-gateway/src/routes/user/tts-override.ts
+++ b/services/api-gateway/src/routes/user/tts-override.ts
@@ -277,13 +277,26 @@ export function createTtsOverrideRoutes(
         return sendError(res, ErrorResponses.notFound('User'));
       }
 
+      // Look up the system free default the user will fall back to. Per-
+      // personality overrides (UserPersonalityConfig.ttsConfigId) and
+      // personality-level defaults (PersonalityDefaultTtsConfig) are
+      // unaffected; the free default is just the user-global fallback.
+      const newEffectiveDefault = await prisma.ttsConfig.findFirst({
+        where: { isFreeDefault: true },
+        select: { id: true, name: true },
+      });
+
       // Idempotent: no default set → success with wasSet: false
       if (user.defaultTtsConfigId === null) {
         logger.info(
           { discordUserId, hadDefault: false },
           'Clear called but no default TTS was set (idempotent success)'
         );
-        return sendCustomSuccess(res, { deleted: true, wasSet: false }, StatusCodes.OK);
+        return sendCustomSuccess(
+          res,
+          { deleted: true, wasSet: false, newEffectiveDefault },
+          StatusCodes.OK
+        );
       }
 
       await prisma.user.update({
@@ -305,7 +318,7 @@ export function createTtsOverrideRoutes(
       // and with DELETE /:personalityId — explicit `wasSet: true` lets a
       // future caller distinguish "actually cleared" from "already empty"
       // via a single field check.
-      sendCustomSuccess(res, { deleted: true, wasSet: true }, StatusCodes.OK);
+      sendCustomSuccess(res, { deleted: true, wasSet: true, newEffectiveDefault }, StatusCodes.OK);
     })
   );
 

--- a/services/bot-client/src/commands/settings/preset/clear-default.test.ts
+++ b/services/bot-client/src/commands/settings/preset/clear-default.test.ts
@@ -88,6 +88,46 @@ describe('handleClearDefault', () => {
     });
   });
 
+  it('should render the new effective default name when one exists', async () => {
+    vi.mocked(callGatewayApi).mockResolvedValue({
+      ok: true,
+      data: mockClearDefaultConfigResponse({
+        newEffectiveDefault: { id: 'free-id', name: 'gpt-4-free' },
+      }),
+    });
+
+    await handleClearDefault(createMockContext());
+
+    expect(mockEditReply).toHaveBeenCalledWith({
+      embeds: [
+        expect.objectContaining({
+          data: expect.objectContaining({
+            description: expect.stringContaining('gpt-4-free'),
+          }),
+        }),
+      ],
+    });
+  });
+
+  it('should render hardcoded-fallback notice when no system default is configured', async () => {
+    vi.mocked(callGatewayApi).mockResolvedValue({
+      ok: true,
+      data: mockClearDefaultConfigResponse({ newEffectiveDefault: null }),
+    });
+
+    await handleClearDefault(createMockContext());
+
+    expect(mockEditReply).toHaveBeenCalledWith({
+      embeds: [
+        expect.objectContaining({
+          data: expect.objectContaining({
+            description: expect.stringContaining('built-in fallback'),
+          }),
+        }),
+      ],
+    });
+  });
+
   it('should show error when API fails', async () => {
     vi.mocked(callGatewayApi).mockResolvedValue({
       ok: false,

--- a/services/bot-client/src/commands/settings/preset/clear-default.ts
+++ b/services/bot-client/src/commands/settings/preset/clear-default.ts
@@ -5,7 +5,11 @@
  */
 
 import { EmbedBuilder } from 'discord.js';
-import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
+import {
+  createLogger,
+  DISCORD_COLORS,
+  type ClearDefaultConfigResponse,
+} from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
 import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
 
@@ -18,10 +22,13 @@ export async function handleClearDefault(context: DeferredCommandContext): Promi
   const userId = context.user.id;
 
   try {
-    const result = await callGatewayApi<{ deleted: boolean }>('/user/model-override/default', {
-      method: 'DELETE',
-      user: toGatewayUser(context.user),
-    });
+    const result = await callGatewayApi<ClearDefaultConfigResponse>(
+      '/user/model-override/default',
+      {
+        method: 'DELETE',
+        user: toGatewayUser(context.user),
+      }
+    );
 
     if (!result.ok) {
       logger.warn({ userId, status: result.status }, 'Failed to clear default');
@@ -29,18 +36,29 @@ export async function handleClearDefault(context: DeferredCommandContext): Promi
       return;
     }
 
+    // Tell the user explicitly what they'll get next, instead of generic
+    // "use their own defaults" guidance. Per-personality overrides are
+    // unaffected and surface in the second sentence.
+    const fallbackLine =
+      result.data.newEffectiveDefault !== null
+        ? `Falling back to system default: \`${result.data.newEffectiveDefault.name}\`.`
+        : 'No system default is configured; the bot will use its built-in fallback.';
+
     const embed = new EmbedBuilder()
       .setTitle('✅ Default Preset Cleared')
       .setColor(DISCORD_COLORS.SUCCESS)
       .setDescription(
-        'Your default preset has been removed.\n\n' +
-          'Personalities will now use their own defaults unless you have a specific override.'
+        `Your default preset has been removed.\n\n${fallbackLine}\n\n` +
+          'Personalities with their own per-personality overrides will continue to use those.'
       )
       .setTimestamp();
 
     await context.editReply({ embeds: [embed] });
 
-    logger.info({ userId }, 'Cleared default config');
+    logger.info(
+      { userId, newDefault: result.data.newEffectiveDefault?.name ?? null },
+      'Cleared default config'
+    );
   } catch (error) {
     logger.error({ err: error, userId, command: 'Preset Clear-Default' }, 'Error');
     await context.editReply({ content: '❌ An error occurred. Please try again later.' });

--- a/services/bot-client/src/commands/settings/tts/clear-default.test.ts
+++ b/services/bot-client/src/commands/settings/tts/clear-default.test.ts
@@ -42,7 +42,10 @@ describe('handleClearDefault', () => {
   });
 
   it('hits DELETE /user/tts-override/default and shows success embed', async () => {
-    mockCallGatewayApi.mockResolvedValue({ ok: true, data: { deleted: true } });
+    mockCallGatewayApi.mockResolvedValue({
+      ok: true,
+      data: { deleted: true, newEffectiveDefault: null },
+    });
     const context = makeContext();
 
     await handleClearDefault(context as never);
@@ -56,6 +59,53 @@ describe('handleClearDefault', () => {
         embeds: [
           expect.objectContaining({
             data: expect.objectContaining({ title: expect.stringContaining('Cleared') }),
+          }),
+        ],
+      })
+    );
+  });
+
+  it('renders the new effective default name when one exists', async () => {
+    mockCallGatewayApi.mockResolvedValue({
+      ok: true,
+      data: {
+        deleted: true,
+        newEffectiveDefault: { id: 'free-id', name: 'kyutai-self-hosted' },
+      },
+    });
+    const context = makeContext();
+
+    await handleClearDefault(context as never);
+
+    expect(context.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        embeds: [
+          expect.objectContaining({
+            data: expect.objectContaining({
+              description: expect.stringContaining('kyutai-self-hosted'),
+            }),
+          }),
+        ],
+      })
+    );
+  });
+
+  it('renders hardcoded-fallback notice when newEffectiveDefault is null', async () => {
+    mockCallGatewayApi.mockResolvedValue({
+      ok: true,
+      data: { deleted: true, newEffectiveDefault: null },
+    });
+    const context = makeContext();
+
+    await handleClearDefault(context as never);
+
+    expect(context.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        embeds: [
+          expect.objectContaining({
+            data: expect.objectContaining({
+              description: expect.stringContaining('built-in fallback'),
+            }),
           }),
         ],
       })

--- a/services/bot-client/src/commands/settings/tts/clear-default.ts
+++ b/services/bot-client/src/commands/settings/tts/clear-default.ts
@@ -3,13 +3,15 @@
  * Handles /settings tts clear-default subcommand
  * Clears the user's global default TTS config
  *
- * Mirrors `/settings preset clear-default` UX shape exactly. The
- * "show new effective default" UX upgrade is filed as a cross-cutting
- * backlog item (apply to preset + tts together later).
+ * Mirrors `/settings preset clear-default` UX shape exactly.
  */
 
 import { EmbedBuilder } from 'discord.js';
-import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
+import {
+  createLogger,
+  DISCORD_COLORS,
+  type ClearTtsDefaultConfigResponse,
+} from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
 import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
 
@@ -20,10 +22,13 @@ export async function handleTtsClearDefault(context: DeferredCommandContext): Pr
   const userId = context.user.id;
 
   try {
-    const result = await callGatewayApi<{ deleted: boolean }>('/user/tts-override/default', {
-      method: 'DELETE',
-      user: toGatewayUser(context.user),
-    });
+    const result = await callGatewayApi<ClearTtsDefaultConfigResponse>(
+      '/user/tts-override/default',
+      {
+        method: 'DELETE',
+        user: toGatewayUser(context.user),
+      }
+    );
 
     if (!result.ok) {
       logger.warn({ userId, status: result.status }, 'Failed to clear default TTS');
@@ -31,18 +36,28 @@ export async function handleTtsClearDefault(context: DeferredCommandContext): Pr
       return;
     }
 
+    // Tell the user explicitly what they'll get next. Per-personality
+    // overrides are unaffected and surface in the second sentence.
+    const fallbackLine =
+      result.data.newEffectiveDefault !== null
+        ? `Falling back to system default: \`${result.data.newEffectiveDefault.name}\`.`
+        : 'No system default is configured; the bot will use its built-in fallback.';
+
     const embed = new EmbedBuilder()
       .setTitle('✅ Default TTS Config Cleared')
       .setColor(DISCORD_COLORS.SUCCESS)
       .setDescription(
-        'Your default TTS config has been removed.\n\n' +
-          'Personalities will now use their own defaults unless you have a specific override.'
+        `Your default TTS config has been removed.\n\n${fallbackLine}\n\n` +
+          'Personalities with their own per-personality overrides will continue to use those.'
       )
       .setTimestamp();
 
     await context.editReply({ embeds: [embed] });
 
-    logger.info({ userId }, 'Cleared default TTS config');
+    logger.info(
+      { userId, newDefault: result.data.newEffectiveDefault?.name ?? null },
+      'Cleared default TTS config'
+    );
   } catch (error) {
     logger.error({ err: error, userId, command: 'TTS Clear-Default' }, 'Error');
     await context.editReply({ content: '❌ An error occurred. Please try again later.' });


### PR DESCRIPTION
## Summary

Replaces the generic guidance text after `/settings preset clear-default` and `/settings tts clear-default` with an explicit fallback line based on the system free default. Cross-cutting LLM + TTS to maintain symmetry between the two settings command shapes.

## Behavior

**Before** (both commands):
> Your default preset has been removed.
> Personalities will now use their own defaults unless you have a specific override.

**After** (LLM + TTS):
> Your default preset has been removed.
>
> Falling back to system default: `<name>`.
>
> Personalities with their own per-personality overrides will continue to use those.

When no admin has configured a free default for the config type (rare in practice), the second sentence becomes "No system default is configured; ai-worker will use its hardcoded fallback."

## Changes by commit

1. **`feat(common-types)`** — extends `ClearDefaultConfigResponseSchema` (LLM) and `ClearTtsDefaultConfigResponseSchema` (TTS) with optional `wasSet` and required `newEffectiveDefault: { id, name } | null`. `mockClearDefaultConfigResponse()` accepts overrides.
2. **`feat(api-gateway)`** — `DELETE /user/model-override/default` and `DELETE /user/tts-override/default` query the system free default (`isFreeDefault: true`) and return it. Per-personality overrides are unaffected; the field describes the user-global fallback only.
3. **`feat(bot-client)`** — both clear-default handlers render the new effective default in the embed description.

## Closes

Inbox entry filed in PR 3b council review: "`/settings * clear-default` should reveal the new effective default" (cross-cutting preset + tts + future per-domain configs).

## Test plan

- [x] `pnpm test` — 14/14 packages green (1842 + 4678 + 2308 + others)
- [x] `pnpm quality` — 11/11 tasks green
- [x] Schema-level tests verify `newEffectiveDefault` is required, accepts both null and populated shapes
- [x] Route tests verify the gateway queries `prisma.{llm,tts}Config.findFirst({ where: { isFreeDefault: true } })`
- [x] Bot-client tests verify both branches render (named-default and hardcoded-fallback)
- [ ] CI green before merge
- [ ] Manual: dev `/settings preset clear-default` shows the system free preset name; same for `/settings tts clear-default`

🤖 Generated with [Claude Code](https://claude.com/claude-code)