### PR TITLE
chore(bot-client): add diagnostic INFO logs to voice transcribe (TEMPORARY)

### DIFF
--- a/services/bot-client/src/services/VoiceTranscriptionService.ts
+++ b/services/bot-client/src/services/VoiceTranscriptionService.ts
@@ -169,14 +169,20 @@ export class VoiceTranscriptionService {
    * @param isReply - Whether message is a reply
    * @returns Transcript text if successful, undefined on error
    */
+  // eslint-disable-next-line complexity, max-lines-per-function -- TEMPORARY: diagnostic INFO logs raise complexity + line count; revert after voice-transcription regression is diagnosed
   async transcribe(
     message: Message,
     hasMention: boolean,
     isReply: boolean
   ): Promise<VoiceTranscriptionResult | null> {
+    logger.info(
+      { messageId: message.id, hasMention, isReply },
+      'TRANSCRIBE_DEBUG: enter transcribe'
+    );
+
     // Skip transcription of bot's own voice messages (e.g., forwarded TTS)
     if (message.author.id === message.client.user?.id) {
-      logger.debug('Skipping transcription of bot own message');
+      logger.info({ messageId: message.id }, 'TRANSCRIBE_DEBUG: skipping bot-own message');
       return null;
     }
 
@@ -185,6 +191,17 @@ export class VoiceTranscriptionService {
     // bail out early when the audio is our own bot's TTS output (encoded in
     // the filename) — no STT cost, no fake typing indicator, no wait.
     const attachments = this.resolveTranscriptionAttachments(message);
+    logger.info(
+      {
+        messageId: message.id,
+        attachmentCount: attachments.length,
+        directAttachmentSize: message.attachments.size,
+        snapshotsSize: message.messageSnapshots?.size ?? 0,
+        firstAttachmentName: attachments[0]?.name,
+        firstAttachmentContentType: attachments[0]?.contentType,
+      },
+      'TRANSCRIBE_DEBUG: attachments resolved'
+    );
 
     // Bot-authored audio short-circuit. Discord's MessageSnapshot strips
     // author metadata from forwards (see botAudioClassifier.ts), so the only
@@ -194,17 +211,27 @@ export class VoiceTranscriptionService {
     // write + reply only fire on the matched branch, keeping the unmatched
     // path microtask-equivalent to the pre-fix behavior.
     const ownAuthoredSlugs = this.classifyAsOwnBotAudio(message, attachments);
+    logger.info(
+      { messageId: message.id, ownAuthored: ownAuthoredSlugs !== null, slugs: ownAuthoredSlugs },
+      'TRANSCRIBE_DEBUG: classifier result'
+    );
     if (ownAuthoredSlugs !== null) {
       return this.handleOwnBotAudio(message, attachments, ownAuthoredSlugs, hasMention, isReply);
     }
 
     let typingInterval: NodeJS.Timeout | undefined;
     try {
+      logger.info({ messageId: message.id }, 'TRANSCRIBE_DEBUG: entering try block');
       // Show typing indicator (if channel supports it)
       // Refresh every 8s to keep it alive during long transcriptions (Discord expires at ~10s)
       if ('sendTyping' in message.channel) {
         const channel = message.channel;
+        logger.info(
+          { messageId: message.id, channelType: message.channel.type },
+          'TRANSCRIBE_DEBUG: about to call sendTyping'
+        );
         await channel.sendTyping();
+        logger.info({ messageId: message.id }, 'TRANSCRIBE_DEBUG: sendTyping returned');
         typingInterval = setInterval(() => {
           void (channel as { sendTyping: () => Promise<void> }).sendTyping().catch(err => {
             handleTypingError(err, {
@@ -219,8 +246,19 @@ export class VoiceTranscriptionService {
         }, TYPING_INDICATOR_INTERVAL_MS);
       }
 
+      logger.info(
+        { messageId: message.id, attachmentCount: attachments.length, userId: message.author.id },
+        'TRANSCRIBE_DEBUG: about to call gatewayClient.transcribe'
+      );
       // Send transcribe job to api-gateway (include userId for BYOK key resolution)
       const response = await this.gatewayClient.transcribe(attachments, message.author.id);
+      logger.info(
+        {
+          messageId: message.id,
+          hasContent: response?.content !== undefined && response.content.length > 0,
+        },
+        'TRANSCRIBE_DEBUG: gatewayClient.transcribe returned'
+      );
 
       if (!response?.content) {
         throw new Error('No transcript returned from transcription service');


### PR DESCRIPTION
## Production fire — diagnostic logging only

Voice transcription regression: bot-client logs \`Processing voice message\` then goes silent. No \`/ai/transcribe\` HTTP request reaches api-gateway. The break is somewhere inside \`VoiceTranscriptionService.transcribe\` between the mention check and the gateway call, but existing debug-level logs aren't enough to localize.

Adds INFO-level breadcrumbs at every checkpoint (prefixed \`TRANSCRIBE_DEBUG:\`):
- Enter
- Bot-own skip
- Attachments resolved (with counts + first attachment metadata)
- Classifier result
- Try block entered
- About to sendTyping
- sendTyping returned
- About to call gatewayClient.transcribe
- gatewayClient.transcribe returned

Once the failure point is identified and fixed, **revert this PR**. The eslint-disable on \`complexity, max-lines-per-function\` is intentional and time-bounded.

## Test plan

- [x] \`pnpm typecheck\` green
- [x] \`pnpm lint\` green (after eslint-disable)
- [ ] Merge → Railway auto-deploys dev → user sends voice → we see exactly where execution stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)