### PR TITLE
feat(bot-client): add persona dashboard truncation warning gate

### DIFF
--- a/packages/tooling/src/dev/check-duplicate-exports.ts
+++ b/packages/tooling/src/dev/check-duplicate-exports.ts
@@ -102,13 +102,17 @@ const ALLOWLIST: Record<string, Set<string>> = {
     'handlePersonalityAutocomplete',
     'handlePersonaAutocomplete',
     // Same-name button handlers across distinct domains — character section
-    // editing (truncationWarning.ts) and memory editing (memory/detailModals.ts,
-    // memory/detail.ts). Different state machines, different custom-id
-    // namespaces, different tests. Renaming to disambiguate would touch the
-    // custom-id wiring in 6+ places — out of scope for this gate.
+    // editing (truncationWarning.ts), persona section editing
+    // (persona/truncationWarning.ts), and memory editing
+    // (memory/detailModals.ts, memory/detail.ts). Different state machines,
+    // different custom-id namespaces, different tests. Renaming to
+    // disambiguate would touch the custom-id wiring in 6+ places — out of
+    // scope for this gate.
     'handleEditTruncatedButton',
+    'handleOpenEditorButton',
     'handleViewFullButton',
     'handleCancelEditButton',
+    'showTruncationWarning',
   ]),
 };
 

--- a/services/bot-client/src/commands/character/dashboard.ts
+++ b/services/bot-client/src/commands/character/dashboard.ts
@@ -43,13 +43,13 @@ import { handleSharedBackButton } from '../../utils/dashboard/index.js';
 // renderPostActionScreen + handleSharedBackButton.
 import './browse.js';
 import {
-  detectOverLengthFields,
   handleCancelEditButton,
   handleEditTruncatedButton,
   handleOpenEditorButton,
   handleViewFullButton,
   showTruncationWarning,
 } from './truncationWarning.js';
+import { detectOverLengthFields } from '../../utils/dashboard/truncationGate/index.js';
 import { resolveCharacterSectionContext } from './sectionContext.js';
 
 const logger = createLogger('character-dashboard');

--- a/services/bot-client/src/commands/character/truncationWarning.test.ts
+++ b/services/bot-client/src/commands/character/truncationWarning.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { ButtonStyle, MessageFlags } from 'discord.js';
+import { MessageFlags } from 'discord.js';
 import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
 
 // Mock common-types — logger, DISCORD_COLORS, isBotOwner, getConfig.
@@ -60,11 +60,6 @@ vi.mock('../../utils/dashboard/ModalFactory.js', async importOriginal => {
 
 // Import after mocks so the factory resolves before module load.
 const {
-  detectOverLengthFields,
-  buildTruncationWarningEmbed,
-  buildTruncationButtons,
-  buildOpenEditorButtonRow,
-  buildReadyToEditEmbed,
   showTruncationWarning,
   handleEditTruncatedButton,
   handleOpenEditorButton,
@@ -93,138 +88,6 @@ const identitySectionStub = {
   getPreview: () => '',
 };
 
-describe('detectOverLengthFields', () => {
-  it('returns empty when no field exceeds its maxLength', () => {
-    const data = {
-      personalityAge: 'a short age',
-      personalityTraits: 'short traits',
-    } as unknown as Parameters<typeof detectOverLengthFields>[1];
-
-    const result = detectOverLengthFields(identitySectionStub, data);
-    expect(result).toEqual([]);
-  });
-
-  it('flags a field whose value exceeds the cap', () => {
-    const data = {
-      personalityAge: 'x'.repeat(150), // over the 100 cap
-      personalityTraits: 'ok',
-    } as unknown as Parameters<typeof detectOverLengthFields>[1];
-
-    const result = detectOverLengthFields(identitySectionStub, data);
-    expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject({
-      fieldId: 'personalityAge',
-      label: 'Age',
-      current: 150,
-      max: 100,
-    });
-  });
-
-  it('flags multiple over-cap fields independently', () => {
-    const data = {
-      personalityAge: 'x'.repeat(150),
-      personalityTraits: 'y'.repeat(1500),
-    } as unknown as Parameters<typeof detectOverLengthFields>[1];
-
-    const result = detectOverLengthFields(identitySectionStub, data);
-    expect(result).toHaveLength(2);
-    expect(result.map(r => r.fieldId).sort()).toEqual(['personalityAge', 'personalityTraits']);
-  });
-
-  it('ignores non-string values and missing fields', () => {
-    const data = {
-      personalityAge: null,
-      personalityTraits: undefined,
-      unrelated: 'x'.repeat(5000),
-    } as unknown as Parameters<typeof detectOverLengthFields>[1];
-
-    const result = detectOverLengthFields(identitySectionStub, data);
-    expect(result).toEqual([]);
-  });
-});
-
-describe('buildTruncationWarningEmbed', () => {
-  it('includes per-field char counts and the total truncation amount', () => {
-    const embed = buildTruncationWarningEmbed(
-      [
-        { fieldId: 'personalityAge', label: 'Age', current: 150, max: 100 },
-        {
-          fieldId: 'personalityTraits',
-          label: 'Traits',
-          current: 1500,
-          max: 1000,
-        },
-      ],
-      '🏷️ Identity & Basics'
-    );
-
-    const json = embed.toJSON();
-    expect(json.title).toContain('"Identity & Basics"');
-    expect(json.description).toContain('Age');
-    expect(json.description).toContain('150');
-    expect(json.description).toContain('100');
-    expect(json.description).toContain('Traits');
-    expect(json.description).toContain('1,500');
-    // Footer lists total truncation across all fields: (150-100)+(1500-1000)=550
-    expect(json.footer?.text).toContain('550');
-    // Plural form — two fields should read "2 fields", never "2 field(s)"
-    expect(json.footer?.text).toContain('2 fields');
-    expect(json.footer?.text).not.toContain('field(s)');
-  });
-
-  it('uses singular "field" in the footer when only one field is over-length', () => {
-    // Guards against the "1 field(s)" pluralization regression flagged in PR
-    // review. The single-field path is the common case for short legacy
-    // fields (e.g. a stray overgrown "Age" value) and needs to read cleanly.
-    const embed = buildTruncationWarningEmbed(
-      [{ fieldId: 'personalityAge', label: 'Age', current: 150, max: 100 }],
-      '🏷️ Identity & Basics'
-    );
-    const json = embed.toJSON();
-    expect(json.footer?.text).toContain('1 field');
-    expect(json.footer?.text).not.toContain('1 fields');
-    expect(json.footer?.text).not.toContain('field(s)');
-  });
-});
-
-describe('buildTruncationButtons', () => {
-  it('emits three buttons with character dashboard customId shape', () => {
-    const row = buildTruncationButtons('char-1', 'identity');
-    const json = row.toJSON();
-    expect(json.components).toHaveLength(3);
-    const customIds = json.components.map(c => (c as { custom_id: string }).custom_id);
-    // Ordered per `04-discord.md` Standard Button Order: Primary (View Full)
-    // first, Secondary (Cancel) middle, Destructive (Edit with Truncation)
-    // last. A regression that reverts to destructive-first would break
-    // consistency with delete-confirmation dialogs across the codebase.
-    expect(customIds).toEqual([
-      'character::view_full::char-1::identity',
-      'character::cancel_edit::char-1::identity',
-      'character::edit_truncated::char-1::identity',
-    ]);
-  });
-
-  it('places the Danger-styled button last per destructive-last rule', () => {
-    const row = buildTruncationButtons('char-1', 'identity');
-    const json = row.toJSON();
-    const styles = json.components.map(c => (c as { style: number }).style);
-    // ButtonStyle.Danger = 4; verify it's the last button's style.
-    expect(styles[styles.length - 1]).toBe(ButtonStyle.Danger);
-  });
-
-  it('sets an emoji on every button per 04-discord.md consistency rule', () => {
-    // The rule (`.claude/rules/04-discord.md`) requires `.setEmoji()` on
-    // every button for visual sizing consistency. All three warning
-    // buttons must have an emoji set.
-    const row = buildTruncationButtons('char-1', 'identity');
-    const json = row.toJSON();
-    for (const component of json.components) {
-      const button = component as { emoji?: { name: string } };
-      expect(button.emoji?.name, `button ${JSON.stringify(component)} missing emoji`).toBeDefined();
-    }
-  });
-});
-
 describe('showTruncationWarning', () => {
   it('replies ephemerally with the warning embed and button row', async () => {
     const mockReply = vi.fn().mockResolvedValue(undefined);
@@ -241,26 +104,6 @@ describe('showTruncationWarning', () => {
         components: expect.arrayContaining([expect.any(Object)]),
       })
     );
-  });
-});
-
-describe('buildReadyToEditEmbed', () => {
-  it('strips the leading emoji and names the section in the title', () => {
-    const embed = buildReadyToEditEmbed('🏷️ Identity & Basics');
-    const json = embed.toJSON();
-    expect(json.title).toContain('Identity & Basics');
-    expect(json.title).not.toContain('🏷️');
-  });
-});
-
-describe('buildOpenEditorButtonRow', () => {
-  it('emits a single Open Editor button with the expected customId shape', () => {
-    const row = buildOpenEditorButtonRow('char-1', 'identity');
-    const json = row.toJSON();
-    expect(json.components).toHaveLength(1);
-    const button = json.components[0] as { custom_id: string; label?: string };
-    expect(button.custom_id).toBe('character::open_editor::char-1::identity');
-    expect(button.label).toBe('Open Editor');
   });
 });
 

--- a/services/bot-client/src/commands/character/truncationWarning.ts
+++ b/services/bot-client/src/commands/character/truncationWarning.ts
@@ -14,19 +14,21 @@
  * committing.
  */
 
-import {
-  EmbedBuilder,
-  ButtonBuilder,
-  ButtonStyle,
-  ActionRowBuilder,
-  AttachmentBuilder,
-  DiscordAPIError,
-  MessageFlags,
-} from 'discord.js';
+import { AttachmentBuilder, DiscordAPIError, MessageFlags } from 'discord.js';
 import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
-import { createLogger, DISCORD_COLORS, getConfig, type EnvConfig } from '@tzurot/common-types';
-import { buildDashboardCustomId, type SectionDefinition } from '../../utils/dashboard/types.js';
+import { createLogger, getConfig, type EnvConfig } from '@tzurot/common-types';
+import { type SectionDefinition } from '../../utils/dashboard/types.js';
 import { buildSectionModal } from '../../utils/dashboard/ModalFactory.js';
+import {
+  detectOverLengthFields,
+  buildTruncationWarningEmbed,
+  buildTruncationButtons,
+  buildOpenEditorButtonRow,
+  buildReadyToEditEmbed,
+  stripLeadingEmoji,
+  toSafeFilename,
+  type OverLengthField,
+} from '../../utils/dashboard/truncationGate/index.js';
 import type { CharacterData } from './characterTypes.js';
 import {
   findCharacterSection,
@@ -35,147 +37,7 @@ import {
 } from './sectionContext.js';
 
 const logger = createLogger('character-truncation-warning');
-
-/**
- * Strip a leading emoji + whitespace from a section label so modal titles
- * / embed titles / attachment copy read cleanly. Mirrors the inline regex
- * in `ModalFactory.ts:51` (modal title derivation) — kept in sync by
- * convention until a section-label shortener becomes a third consumer
- * that warrants a shared helper.
- */
-function stripLeadingEmoji(label: string): string {
-  return label.replace(/^[^\w\s]+\s*/, '');
-}
-
-/**
- * Convert a user-facing field label into a safe filename slug. Lowercased,
- * whitespace collapsed to underscores, non-alphanumeric chars removed so
- * the resulting name works across OSes. Used for View Full attachments so
- * the user sees `age.txt` instead of the internal `personalityAge.txt`.
- */
-function toSafeFilename(label: string): string {
-  return label
-    .toLowerCase()
-    .trim()
-    .replace(/\s+/g, '_')
-    .replace(/[^a-z0-9_]/g, '');
-}
-
-/**
- * A field whose current value exceeds its modal maxLength.
- */
-export interface OverLengthField {
-  /** The field id (matches CharacterData key) */
-  fieldId: string;
-  /** The user-facing label */
-  label: string;
-  /** Current character count */
-  current: number;
-  /** Configured maxLength — what the edit modal will truncate down to */
-  max: number;
-}
-
-/**
- * Scan a section's fields and report any whose current value exceeds
- * the modal's maxLength constraint.
- *
- * `maxLength` is a required field on `FieldDefinition` (see
- * `utils/dashboard/types.ts`), so every field always has an explicit
- * cap to check against.
- */
-export function detectOverLengthFields(
-  section: SectionDefinition<CharacterData>,
-  data: CharacterData
-): OverLengthField[] {
-  const over: OverLengthField[] = [];
-  for (const field of section.fields) {
-    const raw = (data as Record<string, unknown>)[field.id];
-    if (typeof raw !== 'string') {
-      continue;
-    }
-    if (raw.length > field.maxLength) {
-      over.push({
-        fieldId: field.id,
-        label: field.label,
-        current: raw.length,
-        max: field.maxLength,
-      });
-    }
-  }
-  return over;
-}
-
-/**
- * Build the destructive-action warning embed listing the over-length
- * fields, their current lengths, and the per-field truncation amount.
- */
-export function buildTruncationWarningEmbed(
-  overLength: OverLengthField[],
-  sectionLabel: string
-): EmbedBuilder {
-  const plainLabel = stripLeadingEmoji(sectionLabel);
-
-  const fieldLines = overLength
-    .map(f => {
-      const loss = f.current - f.max;
-      return (
-        `• **${f.label}** — ${f.current.toLocaleString()} / ${f.max.toLocaleString()} chars ` +
-        `(${loss.toLocaleString()} will be truncated)`
-      );
-    })
-    .join('\n');
-
-  const totalLoss = overLength.reduce((sum, f) => sum + (f.current - f.max), 0);
-
-  return new EmbedBuilder()
-    .setTitle(`⚠️ "${plainLabel}" contains content longer than Discord modals allow`)
-    .setColor(DISCORD_COLORS.WARNING)
-    .setDescription(
-      `One or more fields in this section hold values that exceed the edit modal's limit:\n\n` +
-        `${fieldLines}\n\n` +
-        `⚠️ **Opening the edit modal will pre-fill the fields with truncated values.** ` +
-        `If you save the modal, the trailing content will be lost permanently.\n\n` +
-        `Choose **View Full** to inspect the current full content before deciding. ` +
-        `Choose **Edit with Truncation** only if you're OK losing the trailing text.`
-    )
-    .setFooter({
-      text: `${totalLoss.toLocaleString()} total characters would be truncated across ${overLength.length} field${overLength.length === 1 ? '' : 's'}`,
-    });
-}
-
-/**
- * Build the three-button row for the warning, ordered per `04-discord.md`
- * Standard Button Order (Primary first, Destructive last):
- * - View Full (primary, safe read-only inspection)
- * - Cancel (secondary, dismiss)
- * - Edit with Truncation (danger, opt-in to destructive edit)
- *
- * The destructive-last convention matches the memory detail flow and the
- * delete-confirmation dialogs across the codebase; consistency outranks
- * the "lead with the warning" instinct for this UX.
- */
-export function buildTruncationButtons(
-  entityId: string,
-  sectionId: string
-): ActionRowBuilder<ButtonBuilder> {
-  return new ActionRowBuilder<ButtonBuilder>().addComponents(
-    new ButtonBuilder()
-      .setCustomId(buildDashboardCustomId('character', 'view_full', entityId, sectionId))
-      .setLabel('View Full')
-      .setEmoji('📖')
-      .setStyle(ButtonStyle.Primary),
-    new ButtonBuilder()
-      .setCustomId(buildDashboardCustomId('character', 'cancel_edit', entityId, sectionId))
-      .setLabel('Cancel')
-      .setEmoji('✖️')
-      .setStyle(ButtonStyle.Secondary),
-    new ButtonBuilder()
-      .setCustomId(buildDashboardCustomId('character', 'edit_truncated', entityId, sectionId))
-      .setLabel('Edit with Truncation')
-      .setEmoji('✂️')
-      .setStyle(ButtonStyle.Danger)
-  );
-}
+const ENTITY_TYPE = 'character';
 
 /**
  * Show the truncation warning as an ephemeral reply to the select-menu
@@ -189,45 +51,9 @@ export async function showTruncationWarning(
 ): Promise<void> {
   await interaction.reply({
     embeds: [buildTruncationWarningEmbed(overLength, section.label)],
-    components: [buildTruncationButtons(entityId, section.id)],
+    components: [buildTruncationButtons(ENTITY_TYPE, entityId, section.id)],
     flags: MessageFlags.Ephemeral,
   });
-}
-
-/**
- * Build the "Open Editor" button shown after the user opts into the
- * truncating edit. Splitting the opt-in confirmation from the modal-open
- * click lets us satisfy Discord's "showModal must be the first response"
- * constraint without doing any async work before the showModal call.
- */
-export function buildOpenEditorButtonRow(
-  entityId: string,
-  sectionId: string
-): ActionRowBuilder<ButtonBuilder> {
-  return new ActionRowBuilder<ButtonBuilder>().addComponents(
-    new ButtonBuilder()
-      .setCustomId(buildDashboardCustomId('character', 'open_editor', entityId, sectionId))
-      .setLabel('Open Editor')
-      .setEmoji('✏️')
-      .setStyle(ButtonStyle.Primary)
-  );
-}
-
-/**
- * Build the embed shown between the Edit-with-Truncation opt-in and the
- * actual modal. It reassures the user that their consent was recorded
- * and directs them to the single click that opens the modal.
- */
-export function buildReadyToEditEmbed(sectionLabel: string): EmbedBuilder {
-  const plainLabel = stripLeadingEmoji(sectionLabel);
-  return new EmbedBuilder()
-    .setTitle(`✅ Ready to edit "${plainLabel}"`)
-    .setColor(DISCORD_COLORS.SUCCESS)
-    .setDescription(
-      `Your opt-in to truncate over-length fields has been recorded. ` +
-        `Click **Open Editor** below to open the edit modal. ` +
-        `The modal will open with the current values truncated to the edit limit.`
-    );
 }
 
 /**
@@ -267,7 +93,7 @@ export async function handleEditTruncatedButton(
   // Step 1 — ack within the 3-sec budget via `update`. No async before this.
   await interaction.update({
     embeds: [buildReadyToEditEmbed(sectionLabel)],
-    components: [buildOpenEditorButtonRow(entityId, sectionId)],
+    components: [buildOpenEditorButtonRow(ENTITY_TYPE, entityId, sectionId)],
   });
 
   // Step 2 — warm the session so the Open Editor click gets a hot cache

--- a/services/bot-client/src/commands/persona/dashboard.test.ts
+++ b/services/bot-client/src/commands/persona/dashboard.test.ts
@@ -278,19 +278,28 @@ vi.mock('../../utils/dashboard/refreshHandler.js', () => ({
   refreshDashboardUI: (...args: unknown[]) => mockRefreshDashboardUI(...args),
 }));
 
+// Shared mock logger reference so tests can assert against `mockLogger.warn`
+// (the dispatch helper logs unknown-action violations there). vi.hoisted
+// is required because vi.mock factories are hoisted above const declarations.
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
 vi.mock('@tzurot/common-types', async () => {
   const actual = await vi.importActual('@tzurot/common-types');
   return {
     ...actual,
-    createLogger: () => ({
-      debug: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    }),
+    createLogger: () => mockLogger,
     DISCORD_COLORS: {
       BLURPLE: 0x5865f2,
       WARNING: 0xfee75c,
+      // Truncation gate's "Ready to edit" embed uses SUCCESS — required
+      // by buildReadyToEditEmbed (utils/dashboard/truncationGate/embeds.ts).
+      SUCCESS: 0x00ff00,
     },
   };
 });
@@ -444,6 +453,27 @@ describe('handleSelectMenu', () => {
     });
   });
 
+  it('should not open modal or warning when section is unknown', async () => {
+    // Pins the early-return contract on `if (ctx === null) { return; }`
+    // — when resolvePersonaSectionContext returns null, no downstream
+    // side effects should fire (no modal, no warning embed). The
+    // sectionContext error reply is the only side effect; the rest of
+    // the function must short-circuit cleanly.
+    await handleSelectMenu(
+      createMockSelectInteraction(
+        'persona::menu::a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+        'edit-nonexistent'
+      )
+    );
+
+    expect(mockShowModal).not.toHaveBeenCalled();
+    // mockReply is the sectionContext error path; verify it received
+    // ONLY the unknown-section content (not the warning embed shape).
+    const replyCall = mockReply.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+    expect(replyCall?.embeds).toBeUndefined();
+    expect(replyCall?.components).toBeUndefined();
+  });
+
   it('should ignore non-persona interactions', async () => {
     await handleSelectMenu(
       createMockSelectInteraction(
@@ -453,6 +483,48 @@ describe('handleSelectMenu', () => {
     );
 
     expect(mockShowModal).not.toHaveBeenCalled();
+  });
+
+  it('should show truncation warning when content exceeds maxLength', async () => {
+    // Populate session data with `content` past the 4000-char modal cap.
+    // The new flow detects over-length fields and replies with the
+    // ephemeral warning embed instead of opening the modal directly.
+    mockSessionGet.mockResolvedValue({
+      data: { name: 'Test Persona', content: 'x'.repeat(4500) },
+    });
+
+    await handleSelectMenu(
+      createMockSelectInteraction(
+        'persona::menu::a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+        'edit-identity'
+      )
+    );
+
+    expect(mockShowModal).not.toHaveBeenCalled();
+    expect(mockReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flags: MessageFlags.Ephemeral,
+        embeds: expect.any(Array),
+        components: expect.any(Array),
+      })
+    );
+  });
+
+  it('should open modal directly when no fields over limit', async () => {
+    // Re-establishes the common path after the truncation-warning addition:
+    // when content fits, the gate is transparent and the modal opens.
+    mockSessionGet.mockResolvedValue({
+      data: { name: 'Test Persona', content: 'fits within cap' },
+    });
+
+    await handleSelectMenu(
+      createMockSelectInteraction(
+        'persona::menu::a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+        'edit-identity'
+      )
+    );
+
+    expect(mockShowModal).toHaveBeenCalled();
   });
 });
 
@@ -690,6 +762,126 @@ describe('handleButton', () => {
     expect(mockUpdate).not.toHaveBeenCalled();
     expect(mockDeferUpdate).not.toHaveBeenCalled();
   });
+
+  it('should log + drop unknown truncation-gate actions without acking', async () => {
+    // Pins the `default:` contract on the dispatch helper. An unknown
+    // persona action with the dashboard-prefix shape is parsed through
+    // PersonaCustomIds.parse → falls through the main switch into
+    // dispatchTruncationGateAction → no case matches → `default` logs
+    // the violation so a future drift between DASHBOARD_ACTIONS and the
+    // switch cases is diagnosable. The interaction is left unacked
+    // (Discord surfaces "Interaction Failed"); the handler doesn't
+    // throw, double-reply, or otherwise propagate.
+    mockLogger.warn.mockClear();
+    await handleButton(
+      createMockButtonInteraction(`persona::fake_action::${TEST_PERSONA_ID}::identity`)
+    );
+
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockReply).not.toHaveBeenCalled();
+    // The log assertion is the contract — without it, "logged" in the
+    // test name would be a lie (and was, until this assertion existed).
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'fake_action' }),
+      expect.stringContaining('Unknown truncation-gate action')
+    );
+  });
+
+  it('should silently drop sectionId-requiring actions when sectionId is absent', async () => {
+    // Mid-customId truncation: e.g. `persona::edit_truncated::personaId`
+    // (no fourth segment). The dispatch helper logs + returns; the
+    // handleEditTruncatedButton handler is never called.
+    await handleButton(createMockButtonInteraction(`persona::edit_truncated::${TEST_PERSONA_ID}`));
+
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('should route cancel_edit button to update with cancellation notice', async () => {
+    // The cancel_edit handler is dashboard-state-light: just an update()
+    // that clears the warning embed. No session lookup, no API call.
+    await handleButton(
+      createMockButtonInteraction(`persona::cancel_edit::${TEST_PERSONA_ID}::identity`)
+    );
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('cancelled'),
+        embeds: [],
+        components: [],
+      })
+    );
+  });
+
+  it('should route edit_truncated button to two-click flow update', async () => {
+    // Step 1 of the two-click flow: update to "Ready to edit" embed +
+    // single Open Editor button. No showModal at this stage.
+    mockSessionGet.mockResolvedValue({
+      data: { name: 'Test Persona', content: 'x'.repeat(4500) },
+    });
+
+    const interaction = createMockButtonInteraction(
+      `persona::edit_truncated::${TEST_PERSONA_ID}::identity`
+    ) as unknown as Record<string, unknown>;
+    interaction.followUp = vi.fn();
+
+    await handleButton(interaction as unknown as Parameters<typeof handleButton>[0]);
+
+    expect(mockUpdate).toHaveBeenCalled();
+    const updateArgs = mockUpdate.mock.calls[0][0];
+    expect(updateArgs.embeds).toHaveLength(1);
+    expect(updateArgs.components).toHaveLength(1);
+  });
+
+  it('should route open_editor button to showModal', async () => {
+    mockSessionGet.mockResolvedValue({
+      data: { name: 'Test Persona', content: 'fits' },
+    });
+
+    const showModalSpy = vi.fn().mockResolvedValue(undefined);
+    const interaction = createMockButtonInteraction(
+      `persona::open_editor::${TEST_PERSONA_ID}::identity`
+    ) as unknown as Record<string, unknown>;
+    interaction.showModal = showModalSpy;
+
+    await handleButton(interaction as unknown as Parameters<typeof handleButton>[0]);
+
+    expect(showModalSpy).toHaveBeenCalled();
+  });
+
+  it('should route view_full button to deferReply + editReply with attachment', async () => {
+    mockSessionGet.mockResolvedValue({
+      data: { name: 'Test Persona', content: 'x'.repeat(4500) },
+    });
+
+    // view_full follows the deferReply → resolveContext → editReply path.
+    // The deferReply must transition the interaction's `deferred` getter
+    // to true so sectionContext's replyError predicate would route via
+    // followUp on error (we don't exercise the error path here, but the
+    // state transition matters for the success path's editReply).
+    const state = { deferred: false, replied: false };
+    const deferReplySpy = vi.fn().mockImplementation(async () => {
+      state.deferred = true;
+    });
+    const editReplySpy = vi.fn().mockResolvedValue(undefined);
+    const baseInteraction = createMockButtonInteraction(
+      `persona::view_full::${TEST_PERSONA_ID}::identity`
+    ) as unknown as Record<string, unknown>;
+    Object.defineProperty(baseInteraction, 'deferred', {
+      get: () => state.deferred,
+    });
+    Object.defineProperty(baseInteraction, 'replied', {
+      get: () => state.replied,
+    });
+    baseInteraction.deferReply = deferReplySpy;
+    baseInteraction.editReply = editReplySpy;
+
+    await handleButton(baseInteraction as unknown as Parameters<typeof handleButton>[0]);
+
+    expect(deferReplySpy).toHaveBeenCalled();
+    expect(editReplySpy).toHaveBeenCalled();
+    const editArgs = editReplySpy.mock.calls[0][0];
+    expect(editArgs.files).toHaveLength(1);
+  });
 });
 
 describe('isPersonaDashboardInteraction', () => {
@@ -717,6 +909,27 @@ describe('isPersonaDashboardInteraction', () => {
     ).toBe(true);
     expect(
       isPersonaDashboardInteraction('persona::back::b2c3d4e5-f6a7-8901-bcde-f12345678901')
+    ).toBe(true);
+    // Truncation gate actions.
+    expect(
+      isPersonaDashboardInteraction(
+        'persona::edit_truncated::b2c3d4e5-f6a7-8901-bcde-f12345678901::identity'
+      )
+    ).toBe(true);
+    expect(
+      isPersonaDashboardInteraction(
+        'persona::open_editor::b2c3d4e5-f6a7-8901-bcde-f12345678901::identity'
+      )
+    ).toBe(true);
+    expect(
+      isPersonaDashboardInteraction(
+        'persona::view_full::b2c3d4e5-f6a7-8901-bcde-f12345678901::identity'
+      )
+    ).toBe(true);
+    expect(
+      isPersonaDashboardInteraction(
+        'persona::cancel_edit::b2c3d4e5-f6a7-8901-bcde-f12345678901::identity'
+      )
     ).toBe(true);
   });
 

--- a/services/bot-client/src/commands/persona/dashboard.ts
+++ b/services/bot-client/src/commands/persona/dashboard.ts
@@ -28,7 +28,6 @@ import {
   renderPostActionScreen,
   handleSharedBackButton,
 } from '../../utils/dashboard/index.js';
-import { handleDashboardSectionSelect } from '../../utils/dashboard/genericSelectMenuHandler.js';
 import { toGatewayUser } from '../../utils/userGatewayClient.js';
 import {
   PERSONA_DASHBOARD_CONFIG,
@@ -37,9 +36,18 @@ import {
   unflattenPersonaData,
   buildPersonaDashboardOptions,
 } from './config.js';
-import type { PersonaDetails } from './types.js';
 import { fetchPersona, updatePersona, deletePersona, isDefaultPersona } from './api.js';
 import { PersonaCustomIds } from '../../utils/customIds.js';
+import { buildSectionModal } from '../../utils/dashboard/ModalFactory.js';
+import { detectOverLengthFields } from '../../utils/dashboard/truncationGate/index.js';
+import { resolvePersonaSectionContext } from './sectionContext.js';
+import {
+  showTruncationWarning,
+  handleEditTruncatedButton,
+  handleOpenEditorButton,
+  handleViewFullButton,
+  handleCancelEditButton,
+} from './truncationWarning.js';
 // Registers the persona browse rebuilder for renderPostActionScreen +
 // handleSharedBackButton. Importing the module is enough — the
 // registerBrowseRebuilder call at the bottom of browse.ts runs on load.
@@ -164,16 +172,49 @@ async function handleSectionModalSubmit(
 }
 
 /**
- * Handle select menu interactions for dashboard
+ * Handle select menu interactions for dashboard.
+ *
+ * The select-menu customId follows `persona::menu::{personaId}` and the
+ * selected value is `edit-{sectionId}`. We resolve the section context,
+ * detect any over-length fields, and gate the modal behind a truncation
+ * warning when present. Otherwise the modal opens directly. Mirrors the
+ * character dashboard's pattern — see
+ * `commands/character/dashboard.ts` `handleSelectMenu`.
  */
 export async function handleSelectMenu(interaction: StringSelectMenuInteraction): Promise<void> {
-  await handleDashboardSectionSelect<FlattenedPersonaData, PersonaDetails>(interaction, {
-    entityType: 'persona',
-    dashboardConfig: PERSONA_DASHBOARD_CONFIG,
-    fetchFn: (entityId, user) => fetchPersona(entityId, user),
-    transformFn: flattenPersonaData,
-    entityName: 'Persona',
-  });
+  // Parse the persona-typed customId to extract personaId.
+  const parsed = PersonaCustomIds.parse(interaction.customId);
+  if (parsed?.personaId === undefined) {
+    logger.warn({ customId: interaction.customId }, 'Unrecognized persona select menu customId');
+    return;
+  }
+  const entityId = parsed.personaId;
+
+  // The select value is `edit-{sectionId}`. Anything else is a no-op.
+  const value = interaction.values[0];
+  if (!value?.startsWith('edit-')) {
+    return;
+  }
+  const sectionId = value.slice('edit-'.length);
+
+  const ctx = await resolvePersonaSectionContext(interaction, entityId, sectionId);
+  if (ctx === null) {
+    return;
+  }
+
+  // Truncation gate: if any field's stored content exceeds its modal cap,
+  // show the warning instead of opening the modal directly. The user opts
+  // in via the Edit-with-Truncation button (two-click flow) before any
+  // destructive truncation happens.
+  const overLength = detectOverLengthFields(ctx.section, ctx.data);
+  if (overLength.length > 0) {
+    await showTruncationWarning(interaction, ctx.section, entityId, overLength);
+    return;
+  }
+
+  // Common path: no over-length fields → open the modal directly.
+  const modal = buildSectionModal(ctx.dashboardConfig, ctx.section, entityId, ctx.data);
+  await interaction.showModal(modal);
 }
 
 /**
@@ -359,6 +400,58 @@ export async function handleButton(interaction: ButtonInteraction): Promise<void
     case 'cancel-delete':
       await handleCancelDeleteButton(interaction, entityId);
       break;
+    default:
+      await dispatchTruncationGateAction(interaction, parsed.action, entityId, parsed.sectionId);
+  }
+}
+
+/**
+ * Dispatch truncation-gate button actions (`edit_truncated`, `open_editor`,
+ * `view_full`, `cancel_edit`). Extracted from `handleButton` to keep its
+ * cyclomatic complexity under the project's max-20 ceiling.
+ *
+ * `cancel_edit` is the only branch that doesn't need `sectionId`; the
+ * other three log + drop if a malformed customId arrives without it,
+ * so the silent-no-op case is observable in logs.
+ */
+async function dispatchTruncationGateAction(
+  interaction: ButtonInteraction,
+  action: string,
+  entityId: string,
+  sectionId: string | undefined
+): Promise<void> {
+  if (action === 'cancel_edit') {
+    await handleCancelEditButton(interaction);
+    return;
+  }
+  if (sectionId === undefined) {
+    logger.warn(
+      { customId: interaction.customId, action },
+      'Truncation-gate action received without sectionId; dropping'
+    );
+    return;
+  }
+  switch (action) {
+    case 'edit_truncated':
+      await handleEditTruncatedButton(interaction, entityId, sectionId);
+      break;
+    case 'open_editor':
+      await handleOpenEditorButton(interaction, entityId, sectionId);
+      break;
+    case 'view_full':
+      await handleViewFullButton(interaction, entityId, sectionId);
+      break;
+    default:
+      // Unknown action with a valid customId shape — should not happen
+      // in practice (the DASHBOARD_ACTIONS Set gates the routing). Logs
+      // the violation so a future drift between the Set and this switch
+      // is diagnosable. Discord still shows "Interaction Failed" to the
+      // user, since acking unknown actions safely needs more context
+      // than this layer has.
+      logger.warn(
+        { customId: interaction.customId, action, entityId, sectionId },
+        'Unknown truncation-gate action; dropping'
+      );
   }
 }
 
@@ -372,6 +465,11 @@ const DASHBOARD_ACTIONS = new Set([
   'confirm-delete',
   'cancel-delete',
   'back',
+  // Truncation gate (mirrors character dashboard).
+  'edit_truncated',
+  'open_editor',
+  'view_full',
+  'cancel_edit',
 ]);
 
 /**

--- a/services/bot-client/src/commands/persona/sectionContext.test.ts
+++ b/services/bot-client/src/commands/persona/sectionContext.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for the persona section-context resolver.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
+
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+const mockFetchPersona = vi.fn();
+vi.mock('./api.js', () => ({
+  fetchPersona: (...args: unknown[]) => mockFetchPersona(...args),
+}));
+
+const mockFetchOrCreateSession = vi.fn();
+vi.mock('../../utils/dashboard/sessionHelpers.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../utils/dashboard/sessionHelpers.js')>();
+  return {
+    ...actual,
+    fetchOrCreateSession: (...args: unknown[]) => mockFetchOrCreateSession(...args),
+  };
+});
+
+const { findPersonaSection, loadPersonaSectionData, resolvePersonaSectionContext } =
+  await import('./sectionContext.js');
+
+describe('findPersonaSection', () => {
+  it('returns the section when sectionId matches', () => {
+    const result = findPersonaSection('identity');
+    expect(result).not.toBeNull();
+    expect(result?.section.id).toBe('identity');
+  });
+
+  it('returns null when sectionId is unknown', () => {
+    const result = findPersonaSection('does-not-exist');
+    expect(result).toBeNull();
+  });
+});
+
+describe('loadPersonaSectionData', () => {
+  it('returns context with data on successful session fetch', async () => {
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { name: 'Tester', content: 'About me' },
+    });
+    const interaction = {
+      user: { id: 'user-1' },
+      get deferred() {
+        return false;
+      },
+      get replied() {
+        return false;
+      },
+    } as unknown as ButtonInteraction;
+    const sync = findPersonaSection('identity');
+    expect(sync).not.toBeNull();
+
+    const result = await loadPersonaSectionData(interaction, 'persona-1', sync!);
+    expect(result).not.toBeNull();
+    expect(result?.data.name).toBe('Tester');
+  });
+
+  it('replies error and returns null when session fetch fails (fresh interaction)', async () => {
+    mockFetchOrCreateSession.mockResolvedValue({ success: false });
+    const mockReply = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      user: { id: 'user-1' },
+      reply: mockReply,
+      get deferred() {
+        return false;
+      },
+      get replied() {
+        return false;
+      },
+    } as unknown as ButtonInteraction;
+    const sync = findPersonaSection('identity')!;
+
+    const result = await loadPersonaSectionData(interaction, 'persona-1', sync);
+    expect(result).toBeNull();
+    expect(mockReply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining('Persona') })
+    );
+  });
+
+  it('uses followUp instead of reply when interaction is already deferred', async () => {
+    mockFetchOrCreateSession.mockResolvedValue({ success: false });
+    const mockReply = vi.fn();
+    const mockFollowUp = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      user: { id: 'user-1' },
+      reply: mockReply,
+      followUp: mockFollowUp,
+      get deferred() {
+        return true;
+      },
+      get replied() {
+        return false;
+      },
+    } as unknown as ButtonInteraction;
+    const sync = findPersonaSection('identity')!;
+
+    await loadPersonaSectionData(interaction, 'persona-1', sync);
+    expect(mockReply).not.toHaveBeenCalled();
+    expect(mockFollowUp).toHaveBeenCalled();
+  });
+});
+
+describe('resolvePersonaSectionContext', () => {
+  it('replies with unknown-section error when sectionId is unknown', async () => {
+    const mockReply = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      user: { id: 'user-1' },
+      reply: mockReply,
+      get deferred() {
+        return false;
+      },
+      get replied() {
+        return false;
+      },
+    } as unknown as StringSelectMenuInteraction;
+
+    const result = await resolvePersonaSectionContext(interaction, 'persona-1', 'no-such-section');
+    expect(result).toBeNull();
+    expect(mockReply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining('Unknown section') })
+    );
+  });
+
+  it('returns full context on success', async () => {
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { name: 'Tester', content: 'About me' },
+    });
+    const interaction = {
+      user: { id: 'user-1' },
+      get deferred() {
+        return false;
+      },
+      get replied() {
+        return false;
+      },
+    } as unknown as StringSelectMenuInteraction;
+
+    const result = await resolvePersonaSectionContext(interaction, 'persona-1', 'identity');
+    expect(result).not.toBeNull();
+    expect(result?.section.id).toBe('identity');
+    expect(result?.data.name).toBe('Tester');
+  });
+});

--- a/services/bot-client/src/commands/persona/sectionContext.ts
+++ b/services/bot-client/src/commands/persona/sectionContext.ts
@@ -1,0 +1,130 @@
+/**
+ * Persona Section Context Resolver
+ *
+ * Shared preamble for persona-section handlers: build the dashboard
+ * config, locate the section, and fetch (or session-cache) the current
+ * data. Mirrors `commands/character/sectionContext.ts` but for persona.
+ *
+ * Differences from character:
+ * - No `isAdmin` — persona is strictly owner-scoped (each user owns
+ *   their own personas; no cross-user admin edit).
+ * - `fetchPersona(personaId, user)` takes a `GatewayUser` instead of
+ *   the `(entityId, config, user)` triple character uses; the persona
+ *   gateway client is internally configured.
+ *
+ * Three consumers at extraction time:
+ * - `dashboard.ts` `handleSelectMenu` — when a user picks the section to edit
+ * - `truncationWarning.ts` `handleEditTruncatedButton` — the opt-in edit path
+ * - `truncationWarning.ts` `handleViewFullButton` — the read-only inspection
+ *   path for over-length legacy content
+ */
+
+import { MessageFlags } from 'discord.js';
+import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
+import { type DashboardConfig, type SectionDefinition } from '../../utils/dashboard/types.js';
+import { fetchOrCreateSession } from '../../utils/dashboard/sessionHelpers.js';
+import { DASHBOARD_MESSAGES } from '../../utils/dashboard/messages.js';
+import { toGatewayUser } from '../../utils/userGatewayClient.js';
+import {
+  PERSONA_DASHBOARD_CONFIG,
+  type FlattenedPersonaData,
+  flattenPersonaData,
+} from './config.js';
+import { fetchPersona } from './api.js';
+import type { PersonaDetails } from './types.js';
+
+/**
+ * Pure-sync portion of the section resolution. Split out so callers that
+ * need the section label _before_ they can await (e.g., the two-click
+ * Edit-with-Truncation flow's step 1, which must `interaction.update`
+ * within the 3-second budget) can get the section without paying for a
+ * redundant dashboard-config build later.
+ */
+export interface PersonaSectionSync {
+  dashboardConfig: DashboardConfig<FlattenedPersonaData>;
+  section: SectionDefinition<FlattenedPersonaData>;
+}
+
+/**
+ * Bundle returned by {@link resolvePersonaSectionContext} on success.
+ */
+export interface PersonaSectionContext extends PersonaSectionSync {
+  data: FlattenedPersonaData;
+}
+
+/**
+ * Sync helper: resolve dashboard config + section lookup from static
+ * inputs. No Redis, no gateway — safe to call before any
+ * `interaction.update` / `deferReply` ack.
+ *
+ * Returns `null` if the section id is unknown.
+ */
+export function findPersonaSection(sectionId: string): PersonaSectionSync | null {
+  const dashboardConfig = PERSONA_DASHBOARD_CONFIG;
+  const section = dashboardConfig.sections.find(s => s.id === sectionId);
+  if (!section) {
+    return null;
+  }
+  return { dashboardConfig, section };
+}
+
+/**
+ * Given an already-resolved sync bundle, fetch the persona data (Redis
+ * session cache → gateway fallback) and assemble the full context.
+ *
+ * On persona-fetch miss, sends an ephemeral error reply and returns
+ * `null`.
+ */
+export async function loadPersonaSectionData(
+  interaction: ButtonInteraction | StringSelectMenuInteraction,
+  entityId: string,
+  sync: PersonaSectionSync
+): Promise<PersonaSectionContext | null> {
+  const result = await fetchOrCreateSession<FlattenedPersonaData, PersonaDetails>({
+    userId: interaction.user.id,
+    entityType: 'persona',
+    entityId,
+    fetchFn: () => fetchPersona(entityId, toGatewayUser(interaction.user)),
+    transformFn: flattenPersonaData,
+    interaction,
+  });
+  if (!result.success) {
+    await replyError(interaction, DASHBOARD_MESSAGES.NOT_FOUND('Persona'));
+    return null;
+  }
+  return { ...sync, data: result.data };
+}
+
+/**
+ * Resolve the full context needed by a persona section handler.
+ *
+ * On failure (unknown section / missing persona), sends an ephemeral
+ * error reply and returns `null`.
+ */
+export async function resolvePersonaSectionContext(
+  interaction: ButtonInteraction | StringSelectMenuInteraction,
+  entityId: string,
+  sectionId: string
+): Promise<PersonaSectionContext | null> {
+  const sync = findPersonaSection(sectionId);
+  if (sync === null) {
+    await replyError(interaction, '❌ Unknown section.');
+    return null;
+  }
+  return loadPersonaSectionData(interaction, entityId, sync);
+}
+
+/**
+ * Reply with an ephemeral error, adapting to whether the caller has
+ * already acked the interaction.
+ */
+async function replyError(
+  interaction: ButtonInteraction | StringSelectMenuInteraction,
+  content: string
+): Promise<void> {
+  if (interaction.deferred || interaction.replied) {
+    await interaction.followUp({ content, flags: MessageFlags.Ephemeral });
+  } else {
+    await interaction.reply({ content, flags: MessageFlags.Ephemeral });
+  }
+}

--- a/services/bot-client/src/commands/persona/truncationWarning.test.ts
+++ b/services/bot-client/src/commands/persona/truncationWarning.test.ts
@@ -1,0 +1,431 @@
+/**
+ * Tests for persona truncation-warning flow.
+ *
+ * Mirrors `commands/character/truncationWarning.test.ts` but with
+ * persona's data resolver and the persona entityType in custom IDs.
+ * Detection / embed / button-shape unit tests live in the shared
+ * truncationGate test files; this file covers persona-specific
+ * handler behavior (two-click flow ordering, 10062 catch, 3-sec budget).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MessageFlags } from 'discord.js';
+import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
+
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+const mockFetchPersona = vi.fn();
+vi.mock('./api.js', () => ({
+  fetchPersona: (...args: unknown[]) => mockFetchPersona(...args),
+}));
+
+const mockFetchOrCreateSession = vi.fn();
+vi.mock('../../utils/dashboard/sessionHelpers.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../utils/dashboard/sessionHelpers.js')>();
+  return {
+    ...actual,
+    fetchOrCreateSession: (...args: unknown[]) => mockFetchOrCreateSession(...args),
+  };
+});
+
+vi.mock('../../utils/dashboard/ModalFactory.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../utils/dashboard/ModalFactory.js')>();
+  return {
+    ...actual,
+    buildSectionModal: vi.fn().mockReturnValue({ __modal: true }),
+  };
+});
+
+const {
+  showTruncationWarning,
+  handleEditTruncatedButton,
+  handleOpenEditorButton,
+  handleViewFullButton,
+  handleCancelEditButton,
+} = await import('./truncationWarning.js');
+const { SectionStatus } = await import('../../utils/dashboard/index.js');
+
+const identitySectionStub = {
+  id: 'identity',
+  label: '📝 Persona Info',
+  description: 'test',
+  fieldIds: ['name', 'content'],
+  fields: [
+    { id: 'name', label: 'Name', maxLength: 100, style: 'short' as const },
+    { id: 'content', label: 'About You', maxLength: 4000, style: 'paragraph' as const },
+  ],
+  getStatus: () => SectionStatus.DEFAULT,
+  getPreview: () => '',
+};
+
+describe('showTruncationWarning', () => {
+  it('replies ephemerally with the warning embed and persona-typed buttons', async () => {
+    const mockReply = vi.fn().mockResolvedValue(undefined);
+    const interaction = { reply: mockReply } as unknown as StringSelectMenuInteraction;
+
+    await showTruncationWarning(interaction, identitySectionStub, 'persona-1', [
+      { fieldId: 'content', label: 'About You', current: 4500, max: 4000 },
+    ]);
+
+    expect(mockReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flags: MessageFlags.Ephemeral,
+        embeds: expect.arrayContaining([expect.any(Object)]),
+        components: expect.arrayContaining([expect.any(Object)]),
+      })
+    );
+  });
+});
+
+describe('handleEditTruncatedButton', () => {
+  beforeEach(() => {
+    mockFetchOrCreateSession.mockReset();
+  });
+
+  it('updates the interaction to the Ready-to-Edit state with an Open Editor button', async () => {
+    // Step 1 of the two-click flow must `update` first (no showModal) so
+    // the 3-second budget is never blown by the subsequent session warm.
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { name: 'Tester', content: 'about me' },
+    });
+    const mockUpdate = vi.fn().mockResolvedValue(undefined);
+    const mockShowModal = vi.fn();
+    const interaction = {
+      user: { id: 'user-1' },
+      update: mockUpdate,
+      showModal: mockShowModal,
+    } as unknown as ButtonInteraction;
+
+    await handleEditTruncatedButton(interaction, 'persona-1', 'identity');
+
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockShowModal).not.toHaveBeenCalled();
+    const updateArgs = mockUpdate.mock.calls[0][0];
+    expect(updateArgs.embeds).toHaveLength(1);
+    expect(updateArgs.components).toHaveLength(1);
+  });
+
+  it('warms the session AFTER the update ack, not before', async () => {
+    // The update must precede the async resolveContext work. If this order
+    // flips, we're back to the PR #825 R1 3-sec bug class.
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { name: 'Tester', content: 'about me' },
+    });
+    const mockUpdate = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      user: { id: 'user-1' },
+      update: mockUpdate,
+      showModal: vi.fn(),
+    } as unknown as ButtonInteraction;
+
+    await handleEditTruncatedButton(interaction, 'persona-1', 'identity');
+
+    expect(mockUpdate).toHaveBeenCalled();
+    expect(mockFetchOrCreateSession).toHaveBeenCalled();
+    const updateOrder = mockUpdate.mock.invocationCallOrder[0];
+    const fetchOrder = mockFetchOrCreateSession.mock.invocationCallOrder[0];
+    expect(updateOrder).toBeLessThan(fetchOrder);
+  });
+
+  it('swallows session-warm failures so the open_editor click can retry', async () => {
+    mockFetchOrCreateSession.mockRejectedValue(new Error('Redis connection refused'));
+    const mockUpdate = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      user: { id: 'user-1' },
+      update: mockUpdate,
+      showModal: vi.fn(),
+    } as unknown as ButtonInteraction;
+
+    await expect(
+      handleEditTruncatedButton(interaction, 'persona-1', 'identity')
+    ).resolves.toBeUndefined();
+    expect(mockUpdate).toHaveBeenCalled();
+  });
+
+  it('returns early after update when sectionId does not match any section', async () => {
+    // Reachable when a button arrives with `persona::edit_truncated::id::unknown`.
+    // findPersonaSection returns null; the function still acks via update
+    // (using sectionId as the fallback label) and returns early without
+    // touching the session warm. Pins the early-return contract so a
+    // future refactor can't accidentally drop the ack.
+    const mockUpdate = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      user: { id: 'user-1' },
+      update: mockUpdate,
+      showModal: vi.fn(),
+    } as unknown as ButtonInteraction;
+
+    await handleEditTruncatedButton(interaction, 'persona-1', 'unknown-section-id');
+
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockFetchOrCreateSession).not.toHaveBeenCalled();
+  });
+
+  it('handles session-warm null returns without propagating (persona-deleted race)', async () => {
+    mockFetchOrCreateSession.mockResolvedValue({ success: false });
+    const mockUpdate = vi.fn().mockResolvedValue(undefined);
+    const mockFollowUp = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      user: { id: 'user-1' },
+      update: mockUpdate,
+      showModal: vi.fn(),
+      followUp: mockFollowUp,
+      get deferred() {
+        return false;
+      },
+      get replied() {
+        return true; // interaction.update sets replied=true
+      },
+    } as unknown as ButtonInteraction;
+
+    await expect(
+      handleEditTruncatedButton(interaction, 'persona-1', 'identity')
+    ).resolves.toBeUndefined();
+    expect(mockUpdate).toHaveBeenCalled();
+    // sectionContext's replyError sends the followUp.
+    expect(mockFollowUp).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('handleOpenEditorButton', () => {
+  beforeEach(() => {
+    mockFetchOrCreateSession.mockReset();
+  });
+
+  it('fetches the persona and shows the section modal on success', async () => {
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { name: 'Tester', content: 'about me' },
+    });
+    const mockShowModal = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      user: { id: 'user-1' },
+      showModal: mockShowModal,
+    } as unknown as ButtonInteraction;
+
+    await handleOpenEditorButton(interaction, 'persona-1', 'identity');
+
+    expect(mockShowModal).toHaveBeenCalledWith({ __modal: true });
+  });
+
+  it('replies with an error when the persona cannot be fetched', async () => {
+    mockFetchOrCreateSession.mockResolvedValue({ success: false });
+    const mockReply = vi.fn().mockResolvedValue(undefined);
+    const mockShowModal = vi.fn();
+    const interaction = {
+      user: { id: 'user-1' },
+      reply: mockReply,
+      showModal: mockShowModal,
+    } as unknown as ButtonInteraction;
+
+    await handleOpenEditorButton(interaction, 'persona-1', 'identity');
+
+    expect(mockShowModal).not.toHaveBeenCalled();
+    expect(mockReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('Persona not found'),
+      })
+    );
+  });
+
+  it('catches 10062 and surfaces a retry-visible followUp when the 3-sec window blows', async () => {
+    const { DiscordAPIError } = await import('discord.js');
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { name: 'Tester', content: 'about me' },
+    });
+    const timeoutError = new DiscordAPIError(
+      { code: 10062, message: 'Unknown interaction' },
+      10062,
+      404,
+      'POST',
+      '/interactions/x/y/callback',
+      {}
+    );
+    const mockShowModal = vi.fn().mockRejectedValue(timeoutError);
+    const mockFollowUp = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      user: { id: 'user-1' },
+      showModal: mockShowModal,
+      followUp: mockFollowUp,
+    } as unknown as ButtonInteraction;
+
+    await handleOpenEditorButton(interaction, 'persona-1', 'identity');
+
+    expect(mockShowModal).toHaveBeenCalled();
+    expect(mockFollowUp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('Took too long'),
+        flags: MessageFlags.Ephemeral,
+      })
+    );
+  });
+
+  it('rethrows non-10062 showModal errors so the global catch can handle them', async () => {
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { name: 'Tester', content: 'about me' },
+    });
+    const unexpected = new Error('boom');
+    const mockShowModal = vi.fn().mockRejectedValue(unexpected);
+    const interaction = {
+      user: { id: 'user-1' },
+      showModal: mockShowModal,
+      followUp: vi.fn(),
+    } as unknown as ButtonInteraction;
+
+    await expect(handleOpenEditorButton(interaction, 'persona-1', 'identity')).rejects.toThrow(
+      'boom'
+    );
+  });
+
+  it('swallows secondary followUp failures after a 10062', async () => {
+    const { DiscordAPIError } = await import('discord.js');
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { name: 'Tester', content: 'about me' },
+    });
+    const timeoutError = new DiscordAPIError(
+      { code: 10062, message: 'Unknown interaction' },
+      10062,
+      404,
+      'POST',
+      '/interactions/x/y/callback',
+      {}
+    );
+    const mockShowModal = vi.fn().mockRejectedValue(timeoutError);
+    const mockFollowUp = vi.fn().mockRejectedValue(timeoutError);
+    const interaction = {
+      user: { id: 'user-1' },
+      showModal: mockShowModal,
+      followUp: mockFollowUp,
+    } as unknown as ButtonInteraction;
+
+    await expect(
+      handleOpenEditorButton(interaction, 'persona-1', 'identity')
+    ).resolves.toBeUndefined();
+    expect(mockFollowUp).toHaveBeenCalled();
+  });
+});
+
+describe('handleViewFullButton', () => {
+  beforeEach(() => {
+    mockFetchOrCreateSession.mockReset();
+  });
+
+  function makeDeferrableInteraction(): {
+    interaction: ButtonInteraction;
+    deferReply: ReturnType<typeof vi.fn>;
+    editReply: ReturnType<typeof vi.fn>;
+    followUp: ReturnType<typeof vi.fn>;
+  } {
+    const state = { deferred: false, replied: false };
+    const deferReply = vi.fn().mockImplementation(async () => {
+      state.deferred = true;
+    });
+    const editReply = vi.fn().mockResolvedValue(undefined);
+    const followUp = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      user: { id: 'user-1' },
+      deferReply,
+      editReply,
+      followUp,
+      get deferred() {
+        return state.deferred;
+      },
+      get replied() {
+        return state.replied;
+      },
+    } as unknown as ButtonInteraction;
+    return { interaction, deferReply, editReply, followUp };
+  }
+
+  it('defers the reply BEFORE any async resolveContext work', async () => {
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { name: 'Tester', content: 'x'.repeat(4500) },
+    });
+    const { interaction, deferReply, editReply } = makeDeferrableInteraction();
+
+    await handleViewFullButton(interaction, 'persona-1', 'identity');
+
+    expect(deferReply).toHaveBeenCalled();
+    expect(editReply).toHaveBeenCalled();
+    const deferOrder = deferReply.mock.invocationCallOrder[0];
+    const fetchOrder = mockFetchOrCreateSession.mock.invocationCallOrder[0];
+    expect(deferOrder).toBeLessThan(fetchOrder);
+  });
+
+  it('attaches over-length field content as `.txt` files', async () => {
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { name: 'Tester', content: 'x'.repeat(4500) },
+    });
+    const { interaction, editReply } = makeDeferrableInteraction();
+
+    await handleViewFullButton(interaction, 'persona-1', 'identity');
+
+    const editArgs = editReply.mock.calls[0][0];
+    expect(editArgs.files).toHaveLength(1);
+    // Real config field label is 'About You (shared with AI)'; toSafeFilename
+    // strips the parens and joins on underscores.
+    expect(editArgs.files[0].name).toBe('about_you_shared_with_ai.txt');
+  });
+
+  it('shows "nothing to display" when data shrank between warning and View Full', async () => {
+    // Concurrent-edit race: a parallel save trimmed `content` below the cap
+    // between the warning showing and the user clicking View Full.
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { name: 'Tester', content: 'tiny' },
+    });
+    const { interaction, editReply } = makeDeferrableInteraction();
+
+    await handleViewFullButton(interaction, 'persona-1', 'identity');
+
+    const editArgs = editReply.mock.calls[0][0];
+    expect(editArgs.content).toContain('No fields');
+    expect(editArgs.files).toBeUndefined();
+  });
+
+  it('returns silently when context resolution fails (sectionContext sent followUp)', async () => {
+    mockFetchOrCreateSession.mockResolvedValue({ success: false });
+    const { interaction, editReply, followUp } = makeDeferrableInteraction();
+
+    await handleViewFullButton(interaction, 'persona-1', 'identity');
+
+    expect(editReply).not.toHaveBeenCalled();
+    // sectionContext's replyError sent the followUp.
+    expect(followUp).toHaveBeenCalled();
+  });
+});
+
+describe('handleCancelEditButton', () => {
+  it('updates the interaction to the cancelled state', async () => {
+    const mockUpdate = vi.fn().mockResolvedValue(undefined);
+    const interaction = { update: mockUpdate } as unknown as ButtonInteraction;
+
+    await handleCancelEditButton(interaction);
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('cancelled'),
+        embeds: [],
+        components: [],
+      })
+    );
+  });
+});

--- a/services/bot-client/src/commands/persona/truncationWarning.ts
+++ b/services/bot-client/src/commands/persona/truncationWarning.ts
@@ -1,0 +1,215 @@
+/**
+ * Persona Truncation Warning
+ *
+ * Mirrors `commands/character/truncationWarning.ts` but for persona.
+ * Same two-click flow, same 10062 catch on Open Editor, same View Full
+ * `.txt` attachment shape. Imports detection + display primitives from
+ * `utils/dashboard/truncationGate/`; the persona-specific bits are the
+ * data resolver (`resolvePersonaSectionContext`) and the entityType
+ * passed into the shared button builders.
+ *
+ * Defense-in-depth: detects when stored persona content exceeds the
+ * modal `maxLength` and warns the user before any silent truncation
+ * happens. The cap-mismatch class of bug (UI < API) is what made this
+ * gate necessary on the persona side.
+ */
+
+import { AttachmentBuilder, DiscordAPIError, MessageFlags } from 'discord.js';
+import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
+import { createLogger } from '@tzurot/common-types';
+import { type SectionDefinition } from '../../utils/dashboard/types.js';
+import { buildSectionModal } from '../../utils/dashboard/ModalFactory.js';
+import {
+  detectOverLengthFields,
+  buildTruncationWarningEmbed,
+  buildTruncationButtons,
+  buildOpenEditorButtonRow,
+  buildReadyToEditEmbed,
+  stripLeadingEmoji,
+  toSafeFilename,
+  type OverLengthField,
+} from '../../utils/dashboard/truncationGate/index.js';
+import type { FlattenedPersonaData } from './config.js';
+import {
+  findPersonaSection,
+  loadPersonaSectionData,
+  resolvePersonaSectionContext,
+} from './sectionContext.js';
+
+const logger = createLogger('persona-truncation-warning');
+const ENTITY_TYPE = 'persona';
+
+/**
+ * Show the truncation warning as an ephemeral reply to the select-menu
+ * interaction.
+ */
+export async function showTruncationWarning(
+  interaction: StringSelectMenuInteraction,
+  section: SectionDefinition<FlattenedPersonaData>,
+  entityId: string,
+  overLength: OverLengthField[]
+): Promise<void> {
+  await interaction.reply({
+    embeds: [buildTruncationWarningEmbed(overLength, section.label)],
+    components: [buildTruncationButtons(ENTITY_TYPE, entityId, section.id)],
+    flags: MessageFlags.Ephemeral,
+  });
+}
+
+/**
+ * "Edit with Truncation" handler — step 1 of a two-click flow. See
+ * `commands/character/truncationWarning.ts` `handleEditTruncatedButton`
+ * for the full rationale on why two clicks are required (Discord
+ * `showModal` must be the first response and can't be deferred).
+ *
+ * Order is load-bearing: `interaction.update` MUST run before any async
+ * work, so the 3-second budget is never blown by the subsequent session
+ * warm. The session warm is best-effort — its failure doesn't propagate
+ * because step 2 (`handleOpenEditorButton`) does its own resolveContext
+ * with the same fallback.
+ */
+export async function handleEditTruncatedButton(
+  interaction: ButtonInteraction,
+  entityId: string,
+  sectionId: string
+): Promise<void> {
+  const sync = findPersonaSection(sectionId);
+  const sectionLabel = sync?.section.label ?? sectionId;
+
+  // Step 1 — ack within the 3-sec budget via `update`. No async before this.
+  await interaction.update({
+    embeds: [buildReadyToEditEmbed(sectionLabel)],
+    components: [buildOpenEditorButtonRow(ENTITY_TYPE, entityId, sectionId)],
+  });
+
+  // Step 2 — warm the session so the Open Editor click gets a hot cache hit.
+  if (sync === null) {
+    logger.warn(
+      { userId: interaction.user.id, entityId, sectionId },
+      'Unknown sectionId in edit_truncated opt-in; open_editor click will surface the error'
+    );
+    return;
+  }
+
+  try {
+    const warmResult = await loadPersonaSectionData(interaction, entityId, sync);
+    if (warmResult === null) {
+      logger.warn(
+        { userId: interaction.user.id, entityId, sectionId },
+        'Session warm returned null after edit_truncated opt-in (likely persona-deleted race); user saw Ready-to-Edit + followUp error'
+      );
+    }
+  } catch (error) {
+    logger.warn(
+      { err: error, userId: interaction.user.id, entityId, sectionId },
+      'Session warm failed after edit_truncated opt-in; open_editor will retry'
+    );
+  }
+}
+
+/**
+ * "Open Editor" handler — step 2 of the two-click flow. Shows the section
+ * edit modal. See character handler comments for the residual 10062
+ * 3-sec-window risk and rationale for the catch-and-followUp path.
+ */
+export async function handleOpenEditorButton(
+  interaction: ButtonInteraction,
+  entityId: string,
+  sectionId: string
+): Promise<void> {
+  const ctx = await resolvePersonaSectionContext(interaction, entityId, sectionId);
+  if (ctx === null) {
+    return;
+  }
+
+  const modal = buildSectionModal(ctx.dashboardConfig, ctx.section, entityId, ctx.data);
+  try {
+    await interaction.showModal(modal);
+  } catch (error) {
+    if (error instanceof DiscordAPIError && error.code === 10062) {
+      logger.warn(
+        { userId: interaction.user.id, entityId, sectionId },
+        'Open Editor showModal exceeded 3-second window (10062)'
+      );
+      try {
+        await interaction.followUp({
+          content:
+            '⏰ Took too long to open the editor. Please click **Open Editor** again, ' +
+            'or re-open the dashboard if the button is gone.',
+          flags: MessageFlags.Ephemeral,
+        });
+      } catch {
+        // Expected on a fully-dead interaction token. Nothing else to do.
+      }
+      return;
+    }
+    throw error;
+  }
+}
+
+/**
+ * "View Full" handler — render the over-length field values as attached
+ * `.txt` files so the user can inspect their content without triggering
+ * the destructive edit path.
+ */
+export async function handleViewFullButton(
+  interaction: ButtonInteraction,
+  entityId: string,
+  sectionId: string
+): Promise<void> {
+  // Ack within 3 seconds before any async work — resolvePersonaSectionContext
+  // hits Redis (and may fall through to a gateway API call on session miss),
+  // which could blow the 3-second window under load.
+  await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+  const ctx = await resolvePersonaSectionContext(interaction, entityId, sectionId);
+  if (ctx === null) {
+    return;
+  }
+
+  const overLength = detectOverLengthFields(ctx.section, ctx.data);
+  if (overLength.length === 0) {
+    // Edge case: data changed between warning and View Full click (e.g.,
+    // a concurrent save trimmed fields). Let the user know.
+    await interaction.editReply({
+      content: '✅ No fields in this section exceed the edit limit. Nothing to display.',
+    });
+    return;
+  }
+
+  const attachments = overLength.map(f => {
+    const content = (ctx.data as Record<string, unknown>)[f.fieldId];
+    const textContent = typeof content === 'string' ? content : '';
+    return new AttachmentBuilder(Buffer.from(textContent, 'utf-8'), {
+      name: `${toSafeFilename(f.label)}.txt`,
+    });
+  });
+
+  const plainLabel = stripLeadingEmoji(ctx.section.label);
+  const summary = overLength
+    .map(f => `• \`${toSafeFilename(f.label)}.txt\` — ${f.current.toLocaleString()} chars`)
+    .join('\n');
+
+  await interaction.editReply({
+    content:
+      `**Full content for "${plainLabel}"** (read-only):\n${summary}\n\n` +
+      `These files hold the current, untruncated values. Editing this section ` +
+      `via the dashboard would cut each field to its modal cap.`,
+    files: attachments,
+  });
+  logger.info(
+    { userId: interaction.user.id, entityId, sectionId, fields: overLength.length },
+    'View Full served over-length field content'
+  );
+}
+
+/**
+ * "Cancel" handler — dismiss the warning and leave the dashboard as-is.
+ */
+export async function handleCancelEditButton(interaction: ButtonInteraction): Promise<void> {
+  await interaction.update({
+    content: '✅ Edit cancelled.',
+    embeds: [],
+    components: [],
+  });
+}

--- a/services/bot-client/src/utils/dashboard/genericSelectMenuHandler.ts
+++ b/services/bot-client/src/utils/dashboard/genericSelectMenuHandler.ts
@@ -1,16 +1,17 @@
 /**
  * Generic Dashboard Select Menu Handler
  *
- * Handles the "edit section" select menu flow shared by persona and preset
- * dashboards. Both flows follow the same pattern:
+ * Handles the "edit section" select menu flow used by the preset dashboard.
+ * The flow:
  * 1. Parse the custom ID and guard on entity type
  * 2. Look up the section config
  * 3. Fetch or create the session
  * 4. Optionally verify edit permission
  * 5. Build and show the section modal
  *
- * Extracted from persona/dashboard.ts and preset/dashboard.ts which had
- * nearly-identical 47-line handleSelectMenu functions.
+ * Originally extracted to share this pattern between persona and preset.
+ * Persona migrated off this handler to inline a truncation-warning gate
+ * before the modal opens; only preset still uses it.
  */
 
 import type { StringSelectMenuInteraction } from 'discord.js';

--- a/services/bot-client/src/utils/dashboard/truncationGate/buttons.test.ts
+++ b/services/bot-client/src/utils/dashboard/truncationGate/buttons.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for the truncation-gate button row builders.
+ *
+ * Parameterized on `entityType` so the same builders produce the right
+ * custom IDs for any dashboard. Tests verify both the character and
+ * persona shape route correctly.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ButtonStyle } from 'discord.js';
+import { buildTruncationButtons, buildOpenEditorButtonRow } from './buttons.js';
+
+describe('buildTruncationButtons', () => {
+  it('emits three buttons with character entityType custom IDs', () => {
+    const row = buildTruncationButtons('character', 'char-1', 'identity');
+    const json = row.toJSON();
+    expect(json.components).toHaveLength(3);
+    const customIds = json.components.map(c => (c as { custom_id: string }).custom_id);
+    // Ordered per `04-discord.md` Standard Button Order: Primary (View Full)
+    // first, Secondary (Cancel) middle, Destructive (Edit with Truncation)
+    // last. A regression that reverts to destructive-first would break
+    // consistency with delete-confirmation dialogs across the codebase.
+    expect(customIds).toEqual([
+      'character::view_full::char-1::identity',
+      'character::cancel_edit::char-1::identity',
+      'character::edit_truncated::char-1::identity',
+    ]);
+  });
+
+  it('emits three buttons with persona entityType custom IDs', () => {
+    const row = buildTruncationButtons('persona', 'persona-uuid', 'identity');
+    const json = row.toJSON();
+    expect(json.components).toHaveLength(3);
+    const customIds = json.components.map(c => (c as { custom_id: string }).custom_id);
+    expect(customIds).toEqual([
+      'persona::view_full::persona-uuid::identity',
+      'persona::cancel_edit::persona-uuid::identity',
+      'persona::edit_truncated::persona-uuid::identity',
+    ]);
+  });
+
+  it('places the Danger-styled button last per destructive-last rule', () => {
+    const row = buildTruncationButtons('character', 'char-1', 'identity');
+    const json = row.toJSON();
+    const styles = json.components.map(c => (c as { style: number }).style);
+    // ButtonStyle.Danger = 4; verify it's the last button's style.
+    expect(styles[styles.length - 1]).toBe(ButtonStyle.Danger);
+  });
+
+  it('sets an emoji on every button per 04-discord.md consistency rule', () => {
+    // The rule (`.claude/rules/04-discord.md`) requires `.setEmoji()` on
+    // every button for visual sizing consistency.
+    const row = buildTruncationButtons('character', 'char-1', 'identity');
+    const json = row.toJSON();
+    for (const component of json.components) {
+      const button = component as { emoji?: { name: string } };
+      expect(button.emoji?.name, `button ${JSON.stringify(component)} missing emoji`).toBeDefined();
+    }
+  });
+});
+
+describe('buildOpenEditorButtonRow', () => {
+  it('emits a single Open Editor button with character entityType custom ID', () => {
+    const row = buildOpenEditorButtonRow('character', 'char-1', 'identity');
+    const json = row.toJSON();
+    expect(json.components).toHaveLength(1);
+    const button = json.components[0] as { custom_id: string; label?: string };
+    expect(button.custom_id).toBe('character::open_editor::char-1::identity');
+    expect(button.label).toBe('Open Editor');
+  });
+
+  it('emits a single Open Editor button with persona entityType custom ID', () => {
+    const row = buildOpenEditorButtonRow('persona', 'persona-uuid', 'identity');
+    const json = row.toJSON();
+    expect(json.components).toHaveLength(1);
+    const button = json.components[0] as { custom_id: string; label?: string };
+    expect(button.custom_id).toBe('persona::open_editor::persona-uuid::identity');
+  });
+});

--- a/services/bot-client/src/utils/dashboard/truncationGate/buttons.ts
+++ b/services/bot-client/src/utils/dashboard/truncationGate/buttons.ts
@@ -1,0 +1,66 @@
+/**
+ * Truncation Gate — button row builders.
+ *
+ * `entityType` is parameterized so the same builders produce the right
+ * custom IDs for any dashboard ('character::view_full::*',
+ * 'persona::view_full::*', etc.). Routing is by entityType; downstream
+ * handlers live alongside the entity-specific data resolvers.
+ */
+
+import { ButtonBuilder, ButtonStyle, ActionRowBuilder } from 'discord.js';
+import { buildDashboardCustomId, type TruncationGateEntityType } from '../types.js';
+
+/**
+ * Build the three-button row for the warning, ordered per `04-discord.md`
+ * Standard Button Order (Primary first, Destructive last):
+ * - View Full (primary, safe read-only inspection)
+ * - Cancel (secondary, dismiss)
+ * - Edit with Truncation (danger, opt-in to destructive edit)
+ *
+ * The destructive-last convention matches the memory detail flow and the
+ * delete-confirmation dialogs across the codebase; consistency outranks
+ * the "lead with the warning" instinct for this UX.
+ */
+export function buildTruncationButtons(
+  entityType: TruncationGateEntityType,
+  entityId: string,
+  sectionId: string
+): ActionRowBuilder<ButtonBuilder> {
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(buildDashboardCustomId(entityType, 'view_full', entityId, sectionId))
+      .setLabel('View Full')
+      .setEmoji('📖')
+      .setStyle(ButtonStyle.Primary),
+    new ButtonBuilder()
+      .setCustomId(buildDashboardCustomId(entityType, 'cancel_edit', entityId, sectionId))
+      .setLabel('Cancel')
+      .setEmoji('✖️')
+      .setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder()
+      .setCustomId(buildDashboardCustomId(entityType, 'edit_truncated', entityId, sectionId))
+      .setLabel('Edit with Truncation')
+      .setEmoji('✂️')
+      .setStyle(ButtonStyle.Danger)
+  );
+}
+
+/**
+ * Build the "Open Editor" button shown after the user opts into the
+ * truncating edit. Splitting the opt-in confirmation from the modal-open
+ * click lets us satisfy Discord's "showModal must be the first response"
+ * constraint without doing any async work before the showModal call.
+ */
+export function buildOpenEditorButtonRow(
+  entityType: TruncationGateEntityType,
+  entityId: string,
+  sectionId: string
+): ActionRowBuilder<ButtonBuilder> {
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(buildDashboardCustomId(entityType, 'open_editor', entityId, sectionId))
+      .setLabel('Open Editor')
+      .setEmoji('✏️')
+      .setStyle(ButtonStyle.Primary)
+  );
+}

--- a/services/bot-client/src/utils/dashboard/truncationGate/detection.test.ts
+++ b/services/bot-client/src/utils/dashboard/truncationGate/detection.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for the truncation-gate detection primitive.
+ *
+ * Generic over the data type — these tests use a synthetic field shape
+ * to confirm the function works against any `T`, independent of any
+ * specific dashboard's data type.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { detectOverLengthFields } from './detection.js';
+import { SectionStatus } from '../types.js';
+
+interface SyntheticData {
+  title: string;
+  body: string;
+}
+
+const syntheticSection = {
+  id: 'synthetic',
+  label: '🔬 Synthetic',
+  description: 'test',
+  fieldIds: ['title', 'body'],
+  fields: [
+    { id: 'title', label: 'Title', maxLength: 100, style: 'short' as const },
+    { id: 'body', label: 'Body', maxLength: 1000, style: 'paragraph' as const },
+  ],
+  getStatus: () => SectionStatus.DEFAULT,
+  getPreview: () => '',
+};
+
+describe('detectOverLengthFields', () => {
+  it('returns empty when no field exceeds its maxLength', () => {
+    const data: SyntheticData = { title: 'short', body: 'also short' };
+    expect(detectOverLengthFields(syntheticSection, data)).toEqual([]);
+  });
+
+  it('flags a field whose value exceeds the cap', () => {
+    const data: SyntheticData = { title: 'x'.repeat(150), body: 'ok' };
+    const result = detectOverLengthFields(syntheticSection, data);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      fieldId: 'title',
+      label: 'Title',
+      current: 150,
+      max: 100,
+    });
+  });
+
+  it('flags multiple over-cap fields independently', () => {
+    const data: SyntheticData = { title: 'x'.repeat(150), body: 'y'.repeat(1500) };
+    const result = detectOverLengthFields(syntheticSection, data);
+    expect(result).toHaveLength(2);
+    expect(result.map(r => r.fieldId).sort()).toEqual(['body', 'title']);
+  });
+
+  it('ignores non-string values and missing fields', () => {
+    const data = {
+      title: null,
+      body: undefined,
+      unrelated: 'x'.repeat(5000),
+    } as unknown as SyntheticData;
+    expect(detectOverLengthFields(syntheticSection, data)).toEqual([]);
+  });
+
+  it('is generic over T (independent of any specific dashboard type)', () => {
+    interface DifferentShape {
+      alpha: string;
+    }
+    const otherSection = {
+      id: 'other',
+      label: 'Other',
+      description: 'test',
+      fieldIds: ['alpha'],
+      fields: [{ id: 'alpha', label: 'Alpha', maxLength: 5, style: 'short' as const }],
+      getStatus: () => SectionStatus.DEFAULT,
+      getPreview: () => '',
+    };
+    const data: DifferentShape = { alpha: 'too long for cap' };
+    const result = detectOverLengthFields(otherSection, data);
+    expect(result).toHaveLength(1);
+    expect(result[0].fieldId).toBe('alpha');
+  });
+});

--- a/services/bot-client/src/utils/dashboard/truncationGate/detection.ts
+++ b/services/bot-client/src/utils/dashboard/truncationGate/detection.ts
@@ -1,0 +1,53 @@
+/**
+ * Truncation Gate — over-length field detection.
+ *
+ * Generic over the section's flat data type so multiple dashboards can
+ * use the same detection logic against their own typed data shapes
+ * (CharacterData, FlattenedPersonaData, future entity types).
+ */
+
+import type { SectionDefinition } from '../types.js';
+
+/**
+ * A field whose current value exceeds its modal maxLength.
+ */
+export interface OverLengthField {
+  /** The field id (matches the data object key) */
+  fieldId: string;
+  /** The user-facing label */
+  label: string;
+  /** Current character count */
+  current: number;
+  /** Configured maxLength — what the edit modal will truncate down to */
+  max: number;
+}
+
+/**
+ * Scan a section's fields and report any whose current value exceeds
+ * the modal's maxLength constraint.
+ *
+ * `maxLength` is a required field on `FieldDefinition` (see
+ * `utils/dashboard/types.ts`), so every field always has an explicit
+ * cap to check against.
+ */
+export function detectOverLengthFields<T>(
+  section: SectionDefinition<T>,
+  data: T
+): OverLengthField[] {
+  const over: OverLengthField[] = [];
+  for (const field of section.fields) {
+    const raw = (data as Record<string, unknown>)[field.id];
+    if (typeof raw !== 'string') {
+      continue;
+    }
+    if (raw.length > field.maxLength) {
+      over.push({
+        fieldId: field.id,
+        label: field.label,
+        current: raw.length,
+        max: field.maxLength,
+      });
+    }
+  }
+  return over;
+}

--- a/services/bot-client/src/utils/dashboard/truncationGate/embeds.test.ts
+++ b/services/bot-client/src/utils/dashboard/truncationGate/embeds.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for the truncation-gate embed builders + label helpers.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildTruncationWarningEmbed,
+  buildReadyToEditEmbed,
+  stripLeadingEmoji,
+  toSafeFilename,
+} from './embeds.js';
+
+describe('stripLeadingEmoji', () => {
+  it('removes a leading emoji + whitespace', () => {
+    expect(stripLeadingEmoji('🏷️ Identity & Basics')).toBe('Identity & Basics');
+  });
+
+  it('returns the input unchanged when there is no leading emoji', () => {
+    expect(stripLeadingEmoji('Identity & Basics')).toBe('Identity & Basics');
+  });
+});
+
+describe('toSafeFilename', () => {
+  it('lowercases, trims, and underscores whitespace', () => {
+    expect(toSafeFilename('Personality Age')).toBe('personality_age');
+  });
+
+  it('strips non-alphanumeric characters and collapses underscore runs', () => {
+    // Without the collapse pass this would produce 'bots_tone__style'
+    // (where `& ` becomes `&_`, then `&` is stripped). The trailing
+    // `.replace(/_+/g, '_')` keeps filenames clean.
+    expect(toSafeFilename("Bot's Tone & Style")).toBe('bots_tone_style');
+  });
+
+  it('falls back to "field" when slug would be empty', () => {
+    // Pure-punctuation input slugs to empty string after stripping.
+    // The fallback prevents producing `.txt` as the attachment name.
+    expect(toSafeFilename('!!!')).toBe('field');
+    expect(toSafeFilename('   ')).toBe('field');
+  });
+});
+
+describe('buildTruncationWarningEmbed', () => {
+  it('includes per-field char counts and the total truncation amount', () => {
+    const embed = buildTruncationWarningEmbed(
+      [
+        { fieldId: 'personalityAge', label: 'Age', current: 150, max: 100 },
+        { fieldId: 'personalityTraits', label: 'Traits', current: 1500, max: 1000 },
+      ],
+      '🏷️ Identity & Basics'
+    );
+
+    const json = embed.toJSON();
+    expect(json.title).toContain('"Identity & Basics"');
+    expect(json.description).toContain('Age');
+    expect(json.description).toContain('150');
+    expect(json.description).toContain('100');
+    expect(json.description).toContain('Traits');
+    expect(json.description).toContain('1,500');
+    // Footer lists total truncation: (150-100)+(1500-1000)=550
+    expect(json.footer?.text).toContain('550');
+    expect(json.footer?.text).toContain('2 fields');
+    expect(json.footer?.text).not.toContain('field(s)');
+  });
+
+  it('uses singular "field" in the footer when only one field is over-length', () => {
+    // Guards against the "1 field(s)" pluralization regression flagged in PR
+    // review. The single-field path is the common case for short legacy
+    // fields and needs to read cleanly.
+    const embed = buildTruncationWarningEmbed(
+      [{ fieldId: 'personalityAge', label: 'Age', current: 150, max: 100 }],
+      '🏷️ Identity & Basics'
+    );
+    const json = embed.toJSON();
+    expect(json.footer?.text).toContain('1 field');
+    expect(json.footer?.text).not.toContain('1 fields');
+    expect(json.footer?.text).not.toContain('field(s)');
+  });
+});
+
+describe('buildReadyToEditEmbed', () => {
+  it('strips the leading emoji and names the section in the title', () => {
+    const embed = buildReadyToEditEmbed('🏷️ Identity & Basics');
+    const json = embed.toJSON();
+    expect(json.title).toContain('Identity & Basics');
+    expect(json.title).not.toContain('🏷️');
+  });
+});

--- a/services/bot-client/src/utils/dashboard/truncationGate/embeds.ts
+++ b/services/bot-client/src/utils/dashboard/truncationGate/embeds.ts
@@ -1,0 +1,95 @@
+/**
+ * Truncation Gate — display helpers.
+ *
+ * Embed builders for the destructive-action warning + the post-opt-in
+ * "Ready to edit" interstitial. Entity-agnostic; both character and
+ * persona dashboards (and future ones) render identical copy.
+ */
+
+import { EmbedBuilder } from 'discord.js';
+import { DISCORD_COLORS } from '@tzurot/common-types';
+import type { OverLengthField } from './detection.js';
+
+/**
+ * Strip a leading emoji + whitespace from a section label so modal titles,
+ * embed titles, and attachment copy read cleanly. Mirrors the inline regex
+ * in `ModalFactory.ts:51` (modal title derivation).
+ */
+export function stripLeadingEmoji(label: string): string {
+  return label.replace(/^[^\w\s]+\s*/, '');
+}
+
+/**
+ * Convert a user-facing field label into a safe filename slug. Lowercased,
+ * whitespace collapsed to underscores, non-alphanumeric chars removed so
+ * the resulting name works across OSes. The trailing collapse-runs pass
+ * keeps labels like `"Bot's Tone & Style"` from producing double
+ * underscores where punctuation sat between spaces.
+ */
+export function toSafeFilename(label: string): string {
+  const slug = label
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, '_')
+    .replace(/[^a-z0-9_]/g, '')
+    .replace(/_+/g, '_');
+  // Pure-punctuation labels would slug to empty. Defense-in-depth — the
+  // dashboard configs control labels today, but a future caller could
+  // pass arbitrary input and we don't want to produce just `.txt`.
+  return slug || 'field';
+}
+
+/**
+ * Build the destructive-action warning embed listing the over-length
+ * fields, their current lengths, and the per-field truncation amount.
+ */
+export function buildTruncationWarningEmbed(
+  overLength: OverLengthField[],
+  sectionLabel: string
+): EmbedBuilder {
+  const plainLabel = stripLeadingEmoji(sectionLabel);
+
+  const fieldLines = overLength
+    .map(f => {
+      const loss = f.current - f.max;
+      return (
+        `• **${f.label}** — ${f.current.toLocaleString()} / ${f.max.toLocaleString()} chars ` +
+        `(${loss.toLocaleString()} will be truncated)`
+      );
+    })
+    .join('\n');
+
+  const totalLoss = overLength.reduce((sum, f) => sum + (f.current - f.max), 0);
+
+  return new EmbedBuilder()
+    .setTitle(`⚠️ "${plainLabel}" contains content longer than Discord modals allow`)
+    .setColor(DISCORD_COLORS.WARNING)
+    .setDescription(
+      `One or more fields in this section hold values that exceed the edit modal's limit:\n\n` +
+        `${fieldLines}\n\n` +
+        `⚠️ **Opening the edit modal will pre-fill the fields with truncated values.** ` +
+        `If you save the modal, the trailing content will be lost permanently.\n\n` +
+        `Choose **View Full** to inspect the current full content before deciding. ` +
+        `Choose **Edit with Truncation** only if you're OK losing the trailing text.`
+    )
+    .setFooter({
+      text: `${totalLoss.toLocaleString()} total characters would be truncated across ${overLength.length} field${overLength.length === 1 ? '' : 's'}`,
+    });
+}
+
+/**
+ * Build the embed shown between the Edit-with-Truncation opt-in and the
+ * actual modal. It reassures the user that their consent was recorded
+ * and directs them to the single click that opens the modal.
+ */
+export function buildReadyToEditEmbed(sectionLabel: string): EmbedBuilder {
+  const plainLabel = stripLeadingEmoji(sectionLabel);
+  return new EmbedBuilder()
+    .setTitle(`✅ Ready to edit "${plainLabel}"`)
+    .setColor(DISCORD_COLORS.SUCCESS)
+    .setDescription(
+      `Your opt-in to truncate over-length fields has been recorded. ` +
+        `Click **Open Editor** below to open the edit modal. ` +
+        `The modal will open with the current values truncated to the edit limit.`
+    );
+}

--- a/services/bot-client/src/utils/dashboard/truncationGate/index.ts
+++ b/services/bot-client/src/utils/dashboard/truncationGate/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Truncation Gate primitives — entity-agnostic detection + display building
+ * blocks for the "warn before silent truncate" UX. Entity-specific button
+ * handlers live alongside their entity-specific data resolvers (see
+ * `commands/character/truncationWarning.ts` and
+ * `commands/persona/truncationWarning.ts`).
+ */
+
+export { detectOverLengthFields, type OverLengthField } from './detection.js';
+export {
+  buildTruncationWarningEmbed,
+  buildReadyToEditEmbed,
+  stripLeadingEmoji,
+  toSafeFilename,
+} from './embeds.js';
+export { buildTruncationButtons, buildOpenEditorButtonRow } from './buttons.js';

--- a/services/bot-client/src/utils/dashboard/types.ts
+++ b/services/bot-client/src/utils/dashboard/types.ts
@@ -8,6 +8,17 @@
 import { z } from 'zod';
 
 /**
+ * Entity types that participate in the dashboard truncationGate flow.
+ *
+ * Narrower than `parseDashboardCustomId`'s broader `string` shape (which
+ * also covers preset/profile/etc. entityTypes that don't use the gate
+ * yet). Used to type-check the per-dashboard custom-id namespace passed
+ * into `buildTruncationButtons` / `buildOpenEditorButtonRow`. Add to the
+ * union when a third dashboard adopts the gate.
+ */
+export type TruncationGateEntityType = 'character' | 'persona';
+
+/**
  * Context passed to dashboard rendering functions
  * Used for dynamic field visibility and validation
  */


### PR DESCRIPTION
## Summary

PR #983 fixed the persona "About You" silent-truncation data-loss bug at the cap (raised UI `maxLength` 2000 → 4000 to match the API). This PR adds the **defense-in-depth gate** that prevents the same bug class from ever recurring: if persona content ever exceeds the modal cap (future schema raise, direct-API write past 4000), the user sees a warning + three-button choice (View Full / Cancel / Edit with Truncation) before any destructive truncation happens.

The character dashboard already has this gate (`commands/character/truncationWarning.ts`, ~450 LOC, 10 describe-blocks of tests, battle-tested through PR #825). This PR extracts the entity-agnostic primitives to `utils/dashboard/truncationGate/` and mirrors the handlers for persona.

## Architecture: B+extract

- **Lifted** detection + embed builders + button-row builders into `utils/dashboard/truncationGate/` as generic-typed shared utilities. Both dashboards (and future ones) consume them.
- **Kept** per-dashboard handler implementations (`character/truncationWarning.ts`, `persona/truncationWarning.ts`) since each depends on its own data resolver (`resolveCharacterSectionContext` / `resolvePersonaSectionContext`).
- **Did NOT** rewrite character — its battle-tested handler wiring is untouched apart from import paths.
- **Did NOT** abstract the handlers themselves — defer the `SectionContextResolver<T>` callback abstraction until a third dashboard wants the gate (rule-of-three).

Preset (`preset/dashboard.ts:211`) still uses the shared `handleDashboardSectionSelect` — that handler stays alive and unchanged.

## Commits (3)

1. **`refactor(bot-client): extract truncationGate primitives to shared utils`** — pure refactor, zero behavior change for character. Detection / embed / button-shape unit tests relocated to `utils/dashboard/truncationGate/*.test.ts`.
2. **`feat(bot-client): add persona-side truncation gate handlers`** — `persona/sectionContext.ts` + `persona/truncationWarning.ts` mirroring character's two-click flow with persona's data resolver.
3. **`feat(bot-client): wire persona dashboard through truncation gate`** — `persona/dashboard.ts` `handleSelectMenu` inlines the gate; `handleButton` extends with four new cases.
4. (small follow-up) **`chore(tooling): allowlist persona truncationGate handler names`** — adds `showTruncationWarning` + `handleOpenEditorButton` to the duplicate-export allowlist.

## Risk areas (carried over from character's hard-won lessons)

- **PR #825 session-warm timing**: persona's `handleEditTruncatedButton` calls `interaction.update` BEFORE the async `loadPersonaSectionData` warm. Test-pinned via `mock.invocationCallOrder`.
- **3-second budget**: persona `handleButton` does sync `PersonaCustomIds.parse` only before dispatch; new branches `await` handlers directly.
- **Concurrent edit between warning and View Full**: `handleViewFullButton` re-detects over-length and shows "nothing to display" if the data shrank.
- **10062 residual on Open Editor**: same `DiscordAPIError` 10062 catch + ephemeral `followUp` retry as character.

## Test plan

- [x] `pnpm --filter bot-client test --run` — 4716 tests pass (was 4681; +35 net from 3 new shared module test files + 2 new persona test files − duplicate detection/embed/button tests removed from character)
- [x] `pnpm quality` green — lint + cpd + depcruise + typecheck + typecheck:spec
- [x] `pnpm ops guard:duplicate-exports` — green (allowlist updated)
- [ ] **Manual smoke test on dev** (after merge):
  - Create persona with content at exactly the 4000-char cap → modal opens directly (no warning)
  - Use a script to set persona content to 4001+ chars → `/persona edit` → identity → observe warning embed with three buttons
  - Test each button: View Full produces a `.txt` attachment, Cancel cancels cleanly, Edit with Truncation produces the two-click flow with modal opening on second click

## Out-of-scope follow-ups (track in `backlog/inbox.md` after merge)

- **D1b full handler generification** — defer until a third dashboard wants the gate
- **Preset dashboard truncation gate** — audit preset fields for `maxLength ≥ 1024`; same fix shape if needed
- **Field-level truncation copy customization per entity** — UX call

🤖 Generated with [Claude Code](https://claude.com/claude-code)