### PR TITLE
fix(api-gateway): protect /voice-references with service auth

### DIFF
--- a/docs/reference/testing/BYOK_MANUAL_TESTING.md
+++ b/docs/reference/testing/BYOK_MANUAL_TESTING.md
@@ -19,15 +19,20 @@ railway variables --set "API_KEY_ENCRYPTION_KEY=<your-64-hex-chars>" --service a
 railway variables --set "API_KEY_ENCRYPTION_KEY=<your-64-hex-chars>" --service ai-worker
 ```
 
-On **both** `api-gateway` and `bot-client` services (for admin commands):
+On **all three** of `api-gateway`, `bot-client`, and `ai-worker` services:
+
+- api-gateway validates incoming `X-Service-Auth` headers
+- bot-client sends it on admin command → gateway calls
+- ai-worker sends it on `/voice-references/:slug` fetches (service-auth-protected)
 
 ```bash
 # Generate admin API key (shared secret for service-to-service auth)
 openssl rand -hex 32
 
-# Set on Railway (same key for both services)
+# Set on Railway (same key for all three services)
 railway variables --set "INTERNAL_SERVICE_SECRET=<your-64-hex-chars>" --service api-gateway
 railway variables --set "INTERNAL_SERVICE_SECRET=<your-64-hex-chars>" --service bot-client
+railway variables --set "INTERNAL_SERVICE_SECRET=<your-64-hex-chars>" --service ai-worker
 ```
 
 ### Verify Setup
@@ -37,9 +42,10 @@ railway variables --set "INTERNAL_SERVICE_SECRET=<your-64-hex-chars>" --service 
 railway variables --service api-gateway | grep API_KEY_ENCRYPTION
 railway variables --service ai-worker | grep API_KEY_ENCRYPTION
 
-# Check admin API key is set (for admin commands)
+# Check admin API key is set on all three services
 railway variables --service api-gateway | grep INTERNAL_SERVICE_SECRET
 railway variables --service bot-client | grep INTERNAL_SERVICE_SECRET
+railway variables --service ai-worker | grep INTERNAL_SERVICE_SECRET
 
 # Check services are healthy
 curl https://api-gateway-<your-deployment>.railway.app/health

--- a/packages/common-types/src/constants/timing.ts
+++ b/packages/common-types/src/constants/timing.ts
@@ -162,8 +162,6 @@ export const RETRY_CONFIG = {
 export const CACHE_CONTROL = {
   /** Cache duration for avatar images (7 days in seconds) */
   AVATAR_MAX_AGE: 604800,
-  /** Cache duration for voice reference audio (1 hour in seconds) */
-  VOICE_REFERENCE_MAX_AGE: 3600,
 } as const;
 
 /**

--- a/services/ai-worker/src/services/voice/ElevenLabsVoiceService.test.ts
+++ b/services/ai-worker/src/services/voice/ElevenLabsVoiceService.test.ts
@@ -23,6 +23,7 @@ vi.mock('@tzurot/common-types', async importOriginal => {
     getConfig: () =>
       ({
         GATEWAY_URL: 'http://localhost:3000',
+        INTERNAL_SERVICE_SECRET: 'test-secret',
       }) as unknown as EnvConfig,
   };
 });

--- a/services/ai-worker/src/services/voice/VoiceRegistrationService.test.ts
+++ b/services/ai-worker/src/services/voice/VoiceRegistrationService.test.ts
@@ -31,6 +31,7 @@ describe('VoiceRegistrationService', () => {
 
     getConfigSpy = vi.spyOn(commonTypes, 'getConfig').mockReturnValue({
       GATEWAY_URL: 'http://localhost:3000',
+      INTERNAL_SERVICE_SECRET: 'test-secret',
     } as unknown as EnvConfig);
 
     service = new VoiceRegistrationService(mockVoiceEngineClient as unknown as VoiceEngineClient);

--- a/services/ai-worker/src/services/voice/voiceReferenceHelper.test.ts
+++ b/services/ai-worker/src/services/voice/voiceReferenceHelper.test.ts
@@ -54,9 +54,10 @@ const mockedGetConfig = vi.mocked(getConfig);
 describe('fetchVoiceReference', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockedGetConfig.mockReturnValue({ GATEWAY_URL: 'http://localhost:3000' } as ReturnType<
-      typeof getConfig
-    >);
+    mockedGetConfig.mockReturnValue({
+      GATEWAY_URL: 'http://localhost:3000',
+      INTERNAL_SERVICE_SECRET: 'test-secret',
+    } as ReturnType<typeof getConfig>);
   });
 
   afterEach(() => {
@@ -78,15 +79,47 @@ describe('fetchVoiceReference', () => {
     expect(result.contentType).toBe('audio/mpeg');
     expect(mockFetch).toHaveBeenCalledWith(
       'http://localhost:3000/voice-references/test-slug',
-      expect.objectContaining({ signal: expect.any(AbortSignal) })
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+        headers: { 'X-Service-Auth': 'test-secret' },
+      })
     );
   });
 
   it('throws when GATEWAY_URL is undefined', async () => {
-    mockedGetConfig.mockReturnValue({} as ReturnType<typeof getConfig>);
+    mockedGetConfig.mockReturnValue({ INTERNAL_SERVICE_SECRET: 'test-secret' } as ReturnType<
+      typeof getConfig
+    >);
 
     await expect(fetchVoiceReference('test-slug')).rejects.toThrow(
       'GATEWAY_URL not configured — cannot fetch voice reference'
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('throws when INTERNAL_SERVICE_SECRET is undefined (fail-fast on misconfiguration)', async () => {
+    // The /voice-references route is service-auth-protected. Missing
+    // secret means every fetch would 403; failing here surfaces the
+    // misconfiguration as a clear error at the call site rather than
+    // letting api-gateway respond with a generic auth rejection.
+    mockedGetConfig.mockReturnValue({ GATEWAY_URL: 'http://localhost:3000' } as ReturnType<
+      typeof getConfig
+    >);
+
+    await expect(fetchVoiceReference('test-slug')).rejects.toThrow(
+      'INTERNAL_SERVICE_SECRET not configured'
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('throws when INTERNAL_SERVICE_SECRET is empty string', async () => {
+    mockedGetConfig.mockReturnValue({
+      GATEWAY_URL: 'http://localhost:3000',
+      INTERNAL_SERVICE_SECRET: '',
+    } as ReturnType<typeof getConfig>);
+
+    await expect(fetchVoiceReference('test-slug')).rejects.toThrow(
+      'INTERNAL_SERVICE_SECRET not configured'
     );
     expect(mockFetch).not.toHaveBeenCalled();
   });

--- a/services/ai-worker/src/services/voice/voiceReferenceHelper.ts
+++ b/services/ai-worker/src/services/voice/voiceReferenceHelper.ts
@@ -4,6 +4,14 @@
  * Fetches voice reference audio from the api-gateway.
  * Shared by ElevenLabsVoiceService (BYOK cloning) and
  * VoiceRegistrationService (self-hosted voice-engine registration).
+ *
+ * The /voice-references route is service-auth-protected; this helper
+ * sends `X-Service-Auth: ${INTERNAL_SERVICE_SECRET}` on every request.
+ * Missing secret is fail-fast — the helper throws before fetching rather
+ * than letting api-gateway respond 403. The fail-fast surfaces a config
+ * misconfiguration as a clear call-site error (with the right
+ * environment variable named) rather than a generic 403 from the
+ * gateway that's harder to attribute.
  */
 
 import { createLogger, getConfig, TimeoutError } from '@tzurot/common-types';
@@ -36,6 +44,12 @@ export async function fetchVoiceReference(slug: string): Promise<VoiceReferenceR
   if (gatewayUrl === undefined) {
     throw new Error('GATEWAY_URL not configured — cannot fetch voice reference');
   }
+  const serviceSecret = config.INTERNAL_SERVICE_SECRET;
+  if (serviceSecret === undefined || serviceSecret.length === 0) {
+    throw new Error(
+      'INTERNAL_SERVICE_SECRET not configured — cannot fetch voice reference (the gateway route requires service auth)'
+    );
+  }
 
   const voiceUrl = `${gatewayUrl}/voice-references/${encodeURIComponent(slug)}`;
   logger.info({ slug }, 'Fetching voice reference from gateway');
@@ -43,6 +57,7 @@ export async function fetchVoiceReference(slug: string): Promise<VoiceReferenceR
   let response: globalThis.Response;
   try {
     response = await fetch(voiceUrl, {
+      headers: { 'X-Service-Auth': serviceSecret },
       signal: AbortSignal.timeout(VOICE_REFERENCE_TIMEOUT_MS),
     });
   } catch (error) {

--- a/services/ai-worker/src/startup.test.ts
+++ b/services/ai-worker/src/startup.test.ts
@@ -20,6 +20,7 @@ vi.mock('@tzurot/common-types', async importOriginal => {
     }),
     getConfig: vi.fn(() => ({
       REDIS_URL: 'redis://localhost:6379',
+      INTERNAL_SERVICE_SECRET: 'test-secret',
     })),
     HealthStatus: actual.HealthStatus,
   };
@@ -39,9 +40,10 @@ describe('Startup Utilities', () => {
   });
 
   describe('validateRequiredEnvVars', () => {
-    it('should not throw when REDIS_URL is set', () => {
+    it('should not throw when all required vars are set', () => {
       const config = {
         REDIS_URL: 'redis://localhost:6379',
+        INTERNAL_SERVICE_SECRET: 'test-secret',
       };
       expect(() =>
         validateRequiredEnvVars(
@@ -53,6 +55,7 @@ describe('Startup Utilities', () => {
     it('should throw when REDIS_URL is undefined', () => {
       const config = {
         REDIS_URL: undefined,
+        INTERNAL_SERVICE_SECRET: 'test-secret',
       };
       expect(() =>
         validateRequiredEnvVars(
@@ -64,12 +67,37 @@ describe('Startup Utilities', () => {
     it('should throw when REDIS_URL is empty', () => {
       const config = {
         REDIS_URL: '',
+        INTERNAL_SERVICE_SECRET: 'test-secret',
       };
       expect(() =>
         validateRequiredEnvVars(
           config as ReturnType<typeof import('@tzurot/common-types').getConfig>
         )
       ).toThrow('REDIS_URL environment variable is required');
+    });
+
+    it('should throw when INTERNAL_SERVICE_SECRET is undefined', () => {
+      const config = {
+        REDIS_URL: 'redis://localhost:6379',
+        INTERNAL_SERVICE_SECRET: undefined,
+      };
+      expect(() =>
+        validateRequiredEnvVars(
+          config as ReturnType<typeof import('@tzurot/common-types').getConfig>
+        )
+      ).toThrow('INTERNAL_SERVICE_SECRET environment variable is required');
+    });
+
+    it('should throw when INTERNAL_SERVICE_SECRET is empty', () => {
+      const config = {
+        REDIS_URL: 'redis://localhost:6379',
+        INTERNAL_SERVICE_SECRET: '',
+      };
+      expect(() =>
+        validateRequiredEnvVars(
+          config as ReturnType<typeof import('@tzurot/common-types').getConfig>
+        )
+      ).toThrow('INTERNAL_SERVICE_SECRET environment variable is required');
     });
   });
 

--- a/services/ai-worker/src/startup.ts
+++ b/services/ai-worker/src/startup.ts
@@ -17,6 +17,11 @@ export function validateRequiredEnvVars(config = getConfig()): void {
   if (config.REDIS_URL === undefined || config.REDIS_URL.length === 0) {
     throw new Error('REDIS_URL environment variable is required');
   }
+  if (config.INTERNAL_SERVICE_SECRET === undefined || config.INTERNAL_SERVICE_SECRET.length === 0) {
+    throw new Error(
+      'INTERNAL_SERVICE_SECRET environment variable is required (service-to-service auth for protected gateway routes)'
+    );
+  }
 }
 
 /**

--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -43,10 +43,9 @@ import { createModelsRouter } from './routes/models/index.js';
 import {
   createHealthRouter,
   createAvatarRouter,
-  createVoiceReferenceRouter,
   createExportsRouter,
 } from './routes/public/index.js';
-import { createMetricsRouter } from './routes/protected/index.js';
+import { createMetricsRouter, createVoiceReferenceRouter } from './routes/protected/index.js';
 
 // Middleware
 import {
@@ -247,17 +246,11 @@ function registerRoutes(app: Express, prisma: PrismaClient, services: ServicesCo
     'Public-route rate limiter initialized'
   );
 
-  // Media routes that legitimately need cross-origin embedding (Discord
-  // fetches avatars and voice samples from outside our origin). Opt these
-  // two specific routers into CORP cross-origin via the per-route
-  // middleware; everything else inherits helmet's same-origin default.
+  // Media route that legitimately needs cross-origin embedding (Discord
+  // fetches avatars from outside our origin). Opt into CORP cross-origin
+  // via the per-route middleware; everything else inherits helmet's
+  // same-origin default.
   app.use('/avatars', publicRateLimiter, allowCrossOriginEmbedding, createAvatarRouter(prisma));
-  app.use(
-    '/voice-references',
-    publicRateLimiter,
-    allowCrossOriginEmbedding,
-    createVoiceReferenceRouter(prisma)
-  );
   app.use('/exports', publicRateLimiter, createExportsRouter(prisma));
 
   // PROTECTED ROUTES (require service authentication)
@@ -273,6 +266,15 @@ function registerRoutes(app: Express, prisma: PrismaClient, services: ServicesCo
   // INTERNAL_SERVICE_SECRET like everything else in the protected section.
   app.use('/metrics', createMetricsRouter(aiQueue, startTime));
   logger.info('Metrics route registered (service-auth protected)');
+
+  // /voice-references serves audio buffers from `personality.voiceReferenceData`.
+  // Sole consumer is ai-worker's voiceReferenceHelper (server-to-server),
+  // so the route is service-auth-protected to close the slug-enumeration
+  // attack surface. Slugs are predictable, so leaving this anonymous would
+  // let an attacker enumerate the voice-clone library — see the route's
+  // module docstring for the historical context.
+  app.use('/voice-references', createVoiceReferenceRouter(prisma));
+  logger.info('Voice references route registered (service-auth protected)');
 
   app.use('/ai', createAIRouter(prisma, aiQueue, queueEvents));
   logger.info('AI routes registered');

--- a/services/api-gateway/src/routes/protected/index.ts
+++ b/services/api-gateway/src/routes/protected/index.ts
@@ -7,3 +7,4 @@
  */
 
 export { createMetricsRouter } from './metrics.js';
+export { createVoiceReferenceRouter } from './voiceReferences.js';

--- a/services/api-gateway/src/routes/protected/voiceReferences.test.ts
+++ b/services/api-gateway/src/routes/protected/voiceReferences.test.ts
@@ -16,9 +16,6 @@ const mockLogger = vi.hoisted(() => ({
 
 vi.mock('@tzurot/common-types', () => ({
   createLogger: () => mockLogger,
-  CACHE_CONTROL: {
-    VOICE_REFERENCE_MAX_AGE: 3600,
-  },
   VOICE_REFERENCE_LIMITS: {
     ALLOWED_TYPES: [
       'audio/wav',
@@ -29,18 +26,30 @@ vi.mock('@tzurot/common-types', () => ({
       'audio/wave',
     ],
   },
+  // requireServiceAuth reads getConfig().INTERNAL_SERVICE_SECRET — stub
+  // it to a known value so the auth-protection test block can verify
+  // both rejection (missing/wrong header) and acceptance (matching header).
+  getConfig: () => ({ INTERNAL_SERVICE_SECRET: 'test-secret' }),
 }));
 
-vi.mock('../../utils/errorResponses.js', () => ({
-  ErrorResponses: {
-    validationError: vi.fn((message: string) => ({ error: 'Validation Error', message })),
-    notFound: vi.fn((resource: string) => ({
-      error: 'Not Found',
-      message: `${resource} not found`,
-    })),
-    internalError: vi.fn((message: string) => ({ error: 'Internal Error', message })),
-  },
-}));
+vi.mock('../../utils/errorResponses.js', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/errorResponses.js')>(
+    '../../utils/errorResponses.js'
+  );
+  return {
+    ...actual,
+    ErrorResponses: {
+      ...actual.ErrorResponses,
+      validationError: vi.fn((message: string) => ({ error: 'Validation Error', message })),
+      notFound: vi.fn((resource: string) => ({
+        error: 'Not Found',
+        message: `${resource} not found`,
+      })),
+      internalError: vi.fn((message: string) => ({ error: 'Internal Error', message })),
+      unauthorized: vi.fn((message: string) => ({ error: 'UNAUTHORIZED', message })),
+    },
+  };
+});
 
 vi.mock('../../utils/validators.js', () => ({
   validateSlug: vi.fn((slug: string | undefined) => {
@@ -52,6 +61,7 @@ vi.mock('../../utils/validators.js', () => ({
 }));
 
 import { createVoiceReferenceRouter } from './voiceReferences.js';
+import { requireServiceAuth } from '../../services/AuthMiddleware.js';
 
 function createMockPrisma() {
   return {
@@ -126,7 +136,7 @@ describe('Voice Reference Routes', () => {
       expect(response.status).toBe(StatusCodes.OK);
       expect(response.headers['content-type']).toContain('audio/wav');
       expect(response.headers['content-length']).toBe(String(audioBuffer.length));
-      expect(response.headers['cache-control']).toContain('max-age=3600');
+      expect(response.headers['cache-control']).toBe('no-store');
       expect(response.body).toEqual(audioBuffer);
     });
 
@@ -178,6 +188,52 @@ describe('Voice Reference Routes', () => {
         where: { slug: 'my-persona' },
         select: { voiceReferenceData: true, voiceReferenceType: true },
       });
+    });
+  });
+
+  describe('with requireServiceAuth mounted upstream', () => {
+    // Verifies the middleware-plus-router composition produces correct
+    // access control: unauthorized requests → 403, matching secret → 200.
+    // Documents that /voice-references requires service auth; production
+    // wiring is the umbrella `app.use(requireServiceAuth())` in index.ts.
+
+    function buildProtectedApp(): express.Express {
+      const protectedApp = express();
+      protectedApp.use(requireServiceAuth());
+      protectedApp.use('/voice-references', createVoiceReferenceRouter(mockPrisma as never));
+      return protectedApp;
+    }
+
+    // Production maps `ErrorCode.UNAUTHORIZED` → HTTP 403 (FORBIDDEN), not
+    // 401 (UNAUTHORIZED). Matches the metrics-route test's expectation
+    // for the same reason — these tests reflect actual behavior.
+    it('should reject requests without the X-Service-Auth header', async () => {
+      const response = await request(buildProtectedApp()).get('/voice-references/testbot');
+
+      expect(response.status).toBe(StatusCodes.FORBIDDEN);
+    });
+
+    it('should reject requests with the wrong X-Service-Auth secret', async () => {
+      const response = await request(buildProtectedApp())
+        .get('/voice-references/testbot')
+        .set('X-Service-Auth', 'wrong-secret');
+
+      expect(response.status).toBe(StatusCodes.FORBIDDEN);
+    });
+
+    it('should allow requests with the correct X-Service-Auth secret', async () => {
+      const audioBuffer = Buffer.from('fake-wav-data');
+      mockPrisma.personality.findUnique.mockResolvedValue({
+        voiceReferenceData: audioBuffer,
+        voiceReferenceType: 'audio/wav',
+      });
+
+      const response = await request(buildProtectedApp())
+        .get('/voice-references/testbot')
+        .set('X-Service-Auth', 'test-secret');
+
+      expect(response.status).toBe(StatusCodes.OK);
+      expect(response.headers['content-type']).toContain('audio/wav');
     });
   });
 });

--- a/services/api-gateway/src/routes/protected/voiceReferences.ts
+++ b/services/api-gateway/src/routes/protected/voiceReferences.ts
@@ -1,31 +1,30 @@
 /**
  * Voice Reference Routes
  *
- * Serves personality voice reference audio from database.
- * Unlike avatars, no filesystem caching — voice references are accessed infrequently
- * (only when registering voices with the voice-engine service).
+ * Serves personality voice reference audio from database. Mounted behind
+ * `requireServiceAuth()` in `index.ts` — sole consumer is ai-worker's
+ * `voiceReferenceHelper` for BYOK cloning + self-hosted voice-engine
+ * registration, both server-to-server within Railway's internal network.
  *
- * ACCESS DECISION: This endpoint is intentionally unauthenticated. Voice
- * references are treated as semi-public data (like avatars) — anyone with the
- * personality slug can retrieve them. The primary consumer is the voice-engine
- * service which fetches reference audio for voice cloning without user auth
- * context. If voice references become sensitive, add a shared service secret.
+ * ACCESS POSTURE: service-auth-required. Slugs are predictable, so an
+ * anonymous endpoint would let an attacker enumerate the voice-clone
+ * library by brute-forcing slug names. No client-side consumer exists —
+ * voice-engine fetches audio inline via TTS request bodies from ai-worker;
+ * it never hits this route directly.
  *
- * CACHE NOTE: max-age=3600 (1 hour) applies to downstream HTTP caches only.
- * The ai-worker's VoiceRegistrationService has its own 30-min positive cache
- * that is the actual user-visible latency bottleneck for voice reference updates.
- * Unlike avatars (which use timestamp-based cache-busting URLs), voice references
- * are served from DB with no filesystem cache layer.
+ * CACHE NOTE: response sends `Cache-Control: no-store` because the sole
+ * consumer is a server-to-server fetch with no HTTP cache layer between
+ * ai-worker and api-gateway within Railway's internal network. The
+ * user-visible latency bottleneck for voice reference updates is
+ * ai-worker's `VoiceRegistrationService` 30-min in-memory positive cache,
+ * which is unaffected by this header. Setting `no-store` also keeps the
+ * response from being cached by any future caching proxy that might be
+ * inserted into the path without `Vary: X-Service-Auth`.
  */
 
 import { Router } from 'express';
 import { StatusCodes } from 'http-status-codes';
-import {
-  createLogger,
-  CACHE_CONTROL,
-  VOICE_REFERENCE_LIMITS,
-  type PrismaClient,
-} from '@tzurot/common-types';
+import { createLogger, VOICE_REFERENCE_LIMITS, type PrismaClient } from '@tzurot/common-types';
 import { ErrorResponses } from '../../utils/errorResponses.js';
 import { validateSlug } from '../../utils/validators.js';
 
@@ -74,7 +73,7 @@ export function createVoiceReferenceRouter(prisma: PrismaClient): Router {
 
         res.set('Content-Type', contentType);
         res.set('Content-Length', String(buffer.length));
-        res.set('Cache-Control', `max-age=${CACHE_CONTROL.VOICE_REFERENCE_MAX_AGE}`);
+        res.set('Cache-Control', 'no-store');
         res.send(buffer);
       } catch (error) {
         logger.error({ err: error, slug }, 'Error serving voice reference');

--- a/services/api-gateway/src/routes/public/index.ts
+++ b/services/api-gateway/src/routes/public/index.ts
@@ -1,11 +1,12 @@
 /**
  * Public Routes
  *
- * Routes that don't require authentication (health, avatars,
- * voice-references, exports).
+ * Routes that don't require authentication (health, avatars, exports).
+ * Voice references moved to `routes/protected/` — they're only consumed
+ * server-to-server by ai-worker, so the previous "intentionally
+ * semi-public" posture invited slug-enumeration attacks for no gain.
  */
 
 export { createHealthRouter } from './health.js';
 export { createAvatarRouter } from './avatars.js';
-export { createVoiceReferenceRouter } from './voiceReferences.js';
 export { createExportsRouter } from './exports.js';


### PR DESCRIPTION
## Summary

Closes the last open item in the **API Security Hardening** theme: slug-enumeration on `/voice-references`. The endpoint was "intentionally semi-public" per its docstring, but slugs are predictable, so an attacker could enumerate the voice-clone library by brute-forcing slug names. Investigation found **only one production consumer** — ai-worker's `voiceReferenceHelper`, server-to-server within Railway's internal network — so locking the route behind `requireServiceAuth()` closes the attack surface with zero UX cost.

## Consumer landscape (verified)

- **ai-worker** `voiceReferenceHelper.ts:40` — sole consumer, used by `ElevenLabsVoiceService` (BYOK cloning) and `VoiceRegistrationService` (self-hosted voice-engine registration). Server-to-server.
- **voice-engine** — **not** a consumer despite the previous route docstring's claim. Voice-engine receives reference audio inline in TTS request bodies from ai-worker; it never fetches the route directly.
- **client-side** — no browser, Discord embed, or external consumer.

## What changed

| File | Change |
|------|--------|
| `routes/public/voiceReferences.{ts,test.ts}` | **Moved** to `routes/protected/` |
| `routes/public/index.ts` | Removed export; barrel docstring updated to explain the move |
| `routes/protected/index.ts` | Added `createVoiceReferenceRouter` export |
| `api-gateway/src/index.ts` | Mount behind `requireServiceAuth()`; drop public rate-limiter + `allowCrossOriginEmbedding` (both moot under service auth) |
| `routes/protected/voiceReferences.ts` | Docstring rewritten — service-auth-required; `Cache-Control: no-store` (no HTTP cache layer in the server-to-server path) |
| `ai-worker/voiceReferenceHelper.ts` | Add `X-Service-Auth` header; fail-fast on missing `INTERNAL_SERVICE_SECRET` (clear call-site error rather than per-request 403) |
| `ai-worker/startup.ts` | Add `INTERNAL_SERVICE_SECRET` to `validateRequiredEnvVars` so misconfig fails at process startup rather than first TTS attempt |
| `BYOK_MANUAL_TESTING.md` | Add ai-worker to the `INTERNAL_SERVICE_SECRET` setup list |

## Deploy requirement

`INTERNAL_SERVICE_SECRET` must be set on the **ai-worker** Railway service with the same value as api-gateway/bot-client **before this PR is in production**. Without it, ai-worker will now fail at startup (the new `validateRequiredEnvVars` check) rather than on first TTS attempt — so the misconfig is unmissable on deploy.

The runtime blast radius of the secret being missing is narrow: only the TTS paths that fetch voice references (BYOK cloning via `ElevenLabsVoiceService`, self-hosted voice-engine registration via `VoiceRegistrationService`). Standard TTS providers that don't need reference audio are unaffected. But with the startup check, ai-worker won't boot without the secret regardless.

```
railway variables --set "INTERNAL_SERVICE_SECRET=<same-as-api-gateway>" --service ai-worker
```

Verify with:

```
railway variables --service ai-worker | grep INTERNAL_SERVICE_SECRET
```

## Test plan

- [x] 3 new tests in `voiceReferences.test.ts` covering the `requireServiceAuth` integration (reject without header, reject with wrong secret, allow with correct secret) — mirrors the existing `metrics.test.ts` pattern
- [x] 2 new tests in `voiceReferenceHelper.test.ts` (fail-fast on missing / empty `INTERNAL_SERVICE_SECRET`); existing happy-path test updated to assert `X-Service-Auth` header is included
- [x] 2 new tests in `startup.test.ts` covering the new `INTERNAL_SERVICE_SECRET` validation (undefined + empty cases)
- [x] `ElevenLabsVoiceService.test.ts` + `VoiceRegistrationService.test.ts` config mocks updated with `INTERNAL_SERVICE_SECRET`
- [x] Full `pnpm test`: all tests pass
- [x] `pnpm quality`: 11/11 tasks green
- [ ] **Manual smoke on dev after deploy**:
  - Set `INTERNAL_SERVICE_SECRET` on ai-worker dev service
  - Trigger a TTS-rendering message; verify voice reference fetches succeed
  - Test with the secret unset (or wrong) — ai-worker should fail to start with the named error

🤖 Generated with [Claude Code](https://claude.com/claude-code)