### PR TITLE
feat(voice-engine): bump pocket-tts 1.1.1 → 2.1.0 (better voice cloning)

### DIFF
--- a/services/voice-engine/requirements.txt
+++ b/services/voice-engine/requirements.txt
@@ -6,6 +6,11 @@ python-multipart>=0.0.18,<1.0.0
 # Audio processing
 scipy>=1.14.0,<2.0.0
 librosa>=0.10.2,<0.11.0
+# soundfile is required by pocket-tts>=2.0 for reading reference audio in
+# formats libsndfile supports (ogg, flac, aiff, wav, etc); without it,
+# pocket-tts raises ImportError. MP3 reference audio continues to go through
+# librosa/ffmpeg as before — soundfile/libsndfile does not decode MP3.
+soundfile>=0.12.0,<1.0.0
 # numpy 2.x required by pocket-tts>=1.1.0; nemo_toolkit 2.1+ targets numpy 2.x
 numpy>=2.0,<3.0
 
@@ -13,7 +18,10 @@ numpy>=2.0,<3.0
 nemo_toolkit[asr]>=2.1.0,<3.0.0
 
 # TTS: Pocket TTS (MIT license)
-pocket-tts>=1.1.0,<2.0.0
+# v2.0+ ships english_2026-04 model with materially better voice cloning vs
+# the older english_2026-01. Default with no language arg is english_2026-04.
+# 2.0.x bound excluded — defensive against future quantize=True usage (broken in 2.0.x, fixed in 2.1.0).
+pocket-tts>=2.1.0,<3.0.0
 
 # PyTorch CPU-only — installed separately in Dockerfile with --index-url
 # to guarantee CPU wheels. Do NOT add torch/torchaudio here; --extra-index-url

--- a/services/voice-engine/server.py
+++ b/services/voice-engine/server.py
@@ -281,7 +281,10 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 
     # --- Load TTS model ---
     logger.info("Loading Kyutai Pocket TTS")
-    tts_model: Any = TTSModel.load_model()
+    # Explicit "english" alias (= english_2026-04) — the default in pocket-tts 2.1+
+    # but pinned here so a future package version that changes the default doesn't
+    # silently shift our voice quality.
+    tts_model: Any = TTSModel.load_model(language="english")
     models["tts"] = tts_model
     logger.info("Pocket TTS loaded", extra={"sample_rate": tts_model.sample_rate})
 

--- a/services/voice-engine/tests/test_lifespan.py
+++ b/services/voice-engine/tests/test_lifespan.py
@@ -1,0 +1,54 @@
+"""Tests for the FastAPI lifespan startup hook.
+
+Verifies model loading wires up with the expected arguments. Heavy ML models
+are mocked at sys.modules level via conftest, so this test exercises the
+real lifespan contract without loading real weights.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, call
+
+import pytest
+from nemo.collections.asr import models as nemo_asr_models
+from pocket_tts import TTSModel
+
+import server
+
+
+@pytest.mark.asyncio
+async def test_lifespan_loads_tts_with_english_language(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Lifespan must call TTSModel.load_model with language='english'.
+
+    Pinning the language argument explicitly is load-bearing — pocket-tts 2.0+
+    defaults to english_2026-04, but a future package version could rotate the
+    default and silently shift our voice quality.
+    """
+    # Mock TTSModel.load_model so we can capture the call arguments.
+    # MagicMock keyword captures live in `mock.call_args.kwargs`.
+    tts_load_mock = MagicMock(name="TTSModel.load_model")
+    fake_tts_instance: Any = MagicMock(name="TTSModel")
+    fake_tts_instance.sample_rate = 24000
+    tts_load_mock.return_value = fake_tts_instance
+
+    monkeypatch.setattr(TTSModel, "load_model", tts_load_mock)
+
+    # Mock ASRModel.from_pretrained too so lifespan doesn't try to download
+    fake_asr: Any = MagicMock(name="ASRModel")
+    monkeypatch.setattr(nemo_asr_models.ASRModel, "from_pretrained", MagicMock(return_value=fake_asr))
+
+    # Drive lifespan through startup
+    async with server.lifespan(server.app):
+        assert "tts" in server.models
+        assert "asr" in server.models
+
+    # Lifespan shutdown clears the model registry — guards against a regression
+    # if `models.clear()` is ever removed from the cleanup block.
+    assert not server.models, "lifespan shutdown should clear models dict"
+
+    # Assert the language pin. Using `call(language=...)` (not `kwargs.get(...)`)
+    # so a future edit that switches to a positional arg `load_model("english")`
+    # would also fail — kwargs path would be empty in that case and silently pass.
+    assert tts_load_mock.call_count == 1, "TTSModel.load_model should be called exactly once"
+    assert tts_load_mock.call_args == call(language="english")


### PR DESCRIPTION
## Summary

- Bumps \`pocket-tts\` to 2.1.0 (from 1.1.1) which ships the \`english_2026-04\` model — notable improvement in voice cloning vs the older \`english_2026-01\` we'd been using
- Pins \`language=\"english\"\` explicitly in \`load_model()\` so a future package default change can't silently shift our voice quality
- Adds \`soundfile\` dep — pocket-tts 2.0+ requires it for non-WAV reference audio (mp3, ogg) and otherwise raises ImportError

## Probe results (2026-05-14, dev voice-engine)

Tested on Sapphire Rapids 8581C with two reference voices:
- **Emily** (Hazbin Hotel YouTube clip)
- **Ha-Shem** (Matrix oracle clip)

User listening verdict on \`english_2026-04\` vs \`english_2026-01\` baseline:
> definitely better. Emily isn't perfect but I could probably get a ref with less pitch variation that would behave better. I'd like to go with v2.1 plus the improved English model

Generation RTF unchanged (~0.5-0.6 for both models). No speed regression.

## Deferred

\`quantize=True\` (docstring claims ~48% memory reduction + ~27% speed via FBGEMM) — probed but speed result didn't match the docstring (saw +6-16% slower instead). Memory measurement was confounded by Python allocator behavior. Filed as a follow-up if Railway memory cost becomes a real concern.

## Test plan

- [x] All 55 voice-engine tests pass locally
- [ ] CI green (will arm Monitor after push)
- [ ] After merge: Railway auto-deploys to dev; manual smoke test by hitting any character on dev to verify TTS still works end-to-end
- [ ] No DB migration in this change — purely a dep + code update

🤖 Generated with [Claude Code](https://claude.com/claude-code)