### PR TITLE
fix: cross-channel followup — DRY consolidation + diagnostic surface

### DIFF
--- a/packages/common-types/src/index.ts
+++ b/packages/common-types/src/index.ts
@@ -84,6 +84,7 @@ export * from './services/SttResolverCacheInvalidationService.js';
 export * from './services/tts/TtsProvider.js';
 export * from './services/tts/TtsProviderError.js';
 export * from './services/ConversationHistoryService.js';
+export * from './services/historyCutoff.js';
 export * from './services/ConversationRetentionService.js';
 export * from './services/ConversationSyncService.js';
 export * from './services/UserService.js';

--- a/packages/common-types/src/services/ConversationHistoryService.test.ts
+++ b/packages/common-types/src/services/ConversationHistoryService.test.ts
@@ -2,7 +2,7 @@
  * Tests for ConversationHistoryService - Token Count Caching
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { PrismaClient } from './prisma.js';
 import { ConversationHistoryService } from './ConversationHistoryService.js';
 import { MessageRole } from '../constants/index.js';
@@ -1055,40 +1055,47 @@ describe('ConversationHistoryService - Token Count Caching', () => {
       );
     });
 
-    it('should apply maxAge filter when provided (no contextEpoch)', async () => {
-      mockPrismaClient.conversationHistory.findMany.mockResolvedValue([]);
-      const before = Date.now();
+    describe('time-filter behavior', () => {
+      // Fake timers per project standard (02-code-standards.md) — collapses the
+      // wall-clock tolerance window to a deterministic equality check, immune
+      // to slow CI.
+      beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-05-10T12:00:00Z'));
+      });
+      afterEach(() => {
+        vi.useRealTimers();
+      });
 
-      await service.getChannelHistory('channel-123', 20, undefined, 60); // 60s
+      it('should apply maxAge filter when provided (no contextEpoch)', async () => {
+        mockPrismaClient.conversationHistory.findMany.mockResolvedValue([]);
 
-      const call = mockPrismaClient.conversationHistory.findMany.mock.calls[0][0];
-      const cutoff = call.where.createdAt.gte as Date;
-      // Cutoff should be roughly (now - 60s); allow small wall-clock drift
-      const expectedCutoffMs = before - 60_000;
-      expect(cutoff.getTime()).toBeGreaterThanOrEqual(expectedCutoffMs);
-      expect(cutoff.getTime()).toBeLessThanOrEqual(expectedCutoffMs + 1000);
-    });
+        await service.getChannelHistory('channel-123', 20, undefined, 60); // 60s
 
-    it('should pick the more recent of maxAge and contextEpoch when both provided', async () => {
-      mockPrismaClient.conversationHistory.findMany.mockResolvedValue([]);
-      // contextEpoch is 1 hour ago; maxAge=60s gives a 60s-ago cutoff
-      // The 60s-ago cutoff is more recent → it wins
-      const contextEpoch = new Date(Date.now() - 60 * 60 * 1000);
+        const call = mockPrismaClient.conversationHistory.findMany.mock.calls[0][0];
+        expect(call.where.createdAt.gte).toEqual(new Date('2026-05-10T11:59:00Z'));
+      });
 
-      await service.getChannelHistory('channel-123', 20, contextEpoch, 60);
+      it('should pick the more recent of maxAge and contextEpoch when both provided', async () => {
+        mockPrismaClient.conversationHistory.findMany.mockResolvedValue([]);
+        // contextEpoch is 1 hour ago; maxAge=60s gives a 60s-ago cutoff
+        // The 60s-ago cutoff is more recent → it wins
+        const contextEpoch = new Date('2026-05-10T11:00:00Z');
 
-      const call = mockPrismaClient.conversationHistory.findMany.mock.calls[0][0];
-      const cutoff = call.where.createdAt.gte as Date;
-      expect(cutoff.getTime()).toBeGreaterThan(contextEpoch.getTime());
-    });
+        await service.getChannelHistory('channel-123', 20, contextEpoch, 60);
 
-    it('omits the time filter when neither maxAge nor contextEpoch is provided', async () => {
-      mockPrismaClient.conversationHistory.findMany.mockResolvedValue([]);
+        const call = mockPrismaClient.conversationHistory.findMany.mock.calls[0][0];
+        expect(call.where.createdAt.gte).toEqual(new Date('2026-05-10T11:59:00Z'));
+      });
 
-      await service.getChannelHistory('channel-123', 20);
+      it('omits the time filter when neither maxAge nor contextEpoch is provided', async () => {
+        mockPrismaClient.conversationHistory.findMany.mockResolvedValue([]);
 
-      const call = mockPrismaClient.conversationHistory.findMany.mock.calls[0][0];
-      expect(call.where).not.toHaveProperty('createdAt');
+        await service.getChannelHistory('channel-123', 20);
+
+        const call = mockPrismaClient.conversationHistory.findMany.mock.calls[0][0];
+        expect(call.where).not.toHaveProperty('createdAt');
+      });
     });
 
     it('should return empty array on error', async () => {
@@ -1280,45 +1287,53 @@ describe('ConversationHistoryService - Token Count Caching', () => {
       );
     });
 
-    it('applies maxAge cutoff when provided', async () => {
-      mockPrismaClient.conversationHistory.findMany.mockResolvedValue([]);
-      const before = Date.now();
-
-      await service.getCrossChannelHistory('persona-1', 'personality-1', 'current-channel', 50, {
-        maxAgeSeconds: 60,
+    describe('time-filter behavior', () => {
+      // Fake timers per project standard (02-code-standards.md). See same block
+      // in getChannelHistory tests above for rationale.
+      beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-05-10T12:00:00Z'));
+      });
+      afterEach(() => {
+        vi.useRealTimers();
       });
 
-      const call = mockPrismaClient.conversationHistory.findMany.mock.calls[0][0];
-      const cutoff = call.where.createdAt.gte as Date;
-      const expectedCutoffMs = before - 60_000;
-      expect(cutoff.getTime()).toBeGreaterThanOrEqual(expectedCutoffMs);
-      expect(cutoff.getTime()).toBeLessThanOrEqual(expectedCutoffMs + 1000);
-    });
+      it('applies maxAge cutoff when provided', async () => {
+        mockPrismaClient.conversationHistory.findMany.mockResolvedValue([]);
 
-    it('applies contextEpoch cutoff when provided', async () => {
-      mockPrismaClient.conversationHistory.findMany.mockResolvedValue([]);
-      const epoch = new Date('2026-05-01T00:00:00Z');
+        await service.getCrossChannelHistory('persona-1', 'personality-1', 'current-channel', 50, {
+          maxAgeSeconds: 60,
+        });
 
-      await service.getCrossChannelHistory('persona-1', 'personality-1', 'current-channel', 50, {
-        contextEpoch: epoch,
+        const call = mockPrismaClient.conversationHistory.findMany.mock.calls[0][0];
+        expect(call.where.createdAt.gte).toEqual(new Date('2026-05-10T11:59:00Z'));
       });
 
-      expect(mockPrismaClient.conversationHistory.findMany).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({
-            createdAt: { gte: epoch },
-          }),
-        })
-      );
-    });
+      it('applies contextEpoch cutoff when provided', async () => {
+        mockPrismaClient.conversationHistory.findMany.mockResolvedValue([]);
+        const epoch = new Date('2026-05-01T00:00:00Z');
 
-    it('omits the time filter when neither maxAge nor contextEpoch is provided', async () => {
-      mockPrismaClient.conversationHistory.findMany.mockResolvedValue([]);
+        await service.getCrossChannelHistory('persona-1', 'personality-1', 'current-channel', 50, {
+          contextEpoch: epoch,
+        });
 
-      await service.getCrossChannelHistory('persona-1', 'personality-1', 'current-channel');
+        expect(mockPrismaClient.conversationHistory.findMany).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: expect.objectContaining({
+              createdAt: { gte: epoch },
+            }),
+          })
+        );
+      });
 
-      const call = mockPrismaClient.conversationHistory.findMany.mock.calls[0][0];
-      expect(call.where).not.toHaveProperty('createdAt');
+      it('omits the time filter when neither maxAge nor contextEpoch is provided', async () => {
+        mockPrismaClient.conversationHistory.findMany.mockResolvedValue([]);
+
+        await service.getCrossChannelHistory('persona-1', 'personality-1', 'current-channel');
+
+        const call = mockPrismaClient.conversationHistory.findMany.mock.calls[0][0];
+        expect(call.where).not.toHaveProperty('createdAt');
+      });
     });
   });
 

--- a/packages/common-types/src/types/diagnostic.ts
+++ b/packages/common-types/src/types/diagnostic.ts
@@ -149,6 +149,14 @@ export interface DiagnosticTokenBudget {
   memoriesDropped: number;
   /** Number of history messages dropped due to budget */
   historyMessagesDropped: number;
+  /**
+   * Number of cross-channel messages actually included in the assembled prompt
+   * (post-token-budget trim). Surfaces a "cross-channel: N msgs" line in the
+   * diagnostic UI so a user can tell at a glance whether their crossChannel
+   * setting + maxAge interaction actually produced context. `undefined` when
+   * cross-channel was disabled for this turn.
+   */
+  crossChannelMessagesIncluded?: number;
 }
 
 /**

--- a/services/ai-worker/src/services/ContentBudgetManager.ts
+++ b/services/ai-worker/src/services/ContentBudgetManager.ts
@@ -94,6 +94,11 @@ export class ContentBudgetManager {
       memoriesDroppedCount,
       messagesDropped,
       contentForStorage,
+      // Attach whenever cross-channel was enabled this turn (groups defined,
+      // even if empty). The empty case must be surfaced — "enabled but found
+      // 0 msgs" is the silent-skip that hides bugs in the time-filter / fetch
+      // path. Disabled turns omit the field entirely (groups === undefined).
+      ...(opts.context.crossChannelHistory !== undefined ? { crossChannelMessagesIncluded } : {}),
     };
   }
 

--- a/services/ai-worker/src/services/ConversationalRAGService.ts
+++ b/services/ai-worker/src/services/ConversationalRAGService.ts
@@ -439,6 +439,7 @@ export class ConversationalRAGService {
           historyTokensUsed: budgetResult.historyTokensUsed,
           memoriesDropped: budgetResult.memoriesDroppedCount,
           historyMessagesDropped: budgetResult.messagesDropped,
+          crossChannelMessagesIncluded: budgetResult.crossChannelMessagesIncluded,
         });
       }
 

--- a/services/ai-worker/src/services/ConversationalRAGTypes.ts
+++ b/services/ai-worker/src/services/ConversationalRAGTypes.ts
@@ -223,6 +223,11 @@ export interface BudgetAllocationResult {
   memoriesDroppedCount: number;
   messagesDropped: number;
   contentForStorage: string;
+  /** How many cross-channel messages survived the token-budget trim and made
+   *  it into `serializedHistory`. Surfaced into diagnostics so users can see
+   *  whether their crossChannel + maxAge configuration produced any context.
+   *  Undefined when cross-channel was disabled for this turn. */
+  crossChannelMessagesIncluded?: number;
 }
 
 /** Result of model invocation */

--- a/services/ai-worker/src/services/DiagnosticCollector.ts
+++ b/services/ai-worker/src/services/DiagnosticCollector.ts
@@ -187,6 +187,9 @@ export class DiagnosticCollector {
       historyTokensUsed: data.historyTokensUsed,
       memoriesDropped: data.memoriesDropped,
       historyMessagesDropped: data.historyMessagesDropped,
+      ...(data.crossChannelMessagesIncluded !== undefined && {
+        crossChannelMessagesIncluded: data.crossChannelMessagesIncluded,
+      }),
     };
   }
 

--- a/services/ai-worker/src/services/diagnostics/DiagnosticTypes.ts
+++ b/services/ai-worker/src/services/diagnostics/DiagnosticTypes.ts
@@ -59,6 +59,8 @@ export interface TokenBudgetData {
   historyTokensUsed: number;
   memoriesDropped: number;
   historyMessagesDropped: number;
+  /** Optional — undefined when cross-channel was disabled for this turn. */
+  crossChannelMessagesIncluded?: number;
 }
 
 /**

--- a/services/bot-client/src/commands/inspect/views.test.ts
+++ b/services/bot-client/src/commands/inspect/views.test.ts
@@ -479,6 +479,36 @@ describe('buildTokenBudgetView', () => {
     const content = result.files![0].attachment.toString();
     expect(content).not.toContain('Dropped:');
   });
+
+  it('renders the cross-channel line when crossChannelMessagesIncluded is set', () => {
+    const payload = createMockPayload();
+    payload.tokenBudget.crossChannelMessagesIncluded = 3;
+    const result = buildTokenBudgetView(payload, 'req-123', OWNER_CTX);
+
+    const content = result.files![0].attachment.toString();
+    expect(content).toContain('Cross-channel: 3 msgs included from other channels');
+  });
+
+  it('renders "0 msgs" when cross-channel was enabled but produced no eligible messages', () => {
+    // The exact silent-skip case the diagnostic exists to surface — this test
+    // pins the empty-but-enabled visibility so a future refactor that
+    // collapses 0 to undefined re-introduces the gap loudly.
+    const payload = createMockPayload();
+    payload.tokenBudget.crossChannelMessagesIncluded = 0;
+    const result = buildTokenBudgetView(payload, 'req-123', OWNER_CTX);
+
+    const content = result.files![0].attachment.toString();
+    expect(content).toContain('Cross-channel: 0 msgs included from other channels');
+  });
+
+  it('omits the cross-channel line when the feature was disabled this turn', () => {
+    const payload = createMockPayload();
+    // crossChannelMessagesIncluded intentionally undefined
+    const result = buildTokenBudgetView(payload, 'req-123', OWNER_CTX);
+
+    const content = result.files![0].attachment.toString();
+    expect(content).not.toContain('Cross-channel:');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/services/bot-client/src/commands/inspect/views.ts
+++ b/services/bot-client/src/commands/inspect/views.ts
@@ -377,6 +377,17 @@ export function buildTokenBudgetView(
     `  ${pad('Remaining:')}${remaining.toLocaleString().padStart(8)} tokens (${remainingPct.toFixed(0).padStart(2)}%)`,
   ];
 
+  // Cross-channel disclosure: surfaces "0 cross-channel msgs" when the user
+  // has crossChannelHistory enabled but the time-filter / personality-history
+  // combination produced nothing. Without this line, the silent-skip case is
+  // indistinguishable from "feature disabled" in the embed.
+  if (tokenBudget.crossChannelMessagesIncluded !== undefined) {
+    lines.push('');
+    lines.push(
+      `Cross-channel: ${tokenBudget.crossChannelMessagesIncluded} msgs included from other channels`
+    );
+  }
+
   const dropped: string[] = [];
   if (tokenBudget.memoriesDropped > 0) {
     dropped.push(`${tokenBudget.memoriesDropped} memories`);

--- a/services/bot-client/src/services/CrossChannelHistoryFetcher.test.ts
+++ b/services/bot-client/src/services/CrossChannelHistoryFetcher.test.ts
@@ -80,12 +80,12 @@ describe('fetchCrossChannelHistory', () => {
     vi.restoreAllMocks();
   });
 
-  it('should return empty array when remainingMessageCount is zero', async () => {
+  it('should return empty array when messageBudget is zero', async () => {
     const result = await fetchCrossChannelHistory({
       personaId: 'persona-1',
       personalityId: 'personality-1',
       currentChannelId: 'channel-1',
-      remainingMessageCount: 0,
+      messageBudget: 0,
       discordClient: createMockDiscordClient(),
       conversationHistoryService: createMockConversationHistoryService(),
     });
@@ -100,7 +100,7 @@ describe('fetchCrossChannelHistory', () => {
       personaId: 'persona-1',
       personalityId: 'personality-1',
       currentChannelId: 'channel-1',
-      remainingMessageCount: 50,
+      messageBudget: 50,
       discordClient: createMockDiscordClient(),
       conversationHistoryService: service,
     });
@@ -139,7 +139,7 @@ describe('fetchCrossChannelHistory', () => {
       personaId: 'persona-1',
       personalityId: 'personality-1',
       currentChannelId: 'channel-1',
-      remainingMessageCount: 50,
+      messageBudget: 50,
       discordClient,
       conversationHistoryService: createMockConversationHistoryService(groups),
     });
@@ -178,7 +178,7 @@ describe('fetchCrossChannelHistory', () => {
       personaId: 'persona-1',
       personalityId: 'personality-1',
       currentChannelId: 'channel-1',
-      remainingMessageCount: 50,
+      messageBudget: 50,
       discordClient,
       conversationHistoryService: createMockConversationHistoryService(groups),
     });
@@ -220,7 +220,7 @@ describe('fetchCrossChannelHistory', () => {
       personaId: 'persona-1',
       personalityId: 'personality-1',
       currentChannelId: 'channel-1',
-      remainingMessageCount: 50,
+      messageBudget: 50,
       discordClient,
       conversationHistoryService: createMockConversationHistoryService(groups),
     });
@@ -245,7 +245,7 @@ describe('fetchCrossChannelHistory', () => {
       personaId: 'persona-1',
       personalityId: 'personality-1',
       currentChannelId: 'channel-1',
-      remainingMessageCount: 50,
+      messageBudget: 50,
       discordClient,
       conversationHistoryService: createMockConversationHistoryService(groups),
     });
@@ -271,7 +271,7 @@ describe('fetchCrossChannelHistory', () => {
       personaId: 'persona-1',
       personalityId: 'personality-1',
       currentChannelId: 'channel-1',
-      remainingMessageCount: 50,
+      messageBudget: 50,
       discordClient,
       conversationHistoryService: createMockConversationHistoryService(groups),
     });
@@ -298,7 +298,7 @@ describe('fetchCrossChannelHistory', () => {
       personaId: 'persona-1',
       personalityId: 'personality-1',
       currentChannelId: 'channel-1',
-      remainingMessageCount: 50,
+      messageBudget: 50,
       discordClient,
       conversationHistoryService: createMockConversationHistoryService(groups),
     });
@@ -344,7 +344,7 @@ describe('fetchCrossChannelHistory', () => {
       personaId: 'persona-1',
       personalityId: 'personality-1',
       currentChannelId: 'channel-1',
-      remainingMessageCount: 50,
+      messageBudget: 50,
       discordClient,
       conversationHistoryService: createMockConversationHistoryService(groups),
     });
@@ -382,7 +382,7 @@ describe('fetchCrossChannelHistory', () => {
       personaId: 'persona-1',
       personalityId: 'personality-1',
       currentChannelId: 'channel-1',
-      remainingMessageCount: 50,
+      messageBudget: 50,
       discordClient,
       conversationHistoryService: createMockConversationHistoryService(groups),
     });
@@ -418,7 +418,7 @@ describe('fetchCrossChannelHistory', () => {
       personaId: 'persona-1',
       personalityId: 'personality-1',
       currentChannelId: 'channel-1',
-      remainingMessageCount: 50,
+      messageBudget: 50,
       discordClient,
       conversationHistoryService: createMockConversationHistoryService(groups),
     });
@@ -457,7 +457,7 @@ describe('fetchCrossChannelHistory', () => {
       personaId: 'persona-1',
       personalityId: 'personality-1',
       currentChannelId: 'channel-1',
-      remainingMessageCount: 50,
+      messageBudget: 50,
       discordClient,
       conversationHistoryService: createMockConversationHistoryService(groups),
     });
@@ -489,9 +489,9 @@ describe('fetchCrossChannelIfEnabled', () => {
   });
 
   it('fetches cross-channel history with its own dbLimit budget regardless of current-channel size', async () => {
-    // Regression test for the residual-filler bug: prior code computed
-    // `remainingMessageCount = dbLimit - currentHistoryLength` and silently
-    // skipped cross-channel when the current channel was full. The user-reported
+    // Regression test for the residual-filler bug: prior code computed the
+    // cross-channel budget as `dbLimit - currentHistoryLength` and silently
+    // skipped when the current channel was full. The user-reported
     // symptom was zero cross-channel context after setting maxAge=48h on a
     // personality whose current thread was 5 days stale — the stale rows leaked
     // through (separate bug, fixed in getChannelHistory) and starved this fetch.
@@ -545,7 +545,12 @@ describe('fetchCrossChannelIfEnabled', () => {
     );
   });
 
-  it('should return undefined when cross-channel returns empty', async () => {
+  it('returns [] (NOT undefined) when enabled but the DB returned no eligible messages', async () => {
+    // Distinguishing []-when-enabled from undefined-when-disabled is what
+    // lets the diagnostic surface render "Cross-channel: 0 msgs" — the
+    // silent-skip case where a context bug (wrong filter, fetch failure)
+    // would otherwise be invisible. Collapsing both to undefined re-creates
+    // the gap.
     const result = await fetchCrossChannelIfEnabled({
       enabled: true,
       channelId: 'channel-1',
@@ -555,7 +560,7 @@ describe('fetchCrossChannelIfEnabled', () => {
       discordClient: createMockDiscordClient(),
       conversationHistoryService: createMockConversationHistoryService([]),
     });
-    expect(result).toBeUndefined();
+    expect(result).toEqual([]);
   });
 });
 

--- a/services/bot-client/src/services/CrossChannelHistoryFetcher.ts
+++ b/services/bot-client/src/services/CrossChannelHistoryFetcher.ts
@@ -30,7 +30,7 @@ interface FetchOptions {
   personalityId: string;
   currentChannelId: string;
   /** Maximum number of messages to fetch across all channels (DB row limit, not token budget) */
-  remainingMessageCount: number;
+  messageBudget: number;
   discordClient: Client;
   conversationHistoryService: ConversationHistoryService;
   /** Max-age cutoff in SECONDS, mirroring the current-channel filter. */
@@ -173,12 +173,12 @@ export async function fetchCrossChannelHistory(
     personaId,
     personalityId,
     currentChannelId,
-    remainingMessageCount,
+    messageBudget,
     discordClient,
     conversationHistoryService,
   } = opts;
 
-  if (remainingMessageCount <= 0) {
+  if (messageBudget <= 0) {
     return [];
   }
 
@@ -186,7 +186,7 @@ export async function fetchCrossChannelHistory(
     personaId,
     personalityId,
     currentChannelId,
-    remainingMessageCount,
+    messageBudget,
     { maxAgeSeconds: opts.maxAge, contextEpoch: opts.contextEpoch }
   );
 
@@ -254,18 +254,24 @@ export async function fetchCrossChannelIfEnabled(opts: {
     return undefined;
   }
 
-  const groups = await fetchCrossChannelHistory({
+  // Return value distinguishes three states for downstream consumers
+  // (notably the diagnostic surface):
+  //   undefined → feature disabled this turn
+  //   []        → feature enabled, fetch ran, no eligible messages
+  //   [...]     → feature enabled, found N messages
+  // Collapsing []-when-enabled to undefined would hide the silent-skip case
+  // where the user enabled cross-channel but the time-filter / fetch path
+  // produced nothing — bugs in either are invisible without it.
+  return fetchCrossChannelHistory({
     personaId: opts.personaId,
     personalityId: opts.personalityId,
     currentChannelId: opts.channelId,
-    remainingMessageCount: opts.dbLimit,
+    messageBudget: opts.dbLimit,
     discordClient: opts.discordClient,
     conversationHistoryService: opts.conversationHistoryService,
     maxAge: opts.maxAge,
     contextEpoch: opts.contextEpoch,
   });
-
-  return groups.length > 0 ? groups : undefined;
 }
 
 /**

--- a/services/bot-client/src/services/DiscordChannelFetcher.ts
+++ b/services/bot-client/src/services/DiscordChannelFetcher.ts
@@ -11,6 +11,7 @@ import {
   MessageRole,
   MESSAGE_LIMITS,
   ConversationSyncService,
+  computeHistoryCutoff,
 } from '@tzurot/common-types';
 import { INTERNAL_DISCORD_ID_PREFIX } from '../constants/personaId.js';
 import type {
@@ -171,7 +172,7 @@ export class DiscordChannelFetcher {
   /**
    * Process and filter Discord messages
    */
-  // eslint-disable-next-line complexity, max-lines-per-function, max-statements, sonarjs/cognitive-complexity -- Cohesive message processing pipeline with sequential filters, voice transcript fallback, and participant collection
+  // eslint-disable-next-line complexity, max-lines-per-function, sonarjs/cognitive-complexity -- Cohesive message processing pipeline with sequential filters, voice transcript fallback, and participant collection
   private async processMessages(
     messages: Message[],
     options: FetchOptions,
@@ -232,6 +233,12 @@ export class DiscordChannelFetcher {
     // Sort by timestamp ascending (oldest first)
     const sortedMessages = [...messages].sort((a, b) => a.createdTimestamp - b.createdTimestamp);
 
+    // Single source of truth for the time-cutoff semantic, shared with the
+    // Prisma queries in ConversationHistoryService. Computed once outside the
+    // loop so a 200-message extended context doesn't re-compute Date.now() per
+    // iteration. `null` maxAge collapses to undefined (no filter).
+    const historyCutoff = computeHistoryCutoff(options.maxAge, options.contextEpoch);
+
     for (const msg of sortedMessages) {
       // Apply filters
       if (!isUserContentMessage(msg)) {
@@ -250,14 +257,8 @@ export class DiscordChannelFetcher {
       if (options.isBlockDenied?.(msg.author.id) === true) {
         continue;
       }
-      if (options.contextEpoch !== undefined && msg.createdAt < options.contextEpoch) {
+      if (historyCutoff !== undefined && msg.createdAt < historyCutoff) {
         continue;
-      }
-      if (options.maxAge !== undefined && options.maxAge !== null) {
-        const cutoffTime = new Date(Date.now() - options.maxAge * 1000);
-        if (msg.createdAt < cutoffTime) {
-          continue;
-        }
       }
 
       // Convert to ConversationMessage


### PR DESCRIPTION
## Summary

Follow-up to **PR #1011** (cross-channel maxAge bug fix). Addresses two architectural concerns surfaced during that PR's review + two reviewer items.

### Concern #1 — DRY consolidation

The "messages older than X seconds are excluded" semantic now lives in three filter sites: `DiscordChannelFetcher` (post-fetch loop), `getChannelHistory` (Prisma where), `getCrossChannelHistory` (Prisma where). PR #1011 added the shared `computeHistoryCutoff` helper but only wired the two Prisma callers. This PR completes the consolidation — `DiscordChannelFetcher` now consumes the helper too.

The cutoff is computed once outside the loop (a 200-message extended-context fetch was re-computing `Date.now()` per iteration before).

### Slice of concern #4 — diagnostic surface

When PR #1011's bug fired, the LLM Diagnostic Summary was completely silent about cross-channel context — there was no way to tell whether the fetch ran and returned 0 vs. didn't run at all. This PR adds `crossChannelMessagesIncluded` to the `TokenBudgetData` payload, plumbs it from `ContentBudgetManager` through `DiagnosticCollector`, and renders it as `"Cross-channel: N msgs included from other channels"` in the Token Budget breakdown when the feature was enabled for the turn.

A future user who hits a similar context-flow bug can self-diagnose from the embed instead of needing a code-trace.

### Reviewer items from PR #1011 round 1

- **Medium**: `ConversationHistoryService.test.ts` maxAge tests now use fake timers per `02-code-standards.md` (was wall-clock with 1-second tolerance window). Cutoff assertions collapsed to deterministic `toEqual`.
- **Nit**: `FetchOptions.remainingMessageCount` renamed to `messageBudget`. The post-fix code passes the full `dbLimit` (not a pre-subtracted residual), so the old name was misleading.

## Out of scope

The other architectural concerns from PR #1011 are filed in `backlog/inbox.md` and not addressed here:
- Audit budget-allocation sites for residual-vs-additive design (research-shape)
- Off-vs-inherit cascade semantics (touches every cascade resolver — needs design pass)
- Pipeline-wide diagnostic surface (this PR is a slice — full pipeline coverage is a separate epic)

## Test plan

- [x] `pnpm test` — all packages green
- [x] `pnpm test:int` — 308 integration tests pass
- [x] `pnpm quality` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)