### PR TITLE
fix: cross-channel history honors maxAge/contextEpoch + gets own budget

### DIFF
--- a/packages/common-types/src/services/ConversationHistoryService.test.ts
+++ b/packages/common-types/src/services/ConversationHistoryService.test.ts
@@ -1039,17 +1039,56 @@ describe('ConversationHistoryService - Token Count Caching', () => {
 
       await service.getChannelHistory('channel-123', 20, contextEpoch);
 
+      // gte (not gt) — matches the DiscordChannelFetcher inclusive cutoff
+      // semantic and ensures a message timestamped at the exact reset moment
+      // is included rather than dropped at the boundary.
       expect(mockPrismaClient.conversationHistory.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
             channelId: 'channel-123',
             deletedAt: null,
             createdAt: {
-              gt: contextEpoch,
+              gte: contextEpoch,
             },
           }),
         })
       );
+    });
+
+    it('should apply maxAge filter when provided (no contextEpoch)', async () => {
+      mockPrismaClient.conversationHistory.findMany.mockResolvedValue([]);
+      const before = Date.now();
+
+      await service.getChannelHistory('channel-123', 20, undefined, 60); // 60s
+
+      const call = mockPrismaClient.conversationHistory.findMany.mock.calls[0][0];
+      const cutoff = call.where.createdAt.gte as Date;
+      // Cutoff should be roughly (now - 60s); allow small wall-clock drift
+      const expectedCutoffMs = before - 60_000;
+      expect(cutoff.getTime()).toBeGreaterThanOrEqual(expectedCutoffMs);
+      expect(cutoff.getTime()).toBeLessThanOrEqual(expectedCutoffMs + 1000);
+    });
+
+    it('should pick the more recent of maxAge and contextEpoch when both provided', async () => {
+      mockPrismaClient.conversationHistory.findMany.mockResolvedValue([]);
+      // contextEpoch is 1 hour ago; maxAge=60s gives a 60s-ago cutoff
+      // The 60s-ago cutoff is more recent → it wins
+      const contextEpoch = new Date(Date.now() - 60 * 60 * 1000);
+
+      await service.getChannelHistory('channel-123', 20, contextEpoch, 60);
+
+      const call = mockPrismaClient.conversationHistory.findMany.mock.calls[0][0];
+      const cutoff = call.where.createdAt.gte as Date;
+      expect(cutoff.getTime()).toBeGreaterThan(contextEpoch.getTime());
+    });
+
+    it('omits the time filter when neither maxAge nor contextEpoch is provided', async () => {
+      mockPrismaClient.conversationHistory.findMany.mockResolvedValue([]);
+
+      await service.getChannelHistory('channel-123', 20);
+
+      const call = mockPrismaClient.conversationHistory.findMany.mock.calls[0][0];
+      expect(call.where).not.toHaveProperty('createdAt');
     });
 
     it('should return empty array on error', async () => {
@@ -1239,6 +1278,47 @@ describe('ConversationHistoryService - Token Count Caching', () => {
           take: 50,
         })
       );
+    });
+
+    it('applies maxAge cutoff when provided', async () => {
+      mockPrismaClient.conversationHistory.findMany.mockResolvedValue([]);
+      const before = Date.now();
+
+      await service.getCrossChannelHistory('persona-1', 'personality-1', 'current-channel', 50, {
+        maxAgeSeconds: 60,
+      });
+
+      const call = mockPrismaClient.conversationHistory.findMany.mock.calls[0][0];
+      const cutoff = call.where.createdAt.gte as Date;
+      const expectedCutoffMs = before - 60_000;
+      expect(cutoff.getTime()).toBeGreaterThanOrEqual(expectedCutoffMs);
+      expect(cutoff.getTime()).toBeLessThanOrEqual(expectedCutoffMs + 1000);
+    });
+
+    it('applies contextEpoch cutoff when provided', async () => {
+      mockPrismaClient.conversationHistory.findMany.mockResolvedValue([]);
+      const epoch = new Date('2026-05-01T00:00:00Z');
+
+      await service.getCrossChannelHistory('persona-1', 'personality-1', 'current-channel', 50, {
+        contextEpoch: epoch,
+      });
+
+      expect(mockPrismaClient.conversationHistory.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            createdAt: { gte: epoch },
+          }),
+        })
+      );
+    });
+
+    it('omits the time filter when neither maxAge nor contextEpoch is provided', async () => {
+      mockPrismaClient.conversationHistory.findMany.mockResolvedValue([]);
+
+      await service.getCrossChannelHistory('persona-1', 'personality-1', 'current-channel');
+
+      const call = mockPrismaClient.conversationHistory.findMany.mock.calls[0][0];
+      expect(call.where).not.toHaveProperty('createdAt');
     });
   });
 

--- a/packages/common-types/src/services/ConversationHistoryService.ts
+++ b/packages/common-types/src/services/ConversationHistoryService.ts
@@ -21,11 +21,24 @@ import {
   type CrossChannelHistoryGroup,
 } from './ConversationMessageMapper.js';
 import { generateConversationHistoryUuid } from '../utils/deterministicUuid.js';
+import { computeHistoryCutoff } from './historyCutoff.js';
 
 // Re-export types for consumers that import from this module
 export type { ConversationMessage, CrossChannelHistoryGroup } from './ConversationMessageMapper.js';
 
 const logger = createLogger('ConversationHistoryService');
+
+/**
+ * Optional time-bound filters for history fetches. Kept as a sub-options
+ * object so adding a new filter (e.g., per-personality scope) doesn't push
+ * `getChannelHistory` / `getCrossChannelHistory` past the max-params limit.
+ */
+export interface HistoryTimeFilter {
+  /** Max-age cutoff in SECONDS (matches DiscordChannelFetcher's unit). */
+  maxAgeSeconds?: number | null;
+  /** Explicit reset point — e.g., from `/conversation reset`. */
+  contextEpoch?: Date;
+}
 
 /**
  * Options for adding a message to conversation history
@@ -362,23 +375,30 @@ export class ConversationHistoryService {
    * @param channelId Channel ID
    * @param limit Number of messages to fetch (default: 20)
    * @param contextEpoch Optional epoch timestamp - messages before this time are excluded
+   * @param maxAgeSeconds Optional max-age cutoff in SECONDS. Mirrors the same filter
+   *   in DiscordChannelFetcher so DB-resident messages don't leak past the user's
+   *   "forget after X" preference (which would otherwise let stale rows fill the
+   *   message budget and starve cross-channel context).
+   *
+   * Time-bound filters are positional rather than collapsed into a sub-options
+   * object to keep the call-site shape stable; the public test surface asserts
+   * positional args. If a 3rd time filter ever lands, fold them all into a
+   * trailing `HistoryTimeFilter` opts object together.
    */
   async getChannelHistory(
     channelId: string,
     limit = 20,
-    contextEpoch?: Date
+    contextEpoch?: Date,
+    maxAgeSeconds?: number | null
   ): Promise<ConversationMessage[]> {
     try {
+      const cutoff = computeHistoryCutoff(maxAgeSeconds, contextEpoch);
       const messages = await this.prisma.conversationHistory.findMany({
         where: {
           channelId,
           // NO personalityId filter - fetch ALL channel messages
           deletedAt: null,
-          ...(contextEpoch !== undefined && {
-            createdAt: {
-              gt: contextEpoch,
-            },
-          }),
+          ...(cutoff !== undefined ? { createdAt: { gte: cutoff } } : {}),
         },
         orderBy: {
           createdAt: 'desc',
@@ -406,8 +426,10 @@ export class ConversationHistoryService {
    * Returns messages grouped by channel, ordered by most recent activity.
    * Messages within each group are in chronological order (oldest first).
    *
-   * Used to fill unused context budget with cross-channel history when
-   * crossChannelHistoryEnabled is true.
+   * Used to surface cross-channel context with a personality when
+   * crossChannelHistoryEnabled is true. Results are NOT scoped to a guild —
+   * messages from any channel (including DMs) the same persona has used
+   * with this personality are eligible.
    *
    * @param personaId User's persona ID
    * @param personalityId AI personality ID
@@ -415,15 +437,21 @@ export class ConversationHistoryService {
    * @param limit Maximum total messages to fetch across all channels (capped at 100).
    *   The limit applies globally, not per-channel. If the N most recent messages
    *   all come from one channel, older channels will be entirely absent from results.
+   * @param timeFilter Optional max-age + contextEpoch cutoffs. Mirrors the
+   *   current-channel filter in DiscordChannelFetcher so a user's "forget after X"
+   *   preference applies uniformly across both context sources. The two cutoffs
+   *   are combined via max(); the more recent timestamp wins.
    */
   async getCrossChannelHistory(
     personaId: string,
     personalityId: string,
     excludeChannelId: string,
-    limit = 50
+    limit = 50,
+    timeFilter: HistoryTimeFilter = {}
   ): Promise<CrossChannelHistoryGroup[]> {
     try {
       const safeLimit = Math.min(limit, 100);
+      const cutoff = computeHistoryCutoff(timeFilter.maxAgeSeconds, timeFilter.contextEpoch);
 
       const messages = await this.prisma.conversationHistory.findMany({
         where: {
@@ -431,6 +459,7 @@ export class ConversationHistoryService {
           personalityId,
           channelId: { not: excludeChannelId },
           deletedAt: null,
+          ...(cutoff !== undefined ? { createdAt: { gte: cutoff } } : {}),
         },
         orderBy: {
           createdAt: 'desc',

--- a/packages/common-types/src/services/historyCutoff.test.ts
+++ b/packages/common-types/src/services/historyCutoff.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { computeHistoryCutoff } from './historyCutoff.js';
+
+describe('computeHistoryCutoff', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-10T12:00:00Z'));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns undefined when neither input is provided', () => {
+    expect(computeHistoryCutoff(undefined, undefined)).toBeUndefined();
+    expect(computeHistoryCutoff(null, undefined)).toBeUndefined();
+  });
+
+  it('derives cutoff from maxAgeSeconds alone', () => {
+    const cutoff = computeHistoryCutoff(3600, undefined); // 1h ago
+    expect(cutoff).toEqual(new Date('2026-05-10T11:00:00Z'));
+  });
+
+  it('uses contextEpoch directly when maxAgeSeconds is missing', () => {
+    const epoch = new Date('2026-05-09T00:00:00Z');
+    expect(computeHistoryCutoff(undefined, epoch)).toBe(epoch);
+  });
+
+  it('returns the more recent (later) cutoff when both are provided', () => {
+    // maxAgeSeconds=3600 → 11:00Z; contextEpoch=09:00Z → 11:00Z wins
+    const epoch = new Date('2026-05-10T09:00:00Z');
+    expect(computeHistoryCutoff(3600, epoch)).toEqual(new Date('2026-05-10T11:00:00Z'));
+
+    // contextEpoch=11:30Z is more recent than maxAgeSeconds=3600 → 11:00Z
+    const laterEpoch = new Date('2026-05-10T11:30:00Z');
+    expect(computeHistoryCutoff(3600, laterEpoch)).toBe(laterEpoch);
+  });
+
+  it('treats null maxAgeSeconds the same as undefined (cascade "off" sentinel)', () => {
+    const epoch = new Date('2026-05-09T00:00:00Z');
+    expect(computeHistoryCutoff(null, epoch)).toBe(epoch);
+  });
+});

--- a/packages/common-types/src/services/historyCutoff.ts
+++ b/packages/common-types/src/services/historyCutoff.ts
@@ -1,0 +1,37 @@
+/**
+ * History fetch time-cutoff helper.
+ *
+ * Conversation-history fetches accept two independent lower-bound filters:
+ *   - `maxAgeSeconds`: a relative window like "messages from the last hour"
+ *     (the user-facing cascade setting; mirrors `DiscordChannelFetcher`)
+ *   - `contextEpoch`: an explicit reset point (e.g., from `/conversation reset`)
+ *
+ * Both are lower bounds — older messages are excluded — so combining them
+ * means taking the more recent (later) cutoff. This is the single source of
+ * truth used by both `getChannelHistory` and `getCrossChannelHistory` so the
+ * two paths can't drift in their interpretation of "after which timestamp".
+ */
+
+/**
+ * Combine an optional max-age window and an optional explicit context epoch
+ * into a single `createdAt >=` cutoff Date.
+ *
+ * Returns undefined when neither input is set, signalling the caller to omit
+ * the time filter entirely from the underlying query.
+ */
+export function computeHistoryCutoff(
+  maxAgeSeconds: number | null | undefined,
+  contextEpoch: Date | undefined
+): Date | undefined {
+  const cutoffs: Date[] = [];
+  if (maxAgeSeconds !== undefined && maxAgeSeconds !== null) {
+    cutoffs.push(new Date(Date.now() - maxAgeSeconds * 1000));
+  }
+  if (contextEpoch !== undefined) {
+    cutoffs.push(contextEpoch);
+  }
+  if (cutoffs.length === 0) {
+    return undefined;
+  }
+  return cutoffs.reduce((latest, c) => (c > latest ? c : latest));
+}

--- a/services/bot-client/src/services/CrossChannelHistoryFetcher.test.ts
+++ b/services/bot-client/src/services/CrossChannelHistoryFetcher.test.ts
@@ -110,7 +110,8 @@ describe('fetchCrossChannelHistory', () => {
       'persona-1',
       'personality-1',
       'channel-1',
-      50
+      50,
+      { maxAgeSeconds: undefined, contextEpoch: undefined }
     );
   });
 
@@ -480,7 +481,6 @@ describe('fetchCrossChannelIfEnabled', () => {
       channelId: 'channel-1',
       personaId: 'persona-1',
       personalityId: 'p-1',
-      currentHistoryLength: 0,
       dbLimit: 50,
       discordClient: createMockDiscordClient(),
       conversationHistoryService: createMockConversationHistoryService(),
@@ -488,37 +488,61 @@ describe('fetchCrossChannelIfEnabled', () => {
     expect(result).toBeUndefined();
   });
 
-  it('should return undefined when no budget remaining', async () => {
-    const result = await fetchCrossChannelIfEnabled({
-      enabled: true,
-      channelId: 'channel-1',
-      personaId: 'persona-1',
-      personalityId: 'p-1',
-      currentHistoryLength: 50,
-      dbLimit: 50,
-      discordClient: createMockDiscordClient(),
-      conversationHistoryService: createMockConversationHistoryService(),
-    });
-    expect(result).toBeUndefined();
-  });
-
-  it('should fetch cross-channel history when enabled with budget', async () => {
-    const groups: CrossChannelHistoryGroup[] = [
+  it('fetches cross-channel history with its own dbLimit budget regardless of current-channel size', async () => {
+    // Regression test for the residual-filler bug: prior code computed
+    // `remainingMessageCount = dbLimit - currentHistoryLength` and silently
+    // skipped cross-channel when the current channel was full. The user-reported
+    // symptom was zero cross-channel context after setting maxAge=48h on a
+    // personality whose current thread was 5 days stale — the stale rows leaked
+    // through (separate bug, fixed in getChannelHistory) and starved this fetch.
+    const service = createMockConversationHistoryService([
       { channelId: 'channel-2', guildId: null, messages: [createMockMessage()] },
-    ];
+    ]);
 
     const result = await fetchCrossChannelIfEnabled({
       enabled: true,
       channelId: 'channel-1',
       personaId: 'persona-1',
       personalityId: 'p-1',
-      currentHistoryLength: 1,
       dbLimit: 50,
       discordClient: createMockDiscordClient(),
-      conversationHistoryService: createMockConversationHistoryService(groups),
+      conversationHistoryService: service,
     });
 
     expect(result).toHaveLength(1);
+    // The DB query receives dbLimit (50) as its own budget, NOT a residual.
+    expect(service.getCrossChannelHistory).toHaveBeenCalledWith(
+      'persona-1',
+      'p-1',
+      'channel-1',
+      50,
+      { maxAgeSeconds: undefined, contextEpoch: undefined }
+    );
+  });
+
+  it('threads maxAge and contextEpoch through to the DB query', async () => {
+    const service = createMockConversationHistoryService([]);
+    const epoch = new Date('2026-05-01T00:00:00Z');
+
+    await fetchCrossChannelIfEnabled({
+      enabled: true,
+      channelId: 'channel-1',
+      personaId: 'persona-1',
+      personalityId: 'p-1',
+      dbLimit: 50,
+      discordClient: createMockDiscordClient(),
+      conversationHistoryService: service,
+      maxAge: 3600,
+      contextEpoch: epoch,
+    });
+
+    expect(service.getCrossChannelHistory).toHaveBeenCalledWith(
+      'persona-1',
+      'p-1',
+      'channel-1',
+      50,
+      { maxAgeSeconds: 3600, contextEpoch: epoch }
+    );
   });
 
   it('should return undefined when cross-channel returns empty', async () => {
@@ -527,7 +551,6 @@ describe('fetchCrossChannelIfEnabled', () => {
       channelId: 'channel-1',
       personaId: 'persona-1',
       personalityId: 'p-1',
-      currentHistoryLength: 1,
       dbLimit: 50,
       discordClient: createMockDiscordClient(),
       conversationHistoryService: createMockConversationHistoryService([]),

--- a/services/bot-client/src/services/CrossChannelHistoryFetcher.ts
+++ b/services/bot-client/src/services/CrossChannelHistoryFetcher.ts
@@ -33,6 +33,10 @@ interface FetchOptions {
   remainingMessageCount: number;
   discordClient: Client;
   conversationHistoryService: ConversationHistoryService;
+  /** Max-age cutoff in SECONDS, mirroring the current-channel filter. */
+  maxAge?: number | null;
+  /** Explicit context epoch from `/conversation reset`. */
+  contextEpoch?: Date;
 }
 
 /**
@@ -182,7 +186,8 @@ export async function fetchCrossChannelHistory(
     personaId,
     personalityId,
     currentChannelId,
-    remainingMessageCount
+    remainingMessageCount,
+    { maxAgeSeconds: opts.maxAge, contextEpoch: opts.contextEpoch }
   );
 
   if (groups.length === 0) {
@@ -220,35 +225,32 @@ export async function fetchCrossChannelHistory(
 }
 
 /**
- * Fetch cross-channel history if enabled and there's remaining budget.
- * Returns undefined if disabled or no room for additional history.
+ * Fetch cross-channel history if enabled.
+ *
+ * Cross-channel context gets its own DB-row budget (capped at `dbLimit`)
+ * rather than what's left over after the current-channel fetch. The previous
+ * "residual filler" model silently zeroed cross-channel out whenever the
+ * current channel was full of stale rows — a privacy / continuity surprise
+ * for users who had set max-age expecting cross-channel to bridge the gap.
+ *
+ * Token-budget enforcement still happens downstream in `ContentBudgetManager`,
+ * which trims both sources to fit the model's context window. Pulling more
+ * DB rows here just gives that layer real choices to make.
  */
 export async function fetchCrossChannelIfEnabled(opts: {
   enabled: boolean;
   channelId: string;
   personaId: string;
   personalityId: string;
-  currentHistoryLength: number;
   dbLimit: number;
   discordClient: Client;
   conversationHistoryService: ConversationHistoryService;
+  /** Max-age cutoff in SECONDS, threaded from the user's LLM config. */
+  maxAge?: number | null;
+  /** Explicit context epoch from `/conversation reset`. */
+  contextEpoch?: Date;
 }): Promise<ResolvedCrossChannelGroup[] | undefined> {
   if (!opts.enabled) {
-    return undefined;
-  }
-
-  // currentHistoryLength is the DB row count from getChannelHistory (before any Discord
-  // extension), so this subtraction gives the correct remaining DB-level message budget.
-  const remainingMessageCount = opts.dbLimit - opts.currentHistoryLength;
-  if (remainingMessageCount <= 0) {
-    logger.debug(
-      {
-        channelId: opts.channelId,
-        currentHistoryLength: opts.currentHistoryLength,
-        dbLimit: opts.dbLimit,
-      },
-      'No remaining message count for cross-channel history'
-    );
     return undefined;
   }
 
@@ -256,9 +258,11 @@ export async function fetchCrossChannelIfEnabled(opts: {
     personaId: opts.personaId,
     personalityId: opts.personalityId,
     currentChannelId: opts.channelId,
-    remainingMessageCount,
+    remainingMessageCount: opts.dbLimit,
     discordClient: opts.discordClient,
     conversationHistoryService: opts.conversationHistoryService,
+    maxAge: opts.maxAge,
+    contextEpoch: opts.contextEpoch,
   });
 
   return groups.length > 0 ? groups : undefined;

--- a/services/bot-client/src/services/MessageContextBuilder.test.ts
+++ b/services/bot-client/src/services/MessageContextBuilder.test.ts
@@ -272,10 +272,13 @@ describe('MessageContextBuilder', () => {
         'personality-123'
       );
 
-      // Verify history retrieval (2nd arg is limit, 3rd is contextEpoch - undefined when no STM clear)
+      // Verify history retrieval. Args: (channelId, limit, contextEpoch, maxAge).
+      // Both contextEpoch and maxAge are undefined here — no STM clear, no
+      // extendedContext.maxAge set on this fixture.
       expect(mockHistoryService.getChannelHistory).toHaveBeenCalledWith(
         'channel-123',
         50,
+        undefined,
         undefined
       );
 
@@ -742,11 +745,12 @@ describe('MessageContextBuilder', () => {
         },
       });
 
-      // Verify history was fetched WITH the context epoch
+      // Verify history was fetched WITH the context epoch (and no maxAge)
       expect(mockHistoryService.getChannelHistory).toHaveBeenCalledWith(
         'channel-123',
         50,
-        contextEpoch
+        contextEpoch,
+        undefined
       );
     });
 
@@ -772,10 +776,11 @@ describe('MessageContextBuilder', () => {
 
       await builder.buildContext(mockMessage, mockPersonality, 'Hello');
 
-      // Verify history was fetched WITHOUT epoch (undefined)
+      // Verify history was fetched WITHOUT epoch (undefined) and without maxAge
       expect(mockHistoryService.getChannelHistory).toHaveBeenCalledWith(
         'channel-123',
         50,
+        undefined,
         undefined
       );
     });

--- a/services/bot-client/src/services/MessageContextBuilder.ts
+++ b/services/bot-client/src/services/MessageContextBuilder.ts
@@ -119,35 +119,6 @@ export class MessageContextBuilder {
   }
 
   /**
-   * Fetch conversation history from database.
-   * Always fetches ALL channel messages (not filtered by personality) to provide
-   * complete conversation context and align with Discord extended context messages.
-   *
-   * The limit parameter caps the DB fetch to the maxMessages setting from LlmConfig,
-   * preventing the DB lookup from going much farther back than necessary.
-   */
-  private async fetchDbHistory(
-    channelId: string,
-    contextEpoch: Date | undefined,
-    limit: number = MESSAGE_LIMITS.DEFAULT_MAX_MESSAGES
-  ): Promise<ConversationMessage[]> {
-    // Always use getChannelHistory for complete conversation context
-    // This prevents divergence between DB and Discord message views
-    const history = await this.conversationHistory.getChannelHistory(
-      channelId,
-      limit,
-      contextEpoch
-    );
-
-    logger.debug(
-      { channelId, limit, dbHistoryCount: history.length },
-      'Fetched conversation history from database'
-    );
-
-    return history;
-  }
-
-  /**
    * Fetch extended context from Discord channel and merge with history.
    */
   // eslint-disable-next-line max-lines-per-function, sonarjs/cognitive-complexity -- Cohesive extended context workflow with guard clauses and optional feature checks
@@ -392,11 +363,19 @@ export class MessageContextBuilder {
     // Always fetch complete channel history (not personality-filtered)
     // Use maxMessages from resolved LLM config or extended context settings
     // Hard cap at MAX_EXTENDED_CONTEXT (100) as defense-in-depth against API validation bypass
+    // dbLimit caps the DB fetch to maxMessages from LlmConfig (hard cap MAX_EXTENDED_CONTEXT).
+    // maxAge mirrors the DiscordChannelFetcher filter so stale DB rows don't leak past
+    // the user's "forget after X" preference and starve cross-channel context.
     const dbLimit = Math.min(
       options.extendedContext?.maxMessages ?? MESSAGE_LIMITS.DEFAULT_MAX_MESSAGES,
       MESSAGE_LIMITS.MAX_EXTENDED_CONTEXT
     );
-    const dbHistory = await this.fetchDbHistory(message.channel.id, contextEpoch, dbLimit);
+    const dbHistory = await this.conversationHistory.getChannelHistory(
+      message.channel.id,
+      dbLimit,
+      contextEpoch,
+      options.extendedContext?.maxAge
+    );
 
     // Step 4: Fetch extended context from Discord (if enabled) and merge with DB history
     const extendedContext = await this.fetchExtendedContext({
@@ -410,19 +389,18 @@ export class MessageContextBuilder {
     const extendedContextAttachments = extendedContext.attachments;
     const participantGuildInfo = extendedContext.participantGuildInfo;
 
-    // Step 4b: Fetch cross-channel history (if enabled and there's remaining budget)
-    // Disabled in weigh-in mode: weigh-in is an anonymous poke that skips LTM and history
-    // from other channels. Cross-channel history would surface prior conversations,
-    // contradicting the "fresh perspective" intent of weigh-in.
+    // Step 4b: Fetch cross-channel history. Disabled in weigh-in mode (anonymous
+    // poke that skips LTM and other-channel history for a fresh-perspective response).
     const crossChannelGroups = await fetchCrossChannelIfEnabled({
       enabled: options.crossChannelHistoryEnabled === true && options.isWeighInMode !== true,
       channelId: message.channel.id,
       personaId,
       personalityId: personality.id,
-      currentHistoryLength: dbHistory.length, // DB row count, not merged DB+Discord count
       dbLimit,
       discordClient: message.client,
       conversationHistoryService: this.conversationHistory,
+      maxAge: options.extendedContext?.maxAge,
+      contextEpoch,
     }).catch((err: unknown) => {
       logger.warn(
         { err, personaId, personalityId: personality.id, channelId: message.channel.id },


### PR DESCRIPTION
## Summary

Closes the production-issue tracked in `backlog/production-issues.md` — user-reported "channel context sharing and max age combination might not be working correctly." Set maxAge=48h on a personality with a stale current thread, expected cross-channel bridging, got zero cross-channel.

Three interlocking bugs unwound:

### Bug A: `getChannelHistory` ignored `maxAge` at the DB layer
Honored `contextEpoch` but not the user's max-age cascade setting. Stale rows leaked through and filled `dbHistory` to `dbLimit`.

### Bug B: Cross-channel budget was a residual
`fetchCrossChannelIfEnabled` computed `remainingMessageCount = dbLimit - currentHistoryLength`. With Bug A filling current-channel to full, cross-channel was silently skipped — the entire fetch never ran. Reframed as a privacy/continuity issue: cross-channel context is part of *long-term memory with that personality*, not a "filler when current is sparse" feature. Now gets its own `dbLimit` budget; token budget at `ContentBudgetManager` still trims downstream.

### Bug C: `getCrossChannelHistory` had no time filter
Even after A + B, cross-channel would surface arbitrarily old context. Now mirrors the current-channel cutoff via the shared `computeHistoryCutoff` helper.

## Implementation

- New `packages/common-types/src/services/historyCutoff.ts` — single source of truth for the `now - maxAgeSeconds` vs `contextEpoch` max() combination. Used by both `getChannelHistory` and `getCrossChannelHistory`.
- New `HistoryTimeFilter` opts type (max-params compliance for `getCrossChannelHistory`'s trailing args).
- `MessageContextBuilder` passes `options.extendedContext?.maxAge` and `contextEpoch` to both fetch paths.
- `fetchDbHistory` wrapper inlined (now a thin one-line passthrough since the real logic is at the DB layer).

## Confirmation

Cross-channel DB query is **not** guild-scoped — it pulls from any channel including DMs, matching the user's stated expectation ("it should pull from anywhere though, even DMs"). The bug was never about guild scoping.

## Test plan

- [x] `pnpm test` — 96 common-types (1 new test file), 299 bot-client, all packages green
- [x] `pnpm test:int` — 308 integration tests pass
- [x] `pnpm quality` — green
- [x] New unit tests at every layer: `historyCutoff.test.ts` (helper invariants), `ConversationHistoryService.test.ts` (Prisma where-clause coverage for both maxAge-only / contextEpoch-only / both), `CrossChannelHistoryFetcher.test.ts` (regression test for the residual-budget bug + opts threading)

🤖 Generated with [Claude Code](https://claude.com/claude-code)