### PR TITLE
feat: layer 3 audit enforcement — baseline meta + drift detection

### DIFF
--- a/.github/baselines/cpd-baseline.json
+++ b/.github/baselines/cpd-baseline.json
@@ -1,11 +1,18 @@
 {
   "version": 1,
-  "lastUpdated": "2026-05-18T22:07:43.301Z",
-  "filteredLines": 1714,
+  "lastUpdated": "2026-05-23T02:58:20.258Z",
+  "filteredLines": 1718,
   "filteredCount": 106,
-  "rawDedupedLines": 1638,
-  "rawCount": 109,
+  "rawDedupedLines": 1657,
+  "rawCount": 110,
   "threshold": 0.8,
   "graceMargin": 10,
-  "notes": "Filtered = jscpd clones minus fragments where >=80% of classifiable lines are call-expression shape (i.e., helper-call-shape uniformity, not real duplication). See docs/reference/CPD_CAMPAIGN_AUDIT.md for the campaign close-out audit and the rationale for accepting structural-skeleton duplication as design intent. The ratchet enforces filteredLines + graceMargin; raw jscpd output stays informational. NOTE: filteredLines uses sum-of-per-clone-lines (counts overlap multiply); rawDedupedLines is jscpd's deduplicated count (each line counted once even if part of multiple clones). The two are not directly comparable — filtered may exceed rawDeduped on small clone sets due to the counting-method difference, not because the filter made things worse."
+  "notes": "Filtered = jscpd clones minus fragments where >=80% of classifiable lines are call-expression shape (i.e., helper-call-shape uniformity, not real duplication). See docs/reference/CPD_CAMPAIGN_AUDIT.md for the campaign close-out audit and the rationale for accepting structural-skeleton duplication as design intent. The ratchet enforces filteredLines + graceMargin; raw jscpd output stays informational. NOTE: filteredLines uses sum-of-per-clone-lines (counts overlap multiply); rawDedupedLines is jscpd's deduplicated count (each line counted once even if part of multiple clones). The two are not directly comparable — filtered may exceed rawDeduped on small clone sets due to the counting-method difference, not because the filter made things worse.",
+  "meta": {
+    "toolVersion": "cpd-check/1.0",
+    "configHash": "a7f4e5150567",
+    "nodeVersion": "v24.11.1",
+    "generatedFromSha": "5faa8f92bc4056b585a64ad8409ab0fb29df6942",
+    "generatedAt": "2026-05-23T02:58:20.257Z"
+  }
 }

--- a/.github/baselines/test-coverage-baseline.json
+++ b/.github/baselines/test-coverage-baseline.json
@@ -1,6 +1,6 @@
 {
-  "version": 8,
-  "lastUpdated": "2026-02-08T20:08:14.209Z",
+  "version": 9,
+  "lastUpdated": "2026-05-23T03:05:15.302Z",
   "services": {
     "detectedPrismaServices": [
       "packages/common-types/src/services/ConversationHistoryService.ts",
@@ -8,7 +8,8 @@
       "packages/common-types/src/services/ConversationSyncService.ts",
       "packages/common-types/src/services/UserService.ts",
       "services/ai-worker/src/services/LongTermMemoryService.ts",
-      "services/api-gateway/src/services/LlmConfigService.ts"
+      "services/api-gateway/src/services/LlmConfigService.ts",
+      "services/api-gateway/src/services/TtsConfigService.ts"
     ],
     "knownGaps": []
   },
@@ -18,5 +19,12 @@
   "notes": {
     "serviceExemptionCriteria": "Services are auto-detected for Prisma usage. Only services with Prisma calls need integration tests.",
     "contractExemptionCriteria": "None - all API schemas need contract tests"
+  },
+  "meta": {
+    "toolVersion": "test-audit/1.0",
+    "configHash": "eef9df4af3ea",
+    "nodeVersion": "v24.11.1",
+    "generatedFromSha": "5faa8f92bc4056b585a64ad8409ab0fb29df6942",
+    "generatedAt": "2026-05-23T03:05:15.302Z"
   }
 }

--- a/docs/proposals/backlog/periodic-audit-enforcement.md
+++ b/docs/proposals/backlog/periodic-audit-enforcement.md
@@ -136,7 +136,7 @@ Four follow-ups from the Layer 2 PR review land alongside Layer 3 — same absor
 
 #### Layer 3 ship status
 
-Shipped in [PR #TBD](https://github.com/lbds137/tzurot/pull/) targeting `develop`:
+Shipped in [PR #1084](https://github.com/lbds137/tzurot/pull/1084) targeting `develop`:
 
 - `audits/baseline-meta.ts` module: shared `BaselineMeta` type, `buildBaselineMeta()` (auto-populates node/git/timestamp), `checkMetaDrift()` (returns aligned/drift verdict), `hashConfigSlice()` (stable 12-char SHA-256 of measurement-affecting config slice)
 - CPD integration: new `FILTER_IMPL_VERSION` constant, `getCpdConfigFingerprint()`, drift hard-fail in `cpd:check`, meta-block write in `cpd:update-baseline`. Backfilled `.github/baselines/cpd-baseline.json`.

--- a/docs/proposals/backlog/periodic-audit-enforcement.md
+++ b/docs/proposals/backlog/periodic-audit-enforcement.md
@@ -100,7 +100,7 @@ Shipped in [PR #1083](https://github.com/lbds137/tzurot/pull/1083) targeting `de
 - Canary tests with deliberate-violation fixtures (valid + stub + non-existent path) asserting all three classification paths work
 - All 3 absorbed Layer-1 hardening items: `runEslint` `additionalIgnoreOverrides` API, single-segment slug hard-fail, non-summary path test for `checkProposalOrphans`
 
-### Layer 3 — Baseline meta blocks (anti-drift)
+### Layer 3 — Baseline meta blocks (anti-drift) (SHIPPED)
 
 Every baseline file (markdown, NOT JSON — see below) carries a metadata header:
 
@@ -121,6 +121,30 @@ generated-at: 2026-05-22T16:32:00Z
 - Baseline was committed against WIP code
 
 **Age-gate fires on config-hash mismatch, not just calendar days.** Without this, a 3-month-old baseline against a config bumped last week is reporting against a different reality than the code is running against.
+
+#### Absorbed Layer-2 hardening (surfaced by PR #1083 review)
+
+Four follow-ups from the Layer 2 PR review land alongside Layer 3 — same absorbing pattern. All touch the audit infrastructure Layer 3 builds on top of:
+
+1. **Rename `singleSegmentSlugs` → `singleSegmentProposals`** in `OrphanCheckResult`: field contained relative paths (not bare slugs), so the parallel-to-`orphans` shape is more accurate.
+
+2. **Lazy-quantifier comment in frontmatter strip regex**: `[\s\S]*?` errs toward false-pass (a stub might exceed the floor if a YAML scalar contained an embedded `---`); greedy would err toward false-fail (body horizontal rules would get stripped). Comment documents the tradeoff so a future reader doesn't optimize toward the wrong shape.
+
+3. **Case-insensitive flag on orphan-check word-boundary regex**: SCREAMING_SNAKE_CASE proposals mentioned in snake_case (or kebab-case proposals as Mixed-Kebab-Case) no longer silently flag as orphan. Multi-segment names are precise enough that the `i` flag doesn't introduce false negatives. Hyphen↔underscore separator differences remain unnormalized (separate concern).
+
+4. **Orphan-WHY.md detection (bidirectional check)**: `guard:audit-tool-docs` now walks `packages/tooling/src/**/*.WHY.md` and asserts each is either registered or on the new `UNREGISTERED_WHY_PATHS` allowlist. Catches the failure mode where a tool gets removed from the registry but its WHY.md is left behind — knip can't detect this (paths are data, not imports).
+
+#### Layer 3 ship status
+
+Shipped in [PR #TBD](https://github.com/lbds137/tzurot/pull/) targeting `develop`:
+
+- `audits/baseline-meta.ts` module: shared `BaselineMeta` type, `buildBaselineMeta()` (auto-populates node/git/timestamp), `checkMetaDrift()` (returns aligned/drift verdict), `hashConfigSlice()` (stable 12-char SHA-256 of measurement-affecting config slice)
+- CPD integration: new `FILTER_IMPL_VERSION` constant, `getCpdConfigFingerprint()`, drift hard-fail in `cpd:check`, meta-block write in `cpd:update-baseline`. Backfilled `.github/baselines/cpd-baseline.json`.
+- test:audit integration: new `TEST_AUDIT_IMPL_VERSION`, `getTestAuditConfigFingerprint()`, drift hard-fail in `auditUnified()`, meta-block write in `--update` path. Backfilled `.github/baselines/test-coverage-baseline.json`.
+- All 4 absorbed Layer-2 hardening items
+- Baselines stay JSON (Layer 4 markdown migration deferred — JSON+meta-block is enough to deliver the drift-detection invariant; markdown's diff-readability benefit is independent)
+
+**Design note: the meta block lives inside the existing JSON baseline** rather than as a sidecar file or markdown frontmatter. The proposal originally drafted Layer 4 (markdown migration) and Layer 3 as separate, but embedding meta in JSON gives the same drift-detection contract with a smaller diff and no file-format migration. Layer 4 can still happen if the diff-readability problem becomes acute.
 
 ### Layer 4 — Markdown baselines (not JSON)
 

--- a/packages/tooling/src/audits/audit-tool-registry.ts
+++ b/packages/tooling/src/audits/audit-tool-registry.ts
@@ -105,10 +105,25 @@ export const AUDIT_TOOL_REGISTRY: readonly AuditToolEntry[] = [
   },
   // NOTE: `memory:analyze` is intentionally NOT in the registry. It's a
   // one-shot remediation tool for the retry-loop-bug cleanup, not a
-  // periodic audit. Its WHY.md at
-  // `packages/tooling/src/memory/cleanup-duplicates.WHY.md` still exists
-  // as operator documentation, but the guard:audit-tool-docs check
-  // doesn't enforce it because it doesn't meet the audit-class criteria
-  // ("runs periodically with a threshold"). If memory:analyze gains an
-  // ongoing periodic use case, re-add it here.
+  // periodic audit. Its WHY.md still exists as operator documentation
+  // but doesn't meet the audit-class criteria ("runs periodically with
+  // a threshold"). If memory:analyze gains an ongoing periodic use case,
+  // re-add it here. The WHY.md path is on the UNREGISTERED_WHY_PATHS
+  // allowlist below so the orphan-WHY sweep doesn't flag it.
+];
+
+/**
+ * WHY.md paths that intentionally do NOT correspond to a registered audit
+ * tool. The orphan-WHY sweep in `checkAuditToolDocsFromRegistry` walks
+ * `packages/tooling/src/**\/*.WHY.md` and asserts each path either
+ * matches a registry entry OR appears here.
+ *
+ * Entries document why a WHY.md exists outside the registry — typically
+ * operator-tool documentation that doesn't meet audit-class criteria but
+ * is still worth preserving as decay-zone context.
+ */
+export const UNREGISTERED_WHY_PATHS: readonly string[] = [
+  // Documents `memory:analyze`, intentionally not registered (one-shot
+  // remediation tool, not a periodic audit).
+  'packages/tooling/src/memory/cleanup-duplicates.WHY.md',
 ];

--- a/packages/tooling/src/audits/baseline-meta.test.ts
+++ b/packages/tooling/src/audits/baseline-meta.test.ts
@@ -64,33 +64,33 @@ describe('checkMetaDrift', () => {
 });
 
 describe('hashConfigSlice', () => {
-  it('produces a stable 12-char hex hash for the same input', async () => {
+  it('produces a stable 12-char hex hash for the same input', () => {
     const input = { threshold: 0.8, version: 1 };
-    const hash1 = await hashConfigSlice(input);
-    const hash2 = await hashConfigSlice(input);
+    const hash1 = hashConfigSlice(input);
+    const hash2 = hashConfigSlice(input);
     expect(hash1).toBe(hash2);
     expect(hash1).toMatch(/^[a-f0-9]{12}$/);
   });
 
-  it('produces different hashes for different inputs', async () => {
-    const hash1 = await hashConfigSlice({ threshold: 0.8 });
-    const hash2 = await hashConfigSlice({ threshold: 0.7 });
+  it('produces different hashes for different inputs', () => {
+    const hash1 = hashConfigSlice({ threshold: 0.8 });
+    const hash2 = hashConfigSlice({ threshold: 0.7 });
     expect(hash1).not.toBe(hash2);
   });
 
-  it('is sensitive to key order (JSON.stringify is order-dependent)', async () => {
+  it('is sensitive to key order (JSON.stringify is order-dependent)', () => {
     // Documenting the contract: hashConfigSlice does NOT canonicalize
     // key order. Callers should construct config slices with stable
     // key order (object literals in source files have stable order
     // in modern JS engines, so this is usually fine).
-    const a = await hashConfigSlice({ a: 1, b: 2 });
-    const b = await hashConfigSlice({ b: 2, a: 1 });
+    const a = hashConfigSlice({ a: 1, b: 2 });
+    const b = hashConfigSlice({ b: 2, a: 1 });
     expect(a).not.toBe(b);
   });
 
-  it('handles primitive inputs', async () => {
-    expect(await hashConfigSlice('hello')).toMatch(/^[a-f0-9]{12}$/);
-    expect(await hashConfigSlice(42)).toMatch(/^[a-f0-9]{12}$/);
-    expect(await hashConfigSlice(null)).toMatch(/^[a-f0-9]{12}$/);
+  it('handles primitive inputs', () => {
+    expect(hashConfigSlice('hello')).toMatch(/^[a-f0-9]{12}$/);
+    expect(hashConfigSlice(42)).toMatch(/^[a-f0-9]{12}$/);
+    expect(hashConfigSlice(null)).toMatch(/^[a-f0-9]{12}$/);
   });
 });

--- a/packages/tooling/src/audits/baseline-meta.test.ts
+++ b/packages/tooling/src/audits/baseline-meta.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for the baseline metadata helpers.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildBaselineMeta,
+  checkMetaDrift,
+  hashConfigSlice,
+  type BaselineMeta,
+} from './baseline-meta.js';
+
+describe('buildBaselineMeta', () => {
+  it('returns a populated meta block', () => {
+    const meta = buildBaselineMeta('1.0.0', 'abc123def456');
+    expect(meta.toolVersion).toBe('1.0.0');
+    expect(meta.configHash).toBe('abc123def456');
+    expect(meta.nodeVersion).toBe(process.version);
+    expect(meta.generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    // generatedFromSha is either a real SHA (40 hex chars) or 'unknown'
+    // (when git is unavailable / tree isn't a repo).
+    expect(meta.generatedFromSha).toMatch(/^([a-f0-9]{40}|unknown)$/);
+  });
+
+  it('generatedAt is ISO-8601 and represents now', () => {
+    const before = Date.now();
+    const meta = buildBaselineMeta('1.0.0', 'hash');
+    const after = Date.now();
+    const captured = new Date(meta.generatedAt).getTime();
+    expect(captured).toBeGreaterThanOrEqual(before);
+    expect(captured).toBeLessThanOrEqual(after);
+  });
+});
+
+describe('checkMetaDrift', () => {
+  const validMeta: BaselineMeta = {
+    toolVersion: '1.0.0',
+    configHash: 'abc123',
+    nodeVersion: 'v25.3.0',
+    generatedFromSha: 'deadbeef',
+    generatedAt: '2026-05-22T00:00:00Z',
+  };
+
+  it('returns aligned when configHash matches', () => {
+    const result = checkMetaDrift(validMeta, 'abc123');
+    expect(result.aligned).toBe(true);
+  });
+
+  it('returns drift when configHash differs', () => {
+    const result = checkMetaDrift(validMeta, 'xyz789');
+    expect(result.aligned).toBe(false);
+    expect(result.detail).toContain('configHash drift');
+    expect(result.detail).toContain('abc123');
+    expect(result.detail).toContain('xyz789');
+  });
+
+  it('treats missing stored meta as drift (migration path)', () => {
+    // Pre-Layer-3 baselines without meta blocks fail the gate, forcing
+    // the operator to capture metadata via `*:update-baseline`.
+    const result = checkMetaDrift(undefined, 'abc123');
+    expect(result.aligned).toBe(false);
+    expect(result.detail).toContain('no meta block');
+  });
+});
+
+describe('hashConfigSlice', () => {
+  it('produces a stable 12-char hex hash for the same input', async () => {
+    const input = { threshold: 0.8, version: 1 };
+    const hash1 = await hashConfigSlice(input);
+    const hash2 = await hashConfigSlice(input);
+    expect(hash1).toBe(hash2);
+    expect(hash1).toMatch(/^[a-f0-9]{12}$/);
+  });
+
+  it('produces different hashes for different inputs', async () => {
+    const hash1 = await hashConfigSlice({ threshold: 0.8 });
+    const hash2 = await hashConfigSlice({ threshold: 0.7 });
+    expect(hash1).not.toBe(hash2);
+  });
+
+  it('is sensitive to key order (JSON.stringify is order-dependent)', async () => {
+    // Documenting the contract: hashConfigSlice does NOT canonicalize
+    // key order. Callers should construct config slices with stable
+    // key order (object literals in source files have stable order
+    // in modern JS engines, so this is usually fine).
+    const a = await hashConfigSlice({ a: 1, b: 2 });
+    const b = await hashConfigSlice({ b: 2, a: 1 });
+    expect(a).not.toBe(b);
+  });
+
+  it('handles primitive inputs', async () => {
+    expect(await hashConfigSlice('hello')).toMatch(/^[a-f0-9]{12}$/);
+    expect(await hashConfigSlice(42)).toMatch(/^[a-f0-9]{12}$/);
+    expect(await hashConfigSlice(null)).toMatch(/^[a-f0-9]{12}$/);
+  });
+});

--- a/packages/tooling/src/audits/baseline-meta.ts
+++ b/packages/tooling/src/audits/baseline-meta.ts
@@ -108,9 +108,10 @@ export function checkMetaDrift(
  * **Key order matters.** `JSON.stringify` is order-dependent, so
  * `{ a: 1, b: 2 }` and `{ b: 2, a: 1 }` hash differently. Callers
  * should construct the slice as a stable-order object literal in
- * source (V8 preserves insertion order for non-integer keys). Don't
- * spread from a dynamically-assembled config object without
- * canonicalizing key order first.
+ * source (V8 preserves insertion order for non-integer keys). If
+ * assembling dynamically (e.g., spreading from a loaded config),
+ * sort keys explicitly before passing — `Object.fromEntries(Object.entries(x).sort())`
+ * is the simplest canonicalization.
  *
  * Each tool defines its own `getConfigFingerprint()` returning the slice;
  * this helper hashes the result. The fingerprint is what each tool

--- a/packages/tooling/src/audits/baseline-meta.ts
+++ b/packages/tooling/src/audits/baseline-meta.ts
@@ -1,0 +1,126 @@
+/**
+ * Baseline Metadata
+ *
+ * Layer 3 of the periodic-audit-enforcement proposal: every audit baseline
+ * file carries a `meta` block with the context that produced it. The two
+ * fields that matter for drift detection are `configHash` (catches "tool
+ * config changed since this baseline was captured") and `generatedFromSha`
+ * (the git commit the baseline reflects).
+ *
+ * The other fields (`toolVersion`, `nodeVersion`, `generatedAt`) are
+ * observability — they don't gate behavior, but they make it possible to
+ * answer "when was this baseline last refreshed?" without git archaeology.
+ *
+ * **Why this exists**: baselines go stale not just because the codebase
+ * changed but because the *tool measuring it* changed. If `cpd:check`'s
+ * threshold drops from 0.8 to 0.7, the existing baseline's filteredLines
+ * count was computed under the old threshold — it's no longer a valid
+ * floor for the new measurement. Without `configHash`, a 3-month-old
+ * baseline against a config bumped last week reports against a different
+ * reality than the code is running against. Calendar-age checks alone
+ * can't catch this (the config change was last week, but only the
+ * baseline FILE looks stale; the actual drift is in the tool config).
+ */
+
+import { execFileSync } from 'node:child_process';
+
+export interface BaselineMeta {
+  /** Tool-internal version string (semver or hash). Convention: the package.json version, or a hash of the tool's source if it's evolving fast. */
+  toolVersion: string;
+  /**
+   * Hash of tool-relevant config (e.g., ESLint rule thresholds for
+   * complexity-report, the post-filter heuristic for CPD). Drift gate.
+   * When this mismatches the baseline's stored value, the baseline
+   * was captured under different rules and can no longer be trusted
+   * as a ratchet floor.
+   */
+  configHash: string;
+  /** Node version the tool ran under at baseline-capture time. */
+  nodeVersion: string;
+  /** Git SHA the baseline was captured against. */
+  generatedFromSha: string;
+  /** ISO-8601 timestamp of when the baseline was captured. */
+  generatedAt: string;
+}
+
+/**
+ * Build a `BaselineMeta` block. Fills in `nodeVersion`, `generatedFromSha`,
+ * and `generatedAt` automatically; the caller supplies the tool-specific
+ * `toolVersion` and `configHash`.
+ *
+ * `generatedFromSha` falls back to `'unknown'` if git is unavailable or
+ * the working tree isn't a repo — the metadata block is still useful
+ * for the other fields. Don't throw on git absence.
+ */
+export function buildBaselineMeta(toolVersion: string, configHash: string): BaselineMeta {
+  return {
+    toolVersion,
+    configHash,
+    nodeVersion: process.version,
+    generatedFromSha: getGitSha(),
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Returns the result of comparing a stored baseline meta against the
+ * current environment's expected meta. `aligned: true` when configHash
+ * matches; `aligned: false` indicates drift the caller should hard-fail
+ * on (per the Layer 3 design — failure mode is "fail with a clear
+ * error message, force operator to explicitly refresh").
+ */
+export interface MetaDriftCheck {
+  aligned: boolean;
+  /** Human-readable summary of the drift, suitable for CLI output. */
+  detail: string;
+}
+
+export function checkMetaDrift(
+  stored: BaselineMeta | undefined,
+  currentConfigHash: string
+): MetaDriftCheck {
+  if (stored === undefined) {
+    // No prior meta — treat as drift so operator is forced to capture
+    // a baseline with metadata. This is the migration path from
+    // pre-Layer-3 baselines.
+    return {
+      aligned: false,
+      detail: 'baseline has no meta block; refresh to capture metadata',
+    };
+  }
+  if (stored.configHash !== currentConfigHash) {
+    return {
+      aligned: false,
+      detail: `configHash drift: baseline=${stored.configHash} current=${currentConfigHash}`,
+    };
+  }
+  return { aligned: true, detail: 'configHash matches' };
+}
+
+/**
+ * Stable hash of a config slice. SHA-256 of the JSON-serialized input,
+ * truncated to 12 hex chars for readability. The slice should contain
+ * ONLY the inputs that affect measurement — versioning, thresholds,
+ * rule lists. Excluding non-measurement noise (file paths, timestamps)
+ * keeps the hash from churning on unrelated changes.
+ *
+ * Each tool defines its own `getConfigFingerprint()` returning the slice;
+ * this helper hashes the result. The fingerprint is what each tool
+ * commits to as its config-stability contract.
+ */
+export async function hashConfigSlice(slice: unknown): Promise<string> {
+  const { createHash } = await import('node:crypto');
+  const serialized = JSON.stringify(slice);
+  return createHash('sha256').update(serialized).digest('hex').slice(0, 12);
+}
+
+function getGitSha(): string {
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return 'unknown';
+  }
+}

--- a/packages/tooling/src/audits/baseline-meta.ts
+++ b/packages/tooling/src/audits/baseline-meta.ts
@@ -105,6 +105,13 @@ export function checkMetaDrift(
  * rule lists. Excluding non-measurement noise (file paths, timestamps)
  * keeps the hash from churning on unrelated changes.
  *
+ * **Key order matters.** `JSON.stringify` is order-dependent, so
+ * `{ a: 1, b: 2 }` and `{ b: 2, a: 1 }` hash differently. Callers
+ * should construct the slice as a stable-order object literal in
+ * source (V8 preserves insertion order for non-integer keys). Don't
+ * spread from a dynamically-assembled config object without
+ * canonicalizing key order first.
+ *
  * Each tool defines its own `getConfigFingerprint()` returning the slice;
  * this helper hashes the result. The fingerprint is what each tool
  * commits to as its config-stability contract.

--- a/packages/tooling/src/audits/baseline-meta.ts
+++ b/packages/tooling/src/audits/baseline-meta.ts
@@ -23,6 +23,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 
 export interface BaselineMeta {
   /** Tool-internal version string (semver or hash). Convention: the package.json version, or a hash of the tool's source if it's evolving fast. */
@@ -108,8 +109,7 @@ export function checkMetaDrift(
  * this helper hashes the result. The fingerprint is what each tool
  * commits to as its config-stability contract.
  */
-export async function hashConfigSlice(slice: unknown): Promise<string> {
-  const { createHash } = await import('node:crypto');
+export function hashConfigSlice(slice: unknown): string {
   const serialized = JSON.stringify(slice);
   return createHash('sha256').update(serialized).digest('hex').slice(0, 12);
 }

--- a/packages/tooling/src/audits/check-audit-tool-docs.test.ts
+++ b/packages/tooling/src/audits/check-audit-tool-docs.test.ts
@@ -212,6 +212,79 @@ description: padding padding padding padding padding padding padding padding pad
       expect(result.stubs[0].command).toBe('tool-b');
     });
   });
+
+  it('flags a WHY.md file with no registry entry as orphan', async () => {
+    // Bidirectional check: a WHY.md sitting in the tooling tree that
+    // isn't registered AND isn't on the allowlist should be flagged.
+    await withTempRepo(root => {
+      const registry: AuditToolEntry[] = [
+        { command: 'tool-a', whyPath: 'src/a.WHY.md', description: 'Tool A' },
+      ];
+      scaffold(root, {
+        'src/a.WHY.md': SUBSTANTIAL_WHY_CONTENT,
+        'src/stale.WHY.md': SUBSTANTIAL_WHY_CONTENT, // orphan — no registry entry
+      });
+      const result = checkAuditToolDocsFromRegistry(root, registry, 'src', []);
+      expect(result.orphanWhyFiles).toHaveLength(1);
+      expect(result.orphanWhyFiles[0]).toBe('src/stale.WHY.md');
+      expect(result.missing).toEqual([]);
+      expect(result.stubs).toEqual([]);
+    });
+  });
+
+  it('does NOT flag a WHY.md on the unregistered-allowlist', async () => {
+    await withTempRepo(root => {
+      const registry: AuditToolEntry[] = [
+        { command: 'tool-a', whyPath: 'src/a.WHY.md', description: 'Tool A' },
+      ];
+      scaffold(root, {
+        'src/a.WHY.md': SUBSTANTIAL_WHY_CONTENT,
+        'src/operator-tool.WHY.md': SUBSTANTIAL_WHY_CONTENT, // unregistered but allowlisted
+      });
+      const result = checkAuditToolDocsFromRegistry(root, registry, 'src', [
+        'src/operator-tool.WHY.md',
+      ]);
+      expect(result.orphanWhyFiles).toEqual([]);
+    });
+  });
+
+  it('walks nested subdirectories for orphan WHY.md files', async () => {
+    await withTempRepo(root => {
+      const registry: AuditToolEntry[] = [];
+      scaffold(root, {
+        'src/lint/complexity-report.WHY.md': SUBSTANTIAL_WHY_CONTENT,
+        'src/db/check-safety.WHY.md': SUBSTANTIAL_WHY_CONTENT,
+        'src/audits/some-tool.WHY.md': SUBSTANTIAL_WHY_CONTENT,
+      });
+      const result = checkAuditToolDocsFromRegistry(root, registry, 'src', []);
+      expect(result.orphanWhyFiles).toHaveLength(3);
+    });
+  });
+
+  it('recognizes both `<basename>.WHY.md` and bare `WHY.md` shapes', async () => {
+    // Some audit tools use `<basename>.WHY.md` next to a single source file;
+    // others use a directory-level `WHY.md` covering a module. Both should
+    // be detected by the sweep.
+    await withTempRepo(root => {
+      const registry: AuditToolEntry[] = [];
+      scaffold(root, {
+        'src/foo/bar.WHY.md': SUBSTANTIAL_WHY_CONTENT,
+        'src/baz/WHY.md': SUBSTANTIAL_WHY_CONTENT,
+      });
+      const result = checkAuditToolDocsFromRegistry(root, registry, 'src', []);
+      expect(result.orphanWhyFiles).toHaveLength(2);
+    });
+  });
+
+  it('returns empty orphan list when the search root does not exist', async () => {
+    // Production calls against test fixtures may pass a nonexistent root;
+    // the walker should handle this gracefully (not throw).
+    await withTempRepo(root => {
+      const registry: AuditToolEntry[] = [];
+      const result = checkAuditToolDocsFromRegistry(root, registry, 'nonexistent', []);
+      expect(result.orphanWhyFiles).toEqual([]);
+    });
+  });
 });
 
 describe('checkAuditToolDocs (CLI entry point with --summary)', () => {

--- a/packages/tooling/src/audits/check-audit-tool-docs.ts
+++ b/packages/tooling/src/audits/check-audit-tool-docs.ts
@@ -18,10 +18,14 @@
  * `MIN_WHY_CONTENT_CHARS` below.
  */
 
-import { readFileSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import { readFileSync, readdirSync, statSync, lstatSync } from 'node:fs';
+import { join, relative } from 'node:path';
 import { emitSummary } from './summary.js';
-import { AUDIT_TOOL_REGISTRY, type AuditToolEntry } from './audit-tool-registry.js';
+import {
+  AUDIT_TOOL_REGISTRY,
+  UNREGISTERED_WHY_PATHS,
+  type AuditToolEntry,
+} from './audit-tool-registry.js';
 
 export interface AuditToolDocsCheckResult {
   totalTools: number;
@@ -29,7 +33,23 @@ export interface AuditToolDocsCheckResult {
   missing: { command: string; whyPath: string }[];
   /** Tools whose WHY.md exists but is below the content threshold. */
   stubs: { command: string; whyPath: string; chars: number }[];
+  /**
+   * WHY.md files found in the tooling tree that don't correspond to any
+   * registered audit tool AND aren't on the `UNREGISTERED_WHY_PATHS`
+   * allowlist. The bidirectional check (Layer 3): every registered tool
+   * must have a WHY.md AND every WHY.md must be either registered or
+   * explicitly allowlisted.
+   */
+  orphanWhyFiles: string[];
 }
+
+/**
+ * Where the bidirectional check scans for WHY.md files. Repo-relative.
+ * Scoped to the tooling package because that's where audit tools live;
+ * a future expansion could broaden this (e.g., to `services/`) if WHY.md
+ * adoption spreads.
+ */
+const WHY_SEARCH_ROOT = 'packages/tooling/src';
 
 /**
  * Minimum-content threshold for a WHY.md to count as "real" documentation.
@@ -43,13 +63,56 @@ export interface AuditToolDocsCheckResult {
 const MIN_WHY_CONTENT_CHARS = 200;
 
 /**
+ * Recursively walk `dir` and return relative paths of every WHY.md file
+ * (basenames ending in `.WHY.md` OR a literal `WHY.md` inside a module
+ * directory). `lstatSync` so symlinks don't cycle; symlinked WHY.md
+ * files are excluded — use a regular file copy if a WHY.md needs to
+ * appear in two locations.
+ */
+function findWhyFiles(repoRoot: string, dir: string): string[] {
+  const results: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    let stat;
+    try {
+      stat = lstatSync(full);
+    } catch {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      results.push(...findWhyFiles(repoRoot, full));
+    } else if (stat.isFile() && (entry.endsWith('.WHY.md') || entry === 'WHY.md')) {
+      results.push(relative(repoRoot, full));
+    }
+  }
+  return results;
+}
+
+/**
  * Pure check function. Reads each registered tool's WHY.md and classifies
- * it as missing / stub / ok. No stdout writes; no process.exit. Exported
- * for testing.
+ * it as missing / stub / ok. Also walks the tooling tree for WHY.md files
+ * with no registry entry (bidirectional check). No stdout writes; no
+ * process.exit. Exported for testing.
+ *
+ * @param whySearchRoot Override the WHY.md walk root. Canary tests use
+ *   a fixture path to scope the orphan sweep to deliberate fixtures.
+ *   Production callers should omit (defaults to `packages/tooling/src`).
+ * @param unregisteredWhyPaths Override the allowlist of WHY.md paths that
+ *   are intentionally not registered. Canary tests pass an empty array
+ *   so the sweep doesn't false-pass on legitimate unregistered files.
+ *   Production callers should omit (defaults to `UNREGISTERED_WHY_PATHS`).
  */
 export function checkAuditToolDocsFromRegistry(
   repoRoot: string,
-  registry: readonly AuditToolEntry[] = AUDIT_TOOL_REGISTRY
+  registry: readonly AuditToolEntry[] = AUDIT_TOOL_REGISTRY,
+  whySearchRoot: string = WHY_SEARCH_ROOT,
+  unregisteredWhyPaths: readonly string[] = UNREGISTERED_WHY_PATHS
 ): AuditToolDocsCheckResult {
   const missing: AuditToolDocsCheckResult['missing'] = [];
   const stubs: AuditToolDocsCheckResult['stubs'] = [];
@@ -83,6 +146,18 @@ export function checkAuditToolDocsFromRegistry(
     // measuring content. Frontmatter is metadata; the test of "is this a
     // real WHY.md?" is whether the body has substance.
     //
+    // The `[\s\S]*?` is intentionally lazy (rather than greedy). The
+    // failure mode of a lazy match is a *false pass* — if a YAML scalar
+    // happened to contain an embedded `---` line, the regex would treat
+    // it as the closing fence and the post-fence content would count
+    // toward the threshold (more bytes survive the strip → a stub might
+    // exceed the floor). The failure mode of a greedy match would be a
+    // *false fail* — if a WHY.md body contained `---` (e.g., a horizontal
+    // rule), the regex would strip past it and undercount the body.
+    // The current WHY.md format doesn't use YAML block scalars or body
+    // horizontal rules, so neither shape bites today; the lazy choice
+    // errs toward "let unusual files pass" rather than "fail surprisingly."
+    //
     // The trailing `[^\n]*(?:\r?\n|$)` handles three shapes:
     // - normal: closing `---` followed by `\r?\n` and a body line
     // - end-of-file: closing `---` is the last line, no trailing newline
@@ -103,7 +178,18 @@ export function checkAuditToolDocsFromRegistry(
     }
   }
 
-  return { totalTools: registry.length, missing, stubs };
+  // Bidirectional check: walk the tooling tree for WHY.md files that
+  // aren't registered AND aren't on the allowlist. Catches the failure
+  // mode where a tool gets removed from the registry but its WHY.md
+  // stays behind — knip can't detect this (paths are data, not imports).
+  const registeredPaths = new Set(registry.map(e => e.whyPath));
+  const allowlistedPaths = new Set(unregisteredWhyPaths);
+  const allWhyFiles = findWhyFiles(repoRoot, join(repoRoot, whySearchRoot));
+  const orphanWhyFiles = allWhyFiles.filter(
+    path => !registeredPaths.has(path) && !allowlistedPaths.has(path)
+  );
+
+  return { totalTools: registry.length, missing, stubs, orphanWhyFiles };
 }
 
 export interface CheckAuditToolDocsOptions {
@@ -120,6 +206,20 @@ export interface CheckAuditToolDocsOptions {
    * real registry. Production callers should omit.
    */
   registry?: readonly AuditToolEntry[];
+  /**
+   * @internal Canary-test seam.
+   *
+   * Override the WHY.md search root for the bidirectional orphan sweep.
+   * Production callers should omit (defaults to `packages/tooling/src`).
+   */
+  whySearchRoot?: string;
+  /**
+   * @internal Canary-test seam.
+   *
+   * Override the allowlist of intentionally-unregistered WHY.md paths.
+   * Production callers should omit (defaults to `UNREGISTERED_WHY_PATHS`).
+   */
+  unregisteredWhyPaths?: readonly string[];
 }
 
 /**
@@ -131,8 +231,13 @@ export interface CheckAuditToolDocsOptions {
  */
 export async function checkAuditToolDocs(options: CheckAuditToolDocsOptions = {}): Promise<void> {
   const repoRoot = options.repoRoot ?? process.cwd();
-  const { totalTools, missing, stubs } = checkAuditToolDocsFromRegistry(repoRoot, options.registry);
-  const totalFindings = missing.length + stubs.length;
+  const { totalTools, missing, stubs, orphanWhyFiles } = checkAuditToolDocsFromRegistry(
+    repoRoot,
+    options.registry,
+    options.whySearchRoot,
+    options.unregisteredWhyPaths
+  );
+  const totalFindings = missing.length + stubs.length + orphanWhyFiles.length;
 
   if (options.summary) {
     emitSummary({
@@ -150,7 +255,8 @@ export async function checkAuditToolDocs(options: CheckAuditToolDocsOptions = {}
   console.log(`\n🔍 Checking ${totalTools} audit tools for WHY.md docs...\n`);
 
   if (totalFindings === 0) {
-    console.log(`✅ All ${totalTools} audit tools have non-stub WHY.md files.\n`);
+    console.log(`✅ All ${totalTools} audit tools have non-stub WHY.md files.`);
+    console.log(`   No orphan WHY.md files in the tooling tree.\n`);
     return;
   }
 
@@ -172,16 +278,28 @@ export async function checkAuditToolDocs(options: CheckAuditToolDocsOptions = {}
     console.log();
   }
 
+  if (orphanWhyFiles.length > 0) {
+    console.log(`❌ Found ${orphanWhyFiles.length} orphan WHY.md file(s) (no registry entry):\n`);
+    for (const path of orphanWhyFiles) {
+      console.log(`   ${path}`);
+    }
+    console.log();
+  }
+
   console.log(`Every audit tool listed in \`AUDIT_TOOL_REGISTRY\` must have a non-stub
-WHY.md at its registered path. The WHY.md is the decay-zone prompt for
-when a Layer-5 cron reminder fires and the operator has to decide whether
-to keep or delete the tool. An empty or stub file defeats that purpose.
+WHY.md at its registered path. AND every WHY.md file in the tooling tree
+must either correspond to a registered audit tool OR appear in the
+\`UNREGISTERED_WHY_PATHS\` allowlist (for operator-tool docs that
+intentionally aren't audit-class).
 
 Fix one of:
   - Write the WHY.md following the template in
     \`docs/proposals/backlog/periodic-audit-enforcement.md\` Layer 2
   - Remove the tool from \`AUDIT_TOOL_REGISTRY\` if it's been deleted
-  - Move the file if you changed its location (and update the registry entry)
+  - Delete the orphan WHY.md if its audit tool no longer exists
+  - Add the WHY.md to \`UNREGISTERED_WHY_PATHS\` if it's intentionally
+    not an audit tool (e.g., operator-tool documentation)
+  - Move the file if you changed its location (and update the registry)
 `);
   process.exit(1);
 }

--- a/packages/tooling/src/audits/check-audit-tool-docs.ts
+++ b/packages/tooling/src/audits/check-audit-tool-docs.ts
@@ -18,7 +18,7 @@
  * `MIN_WHY_CONTENT_CHARS` below.
  */
 
-import { readFileSync, readdirSync, statSync, lstatSync } from 'node:fs';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { emitSummary } from './summary.js';
 import {
@@ -65,29 +65,25 @@ const MIN_WHY_CONTENT_CHARS = 200;
 /**
  * Recursively walk `dir` and return relative paths of every WHY.md file
  * (basenames ending in `.WHY.md` OR a literal `WHY.md` inside a module
- * directory). `lstatSync` so symlinks don't cycle; symlinked WHY.md
- * files are excluded — use a regular file copy if a WHY.md needs to
- * appear in two locations.
+ * directory). Uses `withFileTypes: true` for the Dirent's own
+ * `isDirectory()` / `isFile()` predicates — no separate `lstatSync`
+ * per entry. Dirent does NOT follow symlinks, so symlink cycles are
+ * impossible and symlinked WHY.md files are excluded — use a regular
+ * file copy if a WHY.md needs to appear in two locations.
  */
 function findWhyFiles(repoRoot: string, dir: string): string[] {
   const results: string[] = [];
-  let entries: string[];
+  let entries;
   try {
-    entries = readdirSync(dir);
+    entries = readdirSync(dir, { withFileTypes: true });
   } catch {
     return [];
   }
   for (const entry of entries) {
-    const full = join(dir, entry);
-    let stat;
-    try {
-      stat = lstatSync(full);
-    } catch {
-      continue;
-    }
-    if (stat.isDirectory()) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
       results.push(...findWhyFiles(repoRoot, full));
-    } else if (stat.isFile() && (entry.endsWith('.WHY.md') || entry === 'WHY.md')) {
+    } else if (entry.isFile() && (entry.name.endsWith('.WHY.md') || entry.name === 'WHY.md')) {
       results.push(relative(repoRoot, full));
     }
   }

--- a/packages/tooling/src/audits/check-proposal-orphans.test.ts
+++ b/packages/tooling/src/audits/check-proposal-orphans.test.ts
@@ -64,7 +64,7 @@ describe('findProposalOrphans', () => {
       const result = findProposalOrphans(root);
       expect(result.totalProposals).toBe(2);
       expect(result.orphans).toEqual([]);
-      expect(result.singleSegmentSlugs).toEqual([]);
+      expect(result.singleSegmentProposals).toEqual([]);
     });
   });
 
@@ -149,12 +149,39 @@ describe('findProposalOrphans', () => {
     });
   });
 
+  it('matches inbound links case-insensitively (same-separator case variation)', async () => {
+    // SCREAMING_SNAKE_CASE proposals linked as snake_case (or kebab as
+    // Mixed-Kebab-Case) should not silently flag as orphan. Multi-segment
+    // names are precise enough that the `i` flag doesn't introduce false
+    // negatives. Note: this only normalizes letter case — hyphen↔underscore
+    // separator differences are NOT normalized (a separate concern).
+    await withTempRepo(root => {
+      scaffold(root, {
+        'docs/proposals/backlog/GIT_HOOK_IMPROVEMENTS.md': '# Git hook improvements',
+        'backlog/future-themes.md': 'See git_hook_improvements (lowercased).',
+      });
+      const result = findProposalOrphans(root);
+      expect(result.orphans).toEqual([]);
+    });
+  });
+
+  it('matches a kebab-case proposal linked as Mixed-Kebab-Case', async () => {
+    await withTempRepo(root => {
+      scaffold(root, {
+        'docs/proposals/backlog/memory-redesign-plan.md': '# Memory',
+        'backlog/future-themes.md': 'See Memory-Redesign-Plan in the queue.',
+      });
+      const result = findProposalOrphans(root);
+      expect(result.orphans).toEqual([]);
+    });
+  });
+
   it('handles missing proposals directory gracefully', async () => {
     await withTempRepo(root => {
       const result = findProposalOrphans(root);
       expect(result.totalProposals).toBe(0);
       expect(result.orphans).toEqual([]);
-      expect(result.singleSegmentSlugs).toEqual([]);
+      expect(result.singleSegmentProposals).toEqual([]);
     });
   });
 
@@ -183,9 +210,9 @@ describe('findProposalOrphans', () => {
       });
       const result = findProposalOrphans(root);
       expect(result.totalProposals).toBe(3);
-      expect(result.singleSegmentSlugs).toHaveLength(2);
-      expect(result.singleSegmentSlugs.some(s => s.includes('memory.md'))).toBe(true);
-      expect(result.singleSegmentSlugs.some(s => s.includes('api.md'))).toBe(true);
+      expect(result.singleSegmentProposals).toHaveLength(2);
+      expect(result.singleSegmentProposals.some(s => s.includes('memory.md'))).toBe(true);
+      expect(result.singleSegmentProposals.some(s => s.includes('api.md'))).toBe(true);
       // valid-name had an inbound link → no orphan, and not a single-segment slug
       expect(result.orphans).toEqual([]);
     });
@@ -201,7 +228,7 @@ describe('findProposalOrphans', () => {
           'See [memory](../docs/proposals/backlog/memory.md) in the queue.',
       });
       const result = findProposalOrphans(root);
-      expect(result.singleSegmentSlugs).toHaveLength(1);
+      expect(result.singleSegmentProposals).toHaveLength(1);
       expect(result.orphans).toEqual([]);
     });
   });
@@ -268,7 +295,7 @@ describe('checkProposalOrphans (CLI entry point with --summary)', () => {
   });
 
   it('summary findings count includes single-segment slugs', async () => {
-    // findings = orphans.length + singleSegmentSlugs.length, so a repo
+    // findings = orphans.length + singleSegmentProposals.length, so a repo
     // with one orphan AND one bad slug reports findings=2.
     await withTempRepo(async root => {
       scaffold(root, {
@@ -370,8 +397,8 @@ describe('findProposalOrphans (against real repo)', () => {
         `or CURRENT.md — or delete them if the work shipped.`
     ).toEqual([]);
     expect(
-      result.singleSegmentSlugs,
-      `Found single-segment proposal slugs: ${result.singleSegmentSlugs.join(', ')}. ` +
+      result.singleSegmentProposals,
+      `Found single-segment proposal slugs: ${result.singleSegmentProposals.join(', ')}. ` +
         `Rename to multi-segment kebab-case (e.g., memory.md → memory-and-context-redesign.md).`
     ).toEqual([]);
   });

--- a/packages/tooling/src/audits/check-proposal-orphans.ts
+++ b/packages/tooling/src/audits/check-proposal-orphans.ts
@@ -25,16 +25,19 @@ export interface OrphanCheckResult {
   totalProposals: number;
   orphans: string[];
   /**
-   * Proposals whose basename is a single kebab-segment (no hyphens). Reported
-   * separately from `orphans` because single-segment names defeat the word-
-   * boundary regex's precision: a proposal named `memory.md` would be rescued
-   * by any markdown file containing the word "memory" in prose, silently
-   * producing a false negative on the orphan check.
+   * Relative paths of proposals whose basename is a single segment (no `-`
+   * and no `_`). Reported separately from `orphans` because single-segment
+   * names defeat the word-boundary regex's precision: a proposal named
+   * `memory.md` would be rescued by any markdown file containing the word
+   * "memory" in prose, silently producing a false negative on the orphan
+   * check.
    *
-   * The CLI treats this as a hard failure; multi-segment kebab-case names
-   * are required for the precision the orphan check depends on.
+   * The CLI treats this as a hard failure; multi-segment kebab-case (or
+   * SCREAMING_SNAKE_CASE) names are required for the precision the orphan
+   * check depends on. Parallel shape to `orphans` — both are arrays of
+   * relative paths.
    */
-  singleSegmentSlugs: string[];
+  singleSegmentProposals: string[];
 }
 
 /**
@@ -178,7 +181,7 @@ export function findProposalOrphans(repoRoot: string): OrphanCheckResult {
     .join('\n\n');
 
   const orphans: string[] = [];
-  const singleSegmentSlugs: string[] = [];
+  const singleSegmentProposals: string[] = [];
   for (const proposal of proposals) {
     const slug = basename(proposal, '.md');
 
@@ -187,7 +190,7 @@ export function findProposalOrphans(repoRoot: string): OrphanCheckResult {
       // can't be trusted regardless of outcome (false-positive prone),
       // and the slug itself is a separate hard-fail signal the CLI surfaces
       // alongside any orphans.
-      singleSegmentSlugs.push(relative(repoRoot, proposal));
+      singleSegmentProposals.push(relative(repoRoot, proposal));
       continue;
     }
 
@@ -203,18 +206,23 @@ export function findProposalOrphans(repoRoot: string): OrphanCheckResult {
     // kebab-case proposal names and are safe, but defensive in case
     // future proposals use other characters).
     //
-    // Case-sensitive by intent: proposal slugs are consistently kebab-case
-    // in markdown links and prose mentions, and a mixed-case reference like
-    // `Periodic-Audit-Enforcement` is not an expected shape. Add the `i`
-    // flag here only if a future proposal naming convention diverges.
+    // Case-insensitive (`i` flag): the codebase has both kebab-case
+    // proposals (`memory-and-context-redesign.md`) and legacy
+    // SCREAMING_SNAKE_CASE (`GIT_HOOK_IMPROVEMENTS.md`). A contributor
+    // linking to a SCREAMING_SNAKE_CASE proposal as `git-hook-improvements`
+    // (lowercased) is a plausible mistake that shouldn't silently flag
+    // the proposal as orphan. Multi-segment names are precise enough
+    // that the `i` flag doesn't increase false-negative risk —
+    // `git-hook-improvements` as 3 segments is vanishingly unlikely to
+    // collide with unrelated prose.
     const escapedSlug = slug.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const wordBoundary = new RegExp(`(^|[^a-zA-Z0-9_-])${escapedSlug}([^a-zA-Z0-9_-]|$)`);
+    const wordBoundary = new RegExp(`(^|[^a-zA-Z0-9_-])${escapedSlug}([^a-zA-Z0-9_-]|$)`, 'i');
     if (!wordBoundary.test(haystack)) {
       orphans.push(relative(repoRoot, proposal));
     }
   }
 
-  return { totalProposals: proposals.length, orphans, singleSegmentSlugs };
+  return { totalProposals: proposals.length, orphans, singleSegmentProposals };
 }
 
 export interface CheckProposalOrphansOptions {
@@ -238,8 +246,8 @@ export async function checkProposalOrphans(
   options: CheckProposalOrphansOptions = {}
 ): Promise<void> {
   const repoRoot = options.repoRoot ?? process.cwd();
-  const { totalProposals, orphans, singleSegmentSlugs } = findProposalOrphans(repoRoot);
-  const totalFindings = orphans.length + singleSegmentSlugs.length;
+  const { totalProposals, orphans, singleSegmentProposals } = findProposalOrphans(repoRoot);
+  const totalFindings = orphans.length + singleSegmentProposals.length;
 
   if (options.summary) {
     emitSummary({
@@ -254,10 +262,10 @@ export async function checkProposalOrphans(
     return;
   }
 
-  const linkCheckedCount = totalProposals - singleSegmentSlugs.length;
+  const linkCheckedCount = totalProposals - singleSegmentProposals.length;
   const suffix =
-    singleSegmentSlugs.length > 0
-      ? ` (${singleSegmentSlugs.length} skipped — single-segment slugs)`
+    singleSegmentProposals.length > 0
+      ? ` (${singleSegmentProposals.length} skipped — single-segment slugs)`
       : '';
   console.log(`\n🔍 Checking ${linkCheckedCount} proposals for inbound links${suffix}...\n`);
 
@@ -269,9 +277,9 @@ export async function checkProposalOrphans(
     return;
   }
 
-  if (singleSegmentSlugs.length > 0) {
-    console.log(`❌ Found ${singleSegmentSlugs.length} single-segment proposal slug(s):\n`);
-    for (const slug of singleSegmentSlugs) {
+  if (singleSegmentProposals.length > 0) {
+    console.log(`❌ Found ${singleSegmentProposals.length} single-segment proposal slug(s):\n`);
+    for (const slug of singleSegmentProposals) {
       console.log(`   ${slug}`);
     }
     console.log(`

--- a/packages/tooling/src/audits/check-proposal-orphans.ts
+++ b/packages/tooling/src/audits/check-proposal-orphans.ts
@@ -265,7 +265,7 @@ export async function checkProposalOrphans(
   const linkCheckedCount = totalProposals - singleSegmentProposals.length;
   const suffix =
     singleSegmentProposals.length > 0
-      ? ` (${singleSegmentProposals.length} skipped — single-segment slugs)`
+      ? ` (${singleSegmentProposals.length} skipped — single-segment basenames)`
       : '';
   console.log(`\n🔍 Checking ${linkCheckedCount} proposals for inbound links${suffix}...\n`);
 
@@ -278,7 +278,9 @@ export async function checkProposalOrphans(
   }
 
   if (singleSegmentProposals.length > 0) {
-    console.log(`❌ Found ${singleSegmentProposals.length} single-segment proposal slug(s):\n`);
+    console.log(
+      `❌ Found ${singleSegmentProposals.length} proposal(s) with single-segment basename(s):\n`
+    );
     for (const slug of singleSegmentProposals) {
       console.log(`   ${slug}`);
     }

--- a/packages/tooling/src/commands/cpd.WHY.md
+++ b/packages/tooling/src/commands/cpd.WHY.md
@@ -18,6 +18,12 @@ The CPD-reduction campaign that ran early 2026 reframed the goal mid-campaign �
 
 The full campaign audit is at `docs/reference/CPD_CAMPAIGN_AUDIT.md`. The 2-callback ceiling rule (don't extract a shared helper if it'd require more than 2 callback/predicate parameters) is the working heuristic that prevents this from being a treadmill.
 
+## Drift detection (Layer 3)
+
+`cpd:check` hard-fails when the baseline's stored `meta.configHash` doesn't match the current config fingerprint. The fingerprint hashes `{ threshold, filterImplVersion }` — the two inputs that affect measurement. Bumping `FILTER_IMPL_VERSION` in `postFilter.ts` (when the call-dominance heuristic changes) or changing the `--threshold` invalidates existing baselines and forces an explicit `cpd:update-baseline` refresh. Without this, a heuristic tweak silently makes every subsequent baseline comparison meaningless — the baseline floor was measured under different rules than the current run.
+
+`graceMargin` is intentionally NOT in the fingerprint. It's a tolerance setting, not a measurement input — bumping it doesn't invalidate the underlying line count.
+
 ## Threshold rationale
 
 The ratchet is `baseline.filteredLines + baseline.graceMargin`. `graceMargin` is intentional headroom for legitimate small regressions (a new feature genuinely adds some duplication that hasn't been worth extracting yet) — typically set to 20-50 lines.

--- a/packages/tooling/src/commands/cpd.test.ts
+++ b/packages/tooling/src/commands/cpd.test.ts
@@ -1,5 +1,19 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { assertThresholdInRange, computeUpdatedBaseline, parseBaseline } from './cpd.js';
+import {
+  assertThresholdInRange,
+  computeUpdatedBaseline,
+  parseBaseline,
+  getCpdConfigFingerprint,
+} from './cpd.js';
+import type { BaselineMeta } from '../audits/baseline-meta.js';
+
+const fixtureMeta: BaselineMeta = {
+  toolVersion: 'cpd-check/1.0',
+  configHash: 'abc123def456',
+  nodeVersion: 'v25.3.0',
+  generatedFromSha: 'deadbeef00000000000000000000000000000000',
+  generatedAt: '2026-05-17T12:00:00.000Z',
+};
 
 const filterSummary = (
   overrides: Partial<{
@@ -126,6 +140,7 @@ describe('computeUpdatedBaseline', () => {
       filterSummary({ filteredLines: 1500, filteredCount: 80, rawLines: 1800, rawCount: 100 }),
       {},
       0.8,
+      fixtureMeta,
       fixedDate
     );
 
@@ -138,6 +153,7 @@ describe('computeUpdatedBaseline', () => {
       rawCount: 100,
       threshold: 0.8,
       graceMargin: 10,
+      meta: fixtureMeta,
     });
     expect(result.delta).toBe(1500);
     expect(result.prevLines).toBe(0);
@@ -157,6 +173,7 @@ describe('computeUpdatedBaseline', () => {
       filterSummary({ filteredLines: 1480 }),
       previous,
       0.8,
+      fixtureMeta,
       fixedDate
     );
 
@@ -174,6 +191,7 @@ describe('computeUpdatedBaseline', () => {
       filterSummary({ filteredLines: 1520 }),
       previous,
       0.8,
+      fixtureMeta,
       fixedDate
     );
     expect(result.delta).toBe(20);
@@ -185,6 +203,7 @@ describe('computeUpdatedBaseline', () => {
       filterSummary({ filteredLines: 1400 }),
       previous,
       0.8,
+      fixtureMeta,
       fixedDate
     );
     expect(result.delta).toBe(-100);
@@ -192,25 +211,45 @@ describe('computeUpdatedBaseline', () => {
 
   it('defaults graceMargin to 10 when previous baseline has no graceMargin', () => {
     const previous = { filteredLines: 1500 };
-    const result = computeUpdatedBaseline(filterSummary(), previous, 0.8, fixedDate);
+    const result = computeUpdatedBaseline(filterSummary(), previous, 0.8, fixtureMeta, fixedDate);
     expect(result.updated.graceMargin).toBe(10);
   });
 
   it('defaults version to 1 when previous version is missing or non-numeric', () => {
-    const result1 = computeUpdatedBaseline(filterSummary(), {}, 0.8, fixedDate);
+    const result1 = computeUpdatedBaseline(filterSummary(), {}, 0.8, fixtureMeta, fixedDate);
     expect(result1.updated.version).toBe(1);
 
     const result2 = computeUpdatedBaseline(
       filterSummary(),
       { filteredLines: 100, version: 'broken' },
       0.8,
+      fixtureMeta,
       fixedDate
     );
     expect(result2.updated.version).toBe(1);
   });
 
   it('records the threshold the filter was run at', () => {
-    const result = computeUpdatedBaseline(filterSummary(), {}, 0.5, fixedDate);
+    const result = computeUpdatedBaseline(filterSummary(), {}, 0.5, fixtureMeta, fixedDate);
     expect(result.updated.threshold).toBe(0.5);
+  });
+
+  it('writes the supplied meta block onto the updated baseline', () => {
+    const result = computeUpdatedBaseline(filterSummary(), {}, 0.8, fixtureMeta, fixedDate);
+    expect(result.updated.meta).toEqual(fixtureMeta);
+  });
+});
+
+describe('getCpdConfigFingerprint', () => {
+  it('returns the threshold and filterImplVersion', () => {
+    const fp = getCpdConfigFingerprint(0.8);
+    expect(fp.threshold).toBe(0.8);
+    expect(typeof fp.filterImplVersion).toBe('number');
+  });
+
+  it('different thresholds produce different fingerprints', () => {
+    const a = getCpdConfigFingerprint(0.8);
+    const b = getCpdConfigFingerprint(0.7);
+    expect(a.threshold).not.toBe(b.threshold);
   });
 });

--- a/packages/tooling/src/commands/cpd.ts
+++ b/packages/tooling/src/commands/cpd.ts
@@ -21,7 +21,29 @@ import type { CAC } from 'cac';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import chalk from 'chalk';
-import { JSCPD_REPORT_PATH } from '../cpd/postFilter.js';
+import { JSCPD_REPORT_PATH, FILTER_IMPL_VERSION } from '../cpd/postFilter.js';
+import {
+  buildBaselineMeta,
+  checkMetaDrift,
+  hashConfigSlice,
+  type BaselineMeta,
+} from '../audits/baseline-meta.js';
+
+/**
+ * Returns the measurement-affecting CPD config. Hashed into the baseline
+ * `meta.configHash` so a threshold or filter-implementation change
+ * invalidates the baseline.
+ *
+ * `graceMargin` is intentionally NOT in the fingerprint — it's a
+ * tolerance setting, not a measurement input. Bumping it doesn't
+ * invalidate the underlying line count.
+ */
+export function getCpdConfigFingerprint(threshold: number): {
+  threshold: number;
+  filterImplVersion: number;
+} {
+  return { threshold, filterImplVersion: FILTER_IMPL_VERSION };
+}
 
 const DEFAULT_BASELINE_PATH = '.github/baselines/cpd-baseline.json';
 const THRESHOLD_OPTION_FLAG = '--threshold <ratio>';
@@ -62,7 +84,7 @@ function assertReportExists(): void {
 export function parseBaseline(
   rawContent: string,
   pathForError: string
-): { filteredLines: number; graceMargin?: number } {
+): { filteredLines: number; graceMargin?: number; meta?: BaselineMeta } {
   let parsed: unknown;
   try {
     parsed = JSON.parse(rawContent);
@@ -91,7 +113,37 @@ export function parseBaseline(
     );
     process.exit(1);
   }
-  return { filteredLines: obj.filteredLines, graceMargin: obj.graceMargin };
+
+  // `meta` is optional — pre-Layer-3 baselines don't have one, and the
+  // drift check (in runCheckCommand) treats a missing meta as drift so
+  // the operator is forced to refresh and capture metadata.
+  let meta: BaselineMeta | undefined;
+  if (obj.meta !== undefined) {
+    if (typeof obj.meta !== 'object' || obj.meta === null) {
+      console.error(chalk.red(`Baseline ${pathForError} meta must be an object when set`));
+      process.exit(1);
+    }
+    const m = obj.meta as Record<string, unknown>;
+    // Field-level type check — only validate string-ness; presence is
+    // confirmed by the drift check downstream. This keeps parseBaseline
+    // focused on JSON shape, not semantic alignment.
+    const stringFields: (keyof BaselineMeta)[] = [
+      'toolVersion',
+      'configHash',
+      'nodeVersion',
+      'generatedFromSha',
+      'generatedAt',
+    ];
+    for (const field of stringFields) {
+      if (typeof m[field] !== 'string') {
+        console.error(chalk.red(`Baseline ${pathForError} meta.${field} must be a string`));
+        process.exit(1);
+      }
+    }
+    meta = m as unknown as BaselineMeta;
+  }
+
+  return { filteredLines: obj.filteredLines, graceMargin: obj.graceMargin, meta };
 }
 
 interface FilteredCommandOptions {
@@ -151,6 +203,26 @@ async function runCheckCommand(options: CheckCommandOptions): Promise<void> {
     readFileSync(resolve(process.cwd(), options.baseline), 'utf-8'),
     options.baseline
   );
+
+  // Layer 3 drift detection: hard-fail when the baseline's stored
+  // configHash doesn't match the current config. Forces an intentional
+  // refresh via `cpd:update-baseline` whenever the threshold or filter
+  // implementation changes — without this, a config bump silently makes
+  // every subsequent baseline comparison meaningless.
+  const currentConfigHash = await hashConfigSlice(getCpdConfigFingerprint(options.threshold));
+  const drift = checkMetaDrift(baseline.meta, currentConfigHash);
+  if (!drift.aligned) {
+    console.error();
+    console.error(chalk.red(`❌ CPD baseline meta drift: ${drift.detail}`));
+    console.error(
+      chalk.dim(
+        'The baseline was captured under different CPD config. Run ' +
+          '`pnpm ops cpd:update-baseline` to refresh against the current config.'
+      )
+    );
+    process.exit(1);
+  }
+
   const report = loadJscpdReport(JSCPD_REPORT_PATH);
   const result = filterReport(report, options.threshold);
 
@@ -212,6 +284,7 @@ export interface BaselineUpdateResult {
     rawCount: number;
     threshold: number;
     graceMargin: number;
+    meta: BaselineMeta;
   };
   /** Line-count change (positive = baseline raised). */
   delta: number;
@@ -224,12 +297,18 @@ export interface BaselineUpdateResult {
 /** Pure computation of the new baseline given the current filter result and
  *  the previous baseline (or `{}` if no previous baseline exists). Preserves
  *  existing fields like `notes`, `version`, `graceMargin` from the previous
- *  baseline; overwrites the count/line fields and `lastUpdated`. Exported
- *  for testing — the wrapping command is a thin I/O shell around this. */
+ *  baseline; overwrites the count/line fields, `lastUpdated`, and `meta`.
+ *  Exported for testing — the wrapping command is a thin I/O shell around this.
+ *
+ *  `meta` MUST be supplied by the caller (it's tool-specific — the baseline
+ *  module doesn't know how to compute the configHash). The caller builds it
+ *  via `buildBaselineMeta(toolVersion, configHash)`.
+ */
 export function computeUpdatedBaseline(
   result: FilterSummary,
   previous: Record<string, unknown>,
   threshold: number,
+  meta: BaselineMeta,
   now: Date = new Date()
 ): BaselineUpdateResult {
   // Narrow `version` and `graceMargin` types before merging — the
@@ -255,6 +334,7 @@ export function computeUpdatedBaseline(
     rawCount: result.rawCount,
     threshold,
     graceMargin: prevGraceMargin,
+    meta,
   };
 
   return {
@@ -287,10 +367,17 @@ async function runUpdateBaselineCommand(options: UpdateBaselineCommandOptions): 
       })()
     : {};
 
+  const configHash = await hashConfigSlice(getCpdConfigFingerprint(options.threshold));
+  // toolVersion: hard-coded for now; reconsider if this tool's logic
+  // starts evolving fast enough that callers need to disambiguate.
+  // The configHash captures the measurement-affecting bits anyway.
+  const meta = buildBaselineMeta('cpd-check/1.0', configHash);
+
   const { updated, delta, prevLines, prevCount } = computeUpdatedBaseline(
     result,
     previous,
-    options.threshold
+    options.threshold,
+    meta
   );
 
   const deltaStr =

--- a/packages/tooling/src/commands/cpd.ts
+++ b/packages/tooling/src/commands/cpd.ts
@@ -209,7 +209,7 @@ async function runCheckCommand(options: CheckCommandOptions): Promise<void> {
   // refresh via `cpd:update-baseline` whenever the threshold or filter
   // implementation changes — without this, a config bump silently makes
   // every subsequent baseline comparison meaningless.
-  const currentConfigHash = await hashConfigSlice(getCpdConfigFingerprint(options.threshold));
+  const currentConfigHash = hashConfigSlice(getCpdConfigFingerprint(options.threshold));
   const drift = checkMetaDrift(baseline.meta, currentConfigHash);
   if (!drift.aligned) {
     console.error();
@@ -367,7 +367,7 @@ async function runUpdateBaselineCommand(options: UpdateBaselineCommandOptions): 
       })()
     : {};
 
-  const configHash = await hashConfigSlice(getCpdConfigFingerprint(options.threshold));
+  const configHash = hashConfigSlice(getCpdConfigFingerprint(options.threshold));
   // toolVersion: hard-coded for now; reconsider if this tool's logic
   // starts evolving fast enough that callers need to disambiguate.
   // The configHash captures the measurement-affecting bits anyway.

--- a/packages/tooling/src/commands/test.ts
+++ b/packages/tooling/src/commands/test.ts
@@ -7,6 +7,9 @@
 
 import type { CAC } from 'cac';
 
+const UPDATE_OPTION_DESC = 'Update baseline with current gaps';
+const STRICT_OPTION_DESC = 'Fail if ANY gap exists (not just new ones)';
+
 export function registerTestCommands(cli: CAC): void {
   // Generate PGLite schema
   cli
@@ -21,8 +24,8 @@ export function registerTestCommands(cli: CAC): void {
   // Unified audit command (primary)
   cli
     .command('test:audit', 'Run unified test coverage audit')
-    .option('--update', 'Update baseline with current gaps')
-    .option('--strict', 'Fail if ANY gap exists (not just new ones)')
+    .option('--update', UPDATE_OPTION_DESC)
+    .option('--strict', STRICT_OPTION_DESC)
     .option('--category <cat>', 'Only run: services, contracts')
     .option('--verbose', 'Show detailed output')
     .example('pnpm ops test:audit')
@@ -47,7 +50,7 @@ export function registerTestCommands(cli: CAC): void {
           return;
         }
 
-        const passed = auditUnified({
+        const passed = await auditUnified({
           update: options.update,
           strict: options.strict,
           category,
@@ -62,14 +65,14 @@ export function registerTestCommands(cli: CAC): void {
   // Legacy command - contracts (deprecated)
   cli
     .command('test:audit-contracts', 'DEPRECATED: Use test:audit --category=contracts')
-    .option('--update', 'Update baseline with current gaps')
-    .option('--strict', 'Fail if ANY gap exists (not just new ones)')
+    .option('--update', UPDATE_OPTION_DESC)
+    .option('--strict', STRICT_OPTION_DESC)
     .example('pnpm ops test:audit --category=contracts')
     .action(async (options: { update?: boolean; strict?: boolean }) => {
       console.warn('⚠️  DEPRECATED: Use "pnpm ops test:audit --category=contracts"\n');
 
       const { auditUnified } = await import('../test/audit-unified.js');
-      const passed = auditUnified({
+      const passed = await auditUnified({
         update: options.update,
         strict: options.strict,
         category: 'contracts',
@@ -82,14 +85,14 @@ export function registerTestCommands(cli: CAC): void {
   // Legacy command - services (deprecated)
   cli
     .command('test:audit-services', 'DEPRECATED: Use test:audit --category=services')
-    .option('--update', 'Update baseline with current gaps')
-    .option('--strict', 'Fail if ANY gap exists (not just new ones)')
+    .option('--update', UPDATE_OPTION_DESC)
+    .option('--strict', STRICT_OPTION_DESC)
     .example('pnpm ops test:audit --category=services')
     .action(async (options: { update?: boolean; strict?: boolean }) => {
       console.warn('⚠️  DEPRECATED: Use "pnpm ops test:audit --category=services"\n');
 
       const { auditUnified } = await import('../test/audit-unified.js');
-      const passed = auditUnified({
+      const passed = await auditUnified({
         update: options.update,
         strict: options.strict,
         category: 'services',

--- a/packages/tooling/src/cpd/postFilter.ts
+++ b/packages/tooling/src/cpd/postFilter.ts
@@ -213,6 +213,18 @@ function stripCwd(absPath: string, cwd: string): string {
  *  rather than redefining the string locally. */
 export const JSCPD_REPORT_PATH = 'reports/jscpd/jscpd-report.json';
 
+/**
+ * Implementation version of the post-filter heuristic. Bumped when the
+ * call-dominance classification logic changes (e.g., new exclusion rules,
+ * different tokenizer, threshold-meaning change). Goes into the baseline
+ * meta `configHash` so a heuristic change invalidates existing baselines
+ * and forces an explicit refresh via `cpd:update-baseline`.
+ *
+ * History: v1 — initial heuristic (count call-expression-shape lines,
+ * compare ratio against threshold; see `classifyFragment` above).
+ */
+export const FILTER_IMPL_VERSION = 1;
+
 /** Load jscpd report JSON from the given path. Defaults to JSCPD_REPORT_PATH.
  *
  *  Validates the report shape minimally so a schema drift in jscpd's output

--- a/packages/tooling/src/test/audit-unified.WHY.md
+++ b/packages/tooling/src/test/audit-unified.WHY.md
@@ -25,6 +25,12 @@ The ratchet pattern (file-level coverage baseline that can only go down, not up)
 
 `test:audit` is the structural enforcement that converts "test culture" into a CI gate. `.claude/rules/00-critical.md` "NEVER add NEW code to `knownGaps` baseline — write proper tests instead" is the explicit no-bypass rule.
 
+## Drift detection (Layer 3)
+
+`test:audit` hard-fails when the baseline's stored `meta.configHash` doesn't match the current config fingerprint. The fingerprint hashes `{ implVersion: TEST_AUDIT_IMPL_VERSION }` — bumped whenever the measurement-affecting logic changes (Prisma-detection heuristic, service-file glob, Zod schema enumeration, audit-ignore comment shape). A bump invalidates existing baselines and forces an explicit `test:audit --update` refresh. Without this, a heuristic change silently makes every subsequent ratchet check meaningless — the `knownGaps` baseline was captured under different rules than the current scan.
+
+The drift check is skipped in `--update` mode (that path REFRESHES the meta block; failing there would be circular).
+
 ## Threshold rationale
 
 The baseline is in `.github/baselines/test-coverage-baseline.json` and tracks known-gap files explicitly. The intent:

--- a/packages/tooling/src/test/audit-unified.test.ts
+++ b/packages/tooling/src/test/audit-unified.test.ts
@@ -109,13 +109,7 @@ describe('audit-unified', () => {
             serviceExemptionCriteria: 'Services are auto-detected for Prisma usage',
             contractExemptionCriteria: 'None',
           },
-          meta: {
-            toolVersion: 'test-audit/1.0',
-            configHash: expectedTestAuditConfigHash(),
-            nodeVersion: 'v25.3.0',
-            generatedFromSha: 'deadbeef00000000000000000000000000000000',
-            generatedAt: '2024-01-01T00:00:00.000Z',
-          },
+          meta: VALID_BASELINE_META,
         });
       }
       return '';
@@ -161,6 +155,75 @@ export class SimpleService {
 
       const { auditUnified } = await import('./audit-unified.js');
       const result = await auditUnified();
+
+      expect(result).toBe(true);
+    });
+
+    it('should fail with drift error when baseline configHash mismatches', async () => {
+      // End-to-end coverage of the Layer 3 drift gate. Without this,
+      // someone refactoring `checkBaselineDrift` could accidentally
+      // delete the gate and the tests would still pass.
+      mockExistsSync.mockImplementation((path: string) => {
+        if (path.includes('test-coverage-baseline')) return true;
+        return false;
+      });
+      mockReaddirSync.mockImplementation(() => []);
+      mockReadFileSync.mockImplementation((path: string) => {
+        if (path.includes('test-coverage-baseline')) {
+          return JSON.stringify({
+            version: 1,
+            lastUpdated: '2024-01-01',
+            services: { knownGaps: [] },
+            contracts: { knownGaps: [] },
+            notes: {
+              serviceExemptionCriteria: 'Services are auto-detected for Prisma usage',
+              contractExemptionCriteria: 'None',
+            },
+            meta: {
+              ...VALID_BASELINE_META,
+              // Intentionally wrong — should trigger the drift gate
+              configHash: 'stale0000beef',
+            },
+          });
+        }
+        return '';
+      });
+
+      const { auditUnified } = await import('./audit-unified.js');
+      const result = await auditUnified();
+
+      expect(result).toBe(false);
+    });
+
+    it('should skip drift check in --update mode (avoid circular fail)', async () => {
+      // In `--update` mode, the path refreshes the meta block. Failing
+      // there on the OLD configHash would prevent the refresh from
+      // succeeding — circular. Verify that a stale baseline in update
+      // mode passes through to the refresh.
+      mockExistsSync.mockImplementation((path: string) => {
+        if (path.includes('test-coverage-baseline')) return true;
+        return false;
+      });
+      mockReaddirSync.mockImplementation(() => []);
+      mockReadFileSync.mockImplementation((path: string) => {
+        if (path.includes('test-coverage-baseline')) {
+          return JSON.stringify({
+            version: 1,
+            lastUpdated: '2024-01-01',
+            services: { knownGaps: [] },
+            contracts: { knownGaps: [] },
+            notes: {
+              serviceExemptionCriteria: 'Services are auto-detected for Prisma usage',
+              contractExemptionCriteria: 'None',
+            },
+            meta: { ...VALID_BASELINE_META, configHash: 'stale0000beef' },
+          });
+        }
+        return '';
+      });
+
+      const { auditUnified } = await import('./audit-unified.js');
+      const result = await auditUnified({ update: true });
 
       expect(result).toBe(true);
     });

--- a/packages/tooling/src/test/audit-unified.test.ts
+++ b/packages/tooling/src/test/audit-unified.test.ts
@@ -13,6 +13,12 @@ import { TEST_AUDIT_IMPL_VERSION } from './audit-version.js';
  * works without colliding with the `vi.mock('node:fs', ...)` hoist
  * below. A version bump in `audit-version.ts` propagates here
  * automatically — no manual sync required.
+ *
+ * **Maintenance dependency**: if `hashConfigSlice`'s algorithm changes
+ * (SHA-256 → SHA-512, JSON.stringify → a canonicalized serializer,
+ * different output truncation, etc.), this mirror must be updated too.
+ * Otherwise tests will start producing cryptic hash-mismatch errors
+ * instead of a clear "test helper out of sync" signal.
  */
 function expectedTestAuditConfigHash(): string {
   const slice = { implVersion: TEST_AUDIT_IMPL_VERSION };

--- a/packages/tooling/src/test/audit-unified.test.ts
+++ b/packages/tooling/src/test/audit-unified.test.ts
@@ -3,6 +3,36 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createHash } from 'node:crypto';
+
+/**
+ * Synchronous mirror of `hashConfigSlice` from audits/baseline-meta.ts.
+ * Test setup needs a deterministic hash for the current impl version,
+ * but importing `TEST_AUDIT_IMPL_VERSION` from `./audit-utils.js` here
+ * would pull in `node:fs` before the `vi.mock` below initializes —
+ * hoisting order bites. Inline the value instead; if
+ * `TEST_AUDIT_IMPL_VERSION` is bumped in audit-utils.ts, update this
+ * constant to match (baseline-meta tests will catch the mismatch
+ * because audit-unified will report drift).
+ */
+const TEST_AUDIT_IMPL_VERSION_FOR_TESTS = 1;
+
+function expectedTestAuditConfigHash(): string {
+  const slice = { implVersion: TEST_AUDIT_IMPL_VERSION_FOR_TESTS };
+  return createHash('sha256').update(JSON.stringify(slice)).digest('hex').slice(0, 12);
+}
+
+/**
+ * Shared meta block fixture for test baselines — keeps the drift check
+ * green in tests that aren't exercising drift detection itself.
+ */
+const VALID_BASELINE_META = {
+  toolVersion: 'test-audit/1.0',
+  configHash: expectedTestAuditConfigHash(),
+  nodeVersion: 'v25.3.0',
+  generatedFromSha: 'deadbeef00000000000000000000000000000000',
+  generatedAt: '2024-01-01T00:00:00.000Z',
+};
 
 // Mock fs operations
 const mockExistsSync = vi.fn();
@@ -82,6 +112,13 @@ describe('audit-unified', () => {
             serviceExemptionCriteria: 'Services are auto-detected for Prisma usage',
             contractExemptionCriteria: 'None',
           },
+          meta: {
+            toolVersion: 'test-audit/1.0',
+            configHash: expectedTestAuditConfigHash(),
+            nodeVersion: 'v25.3.0',
+            generatedFromSha: 'deadbeef00000000000000000000000000000000',
+            generatedAt: '2024-01-01T00:00:00.000Z',
+          },
         });
       }
       return '';
@@ -126,7 +163,7 @@ export class SimpleService {
       setupCleanBaseline();
 
       const { auditUnified } = await import('./audit-unified.js');
-      const result = auditUnified();
+      const result = await auditUnified();
 
       expect(result).toBe(true);
     });
@@ -172,6 +209,7 @@ export class SimpleService {
               serviceExemptionCriteria: 'Services are auto-detected for Prisma usage',
               contractExemptionCriteria: 'None',
             },
+            meta: VALID_BASELINE_META,
           });
         }
         if (path.includes('KnownService.ts')) {
@@ -184,7 +222,7 @@ export class SimpleService {
       });
 
       const { auditUnified } = await import('./audit-unified.js');
-      const result = auditUnified();
+      const result = await auditUnified();
 
       // Should pass because gaps are known in baseline
       expect(result).toBe(true);
@@ -227,6 +265,7 @@ export class SimpleService {
               serviceExemptionCriteria: 'Services are auto-detected for Prisma usage',
               contractExemptionCriteria: 'None',
             },
+            meta: VALID_BASELINE_META,
           });
         }
         if (path.includes('NewService.ts')) {
@@ -237,7 +276,7 @@ export class SimpleService {
       });
 
       const { auditUnified } = await import('./audit-unified.js');
-      const result = auditUnified();
+      const result = await auditUnified();
 
       expect(result).toBe(false);
     });
@@ -279,6 +318,7 @@ export class SimpleService {
               serviceExemptionCriteria: 'Services are auto-detected for Prisma usage',
               contractExemptionCriteria: 'None',
             },
+            meta: VALID_BASELINE_META,
           });
         }
         if (path.includes('SimpleService.ts')) {
@@ -289,7 +329,7 @@ export class SimpleService {
       });
 
       const { auditUnified } = await import('./audit-unified.js');
-      const result = auditUnified();
+      const result = await auditUnified();
 
       // Should pass because service without Prisma is auto-exempt
       expect(result).toBe(true);
@@ -332,6 +372,7 @@ export class SimpleService {
               serviceExemptionCriteria: 'Services are auto-detected for Prisma usage',
               contractExemptionCriteria: 'None',
             },
+            meta: VALID_BASELINE_META,
           });
         }
         if (path.includes('NewService.ts')) {
@@ -341,7 +382,7 @@ export class SimpleService {
       });
 
       const { auditUnified } = await import('./audit-unified.js');
-      const result = auditUnified({ update: true });
+      const result = await auditUnified({ update: true });
 
       expect(result).toBe(true);
       expect(mockWriteFileSync).toHaveBeenCalled();
@@ -357,7 +398,7 @@ export class SimpleService {
       setupCleanBaseline();
 
       const { auditUnified } = await import('./audit-unified.js');
-      const result = auditUnified({ category: 'services' });
+      const result = await auditUnified({ category: 'services' });
 
       expect(result).toBe(true);
 
@@ -376,7 +417,7 @@ export class SimpleService {
       setupCleanBaseline();
 
       const { auditUnified } = await import('./audit-unified.js');
-      const result = auditUnified({ category: 'contracts' });
+      const result = await auditUnified({ category: 'contracts' });
 
       expect(result).toBe(true);
 

--- a/packages/tooling/src/test/audit-unified.test.ts
+++ b/packages/tooling/src/test/audit-unified.test.ts
@@ -3,26 +3,25 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { createHash } from 'node:crypto';
+import { hashConfigSlice } from '../audits/baseline-meta.js';
 import { TEST_AUDIT_IMPL_VERSION } from './audit-version.js';
 
 /**
- * Synchronous mirror of `hashConfigSlice` from audits/baseline-meta.ts.
- * `TEST_AUDIT_IMPL_VERSION` is imported from `./audit-version.js` (an
- * fs-free module) rather than `./audit-utils.js` so the static import
- * works without colliding with the `vi.mock('node:fs', ...)` hoist
- * below. A version bump in `audit-version.ts` propagates here
- * automatically — no manual sync required.
+ * Computes the expected baseline configHash for the current
+ * TEST_AUDIT_IMPL_VERSION. Uses `hashConfigSlice` directly (not a
+ * mirrored implementation) so the test setup stays in sync with
+ * production by construction.
  *
- * **Maintenance dependency**: if `hashConfigSlice`'s algorithm changes
- * (SHA-256 → SHA-512, JSON.stringify → a canonicalized serializer,
- * different output truncation, etc.), this mirror must be updated too.
- * Otherwise tests will start producing cryptic hash-mismatch errors
- * instead of a clear "test helper out of sync" signal.
+ * The static import of `hashConfigSlice` is safe alongside the
+ * `vi.mock('node:fs', ...)` below: `baseline-meta.ts` imports only
+ * `node:child_process` and `node:crypto` — neither of which the mock
+ * touches — so module-graph initialization completes without
+ * colliding with the mock. `TEST_AUDIT_IMPL_VERSION` is imported
+ * from the fs-free `audit-version.ts` for the same reason (the
+ * full `audit-utils.ts` does pull `node:fs`).
  */
 function expectedTestAuditConfigHash(): string {
-  const slice = { implVersion: TEST_AUDIT_IMPL_VERSION };
-  return createHash('sha256').update(JSON.stringify(slice)).digest('hex').slice(0, 12);
+  return hashConfigSlice({ implVersion: TEST_AUDIT_IMPL_VERSION });
 }
 
 /**

--- a/packages/tooling/src/test/audit-unified.test.ts
+++ b/packages/tooling/src/test/audit-unified.test.ts
@@ -4,21 +4,18 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createHash } from 'node:crypto';
+import { TEST_AUDIT_IMPL_VERSION } from './audit-version.js';
 
 /**
  * Synchronous mirror of `hashConfigSlice` from audits/baseline-meta.ts.
- * Test setup needs a deterministic hash for the current impl version,
- * but importing `TEST_AUDIT_IMPL_VERSION` from `./audit-utils.js` here
- * would pull in `node:fs` before the `vi.mock` below initializes —
- * hoisting order bites. Inline the value instead; if
- * `TEST_AUDIT_IMPL_VERSION` is bumped in audit-utils.ts, update this
- * constant to match (baseline-meta tests will catch the mismatch
- * because audit-unified will report drift).
+ * `TEST_AUDIT_IMPL_VERSION` is imported from `./audit-version.js` (an
+ * fs-free module) rather than `./audit-utils.js` so the static import
+ * works without colliding with the `vi.mock('node:fs', ...)` hoist
+ * below. A version bump in `audit-version.ts` propagates here
+ * automatically — no manual sync required.
  */
-const TEST_AUDIT_IMPL_VERSION_FOR_TESTS = 1;
-
 function expectedTestAuditConfigHash(): string {
-  const slice = { implVersion: TEST_AUDIT_IMPL_VERSION_FOR_TESTS };
+  const slice = { implVersion: TEST_AUDIT_IMPL_VERSION };
   return createHash('sha256').update(JSON.stringify(slice)).digest('hex').slice(0, 12);
 }
 

--- a/packages/tooling/src/test/audit-unified.ts
+++ b/packages/tooling/src/test/audit-unified.ts
@@ -209,6 +209,7 @@ function findTestedSchemas(projectRoot: string): string[] {
         const schemaFile = match[1];
 
         // Find which schemas from this file are actually used
+        // eslint-disable-next-line regexp/no-super-linear-move -- Input is developer-authored TS source (trusted, bounded by file size); ReDoS not a real attack surface
         const schemaUsageMatches = content.matchAll(/(\w+Schema)\.safeParse/g);
         for (const usageMatch of schemaUsageMatches) {
           tested.push(`${schemaFile}:${usageMatch[1]}`);
@@ -216,6 +217,7 @@ function findTestedSchemas(projectRoot: string): string[] {
       }
 
       // Also check for .parse() usage (some tests use .parse instead of .safeParse)
+      // eslint-disable-next-line regexp/no-super-linear-move -- Input is developer-authored TS source (trusted, bounded by file size); ReDoS not a real attack surface
       const parseMatches = content.matchAll(/(\w+Schema)\.parse\(/g);
       for (const match of parseMatches) {
         const importMatches2 = content.matchAll(/from ['"]\.\/([\w-]+)(?:\.js)?['"]/g);
@@ -234,6 +236,7 @@ function findTestedSchemas(projectRoot: string): string[] {
     for (const file of e2eFiles) {
       const content = readFile(join(e2eTestsDir, file));
 
+      // eslint-disable-next-line regexp/no-super-linear-move -- Input is developer-authored TS source (trusted, bounded by file size); ReDoS not a real attack surface
       const schemaUsageMatches = content.matchAll(/(\w+Schema)\.safeParse/g);
       for (const match of schemaUsageMatches) {
         tested.push(`e2e:${match[1]}`);
@@ -332,9 +335,73 @@ export function collectUnifiedAuditData(
 }
 
 /**
+ * Layer 3 drift detection helper. Returns `true` when the baseline's
+ * stored configHash matches the current measurement-affecting config;
+ * returns `false` after printing an actionable error message on drift.
+ * Extracted from `auditUnified` to keep that function's cognitive
+ * complexity inside the lint budget.
+ */
+async function checkBaselineDrift(baseline: UnifiedBaseline): Promise<boolean> {
+  const { checkMetaDrift, hashConfigSlice } = await import('../audits/baseline-meta.js');
+  const { getTestAuditConfigFingerprint } = await import('./audit-utils.js');
+  const currentConfigHash = await hashConfigSlice(getTestAuditConfigFingerprint());
+  const drift = checkMetaDrift(baseline.meta, currentConfigHash);
+  if (!drift.aligned) {
+    console.error(`\n❌ test-audit baseline meta drift: ${drift.detail}`);
+    console.error(
+      '   The baseline was captured under different test-audit config. Run ' +
+        '`pnpm ops test:audit --update` to refresh against the current config.'
+    );
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Build and save the updated baseline (the `--update` path). Extracted
+ * from `auditUnified` to keep that function's complexity inside the
+ * lint budget.
+ */
+async function writeUpdatedBaseline(
+  projectRoot: string,
+  baseline: UnifiedBaseline,
+  result: { services: ServiceAuditResult; contracts: ContractAuditResult },
+  category: 'services' | 'contracts' | undefined
+): Promise<void> {
+  console.log('📝 Updating baseline file...\n');
+  const { buildBaselineMeta, hashConfigSlice } = await import('../audits/baseline-meta.js');
+  const { getTestAuditConfigFingerprint } = await import('./audit-utils.js');
+  const configHash = await hashConfigSlice(getTestAuditConfigFingerprint());
+  const meta = buildBaselineMeta('test-audit/1.0', configHash);
+
+  const updatedBaseline: UnifiedBaseline = {
+    ...baseline,
+    version: baseline.version + 1,
+    lastUpdated: new Date().toISOString(),
+    services: {
+      // Include detected Prisma services for audit transparency
+      detectedPrismaServices: includesServices(category)
+        ? result.services.servicesWithPrisma
+        : baseline.services.detectedPrismaServices,
+      knownGaps: includesServices(category)
+        ? result.services.untestedServices
+        : baseline.services.knownGaps,
+    },
+    contracts: {
+      knownGaps: includesContracts(category)
+        ? result.contracts.untestedSchemas
+        : baseline.contracts.knownGaps,
+    },
+    meta,
+  };
+  saveUnifiedBaseline(projectRoot, updatedBaseline);
+  console.log(`✅ Baseline updated: ${UNIFIED_BASELINE_PATH}\n`);
+}
+
+/**
  * Main unified audit function
  */
-export function auditUnified(options: AuditUnifiedOptions = {}): boolean {
+export async function auditUnified(options: AuditUnifiedOptions = {}): Promise<boolean> {
   const { update = false, strict = false, category, verbose = false } = options;
   const projectRoot = process.cwd();
 
@@ -345,6 +412,12 @@ export function auditUnified(options: AuditUnifiedOptions = {}): boolean {
 
   const baseline = loadUnifiedBaseline(projectRoot);
   const result = collectUnifiedAuditData(projectRoot, baseline);
+
+  // Layer 3 drift detection. Skipped in `--update` mode because that
+  // path REFRESHES the meta block — failing there would be circular.
+  if (!update && !(await checkBaselineDrift(baseline))) {
+    return false;
+  }
 
   // Print requested sections
   if (includesServices(category)) {
@@ -361,28 +434,7 @@ export function auditUnified(options: AuditUnifiedOptions = {}): boolean {
 
   // Handle update mode
   if (update) {
-    console.log('📝 Updating baseline file...\n');
-    const updatedBaseline: UnifiedBaseline = {
-      ...baseline,
-      version: baseline.version + 1,
-      lastUpdated: new Date().toISOString(),
-      services: {
-        // Include detected Prisma services for audit transparency
-        detectedPrismaServices: includesServices(category)
-          ? result.services.servicesWithPrisma
-          : baseline.services.detectedPrismaServices,
-        knownGaps: includesServices(category)
-          ? result.services.untestedServices
-          : baseline.services.knownGaps,
-      },
-      contracts: {
-        knownGaps: includesContracts(category)
-          ? result.contracts.untestedSchemas
-          : baseline.contracts.knownGaps,
-      },
-    };
-    saveUnifiedBaseline(projectRoot, updatedBaseline);
-    console.log(`✅ Baseline updated: ${UNIFIED_BASELINE_PATH}\n`);
+    await writeUpdatedBaseline(projectRoot, baseline, result, category);
     return true;
   }
 

--- a/packages/tooling/src/test/audit-unified.ts
+++ b/packages/tooling/src/test/audit-unified.ts
@@ -7,6 +7,7 @@
 
 import { readFileSync, writeFileSync, existsSync, readdirSync } from 'node:fs';
 import { join, basename } from 'node:path';
+import chalk from 'chalk';
 
 import {
   type UnifiedBaseline,
@@ -344,13 +345,15 @@ export function collectUnifiedAuditData(
 async function checkBaselineDrift(baseline: UnifiedBaseline): Promise<boolean> {
   const { checkMetaDrift, hashConfigSlice } = await import('../audits/baseline-meta.js');
   const { getTestAuditConfigFingerprint } = await import('./audit-utils.js');
-  const currentConfigHash = await hashConfigSlice(getTestAuditConfigFingerprint());
+  const currentConfigHash = hashConfigSlice(getTestAuditConfigFingerprint());
   const drift = checkMetaDrift(baseline.meta, currentConfigHash);
   if (!drift.aligned) {
-    console.error(`\n❌ test-audit baseline meta drift: ${drift.detail}`);
+    console.error(chalk.red(`\n❌ test-audit baseline meta drift: ${drift.detail}`));
     console.error(
-      '   The baseline was captured under different test-audit config. Run ' +
-        '`pnpm ops test:audit --update` to refresh against the current config.'
+      chalk.dim(
+        '   The baseline was captured under different test-audit config. Run ' +
+          '`pnpm ops test:audit --update` to refresh against the current config.'
+      )
     );
     return false;
   }
@@ -371,7 +374,7 @@ async function writeUpdatedBaseline(
   console.log('📝 Updating baseline file...\n');
   const { buildBaselineMeta, hashConfigSlice } = await import('../audits/baseline-meta.js');
   const { getTestAuditConfigFingerprint } = await import('./audit-utils.js');
-  const configHash = await hashConfigSlice(getTestAuditConfigFingerprint());
+  const configHash = hashConfigSlice(getTestAuditConfigFingerprint());
   const meta = buildBaselineMeta('test-audit/1.0', configHash);
 
   const updatedBaseline: UnifiedBaseline = {

--- a/packages/tooling/src/test/audit-utils.ts
+++ b/packages/tooling/src/test/audit-utils.ts
@@ -4,6 +4,7 @@
 
 import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
 import { join, relative, dirname } from 'node:path';
+import { TEST_AUDIT_IMPL_VERSION } from './audit-version.js';
 
 // ============================================================================
 // Types
@@ -193,7 +194,6 @@ export function hasAuditIgnoreComment(filePath: string): boolean {
  * `audit-version.ts` (fs-free) so the test suite can statically import
  * it without pulling in `node:fs` ahead of `vi.mock` hoisting.
  */
-import { TEST_AUDIT_IMPL_VERSION } from './audit-version.js';
 export { TEST_AUDIT_IMPL_VERSION };
 
 /**

--- a/packages/tooling/src/test/audit-utils.ts
+++ b/packages/tooling/src/test/audit-utils.ts
@@ -188,23 +188,19 @@ export function hasAuditIgnoreComment(filePath: string): boolean {
 // ============================================================================
 
 /**
- * Implementation version of the test-audit measurement logic. Bumped when
- * any of these change: the Prisma-usage detection heuristic, the
- * service-file glob, the contract-file enumeration, or the audit-ignore
- * comment shape. Goes into the baseline meta `configHash` via
- * `getTestAuditConfigFingerprint` so a heuristic change forces an
- * explicit refresh.
- *
- * History: v1 — initial (Prisma auto-detection + `*.service.ts` glob +
- * Zod schema enumeration).
+ * Re-export of TEST_AUDIT_IMPL_VERSION for callers that historically
+ * imported it from this module. The constant itself lives in
+ * `audit-version.ts` (fs-free) so the test suite can statically import
+ * it without pulling in `node:fs` ahead of `vi.mock` hoisting.
  */
-export const TEST_AUDIT_IMPL_VERSION = 1;
+export { TEST_AUDIT_IMPL_VERSION } from './audit-version.js';
+import { TEST_AUDIT_IMPL_VERSION } from './audit-version.js';
 
 /**
  * Returns the measurement-affecting test-audit config. Hashed into the
  * baseline `meta.configHash` so a heuristic change invalidates the
- * baseline. Stable shape — bump `TEST_AUDIT_IMPL_VERSION` when the
- * detection logic changes.
+ * baseline. Stable shape — bump `TEST_AUDIT_IMPL_VERSION` (in
+ * `audit-version.ts`) when the detection logic changes.
  */
 export function getTestAuditConfigFingerprint(): {
   implVersion: number;

--- a/packages/tooling/src/test/audit-utils.ts
+++ b/packages/tooling/src/test/audit-utils.ts
@@ -24,6 +24,13 @@ export interface UnifiedBaseline {
     serviceExemptionCriteria: string;
     contractExemptionCriteria: string;
   };
+  /**
+   * Layer 3 baseline metadata. Optional for backward compat — pre-Layer-3
+   * baselines didn't have this. The drift gate in `auditUnified` treats
+   * a missing meta block as drift, forcing an explicit refresh via
+   * `test:audit --update`.
+   */
+  meta?: import('../audits/baseline-meta.js').BaselineMeta;
 }
 
 export interface ServiceAuditResult {
@@ -161,6 +168,7 @@ export function hasPrismaUsage(filePath: string): boolean {
   // Remove comments to avoid false positives
   const withoutComments = content
     .replace(/\/\*[\s\S]*?\*\//g, '') // Block comments
+    // eslint-disable-next-line regexp/no-super-linear-move -- Input is developer-authored TS source (trusted, bounded by file size); ReDoS not a real attack surface
     .replace(/\/\/.*$/gm, ''); // Line comments
 
   return PRISMA_PATTERNS.some(pattern => pattern.test(withoutComments));
@@ -178,6 +186,31 @@ export function hasAuditIgnoreComment(filePath: string): boolean {
 // ============================================================================
 // Baseline Helpers
 // ============================================================================
+
+/**
+ * Implementation version of the test-audit measurement logic. Bumped when
+ * any of these change: the Prisma-usage detection heuristic, the
+ * service-file glob, the contract-file enumeration, or the audit-ignore
+ * comment shape. Goes into the baseline meta `configHash` via
+ * `getTestAuditConfigFingerprint` so a heuristic change forces an
+ * explicit refresh.
+ *
+ * History: v1 — initial (Prisma auto-detection + `*.service.ts` glob +
+ * Zod schema enumeration).
+ */
+export const TEST_AUDIT_IMPL_VERSION = 1;
+
+/**
+ * Returns the measurement-affecting test-audit config. Hashed into the
+ * baseline `meta.configHash` so a heuristic change invalidates the
+ * baseline. Stable shape — bump `TEST_AUDIT_IMPL_VERSION` when the
+ * detection logic changes.
+ */
+export function getTestAuditConfigFingerprint(): {
+  implVersion: number;
+} {
+  return { implVersion: TEST_AUDIT_IMPL_VERSION };
+}
 
 /**
  * Create default empty baseline

--- a/packages/tooling/src/test/audit-utils.ts
+++ b/packages/tooling/src/test/audit-utils.ts
@@ -193,8 +193,8 @@ export function hasAuditIgnoreComment(filePath: string): boolean {
  * `audit-version.ts` (fs-free) so the test suite can statically import
  * it without pulling in `node:fs` ahead of `vi.mock` hoisting.
  */
-export { TEST_AUDIT_IMPL_VERSION } from './audit-version.js';
 import { TEST_AUDIT_IMPL_VERSION } from './audit-version.js';
+export { TEST_AUDIT_IMPL_VERSION };
 
 /**
  * Returns the measurement-affecting test-audit config. Hashed into the

--- a/packages/tooling/src/test/audit-version.ts
+++ b/packages/tooling/src/test/audit-version.ts
@@ -1,0 +1,17 @@
+/**
+ * Test-audit version constants — extracted to a fs-free module so the
+ * test suite can statically import them without pulling in `node:fs`
+ * (which `audit-utils.ts` imports at the top, ahead of the vi.mock
+ * hoisting in tests).
+ *
+ * Bump these when the measurement-affecting logic changes. The
+ * `getTestAuditConfigFingerprint` helper in `audit-utils.ts` hashes
+ * the constant into the baseline meta `configHash`, so a bump
+ * invalidates existing baselines and forces an explicit refresh
+ * via `test:audit --update`.
+ *
+ * History:
+ *   v1 — initial (Prisma auto-detection + `*.service.ts` glob +
+ *        Zod schema enumeration).
+ */
+export const TEST_AUDIT_IMPL_VERSION = 1;


### PR DESCRIPTION
## Summary

Implements Layer 3 of [docs/proposals/backlog/periodic-audit-enforcement.md](docs/proposals/backlog/periodic-audit-enforcement.md):

1. **Shared `BaselineMeta` type** with `buildBaselineMeta()` / `checkMetaDrift()` / `hashConfigSlice()` helpers in `audits/baseline-meta.ts`. The contract every audit tool's baseline can adopt.

2. **CPD drift detection**: `cpd:check` hard-fails on `configHash` mismatch with an actionable error message. `cpd:update-baseline` writes a fresh meta block on refresh. Backfilled `.github/baselines/cpd-baseline.json`. New `FILTER_IMPL_VERSION` in `postFilter.ts` gets bumped when the call-dominance heuristic changes.

3. **test:audit drift detection**: same shape as CPD. `auditUnified()` is now async (drift check uses dynamic imports of baseline-meta to defer fs-mock loading); callers updated. New `TEST_AUDIT_IMPL_VERSION` in `audit-utils.ts` gets bumped when measurement-affecting logic changes.

4. **4 absorbed Layer-2 hardening items** from PR #1083 post-merge review:
   - `singleSegmentSlugs` → `singleSegmentProposals` rename (field contained paths, not slugs)
   - Lazy-quantifier comment in frontmatter strip regex
   - Case-insensitive flag (`'i'`) on orphan-check word-boundary regex
   - Orphan-WHY.md bidirectional check in `guard:audit-tool-docs`

## Design choice: JSON + meta block (not markdown migration)

The proposal originally drafted Layer 3 (meta) and Layer 4 (markdown) as separate. Embedding the meta block in the existing JSON baselines delivers the drift-detection invariant with a smaller diff and no file-format migration. Layer 4's diff-readability benefit (markdown is more git-diff-friendly than JSON) remains independent — it can ship separately if it ever becomes acute.

## Test plan

- [x] `pnpm --filter @tzurot/tooling test` — 844 passing (+12 from Layer 3, +9 baseline-meta + 3 fingerprint)
- [x] `pnpm ops guard:audit-tool-docs` — green on real repo (12/12 documented, no orphan WHY.md files)
- [x] `pnpm ops guard:proposal-links` — green
- [x] `pnpm ops cpd:check` — green with drift detection
- [x] `pnpm ops test:audit` — green with drift detection
- [x] Lint clean

## Drift detection in action

If you bump `FILTER_IMPL_VERSION` (or `TEST_AUDIT_IMPL_VERSION`), the next `cpd:check` (or `test:audit`) call will hard-fail with:

\`\`\`
❌ CPD baseline meta drift: configHash drift: baseline=a7f4e5150567 current=XXXXXXXX
   The baseline was captured under different CPD config. Run \`pnpm ops cpd:update-baseline\` to refresh against the current config.
\`\`\`

Forces an intentional refresh. No more "baseline was captured 3 months ago against config that's since been bumped, and the ratchet is silently meaningless."

## Layer 4 / 5 still open

- Layer 4: markdown baselines (diff-readability) — deferred, possibly skipped given Layer 3 + JSON works fine
- Layer 5: `ops:health` aggregator + cron — the goal layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)