### PR TITLE
feat: PR-1.5e — RouteDef foundation + preview-token + idempotent lock

### DIFF
--- a/packages/common-types/src/constants/queue.ts
+++ b/packages/common-types/src/constants/queue.ts
@@ -89,6 +89,19 @@ export const REDIS_KEY_PREFIXES = {
   MULTI_TAG_DM_BACKFILL_TRIED: 'multitag:dm-backfill-tried:',
   /** Prefix for per-slot "already delivered" dedup marker (recovery skips dispatch when present) */
   MULTI_TAG_SLOT_DELIVERED: 'multitag:slot-delivered:',
+  /**
+   * Prefix for batch-delete preview tokens. Key: `memory:preview:{userId}:{token}`.
+   * Value: JSON-encoded filter that produced the preview. TTL: 5 min.
+   * Consumer: `api-gateway/MemoryActionTokenService`.
+   */
+  MEMORY_PREVIEW_TOKEN: 'memory:preview:',
+  /**
+   * Prefix for memory purge confirmation tokens. Key:
+   * `memory:purge:{userId}:{token}`. Value: JSON-encoded `{ personalityId }`
+   * binding. TTL: 5 min.
+   * Consumer: `api-gateway/MemoryActionTokenService`.
+   */
+  MEMORY_PURGE_TOKEN: 'memory:purge:',
 } as const;
 
 /**

--- a/packages/common-types/src/routes/types.test.ts
+++ b/packages/common-types/src/routes/types.test.ts
@@ -9,7 +9,15 @@
  */
 
 import { describe, it, expect, expectTypeOf } from 'vitest';
-import { asActor, asSubject } from './types.js';
+import { z } from 'zod';
+import {
+  asActor,
+  asSubject,
+  resolveQueryShape,
+  createPaginationSchema,
+  PreviewTokenSchema,
+  PurgeTokenSchema,
+} from './types.js';
 import type { ActorDiscordId, SubjectDiscordId } from './types.js';
 
 describe('asActor', () => {
@@ -77,5 +85,124 @@ describe('brand distinctness', () => {
     // concatenate the actor into a header value without ceremony.
     const raw: string = actor;
     expect(raw).toBe('111');
+  });
+});
+
+describe('resolveQueryShape', () => {
+  it('returns undefined when query is undefined', () => {
+    expect(resolveQueryShape(undefined)).toBeUndefined();
+  });
+
+  it('returns the Record verbatim when query is a Record', () => {
+    const record = { foo: z.string(), bar: z.number().optional() };
+    expect(resolveQueryShape(record)).toBe(record);
+  });
+
+  it('unwraps a ZodObject to its shape', () => {
+    const schema = z.object({ foo: z.string(), bar: z.number().optional() });
+    const shape = resolveQueryShape(schema);
+    expect(shape).toBeDefined();
+    expect(Object.keys(shape ?? {}).sort()).toEqual(['bar', 'foo']);
+  });
+
+  it('produces a shape suitable for `Object.keys()` iteration', () => {
+    // The codegen calls Object.keys(shape) to emit query param names.
+    // Both forms must produce iterable keys.
+    const recordShape = resolveQueryShape({ a: z.string() });
+    const objectShape = resolveQueryShape(z.object({ a: z.string() }));
+    expect(Object.keys(recordShape ?? {})).toEqual(['a']);
+    expect(Object.keys(objectShape ?? {})).toEqual(['a']);
+  });
+});
+
+describe('createPaginationSchema', () => {
+  it('accepts a minimal valid input (all fields optional)', () => {
+    const schema = createPaginationSchema(['createdAt', 'updatedAt']);
+    expect(schema.safeParse({}).success).toBe(true);
+  });
+
+  it('accepts a fully-populated input', () => {
+    const schema = createPaginationSchema(['createdAt', 'updatedAt']);
+    const result = schema.safeParse({
+      limit: 20,
+      offset: 40,
+      sort: 'updatedAt',
+      order: 'desc',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a sort value not in the declared sortFields tuple', () => {
+    const schema = createPaginationSchema(['createdAt']);
+    expect(schema.safeParse({ sort: 'notARealField' }).success).toBe(false);
+  });
+
+  it('rejects an order outside asc/desc', () => {
+    const schema = createPaginationSchema(['createdAt']);
+    expect(schema.safeParse({ order: 'random' }).success).toBe(false);
+  });
+
+  it('enforces limit bounds (1-100, integer)', () => {
+    const schema = createPaginationSchema(['createdAt']);
+    expect(schema.safeParse({ limit: 0 }).success).toBe(false);
+    expect(schema.safeParse({ limit: 101 }).success).toBe(false);
+    expect(schema.safeParse({ limit: 50.5 }).success).toBe(false);
+    expect(schema.safeParse({ limit: 50 }).success).toBe(true);
+  });
+
+  it('enforces offset >= 0', () => {
+    const schema = createPaginationSchema(['createdAt']);
+    expect(schema.safeParse({ offset: -1 }).success).toBe(false);
+    expect(schema.safeParse({ offset: 0 }).success).toBe(true);
+  });
+
+  it('produces a ZodObject that can be .extend()-ed with per-route fields', () => {
+    const base = createPaginationSchema(['createdAt', 'updatedAt']);
+    const extended = base.extend({ personalityId: z.string().uuid() });
+    expect(extended.safeParse({ personalityId: 'not-a-uuid' }).success).toBe(false);
+    expect(
+      extended.safeParse({ personalityId: '11111111-1111-4111-8111-111111111111' }).success
+    ).toBe(true);
+  });
+
+  it('preserves typed sortFields at the type level', () => {
+    const schema = createPaginationSchema(['createdAt', 'updatedAt']);
+    // Type-level assertion: sort is narrowed to the tuple, not generic string
+    expectTypeOf<z.infer<typeof schema>['sort']>().toEqualTypeOf<
+      'createdAt' | 'updatedAt' | undefined
+    >();
+  });
+});
+
+describe('PreviewTokenSchema', () => {
+  it('accepts a properly-formatted token', () => {
+    expect(PreviewTokenSchema.safeParse('preview_test0000test0000test0000').success).toBe(true);
+  });
+
+  it('rejects an arbitrary string', () => {
+    expect(PreviewTokenSchema.safeParse('not-a-token').success).toBe(false);
+    expect(PreviewTokenSchema.safeParse('').success).toBe(false);
+  });
+
+  it('rejects a string lacking the preview_ prefix', () => {
+    expect(PreviewTokenSchema.safeParse('purge_test0000test0000test0000').success).toBe(false);
+  });
+
+  it('rejects a token that is too short (no payload)', () => {
+    expect(PreviewTokenSchema.safeParse('preview_x').success).toBe(false);
+  });
+});
+
+describe('PurgeTokenSchema', () => {
+  it('accepts a properly-formatted token', () => {
+    expect(PurgeTokenSchema.safeParse('purge_test0000test0000test0000').success).toBe(true);
+  });
+
+  it('rejects a preview-prefixed token (distinct brand)', () => {
+    expect(PurgeTokenSchema.safeParse('preview_test0000test0000test0000').success).toBe(false);
+  });
+
+  it('rejects unbranded raw strings', () => {
+    expect(PurgeTokenSchema.safeParse('test0000test0000test0000').success).toBe(false);
   });
 });

--- a/packages/common-types/src/routes/types.ts
+++ b/packages/common-types/src/routes/types.ts
@@ -13,7 +13,7 @@
  * runtime 401 or a silent data leak.
  */
 
-import type { z } from 'zod';
+import { z } from 'zod';
 
 /**
  * Discord ID of the human (or service principal) initiating the request.
@@ -157,8 +157,56 @@ export interface RouteDef<
    * If a numeric query needs compile-time narrowing on the client
    * side, a follow-up could specialize `buildOptionsType` to inspect
    * the Zod schema kind.
+   *
+   * Two shapes accepted:
+   *   - `Record<string, ZodTypeAny>` — the "spread" form, one entry per
+   *     query param. Use this for ad-hoc per-route queries.
+   *   - `ZodObject<TQuery>` — the "schema" form. Use this when you want
+   *     to share a reusable query schema across routes (e.g., the
+   *     `createPaginationSchema(sortFields)` factory output). The codegen
+   *     unwraps to `.shape` internally so the two forms are equivalent
+   *     at the wire level; the schema form lets you `.extend()` it with
+   *     per-route fields without copying the record entries.
    */
-  readonly query?: TQuery;
+  readonly query?: TQuery | z.ZodObject<TQuery>;
+  /**
+   * Zod schemas for request HEADERS. Each entry is one header name,
+   * lowercased per HTTP convention (`'idempotency-key'`, not `'Idempotency-Key'`).
+   * Generated client method emits these as required positional arguments
+   * (or part of the options bag, depending on optionality). Server-side
+   * the corresponding handler can `req.get(headerName)` and validate.
+   *
+   * Currently used by destructive batch operations (`/memory/delete`,
+   * `/memory/purge`) to require an `Idempotency-Key` UUID so retries on
+   * network timeout don't double-execute.
+   */
+  readonly headers?: Record<string, z.ZodTypeAny>;
+  /**
+   * Opt-in metadata that affects codegen behavior or documents semantic
+   * intent. All fields optional; absence means "use defaults."
+   *
+   *   - `safeRead`: route uses POST for transport reasons (complex body
+   *     that won't fit a query string) but is semantically read-only.
+   *     Generated client treats it like a GET for cache purposes — e.g.,
+   *     React Query wrappers use `useQuery` instead of `useMutation`.
+   *     Without this flag, POST routes are assumed to be mutating.
+   *
+   *   - `softDeleteAware`: the resource supports soft delete. Future
+   *     codegen can honor this to add `includeDeleted?: boolean` to list
+   *     queries or warn when a caller fetches a soft-deleted entity. Set
+   *     on the resource-level routes (list, get-by-id) that participate
+   *     in the soft-delete cycle, not on the delete operation itself.
+   *
+   *   - `idempotent`: route is safe to retry without side effects beyond
+   *     the first call. Set by the route author to document intent;
+   *     destructive routes that achieve idempotency via Idempotency-Key
+   *     headers should also set this true.
+   */
+  readonly meta?: {
+    readonly safeRead?: boolean;
+    readonly softDeleteAware?: boolean;
+    readonly idempotent?: boolean;
+  };
   /**
    * If true, this route operates on a subject distinct from the actor.
    * Generated client method gains `subject?: SubjectDiscordId` parameter.
@@ -219,3 +267,96 @@ export interface RouteDef<
  * is what code that walks the manifest works with.
  */
 export type AnyRouteDef = RouteDef<z.ZodTypeAny | undefined, z.ZodTypeAny>;
+
+/**
+ * Resolve a `RouteDef.query` field to its `Record<string, ZodTypeAny>`
+ * shape, regardless of whether the manifest entry passed a `Record<>` or
+ * a `ZodObject` (the two accepted forms — see `RouteDef.query` JSDoc).
+ *
+ * Returns `undefined` if no query schema was declared. Used by:
+ *   - the codegen (`method-builder.ts`) to iterate query param names
+ *   - the cross-manifest invariant tests to walk every query field
+ *   - any future tooling that wants a uniform query shape
+ */
+export function resolveQueryShape(
+  query: AnyRouteDef['query']
+): Record<string, z.ZodTypeAny> | undefined {
+  if (query === undefined) {
+    return undefined;
+  }
+  if (query instanceof z.ZodObject) {
+    return query.shape;
+  }
+  return query;
+}
+
+// ============================================================================
+// Pagination factory (shared across paginated list endpoints)
+// ============================================================================
+
+/**
+ * Build a reusable Zod object capturing the standard pagination params:
+ * `limit`, `offset`, `sort`, `order`. Returned as a `ZodObject` so callers
+ * can `.extend()` it with route-specific filters and `RouteDef.query`
+ * accepts it directly.
+ *
+ * The `sortFields` tuple is preserved at the type level — generated clients
+ * see `sort?: 'createdAt' | 'updatedAt'` rather than `sort?: string`,
+ * catching drift between the route's declared sort fields and what callers
+ * pass.
+ *
+ * @example
+ * ```ts
+ * const MemoryListQuery = createPaginationSchema(['createdAt', 'updatedAt']);
+ * // RouteDef entry:
+ * query: MemoryListQuery.extend({ personalityId: z.string().uuid() })
+ * ```
+ *
+ * Defaults follow the project convention: `limit=20`, `offset=0`,
+ * `sort=<first field>`, `order='desc'`. Callers wanting different defaults
+ * can override on the returned schema's individual fields.
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- Zod 4's enum-generic inference is too strict for a hand-written return signature; tuple sortFields would erode to `string` if explicitly typed. Inference preserves the narrow type via `const TSort`.
+export function createPaginationSchema<const TSort extends readonly [string, ...string[]]>(
+  sortFields: TSort
+) {
+  return z.object({
+    limit: z.number().int().min(1).max(100).optional(),
+    offset: z.number().int().min(0).optional(),
+    sort: z.enum(sortFields).optional(),
+    order: z.enum(['asc', 'desc'] as const).optional(),
+  });
+}
+
+// ============================================================================
+// Branded token types (preview / purge confirmation)
+// ============================================================================
+
+/**
+ * Branded type for previewed-then-execute batch operations.
+ *
+ * `GET /memory/delete/preview` issues a `PreviewToken` (short-lived,
+ * server-side Redis-backed) along with the impact summary. `POST
+ * /memory/delete` consumes the token — the filter that produced the
+ * preview is stored server-side under the token key, so the execute path
+ * can't drift from the preview path.
+ *
+ * Branding means callers can't accidentally pass an arbitrary string —
+ * they must obtain a real token from the preview endpoint first.
+ */
+export const PreviewTokenSchema = z
+  .string()
+  .regex(/^preview_[A-Za-z0-9_-]{16,64}$/, 'Invalid preview token format')
+  .brand<'PreviewToken'>();
+export type PreviewToken = z.infer<typeof PreviewTokenSchema>;
+
+/**
+ * Branded type for purge confirmation. Same shape as `PreviewToken` but
+ * a distinct brand so callers can't pass a delete-preview token to a
+ * purge endpoint (or vice versa) by accident.
+ */
+export const PurgeTokenSchema = z
+  .string()
+  .regex(/^purge_[A-Za-z0-9_-]{16,64}$/, 'Invalid purge token format')
+  .brand<'PurgeToken'>();
+export type PurgeToken = z.infer<typeof PurgeTokenSchema>;

--- a/packages/common-types/src/routes/types.ts
+++ b/packages/common-types/src/routes/types.ts
@@ -176,9 +176,13 @@ export interface RouteDef<
    * (or part of the options bag, depending on optionality). Server-side
    * the corresponding handler can `req.get(headerName)` and validate.
    *
-   * Currently used by destructive batch operations (`/memory/delete`,
-   * `/memory/purge`) to require an `Idempotency-Key` UUID so retries on
-   * network timeout don't double-execute.
+   * Reserved for future use. The destructive memory batch operations
+   * (`/memory/delete`, `/memory/purge`) achieve idempotency through the
+   * preview-token / purge-token handshake instead — the token IS the
+   * single-use replay key, so a separate `Idempotency-Key` header isn't
+   * needed in the current design. This field stands ready for routes
+   * outside the token-handshake pattern that still need header-driven
+   * idempotency.
    */
   readonly headers?: Record<string, z.ZodTypeAny>;
   /**

--- a/packages/common-types/src/schemas/api/memory.test.ts
+++ b/packages/common-types/src/schemas/api/memory.test.ts
@@ -8,7 +8,9 @@ import { describe, it, expect } from 'vitest';
 import {
   FocusModeSchema,
   MemoryUpdateSchema,
+  BatchDeletePreviewSchema,
   BatchDeleteSchema,
+  IssuePurgeTokenSchema,
   PurgeMemoriesSchema,
   MemorySearchSchema,
 } from './memory.js';
@@ -98,14 +100,14 @@ describe('Memory API Input Schema Tests', () => {
     });
   });
 
-  describe('BatchDeleteSchema', () => {
-    it('should accept minimal input', () => {
-      const result = BatchDeleteSchema.safeParse({ personalityId: 'abc-123' });
+  describe('BatchDeletePreviewSchema', () => {
+    it('accepts minimal input (personalityId only)', () => {
+      const result = BatchDeletePreviewSchema.safeParse({ personalityId: 'abc-123' });
       expect(result.success).toBe(true);
     });
 
-    it('should accept full input with timeframe and personaId', () => {
-      const result = BatchDeleteSchema.safeParse({
+    it('accepts full input with timeframe and personaId', () => {
+      const result = BatchDeletePreviewSchema.safeParse({
         personalityId: 'abc-123',
         personaId: 'persona-1',
         timeframe: '7d',
@@ -113,37 +115,90 @@ describe('Memory API Input Schema Tests', () => {
       expect(result.success).toBe(true);
     });
 
-    it('should reject empty personalityId', () => {
-      const result = BatchDeleteSchema.safeParse({ personalityId: '' });
+    it('rejects empty personalityId', () => {
+      const result = BatchDeletePreviewSchema.safeParse({ personalityId: '' });
       expect(result.success).toBe(false);
     });
 
-    it('should reject missing personalityId', () => {
+    it('rejects missing personalityId', () => {
+      const result = BatchDeletePreviewSchema.safeParse({});
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('BatchDeleteSchema', () => {
+    it('accepts a valid preview_-prefixed token', () => {
+      const result = BatchDeleteSchema.safeParse({
+        previewToken: 'preview_abcdef0123456789',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects a purge_-prefixed token (wrong brand)', () => {
+      const result = BatchDeleteSchema.safeParse({
+        previewToken: 'purge_abcdef0123456789',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects an arbitrary string that doesn't match the token regex", () => {
+      const result = BatchDeleteSchema.safeParse({ previewToken: 'not-a-token' });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects missing previewToken', () => {
       const result = BatchDeleteSchema.safeParse({});
       expect(result.success).toBe(false);
     });
   });
 
-  describe('PurgeMemoriesSchema', () => {
-    it('should accept personalityId with confirmation', () => {
-      const result = PurgeMemoriesSchema.safeParse({
+  describe('IssuePurgeTokenSchema', () => {
+    it('accepts personalityId + confirmation phrase', () => {
+      const result = IssuePurgeTokenSchema.safeParse({
         personalityId: 'abc-123',
         confirmationPhrase: 'DELETE LILITH MEMORIES',
       });
       expect(result.success).toBe(true);
     });
 
-    it('should accept personalityId without confirmation (validation happens in route)', () => {
-      const result = PurgeMemoriesSchema.safeParse({ personalityId: 'abc-123' });
-      expect(result.success).toBe(true);
-    });
-
-    it('should reject empty personalityId', () => {
-      const result = PurgeMemoriesSchema.safeParse({ personalityId: '' });
+    it('rejects empty personalityId', () => {
+      const result = IssuePurgeTokenSchema.safeParse({
+        personalityId: '',
+        confirmationPhrase: 'X',
+      });
       expect(result.success).toBe(false);
     });
 
-    it('should reject missing personalityId', () => {
+    it('rejects missing confirmationPhrase', () => {
+      const result = IssuePurgeTokenSchema.safeParse({ personalityId: 'abc-123' });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects empty confirmationPhrase', () => {
+      const result = IssuePurgeTokenSchema.safeParse({
+        personalityId: 'abc-123',
+        confirmationPhrase: '',
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('PurgeMemoriesSchema', () => {
+    it('accepts a valid purge_-prefixed token', () => {
+      const result = PurgeMemoriesSchema.safeParse({
+        purgeToken: 'purge_abcdef0123456789',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects a preview_-prefixed token (wrong brand)', () => {
+      const result = PurgeMemoriesSchema.safeParse({
+        purgeToken: 'preview_abcdef0123456789',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects missing purgeToken', () => {
       const result = PurgeMemoriesSchema.safeParse({});
       expect(result.success).toBe(false);
     });

--- a/packages/common-types/src/schemas/api/memory.test.ts
+++ b/packages/common-types/src/schemas/api/memory.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   FocusModeSchema,
+  SetMemoryLockSchema,
   MemoryUpdateSchema,
   BatchDeletePreviewSchema,
   BatchDeleteSchema,
@@ -56,6 +57,28 @@ describe('Memory API Input Schema Tests', () => {
         personalityId: 'abc',
         enabled: 'true',
       });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('SetMemoryLockSchema', () => {
+    it('accepts locked: true', () => {
+      const result = SetMemoryLockSchema.safeParse({ locked: true });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts locked: false', () => {
+      const result = SetMemoryLockSchema.safeParse({ locked: false });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects missing locked', () => {
+      const result = SetMemoryLockSchema.safeParse({});
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects non-boolean locked', () => {
+      const result = SetMemoryLockSchema.safeParse({ locked: 'true' });
       expect(result.success).toBe(false);
     });
   });
@@ -129,14 +152,14 @@ describe('Memory API Input Schema Tests', () => {
   describe('BatchDeleteSchema', () => {
     it('accepts a valid preview_-prefixed token', () => {
       const result = BatchDeleteSchema.safeParse({
-        previewToken: 'preview_abcdef0123456789',
+        previewToken: 'preview_test0000test0000',
       });
       expect(result.success).toBe(true);
     });
 
     it('rejects a purge_-prefixed token (wrong brand)', () => {
       const result = BatchDeleteSchema.safeParse({
-        previewToken: 'purge_abcdef0123456789',
+        previewToken: 'purge_test0000test0000',
       });
       expect(result.success).toBe(false);
     });
@@ -186,14 +209,14 @@ describe('Memory API Input Schema Tests', () => {
   describe('PurgeMemoriesSchema', () => {
     it('accepts a valid purge_-prefixed token', () => {
       const result = PurgeMemoriesSchema.safeParse({
-        purgeToken: 'purge_abcdef0123456789',
+        purgeToken: 'purge_test0000test0000',
       });
       expect(result.success).toBe(true);
     });
 
     it('rejects a preview_-prefixed token (wrong brand)', () => {
       const result = PurgeMemoriesSchema.safeParse({
-        purgeToken: 'preview_abcdef0123456789',
+        purgeToken: 'preview_test0000test0000',
       });
       expect(result.success).toBe(false);
     });

--- a/packages/common-types/src/schemas/api/memory.ts
+++ b/packages/common-types/src/schemas/api/memory.ts
@@ -5,6 +5,7 @@
  */
 
 import { z } from 'zod';
+import { PreviewTokenSchema, PurgeTokenSchema } from '../../routes/types.js';
 
 const PERSONALITY_ID_REQUIRED = 'personalityId is required';
 
@@ -50,23 +51,49 @@ export const MemoryUpdateSchema = z.object({
 export type MemoryUpdateInput = z.infer<typeof MemoryUpdateSchema>;
 
 // ============================================================================
-// POST /user/memory/delete
+// POST /user/memory/delete/preview
+// Issues a short-lived PreviewToken bound to the supplied filter. The token
+// is the only legal input to POST /user/memory/delete — the execute path
+// then re-reads the filter server-side and cannot drift from the preview.
 // ============================================================================
 
-export const BatchDeleteSchema = z.object({
+export const BatchDeletePreviewSchema = z.object({
   personalityId: z.string().min(1, PERSONALITY_ID_REQUIRED),
   personaId: z.string().optional(),
   timeframe: z.string().optional(),
 });
+export type BatchDeletePreviewInput = z.infer<typeof BatchDeletePreviewSchema>;
+
+// ============================================================================
+// POST /user/memory/delete
+// Body is a token previously obtained from /memory/delete/preview. The
+// filter that produced the preview is server-side under the token key.
+// ============================================================================
+
+export const BatchDeleteSchema = z.object({
+  previewToken: PreviewTokenSchema,
+});
 export type BatchDeleteInput = z.infer<typeof BatchDeleteSchema>;
 
 // ============================================================================
+// POST /user/memory/purge/token
+// Issues a short-lived PurgeToken after validating the confirmation phrase.
+// ============================================================================
+
+export const IssuePurgeTokenSchema = z.object({
+  personalityId: z.string().min(1, PERSONALITY_ID_REQUIRED),
+  confirmationPhrase: z.string().min(1, 'confirmationPhrase is required'),
+});
+export type IssuePurgeTokenInput = z.infer<typeof IssuePurgeTokenSchema>;
+
+// ============================================================================
 // POST /user/memory/purge
+// Body is a token previously obtained from /memory/purge/token. The
+// personality binding is server-side under the token key.
 // ============================================================================
 
 export const PurgeMemoriesSchema = z.object({
-  personalityId: z.string().min(1, PERSONALITY_ID_REQUIRED),
-  confirmationPhrase: z.string().optional(),
+  purgeToken: PurgeTokenSchema,
 });
 export type PurgeMemoriesInput = z.infer<typeof PurgeMemoriesSchema>;
 

--- a/packages/common-types/src/schemas/api/memory.ts
+++ b/packages/common-types/src/schemas/api/memory.ts
@@ -19,6 +19,17 @@ export const FocusModeSchema = z.object({
 export type FocusModeInput = z.infer<typeof FocusModeSchema>;
 
 // ============================================================================
+// PUT /user/memory/:id/lock
+// Sets the lock state explicitly (idempotent on retry, unlike the prior
+// toggle-on-POST shape).
+// ============================================================================
+
+export const SetMemoryLockSchema = z.object({
+  locked: z.boolean({ error: 'locked must be a boolean' }),
+});
+export type SetMemoryLockInput = z.infer<typeof SetMemoryLockSchema>;
+
+// ============================================================================
 // PATCH /user/memory/:id
 // ============================================================================
 

--- a/packages/tooling/src/codegen/method-builder.test.ts
+++ b/packages/tooling/src/codegen/method-builder.test.ts
@@ -199,4 +199,25 @@ describe('buildMethod — user flavor', () => {
     expect(out).not.toContain('filter?: string');
     expect(out).not.toContain('filter: string } = {}');
   });
+
+  it('accepts a ZodObject query schema (not just Record<string, ZodTypeAny>)', () => {
+    // Shared/reusable query schemas (e.g., createPaginationSchema output) are
+    // ZodObjects, not plain Records. Codegen must unwrap via resolveQueryShape
+    // so the generated client signature is identical for both forms.
+    const querySchema = z.object({
+      limit: z.number().int().optional(),
+      sort: z.enum(['createdAt', 'updatedAt']).optional(),
+      personalityId: z.string(),
+    });
+    const route: RouteDef = {
+      ...baseRoute,
+      query: querySchema,
+    };
+    const out = buildMethod(route, { flavor: 'user', pathPrefix: '/api/user' });
+    // Required `personalityId` forces the options bag to be required;
+    // optional limit/sort get `?` markers.
+    expect(out).toContain(`options: { limit?: string; sort?: string; personalityId: string }`);
+    expect(out).toContain(`['limit', options.limit]`);
+    expect(out).toContain(`['personalityId', options.personalityId]`);
+  });
 });

--- a/packages/tooling/src/codegen/method-builder.ts
+++ b/packages/tooling/src/codegen/method-builder.ts
@@ -9,7 +9,7 @@
  */
 
 import { z } from 'zod';
-import type { Audience, RouteDef } from '@tzurot/common-types';
+import { resolveQueryShape, type Audience, type RouteDef } from '@tzurot/common-types';
 
 /**
  * Detect whether a Zod schema is marked optional. `z.string()` is required,
@@ -28,12 +28,15 @@ function isOptionalZod(schema: z.ZodTypeAny): boolean {
 /**
  * For a route's `query` map, return whether at least one entry is required
  * (used to decide if the entire `options` argument can be omitted).
+ * Accepts either form of `RouteDef.query` (Record or ZodObject) via
+ * `resolveQueryShape`.
  */
 function hasRequiredQueryParam(query: RouteDef['query']): boolean {
-  if (query === undefined) {
+  const shape = resolveQueryShape(query);
+  if (shape === undefined) {
     return false;
   }
-  return Object.values(query).some(schema => !isOptionalZod(schema));
+  return Object.values(shape).some(schema => !isOptionalZod(schema));
 }
 
 /**
@@ -117,8 +120,9 @@ export function buildMethod(route: RouteDef, options: MethodBuildOptions): strin
   if (acceptsSubject) {
     queryEntries.push(`['userId', options.subject]`);
   }
-  if (route.query !== undefined) {
-    for (const key of Object.keys(route.query)) {
+  const queryShape = resolveQueryShape(route.query);
+  if (queryShape !== undefined) {
+    for (const key of Object.keys(queryShape)) {
       queryEntries.push(`['${key}', options.${key}]`);
     }
   }
@@ -221,8 +225,9 @@ function buildOptionsType(route: RouteDef, acceptsSubject: boolean): string {
   if (acceptsSubject) {
     fields.push(`subject?: SubjectDiscordId`);
   }
-  if (route.query !== undefined) {
-    for (const [key, schema] of Object.entries(route.query)) {
+  const shape = resolveQueryShape(route.query);
+  if (shape !== undefined) {
+    for (const [key, schema] of Object.entries(shape)) {
       // All query params are strings at the wire level; their narrower
       // typing lives in the route's Zod schema (validated server-side).
       // Required vs optional is derived from the schema's Zod wrapper:

--- a/services/api-gateway/src/routes/user/memory.ts
+++ b/services/api-gateway/src/routes/user/memory.ts
@@ -277,7 +277,7 @@ type MemoryHandler = (
 /**
  * Wider signature for handlers that depend on the Redis-backed
  * MemoryActionTokenService (preview-token batch ops). `tokenService` is
- * `null` when Redis is unavailable; handlers respond with a 500 in that
+ * `null` when Redis is unavailable; handlers respond with a 503 in that
  * case rather than crashing.
  */
 type MemoryTokenHandler = (
@@ -315,7 +315,7 @@ export function createMemoryRoutes(deps: RouteDeps): Router {
   }
 
   // Token service for preview/purge handshake — null when Redis is absent;
-  // the batch handlers respond with a 500 instead of crashing in that case.
+  // the batch handlers respond with a 503 instead of crashing in that case.
   const tokenService = redis !== undefined ? new MemoryActionTokenService(redis) : null;
 
   /** Bind a token-using handler to the resolved token service. */

--- a/services/api-gateway/src/routes/user/memory.ts
+++ b/services/api-gateway/src/routes/user/memory.ts
@@ -7,13 +7,14 @@
  * GET /user/memory/focus - Get focus mode status
  * POST /user/memory/focus - Enable/disable focus mode
  * POST /user/memory/search - Semantic search of memories
- * GET /user/memory/delete/preview - Preview batch delete without executing
- * POST /user/memory/delete - Batch delete memories with filters
- * POST /user/memory/purge - Purge all memories for a personality (typed confirmation required)
+ * POST /user/memory/delete/preview - Preview batch delete; issues PreviewToken
+ * POST /user/memory/delete - Execute batch delete using PreviewToken
+ * POST /user/memory/purge/token - Validate confirmation phrase; issues PurgeToken
+ * POST /user/memory/purge - Execute purge using PurgeToken
  * GET /user/memory/:id - Get a single memory
  * PATCH /user/memory/:id - Update memory content
  * DELETE /user/memory/:id - Delete a single memory
- * POST /user/memory/:id/lock - Toggle memory lock status
+ * PUT /user/memory/:id/lock - Set memory lock state explicitly (idempotent on retry)
  *
  * Incognito mode (sub-routes mounted at /user/memory/incognito):
  * GET /user/memory/incognito - Get incognito status
@@ -46,8 +47,14 @@ import {
   handleSetMemoryLock,
   handleDeleteMemory,
 } from './memorySingle.js';
-import { handleBatchDelete, handleBatchDeletePreview, handlePurge } from './memoryBatch.js';
+import {
+  handleBatchDelete,
+  handleBatchDeletePreview,
+  handleIssuePurgeToken,
+  handlePurge,
+} from './memoryBatch.js';
 import { createIncognitoRoutes } from './memoryIncognito.js';
+import { MemoryActionTokenService } from '../../services/MemoryActionTokenService.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';
 import { getDefaultPersonaId, getPersonalityById } from './memoryHelpers.js';
 
@@ -267,6 +274,19 @@ type MemoryHandler = (
   res: Response
 ) => Promise<void>;
 
+/**
+ * Wider signature for handlers that depend on the Redis-backed
+ * MemoryActionTokenService (preview-token batch ops). `tokenService` is
+ * `null` when Redis is unavailable; handlers respond with a 500 in that
+ * case rather than crashing.
+ */
+type MemoryTokenHandler = (
+  prisma: PrismaClient,
+  tokenService: MemoryActionTokenService | null,
+  req: ProvisionedRequest,
+  res: Response
+) => Promise<void>;
+
 interface RegisterRouteParams {
   router: Router;
   prisma: PrismaClient;
@@ -294,6 +314,15 @@ export function createMemoryRoutes(deps: RouteDeps): Router {
     router.use('/incognito', createIncognitoRoutes(prisma, redis));
   }
 
+  // Token service for preview/purge handshake — null when Redis is absent;
+  // the batch handlers respond with a 500 instead of crashing in that case.
+  const tokenService = redis !== undefined ? new MemoryActionTokenService(redis) : null;
+
+  /** Bind a token-using handler to the resolved token service. */
+  const bindToken = (handler: MemoryTokenHandler): MemoryHandler => {
+    return (p, req, res) => handler(p, tokenService, req, res);
+  };
+
   const routes: {
     method: RegisterRouteParams['method'];
     path: string;
@@ -305,9 +334,10 @@ export function createMemoryRoutes(deps: RouteDeps): Router {
     { method: 'post', path: '/focus', handler: handleSetFocus },
     { method: 'post', path: '/search', handler: handleSearch },
     // Batch operations — must come before /:id routes
-    { method: 'get', path: '/delete/preview', handler: handleBatchDeletePreview },
-    { method: 'post', path: '/delete', handler: handleBatchDelete },
-    { method: 'post', path: '/purge', handler: handlePurge },
+    { method: 'post', path: '/delete/preview', handler: bindToken(handleBatchDeletePreview) },
+    { method: 'post', path: '/delete', handler: bindToken(handleBatchDelete) },
+    { method: 'post', path: '/purge/token', handler: bindToken(handleIssuePurgeToken) },
+    { method: 'post', path: '/purge', handler: bindToken(handlePurge) },
     // Single memory operations — must come after specific routes
     { method: 'get', path: '/:id', handler: handleGetMemory },
     { method: 'patch', path: '/:id', handler: handleUpdateMemory },

--- a/services/api-gateway/src/routes/user/memory.ts
+++ b/services/api-gateway/src/routes/user/memory.ts
@@ -43,7 +43,7 @@ import { handleList } from './memoryList.js';
 import {
   handleGetMemory,
   handleUpdateMemory,
-  handleToggleLock,
+  handleSetMemoryLock,
   handleDeleteMemory,
 } from './memorySingle.js';
 import { handleBatchDelete, handleBatchDeletePreview, handlePurge } from './memoryBatch.js';
@@ -270,7 +270,7 @@ type MemoryHandler = (
 interface RegisterRouteParams {
   router: Router;
   prisma: PrismaClient;
-  method: 'get' | 'post' | 'patch' | 'delete';
+  method: 'get' | 'post' | 'put' | 'patch' | 'delete';
   path: string;
   handler: MemoryHandler;
 }
@@ -312,7 +312,7 @@ export function createMemoryRoutes(deps: RouteDeps): Router {
     { method: 'get', path: '/:id', handler: handleGetMemory },
     { method: 'patch', path: '/:id', handler: handleUpdateMemory },
     { method: 'delete', path: '/:id', handler: handleDeleteMemory },
-    { method: 'post', path: '/:id/lock', handler: handleToggleLock },
+    { method: 'put', path: '/:id/lock', handler: handleSetMemoryLock },
   ];
 
   for (const route of routes) {

--- a/services/api-gateway/src/routes/user/memoryBatch.test.ts
+++ b/services/api-gateway/src/routes/user/memoryBatch.test.ts
@@ -1,18 +1,22 @@
 /**
  * Tests for /user/memory batch operations
  *
- * Tests batch delete and purge operations:
- * - GET /delete/preview - Preview batch deletion
- * - POST /delete - Batch delete with filters
- * - POST /purge - Purge all memories (requires confirmation)
+ * The destructive batch flows use a preview/execute token handshake:
+ *  - POST /delete/preview      → issues PreviewToken
+ *  - POST /delete              → consumes PreviewToken
+ *  - POST /purge/token         → validates confirmation, issues PurgeToken
+ *  - POST /purge               → consumes PurgeToken
+ *
+ * Tests cover the token-handshake mechanics plus the Redis-unavailable
+ * fallback (503) for each of the four handlers.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Response } from 'express';
-import type { PrismaClient } from '@tzurot/common-types';
+import type { PrismaClient, BatchDeletePreviewInput } from '@tzurot/common-types';
 import type { ProvisionedRequest } from '../../types.js';
+import type { MemoryActionTokenService } from '../../services/MemoryActionTokenService.js';
 
-// Mock logger
 vi.mock('@tzurot/common-types', async () => {
   const actual = await vi.importActual('@tzurot/common-types');
   return {
@@ -26,19 +30,22 @@ vi.mock('@tzurot/common-types', async () => {
   };
 });
 
-// Mock memory helpers
 vi.mock('./memoryHelpers.js', () => ({
   getDefaultPersonaId: vi.fn(),
   getPersonalityById: vi.fn(),
   parseTimeframeFilter: vi.fn(),
 }));
 
-// Mock resolveProvisionedUserId
 vi.mock('../../utils/resolveProvisionedUserId.js', () => ({
   resolveProvisionedUserId: vi.fn(),
 }));
 
-import { handleBatchDelete, handleBatchDeletePreview, handlePurge } from './memoryBatch.js';
+import {
+  handleBatchDelete,
+  handleBatchDeletePreview,
+  handleIssuePurgeToken,
+  handlePurge,
+} from './memoryBatch.js';
 import { getDefaultPersonaId, getPersonalityById, parseTimeframeFilter } from './memoryHelpers.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';
 
@@ -47,13 +54,14 @@ const mockGetDefaultPersonaId = vi.mocked(getDefaultPersonaId);
 const mockGetPersonalityById = vi.mocked(getPersonalityById);
 const mockParseTimeframeFilter = vi.mocked(parseTimeframeFilter);
 
-// Test constants
 const TEST_USER_ID = '00000000-0000-0000-0000-000000000001';
 const TEST_PERSONA_ID = '00000000-0000-0000-0000-000000000002';
 const TEST_PERSONALITY_ID = '00000000-0000-0000-0000-000000000003';
 const TEST_DISCORD_USER_ID = 'discord-user-123';
 
-// Mock Prisma
+const VALID_PREVIEW_TOKEN = 'preview_abcdef0123456789';
+const VALID_PURGE_TOKEN = 'purge_abcdef0123456789';
+
 const mockPrisma = {
   memory: {
     count: vi.fn(),
@@ -64,7 +72,30 @@ const mockPrisma = {
   },
 };
 
-// Helper to create mock request with body
+function createTokenServiceMock(
+  overrides: Partial<{
+    issuePreviewToken: () => Promise<string>;
+    consumePreviewToken: (uid: string, t: string) => Promise<BatchDeletePreviewInput | null>;
+    issuePurgeToken: () => Promise<string>;
+    consumePurgeToken: (uid: string, t: string) => Promise<{ personalityId: string } | null>;
+  }> = {}
+): MemoryActionTokenService {
+  return {
+    issuePreviewToken: vi.fn(overrides.issuePreviewToken ?? (async () => VALID_PREVIEW_TOKEN)),
+    consumePreviewToken: vi.fn(
+      overrides.consumePreviewToken ??
+        (async () => ({
+          personalityId: TEST_PERSONALITY_ID,
+          personaId: TEST_PERSONA_ID,
+        }))
+    ),
+    issuePurgeToken: vi.fn(overrides.issuePurgeToken ?? (async () => VALID_PURGE_TOKEN)),
+    consumePurgeToken: vi.fn(
+      overrides.consumePurgeToken ?? (async () => ({ personalityId: TEST_PERSONALITY_ID }))
+    ),
+  } as unknown as MemoryActionTokenService;
+}
+
 function createMockBodyReq(body: Record<string, unknown> = {}) {
   const req = {
     userId: TEST_DISCORD_USER_ID,
@@ -81,40 +112,22 @@ function createMockBodyReq(body: Record<string, unknown> = {}) {
   return { req, res };
 }
 
-// Helper to create mock request with query params
-function createMockQueryReq(query: Record<string, string> = {}) {
-  const req = {
-    userId: TEST_DISCORD_USER_ID,
-    body: {},
-    params: {},
-    query,
-  } as unknown as ProvisionedRequest;
-
-  const res = {
-    status: vi.fn().mockReturnThis(),
-    json: vi.fn().mockReturnThis(),
-  } as unknown as Response;
-
-  return { req, res };
-}
-
-// Default personality fixture
 const defaultPersonality = {
   id: TEST_PERSONALITY_ID,
   name: 'test-personality',
 };
 
-// Default persona fixture
 const defaultPersona = {
   id: TEST_PERSONA_ID,
   ownerId: TEST_USER_ID,
 };
 
 describe('memoryBatch handlers', () => {
+  let tokenService: MemoryActionTokenService;
+
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // Default successful mocks
     mockResolveProvisionedUserId.mockReturnValue(TEST_USER_ID);
     mockGetDefaultPersonaId.mockResolvedValue(TEST_PERSONA_ID);
     mockGetPersonalityById.mockResolvedValue(defaultPersonality);
@@ -122,14 +135,19 @@ describe('memoryBatch handlers', () => {
     mockPrisma.persona.findUnique.mockResolvedValue(defaultPersona);
     mockPrisma.memory.count.mockResolvedValue(0);
     mockPrisma.memory.updateMany.mockResolvedValue({ count: 0 });
+    tokenService = createTokenServiceMock();
   });
 
   describe('handleBatchDeletePreview', () => {
-    it('should reject missing personalityId', async () => {
-      const { req, res } = createMockQueryReq({});
+    it('returns 503 when token service is null (Redis unavailable)', async () => {
+      const { req, res } = createMockBodyReq({ personalityId: TEST_PERSONALITY_ID });
+      await handleBatchDeletePreview(mockPrisma as unknown as PrismaClient, null, req, res);
+      expect(res.status).toHaveBeenCalledWith(503);
+    });
 
-      await handleBatchDeletePreview(mockPrisma as unknown as PrismaClient, req, res);
-
+    it('rejects missing personalityId', async () => {
+      const { req, res } = createMockBodyReq({});
+      await handleBatchDeletePreview(mockPrisma as unknown as PrismaClient, tokenService, req, res);
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -139,74 +157,47 @@ describe('memoryBatch handlers', () => {
       );
     });
 
-    it('should reject empty personalityId', async () => {
-      const { req, res } = createMockQueryReq({ personalityId: '' });
-
-      await handleBatchDeletePreview(mockPrisma as unknown as PrismaClient, req, res);
-
-      expect(res.status).toHaveBeenCalledWith(400);
-    });
-
-    it('should return early when personality not found', async () => {
+    it('returns early when personality not found', async () => {
       mockGetPersonalityById.mockResolvedValue(null);
-      const { req, res } = createMockQueryReq({ personalityId: TEST_PERSONALITY_ID });
-
-      await handleBatchDeletePreview(mockPrisma as unknown as PrismaClient, req, res);
-
-      // getPersonalityById handles the 404 response internally
-      expect(mockGetPersonalityById).toHaveBeenCalledWith(
-        mockPrisma,
-        TEST_PERSONALITY_ID,
-        expect.anything()
-      );
-      // Handler should not attempt its own response after early return
+      const { req, res } = createMockBodyReq({ personalityId: TEST_PERSONALITY_ID });
+      await handleBatchDeletePreview(mockPrisma as unknown as PrismaClient, tokenService, req, res);
+      expect(mockGetPersonalityById).toHaveBeenCalled();
       expect(res.status).not.toHaveBeenCalled();
     });
 
-    it('should return zero counts when user has no persona', async () => {
+    it('returns 400 when user has no persona', async () => {
       mockGetDefaultPersonaId.mockResolvedValue(null);
-      const { req, res } = createMockQueryReq({ personalityId: TEST_PERSONALITY_ID });
-
-      await handleBatchDeletePreview(mockPrisma as unknown as PrismaClient, req, res);
-
-      expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.json).toHaveBeenCalledWith(
-        expect.objectContaining({
-          wouldDelete: 0,
-          lockedWouldSkip: 0,
-        })
-      );
+      const { req, res } = createMockBodyReq({ personalityId: TEST_PERSONALITY_ID });
+      await handleBatchDeletePreview(mockPrisma as unknown as PrismaClient, tokenService, req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
     });
 
-    it('should reject invalid timeframe format', async () => {
+    it('rejects invalid timeframe format', async () => {
       mockParseTimeframeFilter.mockReturnValue({
         filter: null,
         error: 'Invalid timeframe format. Use: 1h, 24h, 7d, 30d, etc.',
       });
-      const { req, res } = createMockQueryReq({
+      const { req, res } = createMockBodyReq({
         personalityId: TEST_PERSONALITY_ID,
         timeframe: 'invalid',
       });
-
-      await handleBatchDeletePreview(mockPrisma as unknown as PrismaClient, req, res);
-
+      await handleBatchDeletePreview(mockPrisma as unknown as PrismaClient, tokenService, req, res);
       expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: expect.stringContaining('Invalid timeframe'),
-        })
-      );
     });
 
-    it('should return preview counts for valid request', async () => {
-      mockPrisma.memory.count
-        .mockResolvedValueOnce(10) // wouldDelete
-        .mockResolvedValueOnce(2); // lockedWouldSkip
+    it('returns preview counts plus a previewToken for a valid request', async () => {
+      mockPrisma.memory.count.mockResolvedValueOnce(10).mockResolvedValueOnce(2);
 
-      const { req, res } = createMockQueryReq({ personalityId: TEST_PERSONALITY_ID });
+      const { req, res } = createMockBodyReq({ personalityId: TEST_PERSONALITY_ID });
+      await handleBatchDeletePreview(mockPrisma as unknown as PrismaClient, tokenService, req, res);
 
-      await handleBatchDeletePreview(mockPrisma as unknown as PrismaClient, req, res);
-
+      expect(tokenService.issuePreviewToken).toHaveBeenCalledWith(
+        TEST_DISCORD_USER_ID,
+        expect.objectContaining({
+          personalityId: TEST_PERSONALITY_ID,
+          personaId: TEST_PERSONA_ID,
+        })
+      );
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -215,189 +206,93 @@ describe('memoryBatch handlers', () => {
           personalityId: TEST_PERSONALITY_ID,
           personalityName: 'test-personality',
           timeframe: 'all',
+          previewToken: VALID_PREVIEW_TOKEN,
         })
       );
     });
 
-    it('should apply timeframe filter when provided (hours)', async () => {
-      const cutoffDate = new Date(Date.now() - 24 * 60 * 60 * 1000);
-      mockParseTimeframeFilter.mockReturnValue({ filter: { gte: cutoffDate } });
-      mockPrisma.memory.count.mockResolvedValue(5);
-      const { req, res } = createMockQueryReq({
-        personalityId: TEST_PERSONALITY_ID,
-        timeframe: '24h',
-      });
-
-      await handleBatchDeletePreview(mockPrisma as unknown as PrismaClient, req, res);
-
-      expect(mockPrisma.memory.count).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({
-            createdAt: expect.objectContaining({ gte: expect.any(Date) }),
-          }),
-        })
-      );
-      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ timeframe: '24h' }));
-    });
-
-    it('should apply timeframe filter when provided (days)', async () => {
+    it('applies timeframe filter when provided and binds it into the token payload', async () => {
       const cutoffDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
       mockParseTimeframeFilter.mockReturnValue({ filter: { gte: cutoffDate } });
       mockPrisma.memory.count.mockResolvedValue(3);
-      const { req, res } = createMockQueryReq({
+
+      const { req, res } = createMockBodyReq({
         personalityId: TEST_PERSONALITY_ID,
         timeframe: '7d',
       });
+      await handleBatchDeletePreview(mockPrisma as unknown as PrismaClient, tokenService, req, res);
 
-      await handleBatchDeletePreview(mockPrisma as unknown as PrismaClient, req, res);
-
-      expect(mockPrisma.memory.count).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({
-            createdAt: expect.objectContaining({ gte: expect.any(Date) }),
-          }),
-        })
-      );
-    });
-
-    it('should apply timeframe filter when provided (years)', async () => {
-      const cutoffDate = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000);
-      mockParseTimeframeFilter.mockReturnValue({ filter: { gte: cutoffDate } });
-      mockPrisma.memory.count.mockResolvedValue(100);
-      const { req, res } = createMockQueryReq({
-        personalityId: TEST_PERSONALITY_ID,
-        timeframe: '1y',
-      });
-
-      await handleBatchDeletePreview(mockPrisma as unknown as PrismaClient, req, res);
-
-      expect(res.status).toHaveBeenCalledWith(200);
-    });
-
-    it('should use custom personaId when provided', async () => {
-      const customPersonaId = '00000000-0000-0000-0000-000000000099';
-      const { req, res } = createMockQueryReq({
-        personalityId: TEST_PERSONALITY_ID,
-        personaId: customPersonaId,
-      });
-
-      await handleBatchDeletePreview(mockPrisma as unknown as PrismaClient, req, res);
-
-      expect(mockPrisma.memory.count).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({
-            personaId: customPersonaId,
-          }),
-        })
+      expect(tokenService.issuePreviewToken).toHaveBeenCalledWith(
+        TEST_DISCORD_USER_ID,
+        expect.objectContaining({ timeframe: '7d' })
       );
     });
   });
 
   describe('handleBatchDelete', () => {
-    it('should reject missing personalityId', async () => {
+    it('returns 503 when token service is null', async () => {
+      const { req, res } = createMockBodyReq({ previewToken: VALID_PREVIEW_TOKEN });
+      await handleBatchDelete(mockPrisma as unknown as PrismaClient, null, req, res);
+      expect(res.status).toHaveBeenCalledWith(503);
+    });
+
+    it('rejects missing previewToken', async () => {
       const { req, res } = createMockBodyReq({});
+      await handleBatchDelete(mockPrisma as unknown as PrismaClient, tokenService, req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
 
-      await handleBatchDelete(mockPrisma as unknown as PrismaClient, req, res);
+    it('rejects malformed previewToken (wrong prefix)', async () => {
+      const { req, res } = createMockBodyReq({ previewToken: 'purge_abcdef0123456789' });
+      await handleBatchDelete(mockPrisma as unknown as PrismaClient, tokenService, req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
 
+    it('returns 400 when token is unknown / expired / replayed', async () => {
+      tokenService = createTokenServiceMock({
+        consumePreviewToken: async () => null,
+      });
+      const { req, res } = createMockBodyReq({ previewToken: VALID_PREVIEW_TOKEN });
+      await handleBatchDelete(mockPrisma as unknown as PrismaClient, tokenService, req, res);
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
-          error: 'VALIDATION_ERROR',
-          message: expect.stringContaining('personalityId'),
+          message: expect.stringContaining('Preview token'),
         })
       );
     });
 
-    it('should return early when personality not found', async () => {
-      mockGetPersonalityById.mockResolvedValue(null);
-      const { req, res } = createMockBodyReq({ personalityId: TEST_PERSONALITY_ID });
-
-      await handleBatchDelete(mockPrisma as unknown as PrismaClient, req, res);
-
-      // getPersonalityById handles the 404 response internally
-      expect(mockGetPersonalityById).toHaveBeenCalledWith(
-        mockPrisma,
-        TEST_PERSONALITY_ID,
-        expect.anything()
-      );
-      // Handler should not attempt its own response after early return
-      expect(res.status).not.toHaveBeenCalled();
-    });
-
-    it('should return 400 when user has no persona', async () => {
-      mockGetDefaultPersonaId.mockResolvedValue(null);
-      const { req, res } = createMockBodyReq({ personalityId: TEST_PERSONALITY_ID });
-
-      await handleBatchDelete(mockPrisma as unknown as PrismaClient, req, res);
-
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: expect.stringContaining('No persona'),
-        })
-      );
-    });
-
-    it('should return 403 when persona does not belong to user', async () => {
+    it('returns 403 when token-bound persona does not belong to user', async () => {
+      tokenService = createTokenServiceMock({
+        consumePreviewToken: async () => ({
+          personalityId: TEST_PERSONALITY_ID,
+          personaId: TEST_PERSONA_ID,
+        }),
+      });
       mockPrisma.persona.findUnique.mockResolvedValue({
         id: TEST_PERSONA_ID,
         ownerId: 'different-user-id',
       });
-      const { req, res } = createMockBodyReq({
-        personalityId: TEST_PERSONALITY_ID,
-        personaId: TEST_PERSONA_ID,
-      });
-
-      await handleBatchDelete(mockPrisma as unknown as PrismaClient, req, res);
-
+      const { req, res } = createMockBodyReq({ previewToken: VALID_PREVIEW_TOKEN });
+      await handleBatchDelete(mockPrisma as unknown as PrismaClient, tokenService, req, res);
       expect(res.status).toHaveBeenCalledWith(403);
     });
 
-    it('should reject invalid timeframe format', async () => {
-      mockParseTimeframeFilter.mockReturnValue({
-        filter: null,
-        error: 'Invalid timeframe format. Use: 1h, 24h, 7d, 30d, etc.',
-      });
-      const { req, res } = createMockBodyReq({
-        personalityId: TEST_PERSONALITY_ID,
-        timeframe: 'invalid', // not a valid duration format
-      });
-
-      await handleBatchDelete(mockPrisma as unknown as PrismaClient, req, res);
-
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: expect.stringContaining('Invalid timeframe'),
-        })
-      );
-    });
-
-    it('should return success with zero count when no memories match', async () => {
+    it('returns zero-count success when no memories match', async () => {
       mockPrisma.memory.count.mockResolvedValue(0);
-      const { req, res } = createMockBodyReq({ personalityId: TEST_PERSONALITY_ID });
-
-      await handleBatchDelete(mockPrisma as unknown as PrismaClient, req, res);
-
+      const { req, res } = createMockBodyReq({ previewToken: VALID_PREVIEW_TOKEN });
+      await handleBatchDelete(mockPrisma as unknown as PrismaClient, tokenService, req, res);
       expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.json).toHaveBeenCalledWith(
-        expect.objectContaining({
-          deletedCount: 0,
-          message: expect.stringContaining('No memories found'),
-        })
-      );
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ deletedCount: 0 }));
       expect(mockPrisma.memory.updateMany).not.toHaveBeenCalled();
     });
 
-    it('should delete memories and return counts', async () => {
-      mockPrisma.memory.count
-        .mockResolvedValueOnce(5) // count to delete
-        .mockResolvedValueOnce(2); // locked count
+    it('deletes memories and returns counts using the token-bound filter', async () => {
+      mockPrisma.memory.count.mockResolvedValueOnce(5).mockResolvedValueOnce(2);
       mockPrisma.memory.updateMany.mockResolvedValue({ count: 5 });
 
-      const { req, res } = createMockBodyReq({ personalityId: TEST_PERSONALITY_ID });
-
-      await handleBatchDelete(mockPrisma as unknown as PrismaClient, req, res);
+      const { req, res } = createMockBodyReq({ previewToken: VALID_PREVIEW_TOKEN });
+      await handleBatchDelete(mockPrisma as unknown as PrismaClient, tokenService, req, res);
 
       expect(mockPrisma.memory.updateMany).toHaveBeenCalledWith({
         where: expect.objectContaining({
@@ -411,46 +306,32 @@ describe('memoryBatch handlers', () => {
           updatedAt: expect.any(Date),
         }),
       });
-
-      expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
           deletedCount: 5,
           skippedLocked: 2,
           personalityId: TEST_PERSONALITY_ID,
-          personalityName: 'test-personality',
         })
       );
     });
 
-    it('should include locked message when locked memories exist', async () => {
-      mockPrisma.memory.count.mockResolvedValueOnce(3).mockResolvedValueOnce(1);
-      mockPrisma.memory.updateMany.mockResolvedValue({ count: 3 });
-
-      const { req, res } = createMockBodyReq({ personalityId: TEST_PERSONALITY_ID });
-
-      await handleBatchDelete(mockPrisma as unknown as PrismaClient, req, res);
-
-      expect(res.json).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: expect.stringContaining('locked memories were skipped'),
-        })
-      );
-    });
-
-    it('should apply timeframe filter in delete', async () => {
+    it('applies timeframe filter from the token-bound payload', async () => {
+      tokenService = createTokenServiceMock({
+        consumePreviewToken: async () => ({
+          personalityId: TEST_PERSONALITY_ID,
+          personaId: TEST_PERSONA_ID,
+          timeframe: '30d',
+        }),
+      });
       const cutoffDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
       mockParseTimeframeFilter.mockReturnValue({ filter: { gte: cutoffDate } });
       mockPrisma.memory.count.mockResolvedValue(2);
       mockPrisma.memory.updateMany.mockResolvedValue({ count: 2 });
 
-      const { req, res } = createMockBodyReq({
-        personalityId: TEST_PERSONALITY_ID,
-        timeframe: '30d',
-      });
+      const { req, res } = createMockBodyReq({ previewToken: VALID_PREVIEW_TOKEN });
+      await handleBatchDelete(mockPrisma as unknown as PrismaClient, tokenService, req, res);
 
-      await handleBatchDelete(mockPrisma as unknown as PrismaClient, req, res);
-
+      expect(mockParseTimeframeFilter).toHaveBeenCalledWith('30d');
       expect(mockPrisma.memory.updateMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
@@ -459,134 +340,122 @@ describe('memoryBatch handlers', () => {
         })
       );
     });
-
-    it('should use custom personaId when provided', async () => {
-      const customPersonaId = '00000000-0000-0000-0000-000000000099';
-      mockPrisma.persona.findUnique.mockResolvedValue({
-        id: customPersonaId,
-        ownerId: TEST_USER_ID,
-      });
-      mockPrisma.memory.count.mockResolvedValue(1);
-      mockPrisma.memory.updateMany.mockResolvedValue({ count: 1 });
-
-      const { req, res } = createMockBodyReq({
-        personalityId: TEST_PERSONALITY_ID,
-        personaId: customPersonaId,
-      });
-
-      await handleBatchDelete(mockPrisma as unknown as PrismaClient, req, res);
-
-      expect(mockPrisma.memory.updateMany).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({
-            personaId: customPersonaId,
-          }),
-        })
-      );
-    });
   });
 
-  describe('handlePurge', () => {
-    it('should reject missing personalityId', async () => {
-      const { req, res } = createMockBodyReq({});
+  describe('handleIssuePurgeToken', () => {
+    it('returns 503 when token service is null', async () => {
+      const { req, res } = createMockBodyReq({
+        personalityId: TEST_PERSONALITY_ID,
+        confirmationPhrase: 'DELETE TEST-PERSONALITY MEMORIES',
+      });
+      await handleIssuePurgeToken(mockPrisma as unknown as PrismaClient, null, req, res);
+      expect(res.status).toHaveBeenCalledWith(503);
+    });
 
-      await handlePurge(mockPrisma as unknown as PrismaClient, req, res);
-
+    it('rejects missing personalityId', async () => {
+      const { req, res } = createMockBodyReq({ confirmationPhrase: 'DELETE X MEMORIES' });
+      await handleIssuePurgeToken(mockPrisma as unknown as PrismaClient, tokenService, req, res);
       expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith(
-        expect.objectContaining({
-          error: 'VALIDATION_ERROR',
-          message: expect.stringContaining('personalityId'),
-        })
-      );
     });
 
-    it('should return early when personality not found', async () => {
-      mockGetPersonalityById.mockResolvedValue(null);
+    it('rejects missing confirmation phrase', async () => {
       const { req, res } = createMockBodyReq({ personalityId: TEST_PERSONALITY_ID });
-
-      await handlePurge(mockPrisma as unknown as PrismaClient, req, res);
-
-      // getPersonalityById handles the 404 response internally
-      expect(mockGetPersonalityById).toHaveBeenCalledWith(
-        mockPrisma,
-        TEST_PERSONALITY_ID,
-        expect.anything()
-      );
-      // Handler should not attempt its own response after early return
-      expect(res.status).not.toHaveBeenCalled();
-    });
-
-    it('should reject missing confirmation phrase', async () => {
-      const { req, res } = createMockBodyReq({ personalityId: TEST_PERSONALITY_ID });
-
-      await handlePurge(mockPrisma as unknown as PrismaClient, req, res);
-
+      await handleIssuePurgeToken(mockPrisma as unknown as PrismaClient, tokenService, req, res);
       expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: expect.stringContaining('Confirmation required'),
-        })
-      );
     });
 
-    it('should reject incorrect confirmation phrase', async () => {
+    it('rejects incorrect confirmation phrase', async () => {
       const { req, res } = createMockBodyReq({
         personalityId: TEST_PERSONALITY_ID,
         confirmationPhrase: 'wrong phrase',
       });
-
-      await handlePurge(mockPrisma as unknown as PrismaClient, req, res);
-
+      await handleIssuePurgeToken(mockPrisma as unknown as PrismaClient, tokenService, req, res);
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
           message: expect.stringContaining('DELETE TEST-PERSONALITY MEMORIES'),
         })
       );
+      expect(tokenService.issuePurgeToken).not.toHaveBeenCalled();
     });
 
-    it('should accept case-insensitive confirmation phrase', async () => {
+    it('accepts case-insensitive confirmation phrase and issues a token', async () => {
       const { req, res } = createMockBodyReq({
         personalityId: TEST_PERSONALITY_ID,
-        confirmationPhrase: 'delete test-personality memories', // lowercase - should still work
+        confirmationPhrase: 'delete test-personality memories',
       });
-
-      await handlePurge(mockPrisma as unknown as PrismaClient, req, res);
-
-      // Should succeed with lowercase phrase (case-insensitive for better UX)
+      await handleIssuePurgeToken(mockPrisma as unknown as PrismaClient, tokenService, req, res);
+      expect(tokenService.issuePurgeToken).toHaveBeenCalledWith(
+        TEST_DISCORD_USER_ID,
+        TEST_PERSONALITY_ID
+      );
       expect(res.status).toHaveBeenCalledWith(200);
-    });
-
-    it('should return 400 when user has no persona', async () => {
-      mockGetDefaultPersonaId.mockResolvedValue(null);
-      const { req, res } = createMockBodyReq({
-        personalityId: TEST_PERSONALITY_ID,
-        confirmationPhrase: 'DELETE TEST-PERSONALITY MEMORIES',
-      });
-
-      await handlePurge(mockPrisma as unknown as PrismaClient, req, res);
-
-      expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
-          message: expect.stringContaining('No persona'),
+          purgeToken: VALID_PURGE_TOKEN,
+          personalityId: TEST_PERSONALITY_ID,
+          personalityName: 'test-personality',
         })
       );
     });
 
-    it('should purge all non-locked memories with correct confirmation', async () => {
-      mockPrisma.memory.count
-        .mockResolvedValueOnce(10) // total count
-        .mockResolvedValueOnce(3); // locked count
-      mockPrisma.memory.updateMany.mockResolvedValue({ count: 7 });
-
+    it('returns early when personality not found', async () => {
+      mockGetPersonalityById.mockResolvedValue(null);
       const { req, res } = createMockBodyReq({
         personalityId: TEST_PERSONALITY_ID,
         confirmationPhrase: 'DELETE TEST-PERSONALITY MEMORIES',
       });
+      await handleIssuePurgeToken(mockPrisma as unknown as PrismaClient, tokenService, req, res);
+      expect(res.status).not.toHaveBeenCalled();
+    });
+  });
 
-      await handlePurge(mockPrisma as unknown as PrismaClient, req, res);
+  describe('handlePurge', () => {
+    it('returns 503 when token service is null', async () => {
+      const { req, res } = createMockBodyReq({ purgeToken: VALID_PURGE_TOKEN });
+      await handlePurge(mockPrisma as unknown as PrismaClient, null, req, res);
+      expect(res.status).toHaveBeenCalledWith(503);
+    });
+
+    it('rejects missing purgeToken', async () => {
+      const { req, res } = createMockBodyReq({});
+      await handlePurge(mockPrisma as unknown as PrismaClient, tokenService, req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it('rejects malformed purgeToken (wrong prefix)', async () => {
+      const { req, res } = createMockBodyReq({ purgeToken: 'preview_abcdef0123456789' });
+      await handlePurge(mockPrisma as unknown as PrismaClient, tokenService, req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it('returns 400 when token is unknown / expired / replayed', async () => {
+      tokenService = createTokenServiceMock({
+        consumePurgeToken: async () => null,
+      });
+      const { req, res } = createMockBodyReq({ purgeToken: VALID_PURGE_TOKEN });
+      await handlePurge(mockPrisma as unknown as PrismaClient, tokenService, req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('Purge token'),
+        })
+      );
+    });
+
+    it('returns 400 when user has no persona', async () => {
+      mockGetDefaultPersonaId.mockResolvedValue(null);
+      const { req, res } = createMockBodyReq({ purgeToken: VALID_PURGE_TOKEN });
+      await handlePurge(mockPrisma as unknown as PrismaClient, tokenService, req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it('purges all non-locked memories for the token-bound personality', async () => {
+      mockPrisma.memory.count.mockResolvedValueOnce(10).mockResolvedValueOnce(3);
+      mockPrisma.memory.updateMany.mockResolvedValue({ count: 7 });
+
+      const { req, res } = createMockBodyReq({ purgeToken: VALID_PURGE_TOKEN });
+      await handlePurge(mockPrisma as unknown as PrismaClient, tokenService, req, res);
 
       expect(mockPrisma.memory.updateMany).toHaveBeenCalledWith({
         where: {
@@ -600,28 +469,21 @@ describe('memoryBatch handlers', () => {
           updatedAt: expect.any(Date),
         }),
       });
-
-      expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
           deletedCount: 7,
           lockedPreserved: 3,
           personalityId: TEST_PERSONALITY_ID,
-          personalityName: 'test-personality',
         })
       );
     });
 
-    it('should include locked message when locked memories preserved', async () => {
+    it('includes locked-preserved message when locked memories remain', async () => {
       mockPrisma.memory.count.mockResolvedValueOnce(5).mockResolvedValueOnce(2);
       mockPrisma.memory.updateMany.mockResolvedValue({ count: 3 });
 
-      const { req, res } = createMockBodyReq({
-        personalityId: TEST_PERSONALITY_ID,
-        confirmationPhrase: 'DELETE TEST-PERSONALITY MEMORIES',
-      });
-
-      await handlePurge(mockPrisma as unknown as PrismaClient, req, res);
+      const { req, res } = createMockBodyReq({ purgeToken: VALID_PURGE_TOKEN });
+      await handlePurge(mockPrisma as unknown as PrismaClient, tokenService, req, res);
 
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -630,41 +492,11 @@ describe('memoryBatch handlers', () => {
       );
     });
 
-    it('should include simple message when no locked memories', async () => {
-      mockPrisma.memory.count.mockResolvedValueOnce(5).mockResolvedValueOnce(0);
-      mockPrisma.memory.updateMany.mockResolvedValue({ count: 5 });
-
-      const { req, res } = createMockBodyReq({
-        personalityId: TEST_PERSONALITY_ID,
-        confirmationPhrase: 'DELETE TEST-PERSONALITY MEMORIES',
-      });
-
-      await handlePurge(mockPrisma as unknown as PrismaClient, req, res);
-
-      expect(res.json).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: expect.stringContaining('Purged all 5 memories'),
-        })
-      );
-    });
-
-    it('should handle purge with zero memories gracefully', async () => {
-      mockPrisma.memory.count.mockResolvedValueOnce(0).mockResolvedValueOnce(0);
-      mockPrisma.memory.updateMany.mockResolvedValue({ count: 0 });
-
-      const { req, res } = createMockBodyReq({
-        personalityId: TEST_PERSONALITY_ID,
-        confirmationPhrase: 'DELETE TEST-PERSONALITY MEMORIES',
-      });
-
-      await handlePurge(mockPrisma as unknown as PrismaClient, req, res);
-
-      expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.json).toHaveBeenCalledWith(
-        expect.objectContaining({
-          deletedCount: 0,
-        })
-      );
+    it('returns early when token-bound personality is missing', async () => {
+      mockGetPersonalityById.mockResolvedValue(null);
+      const { req, res } = createMockBodyReq({ purgeToken: VALID_PURGE_TOKEN });
+      await handlePurge(mockPrisma as unknown as PrismaClient, tokenService, req, res);
+      expect(res.status).not.toHaveBeenCalled();
     });
   });
 });

--- a/services/api-gateway/src/routes/user/memoryBatch.test.ts
+++ b/services/api-gateway/src/routes/user/memoryBatch.test.ts
@@ -59,8 +59,8 @@ const TEST_PERSONA_ID = '00000000-0000-0000-0000-000000000002';
 const TEST_PERSONALITY_ID = '00000000-0000-0000-0000-000000000003';
 const TEST_DISCORD_USER_ID = 'discord-user-123';
 
-const VALID_PREVIEW_TOKEN = 'preview_abcdef0123456789';
-const VALID_PURGE_TOKEN = 'purge_abcdef0123456789';
+const VALID_PREVIEW_TOKEN = 'preview_test0000test0000';
+const VALID_PURGE_TOKEN = 'purge_test0000test0000';
 
 const mockPrisma = {
   memory: {
@@ -243,7 +243,7 @@ describe('memoryBatch handlers', () => {
     });
 
     it('rejects malformed previewToken (wrong prefix)', async () => {
-      const { req, res } = createMockBodyReq({ previewToken: 'purge_abcdef0123456789' });
+      const { req, res } = createMockBodyReq({ previewToken: 'purge_test0000test0000' });
       await handleBatchDelete(mockPrisma as unknown as PrismaClient, tokenService, req, res);
       expect(res.status).toHaveBeenCalledWith(400);
     });
@@ -424,7 +424,7 @@ describe('memoryBatch handlers', () => {
     });
 
     it('rejects malformed purgeToken (wrong prefix)', async () => {
-      const { req, res } = createMockBodyReq({ purgeToken: 'preview_abcdef0123456789' });
+      const { req, res } = createMockBodyReq({ purgeToken: 'preview_test0000test0000' });
       await handlePurge(mockPrisma as unknown as PrismaClient, tokenService, req, res);
       expect(res.status).toHaveBeenCalledWith(400);
     });

--- a/services/api-gateway/src/routes/user/memoryBatch.test.ts
+++ b/services/api-gateway/src/routes/user/memoryBatch.test.ts
@@ -75,24 +75,25 @@ const mockPrisma = {
 function createTokenServiceMock(
   overrides: Partial<{
     issuePreviewToken: () => Promise<string>;
+    peekPreviewToken: (uid: string, t: string) => Promise<BatchDeletePreviewInput | null>;
     consumePreviewToken: (uid: string, t: string) => Promise<BatchDeletePreviewInput | null>;
     issuePurgeToken: () => Promise<string>;
+    peekPurgeToken: (uid: string, t: string) => Promise<{ personalityId: string } | null>;
     consumePurgeToken: (uid: string, t: string) => Promise<{ personalityId: string } | null>;
   }> = {}
 ): MemoryActionTokenService {
+  const defaultPreview: BatchDeletePreviewInput = {
+    personalityId: TEST_PERSONALITY_ID,
+    personaId: TEST_PERSONA_ID,
+  };
+  const defaultPurge = { personalityId: TEST_PERSONALITY_ID };
   return {
     issuePreviewToken: vi.fn(overrides.issuePreviewToken ?? (async () => VALID_PREVIEW_TOKEN)),
-    consumePreviewToken: vi.fn(
-      overrides.consumePreviewToken ??
-        (async () => ({
-          personalityId: TEST_PERSONALITY_ID,
-          personaId: TEST_PERSONA_ID,
-        }))
-    ),
+    peekPreviewToken: vi.fn(overrides.peekPreviewToken ?? (async () => defaultPreview)),
+    consumePreviewToken: vi.fn(overrides.consumePreviewToken ?? (async () => defaultPreview)),
     issuePurgeToken: vi.fn(overrides.issuePurgeToken ?? (async () => VALID_PURGE_TOKEN)),
-    consumePurgeToken: vi.fn(
-      overrides.consumePurgeToken ?? (async () => ({ personalityId: TEST_PERSONALITY_ID }))
-    ),
+    peekPurgeToken: vi.fn(overrides.peekPurgeToken ?? (async () => defaultPurge)),
+    consumePurgeToken: vi.fn(overrides.consumePurgeToken ?? (async () => defaultPurge)),
   } as unknown as MemoryActionTokenService;
 }
 
@@ -248,9 +249,9 @@ describe('memoryBatch handlers', () => {
       expect(res.status).toHaveBeenCalledWith(400);
     });
 
-    it('returns 400 when token is unknown / expired / replayed', async () => {
+    it('returns 400 when token is unknown / expired (peek miss)', async () => {
       tokenService = createTokenServiceMock({
-        consumePreviewToken: async () => null,
+        peekPreviewToken: async () => null,
       });
       const { req, res } = createMockBodyReq({ previewToken: VALID_PREVIEW_TOKEN });
       await handleBatchDelete(mockPrisma as unknown as PrismaClient, tokenService, req, res);
@@ -260,15 +261,44 @@ describe('memoryBatch handlers', () => {
           message: expect.stringContaining('Preview token'),
         })
       );
+      // Token is NOT consumed on peek miss — user can retry without restarting preview.
+      expect(tokenService.consumePreviewToken).not.toHaveBeenCalled();
     });
 
-    it('returns 403 when token-bound persona does not belong to user', async () => {
+    it('returns 400 when token is concurrently consumed between peek and consume', async () => {
       tokenService = createTokenServiceMock({
-        consumePreviewToken: async () => ({
-          personalityId: TEST_PERSONALITY_ID,
-          personaId: TEST_PERSONA_ID,
-        }),
+        consumePreviewToken: async () => null, // race lost
       });
+      const { req, res } = createMockBodyReq({ previewToken: VALID_PREVIEW_TOKEN });
+      await handleBatchDelete(mockPrisma as unknown as PrismaClient, tokenService, req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('concurrent'),
+        })
+      );
+    });
+
+    it('does NOT consume the token when personality lookup fails post-peek', async () => {
+      mockGetPersonalityById.mockResolvedValue(null);
+      const { req, res } = createMockBodyReq({ previewToken: VALID_PREVIEW_TOKEN });
+      await handleBatchDelete(mockPrisma as unknown as PrismaClient, tokenService, req, res);
+      // Personality 404 is rendered by getPersonalityById itself; importantly,
+      // the token survives the failure so the user can retry.
+      expect(tokenService.peekPreviewToken).toHaveBeenCalled();
+      expect(tokenService.consumePreviewToken).not.toHaveBeenCalled();
+    });
+
+    it('returns early when token-bound personality is missing', async () => {
+      mockGetPersonalityById.mockResolvedValue(null);
+      const { req, res } = createMockBodyReq({ previewToken: VALID_PREVIEW_TOKEN });
+      await handleBatchDelete(mockPrisma as unknown as PrismaClient, tokenService, req, res);
+      // getPersonalityById's own 404 is the only response — handler doesn't double-send.
+      expect(mockGetPersonalityById).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when token-bound persona does not belong to user, without consuming token', async () => {
       mockPrisma.persona.findUnique.mockResolvedValue({
         id: TEST_PERSONA_ID,
         ownerId: 'different-user-id',
@@ -276,6 +306,8 @@ describe('memoryBatch handlers', () => {
       const { req, res } = createMockBodyReq({ previewToken: VALID_PREVIEW_TOKEN });
       await handleBatchDelete(mockPrisma as unknown as PrismaClient, tokenService, req, res);
       expect(res.status).toHaveBeenCalledWith(403);
+      // Token NOT consumed on persona-ownership failure — user can retry.
+      expect(tokenService.consumePreviewToken).not.toHaveBeenCalled();
     });
 
     it('returns zero-count success when no memories match', async () => {
@@ -316,12 +348,14 @@ describe('memoryBatch handlers', () => {
     });
 
     it('applies timeframe filter from the token-bound payload', async () => {
+      const filterWithTimeframe: BatchDeletePreviewInput = {
+        personalityId: TEST_PERSONALITY_ID,
+        personaId: TEST_PERSONA_ID,
+        timeframe: '30d',
+      };
       tokenService = createTokenServiceMock({
-        consumePreviewToken: async () => ({
-          personalityId: TEST_PERSONALITY_ID,
-          personaId: TEST_PERSONA_ID,
-          timeframe: '30d',
-        }),
+        peekPreviewToken: async () => filterWithTimeframe,
+        consumePreviewToken: async () => filterWithTimeframe,
       });
       const cutoffDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
       mockParseTimeframeFilter.mockReturnValue({ filter: { gte: cutoffDate } });
@@ -429,9 +463,9 @@ describe('memoryBatch handlers', () => {
       expect(res.status).toHaveBeenCalledWith(400);
     });
 
-    it('returns 400 when token is unknown / expired / replayed', async () => {
+    it('returns 400 when token is unknown / expired (peek miss)', async () => {
       tokenService = createTokenServiceMock({
-        consumePurgeToken: async () => null,
+        peekPurgeToken: async () => null,
       });
       const { req, res } = createMockBodyReq({ purgeToken: VALID_PURGE_TOKEN });
       await handlePurge(mockPrisma as unknown as PrismaClient, tokenService, req, res);
@@ -441,6 +475,31 @@ describe('memoryBatch handlers', () => {
           message: expect.stringContaining('Purge token'),
         })
       );
+      // Token survives the failure — no destructive consume on peek miss.
+      expect(tokenService.consumePurgeToken).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when token is concurrently consumed between peek and consume', async () => {
+      tokenService = createTokenServiceMock({
+        consumePurgeToken: async () => null, // race lost
+      });
+      const { req, res } = createMockBodyReq({ purgeToken: VALID_PURGE_TOKEN });
+      await handlePurge(mockPrisma as unknown as PrismaClient, tokenService, req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('concurrent'),
+        })
+      );
+    });
+
+    it('does NOT consume the token when personality lookup fails post-peek', async () => {
+      mockGetPersonalityById.mockResolvedValue(null);
+      const { req, res } = createMockBodyReq({ purgeToken: VALID_PURGE_TOKEN });
+      await handlePurge(mockPrisma as unknown as PrismaClient, tokenService, req, res);
+      // Token survives the personality-missing case — user can retry.
+      expect(tokenService.peekPurgeToken).toHaveBeenCalled();
+      expect(tokenService.consumePurgeToken).not.toHaveBeenCalled();
     });
 
     it('returns 400 when user has no persona', async () => {

--- a/services/api-gateway/src/routes/user/memoryBatch.ts
+++ b/services/api-gateway/src/routes/user/memoryBatch.ts
@@ -88,7 +88,7 @@ async function resolvePersonaIdForBatch(
  * the filter is stored server-side under the token key, so the execute
  * path is guaranteed to operate on the same filter the user previewed.
  */
- 
+
 export async function handleBatchDeletePreview(
   prisma: PrismaClient,
   tokenService: MemoryActionTokenService | null,
@@ -211,7 +211,12 @@ export async function handleBatchDelete(
   }
 
   const { previewToken } = parseResult.data;
-  const filter = await tokenService.consumePreviewToken(discordUserId, previewToken);
+
+  // Two-step token redemption: peek to validate preconditions, then
+  // atomically consume. If personality lookup or persona validation fails,
+  // the token stays valid in Redis for the user to retry without restarting
+  // the preview flow.
+  const filter = await tokenService.peekPreviewToken(discordUserId, previewToken);
   if (filter === null) {
     sendError(
       res,
@@ -235,6 +240,20 @@ export async function handleBatchDelete(
   // session that no longer reflects the current persona state.
   const personaId = await resolvePersonaIdForBatch(prisma, userId, filterPersonaId, res);
   if (personaId === null) {
+    return;
+  }
+
+  // Preconditions OK — claim the token atomically. The only failure here is
+  // a concurrent consume by the same user (double-click), which is benign:
+  // the destructive op below is idempotent on already-deleted rows.
+  const consumed = await tokenService.consumePreviewToken(discordUserId, previewToken);
+  if (consumed === null) {
+    sendError(
+      res,
+      ErrorResponses.validationError(
+        'Preview token was consumed by a concurrent request. Re-run the preview to get a fresh token.'
+      )
+    );
     return;
   }
 
@@ -379,7 +398,7 @@ export async function handleIssuePurgeToken(
  * Consumes the token, then soft-deletes all non-locked memories for the
  * personality bound to that token.
  */
- 
+
 export async function handlePurge(
   prisma: PrismaClient,
   tokenService: MemoryActionTokenService | null,
@@ -400,8 +419,11 @@ export async function handlePurge(
   }
 
   const { purgeToken } = parseResult.data;
-  const consumed = await tokenService.consumePurgeToken(discordUserId, purgeToken);
-  if (consumed === null) {
+
+  // Peek first so a personality that was deleted within the 5-min token
+  // window doesn't burn the user's one-shot token.
+  const peeked = await tokenService.peekPurgeToken(discordUserId, purgeToken);
+  if (peeked === null) {
     sendError(
       res,
       ErrorResponses.validationError(
@@ -411,7 +433,7 @@ export async function handlePurge(
     return;
   }
 
-  const { personalityId } = consumed;
+  const { personalityId } = peeked;
   const userId = resolveProvisionedUserId(req);
 
   const personality = await getPersonalityById(prisma, personalityId, res);
@@ -419,6 +441,24 @@ export async function handlePurge(
     return;
   }
 
+  // Preconditions OK — claim the token. Concurrent-consume race is benign
+  // because updateMany of already-deleted rows is a no-op.
+  const consumed = await tokenService.consumePurgeToken(discordUserId, purgeToken);
+  if (consumed === null) {
+    sendError(
+      res,
+      ErrorResponses.validationError(
+        'Purge token was consumed by a concurrent request. Re-issue via /memory/purge/token.'
+      )
+    );
+    return;
+  }
+
+  // Purge always operates on the user's *default* persona. Batch-delete
+  // (above) supports a token-supplied persona override because the preview
+  // flow lets the user filter by persona; purge has no equivalent filter —
+  // it's an all-memories destructive op scoped to the personality. If a
+  // future variant needs persona-scoped purge, mirror resolvePersonaIdForBatch.
   const defaultPersonaId = await getDefaultPersonaId(prisma, userId);
   if (defaultPersonaId === null) {
     sendError(res, ErrorResponses.validationError('No persona found. Create one first.'));

--- a/services/api-gateway/src/routes/user/memoryBatch.ts
+++ b/services/api-gateway/src/routes/user/memoryBatch.ts
@@ -1,9 +1,19 @@
 /**
  * Batch Memory Operations
- * Handles bulk deletion and purge operations for memories
  *
- * POST /user/memory/delete - Batch delete with filters (skips locked)
- * POST /user/memory/purge - Purge all memories for personality (skips locked)
+ * Destructive batch flows use a preview/execute token handshake. The
+ * preview endpoint runs the filter against the DB, returns a summary, and
+ * issues a short-lived token whose Redis value is the bound filter. The
+ * execute endpoint accepts ONLY the token — it never sees the filter from
+ * the client — eliminating drift between preview and execute.
+ *
+ * Endpoints (mounted in memory.ts):
+ *   POST /user/memory/delete/preview  → impact summary + previewToken
+ *   POST /user/memory/delete          → consumes previewToken, soft-deletes
+ *   POST /user/memory/purge/token     → confirmation phrase + purgeToken
+ *   POST /user/memory/purge           → consumes purgeToken, soft-deletes
+ *
+ * Locked memories are always skipped (never touched by either flow).
  */
 
 import type { Response } from 'express';
@@ -12,7 +22,9 @@ import {
   createLogger,
   type PrismaClient,
   Prisma,
+  BatchDeletePreviewSchema,
   BatchDeleteSchema,
+  IssuePurgeTokenSchema,
   PurgeMemoriesSchema,
 } from '@tzurot/common-types';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
@@ -21,50 +33,38 @@ import { sendZodError } from '../../utils/zodHelpers.js';
 import type { ProvisionedRequest } from '../../types.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';
 import { getDefaultPersonaId, getPersonalityById, parseTimeframeFilter } from './memoryHelpers.js';
+import type { MemoryActionTokenService } from '../../services/MemoryActionTokenService.js';
 
 const logger = createLogger('memory-batch');
 
+/** Service-unavailable response when Redis (and therefore the token service) is absent. */
+function sendRedisUnavailable(res: Response): void {
+  sendError(
+    res,
+    ErrorResponses.serviceUnavailable('Batch memory operations require Redis; service unavailable.')
+  );
+}
+
 /**
- * Handler for POST /user/memory/delete
- * Batch delete memories with filters (skips locked memories)
+ * Resolve and validate the personaId for a batch delete preview.
+ * Returns null and sends an error response on failure.
  */
-// eslint-disable-next-line max-lines-per-function -- Procedural handler with sequential validation steps and timeframe parsing
-export async function handleBatchDelete(
+async function resolvePersonaIdForBatch(
   prisma: PrismaClient,
-  req: ProvisionedRequest,
+  userId: string,
+  requestedPersonaId: string | undefined,
   res: Response
-): Promise<void> {
-  const discordUserId = req.userId;
-
-  const parseResult = BatchDeleteSchema.safeParse(req.body);
-  if (!parseResult.success) {
-    sendZodError(res, parseResult.error);
-    return;
-  }
-
-  const { personalityId, personaId: requestedPersonaId, timeframe } = parseResult.data;
-
-  // Get user
-  const userId = resolveProvisionedUserId(req);
-
-  // Validate personality exists
-  const personality = await getPersonalityById(prisma, personalityId, res);
-  if (!personality) {
-    return;
-  }
-
-  // Determine persona ID
+): Promise<string | null> {
   let personaId = requestedPersonaId;
   if (personaId === undefined || personaId === '') {
     const defaultPersonaId = await getDefaultPersonaId(prisma, userId);
     if (defaultPersonaId === null) {
       sendError(res, ErrorResponses.validationError('No persona found. Create one first.'));
-      return;
+      return null;
     }
     personaId = defaultPersonaId;
   }
 
-  // Verify persona belongs to user
   const persona = await prisma.persona.findUnique({
     where: { id: personaId },
     select: { id: true, ownerId: true },
@@ -72,18 +72,63 @@ export async function handleBatchDelete(
 
   if (persona?.ownerId !== userId) {
     sendError(res, ErrorResponses.forbidden('Persona not found or does not belong to you'));
+    return null;
+  }
+
+  return personaId;
+}
+
+/**
+ * Handler for POST /user/memory/delete/preview
+ *
+ * Body: { personalityId, personaId?, timeframe? }
+ * Returns: { wouldDelete, lockedWouldSkip, previewToken, ... }
+ *
+ * The previewToken is the ONLY way to invoke POST /user/memory/delete —
+ * the filter is stored server-side under the token key, so the execute
+ * path is guaranteed to operate on the same filter the user previewed.
+ */
+ 
+export async function handleBatchDeletePreview(
+  prisma: PrismaClient,
+  tokenService: MemoryActionTokenService | null,
+  req: ProvisionedRequest,
+  res: Response
+): Promise<void> {
+  if (tokenService === null) {
+    sendRedisUnavailable(res);
     return;
   }
 
-  // Build where clause for batch delete
+  const discordUserId = req.userId;
+
+  const parseResult = BatchDeletePreviewSchema.safeParse(req.body);
+  if (!parseResult.success) {
+    sendZodError(res, parseResult.error);
+    return;
+  }
+
+  const { personalityId, personaId: requestedPersonaId, timeframe } = parseResult.data;
+
+  const userId = resolveProvisionedUserId(req);
+
+  const personality = await getPersonalityById(prisma, personalityId, res);
+  if (!personality) {
+    return;
+  }
+
+  const personaId = await resolvePersonaIdForBatch(prisma, userId, requestedPersonaId, res);
+  if (personaId === null) {
+    return;
+  }
+
   const where: Prisma.MemoryWhereInput = {
     personaId,
     personalityId,
-    visibility: 'normal', // Only delete normal (visible) memories
-    isLocked: false, // Skip locked memories
+    visibility: 'normal',
+    isLocked: false,
   };
 
-  // Add timeframe filter if provided
   const timeframeParsed = parseTimeframeFilter(timeframe);
   if (timeframeParsed.error !== undefined) {
     sendError(res, ErrorResponses.validationError(timeframeParsed.error));
@@ -93,7 +138,122 @@ export async function handleBatchDelete(
     where.createdAt = timeframeParsed.filter;
   }
 
-  // Count memories that will be deleted
+  const [wouldDelete, lockedWouldSkip] = await Promise.all([
+    prisma.memory.count({ where }),
+    prisma.memory.count({
+      where: {
+        personaId,
+        personalityId,
+        visibility: 'normal',
+        isLocked: true,
+        ...(timeframeParsed.filter !== null ? { createdAt: timeframeParsed.filter } : {}),
+      },
+    }),
+  ]);
+
+  const previewToken = await tokenService.issuePreviewToken(discordUserId, {
+    personalityId,
+    personaId,
+    timeframe,
+  });
+
+  logger.debug(
+    {
+      discordUserId,
+      personalityId,
+      personaId: personaId.substring(0, 8),
+      wouldDelete,
+      lockedWouldSkip,
+    },
+    '[Memory] Batch delete preview issued'
+  );
+
+  sendCustomSuccess(
+    res,
+    {
+      wouldDelete,
+      lockedWouldSkip,
+      personalityId,
+      personalityName: personality.name,
+      timeframe: timeframe ?? 'all',
+      previewToken,
+    },
+    StatusCodes.OK
+  );
+}
+
+/**
+ * Handler for POST /user/memory/delete
+ *
+ * Body: { previewToken }
+ * The filter that produced the preview is re-read from Redis under the
+ * token key and applied verbatim. The token is consumed atomically — it
+ * cannot be replayed.
+ */
+// eslint-disable-next-line max-lines-per-function -- Procedural handler: validate token → re-apply filter → soft-delete
+export async function handleBatchDelete(
+  prisma: PrismaClient,
+  tokenService: MemoryActionTokenService | null,
+  req: ProvisionedRequest,
+  res: Response
+): Promise<void> {
+  if (tokenService === null) {
+    sendRedisUnavailable(res);
+    return;
+  }
+
+  const discordUserId = req.userId;
+
+  const parseResult = BatchDeleteSchema.safeParse(req.body);
+  if (!parseResult.success) {
+    sendZodError(res, parseResult.error);
+    return;
+  }
+
+  const { previewToken } = parseResult.data;
+  const filter = await tokenService.consumePreviewToken(discordUserId, previewToken);
+  if (filter === null) {
+    sendError(
+      res,
+      ErrorResponses.validationError(
+        'Preview token is invalid, expired, or already used. Re-run the preview to get a fresh token.'
+      )
+    );
+    return;
+  }
+
+  const { personalityId, personaId: filterPersonaId, timeframe } = filter;
+  const userId = resolveProvisionedUserId(req);
+
+  const personality = await getPersonalityById(prisma, personalityId, res);
+  if (!personality) {
+    return;
+  }
+
+  // Token-bound personaId should match the user's own persona; re-verify
+  // ownership defense-in-depth in case the token was issued in an older
+  // session that no longer reflects the current persona state.
+  const personaId = await resolvePersonaIdForBatch(prisma, userId, filterPersonaId, res);
+  if (personaId === null) {
+    return;
+  }
+
+  const where: Prisma.MemoryWhereInput = {
+    personaId,
+    personalityId,
+    visibility: 'normal',
+    isLocked: false,
+  };
+
+  const timeframeParsed = parseTimeframeFilter(timeframe);
+  if (timeframeParsed.error !== undefined) {
+    sendError(res, ErrorResponses.validationError(timeframeParsed.error));
+    return;
+  }
+  if (timeframeParsed.filter !== null) {
+    where.createdAt = timeframeParsed.filter;
+  }
+
   const countToDelete = await prisma.memory.count({ where });
 
   if (countToDelete === 0) {
@@ -109,22 +269,19 @@ export async function handleBatchDelete(
     return;
   }
 
-  // Count locked memories that would have matched (for informational purposes)
   const lockedCount = await prisma.memory.count({
     where: {
-      ...where,
-      isLocked: true,
+      personaId,
+      personalityId,
       visibility: 'normal',
+      isLocked: true,
+      ...(timeframeParsed.filter !== null ? { createdAt: timeframeParsed.filter } : {}),
     },
   });
 
-  // Perform soft delete
   const result = await prisma.memory.updateMany({
     where,
-    data: {
-      visibility: 'deleted',
-      updatedAt: new Date(),
-    },
+    data: { visibility: 'deleted', updatedAt: new Date() },
   });
 
   logger.warn(
@@ -157,15 +314,83 @@ export async function handleBatchDelete(
 }
 
 /**
- * Handler for POST /user/memory/purge
- * Purge all memories for a personality (skips locked memories)
- * Requires typed confirmation phrase
+ * Handler for POST /user/memory/purge/token
+ *
+ * Body: { personalityId, confirmationPhrase }
+ * Returns: { purgeToken, personalityName, ... }
+ *
+ * Validates the confirmation phrase against the personality name. On success,
+ * issues a short-lived purge token bound to the personality. The actual
+ * destructive purge requires the token at POST /user/memory/purge.
  */
-export async function handlePurge(
+export async function handleIssuePurgeToken(
   prisma: PrismaClient,
+  tokenService: MemoryActionTokenService | null,
   req: ProvisionedRequest,
   res: Response
 ): Promise<void> {
+  if (tokenService === null) {
+    sendRedisUnavailable(res);
+    return;
+  }
+
+  const discordUserId = req.userId;
+
+  const parseResult = IssuePurgeTokenSchema.safeParse(req.body);
+  if (!parseResult.success) {
+    sendZodError(res, parseResult.error);
+    return;
+  }
+
+  const { personalityId, confirmationPhrase } = parseResult.data;
+
+  const personality = await getPersonalityById(prisma, personalityId, res);
+  if (!personality) {
+    return;
+  }
+
+  const expectedPhrase = `DELETE ${personality.name.toUpperCase()} MEMORIES`;
+  if (confirmationPhrase.toUpperCase() !== expectedPhrase.toUpperCase()) {
+    sendError(
+      res,
+      ErrorResponses.validationError(`Confirmation required. Type: "${expectedPhrase}"`)
+    );
+    return;
+  }
+
+  const purgeToken = await tokenService.issuePurgeToken(discordUserId, personalityId);
+
+  logger.info(
+    { discordUserId, personalityId, personalityName: personality.name },
+    '[Memory] Purge token issued'
+  );
+
+  sendCustomSuccess(
+    res,
+    { purgeToken, personalityId, personalityName: personality.name },
+    StatusCodes.OK
+  );
+}
+
+/**
+ * Handler for POST /user/memory/purge
+ *
+ * Body: { purgeToken }
+ * Consumes the token, then soft-deletes all non-locked memories for the
+ * personality bound to that token.
+ */
+ 
+export async function handlePurge(
+  prisma: PrismaClient,
+  tokenService: MemoryActionTokenService | null,
+  req: ProvisionedRequest,
+  res: Response
+): Promise<void> {
+  if (tokenService === null) {
+    sendRedisUnavailable(res);
+    return;
+  }
+
   const discordUserId = req.userId;
 
   const parseResult = PurgeMemoriesSchema.safeParse(req.body);
@@ -174,55 +399,46 @@ export async function handlePurge(
     return;
   }
 
-  const { personalityId, confirmationPhrase } = parseResult.data;
+  const { purgeToken } = parseResult.data;
+  const consumed = await tokenService.consumePurgeToken(discordUserId, purgeToken);
+  if (consumed === null) {
+    sendError(
+      res,
+      ErrorResponses.validationError(
+        'Purge token is invalid, expired, or already used. Re-issue via /memory/purge/token.'
+      )
+    );
+    return;
+  }
 
-  // Get user
+  const { personalityId } = consumed;
   const userId = resolveProvisionedUserId(req);
 
-  // Validate personality exists
   const personality = await getPersonalityById(prisma, personalityId, res);
   if (!personality) {
     return;
   }
 
-  // Generate expected confirmation phrase
-  const expectedPhrase = `DELETE ${personality.name.toUpperCase()} MEMORIES`;
-
-  // Validate confirmation phrase (case-insensitive for better UX)
-  if (confirmationPhrase?.toUpperCase() !== expectedPhrase.toUpperCase()) {
-    sendError(
-      res,
-      ErrorResponses.validationError(`Confirmation required. Type: "${expectedPhrase}"`)
-    );
-    return;
-  }
-
-  // Get user's persona
   const defaultPersonaId = await getDefaultPersonaId(prisma, userId);
   if (defaultPersonaId === null) {
     sendError(res, ErrorResponses.validationError('No persona found. Create one first.'));
     return;
   }
 
-  // Count memories before purge
-  const totalCount = await prisma.memory.count({
-    where: {
-      personaId: defaultPersonaId,
-      personalityId,
-      visibility: 'normal',
-    },
-  });
+  const [totalCount, lockedCount] = await Promise.all([
+    prisma.memory.count({
+      where: { personaId: defaultPersonaId, personalityId, visibility: 'normal' },
+    }),
+    prisma.memory.count({
+      where: {
+        personaId: defaultPersonaId,
+        personalityId,
+        visibility: 'normal',
+        isLocked: true,
+      },
+    }),
+  ]);
 
-  const lockedCount = await prisma.memory.count({
-    where: {
-      personaId: defaultPersonaId,
-      personalityId,
-      visibility: 'normal',
-      isLocked: true,
-    },
-  });
-
-  // Perform soft delete on all non-locked memories
   const result = await prisma.memory.updateMany({
     where: {
       personaId: defaultPersonaId,
@@ -230,10 +446,7 @@ export async function handlePurge(
       visibility: 'normal',
       isLocked: false,
     },
-    data: {
-      visibility: 'deleted',
-      updatedAt: new Date(),
-    },
+    data: { visibility: 'deleted', updatedAt: new Date() },
   });
 
   logger.warn(
@@ -260,99 +473,6 @@ export async function handlePurge(
         lockedCount > 0
           ? `Purged ${result.count} memories for ${personality.name}. ${lockedCount} locked (core) memories were preserved.`
           : `Purged all ${result.count} memories for ${personality.name}.`,
-    },
-    StatusCodes.OK
-  );
-}
-
-/**
- * Handler for GET /user/memory/delete/preview
- * Preview what would be deleted without actually deleting
- */
-export async function handleBatchDeletePreview(
-  prisma: PrismaClient,
-  req: ProvisionedRequest,
-  res: Response
-): Promise<void> {
-  const {
-    personalityId,
-    personaId: requestedPersonaId,
-    timeframe,
-  } = req.query as {
-    personalityId?: string;
-    personaId?: string;
-    timeframe?: string;
-  };
-
-  // Validate required fields
-  if (personalityId === undefined || personalityId === '') {
-    sendError(res, ErrorResponses.validationError('personalityId query parameter is required'));
-    return;
-  }
-
-  // Get user
-  const userId = resolveProvisionedUserId(req);
-
-  // Validate personality exists
-  const personality = await getPersonalityById(prisma, personalityId, res);
-  if (!personality) {
-    return;
-  }
-
-  // Determine persona ID
-  let personaId = requestedPersonaId;
-  if (personaId === undefined || personaId === '') {
-    const defaultPersonaId = await getDefaultPersonaId(prisma, userId);
-    if (defaultPersonaId === null) {
-      sendCustomSuccess(
-        res,
-        {
-          wouldDelete: 0,
-          lockedWouldSkip: 0,
-          message: 'No persona found',
-        },
-        StatusCodes.OK
-      );
-      return;
-    }
-    personaId = defaultPersonaId;
-  }
-
-  // Build where clause
-  const where: Prisma.MemoryWhereInput = {
-    personaId,
-    personalityId,
-    visibility: 'normal',
-    isLocked: false,
-  };
-
-  // Add timeframe filter if provided
-  const timeframeParsed = parseTimeframeFilter(timeframe);
-  if (timeframeParsed.error !== undefined) {
-    sendError(res, ErrorResponses.validationError(timeframeParsed.error));
-    return;
-  }
-  if (timeframeParsed.filter !== null) {
-    where.createdAt = timeframeParsed.filter;
-  }
-
-  // Count memories that would be deleted
-  const wouldDelete = await prisma.memory.count({ where });
-  const lockedWouldSkip = await prisma.memory.count({
-    where: {
-      ...where,
-      isLocked: true,
-    },
-  });
-
-  sendCustomSuccess(
-    res,
-    {
-      wouldDelete,
-      lockedWouldSkip,
-      personalityId,
-      personalityName: personality.name,
-      timeframe: timeframe ?? 'all',
     },
     StatusCodes.OK
   );

--- a/services/api-gateway/src/routes/user/memorySingle.test.ts
+++ b/services/api-gateway/src/routes/user/memorySingle.test.ts
@@ -40,7 +40,7 @@ vi.mock('../../utils/resolveProvisionedUserId.js', () => ({
 import {
   handleGetMemory,
   handleUpdateMemory,
-  handleToggleLock,
+  handleSetMemoryLock,
   handleDeleteMemory,
 } from './memorySingle.js';
 import { getDefaultPersonaId } from './memoryHelpers.js';
@@ -57,6 +57,7 @@ const TEST_DISCORD_USER_ID = 'discord-user-123';
 const mockPrisma = {
   memory: {
     findFirst: vi.fn(),
+    findUnique: vi.fn(),
     update: vi.fn(),
   },
 };
@@ -348,11 +349,11 @@ describe('memorySingle handlers', () => {
     });
   });
 
-  describe('handleToggleLock', () => {
+  describe('handleSetMemoryLock', () => {
     it('should reject missing memoryId', async () => {
-      const { req, res } = createMockReqRes({ id: '' });
+      const { req, res } = createMockReqRes({ id: '' }, { locked: true });
 
-      await handleToggleLock(mockPrisma as unknown as PrismaClient, req, res);
+      await handleSetMemoryLock(mockPrisma as unknown as PrismaClient, req, res);
 
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith(
@@ -362,26 +363,44 @@ describe('memorySingle handlers', () => {
       );
     });
 
+    it('should reject missing locked field in body', async () => {
+      const { req, res } = createMockReqRes({ id: TEST_MEMORY_ID }, {});
+
+      await handleSetMemoryLock(mockPrisma as unknown as PrismaClient, req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockPrisma.memory.update).not.toHaveBeenCalled();
+    });
+
+    it('should reject non-boolean locked field', async () => {
+      const { req, res } = createMockReqRes({ id: TEST_MEMORY_ID }, { locked: 'yes' });
+
+      await handleSetMemoryLock(mockPrisma as unknown as PrismaClient, req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockPrisma.memory.update).not.toHaveBeenCalled();
+    });
+
     it('should return 404 when user has no persona', async () => {
       mockGetDefaultPersonaId.mockResolvedValue(null);
-      const { req, res } = createMockReqRes({ id: TEST_MEMORY_ID });
+      const { req, res } = createMockReqRes({ id: TEST_MEMORY_ID }, { locked: true });
 
-      await handleToggleLock(mockPrisma as unknown as PrismaClient, req, res);
+      await handleSetMemoryLock(mockPrisma as unknown as PrismaClient, req, res);
 
       expect(res.status).toHaveBeenCalledWith(404);
     });
 
     it('should return 404 when memory not found', async () => {
       mockPrisma.memory.findFirst.mockResolvedValue(null);
-      const { req, res } = createMockReqRes({ id: TEST_MEMORY_ID });
+      const { req, res } = createMockReqRes({ id: TEST_MEMORY_ID }, { locked: true });
 
-      await handleToggleLock(mockPrisma as unknown as PrismaClient, req, res);
+      await handleSetMemoryLock(mockPrisma as unknown as PrismaClient, req, res);
 
       expect(res.status).toHaveBeenCalledWith(404);
       expect(mockPrisma.memory.update).not.toHaveBeenCalled();
     });
 
-    it('should lock an unlocked memory', async () => {
+    it('should lock an unlocked memory when locked=true', async () => {
       mockPrisma.memory.findFirst.mockResolvedValue({
         ...defaultMemory,
         isLocked: false,
@@ -391,9 +410,9 @@ describe('memorySingle handlers', () => {
         isLocked: true,
       });
 
-      const { req, res } = createMockReqRes({ id: TEST_MEMORY_ID });
+      const { req, res } = createMockReqRes({ id: TEST_MEMORY_ID }, { locked: true });
 
-      await handleToggleLock(mockPrisma as unknown as PrismaClient, req, res);
+      await handleSetMemoryLock(mockPrisma as unknown as PrismaClient, req, res);
 
       expect(mockPrisma.memory.update).toHaveBeenCalledWith({
         where: { id: TEST_MEMORY_ID },
@@ -416,7 +435,7 @@ describe('memorySingle handlers', () => {
       );
     });
 
-    it('should unlock a locked memory', async () => {
+    it('should unlock a locked memory when locked=false', async () => {
       mockPrisma.memory.findFirst.mockResolvedValue({
         ...defaultMemory,
         isLocked: true,
@@ -426,9 +445,9 @@ describe('memorySingle handlers', () => {
         isLocked: false,
       });
 
-      const { req, res } = createMockReqRes({ id: TEST_MEMORY_ID });
+      const { req, res } = createMockReqRes({ id: TEST_MEMORY_ID }, { locked: false });
 
-      await handleToggleLock(mockPrisma as unknown as PrismaClient, req, res);
+      await handleSetMemoryLock(mockPrisma as unknown as PrismaClient, req, res);
 
       expect(mockPrisma.memory.update).toHaveBeenCalledWith({
         where: { id: TEST_MEMORY_ID },
@@ -446,11 +465,64 @@ describe('memorySingle handlers', () => {
       );
     });
 
-    it('should update the updatedAt timestamp when toggling', async () => {
-      const beforeToggle = Date.now();
-      const { req, res } = createMockReqRes({ id: TEST_MEMORY_ID });
+    it('idempotent: short-circuits when desired state already holds (locked=true on locked memory)', async () => {
+      // The idempotency property — caller can retry on network timeout
+      // without flipping the state again. handler returns current memory
+      // without calling update.
+      mockPrisma.memory.findFirst.mockResolvedValue({
+        ...defaultMemory,
+        isLocked: true,
+      });
+      mockPrisma.memory.findUnique.mockResolvedValue({
+        ...defaultMemory,
+        isLocked: true,
+      });
 
-      await handleToggleLock(mockPrisma as unknown as PrismaClient, req, res);
+      const { req, res } = createMockReqRes({ id: TEST_MEMORY_ID }, { locked: true });
+
+      await handleSetMemoryLock(mockPrisma as unknown as PrismaClient, req, res);
+
+      expect(mockPrisma.memory.update).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          memory: expect.objectContaining({ isLocked: true }),
+        })
+      );
+    });
+
+    it('idempotent: short-circuits when desired state already holds (locked=false on unlocked memory)', async () => {
+      mockPrisma.memory.findFirst.mockResolvedValue({
+        ...defaultMemory,
+        isLocked: false,
+      });
+      mockPrisma.memory.findUnique.mockResolvedValue({
+        ...defaultMemory,
+        isLocked: false,
+      });
+
+      const { req, res } = createMockReqRes({ id: TEST_MEMORY_ID }, { locked: false });
+
+      await handleSetMemoryLock(mockPrisma as unknown as PrismaClient, req, res);
+
+      expect(mockPrisma.memory.update).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('should update the updatedAt timestamp when state changes', async () => {
+      mockPrisma.memory.findFirst.mockResolvedValue({
+        ...defaultMemory,
+        isLocked: false,
+      });
+      mockPrisma.memory.update.mockResolvedValue({
+        ...defaultMemory,
+        isLocked: true,
+      });
+
+      const beforeToggle = Date.now();
+      const { req, res } = createMockReqRes({ id: TEST_MEMORY_ID }, { locked: true });
+
+      await handleSetMemoryLock(mockPrisma as unknown as PrismaClient, req, res);
 
       const updateCall = mockPrisma.memory.update.mock.calls[0][0];
       const updatedAtDate = updateCall.data.updatedAt as Date;

--- a/services/api-gateway/src/routes/user/memorySingle.ts
+++ b/services/api-gateway/src/routes/user/memorySingle.ts
@@ -5,7 +5,12 @@
 
 import type { Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
-import { createLogger, type PrismaClient, MemoryUpdateSchema } from '@tzurot/common-types';
+import {
+  createLogger,
+  type PrismaClient,
+  MemoryUpdateSchema,
+  SetMemoryLockSchema,
+} from '@tzurot/common-types';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';
 import { sendZodError } from '../../utils/zodHelpers.js';
@@ -197,10 +202,12 @@ export async function handleUpdateMemory(
 }
 
 /**
- * Handler for POST /user/memory/:id/lock
- * Toggle memory lock status
+ * Handler for PUT /user/memory/:id/lock
+ * Set memory lock state explicitly. Idempotent on retry — caller passes
+ * the desired state in the body rather than relying on server-side toggle
+ * of the current state.
  */
-export async function handleToggleLock(
+export async function handleSetMemoryLock(
   prisma: PrismaClient,
   req: ProvisionedRequest,
   res: Response
@@ -213,6 +220,13 @@ export async function handleToggleLock(
     return;
   }
 
+  const parseResult = SetMemoryLockSchema.safeParse(req.body);
+  if (!parseResult.success) {
+    sendZodError(res, parseResult.error);
+    return;
+  }
+  const { locked } = parseResult.data;
+
   const existing = await verifyMemoryOwnership({
     prisma,
     req,
@@ -223,17 +237,34 @@ export async function handleToggleLock(
     return;
   }
 
+  // Short-circuit when the requested state already holds — keeps the
+  // retry path idempotent without an extra DB write.
+  if (existing.isLocked === locked) {
+    const memory = await prisma.memory.findUnique({
+      where: { id: memoryId },
+      include: PERSONALITY_INCLUDE,
+    });
+    // existing already proved the row exists; the `null` branch is unreachable
+    // but TypeScript doesn't know that without the explicit guard.
+    if (memory === null) {
+      sendError(res, ErrorResponses.notFound('Memory'));
+      return;
+    }
+    sendCustomSuccess(res, { memory: transformMemory(memory) }, StatusCodes.OK);
+    return;
+  }
+
   const memory = await prisma.memory.update({
     where: { id: memoryId },
     data: {
-      isLocked: !existing.isLocked,
+      isLocked: locked,
       updatedAt: new Date(),
     },
     include: PERSONALITY_INCLUDE,
   });
 
   const action = memory.isLocked ? 'locked' : 'unlocked';
-  logger.info({ discordUserId, memoryId, action }, 'Memory lock toggled');
+  logger.info({ discordUserId, memoryId, action }, 'Memory lock state set');
   sendCustomSuccess(res, { memory: transformMemory(memory) }, StatusCodes.OK);
 }
 

--- a/services/api-gateway/src/services/MemoryActionTokenService.test.ts
+++ b/services/api-gateway/src/services/MemoryActionTokenService.test.ts
@@ -10,6 +10,7 @@ import { REDIS_KEY_PREFIXES, type BatchDeletePreviewInput } from '@tzurot/common
 function createMockRedis(): Redis {
   return {
     setex: vi.fn().mockResolvedValue('OK'),
+    get: vi.fn().mockResolvedValue(null),
     getdel: vi.fn().mockResolvedValue(null),
   } as unknown as Redis;
 }
@@ -111,6 +112,82 @@ describe('MemoryActionTokenService', () => {
     });
   });
 
+  describe('peekPreviewToken', () => {
+    it('returns the bound filter WITHOUT consuming the key', async () => {
+      const filter: BatchDeletePreviewInput = { personalityId: 'p', timeframe: '7d' };
+      const stored = JSON.stringify({ filter, issuedAt: '2026-05-26T12:00:00.000Z' });
+      (
+        redis.get as unknown as { mockResolvedValueOnce: (v: unknown) => void }
+      ).mockResolvedValueOnce(stored);
+
+      const result = await service.peekPreviewToken('user-a', 'preview_xyz000000test0000');
+
+      expect(result).toEqual(filter);
+      expect(redis.get).toHaveBeenCalledWith(
+        `${REDIS_KEY_PREFIXES.MEMORY_PREVIEW_TOKEN}user-a:preview_xyz000000test0000`
+      );
+      // Critically, peek must NOT call getdel — that's the load-bearing
+      // difference vs consume.
+      expect(redis.getdel).not.toHaveBeenCalled();
+    });
+
+    it('returns null on miss (no key present)', async () => {
+      const result = await service.peekPreviewToken('user-a', 'preview_missing000000test');
+      expect(result).toBeNull();
+    });
+
+    it('returns null on malformed payload', async () => {
+      (
+        redis.get as unknown as { mockResolvedValueOnce: (v: unknown) => void }
+      ).mockResolvedValueOnce('not-json');
+      const result = await service.peekPreviewToken('user-a', 'preview_bad0000000000test');
+      expect(result).toBeNull();
+    });
+
+    it('can be called repeatedly — non-destructive', async () => {
+      const filter: BatchDeletePreviewInput = { personalityId: 'p' };
+      const stored = JSON.stringify({ filter, issuedAt: '2026-05-26T12:00:00.000Z' });
+      const mock = redis.get as unknown as { mockResolvedValue: (v: unknown) => void };
+      mock.mockResolvedValue(stored);
+
+      const a = await service.peekPreviewToken('user-a', 'preview_aaaaaaaaaaaaaaaa');
+      const b = await service.peekPreviewToken('user-a', 'preview_aaaaaaaaaaaaaaaa');
+
+      expect(a).toEqual(filter);
+      expect(b).toEqual(filter);
+    });
+  });
+
+  describe('peekPurgeToken', () => {
+    it('returns the bound personalityId WITHOUT consuming the key', async () => {
+      const stored = JSON.stringify({
+        personalityId: 'persona-1',
+        issuedAt: '2026-05-26T12:00:00.000Z',
+      });
+      (
+        redis.get as unknown as { mockResolvedValueOnce: (v: unknown) => void }
+      ).mockResolvedValueOnce(stored);
+
+      const result = await service.peekPurgeToken('user-a', 'purge_xyz0123456789abc');
+
+      expect(result).toEqual({ personalityId: 'persona-1' });
+      expect(redis.getdel).not.toHaveBeenCalled();
+    });
+
+    it('returns null on miss', async () => {
+      const result = await service.peekPurgeToken('user-a', 'purge_missing000000000000');
+      expect(result).toBeNull();
+    });
+
+    it('returns null on malformed payload', async () => {
+      (
+        redis.get as unknown as { mockResolvedValueOnce: (v: unknown) => void }
+      ).mockResolvedValueOnce('not-json');
+      const result = await service.peekPurgeToken('user-a', 'purge_bad000000000000000');
+      expect(result).toBeNull();
+    });
+  });
+
   describe('issuePurgeToken', () => {
     it('mints a `purge_`-prefixed token and stores personalityId with 5-minute TTL', async () => {
       const token = await service.issuePurgeToken('user-123', 'persona-1');
@@ -141,6 +218,53 @@ describe('MemoryActionTokenService', () => {
     it('returns null on miss', async () => {
       const result = await service.consumePurgeToken('user-a', 'purge_missing000000000000');
       expect(result).toBeNull();
+    });
+
+    it('returns null and logs when payload JSON is malformed', async () => {
+      (
+        redis.getdel as unknown as { mockResolvedValueOnce: (v: unknown) => void }
+      ).mockResolvedValueOnce('not-json');
+      const result = await service.consumePurgeToken('user-a', 'purge_bad000000000000000');
+      expect(result).toBeNull();
+    });
+
+    it('cannot be replayed — a second consume sees null', async () => {
+      const stored = JSON.stringify({
+        personalityId: 'persona-1',
+        issuedAt: '2026-05-26T12:00:00.000Z',
+      });
+      const mock = redis.getdel as unknown as {
+        mockResolvedValueOnce: (v: unknown) => void;
+      };
+      mock.mockResolvedValueOnce(stored);
+      mock.mockResolvedValueOnce(null);
+
+      const first = await service.consumePurgeToken('user-a', 'purge_aaaaaaaaaaaaaaaa');
+      const second = await service.consumePurgeToken('user-a', 'purge_aaaaaaaaaaaaaaaa');
+
+      expect(first).not.toBeNull();
+      expect(second).toBeNull();
+    });
+
+    it('is namespaced by userId — token issued for user A misses for user B', async () => {
+      const result = await service.consumePurgeToken('user-b', 'purge_stolen000000000000');
+      expect(result).toBeNull();
+      expect(redis.getdel).toHaveBeenCalledWith(
+        `${REDIS_KEY_PREFIXES.MEMORY_PURGE_TOKEN}user-b:purge_stolen000000000000`
+      );
+    });
+  });
+
+  describe('issuePreviewToken — Redis errors propagate', () => {
+    it('propagates setex failures (handled by Express global error handler)', async () => {
+      const err = new Error('Redis connection lost');
+      (
+        redis.setex as unknown as { mockRejectedValueOnce: (v: unknown) => void }
+      ).mockRejectedValueOnce(err);
+
+      await expect(service.issuePreviewToken('user-a', { personalityId: 'p' })).rejects.toThrow(
+        'Redis connection lost'
+      );
     });
   });
 });

--- a/services/api-gateway/src/services/MemoryActionTokenService.test.ts
+++ b/services/api-gateway/src/services/MemoryActionTokenService.test.ts
@@ -63,11 +63,11 @@ describe('MemoryActionTokenService', () => {
         redis.getdel as unknown as { mockResolvedValueOnce: (v: unknown) => void }
       ).mockResolvedValueOnce(stored);
 
-      const result = await service.consumePreviewToken('user-a', 'preview_xyz0123456789abc');
+      const result = await service.consumePreviewToken('user-a', 'preview_test0000test0002');
 
       expect(result).toEqual(filter);
       expect(redis.getdel).toHaveBeenCalledWith(
-        `${REDIS_KEY_PREFIXES.MEMORY_PREVIEW_TOKEN}user-a:preview_xyz0123456789abc`
+        `${REDIS_KEY_PREFIXES.MEMORY_PREVIEW_TOKEN}user-a:preview_test0000test0002`
       );
     });
 

--- a/services/api-gateway/src/services/MemoryActionTokenService.test.ts
+++ b/services/api-gateway/src/services/MemoryActionTokenService.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for MemoryActionTokenService
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Redis } from 'ioredis';
+import { MemoryActionTokenService } from './MemoryActionTokenService.js';
+import { REDIS_KEY_PREFIXES, type BatchDeletePreviewInput } from '@tzurot/common-types';
+
+function createMockRedis(): Redis {
+  return {
+    setex: vi.fn().mockResolvedValue('OK'),
+    getdel: vi.fn().mockResolvedValue(null),
+  } as unknown as Redis;
+}
+
+describe('MemoryActionTokenService', () => {
+  let redis: Redis;
+  let service: MemoryActionTokenService;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-26T12:00:00.000Z'));
+    redis = createMockRedis();
+    service = new MemoryActionTokenService(redis);
+  });
+
+  describe('issuePreviewToken', () => {
+    it('mints a `preview_`-prefixed token and stores filter with 5-minute TTL', async () => {
+      const filter: BatchDeletePreviewInput = {
+        personalityId: 'persona-1',
+        personaId: 'me',
+        timeframe: '7d',
+      };
+      const token = await service.issuePreviewToken('user-123', filter);
+
+      expect(token).toMatch(/^preview_[A-Za-z0-9_-]{16,64}$/);
+      expect(redis.setex).toHaveBeenCalledWith(
+        `${REDIS_KEY_PREFIXES.MEMORY_PREVIEW_TOKEN}user-123:${token}`,
+        300,
+        expect.any(String)
+      );
+      const [, , raw] = (redis.setex as unknown as { mock: { calls: unknown[][] } }).mock
+        .calls[0] as [string, number, string];
+      const parsed = JSON.parse(raw) as { filter: BatchDeletePreviewInput; issuedAt: string };
+      expect(parsed.filter).toEqual(filter);
+      expect(parsed.issuedAt).toBe('2026-05-26T12:00:00.000Z');
+    });
+
+    it('produces a unique token per call', async () => {
+      const filter: BatchDeletePreviewInput = { personalityId: 'p' };
+      const t1 = await service.issuePreviewToken('user-a', filter);
+      const t2 = await service.issuePreviewToken('user-a', filter);
+      expect(t1).not.toBe(t2);
+    });
+  });
+
+  describe('consumePreviewToken', () => {
+    it('returns the bound filter and deletes the key atomically', async () => {
+      const filter: BatchDeletePreviewInput = { personalityId: 'p', timeframe: '7d' };
+      const stored = JSON.stringify({ filter, issuedAt: '2026-05-26T12:00:00.000Z' });
+      (
+        redis.getdel as unknown as { mockResolvedValueOnce: (v: unknown) => void }
+      ).mockResolvedValueOnce(stored);
+
+      const result = await service.consumePreviewToken('user-a', 'preview_xyz0123456789abc');
+
+      expect(result).toEqual(filter);
+      expect(redis.getdel).toHaveBeenCalledWith(
+        `${REDIS_KEY_PREFIXES.MEMORY_PREVIEW_TOKEN}user-a:preview_xyz0123456789abc`
+      );
+    });
+
+    it('returns null when the token does not exist', async () => {
+      const result = await service.consumePreviewToken('user-a', 'preview_missing0000000000');
+      expect(result).toBeNull();
+    });
+
+    it('returns null and logs when payload JSON is malformed', async () => {
+      (
+        redis.getdel as unknown as { mockResolvedValueOnce: (v: unknown) => void }
+      ).mockResolvedValueOnce('not-json');
+      const result = await service.consumePreviewToken('user-a', 'preview_bad000000000000000');
+      expect(result).toBeNull();
+    });
+
+    it('cannot be replayed — a second consume sees null', async () => {
+      const stored = JSON.stringify({
+        filter: { personalityId: 'p' },
+        issuedAt: '2026-05-26T12:00:00.000Z',
+      });
+      const mock = redis.getdel as unknown as {
+        mockResolvedValueOnce: (v: unknown) => void;
+      };
+      mock.mockResolvedValueOnce(stored);
+      mock.mockResolvedValueOnce(null);
+
+      const first = await service.consumePreviewToken('user-a', 'preview_aaaaaaaaaaaaaaaa');
+      const second = await service.consumePreviewToken('user-a', 'preview_aaaaaaaaaaaaaaaa');
+
+      expect(first).not.toBeNull();
+      expect(second).toBeNull();
+    });
+
+    it('is namespaced by userId — token issued for user A misses for user B', async () => {
+      const result = await service.consumePreviewToken('user-b', 'preview_stolen000000000000');
+      expect(result).toBeNull();
+      expect(redis.getdel).toHaveBeenCalledWith(
+        `${REDIS_KEY_PREFIXES.MEMORY_PREVIEW_TOKEN}user-b:preview_stolen000000000000`
+      );
+    });
+  });
+
+  describe('issuePurgeToken', () => {
+    it('mints a `purge_`-prefixed token and stores personalityId with 5-minute TTL', async () => {
+      const token = await service.issuePurgeToken('user-123', 'persona-1');
+
+      expect(token).toMatch(/^purge_[A-Za-z0-9_-]{16,64}$/);
+      expect(redis.setex).toHaveBeenCalledWith(
+        `${REDIS_KEY_PREFIXES.MEMORY_PURGE_TOKEN}user-123:${token}`,
+        300,
+        expect.any(String)
+      );
+    });
+  });
+
+  describe('consumePurgeToken', () => {
+    it('returns the bound personalityId', async () => {
+      const stored = JSON.stringify({
+        personalityId: 'persona-1',
+        issuedAt: '2026-05-26T12:00:00.000Z',
+      });
+      (
+        redis.getdel as unknown as { mockResolvedValueOnce: (v: unknown) => void }
+      ).mockResolvedValueOnce(stored);
+
+      const result = await service.consumePurgeToken('user-a', 'purge_xyz0123456789abc');
+      expect(result).toEqual({ personalityId: 'persona-1' });
+    });
+
+    it('returns null on miss', async () => {
+      const result = await service.consumePurgeToken('user-a', 'purge_missing000000000000');
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/services/api-gateway/src/services/MemoryActionTokenService.ts
+++ b/services/api-gateway/src/services/MemoryActionTokenService.ts
@@ -22,6 +22,11 @@
  *
  * TTL is 5 minutes — long enough for confirmation-modal UX, short enough that
  * stale tokens don't accumulate.
+ *
+ * Requires Redis 6.2+ — GETDEL was added in 6.2 and is the load-bearing
+ * atomicity guarantee for replay prevention. Railway ships Redis 7.x, so
+ * production is fine; local dev via Docker should pin redis:7-alpine or
+ * later. (Older Redis would silently degrade to a non-atomic GET+DEL race.)
  */
 
 import { randomBytes } from 'node:crypto';
@@ -87,6 +92,38 @@ export class MemoryActionTokenService {
   }
 
   /**
+   * Non-destructively read a preview token. Use this when you want to
+   * validate preconditions (e.g., the bound personality still exists)
+   * before committing to consuming the token — failed validation should
+   * NOT burn the user's one-shot redemption.
+   *
+   * The 5-min TTL bounds the impact of a peek without consume. Once
+   * preconditions are validated, follow up with `consumePreviewToken`
+   * to atomically claim it.
+   *
+   * Tiny race window: peek → validation → consume can race against a
+   * concurrent consume by the same user (e.g., double-click on confirm).
+   * Both attempts succeed at the peek-and-validate step; the destructive
+   * op below them is idempotent (soft-delete of already-deleted rows is
+   * a no-op), so the race is benign in practice.
+   */
+  async peekPreviewToken(userId: string, token: string): Promise<BatchDeletePreviewInput | null> {
+    const key = buildPreviewKey(userId, token);
+    const raw = await this.redis.get(key);
+    if (raw === null) {
+      logger.debug({ userId, token: `${token.substring(0, 12)}…` }, 'Preview token peek miss');
+      return null;
+    }
+    try {
+      const payload = JSON.parse(raw) as PreviewTokenPayload;
+      return payload.filter;
+    } catch (error) {
+      logger.warn({ err: error, userId }, 'Failed to parse preview token payload on peek');
+      return null;
+    }
+  }
+
+  /**
    * Atomically read and delete a preview token. Returns the bound filter, or
    * null if the token is invalid, expired, or has already been consumed.
    *
@@ -131,6 +168,27 @@ export class MemoryActionTokenService {
       'Purge token issued'
     );
     return token;
+  }
+
+  /**
+   * Non-destructively read a purge token. See `peekPreviewToken` for the
+   * full rationale — same trade-off (avoids burning a token on a 404
+   * personality lookup) and same benign race in the peek → consume window.
+   */
+  async peekPurgeToken(userId: string, token: string): Promise<{ personalityId: string } | null> {
+    const key = buildPurgeKey(userId, token);
+    const raw = await this.redis.get(key);
+    if (raw === null) {
+      logger.debug({ userId, token: `${token.substring(0, 12)}…` }, 'Purge token peek miss');
+      return null;
+    }
+    try {
+      const payload = JSON.parse(raw) as PurgeTokenPayload;
+      return { personalityId: payload.personalityId };
+    } catch (error) {
+      logger.warn({ err: error, userId }, 'Failed to parse purge token payload on peek');
+      return null;
+    }
   }
 
   /**

--- a/services/api-gateway/src/services/MemoryActionTokenService.ts
+++ b/services/api-gateway/src/services/MemoryActionTokenService.ts
@@ -1,0 +1,159 @@
+/**
+ * MemoryActionTokenService
+ *
+ * Issues and consumes short-lived Redis tokens that bind a destructive memory
+ * operation's preview to its execute call:
+ *
+ *   - `PreviewToken` — issued by `POST /user/memory/delete/preview`. The token
+ *     value stores the filter (personality, persona, timeframe) that produced
+ *     the preview summary. `POST /user/memory/delete` consumes the token and
+ *     re-applies the SAME filter — eliminating drift between what the user
+ *     saw and what gets deleted.
+ *
+ *   - `PurgeToken` — issued by `POST /user/memory/purge/token` after the user
+ *     types the confirmation phrase. The token value stores the personalityId
+ *     binding. `POST /user/memory/purge` consumes the token and purges that
+ *     personality's memories.
+ *
+ * Tokens are namespaced by Discord user ID — token-stealing across users is
+ * cut off at the lookup-key boundary (a stolen token won't match another
+ * user's prefix). Consumption uses an atomic GETDEL so a token can only be
+ * redeemed once.
+ *
+ * TTL is 5 minutes — long enough for confirmation-modal UX, short enough that
+ * stale tokens don't accumulate.
+ */
+
+import { randomBytes } from 'node:crypto';
+import type { Redis } from 'ioredis';
+import {
+  createLogger,
+  REDIS_KEY_PREFIXES,
+  type BatchDeletePreviewInput,
+} from '@tzurot/common-types';
+
+const logger = createLogger('MemoryActionTokenService');
+
+/** Token TTL in seconds. 5 minutes covers confirmation-modal UX comfortably. */
+const TOKEN_TTL_SECONDS = 5 * 60;
+
+/** Length of the random suffix following the `preview_` / `purge_` prefix. */
+const TOKEN_RANDOM_BYTES = 16;
+
+interface PreviewTokenPayload {
+  readonly filter: BatchDeletePreviewInput;
+  readonly issuedAt: string;
+}
+
+interface PurgeTokenPayload {
+  readonly personalityId: string;
+  readonly issuedAt: string;
+}
+
+function buildPreviewKey(userId: string, token: string): string {
+  return `${REDIS_KEY_PREFIXES.MEMORY_PREVIEW_TOKEN}${userId}:${token}`;
+}
+
+function buildPurgeKey(userId: string, token: string): string {
+  return `${REDIS_KEY_PREFIXES.MEMORY_PURGE_TOKEN}${userId}:${token}`;
+}
+
+/**
+ * Mint a random token. Uses URL-safe base64 to match the regex enforced by
+ * `PreviewTokenSchema` / `PurgeTokenSchema` (`[A-Za-z0-9_-]{16,64}`).
+ */
+function mintTokenValue(prefix: 'preview' | 'purge'): string {
+  const suffix = randomBytes(TOKEN_RANDOM_BYTES).toString('base64url');
+  return `${prefix}_${suffix}`;
+}
+
+export class MemoryActionTokenService {
+  constructor(private readonly redis: Redis) {}
+
+  /**
+   * Issue a preview token bound to the given filter for the given user.
+   * Returns the token string (caller serializes it into the preview response).
+   */
+  async issuePreviewToken(userId: string, filter: BatchDeletePreviewInput): Promise<string> {
+    const token = mintTokenValue('preview');
+    const key = buildPreviewKey(userId, token);
+    const payload: PreviewTokenPayload = {
+      filter,
+      issuedAt: new Date().toISOString(),
+    };
+    await this.redis.setex(key, TOKEN_TTL_SECONDS, JSON.stringify(payload));
+    logger.debug({ userId, token: `${token.substring(0, 12)}…` }, 'Preview token issued');
+    return token;
+  }
+
+  /**
+   * Atomically read and delete a preview token. Returns the bound filter, or
+   * null if the token is invalid, expired, or has already been consumed.
+   *
+   * `getdel` is a single Redis op — no race between an attacker brute-forcing
+   * tokens and a legitimate consume.
+   */
+  async consumePreviewToken(
+    userId: string,
+    token: string
+  ): Promise<BatchDeletePreviewInput | null> {
+    const key = buildPreviewKey(userId, token);
+    const raw = await this.redis.getdel(key);
+    if (raw === null) {
+      logger.debug({ userId, token: `${token.substring(0, 12)}…` }, 'Preview token miss');
+      return null;
+    }
+    try {
+      const payload = JSON.parse(raw) as PreviewTokenPayload;
+      return payload.filter;
+    } catch (error) {
+      logger.warn({ err: error, userId }, 'Failed to parse preview token payload');
+      return null;
+    }
+  }
+
+  /**
+   * Issue a purge token bound to a specific (user, personality) pair. The
+   * caller is responsible for verifying the confirmation phrase BEFORE
+   * calling this — possession of a purge token is the destructive operation's
+   * final gate.
+   */
+  async issuePurgeToken(userId: string, personalityId: string): Promise<string> {
+    const token = mintTokenValue('purge');
+    const key = buildPurgeKey(userId, token);
+    const payload: PurgeTokenPayload = {
+      personalityId,
+      issuedAt: new Date().toISOString(),
+    };
+    await this.redis.setex(key, TOKEN_TTL_SECONDS, JSON.stringify(payload));
+    logger.info(
+      { userId, personalityId, token: `${token.substring(0, 12)}…` },
+      'Purge token issued'
+    );
+    return token;
+  }
+
+  /**
+   * Atomically read and delete a purge token. Returns the bound personality
+   * ID, or null if the token is invalid, expired, or has already been
+   * consumed.
+   */
+  async consumePurgeToken(
+    userId: string,
+    token: string
+  ): Promise<{ personalityId: string } | null> {
+    const key = buildPurgeKey(userId, token);
+    const raw = await this.redis.getdel(key);
+    if (raw === null) {
+      logger.debug({ userId, token: `${token.substring(0, 12)}…` }, 'Purge token miss');
+      return null;
+    }
+    try {
+      const payload = JSON.parse(raw) as PurgeTokenPayload;
+      return { personalityId: payload.personalityId };
+    } catch (error) {
+      logger.warn({ err: error, userId }, 'Failed to parse purge token payload');
+      return null;
+    }
+  }
+}

--- a/services/api-gateway/src/services/MemoryActionTokenService.ts
+++ b/services/api-gateway/src/services/MemoryActionTokenService.ts
@@ -42,16 +42,22 @@ const logger = createLogger('MemoryActionTokenService');
 /** Token TTL in seconds. 5 minutes covers confirmation-modal UX comfortably. */
 const TOKEN_TTL_SECONDS = 5 * 60;
 
-/** Length of the random suffix following the `preview_` / `purge_` prefix. */
+/**
+ * Length of the random suffix following the `preview_` / `purge_` prefix.
+ * 16 bytes encoded as base64url produces 22 characters (no padding), which
+ * satisfies the brand regex `[A-Za-z0-9_-]{16,64}` with room to spare.
+ */
 const TOKEN_RANDOM_BYTES = 16;
 
 interface PreviewTokenPayload {
   readonly filter: BatchDeletePreviewInput;
+  /** Informational only — Redis TTL is the authoritative expiry gate. */
   readonly issuedAt: string;
 }
 
 interface PurgeTokenPayload {
   readonly personalityId: string;
+  /** Informational only — Redis TTL is the authoritative expiry gate. */
   readonly issuedAt: string;
 }
 

--- a/services/bot-client/src/commands/memory/batchDelete.test.ts
+++ b/services/bot-client/src/commands/memory/batchDelete.test.ts
@@ -233,7 +233,7 @@ describe('handleBatchDelete', () => {
           personalityId: 'personality-uuid-123',
           personalityName: 'Lilith',
           timeframe: 'all',
-          previewToken: 'preview_test0123456789abc',
+          previewToken: 'preview_test0000test0001',
         },
       });
     });
@@ -296,7 +296,7 @@ describe('handleBatchDelete', () => {
             personalityId: 'personality-uuid-123',
             personalityName: 'Lilith',
             timeframe: 'all',
-            previewToken: 'preview_test0123456789abc',
+            previewToken: 'preview_test0000test0001',
           },
         })
         // Delete response
@@ -323,7 +323,7 @@ describe('handleBatchDelete', () => {
         '/user/memory/delete',
         expect.objectContaining({
           method: 'POST',
-          body: { previewToken: 'preview_test0123456789abc' },
+          body: { previewToken: 'preview_test0000test0001' },
         })
       );
 
@@ -343,7 +343,7 @@ describe('handleBatchDelete', () => {
             personalityId: 'personality-uuid-123',
             personalityName: 'Lilith',
             timeframe: '7d',
-            previewToken: 'preview_xyz0123456789abc',
+            previewToken: 'preview_test0000test0002',
           },
         })
         .mockResolvedValueOnce({
@@ -378,7 +378,7 @@ describe('handleBatchDelete', () => {
         '/user/memory/delete',
         expect.objectContaining({
           method: 'POST',
-          body: { previewToken: 'preview_xyz0123456789abc' },
+          body: { previewToken: 'preview_test0000test0002' },
         })
       );
     });
@@ -393,7 +393,7 @@ describe('handleBatchDelete', () => {
             personalityId: 'personality-uuid-123',
             personalityName: 'Lilith',
             timeframe: 'all',
-            previewToken: 'preview_test0123456789abc',
+            previewToken: 'preview_test0000test0001',
           },
         })
         .mockResolvedValueOnce({
@@ -424,7 +424,7 @@ describe('handleBatchDelete', () => {
             personalityId: 'personality-uuid-123',
             personalityName: 'Lilith',
             timeframe: 'all',
-            previewToken: 'preview_test0123456789abc',
+            previewToken: 'preview_test0000test0001',
           },
         })
         .mockResolvedValueOnce({

--- a/services/bot-client/src/commands/memory/batchDelete.test.ts
+++ b/services/bot-client/src/commands/memory/batchDelete.test.ts
@@ -133,8 +133,11 @@ describe('handleBatchDelete', () => {
         'lilith'
       );
       expect(mockCallGatewayApi).toHaveBeenCalledWith(
-        expect.stringContaining('personalityId=personality-uuid-123'),
-        expect.objectContaining({ method: 'GET' })
+        '/user/memory/delete/preview',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.objectContaining({ personalityId: 'personality-uuid-123' }),
+        })
       );
     });
   });
@@ -210,8 +213,11 @@ describe('handleBatchDelete', () => {
       await handleBatchDelete(context);
 
       expect(mockCallGatewayApi).toHaveBeenCalledWith(
-        expect.stringMatching(/timeframe=7d/),
-        expect.any(Object)
+        '/user/memory/delete/preview',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.objectContaining({ timeframe: '7d' }),
+        })
       );
     });
   });
@@ -227,6 +233,7 @@ describe('handleBatchDelete', () => {
           personalityId: 'personality-uuid-123',
           personalityName: 'Lilith',
           timeframe: 'all',
+          previewToken: 'preview_test0123456789abc',
         },
       });
     });
@@ -278,8 +285,8 @@ describe('handleBatchDelete', () => {
       mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
     });
 
-    it('should perform deletion when user confirms', async () => {
-      // Preview response
+    it('should perform deletion using the previewToken when user confirms', async () => {
+      // Preview response — now carries the token bound to the filter
       mockCallGatewayApi
         .mockResolvedValueOnce({
           ok: true,
@@ -289,6 +296,7 @@ describe('handleBatchDelete', () => {
             personalityId: 'personality-uuid-123',
             personalityName: 'Lilith',
             timeframe: 'all',
+            previewToken: 'preview_test0123456789abc',
           },
         })
         // Delete response
@@ -309,25 +317,23 @@ describe('handleBatchDelete', () => {
       const context = createMockContext();
       await handleBatchDelete(context);
 
-      // Verify delete API was called
+      // Delete API is invoked with ONLY the previewToken — the filter
+      // never crosses the wire on the execute path.
       expect(mockCallGatewayApi).toHaveBeenCalledWith(
         '/user/memory/delete',
         expect.objectContaining({
           method: 'POST',
-          body: expect.objectContaining({
-            personalityId: 'personality-uuid-123',
-          }),
+          body: { previewToken: 'preview_test0123456789abc' },
         })
       );
 
-      // Verify success message shown
       expect(buttonInteraction.editReply).toHaveBeenCalledWith({
         embeds: expect.any(Array),
         components: [],
       });
     });
 
-    it('should include timeframe in delete request', async () => {
+    it('should include timeframe only in the preview body — execute uses the token', async () => {
       mockCallGatewayApi
         .mockResolvedValueOnce({
           ok: true,
@@ -337,6 +343,7 @@ describe('handleBatchDelete', () => {
             personalityId: 'personality-uuid-123',
             personalityName: 'Lilith',
             timeframe: '7d',
+            previewToken: 'preview_xyz0123456789abc',
           },
         })
         .mockResolvedValueOnce({
@@ -356,12 +363,22 @@ describe('handleBatchDelete', () => {
       const context = createMockContext('lilith', '7d');
       await handleBatchDelete(context);
 
-      expect(mockCallGatewayApi).toHaveBeenCalledWith(
+      // Preview includes timeframe …
+      expect(mockCallGatewayApi).toHaveBeenNthCalledWith(
+        1,
+        '/user/memory/delete/preview',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.objectContaining({ timeframe: '7d' }),
+        })
+      );
+      // … execute is token-only.
+      expect(mockCallGatewayApi).toHaveBeenNthCalledWith(
+        2,
         '/user/memory/delete',
         expect.objectContaining({
-          body: expect.objectContaining({
-            timeframe: '7d',
-          }),
+          method: 'POST',
+          body: { previewToken: 'preview_xyz0123456789abc' },
         })
       );
     });
@@ -376,6 +393,7 @@ describe('handleBatchDelete', () => {
             personalityId: 'personality-uuid-123',
             personalityName: 'Lilith',
             timeframe: 'all',
+            previewToken: 'preview_test0123456789abc',
           },
         })
         .mockResolvedValueOnce({
@@ -406,6 +424,7 @@ describe('handleBatchDelete', () => {
             personalityId: 'personality-uuid-123',
             personalityName: 'Lilith',
             timeframe: 'all',
+            previewToken: 'preview_test0123456789abc',
           },
         })
         .mockResolvedValueOnce({

--- a/services/bot-client/src/commands/memory/batchDelete.ts
+++ b/services/bot-client/src/commands/memory/batchDelete.ts
@@ -38,6 +38,8 @@ interface PreviewResponse {
   personalityId: string;
   personalityName: string;
   timeframe: string;
+  /** Short-lived token bound to the filter that produced this preview. */
+  previewToken: string;
 }
 
 interface DeleteResponse {
@@ -94,19 +96,18 @@ export async function handleBatchDelete(context: DeferredCommandContext): Promis
       return;
     }
 
-    // Get preview of what would be deleted
-    const queryParams = new URLSearchParams({ personalityId });
-    if (timeframe !== null) {
-      queryParams.set('timeframe', timeframe);
-    }
-
-    const previewResult = await callGatewayApi<PreviewResponse>(
-      `/user/memory/delete/preview?${queryParams.toString()}`,
-      {
-        user,
-        method: 'GET',
-      }
-    );
+    // Preview the deletion and obtain a token bound to this filter. The
+    // execute call below sends ONLY the token — server-side reads the
+    // filter back from Redis under the token key, so the execute path
+    // is guaranteed to match what the user previewed.
+    const previewResult = await callGatewayApi<PreviewResponse>(`/user/memory/delete/preview`, {
+      user,
+      method: 'POST',
+      body: {
+        personalityId,
+        ...(timeframe !== null ? { timeframe } : {}),
+      },
+    });
 
     if (!previewResult.ok) {
       const errorMessage =
@@ -193,10 +194,7 @@ export async function handleBatchDelete(context: DeferredCommandContext): Promis
       const deleteResult = await callGatewayApi<DeleteResponse>('/user/memory/delete', {
         user,
         method: 'POST',
-        body: {
-          personalityId,
-          timeframe,
-        },
+        body: { previewToken: preview.previewToken },
       });
 
       if (!deleteResult.ok) {

--- a/services/bot-client/src/commands/memory/detail.test.ts
+++ b/services/bot-client/src/commands/memory/detail.test.ts
@@ -340,6 +340,25 @@ describe('Memory Detail', () => {
         })
       );
     });
+
+    it('forwards desiredState=false to setMemoryLock for unlock flow', async () => {
+      const memory = createMockMemory({ isLocked: false });
+      mockCallGatewayApi.mockResolvedValue({ ok: true, data: { memory } });
+
+      const interaction = {
+        user: { id: 'user-123' },
+        deferUpdate: vi.fn(),
+        followUp: vi.fn(),
+        editReply: vi.fn(),
+      } as unknown as ButtonInteraction;
+
+      await handleLockButton(interaction, 'memory-123', false);
+
+      expect(mockCallGatewayApi).toHaveBeenCalledWith(
+        expect.stringContaining('/lock'),
+        expect.objectContaining({ method: 'PUT', body: { locked: false } })
+      );
+    });
   });
 
   describe('handleDeleteButton', () => {

--- a/services/bot-client/src/commands/memory/detail.test.ts
+++ b/services/bot-client/src/commands/memory/detail.test.ts
@@ -311,7 +311,7 @@ describe('Memory Detail', () => {
         editReply: mockEditReply,
       } as unknown as ButtonInteraction;
 
-      await handleLockButton(interaction, 'memory-123');
+      await handleLockButton(interaction, 'memory-123', true);
 
       expect(mockDeferUpdate).toHaveBeenCalled();
       expect(mockEditReply).toHaveBeenCalled();
@@ -332,7 +332,7 @@ describe('Memory Detail', () => {
         followUp: mockFollowUp,
       } as unknown as ButtonInteraction;
 
-      await handleLockButton(interaction, 'memory-123');
+      await handleLockButton(interaction, 'memory-123', true);
 
       expect(mockFollowUp).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/services/bot-client/src/commands/memory/detail.ts
+++ b/services/bot-client/src/commands/memory/detail.ts
@@ -18,7 +18,7 @@ import { createLogger, DISCORD_COLORS, formatDateTimeCompact } from '@tzurot/com
 import { CUSTOM_ID_DELIMITER } from '../../utils/customIds.js';
 import { toGatewayUser } from '../../utils/userGatewayClient.js';
 
-import { fetchMemory, toggleMemoryLock, deleteMemory } from './detailApi.js';
+import { fetchMemory, setMemoryLock, deleteMemory } from './detailApi.js';
 import type { MemoryItem } from './detailApi.js';
 import { EMBED_DESCRIPTION_SAFE_LIMIT } from './formatters.js';
 
@@ -144,7 +144,9 @@ export function buildDetailButtons(
       .setEmoji('✏️')
       .setStyle(ButtonStyle.Primary),
     new ButtonBuilder()
-      .setCustomId(buildMemoryActionId('lock', memory.id))
+      // Encode desired final state in customId — the API takes the target
+      // state explicitly so retries can't accidentally flip the wrong way.
+      .setCustomId(buildMemoryActionId('lock', memory.id, memory.isLocked ? '0' : '1'))
       .setLabel(lockLabel)
       .setEmoji(lockEmoji)
       .setStyle(lockStyle),
@@ -234,17 +236,28 @@ export async function handleMemorySelect(interaction: StringSelectMenuInteractio
 }
 
 /**
- * Handle lock/unlock button click
+ * Handle lock/unlock button click.
+ *
+ * The desired target state is encoded in the customId by `buildDetailButtons`
+ * — the button rendered while the memory is unlocked carries `'1'` (lock it),
+ * while the button rendered for a locked memory carries `'0'` (unlock it).
+ * The API takes the target state explicitly so a retried network request
+ * can't accidentally flip the wrong way.
  */
 export async function handleLockButton(
   interaction: ButtonInteraction,
-  memoryId: string
+  memoryId: string,
+  desiredState: boolean
 ): Promise<void> {
   const userId = interaction.user.id;
 
   await interaction.deferUpdate();
 
-  const updatedMemory = await toggleMemoryLock(toGatewayUser(interaction.user), memoryId);
+  const updatedMemory = await setMemoryLock(
+    toGatewayUser(interaction.user),
+    memoryId,
+    desiredState
+  );
   if (updatedMemory === null) {
     await interaction.followUp({
       content: '❌ Failed to update lock status. Please try again.',
@@ -262,7 +275,7 @@ export async function handleLockButton(
   });
 
   const action = updatedMemory.isLocked ? 'locked' : 'unlocked';
-  logger.info({ userId, memoryId, action }, 'Memory lock toggled');
+  logger.info({ userId, memoryId, action }, 'Memory lock set');
 }
 
 /**

--- a/services/bot-client/src/commands/memory/detailActionRouter.test.ts
+++ b/services/bot-client/src/commands/memory/detailActionRouter.test.ts
@@ -87,14 +87,34 @@ describe('handleMemoryDetailAction', () => {
     expect(mockHandleCancelEditButton).toHaveBeenCalledWith(interaction);
   });
 
-  it('should dispatch lock action', async () => {
+  it('dispatches lock action with desiredState=true when extra is "1"', async () => {
+    mockParseMemoryActionId.mockReturnValue({ action: 'lock', memoryId: 'mem-1', extra: '1' });
+    const interaction = createMockButtonInteraction('memory-detail::lock::mem-1::1');
+
+    const result = await handleMemoryDetailAction(interaction, mockOnRefresh);
+
+    expect(result).toBe(true);
+    expect(mockHandleLockButton).toHaveBeenCalledWith(interaction, 'mem-1', true);
+  });
+
+  it('dispatches lock action with desiredState=false when extra is "0"', async () => {
+    mockParseMemoryActionId.mockReturnValue({ action: 'lock', memoryId: 'mem-1', extra: '0' });
+    const interaction = createMockButtonInteraction('memory-detail::lock::mem-1::0');
+
+    const result = await handleMemoryDetailAction(interaction, mockOnRefresh);
+
+    expect(result).toBe(true);
+    expect(mockHandleLockButton).toHaveBeenCalledWith(interaction, 'mem-1', false);
+  });
+
+  it('returns false for lock action without a valid extra (legacy customId)', async () => {
     mockParseMemoryActionId.mockReturnValue({ action: 'lock', memoryId: 'mem-1' });
     const interaction = createMockButtonInteraction('memory-detail::lock::mem-1');
 
     const result = await handleMemoryDetailAction(interaction, mockOnRefresh);
 
-    expect(result).toBe(true);
-    expect(mockHandleLockButton).toHaveBeenCalledWith(interaction, 'mem-1');
+    expect(result).toBe(false);
+    expect(mockHandleLockButton).not.toHaveBeenCalled();
   });
 
   it('should dispatch delete action', async () => {
@@ -202,20 +222,23 @@ describe('handleMemoryDetailAction', () => {
     const SESSION_INDEPENDENT_CASES: Array<{
       action: string;
       memoryId: string | undefined;
+      extra?: string;
     }> = [
       { action: 'edit', memoryId: 'mem-1' },
       { action: 'edit-truncated', memoryId: 'mem-1' },
       { action: 'cancel-edit', memoryId: undefined },
-      { action: 'lock', memoryId: 'mem-1' },
+      { action: 'lock', memoryId: 'mem-1', extra: '1' },
       { action: 'view-full', memoryId: 'mem-1' },
       { action: 'delete', memoryId: 'mem-1' }, // shows confirmation dialog — no refresh
     ];
 
     it.each(SESSION_INDEPENDENT_CASES)(
       '$action action does not call onRefresh',
-      async ({ action, memoryId }) => {
-        mockParseMemoryActionId.mockReturnValue({ action, memoryId });
-        const interaction = createMockButtonInteraction(`memory-detail::${action}::${memoryId}`);
+      async ({ action, memoryId, extra }) => {
+        mockParseMemoryActionId.mockReturnValue({ action, memoryId, extra });
+        const interaction = createMockButtonInteraction(
+          `memory-detail::${action}::${memoryId}${extra !== undefined ? `::${extra}` : ''}`
+        );
 
         await handleMemoryDetailAction(interaction, mockOnRefresh);
 

--- a/services/bot-client/src/commands/memory/detailActionRouter.ts
+++ b/services/bot-client/src/commands/memory/detailActionRouter.ts
@@ -21,6 +21,22 @@ import {
 } from './detailModals.js';
 
 /**
+ * Decode the `extra` segment carried by a `lock` action's customId into the
+ * desired final lock state. Returns null when the segment is missing or
+ * doesn't match `'0' | '1'` (e.g., legacy customId from before the
+ * idempotent-lock migration).
+ */
+function parseLockExtra(extra: string | undefined): boolean | null {
+  if (extra === '1') {
+    return true;
+  }
+  if (extra === '0') {
+    return false;
+  }
+  return null;
+}
+
+/**
  * Handle memory detail action buttons.
  * Returns true if the button was handled, false if not recognized.
  *
@@ -52,7 +68,7 @@ export async function handleMemoryDetailAction(
     return false;
   }
 
-  const { action, memoryId } = parsed;
+  const { action, memoryId, extra } = parsed;
 
   switch (action) {
     case 'edit':
@@ -70,12 +86,14 @@ export async function handleMemoryDetailAction(
     case 'cancel-edit':
       await handleCancelEditButton(buttonInteraction);
       return true;
-    case 'lock':
-      if (memoryId === undefined) {
+    case 'lock': {
+      const desired = parseLockExtra(extra);
+      if (memoryId === undefined || desired === null) {
         return false;
       }
-      await handleLockButton(buttonInteraction, memoryId);
+      await handleLockButton(buttonInteraction, memoryId, desired);
       return true;
+    }
     case 'delete':
       if (memoryId === undefined) {
         return false;

--- a/services/bot-client/src/commands/memory/detailApi.test.ts
+++ b/services/bot-client/src/commands/memory/detailApi.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { fetchMemory, updateMemory, toggleMemoryLock, deleteMemory } from './detailApi.js';
+import { fetchMemory, updateMemory, setMemoryLock, deleteMemory } from './detailApi.js';
 import type { MemoryItem } from './detailApi.js';
 
 // Mock common-types
@@ -121,15 +121,15 @@ describe('Memory Detail API', () => {
     });
   });
 
-  describe('toggleMemoryLock', () => {
-    it('should toggle lock successfully', async () => {
+  describe('setMemoryLock', () => {
+    it('sets the lock state explicitly with PUT + { locked }', async () => {
       const memory = createMockMemory({ isLocked: true });
       mockCallGatewayApi.mockResolvedValue({
         ok: true,
         data: { memory },
       });
 
-      const result = await toggleMemoryLock(TEST_USER, 'memory-123');
+      const result = await setMemoryLock(TEST_USER, 'memory-123', true);
 
       expect(result).toEqual(memory);
       expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/memory/memory-123/lock', {
@@ -138,17 +138,33 @@ describe('Memory Detail API', () => {
           username: 'testuser',
           displayName: 'testuser',
         },
-        method: 'POST',
+        method: 'PUT',
+        body: { locked: true },
       });
     });
 
-    it('should return null on API error', async () => {
+    it('passes locked=false through to the API for unlock', async () => {
+      const memory = createMockMemory({ isLocked: false });
+      mockCallGatewayApi.mockResolvedValue({
+        ok: true,
+        data: { memory },
+      });
+
+      await setMemoryLock(TEST_USER, 'memory-123', false);
+
+      expect(mockCallGatewayApi).toHaveBeenCalledWith(
+        '/user/memory/memory-123/lock',
+        expect.objectContaining({ method: 'PUT', body: { locked: false } })
+      );
+    });
+
+    it('returns null on API error', async () => {
       mockCallGatewayApi.mockResolvedValue({
         ok: false,
         error: 'Lock failed',
       });
 
-      const result = await toggleMemoryLock(TEST_USER, 'memory-123');
+      const result = await setMemoryLock(TEST_USER, 'memory-123', true);
 
       expect(result).toBeNull();
     });

--- a/services/bot-client/src/commands/memory/detailApi.ts
+++ b/services/bot-client/src/commands/memory/detailApi.ts
@@ -77,22 +77,29 @@ export async function updateMemory(
 }
 
 /**
- * Toggle memory lock status
+ * Set memory lock state explicitly. Idempotent on retry — caller supplies
+ * the desired final state so a network-retried request can't accidentally
+ * unlock something the previous attempt locked.
  */
-export async function toggleMemoryLock(
+export async function setMemoryLock(
   user: GatewayUser,
-  memoryId: string
+  memoryId: string,
+  locked: boolean
 ): Promise<MemoryItem | null> {
   const result = await callGatewayApi<SingleMemoryResponse>(
     `/user/memory/${encodeURIComponent(memoryId)}/lock`,
     {
       user,
-      method: 'POST',
+      method: 'PUT',
+      body: { locked },
     }
   );
 
   if (!result.ok) {
-    logger.warn({ userId: user.discordId, memoryId, error: result.error }, 'Failed to toggle lock');
+    logger.warn(
+      { userId: user.discordId, memoryId, locked, error: result.error },
+      'Failed to set memory lock'
+    );
     return null;
   }
 

--- a/services/bot-client/src/commands/memory/purge.test.ts
+++ b/services/bot-client/src/commands/memory/purge.test.ts
@@ -352,7 +352,7 @@ describe('handlePurgeModal (modal submission)', () => {
       .mockResolvedValueOnce({
         ok: true,
         data: {
-          purgeToken: 'purge_test0123456789abc',
+          purgeToken: 'purge_test0000test0001',
           personalityId: PERSONALITY_ID,
           personalityName: PERSONALITY_NAME,
         },
@@ -385,7 +385,7 @@ describe('handlePurgeModal (modal submission)', () => {
       .mockResolvedValueOnce({
         ok: true,
         data: {
-          purgeToken: 'purge_test0123456789abc',
+          purgeToken: 'purge_test0000test0001',
           personalityId: PERSONALITY_ID,
           personalityName: PERSONALITY_NAME,
         },
@@ -423,7 +423,7 @@ describe('handlePurgeModal (modal submission)', () => {
       '/user/memory/purge',
       expect.objectContaining({
         method: 'POST',
-        body: { purgeToken: 'purge_test0123456789abc' },
+        body: { purgeToken: 'purge_test0000test0001' },
       })
     );
     expect(interaction.editReply).toHaveBeenCalledWith(
@@ -449,7 +449,7 @@ describe('handlePurgeModal (modal submission)', () => {
       .mockResolvedValueOnce({
         ok: true,
         data: {
-          purgeToken: 'purge_test0123456789abc',
+          purgeToken: 'purge_test0000test0001',
           personalityId: PERSONALITY_ID,
           personalityName: PERSONALITY_NAME,
         },

--- a/services/bot-client/src/commands/memory/purge.test.ts
+++ b/services/bot-client/src/commands/memory/purge.test.ts
@@ -347,50 +347,69 @@ describe('handlePurgeModal (modal submission)', () => {
     expect(mockCallGatewayApi).not.toHaveBeenCalled();
   });
 
-  it('trims whitespace before validating', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
-        deletedCount: 5,
-        lockedPreserved: 0,
-        personalityId: PERSONALITY_ID,
-        personalityName: PERSONALITY_NAME,
-        message: 'ok',
-      },
-    });
+  it('trims whitespace before validating and forwards trimmed phrase to /purge/token', async () => {
+    mockCallGatewayApi
+      .mockResolvedValueOnce({
+        ok: true,
+        data: {
+          purgeToken: 'purge_test0123456789abc',
+          personalityId: PERSONALITY_ID,
+          personalityName: PERSONALITY_NAME,
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        data: {
+          deletedCount: 5,
+          lockedPreserved: 0,
+          personalityId: PERSONALITY_ID,
+          personalityName: PERSONALITY_NAME,
+          message: 'ok',
+        },
+      });
     const interaction = createMockModalInteraction(`  ${EXPECTED_PHRASE}  `);
 
     await handlePurgeModal(interaction);
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith(
-      '/user/memory/purge',
+    expect(mockCallGatewayApi).toHaveBeenNthCalledWith(
+      1,
+      '/user/memory/purge/token',
       expect.objectContaining({
         body: expect.objectContaining({ confirmationPhrase: EXPECTED_PHRASE }),
       })
     );
   });
 
-  it('performs purge on correct phrase + reports success', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
-        deletedCount: 8,
-        lockedPreserved: 2,
-        personalityId: PERSONALITY_ID,
-        personalityName: PERSONALITY_NAME,
-        message: 'ok',
-      },
-    });
+  it('performs purge as token-handshake (issue → consume) and reports success', async () => {
+    mockCallGatewayApi
+      .mockResolvedValueOnce({
+        ok: true,
+        data: {
+          purgeToken: 'purge_test0123456789abc',
+          personalityId: PERSONALITY_ID,
+          personalityName: PERSONALITY_NAME,
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        data: {
+          deletedCount: 8,
+          lockedPreserved: 2,
+          personalityId: PERSONALITY_ID,
+          personalityName: PERSONALITY_NAME,
+          message: 'ok',
+        },
+      });
     const interaction = createMockModalInteraction(EXPECTED_PHRASE);
 
     await handlePurgeModal(interaction);
 
-    // Modal acked first via update() — clears warning, no async work between.
     expect(interaction.update).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('Purging') })
     );
-    expect(mockCallGatewayApi).toHaveBeenCalledWith(
-      '/user/memory/purge',
+    expect(mockCallGatewayApi).toHaveBeenNthCalledWith(
+      1,
+      '/user/memory/purge/token',
       expect.objectContaining({
         method: 'POST',
         body: expect.objectContaining({
@@ -399,13 +418,43 @@ describe('handlePurgeModal (modal submission)', () => {
         }),
       })
     );
+    expect(mockCallGatewayApi).toHaveBeenNthCalledWith(
+      2,
+      '/user/memory/purge',
+      expect.objectContaining({
+        method: 'POST',
+        body: { purgeToken: 'purge_test0123456789abc' },
+      })
+    );
     expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({ embeds: expect.any(Array) })
     );
   });
 
-  it('reports failure when purge API fails', async () => {
-    mockCallGatewayApi.mockResolvedValue({ ok: false, error: 'Database error' });
+  it('reports failure when token issuance fails (confirmation rejected server-side)', async () => {
+    mockCallGatewayApi.mockResolvedValueOnce({ ok: false, error: 'Confirmation required' });
+    const interaction = createMockModalInteraction(EXPECTED_PHRASE);
+
+    await handlePurgeModal(interaction);
+
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({ content: expect.stringContaining('Failed to confirm') })
+    );
+    // Only the token-issue call should have run; no execute attempt.
+    expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports failure when execute step fails after token issuance', async () => {
+    mockCallGatewayApi
+      .mockResolvedValueOnce({
+        ok: true,
+        data: {
+          purgeToken: 'purge_test0123456789abc',
+          personalityId: PERSONALITY_ID,
+          personalityName: PERSONALITY_NAME,
+        },
+      })
+      .mockResolvedValueOnce({ ok: false, error: 'Database error' });
     const interaction = createMockModalInteraction(EXPECTED_PHRASE);
 
     await handlePurgeModal(interaction);

--- a/services/bot-client/src/commands/memory/purge.ts
+++ b/services/bot-client/src/commands/memory/purge.ts
@@ -63,6 +63,12 @@ interface PurgeResponse {
   message: string;
 }
 
+interface PurgeTokenResponse {
+  purgeToken: string;
+  personalityId: string;
+  personalityName: string;
+}
+
 /** Build the confirmation phrase the user must type to confirm the purge. */
 function getConfirmationPhrase(personalityName: string): string {
   return `DELETE ${personalityName.toUpperCase()} MEMORIES`;
@@ -269,6 +275,55 @@ export async function handlePurgeButton(interaction: ButtonInteraction): Promise
 }
 
 /**
+ * Two-step purge handshake: exchange the confirmation phrase for a short-
+ * lived purge token, then redeem the token to actually purge. The execute
+ * call sees only the token — `personalityId` lives server-side under the
+ * token key, eliminating phrase-vs-personality drift across the round trip.
+ *
+ * Returns the purge result on success, or null when either step failed
+ * (in which case the user-facing error has already been written via
+ * `interaction.editReply`).
+ */
+async function executePurgeHandshake(
+  user: ReturnType<typeof toGatewayUser>,
+  personalityId: string,
+  enteredPhrase: string,
+  interaction: ModalSubmitInteraction
+): Promise<PurgeResponse | null> {
+  const tokenResult = await callGatewayApi<PurgeTokenResponse>('/user/memory/purge/token', {
+    user,
+    method: 'POST',
+    body: { personalityId, confirmationPhrase: enteredPhrase },
+  });
+
+  if (!tokenResult.ok) {
+    await interaction.editReply({
+      content: `Failed to confirm purge: ${tokenResult.error ?? 'Unknown error'}`,
+      embeds: [],
+      components: [],
+    });
+    return null;
+  }
+
+  const purgeResult = await callGatewayApi<PurgeResponse>('/user/memory/purge', {
+    user,
+    method: 'POST',
+    body: { purgeToken: tokenResult.data.purgeToken },
+  });
+
+  if (!purgeResult.ok) {
+    await interaction.editReply({
+      content: `Failed to purge memories: ${purgeResult.error ?? 'Unknown error'}`,
+      embeds: [],
+      components: [],
+    });
+    return null;
+  }
+
+  return purgeResult.data;
+}
+
+/**
  * Handle the "type the phrase" modal submission for /memory purge.
  * Routed from CommandHandler → memory's handleModal.
  */
@@ -344,22 +399,12 @@ export async function handlePurgeModal(interaction: ModalSubmitInteraction): Pro
   });
 
   const user = toGatewayUser(interaction.user);
-  const purgeResult = await callGatewayApi<PurgeResponse>('/user/memory/purge', {
-    user,
-    method: 'POST',
-    body: { personalityId, confirmationPhrase: enteredPhrase },
-  });
-
-  if (!purgeResult.ok) {
-    await interaction.editReply({
-      content: `Failed to purge memories: ${purgeResult.error ?? 'Unknown error'}`,
-      embeds: [],
-      components: [],
-    });
+  const purgeResult = await executePurgeHandshake(user, personalityId, enteredPhrase, interaction);
+  if (purgeResult === null) {
     return;
   }
 
-  const result = purgeResult.data;
+  const result = purgeResult;
   let successDescription = `Purged **${result.deletedCount}** memories for **${escapeMarkdown(result.personalityName)}**.`;
   if (result.lockedPreserved > 0) {
     successDescription += `\n\n**${result.lockedPreserved}** locked (core) memories were preserved.`;


### PR DESCRIPTION
## Summary

Three structurally-related design corrections shipped together:

1. **RouteDef foundation extensions** — `query` now accepts `ZodObject<T>` (the schema form) in addition to the record form, so reusable shapes like the new `createPaginationSchema(sortFields)` factory can be `.extend()`ed per route without copying entries. Also adds `meta` (safeRead / softDeleteAware / idempotent), `headers` (for `Idempotency-Key` etc.), and branded `PreviewTokenSchema` / `PurgeTokenSchema` types.

2. **Preview-token handshake** for destructive memory ops — eliminates filter drift between batch-delete preview and execute. The preview endpoint stores the filter server-side under a short-lived Redis token; the execute endpoint accepts ONLY the token. New `MemoryActionTokenService` (api-gateway) issues + atomically consumes tokens via `GETDEL`, namespaced by Discord user ID so a leaked token can't be redeemed across users. 5-min TTL.

3. **Lock route → PUT with explicit `{ locked }` body** — was POST toggle-on-current-state. Idempotent on retry now: caller supplies the desired final state, encoded in the customId's extras segment by bot-client (`memory-detail::lock::<id>::1` for lock, `::0` for unlock).

Route shape changes:
- `GET /memory/delete/preview` → `POST /memory/delete/preview` (body filter, returns previewToken + summary)
- `POST /memory/delete` body now `{ previewToken }` (was filter)
- `POST /memory/purge/token` (NEW — validates confirmation phrase, issues purgeToken)
- `POST /memory/purge` body now `{ purgeToken }` (was filter)
- `POST /memory/:id/lock` → `PUT /memory/:id/lock` with `{ locked: boolean }` body

## Tests

- common-types: 37 memory-schema tests + 17 RouteDef foundation tests
- api-gateway: 10 token-service tests + 29 batch-handler tests + 34 single-handler tests (= 73 memory tests passing)
- bot-client: 165 memory tests passing (covers both legs of each handshake plus the new lock-state encoding)
- Full `pnpm test` green
- Full `pnpm quality` green

## Out of scope (filed for follow-up)

Per the user's direction at session end: **manifest declarations for the 13 non-incognito memory routes** (stats, list, focus×2, search, batch delete/preview, purge/token, purge, single CRUD, set-lock). These are the natural next chunk of work on the route-manifest epic — coming in PR-1.5f along with voiceModels / personality-config-overrides / a handful of other undeclared user-route files. The deferral keeps PR-1.5e focused on the design-correctness changes (preview-token + idempotent lock) without bloating it with mechanical schema-and-manifest wiring.

## Test plan

- [ ] `/memory delete <character>` — preview shows correct count, confirm executes (uses previewToken end-to-end)
- [ ] `/memory delete <character> <timeframe>` — timeframe filter binds correctly through the handshake
- [ ] `/memory purge <character>` — modal phrase validates, modal-submit issues token, purge runs with token only
- [ ] Memory detail view → Lock button — locks (button label changes to Unlock)
- [ ] Memory detail view → Unlock button — unlocks (button label changes to Lock)
- [ ] Tapping Lock twice in quick succession (simulating network retry) — stays in the requested state, no flip
- [ ] Redis down → 503 on batch ops (graceful degradation, not crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)