### PR TITLE
refactor(api-gateway): tighten collision flow on user-side update handlers

### DIFF
--- a/services/api-gateway/src/routes/user/llm-config.ts
+++ b/services/api-gateway/src/routes/user/llm-config.ts
@@ -12,7 +12,6 @@
 
 import { Router, type Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
-import type { z } from 'zod';
 import {
   createLogger,
   isBotOwner,
@@ -48,8 +47,8 @@ import type { OpenRouterModelCache } from '../../services/OpenRouterModelCache.j
 import { enrichWithModelContext } from '../../utils/modelValidation.js';
 import { validateLlmConfigModelFields } from '../../utils/llmConfigValidation.js';
 import {
+  applyOwnerNamePromotion,
   buildCollisionMessage,
-  computeNameForPromotion,
   getDiscordUsernameFromRequest,
 } from '../../utils/normalizeConfigNameOnPromote.js';
 import { createResolveHandler } from './llmConfigResolve.js';
@@ -220,30 +219,6 @@ function createCreateHandler(service: LlmConfigService, modelCache?: OpenRouterM
   };
 }
 
-type LlmConfigUpdateBody = z.infer<typeof LlmConfigUpdateSchema>;
-
-/**
- * Apply the owner-driven name-promotion logic to an update body. Caller is
- * responsible for guarding admin-edits-on-non-owned-configs (which should
- * apply the name verbatim — suffixing under the bot owner's username would
- * mis-attribute provenance).
- */
-function applyOwnerNamePromotion(
-  body: LlmConfigUpdateBody,
-  config: { name: string; isGlobal: boolean },
-  req: ProvisionedRequest
-): LlmConfigUpdateBody {
-  const effectiveName = computeNameForPromotion({
-    currentName: config.name,
-    currentIsGlobal: config.isGlobal,
-    requestedName: body.name,
-    requestedIsGlobal: body.isGlobal,
-    discordId: req.userId,
-    discordUsername: getDiscordUsernameFromRequest(req),
-  });
-  return { ...body, ...(effectiveName !== undefined ? { name: effectiveName } : {}) };
-}
-
 function createUpdateHandler(service: LlmConfigService, modelCache?: OpenRouterModelCache) {
   return async (req: ProvisionedRequest, res: Response) => {
     const discordUserId = req.userId;
@@ -299,7 +274,8 @@ function createUpdateHandler(service: LlmConfigService, modelCache?: OpenRouterM
 
     // Owner edits run the promotion helper; admin edits on non-owned configs
     // apply the name verbatim (suffixing would mis-attribute provenance).
-    const patch = isOwnedByRequester ? applyOwnerNamePromotion(body, config, req) : { ...body };
+    const user = { discordId: req.userId, discordUsername: getDiscordUsernameFromRequest(req) };
+    const patch = isOwnedByRequester ? applyOwnerNamePromotion(body, config, user) : { ...body };
 
     // Compute post-update isGlobal so the collision check covers the cross-
     // user global-namespace case when the user is promoting (or already
@@ -307,29 +283,25 @@ function createUpdateHandler(service: LlmConfigService, modelCache?: OpenRouterM
     const postIsGlobal = body.isGlobal ?? config.isGlobal;
 
     // Check for duplicate name if a name is being applied (either user-supplied
-    // or normalized by the promotion helper). Use the post-normalization value
-    // so collision checks reflect what will actually land in the DB.
-    // Bot-owner-editing-others uses the OWNER's userId for namespace scoping
-    // (the name lives in the owner's namespace, not the requester's).
-    if (patch.name !== undefined && patch.name.length > 0) {
-      const nameCheck = await service.checkNameExists(
-        patch.name,
-        { type: 'USER', userId: config.ownerId, discordId: discordUserId },
-        configId,
-        postIsGlobal
-      );
-      if (nameCheck.exists) {
-        return sendError(
-          res,
-          ErrorResponses.nameCollision(
-            buildCollisionMessage({
-              effectiveName: patch.name,
-              requestedName: body.name,
-              configKind: 'config',
-            })
-          )
-        );
-      }
+    // or normalized by the promotion helper). Bot-owner-editing-others uses
+    // the OWNER's userId for namespace scoping (the name lives in the
+    // owner's namespace, not the requester's).
+    if (
+      patch.name !== undefined &&
+      !(await ensureNoNameCollision(res, service, {
+        name: patch.name,
+        scope: { type: 'USER', userId: config.ownerId, discordId: discordUserId },
+        excludeId: configId,
+        postIsGlobal,
+        formatCollisionMessage: n =>
+          buildCollisionMessage({
+            effectiveName: n,
+            requestedName: body.name,
+            configKind: 'config',
+          }),
+      }))
+    ) {
+      return;
     }
 
     // Update using service (handles cache invalidation). Empty-body guard

--- a/services/api-gateway/src/routes/user/tts-config.ts
+++ b/services/api-gateway/src/routes/user/tts-config.ts
@@ -47,8 +47,8 @@ import {
   ensureNoNameCollision,
 } from '../../utils/configRouteHelpers.js';
 import {
+  applyOwnerNamePromotion,
   buildCollisionMessage,
-  computeNameForPromotion,
   getDiscordUsernameFromRequest,
 } from '../../utils/normalizeConfigNameOnPromote.js';
 import type { ProvisionedRequest } from '../../types.js';
@@ -242,40 +242,32 @@ function createUpdateHandler(service: TtsConfigService) {
     // users can identify provenance — prevents non-bot-owners from creating
     // names that look admin-curated. Bot owner gets unsuffixed names per
     // `normalizeSlugForUser`'s built-in semantic. Mirrors the LLM route.
-    const effectiveName = computeNameForPromotion({
-      currentName: config.name,
-      currentIsGlobal: config.isGlobal,
-      requestedName: body.name,
-      requestedIsGlobal: body.isGlobal,
+    const patch = applyOwnerNamePromotion(body, config, {
       discordId: discordUserId,
       discordUsername: getDiscordUsernameFromRequest(req),
     });
-    const patch = { ...body, ...(effectiveName !== undefined ? { name: effectiveName } : {}) };
 
     // Compute post-update isGlobal so the collision check covers the cross-
     // user global-namespace case when the user is promoting (or already
     // promoted) their config.
     const postIsGlobal = body.isGlobal ?? config.isGlobal;
 
-    if (patch.name !== undefined && patch.name.length > 0) {
-      const nameCheck = await service.checkNameExists(
-        patch.name,
-        { type: 'USER', userId, discordId: discordUserId },
-        configId,
-        postIsGlobal
-      );
-      if (nameCheck.exists) {
-        return sendError(
-          res,
-          ErrorResponses.nameCollision(
-            buildCollisionMessage({
-              effectiveName: patch.name,
-              requestedName: body.name,
-              configKind: 'TTS config',
-            })
-          )
-        );
-      }
+    if (
+      patch.name !== undefined &&
+      !(await ensureNoNameCollision(res, service, {
+        name: patch.name,
+        scope: { type: 'USER', userId, discordId: discordUserId },
+        excludeId: configId,
+        postIsGlobal,
+        formatCollisionMessage: n =>
+          buildCollisionMessage({
+            effectiveName: n,
+            requestedName: body.name,
+            configKind: 'TTS config',
+          }),
+      }))
+    ) {
+      return;
     }
 
     // Empty-body guard ran earlier; patch is guaranteed non-empty here. Wrap

--- a/services/api-gateway/src/utils/configRouteHelpers.test.ts
+++ b/services/api-gateway/src/utils/configRouteHelpers.test.ts
@@ -229,7 +229,12 @@ describe('ensureNoNameCollision', () => {
     });
 
     expect(result).toBe(true);
-    expect(service.checkNameExists).toHaveBeenCalledWith('NewName', globalScope, undefined);
+    expect(service.checkNameExists).toHaveBeenCalledWith(
+      'NewName',
+      globalScope,
+      undefined,
+      undefined
+    );
     expect(mockSendError).not.toHaveBeenCalled();
   });
 
@@ -270,7 +275,8 @@ describe('ensureNoNameCollision', () => {
     expect(service.checkNameExists).toHaveBeenCalledWith(
       'RenameTarget',
       globalScope,
-      'existing-id-789'
+      'existing-id-789',
+      undefined
     );
   });
 
@@ -286,7 +292,12 @@ describe('ensureNoNameCollision', () => {
       formatCollisionMessage: n => `You already have a config named "${n}"`,
     });
 
-    expect(service.checkNameExists).toHaveBeenCalledWith('MyConfig', userScope, undefined);
+    expect(service.checkNameExists).toHaveBeenCalledWith(
+      'MyConfig',
+      userScope,
+      undefined,
+      undefined
+    );
   });
 
   it('uses the caller-provided formatter for the collision message', async () => {
@@ -306,6 +317,41 @@ describe('ensureNoNameCollision', () => {
       expect.objectContaining({
         message: 'You already have a config named "Duplicate"',
       })
+    );
+  });
+
+  it('forwards postIsGlobal to the service for cross-namespace global checks', async () => {
+    const service = {
+      checkNameExists: vi.fn().mockResolvedValue({ exists: false }),
+    };
+
+    await ensureNoNameCollision(mockRes, service, {
+      name: 'Renamed',
+      scope: userScope,
+      excludeId: 'cfg-1',
+      postIsGlobal: true,
+      formatCollisionMessage: _n => `irrelevant`,
+    });
+
+    expect(service.checkNameExists).toHaveBeenCalledWith('Renamed', userScope, 'cfg-1', true);
+  });
+
+  it('does not pass postIsGlobal when omitted (service receives undefined 4th arg)', async () => {
+    const service = {
+      checkNameExists: vi.fn().mockResolvedValue({ exists: false }),
+    };
+
+    await ensureNoNameCollision(mockRes, service, {
+      name: 'Created',
+      scope: userScope,
+      formatCollisionMessage: _n => `irrelevant`,
+    });
+
+    expect(service.checkNameExists).toHaveBeenCalledWith(
+      'Created',
+      userScope,
+      undefined,
+      undefined
     );
   });
 });

--- a/services/api-gateway/src/utils/configRouteHelpers.ts
+++ b/services/api-gateway/src/utils/configRouteHelpers.ts
@@ -160,9 +160,19 @@ export async function findAdminUserOrSendError(
  * The subset of a config-service used for name-collision checks. Each
  * service implements this method with its own row and scope types; we only
  * care about the boolean `exists` flag.
+ *
+ * `postIsGlobal` is the 4th argument used by user-side update routes that
+ * may promote a config to global — passing `true` widens the collision
+ * check to cover the cross-user global namespace. Admin and create paths
+ * omit it; the service defaults to `false`.
  */
 interface NameExistsChecker<TScope> {
-  checkNameExists(name: string, scope: TScope, excludeId?: string): Promise<{ exists: boolean }>;
+  checkNameExists(
+    name: string,
+    scope: TScope,
+    excludeId?: string,
+    postIsGlobal?: boolean
+  ): Promise<{ exists: boolean }>;
 }
 
 /**
@@ -190,14 +200,18 @@ export async function ensureNoNameCollision<TScope>(
     /** When editing an existing row, pass its id so the row's own current
      *  name doesn't count as a collision against itself. Omit on creates. */
     excludeId?: string;
+    /** For user-side update paths only — set `true` when the post-update
+     *  state would be `isGlobal: true`, so the check widens to the
+     *  cross-user global namespace. Admin and create paths omit this. */
+    postIsGlobal?: boolean;
     /** Caller-provided message formatter. Receives `name` (so the caller
      *  doesn't have to capture it in closure) and returns the full
      *  user-facing message. */
     formatCollisionMessage: (name: string) => string;
   }
 ): Promise<boolean> {
-  const { name, scope, excludeId, formatCollisionMessage } = options;
-  const nameCheck = await service.checkNameExists(name, scope, excludeId);
+  const { name, scope, excludeId, postIsGlobal, formatCollisionMessage } = options;
+  const nameCheck = await service.checkNameExists(name, scope, excludeId, postIsGlobal);
   if (nameCheck.exists) {
     sendError(res, ErrorResponses.nameCollision(formatCollisionMessage(name)));
     return false;

--- a/services/api-gateway/src/utils/normalizeConfigNameOnPromote.test.ts
+++ b/services/api-gateway/src/utils/normalizeConfigNameOnPromote.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { Request } from 'express';
 import {
+  applyOwnerNamePromotion,
   buildCollisionMessage,
   computeNameForPromotion,
   getDiscordUsernameFromRequest,
@@ -210,6 +211,57 @@ describe('getDiscordUsernameFromRequest', () => {
     // Express can deliver array values for repeated headers
     const req = { headers: { 'x-user-username': ['a', 'b'] } } as unknown as Request;
     expect(getDiscordUsernameFromRequest(req)).toBe('');
+  });
+});
+
+describe('applyOwnerNamePromotion', () => {
+  const config = { name: 'MyConfig', isGlobal: false };
+
+  it('returns body unchanged when no promotion or rename', () => {
+    const body: { name?: string; isGlobal?: boolean; description: string } = {
+      description: 'new description',
+    };
+    const result = applyOwnerNamePromotion(body, config, REGULAR_USER);
+    expect(result).toEqual({ description: 'new description' });
+  });
+
+  it('suffixes the name when promoting to global as a regular user', () => {
+    const body = { name: 'Cool', isGlobal: true };
+    const result = applyOwnerNamePromotion(body, config, REGULAR_USER);
+    expect(result).toEqual({ name: 'Cool-bob', isGlobal: true });
+  });
+
+  it('leaves the name unchanged when bot owner promotes to global', () => {
+    const body = { name: 'Official', isGlobal: true };
+    const result = applyOwnerNamePromotion(body, config, BOT_OWNER);
+    expect(result).toEqual({ name: 'Official', isGlobal: true });
+  });
+
+  it('preserves arbitrary extra fields on the body', () => {
+    const body = { name: 'Renamed', isGlobal: true, advancedParameters: { temp: 0.7 } };
+    const result = applyOwnerNamePromotion(body, config, REGULAR_USER);
+    expect(result).toEqual({
+      name: 'Renamed-bob',
+      isGlobal: true,
+      advancedParameters: { temp: 0.7 },
+    });
+  });
+
+  it('works generically for a TTS-shaped body', () => {
+    const ttsBody = { name: 'MyVoice', provider: 'mistral', isGlobal: true };
+    const result = applyOwnerNamePromotion(ttsBody, config, REGULAR_USER);
+    expect(result).toEqual({ name: 'MyVoice-bob', provider: 'mistral', isGlobal: true });
+  });
+
+  it('omits the name field when computeNameForPromotion returns undefined (no rename)', () => {
+    const globalConfig = { name: 'AlreadyGlobal', isGlobal: true };
+    // Description-only update on an already-global config — no rename triggered
+    const body: { name?: string; isGlobal?: boolean; description: string } = {
+      description: 'updated desc',
+    };
+    const result = applyOwnerNamePromotion(body, globalConfig, REGULAR_USER);
+    expect(result).toEqual({ description: 'updated desc' });
+    expect(result).not.toHaveProperty('name');
   });
 });
 

--- a/services/api-gateway/src/utils/normalizeConfigNameOnPromote.ts
+++ b/services/api-gateway/src/utils/normalizeConfigNameOnPromote.ts
@@ -85,6 +85,41 @@ export function computeNameForPromotion(opts: PromotionContext): string | undefi
 }
 
 /**
+ * Apply the owner-driven name-promotion logic to an update body.
+ *
+ * If `computeNameForPromotion` returns an effective name (the user is
+ * promoting their config to global or renaming a global), splice it into
+ * the patch under `name`. Otherwise return the body unchanged.
+ *
+ * Caller is responsible for guarding admin-edits-on-non-owned-configs
+ * (which should apply the body verbatim — suffixing under the bot owner's
+ * username would mis-attribute provenance). The LLM route uses an
+ * `isOwnedByRequester ? applyOwnerNamePromotion(...) : { ...body }` ternary;
+ * the TTS route hard-fails non-owner edits before reaching this point so
+ * the guard is implicit.
+ *
+ * Generic on `TBody extends { name?: string; isGlobal?: boolean }` so both
+ * LlmConfigUpdateBody and TtsConfigUpdateBody work. Takes a minimal
+ * `{ discordId, discordUsername }` shape rather than an Express request to
+ * decouple this util from the route layer.
+ */
+export function applyOwnerNamePromotion<TBody extends { name?: string; isGlobal?: boolean }>(
+  body: TBody,
+  config: { name: string; isGlobal: boolean },
+  user: { discordId: string; discordUsername: string }
+): TBody {
+  const effectiveName = computeNameForPromotion({
+    currentName: config.name,
+    currentIsGlobal: config.isGlobal,
+    requestedName: body.name,
+    requestedIsGlobal: body.isGlobal,
+    discordId: user.discordId,
+    discordUsername: user.discordUsername,
+  });
+  return { ...body, ...(effectiveName !== undefined ? { name: effectiveName } : {}) };
+}
+
+/**
  * Build the user-facing collision message for a config update where the
  * post-update state may be auto-renamed by the promotion helper.
  *


### PR DESCRIPTION
## Summary

**PR 4 of the CPD-reduction campaign — Option A from the council deliberation.** Tightens the last load-bearing inline duplication in the user-side update path: the name-collision flow with post-promotion `isGlobal` awareness.

Three-model council (Gemini 3.1 Pro Preview, Kimi K2.6, GLM 5.1) deliberated on whether to extract this flow. GLM proposed a pre-committed exit criterion: **2-callback ceiling.** I prototyped the kernel signature and it passed with **0 new callbacks added** — the divergences Gemini flagged (admin-edit-bypass, error-class differences) are caller policy, not kernel logic, and stay inline.

## Changes

### 1. `ensureNoNameCollision` gets optional `postIsGlobal?: boolean`

Plumbs through to `NameExistsChecker<TScope>.checkNameExists`'s 4th argument (already supported by both `LlmConfigService` and `TtsConfigService` for cross-namespace promotion checks).

- Admin and create paths omit it → service defaults to `false` → no behavior change for existing callers
- User-side update paths pass `body.isGlobal ?? config.isGlobal` for promotion-aware collision checks

### 2. `applyOwnerNamePromotion` extracted to shared utility

Moved from a local function in `user/llm-config.ts` to `services/api-gateway/src/utils/normalizeConfigNameOnPromote.ts`.

Made generic on `TBody extends { name?: string; isGlobal?: boolean }` so both `LlmConfigUpdateBody` and `TtsConfigUpdateBody` work. Takes a minimal `{ discordId, discordUsername }` shape instead of an Express request to decouple from the route layer.

### 3. Both user-side update handlers consolidated

`user/llm-config.ts createUpdateHandler` and `user/tts-config.ts createUpdateHandler` now use the shared `applyOwnerNamePromotion` + the extended `ensureNoNameCollision`. The LLM-only admin-edit-bypass stays as a one-line ternary at the call site (caller policy, exactly where it belongs per the kernel-vs-wiring distinction). Same for the LLM/TTS error-class translation in `service.update`'s try/catch — different class names, different treatments, stays explicit.

## Verification

- **6 new tests** for `applyOwnerNamePromotion` (generic body, regular user, bot owner, extra fields, TTS-shape, no-rename path)
- **2 new tests** for `ensureNoNameCollision`'s `postIsGlobal` plumbing
- **3 existing tests** updated to assert the new 4-arg `checkNameExists` call
- **144 route tests pass unchanged** (47+25+51+21) — behavior preserved
- **1963 full api-gateway suite** green
- **Lint + typecheck:spec + depcruise** all clean

## CPD impact

Total clone count flat at 113. Per the campaign's late-stage dynamic, the helper-call shape itself gets flagged by jscpd as call-site duplication across consumers. **PR 5 (queued)** introduces the ts-morph post-filter + differential CI ratchet + boundary documentation that resolves the metric paradox and locks in enforcement.

## Files

| File | Change |
|---|---|
| `services/api-gateway/src/utils/configRouteHelpers.ts` | Add optional `postIsGlobal` to `ensureNoNameCollision`; extend `NameExistsChecker<TScope>` interface |
| `services/api-gateway/src/utils/configRouteHelpers.test.ts` | 2 new tests + 3 existing assertions updated |
| `services/api-gateway/src/utils/normalizeConfigNameOnPromote.ts` | Export `applyOwnerNamePromotion` (generic, route-layer decoupled) |
| `services/api-gateway/src/utils/normalizeConfigNameOnPromote.test.ts` | 6 new tests for the new export |
| `services/api-gateway/src/routes/user/llm-config.ts` | Remove local `applyOwnerNamePromotion`; use shared helpers + extended `ensureNoNameCollision` |
| `services/api-gateway/src/routes/user/tts-config.ts` | Same — replace inline `computeNameForPromotion` flow with shared helpers |

## Test plan

- [x] `pnpm --filter @tzurot/api-gateway test` (1963/1963)
- [x] `pnpm cpd` measured and disclosed
- [x] `pnpm --filter @tzurot/api-gateway lint`
- [x] `pnpm --filter @tzurot/api-gateway typecheck:spec`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)