### PR TITLE
refactor(api-gateway): apply config-route helpers to user/{llm,tts}-config

### DIFF
--- a/services/api-gateway/src/routes/user/llm-config.ts
+++ b/services/api-gateway/src/routes/user/llm-config.ts
@@ -30,9 +30,13 @@ import { asyncHandler } from '../../utils/asyncHandler.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
-import { sendZodError } from '../../utils/zodHelpers.js';
 import { isPrismaUniqueConstraintError } from '../../utils/prismaErrors.js';
 import { getRequiredParam } from '../../utils/requestParams.js';
+import {
+  parseBodyOrSendError,
+  findConfigOrSendNotFound,
+  ensureNoNameCollision,
+} from '../../utils/configRouteHelpers.js';
 import type { ProvisionedRequest } from '../../types.js';
 import {
   LlmConfigService,
@@ -96,10 +100,13 @@ function createGetHandler(service: LlmConfigService, modelCache?: OpenRouterMode
     const discordUserId = req.userId;
     const configId = getRequiredParam(req.params.id, 'id');
 
-    // Use service to get config
-    const config = await service.getById(configId);
+    const config = await findConfigOrSendNotFound(
+      res,
+      () => service.getById(configId),
+      CONFIG_RESOURCE
+    );
     if (config === null) {
-      return sendError(res, ErrorResponses.notFound(CONFIG_RESOURCE));
+      return;
     }
 
     const userId = resolveProvisionedUserId(req);
@@ -127,12 +134,10 @@ function createCreateHandler(service: LlmConfigService, modelCache?: OpenRouterM
   return async (req: ProvisionedRequest, res: Response) => {
     const discordUserId = req.userId;
 
-    // Validate request body with shared Zod schema from common-types
-    const parseResult = LlmConfigCreateSchema.safeParse(req.body);
-    if (!parseResult.success) {
-      return sendZodError(res, parseResult.error);
+    const body = parseBodyOrSendError(res, LlmConfigCreateSchema, req.body);
+    if (body === null) {
+      return;
     }
-    const body = parseResult.data;
 
     if (!(await validateLlmConfigModelFields({ res, modelCache, body }))) {
       return;
@@ -144,18 +149,15 @@ function createCreateHandler(service: LlmConfigService, modelCache?: OpenRouterM
     // autoSuffixOnCollision (the preset clone flow): the service will bump
     // the (Copy N) suffix server-side until it finds a free slot. For
     // regular creates, strict name-uniqueness still surfaces as an error.
-    if (body.autoSuffixOnCollision !== true) {
-      const nameCheck = await service.checkNameExists(body.name, {
-        type: 'USER',
-        userId,
-        discordId: discordUserId,
-      });
-      if (nameCheck.exists) {
-        return sendError(
-          res,
-          ErrorResponses.nameCollision(`You already have a config named "${body.name}"`)
-        );
-      }
+    if (
+      body.autoSuffixOnCollision !== true &&
+      !(await ensureNoNameCollision(res, service, {
+        name: body.name,
+        scope: { type: 'USER', userId, discordId: discordUserId },
+        formatCollisionMessage: n => `You already have a config named "${n}"`,
+      }))
+    ) {
+      return;
     }
 
     // Create config using service. Three collision paths to translate:
@@ -247,12 +249,10 @@ function createUpdateHandler(service: LlmConfigService, modelCache?: OpenRouterM
     const discordUserId = req.userId;
     const configId = getRequiredParam(req.params.id, 'id');
 
-    // Validate request body with shared Zod schema from common-types
-    const parseResult = LlmConfigUpdateSchema.safeParse(req.body);
-    if (!parseResult.success) {
-      return sendZodError(res, parseResult.error);
+    const body = parseBodyOrSendError(res, LlmConfigUpdateSchema, req.body);
+    if (body === null) {
+      return;
     }
-    const body = parseResult.data;
 
     if (
       !(await validateLlmConfigModelFields({
@@ -267,10 +267,13 @@ function createUpdateHandler(service: LlmConfigService, modelCache?: OpenRouterM
 
     const userId = resolveProvisionedUserId(req);
 
-    // Get existing config using service
-    const config = await service.getById(configId);
+    const config = await findConfigOrSendNotFound(
+      res,
+      () => service.getById(configId),
+      CONFIG_RESOURCE
+    );
     if (config === null) {
-      return sendError(res, ErrorResponses.notFound(CONFIG_RESOURCE));
+      return;
     }
 
     // Permission gate. computeLlmConfigPermissions grants canEdit to creator
@@ -387,10 +390,13 @@ function createDeleteHandler(service: LlmConfigService) {
 
     const userId = resolveProvisionedUserId(req);
 
-    // Get config using service
-    const config = await service.getById(configId);
+    const config = await findConfigOrSendNotFound(
+      res,
+      () => service.getById(configId),
+      CONFIG_RESOURCE
+    );
     if (config === null) {
-      return sendError(res, ErrorResponses.notFound(CONFIG_RESOURCE));
+      return;
     }
 
     // Use centralized permission computation for consistency

--- a/services/api-gateway/src/routes/user/tts-config.ts
+++ b/services/api-gateway/src/routes/user/tts-config.ts
@@ -39,9 +39,13 @@ import { asyncHandler } from '../../utils/asyncHandler.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
-import { sendZodError } from '../../utils/zodHelpers.js';
 import { isPrismaUniqueConstraintError } from '../../utils/prismaErrors.js';
 import { getRequiredParam } from '../../utils/requestParams.js';
+import {
+  parseBodyOrSendError,
+  findConfigOrSendNotFound,
+  ensureNoNameCollision,
+} from '../../utils/configRouteHelpers.js';
 import {
   buildCollisionMessage,
   computeNameForPromotion,
@@ -101,9 +105,13 @@ function createGetHandler(service: TtsConfigService) {
     const discordUserId = req.userId;
     const configId = getRequiredParam(req.params.id, 'id');
 
-    const config = await service.getById(configId);
+    const config = await findConfigOrSendNotFound(
+      res,
+      () => service.getById(configId),
+      CONFIG_RESOURCE
+    );
     if (config === null) {
-      return sendError(res, ErrorResponses.notFound(CONFIG_RESOURCE));
+      return;
     }
 
     const userId = resolveProvisionedUserId(req);
@@ -124,28 +132,24 @@ function createCreateHandler(service: TtsConfigService) {
   return async (req: ProvisionedRequest, res: Response) => {
     const discordUserId = req.userId;
 
-    const parseResult = TtsConfigCreateSchema.safeParse(req.body);
-    if (!parseResult.success) {
-      return sendZodError(res, parseResult.error);
+    const body = parseBodyOrSendError(res, TtsConfigCreateSchema, req.body);
+    if (body === null) {
+      return;
     }
-    const body = parseResult.data;
 
     const userId = resolveProvisionedUserId(req);
 
     // Skip duplicate-name check when client opts into autoSuffixOnCollision
     // (the clone flow); service bumps `(Copy N)` server-side.
-    if (body.autoSuffixOnCollision !== true) {
-      const nameCheck = await service.checkNameExists(body.name, {
-        type: 'USER',
-        userId,
-        discordId: discordUserId,
-      });
-      if (nameCheck.exists) {
-        return sendError(
-          res,
-          ErrorResponses.nameCollision(`You already have a TTS config named "${body.name}"`)
-        );
-      }
+    if (
+      body.autoSuffixOnCollision !== true &&
+      !(await ensureNoNameCollision(res, service, {
+        name: body.name,
+        scope: { type: 'USER', userId, discordId: discordUserId },
+        formatCollisionMessage: n => `You already have a TTS config named "${n}"`,
+      }))
+    ) {
+      return;
     }
 
     let config;
@@ -205,18 +209,22 @@ function createUpdateHandler(service: TtsConfigService) {
     const discordUserId = req.userId;
     const configId = getRequiredParam(req.params.id, 'id');
 
-    const parseResult = TtsConfigUpdateSchema.safeParse(req.body);
-    if (!parseResult.success) {
-      return sendZodError(res, parseResult.error);
+    const body = parseBodyOrSendError(res, TtsConfigUpdateSchema, req.body);
+    if (body === null) {
+      return;
     }
-    const body = parseResult.data;
 
     const userId = resolveProvisionedUserId(req);
 
-    const config = await service.getById(configId);
+    const config = await findConfigOrSendNotFound(
+      res,
+      () => service.getById(configId),
+      CONFIG_RESOURCE
+    );
     if (config === null) {
-      return sendError(res, ErrorResponses.notFound(CONFIG_RESOURCE));
+      return;
     }
+
     if (config.ownerId !== userId) {
       return sendError(res, ErrorResponses.unauthorized('You can only edit your own TTS configs'));
     }
@@ -323,9 +331,13 @@ function createDeleteHandler(service: TtsConfigService) {
 
     const userId = resolveProvisionedUserId(req);
 
-    const config = await service.getById(configId);
+    const config = await findConfigOrSendNotFound(
+      res,
+      () => service.getById(configId),
+      CONFIG_RESOURCE
+    );
     if (config === null) {
-      return sendError(res, ErrorResponses.notFound(CONFIG_RESOURCE));
+      return;
     }
 
     const permissions = computeLlmConfigPermissions(

--- a/services/api-gateway/src/utils/configRouteHelpers.test.ts
+++ b/services/api-gateway/src/utils/configRouteHelpers.test.ts
@@ -29,6 +29,7 @@ vi.mock('./errorResponses.js', () => ({
 
 import {
   parseBodyOrSendError,
+  findConfigOrSendNotFound,
   findGlobalConfigOrSendError,
   findAdminUserOrSendError,
   ensureNoNameCollision,
@@ -61,6 +62,30 @@ describe('parseBodyOrSendError', () => {
   });
 });
 
+describe('findConfigOrSendNotFound', () => {
+  it('returns the row when fetch resolves to a value', async () => {
+    const row = { id: 'r1', ownerId: 'u1', name: 'User config' };
+    const fetchRow = vi.fn().mockResolvedValue(row);
+
+    const result = await findConfigOrSendNotFound(mockRes, fetchRow, 'Config');
+
+    expect(result).toBe(row);
+    expect(mockSendError).not.toHaveBeenCalled();
+  });
+
+  it('sends 404 and returns null when fetch resolves to null', async () => {
+    const fetchRow = vi.fn().mockResolvedValue(null);
+
+    const result = await findConfigOrSendNotFound(mockRes, fetchRow, 'TtsConfig');
+
+    expect(result).toBeNull();
+    expect(mockSendError).toHaveBeenCalledWith(
+      mockRes,
+      expect.objectContaining({ error: 'NOT_FOUND', message: 'TtsConfig not found' })
+    );
+  });
+});
+
 describe('findGlobalConfigOrSendError', () => {
   const baseOptions = {
     notFoundResource: 'Config',
@@ -69,9 +94,9 @@ describe('findGlobalConfigOrSendError', () => {
 
   it('returns the row when it exists and isGlobal is true', async () => {
     const row = { id: 'r1', isGlobal: true, name: 'Global Default' };
-    const fetch = vi.fn().mockResolvedValue(row);
+    const fetchRow = vi.fn().mockResolvedValue(row);
 
-    const result = await findGlobalConfigOrSendError(mockRes, fetch, {
+    const result = await findGlobalConfigOrSendError(mockRes, fetchRow, {
       ...baseOptions,
       operation: 'edit',
     });
@@ -81,9 +106,9 @@ describe('findGlobalConfigOrSendError', () => {
   });
 
   it('sends 404 and returns null when row is null', async () => {
-    const fetch = vi.fn().mockResolvedValue(null);
+    const fetchRow = vi.fn().mockResolvedValue(null);
 
-    const result = await findGlobalConfigOrSendError(mockRes, fetch, {
+    const result = await findGlobalConfigOrSendError(mockRes, fetchRow, {
       ...baseOptions,
       operation: 'edit',
     });
@@ -97,9 +122,9 @@ describe('findGlobalConfigOrSendError', () => {
 
   it('sends validation error and returns null when isGlobal is false', async () => {
     const row = { id: 'r1', isGlobal: false, name: 'User config' };
-    const fetch = vi.fn().mockResolvedValue(row);
+    const fetchRow = vi.fn().mockResolvedValue(row);
 
-    const result = await findGlobalConfigOrSendError(mockRes, fetch, {
+    const result = await findGlobalConfigOrSendError(mockRes, fetchRow, {
       ...baseOptions,
       operation: 'delete',
     });
@@ -119,9 +144,9 @@ describe('findGlobalConfigOrSendError', () => {
   ] as const)(
     'formats operation %s with the resource label',
     async (operation, expectedMessage) => {
-      const fetch = vi.fn().mockResolvedValue({ id: 'x', isGlobal: false });
+      const fetchRow = vi.fn().mockResolvedValue({ id: 'x', isGlobal: false });
 
-      await findGlobalConfigOrSendError(mockRes, fetch, { ...baseOptions, operation });
+      await findGlobalConfigOrSendError(mockRes, fetchRow, { ...baseOptions, operation });
 
       expect(mockSendError).toHaveBeenCalledWith(
         mockRes,
@@ -131,9 +156,9 @@ describe('findGlobalConfigOrSendError', () => {
   );
 
   it('respects a custom resourceLabel (e.g., "TTS configs")', async () => {
-    const fetch = vi.fn().mockResolvedValue({ id: 'x', isGlobal: false });
+    const fetchRow = vi.fn().mockResolvedValue({ id: 'x', isGlobal: false });
 
-    await findGlobalConfigOrSendError(mockRes, fetch, {
+    await findGlobalConfigOrSendError(mockRes, fetchRow, {
       notFoundResource: 'TtsConfig',
       resourceLabel: 'TTS configs',
       operation: 'edit',

--- a/services/api-gateway/src/utils/configRouteHelpers.ts
+++ b/services/api-gateway/src/utils/configRouteHelpers.ts
@@ -47,6 +47,29 @@ export function parseBodyOrSendError<T>(
   return result.data;
 }
 
+/**
+ * Fetch a config row by id (caller supplies the typed thunk) and 404 if
+ * absent. Unlike findGlobalConfigOrSendError, no isGlobal guard — user-side
+ * routes gate on permissions (computeLlmConfigPermissions → canEdit / canDelete)
+ * separately after the row is fetched, so the row's isGlobal value is not
+ * load-bearing at this point.
+ *
+ * The fetch-thunk pattern preserves Prisma `select` inference at the call
+ * site, same rationale as findGlobalConfigOrSendError.
+ */
+export async function findConfigOrSendNotFound<T>(
+  res: Response,
+  fetchRow: () => Promise<T | null>,
+  notFoundResource: string
+): Promise<T | null> {
+  const row = await fetchRow();
+  if (row === null) {
+    sendError(res, ErrorResponses.notFound(notFoundResource));
+    return null;
+  }
+  return row;
+}
+
 /** Operations governed by the isGlobal guard. Each maps to a scoped error wording. */
 export type GlobalGuardOperation =
   | 'edit'
@@ -61,7 +84,7 @@ export type GlobalGuardOperation =
  */
 export async function findGlobalConfigOrSendError<T extends { isGlobal: boolean }>(
   res: Response,
-  fetch: () => Promise<T | null>,
+  fetchRow: () => Promise<T | null>,
   options: {
     /** Resource name used by the not-found error (e.g., 'Config', 'TtsConfig'). */
     notFoundResource: string;
@@ -71,7 +94,7 @@ export async function findGlobalConfigOrSendError<T extends { isGlobal: boolean 
     operation: GlobalGuardOperation;
   }
 ): Promise<T | null> {
-  const row = await fetch();
+  const row = await fetchRow();
   if (row === null) {
     sendError(res, ErrorResponses.notFound(options.notFoundResource));
     return null;


### PR DESCRIPTION
## Summary

PR 3 of the CPD-reduction campaign. Applies the composable helpers from PR 2 (admin pilot) to the user-side config-route pair, plus adds one new helper specific to the user-route shape.

## What this PR does

User-side files have a meaningfully different shape from admin-side and don't map 1:1:

- **No `isGlobal` guard** — user routes gate on `computeLlmConfigPermissions` (`canEdit`/`canDelete`), not `isGlobal=true`
- **No admin user-lookup** — `requireProvisionedUser` middleware attaches the internal UUID at `req.provisionedUserId`
- **No delete-warning shaping** — user delete unconditionally returns `{ deleted: true }`

So `findGlobalConfigOrSendError`, `findAdminUserOrSendError`, and `shapeDeleteResponse` do not apply on the user side. What does:

| Helper | Sites |
|---|---|
| `parseBodyOrSendError` (existing) | 4 (2 create + 2 update) |
| `ensureNoNameCollision` (existing, generic-on-scope) | 2 (create handlers, non-auto-suffix branch) |
| `findConfigOrSendNotFound` **(NEW)** | 6 (get/update/delete in both files) |

The new `findConfigOrSendNotFound` is the user-route counterpart of `findGlobalConfigOrSendError` without the isGlobal guard — same fetch-thunk pattern for Prisma `select` inference preservation. 2 unit tests added.

## Verification

- **51/51** `user/llm-config.test.ts` pass unchanged
- **21/21** `user/tts-config.test.ts` pass unchanged
- **23/23** `configRouteHelpers.test.ts` (21 from PR 2 + 2 new)
- **1955/1955** full api-gateway suite pass
- **Full workspace** `pnpm test` + `pnpm quality` green
- `depcruise` clean

Existing route tests **unmodified** — characterization-test safety net, same approach as PR 2.

## CPD impact — transparent framing

Total clone count at `minLines=10`: **107 → 113** (+6 clones).
Total duplicated lines: **1604 → 1684** (+80).

Same dynamic as PR 2 — the helper-call shape itself gets flagged by jscpd across files using the same pattern. The architectural value of this PR is **pattern propagation to a meaningfully different file shape**, not headline metric movement.

Cross-pair clones between `user/llm-config.ts ↔ user/tts-config.ts` sit at **45 lines** after this PR, which is now the helper-call-shape floor for this pair. The campaign will compound when adjacent abstractions land — specifically the update-path collision flow (`computeNameForPromotion` + `buildCollisionMessage` + `postIsGlobal`), which is currently the highest-density remaining inline pattern across all 4 config-route files.

## Out of scope (deferred to subsequent campaign PRs)

These are planned campaign scope rather than deferred debt, so they don't need backlog entries:

- **Update-path name-collision flow** (`computeNameForPromotion` + `buildCollisionMessage` + `postIsGlobal` 4th-arg on `checkNameExists`) — needs separate design before extraction
- **Permission-check helper extraction** — user-facing message divergence across routes makes the API design nontrivial
- **Error-translation helper** for the try/catch around `service.create` — error class names differ between LLM and TTS (`AutoSuffixCollisionError` vs `TtsAutoSuffixCollisionError`)
- **3 user-side override files** (`user/{tts,stt,model}-override.ts`) — different shape (cascade override semantics, not CRUD)

## Files

| File | Change |
|---|---|
| `services/api-gateway/src/utils/configRouteHelpers.ts` | +1 helper (~17 lines) |
| `services/api-gateway/src/utils/configRouteHelpers.test.ts` | +2 tests + import update |
| `services/api-gateway/src/routes/user/llm-config.ts` | 6 inline patterns → helper calls |
| `services/api-gateway/src/routes/user/tts-config.ts` | 6 inline patterns → helper calls |

## Test plan

- [x] `pnpm --filter @tzurot/api-gateway test` (1955/1955)
- [x] `pnpm test` workspace (all green)
- [x] `pnpm quality` (lint + cpd + depcruise + typecheck + typecheck:spec)
- [x] `pnpm cpd` measured and disclosed in PR body
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)