### PR TITLE
fix: pre-release fixes for v3.0.0-beta.125 review findings

### DIFF
--- a/services/api-gateway/src/routes/admin/llm-config.test.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.test.ts
@@ -793,6 +793,24 @@ describe('Admin LLM Config Routes', () => {
       expect(response.body.message).toMatch(/default config/i);
     });
 
+    it('should reject deleting the free-tier default config', async () => {
+      // Same hard-block shape as isDefault — guest users would otherwise lose
+      // LLM access until an admin manually sets a new free-tier default.
+      prisma.llmConfig.findUnique.mockResolvedValue({
+        id: 'config-id',
+        isGlobal: true,
+        isDefault: false,
+        isFreeDefault: true,
+        memoryScoreThreshold: { toNumber: () => 0.5 },
+        memoryLimit: 20,
+      });
+
+      const response = await request(app).delete('/admin/llm-config/config-id');
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toMatch(/free tier default/i);
+    });
+
     it('should reject deleting config in use by personalities', async () => {
       prisma.llmConfig.findUnique.mockResolvedValue({
         id: 'config-id',

--- a/services/api-gateway/src/routes/admin/llm-config.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.ts
@@ -255,7 +255,7 @@ function createDeleteConfigHandler(service: LlmConfigService, prisma: PrismaClie
       () =>
         prisma.llmConfig.findUnique({
           where: { id: configId },
-          select: { id: true, name: true, isGlobal: true, isDefault: true },
+          select: { id: true, name: true, isGlobal: true, isDefault: true, isFreeDefault: true },
         }),
       { notFoundResource: CONFIG_RESOURCE, resourceLabel: CONFIG_LABEL, operation: 'delete' }
     );
@@ -267,6 +267,15 @@ function createDeleteConfigHandler(service: LlmConfigService, prisma: PrismaClie
       return sendError(
         res,
         ErrorResponses.validationError('Cannot delete the system default config')
+      );
+    }
+    // Same hard-block shape as isDefault: deleting the free-tier default
+    // would silently break LLM access for all guest users until an admin
+    // sets a new one. Force the admin to promote a replacement first.
+    if (config.isFreeDefault) {
+      return sendError(
+        res,
+        ErrorResponses.validationError('Cannot delete the free tier default config')
       );
     }
 

--- a/services/bot-client/src/utils/GatewayClient.ts
+++ b/services/bot-client/src/utils/GatewayClient.ts
@@ -327,14 +327,17 @@ export class GatewayClient {
    */
   async confirmDelivery(jobId: string): Promise<void> {
     try {
-      const response = await fetch(`${this.baseUrl}/ai/job/${jobId}/confirm-delivery`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': CONTENT_TYPES.JSON,
-          'X-Service-Auth': getValidatedServiceSecret(),
-        },
-        signal: AbortSignal.timeout(TIMEOUTS.GATEWAY_RPC),
-      });
+      const response = await fetch(
+        `${this.baseUrl}/ai/job/${encodeURIComponent(jobId)}/confirm-delivery`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': CONTENT_TYPES.JSON,
+            'X-Service-Auth': getValidatedServiceSecret(),
+          },
+          signal: AbortSignal.timeout(TIMEOUTS.GATEWAY_RPC),
+        }
+      );
 
       if (!response.ok) {
         const errorText = await response.text();
@@ -371,13 +374,16 @@ export class GatewayClient {
     }
 
     try {
-      const response = await fetch(`${this.baseUrl}/user/channel/${channelId}`, {
-        headers: {
-          'X-Service-Auth': getValidatedServiceSecret(),
-          // Note: No X-User-Id needed - this is a service-to-service lookup
-        },
-        signal: AbortSignal.timeout(TIMEOUTS.GATEWAY_RPC),
-      });
+      const response = await fetch(
+        `${this.baseUrl}/user/channel/${encodeURIComponent(channelId)}`,
+        {
+          headers: {
+            'X-Service-Auth': getValidatedServiceSecret(),
+            // Note: No X-User-Id needed - this is a service-to-service lookup
+          },
+          signal: AbortSignal.timeout(TIMEOUTS.GATEWAY_RPC),
+        }
+      );
 
       if (!response.ok) {
         logger.warn({ channelId, status: response.status }, 'Channel settings check failed');


### PR DESCRIPTION
## Summary

Two Medium-priority findings surfaced by claude-review on release PR #1079. Both are pre-existing bugs; fixing inline before the release merges to avoid shipping them to prod.

### Fixes

**1. \`admin/llm-config\` — add \`isFreeDefault\` guard to delete handler**

Mirrors the existing tts-config guard (\`tts-config.ts:278\`). Without it, an admin could silently delete the free-tier LLM default, breaking LLM access for guest users until manually replaced. Added a companion test asserting 400 + "free tier default" message.

**2. \`bot-client/GatewayClient\` — \`encodeURIComponent\` on dynamic URL segments**

Defense-in-depth per \`00-critical.md\` SSRF rule. Sibling endpoints in the same file already follow this pattern.

- \`confirmDelivery\`: \`jobId\` was bare in the URL
- \`getChannelSettings\`: \`channelId\` was bare in the URL

## Test plan

- [x] New test in \`admin/llm-config.test.ts\` covers the isFreeDefault delete guard
- [x] \`pnpm test\` — full repo green
- [x] \`pnpm quality\` — lint + cpd + depcruise + typecheck green
- [x] Verified all other dynamic URL segments in GatewayClient already use \`encodeURIComponent\` (no additional sites needing the same treatment)

## Release coordination

Once this merges, release PR #1079 will auto-update with these commits. The release notes should add a Bug Fixes line for "admin: free-tier default guard on LLM config delete" (the GatewayClient one is defense-in-depth, not user-visible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)