### PR TITLE
feat(bot-client): /admin metrics command

### DIFF
--- a/services/bot-client/src/commands/admin/index.ts
+++ b/services/bot-client/src/commands/admin/index.ts
@@ -40,6 +40,7 @@ import { handleUsage } from './usage.js';
 import { handleCleanup } from './cleanup.js';
 import { handleStopSequences } from './stop-sequences.js';
 import { handleHealth } from './health.js';
+import { handleMetrics } from './metrics.js';
 import { handlePresence } from './presence.js';
 import {
   handleSettings,
@@ -65,6 +66,7 @@ const adminRouter = createSubcommandContextRouter(
     cleanup: handleCleanup,
     'stop-sequences': handleStopSequences,
     health: handleHealth,
+    metrics: handleMetrics,
     presence: handlePresence,
     settings: handleSettings,
   },
@@ -279,6 +281,11 @@ export default defineCommand({
     )
     .addSubcommand(subcommand =>
       subcommand.setName('health').setDescription('Check bot health and connected services')
+    )
+    .addSubcommand(subcommand =>
+      subcommand
+        .setName('metrics')
+        .setDescription('View gateway queue depth, dedup cache size, and uptime')
     )
     .addSubcommand(subcommand =>
       subcommand

--- a/services/bot-client/src/commands/admin/metrics.test.ts
+++ b/services/bot-client/src/commands/admin/metrics.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for Admin Metrics Subcommand
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleMetrics } from './metrics.js';
+import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
+import type { ChatInputCommandInteraction } from 'discord.js';
+
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+const mockAdminFetch = vi.fn();
+vi.mock('../../utils/adminApiClient.js', () => ({
+  adminFetch: (...args: unknown[]) => mockAdminFetch(...args),
+}));
+
+function createMockContext(): DeferredCommandContext {
+  return {
+    interaction: {} as unknown as ChatInputCommandInteraction,
+    user: { id: '123456789' },
+    guild: null,
+    member: null,
+    channel: null,
+    channelId: 'channel-123',
+    guildId: null,
+    commandName: 'admin',
+    isEphemeral: true,
+    getOption: vi.fn(),
+    getRequiredOption: vi.fn(),
+    getSubcommand: () => 'metrics',
+    getSubcommandGroup: () => null,
+    editReply: vi.fn().mockResolvedValue(undefined),
+    followUp: vi.fn(),
+    deleteReply: vi.fn(),
+  } as unknown as DeferredCommandContext;
+}
+
+interface EmbedField {
+  name: string;
+  value: string;
+}
+
+function fieldsFromCall(context: DeferredCommandContext): EmbedField[] {
+  const call = vi.mocked(context.editReply).mock.calls[0][0] as {
+    embeds: { data: { fields: EmbedField[] } }[];
+  };
+  return call.embeds[0].data.fields;
+}
+
+describe('handleMetrics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the queue / cache / uptime fields when the gateway responds OK', async () => {
+    mockAdminFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          queue: { waiting: 3, active: 1, completed: 4200, failed: 17, total: 4 },
+          cache: { size: 256 },
+          uptime: 7200_000, // 2h in ms
+          timestamp: '2026-05-20T12:00:00.000Z',
+        }),
+    });
+
+    const context = createMockContext();
+    await handleMetrics(context);
+
+    expect(mockAdminFetch).toHaveBeenCalledWith('/metrics');
+
+    const fields = fieldsFromCall(context);
+
+    const inFlight = fields.find(f => f.name === '📥 Queue (in flight)');
+    expect(inFlight?.value).toContain('Waiting: **3**');
+    expect(inFlight?.value).toContain('Active: **1**');
+    expect(inFlight?.value).toContain('Total: **4**');
+
+    const lifetime = fields.find(f => f.name === '📈 Queue (lifetime)');
+    expect(lifetime?.value).toContain('Completed: **4200**');
+    expect(lifetime?.value).toContain('Failed: **17**');
+
+    const cache = fields.find(f => f.name === '💾 Dedup cache');
+    expect(cache?.value).toBe('256 entries');
+
+    // Uptime is rendered via formatDuration — exact text depends on the
+    // helper's output, but for 2h in ms it should at minimum contain '2h'.
+    const uptime = fields.find(f => f.name === '⏱️ Gateway uptime');
+    expect(uptime?.value).toMatch(/2\s*h/);
+  });
+
+  it('attaches the snapshot timestamp as the embed footer', async () => {
+    mockAdminFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          queue: { waiting: 0, active: 0, completed: 0, failed: 0, total: 0 },
+          cache: { size: 0 },
+          uptime: 0,
+          timestamp: '2026-05-20T12:00:00.000Z',
+        }),
+    });
+
+    const context = createMockContext();
+    await handleMetrics(context);
+
+    const call = vi.mocked(context.editReply).mock.calls[0][0] as {
+      embeds: { data: { footer?: { text: string } } }[];
+    };
+    expect(call.embeds[0].data.footer?.text).toContain('2026-05-20T12:00:00.000Z');
+  });
+
+  it('renders a warning embed when the gateway responds with non-OK', async () => {
+    mockAdminFetch.mockResolvedValue({
+      ok: false,
+      status: 503,
+    });
+
+    const context = createMockContext();
+    await handleMetrics(context);
+
+    const fields = fieldsFromCall(context);
+    const errorField = fields.find(f => f.name === '📊 Gateway Metrics');
+    expect(errorField?.value).toContain('503');
+  });
+
+  it('renders a warning embed when adminFetch throws (gateway unreachable)', async () => {
+    mockAdminFetch.mockRejectedValue(new Error('Connection refused'));
+
+    const context = createMockContext();
+    await handleMetrics(context);
+
+    const fields = fieldsFromCall(context);
+    const errorField = fields.find(f => f.name === '📊 Gateway Metrics');
+    expect(errorField?.value).toContain('unreachable');
+  });
+});

--- a/services/bot-client/src/commands/admin/metrics.ts
+++ b/services/bot-client/src/commands/admin/metrics.ts
@@ -1,0 +1,88 @@
+/**
+ * Admin Metrics Subcommand
+ * Handles /admin metrics - Renders the gateway /metrics endpoint as a
+ * Discord embed for the bot owner.
+ *
+ * The /metrics endpoint is service-auth-protected and exposes operational
+ * counters (BullMQ queue depth, dedup cache size, uptime). There's no
+ * other in-bot consumer today, so this command is the human-facing window
+ * into those counters when debugging or spot-checking the gateway.
+ *
+ * Gracefully degrades if the gateway is unreachable, mirroring the
+ * /admin health pattern.
+ */
+
+import { EmbedBuilder } from 'discord.js';
+import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
+import { adminFetch } from '../../utils/adminApiClient.js';
+import { formatDuration } from '../../utils/formatting.js';
+import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
+
+const logger = createLogger('admin-metrics');
+
+interface GatewayMetricsResponse {
+  queue: {
+    waiting: number;
+    active: number;
+    completed: number;
+    failed: number;
+    total: number;
+  };
+  cache: {
+    size: number;
+  };
+  uptime: number;
+  timestamp: string;
+}
+
+const METRICS_FIELD_NAME = '📊 Gateway Metrics';
+
+export async function handleMetrics(context: DeferredCommandContext): Promise<void> {
+  const embed = new EmbedBuilder().setTitle('📊 System Metrics').setColor(DISCORD_COLORS.BLURPLE);
+
+  try {
+    const response = await adminFetch('/metrics');
+
+    if (!response.ok) {
+      embed.addFields({
+        name: METRICS_FIELD_NAME,
+        value: `⚠️ Gateway responded with HTTP ${response.status}`,
+      });
+      embed.setColor(DISCORD_COLORS.WARNING);
+      await context.editReply({ embeds: [embed] });
+      return;
+    }
+
+    const metrics = (await response.json()) as GatewayMetricsResponse;
+
+    embed.addFields(
+      {
+        name: '📥 Queue (in flight)',
+        value: `Waiting: **${metrics.queue.waiting}** | Active: **${metrics.queue.active}** | Total: **${metrics.queue.total}**`,
+      },
+      {
+        name: '📈 Queue (lifetime)',
+        value: `Completed: **${metrics.queue.completed}** | Failed: **${metrics.queue.failed}**`,
+      },
+      {
+        name: '💾 Dedup cache',
+        value: `${metrics.cache.size} entries`,
+      },
+      {
+        name: '⏱️ Gateway uptime',
+        value: formatDuration(metrics.uptime),
+      }
+    );
+
+    embed.setFooter({ text: `Snapshot: ${metrics.timestamp}` });
+  } catch (error) {
+    logger.warn({ err: error }, 'Gateway metrics fetch failed');
+    embed.addFields({
+      name: METRICS_FIELD_NAME,
+      value: '❌ Gateway unreachable',
+    });
+    embed.setColor(DISCORD_COLORS.WARNING);
+  }
+
+  await context.editReply({ embeds: [embed] });
+}

--- a/services/bot-client/src/handlers/__snapshots__/CommandHandler.int.test.ts.snap
+++ b/services/bot-client/src/handlers/__snapshots__/CommandHandler.int.test.ts.snap
@@ -167,6 +167,14 @@ exports[`CommandHandler (component) > command structure snapshots > should have 
     "type": 1,
   },
   {
+    "description": "View gateway queue depth, dedup cache size, and uptime",
+    "description_localizations": undefined,
+    "name": "metrics",
+    "name_localizations": undefined,
+    "options": [],
+    "type": 1,
+  },
+  {
     "description": "Set or view the bot presence (activity status)",
     "description_localizations": undefined,
     "name": "presence",


### PR DESCRIPTION
## Summary

Adds `/admin metrics` — bot-owner-only slash command that gives the gateway `/metrics` endpoint a Discord UX. The endpoint is service-auth-protected and exposes BullMQ queue depth, dedup cache size, and gateway uptime; this command renders that as an ephemeral embed.

## What's in the embed

- **📥 Queue (in flight)**: Waiting / Active / Total counters
- **📈 Queue (lifetime)**: Completed / Failed counters
- **💾 Dedup cache**: entry count
- **⏱️ Gateway uptime**: formatted via existing `formatDuration` helper
- **Footer**: snapshot ISO timestamp

Mirrors the `/admin health` pattern: ephemeral deferred reply, graceful degradation when the gateway is unreachable (`❌ Gateway unreachable`) or responds non-OK (`⚠️ Gateway responded with HTTP <status>`), structured logging on the warn path.

## Closes

The `/admin metrics` quick-win from `backlog/quick-wins.md`. Originally surfaced 2026-05-17 in PR #1048 review; triaged 2026-05-19 once the ping-race prod issue resolved (the original "wait until" trigger).

## Test plan

- [x] 4 new unit tests covering happy path, non-OK response, gateway-unreachable throw, and footer-timestamp assertion
- [x] `CommandHandler.int.test.ts` admin-command-options snapshot updated for the new subcommand
- [x] Full `pnpm test` + `pnpm test:int` + `pnpm quality` green
- [ ] Manual smoke on dev after deploy — run `/admin metrics` in DM, confirm all four sections populate and the embed renders without truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)