### PR TITLE
feat: voice transcription clickable attribution + bot-owner Mistral 30s notice

### DIFF
--- a/packages/common-types/src/types/schemas/generation.ts
+++ b/packages/common-types/src/types/schemas/generation.ts
@@ -112,6 +112,16 @@ const generationPayloadSchema = z.object({
        *  Expected values: 'audio/wav' (voice-engine) or 'audio/mpeg' (ElevenLabs).
        *  Consumer defaults to .wav for unrecognized types. */
       ttsAudioContentType: z.string().optional(),
+      /** Bot-owner-visible diagnostics from the TTS dispatcher's fallback walk —
+       *  e.g., "Mistral skipped because reference audio exceeds 30s". Rendered
+       *  by bot-client only when the receiving user is the bot owner; silent
+       *  for other users (the audio still plays via fallback, no UX disruption).
+       *
+       *  Bounded to defend against a future contributor inadvertently sending
+       *  a notice that would push the response past Discord's 2000-char per-message
+       *  limit. The 500-char per-notice cap and 10-notice array cap each give 2x
+       *  headroom over the single-provider-chain worst case. */
+      ttsNotices: z.array(z.string().max(500)).max(10).optional(),
     })
     .optional(),
 });

--- a/packages/common-types/src/types/sttProvider.test.ts
+++ b/packages/common-types/src/types/sttProvider.test.ts
@@ -3,6 +3,7 @@ import {
   isSttProvider,
   isByokAudioProvider,
   sttProviderDisplayName,
+  sttProviderInfoUrl,
   STT_PROVIDERS,
   type SttProvider,
 } from './sttProvider.js';
@@ -58,6 +59,18 @@ describe('SttProvider helpers', () => {
       expect(sttProviderDisplayName('mistral')).toBe('Mistral');
       expect(sttProviderDisplayName('elevenlabs')).toBe('ElevenLabs');
       expect(sttProviderDisplayName('voice-engine')).toContain('Self-hosted');
+    });
+  });
+
+  describe('sttProviderInfoUrl', () => {
+    it('returns the canonical model-card URL for each provider', () => {
+      // Pin the exact URLs so a typo in the metadata table fails here, not in
+      // a downstream rendering test where the failure mode is harder to trace.
+      expect(sttProviderInfoUrl('mistral')).toBe('https://mistral.ai/news/voxtral');
+      expect(sttProviderInfoUrl('elevenlabs')).toBe('https://elevenlabs.io/speech-to-text');
+      expect(sttProviderInfoUrl('voice-engine')).toBe(
+        'https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2'
+      );
     });
   });
 });

--- a/packages/common-types/src/types/sttProvider.ts
+++ b/packages/common-types/src/types/sttProvider.ts
@@ -64,16 +64,45 @@ export const STT_RESOLUTION_SOURCES = ['user-default', 'tts-derived', 'hardcoded
 export type SttResolutionSource = (typeof STT_RESOLUTION_SOURCES)[number];
 
 /**
+ * Display + canonical-URL metadata for each STT provider, kept as a single
+ * data table so adding a new provider is one entry — display name and
+ * canonical URL stay in sync automatically.
+ *
+ * `displayName` is the user-friendly label rendered in `/voice view` and
+ * transcript attribution footers. `infoUrl` points to the canonical model
+ * card / project page (vendor docs for Mistral + ElevenLabs, upstream
+ * HuggingFace card for the self-hosted Parakeet TDT model). There's no
+ * API-discoverable URL for either category, so these are hardcoded — when
+ * a vendor rebrands or relocates their docs, this is the one place to update.
+ */
+const STT_PROVIDER_METADATA: Record<SttProvider, { displayName: string; infoUrl: string }> = {
+  mistral: {
+    displayName: 'Mistral',
+    infoUrl: 'https://mistral.ai/news/voxtral',
+  },
+  elevenlabs: {
+    displayName: 'ElevenLabs',
+    infoUrl: 'https://elevenlabs.io/speech-to-text',
+  },
+  'voice-engine': {
+    displayName: 'Self-hosted (Parakeet TDT)',
+    infoUrl: 'https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2',
+  },
+};
+
+/**
  * User-friendly display name for an STT provider. Used by `/voice view`
  * dashboard sections and embed footers.
  */
 export function sttProviderDisplayName(provider: SttProvider): string {
-  switch (provider) {
-    case 'mistral':
-      return 'Mistral';
-    case 'elevenlabs':
-      return 'ElevenLabs';
-    case 'voice-engine':
-      return 'Self-hosted (Parakeet TDT)';
-  }
+  return STT_PROVIDER_METADATA[provider].displayName;
+}
+
+/**
+ * Canonical project / vendor page for an STT provider's transcription model.
+ * Used to render the transcript attribution as a clickable Discord link, mirroring
+ * the LLM model footer's `Model: [name](<url>)` shape.
+ */
+export function sttProviderInfoUrl(provider: SttProvider): string {
+  return STT_PROVIDER_METADATA[provider].infoUrl;
 }

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.test.ts
@@ -318,6 +318,40 @@ describe('TTSStep', () => {
       await step.process(ctx);
       expect(mockStoreTTSAudio).toHaveBeenCalledWith('req-1', expect.any(Buffer));
     });
+
+    it('forwards dispatcher notices into result.metadata.ttsNotices', async () => {
+      mockDispatchTts.mockResolvedValueOnce({
+        audioBuffer: Buffer.from('synthesized'),
+        providerUsed: 'self-hosted',
+        usedFallback: true,
+        outputFormat: 'wav',
+        notices: ['Voice reference for "testbot" is 45.0s, exceeding limit. Mistral was skipped.'],
+      });
+      const ctx = createContext();
+      await step.process(ctx);
+      expect(ctx.result?.metadata?.ttsNotices).toEqual([
+        'Voice reference for "testbot" is 45.0s, exceeding limit. Mistral was skipped.',
+      ]);
+    });
+
+    it('omits ttsNotices when dispatcher returns no notices (happy path)', async () => {
+      const ctx = createContext();
+      await step.process(ctx);
+      expect(ctx.result?.metadata?.ttsNotices).toBeUndefined();
+    });
+
+    it('omits ttsNotices when dispatcher returns an empty notice list', async () => {
+      mockDispatchTts.mockResolvedValueOnce({
+        audioBuffer: Buffer.from('synthesized'),
+        providerUsed: 'mistral',
+        usedFallback: false,
+        outputFormat: 'wav',
+        notices: [],
+      });
+      const ctx = createContext();
+      await step.process(ctx);
+      expect(ctx.result?.metadata?.ttsNotices).toBeUndefined();
+    });
   });
 
   // ===== Error / timeout paths =============================================

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts
@@ -56,6 +56,10 @@ interface TtsResult {
   key: string;
   audioSize: number;
   contentType: string;
+  /** Bot-owner-visible diagnostics from the dispatcher's fallback walk
+   *  (e.g., "Mistral skipped because reference audio >30s"). Empty/undefined
+   *  on the happy path. */
+  notices?: string[];
 }
 
 export class TTSStep implements IPipelineStep {
@@ -116,12 +120,16 @@ export class TTSStep implements IPipelineStep {
       if (ttsResult !== null && context.result?.metadata !== undefined) {
         context.result.metadata.ttsAudioKey = ttsResult.key;
         context.result.metadata.ttsAudioContentType = ttsResult.contentType;
+        if (ttsResult.notices !== undefined && ttsResult.notices.length > 0) {
+          context.result.metadata.ttsNotices = ttsResult.notices;
+        }
         logger.info(
           {
             slug,
             audioSize: ttsResult.audioSize,
             contentType: ttsResult.contentType,
             key: ttsResult.key,
+            noticeCount: ttsResult.notices?.length ?? 0,
           },
           'TTS audio stored in Redis'
         );
@@ -164,12 +172,30 @@ export class TTSStep implements IPipelineStep {
         audioProviderKeys,
         registry: ttsProviderRegistry,
       });
-      return this.storeTTSResult(
+      const stored = await this.storeTTSResult(
         context,
         dispatchResult.audioBuffer,
         dispatchResult.outputFormat,
         slug
       );
+      // Bind to a local so TS narrowing carries through subsequent checks
+      // without needing `?.length ?? 0` defensiveness inside the warn block.
+      const notices = dispatchResult.notices;
+      const hasNotices = notices !== undefined && notices.length > 0;
+      if (stored === null && hasNotices) {
+        // Notices are observability-only — losing them on a Redis write failure
+        // doesn't change behavior, but the silent drop is surprising. Log so a
+        // future debug session can correlate "missing owner notice" with a
+        // Redis incident in the same window.
+        logger.warn(
+          { slug, noticeCount: notices.length },
+          'TTS notices dropped: storeTTSResult returned null (likely Redis write failure)'
+        );
+      }
+      if (stored === null) {
+        return null;
+      }
+      return hasNotices ? { ...stored, notices } : stored;
     })();
 
     void work.then(

--- a/services/ai-worker/src/services/voice/MistralTtsClient.test.ts
+++ b/services/ai-worker/src/services/voice/MistralTtsClient.test.ts
@@ -443,7 +443,7 @@ describe('MistralReferenceAudioTooLongError', () => {
     const err = new MistralReferenceAudioTooLongError(31.78);
     expect(err.durationSec).toBeCloseTo(31.78, 5);
     expect(err.limitSec).toBe(MISTRAL_MAX_REFERENCE_AUDIO_SEC);
-    expect(err.message).toMatch(/31\.78s/);
+    expect(err.message).toMatch(/31\.8s/);
     expect(err.message).toMatch(/30\.0s/);
   });
 

--- a/services/ai-worker/src/services/voice/MistralTtsClient.ts
+++ b/services/ai-worker/src/services/voice/MistralTtsClient.ts
@@ -212,7 +212,7 @@ export class MistralReferenceAudioTooLongError extends Error {
 
   constructor(durationSec: number, limitSec: number = MISTRAL_MAX_REFERENCE_AUDIO_SEC) {
     super(
-      `Mistral reference audio duration ${durationSec.toFixed(2)}s exceeds the maximum allowed duration of ${limitSec.toFixed(1)}s`
+      `Mistral reference audio duration ${durationSec.toFixed(1)}s exceeds the maximum allowed duration of ${limitSec.toFixed(1)}s`
     );
     this.name = 'MistralReferenceAudioTooLongError';
     this.durationSec = durationSec;

--- a/services/ai-worker/src/services/voice/TtsDispatcher.test.ts
+++ b/services/ai-worker/src/services/voice/TtsDispatcher.test.ts
@@ -782,3 +782,127 @@ describe('dispatchTts — provider.dispose() lifecycle', () => {
     expect(mistral.dispose).toBeUndefined();
   });
 });
+
+describe('dispatchTts — diagnostic notices', () => {
+  it('attaches a notice when MistralReferenceAudioTooLongError causes fallback', async () => {
+    const mistral = makeProvider('mistral', {
+      prepare: vi.fn(async () => {
+        throw new MistralReferenceAudioTooLongError(45.7, 30);
+      }),
+    });
+    const selfHosted = makeProvider('self-hosted');
+
+    const result = await dispatchTts({
+      text: 'hello',
+      resolvedConfig: mistralConfig,
+      ctx: baseCtx,
+      audioProviderKeys: audioKeysWithBoth,
+      registry: makeRegistry([mistral, selfHosted]),
+    });
+
+    expect(result.providerUsed).toBe('self-hosted');
+    expect(result.usedFallback).toBe(true);
+    expect(result.notices).toEqual([
+      `Voice reference for "${baseCtx.slug}" is 45.7s, exceeding Mistral's 30.0s limit. Mistral was skipped; consider re-uploading a shorter reference.`,
+    ]);
+  });
+
+  it('omits notices on the happy path (no fallback)', async () => {
+    const mistral = makeProvider('mistral');
+    const selfHosted = makeProvider('self-hosted');
+
+    const result = await dispatchTts({
+      text: 'hello',
+      resolvedConfig: mistralConfig,
+      ctx: baseCtx,
+      audioProviderKeys: audioKeysWithBoth,
+      registry: makeRegistry([mistral, selfHosted]),
+    });
+
+    expect(result.providerUsed).toBe('mistral');
+    expect(result.notices).toBeUndefined();
+  });
+
+  // Pin the contract that `buildAttemptNotice` only surfaces notices for
+  // errors with explicit registration. A future contributor adding a new
+  // error class without wiring it into the notice builder will see zero
+  // notices in the success result — matching the "non-notable error" row
+  // here. When a new notice class lands, add a row to `NOTICE_CASES` (with
+  // expected presence) so the contract test fails until the wiring exists.
+  describe('buildAttemptNotice extensibility contract', () => {
+    interface NoticeCase {
+      label: string;
+      error: () => Error;
+      expectsNotice: boolean;
+    }
+
+    const NOTICE_CASES: readonly NoticeCase[] = [
+      {
+        label: 'MistralReferenceAudioTooLongError → notice',
+        error: () => new MistralReferenceAudioTooLongError(40.0, 30),
+        expectsNotice: true,
+      },
+      {
+        label: 'generic Error → no notice',
+        error: () => new Error('boom'),
+        expectsNotice: false,
+      },
+      {
+        label: 'TypeError → no notice (not a known surfaceable class)',
+        error: () => new TypeError('whatever'),
+        expectsNotice: false,
+      },
+    ];
+
+    NOTICE_CASES.forEach(({ label, error, expectsNotice }) => {
+      it(label, async () => {
+        const mistral = makeProvider('mistral', {
+          prepare: vi.fn(async () => {
+            throw error();
+          }),
+        });
+        const selfHosted = makeProvider('self-hosted');
+
+        const result = await dispatchTts({
+          text: 'hello',
+          resolvedConfig: mistralConfig,
+          ctx: baseCtx,
+          audioProviderKeys: audioKeysWithBoth,
+          registry: makeRegistry([mistral, selfHosted]),
+        });
+
+        if (expectsNotice) {
+          expect(result.notices).toBeDefined();
+          expect(result.notices?.length).toBeGreaterThan(0);
+        } else {
+          expect(result.notices).toBeUndefined();
+        }
+      });
+    });
+  });
+
+  it('omits notices when fallback is caused by a non-notable error', async () => {
+    // Generic synthesize failure → fallback fires but no notice generated.
+    // Bot owner doesn't need to see "Mistral generic-error fallback" because
+    // (a) it's already in structured logs and (b) it's not actionable from
+    // their end without more context.
+    const mistral = makeProvider('mistral', {
+      synthesize: vi.fn(async () => {
+        throw new Error('mistral 503');
+      }),
+    });
+    const selfHosted = makeProvider('self-hosted');
+
+    const result = await dispatchTts({
+      text: 'hello',
+      resolvedConfig: mistralConfig,
+      ctx: baseCtx,
+      audioProviderKeys: audioKeysWithBoth,
+      registry: makeRegistry([mistral, selfHosted]),
+    });
+
+    expect(result.providerUsed).toBe('self-hosted');
+    expect(result.usedFallback).toBe(true);
+    expect(result.notices).toBeUndefined();
+  });
+});

--- a/services/ai-worker/src/services/voice/TtsDispatcher.ts
+++ b/services/ai-worker/src/services/voice/TtsDispatcher.ts
@@ -52,6 +52,7 @@ import {
   type TtsProvider,
   type TtsProviderId,
 } from '@tzurot/common-types';
+import { MistralReferenceAudioTooLongError } from './MistralTtsClient.js';
 
 const logger = createLogger('TtsDispatcher');
 
@@ -101,6 +102,15 @@ export interface DispatchResult {
   /** Output format from the provider's capabilities — TTSStep normalizes
    *  cross-provider differences before persisting to Redis. */
   outputFormat: 'mp3' | 'wav' | 'pcm' | 'opus';
+  /**
+   * Diagnostic notices accumulated during the fallback walk — typically
+   * "configured-primary-was-skipped-because-X" cases worth surfacing to
+   * the bot owner so they know a personality silently degraded. Empty/undefined
+   * on the happy path. Currently populated only for
+   * `MistralReferenceAudioTooLongError` (reference >30s skips the clone),
+   * but the field is generic so future "primary skipped" diagnostics can use it.
+   */
+  notices?: string[];
 }
 
 /**
@@ -361,6 +371,26 @@ function describeEmptyChainCauses(
 }
 
 /**
+ * Map a fallback-eligible attempt error to a bot-owner-visible notice
+ * describing WHY the attempt was skipped. Returns undefined for errors
+ * that don't warrant surfacing — most failure modes are either transient
+ * (network blips) or already covered by other observability paths.
+ *
+ * The notice is short, actionable, and references the specific personality
+ * (`ctx.slug`) so the bot owner can identify which voice ref needs attention.
+ */
+function buildAttemptNotice(error: unknown, ctx: TtsContext): string | undefined {
+  if (error instanceof MistralReferenceAudioTooLongError) {
+    // We name the skipped provider (Mistral) but NOT the fallback target —
+    // the notice fires before subsequent providers attempt, so the chain
+    // could continue to ElevenLabs or be empty. Hardcoding "falling back to
+    // self-hosted" would be wrong in either of those cases.
+    return `Voice reference for "${ctx.slug}" is ${error.durationSec.toFixed(1)}s, exceeding Mistral's ${error.limitSec.toFixed(1)}s limit. Mistral was skipped; consider re-uploading a shorter reference.`;
+  }
+  return undefined;
+}
+
+/**
  * Walk the fallback chain and return the first successful synthesis result.
  *
  * Errors during one provider's attempt are caught and logged; the walk
@@ -385,6 +415,7 @@ export async function dispatchTts(options: DispatchOptions): Promise<DispatchRes
   );
 
   const attempts: { provider: TtsProviderId; error: unknown }[] = [];
+  const notices: string[] = [];
   const primaryProviderId = resolvedConfig.provider;
   // Explicit flag so the "is this the primary attempt?" invariant doesn't
   // depend on `attempts.length === 0` (which silently breaks if a future
@@ -400,10 +431,14 @@ export async function dispatchTts(options: DispatchOptions): Promise<DispatchRes
     const outcome = await attemptCandidate({ candidateId, isPrimaryAttempt, options });
 
     if (outcome.kind === 'success') {
-      return outcome.result;
+      return notices.length > 0 ? { ...outcome.result, notices } : outcome.result;
     }
     if (outcome.kind === 'failed') {
       attempts.push({ provider: candidateId, error: outcome.error });
+      const notice = buildAttemptNotice(outcome.error, ctx);
+      if (notice !== undefined) {
+        notices.push(notice);
+      }
     }
     // 'skip' → just move on
   }

--- a/services/bot-client/src/handlers/MessageHandler.test.ts
+++ b/services/bot-client/src/handlers/MessageHandler.test.ts
@@ -254,6 +254,7 @@ describe('MessageHandler', () => {
 
       const mockMessage = {
         id: 'msg-123',
+        author: { id: 'user-recipient' },
       } as Message;
 
       const mockContext = {

--- a/services/bot-client/src/handlers/MessageHandler.ts
+++ b/services/bot-client/src/handlers/MessageHandler.ts
@@ -191,6 +191,8 @@ export class MessageHandler {
         showModelFooter: result.metadata?.showModelFooter,
         ttsAudioKey: result.metadata?.ttsAudioKey,
         ttsAudioContentType: result.metadata?.ttsAudioContentType,
+        ttsNotices: result.metadata?.ttsNotices,
+        recipientUserId: message.author.id,
       });
 
       // Save assistant message to conversation history

--- a/services/bot-client/src/services/DiscordResponseSender.test.ts
+++ b/services/bot-client/src/services/DiscordResponseSender.test.ts
@@ -20,6 +20,13 @@ vi.mock('../redis.js', () => ({
   },
 }));
 
+// Hoisted spy so individual tests can flip `isBotOwner` per case without
+// re-mocking the whole common-types module. Default returns false (matches
+// the prod path for non-owner users).
+const { mockIsBotOwner } = vi.hoisted(() => ({
+  mockIsBotOwner: vi.fn((_id: string) => false),
+}));
+
 vi.mock('@tzurot/common-types', async () => {
   const actual = await vi.importActual('@tzurot/common-types');
   return {
@@ -32,6 +39,7 @@ vi.mock('@tzurot/common-types', async () => {
       }
       return chunks.length > 0 ? chunks : [content];
     }),
+    isBotOwner: mockIsBotOwner,
   };
 });
 
@@ -1364,6 +1372,127 @@ describe('DiscordResponseSender', () => {
           },
         ],
       });
+    });
+  });
+
+  describe('sendResponse - TTS owner-only notices', () => {
+    const noticeText = 'Voice reference for "emily" is 45.0s, exceeding 30s limit.';
+
+    it('renders the notice when recipient is the bot owner', async () => {
+      mockIsBotOwner.mockImplementation((id: string) => id === 'owner-id');
+      const mockChannel = createMockTextChannel('channel-1');
+      const mockMessage = createMockMessage(mockChannel, { id: 'guild-1' });
+
+      await sender.sendResponse({
+        content: 'Hello.',
+        personality: mockPersonality,
+        ...senderTargetFrom(mockMessage),
+        ttsNotices: [noticeText],
+        recipientUserId: 'owner-id',
+      });
+
+      const sentContent = mockWebhookManager.sendAsPersonality.mock.calls[0][2] as string;
+      expect(sentContent).toContain(`-# ⚠️ ${noticeText}`);
+    });
+
+    it('omits the notice when recipient is not the bot owner', async () => {
+      mockIsBotOwner.mockReturnValue(false);
+      const mockChannel = createMockTextChannel('channel-2');
+      const mockMessage = createMockMessage(mockChannel, { id: 'guild-2' });
+
+      await sender.sendResponse({
+        content: 'Hello.',
+        personality: mockPersonality,
+        ...senderTargetFrom(mockMessage),
+        ttsNotices: [noticeText],
+        recipientUserId: 'someone-else',
+      });
+
+      const sentContent = mockWebhookManager.sendAsPersonality.mock.calls[0][2] as string;
+      expect(sentContent).not.toContain('⚠️');
+      expect(sentContent).not.toContain(noticeText);
+    });
+
+    it('omits the notice when recipientUserId is missing (fail-closed)', async () => {
+      mockIsBotOwner.mockImplementation(() => true); // even if check would pass
+      const mockChannel = createMockTextChannel('channel-3');
+      const mockMessage = createMockMessage(mockChannel, { id: 'guild-3' });
+
+      await sender.sendResponse({
+        content: 'Hello.',
+        personality: mockPersonality,
+        ...senderTargetFrom(mockMessage),
+        ttsNotices: [noticeText],
+        // recipientUserId intentionally absent
+      });
+
+      const sentContent = mockWebhookManager.sendAsPersonality.mock.calls[0][2] as string;
+      expect(sentContent).not.toContain('⚠️');
+      expect(mockIsBotOwner).not.toHaveBeenCalled();
+    });
+
+    it('omits the notice when the array is empty (defensive guard)', async () => {
+      // Distinct from `ttsNotices: undefined` — verifies the explicit `length === 0`
+      // branch in `buildOwnerOnlyTtsNoticeLines`. An owner sending a response with
+      // an empty notice array should see no warning lines AND no isBotOwner check.
+      mockIsBotOwner.mockImplementation(() => true);
+      const mockChannel = createMockTextChannel('channel-empty');
+      const mockMessage = createMockMessage(mockChannel, { id: 'guild-empty' });
+
+      await sender.sendResponse({
+        content: 'Hello.',
+        personality: mockPersonality,
+        ...senderTargetFrom(mockMessage),
+        ttsNotices: [],
+        recipientUserId: 'owner-id',
+      });
+
+      const sentContent = mockWebhookManager.sendAsPersonality.mock.calls[0][2] as string;
+      expect(sentContent).not.toContain('⚠️');
+      expect(mockIsBotOwner).not.toHaveBeenCalled();
+    });
+
+    it('escapes markdown in the notice (defends against slug-injected formatting)', async () => {
+      mockIsBotOwner.mockImplementation((id: string) => id === 'owner-id');
+      const mockChannel = createMockTextChannel('channel-5');
+      const mockMessage = createMockMessage(mockChannel, { id: 'guild-5' });
+
+      // A malicious or accidental slug containing markdown would otherwise
+      // render with unintended formatting in Discord. The slug travels
+      // through ai-worker → bot-client unescaped; the sender must escape
+      // before rendering.
+      const notice = 'Voice reference for "*evil_slug*" exceeds limit.';
+
+      await sender.sendResponse({
+        content: 'Hello.',
+        personality: mockPersonality,
+        ...senderTargetFrom(mockMessage),
+        ttsNotices: [notice],
+        recipientUserId: 'owner-id',
+      });
+
+      const sentContent = mockWebhookManager.sendAsPersonality.mock.calls[0][2] as string;
+      // discord.js escapeMarkdown turns *...* into \*...\* and _ into \_
+      expect(sentContent).toContain('\\*evil\\_slug\\*');
+      expect(sentContent).not.toContain('*evil_slug*');
+    });
+
+    it('renders multiple notices on separate lines', async () => {
+      mockIsBotOwner.mockImplementation((id: string) => id === 'owner-id');
+      const mockChannel = createMockTextChannel('channel-4');
+      const mockMessage = createMockMessage(mockChannel, { id: 'guild-4' });
+
+      await sender.sendResponse({
+        content: 'Hello.',
+        personality: mockPersonality,
+        ...senderTargetFrom(mockMessage),
+        ttsNotices: ['First notice.', 'Second notice.'],
+        recipientUserId: 'owner-id',
+      });
+
+      const sentContent = mockWebhookManager.sendAsPersonality.mock.calls[0][2] as string;
+      expect(sentContent).toContain('-# ⚠️ First notice.');
+      expect(sentContent).toContain('-# ⚠️ Second notice.');
     });
   });
 });

--- a/services/bot-client/src/services/DiscordResponseSender.ts
+++ b/services/bot-client/src/services/DiscordResponseSender.ts
@@ -6,7 +6,7 @@
  */
 
 import type { DMChannel } from 'discord.js';
-import { NewsChannel, TextChannel, ThreadChannel } from 'discord.js';
+import { NewsChannel, TextChannel, ThreadChannel, escapeMarkdown } from 'discord.js';
 import {
   splitMessage,
   createLogger,
@@ -15,6 +15,7 @@ import {
   BOT_FOOTER_TEXT,
   buildModelFooterText,
   buildModelInfoUrl,
+  isBotOwner,
   type TypingChannel,
 } from '@tzurot/common-types';
 import type { LoadedPersonality } from '@tzurot/common-types';
@@ -90,6 +91,20 @@ interface SendResponseOptions {
   ttsAudioKey?: string;
   /** MIME type of TTS audio (e.g., 'audio/wav', 'audio/mpeg') for file extension */
   ttsAudioContentType?: string;
+  /**
+   * Bot-owner-visible TTS dispatch notices (e.g., "Mistral skipped because
+   * reference audio >30s"). Surfaced as a `-#` subtext only when the user
+   * receiving the response IS the bot owner; silent for everyone else (the
+   * audio still plays via fallback, no UX disruption for normal users).
+   */
+  ttsNotices?: string[];
+  /**
+   * Discord user ID of the user this response is being sent to. Required to
+   * gate `ttsNotices` rendering on `isBotOwner(recipientUserId)`. Optional
+   * because not every caller surfaces notices, but if `ttsNotices` is set
+   * without `recipientUserId`, the notices are silently dropped (fail-closed).
+   */
+  recipientUserId?: string;
 }
 
 /** Shared options for internal send methods */
@@ -269,7 +284,30 @@ export class DiscordResponseSender {
     if (incognitoModeActive === true) {
       footer += `\n-# ${BOT_FOOTER_TEXT.INCOGNITO_MODE}`;
     }
+    footer += this.buildOwnerOnlyTtsNoticeLines(options);
     return footer;
+  }
+
+  /**
+   * TTS dispatch notices (e.g., "Mistral skipped because reference audio >30s")
+   * are bot-owner-visible only — silent for everyone else so a personality with
+   * a too-long voice ref doesn't leak diagnostic noise to its users. The audio
+   * still plays via fallback regardless of who's receiving the response.
+   */
+  private buildOwnerOnlyTtsNoticeLines(options: SendResponseOptions): string {
+    const { ttsNotices, recipientUserId } = options;
+    if (
+      ttsNotices === undefined ||
+      ttsNotices.length === 0 ||
+      recipientUserId === undefined ||
+      !isBotOwner(recipientUserId)
+    ) {
+      return '';
+    }
+    // Escape markdown because the notice embeds user-controllable strings
+    // (personality slug). Bot-owner-only scope keeps the impact cosmetic, but
+    // an unescaped `]` or `(` could break the embedded `-# ⚠️` rendering.
+    return ttsNotices.map(notice => `\n-# ⚠️ ${escapeMarkdown(notice)}`).join('');
   }
 
   /** Fetch TTS audio files from Redis, if a key is provided.

--- a/services/bot-client/src/services/VoiceTranscriptionService.test.ts
+++ b/services/bot-client/src/services/VoiceTranscriptionService.test.ts
@@ -293,7 +293,7 @@ describe('VoiceTranscriptionService', () => {
 
       // Single chunk → attribution appended to the only reply
       expect(message.reply).toHaveBeenCalledWith({
-        content: 'Hello there\n-# transcribed by Mistral',
+        content: 'Hello there\n-# Transcribed by [Mistral](<https://mistral.ai/news/voxtral>)',
         allowedMentions: { parse: [], repliedUser: false },
       });
     });
@@ -424,8 +424,10 @@ describe('VoiceTranscriptionService', () => {
       const calls = (message.reply as ReturnType<typeof vi.fn>).mock.calls;
       expect(calls[0][0].content).toBe('x'.repeat(2000));
       expect(calls[1][0].content).toBe('x'.repeat(2000));
-      expect(calls[1][0].content).not.toContain('-# transcribed by');
-      expect(calls[2][0].content).toBe('-# transcribed by Self-hosted (Parakeet TDT)');
+      expect(calls[1][0].content).not.toContain('-# Transcribed by');
+      expect(calls[2][0].content).toBe(
+        '-# Transcribed by [Self-hosted (Parakeet TDT)](<https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2>)'
+      );
     });
 
     it('attaches the provider attribution only to the LAST chunk on multi-chunk transcripts', async () => {
@@ -458,10 +460,12 @@ describe('VoiceTranscriptionService', () => {
 
       // First chunk: raw, no attribution
       expect(calls[0][0].content).toBe('x'.repeat(2000));
-      expect(calls[0][0].content).not.toContain('-# transcribed by');
+      expect(calls[0][0].content).not.toContain('-# Transcribed by');
 
       // Last chunk: ends with the attribution line
-      expect(calls[1][0].content).toBe(`${'x'.repeat(1000)}\n-# transcribed by Mistral`);
+      expect(calls[1][0].content).toBe(
+        `${'x'.repeat(1000)}\n-# Transcribed by [Mistral](<https://mistral.ai/news/voxtral>)`
+      );
     });
 
     it('should handle missing contentType gracefully', async () => {

--- a/services/bot-client/src/services/VoiceTranscriptionService.ts
+++ b/services/bot-client/src/services/VoiceTranscriptionService.ts
@@ -14,6 +14,7 @@ import {
   DISCORD_LIMITS,
   isTimeoutError,
   sttProviderDisplayName,
+  sttProviderInfoUrl,
   type SttProvider,
 } from '@tzurot/common-types';
 import { voiceTranscriptCache } from '../redis.js';
@@ -26,12 +27,20 @@ const logger = createLogger('VoiceTranscriptionService');
 /** Interval for refreshing the typing indicator (Discord expires at ~10s, matches JobTracker.ts) */
 const TYPING_INDICATOR_INTERVAL_MS = 8000;
 
-/** Uses Discord `-#` subtext so the line renders small+muted under the transcript. */
+/**
+ * Uses Discord `-#` subtext so the line renders small+muted under the transcript.
+ *
+ * Mirrors the LLM model footer's `Model: [name](<url>)` clickable-link shape from
+ * `buildModelFooterText` in `@tzurot/common-types/constants/discord` — readers
+ * can click through to the upstream model card to learn what produced the text.
+ */
 function formatProviderAttribution(provider?: SttProvider): string | null {
   if (provider === undefined) {
     return null;
   }
-  return `-# transcribed by ${sttProviderDisplayName(provider)}`;
+  const name = sttProviderDisplayName(provider);
+  const url = sttProviderInfoUrl(provider);
+  return `-# Transcribed by [${name}](<${url}>)`;
 }
 
 /** Inlines attribution on the last chunk; spills to a follow-up reply when inlining would exceed Discord's per-message length limit. */


### PR DESCRIPTION
## Summary

Two pre-release polish items for the voice surface, batched:

### 1. Transcript attribution becomes a clickable link (~50 LOC)

`-# transcribed by Mistral` → `-# Transcribed by [Mistral](<https://mistral.ai/news/voxtral>)`

Mirrors the LLM model footer's `Model: [name](<url>)` shape from `buildModelFooterText` so transcript readers can click through to the upstream model card just like LLM responses. Vendor URLs go to the canonical model card (Voxtral, Scribe); self-hosted goes to the upstream HuggingFace card for Parakeet TDT.

URL constants live alongside `sttProviderDisplayName` in a single `STT_PROVIDER_METADATA` table — collapses two parallel switch statements into one entry per provider so adding a new provider doesn't require synchronized edits.

### 2. Bot-owner-visible notice when Mistral 30s preflight fires (~150 LOC)

When a personality's voice reference exceeds Mistral's 30s limit, `MistralReferenceAudioTooLongError` was already firing inside `MistralTtsProvider` and the dispatcher was silently falling through to the next provider in the chain. Bot owner had no signal that a personality silently degraded.

Now: the notice surfaces as `-# ⚠️ Voice reference for "..." is N.Ns, exceeding Mistral's 30.0s limit. Mistral was skipped; consider re-uploading a shorter reference.` — but ONLY when the user receiving the response is the bot owner. Silent for all other users so a misconfigured personality doesn't leak diagnostic noise to its users.

Phrasing names the *skipped* provider (Mistral) but NOT the fallback target — the chain could continue to ElevenLabs or be empty after Mistral, so hardcoding "falling back to self-hosted" would be wrong.

Plumbing path:
- `DispatchResult.notices?: string[]` — accumulated by `dispatchTts` when a fallback-eligible error matches a known surfaceable class
- `TTSStep` writes notices through to `LLMGenerationResult.metadata.ttsNotices`
- New Zod field `ttsNotices: z.array(z.string().max(500)).max(10).optional()` on `generationPayloadSchema.metadata` — bounded so a future contributor can't inadvertently push the response past Discord's 2000-char limit
- `DiscordResponseSender.buildOwnerOnlyTtsNoticeLines()` renders notices, gated on `isBotOwner(recipientUserId)` (fail-closed when `recipientUserId` missing); `escapeMarkdown` applied at the render layer since the slug embedded in the notice is user input
- `MessageHandler` passes `recipientUserId: message.author.id` on the message-job send path

Side effect: `MistralReferenceAudioTooLongError.message` format changed from `31.78s` to `31.8s` (`.toFixed(2)` → `.toFixed(1)`) for consistency with the dispatcher notice. The structured `err.durationSec` field still preserves full precision for callers that need it.

### Out of scope (filed as follow-ups, not bundled)

- **Slash-job notice path** — `SlashJobContext` doesn't currently capture `userId`. Lower priority; @mention path is the bigger pain scenario.
- **`showModelFooter` toggle parity** — voice transcription doesn't run an LLM job, so reusing the gate requires bot-client to fetch the user's setting independently. ~30 LOC follow-up.
- **Dispatcher → MistralClient coupling** — the dispatcher currently `instanceof`-checks the Mistral error class directly. Future refactor: have provider errors carry a `userNotice?: string` field so `buildAttemptNotice` becomes a one-liner. Promote when a 2nd provider error needs a notice.

## Test plan

- [x] `pnpm test` — all green
- [x] `pnpm test:int` — 308 integration tests pass
- [x] `pnpm quality` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)