### PR TITLE
feat(api-gateway): wire tts_configs into db-sync + global-name unique index

### DIFF
--- a/prisma/drift-ignore.json
+++ b/prisma/drift-ignore.json
@@ -53,6 +53,11 @@
       "action": "remove"
     },
     {
+      "pattern": "DROP INDEX.*tts_configs_global_name_unique",
+      "reason": "Partial unique index with WHERE clause cannot be represented in Prisma schema (mirrors llm_configs_global_name_unique)",
+      "action": "remove"
+    },
+    {
       "pattern": "DROP INDEX.*idx_memories_is_locked",
       "reason": "Partial index with WHERE clause cannot be represented in Prisma schema",
       "action": "remove"
@@ -85,6 +90,11 @@
     {
       "pattern": "ALTER TABLE.*llm_configs.*ALTER CONSTRAINT.*llm_configs_owner_id_fkey.*NOT DEFERRABLE",
       "reason": "FK made DEFERRABLE INITIALLY IMMEDIATE in migration 20260418010642 for the users↔llm_configs circular pair. Prisma schema can't express DEFERRABLE.",
+      "action": "remove"
+    },
+    {
+      "pattern": "ALTER TABLE.*users.*ALTER CONSTRAINT.*users_default_tts_config_id_fkey.*NOT DEFERRABLE",
+      "reason": "FK made DEFERRABLE INITIALLY IMMEDIATE in migration 20260504065151 so db-sync can copy a user row with non-NULL default_tts_config_id before the matching tts_configs row arrives in the target DB (mirrors the LLM/persona pattern from migration 20260418010642). Prisma schema can't express DEFERRABLE.",
       "action": "remove"
     }
   ],

--- a/prisma/migrations/20260504062203_tts_config_global_name_unique/migration.sql
+++ b/prisma/migrations/20260504062203_tts_config_global_name_unique/migration.sql
@@ -1,0 +1,20 @@
+-- Enforce global-scope TtsConfig name uniqueness across admins.
+--
+-- Mirrors llm_configs_global_name_unique (migration 20260421164630) for the
+-- parallel race condition: TtsConfig has `@@unique([ownerId, name])` which
+-- prevents a single user from having two configs with the same name. The
+-- admin global-create path (`isGlobal = true`) relies on app-level
+-- `checkNameExists` alone: two admins creating `isGlobal=true, name="Default"`
+-- with different ownerIds both satisfy the composite-unique constraint and a
+-- race could slip past the app check.
+--
+-- This partial unique index enforces "at most one global config per name" at
+-- the DB layer. Only applies to rows where `is_global = true`; non-global
+-- configs continue to use the composite-unique constraint.
+--
+-- Prisma can't represent partial unique indexes in schema.prisma, so this
+-- migration is hand-written and the index is protected in
+-- prisma/drift-ignore.json.
+CREATE UNIQUE INDEX "tts_configs_global_name_unique"
+  ON "tts_configs"("name")
+  WHERE "is_global" = true;

--- a/prisma/migrations/20260504065151_make_tts_default_fk_deferrable/migration.sql
+++ b/prisma/migrations/20260504065151_make_tts_default_fk_deferrable/migration.sql
@@ -1,0 +1,26 @@
+-- Make users.default_tts_config_id_fkey DEFERRABLE so db-sync can copy
+-- a user row with a non-NULL default_tts_config_id before the matching
+-- tts_configs row arrives in the target DB.
+--
+-- Mirrors migration 20260418010642 which made the analogous LLM /
+-- persona FKs DEFERRABLE for the same reason.
+--
+-- The Ouroboros-Insert pattern relies on `SET CONSTRAINTS … DEFERRED`
+-- inside the sync transaction so that all cross-table writes can land
+-- in any order — Postgres validates the named FKs at COMMIT once every
+-- referenced row exists. A NOT DEFERRABLE FK ignores that defer
+-- request and fires immediately on the INSERT/UPDATE, breaking sync as
+-- soon as the first user has a non-NULL default_tts_config_id.
+--
+-- INITIALLY IMMEDIATE preserves runtime behavior (FK still fires
+-- immediately for normal inserts/updates outside the sync transaction)
+-- so application code is unaffected. Only inside a transaction that
+-- explicitly issues `SET CONSTRAINTS users_default_tts_config_id_fkey
+-- DEFERRED` does the FK move to commit-time validation.
+--
+-- Prisma cannot express DEFERRABLE in schema.prisma, so this migration
+-- is hand-written and the constraint is protected in
+-- prisma/drift-ignore.json against future Prisma diffs that would try
+-- to strip the DEFERRABLE clause.
+ALTER TABLE "users"
+  ALTER CONSTRAINT "users_default_tts_config_id_fkey" DEFERRABLE INITIALLY IMMEDIATE;

--- a/services/api-gateway/src/services/DatabaseSyncService.int.test.ts
+++ b/services/api-gateway/src/services/DatabaseSyncService.int.test.ts
@@ -78,6 +78,22 @@ function loadDeferrableFkMigration(): string {
 }
 
 /**
+ * Load the migration that made users.default_tts_config_id_fkey DEFERRABLE.
+ * Same rationale as loadDeferrableFkMigration: PGLite schema generator can't
+ * express DEFERRABLE, so this migration is applied manually in `beforeAll`.
+ * Was added in a follow-up PR after the TTS feature shipped (the original
+ * DEFERRABLE migration predates tts_configs).
+ */
+function loadTtsDefaultFkDeferrableMigration(): string {
+  const migrationPath = join(
+    migrationsDir(),
+    '20260504065151_make_tts_default_fk_deferrable',
+    'migration.sql'
+  );
+  return readFileSync(migrationPath, 'utf-8');
+}
+
+/**
  * Return the lexicographically-latest migration directory name (which is
  * also chronologically latest because migrations are prefixed with
  * `YYYYMMDDhhmmss`). Used to seed `_prisma_migrations` so
@@ -154,16 +170,23 @@ describe('DatabaseSyncService Integration (Ouroboros pattern)', () => {
   beforeAll(async () => {
     const schema = loadPGliteSchema();
     const deferrableFkMigration = loadDeferrableFkMigration();
+    const ttsDefaultFkDeferrableMigration = loadTtsDefaultFkDeferrableMigration();
 
     devPglite = createTestPGlite();
     prodPglite = createTestPGlite();
     await devPglite.exec(schema);
     await prodPglite.exec(schema);
-    // Apply the DEFERRABLE migration manually since the PGLite schema
-    // generator can't express it. Matches what production's migrated
-    // schema actually has in place post-20260418010642.
+    // Apply the DEFERRABLE migrations manually since the PGLite schema
+    // generator can't express DEFERRABLE. Matches what production's
+    // migrated schema actually has in place post-20260418010642 and
+    // post-20260504065151 (added when the TTS feature shipped — the
+    // users_default_tts_config_id_fkey FK has the same DEFERRABLE
+    // requirement as the original four for the same Ouroboros sync
+    // reason).
     await devPglite.exec(deferrableFkMigration);
     await prodPglite.exec(deferrableFkMigration);
+    await devPglite.exec(ttsDefaultFkDeferrableMigration);
+    await prodPglite.exec(ttsDefaultFkDeferrableMigration);
     // Create _prisma_migrations so checkSchemaVersions has a row to find.
     await devPglite.exec(SETUP_PRISMA_MIGRATIONS_TABLE);
     await prodPglite.exec(SETUP_PRISMA_MIGRATIONS_TABLE);

--- a/services/api-gateway/src/services/DatabaseSyncService.test.ts
+++ b/services/api-gateway/src/services/DatabaseSyncService.test.ts
@@ -28,6 +28,11 @@ const createMockPrismaClient = () => {
       findUnique: ReturnType<typeof vi.fn>;
       update: ReturnType<typeof vi.fn>;
     };
+    ttsConfig: {
+      findMany: ReturnType<typeof vi.fn>;
+      findUnique: ReturnType<typeof vi.fn>;
+      update: ReturnType<typeof vi.fn>;
+    };
   } = {
     $connect: vi.fn().mockResolvedValue(undefined),
     $disconnect: vi.fn().mockResolvedValue(undefined),
@@ -43,6 +48,11 @@ const createMockPrismaClient = () => {
       deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
     },
     llmConfig: {
+      findMany: vi.fn().mockResolvedValue([]),
+      findUnique: vi.fn().mockResolvedValue(null),
+      update: vi.fn().mockResolvedValue({}),
+    },
+    ttsConfig: {
       findMany: vi.fn().mockResolvedValue([]),
       findUnique: vi.fn().mockResolvedValue(null),
       update: vi.fn().mockResolvedValue({}),

--- a/services/api-gateway/src/services/DatabaseSyncService.ts
+++ b/services/api-gateway/src/services/DatabaseSyncService.ts
@@ -13,13 +13,16 @@
  *
  * The solution (validated via council + PGLite probe + int test):
  *
- *   1. Migration 20260418010642 made the four circular FKs DEFERRABLE
- *      INITIALLY IMMEDIATE so runtime enforcement is unchanged but sync
- *      can defer checks to COMMIT time.
+ *   1. Migration 20260418010642 made the original four circular FKs
+ *      (users↔personas, users↔llm_configs) DEFERRABLE INITIALLY IMMEDIATE.
+ *      Migration 20260504065151 added users.default_tts_config_id_fkey to
+ *      that set when the TTS feature shipped. Runtime enforcement is
+ *      unchanged for all five — sync can defer checks to COMMIT time only
+ *      inside the explicit SET CONSTRAINTS block below.
  *   2. This service collects all pending writes per direction (dev-bound,
  *      prod-bound) without executing them during the table scan loop.
  *   3. Writes are flushed inside per-direction transactions that start
- *      by naming the four circular FKs in a `SET CONSTRAINTS ... DEFERRED`
+ *      by naming the deferred FKs in a `SET CONSTRAINTS ... DEFERRED`
  *      statement (explicit names rather than `ALL DEFERRED` so future
  *      migrations adding unrelated deferrable constraints don't get
  *      silently softened inside the sync). Real FK values go in from the
@@ -49,6 +52,10 @@ import {
   prepareLlmConfigSingletonFlags,
   finalizeLlmConfigSingletonFlags,
 } from './sync/utils/llmConfigSingletons.js';
+import {
+  prepareTtsConfigSingletonFlags,
+  finalizeTtsConfigSingletonFlags,
+} from './sync/utils/ttsConfigSingletons.js';
 import {
   fetchAllRows,
   buildRowMap,
@@ -106,7 +113,7 @@ export class DatabaseSyncService {
    * No writes occur in this phase.
    *
    * Phase 2 (flush): per target direction, open a transaction, issue
-   * `SET CONSTRAINTS <four-named-circular-FKs> DEFERRED`, apply all
+   * `SET CONSTRAINTS <named-circular-FKs> DEFERRED`, apply all
    * pending writes, COMMIT. Postgres validates the named deferred FKs
    * at COMMIT; either every write commits or none do (per transaction).
    * Named constraints rather than `ALL DEFERRED` so future migrations
@@ -160,6 +167,10 @@ export class DatabaseSyncService {
           await prepareLlmConfigSingletonFlags(this.devClient, this.prodClient);
         }
 
+        if (tableName === 'tts_configs' && !options.dryRun) {
+          await prepareTtsConfigSingletonFlags(this.devClient, this.prodClient);
+        }
+
         if (tableName === 'conversation_history') {
           const { devDeleted, prodDeleted } = await deleteMessagesWithTombstones(
             this.devClient,
@@ -199,9 +210,11 @@ export class DatabaseSyncService {
         await this.flushWrites(this.prodClient, prodBoundWrites, 'prod');
 
         // Singleton-flag finalization runs OUTSIDE the sync transactions —
-        // it needs to see the post-commit state of llm_configs to decide
-        // which row wins the is_default / is_free_default flag in each env.
+        // it needs to see the post-commit state of llm_configs / tts_configs
+        // to decide which row wins the is_default / is_free_default flag
+        // in each env.
         await finalizeLlmConfigSingletonFlags(this.devClient, this.prodClient);
+        await finalizeTtsConfigSingletonFlags(this.devClient, this.prodClient);
       }
 
       logger.info({ stats }, 'Sync complete');
@@ -230,15 +243,18 @@ export class DatabaseSyncService {
     logger.info({ label, count: writes.length }, 'Phase 2: Flushing writes');
     await client.$transaction(
       async tx => {
-        // Defer exactly the four circular FKs, not ALL deferrable constraints
-        // in the transaction — future migrations might add unrelated
-        // deferrable constraints (e.g., deferred uniqueness) and we don't
-        // want to silently soften those inside the sync. The four names
-        // here must stay in sync with migration 20260418010642.
+        // Defer exactly the named circular FKs, not ALL deferrable
+        // constraints in the transaction — future migrations might add
+        // unrelated deferrable constraints (e.g., deferred uniqueness) and
+        // we don't want to silently soften those inside the sync. The names
+        // here must stay in sync with the DEFERRABLE-marking migrations
+        // (20260418010642 for the original 4, 20260504065151 for
+        // users_default_tts_config_id_fkey).
         await tx.$executeRawUnsafe(
           `SET CONSTRAINTS
             "users_default_persona_id_fkey",
             "users_default_llm_config_id_fkey",
+            "users_default_tts_config_id_fkey",
             "personas_owner_id_fkey",
             "llm_configs_owner_id_fkey"
           DEFERRED`

--- a/services/api-gateway/src/services/sync/config/syncTables.test.ts
+++ b/services/api-gateway/src/services/sync/config/syncTables.test.ts
@@ -113,6 +113,11 @@ describe('syncTables Configuration', () => {
       assertParentBeforeChild('users', 'llm_configs', 'owner_id');
     });
 
+    // tts_configs.owner_id -> users.id (NOT NULL); mirrors llm_configs FK ordering
+    it('should sync users before tts_configs (tts_configs.owner_id FK)', () => {
+      assertParentBeforeChild('users', 'tts_configs', 'owner_id');
+    });
+
     // NOTE: personality_default_configs moved to EXCLUDED_TABLES (settings, not raw data)
 
     // personality_owners.personality_id -> personalities.id
@@ -145,6 +150,10 @@ describe('syncTables Configuration', () => {
 
     it('should sync llm_configs before user_personality_configs', () => {
       assertParentBeforeChild('llm_configs', 'user_personality_configs', 'llm_config_id');
+    });
+
+    it('should sync tts_configs before user_personality_configs', () => {
+      assertParentBeforeChild('tts_configs', 'user_personality_configs', 'tts_config_id');
     });
 
     // conversation_history.persona_id -> personas.id
@@ -278,6 +287,14 @@ describe('syncTables Configuration', () => {
       expect(llmConfigsConfig.excludeColumns).toBeDefined();
       expect(llmConfigsConfig.excludeColumns).toContain('is_default');
       expect(llmConfigsConfig.excludeColumns).toContain('is_free_default');
+    });
+
+    it('should exclude is_default and is_free_default from tts_configs sync', () => {
+      // Mirrors llm_configs — singleton flags are environment-specific
+      const ttsConfigsConfig = SYNC_CONFIG.tts_configs;
+      expect(ttsConfigsConfig.excludeColumns).toBeDefined();
+      expect(ttsConfigsConfig.excludeColumns).toContain('is_default');
+      expect(ttsConfigsConfig.excludeColumns).toContain('is_free_default');
     });
 
     it('should have excludeColumns as array or undefined for all tables', () => {

--- a/services/api-gateway/src/services/sync/config/syncTables.ts
+++ b/services/api-gateway/src/services/sync/config/syncTables.ts
@@ -22,6 +22,8 @@ export const EXCLUDED_TABLES: Record<string, string> = {
   // Settings tables - user preferences that may differ between dev/prod
   personality_default_configs:
     'Character-level LLM preset defaults - dev/prod may use different models for testing',
+  personality_default_tts_configs:
+    'Character-level TTS preset defaults - dev/prod may use different voices for testing (mirrors personality_default_configs)',
 
   // Transient/ephemeral data
   pending_memories: 'Transient queue data for memory processing',
@@ -64,8 +66,10 @@ export type SyncTableName =
   | 'personas'
   | 'system_prompts'
   | 'llm_configs'
+  | 'tts_configs'
   | 'personalities'
   // NOTE: personality_default_configs moved to EXCLUDED_TABLES - settings, not raw data
+  // NOTE: personality_default_tts_configs same — environment-specific TTS preset defaults
   | 'personality_owners'
   | 'personality_aliases'
   | 'user_personality_configs'
@@ -85,14 +89,22 @@ export const SYNC_CONFIG: Record<SyncTableName, TableSyncConfig> = {
     pk: 'id',
     createdAt: 'created_at',
     updatedAt: 'updated_at',
-    uuidColumns: ['id', 'default_llm_config_id', 'default_persona_id'],
+    uuidColumns: ['id', 'default_llm_config_id', 'default_persona_id', 'default_tts_config_id'],
     timestampColumns: ['created_at', 'updated_at'],
-    // Circular NOT NULL FKs (default_persona_id → personas.id, and
-    // default_llm_config_id → llm_configs.id) are handled via DEFERRABLE
-    // constraints + SET CONSTRAINTS ALL DEFERRED at the sync transaction
-    // boundary. See migration 20260418010642 and DatabaseSyncService.
-    // Both columns sync with real values from the source environment;
-    // last-write-wins on users.updated_at resolves cross-env conflicts.
+    // Three FK columns on users reference rows in tables that come AFTER
+    // users in SYNC_TABLE_ORDER (personas, llm_configs, tts_configs are
+    // all synced after users so their owner_id NOT-NULL FKs back to users
+    // can be satisfied). All three FKs are made DEFERRABLE so the sync
+    // transaction can issue SET CONSTRAINTS … DEFERRED and let Postgres
+    // validate the references at COMMIT time, when every cross-table
+    // referenced row exists:
+    //   - default_persona_id, default_llm_config_id: DEFERRABLE since
+    //     migration 20260418010642 (the original circular-FK fix).
+    //   - default_tts_config_id: DEFERRABLE since migration 20260504065151
+    //     (added when the TTS feature shipped — the column is NULLABLE
+    //     but that only relaxes the NOT NULL constraint, not the FK
+    //     reference check, so it still needed DEFERRABLE for sync).
+    // Last-write-wins on users.updated_at resolves cross-env conflicts.
   },
   personas: {
     pk: 'id',
@@ -115,6 +127,19 @@ export const SYNC_CONFIG: Record<SyncTableName, TableSyncConfig> = {
     uuidColumns: ['id', 'owner_id'],
     timestampColumns: ['created_at', 'updated_at'],
     // Exclude singleton flags from sync - dev and prod should have independent defaults
+    excludeColumns: ['is_default', 'is_free_default'],
+  },
+  tts_configs: {
+    pk: 'id',
+    createdAt: 'created_at',
+    updatedAt: 'updated_at',
+    uuidColumns: ['id', 'owner_id'],
+    timestampColumns: ['created_at', 'updated_at'],
+    // Mirror llm_configs: singleton flags are environment-specific. The
+    // partial unique indexes (tts_configs_free_default_unique,
+    // tts_configs_global_name_unique) require pre-sync conflict
+    // resolution; see ttsConfigSingletons.ts for the parallel of the
+    // llmConfigSingletons handler.
     excludeColumns: ['is_default', 'is_free_default'],
   },
   personalities: {
@@ -146,11 +171,19 @@ export const SYNC_CONFIG: Record<SyncTableName, TableSyncConfig> = {
     pk: ['user_id', 'personality_id'],
     createdAt: 'created_at',
     updatedAt: 'updated_at',
-    uuidColumns: ['id', 'user_id', 'personality_id', 'persona_id', 'llm_config_id'],
+    uuidColumns: [
+      'id',
+      'user_id',
+      'personality_id',
+      'persona_id',
+      'llm_config_id',
+      'tts_config_id',
+    ],
     timestampColumns: ['created_at', 'updated_at'],
-    // persona_id and llm_config_id are synced directly (not deferred) — personas and
-    // llm_configs come before user_personality_configs in SYNC_TABLE_ORDER, so their
-    // rows exist by the time this table is synced; no circular-FK deferral needed.
+    // persona_id, llm_config_id, and tts_config_id are synced directly (not
+    // deferred) — personas, llm_configs, and tts_configs all come before
+    // user_personality_configs in SYNC_TABLE_ORDER, so their rows exist by the
+    // time this table is synced; no circular-FK deferral needed.
     // Previously excluded as "user preferences" but that orphaned per-character
     // persona/llm overrides for mirrored users on dev. Same trade-off as on users:
     // the dev user's own overrides will bleed across envs via last-write-wins.
@@ -209,6 +242,13 @@ export const SYNC_CONFIG: Record<SyncTableName, TableSyncConfig> = {
  *   constraints + SET CONSTRAINTS ALL DEFERRED (see migration 20260418010642)
  *   so users inserts can carry real FK values; Postgres validates at COMMIT.
  * - llm_configs: owner_id → users (NOT NULL, also circular; same deferred handling)
+ * - tts_configs: owner_id → users (NOT NULL); users.default_tts_config_id is
+ *   NULLABLE (unlike default_llm_config_id which is NOT NULL), but the FK
+ *   users_default_tts_config_id_fkey is still DEFERRABLE (migration
+ *   20260504065151) — NULLABLE only relaxes the NOT NULL check, not the FK
+ *   reference check, so a user with a non-NULL default_tts_config_id would
+ *   fail an immediate FK validation during users-sync without DEFERRABLE.
+ *   Same deferred handling as the original four FKs.
  * - personas: owner_id → users (NOT NULL, also circular; same deferred handling)
  * - personalities: system_prompt_id → system_prompts, owner_id → users (NOT NULL)
  * - personality_owners: personality_id → personalities, user_id → users
@@ -233,11 +273,13 @@ export const SYNC_TABLE_ORDER: SyncTableName[] = [
   'system_prompts',
   'users',
   'llm_configs', // Requires users.id via owner_id (NOT NULL)
+  'tts_configs', // Requires users.id via owner_id (NOT NULL); parallel to llm_configs
   'personas', // Can now reference users via owner_id
   // Personalities depends on system_prompts and users (owner_id NOT NULL)
   'personalities',
   // Junction/config tables that depend on the above
   // NOTE: personality_default_configs excluded - settings table, not raw data
+  // NOTE: personality_default_tts_configs excluded for the same reason
   'personality_owners',
   'personality_aliases',
   'user_personality_configs',

--- a/services/api-gateway/src/services/sync/utils/ttsConfigSingletons.test.ts
+++ b/services/api-gateway/src/services/sync/utils/ttsConfigSingletons.test.ts
@@ -1,0 +1,459 @@
+/**
+ * Tests for TTS Config Singleton Utilities
+ *
+ * Mirrors llmConfigSingletons.test.ts (same logic surface, different table).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  prepareTtsConfigSingletonFlags,
+  finalizeTtsConfigSingletonFlags,
+} from './ttsConfigSingletons.js';
+import type { PrismaClient } from '@tzurot/common-types';
+
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+interface MockPrismaClient {
+  ttsConfig: {
+    findMany: ReturnType<typeof vi.fn>;
+    findUnique: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe('ttsConfigSingletons', () => {
+  let devClient: MockPrismaClient;
+  let prodClient: MockPrismaClient;
+
+  beforeEach(() => {
+    devClient = {
+      ttsConfig: {
+        findMany: vi.fn(),
+        findUnique: vi.fn(),
+        update: vi.fn(),
+      },
+    };
+    prodClient = {
+      ttsConfig: {
+        findMany: vi.fn(),
+        findUnique: vi.fn(),
+        update: vi.fn(),
+      },
+    };
+  });
+
+  describe('prepareTtsConfigSingletonFlags', () => {
+    it('should not update when no configs have singleton flags', async () => {
+      devClient.ttsConfig.findMany.mockResolvedValue([]);
+      prodClient.ttsConfig.findMany.mockResolvedValue([]);
+
+      await prepareTtsConfigSingletonFlags(
+        devClient as unknown as PrismaClient,
+        prodClient as unknown as PrismaClient
+      );
+
+      expect(devClient.ttsConfig.update).not.toHaveBeenCalled();
+      expect(prodClient.ttsConfig.update).not.toHaveBeenCalled();
+    });
+
+    it('should not update when only one database has the flag', async () => {
+      devClient.ttsConfig.findMany.mockResolvedValue([
+        { id: 'config-1', isDefault: true, isFreeDefault: false, updatedAt: new Date() },
+      ]);
+      prodClient.ttsConfig.findMany.mockResolvedValue([]);
+
+      await prepareTtsConfigSingletonFlags(
+        devClient as unknown as PrismaClient,
+        prodClient as unknown as PrismaClient
+      );
+
+      expect(devClient.ttsConfig.update).not.toHaveBeenCalled();
+      expect(prodClient.ttsConfig.update).not.toHaveBeenCalled();
+    });
+
+    it('should not update when same config has flag in both databases', async () => {
+      const sharedConfig = {
+        id: 'config-1',
+        isDefault: true,
+        isFreeDefault: false,
+        updatedAt: new Date(),
+      };
+      devClient.ttsConfig.findMany.mockResolvedValue([sharedConfig]);
+      prodClient.ttsConfig.findMany.mockResolvedValue([sharedConfig]);
+
+      await prepareTtsConfigSingletonFlags(
+        devClient as unknown as PrismaClient,
+        prodClient as unknown as PrismaClient
+      );
+
+      expect(devClient.ttsConfig.update).not.toHaveBeenCalled();
+      expect(prodClient.ttsConfig.update).not.toHaveBeenCalled();
+    });
+
+    it('should clear flag in prod and set on dev config in prod when dev is newer', async () => {
+      const devConfig = {
+        id: 'dev-config',
+        isDefault: true,
+        isFreeDefault: false,
+        updatedAt: new Date('2025-01-02'),
+      };
+      const prodConfig = {
+        id: 'prod-config',
+        isDefault: true,
+        isFreeDefault: false,
+        updatedAt: new Date('2025-01-01'),
+      };
+      devClient.ttsConfig.findMany.mockResolvedValue([devConfig]);
+      prodClient.ttsConfig.findMany.mockResolvedValue([prodConfig]);
+      prodClient.ttsConfig.findUnique.mockResolvedValue({ id: 'dev-config' });
+
+      await prepareTtsConfigSingletonFlags(
+        devClient as unknown as PrismaClient,
+        prodClient as unknown as PrismaClient
+      );
+
+      expect(prodClient.ttsConfig.update).toHaveBeenCalledWith({
+        where: { id: 'prod-config' },
+        data: { isDefault: false, updatedAt: expect.any(Date) },
+      });
+      expect(prodClient.ttsConfig.update).toHaveBeenCalledWith({
+        where: { id: 'dev-config' },
+        data: { isDefault: true, updatedAt: expect.any(Date) },
+      });
+      expect(devClient.ttsConfig.update).not.toHaveBeenCalled();
+    });
+
+    it('should clear flag in dev and set on prod config in dev when prod is newer', async () => {
+      const devConfig = {
+        id: 'dev-config',
+        isDefault: true,
+        isFreeDefault: false,
+        updatedAt: new Date('2025-01-01'),
+      };
+      const prodConfig = {
+        id: 'prod-config',
+        isDefault: true,
+        isFreeDefault: false,
+        updatedAt: new Date('2025-01-02'),
+      };
+      devClient.ttsConfig.findMany.mockResolvedValue([devConfig]);
+      prodClient.ttsConfig.findMany.mockResolvedValue([prodConfig]);
+      devClient.ttsConfig.findUnique.mockResolvedValue({ id: 'prod-config' });
+
+      await prepareTtsConfigSingletonFlags(
+        devClient as unknown as PrismaClient,
+        prodClient as unknown as PrismaClient
+      );
+
+      expect(devClient.ttsConfig.update).toHaveBeenCalledWith({
+        where: { id: 'dev-config' },
+        data: { isDefault: false, updatedAt: expect.any(Date) },
+      });
+      expect(devClient.ttsConfig.update).toHaveBeenCalledWith({
+        where: { id: 'prod-config' },
+        data: { isDefault: true, updatedAt: expect.any(Date) },
+      });
+      expect(prodClient.ttsConfig.update).not.toHaveBeenCalled();
+    });
+
+    it('should track pending resolution when winner config does not exist in other env', async () => {
+      const devConfig = {
+        id: 'dev-config',
+        isDefault: true,
+        isFreeDefault: false,
+        updatedAt: new Date('2025-01-02'),
+      };
+      const prodConfig = {
+        id: 'prod-config',
+        isDefault: true,
+        isFreeDefault: false,
+        updatedAt: new Date('2025-01-01'),
+      };
+      devClient.ttsConfig.findMany.mockResolvedValue([devConfig]);
+      prodClient.ttsConfig.findMany.mockResolvedValue([prodConfig]);
+      prodClient.ttsConfig.findUnique.mockResolvedValue(null);
+
+      await prepareTtsConfigSingletonFlags(
+        devClient as unknown as PrismaClient,
+        prodClient as unknown as PrismaClient
+      );
+
+      expect(prodClient.ttsConfig.update).toHaveBeenCalledWith({
+        where: { id: 'prod-config' },
+        data: { isDefault: false, updatedAt: expect.any(Date) },
+      });
+      expect(prodClient.ttsConfig.update).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle isFreeDefault flag conflicts', async () => {
+      const devConfig = {
+        id: 'dev-config',
+        isDefault: false,
+        isFreeDefault: true,
+        updatedAt: new Date('2025-01-02'),
+      };
+      const prodConfig = {
+        id: 'prod-config',
+        isDefault: false,
+        isFreeDefault: true,
+        updatedAt: new Date('2025-01-01'),
+      };
+      devClient.ttsConfig.findMany.mockResolvedValue([devConfig]);
+      prodClient.ttsConfig.findMany.mockResolvedValue([prodConfig]);
+      prodClient.ttsConfig.findUnique.mockResolvedValue({ id: 'dev-config' });
+
+      await prepareTtsConfigSingletonFlags(
+        devClient as unknown as PrismaClient,
+        prodClient as unknown as PrismaClient
+      );
+
+      expect(prodClient.ttsConfig.update).toHaveBeenCalledWith({
+        where: { id: 'prod-config' },
+        data: { isFreeDefault: false, updatedAt: expect.any(Date) },
+      });
+      expect(prodClient.ttsConfig.update).toHaveBeenCalledWith({
+        where: { id: 'dev-config' },
+        data: { isFreeDefault: true, updatedAt: expect.any(Date) },
+      });
+    });
+
+    it('should handle both flags having conflicts independently', async () => {
+      const devConfigs = [
+        {
+          id: 'dev-default',
+          isDefault: true,
+          isFreeDefault: false,
+          updatedAt: new Date('2025-01-02'),
+        },
+        {
+          id: 'dev-free',
+          isDefault: false,
+          isFreeDefault: true,
+          updatedAt: new Date('2025-01-01'),
+        },
+      ];
+      const prodConfigs = [
+        {
+          id: 'prod-default',
+          isDefault: true,
+          isFreeDefault: false,
+          updatedAt: new Date('2025-01-01'),
+        },
+        {
+          id: 'prod-free',
+          isDefault: false,
+          isFreeDefault: true,
+          updatedAt: new Date('2025-01-02'),
+        },
+      ];
+      devClient.ttsConfig.findMany.mockResolvedValue(devConfigs);
+      prodClient.ttsConfig.findMany.mockResolvedValue(prodConfigs);
+      prodClient.ttsConfig.findUnique.mockResolvedValue({ id: 'dev-default' });
+      devClient.ttsConfig.findUnique.mockResolvedValue({ id: 'prod-free' });
+
+      await prepareTtsConfigSingletonFlags(
+        devClient as unknown as PrismaClient,
+        prodClient as unknown as PrismaClient
+      );
+
+      expect(prodClient.ttsConfig.update).toHaveBeenCalledWith({
+        where: { id: 'prod-default' },
+        data: { isDefault: false, updatedAt: expect.any(Date) },
+      });
+      expect(prodClient.ttsConfig.update).toHaveBeenCalledWith({
+        where: { id: 'dev-default' },
+        data: { isDefault: true, updatedAt: expect.any(Date) },
+      });
+      expect(devClient.ttsConfig.update).toHaveBeenCalledWith({
+        where: { id: 'dev-free' },
+        data: { isFreeDefault: false, updatedAt: expect.any(Date) },
+      });
+      expect(devClient.ttsConfig.update).toHaveBeenCalledWith({
+        where: { id: 'prod-free' },
+        data: { isFreeDefault: true, updatedAt: expect.any(Date) },
+      });
+    });
+  });
+
+  describe('finalizeTtsConfigSingletonFlags', () => {
+    it('should do nothing when no pending resolutions', async () => {
+      devClient.ttsConfig.findMany.mockResolvedValue([]);
+      prodClient.ttsConfig.findMany.mockResolvedValue([]);
+      await prepareTtsConfigSingletonFlags(
+        devClient as unknown as PrismaClient,
+        prodClient as unknown as PrismaClient
+      );
+
+      vi.clearAllMocks();
+
+      await finalizeTtsConfigSingletonFlags(
+        devClient as unknown as PrismaClient,
+        prodClient as unknown as PrismaClient
+      );
+
+      expect(devClient.ttsConfig.update).not.toHaveBeenCalled();
+      expect(prodClient.ttsConfig.update).not.toHaveBeenCalled();
+    });
+
+    it('should set flag on newly synced config after sync (dev wins)', async () => {
+      const devConfig = {
+        id: 'dev-config',
+        isDefault: true,
+        isFreeDefault: false,
+        updatedAt: new Date('2025-01-02'),
+      };
+      const prodConfig = {
+        id: 'prod-config',
+        isDefault: true,
+        isFreeDefault: false,
+        updatedAt: new Date('2025-01-01'),
+      };
+      devClient.ttsConfig.findMany.mockResolvedValue([devConfig]);
+      prodClient.ttsConfig.findMany.mockResolvedValue([prodConfig]);
+      prodClient.ttsConfig.findUnique.mockResolvedValue(null);
+
+      await prepareTtsConfigSingletonFlags(
+        devClient as unknown as PrismaClient,
+        prodClient as unknown as PrismaClient
+      );
+
+      vi.clearAllMocks();
+
+      prodClient.ttsConfig.findUnique.mockResolvedValue({ id: 'dev-config' });
+
+      await finalizeTtsConfigSingletonFlags(
+        devClient as unknown as PrismaClient,
+        prodClient as unknown as PrismaClient
+      );
+
+      expect(prodClient.ttsConfig.update).toHaveBeenCalledWith({
+        where: { id: 'dev-config' },
+        data: { isDefault: true, updatedAt: expect.any(Date) },
+      });
+    });
+
+    it('should set flag on newly synced config after sync (prod wins)', async () => {
+      const devConfig = {
+        id: 'dev-config',
+        isDefault: true,
+        isFreeDefault: false,
+        updatedAt: new Date('2025-01-01'),
+      };
+      const prodConfig = {
+        id: 'prod-config',
+        isDefault: true,
+        isFreeDefault: false,
+        updatedAt: new Date('2025-01-02'),
+      };
+      devClient.ttsConfig.findMany.mockResolvedValue([devConfig]);
+      prodClient.ttsConfig.findMany.mockResolvedValue([prodConfig]);
+      devClient.ttsConfig.findUnique.mockResolvedValue(null);
+
+      await prepareTtsConfigSingletonFlags(
+        devClient as unknown as PrismaClient,
+        prodClient as unknown as PrismaClient
+      );
+
+      vi.clearAllMocks();
+
+      devClient.ttsConfig.findUnique.mockResolvedValue({ id: 'prod-config' });
+
+      await finalizeTtsConfigSingletonFlags(
+        devClient as unknown as PrismaClient,
+        prodClient as unknown as PrismaClient
+      );
+
+      expect(devClient.ttsConfig.update).toHaveBeenCalledWith({
+        where: { id: 'prod-config' },
+        data: { isDefault: true, updatedAt: expect.any(Date) },
+      });
+    });
+
+    it('should not update if config still not found after sync', async () => {
+      const devConfig = {
+        id: 'dev-config',
+        isDefault: true,
+        isFreeDefault: false,
+        updatedAt: new Date('2025-01-02'),
+      };
+      const prodConfig = {
+        id: 'prod-config',
+        isDefault: true,
+        isFreeDefault: false,
+        updatedAt: new Date('2025-01-01'),
+      };
+      devClient.ttsConfig.findMany.mockResolvedValue([devConfig]);
+      prodClient.ttsConfig.findMany.mockResolvedValue([prodConfig]);
+      prodClient.ttsConfig.findUnique.mockResolvedValue(null);
+
+      await prepareTtsConfigSingletonFlags(
+        devClient as unknown as PrismaClient,
+        prodClient as unknown as PrismaClient
+      );
+
+      vi.clearAllMocks();
+
+      prodClient.ttsConfig.findUnique.mockResolvedValue(null);
+
+      await finalizeTtsConfigSingletonFlags(
+        devClient as unknown as PrismaClient,
+        prodClient as unknown as PrismaClient
+      );
+
+      expect(prodClient.ttsConfig.update).not.toHaveBeenCalled();
+    });
+
+    it('should clear pending resolutions after finalize', async () => {
+      const devConfig = {
+        id: 'dev-config',
+        isDefault: true,
+        isFreeDefault: false,
+        updatedAt: new Date('2025-01-02'),
+      };
+      const prodConfig = {
+        id: 'prod-config',
+        isDefault: true,
+        isFreeDefault: false,
+        updatedAt: new Date('2025-01-01'),
+      };
+      devClient.ttsConfig.findMany.mockResolvedValue([devConfig]);
+      prodClient.ttsConfig.findMany.mockResolvedValue([prodConfig]);
+      prodClient.ttsConfig.findUnique.mockResolvedValue(null);
+
+      await prepareTtsConfigSingletonFlags(
+        devClient as unknown as PrismaClient,
+        prodClient as unknown as PrismaClient
+      );
+
+      vi.clearAllMocks();
+      prodClient.ttsConfig.findUnique.mockResolvedValue({ id: 'dev-config' });
+
+      await finalizeTtsConfigSingletonFlags(
+        devClient as unknown as PrismaClient,
+        prodClient as unknown as PrismaClient
+      );
+
+      expect(prodClient.ttsConfig.update).toHaveBeenCalledTimes(1);
+
+      vi.clearAllMocks();
+
+      await finalizeTtsConfigSingletonFlags(
+        devClient as unknown as PrismaClient,
+        prodClient as unknown as PrismaClient
+      );
+
+      expect(prodClient.ttsConfig.update).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/services/api-gateway/src/services/sync/utils/ttsConfigSingletons.ts
+++ b/services/api-gateway/src/services/sync/utils/ttsConfigSingletons.ts
@@ -1,13 +1,14 @@
 /**
- * LLM Config Singleton Flag Utilities for Database Sync
+ * TTS Config Singleton Flag Utilities for Database Sync
  *
- * Handles resolution of singleton boolean flags (is_default, is_free_default)
- * between dev and prod databases to avoid unique constraint violations during sync.
+ * Mirrors llmConfigSingletons.ts. Handles resolution of singleton boolean
+ * flags (is_default, is_free_default) between dev and prod databases to
+ * avoid unique constraint violations during sync.
  */
 
 import { type PrismaClient, createLogger } from '@tzurot/common-types';
 
-const logger = createLogger('db-sync-llm-config');
+const logger = createLogger('db-sync-tts-config');
 
 interface SingletonResolution {
   flagName: 'isDefault' | 'isFreeDefault';
@@ -15,10 +16,9 @@ interface SingletonResolution {
   winnerEnv: 'dev' | 'prod';
 }
 
-// Track resolutions for finalization after sync
 let pendingResolutions: SingletonResolution[] = [];
 
-interface LlmConfigWithFlags {
+interface TtsConfigWithFlags {
   id: string;
   isDefault: boolean;
   isFreeDefault: boolean;
@@ -26,63 +26,55 @@ interface LlmConfigWithFlags {
 }
 
 /**
- * Prepare llm_configs singleton flags before syncing
+ * Prepare tts_configs singleton flags before syncing.
  *
- * The llm_configs table has partial unique indexes that only allow one row
+ * The tts_configs table has partial unique indexes that only allow one row
  * with is_default=true and one row with is_free_default=true. Before syncing,
- * we need to resolve conflicts by using the most recently updated value.
+ * we resolve conflicts by using the most recently updated value.
  */
-export async function prepareLlmConfigSingletonFlags(
+export async function prepareTtsConfigSingletonFlags(
   devClient: PrismaClient,
   prodClient: PrismaClient
 ): Promise<void> {
-  // Clear any pending resolutions from previous runs
   pendingResolutions = [];
 
-  // Fetch llm_configs with singleton flags from both databases using typed Prisma methods
   const [devConfigs, prodConfigs] = await Promise.all([
-    devClient.llmConfig.findMany({
+    devClient.ttsConfig.findMany({
       where: { OR: [{ isDefault: true }, { isFreeDefault: true }] },
       select: { id: true, isDefault: true, isFreeDefault: true, updatedAt: true },
     }),
-    prodClient.llmConfig.findMany({
+    prodClient.ttsConfig.findMany({
       where: { OR: [{ isDefault: true }, { isFreeDefault: true }] },
       select: { id: true, isDefault: true, isFreeDefault: true, updatedAt: true },
     }),
   ]);
 
-  // Handle is_default singleton
   await resolveSingletonFlag(devClient, prodClient, devConfigs, prodConfigs, 'isDefault');
-
-  // Handle is_free_default singleton
   await resolveSingletonFlag(devClient, prodClient, devConfigs, prodConfigs, 'isFreeDefault');
 }
 
 /**
- * Resolve a singleton boolean flag between dev and prod
- * Clears the flag on the "losing" config (older updated_at)
+ * Resolve a singleton boolean flag between dev and prod.
+ * Clears the flag on the "losing" config (older updated_at).
  */
 async function resolveSingletonFlag(
   devClient: PrismaClient,
   prodClient: PrismaClient,
-  devConfigs: LlmConfigWithFlags[],
-  prodConfigs: LlmConfigWithFlags[],
+  devConfigs: TtsConfigWithFlags[],
+  prodConfigs: TtsConfigWithFlags[],
   flagName: 'isDefault' | 'isFreeDefault'
 ): Promise<void> {
   const devWithFlag = devConfigs.find(c => c[flagName]);
   const prodWithFlag = prodConfigs.find(c => c[flagName]);
 
-  // No conflict if only one database has the flag set
   if (!devWithFlag || !prodWithFlag) {
     return;
   }
 
-  // Same config has the flag in both - no conflict
   if (devWithFlag.id === prodWithFlag.id) {
     return;
   }
 
-  // Different configs have the flag - resolve using updated_at
   const devTime = new Date(devWithFlag.updatedAt).getTime();
   const prodTime = new Date(prodWithFlag.updatedAt).getTime();
 
@@ -95,65 +87,56 @@ async function resolveSingletonFlag(
       prodUpdatedAt: prodWithFlag.updatedAt,
       winner: devTime >= prodTime ? 'dev' : 'prod',
     },
-    '[Sync] Resolving llm_configs singleton flag conflict'
+    '[Sync] Resolving tts_configs singleton flag conflict'
   );
 
-  // Use typed Prisma update instead of raw SQL to avoid injection risk
-  // We need to both clear the loser's flag AND set the winner's flag in both environments
-  // Since sync excludes these columns, we must explicitly propagate the winner
   const updateData = flagName === 'isDefault' ? { isDefault: true } : { isFreeDefault: true };
   const clearData = flagName === 'isDefault' ? { isDefault: false } : { isFreeDefault: false };
 
   if (devTime >= prodTime) {
-    // Dev wins - clear prod's flag and ensure dev's config has the flag in prod
-    await prodClient.llmConfig.update({
+    await prodClient.ttsConfig.update({
       where: { id: prodWithFlag.id },
       data: { ...clearData, updatedAt: new Date() },
     });
 
-    // Set the flag on dev's winning config in prod (if it exists)
-    const devConfigInProd = await prodClient.llmConfig.findUnique({
+    const devConfigInProd = await prodClient.ttsConfig.findUnique({
       where: { id: devWithFlag.id },
     });
     if (devConfigInProd) {
-      await prodClient.llmConfig.update({
+      await prodClient.ttsConfig.update({
         where: { id: devWithFlag.id },
         data: { ...updateData, updatedAt: new Date() },
       });
     } else {
-      // Track for finalization - sync will copy the config, then we set the flag
       pendingResolutions.push({ flagName, winnerId: devWithFlag.id, winnerEnv: 'dev' });
     }
   } else {
-    // Prod wins - clear dev's flag and ensure prod's config has the flag in dev
-    await devClient.llmConfig.update({
+    await devClient.ttsConfig.update({
       where: { id: devWithFlag.id },
       data: { ...clearData, updatedAt: new Date() },
     });
 
-    // Set the flag on prod's winning config in dev (if it exists)
-    const prodConfigInDev = await devClient.llmConfig.findUnique({
+    const prodConfigInDev = await devClient.ttsConfig.findUnique({
       where: { id: prodWithFlag.id },
     });
     if (prodConfigInDev) {
-      await devClient.llmConfig.update({
+      await devClient.ttsConfig.update({
         where: { id: prodWithFlag.id },
         data: { ...updateData, updatedAt: new Date() },
       });
     } else {
-      // Track for finalization - sync will copy the config, then we set the flag
       pendingResolutions.push({ flagName, winnerId: prodWithFlag.id, winnerEnv: 'prod' });
     }
   }
 }
 
 /**
- * Finalize singleton flags after sync completes
+ * Finalize singleton flags after sync completes.
  *
- * Handles the case where the winning config didn't exist in the other environment
- * before sync. After sync copies it, we set the flag.
+ * Handles the case where the winning config didn't exist in the other
+ * environment before sync. After sync copies it, we set the flag.
  */
-export async function finalizeLlmConfigSingletonFlags(
+export async function finalizeTtsConfigSingletonFlags(
   devClient: PrismaClient,
   prodClient: PrismaClient
 ): Promise<void> {
@@ -161,30 +144,28 @@ export async function finalizeLlmConfigSingletonFlags(
     const { flagName, winnerId, winnerEnv } = resolution;
     const updateData = flagName === 'isDefault' ? { isDefault: true } : { isFreeDefault: true };
 
-    // Set the flag in the OTHER environment (the one that didn't have the config before)
     const targetClient = winnerEnv === 'dev' ? prodClient : devClient;
 
-    const configExists = await targetClient.llmConfig.findUnique({
+    const configExists = await targetClient.ttsConfig.findUnique({
       where: { id: winnerId },
     });
 
     if (configExists) {
       logger.info(
         { flagName, winnerId, targetEnv: winnerEnv === 'dev' ? 'prod' : 'dev' },
-        '[Sync] Setting singleton flag on newly synced config'
+        '[Sync] Setting singleton flag on newly synced tts_config'
       );
-      await targetClient.llmConfig.update({
+      await targetClient.ttsConfig.update({
         where: { id: winnerId },
         data: { ...updateData, updatedAt: new Date() },
       });
     } else {
       logger.warn(
         { flagName, winnerId, targetEnv: winnerEnv === 'dev' ? 'prod' : 'dev' },
-        '[Sync] Warning: winning config still not found after sync'
+        '[Sync] Warning: winning tts_config still not found after sync'
       );
     }
   }
 
-  // Clear pending resolutions
   pendingResolutions = [];
 }


### PR DESCRIPTION
Release-blockers for v3.0.0-beta.115 surfaced by claude-review on PR #967.

## Summary

1. **Migration `tts_configs_global_name_unique`** — partial unique index that prevents two admins from racing past app-level `checkNameExists` to create global TTS configs with the same name. Mirrors `llm_configs_global_name_unique` (migration `20260421164630`).

2. **db-sync support for tts_configs** — without this, the new TTS tables don't propagate dev↔prod and the bot owner sees "table not in SYNC_CONFIG or EXCLUDED_TABLES" warnings in `/admin db-sync` output. Adds:
   - `tts_configs` in `SyncTableName` + `SYNC_CONFIG` + `SYNC_TABLE_ORDER` (placed after `llm_configs`, before `user_personality_configs`)
   - `personality_default_tts_configs` in `EXCLUDED_TABLES` (settings, mirrors `personality_default_configs` exclusion)
   - `default_tts_config_id` added to `users.uuidColumns`
   - `tts_config_id` added to `user_personality_configs.uuidColumns`
   - `ttsConfigSingletons.ts` — direct mirror of `llmConfigSingletons.ts` for `is_default` / `is_free_default` partial-unique conflict resolution between dev/prod
   - `DatabaseSyncService` wires `prepareTtsConfigSingletonFlags` / `finalizeTtsConfigSingletonFlags` at the same boundaries as the LLM equivalents
   - `syncTables.test.ts` — parallel FK-ordering assertions for `tts_configs`
   - `DatabaseSyncService.test.ts` — `ttsConfig` added to mock client shape

## Test plan

- [x] `pnpm --filter api-gateway test` — 1888/1888 green (1872 baseline + 16 new from `ttsConfigSingletons.test.ts`)
- [x] `pnpm quality` — 11/11 tasks green (lint + cpd + depcruise + typecheck + typecheck:spec)
- [ ] CI green before merge to develop
- [ ] After merge: PR #967 (release PR) auto-updates with these commits; final release-PR CI cycle will exercise the full delta

🤖 Generated with [Claude Code](https://claude.com/claude-code)