### PR TITLE
fix(ai-worker,common-types): tts dispatch-layer cleanup

### DIFF
--- a/packages/common-types/src/services/TtsConfigResolver.test.ts
+++ b/packages/common-types/src/services/TtsConfigResolver.test.ts
@@ -2,12 +2,19 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TtsConfigResolver } from './TtsConfigResolver.js';
 import type { PrismaClient } from './prisma.js';
 
+// Hoisted logger spies so tests can assert severity (the WARN→ERROR upgrade
+// for personality-default lookup failures is a behavioral contract worth pinning).
+const { mockLoggerError, mockLoggerWarn } = vi.hoisted(() => ({
+  mockLoggerError: vi.fn(),
+  mockLoggerWarn: vi.fn(),
+}));
+
 vi.mock('../utils/logger.js', () => ({
   createLogger: () => ({
     debug: vi.fn(),
     info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
+    warn: mockLoggerWarn,
+    error: mockLoggerError,
   }),
 }));
 
@@ -190,6 +197,49 @@ describe('TtsConfigResolver', () => {
       expect(result.config.source).toBe('personality');
       expect(result.config.provider).toBe('mistral');
       expect(result.config.modelId).toBe('voxtral-mini-tts-2603');
+    });
+
+    it('logs at ERROR severity when PersonalityDefaultTtsConfig lookup throws (not WARN)', async () => {
+      // The user (bot owner) configured a personality TTS default and we
+      // can't load it — this is a misconfiguration, not graceful
+      // degradation. ERROR severity ensures it surfaces in dashboards
+      // rather than getting filtered with routine WARNs. The resolver
+      // still falls through to free-default for correct runtime behavior.
+      mockPrisma.user.findFirst.mockResolvedValue({
+        id: 'internal-x',
+        defaultTtsConfigId: null,
+        defaultTtsConfig: null,
+      });
+      mockPrisma.userPersonalityConfig.findFirst.mockResolvedValue(null);
+      mockPrisma.personalityDefaultTtsConfig.findUnique.mockRejectedValue(
+        new Error('connection refused')
+      );
+      mockPrisma.ttsConfig.findFirst.mockResolvedValue({
+        name: 'kyutai-self-hosted',
+        provider: 'self-hosted',
+        modelId: null,
+        advancedParameters: null,
+        isGlobal: true,
+        isDefault: false,
+        isFreeDefault: true,
+      });
+
+      const result = await resolver.resolveConfig('user-x', 'p-uuid-123', FAKE_PERSONALITY);
+
+      // Still falls through to free-default — no behavior regression
+      expect(result.source).toBe('free-default');
+
+      // ERROR was called with structured fields (not WARN)
+      const errorCall = mockLoggerError.mock.calls.find(call =>
+        String(call[1]).includes('Failed to load PersonalityDefaultTtsConfig')
+      );
+      expect(errorCall).toBeDefined();
+      expect((errorCall![0] as Record<string, unknown>).personalityId).toBe('p-uuid-123');
+      // No WARN call for this specific failure shape
+      const warnCall = mockLoggerWarn.mock.calls.find(call =>
+        String(call[1]).includes('Failed to load PersonalityDefaultTtsConfig')
+      );
+      expect(warnCall).toBeUndefined();
     });
 
     it('falls through to system free default (tier 4) when no PersonalityDefaultTtsConfig', async () => {

--- a/packages/common-types/src/services/TtsConfigResolver.ts
+++ b/packages/common-types/src/services/TtsConfigResolver.ts
@@ -162,9 +162,16 @@ export class TtsConfigResolver extends BaseConfigResolver<
         };
       }
     } catch (error) {
-      this.logger.warn(
+      // ERROR severity: anything that throws from findUnique here (Prisma
+      // connection issue, schema mismatch, transient network blip) means a
+      // user-configured personality TTS default couldn't be loaded. Falling
+      // through to free-default produces correct runtime behavior but masks
+      // the underlying issue; ERROR makes it visible in dashboards rather
+      // than getting filtered with routine WARNs. The cause (transient vs.
+      // structural) is captured in the err field for triage.
+      this.logger.error(
         { err: error, personalityId: personality.id },
-        'Failed to load PersonalityDefaultTtsConfig — falling through to free default'
+        'Failed to load PersonalityDefaultTtsConfig — falling through to free default (user-configured personality TTS default is unavailable)'
       );
     }
 

--- a/services/ai-worker/src/services/voice/TtsDispatcher.test.ts
+++ b/services/ai-worker/src/services/voice/TtsDispatcher.test.ts
@@ -11,6 +11,29 @@ import {
   type TtsProvider,
   type TtsProviderId,
 } from '@tzurot/common-types';
+
+// Hoisted logger spy so tests can pin the dispose-error logging contract.
+// `vi.hoisted` is required because vi.mock factories run before plain const
+// declarations.
+const { mockLoggerWarn } = vi.hoisted(() => ({
+  mockLoggerWarn: vi.fn(),
+}));
+
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      info: vi.fn(),
+      warn: mockLoggerWarn,
+      error: vi.fn(),
+      debug: vi.fn(),
+      trace: vi.fn(),
+      fatal: vi.fn(),
+    }),
+  };
+});
+
 import { dispatchTts, TtsDispatchError, type TtsProviderRegistry } from './TtsDispatcher.js';
 import { MistralReferenceAudioTooLongError } from './MistralTtsClient.js';
 
@@ -23,6 +46,7 @@ function makeProvider(
     canHandle: boolean;
     prepare: () => Promise<PreparedTts>;
     synthesize: () => Promise<Buffer>;
+    dispose: (handle: PreparedTts) => Promise<void>;
     capabilities: Partial<TtsCapabilities>;
   }> = {}
 ): TtsProvider {
@@ -33,7 +57,7 @@ function makeProvider(
     outputFormat: 'wav',
     ...overrides.capabilities,
   };
-  return {
+  const provider: TtsProvider = {
     id,
     displayName: id,
     capabilities,
@@ -42,6 +66,10 @@ function makeProvider(
     prepare: overrides.prepare ?? vi.fn(async () => buildPreparedVoiceId(id, `${id}-handle`)),
     synthesize: overrides.synthesize ?? vi.fn(async () => Buffer.from(`${id}-audio`)),
   };
+  if (overrides.dispose !== undefined) {
+    provider.dispose = vi.fn(overrides.dispose);
+  }
+  return provider;
 }
 
 function makeRegistry(providers: TtsProvider[]): TtsProviderRegistry {
@@ -604,5 +632,153 @@ describe('TtsDispatchError', () => {
     expect(dispatchError.attempts[1].provider).toBe('self-hosted');
     expect(dispatchError.message).toContain('mistral');
     expect(dispatchError.message).toContain('self-hosted');
+  });
+});
+
+// ===== dispose() lifecycle ==================================================
+
+describe('dispatchTts — provider.dispose() lifecycle', () => {
+  it('calls dispose() with the prepared handle after successful synthesize', async () => {
+    const dispose = vi.fn<(handle: PreparedTts) => Promise<void>>(async () => undefined);
+    const mistral = makeProvider('mistral', { dispose });
+    const selfHosted = makeProvider('self-hosted');
+
+    await dispatchTts({
+      text: 'hi',
+      resolvedConfig: mistralConfig,
+      ctx: baseCtx,
+      audioProviderKeys: audioKeysWithBoth,
+      registry: makeRegistry([mistral, selfHosted]),
+    });
+
+    expect(dispose).toHaveBeenCalledTimes(1);
+    // First arg is the handle returned by prepare()
+    const disposedHandle = dispose.mock.calls[0][0];
+    expect(disposedHandle).toMatchObject({ provider: 'mistral' });
+  });
+
+  it('calls dispose() even when synthesize fails (handle still cleaned up)', async () => {
+    const dispose = vi.fn(async () => undefined);
+    const mistralFails = makeProvider('mistral', {
+      synthesize: vi.fn(async () => {
+        throw new TtsProviderError(ApiErrorCategory.SERVER_ERROR, 'mistral', true, '500');
+      }),
+      dispose,
+    });
+    const selfHosted = makeProvider('self-hosted');
+
+    await dispatchTts({
+      text: 'hi',
+      resolvedConfig: mistralConfig,
+      ctx: baseCtx,
+      audioProviderKeys: audioKeysWithBoth,
+      registry: makeRegistry([mistralFails, selfHosted]),
+    });
+
+    // Mistral's dispose runs even though its synthesize threw
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT call dispose() if prepare() itself threw (no handle to dispose)', async () => {
+    const dispose = vi.fn(async () => undefined);
+    const mistralPrepareFails = makeProvider('mistral', {
+      prepare: vi.fn(async () => {
+        throw new Error('prepare exploded');
+      }),
+      dispose,
+    });
+    const selfHosted = makeProvider('self-hosted');
+
+    await dispatchTts({
+      text: 'hi',
+      resolvedConfig: mistralConfig,
+      ctx: baseCtx,
+      audioProviderKeys: audioKeysWithBoth,
+      registry: makeRegistry([mistralPrepareFails, selfHosted]),
+    });
+
+    expect(dispose).not.toHaveBeenCalled();
+  });
+
+  it('dispose() errors are logged but do not mask the synthesize result', async () => {
+    const dispose = vi.fn(async () => {
+      throw new Error('dispose failed');
+    });
+    const mistral = makeProvider('mistral', { dispose });
+    const selfHosted = makeProvider('self-hosted');
+
+    const result = await dispatchTts({
+      text: 'hi',
+      resolvedConfig: mistralConfig,
+      ctx: baseCtx,
+      audioProviderKeys: audioKeysWithBoth,
+      registry: makeRegistry([mistral, selfHosted]),
+    });
+
+    expect(result.providerUsed).toBe('mistral');
+    expect(result.audioBuffer.toString()).toBe('mistral-audio');
+    // dispose was attempted even though it failed
+    expect(dispose).toHaveBeenCalledTimes(1);
+    // The dispose failure must hit the logger (not silently dropped) so
+    // operators can debug a buggy dispose implementation. Pinning the
+    // logging contract — a future refactor that drops the warn would
+    // produce silent leak telemetry.
+    const disposeWarnCall = mockLoggerWarn.mock.calls.find(call =>
+      String(call[1]).includes('TtsProvider.dispose failed')
+    );
+    expect(disposeWarnCall).toBeDefined();
+  });
+
+  it('calls dispose() before rethrowing non-fallback-eligible TtsProviderError (rethrow path)', async () => {
+    // The catch block rethrows when `isFallbackEligible: false`. JS/TS finally
+    // semantics guarantee dispose() runs before the rethrow propagates, but a
+    // test pins the contract — a future refactor that moves the cleanup out
+    // of `finally` would silently break this guarantee.
+    const dispose = vi.fn(async () => undefined);
+    const mistralFatal = makeProvider('mistral', {
+      synthesize: vi.fn(async () => {
+        throw new TtsProviderError(
+          ApiErrorCategory.BAD_REQUEST,
+          'mistral',
+          false, // NOT fallback-eligible — dispatcher rethrows
+          'text too long'
+        );
+      }),
+      dispose,
+    });
+    const selfHosted = makeProvider('self-hosted');
+
+    await expect(
+      dispatchTts({
+        text: 'hi',
+        resolvedConfig: mistralConfig,
+        ctx: baseCtx,
+        audioProviderKeys: audioKeysWithBoth,
+        registry: makeRegistry([mistralFatal, selfHosted]),
+      })
+    ).rejects.toBeInstanceOf(TtsProviderError);
+
+    // dispose ran despite the rethrow propagating
+    expect(dispose).toHaveBeenCalledTimes(1);
+    // self-hosted was NOT tried (non-fallback-eligible aborts the chain)
+    expect(selfHosted.synthesize).not.toHaveBeenCalled();
+  });
+
+  it('handles providers without dispose() (the optional method) gracefully', async () => {
+    // Sanity check: providers that don't implement dispose still work — the
+    // optional method must remain optional, not become a hard requirement.
+    const mistral = makeProvider('mistral'); // no dispose
+    const selfHosted = makeProvider('self-hosted');
+
+    const result = await dispatchTts({
+      text: 'hi',
+      resolvedConfig: mistralConfig,
+      ctx: baseCtx,
+      audioProviderKeys: audioKeysWithBoth,
+      registry: makeRegistry([mistral, selfHosted]),
+    });
+
+    expect(result.providerUsed).toBe('mistral');
+    expect(mistral.dispose).toBeUndefined();
   });
 });

--- a/services/ai-worker/src/services/voice/TtsDispatcher.ts
+++ b/services/ai-worker/src/services/voice/TtsDispatcher.ts
@@ -273,8 +273,11 @@ async function attemptCandidate(input: AttemptInput): Promise<AttemptOutcome> {
     return { kind: 'skip' };
   }
 
+  // Handle declared outside the try so the finally block can dispose it
+  // regardless of whether synthesize succeeded, failed, or was rethrown.
+  let handle: PreparedTts | undefined;
   try {
-    const handle: PreparedTts = await provider.prepare(candidateCtx);
+    handle = await provider.prepare(candidateCtx);
     const audioBuffer = await provider.synthesize(options.text, handle, candidateCtx);
     const usedFallback = !isPrimaryAttempt;
     logger.info(
@@ -309,6 +312,23 @@ async function attemptCandidate(input: AttemptInput): Promise<AttemptOutcome> {
       'TTS provider failed; attempting next in chain'
     );
     return { kind: 'failed', error };
+  } finally {
+    // Optional handle cleanup. The interface declared `dispose?()` for
+    // future providers with WebSocket / temp-file lifecycles, but no caller
+    // was wired up — any provider implementing it would silently leak.
+    // `handle === undefined` when `prepare()` itself threw — nothing to
+    // dispose. Dispose errors are logged but never propagated, so a buggy
+    // dispose can't mask the original synthesize result/error.
+    if (handle !== undefined && provider.dispose !== undefined) {
+      try {
+        await provider.dispose(handle);
+      } catch (disposeError) {
+        logger.warn(
+          { slug: ctx.slug, provider: candidateId, err: disposeError },
+          'TtsProvider.dispose failed — handle may have leaked'
+        );
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Two related improvements to the TTS dispatch layer, addressing inbox items from PR #967 round 2:

### Bug 1 — Wire `TtsProvider.dispose()` in `attemptCandidate`'s `finally` block

The interface declared `dispose?(handle: PreparedTts): Promise<void>` "Reserved for future providers with WebSocket / temp-file lifecycle needs," but `TtsDispatcher` never invoked it. Any provider implementing the optional method would silently leak resources.

`attemptCandidate` now calls `dispose()` in its `finally` block when a handle was acquired (covers both success and failure paths). Dispose errors are caught + logged but never propagated — a buggy dispose can't mask the original synthesize result/error.

### Bug 2 — Upgrade `TtsConfigResolver` personality-default error severity from WARN → ERROR

When `findUnique({ personalityId })` throws (Prisma error, schema mismatch), the resolver still falls through to free-default for correct runtime behavior — but the user (bot owner) configured a TTS default we couldn't load. That's a misconfiguration, not graceful degradation. ERROR severity surfaces it in dashboards instead of getting filtered with routine WARNs.

## Tests

- 5 new dispose() lifecycle tests in `TtsDispatcher.test.ts`:
  - dispose called with handle after successful synthesize
  - dispose called even when synthesize fails (handle still cleaned up)
  - dispose NOT called if prepare() threw (no handle)
  - dispose error doesn't mask synthesize result
  - providers without dispose() still work (optional method respected)
- 1 new ERROR-severity test in `TtsConfigResolver.test.ts` using hoisted logger spies (same pattern as `MistralTtsProvider.test.ts` from PR #975)

Test count: 3070 → 3076 (+6 net).

## Test plan

- [x] `pnpm test` — 14/14 packages green
- [x] `pnpm quality` + `pnpm knip` — clean
- [ ] CI green before merge

## Related backlog items resolved

- 🧹 `TtsProvider.dispose()` declared but never called
- 🐛 `TtsConfigResolver` personality-default Prisma error silently falls through

🤖 Generated with [Claude Code](https://claude.com/claude-code)
