### PR TITLE
feat(bot-client,common-types): pr-2h — migrate memory commands to userClient

### DIFF
--- a/packages/common-types/src/schemas/api/memory.ts
+++ b/packages/common-types/src/schemas/api/memory.ts
@@ -206,7 +206,11 @@ export const BatchDeletePreviewResponseSchema = z.object({
   personalityId: z.string(),
   personalityName: z.string(),
   timeframe: z.string(),
-  previewToken: z.string(),
+  // Brand here so the round-trip preview-token → batchDelete call site is
+  // type-checked end-to-end: the response carries a `PreviewToken`, and
+  // BatchDeleteSchema's input expects the same brand. Plain `z.string()`
+  // would let a caller paste any string into the next call.
+  previewToken: PreviewTokenSchema,
 });
 export type BatchDeletePreviewResponse = z.infer<typeof BatchDeletePreviewResponseSchema>;
 
@@ -222,7 +226,9 @@ export type BatchDeleteResponse = z.infer<typeof BatchDeleteResponseSchema>;
 
 /** POST /user/memory/purge/token */
 export const IssuePurgeTokenResponseSchema = z.object({
-  purgeToken: z.string(),
+  // Branded so the round-trip purge-token → purge call site is type-checked
+  // end-to-end (mirrors the batchDelete/previewToken pair above).
+  purgeToken: PurgeTokenSchema,
   personalityId: z.string(),
   personalityName: z.string(),
 });

--- a/packages/common-types/src/schemas/api/memoryIncognito.test.ts
+++ b/packages/common-types/src/schemas/api/memoryIncognito.test.ts
@@ -20,17 +20,20 @@ const sampleSession = {
 };
 
 describe('IncognitoSessionWithRemainingSchema', () => {
-  it('accepts session enriched with numeric timeRemaining', () => {
-    const data = { ...sampleSession, timeRemaining: 1000 };
+  // `timeRemaining` is a human-formatted string the handler computes via
+  // `IncognitoSessionManager.getTimeRemaining` — emits "1 hour", "30 minutes",
+  // "Until manually disabled", or "Expired".
+  it('accepts session enriched with a human-formatted timeRemaining string', () => {
+    const data = { ...sampleSession, timeRemaining: '1 hour' };
     expect(IncognitoSessionWithRemainingSchema.safeParse(data).success).toBe(true);
   });
 
-  it('accepts null timeRemaining (forever session)', () => {
+  it('accepts the "Until manually disabled" sentinel for forever sessions', () => {
     const data = {
       ...sampleSession,
       duration: 'forever' as const,
       expiresAt: null,
-      timeRemaining: null,
+      timeRemaining: 'Until manually disabled',
     };
     expect(IncognitoSessionWithRemainingSchema.safeParse(data).success).toBe(true);
   });
@@ -48,19 +51,24 @@ describe('Memory Incognito API Contract Tests', () => {
       ).toBe(true);
     });
 
-    it('accepts active state with sessions + timeRemaining', () => {
+    it('accepts active state with sessions + formatted timeRemaining', () => {
       const data = {
         active: true,
-        sessions: [{ ...sampleSession, timeRemaining: 1_800_000 }],
+        sessions: [{ ...sampleSession, timeRemaining: '30 minutes' }],
       };
       expect(GetIncognitoStatusResponseSchema.safeParse(data).success).toBe(true);
     });
 
-    it('accepts null timeRemaining (forever sessions)', () => {
+    it('accepts forever-session sentinel string', () => {
       const data = {
         active: true,
         sessions: [
-          { ...sampleSession, duration: 'forever' as const, expiresAt: null, timeRemaining: null },
+          {
+            ...sampleSession,
+            duration: 'forever' as const,
+            expiresAt: null,
+            timeRemaining: 'Until manually disabled',
+          },
         ],
       };
       expect(GetIncognitoStatusResponseSchema.safeParse(data).success).toBe(true);
@@ -71,7 +79,7 @@ describe('Memory Incognito API Contract Tests', () => {
     it('accepts newly-enabled response', () => {
       const data = {
         session: sampleSession,
-        timeRemaining: 3_600_000,
+        timeRemaining: '1 hour',
         wasAlreadyActive: false,
         message: 'Incognito mode enabled.',
       };
@@ -81,7 +89,7 @@ describe('Memory Incognito API Contract Tests', () => {
     it('accepts already-active response', () => {
       const data = {
         session: sampleSession,
-        timeRemaining: 1_800_000,
+        timeRemaining: '30 minutes',
         wasAlreadyActive: true,
         message: 'Already active.',
       };

--- a/packages/common-types/src/schemas/api/memoryIncognito.ts
+++ b/packages/common-types/src/schemas/api/memoryIncognito.ts
@@ -14,10 +14,14 @@
 import { z } from 'zod';
 import { IncognitoSessionSchema } from '../../types/incognito.js';
 
-/** A session enriched with `timeRemaining` (ms) computed at response time. */
+/**
+ * A session enriched with `timeRemaining` (human-formatted string) computed
+ * at response time. The handler emits one of: "<n> minutes/hours/days/...",
+ * "Until manually disabled" (for `duration: 'forever'`), or "Expired"
+ * (when the session is past expiry but hasn't been swept yet).
+ */
 export const IncognitoSessionWithRemainingSchema = IncognitoSessionSchema.extend({
-  /** Milliseconds until expiry; null if `duration: 'forever'`. */
-  timeRemaining: z.number().nullable(),
+  timeRemaining: z.string().min(1),
 });
 export type IncognitoSessionWithRemaining = z.infer<typeof IncognitoSessionWithRemainingSchema>;
 
@@ -38,7 +42,12 @@ export type GetIncognitoStatusResponse = z.infer<typeof GetIncognitoStatusRespon
 
 export const EnableIncognitoResponseSchema = z.object({
   session: IncognitoSessionSchema,
-  timeRemaining: z.number().nullable(),
+  /**
+   * Human-formatted string computed by `IncognitoSessionManager.getTimeRemaining`;
+   * never a raw millisecond count. One of "<n> minutes/hours/days/...",
+   * "Until manually disabled" (for `duration: 'forever'`), or "Expired".
+   */
+  timeRemaining: z.string().min(1),
   wasAlreadyActive: z.boolean(),
   message: z.string(),
 });

--- a/services/bot-client/src/commands/memory/batchDelete.test.ts
+++ b/services/bot-client/src/commands/memory/batchDelete.test.ts
@@ -11,8 +11,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { handleBatchDelete } from './batchDelete.js';
 import type { ButtonInteraction } from 'discord.js';
+import { makeOk, makeErr, asUserClient } from '../../test/gatewayClientStubs.js';
 
-// Mock common-types
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal<typeof import('@tzurot/common-types')>();
   return {
@@ -26,19 +26,11 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
-// Mock userGatewayClient
-const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
-    '../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  };
-});
+const clientsForMock = vi.hoisted(() => vi.fn());
+vi.mock('../../utils/gatewayClients.js', () => ({
+  clientsFor: clientsForMock,
+}));
 
-// Mock commandHelpers
 const mockReplyWithError = vi.fn();
 const mockHandleCommandError = vi.fn();
 vi.mock('../../utils/commandHelpers.js', () => ({
@@ -52,18 +44,32 @@ vi.mock('../../utils/commandHelpers.js', () => ({
   })),
 }));
 
-// Mock autocomplete
 const mockResolvePersonalityId = vi.fn();
 vi.mock('./autocomplete.js', () => ({
   resolvePersonalityId: (...args: unknown[]) => mockResolvePersonalityId(...args),
 }));
 
+interface MemoryClientStub {
+  batchDeletePreview: ReturnType<typeof vi.fn>;
+  batchDelete: ReturnType<typeof vi.fn>;
+}
+
+function createStub(): MemoryClientStub {
+  return {
+    batchDeletePreview: vi.fn(),
+    batchDelete: vi.fn(),
+  };
+}
+
 describe('handleBatchDelete', () => {
   const mockEditReply = vi.fn();
   const mockAwaitMessageComponent = vi.fn();
+  let stub: MemoryClientStub;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    stub = createStub();
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
     // Default: editReply returns message with awaitMessageComponent
     mockEditReply.mockResolvedValue({
       awaitMessageComponent: mockAwaitMessageComponent,
@@ -74,6 +80,7 @@ describe('handleBatchDelete', () => {
     return {
       user: { id: 'user-123', username: 'testuser', globalName: 'testuser' },
       interaction: {
+        user: { id: 'user-123', username: 'testuser' },
         options: {
           getString: (name: string, _required?: boolean) => {
             if (name === 'character') return personality;
@@ -114,16 +121,16 @@ describe('handleBatchDelete', () => {
 
     it('should resolve personality slug to ID', async () => {
       mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: {
+      stub.batchDeletePreview.mockResolvedValue(
+        makeOk({
           wouldDelete: 0,
           lockedWouldSkip: 0,
           personalityId: 'personality-uuid-123',
           personalityName: 'Lilith',
           timeframe: 'all',
-        },
-      });
+          previewToken: 'preview_test0000test0001',
+        })
+      );
 
       const context = createMockContext('lilith');
       await handleBatchDelete(context);
@@ -132,12 +139,8 @@ describe('handleBatchDelete', () => {
         { discordId: 'user-123', username: 'testuser', displayName: 'testuser' },
         'lilith'
       );
-      expect(mockCallGatewayApi).toHaveBeenCalledWith(
-        '/user/memory/delete/preview',
-        expect.objectContaining({
-          method: 'POST',
-          body: expect.objectContaining({ personalityId: 'personality-uuid-123' }),
-        })
+      expect(stub.batchDeletePreview).toHaveBeenCalledWith(
+        expect.objectContaining({ personalityId: 'personality-uuid-123' })
       );
     });
   });
@@ -148,11 +151,7 @@ describe('handleBatchDelete', () => {
     });
 
     it('should show error when preview API fails', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: false,
-        status: 500,
-        error: 'Server error',
-      });
+      stub.batchDeletePreview.mockResolvedValue(makeErr(500, 'Server error'));
 
       const context = createMockContext();
       await handleBatchDelete(context);
@@ -163,11 +162,7 @@ describe('handleBatchDelete', () => {
     });
 
     it('should show 404 message when personality not found in API', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: false,
-        status: 404,
-        error: 'Not found',
-      });
+      stub.batchDeletePreview.mockResolvedValue(makeErr(404, 'Not found'));
 
       const context = createMockContext();
       await handleBatchDelete(context);
@@ -178,16 +173,16 @@ describe('handleBatchDelete', () => {
     });
 
     it('should show "no memories" message when nothing to delete', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: {
+      stub.batchDeletePreview.mockResolvedValue(
+        makeOk({
           wouldDelete: 0,
           lockedWouldSkip: 0,
           personalityId: 'personality-uuid-123',
           personalityName: 'Lilith',
           timeframe: 'all',
-        },
-      });
+          previewToken: 'preview_test0000test0001',
+        })
+      );
 
       const context = createMockContext();
       await handleBatchDelete(context);
@@ -198,26 +193,22 @@ describe('handleBatchDelete', () => {
     });
 
     it('should include timeframe in preview request when provided', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: {
+      stub.batchDeletePreview.mockResolvedValue(
+        makeOk({
           wouldDelete: 0,
           lockedWouldSkip: 0,
           personalityId: 'personality-uuid-123',
           personalityName: 'Lilith',
           timeframe: '7d',
-        },
-      });
+          previewToken: 'preview_test0000test0002',
+        })
+      );
 
       const context = createMockContext('lilith', '7d');
       await handleBatchDelete(context);
 
-      expect(mockCallGatewayApi).toHaveBeenCalledWith(
-        '/user/memory/delete/preview',
-        expect.objectContaining({
-          method: 'POST',
-          body: expect.objectContaining({ timeframe: '7d' }),
-        })
+      expect(stub.batchDeletePreview).toHaveBeenCalledWith(
+        expect.objectContaining({ timeframe: '7d' })
       );
     });
   });
@@ -225,17 +216,16 @@ describe('handleBatchDelete', () => {
   describe('confirmation dialog', () => {
     beforeEach(() => {
       mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: {
+      stub.batchDeletePreview.mockResolvedValue(
+        makeOk({
           wouldDelete: 5,
           lockedWouldSkip: 1,
           personalityId: 'personality-uuid-123',
           personalityName: 'Lilith',
           timeframe: 'all',
           previewToken: 'preview_test0000test0001',
-        },
-      });
+        })
+      );
     });
 
     it('should show confirmation embed with memory count', async () => {
@@ -286,30 +276,25 @@ describe('handleBatchDelete', () => {
     });
 
     it('should perform deletion using the previewToken when user confirms', async () => {
-      // Preview response — now carries the token bound to the filter
-      mockCallGatewayApi
-        .mockResolvedValueOnce({
-          ok: true,
-          data: {
-            wouldDelete: 5,
-            lockedWouldSkip: 1,
-            personalityId: 'personality-uuid-123',
-            personalityName: 'Lilith',
-            timeframe: 'all',
-            previewToken: 'preview_test0000test0001',
-          },
+      stub.batchDeletePreview.mockResolvedValue(
+        makeOk({
+          wouldDelete: 5,
+          lockedWouldSkip: 1,
+          personalityId: 'personality-uuid-123',
+          personalityName: 'Lilith',
+          timeframe: 'all',
+          previewToken: 'preview_test0000test0001',
         })
-        // Delete response
-        .mockResolvedValueOnce({
-          ok: true,
-          data: {
-            deletedCount: 5,
-            skippedLocked: 1,
-            personalityId: 'personality-uuid-123',
-            personalityName: 'Lilith',
-            message: 'Deleted 5 memories. 1 locked memories were skipped.',
-          },
-        });
+      );
+      stub.batchDelete.mockResolvedValue(
+        makeOk({
+          deletedCount: 5,
+          skippedLocked: 1,
+          personalityId: 'personality-uuid-123',
+          personalityName: 'Lilith',
+          message: 'Deleted 5 memories. 1 locked memories were skipped.',
+        })
+      );
 
       const buttonInteraction = createMockButtonInteraction('memory-batch-delete::confirm');
       mockAwaitMessageComponent.mockResolvedValue(buttonInteraction);
@@ -319,13 +304,7 @@ describe('handleBatchDelete', () => {
 
       // Delete API is invoked with ONLY the previewToken — the filter
       // never crosses the wire on the execute path.
-      expect(mockCallGatewayApi).toHaveBeenCalledWith(
-        '/user/memory/delete',
-        expect.objectContaining({
-          method: 'POST',
-          body: { previewToken: 'preview_test0000test0001' },
-        })
-      );
+      expect(stub.batchDelete).toHaveBeenCalledWith({ previewToken: 'preview_test0000test0001' });
 
       expect(buttonInteraction.editReply).toHaveBeenCalledWith({
         embeds: expect.any(Array),
@@ -334,28 +313,25 @@ describe('handleBatchDelete', () => {
     });
 
     it('should include timeframe only in the preview body — execute uses the token', async () => {
-      mockCallGatewayApi
-        .mockResolvedValueOnce({
-          ok: true,
-          data: {
-            wouldDelete: 3,
-            lockedWouldSkip: 0,
-            personalityId: 'personality-uuid-123',
-            personalityName: 'Lilith',
-            timeframe: '7d',
-            previewToken: 'preview_test0000test0002',
-          },
+      stub.batchDeletePreview.mockResolvedValue(
+        makeOk({
+          wouldDelete: 3,
+          lockedWouldSkip: 0,
+          personalityId: 'personality-uuid-123',
+          personalityName: 'Lilith',
+          timeframe: '7d',
+          previewToken: 'preview_test0000test0002',
         })
-        .mockResolvedValueOnce({
-          ok: true,
-          data: {
-            deletedCount: 3,
-            skippedLocked: 0,
-            personalityId: 'personality-uuid-123',
-            personalityName: 'Lilith',
-            message: 'Deleted 3 memories.',
-          },
-        });
+      );
+      stub.batchDelete.mockResolvedValue(
+        makeOk({
+          deletedCount: 3,
+          skippedLocked: 0,
+          personalityId: 'personality-uuid-123',
+          personalityName: 'Lilith',
+          message: 'Deleted 3 memories.',
+        })
+      );
 
       const buttonInteraction = createMockButtonInteraction('memory-batch-delete::confirm');
       mockAwaitMessageComponent.mockResolvedValue(buttonInteraction);
@@ -364,42 +340,25 @@ describe('handleBatchDelete', () => {
       await handleBatchDelete(context);
 
       // Preview includes timeframe …
-      expect(mockCallGatewayApi).toHaveBeenNthCalledWith(
-        1,
-        '/user/memory/delete/preview',
-        expect.objectContaining({
-          method: 'POST',
-          body: expect.objectContaining({ timeframe: '7d' }),
-        })
+      expect(stub.batchDeletePreview).toHaveBeenCalledWith(
+        expect.objectContaining({ timeframe: '7d' })
       );
       // … execute is token-only.
-      expect(mockCallGatewayApi).toHaveBeenNthCalledWith(
-        2,
-        '/user/memory/delete',
-        expect.objectContaining({
-          method: 'POST',
-          body: { previewToken: 'preview_test0000test0002' },
-        })
-      );
+      expect(stub.batchDelete).toHaveBeenCalledWith({ previewToken: 'preview_test0000test0002' });
     });
 
     it('should show error when delete API fails', async () => {
-      mockCallGatewayApi
-        .mockResolvedValueOnce({
-          ok: true,
-          data: {
-            wouldDelete: 5,
-            lockedWouldSkip: 0,
-            personalityId: 'personality-uuid-123',
-            personalityName: 'Lilith',
-            timeframe: 'all',
-            previewToken: 'preview_test0000test0001',
-          },
+      stub.batchDeletePreview.mockResolvedValue(
+        makeOk({
+          wouldDelete: 5,
+          lockedWouldSkip: 0,
+          personalityId: 'personality-uuid-123',
+          personalityName: 'Lilith',
+          timeframe: 'all',
+          previewToken: 'preview_test0000test0001',
         })
-        .mockResolvedValueOnce({
-          ok: false,
-          error: 'Database error',
-        });
+      );
+      stub.batchDelete.mockResolvedValue(makeErr(500, 'Database error'));
 
       const buttonInteraction = createMockButtonInteraction('memory-batch-delete::confirm');
       mockAwaitMessageComponent.mockResolvedValue(buttonInteraction);
@@ -415,28 +374,25 @@ describe('handleBatchDelete', () => {
     });
 
     it('should defer update before making API call', async () => {
-      mockCallGatewayApi
-        .mockResolvedValueOnce({
-          ok: true,
-          data: {
-            wouldDelete: 2,
-            lockedWouldSkip: 0,
-            personalityId: 'personality-uuid-123',
-            personalityName: 'Lilith',
-            timeframe: 'all',
-            previewToken: 'preview_test0000test0001',
-          },
+      stub.batchDeletePreview.mockResolvedValue(
+        makeOk({
+          wouldDelete: 2,
+          lockedWouldSkip: 0,
+          personalityId: 'personality-uuid-123',
+          personalityName: 'Lilith',
+          timeframe: 'all',
+          previewToken: 'preview_test0000test0001',
         })
-        .mockResolvedValueOnce({
-          ok: true,
-          data: {
-            deletedCount: 2,
-            skippedLocked: 0,
-            personalityId: 'personality-uuid-123',
-            personalityName: 'Lilith',
-            message: 'Deleted 2 memories.',
-          },
-        });
+      );
+      stub.batchDelete.mockResolvedValue(
+        makeOk({
+          deletedCount: 2,
+          skippedLocked: 0,
+          personalityId: 'personality-uuid-123',
+          personalityName: 'Lilith',
+          message: 'Deleted 2 memories.',
+        })
+      );
 
       const buttonInteraction = createMockButtonInteraction('memory-batch-delete::confirm');
       mockAwaitMessageComponent.mockResolvedValue(buttonInteraction);
@@ -466,7 +422,7 @@ describe('handleBatchDelete', () => {
       await handleBatchDelete(context);
 
       expect(mockResolvePersonalityId).not.toHaveBeenCalled();
-      expect(mockCallGatewayApi).not.toHaveBeenCalled();
+      expect(stub.batchDeletePreview).not.toHaveBeenCalled();
       expect(mockEditReply).toHaveBeenCalledWith({
         content: expect.stringContaining('Autocomplete was unavailable'),
       });

--- a/services/bot-client/src/commands/memory/batchDelete.ts
+++ b/services/bot-client/src/commands/memory/batchDelete.ts
@@ -23,7 +23,8 @@ import {
   AUTOCOMPLETE_UNAVAILABLE_MESSAGE,
   isAutocompleteErrorSentinel,
 } from '../../utils/apiCheck.js';
-import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
+import { toGatewayUser } from '../../utils/userGatewayClient.js';
+import { clientsFor } from '../../utils/gatewayClients.js';
 import { createWarningEmbed, createSuccessEmbed } from '../../utils/commandHelpers.js';
 import { resolvePersonalityId } from './autocomplete.js';
 
@@ -31,24 +32,6 @@ const logger = createLogger('memory-batch-delete');
 
 /** Timeout for confirmation buttons (60 seconds) */
 const CONFIRMATION_TIMEOUT = 60_000;
-
-interface PreviewResponse {
-  wouldDelete: number;
-  lockedWouldSkip: number;
-  personalityId: string;
-  personalityName: string;
-  timeframe: string;
-  /** Short-lived token bound to the filter that produced this preview. */
-  previewToken: string;
-}
-
-interface DeleteResponse {
-  deletedCount: number;
-  skippedLocked: number;
-  personalityId: string;
-  personalityName: string;
-  message: string;
-}
 
 /** Format timeframe for display using shared Duration class */
 function formatTimeframe(timeframe: string | null): string {
@@ -76,6 +59,7 @@ function formatTimeframe(timeframe: string | null): string {
 export async function handleBatchDelete(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
   const user = toGatewayUser(context.user);
+  const { userClient } = clientsFor(context.interaction);
   const options = memoryDeleteOptions(context.interaction);
   const personalityInput = options.character();
   const timeframe = options.timeframe();
@@ -100,13 +84,9 @@ export async function handleBatchDelete(context: DeferredCommandContext): Promis
     // execute call below sends ONLY the token — server-side reads the
     // filter back from Redis under the token key, so the execute path
     // is guaranteed to match what the user previewed.
-    const previewResult = await callGatewayApi<PreviewResponse>(`/user/memory/delete/preview`, {
-      user,
-      method: 'POST',
-      body: {
-        personalityId,
-        ...(timeframe !== null ? { timeframe } : {}),
-      },
+    const previewResult = await userClient.batchDeletePreview({
+      personalityId,
+      ...(timeframe !== null && { timeframe }),
     });
 
     if (!previewResult.ok) {
@@ -191,11 +171,7 @@ export async function handleBatchDelete(context: DeferredCommandContext): Promis
       // User confirmed - perform deletion
       await buttonInteraction.deferUpdate();
 
-      const deleteResult = await callGatewayApi<DeleteResponse>('/user/memory/delete', {
-        user,
-        method: 'POST',
-        body: { previewToken: preview.previewToken },
-      });
+      const deleteResult = await userClient.batchDelete({ previewToken: preview.previewToken });
 
       if (!deleteResult.ok) {
         await buttonInteraction.editReply({
@@ -208,8 +184,13 @@ export async function handleBatchDelete(context: DeferredCommandContext): Promis
 
       const result = deleteResult.data;
 
-      // Show success
-      let successDescription = `Deleted **${result.deletedCount}** memories for **${escapeMarkdown(result.personalityName)}**`;
+      // Show success. `personalityName` is schema-optional because the gateway
+      // returns the 0-result shape without it when nothing matched; in this
+      // branch the preview already confirmed >0 deletions, so the fallback is
+      // a defense-in-depth guard against the rare preview-to-execute race
+      // (memories deleted by another session between preview and execute).
+      const displayName = result.personalityName ?? preview.personalityName;
+      let successDescription = `Deleted **${result.deletedCount}** memories for **${escapeMarkdown(displayName)}**`;
 
       if (timeframe !== null) {
         successDescription += ` from the last **${timeframeDisplay}**`;

--- a/services/bot-client/src/commands/memory/browse.test.ts
+++ b/services/bot-client/src/commands/memory/browse.test.ts
@@ -11,9 +11,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { makeOk, makeErr, asUserClient } from '../../test/gatewayClientStubs.js';
 
 const {
-  mockCallGatewayApi,
+  clientsForMock,
   mockResolveOptionalPersonality,
   mockHandleMemorySelect,
   mockHandleMemoryDetailAction,
@@ -21,7 +22,7 @@ const {
   mockFindMemoryListSessionByMessage,
   mockUpdateMemoryListSessionPage,
 } = vi.hoisted(() => ({
-  mockCallGatewayApi: vi.fn(),
+  clientsForMock: vi.fn(),
   mockResolveOptionalPersonality: vi.fn(),
   mockHandleMemorySelect: vi.fn(),
   mockHandleMemoryDetailAction: vi.fn(),
@@ -42,15 +43,9 @@ vi.mock('@tzurot/common-types', async () => {
   };
 });
 
-vi.mock('../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
-    '../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  };
-});
+vi.mock('../../utils/gatewayClients.js', () => ({
+  clientsFor: clientsForMock,
+}));
 
 vi.mock('./resolveHelpers.js', () => ({
   resolveOptionalPersonality: (...args: unknown[]) => mockResolveOptionalPersonality(...args),
@@ -105,6 +100,7 @@ const TEST_PERSONALITY_ID = '00000000-0000-0000-0000-000000000001';
 const sampleMemory = {
   id: 'mem-1',
   content: 'Test memory content',
+  personalityId: TEST_PERSONALITY_ID,
   personalityName: 'Test Personality',
   isLocked: false,
   createdAt: '2026-01-01T00:00:00Z',
@@ -119,16 +115,29 @@ const sampleResponse = {
   hasMore: false,
 };
 
+interface MemoryClientStub {
+  list: ReturnType<typeof vi.fn>;
+}
+
+function createStub(): MemoryClientStub {
+  return { list: vi.fn() };
+}
+
+let stub: MemoryClientStub;
+
 interface MockDeferredContext {
-  interaction: { options: { getString: ReturnType<typeof vi.fn> } };
-  user: { id: string };
+  interaction: {
+    user: { id: string; username: string };
+    options: { getString: ReturnType<typeof vi.fn> };
+  };
+  user: { id: string; username: string };
   editReply: ReturnType<typeof vi.fn>;
 }
 
 interface MockButtonInteraction {
   customId: string;
   message: { id: string };
-  user: { id: string };
+  user: { id: string; username: string };
   deferUpdate: ReturnType<typeof vi.fn>;
   editReply: ReturnType<typeof vi.fn>;
   followUp: ReturnType<typeof vi.fn>;
@@ -147,11 +156,12 @@ interface MockSelectInteraction {
 function createDeferredContext(): MockDeferredContext {
   return {
     interaction: {
+      user: { id: TEST_USER_ID, username: 'testuser' },
       options: {
         getString: vi.fn((name: string) => (name === 'character' ? null : null)),
       },
     },
-    user: { id: TEST_USER_ID },
+    user: { id: TEST_USER_ID, username: 'testuser' },
     editReply: vi.fn().mockResolvedValue({ id: TEST_MESSAGE_ID, channelId: TEST_CHANNEL_ID }),
   };
 }
@@ -160,7 +170,7 @@ function createButtonInteraction(customId: string): MockButtonInteraction {
   return {
     customId,
     message: { id: TEST_MESSAGE_ID },
-    user: { id: TEST_USER_ID },
+    user: { id: TEST_USER_ID, username: 'testuser' },
     deferUpdate: vi.fn().mockResolvedValue(undefined),
     editReply: vi.fn().mockResolvedValue({ id: TEST_MESSAGE_ID }),
     followUp: vi.fn().mockResolvedValue(undefined),
@@ -182,8 +192,10 @@ function createSelectInteraction(customId: string): MockSelectInteraction {
 describe('handleBrowse', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    stub = createStub();
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
     mockResolveOptionalPersonality.mockResolvedValue(TEST_PERSONALITY_ID);
-    mockCallGatewayApi.mockResolvedValue({ ok: true, data: sampleResponse });
+    stub.list.mockResolvedValue(makeOk(sampleResponse));
   });
 
   it('fetches memories and saves a browse session', async () => {
@@ -191,11 +203,13 @@ describe('handleBrowse', () => {
 
     await handleBrowse(context as unknown as DeferredCommandContext);
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith(
-      expect.stringContaining('/user/memory/list'),
+    expect(stub.list).toHaveBeenCalledWith(
       expect.objectContaining({
-        method: 'GET',
-        user: expect.objectContaining({ discordId: TEST_USER_ID }),
+        limit: '10',
+        offset: '0',
+        sort: 'createdAt',
+        order: 'desc',
+        personalityId: TEST_PERSONALITY_ID,
       })
     );
     expect(context.editReply).toHaveBeenCalledWith(
@@ -222,14 +236,14 @@ describe('handleBrowse', () => {
 
     await handleBrowse(context as unknown as DeferredCommandContext);
 
-    expect(mockCallGatewayApi).not.toHaveBeenCalled();
+    expect(stub.list).not.toHaveBeenCalled();
     expect(mockSaveMemoryListSession).not.toHaveBeenCalled();
     // handleBrowse should NOT double-reply — the helper already did
     expect(context.editReply).not.toHaveBeenCalled();
   });
 
   it('shows error when API call fails', async () => {
-    mockCallGatewayApi.mockResolvedValue({ ok: false, error: 'Server error' });
+    stub.list.mockResolvedValue(makeErr(500, 'Server error'));
     const context = createDeferredContext();
 
     await handleBrowse(context as unknown as DeferredCommandContext);
@@ -241,7 +255,7 @@ describe('handleBrowse', () => {
   });
 
   it('handles unexpected errors gracefully', async () => {
-    mockCallGatewayApi.mockRejectedValue(new Error('network'));
+    stub.list.mockRejectedValue(new Error('network'));
     const context = createDeferredContext();
 
     await handleBrowse(context as unknown as DeferredCommandContext);
@@ -255,6 +269,8 @@ describe('handleBrowse', () => {
 describe('handleBrowsePagination', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    stub = createStub();
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
   });
 
   it('fetches new page and updates message when session exists', async () => {
@@ -262,10 +278,9 @@ describe('handleBrowsePagination', () => {
       data: { kind: 'browse', personalityId: TEST_PERSONALITY_ID, currentPage: 0 },
     });
     // Need a large enough total for page 1 to be valid (itemsPerPage=10)
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: { memories: [sampleMemory], total: 25, limit: 10, offset: 10, hasMore: true },
-    });
+    stub.list.mockResolvedValue(
+      makeOk({ memories: [sampleMemory], total: 25, limit: 10, offset: 10, hasMore: true })
+    );
 
     const customId = browseHelpers.build(1, 'all', 'date', null);
     const interaction = createButtonInteraction(customId);
@@ -273,10 +288,7 @@ describe('handleBrowsePagination', () => {
     await handleBrowsePagination(interaction as unknown as ButtonInteraction);
 
     expect(interaction.deferUpdate).toHaveBeenCalled();
-    expect(mockCallGatewayApi).toHaveBeenCalledWith(
-      expect.stringContaining('offset=10'),
-      expect.any(Object)
-    );
+    expect(stub.list).toHaveBeenCalledWith(expect.objectContaining({ offset: '10' }));
     expect(interaction.editReply).toHaveBeenCalled();
     expect(mockUpdateMemoryListSessionPage).toHaveBeenCalledWith(
       expect.objectContaining({ newPage: 1, kind: 'browse' })
@@ -296,7 +308,7 @@ describe('handleBrowsePagination', () => {
     expect(interaction.followUp).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('expired') })
     );
-    expect(mockCallGatewayApi).not.toHaveBeenCalled();
+    expect(stub.list).not.toHaveBeenCalled();
   });
 
   it('ignores interactions with non-browse custom IDs', async () => {
@@ -305,7 +317,7 @@ describe('handleBrowsePagination', () => {
     await handleBrowsePagination(interaction as unknown as ButtonInteraction);
 
     expect(mockFindMemoryListSessionByMessage).not.toHaveBeenCalled();
-    expect(mockCallGatewayApi).not.toHaveBeenCalled();
+    expect(stub.list).not.toHaveBeenCalled();
   });
 
   it('does not update session when session kind is search', async () => {
@@ -350,22 +362,21 @@ describe('handleBrowseSelect', () => {
 describe('refreshBrowseList', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    stub = createStub();
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
   });
 
   it('re-fetches and updates message on refresh', async () => {
     mockFindMemoryListSessionByMessage.mockResolvedValue({
       data: { kind: 'browse', personalityId: TEST_PERSONALITY_ID, currentPage: 1 },
     });
-    mockCallGatewayApi.mockResolvedValue({ ok: true, data: sampleResponse });
+    stub.list.mockResolvedValue(makeOk(sampleResponse));
 
     const interaction = createButtonInteraction('memory-detail::back');
 
     await refreshBrowseList(interaction as unknown as ButtonInteraction);
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith(
-      expect.stringContaining('offset=10'),
-      expect.any(Object)
-    );
+    expect(stub.list).toHaveBeenCalledWith(expect.objectContaining({ offset: '10' }));
     expect(interaction.editReply).toHaveBeenCalled();
   });
 
@@ -373,18 +384,17 @@ describe('refreshBrowseList', () => {
     mockFindMemoryListSessionByMessage.mockResolvedValue({
       data: { kind: 'browse', personalityId: TEST_PERSONALITY_ID, currentPage: 2 },
     });
-    mockCallGatewayApi
-      .mockResolvedValueOnce({
-        ok: true,
-        data: { memories: [], total: 0, limit: 10, offset: 20, hasMore: false },
-      })
-      .mockResolvedValueOnce({ ok: true, data: sampleResponse });
+    stub.list
+      .mockResolvedValueOnce(
+        makeOk({ memories: [], total: 0, limit: 10, offset: 20, hasMore: false })
+      )
+      .mockResolvedValueOnce(makeOk(sampleResponse));
 
     const interaction = createButtonInteraction('memory-detail::back');
 
     await refreshBrowseList(interaction as unknown as ButtonInteraction);
 
-    expect(mockCallGatewayApi).toHaveBeenCalledTimes(2);
+    expect(stub.list).toHaveBeenCalledTimes(2);
     expect(mockUpdateMemoryListSessionPage).toHaveBeenCalledWith(
       expect.objectContaining({ newPage: 1 })
     );
@@ -396,7 +406,7 @@ describe('refreshBrowseList', () => {
 
     await refreshBrowseList(interaction as unknown as ButtonInteraction);
 
-    expect(mockCallGatewayApi).not.toHaveBeenCalled();
+    expect(stub.list).not.toHaveBeenCalled();
     expect(interaction.editReply).not.toHaveBeenCalled();
   });
 
@@ -408,7 +418,7 @@ describe('refreshBrowseList', () => {
 
     await refreshBrowseList(interaction as unknown as ButtonInteraction);
 
-    expect(mockCallGatewayApi).not.toHaveBeenCalled();
+    expect(stub.list).not.toHaveBeenCalled();
   });
 });
 

--- a/services/bot-client/src/commands/memory/browse.ts
+++ b/services/bot-client/src/commands/memory/browse.ts
@@ -22,9 +22,13 @@ import {
   DISCORD_COLORS,
   memoryBrowseOptions,
   formatDateShort,
+  type MemoryItem,
+  type MemoryListResponse,
+  type UserClient,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi, toGatewayUser, type GatewayUser } from '../../utils/userGatewayClient.js';
+import { toGatewayUser } from '../../utils/userGatewayClient.js';
+import { clientsFor } from '../../utils/gatewayClients.js';
 import {
   createBrowseCustomIdHelpers,
   buildBrowseButtons as buildSharedBrowseButtons,
@@ -39,7 +43,6 @@ import {
 import { resolveOptionalPersonality } from './resolveHelpers.js';
 import { buildMemoryActionId, handleMemorySelect } from './detail.js';
 import { handleMemoryDetailAction } from './detailActionRouter.js';
-import type { MemoryItem } from './detailApi.js';
 import { truncateContent } from './formatters.js';
 import {
   saveMemoryListSession,
@@ -79,13 +82,8 @@ export function isMemoryBrowsePagination(customId: string): boolean {
   return browseHelpers.isBrowse(customId);
 }
 
-interface BrowseResponse {
-  memories: MemoryItem[];
-  total: number;
-  limit: number;
-  offset: number;
-  hasMore: boolean;
-}
+/** Schema-derived response type; mirrors `MemoryListResponseSchema`. */
+type BrowseResponse = MemoryListResponse;
 
 interface BuildBrowseViewOptions {
   memories: MemoryItem[];
@@ -184,28 +182,18 @@ function buildBrowseComponents(
  * Fetch memories from API
  */
 async function fetchMemories(
-  user: GatewayUser,
+  userClient: UserClient,
   personalityId: string | undefined,
   offset: number,
   limit: number
 ): Promise<BrowseResponse | null> {
-  const queryParams = new URLSearchParams();
-  queryParams.set('limit', limit.toString());
-  queryParams.set('offset', offset.toString());
-  queryParams.set('sort', 'createdAt');
-  queryParams.set('order', 'desc');
-
-  if (personalityId !== undefined) {
-    queryParams.set('personalityId', personalityId);
-  }
-
-  const result = await callGatewayApi<BrowseResponse>(
-    `/user/memory/list?${queryParams.toString()}`,
-    {
-      user,
-      method: 'GET',
-    }
-  );
+  const result = await userClient.list({
+    limit: limit.toString(),
+    offset: offset.toString(),
+    sort: 'createdAt',
+    order: 'desc',
+    ...(personalityId !== undefined && { personalityId }),
+  });
 
   if (!result.ok) {
     return null;
@@ -220,6 +208,7 @@ async function fetchMemories(
 export async function handleBrowse(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
   const user = toGatewayUser(context.user);
+  const { userClient } = clientsFor(context.interaction);
   const options = memoryBrowseOptions(context.interaction);
   const personalityInput = options.character();
 
@@ -233,7 +222,7 @@ export async function handleBrowse(context: DeferredCommandContext): Promise<voi
     }
 
     // Fetch first page
-    const data = await fetchMemories(user, personalityId, 0, MEMORIES_PER_PAGE);
+    const data = await fetchMemories(userClient, personalityId, 0, MEMORIES_PER_PAGE);
 
     if (data === null) {
       logger.warn({ userId }, 'Browse failed');
@@ -318,9 +307,10 @@ export async function handleBrowsePagination(interaction: ButtonInteraction): Pr
   const userId = interaction.user.id;
   const { personalityId } = session.data;
   const newPage = parsed.page;
+  const { userClient } = clientsFor(interaction);
 
   const data = await fetchMemories(
-    toGatewayUser(interaction.user),
+    userClient,
     personalityId,
     newPage * MEMORIES_PER_PAGE,
     MEMORIES_PER_PAGE
@@ -384,13 +374,13 @@ export async function refreshBrowseList(interaction: ButtonInteraction): Promise
   }
 
   const userId = interaction.user.id;
-  const user = toGatewayUser(interaction.user);
+  const { userClient } = clientsFor(interaction);
   const { personalityId } = session.data;
 
   const result = await fetchPageWithEmptyFallback({
     currentPage: session.data.currentPage,
     fetchPage: page =>
-      fetchMemories(user, personalityId, page * MEMORIES_PER_PAGE, MEMORIES_PER_PAGE),
+      fetchMemories(userClient, personalityId, page * MEMORIES_PER_PAGE, MEMORIES_PER_PAGE),
     isEmpty: d => d.memories.length === 0,
   });
   if (result === null) {

--- a/services/bot-client/src/commands/memory/detail.test.ts
+++ b/services/bot-client/src/commands/memory/detail.test.ts
@@ -15,12 +15,12 @@ import {
   handleDeleteConfirm,
   handleViewFullButton,
   MEMORY_DETAIL_PREFIX,
-  type MemoryItem,
 } from './detail.js';
+import type { MemoryItem } from '@tzurot/common-types';
 import { CUSTOM_ID_DELIMITER } from '../../utils/customIds.js';
 import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
+import { makeOk, makeErr, asUserClient } from '../../test/gatewayClientStubs.js';
 
-// Mock common-types
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal<typeof import('@tzurot/common-types')>();
   return {
@@ -39,26 +39,36 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
-// Mock userGatewayClient
-const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
-    '../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  };
-});
+const clientsForMock = vi.hoisted(() => vi.fn());
+vi.mock('../../utils/gatewayClients.js', () => ({
+  clientsFor: clientsForMock,
+}));
 
-// Mock customIds
 vi.mock('../../utils/customIds.js', () => ({
   CUSTOM_ID_DELIMITER: '::',
 }));
 
+interface MemoryClientStub {
+  getMemory: ReturnType<typeof vi.fn>;
+  setMemoryLock: ReturnType<typeof vi.fn>;
+  deleteMemory: ReturnType<typeof vi.fn>;
+}
+
+function createStub(): MemoryClientStub {
+  return {
+    getMemory: vi.fn(),
+    setMemoryLock: vi.fn(),
+    deleteMemory: vi.fn(),
+  };
+}
+
 describe('Memory Detail', () => {
+  let stub: MemoryClientStub;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    stub = createStub();
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
   });
 
   const createMockMemory = (overrides: Partial<MemoryItem> = {}): MemoryItem => ({
@@ -240,17 +250,14 @@ describe('Memory Detail', () => {
   describe('handleMemorySelect', () => {
     it('should show detail view on select', async () => {
       const memory = createMockMemory();
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { memory },
-      });
+      stub.getMemory.mockResolvedValue(makeOk({ memory }));
 
       const mockDeferUpdate = vi.fn();
       const mockFollowUp = vi.fn();
       const mockEditReply = vi.fn();
 
       const interaction = {
-        user: { id: 'user-123' },
+        user: { id: 'user-123', username: 'testuser' },
         values: ['memory-123'],
         deferUpdate: mockDeferUpdate,
         followUp: mockFollowUp,
@@ -267,16 +274,13 @@ describe('Memory Detail', () => {
     });
 
     it('should show error if memory not found', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: false,
-        error: 'Not found',
-      });
+      stub.getMemory.mockResolvedValue(makeErr(404, 'Not found'));
 
       const mockDeferUpdate = vi.fn();
       const mockFollowUp = vi.fn();
 
       const interaction = {
-        user: { id: 'user-123' },
+        user: { id: 'user-123', username: 'testuser' },
         values: ['memory-123'],
         deferUpdate: mockDeferUpdate,
         followUp: mockFollowUp,
@@ -295,17 +299,14 @@ describe('Memory Detail', () => {
   describe('handleLockButton', () => {
     it('should toggle lock and update view', async () => {
       const memory = createMockMemory({ isLocked: true });
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { memory },
-      });
+      stub.setMemoryLock.mockResolvedValue(makeOk({ memory }));
 
       const mockDeferUpdate = vi.fn();
       const mockFollowUp = vi.fn();
       const mockEditReply = vi.fn();
 
       const interaction = {
-        user: { id: 'user-123' },
+        user: { id: 'user-123', username: 'testuser' },
         deferUpdate: mockDeferUpdate,
         followUp: mockFollowUp,
         editReply: mockEditReply,
@@ -318,16 +319,13 @@ describe('Memory Detail', () => {
     });
 
     it('should show error on lock failure', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: false,
-        error: 'Lock failed',
-      });
+      stub.setMemoryLock.mockResolvedValue(makeErr(500, 'Lock failed'));
 
       const mockDeferUpdate = vi.fn();
       const mockFollowUp = vi.fn();
 
       const interaction = {
-        user: { id: 'user-123' },
+        user: { id: 'user-123', username: 'testuser' },
         deferUpdate: mockDeferUpdate,
         followUp: mockFollowUp,
       } as unknown as ButtonInteraction;
@@ -343,10 +341,10 @@ describe('Memory Detail', () => {
 
     it('forwards desiredState=false to setMemoryLock for unlock flow', async () => {
       const memory = createMockMemory({ isLocked: false });
-      mockCallGatewayApi.mockResolvedValue({ ok: true, data: { memory } });
+      stub.setMemoryLock.mockResolvedValue(makeOk({ memory }));
 
       const interaction = {
-        user: { id: 'user-123' },
+        user: { id: 'user-123', username: 'testuser' },
         deferUpdate: vi.fn(),
         followUp: vi.fn(),
         editReply: vi.fn(),
@@ -354,27 +352,21 @@ describe('Memory Detail', () => {
 
       await handleLockButton(interaction, 'memory-123', false);
 
-      expect(mockCallGatewayApi).toHaveBeenCalledWith(
-        expect.stringContaining('/lock'),
-        expect.objectContaining({ method: 'PUT', body: { locked: false } })
-      );
+      expect(stub.setMemoryLock).toHaveBeenCalledWith('memory-123', { locked: false });
     });
   });
 
   describe('handleDeleteButton', () => {
     it('should show delete confirmation', async () => {
       const memory = createMockMemory();
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { memory },
-      });
+      stub.getMemory.mockResolvedValue(makeOk({ memory }));
 
       const mockDeferUpdate = vi.fn();
       const mockFollowUp = vi.fn();
       const mockEditReply = vi.fn();
 
       const interaction = {
-        user: { id: 'user-123' },
+        user: { id: 'user-123', username: 'testuser' },
         deferUpdate: mockDeferUpdate,
         followUp: mockFollowUp,
         editReply: mockEditReply,
@@ -397,16 +389,13 @@ describe('Memory Detail', () => {
     });
 
     it('should show error if memory not found', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: false,
-        error: 'Not found',
-      });
+      stub.getMemory.mockResolvedValue(makeErr(404, 'Not found'));
 
       const mockDeferUpdate = vi.fn();
       const mockFollowUp = vi.fn();
 
       const interaction = {
-        user: { id: 'user-123' },
+        user: { id: 'user-123', username: 'testuser' },
         deferUpdate: mockDeferUpdate,
         followUp: mockFollowUp,
       } as unknown as ButtonInteraction;
@@ -423,16 +412,13 @@ describe('Memory Detail', () => {
 
   describe('handleDeleteConfirm', () => {
     it('should delete memory and return true', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { success: true },
-      });
+      stub.deleteMemory.mockResolvedValue(makeOk({ success: true }));
 
       const mockDeferUpdate = vi.fn();
       const mockFollowUp = vi.fn();
 
       const interaction = {
-        user: { id: 'user-123' },
+        user: { id: 'user-123', username: 'testuser' },
         deferUpdate: mockDeferUpdate,
         followUp: mockFollowUp,
       } as unknown as ButtonInteraction;
@@ -444,16 +430,13 @@ describe('Memory Detail', () => {
     });
 
     it('should show error and return false on failure', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: false,
-        error: 'Delete failed',
-      });
+      stub.deleteMemory.mockResolvedValue(makeErr(500, 'Delete failed'));
 
       const mockDeferUpdate = vi.fn();
       const mockFollowUp = vi.fn();
 
       const interaction = {
-        user: { id: 'user-123' },
+        user: { id: 'user-123', username: 'testuser' },
         deferUpdate: mockDeferUpdate,
         followUp: mockFollowUp,
       } as unknown as ButtonInteraction;
@@ -473,16 +456,13 @@ describe('Memory Detail', () => {
       // path (ack-first rule) without handleDeleteConfirm double-acking.
       // Without the guard, Discord rejects the second deferUpdate and the
       // user sees "This interaction failed."
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { success: true },
-      });
+      stub.deleteMemory.mockResolvedValue(makeOk({ success: true }));
 
       const mockDeferUpdate = vi.fn();
       const mockFollowUp = vi.fn();
 
       const interaction = {
-        user: { id: 'user-123' },
+        user: { id: 'user-123', username: 'testuser' },
         deferUpdate: mockDeferUpdate,
         followUp: mockFollowUp,
         deferred: true, // ← pre-deferred by caller
@@ -500,16 +480,13 @@ describe('Memory Detail', () => {
     it('should send full memory content as file attachment', async () => {
       const longContent = 'x'.repeat(5000);
       const memory = createMockMemory({ content: longContent });
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { memory },
-      });
+      stub.getMemory.mockResolvedValue(makeOk({ memory }));
 
       const mockDeferReply = vi.fn();
       const mockEditReply = vi.fn();
 
       const interaction = {
-        user: { id: 'user-123' },
+        user: { id: 'user-123', username: 'testuser' },
         deferReply: mockDeferReply,
         editReply: mockEditReply,
       } as unknown as ButtonInteraction;
@@ -532,16 +509,13 @@ describe('Memory Detail', () => {
     });
 
     it('should show error if memory not found', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: false,
-        error: 'Not found',
-      });
+      stub.getMemory.mockResolvedValue(makeErr(404, 'Not found'));
 
       const mockDeferReply = vi.fn();
       const mockEditReply = vi.fn();
 
       const interaction = {
-        user: { id: 'user-123' },
+        user: { id: 'user-123', username: 'testuser' },
         deferReply: mockDeferReply,
         editReply: mockEditReply,
       } as unknown as ButtonInteraction;

--- a/services/bot-client/src/commands/memory/detail.ts
+++ b/services/bot-client/src/commands/memory/detail.ts
@@ -16,14 +16,11 @@ import {
 import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
 import { createLogger, DISCORD_COLORS, formatDateTimeCompact } from '@tzurot/common-types';
 import { CUSTOM_ID_DELIMITER } from '../../utils/customIds.js';
-import { toGatewayUser } from '../../utils/userGatewayClient.js';
+import { clientsFor } from '../../utils/gatewayClients.js';
 
 import { fetchMemory, setMemoryLock, deleteMemory } from './detailApi.js';
-import type { MemoryItem } from './detailApi.js';
+import type { MemoryItem } from '@tzurot/common-types';
 import { EMBED_DESCRIPTION_SAFE_LIMIT } from './formatters.js';
-
-// Re-export MemoryItem so callers can import it alongside handleMemorySelect.
-export type { MemoryItem } from './detailApi.js';
 
 const logger = createLogger('memory-detail');
 
@@ -217,7 +214,8 @@ export async function handleMemorySelect(interaction: StringSelectMenuInteractio
 
   await interaction.deferUpdate();
 
-  const memory = await fetchMemory(toGatewayUser(interaction.user), memoryId);
+  const { userClient } = clientsFor(interaction);
+  const memory = await fetchMemory(userClient, memoryId, interaction.user.id);
   if (memory === null) {
     await interaction.followUp({
       content: '❌ Failed to load memory details. It may have been deleted.',
@@ -253,11 +251,8 @@ export async function handleLockButton(
 
   await interaction.deferUpdate();
 
-  const updatedMemory = await setMemoryLock(
-    toGatewayUser(interaction.user),
-    memoryId,
-    desiredState
-  );
+  const { userClient } = clientsFor(interaction);
+  const updatedMemory = await setMemoryLock(userClient, memoryId, desiredState, userId);
   if (updatedMemory === null) {
     await interaction.followUp({
       content: '❌ Failed to update lock status. Please try again.',
@@ -287,7 +282,8 @@ export async function handleDeleteButton(
 ): Promise<void> {
   await interaction.deferUpdate();
 
-  const memory = await fetchMemory(toGatewayUser(interaction.user), memoryId);
+  const { userClient } = clientsFor(interaction);
+  const memory = await fetchMemory(userClient, memoryId, interaction.user.id);
   if (memory === null) {
     await interaction.followUp({
       content: '❌ Failed to load memory. It may have already been deleted.',
@@ -332,7 +328,8 @@ export async function handleDeleteConfirm(
     await interaction.deferUpdate();
   }
 
-  const success = await deleteMemory(toGatewayUser(interaction.user), memoryId);
+  const { userClient } = clientsFor(interaction);
+  const success = await deleteMemory(userClient, memoryId, userId);
   if (!success) {
     await interaction.followUp({
       content: '❌ Failed to delete memory. Please try again.',
@@ -356,7 +353,8 @@ export async function handleViewFullButton(
 
   await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
-  const memory = await fetchMemory(toGatewayUser(interaction.user), memoryId);
+  const { userClient } = clientsFor(interaction);
+  const memory = await fetchMemory(userClient, memoryId, userId);
   if (memory === null) {
     await interaction.editReply({
       content: '❌ Failed to load memory. It may have been deleted.',

--- a/services/bot-client/src/commands/memory/detailApi.test.ts
+++ b/services/bot-client/src/commands/memory/detailApi.test.ts
@@ -4,9 +4,9 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fetchMemory, updateMemory, setMemoryLock, deleteMemory } from './detailApi.js';
-import type { MemoryItem } from './detailApi.js';
+import type { MemoryItem } from '@tzurot/common-types';
+import { makeOk, makeErr, asUserClient } from '../../test/gatewayClientStubs.js';
 
-// Mock common-types
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal<typeof import('@tzurot/common-types')>();
   return {
@@ -20,27 +20,28 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
-// Mock userGatewayClient
-const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
-    '../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  };
-});
+interface MemoryClientStub {
+  getMemory: ReturnType<typeof vi.fn>;
+  updateMemory: ReturnType<typeof vi.fn>;
+  deleteMemory: ReturnType<typeof vi.fn>;
+  setMemoryLock: ReturnType<typeof vi.fn>;
+}
 
-const TEST_USER = {
-  discordId: 'user-123',
-  username: 'testuser',
-  displayName: 'testuser',
-} as const;
+function createStub(): MemoryClientStub {
+  return {
+    getMemory: vi.fn(),
+    updateMemory: vi.fn(),
+    deleteMemory: vi.fn(),
+    setMemoryLock: vi.fn(),
+  };
+}
 
 describe('Memory Detail API', () => {
+  let stub: MemoryClientStub;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    stub = createStub();
   });
 
   const createMockMemory = (overrides: Partial<MemoryItem> = {}): MemoryItem => ({
@@ -57,31 +58,18 @@ describe('Memory Detail API', () => {
   describe('fetchMemory', () => {
     it('should fetch memory successfully', async () => {
       const memory = createMockMemory();
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { memory },
-      });
+      stub.getMemory.mockResolvedValue(makeOk({ memory }));
 
-      const result = await fetchMemory(TEST_USER, 'memory-123');
+      const result = await fetchMemory(asUserClient(stub), 'memory-123', 'user-123');
 
       expect(result).toEqual(memory);
-      expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/memory/memory-123', {
-        user: {
-          discordId: 'user-123',
-          username: 'testuser',
-          displayName: 'testuser',
-        },
-        method: 'GET',
-      });
+      expect(stub.getMemory).toHaveBeenCalledWith('memory-123');
     });
 
     it('should return null on API error', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: false,
-        error: 'Not found',
-      });
+      stub.getMemory.mockResolvedValue(makeErr(404, 'Not found'));
 
-      const result = await fetchMemory(TEST_USER, 'memory-123');
+      const result = await fetchMemory(asUserClient(stub), 'memory-123', 'user-123');
 
       expect(result).toBeNull();
     });
@@ -90,32 +78,23 @@ describe('Memory Detail API', () => {
   describe('updateMemory', () => {
     it('should update memory successfully', async () => {
       const memory = createMockMemory({ content: 'Updated content' });
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { memory },
-      });
+      stub.updateMemory.mockResolvedValue(makeOk({ memory }));
 
-      const result = await updateMemory(TEST_USER, 'memory-123', 'Updated content');
+      const result = await updateMemory(
+        asUserClient(stub),
+        'memory-123',
+        'Updated content',
+        'user-123'
+      );
 
       expect(result).toEqual(memory);
-      expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/memory/memory-123', {
-        user: {
-          discordId: 'user-123',
-          username: 'testuser',
-          displayName: 'testuser',
-        },
-        method: 'PATCH',
-        body: { content: 'Updated content' },
-      });
+      expect(stub.updateMemory).toHaveBeenCalledWith('memory-123', { content: 'Updated content' });
     });
 
     it('should return null on API error', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: false,
-        error: 'Update failed',
-      });
+      stub.updateMemory.mockResolvedValue(makeErr(500, 'Update failed'));
 
-      const result = await updateMemory(TEST_USER, 'memory-123', 'New content');
+      const result = await updateMemory(asUserClient(stub), 'memory-123', 'New content');
 
       expect(result).toBeNull();
     });
@@ -124,47 +103,27 @@ describe('Memory Detail API', () => {
   describe('setMemoryLock', () => {
     it('sets the lock state explicitly with PUT + { locked }', async () => {
       const memory = createMockMemory({ isLocked: true });
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { memory },
-      });
+      stub.setMemoryLock.mockResolvedValue(makeOk({ memory }));
 
-      const result = await setMemoryLock(TEST_USER, 'memory-123', true);
+      const result = await setMemoryLock(asUserClient(stub), 'memory-123', true, 'user-123');
 
       expect(result).toEqual(memory);
-      expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/memory/memory-123/lock', {
-        user: {
-          discordId: 'user-123',
-          username: 'testuser',
-          displayName: 'testuser',
-        },
-        method: 'PUT',
-        body: { locked: true },
-      });
+      expect(stub.setMemoryLock).toHaveBeenCalledWith('memory-123', { locked: true });
     });
 
     it('passes locked=false through to the API for unlock', async () => {
       const memory = createMockMemory({ isLocked: false });
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { memory },
-      });
+      stub.setMemoryLock.mockResolvedValue(makeOk({ memory }));
 
-      await setMemoryLock(TEST_USER, 'memory-123', false);
+      await setMemoryLock(asUserClient(stub), 'memory-123', false);
 
-      expect(mockCallGatewayApi).toHaveBeenCalledWith(
-        '/user/memory/memory-123/lock',
-        expect.objectContaining({ method: 'PUT', body: { locked: false } })
-      );
+      expect(stub.setMemoryLock).toHaveBeenCalledWith('memory-123', { locked: false });
     });
 
     it('returns null on API error', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: false,
-        error: 'Lock failed',
-      });
+      stub.setMemoryLock.mockResolvedValue(makeErr(500, 'Lock failed'));
 
-      const result = await setMemoryLock(TEST_USER, 'memory-123', true);
+      const result = await setMemoryLock(asUserClient(stub), 'memory-123', true);
 
       expect(result).toBeNull();
     });
@@ -172,31 +131,18 @@ describe('Memory Detail API', () => {
 
   describe('deleteMemory', () => {
     it('should delete memory successfully', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { success: true },
-      });
+      stub.deleteMemory.mockResolvedValue(makeOk({ success: true }));
 
-      const result = await deleteMemory(TEST_USER, 'memory-123');
+      const result = await deleteMemory(asUserClient(stub), 'memory-123', 'user-123');
 
       expect(result).toBe(true);
-      expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/memory/memory-123', {
-        user: {
-          discordId: 'user-123',
-          username: 'testuser',
-          displayName: 'testuser',
-        },
-        method: 'DELETE',
-      });
+      expect(stub.deleteMemory).toHaveBeenCalledWith('memory-123');
     });
 
     it('should return false on API error', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: false,
-        error: 'Delete failed',
-      });
+      stub.deleteMemory.mockResolvedValue(makeErr(500, 'Delete failed'));
 
-      const result = await deleteMemory(TEST_USER, 'memory-123');
+      const result = await deleteMemory(asUserClient(stub), 'memory-123');
 
       expect(result).toBe(false);
     });

--- a/services/bot-client/src/commands/memory/detailApi.ts
+++ b/services/bot-client/src/commands/memory/detailApi.ts
@@ -1,47 +1,30 @@
 /**
  * Memory Detail API Client
- * API functions for single memory operations
+ * API functions for single memory operations.
+ *
+ * The trailing optional `userId?: string` parameter on each helper is for
+ * structured-logging context only — it never affects request shape or
+ * routing. Production call sites in `detail.ts` / `detailModals.ts` all
+ * pass it; the optionality exists so tests stubbing `UserClient` directly
+ * don't have to thread a userId through.
  */
 
-import { createLogger } from '@tzurot/common-types';
-import { callGatewayApi, type GatewayUser } from '../../utils/userGatewayClient.js';
-
-/**
- * Memory item structure from API
- */
-export interface MemoryItem {
-  id: string;
-  content: string;
-  createdAt: string;
-  updatedAt: string;
-  personalityId: string;
-  personalityName: string;
-  isLocked: boolean;
-}
+import { createLogger, type MemoryItem, type UserClient } from '@tzurot/common-types';
 
 const logger = createLogger('memory-detail-api');
-
-interface SingleMemoryResponse {
-  memory: MemoryItem;
-}
 
 /**
  * Fetch a single memory by ID
  */
-export async function fetchMemory(user: GatewayUser, memoryId: string): Promise<MemoryItem | null> {
-  const result = await callGatewayApi<SingleMemoryResponse>(
-    `/user/memory/${encodeURIComponent(memoryId)}`,
-    {
-      user,
-      method: 'GET',
-    }
-  );
+export async function fetchMemory(
+  userClient: UserClient,
+  memoryId: string,
+  userId?: string
+): Promise<MemoryItem | null> {
+  const result = await userClient.getMemory(memoryId);
 
   if (!result.ok) {
-    logger.warn(
-      { userId: user.discordId, memoryId, error: result.error },
-      'Failed to fetch memory'
-    );
+    logger.warn({ userId, memoryId, error: result.error }, 'Failed to fetch memory');
     return null;
   }
 
@@ -52,24 +35,15 @@ export async function fetchMemory(user: GatewayUser, memoryId: string): Promise<
  * Update memory content
  */
 export async function updateMemory(
-  user: GatewayUser,
+  userClient: UserClient,
   memoryId: string,
-  content: string
+  content: string,
+  userId?: string
 ): Promise<MemoryItem | null> {
-  const result = await callGatewayApi<SingleMemoryResponse>(
-    `/user/memory/${encodeURIComponent(memoryId)}`,
-    {
-      user,
-      method: 'PATCH',
-      body: { content },
-    }
-  );
+  const result = await userClient.updateMemory(memoryId, { content });
 
   if (!result.ok) {
-    logger.warn(
-      { userId: user.discordId, memoryId, error: result.error },
-      'Failed to update memory'
-    );
+    logger.warn({ userId, memoryId, error: result.error }, 'Failed to update memory');
     return null;
   }
 
@@ -82,24 +56,15 @@ export async function updateMemory(
  * unlock something the previous attempt locked.
  */
 export async function setMemoryLock(
-  user: GatewayUser,
+  userClient: UserClient,
   memoryId: string,
-  locked: boolean
+  locked: boolean,
+  userId?: string
 ): Promise<MemoryItem | null> {
-  const result = await callGatewayApi<SingleMemoryResponse>(
-    `/user/memory/${encodeURIComponent(memoryId)}/lock`,
-    {
-      user,
-      method: 'PUT',
-      body: { locked },
-    }
-  );
+  const result = await userClient.setMemoryLock(memoryId, { locked });
 
   if (!result.ok) {
-    logger.warn(
-      { userId: user.discordId, memoryId, locked, error: result.error },
-      'Failed to set memory lock'
-    );
+    logger.warn({ userId, memoryId, locked, error: result.error }, 'Failed to set memory lock');
     return null;
   }
 
@@ -109,20 +74,15 @@ export async function setMemoryLock(
 /**
  * Delete a memory
  */
-export async function deleteMemory(user: GatewayUser, memoryId: string): Promise<boolean> {
-  const result = await callGatewayApi<{ success: boolean }>(
-    `/user/memory/${encodeURIComponent(memoryId)}`,
-    {
-      user,
-      method: 'DELETE',
-    }
-  );
+export async function deleteMemory(
+  userClient: UserClient,
+  memoryId: string,
+  userId?: string
+): Promise<boolean> {
+  const result = await userClient.deleteMemory(memoryId);
 
   if (!result.ok) {
-    logger.warn(
-      { userId: user.discordId, memoryId, error: result.error },
-      'Failed to delete memory'
-    );
+    logger.warn({ userId, memoryId, error: result.error }, 'Failed to delete memory');
     return false;
   }
 

--- a/services/bot-client/src/commands/memory/detailModals.test.ts
+++ b/services/bot-client/src/commands/memory/detailModals.test.ts
@@ -9,10 +9,10 @@ import {
   handleEditModalSubmit,
   MAX_MODAL_CONTENT_LENGTH,
 } from './detailModals.js';
-import type { MemoryItem } from './detailApi.js';
+import type { MemoryItem } from '@tzurot/common-types';
 import type { ButtonInteraction, ModalSubmitInteraction } from 'discord.js';
+import { makeOk, makeErr, asUserClient } from '../../test/gatewayClientStubs.js';
 
-// Mock common-types
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal<typeof import('@tzurot/common-types')>();
   return {
@@ -31,26 +31,34 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
-// Mock userGatewayClient
-const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
-    '../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  };
-});
+const clientsForMock = vi.hoisted(() => vi.fn());
+vi.mock('../../utils/gatewayClients.js', () => ({
+  clientsFor: clientsForMock,
+}));
 
-// Mock customIds
 vi.mock('../../utils/customIds.js', () => ({
   CUSTOM_ID_DELIMITER: '::',
 }));
 
+interface MemoryClientStub {
+  getMemory: ReturnType<typeof vi.fn>;
+  updateMemory: ReturnType<typeof vi.fn>;
+}
+
+function createStub(): MemoryClientStub {
+  return {
+    getMemory: vi.fn(),
+    updateMemory: vi.fn(),
+  };
+}
+
 describe('Memory Detail Modals', () => {
+  let stub: MemoryClientStub;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    stub = createStub();
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
   });
 
   const createMockMemory = (overrides: Partial<MemoryItem> = {}): MemoryItem => ({
@@ -84,16 +92,13 @@ describe('Memory Detail Modals', () => {
   describe('handleEditButton', () => {
     it('should show modal on edit click', async () => {
       const memory = createMockMemory();
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { memory },
-      });
+      stub.getMemory.mockResolvedValue(makeOk({ memory }));
 
       const mockShowModal = vi.fn();
       const mockReply = vi.fn();
 
       const interaction = {
-        user: { id: 'user-123' },
+        user: { id: 'user-123', username: 'testuser' },
         showModal: mockShowModal,
         reply: mockReply,
       } as unknown as ButtonInteraction;
@@ -104,16 +109,13 @@ describe('Memory Detail Modals', () => {
     });
 
     it('should show error if memory not found', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: false,
-        error: 'Not found',
-      });
+      stub.getMemory.mockResolvedValue(makeErr(404, 'Not found'));
 
       const mockShowModal = vi.fn();
       const mockReply = vi.fn();
 
       const interaction = {
-        user: { id: 'user-123' },
+        user: { id: 'user-123', username: 'testuser' },
         showModal: mockShowModal,
         reply: mockReply,
       } as unknown as ButtonInteraction;
@@ -132,10 +134,7 @@ describe('Memory Detail Modals', () => {
   describe('handleEditModalSubmit', () => {
     it('should update memory and show detail view', async () => {
       const memory = createMockMemory({ content: 'Updated content' });
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { memory },
-      });
+      stub.updateMemory.mockResolvedValue(makeOk({ memory }));
 
       const mockDeferUpdate = vi.fn();
       const mockFollowUp = vi.fn();
@@ -143,7 +142,7 @@ describe('Memory Detail Modals', () => {
       const mockGetTextInputValue = vi.fn().mockReturnValue('Updated content');
 
       const interaction = {
-        user: { id: 'user-123' },
+        user: { id: 'user-123', username: 'testuser' },
         fields: { getTextInputValue: mockGetTextInputValue },
         deferUpdate: mockDeferUpdate,
         followUp: mockFollowUp,
@@ -157,17 +156,14 @@ describe('Memory Detail Modals', () => {
     });
 
     it('should show error on update failure', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: false,
-        error: 'Update failed',
-      });
+      stub.updateMemory.mockResolvedValue(makeErr(500, 'Update failed'));
 
       const mockDeferUpdate = vi.fn();
       const mockFollowUp = vi.fn();
       const mockGetTextInputValue = vi.fn().mockReturnValue('Updated content');
 
       const interaction = {
-        user: { id: 'user-123' },
+        user: { id: 'user-123', username: 'testuser' },
         fields: { getTextInputValue: mockGetTextInputValue },
         deferUpdate: mockDeferUpdate,
         followUp: mockFollowUp,

--- a/services/bot-client/src/commands/memory/detailModals.ts
+++ b/services/bot-client/src/commands/memory/detailModals.ts
@@ -16,10 +16,10 @@ import {
 import type { ButtonInteraction, ModalSubmitInteraction } from 'discord.js';
 import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
 import { buildMemoryActionId, buildDetailEmbed, buildDetailButtons } from './detail.js';
-import { toGatewayUser } from '../../utils/userGatewayClient.js';
+import { clientsFor } from '../../utils/gatewayClients.js';
 import { showModalWithTimeoutCatch } from '../../utils/dashboard/showModalWithTimeoutCatch.js';
 import { fetchMemory, updateMemory } from './detailApi.js';
-import type { MemoryItem } from './detailApi.js';
+import type { MemoryItem } from '@tzurot/common-types';
 
 const logger = createLogger('memory-detail-modals');
 
@@ -100,7 +100,8 @@ export async function handleEditButton(
   interaction: ButtonInteraction,
   memoryId: string
 ): Promise<void> {
-  const memory = await fetchMemory(toGatewayUser(interaction.user), memoryId);
+  const { userClient } = clientsFor(interaction);
+  const memory = await fetchMemory(userClient, memoryId, interaction.user.id);
   if (memory === null) {
     await interaction.reply({
       content: '❌ Failed to load memory. It may have been deleted.',
@@ -147,7 +148,8 @@ export async function handleEditTruncatedButton(
   interaction: ButtonInteraction,
   memoryId: string
 ): Promise<void> {
-  const memory = await fetchMemory(toGatewayUser(interaction.user), memoryId);
+  const { userClient } = clientsFor(interaction);
+  const memory = await fetchMemory(userClient, memoryId, interaction.user.id);
   if (memory === null) {
     await interaction.update({
       content: '❌ Failed to load memory. It may have been deleted.',
@@ -215,7 +217,8 @@ export async function handleEditModalSubmit(
     return;
   }
 
-  const updatedMemory = await updateMemory(toGatewayUser(interaction.user), memoryId, newContent);
+  const { userClient } = clientsFor(interaction);
+  const updatedMemory = await updateMemory(userClient, memoryId, newContent, userId);
   if (updatedMemory === null) {
     await interaction.followUp({
       content: '❌ Failed to update memory. Please try again.',

--- a/services/bot-client/src/commands/memory/focus.test.ts
+++ b/services/bot-client/src/commands/memory/focus.test.ts
@@ -4,8 +4,8 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { handleFocusEnable, handleFocusDisable, handleFocusStatus } from './focus.js';
+import { makeOk, makeErr, asUserClient } from '../../test/gatewayClientStubs.js';
 
-// Mock common-types
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal<typeof import('@tzurot/common-types')>();
   return {
@@ -19,19 +19,11 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
-// Mock userGatewayClient
-const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
-    '../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  };
-});
+const clientsForMock = vi.hoisted(() => vi.fn());
+vi.mock('../../utils/gatewayClients.js', () => ({
+  clientsFor: clientsForMock,
+}));
 
-// Mock commandHelpers
 const mockCreateSuccessEmbed = vi.fn(() => ({}));
 const mockCreateInfoEmbed = vi.fn(() => ({}));
 vi.mock('../../utils/commandHelpers.js', () => ({
@@ -41,7 +33,6 @@ vi.mock('../../utils/commandHelpers.js', () => ({
     mockCreateInfoEmbed(...(args as Parameters<typeof mockCreateInfoEmbed>)),
 }));
 
-// Mock autocomplete
 const mockResolvePersonalityId = vi.fn();
 const mockGetPersonalityName = vi.fn();
 vi.mock('./autocomplete.js', () => ({
@@ -49,17 +40,33 @@ vi.mock('./autocomplete.js', () => ({
   getPersonalityName: (...args: unknown[]) => mockGetPersonalityName(...args),
 }));
 
+interface MemoryClientStub {
+  getFocus: ReturnType<typeof vi.fn>;
+  setFocus: ReturnType<typeof vi.fn>;
+}
+
+function createStub(): MemoryClientStub {
+  return {
+    getFocus: vi.fn(),
+    setFocus: vi.fn(),
+  };
+}
+
 describe('Memory Focus Handlers', () => {
   const mockEditReply = vi.fn();
+  let stub: MemoryClientStub;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    stub = createStub();
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
   });
 
   function createMockContext(personalitySlug: string = 'lilith') {
     return {
       user: { id: '123456789', username: 'testuser' },
       interaction: {
+        user: { id: '123456789', username: 'testuser' },
         options: {
           getString: (name: string, _required?: boolean) => {
             if (name === 'character') return personalitySlug;
@@ -74,26 +81,21 @@ describe('Memory Focus Handlers', () => {
   describe('handleFocusEnable', () => {
     it('should enable focus mode successfully', async () => {
       mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: {
+      stub.setFocus.mockResolvedValue(
+        makeOk({
           personalityId: 'personality-uuid-123',
           personalityName: 'Lilith',
           focusModeEnabled: true,
-        },
-      });
+          message: 'Focus mode enabled',
+        })
+      );
 
       const context = createMockContext();
       await handleFocusEnable(context);
 
-      expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/memory/focus', {
-        user: {
-          discordId: '123456789',
-          username: 'testuser',
-          displayName: 'testuser',
-        },
-        method: 'POST',
-        body: { personalityId: 'personality-uuid-123', enabled: true },
+      expect(stub.setFocus).toHaveBeenCalledWith({
+        personalityId: 'personality-uuid-123',
+        enabled: true,
       });
       expect(mockCreateSuccessEmbed).toHaveBeenCalledWith(
         'Focus Mode Enabled',
@@ -111,16 +113,12 @@ describe('Memory Focus Handlers', () => {
       expect(mockEditReply).toHaveBeenCalledWith({
         content: expect.stringContaining('unknown'),
       });
-      expect(mockCallGatewayApi).not.toHaveBeenCalled();
+      expect(stub.setFocus).not.toHaveBeenCalled();
     });
 
     it('should handle API error', async () => {
       mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
-      mockCallGatewayApi.mockResolvedValue({
-        ok: false,
-        status: 500,
-        error: 'Server error',
-      });
+      stub.setFocus.mockResolvedValue(makeErr(500, 'Server error'));
 
       const context = createMockContext();
       await handleFocusEnable(context);
@@ -145,26 +143,21 @@ describe('Memory Focus Handlers', () => {
   describe('handleFocusDisable', () => {
     it('should disable focus mode successfully', async () => {
       mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: {
+      stub.setFocus.mockResolvedValue(
+        makeOk({
           personalityId: 'personality-uuid-123',
           personalityName: 'Lilith',
           focusModeEnabled: false,
-        },
-      });
+          message: 'Focus mode disabled',
+        })
+      );
 
       const context = createMockContext();
       await handleFocusDisable(context);
 
-      expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/memory/focus', {
-        user: {
-          discordId: '123456789',
-          username: 'testuser',
-          displayName: 'testuser',
-        },
-        method: 'POST',
-        body: { personalityId: 'personality-uuid-123', enabled: false },
+      expect(stub.setFocus).toHaveBeenCalledWith({
+        personalityId: 'personality-uuid-123',
+        enabled: false,
       });
       expect(mockCreateSuccessEmbed).toHaveBeenCalledWith(
         'Focus Mode Disabled',
@@ -181,7 +174,7 @@ describe('Memory Focus Handlers', () => {
       expect(mockEditReply).toHaveBeenCalledWith({
         content: expect.stringContaining('unknown'),
       });
-      expect(mockCallGatewayApi).not.toHaveBeenCalled();
+      expect(stub.setFocus).not.toHaveBeenCalled();
     });
   });
 
@@ -189,24 +182,17 @@ describe('Memory Focus Handlers', () => {
     it('should show status when focus mode is enabled', async () => {
       mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
       mockGetPersonalityName.mockResolvedValue('Lilith');
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: {
+      stub.getFocus.mockResolvedValue(
+        makeOk({
           personalityId: 'personality-uuid-123',
           focusModeEnabled: true,
-        },
-      });
+        })
+      );
 
       const context = createMockContext();
       await handleFocusStatus(context);
 
-      expect(mockCallGatewayApi).toHaveBeenCalledWith(
-        '/user/memory/focus?personalityId=personality-uuid-123',
-        {
-          user: { discordId: '123456789', username: 'testuser', displayName: 'testuser' },
-          method: 'GET',
-        }
-      );
+      expect(stub.getFocus).toHaveBeenCalledWith({ personalityId: 'personality-uuid-123' });
       expect(mockCreateInfoEmbed).toHaveBeenCalledWith(
         'Focus Mode Status',
         expect.stringContaining('enabled')
@@ -216,13 +202,12 @@ describe('Memory Focus Handlers', () => {
     it('should show status when focus mode is disabled', async () => {
       mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
       mockGetPersonalityName.mockResolvedValue('Lilith');
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: {
+      stub.getFocus.mockResolvedValue(
+        makeOk({
           personalityId: 'personality-uuid-123',
           focusModeEnabled: false,
-        },
-      });
+        })
+      );
 
       const context = createMockContext();
       await handleFocusStatus(context);
@@ -236,13 +221,12 @@ describe('Memory Focus Handlers', () => {
     it('should use personality slug when name not found', async () => {
       mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
       mockGetPersonalityName.mockResolvedValue(null);
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: {
+      stub.getFocus.mockResolvedValue(
+        makeOk({
           personalityId: 'personality-uuid-123',
           focusModeEnabled: false,
-        },
-      });
+        })
+      );
 
       const context = createMockContext('lilith');
       await handleFocusStatus(context);
@@ -262,16 +246,12 @@ describe('Memory Focus Handlers', () => {
       expect(mockEditReply).toHaveBeenCalledWith({
         content: expect.stringContaining('unknown'),
       });
-      expect(mockCallGatewayApi).not.toHaveBeenCalled();
+      expect(stub.getFocus).not.toHaveBeenCalled();
     });
 
     it('should handle API error', async () => {
       mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
-      mockCallGatewayApi.mockResolvedValue({
-        ok: false,
-        status: 500,
-        error: 'Server error',
-      });
+      stub.getFocus.mockResolvedValue(makeErr(500, 'Server error'));
 
       const context = createMockContext();
       await handleFocusStatus(context);

--- a/services/bot-client/src/commands/memory/focus.ts
+++ b/services/bot-client/src/commands/memory/focus.ts
@@ -14,19 +14,13 @@ import {
   memoryFocusStatusOptions,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
+import { toGatewayUser } from '../../utils/userGatewayClient.js';
+import { clientsFor } from '../../utils/gatewayClients.js';
 import { createSuccessEmbed, createInfoEmbed } from '../../utils/commandHelpers.js';
 import { getPersonalityName } from './autocomplete.js';
 import { resolveRequiredPersonality } from './resolveHelpers.js';
 
 const logger = createLogger('memory-focus');
-
-interface FocusResponse {
-  personalityId: string;
-  personalityName: string;
-  focusModeEnabled: boolean;
-  message?: string;
-}
 
 /**
  * Handle /memory focus enable
@@ -48,6 +42,7 @@ export async function handleFocusDisable(context: DeferredCommandContext): Promi
 export async function handleFocusStatus(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
   const user = toGatewayUser(context.user);
+  const { userClient } = clientsFor(context.interaction);
   const options = memoryFocusStatusOptions(context.interaction);
   const personalityInput = options.character();
 
@@ -58,13 +53,7 @@ export async function handleFocusStatus(context: DeferredCommandContext): Promis
       return;
     }
 
-    const result = await callGatewayApi<FocusResponse>(
-      `/user/memory/focus?personalityId=${encodeURIComponent(personalityId)}`,
-      {
-        user,
-        method: 'GET',
-      }
-    );
+    const result = await userClient.getFocus({ personalityId });
 
     if (!result.ok) {
       logger.warn({ userId, personalityInput, status: result.status }, 'Status check failed');
@@ -102,6 +91,7 @@ export async function handleFocusStatus(context: DeferredCommandContext): Promis
 async function setFocusMode(context: DeferredCommandContext, enabled: boolean): Promise<void> {
   const userId = context.user.id;
   const user = toGatewayUser(context.user);
+  const { userClient } = clientsFor(context.interaction);
   // Both enable and disable use the same option schema
   const options = enabled
     ? memoryFocusEnableOptions(context.interaction)
@@ -115,11 +105,7 @@ async function setFocusMode(context: DeferredCommandContext, enabled: boolean): 
       return;
     }
 
-    const result = await callGatewayApi<FocusResponse>('/user/memory/focus', {
-      user,
-      method: 'POST',
-      body: { personalityId, enabled },
-    });
+    const result = await userClient.setFocus({ personalityId, enabled });
 
     if (!result.ok) {
       logger.warn(

--- a/services/bot-client/src/commands/memory/incognito.test.ts
+++ b/services/bot-client/src/commands/memory/incognito.test.ts
@@ -14,8 +14,8 @@ import {
   handleIncognitoStatus,
   handleIncognitoForget,
 } from './incognito.js';
+import { makeOk, makeErr, asUserClient } from '../../test/gatewayClientStubs.js';
 
-// Mock common-types
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal<typeof import('@tzurot/common-types')>();
   return {
@@ -29,19 +29,11 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
-// Mock userGatewayClient
-const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
-    '../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  };
-});
+const clientsForMock = vi.hoisted(() => vi.fn());
+vi.mock('../../utils/gatewayClients.js', () => ({
+  clientsFor: clientsForMock,
+}));
 
-// Mock commandHelpers - embeds return empty objects for test simplicity
 const mockCreateSuccessEmbed = vi.fn(() => ({ type: 'success' }));
 const mockCreateInfoEmbed = vi.fn(() => ({ type: 'info' }));
 const mockCreateWarningEmbed = vi.fn(() => ({ type: 'warning' }));
@@ -54,7 +46,6 @@ vi.mock('../../utils/commandHelpers.js', () => ({
     mockCreateWarningEmbed(...(args as Parameters<typeof mockCreateWarningEmbed>)),
 }));
 
-// Mock autocomplete
 const mockResolvePersonalityId = vi.fn();
 const mockGetPersonalityName = vi.fn();
 vi.mock('./autocomplete.js', () => ({
@@ -62,14 +53,32 @@ vi.mock('./autocomplete.js', () => ({
   getPersonalityName: (...args: unknown[]) => mockGetPersonalityName(...args),
 }));
 
+interface MemoryClientStub {
+  getIncognitoStatus: ReturnType<typeof vi.fn>;
+  enableIncognito: ReturnType<typeof vi.fn>;
+  disableIncognito: ReturnType<typeof vi.fn>;
+  incognitoForget: ReturnType<typeof vi.fn>;
+}
+
+function createStub(): MemoryClientStub {
+  return {
+    getIncognitoStatus: vi.fn(),
+    enableIncognito: vi.fn(),
+    disableIncognito: vi.fn(),
+    incognitoForget: vi.fn(),
+  };
+}
+
 describe('Memory Incognito Handlers', () => {
   const mockEditReply = vi.fn();
+  let stub: MemoryClientStub;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    stub = createStub();
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
   });
 
-  // Helper to create mock DeferredCommandContext with different options
   function createMockContext(options: {
     character?: string;
     duration?: string;
@@ -78,6 +87,7 @@ describe('Memory Incognito Handlers', () => {
     return {
       user: { id: '123456789', username: 'testuser' },
       interaction: {
+        user: { id: '123456789', username: 'testuser' },
         options: {
           getString: (name: string, _required?: boolean) => {
             if (name === 'character') return options.character ?? 'lilith';
@@ -95,9 +105,8 @@ describe('Memory Incognito Handlers', () => {
     it('should enable incognito mode for specific personality', async () => {
       mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
       mockGetPersonalityName.mockResolvedValue('Lilith');
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: {
+      stub.enableIncognito.mockResolvedValue(
+        makeOk({
           session: {
             user: {
               discordId: '123456789',
@@ -112,20 +121,15 @@ describe('Memory Incognito Handlers', () => {
           timeRemaining: '1h remaining',
           wasAlreadyActive: false,
           message: 'Incognito mode enabled for Lilith (1 hour)',
-        },
-      });
+        })
+      );
 
       const context = createMockContext({ character: 'lilith', duration: '1h' });
       await handleIncognitoEnable(context);
 
-      expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/memory/incognito', {
-        user: {
-          discordId: '123456789',
-          username: 'testuser',
-          displayName: 'testuser',
-        },
-        method: 'POST',
-        body: { personalityId: 'personality-uuid-123', duration: '1h' },
+      expect(stub.enableIncognito).toHaveBeenCalledWith({
+        personalityId: 'personality-uuid-123',
+        duration: '1h',
       });
       expect(mockCreateSuccessEmbed).toHaveBeenCalledWith(
         '👻 Incognito Mode Enabled',
@@ -136,9 +140,8 @@ describe('Memory Incognito Handlers', () => {
 
     it('should enable incognito mode for all personalities', async () => {
       // 'all' is handled specially - no resolvePersonalityId call
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: {
+      stub.enableIncognito.mockResolvedValue(
+        makeOk({
           session: {
             user: {
               discordId: '123456789',
@@ -153,21 +156,16 @@ describe('Memory Incognito Handlers', () => {
           timeRemaining: 'Until manually disabled',
           wasAlreadyActive: false,
           message: 'Incognito mode enabled for all personalities',
-        },
-      });
+        })
+      );
 
       const context = createMockContext({ character: 'all', duration: 'forever' });
       await handleIncognitoEnable(context);
 
       expect(mockResolvePersonalityId).not.toHaveBeenCalled();
-      expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/memory/incognito', {
-        user: {
-          discordId: '123456789',
-          username: 'testuser',
-          displayName: 'testuser',
-        },
-        method: 'POST',
-        body: { personalityId: 'all', duration: 'forever' },
+      expect(stub.enableIncognito).toHaveBeenCalledWith({
+        personalityId: 'all',
+        duration: 'forever',
       });
       expect(mockCreateSuccessEmbed).toHaveBeenCalled();
     });
@@ -175,9 +173,8 @@ describe('Memory Incognito Handlers', () => {
     it('should show info embed when already active', async () => {
       mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
       mockGetPersonalityName.mockResolvedValue('Lilith');
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: {
+      stub.enableIncognito.mockResolvedValue(
+        makeOk({
           session: {
             user: {
               discordId: '123456789',
@@ -192,8 +189,8 @@ describe('Memory Incognito Handlers', () => {
           timeRemaining: '30m remaining',
           wasAlreadyActive: true,
           message: 'Incognito mode is already active for Lilith',
-        },
-      });
+        })
+      );
 
       const context = createMockContext({ character: 'lilith' });
       await handleIncognitoEnable(context);
@@ -213,17 +210,13 @@ describe('Memory Incognito Handlers', () => {
       expect(mockEditReply).toHaveBeenCalledWith({
         content: expect.stringContaining('unknown'),
       });
-      expect(mockCallGatewayApi).not.toHaveBeenCalled();
+      expect(stub.enableIncognito).not.toHaveBeenCalled();
     });
 
     it('should handle API error', async () => {
       mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
       mockGetPersonalityName.mockResolvedValue('Lilith');
-      mockCallGatewayApi.mockResolvedValue({
-        ok: false,
-        status: 500,
-        error: 'Server error',
-      });
+      stub.enableIncognito.mockResolvedValue(makeErr(500, 'Server error'));
 
       const context = createMockContext({ character: 'lilith' });
       await handleIncognitoEnable(context);
@@ -250,7 +243,7 @@ describe('Memory Incognito Handlers', () => {
       await handleIncognitoEnable(context);
 
       expect(mockResolvePersonalityId).not.toHaveBeenCalled();
-      expect(mockCallGatewayApi).not.toHaveBeenCalled();
+      expect(stub.enableIncognito).not.toHaveBeenCalled();
       expect(mockEditReply).toHaveBeenCalledWith({
         content: expect.stringContaining('Autocomplete was unavailable'),
       });
@@ -261,25 +254,18 @@ describe('Memory Incognito Handlers', () => {
     it('should disable incognito mode successfully', async () => {
       mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
       mockGetPersonalityName.mockResolvedValue('Lilith');
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: {
+      stub.disableIncognito.mockResolvedValue(
+        makeOk({
           disabled: true,
           message: 'Incognito mode disabled for Lilith',
-        },
-      });
+        })
+      );
 
       const context = createMockContext({ character: 'lilith' });
       await handleIncognitoDisable(context);
 
-      expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/memory/incognito', {
-        user: {
-          discordId: '123456789',
-          username: 'testuser',
-          displayName: 'testuser',
-        },
-        method: 'DELETE',
-        body: { personalityId: 'personality-uuid-123' },
+      expect(stub.disableIncognito).toHaveBeenCalledWith({
+        personalityId: 'personality-uuid-123',
       });
       expect(mockCreateSuccessEmbed).toHaveBeenCalledWith(
         '👻 Incognito Mode Disabled',
@@ -288,39 +274,29 @@ describe('Memory Incognito Handlers', () => {
     });
 
     it('should disable incognito for all personalities', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: {
+      stub.disableIncognito.mockResolvedValue(
+        makeOk({
           disabled: true,
           message: 'Incognito mode disabled for all personalities',
-        },
-      });
+        })
+      );
 
       const context = createMockContext({ character: 'all' });
       await handleIncognitoDisable(context);
 
       expect(mockResolvePersonalityId).not.toHaveBeenCalled();
-      expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/memory/incognito', {
-        user: {
-          discordId: '123456789',
-          username: 'testuser',
-          displayName: 'testuser',
-        },
-        method: 'DELETE',
-        body: { personalityId: 'all' },
-      });
+      expect(stub.disableIncognito).toHaveBeenCalledWith({ personalityId: 'all' });
     });
 
     it('should show info when incognito was not active', async () => {
       mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
       mockGetPersonalityName.mockResolvedValue('Lilith');
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: {
+      stub.disableIncognito.mockResolvedValue(
+        makeOk({
           disabled: false,
           message: 'Incognito mode was not active for Lilith',
-        },
-      });
+        })
+      );
 
       const context = createMockContext({ character: 'lilith' });
       await handleIncognitoDisable(context);
@@ -344,11 +320,7 @@ describe('Memory Incognito Handlers', () => {
 
     it('should handle API error', async () => {
       mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
-      mockCallGatewayApi.mockResolvedValue({
-        ok: false,
-        status: 500,
-        error: 'Server error',
-      });
+      stub.disableIncognito.mockResolvedValue(makeErr(500, 'Server error'));
 
       const context = createMockContext({ character: 'lilith' });
       await handleIncognitoDisable(context);
@@ -375,7 +347,7 @@ describe('Memory Incognito Handlers', () => {
       await handleIncognitoDisable(context);
 
       expect(mockResolvePersonalityId).not.toHaveBeenCalled();
-      expect(mockCallGatewayApi).not.toHaveBeenCalled();
+      expect(stub.disableIncognito).not.toHaveBeenCalled();
       expect(mockEditReply).toHaveBeenCalledWith({
         content: expect.stringContaining('Autocomplete was unavailable'),
       });
@@ -384,13 +356,12 @@ describe('Memory Incognito Handlers', () => {
 
   describe('handleIncognitoStatus', () => {
     it('should show inactive status when no sessions', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: {
+      stub.getIncognitoStatus.mockResolvedValue(
+        makeOk({
           active: false,
           sessions: [],
-        },
-      });
+        })
+      );
 
       const context = createMockContext({});
       await handleIncognitoStatus(context);
@@ -403,9 +374,8 @@ describe('Memory Incognito Handlers', () => {
 
     it('should show active status with single session', async () => {
       mockGetPersonalityName.mockResolvedValue('Lilith');
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: {
+      stub.getIncognitoStatus.mockResolvedValue(
+        makeOk({
           active: true,
           sessions: [
             {
@@ -421,8 +391,8 @@ describe('Memory Incognito Handlers', () => {
               timeRemaining: '1h remaining',
             },
           ],
-        },
-      });
+        })
+      );
 
       const context = createMockContext({});
       await handleIncognitoStatus(context);
@@ -435,9 +405,8 @@ describe('Memory Incognito Handlers', () => {
 
     it('should show active status with multiple sessions', async () => {
       mockGetPersonalityName.mockResolvedValueOnce('Lilith').mockResolvedValueOnce('Sarcastic');
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: {
+      stub.getIncognitoStatus.mockResolvedValue(
+        makeOk({
           active: true,
           sessions: [
             {
@@ -465,8 +434,8 @@ describe('Memory Incognito Handlers', () => {
               timeRemaining: '3h 30m remaining',
             },
           ],
-        },
-      });
+        })
+      );
 
       const context = createMockContext({});
       await handleIncognitoStatus(context);
@@ -476,9 +445,8 @@ describe('Memory Incognito Handlers', () => {
     });
 
     it('should handle global "all" session', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: {
+      stub.getIncognitoStatus.mockResolvedValue(
+        makeOk({
           active: true,
           sessions: [
             {
@@ -494,8 +462,8 @@ describe('Memory Incognito Handlers', () => {
               timeRemaining: 'Until manually disabled',
             },
           ],
-        },
-      });
+        })
+      );
 
       const context = createMockContext({});
       await handleIncognitoStatus(context);
@@ -509,11 +477,7 @@ describe('Memory Incognito Handlers', () => {
     });
 
     it('should handle API error', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: false,
-        status: 500,
-        error: 'Server error',
-      });
+      stub.getIncognitoStatus.mockResolvedValue(makeErr(500, 'Server error'));
 
       const context = createMockContext({});
       await handleIncognitoStatus(context);
@@ -525,7 +489,7 @@ describe('Memory Incognito Handlers', () => {
 
     it('should handle exceptions', async () => {
       const error = new Error('Network error');
-      mockCallGatewayApi.mockRejectedValue(error);
+      stub.getIncognitoStatus.mockRejectedValue(error);
 
       const context = createMockContext({});
       await handleIncognitoStatus(context);
@@ -540,26 +504,20 @@ describe('Memory Incognito Handlers', () => {
     it('should delete recent memories successfully', async () => {
       mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
       mockGetPersonalityName.mockResolvedValue('Lilith');
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: {
+      stub.incognitoForget.mockResolvedValue(
+        makeOk({
           deletedCount: 5,
           personalities: ['Lilith'],
           message: 'Deleted 5 memories from the last 15m',
-        },
-      });
+        })
+      );
 
       const context = createMockContext({ character: 'lilith', timeframe: '15m' });
       await handleIncognitoForget(context);
 
-      expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/memory/incognito/forget', {
-        user: {
-          discordId: '123456789',
-          username: 'testuser',
-          displayName: 'testuser',
-        },
-        method: 'POST',
-        body: { personalityId: 'personality-uuid-123', timeframe: '15m' },
+      expect(stub.incognitoForget).toHaveBeenCalledWith({
+        personalityId: 'personality-uuid-123',
+        timeframe: '15m',
       });
       expect(mockCreateSuccessEmbed).toHaveBeenCalledWith(
         '🗑️ Memories Deleted',
@@ -568,41 +526,34 @@ describe('Memory Incognito Handlers', () => {
     });
 
     it('should delete memories for all personalities', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: {
+      stub.incognitoForget.mockResolvedValue(
+        makeOk({
           deletedCount: 12,
           personalities: ['Lilith', 'Sarcastic', 'Sage'],
           message: 'Deleted 12 memories from the last 1h',
-        },
-      });
+        })
+      );
 
       const context = createMockContext({ character: 'all', timeframe: '1h' });
       await handleIncognitoForget(context);
 
       expect(mockResolvePersonalityId).not.toHaveBeenCalled();
-      expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/memory/incognito/forget', {
-        user: {
-          discordId: '123456789',
-          username: 'testuser',
-          displayName: 'testuser',
-        },
-        method: 'POST',
-        body: { personalityId: 'all', timeframe: '1h' },
+      expect(stub.incognitoForget).toHaveBeenCalledWith({
+        personalityId: 'all',
+        timeframe: '1h',
       });
     });
 
     it('should show info when no memories found', async () => {
       mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
       mockGetPersonalityName.mockResolvedValue('Lilith');
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: {
+      stub.incognitoForget.mockResolvedValue(
+        makeOk({
           deletedCount: 0,
           personalities: [],
           message: 'No memories found in the last 5m',
-        },
-      });
+        })
+      );
 
       const context = createMockContext({ character: 'lilith', timeframe: '5m' });
       await handleIncognitoForget(context);
@@ -622,16 +573,12 @@ describe('Memory Incognito Handlers', () => {
       expect(mockEditReply).toHaveBeenCalledWith({
         content: expect.stringContaining('unknown'),
       });
-      expect(mockCallGatewayApi).not.toHaveBeenCalled();
+      expect(stub.incognitoForget).not.toHaveBeenCalled();
     });
 
     it('should handle API error', async () => {
       mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
-      mockCallGatewayApi.mockResolvedValue({
-        ok: false,
-        status: 500,
-        error: 'Server error',
-      });
+      stub.incognitoForget.mockResolvedValue(makeErr(500, 'Server error'));
 
       const context = createMockContext({ character: 'lilith' });
       await handleIncognitoForget(context);
@@ -658,7 +605,7 @@ describe('Memory Incognito Handlers', () => {
       await handleIncognitoForget(context);
 
       expect(mockResolvePersonalityId).not.toHaveBeenCalled();
-      expect(mockCallGatewayApi).not.toHaveBeenCalled();
+      expect(stub.incognitoForget).not.toHaveBeenCalled();
       expect(mockEditReply).toHaveBeenCalledWith({
         content: expect.stringContaining('Autocomplete was unavailable'),
       });

--- a/services/bot-client/src/commands/memory/incognito.ts
+++ b/services/bot-client/src/commands/memory/incognito.ts
@@ -17,15 +17,16 @@ import {
   memoryIncognitoEnableOptions,
   memoryIncognitoDisableOptions,
   memoryIncognitoForgetOptions,
-  type IncognitoSession,
   type IncognitoDuration,
+  type IncognitoSessionWithRemaining,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import {
   AUTOCOMPLETE_UNAVAILABLE_MESSAGE,
   isAutocompleteErrorSentinel,
 } from '../../utils/apiCheck.js';
-import { callGatewayApi, toGatewayUser, type GatewayUser } from '../../utils/userGatewayClient.js';
+import { toGatewayUser, type GatewayUser } from '../../utils/userGatewayClient.js';
+import { clientsFor } from '../../utils/gatewayClients.js';
 import {
   createSuccessEmbed,
   createInfoEmbed,
@@ -39,35 +40,10 @@ const logger = createLogger('memory-incognito');
 const UNEXPECTED_ERROR_LOG_MESSAGE = 'Unexpected error';
 
 const ALL_PERSONALITIES_LABEL = 'all characters';
-const INCOGNITO_API_PATH = '/user/memory/incognito';
 const UNEXPECTED_ERROR_MESSAGE = '❌ An unexpected error occurred. Please try again.';
 
-interface SessionWithTime extends IncognitoSession {
-  timeRemaining: string;
-}
-
-interface IncognitoStatusResponse {
-  active: boolean;
-  sessions: SessionWithTime[];
-}
-
-interface IncognitoEnableResponse {
-  session: IncognitoSession;
-  timeRemaining: string;
-  wasAlreadyActive: boolean;
-  message: string;
-}
-
-interface IncognitoDisableResponse {
-  disabled: boolean;
-  message: string;
-}
-
-interface IncognitoForgetResponse {
-  deletedCount: number;
-  personalities: string[];
-  message: string;
-}
+/** Local alias for the schema-derived session-with-time-remaining shape. */
+type SessionWithTime = IncognitoSessionWithRemaining;
 
 /**
  * Format session info for display
@@ -105,6 +81,7 @@ async function resolvePersonalityOrAll(
 export async function handleIncognitoEnable(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
   const user = toGatewayUser(context.user);
+  const { userClient } = clientsFor(context.interaction);
   const options = memoryIncognitoEnableOptions(context.interaction);
   const personalityInput = options.character();
   const duration = options.duration() as IncognitoDuration;
@@ -124,11 +101,7 @@ export async function handleIncognitoEnable(context: DeferredCommandContext): Pr
       return;
     }
 
-    const result = await callGatewayApi<IncognitoEnableResponse>(INCOGNITO_API_PATH, {
-      user,
-      method: 'POST',
-      body: { personalityId: resolved.id, duration },
-    });
+    const result = await userClient.enableIncognito({ personalityId: resolved.id, duration });
 
     if (!result.ok) {
       logger.warn({ userId, personalityInput, duration, status: result.status }, 'Enable failed');
@@ -166,6 +139,7 @@ export async function handleIncognitoEnable(context: DeferredCommandContext): Pr
 export async function handleIncognitoDisable(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
   const user = toGatewayUser(context.user);
+  const { userClient } = clientsFor(context.interaction);
   const options = memoryIncognitoDisableOptions(context.interaction);
   const personalityInput = options.character();
 
@@ -184,11 +158,7 @@ export async function handleIncognitoDisable(context: DeferredCommandContext): P
       return;
     }
 
-    const result = await callGatewayApi<IncognitoDisableResponse>(INCOGNITO_API_PATH, {
-      user,
-      method: 'DELETE',
-      body: { personalityId: resolved.id },
-    });
+    const result = await userClient.disableIncognito({ personalityId: resolved.id });
 
     if (!result.ok) {
       logger.warn({ userId, personalityInput, status: result.status }, 'Disable failed');
@@ -225,12 +195,10 @@ export async function handleIncognitoDisable(context: DeferredCommandContext): P
 export async function handleIncognitoStatus(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
   const user = toGatewayUser(context.user);
+  const { userClient } = clientsFor(context.interaction);
 
   try {
-    const result = await callGatewayApi<IncognitoStatusResponse>(INCOGNITO_API_PATH, {
-      user,
-      method: 'GET',
-    });
+    const result = await userClient.getIncognitoStatus();
 
     if (!result.ok) {
       logger.warn({ userId, status: result.status }, 'Status check failed');
@@ -282,6 +250,7 @@ export async function handleIncognitoStatus(context: DeferredCommandContext): Pr
 export async function handleIncognitoForget(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
   const user = toGatewayUser(context.user);
+  const { userClient } = clientsFor(context.interaction);
   const options = memoryIncognitoForgetOptions(context.interaction);
   const personalityInput = options.character();
   const timeframe = options.timeframe();
@@ -301,10 +270,12 @@ export async function handleIncognitoForget(context: DeferredCommandContext): Pr
       return;
     }
 
-    const result = await callGatewayApi<IncognitoForgetResponse>('/user/memory/incognito/forget', {
-      user,
-      method: 'POST',
-      body: { personalityId: resolved.id, timeframe },
+    // Discord slash-command `choices` constrains the runtime value to one of
+    // these three; the generated `commandOptions` typing is plain `string`,
+    // so we narrow at the boundary to match the schema's enum.
+    const result = await userClient.incognitoForget({
+      personalityId: resolved.id,
+      timeframe: timeframe as '5m' | '15m' | '1h',
     });
 
     if (!result.ok) {

--- a/services/bot-client/src/commands/memory/purge.test.ts
+++ b/services/bot-client/src/commands/memory/purge.test.ts
@@ -14,6 +14,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { handlePurge, handlePurgeButton, handlePurgeModal, MEMORY_PURGE_PREFIX } from './purge.js';
 import type { ButtonInteraction, ModalSubmitInteraction } from 'discord.js';
+import { makeOk, makeErr, asUserClient } from '../../test/gatewayClientStubs.js';
 
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal<typeof import('@tzurot/common-types')>();
@@ -28,16 +29,10 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
-const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
-    '../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  };
-});
+const clientsForMock = vi.hoisted(() => vi.fn());
+vi.mock('../../utils/gatewayClients.js', () => ({
+  clientsFor: clientsForMock,
+}));
 
 vi.mock('../../utils/commandHelpers.js', () => ({
   createDangerEmbed: vi.fn((_title: string, _description: string) => {
@@ -61,10 +56,27 @@ const PERSONALITY_ID = 'personality-uuid-123';
 const PERSONALITY_NAME = 'Lilith';
 const EXPECTED_PHRASE = 'DELETE LILITH MEMORIES';
 
+interface MemoryClientStub {
+  getStats: ReturnType<typeof vi.fn>;
+  issuePurgeToken: ReturnType<typeof vi.fn>;
+  purge: ReturnType<typeof vi.fn>;
+}
+
+function createStub(): MemoryClientStub {
+  return {
+    getStats: vi.fn(),
+    issuePurgeToken: vi.fn(),
+    purge: vi.fn(),
+  };
+}
+
+let stub: MemoryClientStub;
+
 function createMockContext(personality = 'lilith') {
   return {
     user: { id: 'user-123', username: 'testuser', globalName: 'testuser' },
     interaction: {
+      user: { id: 'user-123', username: 'testuser' },
       options: {
         getString: (name: string, _required?: boolean) =>
           name === 'character' ? personality : null,
@@ -120,7 +132,7 @@ function createMockModalInteraction(
   const messageEdit = vi.fn().mockResolvedValue(undefined);
   return {
     customId,
-    user: { id: opts.userId ?? 'user-123' },
+    user: { id: opts.userId ?? 'user-123', username: 'testuser' },
     fields: {
       getTextInputValue: vi.fn((_fieldId: string) => phrase),
     },
@@ -146,6 +158,8 @@ function createMockModalInteraction(
 
 beforeEach(() => {
   vi.clearAllMocks();
+  stub = createStub();
+  clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
 });
 
 describe('handlePurge (slash command entry)', () => {
@@ -162,7 +176,7 @@ describe('handlePurge (slash command entry)', () => {
 
   it('shows error when stats API fails', async () => {
     mockResolvePersonalityId.mockResolvedValue(PERSONALITY_ID);
-    mockCallGatewayApi.mockResolvedValue({ ok: false, status: 500, error: 'Server error' });
+    stub.getStats.mockResolvedValue(makeErr(500, 'Server error'));
     const context = createMockContext();
 
     await handlePurge(context);
@@ -174,7 +188,7 @@ describe('handlePurge (slash command entry)', () => {
 
   it('shows 404 message when personality not in stats', async () => {
     mockResolvePersonalityId.mockResolvedValue(PERSONALITY_ID);
-    mockCallGatewayApi.mockResolvedValue({ ok: false, status: 404, error: 'Not found' });
+    stub.getStats.mockResolvedValue(makeErr(404, 'Not found'));
     const context = createMockContext();
 
     await handlePurge(context);
@@ -186,16 +200,18 @@ describe('handlePurge (slash command entry)', () => {
 
   it('shows "no memories" message when nothing to purge', async () => {
     mockResolvePersonalityId.mockResolvedValue(PERSONALITY_ID);
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
+    stub.getStats.mockResolvedValue(
+      makeOk({
         personalityId: PERSONALITY_ID,
         personalityName: PERSONALITY_NAME,
         personaId: 'persona-123',
         totalCount: 0,
         lockedCount: 0,
-      },
-    });
+        oldestMemory: null,
+        newestMemory: null,
+        focusModeEnabled: false,
+      })
+    );
     const context = createMockContext();
 
     await handlePurge(context);
@@ -207,16 +223,18 @@ describe('handlePurge (slash command entry)', () => {
 
   it('renders warning embed + buttons (does NOT awaitMessageComponent)', async () => {
     mockResolvePersonalityId.mockResolvedValue(PERSONALITY_ID);
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
+    stub.getStats.mockResolvedValue(
+      makeOk({
         personalityId: PERSONALITY_ID,
         personalityName: PERSONALITY_NAME,
         personaId: 'persona-123',
         totalCount: 10,
         lockedCount: 2,
-      },
-    });
+        oldestMemory: null,
+        newestMemory: null,
+        focusModeEnabled: false,
+      })
+    );
     const context = createMockContext();
 
     await handlePurge(context);
@@ -333,32 +351,30 @@ describe('handlePurgeModal (modal submission)', () => {
     expect(interaction.reply).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('did not match') })
     );
-    expect(mockCallGatewayApi).not.toHaveBeenCalled();
+    expect(stub.issuePurgeToken).not.toHaveBeenCalled();
+    expect(stub.purge).not.toHaveBeenCalled();
   });
 
   it('accepts case-mismatched confirmation phrase (case-insensitive compare matches API)', async () => {
     // Case-insensitive compare matches the api-gateway's own .toUpperCase()
     // validation. A user typing the phrase in lowercase shouldn't fail the
     // client gate when the server would accept it.
-    mockCallGatewayApi
-      .mockResolvedValueOnce({
-        ok: true,
-        data: {
-          purgeToken: 'purge_test0000test0002',
-          personalityId: PERSONALITY_ID,
-          personalityName: PERSONALITY_NAME,
-        },
+    stub.issuePurgeToken.mockResolvedValueOnce(
+      makeOk({
+        purgeToken: 'purge_test0000test0002',
+        personalityId: PERSONALITY_ID,
+        personalityName: PERSONALITY_NAME,
       })
-      .mockResolvedValueOnce({
-        ok: true,
-        data: {
-          deletedCount: 0,
-          lockedPreserved: 0,
-          personalityId: PERSONALITY_ID,
-          personalityName: PERSONALITY_NAME,
-          message: 'ok',
-        },
-      });
+    );
+    stub.purge.mockResolvedValueOnce(
+      makeOk({
+        deletedCount: 0,
+        lockedPreserved: 0,
+        personalityId: PERSONALITY_ID,
+        personalityName: PERSONALITY_NAME,
+        message: 'ok',
+      })
+    );
 
     const interaction = createMockModalInteraction('delete lilith memories');
     await handlePurgeModal(interaction);
@@ -367,62 +383,54 @@ describe('handlePurgeModal (modal submission)', () => {
     expect(interaction.reply).not.toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('did not match') })
     );
-    expect(mockCallGatewayApi).toHaveBeenCalledTimes(2);
+    expect(stub.issuePurgeToken).toHaveBeenCalledTimes(1);
+    expect(stub.purge).toHaveBeenCalledTimes(1);
   });
 
   it('trims whitespace before validating and forwards trimmed phrase to /purge/token', async () => {
-    mockCallGatewayApi
-      .mockResolvedValueOnce({
-        ok: true,
-        data: {
-          purgeToken: 'purge_test0000test0001',
-          personalityId: PERSONALITY_ID,
-          personalityName: PERSONALITY_NAME,
-        },
+    stub.issuePurgeToken.mockResolvedValueOnce(
+      makeOk({
+        purgeToken: 'purge_test0000test0001',
+        personalityId: PERSONALITY_ID,
+        personalityName: PERSONALITY_NAME,
       })
-      .mockResolvedValueOnce({
-        ok: true,
-        data: {
-          deletedCount: 5,
-          lockedPreserved: 0,
-          personalityId: PERSONALITY_ID,
-          personalityName: PERSONALITY_NAME,
-          message: 'ok',
-        },
-      });
+    );
+    stub.purge.mockResolvedValueOnce(
+      makeOk({
+        deletedCount: 5,
+        lockedPreserved: 0,
+        personalityId: PERSONALITY_ID,
+        personalityName: PERSONALITY_NAME,
+        message: 'ok',
+      })
+    );
     const interaction = createMockModalInteraction(`  ${EXPECTED_PHRASE}  `);
 
     await handlePurgeModal(interaction);
 
-    expect(mockCallGatewayApi).toHaveBeenNthCalledWith(
-      1,
-      '/user/memory/purge/token',
-      expect.objectContaining({
-        body: expect.objectContaining({ confirmationPhrase: EXPECTED_PHRASE }),
-      })
-    );
+    expect(stub.issuePurgeToken).toHaveBeenCalledWith({
+      personalityId: PERSONALITY_ID,
+      confirmationPhrase: EXPECTED_PHRASE,
+    });
   });
 
   it('performs purge as token-handshake (issue → consume) and reports success', async () => {
-    mockCallGatewayApi
-      .mockResolvedValueOnce({
-        ok: true,
-        data: {
-          purgeToken: 'purge_test0000test0001',
-          personalityId: PERSONALITY_ID,
-          personalityName: PERSONALITY_NAME,
-        },
+    stub.issuePurgeToken.mockResolvedValueOnce(
+      makeOk({
+        purgeToken: 'purge_test0000test0001',
+        personalityId: PERSONALITY_ID,
+        personalityName: PERSONALITY_NAME,
       })
-      .mockResolvedValueOnce({
-        ok: true,
-        data: {
-          deletedCount: 8,
-          lockedPreserved: 2,
-          personalityId: PERSONALITY_ID,
-          personalityName: PERSONALITY_NAME,
-          message: 'ok',
-        },
-      });
+    );
+    stub.purge.mockResolvedValueOnce(
+      makeOk({
+        deletedCount: 8,
+        lockedPreserved: 2,
+        personalityId: PERSONALITY_ID,
+        personalityName: PERSONALITY_NAME,
+        message: 'ok',
+      })
+    );
     const interaction = createMockModalInteraction(EXPECTED_PHRASE);
 
     await handlePurgeModal(interaction);
@@ -430,32 +438,18 @@ describe('handlePurgeModal (modal submission)', () => {
     expect(interaction.update).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('Purging') })
     );
-    expect(mockCallGatewayApi).toHaveBeenNthCalledWith(
-      1,
-      '/user/memory/purge/token',
-      expect.objectContaining({
-        method: 'POST',
-        body: expect.objectContaining({
-          personalityId: PERSONALITY_ID,
-          confirmationPhrase: EXPECTED_PHRASE,
-        }),
-      })
-    );
-    expect(mockCallGatewayApi).toHaveBeenNthCalledWith(
-      2,
-      '/user/memory/purge',
-      expect.objectContaining({
-        method: 'POST',
-        body: { purgeToken: 'purge_test0000test0001' },
-      })
-    );
+    expect(stub.issuePurgeToken).toHaveBeenCalledWith({
+      personalityId: PERSONALITY_ID,
+      confirmationPhrase: EXPECTED_PHRASE,
+    });
+    expect(stub.purge).toHaveBeenCalledWith({ purgeToken: 'purge_test0000test0001' });
     expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({ embeds: expect.any(Array) })
     );
   });
 
   it('reports failure when token issuance fails (confirmation rejected server-side)', async () => {
-    mockCallGatewayApi.mockResolvedValueOnce({ ok: false, error: 'Confirmation required' });
+    stub.issuePurgeToken.mockResolvedValueOnce(makeErr(400, 'Confirmation required'));
     const interaction = createMockModalInteraction(EXPECTED_PHRASE);
 
     await handlePurgeModal(interaction);
@@ -464,20 +458,19 @@ describe('handlePurgeModal (modal submission)', () => {
       expect.objectContaining({ content: expect.stringContaining('Failed to confirm') })
     );
     // Only the token-issue call should have run; no execute attempt.
-    expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
+    expect(stub.issuePurgeToken).toHaveBeenCalledTimes(1);
+    expect(stub.purge).not.toHaveBeenCalled();
   });
 
   it('reports failure when execute step fails after token issuance', async () => {
-    mockCallGatewayApi
-      .mockResolvedValueOnce({
-        ok: true,
-        data: {
-          purgeToken: 'purge_test0000test0001',
-          personalityId: PERSONALITY_ID,
-          personalityName: PERSONALITY_NAME,
-        },
+    stub.issuePurgeToken.mockResolvedValueOnce(
+      makeOk({
+        purgeToken: 'purge_test0000test0001',
+        personalityId: PERSONALITY_ID,
+        personalityName: PERSONALITY_NAME,
       })
-      .mockResolvedValueOnce({ ok: false, error: 'Database error' });
+    );
+    stub.purge.mockResolvedValueOnce(makeErr(500, 'Database error'));
     const interaction = createMockModalInteraction(EXPECTED_PHRASE);
 
     await handlePurgeModal(interaction);
@@ -522,7 +515,7 @@ describe('handlePurgeModal (modal submission)', () => {
         content: expect.stringContaining('Only the person who ran this command'),
       })
     );
-    expect(mockCallGatewayApi).not.toHaveBeenCalled();
+    expect(stub.issuePurgeToken).not.toHaveBeenCalled();
   });
 });
 

--- a/services/bot-client/src/commands/memory/purge.ts
+++ b/services/bot-client/src/commands/memory/purge.ts
@@ -26,9 +26,15 @@ import {
   type ButtonInteraction,
   type ModalSubmitInteraction,
 } from 'discord.js';
-import { createLogger, memoryPurgeOptions } from '@tzurot/common-types';
+import {
+  createLogger,
+  memoryPurgeOptions,
+  type PurgeMemoriesResponse,
+  type UserClient,
+} from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
+import { toGatewayUser } from '../../utils/userGatewayClient.js';
+import { clientsFor } from '../../utils/gatewayClients.js';
 import { createDangerEmbed, createSuccessEmbed } from '../../utils/commandHelpers.js';
 import { resolveRequiredPersonality } from './resolveHelpers.js';
 
@@ -46,28 +52,6 @@ const FOOTER_PREFIX = 'Personality: ';
 
 /** Buffer for confirmation phrase input to allow minor whitespace. */
 const CONFIRMATION_PHRASE_LENGTH_BUFFER = 5;
-
-interface StatsResponse {
-  personalityId: string;
-  personalityName: string;
-  personaId: string | null;
-  totalCount: number;
-  lockedCount: number;
-}
-
-interface PurgeResponse {
-  deletedCount: number;
-  lockedPreserved: number;
-  personalityId: string;
-  personalityName: string;
-  message: string;
-}
-
-interface PurgeTokenResponse {
-  purgeToken: string;
-  personalityId: string;
-  personalityName: string;
-}
 
 /** Build the confirmation phrase the user must type to confirm the purge. */
 function getConfirmationPhrase(personalityName: string): string {
@@ -123,6 +107,7 @@ async function assertInvokerOwnership(
 export async function handlePurge(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
   const user = toGatewayUser(context.user);
+  const { userClient } = clientsFor(context.interaction);
   const options = memoryPurgeOptions(context.interaction);
   const personalityInput = options.character();
 
@@ -132,10 +117,7 @@ export async function handlePurge(context: DeferredCommandContext): Promise<void
       return;
     }
 
-    const statsResult = await callGatewayApi<StatsResponse>(
-      `/user/memory/stats?personalityId=${encodeURIComponent(personalityId)}`,
-      { user, method: 'GET' }
-    );
+    const statsResult = await userClient.getStats({ personalityId });
 
     if (!statsResult.ok) {
       const errorMessage =
@@ -285,15 +267,14 @@ export async function handlePurgeButton(interaction: ButtonInteraction): Promise
  * `interaction.editReply`).
  */
 async function executePurgeHandshake(
-  user: ReturnType<typeof toGatewayUser>,
+  userClient: UserClient,
   personalityId: string,
   enteredPhrase: string,
   interaction: ModalSubmitInteraction
-): Promise<PurgeResponse | null> {
-  const tokenResult = await callGatewayApi<PurgeTokenResponse>('/user/memory/purge/token', {
-    user,
-    method: 'POST',
-    body: { personalityId, confirmationPhrase: enteredPhrase },
+): Promise<PurgeMemoriesResponse | null> {
+  const tokenResult = await userClient.issuePurgeToken({
+    personalityId,
+    confirmationPhrase: enteredPhrase,
   });
 
   if (!tokenResult.ok) {
@@ -305,11 +286,7 @@ async function executePurgeHandshake(
     return null;
   }
 
-  const purgeResult = await callGatewayApi<PurgeResponse>('/user/memory/purge', {
-    user,
-    method: 'POST',
-    body: { purgeToken: tokenResult.data.purgeToken },
-  });
+  const purgeResult = await userClient.purge({ purgeToken: tokenResult.data.purgeToken });
 
   if (!purgeResult.ok) {
     await interaction.editReply({
@@ -401,8 +378,13 @@ export async function handlePurgeModal(interaction: ModalSubmitInteraction): Pro
     components: [],
   });
 
-  const user = toGatewayUser(interaction.user);
-  const purgeResult = await executePurgeHandshake(user, personalityId, enteredPhrase, interaction);
+  const { userClient } = clientsFor(interaction);
+  const purgeResult = await executePurgeHandshake(
+    userClient,
+    personalityId,
+    enteredPhrase,
+    interaction
+  );
   if (purgeResult === null) {
     return;
   }

--- a/services/bot-client/src/commands/memory/search.test.ts
+++ b/services/bot-client/src/commands/memory/search.test.ts
@@ -12,9 +12,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { makeOk, makeErr, asUserClient } from '../../test/gatewayClientStubs.js';
 
 const {
-  mockCallGatewayApi,
+  clientsForMock,
   mockResolveOptionalPersonality,
   mockHandleMemorySelect,
   mockHandleMemoryDetailAction,
@@ -22,7 +23,7 @@ const {
   mockFindMemoryListSessionByMessage,
   mockUpdateMemoryListSessionPage,
 } = vi.hoisted(() => ({
-  mockCallGatewayApi: vi.fn(),
+  clientsForMock: vi.fn(),
   mockResolveOptionalPersonality: vi.fn(),
   mockHandleMemorySelect: vi.fn(),
   mockHandleMemoryDetailAction: vi.fn(),
@@ -50,15 +51,9 @@ vi.mock('@tzurot/common-types', async () => {
   };
 });
 
-vi.mock('../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
-    '../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  };
-});
+vi.mock('../../utils/gatewayClients.js', () => ({
+  clientsFor: clientsForMock,
+}));
 
 vi.mock('./resolveHelpers.js', () => ({
   resolveOptionalPersonality: (...args: unknown[]) => mockResolveOptionalPersonality(...args),
@@ -113,6 +108,7 @@ const TEST_QUERY = 'love and loss';
 const sampleResult = {
   id: 'mem-1',
   content: 'A memory about love',
+  personalityId: TEST_PERSONALITY_ID,
   personalityName: 'Test',
   isLocked: false,
   createdAt: '2026-01-01T00:00:00Z',
@@ -127,21 +123,32 @@ const sampleSemanticResponse = {
   searchType: 'semantic' as const,
 };
 
+interface MemoryClientStub {
+  search: ReturnType<typeof vi.fn>;
+}
+
+function createStub(): MemoryClientStub {
+  return { search: vi.fn() };
+}
+
+let stub: MemoryClientStub;
+
 interface MockDeferredContext {
   interaction: {
+    user: { id: string; username: string };
     options: {
       getString: ReturnType<typeof vi.fn>;
       getInteger: ReturnType<typeof vi.fn>;
     };
   };
-  user: { id: string };
+  user: { id: string; username: string };
   editReply: ReturnType<typeof vi.fn>;
 }
 
 interface MockButtonInteraction {
   customId: string;
   message: { id: string };
-  user: { id: string };
+  user: { id: string; username: string };
   deferUpdate: ReturnType<typeof vi.fn>;
   editReply: ReturnType<typeof vi.fn>;
   followUp: ReturnType<typeof vi.fn>;
@@ -163,6 +170,7 @@ function createDeferredContext(
 ): MockDeferredContext {
   return {
     interaction: {
+      user: { id: TEST_USER_ID, username: 'testuser' },
       options: {
         getString: vi.fn((name: string) =>
           name === 'query' ? query : name === 'character' ? null : null
@@ -170,7 +178,7 @@ function createDeferredContext(
         getInteger: vi.fn((name: string) => (name === 'limit' ? limit : null)),
       },
     },
-    user: { id: TEST_USER_ID },
+    user: { id: TEST_USER_ID, username: 'testuser' },
     editReply: vi.fn().mockResolvedValue({ id: TEST_MESSAGE_ID, channelId: TEST_CHANNEL_ID }),
   };
 }
@@ -179,7 +187,7 @@ function createButtonInteraction(customId: string): MockButtonInteraction {
   return {
     customId,
     message: { id: TEST_MESSAGE_ID },
-    user: { id: TEST_USER_ID },
+    user: { id: TEST_USER_ID, username: 'testuser' },
     deferUpdate: vi.fn().mockResolvedValue(undefined),
     editReply: vi.fn().mockResolvedValue({ id: TEST_MESSAGE_ID }),
     followUp: vi.fn().mockResolvedValue(undefined),
@@ -201,8 +209,10 @@ function createSelectInteraction(customId: string): MockSelectInteraction {
 describe('handleSearch', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    stub = createStub();
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
     mockResolveOptionalPersonality.mockResolvedValue(TEST_PERSONALITY_ID);
-    mockCallGatewayApi.mockResolvedValue({ ok: true, data: sampleSemanticResponse });
+    stub.search.mockResolvedValue(makeOk(sampleSemanticResponse));
   });
 
   it('fetches semantic results and saves a search session', async () => {
@@ -210,11 +220,12 @@ describe('handleSearch', () => {
 
     await handleSearch(context as unknown as DeferredCommandContext);
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith(
-      '/user/memory/search',
+    expect(stub.search).toHaveBeenCalledWith(
       expect.objectContaining({
-        method: 'POST',
-        body: expect.objectContaining({ query: TEST_QUERY, limit: 5, offset: 0 }),
+        query: TEST_QUERY,
+        limit: 5,
+        offset: 0,
+        personalityId: TEST_PERSONALITY_ID,
       })
     );
     expect(mockSaveMemoryListSession).toHaveBeenCalledWith(
@@ -237,12 +248,7 @@ describe('handleSearch', () => {
 
     await handleSearch(context as unknown as DeferredCommandContext);
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith(
-      '/user/memory/search',
-      expect.objectContaining({
-        body: expect.objectContaining({ limit: 8 }),
-      })
-    );
+    expect(stub.search).toHaveBeenCalledWith(expect.objectContaining({ limit: 8 }));
     expect(mockSaveMemoryListSession).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({ kind: 'search', pageSize: 8 }),
@@ -251,10 +257,9 @@ describe('handleSearch', () => {
   });
 
   it('handles text fallback searches and persists searchType in session', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: { ...sampleSemanticResponse, searchType: 'text' as const },
-    });
+    stub.search.mockResolvedValue(
+      makeOk({ ...sampleSemanticResponse, searchType: 'text' as const })
+    );
     const context = createDeferredContext();
 
     await handleSearch(context as unknown as DeferredCommandContext);
@@ -278,13 +283,13 @@ describe('handleSearch', () => {
 
     await handleSearch(context as unknown as DeferredCommandContext);
 
-    expect(mockCallGatewayApi).not.toHaveBeenCalled();
+    expect(stub.search).not.toHaveBeenCalled();
     // handleSearch should NOT double-reply — the helper already did
     expect(context.editReply).not.toHaveBeenCalled();
   });
 
   it('shows error when API call fails', async () => {
-    mockCallGatewayApi.mockResolvedValue({ ok: false, error: 'Server error' });
+    stub.search.mockResolvedValue(makeErr(500, 'Server error'));
     const context = createDeferredContext();
 
     await handleSearch(context as unknown as DeferredCommandContext);
@@ -296,7 +301,7 @@ describe('handleSearch', () => {
   });
 
   it('handles unexpected errors', async () => {
-    mockCallGatewayApi.mockRejectedValue(new Error('network'));
+    stub.search.mockRejectedValue(new Error('network'));
     const context = createDeferredContext();
 
     await handleSearch(context as unknown as DeferredCommandContext);
@@ -310,6 +315,8 @@ describe('handleSearch', () => {
 describe('handleSearchPagination', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    stub = createStub();
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
   });
 
   it('re-runs search with new page when session exists', async () => {
@@ -322,21 +329,15 @@ describe('handleSearchPagination', () => {
         pageSize: 5,
       },
     });
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: { ...sampleSemanticResponse, hasMore: true },
-    });
+    stub.search.mockResolvedValue(makeOk({ ...sampleSemanticResponse, hasMore: true }));
 
     const interaction = createButtonInteraction(searchHelpers.build(1, 'all', 'date', null));
 
     await handleSearchPagination(interaction as unknown as ButtonInteraction);
 
     expect(interaction.deferUpdate).toHaveBeenCalled();
-    expect(mockCallGatewayApi).toHaveBeenCalledWith(
-      '/user/memory/search',
-      expect.objectContaining({
-        body: expect.objectContaining({ query: TEST_QUERY, offset: 5 }),
-      })
+    expect(stub.search).toHaveBeenCalledWith(
+      expect.objectContaining({ query: TEST_QUERY, offset: 5 })
     );
     expect(mockUpdateMemoryListSessionPage).toHaveBeenCalledWith(
       expect.objectContaining({ newPage: 1, kind: 'search' })
@@ -355,21 +356,15 @@ describe('handleSearchPagination', () => {
         pageSize: 8,
       },
     });
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: { ...sampleSemanticResponse, hasMore: false },
-    });
+    stub.search.mockResolvedValue(makeOk({ ...sampleSemanticResponse, hasMore: false }));
 
     const interaction = createButtonInteraction(searchHelpers.build(2, 'all', 'date', null));
 
     await handleSearchPagination(interaction as unknown as ButtonInteraction);
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith(
-      '/user/memory/search',
-      expect.objectContaining({
-        // Page 2 of 8-per-page → offset 16, limit 8
-        body: expect.objectContaining({ offset: 16, limit: 8 }),
-      })
+    expect(stub.search).toHaveBeenCalledWith(
+      // Page 2 of 8-per-page → offset 16, limit 8
+      expect.objectContaining({ offset: 16, limit: 8 })
     );
   });
 
@@ -387,21 +382,13 @@ describe('handleSearchPagination', () => {
         searchType: 'text',
       },
     });
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: { ...sampleSemanticResponse, hasMore: false },
-    });
+    stub.search.mockResolvedValue(makeOk({ ...sampleSemanticResponse, hasMore: false }));
 
     const interaction = createButtonInteraction(searchHelpers.build(1, 'all', 'date', null));
 
     await handleSearchPagination(interaction as unknown as ButtonInteraction);
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith(
-      '/user/memory/search',
-      expect.objectContaining({
-        body: expect.objectContaining({ preferTextSearch: true }),
-      })
-    );
+    expect(stub.search).toHaveBeenCalledWith(expect.objectContaining({ preferTextSearch: true }));
   });
 
   it('omits preferTextSearch when session searchType is semantic', async () => {
@@ -415,10 +402,7 @@ describe('handleSearchPagination', () => {
         searchType: 'semantic',
       },
     });
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: { ...sampleSemanticResponse, hasMore: false },
-    });
+    stub.search.mockResolvedValue(makeOk({ ...sampleSemanticResponse, hasMore: false }));
 
     const interaction = createButtonInteraction(searchHelpers.build(1, 'all', 'date', null));
 
@@ -426,11 +410,8 @@ describe('handleSearchPagination', () => {
 
     // fetchSearchResults only sets preferTextSearch in the body when true,
     // so a semantic session must NOT include the field at all.
-    const [, callOptions] = mockCallGatewayApi.mock.calls[0] as [
-      string,
-      { body: Record<string, unknown> },
-    ];
-    expect(callOptions.body).not.toHaveProperty('preferTextSearch');
+    const callArgs = stub.search.mock.calls[0][0] as Record<string, unknown>;
+    expect(callArgs).not.toHaveProperty('preferTextSearch');
   });
 
   it('defers immediately and shows expired message via followUp when session is missing', async () => {
@@ -446,7 +427,7 @@ describe('handleSearchPagination', () => {
     expect(interaction.followUp).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('expired') })
     );
-    expect(mockCallGatewayApi).not.toHaveBeenCalled();
+    expect(stub.search).not.toHaveBeenCalled();
   });
 
   it('shows expired message when session kind is browse', async () => {
@@ -498,6 +479,8 @@ describe('handleSearchSelect', () => {
 describe('refreshSearchList', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    stub = createStub();
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
   });
 
   it('re-fetches and updates message using session state', async () => {
@@ -510,17 +493,14 @@ describe('refreshSearchList', () => {
         pageSize: 5,
       },
     });
-    mockCallGatewayApi.mockResolvedValue({ ok: true, data: sampleSemanticResponse });
+    stub.search.mockResolvedValue(makeOk(sampleSemanticResponse));
 
     const interaction = createButtonInteraction('memory-detail::back');
 
     await refreshSearchList(interaction as unknown as ButtonInteraction);
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith(
-      '/user/memory/search',
-      expect.objectContaining({
-        body: expect.objectContaining({ query: TEST_QUERY, offset: 5 }),
-      })
+    expect(stub.search).toHaveBeenCalledWith(
+      expect.objectContaining({ query: TEST_QUERY, offset: 5 })
     );
     expect(interaction.editReply).toHaveBeenCalled();
   });
@@ -535,15 +515,15 @@ describe('refreshSearchList', () => {
         pageSize: 5,
       },
     });
-    mockCallGatewayApi
-      .mockResolvedValueOnce({ ok: true, data: { results: [], count: 0, hasMore: false } })
-      .mockResolvedValueOnce({ ok: true, data: sampleSemanticResponse });
+    stub.search
+      .mockResolvedValueOnce(makeOk({ results: [], count: 0, hasMore: false }))
+      .mockResolvedValueOnce(makeOk(sampleSemanticResponse));
 
     const interaction = createButtonInteraction('memory-detail::back');
 
     await refreshSearchList(interaction as unknown as ButtonInteraction);
 
-    expect(mockCallGatewayApi).toHaveBeenCalledTimes(2);
+    expect(stub.search).toHaveBeenCalledTimes(2);
     expect(mockUpdateMemoryListSessionPage).toHaveBeenCalledWith(
       expect.objectContaining({ newPage: 1 })
     );
@@ -555,7 +535,7 @@ describe('refreshSearchList', () => {
 
     await refreshSearchList(interaction as unknown as ButtonInteraction);
 
-    expect(mockCallGatewayApi).not.toHaveBeenCalled();
+    expect(stub.search).not.toHaveBeenCalled();
   });
 
   it('no-ops when session kind is browse', async () => {
@@ -566,7 +546,7 @@ describe('refreshSearchList', () => {
 
     await refreshSearchList(interaction as unknown as ButtonInteraction);
 
-    expect(mockCallGatewayApi).not.toHaveBeenCalled();
+    expect(stub.search).not.toHaveBeenCalled();
   });
 
   // Note: a "search session without searchQuery" test was deleted along with

--- a/services/bot-client/src/commands/memory/search.ts
+++ b/services/bot-client/src/commands/memory/search.ts
@@ -24,9 +24,11 @@ import {
   DISCORD_COLORS,
   memorySearchOptions,
   formatDateShort,
+  type UserClient,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi, toGatewayUser, type GatewayUser } from '../../utils/userGatewayClient.js';
+import { toGatewayUser } from '../../utils/userGatewayClient.js';
+import { clientsFor } from '../../utils/gatewayClients.js';
 import {
   createBrowseCustomIdHelpers,
   buildBrowseButtons as buildSharedBrowseButtons,
@@ -35,7 +37,8 @@ import {
   formatPageIndicator,
 } from '../../utils/browse/index.js';
 import { resolveOptionalPersonality } from './resolveHelpers.js';
-import { buildMemoryActionId, handleMemorySelect, type MemoryItem } from './detail.js';
+import { buildMemoryActionId, handleMemorySelect } from './detail.js';
+import type { MemoryItem } from '@tzurot/common-types';
 import { handleMemoryDetailAction } from './detailActionRouter.js';
 import { formatSimilarity, truncateContent } from './formatters.js';
 import {
@@ -224,7 +227,7 @@ function buildSearchView(opts: {
 }
 
 interface FetchSearchOptions {
-  user: GatewayUser;
+  userClient: UserClient;
   query: string;
   personalityId?: string;
   offset: number;
@@ -237,27 +240,15 @@ interface FetchSearchOptions {
  * Fetch search results from API
  */
 async function fetchSearchResults(options: FetchSearchOptions): Promise<SearchResponse | null> {
-  const { user, query, personalityId, offset, limit, preferTextSearch } = options;
+  const { userClient, query, personalityId, offset, limit, preferTextSearch } = options;
 
-  const requestBody: Record<string, unknown> = {
+  const result = await userClient.search({
     query,
     limit,
     offset,
-  };
-
-  if (personalityId !== undefined) {
-    requestBody.personalityId = personalityId;
-  }
-
-  // Optimization: skip semantic search attempt if we know first page fell back to text
-  if (preferTextSearch === true) {
-    requestBody.preferTextSearch = true;
-  }
-
-  const result = await callGatewayApi<SearchResponse>('/user/memory/search', {
-    user,
-    method: 'POST',
-    body: requestBody,
+    ...(personalityId !== undefined && { personalityId }),
+    // Optimization: skip semantic search attempt if we know first page fell back to text
+    ...(preferTextSearch === true && { preferTextSearch: true }),
   });
 
   if (!result.ok) {
@@ -273,6 +264,7 @@ async function fetchSearchResults(options: FetchSearchOptions): Promise<SearchRe
 export async function handleSearch(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
   const user = toGatewayUser(context.user);
+  const { userClient } = clientsFor(context.interaction);
   const options = memorySearchOptions(context.interaction);
   const query = options.query();
   const personalityInput = options.character();
@@ -292,7 +284,7 @@ export async function handleSearch(context: DeferredCommandContext): Promise<voi
 
     // Fetch first page
     const data = await fetchSearchResults({
-      user,
+      userClient,
       query,
       personalityId,
       offset: 0,
@@ -398,9 +390,10 @@ export async function handleSearchPagination(interaction: ButtonInteraction): Pr
 
   const userId = interaction.user.id;
   const newPage = parsed.page;
+  const { userClient } = clientsFor(interaction);
 
   const data = await fetchSearchResults({
-    user: toGatewayUser(interaction.user),
+    userClient,
     query: searchQuery,
     personalityId,
     offset: newPage * pageSize,
@@ -472,13 +465,13 @@ export async function refreshSearchList(interaction: ButtonInteraction): Promise
   const { personalityId, searchQuery, pageSize, searchType } = session.data;
 
   const userId = interaction.user.id;
-  const user = toGatewayUser(interaction.user);
+  const { userClient } = clientsFor(interaction);
 
   const result = await fetchPageWithEmptyFallback({
     currentPage: session.data.currentPage,
     fetchPage: page =>
       fetchSearchResults({
-        user,
+        userClient,
         query: searchQuery,
         personalityId,
         offset: page * pageSize,

--- a/services/bot-client/src/commands/memory/stats.test.ts
+++ b/services/bot-client/src/commands/memory/stats.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { handleStats } from './stats.js';
+import { makeOk, makeErr, asUserClient } from '../../test/gatewayClientStubs.js';
 
 // Mock common-types
 vi.mock('@tzurot/common-types', async importOriginal => {
@@ -19,17 +20,10 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
-// Mock userGatewayClient
-const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
-    '../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  };
-});
+const clientsForMock = vi.hoisted(() => vi.fn());
+vi.mock('../../utils/gatewayClients.js', () => ({
+  clientsFor: clientsForMock,
+}));
 
 // Mock commandHelpers
 const mockCreateInfoEmbed = vi.fn(() => ({
@@ -46,17 +40,29 @@ vi.mock('./autocomplete.js', () => ({
   resolvePersonalityId: (...args: unknown[]) => mockResolvePersonalityId(...args),
 }));
 
+interface MemoryClientStub {
+  getStats: ReturnType<typeof vi.fn>;
+}
+
+function createStub(): MemoryClientStub {
+  return { getStats: vi.fn() };
+}
+
 describe('handleStats', () => {
   const mockEditReply = vi.fn();
+  let stub: MemoryClientStub;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    stub = createStub();
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
   });
 
   function createMockContext(personalitySlug: string = 'lilith') {
     return {
       user: { id: '123456789', username: 'testuser', globalName: 'testuser' },
       interaction: {
+        user: { id: '123456789', username: 'testuser' },
         options: {
           getString: (name: string, _required?: boolean) => {
             if (name === 'character') return personalitySlug;
@@ -70,9 +76,8 @@ describe('handleStats', () => {
 
   it('should get stats successfully', async () => {
     mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
+    stub.getStats.mockResolvedValue(
+      makeOk({
         personalityId: 'personality-uuid-123',
         personalityName: 'Lilith',
         personaId: 'persona-123',
@@ -81,8 +86,8 @@ describe('handleStats', () => {
         oldestMemory: '2025-01-01T00:00:00.000Z',
         newestMemory: '2025-06-15T12:00:00.000Z',
         focusModeEnabled: false,
-      },
-    });
+      })
+    );
 
     const context = createMockContext();
     await handleStats(context);
@@ -91,13 +96,7 @@ describe('handleStats', () => {
       { discordId: '123456789', username: 'testuser', displayName: 'testuser' },
       'lilith'
     );
-    expect(mockCallGatewayApi).toHaveBeenCalledWith(
-      '/user/memory/stats?personalityId=personality-uuid-123',
-      {
-        user: { discordId: '123456789', username: 'testuser', displayName: 'testuser' },
-        method: 'GET',
-      }
-    );
+    expect(stub.getStats).toHaveBeenCalledWith({ personalityId: 'personality-uuid-123' });
     expect(mockCreateInfoEmbed).toHaveBeenCalledWith(
       'Memory Statistics',
       expect.stringContaining('Lilith')
@@ -110,9 +109,8 @@ describe('handleStats', () => {
     mockCreateInfoEmbed.mockReturnValue(mockEmbed);
     mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
 
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
+    stub.getStats.mockResolvedValue(
+      makeOk({
         personalityId: 'personality-uuid-123',
         personalityName: 'Lilith',
         personaId: 'persona-123',
@@ -121,8 +119,8 @@ describe('handleStats', () => {
         oldestMemory: '2025-01-01T00:00:00.000Z',
         newestMemory: '2025-06-15T12:00:00.000Z',
         focusModeEnabled: true,
-      },
-    });
+      })
+    );
 
     const context = createMockContext();
     await handleStats(context);
@@ -138,9 +136,8 @@ describe('handleStats', () => {
     mockCreateInfoEmbed.mockReturnValue(mockEmbed);
     mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
 
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
+    stub.getStats.mockResolvedValue(
+      makeOk({
         personalityId: 'personality-uuid-123',
         personalityName: 'Lilith',
         personaId: null,
@@ -149,8 +146,8 @@ describe('handleStats', () => {
         oldestMemory: null,
         newestMemory: null,
         focusModeEnabled: false,
-      },
-    });
+      })
+    );
 
     const context = createMockContext();
     await handleStats(context);
@@ -179,16 +176,12 @@ describe('handleStats', () => {
     expect(mockEditReply).toHaveBeenCalledWith({
       content: expect.stringContaining('unknown'),
     });
-    expect(mockCallGatewayApi).not.toHaveBeenCalled();
+    expect(stub.getStats).not.toHaveBeenCalled();
   });
 
   it('should handle personality not found (404)', async () => {
     mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
-    mockCallGatewayApi.mockResolvedValue({
-      ok: false,
-      status: 404,
-      error: 'Not found',
-    });
+    stub.getStats.mockResolvedValue(makeErr(404, 'Not found'));
 
     const context = createMockContext('unknown');
     await handleStats(context);
@@ -200,11 +193,7 @@ describe('handleStats', () => {
 
   it('should handle generic API error', async () => {
     mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
-    mockCallGatewayApi.mockResolvedValue({
-      ok: false,
-      status: 500,
-      error: 'Server error',
-    });
+    stub.getStats.mockResolvedValue(makeErr(500, 'Server error'));
 
     const context = createMockContext();
     await handleStats(context);

--- a/services/bot-client/src/commands/memory/stats.ts
+++ b/services/bot-client/src/commands/memory/stats.ts
@@ -6,22 +6,12 @@
 import { escapeMarkdown } from 'discord.js';
 import { createLogger, memoryStatsOptions, formatDateTimeCompact } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
+import { toGatewayUser } from '../../utils/userGatewayClient.js';
+import { clientsFor } from '../../utils/gatewayClients.js';
 import { createInfoEmbed } from '../../utils/commandHelpers.js';
 import { resolveRequiredPersonality } from './resolveHelpers.js';
 
 const logger = createLogger('memory-stats');
-
-interface StatsResponse {
-  personalityId: string;
-  personalityName: string;
-  personaId: string | null;
-  totalCount: number;
-  lockedCount: number;
-  oldestMemory: string | null;
-  newestMemory: string | null;
-  focusModeEnabled: boolean;
-}
 
 /** Format date or return 'N/A' for null */
 function formatDateOrNA(dateStr: string | null): string {
@@ -34,6 +24,7 @@ function formatDateOrNA(dateStr: string | null): string {
 export async function handleStats(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
   const user = toGatewayUser(context.user);
+  const { userClient } = clientsFor(context.interaction);
   const options = memoryStatsOptions(context.interaction);
   const personalityInput = options.character();
 
@@ -44,13 +35,7 @@ export async function handleStats(context: DeferredCommandContext): Promise<void
       return;
     }
 
-    const result = await callGatewayApi<StatsResponse>(
-      `/user/memory/stats?personalityId=${encodeURIComponent(personalityId)}`,
-      {
-        user,
-        method: 'GET',
-      }
-    );
+    const result = await userClient.getStats({ personalityId });
 
     if (!result.ok) {
       const errorMessage =


### PR DESCRIPTION
## Summary

Phase 4 of the route-manifest epic — migrates all 8 production memory command files in bot-client from `callGatewayApi` to the typed `userClient`. Eliminates 26 raw call sites, propagates end-to-end type safety through detail wrappers, and surfaces two latent schema-correctness bugs.

## Schema correctness fixes

The route-manifest epic's typed-client codegen surfaces handler/schema divergences that the loose `callGatewayApi<T>()` shape silently absorbed. Two fixes ride alongside the migration:

- **`previewToken` / `purgeToken` brand round-trip.** `BatchDeletePreviewResponseSchema.previewToken` and `IssuePurgeTokenResponseSchema.purgeToken` now use the existing `PreviewTokenSchema` / `PurgeTokenSchema` brands instead of plain `z.string()`. The gateway always emits `preview_…` / `purge_…` formatted tokens; the brand now flows through to the next-call's input so the handshake (preview→batchDelete, issueToken→purge) is type-checked end-to-end. A caller can no longer paste an arbitrary string into the second call.

- **`IncognitoSession.timeRemaining` is a string, not a number.** `IncognitoSessionWithRemainingSchema.timeRemaining` and `EnableIncognitoResponseSchema.timeRemaining` were declared as `z.number().nullable()`, but `IncognitoSessionManager.getTimeRemaining` always returns a human-formatted string (`'1 hour'`, `'Until manually disabled'`, `'Expired'`). The bot-client treated the field as a string regardless, so this is a contract fix only — no behavior change. Contract tests updated to assert against the corrected shape.

## Bot-client migrations (production files)

- `stats.ts`, `focus.ts`, `search.ts`, `browse.ts`, `batchDelete.ts`, `purge.ts`, `incognito.ts` — converted to `clientsFor(context.interaction).userClient` and the typed methods on it. Local response interfaces dropped in favor of schema-derived types.
- `detailApi.ts` — the 4 wrapper helpers (`fetchMemory`, `updateMemory`, `setMemoryLock`, `deleteMemory`) now take `userClient: UserClient` instead of `user: GatewayUser`. Local `MemoryItem` interface dropped in favor of the schema-derived re-export from common-types.
- `detail.ts` and `detailModals.ts` — updated to pass `userClient` through the wrappers above.

The `resolveOptionalPersonality` / `resolveRequiredPersonality` helpers in `resolveHelpers.ts` remain on the old `GatewayUser` shape because they call `getCachedPersonalities`, which still uses `callGatewayApi`. The autocomplete-cache migration is a separate follow-up that affects multiple command groups (memory, character, persona, shapes), out of scope here.

## Test rewrites

All 9 test files were rewritten to use the shared `gatewayClientStubs` pattern (`makeOk` / `makeErr` / `asUserClient`):

- `stats.test.ts`, `focus.test.ts`, `search.test.ts`, `browse.test.ts`, `batchDelete.test.ts`, `purge.test.ts`, `incognito.test.ts`, `detailApi.test.ts`, `detail.test.ts`, `detailModals.test.ts` — 286 tests passing.

## Burn-down

`callGatewayApi`: 141 → 115 (-26).

## Test plan

- [x] `pnpm test` — all suites green (4979 bot-client + 2802 common-types + 985 tooling + 2053 api-gateway + 3098 ai-worker)
- [x] `pnpm quality` — lint + cpd + depcruise + typecheck + typecheck:spec all clean
- [ ] `claude-review` post-CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)