### PR TITLE
fix(bot-client): let activation slot fire on forwarded messages

### DIFF
--- a/services/bot-client/src/processors/PersonalityTriggerProcessor.test.ts
+++ b/services/bot-client/src/processors/PersonalityTriggerProcessor.test.ts
@@ -98,13 +98,6 @@ describe('PersonalityTriggerProcessor', () => {
   });
 
   describe('Pass-through cases', () => {
-    it('returns false for forwarded messages', async () => {
-      vi.mocked(isForwardedMessage).mockReturnValueOnce(true);
-      const result = await processor.process(buildMessage());
-      expect(result).toBe(false);
-      expect(coordinator.startFanOut).not.toHaveBeenCalled();
-    });
-
     it('returns false when no trigger sources match', async () => {
       const result = await processor.process(buildMessage());
       expect(result).toBe(false);
@@ -323,6 +316,68 @@ describe('PersonalityTriggerProcessor', () => {
       expect(arg.slots).toHaveLength(1);
       expect(arg.slots[0].source).toBe('mention');
       expect(result).toBe(true);
+    });
+  });
+
+  describe('Forwarded messages', () => {
+    it('lets activation slot fire on forwarded messages (image-only screenshots etc.)', async () => {
+      // Invariant: in an activated channel, the activation slot fires for
+      // forwarded messages regardless of text content. The forwarder's intent
+      // is to share something into the channel; the activated personality
+      // owns the response policy.
+      vi.mocked(isForwardedMessage).mockReturnValue(true);
+      const ambient = buildPersonality('Ambient');
+      gatewayClient.getChannelSettings.mockResolvedValue({
+        hasSettings: true,
+        settings: { personalitySlug: 'ambient', personalityName: 'Ambient' },
+      });
+      personalityService.loadPersonality.mockResolvedValue(ambient);
+
+      const result = await processor.process(buildMessage({ content: '' }));
+
+      expect(result).toBe(true);
+      expect(coordinator.startFanOut).toHaveBeenCalledOnce();
+      const arg = coordinator.startFanOut.mock.calls[0][0];
+      expect(arg.slots).toHaveLength(1);
+      expect(arg.slots[0]).toMatchObject({
+        personality: ambient,
+        source: 'activation',
+        isAutoResponse: true,
+      });
+    });
+
+    it('skips reply resolution on forwarded messages even if message.reference is set', async () => {
+      // A forwarded message can technically carry a `reference` field, but
+      // the forwarder isn't replying to the bot — the field tracks the
+      // origin of the forward, not a webhook-reply intent. Skip resolution
+      // to avoid spurious slot population.
+      vi.mocked(isForwardedMessage).mockReturnValue(true);
+      const ambient = buildPersonality('Ambient');
+      gatewayClient.getChannelSettings.mockResolvedValue({
+        hasSettings: true,
+        settings: { personalitySlug: 'ambient', personalityName: 'Ambient' },
+      });
+      personalityService.loadPersonality.mockResolvedValue(ambient);
+
+      await processor.process(buildMessage({ reference: { messageId: 'origin-msg' } }));
+
+      expect(replyResolver.resolvePersonality).not.toHaveBeenCalled();
+      expect(coordinator.startFanOut).toHaveBeenCalledOnce();
+    });
+
+    it('skips inline mention resolution on forwarded messages — text content is the original author, not the forwarder', async () => {
+      vi.mocked(isForwardedMessage).mockReturnValue(true);
+      const alice = buildPersonality('Alice');
+      vi.mocked(findPersonalityMentions).mockResolvedValue([{ personality: alice, startIndex: 0 }]);
+      // No activation either — the forwarded message should fall through to
+      // the next processor since neither activation nor mention applies.
+      gatewayClient.getChannelSettings.mockResolvedValue({ hasSettings: false });
+
+      const result = await processor.process(buildMessage({ content: '@Alice forwarded' }));
+
+      expect(findPersonalityMentions).not.toHaveBeenCalled();
+      expect(result).toBe(false);
+      expect(coordinator.startFanOut).not.toHaveBeenCalled();
     });
   });
 

--- a/services/bot-client/src/processors/PersonalityTriggerProcessor.ts
+++ b/services/bot-client/src/processors/PersonalityTriggerProcessor.ts
@@ -51,10 +51,6 @@ export class PersonalityTriggerProcessor implements IMessageProcessor {
   constructor(private readonly deps: PersonalityTriggerProcessorDeps) {}
 
   async process(message: Message): Promise<boolean> {
-    if (isForwardedMessage(message)) {
-      logger.debug({ messageId: message.id }, 'Skipping forwarded message');
-      return false;
-    }
     if (!isTypingChannel(message.channel)) {
       // Coordinator + chat manager need a TypingChannel for delivery; bail
       // out for channel types we don't support (announcement guild forum,
@@ -64,6 +60,11 @@ export class PersonalityTriggerProcessor implements IMessageProcessor {
 
     const userId = message.author.id;
     const channel = message.channel;
+    // Forwards: activation fires (forwarder posted into activated channel),
+    // but reply/mention resolution is skipped — forwards carry no webhook-
+    // reply relationship and text content was authored by the *original*
+    // sender.
+    const forwarded = isForwardedMessage(message);
 
     // Resolve the three trigger sources in parallel — they don't depend on
     // each other and each may produce 0..1 personalities.
@@ -75,9 +76,11 @@ export class PersonalityTriggerProcessor implements IMessageProcessor {
     // resolution doesn't propagate. The duplicated cold-cache fetch is an
     // acceptable cost for keeping the resolvers independent.
     const [replyPersonality, activatedPersonality, mentionedPersonalities] = await Promise.all([
-      this.resolveReplyPersonality(message, userId),
+      forwarded ? Promise.resolve(null) : this.resolveReplyPersonality(message, userId),
       this.resolveActivatedPersonality(message, userId),
-      this.resolveMentionedPersonalities(message, userId),
+      forwarded
+        ? Promise.resolve<LoadedPersonality[]>([])
+        : this.resolveMentionedPersonalities(message, userId),
     ]);
 
     const slots = resolveSlots({


### PR DESCRIPTION
## Summary

Closes intake item #2 from the 2026-05-17 system-prompt-dump intake.

\`PersonalityTriggerProcessor\` previously skipped ALL forwarded messages unconditionally at the top of \`process()\`. The user-visible symptom: in an activated channel, a forwarded screenshot (or any forwarded image-only message) was silently dropped — even though the forwarder's intent was clearly to share something into a channel where the activated personality is supposed to respond to everything.

**Fix:** carve out reply + mention slot resolution for forwarded messages while keeping activation active.

- **Reply slot skipped** — forwards don't carry a webhook-reply relationship; \`message.reference\` (if set) tracks the origin of the forward, not a reply target.
- **Mention slot skipped** — any \"@Cold\" text inside a forwarded screenshot caption was authored by the *original* sender, not the forwarder. Treating it as a mention would respond to phantom intent.
- **Activation slot active** — the forwarder posted into an activated channel. The activated personality should respond to whatever was shared.

## Test plan

- [x] \`pnpm --filter bot-client test\` (4866 tests, 3 new for the carve-out: activation fires, reply skipped even with \`reference\` set, mention skipped even when \`findPersonalityMentions\` would resolve a hit)
- [x] \`pnpm quality\` (lint + cpd + depcruise + typecheck all green)
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)