### PR TITLE
fix(bot-client): voice transcription cache-key parity + STT timeout headroom

### DIFF
--- a/packages/common-types/src/constants/timing.ts
+++ b/packages/common-types/src/constants/timing.ts
@@ -33,10 +33,15 @@ export const TIMEOUTS = {
   SYSTEM_OVERHEAD: 15000,
   /** Job wait timeout in gateway (10 minutes - Railway safety buffer) */
   JOB_WAIT: 600000,
-  /** Client-side timeout for STT transcription gateway requests (2 minutes).
-   * Shorter than JOB_WAIT to provide timely user feedback on failure.
-   * Covers: cold start warmup (~75s) + audio fetch (~30s) + transcription (~15s). */
-  STT_GATEWAY: 120_000,
+  /** Client-side timeout for STT transcription gateway requests (4 minutes).
+   * Must exceed AUDIO_FETCH (30s) + VOICE_ENGINE_API (180s) + a queue/network
+   * margin — otherwise the bot-client AbortSignal fires while ai-worker is
+   * still mid-call. 240s = 30 + 180 + 30s margin. Covers the observed
+   * Railway-serverless cold-start (~135s end-to-end) with headroom for
+   * queue latency when the downstream steps approach their individual caps.
+   * Stays well under JOB_WAIT (10 min) so user feedback stays timely on
+   * real hangs. Bump this if `AUDIO_FETCH` or `VOICE_ENGINE_API` change. */
+  STT_GATEWAY: 240_000,
   /** BullMQ worker lock duration - maximum time a job can run before being considered stalled (20 minutes - safety net for hung jobs) */
   WORKER_LOCK_DURATION: 20 * 60 * 1000,
 } as const;

--- a/services/bot-client/src/services/VoiceTranscriptionService.test.ts
+++ b/services/bot-client/src/services/VoiceTranscriptionService.test.ts
@@ -248,6 +248,7 @@ describe('VoiceTranscriptionService', () => {
         [
           {
             url: 'https://cdn.discord.com/voice/123.ogg',
+            originalUrl: 'https://cdn.discord.com/voice/123.ogg',
             contentType: 'audio/ogg',
             name: 'voice-message.ogg',
             size: 50000,
@@ -840,6 +841,7 @@ describe('VoiceTranscriptionService', () => {
         [
           {
             url: 'https://cdn.discord.com/voice/forwarded.ogg',
+            originalUrl: 'https://cdn.discord.com/voice/forwarded.ogg',
             contentType: 'audio/ogg',
             name: 'forwarded-voice.ogg',
             size: 45000,

--- a/services/bot-client/src/services/VoiceTranscriptionService.ts
+++ b/services/bot-client/src/services/VoiceTranscriptionService.ts
@@ -86,6 +86,8 @@ async function sendTranscriptChunks(
 /** Attachment info for transcription */
 interface TranscriptionAttachment {
   url: string;
+  // Canonical cache-key field — matches `AttachmentMetadata.originalUrl` used by ai-worker's `lookupCachedTranscript`. Equals `url` at construction time (no bot-client pipeline transforms).
+  originalUrl: string;
   contentType: string;
   name: string;
   size: number;
@@ -121,6 +123,7 @@ function extractAudioFromSnapshot(snapshot: {
     )
     .map(attachment => ({
       url: attachment.url,
+      originalUrl: attachment.url,
       contentType:
         attachment.contentType !== null &&
         attachment.contentType !== undefined &&
@@ -309,12 +312,11 @@ export class VoiceTranscriptionService {
         'Transcription complete'
       );
 
-      // Cache transcript in Redis BEFORE sending Discord replies to prevent race condition
-      // If personality processing starts before cache storage completes, it might re-transcribe
-      // Key by attachment URL with 5 min TTL (long enough for personality processing)
+      // Cache BEFORE Discord replies (5-min TTL via voiceTranscriptCache default).
+      // Key by `originalUrl` — same field ai-worker reads in `lookupCachedTranscript`. Explicit field reference survives future refactors that might diverge `url` from `originalUrl`.
       const voiceAttachment = attachments[0]; // We know there's at least one
       if (voiceAttachment !== undefined && voiceAttachment !== null) {
-        await voiceTranscriptCache.store(voiceAttachment.url, response.content);
+        await voiceTranscriptCache.store(voiceAttachment.originalUrl, response.content);
         logger.debug(
           { urlPreview: voiceAttachment.url.substring(0, 50) },
           'Cached transcript for attachment'

--- a/services/bot-client/src/utils/attachmentExtractor.test.ts
+++ b/services/bot-client/src/utils/attachmentExtractor.test.ts
@@ -71,6 +71,10 @@ describe('extractAttachments', () => {
       expect(result![0]).toEqual({
         id: '123',
         url: 'https://cdn.discord.com/attachments/guild/channel/123/image.png',
+        // Discord CDN URL is duplicated into originalUrl so the cache-stable
+        // key survives pipeline transformations (DownloadAttachmentsStep
+        // rewrites `url` to a data URL).
+        originalUrl: 'https://cdn.discord.com/attachments/guild/channel/123/image.png',
         contentType: 'image/png',
         name: 'image.png',
         size: 2048,
@@ -298,6 +302,26 @@ describe('extractAttachments', () => {
       const result = extractAttachments(collection);
 
       expect(result![0].url).toBe(longUrl);
+    });
+  });
+
+  describe('cache-key invariant', () => {
+    // VoiceTranscriptCache keys by `originalUrl` (the field that survives
+    // pipeline transformations downstream). Both the writer (bot-client
+    // VoiceTranscriptionService) and the reader (ai-worker AudioProcessor)
+    // must see the same Discord CDN URL in that field, or every voice
+    // message gets transcribed twice.
+    it('should set originalUrl equal to url for cache-stable lookup', () => {
+      const cdnUrl = 'https://cdn.discord.com/attachments/g/c/v/voice.ogg?ex=A&hm=B';
+      const attachment = createMockAttachment('vm', { url: cdnUrl });
+      const collection = createAttachmentCollection([attachment]);
+
+      const result = extractAttachments(collection);
+
+      // originalUrl must equal url at extraction time — this is the
+      // invariant the cross-service VoiceTranscriptCache depends on.
+      expect(result![0].url).toBe(cdnUrl);
+      expect(result![0].originalUrl).toBe(cdnUrl);
     });
   });
 });

--- a/services/bot-client/src/utils/attachmentExtractor.ts
+++ b/services/bot-client/src/utils/attachmentExtractor.ts
@@ -25,6 +25,8 @@ export function extractAttachments(
     // Discord attachment ID - stable snowflake for caching (preferred over URL hash)
     id: attachment.id,
     url: attachment.url,
+    // Cache-stable Discord CDN URL — survives ai-worker pipeline transforms that overwrite `url`.
+    originalUrl: attachment.url,
     contentType: attachment.contentType ?? CONTENT_TYPES.BINARY,
     name: attachment.name,
     size: attachment.size,


### PR DESCRIPTION
## Summary

Fixes two production-observed bugs from the 2026-05-18 voice QA session.

### Bug 1: Voice transcription doubling

Every voice message was hitting voice-engine **twice**, with each pass producing slightly different transcripts that diverged between the Redis cache (length 216) and the database (length 461) for the same message.

User-visible symptoms (per the QA report):
> "voice messages have been fighting you all night — doubling, cutting out, transcribing in ways that didn't match what you said"

**Root cause:** `VoiceTranscriptCache` writer (bot-client) keyed by `voiceAttachment.url`. Reader (ai-worker `AudioProcessor.lookupCachedTranscript`) keyed by `attachment.originalUrl`. `extractAttachments` (`bot-client/utils/attachmentExtractor.ts`) never set `originalUrl`. The reader's early-return guard (`if (originalUrl === undefined) return null`) bailed on EVERY lookup — zero cache hits in prod across ~14 transcriptions observed in the window.

The cache lookup runs in the AudioTranscriptionJob child of the LLM generation flow. With no cache hit, voice-engine got called a second time for the same audio, producing different text (STT is non-deterministic on noisy audio).

**Fix:** `extractAttachments` now sets `originalUrl: attachment.url`. Cache-stable key now survives downstream pipeline transformations (DownloadAttachmentsStep rewrites `url` to a data URL but preserves `originalUrl`).

### Bug 2: Cold-start timeout

`STT_GATEWAY = 120s` was too tight for the observed Railway-serverless cold-start. Voice-engine wake + model load + first transcription took 135s end-to-end on the user's request. Bot-client timed out at 120s.

**Fix:** `STT_GATEWAY → 240s` (= `AUDIO_FETCH 30s + VOICE_ENGINE_API 180s + 30s queue/network margin`). Absorbs the observed cold-start worst case with headroom for downstream caps, while staying well under `JOB_WAIT` (10 min) so user feedback stays timely on real hangs.

## Evidence trail (from prod logs)

| Layer | Doubling evidence |
|-------|-------------------|
| voice-engine | 8 confirmed `Transcribed audio` pairs in 16 min, identical char counts within each pair |
| ai-worker | `Audio transcribed via Mistral STT` (186 chars) appears twice for same audio |
| api-gateway | TWO `Created transcribe job` events per voice message (different requestIds) |
| Cache | `Using cached voice transcript from Redis` log fires **0 times** across the window |

Discord webhook send pairs at 03:00:36.013/.014/.019 confirmed the symptom was bi-directional and visible to the user.

## Test plan
- [x] New regression test in `attachmentExtractor.test.ts`: \"should set originalUrl equal to url for cache-stable lookup\"
- [x] Existing full-shape test (line 71) updated to include \`originalUrl\` in the expected object; other tests use field-level assertions that didn't need updating
- [x] Full \`pnpm test\` green (~7000 tests across services)
- [x] \`pnpm quality\` green
- [ ] Manual: post-deploy, verify voice-engine logs show single transcription per audio + voice messages succeed on a cold-start cycle (Railway serverless wake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)