### PR TITLE
fix(ai-worker): logAllocation surfaces 0 cross-channel msgs when enabled

### DIFF
--- a/services/ai-worker/src/services/ContentBudgetManager.ts
+++ b/services/ai-worker/src/services/ContentBudgetManager.ts
@@ -82,7 +82,8 @@ export class ContentBudgetManager {
       historyBudget,
       historyTokensUsed,
       messagesDropped,
-      crossChannelMessagesIncluded,
+      crossChannelMessagesIncluded:
+        opts.context.crossChannelHistory !== undefined ? crossChannelMessagesIncluded : undefined,
     });
 
     return {
@@ -278,7 +279,10 @@ export class ContentBudgetManager {
     historyBudget: number;
     historyTokensUsed: number;
     messagesDropped: number;
-    crossChannelMessagesIncluded: number;
+    /** Undefined when cross-channel was disabled this turn; 0 when enabled but
+     *  no eligible messages (still logged so a "why are my logs showing 0?"
+     *  debugging session sees the silent-skip case explicitly). */
+    crossChannelMessagesIncluded: number | undefined;
   }): void {
     const {
       contextWindowTokens,
@@ -300,8 +304,7 @@ export class ContentBudgetManager {
         memoryTokensTotal: this.countMemoryTokensSafe(retrievedMemories),
         historyBudget,
         historyTokensUsed,
-        crossChannelMessagesIncluded:
-          crossChannelMessagesIncluded > 0 ? crossChannelMessagesIncluded : undefined,
+        crossChannelMessagesIncluded,
       },
       'Token allocation'
     );


### PR DESCRIPTION
## Summary

Reviewer follow-up from PR #1012 (post-autosquash review). 5-LOC log consistency fix.

`ContentBudgetManager.logAllocation` was filtering `crossChannelMessagesIncluded` with `> 0 ? value : undefined`, suppressing the "enabled but found 0 msgs" case from logs. Every other layer in the chain (the allocate spread, DiagnosticCollector, views) preserves it precisely because the silent-skip case is the diagnostic signal that hid the original PR #1011 bug. The log was the one inconsistent place.

A developer debugging a "why am I getting 0 cross-channel context" incident from server logs would see nothing where they'd expect a `0`.

**Fix**: thread `opts.context.crossChannelHistory !== undefined` to `logAllocation` as the discriminant (mirrors the allocate-side spread). Disabled turns omit the field; enabled turns log the count including `0`.

## Test plan

- [x] `pnpm --filter ai-worker test src/services/ContentBudgetManager.test.ts` — 15 tests pass
- [x] No new tests needed — existing tests don't assert on log shape, and the behavior change is observable only in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)