### PR TITLE
fix(bot-client): dashboard 3-sec budget follow-ups from PR #984 review

### DIFF
--- a/services/bot-client/src/commands/character/dashboard.test.ts
+++ b/services/bot-client/src/commands/character/dashboard.test.ts
@@ -68,10 +68,13 @@ vi.mock('./truncationWarning.js', () => ({
 // renderTerminalScreen imports getSessionManager directly from the source
 // module, so mocking the barrel below isn't enough — add a source-level stub
 // so handleRefreshButton's NOT_FOUND path doesn't blow up on an uninitialized
-// session manager.
+// session manager. `get` returns `null` (not undefined) to match the real
+// contract: `fetchOrCreateSession` checks `session !== null` to decide
+// cache hit vs miss; vi.fn()'s default undefined would cause a runtime
+// crash on the cache-miss path.
 vi.mock('../../utils/dashboard/SessionManager.js', () => ({
   getSessionManager: vi.fn().mockReturnValue({
-    get: vi.fn(),
+    get: vi.fn().mockResolvedValue(null),
     set: vi.fn(),
     update: vi.fn(),
     delete: vi.fn(),
@@ -305,6 +308,73 @@ describe('Character Dashboard', () => {
 
       expect(mockInteraction.showModal).not.toHaveBeenCalled();
       expect(mockInteraction.reply).not.toHaveBeenCalled();
+    });
+
+    it('catches 10062 on showModal and surfaces a retry followUp', async () => {
+      // Mirrors handleOpenEditorButton's 10062 catch — same residual risk
+      // (Redis/gateway slow + can't deferReply before showModal). Without
+      // this catch, the user sees a silent "Interaction Failed" with no
+      // diagnostic signal in logs.
+      const { DiscordAPIError } = await import('discord.js');
+      vi.mocked(dashboardUtils.parseDashboardCustomId).mockReturnValue({
+        entityType: 'character',
+        action: 'menu',
+        entityId: 'test-char',
+      });
+      vi.mocked(api.fetchCharacter).mockResolvedValue({
+        id: 'uuid',
+        name: 'Test',
+        slug: 'test-char',
+        displayName: null,
+        characterInfo: '',
+        personalityTraits: '',
+        personalityTone: null,
+        personalityAge: null,
+        personalityAppearance: null,
+        personalityLikes: null,
+        personalityDislikes: null,
+        conversationalGoals: null,
+        conversationalExamples: null,
+        errorMessage: null,
+        birthMonth: null,
+        birthDay: null,
+        birthYear: null,
+        ownerId: 'owner-1',
+        isPublic: false,
+        voiceEnabled: false,
+        hasVoiceReference: false,
+        imageEnabled: false,
+        avatarData: null,
+        canEdit: true,
+        createdAt: '',
+        updatedAt: '',
+      });
+      const timeoutError = new DiscordAPIError(
+        { code: 10062, message: 'Unknown interaction' },
+        10062,
+        404,
+        'POST',
+        '/interactions/x/y/callback',
+        {}
+      );
+      const failingShowModal = vi.fn().mockRejectedValue(timeoutError);
+      const followUpSpy = vi.fn().mockResolvedValue(undefined);
+      const mockInteraction = createMockSelectInteraction(
+        'character::menu::test-char',
+        'edit-identity'
+      );
+      mockInteraction.showModal = failingShowModal;
+      mockInteraction.followUp = followUpSpy;
+
+      await handleSelectMenu(mockInteraction);
+
+      expect(failingShowModal).toHaveBeenCalled();
+      expect(followUpSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining('Took too long'),
+          flags: MessageFlags.Ephemeral,
+        })
+      );
     });
 
     it('should handle action-visibility selection', async () => {

--- a/services/bot-client/src/commands/character/dashboard.ts
+++ b/services/bot-client/src/commands/character/dashboard.ts
@@ -24,6 +24,7 @@ import {
   parseDashboardCustomId,
   isDashboardInteraction,
 } from '../../utils/dashboard/index.js';
+import { showModalWithTimeoutCatch } from '../../utils/dashboard/showModalWithTimeoutCatch.js';
 import { CharacterCustomIds } from '../../utils/customIds.js';
 import {
   getCharacterDashboardConfig,
@@ -245,7 +246,10 @@ export async function handleSelectMenu(interaction: StringSelectMenuInteraction)
       return;
     }
 
-    // Build and show section modal (with context for field visibility)
+    // Build and show section modal (with context for field visibility).
+    // The showModal call is wrapped via showModalWithTimeoutCatch to handle
+    // the 10062 case where Redis/gateway latency + the (forbidden-by-Discord)
+    // inability to deferReply before showModal blew the 3-second budget.
     const modal = buildSectionModal(
       ctx.dashboardConfig,
       ctx.section,
@@ -253,7 +257,13 @@ export async function handleSelectMenu(interaction: StringSelectMenuInteraction)
       ctx.data,
       ctx.context
     );
-    await interaction.showModal(modal);
+    await showModalWithTimeoutCatch(
+      interaction,
+      modal,
+      { source: 'handleSelectMenu', userId: interaction.user.id, entityId, sectionId },
+      '⏰ Took too long to open the editor. Please re-select the section from the dashboard, ' +
+        'or click Refresh if the menu is no longer responsive.'
+    );
     return;
   }
 

--- a/services/bot-client/src/commands/character/sectionContext.test.ts
+++ b/services/bot-client/src/commands/character/sectionContext.test.ts
@@ -154,17 +154,20 @@ describe('resolveCharacterSectionContext', () => {
     );
   });
 
-  it('routes error replies through followUp when the caller already deferred', async () => {
+  it('routes error replies through editReply when the caller already deferred but not replied', async () => {
     // Simulates `handleViewFullButton`, which `deferReply`s before calling
-    // this helper. The helper must detect `interaction.deferred` and use
-    // `followUp` — `reply()` on a deferred interaction throws.
+    // this helper. The helper must use `editReply` to fill the deferred
+    // slot — `followUp` would leave the loading indicator dangling, and
+    // `reply` would throw on a deferred interaction.
     mockFetchOrCreateSession.mockResolvedValue({ success: false });
+    const mockEditReply = vi.fn().mockResolvedValue(undefined);
     const mockFollowUp = vi.fn().mockResolvedValue(undefined);
     const mockReply = vi.fn().mockResolvedValue(undefined);
     const interaction = {
       user: { id: 'user-1' },
       deferred: true,
       replied: false,
+      editReply: mockEditReply,
       followUp: mockFollowUp,
       reply: mockReply,
     } as unknown as ButtonInteraction;
@@ -178,10 +181,10 @@ describe('resolveCharacterSectionContext', () => {
 
     expect(result).toBeNull();
     expect(mockReply).not.toHaveBeenCalled();
-    expect(mockFollowUp).toHaveBeenCalledWith(
+    expect(mockFollowUp).not.toHaveBeenCalled();
+    expect(mockEditReply).toHaveBeenCalledWith(
       expect.objectContaining({
         content: expect.stringContaining('not found'),
-        flags: MessageFlags.Ephemeral,
       })
     );
   });

--- a/services/bot-client/src/commands/character/sectionContext.ts
+++ b/services/bot-client/src/commands/character/sectionContext.ts
@@ -145,17 +145,35 @@ export async function resolveCharacterSectionContext(
 }
 
 /**
- * Reply with an ephemeral error, adapting to whether the caller has
- * already acked the interaction. Callers that `deferReply`-ed before
- * invoking this helper need `followUp`; fresh callers need `reply`.
- * Checking `interaction.deferred || interaction.replied` lets the helper
- * work transparently under both call shapes.
+ * Reply with an ephemeral error, adapting to the interaction's ack state.
+ *
+ * Three states map to three response APIs:
+ * - `deferred && !replied` (caller did `deferReply`, hasn't sent the
+ *   actual response yet) → `editReply` fills the deferred slot. This
+ *   replaces the "Thinking…" loading indicator with the error message
+ *   instead of leaving the indicator dangling + spawning a separate
+ *   followUp.
+ * - `replied` (caller already sent a response) → `followUp` for an
+ *   additional ephemeral message.
+ * - fresh (neither deferred nor replied) → `reply`.
+ *
+ * **PRECONDITION (deferred path)**: Callers that take the
+ * `deferred && !replied` path must have called `deferReply({ flags:
+ * MessageFlags.Ephemeral })`. `editReply` inherits whatever flags were
+ * set by `deferReply` — passing flags here has no effect. A caller that
+ * defers without ephemeral and then hits this helper would expose the
+ * error message publicly.
+ *
+ * The deferred slot's ephemeral flag is what makes the error message
+ * private; the other two paths pass `flags: Ephemeral` explicitly.
  */
 async function replyError(
   interaction: ButtonInteraction | StringSelectMenuInteraction,
   content: string
 ): Promise<void> {
-  if (interaction.deferred || interaction.replied) {
+  if (interaction.deferred && !interaction.replied) {
+    await interaction.editReply({ content });
+  } else if (interaction.replied) {
     await interaction.followUp({ content, flags: MessageFlags.Ephemeral });
   } else {
     await interaction.reply({ content, flags: MessageFlags.Ephemeral });

--- a/services/bot-client/src/commands/character/truncationWarning.test.ts
+++ b/services/bot-client/src/commands/character/truncationWarning.test.ts
@@ -456,18 +456,20 @@ describe('handleViewFullButton', () => {
     expect(editReply.mock.calls[0][0].files).toBeUndefined();
   });
 
-  it('surfaces fetch-failure via followUp (sectionContext detects defer)', async () => {
+  it('surfaces fetch-failure via editReply (sectionContext fills the deferred slot)', async () => {
     mockFetchOrCreateSession.mockResolvedValue({ success: false });
-    const { interaction, followUp, reply } = makeDeferrableInteraction();
+    const { interaction, editReply, followUp, reply } = makeDeferrableInteraction();
 
     await handleViewFullButton(interaction, 'char-1', 'identity');
 
-    // After deferReply, sectionContext must use followUp, not reply
+    // After deferReply, sectionContext uses editReply to fill the deferred
+    // slot (replaces the loading indicator with the error message) rather
+    // than spawning a separate followUp that leaves the indicator dangling.
     expect(reply).not.toHaveBeenCalled();
-    expect(followUp).toHaveBeenCalledWith(
+    expect(followUp).not.toHaveBeenCalled();
+    expect(editReply).toHaveBeenCalledWith(
       expect.objectContaining({
         content: expect.stringContaining('not found'),
-        flags: MessageFlags.Ephemeral,
       })
     );
   });

--- a/services/bot-client/src/commands/character/truncationWarning.ts
+++ b/services/bot-client/src/commands/character/truncationWarning.ts
@@ -14,11 +14,12 @@
  * committing.
  */
 
-import { AttachmentBuilder, DiscordAPIError, MessageFlags } from 'discord.js';
+import { AttachmentBuilder, MessageFlags } from 'discord.js';
 import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
 import { createLogger, getConfig, type EnvConfig } from '@tzurot/common-types';
 import { type SectionDefinition } from '../../utils/dashboard/types.js';
 import { buildSectionModal } from '../../utils/dashboard/ModalFactory.js';
+import { showModalWithTimeoutCatch } from '../../utils/dashboard/showModalWithTimeoutCatch.js';
 import {
   detectOverLengthFields,
   buildTruncationWarningEmbed,
@@ -170,33 +171,13 @@ export async function handleOpenEditorButton(
     ctx.data,
     ctx.context
   );
-  try {
-    await interaction.showModal(modal);
-  } catch (error) {
-    if (error instanceof DiscordAPIError && error.code === 10062) {
-      // 3-sec window blew despite the session warm (e.g., Redis latency
-      // spike). Log with enough context to track frequency. The interaction
-      // token is dead so followUp also fails — we try once anyway for the
-      // rare race where Discord still accepts it, and swallow the inner
-      // failure so the outer CommandHandler catch doesn't log twice.
-      logger.warn(
-        { userId: interaction.user.id, entityId, sectionId },
-        'Open Editor showModal exceeded 3-second window (10062)'
-      );
-      try {
-        await interaction.followUp({
-          content:
-            '⏰ Took too long to open the editor. Please click **Open Editor** again, ' +
-            'or re-open the dashboard if the button is gone.',
-          flags: MessageFlags.Ephemeral,
-        });
-      } catch {
-        // Expected on a fully-dead interaction token. Nothing else to do.
-      }
-      return;
-    }
-    throw error;
-  }
+  await showModalWithTimeoutCatch(
+    interaction,
+    modal,
+    { source: 'handleOpenEditorButton', userId: interaction.user.id, entityId, sectionId },
+    '⏰ Took too long to open the editor. Please click **Open Editor** again, ' +
+      'or re-open the dashboard if the button is gone.'
+  );
 }
 
 /**

--- a/services/bot-client/src/commands/persona/dashboard.test.ts
+++ b/services/bot-client/src/commands/persona/dashboard.test.ts
@@ -510,6 +510,47 @@ describe('handleSelectMenu', () => {
     );
   });
 
+  it('should catch 10062 on showModal and surface a retry followUp', async () => {
+    // Mirrors handleOpenEditorButton's 10062 catch — same residual risk
+    // (Redis/gateway slow, can't deferReply before showModal). Without
+    // this catch, the user sees a silent "Interaction Failed" with no
+    // diagnostic signal in logs.
+    const { DiscordAPIError } = await import('discord.js');
+    mockSessionGet.mockResolvedValue({
+      data: { name: 'Test Persona', content: 'fits' },
+    });
+    const timeoutError = new DiscordAPIError(
+      { code: 10062, message: 'Unknown interaction' },
+      10062,
+      404,
+      'POST',
+      '/interactions/x/y/callback',
+      {}
+    );
+    const failingShowModal = vi.fn().mockRejectedValue(timeoutError);
+    const followUpSpy = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      customId: `persona::menu::${TEST_PERSONA_ID}`,
+      values: ['edit-identity'],
+      user: { id: '123456789', username: 'testuser' },
+      message: { id: 'message-123' },
+      channelId: 'channel-123',
+      showModal: failingShowModal,
+      followUp: followUpSpy,
+      reply: vi.fn(),
+    } as unknown as Parameters<typeof handleSelectMenu>[0];
+
+    await handleSelectMenu(interaction);
+
+    expect(failingShowModal).toHaveBeenCalled();
+    expect(followUpSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('Took too long'),
+        flags: MessageFlags.Ephemeral,
+      })
+    );
+  });
+
   it('should open modal directly when no fields over limit', async () => {
     // Re-establishes the common path after the truncation-warning addition:
     // when content fits, the gate is transparent and the modal opens.

--- a/services/bot-client/src/commands/persona/dashboard.ts
+++ b/services/bot-client/src/commands/persona/dashboard.ts
@@ -39,6 +39,7 @@ import {
 import { fetchPersona, updatePersona, deletePersona, isDefaultPersona } from './api.js';
 import { PersonaCustomIds } from '../../utils/customIds.js';
 import { buildSectionModal } from '../../utils/dashboard/ModalFactory.js';
+import { showModalWithTimeoutCatch } from '../../utils/dashboard/showModalWithTimeoutCatch.js';
 import { detectOverLengthFields } from '../../utils/dashboard/truncationGate/index.js';
 import { resolvePersonaSectionContext } from './sectionContext.js';
 import {
@@ -212,9 +213,18 @@ export async function handleSelectMenu(interaction: StringSelectMenuInteraction)
     return;
   }
 
-  // Common path: no over-length fields → open the modal directly.
+  // Common path: no over-length fields → open the modal directly. The
+  // showModal call is wrapped via showModalWithTimeoutCatch to handle
+  // the 10062 case where Redis/gateway latency + the (forbidden-by-Discord)
+  // inability to deferReply before showModal blew the 3-second budget.
   const modal = buildSectionModal(ctx.dashboardConfig, ctx.section, entityId, ctx.data);
-  await interaction.showModal(modal);
+  await showModalWithTimeoutCatch(
+    interaction,
+    modal,
+    { source: 'handleSelectMenu', userId: interaction.user.id, entityId, sectionId },
+    '⏰ Took too long to open the editor. Please re-select the section from the dashboard, ' +
+      'or click Refresh if the menu is no longer responsive.'
+  );
 }
 
 /**

--- a/services/bot-client/src/commands/persona/sectionContext.test.ts
+++ b/services/bot-client/src/commands/persona/sectionContext.test.ts
@@ -93,13 +93,18 @@ describe('loadPersonaSectionData', () => {
     );
   });
 
-  it('uses followUp instead of reply when interaction is already deferred', async () => {
+  it('uses editReply when interaction is deferred-but-not-replied', async () => {
+    // After deferReply but before any actual response, the deferred slot
+    // is "Thinking…" and editReply fills it. Using followUp here would
+    // leave the loading indicator dangling and spawn a separate message.
     mockFetchOrCreateSession.mockResolvedValue({ success: false });
     const mockReply = vi.fn();
-    const mockFollowUp = vi.fn().mockResolvedValue(undefined);
+    const mockEditReply = vi.fn().mockResolvedValue(undefined);
+    const mockFollowUp = vi.fn();
     const interaction = {
       user: { id: 'user-1' },
       reply: mockReply,
+      editReply: mockEditReply,
       followUp: mockFollowUp,
       get deferred() {
         return true;
@@ -112,6 +117,37 @@ describe('loadPersonaSectionData', () => {
 
     await loadPersonaSectionData(interaction, 'persona-1', sync);
     expect(mockReply).not.toHaveBeenCalled();
+    expect(mockFollowUp).not.toHaveBeenCalled();
+    expect(mockEditReply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining('Persona') })
+    );
+  });
+
+  it('uses followUp when interaction has already been replied to', async () => {
+    // After interaction.update() (which sets `replied=true`), an additional
+    // ephemeral error message should use followUp, not editReply (which
+    // would replace the original visible response).
+    mockFetchOrCreateSession.mockResolvedValue({ success: false });
+    const mockReply = vi.fn();
+    const mockEditReply = vi.fn();
+    const mockFollowUp = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      user: { id: 'user-1' },
+      reply: mockReply,
+      editReply: mockEditReply,
+      followUp: mockFollowUp,
+      get deferred() {
+        return false;
+      },
+      get replied() {
+        return true;
+      },
+    } as unknown as ButtonInteraction;
+    const sync = findPersonaSection('identity')!;
+
+    await loadPersonaSectionData(interaction, 'persona-1', sync);
+    expect(mockReply).not.toHaveBeenCalled();
+    expect(mockEditReply).not.toHaveBeenCalled();
     expect(mockFollowUp).toHaveBeenCalled();
   });
 });

--- a/services/bot-client/src/commands/persona/sectionContext.ts
+++ b/services/bot-client/src/commands/persona/sectionContext.ts
@@ -115,14 +115,27 @@ export async function resolvePersonaSectionContext(
 }
 
 /**
- * Reply with an ephemeral error, adapting to whether the caller has
- * already acked the interaction.
+ * Reply with an ephemeral error, adapting to the interaction's ack state.
+ *
+ * - `deferred && !replied` → `editReply` fills the deferred slot (replaces
+ *   the loading indicator instead of leaving it dangling + spawning a
+ *   separate followUp).
+ * - `replied` → `followUp` for an additional ephemeral message.
+ * - fresh → `reply`.
+ *
+ * **PRECONDITION (deferred path)**: Callers must have called
+ * `deferReply({ flags: MessageFlags.Ephemeral })`. `editReply` inherits
+ * the deferred slot's flags; a non-ephemeral defer would expose the
+ * error publicly. See `commands/character/sectionContext.ts` for the
+ * canonical longer rationale.
  */
 async function replyError(
   interaction: ButtonInteraction | StringSelectMenuInteraction,
   content: string
 ): Promise<void> {
-  if (interaction.deferred || interaction.replied) {
+  if (interaction.deferred && !interaction.replied) {
+    await interaction.editReply({ content });
+  } else if (interaction.replied) {
     await interaction.followUp({ content, flags: MessageFlags.Ephemeral });
   } else {
     await interaction.reply({ content, flags: MessageFlags.Ephemeral });

--- a/services/bot-client/src/commands/persona/truncationWarning.test.ts
+++ b/services/bot-client/src/commands/persona/truncationWarning.test.ts
@@ -401,15 +401,21 @@ describe('handleViewFullButton', () => {
     expect(editArgs.files).toBeUndefined();
   });
 
-  it('returns silently when context resolution fails (sectionContext sent followUp)', async () => {
+  it('surfaces fetch-failure via editReply (sectionContext fills the deferred slot)', async () => {
     mockFetchOrCreateSession.mockResolvedValue({ success: false });
     const { interaction, editReply, followUp } = makeDeferrableInteraction();
 
     await handleViewFullButton(interaction, 'persona-1', 'identity');
 
-    expect(editReply).not.toHaveBeenCalled();
-    // sectionContext's replyError sent the followUp.
-    expect(followUp).toHaveBeenCalled();
+    // sectionContext.replyError uses editReply on a deferred-but-not-replied
+    // interaction to fill the loading slot, not followUp (which would leave
+    // the "Thinking…" indicator dangling).
+    expect(followUp).not.toHaveBeenCalled();
+    expect(editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('Persona'),
+      })
+    );
   });
 });
 

--- a/services/bot-client/src/commands/persona/truncationWarning.ts
+++ b/services/bot-client/src/commands/persona/truncationWarning.ts
@@ -14,11 +14,12 @@
  * gate necessary on the persona side.
  */
 
-import { AttachmentBuilder, DiscordAPIError, MessageFlags } from 'discord.js';
+import { AttachmentBuilder, MessageFlags } from 'discord.js';
 import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
 import { type SectionDefinition } from '../../utils/dashboard/types.js';
 import { buildSectionModal } from '../../utils/dashboard/ModalFactory.js';
+import { showModalWithTimeoutCatch } from '../../utils/dashboard/showModalWithTimeoutCatch.js';
 import {
   detectOverLengthFields,
   buildTruncationWarningEmbed,
@@ -123,28 +124,13 @@ export async function handleOpenEditorButton(
   }
 
   const modal = buildSectionModal(ctx.dashboardConfig, ctx.section, entityId, ctx.data);
-  try {
-    await interaction.showModal(modal);
-  } catch (error) {
-    if (error instanceof DiscordAPIError && error.code === 10062) {
-      logger.warn(
-        { userId: interaction.user.id, entityId, sectionId },
-        'Open Editor showModal exceeded 3-second window (10062)'
-      );
-      try {
-        await interaction.followUp({
-          content:
-            '⏰ Took too long to open the editor. Please click **Open Editor** again, ' +
-            'or re-open the dashboard if the button is gone.',
-          flags: MessageFlags.Ephemeral,
-        });
-      } catch {
-        // Expected on a fully-dead interaction token. Nothing else to do.
-      }
-      return;
-    }
-    throw error;
-  }
+  await showModalWithTimeoutCatch(
+    interaction,
+    modal,
+    { source: 'handleOpenEditorButton', userId: interaction.user.id, entityId, sectionId },
+    '⏰ Took too long to open the editor. Please click **Open Editor** again, ' +
+      'or re-open the dashboard if the button is gone.'
+  );
 }
 
 /**

--- a/services/bot-client/src/utils/dashboard/showModalWithTimeoutCatch.test.ts
+++ b/services/bot-client/src/utils/dashboard/showModalWithTimeoutCatch.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for showModalWithTimeoutCatch.
+ *
+ * Pins the 10062 contract: log + ephemeral followUp + swallow secondary
+ * 10062. Non-10062 errors rethrow.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DiscordAPIError, MessageFlags, type ModalBuilder } from 'discord.js';
+import type { ButtonInteraction } from 'discord.js';
+
+// Shared mock logger so tests can assert against `mockLogger.warn`
+// (the helper logs unexpected followUp failures there). vi.hoisted is
+// required because vi.mock factories are hoisted above const declarations.
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => mockLogger,
+  };
+});
+
+const { showModalWithTimeoutCatch } = await import('./showModalWithTimeoutCatch.js');
+
+const FAKE_MODAL = { __modal: true } as unknown as ModalBuilder;
+const DIAG = {
+  source: 'handleTest',
+  userId: 'user-1',
+  entityId: 'entity-1',
+  sectionId: 'identity',
+};
+const RETRY = '⏰ Took too long, please retry.';
+
+function make10062Error(): DiscordAPIError {
+  return new DiscordAPIError(
+    { code: 10062, message: 'Unknown interaction' },
+    10062,
+    404,
+    'POST',
+    '/interactions/x/y/callback',
+    {}
+  );
+}
+
+describe('showModalWithTimeoutCatch', () => {
+  // Reset all mock fn state between tests so warn-call-count assertions
+  // don't leak across tests if execution order changes or a new test is
+  // inserted between two count-asserting tests. Per 02-code-standards.md:
+  // "Each it() block sets up its own data; never depend on side effects
+  // from prior tests."
+  beforeEach(() => {
+    mockLogger.warn.mockClear();
+  });
+
+  it('forwards a successful showModal call without a followUp', async () => {
+    const showModal = vi.fn().mockResolvedValue(undefined);
+    const followUp = vi.fn();
+    const interaction = { showModal, followUp } as unknown as ButtonInteraction;
+
+    await showModalWithTimeoutCatch(interaction, FAKE_MODAL, DIAG, RETRY);
+
+    expect(showModal).toHaveBeenCalledWith(FAKE_MODAL);
+    expect(followUp).not.toHaveBeenCalled();
+  });
+
+  it('catches 10062 and surfaces an ephemeral retry followUp', async () => {
+    const showModal = vi.fn().mockRejectedValue(make10062Error());
+    const followUp = vi.fn().mockResolvedValue(undefined);
+    const interaction = { showModal, followUp } as unknown as ButtonInteraction;
+
+    await showModalWithTimeoutCatch(interaction, FAKE_MODAL, DIAG, RETRY);
+
+    expect(followUp).toHaveBeenCalledWith({
+      content: RETRY,
+      flags: MessageFlags.Ephemeral,
+    });
+  });
+
+  it('swallows secondary 10062 on the followUp without logging (fully-dead token)', async () => {
+    // When the interaction token is fully dead, even the followUp throws
+    // 10062. The helper must not propagate that — the outer CommandHandler
+    // catch would re-log and re-attempt a send. AND it must NOT log warn
+    // for this expected case, since 10062-after-10062 is the documented
+    // fully-dead-token path.
+    const err = make10062Error();
+    const showModal = vi.fn().mockRejectedValue(err);
+    const followUp = vi.fn().mockRejectedValue(err);
+    const interaction = { showModal, followUp } as unknown as ButtonInteraction;
+
+    await expect(
+      showModalWithTimeoutCatch(interaction, FAKE_MODAL, DIAG, RETRY)
+    ).resolves.toBeUndefined();
+    expect(followUp).toHaveBeenCalled();
+    // First warn is the 10062 on showModal; no second warn for the
+    // followUp's 10062 (that's the expected fully-dead-token signal).
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs warn when followUp fails with a non-10062 error', async () => {
+    // Network partition, rate limit, or any non-10062 Discord error on
+    // the followUp is genuinely unexpected — the helper must surface it
+    // via warn (with the original showModal-10062 warn already emitted
+    // first). Without this, observability into followUp infrastructure
+    // failures is invisible.
+    const showModal = vi.fn().mockRejectedValue(make10062Error());
+    const networkErr = new Error('ECONNRESET');
+    const followUp = vi.fn().mockRejectedValue(networkErr);
+    const interaction = { showModal, followUp } as unknown as ButtonInteraction;
+
+    await expect(
+      showModalWithTimeoutCatch(interaction, FAKE_MODAL, DIAG, RETRY)
+    ).resolves.toBeUndefined();
+    // Two warn calls: 1) showModal 10062, 2) followUp non-10062 unexpected.
+    expect(mockLogger.warn).toHaveBeenCalledTimes(2);
+    expect(mockLogger.warn).toHaveBeenLastCalledWith(
+      expect.objectContaining({ err: networkErr }),
+      expect.stringContaining('followUp after 10062 failed with unexpected error')
+    );
+  });
+
+  it('rethrows non-10062 showModal errors', async () => {
+    const unexpected = new Error('boom');
+    const showModal = vi.fn().mockRejectedValue(unexpected);
+    const followUp = vi.fn();
+    const interaction = { showModal, followUp } as unknown as ButtonInteraction;
+
+    await expect(showModalWithTimeoutCatch(interaction, FAKE_MODAL, DIAG, RETRY)).rejects.toThrow(
+      'boom'
+    );
+    expect(followUp).not.toHaveBeenCalled();
+  });
+
+  it('rethrows non-10062 DiscordAPIError codes', async () => {
+    // 50001 (Missing Access) is a different DiscordAPIError; should rethrow,
+    // not get treated as a 3-sec budget timeout.
+    const accessError = new DiscordAPIError(
+      { code: 50001, message: 'Missing Access' },
+      50001,
+      403,
+      'POST',
+      '/interactions/x/y/callback',
+      {}
+    );
+    const showModal = vi.fn().mockRejectedValue(accessError);
+    const followUp = vi.fn();
+    const interaction = { showModal, followUp } as unknown as ButtonInteraction;
+
+    await expect(showModalWithTimeoutCatch(interaction, FAKE_MODAL, DIAG, RETRY)).rejects.toThrow(
+      'Missing Access'
+    );
+  });
+});

--- a/services/bot-client/src/utils/dashboard/showModalWithTimeoutCatch.ts
+++ b/services/bot-client/src/utils/dashboard/showModalWithTimeoutCatch.ts
@@ -1,0 +1,69 @@
+/**
+ * Show a Discord modal, catching the 10062 "Unknown interaction"
+ * timeout when the 3-second budget blew before `showModal` reached the
+ * Discord edge.
+ *
+ * Discord forbids `deferReply` before `showModal`, so any async work
+ * before the modal show (Redis lookup, gateway fallback) eats into the
+ * 3-second budget. Under load, the budget can blow and `showModal`
+ * throws `DiscordAPIError(10062)`. Without this catch the user sees a
+ * silent "Interaction Failed" with no diagnostic signal in logs.
+ *
+ * On 10062: log + send an ephemeral `followUp` with a retry message.
+ * The followUp itself can also 10062 on a fully-dead interaction
+ * token; that secondary failure is swallowed.
+ *
+ * On any other error: rethrow so the global handler can surface it.
+ */
+
+import { DiscordAPIError, MessageFlags, type ModalBuilder } from 'discord.js';
+import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
+import { createLogger } from '@tzurot/common-types';
+
+const logger = createLogger('show-modal-with-timeout-catch');
+
+export interface ShowModalDiagContext {
+  /** Originating handler name, e.g. 'handleSelectMenu' / 'handleOpenEditorButton'. */
+  source: string;
+  /** Discord user id (safe to log). */
+  userId: string;
+  /** Entity id (e.g. character/persona id) for diagnostic context. */
+  entityId: string;
+  /** Section id being edited. */
+  sectionId: string;
+}
+
+export async function showModalWithTimeoutCatch(
+  interaction: StringSelectMenuInteraction | ButtonInteraction,
+  modal: ModalBuilder,
+  diagContext: ShowModalDiagContext,
+  retryMessage: string
+): Promise<void> {
+  try {
+    await interaction.showModal(modal);
+  } catch (error) {
+    if (error instanceof DiscordAPIError && error.code === 10062) {
+      logger.warn(diagContext, 'showModal exceeded 3-second window (10062)');
+      try {
+        await interaction.followUp({
+          content: retryMessage,
+          flags: MessageFlags.Ephemeral,
+        });
+      } catch (followUpErr) {
+        // Swallow only 10062 (the expected fully-dead-token case where
+        // even followUp fails). Anything else (network partition, rate
+        // limit, unexpected Discord error) is genuinely unexpected — log
+        // as warn so it surfaces in observability without propagating to
+        // the outer CommandHandler catch (which would re-log + re-attempt).
+        if (!(followUpErr instanceof DiscordAPIError && followUpErr.code === 10062)) {
+          logger.warn(
+            { ...diagContext, err: followUpErr },
+            'followUp after 10062 failed with unexpected error'
+          );
+        }
+      }
+      return;
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary

Two reviewer-flagged dashboard robustness fixes from PR #984's final review rounds, both pre-existing in character and mirrored to persona, both fixing real Discord-UX gaps:

1. **`handleSelectMenu` 10062 catch** — Redis/gateway latency before `showModal` could blow the 3-second budget; `showModal` then throws `DiscordAPIError 10062` with no recovery. User sees silent "Interaction Failed" and nothing in logs. Now wrapped in a try/catch that logs + sends an ephemeral retry message. Applied to both `character/dashboard.ts` and `persona/dashboard.ts`.

2. **`replyError` deferReply UX** — When `handleViewFullButton` calls `deferReply({ ephemeral })` then hits a session miss, `replyError` was sending a separate `followUp` while leaving the ephemeral deferred slot in unresolved "Thinking…" state. Split the predicate so `deferred && !replied` routes to `editReply` (replaces the loading indicator), `replied` to `followUp`, fresh to `reply`. Applied to both `sectionContext.ts` files.

## DRY-up

The `handleSelectMenu` 10062 catch was the **4th site** in the codebase with the same `showModal` + 10062-catch pattern (the other 3 are `handleOpenEditorButton` × 2 + `handleSelectMenu` × 2 added here). Rule-of-three exceeded twice, so extracted the pattern into `utils/dashboard/showModalWithTimeoutCatch.ts` and refactored all four sites to use it. The helper takes a diagnostic context object + per-site retry message so log output and user-facing copy stay informative.

## Commits (2)

1. \`fix(bot-client): replyError uses editReply when interaction is deferred-but-not-replied\`
2. \`fix(bot-client): catch 10062 timeout on showModal in handleSelectMenu\` (includes the helper extraction + 4-site refactor)

## Test plan

- [x] \`pnpm --filter bot-client test --run\` — 4729 tests pass (was 4720, +9 net: 5 helper tests, 2 dashboard 10062 tests, 1 persona post-reply followUp test, 1 character section-context defer-state branch test)
- [x] \`pnpm quality\` green — lint + cpd + depcruise + typecheck + typecheck:spec
- [ ] **Manual smoke test on dev** (after merge): induce slow gateway, click section in dashboard → observe "⏰ Took too long" followUp instead of silent failure; trigger View Full on a section that's been deleted concurrently → observe loading indicator replaced with error message instead of dangling

## Backlog items closed

This PR closes the two reviewer-surfaced backlog entries filed at the end of session 2026-05-06:
- "Both dashboards: \`handleSelectMenu\` lacks 10062 catch around \`showModal\` after slow session fetch"
- "Both \`sectionContext.ts\`: \`replyError\` uses \`followUp\` instead of \`editReply\` when interaction is deferred"

Both will be removed from \`backlog/inbox.md\` post-merge per session-end-removals gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)