### PR TITLE
fix(bot-client): bound adminFetch with a 10s timeout

### DIFF
--- a/packages/common-types/src/constants/timing.ts
+++ b/packages/common-types/src/constants/timing.ts
@@ -44,6 +44,12 @@ export const TIMEOUTS = {
   STT_GATEWAY: 240_000,
   /** BullMQ worker lock duration - maximum time a job can run before being considered stalled (20 minutes - safety net for hung jobs) */
   WORKER_LOCK_DURATION: 20 * 60 * 1000,
+  /** Client-side timeout for admin slash command → api-gateway requests (10 s).
+   * Well inside Discord's 15-minute interaction expiry — covers a healthy
+   * gateway response plus generous headroom, but short enough that a hung
+   * gateway surfaces as "Gateway unreachable" rather than letting the slash
+   * command sit in "Thinking…" until Discord's deferReply window expires. */
+  ADMIN_GATEWAY: 10_000,
 } as const;
 
 /**

--- a/services/bot-client/src/utils/adminApiClient.test.ts
+++ b/services/bot-client/src/utils/adminApiClient.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    getConfig: vi.fn(() => ({
+      GATEWAY_URL: 'http://gateway.test',
+      INTERNAL_SERVICE_SECRET: 'test-secret',
+    })),
+  };
+});
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+import { adminFetch, adminPostJson, adminPutJson, adminPatchJson } from './adminApiClient.js';
+import { TIMEOUTS } from '@tzurot/common-types';
+
+describe('adminApiClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve({}) });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('signal / timeout wiring', () => {
+    it('attaches an AbortSignal that fires by ADMIN_GATEWAY timeout', async () => {
+      // Sanity: the test infrastructure can construct a timeout-style signal
+      // and the helper forwards one to fetch. The actual timer firing is
+      // covered by AbortSignal.timeout's contract; we verify the wiring.
+      await adminFetch('/admin/metrics');
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [, init] = mockFetch.mock.calls[0];
+      expect(init.signal).toBeInstanceOf(AbortSignal);
+      // Pin the contract: 10s is well inside Discord's 15-min interaction
+      // expiry but short enough to surface real gateway hangs.
+      expect(TIMEOUTS.ADMIN_GATEWAY).toBe(10_000);
+    });
+
+    it('respects a caller-supplied signal alongside the default timeout', async () => {
+      // AbortSignal.any composes signals — abort fires if EITHER the caller's
+      // signal or the timeout aborts. We verify the resulting signal can be
+      // aborted via the caller's controller (proving the caller's signal is
+      // wired into the merged signal, not silently dropped).
+      const controller = new AbortController();
+      await adminFetch('/admin/metrics', { signal: controller.signal });
+
+      const [, init] = mockFetch.mock.calls[0];
+      const mergedSignal = init.signal as AbortSignal;
+      expect(mergedSignal.aborted).toBe(false);
+      controller.abort();
+      expect(mergedSignal.aborted).toBe(true);
+    });
+  });
+
+  describe('headers', () => {
+    it('sends X-Service-Auth on every request', async () => {
+      await adminFetch('/admin/metrics');
+      const [, init] = mockFetch.mock.calls[0];
+      expect(init.headers['X-Service-Auth']).toBe('test-secret');
+    });
+
+    it('adds X-User-Id when userId is provided', async () => {
+      await adminFetch('/admin/settings', { userId: 'discord-user-123' });
+      const [, init] = mockFetch.mock.calls[0];
+      expect(init.headers['X-User-Id']).toBe('discord-user-123');
+    });
+
+    it('omits X-User-Id when userId is absent', async () => {
+      await adminFetch('/admin/metrics');
+      const [, init] = mockFetch.mock.calls[0];
+      expect(init.headers['X-User-Id']).toBeUndefined();
+    });
+
+    it('merges custom headers without losing X-Service-Auth', async () => {
+      await adminFetch('/admin/db-sync', { headers: { 'X-Custom': 'value' } });
+      const [, init] = mockFetch.mock.calls[0];
+      expect(init.headers['X-Service-Auth']).toBe('test-secret');
+      expect(init.headers['X-Custom']).toBe('value');
+    });
+  });
+
+  describe('adminPostJson', () => {
+    it('serializes body as JSON with the correct content-type', async () => {
+      await adminPostJson('/admin/db-sync', { dryRun: true });
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe('http://gateway.test/admin/db-sync');
+      expect(init.method).toBe('POST');
+      expect(init.body).toBe(JSON.stringify({ dryRun: true }));
+      expect(init.headers['Content-Type']).toContain('application/json');
+    });
+  });
+
+  describe('adminPutJson', () => {
+    it('serializes body as JSON with PUT method', async () => {
+      await adminPutJson('/admin/llm-config/123', { name: 'updated' });
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe('http://gateway.test/admin/llm-config/123');
+      expect(init.method).toBe('PUT');
+      expect(init.body).toBe(JSON.stringify({ name: 'updated' }));
+    });
+  });
+
+  describe('adminPatchJson', () => {
+    it('serializes body as JSON with PATCH method', async () => {
+      await adminPatchJson('/admin/llm-config/123', { name: 'updated' });
+      const [url, init] = mockFetch.mock.calls[0];
+      expect(url).toBe('http://gateway.test/admin/llm-config/123');
+      expect(init.method).toBe('PATCH');
+      expect(init.body).toBe(JSON.stringify({ name: 'updated' }));
+    });
+  });
+
+  describe('error paths', () => {
+    it('throws when GATEWAY_URL is not configured', async () => {
+      const { getConfig } = await import('@tzurot/common-types');
+      vi.mocked(getConfig).mockReturnValueOnce({} as ReturnType<typeof getConfig>);
+
+      await expect(adminFetch('/admin/metrics')).rejects.toThrow('GATEWAY_URL is not configured');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/services/bot-client/src/utils/adminApiClient.ts
+++ b/services/bot-client/src/utils/adminApiClient.ts
@@ -8,7 +8,7 @@
  * Currently this includes /admin/settings endpoints.
  */
 
-import { getConfig, CONTENT_TYPES } from '@tzurot/common-types';
+import { getConfig, CONTENT_TYPES, TIMEOUTS } from '@tzurot/common-types';
 
 /**
  * Options for admin API requests
@@ -55,7 +55,7 @@ export async function adminFetch(path: string, options: AdminFetchOptions = {}):
     throw new Error('GATEWAY_URL is not configured');
   }
 
-  const { headers: customHeaders, userId, ...restOptions } = options;
+  const { headers: customHeaders, userId, signal: callerSignal, ...restOptions } = options;
 
   // Build headers with service auth and optional user ID
   const headers: Record<string, string> = {
@@ -68,9 +68,20 @@ export async function adminFetch(path: string, options: AdminFetchOptions = {}):
     headers['X-User-Id'] = userId;
   }
 
+  // Bound the request so a hung api-gateway doesn't leave the slash command
+  // sitting in "Thinking…" until Discord's 15-min interaction expiry fires.
+  // Caller-supplied signal is composed via `AbortSignal.any` so either
+  // intentional cancellation OR our timeout aborts the fetch.
+  const timeoutSignal = AbortSignal.timeout(TIMEOUTS.ADMIN_GATEWAY);
+  const signal =
+    callerSignal !== undefined && callerSignal !== null
+      ? AbortSignal.any([callerSignal, timeoutSignal])
+      : timeoutSignal;
+
   return fetch(`${gatewayUrl}${path}`, {
     ...restOptions,
     headers,
+    signal,
   });
 }
 


### PR DESCRIPTION
## Summary

Surfaced by claude-review on release PR #1071. Without `AbortSignal.timeout`, a hung api-gateway leaves admin slash commands (`/admin metrics`, `/admin db-sync`, etc.) sitting in "Thinking…" until Discord's 15-minute interaction expiry fires — at which point `editReply` throws because the interaction is expired.

## Approach

Add a 10s default timeout via a new `TIMEOUTS.ADMIN_GATEWAY` constant. 10s is well inside Discord's 15-min interaction window but short enough that a hung gateway surfaces as "Gateway unreachable" rather than letting the slash command sit silent.

Caller-supplied signals are merged via `AbortSignal.any` so explicit cancellation still works alongside the timeout.

## What changed

| File | Change |
|------|--------|
| `packages/common-types/src/constants/timing.ts` | New `TIMEOUTS.ADMIN_GATEWAY = 10_000` constant |
| `services/bot-client/src/utils/adminApiClient.ts` | Wire `AbortSignal.timeout(...)` into every `fetch()` call; merge with caller signal if provided |
| `services/bot-client/src/utils/adminApiClient.test.ts` (NEW) | 9 tests covering signal wiring, header construction, JSON helpers, and the GATEWAY_URL-missing error path |

## Test plan

- [x] 9 new tests in colocated `adminApiClient.test.ts` — signal wiring (default + caller-supplied composes via `AbortSignal.any`), all header paths, `adminPostJson`/`adminPutJson` JSON serialization, error path
- [x] Full `pnpm test`: 14 packages green
- [x] `pnpm quality`: 11/11 tasks green
- [ ] Manual: `/admin metrics` on dev — should still work normally (happy path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)