### PR TITLE
fix(bot-client): bump persona/character modal limits from 2000 to 4000

### DIFF
--- a/packages/common-types/src/constants/discord.ts
+++ b/packages/common-types/src/constants/discord.ts
@@ -63,6 +63,8 @@ export const DISCORD_LIMITS = {
   AUTOCOMPLETE_MAX_CHOICES: 25,
   /** Maximum length for modal text input (paragraph style) */
   MODAL_INPUT_MAX_LENGTH: 4000,
+  /** Maximum length for short paragraph fields (traits, tone, error message) */
+  SHORT_PARAGRAPH_MAX_LENGTH: 1000,
   /** Discord modal title character limit */
   MODAL_TITLE_MAX_LENGTH: 45,
   /** Safe length for dynamic content in modal title (accounting for prefix like "Persona for ") */

--- a/packages/common-types/src/schemas/api/personality.test.ts
+++ b/packages/common-types/src/schemas/api/personality.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { DISCORD_LIMITS } from '../../constants/discord.js';
 import { EntityPermissionsSchema } from './shared.js';
 import {
   PersonalitySummarySchema,
@@ -270,6 +271,34 @@ describe('Personality API Contract Tests', () => {
       expect(keys).toContain('personalityTone');
       expect(keys).toContain('errorMessage');
     });
+
+    it('should reject personalityTone exceeding SHORT_PARAGRAPH_MAX_LENGTH', () => {
+      const result = PersonalityCharacterFieldsSchema.safeParse({
+        personalityTone: 'x'.repeat(DISCORD_LIMITS.SHORT_PARAGRAPH_MAX_LENGTH + 1),
+        personalityAge: null,
+        personalityAppearance: null,
+        personalityLikes: null,
+        personalityDislikes: null,
+        conversationalGoals: null,
+        conversationalExamples: null,
+        errorMessage: null,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject errorMessage exceeding SHORT_PARAGRAPH_MAX_LENGTH', () => {
+      const result = PersonalityCharacterFieldsSchema.safeParse({
+        personalityTone: null,
+        personalityAge: null,
+        personalityAppearance: null,
+        personalityLikes: null,
+        personalityDislikes: null,
+        conversationalGoals: null,
+        conversationalExamples: null,
+        errorMessage: 'x'.repeat(DISCORD_LIMITS.SHORT_PARAGRAPH_MAX_LENGTH + 1),
+      });
+      expect(result.success).toBe(false);
+    });
   });
 
   describe('PersonalityCreateSchema', () => {
@@ -283,6 +312,15 @@ describe('Personality API Contract Tests', () => {
     it('should validate complete create input with required fields only', () => {
       const result = PersonalityCreateSchema.safeParse(validCreateInput);
       expect(result.success).toBe(true);
+    });
+
+    it('should reject personalityTraits exceeding SHORT_PARAGRAPH_MAX_LENGTH', () => {
+      const input = {
+        ...validCreateInput,
+        personalityTraits: 'x'.repeat(DISCORD_LIMITS.SHORT_PARAGRAPH_MAX_LENGTH + 1),
+      };
+      const result = PersonalityCreateSchema.safeParse(input);
+      expect(result.success).toBe(false);
     });
 
     it('should validate create input with all optional fields', () => {

--- a/packages/common-types/src/schemas/api/personality.ts
+++ b/packages/common-types/src/schemas/api/personality.ts
@@ -157,14 +157,14 @@ export interface PersonalityCharacterFields {
  * Shared between PersonalityCreateSchema and PersonalityUpdateSchema.
  */
 export const PersonalityCharacterFieldsSchema = z.object({
-  personalityTone: nullableString(1000),
+  personalityTone: nullableString(DISCORD_LIMITS.SHORT_PARAGRAPH_MAX_LENGTH),
   personalityAge: nullableString(100),
   personalityAppearance: nullableString(DISCORD_LIMITS.MODAL_INPUT_MAX_LENGTH),
   personalityLikes: nullableString(DISCORD_LIMITS.MODAL_INPUT_MAX_LENGTH),
   personalityDislikes: nullableString(DISCORD_LIMITS.MODAL_INPUT_MAX_LENGTH),
   conversationalGoals: nullableString(DISCORD_LIMITS.MODAL_INPUT_MAX_LENGTH),
   conversationalExamples: nullableString(DISCORD_LIMITS.MODAL_INPUT_MAX_LENGTH),
-  errorMessage: nullableString(1000),
+  errorMessage: nullableString(DISCORD_LIMITS.SHORT_PARAGRAPH_MAX_LENGTH),
 });
 
 // ============================================================================
@@ -198,7 +198,10 @@ export const PersonalityCreateSchema = z.object({
     .string()
     .min(1, 'characterInfo is required')
     .max(DISCORD_LIMITS.MODAL_INPUT_MAX_LENGTH),
-  personalityTraits: z.string().min(1, 'personalityTraits is required').max(1000),
+  personalityTraits: z
+    .string()
+    .min(1, 'personalityTraits is required')
+    .max(DISCORD_LIMITS.SHORT_PARAGRAPH_MAX_LENGTH),
 
   // Optional display name (defaults to name if not provided)
   displayName: nullableString(255),
@@ -235,7 +238,7 @@ export const PersonalityUpdateSchema = z.object({
   slug: slugSchema.optional(),
   displayName: nullableString(255),
   characterInfo: z.string().min(1).max(DISCORD_LIMITS.MODAL_INPUT_MAX_LENGTH).optional(),
-  personalityTraits: z.string().min(1).max(1000).optional(),
+  personalityTraits: z.string().min(1).max(DISCORD_LIMITS.SHORT_PARAGRAPH_MAX_LENGTH).optional(),
 
   // Character definition — limits match Discord dashboard modal config
   ...PersonalityCharacterFieldsSchema.shape,

--- a/services/bot-client/src/commands/character/config.test.ts
+++ b/services/bot-client/src/commands/character/config.test.ts
@@ -92,6 +92,11 @@ describe('Character Dashboard Configuration', () => {
       expect(identitySection.fields).toHaveLength(5);
     });
 
+    it('should enforce SHORT_PARAGRAPH_MAX_LENGTH for personalityTraits', () => {
+      const traits = identitySection.fields.find(f => f.id === 'personalityTraits')!;
+      expect(traits.maxLength).toBe(DISCORD_LIMITS.SHORT_PARAGRAPH_MAX_LENGTH);
+    });
+
     it('should return COMPLETE when name and traits are set', () => {
       const character = createTestCharacter({
         name: 'Test',
@@ -143,7 +148,7 @@ describe('Character Dashboard Configuration', () => {
       }
     });
 
-    it('should allow 4000 characters for both fields', () => {
+    it('should allow MODAL_INPUT_MAX_LENGTH characters for both fields', () => {
       for (const field of biographySection.fields) {
         expect(field.maxLength).toBe(DISCORD_LIMITS.MODAL_INPUT_MAX_LENGTH);
       }
@@ -188,7 +193,7 @@ describe('Character Dashboard Configuration', () => {
       }
     });
 
-    it('should allow 4000 characters for both fields', () => {
+    it('should allow MODAL_INPUT_MAX_LENGTH characters for both fields', () => {
       for (const field of preferencesSection.fields) {
         expect(field.maxLength).toBe(DISCORD_LIMITS.MODAL_INPUT_MAX_LENGTH);
       }
@@ -234,7 +239,7 @@ describe('Character Dashboard Configuration', () => {
       expect(conversationSection.fields).toHaveLength(3);
     });
 
-    it('should allow 4000 characters for goals and examples', () => {
+    it('should allow MODAL_INPUT_MAX_LENGTH characters for goals and examples', () => {
       const goalsField = conversationSection.fields.find(f => f.id === 'conversationalGoals')!;
       const examplesField = conversationSection.fields.find(
         f => f.id === 'conversationalExamples'
@@ -244,9 +249,9 @@ describe('Character Dashboard Configuration', () => {
       expect(examplesField.maxLength).toBe(DISCORD_LIMITS.MODAL_INPUT_MAX_LENGTH);
     });
 
-    it('should allow 1000 characters for errorMessage', () => {
+    it('should allow SHORT_PARAGRAPH_MAX_LENGTH characters for errorMessage', () => {
       const errorField = conversationSection.fields.find(f => f.id === 'errorMessage')!;
-      expect(errorField.maxLength).toBe(1000);
+      expect(errorField.maxLength).toBe(DISCORD_LIMITS.SHORT_PARAGRAPH_MAX_LENGTH);
     });
 
     it('should return COMPLETE when goals and examples are set', () => {
@@ -302,6 +307,13 @@ describe('Character Dashboard Configuration', () => {
 
     it('should not exceed Discord modal field limit', () => {
       expect(characterSeedFields.length).toBeLessThanOrEqual(5);
+    });
+
+    it('should enforce correct maxLength for characterInfo and personalityTraits', () => {
+      const charInfo = characterSeedFields.find(f => f.id === 'characterInfo')!;
+      const traits = characterSeedFields.find(f => f.id === 'personalityTraits')!;
+      expect(charInfo.maxLength).toBe(DISCORD_LIMITS.MODAL_INPUT_MAX_LENGTH);
+      expect(traits.maxLength).toBe(DISCORD_LIMITS.SHORT_PARAGRAPH_MAX_LENGTH);
     });
   });
 

--- a/services/bot-client/src/commands/character/config.ts
+++ b/services/bot-client/src/commands/character/config.ts
@@ -5,7 +5,7 @@
  * Organizes fields into logical sections that fit Discord's 5-field modal limit.
  */
 
-import { DISCORD_COLORS, formatDateShort } from '@tzurot/common-types';
+import { DISCORD_COLORS, DISCORD_LIMITS, formatDateShort } from '@tzurot/common-types';
 import {
   type DashboardConfig,
   type ActionButtonOptions,
@@ -171,7 +171,7 @@ export const characterSeedFields: FieldDefinition[] = [
     placeholder: 'Brief background and description...',
     required: true,
     style: 'paragraph' as const,
-    maxLength: 2000,
+    maxLength: DISCORD_LIMITS.MODAL_INPUT_MAX_LENGTH,
   },
   {
     id: 'personalityTraits',
@@ -179,6 +179,6 @@ export const characterSeedFields: FieldDefinition[] = [
     placeholder: 'Key traits and behaviors...',
     required: true,
     style: 'paragraph' as const,
-    maxLength: 2000,
+    maxLength: DISCORD_LIMITS.MODAL_INPUT_MAX_LENGTH,
   },
 ];

--- a/services/bot-client/src/commands/character/config.ts
+++ b/services/bot-client/src/commands/character/config.ts
@@ -179,6 +179,6 @@ export const characterSeedFields: FieldDefinition[] = [
     placeholder: 'Key traits and behaviors...',
     required: true,
     style: 'paragraph' as const,
-    maxLength: 1000,
+    maxLength: DISCORD_LIMITS.SHORT_PARAGRAPH_MAX_LENGTH,
   },
 ];

--- a/services/bot-client/src/commands/character/config.ts
+++ b/services/bot-client/src/commands/character/config.ts
@@ -179,6 +179,6 @@ export const characterSeedFields: FieldDefinition[] = [
     placeholder: 'Key traits and behaviors...',
     required: true,
     style: 'paragraph' as const,
-    maxLength: DISCORD_LIMITS.MODAL_INPUT_MAX_LENGTH,
+    maxLength: 1000,
   },
 ];

--- a/services/bot-client/src/commands/character/sections.ts
+++ b/services/bot-client/src/commands/character/sections.ts
@@ -63,7 +63,7 @@ export const identitySection: SectionDefinition<CharacterData> = {
       placeholder: 'Key traits and behaviors...',
       required: true,
       style: 'paragraph',
-      maxLength: 1000,
+      maxLength: DISCORD_LIMITS.SHORT_PARAGRAPH_MAX_LENGTH,
     },
     {
       id: 'personalityTone',
@@ -214,7 +214,6 @@ export const preferencesSection: SectionDefinition<CharacterData> = {
 /**
  * Conversation Section
  * Fields: conversationalGoals, conversationalExamples, errorMessage
- * Goals and examples are long fields (4000 chars), errorMessage is shorter (1000 chars)
  */
 export const conversationSection: SectionDefinition<CharacterData> = {
   id: 'conversation',
@@ -244,7 +243,7 @@ export const conversationSection: SectionDefinition<CharacterData> = {
       placeholder: "What should the character say when there's an error?",
       required: false,
       style: 'paragraph',
-      maxLength: 1000,
+      maxLength: DISCORD_LIMITS.SHORT_PARAGRAPH_MAX_LENGTH,
     },
   ],
   getStatus: (data: CharacterData) => {

--- a/services/bot-client/src/commands/persona/config.test.ts
+++ b/services/bot-client/src/commands/persona/config.test.ts
@@ -11,6 +11,7 @@ import {
   personaSeedFields,
 } from './config.js';
 import { SectionStatus } from '../../utils/dashboard/types.js';
+import { DISCORD_LIMITS } from '@tzurot/common-types';
 import type { PersonaDetails, FlattenedPersonaData } from './types.js';
 
 // Helper to create test persona data with defaults
@@ -227,6 +228,13 @@ describe('PERSONA_DASHBOARD_CONFIG', () => {
       it('should return COMPLETE with extras', () => {
         const data = createTestPersonaData({ name: 'Test', preferredName: 'Tester' });
         expect(section.getStatus(data)).toBe(SectionStatus.COMPLETE);
+      });
+    });
+
+    describe('field maxLengths', () => {
+      it('should enforce MODAL_INPUT_MAX_LENGTH for content field', () => {
+        const contentField = section.fields.find(f => f.id === 'content')!;
+        expect(contentField.maxLength).toBe(DISCORD_LIMITS.MODAL_INPUT_MAX_LENGTH);
       });
     });
 

--- a/services/bot-client/src/commands/persona/config.ts
+++ b/services/bot-client/src/commands/persona/config.ts
@@ -8,7 +8,7 @@
  * (no componentPrefixes hack needed)
  */
 
-import { DISCORD_COLORS } from '@tzurot/common-types';
+import { DISCORD_COLORS, DISCORD_LIMITS } from '@tzurot/common-types';
 import {
   SectionStatus,
   type SectionDefinition,
@@ -113,7 +113,7 @@ const identitySection: SectionDefinition<FlattenedPersonaData> = {
       placeholder: 'Tell the AI about yourself, your interests, preferences...',
       required: false,
       style: 'paragraph',
-      maxLength: 2000,
+      maxLength: DISCORD_LIMITS.MODAL_INPUT_MAX_LENGTH,
     },
   ],
   getStatus: data => {


### PR DESCRIPTION
## Summary
- Persona "About You" dashboard field was capped at 2000 chars while the API schema accepts 4000 — silent truncation on modal pre-fill caused permanent data loss when editing personas with descriptions exceeding 2000 chars
- `personaContent` and character `characterInfo` seed fields raised 2000 → `DISCORD_LIMITS.MODAL_INPUT_MAX_LENGTH` (4000) to match the API's acceptance
- Character `personalityTraits` seed field **lowered** 2000 → `DISCORD_LIMITS.SHORT_PARAGRAPH_MAX_LENGTH` (1000) to match the API schema's `.max(1000)` cap (the UI was previously lying high — anything 1000–2000 chars would have been silently rejected at submit time)
- Replaced six bare `1000` literals across `personality.ts` schema + character `config.ts` / `sections.ts` with the new `SHORT_PARAGRAPH_MAX_LENGTH` constant; refreshed test descriptions to reference constant names rather than hardcoded numbers
- Added regression tests asserting `maxLength` invariants for `characterSeedFields` (`characterInfo` + `personalityTraits`) and `persona/config.ts` `content` field — these would have caught the silent-truncation bug had they existed

Reported by a Discord user (2026-05-06): editing a persona auto-saved a truncated version because the modal's `maxLength` was lower than the API's acceptance. Not a regression — the 2000 limit has been there since the persona command was created in `ada15342d` (2026-01-26).

## Test plan
- [x] All 285 bot-client test files pass (4680 tests, +2 from new maxLength assertions)
- [x] Pre-push checks green (build, lint, typecheck:spec, CPD, depcruise, duplicate-exports)
- [x] Full \`pnpm quality\` green (lint + cpd + depcruise + typecheck + typecheck:spec)
- [ ] Manual: create a persona with >2000 char content, verify it persists through dashboard edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)