### PR TITLE
fix(ai-worker): Mistral STT model ID was always invalid (the actual reason Mistral seemed identical to self-hosted)

### DIFF
--- a/services/ai-worker/src/services/voice/MistralSttClient.test.ts
+++ b/services/ai-worker/src/services/voice/MistralSttClient.test.ts
@@ -73,17 +73,20 @@ describe('mistralTranscribeAudio', () => {
 
     const init = mockFetch.mock.calls[0][1];
     const body = init.body as FormData;
-    expect(body.get('model')).toBe('voxtral-mini-transcribe-latest');
+    expect(body.get('model')).toBe('voxtral-mini-latest');
   });
 
   it('respects an explicit modelId override', async () => {
     mockFetch.mockResolvedValue(jsonResponse(200, { text: 'ok' }));
 
-    await mistralTranscribeAudio({ ...baseOpts, modelId: 'voxtral-mini-transcribe-2507' });
+    // Pinned dated model ID for the dedicated transcription endpoint
+    // (*-latest aliases live on the broader voxtral-mini family;
+    // voxtral-mini-transcribe-* only ships dated IDs).
+    await mistralTranscribeAudio({ ...baseOpts, modelId: 'voxtral-mini-transcribe-26-02' });
 
     const init = mockFetch.mock.calls[0][1];
     const body = init.body as FormData;
-    expect(body.get('model')).toBe('voxtral-mini-transcribe-2507');
+    expect(body.get('model')).toBe('voxtral-mini-transcribe-26-02');
   });
 
   it('throws MistralSttApiError on a 401 with body forwarded', async () => {

--- a/services/ai-worker/src/services/voice/MistralSttClient.ts
+++ b/services/ai-worker/src/services/voice/MistralSttClient.ts
@@ -34,13 +34,17 @@ const BASE_URL = AI_ENDPOINTS.MISTRAL_BASE_URL;
 const MISTRAL_STT_TIMEOUT_MS = 60_000;
 
 /**
- * Default Mistral STT model alias. Following the TTS pattern of using
- * `*-latest` rather than a pinned version (e.g., `voxtral-mini-transcribe-2507`)
- * so we automatically pick up Mistral's published improvements without
- * a code change. Mistral has historically broken `*-latest` aliases on
- * occasion — backlog item filed for startup-time canary monitoring.
+ * Default Mistral STT model alias. `voxtral-mini-latest` is the only
+ * `*-latest` alias Mistral publishes for Voxtral; the `voxtral-mini-transcribe-*`
+ * family only ships pinned dated IDs (e.g., `voxtral-mini-transcribe-26-02`).
+ * Picking the alias keeps us on Mistral's "current best" without code changes.
+ *
+ * Backlog item filed for startup-time canary monitoring — Mistral has
+ * historically broken `*-latest` aliases on occasion; without monitoring,
+ * those failures are silently absorbed by the voice-engine fallback path
+ * and become invisible to operators.
  */
-const DEFAULT_MISTRAL_STT_MODEL = 'voxtral-mini-transcribe-latest';
+const DEFAULT_MISTRAL_STT_MODEL = 'voxtral-mini-latest';
 
 // ============================================================================
 // Public types
@@ -54,7 +58,7 @@ export interface MistralSTTOptions {
   filename: string;
   contentType: string;
   apiKey: string;
-  /** Model override. Defaults to `voxtral-mini-transcribe-latest`. */
+  /** Model override. Defaults to `voxtral-mini-latest`. */
   modelId?: string;
 }
 


### PR DESCRIPTION
## Summary

Production logs from Railway dev showed **every Mistral STT request since the feature shipped** returning the same HTTP 400:

```
{"object":"error","message":"Invalid model: voxtral-mini-transcribe-latest","type":"invalid_model","code":"1500"}
```

The hardcoded default model ID `voxtral-mini-transcribe-latest` does not exist in Mistral's catalog. **Every transcription was silently falling through to voice-engine.** The silent-fallback completely masked this from the user — that's why the symptom was "Mistral seems to have identical results to our self-hosted TTS." Mistral was never producing any output.

## Fix

Per Mistral's docs ([capabilities/audio](https://docs.mistral.ai/capabilities/audio/), [models overview](https://docs.mistral.ai/getting-started/models/models_overview/)):

- The correct `*-latest` alias for Voxtral transcription is **`voxtral-mini-latest`**
- The `voxtral-mini-transcribe-*` family only ships pinned dated IDs (e.g., `voxtral-mini-transcribe-26-02`); no `*-latest` alias exists for that variant

Two-line code change:
- `DEFAULT_MISTRAL_STT_MODEL = 'voxtral-mini-transcribe-latest'` → `'voxtral-mini-latest'`
- Test override case updated to use a valid pinned ID (`voxtral-mini-transcribe-26-02`) instead of the never-valid `voxtral-mini-transcribe-2507`

## Companion PR

[PR #1014](https://github.com/lbds137/tzurot/pull/1014) fixes the *misattribution* that hid this bug (the clickable badge said "Mistral" over voice-engine output). #1014 closes the diagnostic gap so future bugs of this class are visible. **This PR makes the specific feature actually produce Mistral output.** Both should ship — they're independent fixes for the same observable symptom.

Discovery sequence:
1. User: "Mistral STT seems to have identical results to our self-hosted TTS"
2. Investigation found `provider: sttOpts.provider` (requested) vs actual provider — opened #1014 for the attribution lie
3. While #1014 was in CI, user asked to verify in dev logs
4. Logs showed 100% Mistral failure rate with the same invalid-model error → this PR

Without #1014's attribution fix, this bug could recur silently after the next Mistral catalog change. Without this PR, #1014 just makes the silence visible without curing it.

## Test plan

- [x] `pnpm --filter ai-worker test src/services/voice/MistralSttClient.test.ts` — 11 tests pass
- [x] `pnpm quality` — green
- [ ] Post-merge: confirm in dev logs that next Mistral STT request returns 200 + transcript instead of 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)