### PR TITLE
chore: bundle A — type-narrow LLM mirror + generic showModal 10062 catch

### DIFF
--- a/packages/common-types/src/utils/deterministicUuid.test.ts
+++ b/packages/common-types/src/utils/deterministicUuid.test.ts
@@ -485,29 +485,26 @@ describe('Deterministic UUID Generation', () => {
       expect(id1).not.toBe(id2);
     });
 
-    it('different provider produces different UUID', () => {
-      const id1 = generateByokLlmConfigUuid(TEST_OWNER, 'openrouter');
-      const id2 = generateByokLlmConfigUuid(TEST_OWNER, 'anthropic');
-      expect(id1).not.toBe(id2);
-    });
+    // No "different provider produces different UUID" test for LLM today —
+    // `ByokLlmProvider` has only one member ('openrouter') currently. Add
+    // back when the union widens (e.g., when a 2nd BYOK LLM provider lands).
 
     it('returns a valid v5 UUID format', () => {
       const id = generateByokLlmConfigUuid(TEST_OWNER, 'openrouter');
       expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
     });
 
-    it('uses a different name-seed prefix than TTS — same (ownerId, provider) produces a different UUID', () => {
+    it('uses a different name-seed prefix than TTS — produces different UUIDs even with overlapping inputs', () => {
       // `tts_config_byok:` vs `llm_config_byok:` — separation by name-seed
-      // prefix (TZUROT_NAMESPACE is shared across all helpers).
+      // prefix (TZUROT_NAMESPACE is shared across all helpers). Each side
+      // uses its respective union's first member; the namespace prefix is
+      // what makes the UUIDs differ regardless of the literal input.
       const ttsId = generateByokTtsConfigUuid(TEST_OWNER, 'elevenlabs');
-      const llmId = generateByokLlmConfigUuid(TEST_OWNER, 'elevenlabs');
+      const llmId = generateByokLlmConfigUuid(TEST_OWNER, 'openrouter');
       expect(ttsId).not.toBe(llmId);
     });
 
     it('returns the documented stable UUID for a known (ownerId, provider) pair', () => {
-      expect(generateByokLlmConfigUuid(TEST_OWNER, 'elevenlabs')).toBe(
-        '7f8a3518-336b-5dc8-973e-cc302405d333'
-      );
       expect(generateByokLlmConfigUuid(TEST_OWNER, 'openrouter')).toBe(
         '287bae65-55ef-591a-9cd1-c567b5d3e2e1'
       );

--- a/packages/common-types/src/utils/deterministicUuid.ts
+++ b/packages/common-types/src/utils/deterministicUuid.ts
@@ -185,6 +185,15 @@ export function generateByokTtsConfigUuid(ownerId: string, provider: ByokTtsProv
 }
 
 /**
+ * Set of LLM providers eligible for migration-seeded BYOK rows. Mirrors
+ * {@link ByokTtsProvider} for the LLM side. The union has only one
+ * member today because OpenRouter is the sole BYOK LLM provider; adding
+ * z.ai or anthropic-direct as future BYOK providers means widening this
+ * union and updating the helper's deterministic-UUID coverage tests.
+ */
+export type ByokLlmProvider = 'openrouter';
+
+/**
  * Deterministic UUID for a per-user BYOK-style LlmConfig row.
  *
  * Mirrors {@link generateByokTtsConfigUuid}. Currently unused — LLM has no
@@ -198,7 +207,7 @@ export function generateByokTtsConfigUuid(ownerId: string, provider: ByokTtsProv
  * future-reserved exports, suppress with a `knip-ignore` directive
  * pointing at this JSDoc rather than removing the helper.
  */
-export function generateByokLlmConfigUuid(ownerId: string, provider: string): string {
+export function generateByokLlmConfigUuid(ownerId: string, provider: ByokLlmProvider): string {
   return uuidv5(`llm_config_byok:${ownerId}:${provider}`, TZUROT_NAMESPACE);
 }
 

--- a/services/bot-client/src/utils/dashboard/genericSelectMenuHandler.test.ts
+++ b/services/bot-client/src/utils/dashboard/genericSelectMenuHandler.test.ts
@@ -64,6 +64,7 @@ interface MockInteraction {
   user: { id: string };
   reply: ReturnType<typeof vi.fn>;
   showModal: ReturnType<typeof vi.fn>;
+  followUp: ReturnType<typeof vi.fn>;
 }
 
 function createInteraction(customId: string, value: string): MockInteraction {
@@ -73,6 +74,7 @@ function createInteraction(customId: string, value: string): MockInteraction {
     user: { id: 'user-123' },
     reply: vi.fn().mockResolvedValue(undefined),
     showModal: vi.fn().mockResolvedValue(undefined),
+    followUp: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -200,6 +202,44 @@ describe('handleDashboardSectionSelect', () => {
 
     expect(mockBuildSectionModal).toHaveBeenCalled();
     expect(interaction.showModal).toHaveBeenCalledWith({ customId: 'modal-1' });
+  });
+
+  it('catches 10062 on showModal and surfaces a retry followUp', async () => {
+    // fetchOrCreateSession on cold cache hits the gateway (multi-second
+    // worst case under load); the subsequent showModal can throw 10062
+    // because Discord forbids deferReply before showModal. Without the
+    // showModalWithTimeoutCatch wrap, the user sees "Interaction Failed"
+    // with no diagnostic signal in logs.
+    const { DiscordAPIError } = await import('discord.js');
+    mockParseDashboardCustomId.mockReturnValue({
+      entityType: 'test',
+      entityId: 'e1',
+    });
+    mockFetchOrCreateSession.mockResolvedValue({
+      success: true,
+      data: { name: 'Test', canEdit: true },
+      fromCache: false,
+    });
+    mockBuildSectionModal.mockReturnValue({ customId: 'modal-1' });
+    const timeoutError = new DiscordAPIError(
+      { code: 10062, message: 'Unknown interaction' },
+      10062,
+      404,
+      'POST',
+      '/interactions/x/y/callback',
+      {}
+    );
+    const interaction = createInteraction('test::select::e1', 'edit-section-a');
+    interaction.showModal = vi.fn().mockRejectedValue(timeoutError);
+
+    await handleDashboardSectionSelect(interaction as never, createConfig());
+
+    expect(interaction.showModal).toHaveBeenCalled();
+    expect(interaction.followUp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('Took too long'),
+      })
+    );
   });
 
   it('skips canEdit check when not provided', async () => {

--- a/services/bot-client/src/utils/dashboard/genericSelectMenuHandler.ts
+++ b/services/bot-client/src/utils/dashboard/genericSelectMenuHandler.ts
@@ -20,6 +20,7 @@ import { toGatewayUser, type GatewayUser } from '../userGatewayClient.js';
 import { parseDashboardCustomId, type DashboardConfig } from './types.js';
 import { fetchOrCreateSession } from './sessionHelpers.js';
 import { buildSectionModal } from './ModalFactory.js';
+import { showModalWithTimeoutCatch } from './showModalWithTimeoutCatch.js';
 import { DASHBOARD_MESSAGES } from './messages.js';
 
 /** Configuration for a generic dashboard select menu handler */
@@ -101,7 +102,21 @@ export async function handleDashboardSectionSelect<TFlat extends Record<string, 
     return;
   }
 
-  // Build and show the section modal
+  // Build and show the section modal. Wrapped via showModalWithTimeoutCatch
+  // so that Redis/gateway latency before showModal can't blow the 3-second
+  // budget silently — a 10062 produces a logged warn + ephemeral retry
+  // followUp instead of a Discord "Interaction Failed" with no signal.
   const modal = buildSectionModal<TFlat>(config.dashboardConfig, section, entityId, result.data);
-  await interaction.showModal(modal);
+  await showModalWithTimeoutCatch(
+    interaction,
+    modal,
+    {
+      source: 'handleDashboardSectionSelect',
+      userId: interaction.user.id,
+      entityId,
+      sectionId: section.id,
+    },
+    '⏰ Took too long to open the editor. Please re-select the section from the dashboard, ' +
+      'or click Refresh if the menu is no longer responsive.'
+  );
 }


### PR DESCRIPTION
## Summary

Two PR follow-ups bundled — both have fresh context from PRs #985 and #986 that just merged:

1. **Type-narrow `generateByokLlmConfigUuid`'s `provider` param** to `ByokLlmProvider` union (`'openrouter'` currently). Mirrors PR #986's TTS narrow. The mirror function now matches the safety property of `generateByokTtsConfigUuid` — typos caught at the call site instead of producing an unrecoverable UUID for a never-existed provider.

2. **Wrap `genericSelectMenuHandler.ts` showModal** with the `showModalWithTimeoutCatch` helper from PR #985. This is the 5th and final **dashboard section-edit** site with the showModal+10062 pattern (PR #985 covered the other 4). Now all dashboard section-edit sites use the shared helper.

> **Scope clarification**: PR #987 round 3 review surfaced 3 *additional* `showModal` sites in different domains (memory edit modal × 2 + settings dashboard) that share the same async-before-showModal risk profile but weren't in #985's section-edit audit scope. Those are tracked as a follow-up backlog entry filed on develop (`2f2911f7b`) for a separate PR.

## Test changes

- `deterministicUuid.test.ts`: removed the "different provider produces different UUID" test for LLM (untestable with single-member union; re-add when the union widens). Updated the LLM/TTS namespace separation test to use each side's respective union member instead of crossing the type.
- `genericSelectMenuHandler.test.ts`: added a 10062-catch coverage test mirroring the helper's contract. Added `followUp` field to `MockInteraction` interface so the new test doesn't need a type cast.

## Backlog cleanup (already on develop)

This session also did an aggressive inbox triage (29 → 9 items) — moved 14 trigger-gated items to `deferred.md`. That cleanup is on develop already; this PR closes 2 more inbox entries via shipping the work.

## Test plan

- [x] `pnpm --filter @tzurot/common-types test --run` — 2340 tests pass
- [x] `pnpm --filter bot-client test --run` — 4731 tests pass (+1 new helper coverage)
- [x] `pnpm quality` green — lint + cpd + depcruise + typecheck + typecheck:spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)