### PR TITLE
fix(common-types,repo): deterministic UUIDs for BYOK tts-byok-* rows

### DIFF
--- a/packages/common-types/src/utils/deterministicUuid.test.ts
+++ b/packages/common-types/src/utils/deterministicUuid.test.ts
@@ -13,6 +13,8 @@ import {
   newTtsConfigId,
   generateSystemGlobalTtsConfigUuid,
   generateSystemGlobalLlmConfigUuid,
+  generateByokTtsConfigUuid,
+  generateByokLlmConfigUuid,
   generateUserPersonalityConfigUuid,
   generateConversationHistoryUuid,
   generateChannelSettingsUuid,
@@ -425,6 +427,87 @@ describe('Deterministic UUID Generation', () => {
       const ttsId = generateSystemGlobalTtsConfigUuid('shared-name');
       const llmId = generateSystemGlobalLlmConfigUuid('shared-name');
       expect(ttsId).not.toBe(llmId);
+    });
+  });
+
+  describe('generateByokTtsConfigUuid', () => {
+    const TEST_OWNER = '00000000-0000-0000-0000-000000000001';
+
+    it('returns the same UUID for the same (ownerId, provider) tuple (deterministic)', () => {
+      const id1 = generateByokTtsConfigUuid(TEST_OWNER, 'elevenlabs');
+      const id2 = generateByokTtsConfigUuid(TEST_OWNER, 'elevenlabs');
+      expect(id1).toBe(id2);
+    });
+
+    it('different ownerId produces different UUID', () => {
+      const id1 = generateByokTtsConfigUuid(TEST_OWNER, 'elevenlabs');
+      const id2 = generateByokTtsConfigUuid('00000000-0000-0000-0000-000000000002', 'elevenlabs');
+      expect(id1).not.toBe(id2);
+    });
+
+    it('different provider produces different UUID', () => {
+      const id1 = generateByokTtsConfigUuid(TEST_OWNER, 'elevenlabs');
+      const id2 = generateByokTtsConfigUuid(TEST_OWNER, 'mistral');
+      expect(id1).not.toBe(id2);
+    });
+
+    it('returns a valid v5 UUID format', () => {
+      const id = generateByokTtsConfigUuid(TEST_OWNER, 'elevenlabs');
+      expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    });
+
+    it('returns the documented stable UUID for a known (ownerId, provider) pair', () => {
+      // Pinned values for the test owner. If this test fails, either the
+      // namespace or seed-prefix format changed; investigate before the
+      // recovery script runs against any data. Same cross-pinning pattern
+      // as PR #969's system-global UUIDs.
+      expect(generateByokTtsConfigUuid(TEST_OWNER, 'elevenlabs')).toBe(
+        '888c58ff-d8f4-5f82-9c75-33aa39b7b905'
+      );
+      expect(generateByokTtsConfigUuid(TEST_OWNER, 'mistral')).toBe(
+        '65fa408e-bd23-5f2e-baa0-8e2b0ca7a944'
+      );
+    });
+  });
+
+  describe('generateByokLlmConfigUuid', () => {
+    const TEST_OWNER = '00000000-0000-0000-0000-000000000001';
+
+    it('returns the same UUID for the same (ownerId, provider) tuple (deterministic)', () => {
+      const id1 = generateByokLlmConfigUuid(TEST_OWNER, 'openrouter');
+      const id2 = generateByokLlmConfigUuid(TEST_OWNER, 'openrouter');
+      expect(id1).toBe(id2);
+    });
+
+    it('different ownerId produces different UUID', () => {
+      const id1 = generateByokLlmConfigUuid(TEST_OWNER, 'openrouter');
+      const id2 = generateByokLlmConfigUuid('00000000-0000-0000-0000-000000000002', 'openrouter');
+      expect(id1).not.toBe(id2);
+    });
+
+    it('different provider produces different UUID', () => {
+      const id1 = generateByokLlmConfigUuid(TEST_OWNER, 'openrouter');
+      const id2 = generateByokLlmConfigUuid(TEST_OWNER, 'anthropic');
+      expect(id1).not.toBe(id2);
+    });
+
+    it('returns a valid v5 UUID format', () => {
+      const id = generateByokLlmConfigUuid(TEST_OWNER, 'openrouter');
+      expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    });
+
+    it('uses a different name-seed prefix than TTS — same (ownerId, provider) produces a different UUID', () => {
+      // `tts_config_byok:` vs `llm_config_byok:` — separation by name-seed
+      // prefix (TZUROT_NAMESPACE is shared across all helpers).
+      const ttsId = generateByokTtsConfigUuid(TEST_OWNER, 'elevenlabs');
+      const llmId = generateByokLlmConfigUuid(TEST_OWNER, 'elevenlabs');
+      expect(ttsId).not.toBe(llmId);
+    });
+
+    it('returns the documented stable UUID for a known (ownerId, provider) pair', () => {
+      expect(generateByokLlmConfigUuid(TEST_OWNER, 'elevenlabs')).toBe(
+        '7f8a3518-336b-5dc8-973e-cc302405d333'
+      );
     });
   });
 });

--- a/packages/common-types/src/utils/deterministicUuid.test.ts
+++ b/packages/common-types/src/utils/deterministicUuid.test.ts
@@ -508,6 +508,9 @@ describe('Deterministic UUID Generation', () => {
       expect(generateByokLlmConfigUuid(TEST_OWNER, 'elevenlabs')).toBe(
         '7f8a3518-336b-5dc8-973e-cc302405d333'
       );
+      expect(generateByokLlmConfigUuid(TEST_OWNER, 'openrouter')).toBe(
+        '287bae65-55ef-591a-9cd1-c567b5d3e2e1'
+      );
     });
   });
 });

--- a/packages/common-types/src/utils/deterministicUuid.ts
+++ b/packages/common-types/src/utils/deterministicUuid.ts
@@ -153,6 +153,41 @@ export function generateSystemGlobalLlmConfigUuid(name: string): string {
 }
 
 /**
+ * Deterministic UUID for a per-user BYOK-style TtsConfig row.
+ *
+ * Used by `scripts/src/align-byok-tts-configs.ts` to align existing
+ * `tts-byok-*` rows (created by migration 20260502185237's one-shot data
+ * seed for users with legacy `elevenlabsTtsModel` JSONB) to deterministic
+ * UUIDs. Without this, dev and prod each generated their own random UUIDs
+ * for the same logical row → /admin db-sync collision on the
+ * `tts_configs_owner_id_name_key` composite-unique constraint.
+ *
+ * Scoped to migration-seeded BYOK rows. Do NOT use for user-created configs
+ * via `/settings tts create` — those have user-editable names and should
+ * keep UUIDv7 to avoid the rename-collision bug documented on
+ * {@link generateLlmConfigUuid}'s `@deprecated` notice.
+ *
+ * Why `(ownerId, provider)` not `(ownerId, name)`: name is mutable (the
+ * UPDATE route at `services/api-gateway/src/routes/user/tts-config.ts` has
+ * no guard preventing rename of `tts-byok-*` rows). Provider is fixed for
+ * the row's lifetime.
+ */
+export function generateByokTtsConfigUuid(ownerId: string, provider: string): string {
+  return uuidv5(`tts_config_byok:${ownerId}:${provider}`, TZUROT_NAMESPACE);
+}
+
+/**
+ * Deterministic UUID for a per-user BYOK-style LlmConfig row.
+ *
+ * Mirrors {@link generateByokTtsConfigUuid}. Currently unused — LLM has no
+ * equivalent BYOK auto-migration today. Exported for symmetry and to
+ * reserve the namespace for future use.
+ */
+export function generateByokLlmConfigUuid(ownerId: string, provider: string): string {
+  return uuidv5(`llm_config_byok:${ownerId}:${provider}`, TZUROT_NAMESPACE);
+}
+
+/**
  * Generate deterministic UUID for UserPersonalityConfig
  * Seed: user_personality_settings:{userId}:{personalityId}
  * Note: Seed pattern kept as 'user_personality_settings' for UUID consistency (renamed from UserPersonalitySettings)

--- a/packages/common-types/src/utils/deterministicUuid.ts
+++ b/packages/common-types/src/utils/deterministicUuid.ts
@@ -182,6 +182,13 @@ export function generateByokTtsConfigUuid(ownerId: string, provider: string): st
  * Mirrors {@link generateByokTtsConfigUuid}. Currently unused — LLM has no
  * equivalent BYOK auto-migration today. Exported for symmetry and to
  * reserve the namespace for future use.
+ *
+ * **Knip note**: same as {@link generateSystemGlobalLlmConfigUuid} — no
+ * production callers by design. The pinned-value test in
+ * `deterministicUuid.test.ts` plus the barrel `export *` from common-types
+ * keep this reachable. If a future knip configuration starts flagging
+ * future-reserved exports, suppress with a `knip-ignore` directive
+ * pointing at this JSDoc rather than removing the helper.
  */
 export function generateByokLlmConfigUuid(ownerId: string, provider: string): string {
   return uuidv5(`llm_config_byok:${ownerId}:${provider}`, TZUROT_NAMESPACE);

--- a/packages/tooling/src/commands/inspect.ts
+++ b/packages/tooling/src/commands/inspect.ts
@@ -7,10 +7,14 @@
 import type { CAC } from 'cac';
 import type { Environment } from '../utils/env-runner.js';
 
+const ENV_OPTION = '--env <env>';
+const ENV_OPTION_DESC = 'Environment: local, dev, or prod';
+const ENV_OPTION_DEFAULT = { default: 'dev' };
+
 export function registerInspectCommands(cli: CAC): void {
   cli
     .command('inspect:queue', 'Inspect BullMQ queue state')
-    .option('--env <env>', 'Environment: local, dev, or prod', { default: 'dev' })
+    .option(ENV_OPTION, ENV_OPTION_DESC, ENV_OPTION_DEFAULT)
     .option('--queue <name>', 'Queue name', { default: 'ai-requests' })
     .option('--failed-limit <n>', 'Number of failed jobs to show', { default: 5 })
     .option('--verbose', 'Show detailed job data')
@@ -35,8 +39,18 @@ export function registerInspectCommands(cli: CAC): void {
     );
 
   cli
+    .command('inspect:tts-configs', 'List all tts_configs rows for the current env')
+    .option(ENV_OPTION, ENV_OPTION_DESC, ENV_OPTION_DEFAULT)
+    .example('pnpm ops inspect:tts-configs')
+    .example('pnpm ops inspect:tts-configs --env prod')
+    .action(async (options: { env?: Environment }) => {
+      const { inspectTtsConfigs } = await import('../inspect/tts-configs.js');
+      await inspectTtsConfigs({ env: options.env ?? 'dev' });
+    });
+
+  cli
     .command('inspect:dlq', 'View failed jobs in BullMQ dead letter queue')
-    .option('--env <env>', 'Environment: local, dev, or prod', { default: 'dev' })
+    .option(ENV_OPTION, ENV_OPTION_DESC, ENV_OPTION_DEFAULT)
     .option('--queue <name>', 'Queue name', { default: 'ai-requests' })
     .option('--limit <n>', 'Number of failed jobs to show', { default: 10 })
     .option('--json', 'Output as JSON for scripting')

--- a/packages/tooling/src/inspect/tts-configs.test.ts
+++ b/packages/tooling/src/inspect/tts-configs.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for the `inspect:tts-configs` ops command.
+ *
+ * The implementation runs an inline tsx subprocess to query the DB. We
+ * test the pure parts (script-builder output, env validation) directly,
+ * and mock execFileSync to assert the subprocess is invoked correctly
+ * for each environment.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('chalk', () => ({
+  default: {
+    cyan: (s: string) => s,
+    dim: (s: string) => s,
+  },
+}));
+
+const { mockExecFileSync, mockGetRailwayDatabaseUrl, mockGetRailwayEnvName } = vi.hoisted(() => ({
+  mockExecFileSync: vi.fn(),
+  mockGetRailwayDatabaseUrl: vi.fn(),
+  mockGetRailwayEnvName: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+  execFileSync: mockExecFileSync,
+}));
+
+vi.mock('../utils/env-runner.js', () => ({
+  getRailwayDatabaseUrl: mockGetRailwayDatabaseUrl,
+  getRailwayEnvName: mockGetRailwayEnvName,
+}));
+
+import { inspectTtsConfigs, buildInspectorScript } from './tts-configs.js';
+
+describe('buildInspectorScript', () => {
+  it('embeds the configured take limit in the rendered script', () => {
+    const script = buildInspectorScript(200);
+    expect(script).toContain('take: 200');
+    expect(script).toContain("'⚠️  Result may be truncated at the ' + 200 + '-row take limit");
+  });
+
+  it('produces deterministic output for the same input', () => {
+    expect(buildInspectorScript(50)).toBe(buildInspectorScript(50));
+  });
+
+  it('different take limits produce different scripts', () => {
+    expect(buildInspectorScript(100)).not.toBe(buildInspectorScript(200));
+  });
+
+  it('imports the prisma helpers from common-types', () => {
+    const script = buildInspectorScript(200);
+    expect(script).toContain(
+      "import { getPrismaClient, disconnectPrisma } from '@tzurot/common-types';"
+    );
+  });
+
+  it('selects exactly the columns the formatter prints', () => {
+    const script = buildInspectorScript(200);
+    expect(script).toContain('id: true');
+    expect(script).toContain('ownerId: true');
+    expect(script).toContain('name: true');
+    expect(script).toContain('isGlobal: true');
+    expect(script).toContain('provider: true');
+  });
+
+  it('orders results by name ascending so cross-env diffs are stable', () => {
+    const script = buildInspectorScript(200);
+    expect(script).toContain("orderBy: [{ name: 'asc' }]");
+  });
+});
+
+describe('inspectTtsConfigs', () => {
+  beforeEach(() => {
+    mockExecFileSync.mockReset();
+    mockGetRailwayDatabaseUrl.mockReset();
+    mockGetRailwayEnvName.mockReset();
+    mockGetRailwayEnvName.mockImplementation((env: string) => env);
+  });
+
+  afterEach(() => {
+    delete process.env.DATABASE_URL;
+  });
+
+  it('uses Railway DATABASE_PUBLIC_URL for env=dev', async () => {
+    mockGetRailwayDatabaseUrl.mockReturnValue('postgresql://dev-host/db');
+
+    await inspectTtsConfigs({ env: 'dev' });
+
+    expect(mockGetRailwayDatabaseUrl).toHaveBeenCalledWith('dev');
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+    const call = mockExecFileSync.mock.calls[0];
+    expect(call[0]).toBe('tsx');
+    expect(call[1]).toEqual(['-e', expect.stringContaining('prisma.ttsConfig.findMany')]);
+    expect(call[2].env.DATABASE_URL).toBe('postgresql://dev-host/db');
+  });
+
+  it('uses Railway DATABASE_PUBLIC_URL for env=prod', async () => {
+    mockGetRailwayDatabaseUrl.mockReturnValue('postgresql://prod-host/db');
+
+    await inspectTtsConfigs({ env: 'prod' });
+
+    expect(mockGetRailwayDatabaseUrl).toHaveBeenCalledWith('prod');
+    const call = mockExecFileSync.mock.calls[0];
+    expect(call[2].env.DATABASE_URL).toBe('postgresql://prod-host/db');
+  });
+
+  it('uses local DATABASE_URL for env=local', async () => {
+    process.env.DATABASE_URL = 'postgresql://localhost/db';
+
+    await inspectTtsConfigs({ env: 'local' });
+
+    expect(mockGetRailwayDatabaseUrl).not.toHaveBeenCalled();
+    const call = mockExecFileSync.mock.calls[0];
+    expect(call[2].env.DATABASE_URL).toBe('postgresql://localhost/db');
+  });
+
+  it('throws when env=local but DATABASE_URL is not set', async () => {
+    delete process.env.DATABASE_URL;
+
+    await expect(inspectTtsConfigs({ env: 'local' })).rejects.toThrow(
+      'DATABASE_URL not set in local environment'
+    );
+  });
+
+  it('throws on an invalid env value', async () => {
+    await expect(inspectTtsConfigs({ env: 'staging' as unknown as 'dev' })).rejects.toThrow(
+      'Invalid env: staging'
+    );
+  });
+});

--- a/packages/tooling/src/inspect/tts-configs.ts
+++ b/packages/tooling/src/inspect/tts-configs.ts
@@ -1,0 +1,108 @@
+/**
+ * TTS Configs Inspection
+ *
+ * List all `tts_configs` rows for a given environment. Useful for:
+ * - Debugging cross-env ID drift (system-globals + BYOK rows)
+ * - Verifying recovery scripts (`align-byok-tts-configs`, etc.) ran correctly
+ * - Auditing the bot owner's configs against expected state
+ */
+
+import chalk from 'chalk';
+import { execFileSync } from 'node:child_process';
+
+import type { Environment } from '../utils/env-runner.js';
+import { getRailwayDatabaseUrl, getRailwayEnvName } from '../utils/env-runner.js';
+
+interface InspectTtsConfigsOptions {
+  env: Environment;
+}
+
+const TAKE_LIMIT = 200;
+
+/**
+ * Build the env vars for executing the inspector against the requested env's DB.
+ * For 'local', we use the local DATABASE_URL; for 'dev'/'prod', we fetch the
+ * Railway DATABASE_PUBLIC_URL via railway CLI.
+ */
+function resolveDatabaseUrl(env: Environment): string {
+  if (env === 'local') {
+    const local = process.env.DATABASE_URL;
+    if (local === undefined || local.length === 0) {
+      throw new Error('DATABASE_URL not set in local environment');
+    }
+    return local;
+  }
+  return getRailwayDatabaseUrl(env);
+}
+
+/**
+ * Run `tsx` to execute the inspection logic in a child process with the
+ * requested environment's DATABASE_URL injected. We do this via subprocess
+ * (rather than importing Prisma directly) for two reasons:
+ *
+ * 1. Prisma's adapter binds to DATABASE_URL at construction time — running
+ *    the query in-process would require either re-instantiation or env
+ *    mutation, both fragile across multiple inspections.
+ * 2. The subprocess pattern matches how other ops commands (db:migrate,
+ *    db:status) inject Railway URLs — consistent with the rest of the
+ *    tooling package.
+ */
+export async function inspectTtsConfigs(options: InspectTtsConfigsOptions): Promise<void> {
+  const env = options.env;
+  if (env !== 'local' && env !== 'dev' && env !== 'prod') {
+    throw new Error(`Invalid env: ${String(env)}`);
+  }
+
+  const railwayLabel = env === 'local' ? 'LOCAL' : getRailwayEnvName(env).toUpperCase();
+  console.log(chalk.cyan(`\n🗄️  Environment: ${railwayLabel}`));
+  console.log(chalk.dim('────────────────────────────────────────\n'));
+
+  const databaseUrl = resolveDatabaseUrl(env);
+  const inlineScript = buildInspectorScript(TAKE_LIMIT);
+
+  // Run via `tsx -e`. cwd inherits from the parent process — in normal
+  // pnpm-workspace usage that's the repo root, where `@tzurot/common-types`
+  // resolves via the hoisted `node_modules/`. Invoking from outside the
+  // workspace will fail to resolve the import.
+  execFileSync('tsx', ['-e', inlineScript], {
+    stdio: 'inherit',
+    env: { ...process.env, DATABASE_URL: databaseUrl },
+    cwd: process.cwd(),
+  });
+}
+
+/**
+ * Build the inline tsx script that runs against the supplied DATABASE_URL.
+ * Kept pure (no closures over caller state) so the output is deterministic
+ * and easy to test.
+ */
+export function buildInspectorScript(takeLimit: number): string {
+  return `
+import { getPrismaClient, disconnectPrisma } from '@tzurot/common-types';
+
+async function main() {
+  const prisma = getPrismaClient();
+  try {
+    const rows = await prisma.ttsConfig.findMany({
+      select: { id: true, ownerId: true, name: true, isGlobal: true, provider: true },
+      orderBy: [{ name: 'asc' }],
+      take: ${takeLimit},
+    });
+    for (const r of rows) {
+      const owner = r.ownerId.slice(0, 8);
+      const global = r.isGlobal ? 'Y' : 'N';
+      const provider = r.provider.padEnd(12);
+      console.log(\`\${r.id}  owner=\${owner}..  global=\${global}  provider=\${provider}  name=\${r.name}\`);
+    }
+    console.log(\`\\nTotal: \${rows.length} rows\`);
+    if (rows.length === ${takeLimit}) {
+      console.warn('⚠️  Result may be truncated at the ' + ${takeLimit} + '-row take limit — re-run with a higher limit if you need to see all rows');
+    }
+  } finally {
+    await disconnectPrisma();
+  }
+}
+
+await main();
+`.trim();
+}

--- a/scripts/src/align-byok-tts-configs.ts
+++ b/scripts/src/align-byok-tts-configs.ts
@@ -1,0 +1,94 @@
+/**
+ * Align migration-seeded BYOK TTS config rows to deterministic UUIDs.
+ *
+ * Targets rows created by migration `20260502185237_add_tts_configs_cascade`
+ * (lines 145-160) — the one-shot data seed that auto-migrated users with
+ * legacy `elevenlabsTtsModel` JSONB to dedicated tts_configs rows named
+ * `tts-byok-{discordId}`. Each env ran the migration independently with
+ * `gen_random_uuid()`, so dev and prod ended up with different IDs for
+ * the same logical row → /admin db-sync collision on
+ * `tts_configs_owner_id_name_key`.
+ *
+ * This script is idempotent: rows already at the deterministic UUID are
+ * skipped. Safe to run multiple times. ON UPDATE CASCADE on every FK to
+ * tts_configs.id propagates the id change automatically (verified in
+ * PR #969's int-test suite).
+ *
+ * Why a script instead of a SQL migration:
+ * - `uuid-ossp` is not enabled in the codebase or pglite, so per-row
+ *   uuidv5 computation in SQL would require new infrastructure.
+ * - Future fresh DBs don't have these rows (the migration's WHERE clause
+ *   only fires for users with legacy JSONB), so no migration-history
+ *   tracking is needed.
+ * - Strong precedent: `scripts/src/db/fix-phantom-migration.ts` uses the
+ *   same one-shot ops-script pattern for data fixes.
+ *
+ * Run via:
+ *   pnpm ops run --env dev tsx scripts/src/align-byok-tts-configs.ts
+ *   pnpm ops run --env prod --force tsx scripts/src/align-byok-tts-configs.ts
+ */
+import { getPrismaClient, disconnectPrisma, generateByokTtsConfigUuid } from '@tzurot/common-types';
+
+async function main(): Promise<void> {
+  const prisma = getPrismaClient();
+  try {
+    const TAKE_LIMIT = 10_000;
+    const rows = await prisma.ttsConfig.findMany({
+      where: {
+        name: { startsWith: 'tts-byok-' },
+        // Explicit guard — system-globals (isGlobal: true) are aligned by
+        // migration 20260504140720 from PR #969 and never have a name
+        // starting with `tts-byok-` anyway. Belt-and-suspenders.
+        isGlobal: false,
+      },
+      select: { id: true, ownerId: true, name: true, provider: true },
+      // Bounded per `03-database.md` (CRITICAL rule). Real-world expected
+      // row count is one per BYOK user — even at scale this should never
+      // approach 10k. Sentinel below catches a runaway count before silent
+      // truncation.
+      take: TAKE_LIMIT,
+    });
+    if (rows.length === TAKE_LIMIT) {
+      throw new Error(
+        `Hit findMany take limit (${TAKE_LIMIT}) — re-run after investigating row count`
+      );
+    }
+
+    console.log(`Found ${rows.length} tts-byok-* rows`);
+
+    // Wrapped in a transaction so a mid-run failure rolls back partial
+    // updates. Idempotency makes re-running safe regardless, but atomicity
+    // means an inspector after a failure shows the pre-run state, not a
+    // confusing mix.
+    const { updated, skipped } = await prisma.$transaction(async tx => {
+      let updated = 0;
+      let skipped = 0;
+      for (const row of rows) {
+        const targetId = generateByokTtsConfigUuid(row.ownerId, row.provider);
+        if (row.id === targetId) {
+          skipped++;
+          continue;
+        }
+        // Parameterized via Prisma's tagged-template raw SQL — both targetId
+        // and row.id are bind parameters, not string-interpolated.
+        await tx.$executeRaw`
+          UPDATE "tts_configs"
+          SET "id" = ${targetId}::uuid,
+              "updated_at" = NOW()
+          WHERE "id" = ${row.id}::uuid
+        `;
+        console.log(
+          `  ${row.name}: ${row.id.slice(0, 8)} → ${targetId.slice(0, 8)} (provider=${row.provider})`
+        );
+        updated++;
+      }
+      return { updated, skipped };
+    });
+
+    console.log(`\nUpdated: ${updated}; already aligned: ${skipped}`);
+  } finally {
+    await disconnectPrisma();
+  }
+}
+
+await main();


### PR DESCRIPTION
## Summary

Follow-up to PR #969 — fixes a SECOND class of tts_configs ID drift that surfaced after the system-globals fix landed. `/admin db-sync` continued failing with `Code: 23505 duplicate key value violates unique constraint "tts_configs_owner_id_name_key"` because a 4th row pattern, `tts-byok-{discordId}`, was created by the one-shot migration `20260502185237` (lines 145-160) using `gen_random_uuid()` — each env got different UUIDs for the same logical row.

This PR ships the structural fix per the user's directive ("I want the structural fix. I don't like deferring things like this"):

1. **`generateByokTtsConfigUuid(ownerId, provider)`** + symmetric LLM helper in `packages/common-types/src/utils/deterministicUuid.ts` — uuidv5 derived from `(ownerId, provider)`. The provider field is fixed for the row's lifetime; the name is mutable. Mirrors the system-globals pattern from PR #969.
2. **`scripts/src/align-byok-tts-configs.ts`** — one-shot recovery script that aligns existing `tts-byok-*` rows to deterministic UUIDs. Idempotent, transaction-wrapped. ON UPDATE CASCADE handles FK propagation. Run via `pnpm ops run --env <env> tsx scripts/src/align-byok-tts-configs.ts`.
3. **`packages/tooling/src/inspect/tts-configs.ts`** — persistent `pnpm ops inspect:tts-configs` diagnostic (created today during debugging, scope expanded beyond one-shot, moved from `scripts/` to `tooling/` per `05-tooling.md`).

## Class-of-problem audit

3 Explore agents audited every random-UUID row-creation site in the synced tables. Findings:
- **11 sites** correctly use deterministic UUIDs already (`generateUserUuid`, `generatePersonalityUuid`, etc.)
- **2 sites** were correctly UUIDv7 (user-action-triggered with mutable names)
- **1 site** was the system-globals (fixed in PR #969)
- **1 site** is this BYOK migration (fixed by this PR)

No other auto-named-but-random-UUID sites are lurking. The audit closes the gap structurally.

## Why ops script not SQL migration

- `uuid-ossp` is NOT enabled in the codebase (verified via grep across all migrations) and not bundled in pglite, so per-row uuidv5 in SQL would need new extension infrastructure.
- Future fresh DBs don't have these rows: the original migration's WHERE clause (`u.config_defaults ? 'elevenlabsTtsModel'`) only fires for users with legacy JSONB. Nothing to migrate on a fresh DB.
- Strong precedent: `scripts/src/db/fix-phantom-migration.ts` uses the same one-shot ops-script pattern.

## Test plan

- [x] `pnpm test` — all packages green
- [x] `pnpm quality` — 11/11 tasks green
- [x] Pinned-value tests on the helpers (cross-pinning pattern from PR #969 — helper output ↔ recovery script ↔ database consistency)
- [ ] CI green before merge
- [ ] Post-merge: `pnpm ops run --env dev tsx scripts/src/align-byok-tts-configs.ts`
- [ ] Post-merge: `pnpm ops run --env prod --force tsx scripts/src/align-byok-tts-configs.ts` (with explicit user approval)
- [ ] Post-recovery: `/admin db-sync` from Discord — confirm the `tts_configs_owner_id_name_key` collision is gone
- [ ] **After both env runs verified successful**: delete `scripts/src/align-byok-tts-configs.ts` and commit to develop (per `05-tooling.md` — `scripts/` is for one-shot scripts that run once and are deleted)

## Why this is the structural fix

Root cause addressed (helper exists with documented derivation rationale), existing data aligned (recovery script for dev + prod), audit-confirmed no other sites lurk, JSDoc cross-references the rename-collision lesson so future engineers don't re-discover.

**What this PR deliberately does NOT include**: no service-layer changes (the BYOK migration was one-shot — no active flow needs updating), no name-pattern guard (user-created configs named `tts-byok-anything` would correctly fall into UUIDv7 territory), no SQL migration (fresh DBs don't have these rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
