### PR TITLE
chore(repo): raise jscpd minLines from 5 to 10

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -19,7 +19,7 @@
     "reports/**"
   ],
   "format": ["typescript"],
-  "minLines": 5,
+  "minLines": 10,
   "minTokens": 50,
   "gitignore": true,
   "absolute": true,


### PR DESCRIPTION
## Summary

Bumps `.jscpd.json` `minLines` from 5 → 10. Measurement-correction PR ahead of the broader CPD-reduction sweep — no code refactored.

## Why

At `minLines: 5, minTokens: 50`, jscpd flagged structural boilerplate (try/catch shells, `SlashCommandBuilder` chains, basic Express handler shapes) alongside genuine business-logic duplication. Driving the count to zero under that config would force premature abstraction over idiomatic 5-9 line patterns that read past like whitespace.

`minLines: 10` isolates clones that represent actual duplicated logic. The remaining 107 clones cluster exactly where we'd expect from the TTS/STT regression — `api-gateway/routes` (34) and `bot-client/commands` (32) — making the next sweep PR's target list clean.

## Measured impact

|                  | minLines=5 | minLines=10 | Δ        |
| ---------------- | ---------- | ----------- | -------- |
| Clones           | 178        | 107         | -71      |
| Duplicated lines | 2153       | 1604        | -549     |
| Duplication %    | 1.44       | 1.07        | -0.37pp  |

Top remaining offenders confirm the templated-CRUD-route hypothesis from the TTS/STT epic:

- `user/tts-override.ts` (5 clones)
- `admin/llm-config.ts` (5)
- `user/model-override.ts` (4)
- `user/llm-config.ts` (3)

Composable Express middleware (`validateBody`, `handlePrismaErrors`, `publishInvalidation`) is the planned attack vector for the next PR, not a generic `createConfigCrudRoutes` factory.

## Context

This is the first of a multi-PR campaign to drive `pnpm cpd` toward "meaningful zero" (business-logic clones at minLines=10) and then enforce via a differential CI gate. Approach validated against three council reviewers (Gemini 3.1 Pro, GLM 5.1, Kimi K2.6) — they converged on "raise the threshold first; don't chase zero at minLines=5."

## Test plan

- [x] `pnpm cpd` runs cleanly at new threshold (107 clones reported)
- [x] No code paths changed; config-only diff
- [ ] CI green (lint/typecheck/tests should all be unaffected by jscpd config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)