### PR TITLE
fix(bot-client): voice transcription hang via sendTyping helper + ESLint guard

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -48,6 +48,23 @@ const PINO_LOGGER_RULES = PINO_LEVELS.flatMap(level => [
 // route through UserService. Shared across the main block and the route-level
 // override so it stays enforced even when the routes override replaces the
 // `no-restricted-syntax` rule wholesale.
+// Block `await channel.sendTyping()` — the specific pattern that exposes the
+// hang. discord.js's sendTyping has been observed to hang indefinitely under
+// sustained Discord rate-limit pressure (the promise neither resolves nor
+// rejects), so awaiting it blocks the surrounding pipeline indefinitely.
+// Direct `.then()/.catch()` chains on `channel.sendTyping()` aren't blocked
+// here — they're fire-and-forget by construction and don't expose the bug —
+// but contributors should still prefer the `sendTypingIndicator` helper at
+// services/bot-client/src/utils/typingErrorClassifier.ts for latency
+// telemetry + classified error handling.
+const SEND_TYPING_RULES = [
+  {
+    selector: "AwaitExpression > CallExpression[callee.property.name='sendTyping']",
+    message:
+      'Never `await channel.sendTyping()` — discord.js sendTyping can hang indefinitely under rate-limit pressure (queue stall with no resolver). Use `sendTypingIndicator(channel, { logger, source, typingInterval? })` from utils/typingErrorClassifier instead. See its docstring for rationale.',
+  },
+];
+
 const IDENTITY_PROVISIONING_RULES = [
   {
     selector:
@@ -254,7 +271,12 @@ export default tseslint.config(
       // syntactic rule is a strong first line of defense. If that changes,
       // either stop the destructure in review or extend this with a
       // dependency-cruiser rule that catches the import-level pattern.
-      'no-restricted-syntax': ['error', ...PINO_LOGGER_RULES, ...IDENTITY_PROVISIONING_RULES],
+      'no-restricted-syntax': [
+        'error',
+        ...PINO_LOGGER_RULES,
+        ...IDENTITY_PROVISIONING_RULES,
+        ...SEND_TYPING_RULES,
+      ],
 
       // ============================================================================
       // MODULE SIZE & COMPLEXITY RULES

--- a/services/bot-client/src/services/JobTracker.ts
+++ b/services/bot-client/src/services/JobTracker.ts
@@ -9,7 +9,7 @@
 import { createLogger, type TypingChannel } from '@tzurot/common-types';
 import type { LoadedPersonality } from '@tzurot/common-types';
 import type { Message } from 'discord.js';
-import { handleTypingError } from '../utils/typingErrorClassifier.js';
+import { sendTypingIndicator } from '../utils/typingErrorClassifier.js';
 import type { ResponseOrderingService } from './ResponseOrderingService.js';
 
 /**
@@ -191,28 +191,23 @@ export class JobTracker {
           return;
         }
 
-        try {
-          await channel.sendTyping();
-          logger.debug({ jobId }, 'Sent typing indicator');
-        } catch (error) {
-          handleTypingError(error, {
-            logger,
-            context: { jobId, source: 'interval-refresh' },
-            typingInterval,
-          });
-        }
+        sendTypingIndicator(channel, {
+          logger,
+          source: 'interval-refresh',
+          typingInterval,
+          extraContext: { jobId },
+        });
       })();
     }, TYPING_INDICATOR_INTERVAL_MS);
 
     // Send initial typing indicator immediately. Channel-unreachable at this
     // stage clears the interval we just armed so we don't wait a full
     // TYPING_INDICATOR_INTERVAL_MS for the next tick to discover the same.
-    channel.sendTyping().catch(error => {
-      handleTypingError(error, {
-        logger,
-        context: { jobId, source: 'initial' },
-        typingInterval,
-      });
+    sendTypingIndicator(channel, {
+      logger,
+      source: 'initial',
+      typingInterval,
+      extraContext: { jobId },
     });
 
     this.activeJobs.set(jobId, {

--- a/services/bot-client/src/services/VoiceTranscriptionService.ts
+++ b/services/bot-client/src/services/VoiceTranscriptionService.ts
@@ -10,7 +10,7 @@ import { GatewayClient } from '../utils/GatewayClient.js';
 import { splitMessage, createLogger, CONTENT_TYPES, isTimeoutError } from '@tzurot/common-types';
 import { voiceTranscriptCache } from '../redis.js';
 import { hasForwardedSnapshots, getSnapshots } from '../utils/forwardedMessageUtils.js';
-import { handleTypingError } from '../utils/typingErrorClassifier.js';
+import { sendTypingIndicator } from '../utils/typingErrorClassifier.js';
 import { classifyBotAudio } from '../utils/botAudioClassifier.js';
 
 const logger = createLogger('VoiceTranscriptionService');
@@ -169,20 +169,14 @@ export class VoiceTranscriptionService {
    * @param isReply - Whether message is a reply
    * @returns Transcript text if successful, undefined on error
    */
-  // eslint-disable-next-line complexity, max-lines-per-function -- TEMPORARY: diagnostic INFO logs raise complexity + line count; revert after voice-transcription regression is diagnosed
   async transcribe(
     message: Message,
     hasMention: boolean,
     isReply: boolean
   ): Promise<VoiceTranscriptionResult | null> {
-    logger.info(
-      { messageId: message.id, hasMention, isReply },
-      'TRANSCRIBE_DEBUG: enter transcribe'
-    );
-
     // Skip transcription of bot's own voice messages (e.g., forwarded TTS)
     if (message.author.id === message.client.user?.id) {
-      logger.info({ messageId: message.id }, 'TRANSCRIBE_DEBUG: skipping bot-own message');
+      logger.debug({ messageId: message.id }, 'Skipping transcription of bot own message');
       return null;
     }
 
@@ -191,17 +185,6 @@ export class VoiceTranscriptionService {
     // bail out early when the audio is our own bot's TTS output (encoded in
     // the filename) — no STT cost, no fake typing indicator, no wait.
     const attachments = this.resolveTranscriptionAttachments(message);
-    logger.info(
-      {
-        messageId: message.id,
-        attachmentCount: attachments.length,
-        directAttachmentSize: message.attachments.size,
-        snapshotsSize: message.messageSnapshots?.size ?? 0,
-        firstAttachmentName: attachments[0]?.name,
-        firstAttachmentContentType: attachments[0]?.contentType,
-      },
-      'TRANSCRIBE_DEBUG: attachments resolved'
-    );
 
     // Bot-authored audio short-circuit. Discord's MessageSnapshot strips
     // author metadata from forwards (see botAudioClassifier.ts), so the only
@@ -211,54 +194,43 @@ export class VoiceTranscriptionService {
     // write + reply only fire on the matched branch, keeping the unmatched
     // path microtask-equivalent to the pre-fix behavior.
     const ownAuthoredSlugs = this.classifyAsOwnBotAudio(message, attachments);
-    logger.info(
-      { messageId: message.id, ownAuthored: ownAuthoredSlugs !== null, slugs: ownAuthoredSlugs },
-      'TRANSCRIBE_DEBUG: classifier result'
-    );
     if (ownAuthoredSlugs !== null) {
       return this.handleOwnBotAudio(message, attachments, ownAuthoredSlugs, hasMention, isReply);
     }
 
     let typingInterval: NodeJS.Timeout | undefined;
     try {
-      logger.info({ messageId: message.id }, 'TRANSCRIBE_DEBUG: entering try block');
-      // Show typing indicator (if channel supports it)
-      // Refresh every 8s to keep it alive during long transcriptions (Discord expires at ~10s)
+      // Show typing indicator (if channel supports it). All sendTyping calls
+      // route through the helper for fire-and-forget semantics + latency
+      // telemetry — see sendTypingIndicator's docstring for why we never
+      // await sendTyping directly.
+      //
+      // Order matters: arm the interval BEFORE the initial send so that if
+      // the initial send fails with `channel-unreachable`, handleTypingError
+      // can clear the interval immediately. Reversed order means the initial
+      // send sees `typingInterval = undefined` and the interval fires once
+      // more before self-terminating. JobTracker.trackJob uses this same
+      // order for the same reason.
       if ('sendTyping' in message.channel) {
         const channel = message.channel;
-        logger.info(
-          { messageId: message.id, channelType: message.channel.type },
-          'TRANSCRIBE_DEBUG: about to call sendTyping'
-        );
-        await channel.sendTyping();
-        logger.info({ messageId: message.id }, 'TRANSCRIBE_DEBUG: sendTyping returned');
         typingInterval = setInterval(() => {
-          void (channel as { sendTyping: () => Promise<void> }).sendTyping().catch(err => {
-            handleTypingError(err, {
-              logger,
-              context: {
-                channelId: message.channelId,
-                source: 'voice-transcription-interval',
-              },
-              typingInterval,
-            });
+          sendTypingIndicator(channel, {
+            logger,
+            source: 'voice-transcription-interval',
+            typingInterval,
+            extraContext: { messageId: message.id },
           });
         }, TYPING_INDICATOR_INTERVAL_MS);
+        sendTypingIndicator(channel, {
+          logger,
+          source: 'voice-transcription-initial',
+          typingInterval,
+          extraContext: { messageId: message.id },
+        });
       }
 
-      logger.info(
-        { messageId: message.id, attachmentCount: attachments.length, userId: message.author.id },
-        'TRANSCRIBE_DEBUG: about to call gatewayClient.transcribe'
-      );
       // Send transcribe job to api-gateway (include userId for BYOK key resolution)
       const response = await this.gatewayClient.transcribe(attachments, message.author.id);
-      logger.info(
-        {
-          messageId: message.id,
-          hasContent: response?.content !== undefined && response.content.length > 0,
-        },
-        'TRANSCRIBE_DEBUG: gatewayClient.transcribe returned'
-      );
 
       if (!response?.content) {
         throw new Error('No transcript returned from transcription service');

--- a/services/bot-client/src/utils/typingErrorClassifier.test.ts
+++ b/services/bot-client/src/utils/typingErrorClassifier.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { DiscordAPIError } from 'discord.js';
 import type { Logger } from 'pino';
-import { classifyTypingError, handleTypingError } from './typingErrorClassifier.js';
+import {
+  classifyTypingError,
+  handleTypingError,
+  sendTypingIndicator,
+} from './typingErrorClassifier.js';
 
 function buildMockLogger(): Logger {
   return {
@@ -219,6 +223,98 @@ describe('handleTypingError', () => {
     expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({ jobId: 'job-5', err }),
       expect.stringContaining('unclassified')
+    );
+  });
+});
+
+describe('sendTypingIndicator', () => {
+  function buildMockChannel(sendTypingImpl: () => Promise<void>) {
+    return {
+      id: 'channel-test',
+      sendTyping: vi.fn(sendTypingImpl),
+    };
+  }
+
+  it('returns void (not a Promise) so callers cannot accidentally await', () => {
+    // Type-level guarantee + runtime check: if a future contributor changes
+    // the helper to return a Promise, this test catches the regression. The
+    // whole point of the helper is to enforce fire-and-forget semantics.
+    const channel = buildMockChannel(() => Promise.resolve());
+    const logger = buildMockLogger();
+    const result = sendTypingIndicator(channel, { logger, source: 'unit-test' });
+    expect(result).toBeUndefined();
+  });
+
+  it('invokes channel.sendTyping exactly once per call', async () => {
+    const channel = buildMockChannel(() => Promise.resolve());
+    const logger = buildMockLogger();
+    sendTypingIndicator(channel, { logger, source: 'unit-test' });
+    // Microtask flush so the .then() inside the helper runs.
+    await Promise.resolve();
+    expect(channel.sendTyping).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs warn with elapsedMs when sendTyping resolves slower than threshold', async () => {
+    // Simulate a slow resolution by stubbing Date.now: first call captures
+    // start, second call returns start + 4000 (above the 3000ms threshold).
+    let nowReturn = 1_000_000;
+    const dateNowSpy = vi.spyOn(Date, 'now').mockImplementation(() => nowReturn);
+    const channel = buildMockChannel(() => {
+      // Bump the clock between start and resolution so elapsed crosses threshold.
+      nowReturn += 4000;
+      return Promise.resolve();
+    });
+    const logger = buildMockLogger();
+
+    sendTypingIndicator(channel, { logger, source: 'unit-test-slow' });
+    await Promise.resolve(); // Flush the .then()
+    await Promise.resolve(); // Second tick for nested microtasks if any
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'unit-test-slow',
+        channelId: 'channel-test',
+        elapsedMs: 4000,
+      }),
+      expect.stringContaining('slowly')
+    );
+    dateNowSpy.mockRestore();
+  });
+
+  it('does NOT log warn when sendTyping resolves under the threshold', async () => {
+    const channel = buildMockChannel(() => Promise.resolve());
+    const logger = buildMockLogger();
+
+    sendTypingIndicator(channel, { logger, source: 'unit-test-fast' });
+    await Promise.resolve();
+
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('routes errors through handleTypingError on rejection', async () => {
+    // Use a rate-limit error so handleTypingError logs warn (the easiest
+    // assertion target — the helper itself doesn't log on the error path).
+    // Mirror buildDiscordApiError's bodyData shape (`{ body, files }`) — the
+    // discord.js constructor reads `.files` and crashes on undefined.
+    const rateLimitErr = new DiscordAPIError(
+      { code: 0, message: 'You are being rate limited.', retry_after: 1.5 } as never,
+      0,
+      429,
+      'POST',
+      'https://discord.com/api/v10/channels/123/typing',
+      { body: undefined, files: [] }
+    );
+    const channel = buildMockChannel(() => Promise.reject(rateLimitErr));
+    const logger = buildMockLogger();
+
+    sendTypingIndicator(channel, { logger, source: 'unit-test-error' });
+    // Rejection routes through .catch → handleTypingError → logger.warn (rate-limit branch)
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'unit-test-error', channelId: 'channel-test' }),
+      expect.stringContaining('rate-limited')
     );
   });
 });

--- a/services/bot-client/src/utils/typingErrorClassifier.ts
+++ b/services/bot-client/src/utils/typingErrorClassifier.ts
@@ -79,6 +79,96 @@ export interface HandleTypingErrorOptions {
 }
 
 /**
+ * Latency threshold above which a successful sendTyping call is logged as
+ * a warning. Discord's typical sendTyping latency is <500ms; sustained
+ * latency above this threshold is the early-warning signal for the
+ * REST-queue stall class of bug (see callers — sendTyping has been
+ * observed to hang indefinitely under sustained rate-limit pressure).
+ *
+ * The 3000ms value coincides with Discord's interaction-acknowledgement
+ * deadline (3s) — chosen deliberately. A sendTyping call slower than the
+ * smallest deadline the bot must meet for any Discord operation is already
+ * in problem territory, regardless of REST-queue stall specifics.
+ */
+const SLOW_TYPING_THRESHOLD_MS = 3000;
+
+/**
+ * Channel-shape we need from the caller. discord.js channel types
+ * conditionally have `sendTyping`; callers are responsible for the
+ * `'sendTyping' in channel` guard before calling this helper.
+ */
+interface SendTypingChannel {
+  id: string;
+  sendTyping: () => Promise<void>;
+}
+
+export interface SendTypingIndicatorOptions {
+  logger: Logger;
+  /**
+   * Free-form label describing where this typing indicator is being fired
+   * from (e.g., 'voice-transcription-initial', 'job-tracker-initial').
+   * Surfaces in both the slow-warn log and the handleTypingError log.
+   */
+  source: string;
+  /** If provided, cleared when handleTypingError sees `channel-unreachable`. */
+  typingInterval?: NodeJS.Timeout;
+  /**
+   * Optional structured fields to merge into log entries (slow-warn and
+   * error). Use for caller-specific correlation IDs that aren't covered by
+   * the default `source` + `channelId` fields — e.g., `{ jobId }` for
+   * JobTracker calls, `{ messageId }` for one-shot calls. Spread last so
+   * caller fields can override defaults if they have richer info for the
+   * same key.
+   */
+  extraContext?: Record<string, unknown>;
+}
+
+/**
+ * Single source of truth for firing a Discord typing indicator. Three
+ * properties of this helper that callers should NOT replicate inline:
+ *
+ *  1. **Fire-and-forget**: never returns a Promise, never awaitable. Awaiting
+ *     `channel.sendTyping()` directly has been observed to hang indefinitely
+ *     when Discord's REST queue stalls under rate-limit pressure (the
+ *     promise neither resolves nor rejects). The typing indicator is purely
+ *     visual; a missed flash is strictly better than a hung pipeline.
+ *  2. **Latency telemetry**: warns when sendTyping resolves slower than
+ *     SLOW_TYPING_THRESHOLD_MS. Provides early warning for the queue-stall
+ *     class of bug before it degrades into a full hang.
+ *  3. **Error classification**: routes failures through `handleTypingError`
+ *     so rate-limit / channel-unreachable / network / unknown all get the
+ *     right log level + interval cleanup.
+ *
+ * An ESLint rule (no-restricted-syntax) blocks `await channel.sendTyping()`
+ * project-wide to prevent accidental reintroduction of the hang.
+ */
+export function sendTypingIndicator(
+  channel: SendTypingChannel,
+  options: SendTypingIndicatorOptions
+): void {
+  const { logger, source, typingInterval, extraContext } = options;
+  const start = Date.now();
+  channel
+    .sendTyping()
+    .then(() => {
+      const elapsed = Date.now() - start;
+      if (elapsed > SLOW_TYPING_THRESHOLD_MS) {
+        logger.warn(
+          { source, channelId: channel.id, elapsedMs: elapsed, ...extraContext },
+          'sendTyping resolved slowly — possible REST queue pressure'
+        );
+      }
+    })
+    .catch((err: unknown) => {
+      handleTypingError(err, {
+        logger,
+        context: { source, channelId: channel.id, ...extraContext },
+        typingInterval,
+      });
+    });
+}
+
+/**
  * Log a sendTyping failure with the right level for its classification, and
  * clear the typing interval when the channel has become unreachable. Returns
  * the classification so callers can take additional action (e.g., marking the


### PR DESCRIPTION
## What broke

\`/character chat\` voice transcription was hanging silently. Diagnostic logs from #999 showed execution reached \`await channel.sendTyping()\` in \`VoiceTranscriptionService.transcribe\` and never returned — neither resolved nor rejected. The await blocked the entire transcription pipeline; \`/ai/transcribe\` HTTP call was never made.

Hypothesis (council-confirmed): discord.js's REST queue can stall under sustained Discord rate-limit pressure on \`POST /channels/{id}/typing\`, leaving the promise orphaned. JobTracker's interval-tick \`sendTyping\` worked because it's wrapped in a fire-and-forget IIFE; the initial-typing call there was already \`.then().catch()\`. VoiceTranscriptionService's was \`await\` and exposed the bug.

## What this PR ships

1. **\`sendTypingIndicator()\` helper** in \`utils/typingErrorClassifier.ts\` — single source of truth: fire-and-forget, latency telemetry (warns >3s), classified error handling. Three call sites converted (initial + interval in both VoiceTranscriptionService and JobTracker).

2. **ESLint guard** (\`SEND_TYPING_RULES\`) blocks \`AwaitExpression > CallExpression[callee.property.name='sendTyping']\` project-wide so the bug class can't be reintroduced.

3. **Reverts diagnostic INFO logs** from #999 (\`TRANSCRIBE_DEBUG\` prefix) — they served their purpose.

## Council consultation

Asked anthropic/claude-opus-4.6 between three options. Council recommended A+ (fire-and-forget + helper + telemetry + ESLint guard) which is what shipped here. Deferred:
- **Promise.race timeout wrappers** (Option B): YAGNI now we're not awaiting; hung promises leak ~200 bytes each
- **discord.js upstream investigation** (Option C): backlog item to investigate \`@discordjs/rest@2.6.1\` upgrade path

## Test plan

- [x] \`pnpm test\` — 292 test files green
- [x] \`pnpm lint\` — green (new ESLint rule fires only on \`await sendTyping\`)
- [x] \`pnpm typecheck\` — green
- [ ] Merge → Railway auto-deploys dev → user sends voice → transcription succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)