### PR TITLE
fix: address security-audit findings (4 items)

### DIFF
--- a/services/ai-worker/src/jobs/PendingMemoryProcessor.test.ts
+++ b/services/ai-worker/src/jobs/PendingMemoryProcessor.test.ts
@@ -34,6 +34,7 @@ describe('PendingMemoryProcessor', () => {
       findMany: ReturnType<typeof vi.fn>;
       update: ReturnType<typeof vi.fn>;
       delete: ReturnType<typeof vi.fn>;
+      groupBy: ReturnType<typeof vi.fn>;
     };
     $disconnect: ReturnType<typeof vi.fn>;
   };
@@ -57,6 +58,7 @@ describe('PendingMemoryProcessor', () => {
         findMany: vi.fn(),
         update: vi.fn(),
         delete: vi.fn(),
+        groupBy: vi.fn(),
       },
       $disconnect: vi.fn(),
     };
@@ -354,9 +356,12 @@ describe('PendingMemoryProcessor', () => {
 
   describe('getStats', () => {
     it('should return statistics about pending memories', async () => {
-      const pending = [{ attempts: 0 }, { attempts: 0 }, { attempts: 1 }, { attempts: 2 }];
-
-      mockPrisma.pendingMemory.findMany.mockResolvedValue(pending);
+      // Prisma groupBy shape: one row per distinct `attempts` value with _count._all
+      mockPrisma.pendingMemory.groupBy.mockResolvedValue([
+        { attempts: 0, _count: { _all: 2 } },
+        { attempts: 1, _count: { _all: 1 } },
+        { attempts: 2, _count: { _all: 1 } },
+      ]);
 
       const processor = new PendingMemoryProcessor(
         mockPrisma as unknown as PrismaClient,
@@ -376,7 +381,7 @@ describe('PendingMemoryProcessor', () => {
     });
 
     it('should return empty stats when no pending memories exist', async () => {
-      mockPrisma.pendingMemory.findMany.mockResolvedValue([]);
+      mockPrisma.pendingMemory.groupBy.mockResolvedValue([]);
 
       const processor = new PendingMemoryProcessor(
         mockPrisma as unknown as PrismaClient,
@@ -392,7 +397,7 @@ describe('PendingMemoryProcessor', () => {
     });
 
     it('should handle database errors gracefully', async () => {
-      mockPrisma.pendingMemory.findMany.mockRejectedValue(new Error('Database error'));
+      mockPrisma.pendingMemory.groupBy.mockRejectedValue(new Error('Database error'));
 
       const processor = new PendingMemoryProcessor(
         mockPrisma as unknown as PrismaClient,

--- a/services/ai-worker/src/jobs/PendingMemoryProcessor.ts
+++ b/services/ai-worker/src/jobs/PendingMemoryProcessor.ts
@@ -158,19 +158,22 @@ export class PendingMemoryProcessor {
     byAttempts: Record<number, number>;
   }> {
     try {
-      const pending = await this.prisma.pendingMemory.findMany({
-        select: { attempts: true },
+      // groupBy at the DB layer instead of fetching all rows — memory is
+      // bounded by the count of distinct attempt values (~retry step count),
+      // not the row count, so a stuck-job incident can't OOM this call.
+      const grouped = await this.prisma.pendingMemory.groupBy({
+        by: ['attempts'],
+        _count: { _all: true },
       });
 
       const byAttempts: Record<number, number> = {};
-      for (const p of pending) {
-        byAttempts[p.attempts] = (byAttempts[p.attempts] || 0) + 1;
+      let total = 0;
+      for (const row of grouped) {
+        byAttempts[row.attempts] = row._count._all;
+        total += row._count._all;
       }
 
-      return {
-        total: pending.length,
-        byAttempts,
-      };
+      return { total, byAttempts };
     } catch (error) {
       logger.error({ err: error }, 'Failed to get stats');
       return { total: 0, byAttempts: {} };

--- a/services/ai-worker/src/services/UserReferenceResolver.ts
+++ b/services/ai-worker/src/services/UserReferenceResolver.ts
@@ -49,7 +49,8 @@ export class UserReferenceResolver {
     if (persona === null) {
       const replacement = fallbackName ?? fullMatch;
       if (fallbackName !== undefined) {
-        logger.debug({ ...logContext, fallbackName }, `No mapping found, falling back to username`);
+        // fallbackName is a Discord display name — logging it is a PII violation.
+        logger.debug(logContext, `No mapping found, falling back to username`);
       }
       return {
         updatedText: ctx.currentText.replaceAll(fullMatch, replacement),

--- a/services/api-gateway/src/routes/admin/denylist.test.ts
+++ b/services/api-gateway/src/routes/admin/denylist.test.ts
@@ -10,6 +10,10 @@ import { createDenylistRoutes } from './denylist.js';
 // Mock AuthMiddleware
 vi.mock('../../services/AuthMiddleware.js', () => ({
   extractOwnerId: () => '999999999999999999',
+  requireOwnerAuth: () => (req: { userId?: string }, _res: unknown, next: () => void) => {
+    req.userId = '999999999999999999';
+    next();
+  },
 }));
 
 // Mock isBotOwner
@@ -48,7 +52,50 @@ const createMockDenylistInvalidation = () => ({
   unsubscribe: vi.fn().mockResolvedValue(undefined),
 });
 
+interface RouterLayer {
+  route?: {
+    path: string;
+    methods: Record<string, boolean>;
+    stack: unknown[];
+  };
+}
+
 describe('Denylist Admin Routes', () => {
+  describe('middleware composition', () => {
+    it('wires requireOwnerAuth on user-facing routes but not on /cache', () => {
+      // /cache is the service-only cache hydration endpoint — bot-client
+      // hits this at startup before any Discord user context exists, so
+      // adding requireOwnerAuth here would break startup silently. Lock
+      // the design in by asserting /cache has exactly one handler in its
+      // route stack (asyncHandler only), while every other route has at
+      // least two (auth + business logic, plus optional rate limiter).
+      const router = createDenylistRoutes(
+        createMockPrisma() as never,
+        createMockDenylistInvalidation() as never
+      );
+      const stack = (router as unknown as { stack: RouterLayer[] }).stack;
+      let cacheChecked = false;
+      let otherRoutesChecked = 0;
+      for (const layer of stack) {
+        if (!layer.route) continue;
+        if (layer.route.path === '/cache') {
+          expect(layer.route.stack.length, '/cache must remain service-only (no owner-auth)').toBe(
+            1
+          );
+          cacheChecked = true;
+        } else {
+          expect(
+            layer.route.stack.length,
+            `${layer.route.path} missing auth middleware`
+          ).toBeGreaterThanOrEqual(2);
+          otherRoutesChecked += 1;
+        }
+      }
+      expect(cacheChecked, '/cache route not found in router stack').toBe(true);
+      expect(otherRoutesChecked, 'expected at least one non-/cache route').toBeGreaterThan(0);
+    });
+  });
+
   let app: Express;
   let mockPrisma: ReturnType<typeof createMockPrisma>;
   let mockInvalidation: ReturnType<typeof createMockDenylistInvalidation>;

--- a/services/api-gateway/src/routes/admin/denylist.ts
+++ b/services/api-gateway/src/routes/admin/denylist.ts
@@ -3,7 +3,10 @@
  *
  * CRUD endpoints for managing denylisted users and guilds.
  * All endpoints require service authentication (applied globally).
- * Bot-client handles three-tier permission checking before calling these.
+ * User-facing endpoints additionally require bot-owner auth (defense-in-depth
+ * against post-INTERNAL_SERVICE_SECRET-compromise privilege escalation).
+ * The /cache endpoint is service-only — bot-client hydrates the denylist
+ * cache at startup, before any Discord user context exists.
  */
 
 import { Router, type Request, type Response } from 'express';
@@ -17,7 +20,7 @@ import {
   type PrismaClient,
   type DenylistCacheInvalidationService,
 } from '@tzurot/common-types';
-import { extractOwnerId } from '../../services/AuthMiddleware.js';
+import { extractOwnerId, requireOwnerAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendCustomSuccess, sendError } from '../../utils/responseHelpers.js';
 import { sendZodError } from '../../utils/zodHelpers.js';
@@ -104,6 +107,7 @@ export function createDenylistRoutes(
   // GET / — List all entries (optional ?type= filter)
   router.get(
     '/',
+    requireOwnerAuth(),
     asyncHandler(async (req: Request, res: Response) => {
       const typeFilter = req.query.type;
       let where = {};
@@ -146,11 +150,17 @@ export function createDenylistRoutes(
 
   // POST / — Add denylist entry (rate limited)
   const mutationMiddleware = rateLimiter !== undefined ? [rateLimiter] : [];
-  router.post('/', ...mutationMiddleware, handleAddEntry(prisma, denylistInvalidation));
+  router.post(
+    '/',
+    requireOwnerAuth(),
+    ...mutationMiddleware,
+    handleAddEntry(prisma, denylistInvalidation)
+  );
 
   // DELETE /:type/:discordId/:scope/:scopeId — Remove entry (rate limited)
   router.delete(
     '/:type/:discordId/:scope/:scopeId',
+    requireOwnerAuth(),
     ...mutationMiddleware,
     asyncHandler(async (req: Request, res: Response) => {
       const typeResult = denylistEntityTypeSchema.safeParse(req.params.type);

--- a/services/api-gateway/src/routes/admin/diagnostic.test.ts
+++ b/services/api-gateway/src/routes/admin/diagnostic.test.ts
@@ -29,6 +29,14 @@ vi.mock('@tzurot/common-types', async () => {
   };
 });
 
+// Mock AuthMiddleware — owner-auth gating runs unconditionally in tests
+vi.mock('../../services/AuthMiddleware.js', () => ({
+  requireOwnerAuth: () => (req: { userId?: string }, _res: unknown, next: () => void) => {
+    req.userId = 'admin-discord-id';
+    next();
+  },
+}));
+
 describe('Admin Diagnostic Routes', () => {
   let mockPrisma: {
     llmDiagnosticLog: {

--- a/services/api-gateway/src/routes/admin/diagnostic.ts
+++ b/services/api-gateway/src/routes/admin/diagnostic.ts
@@ -23,6 +23,7 @@ import {
   type DiagnosticPayload,
   DiagnosticUpdateSchema,
 } from '@tzurot/common-types';
+import { requireOwnerAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
@@ -345,12 +346,12 @@ function handleUpdateResponseIds(prisma: PrismaClient): RequestHandler {
 export function createDiagnosticRoutes(prisma: PrismaClient): Router {
   const router = Router();
 
-  router.get('/recent', handleGetRecent(prisma));
-  router.get('/by-message/:messageId', handleGetByMessage(prisma));
-  router.get('/by-response/:messageId', handleGetByResponse(prisma));
+  router.get('/recent', requireOwnerAuth(), handleGetRecent(prisma));
+  router.get('/by-message/:messageId', requireOwnerAuth(), handleGetByMessage(prisma));
+  router.get('/by-response/:messageId', requireOwnerAuth(), handleGetByResponse(prisma));
   // Note: /:requestId must come after /by-* routes to avoid matching 'by-message' as a requestId
-  router.get('/:requestId', handleGetByRequestId(prisma));
-  router.patch('/:requestId/response-ids', handleUpdateResponseIds(prisma));
+  router.get('/:requestId', requireOwnerAuth(), handleGetByRequestId(prisma));
+  router.patch('/:requestId/response-ids', requireOwnerAuth(), handleUpdateResponseIds(prisma));
 
   return router;
 }

--- a/services/api-gateway/src/routes/admin/llm-config.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.ts
@@ -22,6 +22,7 @@ import {
   LlmConfigCreateSchema,
   LlmConfigUpdateSchema,
 } from '@tzurot/common-types';
+import { requireOwnerAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
@@ -304,13 +305,33 @@ export function createAdminLlmConfigRoutes(
   // Instantiate service with dependencies
   const service = new LlmConfigService(prisma, llmConfigCacheInvalidation);
 
-  router.get('/', asyncHandler(createListHandler(service)));
-  router.get('/:id', asyncHandler(createGetHandler(service, modelCache)));
-  router.post('/', asyncHandler(createCreateConfigHandler(service, prisma, modelCache)));
-  router.put('/:id', asyncHandler(createEditConfigHandler(service, prisma, modelCache)));
-  router.put('/:id/set-default', asyncHandler(createSetDefaultHandler(service, prisma)));
-  router.put('/:id/set-free-default', asyncHandler(createSetFreeDefaultHandler(service, prisma)));
-  router.delete('/:id', asyncHandler(createDeleteConfigHandler(service, prisma)));
+  router.get('/', requireOwnerAuth(), asyncHandler(createListHandler(service)));
+  router.get('/:id', requireOwnerAuth(), asyncHandler(createGetHandler(service, modelCache)));
+  router.post(
+    '/',
+    requireOwnerAuth(),
+    asyncHandler(createCreateConfigHandler(service, prisma, modelCache))
+  );
+  router.put(
+    '/:id',
+    requireOwnerAuth(),
+    asyncHandler(createEditConfigHandler(service, prisma, modelCache))
+  );
+  router.put(
+    '/:id/set-default',
+    requireOwnerAuth(),
+    asyncHandler(createSetDefaultHandler(service, prisma))
+  );
+  router.put(
+    '/:id/set-free-default',
+    requireOwnerAuth(),
+    asyncHandler(createSetFreeDefaultHandler(service, prisma))
+  );
+  router.delete(
+    '/:id',
+    requireOwnerAuth(),
+    asyncHandler(createDeleteConfigHandler(service, prisma))
+  );
 
   return router;
 }

--- a/services/api-gateway/src/routes/admin/stopSequences.test.ts
+++ b/services/api-gateway/src/routes/admin/stopSequences.test.ts
@@ -22,6 +22,14 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
+// Mock AuthMiddleware — owner-auth gating runs unconditionally in tests
+vi.mock('../../services/AuthMiddleware.js', () => ({
+  requireOwnerAuth: () => (req: { userId?: string }, _res: unknown, next: () => void) => {
+    req.userId = 'admin-discord-id';
+    next();
+  },
+}));
+
 function createMockRedis(
   overrides: {
     total?: string | null;

--- a/services/api-gateway/src/routes/admin/stopSequences.ts
+++ b/services/api-gateway/src/routes/admin/stopSequences.ts
@@ -10,6 +10,7 @@ import { Router, type Response, type Request } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { createLogger } from '@tzurot/common-types';
 import type { Redis } from 'ioredis';
+import { requireOwnerAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendCustomSuccess } from '../../utils/responseHelpers.js';
 
@@ -28,6 +29,7 @@ export function createStopSequenceRoutes(redis: Redis): Router {
 
   router.get(
     '/',
+    requireOwnerAuth(),
     asyncHandler(async (_req: Request, res: Response) => {
       const [totalStr, bySequence, byModel, startedAt] = await Promise.all([
         redis.get(REDIS_KEYS.TOTAL),

--- a/services/api-gateway/src/routes/admin/tts-config.test.ts
+++ b/services/api-gateway/src/routes/admin/tts-config.test.ts
@@ -129,6 +129,23 @@ function buildRouter() {
 }
 
 describe('admin/tts-config routes', () => {
+  describe('middleware composition', () => {
+    it('wires requireOwnerAuth on every route', () => {
+      // Handler-extraction tests pick the last handler, which bypasses
+      // middleware. Inspect the router stack directly so a regression that
+      // removed requireOwnerAuth() from any route would fail this check.
+      const router = buildRouter();
+      const stack = (router as unknown as { stack: RouterLayer[] }).stack;
+      for (const layer of stack) {
+        if (!layer.route) continue;
+        expect(
+          layer.route.stack.length,
+          `${layer.route.path} missing auth middleware`
+        ).toBeGreaterThanOrEqual(2);
+      }
+    });
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(mockService.formatConfigDetail).mockImplementation((c: typeof sampleRawConfig) => ({

--- a/services/api-gateway/src/routes/admin/tts-config.ts
+++ b/services/api-gateway/src/routes/admin/tts-config.ts
@@ -31,6 +31,7 @@ import {
   TtsConfigCreateSchema,
   TtsConfigUpdateSchema,
 } from '@tzurot/common-types';
+import { requireOwnerAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
@@ -313,13 +314,21 @@ export function createAdminTtsConfigRoutes(
   const router = Router();
   const service = new TtsConfigService(prisma, ttsConfigCacheInvalidation);
 
-  router.get('/', asyncHandler(createListHandler(service)));
-  router.get('/:id', asyncHandler(createGetHandler(service)));
-  router.post('/', asyncHandler(createCreateHandler(service, prisma)));
-  router.put('/:id', asyncHandler(createEditHandler(service, prisma)));
-  router.put('/:id/set-default', asyncHandler(createSetDefaultHandler(service, prisma)));
-  router.put('/:id/set-free-default', asyncHandler(createSetFreeDefaultHandler(service, prisma)));
-  router.delete('/:id', asyncHandler(createDeleteHandler(service, prisma)));
+  router.get('/', requireOwnerAuth(), asyncHandler(createListHandler(service)));
+  router.get('/:id', requireOwnerAuth(), asyncHandler(createGetHandler(service)));
+  router.post('/', requireOwnerAuth(), asyncHandler(createCreateHandler(service, prisma)));
+  router.put('/:id', requireOwnerAuth(), asyncHandler(createEditHandler(service, prisma)));
+  router.put(
+    '/:id/set-default',
+    requireOwnerAuth(),
+    asyncHandler(createSetDefaultHandler(service, prisma))
+  );
+  router.put(
+    '/:id/set-free-default',
+    requireOwnerAuth(),
+    asyncHandler(createSetFreeDefaultHandler(service, prisma))
+  );
+  router.delete('/:id', requireOwnerAuth(), asyncHandler(createDeleteHandler(service, prisma)));
 
   return router;
 }

--- a/services/api-gateway/src/routes/admin/usage.test.ts
+++ b/services/api-gateway/src/routes/admin/usage.test.ts
@@ -22,6 +22,14 @@ vi.mock('@tzurot/common-types', async () => {
   };
 });
 
+// Mock AuthMiddleware — owner-auth gating runs unconditionally in tests
+vi.mock('../../services/AuthMiddleware.js', () => ({
+  requireOwnerAuth: () => (req: { userId?: string }, _res: unknown, next: () => void) => {
+    req.userId = 'admin-discord-id';
+    next();
+  },
+}));
+
 describe('Admin Usage Routes', () => {
   let mockPrisma: {
     usageLog: {

--- a/services/api-gateway/src/routes/admin/usage.ts
+++ b/services/api-gateway/src/routes/admin/usage.ts
@@ -11,6 +11,7 @@ import {
   Duration,
   DurationParseError,
 } from '@tzurot/common-types';
+import { requireOwnerAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendCustomSuccess } from '../../utils/responseHelpers.js';
 
@@ -67,6 +68,7 @@ export function createAdminUsageRoutes(prisma: PrismaClient): Router {
    */
   router.get(
     '/',
+    requireOwnerAuth(),
     asyncHandler(async (req: Request, res: Response) => {
       const timeframe = (req.query.timeframe as string) ?? '7d';
       const periodStart = parseTimeframe(timeframe);

--- a/services/api-gateway/src/routes/wallet/listKeys.test.ts
+++ b/services/api-gateway/src/routes/wallet/listKeys.test.ts
@@ -118,6 +118,7 @@ describe('GET /wallet/list', () => {
           lastUsedAt: true,
         },
         orderBy: { createdAt: 'desc' },
+        take: 100,
       });
     });
 

--- a/services/api-gateway/src/routes/wallet/listKeys.ts
+++ b/services/api-gateway/src/routes/wallet/listKeys.ts
@@ -43,6 +43,7 @@ export function createListKeysRoute(prisma: PrismaClient): Router {
           lastUsedAt: true,
         },
         orderBy: { createdAt: 'desc' },
+        take: 100, // User-scoped ceiling; provider count is bounded by a small handful
       });
 
       logger.info({ discordUserId, keyCount: keys.length }, 'Listed API keys');


### PR DESCRIPTION
## Summary

Discovery audit on 2026-05-21 surfaced four backlog items (filed to `backlog/inbox.md` earlier today). This PR addresses all of them in one cohesive hardening pass.

| Severity | Finding | Fix |
| --- | --- | --- |
| MEDIUM:b | 6 of 12 admin routes missing `requireOwnerAuth` | Add per-route owner-auth to `denylist`, `diagnostic`, `llm-config`, `stopSequences`, `tts-config`, `usage` (+ test mocks) |
| MEDIUM:c | `PendingMemoryProcessor.getStats()` unbounded `findMany` | Replace with `groupBy` — DB does the aggregation; memory is O(distinct-counts) instead of O(row-count) |
| LOW:c | Unbounded user-scoped `findMany` | Only `wallet/listKeys.ts` was actually unbounded (3/4 already had `take:` bounds — audit correction). Added `take: 100` |
| LOW:e | Username PII in debug log | Drop `fallbackName` from `UserReferenceResolver.ts:52` logger.debug per `00-critical.md` "NEVER log: usernames" |

## Notable design call: denylist GET `/cache` exception

The `/admin/denylist/cache` endpoint stays without `requireOwnerAuth`. Bot-client hydrates the in-memory denylist at startup via raw `fetch` with only `X-Service-Auth` (no Discord user context yet — see `GatewayClient.ts:414`). This matches the `settings.ts` "service-only operation" precedent. Module docstring updated to call out the exception.

## Audit correction

The original [LOW:c] finding listed 4 unbounded user-scoped `findMany` calls. On closer inspection, 3 of them (`channel/list.ts:48`, `tts-override.ts:76`, `model-override.ts:77`) already had `take:` bounds — my initial discovery awk window truncated before the `take:` line. Only `wallet/listKeys.ts:37` was actually unbounded. PR addresses the real case.

## Threat model

Worth being explicit: none of these are externally exploitable. The admin owner-auth findings are defense-in-depth against `INTERNAL_SERVICE_SECRET` compromise. The `getStats()` finding is operational (memory spike during a stuck-job incident). The PII finding is debug-level (won't reach prod logs).

## Test plan

- [x] `pnpm test` — 14 packages, all green (9034 tests)
- [x] `pnpm quality` — lint + cpd + depcruise + typecheck + typecheck:spec, all green
- [x] `depcruise` — 1655 modules / 5020 dependencies, 0 violations
- [ ] Manual smoke: hit `/admin/denylist/cache` from bot-client startup, confirm it loads without owner-auth (verifies the exception works as designed)
- [ ] Manual smoke: hit any `/admin/diagnostic/*` endpoint as a non-owner, confirm 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)