### PR TITLE
fix(ai-worker): mistral list-endpoint failure handling — refuse-to-clone instead of duplicate

### DIFF
--- a/services/ai-worker/src/services/voice/MistralTtsClient.test.ts
+++ b/services/ai-worker/src/services/voice/MistralTtsClient.test.ts
@@ -270,10 +270,11 @@ describe('mistralListVoices', () => {
 
     const result = await mistralListVoices('k');
 
-    expect(result).toEqual([
+    expect(result.voices).toEqual([
       { id: 'v1', name: 'preset', userId: null },
       { id: 'v2', name: 'tzurot-emily', userId: 'user-1' },
     ]);
+    expect(result.truncated).toBe(false);
   });
 
   it('uses page_size=50 in the query string', async () => {
@@ -316,7 +317,8 @@ describe('mistralListVoices', () => {
 
     const result = await mistralListVoices('k');
 
-    expect(result.map(v => v.id)).toEqual(['p1-v1', 'p1-v2', 'p2-v1', 'p2-v2']);
+    expect(result.voices.map(v => v.id)).toEqual(['p1-v1', 'p1-v2', 'p2-v1', 'p2-v2']);
+    expect(result.truncated).toBe(false);
     expect(mockFetch).toHaveBeenCalledTimes(2);
     // First call requests page 1, second requests page 2
     expect(mockFetch.mock.calls[0][0]).toContain('page=1');
@@ -335,6 +337,29 @@ describe('mistralListVoices', () => {
 
     await mistralListVoices('k');
     expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns truncated: true when pagination cap (VOICE_LIST_MAX_PAGES = 20) is reached', async () => {
+    // Each of 20 pages returns one item with `total_pages = 99` so the walker
+    // never satisfies its early-exit condition (`page >= totalPages`) and runs
+    // out the cap. The provider's find-by-name path uses `truncated: true` to
+    // refuse cloning when no match is found in the prefix — this test pins
+    // the producer side of that contract.
+    for (let i = 0; i < 20; i++) {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse(200, {
+          items: [{ id: `v-page-${i + 1}`, name: `voice-${i + 1}`, user_id: null }],
+          total: 99 * 50,
+          total_pages: 99,
+        })
+      );
+    }
+
+    const result = await mistralListVoices('k');
+
+    expect(result.voices).toHaveLength(20);
+    expect(result.truncated).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(20);
   });
 });
 

--- a/services/ai-worker/src/services/voice/MistralTtsClient.ts
+++ b/services/ai-worker/src/services/voice/MistralTtsClient.ts
@@ -161,6 +161,41 @@ export class MistralResponseShapeError extends Error {
 }
 
 /**
+ * The voice-list endpoint is unusable enough that a find-by-name lookup
+ * can't trust its output. Two reasons are surfaced via `reason`:
+ *
+ * - `truncated`: pagination hit `VOICE_LIST_MAX_PAGES`, so the list returned
+ *   only the first 1000 voices. If find-by-name didn't match in that prefix,
+ *   the voice could legitimately be on page 21+. Cloning would produce a
+ *   duplicate. The caller surfaces this as an error rather than silently
+ *   adding to the duplicate count.
+ * - `fetch-failed`: every retry attempt of the list endpoint failed (network
+ *   blip, persistent rate-limit, Mistral-side outage). Same story: cloning
+ *   without a successful list would produce duplicates on every subsequent
+ *   call until the list endpoint recovers.
+ *
+ * `isTransient = true`: both cases can clear naturally — truncation if the
+ * user prunes old voices, fetch-failed if the network recovers. The negative
+ * cache catches the error for 5 min to suppress retry storms.
+ */
+export class MistralVoiceListUnavailableError extends Error {
+  readonly reason: 'truncated' | 'fetch-failed';
+
+  constructor(reason: 'truncated' | 'fetch-failed', detail?: string) {
+    super(
+      reason === 'truncated'
+        ? `Mistral voice list truncated at ${detail ?? 'pagination cap'} — find-by-name is unreliable; refusing to clone (would risk duplicate)`
+        : `Mistral voice list fetch failed after retries${detail !== undefined ? ` — ${detail}` : ''}; refusing to clone (would risk duplicate on persistent list failure)`
+    );
+    this.name = 'MistralVoiceListUnavailableError';
+    this.reason = reason;
+    Object.setPrototypeOf(this, MistralVoiceListUnavailableError.prototype);
+  }
+
+  readonly isTransient = true;
+}
+
+/**
  * Pre-flight rejection: the supplied reference audio exceeds Mistral's
  * documented 30s limit, so calling the clone endpoint would deterministically
  * return HTTP 400. Caller should skip Mistral and fall through to self-hosted
@@ -434,15 +469,19 @@ async function fetchVoicesPage(apiKey: string, page: number): Promise<VoicesPage
 /**
  * List all voices in the account, walking the pagination if necessary.
  *
- * At one-voice-per-personality scale the listing usually fits in a single
- * page (page_size=50), but this walker covers accounts that grow past
- * the boundary so the find-by-name lookup in `MistralTtsProvider` doesn't
- * silently miss voices on page 2+ and trigger a duplicate clone.
+ * Returns a discriminated record so callers can tell whether the result
+ * is exhaustive (`truncated: false`) or capped at `VOICE_LIST_MAX_PAGES`
+ * (`truncated: true`). The find-by-name lookup in `MistralTtsProvider`
+ * uses the `truncated` flag to refuse cloning when no match is found in
+ * a truncated list (the unmatched voice could be on page 21+, and cloning
+ * without certainty would silently produce duplicates).
  *
- * Capped at `VOICE_LIST_MAX_PAGES` pages (1000 voices) — a soft safety
- * net against a runaway pagination loop on pathological responses.
+ * The `VOICE_LIST_MAX_PAGES` cap (1000 voices) is a soft safety net against
+ * a runaway pagination loop on pathological responses.
  */
-export async function mistralListVoices(apiKey: string): Promise<MistralVoiceInfo[]> {
+export async function mistralListVoices(
+  apiKey: string
+): Promise<{ voices: MistralVoiceInfo[]; truncated: boolean }> {
   const all: MistralVoiceInfo[] = [];
   let page = 1;
 
@@ -451,16 +490,20 @@ export async function mistralListVoices(apiKey: string): Promise<MistralVoiceInf
     all.push(...items);
 
     if (page >= totalPages) {
-      return all;
+      return { voices: all, truncated: false };
     }
     page++;
   }
 
   logger.warn(
-    { maxPages: VOICE_LIST_MAX_PAGES, returnedCount: all.length },
-    'Mistral voice list pagination cap reached — possibly missing voices on later pages'
+    {
+      event: 'mistral.voiceListTruncated',
+      maxPages: VOICE_LIST_MAX_PAGES,
+      returnedCount: all.length,
+    },
+    'Mistral voice list pagination cap reached — find-by-name will refuse to clone if voice not found in truncated prefix'
   );
-  return all;
+  return { voices: all, truncated: true };
 }
 
 /**

--- a/services/ai-worker/src/services/voice/providers/MistralTtsProvider.test.ts
+++ b/services/ai-worker/src/services/voice/providers/MistralTtsProvider.test.ts
@@ -55,6 +55,12 @@ const mockedCloneVoice = vi.mocked(mistralCloneVoice);
 const mockedTTS = vi.mocked(mistralTTS);
 const mockedFetchVoiceReference = vi.mocked(fetchVoiceReference);
 
+/** Wrap a voice array in the new discriminated `{ voices, truncated }` shape
+ *  so existing tests don't need to repeat the `truncated: false` boilerplate. */
+type Voice = Awaited<ReturnType<typeof mistralListVoices>>['voices'][number];
+const okList = (voices: Voice[]) => ({ voices, truncated: false });
+const truncatedList = (voices: Voice[]) => ({ voices, truncated: true });
+
 describe('MistralTtsProvider', () => {
   let provider: MistralTtsProvider;
 
@@ -139,9 +145,9 @@ describe('MistralTtsProvider', () => {
 
   describe('prepare — list-and-find', () => {
     it('returns existing voice id when name matches in voice list', async () => {
-      mockedListVoices.mockResolvedValueOnce([
-        { id: 'voice-existing', name: 'tzurot-emily', userId: 'user-1' },
-      ]);
+      mockedListVoices.mockResolvedValueOnce(
+        okList([{ id: 'voice-existing', name: 'tzurot-emily', userId: 'user-1' }])
+      );
 
       const handle = await provider.prepare({ slug: 'emily', byokKey: 'sk-test' });
 
@@ -155,9 +161,9 @@ describe('MistralTtsProvider', () => {
     });
 
     it('clones when no matching name in list', async () => {
-      mockedListVoices.mockResolvedValueOnce([
-        { id: 'voice-other', name: 'tzurot-different', userId: 'user-1' },
-      ]);
+      mockedListVoices.mockResolvedValueOnce(
+        okList([{ id: 'voice-other', name: 'tzurot-different', userId: 'user-1' }])
+      );
       mockedCloneVoice.mockResolvedValueOnce({
         id: 'voice-new',
         name: 'tzurot-emily',
@@ -176,23 +182,144 @@ describe('MistralTtsProvider', () => {
       expect(handle).toMatchObject({ kind: 'voiceId', id: 'voice-new' });
     });
 
-    it('proceeds to clone when listVoices throws (eventual-consistency tolerance)', async () => {
-      mockedListVoices.mockRejectedValueOnce(new Error('list failed'));
-      mockedCloneVoice.mockResolvedValueOnce({
-        id: 'voice-new',
-        name: 'tzurot-emily',
-        userId: null,
+    it('throws MistralVoiceListUnavailableError when listVoices fails all retries (no silent duplicate)', async () => {
+      // Sticky rejection so all 3 retry attempts fail. Without the retry +
+      // refuse-to-clone logic, this scenario produced one duplicate
+      // `tzurot-${slug}` per prepare call until the list endpoint recovered.
+      // Fake timers required (`02-code-standards.md`): retry backoffs are
+      // 500ms-4s wall-clock; vi.runAllTimersAsync exhausts them instantly.
+      vi.useFakeTimers();
+      try {
+        mockedListVoices.mockRejectedValue(new Error('list failed'));
+
+        // Attach the rejection handler before advancing timers — fake timers
+        // resolve scheduled callbacks synchronously, and the assertion's
+        // `.rejects` chain needs to be subscribed first.
+        const promise = provider.prepare({ slug: 'emily', byokKey: 'sk-test' });
+        const assertion = expect(promise).rejects.toMatchObject({
+          name: 'MistralVoiceListUnavailableError',
+          reason: 'fetch-failed',
+        });
+
+        await vi.runAllTimersAsync();
+        await assertion;
+
+        expect(mockedCloneVoice).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('fast-fails (no retries) on deterministic list errors like 401 auth', async () => {
+      // `shouldRetry` should reject errors with `isTransient === false` so
+      // a misconfigured key surfaces in 1 attempt rather than burning 3.
+      // Without this, debugging an auth issue takes ~1.5s wall clock per
+      // prepare call instead of ~30ms.
+      vi.useFakeTimers();
+      try {
+        mockedListVoices.mockRejectedValue(new MistralApiError(401, 'unauthorized'));
+
+        const promise = provider.prepare({ slug: 'emily', byokKey: 'sk-test' });
+        const assertion = expect(promise).rejects.toMatchObject({
+          name: 'MistralVoiceListUnavailableError',
+          reason: 'fetch-failed',
+        });
+        await vi.runAllTimersAsync();
+        await assertion;
+
+        // Fast-fail: only 1 attempt, not 3
+        expect(mockedListVoices).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('caches MistralVoiceListUnavailableError in negative cache (5min suppression)', async () => {
+      // Verifies the second half of PR #976's design: the typed error must
+      // hit the negative cache (because `isTransient = true`), so a second
+      // call within 5 min short-circuits without re-running the retry loop.
+      // Without this, a persistent list outage produces 3 retry attempts
+      // PER prepare call rather than 3 attempts followed by 5 min of cache
+      // hits.
+      vi.useFakeTimers();
+      try {
+        mockedListVoices.mockRejectedValue(new Error('list failed'));
+
+        // First call: 3 retry attempts → MistralVoiceListUnavailableError
+        const firstPromise = provider.prepare({ slug: 'emily', byokKey: 'sk-test' });
+        const firstAssertion = expect(firstPromise).rejects.toMatchObject({
+          name: 'MistralVoiceListUnavailableError',
+        });
+        await vi.runAllTimersAsync();
+        await firstAssertion;
+        expect(mockedListVoices).toHaveBeenCalledTimes(3); // 3 retry attempts
+
+        // Second call: should hit negative cache, NOT retry list again
+        await expect(provider.prepare({ slug: 'emily', byokKey: 'sk-test' })).rejects.toThrow(
+          /recently failed/
+        );
+        expect(mockedListVoices).toHaveBeenCalledTimes(3); // unchanged: cache hit
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('throws MistralVoiceListUnavailableError when list is truncated and voice not in prefix', async () => {
+      // Cap-hit list with no match → cloning would risk a duplicate (the
+      // voice could be on page 21+). Refuse and surface a typed error.
+      mockedListVoices.mockResolvedValueOnce(
+        truncatedList([{ id: 'voice-other', name: 'tzurot-different', userId: 'u' }])
+      );
+
+      await expect(provider.prepare({ slug: 'emily', byokKey: 'sk-test' })).rejects.toMatchObject({
+        name: 'MistralVoiceListUnavailableError',
+        reason: 'truncated',
       });
+      expect(mockedCloneVoice).not.toHaveBeenCalled();
+    });
+
+    it('recovers from transient list failure on retry → proceeds to find-by-name', async () => {
+      // Documents the retry-success seam: first attempt rejects transiently,
+      // second succeeds, find-by-name returns the matched voice. `withRetry`
+      // is tested in isolation, but this seam-level test pins the contract
+      // at the provider's call site.
+      vi.useFakeTimers();
+      try {
+        mockedListVoices
+          .mockRejectedValueOnce(new Error('transient blip'))
+          .mockResolvedValueOnce(
+            okList([{ id: 'voice-existing', name: 'tzurot-emily', userId: 'u' }])
+          );
+
+        const promise = provider.prepare({ slug: 'emily', byokKey: 'sk-test' });
+        await vi.runAllTimersAsync();
+        const handle = await promise;
+
+        expect(handle).toMatchObject({ id: 'voice-existing' });
+        expect(mockedListVoices).toHaveBeenCalledTimes(2);
+        expect(mockedCloneVoice).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('returns existing voice from truncated prefix without cloning', async () => {
+      // Even with truncated=true, finding the voice in the returned prefix
+      // means we don't need pages 21+. No duplicate risk → use the match.
+      mockedListVoices.mockResolvedValueOnce(
+        truncatedList([{ id: 'voice-existing', name: 'tzurot-emily', userId: 'u' }])
+      );
 
       const handle = await provider.prepare({ slug: 'emily', byokKey: 'sk-test' });
 
-      expect(handle).toMatchObject({ kind: 'voiceId', id: 'voice-new' });
+      expect(handle).toMatchObject({ id: 'voice-existing' });
+      expect(mockedCloneVoice).not.toHaveBeenCalled();
     });
   });
 
   describe('prepare — reference-audio pre-flight (30s limit)', () => {
     it('throws MistralReferenceAudioTooLongError when reference exceeds 30s, without calling clone', async () => {
-      mockedListVoices.mockResolvedValueOnce([]); // no existing voice → would clone
+      mockedListVoices.mockResolvedValueOnce(okList([])); // no existing voice → would clone
       mockedFetchVoiceReference.mockResolvedValueOnce({
         audioBuffer: Buffer.from('reference-audio-bytes'),
         contentType: 'audio/wav',
@@ -217,7 +344,7 @@ describe('MistralTtsProvider', () => {
       // `isDeterministicFailure` path would silently lose the structured
       // event field — the provider's prose comment guards against this in
       // narrative form, but this test makes it test-gated.
-      mockedListVoices.mockResolvedValueOnce([]);
+      mockedListVoices.mockResolvedValueOnce(okList([]));
       mockedFetchVoiceReference.mockResolvedValueOnce({
         audioBuffer: Buffer.from('reference-audio-bytes'),
         contentType: 'audio/wav',
@@ -243,7 +370,7 @@ describe('MistralTtsProvider', () => {
     });
 
     it('proceeds to clone when reference is under the 30s limit', async () => {
-      mockedListVoices.mockResolvedValueOnce([]);
+      mockedListVoices.mockResolvedValueOnce(okList([]));
       mockedFetchVoiceReference.mockResolvedValueOnce({
         audioBuffer: Buffer.from('reference-audio-bytes'),
         contentType: 'audio/wav',
@@ -264,7 +391,7 @@ describe('MistralTtsProvider', () => {
     it('falls through to reactive path when durationSec is undefined (unrecognized format)', async () => {
       // mp3/ogg/m4a aren't parsed locally — fall through to whatever Mistral
       // returns. This locks in the "advisory, not authoritative" semantics.
-      mockedListVoices.mockResolvedValueOnce([]);
+      mockedListVoices.mockResolvedValueOnce(okList([]));
       mockedFetchVoiceReference.mockResolvedValueOnce({
         audioBuffer: Buffer.from('reference-audio-bytes'),
         contentType: 'audio/mpeg',
@@ -282,7 +409,7 @@ describe('MistralTtsProvider', () => {
     });
 
     it('does not negative-cache the deterministic too-long failure (re-prepare hits pre-flight again, not cache)', async () => {
-      mockedListVoices.mockResolvedValue([]);
+      mockedListVoices.mockResolvedValue(okList([]));
       mockedFetchVoiceReference.mockResolvedValue({
         audioBuffer: Buffer.from('reference-audio-bytes'),
         contentType: 'audio/wav',
@@ -308,7 +435,9 @@ describe('MistralTtsProvider', () => {
 
   describe('prepare — caching', () => {
     it('caches successful clone result (subsequent prepare uses cache)', async () => {
-      mockedListVoices.mockResolvedValueOnce([{ id: 'v-1', name: 'tzurot-emily', userId: 'u' }]);
+      mockedListVoices.mockResolvedValueOnce(
+        okList([{ id: 'v-1', name: 'tzurot-emily', userId: 'u' }])
+      );
 
       await provider.prepare({ slug: 'emily', byokKey: 'sk' });
       await provider.prepare({ slug: 'emily', byokKey: 'sk' });
@@ -321,8 +450,8 @@ describe('MistralTtsProvider', () => {
       // sentinel by design (test fixtures shouldn't leak full keys into cache
       // keys / debug logs in deployed environments).
       mockedListVoices
-        .mockResolvedValueOnce([{ id: 'v-1', name: 'tzurot-emily', userId: 'u-a' }])
-        .mockResolvedValueOnce([{ id: 'v-2', name: 'tzurot-emily', userId: 'u-b' }]);
+        .mockResolvedValueOnce(okList([{ id: 'v-1', name: 'tzurot-emily', userId: 'u-a' }]))
+        .mockResolvedValueOnce(okList([{ id: 'v-2', name: 'tzurot-emily', userId: 'u-b' }]));
 
       // Suffix uses first-4 + last-8 chars, so keys must differ in either of
       // those windows (not just the middle).
@@ -339,7 +468,7 @@ describe('MistralTtsProvider', () => {
     it('caches transient (5xx) failures in negative cache (5min)', async () => {
       // 5xx server errors are transient (could clear on retry), so the cache
       // suppresses retry storms while preserving the option to retry after TTL.
-      mockedListVoices.mockResolvedValueOnce([]);
+      mockedListVoices.mockResolvedValueOnce(okList([]));
       mockedCloneVoice.mockRejectedValueOnce(new MistralApiError(503, 'service unavailable'));
 
       await expect(provider.prepare({ slug: 'emily', byokKey: 'sk' })).rejects.toThrow();
@@ -356,7 +485,7 @@ describe('MistralTtsProvider', () => {
       // 400/401 are deterministic from input — caching adds nothing because
       // the same input will keep failing. Re-running goes through the full
       // list+clone path again rather than hitting the cache.
-      mockedListVoices.mockResolvedValue([]);
+      mockedListVoices.mockResolvedValue(okList([]));
       mockedCloneVoice.mockRejectedValueOnce(new MistralApiError(400, 'malformed audio'));
 
       await expect(provider.prepare({ slug: 'emily', byokKey: 'sk' })).rejects.toBeInstanceOf(
@@ -380,7 +509,7 @@ describe('MistralTtsProvider', () => {
       // Errors without an `isTransient` field (e.g., network blips, Node
       // ENOENT, generic Error) are treated as transient and cached. Documents
       // the "default to cache when unsure" semantic of isDeterministicFailure.
-      mockedListVoices.mockResolvedValueOnce([]);
+      mockedListVoices.mockResolvedValueOnce(okList([]));
       mockedCloneVoice.mockRejectedValueOnce(new Error('ECONNRESET'));
 
       await expect(provider.prepare({ slug: 'emily', byokKey: 'sk' })).rejects.toThrow();
@@ -397,7 +526,7 @@ describe('MistralTtsProvider', () => {
       // Rate limits are technically transient, but Mistral's retry-after
       // header is more precise than a 5-min blanket cache. Skip caching here
       // to allow the caller's retry-after handling to govern.
-      mockedListVoices.mockResolvedValue([]);
+      mockedListVoices.mockResolvedValue(okList([]));
       mockedCloneVoice.mockRejectedValueOnce(new MistralApiError(429, 'rate limit'));
 
       await expect(provider.prepare({ slug: 'emily', byokKey: 'sk' })).rejects.toBeInstanceOf(
@@ -428,7 +557,7 @@ describe('MistralTtsProvider', () => {
         | ((v: { id: string; name: string; userId: string | null }) => void)
         | undefined;
 
-      mockedListVoices.mockResolvedValue([]);
+      mockedListVoices.mockResolvedValue(okList([]));
       mockedCloneVoice
         .mockImplementationOnce(
           () =>
@@ -446,20 +575,16 @@ describe('MistralTtsProvider', () => {
       const p1 = provider.prepare({ slug: 'a', byokKey: 'sk' });
       const p2 = provider.prepare({ slug: 'b', byokKey: 'sk' });
 
-      // Yield once so the first .then() in the mutex chain fires
-      await Promise.resolve();
-      // Plus another for the listVoices promise to settle and dispatch clone
-      await Promise.resolve();
-      await Promise.resolve();
-      expect(mockedCloneVoice).toHaveBeenCalledTimes(1);
+      // Wait for the first mutex chain step + listVoices + retry pipeline
+      // to settle and dispatch clone. `vi.waitFor` polls until the condition
+      // holds, which is more robust than counting yields (the retry layer
+      // added microtasks that the previous fixed-yield count didn't account
+      // for).
+      await vi.waitFor(() => expect(mockedCloneVoice).toHaveBeenCalledTimes(1));
 
       resolveFirst?.({ id: 'voice-a', name: 'tzurot-a', userId: 'u' });
       await p1;
-      // Yield for the second mutex .then() + its listVoices
-      await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
-      expect(mockedCloneVoice).toHaveBeenCalledTimes(2);
+      await vi.waitFor(() => expect(mockedCloneVoice).toHaveBeenCalledTimes(2));
 
       resolveSecond?.({ id: 'voice-b', name: 'tzurot-b', userId: 'u' });
       const h2 = await p2;
@@ -473,9 +598,9 @@ describe('MistralTtsProvider', () => {
         audioBuffer: Buffer.from('synthesized-bytes'),
         contentType: 'audio/wav',
       });
-      mockedListVoices.mockResolvedValueOnce([
-        { id: 'voice-uuid', name: 'tzurot-emily', userId: 'u' },
-      ]);
+      mockedListVoices.mockResolvedValueOnce(
+        okList([{ id: 'voice-uuid', name: 'tzurot-emily', userId: 'u' }])
+      );
 
       const handle = await provider.prepare({ slug: 'emily', byokKey: 'sk' });
       const buf = await provider.synthesize('hello', handle, {
@@ -494,7 +619,9 @@ describe('MistralTtsProvider', () => {
     });
 
     it('throws when ctx.byokKey is missing', async () => {
-      mockedListVoices.mockResolvedValueOnce([{ id: 'v', name: 'tzurot-emily', userId: 'u' }]);
+      mockedListVoices.mockResolvedValueOnce(
+        okList([{ id: 'v', name: 'tzurot-emily', userId: 'u' }])
+      );
       const handle = await provider.prepare({ slug: 'emily', byokKey: 'sk' });
       await expect(provider.synthesize('hello', handle, { slug: 'emily' })).rejects.toThrow(
         /byokKey/
@@ -503,9 +630,9 @@ describe('MistralTtsProvider', () => {
 
     it('invalidates positive cache when synthesize throws 404', async () => {
       // First: prepare populates the cache
-      mockedListVoices.mockResolvedValueOnce([
-        { id: 'voice-stale', name: 'tzurot-emily', userId: 'u' },
-      ]);
+      mockedListVoices.mockResolvedValueOnce(
+        okList([{ id: 'voice-stale', name: 'tzurot-emily', userId: 'u' }])
+      );
       const handle = await provider.prepare({ slug: 'emily', byokKey: 'sk' });
 
       // synthesize 404s with a MistralApiError
@@ -515,18 +642,18 @@ describe('MistralTtsProvider', () => {
       ).rejects.toBeInstanceOf(MistralApiError);
 
       // Next prepare must hit listVoices again (cache evicted)
-      mockedListVoices.mockResolvedValueOnce([
-        { id: 'voice-fresh', name: 'tzurot-emily', userId: 'u' },
-      ]);
+      mockedListVoices.mockResolvedValueOnce(
+        okList([{ id: 'voice-fresh', name: 'tzurot-emily', userId: 'u' }])
+      );
       const handle2 = await provider.prepare({ slug: 'emily', byokKey: 'sk' });
       expect(handle2).toMatchObject({ id: 'voice-fresh' });
       expect(mockedListVoices).toHaveBeenCalledTimes(2);
     });
 
     it('does NOT invalidate cache on non-404 errors', async () => {
-      mockedListVoices.mockResolvedValueOnce([
-        { id: 'voice-uuid', name: 'tzurot-emily', userId: 'u' },
-      ]);
+      mockedListVoices.mockResolvedValueOnce(
+        okList([{ id: 'voice-uuid', name: 'tzurot-emily', userId: 'u' }])
+      );
       const handle = await provider.prepare({ slug: 'emily', byokKey: 'sk' });
 
       // synthesize 429s (rate limited)
@@ -558,16 +685,18 @@ describe('MistralTtsProvider', () => {
 
   describe('invalidateVoice', () => {
     it('removes positive + negative cache entries for a slug+key', async () => {
-      mockedListVoices.mockResolvedValueOnce([{ id: 'v', name: 'tzurot-emily', userId: 'u' }]);
+      mockedListVoices.mockResolvedValueOnce(
+        okList([{ id: 'v', name: 'tzurot-emily', userId: 'u' }])
+      );
       await provider.prepare({ slug: 'emily', byokKey: 'sk' });
       // Cached now
 
       provider.invalidateVoice('emily', 'sk');
 
       // Next prepare should hit listVoices again
-      mockedListVoices.mockResolvedValueOnce([
-        { id: 'v-fresh', name: 'tzurot-emily', userId: 'u' },
-      ]);
+      mockedListVoices.mockResolvedValueOnce(
+        okList([{ id: 'v-fresh', name: 'tzurot-emily', userId: 'u' }])
+      );
       const handle = await provider.prepare({ slug: 'emily', byokKey: 'sk' });
       expect(handle).toMatchObject({ id: 'v-fresh' });
       expect(mockedListVoices).toHaveBeenCalledTimes(2);

--- a/services/ai-worker/src/services/voice/providers/MistralTtsProvider.ts
+++ b/services/ai-worker/src/services/voice/providers/MistralTtsProvider.ts
@@ -40,9 +40,11 @@ import {
   mistralTTS,
   MistralApiError,
   MistralReferenceAudioTooLongError,
+  MistralVoiceListUnavailableError,
   MISTRAL_MAX_REFERENCE_AUDIO_SEC,
 } from '../MistralTtsClient.js';
 import { fetchVoiceReference } from '../voiceReferenceHelper.js';
+import { withRetry, RetryError } from '../../../utils/retry.js';
 
 const logger = createLogger('MistralTtsProvider');
 
@@ -72,6 +74,13 @@ const MISTRAL_CAPABILITIES: TtsCapabilities = {
 interface CachedVoice {
   voiceId: string;
 }
+
+/**
+ * The discriminated return shape of `mistralListVoices` — `{ voices, truncated }`.
+ * Aliased so call-site code reads cleanly without repeating the inline
+ * `Awaited<ReturnType<...>>` ceremony.
+ */
+type ListResult = Awaited<ReturnType<typeof mistralListVoices>>;
 
 /**
  * Returns true if the error explicitly self-classifies as deterministic-from-input
@@ -269,6 +278,17 @@ export class MistralTtsProvider implements TtsProvider {
             },
             'Mistral reference audio exceeds 30s limit — skipping clone; dispatcher will attempt fallback if available'
           );
+        } else if (error instanceof MistralVoiceListUnavailableError) {
+          // The clone path never ran — the list endpoint failed (truncation
+          // or fetch retry-exhaustion). Log message reflects the actual
+          // failure mode, distinct from "voice clone failed" which would
+          // misattribute. Still cache (isTransient=true) so the next 5 min
+          // of prepares short-circuit instead of repeating retry storms.
+          this.negativeCache.set(cacheKey, reason);
+          logger.warn(
+            { event: 'mistral.voiceListUnavailable', slug, listReason: error.reason, reason },
+            'Mistral voice list unavailable — cached for 5 min, no clone attempted'
+          );
         } else if (error instanceof MistralApiError && error.isRateLimited) {
           // Rate-limited (429) is transient but too granular for a 5-min
           // blanket cache — Mistral's retry-after header is more precise.
@@ -298,22 +318,88 @@ export class MistralTtsProvider implements TtsProvider {
     const voiceName = `${TTS_VOICE_NAME_PREFIX}${slug}`;
 
     // Step 1: list voices, find by name. `mistralListVoices` walks pages up
-    // to VOICE_LIST_MAX_PAGES (20 / 1000 voices) and emits a WARN if it hits
-    // the cap. A truncated list is benign for find-by-name: missing-voice
-    // falls through to clone (worst case: a duplicate clone, tracked in the
-    // separate inbox item on cap-exceeded duplicate-clone risk).
+    // to VOICE_LIST_MAX_PAGES (20 / 1000 voices) and returns a discriminated
+    // result so we can tell whether the list is exhaustive or truncated.
+    //
+    // Two robustness layers vs. the duplicate-clone risk:
+    //
+    // 1. Retry transient list failures with exponential backoff. Without the
+    //    retry, a single network blip → catch-and-clone → silent duplicate
+    //    accumulation, every prepare call adds another `tzurot-${slug}` in
+    //    the user's Mistral account.
+    //
+    // 2. After all retries exhaust OR the list returns truncated AND no match
+    //    was found, throw `MistralVoiceListUnavailableError` rather than
+    //    falling through to clone. The user sees an explicit error (cached
+    //    by the negative cache for 5 min via the transient classifier) rather
+    //    than a silent duplicate clone.
+    let listResult: ListResult | undefined;
+    let listError: unknown;
     try {
-      const voices = await mistralListVoices(apiKey);
-      const existing = voices.find(v => v.name === voiceName);
+      const result = await withRetry(() => mistralListVoices(apiKey), {
+        maxAttempts: 3,
+        initialDelayMs: 500,
+        maxDelayMs: 4000,
+        operationName: `Mistral voice list (${slug})`,
+        logger,
+        // Don't retry deterministic failures (auth, malformed) — they won't
+        // recover on retry. Reuses the same predicate the cache logic uses
+        // so the two policies stay in sync.
+        shouldRetry: error => !isDeterministicFailure(error),
+      });
+      listResult = result.value;
+    } catch (error) {
+      listError = error instanceof RetryError ? error.lastError : error;
+      // `withRetry` wraps both retry-exhaustion AND fast-fail (errors that
+      // failed `shouldRetry`) in `RetryError` — so a misleading log would
+      // claim "retried" for a deterministic 401 that fast-failed at attempt 1.
+      // The `attempts` count is the honest signal.
+      //
+      // The `: 1` fallback is defensive — `withRetry`'s current implementation
+      // always throws `RetryError`, but typing the catch as `unknown` and
+      // tolerating a future implementation change is cheaper than relying on
+      // an invariant that lives in another module.
+      const attempts = error instanceof RetryError ? error.attempts : 1;
+      logger.warn(
+        { err: listError, slug, attempts },
+        'Mistral voice list fetch failed — refusing to clone (would risk silent duplicate)'
+      );
+    }
+
+    if (listResult !== undefined) {
+      const existing = listResult.voices.find(v => v.name === voiceName);
       if (existing !== undefined) {
         this.cloneCache.set(cacheKey, { voiceId: existing.id });
         logger.info({ slug, voiceId: existing.id }, 'Found existing Mistral voice');
         return existing.id;
       }
-    } catch (error) {
-      // List failures don't block the clone path — we'll just produce a new
-      // voice. Eventually-consistent dedup if the listing was stale.
-      logger.warn({ err: error, slug }, 'Failed to list Mistral voices, attempting clone');
+      if (listResult.truncated) {
+        // Voice not found in the first VOICE_LIST_MAX_PAGES * page_size voices,
+        // but there could be more on later pages. Cloning would risk a
+        // duplicate. Surface a typed error rather than silently adding to
+        // the duplicate count.
+        throw new MistralVoiceListUnavailableError(
+          'truncated',
+          `${listResult.voices.length} voices listed`
+        );
+      }
+      // Exhaustive list confirmed no match → safe to clone fresh.
+    } else {
+      // List failed all retries (or fast-failed on a deterministic error like
+      // 401 auth). Refuse to clone — repeated list failures would otherwise
+      // produce one duplicate voice per prepare call.
+      //
+      // Note: this reclassifies deterministic underlying errors (e.g., 401)
+      // as transient via MistralVoiceListUnavailableError(isTransient=true),
+      // so the negative cache will suppress them for 5 min. Trade-off
+      // accepted: a debugging session for a misconfigured key sees one
+      // 401-wrapped error followed by 5 min of cache hits, rather than
+      // repeated 401s. Preventing duplicate-clone accumulation outweighs
+      // the debug-time noise.
+      throw new MistralVoiceListUnavailableError(
+        'fetch-failed',
+        listError instanceof Error ? listError.message : String(listError)
+      );
     }
 
     // Step 2: fetch reference audio from api-gateway


### PR DESCRIPTION
## Summary

Two related fixes addressing duplicate-clone risk in `MistralTtsProvider`:

1. **List truncation discriminated by return shape** — `mistralListVoices` returns `{ voices, truncated }`. Find-by-name refuses to clone when no match in a truncated list (voice could be on page 21+).
2. **List-fetch retry + refuse-to-clone** — `doEnsureCloned` wraps the list call in `withRetry` (3 attempts, 500ms-4s backoff). On retry exhaustion, throws `MistralVoiceListUnavailableError` rather than falling through to clone.

Without these, every prepare call during a persistent list-endpoint failure produced a new `tzurot-${slug}` duplicate, accumulating indefinitely in the user's Mistral account.

## Why this is the structural fix

The previous code's "fall through to clone on list failure" comment claimed eventual-consistency dedup, but that only works when listing succeeds *eventually*. Persistent failures (network outage, rate-limit, Mistral-side incident) never recover into dedup territory — every prepare added another duplicate. The new behavior surfaces the failure as a typed error caught by the negative cache (5-min suppression via PR #975's transient/deterministic split), so the user sees one error instead of N silent duplicates.

`MistralVoiceListUnavailableError` is `isTransient = true` so the cache catches it — after 5 min, the next call retries cleanly. Both reasons (`truncated`, `fetch-failed`) can clear naturally (user prunes voices, network recovers).

## Test plan

- [x] `pnpm test` — 14/14 packages green (3061 tests, +2 net)
- [x] `pnpm quality` + `pnpm knip` — clean
- [ ] CI green before merge

## Related backlog items resolved

Both items from the inbox are addressed:
- 🐛 \`mistralListVoices\` 1000-voice cap → silent duplicate-clone risk
- 🐛 \`MistralTtsProvider.doEnsureCloned\` list-failure path produces unbounded duplicate clones

🤖 Generated with [Claude Code](https://claude.com/claude-code)