### PR TITLE
fix(voice-engine): serialize Parakeet TDT transcribe to fix concurrent-call ValueError

### DIFF
--- a/services/voice-engine/server.py
+++ b/services/voice-engine/server.py
@@ -178,6 +178,16 @@ except ValueError:
     _INFERENCE_CONCURRENCY = 2
 _inference_semaphore: asyncio.Semaphore = asyncio.Semaphore(_INFERENCE_CONCURRENCY)
 
+# Serializes calls into Parakeet TDT's `.transcribe()`. NeMo's RNNT models share
+# `freeze()`/`unfreeze()` state across concurrent invocations on a single model
+# instance — when two transcribes interleave, the second one's `_transcribe_on_end`
+# cleanup raises `ValueError: Cannot unfreeze partially without first freezing the
+# module with freeze()` because the first call already unfroze it. Audio decoding
+# and resampling stay outside this lock so they overlap freely; only the NeMo
+# call itself is serialized. Throughput cost is minimal — Parakeet is CPU-bound
+# and `_inference_semaphore` already caps total concurrent flights.
+_asr_inference_lock: asyncio.Lock = asyncio.Lock()
+
 
 def _cache_voice(voice_id: str, voice_state: Any) -> None:
     """Cache a voice state with LRU eviction when at capacity."""
@@ -376,8 +386,12 @@ async def transcribe(file: UploadFile = File(...)) -> dict[str, str]:
                     partial(librosa.resample, audio_array, orig_sr=sample_rate, target_sr=16000),
                 )
 
-            # Transcribe — NeMo returns objects with .text attribute
-            transcriptions: list[Any] = await loop.run_in_executor(None, asr_model.transcribe, [audio_array])
+            # Transcribe — NeMo returns objects with .text attribute. The lock
+            # serializes parallel callers because NeMo's freeze/unfreeze state
+            # is per-model not per-call (see _asr_inference_lock definition).
+            async with _asr_inference_lock:
+                transcriptions: list[Any] = await loop.run_in_executor(None, asr_model.transcribe, [audio_array])
+            # transcriptions is coroutine-local — safe to read after lock release.
             text: str = transcriptions[0].text if transcriptions else ""
 
         # Cleanup

--- a/services/voice-engine/tests/test_transcribe.py
+++ b/services/voice-engine/tests/test_transcribe.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import MagicMock
 
 import httpx
@@ -61,9 +62,7 @@ async def test_transcribe_requires_auth_when_key_set(
     assert response.status_code == 401
 
 
-async def test_transcribe_accepts_bearer_token(
-    client: httpx.AsyncClient, mock_asr: MagicMock, api_key: str
-) -> None:
+async def test_transcribe_accepts_bearer_token(client: httpx.AsyncClient, mock_asr: MagicMock, api_key: str) -> None:
     response = await client.post(
         "/v1/transcribe",
         files={"file": ("test.wav", b"RIFF" + b"\x00" * 100, "audio/wav")},
@@ -85,9 +84,7 @@ async def test_transcribe_accepts_x_api_key_header(
     assert response.status_code == 200
 
 
-async def test_transcribe_returns_empty_string_for_silent_audio(
-    client: httpx.AsyncClient, mock_asr: MagicMock
-) -> None:
+async def test_transcribe_returns_empty_string_for_silent_audio(client: httpx.AsyncClient, mock_asr: MagicMock) -> None:
     from tests.helpers import FakeTranscription
 
     mock_asr.transcribe.return_value = [FakeTranscription("")]
@@ -111,3 +108,33 @@ async def test_transcribe_handles_model_error(client: httpx.AsyncClient, mock_as
 
     assert response.status_code == 500
     assert "Transcription failed" in response.json()["detail"]
+
+
+async def test_transcribe_serializes_concurrent_calls(client: httpx.AsyncClient, mock_asr: MagicMock) -> None:
+    # NeMo's RNNT freeze/unfreeze state is shared per-model. Without the lock,
+    # two concurrent transcribe calls overlap inside `.transcribe()` and the
+    # second one's cleanup hook raises ValueError. The lock guarantees the
+    # underlying call is invoked one-at-a-time even when callers race.
+    from tests.helpers import FakeTranscription
+
+    in_flight = 0
+    max_in_flight = 0
+
+    def tracking_transcribe(_audio: object) -> list[object]:
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        try:
+            return [FakeTranscription("ok")]
+        finally:
+            in_flight -= 1
+
+    mock_asr.transcribe.side_effect = tracking_transcribe
+    fake_wav = b"RIFF" + b"\x00" * 100
+
+    responses = await asyncio.gather(
+        *(client.post("/v1/transcribe", files={"file": ("t.wav", fake_wav, "audio/wav")}) for _ in range(4))
+    )
+
+    assert all(r.status_code == 200 for r in responses)
+    assert max_in_flight == 1


### PR DESCRIPTION
## Summary

NeMo's RNNT freeze/unfreeze state is shared per-model. When two `/v1/transcribe` requests run concurrently against the single Parakeet TDT instance, the second one's `_transcribe_on_end` cleanup raises:

```
ValueError: Cannot unfreeze partially without first freezing the module with `freeze()`
```

…because the first call already unfroze the encoder. Voice-engine catches this as a generic `Exception` and returns 500 to ai-worker, which surfaces to the user as "Sorry, I couldn't transcribe that voice message."

## Root cause

Observed 2026-05-08 in dev: user sent two voice messages back-to-back (17µs apart in bot-client). After PR #1000 unblocked the typing-indicator hang, both jobs reached voice-engine concurrently. First returned 200 OK with a 68-char transcript; second returned 500 with the NeMo `ValueError` traceback.

`server.py` runs the model call via `loop.run_in_executor(None, asr_model.transcribe, [audio_array])`, which uses the default thread executor — no per-model serialization. The existing `_inference_semaphore` caps total flights at 2 but allows them to interleave inside `.transcribe()`.

## Fix

Add `_asr_inference_lock = asyncio.Lock()` and wrap only the NeMo `.transcribe()` call. Audio decode + resample stay outside the lock so they overlap freely; only the NeMo invocation is serialized. Throughput cost is negligible — Parakeet is CPU-bound, parallelism wasn't gaining anything.

## Test plan

- [x] `ruff check server.py tests/test_transcribe.py` — passes
- [x] `pytest tests/test_transcribe.py` — 9 tests pass (8 original + 1 new serialization test)
- [x] New `test_transcribe_serializes_concurrent_calls` fires 4 concurrent requests, asserts `max_in_flight == 1` inside the locked region
- [ ] Manual verification on dev after merge: two back-to-back voice messages both transcribe without 500

## Why narrow scope

Could pool multiple Parakeet model instances for true parallelism, but: (a) ~1.2GB per model instance, Railway has a 4GB ceiling shared with TTS; (b) actual user voice load is bursty + low-volume; (c) lock is a one-line correctness fix — pooling is a throughput optimization that would warrant its own design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)