### PR TITLE
feat(bot-client): plain-language /voice surface + transcript provider attribution

### DIFF
--- a/packages/common-types/src/types/api-types.ts
+++ b/packages/common-types/src/types/api-types.ts
@@ -7,6 +7,7 @@
 
 import { JobStatus } from '../constants/index.js';
 import type { LLMGenerationResult } from './schemas/index.js';
+import type { AudioTranscriptionResult } from './jobs.js';
 
 // Re-export schema-derived types
 export type {
@@ -64,5 +65,20 @@ export interface GenerateResponse {
   status: JobStatus;
   // When wait=true, includes the result directly (uses full LLMGenerationResult)
   result?: LLMGenerationResult;
+  timestamp?: string;
+}
+
+/**
+ * Response from /ai/transcribe endpoint
+ *
+ * Same envelope shape as GenerateResponse but typed against
+ * AudioTranscriptionResult so the `provider` field is reachable on the
+ * caller side without unsafe casts.
+ */
+export interface TranscribeResponse {
+  jobId: string;
+  requestId: string;
+  status: JobStatus;
+  result?: AudioTranscriptionResult;
   timestamp?: string;
 }

--- a/packages/common-types/src/types/jobs.ts
+++ b/packages/common-types/src/types/jobs.ts
@@ -33,6 +33,7 @@ import {
 } from './schemas/index.js';
 import { JobType, JobStatus } from '../constants/queue.js';
 import { MessageRole } from '../constants/message.js';
+import type { SttProvider } from './sttProvider.js';
 
 /**
  * Job dependency - represents a preprocessing job that must complete first
@@ -201,6 +202,8 @@ export interface AudioTranscriptionResult {
   sourceReferenceNumber?: number;
   /** Error message if failed */
   error?: string;
+  /** Which STT provider produced the transcript; surfaced as user-visible attribution. */
+  provider?: SttProvider;
   metadata?: {
     processingTimeMs?: number;
     duration?: number;

--- a/services/ai-worker/src/jobs/AudioTranscriptionJob.test.ts
+++ b/services/ai-worker/src/jobs/AudioTranscriptionJob.test.ts
@@ -83,6 +83,7 @@ describe('AudioTranscriptionJob', () => {
         content: 'Mocked transcription text',
         attachmentUrl: 'https://example.com/audio.ogg',
         attachmentName: 'audio.ogg',
+        provider: 'voice-engine',
         metadata: {
           processingTimeMs: 1000,
           duration: 10,

--- a/services/ai-worker/src/jobs/AudioTranscriptionJob.ts
+++ b/services/ai-worker/src/jobs/AudioTranscriptionJob.ts
@@ -110,6 +110,7 @@ export async function processAudioTranscriptionJob(
       attachmentUrl: attachment.url,
       attachmentName: attachment.name,
       sourceReferenceNumber,
+      provider: sttOpts.provider,
       metadata: {
         processingTimeMs: result.totalTimeMs,
         duration: attachment.duration,

--- a/services/bot-client/src/commands/voice/provider/clear.ts
+++ b/services/bot-client/src/commands/voice/provider/clear.ts
@@ -35,9 +35,9 @@ export async function handleProviderClear(context: DeferredCommandContext): Prom
       .setTitle('✅ Voice Provider Default Cleared')
       .setColor(DISCORD_COLORS.SUCCESS)
       .setDescription(
-        'Your foundational voice provider has been removed.\n\n' +
-          'STT now falls through to voice-engine (free tier). ' +
-          'Per-direction overrides via `/voice tts` and `/voice stt` are unaffected.'
+        'Your default voice provider has been cleared.\n\n' +
+          'Voice messages will be transcribed by the free self-hosted engine. ' +
+          'Any per-personality preferences you set are unchanged.'
       )
       .setTimestamp();
 

--- a/services/bot-client/src/commands/voice/provider/set.ts
+++ b/services/bot-client/src/commands/voice/provider/set.ts
@@ -42,9 +42,10 @@ export async function handleProviderSet(context: DeferredCommandContext): Promis
       .setTitle('✅ Voice Provider Default Set')
       .setColor(DISCORD_COLORS.SUCCESS)
       .setDescription(
-        `Your foundational voice provider is now **${sttProviderDisplayName(providerId)}**.\n\n` +
-          'This is the baseline both TTS and STT cascade through if no other layer wins. ' +
-          'Use `/voice tts set-default` or `/voice stt set-default` to override on a per-direction basis.'
+        `**${sttProviderDisplayName(providerId)}** will now handle both:\n` +
+          '🔊 **Speaking** — when the bot replies with audio\n' +
+          '🎤 **Listening** — when you send voice messages\n\n' +
+          '_Per-personality choices take priority over this default._'
       )
       .setFooter({ text: 'Use /voice provider clear to remove this setting' })
       .setTimestamp();

--- a/services/bot-client/src/commands/voice/provider/subcommandBuilder.ts
+++ b/services/bot-client/src/commands/voice/provider/subcommandBuilder.ts
@@ -19,20 +19,20 @@ export function buildVoiceProviderSubcommandGroup(
 ): SlashCommandSubcommandGroupBuilder {
   return group
     .setName('provider')
-    .setDescription('Manage your foundational voice provider default')
+    .setDescription('Pick a default voice provider for both speaking and transcription')
     .addSubcommand(subcommand =>
       subcommand
         .setName('set')
-        .setDescription('Set your foundational voice provider (Layer 4 of the STT cascade)')
+        .setDescription('Pick a default voice provider used for both speaking and transcription')
         .addStringOption(option =>
           option
             .setName('provider')
-            .setDescription('Which voice provider to use as your baseline')
+            .setDescription('Which voice provider to use')
             .setRequired(true)
             .addChoices(...PROVIDER_CHOICES)
         )
     )
     .addSubcommand(subcommand =>
-      subcommand.setName('clear').setDescription('Clear your foundational voice provider')
+      subcommand.setName('clear').setDescription('Remove your default voice provider')
     );
 }

--- a/services/bot-client/src/commands/voice/stt/browse.ts
+++ b/services/bot-client/src/commands/voice/stt/browse.ts
@@ -45,23 +45,23 @@ export async function handleSttBrowse(context: DeferredCommandContext): Promise<
       defaultResult.ok && defaultResult.data.default.providerId !== null
         ? sttProviderDisplayName(defaultResult.data.default.providerId)
         : null;
-    const adminDefault =
+    const voiceProviderDefault =
       providerResult.ok && providerResult.data.providerId !== null
         ? sttProviderDisplayName(providerResult.data.providerId)
         : null;
 
     const lines: string[] = [];
-    lines.push(`**User-default STT:** ${userDefault ?? '_(not set — cascade falls through)_'}`);
-    lines.push(`**Admin default provider:** ${adminDefault ?? '_(not set)_'}`);
+    lines.push(`**Default transcription provider:** ${userDefault ?? '_(not set)_'}`);
+    lines.push(`**Default voice provider:** ${voiceProviderDefault ?? '_(not set)_'}`);
     lines.push('');
 
     if (overrides.length === 0) {
-      lines.push('_No per-personality STT overrides set._');
+      lines.push('_No per-personality transcription preferences set._');
       lines.push(
-        'Use `/voice stt set <personality> <provider>` to override STT for a specific personality.'
+        'Use `/voice stt set <personality> <provider>` to pick a transcription provider for a specific personality.'
       );
     } else {
-      lines.push(`**Per-personality overrides (${overrides.length}):**`);
+      lines.push(`**Per-personality preferences (${overrides.length}):**`);
       for (const o of overrides) {
         const providerLabel =
           o.providerId !== null ? sttProviderDisplayName(o.providerId) : '_(cleared)_';
@@ -70,11 +70,11 @@ export async function handleSttBrowse(context: DeferredCommandContext): Promise<
     }
 
     const embed = new EmbedBuilder()
-      .setTitle('🎤 Your STT Settings')
+      .setTitle('🎤 Your Transcription Settings')
       .setColor(DISCORD_COLORS.BLURPLE)
       .setDescription(lines.join('\n'))
       .setFooter({
-        text: 'Cascade: per-personality > user-default > TTS-derived > admin > fallback',
+        text: 'Per-personality preferences win over your defaults.',
       })
       .setTimestamp();
 

--- a/services/bot-client/src/commands/voice/stt/clear-default.ts
+++ b/services/bot-client/src/commands/voice/stt/clear-default.ts
@@ -36,11 +36,12 @@ export async function handleSttClearDefault(context: DeferredCommandContext): Pr
     }
 
     const embed = new EmbedBuilder()
-      .setTitle('✅ Default STT Provider Cleared')
+      .setTitle('✅ Transcription Default Cleared')
       .setColor(DISCORD_COLORS.SUCCESS)
       .setDescription(
-        'Your default STT provider has been removed.\n\n' +
-          'Cascade now resolves via TTS-derived → admin default → voice-engine fallback.'
+        'Your transcription default has been cleared.\n\n' +
+          'Voice messages will be transcribed by the same provider you use for speaking, ' +
+          'or by the free self-hosted engine if neither applies.'
       )
       .setTimestamp();
 

--- a/services/bot-client/src/commands/voice/stt/clear.ts
+++ b/services/bot-client/src/commands/voice/stt/clear.ts
@@ -1,8 +1,9 @@
 /**
  * Voice STT Clear Handler
- * Handles /voice stt clear <personality> — clears the per-personality STT
- * override (Layer 1 of the cascade). Cascade falls through to user-default
- * (Layer 2) on the next transcription for that personality.
+ *
+ * Handles /voice stt clear <personality> — removes the per-personality
+ * transcription preference. Subsequent voice messages to that personality
+ * use the user's default transcription provider (or the free fallback).
  */
 
 import {
@@ -41,24 +42,32 @@ export async function handleSttClear(context: DeferredCommandContext): Promise<v
     );
 
     if (!result.ok) {
-      logger.warn({ userId, status: result.status, personalityId }, 'Failed to clear STT override');
-      await context.editReply({ content: `❌ Failed to clear STT: ${result.error}` });
+      logger.warn(
+        { userId, status: result.status, personalityId },
+        'Failed to clear transcription preference'
+      );
+      await context.editReply({
+        content: `❌ Failed to clear transcription preference: ${result.error}`,
+      });
       return;
     }
 
     const wasSet = result.data.wasSet !== false;
     const embed = wasSet
       ? createSuccessEmbed(
-          '🔄 STT Override Removed',
-          'The personality will now use the cascade fallback for transcription.'
+          '✅ Transcription Preference Removed',
+          'This personality will now use your default transcription provider.'
         )
-      : createInfoEmbed('ℹ️ No Override Set', 'This personality had no STT override.');
+      : createInfoEmbed(
+          'ℹ️ Nothing to Remove',
+          'This personality has no transcription preference set.'
+        );
 
     await context.editReply({ embeds: [embed] });
 
-    logger.info({ userId, personalityId, wasSet }, 'Cleared STT override');
+    logger.info({ userId, personalityId, wasSet }, 'Cleared transcription preference');
   } catch (error) {
-    logger.error({ err: error, userId, command: 'STT Clear' }, 'Error');
+    logger.error({ err: error, userId, command: 'voice stt clear' }, 'Error');
     await context.editReply({ content: '❌ An error occurred. Please try again later.' });
   }
 }

--- a/services/bot-client/src/commands/voice/stt/set-default.ts
+++ b/services/bot-client/src/commands/voice/stt/set-default.ts
@@ -41,12 +41,11 @@ export async function handleSttSetDefault(context: DeferredCommandContext): Prom
     }
 
     const embed = new EmbedBuilder()
-      .setTitle('✅ Default STT Provider Set')
+      .setTitle('✅ Transcription Default Set')
       .setColor(DISCORD_COLORS.SUCCESS)
       .setDescription(
-        `Your default STT provider is now **${sttProviderDisplayName(providerId)}**.\n\n` +
-          'Personalities without their own per-personality STT override will use this. ' +
-          'Personalities with overrides are unaffected.'
+        `🎤 **${sttProviderDisplayName(providerId)}** will now transcribe your voice messages.\n\n` +
+          '_Per-personality preferences take priority over this default._'
       )
       .setFooter({ text: 'Use /voice stt clear-default to remove this setting' })
       .setTimestamp();

--- a/services/bot-client/src/commands/voice/stt/set.ts
+++ b/services/bot-client/src/commands/voice/stt/set.ts
@@ -51,12 +51,12 @@ export async function handleSttSet(context: DeferredCommandContext): Promise<voi
     }
 
     const embed = new EmbedBuilder()
-      .setTitle('✅ STT Override Set')
+      .setTitle('✅ Transcription Preference Set')
       .setColor(DISCORD_COLORS.SUCCESS)
       .setDescription(
-        `**${result.data.override.personalityName}** will now use **${sttProviderDisplayName(providerId)}** for transcription.`
+        `🎤 Your voice messages to **${result.data.override.personalityName}** will now be transcribed by **${sttProviderDisplayName(providerId)}**.`
       )
-      .setFooter({ text: 'Use /voice stt clear to remove this override' })
+      .setFooter({ text: 'Use /voice stt clear to remove this preference' })
       .setTimestamp();
 
     await context.editReply({ embeds: [embed] });

--- a/services/bot-client/src/commands/voice/stt/subcommandBuilder.ts
+++ b/services/bot-client/src/commands/voice/stt/subcommandBuilder.ts
@@ -19,25 +19,25 @@ export function buildVoiceSttSubcommandGroup(
 ): SlashCommandSubcommandGroupBuilder {
   return group
     .setName('stt')
-    .setDescription('Manage speech-to-text provider overrides')
+    .setDescription('Choose who transcribes your voice messages')
     .addSubcommand(subcommand =>
-      subcommand.setName('browse').setDescription('Browse your STT provider overrides')
+      subcommand.setName('browse').setDescription('See your transcription preferences')
     )
     .addSubcommand(subcommand =>
       subcommand
         .setName('set')
-        .setDescription('Override STT provider for a personality')
+        .setDescription('Pick who transcribes your voice messages for a specific personality')
         .addStringOption(option =>
           option
             .setName('personality')
-            .setDescription('The personality to override')
+            .setDescription('The personality')
             .setRequired(true)
             .setAutocomplete(true)
         )
         .addStringOption(option =>
           option
             .setName('provider')
-            .setDescription('Which STT backend to use for this personality')
+            .setDescription('Which provider to transcribe with')
             .setRequired(true)
             .addChoices(...PROVIDER_CHOICES)
         )
@@ -45,11 +45,11 @@ export function buildVoiceSttSubcommandGroup(
     .addSubcommand(subcommand =>
       subcommand
         .setName('clear')
-        .setDescription('Remove STT provider override for a personality')
+        .setDescription('Remove your transcription preference for a personality')
         .addStringOption(option =>
           option
             .setName('personality')
-            .setDescription('The personality to clear')
+            .setDescription('The personality')
             .setRequired(true)
             .setAutocomplete(true)
         )
@@ -57,16 +57,18 @@ export function buildVoiceSttSubcommandGroup(
     .addSubcommand(subcommand =>
       subcommand
         .setName('set-default')
-        .setDescription('Set your global default STT provider')
+        .setDescription('Pick a default provider for transcribing your voice messages')
         .addStringOption(option =>
           option
             .setName('provider')
-            .setDescription('Which STT backend to use as your default')
+            .setDescription('Which provider to transcribe with')
             .setRequired(true)
             .addChoices(...PROVIDER_CHOICES)
         )
     )
     .addSubcommand(subcommand =>
-      subcommand.setName('clear-default').setDescription('Clear your global default STT provider')
+      subcommand
+        .setName('clear-default')
+        .setDescription('Remove your default transcription provider')
     );
 }

--- a/services/bot-client/src/commands/voice/tts/set.test.ts
+++ b/services/bot-client/src/commands/voice/tts/set.test.ts
@@ -167,7 +167,7 @@ describe('handleSet', () => {
       embeds: Array<{ data: { footer?: { text: string } } }>;
     };
     const footer = reply.embeds[0].data.footer?.text ?? '';
-    expect(footer).toContain('STT now resolves');
+    expect(footer).toContain('Transcription will now use');
     expect(footer).toContain('Mistral');
   });
 
@@ -185,7 +185,7 @@ describe('handleSet', () => {
       embeds: Array<{ data: { footer?: { text: string } } }>;
     };
     const footer = reply.embeds[0].data.footer?.text ?? '';
-    expect(footer).not.toContain('STT now resolves');
+    expect(footer).not.toContain('Transcription will now use');
     expect(footer).toContain('Use /voice tts clear');
   });
 
@@ -257,6 +257,6 @@ describe('handleSet', () => {
       embeds: Array<{ data: { footer?: { text: string } } }>;
     };
     const footer = reply.embeds[0].data.footer?.text ?? '';
-    expect(footer).not.toContain('STT now resolves');
+    expect(footer).not.toContain('Transcription will now use');
   });
 });

--- a/services/bot-client/src/commands/voice/tts/set.ts
+++ b/services/bot-client/src/commands/voice/tts/set.ts
@@ -164,5 +164,5 @@ function buildSttDerivedFooter(oldStt: SttSnapshot, newStt: SttSnapshot): string
     ? sttProviderDisplayName(oldStt.provider)
     : oldStt.provider;
 
-  return `ℹ️ STT now resolves to ${newLabel} (was ${oldLabel}) via your TTS choice. Use /voice stt set to override.`;
+  return `ℹ️ Transcription will now use ${newLabel} (was ${oldLabel}) to match your TTS choice. Use /voice stt set to pick a different one.`;
 }

--- a/services/bot-client/src/commands/voice/view.ts
+++ b/services/bot-client/src/commands/voice/view.ts
@@ -25,35 +25,35 @@ import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js'
 
 const logger = createLogger('voice-view');
 
-/** User-friendly name for an STT cascade source layer. */
+/** Friendly description of why this provider was chosen for transcription. */
 function sttSourceLabel(source: SttResolutionSource): string {
   switch (source) {
     case 'user-personality':
-      return 'per-personality override';
+      return 'set for this personality';
     case 'user-default':
-      return 'your user-default';
+      return 'your transcription default';
     case 'tts-derived':
-      return 'derived from your TTS choice';
+      return 'matches your TTS choice';
     case 'admin-default':
-      return 'your /voice provider baseline';
+      return 'your default voice provider';
     case 'hardcoded':
-      return 'free-tier fallback';
+      return 'free fallback';
   }
 }
 
-/** User-friendly name for a TTS cascade source layer. */
+/** Friendly description of why this provider was chosen for speaking. */
 function ttsSourceLabel(source: TtsResolutionSource): string {
   switch (source) {
     case 'user-personality':
-      return 'per-personality override';
+      return 'set for this personality';
     case 'user-default':
-      return 'your user-default';
+      return 'your TTS default';
     case 'personality':
       return 'personality default';
     case 'free-default':
-      return 'system free default';
+      return 'system default';
     case 'hardcoded':
-      return 'self-hosted fallback';
+      return 'free fallback';
   }
 }
 
@@ -112,7 +112,7 @@ export async function handleVoiceView(context: DeferredCommandContext): Promise<
         { name: '📚 Cloned Voices', value: voicesLine, inline: false }
       )
       .setFooter({
-        text: 'Cascade: per-personality > user-default > TTS-derived > admin > fallback',
+        text: 'Per-personality settings win over your defaults.',
       })
       .setTimestamp();
 

--- a/services/bot-client/src/handlers/__snapshots__/CommandHandler.int.test.ts.snap
+++ b/services/bot-client/src/handlers/__snapshots__/CommandHandler.int.test.ts.snap
@@ -1313,13 +1313,13 @@ exports[`CommandHandler (component) > command structure snapshots > should have 
     "type": 2,
   },
   {
-    "description": "Manage speech-to-text provider overrides",
+    "description": "Choose who transcribes your voice messages",
     "description_localizations": undefined,
     "name": "stt",
     "name_localizations": undefined,
     "options": [
       {
-        "description": "Browse your STT provider overrides",
+        "description": "See your transcription preferences",
         "description_localizations": undefined,
         "name": "browse",
         "name_localizations": undefined,
@@ -1327,7 +1327,7 @@ exports[`CommandHandler (component) > command structure snapshots > should have 
         "type": 1,
       },
       {
-        "description": "Override STT provider for a personality",
+        "description": "Pick who transcribes your voice messages for a specific personality",
         "description_localizations": undefined,
         "name": "set",
         "name_localizations": undefined,
@@ -1335,7 +1335,7 @@ exports[`CommandHandler (component) > command structure snapshots > should have 
           {
             "autocomplete": true,
             "choices": undefined,
-            "description": "The personality to override",
+            "description": "The personality",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
@@ -1363,7 +1363,7 @@ exports[`CommandHandler (component) > command structure snapshots > should have 
                 "value": "voice-engine",
               },
             ],
-            "description": "Which STT backend to use for this personality",
+            "description": "Which provider to transcribe with",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
@@ -1376,7 +1376,7 @@ exports[`CommandHandler (component) > command structure snapshots > should have 
         "type": 1,
       },
       {
-        "description": "Remove STT provider override for a personality",
+        "description": "Remove your transcription preference for a personality",
         "description_localizations": undefined,
         "name": "clear",
         "name_localizations": undefined,
@@ -1384,7 +1384,7 @@ exports[`CommandHandler (component) > command structure snapshots > should have 
           {
             "autocomplete": true,
             "choices": undefined,
-            "description": "The personality to clear",
+            "description": "The personality",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
@@ -1397,7 +1397,7 @@ exports[`CommandHandler (component) > command structure snapshots > should have 
         "type": 1,
       },
       {
-        "description": "Set your global default STT provider",
+        "description": "Pick a default provider for transcribing your voice messages",
         "description_localizations": undefined,
         "name": "set-default",
         "name_localizations": undefined,
@@ -1421,7 +1421,7 @@ exports[`CommandHandler (component) > command structure snapshots > should have 
                 "value": "voice-engine",
               },
             ],
-            "description": "Which STT backend to use as your default",
+            "description": "Which provider to transcribe with",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
@@ -1434,7 +1434,7 @@ exports[`CommandHandler (component) > command structure snapshots > should have 
         "type": 1,
       },
       {
-        "description": "Clear your global default STT provider",
+        "description": "Remove your default transcription provider",
         "description_localizations": undefined,
         "name": "clear-default",
         "name_localizations": undefined,
@@ -1445,13 +1445,13 @@ exports[`CommandHandler (component) > command structure snapshots > should have 
     "type": 2,
   },
   {
-    "description": "Manage your foundational voice provider default",
+    "description": "Pick a default voice provider for both speaking and transcription",
     "description_localizations": undefined,
     "name": "provider",
     "name_localizations": undefined,
     "options": [
       {
-        "description": "Set your foundational voice provider (Layer 4 of the STT cascade)",
+        "description": "Pick a default voice provider used for both speaking and transcription",
         "description_localizations": undefined,
         "name": "set",
         "name_localizations": undefined,
@@ -1475,7 +1475,7 @@ exports[`CommandHandler (component) > command structure snapshots > should have 
                 "value": "voice-engine",
               },
             ],
-            "description": "Which voice provider to use as your baseline",
+            "description": "Which voice provider to use",
             "description_localizations": undefined,
             "max_length": undefined,
             "min_length": undefined,
@@ -1488,7 +1488,7 @@ exports[`CommandHandler (component) > command structure snapshots > should have 
         "type": 1,
       },
       {
-        "description": "Clear your foundational voice provider",
+        "description": "Remove your default voice provider",
         "description_localizations": undefined,
         "name": "clear",
         "name_localizations": undefined,

--- a/services/bot-client/src/services/VoiceTranscriptionService.test.ts
+++ b/services/bot-client/src/services/VoiceTranscriptionService.test.ts
@@ -272,6 +272,57 @@ describe('VoiceTranscriptionService', () => {
       );
     });
 
+    it('appends a Discord subtext attribution to the last chunk when provider is known', async () => {
+      const message = createMockMessage({
+        attachments: [
+          {
+            url: 'https://cdn.discord.com/voice/123.ogg',
+            contentType: 'audio/ogg',
+            name: 'voice.ogg',
+            size: 50000,
+            duration: 5.2,
+          },
+        ],
+      });
+      mockGatewayClient.transcribe.mockResolvedValue({
+        content: 'Hello there',
+        provider: 'mistral',
+      });
+
+      await service.transcribe(message, false, false);
+
+      // Single chunk → attribution appended to the only reply
+      expect(message.reply).toHaveBeenCalledWith({
+        content: 'Hello there\n-# transcribed by Mistral',
+        allowedMentions: { parse: [], repliedUser: false },
+      });
+    });
+
+    it('omits attribution when provider is unknown (silent rather than ugly)', async () => {
+      const message = createMockMessage({
+        attachments: [
+          {
+            url: 'https://cdn.discord.com/voice/123.ogg',
+            contentType: 'audio/ogg',
+            name: 'voice.ogg',
+            size: 50000,
+            duration: 5.2,
+          },
+        ],
+      });
+      mockGatewayClient.transcribe.mockResolvedValue({
+        content: 'Hello there',
+        // no provider field
+      });
+
+      await service.transcribe(message, false, false);
+
+      expect(message.reply).toHaveBeenCalledWith({
+        content: 'Hello there',
+        allowedMentions: { parse: [], repliedUser: false },
+      });
+    });
+
     it('should set continueToPersonalityHandler=true when hasMention=true', async () => {
       const message = createMockMessage({
         attachments: [
@@ -342,6 +393,75 @@ describe('VoiceTranscriptionService', () => {
 
       // Should send multiple replies (mocked to create 2 chunks)
       expect(message.reply).toHaveBeenCalledTimes(2);
+    });
+
+    it('falls back to a separate attribution message when inline would exceed the 2000-char limit', async () => {
+      const message = createMockMessage({
+        attachments: [
+          {
+            url: 'https://cdn.discord.com/voice/123.ogg',
+            contentType: 'audio/ogg',
+            name: 'voice.ogg',
+            size: 50000,
+            duration: 30.0,
+          },
+        ],
+      });
+
+      // 4000-char transcript → splits into [2000, 2000]. Inlining attribution
+      // on the last chunk would yield 2045+ chars, tripping Discord's 50035
+      // error. Verify the helper falls back to a separate follow-up reply.
+      const longTranscript = 'x'.repeat(4000);
+      mockGatewayClient.transcribe.mockResolvedValue({
+        content: longTranscript,
+        provider: 'voice-engine', // longest display name → worst-case overflow
+      });
+
+      await service.transcribe(message, false, false);
+
+      // Expect 3 replies: chunk1 (2000), chunk2 (2000, raw), attribution (~46)
+      expect(message.reply).toHaveBeenCalledTimes(3);
+      const calls = (message.reply as ReturnType<typeof vi.fn>).mock.calls;
+      expect(calls[0][0].content).toBe('x'.repeat(2000));
+      expect(calls[1][0].content).toBe('x'.repeat(2000));
+      expect(calls[1][0].content).not.toContain('-# transcribed by');
+      expect(calls[2][0].content).toBe('-# transcribed by Self-hosted (Parakeet TDT)');
+    });
+
+    it('attaches the provider attribution only to the LAST chunk on multi-chunk transcripts', async () => {
+      const message = createMockMessage({
+        attachments: [
+          {
+            url: 'https://cdn.discord.com/voice/123.ogg',
+            contentType: 'audio/ogg',
+            name: 'voice.ogg',
+            size: 50000,
+            duration: 30.0,
+          },
+        ],
+      });
+
+      // 3000-char transcript splits into two 2000-char chunks via the mocked
+      // splitMessage at the top of this file. Pin the invariant that the
+      // attribution rides only on the final chunk so future loop changes
+      // can't silently put it on every chunk or skip it entirely.
+      const longTranscript = 'x'.repeat(3000);
+      mockGatewayClient.transcribe.mockResolvedValue({
+        content: longTranscript,
+        provider: 'mistral',
+      });
+
+      await service.transcribe(message, false, false);
+
+      expect(message.reply).toHaveBeenCalledTimes(2);
+      const calls = (message.reply as ReturnType<typeof vi.fn>).mock.calls;
+
+      // First chunk: raw, no attribution
+      expect(calls[0][0].content).toBe('x'.repeat(2000));
+      expect(calls[0][0].content).not.toContain('-# transcribed by');
+
+      // Last chunk: ends with the attribution line
+      expect(calls[1][0].content).toBe(`${'x'.repeat(1000)}\n-# transcribed by Mistral`);
     });
 
     it('should handle missing contentType gracefully', async () => {

--- a/services/bot-client/src/services/VoiceTranscriptionService.ts
+++ b/services/bot-client/src/services/VoiceTranscriptionService.ts
@@ -5,9 +5,17 @@
  * Sends transcription to Discord and stores in Redis for personality processing.
  */
 
-import type { Message } from 'discord.js';
+import type { Message, MessageMentionOptions } from 'discord.js';
 import { GatewayClient } from '../utils/GatewayClient.js';
-import { splitMessage, createLogger, CONTENT_TYPES, isTimeoutError } from '@tzurot/common-types';
+import {
+  splitMessage,
+  createLogger,
+  CONTENT_TYPES,
+  DISCORD_LIMITS,
+  isTimeoutError,
+  sttProviderDisplayName,
+  type SttProvider,
+} from '@tzurot/common-types';
 import { voiceTranscriptCache } from '../redis.js';
 import { hasForwardedSnapshots, getSnapshots } from '../utils/forwardedMessageUtils.js';
 import { sendTypingIndicator } from '../utils/typingErrorClassifier.js';
@@ -17,6 +25,42 @@ const logger = createLogger('VoiceTranscriptionService');
 
 /** Interval for refreshing the typing indicator (Discord expires at ~10s, matches JobTracker.ts) */
 const TYPING_INDICATOR_INTERVAL_MS = 8000;
+
+/** Uses Discord `-#` subtext so the line renders small+muted under the transcript. */
+function formatProviderAttribution(provider?: SttProvider): string | null {
+  if (provider === undefined) {
+    return null;
+  }
+  return `-# transcribed by ${sttProviderDisplayName(provider)}`;
+}
+
+/** Inlines attribution on the last chunk; spills to a follow-up reply when inlining would exceed Discord's 2000-char limit (50035). */
+async function sendTranscriptChunks(
+  message: Message,
+  chunks: string[],
+  attribution: string | null
+): Promise<void> {
+  const allowedMentions: MessageMentionOptions = { parse: [], repliedUser: false };
+
+  for (let i = 0; i < chunks.length; i++) {
+    const isLast = i === chunks.length - 1;
+
+    // Non-last chunks (and last chunk with no attribution to append) just go out as-is.
+    if (!isLast || attribution === null) {
+      await message.reply({ content: chunks[i], allowedMentions });
+      continue;
+    }
+
+    // Last chunk + attribution present: try inline; spill to a follow-up if too long.
+    const withAttribution = `${chunks[i]}\n${attribution}`;
+    if (withAttribution.length > DISCORD_LIMITS.MESSAGE_LENGTH) {
+      await message.reply({ content: chunks[i], allowedMentions });
+      await message.reply({ content: attribution, allowedMentions });
+    } else {
+      await message.reply({ content: withAttribution, allowedMentions });
+    }
+  }
+}
 
 /** Attachment info for transcription */
 interface TranscriptionAttachment {
@@ -256,14 +300,10 @@ export class VoiceTranscriptionService {
         );
       }
 
-      // Send each chunk as a reply (these will appear BEFORE personality webhook response)
-      // Don't ping the user - they already know they sent a voice message
-      for (const chunk of chunks) {
-        await message.reply({
-          content: chunk,
-          allowedMentions: { parse: [], repliedUser: false },
-        });
-      }
+      // Send chunks + the attribution suffix to Discord as message replies.
+      // These appear BEFORE the personality webhook response so the user
+      // sees their transcript first.
+      await sendTranscriptChunks(message, chunks, formatProviderAttribution(response.provider));
 
       // Determine if we should continue to personality handler
       const continueToPersonalityHandler = hasMention || isReply;

--- a/services/bot-client/src/types.ts
+++ b/services/bot-client/src/types.ts
@@ -19,12 +19,13 @@ import type {
   GenerateResponse,
   LoadedPersonality,
   RequestContext,
+  TranscribeResponse,
 } from '@tzurot/common-types';
 import { MessageRole } from '@tzurot/common-types';
 import type { DeferralMode, SafeCommandContext } from './utils/commandContext/index.js';
 
 // Re-export shared API types
-export type { GenerateResponse, LoadedPersonality };
+export type { GenerateResponse, LoadedPersonality, TranscribeResponse };
 
 /**
  * Message context for AI generation

--- a/services/bot-client/src/utils/GatewayClient.test.ts
+++ b/services/bot-client/src/utils/GatewayClient.test.ts
@@ -183,6 +183,35 @@ describe('GatewayClient', () => {
       });
     });
 
+    it('passes the provider field through when present in the result', async () => {
+      // Pins the field through the response shape: an unsafe cast back to
+      // GenerateResponse (which lacks `provider`) would silently drop it.
+      const client = new GatewayClient('http://test.gateway');
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            jobId: 'job-1',
+            status: JobStatus.Completed,
+            result: {
+              content: 'Transcribed text',
+              provider: 'mistral',
+              metadata: { processingTimeMs: 1500 },
+            },
+          }),
+      });
+
+      const result = await client.transcribe([
+        { url: 'http://audio.test/file.ogg', contentType: 'audio/ogg' },
+      ]);
+
+      expect(result).toEqual({
+        content: 'Transcribed text',
+        provider: 'mistral',
+        metadata: { processingTimeMs: 1500 },
+      });
+    });
+
     it('should throw on non-ok response', async () => {
       const client = new GatewayClient('http://test.gateway');
       mockFetch.mockResolvedValueOnce({

--- a/services/bot-client/src/utils/GatewayClient.ts
+++ b/services/bot-client/src/utils/GatewayClient.ts
@@ -14,8 +14,9 @@ import {
   type GetChannelSettingsResponse,
   type GetAdminSettingsResponse,
   type DenylistCacheResponse,
+  type SttProvider,
 } from '@tzurot/common-types';
-import type { LoadedPersonality, MessageContext, GenerateResponse } from '../types.js';
+import type { LoadedPersonality, MessageContext, TranscribeResponse } from '../types.js';
 
 const logger = createLogger('GatewayClient');
 const config = getConfig();
@@ -158,6 +159,8 @@ export class GatewayClient {
     userId?: string
   ): Promise<{
     content: string;
+    /** Which STT provider produced the transcript; surfaced as user-visible attribution. */
+    provider?: SttProvider;
     metadata?: {
       processingTimeMs?: number;
     };
@@ -181,7 +184,7 @@ export class GatewayClient {
         throw new Error(`Transcription request failed: ${response.status} ${errorText}`);
       }
 
-      const data = (await response.json()) as GenerateResponse;
+      const data = (await response.json()) as TranscribeResponse;
 
       if (data.status !== JobStatus.Completed) {
         throw new Error(`Transcription job ${data.jobId} status: ${data.status}`);
@@ -199,6 +202,7 @@ export class GatewayClient {
 
       return {
         content: data.result.content,
+        provider: data.result.provider,
         metadata: data.result.metadata,
       };
     } catch (error) {


### PR DESCRIPTION
## Summary

Two related polish improvements after PR #1005 shipped, both surfaced by user dogfooding:

### 1. UX language cleanup on the new `/voice` surface

The Phase-3 PR-2 success embeds were leaking implementation jargon. The `/voice provider set mistral` reply read:

> "Your foundational voice provider is now Mistral. This is the baseline both TTS and STT cascade through if no other layer wins. Use /voice tts set-default or /voice stt set-default to override on a per-direction basis."

User reaction: **\"I barely understand and I'm a technical person.\"**

Council pass (Gemini 3.1 Pro + Kimi K2.6) called this out as not just a vocabulary problem but an abstraction-leak problem — the messages were describing _how the system works_ (Layer 4, cascade) instead of _what happened to the user_ (Mistral will speak and listen for you).

Rewrote with three principles:
- **Verbs not protocols** — \"Speaking\" / \"Listening\" instead of \"TTS\" / \"STT\"
- **Visual structure** — bullets + bold + subtle italics for disclaimers, not explanation paragraphs
- **No teaching in success messages** — the user just wanted confirmation; override commands are discoverable via `/voice` autocomplete

Sample of the new copy on `/voice provider set mistral`:

> ✅ Voice Provider Default Set
>
> **Mistral** will now handle both:
> 🔊 **Speaking** — when the bot replies with audio
> 🎤 **Listening** — when you send voice messages
>
> _Per-personality choices take priority over this default._

Same treatment applied to `/voice provider clear`, `/voice stt set`, `/voice stt set-default`, `/voice stt clear-default`, `/voice stt browse`, `/voice view`, the `/voice tts set` JIT footer, and the slash command picker descriptions.

### 2. Transcript provider attribution

User couldn't visually distinguish Mistral (dev) from ElevenLabs/voice-engine (prod) when both bots transcribed the same voice memo in their test server — the transcripts were identical text and there was no provider attribution.

Added a Discord `-#` subtext line to the last chunk of every transcript:

```
Yeah, well you named the exact problem. I don't really know how to celebrate...
-# transcribed by Mistral
```

Renders small + muted under the transcript text. Confirms which engine fired without log-diving.

Provider plumbed end-to-end:
- `AudioTranscriptionResult.provider` added in `common-types/types/jobs.ts`
- `AudioTranscriptionJob` populates from `sttOpts.provider`
- New `TranscribeResponse` type in `api-types.ts` — fixes a pre-existing mistype where the transcribe path was reusing `GenerateResponse` (which embeds `LLMGenerationResult`); both shapes happened to have a `content` field, so it worked by coincidence
- `GatewayClient.transcribe` returns `provider`
- `VoiceTranscriptionService` appends the subtext line to the last chunk via a helper that returns `null` on unknown provider (fails silent rather than rendering \"transcribed by undefined\")

## Test plan

- [x] `pnpm test` — 712/712 test files green
- [x] `pnpm quality` — lint + cpd + depcruise + typecheck + typecheck:spec all green
- [x] Two new VoiceTranscriptionService tests: attribution renders for known provider; silent for unknown
- [x] AudioTranscriptionJob test updated to assert `provider` field on result
- [ ] Manual on dev after deploy: send voice message, confirm \"-# transcribed by Mistral\" appears under transcript
- [ ] Manual on dev: trigger `/voice provider set mistral`, verify the new bullet-formatted embed renders correctly
- [ ] Manual on dev: trigger `/voice tts set <personality> <Mistral config>`, verify the JIT footer reads naturally

## Notes

This is purely UX polish + a small data-flow addition. No schema changes, no new commands, no new dependencies. Safe to merge into the beta.120 release bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)