### PR TITLE
chore: post-beta.120 quick-wins warmup (3 small fixes)

### DIFF
--- a/packages/common-types/src/types/sttProvider.ts
+++ b/packages/common-types/src/types/sttProvider.ts
@@ -12,9 +12,11 @@
  * the self-hosted free-tier backend that needs no key and is the
  * cascade's hardcoded fallback.
  *
- * Stable contract: these strings are persisted in `users.default_provider`,
- * `users.default_stt_provider_id`, and `user_personality_configs.stt_provider_id`.
- * Renaming any of them is a database migration.
+ * Stable contract: these strings are persisted in
+ * `users.default_stt_provider_id` (the surviving column after the cascade
+ * simplification migration). Renaming any of them is a database migration
+ * — and any new value added here also needs a companion ALTER on the
+ * `valid_default_stt_provider_id` CHECK constraint.
  */
 export type SttProvider = 'mistral' | 'elevenlabs' | 'voice-engine';
 

--- a/prisma/migrations/20260510202611_add_stt_provider_check_constraint/migration.sql
+++ b/prisma/migrations/20260510202611_add_stt_provider_check_constraint/migration.sql
@@ -4,6 +4,10 @@
 -- admin scripts, future migrations). Application-side narrowing via
 -- isSttProvider() already handles unknown values at every read site, but a
 -- DB-level check fails fast at the write boundary.
+--
+-- Companion to STT_PROVIDERS in packages/common-types/src/types/sttProvider.ts:
+-- adding a new provider there requires a companion migration here to extend
+-- the CHECK list (DROP CONSTRAINT + ADD CONSTRAINT with the new value).
 
 ALTER TABLE "users"
   ADD CONSTRAINT "valid_default_stt_provider_id"

--- a/services/bot-client/src/commands/voice/index.test.ts
+++ b/services/bot-client/src/commands/voice/index.test.ts
@@ -216,7 +216,7 @@ describe('Voice Command', () => {
   describe('handleButton', () => {
     it('routes voice-browse customIds to handleVoiceBrowsePagination', async () => {
       vi.mocked(isVoiceBrowseInteraction).mockReturnValue(true);
-      const interaction = { customId: 'settings-voices::browse::all::1' };
+      const interaction = { customId: 'voice-voices::browse::all::1' };
       await handleButton!(interaction as any);
       expect(handleVoiceBrowsePagination).toHaveBeenCalledOnce();
     });

--- a/services/bot-client/src/commands/voice/index.ts
+++ b/services/bot-client/src/commands/voice/index.ts
@@ -210,4 +210,5 @@ export default defineCommand({
   handleButton,
   handleModal,
   handleSelectMenu,
+  componentPrefixes: ['voice-voices'],
 });

--- a/services/bot-client/src/commands/voice/voices/browse.test.ts
+++ b/services/bot-client/src/commands/voice/voices/browse.test.ts
@@ -281,8 +281,8 @@ describe('handleBrowseVoices', () => {
 
 describe('isVoiceBrowseInteraction', () => {
   it('should match voice browse pagination custom IDs', () => {
-    expect(isVoiceBrowseInteraction('settings-voices::browse::0::all::')).toBe(true);
-    expect(isVoiceBrowseInteraction('settings-voices::browse::1::all::')).toBe(true);
+    expect(isVoiceBrowseInteraction('voice-voices::browse::0::all::')).toBe(true);
+    expect(isVoiceBrowseInteraction('voice-voices::browse::1::all::')).toBe(true);
   });
 
   it('should not match unrelated custom IDs', () => {
@@ -321,7 +321,7 @@ describe('handleVoiceBrowsePagination', () => {
 
     // Click "next" to go to page 1
     await handleVoiceBrowsePagination(
-      createMockButtonInteraction('settings-voices::browse::1::all::')
+      createMockButtonInteraction('voice-voices::browse::1::all::')
     );
 
     expect(mockDeferUpdate).toHaveBeenCalled();
@@ -356,7 +356,7 @@ describe('handleVoiceBrowsePagination', () => {
     });
 
     await handleVoiceBrowsePagination(
-      createMockButtonInteraction('settings-voices::browse::1::all::')
+      createMockButtonInteraction('voice-voices::browse::1::all::')
     );
 
     expect(mockDeferUpdate).toHaveBeenCalled();
@@ -371,7 +371,7 @@ describe('handleVoiceBrowsePagination', () => {
     mockCallGatewayApi.mockRejectedValue(new Error('Network error'));
 
     await handleVoiceBrowsePagination(
-      createMockButtonInteraction('settings-voices::browse::1::all::')
+      createMockButtonInteraction('voice-voices::browse::1::all::')
     );
 
     expect(mockDeferUpdate).toHaveBeenCalled();

--- a/services/bot-client/src/commands/voice/voices/browse.ts
+++ b/services/bot-client/src/commands/voice/voices/browse.ts
@@ -37,7 +37,7 @@ const logger = createLogger('voice-voices-browse');
 type VoiceBrowseFilter = 'all';
 
 const browseHelpers = createBrowseCustomIdHelpers<VoiceBrowseFilter>({
-  prefix: 'settings-voices',
+  prefix: 'voice-voices',
   validFilters: ['all'] as const,
   includeSort: false,
 });

--- a/services/bot-client/src/handlers/CommandHandler.int.test.ts
+++ b/services/bot-client/src/handlers/CommandHandler.int.test.ts
@@ -367,6 +367,7 @@ describe('CommandHandler (component)', () => {
           'settings', // Settings command - consolidates timezone, apikey, preset
           'shapes', // Shapes command - import/export from shapes.inc
           'voice', // Voice command - TTS provider config + cloned-voice lifecycle
+          'voice-voices', // Voice voices browse pagination (componentPrefixes alt)
         ])
       );
     });

--- a/services/bot-client/src/utils/GatewayClient.ts
+++ b/services/bot-client/src/utils/GatewayClient.ts
@@ -27,7 +27,7 @@ const config = getConfig();
  * listener isn't bound yet, so undici closes the socket. Safe to retry.
  */
 const TRANSIENT_NETWORK_CODES = new Set(['UND_ERR_SOCKET', 'ECONNRESET', 'ECONNREFUSED']);
-const TRANSCRIBE_RETRY_ATTEMPTS = 3;
+const TRANSCRIBE_MAX_ATTEMPTS = 3;
 const TRANSCRIBE_RETRY_BASE_DELAY_MS = 500;
 
 function isTransientNetworkError(err: unknown): boolean {
@@ -39,7 +39,7 @@ function isTransientNetworkError(err: unknown): boolean {
 }
 
 async function retryTranscribeOnTransientNetworkError<T>(fn: () => Promise<T>): Promise<T> {
-  for (let attempt = 1; attempt < TRANSCRIBE_RETRY_ATTEMPTS; attempt++) {
+  for (let attempt = 1; attempt < TRANSCRIBE_MAX_ATTEMPTS; attempt++) {
     try {
       return await fn();
     } catch (err) {


### PR DESCRIPTION
## Summary

Three mechanical fixes carried forward from PR #1022 reviewer items and prior backlog. Warmup pass before diving into TTS Phase 2 (NeuTTS Air).

1. **`sttProvider.ts` JSDoc** — drop the 2 columns deleted in migration #1007 (`users.default_provider`, `user_personality_configs.stt_provider_id`). Only `users.default_stt_provider_id` survives. Folds in the CHECK constraint cross-reference so the next contributor adding a 4th STT provider finds both touch-points.

2. **`TRANSCRIBE_RETRY_ATTEMPTS` → `TRANSCRIBE_MAX_ATTEMPTS`** in `GatewayClient.ts`. Reviewer point on #1022: the conventional "total call count" naming makes the loop arithmetic self-documenting.

3. **`settings-voices` → `voice-voices`** customId prefix for voice browse pagination. Last cleanup from #1003's namespace consolidation; #1021 already removed the deprecation stubs that justified preserving the legacy prefix.

## Test plan
- [x] `pnpm test` — all 14 packages pass
- [x] `pnpm quality` — clean
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)