### PR TITLE
ci: enforce knip:dead in CI lint job and pre-push hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Check for unused code (knip)
         run: pnpm knip
 
+      - name: Check for dead files (knip:dead)
+        run: pnpm knip:dead
+
       - name: Run typecheck:spec
         run: pnpm typecheck:spec
 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -138,7 +138,21 @@ if ! pnpm ops guard:duplicate-exports; then
     exit 1
 fi
 
-# 10. Run dependency boundary checks (BLOCKING)
+# 10. Run dead-file check (BLOCKING)
+# `pnpm knip:dead` flags source files whose only references are their own
+# colocated tests — i.e., production code with zero live consumers. CI runs
+# this in the lint job; mirroring it here catches dead code before push,
+# saving a CI round-trip. Fast (~5s).
+echo "Running dead-file check..."
+if ! pnpm knip:dead; then
+    echo "${RED}Dead-file check failed!${NC}"
+    echo "Either remove the dead file(s), or wire up production consumers."
+    echo "If knip:dead's basename matcher reports a false positive, verify"
+    echo "the file is actually reachable via 'grep -rln <filename> services/ packages/'."
+    exit 1
+fi
+
+# 11. Run dependency boundary checks (BLOCKING)
 # Clear the depcruise cache first — content-strategy caching has missed
 # circular-dependency violations across renamed/moved files at least once
 # (PR #901, 2026-04-25). The full analysis takes ~5s, so the cost of always
@@ -152,7 +166,7 @@ if ! pnpm depcruise; then
     exit 1
 fi
 
-# 11. Run Python quality checks if Python files changed
+# 12. Run Python quality checks if Python files changed
 if [ -n "$PYTHON_FILES" ]; then
     echo "Running Python quality checks (ruff + mypy + pytest)..."
     if ! (cd services/voice-engine && ruff check .); then

--- a/backlog/future-themes.md
+++ b/backlog/future-themes.md
@@ -684,10 +684,10 @@ _Developer experience, schema-type discipline, CI strictness, and test infrastru
 
 Pre-push hook runs CPD and depcruise in warning-only mode (non-blocking). ESLint has warnings for complexity/statements that don't block CI. As we hit targets, tighten the ratchet:
 
-- [ ] **CPD**: Currently non-blocking in pre-push. Once under target (<100 clones), add threshold check that blocks push
+- [x] **CPD**: ratchet shipped 2026-05-16 as `pnpm ops cpd:check` (CI lint job) + post-filter heuristic + boundary docs. See `docs/reference/CPD_CAMPAIGN_AUDIT.md` for the close-out audit and `02-code-standards.md` "Duplication, Helpers, and the CPD Ratchet" for the rules.
 - [ ] **Duplicate Exports**: `guard:duplicate-exports` runs in CI with `continue-on-error: true`. Add ratchet (baseline count file + "new duplicates above baseline" check) so it blocks CI while still allowing existing allowlisted duplicates. Then drop `continue-on-error`
 - [ ] **ESLint warnings**: `max-statements`, `complexity`, `max-lines-per-function` are warn-level. Audit current violation count, set a baseline, block new violations
-- [ ] **Knip**: Dead code detection runs manually. Add to pre-push or CI as blocking check
+- [x] **Knip dead-files**: shipped 2026-05-17 — `pnpm knip:dead` now blocks in both the pre-push hook and the CI lint job. `pnpm knip` (unused exports/imports/deps) was already CI-blocking. Goal achieved: dead files surface immediately, not by audit cycle. The unused-exports half (`pnpm knip`) has been CI-blocking for a while; this closes the dead-files half.
 
 Goal: every quality check that currently warns should eventually block, with a clear baseline so new violations are caught immediately.
 


### PR DESCRIPTION
## Summary

- Wire `pnpm knip:dead` into both the **pre-push hook** (step 10) and the **CI lint job** (after the existing `pnpm knip` step) as a **blocking** check
- Closes the dead-files half of the Tooling & Quality Ratchet theme; the unused-exports half (`pnpm knip`) was already CI-blocking

## Why

`pnpm knip:dead` flags source files whose only references are their own colocated tests — i.e., production code with zero live consumers. PR #1044 cleaned the existing dead files but the check was on-demand only. Wiring it into pre-push + CI means new dead files surface immediately instead of accumulating between audit cycles.

## Trade-off

`knip:dead` uses a basename-only matcher (documented caveat in `packages/tooling/src/dev/dead-files.ts`). False positives are possible if a file has the same basename as another file referenced elsewhere. The error message in the pre-push hook tells contributors how to verify (`grep -rln <filename> services/ packages/`); they can either fix the dead file or wire up the consumer. The CI failure is recoverable on the same PR via fixup commit.

Verified locally: \`pnpm knip:dead\` is clean on this branch (0 dead files).

## Test plan

- [x] `pnpm knip:dead` exits 0 locally
- [x] Pre-push hook fires the new step on a normal push
- [ ] CI lint job passes the new step
- [ ] (negative test) A synthetic dead file would fail both gates — verified by inspection of the script behavior; not exercised here to avoid noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)