### PR TITLE
feat: suffix user-promoted global config names with username (LLM + TTS)

### DIFF
--- a/packages/common-types/src/utils/slugUtils.test.ts
+++ b/packages/common-types/src/utils/slugUtils.test.ts
@@ -73,6 +73,26 @@ describe('normalizeSlugForUser', () => {
     });
   });
 
+  describe('idempotency', () => {
+    it('does not double-suffix an already-normalized slug for the same user', () => {
+      // Without idempotency: 'lilith-bob' → 'lilith-bob-bob'. With it: stays 'lilith-bob'.
+      const result = normalizeSlugForUser('lilith-bob', 'user-456', 'bob');
+      expect(result).toBe('lilith-bob');
+    });
+
+    it('still appends suffix when slug ends in a different username', () => {
+      // 'lilith-alice' from user 'bob' should become 'lilith-alice-bob' — alice's suffix
+      // is part of the base slug from bob's perspective, not bob's own suffix.
+      const result = normalizeSlugForUser('lilith-alice', 'user-456', 'bob');
+      expect(result).toBe('lilith-alice-bob');
+    });
+
+    it('idempotent on the user-id fallback suffix when username sanitizes empty', () => {
+      const result = normalizeSlugForUser('char-user-456', 'user-456', '!!!');
+      expect(result).toBe('char-user-456');
+    });
+  });
+
   describe('edge cases', () => {
     it('should fall back to user ID if username sanitizes to empty', () => {
       const result = normalizeSlugForUser('char', 'user-456', '!!!');

--- a/packages/common-types/src/utils/slugUtils.ts
+++ b/packages/common-types/src/utils/slugUtils.ts
@@ -56,10 +56,15 @@ export function normalizeSlugForUser(
 
   // Regular users get username appended
   const sanitizedUsername = sanitizeUsernameForSlug(discordUsername);
-  if (sanitizedUsername.length === 0) {
-    // Fallback to user ID if username sanitizes to empty string
-    return `${slug}-${discordUserId}`;
+  const suffix = sanitizedUsername.length === 0 ? `-${discordUserId}` : `-${sanitizedUsername}`;
+
+  // Idempotent: if the slug is already suffixed for this user, leave it alone.
+  // Without this, calling normalizeSlugForUser on a previously-normalized slug
+  // would double-suffix (`lilith-bob` → `lilith-bob-bob`). Matters in update
+  // paths where the input may already carry the suffix from a prior call.
+  if (slug.endsWith(suffix)) {
+    return slug;
   }
 
-  return `${slug}-${sanitizedUsername}`;
+  return `${slug}${suffix}`;
 }

--- a/services/api-gateway/src/routes/user/llm-config.test.ts
+++ b/services/api-gateway/src/routes/user/llm-config.test.ts
@@ -589,6 +589,63 @@ describe('/user/llm-config routes', () => {
       expect(res.status).toHaveBeenCalledWith(404);
     });
 
+    // Bot-owner short-circuit is exercised at the helper level in
+    // `normalizeConfigNameOnPromote.test.ts` (which mocks isBotOwner directly).
+    // Mocking `isBotOwner` at the route level would require deep internals
+    // (the package's `slugUtils.ts` calls a relative-path `isBotOwner`, not
+    // the public export), so the route test focuses on the non-owner path
+    // and trusts the helper unit tests for the bot-owner path.
+    it('suffixes the name with username when non-owner promotes to global', async () => {
+      mockPrisma.llmConfig.findUnique.mockResolvedValue({
+        id: 'config-123',
+        ownerId: 'user-uuid-123',
+        isGlobal: false,
+        name: 'AdminVoice',
+      });
+      // Existing-name check: the post-normalization name doesn't collide
+      mockPrisma.llmConfig.findFirst.mockResolvedValue(null);
+      mockPrisma.llmConfig.update.mockResolvedValue({
+        id: 'config-123',
+        name: 'AdminVoice-bob',
+        description: null,
+        model: 'test-model',
+        provider: 'openrouter',
+        visionModel: null,
+        isGlobal: true,
+        isDefault: false,
+        ownerId: 'user-uuid-123',
+        advancedParameters: {},
+      });
+
+      const router = createLlmConfigRoutes(
+        mockPrisma as unknown as PrismaClient,
+        mockCacheInvalidation
+      );
+      const handler = getHandler(router, 'put', '/:id');
+      const req = {
+        body: { isGlobal: true },
+        params: { id: 'config-123' },
+        userId: 'discord-user-123',
+        provisionedUserId: 'user-uuid-123',
+        provisionedDefaultPersonaId: 'persona-uuid-default',
+        headers: { 'x-user-username': 'bob' },
+      } as unknown as Request & { userId: string };
+      const res = {
+        status: vi.fn().mockReturnThis(),
+        json: vi.fn().mockReturnThis(),
+      } as unknown as Response;
+
+      await handler(req, res);
+
+      // The update call should have name: 'AdminVoice-bob' even though body had no name
+      expect(mockPrisma.llmConfig.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'config-123' },
+          data: expect.objectContaining({ name: 'AdminVoice-bob', isGlobal: true }),
+        })
+      );
+    });
+
     it('should allow owner to edit own global config', async () => {
       mockPrisma.llmConfig.findUnique.mockResolvedValue({
         id: 'config-123',

--- a/services/api-gateway/src/routes/user/llm-config.ts
+++ b/services/api-gateway/src/routes/user/llm-config.ts
@@ -42,6 +42,10 @@ import {
 import type { OpenRouterModelCache } from '../../services/OpenRouterModelCache.js';
 import { enrichWithModelContext } from '../../utils/modelValidation.js';
 import { validateLlmConfigModelFields } from '../../utils/llmConfigValidation.js';
+import {
+  computeNameForPromotion,
+  getDiscordUsernameFromRequest,
+} from '../../utils/normalizeConfigNameOnPromote.js';
 import { createResolveHandler } from './llmConfigResolve.js';
 
 const logger = createLogger('user-llm-config');
@@ -248,27 +252,55 @@ function createUpdateHandler(service: LlmConfigService, modelCache?: OpenRouterM
       return sendError(res, ErrorResponses.unauthorized('You can only edit your own configs'));
     }
 
-    // Check for duplicate name if name is being changed
-    if (body.name !== undefined) {
-      const nameCheck = await service.checkNameExists(
-        body.name,
-        { type: 'USER', userId, discordId: discordUserId },
-        configId
-      );
-      if (nameCheck.exists) {
-        return sendError(
-          res,
-          ErrorResponses.nameCollision(`You already have a config named "${body.name}"`)
-        );
-      }
-    }
-
+    // Empty-body guard runs BEFORE the promotion helper so that a PUT with
+    // `{}` returns 400 (preserves the original API contract) rather than
+    // silently triggering a retroactive rename on already-global configs
+    // whose name predates this PR.
     if (Object.keys(body).length === 0) {
       return sendError(res, ErrorResponses.validationError('No fields to update'));
     }
 
-    // Update using service (handles cache invalidation)
-    const updated = await service.update(configId, body);
+    // If the user is promoting their own config to global (or already had it
+    // global and is renaming), suffix the name with their username so other
+    // users can identify provenance — prevents non-bot-owners from creating
+    // names that look admin-curated. Bot owner gets unsuffixed names per
+    // `normalizeSlugForUser`'s built-in semantic.
+    const effectiveName = computeNameForPromotion({
+      currentName: config.name,
+      currentIsGlobal: config.isGlobal,
+      requestedName: body.name,
+      requestedIsGlobal: body.isGlobal,
+      discordId: discordUserId,
+      discordUsername: getDiscordUsernameFromRequest(req),
+    });
+    const patch = { ...body, ...(effectiveName !== undefined ? { name: effectiveName } : {}) };
+
+    // Check for duplicate name if a name is being applied (either user-supplied
+    // or normalized by the promotion helper). Use the post-normalization value
+    // so collision checks reflect what will actually land in the DB.
+    if (patch.name !== undefined && patch.name.length > 0) {
+      const nameCheck = await service.checkNameExists(
+        patch.name,
+        { type: 'USER', userId, discordId: discordUserId },
+        configId
+      );
+      if (nameCheck.exists) {
+        // When the post-normalization name differs from what the user
+        // actually typed (either the user sent only `{ isGlobal: true }`
+        // and the suffix was synthesized, OR they typed a base name that
+        // got suffixed), the message should explain the auto-rename rather
+        // than imply they chose the exact colliding name.
+        const wasNormalized = patch.name !== body.name;
+        const msg = wasNormalized
+          ? `Promotion would rename your config to "${patch.name}", but that name is already taken`
+          : `You already have a config named "${patch.name}"`;
+        return sendError(res, ErrorResponses.nameCollision(msg));
+      }
+    }
+
+    // Update using service (handles cache invalidation). Empty-body guard
+    // ran earlier; patch is guaranteed non-empty here.
+    const updated = await service.update(configId, patch);
 
     // User always owns their own updated config (we already checked ownership above)
     const permissions = computeLlmConfigPermissions(

--- a/services/api-gateway/src/routes/user/tts-config.test.ts
+++ b/services/api-gateway/src/routes/user/tts-config.test.ts
@@ -327,6 +327,57 @@ describe('user/tts-config routes', () => {
       expect(json).toHaveBeenCalledWith(expect.objectContaining({ error: 'UNAUTHORIZED' }));
     });
 
+    // Bot-owner short-circuit is exercised at the helper level in
+    // `normalizeConfigNameOnPromote.test.ts`. Mocking `isBotOwner` at the
+    // route level doesn't work because `slugUtils.ts` calls a relative-path
+    // `isBotOwner`, not the public package export — so the route test
+    // focuses on the non-owner path and trusts the helper unit tests for
+    // the bot-owner path.
+    it('suffixes the name with username when non-owner promotes to global', async () => {
+      vi.mocked(mockService.getById).mockResolvedValue({
+        ...sampleRawConfig,
+        name: 'AdminVoice',
+        isGlobal: false,
+      });
+      vi.mocked(mockService.checkNameExists).mockResolvedValue({ exists: false });
+      vi.mocked(mockService.update).mockResolvedValue({
+        ...sampleRawConfig,
+        name: 'AdminVoice-bob',
+        isGlobal: true,
+      });
+      vi.mocked(mockService.formatConfigDetail).mockReturnValue({
+        id: 'cfg-uuid-1',
+        name: 'AdminVoice-bob',
+        description: null,
+        provider: 'elevenlabs',
+        modelId: null,
+        isGlobal: true,
+        isDefault: false,
+        isFreeDefault: false,
+        ownerId: 'user-uuid-1',
+        advancedParameters: null,
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        updatedAt: new Date('2026-01-01T00:00:00Z'),
+      });
+      const handler = extractHandler(buildRouter(), 'PUT', '/:id');
+      const { res } = makeMockRes();
+
+      await handler(
+        makeMockReq({
+          params: { id: 'cfg-uuid-1' },
+          body: { isGlobal: true },
+          headers: { 'x-user-username': 'bob' },
+        }),
+        res
+      );
+
+      // The update call should have name: 'AdminVoice-bob' even though body had no name
+      expect(mockService.update).toHaveBeenCalledWith(
+        'cfg-uuid-1',
+        expect.objectContaining({ name: 'AdminVoice-bob', isGlobal: true })
+      );
+    });
+
     it('returns 400 VALIDATION_ERROR when service rejects invalid provider', async () => {
       vi.mocked(mockService.getById).mockResolvedValue(sampleRawConfig);
       vi.mocked(mockService.update).mockRejectedValue(new TtsInvalidProviderError('mistal'));

--- a/services/api-gateway/src/routes/user/tts-config.ts
+++ b/services/api-gateway/src/routes/user/tts-config.ts
@@ -42,6 +42,10 @@ import { ErrorResponses } from '../../utils/errorResponses.js';
 import { sendZodError } from '../../utils/zodHelpers.js';
 import { isPrismaUniqueConstraintError } from '../../utils/prismaErrors.js';
 import { getRequiredParam } from '../../utils/requestParams.js';
+import {
+  computeNameForPromotion,
+  getDiscordUsernameFromRequest,
+} from '../../utils/normalizeConfigNameOnPromote.js';
 import type { ProvisionedRequest } from '../../types.js';
 import {
   TtsConfigService,
@@ -216,27 +220,53 @@ function createUpdateHandler(service: TtsConfigService) {
       return sendError(res, ErrorResponses.unauthorized('You can only edit your own TTS configs'));
     }
 
-    if (body.name !== undefined && body.name.length > 0) {
-      const nameCheck = await service.checkNameExists(
-        body.name,
-        { type: 'USER', userId, discordId: discordUserId },
-        configId
-      );
-      if (nameCheck.exists) {
-        return sendError(
-          res,
-          ErrorResponses.nameCollision(`You already have a TTS config named "${body.name}"`)
-        );
-      }
-    }
-
+    // Empty-body guard runs BEFORE the promotion helper so that a PUT with
+    // `{}` returns 400 (preserves the original API contract) rather than
+    // silently triggering a retroactive rename on already-global configs
+    // whose name predates this PR.
     if (Object.keys(body).length === 0) {
       return sendError(res, ErrorResponses.validationError('No fields to update'));
     }
 
+    // If the user is promoting their own config to global (or already had it
+    // global and is renaming), suffix the name with their username so other
+    // users can identify provenance — prevents non-bot-owners from creating
+    // names that look admin-curated. Bot owner gets unsuffixed names per
+    // `normalizeSlugForUser`'s built-in semantic. Mirrors the LLM route.
+    const effectiveName = computeNameForPromotion({
+      currentName: config.name,
+      currentIsGlobal: config.isGlobal,
+      requestedName: body.name,
+      requestedIsGlobal: body.isGlobal,
+      discordId: discordUserId,
+      discordUsername: getDiscordUsernameFromRequest(req),
+    });
+    const patch = { ...body, ...(effectiveName !== undefined ? { name: effectiveName } : {}) };
+
+    if (patch.name !== undefined && patch.name.length > 0) {
+      const nameCheck = await service.checkNameExists(
+        patch.name,
+        { type: 'USER', userId, discordId: discordUserId },
+        configId
+      );
+      if (nameCheck.exists) {
+        // When the post-normalization name differs from what the user
+        // actually typed (either the user sent only `{ isGlobal: true }`
+        // and the suffix was synthesized, OR they typed a base name that
+        // got suffixed), the message should explain the auto-rename rather
+        // than imply they chose the exact colliding name.
+        const wasNormalized = patch.name !== body.name;
+        const msg = wasNormalized
+          ? `Promotion would rename your TTS config to "${patch.name}", but that name is already taken`
+          : `You already have a TTS config named "${patch.name}"`;
+        return sendError(res, ErrorResponses.nameCollision(msg));
+      }
+    }
+
+    // Empty-body guard ran earlier; patch is guaranteed non-empty here.
     let updated;
     try {
-      updated = await service.update(configId, body);
+      updated = await service.update(configId, patch);
     } catch (err) {
       if (err instanceof TtsInvalidProviderError) {
         return sendError(

--- a/services/api-gateway/src/utils/normalizeConfigNameOnPromote.test.ts
+++ b/services/api-gateway/src/utils/normalizeConfigNameOnPromote.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Request } from 'express';
+import {
+  computeNameForPromotion,
+  getDiscordUsernameFromRequest,
+} from './normalizeConfigNameOnPromote.js';
+
+// Mock isBotOwner so we can flip between bot-owner and regular-user identities
+// independent of process env. The actual `normalizeSlugForUser` is fully tested
+// in common-types; here we focus on the route-level decision logic that wraps it.
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    normalizeSlugForUser: (slug: string, _id: string, username: string): string => {
+      // Recreate the production-equivalent contract for these tests:
+      // - bot-owner ('owner-id') gets unchanged slug
+      // - others get `-${username}` suffix, idempotent if already present
+      if (_id === 'owner-id') return slug;
+      const suffix = `-${username}`;
+      return slug.endsWith(suffix) ? slug : `${slug}${suffix}`;
+    },
+  };
+});
+
+const REGULAR_USER = { discordId: 'user-456', discordUsername: 'bob' };
+const BOT_OWNER = { discordId: 'owner-id', discordUsername: 'lbds137' };
+
+describe('computeNameForPromotion', () => {
+  describe('not promoting to global', () => {
+    it('returns requestedName unchanged when post-state is not global', () => {
+      const result = computeNameForPromotion({
+        currentName: 'old',
+        currentIsGlobal: false,
+        requestedName: 'new',
+        requestedIsGlobal: false,
+        ...REGULAR_USER,
+      });
+      expect(result).toBe('new');
+    });
+
+    it('returns undefined when no rename and not promoting', () => {
+      const result = computeNameForPromotion({
+        currentName: 'old',
+        currentIsGlobal: false,
+        ...REGULAR_USER,
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when toggling isGlobal true→false (no name change)', () => {
+      const result = computeNameForPromotion({
+        currentName: 'old-bob',
+        currentIsGlobal: true,
+        requestedIsGlobal: false,
+        ...REGULAR_USER,
+      });
+      // No name in patch; no normalization since post-state is private
+      expect(result).toBeUndefined();
+    });
+
+    it('does NOT retroactively rename already-global config on a non-name update', () => {
+      // The user updates only `description` on a legacy global config whose
+      // name predates this PR (no suffix). Without the narrow trigger, the
+      // helper would silently rename it to `OfficialVoice-bob`. With the
+      // narrow trigger (only on promotion or explicit rename), the helper
+      // returns undefined — no name field added to the patch.
+      const result = computeNameForPromotion({
+        currentName: 'OfficialVoice',
+        currentIsGlobal: true,
+        // requestedIsGlobal undefined (user didn't touch it)
+        // requestedName undefined (user only edited description, not name)
+        ...REGULAR_USER,
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it('does NOT rename already-global config when isGlobal:true is resent without name', () => {
+      // Bot-client dashboard PUT may resend isGlobal: true with the current
+      // value (no actual change). This is not a "promotion" — currentIsGlobal
+      // was already true. Helper should treat as no-op.
+      const result = computeNameForPromotion({
+        currentName: 'OfficialVoice',
+        currentIsGlobal: true,
+        requestedIsGlobal: true,
+        ...REGULAR_USER,
+      });
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('promoting non-bot-owner to global', () => {
+    it('suffixes the requestedName when toggling false→true', () => {
+      const result = computeNameForPromotion({
+        currentName: 'MyVoice',
+        currentIsGlobal: false,
+        requestedIsGlobal: true,
+        ...REGULAR_USER,
+      });
+      expect(result).toBe('MyVoice-bob');
+    });
+
+    it('suffixes a fresh rename when post-state is global', () => {
+      const result = computeNameForPromotion({
+        currentName: 'OldName',
+        currentIsGlobal: true,
+        requestedName: 'AdminVoice',
+        ...REGULAR_USER,
+      });
+      expect(result).toBe('AdminVoice-bob');
+    });
+
+    it('idempotent: does not double-suffix when already normalized', () => {
+      const result = computeNameForPromotion({
+        currentName: 'OldName-bob',
+        currentIsGlobal: true,
+        requestedName: 'NewName-bob',
+        ...REGULAR_USER,
+      });
+      // requestedName is already suffixed; normalizeSlugForUser returns it unchanged.
+      // The helper then sees normalized === baseName and returns the original
+      // requestedName to preserve route intent.
+      expect(result).toBe('NewName-bob');
+    });
+
+    it('uses currentName as base when toggling without rename', () => {
+      const result = computeNameForPromotion({
+        currentName: 'PrivateVoice',
+        currentIsGlobal: false,
+        requestedIsGlobal: true,
+        // No requestedName
+        ...REGULAR_USER,
+      });
+      expect(result).toBe('PrivateVoice-bob');
+    });
+  });
+
+  describe('empty discordUsername fallback', () => {
+    it('falls through to user-id-based suffix per normalizeSlugForUser semantics', () => {
+      // When the username header is missing/malformed, getDiscordUsernameFromRequest
+      // returns ''. The mocked normalizeSlugForUser appends `-${username}` even for
+      // empty username (mock simplification); the production normalizeSlugForUser
+      // detects this and falls back to `-${discordUserId}`. This test documents
+      // that the route helper passes the empty string through to the slug
+      // function rather than short-circuiting.
+      const result = computeNameForPromotion({
+        currentName: 'OldName',
+        currentIsGlobal: false,
+        requestedIsGlobal: true,
+        discordId: 'user-456',
+        discordUsername: '',
+      });
+      // Mock returns 'OldName-' (mock simplification); real production behavior
+      // would yield 'OldName-user-456'. The test asserts the fall-through path
+      // is taken — a return value distinct from the input.
+      expect(result).not.toBe('OldName');
+      expect(result).toContain('OldName');
+    });
+  });
+
+  describe('bot owner', () => {
+    it('returns requestedName unchanged when promoting to global', () => {
+      const result = computeNameForPromotion({
+        currentName: 'old',
+        currentIsGlobal: false,
+        requestedName: 'kyutai-self-hosted',
+        requestedIsGlobal: true,
+        ...BOT_OWNER,
+      });
+      expect(result).toBe('kyutai-self-hosted');
+    });
+
+    it('returns undefined when no rename and post-state is global', () => {
+      const result = computeNameForPromotion({
+        currentName: 'kyutai-self-hosted',
+        currentIsGlobal: true,
+        ...BOT_OWNER,
+      });
+      // Bot owner with no rename → normalize returns base unchanged → helper
+      // returns requestedName (undefined) to preserve "no field to update"
+      expect(result).toBeUndefined();
+    });
+  });
+});
+
+describe('getDiscordUsernameFromRequest', () => {
+  it('decodes a URI-encoded username header', () => {
+    const req = { headers: { 'x-user-username': 'cool%20user' } } as unknown as Request;
+    expect(getDiscordUsernameFromRequest(req)).toBe('cool user');
+  });
+
+  it('returns plain string when no encoding needed', () => {
+    const req = { headers: { 'x-user-username': 'bob' } } as unknown as Request;
+    expect(getDiscordUsernameFromRequest(req)).toBe('bob');
+  });
+
+  it('returns empty string on missing header', () => {
+    const req = { headers: {} } as unknown as Request;
+    expect(getDiscordUsernameFromRequest(req)).toBe('');
+  });
+
+  it('returns empty string on malformed URI', () => {
+    // %ZZ is not valid percent-encoding; decodeURIComponent throws
+    const req = { headers: { 'x-user-username': '%ZZ' } } as unknown as Request;
+    expect(getDiscordUsernameFromRequest(req)).toBe('');
+  });
+
+  it('returns empty string on non-string header value (array)', () => {
+    // Express can deliver array values for repeated headers
+    const req = { headers: { 'x-user-username': ['a', 'b'] } } as unknown as Request;
+    expect(getDiscordUsernameFromRequest(req)).toBe('');
+  });
+});

--- a/services/api-gateway/src/utils/normalizeConfigNameOnPromote.ts
+++ b/services/api-gateway/src/utils/normalizeConfigNameOnPromote.ts
@@ -1,0 +1,111 @@
+/**
+ * Helper for `/user/{llm,tts}-config` PUT routes that compute the name
+ * a user-owned config should have after a mutation, accounting for the
+ * "user-promoted globals get username-suffixed" UX pattern.
+ *
+ * **Why this exists**: a non-bot-owner user can promote their own config
+ * to global via the preset/tts dashboard's `isGlobal` toggle. Without
+ * normalization, they could create a config named "OfficialAdminVoice"
+ * and toggle it global, confusing other users about provenance. Suffixing
+ * the name with the user's username (`OfficialAdminVoice-bob`) makes
+ * provenance visible everywhere the name renders.
+ *
+ * **Why route-level not service-level**: keeps `LlmConfigService.update()`
+ * and `TtsConfigService.update()` agnostic of user identity. The route
+ * already fetches the current config for ownership checks, so it has
+ * `currentName` + `currentIsGlobal` available locally. The route also
+ * has direct access to the Discord username via the `x-user-username`
+ * header (already validated by `requireProvisionedUser` middleware).
+ *
+ * Bot-owner gets the original name unchanged (per `normalizeSlugForUser`'s
+ * existing semantic). Same helper covers both LLM and TTS — names are
+ * citext-unique strings on both sides, and the algorithm is identical.
+ */
+
+import type { Request } from 'express';
+import { normalizeSlugForUser } from '@tzurot/common-types';
+
+interface PromotionContext {
+  /** Current state of the config (from `service.getById`). */
+  currentName: string;
+  currentIsGlobal: boolean;
+  /** Patch fields from the user's request (after Zod parse). */
+  requestedName?: string;
+  requestedIsGlobal?: boolean;
+  /** Discord identity of the calling user (required for normalization). */
+  discordId: string;
+  discordUsername: string;
+}
+
+/**
+ * Compute the effective name to write on a config update.
+ *
+ * Returns:
+ * - The requested name unchanged if no promotion is happening
+ * - The normalized name (suffixed with username) if the post-update
+ *   state is `isGlobal: true` AND the user isn't the bot owner
+ * - The bot owner's exact requested name if `isBotOwner` returns true
+ *   (handled inside `normalizeSlugForUser`)
+ *
+ * `undefined` return means "don't touch the name" — matches the convention
+ * the route handlers use: only set `data.name` if explicitly changing it.
+ */
+export function computeNameForPromotion(opts: PromotionContext): string | undefined {
+  // Two trigger conditions for normalization:
+  //   1. The user is actively promoting their config to global
+  //      (currentIsGlobal=false → requestedIsGlobal=true)
+  //   2. The user is explicitly renaming a config that is currently OR
+  //      will-be global (requestedName is set AND post-state is global)
+  //
+  // Without this narrow trigger, ANY field update to a pre-existing global
+  // config without a suffix would silently rename it (e.g. a description-
+  // only edit on a legacy global preset would become a rename). That
+  // surprised the user even though no name change was requested.
+  const postIsGlobal = opts.requestedIsGlobal ?? opts.currentIsGlobal;
+  const isPromotingToGlobal = !opts.currentIsGlobal && opts.requestedIsGlobal === true;
+  const isExplicitRenameWhileGlobal = postIsGlobal && opts.requestedName !== undefined;
+
+  if (!isPromotingToGlobal && !isExplicitRenameWhileGlobal) {
+    // Pass through whatever the route already had: an explicit rename for
+    // a non-global config, or `undefined` for a no-name update.
+    return opts.requestedName;
+  }
+
+  const baseName = opts.requestedName ?? opts.currentName;
+  const normalized = normalizeSlugForUser(baseName, opts.discordId, opts.discordUsername);
+
+  // If normalization didn't actually change the name (bot owner, or already
+  // suffixed), preserve the route's original intent: only emit `name` in the
+  // patch when the user requested a rename.
+  if (normalized === baseName) {
+    return opts.requestedName;
+  }
+
+  return normalized;
+}
+
+/**
+ * Read the URI-encoded `x-user-username` header that bot-client sends and
+ * `requireProvisionedUser` already validates. Headers are lowercased by
+ * Express; the encoding round-trip preserves Discord's allowed username
+ * character set (which can include `_`, `.`, etc. that don't survive raw
+ * HTTP). Returns the raw username — sanitization for the slug suffix
+ * happens inside `normalizeSlugForUser`.
+ *
+ * Fallback to empty string if missing — `requireProvisionedUser` would
+ * have rejected the request before reaching this code, so an absent
+ * header is "shouldn't happen" defense rather than a real branch.
+ */
+export function getDiscordUsernameFromRequest(req: Request): string {
+  // `req.headers` may be undefined in unit-test mock requests that construct
+  // a minimal Request object — production Express always populates it.
+  const raw = req.headers?.['x-user-username'];
+  if (typeof raw !== 'string' || raw.length === 0) {
+    return '';
+  }
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return '';
+  }
+}


### PR DESCRIPTION
## Summary

Closes the namespace-pollution UX gap surfaced in PR #961 (originally framed as a "🔴 security issue" by claude-review, redirected to a UX/provenance design question by user). When a non-bot-owner promotes their own LLM/TTS config to global, the name now gets the user's Discord username appended as a suffix — same pattern personalities use via `normalizeSlugForUser`.

## Behavior

| Scenario | Old name | New name |
|---|---|---|
| Bot-owner creates "kyutai-self-hosted" + global | `kyutai-self-hosted` | `kyutai-self-hosted` (unchanged) |
| User Bob creates "OfficialAdminVoice" + toggles global | `OfficialAdminVoice` | `OfficialAdminVoice-bob` |
| User Bob renames already-global config | `OldName` | `NewName-bob` |
| User Bob's already-suffixed config gets re-saved | `MyVoice-bob` | `MyVoice-bob` (idempotent — no double-suffix) |

The phishing/spam vector ("user names config 'OfficialAdminVoice' to confuse other users") is closed because the `-bob` suffix is visible everywhere the name renders.

## Why route-level, not service-level

Keeps `LlmConfigService.update()` and `TtsConfigService.update()` agnostic of user identity. The user route already fetches the current config for ownership checks (so it has `currentName` + `currentIsGlobal` locally), and the route has direct access to the validated `x-user-username` header from `requireProvisionedUser` middleware.

## Side fix: `normalizeSlugForUser` is now idempotent

Previously, `normalizeSlugForUser('lilith-bob', 'user-456', 'bob')` returned `'lilith-bob-bob'` — applying the suffix twice. Matters in update paths where the input may already carry the suffix from a prior call. Fixed by checking if the slug already ends with the suffix; if so, return unchanged. Behavior unchanged for fresh slugs and bot-owner.

## Changes by commit

1. **`fix(common-types)`** — `normalizeSlugForUser` idempotency + `sanitizeUsernameForSlug` export. New tests cover idempotency cases.
2. **`feat(api-gateway)`** — new shared helper `computeNameForPromotion` + `getDiscordUsernameFromRequest`. 11 unit tests covering bot-owner short-circuit, idempotency, all 4 cells of (currentIsGlobal × requestedIsGlobal).
3. **`feat(api-gateway)`** — wires the helper into both `/user/llm-config` PUT and `/user/tts-config` PUT route handlers. Collision check now runs against post-normalization name.

## Closes

Inbox entry filed in PR #961: "Apply `normalizeSlugForUser` pattern to user-promoted global LLM/TTS configs (cross-cutting)" — reframed by user from claude-review's "security issue" to a namespace UX/provenance design question.

## Test plan

- [x] `pnpm test` — 14/14 packages green (1860 + 4678 + 2317 + others)
- [x] `pnpm quality` — 11/11 tasks green
- [x] Idempotency: `normalizeSlugForUser('lilith-bob', '456', 'bob')` returns `'lilith-bob'` (no double-suffix)
- [x] Route end-to-end: PUT with `{ isGlobal: true }` (no name change) suffixes the existing currentName
- [x] Bot-owner: `BOT_OWNER_ID` env match → unsuffixed names preserved
- [ ] CI green before merge
- [ ] Manual: dev — log in as a non-owner Discord user, run `/settings preset edit <preset>` on an existing private preset, toggle `Make Global` button, observe the renamed preset shows `-username` suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)