### PR TITLE
fix(bot-client): retry transient network errors in GatewayClient.transcribe

### DIFF
--- a/services/bot-client/src/utils/GatewayClient.test.ts
+++ b/services/bot-client/src/utils/GatewayClient.test.ts
@@ -320,6 +320,118 @@ describe('GatewayClient', () => {
       expect(body.userId).toBeUndefined();
     });
 
+    describe('transient network retry', () => {
+      beforeEach(() => {
+        vi.useFakeTimers();
+      });
+
+      function buildSocketError(code: 'UND_ERR_SOCKET' | 'ECONNRESET' | 'ECONNREFUSED'): Error {
+        const err = new TypeError('fetch failed');
+        (err as Error & { cause: { code: string } }).cause = { code };
+        return err;
+      }
+
+      function buildSuccessResponse(): {
+        ok: boolean;
+        json: () => Promise<unknown>;
+      } {
+        return {
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              jobId: 'job-after-retry',
+              status: JobStatus.Completed,
+              result: { content: 'recovered' },
+            }),
+        };
+      }
+
+      it('should retry on UND_ERR_SOCKET and succeed on second attempt', async () => {
+        const client = new GatewayClient('http://test.gateway');
+        mockFetch
+          .mockRejectedValueOnce(buildSocketError('UND_ERR_SOCKET'))
+          .mockResolvedValueOnce(buildSuccessResponse());
+
+        const promise = client.transcribe([
+          { url: 'http://test/audio.ogg', contentType: 'audio/ogg' },
+        ]);
+        await vi.runAllTimersAsync();
+        const result = await promise;
+
+        expect(result.content).toBe('recovered');
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      });
+
+      it('should retry on ECONNRESET and ECONNREFUSED', async () => {
+        const client = new GatewayClient('http://test.gateway');
+        mockFetch
+          .mockRejectedValueOnce(buildSocketError('ECONNRESET'))
+          .mockRejectedValueOnce(buildSocketError('ECONNREFUSED'))
+          .mockResolvedValueOnce(buildSuccessResponse());
+
+        const promise = client.transcribe([
+          { url: 'http://test/audio.ogg', contentType: 'audio/ogg' },
+        ]);
+        await vi.runAllTimersAsync();
+        const result = await promise;
+
+        expect(result.content).toBe('recovered');
+        expect(mockFetch).toHaveBeenCalledTimes(3);
+      });
+
+      it('should throw after exhausting all retry attempts', async () => {
+        const client = new GatewayClient('http://test.gateway');
+        mockFetch.mockRejectedValue(buildSocketError('UND_ERR_SOCKET'));
+
+        const promise = client.transcribe([
+          { url: 'http://test/audio.ogg', contentType: 'audio/ogg' },
+        ]);
+        const assertion = expect(promise).rejects.toThrow('fetch failed');
+        await vi.runAllTimersAsync();
+        await assertion;
+
+        expect(mockFetch).toHaveBeenCalledTimes(3);
+      });
+
+      it('should not retry on non-transient errors (e.g., 4xx HTTP responses)', async () => {
+        const client = new GatewayClient('http://test.gateway');
+        mockFetch.mockResolvedValueOnce({
+          ok: false,
+          status: 400,
+          text: () => Promise.resolve('Bad Request'),
+        });
+
+        await expect(
+          client.transcribe([{ url: 'http://test/audio.ogg', contentType: 'audio/ogg' }])
+        ).rejects.toThrow('Transcription request failed: 400 Bad Request');
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      it('should not retry on 5xx HTTP responses', async () => {
+        const client = new GatewayClient('http://test.gateway');
+        mockFetch.mockResolvedValueOnce({
+          ok: false,
+          status: 503,
+          text: () => Promise.resolve('Service Unavailable'),
+        });
+
+        await expect(
+          client.transcribe([{ url: 'http://test/audio.ogg', contentType: 'audio/ogg' }])
+        ).rejects.toThrow('Transcription request failed: 503 Service Unavailable');
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      it('should not retry on errors without cause.code', async () => {
+        const client = new GatewayClient('http://test.gateway');
+        mockFetch.mockRejectedValueOnce(new Error('Generic error'));
+
+        await expect(
+          client.transcribe([{ url: 'http://test/audio.ogg', contentType: 'audio/ogg' }])
+        ).rejects.toThrow('Generic error');
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+    });
+
     it('should include AbortSignal timeout on transcribe requests', async () => {
       const client = new GatewayClient('http://test.gateway');
       mockFetch.mockResolvedValueOnce({

--- a/services/bot-client/src/utils/GatewayClient.ts
+++ b/services/bot-client/src/utils/GatewayClient.ts
@@ -22,6 +22,42 @@ const logger = createLogger('GatewayClient');
 const config = getConfig();
 
 /**
+ * Transport-layer error codes that indicate the api-gateway is mid-restart
+ * (Railway container swap). The TCP connection is accepted but the HTTP
+ * listener isn't bound yet, so undici closes the socket. Safe to retry.
+ */
+const TRANSIENT_NETWORK_CODES = new Set(['UND_ERR_SOCKET', 'ECONNRESET', 'ECONNREFUSED']);
+const TRANSCRIBE_RETRY_ATTEMPTS = 3;
+const TRANSCRIBE_RETRY_BASE_DELAY_MS = 500;
+
+function isTransientNetworkError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  const cause = (err as Error & { cause?: { code?: string } }).cause;
+  return cause?.code !== undefined && TRANSIENT_NETWORK_CODES.has(cause.code);
+}
+
+async function retryTranscribeOnTransientNetworkError<T>(fn: () => Promise<T>): Promise<T> {
+  for (let attempt = 1; attempt < TRANSCRIBE_RETRY_ATTEMPTS; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (!isTransientNetworkError(err)) {
+        throw err;
+      }
+      const delayMs = TRANSCRIBE_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+      logger.warn(
+        { err, attempt, nextDelayMs: delayMs },
+        'Transient network error during transcribe; retrying'
+      );
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+  }
+  return fn();
+}
+
+/**
  * Cache for channel settings lookups.
  * TTL of 30 seconds balances performance with responsiveness to changes.
  * Max 1000 channels to prevent unbounded memory growth.
@@ -145,6 +181,13 @@ export class GatewayClient {
 
   /**
    * Request voice transcription from the gateway
+   *
+   * Retries on transient network errors (api-gateway container swap during
+   * Railway deploy: socket accepted but HTTP listener not bound yet, surfacing
+   * as `UND_ERR_SOCKET` / `ECONNRESET` / `ECONNREFUSED`). Safe to retry
+   * because transcription is idempotent — the ai-worker job is keyed by
+   * `requestId`. HTTP-level errors (non-2xx responses, validation failures,
+   * empty results) are NOT retried — only transport-layer failures.
    */
   async transcribe(
     attachments: {
@@ -166,49 +209,62 @@ export class GatewayClient {
     };
   }> {
     try {
-      const response = await fetch(`${this.baseUrl}/ai/transcribe?wait=true`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': CONTENT_TYPES.JSON,
-          'X-Service-Auth': config.INTERNAL_SERVICE_SECRET ?? '',
-        },
-        body: JSON.stringify({
-          attachments,
-          ...(userId !== undefined && { userId }),
-        }),
-        signal: AbortSignal.timeout(TIMEOUTS.STT_GATEWAY),
-      });
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        throw new Error(`Transcription request failed: ${response.status} ${errorText}`);
-      }
-
-      const data = (await response.json()) as TranscribeResponse;
-
-      if (data.status !== JobStatus.Completed) {
-        throw new Error(`Transcription job ${data.jobId} status: ${data.status}`);
-      }
-
-      if (
-        data.result?.content === undefined ||
-        data.result.content === null ||
-        data.result.content.length === 0
-      ) {
-        throw new Error('No transcript in job result');
-      }
-
-      logger.info({ jobId: data.jobId }, 'Transcription completed');
-
-      return {
-        content: data.result.content,
-        provider: data.result.provider,
-        metadata: data.result.metadata,
-      };
+      return await retryTranscribeOnTransientNetworkError(() =>
+        this.transcribeOnce(attachments, userId)
+      );
     } catch (error) {
       logger.error({ err: error }, 'Transcription failed');
       throw error;
     }
+  }
+
+  private async transcribeOnce(
+    attachments: Parameters<GatewayClient['transcribe']>[0],
+    userId: string | undefined
+  ): Promise<{
+    content: string;
+    provider?: SttProvider;
+    metadata?: { processingTimeMs?: number };
+  }> {
+    const response = await fetch(`${this.baseUrl}/ai/transcribe?wait=true`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': CONTENT_TYPES.JSON,
+        'X-Service-Auth': config.INTERNAL_SERVICE_SECRET ?? '',
+      },
+      body: JSON.stringify({
+        attachments,
+        ...(userId !== undefined && { userId }),
+      }),
+      signal: AbortSignal.timeout(TIMEOUTS.STT_GATEWAY),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Transcription request failed: ${response.status} ${errorText}`);
+    }
+
+    const data = (await response.json()) as TranscribeResponse;
+
+    if (data.status !== JobStatus.Completed) {
+      throw new Error(`Transcription job ${data.jobId} status: ${data.status}`);
+    }
+
+    if (
+      data.result?.content === undefined ||
+      data.result.content === null ||
+      data.result.content.length === 0
+    ) {
+      throw new Error('No transcript in job result');
+    }
+
+    logger.info({ jobId: data.jobId }, 'Transcription completed');
+
+    return {
+      content: data.result.content,
+      provider: data.result.provider,
+      metadata: data.result.metadata,
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary

Closes the silent-failure window when api-gateway is mid-restart on Railway. Pre-release polish.

**Problem**: User taps a voice message during a Railway deploy → bot replies "Sorry, I couldn't transcribe that voice message." Root cause: api-gateway's TCP socket is accepted (kernel-level) before the HTTP listener binds (Node-level), so undici closes the socket and surfaces `UND_ERR_SOCKET` / `ECONNRESET` / `ECONNREFUSED`. Observed in dev where every develop push triggers a deploy; rare in prod but possible.

**Fix**: 3-attempt retry with exponential backoff (500ms, 1000ms — total worst-case wait time 1500ms before the final throw) on transport-layer failures only. Transcription is idempotent (ai-worker job keyed by `requestId`), so retrying is safe.

**What's NOT retried**: HTTP-level errors (4xx/5xx response codes, validation failures, empty job results). Only socket-layer failures, identified by `err.cause.code in {UND_ERR_SOCKET, ECONNRESET, ECONNREFUSED}`.

## Implementation notes

- Retry helper kept inline in `GatewayClient.ts` (bot-client has no shared `withRetry` util — `StartupDMPrewarmer` is the closest precedent and uses a bespoke tagged-union classifier)
- `transcribeOnce` extracted as the per-attempt function so the retry wrapper stays a small lift
- Logger emits a `warn` per retry with the next backoff delay for observability

## Test plan

- [x] 5 new tests in `GatewayClient.test.ts`: retry-then-success on each transient code, exhaustion-then-throw, no-retry on 4xx, no-retry on errors without `cause.code`
- [x] `pnpm test` — 50 GatewayClient tests pass; full suite green
- [x] `pnpm test:int` — 308 integration tests pass
- [x] `pnpm quality` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)