### PR TITLE
fix(api-gateway,prisma): deterministic UUIDs for TTS system-globals (unblock /admin db-sync)

### DIFF
--- a/packages/common-types/src/utils/deterministicUuid.test.ts
+++ b/packages/common-types/src/utils/deterministicUuid.test.ts
@@ -11,6 +11,8 @@ import {
   generateLlmConfigUuid,
   newLlmConfigId,
   newTtsConfigId,
+  generateSystemGlobalTtsConfigUuid,
+  generateSystemGlobalLlmConfigUuid,
   generateUserPersonalityConfigUuid,
   generateConversationHistoryUuid,
   generateChannelSettingsUuid,
@@ -366,6 +368,63 @@ describe('Deterministic UUID Generation', () => {
       expect(intersection).toHaveLength(0);
       expect(ttsIds.size).toBe(100); // all unique
       expect(llmIds.size).toBe(100);
+    });
+  });
+
+  describe('generateSystemGlobalTtsConfigUuid', () => {
+    it('returns the same UUID for the same name (deterministic)', () => {
+      const id1 = generateSystemGlobalTtsConfigUuid('kyutai-self-hosted');
+      const id2 = generateSystemGlobalTtsConfigUuid('kyutai-self-hosted');
+      expect(id1).toBe(id2);
+    });
+
+    it('returns different UUIDs for different names', () => {
+      const id1 = generateSystemGlobalTtsConfigUuid('kyutai-self-hosted');
+      const id2 = generateSystemGlobalTtsConfigUuid('elevenlabs-multilingual-v2');
+      expect(id1).not.toBe(id2);
+    });
+
+    it('returns a valid v5 UUID format', () => {
+      const id = generateSystemGlobalTtsConfigUuid('kyutai-self-hosted');
+      // v5 UUIDs have version=5 in the 13th character (0-indexed position 14)
+      expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    });
+
+    it('returns the documented stable UUIDs for the 3 well-known names', () => {
+      // These literals are pasted into the recovery migration SQL — assert
+      // they don't drift. If this test fails, either the namespace or the
+      // seed format changed; investigate before regenerating the migration.
+      expect(generateSystemGlobalTtsConfigUuid('kyutai-self-hosted')).toBe(
+        '50411d3c-cc98-5f39-839e-abd4fb84b0c8'
+      );
+      expect(generateSystemGlobalTtsConfigUuid('elevenlabs-multilingual-v2')).toBe(
+        '845d224f-ad28-5ce1-8b27-f5588d3ae2d1'
+      );
+      expect(generateSystemGlobalTtsConfigUuid('mistral-voxtral-mini')).toBe(
+        '8aa02cad-2c39-5b5b-9d37-482aacb7788d'
+      );
+    });
+  });
+
+  describe('generateSystemGlobalLlmConfigUuid', () => {
+    it('returns the same UUID for the same name (deterministic)', () => {
+      const id1 = generateSystemGlobalLlmConfigUuid('claude-sonnet-default');
+      const id2 = generateSystemGlobalLlmConfigUuid('claude-sonnet-default');
+      expect(id1).toBe(id2);
+    });
+
+    it('returns a valid v5 UUID format', () => {
+      const id = generateSystemGlobalLlmConfigUuid('claude-sonnet-default');
+      expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    });
+
+    it('uses a different name-seed prefix than TTS — same name produces a different UUID', () => {
+      // Both helpers use TZUROT_NAMESPACE (shared); separation comes from
+      // the name-seed prefix (`tts_config_global:` vs `llm_config_global:`)
+      // passed to uuidv5 alongside the shared namespace.
+      const ttsId = generateSystemGlobalTtsConfigUuid('shared-name');
+      const llmId = generateSystemGlobalLlmConfigUuid('shared-name');
+      expect(ttsId).not.toBe(llmId);
     });
   });
 });

--- a/packages/common-types/src/utils/deterministicUuid.ts
+++ b/packages/common-types/src/utils/deterministicUuid.ts
@@ -106,6 +106,53 @@ export function newTtsConfigId(): string {
 }
 
 /**
+ * Deterministic UUID for a system-global TtsConfig row.
+ *
+ * Used by both the migration seed (paste-in literal computed via this helper)
+ * and `TtsConfigService.bootstrapSystemGlobalsIfNeeded` so dev and prod always
+ * assign the same UUID for the same well-known name. Without this, `/admin
+ * db-sync` fails with `tts_configs_owner_id_name_key` collisions because each
+ * env independently generated random UUIDs for the same logical row.
+ *
+ * Scoped to system-globals only (names are code-defined, stable, never
+ * renamed by users). Do NOT use for user-created configs — see
+ * {@link generateLlmConfigUuid}'s deprecation notice for the rename-collision
+ * rationale that drove user-created configs to UUIDv7.
+ */
+export function generateSystemGlobalTtsConfigUuid(name: string): string {
+  return uuidv5(`tts_config_global:${name}`, TZUROT_NAMESPACE);
+}
+
+/**
+ * Deterministic UUID for a system-global LlmConfig row.
+ *
+ * Mirrors {@link generateSystemGlobalTtsConfigUuid}. Currently unused — LLM
+ * has no migration-seeded globals or bootstrap loop today. Exported for
+ * symmetry and to reserve the namespace for future use (e.g., if Phase 3
+ * STT cutover adds a system-global free-tier LLM mapping).
+ *
+ * **Knip note**: this export has no production callers by design. As of
+ * v3.0.0-beta.116, `pnpm knip` does not flag it (the test in
+ * `deterministicUuid.test.ts` and the barrel `export *` from the
+ * common-types entry point satisfy reachability). If a future knip
+ * configuration starts flagging future-reserved exports, suppress with a
+ * `knip-ignore` directive that points at this JSDoc rather than removing
+ * the helper.
+ *
+ * **When adding the first LLM system-global**, follow the TTS pattern:
+ * (a) bootstrap the row with this helper, (b) add a pinned-value test in
+ * `deterministicUuid.test.ts` asserting the exact UUID for the well-known
+ * name (matches the test for kyutai-self-hosted etc.), and (c) if rows
+ * already exist in any env with non-deterministic IDs, write a recovery
+ * migration mirroring `20260504140720_align_tts_globals_to_deterministic_ids`.
+ * The cross-pinning (helper test + migration SQL + service test) is the
+ * mechanism that prevents migration-vs-helper drift.
+ */
+export function generateSystemGlobalLlmConfigUuid(name: string): string {
+  return uuidv5(`llm_config_global:${name}`, TZUROT_NAMESPACE);
+}
+
+/**
  * Generate deterministic UUID for UserPersonalityConfig
  * Seed: user_personality_settings:{userId}:{personalityId}
  * Note: Seed pattern kept as 'user_personality_settings' for UUID consistency (renamed from UserPersonalitySettings)

--- a/prisma/migrations/20260504140720_align_tts_globals_to_deterministic_ids/migration.sql
+++ b/prisma/migrations/20260504140720_align_tts_globals_to_deterministic_ids/migration.sql
@@ -1,0 +1,68 @@
+-- Align TTS system-global rows to deterministic UUIDs (uuidv5).
+--
+-- Before this migration: dev and prod each generated random UUIDs via
+-- `gen_random_uuid()` (migration 20260502185237) and `newTtsConfigId()`
+-- UUIDv7 in `TtsConfigService.bootstrapSystemGlobalsIfNeeded`. Each env
+-- bootstrapped independently, so the same logical row (`kyutai-self-hosted`,
+-- `elevenlabs-multilingual-v2`, `mistral-voxtral-mini`) ended up with
+-- different surrogate IDs across envs. `/admin db-sync` then failed with
+-- `tts_configs_owner_id_name_key` violations because db-sync inserts by id
+-- and the (owner_id, name) composite-unique constraint fired on the target
+-- env's pre-existing row with the same name.
+--
+-- This migration aligns the 3 well-known system-global rows to deterministic
+-- UUIDs computed via `uuidv5('tts_config_global:${name}', TZUROT_NAMESPACE)`
+-- where TZUROT_NAMESPACE is the standard DNS namespace
+-- `6ba7b810-9dad-11d1-80b4-00c04fd430c8`. The literal UUIDs below are the
+-- output of `generateSystemGlobalTtsConfigUuid(name)` from
+-- `packages/common-types/src/utils/deterministicUuid.ts` — pinned in tests
+-- so this migration won't drift if the helper is ever modified.
+--
+-- Going forward, both the migration seed (none required for the helper, but
+-- the application bootstrap path uses it) and
+-- `TtsConfigService.bootstrapSystemGlobalsIfNeeded` use the same helper, so
+-- future fresh DBs come up with these IDs already correct.
+--
+-- FK cascade: every FK to `tts_configs.id` declares `ON UPDATE CASCADE`.
+-- UPDATEs propagate automatically to:
+--   - users.default_tts_config_id (constraint
+--     users_default_tts_config_id_fkey; DEFERRABLE INITIALLY IMMEDIATE per
+--     migration 20260504065151 — but no special transaction handling needed
+--     here since we're not writing the conflicting rows in the same
+--     statement, just relying on the cascade)
+--   - personality_default_tts_configs.tts_config_id (constraint
+--     personality_default_tts_configs_tts_config_id_fkey, added in
+--     migration 20260502185237)
+--   - user_personality_configs.tts_config_id (constraint
+--     user_personality_configs_tts_config_id_fkey, added in migration
+--     20260502185237)
+-- No explicit FK-fixup SQL needed.
+--
+-- Idempotent: WHERE clauses skip rows that already have the target id
+-- (covers re-runs, plus any env where the bootstrap already happened to
+-- produce these IDs by accident — vanishingly improbable but free).
+--
+-- This is the first PK-rewriting migration in the codebase. The
+-- DEFERRABLE-FK + ON UPDATE CASCADE infrastructure existed already; this
+-- migration just leverages it.
+
+UPDATE "tts_configs"
+SET "id" = '50411d3c-cc98-5f39-839e-abd4fb84b0c8'::uuid,
+    "updated_at" = NOW()
+WHERE "name" = 'kyutai-self-hosted'
+  AND "is_global" = true
+  AND "id" != '50411d3c-cc98-5f39-839e-abd4fb84b0c8'::uuid;
+
+UPDATE "tts_configs"
+SET "id" = '845d224f-ad28-5ce1-8b27-f5588d3ae2d1'::uuid,
+    "updated_at" = NOW()
+WHERE "name" = 'elevenlabs-multilingual-v2'
+  AND "is_global" = true
+  AND "id" != '845d224f-ad28-5ce1-8b27-f5588d3ae2d1'::uuid;
+
+UPDATE "tts_configs"
+SET "id" = '8aa02cad-2c39-5b5b-9d37-482aacb7788d'::uuid,
+    "updated_at" = NOW()
+WHERE "name" = 'mistral-voxtral-mini'
+  AND "is_global" = true
+  AND "id" != '8aa02cad-2c39-5b5b-9d37-482aacb7788d'::uuid;

--- a/services/api-gateway/src/services/DatabaseSyncService.int.test.ts
+++ b/services/api-gateway/src/services/DatabaseSyncService.int.test.ts
@@ -94,6 +94,23 @@ function loadTtsDefaultFkDeferrableMigration(): string {
 }
 
 /**
+ * Load the recovery migration that aligns TTS system-global rows to
+ * deterministic UUIDs. Same rationale as the DEFERRABLE migrations: applied
+ * manually in `beforeAll` to keep the pglite environment matching production
+ * post-20260504140720. Idempotent (WHERE-clauses skip rows already at the
+ * target id), so safe to run on a freshly-seeded pglite even though no
+ * pre-migration TTS rows exist there.
+ */
+function loadAlignTtsGlobalsMigration(): string {
+  const migrationPath = join(
+    migrationsDir(),
+    '20260504140720_align_tts_globals_to_deterministic_ids',
+    'migration.sql'
+  );
+  return readFileSync(migrationPath, 'utf-8');
+}
+
+/**
  * Return the lexicographically-latest migration directory name (which is
  * also chronologically latest because migrations are prefixed with
  * `YYYYMMDDhhmmss`). Used to seed `_prisma_migrations` so
@@ -171,6 +188,7 @@ describe('DatabaseSyncService Integration (Ouroboros pattern)', () => {
     const schema = loadPGliteSchema();
     const deferrableFkMigration = loadDeferrableFkMigration();
     const ttsDefaultFkDeferrableMigration = loadTtsDefaultFkDeferrableMigration();
+    const alignTtsGlobalsMigration = loadAlignTtsGlobalsMigration();
 
     devPglite = createTestPGlite();
     prodPglite = createTestPGlite();
@@ -187,6 +205,13 @@ describe('DatabaseSyncService Integration (Ouroboros pattern)', () => {
     await prodPglite.exec(deferrableFkMigration);
     await devPglite.exec(ttsDefaultFkDeferrableMigration);
     await prodPglite.exec(ttsDefaultFkDeferrableMigration);
+    // Recovery migration aligning TTS system-global rows to deterministic
+    // UUIDs. Idempotent — these pglite instances have no TTS rows yet, so
+    // the WHERE clauses match nothing on the first run. Loaded here for
+    // parity with production's migration history (and so the
+    // _prisma_migrations seed below picks up its name as the latest).
+    await devPglite.exec(alignTtsGlobalsMigration);
+    await prodPglite.exec(alignTtsGlobalsMigration);
     // Create _prisma_migrations so checkSchemaVersions has a row to find.
     await devPglite.exec(SETUP_PRISMA_MIGRATIONS_TABLE);
     await prodPglite.exec(SETUP_PRISMA_MIGRATIONS_TABLE);

--- a/services/api-gateway/src/services/TtsConfigService.test.ts
+++ b/services/api-gateway/src/services/TtsConfigService.test.ts
@@ -208,7 +208,7 @@ describe('TtsConfigService', () => {
       expect(createCall).toBeDefined();
       const seedRows = (
         createCall as {
-          data: Array<{ name: string; isDefault: boolean; isFreeDefault: boolean }>;
+          data: Array<{ id: string; name: string; isDefault: boolean; isFreeDefault: boolean }>;
         }
       ).data;
       expect(seedRows.map(d => d.name)).toEqual([
@@ -225,6 +225,17 @@ describe('TtsConfigService', () => {
       // The other two are not defaults
       expect(seedRows.find(d => d.name === 'elevenlabs-multilingual-v2')?.isDefault).toBe(false);
       expect(seedRows.find(d => d.name === 'mistral-voxtral-mini')?.isDefault).toBe(false);
+
+      // Bootstrap rows use deterministic UUIDs (uuidv5 from name) so dev and
+      // prod always assign the same id for the same logical row. Pinned to
+      // the documented stable values from deterministicUuid.test.ts.
+      expect(kyutaiSeed?.id).toBe('50411d3c-cc98-5f39-839e-abd4fb84b0c8');
+      expect(seedRows.find(d => d.name === 'elevenlabs-multilingual-v2')?.id).toBe(
+        '845d224f-ad28-5ce1-8b27-f5588d3ae2d1'
+      );
+      expect(seedRows.find(d => d.name === 'mistral-voxtral-mini')?.id).toBe(
+        '8aa02cad-2c39-5b5b-9d37-482aacb7788d'
+      );
 
       expect(result).toEqual(seeded);
     });

--- a/services/api-gateway/src/services/TtsConfigService.ts
+++ b/services/api-gateway/src/services/TtsConfigService.ts
@@ -35,6 +35,7 @@ import {
   TTS_CONFIG_DETAIL_SELECT,
   TTS_CONFIG_DEFAULTS,
   newTtsConfigId,
+  generateSystemGlobalTtsConfigUuid,
   generateClonedName,
   stripCopySuffix,
   isTtsProviderId,
@@ -263,9 +264,14 @@ export class TtsConfigService {
       return;
     }
 
+    // System-globals use deterministic UUIDs (uuidv5 from name) so dev and
+    // prod always produce the same ID for the same logical row. Without
+    // this, /admin db-sync collides on the (owner_id, name) composite-unique
+    // constraint when each env independently bootstrapped with random UUIDs.
+    // User-created configs continue to use newTtsConfigId() (UUIDv7).
     const result = await this.prisma.ttsConfig.createMany({
       data: SYSTEM_GLOBALS.map(seed => ({
-        id: newTtsConfigId(),
+        id: generateSystemGlobalTtsConfigUuid(seed.name),
         name: seed.name,
         description: seed.description,
         ownerId: superuser.id,

--- a/services/api-gateway/src/services/sync/utils/alignTtsGlobalsRecovery.int.test.ts
+++ b/services/api-gateway/src/services/sync/utils/alignTtsGlobalsRecovery.int.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Integration tests for the TTS-globals deterministic-UUID recovery migration
+ * (`20260504140720_align_tts_globals_to_deterministic_ids`).
+ *
+ * This is the first PK-rewriting migration in the codebase. Tests verify:
+ *   1. UPDATE id propagates via ON UPDATE CASCADE to referring FKs
+ *   2. Idempotent — re-running the migration is a no-op
+ *   3. Cross-env alignment — dev and prod converge on the same IDs after both
+ *      have applied the migration, even though each started with random UUIDs
+ *   4. The literal UUIDs in the migration SQL match `generateSystemGlobalTtsConfigUuid`
+ *
+ * Establishes the test pattern for any future "fix already-deployed-data IDs
+ * in-place" migration.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import {
+  PrismaClient,
+  generateSystemGlobalTtsConfigUuid,
+  generateUserPersonalityConfigUuid,
+  newTtsConfigId,
+} from '@tzurot/common-types';
+import type { PGlite } from '@electric-sql/pglite';
+import { PrismaPGlite } from 'pglite-prisma-adapter';
+import { createTestPGlite, loadPGliteSchema, seedUserWithPersona } from '@tzurot/test-utils';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function migrationsDir(): string {
+  // services/api-gateway/src/services/sync/utils/ → repo root is 6x ..
+  return join(__dirname, '..', '..', '..', '..', '..', '..', 'prisma', 'migrations');
+}
+
+function loadDeferrableFkMigration(): string {
+  return readFileSync(
+    join(migrationsDir(), '20260418010642_make_circular_fks_deferrable', 'migration.sql'),
+    'utf-8'
+  );
+}
+
+function loadTtsDefaultFkDeferrableMigration(): string {
+  return readFileSync(
+    join(migrationsDir(), '20260504065151_make_tts_default_fk_deferrable', 'migration.sql'),
+    'utf-8'
+  );
+}
+
+function loadAlignTtsGlobalsMigration(): string {
+  return readFileSync(
+    join(migrationsDir(), '20260504140720_align_tts_globals_to_deterministic_ids', 'migration.sql'),
+    'utf-8'
+  );
+}
+
+const SUPERUSER_ID = '00000000-0000-0000-0000-0000000000a1';
+const SUPERUSER_PERSONA_ID = '00000000-0000-0000-0000-0000000000a2';
+
+const ALIGNED_KYUTAI_ID = '50411d3c-cc98-5f39-839e-abd4fb84b0c8';
+const ALIGNED_ELEVENLABS_ID = '845d224f-ad28-5ce1-8b27-f5588d3ae2d1';
+const ALIGNED_MISTRAL_ID = '8aa02cad-2c39-5b5b-9d37-482aacb7788d';
+
+async function setupPglite(): Promise<PGlite> {
+  const pglite = createTestPGlite();
+  await pglite.exec(loadPGliteSchema());
+  await pglite.exec(loadDeferrableFkMigration());
+  await pglite.exec(loadTtsDefaultFkDeferrableMigration());
+  return pglite;
+}
+
+/** Insert the superuser (with persona), then 3 TTS system-globals with the supplied IDs. */
+async function seedSuperuserAndTtsGlobals(
+  prisma: PrismaClient,
+  ids: { kyutai: string; elevenlabs: string; mistral: string }
+): Promise<void> {
+  await seedUserWithPersona(prisma, {
+    userId: SUPERUSER_ID,
+    personaId: SUPERUSER_PERSONA_ID,
+    discordId: '111111111111111111',
+    username: 'admin',
+    isSuperuser: true,
+  });
+  const seeds = [
+    {
+      id: ids.kyutai,
+      name: 'kyutai-self-hosted',
+      provider: 'self-hosted',
+      modelId: null,
+      isDefault: true,
+      isFreeDefault: true,
+    },
+    {
+      id: ids.elevenlabs,
+      name: 'elevenlabs-multilingual-v2',
+      provider: 'elevenlabs',
+      modelId: 'eleven_multilingual_v2',
+      isDefault: false,
+      isFreeDefault: false,
+    },
+    {
+      id: ids.mistral,
+      name: 'mistral-voxtral-mini',
+      provider: 'mistral',
+      modelId: 'voxtral-mini-tts-2603',
+      isDefault: false,
+      isFreeDefault: false,
+    },
+  ];
+  for (const seed of seeds) {
+    await prisma.ttsConfig.create({
+      data: {
+        id: seed.id,
+        name: seed.name,
+        ownerId: SUPERUSER_ID,
+        isGlobal: true,
+        isDefault: seed.isDefault,
+        isFreeDefault: seed.isFreeDefault,
+        provider: seed.provider,
+        modelId: seed.modelId,
+      },
+    });
+  }
+}
+
+describe('Recovery migration: align_tts_globals_to_deterministic_ids', () => {
+  let pglite: PGlite;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    pglite = await setupPglite();
+    prisma = new PrismaClient({ adapter: new PrismaPGlite(pglite) }) as PrismaClient;
+  }, 60000);
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+    await pglite.close();
+  });
+
+  beforeEach(async () => {
+    // Clean state per test. TRUNCATE ... CASCADE handles the circular
+    // users↔personas FK pair without depending on DEFERRABLE behavior under
+    // pglite (which doesn't respect SET CONSTRAINTS DEFERRED reliably across
+    // separate $executeRawUnsafe calls in a single $transaction).
+    await prisma.$executeRawUnsafe(
+      'TRUNCATE "users", "personas", "personalities", "tts_configs", "user_personality_configs", "personality_default_tts_configs" CASCADE'
+    );
+  });
+
+  it('updates the 3 system-global rows to their deterministic IDs', async () => {
+    await seedSuperuserAndTtsGlobals(prisma, {
+      kyutai: newTtsConfigId(),
+      elevenlabs: newTtsConfigId(),
+      mistral: newTtsConfigId(),
+    });
+
+    await pglite.exec(loadAlignTtsGlobalsMigration());
+
+    const rows = await prisma.ttsConfig.findMany({
+      where: { isGlobal: true },
+      select: { id: true, name: true },
+      orderBy: { name: 'asc' },
+      // Bounded query per `03-database.md` (CRITICAL rule). Test files are
+      // ESLint-excluded so this isn't enforced, but keeping the convention
+      // here so future authors copying this test pattern get the right
+      // defaults for production code.
+      take: 10,
+    });
+    const byName = Object.fromEntries(rows.map(r => [r.name, r.id]));
+    expect(byName['kyutai-self-hosted']).toBe(ALIGNED_KYUTAI_ID);
+    expect(byName['elevenlabs-multilingual-v2']).toBe(ALIGNED_ELEVENLABS_ID);
+    expect(byName['mistral-voxtral-mini']).toBe(ALIGNED_MISTRAL_ID);
+  });
+
+  it('cascades the UPDATE to users.default_tts_config_id', async () => {
+    const randomKyutaiId = newTtsConfigId();
+    await seedSuperuserAndTtsGlobals(prisma, {
+      kyutai: randomKyutaiId,
+      elevenlabs: newTtsConfigId(),
+      mistral: newTtsConfigId(),
+    });
+    // Set the superuser's `default_tts_config_id` to the random kyutai id —
+    // this FK referrer should auto-update when the recovery migration
+    // changes the kyutai row's id.
+    await prisma.user.update({
+      where: { id: SUPERUSER_ID },
+      data: { defaultTtsConfigId: randomKyutaiId },
+    });
+
+    await pglite.exec(loadAlignTtsGlobalsMigration());
+
+    const user = await prisma.user.findUnique({
+      where: { id: SUPERUSER_ID },
+      select: { defaultTtsConfigId: true },
+    });
+    expect(user?.defaultTtsConfigId).toBe(ALIGNED_KYUTAI_ID);
+  });
+
+  it('cascades the UPDATE to personality_default_tts_configs.tts_config_id', async () => {
+    // Verifies the cascade fires on a NON-users FK referrer too — the
+    // migration comment lists three cascade paths (users, personality
+    // defaults, user-personality configs) and this proves the mechanism
+    // isn't users-table-specific.
+    const randomKyutaiId = newTtsConfigId();
+    await seedSuperuserAndTtsGlobals(prisma, {
+      kyutai: randomKyutaiId,
+      elevenlabs: newTtsConfigId(),
+      mistral: newTtsConfigId(),
+    });
+    // Create a personality (system_prompt_id is NULLABLE in schema, so we
+    // can skip the system_prompt fixture entirely).
+    const personalityId = '00000000-0000-0000-0000-0000000000c1';
+    await prisma.personality.create({
+      data: {
+        id: personalityId,
+        name: 'TestPersonality',
+        slug: 'test-personality-cascade',
+        ownerId: SUPERUSER_ID,
+        characterInfo: 'test',
+        personalityTraits: 'test',
+      },
+    });
+    // Create the personality_default_tts_configs row pointing at the
+    // pre-migration random kyutai ID — this is the FK that should cascade
+    // when the recovery migration UPDATE-rewrites kyutai's id.
+    await prisma.personalityDefaultTtsConfig.create({
+      data: {
+        personalityId,
+        ttsConfigId: randomKyutaiId,
+      },
+    });
+
+    await pglite.exec(loadAlignTtsGlobalsMigration());
+
+    const row = await prisma.personalityDefaultTtsConfig.findUnique({
+      where: { personalityId },
+      select: { ttsConfigId: true },
+    });
+    expect(row?.ttsConfigId).toBe(ALIGNED_KYUTAI_ID);
+  });
+
+  it('cascades the UPDATE to user_personality_configs.tts_config_id', async () => {
+    // Verifies the third FK cascade path called out in the migration
+    // comment. Same pattern as the personality_default_tts_configs test —
+    // seed a row with the random kyutai id, run migration, assert the
+    // ON UPDATE CASCADE propagated to the aligned id.
+    const randomKyutaiId = newTtsConfigId();
+    await seedSuperuserAndTtsGlobals(prisma, {
+      kyutai: randomKyutaiId,
+      elevenlabs: newTtsConfigId(),
+      mistral: newTtsConfigId(),
+    });
+    const personalityId = '00000000-0000-0000-0000-0000000000c2';
+    await prisma.personality.create({
+      data: {
+        id: personalityId,
+        name: 'TestPersonality',
+        slug: 'test-personality-upc-cascade',
+        ownerId: SUPERUSER_ID,
+        characterInfo: 'test',
+        personalityTraits: 'test',
+      },
+    });
+    await prisma.userPersonalityConfig.create({
+      data: {
+        id: generateUserPersonalityConfigUuid(SUPERUSER_ID, personalityId),
+        userId: SUPERUSER_ID,
+        personalityId,
+        ttsConfigId: randomKyutaiId,
+      },
+    });
+
+    await pglite.exec(loadAlignTtsGlobalsMigration());
+
+    const row = await prisma.userPersonalityConfig.findUnique({
+      where: { userId_personalityId: { userId: SUPERUSER_ID, personalityId } },
+      select: { ttsConfigId: true },
+    });
+    expect(row?.ttsConfigId).toBe(ALIGNED_KYUTAI_ID);
+  });
+
+  it('is idempotent — re-running the migration is a no-op with no errors', async () => {
+    // Seed with already-aligned IDs (the post-first-run state).
+    await seedSuperuserAndTtsGlobals(prisma, {
+      kyutai: ALIGNED_KYUTAI_ID,
+      elevenlabs: ALIGNED_ELEVENLABS_ID,
+      mistral: ALIGNED_MISTRAL_ID,
+    });
+
+    // Run twice. WHERE clauses skip rows that already match — no UPDATE fires.
+    await expect(pglite.exec(loadAlignTtsGlobalsMigration())).resolves.not.toThrow();
+    await expect(pglite.exec(loadAlignTtsGlobalsMigration())).resolves.not.toThrow();
+
+    const rows = await prisma.ttsConfig.findMany({
+      where: { isGlobal: true },
+      select: { id: true, name: true },
+      // Bounded query per `03-database.md` (CRITICAL rule). Test files are
+      // ESLint-excluded so this isn't enforced, but keeping the convention
+      // here so future authors copying this test pattern get the right
+      // defaults for production code.
+      take: 10,
+    });
+    expect(rows.find(r => r.name === 'kyutai-self-hosted')?.id).toBe(ALIGNED_KYUTAI_ID);
+    expect(rows.find(r => r.name === 'elevenlabs-multilingual-v2')?.id).toBe(ALIGNED_ELEVENLABS_ID);
+    expect(rows.find(r => r.name === 'mistral-voxtral-mini')?.id).toBe(ALIGNED_MISTRAL_ID);
+  });
+
+  it('matches `generateSystemGlobalTtsConfigUuid` output exactly', async () => {
+    // Sanity check that the literals pasted into the migration SQL match
+    // what the helper produces. If this fails, either the helper changed
+    // (and the migration is now stale) or the migration's literals are a
+    // typo. No DB needed.
+    expect(generateSystemGlobalTtsConfigUuid('kyutai-self-hosted')).toBe(ALIGNED_KYUTAI_ID);
+    expect(generateSystemGlobalTtsConfigUuid('elevenlabs-multilingual-v2')).toBe(
+      ALIGNED_ELEVENLABS_ID
+    );
+    expect(generateSystemGlobalTtsConfigUuid('mistral-voxtral-mini')).toBe(ALIGNED_MISTRAL_ID);
+  });
+});


### PR DESCRIPTION
## Summary

`/admin db-sync` fails with \`Code: 23505 duplicate key value violates unique constraint \"tts_configs_owner_id_name_key\"\` because dev and prod each independently bootstrapped the 3 TTS system-global rows (\`kyutai-self-hosted\`, \`elevenlabs-multilingual-v2\`, \`mistral-voxtral-mini\`) with **random UUIDs** (\`gen_random_uuid()\` in the migration seed, \`newTtsConfigId()\` UUIDv7 in the application bootstrap). Same logical row, different surrogate IDs across envs → sync's \`INSERT ON CONFLICT (id)\` doesn't reconcile, and the \`(owner_id, name)\` composite-unique constraint fires.

This PR fixes the design — system-global UUIDs are now derived deterministically from the name via uuidv5 with \`TZUROT_NAMESPACE\`, mirroring the existing pattern for \`discord:\`, \`personality:\`, \`system_prompt:\`, \`channel_settings:\`. Dev and prod now produce the same UUID for the same well-known name, both at fresh-DB-bootstrap time and after the recovery migration aligns existing rows.

## Changes

### Commit 1: \`feat(common-types,api-gateway): deterministic UUIDs for TTS system-globals\`

- New \`generateSystemGlobalTtsConfigUuid(name)\` and symmetric \`generateSystemGlobalLlmConfigUuid(name)\` helpers in \`packages/common-types/src/utils/deterministicUuid.ts\`.
- \`TtsConfigService.bootstrapSystemGlobalsIfNeeded\` uses the helper for the 3 well-known names. User-create paths still use \`newTtsConfigId()\` (UUIDv7) — see the \`@deprecated\` notice on \`generateLlmConfigUuid\` for why deriving USER-CREATED config IDs from name caused phantom-PK collisions in April 2026.
- Tests: 7 new test cases pinning the deterministic outputs.

### Commit 2: \`feat(prisma,api-gateway): align existing TTS system-global IDs to deterministic UUIDs\`

- Recovery migration \`20260504140720_align_tts_globals_to_deterministic_ids\` UPDATEs the 3 existing rows to their deterministic UUIDs. Idempotent via WHERE clauses that skip already-aligned rows.
- ON UPDATE CASCADE on every FK to \`tts_configs.id\` auto-propagates the change to \`users.default_tts_config_id\`, \`personality_default_tts_configs.tts_config_id\`, \`user_personality_configs.tts_config_id\` — no explicit FK fixup SQL needed.
- New integration test \`alignTtsGlobalsRecovery.int.test.ts\` covers UPDATE behavior, FK cascade propagation, idempotency, and helper-vs-migration consistency.

## This is the first PK-rewriting migration in the codebase

The DEFERRABLE-FK + ON UPDATE CASCADE infrastructure existed already (from the original db-sync Ouroboros work and the TTS DEFERRABLE migration in beta.115); this migration just leverages it. The new int-test establishes the pattern for any future "fix already-deployed-data IDs in-place" migration.

## Out of scope

- User-created TTS configs that may already have dev/prod ID drift (manual recovery if any surface)
- LLM-side recovery (LLM has no migration-seeded globals or bootstrap loop today; the helper is added for symmetry/future-readiness)

## Test plan

- [x] \`pnpm test\` — all 14 packages green (4678 bot-client + 1888 api-gateway + 2324 common-types + ...)
- [x] \`pnpm test:int\` — 24/24 int test files green, 301/301 tests including 4 new recovery-migration tests
- [x] \`pnpm quality\` — 11/11 quality tasks green
- [ ] CI green before merge
- [ ] Post-merge: \`pnpm ops db:migrate --env dev\` + \`pnpm ops db:migrate --env prod\` apply the recovery migration
- [ ] Post-merge: \`/admin db-sync\` succeeds (no more \`tts_configs_owner_id_name_key\` collision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)