### PR TITLE
fix(bot-client): route multi-tag live-failure events via MultiTagCoordinator

### DIFF
--- a/services/bot-client/src/index.ts
+++ b/services/bot-client/src/index.ts
@@ -191,7 +191,10 @@ function createServices(): Services {
   const responseOrderingService = new ResponseOrderingService();
   const jobTracker = new JobTracker(responseOrderingService);
   const resultsListener = new ResultsListener();
-  const jobFailureListener = new JobFailureListener(jobTracker, responseOrderingService);
+  // jobFailureListener is constructed AFTER the multi-tag coordinator below
+  // — it needs the coordinator to route live multi-tag slot failures
+  // through `handleJobResult` instead of leaving them to the 10-min safety
+  // timeout. See its module-level docstring for the dual-routing story.
 
   // Shared services (used by multiple processors)
   const personalityService = new PersonalityService(prisma);
@@ -274,6 +277,16 @@ function createServices(): Services {
     discordClient: client,
     recoveryQueue: multiTagRecoveryQueue,
   });
+
+  // Live failure routing: now that the coordinator exists, wire the
+  // failure listener so it can route multi-tag slot failures through
+  // `coordinator.handleJobResult` instead of falling through to the
+  // single-tag-only `cancelJob` path.
+  const jobFailureListener = new JobFailureListener(
+    jobTracker,
+    responseOrderingService,
+    multiTagCoordinator
+  );
 
   // Processor chain (order matters — see buildProcessorChain doc).
   const processors = buildProcessorChain({

--- a/services/bot-client/src/services/JobFailureListener.test.ts
+++ b/services/bot-client/src/services/JobFailureListener.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { JobFailureListener } from './JobFailureListener.js';
 import type { JobTracker } from './JobTracker.js';
+import type { MultiTagCoordinator } from './MultiTagCoordinator.js';
 import type { ResponseOrderingService } from './ResponseOrderingService.js';
 
 // Mock bullmq's QueueEvents so start()/stop() lifecycle tests don't need a
@@ -42,6 +43,10 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 describe('JobFailureListener', () => {
   let jobTracker: { getContext: ReturnType<typeof vi.fn>; completeJob: ReturnType<typeof vi.fn> };
   let orderingService: { cancelJob: ReturnType<typeof vi.fn> };
+  let multiTagCoordinator: {
+    ownsJob: ReturnType<typeof vi.fn>;
+    handleJobResult: ReturnType<typeof vi.fn>;
+  };
   let listener: JobFailureListener;
 
   beforeEach(() => {
@@ -53,20 +58,29 @@ describe('JobFailureListener', () => {
     orderingService = {
       cancelJob: vi.fn().mockResolvedValue(undefined),
     };
+    multiTagCoordinator = {
+      // Default: jobs are NOT multi-tag (single-tag routing path). Tests for
+      // the multi-tag branch override this per-call.
+      ownsJob: vi.fn().mockReturnValue(false),
+      handleJobResult: vi.fn().mockResolvedValue(undefined),
+    };
     listener = new JobFailureListener(
       jobTracker as unknown as JobTracker,
-      orderingService as unknown as ResponseOrderingService
+      orderingService as unknown as ResponseOrderingService,
+      multiTagCoordinator as unknown as MultiTagCoordinator
     );
   });
 
-  describe('handleTerminalEvent', () => {
+  describe('handleTerminalEvent — single-tag routing', () => {
     it('calls cancelJob with channelId from JobTracker context on failed', async () => {
       jobTracker.getContext.mockReturnValue({ channel: { id: 'channel-abc' } });
 
       await listener.handleTerminalEvent('failed', 'job-123', 'connection refused');
 
+      expect(multiTagCoordinator.ownsJob).toHaveBeenCalledWith('job-123');
       expect(jobTracker.getContext).toHaveBeenCalledWith('job-123');
       expect(orderingService.cancelJob).toHaveBeenCalledWith('channel-abc', 'job-123');
+      expect(multiTagCoordinator.handleJobResult).not.toHaveBeenCalled();
     });
 
     it('calls cancelJob on removed events', async () => {
@@ -83,6 +97,7 @@ describe('JobFailureListener', () => {
       await listener.handleTerminalEvent('failed', 'unknown-job', 'whatever');
 
       expect(orderingService.cancelJob).not.toHaveBeenCalled();
+      expect(multiTagCoordinator.handleJobResult).not.toHaveBeenCalled();
     });
 
     it('does not call jobTracker.completeJob — failure path must not silently delete the "taking longer" notification', async () => {
@@ -95,6 +110,53 @@ describe('JobFailureListener', () => {
 
       expect(orderingService.cancelJob).toHaveBeenCalled();
       expect(jobTracker.completeJob).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleTerminalEvent — multi-tag routing', () => {
+    it('routes failure through coordinator.handleJobResult with synthesized failure result', async () => {
+      // Without this routing, a live multi-tag slot failure would leave the
+      // slot in 'pending' until the 10-min safety timeout fires. Routing
+      // through handleJobResult transitions the slot to 'errored' immediately
+      // so the group can flush as soon as all slots are terminal.
+      multiTagCoordinator.ownsJob.mockReturnValue(true);
+
+      await listener.handleTerminalEvent('failed', 'multitag-job-1', 'OpenRouter 502');
+
+      expect(multiTagCoordinator.handleJobResult).toHaveBeenCalledWith('multitag-job-1', {
+        requestId: 'multitag-job-1',
+        success: false,
+        error: 'OpenRouter 502',
+      });
+      // Single-tag path NOT taken for a multi-tag jobId.
+      expect(orderingService.cancelJob).not.toHaveBeenCalled();
+    });
+
+    it("synthesizes a default error when failedReason is missing (e.g., 'removed' event)", async () => {
+      multiTagCoordinator.ownsJob.mockReturnValue(true);
+
+      await listener.handleTerminalEvent('removed', 'multitag-job-2');
+
+      expect(multiTagCoordinator.handleJobResult).toHaveBeenCalledWith('multitag-job-2', {
+        requestId: 'multitag-job-2',
+        success: false,
+        error: 'Job removed (no reason provided)',
+      });
+    });
+
+    it('does not fall through to single-tag path even if jobTracker also tracks the jobId', async () => {
+      // Defense against an exotic race: if the same jobId somehow appeared in
+      // BOTH the coordinator's jobToGroup map AND the JobTracker, the routing
+      // must be deterministic and pick the multi-tag path (the coordinator
+      // owns the user-facing delivery for multi-tag slots).
+      multiTagCoordinator.ownsJob.mockReturnValue(true);
+      jobTracker.getContext.mockReturnValue({ channel: { id: 'channel-1' } });
+
+      await listener.handleTerminalEvent('failed', 'shared-job-id', 'reason');
+
+      expect(multiTagCoordinator.handleJobResult).toHaveBeenCalledOnce();
+      expect(jobTracker.getContext).not.toHaveBeenCalled();
+      expect(orderingService.cancelJob).not.toHaveBeenCalled();
     });
   });
 

--- a/services/bot-client/src/services/JobFailureListener.ts
+++ b/services/bot-client/src/services/JobFailureListener.ts
@@ -5,11 +5,20 @@
  * channel-ordering bookkeeping when a job fails or is removed without
  * producing a result.
  *
- * Without this listener, a failed AI job leaves a "pending job" entry in
- * ResponseOrderingService that blocks any later response in the same channel
- * until MAX_WAIT_MS (10 min) elapses via the timeout-escape path. With it,
- * failures unblock the queue immediately by calling orderingService.cancelJob
- * via the JobTracker-managed jobId → channelId lookup.
+ * Two routing paths depending on which subsystem owns the failed jobId:
+ *
+ *   1. **Multi-tag slot job**: route through `MultiTagCoordinator.handleJobResult`
+ *      with a synthesized failure `LLMGenerationResult`. Without this, the
+ *      slot stays in `'pending'` status until the coordinator's safety
+ *      timeout fires after 10 min, at which point the user sees a generic
+ *      bot error. Live-failure routing matches the rehydration-time
+ *      synthesis path: same shape, same flush behavior.
+ *
+ *   2. **Single-tag (legacy) job**: unblock the channel-ordering queue via
+ *      `orderingService.cancelJob`. This was the listener's original purpose
+ *      — multi-tag jobs register the groupId in the ordering service rather
+ *      than individual slot.jobIds, so cancelJob is a safe no-op for them
+ *      (kept as the fall-through path for non-multi-tag failures).
  */
 
 import { QueueEvents } from 'bullmq';
@@ -18,8 +27,10 @@ import {
   getConfig,
   parseRedisUrl,
   createBullMQRedisConfig,
+  type LLMGenerationResult,
 } from '@tzurot/common-types';
 import type { JobTracker } from './JobTracker.js';
+import type { MultiTagCoordinator } from './MultiTagCoordinator.js';
 import type { ResponseOrderingService } from './ResponseOrderingService.js';
 
 const logger = createLogger('JobFailureListener');
@@ -29,7 +40,8 @@ export class JobFailureListener {
 
   constructor(
     private readonly jobTracker: JobTracker,
-    private readonly orderingService: ResponseOrderingService
+    private readonly orderingService: ResponseOrderingService,
+    private readonly multiTagCoordinator: MultiTagCoordinator
   ) {}
 
   start(): void {
@@ -94,6 +106,28 @@ export class JobFailureListener {
     // wiring discards the promise and any thrown error surfaces as
     // unhandledRejection — which terminates the Node process in Node 15+.
     try {
+      // Multi-tag path: synthesize a failure result and route through the
+      // coordinator's normal delivery flow. This drives the slot to terminal
+      // immediately instead of waiting for the 10-min safety timeout.
+      if (this.multiTagCoordinator.ownsJob(jobId)) {
+        const syntheticFailure: LLMGenerationResult = {
+          requestId: jobId,
+          success: false,
+          error: failedReason ?? `Job ${reason} (no reason provided)`,
+        };
+        logger.info(
+          { jobId, reason, failedReason },
+          'Multi-tag slot terminal event — routing to coordinator'
+        );
+        await this.multiTagCoordinator.handleJobResult(jobId, syntheticFailure);
+        return;
+      }
+
+      // Single-tag path: unblock the channel-ordering queue. (Multi-tag jobs
+      // register groupId on the ordering service rather than individual
+      // slot.jobIds, so reaching this branch for a multi-tag jobId is
+      // already a safe no-op — but the ownsJob check above keeps the
+      // semantics explicit.)
       const context = this.jobTracker.getContext(jobId);
       if (context === null) {
         logger.debug({ jobId, reason }, 'Terminal event for unknown job — no action');
@@ -104,15 +138,9 @@ export class JobFailureListener {
         { jobId, channelId, reason, failedReason },
         'AI job terminal event — unblocking channel ordering queue'
       );
-      // cancelJob is idempotent: it no-ops if jobId isn't in the channel's
-      // pending set. Multi-tag's normal path registers groupId rather than the
-      // individual slot.jobId, so a slot failure here is a safe no-op.
       await this.orderingService.cancelJob(channelId, jobId);
     } catch (err) {
-      logger.error(
-        { err, jobId, reason, failedReason },
-        'Failed to unblock channel ordering queue on AI job terminal event'
-      );
+      logger.error({ err, jobId, reason, failedReason }, 'Failed to handle AI job terminal event');
     }
   }
 }


### PR DESCRIPTION
## Summary

Closes the **multi-tag live-failure listener** item from `backlog/inbox.md` (surfaced during PR #1063 planning). When a multi-tag slot's BullMQ job fails during *live* operation (not at restart), nothing was routing the failure to `MultiTagCoordinator` — the slot stayed in `'pending'` until the 10-min safety timeout fired, at which point the user saw a generic bot error.

Same UX symptom as the rehydration bug PR #1063 fixed, but a different root cause:
- **Rehydration bug (PR #1063)**: result lost because new bot-client's stream subscriptions don't replay pre-shutdown events.
- **This bug**: failure event fires on `QueueEvents` while the slot is live, but no consumer routes it to `MultiTagCoordinator`.

## What changed

`JobFailureListener.handleTerminalEvent` now branches on `coordinator.ownsJob(jobId)`:
- **Multi-tag path (new)**: synthesize an `LLMGenerationResult` with `success: false` + the failure reason, route via `coordinator.handleJobResult`. Same flush behavior as the rehydration-time synthesis path (PR #1063).
- **Single-tag path (existing)**: fall through to `orderingService.cancelJob` to unblock the channel-ordering queue.

`JobFailureListener` constructor now takes `MultiTagCoordinator` as a dep. Wiring in `index.ts` reordered so `jobFailureListener` is constructed AFTER `buildMultiTagStack` produces the coordinator.

## Test plan

- [x] +3 new `JobFailureListener` tests covering multi-tag routing: synthesized failure shape, `removed`-event fallback message, deterministic precedence over single-tag path on shared jobIds. Existing single-tag tests preserved.
- [x] Full `pnpm test`: 4915+ tests pass (13 in JobFailureListener.test.ts, +3 net new)
- [x] `pnpm quality`: lint + cpd + depcruise + typecheck + typecheck:spec all green
- [ ] **Manual dev-env e2e**: trigger a multi-tag fan-out where one slot's AI job fails (e.g., trigger an OpenRouter 5xx via a malformed prompt). Observe: failed slot transitions to errored within seconds (not 10 min), group flushes the per-slot error message in character voice, no safety-timeout log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)