### PR TITLE
fix: symmetric INTERNAL_SERVICE_SECRET startup validation

### DIFF
--- a/services/api-gateway/src/bootstrap/startup.test.ts
+++ b/services/api-gateway/src/bootstrap/startup.test.ts
@@ -194,13 +194,26 @@ describe('Startup Utilities', () => {
       expect(() => validateServiceAuthConfig()).not.toThrow();
     });
 
-    it('should not throw when service secret is missing (just logs warning)', async () => {
+    it('should throw when service secret is undefined', async () => {
       vi.mocked(getConfig).mockReturnValue({
         INTERNAL_SERVICE_SECRET: undefined,
       } as ReturnType<typeof getConfig>);
 
       const { validateServiceAuthConfig } = await import('./startup.js');
-      expect(() => validateServiceAuthConfig()).not.toThrow();
+      expect(() => validateServiceAuthConfig()).toThrow(
+        'INTERNAL_SERVICE_SECRET environment variable is required'
+      );
+    });
+
+    it('should throw when service secret is empty string', async () => {
+      vi.mocked(getConfig).mockReturnValue({
+        INTERNAL_SERVICE_SECRET: '',
+      } as ReturnType<typeof getConfig>);
+
+      const { validateServiceAuthConfig } = await import('./startup.js');
+      expect(() => validateServiceAuthConfig()).toThrow(
+        'INTERNAL_SERVICE_SECRET environment variable is required'
+      );
     });
   });
 });

--- a/services/api-gateway/src/bootstrap/startup.ts
+++ b/services/api-gateway/src/bootstrap/startup.ts
@@ -103,17 +103,17 @@ export function validateRequiredEnvVars(): void {
 }
 
 /**
- * Log warning if service auth secret is not configured
+ * Validate service auth secret is configured. Throws at startup so a
+ * misconfigured deploy fails to boot rather than silently 403-ing every
+ * protected-route request. Symmetric with ai-worker and bot-client startup checks.
  */
 export function validateServiceAuthConfig(): void {
   if (
     envConfig.INTERNAL_SERVICE_SECRET === undefined ||
     envConfig.INTERNAL_SERVICE_SECRET.length === 0
   ) {
-    logger.warn(
-      {},
-      'INTERNAL_SERVICE_SECRET is not set - all protected endpoints will reject requests. ' +
-        'Set INTERNAL_SERVICE_SECRET as a shared Railway variable to enable service-to-service auth.'
+    throw new Error(
+      'INTERNAL_SERVICE_SECRET environment variable is required (service-to-service auth for protected gateway routes)'
     );
   }
 }

--- a/services/bot-client/src/index.ts
+++ b/services/bot-client/src/index.ts
@@ -70,7 +70,12 @@ import {
   startVerificationCleanupScheduler,
   stopVerificationCleanupScheduler,
 } from './services/VerificationCleanupScheduler.js';
-import { validateDiscordToken, validateRedisUrl, logGatewayHealthStatus } from './startup.js';
+import {
+  validateDiscordToken,
+  validateRedisUrl,
+  validateInternalServiceSecret,
+  logGatewayHealthStatus,
+} from './startup.js';
 import { restoreBotPresence } from './commands/admin/presence.js';
 import {
   createDeferredContext,
@@ -84,6 +89,7 @@ const envConfig = getConfig();
 
 // Validate bot-client specific required env vars
 validateDiscordToken();
+validateInternalServiceSecret();
 
 // Configuration from environment
 const config = {

--- a/services/bot-client/src/startup.test.ts
+++ b/services/bot-client/src/startup.test.ts
@@ -25,7 +25,12 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
-import { validateDiscordToken, validateRedisUrl, logGatewayHealthStatus } from './startup.js';
+import {
+  validateDiscordToken,
+  validateRedisUrl,
+  validateInternalServiceSecret,
+  logGatewayHealthStatus,
+} from './startup.js';
 
 describe('Startup Utilities', () => {
   beforeEach(() => {
@@ -87,6 +92,41 @@ describe('Startup Utilities', () => {
       expect(() =>
         validateRedisUrl(config as ReturnType<typeof import('@tzurot/common-types').getConfig>)
       ).toThrow('REDIS_URL environment variable is required');
+    });
+  });
+
+  describe('validateInternalServiceSecret', () => {
+    it('should not throw when INTERNAL_SERVICE_SECRET is set', () => {
+      const config = {
+        INTERNAL_SERVICE_SECRET: 'test-secret',
+      };
+      expect(() =>
+        validateInternalServiceSecret(
+          config as ReturnType<typeof import('@tzurot/common-types').getConfig>
+        )
+      ).not.toThrow();
+    });
+
+    it('should throw when INTERNAL_SERVICE_SECRET is undefined', () => {
+      const config = {
+        INTERNAL_SERVICE_SECRET: undefined,
+      };
+      expect(() =>
+        validateInternalServiceSecret(
+          config as ReturnType<typeof import('@tzurot/common-types').getConfig>
+        )
+      ).toThrow('INTERNAL_SERVICE_SECRET environment variable is required');
+    });
+
+    it('should throw when INTERNAL_SERVICE_SECRET is empty', () => {
+      const config = {
+        INTERNAL_SERVICE_SECRET: '',
+      };
+      expect(() =>
+        validateInternalServiceSecret(
+          config as ReturnType<typeof import('@tzurot/common-types').getConfig>
+        )
+      ).toThrow('INTERNAL_SERVICE_SECRET environment variable is required');
     });
   });
 

--- a/services/bot-client/src/startup.ts
+++ b/services/bot-client/src/startup.ts
@@ -30,6 +30,22 @@ export function validateRedisUrl(config = getConfig()): void {
 }
 
 /**
+ * Validate internal service secret is configured. Throws at startup so a
+ * misconfigured deploy fails to boot rather than silently sending empty
+ * `X-Service-Auth` headers and watching every gateway call return 403.
+ * Symmetric with the api-gateway and ai-worker startup checks.
+ *
+ * @throws Error if INTERNAL_SERVICE_SECRET is missing or empty
+ */
+export function validateInternalServiceSecret(config = getConfig()): void {
+  if (config.INTERNAL_SERVICE_SECRET === undefined || config.INTERNAL_SERVICE_SECRET.length === 0) {
+    throw new Error(
+      'INTERNAL_SERVICE_SECRET environment variable is required (service-to-service auth for protected gateway routes)'
+    );
+  }
+}
+
+/**
  * Log gateway health check result
  * @param isHealthy Whether the gateway health check passed
  */


### PR DESCRIPTION
## Summary

Resolves a loose end from PR #1068. After that PR added `INTERNAL_SERVICE_SECRET` validation to ai-worker's startup (`validateRequiredEnvVars`), the three services' behavior on missing/empty secret was asymmetric:

| Service | Pre-PR behavior on missing `INTERNAL_SERVICE_SECRET` |
|---------|-----------------------------------------------------|
| api-gateway | `validateServiceAuthConfig` logs a warning, starts up, then `requireServiceAuth()` middleware 403s every protected-route request |
| bot-client | No startup check at all. Sends `X-Service-Auth: ''` on every gateway call (`?? ''` fallbacks in `GatewayClient.ts`); every call returns 403 with no clear attribution at the call site |
| ai-worker (post-#1068) | `validateRequiredEnvVars` throws; service refuses to boot |

A round-7 reviewer observation on #1068 flagged this ("not symmetric yet… could consolidate into a shared `common-types` startup-validation utility"). The user surfaced it as a loose end worth tying.

## Approach

**Make all three services fail-fast at startup.** No shared abstraction — each service has its own startup pattern (`validateRequiredEnvVars` in ai-worker, named `validateXxx` functions in bot-client + api-gateway), and the duplication is two short functions. Extracting a shared helper would be premature abstraction for two consumers; symmetric inline checks are clearer.

## What changed

| File | Change |
|------|--------|
| `services/api-gateway/src/bootstrap/startup.ts` | `validateServiceAuthConfig` warn → throw; docstring updated to point at the symmetric ai-worker check |
| `services/api-gateway/src/bootstrap/startup.test.ts` | Replace the "should not throw when missing (just logs warning)" test with two new tests (undefined + empty string → throw) |
| `services/bot-client/src/startup.ts` | Add `validateInternalServiceSecret` matching the existing `validateDiscordToken` / `validateRedisUrl` pattern |
| `services/bot-client/src/startup.test.ts` | 3 new tests covering set / undefined / empty |
| `services/bot-client/src/index.ts` | Call `validateInternalServiceSecret()` next to `validateDiscordToken()` at module load |

## Behavior change

With this PR, **all three services refuse to boot if `INTERNAL_SERVICE_SECRET` is missing/empty**. This is the right posture:

- The secret is set on dev + prod Railway services for all three (user confirmed 2026-05-20)
- Local-dev workflow already requires it for any meaningful bot operation (gateway-call cascade)
- Hard startup failure surfaces misconfig immediately; the previous warn-only path produced a cascade of 403s with no central attribution

## Test plan

- [x] `services/api-gateway/src/bootstrap/startup.test.ts`: 16 tests pass (3 new for `validateServiceAuthConfig`)
- [x] `services/bot-client/src/startup.test.ts`: 13 tests pass (3 new for `validateInternalServiceSecret`)
- [x] Full `pnpm test`: all packages green
- [x] `pnpm quality`: 11/11 tasks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)