### PR TITLE
fix(bot-client): poll BullMQ job state on MultiTagRecovery rehydration

### DIFF
--- a/services/bot-client/src/composition.ts
+++ b/services/bot-client/src/composition.ts
@@ -39,6 +39,7 @@ import { SlotDeliveryService } from './services/SlotDeliveryService.js';
 import { MultiTagCoordinator } from './services/MultiTagCoordinator.js';
 import { MultiTagPersistence } from './services/MultiTagPersistence.js';
 import { MultiTagRecovery } from './services/MultiTagRecovery.js';
+import type { Queue } from 'bullmq';
 import type { Redis } from 'ioredis';
 import type { Client } from 'discord.js';
 import type { IPersonalityLoader } from './types/IPersonalityLoader.js';
@@ -109,18 +110,16 @@ export function buildMultiTagCoordinator(deps: {
 export function buildMultiTagRecovery(deps: {
   persistence: MultiTagPersistence;
   coordinator: MultiTagCoordinator;
-  chatManager: PersonalityChatManager;
-  jobTracker: JobTracker;
   personalityService: IPersonalityLoader;
   discordClient: Client;
+  queue: Queue;
 }): MultiTagRecovery {
   return new MultiTagRecovery({
     persistence: deps.persistence,
     coordinator: deps.coordinator,
-    chatManager: deps.chatManager,
-    jobTracker: deps.jobTracker,
     personalityService: deps.personalityService,
     discordClient: deps.discordClient,
+    queue: deps.queue,
   });
 }
 
@@ -138,6 +137,7 @@ export function buildMultiTagStack(deps: {
   slotDelivery: SlotDeliveryService;
   personalityService: IPersonalityLoader;
   discordClient: Client;
+  recoveryQueue: Queue;
 }): {
   coordinator: MultiTagCoordinator;
   persistence: MultiTagPersistence;
@@ -154,10 +154,9 @@ export function buildMultiTagStack(deps: {
   const recovery = buildMultiTagRecovery({
     persistence,
     coordinator,
-    chatManager: deps.chatManager,
-    jobTracker: deps.jobTracker,
     personalityService: deps.personalityService,
     discordClient: deps.discordClient,
+    queue: deps.recoveryQueue,
   });
   return { coordinator, persistence, recovery };
 }

--- a/services/bot-client/src/index.ts
+++ b/services/bot-client/src/index.ts
@@ -6,6 +6,7 @@ import {
   Partials,
   type ChatInputCommandInteraction,
 } from 'discord.js';
+import { Queue } from 'bullmq';
 import { Redis } from 'ioredis';
 import {
   createLogger,
@@ -21,6 +22,8 @@ import {
   disconnectPrisma,
   getPrismaClient,
   getConfig,
+  parseRedisUrl,
+  createBullMQRedisConfig,
 } from '@tzurot/common-types';
 import {
   GatewayClient,
@@ -143,6 +146,12 @@ interface Services {
   multiTagCoordinator: MultiTagCoordinator;
   multiTagPersistence: MultiTagPersistence;
   multiTagRecovery: MultiTagRecovery;
+  /**
+   * BullMQ Queue handle used by MultiTagRecovery to poll the authoritative
+   * state of jobs that were in flight at the previous process's shutdown.
+   * Owned by the composition root; closed in the shutdown sequence.
+   */
+  multiTagRecoveryQueue: Queue;
 }
 
 /**
@@ -236,6 +245,16 @@ function createServices(): Services {
     gatewayClient,
   });
 
+  // BullMQ Queue handle for MultiTagRecovery's state polling. Constructed
+  // here (rather than inside MultiTagRecovery) so its lifecycle is visible
+  // to the shutdown sequence below. Mirrors the existing
+  // BullMQ-config pattern in JobFailureListener — same QUEUE_NAME + same
+  // ioredis connection config derived from REDIS_URL.
+  const multiTagRecoveryQueue = new Queue(envConfig.QUEUE_NAME, {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- REDIS_URL validated by validateRedisUrl() in buildCacheRedis() above
+    connection: createBullMQRedisConfig(parseRedisUrl(envConfig.REDIS_URL!)),
+  });
+
   // Multi-tag stack: coordinator + Redis persistence + recovery service.
   // Persistence is shared with DMSessionProcessor (backfill sentinel).
   // Recovery's `run()` is invoked later in start() AFTER `client.login()`.
@@ -252,6 +271,7 @@ function createServices(): Services {
     slotDelivery,
     personalityService,
     discordClient: client,
+    recoveryQueue: multiTagRecoveryQueue,
   });
 
   // Processor chain (order matters — see buildProcessorChain doc).
@@ -309,6 +329,7 @@ function createServices(): Services {
     multiTagCoordinator,
     multiTagPersistence,
     multiTagRecovery,
+    multiTagRecoveryQueue,
     dmCacheWarmer,
   };
 }
@@ -583,6 +604,7 @@ function handleShutdownSignal(signal: NodeJS.Signals): void {
           services.personaCacheInvalidationService.unsubscribe(),
           services.channelActivationCacheInvalidationService.unsubscribe(),
           services.denylistCacheInvalidationService.unsubscribe(),
+          services.multiTagRecoveryQueue.close(),
           closeRedis(),
           client.destroy(),
           disconnectPrisma(),

--- a/services/bot-client/src/services/MultiTagRecovery.test.ts
+++ b/services/bot-client/src/services/MultiTagRecovery.test.ts
@@ -2,16 +2,24 @@
  * Tests for MultiTagRecovery — the startup hook that rehydrates in-flight
  * multi-tag fan-outs after a bot restart.
  *
- * Strategy: mock every external dep (persistence, coordinator, chatManager,
- * jobTracker, personalityService, Discord client). Drive the recovery
- * lifecycle by feeding in pre-built snapshots and asserting on the calls
- * the recovery service makes downstream.
+ * Strategy: mock every external dep (persistence, coordinator, queue,
+ * personalityService, Discord client). Drive the recovery lifecycle by
+ * feeding in pre-built snapshots and asserting on the calls the recovery
+ * service makes downstream.
+ *
+ * The core invariant under test: rebuildSlot polls BullMQ for the prior
+ * job's authoritative state and dispatches accordingly — completed/failed
+ * results from the prior process get delivered via handleJobResult AFTER
+ * adoption, in-flight jobs are trusted to the live stream subscription,
+ * and unrecoverable jobs (evicted from Redis) get a synthetic error
+ * delivered.
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { Client, Message, Channel } from 'discord.js';
+import type { Queue } from 'bullmq';
 import { ChannelType } from 'discord.js';
-import type { LoadedPersonality } from '@tzurot/common-types';
+import type { LLMGenerationResult, LoadedPersonality } from '@tzurot/common-types';
 import { MultiTagRecovery, type MultiTagRecoveryDeps } from './MultiTagRecovery.js';
 import type { CoordinatorEntrySnapshot } from './MultiTagPersistence.js';
 
@@ -52,6 +60,28 @@ function buildSnapshot(
   };
 }
 
+/**
+ * Builder for the mocked BullMQ Job returned by queue.getJob. State and
+ * payload are parameterized; the mock surface is intentionally narrow —
+ * production code only reads `getState()`, `returnvalue`, and
+ * `failedReason`, so the test mock matches.
+ */
+function buildMockJob(opts: {
+  state: string;
+  returnvalue?: LLMGenerationResult;
+  failedReason?: string;
+}): {
+  getState: ReturnType<typeof vi.fn>;
+  returnvalue?: LLMGenerationResult;
+  failedReason?: string;
+} {
+  return {
+    getState: vi.fn().mockResolvedValue(opts.state),
+    returnvalue: opts.returnvalue,
+    failedReason: opts.failedReason,
+  };
+}
+
 describe('MultiTagRecovery', () => {
   let persistence: {
     scanAllEntries: ReturnType<typeof vi.fn>;
@@ -63,12 +93,10 @@ describe('MultiTagRecovery', () => {
     adoptRehydratedEntry: ReturnType<typeof vi.fn>;
     noteRecoveryMarkedStale: ReturnType<typeof vi.fn>;
     handleSafetyTimeoutPublic: ReturnType<typeof vi.fn>;
+    handleJobResult: ReturnType<typeof vi.fn>;
   };
-  let chatManager: {
-    submitChatJob: ReturnType<typeof vi.fn>;
-  };
-  let jobTracker: {
-    trackJob: ReturnType<typeof vi.fn>;
+  let queue: {
+    getJob: ReturnType<typeof vi.fn>;
   };
   let personalityService: {
     loadPersonality: ReturnType<typeof vi.fn>;
@@ -95,15 +123,13 @@ describe('MultiTagRecovery', () => {
       adoptRehydratedEntry: vi.fn().mockResolvedValue(undefined),
       noteRecoveryMarkedStale: vi.fn(),
       handleSafetyTimeoutPublic: vi.fn().mockResolvedValue(undefined),
+      handleJobResult: vi.fn().mockResolvedValue(undefined),
     };
-    chatManager = {
-      submitChatJob: vi.fn().mockImplementation(async ({ personality }) => ({
-        kind: 'submitted',
-        jobId: `new-job-${personality.name}`,
-        trackingContext: { personaId: `persona-${personality.name}` },
-      })),
+    // Default: every job returns 'active' state — the "trust the stream"
+    // path. Individual tests override per-jobId via mockImplementation.
+    queue = {
+      getJob: vi.fn().mockImplementation(async () => buildMockJob({ state: 'active' })),
     };
-    jobTracker = { trackJob: vi.fn() };
     personalityService = {
       // Recovery looks up by ID first (stable), falls back to slug (mutable).
       // Snapshots in this test use `personalityId: 'id-alice'` and
@@ -131,57 +157,227 @@ describe('MultiTagRecovery', () => {
     recovery = new MultiTagRecovery({
       persistence: persistence as unknown as MultiTagRecoveryDeps['persistence'],
       coordinator: coordinator as unknown as MultiTagRecoveryDeps['coordinator'],
-      chatManager: chatManager as unknown as MultiTagRecoveryDeps['chatManager'],
-      jobTracker: jobTracker as unknown as MultiTagRecoveryDeps['jobTracker'],
       personalityService:
         personalityService as unknown as MultiTagRecoveryDeps['personalityService'],
       discordClient: discordClient as unknown as Client,
+      queue: queue as unknown as Queue,
     });
   });
 
-  describe('happy path', () => {
-    it('rehydrates a single pending slot and reports stats', async () => {
+  describe('completed-job recovery (synthetic delivery)', () => {
+    it("polls BullMQ, finds 'completed' state, and delivers job.returnvalue via handleJobResult", async () => {
+      const priorResult: LLMGenerationResult = {
+        requestId: 'old-job-Alice',
+        success: true,
+        content: 'response from the prior process',
+      };
+      queue.getJob.mockResolvedValue(
+        buildMockJob({ state: 'completed', returnvalue: priorResult })
+      );
       persistence.scanAllEntries.mockResolvedValue([buildSnapshot()]);
 
       const stats = await recovery.run();
 
       expect(stats.entriesScanned).toBe(1);
       expect(stats.entriesResumed).toBe(1);
-      expect(stats.slotsResubmitted).toBe(1);
-      expect(stats.staleJobIdsMarked).toBe(1);
-
-      // Old jobId marked stale
-      expect(persistence.markStale).toHaveBeenCalledWith('old-job-Alice');
-      // New job submitted + tracked
-      expect(chatManager.submitChatJob).toHaveBeenCalledOnce();
-      expect(jobTracker.trackJob).toHaveBeenCalledWith('new-job-alice', expect.any(Object), {
-        skipOrderingRegistration: true,
-      });
-      // Adopted into coordinator
+      expect(stats.slotsRecoveredCompleted).toBe(1);
+      expect(stats.slotsTrustedToStream).toBe(0);
+      // Entry adopted; THEN handleJobResult invoked with prior process's result.
       expect(coordinator.adoptRehydratedEntry).toHaveBeenCalledOnce();
-      // Coordinator notified about stale marks
-      expect(coordinator.noteRecoveryMarkedStale).toHaveBeenCalledOnce();
-      // Updated snapshot persisted with the new jobId, not the stale one.
-      // This locks in the EXPIRE→SET fix in updateEntry: the new jobId's
-      // reverse-index must be CREATED here, not just have its TTL
-      // refreshed (refresh on a non-existent key is a Redis no-op).
-      expect(persistence.updateEntry).toHaveBeenCalledOnce();
-      expect(persistence.updateEntry).toHaveBeenCalledWith(
+      expect(coordinator.handleJobResult).toHaveBeenCalledOnce();
+      expect(coordinator.handleJobResult).toHaveBeenCalledWith('old-job-Alice', priorResult);
+      // No stale marking on the recovered slot — its jobId is still the live
+      // tracking ID, and the prior result is what we're consuming.
+      expect(persistence.markStale).not.toHaveBeenCalled();
+    });
+
+    it('preserves call ordering: adoptRehydratedEntry runs strictly before handleJobResult', async () => {
+      // The coordinator's jobToGroup map is populated by adoption; calling
+      // handleJobResult first would silently drop the result (warn + return).
+      // This ordering is load-bearing.
+      const callOrder: string[] = [];
+      coordinator.adoptRehydratedEntry.mockImplementation(async () => {
+        callOrder.push('adopt');
+      });
+      coordinator.handleJobResult.mockImplementation(async () => {
+        callOrder.push('handleJobResult');
+      });
+      queue.getJob.mockResolvedValue(
+        buildMockJob({
+          state: 'completed',
+          returnvalue: { requestId: 'old-job-Alice', success: true, content: 'hi' },
+        })
+      );
+      persistence.scanAllEntries.mockResolvedValue([buildSnapshot()]);
+
+      await recovery.run();
+
+      expect(callOrder).toEqual(['adopt', 'handleJobResult']);
+    });
+  });
+
+  describe('failed-job recovery (synthetic error delivery)', () => {
+    it("polls BullMQ, finds 'failed' state, and synthesizes an error LLMGenerationResult", async () => {
+      queue.getJob.mockResolvedValue(
+        buildMockJob({ state: 'failed', failedReason: 'OpenRouter 502 Bad Gateway' })
+      );
+      persistence.scanAllEntries.mockResolvedValue([buildSnapshot()]);
+
+      const stats = await recovery.run();
+
+      expect(stats.slotsRecoveredFailed).toBe(1);
+      expect(coordinator.handleJobResult).toHaveBeenCalledWith(
+        'old-job-Alice',
         expect.objectContaining({
-          slots: expect.arrayContaining([
-            expect.objectContaining({ jobId: 'new-job-alice', status: 'pending' }),
-          ]),
+          requestId: 'old-job-Alice',
+          success: false,
+          error: 'OpenRouter 502 Bad Gateway',
         })
       );
     });
 
-    it('rehydrates multiple pending slots with fresh jobIds each', async () => {
+    it("falls back to 'Unknown failure' when job has no failedReason", async () => {
+      queue.getJob.mockResolvedValue(buildMockJob({ state: 'failed' }));
+      persistence.scanAllEntries.mockResolvedValue([buildSnapshot()]);
+
+      await recovery.run();
+
+      expect(coordinator.handleJobResult).toHaveBeenCalledWith(
+        'old-job-Alice',
+        expect.objectContaining({ success: false, error: 'Unknown failure' })
+      );
+    });
+  });
+
+  describe('in-flight job recovery (trust the stream)', () => {
+    it.each(['active', 'waiting', 'delayed', 'prioritized', 'waiting-children'])(
+      "leaves slot pending with old jobId when state is '%s'",
+      async (state: string) => {
+        queue.getJob.mockResolvedValue(buildMockJob({ state }));
+        persistence.scanAllEntries.mockResolvedValue([buildSnapshot()]);
+
+        const stats = await recovery.run();
+
+        expect(stats.slotsTrustedToStream).toBe(1);
+        expect(stats.slotsRecoveredCompleted).toBe(0);
+        expect(stats.slotsRecoveredFailed).toBe(0);
+        expect(coordinator.adoptRehydratedEntry).toHaveBeenCalledOnce();
+        // No deferred delivery; the live stream + QueueEvents will deliver
+        // once they attach.
+        expect(coordinator.handleJobResult).not.toHaveBeenCalled();
+        // Slot keeps its original jobId — not marked stale, not resubmitted.
+        expect(persistence.markStale).not.toHaveBeenCalled();
+      }
+    );
+  });
+
+  describe('unrecoverable job (evicted from Redis or unknown state)', () => {
+    it('delivers synthetic "Result unavailable after restart" when getJob returns null', async () => {
+      queue.getJob.mockResolvedValue(null);
+      persistence.scanAllEntries.mockResolvedValue([buildSnapshot()]);
+
+      const stats = await recovery.run();
+
+      expect(stats.slotsUnrecoverable).toBe(1);
+      expect(coordinator.handleJobResult).toHaveBeenCalledWith(
+        'old-job-Alice',
+        expect.objectContaining({
+          success: false,
+          error: 'Result unavailable after restart',
+        })
+      );
+    });
+
+    it("treats 'completed' with undefined returnvalue as unrecoverable (worker-crash or GC-race guard)", async () => {
+      // Architectural guarantee: ai-worker handlers return LLMGenerationResult.
+      // Edge cases that break that guarantee at runtime: worker crash after
+      // moveToCompleted but before returnvalue persist, or removeOnComplete
+      // GC racing the state→returnvalue read window. Routing through the
+      // unrecoverable path keeps the user-visible error message correct
+      // ("Result unavailable") instead of letting a malformed result reach
+      // coordinator.handleJobResult.
+      queue.getJob.mockResolvedValue(buildMockJob({ state: 'completed', returnvalue: undefined }));
+      persistence.scanAllEntries.mockResolvedValue([buildSnapshot()]);
+
+      const stats = await recovery.run();
+
+      expect(stats.slotsUnrecoverable).toBe(1);
+      expect(stats.slotsRecoveredCompleted).toBe(0);
+      expect(coordinator.handleJobResult).toHaveBeenCalledWith(
+        'old-job-Alice',
+        expect.objectContaining({
+          success: false,
+          error: 'Result unavailable after restart',
+        })
+      );
+    });
+
+    it("delivers synthetic error when state is 'unknown' (or any future BullMQ state)", async () => {
+      queue.getJob.mockResolvedValue(buildMockJob({ state: 'unknown' }));
+      persistence.scanAllEntries.mockResolvedValue([buildSnapshot()]);
+
+      const stats = await recovery.run();
+
+      expect(stats.slotsUnrecoverable).toBe(1);
+      expect(coordinator.handleJobResult).toHaveBeenCalledWith(
+        'old-job-Alice',
+        expect.objectContaining({ success: false })
+      );
+    });
+  });
+
+  describe('error tolerance during state polling', () => {
+    it("falls back to 'inFlight' (no delivery, trust stream) when queue.getJob throws", async () => {
+      queue.getJob.mockRejectedValue(new Error('Redis blip'));
+      persistence.scanAllEntries.mockResolvedValue([buildSnapshot()]);
+
+      const stats = await recovery.run();
+
+      expect(stats.slotsTrustedToStream).toBe(1);
+      expect(stats.slotsUnrecoverable).toBe(0);
+      expect(coordinator.handleJobResult).not.toHaveBeenCalled();
+      // Slot still adopted — recovery continues normally.
+      expect(coordinator.adoptRehydratedEntry).toHaveBeenCalledOnce();
+    });
+
+    it("falls back to 'inFlight' when job.getState throws", async () => {
+      queue.getJob.mockResolvedValue({
+        getState: vi.fn().mockRejectedValue(new Error('Connection lost')),
+        returnvalue: undefined,
+        failedReason: undefined,
+      });
+      persistence.scanAllEntries.mockResolvedValue([buildSnapshot()]);
+
+      const stats = await recovery.run();
+
+      expect(stats.slotsTrustedToStream).toBe(1);
+      expect(coordinator.handleJobResult).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('mixed entries', () => {
+    it('routes each slot independently when an entry has slots in different BullMQ states', async () => {
+      const completedResult: LLMGenerationResult = {
+        requestId: 'old-job-Alice',
+        success: true,
+        content: 'Alice completed during the gap',
+      };
+      // Slot A completed; slot B still active.
+      queue.getJob.mockImplementation(async (jobId: string) => {
+        if (jobId === 'old-job-Alice') {
+          return buildMockJob({ state: 'completed', returnvalue: completedResult });
+        }
+        if (jobId === 'old-job-Bob') {
+          return buildMockJob({ state: 'active' });
+        }
+        return null;
+      });
       const snapshot = buildSnapshot({
         slots: [
           {
             slotIndex: 0,
             personalityId: 'id-alice',
-            personalitySlug: 'Alice',
+            personalitySlug: 'alice',
             source: 'mention',
             isAutoResponse: false,
             jobId: 'old-job-Alice',
@@ -190,7 +386,7 @@ describe('MultiTagRecovery', () => {
           {
             slotIndex: 1,
             personalityId: 'id-bob',
-            personalitySlug: 'Bob',
+            personalitySlug: 'bob',
             source: 'mention',
             isAutoResponse: false,
             jobId: 'old-job-Bob',
@@ -202,10 +398,11 @@ describe('MultiTagRecovery', () => {
 
       const stats = await recovery.run();
 
-      expect(stats.slotsResubmitted).toBe(2);
-      expect(stats.staleJobIdsMarked).toBe(2);
-      expect(persistence.markStale).toHaveBeenCalledWith('old-job-Alice');
-      expect(persistence.markStale).toHaveBeenCalledWith('old-job-Bob');
+      expect(stats.slotsRecoveredCompleted).toBe(1);
+      expect(stats.slotsTrustedToStream).toBe(1);
+      // Only Alice's completed result delivers; Bob waits for the stream.
+      expect(coordinator.handleJobResult).toHaveBeenCalledOnce();
+      expect(coordinator.handleJobResult).toHaveBeenCalledWith('old-job-Alice', completedResult);
     });
   });
 
@@ -218,12 +415,13 @@ describe('MultiTagRecovery', () => {
 
       expect(stats.entriesDiscarded).toBe(1);
       expect(stats.entriesResumed).toBe(0);
-      // Old jobId still marked stale to protect against late delivery
+      // Pending jobIds still marked stale on discard — late deliveries
+      // wouldn't have an entry to route to and should be silently dropped.
       expect(persistence.markStale).toHaveBeenCalledWith('old-job-Alice');
-      // Entry removed from Redis
       expect(persistence.deleteEntry).toHaveBeenCalledOnce();
-      // Coordinator NOT adopted
       expect(coordinator.adoptRehydratedEntry).not.toHaveBeenCalled();
+      // No state poll either — the discard short-circuits before slot rebuild.
+      expect(queue.getJob).not.toHaveBeenCalled();
     });
 
     it('discards an entry when the source message is gone', async () => {
@@ -254,119 +452,45 @@ describe('MultiTagRecovery', () => {
 
   describe('access-revoked slots', () => {
     it('marks a slot errored when its personality is no longer accessible', async () => {
-      // Recovery now tries ID first, falls back to slug. Both must return
-      // null for the slot to be treated as revoked.
+      // Recovery tries ID first, falls back to slug. Both must return null
+      // for the slot to be treated as revoked.
       personalityService.loadPersonality.mockResolvedValue(null);
       persistence.scanAllEntries.mockResolvedValue([buildSnapshot()]);
 
       const stats = await recovery.run();
 
       expect(stats.slotsAccessRevoked).toBe(1);
-      // Slot still marked stale; the slot stays in the entry as errored
-      expect(persistence.markStale).toHaveBeenCalledWith('old-job-Alice');
-      // Resubmit NOT called because personality couldn't be loaded
-      expect(chatManager.submitChatJob).not.toHaveBeenCalled();
+      // No state poll — when the personality is gone we can't render the
+      // result anyway, so the slot becomes a synthetic-error slot regardless
+      // of the prior job's state.
+      expect(queue.getJob).not.toHaveBeenCalled();
       // Entry STILL adopted (errored slot is delivered as an error message)
       expect(coordinator.adoptRehydratedEntry).toHaveBeenCalledOnce();
       expect(stats.entriesResumed).toBe(1);
     });
 
-    it('keeps slot as errored (not dropped) when personality is inaccessible at recovery', async () => {
-      const snapshot = buildSnapshot({
-        slots: [
-          {
-            slotIndex: 0,
-            personalityId: 'id-a',
-            personalitySlug: 'a',
-            source: 'mention',
-            isAutoResponse: false,
-            jobId: 'old-a',
-            status: 'pending',
-          },
-        ],
-      });
-      personalityService.loadPersonality.mockResolvedValue(null);
-      persistence.scanAllEntries.mockResolvedValue([snapshot]);
-
-      const stats = await recovery.run();
-
-      // Revoked slots are kept (with sentinel personality) rather than
-      // dropped — the group still flushes a fallback error message for
-      // that slot rather than silently vanishing it. So the entry IS
-      // adopted, and `slotsAccessRevoked` reflects the loss.
-      expect(stats.slotsAccessRevoked).toBe(1);
-      expect(stats.entriesResumed).toBe(1);
-      expect(stats.entriesDiscarded).toBe(0);
-    });
-
     it('falls back to slug lookup when ID lookup returns null (slug rename)', async () => {
-      // Scenario: personality was renamed (new slug) between snapshot
-      // write and recovery. Looking up by the OLD slug from the snapshot
-      // would fail, but the ID is stable. Reverse: this test simulates
-      // ID failing first (loader doesn't recognize the UUID for some
-      // reason), and the slug fallback rescues the lookup.
+      // Scenario: ID-form lookup fails (loader doesn't recognize the UUID
+      // for some reason), slug-form succeeds. Slot recovers normally.
       personalityService.loadPersonality.mockImplementation(
         async (nameOrId: string): Promise<LoadedPersonality | null> => {
-          // ID-form lookup fails; slug-form succeeds.
           if (nameOrId.startsWith('id-')) return null;
           return buildPersonality(nameOrId);
         }
       );
       persistence.scanAllEntries.mockResolvedValue([buildSnapshot()]);
 
-      const stats = await recovery.run();
+      await recovery.run();
 
-      // Both lookups attempted: ID first (null), then slug (success).
       expect(personalityService.loadPersonality).toHaveBeenCalledWith('id-alice', 'user-1');
       expect(personalityService.loadPersonality).toHaveBeenCalledWith('alice', 'user-1');
-      // Slot recovered via slug fallback — not treated as revoked.
-      expect(stats.slotsAccessRevoked).toBe(0);
-      expect(stats.slotsResubmitted).toBe(1);
+      // State poll runs because the slug fallback rescued the personality.
+      expect(queue.getJob).toHaveBeenCalledWith('old-job-Alice');
     });
   });
 
-  describe('terminal slots', () => {
-    it('preserves slots already in completed/errored state without resubmitting', async () => {
-      const snapshot = buildSnapshot({
-        slots: [
-          {
-            slotIndex: 0,
-            personalityId: 'id-alice',
-            personalitySlug: 'Alice',
-            source: 'mention',
-            isAutoResponse: false,
-            jobId: 'old-job-Alice',
-            status: 'completed',
-          },
-          {
-            slotIndex: 1,
-            personalityId: 'id-bob',
-            personalitySlug: 'Bob',
-            source: 'mention',
-            isAutoResponse: false,
-            jobId: 'old-job-Bob',
-            status: 'pending',
-          },
-        ],
-      });
-      persistence.scanAllEntries.mockResolvedValue([snapshot]);
-
-      const stats = await recovery.run();
-
-      expect(stats.slotsResubmitted).toBe(1); // Only Bob
-      expect(stats.staleJobIdsMarked).toBe(1); // Only Bob's jobId
-      // Alice not resubmitted
-      expect(chatManager.submitChatJob).toHaveBeenCalledOnce();
-      expect(chatManager.submitChatJob).toHaveBeenCalledWith(
-        expect.objectContaining({ personality: expect.objectContaining({ slug: 'bob' }) })
-      );
-    });
-
-    it('skips updateEntry when every slot is already terminal (adoptRehydratedEntry flushes immediately)', async () => {
-      // When all slots are terminal at recovery time, adoptRehydratedEntry
-      // calls flushEntry → deliverGroup → deleteEntry synchronously. The
-      // subsequent updateEntry call must be skipped so we don't orphan a
-      // snapshot at a Redis key that was just deleted.
+  describe('terminal slots in snapshot', () => {
+    it('preserves slots already in completed/errored state without polling BullMQ', async () => {
       const snapshot = buildSnapshot({
         slots: [
           {
@@ -378,19 +502,25 @@ describe('MultiTagRecovery', () => {
             jobId: 'old-job-Alice',
             status: 'completed',
           },
+          {
+            slotIndex: 1,
+            personalityId: 'id-bob',
+            personalitySlug: 'bob',
+            source: 'mention',
+            isAutoResponse: false,
+            jobId: 'old-job-Bob',
+            status: 'pending',
+          },
         ],
       });
       persistence.scanAllEntries.mockResolvedValue([snapshot]);
 
-      const stats = await recovery.run();
+      await recovery.run();
 
-      expect(stats.entriesResumed).toBe(1);
-      expect(stats.slotsResubmitted).toBe(0); // Nothing to resubmit
-      // Adopted into coordinator (which would synchronously flush)
-      expect(coordinator.adoptRehydratedEntry).toHaveBeenCalledOnce();
-      // updateEntry NOT called — entry was already terminal, no new state
-      // to persist back, and deleteEntry already ran inside the flush.
-      expect(persistence.updateEntry).not.toHaveBeenCalled();
+      // Only Bob's pending slot triggers a state poll; Alice's snapshot-terminal
+      // slot is preserved as-is.
+      expect(queue.getJob).toHaveBeenCalledOnce();
+      expect(queue.getJob).toHaveBeenCalledWith('old-job-Bob');
     });
   });
 
@@ -433,26 +563,27 @@ describe('MultiTagRecovery', () => {
   });
 
   describe('coordinator notification', () => {
-    it('calls noteRecoveryMarkedStale only when at least one stale jobId was marked', async () => {
-      // Pure-terminal entries: no pending slots, no stale marks.
-      const allTerminalSnapshot = buildSnapshot({
-        slots: [
-          {
-            slotIndex: 0,
-            personalityId: 'id-alice',
-            personalitySlug: 'Alice',
-            source: 'mention',
-            isAutoResponse: false,
-            jobId: 'old-job-Alice',
-            status: 'completed',
-          },
-        ],
-      });
-      persistence.scanAllEntries.mockResolvedValue([allTerminalSnapshot]);
+    it('does NOT call noteRecoveryMarkedStale when no entries are discarded and no stale marks happen', async () => {
+      // Happy path: pending slots adopted with old jobIds, no stale marks
+      // generated. The flag should stay off so MessageHandler's hot path
+      // doesn't do unnecessary stale-set lookups.
+      persistence.scanAllEntries.mockResolvedValue([buildSnapshot()]);
 
       await recovery.run();
 
       expect(coordinator.noteRecoveryMarkedStale).not.toHaveBeenCalled();
+    });
+
+    it('calls noteRecoveryMarkedStale when entries are discarded', async () => {
+      // Channel gone → entry discarded → pending jobIds marked stale.
+      discordClient.channels.fetch.mockResolvedValue(null);
+      persistence.scanAllEntries.mockResolvedValue([buildSnapshot()]);
+
+      const stats = await recovery.run();
+
+      expect(stats.entriesDiscarded).toBe(1);
+      expect(stats.staleJobIdsMarked).toBe(1);
+      expect(coordinator.noteRecoveryMarkedStale).toHaveBeenCalledOnce();
     });
 
     it('calls noteRecoveryMarkedStale when entries are discarded even without stale jobIds', async () => {
@@ -467,7 +598,7 @@ describe('MultiTagRecovery', () => {
           {
             slotIndex: 0,
             personalityId: 'id-alice',
-            personalitySlug: 'Alice',
+            personalitySlug: 'alice',
             source: 'mention',
             isAutoResponse: false,
             jobId: 'old-job-Alice',
@@ -475,15 +606,13 @@ describe('MultiTagRecovery', () => {
           },
         ],
       });
-      // Channel gone → entry discarded
       discordClient.channels.fetch.mockResolvedValue(null);
       persistence.scanAllEntries.mockResolvedValue([allTerminalSnapshot]);
 
       const stats = await recovery.run();
 
       expect(stats.entriesDiscarded).toBe(1);
-      expect(stats.staleJobIdsMarked).toBe(0); // no pending slots to mark
-      // Defensive: flag flipped via the entriesDiscarded branch
+      expect(stats.staleJobIdsMarked).toBe(0);
       expect(coordinator.noteRecoveryMarkedStale).toHaveBeenCalledOnce();
     });
   });

--- a/services/bot-client/src/services/MultiTagRecovery.ts
+++ b/services/bot-client/src/services/MultiTagRecovery.ts
@@ -4,13 +4,11 @@
  *
  * **Why this exists**: when the bot shuts down (graceful or crash), pending
  * multi-tag fan-outs leave Redis entries behind. Without recovery, those
- * entries' old jobIds would never produce user-visible responses — and on
- * the next restart, the SET-of-stale-jobIds would block delivery for any
- * jobs that DID return between shutdown and restart. The
- * `beginShutdown` path (MultiTagCoordinator) marks pending jobIds stale so
- * pre-restart results get discarded; this service does the converse —
- * resubmits fresh jobs for those slots so the user eventually sees a
- * response.
+ * entries would never produce user-visible responses, and any results the
+ * old ai-worker finished publishing AFTER the old bot-client died would be
+ * silently lost — the new bot-client's fresh `QueueEvents` / Redis-Stream
+ * subscriptions don't replay events emitted before they attached, even
+ * though the BullMQ job state itself still holds the result.
  *
  * **Algorithm** (run BEFORE ResultsListener starts):
  *   1. Scan `multitag:entry:*` Redis keys via `MultiTagPersistence.scanAllEntries`.
@@ -18,30 +16,56 @@
  *      - Fetch Discord channel + source message. If either fails (channel
  *        deleted, message deleted), discard the entry — the user can't be
  *        delivered to anyway.
- *      - For each pending slot: mark old jobId stale, load personality
- *        (may be revoked), resubmit chat job, replace jobId in snapshot.
- *      - For each terminal slot: leave as-is (it'll flush along with the
- *        last pending slot's completion).
+ *      - For each pending slot: poll BullMQ for the OLD job's authoritative
+ *        state via `queue.getJob().getState()`. Routes:
+ *          • `'completed'` → consume `job.returnvalue` and feed it through
+ *            `coordinator.handleJobResult` after adoption (deferred delivery).
+ *          • `'failed'` → synthesize an error `LLMGenerationResult` from
+ *            `job.failedReason` and route through the same entrypoint.
+ *          • `'active' | 'waiting' | 'delayed' | 'prioritized' | 'waiting-children'` →
+ *            adopt the slot as still-pending with the old jobId; the live
+ *            stream + QueueEvents subscriptions will deliver the result
+ *            when the ai-worker finishes.
+ *          • Job evicted from Redis (`getJob` returns null) → synthesize
+ *            an "unavailable after restart" failure result.
+ *          • `getJob` / `getState` throws → fall back to adopting as
+ *            still-pending; don't fail recovery for a transient Redis blip.
+ *      - For each terminal slot in the snapshot: preserve as-is (the result
+ *        was never persisted in the snapshot, so the slot will flush as an
+ *        error via the existing `deliverError` path — same as before).
  *      - Adopt the rehydrated runtime entry into the coordinator's
  *        in-memory maps + register with orderingService.
- *      - Persist the updated snapshot back to Redis with new jobIds.
+ *      - After adoption, dispatch the collected deferred deliveries via
+ *        `coordinator.handleJobResult(jobId, syntheticResult)`. This routes
+ *        through the same flush path live results travel.
  *   3. Notify coordinator that stale jobIds exist (flips the
  *      `staleCheckNeeded` fast-path flag) so MessageHandler runs the
- *      isStale check post-recovery.
+ *      isStale check post-recovery for any entries that were discarded.
+ *
+ * **No resubmission**: prior versions of this service resubmitted a fresh
+ * AI job for every still-pending slot at recovery time. That wasted API
+ * tokens and produced different content than what the user would have
+ * received absent the restart — and crucially, results the prior process
+ * had already produced were thrown away in favour of duplicate work. The
+ * BullMQ-state poll above replaces resubmission entirely.
  *
  * **Critical ordering**: `run()` MUST complete before `ResultsListener.start()`.
- * The stale-set filter is what makes pre-restart-jobId results safe to
- * discard; without it, an old result could arrive during recovery and
- * race the rehydration.
+ * The stale-set filter (populated during discard) is what makes results
+ * for discarded entries safe to drop; without it, a delayed delivery could
+ * arrive during recovery and race the discard logic. For the in-flight
+ * branch, the slot retains its original jobId, so the stream/event
+ * subscriptions deliver normally once they attach.
  *
  * **Discord readiness**: callers must invoke `run()` AFTER `client.login()`
  * completes — channel/message fetches require an authenticated client.
  */
 
 import type { Client, Message, Channel } from 'discord.js';
+import type { Queue } from 'bullmq';
 import {
   createLogger,
   isTypingChannel,
+  type LLMGenerationResult,
   type LoadedPersonality,
   type TypingChannel,
   MULTI_TAG,
@@ -52,30 +76,64 @@ import type {
   CoordinatorEntrySnapshot,
   SlotSnapshot,
 } from './MultiTagPersistence.js';
-import type { PersonalityChatManager } from './character/PersonalityChatManager.js';
-import type { JobTracker } from './JobTracker.js';
 import type { IPersonalityLoader } from '../types/IPersonalityLoader.js';
-import { toSnapshot, type RuntimeEntry, type RuntimeSlot } from './multiTagCoordinatorHelpers.js';
+import type { RuntimeEntry, RuntimeSlot } from './multiTagCoordinatorHelpers.js';
 
 const logger = createLogger('MultiTagRecovery');
 
 export interface MultiTagRecoveryDeps {
   persistence: MultiTagPersistence;
   coordinator: MultiTagCoordinator;
-  chatManager: PersonalityChatManager;
-  jobTracker: JobTracker;
   personalityService: IPersonalityLoader;
   discordClient: Client;
+  /**
+   * BullMQ queue handle for the AI-requests queue. Used to poll the
+   * authoritative state (`completed | failed | active | ...`) of jobs that
+   * were in flight when the bot last shut down. Constructed in
+   * `index.ts`'s composition root and closed in the shutdown sequence.
+   */
+  queue: Queue;
 }
 
 export interface RecoveryStats {
   entriesScanned: number;
   entriesResumed: number;
   entriesDiscarded: number;
-  slotsResubmitted: number;
+  /** Slots whose old job was found completed; result delivered synthetically. */
+  slotsRecoveredCompleted: number;
+  /** Slots whose old job was found failed; error delivered synthetically. */
+  slotsRecoveredFailed: number;
+  /** Slots whose old job was still in flight; adopted as-is, stream will deliver. */
+  slotsTrustedToStream: number;
+  /**
+   * Slots whose old job was evicted from Redis (or whose state poll
+   * returned 'unknown'); error delivered synthetically because the result
+   * is unrecoverable.
+   */
+  slotsUnrecoverable: number;
   slotsAccessRevoked: number;
   staleJobIdsMarked: number;
 }
+
+interface DeferredDelivery {
+  jobId: string;
+  result: LLMGenerationResult;
+  /**
+   * Why this delivery exists — preserves the recovery-outcome category through
+   * the deferred-dispatch loop. The per-entry log emits these as distinct
+   * counters; operators diagnosing eviction frequency need to distinguish
+   * `'unrecoverable'` from `'recoveredFailed'`, since both materialize as
+   * `success: false` results that filtering on `result.success` alone would
+   * collapse together.
+   */
+  kind: 'recoveredCompleted' | 'recoveredFailed' | 'unrecoverable';
+}
+
+type SlotStateOutcome =
+  | { kind: 'completed'; result: LLMGenerationResult }
+  | { kind: 'failed'; failedReason: string }
+  | { kind: 'inFlight' }
+  | { kind: 'unrecoverable' };
 
 export class MultiTagRecovery {
   constructor(private readonly deps: MultiTagRecoveryDeps) {}
@@ -85,7 +143,10 @@ export class MultiTagRecovery {
       entriesScanned: 0,
       entriesResumed: 0,
       entriesDiscarded: 0,
-      slotsResubmitted: 0,
+      slotsRecoveredCompleted: 0,
+      slotsRecoveredFailed: 0,
+      slotsTrustedToStream: 0,
+      slotsUnrecoverable: 0,
       slotsAccessRevoked: 0,
       staleJobIdsMarked: 0,
     };
@@ -106,11 +167,11 @@ export class MultiTagRecovery {
 
     // Sequential (not Promise.allSettled) is intentional. Each entry
     // makes 2 Discord API calls (channels.fetch + messages.fetch) plus
-    // a chat-job resubmission per pending slot. Parallelizing across N
+    // one BullMQ state-poll per pending slot. Parallelizing across N
     // entries on a fresh bot startup would risk Discord rate limits
     // (especially after a heavy-traffic shutdown that left many in-flight
-    // fan-outs) and burst the gateway/queue. Recovery is rare and runs
-    // once per process; the extra wall time is acceptable.
+    // fan-outs). Recovery is rare and runs once per process; the extra
+    // wall time is acceptable.
     for (const snapshot of snapshots) {
       await this.recoverOne(snapshot, stats);
     }
@@ -118,7 +179,7 @@ export class MultiTagRecovery {
     // Notify coordinator so its `staleCheckNeeded` fast-path skip-flag
     // becomes active for the rest of the process lifetime. Without this,
     // MessageHandler would skip the isStale check and could deliver
-    // pre-restart results.
+    // pre-restart results to entries that were discarded here.
     //
     // Defensive `entriesDiscarded` clause: discardEntry only counts
     // staleJobIdsMarked for the PENDING slots it marks stale. An entry
@@ -158,15 +219,31 @@ export class MultiTagRecovery {
         return;
       }
 
-      // Build runtime slots: resubmit pending, preserve terminal. Slots
-      // whose personality became inaccessible are kept as errored sentinel
-      // slots (not dropped) so the group still flushes a fallback error
-      // message for each position — `rebuildSlot` never returns null
-      // today, so the loop just maps 1:1.
+      // Build runtime slots: poll BullMQ state for pending slots, preserve
+      // terminal ones. Slots whose personality became inaccessible are
+      // kept as errored sentinel slots (not dropped) so the group still
+      // flushes a fallback error message for each position.
+      //
+      // Track inFlight slot count locally during the loop rather than
+      // re-deriving from `runtimeSlots` post-`handleJobResult`. The
+      // derive-from-slot-status approach is load-bearing on the
+      // coordinator mutating slot objects in place when delivering — it
+      // works today (see `MultiTagCoordinator.handleJobResult`), but
+      // counting here keeps the per-entry log independent of that
+      // implementation detail. A slot enters this count iff its outcome
+      // was `inFlight` (returns a pending base slot with no deferred
+      // delivery); revoked/terminal slots don't qualify.
       const runtimeSlots: RuntimeSlot[] = [];
+      const deferredDeliveries: DeferredDelivery[] = [];
+      let entryTrustedToStreamCount = 0;
       for (const slotSnap of snapshot.slots) {
-        const rebuilt = await this.rebuildSlot(slotSnap, sourceMessage, snapshot, stats);
-        runtimeSlots.push(rebuilt);
+        const { slot, deferredDelivery } = await this.rebuildSlot(slotSnap, snapshot, stats);
+        runtimeSlots.push(slot);
+        if (deferredDelivery !== undefined) {
+          deferredDeliveries.push(deferredDelivery);
+        } else if (slot.status === 'pending') {
+          entryTrustedToStreamCount++;
+        }
       }
 
       if (runtimeSlots.length === 0) {
@@ -179,8 +256,8 @@ export class MultiTagRecovery {
       }
 
       // Build runtime entry. Safety timer is re-armed from rehydrate time
-      // (giving the resubmitted jobs the full timeout budget) rather than
-      // counting against the original createdAt.
+      // (giving any genuinely-in-flight jobs the full timeout budget)
+      // rather than counting against the original createdAt.
       //
       // **Safe-against-adoption-throw**: this timer is armed BEFORE
       // `adoptRehydratedEntry` runs below. If adoption throws, the timer
@@ -213,33 +290,33 @@ export class MultiTagRecovery {
         truncated: snapshot.truncated,
       };
 
-      // Adopt: coordinator wires the in-memory state and triggers
-      // immediate flush if every slot is already terminal.
-      //
-      // **Capture `allTerminal` BEFORE the adopt await.** When the entry
-      // has no pending slots, `adoptRehydratedEntry` calls `flushEntry`
-      // → `deliverGroup` → `persistence.deleteEntry` synchronously
-      // before returning. If we inspected `entry.slots` after the await,
-      // we'd skip the updateEntry below correctly but the reasoning
-      // would be load-bearing on coordinator-internal timing rather than
-      // captured intent. Pre-capture makes the ordering explicit.
-      const allTerminal = entry.slots.every(s => s.status !== 'pending');
+      // Adopt: coordinator wires the in-memory state. The jobToGroup map
+      // is populated here, which is the precondition for handleJobResult
+      // to find the slot via its jobId in the deferred-delivery loop below.
       await this.deps.coordinator.adoptRehydratedEntry(entry);
 
-      // Persist the updated snapshot (new jobIds in pending slots). Skip
-      // when every slot was already terminal at adopt time — the immediate
-      // flush triggered by adoptRehydratedEntry already called
-      // deleteEntry, so writing back here would orphan a snapshot at a
-      // key that's about to expire via TTL anyway.
-      if (!allTerminal) {
-        try {
-          await this.deps.persistence.updateEntry(toSnapshot(entry));
-        } catch (err) {
-          logger.warn(
-            { err, groupId: snapshot.groupId },
-            'Failed to persist rehydrated snapshot — coordinator will continue in-memory only'
-          );
-        }
+      // Dispatch any deferred deliveries (completed / failed / unrecoverable
+      // results from the prior process). Each call routes through the same
+      // entrypoint live results use — including the flush trigger when all
+      // slots in the group reach terminal state, and the per-call
+      // updateEntry persistence write inside handleJobResult itself. No
+      // explicit updateEntry needed at this layer.
+      //
+      // **Non-idempotency window**: if the process crashes between two
+      // successive `handleJobResult` calls in this loop, the next recovery
+      // run can re-dispatch the same already-delivered result. Whether
+      // the user sees a duplicate Discord message depends on
+      // `handleJobResult`'s persistence timing — if updateEntry runs
+      // before the user-visible send (current behavior in non-flush
+      // cases), the re-dispatch sees terminal status and skips; the
+      // all-terminal flush path deletes the entry, so a crash there
+      // means recovery is already done. The behavior is "potentially
+      // duplicate message" rather than "no message" — the better
+      // failure mode — and the exposure window is tiny (only between
+      // two awaits within recovery itself). Idempotent re-dispatch is
+      // tracked as a follow-up; see backlog/deferred.md.
+      for (const delivery of deferredDeliveries) {
+        await this.deps.coordinator.handleJobResult(delivery.jobId, delivery.result);
       }
 
       stats.entriesResumed++;
@@ -247,7 +324,11 @@ export class MultiTagRecovery {
         {
           groupId: snapshot.groupId,
           channelId: snapshot.channelId,
-          slotsResubmitted: snapshot.slots.filter(s => s.status === 'pending').length,
+          slotsRecoveredCompleted: deferredDeliveries.filter(d => d.kind === 'recoveredCompleted')
+            .length,
+          slotsRecoveredFailed: deferredDeliveries.filter(d => d.kind === 'recoveredFailed').length,
+          slotsUnrecoverable: deferredDeliveries.filter(d => d.kind === 'unrecoverable').length,
+          slotsTrustedToStream: entryTrustedToStreamCount,
         },
         'Multi-tag entry rehydrated'
       );
@@ -260,144 +341,221 @@ export class MultiTagRecovery {
   }
 
   /**
-   * Rebuild one slot: resubmit pending, preserve terminal. Always returns
-   * a slot — when the personality is inaccessible, builds a sentinel slot
-   * (errored status, sentinel personality) so the group still flushes with
-   * a fallback error message for that position rather than silently
-   * dropping the slot.
+   * Rebuild one slot. For pending slots: poll BullMQ for authoritative
+   * state and dispatch on the outcome. For already-terminal slots in the
+   * snapshot: preserve as-is (the result was never persisted in the
+   * snapshot, so the slot flushes via `deliverError`'s synthetic-error
+   * path — same as the prior implementation).
+   *
+   * Returns a `RuntimeSlot` plus an optional `deferredDelivery` — the
+   * `LLMGenerationResult` to feed through `coordinator.handleJobResult`
+   * AFTER `adoptRehydratedEntry` registers the entry. Delivery is
+   * deferred (not pre-seeded on the slot) so the slot's transition to
+   * terminal travels the same canonical path live results travel.
    */
   private async rebuildSlot(
     slotSnap: SlotSnapshot,
-    sourceMessage: Message,
     entrySnap: CoordinatorEntrySnapshot,
     stats: RecoveryStats
-  ): Promise<RuntimeSlot> {
+  ): Promise<{ slot: RuntimeSlot; deferredDelivery?: DeferredDelivery }> {
+    // Hoisted from the per-branch lookups in the old resubmit implementation:
+    // both the terminal-snapshot path and the pending-poll path need the
+    // personality (for displayName/id rendering during deliverGroup), so
+    // looking it up unconditionally collapses two near-duplicate calls
+    // into one. Recovery is rare enough that the extra lookup for an
+    // already-revoked terminal slot is acceptable.
+    const personality = await this.lookupPersonalityWithFallback(slotSnap, entrySnap.userId);
+
+    // Already-terminal slots in the snapshot: preserve. No state poll, no
+    // deferred delivery — the snapshot status is the source of truth here
+    // and the slot will flush via the existing deliverError path (the
+    // snapshot doesn't carry `result`, so an "errored" or "completed"
+    // slot from the snapshot becomes a fallback-error in the flushed
+    // burst — same as the prior implementation; this is not a regression).
     if (slotSnap.status !== 'pending') {
-      // Already terminal — preserve as-is. result is NOT in the snapshot
-      // (we only persist the SlotSnapshot subset); the existing slot will
-      // synthesize an error in deliverGroup if result is missing, which
-      // is correct for slots that completed before shutdown but never
-      // got their result back from Redis.
-      const personality = await this.lookupPersonalityWithFallback(slotSnap, entrySnap.userId);
       if (personality === null) {
-        // Personality became inaccessible between completion and recovery.
-        // Keep the slot (with sentinel personality) so the group still
-        // flushes a fallback error in that position — symmetric with the
-        // pending-branch handling below. Count it in stats so observers
-        // can see "this many slots lost access during recovery."
-        //
-        // **About the synthetic `personaId`**: `personaId` is a Prisma
-        // UUID FK to the `personas` table. The `recovery-revoked-*`
-        // string isn't a valid UUID, so `saveAssistantMessage` would
-        // hit a FK violation when SlotDeliveryService's deliverError
-        // path tries to persist the synthetic error message. That's
-        // acceptable degradation: `deliverError` wraps the persist call
-        // in try/catch (the webhook already sent), so the user sees
-        // the error message but conversation history doesn't record
-        // it. The same applies to `recovery-denied-*` below. Recovery
-        // could look up the user's default persona here to make
-        // persistence work, but synthetic-strings + log-and-swallow
-        // is acceptable for the rare access-revoked / denied edge cases.
         stats.slotsAccessRevoked++;
-        return {
-          slotIndex: slotSnap.slotIndex,
-          personality: this.buildSentinelPersonality(slotSnap),
-          personaId: `recovery-revoked-${slotSnap.personalitySlug}`,
-          source: slotSnap.source,
-          isAutoResponse: slotSnap.isAutoResponse,
-          jobId: slotSnap.jobId,
-          status: 'errored',
-        };
+        return { slot: this.buildRevokedSlot(slotSnap) };
       }
-      // Same synthetic-personaId trap as the revoked branch above: result
-      // is never persisted in SlotSnapshot, so recovered terminal slots
-      // route through deliverError → saveAssistantMessage → FK violation
-      // (caught + logged by SlotDeliveryService). User regression: a
-      // pre-restart "completed" slot becomes a delivered-as-error slot on
-      // the channel. Acceptable for an already-rare recovery edge case;
-      // a future fix would resolve the user's default persona at recovery
-      // time and use that as personaId.
-      return {
-        slotIndex: slotSnap.slotIndex,
-        personality,
-        personaId: `recovery-persona-${personality.id}`,
-        source: slotSnap.source,
-        isAutoResponse: slotSnap.isAutoResponse,
-        jobId: slotSnap.jobId,
-        status: slotSnap.status,
-      };
+      return { slot: this.buildPreservedTerminalSlot(slotSnap, personality) };
     }
 
-    // Pending slot: mark old jobId stale BEFORE resubmitting (closes the
-    // race where the old result arrives during the resubmit roundtrip).
-    await this.deps.persistence.markStale(slotSnap.jobId);
-    stats.staleJobIdsMarked++;
-
-    const personality = await this.lookupPersonalityWithFallback(slotSnap, entrySnap.userId);
+    // Pending slot with revoked personality: still keep the slot (with
+    // sentinel personality) so the group flushes a fallback error in that
+    // position. No state poll needed — even if the prior job completed
+    // successfully, we can't render the result without the personality.
     if (personality === null) {
       stats.slotsAccessRevoked++;
-      // Personality access revoked since the original fan-out. Keep the
-      // slot in the entry but flag it as errored so the group can still
-      // flush (the error path will render a fallback message for this
-      // slot).
-      return {
-        slotIndex: slotSnap.slotIndex,
-        // Use a sentinel personality object so downstream code that
-        // accesses .id/.slug/.displayName doesn't NPE. The deliverError
-        // path will produce a "couldn't reach this personality" message.
-        personality: this.buildSentinelPersonality(slotSnap),
-        personaId: `recovery-revoked-${slotSnap.personalitySlug}`,
-        source: slotSnap.source,
-        isAutoResponse: slotSnap.isAutoResponse,
-        jobId: slotSnap.jobId,
-        status: 'errored',
-      };
+      return { slot: this.buildRevokedSlot(slotSnap) };
     }
 
-    // Resubmit the chat job. Treat any failure (denied / network / etc.)
-    // the same as access-revoked — slot becomes errored.
-    const submitResult = await this.deps.chatManager.submitChatJob({
-      message: sourceMessage,
+    // Pending slot, personality accessible: poll BullMQ for the old job's
+    // authoritative state.
+    const outcome = await this.pollPriorJobState(slotSnap.jobId);
+    const baseSlot: RuntimeSlot = {
+      slotIndex: slotSnap.slotIndex,
       personality,
-      content: entrySnap.userMessageContent,
+      personaId: `recovery-persona-${personality.id}`,
+      source: slotSnap.source,
       isAutoResponse: slotSnap.isAutoResponse,
-    });
-    if (submitResult.kind !== 'submitted') {
-      logger.warn(
-        {
-          groupId: entrySnap.groupId,
-          slotIndex: slotSnap.slotIndex,
-          personalityId: personality.id,
-          reason: submitResult.reason,
-        },
-        'Recovery resubmit denied — marking slot errored'
-      );
-      return {
-        slotIndex: slotSnap.slotIndex,
-        personality,
-        personaId: `recovery-denied-${personality.id}`,
-        source: slotSnap.source,
-        isAutoResponse: slotSnap.isAutoResponse,
-        jobId: slotSnap.jobId,
-        status: 'errored',
-      };
+      jobId: slotSnap.jobId,
+      status: 'pending',
+    };
+
+    switch (outcome.kind) {
+      case 'completed':
+        stats.slotsRecoveredCompleted++;
+        return {
+          slot: baseSlot,
+          deferredDelivery: {
+            jobId: slotSnap.jobId,
+            result: outcome.result,
+            kind: 'recoveredCompleted',
+          },
+        };
+      case 'failed':
+        stats.slotsRecoveredFailed++;
+        return {
+          slot: baseSlot,
+          deferredDelivery: {
+            jobId: slotSnap.jobId,
+            result: synthesizeFailureResult(slotSnap, outcome.failedReason),
+            kind: 'recoveredFailed',
+          },
+        };
+      case 'inFlight':
+        stats.slotsTrustedToStream++;
+        return { slot: baseSlot };
+      case 'unrecoverable':
+        stats.slotsUnrecoverable++;
+        return {
+          slot: baseSlot,
+          deferredDelivery: {
+            jobId: slotSnap.jobId,
+            result: synthesizeFailureResult(slotSnap, 'Result unavailable after restart'),
+            kind: 'unrecoverable',
+          },
+        };
+    }
+  }
+
+  /**
+   * Poll BullMQ for the authoritative state of a job that was pending at
+   * snapshot time. Wraps `queue.getJob().getState()` with bounded error
+   * handling — a transient Redis blip during recovery falls back to
+   * "trust the stream" rather than failing the slot, so the live
+   * subscription can still deliver once it's running.
+   */
+  private async pollPriorJobState(jobId: string): Promise<SlotStateOutcome> {
+    let job;
+    try {
+      job = await this.deps.queue.getJob(jobId);
+    } catch (err) {
+      logger.warn({ err, jobId }, 'Recovery: queue.getJob threw — treating as in-flight');
+      return { kind: 'inFlight' };
+    }
+    if (!job) {
+      return { kind: 'unrecoverable' };
     }
 
-    // Register the new jobId with JobTracker so typing indicator runs
-    // and the result eventually routes back to handleJobResult.
-    this.deps.jobTracker.trackJob(submitResult.jobId, submitResult.trackingContext, {
-      skipOrderingRegistration: true,
-    });
-    stats.slotsResubmitted++;
+    let state: string;
+    try {
+      state = await job.getState();
+    } catch (err) {
+      logger.warn({ err, jobId }, 'Recovery: job.getState threw — treating as in-flight');
+      return { kind: 'inFlight' };
+    }
 
+    switch (state) {
+      case 'completed':
+        // Cast required because BullMQ's Job#returnvalue is typed `unknown`
+        // at the generic-Queue level. The ai-worker handler's signature
+        // (`Promise<LLMGenerationResult>` in LLMGenerationHandler.processJob)
+        // guarantees this shape architecturally for jobs on the AI-requests
+        // queue — but the contract isn't enforced at the boundary.
+        //
+        // **The most common runtime cause of `returnvalue === undefined`
+        // here is BullMQ's `removeOnComplete: { count: N }` eviction
+        // racing the `getState()`→`returnvalue` access window**: state
+        // returns 'completed', then the job record is GC'd before we read
+        // returnvalue. Worker crash between completion-write and
+        // returnvalue-write is a possible but rarer cause. Operators
+        // investigating non-zero `slotsUnrecoverable` on a healthy cluster
+        // should check the queue's `removeOnComplete` retention first.
+        //
+        // Either way, route through the unrecoverable path so
+        // coordinator.handleJobResult never receives a malformed result.
+        if (job.returnvalue === null || job.returnvalue === undefined) {
+          return { kind: 'unrecoverable' };
+        }
+        return { kind: 'completed', result: job.returnvalue as LLMGenerationResult };
+      case 'failed':
+        return { kind: 'failed', failedReason: job.failedReason ?? 'Unknown failure' };
+      case 'active':
+      case 'waiting':
+      case 'waiting-children':
+      case 'delayed':
+      case 'prioritized':
+        return { kind: 'inFlight' };
+      default:
+        // 'unknown' or any future state BullMQ adds. Treat as unrecoverable
+        // so the user gets a synthetic-error message instead of a silent
+        // wait until the safety timeout fires.
+        return { kind: 'unrecoverable' };
+    }
+  }
+
+  /**
+   * Build a runtime slot for an already-terminal snapshot slot. The
+   * snapshot doesn't carry `result`, so the flushed burst will produce a
+   * fallback error message for this slot via the existing deliverError
+   * path. Same trade-off applies as in the revoked-slot branch: synthetic
+   * personaId (`recovery-persona-*`) will hit a Prisma FK violation when
+   * `saveAssistantMessage` tries to persist the synthetic message; the
+   * persist call is wrapped in try/catch in deliverError, so the user
+   * sees the message but conversation history doesn't record it.
+   */
+  private buildPreservedTerminalSlot(
+    slotSnap: SlotSnapshot,
+    personality: LoadedPersonality
+  ): RuntimeSlot {
     return {
       slotIndex: slotSnap.slotIndex,
       personality,
-      personaId: submitResult.trackingContext.personaId,
+      personaId: `recovery-persona-${personality.id}`,
       source: slotSnap.source,
       isAutoResponse: slotSnap.isAutoResponse,
-      jobId: submitResult.jobId,
-      status: 'pending',
+      jobId: slotSnap.jobId,
+      status: slotSnap.status,
+    };
+  }
+
+  /**
+   * Build a sentinel slot for a personality that's no longer accessible
+   * (deleted, ownership revoked, etc.). Status is forced to `'errored'`
+   * so the group flushes a fallback error message in that position rather
+   * than silently dropping the slot.
+   *
+   * **About the synthetic `personaId`**: `personaId` is a Prisma UUID FK
+   * to the `personas` table. The `recovery-revoked-*` string isn't a
+   * valid UUID, so `saveAssistantMessage` would hit a FK violation when
+   * SlotDeliveryService's deliverError path tries to persist the
+   * synthetic error message. That's acceptable degradation: `deliverError`
+   * wraps the persist call in try/catch (the webhook already sent), so
+   * the user sees the error message but conversation history doesn't
+   * record it. Recovery could look up the user's default persona here to
+   * make persistence work, but synthetic-strings + log-and-swallow is
+   * acceptable for the rare access-revoked edge case.
+   */
+  private buildRevokedSlot(slotSnap: SlotSnapshot): RuntimeSlot {
+    return {
+      slotIndex: slotSnap.slotIndex,
+      personality: this.buildSentinelPersonality(slotSnap),
+      personaId: `recovery-revoked-${slotSnap.personalitySlug}`,
+      source: slotSnap.source,
+      isAutoResponse: slotSnap.isAutoResponse,
+      jobId: slotSnap.jobId,
+      status: 'errored',
     };
   }
 
@@ -489,7 +647,7 @@ export class MultiTagRecovery {
    * future refactor changes deliverError to access additional
    * LoadedPersonality fields, this sentinel must be extended accordingly.
    * A typed `Partial<LoadedPersonality>` + a discriminated-union sentinel
-   * shape would be cleaner; deferred as out of scope for this PR.
+   * shape would be cleaner; tracked in backlog/deferred.md.
    */
   private buildSentinelPersonality(slotSnap: SlotSnapshot): LoadedPersonality {
     return {
@@ -533,4 +691,24 @@ export class MultiTagRecovery {
       'Multi-tag entry discarded during recovery'
     );
   }
+}
+
+/**
+ * Build a synthetic `LLMGenerationResult` for slots whose old job failed
+ * (handler threw or job was evicted). The shape matches what
+ * `coordinator.handleJobResult` expects on the failure branch — `success:
+ * false` triggers the `'errored'` slot transition, and `error` is rendered
+ * by the deliverError path.
+ *
+ * The `requestId` is set to the old jobId so log correlation still works
+ * (the prior process's logs reference the same id). `content` is omitted
+ * because the success-path consumer wouldn't reach it anyway when
+ * `success === false`.
+ */
+function synthesizeFailureResult(slotSnap: SlotSnapshot, error: string): LLMGenerationResult {
+  return {
+    requestId: slotSnap.jobId,
+    success: false,
+    error,
+  };
 }

--- a/services/bot-client/src/services/SlotDeliveryService.test.ts
+++ b/services/bot-client/src/services/SlotDeliveryService.test.ts
@@ -161,6 +161,27 @@ describe('SlotDeliveryService', () => {
         expect.objectContaining({ isAutoResponse: true })
       );
     });
+
+    it('does NOT propagate when webhook succeeded but persistence threw', async () => {
+      // Mirrors the deliverError try/catch around saveAssistantMessage:
+      // once the webhook delivers, the user has the message and a
+      // persistence failure must not surface as an exception to the
+      // caller (the per-slot catch in multiTagDeliveryFlow would log
+      // "Slot delivery threw" even though delivery succeeded). The
+      // guard logs the persist failure and returns normally.
+      responseSender.sendResponse.mockResolvedValue({ chunkMessageIds: ['chunk-ok-1'] });
+      persistence.saveAssistantMessage.mockRejectedValue(new Error('FK constraint violation'));
+      const result = buildSuccessResult();
+      const slot = buildSlotContext();
+
+      // Should NOT throw — the user got the message; conversation history
+      // just isn't recorded.
+      const out = await service.deliverSuccess(result, slot);
+
+      expect(responseSender.sendResponse).toHaveBeenCalledTimes(1);
+      expect(persistence.saveAssistantMessage).toHaveBeenCalledTimes(1);
+      expect(out.chunkMessageIds).toEqual(['chunk-ok-1']);
+    });
   });
 
   describe('deliverError', () => {

--- a/services/bot-client/src/services/SlotDeliveryService.ts
+++ b/services/bot-client/src/services/SlotDeliveryService.ts
@@ -142,14 +142,27 @@ export class SlotDeliveryService {
       recipientUserId: slot.recipientUserId,
     });
 
-    await this.persistence.saveAssistantMessage({
-      message: slot.message,
-      personality: slot.personality,
-      personaId: slot.personaId,
-      content: result.content,
-      chunkMessageIds,
-      userMessageTime: slot.userMessageTime,
-    });
+    // Webhook send already succeeded above — the user has received the
+    // message. Persistence failures from here MUST NOT propagate, so the
+    // caller's per-slot catch doesn't log a misleading "Slot delivery
+    // threw" while the user just got their response. Symmetric with the
+    // try/catch in deliverError: after a successful webhook send,
+    // persist failures are logged but never bubble to the caller.
+    try {
+      await this.persistence.saveAssistantMessage({
+        message: slot.message,
+        personality: slot.personality,
+        personaId: slot.personaId,
+        content: result.content,
+        chunkMessageIds,
+        userMessageTime: slot.userMessageTime,
+      });
+    } catch (persistError) {
+      logger.error(
+        { err: persistError, personalityId: slot.personality.id },
+        'Failed to persist assistant message to conversation history (webhook already sent)'
+      );
+    }
 
     if (chunkMessageIds.length > 0) {
       void this.gatewayClient


### PR DESCRIPTION
## Summary

- When bot-client restarts during an in-flight multi-tag fan-out, the new process's fresh `QueueEvents`/Redis-Stream subscriptions don't replay events from before they attached — results the prior ai-worker published AFTER the prior bot-client SIGTERM'd were permanently lost. Prior behavior resubmitted a fresh AI job for every still-pending slot, which wasted tokens and produced different content than what the user would have received absent the restart.
- New behavior: `MultiTagRecovery.rebuildSlot` polls BullMQ for each pending slot's authoritative state via `Job.fromId().getState()` and routes accordingly:
  - `'completed'` → consume `job.returnvalue` via `coordinator.handleJobResult`
  - `'failed'` → synthesize an error `LLMGenerationResult` from `failedReason`
  - in-flight states (`active|waiting|delayed|prioritized|waiting-children`) → adopt slot with old jobId, trust the live stream
  - evicted/unknown → synthesize "Result unavailable after restart" error
- No resubmission in any branch. Adoption runs before `handleJobResult` so the coordinator's `jobToGroup` map has the slot's jobId registered before the synthetic result routes.
- Queue handle is constructed in `createServices()` symmetric with the existing `JobFailureListener` BullMQ pattern, threaded through `buildMultiTagStack → buildMultiTagRecovery` via deps, and closed in the shutdown `Promise.all` batch. Council (Claude Opus 4.6) confirmed the deps-injection wiring over both internal-construction and static-factory alternatives, primarily on testability grounds.

## Why now

Confirmed in-prod failure on the v3.0.0-beta.123 deploy at 05:16 UTC on 2026-05-19:

- `05:16:15 UTC` — old bot-client SIGTERM'd cleanly
- `05:16:32 UTC` — old ai-worker completed job `llm-60db77c9...` (17s AFTER bot-client gone); result published with no consumer
- `05:26:25 UTC` — new bot-client's `MultiTagCoordinator.handleSafetyTimeout` fired → user got a generic error in Discord; generated content silently lost

Reproducible on every deploy with in-flight multi-tag jobs, so the next deploy would hit it again unless fixed. PR #1062 made the safety-timeout error render in the persona's voice but didn't recover the actual response — this PR does.

## Files changed

| File | Change |
|------|--------|
| `services/bot-client/src/services/MultiTagRecovery.ts` | Replace resubmit-based `rebuildSlot` with state-polling dispatcher. New `pollPriorJobState` helper. Deferred-delivery loop after `adoptRehydratedEntry`. Drop `chatManager` + `jobTracker` from deps (no longer needed). New `queue: Queue` dep. Updated `RecoveryStats` shape: `slotsResubmitted` → `slotsRecoveredCompleted` + `slotsRecoveredFailed` + `slotsTrustedToStream` + `slotsUnrecoverable`. |
| `services/bot-client/src/services/MultiTagRecovery.test.ts` | 26 tests covering each state branch (completed delivery, failed delivery, in-flight per state via `it.each`, evicted unrecoverable, getJob/getState throws, mixed entries, discard cases, access-revoked, terminal-slot preservation, adoption-ordering invariant). |
| `services/bot-client/src/index.ts` | Construct `multiTagRecoveryQueue = new Queue(QUEUE_NAME, { connection: redisConfig })` in `createServices`, register in `Services` interface, close in shutdown `Promise.all` batch. Add `parseRedisUrl`, `createBullMQRedisConfig` to common-types imports. |
| `services/bot-client/src/composition.ts` | Thread `recoveryQueue` through `buildMultiTagStack → buildMultiTagRecovery`. Drop unused `chatManager` + `jobTracker` from recovery deps. |

## Test plan

- [x] Full `pnpm test` passes (4887 / 4887)
- [x] `pnpm quality` passes (lint + cpd + depcruise + typecheck + typecheck:spec)
- [x] Manual code path review: adoption strictly precedes `handleJobResult` synthetic dispatch
- [x] All 5 BullMQ state branches covered by unit tests
- [x] Error-tolerance branches covered (`queue.getJob` throws → trust stream, `job.getState` throws → trust stream)
- [ ] **Manual dev-env e2e**: tag a personality with a long-running prompt, restart bot-client mid-job, observe that the response delivers in the persona's voice with the *original* generated content (not a fresh resubmission) and no 10-min safety timeout. Log should show `Multi-tag recovery complete` with `slotsRecoveredCompleted > 0` or `slotsTrustedToStream > 0`.

## Out of scope (tracked in backlog)

- **No multi-tag failure listener for LIVE failures** — separate pre-existing gap. If a multi-tag job fails during normal operation (not at restart), no listener notifies `MultiTagCoordinator`; the slot stays pending until safety timeout. Same 10-min UX as the rehydration bug but different root cause and fix. Will be filed in `backlog/inbox.md` post-merge.
- **Single-tag (`@mention` / `/character chat`) job rehydration** — likely has the same vulnerability via the `JobTracker` + `ResultsListener` path. Separate PR with its own design pass.
- **Synthetic `personaId` FK violation in `saveAssistantMessage`** for recovery-revoked slots — pre-existing in code, already documented in the existing JSDoc on `buildRevokedSlot` and `buildPreservedTerminalSlot`. Acceptable degradation for the rare access-revoked path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)