### PR TITLE
fix(bot-client): wrap remaining showModal sites with timeout catch

### DIFF
--- a/services/bot-client/src/commands/deny/detailEdit.ts
+++ b/services/bot-client/src/commands/deny/detailEdit.ts
@@ -16,6 +16,7 @@ import {
 import type { ButtonInteraction, ModalSubmitInteraction } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
 import { getSessionManager } from '../../utils/dashboard/SessionManager.js';
+import { showModalWithTimeoutCatch } from '../../utils/dashboard/showModalWithTimeoutCatch.js';
 import { DASHBOARD_MESSAGES } from '../../utils/dashboard/messages.js';
 import { adminPostJson, adminFetch } from '../../utils/adminApiClient.js';
 import type { DenylistEntryResponse } from './browseTypes.js';
@@ -76,7 +77,19 @@ export async function handleEdit(interaction: ButtonInteraction, entryId: string
     )
   );
 
-  await interaction.showModal(modal);
+  // Wrap showModal so the 3-second budget can't blow silently after the
+  // preceding sessionManager.get() Redis lookup — see showModalWithTimeoutCatch JSDoc.
+  await showModalWithTimeoutCatch(
+    interaction,
+    modal,
+    {
+      source: 'handleEdit',
+      userId: interaction.user.id,
+      entityId: entryId,
+      sectionId: 'edit',
+    },
+    '⏰ Took too long to open the editor. Please click the Edit button again.'
+  );
 }
 
 const MAX_REASON_LENGTH = 500;

--- a/services/bot-client/src/commands/memory/detailModals.ts
+++ b/services/bot-client/src/commands/memory/detailModals.ts
@@ -17,6 +17,7 @@ import type { ButtonInteraction, ModalSubmitInteraction } from 'discord.js';
 import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
 import { buildMemoryActionId, buildDetailEmbed, buildDetailButtons } from './detail.js';
 import { toGatewayUser } from '../../utils/userGatewayClient.js';
+import { showModalWithTimeoutCatch } from '../../utils/dashboard/showModalWithTimeoutCatch.js';
 import { fetchMemory, updateMemory } from './detailApi.js';
 import type { MemoryItem } from './detailApi.js';
 
@@ -123,8 +124,20 @@ export async function handleEditButton(
     return;
   }
 
+  // Wrap showModal so the 3-second budget can't blow silently after
+  // fetchMemory's gateway call — see showModalWithTimeoutCatch JSDoc.
   const modal = buildEditModal(memory);
-  await interaction.showModal(modal);
+  await showModalWithTimeoutCatch(
+    interaction,
+    modal,
+    {
+      source: 'handleEditButton',
+      userId: interaction.user.id,
+      entityId: memoryId,
+      sectionId: 'edit',
+    },
+    '⏰ Took too long to open the editor. Please click the Edit button again.'
+  );
 }
 
 /**
@@ -148,7 +161,17 @@ export async function handleEditTruncatedButton(
   const truncatedContent = memory.content.substring(0, MAX_MODAL_CONTENT_LENGTH);
 
   const modal = buildEditModal(memory, truncatedContent);
-  await interaction.showModal(modal);
+  await showModalWithTimeoutCatch(
+    interaction,
+    modal,
+    {
+      source: 'handleEditTruncatedButton',
+      userId: interaction.user.id,
+      entityId: memoryId,
+      sectionId: 'edit-truncated',
+    },
+    '⏰ Took too long to open the editor. Please click **Edit with Truncation** again.'
+  );
 }
 
 /**

--- a/services/bot-client/src/utils/dashboard/settings/SettingsDashboardHandler.ts
+++ b/services/bot-client/src/utils/dashboard/settings/SettingsDashboardHandler.ts
@@ -18,6 +18,7 @@ import {
   MessageFlags,
 } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
+import { showModalWithTimeoutCatch } from '../showModalWithTimeoutCatch.js';
 import {
   type SettingsDashboardConfig,
   type SettingsDashboardSession,
@@ -364,15 +365,26 @@ async function handleEditButton(
   // Get current value for the modal
   const currentValue = session.data[settingId as keyof SettingsData] as SettingValue<unknown>;
 
-  // Build and show modal
+  // Build and show modal. Wrap showModal so the 3-second budget can't
+  // blow silently after the preceding getSession await — see
+  // showModalWithTimeoutCatch JSDoc.
   const modal = buildSettingEditModal(
     config.entityType,
     session.entityId,
     setting,
     currentValue.effectiveValue
   );
-
-  await interaction.showModal(modal);
+  await showModalWithTimeoutCatch(
+    interaction,
+    modal,
+    {
+      source: 'handleSettingsButton/edit',
+      userId: interaction.user.id,
+      entityId: session.entityId,
+      sectionId: settingId,
+    },
+    '⏰ Took too long to open the editor. Please click the setting button again.'
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes the audit gap surfaced by PR #987's reviewer. PRs #985 + #987 wrapped the 5 dashboard section-edit `showModal` sites with `showModalWithTimeoutCatch`. The reviewer identified additional sites in different domains with the same async-before-`showModal` risk profile that weren't in the original section-edit audit scope:

| Site | Pre-existing async work |
|---|---|
| `commands/memory/detailModals.ts` `handleEditButton` | `await fetchMemory(...)` |
| `commands/memory/detailModals.ts` `handleEditTruncatedButton` | `await fetchMemory(...)` |
| `utils/dashboard/settings/SettingsDashboardHandler.ts` `handleSettingsButton` | `await getSession(...)` |
| `commands/deny/detailEdit.ts` `handleEdit` | `await sessionManager.get(...)` (added round 1 in response to reviewer audit) |

Same fix shape as the previously-wrapped sites — replace `await interaction.showModal(modal)` with `await showModalWithTimeoutCatch(interaction, modal, diagContext, retryMessage)` using a per-site `source` field and an actionable retry message.

After this PR, all 9 known `showModal` sites with async-before risk are wrapped. The slash-command-side `context.showModal` calls (in `create.ts` files) are NOT at risk because they are the first response to the slash command (no preceding await consumes the budget). Other safe-by-construction sites (`destructiveConfirmation.ts:158`, `commands/memory/purge.ts:183`, `commands/shapes/interactionHandlers.ts:113 auth-continue`) were verified during the round-1 reviewer audit.

## Test plan

- [x] `pnpm --filter bot-client test --run` — 4731 tests pass (no new tests added; helper's contract is already pinned in `showModalWithTimeoutCatch.test.ts` and integration test patterns from PRs #985/#987)
- [x] `pnpm quality` green — lint + cpd + depcruise + typecheck + typecheck:spec

> Note: I deliberately didn't add per-site 10062 catch tests on the assumption that the helper's contract being pinned (success path, 10062 catch with retry, secondary 10062 swallow, non-10062 rethrow) plus the integration tests already in PR #987 covers the behavior. If reviewer wants per-site coverage, happy to add it.

## Backlog cleanup

This closes the inbox entry "Wrap remaining `showModal` sites with timeout catch (memory + settings dashboards)" filed during PR #987 review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)