### PR TITLE
fix(bot-client): deny handleEdit uses reply not followUp on unacknowledged button

### DIFF
--- a/services/bot-client/src/commands/deny/detailEdit.test.ts
+++ b/services/bot-client/src/commands/deny/detailEdit.test.ts
@@ -89,6 +89,7 @@ function createMockButtonInteraction(customId: string): ButtonInteraction {
     message: { id: 'msg-1' },
     deferUpdate: vi.fn(),
     editReply: vi.fn(),
+    reply: vi.fn(),
     followUp: vi.fn(),
     showModal: vi.fn(),
   } as unknown as ButtonInteraction;
@@ -128,15 +129,18 @@ describe('handleEdit', () => {
     expect(interaction.deferUpdate).not.toHaveBeenCalled();
   });
 
-  it('should handle session expiry', async () => {
+  it('should handle session expiry via reply (unacknowledged button needs initial response)', async () => {
     mockSessionManager.get.mockResolvedValue(null);
     const interaction = createMockButtonInteraction('deny::edit::entry-uuid-1234');
 
     await handleEdit(interaction, 'entry-uuid-1234');
 
-    expect(interaction.followUp).toHaveBeenCalledWith(
+    // Must use reply (not followUp) — followUp without prior ack lands via the
+    // webhook endpoint after Discord's "Application did not respond" banner fires.
+    expect(interaction.reply).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('Session expired') })
     );
+    expect(interaction.followUp).not.toHaveBeenCalled();
   });
 });
 

--- a/services/bot-client/src/commands/deny/detailEdit.ts
+++ b/services/bot-client/src/commands/deny/detailEdit.ts
@@ -35,7 +35,10 @@ export async function handleEdit(interaction: ButtonInteraction, entryId: string
   );
 
   if (session === null) {
-    await interaction.followUp({
+    // First response to an unacknowledged button click must be reply/deferUpdate.
+    // followUp here would land via the webhook endpoint after Discord shows
+    // "Application did not respond" — a confusing double-message UX.
+    await interaction.reply({
       content: DASHBOARD_MESSAGES.SESSION_EXPIRED,
       flags: MessageFlags.Ephemeral,
     });


### PR DESCRIPTION
## Summary

Fixes a pre-existing UX bug in `deny/detailEdit.ts handleEdit`: when `sessionManager.get` returns null on the session-expiry branch, the code called `interaction.followUp(...)` without first acknowledging the button click. Discord accepts `followUp` via the webhook endpoint (15-min validity), but with no initial callback response in the 3-second window, the user sees BOTH:

- Discord's default "Application did not respond" banner
- The ephemeral "Session expired" message

Confusing double-message UX. Switching to `interaction.reply(...)` — the correct idiom for the initial response to an unacknowledged button.

Surfaced in PR #988 round 3 claude-review.

## Audit

Greped all `commands/deny/*.ts` for `interaction.followUp` calls and ack patterns. This is the only site with the followUp-without-prior-ack pattern; the rest use `deferUpdate` correctly.

## Test plan

- [x] `detailEdit.test.ts` session-expiry fixture updated: asserts `reply` is called, `followUp` is NOT called
- [x] All 4745 unit tests pass
- [x] Lint + typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)