### PR TITLE
chore(api-gateway): require auth on /metrics + scope CORP to media routes

### DIFF
--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -49,7 +49,12 @@ import {
 } from './routes/public/index.js';
 
 // Middleware
-import { createCorsMiddleware, notFoundHandler, globalErrorHandler } from './middleware/index.js';
+import {
+  createCorsMiddleware,
+  allowCrossOriginEmbedding,
+  notFoundHandler,
+  globalErrorHandler,
+} from './middleware/index.js';
 
 // Services
 import { DatabaseNotificationListener } from './services/DatabaseNotificationListener.js';
@@ -241,15 +246,33 @@ function registerRoutes(app: Express, prisma: PrismaClient, services: ServicesCo
     { maxRequestsPerMinute: envConfig.PUBLIC_RATE_LIMIT_PER_MIN },
     'Public-route rate limiter initialized'
   );
-  app.use('/metrics', publicRateLimiter, createMetricsRouter(aiQueue, startTime));
-  app.use('/avatars', publicRateLimiter, createAvatarRouter(prisma));
-  app.use('/voice-references', publicRateLimiter, createVoiceReferenceRouter(prisma));
+
+  // Media routes that legitimately need cross-origin embedding (Discord
+  // fetches avatars and voice samples from outside our origin). Opt these
+  // two specific routers into CORP cross-origin via the per-route
+  // middleware; everything else inherits helmet's same-origin default.
+  app.use('/avatars', publicRateLimiter, allowCrossOriginEmbedding, createAvatarRouter(prisma));
+  app.use(
+    '/voice-references',
+    publicRateLimiter,
+    allowCrossOriginEmbedding,
+    createVoiceReferenceRouter(prisma)
+  );
   app.use('/exports', publicRateLimiter, createExportsRouter(prisma));
 
   // PROTECTED ROUTES (require service authentication)
   validateServiceAuthConfig();
   app.use(requireServiceAuth());
   logger.info('Service authentication middleware applied globally');
+
+  // /metrics exposes BullMQ queue depth, completed/failed counts, and uptime.
+  // Operational telemetry — no PII, but useful intelligence for an attacker
+  // (timing high-load windows, detecting deploys). No external consumer
+  // exists today (bot-client uses /health for status), so requiring auth is
+  // free; if a future Prometheus-style scraper is added, it authenticates
+  // via INTERNAL_SERVICE_SECRET like everything else.
+  app.use('/metrics', createMetricsRouter(aiQueue, startTime));
+  logger.info('Metrics route registered (service-auth protected)');
 
   app.use('/ai', createAIRouter(prisma, aiQueue, queueEvents));
   logger.info('AI routes registered');
@@ -387,11 +410,11 @@ async function main(): Promise<void> {
   // own append) — see `publicRouteKeyGenerator` in RedisRateLimiter.ts.
   app.set('trust proxy', 1);
 
-  // Security headers. crossOriginResourcePolicy is loosened to 'cross-origin'
-  // so /avatars and /voice-references can be fetched by Discord and other
-  // consumers; without this, helmet's default 'same-origin' policy would
-  // block external embedding of these intentionally-public media routes.
-  app.use(helmet({ crossOriginResourcePolicy: { policy: 'cross-origin' } }));
+  // Security headers. Helmet defaults apply globally (CORP = 'same-origin').
+  // The two media routes that need cross-origin embedding (/avatars and
+  // /voice-references) opt in to a looser CORP per-route below, so the
+  // permissive policy doesn't leak onto every other endpoint.
+  app.use(helmet());
 
   // 20MB to accommodate base64-encoded voice reference audio (up to 10MB raw → ~13.3MB base64).
   // Applied globally — acceptable for single-tenant bot. Could be scoped per-route if needed.

--- a/services/api-gateway/src/middleware/crossOriginResource.test.ts
+++ b/services/api-gateway/src/middleware/crossOriginResource.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for the CORP-loosening middleware.
+ */
+
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import helmet from 'helmet';
+import request from 'supertest';
+import { allowCrossOriginEmbedding } from './crossOriginResource.js';
+
+describe('allowCrossOriginEmbedding', () => {
+  it('should set Cross-Origin-Resource-Policy: cross-origin on the response', async () => {
+    const app = express();
+    app.get('/test', allowCrossOriginEmbedding, (_req, res) => {
+      res.send('ok');
+    });
+
+    const response = await request(app).get('/test');
+
+    expect(response.headers['cross-origin-resource-policy']).toBe('cross-origin');
+  });
+
+  it('should override helmet defaults when mounted after them', async () => {
+    // Reproduces the production wiring: helmet sets CORP same-origin
+    // globally, then the per-route middleware overrides for specific
+    // routes. The override-wins pattern is the whole point.
+    const app = express();
+    app.use(helmet());
+    app.get('/media', allowCrossOriginEmbedding, (_req, res) => {
+      res.send('ok');
+    });
+    app.get('/other', (_req, res) => {
+      res.send('ok');
+    });
+
+    const mediaResponse = await request(app).get('/media');
+    const otherResponse = await request(app).get('/other');
+
+    expect(mediaResponse.headers['cross-origin-resource-policy']).toBe('cross-origin');
+    expect(otherResponse.headers['cross-origin-resource-policy']).toBe('same-origin');
+  });
+
+  it('should call next() so the response handler still runs', async () => {
+    const app = express();
+    app.get('/test', allowCrossOriginEmbedding, (_req, res) => {
+      res.json({ ok: true });
+    });
+
+    const response = await request(app).get('/test');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+  });
+});

--- a/services/api-gateway/src/middleware/crossOriginResource.ts
+++ b/services/api-gateway/src/middleware/crossOriginResource.ts
@@ -1,0 +1,7 @@
+import type { RequestHandler } from 'express';
+
+// Opt specific routes into CORP cross-origin; do NOT mount globally (helmet's same-origin default is the right posture for everything else).
+export const allowCrossOriginEmbedding: RequestHandler = (_req, res, next) => {
+  res.set('Cross-Origin-Resource-Policy', 'cross-origin');
+  next();
+};

--- a/services/api-gateway/src/middleware/index.ts
+++ b/services/api-gateway/src/middleware/index.ts
@@ -5,4 +5,5 @@
  */
 
 export { createCorsMiddleware } from './cors.js';
+export { allowCrossOriginEmbedding } from './crossOriginResource.js';
 export { notFoundHandler, globalErrorHandler } from './errorHandler.js';

--- a/services/api-gateway/src/routes/public/index.ts
+++ b/services/api-gateway/src/routes/public/index.ts
@@ -1,7 +1,10 @@
 /**
  * Public Routes
  *
- * Routes that don't require authentication (health, metrics, avatars, exports).
+ * Route factories grouped here for historical reasons. Most are mounted
+ * publicly (health, avatars, voice-references, exports), but `metrics`
+ * is mounted behind service auth despite living in this directory — the
+ * factory shape is identical, only the mount-point auth posture differs.
  */
 
 export { createHealthRouter } from './health.js';

--- a/services/api-gateway/src/routes/public/metrics.test.ts
+++ b/services/api-gateway/src/routes/public/metrics.test.ts
@@ -22,15 +22,24 @@ vi.mock('@tzurot/common-types', () => ({
     error: vi.fn(),
     debug: vi.fn(),
   }),
+  // requireServiceAuth reads getConfig().INTERNAL_SERVICE_SECRET — stub
+  // it to a known value so the auth-protection test can verify rejection
+  // (missing header) and acceptance (matching header).
+  getConfig: () => ({ INTERNAL_SERVICE_SECRET: 'test-secret' }),
 }));
 
 vi.mock('../../utils/errorResponses.js', () => ({
   ErrorResponses: {
     metricsError: vi.fn((message: string) => ({ error: 'Metrics Error', message })),
+    unauthorized: vi.fn((message: string) => ({ error: 'UNAUTHORIZED', message })),
   },
+  getStatusCode: vi.fn((errorCode: string) =>
+    errorCode === 'UNAUTHORIZED' ? StatusCodes.UNAUTHORIZED : StatusCodes.INTERNAL_SERVER_ERROR
+  ),
 }));
 
 import { createMetricsRouter } from './metrics.js';
+import { requireServiceAuth } from '../../services/AuthMiddleware.js';
 
 describe('Metrics Route', () => {
   let app: express.Express;
@@ -85,5 +94,42 @@ describe('Metrics Route', () => {
     expect(mockQueue.getActiveCount).toHaveBeenCalled();
     expect(mockQueue.getCompletedCount).toHaveBeenCalled();
     expect(mockQueue.getFailedCount).toHaveBeenCalled();
+  });
+
+  describe('with requireServiceAuth mounted upstream', () => {
+    // Reproduces the production wiring: auth middleware runs before the
+    // route handler. Locks in the invariant that /metrics is NOT public —
+    // future accidental removal of the auth middleware in index.ts would
+    // fail this test rather than ship as a regression.
+
+    function buildProtectedApp(): express.Express {
+      const protectedApp = express();
+      protectedApp.use(requireServiceAuth());
+      protectedApp.use('/metrics', createMetricsRouter(mockQueue as Queue, startTime));
+      return protectedApp;
+    }
+
+    it('should reject requests without the X-Service-Auth header', async () => {
+      const response = await request(buildProtectedApp()).get('/metrics');
+
+      expect(response.status).toBe(StatusCodes.UNAUTHORIZED);
+    });
+
+    it('should reject requests with the wrong X-Service-Auth secret', async () => {
+      const response = await request(buildProtectedApp())
+        .get('/metrics')
+        .set('X-Service-Auth', 'wrong-secret');
+
+      expect(response.status).toBe(StatusCodes.UNAUTHORIZED);
+    });
+
+    it('should allow requests with the correct X-Service-Auth secret', async () => {
+      const response = await request(buildProtectedApp())
+        .get('/metrics')
+        .set('X-Service-Auth', 'test-secret');
+
+      expect(response.status).toBe(StatusCodes.OK);
+      expect(response.body.queue).toBeDefined();
+    });
   });
 });

--- a/services/api-gateway/src/routes/public/metrics.ts
+++ b/services/api-gateway/src/routes/public/metrics.ts
@@ -1,7 +1,8 @@
 /**
  * Metrics Routes
  *
- * Public endpoint for service metrics.
+ * Service-auth-protected endpoint for operational metrics (queue depth,
+ * cache size, uptime). Mounted behind requireServiceAuth() in index.ts.
  */
 
 import { Router } from 'express';


### PR DESCRIPTION
## Summary

Closes two related security tightenings filed in `backlog/inbox.md` after PR #1046:

### 1. `/metrics` now requires service authentication

Was: unauthenticated + IP rate-limited at 60 req/min.
Now: behind `requireServiceAuth()` like the rest of the gateway.

What the route exposes:

\`\`\`json
{
  "queue": { "waiting": N, "active": N, "completed": N, "failed": N, "total": N },
  "cache": { "size": N },
  "uptime": <ms>,
  "timestamp": "..."
}
\`\`\`

Operational telemetry — no PII, no user data. But useful intelligence for an attacker: timing high-load windows, detecting deploys via uptime resets, estimating user base from completed-job counts.

**Verified no current external consumer.** `bot-client` uses `/health` for status checks (\`grep -rln "/metrics" services/\` → only api-gateway-internal references). Requiring auth is zero-cost today and future-proof if a Prometheus-style scraper is ever added — it'll authenticate via \`INTERNAL_SERVICE_SECRET\` like everything else.

### 2. `crossOriginResourcePolicy: 'cross-origin'` scoped to media routes only

Was: \`helmet({ crossOriginResourcePolicy: { policy: 'cross-origin' } })\` applied globally.
Now: \`helmet()\` (CORP defaults to \`same-origin\`), with a per-route middleware opting in on \`/avatars\` and \`/voice-references\`.

The cross-origin loosening was always intended for the two media routes that Discord embeds. The global application was leaking the permissive CORP header onto `/exports`, `/ai`, `/admin`, etc. where it adds no value.

## Test plan

- [x] \`pnpm test\` — 4850 bot-client + ~2000 across other services all green
- [x] \`pnpm quality\` green
- [x] Manual verification: \`grep\` confirms no external \`/metrics\` consumer
- [ ] On deploy: hit \`/metrics\` without service auth → expect 401 (was 200)
- [ ] On deploy: hit \`/avatars/:id\` → expect \`Cross-Origin-Resource-Policy: cross-origin\` header (unchanged)
- [ ] On deploy: hit \`/ai/generate\` (with auth) → expect default \`same-origin\` header (was \`cross-origin\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)