### PR TITLE
refactor(api-gateway): handler-export + RouteDeps deps-object pattern

### DIFF
--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -276,7 +276,7 @@ function registerRoutes(app: Express, prisma: PrismaClient, services: ServicesCo
   app.use('/voice-references', createVoiceReferenceRouter(prisma));
   logger.info('Voice references route registered (service-auth protected)');
 
-  app.use('/ai', createAIRouter(prisma, aiQueue, queueEvents));
+  app.use('/ai', createAIRouter({ prisma, aiQueue, queueEvents }));
   logger.info('AI routes registered');
 
   app.use('/wallet', createWalletRouter(prisma, cacheRedis, apiKeyCacheInvalidation));
@@ -302,7 +302,7 @@ function registerRoutes(app: Express, prisma: PrismaClient, services: ServicesCo
   app.use('/models', createModelsRouter(modelCache));
   logger.info('Models routes registered');
 
-  app.use('/internal', createInternalRouter(prisma));
+  app.use('/internal', createInternalRouter({ prisma }));
   logger.info('Internal routes registered');
 
   app.use(

--- a/services/api-gateway/src/routes/admin/cleanup.test.ts
+++ b/services/api-gateway/src/routes/admin/cleanup.test.ts
@@ -4,7 +4,8 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createCleanupRoute } from './cleanup.js';
-import type { ConversationRetentionService } from '@tzurot/common-types';
+import type { ConversationRetentionService, PrismaClient } from '@tzurot/common-types';
+import type { RouteDeps } from '../routeDeps.js';
 import express from 'express';
 import request from 'supertest';
 
@@ -45,12 +46,13 @@ describe('Admin Cleanup Routes', () => {
       cleanupOldTombstones: vi.fn().mockResolvedValue(0),
     };
 
+    const deps: RouteDeps = {
+      prisma: {} as PrismaClient,
+      retentionService: mockService as unknown as ConversationRetentionService,
+    };
     app = express();
     app.use(express.json());
-    app.use(
-      '/admin/cleanup',
-      createCleanupRoute(mockService as unknown as ConversationRetentionService)
-    );
+    app.use('/admin/cleanup', createCleanupRoute(deps));
     // Add error handler for debugging
     app.use(
       (err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/services/api-gateway/src/routes/admin/cleanup.ts
+++ b/services/api-gateway/src/routes/admin/cleanup.ts
@@ -3,16 +3,13 @@
  * Manually trigger cleanup of old conversation history and tombstones
  */
 
-import { Router, type Request, type Response } from 'express';
-import {
-  createLogger,
-  CLEANUP_DEFAULTS,
-  type ConversationRetentionService,
-} from '@tzurot/common-types';
+import { Router, type Request, type RequestHandler, type Response } from 'express';
+import { createLogger, CLEANUP_DEFAULTS } from '@tzurot/common-types';
 import { requireOwnerAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('admin-cleanup');
 
@@ -42,69 +39,84 @@ function buildCleanupMessage(
   }
 }
 
-export function createCleanupRoute(retentionService: ConversationRetentionService): Router {
+/**
+ * POST /api/admin/cleanup — named handler export. Returns 503 if the
+ * retention service wasn't wired. The legacy aggregator gates
+ * conditionally so this branch is only reachable when the route is
+ * mounted unconditionally.
+ */
+export const handleCleanup = (deps: RouteDeps): RequestHandler => {
+  const { retentionService } = deps;
+  if (retentionService === undefined) {
+    return (_req, res) => {
+      sendError(res, ErrorResponses.serviceUnavailable('Retention service not configured'));
+    };
+  }
+  return asyncHandler(async (req: Request, res: Response) => {
+    // Handle missing body gracefully
+    const body = (req.body ?? {}) as {
+      daysToKeep?: number;
+      target?: 'history' | 'tombstones' | 'all';
+    };
+    const { daysToKeep = CLEANUP_DEFAULTS.DAYS_TO_KEEP_HISTORY, target = 'all' } = body;
+
+    // Validate daysToKeep
+    if (
+      typeof daysToKeep !== 'number' ||
+      daysToKeep < CLEANUP_DEFAULTS.MIN_DAYS ||
+      daysToKeep > CLEANUP_DEFAULTS.MAX_DAYS
+    ) {
+      return sendError(
+        res,
+        ErrorResponses.validationError(
+          `daysToKeep must be a number between ${CLEANUP_DEFAULTS.MIN_DAYS} and ${CLEANUP_DEFAULTS.MAX_DAYS}`
+        )
+      );
+    }
+
+    // Validate target
+    if (!['history', 'tombstones', 'all'].includes(target)) {
+      return sendError(
+        res,
+        ErrorResponses.validationError('target must be "history", "tombstones", or "all"')
+      );
+    }
+
+    let historyDeleted = 0;
+    let tombstonesDeleted = 0;
+
+    if (target === 'history' || target === 'all') {
+      historyDeleted = await retentionService.cleanupOldHistory(daysToKeep);
+      logger.info({ historyDeleted, daysToKeep }, 'Cleaned up old conversation history');
+    }
+
+    if (target === 'tombstones' || target === 'all') {
+      tombstonesDeleted = await retentionService.cleanupOldTombstones(daysToKeep);
+      logger.info({ tombstonesDeleted, daysToKeep }, 'Cleaned up old tombstones');
+    }
+
+    const result: CleanupResult = {
+      historyDeleted,
+      tombstonesDeleted,
+      daysKept: daysToKeep,
+    };
+
+    sendCustomSuccess(res, {
+      success: true,
+      ...result,
+      message: buildCleanupMessage(target, historyDeleted, tombstonesDeleted, daysToKeep),
+      timestamp: new Date().toISOString(),
+    });
+  });
+};
+
+/**
+ * Legacy factory for the `/admin/cleanup` mount. Wraps the named
+ * handler with per-route middleware for callers that haven't yet
+ * migrated to the bare handler export.
+ */
+export function createCleanupRoute(deps: RouteDeps): Router {
   const router = Router();
-
-  router.post(
-    '/',
-    requireOwnerAuth(),
-    asyncHandler(async (req: Request, res: Response) => {
-      // Handle missing body gracefully
-      const body = (req.body ?? {}) as {
-        daysToKeep?: number;
-        target?: 'history' | 'tombstones' | 'all';
-      };
-      const { daysToKeep = CLEANUP_DEFAULTS.DAYS_TO_KEEP_HISTORY, target = 'all' } = body;
-
-      // Validate daysToKeep
-      if (
-        typeof daysToKeep !== 'number' ||
-        daysToKeep < CLEANUP_DEFAULTS.MIN_DAYS ||
-        daysToKeep > CLEANUP_DEFAULTS.MAX_DAYS
-      ) {
-        return sendError(
-          res,
-          ErrorResponses.validationError(
-            `daysToKeep must be a number between ${CLEANUP_DEFAULTS.MIN_DAYS} and ${CLEANUP_DEFAULTS.MAX_DAYS}`
-          )
-        );
-      }
-
-      // Validate target
-      if (!['history', 'tombstones', 'all'].includes(target)) {
-        return sendError(
-          res,
-          ErrorResponses.validationError('target must be "history", "tombstones", or "all"')
-        );
-      }
-
-      let historyDeleted = 0;
-      let tombstonesDeleted = 0;
-
-      if (target === 'history' || target === 'all') {
-        historyDeleted = await retentionService.cleanupOldHistory(daysToKeep);
-        logger.info({ historyDeleted, daysToKeep }, 'Cleaned up old conversation history');
-      }
-
-      if (target === 'tombstones' || target === 'all') {
-        tombstonesDeleted = await retentionService.cleanupOldTombstones(daysToKeep);
-        logger.info({ tombstonesDeleted, daysToKeep }, 'Cleaned up old tombstones');
-      }
-
-      const result: CleanupResult = {
-        historyDeleted,
-        tombstonesDeleted,
-        daysKept: daysToKeep,
-      };
-
-      sendCustomSuccess(res, {
-        success: true,
-        ...result,
-        message: buildCleanupMessage(target, historyDeleted, tombstonesDeleted, daysToKeep),
-        timestamp: new Date().toISOString(),
-      });
-    })
-  );
-
+  router.post('/', requireOwnerAuth(), handleCleanup(deps));
   return router;
 }

--- a/services/api-gateway/src/routes/admin/createPersonality.test.ts
+++ b/services/api-gateway/src/routes/admin/createPersonality.test.ts
@@ -64,7 +64,10 @@ describe('POST /admin/personality', () => {
     // Create Express app with create personality router
     app = express();
     app.use(express.json());
-    app.use('/admin/personality', createCreatePersonalityRoute(prisma as unknown as PrismaClient));
+    app.use(
+      '/admin/personality',
+      createCreatePersonalityRoute({ prisma: prisma as unknown as PrismaClient })
+    );
   });
 
   it('should create a new personality with required fields', async () => {
@@ -638,7 +641,10 @@ describe('POST /admin/personality', () => {
       appWithCache.use(express.json());
       appWithCache.use(
         '/admin/personality',
-        createCreatePersonalityRoute(prisma as unknown as PrismaClient, mockCacheService)
+        createCreatePersonalityRoute({
+          prisma: prisma as unknown as PrismaClient,
+          cacheInvalidationService: mockCacheService,
+        })
       );
 
       prisma.personality.findUnique.mockResolvedValue(null);
@@ -692,7 +698,10 @@ describe('POST /admin/personality', () => {
       appWithCache.use(express.json());
       appWithCache.use(
         '/admin/personality',
-        createCreatePersonalityRoute(prisma as unknown as PrismaClient, mockCacheService)
+        createCreatePersonalityRoute({
+          prisma: prisma as unknown as PrismaClient,
+          cacheInvalidationService: mockCacheService,
+        })
       );
 
       prisma.personality.findUnique.mockResolvedValue(null);
@@ -746,7 +755,10 @@ describe('POST /admin/personality', () => {
       appWithCache.use(express.json());
       appWithCache.use(
         '/admin/personality',
-        createCreatePersonalityRoute(prisma as unknown as PrismaClient, mockCacheService)
+        createCreatePersonalityRoute({
+          prisma: prisma as unknown as PrismaClient,
+          cacheInvalidationService: mockCacheService,
+        })
       );
 
       prisma.personality.findUnique.mockResolvedValue(null);

--- a/services/api-gateway/src/routes/admin/createPersonality.ts
+++ b/services/api-gateway/src/routes/admin/createPersonality.ts
@@ -3,7 +3,7 @@
  * Create a new AI personality
  */
 
-import { Router, type Response } from 'express';
+import { Router, type RequestHandler, type Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import {
   createLogger,
@@ -12,7 +12,7 @@ import {
   PersonalityCreateSchema,
   type PersonalityCreateInput,
 } from '@tzurot/common-types';
-import { type PrismaClient, Prisma } from '@tzurot/common-types';
+import { Prisma } from '@tzurot/common-types';
 import { requireOwnerAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
@@ -20,6 +20,7 @@ import { ErrorResponses } from '../../utils/errorResponses.js';
 import { sendZodError } from '../../utils/zodHelpers.js';
 import { processAvatarData } from '../../utils/avatarProcessor.js';
 import type { AuthenticatedRequest } from '../../types.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('admin-create-personality');
 
@@ -85,95 +86,91 @@ function buildPersonalityCreateData(
   };
 }
 
-export function createCreatePersonalityRoute(
-  prisma: PrismaClient,
-  cacheInvalidationService?: CacheInvalidationService
-): Router {
-  const router = Router();
+export const handleCreateGlobalPersonality = (deps: RouteDeps): RequestHandler => {
+  const { prisma, cacheInvalidationService } = deps;
+  return asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+    const discordUserId = req.userId;
 
-  router.post(
-    '/',
-    requireOwnerAuth(),
-    asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
-      const discordUserId = req.userId;
+    // Validate request body with Zod schema
+    const parseResult = PersonalityCreateSchema.safeParse(req.body);
+    if (!parseResult.success) {
+      return sendZodError(res, parseResult.error);
+    }
+    const validated = parseResult.data;
+    const { slug } = validated;
 
-      // Validate request body with Zod schema
-      const parseResult = PersonalityCreateSchema.safeParse(req.body);
-      if (!parseResult.success) {
-        return sendZodError(res, parseResult.error);
-      }
-      const validated = parseResult.data;
-      const { slug } = validated;
+    // Get admin user's internal ID for ownership
+    const adminUser = await prisma.user.findUnique({
+      // eslint-disable-next-line no-restricted-syntax -- Admin owner lookup: route is behind requireOwnerAuth, not requireProvisionedUser, so provisionedUserId is not attached; the Discord ID comes from the X-User-Id header and the internal UUID is needed to populate Personality.ownerId
+      where: { discordId: discordUserId },
+      select: { id: true },
+    });
 
-      // Get admin user's internal ID for ownership
-      const adminUser = await prisma.user.findUnique({
-        // eslint-disable-next-line no-restricted-syntax -- Admin owner lookup: route is behind requireOwnerAuth, not requireProvisionedUser, so provisionedUserId is not attached; the Discord ID comes from the X-User-Id header and the internal UUID is needed to populate Personality.ownerId
-        where: { discordId: discordUserId },
-        select: { id: true },
-      });
+    if (adminUser === null) {
+      logger.warn({ discordUserId }, 'Admin user not found in database');
+      return sendError(res, ErrorResponses.unauthorized('Admin user not found in database'));
+    }
 
-      if (adminUser === null) {
-        logger.warn({ discordUserId }, 'Admin user not found in database');
-        return sendError(res, ErrorResponses.unauthorized('Admin user not found in database'));
-      }
-
-      // Check if personality already exists
-      const existing = await prisma.personality.findUnique({ where: { slug } });
-      if (existing !== null) {
-        return sendError(
-          res,
-          ErrorResponses.conflict(`A personality with slug '${slug}' already exists`)
-        );
-      }
-
-      // Process avatar if provided
-      const avatarResult = await processAvatarData(validated.avatarData, slug);
-      if (avatarResult !== null && !avatarResult.ok) {
-        return sendError(res, avatarResult.error);
-      }
-
-      // Find default system prompt
-      const defaultSystemPrompt = await prisma.systemPrompt.findFirst({
-        where: { isDefault: true },
-        select: { id: true },
-      });
-
-      // Create personality in database
-      const createData = buildPersonalityCreateData({
-        validated,
-        ownerId: adminUser.id,
-        systemPromptId: defaultSystemPrompt?.id ?? null,
-        avatarBuffer: avatarResult?.ok === true ? avatarResult.buffer : undefined,
-      });
-      const personality = await prisma.personality.create({ data: createData });
-
-      logger.info({ slug, personalityId: personality.id }, 'Created personality');
-
-      // Post-creation tasks.
-      // Note: personality_default_configs is intentionally NOT populated here.
-      // New personalities cascade to the current global default at request time
-      // (see PersonalityService.loadPersonality → loadGlobalDefaultConfig). A
-      // per-personality preset pin is an opt-in override, not a creation-time
-      // snapshot — see the "Preset cascade standardization" backlog epic.
-      await invalidateCacheIfPublic(cacheInvalidationService, validated.isPublic, personality.id);
-
-      sendCustomSuccess(
+    // Check if personality already exists
+    const existing = await prisma.personality.findUnique({ where: { slug } });
+    if (existing !== null) {
+      return sendError(
         res,
-        {
-          success: true,
-          personality: {
-            id: personality.id,
-            name: personality.name,
-            slug: personality.slug,
-            displayName: personality.displayName,
-            hasAvatar: avatarResult?.ok === true,
-          },
-          timestamp: new Date().toISOString(),
-        },
-        StatusCodes.CREATED
+        ErrorResponses.conflict(`A personality with slug '${slug}' already exists`)
       );
-    })
-  );
+    }
 
+    // Process avatar if provided
+    const avatarResult = await processAvatarData(validated.avatarData, slug);
+    if (avatarResult !== null && !avatarResult.ok) {
+      return sendError(res, avatarResult.error);
+    }
+
+    // Find default system prompt
+    const defaultSystemPrompt = await prisma.systemPrompt.findFirst({
+      where: { isDefault: true },
+      select: { id: true },
+    });
+
+    // Create personality in database
+    const createData = buildPersonalityCreateData({
+      validated,
+      ownerId: adminUser.id,
+      systemPromptId: defaultSystemPrompt?.id ?? null,
+      avatarBuffer: avatarResult?.ok === true ? avatarResult.buffer : undefined,
+    });
+    const personality = await prisma.personality.create({ data: createData });
+
+    logger.info({ slug, personalityId: personality.id }, 'Created personality');
+
+    // Post-creation tasks.
+    // Note: personality_default_configs is intentionally NOT populated here.
+    // New personalities cascade to the current global default at request time
+    // (see PersonalityService.loadPersonality → loadGlobalDefaultConfig). A
+    // per-personality preset pin is an opt-in override, not a creation-time
+    // snapshot — see the "Preset cascade standardization" backlog epic.
+    await invalidateCacheIfPublic(cacheInvalidationService, validated.isPublic, personality.id);
+
+    sendCustomSuccess(
+      res,
+      {
+        success: true,
+        personality: {
+          id: personality.id,
+          name: personality.name,
+          slug: personality.slug,
+          displayName: personality.displayName,
+          hasAvatar: avatarResult?.ok === true,
+        },
+        timestamp: new Date().toISOString(),
+      },
+      StatusCodes.CREATED
+    );
+  });
+};
+
+export function createCreatePersonalityRoute(deps: RouteDeps): Router {
+  const router = Router();
+  router.post('/', requireOwnerAuth(), handleCreateGlobalPersonality(deps));
   return router;
 }

--- a/services/api-gateway/src/routes/admin/dbSync.test.ts
+++ b/services/api-gateway/src/routes/admin/dbSync.test.ts
@@ -5,7 +5,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import express, { type Express } from 'express';
 import request from 'supertest';
+import type { PrismaClient } from '@tzurot/common-types';
 import { createDbSyncRoute } from './dbSync.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 // Mock DatabaseSyncService
 const mockSync = vi.fn();
@@ -46,10 +48,13 @@ describe('POST /admin/db-sync', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // Create Express app with db-sync router
+    // Create Express app with db-sync router. dbSync doesn't actually
+    // use deps.prisma at runtime (it constructs its own clients from
+    // env-var URLs), so a minimal cast satisfies the type contract.
+    const deps = { prisma: {} as PrismaClient } satisfies RouteDeps;
     app = express();
     app.use(express.json());
-    app.use('/admin/db-sync', createDbSyncRoute());
+    app.use('/admin/db-sync', createDbSyncRoute(deps));
   });
 
   it('should perform database sync successfully', async () => {

--- a/services/api-gateway/src/routes/admin/dbSync.ts
+++ b/services/api-gateway/src/routes/admin/dbSync.ts
@@ -3,7 +3,7 @@
  * Bidirectional database synchronization between dev and prod
  */
 
-import { Router, type Request, type Response } from 'express';
+import { Router, type Request, type RequestHandler, type Response } from 'express';
 import { createLogger, getConfig, DbSyncSchema } from '@tzurot/common-types';
 import { PrismaClient } from '@tzurot/common-types';
 import { PrismaPg } from '@prisma/adapter-pg';
@@ -13,61 +13,71 @@ import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
 import { sendZodError } from '../../utils/zodHelpers.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('admin-db-sync');
 
-export function createDbSyncRoute(): Router {
+/**
+ * POST /api/admin/db-sync — named handler export consumed by the
+ * generated mounts.ts codegen. The returned `RequestHandler` is
+ * composition-ready; middleware (auth, rate limiters) is applied by
+ * the caller — at the prefix mount for codegen-driven routes, or
+ * per-route for the legacy factory below.
+ */
+export const handleDbSync = (_deps: RouteDeps): RequestHandler =>
+  asyncHandler(async (req: Request, res: Response) => {
+    const parseResult = DbSyncSchema.safeParse(req.body);
+    if (!parseResult.success) {
+      return sendZodError(res, parseResult.error);
+    }
+
+    const { dryRun } = parseResult.data;
+    const config = getConfig();
+
+    // Verify database URLs are configured
+    if (
+      config.DEV_DATABASE_URL === undefined ||
+      config.DEV_DATABASE_URL.length === 0 ||
+      config.PROD_DATABASE_URL === undefined ||
+      config.PROD_DATABASE_URL.length === 0
+    ) {
+      return sendError(
+        res,
+        ErrorResponses.configurationError(
+          'Both DEV_DATABASE_URL and PROD_DATABASE_URL must be configured'
+        )
+      );
+    }
+
+    logger.info({ dryRun }, 'Starting database sync');
+
+    // Create Prisma clients for dev and prod databases using driver adapters
+    const devAdapter = new PrismaPg({ connectionString: config.DEV_DATABASE_URL });
+    const devClient = new PrismaClient({ adapter: devAdapter });
+
+    const prodAdapter = new PrismaPg({ connectionString: config.PROD_DATABASE_URL });
+    const prodClient = new PrismaClient({ adapter: prodAdapter });
+
+    // Execute sync - the service handles connect/disconnect internally
+    const syncService = new DatabaseSyncService(devClient, prodClient);
+    const result = await syncService.sync({ dryRun });
+
+    logger.info({ result }, 'Database sync complete');
+
+    sendCustomSuccess(res, {
+      success: true,
+      ...result,
+      timestamp: new Date().toISOString(),
+    });
+  });
+
+/**
+ * Legacy factory for the `/admin/db-sync` mount. Wraps the named
+ * handler with the per-route middleware for callers that haven't
+ * yet migrated to the bare handler export.
+ */
+export function createDbSyncRoute(deps: RouteDeps): Router {
   const router = Router();
-
-  router.post(
-    '/',
-    requireOwnerAuth(),
-    asyncHandler(async (req: Request, res: Response) => {
-      const parseResult = DbSyncSchema.safeParse(req.body);
-      if (!parseResult.success) {
-        return sendZodError(res, parseResult.error);
-      }
-
-      const { dryRun } = parseResult.data;
-      const config = getConfig();
-
-      // Verify database URLs are configured
-      if (
-        config.DEV_DATABASE_URL === undefined ||
-        config.DEV_DATABASE_URL.length === 0 ||
-        config.PROD_DATABASE_URL === undefined ||
-        config.PROD_DATABASE_URL.length === 0
-      ) {
-        return sendError(
-          res,
-          ErrorResponses.configurationError(
-            'Both DEV_DATABASE_URL and PROD_DATABASE_URL must be configured'
-          )
-        );
-      }
-
-      logger.info({ dryRun }, 'Starting database sync');
-
-      // Create Prisma clients for dev and prod databases using driver adapters
-      const devAdapter = new PrismaPg({ connectionString: config.DEV_DATABASE_URL });
-      const devClient = new PrismaClient({ adapter: devAdapter });
-
-      const prodAdapter = new PrismaPg({ connectionString: config.PROD_DATABASE_URL });
-      const prodClient = new PrismaClient({ adapter: prodAdapter });
-
-      // Execute sync - the service handles connect/disconnect internally
-      const syncService = new DatabaseSyncService(devClient, prodClient);
-      const result = await syncService.sync({ dryRun });
-
-      logger.info({ result }, 'Database sync complete');
-
-      sendCustomSuccess(res, {
-        success: true,
-        ...result,
-        timestamp: new Date().toISOString(),
-      });
-    })
-  );
-
+  router.post('/', requireOwnerAuth(), handleDbSync(deps));
   return router;
 }

--- a/services/api-gateway/src/routes/admin/denylist.test.ts
+++ b/services/api-gateway/src/routes/admin/denylist.test.ts
@@ -62,10 +62,10 @@ describe('Denylist Admin Routes', () => {
       // the design in by asserting /cache has exactly one handler in its
       // route stack (asyncHandler only), while every other route has at
       // least two (auth + business logic, plus optional rate limiter).
-      const router = createDenylistRoutes(
-        createMockPrisma() as never,
-        createMockDenylistInvalidation() as never
-      );
+      const router = createDenylistRoutes({
+        prisma: createMockPrisma() as never,
+        denylistInvalidation: createMockDenylistInvalidation() as never,
+      });
       const routes = getAllRoutes(router);
       const cacheRoute = routes.find(r => r.path === '/cache');
       expect(cacheRoute, '/cache route not found in router stack').toBeDefined();
@@ -94,7 +94,10 @@ describe('Denylist Admin Routes', () => {
     app.use(express.json());
     app.use(
       '/admin/denylist',
-      createDenylistRoutes(mockPrisma as never, mockInvalidation as never)
+      createDenylistRoutes({
+        prisma: mockPrisma as never,
+        denylistInvalidation: mockInvalidation as never,
+      })
     );
   });
 

--- a/services/api-gateway/src/routes/admin/denylist.ts
+++ b/services/api-gateway/src/routes/admin/denylist.ts
@@ -9,8 +9,7 @@
  * cache at startup, before any Discord user context exists.
  */
 
-import { Router, type Request, type Response } from 'express';
-import type { Redis } from 'ioredis';
+import { Router, type Request, type RequestHandler, type Response } from 'express';
 import {
   createLogger,
   isBotOwner,
@@ -26,6 +25,7 @@ import { sendCustomSuccess, sendError } from '../../utils/responseHelpers.js';
 import { sendZodError } from '../../utils/zodHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
 import { createRedisDenylistRateLimiter } from '../../utils/RedisRateLimiter.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('admin-denylist');
 
@@ -96,114 +96,132 @@ function handleAddEntry(
 /**
  * Create denylist admin routes
  */
-export function createDenylistRoutes(
-  prisma: PrismaClient,
-  denylistInvalidation: DenylistCacheInvalidationService,
-  redis?: Redis
-): Router {
-  const router = Router();
-  const rateLimiter = redis !== undefined ? createRedisDenylistRateLimiter(redis) : undefined;
-
-  // GET / — List all entries (optional ?type= filter)
-  router.get(
-    '/',
-    requireOwnerAuth(),
-    asyncHandler(async (req: Request, res: Response) => {
-      const typeFilter = req.query.type;
-      let where = {};
-      if (typeof typeFilter === 'string' && typeFilter.length > 0) {
-        const parsed = denylistEntityTypeSchema.safeParse(typeFilter);
-        if (!parsed.success) {
-          sendError(
-            res,
-            ErrorResponses.validationError('Invalid type filter — must be USER or GUILD')
-          );
-          return;
-        }
-        where = { type: parsed.data };
-      }
-
-      const entries = await prisma.denylistedEntity.findMany({
-        where,
-        orderBy: { addedAt: 'desc' },
-        take: LIST_MAX_ENTRIES,
-      });
-
-      sendCustomSuccess(res, { success: true, entries, count: entries.length });
-    })
-  );
-
-  // GET /cache — Bulk fetch for bot-client hydration
-  router.get(
-    '/cache',
-    asyncHandler(async (_req: Request, res: Response) => {
-      const entries = await prisma.denylistedEntity.findMany({ take: CACHE_HYDRATION_MAX_ENTRIES });
-      if (entries.length >= CACHE_HYDRATION_MAX_ENTRIES) {
-        logger.warn(
-          { count: entries.length, limit: CACHE_HYDRATION_MAX_ENTRIES },
-          'Cache hydration hit max entry limit — some entries may not be cached'
+/** GET /api/admin/denylist — list all entries (optional ?type= filter) */
+export const handleListDenylistEntries = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: Request, res: Response) => {
+    const typeFilter = req.query.type;
+    let where = {};
+    if (typeof typeFilter === 'string' && typeFilter.length > 0) {
+      const parsed = denylistEntityTypeSchema.safeParse(typeFilter);
+      if (!parsed.success) {
+        sendError(
+          res,
+          ErrorResponses.validationError('Invalid type filter — must be USER or GUILD')
         );
+        return;
       }
-      sendCustomSuccess(res, { entries });
-    })
-  );
+      where = { type: parsed.data };
+    }
 
-  // POST / — Add denylist entry (rate limited)
+    const entries = await prisma.denylistedEntity.findMany({
+      where,
+      orderBy: { addedAt: 'desc' },
+      take: LIST_MAX_ENTRIES,
+    });
+
+    sendCustomSuccess(res, { success: true, entries, count: entries.length });
+  });
+};
+
+/** GET /api/admin/denylist/cache — bulk fetch for bot-client hydration (service-only) */
+export const handleGetDenylistCache = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (_req: Request, res: Response) => {
+    const entries = await prisma.denylistedEntity.findMany({ take: CACHE_HYDRATION_MAX_ENTRIES });
+    if (entries.length >= CACHE_HYDRATION_MAX_ENTRIES) {
+      logger.warn(
+        { count: entries.length, limit: CACHE_HYDRATION_MAX_ENTRIES },
+        'Cache hydration hit max entry limit — some entries may not be cached'
+      );
+    }
+    sendCustomSuccess(res, { entries });
+  });
+};
+
+/** POST /api/admin/denylist — add/update a denylist entry */
+export const handleAddDenylistEntry = (deps: RouteDeps): RequestHandler => {
+  const { prisma, denylistInvalidation } = deps;
+  if (denylistInvalidation === undefined) {
+    return (_req, res) => {
+      sendError(res, ErrorResponses.serviceUnavailable('Denylist invalidation not configured'));
+    };
+  }
+  return handleAddEntry(prisma, denylistInvalidation);
+};
+
+/** DELETE /api/admin/denylist/:type/:discordId/:scope/:scopeId — remove entry */
+export const handleRemoveDenylistEntry = (deps: RouteDeps): RequestHandler => {
+  const { prisma, denylistInvalidation } = deps;
+  if (denylistInvalidation === undefined) {
+    return (_req, res) => {
+      sendError(res, ErrorResponses.serviceUnavailable('Denylist invalidation not configured'));
+    };
+  }
+  return asyncHandler(async (req: Request, res: Response) => {
+    const typeResult = denylistEntityTypeSchema.safeParse(req.params.type);
+    if (!typeResult.success) {
+      sendError(res, ErrorResponses.validationError('Invalid type — must be USER or GUILD'));
+      return;
+    }
+    const scopeResult = denylistScopeSchema.safeParse(req.params.scope);
+    if (!scopeResult.success) {
+      sendError(
+        res,
+        ErrorResponses.validationError(
+          'Invalid scope — must be BOT, GUILD, CHANNEL, or PERSONALITY'
+        )
+      );
+      return;
+    }
+    const type = typeResult.data;
+    const discordId = req.params.discordId as string;
+    const scope = scopeResult.data;
+    const scopeId = req.params.scopeId as string;
+
+    const existing = await prisma.denylistedEntity.findUnique({
+      where: { type_discordId_scope_scopeId: { type, discordId, scope, scopeId } },
+    });
+
+    if (existing === null) {
+      sendError(res, ErrorResponses.notFound('Denylist entry'));
+      return;
+    }
+
+    await prisma.denylistedEntity.delete({ where: { id: existing.id } });
+
+    await denylistInvalidation.publishRemove({
+      type,
+      discordId,
+      scope,
+      scopeId,
+      mode: existing.mode,
+    });
+    logger.info({ type, discordId, scope, scopeId }, 'Denylist entry removed');
+    sendCustomSuccess(res, { success: true, removed: true });
+  });
+};
+
+/**
+ * Legacy factory composing the 4 denylist endpoints with per-route
+ * middleware (the rate limiter ties them together at the factory
+ * level, so callers that haven't migrated to the bare handlers can
+ * keep the existing mount shape).
+ */
+export function createDenylistRoutes(deps: RouteDeps): Router {
+  const router = Router();
+  const rateLimiter =
+    deps.redis !== undefined ? createRedisDenylistRateLimiter(deps.redis) : undefined;
   const mutationMiddleware = rateLimiter !== undefined ? [rateLimiter] : [];
-  router.post(
-    '/',
-    requireOwnerAuth(),
-    ...mutationMiddleware,
-    handleAddEntry(prisma, denylistInvalidation)
-  );
 
-  // DELETE /:type/:discordId/:scope/:scopeId — Remove entry (rate limited)
+  router.get('/', requireOwnerAuth(), handleListDenylistEntries(deps));
+  router.get('/cache', handleGetDenylistCache(deps));
+  router.post('/', requireOwnerAuth(), ...mutationMiddleware, handleAddDenylistEntry(deps));
   router.delete(
     '/:type/:discordId/:scope/:scopeId',
     requireOwnerAuth(),
     ...mutationMiddleware,
-    asyncHandler(async (req: Request, res: Response) => {
-      const typeResult = denylistEntityTypeSchema.safeParse(req.params.type);
-      if (!typeResult.success) {
-        sendError(res, ErrorResponses.validationError('Invalid type — must be USER or GUILD'));
-        return;
-      }
-      const scopeResult = denylistScopeSchema.safeParse(req.params.scope);
-      if (!scopeResult.success) {
-        sendError(
-          res,
-          ErrorResponses.validationError(
-            'Invalid scope — must be BOT, GUILD, CHANNEL, or PERSONALITY'
-          )
-        );
-        return;
-      }
-      const type = typeResult.data;
-      const discordId = req.params.discordId as string;
-      const scope = scopeResult.data;
-      const scopeId = req.params.scopeId as string;
-
-      const existing = await prisma.denylistedEntity.findUnique({
-        where: { type_discordId_scope_scopeId: { type, discordId, scope, scopeId } },
-      });
-
-      if (existing === null) {
-        sendError(res, ErrorResponses.notFound('Denylist entry'));
-        return;
-      }
-
-      await prisma.denylistedEntity.delete({ where: { id: existing.id } });
-
-      await denylistInvalidation.publishRemove({
-        type,
-        discordId,
-        scope,
-        scopeId,
-        mode: existing.mode,
-      });
-      logger.info({ type, discordId, scope, scopeId }, 'Denylist entry removed');
-      sendCustomSuccess(res, { success: true, removed: true });
-    })
+    handleRemoveDenylistEntry(deps)
   );
 
   return router;

--- a/services/api-gateway/src/routes/admin/index.ts
+++ b/services/api-gateway/src/routes/admin/index.ts
@@ -87,13 +87,10 @@ export function createAdminRouter(opts: AdminRouterOptions): Router {
   router.use('/personality', createUpdatePersonalityRoute(deps));
 
   // LLM config management endpoints
-  router.use(
-    '/llm-config',
-    createAdminLlmConfigRoutes(prisma, llmConfigCacheInvalidation, modelCache)
-  );
+  router.use('/llm-config', createAdminLlmConfigRoutes(deps));
 
   // TTS config management endpoints
-  router.use('/tts-config', createAdminTtsConfigRoutes(prisma, ttsConfigCacheInvalidation));
+  router.use('/tts-config', createAdminTtsConfigRoutes(deps));
 
   // Cache invalidation endpoint
   router.use('/invalidate-cache', createInvalidateCacheRoute(deps));
@@ -102,7 +99,7 @@ export function createAdminRouter(opts: AdminRouterOptions): Router {
   router.use('/usage', createAdminUsageRoutes(deps));
 
   // Bot settings endpoint
-  router.use('/settings', createAdminSettingsRoutes(prisma, cascadeInvalidation));
+  router.use('/settings', createAdminSettingsRoutes(deps));
 
   // Cleanup endpoint (for conversation history and tombstones)
   if (retentionService !== undefined) {
@@ -114,7 +111,7 @@ export function createAdminRouter(opts: AdminRouterOptions): Router {
 
   // Denylist management endpoints (user/guild blocking)
   if (denylistInvalidation !== undefined) {
-    router.use('/denylist', createDenylistRoutes(prisma, denylistInvalidation, redis));
+    router.use('/denylist', createDenylistRoutes(deps));
   }
 
   // Stop sequence activation stats (read from Redis, written by ai-worker)

--- a/services/api-gateway/src/routes/admin/index.ts
+++ b/services/api-gateway/src/routes/admin/index.ts
@@ -84,7 +84,7 @@ export function createAdminRouter(opts: AdminRouterOptions): Router {
 
   // Personality management endpoints
   router.use('/personality', createCreatePersonalityRoute(deps));
-  router.use('/personality', createUpdatePersonalityRoute(prisma, cacheInvalidationService));
+  router.use('/personality', createUpdatePersonalityRoute(deps));
 
   // LLM config management endpoints
   router.use(
@@ -99,7 +99,7 @@ export function createAdminRouter(opts: AdminRouterOptions): Router {
   router.use('/invalidate-cache', createInvalidateCacheRoute(deps));
 
   // Usage statistics endpoint
-  router.use('/usage', createAdminUsageRoutes(prisma));
+  router.use('/usage', createAdminUsageRoutes(deps));
 
   // Bot settings endpoint
   router.use('/settings', createAdminSettingsRoutes(prisma, cascadeInvalidation));
@@ -119,7 +119,7 @@ export function createAdminRouter(opts: AdminRouterOptions): Router {
 
   // Stop sequence activation stats (read from Redis, written by ai-worker)
   if (redis !== undefined) {
-    router.use('/stop-sequences', createStopSequenceRoutes(redis));
+    router.use('/stop-sequences', createStopSequenceRoutes(deps));
   }
 
   return router;

--- a/services/api-gateway/src/routes/admin/index.ts
+++ b/services/api-gateway/src/routes/admin/index.ts
@@ -83,7 +83,7 @@ export function createAdminRouter(opts: AdminRouterOptions): Router {
   router.use('/db-sync', createDbSyncRoute(deps));
 
   // Personality management endpoints
-  router.use('/personality', createCreatePersonalityRoute(prisma, cacheInvalidationService));
+  router.use('/personality', createCreatePersonalityRoute(deps));
   router.use('/personality', createUpdatePersonalityRoute(prisma, cacheInvalidationService));
 
   // LLM config management endpoints

--- a/services/api-gateway/src/routes/admin/index.ts
+++ b/services/api-gateway/src/routes/admin/index.ts
@@ -18,6 +18,7 @@ import {
 } from '@tzurot/common-types';
 import type { Redis } from 'ioredis';
 import type { OpenRouterModelCache } from '../../services/OpenRouterModelCache.js';
+import type { RouteDeps } from '../routeDeps.js';
 import { createDbSyncRoute } from './dbSync.js';
 import { createCreatePersonalityRoute } from './createPersonality.js';
 import { createUpdatePersonalityRoute } from './updatePersonality.js';
@@ -58,12 +59,28 @@ export function createAdminRouter(opts: AdminRouterOptions): Router {
     cascadeInvalidation,
     redis,
   } = opts;
+
+  // Build the shared RouteDeps once; refactored factories accept it.
+  // Legacy factories that still take per-arg signatures get the
+  // individual values forwarded below.
+  const deps: RouteDeps = {
+    prisma,
+    cacheInvalidationService,
+    llmConfigCacheInvalidation,
+    ttsConfigCacheInvalidation,
+    retentionService,
+    modelCache,
+    denylistInvalidation,
+    cascadeInvalidation,
+    redis,
+  };
+
   const router = Router();
 
   // Note: Service auth is applied globally - no need to apply here
 
   // Database sync endpoint
-  router.use('/db-sync', createDbSyncRoute());
+  router.use('/db-sync', createDbSyncRoute(deps));
 
   // Personality management endpoints
   router.use('/personality', createCreatePersonalityRoute(prisma, cacheInvalidationService));

--- a/services/api-gateway/src/routes/admin/index.ts
+++ b/services/api-gateway/src/routes/admin/index.ts
@@ -96,7 +96,7 @@ export function createAdminRouter(opts: AdminRouterOptions): Router {
   router.use('/tts-config', createAdminTtsConfigRoutes(prisma, ttsConfigCacheInvalidation));
 
   // Cache invalidation endpoint
-  router.use('/invalidate-cache', createInvalidateCacheRoute(cacheInvalidationService));
+  router.use('/invalidate-cache', createInvalidateCacheRoute(deps));
 
   // Usage statistics endpoint
   router.use('/usage', createAdminUsageRoutes(prisma));
@@ -106,7 +106,7 @@ export function createAdminRouter(opts: AdminRouterOptions): Router {
 
   // Cleanup endpoint (for conversation history and tombstones)
   if (retentionService !== undefined) {
-    router.use('/cleanup', createCleanupRoute(retentionService));
+    router.use('/cleanup', createCleanupRoute(deps));
   }
 
   // Diagnostic logs endpoint (flight recorder for LLM requests)

--- a/services/api-gateway/src/routes/admin/invalidateCache.test.ts
+++ b/services/api-gateway/src/routes/admin/invalidateCache.test.ts
@@ -5,7 +5,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import express, { type Express } from 'express';
 import request from 'supertest';
+import type { PrismaClient } from '@tzurot/common-types';
 import { createInvalidateCacheRoute } from './invalidateCache.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 // Mock AuthMiddleware
 vi.mock('../../services/AuthMiddleware.js', () => ({
@@ -34,9 +36,14 @@ describe('POST /admin/invalidate-cache', () => {
     cacheInvalidationService = createMockCacheInvalidationService();
 
     // Create Express app with invalidate cache router
+    const deps: RouteDeps = {
+      prisma: {} as PrismaClient,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock service satisfies the interface at the call sites the handler exercises
+      cacheInvalidationService: cacheInvalidationService as any,
+    };
     app = express();
     app.use(express.json());
-    app.use('/admin/invalidate-cache', createInvalidateCacheRoute(cacheInvalidationService as any));
+    app.use('/admin/invalidate-cache', createInvalidateCacheRoute(deps));
   });
 
   it('should invalidate specific personality cache', async () => {

--- a/services/api-gateway/src/routes/admin/invalidateCache.ts
+++ b/services/api-gateway/src/routes/admin/invalidateCache.ts
@@ -3,59 +3,62 @@
  * Manually trigger cache invalidation for personality configurations
  */
 
-import { Router, type Request, type Response } from 'express';
-import {
-  createLogger,
-  type CacheInvalidationService,
-  InvalidateCacheSchema,
-} from '@tzurot/common-types';
+import { Router, type Request, type RequestHandler, type Response } from 'express';
+import { createLogger, InvalidateCacheSchema } from '@tzurot/common-types';
 import { requireOwnerAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
-import { sendCustomSuccess } from '../../utils/responseHelpers.js';
+import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
+import { ErrorResponses } from '../../utils/errorResponses.js';
 import { sendZodError } from '../../utils/zodHelpers.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('admin-invalidate-cache');
 
-export function createInvalidateCacheRoute(
-  cacheInvalidationService: CacheInvalidationService
-): Router {
+export const handleInvalidateCache = (deps: RouteDeps): RequestHandler => {
+  const { cacheInvalidationService } = deps;
+  if (cacheInvalidationService === undefined) {
+    return (_req, res) => {
+      sendError(
+        res,
+        ErrorResponses.serviceUnavailable('Cache invalidation service not configured')
+      );
+    };
+  }
+  return asyncHandler(async (req: Request, res: Response) => {
+    const parseResult = InvalidateCacheSchema.safeParse(req.body);
+    if (!parseResult.success) {
+      return sendZodError(res, parseResult.error);
+    }
+
+    const { personalityId, all } = parseResult.data;
+
+    if (all) {
+      // Invalidate all personality caches
+      await cacheInvalidationService.invalidateAll();
+      logger.info('Invalidated all personality caches');
+
+      sendCustomSuccess(res, {
+        success: true,
+        invalidated: 'all',
+        message: 'All personality caches invalidated across all services',
+        timestamp: new Date().toISOString(),
+      });
+    } else if (personalityId !== undefined) {
+      await cacheInvalidationService.invalidatePersonality(personalityId);
+      logger.info({ personalityId }, 'Invalidated cache for personality');
+
+      sendCustomSuccess(res, {
+        success: true,
+        invalidated: personalityId,
+        message: `Cache invalidated for personality ${personalityId} across all services`,
+        timestamp: new Date().toISOString(),
+      });
+    }
+  });
+};
+
+export function createInvalidateCacheRoute(deps: RouteDeps): Router {
   const router = Router();
-
-  router.post(
-    '/',
-    requireOwnerAuth(),
-    asyncHandler(async (req: Request, res: Response) => {
-      const parseResult = InvalidateCacheSchema.safeParse(req.body);
-      if (!parseResult.success) {
-        return sendZodError(res, parseResult.error);
-      }
-
-      const { personalityId, all } = parseResult.data;
-
-      if (all) {
-        // Invalidate all personality caches
-        await cacheInvalidationService.invalidateAll();
-        logger.info('Invalidated all personality caches');
-
-        sendCustomSuccess(res, {
-          success: true,
-          invalidated: 'all',
-          message: 'All personality caches invalidated across all services',
-          timestamp: new Date().toISOString(),
-        });
-      } else if (personalityId !== undefined) {
-        await cacheInvalidationService.invalidatePersonality(personalityId);
-        logger.info({ personalityId }, 'Invalidated cache for personality');
-
-        sendCustomSuccess(res, {
-          success: true,
-          invalidated: personalityId,
-          message: `Cache invalidated for personality ${personalityId} across all services`,
-          timestamp: new Date().toISOString(),
-        });
-      }
-    })
-  );
-
+  router.post('/', requireOwnerAuth(), handleInvalidateCache(deps));
   return router;
 }

--- a/services/api-gateway/src/routes/admin/llm-config.test.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.test.ts
@@ -79,7 +79,9 @@ const createMockPrismaClient = () => {
 describe('Admin LLM Config Routes', () => {
   describe('middleware composition', () => {
     it('wires requireOwnerAuth on every route', () => {
-      const routes = getAllRoutes(createAdminLlmConfigRoutes({} as unknown as PrismaClient));
+      const routes = getAllRoutes(
+        createAdminLlmConfigRoutes({ prisma: {} as unknown as PrismaClient })
+      );
       expect(routes.length, 'expected at least one registered route').toBeGreaterThan(0);
       for (const route of routes) {
         expect(route.stackLength, `${route.path} missing auth middleware`).toBeGreaterThanOrEqual(
@@ -101,7 +103,10 @@ describe('Admin LLM Config Routes', () => {
 
     app = express();
     app.use(express.json());
-    app.use('/admin/llm-config', createAdminLlmConfigRoutes(prisma as unknown as PrismaClient));
+    app.use(
+      '/admin/llm-config',
+      createAdminLlmConfigRoutes({ prisma: prisma as unknown as PrismaClient })
+    );
   });
 
   describe('GET /admin/llm-config', () => {
@@ -966,10 +971,10 @@ describe('Admin LLM Config Routes', () => {
       appWithCache.use(express.json());
       appWithCache.use(
         '/admin/llm-config',
-        createAdminLlmConfigRoutes(
-          prisma as unknown as PrismaClient,
-          cacheService as unknown as LlmConfigCacheInvalidationService
-        )
+        createAdminLlmConfigRoutes({
+          prisma: prisma as unknown as PrismaClient,
+          llmConfigCacheInvalidation: cacheService as unknown as LlmConfigCacheInvalidationService,
+        })
       );
     });
 
@@ -1062,11 +1067,12 @@ describe('Admin LLM Config Routes', () => {
       appWithModel.use(express.json());
       appWithModel.use(
         '/admin/llm-config',
-        createAdminLlmConfigRoutes(
-          prisma as unknown as PrismaClient,
-          cacheService as unknown as LlmConfigCacheInvalidationService,
-          mockModelCache as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache
-        )
+        createAdminLlmConfigRoutes({
+          prisma: prisma as unknown as PrismaClient,
+          llmConfigCacheInvalidation: cacheService as unknown as LlmConfigCacheInvalidationService,
+          modelCache:
+            mockModelCache as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache,
+        })
       );
 
       prisma.llmConfig.findUnique.mockResolvedValue({
@@ -1114,11 +1120,12 @@ describe('Admin LLM Config Routes', () => {
       appWithModel.use(express.json());
       appWithModel.use(
         '/admin/llm-config',
-        createAdminLlmConfigRoutes(
-          prisma as unknown as PrismaClient,
-          cacheService as unknown as LlmConfigCacheInvalidationService,
-          mockModelCache as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache
-        )
+        createAdminLlmConfigRoutes({
+          prisma: prisma as unknown as PrismaClient,
+          llmConfigCacheInvalidation: cacheService as unknown as LlmConfigCacheInvalidationService,
+          modelCache:
+            mockModelCache as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache,
+        })
       );
 
       prisma.llmConfig.findFirst.mockResolvedValue(null);
@@ -1169,11 +1176,12 @@ describe('Admin LLM Config Routes', () => {
       appWithModel.use(express.json());
       appWithModel.use(
         '/admin/llm-config',
-        createAdminLlmConfigRoutes(
-          prisma as unknown as PrismaClient,
-          cacheService as unknown as LlmConfigCacheInvalidationService,
-          mockModelCache as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache
-        )
+        createAdminLlmConfigRoutes({
+          prisma: prisma as unknown as PrismaClient,
+          llmConfigCacheInvalidation: cacheService as unknown as LlmConfigCacheInvalidationService,
+          modelCache:
+            mockModelCache as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache,
+        })
       );
 
       prisma.llmConfig.findUnique.mockResolvedValue({

--- a/services/api-gateway/src/routes/admin/llm-config.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.ts
@@ -12,12 +12,11 @@
  * - DELETE /admin/llm-config/:id - Delete a global config
  */
 
-import { Router, type Response, type Request } from 'express';
+import { Router, type Response, type Request, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import {
   createLogger,
   type PrismaClient,
-  type LlmConfigCacheInvalidationService,
   // Shared schemas from common-types - single source of truth
   LlmConfigCreateSchema,
   LlmConfigUpdateSchema,
@@ -39,6 +38,7 @@ import {
   ensureNoNameCollision,
   shapeDeleteResponse,
 } from '../../utils/configRouteHelpers.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('admin-llm-config');
 
@@ -302,45 +302,49 @@ function createDeleteConfigHandler(service: LlmConfigService, prisma: PrismaClie
   };
 }
 
+// --- Exported handler factories (each constructs its own service from deps) ---
+
+function buildService(deps: RouteDeps): LlmConfigService {
+  return new LlmConfigService(deps.prisma, deps.llmConfigCacheInvalidation);
+}
+
+export const handleListGlobalLlmConfigs = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createListHandler(buildService(deps)));
+
+export const handleGetGlobalLlmConfig = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createGetHandler(buildService(deps), deps.modelCache));
+
+export const handleCreateGlobalLlmConfig = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createCreateConfigHandler(buildService(deps), deps.prisma, deps.modelCache));
+
+export const handleUpdateGlobalLlmConfig = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createEditConfigHandler(buildService(deps), deps.prisma, deps.modelCache));
+
+export const handleSetGlobalLlmConfigDefault = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createSetDefaultHandler(buildService(deps), deps.prisma));
+
+export const handleSetGlobalLlmConfigFreeDefault = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createSetFreeDefaultHandler(buildService(deps), deps.prisma));
+
+export const handleDeleteGlobalLlmConfig = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createDeleteConfigHandler(buildService(deps), deps.prisma));
+
 // --- Main Route Factory ---
 
-export function createAdminLlmConfigRoutes(
-  prisma: PrismaClient,
-  llmConfigCacheInvalidation?: LlmConfigCacheInvalidationService,
-  modelCache?: OpenRouterModelCache
-): Router {
+export function createAdminLlmConfigRoutes(deps: RouteDeps): Router {
   const router = Router();
 
-  // Instantiate service with dependencies
-  const service = new LlmConfigService(prisma, llmConfigCacheInvalidation);
-
-  router.get('/', requireOwnerAuth(), asyncHandler(createListHandler(service)));
-  router.get('/:id', requireOwnerAuth(), asyncHandler(createGetHandler(service, modelCache)));
-  router.post(
-    '/',
-    requireOwnerAuth(),
-    asyncHandler(createCreateConfigHandler(service, prisma, modelCache))
-  );
-  router.put(
-    '/:id',
-    requireOwnerAuth(),
-    asyncHandler(createEditConfigHandler(service, prisma, modelCache))
-  );
-  router.put(
-    '/:id/set-default',
-    requireOwnerAuth(),
-    asyncHandler(createSetDefaultHandler(service, prisma))
-  );
+  router.get('/', requireOwnerAuth(), handleListGlobalLlmConfigs(deps));
+  router.get('/:id', requireOwnerAuth(), handleGetGlobalLlmConfig(deps));
+  router.post('/', requireOwnerAuth(), handleCreateGlobalLlmConfig(deps));
+  router.put('/:id', requireOwnerAuth(), handleUpdateGlobalLlmConfig(deps));
+  router.put('/:id/set-default', requireOwnerAuth(), handleSetGlobalLlmConfigDefault(deps));
   router.put(
     '/:id/set-free-default',
     requireOwnerAuth(),
-    asyncHandler(createSetFreeDefaultHandler(service, prisma))
+    handleSetGlobalLlmConfigFreeDefault(deps)
   );
-  router.delete(
-    '/:id',
-    requireOwnerAuth(),
-    asyncHandler(createDeleteConfigHandler(service, prisma))
-  );
+  router.delete('/:id', requireOwnerAuth(), handleDeleteGlobalLlmConfig(deps));
 
   return router;
 }

--- a/services/api-gateway/src/routes/admin/settings.test.ts
+++ b/services/api-gateway/src/routes/admin/settings.test.ts
@@ -110,7 +110,9 @@ describe('Admin Settings Routes (Singleton)', () => {
       // owner-only writes — they got the standard requireOwnerAuth middleware
       // in this PR. Lock the asymmetry in by asserting the resulting stack
       // lengths.
-      const router = createAdminSettingsRoutes(createMockPrisma() as unknown as PrismaClient);
+      const router = createAdminSettingsRoutes({
+        prisma: createMockPrisma() as unknown as PrismaClient,
+      });
       const routes = getAllRoutes(router);
       const byPath = new Map(routes.map(r => [`${r.methods[0]} ${r.path}`, r]));
       expect(byPath.get('get /')?.stackLength, 'GET / must stay inline-auth (1 handler)').toBe(1);
@@ -147,7 +149,10 @@ describe('Admin Settings Routes (Singleton)', () => {
       req.headers['x-user-id'] = MOCK_USER_ID;
       next();
     });
-    app.use('/admin/settings', createAdminSettingsRoutes(mockPrisma as unknown as PrismaClient));
+    app.use(
+      '/admin/settings',
+      createAdminSettingsRoutes({ prisma: mockPrisma as unknown as PrismaClient })
+    );
     // Add error handler
     app.use(
       (err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
@@ -210,7 +215,7 @@ describe('Admin Settings Routes (Singleton)', () => {
       // Intentionally NOT injecting userId - simulating internal service call
       appWithoutUserId.use(
         '/admin/settings',
-        createAdminSettingsRoutes(mockPrisma as unknown as PrismaClient)
+        createAdminSettingsRoutes({ prisma: mockPrisma as unknown as PrismaClient })
       );
     });
 
@@ -314,7 +319,10 @@ describe('Admin Settings Routes (Singleton)', () => {
       });
       appWithInvalidation.use(
         '/admin/settings',
-        createAdminSettingsRoutes(mockPrisma as unknown as PrismaClient, mockInvalidation as never)
+        createAdminSettingsRoutes({
+          prisma: mockPrisma as unknown as PrismaClient,
+          cascadeInvalidation: mockInvalidation as never,
+        })
       );
 
       const updatedSettings = createDefaultSettings({
@@ -385,7 +393,10 @@ describe('Admin Settings Routes (Singleton)', () => {
       });
       appWithInvalidation.use(
         '/admin/settings',
-        createAdminSettingsRoutes(mockPrisma as unknown as PrismaClient, mockInvalidation as never)
+        createAdminSettingsRoutes({
+          prisma: mockPrisma as unknown as PrismaClient,
+          cascadeInvalidation: mockInvalidation as never,
+        })
       );
 
       mockPrisma.adminSettings.update.mockResolvedValue(createDefaultSettings());

--- a/services/api-gateway/src/routes/admin/settings.ts
+++ b/services/api-gateway/src/routes/admin/settings.ts
@@ -15,7 +15,7 @@
  * user-context requests from non-owners (see `GatewayClient.getAdminSettings()`).
  */
 
-import { Router, type Request, type Response } from 'express';
+import { Router, type Request, type RequestHandler, type Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import {
   type PrismaClient,
@@ -31,6 +31,7 @@ import { mergeConfigOverrides } from '../../utils/configOverrideMerge.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
 import { isAuthorizedForRead, requireOwnerAuth } from '../../services/AuthMiddleware.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('admin-settings-routes');
 
@@ -130,57 +131,56 @@ function createConfigDefaultsPatchHandler(
   });
 }
 
-export function createAdminSettingsRoutes(
-  prisma: PrismaClient,
-  cascadeInvalidation?: ConfigCascadeCacheInvalidationService
-): Router {
+/**
+ * GET /api/admin/settings — Get the AdminSettings singleton.
+ * Authorization: service-only OR bot owner (special auth shape — see file
+ * header). The handler keeps the inline `isAuthorizedForRead` check.
+ */
+export const handleGetAdminSettings = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+    if (!isAuthorizedForRead(req.userId)) {
+      sendError(res, ErrorResponses.unauthorized('Only bot owners can view settings'));
+      return;
+    }
+
+    const settings = await getOrCreateSettings(prisma);
+    const response = buildResponse(settings);
+    AdminSettingsSchema.parse(response);
+    sendCustomSuccess(res, response, StatusCodes.OK);
+  });
+};
+
+/** PATCH /api/admin/settings/config-defaults — flat-body partial update */
+export const handleUpdateAdminSettings = (deps: RouteDeps): RequestHandler => {
+  return createConfigDefaultsPatchHandler(deps.prisma, deps.cascadeInvalidation);
+};
+
+/** DELETE /api/admin/settings/config-defaults — clear all admin config defaults */
+export const handleClearAdminSettings = (deps: RouteDeps): RequestHandler => {
+  const { prisma, cascadeInvalidation } = deps;
+  return asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+    const userUuid = await resolveUserUuid(prisma, req.userId);
+    await getOrCreateSettings(prisma); // Ensure singleton exists
+
+    await prisma.adminSettings.update({
+      where: { id: ADMIN_SETTINGS_SINGLETON_ID },
+      data: {
+        configDefaults: Prisma.JsonNull,
+        updatedBy: userUuid,
+      },
+    });
+
+    await tryInvalidateAdmin(cascadeInvalidation);
+
+    sendCustomSuccess(res, { success: true }, StatusCodes.OK);
+  });
+};
+
+export function createAdminSettingsRoutes(deps: RouteDeps): Router {
   const router = Router();
-
-  // GET /admin/settings - Get the AdminSettings singleton
-  // Authorization: allows service-only calls, requires bot owner for user requests
-  router.get(
-    '/',
-    asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
-      if (!isAuthorizedForRead(req.userId)) {
-        sendError(res, ErrorResponses.unauthorized('Only bot owners can view settings'));
-        return;
-      }
-
-      const settings = await getOrCreateSettings(prisma);
-      const response = buildResponse(settings);
-      AdminSettingsSchema.parse(response);
-      sendCustomSuccess(res, response, StatusCodes.OK);
-    })
-  );
-
-  // PATCH /admin/settings/config-defaults - Flat body (same shape as all cascade tiers)
-  router.patch(
-    '/config-defaults',
-    requireOwnerAuth(),
-    createConfigDefaultsPatchHandler(prisma, cascadeInvalidation)
-  );
-
-  // DELETE /admin/settings/config-defaults - Clear all admin config defaults
-  router.delete(
-    '/config-defaults',
-    requireOwnerAuth(),
-    asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
-      const userUuid = await resolveUserUuid(prisma, req.userId);
-      await getOrCreateSettings(prisma); // Ensure singleton exists
-
-      await prisma.adminSettings.update({
-        where: { id: ADMIN_SETTINGS_SINGLETON_ID },
-        data: {
-          configDefaults: Prisma.JsonNull,
-          updatedBy: userUuid,
-        },
-      });
-
-      await tryInvalidateAdmin(cascadeInvalidation);
-
-      sendCustomSuccess(res, { success: true }, StatusCodes.OK);
-    })
-  );
-
+  router.get('/', handleGetAdminSettings(deps));
+  router.patch('/config-defaults', requireOwnerAuth(), handleUpdateAdminSettings(deps));
+  router.delete('/config-defaults', requireOwnerAuth(), handleClearAdminSettings(deps));
   return router;
 }

--- a/services/api-gateway/src/routes/admin/stopSequences.test.ts
+++ b/services/api-gateway/src/routes/admin/stopSequences.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 import type { Redis } from 'ioredis';
+import type { PrismaClient } from '@tzurot/common-types';
 import { createStopSequenceRoutes } from './stopSequences.js';
 import { getAllRoutes } from '../../test/expressRouterUtils.js';
 
@@ -57,14 +58,22 @@ function createMockRedis(
 
 function createApp(redis: Redis) {
   const app = express();
-  app.use('/admin/stop-sequences', createStopSequenceRoutes(redis));
+  app.use(
+    '/admin/stop-sequences',
+    createStopSequenceRoutes({ prisma: {} as unknown as PrismaClient, redis })
+  );
   return app;
 }
 
 describe('Admin Stop Sequence Routes', () => {
   describe('middleware composition', () => {
     it('wires requireOwnerAuth on every route', () => {
-      const routes = getAllRoutes(createStopSequenceRoutes({} as unknown as Redis));
+      const routes = getAllRoutes(
+        createStopSequenceRoutes({
+          prisma: {} as unknown as PrismaClient,
+          redis: {} as unknown as Redis,
+        })
+      );
       expect(routes.length, 'expected at least one registered route').toBeGreaterThan(0);
       for (const route of routes) {
         expect(route.stackLength, `${route.path} missing auth middleware`).toBeGreaterThanOrEqual(

--- a/services/api-gateway/src/routes/admin/stopSequences.ts
+++ b/services/api-gateway/src/routes/admin/stopSequences.ts
@@ -6,13 +6,14 @@
  * so bot-client can display them without direct ai-worker access.
  */
 
-import { Router, type Response, type Request } from 'express';
+import { Router, type Response, type Request, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { createLogger } from '@tzurot/common-types';
-import type { Redis } from 'ioredis';
 import { requireOwnerAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
-import { sendCustomSuccess } from '../../utils/responseHelpers.js';
+import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
+import { ErrorResponses } from '../../utils/errorResponses.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('admin-stop-sequences');
 
@@ -24,47 +25,51 @@ const REDIS_KEYS = {
   STARTED_AT: 'stop_seq:started_at',
 } as const;
 
-export function createStopSequenceRoutes(redis: Redis): Router {
+export const handleGetStopSequencesStats = (deps: RouteDeps): RequestHandler => {
+  const { redis } = deps;
+  if (redis === undefined) {
+    return (_req, res) => {
+      sendError(res, ErrorResponses.serviceUnavailable('Redis not configured'));
+    };
+  }
+  return asyncHandler(async (_req: Request, res: Response) => {
+    const [totalStr, bySequence, byModel, startedAt] = await Promise.all([
+      redis.get(REDIS_KEYS.TOTAL),
+      redis.hgetall(REDIS_KEYS.BY_SEQUENCE),
+      redis.hgetall(REDIS_KEYS.BY_MODEL),
+      redis.get(REDIS_KEYS.STARTED_AT),
+    ]);
+
+    const total = totalStr !== null ? parseInt(totalStr, 10) : 0;
+
+    // Convert hash string values to numbers
+    const bySequenceNums: Record<string, number> = {};
+    for (const [key, val] of Object.entries(bySequence)) {
+      bySequenceNums[key] = parseInt(val, 10);
+    }
+
+    const byModelNums: Record<string, number> = {};
+    for (const [key, val] of Object.entries(byModel)) {
+      byModelNums[key] = parseInt(val, 10);
+    }
+
+    logger.info({ total }, 'Returned stats');
+
+    sendCustomSuccess(
+      res,
+      {
+        totalActivations: total,
+        bySequence: bySequenceNums,
+        byModel: byModelNums,
+        startedAt: startedAt ?? new Date().toISOString(),
+      },
+      StatusCodes.OK
+    );
+  });
+};
+
+export function createStopSequenceRoutes(deps: RouteDeps): Router {
   const router = Router();
-
-  router.get(
-    '/',
-    requireOwnerAuth(),
-    asyncHandler(async (_req: Request, res: Response) => {
-      const [totalStr, bySequence, byModel, startedAt] = await Promise.all([
-        redis.get(REDIS_KEYS.TOTAL),
-        redis.hgetall(REDIS_KEYS.BY_SEQUENCE),
-        redis.hgetall(REDIS_KEYS.BY_MODEL),
-        redis.get(REDIS_KEYS.STARTED_AT),
-      ]);
-
-      const total = totalStr !== null ? parseInt(totalStr, 10) : 0;
-
-      // Convert hash string values to numbers
-      const bySequenceNums: Record<string, number> = {};
-      for (const [key, val] of Object.entries(bySequence)) {
-        bySequenceNums[key] = parseInt(val, 10);
-      }
-
-      const byModelNums: Record<string, number> = {};
-      for (const [key, val] of Object.entries(byModel)) {
-        byModelNums[key] = parseInt(val, 10);
-      }
-
-      logger.info({ total }, 'Returned stats');
-
-      sendCustomSuccess(
-        res,
-        {
-          totalActivations: total,
-          bySequence: bySequenceNums,
-          byModel: byModelNums,
-          startedAt: startedAt ?? new Date().toISOString(),
-        },
-        StatusCodes.OK
-      );
-    })
-  );
-
+  router.get('/', requireOwnerAuth(), handleGetStopSequencesStats(deps));
   return router;
 }

--- a/services/api-gateway/src/routes/admin/tts-config.test.ts
+++ b/services/api-gateway/src/routes/admin/tts-config.test.ts
@@ -126,7 +126,7 @@ const mockPrisma = {
 };
 
 function buildRouter() {
-  return createAdminTtsConfigRoutes(mockPrisma as never);
+  return createAdminTtsConfigRoutes({ prisma: mockPrisma as never });
 }
 
 describe('admin/tts-config routes', () => {

--- a/services/api-gateway/src/routes/admin/tts-config.ts
+++ b/services/api-gateway/src/routes/admin/tts-config.ts
@@ -21,13 +21,12 @@
  * (LLM-specific OpenRouter convention) but applies the TTS-shaped invariant.
  */
 
-import { Router, type Response, type Request } from 'express';
+import { Router, type Response, type Request, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import {
   createLogger,
   isSelfHostedTtsProvider,
   type PrismaClient,
-  type TtsConfigCacheInvalidationService,
   TtsConfigCreateSchema,
   TtsConfigUpdateSchema,
 } from '@tzurot/common-types';
@@ -45,6 +44,7 @@ import {
   ensureNoNameCollision,
   shapeDeleteResponse,
 } from '../../utils/configRouteHelpers.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('admin-tts-config');
 
@@ -305,30 +305,49 @@ function createDeleteHandler(service: TtsConfigService, prisma: PrismaClient) {
   };
 }
 
+// --- Exported handler factories --------------------------------------------
+
+function buildService(deps: RouteDeps): TtsConfigService {
+  return new TtsConfigService(deps.prisma, deps.ttsConfigCacheInvalidation);
+}
+
+export const handleListGlobalTtsConfigs = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createListHandler(buildService(deps)));
+
+export const handleGetGlobalTtsConfig = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createGetHandler(buildService(deps)));
+
+export const handleCreateGlobalTtsConfig = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createCreateHandler(buildService(deps), deps.prisma));
+
+export const handleUpdateGlobalTtsConfig = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createEditHandler(buildService(deps), deps.prisma));
+
+export const handleSetGlobalTtsConfigDefault = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createSetDefaultHandler(buildService(deps), deps.prisma));
+
+export const handleSetGlobalTtsConfigFreeDefault = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createSetFreeDefaultHandler(buildService(deps), deps.prisma));
+
+export const handleDeleteGlobalTtsConfig = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createDeleteHandler(buildService(deps), deps.prisma));
+
 // --- Main route factory ----------------------------------------------------
 
-export function createAdminTtsConfigRoutes(
-  prisma: PrismaClient,
-  ttsConfigCacheInvalidation?: TtsConfigCacheInvalidationService
-): Router {
+export function createAdminTtsConfigRoutes(deps: RouteDeps): Router {
   const router = Router();
-  const service = new TtsConfigService(prisma, ttsConfigCacheInvalidation);
 
-  router.get('/', requireOwnerAuth(), asyncHandler(createListHandler(service)));
-  router.get('/:id', requireOwnerAuth(), asyncHandler(createGetHandler(service)));
-  router.post('/', requireOwnerAuth(), asyncHandler(createCreateHandler(service, prisma)));
-  router.put('/:id', requireOwnerAuth(), asyncHandler(createEditHandler(service, prisma)));
-  router.put(
-    '/:id/set-default',
-    requireOwnerAuth(),
-    asyncHandler(createSetDefaultHandler(service, prisma))
-  );
+  router.get('/', requireOwnerAuth(), handleListGlobalTtsConfigs(deps));
+  router.get('/:id', requireOwnerAuth(), handleGetGlobalTtsConfig(deps));
+  router.post('/', requireOwnerAuth(), handleCreateGlobalTtsConfig(deps));
+  router.put('/:id', requireOwnerAuth(), handleUpdateGlobalTtsConfig(deps));
+  router.put('/:id/set-default', requireOwnerAuth(), handleSetGlobalTtsConfigDefault(deps));
   router.put(
     '/:id/set-free-default',
     requireOwnerAuth(),
-    asyncHandler(createSetFreeDefaultHandler(service, prisma))
+    handleSetGlobalTtsConfigFreeDefault(deps)
   );
-  router.delete('/:id', requireOwnerAuth(), asyncHandler(createDeleteHandler(service, prisma)));
+  router.delete('/:id', requireOwnerAuth(), handleDeleteGlobalTtsConfig(deps));
 
   return router;
 }

--- a/services/api-gateway/src/routes/admin/updatePersonality.test.ts
+++ b/services/api-gateway/src/routes/admin/updatePersonality.test.ts
@@ -55,7 +55,10 @@ describe('PATCH /admin/personality/:slug', () => {
     // Create Express app with update personality router
     app = express();
     app.use(express.json());
-    app.use('/admin/personality', createUpdatePersonalityRoute(prisma as unknown as PrismaClient));
+    app.use(
+      '/admin/personality',
+      createUpdatePersonalityRoute({ prisma: prisma as unknown as PrismaClient })
+    );
   });
 
   describe('successful updates', () => {
@@ -446,7 +449,10 @@ describe('PATCH /admin/personality/:slug', () => {
       appWithCache.use(express.json());
       appWithCache.use(
         '/admin/personality',
-        createUpdatePersonalityRoute(prisma as unknown as PrismaClient, mockCacheService)
+        createUpdatePersonalityRoute({
+          prisma: prisma as unknown as PrismaClient,
+          cacheInvalidationService: mockCacheService,
+        })
       );
     });
 

--- a/services/api-gateway/src/routes/admin/updatePersonality.ts
+++ b/services/api-gateway/src/routes/admin/updatePersonality.ts
@@ -3,15 +3,15 @@
  * Edit an existing AI personality
  */
 
-import { Router, type Request, type Response } from 'express';
+import { Router, type Request, type RequestHandler, type Response } from 'express';
 import {
   createLogger,
   type CacheInvalidationService,
   PersonalityUpdateSchema,
   type PersonalityUpdateInput,
 } from '@tzurot/common-types';
-import { type PrismaClient } from '@tzurot/common-types';
 import { requireOwnerAuth } from '../../services/AuthMiddleware.js';
+import type { RouteDeps } from '../routeDeps.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
@@ -98,98 +98,94 @@ async function invalidateCacheAfterUpdate(
 
 // --- Route Handler ---
 
-export function createUpdatePersonalityRoute(
-  prisma: PrismaClient,
-  cacheInvalidationService?: CacheInvalidationService
-): Router {
+export const handleUpdateGlobalPersonality = (deps: RouteDeps): RequestHandler => {
+  const { prisma, cacheInvalidationService } = deps;
+  return asyncHandler(async (req: Request, res: Response) => {
+    const slug = getParam(req.params.slug);
+    if (slug === undefined) {
+      return sendError(res, ErrorResponses.validationError('slug is required'));
+    }
+
+    // Validate URL param slug format and reserved names
+    const slugValidation = validateSlug(slug);
+    if (!slugValidation.valid) {
+      return sendError(res, slugValidation.error);
+    }
+
+    // Validate request body with Zod schema
+    const parseResult = PersonalityUpdateSchema.safeParse(req.body);
+    if (!parseResult.success) {
+      return sendZodError(res, parseResult.error);
+    }
+    const validated = parseResult.data;
+
+    // Check if personality exists and get current visibility state
+    const existing = await prisma.personality.findUnique({
+      where: { slug },
+      select: { id: true, isPublic: true },
+    });
+    if (existing === null) {
+      return sendError(res, ErrorResponses.notFound(`Personality with slug '${slug}'`));
+    }
+
+    // Check slug uniqueness if being changed
+    if (validated.slug !== undefined && validated.slug !== slug) {
+      const conflicting = await prisma.personality.findUnique({
+        where: { slug: validated.slug },
+        select: { id: true },
+      });
+      if (conflicting !== null) {
+        return sendError(
+          res,
+          ErrorResponses.conflict(`A personality with slug '${validated.slug}' already exists`)
+        );
+      }
+    }
+
+    // Process avatar if provided
+    const avatarResult = await processAvatarData(validated.avatarData, slug);
+    if (avatarResult !== null && !avatarResult.ok) {
+      return sendError(res, avatarResult.error);
+    }
+
+    // Build and execute update
+    const updateData = buildUpdateData(
+      validated,
+      avatarResult?.ok === true ? avatarResult.buffer : undefined
+    );
+    const personality = await prisma.personality.update({
+      where: { slug },
+      data: updateData,
+    });
+
+    logger.info({ slug, personalityId: personality.id }, 'Updated personality');
+
+    // Invalidate cache with visibility-aware logic
+    const wasPublic = existing.isPublic;
+    const isNowPublic = validated.isPublic ?? wasPublic;
+    await invalidateCacheAfterUpdate(
+      cacheInvalidationService,
+      personality.id,
+      wasPublic,
+      isNowPublic
+    );
+
+    sendCustomSuccess(res, {
+      success: true,
+      personality: {
+        id: personality.id,
+        name: personality.name,
+        slug: personality.slug,
+        displayName: personality.displayName,
+        hasAvatar: personality.avatarData !== null,
+      },
+      timestamp: new Date().toISOString(),
+    });
+  });
+};
+
+export function createUpdatePersonalityRoute(deps: RouteDeps): Router {
   const router = Router();
-
-  router.patch(
-    '/:slug',
-    requireOwnerAuth(),
-    asyncHandler(async (req: Request, res: Response) => {
-      const slug = getParam(req.params.slug);
-      if (slug === undefined) {
-        return sendError(res, ErrorResponses.validationError('slug is required'));
-      }
-
-      // Validate URL param slug format and reserved names
-      const slugValidation = validateSlug(slug);
-      if (!slugValidation.valid) {
-        return sendError(res, slugValidation.error);
-      }
-
-      // Validate request body with Zod schema
-      const parseResult = PersonalityUpdateSchema.safeParse(req.body);
-      if (!parseResult.success) {
-        return sendZodError(res, parseResult.error);
-      }
-      const validated = parseResult.data;
-
-      // Check if personality exists and get current visibility state
-      const existing = await prisma.personality.findUnique({
-        where: { slug },
-        select: { id: true, isPublic: true },
-      });
-      if (existing === null) {
-        return sendError(res, ErrorResponses.notFound(`Personality with slug '${slug}'`));
-      }
-
-      // Check slug uniqueness if being changed
-      if (validated.slug !== undefined && validated.slug !== slug) {
-        const conflicting = await prisma.personality.findUnique({
-          where: { slug: validated.slug },
-          select: { id: true },
-        });
-        if (conflicting !== null) {
-          return sendError(
-            res,
-            ErrorResponses.conflict(`A personality with slug '${validated.slug}' already exists`)
-          );
-        }
-      }
-
-      // Process avatar if provided
-      const avatarResult = await processAvatarData(validated.avatarData, slug);
-      if (avatarResult !== null && !avatarResult.ok) {
-        return sendError(res, avatarResult.error);
-      }
-
-      // Build and execute update
-      const updateData = buildUpdateData(
-        validated,
-        avatarResult?.ok === true ? avatarResult.buffer : undefined
-      );
-      const personality = await prisma.personality.update({
-        where: { slug },
-        data: updateData,
-      });
-
-      logger.info({ slug, personalityId: personality.id }, 'Updated personality');
-
-      // Invalidate cache with visibility-aware logic
-      const wasPublic = existing.isPublic;
-      const isNowPublic = validated.isPublic ?? wasPublic;
-      await invalidateCacheAfterUpdate(
-        cacheInvalidationService,
-        personality.id,
-        wasPublic,
-        isNowPublic
-      );
-
-      sendCustomSuccess(res, {
-        success: true,
-        personality: {
-          id: personality.id,
-          name: personality.name,
-          slug: personality.slug,
-          displayName: personality.displayName,
-          hasAvatar: personality.avatarData !== null,
-        },
-        timestamp: new Date().toISOString(),
-      });
-    })
-  );
-
+  router.patch('/:slug', requireOwnerAuth(), handleUpdateGlobalPersonality(deps));
   return router;
 }

--- a/services/api-gateway/src/routes/admin/usage.test.ts
+++ b/services/api-gateway/src/routes/admin/usage.test.ts
@@ -34,7 +34,9 @@ vi.mock('../../services/AuthMiddleware.js', () => ({
 describe('Admin Usage Routes', () => {
   describe('middleware composition', () => {
     it('wires requireOwnerAuth on every route', () => {
-      const routes = getAllRoutes(createAdminUsageRoutes({} as unknown as PrismaClient));
+      const routes = getAllRoutes(
+        createAdminUsageRoutes({ prisma: {} as unknown as PrismaClient })
+      );
       expect(routes.length, 'expected at least one registered route').toBeGreaterThan(0);
       for (const route of routes) {
         expect(route.stackLength, `${route.path} missing auth middleware`).toBeGreaterThanOrEqual(
@@ -68,7 +70,10 @@ describe('Admin Usage Routes', () => {
 
     app = express();
     app.use(express.json());
-    app.use('/admin/usage', createAdminUsageRoutes(mockPrisma as unknown as PrismaClient));
+    app.use(
+      '/admin/usage',
+      createAdminUsageRoutes({ prisma: mockPrisma as unknown as PrismaClient })
+    );
   });
 
   describe('GET /admin/usage', () => {

--- a/services/api-gateway/src/routes/admin/usage.ts
+++ b/services/api-gateway/src/routes/admin/usage.ts
@@ -3,17 +3,13 @@
  * GET /admin/usage - Get global token usage statistics (all users)
  */
 
-import { Router, type Response, type Request } from 'express';
+import { Router, type Response, type Request, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
-import {
-  createLogger,
-  type PrismaClient,
-  Duration,
-  DurationParseError,
-} from '@tzurot/common-types';
+import { createLogger, Duration, DurationParseError } from '@tzurot/common-types';
 import { requireOwnerAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendCustomSuccess } from '../../utils/responseHelpers.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('admin-usage');
 
@@ -56,127 +52,123 @@ interface AdminUsageStats {
   limitReached?: boolean;
 }
 
-export function createAdminUsageRoutes(prisma: PrismaClient): Router {
-  const router = Router();
+/**
+ * GET /api/admin/usage — Get global token usage statistics.
+ * Query params: timeframe ('24h', '7d', '30d', etc.; default '7d')
+ */
+export const handleGetAdminUsageStats = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: Request, res: Response) => {
+    const timeframe = (req.query.timeframe as string) ?? '7d';
+    const periodStart = parseTimeframe(timeframe);
 
-  /**
-   * GET /admin/usage
-   * Get global token usage statistics
-   *
-   * Query params:
-   * - timeframe: '24h', '7d', '30d', etc. (default: '7d')
-   */
-  router.get(
-    '/',
-    requireOwnerAuth(),
-    asyncHandler(async (req: Request, res: Response) => {
-      const timeframe = (req.query.timeframe as string) ?? '7d';
-      const periodStart = parseTimeframe(timeframe);
+    // Build where clause
+    const where: { createdAt?: { gte: Date } } = {};
+    if (periodStart !== null) {
+      where.createdAt = { gte: periodStart };
+    }
 
-      // Build where clause
-      const where: { createdAt?: { gte: Date } } = {};
-      if (periodStart !== null) {
-        where.createdAt = { gte: periodStart };
-      }
+    // Get usage logs for the period (bounded to prevent OOM on large datasets)
+    const MAX_USAGE_LOGS = 50000;
+    const usageLogs = await prisma.usageLog.findMany({
+      where,
+      select: {
+        userId: true,
+        provider: true,
+        model: true,
+        tokensIn: true,
+        tokensOut: true,
+        requestType: true,
+      },
+      take: MAX_USAGE_LOGS,
+      orderBy: { createdAt: 'desc' },
+    });
+    const limitReached = usageLogs.length === MAX_USAGE_LOGS;
 
-      // Get usage logs for the period (bounded to prevent OOM on large datasets)
-      const MAX_USAGE_LOGS = 50000;
-      const usageLogs = await prisma.usageLog.findMany({
-        where,
-        select: {
-          userId: true,
-          provider: true,
-          model: true,
-          tokensIn: true,
-          tokensOut: true,
-          requestType: true,
-        },
-        take: MAX_USAGE_LOGS,
-        orderBy: { createdAt: 'desc' },
-      });
-      const limitReached = usageLogs.length === MAX_USAGE_LOGS;
+    // Get user discord IDs for the user IDs we found
+    const userIds = [...new Set(usageLogs.map(log => log.userId))];
+    const users = await prisma.user.findMany({
+      where: { id: { in: userIds } },
+      select: { id: true, discordId: true },
+    });
+    const userIdToDiscordId = new Map(users.map(u => [u.id, u.discordId]));
 
-      // Get user discord IDs for the user IDs we found
-      const userIds = [...new Set(usageLogs.map(log => log.userId))];
-      const users = await prisma.user.findMany({
-        where: { id: { in: userIds } },
-        select: { id: true, discordId: true },
-      });
-      const userIdToDiscordId = new Map(users.map(u => [u.id, u.discordId]));
+    // Aggregate stats
+    const stats: AdminUsageStats = {
+      timeframe,
+      periodStart: periodStart?.toISOString() ?? null,
+      periodEnd: new Date().toISOString(),
+      totalRequests: usageLogs.length,
+      totalTokensIn: 0,
+      totalTokensOut: 0,
+      totalTokens: 0,
+      uniqueUsers: userIds.length,
+      byProvider: {},
+      byModel: {},
+      byRequestType: {},
+      topUsers: [],
+      limitReached,
+    };
 
-      // Aggregate stats
-      const stats: AdminUsageStats = {
+    // Track per-user usage for top users
+    const userUsage = new Map<string, { requests: number; tokens: number }>();
+
+    for (const log of usageLogs) {
+      const tokens = log.tokensIn + log.tokensOut;
+
+      // Totals
+      stats.totalTokensIn += log.tokensIn;
+      stats.totalTokensOut += log.tokensOut;
+      stats.totalTokens += tokens;
+
+      // By provider
+      stats.byProvider[log.provider] ??= { requests: 0, tokensIn: 0, tokensOut: 0 };
+      stats.byProvider[log.provider].requests++;
+      stats.byProvider[log.provider].tokensIn += log.tokensIn;
+      stats.byProvider[log.provider].tokensOut += log.tokensOut;
+
+      // By model
+      stats.byModel[log.model] ??= { requests: 0, tokensIn: 0, tokensOut: 0 };
+      stats.byModel[log.model].requests++;
+      stats.byModel[log.model].tokensIn += log.tokensIn;
+      stats.byModel[log.model].tokensOut += log.tokensOut;
+
+      // By request type
+      stats.byRequestType[log.requestType] ??= { requests: 0, tokensIn: 0, tokensOut: 0 };
+      stats.byRequestType[log.requestType].requests++;
+      stats.byRequestType[log.requestType].tokensIn += log.tokensIn;
+      stats.byRequestType[log.requestType].tokensOut += log.tokensOut;
+
+      // Per-user tracking
+      const discordId = userIdToDiscordId.get(log.userId) ?? log.userId;
+      const existing = userUsage.get(discordId) ?? { requests: 0, tokens: 0 };
+      existing.requests++;
+      existing.tokens += tokens;
+      userUsage.set(discordId, existing);
+    }
+
+    // Get top 10 users by token usage
+    stats.topUsers = [...userUsage.entries()]
+      .map(([discordId, usage]) => ({ discordId, ...usage }))
+      .sort((a, b) => b.tokens - a.tokens)
+      .slice(0, 10);
+
+    logger.info(
+      {
         timeframe,
-        periodStart: periodStart?.toISOString() ?? null,
-        periodEnd: new Date().toISOString(),
-        totalRequests: usageLogs.length,
-        totalTokensIn: 0,
-        totalTokensOut: 0,
-        totalTokens: 0,
-        uniqueUsers: userIds.length,
-        byProvider: {},
-        byModel: {},
-        byRequestType: {},
-        topUsers: [],
-        limitReached,
-      };
+        totalRequests: stats.totalRequests,
+        totalTokens: stats.totalTokens,
+        uniqueUsers: stats.uniqueUsers,
+      },
+      'Returned global usage stats'
+    );
 
-      // Track per-user usage for top users
-      const userUsage = new Map<string, { requests: number; tokens: number }>();
+    sendCustomSuccess(res, stats, StatusCodes.OK);
+  });
+};
 
-      for (const log of usageLogs) {
-        const tokens = log.tokensIn + log.tokensOut;
-
-        // Totals
-        stats.totalTokensIn += log.tokensIn;
-        stats.totalTokensOut += log.tokensOut;
-        stats.totalTokens += tokens;
-
-        // By provider
-        stats.byProvider[log.provider] ??= { requests: 0, tokensIn: 0, tokensOut: 0 };
-        stats.byProvider[log.provider].requests++;
-        stats.byProvider[log.provider].tokensIn += log.tokensIn;
-        stats.byProvider[log.provider].tokensOut += log.tokensOut;
-
-        // By model
-        stats.byModel[log.model] ??= { requests: 0, tokensIn: 0, tokensOut: 0 };
-        stats.byModel[log.model].requests++;
-        stats.byModel[log.model].tokensIn += log.tokensIn;
-        stats.byModel[log.model].tokensOut += log.tokensOut;
-
-        // By request type
-        stats.byRequestType[log.requestType] ??= { requests: 0, tokensIn: 0, tokensOut: 0 };
-        stats.byRequestType[log.requestType].requests++;
-        stats.byRequestType[log.requestType].tokensIn += log.tokensIn;
-        stats.byRequestType[log.requestType].tokensOut += log.tokensOut;
-
-        // Per-user tracking
-        const discordId = userIdToDiscordId.get(log.userId) ?? log.userId;
-        const existing = userUsage.get(discordId) ?? { requests: 0, tokens: 0 };
-        existing.requests++;
-        existing.tokens += tokens;
-        userUsage.set(discordId, existing);
-      }
-
-      // Get top 10 users by token usage
-      stats.topUsers = [...userUsage.entries()]
-        .map(([discordId, usage]) => ({ discordId, ...usage }))
-        .sort((a, b) => b.tokens - a.tokens)
-        .slice(0, 10);
-
-      logger.info(
-        {
-          timeframe,
-          totalRequests: stats.totalRequests,
-          totalTokens: stats.totalTokens,
-          uniqueUsers: stats.uniqueUsers,
-        },
-        'Returned global usage stats'
-      );
-
-      sendCustomSuccess(res, stats, StatusCodes.OK);
-    })
-  );
-
+export function createAdminUsageRoutes(deps: RouteDeps): Router {
+  const router = Router();
+  router.get('/', requireOwnerAuth(), handleGetAdminUsageStats(deps));
   return router;
 }

--- a/services/api-gateway/src/routes/ai/AIRoutes.int.test.ts
+++ b/services/api-gateway/src/routes/ai/AIRoutes.int.test.ts
@@ -88,7 +88,7 @@ describe('AI Routes Integration', () => {
     } as unknown as QueueEvents;
 
     // Mount AI router
-    const aiRouter = createAIRouter(prisma, mockQueue, mockQueueEvents);
+    const aiRouter = createAIRouter({ prisma, aiQueue: mockQueue, queueEvents: mockQueueEvents });
     app.use('/ai', aiRouter);
   }, 30000);
 

--- a/services/api-gateway/src/routes/ai/index.ts
+++ b/services/api-gateway/src/routes/ai/index.ts
@@ -4,25 +4,28 @@
  */
 
 import { Router } from 'express';
-import type { Queue, QueueEvents } from 'bullmq';
-import type { PrismaClient } from '@tzurot/common-types';
+import type { RouteDeps } from '../routeDeps.js';
 import { createGenerateRoute } from './generate.js';
 import { createTranscribeRoute } from './transcribe.js';
 import { createJobStatusRoute } from './jobStatus.js';
 import { createConfirmDeliveryRoute } from './confirmDelivery.js';
 
 /**
- * Create AI router with injected dependencies
- * @param prisma - Prisma client for database operations
- * @param aiQueue - BullMQ queue for AI job processing
- * @param queueEvents - BullMQ queue events for job completion waiting
+ * Create AI router. The required deps are aiQueue + queueEvents;
+ * transcribe also needs prisma.
  */
-export function createAIRouter(
-  prisma: PrismaClient,
-  aiQueue: Queue,
-  queueEvents: QueueEvents
-): Router {
+export function createAIRouter(deps: RouteDeps): Router {
   const router = Router();
+  const { prisma, aiQueue, queueEvents } = deps;
+
+  // Hard-fail at startup: aiQueue + queueEvents are not optional for the AI
+  // routes (no degraded mode makes sense — the BullMQ queue IS the routing
+  // pipeline). Contrast with admin/cleanup, which graceful-degrades to 503
+  // when retentionService is absent, and shapes, which logs and skips the
+  // affected routes when aiQueue is absent.
+  if (aiQueue === undefined || queueEvents === undefined) {
+    throw new Error('createAIRouter requires aiQueue and queueEvents in RouteDeps');
+  }
 
   // AI generation endpoint
   router.use('/generate', createGenerateRoute());

--- a/services/api-gateway/src/routes/internal/index.test.ts
+++ b/services/api-gateway/src/routes/internal/index.test.ts
@@ -32,7 +32,7 @@ describe('createInternalRouter', () => {
     vi.clearAllMocks();
     mockPrisma = { $queryRaw: vi.fn().mockResolvedValue([]) };
     app = express();
-    app.use('/internal', createInternalRouter(mockPrisma as unknown as PrismaClient));
+    app.use('/internal', createInternalRouter({ prisma: mockPrisma as unknown as PrismaClient }));
   });
 
   it('mounts GET /users/recent', async () => {

--- a/services/api-gateway/src/routes/internal/index.ts
+++ b/services/api-gateway/src/routes/internal/index.ts
@@ -7,12 +7,13 @@
  */
 
 import { Router } from 'express';
-import type { PrismaClient } from '@tzurot/common-types';
+import type { RouteDeps } from '../routeDeps.js';
 import { createUsersRecentHandler } from './usersRecent.js';
 import { createDmSessionSetHandler } from './dmSessionSet.js';
 
-export function createInternalRouter(prisma: PrismaClient): Router {
+export function createInternalRouter(deps: RouteDeps): Router {
   const router = Router();
+  const { prisma } = deps;
   router.get('/users/recent', createUsersRecentHandler(prisma));
   router.post('/channel/dm-session/set', ...createDmSessionSetHandler(prisma));
   return router;

--- a/services/api-gateway/src/routes/user/channel/activate.test.ts
+++ b/services/api-gateway/src/routes/user/channel/activate.test.ts
@@ -73,7 +73,7 @@ describe('POST /user/channel/activate', () => {
     mockPrisma.personality.findUnique.mockResolvedValue(personality);
     mockPrisma.channelSettings.upsert.mockResolvedValue(createdSettings);
 
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'post', '/activate');
     const { req, res } = createMockReqRes({
       channelId: MOCK_DISCORD_USER_ID,
@@ -108,7 +108,7 @@ describe('POST /user/channel/activate', () => {
     mockPrisma.channelSettings.findUnique.mockResolvedValue(existingSettings);
     mockPrisma.channelSettings.upsert.mockResolvedValue(updatedSettings);
 
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'post', '/activate');
     const { req, res } = createMockReqRes({
       channelId: MOCK_DISCORD_USER_ID,
@@ -130,7 +130,7 @@ describe('POST /user/channel/activate', () => {
   });
 
   it('should reject invalid request body', async () => {
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'post', '/activate');
     const { req, res } = createMockReqRes({
       channelId: '', // Invalid - empty string
@@ -151,7 +151,7 @@ describe('POST /user/channel/activate', () => {
   it('should return 404 for non-existent personality', async () => {
     mockPrisma.personality.findUnique.mockResolvedValue(null);
 
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'post', '/activate');
     const { req, res } = createMockReqRes({
       channelId: MOCK_DISCORD_USER_ID,
@@ -179,7 +179,7 @@ describe('POST /user/channel/activate', () => {
 
     mockPrisma.personality.findUnique.mockResolvedValue(privatePersonality);
 
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'post', '/activate');
     const { req, res } = createMockReqRes({
       channelId: MOCK_DISCORD_USER_ID,
@@ -210,7 +210,7 @@ describe('POST /user/channel/activate', () => {
     mockPrisma.personality.findUnique.mockResolvedValue(privatePersonality);
     mockPrisma.channelSettings.upsert.mockResolvedValue(settings);
 
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'post', '/activate');
     const { req, res } = createMockReqRes({
       channelId: MOCK_DISCORD_USER_ID,
@@ -233,7 +233,7 @@ describe('POST /user/channel/activate', () => {
     mockPrisma.personality.findUnique.mockResolvedValue(ownedPersonality);
     mockPrisma.channelSettings.upsert.mockResolvedValue(settings);
 
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'post', '/activate');
     const { req, res } = createMockReqRes({
       channelId: MOCK_DISCORD_USER_ID,

--- a/services/api-gateway/src/routes/user/channel/activate.ts
+++ b/services/api-gateway/src/routes/user/channel/activate.ts
@@ -10,7 +10,6 @@ import { type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import {
   createLogger,
-  type PrismaClient,
   generateChannelSettingsUuid,
   ActivateChannelRequestSchema,
   ActivateChannelResponseSchema,
@@ -23,6 +22,7 @@ import { sendZodError } from '../../../utils/zodHelpers.js';
 import type { ProvisionedRequest } from '../../../types.js';
 import { getOrCreateInternalUser } from '../userHelpers.js';
 import { canUserViewPersonality } from '../personality/helpers.js';
+import type { RouteDeps } from '../../routeDeps.js';
 
 const logger = createLogger('channel-activate');
 
@@ -82,11 +82,11 @@ function buildActivationResponse(
 }
 
 /**
- * Create handler for POST /user/channel/activate
- * Activates a personality in a channel. Replaces any existing activation.
+ * POST /api/user/channel/activate — activate personality in a channel.
  */
-export function createActivateHandler(prisma: PrismaClient): RequestHandler[] {
-  const handler = asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+export const handleActivateChannel = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
     const discordUserId = req.userId;
 
     // Validate request body
@@ -164,6 +164,8 @@ export function createActivateHandler(prisma: PrismaClient): RequestHandler[] {
 
     sendCustomSuccess(res, buildActivationResponse(settings, wasReplaced), StatusCodes.CREATED);
   });
+};
 
-  return [requireUserAuth(), requireProvisionedUser(prisma), handler];
+export function createActivateHandler(deps: RouteDeps): RequestHandler[] {
+  return [requireUserAuth(), requireProvisionedUser(deps.prisma), handleActivateChannel(deps)];
 }

--- a/services/api-gateway/src/routes/user/channel/configOverrides.test.ts
+++ b/services/api-gateway/src/routes/user/channel/configOverrides.test.ts
@@ -48,7 +48,10 @@ describe('Channel Config Overrides Routes', () => {
 
     app = express();
     app.use(express.json());
-    app.use('/user/channel', createChannelRoutes(mockPrisma as unknown as PrismaClient));
+    app.use(
+      '/user/channel',
+      createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient })
+    );
   });
 
   describe('channelId validation', () => {
@@ -143,7 +146,10 @@ describe('Channel Config Overrides Routes', () => {
       appWithInvalidation.use(express.json());
       appWithInvalidation.use(
         '/user/channel',
-        createChannelRoutes(mockPrisma as unknown as PrismaClient, mockInvalidation as never)
+        createChannelRoutes({
+          prisma: mockPrisma as unknown as PrismaClient,
+          cascadeInvalidation: mockInvalidation as never,
+        })
       );
 
       await request(appWithInvalidation)
@@ -167,7 +173,10 @@ describe('Channel Config Overrides Routes', () => {
       appWithInvalidation.use(express.json());
       appWithInvalidation.use(
         '/user/channel',
-        createChannelRoutes(mockPrisma as unknown as PrismaClient, mockInvalidation as never)
+        createChannelRoutes({
+          prisma: mockPrisma as unknown as PrismaClient,
+          cascadeInvalidation: mockInvalidation as never,
+        })
       );
 
       const response = await request(appWithInvalidation)
@@ -192,7 +201,10 @@ describe('Channel Config Overrides Routes', () => {
       appWithInvalidation.use(express.json());
       appWithInvalidation.use(
         '/user/channel',
-        createChannelRoutes(mockPrisma as unknown as PrismaClient, mockInvalidation as never)
+        createChannelRoutes({
+          prisma: mockPrisma as unknown as PrismaClient,
+          cascadeInvalidation: mockInvalidation as never,
+        })
       );
 
       const response = await request(appWithInvalidation).delete(

--- a/services/api-gateway/src/routes/user/channel/configOverrides.ts
+++ b/services/api-gateway/src/routes/user/channel/configOverrides.ts
@@ -22,8 +22,6 @@ import {
   generateChannelSettingsUuid,
   isValidDiscordId,
   Prisma,
-  type PrismaClient,
-  type ConfigCascadeCacheInvalidationService,
 } from '@tzurot/common-types';
 import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
@@ -35,6 +33,7 @@ import { sendError, sendCustomSuccess } from '../../../utils/responseHelpers.js'
 import { ErrorResponses } from '../../../utils/errorResponses.js';
 import { getRequiredParam } from '../../../utils/requestParams.js';
 import type { AuthenticatedRequest } from '../../../types.js';
+import type { RouteDeps } from '../../routeDeps.js';
 
 const logger = createLogger('channel-config-overrides');
 
@@ -47,124 +46,122 @@ function validateChannelId(channelId: string, res: Response): boolean {
   return true;
 }
 
+/** GET /api/user/channel/:channelId/config-overrides — raw overrides */
+export const handleGetChannelConfigOverrides = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+    const channelId = getRequiredParam(req.params.channelId, 'channelId');
+    if (!validateChannelId(channelId, res)) {
+      return;
+    }
+
+    const settings = await prisma.channelSettings.findUnique({
+      where: { channelId },
+      select: { configOverrides: true },
+    });
+
+    sendCustomSuccess(
+      res,
+      { configOverrides: (settings?.configOverrides as Record<string, unknown> | null) ?? null },
+      StatusCodes.OK
+    );
+  });
+};
+
 /**
- * Create GET handler for channel config overrides
- * GET /user/channel/:channelId/config-overrides
+ * PATCH /api/user/channel/:channelId/config-overrides — merge update.
+ * Accepts Partial<ConfigOverrides> directly; send a null field value to clear it.
  */
-export function createGetConfigOverridesHandler(prisma: PrismaClient): RequestHandler[] {
+export const handleUpdateChannelConfigOverrides = (deps: RouteDeps): RequestHandler => {
+  const { prisma, cascadeInvalidation } = deps;
+  return asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+    const channelId = getRequiredParam(req.params.channelId, 'channelId');
+    if (!validateChannelId(channelId, res)) {
+      return;
+    }
+    const input = req.body as Record<string, unknown>;
+
+    const settingsId = generateChannelSettingsUuid(channelId);
+    const existing = await prisma.channelSettings.findUnique({
+      where: { channelId },
+      select: { configOverrides: true },
+    });
+
+    const { merged, prismaValue } = mergeAndValidateOverrides(
+      existing?.configOverrides,
+      input,
+      res
+    );
+    if (merged === undefined) {
+      return;
+    }
+
+    await prisma.channelSettings.upsert({
+      where: { channelId },
+      create: {
+        id: settingsId,
+        channelId,
+        configOverrides: prismaValue,
+      },
+      update: {
+        configOverrides: prismaValue,
+      },
+    });
+
+    await tryInvalidateCache(
+      cascadeInvalidation?.invalidateChannel.bind(cascadeInvalidation, channelId),
+      { channelId }
+    );
+
+    logger.info({ channelId, userId: req.userId }, 'Updated channel config overrides');
+    sendCustomSuccess(res, { configOverrides: merged }, StatusCodes.OK);
+  });
+};
+
+/** DELETE /api/user/channel/:channelId/config-overrides — clear */
+export const handleClearChannelConfigOverrides = (deps: RouteDeps): RequestHandler => {
+  const { prisma, cascadeInvalidation } = deps;
+  return asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+    const channelId = getRequiredParam(req.params.channelId, 'channelId');
+    if (!validateChannelId(channelId, res)) {
+      return;
+    }
+
+    await prisma.channelSettings.updateMany({
+      where: { channelId },
+      data: { configOverrides: Prisma.JsonNull },
+    });
+
+    await tryInvalidateCache(
+      cascadeInvalidation?.invalidateChannel.bind(cascadeInvalidation, channelId),
+      { channelId }
+    );
+
+    logger.info({ channelId, userId: req.userId }, 'Cleared channel config overrides');
+    sendCustomSuccess(res, { success: true }, StatusCodes.OK);
+  });
+};
+
+export function createGetConfigOverridesHandler(deps: RouteDeps): RequestHandler[] {
   return [
     requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
-      const channelId = getRequiredParam(req.params.channelId, 'channelId');
-      if (!validateChannelId(channelId, res)) {
-        return;
-      }
-
-      const settings = await prisma.channelSettings.findUnique({
-        where: { channelId },
-        select: { configOverrides: true },
-      });
-
-      sendCustomSuccess(
-        res,
-        { configOverrides: (settings?.configOverrides as Record<string, unknown> | null) ?? null },
-        StatusCodes.OK
-      );
-    }),
+    requireProvisionedUser(deps.prisma),
+    handleGetChannelConfigOverrides(deps),
   ];
 }
 
-/**
- * Create PATCH handler for channel config overrides
- * PATCH /user/channel/:channelId/config-overrides
- *
- * Accepts Partial<ConfigOverrides> directly (same shape as user/personality tiers).
- * Send null for a field value to clear that override.
- */
-export function createPatchConfigOverridesHandler(
-  prisma: PrismaClient,
-  cascadeInvalidation?: ConfigCascadeCacheInvalidationService
-): RequestHandler[] {
+export function createPatchConfigOverridesHandler(deps: RouteDeps): RequestHandler[] {
   return [
     requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
-      const channelId = getRequiredParam(req.params.channelId, 'channelId');
-      if (!validateChannelId(channelId, res)) {
-        return;
-      }
-      const input = req.body as Record<string, unknown>;
-
-      // Get or create channel settings
-      const settingsId = generateChannelSettingsUuid(channelId);
-      const existing = await prisma.channelSettings.findUnique({
-        where: { channelId },
-        select: { configOverrides: true },
-      });
-
-      const { merged, prismaValue } = mergeAndValidateOverrides(
-        existing?.configOverrides,
-        input,
-        res
-      );
-      if (merged === undefined) {
-        return;
-      }
-
-      // Upsert: create channel settings if they don't exist yet
-      await prisma.channelSettings.upsert({
-        where: { channelId },
-        create: {
-          id: settingsId,
-          channelId,
-          configOverrides: prismaValue,
-        },
-        update: {
-          configOverrides: prismaValue,
-        },
-      });
-
-      await tryInvalidateCache(
-        cascadeInvalidation?.invalidateChannel.bind(cascadeInvalidation, channelId),
-        { channelId }
-      );
-
-      logger.info({ channelId, userId: req.userId }, 'Updated channel config overrides');
-      sendCustomSuccess(res, { configOverrides: merged }, StatusCodes.OK);
-    }),
+    requireProvisionedUser(deps.prisma),
+    handleUpdateChannelConfigOverrides(deps),
   ];
 }
 
-/**
- * Create DELETE handler for channel config overrides
- * DELETE /user/channel/:channelId/config-overrides
- */
-export function createDeleteConfigOverridesHandler(
-  prisma: PrismaClient,
-  cascadeInvalidation?: ConfigCascadeCacheInvalidationService
-): RequestHandler[] {
+export function createDeleteConfigOverridesHandler(deps: RouteDeps): RequestHandler[] {
   return [
     requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
-      const channelId = getRequiredParam(req.params.channelId, 'channelId');
-      if (!validateChannelId(channelId, res)) {
-        return;
-      }
-
-      await prisma.channelSettings.updateMany({
-        where: { channelId },
-        data: { configOverrides: Prisma.JsonNull },
-      });
-
-      await tryInvalidateCache(
-        cascadeInvalidation?.invalidateChannel.bind(cascadeInvalidation, channelId),
-        { channelId }
-      );
-
-      logger.info({ channelId, userId: req.userId }, 'Cleared channel config overrides');
-      sendCustomSuccess(res, { success: true }, StatusCodes.OK);
-    }),
+    requireProvisionedUser(deps.prisma),
+    handleClearChannelConfigOverrides(deps),
   ];
 }

--- a/services/api-gateway/src/routes/user/channel/deactivate.test.ts
+++ b/services/api-gateway/src/routes/user/channel/deactivate.test.ts
@@ -56,7 +56,7 @@ describe('DELETE /user/channel/deactivate', () => {
     const existingSettings = createMockActivation();
     mockPrisma.channelSettings.findUnique.mockResolvedValue(existingSettings);
 
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'delete', '/deactivate');
     const { req, res } = createMockReqRes({
       channelId: MOCK_DISCORD_USER_ID,
@@ -81,7 +81,7 @@ describe('DELETE /user/channel/deactivate', () => {
   it('should return deactivated=false when no settings exist', async () => {
     mockPrisma.channelSettings.findUnique.mockResolvedValue(null);
 
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'delete', '/deactivate');
     const { req, res } = createMockReqRes({
       channelId: MOCK_DISCORD_USER_ID,
@@ -98,7 +98,7 @@ describe('DELETE /user/channel/deactivate', () => {
   });
 
   it('should reject invalid request body', async () => {
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'delete', '/deactivate');
     const { req, res } = createMockReqRes({
       channelId: '', // Invalid - empty string
@@ -115,7 +115,7 @@ describe('DELETE /user/channel/deactivate', () => {
   });
 
   it('should reject missing channelId', async () => {
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'delete', '/deactivate');
     const { req, res } = createMockReqRes({}); // Missing channelId
 

--- a/services/api-gateway/src/routes/user/channel/deactivate.ts
+++ b/services/api-gateway/src/routes/user/channel/deactivate.ts
@@ -10,7 +10,6 @@ import { type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import {
   createLogger,
-  type PrismaClient,
   DeactivateChannelRequestSchema,
   DeactivateChannelResponseSchema,
 } from '@tzurot/common-types';
@@ -19,15 +18,16 @@ import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendCustomSuccess } from '../../../utils/responseHelpers.js';
 import { sendZodError } from '../../../utils/zodHelpers.js';
 import type { AuthenticatedRequest } from '../../../types.js';
+import type { RouteDeps } from '../../routeDeps.js';
 
 const logger = createLogger('channel-deactivate');
 
 /**
- * Create handler for DELETE /user/channel/deactivate
- * Deactivates any personality from the channel by clearing activatedPersonalityId.
+ * DELETE /api/user/channel/deactivate — clear activated personality on a channel.
  */
-export function createDeactivateHandler(prisma: PrismaClient): RequestHandler[] {
-  const handler = asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+export const handleDeactivateChannel = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
     const discordUserId = req.userId;
 
     // Validate request body
@@ -89,6 +89,8 @@ export function createDeactivateHandler(prisma: PrismaClient): RequestHandler[] 
 
     sendCustomSuccess(res, response, StatusCodes.OK);
   });
+};
 
-  return [requireUserAuth(), requireProvisionedUser(prisma), handler];
+export function createDeactivateHandler(deps: RouteDeps): RequestHandler[] {
+  return [requireUserAuth(), requireProvisionedUser(deps.prisma), handleDeactivateChannel(deps)];
 }

--- a/services/api-gateway/src/routes/user/channel/get.test.ts
+++ b/services/api-gateway/src/routes/user/channel/get.test.ts
@@ -57,7 +57,7 @@ describe('GET /user/channel/:channelId', () => {
     const settings = createMockActivation();
     mockPrisma.channelSettings.findUnique.mockResolvedValue(settings);
 
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'get', '/:channelId');
     const { req, res } = createMockReqRes({}, { channelId: MOCK_DISCORD_USER_ID });
 
@@ -82,7 +82,7 @@ describe('GET /user/channel/:channelId', () => {
   it('should return hasSettings=false when channel has no settings', async () => {
     mockPrisma.channelSettings.findUnique.mockResolvedValue(null);
 
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'get', '/:channelId');
     const { req, res } = createMockReqRes({}, { channelId: MOCK_DISCORD_USER_ID });
 
@@ -95,7 +95,7 @@ describe('GET /user/channel/:channelId', () => {
   });
 
   it('should reject empty channelId', async () => {
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'get', '/:channelId');
     const { req, res } = createMockReqRes({}, { channelId: '' });
 
@@ -115,7 +115,7 @@ describe('GET /user/channel/:channelId', () => {
     });
     mockPrisma.channelSettings.findUnique.mockResolvedValue(settingsWithNullCreator);
 
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'get', '/:channelId');
     const { req, res } = createMockReqRes({}, { channelId: MOCK_DISCORD_USER_ID });
 

--- a/services/api-gateway/src/routes/user/channel/get.ts
+++ b/services/api-gateway/src/routes/user/channel/get.ts
@@ -5,26 +5,23 @@
 
 import { type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
-import {
-  createLogger,
-  type PrismaClient,
-  GetChannelSettingsResponseSchema,
-} from '@tzurot/common-types';
+import { createLogger, GetChannelSettingsResponseSchema } from '@tzurot/common-types';
 import { requireServiceAuth } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendCustomSuccess, sendError } from '../../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
 import { getParam } from '../../../utils/requestParams.js';
 import type { AuthenticatedRequest } from '../../../types.js';
+import type { RouteDeps } from '../../routeDeps.js';
 
 const logger = createLogger('channel-get');
 
 /**
- * Create handler for GET /user/channel/:channelId
- * Returns channel settings including activation status.
+ * GET /api/user/channel/:channelId — channel settings (service-only).
  */
-export function createGetHandler(prisma: PrismaClient): RequestHandler[] {
-  const handler = asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+export const handleGetChannelSettings = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
     const channelId = getParam(req.params.channelId);
 
     // Validate channelId
@@ -89,7 +86,9 @@ export function createGetHandler(prisma: PrismaClient): RequestHandler[] {
 
     sendCustomSuccess(res, response, StatusCodes.OK);
   });
+};
 
-  // Service auth only - this is a service-to-service lookup, not user-specific
-  return [requireServiceAuth(), handler];
+// Service auth only — service-to-service lookup, not user-specific
+export function createGetHandler(deps: RouteDeps): RequestHandler[] {
+  return [requireServiceAuth(), handleGetChannelSettings(deps)];
 }

--- a/services/api-gateway/src/routes/user/channel/index.ts
+++ b/services/api-gateway/src/routes/user/channel/index.ts
@@ -14,10 +14,7 @@
  */
 
 import { Router } from 'express';
-import {
-  type PrismaClient,
-  type ConfigCascadeCacheInvalidationService,
-} from '@tzurot/common-types';
+import type { RouteDeps } from '../../routeDeps.js';
 import { createActivateHandler } from './activate.js';
 import { createDeactivateHandler } from './deactivate.js';
 import { createGetHandler } from './get.js';
@@ -31,41 +28,30 @@ import {
 
 /**
  * Create channel activation router with injected dependencies
- * @param prisma - Database client
- * @param cascadeInvalidation - Config cascade cache invalidation service (optional)
  */
-export function createChannelRoutes(
-  prisma: PrismaClient,
-  cascadeInvalidation?: ConfigCascadeCacheInvalidationService
-): Router {
+export function createChannelRoutes(deps: RouteDeps): Router {
   const router = Router();
 
   // List activations - GET /list (must come before /:channelId)
-  router.get('/list', ...createListHandler(prisma));
+  router.get('/list', ...createListHandler(deps));
 
   // Activate personality - POST /activate
-  router.post('/activate', ...createActivateHandler(prisma));
+  router.post('/activate', ...createActivateHandler(deps));
 
   // Deactivate personality - DELETE /deactivate
-  router.delete('/deactivate', ...createDeactivateHandler(prisma));
+  router.delete('/deactivate', ...createDeactivateHandler(deps));
 
   // Update guildId - PATCH /update-guild (for lazy backfill)
-  router.patch('/update-guild', ...createUpdateGuildHandler(prisma));
+  router.patch('/update-guild', ...createUpdateGuildHandler(deps));
 
   // Channel config overrides
   const configOverridesPath = '/:channelId/config-overrides';
-  router.get(configOverridesPath, ...createGetConfigOverridesHandler(prisma));
-  router.patch(
-    configOverridesPath,
-    ...createPatchConfigOverridesHandler(prisma, cascadeInvalidation)
-  );
-  router.delete(
-    configOverridesPath,
-    ...createDeleteConfigOverridesHandler(prisma, cascadeInvalidation)
-  );
+  router.get(configOverridesPath, ...createGetConfigOverridesHandler(deps));
+  router.patch(configOverridesPath, ...createPatchConfigOverridesHandler(deps));
+  router.delete(configOverridesPath, ...createDeleteConfigOverridesHandler(deps));
 
   // Get settings - GET /:channelId
-  router.get('/:channelId', ...createGetHandler(prisma));
+  router.get('/:channelId', ...createGetHandler(deps));
 
   return router;
 }

--- a/services/api-gateway/src/routes/user/channel/list.test.ts
+++ b/services/api-gateway/src/routes/user/channel/list.test.ts
@@ -73,7 +73,7 @@ describe('GET /user/channel/list', () => {
     ];
     mockPrisma.channelSettings.findMany.mockResolvedValue(activations);
 
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'get', '/list');
     const { req, res } = createMockReqRes();
 
@@ -103,7 +103,7 @@ describe('GET /user/channel/list', () => {
   it('should return empty array when no activations exist', async () => {
     mockPrisma.channelSettings.findMany.mockResolvedValue([]);
 
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'get', '/list');
     const { req, res } = createMockReqRes();
 
@@ -119,7 +119,7 @@ describe('GET /user/channel/list', () => {
     const activation = createMockActivation();
     mockPrisma.channelSettings.findMany.mockResolvedValue([activation]);
 
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'get', '/list');
     const { req, res } = createMockReqRes();
 
@@ -146,7 +146,7 @@ describe('GET /user/channel/list', () => {
     const activation = createMockActivation();
     mockPrisma.channelSettings.findMany.mockResolvedValue([activation]);
 
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'get', '/list');
     const { req, res } = createMockReqRes({}, {}, { guildId: MOCK_GUILD_ID });
 
@@ -167,7 +167,7 @@ describe('GET /user/channel/list', () => {
   it('should only return channels with activated personalities', async () => {
     mockPrisma.channelSettings.findMany.mockResolvedValue([]);
 
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'get', '/list');
     const { req, res } = createMockReqRes();
 
@@ -187,7 +187,7 @@ describe('GET /user/channel/list', () => {
     const activation = createMockActivation({ createdBy: null });
     mockPrisma.channelSettings.findMany.mockResolvedValue([activation]);
 
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'get', '/list');
     const { req, res } = createMockReqRes();
 
@@ -205,7 +205,7 @@ describe('GET /user/channel/list', () => {
   });
 
   it('should order activations by createdAt descending', async () => {
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'get', '/list');
     const { req, res } = createMockReqRes();
 

--- a/services/api-gateway/src/routes/user/channel/list.ts
+++ b/services/api-gateway/src/routes/user/channel/list.ts
@@ -8,25 +8,22 @@
 
 import { type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
-import {
-  createLogger,
-  type PrismaClient,
-  ListChannelSettingsResponseSchema,
-} from '@tzurot/common-types';
+import { createLogger, ListChannelSettingsResponseSchema } from '@tzurot/common-types';
 import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendCustomSuccess, sendError } from '../../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
 import type { AuthenticatedRequest } from '../../../types.js';
+import type { RouteDeps } from '../../routeDeps.js';
 
 const logger = createLogger('channel-list');
 
 /**
- * Create handler for GET /user/channel/list
- * Returns all channel settings with activated personalities, optionally filtered by guildId.
+ * GET /api/user/channel/list — all channel settings with activated personalities.
  */
-export function createListHandler(prisma: PrismaClient): RequestHandler[] {
-  const handler = asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+export const handleListChannelSettings = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
     const discordUserId = req.userId;
 
     // Optional guildId filter from query params
@@ -94,6 +91,8 @@ export function createListHandler(prisma: PrismaClient): RequestHandler[] {
 
     sendCustomSuccess(res, response, StatusCodes.OK);
   });
+};
 
-  return [requireUserAuth(), requireProvisionedUser(prisma), handler];
+export function createListHandler(deps: RouteDeps): RequestHandler[] {
+  return [requireUserAuth(), requireProvisionedUser(deps.prisma), handleListChannelSettings(deps)];
 }

--- a/services/api-gateway/src/routes/user/channel/updateGuild.test.ts
+++ b/services/api-gateway/src/routes/user/channel/updateGuild.test.ts
@@ -54,7 +54,7 @@ describe('PATCH /user/channel/update-guild', () => {
   it('should update guildId when activation has null guildId', async () => {
     mockPrisma.channelSettings.updateMany.mockResolvedValue({ count: 1 });
 
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'patch', '/update-guild');
     const { req, res } = createMockReqRes({
       channelId: MOCK_DISCORD_USER_ID,
@@ -78,7 +78,7 @@ describe('PATCH /user/channel/update-guild', () => {
   it('should return updated=false when no activation needs updating', async () => {
     mockPrisma.channelSettings.updateMany.mockResolvedValue({ count: 0 });
 
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'patch', '/update-guild');
     const { req, res } = createMockReqRes({
       channelId: MOCK_DISCORD_USER_ID,
@@ -92,7 +92,7 @@ describe('PATCH /user/channel/update-guild', () => {
   });
 
   it('should reject empty channelId', async () => {
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'patch', '/update-guild');
     const { req, res } = createMockReqRes({
       channelId: '',
@@ -111,7 +111,7 @@ describe('PATCH /user/channel/update-guild', () => {
   });
 
   it('should reject empty guildId', async () => {
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'patch', '/update-guild');
     const { req, res } = createMockReqRes({
       channelId: MOCK_DISCORD_USER_ID,
@@ -130,7 +130,7 @@ describe('PATCH /user/channel/update-guild', () => {
   });
 
   it('should reject missing fields', async () => {
-    const router = createChannelRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createChannelRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'patch', '/update-guild');
     const { req, res } = createMockReqRes({});
 

--- a/services/api-gateway/src/routes/user/channel/updateGuild.ts
+++ b/services/api-gateway/src/routes/user/channel/updateGuild.ts
@@ -10,7 +10,6 @@ import { type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import {
   createLogger,
-  type PrismaClient,
   UpdateChannelGuildRequestSchema,
   UpdateChannelGuildResponseSchema,
 } from '@tzurot/common-types';
@@ -19,15 +18,16 @@ import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendCustomSuccess } from '../../../utils/responseHelpers.js';
 import { sendZodError } from '../../../utils/zodHelpers.js';
 import type { AuthenticatedRequest } from '../../../types.js';
+import type { RouteDeps } from '../../routeDeps.js';
 
 const logger = createLogger('channel-update-guild');
 
 /**
- * Create handler for PATCH /user/channel/update-guild
- * Updates guildId for channel settings that are missing it (legacy backfill).
+ * PATCH /api/user/channel/update-guild — backfill missing guildId.
  */
-export function createUpdateGuildHandler(prisma: PrismaClient): RequestHandler[] {
-  const handler = asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+export const handleUpdateChannelGuild = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
     // Validate request body
     const parseResult = UpdateChannelGuildRequestSchema.safeParse(req.body);
     if (!parseResult.success) {
@@ -63,6 +63,8 @@ export function createUpdateGuildHandler(prisma: PrismaClient): RequestHandler[]
 
     sendCustomSuccess(res, response, StatusCodes.OK);
   });
+};
 
-  return [requireUserAuth(), requireProvisionedUser(prisma), handler];
+export function createUpdateGuildHandler(deps: RouteDeps): RequestHandler[] {
+  return [requireUserAuth(), requireProvisionedUser(deps.prisma), handleUpdateChannelGuild(deps)];
 }

--- a/services/api-gateway/src/routes/user/config-overrides.test.ts
+++ b/services/api-gateway/src/routes/user/config-overrides.test.ts
@@ -150,7 +150,7 @@ describe('/user/config-overrides routes', () => {
 
   describe('route factory', () => {
     it('should create a router with all expected routes', () => {
-      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createConfigOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(router).toBeDefined();
       expect(findRoute(router, 'get', '/resolve-defaults')).toBeDefined();
@@ -165,7 +165,7 @@ describe('/user/config-overrides routes', () => {
 
   describe('GET /resolve-defaults', () => {
     it('should return hardcoded defaults when no overrides exist', async () => {
-      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createConfigOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/resolve-defaults');
       const { req, res } = createMockReqRes();
 
@@ -190,7 +190,7 @@ describe('/user/config-overrides routes', () => {
         configDefaults: { maxMessages: 75, focusModeEnabled: true },
       });
 
-      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createConfigOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/resolve-defaults');
       const { req, res } = createMockReqRes();
 
@@ -220,7 +220,7 @@ describe('/user/config-overrides routes', () => {
         configDefaults: { maxMessages: 30, maxImages: 5 },
       });
 
-      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createConfigOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/resolve-defaults');
       const { req, res } = createMockReqRes();
 
@@ -248,7 +248,7 @@ describe('/user/config-overrides routes', () => {
         configDefaults: { maxImages: 5 },
       });
 
-      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createConfigOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/resolve-defaults');
       const { req, res } = createMockReqRes();
 
@@ -272,7 +272,7 @@ describe('/user/config-overrides routes', () => {
 
   describe('GET /defaults', () => {
     it('should return null when no config defaults set', async () => {
-      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createConfigOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/defaults');
       const { req, res } = createMockReqRes();
 
@@ -287,7 +287,7 @@ describe('/user/config-overrides routes', () => {
         configDefaults: { maxMessages: 30, maxImages: 5 },
       });
 
-      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createConfigOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/defaults');
       const { req, res } = createMockReqRes();
 
@@ -308,7 +308,7 @@ describe('/user/config-overrides routes', () => {
         configDefaults: { maxMessages: 30 },
       });
 
-      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createConfigOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'patch', '/defaults');
       const { req, res } = createMockReqRes({ maxImages: 5 });
 
@@ -324,7 +324,7 @@ describe('/user/config-overrides routes', () => {
     });
 
     it('should reject non-object request body', async () => {
-      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createConfigOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'patch', '/defaults');
       const { req, res } = createMockReqRes();
       req.body = 'not-an-object' as unknown as Record<string, unknown>;
@@ -342,7 +342,7 @@ describe('/user/config-overrides routes', () => {
     });
 
     it('should reject invalid config format', async () => {
-      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createConfigOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'patch', '/defaults');
       const { req, res } = createMockReqRes({ maxMessages: 'not-a-number' });
 
@@ -359,7 +359,7 @@ describe('/user/config-overrides routes', () => {
 
   describe('DELETE /defaults', () => {
     it('should clear user config defaults', async () => {
-      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createConfigOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/defaults');
       const { req, res } = createMockReqRes();
 
@@ -377,7 +377,7 @@ describe('/user/config-overrides routes', () => {
 
   describe('GET /resolve/:personalityId', () => {
     it('should return resolved cascade overrides', async () => {
-      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createConfigOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/resolve/:personalityId');
       const { req, res } = createMockReqRes({}, { personalityId: TEST_PERSONALITY_ID });
 
@@ -395,7 +395,7 @@ describe('/user/config-overrides routes', () => {
     });
 
     it('should pass channelId query param to resolver', async () => {
-      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createConfigOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/resolve/:personalityId');
       const { req, res } = createMockReqRes(
         {},
@@ -413,7 +413,7 @@ describe('/user/config-overrides routes', () => {
     });
 
     it('should reject invalid channelId format', async () => {
-      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createConfigOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/resolve/:personalityId');
       const { req, res } = createMockReqRes(
         {},
@@ -428,7 +428,7 @@ describe('/user/config-overrides routes', () => {
     });
 
     it('should pass undefined channelId when query param not provided', async () => {
-      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createConfigOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/resolve/:personalityId');
       const { req, res } = createMockReqRes({}, { personalityId: TEST_PERSONALITY_ID });
 
@@ -444,7 +444,7 @@ describe('/user/config-overrides routes', () => {
 
   describe('PATCH /:personalityId', () => {
     it('should reject non-UUID personalityId', async () => {
-      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createConfigOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'patch', '/:personalityId');
       const { req, res } = createMockReqRes(
         { maxMessages: 25 },
@@ -464,7 +464,7 @@ describe('/user/config-overrides routes', () => {
     });
 
     it('should reject non-object request body', async () => {
-      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createConfigOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'patch', '/:personalityId');
       const { req, res } = createMockReqRes(undefined as unknown as Record<string, unknown>, {
         personalityId: TEST_PERSONALITY_ID,
@@ -484,7 +484,7 @@ describe('/user/config-overrides routes', () => {
     });
 
     it('should upsert valid per-personality overrides', async () => {
-      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createConfigOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'patch', '/:personalityId');
       const { req, res } = createMockReqRes(
         { maxMessages: 25 },
@@ -503,7 +503,7 @@ describe('/user/config-overrides routes', () => {
     });
 
     it('should reject invalid config format', async () => {
-      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createConfigOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'patch', '/:personalityId');
       const { req, res } = createMockReqRes(
         { maxMessages: -5 },
@@ -525,7 +525,7 @@ describe('/user/config-overrides routes', () => {
         configOverrides: { maxImages: 5 },
       });
 
-      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createConfigOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'patch', '/:personalityId');
       const { req, res } = createMockReqRes(
         { maxMessages: 25 },
@@ -545,7 +545,7 @@ describe('/user/config-overrides routes', () => {
 
   describe('DELETE /:personalityId', () => {
     it('should reject non-UUID personalityId', async () => {
-      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createConfigOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:personalityId');
       const { req, res } = createMockReqRes({}, { personalityId: 'resolve-defaults' });
 
@@ -566,7 +566,7 @@ describe('/user/config-overrides routes', () => {
         configOverrides: { maxMessages: 30 },
       });
 
-      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createConfigOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:personalityId');
       const { req, res } = createMockReqRes({}, { personalityId: TEST_PERSONALITY_ID });
 
@@ -580,7 +580,7 @@ describe('/user/config-overrides routes', () => {
     it('should succeed even when no overrides exist', async () => {
       mockPrisma.userPersonalityConfig.findUnique.mockResolvedValue(null);
 
-      const router = createConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createConfigOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:personalityId');
       const { req, res } = createMockReqRes({}, { personalityId: TEST_PERSONALITY_ID });
 
@@ -598,10 +598,12 @@ describe('/user/config-overrides routes', () => {
         invalidateUser: vi.fn().mockResolvedValue(undefined),
       };
 
-      const router = createConfigOverrideRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockInvalidation as unknown as Parameters<typeof createConfigOverrideRoutes>[1]
-      );
+      const router = createConfigOverrideRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        cascadeInvalidation: mockInvalidation as unknown as NonNullable<
+          Parameters<typeof createConfigOverrideRoutes>[0]['cascadeInvalidation']
+        >,
+      });
       const handler = getHandler(router, 'patch', '/defaults');
       const { req, res } = createMockReqRes({ maxMessages: 25 });
 
@@ -615,10 +617,12 @@ describe('/user/config-overrides routes', () => {
         invalidateUser: vi.fn().mockRejectedValue(new Error('Redis down')),
       };
 
-      const router = createConfigOverrideRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockInvalidation as unknown as Parameters<typeof createConfigOverrideRoutes>[1]
-      );
+      const router = createConfigOverrideRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        cascadeInvalidation: mockInvalidation as unknown as NonNullable<
+          Parameters<typeof createConfigOverrideRoutes>[0]['cascadeInvalidation']
+        >,
+      });
       const handler = getHandler(router, 'delete', '/defaults');
       const { req, res } = createMockReqRes();
 

--- a/services/api-gateway/src/routes/user/config-overrides.ts
+++ b/services/api-gateway/src/routes/user/config-overrides.ts
@@ -12,7 +12,7 @@
  * - DELETE /user/config-overrides/defaults - Clear user's global defaults
  */
 
-import { Router, type Response } from 'express';
+import { Router, type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { z } from 'zod';
 import {
@@ -24,8 +24,6 @@ import {
   HARDCODED_CONFIG_DEFAULTS,
   ADMIN_SETTINGS_SINGLETON_ID,
   ConfigOverridesSchema,
-  type PrismaClient,
-  type ConfigCascadeCacheInvalidationService,
   type ConfigOverrideSource,
 } from '@tzurot/common-types';
 import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
@@ -39,6 +37,7 @@ import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
 import { getRequiredParam } from '../../utils/requestParams.js';
 import type { AuthenticatedRequest, ProvisionedRequest } from '../../types.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('user-config-overrides');
 
@@ -55,278 +54,251 @@ function parseConfigTier(raw: unknown): Record<string, unknown> | null {
   return result.data;
 }
 
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 /** Query schema for resolve endpoint */
 const resolveQuerySchema = z.object({
   channelId: z.string().regex(DISCORD_SNOWFLAKE.PATTERN, 'Invalid channelId format').optional(),
 });
 
-// eslint-disable-next-line max-lines-per-function -- Route factory with 7 endpoints following model-override.ts pattern
-export function createConfigOverrideRoutes(
-  prisma: PrismaClient,
-  cascadeInvalidation?: ConfigCascadeCacheInvalidationService
-): Router {
-  const router = Router();
-  const cascadeResolver = new ConfigCascadeResolver(prisma, { enableCleanup: false });
+/** GET /api/user/config-overrides/resolve-defaults — admin → user-default cascade */
+export const handleResolveUserDefaults = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const userId = resolveProvisionedUserId(req);
 
-  // All routes require authentication
-  router.use(requireUserAuth());
-  router.use(requireProvisionedUser(prisma));
-
-  /**
-   * GET /user/config-overrides/resolve-defaults
-   * Resolve admin → user-default cascade (no personality/channel context).
-   * Returns resolved values with per-field source tracking and raw user overrides.
-   */
-  router.get(
-    '/resolve-defaults',
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const userId = resolveProvisionedUserId(req);
-
-      // Load admin and user tiers in parallel
-      const [adminSettings, user] = await Promise.all([
-        prisma.adminSettings.findUnique({
-          where: { id: ADMIN_SETTINGS_SINGLETON_ID },
-          select: { configDefaults: true },
-        }),
-        prisma.user.findUnique({
-          where: { id: userId },
-          select: { configDefaults: true },
-        }),
-      ]);
-
-      // Parse and validate each tier
-      const adminDefaults = parseConfigTier(adminSettings?.configDefaults);
-      const userDefaults = parseConfigTier(user?.configDefaults);
-
-      // Merge: hardcoded → admin → user-default
-      const resolved: Record<string, unknown> = { ...HARDCODED_CONFIG_DEFAULTS };
-      const sources: Record<string, ConfigOverrideSource> = {};
-
-      for (const key of Object.keys(HARDCODED_CONFIG_DEFAULTS)) {
-        sources[key] = 'hardcoded';
-      }
-
-      if (adminDefaults !== null) {
-        for (const [key, value] of Object.entries(adminDefaults)) {
-          if (value !== undefined) {
-            resolved[key] = value;
-            sources[key] = 'admin';
-          }
-        }
-      }
-
-      if (userDefaults !== null) {
-        for (const [key, value] of Object.entries(userDefaults)) {
-          if (value !== undefined) {
-            resolved[key] = value;
-            sources[key] = 'user-default';
-          }
-        }
-      }
-
-      // Note: 'sources' and 'userOverrides' are reserved metadata keys in this flat response.
-      // Config field names (from ConfigOverridesSchema) must not collide with them.
-      sendCustomSuccess(res, { ...resolved, sources, userOverrides: userDefaults }, StatusCodes.OK);
-    })
-  );
-
-  /**
-   * GET /user/config-overrides/defaults
-   * Get user's global config defaults (User.configDefaults)
-   */
-  router.get(
-    '/defaults',
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const userId = resolveProvisionedUserId(req);
-
-      const user = await prisma.user.findUnique({
+    // Load admin and user tiers in parallel
+    const [adminSettings, user] = await Promise.all([
+      prisma.adminSettings.findUnique({
+        where: { id: ADMIN_SETTINGS_SINGLETON_ID },
+        select: { configDefaults: true },
+      }),
+      prisma.user.findUnique({
         where: { id: userId },
         select: { configDefaults: true },
-      });
+      }),
+    ]);
 
-      sendCustomSuccess(
-        res,
-        { configDefaults: (user?.configDefaults as Record<string, unknown> | null) ?? null },
-        StatusCodes.OK
-      );
-    })
-  );
+    const adminDefaults = parseConfigTier(adminSettings?.configDefaults);
+    const userDefaults = parseConfigTier(user?.configDefaults);
 
-  /**
-   * PATCH /user/config-overrides/defaults
-   * Update user's global config defaults (merge semantics)
-   * Body: Partial<ConfigOverrides>
-   */
-  router.patch(
-    '/defaults',
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const userId = resolveProvisionedUserId(req);
+    // Merge: hardcoded → admin → user-default
+    const resolved: Record<string, unknown> = { ...HARDCODED_CONFIG_DEFAULTS };
+    const sources: Record<string, ConfigOverrideSource> = {};
 
-      const user = await prisma.user.findUnique({
-        where: { id: userId },
-        select: { configDefaults: true },
-      });
+    for (const key of Object.keys(HARDCODED_CONFIG_DEFAULTS)) {
+      sources[key] = 'hardcoded';
+    }
 
-      const { merged, prismaValue } = mergeAndValidateOverrides(
-        user?.configDefaults,
-        req.body,
-        res
-      );
-      if (merged === undefined) {
-        return;
+    if (adminDefaults !== null) {
+      for (const [key, value] of Object.entries(adminDefaults)) {
+        if (value !== undefined) {
+          resolved[key] = value;
+          sources[key] = 'admin';
+        }
       }
+    }
 
-      await prisma.user.update({
-        where: { id: userId },
-        data: { configDefaults: prismaValue },
-      });
-
-      await tryInvalidateCache(
-        cascadeInvalidation?.invalidateUser.bind(cascadeInvalidation, req.userId),
-        { discordUserId: req.userId }
-      );
-
-      sendCustomSuccess(res, { configDefaults: merged }, StatusCodes.OK);
-    })
-  );
-
-  /**
-   * DELETE /user/config-overrides/defaults
-   * Clear user's global config defaults
-   */
-  router.delete(
-    '/defaults',
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const userId = resolveProvisionedUserId(req);
-
-      await prisma.user.update({
-        where: { id: userId },
-        data: { configDefaults: Prisma.JsonNull },
-      });
-
-      await tryInvalidateCache(
-        cascadeInvalidation?.invalidateUser.bind(cascadeInvalidation, req.userId),
-        { discordUserId: req.userId }
-      );
-
-      sendCustomSuccess(res, { success: true }, StatusCodes.OK);
-    })
-  );
-
-  /**
-   * GET /user/config-overrides/resolve/:personalityId?channelId=xxx
-   * Resolve cascade overrides for a user+personality+channel combination.
-   * Returns fully resolved values with per-field source tracking.
-   */
-  router.get(
-    '/resolve/:personalityId',
-    asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
-      const personalityId = getRequiredParam(req.params.personalityId, 'personalityId');
-      const queryResult = resolveQuerySchema.safeParse(req.query);
-      if (!queryResult.success) {
-        sendError(res, ErrorResponses.validationError('Invalid channelId format'));
-        return;
+    if (userDefaults !== null) {
+      for (const [key, value] of Object.entries(userDefaults)) {
+        if (value !== undefined) {
+          resolved[key] = value;
+          sources[key] = 'user-default';
+        }
       }
-      const resolved = await cascadeResolver.resolveOverrides(
-        req.userId,
+    }
+
+    // Note: 'sources' and 'userOverrides' are reserved metadata keys in this flat response.
+    // Config field names (from ConfigOverridesSchema) must not collide with them.
+    sendCustomSuccess(res, { ...resolved, sources, userOverrides: userDefaults }, StatusCodes.OK);
+  });
+};
+
+/** GET /api/user/config-overrides/defaults — user's raw global config defaults */
+export const handleGetUserDefaults = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const userId = resolveProvisionedUserId(req);
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { configDefaults: true },
+    });
+
+    sendCustomSuccess(
+      res,
+      { configDefaults: (user?.configDefaults as Record<string, unknown> | null) ?? null },
+      StatusCodes.OK
+    );
+  });
+};
+
+/** PATCH /api/user/config-overrides/defaults — merge update user's global defaults */
+export const handleUpdateUserDefaults = (deps: RouteDeps): RequestHandler => {
+  const { prisma, cascadeInvalidation } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const userId = resolveProvisionedUserId(req);
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { configDefaults: true },
+    });
+
+    const { merged, prismaValue } = mergeAndValidateOverrides(user?.configDefaults, req.body, res);
+    if (merged === undefined) {
+      return;
+    }
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: { configDefaults: prismaValue },
+    });
+
+    await tryInvalidateCache(
+      cascadeInvalidation?.invalidateUser.bind(cascadeInvalidation, req.userId),
+      { discordUserId: req.userId }
+    );
+
+    sendCustomSuccess(res, { configDefaults: merged }, StatusCodes.OK);
+  });
+};
+
+/** DELETE /api/user/config-overrides/defaults — clear user's global defaults */
+export const handleClearUserDefaults = (deps: RouteDeps): RequestHandler => {
+  const { prisma, cascadeInvalidation } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const userId = resolveProvisionedUserId(req);
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: { configDefaults: Prisma.JsonNull },
+    });
+
+    await tryInvalidateCache(
+      cascadeInvalidation?.invalidateUser.bind(cascadeInvalidation, req.userId),
+      { discordUserId: req.userId }
+    );
+
+    sendCustomSuccess(res, { success: true }, StatusCodes.OK);
+  });
+};
+
+/** GET /api/user/config-overrides/resolve/:personalityId — full cascade resolution */
+export const handleResolveCascade = (deps: RouteDeps): RequestHandler => {
+  const cascadeResolver = new ConfigCascadeResolver(deps.prisma, { enableCleanup: false });
+  return asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+    const personalityId = getRequiredParam(req.params.personalityId, 'personalityId');
+    const queryResult = resolveQuerySchema.safeParse(req.query);
+    if (!queryResult.success) {
+      sendError(res, ErrorResponses.validationError('Invalid channelId format'));
+      return;
+    }
+    const resolved = await cascadeResolver.resolveOverrides(
+      req.userId,
+      personalityId,
+      queryResult.data.channelId
+    );
+    sendCustomSuccess(res, resolved, StatusCodes.OK);
+  });
+};
+
+/** PATCH /api/user/config-overrides/:personalityId — merge update per-personality overrides */
+export const handleUpdatePersonalityOverrides = (deps: RouteDeps): RequestHandler => {
+  const { prisma, cascadeInvalidation } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const personalityId = getRequiredParam(req.params.personalityId, 'personalityId');
+
+    if (!UUID_PATTERN.test(personalityId)) {
+      return sendError(res, ErrorResponses.validationError('Invalid personalityId format'));
+    }
+
+    const userId = resolveProvisionedUserId(req);
+
+    const upcId = generateUserPersonalityConfigUuid(userId, personalityId);
+
+    const existing = await prisma.userPersonalityConfig.findUnique({
+      where: { id: upcId },
+      select: { configOverrides: true },
+    });
+
+    const { merged, prismaValue } = mergeAndValidateOverrides(
+      existing?.configOverrides,
+      req.body,
+      res
+    );
+    if (merged === undefined) {
+      return;
+    }
+
+    await prisma.userPersonalityConfig.upsert({
+      where: { id: upcId },
+      create: {
+        id: upcId,
+        userId,
         personalityId,
-        queryResult.data.channelId
-      );
-      sendCustomSuccess(res, resolved, StatusCodes.OK);
-    })
-  );
+        configOverrides: prismaValue,
+      },
+      update: {
+        configOverrides: prismaValue,
+      },
+    });
 
-  /**
-   * PATCH /user/config-overrides/:personalityId
-   * Update per-personality config overrides (merge semantics)
-   * Body: Partial<ConfigOverrides>
-   */
-  router.patch(
-    '/:personalityId',
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const personalityId = getRequiredParam(req.params.personalityId, 'personalityId');
+    await tryInvalidateCache(
+      cascadeInvalidation?.invalidateUser.bind(cascadeInvalidation, req.userId),
+      { discordUserId: req.userId }
+    );
 
-      if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(personalityId)) {
-        return sendError(res, ErrorResponses.validationError('Invalid personalityId format'));
-      }
+    sendCustomSuccess(res, { configOverrides: merged }, StatusCodes.OK);
+  });
+};
 
-      const userId = resolveProvisionedUserId(req);
+/** DELETE /api/user/config-overrides/:personalityId — clear per-personality overrides */
+export const handleClearPersonalityOverrides = (deps: RouteDeps): RequestHandler => {
+  const { prisma, cascadeInvalidation } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const personalityId = getRequiredParam(req.params.personalityId, 'personalityId');
 
-      // Upsert UserPersonalityConfig with deterministic UUID
-      const upcId = generateUserPersonalityConfigUuid(userId, personalityId);
+    if (!UUID_PATTERN.test(personalityId)) {
+      return sendError(res, ErrorResponses.validationError('Invalid personalityId format'));
+    }
 
-      const existing = await prisma.userPersonalityConfig.findUnique({
+    const userId = resolveProvisionedUserId(req);
+
+    const upcId = generateUserPersonalityConfigUuid(userId, personalityId);
+
+    const existing = await prisma.userPersonalityConfig.findUnique({
+      where: { id: upcId },
+    });
+
+    if (existing !== null) {
+      await prisma.userPersonalityConfig.update({
         where: { id: upcId },
-        select: { configOverrides: true },
+        data: { configOverrides: Prisma.JsonNull },
       });
+    }
 
-      const { merged, prismaValue } = mergeAndValidateOverrides(
-        existing?.configOverrides,
-        req.body,
-        res
-      );
-      if (merged === undefined) {
-        return;
-      }
+    await tryInvalidateCache(
+      cascadeInvalidation?.invalidateUser.bind(cascadeInvalidation, req.userId),
+      { discordUserId: req.userId }
+    );
 
-      await prisma.userPersonalityConfig.upsert({
-        where: { id: upcId },
-        create: {
-          id: upcId,
-          userId,
-          personalityId,
-          configOverrides: prismaValue,
-        },
-        update: {
-          configOverrides: prismaValue,
-        },
-      });
+    sendCustomSuccess(res, { success: true }, StatusCodes.OK);
+  });
+};
 
-      await tryInvalidateCache(
-        cascadeInvalidation?.invalidateUser.bind(cascadeInvalidation, req.userId),
-        { discordUserId: req.userId }
-      );
+export function createConfigOverrideRoutes(deps: RouteDeps): Router {
+  const router = Router();
 
-      sendCustomSuccess(res, { configOverrides: merged }, StatusCodes.OK);
-    })
-  );
+  router.use(requireUserAuth());
+  router.use(requireProvisionedUser(deps.prisma));
 
-  /**
-   * DELETE /user/config-overrides/:personalityId
-   * Clear per-personality config overrides
-   */
-  router.delete(
-    '/:personalityId',
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const personalityId = getRequiredParam(req.params.personalityId, 'personalityId');
-
-      if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(personalityId)) {
-        return sendError(res, ErrorResponses.validationError('Invalid personalityId format'));
-      }
-
-      const userId = resolveProvisionedUserId(req);
-
-      const upcId = generateUserPersonalityConfigUuid(userId, personalityId);
-
-      const existing = await prisma.userPersonalityConfig.findUnique({
-        where: { id: upcId },
-      });
-
-      if (existing !== null) {
-        await prisma.userPersonalityConfig.update({
-          where: { id: upcId },
-          data: { configOverrides: Prisma.JsonNull },
-        });
-      }
-
-      await tryInvalidateCache(
-        cascadeInvalidation?.invalidateUser.bind(cascadeInvalidation, req.userId),
-        { discordUserId: req.userId }
-      );
-
-      sendCustomSuccess(res, { success: true }, StatusCodes.OK);
-    })
-  );
+  router.get('/resolve-defaults', handleResolveUserDefaults(deps));
+  router.get('/defaults', handleGetUserDefaults(deps));
+  router.patch('/defaults', handleUpdateUserDefaults(deps));
+  router.delete('/defaults', handleClearUserDefaults(deps));
+  router.get('/resolve/:personalityId', handleResolveCascade(deps));
+  router.patch('/:personalityId', handleUpdatePersonalityOverrides(deps));
+  router.delete('/:personalityId', handleClearPersonalityOverrides(deps));
 
   return router;
 }

--- a/services/api-gateway/src/routes/user/conversationLookup.test.ts
+++ b/services/api-gateway/src/routes/user/conversationLookup.test.ts
@@ -58,7 +58,7 @@ describe('conversationLookup routes', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    router = createConversationLookupRoutes(mockPrisma as unknown as PrismaClient);
+    router = createConversationLookupRoutes({ prisma: mockPrisma as unknown as PrismaClient });
   });
 
   describe('GET /conversation/message-personality', () => {

--- a/services/api-gateway/src/routes/user/conversationLookup.ts
+++ b/services/api-gateway/src/routes/user/conversationLookup.ts
@@ -5,81 +5,63 @@
  * GET /user/conversation/message-personality - Get personality from Discord message ID
  */
 
-import { Router, type Request, type Response } from 'express';
+import { Router, type Request, type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
-import { createLogger, type PrismaClient, ConversationHistoryService } from '@tzurot/common-types';
+import { createLogger, ConversationHistoryService } from '@tzurot/common-types';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
 import { getParam } from '../../utils/requestParams.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('conversation-lookup');
 
-/**
- * Response for message personality lookup
- */
 interface MessagePersonalityResponse {
   personalityId: string;
   personalityName?: string;
 }
 
 /**
- * Create conversation lookup routes
- * These are internal service-to-service endpoints (no user auth required)
+ * GET /api/user/conversation/message-personality — lookup personality by Discord message ID
+ * Internal service-to-service endpoint (no user auth required).
  */
-export function createConversationLookupRoutes(prisma: PrismaClient): Router {
+export const handleLookupMessagePersonality = (deps: RouteDeps): RequestHandler => {
+  const conversationHistoryService = new ConversationHistoryService(deps.prisma);
+  return asyncHandler(async (req: Request, res: Response): Promise<void> => {
+    const discordMessageId = getParam(req.query.discordMessageId as string | string[] | undefined);
+
+    if (discordMessageId === undefined) {
+      sendError(
+        res,
+        ErrorResponses.validationError('discordMessageId query parameter is required')
+      );
+      return;
+    }
+
+    const message = await conversationHistoryService.getMessageByDiscordId(discordMessageId);
+
+    if (message?.personalityId === undefined) {
+      logger.debug({ discordMessageId }, 'No message found for Discord message ID');
+      res.status(StatusCodes.NOT_FOUND).json(null);
+      return;
+    }
+
+    const response: MessagePersonalityResponse = {
+      personalityId: message.personalityId,
+      personalityName: message.personalityName,
+    };
+
+    logger.debug(
+      { discordMessageId, personalityId: message.personalityId },
+      'Found personality for Discord message'
+    );
+
+    sendCustomSuccess(res, response, StatusCodes.OK);
+  });
+};
+
+export function createConversationLookupRoutes(deps: RouteDeps): Router {
   const router = Router();
-  const conversationHistoryService = new ConversationHistoryService(prisma);
-
-  /**
-   * GET /conversation/message-personality
-   *
-   * Lookup which personality sent a message by Discord message ID.
-   * Used by bot-client to resolve DM reply targets.
-   *
-   * Query params:
-   * - discordMessageId: The Discord snowflake ID to look up
-   *
-   * Returns:
-   * - 200 with { personalityId, personalityName } if found
-   * - 404 with null if not found
-   */
-  router.get(
-    '/message-personality',
-    asyncHandler(async (req: Request, res: Response): Promise<void> => {
-      const discordMessageId = getParam(
-        req.query.discordMessageId as string | string[] | undefined
-      );
-
-      if (discordMessageId === undefined) {
-        sendError(
-          res,
-          ErrorResponses.validationError('discordMessageId query parameter is required')
-        );
-        return;
-      }
-
-      const message = await conversationHistoryService.getMessageByDiscordId(discordMessageId);
-
-      if (message?.personalityId === undefined) {
-        logger.debug({ discordMessageId }, 'No message found for Discord message ID');
-        res.status(StatusCodes.NOT_FOUND).json(null);
-        return;
-      }
-
-      const response: MessagePersonalityResponse = {
-        personalityId: message.personalityId,
-        personalityName: message.personalityName,
-      };
-
-      logger.debug(
-        { discordMessageId, personalityId: message.personalityId },
-        'Found personality for Discord message'
-      );
-
-      sendCustomSuccess(res, response, StatusCodes.OK);
-    })
-  );
-
+  router.get('/message-personality', handleLookupMessagePersonality(deps));
   return router;
 }

--- a/services/api-gateway/src/routes/user/history.test.ts
+++ b/services/api-gateway/src/routes/user/history.test.ts
@@ -174,26 +174,26 @@ describe('/user/history routes', () => {
 
   describe('route factory', () => {
     it('should create a router', () => {
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(router).toBeDefined();
       expect(typeof router).toBe('function');
     });
 
     it('should have POST /clear route registered', () => {
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(findRoute(router, 'post', '/clear')).toBeDefined();
     });
 
     it('should have POST /undo route registered', () => {
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(findRoute(router, 'post', '/undo')).toBeDefined();
     });
 
     it('should have GET /stats route registered', () => {
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(findRoute(router, 'get', '/stats')).toBeDefined();
     });
@@ -201,7 +201,7 @@ describe('/user/history routes', () => {
 
   describe('POST /user/history/clear', () => {
     it('should reject missing personalitySlug', async () => {
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/clear');
       const { req, res } = createMockReqRes({});
 
@@ -217,7 +217,7 @@ describe('/user/history routes', () => {
     });
 
     it('should reject empty personalitySlug', async () => {
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/clear');
       const { req, res } = createMockReqRes({ personalitySlug: '' });
 
@@ -229,7 +229,7 @@ describe('/user/history routes', () => {
     it('should return 404 when user not found', async () => {
       mockPrisma.user.findFirst.mockResolvedValue(null);
 
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/clear');
       const { req, res } = createMockReqRes({ personalitySlug: TEST_PERSONALITY_SLUG });
 
@@ -241,7 +241,7 @@ describe('/user/history routes', () => {
     it('should return 404 when personality not found', async () => {
       mockPrisma.personality.findUnique.mockResolvedValue(null);
 
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/clear');
       const { req, res } = createMockReqRes({ personalitySlug: TEST_PERSONALITY_SLUG });
 
@@ -257,7 +257,7 @@ describe('/user/history routes', () => {
         config: {},
       });
 
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/clear');
       const { req, res } = createMockReqRes({ personalitySlug: TEST_PERSONALITY_SLUG });
 
@@ -267,7 +267,7 @@ describe('/user/history routes', () => {
     });
 
     it('should set epoch on new config', async () => {
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/clear');
       const { req, res } = createMockReqRes({ personalitySlug: TEST_PERSONALITY_SLUG });
 
@@ -313,7 +313,7 @@ describe('/user/history routes', () => {
         previousContextReset: null,
       });
 
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/clear');
       const { req, res } = createMockReqRes({ personalitySlug: TEST_PERSONALITY_SLUG });
 
@@ -336,7 +336,7 @@ describe('/user/history routes', () => {
     });
 
     it('should use explicit personaId when provided', async () => {
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/clear');
       const { req, res } = createMockReqRes({
         personalitySlug: TEST_PERSONALITY_SLUG,
@@ -359,7 +359,7 @@ describe('/user/history routes', () => {
     it('should return 404 for explicit personaId not owned by user', async () => {
       mockPrisma.persona.findFirst.mockResolvedValue(null); // Persona not found or not owned
 
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/clear');
       const { req, res } = createMockReqRes({
         personalitySlug: TEST_PERSONALITY_SLUG,
@@ -374,7 +374,7 @@ describe('/user/history routes', () => {
 
   describe('POST /user/history/undo', () => {
     it('should reject missing personalitySlug', async () => {
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/undo');
       const { req, res } = createMockReqRes({});
 
@@ -386,7 +386,7 @@ describe('/user/history routes', () => {
     it('should return 404 when user not found', async () => {
       mockPrisma.user.findFirst.mockResolvedValue(null);
 
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/undo');
       const { req, res } = createMockReqRes({ personalitySlug: TEST_PERSONALITY_SLUG });
 
@@ -404,7 +404,7 @@ describe('/user/history routes', () => {
         previousContextReset: null, // First clear - no previous epoch
       });
 
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/undo');
       const { req, res } = createMockReqRes({ personalitySlug: TEST_PERSONALITY_SLUG });
 
@@ -436,7 +436,7 @@ describe('/user/history routes', () => {
     it('should return error when config does not exist', async () => {
       mockPrisma.userPersonaHistoryConfig.findUnique.mockResolvedValue(null);
 
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/undo');
       const { req, res } = createMockReqRes({ personalitySlug: TEST_PERSONALITY_SLUG });
 
@@ -454,7 +454,7 @@ describe('/user/history routes', () => {
         previousContextReset: null,
       });
 
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/undo');
       const { req, res } = createMockReqRes({ personalitySlug: TEST_PERSONALITY_SLUG });
 
@@ -476,7 +476,7 @@ describe('/user/history routes', () => {
         previousContextReset: previousEpoch,
       });
 
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/undo');
       const { req, res } = createMockReqRes({ personalitySlug: TEST_PERSONALITY_SLUG });
 
@@ -509,7 +509,7 @@ describe('/user/history routes', () => {
 
   describe('GET /user/history/stats', () => {
     it('should reject missing personalitySlug', async () => {
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/stats');
       const { req, res } = createMockReqRes({}, { channelId: TEST_CHANNEL_ID });
 
@@ -524,7 +524,7 @@ describe('/user/history routes', () => {
     });
 
     it('should reject missing channelId', async () => {
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/stats');
       const { req, res } = createMockReqRes({}, { personalitySlug: TEST_PERSONALITY_SLUG });
 
@@ -541,7 +541,7 @@ describe('/user/history routes', () => {
     it('should return 404 when user not found', async () => {
       mockPrisma.user.findFirst.mockResolvedValue(null);
 
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/stats');
       const { req, res } = createMockReqRes(
         {},
@@ -562,7 +562,7 @@ describe('/user/history routes', () => {
         newestMessage: new Date('2024-01-02'),
       });
 
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/stats');
       const { req, res } = createMockReqRes(
         {},
@@ -617,7 +617,7 @@ describe('/user/history routes', () => {
         newestMessage: new Date('2024-01-02'),
       });
 
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/stats');
       const { req, res } = createMockReqRes(
         {},
@@ -665,7 +665,7 @@ describe('/user/history routes', () => {
         previousContextReset: new Date('2024-01-01'), // Has previous epoch
       });
 
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/stats');
       const { req, res } = createMockReqRes(
         {},
@@ -684,13 +684,13 @@ describe('/user/history routes', () => {
 
   describe('DELETE /user/history/hard-delete', () => {
     it('should have DELETE /hard-delete route registered', () => {
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(findRoute(router, 'delete', '/hard-delete')).toBeDefined();
     });
 
     it('should reject missing personalitySlug', async () => {
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/hard-delete');
       const { req, res } = createMockReqRes({ channelId: TEST_CHANNEL_ID });
 
@@ -706,7 +706,7 @@ describe('/user/history routes', () => {
     });
 
     it('should reject missing channelId', async () => {
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/hard-delete');
       const { req, res } = createMockReqRes({ personalitySlug: TEST_PERSONALITY_SLUG });
 
@@ -724,7 +724,7 @@ describe('/user/history routes', () => {
     it('should return 404 when user not found', async () => {
       mockPrisma.user.findFirst.mockResolvedValue(null);
 
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/hard-delete');
       const { req, res } = createMockReqRes({
         personalitySlug: TEST_PERSONALITY_SLUG,
@@ -739,7 +739,7 @@ describe('/user/history routes', () => {
     it('should return 404 when personality not found', async () => {
       mockPrisma.personality.findUnique.mockResolvedValue(null);
 
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/hard-delete');
       const { req, res } = createMockReqRes({
         personalitySlug: TEST_PERSONALITY_SLUG,
@@ -754,7 +754,7 @@ describe('/user/history routes', () => {
     it('should delete history for resolved persona by default', async () => {
       mockClearHistory.mockResolvedValue(15);
 
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/hard-delete');
       const { req, res } = createMockReqRes({
         personalitySlug: TEST_PERSONALITY_SLUG,
@@ -783,7 +783,7 @@ describe('/user/history routes', () => {
     it('should handle singular message count in response', async () => {
       mockClearHistory.mockResolvedValue(1);
 
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/hard-delete');
       const { req, res } = createMockReqRes({
         personalitySlug: TEST_PERSONALITY_SLUG,
@@ -800,7 +800,7 @@ describe('/user/history routes', () => {
     });
 
     it('should set irreversible context epoch instead of deleting config', async () => {
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/hard-delete');
       const { req, res } = createMockReqRes({
         personalitySlug: TEST_PERSONALITY_SLUG,
@@ -839,7 +839,7 @@ describe('/user/history routes', () => {
     it('should succeed and set epoch even when no messages to delete', async () => {
       mockClearHistory.mockResolvedValue(0);
 
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/hard-delete');
       const { req, res } = createMockReqRes({
         personalitySlug: TEST_PERSONALITY_SLUG,
@@ -860,7 +860,7 @@ describe('/user/history routes', () => {
     it('should handle zero messages deleted', async () => {
       mockClearHistory.mockResolvedValue(0);
 
-      const router = createHistoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createHistoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/hard-delete');
       const { req, res } = createMockReqRes({
         personalitySlug: TEST_PERSONALITY_SLUG,

--- a/services/api-gateway/src/routes/user/history.ts
+++ b/services/api-gateway/src/routes/user/history.ts
@@ -10,7 +10,7 @@
  * GET /user/history/stats - Get history statistics
  */
 
-import { Router, type Response, type Request } from 'express';
+import { Router, type Response, type Request, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import {
   createLogger,
@@ -30,6 +30,7 @@ import { ErrorResponses } from '../../utils/errorResponses.js';
 import { sendZodError } from '../../utils/zodHelpers.js';
 import { resolveHistoryContext } from '../../utils/historyContextResolver.js';
 import type { AuthenticatedRequest } from '../../types.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('user-history');
 
@@ -355,34 +356,42 @@ function createHardDeleteHandler(deps: HistoryHandlerDeps): RouteHandler {
   });
 }
 
-export function createHistoryRoutes(prisma: PrismaClient): Router {
-  const router = Router();
-  const deps: HistoryHandlerDeps = {
-    prisma,
-    conversationHistoryService: new ConversationHistoryService(prisma),
-    retentionService: new ConversationRetentionService(prisma),
+function buildHistoryDeps(deps: RouteDeps): HistoryHandlerDeps {
+  return {
+    prisma: deps.prisma,
+    conversationHistoryService: new ConversationHistoryService(deps.prisma),
+    retentionService: deps.retentionService ?? new ConversationRetentionService(deps.prisma),
   };
+}
 
-  // POST /user/history/clear - Set context epoch (soft reset)
-  router.post(
-    '/clear',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    createClearHandler(deps)
-  );
+/** POST /api/user/history/clear — soft-reset context via epoch */
+export const handleClearHistory = (deps: RouteDeps): RequestHandler =>
+  createClearHandler(buildHistoryDeps(deps));
 
-  // POST /user/history/undo - Restore previous epoch
-  router.post('/undo', requireUserAuth(), requireProvisionedUser(prisma), createUndoHandler(deps));
+/** POST /api/user/history/undo — restore previous context epoch */
+export const handleUndoHistory = (deps: RouteDeps): RequestHandler =>
+  createUndoHandler(buildHistoryDeps(deps));
 
-  // GET /user/history/stats - Get history statistics
-  router.get('/stats', requireUserAuth(), requireProvisionedUser(prisma), createStatsHandler(deps));
+/** GET /api/user/history/stats — conversation history statistics */
+export const handleGetHistoryStats = (deps: RouteDeps): RequestHandler =>
+  createStatsHandler(buildHistoryDeps(deps));
 
-  // DELETE /user/history/hard-delete - Permanently delete history
+/** DELETE /api/user/history/hard-delete — permanent deletion */
+export const handleHardDeleteHistory = (deps: RouteDeps): RequestHandler =>
+  createHardDeleteHandler(buildHistoryDeps(deps));
+
+export function createHistoryRoutes(deps: RouteDeps): Router {
+  const router = Router();
+  const requireProvisioned = requireProvisionedUser(deps.prisma);
+
+  router.post('/clear', requireUserAuth(), requireProvisioned, handleClearHistory(deps));
+  router.post('/undo', requireUserAuth(), requireProvisioned, handleUndoHistory(deps));
+  router.get('/stats', requireUserAuth(), requireProvisioned, handleGetHistoryStats(deps));
   router.delete(
     '/hard-delete',
     requireUserAuth(),
-    requireProvisionedUser(prisma),
-    createHardDeleteHandler(deps)
+    requireProvisioned,
+    handleHardDeleteHistory(deps)
   );
 
   return router;

--- a/services/api-gateway/src/routes/user/index.ts
+++ b/services/api-gateway/src/routes/user/index.ts
@@ -140,7 +140,7 @@ export function createUserRouter(opts: UserRouterOptions): Router {
   router.use('/usage', createUsageRoutes(deps));
 
   // Personality routes (with cache invalidation for avatar changes)
-  router.use('/personality', createPersonalityRoutes(prisma, cacheInvalidationService));
+  router.use('/personality', createPersonalityRoutes(deps));
 
   // LLM config routes (with cache invalidation for user config changes)
   router.use('/llm-config', createLlmConfigRoutes(deps));
@@ -167,7 +167,7 @@ export function createUserRouter(opts: UserRouterOptions): Router {
   router.use('/history', createHistoryRoutes(deps));
 
   // Channel activation routes (auto-respond to all messages in a channel)
-  router.use('/channel', createChannelRoutes(prisma, cascadeInvalidation));
+  router.use('/channel', createChannelRoutes(deps));
 
   // Memory routes (LTM management - stats, focus mode, search, browse, incognito)
   router.use('/memory', createMemoryRoutes(prisma, redis));

--- a/services/api-gateway/src/routes/user/index.ts
+++ b/services/api-gateway/src/routes/user/index.ts
@@ -161,7 +161,7 @@ export function createUserRouter(opts: UserRouterOptions): Router {
   router.use('/model-override', createModelOverrideRoutes(deps));
 
   // Persona routes (user profiles that tell AI about the user)
-  router.use('/persona', createPersonaRoutes(prisma));
+  router.use('/persona', createPersonaRoutes(deps));
 
   // History routes (STM management via context epochs)
   router.use('/history', createHistoryRoutes(deps));
@@ -170,7 +170,7 @@ export function createUserRouter(opts: UserRouterOptions): Router {
   router.use('/channel', createChannelRoutes(deps));
 
   // Memory routes (LTM management - stats, focus mode, search, browse, incognito)
-  router.use('/memory', createMemoryRoutes(prisma, redis));
+  router.use('/memory', createMemoryRoutes(deps));
 
   // NSFW verification routes (for DM interactions)
   router.use('/nsfw', createNsfwRoutes(deps));
@@ -186,7 +186,7 @@ export function createUserRouter(opts: UserRouterOptions): Router {
   router.use('/conversation', createConversationLookupRoutes(deps));
 
   // Shapes.inc import routes (credential management, import jobs)
-  router.use('/shapes', createShapesRoutes(prisma, aiQueue));
+  router.use('/shapes', createShapesRoutes(deps));
 
   // Voice management routes (ElevenLabs cloned voice CRUD)
   router.use('/voices', createVoicesRoutes(deps));

--- a/services/api-gateway/src/routes/user/index.ts
+++ b/services/api-gateway/src/routes/user/index.ts
@@ -146,10 +146,10 @@ export function createUserRouter(opts: UserRouterOptions): Router {
   router.use('/llm-config', createLlmConfigRoutes(deps));
 
   // TTS config routes (with cache invalidation for user TTS config changes)
-  router.use('/tts-config', createTtsConfigRoutes(prisma, ttsConfigCacheInvalidation));
+  router.use('/tts-config', createTtsConfigRoutes(deps));
 
   // TTS override routes (per-personality TTS overrides + user global default)
-  router.use('/tts-override', createTtsOverrideRoutes(prisma, ttsConfigCacheInvalidation));
+  router.use('/tts-override', createTtsOverrideRoutes(deps));
 
   // STT preference (user-level — STT is speaker-bound, no per-personality dimension)
   router.use('/stt-override', createSttOverrideRoutes(deps));
@@ -158,7 +158,7 @@ export function createUserRouter(opts: UserRouterOptions): Router {
   router.use('/voice-resolution', createVoiceResolutionRoutes(deps));
 
   // Model override routes (with cache invalidation for default config changes)
-  router.use('/model-override', createModelOverrideRoutes(prisma, llmConfigCacheInvalidation));
+  router.use('/model-override', createModelOverrideRoutes(deps));
 
   // Persona routes (user profiles that tell AI about the user)
   router.use('/persona', createPersonaRoutes(prisma));

--- a/services/api-gateway/src/routes/user/index.ts
+++ b/services/api-gateway/src/routes/user/index.ts
@@ -64,6 +64,7 @@ import type {
   SttResolverCacheInvalidationService,
 } from '@tzurot/common-types';
 import type { OpenRouterModelCache } from '../../services/OpenRouterModelCache.js';
+import type { RouteDeps } from '../routeDeps.js';
 import { createTimezoneRoutes } from './timezone.js';
 import { createUsageRoutes } from './usage.js';
 import { createPersonalityRoutes } from './personality/index.js';
@@ -114,13 +115,29 @@ export function createUserRouter(opts: UserRouterOptions): Router {
     aiQueue,
     sttResolverCacheInvalidation,
   } = opts;
+
+  // Build the shared RouteDeps once; refactored factories accept it,
+  // legacy per-arg factories take individual values forwarded below.
+  const deps: RouteDeps = {
+    prisma,
+    llmConfigCacheInvalidation,
+    ttsConfigCacheInvalidation,
+    cacheInvalidationService,
+    redis,
+    modelCache,
+    cascadeInvalidation,
+    cascadeResolver,
+    aiQueue,
+    sttResolverCacheInvalidation,
+  };
+
   const router = Router();
 
   // Timezone routes
-  router.use('/timezone', createTimezoneRoutes(prisma));
+  router.use('/timezone', createTimezoneRoutes(deps));
 
   // Usage routes
-  router.use('/usage', createUsageRoutes(prisma));
+  router.use('/usage', createUsageRoutes(deps));
 
   // Personality routes (with cache invalidation for avatar changes)
   router.use('/personality', createPersonalityRoutes(prisma, cacheInvalidationService));
@@ -141,7 +158,7 @@ export function createUserRouter(opts: UserRouterOptions): Router {
   router.use('/stt-override', createSttOverrideRoutes(prisma, sttResolverCacheInvalidation));
 
   // Voice resolution aggregate read endpoint (powers /voice view dashboard)
-  router.use('/voice-resolution', createVoiceResolutionRoutes(prisma));
+  router.use('/voice-resolution', createVoiceResolutionRoutes(deps));
 
   // Model override routes (with cache invalidation for default config changes)
   router.use('/model-override', createModelOverrideRoutes(prisma, llmConfigCacheInvalidation));
@@ -159,7 +176,7 @@ export function createUserRouter(opts: UserRouterOptions): Router {
   router.use('/memory', createMemoryRoutes(prisma, redis));
 
   // NSFW verification routes (for DM interactions)
-  router.use('/nsfw', createNsfwRoutes(prisma));
+  router.use('/nsfw', createNsfwRoutes(deps));
 
   // Config override routes — two routers layered on the same path.
   // Express chains them sequentially and route patterns don't overlap:
@@ -172,7 +189,7 @@ export function createUserRouter(opts: UserRouterOptions): Router {
   );
 
   // Conversation lookup routes (internal service-to-service, no user auth)
-  router.use('/conversation', createConversationLookupRoutes(prisma));
+  router.use('/conversation', createConversationLookupRoutes(deps));
 
   // Shapes.inc import routes (credential management, import jobs)
   router.use('/shapes', createShapesRoutes(prisma, aiQueue));

--- a/services/api-gateway/src/routes/user/index.ts
+++ b/services/api-gateway/src/routes/user/index.ts
@@ -143,10 +143,7 @@ export function createUserRouter(opts: UserRouterOptions): Router {
   router.use('/personality', createPersonalityRoutes(prisma, cacheInvalidationService));
 
   // LLM config routes (with cache invalidation for user config changes)
-  router.use(
-    '/llm-config',
-    createLlmConfigRoutes(prisma, llmConfigCacheInvalidation, modelCache, cascadeResolver)
-  );
+  router.use('/llm-config', createLlmConfigRoutes(deps));
 
   // TTS config routes (with cache invalidation for user TTS config changes)
   router.use('/tts-config', createTtsConfigRoutes(prisma, ttsConfigCacheInvalidation));
@@ -155,7 +152,7 @@ export function createUserRouter(opts: UserRouterOptions): Router {
   router.use('/tts-override', createTtsOverrideRoutes(prisma, ttsConfigCacheInvalidation));
 
   // STT preference (user-level — STT is speaker-bound, no per-personality dimension)
-  router.use('/stt-override', createSttOverrideRoutes(prisma, sttResolverCacheInvalidation));
+  router.use('/stt-override', createSttOverrideRoutes(deps));
 
   // Voice resolution aggregate read endpoint (powers /voice view dashboard)
   router.use('/voice-resolution', createVoiceResolutionRoutes(deps));
@@ -182,11 +179,8 @@ export function createUserRouter(opts: UserRouterOptions): Router {
   // Express chains them sequentially and route patterns don't overlap:
   // - config-overrides.ts: /resolve/:id, /resolve-defaults, PATCH /:id, etc. (user/channel tiers)
   // - personality-config-overrides.ts: /resolve-personality/:id, /personality/:id (creator tier)
-  router.use('/config-overrides', createConfigOverrideRoutes(prisma, cascadeInvalidation));
-  router.use(
-    '/config-overrides',
-    createPersonalityConfigOverrideRoutes(prisma, cascadeInvalidation)
-  );
+  router.use('/config-overrides', createConfigOverrideRoutes(deps));
+  router.use('/config-overrides', createPersonalityConfigOverrideRoutes(deps));
 
   // Conversation lookup routes (internal service-to-service, no user auth)
   router.use('/conversation', createConversationLookupRoutes(deps));

--- a/services/api-gateway/src/routes/user/index.ts
+++ b/services/api-gateway/src/routes/user/index.ts
@@ -167,7 +167,7 @@ export function createUserRouter(opts: UserRouterOptions): Router {
   router.use('/persona', createPersonaRoutes(prisma));
 
   // History routes (STM management via context epochs)
-  router.use('/history', createHistoryRoutes(prisma));
+  router.use('/history', createHistoryRoutes(deps));
 
   // Channel activation routes (auto-respond to all messages in a channel)
   router.use('/channel', createChannelRoutes(prisma, cascadeInvalidation));
@@ -195,7 +195,7 @@ export function createUserRouter(opts: UserRouterOptions): Router {
   router.use('/shapes', createShapesRoutes(prisma, aiQueue));
 
   // Voice management routes (ElevenLabs cloned voice CRUD)
-  router.use('/voices', createVoicesRoutes(prisma));
+  router.use('/voices', createVoicesRoutes(deps));
 
   return router;
 }

--- a/services/api-gateway/src/routes/user/llm-config.int.test.ts
+++ b/services/api-gateway/src/routes/user/llm-config.int.test.ts
@@ -81,7 +81,7 @@ describe('LLM Config Resolution Integration', () => {
     app.use(express.json());
 
     // Mount LLM config routes (auth is mocked above)
-    const router = createLlmConfigRoutes(prisma);
+    const router = createLlmConfigRoutes({ prisma });
     app.use('/user/llm-config', router);
   }, 30000);
 

--- a/services/api-gateway/src/routes/user/llm-config.test.ts
+++ b/services/api-gateway/src/routes/user/llm-config.test.ts
@@ -199,14 +199,14 @@ describe('/user/llm-config routes', () => {
 
   describe('route factory', () => {
     it('should create a router', () => {
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(router).toBeDefined();
       expect(typeof router).toBe('function');
     });
 
     it('should have GET / route registered', () => {
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(router.stack).toBeDefined();
       expect(router.stack.length).toBeGreaterThan(0);
@@ -215,25 +215,25 @@ describe('/user/llm-config routes', () => {
     });
 
     it('should have GET /:id route registered', () => {
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(findRoute(router, 'get', '/:id')).toBeDefined();
     });
 
     it('should have POST route registered', () => {
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(findRoute(router, 'post', '/')).toBeDefined();
     });
 
     it('should have PUT /:id route registered', () => {
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(findRoute(router, 'put', '/:id')).toBeDefined();
     });
 
     it('should have DELETE route registered', () => {
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(findRoute(router, 'delete', '/:id')).toBeDefined();
     });
@@ -253,7 +253,7 @@ describe('/user/llm-config routes', () => {
       };
       mockPrisma.llmConfig.findMany.mockResolvedValueOnce([globalConfig]).mockResolvedValueOnce([]);
 
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/');
       const { req, res } = createMockReqRes();
 
@@ -281,7 +281,7 @@ describe('/user/llm-config routes', () => {
       };
       mockPrisma.llmConfig.findMany.mockResolvedValueOnce([]).mockResolvedValueOnce([userConfig]);
 
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/');
       const { req, res } = createMockReqRes();
 
@@ -299,7 +299,7 @@ describe('/user/llm-config routes', () => {
     it('should return 404 when config not found', async () => {
       mockPrisma.llmConfig.findUnique.mockResolvedValue(null);
 
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/:id');
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
@@ -324,7 +324,7 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/:id');
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
@@ -359,7 +359,7 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/:id');
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
@@ -386,7 +386,7 @@ describe('/user/llm-config routes', () => {
       // (otherwise supertest hangs waiting for a response that never comes).
       mockValidateLlmConfigModelFields.mockResolvedValueOnce(false);
 
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/');
       const { req, res } = createMockReqRes({ name: 'My Config', model: 'bad-model' });
 
@@ -398,7 +398,7 @@ describe('/user/llm-config routes', () => {
     });
 
     it('should reject missing name', async () => {
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/');
       const { req, res } = createMockReqRes({ model: 'gpt-4' });
 
@@ -414,7 +414,7 @@ describe('/user/llm-config routes', () => {
     });
 
     it('should reject missing model', async () => {
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/');
       const { req, res } = createMockReqRes({ name: 'My Config' });
 
@@ -429,7 +429,7 @@ describe('/user/llm-config routes', () => {
     });
 
     it('should reject name over 100 characters', async () => {
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/');
       const { req, res } = createMockReqRes({
         name: 'a'.repeat(101),
@@ -450,7 +450,7 @@ describe('/user/llm-config routes', () => {
     it('should reject duplicate name for user', async () => {
       mockPrisma.llmConfig.findFirst.mockResolvedValue({ id: 'existing' });
 
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/');
       const { req, res } = createMockReqRes({ name: 'My Config', model: 'gpt-4' });
 
@@ -478,7 +478,7 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/');
       const { req, res } = createMockReqRes({ name: 'My Config', model: 'gpt-4' });
 
@@ -511,7 +511,7 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/');
       const { req, res } = createMockReqRes({
         name: 'My Config',
@@ -548,7 +548,7 @@ describe('/user/llm-config routes', () => {
         contextWindowTokens: 100000,
       });
 
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/');
       const { req, res } = createMockReqRes({
         name: 'Memory Config',
@@ -579,10 +579,10 @@ describe('/user/llm-config routes', () => {
     it('should return 400 when model validation fails on update', async () => {
       mockValidateLlmConfigModelFields.mockResolvedValueOnce(false);
 
-      const router = createLlmConfigRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockCacheInvalidation
-      );
+      const router = createLlmConfigRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        llmConfigCacheInvalidation: mockCacheInvalidation,
+      });
       const handler = getHandler(router, 'put', '/:id');
       const { req, res } = createMockReqRes(
         { contextWindowTokens: 999999999 },
@@ -598,10 +598,10 @@ describe('/user/llm-config routes', () => {
     it('should return 404 when config not found', async () => {
       mockPrisma.llmConfig.findUnique.mockResolvedValue(null);
 
-      const router = createLlmConfigRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockCacheInvalidation
-      );
+      const router = createLlmConfigRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        llmConfigCacheInvalidation: mockCacheInvalidation,
+      });
       const handler = getHandler(router, 'put', '/:id');
       const { req, res } = createMockReqRes({ name: 'New Name' }, { id: 'config-123' });
 
@@ -642,10 +642,10 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockCacheInvalidation
-      );
+      const router = createLlmConfigRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        llmConfigCacheInvalidation: mockCacheInvalidation,
+      });
       const handler = getHandler(router, 'put', '/:id');
       const req = {
         body: { isGlobal: true },
@@ -695,10 +695,10 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockCacheInvalidation
-      );
+      const router = createLlmConfigRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        llmConfigCacheInvalidation: mockCacheInvalidation,
+      });
       const handler = getHandler(router, 'put', '/:id');
       const { req, res } = createMockReqRes(
         { name: 'Updated Global Config' },
@@ -724,10 +724,10 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockCacheInvalidation
-      );
+      const router = createLlmConfigRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        llmConfigCacheInvalidation: mockCacheInvalidation,
+      });
       const handler = getHandler(router, 'put', '/:id');
       const { req, res } = createMockReqRes({ name: 'New Name' }, { id: 'config-123' });
 
@@ -746,10 +746,10 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockCacheInvalidation
-      );
+      const router = createLlmConfigRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        llmConfigCacheInvalidation: mockCacheInvalidation,
+      });
       const handler = getHandler(router, 'put', '/:id');
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
@@ -764,10 +764,10 @@ describe('/user/llm-config routes', () => {
     });
 
     it('should reject non-boolean isGlobal value', async () => {
-      const router = createLlmConfigRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockCacheInvalidation
-      );
+      const router = createLlmConfigRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        llmConfigCacheInvalidation: mockCacheInvalidation,
+      });
       const handler = getHandler(router, 'put', '/:id');
       // Send string instead of boolean - Zod validates before DB lookup
       const { req, res } = createMockReqRes({ isGlobal: 'true' }, { id: 'config-123' });
@@ -813,10 +813,10 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockCacheInvalidation
-      );
+      const router = createLlmConfigRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        llmConfigCacheInvalidation: mockCacheInvalidation,
+      });
       const handler = getHandler(router, 'put', '/:id');
       const { req, res } = createMockReqRes(
         { name: 'New Name', advancedParameters: { temperature: 0.9 } },
@@ -871,10 +871,10 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockCacheInvalidation
-      );
+      const router = createLlmConfigRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        llmConfigCacheInvalidation: mockCacheInvalidation,
+      });
       const handler = getHandler(router, 'put', '/:id');
       const { req, res } = createMockReqRes({ name: 'New Name' }, { id: 'config-123' });
 
@@ -916,7 +916,7 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:id');
       const { req, res } = createMockReqRes({ model: 'claude-3' }, { id: 'config-123' });
 
@@ -968,7 +968,7 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:id');
       const { req, res } = createMockReqRes({ name: 'Renamed Verbatim' }, { id: 'config-123' });
 
@@ -998,7 +998,7 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:id');
       const { req, res } = createMockReqRes({ model: 'new-model' }, { id: 'config-123' });
 
@@ -1013,7 +1013,7 @@ describe('/user/llm-config routes', () => {
     it('should return 404 when user not found', async () => {
       mockPrisma.user.findFirst.mockResolvedValue(null);
 
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:id');
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
@@ -1026,7 +1026,7 @@ describe('/user/llm-config routes', () => {
       // Service uses findUnique for getById
       mockPrisma.llmConfig.findUnique.mockResolvedValue(null);
 
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:id');
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
@@ -1051,7 +1051,7 @@ describe('/user/llm-config routes', () => {
       mockPrisma.userPersonalityConfig.count.mockResolvedValue(0);
       mockPrisma.llmConfig.delete.mockResolvedValue({} as unknown);
 
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:id');
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
@@ -1077,7 +1077,7 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:id');
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
@@ -1100,7 +1100,7 @@ describe('/user/llm-config routes', () => {
       mockPrisma.personalityDefaultConfig.count.mockResolvedValue(0);
       mockPrisma.userPersonalityConfig.count.mockResolvedValue(2);
 
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:id');
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
@@ -1128,7 +1128,7 @@ describe('/user/llm-config routes', () => {
       mockPrisma.personalityDefaultConfig.count.mockResolvedValue(0);
       mockPrisma.userPersonalityConfig.count.mockResolvedValue(0);
 
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:id');
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
@@ -1163,7 +1163,7 @@ describe('/user/llm-config routes', () => {
       // Force the service to return a non-null warning via the underlying user.count.
       mockPrisma.user.count.mockResolvedValueOnce(5);
 
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:id');
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
@@ -1193,7 +1193,7 @@ describe('/user/llm-config routes', () => {
       mockPrisma.personalityDefaultConfig.count.mockResolvedValue(0);
       mockPrisma.userPersonalityConfig.count.mockResolvedValue(0);
 
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:id');
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
@@ -1220,7 +1220,7 @@ describe('/user/llm-config routes', () => {
       mockPrisma.personalityDefaultConfig.count.mockResolvedValue(0);
       mockPrisma.userPersonalityConfig.count.mockResolvedValue(7);
 
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:id');
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
@@ -1245,7 +1245,7 @@ describe('/user/llm-config routes', () => {
       mockPrisma.personalityDefaultConfig.count.mockResolvedValue(0);
       mockPrisma.userPersonalityConfig.count.mockResolvedValue(2);
 
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:id');
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
@@ -1298,11 +1298,11 @@ describe('/user/llm-config routes', () => {
         memoryLimit: 20,
       });
 
-      const router = createLlmConfigRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockCacheInvalidation,
-        mockModelCache
-      );
+      const router = createLlmConfigRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        llmConfigCacheInvalidation: mockCacheInvalidation,
+        modelCache: mockModelCache,
+      });
       const handler = getHandler(router, 'get', '/:id');
       const { req, res } = createMockReqRes({}, { id: 'config-123' });
 
@@ -1339,11 +1339,11 @@ describe('/user/llm-config routes', () => {
         advancedParameters: null,
       });
 
-      const router = createLlmConfigRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockCacheInvalidation,
-        mockModelCache
-      );
+      const router = createLlmConfigRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        llmConfigCacheInvalidation: mockCacheInvalidation,
+        modelCache: mockModelCache,
+      });
       const handler = getHandler(router, 'post', '/');
       const { req, res } = createMockReqRes({
         name: 'New Config',
@@ -1395,11 +1395,11 @@ describe('/user/llm-config routes', () => {
         advancedParameters: null,
       });
 
-      const router = createLlmConfigRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockCacheInvalidation,
-        mockModelCache
-      );
+      const router = createLlmConfigRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        llmConfigCacheInvalidation: mockCacheInvalidation,
+        modelCache: mockModelCache,
+      });
       const handler = getHandler(router, 'put', '/:id');
       const { req, res } = createMockReqRes({ name: 'Updated Config' }, { id: 'config-123' });
 
@@ -1419,7 +1419,7 @@ describe('/user/llm-config routes', () => {
 
   describe('POST /user/llm-config/resolve', () => {
     it('should reject missing personalityId', async () => {
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/resolve');
       const { req, res } = createMockReqRes({
         personalityConfig: { id: 'p-1', name: 'Test', model: 'gpt-4' },
@@ -1431,7 +1431,7 @@ describe('/user/llm-config routes', () => {
     });
 
     it('should reject missing personalityConfig', async () => {
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/resolve');
       const { req, res } = createMockReqRes({
         personalityId: 'personality-123',
@@ -1443,7 +1443,7 @@ describe('/user/llm-config routes', () => {
     });
 
     it('should reject invalid personalityConfig structure', async () => {
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/resolve');
       const { req, res } = createMockReqRes({
         personalityId: 'personality-123',
@@ -1456,7 +1456,7 @@ describe('/user/llm-config routes', () => {
     });
 
     it('should resolve config and include overrides in response', async () => {
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/resolve');
       const { req, res } = createMockReqRes({
         personalityId: 'personality-123',
@@ -1483,7 +1483,7 @@ describe('/user/llm-config routes', () => {
     });
 
     it('should pass channelId to cascade resolver when provided', async () => {
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/resolve');
       const { req, res } = createMockReqRes({
         personalityId: 'personality-123',
@@ -1502,7 +1502,7 @@ describe('/user/llm-config routes', () => {
     });
 
     it('should reject invalid channelId format', async () => {
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/resolve');
       const { req, res } = createMockReqRes({
         personalityId: 'personality-123',
@@ -1517,7 +1517,7 @@ describe('/user/llm-config routes', () => {
 
     it('should return 500 when resolver throws', async () => {
       mockResolveConfig.mockRejectedValueOnce(new Error('DB error'));
-      const router = createLlmConfigRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/resolve');
       const { req, res } = createMockReqRes({
         personalityId: 'personality-123',

--- a/services/api-gateway/src/routes/user/llm-config.ts
+++ b/services/api-gateway/src/routes/user/llm-config.ts
@@ -10,15 +10,12 @@
  * - DELETE /user/llm-config/:id - Delete user config
  */
 
-import { Router, type Response } from 'express';
+import { Router, type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import {
   createLogger,
   isBotOwner,
-  type PrismaClient,
   type LlmConfigSummary,
-  type LlmConfigCacheInvalidationService,
-  type ConfigCascadeResolver,
   computeLlmConfigPermissions,
   // Shared schemas from common-types - single source of truth
   LlmConfigCreateSchema,
@@ -52,6 +49,7 @@ import {
   getDiscordUsernameFromRequest,
 } from '../../utils/normalizeConfigNameOnPromote.js';
 import { createResolveHandler } from './llmConfigResolve.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('user-llm-config');
 
@@ -410,55 +408,42 @@ function createDeleteHandler(service: LlmConfigService) {
   };
 }
 
+// --- Exported handler factories ---
+
+function buildService(deps: RouteDeps): LlmConfigService {
+  return new LlmConfigService(deps.prisma, deps.llmConfigCacheInvalidation);
+}
+
+export const handleListUserLlmConfigs = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createListHandler(buildService(deps)));
+
+export const handleGetUserLlmConfig = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createGetHandler(buildService(deps), deps.modelCache));
+
+export const handleCreateUserLlmConfig = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createCreateHandler(buildService(deps), deps.modelCache));
+
+export const handleResolveUserLlmConfig = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createResolveHandler(deps.prisma, deps.cascadeResolver));
+
+export const handleUpdateUserLlmConfig = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createUpdateHandler(buildService(deps), deps.modelCache));
+
+export const handleDeleteUserLlmConfig = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createDeleteHandler(buildService(deps)));
+
 // --- Main Route Factory ---
 
-export function createLlmConfigRoutes(
-  prisma: PrismaClient,
-  llmConfigCacheInvalidation?: LlmConfigCacheInvalidationService,
-  modelCache?: OpenRouterModelCache,
-  cascadeResolver?: ConfigCascadeResolver
-): Router {
+export function createLlmConfigRoutes(deps: RouteDeps): Router {
   const router = Router();
+  const requireProvisioned = requireProvisionedUser(deps.prisma);
 
-  // Instantiate services with dependencies
-  const service = new LlmConfigService(prisma, llmConfigCacheInvalidation);
-
-  router.get(
-    '/',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(createListHandler(service))
-  );
-  router.get(
-    '/:id',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(createGetHandler(service, modelCache))
-  );
-  router.post(
-    '/',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(createCreateHandler(service, modelCache))
-  );
-  router.post(
-    '/resolve',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(createResolveHandler(prisma, cascadeResolver))
-  );
-  router.put(
-    '/:id',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(createUpdateHandler(service, modelCache))
-  );
-  router.delete(
-    '/:id',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(createDeleteHandler(service))
-  );
+  router.get('/', requireUserAuth(), requireProvisioned, handleListUserLlmConfigs(deps));
+  router.get('/:id', requireUserAuth(), requireProvisioned, handleGetUserLlmConfig(deps));
+  router.post('/', requireUserAuth(), requireProvisioned, handleCreateUserLlmConfig(deps));
+  router.post('/resolve', requireUserAuth(), requireProvisioned, handleResolveUserLlmConfig(deps));
+  router.put('/:id', requireUserAuth(), requireProvisioned, handleUpdateUserLlmConfig(deps));
+  router.delete('/:id', requireUserAuth(), requireProvisioned, handleDeleteUserLlmConfig(deps));
 
   return router;
 }

--- a/services/api-gateway/src/routes/user/memory.test.ts
+++ b/services/api-gateway/src/routes/user/memory.test.ts
@@ -138,26 +138,26 @@ describe('/user/memory routes', () => {
 
   describe('route factory', () => {
     it('should create a router', () => {
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(router).toBeDefined();
       expect(typeof router).toBe('function');
     });
 
     it('should have GET /stats route registered', () => {
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(findRoute(router, 'get', '/stats')).toBeDefined();
     });
 
     it('should have GET /focus route registered', () => {
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(findRoute(router, 'get', '/focus')).toBeDefined();
     });
 
     it('should have POST /focus route registered', () => {
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(findRoute(router, 'post', '/focus')).toBeDefined();
     });
@@ -165,7 +165,7 @@ describe('/user/memory routes', () => {
 
   describe('GET /user/memory/stats', () => {
     it('should reject missing personalityId', async () => {
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/stats');
       const { req, res } = createMockReqRes({}, {});
 
@@ -183,7 +183,7 @@ describe('/user/memory routes', () => {
     it('should return 404 when personality not found', async () => {
       mockPrisma.personality.findUnique.mockResolvedValue(null);
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/stats');
       const { req, res } = createMockReqRes({}, { personalityId: TEST_PERSONALITY_ID });
 
@@ -198,7 +198,7 @@ describe('/user/memory routes', () => {
         .mockResolvedValueOnce({ id: TEST_USER_ID }) // First call - check user
         .mockResolvedValueOnce({ defaultPersonaId: null }); // Second call - get default persona
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/stats');
       const { req, res } = createMockReqRes({}, { personalityId: TEST_PERSONALITY_ID });
 
@@ -229,7 +229,7 @@ describe('/user/memory routes', () => {
         .mockResolvedValueOnce({ createdAt: oldestDate }) // oldest
         .mockResolvedValueOnce({ createdAt: newestDate }); // newest
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/stats');
       const { req, res } = createMockReqRes({}, { personalityId: TEST_PERSONALITY_ID });
 
@@ -256,7 +256,7 @@ describe('/user/memory routes', () => {
         configOverrides: { focusModeEnabled: true },
       });
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/stats');
       const { req, res } = createMockReqRes({}, { personalityId: TEST_PERSONALITY_ID });
 
@@ -272,7 +272,7 @@ describe('/user/memory routes', () => {
 
   describe('GET /user/memory/focus', () => {
     it('should reject missing personalityId', async () => {
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/focus');
       const { req, res } = createMockReqRes({}, {});
 
@@ -289,7 +289,7 @@ describe('/user/memory routes', () => {
     it('should return focusModeEnabled false when no config exists', async () => {
       mockPrisma.userPersonalityConfig.findUnique.mockResolvedValue(null);
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/focus');
       const { req, res } = createMockReqRes({}, { personalityId: TEST_PERSONALITY_ID });
 
@@ -309,7 +309,7 @@ describe('/user/memory routes', () => {
         configOverrides: { focusModeEnabled: true },
       });
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/focus');
       const { req, res } = createMockReqRes({}, { personalityId: TEST_PERSONALITY_ID });
 
@@ -327,7 +327,7 @@ describe('/user/memory routes', () => {
 
   describe('POST /user/memory/focus', () => {
     it('should reject missing personalityId', async () => {
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/focus');
       const { req, res } = createMockReqRes({ enabled: true });
 
@@ -342,7 +342,7 @@ describe('/user/memory routes', () => {
     });
 
     it('should reject missing enabled field', async () => {
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/focus');
       const { req, res } = createMockReqRes({ personalityId: TEST_PERSONALITY_ID });
 
@@ -357,7 +357,7 @@ describe('/user/memory routes', () => {
     });
 
     it('should reject non-boolean enabled', async () => {
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/focus');
       const { req, res } = createMockReqRes({
         personalityId: TEST_PERSONALITY_ID,
@@ -372,7 +372,7 @@ describe('/user/memory routes', () => {
     it('should return 404 when personality not found', async () => {
       mockPrisma.personality.findUnique.mockResolvedValue(null);
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/focus');
       const { req, res } = createMockReqRes({
         personalityId: TEST_PERSONALITY_ID,
@@ -388,7 +388,7 @@ describe('/user/memory routes', () => {
       // No existing UPC record
       mockPrisma.userPersonalityConfig.findUnique.mockResolvedValue(null);
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/focus');
       const { req, res } = createMockReqRes({
         personalityId: TEST_PERSONALITY_ID,
@@ -431,7 +431,7 @@ describe('/user/memory routes', () => {
         configOverrides: { focusModeEnabled: true, maxMessages: 30 },
       });
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/focus');
       const { req, res } = createMockReqRes({
         personalityId: TEST_PERSONALITY_ID,
@@ -466,7 +466,7 @@ describe('/user/memory routes', () => {
         configOverrides: { maxMessages: 25, maxImages: 5 },
       });
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/focus');
       const { req, res } = createMockReqRes({
         personalityId: TEST_PERSONALITY_ID,
@@ -497,7 +497,7 @@ describe('/user/memory routes', () => {
     });
 
     it('should have POST /search route registered', () => {
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(findRoute(router, 'post', '/search')).toBeDefined();
     });
@@ -505,7 +505,7 @@ describe('/user/memory routes', () => {
     it('should return 503 when embedding service is not available', async () => {
       mockIsEmbeddingServiceAvailable.mockReturnValue(false);
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/search');
       const { req, res } = createMockReqRes({ query: 'test search' }, {});
 
@@ -520,7 +520,7 @@ describe('/user/memory routes', () => {
     });
 
     it('should reject missing query', async () => {
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/search');
       const { req, res } = createMockReqRes({}, {});
 
@@ -536,7 +536,7 @@ describe('/user/memory routes', () => {
     });
 
     it('should reject empty query', async () => {
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/search');
       const { req, res } = createMockReqRes({ query: '' }, {});
 
@@ -551,7 +551,7 @@ describe('/user/memory routes', () => {
     });
 
     it('should return 400 for query exceeding max length', async () => {
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/search');
       const longQuery = 'a'.repeat(501); // Exceeds 500 char limit
       const { req, res } = createMockReqRes({ query: longQuery }, {});
@@ -574,7 +574,7 @@ describe('/user/memory routes', () => {
         defaultPersonaId: null,
       });
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/search');
       const { req, res } = createMockReqRes({ query: 'test search' }, {});
 
@@ -605,7 +605,7 @@ describe('/user/memory routes', () => {
       ];
       mockPrisma.$queryRaw.mockResolvedValue(mockResults);
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/search');
       const { req, res } = createMockReqRes({ query: 'test search' }, {});
 
@@ -648,7 +648,7 @@ describe('/user/memory routes', () => {
         .mockResolvedValueOnce([]) // semantic search - no results
         .mockResolvedValueOnce(textResults); // text search - has results
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/search');
       const { req, res } = createMockReqRes({ query: 'Draco' }, {});
 
@@ -677,7 +677,7 @@ describe('/user/memory routes', () => {
         .mockResolvedValueOnce([]) // semantic search
         .mockResolvedValueOnce([]); // text search
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/search');
       const { req, res } = createMockReqRes({ query: 'nonexistent' }, {});
 
@@ -695,7 +695,7 @@ describe('/user/memory routes', () => {
     });
 
     it('should reject limit exceeding max 50', async () => {
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/search');
       const { req, res } = createMockReqRes({ query: 'test search', limit: 100 }, {});
 
@@ -714,7 +714,7 @@ describe('/user/memory routes', () => {
     it('should handle embedding generation error', async () => {
       mockGenerateEmbedding.mockRejectedValue(new Error('OpenAI API error'));
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/search');
       const { req, res } = createMockReqRes({ query: 'test search' }, {});
 
@@ -742,7 +742,7 @@ describe('/user/memory routes', () => {
       }));
       mockPrisma.$queryRaw.mockResolvedValue(mockResults);
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/search');
       // Request with limit=5, but API returns 6 to check for hasMore
       const { req, res } = createMockReqRes({ query: 'test search', limit: 5 }, {});
@@ -770,7 +770,7 @@ describe('/user/memory routes', () => {
       ];
       mockPrisma.$queryRaw.mockResolvedValue(textResults);
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/search');
       const { req, res } = createMockReqRes({ query: 'test search', preferTextSearch: true }, {});
 
@@ -791,7 +791,7 @@ describe('/user/memory routes', () => {
     it('should return 503 when embedding service returns null', async () => {
       mockGenerateEmbedding.mockResolvedValue(null);
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/search');
       const { req, res } = createMockReqRes({ query: 'test search' }, {});
 
@@ -808,7 +808,7 @@ describe('/user/memory routes', () => {
 
   describe('GET /user/memory/list', () => {
     it('should have GET /list route registered', () => {
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(findRoute(router, 'get', '/list')).toBeDefined();
     });
@@ -816,7 +816,7 @@ describe('/user/memory routes', () => {
     it('should return empty list when user has no persona', async () => {
       mockPrisma.user.findUnique.mockResolvedValueOnce({ defaultPersonaId: null });
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/list');
       const { req, res } = createMockReqRes({}, {});
 
@@ -857,7 +857,7 @@ describe('/user/memory routes', () => {
       mockPrisma.memory.count.mockResolvedValue(2);
       mockPrisma.memory.findMany.mockResolvedValue(mockMemories);
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/list');
       const { req, res } = createMockReqRes({}, { limit: '10', offset: '0' });
 
@@ -890,7 +890,7 @@ describe('/user/memory routes', () => {
       mockPrisma.memory.count.mockResolvedValue(0);
       mockPrisma.memory.findMany.mockResolvedValue([]);
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/list');
       const { req, res } = createMockReqRes({}, { personalityId: TEST_PERSONALITY_ID });
 
@@ -909,7 +909,7 @@ describe('/user/memory routes', () => {
       mockPrisma.memory.count.mockResolvedValue(0);
       mockPrisma.memory.findMany.mockResolvedValue([]);
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/list');
       const { req, res } = createMockReqRes({}, { limit: '100' });
 
@@ -926,7 +926,7 @@ describe('/user/memory routes', () => {
       mockPrisma.memory.count.mockResolvedValue(0);
       mockPrisma.memory.findMany.mockResolvedValue([]);
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/list');
       const { req, res } = createMockReqRes({}, {});
 
@@ -943,7 +943,7 @@ describe('/user/memory routes', () => {
       mockPrisma.memory.count.mockResolvedValue(25);
       mockPrisma.memory.findMany.mockResolvedValue([]);
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/list');
       const { req, res } = createMockReqRes({}, { limit: '10', offset: '10' });
 
@@ -973,7 +973,7 @@ describe('/user/memory routes', () => {
       mockPrisma.memory.count.mockResolvedValue(25);
       mockPrisma.memory.findMany.mockResolvedValue(mockMemories);
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/list');
       const { req, res } = createMockReqRes({}, { limit: '10', offset: '0' });
 
@@ -990,7 +990,7 @@ describe('/user/memory routes', () => {
       mockPrisma.memory.count.mockResolvedValue(0);
       mockPrisma.memory.findMany.mockResolvedValue([]);
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/list');
       const { req, res } = createMockReqRes({}, { sort: 'updatedAt', order: 'asc' });
 
@@ -1007,7 +1007,7 @@ describe('/user/memory routes', () => {
       mockPrisma.memory.count.mockResolvedValue(0);
       mockPrisma.memory.findMany.mockResolvedValue([]);
 
-      const router = createMemoryRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createMemoryRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/list');
       const { req, res } = createMockReqRes({}, {});
 

--- a/services/api-gateway/src/routes/user/memory.ts
+++ b/services/api-gateway/src/routes/user/memory.ts
@@ -24,7 +24,6 @@
 
 import { Router, type Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
-import type { Redis } from 'ioredis';
 import {
   createLogger,
   Prisma,
@@ -32,6 +31,7 @@ import {
   generateUserPersonalityConfigUuid,
   FocusModeSchema,
 } from '@tzurot/common-types';
+import type { RouteDeps } from '../routeDeps.js';
 import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
@@ -285,8 +285,9 @@ function registerMemoryRoute(params: RegisterRouteParams): void {
   );
 }
 
-export function createMemoryRoutes(prisma: PrismaClient, redis?: Redis): Router {
+export function createMemoryRoutes(deps: RouteDeps): Router {
   const router = Router();
+  const { prisma, redis } = deps;
 
   // Incognito mode routes (requires Redis)
   if (redis !== undefined) {

--- a/services/api-gateway/src/routes/user/model-override.test.ts
+++ b/services/api-gateway/src/routes/user/model-override.test.ts
@@ -118,14 +118,14 @@ describe('/user/model-override routes', () => {
 
   describe('route factory', () => {
     it('should create a router', () => {
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(router).toBeDefined();
       expect(typeof router).toBe('function');
     });
 
     it('should have GET route registered', () => {
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(router.stack).toBeDefined();
       expect(router.stack.length).toBeGreaterThan(0);
@@ -134,13 +134,13 @@ describe('/user/model-override routes', () => {
     });
 
     it('should have PUT route registered', () => {
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(findRoute(router, 'put', '/')).toBeDefined();
     });
 
     it('should have DELETE route registered', () => {
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(findRoute(router, 'delete', '/:personalityId')).toBeDefined();
     });
@@ -150,7 +150,7 @@ describe('/user/model-override routes', () => {
     it('should return empty list when user not found', async () => {
       mockPrisma.user.findFirst.mockResolvedValue(null);
 
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/');
       const { req, res } = createMockReqRes();
 
@@ -174,7 +174,7 @@ describe('/user/model-override routes', () => {
         },
       ]);
 
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/');
       const { req, res } = createMockReqRes();
 
@@ -204,7 +204,7 @@ describe('/user/model-override routes', () => {
         },
       ]);
 
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/');
       const { req, res } = createMockReqRes();
 
@@ -224,7 +224,7 @@ describe('/user/model-override routes', () => {
 
   describe('PUT /user/model-override', () => {
     it('should reject missing personalityId', async () => {
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/');
       const { req, res } = createMockReqRes({ configId: '22222222-2222-4222-a222-222222222222' });
 
@@ -239,7 +239,7 @@ describe('/user/model-override routes', () => {
     });
 
     it('should reject missing configId', async () => {
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/');
       const { req, res } = createMockReqRes({
         personalityId: '11111111-1111-4111-a111-111111111111',
@@ -258,7 +258,7 @@ describe('/user/model-override routes', () => {
     it('should return 404 when personality not found', async () => {
       mockPrisma.personality.findFirst.mockResolvedValue(null);
 
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/');
       const { req, res } = createMockReqRes({
         personalityId: '11111111-1111-4111-a111-111111111111',
@@ -282,7 +282,7 @@ describe('/user/model-override routes', () => {
       });
       mockPrisma.llmConfig.findFirst.mockResolvedValue(null);
 
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/');
       const { req, res } = createMockReqRes({
         personalityId: '11111111-1111-4111-a111-111111111111',
@@ -315,7 +315,7 @@ describe('/user/model-override routes', () => {
         llmConfig: { name: 'GPT-4' },
       });
 
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/');
       const { req, res } = createMockReqRes({
         personalityId: '11111111-1111-4111-a111-111111111111',
@@ -364,7 +364,7 @@ describe('/user/model-override routes', () => {
     it('should return 200 (idempotent) when override not found', async () => {
       mockPrisma.userPersonalityConfig.findFirst.mockResolvedValue(null);
 
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:personalityId');
       const { req, res } = createMockReqRes(
         {},
@@ -386,7 +386,7 @@ describe('/user/model-override routes', () => {
         personality: { name: 'Lilith' },
       });
 
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:personalityId');
       const { req, res } = createMockReqRes(
         {},
@@ -408,7 +408,7 @@ describe('/user/model-override routes', () => {
         personality: { name: 'Lilith' },
       });
 
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:personalityId');
       const { req, res } = createMockReqRes(
         {},
@@ -438,7 +438,7 @@ describe('/user/model-override routes', () => {
         defaultLlmConfig: null,
       });
 
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/default');
       const { req, res } = createMockReqRes();
 
@@ -462,7 +462,7 @@ describe('/user/model-override routes', () => {
         defaultLlmConfig: { name: 'My Default Config' },
       });
 
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/default');
       const { req, res } = createMockReqRes();
 
@@ -482,7 +482,7 @@ describe('/user/model-override routes', () => {
 
   describe('PUT /user/model-override/default', () => {
     it('should reject missing configId', async () => {
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/default');
       const { req, res } = createMockReqRes({});
 
@@ -497,7 +497,7 @@ describe('/user/model-override routes', () => {
     });
 
     it('should reject empty configId', async () => {
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/default');
       const { req, res } = createMockReqRes({ configId: '  ' });
 
@@ -509,7 +509,7 @@ describe('/user/model-override routes', () => {
     it('should return 404 when config not found or not accessible', async () => {
       mockPrisma.llmConfig.findFirst.mockResolvedValue(null);
 
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/default');
       const { req, res } = createMockReqRes({ configId: '22222222-2222-4222-a222-222222222222' });
 
@@ -529,7 +529,7 @@ describe('/user/model-override routes', () => {
         name: 'Test Config',
       });
 
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/default');
       const { req, res } = createMockReqRes({ configId: '22222222-2222-4222-a222-222222222222' });
 
@@ -561,10 +561,11 @@ describe('/user/model-override routes', () => {
         invalidateUserLlmConfig: vi.fn().mockResolvedValue(undefined),
       };
 
-      const router = createModelOverrideRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockInvalidation as unknown as import('@tzurot/common-types').LlmConfigCacheInvalidationService
-      );
+      const router = createModelOverrideRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        llmConfigCacheInvalidation:
+          mockInvalidation as unknown as import('@tzurot/common-types').LlmConfigCacheInvalidationService,
+      });
       const handler = getHandler(router, 'put', '/default');
       const { req, res } = createMockReqRes({ configId: '22222222-2222-4222-a222-222222222222' });
 
@@ -583,10 +584,11 @@ describe('/user/model-override routes', () => {
         invalidateUserLlmConfig: vi.fn().mockRejectedValue(new Error('Redis error')),
       };
 
-      const router = createModelOverrideRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockInvalidation as unknown as import('@tzurot/common-types').LlmConfigCacheInvalidationService
-      );
+      const router = createModelOverrideRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        llmConfigCacheInvalidation:
+          mockInvalidation as unknown as import('@tzurot/common-types').LlmConfigCacheInvalidationService,
+      });
       const handler = getHandler(router, 'put', '/default');
       const { req, res } = createMockReqRes({ configId: '22222222-2222-4222-a222-222222222222' });
 
@@ -602,7 +604,7 @@ describe('/user/model-override routes', () => {
         name: 'Test Config',
       });
 
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/default');
       const { req, res } = createMockReqRes({ configId: '22222222-2222-4222-a222-222222222222' });
 
@@ -617,7 +619,7 @@ describe('/user/model-override routes', () => {
       // Provisioning middleware sets the UUID; handler-level findUnique returns null (e.g., race with user deletion).
       mockPrisma.user.findUnique.mockResolvedValueOnce(null);
 
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/default');
       const { req, res } = createMockReqRes();
 
@@ -632,7 +634,7 @@ describe('/user/model-override routes', () => {
       });
       mockPrisma.llmConfig.findFirst.mockResolvedValueOnce(null);
 
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/default');
       const { req, res } = createMockReqRes();
 
@@ -654,7 +656,7 @@ describe('/user/model-override routes', () => {
       });
       mockPrisma.llmConfig.findFirst.mockResolvedValueOnce(null);
 
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/default');
       const { req, res } = createMockReqRes();
 
@@ -686,7 +688,7 @@ describe('/user/model-override routes', () => {
         name: 'gpt-4-free',
       });
 
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/default');
       const { req, res } = createMockReqRes();
 
@@ -711,7 +713,7 @@ describe('/user/model-override routes', () => {
         name: 'gpt-4-free',
       });
 
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/default');
       const { req, res } = createMockReqRes();
 
@@ -739,10 +741,11 @@ describe('/user/model-override routes', () => {
         invalidateUserLlmConfig: vi.fn().mockResolvedValue(undefined),
       };
 
-      const router = createModelOverrideRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockInvalidation as unknown as import('@tzurot/common-types').LlmConfigCacheInvalidationService
-      );
+      const router = createModelOverrideRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        llmConfigCacheInvalidation:
+          mockInvalidation as unknown as import('@tzurot/common-types').LlmConfigCacheInvalidationService,
+      });
       const handler = getHandler(router, 'delete', '/default');
       const { req, res } = createMockReqRes();
 
@@ -761,10 +764,11 @@ describe('/user/model-override routes', () => {
         invalidateUserLlmConfig: vi.fn().mockRejectedValue(new Error('Redis error')),
       };
 
-      const router = createModelOverrideRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockInvalidation as unknown as import('@tzurot/common-types').LlmConfigCacheInvalidationService
-      );
+      const router = createModelOverrideRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        llmConfigCacheInvalidation:
+          mockInvalidation as unknown as import('@tzurot/common-types').LlmConfigCacheInvalidationService,
+      });
       const handler = getHandler(router, 'delete', '/default');
       const { req, res } = createMockReqRes();
 
@@ -785,7 +789,7 @@ describe('/user/model-override routes', () => {
         defaultLlmConfigId: 'config-123',
       });
 
-      const router = createModelOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/default');
       const { req, res } = createMockReqRes();
 

--- a/services/api-gateway/src/routes/user/model-override.ts
+++ b/services/api-gateway/src/routes/user/model-override.ts
@@ -11,14 +11,13 @@
  * - DELETE /user/model-override/:personalityId - Remove override (MUST be after /default routes)
  */
 
-import { Router, type Response } from 'express';
+import { Router, type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import {
   createLogger,
   generateUserPersonalityConfigUuid,
   type PrismaClient,
   type ModelOverrideSummary,
-  type LlmConfigCacheInvalidationService,
   type UserDefaultConfig,
   SetModelOverrideSchema,
   SetDefaultConfigSchema,
@@ -32,6 +31,7 @@ import { ErrorResponses } from '../../utils/errorResponses.js';
 import { sendZodError } from '../../utils/zodHelpers.js';
 import { getParam } from '../../utils/requestParams.js';
 import type { ProvisionedRequest } from '../../types.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('user-model-override');
 
@@ -53,347 +53,290 @@ async function verifyConfigAccess(
   });
 }
 
-// eslint-disable-next-line max-lines-per-function -- Route factory with multiple endpoints
-export function createModelOverrideRoutes(
-  prisma: PrismaClient,
-  llmConfigCacheInvalidation?: LlmConfigCacheInvalidationService
-): Router {
-  const router = Router();
+/** GET /api/user/model-override — list all user model overrides */
+export const handleListModelOverrides = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const discordUserId = req.userId;
+    const userId = resolveProvisionedUserId(req);
 
-  /**
-   * GET /user/model-override
-   * List all model overrides for the user
-   */
-  router.get(
-    '/',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const discordUserId = req.userId;
+    const overrides = await prisma.userPersonalityConfig.findMany({
+      where: {
+        userId,
+        llmConfigId: { not: null },
+      },
+      select: {
+        personalityId: true,
+        personality: { select: { name: true } },
+        llmConfigId: true,
+        llmConfig: { select: { name: true } },
+      },
+      take: 100,
+    });
 
-      const userId = resolveProvisionedUserId(req);
+    const result: ModelOverrideSummary[] = overrides.map(o => ({
+      personalityId: o.personalityId,
+      personalityName: o.personality.name,
+      configId: o.llmConfigId,
+      configName: o.llmConfig?.name ?? null,
+    }));
 
-      // Get all overrides with personality and config names
-      const overrides = await prisma.userPersonalityConfig.findMany({
-        where: {
-          userId,
-          llmConfigId: { not: null },
-        },
-        select: {
-          personalityId: true,
-          personality: { select: { name: true } },
-          llmConfigId: true,
-          llmConfig: { select: { name: true } },
-        },
-        take: 100,
-      });
+    logger.info({ discordUserId, count: result.length }, 'Listed overrides');
+    sendCustomSuccess(res, { overrides: result }, StatusCodes.OK);
+  });
+};
 
-      const result: ModelOverrideSummary[] = overrides.map(o => ({
-        personalityId: o.personalityId,
-        personalityName: o.personality.name,
-        configId: o.llmConfigId,
-        configName: o.llmConfig?.name ?? null,
-      }));
+/** PUT /api/user/model-override — set model override for a personality */
+export const handleSetModelOverride = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const discordUserId = req.userId;
 
-      logger.info({ discordUserId, count: result.length }, 'Listed overrides');
+    const parseResult = SetModelOverrideSchema.safeParse(req.body);
+    if (!parseResult.success) {
+      return sendZodError(res, parseResult.error);
+    }
 
-      sendCustomSuccess(res, { overrides: result }, StatusCodes.OK);
-    })
-  );
+    const { personalityId, configId } = parseResult.data;
+    const userId = resolveProvisionedUserId(req);
 
-  /**
-   * PUT /user/model-override
-   * Set model override for a personality
-   */
-  router.put(
-    '/',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const discordUserId = req.userId;
+    const personality = await prisma.personality.findFirst({
+      where: { id: personalityId },
+      select: { id: true, name: true },
+    });
 
-      // Validate request body with Zod
-      const parseResult = SetModelOverrideSchema.safeParse(req.body);
-      if (!parseResult.success) {
-        return sendZodError(res, parseResult.error);
-      }
+    if (personality === null) {
+      return sendError(res, ErrorResponses.notFound('Personality'));
+    }
 
-      const { personalityId, configId } = parseResult.data;
+    const llmConfig = await verifyConfigAccess(prisma, configId, userId);
+    if (llmConfig === null) {
+      return sendError(res, ErrorResponses.notFound('Config'));
+    }
 
-      const userId = resolveProvisionedUserId(req);
-
-      // Verify personality exists
-      const personality = await prisma.personality.findFirst({
-        where: { id: personalityId },
-        select: { id: true, name: true },
-      });
-
-      if (personality === null) {
-        return sendError(res, ErrorResponses.notFound('Personality'));
-      }
-
-      // Verify config exists and user can access it
-      const llmConfig = await verifyConfigAccess(prisma, configId, userId);
-      if (llmConfig === null) {
-        return sendError(res, ErrorResponses.notFound('Config'));
-      }
-
-      // Upsert the UserPersonalityConfig (use deterministic UUID for cross-env sync)
-      const override = await prisma.userPersonalityConfig.upsert({
-        where: {
-          userId_personalityId: {
-            userId,
-            personalityId,
-          },
-        },
-        create: {
-          id: generateUserPersonalityConfigUuid(userId, personalityId),
+    const override = await prisma.userPersonalityConfig.upsert({
+      where: {
+        userId_personalityId: {
           userId,
           personalityId,
-          llmConfigId: configId,
         },
-        update: {
-          llmConfigId: configId,
-        },
-        select: {
-          personalityId: true,
-          personality: { select: { name: true } },
-          llmConfigId: true,
-          llmConfig: { select: { name: true } },
-        },
-      });
+      },
+      create: {
+        id: generateUserPersonalityConfigUuid(userId, personalityId),
+        userId,
+        personalityId,
+        llmConfigId: configId,
+      },
+      update: {
+        llmConfigId: configId,
+      },
+      select: {
+        personalityId: true,
+        personality: { select: { name: true } },
+        llmConfigId: true,
+        llmConfig: { select: { name: true } },
+      },
+    });
 
-      const result: ModelOverrideSummary = {
-        personalityId: override.personalityId,
-        personalityName: override.personality.name,
-        configId: override.llmConfigId,
-        configName: override.llmConfig?.name ?? null,
-      };
+    const result: ModelOverrideSummary = {
+      personalityId: override.personalityId,
+      personalityName: override.personality.name,
+      configId: override.llmConfigId,
+      configName: override.llmConfig?.name ?? null,
+    };
 
-      logger.info(
-        {
-          discordUserId,
-          personalityId,
-          personalityName: personality.name,
-          configId,
-          configName: llmConfig.name,
-        },
-        'Set override'
-      );
-
-      sendCustomSuccess(res, { override: result }, StatusCodes.OK);
-    })
-  );
-
-  // ============================================
-  // User Global Default Config Routes
-  // NOTE: These MUST be defined BEFORE /:personalityId to avoid
-  // Express matching "default" as a personalityId parameter
-  // ============================================
-
-  /**
-   * GET /user/model-override/default
-   * Get user's global default LLM config
-   */
-  router.get(
-    '/default',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const discordUserId = req.userId;
-
-      const userId = resolveProvisionedUserId(req);
-
-      const user = await prisma.user.findUnique({
-        where: { id: userId },
-        select: {
-          defaultLlmConfigId: true,
-          defaultLlmConfig: { select: { name: true } },
-        },
-      });
-
-      const result: UserDefaultConfig = {
-        configId: user?.defaultLlmConfigId ?? null,
-        configName: user?.defaultLlmConfig?.name ?? null,
-      };
-
-      logger.info({ discordUserId, configId: result.configId }, 'Got default config');
-
-      sendCustomSuccess(res, { default: result }, StatusCodes.OK);
-    })
-  );
-
-  /**
-   * PUT /user/model-default
-   * Set user's global default LLM config
-   */
-  router.put(
-    '/default',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const discordUserId = req.userId;
-
-      // Validate request body with Zod
-      const parseResult = SetDefaultConfigSchema.safeParse(req.body);
-      if (!parseResult.success) {
-        return sendZodError(res, parseResult.error);
-      }
-
-      const { configId } = parseResult.data;
-
-      const userId = resolveProvisionedUserId(req);
-
-      // Verify config exists and user can access it (global or owned)
-      const llmConfig = await verifyConfigAccess(prisma, configId, userId);
-      if (llmConfig === null) {
-        return sendError(res, ErrorResponses.notFound('Config'));
-      }
-
-      // Update user's default config
-      await prisma.user.update({
-        where: { id: userId },
-        data: { defaultLlmConfigId: configId },
-      });
-
-      const result: UserDefaultConfig = {
-        configId: llmConfig.id,
+    logger.info(
+      {
+        discordUserId,
+        personalityId,
+        personalityName: personality.name,
+        configId,
         configName: llmConfig.name,
-      };
+      },
+      'Set override'
+    );
 
-      logger.info({ discordUserId, configId, configName: llmConfig.name }, 'Set default config');
+    sendCustomSuccess(res, { override: result }, StatusCodes.OK);
+  });
+};
 
-      // Invalidate user's LLM config cache so ai-worker picks up the change
-      await tryInvalidateCache(
-        llmConfigCacheInvalidation?.invalidateUserLlmConfig.bind(
-          llmConfigCacheInvalidation,
-          discordUserId
-        ),
-        { discordUserId }
+/** GET /api/user/model-override/default — read user's global default LLM config */
+export const handleGetModelDefault = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const discordUserId = req.userId;
+    const userId = resolveProvisionedUserId(req);
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        defaultLlmConfigId: true,
+        defaultLlmConfig: { select: { name: true } },
+      },
+    });
+
+    const result: UserDefaultConfig = {
+      configId: user?.defaultLlmConfigId ?? null,
+      configName: user?.defaultLlmConfig?.name ?? null,
+    };
+
+    logger.info({ discordUserId, configId: result.configId }, 'Got default config');
+    sendCustomSuccess(res, { default: result }, StatusCodes.OK);
+  });
+};
+
+/** PUT /api/user/model-override/default — set user's global default LLM config */
+export const handleSetModelDefault = (deps: RouteDeps): RequestHandler => {
+  const { prisma, llmConfigCacheInvalidation } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const discordUserId = req.userId;
+
+    const parseResult = SetDefaultConfigSchema.safeParse(req.body);
+    if (!parseResult.success) {
+      return sendZodError(res, parseResult.error);
+    }
+
+    const { configId } = parseResult.data;
+    const userId = resolveProvisionedUserId(req);
+
+    const llmConfig = await verifyConfigAccess(prisma, configId, userId);
+    if (llmConfig === null) {
+      return sendError(res, ErrorResponses.notFound('Config'));
+    }
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: { defaultLlmConfigId: configId },
+    });
+
+    const result: UserDefaultConfig = {
+      configId: llmConfig.id,
+      configName: llmConfig.name,
+    };
+
+    logger.info({ discordUserId, configId, configName: llmConfig.name }, 'Set default config');
+
+    await tryInvalidateCache(
+      llmConfigCacheInvalidation?.invalidateUserLlmConfig.bind(
+        llmConfigCacheInvalidation,
+        discordUserId
+      ),
+      { discordUserId }
+    );
+
+    sendCustomSuccess(res, { default: result }, StatusCodes.OK);
+  });
+};
+
+/** DELETE /api/user/model-override/default — clear user's global default LLM config */
+export const handleClearModelDefault = (deps: RouteDeps): RequestHandler => {
+  const { prisma, llmConfigCacheInvalidation } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const discordUserId = req.userId;
+    const userId = resolveProvisionedUserId(req);
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { defaultLlmConfigId: true },
+    });
+
+    if (user === null) {
+      return sendError(res, ErrorResponses.notFound('User'));
+    }
+
+    // Look up the system free default the user will fall back to. Per-
+    // personality overrides (UserPersonalityConfig.llmConfigId) and
+    // personality-level defaults (PersonalityDefaultLlmConfig) are
+    // unaffected; the free default is just the user-global fallback.
+    const newEffectiveDefault = await prisma.llmConfig.findFirst({
+      where: { isFreeDefault: true },
+      select: { id: true, name: true },
+    });
+
+    if (user.defaultLlmConfigId === null) {
+      logger.info(
+        { discordUserId, hadDefault: false },
+        'Clear called but no default was set (idempotent success)'
       );
-
-      sendCustomSuccess(res, { default: result }, StatusCodes.OK);
-    })
-  );
-
-  /**
-   * DELETE /user/model-default
-   * Clear user's global default LLM config
-   */
-  router.delete(
-    '/default',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const discordUserId = req.userId;
-
-      const userId = resolveProvisionedUserId(req);
-
-      const user = await prisma.user.findUnique({
-        where: { id: userId },
-        select: { defaultLlmConfigId: true },
-      });
-
-      if (user === null) {
-        return sendError(res, ErrorResponses.notFound('User'));
-      }
-
-      // Look up the system free default that the user will fall back to.
-      // Per-personality overrides (UserPersonalityConfig.llmConfigId) and
-      // personality-level defaults (PersonalityDefaultLlmConfig) are
-      // unaffected by this action — the free default is just the user-global
-      // fallback for personalities without their own override or default.
-      const newEffectiveDefault = await prisma.llmConfig.findFirst({
-        where: { isFreeDefault: true },
-        select: { id: true, name: true },
-      });
-
-      // Idempotent: if no default config is set, return success with wasSet: false
-      if (user.defaultLlmConfigId === null) {
-        logger.info(
-          { discordUserId, hadDefault: false },
-          'Clear called but no default was set (idempotent success)'
-        );
-        return sendCustomSuccess(
-          res,
-          { deleted: true, wasSet: false, newEffectiveDefault },
-          StatusCodes.OK
-        );
-      }
-
-      await prisma.user.update({
-        where: { id: userId },
-        data: { defaultLlmConfigId: null },
-      });
-
-      logger.info({ discordUserId }, 'Cleared default config');
-
-      // Invalidate user's LLM config cache so ai-worker picks up the change
-      await tryInvalidateCache(
-        llmConfigCacheInvalidation?.invalidateUserLlmConfig.bind(
-          llmConfigCacheInvalidation,
-          discordUserId
-        ),
-        { discordUserId }
+      return sendCustomSuccess(
+        res,
+        { deleted: true, wasSet: false, newEffectiveDefault },
+        StatusCodes.OK
       );
+    }
 
-      // Symmetric with the no-op `wasSet: false` branch above and with TTS's
-      // DELETE /default — explicit `wasSet: true` lets a caller distinguish
-      // "actually cleared" from "already empty" via a single field check.
-      sendCustomSuccess(res, { deleted: true, wasSet: true, newEffectiveDefault }, StatusCodes.OK);
-    })
-  );
+    await prisma.user.update({
+      where: { id: userId },
+      data: { defaultLlmConfigId: null },
+    });
 
-  // ============================================
-  // Personality-specific Override Route
-  // NOTE: This wildcard route MUST come AFTER /default routes
-  // ============================================
+    logger.info({ discordUserId }, 'Cleared default config');
 
-  /**
-   * DELETE /user/model-override/:personalityId
-   * Remove model override for a personality
-   */
+    await tryInvalidateCache(
+      llmConfigCacheInvalidation?.invalidateUserLlmConfig.bind(
+        llmConfigCacheInvalidation,
+        discordUserId
+      ),
+      { discordUserId }
+    );
+
+    sendCustomSuccess(res, { deleted: true, wasSet: true, newEffectiveDefault }, StatusCodes.OK);
+  });
+};
+
+/** DELETE /api/user/model-override/:personalityId — remove model override for a personality */
+export const handleClearModelOverride = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const discordUserId = req.userId;
+    const personalityId = getParam(req.params.personalityId);
+    const userId = resolveProvisionedUserId(req);
+
+    const override = await prisma.userPersonalityConfig.findFirst({
+      where: {
+        userId,
+        personalityId,
+      },
+      select: { id: true, llmConfigId: true, personality: { select: { name: true } } },
+    });
+
+    if (override?.llmConfigId === null || override?.llmConfigId === undefined) {
+      logger.info(
+        { discordUserId, personalityId, hadOverride: false },
+        'Reset called but no override was set (idempotent success)'
+      );
+      return sendCustomSuccess(res, { deleted: true, wasSet: false }, StatusCodes.OK);
+    }
+
+    await prisma.userPersonalityConfig.update({
+      where: { id: override.id },
+      data: { llmConfigId: null },
+    });
+
+    logger.info(
+      { discordUserId, personalityId, personalityName: override.personality.name },
+      'Removed override'
+    );
+
+    sendCustomSuccess(res, { deleted: true }, StatusCodes.OK);
+  });
+};
+
+export function createModelOverrideRoutes(deps: RouteDeps): Router {
+  const router = Router();
+  const requireProvisioned = requireProvisionedUser(deps.prisma);
+
+  router.get('/', requireUserAuth(), requireProvisioned, handleListModelOverrides(deps));
+  router.put('/', requireUserAuth(), requireProvisioned, handleSetModelOverride(deps));
+  // /default routes MUST come before /:personalityId to avoid the parameter shadowing them
+  router.get('/default', requireUserAuth(), requireProvisioned, handleGetModelDefault(deps));
+  router.put('/default', requireUserAuth(), requireProvisioned, handleSetModelDefault(deps));
+  router.delete('/default', requireUserAuth(), requireProvisioned, handleClearModelDefault(deps));
   router.delete(
     '/:personalityId',
     requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const discordUserId = req.userId;
-      const personalityId = getParam(req.params.personalityId);
-
-      const userId = resolveProvisionedUserId(req);
-
-      // Find the override
-      const override = await prisma.userPersonalityConfig.findFirst({
-        where: {
-          userId,
-          personalityId,
-        },
-        select: { id: true, llmConfigId: true, personality: { select: { name: true } } },
-      });
-
-      // Idempotent: if no override exists or llmConfigId is already null, return success
-      if (override?.llmConfigId === null || override?.llmConfigId === undefined) {
-        logger.info(
-          { discordUserId, personalityId, hadOverride: false },
-          'Reset called but no override was set (idempotent success)'
-        );
-        return sendCustomSuccess(res, { deleted: true, wasSet: false }, StatusCodes.OK);
-      }
-
-      // Remove the override (set llmConfigId to null)
-      await prisma.userPersonalityConfig.update({
-        where: { id: override.id },
-        data: { llmConfigId: null },
-      });
-
-      logger.info(
-        { discordUserId, personalityId, personalityName: override.personality.name },
-        'Removed override'
-      );
-
-      sendCustomSuccess(res, { deleted: true }, StatusCodes.OK);
-    })
+    requireProvisioned,
+    handleClearModelOverride(deps)
   );
 
   return router;

--- a/services/api-gateway/src/routes/user/nsfw.test.ts
+++ b/services/api-gateway/src/routes/user/nsfw.test.ts
@@ -70,7 +70,7 @@ function createTestApp() {
     (req as any).provisionedDefaultPersonaId = 'persona-uuid-default';
     next();
   });
-  app.use('/nsfw', createNsfwRoutes(mockPrisma as any));
+  app.use('/nsfw', createNsfwRoutes({ prisma: mockPrisma as any }));
   return app;
 }
 

--- a/services/api-gateway/src/routes/user/nsfw.ts
+++ b/services/api-gateway/src/routes/user/nsfw.ts
@@ -4,117 +4,114 @@
  * POST /user/nsfw/verify - Mark user as NSFW verified (called when user interacts in NSFW channel)
  */
 
-import { Router, type Response } from 'express';
+import { Router, type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
-import { createLogger, type PrismaClient } from '@tzurot/common-types';
+import { createLogger } from '@tzurot/common-types';
 import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';
 import { sendCustomSuccess } from '../../utils/responseHelpers.js';
 import type { ProvisionedRequest } from '../../types.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('user-nsfw');
 
-export function createNsfwRoutes(prisma: PrismaClient): Router {
-  const router = Router();
+/** GET /api/user/nsfw — current NSFW verification state */
+export const handleGetNsfwStatus = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const userId = resolveProvisionedUserId(req);
 
-  /**
-   * GET /user/nsfw
-   * Get current user's NSFW verification status
-   */
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { nsfwVerified: true, nsfwVerifiedAt: true },
+    });
+
+    if (user === null) {
+      return sendCustomSuccess(
+        res,
+        {
+          nsfwVerified: false,
+          nsfwVerifiedAt: null,
+        },
+        StatusCodes.OK
+      );
+    }
+
+    sendCustomSuccess(
+      res,
+      {
+        nsfwVerified: user.nsfwVerified,
+        nsfwVerifiedAt: user.nsfwVerifiedAt?.toISOString() ?? null,
+      },
+      StatusCodes.OK
+    );
+  });
+};
+
+/** POST /api/user/nsfw/verify — mark user as NSFW verified */
+export const handleVerifyNsfw = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const discordUserId = req.userId;
+
+    logger.info({ discordUserId }, 'Verifying user via NSFW channel interaction');
+
+    const userId = resolveProvisionedUserId(req);
+
+    const existingUser = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { nsfwVerified: true, nsfwVerifiedAt: true },
+    });
+
+    if (existingUser?.nsfwVerified === true) {
+      return sendCustomSuccess(
+        res,
+        {
+          nsfwVerified: true,
+          nsfwVerifiedAt: existingUser.nsfwVerifiedAt?.toISOString() ?? null,
+          alreadyVerified: true,
+        },
+        StatusCodes.OK
+      );
+    }
+
+    const now = new Date();
+    await prisma.user.update({
+      where: { id: userId },
+      data: {
+        nsfwVerified: true,
+        nsfwVerifiedAt: now,
+      },
+    });
+
+    logger.info({ discordUserId }, 'User successfully verified');
+
+    sendCustomSuccess(
+      res,
+      {
+        nsfwVerified: true,
+        nsfwVerifiedAt: now.toISOString(),
+        alreadyVerified: false,
+      },
+      StatusCodes.OK
+    );
+  });
+};
+
+export function createNsfwRoutes(deps: RouteDeps): Router {
+  const router = Router();
   router.get(
     '/',
     requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const userId = resolveProvisionedUserId(req);
-
-      const user = await prisma.user.findUnique({
-        where: { id: userId },
-        select: { nsfwVerified: true, nsfwVerifiedAt: true },
-      });
-
-      if (user === null) {
-        // User row doesn't exist yet, not verified
-        return sendCustomSuccess(
-          res,
-          {
-            nsfwVerified: false,
-            nsfwVerifiedAt: null,
-          },
-          StatusCodes.OK
-        );
-      }
-
-      sendCustomSuccess(
-        res,
-        {
-          nsfwVerified: user.nsfwVerified,
-          nsfwVerifiedAt: user.nsfwVerifiedAt?.toISOString() ?? null,
-        },
-        StatusCodes.OK
-      );
-    })
+    requireProvisionedUser(deps.prisma),
+    handleGetNsfwStatus(deps)
   );
-
-  /**
-   * POST /user/nsfw/verify
-   * Mark user as NSFW verified
-   * Called when user interacts with the bot in an age-restricted (NSFW) Discord channel
-   */
   router.post(
     '/verify',
     requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const discordUserId = req.userId;
-
-      logger.info({ discordUserId }, 'Verifying user via NSFW channel interaction');
-
-      const userId = resolveProvisionedUserId(req);
-
-      // Check if already verified
-      const existingUser = await prisma.user.findUnique({
-        where: { id: userId },
-        select: { nsfwVerified: true, nsfwVerifiedAt: true },
-      });
-
-      if (existingUser?.nsfwVerified === true) {
-        // Already verified, return success with existing timestamp
-        return sendCustomSuccess(
-          res,
-          {
-            nsfwVerified: true,
-            nsfwVerifiedAt: existingUser.nsfwVerifiedAt?.toISOString() ?? null,
-            alreadyVerified: true,
-          },
-          StatusCodes.OK
-        );
-      }
-
-      // Update the NSFW verification status
-      const now = new Date();
-      await prisma.user.update({
-        where: { id: userId },
-        data: {
-          nsfwVerified: true,
-          nsfwVerifiedAt: now,
-        },
-      });
-
-      logger.info({ discordUserId }, 'User successfully verified');
-
-      sendCustomSuccess(
-        res,
-        {
-          nsfwVerified: true,
-          nsfwVerifiedAt: now.toISOString(),
-          alreadyVerified: false,
-        },
-        StatusCodes.OK
-      );
-    })
+    requireProvisionedUser(deps.prisma),
+    handleVerifyNsfw(deps)
   );
-
   return router;
 }

--- a/services/api-gateway/src/routes/user/persona/crud.test.ts
+++ b/services/api-gateway/src/routes/user/persona/crud.test.ts
@@ -66,7 +66,7 @@ describe('persona CRUD routes', () => {
   describe('GET /user/persona', () => {
     it('should return empty array when user has no personas', async () => {
       mockPrisma.persona.findMany.mockResolvedValue([]);
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/');
 
       const { req, res } = createMockReqRes();
@@ -77,7 +77,7 @@ describe('persona CRUD routes', () => {
 
     it('should return list of personas with isDefault flag', async () => {
       mockPrisma.persona.findMany.mockResolvedValue([mockPersona]);
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/');
 
       const { req, res } = createMockReqRes();
@@ -98,7 +98,7 @@ describe('persona CRUD routes', () => {
       // This test ensures the API response matches the shared contract in common-types
       // If this test fails, the bot-client will break because it uses the same schema
       mockPrisma.persona.findMany.mockResolvedValue([mockPersona]);
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/');
 
       const { req, res } = createMockReqRes();
@@ -125,7 +125,7 @@ describe('persona CRUD routes', () => {
         description: null,
       };
       mockPrisma.persona.findMany.mockResolvedValue([personaWithNulls]);
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/');
 
       const { req, res } = createMockReqRes();
@@ -156,7 +156,7 @@ describe('persona CRUD routes', () => {
   describe('GET /user/persona/:id', () => {
     it('should return persona details', async () => {
       mockPrisma.persona.findFirst.mockResolvedValue(mockPersona);
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/:id');
 
       const { req, res } = createMockReqRes({}, { id: MOCK_PERSONA_ID });
@@ -174,7 +174,7 @@ describe('persona CRUD routes', () => {
 
     it('should return 404 when persona not found', async () => {
       mockPrisma.persona.findFirst.mockResolvedValue(null);
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/:id');
 
       const { req, res } = createMockReqRes({}, { id: NONEXISTENT_UUID });
@@ -189,7 +189,7 @@ describe('persona CRUD routes', () => {
     });
 
     it('should return 400 for invalid UUID format', async () => {
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/:id');
 
       const { req, res } = createMockReqRes({}, { id: 'invalid-uuid-format' });
@@ -211,7 +211,7 @@ describe('persona CRUD routes', () => {
         id: 'e5f6a7b8-c9d0-1234-ef01-345678901234',
       });
 
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/');
 
       const { req, res } = createMockReqRes({
@@ -234,7 +234,7 @@ describe('persona CRUD routes', () => {
     });
 
     it('should reject empty name', async () => {
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/');
 
       const { req, res } = createMockReqRes({ name: '', content: 'Valid content' });
@@ -249,7 +249,7 @@ describe('persona CRUD routes', () => {
     });
 
     it('should reject empty content', async () => {
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/');
 
       const { req, res } = createMockReqRes({ name: 'Valid', content: '' });
@@ -259,7 +259,7 @@ describe('persona CRUD routes', () => {
     });
 
     it('should reject content exceeding max length', async () => {
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/');
 
       const { req, res } = createMockReqRes({
@@ -285,7 +285,7 @@ describe('persona CRUD routes', () => {
         name: 'Updated Name',
       });
 
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:id');
 
       const { req, res } = createMockReqRes({ name: 'Updated Name' }, { id: MOCK_PERSONA_ID });
@@ -301,7 +301,7 @@ describe('persona CRUD routes', () => {
     it('should return 404 for non-existent persona', async () => {
       mockPrisma.persona.findFirst.mockResolvedValue(null);
 
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:id');
 
       const { req, res } = createMockReqRes({ name: 'Updated' }, { id: NONEXISTENT_UUID });
@@ -315,7 +315,7 @@ describe('persona CRUD routes', () => {
       mockPrisma.persona.findFirst.mockResolvedValue({ id: MOCK_PERSONA_ID });
       mockPrisma.persona.update.mockResolvedValue(existingPersona);
 
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:id');
 
       // Empty name should NOT be included in update (preserves existing)
@@ -332,7 +332,7 @@ describe('persona CRUD routes', () => {
     });
 
     it('should return 400 for invalid UUID format', async () => {
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:id');
 
       const { req, res } = createMockReqRes({ name: 'Updated' }, { id: 'invalid-uuid' });
@@ -351,7 +351,7 @@ describe('persona CRUD routes', () => {
       mockPrisma.persona.findFirst.mockResolvedValue({ id: MOCK_PERSONA_ID });
       mockPrisma.persona.update.mockResolvedValue(existingPersona);
 
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:id');
 
       // Empty content should NOT be included in update (preserves existing)
@@ -370,7 +370,7 @@ describe('persona CRUD routes', () => {
     it('should reject content update exceeding max length', async () => {
       mockPrisma.persona.findFirst.mockResolvedValue({ id: MOCK_PERSONA_ID });
 
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:id');
 
       const { req, res } = createMockReqRes({ content: 'x'.repeat(5000) }, { id: MOCK_PERSONA_ID });
@@ -393,7 +393,7 @@ describe('persona CRUD routes', () => {
         pronouns: 'they/them',
       });
 
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:id');
 
       const { req, res } = createMockReqRes(
@@ -426,7 +426,7 @@ describe('persona CRUD routes', () => {
       mockPrisma.persona.findFirst.mockResolvedValue({ id: MOCK_PERSONA_ID_2 });
       mockPrisma.persona.delete.mockResolvedValue({});
 
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:id');
 
       const { req, res } = createMockReqRes({}, { id: MOCK_PERSONA_ID_2 });
@@ -439,7 +439,7 @@ describe('persona CRUD routes', () => {
     it('should prevent deleting default persona', async () => {
       mockPrisma.persona.findFirst.mockResolvedValue({ id: MOCK_PERSONA_ID });
 
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:id');
 
       const { req, res } = createMockReqRes({}, { id: MOCK_PERSONA_ID });
@@ -456,7 +456,7 @@ describe('persona CRUD routes', () => {
     it('should return 404 for non-existent persona', async () => {
       mockPrisma.persona.findFirst.mockResolvedValue(null);
 
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:id');
 
       const { req, res } = createMockReqRes({}, { id: NONEXISTENT_UUID });
@@ -466,7 +466,7 @@ describe('persona CRUD routes', () => {
     });
 
     it('should return 400 for invalid UUID format', async () => {
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:id');
 
       const { req, res } = createMockReqRes({}, { id: 'not-a-valid-uuid' });

--- a/services/api-gateway/src/routes/user/persona/default.test.ts
+++ b/services/api-gateway/src/routes/user/persona/default.test.ts
@@ -57,7 +57,7 @@ describe('PATCH /user/persona/:id/default', () => {
     });
     mockPrisma.user.update.mockResolvedValue({});
 
-    const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'patch', '/:id/default');
 
     const { req, res } = createMockReqRes({}, { id: MOCK_PERSONA_ID_2 });
@@ -83,7 +83,7 @@ describe('PATCH /user/persona/:id/default', () => {
   it('should return 404 for non-existent persona', async () => {
     mockPrisma.persona.findFirst.mockResolvedValue(null);
 
-    const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'patch', '/:id/default');
 
     const { req, res } = createMockReqRes({}, { id: NONEXISTENT_UUID });

--- a/services/api-gateway/src/routes/user/persona/index.test.ts
+++ b/services/api-gateway/src/routes/user/persona/index.test.ts
@@ -37,14 +37,14 @@ describe('createPersonaRoutes', () => {
   const mockPrisma = createMockPrisma();
 
   it('should create a router', () => {
-    const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
     expect(router).toBeDefined();
     expect(typeof router).toBe('function');
   });
 
   it('should have GET / route registered', () => {
-    const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
     const getRoute = (
       router.stack as unknown as Array<{ route?: { path?: string; methods?: { get?: boolean } } }>
@@ -53,7 +53,7 @@ describe('createPersonaRoutes', () => {
   });
 
   it('should have POST / route registered', () => {
-    const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
     const postRoute = (
       router.stack as unknown as Array<{ route?: { path?: string; methods?: { post?: boolean } } }>
@@ -62,7 +62,7 @@ describe('createPersonaRoutes', () => {
   });
 
   it('should have override routes registered', () => {
-    const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
     const overrideRoute = (
       router.stack as unknown as Array<{ route?: { path?: string; methods?: { get?: boolean } } }>
@@ -71,7 +71,7 @@ describe('createPersonaRoutes', () => {
   });
 
   it('should have default route registered', () => {
-    const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
     const defaultRoute = (
       router.stack as unknown as Array<{

--- a/services/api-gateway/src/routes/user/persona/index.ts
+++ b/services/api-gateway/src/routes/user/persona/index.ts
@@ -16,24 +16,23 @@
  */
 
 import { Router } from 'express';
-import type { PrismaClient } from '@tzurot/common-types';
+import type { RouteDeps } from '../../routeDeps.js';
 import { addCrudRoutes } from './crud.js';
 import { addDefaultRoutes } from './default.js';
 import { addOverrideRoutes } from './override.js';
 
-// Re-export types for external consumers
-export function createPersonaRoutes(prisma: PrismaClient): Router {
+export function createPersonaRoutes(deps: RouteDeps): Router {
   const router = Router();
 
   // Order matters: routes with parameters must come after specific paths
   // Override routes have /override prefix so they won't conflict with /:id
-  addOverrideRoutes(router, prisma);
+  addOverrideRoutes(router, deps.prisma);
 
   // Default route (/:id/default) - before general /:id
-  addDefaultRoutes(router, prisma);
+  addDefaultRoutes(router, deps.prisma);
 
   // CRUD routes last (/ and /:id)
-  addCrudRoutes(router, prisma);
+  addCrudRoutes(router, deps.prisma);
 
   return router;
 }

--- a/services/api-gateway/src/routes/user/persona/override.test.ts
+++ b/services/api-gateway/src/routes/user/persona/override.test.ts
@@ -65,7 +65,7 @@ describe('persona override routes', () => {
         },
       ]);
 
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/override');
 
       const { req, res } = createMockReqRes();
@@ -87,7 +87,7 @@ describe('persona override routes', () => {
     it('should return empty array when no overrides exist', async () => {
       mockPrisma.userPersonalityConfig.findMany.mockResolvedValue([]);
 
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/override');
 
       const { req, res } = createMockReqRes();
@@ -105,7 +105,7 @@ describe('persona override routes', () => {
         displayName: 'Lilith the Succubus',
       });
 
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/override/:personalitySlug');
 
       const { req, res } = createMockReqRes({}, { personalitySlug: 'lilith' });
@@ -123,7 +123,7 @@ describe('persona override routes', () => {
     it('should return 404 for non-existent personality', async () => {
       mockPrisma.personality.findUnique.mockResolvedValue(null);
 
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/override/:personalitySlug');
 
       const { req, res } = createMockReqRes({}, { personalitySlug: 'nonexistent' });
@@ -147,7 +147,7 @@ describe('persona override routes', () => {
       });
       mockPrisma.userPersonalityConfig.upsert.mockResolvedValue({});
 
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/override/:personalitySlug');
 
       const { req, res } = createMockReqRes(
@@ -187,7 +187,7 @@ describe('persona override routes', () => {
     it('should return 404 for non-existent persona', async () => {
       mockPrisma.persona.findFirst.mockResolvedValue(null);
 
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/override/:personalitySlug');
 
       const { req, res } = createMockReqRes(
@@ -203,7 +203,7 @@ describe('persona override routes', () => {
       mockPrisma.persona.findFirst.mockResolvedValue({ id: MOCK_PERSONA_ID, name: 'Test' });
       mockPrisma.personality.findUnique.mockResolvedValue(null);
 
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/override/:personalitySlug');
 
       const { req, res } = createMockReqRes(
@@ -216,7 +216,7 @@ describe('persona override routes', () => {
     });
 
     it('should reject missing personaId', async () => {
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/override/:personalitySlug');
 
       const { req, res } = createMockReqRes({}, { personalitySlug: 'lilith' });
@@ -239,7 +239,7 @@ describe('persona override routes', () => {
       });
       mockPrisma.userPersonalityConfig.delete.mockResolvedValue({});
 
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/override/:personalitySlug');
 
       const { req, res } = createMockReqRes({}, { personalitySlug: 'lilith' });
@@ -271,7 +271,7 @@ describe('persona override routes', () => {
       });
       mockPrisma.userPersonalityConfig.update.mockResolvedValue({});
 
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/override/:personalitySlug');
 
       const { req, res } = createMockReqRes({}, { personalitySlug: 'lilith' });
@@ -289,7 +289,7 @@ describe('persona override routes', () => {
     it('should return 404 for non-existent personality', async () => {
       mockPrisma.personality.findUnique.mockResolvedValue(null);
 
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/override/:personalitySlug');
 
       const { req, res } = createMockReqRes({}, { personalitySlug: 'nonexistent' });
@@ -306,7 +306,7 @@ describe('persona override routes', () => {
       });
       mockPrisma.userPersonalityConfig.findUnique.mockResolvedValue(null);
 
-      const router = createPersonaRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/override/:personalitySlug');
 
       const { req, res } = createMockReqRes({}, { personalitySlug: 'lilith' });

--- a/services/api-gateway/src/routes/user/personality-config-overrides.test.ts
+++ b/services/api-gateway/src/routes/user/personality-config-overrides.test.ts
@@ -121,7 +121,9 @@ describe('/user/config-overrides personality routes', () => {
 
   describe('route factory', () => {
     it('should create a router with personality routes', () => {
-      const router = createPersonalityConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityConfigOverrideRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+      });
 
       expect(router).toBeDefined();
       expect(findRoute(router, 'get', '/resolve-personality/:personalityId')).toBeDefined();
@@ -131,7 +133,9 @@ describe('/user/config-overrides personality routes', () => {
 
   describe('GET /resolve-personality/:personalityId', () => {
     it('should return resolved 3-tier cascade', async () => {
-      const router = createPersonalityConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityConfigOverrideRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+      });
       const handler = getHandler(router, 'get', '/resolve-personality/:personalityId');
       const { req, res } = createMockReqRes({}, { personalityId: TEST_PERSONALITY_ID });
 
@@ -142,7 +146,9 @@ describe('/user/config-overrides personality routes', () => {
     });
 
     it('should reject non-UUID personalityId', async () => {
-      const router = createPersonalityConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityConfigOverrideRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+      });
       const handler = getHandler(router, 'get', '/resolve-personality/:personalityId');
       const { req, res } = createMockReqRes({}, { personalityId: 'not-a-uuid' });
 
@@ -155,7 +161,9 @@ describe('/user/config-overrides personality routes', () => {
 
   describe('PATCH /personality/:personalityId', () => {
     it('should reject non-UUID personalityId', async () => {
-      const router = createPersonalityConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityConfigOverrideRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+      });
       const handler = getHandler(router, 'patch', '/personality/:personalityId');
       const { req, res } = createMockReqRes({ maxMessages: 25 }, { personalityId: 'not-a-uuid' });
 
@@ -165,7 +173,9 @@ describe('/user/config-overrides personality routes', () => {
     });
 
     it('should return 404 when personality not found', async () => {
-      const router = createPersonalityConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityConfigOverrideRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+      });
       const handler = getHandler(router, 'patch', '/personality/:personalityId');
       const { req, res } = createMockReqRes(
         { maxMessages: 25 },
@@ -183,7 +193,9 @@ describe('/user/config-overrides personality routes', () => {
         configDefaults: null,
       });
 
-      const router = createPersonalityConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityConfigOverrideRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+      });
       const handler = getHandler(router, 'patch', '/personality/:personalityId');
       const { req, res } = createMockReqRes(
         { maxMessages: 25 },
@@ -201,7 +213,9 @@ describe('/user/config-overrides personality routes', () => {
         configDefaults: null,
       });
 
-      const router = createPersonalityConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityConfigOverrideRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+      });
       const handler = getHandler(router, 'patch', '/personality/:personalityId');
       const { req, res } = createMockReqRes(
         { maxMessages: 25 },
@@ -229,7 +243,9 @@ describe('/user/config-overrides personality routes', () => {
         configDefaults: { maxImages: 5 },
       });
 
-      const router = createPersonalityConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityConfigOverrideRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+      });
       const handler = getHandler(router, 'patch', '/personality/:personalityId');
       const { req, res } = createMockReqRes(
         { maxMessages: 25 },
@@ -256,10 +272,12 @@ describe('/user/config-overrides personality routes', () => {
         invalidatePersonality: vi.fn().mockResolvedValue(undefined),
       };
 
-      const router = createPersonalityConfigOverrideRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockInvalidation as unknown as Parameters<typeof createPersonalityConfigOverrideRoutes>[1]
-      );
+      const router = createPersonalityConfigOverrideRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        cascadeInvalidation: mockInvalidation as unknown as NonNullable<
+          Parameters<typeof createPersonalityConfigOverrideRoutes>[0]['cascadeInvalidation']
+        >,
+      });
       const handler = getHandler(router, 'patch', '/personality/:personalityId');
       const { req, res } = createMockReqRes(
         { maxMessages: 25 },
@@ -281,10 +299,12 @@ describe('/user/config-overrides personality routes', () => {
         invalidatePersonality: vi.fn().mockRejectedValue(new Error('Redis connection lost')),
       };
 
-      const router = createPersonalityConfigOverrideRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockInvalidation as unknown as Parameters<typeof createPersonalityConfigOverrideRoutes>[1]
-      );
+      const router = createPersonalityConfigOverrideRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        cascadeInvalidation: mockInvalidation as unknown as NonNullable<
+          Parameters<typeof createPersonalityConfigOverrideRoutes>[0]['cascadeInvalidation']
+        >,
+      });
       const handler = getHandler(router, 'patch', '/personality/:personalityId');
       const { req, res } = createMockReqRes(
         { maxMessages: 25 },
@@ -304,7 +324,9 @@ describe('/user/config-overrides personality routes', () => {
         configDefaults: null,
       });
 
-      const router = createPersonalityConfigOverrideRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityConfigOverrideRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+      });
       const handler = getHandler(router, 'patch', '/personality/:personalityId');
       const { req, res } = createMockReqRes(
         { maxMessages: -5 },

--- a/services/api-gateway/src/routes/user/personality-config-overrides.ts
+++ b/services/api-gateway/src/routes/user/personality-config-overrides.ts
@@ -8,13 +8,9 @@
  * These are mounted under /user/config-overrides/ alongside the user-level endpoints.
  */
 
-import { Router, type Response } from 'express';
+import { Router, type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
-import {
-  ConfigCascadeResolver,
-  type PrismaClient,
-  type ConfigCascadeCacheInvalidationService,
-} from '@tzurot/common-types';
+import { ConfigCascadeResolver } from '@tzurot/common-types';
 import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import {
@@ -26,95 +22,90 @@ import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
 import { getRequiredParam } from '../../utils/requestParams.js';
 import type { AuthenticatedRequest, ProvisionedRequest } from '../../types.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-export function createPersonalityConfigOverrideRoutes(
-  prisma: PrismaClient,
-  cascadeInvalidation?: ConfigCascadeCacheInvalidationService
-): Router {
+/**
+ * GET /api/user/config-overrides/resolve-personality/:personalityId — resolve 3-tier cascade.
+ *
+ * Intentionally no creator-check: the resolved 3-tier cascade is non-sensitive
+ * (same data any user would experience). Only writes (PATCH) are creator-gated.
+ */
+export const handleResolvePersonalityCascade = (deps: RouteDeps): RequestHandler => {
+  const cascadeResolver = new ConfigCascadeResolver(deps.prisma, { enableCleanup: false });
+  return asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+    const personalityId = getRequiredParam(req.params.personalityId, 'personalityId');
+
+    if (!UUID_PATTERN.test(personalityId)) {
+      return sendError(res, ErrorResponses.validationError('Invalid personalityId format'));
+    }
+
+    // Pass undefined for userId and channelId to skip user/channel tiers
+    const resolved = await cascadeResolver.resolveOverrides(undefined, personalityId, undefined);
+    sendCustomSuccess(res, resolved, StatusCodes.OK);
+  });
+};
+
+/**
+ * PATCH /api/user/config-overrides/personality/:personalityId — update personality
+ * config defaults. Auth: requesting user must be the personality creator.
+ */
+export const handleUpdatePersonalityConfigDefaults = (deps: RouteDeps): RequestHandler => {
+  const { prisma, cascadeInvalidation } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const personalityId = getRequiredParam(req.params.personalityId, 'personalityId');
+
+    if (!UUID_PATTERN.test(personalityId)) {
+      return sendError(res, ErrorResponses.validationError('Invalid personalityId format'));
+    }
+
+    const userId = resolveProvisionedUserId(req);
+
+    const personality = await prisma.personality.findUnique({
+      where: { id: personalityId },
+      select: { ownerId: true, configDefaults: true },
+    });
+    if (personality === null) {
+      return sendError(res, ErrorResponses.notFound('Personality'));
+    }
+    if (personality.ownerId !== userId) {
+      return sendError(
+        res,
+        ErrorResponses.forbidden('Only the personality creator can edit defaults')
+      );
+    }
+
+    const { merged, prismaValue } = mergeAndValidateOverrides(
+      personality.configDefaults,
+      req.body,
+      res
+    );
+    if (merged === undefined) {
+      return;
+    }
+
+    await prisma.personality.update({
+      where: { id: personalityId },
+      data: { configDefaults: prismaValue },
+    });
+
+    await tryInvalidateCache(
+      cascadeInvalidation?.invalidatePersonality.bind(cascadeInvalidation, personalityId),
+      { personalityId }
+    );
+
+    sendCustomSuccess(res, { configDefaults: merged }, StatusCodes.OK);
+  });
+};
+
+export function createPersonalityConfigOverrideRoutes(deps: RouteDeps): Router {
   const router = Router();
-  const cascadeResolver = new ConfigCascadeResolver(prisma, { enableCleanup: false });
-
   router.use(requireUserAuth());
-  router.use(requireProvisionedUser(prisma));
+  router.use(requireProvisionedUser(deps.prisma));
 
-  /**
-   * GET /resolve-personality/:personalityId
-   * Resolve 3-tier cascade: hardcoded → admin → personality.
-   * Used by personality creator dashboards to see what their defaults resolve to.
-   *
-   * Intentionally no creator-check: the resolved 3-tier cascade is non-sensitive
-   * (same data any user would experience). Only writes (PATCH) are creator-gated.
-   */
-  router.get(
-    '/resolve-personality/:personalityId',
-    asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
-      const personalityId = getRequiredParam(req.params.personalityId, 'personalityId');
-
-      if (!UUID_PATTERN.test(personalityId)) {
-        return sendError(res, ErrorResponses.validationError('Invalid personalityId format'));
-      }
-
-      // Pass undefined for userId and channelId to skip user/channel tiers
-      const resolved = await cascadeResolver.resolveOverrides(undefined, personalityId, undefined);
-      sendCustomSuccess(res, resolved, StatusCodes.OK);
-    })
-  );
-
-  /**
-   * PATCH /personality/:personalityId
-   * Update personality-level config defaults (Personality.configDefaults).
-   * Auth: Must be personality creator (ownerId matches requesting user).
-   */
-  router.patch(
-    '/personality/:personalityId',
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const personalityId = getRequiredParam(req.params.personalityId, 'personalityId');
-
-      if (!UUID_PATTERN.test(personalityId)) {
-        return sendError(res, ErrorResponses.validationError('Invalid personalityId format'));
-      }
-
-      const userId = resolveProvisionedUserId(req);
-
-      // Verify creator ownership
-      const personality = await prisma.personality.findUnique({
-        where: { id: personalityId },
-        select: { ownerId: true, configDefaults: true },
-      });
-      if (personality === null) {
-        return sendError(res, ErrorResponses.notFound('Personality'));
-      }
-      if (personality.ownerId !== userId) {
-        return sendError(
-          res,
-          ErrorResponses.forbidden('Only the personality creator can edit defaults')
-        );
-      }
-
-      const { merged, prismaValue } = mergeAndValidateOverrides(
-        personality.configDefaults,
-        req.body,
-        res
-      );
-      if (merged === undefined) {
-        return;
-      }
-
-      await prisma.personality.update({
-        where: { id: personalityId },
-        data: { configDefaults: prismaValue },
-      });
-
-      await tryInvalidateCache(
-        cascadeInvalidation?.invalidatePersonality.bind(cascadeInvalidation, personalityId),
-        { personalityId }
-      );
-
-      sendCustomSuccess(res, { configDefaults: merged }, StatusCodes.OK);
-    })
-  );
+  router.get('/resolve-personality/:personalityId', handleResolvePersonalityCascade(deps));
+  router.patch('/personality/:personalityId', handleUpdatePersonalityConfigDefaults(deps));
 
   return router;
 }

--- a/services/api-gateway/src/routes/user/personality/create.test.ts
+++ b/services/api-gateway/src/routes/user/personality/create.test.ts
@@ -63,7 +63,7 @@ describe('POST /user/personality (create)', () => {
   });
 
   it('should reject missing name', async () => {
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'post', '/');
     const { req, res } = createMockReqRes({
       slug: 'test-char',
@@ -77,7 +77,7 @@ describe('POST /user/personality (create)', () => {
   });
 
   it('should reject missing slug', async () => {
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'post', '/');
     const { req, res } = createMockReqRes({
       name: 'Test Character',
@@ -91,7 +91,7 @@ describe('POST /user/personality (create)', () => {
   });
 
   it('should reject missing characterInfo', async () => {
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'post', '/');
     const { req, res } = createMockReqRes({
       name: 'Test Character',
@@ -105,7 +105,7 @@ describe('POST /user/personality (create)', () => {
   });
 
   it('should reject missing personalityTraits', async () => {
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'post', '/');
     const { req, res } = createMockReqRes({
       name: 'Test Character',
@@ -119,7 +119,7 @@ describe('POST /user/personality (create)', () => {
   });
 
   it('should reject invalid slug format', async () => {
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'post', '/');
     const { req, res } = createMockReqRes({
       name: 'Test Character',
@@ -136,7 +136,7 @@ describe('POST /user/personality (create)', () => {
   it('should reject duplicate slug', async () => {
     mockPrisma.personality.findUnique.mockResolvedValue({ id: 'existing' });
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'post', '/');
     const { req, res } = createMockReqRes({
       name: 'Test Character',
@@ -158,7 +158,7 @@ describe('POST /user/personality (create)', () => {
       })
     );
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'post', '/');
     const { req, res } = createMockReqRes({
       name: 'New Character',
@@ -206,7 +206,7 @@ describe('POST /user/personality (create)', () => {
     // — that path is unaffected by this change.
     mockPrisma.personality.create.mockResolvedValue(createMockPersonality());
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'post', '/');
     const { req, res } = createMockReqRes({
       name: 'New Character',
@@ -226,7 +226,7 @@ describe('POST /user/personality (create)', () => {
     });
     mockPrisma.personality.create.mockResolvedValue(createMockPersonality());
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'post', '/');
     const { req, res } = createMockReqRes({
       name: 'New Character',
@@ -254,7 +254,7 @@ describe('POST /user/personality (create)', () => {
     mockPrisma.systemPrompt.findFirst.mockResolvedValue(null);
     mockPrisma.personality.create.mockResolvedValue(createMockPersonality());
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'post', '/');
     const { req, res } = createMockReqRes({
       name: 'New Character',
@@ -279,7 +279,7 @@ describe('POST /user/personality (create)', () => {
       createMockPersonality({ errorMessage: 'Custom error message for this character' })
     );
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'post', '/');
     const { req, res } = createMockReqRes({
       name: 'New Character',
@@ -303,7 +303,7 @@ describe('POST /user/personality (create)', () => {
   it('should set errorMessage to null when not provided', async () => {
     mockPrisma.personality.create.mockResolvedValue(createMockPersonality());
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'post', '/');
     const { req, res } = createMockReqRes({
       name: 'New Character',
@@ -337,7 +337,7 @@ describe('POST /user/personality (create)', () => {
       });
       mockPrisma.personality.create.mockResolvedValue(createMockPersonality());
 
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/');
       const { req, res } = createMockReqRes({
         name: 'Big Avatar Character',
@@ -359,7 +359,7 @@ describe('POST /user/personality (create)', () => {
       const mockOptimizeAvatar = vi.mocked(optimizeAvatar);
       mockOptimizeAvatar.mockRejectedValueOnce(new Error('Invalid image format'));
 
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/');
       const { req, res } = createMockReqRes({
         name: 'Bad Avatar Character',
@@ -379,7 +379,7 @@ describe('POST /user/personality (create)', () => {
 
   describe('voice reference processing', () => {
     it('should return error for invalid voice reference data URI', async () => {
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/');
       const { req, res } = createMockReqRes({
         name: 'Voice Char',
@@ -396,7 +396,7 @@ describe('POST /user/personality (create)', () => {
     });
 
     it('should return error for unsupported voice reference MIME type', async () => {
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/');
       const { req, res } = createMockReqRes({
         name: 'Voice Char',
@@ -421,7 +421,7 @@ describe('POST /user/personality (create)', () => {
       const base64 = audioBytes.toString('base64');
       const dataUri = `data:audio/wav;base64,${base64}`;
 
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'post', '/');
       const { req, res } = createMockReqRes({
         name: 'Voice Char',

--- a/services/api-gateway/src/routes/user/personality/create.ts
+++ b/services/api-gateway/src/routes/user/personality/create.ts
@@ -7,7 +7,6 @@ import { type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import {
   createLogger,
-  type PrismaClient,
   Prisma,
   generatePersonalityUuid,
   PersonalityCreateSchema,
@@ -25,6 +24,7 @@ import { processVoiceReferenceData } from '../../../utils/voiceReferenceProcesso
 import { formatPersonalityResponse } from './formatters.js';
 import type { ProvisionedRequest } from '../../../types.js';
 import { getOrCreateInternalUser } from '../userHelpers.js';
+import type { RouteDeps } from '../../routeDeps.js';
 
 const logger = createLogger('user-personality-create');
 
@@ -73,11 +73,11 @@ function buildCreateData(
 }
 
 /**
- * Create handler for POST /user/personality
- * Create a new personality owned by the user
+ * POST /api/user/personality — create a new personality owned by the user.
  */
-export function createCreateHandler(prisma: PrismaClient): RequestHandler[] {
-  const handler = asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+export const handleCreateUserPersonality = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
     const discordUserId = req.userId;
 
     // Validate request body with Zod schema
@@ -147,6 +147,12 @@ export function createCreateHandler(prisma: PrismaClient): RequestHandler[] {
       StatusCodes.CREATED
     );
   });
+};
 
-  return [requireUserAuth(), requireProvisionedUser(prisma), handler];
+export function createCreateHandler(deps: RouteDeps): RequestHandler[] {
+  return [
+    requireUserAuth(),
+    requireProvisionedUser(deps.prisma),
+    handleCreateUserPersonality(deps),
+  ];
 }

--- a/services/api-gateway/src/routes/user/personality/delete.test.ts
+++ b/services/api-gateway/src/routes/user/personality/delete.test.ts
@@ -78,7 +78,7 @@ describe('DELETE /user/personality/:slug', () => {
   it('should return 404 when personality not found', async () => {
     mockPrisma.personality.findUnique.mockResolvedValue(null);
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'delete', '/:slug');
     const { req, res } = createMockReqRes({}, { slug: 'nonexistent' });
 
@@ -100,7 +100,7 @@ describe('DELETE /user/personality/:slug', () => {
       },
     });
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'delete', '/:slug');
     const { req, res } = createMockReqRes({}, { slug: 'not-mine' });
 
@@ -124,7 +124,7 @@ describe('DELETE /user/personality/:slug', () => {
     });
     mockPrisma.pendingMemory.count.mockResolvedValue(3);
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'delete', '/:slug');
     const { req, res } = createMockReqRes({}, { slug: 'my-char' });
 
@@ -153,7 +153,7 @@ describe('DELETE /user/personality/:slug', () => {
     });
     mockPrisma.pendingMemory.count.mockResolvedValue(10);
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'delete', '/:slug');
     const { req, res } = createMockReqRes({}, { slug: 'count-test' });
 
@@ -189,7 +189,7 @@ describe('DELETE /user/personality/:slug', () => {
     });
     mockPrisma.pendingMemory.count.mockResolvedValue(2);
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'delete', '/:slug');
     const { req, res } = createMockReqRes({}, { slug: 'schema-test' });
 
@@ -217,7 +217,7 @@ describe('DELETE /user/personality/:slug', () => {
     });
     mockPrisma.pendingMemory.count.mockResolvedValue(0);
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'delete', '/:slug');
     const { req, res } = createMockReqRes({}, { slug: 'no-pending' });
 
@@ -247,7 +247,7 @@ describe('DELETE /user/personality/:slug', () => {
     });
     mockPrisma.pendingMemory.count.mockResolvedValue(0);
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'delete', '/:slug');
     const { req, res } = createMockReqRes({}, { slug: 'other-user-char' });
 
@@ -280,7 +280,7 @@ describe('DELETE /user/personality/:slug', () => {
     });
     mockPrisma.pendingMemory.count.mockResolvedValue(0);
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'delete', '/:slug');
     const { req, res } = createMockReqRes({}, { slug: 'coowned-char' });
 
@@ -317,7 +317,7 @@ describe('DELETE /user/personality/:slug', () => {
       );
       mockUnlink.mockResolvedValue(undefined);
 
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:slug');
       const { req, res } = createMockReqRes({}, { slug: 'valid-slug' });
 
@@ -336,7 +336,7 @@ describe('DELETE /user/personality/:slug', () => {
         throw enoentError;
       });
 
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:slug');
       const { req, res } = createMockReqRes({}, { slug: 'valid-slug' });
 
@@ -353,7 +353,7 @@ describe('DELETE /user/personality/:slug', () => {
       enoentError.code = 'ENOENT';
       mockUnlink.mockRejectedValue(enoentError);
 
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:slug');
       const { req, res } = createMockReqRes({}, { slug: 'valid-slug' });
 
@@ -366,7 +366,7 @@ describe('DELETE /user/personality/:slug', () => {
     it('should skip avatar deletion for invalid slug format (path traversal protection)', async () => {
       // This tests the CWE-22 path traversal protection
       // Invalid slugs should not trigger glob at all
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:slug');
       const { req, res } = createMockReqRes({}, { slug: '../../../etc/passwd' });
 
@@ -379,7 +379,7 @@ describe('DELETE /user/personality/:slug', () => {
     });
 
     it('should skip avatar deletion for slug with spaces', async () => {
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:slug');
       const { req, res } = createMockReqRes({}, { slug: 'invalid slug' });
 
@@ -414,10 +414,10 @@ describe('DELETE /user/personality/:slug', () => {
         invalidatePersonality: vi.fn().mockResolvedValue(undefined),
       } as unknown as import('@tzurot/common-types').CacheInvalidationService;
 
-      const router = createPersonalityRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockCacheInvalidationService
-      );
+      const router = createPersonalityRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        cacheInvalidationService: mockCacheInvalidationService,
+      });
       const handler = getHandler(router, 'delete', '/:slug');
       const { req, res } = createMockReqRes({}, { slug: 'cache-test' });
 
@@ -434,10 +434,10 @@ describe('DELETE /user/personality/:slug', () => {
         invalidatePersonality: vi.fn().mockRejectedValue(new Error('Redis connection failed')),
       } as unknown as import('@tzurot/common-types').CacheInvalidationService;
 
-      const router = createPersonalityRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockCacheInvalidationService
-      );
+      const router = createPersonalityRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        cacheInvalidationService: mockCacheInvalidationService,
+      });
       const handler = getHandler(router, 'delete', '/:slug');
       const { req, res } = createMockReqRes({}, { slug: 'cache-test' });
 
@@ -449,7 +449,7 @@ describe('DELETE /user/personality/:slug', () => {
     });
 
     it('should succeed without cache invalidation service', async () => {
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:slug');
       const { req, res } = createMockReqRes({}, { slug: 'no-cache-service' });
 

--- a/services/api-gateway/src/routes/user/personality/delete.ts
+++ b/services/api-gateway/src/routes/user/personality/delete.ts
@@ -19,6 +19,7 @@ import { deleteAllAvatarVersions } from '../../../utils/avatarPaths.js';
 import type { ProvisionedRequest } from '../../../types.js';
 import { getParam } from '../../../utils/requestParams.js';
 import { resolvePersonalityForEdit } from './helpers.js';
+import type { RouteDeps } from '../../routeDeps.js';
 
 const logger = createLogger('user-personality-delete');
 
@@ -135,15 +136,15 @@ function createHandler(prisma: PrismaClient, cacheInvalidationService?: CacheInv
   };
 }
 
-// --- Route Factory ---
+// --- Handler factory + route chain ---
 
-export function createDeleteHandler(
-  prisma: PrismaClient,
-  cacheInvalidationService?: CacheInvalidationService
-): RequestHandler[] {
+export const handleDeleteUserPersonality = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createHandler(deps.prisma, deps.cacheInvalidationService));
+
+export function createDeleteHandler(deps: RouteDeps): RequestHandler[] {
   return [
     requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(createHandler(prisma, cacheInvalidationService)),
+    requireProvisionedUser(deps.prisma),
+    handleDeleteUserPersonality(deps),
   ];
 }

--- a/services/api-gateway/src/routes/user/personality/get.test.ts
+++ b/services/api-gateway/src/routes/user/personality/get.test.ts
@@ -49,7 +49,7 @@ describe('GET /user/personality/:slug', () => {
   it('should return 404 when personality not found', async () => {
     mockPrisma.personality.findUnique.mockResolvedValue(null);
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'get', '/:slug');
     const { req, res } = createMockReqRes({}, { slug: 'nonexistent' });
 
@@ -71,7 +71,7 @@ describe('GET /user/personality/:slug', () => {
       updatedAt: new Date(),
     });
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'get', '/:slug');
     const { req, res } = createMockReqRes({}, { slug: 'private-char' });
 
@@ -109,7 +109,7 @@ describe('GET /user/personality/:slug', () => {
       updatedAt: new Date('2024-01-02'),
     });
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'get', '/:slug');
     const { req, res } = createMockReqRes({}, { slug: 'public-char' });
 
@@ -158,7 +158,7 @@ describe('GET /user/personality/:slug', () => {
       updatedAt: new Date('2024-01-02'),
     });
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'get', '/:slug');
     const { req, res } = createMockReqRes({}, { slug: 'my-char' });
 

--- a/services/api-gateway/src/routes/user/personality/get.ts
+++ b/services/api-gateway/src/routes/user/personality/get.ts
@@ -20,6 +20,7 @@ import type { ProvisionedRequest } from '../../../types.js';
 import { getParam } from '../../../utils/requestParams.js';
 import { canUserEditPersonality } from './helpers.js';
 import { formatPersonalityResponse } from './formatters.js';
+import type { RouteDeps } from '../../routeDeps.js';
 
 const logger = createLogger('user-personality-get');
 
@@ -91,8 +92,11 @@ function createHandler(prisma: PrismaClient) {
   };
 }
 
-// --- Route Factory ---
+// --- Handler factory + route chain ---
 
-export function createGetHandler(prisma: PrismaClient): RequestHandler[] {
-  return [requireUserAuth(), requireProvisionedUser(prisma), asyncHandler(createHandler(prisma))];
+export const handleGetUserPersonality = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createHandler(deps.prisma));
+
+export function createGetHandler(deps: RouteDeps): RequestHandler[] {
+  return [requireUserAuth(), requireProvisionedUser(deps.prisma), handleGetUserPersonality(deps)];
 }

--- a/services/api-gateway/src/routes/user/personality/index.test.ts
+++ b/services/api-gateway/src/routes/user/personality/index.test.ts
@@ -40,14 +40,14 @@ describe('/user/personality route composition', () => {
 
   describe('route factory', () => {
     it('should create a router', () => {
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(router).toBeDefined();
       expect(typeof router).toBe('function');
     });
 
     it('should have GET / route registered', () => {
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(router.stack).toBeDefined();
       expect(router.stack.length).toBeGreaterThan(0);
@@ -59,7 +59,7 @@ describe('/user/personality route composition', () => {
     });
 
     it('should have GET /:slug route registered', () => {
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       const getRoute = (
         router.stack as unknown as { route?: { path?: string; methods?: { get?: boolean } } }[]
@@ -68,7 +68,7 @@ describe('/user/personality route composition', () => {
     });
 
     it('should have POST / route registered', () => {
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       const postRoute = (
         router.stack as unknown as { route?: { path?: string; methods?: { post?: boolean } } }[]
@@ -77,7 +77,7 @@ describe('/user/personality route composition', () => {
     });
 
     it('should have PUT /:slug route registered', () => {
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       const putRoute = (
         router.stack as unknown as { route?: { path?: string; methods?: { put?: boolean } } }[]
@@ -86,7 +86,7 @@ describe('/user/personality route composition', () => {
     });
 
     it('should have PATCH /:slug/visibility route registered', () => {
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       const patchRoute = (
         router.stack as unknown as { route?: { path?: string; methods?: { patch?: boolean } } }[]
@@ -95,7 +95,7 @@ describe('/user/personality route composition', () => {
     });
 
     it('should have DELETE /:slug route registered', () => {
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       const deleteRoute = (
         router.stack as unknown as { route?: { path?: string; methods?: { delete?: boolean } } }[]

--- a/services/api-gateway/src/routes/user/personality/index.ts
+++ b/services/api-gateway/src/routes/user/personality/index.ts
@@ -12,7 +12,7 @@
  */
 
 import { Router } from 'express';
-import { type PrismaClient, type CacheInvalidationService } from '@tzurot/common-types';
+import type { RouteDeps } from '../../routeDeps.js';
 import { createListHandler } from './list.js';
 import { createGetHandler } from './get.js';
 import { createCreateHandler } from './create.js';
@@ -22,34 +22,16 @@ import { createDeleteHandler } from './delete.js';
 
 /**
  * Create personality router with injected dependencies
- * @param prisma - Database client
- * @param cacheInvalidationService - Service for invalidating personality caches across all services
  */
-export function createPersonalityRoutes(
-  prisma: PrismaClient,
-  cacheInvalidationService?: CacheInvalidationService
-): Router {
+export function createPersonalityRoutes(deps: RouteDeps): Router {
   const router = Router();
 
-  // List personalities - GET /
-  router.get('/', ...createListHandler(prisma));
-
-  // Get single personality - GET /:slug
-  router.get('/:slug', ...createGetHandler(prisma));
-
-  // Create personality - POST /
-  router.post('/', ...createCreateHandler(prisma));
-
-  // Update personality - PUT /:slug
-  router.put('/:slug', ...createUpdateHandler(prisma, cacheInvalidationService));
-
-  // Toggle visibility - PATCH /:slug/visibility
-  router.patch('/:slug/visibility', ...createVisibilityHandler(prisma));
-
-  // Delete personality - DELETE /:slug
-  router.delete('/:slug', ...createDeleteHandler(prisma, cacheInvalidationService));
+  router.get('/', ...createListHandler(deps));
+  router.get('/:slug', ...createGetHandler(deps));
+  router.post('/', ...createCreateHandler(deps));
+  router.put('/:slug', ...createUpdateHandler(deps));
+  router.patch('/:slug/visibility', ...createVisibilityHandler(deps));
+  router.delete('/:slug', ...createDeleteHandler(deps));
 
   return router;
 }
-
-// Re-export helpers for use by other modules if needed

--- a/services/api-gateway/src/routes/user/personality/list.test.ts
+++ b/services/api-gateway/src/routes/user/personality/list.test.ts
@@ -82,7 +82,7 @@ describe('GET /user/personality (list)', () => {
       .mockResolvedValueOnce([publicPersonality])
       .mockResolvedValueOnce([]);
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'get', '/');
     const { req, res } = createMockReqRes();
 
@@ -118,7 +118,7 @@ describe('GET /user/personality (list)', () => {
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([ownedPersonality]);
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'get', '/');
     const { req, res } = createMockReqRes();
 
@@ -143,7 +143,7 @@ describe('GET /user/personality (list)', () => {
     mockPrisma.user.findFirst.mockResolvedValue(null);
     mockPrisma.personality.findMany.mockResolvedValue([]);
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'get', '/');
     const { req, res } = createMockReqRes();
 
@@ -195,7 +195,7 @@ describe('GET /user/personality (list)', () => {
       ];
       mockPrisma.personality.findMany.mockResolvedValueOnce(allPersonalities);
 
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/');
       const { req, res } = createMockReqRes();
 
@@ -243,7 +243,7 @@ describe('GET /user/personality (list)', () => {
       };
       mockPrisma.personality.findMany.mockResolvedValueOnce([personalityWithOwner]);
 
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/');
       const { req, res } = createMockReqRes();
 
@@ -272,7 +272,7 @@ describe('GET /user/personality (list)', () => {
       };
       mockPrisma.personality.findMany.mockResolvedValueOnce([personalityWithOwner]);
 
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/');
       const { req, res } = createMockReqRes();
 

--- a/services/api-gateway/src/routes/user/personality/list.ts
+++ b/services/api-gateway/src/routes/user/personality/list.ts
@@ -18,6 +18,7 @@ import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { resolveProvisionedUserId } from '../../../utils/resolveProvisionedUserId.js';
 import { sendCustomSuccess } from '../../../utils/responseHelpers.js';
 import type { ProvisionedRequest } from '../../../types.js';
+import type { RouteDeps } from '../../routeDeps.js';
 
 const logger = createLogger('user-personality-list');
 
@@ -124,13 +125,12 @@ async function fetchUserPersonalities(
 }
 
 /**
- * Create handler for GET /user/personality
- * List all personalities visible to the user
- * - Public personalities (isPublic = true)
- * - User-owned personalities (ownerId = user.id OR PersonalityOwner entry)
+ * GET /api/user/personality — List all personalities visible to the user
+ * (public + user-owned for regular users; all for admins).
  */
-export function createListHandler(prisma: PrismaClient): RequestHandler[] {
-  const handler = asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+export const handleListUserPersonalities = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
     const discordUserId = req.userId;
     const isAdmin = isBotOwner(discordUserId);
 
@@ -149,6 +149,13 @@ export function createListHandler(prisma: PrismaClient): RequestHandler[] {
     logger.info({ discordUserId, totalCount: personalities.length }, 'Listed personalities');
     sendCustomSuccess(res, { personalities }, StatusCodes.OK);
   });
+};
 
-  return [requireUserAuth(), requireProvisionedUser(prisma), handler];
+/** Legacy chain (auth middleware + handler) — kept for the existing aggregator. */
+export function createListHandler(deps: RouteDeps): RequestHandler[] {
+  return [
+    requireUserAuth(),
+    requireProvisionedUser(deps.prisma),
+    handleListUserPersonalities(deps),
+  ];
 }

--- a/services/api-gateway/src/routes/user/personality/update.test.ts
+++ b/services/api-gateway/src/routes/user/personality/update.test.ts
@@ -89,7 +89,7 @@ describe('PUT /user/personality/:slug (update)', () => {
   it('should return 404 when personality not found', async () => {
     mockPrisma.personality.findUnique.mockResolvedValue(null);
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'put', '/:slug');
     const { req, res } = createMockReqRes({ name: 'Updated' }, { slug: 'nonexistent' });
 
@@ -104,7 +104,7 @@ describe('PUT /user/personality/:slug (update)', () => {
       ownerId: 'other-user',
     });
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'put', '/:slug');
     const { req, res } = createMockReqRes({ name: 'Updated' }, { slug: 'not-mine' });
 
@@ -129,7 +129,7 @@ describe('PUT /user/personality/:slug (update)', () => {
       })
     );
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'put', '/:slug');
     const { req, res } = createMockReqRes(
       { name: 'Updated Name', displayName: 'Updated Display' },
@@ -183,7 +183,7 @@ describe('PUT /user/personality/:slug (update)', () => {
       })
     );
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'put', '/:slug');
     const { req, res } = createMockReqRes({ name: 'Updated' }, { slug: 'shared-char' });
 
@@ -213,7 +213,7 @@ describe('PUT /user/personality/:slug (update)', () => {
         })
       );
 
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:slug');
       const { req, res } = createMockReqRes(
         { avatarData: 'data:image/png;base64,iVBORw0KGgo=' }, // Only avatar, no displayName
@@ -243,7 +243,7 @@ describe('PUT /user/personality/:slug (update)', () => {
         })
       );
 
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:slug');
       const { req, res } = createMockReqRes(
         { name: 'NewName' }, // Only name, no displayName
@@ -274,7 +274,7 @@ describe('PUT /user/personality/:slug (update)', () => {
         })
       );
 
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:slug');
       const { req, res } = createMockReqRes(
         { displayName: 'Custom Display Name' },
@@ -303,7 +303,7 @@ describe('PUT /user/personality/:slug (update)', () => {
         })
       );
 
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:slug');
       const { req, res } = createMockReqRes(
         { displayName: '' }, // Explicitly empty
@@ -354,7 +354,7 @@ describe('PUT /user/personality/:slug (update)', () => {
       );
       mockUnlink.mockResolvedValue(undefined);
 
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:slug');
       const { req, res } = createMockReqRes(
         { name: 'Updated', avatarData: 'data:image/png;base64,iVBORw0KGgo=' },
@@ -376,7 +376,7 @@ describe('PUT /user/personality/:slug (update)', () => {
         throw enoentError;
       });
 
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:slug');
       const { req, res } = createMockReqRes(
         { name: 'Updated', avatarData: 'data:image/png;base64,iVBORw0KGgo=' },
@@ -396,7 +396,7 @@ describe('PUT /user/personality/:slug (update)', () => {
       enoentError.code = 'ENOENT';
       mockUnlink.mockRejectedValue(enoentError);
 
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:slug');
       const { req, res } = createMockReqRes(
         { name: 'Updated', avatarData: 'data:image/png;base64,iVBORw0KGgo=' },
@@ -417,7 +417,7 @@ describe('PUT /user/personality/:slug (update)', () => {
         throw permError;
       });
 
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:slug');
       const { req, res } = createMockReqRes(
         { name: 'Updated', avatarData: 'data:image/png;base64,iVBORw0KGgo=' },
@@ -440,7 +440,7 @@ describe('PUT /user/personality/:slug (update)', () => {
         avatarData: null,
       });
 
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:slug');
       const { req, res } = createMockReqRes(
         { name: 'Updated', avatarData: 'data:image/png;base64,iVBORw0KGgo=' },
@@ -480,10 +480,10 @@ describe('PUT /user/personality/:slug (update)', () => {
         invalidatePersonality: vi.fn().mockResolvedValue(undefined),
       } as unknown as import('@tzurot/common-types').CacheInvalidationService;
 
-      const router = createPersonalityRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockCacheInvalidationService
-      );
+      const router = createPersonalityRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        cacheInvalidationService: mockCacheInvalidationService,
+      });
       const handler = getHandler(router, 'put', '/:slug');
       const { req, res } = createMockReqRes(
         { avatarData: 'data:image/png;base64,iVBORw0KGgo=' },
@@ -503,10 +503,10 @@ describe('PUT /user/personality/:slug (update)', () => {
         invalidatePersonality: vi.fn().mockRejectedValue(new Error('Cache service unavailable')),
       } as unknown as import('@tzurot/common-types').CacheInvalidationService;
 
-      const router = createPersonalityRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockCacheInvalidationService
-      );
+      const router = createPersonalityRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        cacheInvalidationService: mockCacheInvalidationService,
+      });
       const handler = getHandler(router, 'put', '/:slug');
       const { req, res } = createMockReqRes(
         { avatarData: 'data:image/png;base64,iVBORw0KGgo=' },
@@ -525,10 +525,10 @@ describe('PUT /user/personality/:slug (update)', () => {
         invalidatePersonality: vi.fn().mockResolvedValue(undefined),
       } as unknown as import('@tzurot/common-types').CacheInvalidationService;
 
-      const router = createPersonalityRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockCacheInvalidationService
-      );
+      const router = createPersonalityRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        cacheInvalidationService: mockCacheInvalidationService,
+      });
       const handler = getHandler(router, 'put', '/:slug');
       const { req, res } = createMockReqRes(
         { name: 'Updated Name' }, // No avatar update
@@ -561,7 +561,7 @@ describe('PUT /user/personality/:slug (update)', () => {
     });
 
     it('should return error for invalid voice reference data URI', async () => {
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:slug');
       const { req, res } = createMockReqRes(
         { voiceReferenceData: 'not-a-data-uri' },
@@ -575,7 +575,7 @@ describe('PUT /user/personality/:slug (update)', () => {
     });
 
     it('should return error for unsupported voice reference MIME type', async () => {
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:slug');
       const { req, res } = createMockReqRes(
         { voiceReferenceData: 'data:image/png;base64,iVBORw0KGgo=' },
@@ -599,7 +599,7 @@ describe('PUT /user/personality/:slug (update)', () => {
         })
       );
 
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:slug');
       const { req, res } = createMockReqRes({ voiceReferenceData: null }, { slug: 'test-char' });
 
@@ -633,7 +633,7 @@ describe('PUT /user/personality/:slug (update)', () => {
         })
       );
 
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:slug');
       const { req, res } = createMockReqRes(
         { name: 'Updated' }, // No voiceReferenceData field
@@ -668,7 +668,7 @@ describe('PUT /user/personality/:slug (update)', () => {
       const base64 = audioBytes.toString('base64');
       const dataUri = `data:audio/wav;base64,${base64}`;
 
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:slug');
       const { req, res } = createMockReqRes({ voiceReferenceData: dataUri }, { slug: 'test-char' });
 
@@ -706,7 +706,7 @@ describe('PUT /user/personality/:slug (update)', () => {
     it('should reject slug update from non-admin user', async () => {
       mockIsBotOwner.mockReturnValue(false);
 
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:slug');
       const { req, res } = createMockReqRes(
         { slug: 'new-slug' }, // Attempting to change slug
@@ -745,7 +745,7 @@ describe('PUT /user/personality/:slug (update)', () => {
         })
       );
 
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:slug');
       const { req, res } = createMockReqRes({ slug: 'new-slug' }, { slug: 'old-slug' });
 
@@ -796,10 +796,10 @@ describe('PUT /user/personality/:slug (update)', () => {
         invalidatePersonality: vi.fn().mockResolvedValue(undefined),
       } as unknown as import('@tzurot/common-types').CacheInvalidationService;
 
-      const router = createPersonalityRoutes(
-        mockPrisma as unknown as PrismaClient,
-        mockCacheInvalidationService
-      );
+      const router = createPersonalityRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        cacheInvalidationService: mockCacheInvalidationService,
+      });
       const handler = getHandler(router, 'put', '/:slug');
       const { req, res } = createMockReqRes({ slug: 'new-slug' }, { slug: 'old-slug' });
 
@@ -819,7 +819,7 @@ describe('PUT /user/personality/:slug (update)', () => {
     it('should reject invalid slug format', async () => {
       mockIsBotOwner.mockReturnValue(true);
 
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:slug');
       const { req, res } = createMockReqRes(
         { slug: 'Invalid Slug With Spaces!' }, // Invalid format
@@ -849,7 +849,7 @@ describe('PUT /user/personality/:slug (update)', () => {
         })
         .mockResolvedValueOnce({ id: 'other-personality' }); // Another personality has this slug
 
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:slug');
       const { req, res } = createMockReqRes({ slug: 'taken-slug' }, { slug: 'old-slug' });
 
@@ -876,7 +876,7 @@ describe('PUT /user/personality/:slug (update)', () => {
         })
       );
 
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:slug');
       const { req, res } = createMockReqRes(
         { name: 'Updated Name', slug: 'same-slug' }, // Same slug as URL param
@@ -892,7 +892,7 @@ describe('PUT /user/personality/:slug (update)', () => {
     it('should reject reserved slug names', async () => {
       mockIsBotOwner.mockReturnValue(true);
 
-      const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/:slug');
       const { req, res } = createMockReqRes(
         { slug: 'admin' }, // Reserved slug

--- a/services/api-gateway/src/routes/user/personality/update.ts
+++ b/services/api-gateway/src/routes/user/personality/update.ts
@@ -28,6 +28,7 @@ import type { ProvisionedRequest } from '../../../types.js';
 import { getParam } from '../../../utils/requestParams.js';
 import { resolvePersonalityForEdit } from './helpers.js';
 import { formatPersonalityResponse } from './formatters.js';
+import type { RouteDeps } from '../../routeDeps.js';
 
 const logger = createLogger('user-personality-update');
 
@@ -276,15 +277,15 @@ function createHandler(prisma: PrismaClient, cacheInvalidationService?: CacheInv
   };
 }
 
-// --- Route Factory ---
+// --- Handler factory + route chain ---
 
-export function createUpdateHandler(
-  prisma: PrismaClient,
-  cacheInvalidationService?: CacheInvalidationService
-): RequestHandler[] {
+export const handleUpdateUserPersonality = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createHandler(deps.prisma, deps.cacheInvalidationService));
+
+export function createUpdateHandler(deps: RouteDeps): RequestHandler[] {
   return [
     requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(createHandler(prisma, cacheInvalidationService)),
+    requireProvisionedUser(deps.prisma),
+    handleUpdateUserPersonality(deps),
   ];
 }

--- a/services/api-gateway/src/routes/user/personality/visibility.test.ts
+++ b/services/api-gateway/src/routes/user/personality/visibility.test.ts
@@ -47,7 +47,7 @@ describe('PATCH /user/personality/:slug/visibility', () => {
   });
 
   it('should reject missing isPublic', async () => {
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'patch', '/:slug/visibility');
     const { req, res } = createMockReqRes({}, { slug: 'test-char' });
 
@@ -59,7 +59,7 @@ describe('PATCH /user/personality/:slug/visibility', () => {
   it('should return 404 when personality not found', async () => {
     mockPrisma.personality.findUnique.mockResolvedValue(null);
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'patch', '/:slug/visibility');
     const { req, res } = createMockReqRes({ isPublic: true }, { slug: 'nonexistent' });
 
@@ -75,7 +75,7 @@ describe('PATCH /user/personality/:slug/visibility', () => {
       isPublic: false,
     });
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'patch', '/:slug/visibility');
     const { req, res } = createMockReqRes({ isPublic: true }, { slug: 'not-mine' });
 
@@ -96,7 +96,7 @@ describe('PATCH /user/personality/:slug/visibility', () => {
       isPublic: true,
     });
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'patch', '/:slug/visibility');
     const { req, res } = createMockReqRes({ isPublic: true }, { slug: 'my-char' });
 
@@ -130,7 +130,7 @@ describe('PATCH /user/personality/:slug/visibility', () => {
       isPublic: false,
     });
 
-    const router = createPersonalityRoutes(mockPrisma as unknown as PrismaClient);
+    const router = createPersonalityRoutes({ prisma: mockPrisma as unknown as PrismaClient });
     const handler = getHandler(router, 'patch', '/:slug/visibility');
     const { req, res } = createMockReqRes({ isPublic: false }, { slug: 'my-char' });
 

--- a/services/api-gateway/src/routes/user/personality/visibility.ts
+++ b/services/api-gateway/src/routes/user/personality/visibility.ts
@@ -5,7 +5,7 @@
 
 import { type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
-import { createLogger, type PrismaClient, SetVisibilitySchema } from '@tzurot/common-types';
+import { createLogger, SetVisibilitySchema } from '@tzurot/common-types';
 import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendCustomSuccess, sendError } from '../../../utils/responseHelpers.js';
@@ -14,15 +14,16 @@ import { sendZodError } from '../../../utils/zodHelpers.js';
 import type { ProvisionedRequest } from '../../../types.js';
 import { getParam } from '../../../utils/requestParams.js';
 import { resolvePersonalityForEdit } from './helpers.js';
+import type { RouteDeps } from '../../routeDeps.js';
 
 const logger = createLogger('user-personality-visibility');
 
 /**
- * Create handler for PATCH /user/personality/:slug/visibility
- * Toggle visibility of an owned personality
+ * PATCH /api/user/personality/:slug/visibility — toggle visibility.
  */
-export function createVisibilityHandler(prisma: PrismaClient): RequestHandler[] {
-  const handler = asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+export const handleSetPersonalityVisibility = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
     const discordUserId = req.userId;
     const slug = getParam(req.params.slug);
     if (slug === undefined || slug === '') {
@@ -80,6 +81,12 @@ export function createVisibilityHandler(prisma: PrismaClient): RequestHandler[] 
       StatusCodes.OK
     );
   });
+};
 
-  return [requireUserAuth(), requireProvisionedUser(prisma), handler];
+export function createVisibilityHandler(deps: RouteDeps): RequestHandler[] {
+  return [
+    requireUserAuth(),
+    requireProvisionedUser(deps.prisma),
+    handleSetPersonalityVisibility(deps),
+  ];
 }

--- a/services/api-gateway/src/routes/user/shapes/index.ts
+++ b/services/api-gateway/src/routes/user/shapes/index.ts
@@ -13,8 +13,8 @@
  */
 
 import { Router } from 'express';
-import type { Queue } from 'bullmq';
-import { createLogger, type PrismaClient } from '@tzurot/common-types';
+import { createLogger } from '@tzurot/common-types';
+import type { RouteDeps } from '../../routeDeps.js';
 import { createShapesAuthRoutes } from './auth.js';
 import { createShapesListRoutes } from './list.js';
 import { createShapesImportRoutes } from './import.js';
@@ -22,15 +22,16 @@ import { createShapesExportRoutes } from './export.js';
 
 const logger = createLogger('shapes-routes');
 
-export function createShapesRoutes(prisma: PrismaClient, queue?: Queue): Router {
+export function createShapesRoutes(deps: RouteDeps): Router {
   const router = Router();
+  const { prisma, aiQueue } = deps;
 
   router.use('/auth', createShapesAuthRoutes(prisma));
   router.use('/list', createShapesListRoutes(prisma));
 
-  if (queue !== undefined) {
-    router.use('/import', createShapesImportRoutes(prisma, queue));
-    router.use('/export', createShapesExportRoutes(prisma, queue));
+  if (aiQueue !== undefined) {
+    router.use('/import', createShapesImportRoutes(prisma, aiQueue));
+    router.use('/export', createShapesExportRoutes(prisma, aiQueue));
   } else {
     logger.warn('BullMQ queue unavailable — /import and /export routes disabled');
   }

--- a/services/api-gateway/src/routes/user/stt-override.test.ts
+++ b/services/api-gateway/src/routes/user/stt-override.test.ts
@@ -90,7 +90,10 @@ const mockPrisma = {
 const mockCache = { invalidateUserStt: vi.fn().mockResolvedValue(undefined) };
 
 function buildRouter() {
-  return createSttOverrideRoutes(mockPrisma as never, mockCache as never);
+  return createSttOverrideRoutes({
+    prisma: mockPrisma as never,
+    sttResolverCacheInvalidation: mockCache as never,
+  });
 }
 
 describe('user/stt-override routes', () => {

--- a/services/api-gateway/src/routes/user/stt-override.ts
+++ b/services/api-gateway/src/routes/user/stt-override.ts
@@ -13,12 +13,10 @@
  *   DELETE /user/stt-override — clear
  */
 
-import { Router, type Response } from 'express';
+import { Router, type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import {
   createLogger,
-  type PrismaClient,
-  type SttResolverCacheInvalidationService,
   type UserDefaultSttProvider,
   SetSttDefaultProviderSchema,
   isSttProvider,
@@ -31,113 +29,118 @@ import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
 import { sendZodError } from '../../utils/zodHelpers.js';
 import type { ProvisionedRequest } from '../../types.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('user-stt-override');
 
-export function createSttOverrideRoutes(
-  prisma: PrismaClient,
-  sttCacheInvalidation?: SttResolverCacheInvalidationService
-): Router {
+/** GET /api/user/stt-override — read user's STT preference */
+export const handleGetSttOverride = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const discordUserId = req.userId;
+    const userId = resolveProvisionedUserId(req);
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { defaultSttProviderId: true },
+    });
+
+    // Defensive narrowing: DB column has no CHECK constraint, so legacy
+    // rows or out-of-band SQL inserts could carry an unrecognized provider
+    // string. Mirror SttResolver.narrow() — surface unknown values as null.
+    const raw = user?.defaultSttProviderId ?? null;
+    const result: UserDefaultSttProvider = {
+      providerId: raw !== null && isSttProvider(raw) ? raw : null,
+    };
+
+    logger.info({ discordUserId, providerId: result.providerId }, 'Got STT preference');
+    sendCustomSuccess(res, { default: result }, StatusCodes.OK);
+  });
+};
+
+/** PUT /api/user/stt-override — set the user's STT preference */
+export const handleSetSttOverride = (deps: RouteDeps): RequestHandler => {
+  const { prisma, sttResolverCacheInvalidation } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const discordUserId = req.userId;
+
+    const parseResult = SetSttDefaultProviderSchema.safeParse(req.body);
+    if (!parseResult.success) {
+      return sendZodError(res, parseResult.error);
+    }
+    const { providerId } = parseResult.data;
+    const userId = resolveProvisionedUserId(req);
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: { defaultSttProviderId: providerId },
+    });
+
+    const result: UserDefaultSttProvider = { providerId };
+
+    logger.info({ discordUserId, providerId }, 'Set STT preference');
+
+    await tryInvalidateCache(
+      sttResolverCacheInvalidation?.invalidateUserStt.bind(
+        sttResolverCacheInvalidation,
+        discordUserId
+      ),
+      { discordUserId }
+    );
+
+    sendCustomSuccess(res, { default: result }, StatusCodes.OK);
+  });
+};
+
+/** DELETE /api/user/stt-override — clear the user's STT preference */
+export const handleClearSttOverride = (deps: RouteDeps): RequestHandler => {
+  const { prisma, sttResolverCacheInvalidation } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const discordUserId = req.userId;
+    const userId = resolveProvisionedUserId(req);
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { defaultSttProviderId: true },
+    });
+    if (user === null) {
+      return sendError(res, ErrorResponses.notFound('User'));
+    }
+
+    if (user.defaultSttProviderId === null) {
+      logger.info(
+        { discordUserId, hadDefault: false },
+        'Clear called but no STT preference was set (idempotent success)'
+      );
+      return sendCustomSuccess(res, { deleted: true, wasSet: false }, StatusCodes.OK);
+    }
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: { defaultSttProviderId: null },
+    });
+
+    logger.info({ discordUserId }, 'Cleared STT preference');
+
+    await tryInvalidateCache(
+      sttResolverCacheInvalidation?.invalidateUserStt.bind(
+        sttResolverCacheInvalidation,
+        discordUserId
+      ),
+      { discordUserId }
+    );
+
+    sendCustomSuccess(res, { deleted: true, wasSet: true }, StatusCodes.OK);
+  });
+};
+
+export function createSttOverrideRoutes(deps: RouteDeps): Router {
   const router = Router();
+  const requireProvisioned = requireProvisionedUser(deps.prisma);
 
-  router.get(
-    '/',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const discordUserId = req.userId;
-      const userId = resolveProvisionedUserId(req);
-
-      const user = await prisma.user.findUnique({
-        where: { id: userId },
-        select: { defaultSttProviderId: true },
-      });
-
-      // Defensive narrowing: DB column has no CHECK constraint, so legacy
-      // rows or out-of-band SQL inserts could carry an unrecognized provider
-      // string. Mirror SttResolver.narrow() — surface unknown values as null.
-      const raw = user?.defaultSttProviderId ?? null;
-      const result: UserDefaultSttProvider = {
-        providerId: raw !== null && isSttProvider(raw) ? raw : null,
-      };
-
-      logger.info({ discordUserId, providerId: result.providerId }, 'Got STT preference');
-      sendCustomSuccess(res, { default: result }, StatusCodes.OK);
-    })
-  );
-
-  router.put(
-    '/',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const discordUserId = req.userId;
-
-      const parseResult = SetSttDefaultProviderSchema.safeParse(req.body);
-      if (!parseResult.success) {
-        return sendZodError(res, parseResult.error);
-      }
-      const { providerId } = parseResult.data;
-      const userId = resolveProvisionedUserId(req);
-
-      await prisma.user.update({
-        where: { id: userId },
-        data: { defaultSttProviderId: providerId },
-      });
-
-      const result: UserDefaultSttProvider = { providerId };
-
-      logger.info({ discordUserId, providerId }, 'Set STT preference');
-
-      await tryInvalidateCache(
-        sttCacheInvalidation?.invalidateUserStt.bind(sttCacheInvalidation, discordUserId),
-        { discordUserId }
-      );
-
-      sendCustomSuccess(res, { default: result }, StatusCodes.OK);
-    })
-  );
-
-  router.delete(
-    '/',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const discordUserId = req.userId;
-      const userId = resolveProvisionedUserId(req);
-
-      const user = await prisma.user.findUnique({
-        where: { id: userId },
-        select: { defaultSttProviderId: true },
-      });
-      if (user === null) {
-        return sendError(res, ErrorResponses.notFound('User'));
-      }
-
-      // Idempotent: nothing set → wasSet:false success
-      if (user.defaultSttProviderId === null) {
-        logger.info(
-          { discordUserId, hadDefault: false },
-          'Clear called but no STT preference was set (idempotent success)'
-        );
-        return sendCustomSuccess(res, { deleted: true, wasSet: false }, StatusCodes.OK);
-      }
-
-      await prisma.user.update({
-        where: { id: userId },
-        data: { defaultSttProviderId: null },
-      });
-
-      logger.info({ discordUserId }, 'Cleared STT preference');
-
-      await tryInvalidateCache(
-        sttCacheInvalidation?.invalidateUserStt.bind(sttCacheInvalidation, discordUserId),
-        { discordUserId }
-      );
-
-      sendCustomSuccess(res, { deleted: true, wasSet: true }, StatusCodes.OK);
-    })
-  );
+  router.get('/', requireUserAuth(), requireProvisioned, handleGetSttOverride(deps));
+  router.put('/', requireUserAuth(), requireProvisioned, handleSetSttOverride(deps));
+  router.delete('/', requireUserAuth(), requireProvisioned, handleClearSttOverride(deps));
 
   return router;
 }

--- a/services/api-gateway/src/routes/user/timezone.test.ts
+++ b/services/api-gateway/src/routes/user/timezone.test.ts
@@ -104,14 +104,14 @@ describe('/user/timezone routes', () => {
 
   describe('route factory', () => {
     it('should create a router', () => {
-      const router = createTimezoneRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createTimezoneRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(router).toBeDefined();
       expect(typeof router).toBe('function');
     });
 
     it('should have GET route registered', () => {
-      const router = createTimezoneRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createTimezoneRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(router.stack).toBeDefined();
       expect(router.stack.length).toBeGreaterThan(0);
@@ -120,7 +120,7 @@ describe('/user/timezone routes', () => {
     });
 
     it('should have PUT route registered', () => {
-      const router = createTimezoneRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createTimezoneRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(findRoute(router, 'put', '/')).toBeDefined();
     });
@@ -134,7 +134,7 @@ describe('/user/timezone routes', () => {
     it('should return 404 when user row is missing', async () => {
       mockPrisma.user.findUnique.mockResolvedValueOnce(null);
 
-      const router = createTimezoneRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createTimezoneRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/');
       const { req, res } = createMockReqRes();
 
@@ -146,7 +146,7 @@ describe('/user/timezone routes', () => {
     it('should return user timezone', async () => {
       mockPrisma.user.findUnique.mockResolvedValueOnce({ timezone: 'America/New_York' });
 
-      const router = createTimezoneRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createTimezoneRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/');
       const { req, res } = createMockReqRes();
 
@@ -164,7 +164,7 @@ describe('/user/timezone routes', () => {
     it('should return isDefault=true for UTC timezone', async () => {
       mockPrisma.user.findUnique.mockResolvedValueOnce({ timezone: 'UTC' });
 
-      const router = createTimezoneRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createTimezoneRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/');
       const { req, res } = createMockReqRes();
 
@@ -181,7 +181,7 @@ describe('/user/timezone routes', () => {
     it('should query user timezone by internal UUID', async () => {
       mockPrisma.user.findUnique.mockResolvedValueOnce({ timezone: 'UTC' });
 
-      const router = createTimezoneRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createTimezoneRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/');
       const { req, res } = createMockReqRes();
 
@@ -196,7 +196,7 @@ describe('/user/timezone routes', () => {
 
   describe('PUT /user/timezone', () => {
     it('should reject missing timezone', async () => {
-      const router = createTimezoneRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createTimezoneRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/');
       const { req, res } = createMockReqRes({});
 
@@ -212,7 +212,7 @@ describe('/user/timezone routes', () => {
     });
 
     it('should reject null timezone', async () => {
-      const router = createTimezoneRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createTimezoneRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/');
       const { req, res } = createMockReqRes({ timezone: null });
 
@@ -222,7 +222,7 @@ describe('/user/timezone routes', () => {
     });
 
     it('should reject empty timezone', async () => {
-      const router = createTimezoneRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createTimezoneRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/');
       const { req, res } = createMockReqRes({ timezone: '' });
 
@@ -232,7 +232,7 @@ describe('/user/timezone routes', () => {
     });
 
     it('should reject invalid timezone', async () => {
-      const router = createTimezoneRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createTimezoneRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/');
       const { req, res } = createMockReqRes({ timezone: 'Invalid/Timezone' });
 
@@ -247,7 +247,7 @@ describe('/user/timezone routes', () => {
     });
 
     it('should accept valid IANA timezone', async () => {
-      const router = createTimezoneRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createTimezoneRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/');
       const { req, res } = createMockReqRes({ timezone: 'America/New_York' });
 
@@ -263,7 +263,7 @@ describe('/user/timezone routes', () => {
     });
 
     it('should accept UTC timezone', async () => {
-      const router = createTimezoneRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createTimezoneRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/');
       const { req, res } = createMockReqRes({ timezone: 'UTC' });
 
@@ -279,7 +279,7 @@ describe('/user/timezone routes', () => {
     });
 
     it('should return timezone info in response', async () => {
-      const router = createTimezoneRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createTimezoneRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'put', '/');
       const { req, res } = createMockReqRes({ timezone: 'America/Los_Angeles' });
 

--- a/services/api-gateway/src/routes/user/timezone.ts
+++ b/services/api-gateway/src/routes/user/timezone.ts
@@ -4,11 +4,10 @@
  * PUT /user/timezone - Set timezone
  */
 
-import { Router, type Response } from 'express';
+import { Router, type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import {
   createLogger,
-  type PrismaClient,
   isValidTimezone,
   getTimezoneInfo,
   SetTimezoneInputSchema,
@@ -20,96 +19,83 @@ import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
 import { sendZodError } from '../../utils/zodHelpers.js';
 import type { ProvisionedRequest } from '../../types.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('user-timezone');
 
-export function createTimezoneRoutes(prisma: PrismaClient): Router {
+/** GET /api/user/timezone — fetch current user's timezone */
+export const handleGetTimezone = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const userId = resolveProvisionedUserId(req);
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { timezone: true },
+    });
+
+    if (user === null) {
+      return sendError(res, ErrorResponses.notFound('User'));
+    }
+
+    sendCustomSuccess(
+      res,
+      {
+        timezone: user.timezone,
+        isDefault: user.timezone === 'UTC',
+      },
+      StatusCodes.OK
+    );
+  });
+};
+
+/** PUT /api/user/timezone — set the current user's timezone */
+export const handleSetTimezone = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const discordUserId = req.userId;
+
+    const parseResult = SetTimezoneInputSchema.safeParse(req.body);
+    if (!parseResult.success) {
+      return sendZodError(res, parseResult.error);
+    }
+
+    const { timezone } = parseResult.data;
+
+    if (!isValidTimezone(timezone)) {
+      return sendError(
+        res,
+        ErrorResponses.validationError(`Invalid timezone: ${timezone}. Use a valid IANA timezone.`)
+      );
+    }
+
+    logger.info({ discordUserId, timezone }, 'Setting user timezone');
+
+    const userId = resolveProvisionedUserId(req);
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: { timezone },
+    });
+
+    const tzInfo = getTimezoneInfo(timezone);
+
+    sendCustomSuccess(
+      res,
+      {
+        success: true,
+        timezone,
+        label: tzInfo?.label ?? timezone,
+        offset: tzInfo?.offset ?? 'Unknown',
+      },
+      StatusCodes.OK
+    );
+  });
+};
+
+export function createTimezoneRoutes(deps: RouteDeps): Router {
   const router = Router();
-
-  /**
-   * GET /user/timezone
-   * Get current user's timezone
-   */
-  router.get(
-    '/',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const userId = resolveProvisionedUserId(req);
-
-      const user = await prisma.user.findUnique({
-        where: { id: userId },
-        select: { timezone: true },
-      });
-
-      if (user === null) {
-        return sendError(res, ErrorResponses.notFound('User'));
-      }
-
-      sendCustomSuccess(
-        res,
-        {
-          timezone: user.timezone,
-          isDefault: user.timezone === 'UTC',
-        },
-        StatusCodes.OK
-      );
-    })
-  );
-
-  /**
-   * PUT /user/timezone
-   * Set user's timezone
-   */
-  router.put(
-    '/',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const discordUserId = req.userId;
-
-      const parseResult = SetTimezoneInputSchema.safeParse(req.body);
-      if (!parseResult.success) {
-        return sendZodError(res, parseResult.error);
-      }
-
-      const { timezone } = parseResult.data;
-
-      // Validate timezone
-      if (!isValidTimezone(timezone)) {
-        return sendError(
-          res,
-          ErrorResponses.validationError(
-            `Invalid timezone: ${timezone}. Use a valid IANA timezone.`
-          )
-        );
-      }
-
-      logger.info({ discordUserId, timezone }, 'Setting user timezone');
-
-      const userId = resolveProvisionedUserId(req);
-
-      // Update the timezone
-      await prisma.user.update({
-        where: { id: userId },
-        data: { timezone },
-      });
-
-      // Find the label for the timezone
-      const tzInfo = getTimezoneInfo(timezone);
-
-      sendCustomSuccess(
-        res,
-        {
-          success: true,
-          timezone,
-          label: tzInfo?.label ?? timezone,
-          offset: tzInfo?.offset ?? 'Unknown',
-        },
-        StatusCodes.OK
-      );
-    })
-  );
-
+  router.get('/', requireUserAuth(), requireProvisionedUser(deps.prisma), handleGetTimezone(deps));
+  router.put('/', requireUserAuth(), requireProvisionedUser(deps.prisma), handleSetTimezone(deps));
   return router;
 }

--- a/services/api-gateway/src/routes/user/tts-config.ts
+++ b/services/api-gateway/src/routes/user/tts-config.ts
@@ -21,14 +21,12 @@
  * filed as a follow-up rather than introduced in PR 3b.
  */
 
-import { Router, type Response } from 'express';
+import { Router, type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import {
   createLogger,
   isBotOwner,
-  type PrismaClient,
   type TtsConfigSummary,
-  type TtsConfigCacheInvalidationService,
   type TtsProviderId,
   computeLlmConfigPermissions,
   TtsConfigCreateSchema,
@@ -59,6 +57,7 @@ import {
   TtsInvalidProviderError,
   type TtsConfigScope,
 } from '../../services/TtsConfigService.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('user-tts-config');
 
@@ -360,45 +359,38 @@ function createDeleteHandler(service: TtsConfigService) {
   };
 }
 
+// --- Exported handler factories --------------------------------------------
+
+function buildService(deps: RouteDeps): TtsConfigService {
+  return new TtsConfigService(deps.prisma, deps.ttsConfigCacheInvalidation);
+}
+
+export const handleListUserTtsConfigs = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createListHandler(buildService(deps)));
+
+export const handleGetUserTtsConfig = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createGetHandler(buildService(deps)));
+
+export const handleCreateUserTtsConfig = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createCreateHandler(buildService(deps)));
+
+export const handleUpdateUserTtsConfig = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createUpdateHandler(buildService(deps)));
+
+export const handleDeleteUserTtsConfig = (deps: RouteDeps): RequestHandler =>
+  asyncHandler(createDeleteHandler(buildService(deps)));
+
 // --- Main route factory ----------------------------------------------------
 
-export function createTtsConfigRoutes(
-  prisma: PrismaClient,
-  ttsConfigCacheInvalidation?: TtsConfigCacheInvalidationService
-): Router {
+export function createTtsConfigRoutes(deps: RouteDeps): Router {
   const router = Router();
-  const service = new TtsConfigService(prisma, ttsConfigCacheInvalidation);
+  const requireProvisioned = requireProvisionedUser(deps.prisma);
 
-  router.get(
-    '/',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(createListHandler(service))
-  );
-  router.get(
-    '/:id',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(createGetHandler(service))
-  );
-  router.post(
-    '/',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(createCreateHandler(service))
-  );
-  router.put(
-    '/:id',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(createUpdateHandler(service))
-  );
-  router.delete(
-    '/:id',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(createDeleteHandler(service))
-  );
+  router.get('/', requireUserAuth(), requireProvisioned, handleListUserTtsConfigs(deps));
+  router.get('/:id', requireUserAuth(), requireProvisioned, handleGetUserTtsConfig(deps));
+  router.post('/', requireUserAuth(), requireProvisioned, handleCreateUserTtsConfig(deps));
+  router.put('/:id', requireUserAuth(), requireProvisioned, handleUpdateUserTtsConfig(deps));
+  router.delete('/:id', requireUserAuth(), requireProvisioned, handleDeleteUserTtsConfig(deps));
 
   return router;
 }

--- a/services/api-gateway/src/routes/user/tts-override.test.ts
+++ b/services/api-gateway/src/routes/user/tts-override.test.ts
@@ -110,7 +110,10 @@ const mockCache = {
 };
 
 function buildRouter() {
-  return createTtsOverrideRoutes(mockPrisma as never, mockCache as never);
+  return createTtsOverrideRoutes({
+    prisma: mockPrisma as never,
+    ttsConfigCacheInvalidation: mockCache as never,
+  });
 }
 
 const VALID_UUID_A = '11111111-1111-4111-8111-111111111111';

--- a/services/api-gateway/src/routes/user/tts-override.ts
+++ b/services/api-gateway/src/routes/user/tts-override.ts
@@ -15,14 +15,13 @@
  * and `User.defaultTtsConfigId` instead of the LLM equivalents.
  */
 
-import { Router, type Response } from 'express';
+import { Router, type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import {
   createLogger,
   generateUserPersonalityConfigUuid,
   type PrismaClient,
   type TtsOverrideSummary,
-  type TtsConfigCacheInvalidationService,
   type UserDefaultTtsConfig,
   SetTtsOverrideSchema,
   SetTtsDefaultConfigSchema,
@@ -36,6 +35,7 @@ import { ErrorResponses } from '../../utils/errorResponses.js';
 import { sendZodError } from '../../utils/zodHelpers.js';
 import { getParam } from '../../utils/requestParams.js';
 import type { ProvisionedRequest } from '../../types.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('user-tts-override');
 
@@ -57,319 +57,297 @@ async function verifyTtsConfigAccess(
   });
 }
 
-// eslint-disable-next-line max-lines-per-function -- Route factory with multiple endpoints (mirrors model-override.ts shape)
-export function createTtsOverrideRoutes(
-  prisma: PrismaClient,
-  ttsConfigCacheInvalidation?: TtsConfigCacheInvalidationService
-): Router {
-  const router = Router();
+/** GET /api/user/tts-override — list all user TTS overrides */
+export const handleListTtsOverrides = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const discordUserId = req.userId;
+    const userId = resolveProvisionedUserId(req);
 
-  /** GET /user/tts-override — list all user TTS overrides */
-  router.get(
-    '/',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const discordUserId = req.userId;
-      const userId = resolveProvisionedUserId(req);
+    const overrides = await prisma.userPersonalityConfig.findMany({
+      where: {
+        userId,
+        ttsConfigId: { not: null },
+      },
+      select: {
+        personalityId: true,
+        personality: { select: { name: true } },
+        ttsConfigId: true,
+        ttsConfig: { select: { name: true } },
+      },
+      take: 100,
+    });
 
-      const overrides = await prisma.userPersonalityConfig.findMany({
-        where: {
-          userId,
-          ttsConfigId: { not: null },
-        },
-        select: {
-          personalityId: true,
-          personality: { select: { name: true } },
-          ttsConfigId: true,
-          ttsConfig: { select: { name: true } },
-        },
-        take: 100,
-      });
+    const result: TtsOverrideSummary[] = overrides.map(o => ({
+      personalityId: o.personalityId,
+      personalityName: o.personality.name,
+      configId: o.ttsConfigId,
+      configName: o.ttsConfig?.name ?? null,
+    }));
 
-      const result: TtsOverrideSummary[] = overrides.map(o => ({
-        personalityId: o.personalityId,
-        personalityName: o.personality.name,
-        configId: o.ttsConfigId,
-        configName: o.ttsConfig?.name ?? null,
-      }));
+    logger.info({ discordUserId, count: result.length }, 'Listed TTS overrides');
+    sendCustomSuccess(res, { overrides: result }, StatusCodes.OK);
+  });
+};
 
-      logger.info({ discordUserId, count: result.length }, 'Listed TTS overrides');
-      sendCustomSuccess(res, { overrides: result }, StatusCodes.OK);
-    })
-  );
+/** PUT /api/user/tts-override — set TTS override for a personality */
+export const handleSetTtsOverride = (deps: RouteDeps): RequestHandler => {
+  const { prisma, ttsConfigCacheInvalidation } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const discordUserId = req.userId;
 
-  /** PUT /user/tts-override — set TTS override for a personality */
-  router.put(
-    '/',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const discordUserId = req.userId;
+    const parseResult = SetTtsOverrideSchema.safeParse(req.body);
+    if (!parseResult.success) {
+      return sendZodError(res, parseResult.error);
+    }
+    const { personalityId, configId } = parseResult.data;
 
-      const parseResult = SetTtsOverrideSchema.safeParse(req.body);
-      if (!parseResult.success) {
-        return sendZodError(res, parseResult.error);
-      }
-      const { personalityId, configId } = parseResult.data;
+    const userId = resolveProvisionedUserId(req);
 
-      const userId = resolveProvisionedUserId(req);
+    const personality = await prisma.personality.findFirst({
+      where: { id: personalityId },
+      select: { id: true, name: true },
+    });
+    if (personality === null) {
+      return sendError(res, ErrorResponses.notFound('Personality'));
+    }
 
-      const personality = await prisma.personality.findFirst({
-        where: { id: personalityId },
-        select: { id: true, name: true },
-      });
-      if (personality === null) {
-        return sendError(res, ErrorResponses.notFound('Personality'));
-      }
+    const ttsConfig = await verifyTtsConfigAccess(prisma, configId, userId);
+    if (ttsConfig === null) {
+      return sendError(res, ErrorResponses.notFound('TtsConfig'));
+    }
 
-      const ttsConfig = await verifyTtsConfigAccess(prisma, configId, userId);
-      if (ttsConfig === null) {
-        return sendError(res, ErrorResponses.notFound('TtsConfig'));
-      }
+    const override = await prisma.userPersonalityConfig.upsert({
+      where: {
+        userId_personalityId: { userId, personalityId },
+      },
+      create: {
+        id: generateUserPersonalityConfigUuid(userId, personalityId),
+        userId,
+        personalityId,
+        ttsConfigId: configId,
+      },
+      update: {
+        ttsConfigId: configId,
+      },
+      select: {
+        personalityId: true,
+        personality: { select: { name: true } },
+        ttsConfigId: true,
+        ttsConfig: { select: { name: true } },
+      },
+    });
 
-      const override = await prisma.userPersonalityConfig.upsert({
-        where: {
-          userId_personalityId: { userId, personalityId },
-        },
-        create: {
-          id: generateUserPersonalityConfigUuid(userId, personalityId),
-          userId,
-          personalityId,
-          ttsConfigId: configId,
-        },
-        update: {
-          ttsConfigId: configId,
-        },
-        select: {
-          personalityId: true,
-          personality: { select: { name: true } },
-          ttsConfigId: true,
-          ttsConfig: { select: { name: true } },
-        },
-      });
+    const result: TtsOverrideSummary = {
+      personalityId: override.personalityId,
+      personalityName: override.personality.name,
+      configId: override.ttsConfigId,
+      configName: override.ttsConfig?.name ?? null,
+    };
 
-      const result: TtsOverrideSummary = {
-        personalityId: override.personalityId,
-        personalityName: override.personality.name,
-        configId: override.ttsConfigId,
-        configName: override.ttsConfig?.name ?? null,
-      };
-
-      logger.info(
-        {
-          discordUserId,
-          personalityId,
-          personalityName: personality.name,
-          configId,
-          configName: ttsConfig.name,
-        },
-        'Set TTS override'
-      );
-
-      // Invalidate per-user TTS cache so the dispatcher picks up the change
-      await tryInvalidateCache(
-        ttsConfigCacheInvalidation?.invalidateUserTtsConfig.bind(
-          ttsConfigCacheInvalidation,
-          discordUserId
-        ),
-        { discordUserId }
-      );
-
-      sendCustomSuccess(res, { override: result }, StatusCodes.OK);
-    })
-  );
-
-  // ============================================
-  // User Global Default TTS Config Routes
-  // NOTE: These MUST be defined BEFORE /:personalityId to avoid Express
-  // matching "default" as a personalityId parameter.
-  // ============================================
-
-  /** GET /user/tts-override/default — get user's global default TTS config */
-  router.get(
-    '/default',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const discordUserId = req.userId;
-      const userId = resolveProvisionedUserId(req);
-
-      const user = await prisma.user.findUnique({
-        where: { id: userId },
-        select: {
-          defaultTtsConfigId: true,
-          defaultTtsConfig: { select: { name: true } },
-        },
-      });
-
-      const result: UserDefaultTtsConfig = {
-        configId: user?.defaultTtsConfigId ?? null,
-        configName: user?.defaultTtsConfig?.name ?? null,
-      };
-
-      logger.info({ discordUserId, configId: result.configId }, 'Got default TTS config');
-      sendCustomSuccess(res, { default: result }, StatusCodes.OK);
-    })
-  );
-
-  /** PUT /user/tts-override/default — set user's global default TTS config */
-  router.put(
-    '/default',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const discordUserId = req.userId;
-
-      const parseResult = SetTtsDefaultConfigSchema.safeParse(req.body);
-      if (!parseResult.success) {
-        return sendZodError(res, parseResult.error);
-      }
-      const { configId } = parseResult.data;
-      const userId = resolveProvisionedUserId(req);
-
-      const ttsConfig = await verifyTtsConfigAccess(prisma, configId, userId);
-      if (ttsConfig === null) {
-        return sendError(res, ErrorResponses.notFound('TtsConfig'));
-      }
-
-      await prisma.user.update({
-        where: { id: userId },
-        data: { defaultTtsConfigId: configId },
-      });
-
-      const result: UserDefaultTtsConfig = {
-        configId: ttsConfig.id,
+    logger.info(
+      {
+        discordUserId,
+        personalityId,
+        personalityName: personality.name,
+        configId,
         configName: ttsConfig.name,
-      };
+      },
+      'Set TTS override'
+    );
 
+    await tryInvalidateCache(
+      ttsConfigCacheInvalidation?.invalidateUserTtsConfig.bind(
+        ttsConfigCacheInvalidation,
+        discordUserId
+      ),
+      { discordUserId }
+    );
+
+    sendCustomSuccess(res, { override: result }, StatusCodes.OK);
+  });
+};
+
+/** GET /api/user/tts-override/default — get user's global default TTS config */
+export const handleGetTtsDefault = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const discordUserId = req.userId;
+    const userId = resolveProvisionedUserId(req);
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        defaultTtsConfigId: true,
+        defaultTtsConfig: { select: { name: true } },
+      },
+    });
+
+    const result: UserDefaultTtsConfig = {
+      configId: user?.defaultTtsConfigId ?? null,
+      configName: user?.defaultTtsConfig?.name ?? null,
+    };
+
+    logger.info({ discordUserId, configId: result.configId }, 'Got default TTS config');
+    sendCustomSuccess(res, { default: result }, StatusCodes.OK);
+  });
+};
+
+/** PUT /api/user/tts-override/default — set user's global default TTS config */
+export const handleSetTtsDefault = (deps: RouteDeps): RequestHandler => {
+  const { prisma, ttsConfigCacheInvalidation } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const discordUserId = req.userId;
+
+    const parseResult = SetTtsDefaultConfigSchema.safeParse(req.body);
+    if (!parseResult.success) {
+      return sendZodError(res, parseResult.error);
+    }
+    const { configId } = parseResult.data;
+    const userId = resolveProvisionedUserId(req);
+
+    const ttsConfig = await verifyTtsConfigAccess(prisma, configId, userId);
+    if (ttsConfig === null) {
+      return sendError(res, ErrorResponses.notFound('TtsConfig'));
+    }
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: { defaultTtsConfigId: configId },
+    });
+
+    const result: UserDefaultTtsConfig = {
+      configId: ttsConfig.id,
+      configName: ttsConfig.name,
+    };
+
+    logger.info({ discordUserId, configId, configName: ttsConfig.name }, 'Set default TTS config');
+
+    await tryInvalidateCache(
+      ttsConfigCacheInvalidation?.invalidateUserTtsConfig.bind(
+        ttsConfigCacheInvalidation,
+        discordUserId
+      ),
+      { discordUserId }
+    );
+
+    sendCustomSuccess(res, { default: result }, StatusCodes.OK);
+  });
+};
+
+/** DELETE /api/user/tts-override/default — clear user's global default TTS config */
+export const handleClearTtsDefault = (deps: RouteDeps): RequestHandler => {
+  const { prisma, ttsConfigCacheInvalidation } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const discordUserId = req.userId;
+    const userId = resolveProvisionedUserId(req);
+
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { defaultTtsConfigId: true },
+    });
+    if (user === null) {
+      return sendError(res, ErrorResponses.notFound('User'));
+    }
+
+    // Look up the system free default the user will fall back to. Per-
+    // personality overrides (UserPersonalityConfig.ttsConfigId) and
+    // personality-level defaults (PersonalityDefaultTtsConfig) are
+    // unaffected; the free default is just the user-global fallback.
+    const newEffectiveDefault = await prisma.ttsConfig.findFirst({
+      where: { isFreeDefault: true },
+      select: { id: true, name: true },
+    });
+
+    if (user.defaultTtsConfigId === null) {
       logger.info(
-        { discordUserId, configId, configName: ttsConfig.name },
-        'Set default TTS config'
+        { discordUserId, hadDefault: false },
+        'Clear called but no default TTS was set (idempotent success)'
       );
-
-      await tryInvalidateCache(
-        ttsConfigCacheInvalidation?.invalidateUserTtsConfig.bind(
-          ttsConfigCacheInvalidation,
-          discordUserId
-        ),
-        { discordUserId }
+      return sendCustomSuccess(
+        res,
+        { deleted: true, wasSet: false, newEffectiveDefault },
+        StatusCodes.OK
       );
+    }
 
-      sendCustomSuccess(res, { default: result }, StatusCodes.OK);
-    })
-  );
+    await prisma.user.update({
+      where: { id: userId },
+      data: { defaultTtsConfigId: null },
+    });
 
-  /** DELETE /user/tts-override/default — clear user's global default TTS config */
-  router.delete(
-    '/default',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const discordUserId = req.userId;
-      const userId = resolveProvisionedUserId(req);
+    logger.info({ discordUserId }, 'Cleared default TTS config');
 
-      const user = await prisma.user.findUnique({
-        where: { id: userId },
-        select: { defaultTtsConfigId: true },
-      });
-      if (user === null) {
-        return sendError(res, ErrorResponses.notFound('User'));
-      }
+    await tryInvalidateCache(
+      ttsConfigCacheInvalidation?.invalidateUserTtsConfig.bind(
+        ttsConfigCacheInvalidation,
+        discordUserId
+      ),
+      { discordUserId }
+    );
 
-      // Look up the system free default the user will fall back to. Per-
-      // personality overrides (UserPersonalityConfig.ttsConfigId) and
-      // personality-level defaults (PersonalityDefaultTtsConfig) are
-      // unaffected; the free default is just the user-global fallback.
-      const newEffectiveDefault = await prisma.ttsConfig.findFirst({
-        where: { isFreeDefault: true },
-        select: { id: true, name: true },
-      });
+    sendCustomSuccess(res, { deleted: true, wasSet: true, newEffectiveDefault }, StatusCodes.OK);
+  });
+};
 
-      // Idempotent: no default set → success with wasSet: false
-      if (user.defaultTtsConfigId === null) {
-        logger.info(
-          { discordUserId, hadDefault: false },
-          'Clear called but no default TTS was set (idempotent success)'
-        );
-        return sendCustomSuccess(
-          res,
-          { deleted: true, wasSet: false, newEffectiveDefault },
-          StatusCodes.OK
-        );
-      }
+/** DELETE /api/user/tts-override/:personalityId — remove TTS override for a personality */
+export const handleClearTtsOverride = (deps: RouteDeps): RequestHandler => {
+  const { prisma, ttsConfigCacheInvalidation } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const discordUserId = req.userId;
+    const personalityId = getParam(req.params.personalityId);
+    const userId = resolveProvisionedUserId(req);
 
-      await prisma.user.update({
-        where: { id: userId },
-        data: { defaultTtsConfigId: null },
-      });
+    const override = await prisma.userPersonalityConfig.findFirst({
+      where: { userId, personalityId },
+      select: { id: true, ttsConfigId: true, personality: { select: { name: true } } },
+    });
 
-      logger.info({ discordUserId }, 'Cleared default TTS config');
-
-      await tryInvalidateCache(
-        ttsConfigCacheInvalidation?.invalidateUserTtsConfig.bind(
-          ttsConfigCacheInvalidation,
-          discordUserId
-        ),
-        { discordUserId }
+    if (override?.ttsConfigId === null || override?.ttsConfigId === undefined) {
+      logger.info(
+        { discordUserId, personalityId, hadOverride: false },
+        'Reset called but no TTS override was set (idempotent success)'
       );
+      return sendCustomSuccess(res, { deleted: true, wasSet: false }, StatusCodes.OK);
+    }
 
-      // Symmetric with the no-op branch above (which returns wasSet: false)
-      // and with DELETE /:personalityId — explicit `wasSet: true` lets a
-      // future caller distinguish "actually cleared" from "already empty"
-      // via a single field check.
-      sendCustomSuccess(res, { deleted: true, wasSet: true, newEffectiveDefault }, StatusCodes.OK);
-    })
-  );
+    await prisma.userPersonalityConfig.update({
+      where: { id: override.id },
+      data: { ttsConfigId: null },
+    });
 
-  // ============================================
-  // Personality-specific override route — MUST come AFTER /default
-  // ============================================
+    logger.info(
+      { discordUserId, personalityId, personalityName: override.personality.name },
+      'Removed TTS override'
+    );
 
-  /** DELETE /user/tts-override/:personalityId — remove TTS override for a personality */
+    await tryInvalidateCache(
+      ttsConfigCacheInvalidation?.invalidateUserTtsConfig.bind(
+        ttsConfigCacheInvalidation,
+        discordUserId
+      ),
+      { discordUserId }
+    );
+
+    sendCustomSuccess(res, { deleted: true, wasSet: true }, StatusCodes.OK);
+  });
+};
+
+export function createTtsOverrideRoutes(deps: RouteDeps): Router {
+  const router = Router();
+  const requireProvisioned = requireProvisionedUser(deps.prisma);
+
+  router.get('/', requireUserAuth(), requireProvisioned, handleListTtsOverrides(deps));
+  router.put('/', requireUserAuth(), requireProvisioned, handleSetTtsOverride(deps));
+  // /default routes MUST come before /:personalityId to avoid the parameter shadowing them
+  router.get('/default', requireUserAuth(), requireProvisioned, handleGetTtsDefault(deps));
+  router.put('/default', requireUserAuth(), requireProvisioned, handleSetTtsDefault(deps));
+  router.delete('/default', requireUserAuth(), requireProvisioned, handleClearTtsDefault(deps));
   router.delete(
     '/:personalityId',
     requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const discordUserId = req.userId;
-      const personalityId = getParam(req.params.personalityId);
-      const userId = resolveProvisionedUserId(req);
-
-      const override = await prisma.userPersonalityConfig.findFirst({
-        where: { userId, personalityId },
-        select: { id: true, ttsConfigId: true, personality: { select: { name: true } } },
-      });
-
-      // Idempotent: no override or already null
-      if (override?.ttsConfigId === null || override?.ttsConfigId === undefined) {
-        logger.info(
-          { discordUserId, personalityId, hadOverride: false },
-          'Reset called but no TTS override was set (idempotent success)'
-        );
-        return sendCustomSuccess(res, { deleted: true, wasSet: false }, StatusCodes.OK);
-      }
-
-      await prisma.userPersonalityConfig.update({
-        where: { id: override.id },
-        data: { ttsConfigId: null },
-      });
-
-      logger.info(
-        { discordUserId, personalityId, personalityName: override.personality.name },
-        'Removed TTS override'
-      );
-
-      await tryInvalidateCache(
-        ttsConfigCacheInvalidation?.invalidateUserTtsConfig.bind(
-          ttsConfigCacheInvalidation,
-          discordUserId
-        ),
-        { discordUserId }
-      );
-
-      sendCustomSuccess(res, { deleted: true, wasSet: true }, StatusCodes.OK);
-    })
+    requireProvisioned,
+    handleClearTtsOverride(deps)
   );
 
   return router;

--- a/services/api-gateway/src/routes/user/usage.test.ts
+++ b/services/api-gateway/src/routes/user/usage.test.ts
@@ -74,7 +74,7 @@ async function callHandler(
   req: Request & { userId: string },
   res: Response
 ): Promise<void> {
-  const router = createUsageRoutes(prisma as PrismaClient);
+  const router = createUsageRoutes({ prisma: prisma as PrismaClient });
   const handler = getRouteHandler(router, 'get');
   await handler(req, res);
 }
@@ -88,14 +88,14 @@ describe('/user/usage routes', () => {
 
   describe('route factory', () => {
     it('should create a router', () => {
-      const router = createUsageRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createUsageRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(router).toBeDefined();
       expect(typeof router).toBe('function');
     });
 
     it('should have GET route registered', () => {
-      const router = createUsageRoutes(mockPrisma as unknown as PrismaClient);
+      const router = createUsageRoutes({ prisma: mockPrisma as unknown as PrismaClient });
 
       expect(router.stack).toBeDefined();
       expect(router.stack.length).toBeGreaterThan(0);

--- a/services/api-gateway/src/routes/user/usage.ts
+++ b/services/api-gateway/src/routes/user/usage.ts
@@ -3,20 +3,16 @@
  * GET /user/usage - Get token usage statistics
  */
 
-import { Router, type Response } from 'express';
+import { Router, type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
-import {
-  createLogger,
-  type PrismaClient,
-  type UsagePeriod,
-  type UsageStats,
-} from '@tzurot/common-types';
+import { createLogger, type UsagePeriod, type UsageStats } from '@tzurot/common-types';
 import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
 import type { ProvisionedRequest } from '../../types.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('user-usage');
 
@@ -48,108 +44,100 @@ function getPeriodStartDate(period: UsagePeriod): Date | null {
   }
 }
 
-export function createUsageRoutes(prisma: PrismaClient): Router {
-  const router = Router();
+/** GET /api/user/usage — token usage statistics for the current user */
+export const handleGetUserUsage = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const discordUserId = req.userId;
+    const period = (req.query.period as UsagePeriod) ?? 'month';
 
-  /**
-   * GET /user/usage
-   * Get token usage statistics
-   *
-   * Query params:
-   * - period: 'day' | 'week' | 'month' | 'all' (default: 'month')
-   */
-  router.get(
-    '/',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const discordUserId = req.userId;
-      const period = (req.query.period as UsagePeriod) ?? 'month';
-
-      // Validate period
-      if (!['day', 'week', 'month', 'all'].includes(period)) {
-        return sendError(
-          res,
-          ErrorResponses.validationError("period must be 'day', 'week', 'month', or 'all'")
-        );
-      }
-
-      const userId = resolveProvisionedUserId(req);
-
-      const periodStart = getPeriodStartDate(period);
-
-      // Build where clause
-      const where: { userId: string; createdAt?: { gte: Date } } = {
-        userId,
-      };
-      if (periodStart !== null) {
-        where.createdAt = { gte: periodStart };
-      }
-
-      // Get usage logs for the period (bounded to prevent OOM on large datasets)
-      const MAX_USAGE_LOGS = 10000;
-      const usageLogs = await prisma.usageLog.findMany({
-        where,
-        select: {
-          provider: true,
-          model: true,
-          tokensIn: true,
-          tokensOut: true,
-          requestType: true,
-        },
-        take: MAX_USAGE_LOGS,
-        orderBy: { createdAt: 'desc' },
-      });
-      const limitReached = usageLogs.length === MAX_USAGE_LOGS;
-
-      // Aggregate stats
-      const stats: UsageStats = {
-        period,
-        periodStart: periodStart?.toISOString() ?? null,
-        periodEnd: new Date().toISOString(),
-        totalRequests: usageLogs.length,
-        totalTokensIn: 0,
-        totalTokensOut: 0,
-        totalTokens: 0,
-        byProvider: {},
-        byModel: {},
-        byRequestType: {},
-        limitReached,
-      };
-
-      for (const log of usageLogs) {
-        // Totals
-        stats.totalTokensIn += log.tokensIn;
-        stats.totalTokensOut += log.tokensOut;
-        stats.totalTokens += log.tokensIn + log.tokensOut;
-
-        // By provider
-        stats.byProvider[log.provider] ??= { requests: 0, tokensIn: 0, tokensOut: 0 };
-        stats.byProvider[log.provider].requests++;
-        stats.byProvider[log.provider].tokensIn += log.tokensIn;
-        stats.byProvider[log.provider].tokensOut += log.tokensOut;
-
-        // By model
-        stats.byModel[log.model] ??= { requests: 0, tokensIn: 0, tokensOut: 0 };
-        stats.byModel[log.model].requests++;
-        stats.byModel[log.model].tokensIn += log.tokensIn;
-        stats.byModel[log.model].tokensOut += log.tokensOut;
-
-        // By request type
-        stats.byRequestType[log.requestType] ??= { requests: 0, tokensIn: 0, tokensOut: 0 };
-        stats.byRequestType[log.requestType].requests++;
-        stats.byRequestType[log.requestType].tokensIn += log.tokensIn;
-        stats.byRequestType[log.requestType].tokensOut += log.tokensOut;
-      }
-
-      logger.info(
-        { discordUserId, period, totalRequests: stats.totalRequests },
-        'Returned usage stats'
+    // Validate period
+    if (!['day', 'week', 'month', 'all'].includes(period)) {
+      return sendError(
+        res,
+        ErrorResponses.validationError("period must be 'day', 'week', 'month', or 'all'")
       );
+    }
 
-      sendCustomSuccess(res, stats, StatusCodes.OK);
-    })
-  );
+    const userId = resolveProvisionedUserId(req);
 
+    const periodStart = getPeriodStartDate(period);
+
+    // Build where clause
+    const where: { userId: string; createdAt?: { gte: Date } } = {
+      userId,
+    };
+    if (periodStart !== null) {
+      where.createdAt = { gte: periodStart };
+    }
+
+    // Get usage logs for the period (bounded to prevent OOM on large datasets)
+    const MAX_USAGE_LOGS = 10000;
+    const usageLogs = await prisma.usageLog.findMany({
+      where,
+      select: {
+        provider: true,
+        model: true,
+        tokensIn: true,
+        tokensOut: true,
+        requestType: true,
+      },
+      take: MAX_USAGE_LOGS,
+      orderBy: { createdAt: 'desc' },
+    });
+    const limitReached = usageLogs.length === MAX_USAGE_LOGS;
+
+    // Aggregate stats
+    const stats: UsageStats = {
+      period,
+      periodStart: periodStart?.toISOString() ?? null,
+      periodEnd: new Date().toISOString(),
+      totalRequests: usageLogs.length,
+      totalTokensIn: 0,
+      totalTokensOut: 0,
+      totalTokens: 0,
+      byProvider: {},
+      byModel: {},
+      byRequestType: {},
+      limitReached,
+    };
+
+    for (const log of usageLogs) {
+      // Totals
+      stats.totalTokensIn += log.tokensIn;
+      stats.totalTokensOut += log.tokensOut;
+      stats.totalTokens += log.tokensIn + log.tokensOut;
+
+      // By provider
+      stats.byProvider[log.provider] ??= { requests: 0, tokensIn: 0, tokensOut: 0 };
+      stats.byProvider[log.provider].requests++;
+      stats.byProvider[log.provider].tokensIn += log.tokensIn;
+      stats.byProvider[log.provider].tokensOut += log.tokensOut;
+
+      // By model
+      stats.byModel[log.model] ??= { requests: 0, tokensIn: 0, tokensOut: 0 };
+      stats.byModel[log.model].requests++;
+      stats.byModel[log.model].tokensIn += log.tokensIn;
+      stats.byModel[log.model].tokensOut += log.tokensOut;
+
+      // By request type
+      stats.byRequestType[log.requestType] ??= { requests: 0, tokensIn: 0, tokensOut: 0 };
+      stats.byRequestType[log.requestType].requests++;
+      stats.byRequestType[log.requestType].tokensIn += log.tokensIn;
+      stats.byRequestType[log.requestType].tokensOut += log.tokensOut;
+    }
+
+    logger.info(
+      { discordUserId, period, totalRequests: stats.totalRequests },
+      'Returned usage stats'
+    );
+
+    sendCustomSuccess(res, stats, StatusCodes.OK);
+  });
+};
+
+export function createUsageRoutes(deps: RouteDeps): Router {
+  const router = Router();
+  router.get('/', requireUserAuth(), requireProvisionedUser(deps.prisma), handleGetUserUsage(deps));
   return router;
 }

--- a/services/api-gateway/src/routes/user/voice-resolution.test.ts
+++ b/services/api-gateway/src/routes/user/voice-resolution.test.ts
@@ -91,7 +91,7 @@ const mockPrisma = {
 };
 
 function buildRouter() {
-  return createVoiceResolutionRoutes(mockPrisma as never);
+  return createVoiceResolutionRoutes({ prisma: mockPrisma as never });
 }
 
 describe('user/voice-resolution route', () => {

--- a/services/api-gateway/src/routes/user/voice-resolution.ts
+++ b/services/api-gateway/src/routes/user/voice-resolution.ts
@@ -13,11 +13,10 @@
  * does vary per personality.
  */
 
-import { Router, type Response } from 'express';
+import { Router, type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import {
   createLogger,
-  type PrismaClient,
   type GetVoiceResolutionResponse,
   type ResolvedTtsView,
   type ResolvedSttView,
@@ -36,114 +35,121 @@ import { sendZodError } from '../../utils/zodHelpers.js';
 import { resolveAudioProviderKeys } from '../../utils/audioProviderKeyResolver.js';
 import { fetchAllTzurotVoices } from './voices.js';
 import type { ProvisionedRequest } from '../../types.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('user-voice-resolution');
 
 /** Cap inline preview slugs at this many to keep the dashboard embed compact. */
 const MAX_PREVIEW_SLUGS = 5;
 
-export function createVoiceResolutionRoutes(prisma: PrismaClient): Router {
-  const router = Router();
-
-  // Per-process resolver instances. Cache lifetime ~5 min; mutating endpoints
-  // publish invalidation events but the gateway doesn't subscribe to them
-  // here, so cache lifetime is the TTL.
+/**
+ * GET /api/user/voice-resolution?personalityId=X — aggregate TTS+STT+voices summary
+ *
+ * Per-process resolver instances. Cache lifetime ~5 min; mutating endpoints
+ * publish invalidation events but the gateway doesn't subscribe to them
+ * here, so cache lifetime is the TTL.
+ */
+export const handleGetVoiceResolution = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
   const ttsResolver = new TtsConfigResolver(prisma);
   const sttResolver = new SttResolver(prisma);
+  return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
+    const discordUserId = req.userId;
+    const userId = resolveProvisionedUserId(req);
 
+    const parseResult = GetVoiceResolutionQuerySchema.safeParse(req.query);
+    if (!parseResult.success) {
+      return sendZodError(res, parseResult.error);
+    }
+    const { personalityId } = parseResult.data;
+
+    // Independent existence checks — issue them in parallel.
+    const [personality, userExists] = await Promise.all([
+      prisma.personality.findFirst({
+        where: { id: personalityId },
+        select: { id: true, name: true },
+      }),
+      prisma.user.findUnique({
+        where: { id: userId },
+        select: { id: true },
+      }),
+    ]);
+    if (personality === null) {
+      return sendError(res, ErrorResponses.notFound('Personality'));
+    }
+    if (userExists === null) {
+      return sendError(res, ErrorResponses.notFound('User'));
+    }
+
+    // TTS resolution — defer to the cached resolver.
+    const personalityForResolver: LoadedTtsPersonality = { id: personality.id };
+    const ttsResolution = await ttsResolver.resolveConfig(
+      discordUserId,
+      personalityId,
+      personalityForResolver
+    );
+
+    const ttsView: ResolvedTtsView = {
+      // resolver surfaces configName but not configId at the top level
+      configId: null,
+      configName: ttsResolution.configName ?? null,
+      provider: ttsResolution.config.provider,
+      source: ttsResolution.source,
+    };
+
+    // STT resolution — user-scoped (no personalityId argument).
+    const sttResult = await sttResolver.resolveProvider(discordUserId);
+    const sttView: ResolvedSttView = sttResult;
+
+    // Cloned-voice summary — only if the user has at least one BYOK key.
+    // No keys → summary is "0 voices" (avoids surfacing a 404).
+    let voicesSummary: ClonedVoicesSummary = {
+      tzurotCount: 0,
+      totalVoices: 0,
+      previewSlugs: [],
+    };
+    const keysResult = await resolveAudioProviderKeys(prisma, discordUserId);
+    if ('keys' in keysResult && keysResult.keys.size > 0) {
+      const { voices, totalVoicesByProvider } = await fetchAllTzurotVoices(keysResult.keys);
+      const totalVoices = Array.from(totalVoicesByProvider.values()).reduce((a, b) => a + b, 0);
+      voicesSummary = {
+        tzurotCount: voices.length,
+        totalVoices,
+        previewSlugs: voices.slice(0, MAX_PREVIEW_SLUGS).map(v => v.slug),
+      };
+    }
+
+    const response: GetVoiceResolutionResponse = {
+      personalityName: personality.name,
+      tts: ttsView,
+      stt: sttView,
+      voices: voicesSummary,
+    };
+
+    logger.info(
+      {
+        discordUserId,
+        personalityId,
+        ttsProvider: ttsView.provider,
+        ttsSource: ttsView.source,
+        sttProvider: sttView.provider,
+        sttSource: sttView.source,
+        tzurotCount: voicesSummary.tzurotCount,
+      },
+      'Resolved voice context for /voice view'
+    );
+
+    sendCustomSuccess(res, response, StatusCodes.OK);
+  });
+};
+
+export function createVoiceResolutionRoutes(deps: RouteDeps): Router {
+  const router = Router();
   router.get(
     '/',
     requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: ProvisionedRequest, res: Response) => {
-      const discordUserId = req.userId;
-      const userId = resolveProvisionedUserId(req);
-
-      const parseResult = GetVoiceResolutionQuerySchema.safeParse(req.query);
-      if (!parseResult.success) {
-        return sendZodError(res, parseResult.error);
-      }
-      const { personalityId } = parseResult.data;
-
-      // Independent existence checks — issue them in parallel.
-      const [personality, userExists] = await Promise.all([
-        prisma.personality.findFirst({
-          where: { id: personalityId },
-          select: { id: true, name: true },
-        }),
-        prisma.user.findUnique({
-          where: { id: userId },
-          select: { id: true },
-        }),
-      ]);
-      if (personality === null) {
-        return sendError(res, ErrorResponses.notFound('Personality'));
-      }
-      if (userExists === null) {
-        return sendError(res, ErrorResponses.notFound('User'));
-      }
-
-      // TTS resolution — defer to the cached resolver.
-      const personalityForResolver: LoadedTtsPersonality = { id: personality.id };
-      const ttsResolution = await ttsResolver.resolveConfig(
-        discordUserId,
-        personalityId,
-        personalityForResolver
-      );
-
-      const ttsView: ResolvedTtsView = {
-        // resolver surfaces configName but not configId at the top level
-        configId: null,
-        configName: ttsResolution.configName ?? null,
-        provider: ttsResolution.config.provider,
-        source: ttsResolution.source,
-      };
-
-      // STT resolution — user-scoped (no personalityId argument).
-      const sttResult = await sttResolver.resolveProvider(discordUserId);
-      const sttView: ResolvedSttView = sttResult;
-
-      // Cloned-voice summary — only if the user has at least one BYOK key.
-      // No keys → summary is "0 voices" (avoids surfacing a 404).
-      let voicesSummary: ClonedVoicesSummary = {
-        tzurotCount: 0,
-        totalVoices: 0,
-        previewSlugs: [],
-      };
-      const keysResult = await resolveAudioProviderKeys(prisma, discordUserId);
-      if ('keys' in keysResult && keysResult.keys.size > 0) {
-        const { voices, totalVoicesByProvider } = await fetchAllTzurotVoices(keysResult.keys);
-        const totalVoices = Array.from(totalVoicesByProvider.values()).reduce((a, b) => a + b, 0);
-        voicesSummary = {
-          tzurotCount: voices.length,
-          totalVoices,
-          previewSlugs: voices.slice(0, MAX_PREVIEW_SLUGS).map(v => v.slug),
-        };
-      }
-
-      const response: GetVoiceResolutionResponse = {
-        personalityName: personality.name,
-        tts: ttsView,
-        stt: sttView,
-        voices: voicesSummary,
-      };
-
-      logger.info(
-        {
-          discordUserId,
-          personalityId,
-          ttsProvider: ttsView.provider,
-          ttsSource: ttsView.source,
-          sttProvider: sttView.provider,
-          sttSource: sttView.source,
-          tzurotCount: voicesSummary.tzurotCount,
-        },
-        'Resolved voice context for /voice view'
-      );
-
-      sendCustomSuccess(res, response, StatusCodes.OK);
-    })
+    requireProvisionedUser(deps.prisma),
+    handleGetVoiceResolution(deps)
   );
-
   return router;
 }

--- a/services/api-gateway/src/routes/user/voices.test.ts
+++ b/services/api-gateway/src/routes/user/voices.test.ts
@@ -146,7 +146,7 @@ describe('Voice Management Routes', () => {
 
     app = express();
     app.use(express.json());
-    app.use('/voices', createVoicesRoutes(mockPrisma));
+    app.use('/voices', createVoicesRoutes({ prisma: mockPrisma }));
 
     // Default: user has ElevenLabs key only (mirrors the legacy single-provider
     // setup that pre-PR-3 was the only supported configuration).
@@ -265,7 +265,6 @@ describe('Voice Management Routes', () => {
         { provider: 'mistral', message: 'Provider temporarily unavailable' },
       ]);
     });
-
   });
 
   // ===== DELETE /:provider/:voiceId =======================================

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -11,7 +11,7 @@
  * - POST /clear              — delete ALL tzurot-prefixed voices across all providers
  */
 
-import { Router, type Response as ExpressResponse } from 'express';
+import { Router, type Response as ExpressResponse, type RequestHandler } from 'express';
 import {
   createLogger,
   TTS_VOICE_NAME_PREFIX,
@@ -38,7 +38,8 @@ import {
   type MistralCloned,
 } from '../../utils/mistralVoicesClient.js';
 import type { AuthenticatedRequest } from '../../types.js';
-import { handleListModels } from './voiceModels.js';
+import { handleListModels as listModelsImpl } from './voiceModels.js';
+import type { RouteDeps } from '../routeDeps.js';
 
 const logger = createLogger('VoicesRoute');
 
@@ -246,7 +247,7 @@ async function deleteVoiceAtProvider(
 // ===== Handlers ============================================================
 
 /** GET / — list tzurot-prefixed voices across all providers the user has keys for. */
-async function handleListVoices(
+async function listVoicesImpl(
   prisma: PrismaClient,
   req: AuthenticatedRequest,
   res: ExpressResponse
@@ -295,7 +296,7 @@ async function handleListVoices(
 }
 
 /** DELETE /:provider/:voiceId — delete a single tzurot-prefixed voice from a specific provider. */
-async function handleDeleteVoice(
+async function deleteVoiceImpl(
   prisma: PrismaClient,
   req: AuthenticatedRequest,
   res: ExpressResponse
@@ -387,7 +388,7 @@ async function handleDeleteVoice(
  * response body: `{ deleted, total, errors? }`. When `errors` is present,
  * some deletions failed but others succeeded.
  */
-async function handleClearVoices(
+async function clearVoicesImpl(
   prisma: PrismaClient,
   req: AuthenticatedRequest,
   res: ExpressResponse
@@ -468,47 +469,55 @@ async function handleClearVoices(
   });
 }
 
+// ===== Handler factories ===================================================
+
+/** GET /api/user/voices — list cloned voices across configured providers */
+export const handleListVoices = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: AuthenticatedRequest, res: ExpressResponse) => {
+    await listVoicesImpl(prisma, req, res);
+  });
+};
+
+/** GET /api/user/voices/models — list available voice models per provider */
+export const handleListVoiceModels = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: AuthenticatedRequest, res: ExpressResponse) => {
+    await listModelsImpl(prisma, req, res);
+  });
+};
+
+/** POST /api/user/voices/clear — delete all tzurot-prefixed voices */
+export const handleClearVoices = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: AuthenticatedRequest, res: ExpressResponse) => {
+    await clearVoicesImpl(prisma, req, res);
+  });
+};
+
+/** DELETE /api/user/voices/:provider/:voiceId — delete a single voice */
+export const handleDeleteVoice = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  return asyncHandler(async (req: AuthenticatedRequest, res: ExpressResponse) => {
+    await deleteVoiceImpl(prisma, req, res);
+  });
+};
+
 // ===== Router setup ========================================================
 
-export function createVoicesRoutes(prisma: PrismaClient): Router {
+export function createVoicesRoutes(deps: RouteDeps): Router {
   const router = Router();
+  const requireProvisioned = requireProvisionedUser(deps.prisma);
 
-  router.get(
-    '/',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: AuthenticatedRequest, res: ExpressResponse) => {
-      await handleListVoices(prisma, req, res);
-    })
-  );
-
-  // Register /models before /:provider/:voiceId so the wildcard doesn't shadow it
-  router.get(
-    '/models',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: AuthenticatedRequest, res: ExpressResponse) => {
-      await handleListModels(prisma, req, res);
-    })
-  );
-
-  // Register /clear before /:provider/:voiceId so the wildcard doesn't shadow it
-  router.post(
-    '/clear',
-    requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: AuthenticatedRequest, res: ExpressResponse) => {
-      await handleClearVoices(prisma, req, res);
-    })
-  );
-
+  router.get('/', requireUserAuth(), requireProvisioned, handleListVoices(deps));
+  // Register /models and /clear before /:provider/:voiceId so the wildcard doesn't shadow them
+  router.get('/models', requireUserAuth(), requireProvisioned, handleListVoiceModels(deps));
+  router.post('/clear', requireUserAuth(), requireProvisioned, handleClearVoices(deps));
   router.delete(
     '/:provider/:voiceId',
     requireUserAuth(),
-    requireProvisionedUser(prisma),
-    asyncHandler(async (req: AuthenticatedRequest, res: ExpressResponse) => {
-      await handleDeleteVoice(prisma, req, res);
-    })
+    requireProvisioned,
+    handleDeleteVoice(deps)
   );
 
   return router;


### PR DESCRIPTION
## Summary

Refactors the entire api-gateway route layer to the **deps-object factory pattern**: every `createXxxRoutes` factory now takes a single `RouteDeps` parameter (introduced in PR #1092), and per-endpoint handlers are exported as named `handleXxx(deps): RequestHandler` factories. This is the prerequisite for the route-manifest codegen to wire generated \`mounts.ts\` (follow-up PR-1.5b.2b).

## Why

PR-1.5b shipped the generator and \`RouteDeps\` shape. PR-1.5b.2a (this PR) is the bulk-mechanical refactor that adapts every existing route file to expose handlers in the shape the generator will consume. Behavior is unchanged — legacy \`createXxxRoutes\` factories all still exist and now just delegate to the new \`handle*\` exports.

## Files migrated

- **Admin routes**: dbSync, cleanup, invalidateCache, createPersonality, updatePersonality, usage, stopSequences, settings, denylist, llm-config, tts-config (12 files)
- **User routes**: timezone, usage, nsfw, conversationLookup, voice-resolution, history, voices, stt-override, llm-config, config-overrides, personality-config-overrides, tts-config, tts-override, model-override, plus the personality/, persona/, channel/, shapes/, memory subdirectories
- **AI + internal**: aggregator routers (\`createAIRouter\`, \`createInternalRouter\`) now take \`RouteDeps\`

Total: ~92 files changed, ~3200 lines.

## Out of scope (tracked for PR-1.5b.2b)

- Handler-name vs manifest-ID reconciliation. A number of handlers I created (e.g. \`handleClearModelOverride\`) need to be renamed to match the manifest IDs exactly (\`handleDeleteModelOverride\`) so the codegen's \`handle\${pascalCase(id)}\` resolver works. ~10 handlers affected; mechanical.
- Wiring the existing \`mounts-builder.ts\` into the codegen CLI orchestrator + writing the \`handlerPathFor\` resolver + actually generating \`mounts.ts\`.
- Integration test for mounted routes (\`mounts.int.test.ts\`).

## Verification

- \`pnpm test\` — all 2004 api-gateway tests pass (130 test files)
- \`pnpm quality\` — lint + typecheck + typecheck:spec + cpd + depcruise all green
- No behavior changes; pure refactor.

## Test plan

- [ ] CI green (lint, typecheck, test, claude-review)
- [ ] Smoke-test \`/inspect\`, \`/timezone\`, \`/admin settings\` post-merge on dev to confirm the deps-pass-through composition matches the legacy per-arg signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)