### PR TITLE
chore: pre-commit hook scans for temporal markers in code comments

### DIFF
--- a/.claude/rules/02-code-standards.md
+++ b/.claude/rules/02-code-standards.md
@@ -39,6 +39,23 @@ Rules:
 3. **"pre-existing" is not a justification** — it just means nobody bothered to explain
 4. Run `pnpm ops xray --suppressions` to audit; target 0 unjustified items
 
+## Temporal Markers in Code Comments
+
+**Don't reference dates, PR numbers, or review-archaeology in code comments.** They rot meaninglessly the moment the surrounding context shifts — a `// Caught in PR #847 round 3` marker tells a future reader nothing useful once #847 is squashed into the history. Keep the _invariant explanation_ (why this constraint exists, what it protects against) and drop the _archaeology_ (when, who, which review).
+
+| ❌ Don't write                                 | ✅ Instead                                                                                |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `// Added 2026-05-06 to fix data loss`         | `// Required for parity with API schema cap; UI silently truncated otherwise`             |
+| `// Caught in PR #985 final round review`      | `// Async work before showModal blows the 3-second budget; must wrap in timeout helper`   |
+| `// Surfaced 2026-04-25 by claude-bot`         | `// guards against the empty-default leaking into ON CONFLICT path`                       |
+| `* Background: PR #983 raised the cap to 4000` | `* Cap mirrors API schema's SHORT_PARAGRAPH_MAX_LENGTH; do not raise without bumping API` |
+
+This applies to all comment shapes: full-line `//`, JSDoc `*` body, block `/* */`. Backlog markdown (`backlog/*.md`) is exempt — it intentionally tracks surfacing dates and PR origins.
+
+**Where archaeology _does_ belong**: commit messages (preserved by git), PR descriptions, post-mortems (`docs/incidents/`), and backlog entries with explicit "Surfaced 20YY-MM-DD" prefixes. Code comments document the _invariant_, not the _journey_.
+
+**Enforcement**: `.husky/pre-commit` scans newly-added comment lines in `*.ts`/`*.tsx`/`*.js`/`*.jsx` for date stamps, PR refs, and round/review markers. Override with `TZUROT_SKIP_TEMPORAL_CHECK=1` for the rare intentional case (post-mortem references where the date is the point).
+
 ## TypeScript Strict Rules
 
 - TypeScript `strict: true`, no `any` types

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -40,6 +40,61 @@ if [ -n "$STAGED_PRISMA_SCHEMA" ]; then
     echo "✓ pglite-schema.sql regenerated and staged"
 fi
 
+# Check for temporal markers in code comments (dates / PR refs / round refs)
+# Recurring failure mode: agent or contributor adds "PR #X" / "2026-XX-XX" /
+# "caught in round N" inside JSDoc or `//` comments. These rot meaninglessly
+# (per feedback_no_temporal_refs_in_comments memory + 02-code-standards rule).
+# Backlog markdown is allowed — it tracks surfacing dates intentionally.
+STAGED_CODE_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(ts|tsx|js|jsx)$' || true)
+
+if [ -n "$STAGED_CODE_FILES" ]; then
+    # Match ADDED lines that look like comments (start with // or * after whitespace
+    # or contain /*) AND contain a temporal-marker pattern.
+    # Note on regex portability: `\+` is BRE GNU's one-or-more quantifier, not
+    # a literal plus, so we use bracket form `[+]` for the line-prefix anchors.
+    # Works in both BRE and ERE without warnings.
+    # Scope boundary: only catches full-line comments (`//`, JSDoc `*`, block
+    # `/*`). Inline comments after code (`doSomething(); // PR #X`) are
+    # intentionally NOT caught — robustly distinguishing string literals from
+    # inline comments needs a real lexer, not a grep chain. The full-line case
+    # is the dominant violation pattern in observed data; inline cases are rare.
+    # Date pattern is decade-scoped (`202[0-9]`) so RFC/spec date references
+    # like "RFC 3339 (2002-07-15)" don't trip the hook.
+    TEMPORAL_PATTERN='PR #[0-9]+|202[0-9]-[0-9]{2}-[0-9]{2}|Surfaced 202[0-9]|caught in (round|PR )|flagged by (review|PR)|round [0-9]+ (claude-review|review)'
+    HAS_VIOLATIONS=0
+    VIOLATION_OUTPUT=""
+    for file in $STAGED_CODE_FILES; do
+        FILE_VIOLATIONS=$(git diff --cached -- "$file" | \
+            grep -E '^[+]' | grep -v '^[+][+][+]' | \
+            grep -E '^[+][[:space:]]*(//|\*|/\*)' | \
+            grep -E "$TEMPORAL_PATTERN" || true)
+        if [ -n "$FILE_VIOLATIONS" ]; then
+            HAS_VIOLATIONS=1
+            VIOLATION_OUTPUT="${VIOLATION_OUTPUT}   ${file}:
+$(echo "$FILE_VIOLATIONS" | sed 's/^/     /')
+"
+        fi
+    done
+
+    if [ "$HAS_VIOLATIONS" = "1" ]; then
+        echo ""
+        echo "❌ Temporal markers detected in code comments:"
+        printf '%s' "$VIOLATION_OUTPUT"
+        echo ""
+        echo "Per .claude/rules/02-code-standards.md and project preferences:"
+        echo "  Don't reference dates, PR numbers, or 'caught in X' markers in"
+        echo "  code comments. They rot meaninglessly. Keep the invariant"
+        echo "  explanation, drop the archaeology. These belong in commit"
+        echo "  messages and PR descriptions."
+        echo ""
+        echo "Override (rare): TZUROT_SKIP_TEMPORAL_CHECK=1 git commit ..."
+        if [ "$TZUROT_SKIP_TEMPORAL_CHECK" != "1" ]; then
+            exit 1
+        fi
+        echo "⚠️  TZUROT_SKIP_TEMPORAL_CHECK=1 set — proceeding anyway"
+    fi
+fi
+
 # Check for dangerous Prisma migrations
 STAGED_MIGRATION_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^prisma/migrations/.*\.sql$' || true)
 


### PR DESCRIPTION
## Summary

Adds a `.husky/pre-commit` section that scans staged `*.ts`/`*.tsx`/`*.js`/`*.jsx` files for temporal markers in newly-added comment lines (dates like `2026-05-07`, `PR #N` references, `Surfaced 20YY`, `caught in round N`, etc.). Blocks the commit with a one-line-per-violation report pointing at the rule and offering a `TZUROT_SKIP_TEMPORAL_CHECK=1` override for the rare intentional case.

## Why

The existing rule against temporal markers in code comments (memory + `02-code-standards.md`) is attention-dependent and was violated repeatedly across recent PRs despite being captured in auto-memory. The structural-fix escalation (`00-critical.md` "Fix Recurring Failures Structurally") prescribes elevating recurring failure modes from memory to a hook when the trigger is deterministic — which it is here (added comment line + literal pattern match).

Backlog markdown is intentionally exempted via the file-extension filter; backlog entries track surfacing dates as load-bearing context.

## Patterns matched

- `PR #\d+` — PR-archaeology references
- `2026-XX-XX` — ISO-style dates
- `Surfaced 20YY` — backlog-style date prefixes leaking into code
- `caught in (round|PR )` — review-cycle archaeology
- `flagged by (review|PR)` — same
- `round N (claude-review|review)` — round-counting noise

Comment-shape gate (`^[+][[:space:]]*(//|\*|/\*)`) keeps string literals containing dates from tripping (e.g., `const date = '2026-01-01'`).

## Implementation notes

- Bracket form `[+]` for line-prefix anchors instead of `\+\+\+` — `\+` in BRE is GNU's one-or-more quantifier, which causes "stray \ before +" warnings under `/bin/sh` and produces wrong matches against `grep -v`. `[+]` is unambiguous in both BRE and ERE.
- Hook position: after `lint-staged` (already runs), before the dangerous-migration check. Same fail-closed pattern as the migration check.
- Override: `TZUROT_SKIP_TEMPORAL_CHECK=1 git commit ...` for the intentional-archaeology case (rare, e.g., a post-mortem reference where the date is the point).

## Test plan

- [x] Regex validated against 5 known-violating shapes from recent PRs (full-line `//`, JSDoc `*` body, indented `/*` block) and 3 false-positive candidates (string literals with dates, "round trips" comment).
- [x] Integration test: stage a synthetic temporal-marker comment in `services/bot-client/src/utils/dashboard/showModalWithTimeoutCatch.ts`, confirm `git commit` blocks with the expected output, lint-staged still runs first.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)