### PR TITLE
fix(bot-client): close 3 multi-tag delivery gaps from PR #1062/#1063/#1066 review

### DIFF
--- a/packages/common-types/src/constants/queue.ts
+++ b/packages/common-types/src/constants/queue.ts
@@ -87,6 +87,8 @@ export const REDIS_KEY_PREFIXES = {
   MULTI_TAG_STALE_JOBS: 'multitag:stale-jobids',
   /** Prefix for the DM "we already attempted history-scan backfill" sentinel */
   MULTI_TAG_DM_BACKFILL_TRIED: 'multitag:dm-backfill-tried:',
+  /** Prefix for per-slot "already delivered" dedup marker (recovery skips dispatch when present) */
+  MULTI_TAG_SLOT_DELIVERED: 'multitag:slot-delivered:',
 } as const;
 
 /**

--- a/services/bot-client/src/services/MultiTagPersistence.test.ts
+++ b/services/bot-client/src/services/MultiTagPersistence.test.ts
@@ -332,4 +332,46 @@ describe('MultiTagPersistence', () => {
       expect(await persistence.wasDMBackfillTried('dm-channel-1')).toBe(false);
     });
   });
+
+  describe('slot-delivered marker (recovery idempotency)', () => {
+    it('markSlotDelivered writes a TTL marker keyed by jobId', async () => {
+      await persistence.markSlotDelivered('job-abc');
+      expect(mockRedis.set).toHaveBeenCalledWith(
+        `${REDIS_KEY_PREFIXES.MULTI_TAG_SLOT_DELIVERED}job-abc`,
+        '1',
+        'EX',
+        expect.any(Number)
+      );
+      const setCall = mockRedis.set.mock.calls[0];
+      expect(setCall[3]).toBeGreaterThan(0);
+    });
+
+    it('markSlotDelivered soft-fails on Redis error', async () => {
+      // A failed marker write means a subsequent recovery may re-dispatch
+      // and produce a duplicate message — exactly the failure mode the
+      // marker is designed to prevent. We log it but don't throw, because
+      // throwing would propagate up and break the delivery flow's per-slot
+      // try/catch contract.
+      mockRedis.set.mockRejectedValue(new Error('Redis down'));
+      await expect(persistence.markSlotDelivered('job-abc')).resolves.toBeUndefined();
+    });
+
+    it('isSlotDelivered returns true when the marker exists', async () => {
+      mockRedis.get.mockResolvedValue('1');
+      expect(await persistence.isSlotDelivered('job-abc')).toBe(true);
+    });
+
+    it('isSlotDelivered returns false when the marker is missing', async () => {
+      mockRedis.get.mockResolvedValue(null);
+      expect(await persistence.isSlotDelivered('job-abc')).toBe(false);
+    });
+
+    it('isSlotDelivered fails closed (returns false) on Redis error', async () => {
+      // Fail-closed is the safer side here: a false negative produces at-worst
+      // a duplicate message; a false positive permanently drops the user's
+      // message. Duplicate is the better failure mode.
+      mockRedis.get.mockRejectedValue(new Error('Redis down'));
+      expect(await persistence.isSlotDelivered('job-abc')).toBe(false);
+    });
+  });
 });

--- a/services/bot-client/src/services/MultiTagPersistence.ts
+++ b/services/bot-client/src/services/MultiTagPersistence.ts
@@ -45,6 +45,14 @@ const STALE_SET_TTL_SEC = 24 * 60 * 60;
 const DM_BACKFILL_TRIED_TTL_SEC = 60 * 60;
 
 /**
+ * TTL for the per-slot "already delivered" marker. Bound to
+ * `STALE_SET_TTL_SEC` because both guard the same invariant: "recovery
+ * sees stale state and decides to act." Sharing the constant keeps the
+ * two markers aligned through any future tuning of the stale-window.
+ */
+const SLOT_DELIVERED_TTL_SEC = STALE_SET_TTL_SEC;
+
+/**
  * SCAN COUNT hint for `scanAllEntries`. Not a hard cap — Redis treats this
  * as a per-call guideline. 100 matches the Redis convention for "moderate
  * batch" scans; small enough to avoid blocking, large enough that recovery
@@ -323,6 +331,54 @@ export class MultiTagPersistence {
         { err, channelId },
         'clearDMBackfillTried Redis call failed — sentinel will expire via TTL'
       );
+    }
+  }
+
+  /**
+   * Mark a slot's jobId as delivered. Written by `deliverSlot` after a
+   * successful Discord send so a subsequent recovery run knows not to
+   * re-dispatch the same result. Closes the narrow crash window between
+   * Discord send and `deleteEntry` in `deliverGroup` where the entry
+   * snapshot still shows the flush-trigger slot as pending — without
+   * this marker, recovery polls BullMQ, finds the job completed, and
+   * re-dispatches → duplicate user-visible delivery.
+   *
+   * Soft-fails on Redis errors: a marker that didn't get written results
+   * in at-worst one duplicate message on a crash-during-flush, which is
+   * the same failure mode the marker is designed to prevent. Logging the
+   * miss is the only meaningful action.
+   */
+  async markSlotDelivered(jobId: string): Promise<void> {
+    const key = `${REDIS_KEY_PREFIXES.MULTI_TAG_SLOT_DELIVERED}${jobId}`;
+    try {
+      await this.redis.set(key, '1', 'EX', SLOT_DELIVERED_TTL_SEC);
+    } catch (err) {
+      logger.warn(
+        { err, jobId },
+        'markSlotDelivered Redis call failed — recovery may re-dispatch this slot if a crash follows before deleteEntry runs'
+      );
+    }
+  }
+
+  /**
+   * Returns true if a previous run already delivered this slot to Discord.
+   * Used by `MultiTagRecovery` to skip re-dispatching deferred deliveries
+   * for slots already sent. Fails closed (returns false) on Redis errors
+   * because re-dispatching is safer than silently dropping: the failure
+   * mode of a false negative is duplicate message; of a false positive,
+   * permanently missing message. Duplicate is the better mode.
+   */
+  async isSlotDelivered(jobId: string): Promise<boolean> {
+    const key = `${REDIS_KEY_PREFIXES.MULTI_TAG_SLOT_DELIVERED}${jobId}`;
+    try {
+      const v = await this.redis.get(key);
+      return v !== null;
+    } catch (err) {
+      logger.warn(
+        { err, jobId },
+        'isSlotDelivered Redis check failed; failing closed (will re-dispatch — accepts duplicate over missing)'
+      );
+      return false;
     }
   }
 }

--- a/services/bot-client/src/services/MultiTagRecovery.test.ts
+++ b/services/bot-client/src/services/MultiTagRecovery.test.ts
@@ -91,6 +91,7 @@ describe('MultiTagRecovery', () => {
     markStale: ReturnType<typeof vi.fn>;
     deleteEntry: ReturnType<typeof vi.fn>;
     updateEntry: ReturnType<typeof vi.fn>;
+    isSlotDelivered: ReturnType<typeof vi.fn>;
   };
   let coordinator: {
     adoptRehydratedEntry: ReturnType<typeof vi.fn>;
@@ -124,6 +125,7 @@ describe('MultiTagRecovery', () => {
       markStale: vi.fn().mockResolvedValue(undefined),
       deleteEntry: vi.fn().mockResolvedValue(undefined),
       updateEntry: vi.fn().mockResolvedValue(undefined),
+      isSlotDelivered: vi.fn().mockResolvedValue(false),
     };
     coordinator = {
       adoptRehydratedEntry: vi.fn().mockResolvedValue(undefined),
@@ -476,6 +478,141 @@ describe('MultiTagRecovery', () => {
       expect(coordinator.handleJobResult).toHaveBeenCalledTimes(2);
       expect(coordinator.handleJobResult).toHaveBeenNthCalledWith(1, 'old-job-Alice', aliceResult);
       expect(coordinator.handleJobResult).toHaveBeenNthCalledWith(2, 'old-job-Bob', bobResult);
+    });
+  });
+
+  describe('idempotent re-dispatch (slot-delivered marker)', () => {
+    it('skips dispatch when a prior run already delivered the slot', async () => {
+      // Scenario: previous bot lifecycle delivered the message to Discord
+      // but crashed before deliverGroup's deleteEntry call ran. The entry
+      // snapshot still shows the flush-trigger slot as pending, BullMQ
+      // shows the job as completed. Without the marker check, recovery
+      // would re-dispatch → second user-visible delivery.
+      const aliceResult: LLMGenerationResult = {
+        requestId: 'old-job-Alice',
+        success: true,
+        content: 'alice content (already delivered)',
+      };
+      queue.getJob.mockImplementation(async (jobId: string) => {
+        if (jobId === 'old-job-Alice') {
+          return buildMockJob({ state: 'completed', returnvalue: aliceResult });
+        }
+        return null;
+      });
+      persistence.isSlotDelivered.mockImplementation(
+        async (jobId: string) => jobId === 'old-job-Alice'
+      );
+      const snapshot = buildSnapshot({
+        slots: [
+          {
+            slotIndex: 0,
+            personalityId: 'id-alice',
+            personalitySlug: 'alice',
+            source: 'mention',
+            isAutoResponse: false,
+            jobId: 'old-job-Alice',
+            status: 'pending',
+          },
+        ],
+      });
+      persistence.scanAllEntries.mockResolvedValue([snapshot]);
+
+      const stats = await recovery.run();
+
+      expect(persistence.isSlotDelivered).toHaveBeenCalledWith('old-job-Alice');
+      expect(coordinator.handleJobResult).not.toHaveBeenCalled();
+      expect(stats.slotsAlreadyDelivered).toBe(1);
+    });
+
+    it('dispatches normally when the marker is absent', async () => {
+      const aliceResult: LLMGenerationResult = {
+        requestId: 'old-job-Alice',
+        success: true,
+        content: 'alice content',
+      };
+      queue.getJob.mockImplementation(async (jobId: string) => {
+        if (jobId === 'old-job-Alice') {
+          return buildMockJob({ state: 'completed', returnvalue: aliceResult });
+        }
+        return null;
+      });
+      // Default isSlotDelivered returns false — exercised here explicitly.
+      persistence.isSlotDelivered.mockResolvedValue(false);
+      const snapshot = buildSnapshot({
+        slots: [
+          {
+            slotIndex: 0,
+            personalityId: 'id-alice',
+            personalitySlug: 'alice',
+            source: 'mention',
+            isAutoResponse: false,
+            jobId: 'old-job-Alice',
+            status: 'pending',
+          },
+        ],
+      });
+      persistence.scanAllEntries.mockResolvedValue([snapshot]);
+
+      const stats = await recovery.run();
+
+      expect(coordinator.handleJobResult).toHaveBeenCalledWith('old-job-Alice', aliceResult);
+      expect(stats.slotsAlreadyDelivered).toBe(0);
+    });
+
+    it('skips per-slot based on marker presence in mixed entries', async () => {
+      // Slot A: previously delivered (marker present). Slot B: not delivered.
+      // Only Slot B's dispatch should fire.
+      const aliceResult: LLMGenerationResult = {
+        requestId: 'old-job-Alice',
+        success: true,
+        content: 'alice (delivered)',
+      };
+      const bobResult: LLMGenerationResult = {
+        requestId: 'old-job-Bob',
+        success: true,
+        content: 'bob (not delivered)',
+      };
+      queue.getJob.mockImplementation(async (jobId: string) => {
+        if (jobId === 'old-job-Alice') {
+          return buildMockJob({ state: 'completed', returnvalue: aliceResult });
+        }
+        if (jobId === 'old-job-Bob') {
+          return buildMockJob({ state: 'completed', returnvalue: bobResult });
+        }
+        return null;
+      });
+      persistence.isSlotDelivered.mockImplementation(
+        async (jobId: string) => jobId === 'old-job-Alice'
+      );
+      const snapshot = buildSnapshot({
+        slots: [
+          {
+            slotIndex: 0,
+            personalityId: 'id-alice',
+            personalitySlug: 'alice',
+            source: 'mention',
+            isAutoResponse: false,
+            jobId: 'old-job-Alice',
+            status: 'pending',
+          },
+          {
+            slotIndex: 1,
+            personalityId: 'id-bob',
+            personalitySlug: 'bob',
+            source: 'mention',
+            isAutoResponse: false,
+            jobId: 'old-job-Bob',
+            status: 'pending',
+          },
+        ],
+      });
+      persistence.scanAllEntries.mockResolvedValue([snapshot]);
+
+      const stats = await recovery.run();
+
+      expect(coordinator.handleJobResult).toHaveBeenCalledOnce();
+      expect(coordinator.handleJobResult).toHaveBeenCalledWith('old-job-Bob', bobResult);
+      expect(stats.slotsAlreadyDelivered).toBe(1);
     });
   });
 

--- a/services/bot-client/src/services/MultiTagRecovery.ts
+++ b/services/bot-client/src/services/MultiTagRecovery.ts
@@ -116,6 +116,13 @@ export interface RecoveryStats {
   slotsUnrecoverable: number;
   slotsAccessRevoked: number;
   staleJobIdsMarked: number;
+  /**
+   * Slots that a prior recovery run already delivered (per the
+   * `slot-delivered:{jobId}` marker written by `deliverSlot`). Skipped to
+   * avoid duplicate user-visible delivery on a re-run after a crash
+   * during `deliverGroup`'s post-Discord-send cleanup.
+   */
+  slotsAlreadyDelivered: number;
 }
 
 interface DeferredDelivery {
@@ -146,6 +153,7 @@ export class MultiTagRecovery {
       slotsUnrecoverable: 0,
       slotsAccessRevoked: 0,
       staleJobIdsMarked: 0,
+      slotsAlreadyDelivered: 0,
     };
 
     let snapshots: CoordinatorEntrySnapshot[];
@@ -299,19 +307,14 @@ export class MultiTagRecovery {
       // updateEntry persistence write inside handleJobResult itself. No
       // explicit updateEntry needed at this layer.
       //
-      // **Non-idempotency window**: if the process crashes between two
-      // successive `handleJobResult` calls in this loop, the next recovery
-      // run can re-dispatch the same already-delivered result. Whether
-      // the user sees a duplicate Discord message depends on
-      // `handleJobResult`'s persistence timing — if updateEntry runs
-      // before the user-visible send (current behavior in non-flush
-      // cases), the re-dispatch sees terminal status and skips; the
-      // all-terminal flush path deletes the entry, so a crash there
-      // means recovery is already done. The behavior is "potentially
-      // duplicate message" rather than "no message" — the better
-      // failure mode — and the exposure window is tiny (only between
-      // two awaits within recovery itself). Idempotent re-dispatch is
-      // tracked as a follow-up; see backlog/deferred.md.
+      // **Idempotency**: `multiTagDeliveryFlow.deliverSlot` writes a per-slot
+      // `slot-delivered:{jobId}` marker after every successful Discord send.
+      // Checking it here closes the narrow crash window where a prior recovery
+      // run delivered the slot but crashed before `deleteEntry` ran (the
+      // entry-snapshot still shows the flush-trigger slot as pending, the
+      // BullMQ job is completed, and without the marker this loop would
+      // re-dispatch → duplicate user-visible message). Two awaits across the
+      // bus rather than one, paid only on the recovery path which is rare.
       //
       // Per-delivery try/catch: a throw from one `handleJobResult` must
       // not block subsequent deliveries in the same entry. The narrow
@@ -321,6 +324,14 @@ export class MultiTagRecovery {
       // resilience matches the per-slot catch in `multiTagDeliveryFlow.deliverSlot`.
       for (const delivery of deferredDeliveries) {
         try {
+          if (await this.deps.persistence.isSlotDelivered(delivery.jobId)) {
+            logger.info(
+              { groupId: snapshot.groupId, jobId: delivery.jobId, kind: delivery.kind },
+              'Recovery: slot already delivered by a prior run — skipping dispatch'
+            );
+            stats.slotsAlreadyDelivered++;
+            continue;
+          }
           await this.deps.coordinator.handleJobResult(delivery.jobId, delivery.result);
         } catch (err) {
           logger.error(

--- a/services/bot-client/src/services/multiTagDeliveryFlow.test.ts
+++ b/services/bot-client/src/services/multiTagDeliveryFlow.test.ts
@@ -82,6 +82,7 @@ describe('deliverGroup', () => {
   let persistence: {
     deleteEntry: ReturnType<typeof vi.fn>;
     clearDMBackfillTried: ReturnType<typeof vi.fn>;
+    markSlotDelivered: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {
@@ -96,6 +97,7 @@ describe('deliverGroup', () => {
     persistence = {
       deleteEntry: vi.fn().mockResolvedValue(undefined),
       clearDMBackfillTried: vi.fn().mockResolvedValue(undefined),
+      markSlotDelivered: vi.fn().mockResolvedValue(undefined),
     };
     deps = {
       slotDelivery: slotDelivery as unknown as DeliveryFlowDeps['slotDelivery'],
@@ -207,6 +209,132 @@ describe('deliverGroup', () => {
     // No personalityErrorMessage configured → falls through to the
     // UNKNOWN category's user message, NOT the generic bot fallback.
     expect(rendered).not.toContain('Sorry, I encountered an error');
+  });
+
+  it('overlays personalityErrorMessage when synthesized failure result lacks it', async () => {
+    // Path: JobFailureListener or MultiTagRecovery synthesized a failure result
+    // and routed it via coordinator.handleJobResult. The synthetic result has
+    // `success: false` but no `personalityErrorMessage`. Without the overlay,
+    // `??` would short-circuit and the user sees DEFAULT_ERROR instead of the
+    // personality's voice.
+    const entry = buildEntry({
+      slots: [
+        buildSlot('Alice', {
+          status: 'errored',
+          result: {
+            requestId: 'r1',
+            success: false,
+            error: 'Upstream gateway failure',
+          } as LLMGenerationResult,
+          personalityErrorMessage: 'Static crackles. Did something break?',
+        }),
+      ],
+    });
+
+    await deliverGroup(entry, deps);
+
+    const [rendered, synthetic] = slotDelivery.deliverError.mock.calls[0];
+    expect(synthetic.personalityErrorMessage).toBe('Static crackles. Did something break?');
+    expect(rendered).toContain('Static crackles');
+    expect(rendered).not.toContain('Sorry, I encountered an error');
+  });
+
+  it('overlays personalityErrorMessage on completed-but-empty success result', async () => {
+    // Path: ai-worker emits success:true with empty content (rare upstream
+    // edge — rate-limit soft-fail). hasUsableContent returns false; we route
+    // through the error path. The original result has no personalityErrorMessage,
+    // so without the overlay the user sees DEFAULT_ERROR.
+    const entry = buildEntry({
+      slots: [
+        buildSlot('Alice', {
+          status: 'completed',
+          result: {
+            requestId: 'r1',
+            success: true,
+            content: '',
+          } as LLMGenerationResult,
+          personalityErrorMessage: 'Words escape me, just for a moment.',
+        }),
+      ],
+    });
+
+    await deliverGroup(entry, deps);
+
+    const [rendered, synthetic] = slotDelivery.deliverError.mock.calls[0];
+    expect(synthetic.personalityErrorMessage).toBe('Words escape me, just for a moment.');
+    expect(rendered).toContain('Words escape me');
+    expect(rendered).not.toContain('Sorry, I encountered an error');
+  });
+
+  it('preserves an already-set personalityErrorMessage on the result without overwriting', async () => {
+    // Sanity: if the upstream already enriched the result, don't replace it
+    // with `slot.personality.errorMessage` (which may differ if the persona
+    // was edited mid-flight).
+    const entry = buildEntry({
+      slots: [
+        buildSlot('Alice', {
+          status: 'errored',
+          result: {
+            requestId: 'r1',
+            success: false,
+            error: 'Upstream',
+            personalityErrorMessage: 'Original enriched message',
+          } as LLMGenerationResult,
+          personalityErrorMessage: 'Slot-personality message (should NOT win)',
+        }),
+      ],
+    });
+
+    await deliverGroup(entry, deps);
+
+    const [, synthetic] = slotDelivery.deliverError.mock.calls[0];
+    expect(synthetic.personalityErrorMessage).toBe('Original enriched message');
+  });
+
+  it('writes slot-delivered marker after each successful slot send', async () => {
+    const entry = buildEntry({
+      slots: [
+        buildSlot('Alice', { slotIndex: 0, jobId: 'job-Alice' }),
+        buildSlot('Bob', { slotIndex: 1, jobId: 'job-Bob' }),
+      ],
+    });
+
+    await deliverGroup(entry, deps);
+
+    expect(persistence.markSlotDelivered).toHaveBeenCalledWith('job-Alice');
+    expect(persistence.markSlotDelivered).toHaveBeenCalledWith('job-Bob');
+    expect(persistence.markSlotDelivered).toHaveBeenCalledTimes(2);
+  });
+
+  it('writes slot-delivered marker after error-path delivery too', async () => {
+    // `timedout` status → hasUsableContent returns false → routes through
+    // deliverError. The marker is still written because the user-visible
+    // Discord message DID land (an in-character error message); a recovery
+    // re-dispatch would still be a duplicate.
+    const entry = buildEntry({
+      slots: [buildSlot('Alice', { status: 'timedout', result: undefined, jobId: 'job-Alice' })],
+    });
+
+    await deliverGroup(entry, deps);
+
+    expect(slotDelivery.deliverError).toHaveBeenCalledOnce();
+    expect(persistence.markSlotDelivered).toHaveBeenCalledWith('job-Alice');
+  });
+
+  it('does NOT write slot-delivered marker when delivery throws', async () => {
+    slotDelivery.deliverSuccess.mockRejectedValueOnce(new Error('Discord 500'));
+    const entry = buildEntry({
+      slots: [
+        buildSlot('Alice', { slotIndex: 0, jobId: 'job-Alice' }),
+        buildSlot('Bob', { slotIndex: 1, jobId: 'job-Bob' }),
+      ],
+    });
+
+    await deliverGroup(entry, deps);
+
+    // Alice's send threw — no marker. Bob's send succeeded — marker.
+    expect(persistence.markSlotDelivered).not.toHaveBeenCalledWith('job-Alice');
+    expect(persistence.markSlotDelivered).toHaveBeenCalledWith('job-Bob');
   });
 
   it('continues delivering remaining slots when one slot throws', async () => {

--- a/services/bot-client/src/services/multiTagDeliveryFlow.ts
+++ b/services/bot-client/src/services/multiTagDeliveryFlow.ts
@@ -87,6 +87,7 @@ async function deliverSlot(
         slot.result as LLMGenerationResult & { success: true },
         slotContext
       );
+      await deps.persistence.markSlotDelivered(slot.jobId);
       return;
     }
     if (slot.status === 'completed' && slot.result !== undefined) {
@@ -118,7 +119,15 @@ async function deliverSlot(
     const isTimeout = slot.status === 'timedout';
     const category = isTimeout ? ApiErrorCategory.TIMEOUT : ApiErrorCategory.UNKNOWN;
     const technicalMessage = isTimeout ? 'Response timed out' : 'No response received';
-    const synthetic: LLMGenerationResult = slot.result ?? {
+    // When `slot.result` is defined but lacks `personalityErrorMessage`, the
+    // unguarded `??` would short-circuit and `buildErrorContent` would render
+    // the generic DEFAULT_ERROR instead of the persona-voice fallback. This
+    // applies to two paths: (a) `JobFailureListener` / `MultiTagRecovery`
+    // synthesize a failure result without enriching it; (b) ai-worker rarely
+    // emits an empty-content success result that fails `hasUsableContent`
+    // but lacks the error metadata. Overlay the personality's `errorMessage`
+    // before passing through so the user sees the character's voice.
+    const baseSynthetic: LLMGenerationResult = slot.result ?? {
       requestId: entry.groupId,
       success: false,
       error: technicalMessage,
@@ -135,7 +144,13 @@ async function deliverSlot(
         shouldRetry: false,
       },
     };
+    const synthetic: LLMGenerationResult =
+      baseSynthetic.personalityErrorMessage === undefined &&
+      slot.personality.errorMessage !== undefined
+        ? { ...baseSynthetic, personalityErrorMessage: slot.personality.errorMessage }
+        : baseSynthetic;
     await deps.slotDelivery.deliverError(buildErrorContent(synthetic), synthetic, slotContext);
+    await deps.persistence.markSlotDelivered(slot.jobId);
   } catch (err) {
     logger.error(
       {


### PR DESCRIPTION
## Summary

Bundles three small, related fixes in multi-tag fan-out delivery that were deferred from review feedback on the MultiTagRecovery hardening chain. All three live in the same code area (`multiTagDeliveryFlow.deliverSlot`); two of them collapse to the same one-line overlay.

## Fixes

### 1. Persona-voice on synthesized failure results (from PR #1066 round 1)

`JobFailureListener` (live-failure path) and `MultiTagRecovery` (rehydration path) synthesize failure `LLMGenerationResult`s without `personalityErrorMessage`. `deliverSlot`'s `slot.result ?? syntheticWithEnrichment` short-circuits because `slot.result` is defined, so the user sees the generic `DEFAULT_ERROR` ("Sorry, I encountered an error...") instead of the persona's configured error voice.

**Fix**: overlay `slot.personality.errorMessage` onto the result before passing to `buildErrorContent` when the result lacks the field.

### 2. Persona-voice on completed-but-empty results (from PR #1062 round 3)

Same shape as #1, different trigger: ai-worker can rarely emit `success: true` with empty content (rate-limit soft-fail, etc.). `hasUsableContent` returns false → routes through error path → same `??` short-circuit → user sees generic error.

**Fix**: same overlay as #1 covers this case too.

### 3. Idempotent re-dispatch in MultiTagRecovery (from PR #1063 round 6)

The flush path in `MultiTagCoordinator.handleJobResult` intentionally skips the final `updateEntry` (one Redis roundtrip instead of two — the entry's about to be deleted anyway). If we crash AFTER `deliverGroup` sends to Discord but BEFORE `deleteEntry` runs:
- Entry snapshot still shows the flush-trigger slot as **pending**
- BullMQ shows the job as completed
- Next recovery polls → re-dispatches → second `handleJobResult` → second flush → **duplicate Discord delivery**

The backlog entry's suggested fix shape (per-slot persistence check in snapshot) doesn't catch this — the snapshot's slot status IS pending, that's the stale data we'd be acting on.

**Fix**: write a per-slot `slot-delivered:{jobId}` marker in Redis after every successful `deliverSlot` call. Recovery checks the marker before dispatching each deferred delivery and skips if present.

## Why this design

**Per-slot dedup key** (not per-group, not snapshot-embedded):
- Per-slot because `deliverSlot` is the atomic Discord-send unit — granularity matches the failure boundary
- Separate Redis key (not snapshot-embedded) so no schema migration; older snapshots still work
- TTL 24h matches `STALE_SET_TTL_SEC` (comfortably exceeds the entry TTL so a recovery picking up an aged entry still sees the marker)
- Adds one Redis `SET` per slot delivery (paid in the happy path); the corresponding `GET` per slot is paid in recovery only (rare)

**Failure modes**:
- `markSlotDelivered` soft-fails on Redis error (logged, but the delivery already happened — at worst the next recovery may re-dispatch, which is the failure this marker would have prevented). Throwing would propagate up and break `deliverSlot`'s per-slot try/catch contract.
- `isSlotDelivered` fails closed (returns `false`) on Redis error — duplicate message is the better failure mode than permanently dropping a message.

## What changed

| File | Change |
|------|--------|
| `packages/common-types/src/constants/queue.ts` | Add `MULTI_TAG_SLOT_DELIVERED` Redis key prefix |
| `services/bot-client/src/services/MultiTagPersistence.ts` | Add `markSlotDelivered` + `isSlotDelivered` methods with 24h TTL |
| `services/bot-client/src/services/multiTagDeliveryFlow.ts` | Personality-error-message overlay; call `markSlotDelivered` after `deliverSuccess` / `deliverError` |
| `services/bot-client/src/services/MultiTagRecovery.ts` | Check `isSlotDelivered` before each deferred-delivery dispatch; new `slotsAlreadyDelivered` stat |
| `*.test.ts` for all three modules | 14 new tests covering the new shapes |

## Test plan

- [x] `MultiTagPersistence.test.ts`: 5 new tests (markSlotDelivered happy + soft-fail; isSlotDelivered true/false/fail-closed)
- [x] `multiTagDeliveryFlow.test.ts`: 6 new tests (overlay on synthesized failure; overlay on empty-content; preserve already-set; markSlotDelivered on success; markSlotDelivered on error; no marker when delivery throws)
- [x] `MultiTagRecovery.test.ts`: 3 new tests (skip dispatch on marker present; dispatch when marker absent; per-slot skip in mixed entries)
- [x] Full `pnpm test`: 14 packages green
- [x] `pnpm quality`: 11/11 tasks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)