### PR TITLE
fix(ai-worker): tighten TTS fallback semantics + Mistral 30s pre-flight

### DIFF
--- a/services/ai-worker/src/services/voice/MistralTtsClient.test.ts
+++ b/services/ai-worker/src/services/voice/MistralTtsClient.test.ts
@@ -7,8 +7,10 @@ import {
   mistralListVoices,
   mistralDeleteVoice,
   MistralApiError,
+  MistralReferenceAudioTooLongError,
   MistralResponseShapeError,
   MistralTimeoutError,
+  MISTRAL_MAX_REFERENCE_AUDIO_SEC,
 } from './MistralTtsClient.js';
 
 // We mock global fetch directly — MistralTtsClient uses it without an HTTP
@@ -406,5 +408,28 @@ describe('MistralResponseShapeError', () => {
     const shape = new MistralResponseShapeError('/v1/audio/speech', 'audio_data');
     expect(shape).toBeInstanceOf(MistralResponseShapeError);
     expect(shape).not.toBeInstanceOf(MistralApiError);
+  });
+});
+
+// ===== MistralReferenceAudioTooLongError ====================================
+
+describe('MistralReferenceAudioTooLongError', () => {
+  it('carries durationSec and limitSec on the error instance', () => {
+    const err = new MistralReferenceAudioTooLongError(31.78);
+    expect(err.durationSec).toBeCloseTo(31.78, 5);
+    expect(err.limitSec).toBe(MISTRAL_MAX_REFERENCE_AUDIO_SEC);
+    expect(err.message).toMatch(/31\.78s/);
+    expect(err.message).toMatch(/30\.0s/);
+  });
+
+  it('flags as non-transient (deterministic from input — retry would fail again)', () => {
+    expect(new MistralReferenceAudioTooLongError(35).isTransient).toBe(false);
+  });
+
+  it('is a separate class from MistralApiError (instanceof discrimination)', () => {
+    const tooLong = new MistralReferenceAudioTooLongError(40);
+    expect(tooLong).toBeInstanceOf(MistralReferenceAudioTooLongError);
+    expect(tooLong).not.toBeInstanceOf(MistralApiError);
+    expect(tooLong).not.toBeInstanceOf(MistralResponseShapeError);
   });
 });

--- a/services/ai-worker/src/services/voice/MistralTtsClient.ts
+++ b/services/ai-worker/src/services/voice/MistralTtsClient.ts
@@ -42,6 +42,16 @@ const MISTRAL_FAST_TIMEOUT_MS = 15_000;
 /** Default page size for list voices. Smoke test confirmed 50 works. */
 const VOICE_LIST_PAGE_SIZE = 50;
 
+/**
+ * Mistral's `/v1/audio/voices` (clone) endpoint rejects reference audio with
+ * duration > 30s using HTTP 400 ("Reference audio duration {N}s exceeds the
+ * maximum allowed duration of 30.0s"). The provider pre-flight-checks this
+ * locally to avoid the wasted round-trip + negative-cache poisoning that the
+ * reactive path produces. Empirically observed in prod 2026-05-04 via the
+ * `ha-shem-keev-ima` slug (31.78s reference).
+ */
+export const MISTRAL_MAX_REFERENCE_AUDIO_SEC = 30;
+
 // ============================================================================
 // Public types
 // ============================================================================
@@ -143,6 +153,34 @@ export class MistralResponseShapeError extends Error {
 
   /** Transient: response-shape failures may stabilize on retry. */
   readonly isTransient = true;
+}
+
+/**
+ * Pre-flight rejection: the supplied reference audio exceeds Mistral's
+ * documented 30s limit, so calling the clone endpoint would deterministically
+ * return HTTP 400. Caller should skip Mistral and fall through to self-hosted
+ * without the wasted round-trip. Carries `durationSec` for structured logging.
+ *
+ * `isTransient = false`: the failure is deterministic from input, so the
+ * negative-cache (which exists to suppress retry storms on transient failures)
+ * adds nothing — re-running with the same reference will hit this same
+ * pre-flight check.
+ */
+export class MistralReferenceAudioTooLongError extends Error {
+  readonly durationSec: number;
+  readonly limitSec: number;
+
+  constructor(durationSec: number, limitSec: number = MISTRAL_MAX_REFERENCE_AUDIO_SEC) {
+    super(
+      `Mistral reference audio duration ${durationSec.toFixed(2)}s exceeds the maximum allowed duration of ${limitSec.toFixed(1)}s`
+    );
+    this.name = 'MistralReferenceAudioTooLongError';
+    this.durationSec = durationSec;
+    this.limitSec = limitSec;
+    Object.setPrototypeOf(this, MistralReferenceAudioTooLongError.prototype);
+  }
+
+  readonly isTransient = false;
 }
 
 // ============================================================================

--- a/services/ai-worker/src/services/voice/TtsDispatcher.test.ts
+++ b/services/ai-worker/src/services/voice/TtsDispatcher.test.ts
@@ -12,6 +12,7 @@ import {
   type TtsProviderId,
 } from '@tzurot/common-types';
 import { dispatchTts, TtsDispatchError, type TtsProviderRegistry } from './TtsDispatcher.js';
+import { MistralReferenceAudioTooLongError } from './MistralTtsClient.js';
 
 // ===== Test fixtures ========================================================
 
@@ -225,15 +226,98 @@ describe('dispatchTts — chain construction', () => {
     expect(failingSelfHosted.synthesize).toHaveBeenCalledTimes(1);
   });
 
-  it('tries all available BYOK providers before self-hosted', async () => {
+  it('self-hosted primary with paid keys present does NOT fall back to paid (no implicit BYOK billing)', async () => {
+    // Symmetric to the paid-primary tests: a user whose primary is self-hosted
+    // does not implicitly opt into ANY paid provider's billing, even if their
+    // BYOK keys for Mistral/ElevenLabs are configured. With audioKeysEmpty the
+    // BYOK key check would filter paid providers anyway — this test uses
+    // audioKeysWithBoth so the gate is the chain-shape rule itself, not the
+    // key-availability filter.
+    const failingSelfHosted = makeProvider('self-hosted', {
+      synthesize: vi.fn(async () => {
+        throw new TtsProviderError(ApiErrorCategory.SERVER_ERROR, 'self-hosted', true, '503');
+      }),
+    });
+    const mistral = makeProvider('mistral');
+    const elevenLabs = makeProvider('elevenlabs');
+
+    await expect(
+      dispatchTts({
+        text: 'hi',
+        resolvedConfig: selfHostedConfig,
+        ctx: baseCtx,
+        audioProviderKeys: audioKeysWithBoth,
+        registry: makeRegistry([failingSelfHosted, mistral, elevenLabs]),
+      })
+    ).rejects.toBeInstanceOf(TtsDispatchError);
+
+    expect(failingSelfHosted.synthesize).toHaveBeenCalledTimes(1);
+    expect(mistral.synthesize).not.toHaveBeenCalled();
+    expect(elevenLabs.synthesize).not.toHaveBeenCalled();
+  });
+
+  it('paid primary failure falls through to self-hosted only (skips other paid)', async () => {
+    // Paid → free only: Mistral fails, ElevenLabs MUST NOT be tried even if
+    // available, self-hosted picks up. Cross-paid fallback would produce
+    // unexpected billing for users who configured only Mistral.
     const mistralFails = makeProvider('mistral', {
       synthesize: vi.fn(async () => {
         throw new TtsProviderError(ApiErrorCategory.RATE_LIMIT, 'mistral', true, '429');
       }),
     });
+    const elevenLabs = makeProvider('elevenlabs');
+    const selfHosted = makeProvider('self-hosted');
+
+    const result = await dispatchTts({
+      text: 'hi',
+      resolvedConfig: mistralConfig,
+      ctx: baseCtx,
+      audioProviderKeys: audioKeysWithBoth,
+      registry: makeRegistry([mistralFails, elevenLabs, selfHosted]),
+    });
+
+    expect(mistralFails.synthesize).toHaveBeenCalledTimes(1);
+    expect(elevenLabs.synthesize).not.toHaveBeenCalled();
+    expect(selfHosted.synthesize).toHaveBeenCalledTimes(1);
+    expect(result.providerUsed).toBe('self-hosted');
+    expect(result.usedFallback).toBe(true);
+  });
+
+  it('paid primary failure (ElevenLabs side) also skips other paid (symmetry check)', async () => {
+    // Documents the symmetric "paid → free only" rule: ElevenLabs primary
+    // failure must NOT cascade through Mistral. Locks in the "vice versa"
+    // claim in buildFallbackChain's docstring.
     const elevenFails = makeProvider('elevenlabs', {
       synthesize: vi.fn(async () => {
         throw new TtsProviderError(ApiErrorCategory.RATE_LIMIT, 'elevenlabs', true, '429');
+      }),
+    });
+    const mistral = makeProvider('mistral');
+    const selfHosted = makeProvider('self-hosted');
+
+    const result = await dispatchTts({
+      text: 'hi',
+      resolvedConfig: elevenlabsConfig,
+      ctx: baseCtx,
+      audioProviderKeys: audioKeysWithBoth,
+      registry: makeRegistry([elevenFails, mistral, selfHosted]),
+    });
+
+    expect(elevenFails.synthesize).toHaveBeenCalledTimes(1);
+    expect(mistral.synthesize).not.toHaveBeenCalled();
+    expect(selfHosted.synthesize).toHaveBeenCalledTimes(1);
+    expect(result.providerUsed).toBe('self-hosted');
+    expect(result.usedFallback).toBe(true);
+  });
+
+  it('non-TtsProviderError from prepare() (e.g. MistralReferenceAudioTooLongError) falls through to self-hosted', async () => {
+    // Documents the dispatcher's catch-block contract: anything that is not
+    // a `TtsProviderError + !isFallbackEligible` returns `{ kind: 'failed' }`
+    // and the chain continues. MistralReferenceAudioTooLongError is the
+    // motivating case (deterministic input-shape rejection from pre-flight).
+    const mistralRejects = makeProvider('mistral', {
+      prepare: vi.fn(async () => {
+        throw new MistralReferenceAudioTooLongError(31.78);
       }),
     });
     const selfHosted = makeProvider('self-hosted');
@@ -243,13 +327,50 @@ describe('dispatchTts — chain construction', () => {
       resolvedConfig: mistralConfig,
       ctx: baseCtx,
       audioProviderKeys: audioKeysWithBoth,
-      registry: makeRegistry([mistralFails, elevenFails, selfHosted]),
+      registry: makeRegistry([mistralRejects, selfHosted]),
     });
 
-    // Walk: mistral (primary, fails) → elevenlabs (fails) → self-hosted (success)
-    expect(mistralFails.synthesize).toHaveBeenCalledTimes(1);
-    expect(elevenFails.synthesize).toHaveBeenCalledTimes(1);
+    expect(mistralRejects.prepare).toHaveBeenCalledTimes(1);
+    expect(selfHosted.synthesize).toHaveBeenCalledTimes(1);
     expect(result.providerUsed).toBe('self-hosted');
+    expect(result.usedFallback).toBe(true);
+  });
+
+  it('fallback ctx drops the primary provider modelId (regression: cross-provider leak)', async () => {
+    // The primary's modelId is provider-specific and meaningless to fallbacks
+    // (handing Mistral's "voxtral-mini-tts-2603" to ElevenLabs causes a 400).
+    // The synthetic config on `attemptCandidate` already drops modelId from
+    // the resolved-config side; this test locks the parallel ctx-path fix.
+    const mistralFails = makeProvider('mistral', {
+      synthesize: vi.fn(async () => {
+        throw new TtsProviderError(ApiErrorCategory.RATE_LIMIT, 'mistral', true, '429');
+      }),
+    });
+    const selfHosted = makeProvider('self-hosted');
+
+    const ctxWithModelId: TtsContext = {
+      slug: 'emily',
+      modelId: 'voxtral-mini-tts-latest', // Mistral-specific
+    };
+
+    await dispatchTts({
+      text: 'hi',
+      resolvedConfig: mistralConfig,
+      ctx: ctxWithModelId,
+      audioProviderKeys: audioKeysWithBoth,
+      registry: makeRegistry([mistralFails, selfHosted]),
+    });
+
+    // Mistral primary attempt SHOULD see the original modelId
+    const mistralPrepareCall = (mistralFails.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(mistralPrepareCall.modelId).toBe('voxtral-mini-tts-latest');
+
+    // Self-hosted fallback attempt MUST NOT see the Mistral modelId
+    const selfHostedPrepareCall = (selfHosted.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(selfHostedPrepareCall.modelId).toBeUndefined();
+    const selfHostedSynthesizeCtx = (selfHosted.synthesize as ReturnType<typeof vi.fn>).mock
+      .calls[0][2];
+    expect(selfHostedSynthesizeCtx.modelId).toBeUndefined();
   });
 
   it('throws TtsDispatchError when no providers available', async () => {

--- a/services/ai-worker/src/services/voice/TtsDispatcher.ts
+++ b/services/ai-worker/src/services/voice/TtsDispatcher.ts
@@ -11,15 +11,20 @@
  *
  * Walk semantics:
  *
- *   1. Build the chain: `[primary, ...remaining-available, self-hosted]`,
- *      deduped and filtered by `isAvailable(ctx)`. Self-hosted is always
- *      appended last as the safety net (assuming VOICE_ENGINE_URL is set —
- *      registry omits it otherwise).
+ *   1. Build the chain: `[primary, self-hosted]`, deduped and filtered by
+ *      `isAvailable(ctx)`. Self-hosted is the only safety-net fallback —
+ *      cross-paid fallbacks (Mistral → ElevenLabs and vice versa) are
+ *      deliberately excluded so a user who configured one paid provider
+ *      doesn't get billed by the other. If primary IS self-hosted, the
+ *      chain is just `[self-hosted]` (no fallback). If `VOICE_ENGINE_URL`
+ *      is unset, the registry omits self-hosted and the chain may be just
+ *      `[primary]` or empty.
  *
  *   2. For each candidate, call `prepare()` then `synthesize()`. The primary
- *      candidate sees the real `ResolvedTtsConfig`; fallback candidates see a
- *      synthetic "self-named" config (the resolved config's `modelId` and
- *      `advancedParameters` only apply to its own provider).
+ *      candidate sees the real `ResolvedTtsConfig` and the original
+ *      `ctx.modelId`; fallback candidates see a synthetic "self-named" config
+ *      AND a sanitized ctx (no modelId) — provider-specific model identifiers
+ *      and advanced params don't cross provider boundaries.
  *
  *   3. On any error:
  *      - If the error is a `TtsProviderError` with `isFallbackEligible: false`
@@ -126,21 +131,20 @@ function describeError(error: unknown): string {
 /**
  * Build the ordered list of provider ids the dispatcher will attempt.
  *
- * Order:
- *   1. Primary (from resolved config) if available
- *   2. Other registered providers in registration order, available, not equal to primary
- *   3. `self-hosted` always last (deduped — if it's already in the list it stays at its earlier position)
+ * Rule: paid → free only. The chain is at most `[primary, self-hosted]`,
+ * deduped — if primary IS self-hosted, the chain is `[self-hosted]` with
+ * no fallback. Cross-paid fallbacks (Mistral → ElevenLabs or vice versa)
+ * are deliberately excluded: a user who configured Mistral did not opt
+ * into ElevenLabs billing, and vice versa.
  *
- * `isAvailable` and BYOK key presence are checked here so the walk loop is
- * a clean iteration.
+ * Symmetrically, a user whose primary is self-hosted does not implicitly
+ * opt into ANY paid provider — self-hosted-primary configurations have no
+ * fallback (the chain is just `[self-hosted]`).
  *
- * Note: if the primary provider is unavailable, the walk continues to BYOK
- * providers the user has configured, then self-hosted. A user whose primary
- * is self-hosted and whose `VOICE_ENGINE_URL` is unset will fall back to
- * BYOK providers (Mistral / ElevenLabs) if they have keys configured —
- * intentional graceful degradation, but callers should be aware that a
- * self-hosted-primary configuration can produce BYOK synthesis when the
- * voice-engine is misconfigured.
+ * If the primary is BYOK and unavailable (no key, isAvailable returns false),
+ * the chain falls through to `[self-hosted]` only. If self-hosted is also
+ * unavailable (VOICE_ENGINE_URL unset), the chain is empty and dispatchTts
+ * raises a structured error explaining why.
  */
 function buildFallbackChain(
   resolvedConfig: ResolvedTtsConfig,
@@ -159,7 +163,8 @@ function buildFallbackChain(
         return false;
       }
     }
-    return provider.isAvailable(buildCtxForProvider(ctx, id, audioProviderKeys));
+    const isPrimaryAttempt = id === resolvedConfig.provider;
+    return provider.isAvailable(buildCtxForProvider(ctx, id, audioProviderKeys, isPrimaryAttempt));
   };
 
   const chain: TtsProviderId[] = [];
@@ -173,11 +178,6 @@ function buildFallbackChain(
   };
 
   add(resolvedConfig.provider);
-  for (const id of registry.listProviderIds()) {
-    if (id !== SELF_HOSTED) {
-      add(id);
-    }
-  }
   add(SELF_HOSTED);
 
   return chain;
@@ -188,18 +188,28 @@ function buildFallbackChain(
  * provider-specific BYOK key if applicable. The caller-supplied ctx may carry
  * a `byokKey` set for the primary provider; for fallback providers we look up
  * their own key from the audioProviderKeys map (or leave it undefined).
+ *
+ * `modelId` is only forwarded on the primary attempt. Provider-specific model
+ * identifiers don't cross provider boundaries — handing Mistral's
+ * `voxtral-mini-tts-2603` to ElevenLabs causes a 400. `buildSyntheticConfigFor`
+ * already drops modelId from the fallback's `ResolvedTtsConfig`; this closes
+ * the parallel ctx-path leak (provider implementations read `ctx.modelId`,
+ * not `config.modelId`, so both paths must be sanitized).
  */
 function buildCtxForProvider(
   baseCtx: TtsContext,
   providerId: TtsProviderId,
-  audioProviderKeys: ReadonlyMap<AudioProviderId, string>
+  audioProviderKeys: ReadonlyMap<AudioProviderId, string>,
+  isPrimaryAttempt: boolean
 ): TtsContext {
+  const modelId = isPrimaryAttempt ? baseCtx.modelId : undefined;
+
   if (!BYOK_PROVIDERS.has(providerId)) {
-    return { slug: baseCtx.slug, modelId: baseCtx.modelId };
+    return { slug: baseCtx.slug, modelId };
   }
   const audioId = TTS_TO_AUDIO_PROVIDER.get(providerId);
   const byokKey = audioId !== undefined ? audioProviderKeys.get(audioId) : undefined;
-  return { slug: baseCtx.slug, modelId: baseCtx.modelId, byokKey };
+  return { slug: baseCtx.slug, modelId, byokKey };
 }
 
 /**
@@ -248,7 +258,7 @@ async function attemptCandidate(input: AttemptInput): Promise<AttemptOutcome> {
   }
 
   const candidateConfig = isPrimaryAttempt ? resolvedConfig : buildSyntheticConfigFor(candidateId);
-  const candidateCtx = buildCtxForProvider(ctx, candidateId, audioProviderKeys);
+  const candidateCtx = buildCtxForProvider(ctx, candidateId, audioProviderKeys, isPrimaryAttempt);
 
   // Defensive backstop — `buildFallbackChain` already filters by `isAvailable`
   // and fallback synthetic configs name the candidate provider, so `canHandle`

--- a/services/ai-worker/src/services/voice/providers/MistralTtsProvider.test.ts
+++ b/services/ai-worker/src/services/voice/providers/MistralTtsProvider.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MistralTtsProvider } from './MistralTtsProvider.js';
-import { MistralApiError } from '../MistralTtsClient.js';
+import {
+  MistralApiError,
+  MistralReferenceAudioTooLongError,
+  MISTRAL_MAX_REFERENCE_AUDIO_SEC,
+} from '../MistralTtsClient.js';
 
 vi.mock('../MistralTtsClient.js', async importOriginal => {
   const actual = await importOriginal<typeof import('../MistralTtsClient.js')>();
@@ -155,6 +159,90 @@ describe('MistralTtsProvider', () => {
       const handle = await provider.prepare({ slug: 'emily', byokKey: 'sk-test' });
 
       expect(handle).toMatchObject({ kind: 'voiceId', id: 'voice-new' });
+    });
+  });
+
+  describe('prepare — reference-audio pre-flight (30s limit)', () => {
+    it('throws MistralReferenceAudioTooLongError when reference exceeds 30s, without calling clone', async () => {
+      mockedListVoices.mockResolvedValueOnce([]); // no existing voice → would clone
+      mockedFetchVoiceReference.mockResolvedValueOnce({
+        audioBuffer: Buffer.from('reference-audio-bytes'),
+        contentType: 'audio/wav',
+        durationSec: 31.78, // recreating the prod incident shape
+      });
+
+      const promise = provider.prepare({ slug: 'ha-shem-keev-ima', byokKey: 'sk-test' });
+
+      const error = await promise.catch(e => e);
+      expect(error).toBeInstanceOf(MistralReferenceAudioTooLongError);
+      expect((error as MistralReferenceAudioTooLongError).durationSec).toBeCloseTo(31.78, 5);
+      expect((error as MistralReferenceAudioTooLongError).limitSec).toBe(
+        MISTRAL_MAX_REFERENCE_AUDIO_SEC
+      );
+      expect(mockedCloneVoice).not.toHaveBeenCalled();
+    });
+
+    it('proceeds to clone when reference is under the 30s limit', async () => {
+      mockedListVoices.mockResolvedValueOnce([]);
+      mockedFetchVoiceReference.mockResolvedValueOnce({
+        audioBuffer: Buffer.from('reference-audio-bytes'),
+        contentType: 'audio/wav',
+        durationSec: 12.3,
+      });
+      mockedCloneVoice.mockResolvedValueOnce({
+        id: 'voice-new',
+        name: 'tzurot-emily',
+        userId: null,
+      });
+
+      const handle = await provider.prepare({ slug: 'emily', byokKey: 'sk-test' });
+
+      expect(handle).toMatchObject({ kind: 'voiceId', id: 'voice-new' });
+      expect(mockedCloneVoice).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls through to reactive path when durationSec is undefined (unrecognized format)', async () => {
+      // mp3/ogg/m4a aren't parsed locally — fall through to whatever Mistral
+      // returns. This locks in the "advisory, not authoritative" semantics.
+      mockedListVoices.mockResolvedValueOnce([]);
+      mockedFetchVoiceReference.mockResolvedValueOnce({
+        audioBuffer: Buffer.from('reference-audio-bytes'),
+        contentType: 'audio/mpeg',
+        durationSec: undefined,
+      });
+      mockedCloneVoice.mockResolvedValueOnce({
+        id: 'voice-new',
+        name: 'tzurot-emily',
+        userId: null,
+      });
+
+      await provider.prepare({ slug: 'emily', byokKey: 'sk-test' });
+
+      expect(mockedCloneVoice).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not negative-cache the deterministic too-long failure (re-prepare hits pre-flight again, not cache)', async () => {
+      mockedListVoices.mockResolvedValue([]);
+      mockedFetchVoiceReference.mockResolvedValue({
+        audioBuffer: Buffer.from('reference-audio-bytes'),
+        contentType: 'audio/wav',
+        durationSec: 35,
+      });
+
+      // First call fails pre-flight
+      await provider
+        .prepare({ slug: 'too-long-slug', byokKey: 'sk-test' })
+        .catch((): void => undefined);
+
+      // Second call also fails pre-flight (not the negative-cache message)
+      const error = await provider
+        .prepare({ slug: 'too-long-slug', byokKey: 'sk-test' })
+        .catch(e => e);
+
+      expect(error).toBeInstanceOf(MistralReferenceAudioTooLongError);
+      // If the negative cache had captured the first failure, the second call
+      // would throw a generic Error wrapping the cached `reason` string. The
+      // typed error confirms pre-flight ran cleanly both times.
     });
   });
 

--- a/services/ai-worker/src/services/voice/providers/MistralTtsProvider.ts
+++ b/services/ai-worker/src/services/voice/providers/MistralTtsProvider.ts
@@ -39,6 +39,8 @@ import {
   mistralListVoices,
   mistralTTS,
   MistralApiError,
+  MistralReferenceAudioTooLongError,
+  MISTRAL_MAX_REFERENCE_AUDIO_SEC,
 } from '../MistralTtsClient.js';
 import { fetchVoiceReference } from '../voiceReferenceHelper.js';
 
@@ -231,6 +233,19 @@ export class MistralTtsProvider implements TtsProvider {
         // Rate limit (429) is transient — don't poison the negative cache
         if (error instanceof MistralApiError && error.isRateLimited) {
           logger.warn({ slug, reason }, 'Mistral voice clone rate limited (not cached)');
+        } else if (error instanceof MistralReferenceAudioTooLongError) {
+          // Deterministic from input — the audio length isn't going to shrink
+          // on retry. Skip the negative cache (it would add nothing), and emit
+          // a structured WARN so log consumers can route this distinct case.
+          logger.warn(
+            {
+              event: 'mistral.referenceAudioTooLong',
+              slug,
+              durationSec: error.durationSec,
+              limitSec: error.limitSec,
+            },
+            'Mistral reference audio exceeds 30s limit — skipping clone; dispatcher will attempt fallback if available'
+          );
         } else {
           this.negativeCache.set(cacheKey, reason);
           logger.warn({ slug, reason }, 'Mistral voice clone failed — cached for 5 min');
@@ -264,7 +279,17 @@ export class MistralTtsProvider implements TtsProvider {
     }
 
     // Step 2: fetch reference audio from api-gateway
-    const { audioBuffer, contentType } = await fetchVoiceReference(slug);
+    const { audioBuffer, contentType, durationSec } = await fetchVoiceReference(slug);
+
+    // Step 2.5: pre-flight Mistral's 30s reference-audio limit. Cheaper to
+    // reject here than to round-trip the full base64 payload to Mistral and
+    // get a 400 back — and `MistralReferenceAudioTooLongError` carries
+    // structured fields for diagnostic logging at the catch site. Only
+    // applies when we could parse the duration; unrecognized formats fall
+    // through to the reactive path (Mistral returns 400 if too long).
+    if (durationSec !== undefined && durationSec > MISTRAL_MAX_REFERENCE_AUDIO_SEC) {
+      throw new MistralReferenceAudioTooLongError(durationSec);
+    }
 
     // Step 3: clone
     logger.info({ slug, audioSize: audioBuffer.length }, 'Cloning voice via Mistral');

--- a/services/ai-worker/src/services/voice/voiceReferenceHelper.test.ts
+++ b/services/ai-worker/src/services/voice/voiceReferenceHelper.test.ts
@@ -19,7 +19,35 @@ const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
 import { getConfig } from '@tzurot/common-types';
-import { fetchVoiceReference } from './voiceReferenceHelper.js';
+import { fetchVoiceReference, parseAudioDurationSec } from './voiceReferenceHelper.js';
+
+/**
+ * Build a minimal valid WAV buffer for tests. Returns a buffer with correct
+ * RIFF + fmt + data chunks at the supplied parameters.
+ */
+function makeWavBuffer(opts: {
+  sampleRate: number;
+  channels: number;
+  bitsPerSample: number;
+  dataBytes: number;
+}): Buffer {
+  const { sampleRate, channels, bitsPerSample, dataBytes } = opts;
+  const buf = Buffer.alloc(44 + dataBytes);
+  buf.write('RIFF', 0);
+  buf.writeUInt32LE(36 + dataBytes, 4);
+  buf.write('WAVE', 8);
+  buf.write('fmt ', 12);
+  buf.writeUInt32LE(16, 16); // PCM fmt subchunk size
+  buf.writeUInt16LE(1, 20); // audioFormat = PCM
+  buf.writeUInt16LE(channels, 22);
+  buf.writeUInt32LE(sampleRate, 24);
+  buf.writeUInt32LE(sampleRate * channels * (bitsPerSample / 8), 28); // byteRate
+  buf.writeUInt16LE(channels * (bitsPerSample / 8), 32); // blockAlign
+  buf.writeUInt16LE(bitsPerSample, 34);
+  buf.write('data', 36);
+  buf.writeUInt32LE(dataBytes, 40);
+  return buf;
+}
 
 const mockedGetConfig = vi.mocked(getConfig);
 
@@ -134,5 +162,206 @@ describe('fetchVoiceReference', () => {
       'http://localhost:3000/voice-references/slug%20with%20spaces%2Fand..%2Ftraversal',
       expect.any(Object)
     );
+  });
+
+  it('returns durationSec for WAV reference audio', async () => {
+    // 16 kHz mono 16-bit, 2.5s of audio = 16000 * 2 * 2.5 = 80000 data bytes
+    const wav = makeWavBuffer({
+      sampleRate: 16000,
+      channels: 1,
+      bitsPerSample: 16,
+      dataBytes: 80000,
+    });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      arrayBuffer: () =>
+        Promise.resolve(wav.buffer.slice(wav.byteOffset, wav.byteOffset + wav.byteLength)),
+      headers: new Headers({ 'content-type': 'audio/wav' }),
+    });
+
+    const result = await fetchVoiceReference('test-slug');
+
+    expect(result.durationSec).toBeCloseTo(2.5, 5);
+  });
+
+  it('returns undefined durationSec for non-WAV content type without RIFF magic', async () => {
+    const fakeAudio = Buffer.from([0xff, 0xfb, 0x90, 0x00]); // mp3-shaped bytes
+    mockFetch.mockResolvedValue({
+      ok: true,
+      arrayBuffer: () =>
+        Promise.resolve(
+          fakeAudio.buffer.slice(fakeAudio.byteOffset, fakeAudio.byteOffset + fakeAudio.byteLength)
+        ),
+      headers: new Headers({ 'content-type': 'audio/mpeg' }),
+    });
+
+    const result = await fetchVoiceReference('test-slug');
+
+    expect(result.durationSec).toBeUndefined();
+  });
+});
+
+describe('parseAudioDurationSec', () => {
+  it('computes duration from valid WAV at 16kHz mono 16-bit', () => {
+    // 30 seconds = 16000 samples/s * 1 channel * 2 bytes/sample * 30 = 960000 bytes
+    const wav = makeWavBuffer({
+      sampleRate: 16000,
+      channels: 1,
+      bitsPerSample: 16,
+      dataBytes: 960000,
+    });
+    expect(parseAudioDurationSec(wav, 'audio/wav')).toBeCloseTo(30, 5);
+  });
+
+  it('handles 31.78s reference (the prod incident shape)', () => {
+    // Recreating the ha-shem-keev-ima case: 31.78s at 16kHz mono 16-bit
+    const sampleRate = 16000;
+    const dataBytes = Math.round(sampleRate * 1 * 2 * 31.78);
+    const wav = makeWavBuffer({
+      sampleRate,
+      channels: 1,
+      bitsPerSample: 16,
+      dataBytes,
+    });
+    const duration = parseAudioDurationSec(wav, 'audio/wav');
+    expect(duration).toBeDefined();
+    expect(duration).toBeGreaterThan(30);
+    expect(duration).toBeCloseTo(31.78, 1);
+  });
+
+  it('handles stereo 44.1kHz 24-bit', () => {
+    // 5 seconds at 44100Hz stereo 24-bit = 44100 * 2 * 3 * 5 = 1323000 bytes
+    const wav = makeWavBuffer({
+      sampleRate: 44100,
+      channels: 2,
+      bitsPerSample: 24,
+      dataBytes: 1323000,
+    });
+    expect(parseAudioDurationSec(wav, 'audio/wav')).toBeCloseTo(5, 5);
+  });
+
+  it('detects WAV via RIFF magic when content-type is generic', () => {
+    const wav = makeWavBuffer({
+      sampleRate: 16000,
+      channels: 1,
+      bitsPerSample: 16,
+      dataBytes: 32000, // 1 second
+    });
+    expect(parseAudioDurationSec(wav, 'application/octet-stream')).toBeCloseTo(1, 5);
+  });
+
+  it('returns undefined for non-WAV content without RIFF/WAVE magic', () => {
+    const notWav = Buffer.from([
+      0xff, 0xfb, 0x90, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ]);
+    expect(parseAudioDurationSec(notWav, 'audio/mpeg')).toBeUndefined();
+  });
+
+  it('returns undefined for buffer too short to contain RIFF header', () => {
+    const tooShort = Buffer.from([0x52, 0x49]); // partial "RI"
+    expect(parseAudioDurationSec(tooShort, 'audio/wav')).toBeUndefined();
+  });
+
+  it('returns undefined when fmt chunk is missing', () => {
+    // RIFF + WAVE header but no fmt or data chunk
+    const buf = Buffer.alloc(12);
+    buf.write('RIFF', 0);
+    buf.writeUInt32LE(4, 4);
+    buf.write('WAVE', 8);
+    expect(parseAudioDurationSec(buf, 'audio/wav')).toBeUndefined();
+  });
+
+  it('returns undefined when byteRate is zero (corrupted fmt)', () => {
+    const wav = makeWavBuffer({
+      sampleRate: 16000,
+      channels: 1,
+      bitsPerSample: 16,
+      dataBytes: 100,
+    });
+    // Corrupt: zero out byteRate (file offset 28, 4 bytes — fmt chunk dataStart=20, +8 = 28)
+    wav.writeUInt32LE(0, 28);
+    expect(parseAudioDurationSec(wav, 'audio/wav')).toBeUndefined();
+  });
+
+  it('returns undefined when fmt chunk is truncated (header claims 16 bytes but buffer ends short)', () => {
+    // RIFF + WAVE + fmt header but the fmt subchunk extends past buffer end
+    const buf = Buffer.alloc(20);
+    buf.write('RIFF', 0);
+    buf.writeUInt32LE(12, 4);
+    buf.write('WAVE', 8);
+    buf.write('fmt ', 12);
+    buf.writeUInt32LE(16, 16); // claims 16 bytes of fmt payload, but buffer ends here
+    expect(parseAudioDurationSec(buf, 'audio/wav')).toBeUndefined();
+  });
+
+  it('handles word-aligned odd-size chunks before fmt (RIFF padding)', () => {
+    // Build a buffer with a JUNK chunk (odd size = 5) before fmt, exercising
+    // the +1 padding branch on `chunkSize % 2`. The walker should skip JUNK,
+    // honor the padding, and reach fmt + data correctly.
+    const junkPayload = 5;
+    const junkPadding = 1; // odd → +1 word-align byte
+    const fmtSize = 16;
+    const dataSize = 32000;
+    const buf = Buffer.alloc(12 + 8 + junkPayload + junkPadding + 8 + fmtSize + 8 + dataSize);
+
+    let off = 0;
+    buf.write('RIFF', off);
+    off += 4;
+    buf.writeUInt32LE(buf.length - 8, off);
+    off += 4;
+    buf.write('WAVE', off);
+    off += 4;
+
+    // JUNK chunk with odd payload size
+    buf.write('JUNK', off);
+    off += 4;
+    buf.writeUInt32LE(junkPayload, off);
+    off += 4;
+    off += junkPayload + junkPadding;
+
+    // fmt chunk
+    buf.write('fmt ', off);
+    off += 4;
+    buf.writeUInt32LE(fmtSize, off);
+    off += 4;
+    buf.writeUInt16LE(1, off); // audioFormat
+    buf.writeUInt16LE(1, off + 2); // channels
+    buf.writeUInt32LE(16000, off + 4); // sampleRate
+    buf.writeUInt32LE(32000, off + 8); // byteRate (16000 * 1 * 2)
+    buf.writeUInt16LE(2, off + 12); // blockAlign
+    buf.writeUInt16LE(16, off + 14); // bitsPerSample
+    off += fmtSize;
+
+    // data chunk
+    buf.write('data', off);
+    off += 4;
+    buf.writeUInt32LE(dataSize, off);
+
+    // 32000 dataBytes / 32000 byteRate = 1.0s
+    expect(parseAudioDurationSec(buf, 'audio/wav')).toBeCloseTo(1, 5);
+  });
+
+  it('uses the stored byteRate (correct for non-PCM audioFormat)', () => {
+    // Build a fmt chunk with derived-formula values that would produce a
+    // wrong duration if the parser computed byteRate locally. The stored
+    // byteRate field declares the true encoded rate.
+    //
+    // For ADPCM at 8kHz mono 4-bit: stored byteRate is sampleRate * 0.5 = 4000
+    // (each sample = 4 bits = 0.5 bytes). The naive formula
+    // (sampleRate * channels * bitsPerSample/8) = 8000 * 1 * 0.5 = 4000 happens
+    // to coincide here, so we use mismatched values to make the test discriminative.
+    const wav = makeWavBuffer({
+      sampleRate: 16000,
+      channels: 1,
+      bitsPerSample: 16,
+      dataBytes: 32000,
+    });
+    // Override stored byteRate to half the derived value (simulates a non-PCM
+    // codec that encodes at half the naive rate).
+    wav.writeUInt32LE(16000, 28); // half of 32000 (16000 * 1 * 2)
+    // Naive formula would compute 32000 / (16000*1*2) = 1s.
+    // Stored byteRate=16000 gives 32000 / 16000 = 2s. The stored value is
+    // authoritative.
+    expect(parseAudioDurationSec(wav, 'audio/wav')).toBeCloseTo(2, 5);
   });
 });

--- a/services/ai-worker/src/services/voice/voiceReferenceHelper.ts
+++ b/services/ai-worker/src/services/voice/voiceReferenceHelper.ts
@@ -17,6 +17,17 @@ const VOICE_REFERENCE_TIMEOUT_MS = 15_000;
 export interface VoiceReferenceResult {
   audioBuffer: Buffer;
   contentType: string;
+  /**
+   * Duration in seconds, parsed from the buffer's container header where
+   * cheaply possible. `undefined` if the format isn't recognized — callers
+   * fall back to whatever reactive validation the downstream API does.
+   *
+   * Currently parsed for: WAV (RIFF header). Other formats (mp3/ogg/m4a/flac)
+   * would need format-specific parsers; not implemented because the only
+   * caller needing duration today (`MistralTtsProvider`'s 30s pre-flight)
+   * primarily sees WAV.
+   */
+  durationSec?: number;
 }
 
 export async function fetchVoiceReference(slug: string): Promise<VoiceReferenceResult> {
@@ -56,6 +67,102 @@ export async function fetchVoiceReference(slug: string): Promise<VoiceReferenceR
 
   const audioBuffer = Buffer.from(await response.arrayBuffer());
   const contentType = response.headers.get('content-type') ?? 'audio/wav';
+  const durationSec = parseAudioDurationSec(audioBuffer, contentType);
 
-  return { audioBuffer, contentType };
+  return { audioBuffer, contentType, durationSec };
+}
+
+/**
+ * Best-effort duration parser. Returns `undefined` for unrecognized formats
+ * rather than throwing — callers should treat duration as advisory.
+ */
+export function parseAudioDurationSec(
+  audioBuffer: Buffer,
+  contentType: string
+): number | undefined {
+  if (isWavBuffer(audioBuffer, contentType)) {
+    return parseWavDurationSec(audioBuffer);
+  }
+  return undefined;
+}
+
+function isWavBuffer(audioBuffer: Buffer, contentType: string): boolean {
+  if (contentType.includes('wav') || contentType.includes('wave')) {
+    return true;
+  }
+  // Fallback: detect by RIFF/WAVE magic bytes — some servers return generic
+  // 'application/octet-stream' for WAV uploads.
+  return (
+    audioBuffer.length >= 12 &&
+    audioBuffer.toString('ascii', 0, 4) === 'RIFF' &&
+    audioBuffer.toString('ascii', 8, 12) === 'WAVE'
+  );
+}
+
+/**
+ * Parse a WAV (RIFF/WAVE) buffer's duration in seconds.
+ *
+ * Walks the RIFF chunk list to find both `fmt ` (for the stored byteRate) and
+ * `data` (audio bytes). Duration = `data_bytes / byteRate`. Reads the stored
+ * `byteRate` field directly rather than deriving it from sampleRate × channels
+ * × bytesPerSample — the derived formula is only correct for PCM
+ * (audioFormat=1) and silently produces wrong durations for compressed WAV
+ * formats (ADPCM, A-law, μ-law). The stored byteRate is correct for any
+ * audioFormat.
+ *
+ * Assumes `fmt ` appears before `data` in the chunk stream — universally true
+ * in practice (Mistral references, Discord exports, every standard WAV
+ * encoder), but technically a non-conforming WAV could place `data` first. In
+ * that case `byteRate` is missing when we hit the data-chunk break and the
+ * function returns `undefined` (safe degradation; caller falls through to the
+ * reactive Mistral 400 path).
+ *
+ * Returns `undefined` when the buffer is too short, the chunks aren't found,
+ * or `byteRate === 0` — the caller proceeds without the optimization rather
+ * than failing the whole TTS path on a malformed reference.
+ */
+function parseWavDurationSec(audioBuffer: Buffer): number | undefined {
+  // RIFF header: 12 bytes ("RIFF" + chunk size + "WAVE")
+  if (audioBuffer.length < 12) {
+    return undefined;
+  }
+  if (
+    audioBuffer.toString('ascii', 0, 4) !== 'RIFF' ||
+    audioBuffer.toString('ascii', 8, 12) !== 'WAVE'
+  ) {
+    return undefined;
+  }
+
+  let byteRate: number | undefined;
+  let dataSize: number | undefined;
+
+  // Walk subchunks starting at byte 12.
+  let offset = 12;
+  while (offset + 8 <= audioBuffer.length) {
+    const chunkId = audioBuffer.toString('ascii', offset, offset + 4);
+    const chunkSize = audioBuffer.readUInt32LE(offset + 4);
+    const dataStart = offset + 8;
+
+    if (chunkId === 'fmt ' && chunkSize >= 16 && dataStart + 16 <= audioBuffer.length) {
+      // fmt chunk layout (PCM, 16 bytes — extended formats add fields after
+      // bitsPerSample, but byteRate is at the same offset for all): audioFormat(2)
+      // numChannels(2) sampleRate(4) byteRate(4) blockAlign(2) bitsPerSample(2).
+      // The `chunkSize >= 16` guard prevents reading past the chunk's declared
+      // bounds — a malformed WAV with `chunkSize=4` could otherwise pass the
+      // buffer-length check and read garbage from the next chunk's territory.
+      byteRate = audioBuffer.readUInt32LE(dataStart + 8);
+    } else if (chunkId === 'data') {
+      dataSize = chunkSize;
+      break; // data chunk found — stop walking
+    }
+
+    // RIFF chunks are word-aligned: pad odd sizes by 1 byte.
+    offset = dataStart + chunkSize + (chunkSize % 2);
+  }
+
+  if (byteRate === undefined || dataSize === undefined || byteRate === 0) {
+    return undefined;
+  }
+
+  return dataSize / byteRate;
 }


### PR DESCRIPTION
## Summary

Three closely-related fixes to TTS dispatch, surfaced by prod-log analysis of the cross-personality cascade for `ha-shem-keev-ima` (#83):

- **Bug A** — Cross-provider `modelId` leak in fallback context. `buildCtxForProvider` was unconditionally forwarding `baseCtx.modelId` to fallback callees, handing Mistral's `voxtral-mini-tts-2603` to ElevenLabs and producing a 400. Fix: thread `isPrimaryAttempt` and clear `modelId` for fallback ctx.
- **Bug B** — Mistral 30s reference-audio pre-flight. Old code discovered the limit reactively per call, polluted the negative cache, and buried the cause inside a JSON-encoded error string at INFO. New: WAV duration parser → typed `MistralReferenceAudioTooLongError` → structured WARN log with `event: 'mistral.referenceAudioTooLong'` and skip the negative cache for this deterministic-from-input case.
- **Bug C** — Paid → free fallback only. Chain shape changes from `[primary, ...all-byok, self-hosted]` to `[primary, self-hosted]`. A user who configured Mistral did not implicitly opt into ElevenLabs billing. Subsumes the existing inbox item on the parallel direction (self-hosted → BYOK).

## Investigation context

#83 was originally reported as "ai-worker logs claim Mistral fired but voice-engine actually generates audio." Prod log analysis at 2026-05-04 19:34 UTC for `lilith-tzel-shani` showed Mistral firing correctly (`provider="mistral", primary="mistral", usedFallback=false`, real audio bytes). The user's "voice-engine waking up" was correct for OTHER personalities — `baphomet-ani-miqdash-tame` (configured self-hosted primary) and `ha-shem-keev-ima` (Mistral primary always failing on the 30s limit, cascading through ElevenLabs which also failed due to the modelId leak, finally landing on self-hosted with Kyutai-quality output).

## Test plan

- [x] `pnpm test` — 14/14 packages green (3047 tests)
- [x] `pnpm quality` — 11/11 tasks green
- [x] `pnpm knip` — clean
- [ ] CI green before merge
- [ ] Post-merge dev smoke: re-trigger TTS for `ha-shem-keev-ima` (or any personality with reference audio >30s) and confirm:
  - WARN log: `'Mistral reference audio exceeds 30s limit — skipping clone, falling through to self-hosted'` with structured `durationSec`/`limitSec`
  - NO Mistral 400 round-trip (skipped pre-flight)
  - NO ElevenLabs 400 (cross-paid fallback disabled)
  - `'TTS dispatched via fallback' provider="self-hosted" primary="mistral" usedFallback=true`

## Backlog additions filed

Two inbox items (will land in a follow-up doc commit per the doc-commit exception):
1. 🐛 [FIX] Trim reference audio to ≤30s before sending to Mistral (or surface user notice). Product call deferred — this PR ensures clean fallback; whether to trim or surface is a UX decision.
2. 🧹 [CHORE] Remove negative-cache for deterministic-failure paths. Distinguish transient (5xx, network) from deterministic (input-shape) via `error.isTransient`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)