### PR TITLE
fix(api-gateway): close PR #1074 follow-ups (admin auth coverage)

### DIFF
--- a/services/api-gateway/src/routes/admin/denylist.test.ts
+++ b/services/api-gateway/src/routes/admin/denylist.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import express, { type Express } from 'express';
 import request from 'supertest';
 import { createDenylistRoutes } from './denylist.js';
+import { getAllRoutes } from '../../test/expressRouterUtils.js';
 
 // Mock AuthMiddleware
 vi.mock('../../services/AuthMiddleware.js', () => ({
@@ -52,14 +53,6 @@ const createMockDenylistInvalidation = () => ({
   unsubscribe: vi.fn().mockResolvedValue(undefined),
 });
 
-interface RouterLayer {
-  route?: {
-    path: string;
-    methods: Record<string, boolean>;
-    stack: unknown[];
-  };
-}
-
 describe('Denylist Admin Routes', () => {
   describe('middleware composition', () => {
     it('wires requireOwnerAuth on user-facing routes but not on /cache', () => {
@@ -73,26 +66,18 @@ describe('Denylist Admin Routes', () => {
         createMockPrisma() as never,
         createMockDenylistInvalidation() as never
       );
-      const stack = (router as unknown as { stack: RouterLayer[] }).stack;
-      let cacheChecked = false;
-      let otherRoutesChecked = 0;
-      for (const layer of stack) {
-        if (!layer.route) continue;
-        if (layer.route.path === '/cache') {
-          expect(layer.route.stack.length, '/cache must remain service-only (no owner-auth)').toBe(
-            1
-          );
-          cacheChecked = true;
-        } else {
-          expect(
-            layer.route.stack.length,
-            `${layer.route.path} missing auth middleware`
-          ).toBeGreaterThanOrEqual(2);
-          otherRoutesChecked += 1;
-        }
+      const routes = getAllRoutes(router);
+      const cacheRoute = routes.find(r => r.path === '/cache');
+      expect(cacheRoute, '/cache route not found in router stack').toBeDefined();
+      expect(cacheRoute?.stackLength, '/cache must remain service-only (no owner-auth)').toBe(1);
+
+      const nonCacheRoutes = routes.filter(r => r.path !== '/cache');
+      expect(nonCacheRoutes.length, 'expected at least one non-/cache route').toBeGreaterThan(0);
+      for (const route of nonCacheRoutes) {
+        expect(route.stackLength, `${route.path} missing auth middleware`).toBeGreaterThanOrEqual(
+          2
+        );
       }
-      expect(cacheChecked, '/cache route not found in router stack').toBe(true);
-      expect(otherRoutesChecked, 'expected at least one non-/cache route').toBeGreaterThan(0);
     });
   });
 

--- a/services/api-gateway/src/routes/admin/diagnostic.test.ts
+++ b/services/api-gateway/src/routes/admin/diagnostic.test.ts
@@ -14,6 +14,7 @@ import { createDiagnosticRoutes } from './diagnostic.js';
 import type { PrismaClient, DiagnosticPayload } from '@tzurot/common-types';
 import express from 'express';
 import request from 'supertest';
+import { getAllRoutes } from '../../test/expressRouterUtils.js';
 
 // Mock logger
 vi.mock('@tzurot/common-types', async () => {
@@ -38,6 +39,20 @@ vi.mock('../../services/AuthMiddleware.js', () => ({
 }));
 
 describe('Admin Diagnostic Routes', () => {
+  describe('middleware composition', () => {
+    it('wires requireOwnerAuth on every route', () => {
+      // Mock prisma isn't invoked at router-registration time — pass an empty
+      // stub. The structural test only inspects the resulting router stack.
+      const routes = getAllRoutes(createDiagnosticRoutes({} as unknown as PrismaClient));
+      expect(routes.length, 'expected at least one registered route').toBeGreaterThan(0);
+      for (const route of routes) {
+        expect(route.stackLength, `${route.path} missing auth middleware`).toBeGreaterThanOrEqual(
+          2
+        );
+      }
+    });
+  });
+
   let mockPrisma: {
     llmDiagnosticLog: {
       findMany: ReturnType<typeof vi.fn>;

--- a/services/api-gateway/src/routes/admin/llm-config.test.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.test.ts
@@ -7,6 +7,7 @@ import express, { type Express } from 'express';
 import request from 'supertest';
 import { createAdminLlmConfigRoutes } from './llm-config.js';
 import type { PrismaClient, LlmConfigCacheInvalidationService } from '@tzurot/common-types';
+import { getAllRoutes } from '../../test/expressRouterUtils.js';
 
 // Mock the admin auth middleware
 vi.mock('../../services/AuthMiddleware.js', () => ({
@@ -76,6 +77,18 @@ const createMockPrismaClient = () => {
 };
 
 describe('Admin LLM Config Routes', () => {
+  describe('middleware composition', () => {
+    it('wires requireOwnerAuth on every route', () => {
+      const routes = getAllRoutes(createAdminLlmConfigRoutes({} as unknown as PrismaClient));
+      expect(routes.length, 'expected at least one registered route').toBeGreaterThan(0);
+      for (const route of routes) {
+        expect(route.stackLength, `${route.path} missing auth middleware`).toBeGreaterThanOrEqual(
+          2
+        );
+      }
+    });
+  });
+
   let app: Express;
   let prisma: ReturnType<typeof createMockPrismaClient>;
 

--- a/services/api-gateway/src/routes/admin/settings.test.ts
+++ b/services/api-gateway/src/routes/admin/settings.test.ts
@@ -10,6 +10,7 @@ import { createAdminSettingsRoutes } from './settings.js';
 import { ADMIN_SETTINGS_SINGLETON_ID, type PrismaClient } from '@tzurot/common-types';
 import express from 'express';
 import request from 'supertest';
+import { getAllRoutes } from '../../test/expressRouterUtils.js';
 
 // Mock isBotOwner - must be before vi.mock to be hoisted
 const mockIsBotOwner = vi.fn().mockReturnValue(true);
@@ -26,6 +27,34 @@ vi.mock('@tzurot/common-types', async importOriginal => {
       error: vi.fn(),
     }),
     isBotOwner: (...args: unknown[]) => mockIsBotOwner(...args),
+  };
+});
+
+// Mock AuthMiddleware so requireOwnerAuth() routes through the same
+// mockIsBotOwner that the inline isAuthorizedForRead path uses. Without
+// this, requireOwnerAuth would call the real isValidOwner -> config check
+// (which has no BOT_OWNER_ID in .env.test), failing all PATCH/DELETE tests.
+// isAuthorizedForRead stays real because GET / still uses it inline (the
+// service-only path can't migrate to middleware).
+vi.mock('../../services/AuthMiddleware.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../services/AuthMiddleware.js')>();
+  return {
+    ...actual,
+    requireOwnerAuth:
+      () =>
+      (
+        req: { userId?: string },
+        res: { status: (n: number) => { json: (b: unknown) => void } },
+        next: () => void
+      ): void => {
+        if (mockIsBotOwner(req.userId)) {
+          next();
+        } else {
+          res
+            .status(403)
+            .json({ error: 'UNAUTHORIZED', message: 'Only bot owners can modify this' });
+        }
+      },
   };
 });
 
@@ -73,6 +102,29 @@ function createDefaultSettings(
 }
 
 describe('Admin Settings Routes (Singleton)', () => {
+  describe('middleware composition', () => {
+    it('GET / stays inline-auth (service-only allowed); PATCH/DELETE use middleware', () => {
+      // settings.ts has a mixed auth shape: GET supports service-only calls
+      // (bot-client hydrates admin settings at startup with no userId), so it
+      // can't migrate to requireOwnerAuth() middleware. PATCH and DELETE are
+      // owner-only writes — they got the standard requireOwnerAuth middleware
+      // in this PR. Lock the asymmetry in by asserting the resulting stack
+      // lengths.
+      const router = createAdminSettingsRoutes(createMockPrisma() as unknown as PrismaClient);
+      const routes = getAllRoutes(router);
+      const byPath = new Map(routes.map(r => [`${r.methods[0]} ${r.path}`, r]));
+      expect(byPath.get('get /')?.stackLength, 'GET / must stay inline-auth (1 handler)').toBe(1);
+      expect(
+        byPath.get('patch /config-defaults')?.stackLength,
+        'PATCH /config-defaults must use requireOwnerAuth middleware'
+      ).toBeGreaterThanOrEqual(2);
+      expect(
+        byPath.get('delete /config-defaults')?.stackLength,
+        'DELETE /config-defaults must use requireOwnerAuth middleware'
+      ).toBeGreaterThanOrEqual(2);
+    });
+  });
+
   let mockPrisma: ReturnType<typeof createMockPrisma>;
   let app: express.Express;
 
@@ -87,9 +139,13 @@ describe('Admin Settings Routes (Singleton)', () => {
 
     app = express();
     app.use(express.json());
-    // Add middleware to inject userId
+    // Add middleware to inject userId AND X-Owner-Id header. The header is
+    // required because PATCH/DELETE now use requireOwnerAuth() middleware,
+    // which reads ownerId via extractOwnerId() from the X-Owner-Id header.
+    // GET still consults req.userId via the inline isAuthorizedForRead check.
     app.use((req, _res, next) => {
       (req as express.Request & { userId: string }).userId = MOCK_USER_ID;
+      req.headers['x-owner-id'] = MOCK_USER_ID;
       next();
     });
     app.use('/admin/settings', createAdminSettingsRoutes(mockPrisma as unknown as PrismaClient));

--- a/services/api-gateway/src/routes/admin/settings.ts
+++ b/services/api-gateway/src/routes/admin/settings.ts
@@ -3,9 +3,16 @@
  * Owner-only endpoints for managing the global AdminSettings singleton
  *
  * Endpoints:
- * - GET /admin/settings - Get the AdminSettings singleton
- * - PATCH /admin/settings/config-defaults - Update configDefaults directly (flat body)
- * - DELETE /admin/settings/config-defaults - Clear all admin config defaults
+ * - GET /admin/settings - Get the AdminSettings singleton (service-only OR owner)
+ * - PATCH /admin/settings/config-defaults - Update configDefaults (owner only)
+ * - DELETE /admin/settings/config-defaults - Clear all admin config defaults (owner only)
+ *
+ * Auth shape: PATCH and DELETE use the standard `requireOwnerAuth()` middleware
+ * (consistent with the other 12 admin route modules). GET cannot — it must
+ * accept service-only calls (no Discord user context) so bot-client can
+ * hydrate its admin-settings cache at startup. The GET keeps the inline
+ * `isAuthorizedForRead` check, which permits no-userId requests but rejects
+ * user-context requests from non-owners (see `GatewayClient.getAdminSettings()`).
  */
 
 import { Router, type Request, type Response } from 'express';
@@ -23,7 +30,7 @@ import { asyncHandler } from '../../utils/asyncHandler.js';
 import { mergeConfigOverrides } from '../../utils/configOverrideMerge.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
-import { isAuthorizedForRead, isAuthorizedForWrite } from '../../services/AuthMiddleware.js';
+import { isAuthorizedForRead, requireOwnerAuth } from '../../services/AuthMiddleware.js';
 
 const logger = createLogger('admin-settings-routes');
 
@@ -97,11 +104,6 @@ function createConfigDefaultsPatchHandler(
   cascadeInvalidation?: ConfigCascadeCacheInvalidationService
 ): (req: Request, res: Response) => void {
   return asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
-    if (!isAuthorizedForWrite(req.userId)) {
-      sendError(res, ErrorResponses.unauthorized('Only bot owners can update settings'));
-      return;
-    }
-
     const input = req.body as Record<string, unknown>;
     const userUuid = await resolveUserUuid(prisma, req.userId);
     const existing = await getOrCreateSettings(prisma);
@@ -152,17 +154,17 @@ export function createAdminSettingsRoutes(
   );
 
   // PATCH /admin/settings/config-defaults - Flat body (same shape as all cascade tiers)
-  router.patch('/config-defaults', createConfigDefaultsPatchHandler(prisma, cascadeInvalidation));
+  router.patch(
+    '/config-defaults',
+    requireOwnerAuth(),
+    createConfigDefaultsPatchHandler(prisma, cascadeInvalidation)
+  );
 
   // DELETE /admin/settings/config-defaults - Clear all admin config defaults
   router.delete(
     '/config-defaults',
+    requireOwnerAuth(),
     asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
-      if (!isAuthorizedForWrite(req.userId)) {
-        sendError(res, ErrorResponses.unauthorized('Only bot owners can update settings'));
-        return;
-      }
-
       const userUuid = await resolveUserUuid(prisma, req.userId);
       await getOrCreateSettings(prisma); // Ensure singleton exists
 

--- a/services/api-gateway/src/routes/admin/stopSequences.test.ts
+++ b/services/api-gateway/src/routes/admin/stopSequences.test.ts
@@ -7,6 +7,7 @@ import express from 'express';
 import request from 'supertest';
 import type { Redis } from 'ioredis';
 import { createStopSequenceRoutes } from './stopSequences.js';
+import { getAllRoutes } from '../../test/expressRouterUtils.js';
 
 // Mock the logger
 vi.mock('@tzurot/common-types', async importOriginal => {
@@ -60,41 +61,55 @@ function createApp(redis: Redis) {
   return app;
 }
 
-describe('GET /admin/stop-sequences', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('should return stats from Redis', async () => {
-    const redis = createMockRedis({
-      total: '42',
-      bySequence: { '\nUser:': '30', '\nHuman:': '12' },
-      byModel: { 'gpt-4': '25', 'claude-3': '17' },
-      startedAt: '2026-02-10T00:00:00.000Z',
+describe('Admin Stop Sequence Routes', () => {
+  describe('middleware composition', () => {
+    it('wires requireOwnerAuth on every route', () => {
+      const routes = getAllRoutes(createStopSequenceRoutes({} as unknown as Redis));
+      expect(routes.length, 'expected at least one registered route').toBeGreaterThan(0);
+      for (const route of routes) {
+        expect(route.stackLength, `${route.path} missing auth middleware`).toBeGreaterThanOrEqual(
+          2
+        );
+      }
     });
-    const app = createApp(redis);
-
-    const res = await request(app).get('/admin/stop-sequences');
-
-    expect(res.status).toBe(200);
-    expect(res.body.totalActivations).toBe(42);
-    expect(res.body.bySequence['\nUser:']).toBe(30);
-    expect(res.body.bySequence['\nHuman:']).toBe(12);
-    expect(res.body.byModel['gpt-4']).toBe(25);
-    expect(res.body.byModel['claude-3']).toBe(17);
-    expect(res.body.startedAt).toBe('2026-02-10T00:00:00.000Z');
   });
 
-  it('should handle empty Redis keys gracefully', async () => {
-    const redis = createMockRedis();
-    const app = createApp(redis);
+  describe('GET /admin/stop-sequences', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
 
-    const res = await request(app).get('/admin/stop-sequences');
+    it('should return stats from Redis', async () => {
+      const redis = createMockRedis({
+        total: '42',
+        bySequence: { '\nUser:': '30', '\nHuman:': '12' },
+        byModel: { 'gpt-4': '25', 'claude-3': '17' },
+        startedAt: '2026-02-10T00:00:00.000Z',
+      });
+      const app = createApp(redis);
 
-    expect(res.status).toBe(200);
-    expect(res.body.totalActivations).toBe(0);
-    expect(res.body.bySequence).toEqual({});
-    expect(res.body.byModel).toEqual({});
-    expect(res.body.startedAt).toBeDefined();
+      const res = await request(app).get('/admin/stop-sequences');
+
+      expect(res.status).toBe(200);
+      expect(res.body.totalActivations).toBe(42);
+      expect(res.body.bySequence['\nUser:']).toBe(30);
+      expect(res.body.bySequence['\nHuman:']).toBe(12);
+      expect(res.body.byModel['gpt-4']).toBe(25);
+      expect(res.body.byModel['claude-3']).toBe(17);
+      expect(res.body.startedAt).toBe('2026-02-10T00:00:00.000Z');
+    });
+
+    it('should handle empty Redis keys gracefully', async () => {
+      const redis = createMockRedis();
+      const app = createApp(redis);
+
+      const res = await request(app).get('/admin/stop-sequences');
+
+      expect(res.status).toBe(200);
+      expect(res.body.totalActivations).toBe(0);
+      expect(res.body.bySequence).toEqual({});
+      expect(res.body.byModel).toEqual({});
+      expect(res.body.startedAt).toBeDefined();
+    });
   });
 });

--- a/services/api-gateway/src/routes/admin/tts-config.test.ts
+++ b/services/api-gateway/src/routes/admin/tts-config.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Request, Response, Router } from 'express';
 import { StatusCodes } from 'http-status-codes';
+import { getAllRoutes } from '../../test/expressRouterUtils.js';
 
 const sampleRawConfig = {
   id: 'cfg-uuid-1',
@@ -134,14 +135,12 @@ describe('admin/tts-config routes', () => {
       // Handler-extraction tests pick the last handler, which bypasses
       // middleware. Inspect the router stack directly so a regression that
       // removed requireOwnerAuth() from any route would fail this check.
-      const router = buildRouter();
-      const stack = (router as unknown as { stack: RouterLayer[] }).stack;
-      for (const layer of stack) {
-        if (!layer.route) continue;
-        expect(
-          layer.route.stack.length,
-          `${layer.route.path} missing auth middleware`
-        ).toBeGreaterThanOrEqual(2);
+      const routes = getAllRoutes(buildRouter());
+      expect(routes.length, 'expected at least one registered route').toBeGreaterThan(0);
+      for (const route of routes) {
+        expect(route.stackLength, `${route.path} missing auth middleware`).toBeGreaterThanOrEqual(
+          2
+        );
       }
     });
   });

--- a/services/api-gateway/src/routes/admin/usage.test.ts
+++ b/services/api-gateway/src/routes/admin/usage.test.ts
@@ -7,6 +7,7 @@ import { createAdminUsageRoutes } from './usage.js';
 import type { PrismaClient } from '@tzurot/common-types';
 import express from 'express';
 import request from 'supertest';
+import { getAllRoutes } from '../../test/expressRouterUtils.js';
 
 // Mock logger
 vi.mock('@tzurot/common-types', async () => {
@@ -31,6 +32,18 @@ vi.mock('../../services/AuthMiddleware.js', () => ({
 }));
 
 describe('Admin Usage Routes', () => {
+  describe('middleware composition', () => {
+    it('wires requireOwnerAuth on every route', () => {
+      const routes = getAllRoutes(createAdminUsageRoutes({} as unknown as PrismaClient));
+      expect(routes.length, 'expected at least one registered route').toBeGreaterThan(0);
+      for (const route of routes) {
+        expect(route.stackLength, `${route.path} missing auth middleware`).toBeGreaterThanOrEqual(
+          2
+        );
+      }
+    });
+  });
+
   let mockPrisma: {
     usageLog: {
       findMany: ReturnType<typeof vi.fn>;

--- a/services/api-gateway/src/test/expressRouterUtils.test.ts
+++ b/services/api-gateway/src/test/expressRouterUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { Router } from 'express';
-import { findRoute, getRouteHandler } from './expressRouterUtils.js';
+import { findRoute, getRouteHandler, getAllRoutes } from './expressRouterUtils.js';
 
 function createTestRouter(): Router {
   const router = Router();
@@ -65,6 +65,37 @@ describe('expressRouterUtils', () => {
     it('should throw with descriptive message when no path specified', () => {
       const router = createTestRouter();
       expect(() => getRouteHandler(router, 'patch')).toThrow('No route found for PATCH (any path)');
+    });
+  });
+
+  describe('getAllRoutes', () => {
+    it('returns one summary per registered route', () => {
+      const router = createTestRouter();
+      const routes = getAllRoutes(router);
+      expect(routes).toHaveLength(4);
+      const byPath = new Map(routes.map(r => [`${r.methods[0]} ${r.path}`, r]));
+      expect(byPath.get('get /')).toBeDefined();
+      expect(byPath.get('post /items')).toBeDefined();
+      expect(byPath.get('put /items/:id')).toBeDefined();
+      expect(byPath.get('delete /items/:id')).toBeDefined();
+    });
+
+    it('reports stackLength reflecting wrapped middleware', () => {
+      const router = Router();
+      const noMiddleware = (_req: unknown, _res: unknown): void => {};
+      const oneMiddleware = (_req: unknown, _res: unknown, next: () => void): void => next();
+      router.get('/bare', noMiddleware);
+      router.get('/wrapped', oneMiddleware, noMiddleware);
+      router.get('/double-wrapped', oneMiddleware, oneMiddleware, noMiddleware);
+      const routes = getAllRoutes(router);
+      const byPath = new Map(routes.map(r => [r.path, r.stackLength]));
+      expect(byPath.get('/bare')).toBe(1);
+      expect(byPath.get('/wrapped')).toBe(2);
+      expect(byPath.get('/double-wrapped')).toBe(3);
+    });
+
+    it('returns an empty array for a router with no routes', () => {
+      expect(getAllRoutes(Router())).toEqual([]);
     });
   });
 });

--- a/services/api-gateway/src/test/expressRouterUtils.ts
+++ b/services/api-gateway/src/test/expressRouterUtils.ts
@@ -77,3 +77,37 @@ export function getRouteHandler(
   const stack = layer.route.stack;
   return stack[stack.length - 1].handle;
 }
+
+/** Per-route summary used by structural middleware-composition tests. */
+export interface RouteSummary {
+  path: string;
+  methods: string[];
+  /**
+   * Number of handlers in the route's stack. A route registered as
+   * `router.METHOD(path, handler)` has length 1; one wrapped by a single
+   * middleware (e.g., `requireOwnerAuth()`) has length 2.
+   */
+  stackLength: number;
+}
+
+/**
+ * Summarize every route declared on `router`. Intended for structural tests
+ * that assert middleware presence (e.g., "every admin route must have at
+ * least 2 stack entries because `requireOwnerAuth()` wraps the handler").
+ *
+ * Sub-routers and middleware-only layers (no `.route`) are skipped.
+ */
+export function getAllRoutes(router: Router): RouteSummary[] {
+  const summaries: RouteSummary[] = [];
+  for (const layer of getRouterStack(router)) {
+    if (layer.route === undefined) {
+      continue;
+    }
+    const path = layer.route.path ?? '<unnamed>';
+    const methods = Object.entries(layer.route.methods ?? {})
+      .filter(([, enabled]) => enabled === true)
+      .map(([m]) => m);
+    summaries.push({ path, methods, stackLength: layer.route.stack.length });
+  }
+  return summaries;
+}


### PR DESCRIPTION
## Summary

Closes the 3 PR #1074 follow-up items filed in `backlog/inbox.md` (raised across rounds 4 + 5 of #1074's review):

1. **Extend middleware-composition test pattern to 4 remaining admin route test files** — diagnostic, llm-config, stopSequences, usage. PR #1074 added the structural router-stack-inspection test to denylist and tts-config; this PR brings the other 4 in line.

2. **Extract shared route-inspection helper** — added `getAllRoutes()` to `src/test/expressRouterUtils.ts` alongside the existing `findRoute` / `getRouteHandler`. Eliminates the local `RouterLayer` interface that PR #1074 added to `denylist.test.ts` (`tts-config.test.ts` keeps its local `RouterLayer` because the pre-existing `extractHandler` helper has 25 call sites — out of scope to migrate here).

3. **Migrate `settings.ts` PATCH/DELETE to `requireOwnerAuth()` middleware** — *partial migration*. GET cannot migrate because `GatewayClient.getAdminSettings()` calls `/admin/settings` at bot-client startup with only `X-Service-Auth` (no Discord user context), and `isAuthorizedForRead` is what permits this service-only path. PATCH and DELETE are owner-only writes that became inconsistent with the rest of admin/* — they now use the standard middleware.

## Notable design call: mixed auth shape in settings.ts

Documented in the module docstring and locked in by a structural test that asserts `GET /` has stackLength=1 (inline auth) while `PATCH/DELETE /config-defaults` have stackLength≥2 (middleware + handler).

## Test fixture adjustment

`settings.test.ts` now mocks `requireOwnerAuth` to route through the existing `mockIsBotOwner` so the \"reject non-owners\" tests continue to work via the same mock flip (without this, real `requireOwnerAuth` consults `config.BOT_OWNER_ID` which isn't set in `.env.test` → all PATCH/DELETE tests would 403). Test app middleware also injects `X-Owner-Id` header alongside `req.userId` (requireOwnerAuth reads from `X-Owner-Id` via `extractOwnerId`).

## Test plan

- [x] \`pnpm test\` — 14 packages green, 1994 tests (+8 since develop: 5 new middleware-composition tests for the 4 admin modules + settings, 3 new \`getAllRoutes\` unit tests)
- [x] \`pnpm quality\` — lint + cpd + depcruise + typecheck + typecheck:spec, all green
- [x] depcruise: 0 violations
- [ ] Manual smoke: hit \`/admin/settings\` from bot-client startup (no userId), confirm the inline auth still allows it
- [ ] Manual smoke: hit \`/admin/settings/config-defaults\` PATCH with a non-owner user, confirm 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)