### PR TITLE
fix(bot-client): resolve real persona UUID at MultiTagRecovery time

### DIFF
--- a/services/bot-client/src/composition.ts
+++ b/services/bot-client/src/composition.ts
@@ -42,6 +42,7 @@ import { MultiTagRecovery } from './services/MultiTagRecovery.js';
 import type { Queue } from 'bullmq';
 import type { Redis } from 'ioredis';
 import type { Client } from 'discord.js';
+import type { PersonaResolver } from '@tzurot/common-types';
 import type { IPersonalityLoader } from './types/IPersonalityLoader.js';
 
 /**
@@ -111,6 +112,7 @@ export function buildMultiTagRecovery(deps: {
   persistence: MultiTagPersistence;
   coordinator: MultiTagCoordinator;
   personalityService: IPersonalityLoader;
+  personaResolver: PersonaResolver;
   discordClient: Client;
   queue: Queue;
 }): MultiTagRecovery {
@@ -118,6 +120,7 @@ export function buildMultiTagRecovery(deps: {
     persistence: deps.persistence,
     coordinator: deps.coordinator,
     personalityService: deps.personalityService,
+    personaResolver: deps.personaResolver,
     discordClient: deps.discordClient,
     queue: deps.queue,
   });
@@ -136,6 +139,7 @@ export function buildMultiTagStack(deps: {
   orderingService: ResponseOrderingService;
   slotDelivery: SlotDeliveryService;
   personalityService: IPersonalityLoader;
+  personaResolver: PersonaResolver;
   discordClient: Client;
   recoveryQueue: Queue;
 }): {
@@ -155,6 +159,7 @@ export function buildMultiTagStack(deps: {
     persistence,
     coordinator,
     personalityService: deps.personalityService,
+    personaResolver: deps.personaResolver,
     discordClient: deps.discordClient,
     queue: deps.recoveryQueue,
   });

--- a/services/bot-client/src/index.ts
+++ b/services/bot-client/src/index.ts
@@ -270,6 +270,7 @@ function createServices(): Services {
     orderingService: responseOrderingService,
     slotDelivery,
     personalityService,
+    personaResolver,
     discordClient: client,
     recoveryQueue: multiTagRecoveryQueue,
   });

--- a/services/bot-client/src/services/MultiTagRecovery.test.ts
+++ b/services/bot-client/src/services/MultiTagRecovery.test.ts
@@ -19,9 +19,12 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { Client, Message, Channel } from 'discord.js';
 import type { Queue } from 'bullmq';
 import { ChannelType } from 'discord.js';
-import type { LLMGenerationResult, LoadedPersonality } from '@tzurot/common-types';
+import type { LLMGenerationResult, LoadedPersonality, PersonaResolver } from '@tzurot/common-types';
 import { MultiTagRecovery, type MultiTagRecoveryDeps } from './MultiTagRecovery.js';
 import type { CoordinatorEntrySnapshot } from './MultiTagPersistence.js';
+
+// Stable UUID for the test user's default persona; exercised in every resolution assertion.
+const RESOLVED_PERSONA_ID = '00000000-0000-4000-8000-000000000aaa';
 
 function buildPersonality(name: string): LoadedPersonality {
   return {
@@ -101,6 +104,9 @@ describe('MultiTagRecovery', () => {
   let personalityService: {
     loadPersonality: ReturnType<typeof vi.fn>;
   };
+  let personaResolver: {
+    resolveForMemory: ReturnType<typeof vi.fn>;
+  };
   let discordClient: {
     channels: { fetch: ReturnType<typeof vi.fn> };
   };
@@ -140,6 +146,14 @@ describe('MultiTagRecovery', () => {
         return buildPersonality(slug);
       }),
     };
+    personaResolver = {
+      // Default: resolver returns the real persona UUID via cascade. Tests
+      // that need the null-fallback or throw-fallback path override per-call.
+      resolveForMemory: vi.fn().mockResolvedValue({
+        personaId: RESOLVED_PERSONA_ID,
+        focusModeEnabled: false,
+      }),
+    };
     mockMessage = { id: 'msg-1', client: { user: { id: 'bot-1' } } };
     mockChannel = {
       id: 'channel-1',
@@ -159,6 +173,7 @@ describe('MultiTagRecovery', () => {
       coordinator: coordinator as unknown as MultiTagRecoveryDeps['coordinator'],
       personalityService:
         personalityService as unknown as MultiTagRecoveryDeps['personalityService'],
+      personaResolver: personaResolver as unknown as PersonaResolver,
       discordClient: discordClient as unknown as Client,
       queue: queue as unknown as Queue,
     });
@@ -486,6 +501,105 @@ describe('MultiTagRecovery', () => {
       expect(personalityService.loadPersonality).toHaveBeenCalledWith('alice', 'user-1');
       // State poll runs because the slug fallback rescued the personality.
       expect(queue.getJob).toHaveBeenCalledWith('old-job-Alice');
+    });
+  });
+
+  describe('personaId resolution via PersonaResolver', () => {
+    it('resolves the real persona UUID via cascade and attaches it to the runtime slot', async () => {
+      // Resolver returns a valid memoryInfo → slot carries the resolved
+      // UUID, NOT a synthetic `recovery-*` string. A real `personas.id`
+      // FK means `saveAssistantMessage` succeeds and the recovered
+      // message lands in conversation history.
+      persistence.scanAllEntries.mockResolvedValue([buildSnapshot()]);
+
+      await recovery.run();
+
+      expect(personaResolver.resolveForMemory).toHaveBeenCalledWith('user-1', 'id-alice');
+      const adoptedEntry = coordinator.adoptRehydratedEntry.mock.calls[0]?.[0] as {
+        slots: Array<{ personaId: string }>;
+      };
+      expect(adoptedEntry.slots[0]?.personaId).toBe(RESOLVED_PERSONA_ID);
+    });
+
+    it('passes the LOADED personality.id (not the snapshot id) when ID-lookup fell back to slug', async () => {
+      // Slug fallback can rescue a personality whose UUID changed since the
+      // snapshot was written. The resolver call should use the current
+      // personality.id from the loaded record — that's the FK the
+      // UserPersonalityConfig cascade keys on today.
+      personalityService.loadPersonality.mockImplementation(
+        async (nameOrId: string): Promise<LoadedPersonality | null> => {
+          if (nameOrId.startsWith('id-')) return null;
+          return {
+            id: 'new-id-after-rename',
+            slug: nameOrId,
+            displayName: nameOrId,
+            name: nameOrId,
+          } as unknown as LoadedPersonality;
+        }
+      );
+      persistence.scanAllEntries.mockResolvedValue([buildSnapshot()]);
+
+      await recovery.run();
+
+      // The resolver is called with the LOADED personality's id, not the
+      // snapshot's stale id-alice value.
+      expect(personaResolver.resolveForMemory).toHaveBeenCalledWith(
+        'user-1',
+        'new-id-after-rename'
+      );
+    });
+
+    it('falls back to synthetic personaId when resolver returns null (user has no personas)', async () => {
+      // SYSTEM_DEFAULT case: resolver returns null when the user has zero
+      // personas. The slot still adopts and delivers — the synthetic
+      // `recovery-fallback-*` string is caught by the saveAssistantMessage
+      // try/catch in SlotDeliveryService, so the user gets their message;
+      // conversation history just doesn't persist for this edge case.
+      personaResolver.resolveForMemory.mockResolvedValue(null);
+      persistence.scanAllEntries.mockResolvedValue([buildSnapshot()]);
+
+      const stats = await recovery.run();
+
+      expect(stats.entriesResumed).toBe(1);
+      const adoptedEntry = coordinator.adoptRehydratedEntry.mock.calls[0]?.[0] as {
+        slots: Array<{ personaId: string }>;
+      };
+      expect(adoptedEntry.slots[0]?.personaId).toBe('recovery-fallback-alice');
+    });
+
+    it('falls back to synthetic personaId when resolver throws (transient Prisma blip)', async () => {
+      // Defensive: a Prisma blip during recovery shouldn't fail the slot.
+      // The slot still adopts and delivers via the same fallback path as
+      // the null-return case.
+      personaResolver.resolveForMemory.mockRejectedValue(new Error('connection refused'));
+      persistence.scanAllEntries.mockResolvedValue([buildSnapshot()]);
+
+      const stats = await recovery.run();
+
+      expect(stats.entriesResumed).toBe(1);
+      const adoptedEntry = coordinator.adoptRehydratedEntry.mock.calls[0]?.[0] as {
+        slots: Array<{ personaId: string }>;
+      };
+      expect(adoptedEntry.slots[0]?.personaId).toBe('recovery-fallback-alice');
+    });
+
+    it('uses snapshot personalityId for resolver lookup when personality is revoked', async () => {
+      // Revoked-personality path: we don't have a loaded personality.id, so
+      // the resolver call uses slotSnap.personalityId as the cascade key.
+      // The user's default persona still resolves correctly, so the
+      // synthetic-error message for this slot persists under the user's
+      // own persona.
+      personalityService.loadPersonality.mockResolvedValue(null);
+      persistence.scanAllEntries.mockResolvedValue([buildSnapshot()]);
+
+      await recovery.run();
+
+      expect(personaResolver.resolveForMemory).toHaveBeenCalledWith('user-1', 'id-alice');
+      const adoptedEntry = coordinator.adoptRehydratedEntry.mock.calls[0]?.[0] as {
+        slots: Array<{ personaId: string; status: string }>;
+      };
+      expect(adoptedEntry.slots[0]?.status).toBe('errored');
+      expect(adoptedEntry.slots[0]?.personaId).toBe(RESOLVED_PERSONA_ID);
     });
   });
 

--- a/services/bot-client/src/services/MultiTagRecovery.ts
+++ b/services/bot-client/src/services/MultiTagRecovery.ts
@@ -67,6 +67,7 @@ import {
   isTypingChannel,
   type LLMGenerationResult,
   type LoadedPersonality,
+  type PersonaResolver,
   type TypingChannel,
   MULTI_TAG,
 } from '@tzurot/common-types';
@@ -78,6 +79,11 @@ import type {
 } from './MultiTagPersistence.js';
 import type { IPersonalityLoader } from '../types/IPersonalityLoader.js';
 import type { RuntimeEntry, RuntimeSlot } from './multiTagCoordinatorHelpers.js';
+import {
+  pollPriorJobState,
+  synthesizeFailureResult,
+  type SlotStateOutcome,
+} from './multiTagRecoveryHelpers.js';
 
 const logger = createLogger('MultiTagRecovery');
 
@@ -85,6 +91,7 @@ export interface MultiTagRecoveryDeps {
   persistence: MultiTagPersistence;
   coordinator: MultiTagCoordinator;
   personalityService: IPersonalityLoader;
+  personaResolver: PersonaResolver;
   discordClient: Client;
   /**
    * BullMQ queue handle for the AI-requests queue. Used to poll the
@@ -128,12 +135,6 @@ interface DeferredDelivery {
    */
   kind: 'recoveredCompleted' | 'recoveredFailed' | 'unrecoverable';
 }
-
-type SlotStateOutcome =
-  | { kind: 'completed'; result: LLMGenerationResult }
-  | { kind: 'failed'; failedReason: string }
-  | { kind: 'inFlight' }
-  | { kind: 'unrecoverable' };
 
 export class MultiTagRecovery {
   constructor(private readonly deps: MultiTagRecoveryDeps) {}
@@ -366,6 +367,14 @@ export class MultiTagRecovery {
     // already-revoked terminal slot is acceptable.
     const personality = await this.lookupPersonalityWithFallback(slotSnap, entrySnap.userId);
 
+    // See `resolvePersonaIdOrFallback` JSDoc for cascade semantics and
+    // the synthetic-fallback safety net.
+    const personaId = await this.resolvePersonaIdOrFallback(
+      entrySnap.userId,
+      personality?.id ?? slotSnap.personalityId,
+      slotSnap.personalitySlug
+    );
+
     // Already-terminal slots in the snapshot: preserve. No state poll, no
     // deferred delivery — the snapshot status is the source of truth here
     // and the slot will flush via the existing deliverError path (the
@@ -375,9 +384,9 @@ export class MultiTagRecovery {
     if (slotSnap.status !== 'pending') {
       if (personality === null) {
         stats.slotsAccessRevoked++;
-        return { slot: this.buildRevokedSlot(slotSnap) };
+        return { slot: this.buildRevokedSlot(slotSnap, personaId) };
       }
-      return { slot: this.buildPreservedTerminalSlot(slotSnap, personality) };
+      return { slot: this.buildPreservedTerminalSlot(slotSnap, personality, personaId) };
     }
 
     // Pending slot with revoked personality: still keep the slot (with
@@ -386,16 +395,16 @@ export class MultiTagRecovery {
     // successfully, we can't render the result without the personality.
     if (personality === null) {
       stats.slotsAccessRevoked++;
-      return { slot: this.buildRevokedSlot(slotSnap) };
+      return { slot: this.buildRevokedSlot(slotSnap, personaId) };
     }
 
     // Pending slot, personality accessible: poll BullMQ for the old job's
     // authoritative state.
-    const outcome = await this.pollPriorJobState(slotSnap.jobId);
+    const outcome: SlotStateOutcome = await pollPriorJobState(this.deps.queue, slotSnap.jobId);
     const baseSlot: RuntimeSlot = {
       slotIndex: slotSnap.slotIndex,
       personality,
-      personaId: `recovery-persona-${personality.id}`,
+      personaId,
       source: slotSnap.source,
       isAutoResponse: slotSnap.isAutoResponse,
       jobId: slotSnap.jobId,
@@ -440,89 +449,22 @@ export class MultiTagRecovery {
   }
 
   /**
-   * Poll BullMQ for the authoritative state of a job that was pending at
-   * snapshot time. Wraps `queue.getJob().getState()` with bounded error
-   * handling — a transient Redis blip during recovery falls back to
-   * "trust the stream" rather than failing the slot, so the live
-   * subscription can still deliver once it's running.
-   */
-  private async pollPriorJobState(jobId: string): Promise<SlotStateOutcome> {
-    let job;
-    try {
-      job = await this.deps.queue.getJob(jobId);
-    } catch (err) {
-      logger.warn({ err, jobId }, 'Recovery: queue.getJob threw — treating as in-flight');
-      return { kind: 'inFlight' };
-    }
-    if (!job) {
-      return { kind: 'unrecoverable' };
-    }
-
-    let state: string;
-    try {
-      state = await job.getState();
-    } catch (err) {
-      logger.warn({ err, jobId }, 'Recovery: job.getState threw — treating as in-flight');
-      return { kind: 'inFlight' };
-    }
-
-    switch (state) {
-      case 'completed':
-        // Cast required because BullMQ's Job#returnvalue is typed `unknown`
-        // at the generic-Queue level. The ai-worker handler's signature
-        // (`Promise<LLMGenerationResult>` in LLMGenerationHandler.processJob)
-        // guarantees this shape architecturally for jobs on the AI-requests
-        // queue — but the contract isn't enforced at the boundary.
-        //
-        // **The most common runtime cause of `returnvalue === undefined`
-        // here is BullMQ's `removeOnComplete: { count: N }` eviction
-        // racing the `getState()`→`returnvalue` access window**: state
-        // returns 'completed', then the job record is GC'd before we read
-        // returnvalue. Worker crash between completion-write and
-        // returnvalue-write is a possible but rarer cause. Operators
-        // investigating non-zero `slotsUnrecoverable` on a healthy cluster
-        // should check the queue's `removeOnComplete` retention first.
-        //
-        // Either way, route through the unrecoverable path so
-        // coordinator.handleJobResult never receives a malformed result.
-        if (job.returnvalue === null || job.returnvalue === undefined) {
-          return { kind: 'unrecoverable' };
-        }
-        return { kind: 'completed', result: job.returnvalue as LLMGenerationResult };
-      case 'failed':
-        return { kind: 'failed', failedReason: job.failedReason ?? 'Unknown failure' };
-      case 'active':
-      case 'waiting':
-      case 'waiting-children':
-      case 'delayed':
-      case 'prioritized':
-        return { kind: 'inFlight' };
-      default:
-        // 'unknown' or any future state BullMQ adds. Treat as unrecoverable
-        // so the user gets a synthetic-error message instead of a silent
-        // wait until the safety timeout fires.
-        return { kind: 'unrecoverable' };
-    }
-  }
-
-  /**
    * Build a runtime slot for an already-terminal snapshot slot. The
    * snapshot doesn't carry `result`, so the flushed burst will produce a
    * fallback error message for this slot via the existing deliverError
-   * path. Same trade-off applies as in the revoked-slot branch: synthetic
-   * personaId (`recovery-persona-*`) will hit a Prisma FK violation when
-   * `saveAssistantMessage` tries to persist the synthetic message; the
-   * persist call is wrapped in try/catch in deliverError, so the user
-   * sees the message but conversation history doesn't record it.
+   * path. The `personaId` is resolved via `PersonaResolver` upstream
+   * (see `rebuildSlot`), so persistence of the synthetic error message
+   * succeeds against the `personas.id` FK in the typical case.
    */
   private buildPreservedTerminalSlot(
     slotSnap: SlotSnapshot,
-    personality: LoadedPersonality
+    personality: LoadedPersonality,
+    personaId: string
   ): RuntimeSlot {
     return {
       slotIndex: slotSnap.slotIndex,
       personality,
-      personaId: `recovery-persona-${personality.id}`,
+      personaId,
       source: slotSnap.source,
       isAutoResponse: slotSnap.isAutoResponse,
       jobId: slotSnap.jobId,
@@ -534,29 +476,63 @@ export class MultiTagRecovery {
    * Build a sentinel slot for a personality that's no longer accessible
    * (deleted, ownership revoked, etc.). Status is forced to `'errored'`
    * so the group flushes a fallback error message in that position rather
-   * than silently dropping the slot.
-   *
-   * **About the synthetic `personaId`**: `personaId` is a Prisma UUID FK
-   * to the `personas` table. The `recovery-revoked-*` string isn't a
-   * valid UUID, so `saveAssistantMessage` would hit a FK violation when
-   * SlotDeliveryService's deliverError path tries to persist the
-   * synthetic error message. That's acceptable degradation: `deliverError`
-   * wraps the persist call in try/catch (the webhook already sent), so
-   * the user sees the error message but conversation history doesn't
-   * record it. Recovery could look up the user's default persona here to
-   * make persistence work, but synthetic-strings + log-and-swallow is
-   * acceptable for the rare access-revoked edge case.
+   * than silently dropping the slot. The `personaId` is resolved via
+   * `PersonaResolver` upstream (see `rebuildSlot`), so the synthetic
+   * error message persists against a real `personas.id` FK in the
+   * typical case — the user's conversation history records the
+   * "couldn't reach this personality" entry under their own persona.
    */
-  private buildRevokedSlot(slotSnap: SlotSnapshot): RuntimeSlot {
+  private buildRevokedSlot(slotSnap: SlotSnapshot, personaId: string): RuntimeSlot {
     return {
       slotIndex: slotSnap.slotIndex,
       personality: this.buildSentinelPersonality(slotSnap),
-      personaId: `recovery-revoked-${slotSnap.personalitySlug}`,
+      personaId,
       source: slotSnap.source,
       isAutoResponse: slotSnap.isAutoResponse,
       jobId: slotSnap.jobId,
       status: 'errored',
     };
+  }
+
+  /**
+   * Resolve a real `personas.id` UUID for the slot via the PersonaResolver
+   * cascade (per-personality override → user default → first-owned-persona).
+   * Returns the resolved UUID, or a synthetic-string fallback when the
+   * cascade returns null (user has zero personas at all) OR the resolver
+   * call throws (transient Prisma blip). The synthetic-fallback path
+   * keeps the slot deliverable — the `saveAssistantMessage` try/catch
+   * in both deliverSuccess and deliverError swallows the FK violation
+   * so the user still gets their message, history just doesn't persist.
+   *
+   * `fallbackSlug` is passed separately rather than derived from a
+   * `SlotSnapshot` argument because the synthetic-fallback string is
+   * the only thing the function needs from the slot; threading the full
+   * snapshot would be a leaky boundary.
+   */
+  private async resolvePersonaIdOrFallback(
+    discordUserId: string,
+    personalityId: string,
+    fallbackSlug: string
+  ): Promise<string> {
+    try {
+      const memoryInfo = await this.deps.personaResolver.resolveForMemory(
+        discordUserId,
+        personalityId
+      );
+      if (memoryInfo !== null) {
+        return memoryInfo.personaId;
+      }
+      logger.warn(
+        { discordUserId, personalityId },
+        'Recovery: PersonaResolver returned null (user has no personas); falling back to synthetic personaId'
+      );
+    } catch (err) {
+      logger.warn(
+        { err, discordUserId, personalityId },
+        'Recovery: PersonaResolver threw; falling back to synthetic personaId'
+      );
+    }
+    return `recovery-fallback-${fallbackSlug}`;
   }
 
   private async fetchTypingChannel(channelId: string): Promise<TypingChannel | null> {
@@ -691,24 +667,4 @@ export class MultiTagRecovery {
       'Multi-tag entry discarded during recovery'
     );
   }
-}
-
-/**
- * Build a synthetic `LLMGenerationResult` for slots whose old job failed
- * (handler threw or job was evicted). The shape matches what
- * `coordinator.handleJobResult` expects on the failure branch — `success:
- * false` triggers the `'errored'` slot transition, and `error` is rendered
- * by the deliverError path.
- *
- * The `requestId` is set to the old jobId so log correlation still works
- * (the prior process's logs reference the same id). `content` is omitted
- * because the success-path consumer wouldn't reach it anyway when
- * `success === false`.
- */
-function synthesizeFailureResult(slotSnap: SlotSnapshot, error: string): LLMGenerationResult {
-  return {
-    requestId: slotSnap.jobId,
-    success: false,
-    error,
-  };
 }

--- a/services/bot-client/src/services/multiTagRecoveryHelpers.test.ts
+++ b/services/bot-client/src/services/multiTagRecoveryHelpers.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for multiTagRecoveryHelpers — the BullMQ-state polling helper and
+ * the synthetic failure-result constructor. Both extracted from
+ * MultiTagRecovery.ts to keep the main service under the file-length cap.
+ *
+ * The helpers are tested independently from the recovery flow so a future
+ * refactor that moves the call site won't lose coverage on the polling
+ * state machine itself.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { Queue } from 'bullmq';
+import type { LLMGenerationResult } from '@tzurot/common-types';
+import { pollPriorJobState, synthesizeFailureResult } from './multiTagRecoveryHelpers.js';
+import type { SlotSnapshot } from './MultiTagPersistence.js';
+
+function buildSlotSnapshot(overrides: Partial<SlotSnapshot> = {}): SlotSnapshot {
+  return {
+    slotIndex: 0,
+    personalityId: 'id-alice',
+    personalitySlug: 'alice',
+    source: 'mention',
+    isAutoResponse: false,
+    jobId: 'old-job-Alice',
+    status: 'pending',
+    ...overrides,
+  };
+}
+
+/** Builder for the narrow BullMQ Job surface pollPriorJobState consumes. */
+function buildMockJob(opts: {
+  state: string;
+  returnvalue?: LLMGenerationResult | null;
+  failedReason?: string;
+}): { getState: ReturnType<typeof vi.fn>; returnvalue?: unknown; failedReason?: string } {
+  return {
+    getState: vi.fn().mockResolvedValue(opts.state),
+    returnvalue: opts.returnvalue,
+    failedReason: opts.failedReason,
+  };
+}
+
+function buildMockQueue(job: unknown): Queue {
+  return {
+    getJob: vi.fn().mockResolvedValue(job),
+  } as unknown as Queue;
+}
+
+describe('pollPriorJobState', () => {
+  it('returns completed with the returnvalue when the job is in completed state', async () => {
+    const priorResult: LLMGenerationResult = {
+      requestId: 'old-job-Alice',
+      success: true,
+      content: 'response from the prior process',
+    };
+    const queue = buildMockQueue(buildMockJob({ state: 'completed', returnvalue: priorResult }));
+
+    const outcome = await pollPriorJobState(queue, 'old-job-Alice');
+
+    expect(outcome).toEqual({ kind: 'completed', result: priorResult });
+  });
+
+  it('returns unrecoverable when a completed job has null returnvalue (removeOnComplete GC race)', async () => {
+    const queue = buildMockQueue(buildMockJob({ state: 'completed', returnvalue: null }));
+
+    const outcome = await pollPriorJobState(queue, 'old-job-Alice');
+
+    expect(outcome).toEqual({ kind: 'unrecoverable' });
+  });
+
+  it('returns unrecoverable when a completed job has undefined returnvalue', async () => {
+    const queue = buildMockQueue(buildMockJob({ state: 'completed', returnvalue: undefined }));
+
+    const outcome = await pollPriorJobState(queue, 'old-job-Alice');
+
+    expect(outcome).toEqual({ kind: 'unrecoverable' });
+  });
+
+  it('returns failed with the failedReason when the job is in failed state', async () => {
+    const queue = buildMockQueue(buildMockJob({ state: 'failed', failedReason: 'OpenRouter 502' }));
+
+    const outcome = await pollPriorJobState(queue, 'old-job-Alice');
+
+    expect(outcome).toEqual({ kind: 'failed', failedReason: 'OpenRouter 502' });
+  });
+
+  it("returns failed with 'Unknown failure' when failedReason is missing", async () => {
+    const queue = buildMockQueue(buildMockJob({ state: 'failed' }));
+
+    const outcome = await pollPriorJobState(queue, 'old-job-Alice');
+
+    expect(outcome).toEqual({ kind: 'failed', failedReason: 'Unknown failure' });
+  });
+
+  it.each(['active', 'waiting', 'waiting-children', 'delayed', 'prioritized'])(
+    "returns inFlight for state '%s'",
+    async (state: string) => {
+      const queue = buildMockQueue(buildMockJob({ state }));
+
+      const outcome = await pollPriorJobState(queue, 'old-job-Alice');
+
+      expect(outcome).toEqual({ kind: 'inFlight' });
+    }
+  );
+
+  it("returns unrecoverable for the 'unknown' state", async () => {
+    const queue = buildMockQueue(buildMockJob({ state: 'unknown' }));
+
+    const outcome = await pollPriorJobState(queue, 'old-job-Alice');
+
+    expect(outcome).toEqual({ kind: 'unrecoverable' });
+  });
+
+  it('returns unrecoverable when queue.getJob returns null (job evicted from Redis)', async () => {
+    const queue = buildMockQueue(null);
+
+    const outcome = await pollPriorJobState(queue, 'old-job-Alice');
+
+    expect(outcome).toEqual({ kind: 'unrecoverable' });
+  });
+
+  it('returns inFlight when queue.getJob throws (treat transient Redis blip as trust-the-stream)', async () => {
+    const queue = {
+      getJob: vi.fn().mockRejectedValue(new Error('Redis connection refused')),
+    } as unknown as Queue;
+
+    const outcome = await pollPriorJobState(queue, 'old-job-Alice');
+
+    expect(outcome).toEqual({ kind: 'inFlight' });
+  });
+
+  it('returns inFlight when job.getState throws (treat transient Redis blip as trust-the-stream)', async () => {
+    const queue = buildMockQueue({
+      getState: vi.fn().mockRejectedValue(new Error('Lost connection mid-call')),
+      returnvalue: undefined,
+      failedReason: undefined,
+    });
+
+    const outcome = await pollPriorJobState(queue, 'old-job-Alice');
+
+    expect(outcome).toEqual({ kind: 'inFlight' });
+  });
+});
+
+describe('synthesizeFailureResult', () => {
+  it('builds a success:false LLMGenerationResult using the slot jobId as requestId', () => {
+    const slotSnap = buildSlotSnapshot();
+
+    const result = synthesizeFailureResult(slotSnap, 'OpenRouter 500');
+
+    expect(result).toEqual({
+      requestId: 'old-job-Alice',
+      success: false,
+      error: 'OpenRouter 500',
+    });
+  });
+
+  it('preserves whatever error string the caller passes through (no normalization)', () => {
+    const slotSnap = buildSlotSnapshot();
+
+    const result = synthesizeFailureResult(slotSnap, 'Result unavailable after restart');
+
+    expect(result.error).toBe('Result unavailable after restart');
+    expect(result.success).toBe(false);
+  });
+
+  it('omits content (success:false consumers do not read it)', () => {
+    const slotSnap = buildSlotSnapshot();
+
+    const result = synthesizeFailureResult(slotSnap, 'whatever');
+
+    expect(result.content).toBeUndefined();
+  });
+});

--- a/services/bot-client/src/services/multiTagRecoveryHelpers.ts
+++ b/services/bot-client/src/services/multiTagRecoveryHelpers.ts
@@ -1,0 +1,115 @@
+/**
+ * Recovery-time invariants for `MultiTagRecovery`: BullMQ state polling
+ * and synthetic failure-result construction. All helpers here shape
+ * BullMQ job state into the form `coordinator.handleJobResult` consumes
+ * during recovery.
+ *
+ * Separate from `multiTagCoordinatorHelpers.ts` (coordinator-time
+ * invariants: `RuntimeSlot`, `RuntimeEntry`, snapshot projections)
+ * because coordinator and recovery are different lifecycle phases.
+ */
+
+import type { Queue } from 'bullmq';
+import { createLogger, type LLMGenerationResult } from '@tzurot/common-types';
+import type { SlotSnapshot } from './MultiTagPersistence.js';
+
+const logger = createLogger('MultiTagRecoveryHelpers');
+
+/**
+ * Outcome of polling BullMQ for a slot's job state at recovery time.
+ * Discriminated union; consumers `switch` on `kind`.
+ */
+export type SlotStateOutcome =
+  | { kind: 'completed'; result: LLMGenerationResult }
+  | { kind: 'failed'; failedReason: string }
+  | { kind: 'inFlight' }
+  | { kind: 'unrecoverable' };
+
+/**
+ * Poll BullMQ for the authoritative state of a job that was pending at
+ * snapshot time. Wraps `queue.getJob().getState()` with bounded error
+ * handling — a transient Redis blip during recovery falls back to
+ * "trust the stream" rather than failing the slot, so the live
+ * subscription can still deliver once it's running.
+ */
+export async function pollPriorJobState(queue: Queue, jobId: string): Promise<SlotStateOutcome> {
+  let job;
+  try {
+    job = await queue.getJob(jobId);
+  } catch (err) {
+    logger.warn({ err, jobId }, 'Recovery: queue.getJob threw — treating as in-flight');
+    return { kind: 'inFlight' };
+  }
+  if (!job) {
+    return { kind: 'unrecoverable' };
+  }
+
+  let state: string;
+  try {
+    state = await job.getState();
+  } catch (err) {
+    logger.warn({ err, jobId }, 'Recovery: job.getState threw — treating as in-flight');
+    return { kind: 'inFlight' };
+  }
+
+  switch (state) {
+    case 'completed':
+      // Cast required because BullMQ's Job#returnvalue is typed `unknown`
+      // at the generic-Queue level. The ai-worker handler's signature
+      // (`Promise<LLMGenerationResult>` in LLMGenerationHandler.processJob)
+      // guarantees this shape architecturally for jobs on the AI-requests
+      // queue — but the contract isn't enforced at the boundary.
+      //
+      // **The most common runtime cause of `returnvalue === undefined`
+      // here is BullMQ's `removeOnComplete: { count: N }` eviction
+      // racing the `getState()`→`returnvalue` access window**: state
+      // returns 'completed', then the job record is GC'd before we read
+      // returnvalue. Worker crash between completion-write and
+      // returnvalue-write is a possible but rarer cause. Operators
+      // investigating non-zero `slotsUnrecoverable` on a healthy cluster
+      // should check the queue's `removeOnComplete` retention first.
+      //
+      // Either way, route through the unrecoverable path so
+      // coordinator.handleJobResult never receives a malformed result.
+      if (job.returnvalue === null || job.returnvalue === undefined) {
+        return { kind: 'unrecoverable' };
+      }
+      return { kind: 'completed', result: job.returnvalue as LLMGenerationResult };
+    case 'failed':
+      return { kind: 'failed', failedReason: job.failedReason ?? 'Unknown failure' };
+    case 'active':
+    case 'waiting':
+    case 'waiting-children':
+    case 'delayed':
+    case 'prioritized':
+      return { kind: 'inFlight' };
+    default:
+      // 'unknown' or any future state BullMQ adds. Treat as unrecoverable
+      // so the user gets a synthetic-error message instead of a silent
+      // wait until the safety timeout fires.
+      return { kind: 'unrecoverable' };
+  }
+}
+
+/**
+ * Build a synthetic `LLMGenerationResult` for slots whose old job failed
+ * (handler threw or job was evicted). The shape matches what
+ * `coordinator.handleJobResult` expects on the failure branch — `success:
+ * false` triggers the `'errored'` slot transition, and `error` is rendered
+ * by the deliverError path.
+ *
+ * The `requestId` is set to the old jobId so log correlation still works
+ * (the prior process's logs reference the same id). `content` is omitted
+ * because the success-path consumer wouldn't reach it anyway when
+ * `success === false`.
+ */
+export function synthesizeFailureResult(
+  slotSnap: SlotSnapshot,
+  error: string
+): LLMGenerationResult {
+  return {
+    requestId: slotSnap.jobId,
+    success: false,
+    error,
+  };
+}


### PR DESCRIPTION
## Summary

Closes the underlying FK-violation issue PR #1063 mitigated symmetrically. Recovered slots in `MultiTagRecovery` now carry a **real `personas.id` UUID** resolved via `PersonaResolver`'s cascade (per-personality override → user default → first-owned-persona), so `saveAssistantMessage` succeeds and conversation history records the recovered message correctly.

PR #1063 made the FK violation safe (try/catch around `saveAssistantMessage` in both `deliverSuccess` and `deliverError` — webhook succeeds, persistence failure is logged but doesn't propagate). But the user was still seeing their recovered messages dropped from conversation history because `recovery-persona-${id}` and `recovery-revoked-${slug}` aren't valid UUIDs. This PR closes that loop.

## What changed

| File | Change |
|------|--------|
| `services/bot-client/src/services/MultiTagRecovery.ts` | Inject `PersonaResolver` into deps; `rebuildSlot` now calls a new `resolvePersonaIdOrFallback` helper that hits the resolver cascade before constructing the slot. All three slot builders (pending, terminal, revoked) receive the resolved UUID. |
| `services/bot-client/src/services/multiTagRecoveryHelpers.ts` | **New file**. Extracted `pollPriorJobState`, `synthesizeFailureResult`, and `SlotStateOutcome` from `MultiTagRecovery.ts` to keep the main service under the 400-line cap. Pure functions; no behavior change. |
| `services/bot-client/src/services/multiTagRecoveryHelpers.test.ts` | **New file** — 17 colocated tests covering all `pollPriorJobState` state branches (completed, completed-with-null-returnvalue, completed-with-undefined-returnvalue, failed, failed-without-reason, 5 in-flight states, unknown, evicted, getJob-throws, getState-throws) + `synthesizeFailureResult` shape contract. |
| `services/bot-client/src/services/MultiTagRecovery.test.ts` | Added `personaResolver` mock to test deps; added new `describe('personaId resolution via PersonaResolver')` block with 5 tests: happy-path resolution, slug-fallback uses LOADED personality.id, null-return → synthetic fallback, throw → synthetic fallback, revoked-personality uses snapshot personalityId. |
| `services/bot-client/src/services/MultiTagRecovery.ts` (cont'd) | Slot-builder signatures now take `personaId: string` as a parameter (was: hardcoded synthetic strings). |
| `services/bot-client/src/composition.ts` | Thread `personaResolver` through `buildMultiTagStack` → `buildMultiTagRecovery`. |
| `services/bot-client/src/index.ts` | Pass `personaResolver` (already in scope at line 204) into `buildMultiTagStack`. |

## Fallback retention (defense in depth)

The synthetic-string path is retained for two narrow edge cases:

1. `PersonaResolver.resolveForMemory` returns null — user has zero personas at all (SYSTEM_DEFAULT)
2. The resolver call throws — transient Prisma blip during recovery

In either case the slot is still adopted and delivered. The synthetic string (`recovery-fallback-${slug}`) reaches `saveAssistantMessage`, which fails the FK constraint, which is caught by the try/catch from PR #1063 — user sees the message, history just doesn't persist for that edge case.

## Test plan

- [x] Full `pnpm test` (4906 / 4906 — +12 new tests across 2 files)
- [x] `pnpm quality` — all 11 tasks green
- [x] Lint passes (file extraction brought `MultiTagRecovery.ts` back under the 400-line cap)
- [x] All 17 `multiTagRecoveryHelpers` tests pass independently of recovery flow
- [x] All 32 `MultiTagRecovery` tests pass with the new persona-resolution describe block
- [ ] **Manual dev-env e2e**: tag a personality with a long-running prompt, restart bot-client mid-job, observe conversation history records the recovered message (run `pnpm ops db:inspect` and confirm the assistant message row landed under the user's default persona UUID, not a `recovery-*` synthetic string).

## Carries over from PR #1063

- The `saveAssistantMessage` try/catch in `SlotDeliveryService.deliverSuccess` (added in #1063) is now belt-and-suspenders rather than load-bearing — it only fires in the rare fallback case where the resolver couldn't return a UUID.
- The non-idempotency window, returnvalue shape guard, and per-delivery error handling backlog items from PR #1063 are still tracked in `backlog/deferred.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)