### PR TITLE
feat(bot-client): pr-2j — autocompleteCache + settingsUpdateFactory + voice → userClient

### DIFF
--- a/packages/common-types/src/clients/_generated/owner-client.ts
+++ b/packages/common-types/src/clients/_generated/owner-client.ts
@@ -38,7 +38,7 @@ export interface OwnerClientOptions {
 export class OwnerClient {
   private readonly baseUrl: string;
   private readonly serviceSecret: string;
-  private readonly actor: ActorDiscordId;
+  readonly actor: ActorDiscordId;
 
   constructor(options: OwnerClientOptions) {
     this.baseUrl = options.baseUrl;

--- a/packages/common-types/src/clients/_generated/user-client.ts
+++ b/packages/common-types/src/clients/_generated/user-client.ts
@@ -306,6 +306,7 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.listTtsOverrides.output,
+      timeoutMs: ROUTE_MANIFEST.listTtsOverrides.timeoutMs,
     });
   }
 
@@ -326,6 +327,7 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.setTtsOverride.output,
+      timeoutMs: ROUTE_MANIFEST.setTtsOverride.timeoutMs,
     });
   }
 
@@ -342,6 +344,7 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.deleteTtsOverride.output,
+      timeoutMs: ROUTE_MANIFEST.deleteTtsOverride.timeoutMs,
     });
   }
 
@@ -381,6 +384,7 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.setTtsDefaultConfig.output,
+      timeoutMs: ROUTE_MANIFEST.setTtsDefaultConfig.timeoutMs,
     });
   }
 
@@ -397,6 +401,7 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.clearTtsDefaultConfig.output,
+      timeoutMs: ROUTE_MANIFEST.clearTtsDefaultConfig.timeoutMs,
     });
   }
 
@@ -436,6 +441,7 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.setSttDefaultProvider.output,
+      timeoutMs: ROUTE_MANIFEST.setSttDefaultProvider.timeoutMs,
     });
   }
 
@@ -452,6 +458,7 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.clearSttDefaultProvider.output,
+      timeoutMs: ROUTE_MANIFEST.clearSttDefaultProvider.timeoutMs,
     });
   }
 
@@ -1230,6 +1237,7 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.getVoiceResolution.output,
+      timeoutMs: ROUTE_MANIFEST.getVoiceResolution.timeoutMs,
     });
   }
 
@@ -1285,6 +1293,7 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.clearVoices.output,
+      timeoutMs: ROUTE_MANIFEST.clearVoices.timeoutMs,
     });
   }
 
@@ -1301,6 +1310,7 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.deleteVoice.output,
+      timeoutMs: ROUTE_MANIFEST.deleteVoice.timeoutMs,
     });
   }
 

--- a/packages/common-types/src/clients/_generated/user-client.ts
+++ b/packages/common-types/src/clients/_generated/user-client.ts
@@ -214,6 +214,7 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.listUserTtsConfigs.output,
+      timeoutMs: ROUTE_MANIFEST.listUserTtsConfigs.timeoutMs,
     });
   }
 
@@ -1248,6 +1249,7 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.listVoices.output,
+      timeoutMs: ROUTE_MANIFEST.listVoices.timeoutMs,
     });
   }
 
@@ -1725,6 +1727,7 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.updatePersonalityOverrides.output,
+      timeoutMs: ROUTE_MANIFEST.updatePersonalityOverrides.timeoutMs,
     });
   }
 
@@ -1778,6 +1781,7 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.updatePersonalityConfigDefaults.output,
+      timeoutMs: ROUTE_MANIFEST.updatePersonalityConfigDefaults.timeoutMs,
     });
   }
 

--- a/packages/common-types/src/clients/_generated/user-client.ts
+++ b/packages/common-types/src/clients/_generated/user-client.ts
@@ -41,8 +41,8 @@ export interface UserClientOptions {
 export class UserClient {
   private readonly baseUrl: string;
   private readonly serviceSecret: string;
-  private readonly actor: ActorDiscordId;
-  private readonly user: GatewayUser;
+  readonly actor: ActorDiscordId;
+  readonly user: GatewayUser;
 
   constructor(options: UserClientOptions) {
     this.baseUrl = options.baseUrl;
@@ -580,6 +580,7 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.listPersonalities.output,
+      timeoutMs: ROUTE_MANIFEST.listPersonalities.timeoutMs,
     });
   }
 
@@ -689,6 +690,7 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.listPersonas.output,
+      timeoutMs: ROUTE_MANIFEST.listPersonas.timeoutMs,
     });
   }
 
@@ -1847,6 +1849,7 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.listShapes.output,
+      timeoutMs: ROUTE_MANIFEST.listShapes.timeoutMs,
     });
   }
 

--- a/packages/common-types/src/routes/user/config-overrides.ts
+++ b/packages/common-types/src/routes/user/config-overrides.ts
@@ -113,10 +113,8 @@ export const userConfigOverrideRoutes = {
     input: ConfigOverridesSchema,
     output: UpdatePersonalityConfigOverridesResponseSchema,
     requiresProvisionedUser: true,
-    // Called from settingsUpdateFactory in a deferred dashboard context;
-    // mirrors the resolve-side timeout so PATCH+resolve handshakes have a
-    // consistent budget. Replaces the per-call timeout the legacy
-    // callGatewayApi callsite threaded through.
+    // PATCH + resolve form a paired handshake; consistent budget across
+    // both prevents the resolve from timing out after a successful PATCH.
     timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
@@ -166,8 +164,7 @@ export const userConfigOverrideRoutes = {
     input: ConfigOverridesSchema,
     output: UpdateConfigDefaultsResponseSchema,
     requiresProvisionedUser: true,
-    // Same deferred-context callers as updatePersonalityOverrides; the
-    // personality-tier PATCH+resolve handshake needs the longer budget.
+    // Same PATCH + resolve handshake invariant as updatePersonalityOverrides.
     timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 } as const satisfies Record<string, RouteDef>;

--- a/packages/common-types/src/routes/user/config-overrides.ts
+++ b/packages/common-types/src/routes/user/config-overrides.ts
@@ -113,6 +113,11 @@ export const userConfigOverrideRoutes = {
     input: ConfigOverridesSchema,
     output: UpdatePersonalityConfigOverridesResponseSchema,
     requiresProvisionedUser: true,
+    // Called from settingsUpdateFactory in a deferred dashboard context;
+    // mirrors the resolve-side timeout so PATCH+resolve handshakes have a
+    // consistent budget. Replaces the per-call timeout the legacy
+    // callGatewayApi callsite threaded through.
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   clearPersonalityOverrides: {
@@ -161,5 +166,8 @@ export const userConfigOverrideRoutes = {
     input: ConfigOverridesSchema,
     output: UpdateConfigDefaultsResponseSchema,
     requiresProvisionedUser: true,
+    // Same deferred-context callers as updatePersonalityOverrides; the
+    // personality-tier PATCH+resolve handshake needs the longer budget.
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 } as const satisfies Record<string, RouteDef>;

--- a/packages/common-types/src/routes/user/configs.ts
+++ b/packages/common-types/src/routes/user/configs.ts
@@ -172,6 +172,10 @@ export const userConfigRoutes = {
     output: ListTtsConfigsResponseSchema,
     requiresProvisionedUser: true,
     meta: { safeRead: true },
+    // Same dual-use as listVoices: autocomplete and deferred-context
+    // BYOK probe (guestModeValidation). Longer budget protects the
+    // deferred caller.
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   getUserTtsConfig: {

--- a/packages/common-types/src/routes/user/configs.ts
+++ b/packages/common-types/src/routes/user/configs.ts
@@ -57,6 +57,7 @@ import {
   ClearDefaultConfigResponseSchema,
   DeleteModelOverrideResponseSchema,
 } from '../../schemas/api/index.js';
+import { GATEWAY_TIMEOUTS } from '../../constants/discord.js';
 import type { RouteDef } from '../types.js';
 
 // Shared CRUD-detail path constants — GET/PUT/DELETE on the same :id share
@@ -172,9 +173,9 @@ export const userConfigRoutes = {
     output: ListTtsConfigsResponseSchema,
     requiresProvisionedUser: true,
     meta: { safeRead: true },
-    // Same dual-use as listVoices: autocomplete and deferred-context
-    // BYOK probe (guestModeValidation). Longer budget protects the
-    // deferred caller.
+    // Dual-context route: autocomplete clients are bounded by Discord's
+    // own 3s deadline, so the longer budget exists for the BYOK-probe
+    // path where a list fetch precedes downstream gating logic.
     timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
@@ -233,6 +234,7 @@ export const userConfigRoutes = {
     output: ListTtsOverridesResponseSchema,
     requiresProvisionedUser: true,
     meta: { safeRead: true },
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   setTtsOverride: {
@@ -244,6 +246,7 @@ export const userConfigRoutes = {
     output: SetTtsOverrideResponseSchema,
     requiresProvisionedUser: true,
     meta: { idempotent: true },
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   deleteTtsOverride: {
@@ -254,6 +257,7 @@ export const userConfigRoutes = {
     params: { personalityId: z.string() },
     output: DeleteTtsOverrideResponseSchema,
     requiresProvisionedUser: true,
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   getTtsDefaultConfig: {
@@ -275,6 +279,7 @@ export const userConfigRoutes = {
     output: SetTtsDefaultConfigResponseSchema,
     requiresProvisionedUser: true,
     meta: { idempotent: true },
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   clearTtsDefaultConfig: {
@@ -284,6 +289,7 @@ export const userConfigRoutes = {
     id: 'clearTtsDefaultConfig',
     output: ClearTtsDefaultConfigResponseSchema,
     requiresProvisionedUser: true,
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   // ============================================================================
@@ -309,6 +315,7 @@ export const userConfigRoutes = {
     output: SetSttDefaultProviderResponseSchema,
     requiresProvisionedUser: true,
     meta: { idempotent: true },
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   clearSttDefaultProvider: {
@@ -318,6 +325,7 @@ export const userConfigRoutes = {
     id: 'clearSttDefaultProvider',
     output: ClearSttDefaultProviderResponseSchema,
     requiresProvisionedUser: true,
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   // ============================================================================

--- a/packages/common-types/src/routes/user/ownership.ts
+++ b/packages/common-types/src/routes/user/ownership.ts
@@ -52,6 +52,10 @@ export const userOwnershipRoutes = {
     output: ListPersonalitiesResponseSchema,
     requiresProvisionedUser: true,
     meta: { safeRead: true },
+    // Called only from autocomplete via getCachedPersonalities. Pinned at
+    // the manifest level so a future transport.ts default change can't
+    // silently shift the budget past Discord's 3s autocomplete deadline.
+    timeoutMs: GATEWAY_TIMEOUTS.AUTOCOMPLETE,
   },
 
   getPersonality: {
@@ -125,6 +129,8 @@ export const userOwnershipRoutes = {
     output: ListPersonasResponseSchema,
     requiresProvisionedUser: true,
     meta: { safeRead: true },
+    // Same autocomplete-only pinning as listPersonalities.
+    timeoutMs: GATEWAY_TIMEOUTS.AUTOCOMPLETE,
   },
 
   getPersona: {

--- a/packages/common-types/src/routes/user/ownership.ts
+++ b/packages/common-types/src/routes/user/ownership.ts
@@ -52,9 +52,9 @@ export const userOwnershipRoutes = {
     output: ListPersonalitiesResponseSchema,
     requiresProvisionedUser: true,
     meta: { safeRead: true },
-    // Called only from autocomplete via getCachedPersonalities. Pinned at
-    // the manifest level so a future transport.ts default change can't
-    // silently shift the budget past Discord's 3s autocomplete deadline.
+    // Autocomplete-only consumer; pinned at the manifest so a future
+    // transport-default change can't silently overshoot Discord's 3s
+    // autocomplete deadline.
     timeoutMs: GATEWAY_TIMEOUTS.AUTOCOMPLETE,
   },
 

--- a/packages/common-types/src/routes/user/resources.ts
+++ b/packages/common-types/src/routes/user/resources.ts
@@ -314,6 +314,11 @@ export const userResourceRoutes = {
     output: ListVoicesResponseSchema,
     requiresProvisionedUser: true,
     meta: { safeRead: true },
+    // Called from both autocomplete (clientside has the 3s Discord budget)
+    // and deferred contexts (voice browse / clear / guestModeValidation
+    // probe). The longer budget protects the deferred callers; autocomplete
+    // calls die at 3s via Discord regardless.
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   listVoiceModels: {

--- a/packages/common-types/src/routes/user/resources.ts
+++ b/packages/common-types/src/routes/user/resources.ts
@@ -54,6 +54,7 @@ import {
   ClearVoicesResponseSchema,
   DeleteVoiceResponseSchema,
 } from '../../schemas/api/index.js';
+import { GATEWAY_TIMEOUTS } from '../../constants/discord.js';
 import type { RouteDef } from '../types.js';
 
 const CHANNEL_CONFIG_OVERRIDES_PATH = '/channel/:channelId/config-overrides';
@@ -300,6 +301,9 @@ export const userResourceRoutes = {
     output: GetVoiceResolutionResponseSchema,
     requiresProvisionedUser: true,
     meta: { safeRead: true },
+    // Cascade resolution can chain multiple Prisma reads — the autocomplete
+    // default isn't enough headroom for the slowest legs.
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   // ============================================================================
@@ -314,10 +318,9 @@ export const userResourceRoutes = {
     output: ListVoicesResponseSchema,
     requiresProvisionedUser: true,
     meta: { safeRead: true },
-    // Called from both autocomplete (clientside has the 3s Discord budget)
-    // and deferred contexts (voice browse / clear / guestModeValidation
-    // probe). The longer budget protects the deferred callers; autocomplete
-    // calls die at 3s via Discord regardless.
+    // Dual-context route: autocomplete callers are bounded by Discord's
+    // own 3s deadline, so the longer budget exists for the deferred-handler
+    // paths where a list fetch may run alongside other Prisma work.
     timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
@@ -338,6 +341,9 @@ export const userResourceRoutes = {
     id: 'clearVoices',
     output: ClearVoicesResponseSchema,
     requiresProvisionedUser: true,
+    // Iterates per-voice DELETEs against the third-party audio provider;
+    // a user with many cloned voices can exceed the DEFERRED budget.
+    timeoutMs: GATEWAY_TIMEOUTS.BULK_OPERATION,
   },
 
   deleteVoice: {
@@ -348,5 +354,6 @@ export const userResourceRoutes = {
     params: { provider: z.string(), voiceId: z.string() },
     output: DeleteVoiceResponseSchema,
     requiresProvisionedUser: true,
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 } as const satisfies Record<string, RouteDef>;

--- a/packages/common-types/src/routes/user/shapes.ts
+++ b/packages/common-types/src/routes/user/shapes.ts
@@ -23,6 +23,7 @@ import {
   StartShapesExportResponseSchema,
   ListShapesExportJobsResponseSchema,
 } from '../../schemas/api/index.js';
+import { GATEWAY_TIMEOUTS } from '../../constants/discord.js';
 import type { RouteDef } from '../types.js';
 
 const BASE = '/shapes';
@@ -73,6 +74,10 @@ export const userShapesRoutes = {
     output: ListShapesResponseSchema,
     requiresProvisionedUser: true,
     meta: { safeRead: true },
+    // Pin to the 3s Discord autocomplete budget at the manifest level so a
+    // future transport.ts default change can't silently shift it. Called
+    // only from autocomplete via getCachedShapes.
+    timeoutMs: GATEWAY_TIMEOUTS.AUTOCOMPLETE,
   },
 
   // ============================================================================

--- a/packages/common-types/src/routes/user/shapes.ts
+++ b/packages/common-types/src/routes/user/shapes.ts
@@ -74,9 +74,9 @@ export const userShapesRoutes = {
     output: ListShapesResponseSchema,
     requiresProvisionedUser: true,
     meta: { safeRead: true },
-    // Pin to the 3s Discord autocomplete budget at the manifest level so a
-    // future transport.ts default change can't silently shift it. Called
-    // only from autocomplete via getCachedShapes.
+    // Autocomplete-only consumer; pinned at the manifest so a future
+    // transport-default change can't silently overshoot Discord's 3s
+    // autocomplete deadline.
     timeoutMs: GATEWAY_TIMEOUTS.AUTOCOMPLETE,
   },
 

--- a/packages/tooling/src/codegen/client-builder.ts
+++ b/packages/tooling/src/codegen/client-builder.ts
@@ -119,11 +119,11 @@ function buildClassDecl(className: string, flavor: ClientFlavor): string {
   ];
 
   if (flavor === 'owner' || flavor === 'user') {
-    fields.push(`  private readonly actor: ActorDiscordId;`);
+    fields.push(`  readonly actor: ActorDiscordId;`);
     ctorAssigns.push(`    this.actor = options.actor;`);
   }
   if (flavor === 'user') {
-    fields.push(`  private readonly user: GatewayUser;`);
+    fields.push(`  readonly user: GatewayUser;`);
     ctorAssigns.push(`    this.user = options.user;`);
   }
 

--- a/services/bot-client/src/commands/character/autocomplete.test.ts
+++ b/services/bot-client/src/commands/character/autocomplete.test.ts
@@ -12,6 +12,12 @@ vi.mock('../../utils/autocomplete/autocompleteCache.js', () => ({
   getCachedPersonalities: (...args: unknown[]) => mockGetCachedPersonalities(...args),
 }));
 
+// Mock clientsFor — the cache mock returns ok directly, so a structurally
+// empty userClient stub suffices.
+vi.mock('../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: {} })),
+}));
+
 // Mock logger
 vi.mock('@tzurot/common-types', async () => {
   const actual = await vi.importActual('@tzurot/common-types');

--- a/services/bot-client/src/commands/character/chat.test.ts
+++ b/services/bot-client/src/commands/character/chat.test.ts
@@ -63,17 +63,11 @@ vi.mock('../../utils/autocomplete/autocompleteCache.js', () => ({
   getCachedPersonalities: (...args: unknown[]) => mockGetCachedPersonalities(...args),
 }));
 
-vi.mock('../../utils/userGatewayClient.js', async importOriginal => {
-  const actual = (await importOriginal()) as Record<string, unknown>;
-  return {
-    ...actual,
-    toGatewayUser: vi.fn((user: { id: string; displayName: string }) => ({
-      discordId: user.id,
-      username: user.displayName,
-      displayName: user.displayName,
-    })),
-  };
-});
+// Mock clientsFor — the cache + persona resolution mocks return data
+// directly, so a structurally empty userClient stub suffices.
+vi.mock('../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: {} })),
+}));
 
 vi.mock('../../redis.js', () => ({
   redisService: { storeWebhookMessage: vi.fn() },

--- a/services/bot-client/src/commands/character/overrides.test.ts
+++ b/services/bot-client/src/commands/character/overrides.test.ts
@@ -32,32 +32,22 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 interface StubUserClient {
   getPersonality: ReturnType<typeof vi.fn>;
   resolveCascade: ReturnType<typeof vi.fn>;
+  updatePersonalityOverrides: ReturnType<typeof vi.fn>;
 }
 
 const stub: StubUserClient = {
   getPersonality: vi.fn(),
   resolveCascade: vi.fn(),
+  updatePersonalityOverrides: vi.fn(),
 };
 
+// Single transport: `handleOverrides` (entry) calls `getPersonality` +
+// `resolveCascade` via `clientsFor`. Button/modal handlers funnel through
+// `settingsUpdateFactory`, which also uses `clientsFor` to call
+// `updatePersonalityOverrides` + `resolveCascade`.
 vi.mock('../../utils/gatewayClients.js', () => ({
   clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
 }));
-
-// The button/modal handlers go through the shared `createSettingsCommandHandlers`
-// factory, which still uses the legacy `callGatewayApi` transport for PATCH +
-// resolve calls. Migrating that factory is out of scope (factory shared with
-// channel/settings, etc.). Mocking it here keeps factory-driven tests working
-// without forcing the factory migration in.
-const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
-    '../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  };
-});
 
 // Mock the session manager
 const mockSessionManager = {
@@ -155,6 +145,7 @@ describe('Character Overrides Dashboard', () => {
     vi.clearAllMocks();
     stub.getPersonality.mockReset();
     stub.resolveCascade.mockReset();
+    stub.updatePersonalityOverrides.mockReset();
   });
 
   describe('handleOverrides', () => {
@@ -332,20 +323,14 @@ describe('Character Overrides Dashboard', () => {
         },
       });
 
-      mockCallGatewayApi
-        .mockResolvedValueOnce({ ok: true }) // PATCH config-overrides
-        .mockResolvedValueOnce({ ok: true, data: mockResolvedOverrides }); // GET resolve
+      stub.updatePersonalityOverrides.mockResolvedValueOnce({ ok: true });
+      stub.resolveCascade.mockResolvedValueOnce({ ok: true, data: mockResolvedOverrides });
 
       await handleCharacterOverridesButton(interaction as unknown as ButtonInteraction);
 
-      // Factory still uses callGatewayApi (out of scope here (see file header)).
-      expect(mockCallGatewayApi).toHaveBeenCalledWith(
-        '/user/config-overrides/personality-123',
-        expect.objectContaining({
-          method: 'PATCH',
-          body: { crossChannelHistoryEnabled: true },
-        })
-      );
+      expect(stub.updatePersonalityOverrides).toHaveBeenCalledWith('personality-123', {
+        crossChannelHistoryEnabled: true,
+      });
     });
   });
 
@@ -383,20 +368,14 @@ describe('Character Overrides Dashboard', () => {
       );
 
       mockSessionManager.get.mockReturnValue(createSessionWithSetting('maxMessages'));
-      mockCallGatewayApi
-        .mockResolvedValueOnce({ ok: true }) // PATCH config-overrides
-        .mockResolvedValueOnce({ ok: true, data: mockResolvedOverrides }); // GET resolve
+      stub.updatePersonalityOverrides.mockResolvedValueOnce({ ok: true });
+      stub.resolveCascade.mockResolvedValueOnce({ ok: true, data: mockResolvedOverrides });
 
       await handleCharacterOverridesModal(interaction as never);
 
-      // Factory still uses callGatewayApi (out of scope here (see file header)).
-      expect(mockCallGatewayApi).toHaveBeenCalledWith(
-        '/user/config-overrides/personality-123',
-        expect.objectContaining({
-          method: 'PATCH',
-          body: { maxMessages: 75 },
-        })
-      );
+      expect(stub.updatePersonalityOverrides).toHaveBeenCalledWith('personality-123', {
+        maxMessages: 75,
+      });
     });
   });
 });

--- a/services/bot-client/src/commands/character/overrides.ts
+++ b/services/bot-client/src/commands/character/overrides.ts
@@ -34,6 +34,7 @@ import {
 import {
   createSettingsUpdateHandler,
   convertCascadeToSettingsData,
+  type SettingUpdateConfig,
 } from '../../utils/dashboard/settings/settingsUpdateFactory.js';
 
 const logger = createLogger('character-overrides');
@@ -131,10 +132,10 @@ export async function handleOverrides(
 }
 
 /** Config for the character overrides update handler (full user-personality cascade) */
-const CHARACTER_OVERRIDES_UPDATE_CONFIG = {
-  patchEndpoint: (id: string) => `/user/config-overrides/${encodeURIComponent(id)}`,
-  resolveEndpoint: (id: string) => `/user/config-overrides/resolve/${encodeURIComponent(id)}`,
-  sourceTier: 'user-personality' as const,
+const CHARACTER_OVERRIDES_UPDATE_CONFIG: SettingUpdateConfig = {
+  patchFn: (uc, id, body) => uc.updatePersonalityOverrides(id, body),
+  resolveFn: (uc, id) => uc.resolveCascade(id),
+  sourceTier: 'user-personality',
   logContext: '[Character Overrides]',
 };
 

--- a/services/bot-client/src/commands/character/randomPick.test.ts
+++ b/services/bot-client/src/commands/character/randomPick.test.ts
@@ -26,17 +26,11 @@ vi.mock('../../utils/autocomplete/autocompleteCache.js', () => ({
   getCachedPersonalities: (...args: unknown[]) => mockGetCachedPersonalities(...args),
 }));
 
-vi.mock('../../utils/userGatewayClient.js', async importOriginal => {
-  const actual = (await importOriginal()) as Record<string, unknown>;
-  return {
-    ...actual,
-    toGatewayUser: vi.fn((user: { id: string; displayName: string }) => ({
-      discordId: user.id,
-      username: user.displayName,
-      displayName: user.displayName,
-    })),
-  };
-});
+// Mock clientsFor — the cache mock above doesn't care about the userClient
+// identity, so a structurally-empty stub suffices.
+vi.mock('../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: {} })),
+}));
 
 import { resolveCharacterSlug, finalizeDeferredReply } from './randomPick.js';
 

--- a/services/bot-client/src/commands/character/randomPick.ts
+++ b/services/bot-client/src/commands/character/randomPick.ts
@@ -11,7 +11,7 @@
 import { createLogger, type LoadedPersonality } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import { getCachedPersonalities } from '../../utils/autocomplete/autocompleteCache.js';
-import { toGatewayUser } from '../../utils/userGatewayClient.js';
+import { clientsFor } from '../../utils/gatewayClients.js';
 
 const logger = createLogger('character-random-pick');
 
@@ -49,7 +49,8 @@ export async function resolveCharacterSlug(
     return { kind: 'slug', slug: providedSlug, randomPick: false };
   }
 
-  const result = await getCachedPersonalities(toGatewayUser(context.user));
+  const { userClient } = clientsFor(context.interaction);
+  const result = await getCachedPersonalities(userClient);
   if (result.kind === 'error') {
     // Log so a systematic gateway failure leaves a server-side trace; the
     // user-facing message alone gives no signal in Railway logs.

--- a/services/bot-client/src/commands/character/settings.test.ts
+++ b/services/bot-client/src/commands/character/settings.test.ts
@@ -32,34 +32,24 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 interface StubUserClient {
   getPersonality: ReturnType<typeof vi.fn>;
   resolvePersonalityCascade: ReturnType<typeof vi.fn>;
+  updatePersonalityConfigDefaults: ReturnType<typeof vi.fn>;
 }
 
 const stub: StubUserClient = {
   getPersonality: vi.fn(),
   resolvePersonalityCascade: vi.fn(),
+  updatePersonalityConfigDefaults: vi.fn(),
 };
 
-// `handleSettings` (the slash-command entry point) calls these two typed
-// methods through `clientsFor`. The button/modal handlers go through the
-// shared `createSettingsCommandHandlers` factory which still uses the
-// legacy `callGatewayApi` transport — that factory migration is out of scope
-// here, so we mock both transports.
+// `handleSettings` (entry) calls `getPersonality` + `resolvePersonalityCascade`
+// via `clientsFor`. Button/modal handlers funnel through `settingsUpdateFactory`,
+// which now also uses `clientsFor` to call `updatePersonalityConfigDefaults` +
+// `resolvePersonalityCascade`. Single transport mocked.
 vi.mock('../../utils/gatewayClients.js', () => ({
   clientsFor: vi.fn(() => ({
     userClient: stub as unknown as import('@tzurot/common-types').UserClient,
   })),
 }));
-
-const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
-    '../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  };
-});
 
 // Mock the session manager
 const mockSessionManager = {
@@ -157,6 +147,7 @@ describe('Character Settings Dashboard', () => {
     vi.clearAllMocks();
     stub.getPersonality.mockReset();
     stub.resolvePersonalityCascade.mockReset();
+    stub.updatePersonalityConfigDefaults.mockReset();
   });
 
   describe('handleSettings', () => {
@@ -358,19 +349,17 @@ describe('Character Settings Dashboard', () => {
         },
       });
 
-      mockCallGatewayApi
-        .mockResolvedValueOnce({ ok: true }) // PATCH config-overrides
-        .mockResolvedValueOnce({ ok: true, data: mockResolvedOverrides }); // GET resolve
+      stub.updatePersonalityConfigDefaults.mockResolvedValueOnce({ ok: true });
+      stub.resolvePersonalityCascade.mockResolvedValueOnce({
+        ok: true,
+        data: mockResolvedOverrides,
+      });
 
       await handleCharacterSettingsButton(interaction as unknown as ButtonInteraction);
 
-      expect(mockCallGatewayApi).toHaveBeenCalledWith(
-        '/user/config-overrides/personality/personality-123',
-        expect.objectContaining({
-          method: 'PATCH',
-          body: { crossChannelHistoryEnabled: true },
-        })
-      );
+      expect(stub.updatePersonalityConfigDefaults).toHaveBeenCalledWith('personality-123', {
+        crossChannelHistoryEnabled: true,
+      });
     });
 
     it('should update shareLtmAcrossPersonalities via set button', async () => {
@@ -406,19 +395,17 @@ describe('Character Settings Dashboard', () => {
         },
       });
 
-      mockCallGatewayApi
-        .mockResolvedValueOnce({ ok: true }) // PATCH config-overrides
-        .mockResolvedValueOnce({ ok: true, data: mockResolvedOverrides }); // GET resolve
+      stub.updatePersonalityConfigDefaults.mockResolvedValueOnce({ ok: true });
+      stub.resolvePersonalityCascade.mockResolvedValueOnce({
+        ok: true,
+        data: mockResolvedOverrides,
+      });
 
       await handleCharacterSettingsButton(interaction as unknown as ButtonInteraction);
 
-      expect(mockCallGatewayApi).toHaveBeenCalledWith(
-        '/user/config-overrides/personality/personality-123',
-        expect.objectContaining({
-          method: 'PATCH',
-          body: { shareLtmAcrossPersonalities: true },
-        })
-      );
+      expect(stub.updatePersonalityConfigDefaults).toHaveBeenCalledWith('personality-123', {
+        shareLtmAcrossPersonalities: true,
+      });
     });
 
     it('should handle permission denied (401) response', async () => {
@@ -445,7 +432,7 @@ describe('Character Settings Dashboard', () => {
         },
       });
 
-      mockCallGatewayApi.mockResolvedValue({
+      stub.updatePersonalityConfigDefaults.mockResolvedValue({
         ok: false,
         status: 401,
         error: 'Unauthorized',
@@ -484,7 +471,7 @@ describe('Character Settings Dashboard', () => {
         },
       });
 
-      mockCallGatewayApi.mockResolvedValue({
+      stub.updatePersonalityConfigDefaults.mockResolvedValue({
         ok: false,
         status: 404,
         error: 'Not found',
@@ -536,20 +523,18 @@ describe('Character Settings Dashboard', () => {
       );
 
       mockSessionManager.get.mockReturnValue(createSessionWithSetting('maxMessages'));
-      mockCallGatewayApi
-        .mockResolvedValueOnce({ ok: true }) // PATCH config-overrides
-        .mockResolvedValueOnce({ ok: true, data: mockResolvedOverrides }); // GET resolve
+      stub.updatePersonalityConfigDefaults.mockResolvedValueOnce({ ok: true });
+      stub.resolvePersonalityCascade.mockResolvedValueOnce({
+        ok: true,
+        data: mockResolvedOverrides,
+      });
 
       await handleCharacterSettingsModal(interaction as never);
 
-      // Should call PATCH on cascade endpoint with correct field
-      expect(mockCallGatewayApi).toHaveBeenCalledWith(
-        '/user/config-overrides/personality/personality-123',
-        expect.objectContaining({
-          method: 'PATCH',
-          body: { maxMessages: 75 },
-        })
-      );
+      // Should call the typed-client method with the correct field
+      expect(stub.updatePersonalityConfigDefaults).toHaveBeenCalledWith('personality-123', {
+        maxMessages: 75,
+      });
     });
 
     it('should update maxAge setting with duration string (2h)', async () => {
@@ -559,19 +544,17 @@ describe('Character Settings Dashboard', () => {
       );
 
       mockSessionManager.get.mockReturnValue(createSessionWithSetting('maxAge'));
-      mockCallGatewayApi
-        .mockResolvedValueOnce({ ok: true })
-        .mockResolvedValueOnce({ ok: true, data: mockResolvedOverrides });
+      stub.updatePersonalityConfigDefaults.mockResolvedValueOnce({ ok: true });
+      stub.resolvePersonalityCascade.mockResolvedValueOnce({
+        ok: true,
+        data: mockResolvedOverrides,
+      });
 
       await handleCharacterSettingsModal(interaction as never);
 
-      expect(mockCallGatewayApi).toHaveBeenCalledWith(
-        '/user/config-overrides/personality/personality-123',
-        expect.objectContaining({
-          method: 'PATCH',
-          body: { maxAge: 7200 },
-        })
-      );
+      expect(stub.updatePersonalityConfigDefaults).toHaveBeenCalledWith('personality-123', {
+        maxAge: 7200,
+      });
     });
 
     it('should update maxAge setting to "off" (disabled)', async () => {
@@ -581,20 +564,18 @@ describe('Character Settings Dashboard', () => {
       );
 
       mockSessionManager.get.mockReturnValue(createSessionWithSetting('maxAge'));
-      mockCallGatewayApi
-        .mockResolvedValueOnce({ ok: true })
-        .mockResolvedValueOnce({ ok: true, data: mockResolvedOverrides });
+      stub.updatePersonalityConfigDefaults.mockResolvedValueOnce({ ok: true });
+      stub.resolvePersonalityCascade.mockResolvedValueOnce({
+        ok: true,
+        data: mockResolvedOverrides,
+      });
 
       await handleCharacterSettingsModal(interaction as never);
 
       // "off" maps to null in cascade config overrides
-      expect(mockCallGatewayApi).toHaveBeenCalledWith(
-        '/user/config-overrides/personality/personality-123',
-        expect.objectContaining({
-          method: 'PATCH',
-          body: { maxAge: null },
-        })
-      );
+      expect(stub.updatePersonalityConfigDefaults).toHaveBeenCalledWith('personality-123', {
+        maxAge: null,
+      });
     });
 
     it('should set maxAge to auto (null) when auto selected', async () => {
@@ -604,20 +585,18 @@ describe('Character Settings Dashboard', () => {
       );
 
       mockSessionManager.get.mockReturnValue(createSessionWithSetting('maxAge'));
-      mockCallGatewayApi
-        .mockResolvedValueOnce({ ok: true })
-        .mockResolvedValueOnce({ ok: true, data: mockResolvedOverrides });
+      stub.updatePersonalityConfigDefaults.mockResolvedValueOnce({ ok: true });
+      stub.resolvePersonalityCascade.mockResolvedValueOnce({
+        ok: true,
+        data: mockResolvedOverrides,
+      });
 
       await handleCharacterSettingsModal(interaction as never);
 
       // "auto" means inherit (null) — inherit from lower cascade tier
-      expect(mockCallGatewayApi).toHaveBeenCalledWith(
-        '/user/config-overrides/personality/personality-123',
-        expect.objectContaining({
-          method: 'PATCH',
-          body: { maxAge: null },
-        })
-      );
+      expect(stub.updatePersonalityConfigDefaults).toHaveBeenCalledWith('personality-123', {
+        maxAge: null,
+      });
     });
 
     it('should update maxImages setting via cascade endpoint', async () => {
@@ -627,19 +606,17 @@ describe('Character Settings Dashboard', () => {
       );
 
       mockSessionManager.get.mockReturnValue(createSessionWithSetting('maxImages'));
-      mockCallGatewayApi
-        .mockResolvedValueOnce({ ok: true })
-        .mockResolvedValueOnce({ ok: true, data: mockResolvedOverrides });
+      stub.updatePersonalityConfigDefaults.mockResolvedValueOnce({ ok: true });
+      stub.resolvePersonalityCascade.mockResolvedValueOnce({
+        ok: true,
+        data: mockResolvedOverrides,
+      });
 
       await handleCharacterSettingsModal(interaction as never);
 
-      expect(mockCallGatewayApi).toHaveBeenCalledWith(
-        '/user/config-overrides/personality/personality-123',
-        expect.objectContaining({
-          method: 'PATCH',
-          body: { maxImages: 10 },
-        })
-      );
+      expect(stub.updatePersonalityConfigDefaults).toHaveBeenCalledWith('personality-123', {
+        maxImages: 10,
+      });
     });
 
     it('should handle refresh failure after update', async () => {
@@ -649,9 +626,8 @@ describe('Character Settings Dashboard', () => {
       );
 
       mockSessionManager.get.mockReturnValue(createSessionWithSetting('maxMessages'));
-      mockCallGatewayApi
-        .mockResolvedValueOnce({ ok: true }) // PATCH succeeds
-        .mockResolvedValueOnce({ ok: false, error: 'Fetch failed' }); // resolve fails
+      stub.updatePersonalityConfigDefaults.mockResolvedValueOnce({ ok: true });
+      stub.resolvePersonalityCascade.mockResolvedValueOnce({ ok: false, error: 'Fetch failed' });
 
       await handleCharacterSettingsModal(interaction as never);
 
@@ -666,7 +642,7 @@ describe('Character Settings Dashboard', () => {
       );
 
       mockSessionManager.get.mockReturnValue(createSessionWithSetting('maxMessages'));
-      mockCallGatewayApi.mockRejectedValueOnce(new Error('Network error'));
+      stub.updatePersonalityConfigDefaults.mockRejectedValueOnce(new Error('Network error'));
 
       await handleCharacterSettingsModal(interaction as never);
 

--- a/services/bot-client/src/commands/character/settings.ts
+++ b/services/bot-client/src/commands/character/settings.ts
@@ -34,6 +34,7 @@ import {
 import {
   createSettingsUpdateHandler,
   convertCascadeToSettingsData,
+  type SettingUpdateConfig,
 } from '../../utils/dashboard/settings/settingsUpdateFactory.js';
 
 const logger = createLogger('character-settings');
@@ -130,11 +131,10 @@ export async function handleSettings(
 }
 
 /** Config for the character settings update handler (3-tier cascade, creator-only) */
-const CHARACTER_SETTINGS_UPDATE_CONFIG = {
-  patchEndpoint: (id: string) => `/user/config-overrides/personality/${encodeURIComponent(id)}`,
-  resolveEndpoint: (id: string) =>
-    `/user/config-overrides/resolve-personality/${encodeURIComponent(id)}`,
-  sourceTier: 'personality' as const,
+const CHARACTER_SETTINGS_UPDATE_CONFIG: SettingUpdateConfig = {
+  patchFn: (uc, id, body) => uc.updatePersonalityConfigDefaults(id, body),
+  resolveFn: (uc, id) => uc.resolvePersonalityCascade(id),
+  sourceTier: 'personality',
   logContext: '[Character Settings]',
 };
 

--- a/services/bot-client/src/commands/memory/autocomplete.test.ts
+++ b/services/bot-client/src/commands/memory/autocomplete.test.ts
@@ -9,10 +9,12 @@ import {
   getPersonalityName,
 } from './autocomplete.js';
 import type { AutocompleteInteraction } from 'discord.js';
-import type { GatewayUser } from '../../utils/userGatewayClient.js';
+import type { UserClient } from '@tzurot/common-types';
 
-function mkUser(discordId = 'user-123'): GatewayUser {
-  return { discordId, username: 'test-user', displayName: 'Test User' };
+function mkUser(discordId = 'user-123'): UserClient {
+  // Cache-key only — `actor` is the field getCachedPersonalities reads via
+  // the mocked autocompleteCache module.
+  return { actor: discordId } as unknown as UserClient;
 }
 
 // Mock shared autocomplete utility

--- a/services/bot-client/src/commands/memory/autocomplete.ts
+++ b/services/bot-client/src/commands/memory/autocomplete.ts
@@ -5,9 +5,9 @@
  */
 
 import type { AutocompleteInteraction } from 'discord.js';
+import type { UserClient } from '@tzurot/common-types';
 import { handlePersonalityAutocomplete as sharedPersonalityAutocomplete } from '../../utils/autocomplete/personalityAutocomplete.js';
 import { getCachedPersonalities } from '../../utils/autocomplete/autocompleteCache.js';
-import { type GatewayUser } from '../../utils/userGatewayClient.js';
 
 /**
  * Handle personality autocomplete for memory commands
@@ -28,15 +28,15 @@ export async function handlePersonalityAutocomplete(
  * Resolve a personality slug to its UUID
  * Uses the autocomplete cache for performance
  *
- * @param userId - Discord user ID (for cache lookup)
+ * @param userClient - Typed gateway client bound to the caller (for cache lookup)
  * @param slugOrId - Personality slug or ID from user input
  * @returns Personality UUID or null if not found
  */
 export async function resolvePersonalityId(
-  user: GatewayUser,
+  userClient: UserClient,
   slugOrId: string
 ): Promise<string | null> {
-  const result = await getCachedPersonalities(user);
+  const result = await getCachedPersonalities(userClient);
   if (result.kind === 'error') {
     return null;
   }
@@ -66,15 +66,15 @@ export async function resolvePersonalityId(
 /**
  * Get a personality's display name by ID
  *
- * @param userId - Discord user ID (for cache lookup)
+ * @param userClient - Typed gateway client bound to the caller (for cache lookup)
  * @param personalityId - Personality UUID
  * @returns Personality display name or null if not found
  */
 export async function getPersonalityName(
-  user: GatewayUser,
+  userClient: UserClient,
   personalityId: string
 ): Promise<string | null> {
-  const result = await getCachedPersonalities(user);
+  const result = await getCachedPersonalities(userClient);
   if (result.kind === 'error') {
     return null;
   }

--- a/services/bot-client/src/commands/memory/batchDelete.test.ts
+++ b/services/bot-client/src/commands/memory/batchDelete.test.ts
@@ -135,10 +135,9 @@ describe('handleBatchDelete', () => {
       const context = createMockContext('lilith');
       await handleBatchDelete(context);
 
-      expect(mockResolvePersonalityId).toHaveBeenCalledWith(
-        { discordId: 'user-123', username: 'testuser', displayName: 'testuser' },
-        'lilith'
-      );
+      // Identity carried at the clientsFor boundary; first arg is the bound
+      // userClient stub. See gatewayClients.test.ts for the brand-binding contract.
+      expect(mockResolvePersonalityId).toHaveBeenCalledWith(expect.any(Object), 'lilith');
       expect(stub.batchDeletePreview).toHaveBeenCalledWith(
         expect.objectContaining({ personalityId: 'personality-uuid-123' })
       );

--- a/services/bot-client/src/commands/memory/batchDelete.ts
+++ b/services/bot-client/src/commands/memory/batchDelete.ts
@@ -23,7 +23,6 @@ import {
   AUTOCOMPLETE_UNAVAILABLE_MESSAGE,
   isAutocompleteErrorSentinel,
 } from '../../utils/apiCheck.js';
-import { toGatewayUser } from '../../utils/userGatewayClient.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import { createWarningEmbed, createSuccessEmbed } from '../../utils/commandHelpers.js';
 import { resolvePersonalityId } from './autocomplete.js';
@@ -58,7 +57,6 @@ function formatTimeframe(timeframe: string | null): string {
 // eslint-disable-next-line max-lines-per-function, max-statements -- Discord command handler with sequential UI flow
 export async function handleBatchDelete(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
-  const user = toGatewayUser(context.user);
   const { userClient } = clientsFor(context.interaction);
   const options = memoryDeleteOptions(context.interaction);
   const personalityInput = options.character();
@@ -71,7 +69,7 @@ export async function handleBatchDelete(context: DeferredCommandContext): Promis
 
   try {
     // Resolve personality slug to ID
-    const personalityId = await resolvePersonalityId(user, personalityInput);
+    const personalityId = await resolvePersonalityId(userClient, personalityInput);
 
     if (personalityId === null) {
       await context.editReply({

--- a/services/bot-client/src/commands/memory/browse.ts
+++ b/services/bot-client/src/commands/memory/browse.ts
@@ -27,7 +27,6 @@ import {
   type UserClient,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { toGatewayUser } from '../../utils/userGatewayClient.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import {
   createBrowseCustomIdHelpers,
@@ -207,7 +206,6 @@ async function fetchMemories(
  */
 export async function handleBrowse(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
-  const user = toGatewayUser(context.user);
   const { userClient } = clientsFor(context.interaction);
   const options = memoryBrowseOptions(context.interaction);
   const personalityInput = options.character();
@@ -216,7 +214,7 @@ export async function handleBrowse(context: DeferredCommandContext): Promise<voi
     // Resolve personality if provided. Contract: null means the helper
     // already sent an error reply via editReply, so we must return early
     // without sending another reply (Discord would reject the double-reply).
-    const personalityId = await resolveOptionalPersonality(context, user, personalityInput);
+    const personalityId = await resolveOptionalPersonality(context, userClient, personalityInput);
     if (personalityId === null) {
       return;
     }

--- a/services/bot-client/src/commands/memory/focus.ts
+++ b/services/bot-client/src/commands/memory/focus.ts
@@ -14,7 +14,6 @@ import {
   memoryFocusStatusOptions,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { toGatewayUser } from '../../utils/userGatewayClient.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import { createSuccessEmbed, createInfoEmbed } from '../../utils/commandHelpers.js';
 import { getPersonalityName } from './autocomplete.js';
@@ -41,14 +40,13 @@ export async function handleFocusDisable(context: DeferredCommandContext): Promi
  */
 export async function handleFocusStatus(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
-  const user = toGatewayUser(context.user);
   const { userClient } = clientsFor(context.interaction);
   const options = memoryFocusStatusOptions(context.interaction);
   const personalityInput = options.character();
 
   try {
     // Resolve personality slug to ID
-    const personalityId = await resolveRequiredPersonality(context, user, personalityInput);
+    const personalityId = await resolveRequiredPersonality(context, userClient, personalityInput);
     if (personalityId === null) {
       return;
     }
@@ -64,7 +62,7 @@ export async function handleFocusStatus(context: DeferredCommandContext): Promis
     }
 
     const data = result.data;
-    const personalityName = await getPersonalityName(user, personalityId);
+    const personalityName = await getPersonalityName(userClient, personalityId);
 
     const embed = createInfoEmbed(
       'Focus Mode Status',
@@ -90,7 +88,6 @@ export async function handleFocusStatus(context: DeferredCommandContext): Promis
  */
 async function setFocusMode(context: DeferredCommandContext, enabled: boolean): Promise<void> {
   const userId = context.user.id;
-  const user = toGatewayUser(context.user);
   const { userClient } = clientsFor(context.interaction);
   // Both enable and disable use the same option schema
   const options = enabled
@@ -100,7 +97,7 @@ async function setFocusMode(context: DeferredCommandContext, enabled: boolean): 
 
   try {
     // Resolve personality slug to ID
-    const personalityId = await resolveRequiredPersonality(context, user, personalityInput);
+    const personalityId = await resolveRequiredPersonality(context, userClient, personalityInput);
     if (personalityId === null) {
       return;
     }

--- a/services/bot-client/src/commands/memory/incognito.ts
+++ b/services/bot-client/src/commands/memory/incognito.ts
@@ -25,7 +25,7 @@ import {
   AUTOCOMPLETE_UNAVAILABLE_MESSAGE,
   isAutocompleteErrorSentinel,
 } from '../../utils/apiCheck.js';
-import { toGatewayUser, type GatewayUser } from '../../utils/userGatewayClient.js';
+import type { UserClient } from '@tzurot/common-types';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import {
   createSuccessEmbed,
@@ -59,19 +59,19 @@ function formatSessionInfo(session: SessionWithTime, personalityName?: string): 
  * @returns { id: personality UUID or 'all', name: display name or null }
  */
 async function resolvePersonalityOrAll(
-  user: GatewayUser,
+  userClient: UserClient,
   personalityInput: string
 ): Promise<{ id: string; name: string | null } | null> {
   if (personalityInput.toLowerCase() === 'all') {
     return { id: 'all', name: ALL_PERSONALITIES_LABEL };
   }
 
-  const personalityId = await resolvePersonalityId(user, personalityInput);
+  const personalityId = await resolvePersonalityId(userClient, personalityInput);
   if (personalityId === null) {
     return null;
   }
 
-  const name = await getPersonalityName(user, personalityId);
+  const name = await getPersonalityName(userClient, personalityId);
   return { id: personalityId, name };
 }
 
@@ -80,7 +80,6 @@ async function resolvePersonalityOrAll(
  */
 export async function handleIncognitoEnable(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
-  const user = toGatewayUser(context.user);
   const { userClient } = clientsFor(context.interaction);
   const options = memoryIncognitoEnableOptions(context.interaction);
   const personalityInput = options.character();
@@ -92,7 +91,7 @@ export async function handleIncognitoEnable(context: DeferredCommandContext): Pr
   }
 
   try {
-    const resolved = await resolvePersonalityOrAll(user, personalityInput);
+    const resolved = await resolvePersonalityOrAll(userClient, personalityInput);
 
     if (resolved === null) {
       await context.editReply({
@@ -138,7 +137,6 @@ export async function handleIncognitoEnable(context: DeferredCommandContext): Pr
  */
 export async function handleIncognitoDisable(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
-  const user = toGatewayUser(context.user);
   const { userClient } = clientsFor(context.interaction);
   const options = memoryIncognitoDisableOptions(context.interaction);
   const personalityInput = options.character();
@@ -149,7 +147,7 @@ export async function handleIncognitoDisable(context: DeferredCommandContext): P
   }
 
   try {
-    const resolved = await resolvePersonalityOrAll(user, personalityInput);
+    const resolved = await resolvePersonalityOrAll(userClient, personalityInput);
 
     if (resolved === null) {
       await context.editReply({
@@ -194,7 +192,6 @@ export async function handleIncognitoDisable(context: DeferredCommandContext): P
  */
 export async function handleIncognitoStatus(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
-  const user = toGatewayUser(context.user);
   const { userClient } = clientsFor(context.interaction);
 
   try {
@@ -225,7 +222,7 @@ export async function handleIncognitoStatus(context: DeferredCommandContext): Pr
         if (session.personalityId === 'all') {
           return formatSessionInfo(session, ALL_PERSONALITIES_LABEL);
         }
-        const name = await getPersonalityName(user, session.personalityId);
+        const name = await getPersonalityName(userClient, session.personalityId);
         return formatSessionInfo(session, name ?? session.personalityId);
       })
     );
@@ -249,7 +246,6 @@ export async function handleIncognitoStatus(context: DeferredCommandContext): Pr
  */
 export async function handleIncognitoForget(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
-  const user = toGatewayUser(context.user);
   const { userClient } = clientsFor(context.interaction);
   const options = memoryIncognitoForgetOptions(context.interaction);
   const personalityInput = options.character();
@@ -261,7 +257,7 @@ export async function handleIncognitoForget(context: DeferredCommandContext): Pr
   }
 
   try {
-    const resolved = await resolvePersonalityOrAll(user, personalityInput);
+    const resolved = await resolvePersonalityOrAll(userClient, personalityInput);
 
     if (resolved === null) {
       await context.editReply({

--- a/services/bot-client/src/commands/memory/purge.ts
+++ b/services/bot-client/src/commands/memory/purge.ts
@@ -33,7 +33,6 @@ import {
   type UserClient,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { toGatewayUser } from '../../utils/userGatewayClient.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import { createDangerEmbed, createSuccessEmbed } from '../../utils/commandHelpers.js';
 import { resolveRequiredPersonality } from './resolveHelpers.js';
@@ -106,13 +105,12 @@ async function assertInvokerOwnership(
  */
 export async function handlePurge(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
-  const user = toGatewayUser(context.user);
   const { userClient } = clientsFor(context.interaction);
   const options = memoryPurgeOptions(context.interaction);
   const personalityInput = options.character();
 
   try {
-    const personalityId = await resolveRequiredPersonality(context, user, personalityInput);
+    const personalityId = await resolveRequiredPersonality(context, userClient, personalityInput);
     if (personalityId === null) {
       return;
     }

--- a/services/bot-client/src/commands/memory/resolveHelpers.test.ts
+++ b/services/bot-client/src/commands/memory/resolveHelpers.test.ts
@@ -9,10 +9,13 @@ import {
   AUTOCOMPLETE_UNAVAILABLE_MESSAGE,
 } from '../../utils/apiCheck.js';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import type { GatewayUser } from '../../utils/userGatewayClient.js';
+import type { UserClient } from '@tzurot/common-types';
 
-function mkUser(discordId = 'user-123'): GatewayUser {
-  return { discordId, username: 'test-user', displayName: 'Test User' };
+function mkUser(discordId = 'user-123'): UserClient {
+  // Cache-key only — `actor` is the only field resolvePersonalityId reads via
+  // the mocked autocomplete module. Cast through unknown to bypass the full
+  // typed-client surface.
+  return { actor: discordId } as unknown as UserClient;
 }
 
 // Mock the autocomplete module

--- a/services/bot-client/src/commands/memory/resolveHelpers.ts
+++ b/services/bot-client/src/commands/memory/resolveHelpers.ts
@@ -10,7 +10,7 @@ import {
   AUTOCOMPLETE_UNAVAILABLE_MESSAGE,
   isAutocompleteErrorSentinel,
 } from '../../utils/apiCheck.js';
-import { type GatewayUser } from '../../utils/userGatewayClient.js';
+import type { UserClient } from '@tzurot/common-types';
 import { resolvePersonalityId } from './autocomplete.js';
 
 /**
@@ -33,7 +33,7 @@ import { resolvePersonalityId } from './autocomplete.js';
  */
 export async function resolveOptionalPersonality(
   context: DeferredCommandContext,
-  user: GatewayUser,
+  userClient: UserClient,
   personalityInput: string | null
 ): Promise<string | undefined | null> {
   if (personalityInput === null || personalityInput.length === 0) {
@@ -45,7 +45,7 @@ export async function resolveOptionalPersonality(
     return null;
   }
 
-  const resolved = await resolvePersonalityId(user, personalityInput);
+  const resolved = await resolvePersonalityId(userClient, personalityInput);
   if (resolved === null) {
     await context.editReply({
       content: `❌ Personality "${personalityInput}" not found. Use autocomplete to select a valid personality.`,
@@ -69,7 +69,7 @@ export async function resolveOptionalPersonality(
  */
 export async function resolveRequiredPersonality(
   context: DeferredCommandContext,
-  user: GatewayUser,
+  userClient: UserClient,
   personalityInput: string
 ): Promise<string | null> {
   if (isAutocompleteErrorSentinel(personalityInput)) {
@@ -77,7 +77,7 @@ export async function resolveRequiredPersonality(
     return null;
   }
 
-  const resolved = await resolvePersonalityId(user, personalityInput);
+  const resolved = await resolvePersonalityId(userClient, personalityInput);
   if (resolved === null) {
     await context.editReply({
       content: `❌ Personality "${personalityInput}" not found. Use autocomplete to select a valid personality.`,

--- a/services/bot-client/src/commands/memory/search.ts
+++ b/services/bot-client/src/commands/memory/search.ts
@@ -27,7 +27,6 @@ import {
   type UserClient,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { toGatewayUser } from '../../utils/userGatewayClient.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import {
   createBrowseCustomIdHelpers,
@@ -263,7 +262,6 @@ async function fetchSearchResults(options: FetchSearchOptions): Promise<SearchRe
  */
 export async function handleSearch(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
-  const user = toGatewayUser(context.user);
   const { userClient } = clientsFor(context.interaction);
   const options = memorySearchOptions(context.interaction);
   const query = options.query();
@@ -277,7 +275,7 @@ export async function handleSearch(context: DeferredCommandContext): Promise<voi
     // Resolve personality if provided. Contract: null means the helper
     // already sent an error reply via editReply, so we must return early
     // without sending another reply (Discord would reject the double-reply).
-    const personalityId = await resolveOptionalPersonality(context, user, personalityInput);
+    const personalityId = await resolveOptionalPersonality(context, userClient, personalityInput);
     if (personalityId === null) {
       return;
     }

--- a/services/bot-client/src/commands/memory/stats.test.ts
+++ b/services/bot-client/src/commands/memory/stats.test.ts
@@ -92,10 +92,9 @@ describe('handleStats', () => {
     const context = createMockContext();
     await handleStats(context);
 
-    expect(mockResolvePersonalityId).toHaveBeenCalledWith(
-      { discordId: '123456789', username: 'testuser', displayName: 'testuser' },
-      'lilith'
-    );
+    // Identity carried at the clientsFor boundary; first arg is the bound
+    // userClient stub. See gatewayClients.test.ts for the brand-binding contract.
+    expect(mockResolvePersonalityId).toHaveBeenCalledWith(expect.any(Object), 'lilith');
     expect(stub.getStats).toHaveBeenCalledWith({ personalityId: 'personality-uuid-123' });
     expect(mockCreateInfoEmbed).toHaveBeenCalledWith(
       'Memory Statistics',

--- a/services/bot-client/src/commands/memory/stats.ts
+++ b/services/bot-client/src/commands/memory/stats.ts
@@ -6,7 +6,6 @@
 import { escapeMarkdown } from 'discord.js';
 import { createLogger, memoryStatsOptions, formatDateTimeCompact } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { toGatewayUser } from '../../utils/userGatewayClient.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import { createInfoEmbed } from '../../utils/commandHelpers.js';
 import { resolveRequiredPersonality } from './resolveHelpers.js';
@@ -23,14 +22,13 @@ function formatDateOrNA(dateStr: string | null): string {
  */
 export async function handleStats(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
-  const user = toGatewayUser(context.user);
   const { userClient } = clientsFor(context.interaction);
   const options = memoryStatsOptions(context.interaction);
   const personalityInput = options.character();
 
   try {
     // Resolve personality slug to ID
-    const personalityId = await resolveRequiredPersonality(context, user, personalityInput);
+    const personalityId = await resolveRequiredPersonality(context, userClient, personalityInput);
     if (personalityId === null) {
       return;
     }

--- a/services/bot-client/src/commands/settings/preset/autocomplete.test.ts
+++ b/services/bot-client/src/commands/settings/preset/autocomplete.test.ts
@@ -38,6 +38,12 @@ vi.mock('../../../utils/autocomplete/autocompleteCache.js', () => ({
   getCachedPersonalities: (...args: unknown[]) => mockGetCachedPersonalities(...args),
 }));
 
+// Mock clientsFor — the cache mock returns ok directly, so a structurally
+// empty userClient stub suffices.
+vi.mock('../../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: {} })),
+}));
+
 import { callGatewayApi } from '../../../utils/userGatewayClient.js';
 import { UNLOCK_MODELS_VALUE } from './autocomplete.js';
 import type { PersonalitySummary } from '@tzurot/common-types';
@@ -138,11 +144,9 @@ describe('handleAutocomplete', () => {
 
       await handleAutocomplete(mockInteraction);
 
-      expect(mockGetCachedPersonalities).toHaveBeenCalledWith({
-        discordId: 'user-123',
-        username: 'testuser',
-        displayName: 'testuser',
-      });
+      // Identity carried at the clientsFor boundary; see gatewayClients.test.ts
+      // for the brand-binding contract.
+      expect(mockGetCachedPersonalities).toHaveBeenCalledWith(expect.any(Object));
       // 🔒 = owned + private, includes slug in parentheses, value is id (model override API expects ID)
       expect(mockInteraction.respond).toHaveBeenCalledWith([
         { name: '🔒 Test Bot (testbot)', value: 'p1' },

--- a/services/bot-client/src/commands/shapes/autocomplete.test.ts
+++ b/services/bot-client/src/commands/shapes/autocomplete.test.ts
@@ -27,6 +27,12 @@ vi.mock('../../utils/autocomplete/autocompleteCache.js', () => ({
   getCachedShapes: (...args: unknown[]) => mockGetCachedShapes(...args),
 }));
 
+// Mock clientsFor — the cache mock above doesn't care about the userClient
+// identity, so a structurally-empty stub suffices.
+vi.mock('../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: {} })),
+}));
+
 describe('handleShapesSlugAutocomplete', () => {
   const mockRespond = vi.fn();
 

--- a/services/bot-client/src/commands/shapes/autocomplete.ts
+++ b/services/bot-client/src/commands/shapes/autocomplete.ts
@@ -10,7 +10,7 @@
 import type { AutocompleteInteraction } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
 import { getCachedShapes } from '../../utils/autocomplete/autocompleteCache.js';
-import { toGatewayUser } from '../../utils/userGatewayClient.js';
+import { clientsFor } from '../../utils/gatewayClients.js';
 import { truncateForSelect } from '../../utils/browse/truncation.js';
 import { AUTOCOMPLETE_ERROR_SENTINEL } from '../../utils/apiCheck.js';
 
@@ -29,7 +29,8 @@ export async function handleShapesSlugAutocomplete(
   const userId = interaction.user.id;
 
   try {
-    const result = await getCachedShapes(toGatewayUser(interaction.user));
+    const { userClient } = clientsFor(interaction);
+    const result = await getCachedShapes(userClient);
     if (result.kind === 'error') {
       // Backend failed AND no stale cache to fall back on. Render a visible
       // error choice instead of an empty list — an empty list reads as

--- a/services/bot-client/src/commands/voice/stt/clear.test.ts
+++ b/services/bot-client/src/commands/voice/stt/clear.test.ts
@@ -3,14 +3,15 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { makeOk, makeErr } from '../../../test/gatewayClientStubs.js';
+import type { UserClient } from '@tzurot/common-types';
 
-const { mockCallGatewayApi } = vi.hoisted(() => ({
-  mockCallGatewayApi: vi.fn(),
-}));
+const stub = {
+  clearSttDefaultProvider: vi.fn(),
+};
 
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: mockCallGatewayApi,
-  toGatewayUser: vi.fn(user => ({ id: user.id })),
+vi.mock('../../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
 }));
 
 vi.mock('@tzurot/common-types', async importOriginal => {
@@ -32,21 +33,21 @@ function makeContext() {
 }
 
 describe('handleSttClear', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stub.clearSttDefaultProvider.mockReset();
+  });
 
-  it('DELETEs /user/stt-override', async () => {
-    mockCallGatewayApi.mockResolvedValue({ ok: true, data: { deleted: true, wasSet: true } });
+  it('calls clearSttDefaultProvider', async () => {
+    stub.clearSttDefaultProvider.mockResolvedValue(makeOk({ deleted: true, wasSet: true }));
 
     await handleSttClear(makeContext() as never);
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith(
-      '/user/stt-override',
-      expect.objectContaining({ method: 'DELETE' })
-    );
+    expect(stub.clearSttDefaultProvider).toHaveBeenCalled();
   });
 
   it('reports gateway error', async () => {
-    mockCallGatewayApi.mockResolvedValue({ ok: false, status: 500, error: 'oh no' });
+    stub.clearSttDefaultProvider.mockResolvedValue(makeErr(500, 'oh no'));
     const context = makeContext();
 
     await handleSttClear(context as never);

--- a/services/bot-client/src/commands/voice/stt/clear.ts
+++ b/services/bot-client/src/commands/voice/stt/clear.ts
@@ -6,13 +6,9 @@
  */
 
 import { EmbedBuilder } from 'discord.js';
-import {
-  createLogger,
-  DISCORD_COLORS,
-  type ClearSttDefaultProviderResponse,
-} from '@tzurot/common-types';
+import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
+import { clientsFor } from '../../../utils/gatewayClients.js';
 
 const logger = createLogger('voice-stt-clear');
 
@@ -21,10 +17,8 @@ export async function handleSttClear(context: DeferredCommandContext): Promise<v
   const userId = context.user.id;
 
   try {
-    const result = await callGatewayApi<ClearSttDefaultProviderResponse>('/user/stt-override', {
-      method: 'DELETE',
-      user: toGatewayUser(context.user),
-    });
+    const { userClient } = clientsFor(context.interaction);
+    const result = await userClient.clearSttDefaultProvider();
 
     if (!result.ok) {
       logger.warn({ userId, status: result.status }, 'Failed to clear transcription preference');

--- a/services/bot-client/src/commands/voice/stt/set.test.ts
+++ b/services/bot-client/src/commands/voice/stt/set.test.ts
@@ -3,14 +3,15 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { makeOk, makeErr } from '../../../test/gatewayClientStubs.js';
+import type { UserClient } from '@tzurot/common-types';
 
-const { mockCallGatewayApi } = vi.hoisted(() => ({
-  mockCallGatewayApi: vi.fn(),
-}));
+const stub = {
+  setSttDefaultProvider: vi.fn(),
+};
 
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: mockCallGatewayApi,
-  toGatewayUser: vi.fn(user => ({ id: user.id })),
+vi.mock('../../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
 }));
 
 vi.mock('@tzurot/common-types', async importOriginal => {
@@ -35,31 +36,27 @@ function makeContext() {
 }
 
 describe('handleSttSet', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stub.setSttDefaultProvider.mockReset();
+  });
 
-  it('PUTs /user/stt-override with the provider and shows the success embed', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: { default: { providerId: 'voice-engine' } },
-    });
+  it('calls setSttDefaultProvider with the provider and shows the success embed', async () => {
+    stub.setSttDefaultProvider.mockResolvedValue(
+      makeOk({ default: { providerId: 'voice-engine' } })
+    );
     const context = makeContext();
 
     await handleSttSet(context as never);
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith(
-      '/user/stt-override',
-      expect.objectContaining({
-        method: 'PUT',
-        body: { providerId: 'voice-engine' },
-      })
-    );
+    expect(stub.setSttDefaultProvider).toHaveBeenCalledWith({ providerId: 'voice-engine' });
     expect(context.editReply).toHaveBeenCalledWith(
       expect.objectContaining({ embeds: expect.any(Array) })
     );
   });
 
   it('reports gateway error', async () => {
-    mockCallGatewayApi.mockResolvedValue({ ok: false, status: 500, error: 'oops' });
+    stub.setSttDefaultProvider.mockResolvedValue(makeErr(500, 'oops'));
     const context = makeContext();
 
     await handleSttSet(context as never);

--- a/services/bot-client/src/commands/voice/stt/set.ts
+++ b/services/bot-client/src/commands/voice/stt/set.ts
@@ -11,11 +11,10 @@ import {
   DISCORD_COLORS,
   voiceSttSetOptions,
   sttProviderDisplayName,
-  type SetSttDefaultProviderResponse,
   type SttProvider,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
+import { clientsFor } from '../../../utils/gatewayClients.js';
 
 const logger = createLogger('voice-stt-set');
 
@@ -26,11 +25,8 @@ export async function handleSttSet(context: DeferredCommandContext): Promise<voi
   const providerId = options.provider() as SttProvider;
 
   try {
-    const result = await callGatewayApi<SetSttDefaultProviderResponse>('/user/stt-override', {
-      method: 'PUT',
-      user: toGatewayUser(context.user),
-      body: { providerId },
-    });
+    const { userClient } = clientsFor(context.interaction);
+    const result = await userClient.setSttDefaultProvider({ providerId });
 
     if (!result.ok) {
       logger.warn(

--- a/services/bot-client/src/commands/voice/tts/autocomplete.test.ts
+++ b/services/bot-client/src/commands/voice/tts/autocomplete.test.ts
@@ -4,15 +4,19 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { makeOk, makeErr } from '../../../test/gatewayClientStubs.js';
+import type { UserClient } from '@tzurot/common-types';
 
-const { mockCallGatewayApi, mockHandlePersonalityAutocomplete } = vi.hoisted(() => ({
-  mockCallGatewayApi: vi.fn(),
+const { mockHandlePersonalityAutocomplete } = vi.hoisted(() => ({
   mockHandlePersonalityAutocomplete: vi.fn(),
 }));
 
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: mockCallGatewayApi,
-  toGatewayUser: vi.fn(user => ({ id: user.id })),
+const stub = {
+  listUserTtsConfigs: vi.fn(),
+};
+
+vi.mock('../../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
 }));
 
 vi.mock('../../../utils/autocomplete/index.js', () => ({
@@ -50,6 +54,7 @@ function makeInteraction(focusedName: string, focusedValue: string) {
 describe('handleAutocomplete', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    stub.listUserTtsConfigs.mockReset();
   });
 
   it('routes character option to handlePersonalityAutocomplete', async () => {
@@ -63,10 +68,9 @@ describe('handleAutocomplete', () => {
     );
   });
 
-  it('queries /user/tts-config for tts option and formats with provider badge', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
+  it('queries listUserTtsConfigs for tts option and formats with provider badge', async () => {
+    stub.listUserTtsConfigs.mockResolvedValue(
+      makeOk({
         configs: [
           {
             id: 'c1',
@@ -80,20 +84,20 @@ describe('handleAutocomplete', () => {
             permissions: { canEdit: false, canDelete: false },
           },
         ],
-      },
-    });
+      })
+    );
     const interaction = makeInteraction('tts', 'kyutai');
 
     await handleAutocomplete(interaction as never);
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/tts-config', expect.any(Object));
+    expect(stub.listUserTtsConfigs).toHaveBeenCalled();
     expect(interaction.respond).toHaveBeenCalledWith(
       expect.arrayContaining([expect.objectContaining({ value: 'c1' })])
     );
   });
 
   it('responds empty list on gateway failure', async () => {
-    mockCallGatewayApi.mockResolvedValue({ ok: false, error: 'INTERNAL_ERROR' });
+    stub.listUserTtsConfigs.mockResolvedValue(makeErr(500, 'INTERNAL_ERROR'));
     const interaction = makeInteraction('tts', '');
 
     await handleAutocomplete(interaction as never);
@@ -110,9 +114,8 @@ describe('handleAutocomplete', () => {
   });
 
   it('filters tts configs by query against name + provider + modelId', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
+    stub.listUserTtsConfigs.mockResolvedValue(
+      makeOk({
         configs: [
           {
             id: 'c1',
@@ -137,8 +140,8 @@ describe('handleAutocomplete', () => {
             permissions: { canEdit: false, canDelete: false },
           },
         ],
-      },
-    });
+      })
+    );
     const interaction = makeInteraction('tts', 'mistral');
 
     await handleAutocomplete(interaction as never);

--- a/services/bot-client/src/commands/voice/tts/autocomplete.ts
+++ b/services/bot-client/src/commands/voice/tts/autocomplete.ts
@@ -18,10 +18,9 @@ import {
   DISCORD_LIMITS,
   AUTOCOMPLETE_BADGES,
   formatAutocompleteOption,
-  type TtsConfigSummary,
   type AutocompleteBadge,
 } from '@tzurot/common-types';
-import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
+import { clientsFor } from '../../../utils/gatewayClients.js';
 import { handlePersonalityAutocomplete } from '../../../utils/autocomplete/index.js';
 
 const logger = createLogger('voice-tts-autocomplete');
@@ -66,10 +65,8 @@ async function handleTtsConfigAutocomplete(
   query: string,
   userId: string
 ): Promise<void> {
-  const user = toGatewayUser(interaction.user);
-  const result = await callGatewayApi<{ configs: TtsConfigSummary[] }>('/user/tts-config', {
-    user,
-  });
+  const { userClient } = clientsFor(interaction);
+  const result = await userClient.listUserTtsConfigs();
 
   if (!result.ok) {
     logger.warn({ userId, error: result.error }, 'Failed to fetch TTS configs');

--- a/services/bot-client/src/commands/voice/tts/clear-default.test.ts
+++ b/services/bot-client/src/commands/voice/tts/clear-default.test.ts
@@ -4,14 +4,15 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { makeOk, makeErr } from '../../../test/gatewayClientStubs.js';
+import type { UserClient } from '@tzurot/common-types';
 
-const { mockCallGatewayApi } = vi.hoisted(() => ({
-  mockCallGatewayApi: vi.fn(),
-}));
+const stub = {
+  clearTtsDefaultConfig: vi.fn(),
+};
 
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: mockCallGatewayApi,
-  toGatewayUser: vi.fn(user => ({ id: user.id })),
+vi.mock('../../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
 }));
 
 vi.mock('@tzurot/common-types', async importOriginal => {
@@ -34,6 +35,7 @@ const { handleTtsClearDefault: handleClearDefault } = await import('./clear-defa
 function makeContext() {
   return {
     user: { id: 'discord-user-1' },
+    interaction: {} as never,
     editReply: vi.fn(),
   };
 }
@@ -41,21 +43,16 @@ function makeContext() {
 describe('handleClearDefault', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    stub.clearTtsDefaultConfig.mockReset();
   });
 
-  it('hits DELETE /user/tts-override/default and shows success embed', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: mockClearTtsDefaultConfigResponse(),
-    });
+  it('calls clearTtsDefaultConfig and shows success embed', async () => {
+    stub.clearTtsDefaultConfig.mockResolvedValue(makeOk(mockClearTtsDefaultConfigResponse()));
     const context = makeContext();
 
     await handleClearDefault(context as never);
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith(
-      '/user/tts-override/default',
-      expect.objectContaining({ method: 'DELETE' })
-    );
+    expect(stub.clearTtsDefaultConfig).toHaveBeenCalled();
     expect(context.editReply).toHaveBeenCalledWith(
       expect.objectContaining({
         embeds: [
@@ -68,12 +65,13 @@ describe('handleClearDefault', () => {
   });
 
   it('renders the new effective default name when one exists', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: mockClearTtsDefaultConfigResponse({
-        newEffectiveDefault: { id: 'free-id', name: 'kyutai-self-hosted' },
-      }),
-    });
+    stub.clearTtsDefaultConfig.mockResolvedValue(
+      makeOk(
+        mockClearTtsDefaultConfigResponse({
+          newEffectiveDefault: { id: 'free-id', name: 'kyutai-self-hosted' },
+        })
+      )
+    );
     const context = makeContext();
 
     await handleClearDefault(context as never);
@@ -92,10 +90,9 @@ describe('handleClearDefault', () => {
   });
 
   it('renders hardcoded-fallback notice when newEffectiveDefault is null', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: mockClearTtsDefaultConfigResponse({ newEffectiveDefault: null }),
-    });
+    stub.clearTtsDefaultConfig.mockResolvedValue(
+      makeOk(mockClearTtsDefaultConfigResponse({ newEffectiveDefault: null }))
+    );
     const context = makeContext();
 
     await handleClearDefault(context as never);
@@ -114,7 +111,7 @@ describe('handleClearDefault', () => {
   });
 
   it('shows error message on gateway failure', async () => {
-    mockCallGatewayApi.mockResolvedValue({ ok: false, status: 500, error: 'INTERNAL_ERROR' });
+    stub.clearTtsDefaultConfig.mockResolvedValue(makeErr(500, 'INTERNAL_ERROR'));
     const context = makeContext();
 
     await handleClearDefault(context as never);
@@ -125,7 +122,7 @@ describe('handleClearDefault', () => {
   });
 
   it('catches and reports unexpected errors', async () => {
-    mockCallGatewayApi.mockRejectedValue(new Error('network down'));
+    stub.clearTtsDefaultConfig.mockRejectedValue(new Error('network down'));
     const context = makeContext();
 
     await handleClearDefault(context as never);

--- a/services/bot-client/src/commands/voice/tts/clear-default.ts
+++ b/services/bot-client/src/commands/voice/tts/clear-default.ts
@@ -7,13 +7,9 @@
  */
 
 import { EmbedBuilder } from 'discord.js';
-import {
-  createLogger,
-  DISCORD_COLORS,
-  type ClearTtsDefaultConfigResponse,
-} from '@tzurot/common-types';
+import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
+import { clientsFor } from '../../../utils/gatewayClients.js';
 
 const logger = createLogger('voice-tts-clear-default');
 
@@ -22,13 +18,8 @@ export async function handleTtsClearDefault(context: DeferredCommandContext): Pr
   const userId = context.user.id;
 
   try {
-    const result = await callGatewayApi<ClearTtsDefaultConfigResponse>(
-      '/user/tts-override/default',
-      {
-        method: 'DELETE',
-        user: toGatewayUser(context.user),
-      }
-    );
+    const { userClient } = clientsFor(context.interaction);
+    const result = await userClient.clearTtsDefaultConfig();
 
     if (!result.ok) {
       logger.warn({ userId, status: result.status }, 'Failed to clear default TTS');

--- a/services/bot-client/src/commands/voice/tts/clear.test.ts
+++ b/services/bot-client/src/commands/voice/tts/clear.test.ts
@@ -4,14 +4,15 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { makeOk, makeErr } from '../../../test/gatewayClientStubs.js';
+import type { UserClient } from '@tzurot/common-types';
 
-const { mockCallGatewayApi } = vi.hoisted(() => ({
-  mockCallGatewayApi: vi.fn(),
-}));
+const stub = {
+  deleteTtsOverride: vi.fn(),
+};
 
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: mockCallGatewayApi,
-  toGatewayUser: vi.fn(user => ({ id: user.id })),
+vi.mock('../../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
 }));
 
 vi.mock('@tzurot/common-types', async importOriginal => {
@@ -48,18 +49,16 @@ function makeContext() {
 describe('handleTtsClear', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    stub.deleteTtsOverride.mockReset();
   });
 
   it('shows success embed when an override was actually removed', async () => {
-    mockCallGatewayApi.mockResolvedValue({ ok: true, data: { deleted: true } });
+    stub.deleteTtsOverride.mockResolvedValue(makeOk({ deleted: true }));
     const context = makeContext();
 
     await handleClear(context as never);
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith(
-      expect.stringContaining('/user/tts-override/'),
-      expect.objectContaining({ method: 'DELETE' })
-    );
+    expect(stub.deleteTtsOverride).toHaveBeenCalledWith('personality-uuid-1');
     expect(context.editReply).toHaveBeenCalledWith(
       expect.objectContaining({
         embeds: [
@@ -72,10 +71,7 @@ describe('handleTtsClear', () => {
   });
 
   it('shows info embed when no override was set (wasSet: false)', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: { deleted: true, wasSet: false },
-    });
+    stub.deleteTtsOverride.mockResolvedValue(makeOk({ deleted: true, wasSet: false }));
     const context = makeContext();
 
     await handleClear(context as never);
@@ -92,7 +88,7 @@ describe('handleTtsClear', () => {
   });
 
   it('shows error message on gateway failure', async () => {
-    mockCallGatewayApi.mockResolvedValue({ ok: false, status: 500, error: 'INTERNAL_ERROR' });
+    stub.deleteTtsOverride.mockResolvedValue(makeErr(500, 'INTERNAL_ERROR'));
     const context = makeContext();
 
     await handleClear(context as never);

--- a/services/bot-client/src/commands/voice/tts/clear.ts
+++ b/services/bot-client/src/commands/voice/tts/clear.ts
@@ -9,15 +9,10 @@ import {
   AUTOCOMPLETE_UNAVAILABLE_MESSAGE,
   isAutocompleteErrorSentinel,
 } from '../../../utils/apiCheck.js';
-import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
+import { clientsFor } from '../../../utils/gatewayClients.js';
 import { createSuccessEmbed, createInfoEmbed } from '../../../utils/commandHelpers.js';
 
 const logger = createLogger('voice-tts-clear');
-
-interface ClearResponse {
-  deleted: boolean;
-  wasSet?: boolean;
-}
 
 /** Handle /voice tts clear */
 export async function handleTtsClear(context: DeferredCommandContext): Promise<void> {
@@ -31,13 +26,8 @@ export async function handleTtsClear(context: DeferredCommandContext): Promise<v
   }
 
   try {
-    const result = await callGatewayApi<ClearResponse>(
-      `/user/tts-override/${encodeURIComponent(personalityId)}`,
-      {
-        method: 'DELETE',
-        user: toGatewayUser(context.user),
-      }
-    );
+    const { userClient } = clientsFor(context.interaction);
+    const result = await userClient.deleteTtsOverride(personalityId);
 
     if (!result.ok) {
       logger.warn({ userId, status: result.status, personalityId }, 'Failed to clear TTS override');

--- a/services/bot-client/src/commands/voice/tts/guestModeValidation.test.ts
+++ b/services/bot-client/src/commands/voice/tts/guestModeValidation.test.ts
@@ -8,15 +8,12 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { makeOk, makeErr, asUserClient } from '../../../test/gatewayClientStubs.js';
 
-const { mockCallGatewayApi } = vi.hoisted(() => ({
-  mockCallGatewayApi: vi.fn(),
-}));
-
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: mockCallGatewayApi,
-  toGatewayUser: vi.fn(user => ({ id: user.id })),
-}));
+const stub = {
+  listUserTtsConfigs: vi.fn(),
+  listVoices: vi.fn(),
+};
 
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal<typeof import('@tzurot/common-types')>();
@@ -55,65 +52,59 @@ const baseConfig = {
 describe('checkTtsByokAccess', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    stub.listUserTtsConfigs.mockReset();
+    stub.listVoices.mockReset();
   });
 
   it('allows self-hosted configs without checking keys', async () => {
-    mockCallGatewayApi.mockResolvedValueOnce({
-      ok: true,
-      data: { configs: [{ ...baseConfig, provider: 'self-hosted', name: 'kyutai-self-hosted' }] },
-    });
+    stub.listUserTtsConfigs.mockResolvedValue(
+      makeOk({
+        configs: [{ ...baseConfig, provider: 'self-hosted', name: 'kyutai-self-hosted' }],
+      })
+    );
     const context = makeContext();
 
-    const result = await checkTtsByokAccess(context as never, 'c1', {
-      id: 'discord-user-1',
-    } as never);
+    const result = await checkTtsByokAccess(context as never, 'c1', asUserClient(stub));
 
     expect(result).toEqual({ blocked: false, reason: 'self-hosted' });
-    // Should NOT have called /user/voices since self-hosted bypasses
-    expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
-    expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/tts-config', expect.any(Object));
+    // Should NOT have called listVoices since self-hosted bypasses
+    expect(stub.listVoices).not.toHaveBeenCalled();
+    expect(stub.listUserTtsConfigs).toHaveBeenCalled();
   });
 
-  it('allows mistral provider without probing /user/voices (per-provider-aware gate)', async () => {
-    // /user/voices is the ElevenLabs voices endpoint and would 404 for any
+  it('allows mistral provider without probing listVoices (per-provider-aware gate)', async () => {
+    // listVoices is the ElevenLabs voices endpoint and would 404 for any
     // user without ElevenLabs setup — even users who have a Mistral key.
     // The fix loosens the gate: non-elevenlabs configs always pass at
     // command time and the ai-worker dispatcher's isAvailable() enforces
     // at synthesis. Verify the probe is NOT called for mistral.
-    mockCallGatewayApi.mockResolvedValueOnce({
-      ok: true,
-      data: { configs: [{ ...baseConfig, provider: 'mistral', name: 'mistral-voxtral-mini' }] },
-    });
+    stub.listUserTtsConfigs.mockResolvedValue(
+      makeOk({
+        configs: [{ ...baseConfig, provider: 'mistral', name: 'mistral-voxtral-mini' }],
+      })
+    );
     const context = makeContext();
 
-    const result = await checkTtsByokAccess(context as never, 'c1', {
-      id: 'discord-user-1',
-    } as never);
+    const result = await checkTtsByokAccess(context as never, 'c1', asUserClient(stub));
 
     // 'check-skipped' (not 'has-key') is the correct audit-trail signal:
     // no verification ran, the decision was deferred to ai-worker's
     // isAvailable() at synthesis. Distinguishes "verified vs deferred"
     // for log analysis.
     expect(result).toEqual({ blocked: false, reason: 'check-skipped' });
-    // Only the /user/tts-config call — no /user/voices probe
-    expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
-    expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/tts-config', expect.any(Object));
+    expect(stub.listVoices).not.toHaveBeenCalled();
   });
 
-  it('blocks ElevenLabs provider when /user/voices returns 404 (no key)', async () => {
-    mockCallGatewayApi
-      .mockResolvedValueOnce({
-        ok: true,
-        data: {
-          configs: [{ ...baseConfig, provider: 'elevenlabs', name: 'elevenlabs-multilingual-v2' }],
-        },
+  it('blocks ElevenLabs provider when listVoices returns 404 (no key)', async () => {
+    stub.listUserTtsConfigs.mockResolvedValue(
+      makeOk({
+        configs: [{ ...baseConfig, provider: 'elevenlabs', name: 'elevenlabs-multilingual-v2' }],
       })
-      .mockResolvedValueOnce({ ok: false, status: 404, error: 'NOT_FOUND' });
+    );
+    stub.listVoices.mockResolvedValue(makeErr(404, 'NOT_FOUND'));
     const context = makeContext();
 
-    const result = await checkTtsByokAccess(context as never, 'c1', {
-      id: 'discord-user-1',
-    } as never);
+    const result = await checkTtsByokAccess(context as never, 'c1', asUserClient(stub));
 
     expect(result.blocked).toBe(true);
     expect(result.reason).toBe('blocked-byok');
@@ -130,68 +121,49 @@ describe('checkTtsByokAccess', () => {
     );
   });
 
-  it('fails open on transient /user/tts-config error', async () => {
-    mockCallGatewayApi.mockResolvedValueOnce({
-      ok: false,
-      status: 500,
-      error: 'INTERNAL_ERROR',
-    });
+  it('fails open on transient listUserTtsConfigs error', async () => {
+    stub.listUserTtsConfigs.mockResolvedValue(makeErr(500, 'INTERNAL_ERROR'));
     const context = makeContext();
 
-    const result = await checkTtsByokAccess(context as never, 'c1', {
-      id: 'discord-user-1',
-    } as never);
+    const result = await checkTtsByokAccess(context as never, 'c1', asUserClient(stub));
 
     expect(result).toEqual({ blocked: false, reason: 'check-failed' });
   });
 
-  it('fails open on transient /user/voices error for elevenlabs (non-404)', async () => {
-    mockCallGatewayApi
-      .mockResolvedValueOnce({
-        ok: true,
-        data: {
-          configs: [{ ...baseConfig, provider: 'elevenlabs', name: 'elevenlabs-multilingual-v2' }],
-        },
+  it('fails open on transient listVoices error for elevenlabs (non-404)', async () => {
+    stub.listUserTtsConfigs.mockResolvedValue(
+      makeOk({
+        configs: [{ ...baseConfig, provider: 'elevenlabs', name: 'elevenlabs-multilingual-v2' }],
       })
-      .mockResolvedValueOnce({ ok: false, status: 500, error: 'INTERNAL_ERROR' });
+    );
+    stub.listVoices.mockResolvedValue(makeErr(500, 'INTERNAL_ERROR'));
     const context = makeContext();
 
-    const result = await checkTtsByokAccess(context as never, 'c1', {
-      id: 'discord-user-1',
-    } as never);
+    const result = await checkTtsByokAccess(context as never, 'c1', asUserClient(stub));
 
     expect(result.blocked).toBe(false);
     expect(result.reason).toBe('check-failed');
   });
 
   it('fails open when configId is not in the user-visible list', async () => {
-    mockCallGatewayApi.mockResolvedValueOnce({
-      ok: true,
-      data: { configs: [] },
-    });
+    stub.listUserTtsConfigs.mockResolvedValue(makeOk({ configs: [] }));
     const context = makeContext();
 
-    const result = await checkTtsByokAccess(context as never, 'c-missing', {
-      id: 'discord-user-1',
-    } as never);
+    const result = await checkTtsByokAccess(context as never, 'c-missing', asUserClient(stub));
 
     expect(result).toEqual({ blocked: false, reason: 'no-config-found' });
   });
 
   it('allows elevenlabs provider when user has keys', async () => {
-    mockCallGatewayApi
-      .mockResolvedValueOnce({
-        ok: true,
-        data: {
-          configs: [{ ...baseConfig, provider: 'elevenlabs', name: 'elevenlabs-multilingual-v2' }],
-        },
+    stub.listUserTtsConfigs.mockResolvedValue(
+      makeOk({
+        configs: [{ ...baseConfig, provider: 'elevenlabs', name: 'elevenlabs-multilingual-v2' }],
       })
-      .mockResolvedValueOnce({ ok: true, data: { totalVoices: 5 } });
+    );
+    stub.listVoices.mockResolvedValue(makeOk({ totalVoices: 5 }));
     const context = makeContext();
 
-    const result = await checkTtsByokAccess(context as never, 'c1', {
-      id: 'discord-user-1',
-    } as never);
+    const result = await checkTtsByokAccess(context as never, 'c1', asUserClient(stub));
     expect(result).toEqual({ blocked: false, reason: 'has-key' });
   });
 });

--- a/services/bot-client/src/commands/voice/tts/guestModeValidation.ts
+++ b/services/bot-client/src/commands/voice/tts/guestModeValidation.ts
@@ -20,11 +20,9 @@ import {
   DISCORD_COLORS,
   isSelfHostedTtsProvider,
   type TtsConfigSummary,
-  type ListTtsConfigsResponse,
+  type UserClient,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import type { GatewayUser } from '../../../utils/userGatewayClient.js';
-import { callGatewayApi } from '../../../utils/userGatewayClient.js';
 
 const logger = createLogger('voice-tts-byok-validation');
 
@@ -66,15 +64,13 @@ export interface ByokAccessOutcome {
 export async function checkTtsByokAccess(
   context: DeferredCommandContext,
   configId: string,
-  user: GatewayUser
+  userClient: UserClient
 ): Promise<ByokAccessOutcome> {
   const userId = context.user.id;
 
   // Fetch the user's visible TTS configs (globals + user-owned). This
   // validates that the configId is real AND surfaces the provider field.
-  const configsResult = await callGatewayApi<ListTtsConfigsResponse>('/user/tts-config', {
-    user,
-  });
+  const configsResult = await userClient.listUserTtsConfigs();
   if (!configsResult.ok) {
     logger.warn(
       { userId, status: configsResult.status },
@@ -103,7 +99,7 @@ export async function checkTtsByokAccess(
   // voices endpoint. 404 = no ElevenLabs key configured → block at command
   // time so the user gets immediate feedback. Other errors fail-open.
   if (config.provider === 'elevenlabs') {
-    const keysResult = await callGatewayApi<{ totalVoices?: number }>('/user/voices', { user });
+    const keysResult = await userClient.listVoices();
     if (!keysResult.ok) {
       if (keysResult.status === 404) {
         const embed = new EmbedBuilder()

--- a/services/bot-client/src/commands/voice/tts/list.test.ts
+++ b/services/bot-client/src/commands/voice/tts/list.test.ts
@@ -4,15 +4,15 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { makeOk, makeErr } from '../../../test/gatewayClientStubs.js';
+import type { UserClient } from '@tzurot/common-types';
 
-const { mockCallGatewayApi } = vi.hoisted(() => ({
-  mockCallGatewayApi: vi.fn(),
-}));
+const stub = {
+  listTtsOverrides: vi.fn(),
+};
 
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: mockCallGatewayApi,
-  toGatewayUser: vi.fn(user => ({ id: user.id })),
-  GATEWAY_TIMEOUTS: { DEFERRED: 30000 },
+vi.mock('../../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
 }));
 
 vi.mock('@tzurot/common-types', async importOriginal => {
@@ -33,6 +33,7 @@ const { handleTtsListOverrides: handleListOverrides } = await import('./list.js'
 function makeContext() {
   return {
     user: { id: 'discord-user-1' },
+    interaction: {} as never,
     editReply: vi.fn(),
   };
 }
@@ -40,10 +41,11 @@ function makeContext() {
 describe('handleListOverrides', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    stub.listTtsOverrides.mockReset();
   });
 
   it('shows empty-state guidance when no overrides', async () => {
-    mockCallGatewayApi.mockResolvedValue({ ok: true, data: { overrides: [] } });
+    stub.listTtsOverrides.mockResolvedValue(makeOk({ overrides: [] }));
     const context = makeContext();
 
     await handleListOverrides(context as never);
@@ -62,9 +64,8 @@ describe('handleListOverrides', () => {
   });
 
   it('renders override list with personality+config names', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
+    stub.listTtsOverrides.mockResolvedValue(
+      makeOk({
         overrides: [
           {
             personalityId: 'p1',
@@ -73,8 +74,8 @@ describe('handleListOverrides', () => {
             configName: 'kyutai-self-hosted',
           },
         ],
-      },
-    });
+      })
+    );
     const context = makeContext();
 
     await handleListOverrides(context as never);
@@ -93,7 +94,7 @@ describe('handleListOverrides', () => {
   });
 
   it('shows error message on gateway failure', async () => {
-    mockCallGatewayApi.mockResolvedValue({ ok: false, status: 500, error: 'INTERNAL_ERROR' });
+    stub.listTtsOverrides.mockResolvedValue(makeErr(500, 'INTERNAL_ERROR'));
     const context = makeContext();
 
     await handleListOverrides(context as never);

--- a/services/bot-client/src/commands/voice/tts/list.ts
+++ b/services/bot-client/src/commands/voice/tts/list.ts
@@ -8,29 +8,19 @@
  */
 
 import { EmbedBuilder, escapeMarkdown } from 'discord.js';
-import { createLogger, DISCORD_COLORS, type TtsOverrideSummary } from '@tzurot/common-types';
+import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import {
-  callGatewayApi,
-  GATEWAY_TIMEOUTS,
-  toGatewayUser,
-} from '../../../utils/userGatewayClient.js';
+import { clientsFor } from '../../../utils/gatewayClients.js';
 
 const logger = createLogger('voice-tts-browse');
-
-interface ListResponse {
-  overrides: TtsOverrideSummary[];
-}
 
 /** Handle /voice tts list */
 export async function handleTtsListOverrides(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
 
   try {
-    const result = await callGatewayApi<ListResponse>('/user/tts-override', {
-      user: toGatewayUser(context.user),
-      timeout: GATEWAY_TIMEOUTS.DEFERRED,
-    });
+    const { userClient } = clientsFor(context.interaction);
+    const result = await userClient.listTtsOverrides();
 
     if (!result.ok) {
       logger.warn({ userId, status: result.status }, 'Failed to list TTS overrides');

--- a/services/bot-client/src/commands/voice/tts/set-default.test.ts
+++ b/services/bot-client/src/commands/voice/tts/set-default.test.ts
@@ -4,15 +4,19 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { makeOk, makeErr } from '../../../test/gatewayClientStubs.js';
+import type { UserClient } from '@tzurot/common-types';
 
-const { mockCallGatewayApi, mockCheckTtsByokAccess } = vi.hoisted(() => ({
-  mockCallGatewayApi: vi.fn(),
+const { mockCheckTtsByokAccess } = vi.hoisted(() => ({
   mockCheckTtsByokAccess: vi.fn(),
 }));
 
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: mockCallGatewayApi,
-  toGatewayUser: vi.fn(user => ({ id: user.id })),
+const stub = {
+  setTtsDefaultConfig: vi.fn(),
+};
+
+vi.mock('../../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
 }));
 
 vi.mock('./guestModeValidation.js', () => ({
@@ -48,6 +52,7 @@ function makeContext() {
 describe('handleSetDefault', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    stub.setTtsDefaultConfig.mockReset();
   });
 
   it('blocks at command time when BYOK gate fails', async () => {
@@ -56,26 +61,19 @@ describe('handleSetDefault', () => {
 
     await handleSetDefault(context as never);
 
-    expect(mockCallGatewayApi).not.toHaveBeenCalled();
+    expect(stub.setTtsDefaultConfig).not.toHaveBeenCalled();
   });
 
-  it('PUTs /user/tts-override/default on happy path', async () => {
+  it('calls setTtsDefaultConfig on happy path', async () => {
     mockCheckTtsByokAccess.mockResolvedValue({ blocked: false, reason: 'self-hosted' });
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: { default: { configId: 'cfg-uuid-1', configName: 'kyutai-self-hosted' } },
-    });
+    stub.setTtsDefaultConfig.mockResolvedValue(
+      makeOk({ default: { configId: 'cfg-uuid-1', configName: 'kyutai-self-hosted' } })
+    );
     const context = makeContext();
 
     await handleSetDefault(context as never);
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith(
-      '/user/tts-override/default',
-      expect.objectContaining({
-        method: 'PUT',
-        body: { configId: 'cfg-uuid-1' },
-      })
-    );
+    expect(stub.setTtsDefaultConfig).toHaveBeenCalledWith({ configId: 'cfg-uuid-1' });
     expect(context.editReply).toHaveBeenCalledWith(
       expect.objectContaining({
         embeds: [
@@ -89,7 +87,7 @@ describe('handleSetDefault', () => {
 
   it('shows error embed on gateway failure', async () => {
     mockCheckTtsByokAccess.mockResolvedValue({ blocked: false, reason: 'has-key' });
-    mockCallGatewayApi.mockResolvedValue({ ok: false, status: 500, error: 'INTERNAL_ERROR' });
+    stub.setTtsDefaultConfig.mockResolvedValue(makeErr(500, 'INTERNAL_ERROR'));
     const context = makeContext();
 
     await handleSetDefault(context as never);

--- a/services/bot-client/src/commands/voice/tts/set-default.ts
+++ b/services/bot-client/src/commands/voice/tts/set-default.ts
@@ -11,17 +11,10 @@ import {
   AUTOCOMPLETE_UNAVAILABLE_MESSAGE,
   isAutocompleteErrorSentinel,
 } from '../../../utils/apiCheck.js';
-import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
+import { clientsFor } from '../../../utils/gatewayClients.js';
 import { checkTtsByokAccess } from './guestModeValidation.js';
 
 const logger = createLogger('voice-tts-set-default');
-
-interface SetDefaultResponse {
-  default: {
-    configId: string;
-    configName: string;
-  };
-}
 
 /** Handle /voice tts set-default */
 export async function handleTtsSetDefault(context: DeferredCommandContext): Promise<void> {
@@ -38,21 +31,17 @@ export async function handleTtsSetDefault(context: DeferredCommandContext): Prom
   }
 
   try {
-    const user = toGatewayUser(context.user);
+    const { userClient } = clientsFor(context.interaction);
 
     // BYOK gate: block at command time if config requires a provider key
     // the user hasn't configured. Self-hosted always allowed; mistral and
     // elevenlabs require BYOK keys.
-    const outcome = await checkTtsByokAccess(context, configId, user);
+    const outcome = await checkTtsByokAccess(context, configId, userClient);
     if (outcome.blocked) {
       return;
     }
 
-    const result = await callGatewayApi<SetDefaultResponse>('/user/tts-override/default', {
-      method: 'PUT',
-      user,
-      body: { configId },
-    });
+    const result = await userClient.setTtsDefaultConfig({ configId });
 
     if (!result.ok) {
       logger.warn({ userId, status: result.status, configId }, 'Failed to set default TTS');

--- a/services/bot-client/src/commands/voice/tts/set.test.ts
+++ b/services/bot-client/src/commands/voice/tts/set.test.ts
@@ -4,15 +4,19 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { makeOk, makeErr } from '../../../test/gatewayClientStubs.js';
+import type { UserClient } from '@tzurot/common-types';
 
-const { mockCallGatewayApi, mockCheckTtsByokAccess } = vi.hoisted(() => ({
-  mockCallGatewayApi: vi.fn(),
+const { mockCheckTtsByokAccess } = vi.hoisted(() => ({
   mockCheckTtsByokAccess: vi.fn(),
 }));
 
-vi.mock('../../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: mockCallGatewayApi,
-  toGatewayUser: vi.fn(user => ({ id: user.id })),
+const stub = {
+  setTtsOverride: vi.fn(),
+};
+
+vi.mock('../../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
 }));
 
 vi.mock('./guestModeValidation.js', () => ({
@@ -54,6 +58,7 @@ function makeContext() {
 describe('handleTtsSet', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    stub.setTtsOverride.mockReset();
   });
 
   it('blocks at command time when BYOK gate fails', async () => {
@@ -61,33 +66,29 @@ describe('handleTtsSet', () => {
     const context = makeContext();
 
     await handleSet(context as never);
-    expect(mockCallGatewayApi).not.toHaveBeenCalled();
+    expect(stub.setTtsOverride).not.toHaveBeenCalled();
   });
 
-  it('PUTs /user/tts-override on happy path', async () => {
+  it('calls setTtsOverride on happy path', async () => {
     mockCheckTtsByokAccess.mockResolvedValue({ blocked: false, reason: 'has-key' });
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
+    stub.setTtsOverride.mockResolvedValue(
+      makeOk({
         override: {
           personalityId: 'personality-uuid-1',
           personalityName: 'Alice',
           configId: 'cfg-uuid-1',
           configName: 'kyutai-self-hosted',
         },
-      },
-    });
+      })
+    );
     const context = makeContext();
 
     await handleSet(context as never);
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith(
-      '/user/tts-override',
-      expect.objectContaining({
-        method: 'PUT',
-        body: { personalityId: 'personality-uuid-1', configId: 'cfg-uuid-1' },
-      })
-    );
+    expect(stub.setTtsOverride).toHaveBeenCalledWith({
+      personalityId: 'personality-uuid-1',
+      configId: 'cfg-uuid-1',
+    });
     expect(context.editReply).toHaveBeenCalledWith(
       expect.objectContaining({
         embeds: [
@@ -101,7 +102,7 @@ describe('handleTtsSet', () => {
 
   it('shows error embed on gateway failure', async () => {
     mockCheckTtsByokAccess.mockResolvedValue({ blocked: false, reason: 'has-key' });
-    mockCallGatewayApi.mockResolvedValue({ ok: false, status: 500, error: 'INTERNAL_ERROR' });
+    stub.setTtsOverride.mockResolvedValue(makeErr(500, 'INTERNAL_ERROR'));
     const context = makeContext();
 
     await handleSet(context as never);

--- a/services/bot-client/src/commands/voice/tts/set.ts
+++ b/services/bot-client/src/commands/voice/tts/set.ts
@@ -10,19 +10,10 @@ import {
   AUTOCOMPLETE_UNAVAILABLE_MESSAGE,
   isAutocompleteErrorSentinel,
 } from '../../../utils/apiCheck.js';
-import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
+import { clientsFor } from '../../../utils/gatewayClients.js';
 import { checkTtsByokAccess } from './guestModeValidation.js';
 
 const logger = createLogger('voice-tts-set');
-
-interface SetResponse {
-  override: {
-    personalityId: string;
-    personalityName: string;
-    configId: string | null;
-    configName: string | null;
-  };
-}
 
 /** Handle /voice tts set */
 export async function handleTtsSet(context: DeferredCommandContext): Promise<void> {
@@ -37,18 +28,14 @@ export async function handleTtsSet(context: DeferredCommandContext): Promise<voi
   }
 
   try {
-    const user = toGatewayUser(context.user);
+    const { userClient } = clientsFor(context.interaction);
 
-    const outcome = await checkTtsByokAccess(context, configId, user);
+    const outcome = await checkTtsByokAccess(context, configId, userClient);
     if (outcome.blocked) {
       return;
     }
 
-    const result = await callGatewayApi<SetResponse>('/user/tts-override', {
-      method: 'PUT',
-      user,
-      body: { personalityId, configId },
-    });
+    const result = await userClient.setTtsOverride({ personalityId, configId });
 
     if (!result.ok) {
       logger.warn(

--- a/services/bot-client/src/commands/voice/view.test.ts
+++ b/services/bot-client/src/commands/voice/view.test.ts
@@ -6,14 +6,15 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { makeOk, makeErr } from '../../test/gatewayClientStubs.js';
+import type { UserClient } from '@tzurot/common-types';
 
-const { mockCallGatewayApi } = vi.hoisted(() => ({
-  mockCallGatewayApi: vi.fn(),
-}));
+const stub = {
+  getVoiceResolution: vi.fn(),
+};
 
-vi.mock('../../utils/userGatewayClient.js', () => ({
-  callGatewayApi: mockCallGatewayApi,
-  toGatewayUser: vi.fn(user => ({ id: user.id })),
+vi.mock('../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
 }));
 
 vi.mock('@tzurot/common-types', async importOriginal => {
@@ -43,12 +44,14 @@ function makeContext() {
 }
 
 describe('handleVoiceView', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stub.getVoiceResolution.mockReset();
+  });
 
-  it('GETs /user/voice-resolution with the encoded personalityId', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
+  it('calls userClient.getVoiceResolution with the picked personalityId', async () => {
+    stub.getVoiceResolution.mockResolvedValue(
+      makeOk({
         personalityName: 'Test Character',
         tts: {
           configId: 'cfg-1',
@@ -58,15 +61,12 @@ describe('handleVoiceView', () => {
         },
         stt: { provider: 'voice-engine', source: 'hardcoded' },
         voices: { tzurotCount: 0, totalVoices: 0, previewSlugs: [] },
-      },
-    });
+      })
+    );
 
     await handleVoiceView(makeContext() as never);
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith(
-      '/user/voice-resolution?personalityId=personality-uuid-1',
-      expect.objectContaining({ method: 'GET' })
-    );
+    expect(stub.getVoiceResolution).toHaveBeenCalledWith({ personalityId: 'personality-uuid-1' });
   });
 
   it('renders an embed scoped to the resolved character (title + TTS + STT)', async () => {
@@ -74,9 +74,8 @@ describe('handleVoiceView', () => {
     // the embed title MUST name the character so the view doesn't read like
     // global state. Cloned-voice library is intentionally NOT shown — that's
     // user-scoped and lives in /voice voices browse.
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
+    stub.getVoiceResolution.mockResolvedValue(
+      makeOk({
         personalityName: 'Lila',
         tts: {
           configId: 'cfg-1',
@@ -90,8 +89,8 @@ describe('handleVoiceView', () => {
           totalVoices: 3,
           previewSlugs: ['alice', 'bob', 'carol'],
         },
-      },
-    });
+      })
+    );
     const context = makeContext();
 
     await handleVoiceView(context as never);
@@ -123,9 +122,8 @@ describe('handleVoiceView', () => {
       // Pins each cascade-source branch in the label switch — without this,
       // a future cascade-source addition that forgets a `case` arm would
       // silently produce `undefined` in the embed body.
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: {
+      stub.getVoiceResolution.mockResolvedValue(
+        makeOk({
           personalityName: 'Char',
           tts: {
             configId: null,
@@ -135,8 +133,8 @@ describe('handleVoiceView', () => {
           },
           stt: { provider: 'voice-engine', source: sttSource },
           voices: { tzurotCount: 0, totalVoices: 0, previewSlugs: [] },
-        },
-      });
+        })
+      );
       const context = makeContext();
       await handleVoiceView(context as never);
 
@@ -151,7 +149,7 @@ describe('handleVoiceView', () => {
   );
 
   it('reports gateway error', async () => {
-    mockCallGatewayApi.mockResolvedValue({ ok: false, status: 500, error: 'oops' });
+    stub.getVoiceResolution.mockResolvedValue(makeErr(500, 'oops'));
     const context = makeContext();
 
     await handleVoiceView(context as never);
@@ -167,6 +165,6 @@ describe('handleVoiceView', () => {
 
     await handleVoiceView(makeContext() as never);
 
-    expect(mockCallGatewayApi).not.toHaveBeenCalled();
+    expect(stub.getVoiceResolution).not.toHaveBeenCalled();
   });
 });

--- a/services/bot-client/src/commands/voice/view.ts
+++ b/services/bot-client/src/commands/voice/view.ts
@@ -20,7 +20,6 @@ import {
   voiceViewOptions,
   sttProviderDisplayName,
   isSttProvider,
-  type GetVoiceResolutionResponse,
   type SttResolutionSource,
   type TtsResolutionSource,
 } from '@tzurot/common-types';
@@ -29,7 +28,7 @@ import {
   AUTOCOMPLETE_UNAVAILABLE_MESSAGE,
   isAutocompleteErrorSentinel,
 } from '../../utils/apiCheck.js';
-import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
+import { clientsFor } from '../../utils/gatewayClients.js';
 
 const logger = createLogger('voice-view');
 
@@ -85,10 +84,8 @@ export async function handleVoiceView(context: DeferredCommandContext): Promise<
   }
 
   try {
-    const result = await callGatewayApi<GetVoiceResolutionResponse>(
-      `/user/voice-resolution?personalityId=${encodeURIComponent(personalityId)}`,
-      { method: 'GET', user: toGatewayUser(context.user) }
-    );
+    const { userClient } = clientsFor(context.interaction);
+    const result = await userClient.getVoiceResolution({ personalityId });
 
     if (!result.ok) {
       logger.warn({ userId, personalityId, status: result.status }, 'Failed to resolve voice view');

--- a/services/bot-client/src/commands/voice/voices/browse.test.ts
+++ b/services/bot-client/src/commands/voice/voices/browse.test.ts
@@ -11,6 +11,8 @@ import {
 } from './browse.js';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
 import type { VoiceEntry } from './types.js';
+import { makeOk, makeErr } from '../../../test/gatewayClientStubs.js';
+import type { UserClient } from '@tzurot/common-types';
 
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal<typeof import('@tzurot/common-types')>();
@@ -25,16 +27,13 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
-const mockCallGatewayApi = vi.fn();
-vi.mock('../../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
-    '../../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  };
-});
+const stub = {
+  listVoices: vi.fn(),
+};
+
+vi.mock('../../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
+}));
 
 /** Generate N voice entries for pagination tests */
 function generateVoices(count: number): VoiceEntry[] {
@@ -51,6 +50,7 @@ describe('handleBrowseVoices', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    stub.listVoices.mockReset();
   });
 
   function createMockContext(): DeferredCommandContext {
@@ -80,26 +80,20 @@ describe('handleBrowseVoices', () => {
   }
 
   it('should list voices successfully with no pagination buttons for small lists', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
+    stub.listVoices.mockResolvedValue(
+      makeOk({
         voices: [
           { provider: 'elevenlabs', voiceId: 'v1', name: 'tzurot-alice', slug: 'alice' },
           { provider: 'mistral', voiceId: 'v2', name: 'tzurot-bob', slug: 'bob' },
         ],
         totalVoices: 10,
         tzurotCount: 2,
-      },
-    });
+      })
+    );
 
     await handleBrowseVoices(createMockContext());
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith(
-      '/user/voices',
-      expect.objectContaining({
-        user: { discordId: 'user-123', username: 'testuser', displayName: 'testuser' },
-      })
-    );
+    expect(stub.listVoices).toHaveBeenCalled();
     expect(mockEditReply).toHaveBeenCalledWith({
       embeds: [
         expect.objectContaining({
@@ -116,14 +110,13 @@ describe('handleBrowseVoices', () => {
   it('should show pagination buttons when voices exceed page size', async () => {
     const voices = generateVoices(12); // 12 voices = 2 pages at 10/page
 
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
+    stub.listVoices.mockResolvedValue(
+      makeOk({
         voices,
         totalVoices: 30,
         tzurotCount: 12,
-      },
-    });
+      })
+    );
 
     await handleBrowseVoices(createMockContext());
 
@@ -147,14 +140,13 @@ describe('handleBrowseVoices', () => {
   });
 
   it('should show management hints on first page only', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
+    stub.listVoices.mockResolvedValue(
+      makeOk({
         voices: [{ provider: 'elevenlabs', voiceId: 'v1', name: 'tzurot-alice', slug: 'alice' }],
         totalVoices: 5,
         tzurotCount: 1,
-      },
-    });
+      })
+    );
 
     await handleBrowseVoices(createMockContext());
 
@@ -170,14 +162,13 @@ describe('handleBrowseVoices', () => {
   });
 
   it('should show empty state when no voices', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
+    stub.listVoices.mockResolvedValue(
+      makeOk({
         voices: [],
         totalVoices: 5,
         tzurotCount: 0,
-      },
-    });
+      })
+    );
 
     await handleBrowseVoices(createMockContext());
 
@@ -194,15 +185,14 @@ describe('handleBrowseVoices', () => {
   });
 
   it('should render warnings field above voices when gateway surfaces provider failures', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
+    stub.listVoices.mockResolvedValue(
+      makeOk({
         voices: generateVoices(2),
         totalVoices: 2,
         tzurotCount: 2,
         warnings: [{ provider: 'mistral', message: 'API key invalid or expired' }],
-      },
-    });
+      })
+    );
 
     await handleBrowseVoices(createMockContext());
 
@@ -225,15 +215,14 @@ describe('handleBrowseVoices', () => {
   });
 
   it('uses correct display name for elevenlabs warnings (regression for ternary mislabeling)', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
+    stub.listVoices.mockResolvedValue(
+      makeOk({
         voices: generateVoices(2),
         totalVoices: 2,
         tzurotCount: 2,
         warnings: [{ provider: 'elevenlabs', message: 'Provider temporarily unavailable' }],
-      },
-    });
+      })
+    );
 
     await handleBrowseVoices(createMockContext());
 
@@ -255,11 +244,7 @@ describe('handleBrowseVoices', () => {
   });
 
   it('should handle API error', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: false,
-      status: 404,
-      error: 'ElevenLabs API key not found',
-    });
+    stub.listVoices.mockResolvedValue(makeErr(404, 'ElevenLabs API key not found'));
 
     await handleBrowseVoices(createMockContext());
 
@@ -269,7 +254,7 @@ describe('handleBrowseVoices', () => {
   });
 
   it('should handle exceptions', async () => {
-    mockCallGatewayApi.mockRejectedValue(new Error('Network error'));
+    stub.listVoices.mockRejectedValue(new Error('Network error'));
 
     await handleBrowseVoices(createMockContext());
 
@@ -300,6 +285,7 @@ describe('handleVoiceBrowsePagination', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    stub.listVoices.mockReset();
   });
 
   function createMockButtonInteraction(customId: string): ButtonInteraction {
@@ -314,10 +300,7 @@ describe('handleVoiceBrowsePagination', () => {
   it('should navigate to requested page', async () => {
     const voices = generateVoices(12);
 
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: { voices, totalVoices: 30, tzurotCount: 12 },
-    });
+    stub.listVoices.mockResolvedValue(makeOk({ voices, totalVoices: 30, tzurotCount: 12 }));
 
     // Click "next" to go to page 1
     await handleVoiceBrowsePagination(
@@ -346,14 +329,11 @@ describe('handleVoiceBrowsePagination', () => {
     await handleVoiceBrowsePagination(createMockButtonInteraction('garbage-custom-id'));
 
     expect(mockDeferUpdate).not.toHaveBeenCalled();
-    expect(mockCallGatewayApi).not.toHaveBeenCalled();
+    expect(stub.listVoices).not.toHaveBeenCalled();
   });
 
   it('should handle API error during pagination', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: false,
-      error: 'ElevenLabs key expired',
-    });
+    stub.listVoices.mockResolvedValue(makeErr(500, 'ElevenLabs key expired'));
 
     await handleVoiceBrowsePagination(
       createMockButtonInteraction('voice-voices::browse::1::all::')
@@ -368,7 +348,7 @@ describe('handleVoiceBrowsePagination', () => {
   });
 
   it('should keep existing content on fetch exception', async () => {
-    mockCallGatewayApi.mockRejectedValue(new Error('Network error'));
+    stub.listVoices.mockRejectedValue(new Error('Network error'));
 
     await handleVoiceBrowsePagination(
       createMockButtonInteraction('voice-voices::browse::1::all::')

--- a/services/bot-client/src/commands/voice/voices/browse.ts
+++ b/services/bot-client/src/commands/voice/voices/browse.ts
@@ -8,11 +8,7 @@ import { EmbedBuilder } from 'discord.js';
 import type { ButtonInteraction, ActionRowBuilder, ButtonBuilder } from 'discord.js';
 import { createLogger, DISCORD_COLORS, type AudioProviderId } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import {
-  callGatewayApi,
-  GATEWAY_TIMEOUTS,
-  toGatewayUser,
-} from '../../../utils/userGatewayClient.js';
+import { clientsFor } from '../../../utils/gatewayClients.js';
 import {
   ITEMS_PER_PAGE,
   createBrowseCustomIdHelpers,
@@ -162,10 +158,8 @@ export async function handleBrowseVoices(context: DeferredCommandContext): Promi
   const userId = context.user.id;
 
   try {
-    const result = await callGatewayApi<VoicesListResponse>('/user/voices', {
-      user: toGatewayUser(context.user),
-      timeout: GATEWAY_TIMEOUTS.DEFERRED,
-    });
+    const { userClient } = clientsFor(context.interaction);
+    const result = await userClient.listVoices();
 
     if (!result.ok) {
       await context.editReply({ content: `❌ ${result.error}` });
@@ -200,10 +194,8 @@ export async function handleVoiceBrowsePagination(interaction: ButtonInteraction
   const userId = interaction.user.id;
 
   try {
-    const result = await callGatewayApi<VoicesListResponse>('/user/voices', {
-      user: toGatewayUser(interaction.user),
-      timeout: GATEWAY_TIMEOUTS.DEFERRED,
-    });
+    const { userClient } = clientsFor(interaction);
+    const result = await userClient.listVoices();
 
     if (!result.ok) {
       await interaction.editReply({ content: `❌ ${result.error}`, embeds: [], components: [] });

--- a/services/bot-client/src/commands/voice/voices/clear.test.ts
+++ b/services/bot-client/src/commands/voice/voices/clear.test.ts
@@ -15,6 +15,8 @@ import {
   VOICE_CLEAR_OPERATION,
 } from './clear.js';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
+import { makeOk, makeErr } from '../../../test/gatewayClientStubs.js';
+import type { UserClient } from '@tzurot/common-types';
 
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal<typeof import('@tzurot/common-types')>();
@@ -29,16 +31,14 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
-const mockCallGatewayApi = vi.fn();
-vi.mock('../../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
-    '../../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  };
-});
+const stub = {
+  listVoices: vi.fn(),
+  clearVoices: vi.fn(),
+};
+
+vi.mock('../../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
+}));
 
 const mockBuildDestructiveWarning = vi.fn().mockReturnValue({ embeds: [], components: [] });
 const mockHandleDestructiveConfirmButton = vi.fn();
@@ -73,6 +73,8 @@ describe('handleClearVoices', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    stub.listVoices.mockReset();
+    stub.clearVoices.mockReset();
   });
 
   function createMockContext(): DeferredCommandContext {
@@ -102,17 +104,16 @@ describe('handleClearVoices', () => {
   }
 
   it('should show destructive warning when voices exist', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
+    stub.listVoices.mockResolvedValue(
+      makeOk({
         voices: [
           { voiceId: 'v1', name: 'tzurot-alice', slug: 'alice' },
           { voiceId: 'v2', name: 'tzurot-bob', slug: 'bob' },
         ],
         totalVoices: 10,
         tzurotCount: 2,
-      },
-    });
+      })
+    );
 
     await handleClearVoices(createMockContext());
 
@@ -126,17 +127,16 @@ describe('handleClearVoices', () => {
   });
 
   it('warning entityName does not include a numeric count (avoids snapshot drift)', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
+    stub.listVoices.mockResolvedValue(
+      makeOk({
         voices: [
           { voiceId: 'v1', name: 'tzurot-alice', slug: 'alice' },
           { voiceId: 'v2', name: 'tzurot-bob', slug: 'bob' },
         ],
         totalVoices: 10,
         tzurotCount: 2,
-      },
-    });
+      })
+    );
 
     await handleClearVoices(createMockContext());
 
@@ -149,10 +149,7 @@ describe('handleClearVoices', () => {
   });
 
   it('should show message when no voices to clear', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: { voices: [], totalVoices: 5, tzurotCount: 0 },
-    });
+    stub.listVoices.mockResolvedValue(makeOk({ voices: [], totalVoices: 5, tzurotCount: 0 }));
 
     await handleClearVoices(createMockContext());
 
@@ -163,11 +160,7 @@ describe('handleClearVoices', () => {
   });
 
   it('should handle API error', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: false,
-      status: 404,
-      error: 'ElevenLabs API key not found',
-    });
+    stub.listVoices.mockResolvedValue(makeErr(404, 'ElevenLabs API key not found'));
 
     await handleClearVoices(createMockContext());
 
@@ -177,7 +170,7 @@ describe('handleClearVoices', () => {
   });
 
   it('should handle exceptions', async () => {
-    mockCallGatewayApi.mockRejectedValue(new Error('Network error'));
+    stub.listVoices.mockRejectedValue(new Error('Network error'));
 
     await handleClearVoices(createMockContext());
 

--- a/services/bot-client/src/commands/voice/voices/clear.test.ts
+++ b/services/bot-client/src/commands/voice/voices/clear.test.ts
@@ -216,6 +216,7 @@ describe('handleVoiceClearButton', () => {
 describe('handleVoiceClearModal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    stub.clearVoices.mockReset();
   });
 
   it('should handle modal submit', async () => {
@@ -227,5 +228,28 @@ describe('handleVoiceClearModal', () => {
     await handleVoiceClearModal(interaction);
 
     expect(mockHandleDestructiveModalSubmit).toHaveBeenCalled();
+  });
+
+  it('invokes clearVoices via the typed client when the destructive callback runs', async () => {
+    // The handler delegates to `handleDestructiveModalSubmit`, which decides
+    // whether to run the inner callback. Drive the mock to invoke the
+    // callback so the userClient.clearVoices closure is exercised.
+    mockHandleDestructiveModalSubmit.mockImplementationOnce(
+      async (_interaction, _word, callback) => {
+        await callback();
+      }
+    );
+    stub.clearVoices.mockResolvedValue({
+      ok: true,
+      data: { deleted: 3, total: 3 },
+    });
+    const interaction = {
+      customId: `voice::destructive::modal_submit::${VOICE_CLEAR_OPERATION}::all`,
+      user: { id: 'user-123' },
+    } as unknown as ModalSubmitInteraction;
+
+    await handleVoiceClearModal(interaction);
+
+    expect(stub.clearVoices).toHaveBeenCalled();
   });
 });

--- a/services/bot-client/src/commands/voice/voices/clear.ts
+++ b/services/bot-client/src/commands/voice/voices/clear.ts
@@ -13,11 +13,7 @@ import { EmbedBuilder } from 'discord.js';
 import type { ButtonInteraction, ModalSubmitInteraction } from 'discord.js';
 import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import {
-  callGatewayApi,
-  GATEWAY_TIMEOUTS,
-  toGatewayUser,
-} from '../../../utils/userGatewayClient.js';
+import { clientsFor } from '../../../utils/gatewayClients.js';
 import {
   buildDestructiveWarning,
   createHardDeleteConfig,
@@ -26,20 +22,12 @@ import {
   handleDestructiveModalSubmit,
 } from '../../../utils/destructiveConfirmation.js';
 import { DestructiveCustomIds } from '../../../utils/customIds.js';
-import type { VoicesListResponse } from './types.js';
 import { invalidateVoiceCache } from './voiceCache.js';
 
 const logger = createLogger('voice-voices-clear');
 
 /** Operation name for destructive confirmation custom IDs */
 export const VOICE_CLEAR_OPERATION = 'voice-clear';
-
-interface VoiceClearResponse {
-  deleted: number;
-  total: number;
-  message?: string;
-  errors?: string[];
-}
 
 /**
  * Handle /voice voices clear
@@ -49,10 +37,8 @@ export async function handleClearVoices(context: DeferredCommandContext): Promis
   const userId = context.user.id;
 
   try {
-    const result = await callGatewayApi<VoicesListResponse>('/user/voices', {
-      user: toGatewayUser(context.user),
-      timeout: GATEWAY_TIMEOUTS.DEFERRED,
-    });
+    const { userClient } = clientsFor(context.interaction);
+    const result = await userClient.listVoices();
 
     if (!result.ok) {
       await context.editReply({ content: `❌ ${result.error}` });
@@ -118,11 +104,8 @@ export async function handleVoiceClearModalSubmit(
   const userId = interaction.user.id;
 
   await handleDestructiveModalSubmit(interaction, 'DELETE', async () => {
-    const result = await callGatewayApi<VoiceClearResponse>('/user/voices/clear', {
-      method: 'POST',
-      user: toGatewayUser(interaction.user),
-      timeout: GATEWAY_TIMEOUTS.BULK_OPERATION,
-    });
+    const { userClient } = clientsFor(interaction);
+    const result = await userClient.clearVoices();
 
     if (!result.ok) {
       return { success: false, errorMessage: `❌ ${result.error}` };

--- a/services/bot-client/src/commands/voice/voices/delete.test.ts
+++ b/services/bot-client/src/commands/voice/voices/delete.test.ts
@@ -2,7 +2,7 @@
  * Tests for Voice Delete Handler and Autocomplete (provider-agnostic)
  *
  * Autocomplete value encodes `${provider}:${voiceId}`; the handler splits
- * it on the seam to route to the right gateway URL.
+ * it on the seam to route to the right typed-client method.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -10,6 +10,8 @@ import type { ChatInputCommandInteraction, AutocompleteInteraction } from 'disco
 import { handleDeleteVoice, handleVoiceAutocomplete } from './delete.js';
 import { _clearVoiceCacheForTesting } from './voiceCache.js';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
+import { makeOk, makeErr } from '../../../test/gatewayClientStubs.js';
+import type { UserClient } from '@tzurot/common-types';
 
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal<typeof import('@tzurot/common-types')>();
@@ -24,22 +26,22 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
-const mockCallGatewayApi = vi.fn();
-vi.mock('../../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
-    '../../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  };
-});
+const stub = {
+  deleteVoice: vi.fn(),
+  listVoices: vi.fn(),
+};
+
+vi.mock('../../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
+}));
 
 describe('handleDeleteVoice', () => {
   const mockEditReply = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
+    stub.deleteVoice.mockReset();
+    stub.listVoices.mockReset();
   });
 
   function createMockContext(optionValue = 'elevenlabs:voice-1'): DeferredCommandContext {
@@ -68,27 +70,20 @@ describe('handleDeleteVoice', () => {
     } as unknown as DeferredCommandContext;
   }
 
-  it('routes ElevenLabs voice deletion to the correct gateway URL', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
+  it('routes ElevenLabs voice deletion via the typed client', async () => {
+    stub.deleteVoice.mockResolvedValue(
+      makeOk({
         deleted: true,
         provider: 'elevenlabs',
         voiceId: 'voice-1',
         name: 'tzurot-alice',
         slug: 'alice',
-      },
-    });
+      })
+    );
 
     await handleDeleteVoice(createMockContext('elevenlabs:voice-1'));
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith(
-      '/user/voices/elevenlabs/voice-1',
-      expect.objectContaining({
-        method: 'DELETE',
-        user: { discordId: 'user-123', username: 'testuser', displayName: 'testuser' },
-      })
-    );
+    expect(stub.deleteVoice).toHaveBeenCalledWith('elevenlabs', 'voice-1');
     expect(mockEditReply).toHaveBeenCalledWith({
       embeds: [
         expect.objectContaining({
@@ -101,41 +96,26 @@ describe('handleDeleteVoice', () => {
     });
   });
 
-  it('routes Mistral voice deletion to the Mistral-tagged URL', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
+  it('routes Mistral voice deletion via the typed client', async () => {
+    stub.deleteVoice.mockResolvedValue(
+      makeOk({
         deleted: true,
         provider: 'mistral',
         voiceId: 'mi-voice-1',
         name: 'tzurot-charlie',
         slug: 'charlie',
-      },
-    });
+      })
+    );
 
     await handleDeleteVoice(createMockContext('mistral:mi-voice-1'));
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith(
-      '/user/voices/mistral/mi-voice-1',
-      expect.objectContaining({ method: 'DELETE' })
-    );
-  });
-
-  it('encodes the voiceId portion (defense against weird ids)', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: { deleted: true, provider: 'mistral', voiceId: 'a/b', name: 'x', slug: 'x' },
-    });
-    await handleDeleteVoice(createMockContext('mistral:a/b'));
-
-    const url = mockCallGatewayApi.mock.calls[0][0] as string;
-    expect(url).toBe('/user/voices/mistral/a%2Fb');
+    expect(stub.deleteVoice).toHaveBeenCalledWith('mistral', 'mi-voice-1');
   });
 
   it('rejects malformed option value (not provider:id) with a friendly error', async () => {
     await handleDeleteVoice(createMockContext('not-a-composite-id'));
 
-    expect(mockCallGatewayApi).not.toHaveBeenCalled();
+    expect(stub.deleteVoice).not.toHaveBeenCalled();
     expect(mockEditReply).toHaveBeenCalledWith(
       expect.objectContaining({
         content: expect.stringContaining('Invalid voice selection'),
@@ -146,18 +126,14 @@ describe('handleDeleteVoice', () => {
   it('rejects unknown provider segment in option value', async () => {
     await handleDeleteVoice(createMockContext('openai:some-voice'));
 
-    expect(mockCallGatewayApi).not.toHaveBeenCalled();
+    expect(stub.deleteVoice).not.toHaveBeenCalled();
     expect(mockEditReply).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('Invalid voice selection') })
     );
   });
 
   it('handles not-found error from gateway', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: false,
-      status: 404,
-      error: 'Voice not found',
-    });
+    stub.deleteVoice.mockResolvedValue(makeErr(404, 'Voice not found'));
 
     await handleDeleteVoice(createMockContext('elevenlabs:nonexistent'));
 
@@ -165,7 +141,7 @@ describe('handleDeleteVoice', () => {
   });
 
   it('handles unexpected exceptions gracefully', async () => {
-    mockCallGatewayApi.mockRejectedValue(new Error('Network error'));
+    stub.deleteVoice.mockRejectedValue(new Error('Network error'));
 
     await handleDeleteVoice(createMockContext('elevenlabs:voice-1'));
 
@@ -180,6 +156,8 @@ describe('handleVoiceAutocomplete', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    stub.deleteVoice.mockReset();
+    stub.listVoices.mockReset();
     _clearVoiceCacheForTesting();
   });
 
@@ -196,17 +174,16 @@ describe('handleVoiceAutocomplete', () => {
   }
 
   it('emits provider-tagged choices with composite values', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
+    stub.listVoices.mockResolvedValue(
+      makeOk({
         voices: [
           { provider: 'elevenlabs', voiceId: 'el1', name: 'tzurot-alice', slug: 'alice' },
           { provider: 'mistral', voiceId: 'mi1', name: 'tzurot-bob', slug: 'bob' },
         ],
         totalVoices: 10,
         tzurotCount: 2,
-      },
-    });
+      })
+    );
 
     await handleVoiceAutocomplete(createMockAutocomplete());
 
@@ -217,17 +194,16 @@ describe('handleVoiceAutocomplete', () => {
   });
 
   it('filters by query against slug', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
+    stub.listVoices.mockResolvedValue(
+      makeOk({
         voices: [
           { provider: 'elevenlabs', voiceId: 'v1', name: 'tzurot-alice', slug: 'alice' },
           { provider: 'mistral', voiceId: 'v2', name: 'tzurot-bob', slug: 'bob' },
         ],
         totalVoices: 10,
         tzurotCount: 2,
-      },
-    });
+      })
+    );
 
     await handleVoiceAutocomplete(createMockAutocomplete('ali'));
 
@@ -237,48 +213,45 @@ describe('handleVoiceAutocomplete', () => {
   });
 
   it('uses cached voices on subsequent calls', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
+    stub.listVoices.mockResolvedValue(
+      makeOk({
         voices: [{ provider: 'elevenlabs', voiceId: 'v1', name: 'tzurot-alice', slug: 'alice' }],
         totalVoices: 10,
         tzurotCount: 1,
-      },
-    });
+      })
+    );
 
     await handleVoiceAutocomplete(createMockAutocomplete());
     await handleVoiceAutocomplete(createMockAutocomplete('ali'));
 
-    expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
+    expect(stub.listVoices).toHaveBeenCalledTimes(1);
     expect(mockRespond).toHaveBeenCalledTimes(2);
   });
 
   it('invalidates cache after successful delete', async () => {
     // Pre-populate cache via autocomplete
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
+    stub.listVoices.mockResolvedValue(
+      makeOk({
         voices: [
           { provider: 'elevenlabs', voiceId: 'voice-1', name: 'tzurot-alice', slug: 'alice' },
         ],
         totalVoices: 10,
         tzurotCount: 1,
-      },
-    });
+      })
+    );
     await handleVoiceAutocomplete(createMockAutocomplete());
-    expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
+    expect(stub.listVoices).toHaveBeenCalledTimes(1);
 
     // Delete should invalidate cache
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: {
+    stub.deleteVoice.mockResolvedValue(
+      makeOk({
         deleted: true,
         provider: 'elevenlabs',
         voiceId: 'voice-1',
         name: 'tzurot-alice',
         slug: 'alice',
-      },
-    });
+      })
+    );
     const mockEditReply = vi.fn();
     const mockContext = {
       interaction: { user: { id: 'user-123', username: 'testuser' }, editReply: mockEditReply },
@@ -301,16 +274,13 @@ describe('handleVoiceAutocomplete', () => {
     await handleDeleteVoice(mockContext);
 
     // Autocomplete re-fetches (cache invalidated)
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: { voices: [], totalVoices: 10, tzurotCount: 0 },
-    });
+    stub.listVoices.mockResolvedValue(makeOk({ voices: [], totalVoices: 10, tzurotCount: 0 }));
     await handleVoiceAutocomplete(createMockAutocomplete());
-    expect(mockCallGatewayApi).toHaveBeenCalledTimes(3);
+    expect(stub.listVoices).toHaveBeenCalledTimes(2);
   });
 
   it('returns empty on API error', async () => {
-    mockCallGatewayApi.mockResolvedValue({ ok: false, status: 404, error: 'Not found' });
+    stub.listVoices.mockResolvedValue(makeErr(404, 'Not found'));
 
     await handleVoiceAutocomplete(createMockAutocomplete());
 
@@ -318,7 +288,7 @@ describe('handleVoiceAutocomplete', () => {
   });
 
   it('returns empty on exception', async () => {
-    mockCallGatewayApi.mockRejectedValue(new Error('timeout'));
+    stub.listVoices.mockRejectedValue(new Error('timeout'));
 
     await handleVoiceAutocomplete(createMockAutocomplete());
 

--- a/services/bot-client/src/commands/voice/voices/delete.ts
+++ b/services/bot-client/src/commands/voice/voices/delete.ts
@@ -17,23 +17,10 @@ import {
   type AudioProviderId,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import {
-  callGatewayApi,
-  GATEWAY_TIMEOUTS,
-  toGatewayUser,
-} from '../../../utils/userGatewayClient.js';
-import type { VoicesListResponse } from './types.js';
+import { clientsFor } from '../../../utils/gatewayClients.js';
 import { getCachedVoices, setCachedVoices, invalidateVoiceCache } from './voiceCache.js';
 
 const logger = createLogger('voice-voices-delete');
-
-interface VoiceDeleteResponse {
-  deleted: boolean;
-  provider: AudioProviderId;
-  voiceId: string;
-  name: string;
-  slug: string;
-}
 
 /** Parse the autocomplete value (`${provider}:${voiceId}`) into its parts.
  *  Returns null if the format is unexpected — caller surfaces an error.
@@ -70,14 +57,8 @@ export async function handleDeleteVoice(context: DeferredCommandContext): Promis
   }
 
   try {
-    const result = await callGatewayApi<VoiceDeleteResponse>(
-      `/user/voices/${parsed.provider}/${encodeURIComponent(parsed.voiceId)}`,
-      {
-        method: 'DELETE',
-        user: toGatewayUser(context.user),
-        timeout: GATEWAY_TIMEOUTS.DEFERRED,
-      }
-    );
+    const { userClient } = clientsFor(context.interaction);
+    const result = await userClient.deleteVoice(parsed.provider, parsed.voiceId);
 
     if (!result.ok) {
       await context.editReply({ content: `❌ ${result.error}` });
@@ -118,10 +99,8 @@ export async function handleVoiceAutocomplete(interaction: AutocompleteInteracti
     let voices = getCachedVoices(userId);
 
     if (voices === null) {
-      const result = await callGatewayApi<VoicesListResponse>('/user/voices', {
-        user: toGatewayUser(interaction.user),
-        timeout: GATEWAY_TIMEOUTS.AUTOCOMPLETE,
-      });
+      const { userClient } = clientsFor(interaction);
+      const result = await userClient.listVoices();
 
       if (!result.ok) {
         await interaction.respond([]);

--- a/services/bot-client/src/utils/autocomplete/autocompleteCache.test.ts
+++ b/services/bot-client/src/utils/autocomplete/autocompleteCache.test.ts
@@ -14,19 +14,9 @@ import {
   _getCacheSizeForTesting,
   _getStaleCacheSizeForTesting,
 } from './autocompleteCache.js';
-import type { PersonalitySummary } from '@tzurot/common-types';
+import type { PersonalitySummary, UserClient } from '@tzurot/common-types';
 import type { PersonaSummary, ShapesSummary } from './autocompleteCache.js';
-
-// Mock the gateway client
-const mockCallGatewayApi = vi.fn();
-vi.mock('../userGatewayClient.js', async () => {
-  const actual =
-    await vi.importActual<typeof import('../userGatewayClient.js')>('../userGatewayClient.js');
-  return {
-    ...actual,
-    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  };
-});
+import { makeOk, makeErr } from '../../test/gatewayClientStubs.js';
 
 vi.mock('@tzurot/common-types', async () => {
   const actual = await vi.importActual('@tzurot/common-types');
@@ -41,17 +31,26 @@ vi.mock('@tzurot/common-types', async () => {
   };
 });
 
+// One mock per typed-client method, shared across tests. `vi.clearAllMocks()`
+// in beforeEach resets call records but the same fn identity is reused — so
+// the helper-built stub always points at these and tests can drive responses
+// via mockResolvedValue / mockRejectedValue.
+const mockListPersonalities = vi.fn();
+const mockListPersonas = vi.fn();
+const mockListShapes = vi.fn();
+
+function stubUser(userId: string): UserClient {
+  return {
+    actor: userId,
+    listPersonalities: mockListPersonalities,
+    listPersonas: mockListPersonas,
+    listShapes: mockListShapes,
+  } as unknown as UserClient;
+}
+
 describe('autocompleteCache', () => {
   const testUserId = 'user-123';
-  const testUser = {
-    discordId: 'user-123',
-    username: 'testuser',
-    displayName: 'testuser',
-  } as const;
-
-  function mkUser(id: string) {
-    return { discordId: id, username: 'testuser', displayName: 'testuser' } as const;
-  }
+  const testUser = stubUser(testUserId);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -89,55 +88,42 @@ describe('autocompleteCache', () => {
     ];
 
     it('should fetch from gateway on cache miss', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { personalities: mockPersonalities },
-      });
+      mockListPersonalities.mockResolvedValue(makeOk({ personalities: mockPersonalities }));
 
       const result = await getCachedPersonalities(testUser);
 
-      expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/personality', { user: testUser });
+      expect(mockListPersonalities).toHaveBeenCalled();
       expect(result).toEqual({ kind: 'ok', value: mockPersonalities });
     });
 
     it('should return cached data on cache hit', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { personalities: mockPersonalities },
-      });
+      mockListPersonalities.mockResolvedValue(makeOk({ personalities: mockPersonalities }));
 
       // First call - cache miss
       await getCachedPersonalities(testUser);
-      expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
+      expect(mockListPersonalities).toHaveBeenCalledTimes(1);
 
       // Second call - cache hit
       const result = await getCachedPersonalities(testUser);
-      expect(mockCallGatewayApi).toHaveBeenCalledTimes(1); // Still only 1 call
+      expect(mockListPersonalities).toHaveBeenCalledTimes(1); // Still only 1 call
       expect(result).toEqual({ kind: 'ok', value: mockPersonalities });
     });
 
     it('should cache empty personality list (not treat as cache miss)', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { personalities: [] },
-      });
+      mockListPersonalities.mockResolvedValue(makeOk({ personalities: [] }));
 
       // First call - cache miss
       await getCachedPersonalities(testUser);
-      expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
+      expect(mockListPersonalities).toHaveBeenCalledTimes(1);
 
       // Second call - should be cache hit even with empty list
       const result = await getCachedPersonalities(testUser);
-      expect(mockCallGatewayApi).toHaveBeenCalledTimes(1); // Still only 1 call
+      expect(mockListPersonalities).toHaveBeenCalledTimes(1); // Still only 1 call
       expect(result).toEqual({ kind: 'ok', value: [] });
     });
 
     it('should return error on gateway error', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: false,
-        error: 'Gateway error',
-        status: 500,
-      });
+      mockListPersonalities.mockResolvedValue(makeErr(500, 'Gateway error'));
 
       const result = await getCachedPersonalities(testUser);
 
@@ -145,7 +131,7 @@ describe('autocompleteCache', () => {
     });
 
     it('should return error on exception', async () => {
-      mockCallGatewayApi.mockRejectedValue(new Error('Network error'));
+      mockListPersonalities.mockRejectedValue(new Error('Network error'));
 
       const result = await getCachedPersonalities(testUser);
 
@@ -153,15 +139,12 @@ describe('autocompleteCache', () => {
     });
 
     it('should cache per user', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { personalities: mockPersonalities },
-      });
+      mockListPersonalities.mockResolvedValue(makeOk({ personalities: mockPersonalities }));
 
-      await getCachedPersonalities(mkUser('user-1'));
-      await getCachedPersonalities(mkUser('user-2'));
+      await getCachedPersonalities(stubUser('user-1'));
+      await getCachedPersonalities(stubUser('user-2'));
 
-      expect(mockCallGatewayApi).toHaveBeenCalledTimes(2);
+      expect(mockListPersonalities).toHaveBeenCalledTimes(2);
       expect(_getCacheSizeForTesting()).toBe(2);
     });
   });
@@ -183,30 +166,24 @@ describe('autocompleteCache', () => {
     ];
 
     it('should fetch from gateway on cache miss', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { personas: mockPersonas },
-      });
+      mockListPersonas.mockResolvedValue(makeOk({ personas: mockPersonas }));
 
       const result = await getCachedPersonas(testUser);
 
-      expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/persona', { user: testUser });
+      expect(mockListPersonas).toHaveBeenCalled();
       expect(result).toEqual({ kind: 'ok', value: mockPersonas });
     });
 
     it('should return cached data on cache hit', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { personas: mockPersonas },
-      });
+      mockListPersonas.mockResolvedValue(makeOk({ personas: mockPersonas }));
 
       // First call - cache miss
       await getCachedPersonas(testUser);
-      expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
+      expect(mockListPersonas).toHaveBeenCalledTimes(1);
 
       // Second call - cache hit
       const result = await getCachedPersonas(testUser);
-      expect(mockCallGatewayApi).toHaveBeenCalledTimes(1); // Still only 1 call
+      expect(mockListPersonas).toHaveBeenCalledTimes(1); // Still only 1 call
       expect(result).toEqual({ kind: 'ok', value: mockPersonas });
     });
 
@@ -216,27 +193,20 @@ describe('autocompleteCache', () => {
      * `cached.personas.length > 0` check, causing repeated API calls.
      */
     it('should cache empty persona list (not treat as cache miss)', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { personas: [] },
-      });
+      mockListPersonas.mockResolvedValue(makeOk({ personas: [] }));
 
       // First call - cache miss
       await getCachedPersonas(testUser);
-      expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
+      expect(mockListPersonas).toHaveBeenCalledTimes(1);
 
       // Second call - should be cache hit even with empty list
       const result = await getCachedPersonas(testUser);
-      expect(mockCallGatewayApi).toHaveBeenCalledTimes(1); // Still only 1 call!
+      expect(mockListPersonas).toHaveBeenCalledTimes(1); // Still only 1 call!
       expect(result).toEqual({ kind: 'ok', value: [] });
     });
 
     it('should return error on gateway error', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: false,
-        error: 'Gateway error',
-        status: 500,
-      });
+      mockListPersonas.mockResolvedValue(makeErr(500, 'Gateway error'));
 
       const result = await getCachedPersonas(testUser);
 
@@ -244,7 +214,7 @@ describe('autocompleteCache', () => {
     });
 
     it('should return error on exception', async () => {
-      mockCallGatewayApi.mockRejectedValue(new Error('Network error'));
+      mockListPersonas.mockRejectedValue(new Error('Network error'));
 
       const result = await getCachedPersonas(testUser);
 
@@ -259,53 +229,38 @@ describe('autocompleteCache', () => {
     ];
 
     it('should fetch from gateway on cache miss', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { shapes: mockShapes },
-      });
+      mockListShapes.mockResolvedValue(makeOk({ shapes: mockShapes }));
 
       const result = await getCachedShapes(testUser);
 
-      expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/shapes/list', {
-        user: testUser,
-      });
+      expect(mockListShapes).toHaveBeenCalled();
       expect(result).toEqual({ kind: 'ok', value: mockShapes });
     });
 
     it('should return cached data on cache hit', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { shapes: mockShapes },
-      });
+      mockListShapes.mockResolvedValue(makeOk({ shapes: mockShapes }));
 
       await getCachedShapes(testUser);
-      expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
+      expect(mockListShapes).toHaveBeenCalledTimes(1);
 
       const result = await getCachedShapes(testUser);
-      expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
+      expect(mockListShapes).toHaveBeenCalledTimes(1);
       expect(result).toEqual({ kind: 'ok', value: mockShapes });
     });
 
     it('should cache empty shapes list (not treat as cache miss)', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { shapes: [] },
-      });
+      mockListShapes.mockResolvedValue(makeOk({ shapes: [] }));
 
       await getCachedShapes(testUser);
-      expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
+      expect(mockListShapes).toHaveBeenCalledTimes(1);
 
       const result = await getCachedShapes(testUser);
-      expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
+      expect(mockListShapes).toHaveBeenCalledTimes(1);
       expect(result).toEqual({ kind: 'ok', value: [] });
     });
 
     it('should return error on gateway error', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: false,
-        error: 'Gateway error',
-        status: 500,
-      });
+      mockListShapes.mockResolvedValue(makeErr(500, 'Gateway error'));
 
       const result = await getCachedShapes(testUser);
 
@@ -313,7 +268,7 @@ describe('autocompleteCache', () => {
     });
 
     it('should return error on exception', async () => {
-      mockCallGatewayApi.mockRejectedValue(new Error('Network error'));
+      mockListShapes.mockRejectedValue(new Error('Network error'));
 
       const result = await getCachedShapes(testUser);
 
@@ -323,10 +278,23 @@ describe('autocompleteCache', () => {
 
   describe('invalidateUserCache', () => {
     it('should remove user from cache', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { personalities: [{ id: '1', name: 'Test', slug: 'test' }] },
-      });
+      mockListPersonalities.mockResolvedValue(
+        makeOk({
+          personalities: [
+            {
+              id: '1',
+              name: 'Test',
+              displayName: null,
+              slug: 'test',
+              isPublic: true,
+              isOwned: true,
+              ownerId: 'owner-1',
+              ownerDiscordId: 'discord-123',
+              permissions: { canEdit: true, canDelete: true },
+            },
+          ],
+        })
+      );
 
       // Populate cache
       await getCachedPersonalities(testUser);
@@ -338,21 +306,18 @@ describe('autocompleteCache', () => {
     });
 
     it('should cause next fetch to be cache miss', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { personalities: [] },
-      });
+      mockListPersonalities.mockResolvedValue(makeOk({ personalities: [] }));
 
       // First call - cache miss
       await getCachedPersonalities(testUser);
-      expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
+      expect(mockListPersonalities).toHaveBeenCalledTimes(1);
 
       // Invalidate
       invalidateUserCache(testUserId);
 
       // Next call - cache miss again
       await getCachedPersonalities(testUser);
-      expect(mockCallGatewayApi).toHaveBeenCalledTimes(2);
+      expect(mockListPersonalities).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -375,26 +340,20 @@ describe('autocompleteCache', () => {
         { id: 'per1', name: 'Profile', preferredName: null, isDefault: true },
       ];
 
-      // First fetch personalities
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { personalities: mockPersonalities },
-      });
+      mockListPersonalities.mockResolvedValue(makeOk({ personalities: mockPersonalities }));
       await getCachedPersonalities(testUser);
 
-      // Then fetch personas (should preserve personalities)
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { personas: mockPersonas },
-      });
+      mockListPersonas.mockResolvedValue(makeOk({ personas: mockPersonas }));
       await getCachedPersonas(testUser);
 
-      // Verify both are cached
-      mockCallGatewayApi.mockClear();
+      // Verify both are cached — neither method called again
+      mockListPersonalities.mockClear();
+      mockListPersonas.mockClear();
       const personalities = await getCachedPersonalities(testUser);
       const personas = await getCachedPersonas(testUser);
 
-      expect(mockCallGatewayApi).not.toHaveBeenCalled();
+      expect(mockListPersonalities).not.toHaveBeenCalled();
+      expect(mockListPersonas).not.toHaveBeenCalled();
       expect(personalities).toEqual({ kind: 'ok', value: mockPersonalities });
       expect(personas).toEqual({ kind: 'ok', value: mockPersonas });
     });
@@ -415,26 +374,19 @@ describe('autocompleteCache', () => {
       ];
       const mockShapes: ShapesSummary[] = [{ name: 'Shape', username: 'shape' }];
 
-      // Fetch personalities first
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { personalities: mockPersonalities },
-      });
+      mockListPersonalities.mockResolvedValue(makeOk({ personalities: mockPersonalities }));
       await getCachedPersonalities(testUser);
 
-      // Then fetch shapes (should preserve personalities)
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: { shapes: mockShapes },
-      });
+      mockListShapes.mockResolvedValue(makeOk({ shapes: mockShapes }));
       await getCachedShapes(testUser);
 
-      // Verify both are cached
-      mockCallGatewayApi.mockClear();
+      mockListPersonalities.mockClear();
+      mockListShapes.mockClear();
       const personalities = await getCachedPersonalities(testUser);
       const shapes = await getCachedShapes(testUser);
 
-      expect(mockCallGatewayApi).not.toHaveBeenCalled();
+      expect(mockListPersonalities).not.toHaveBeenCalled();
+      expect(mockListShapes).not.toHaveBeenCalled();
       expect(personalities).toEqual({ kind: 'ok', value: mockPersonalities });
       expect(shapes).toEqual({ kind: 'ok', value: mockShapes });
     });
@@ -469,10 +421,7 @@ describe('autocompleteCache', () => {
      * exercising `personalities` alone is sufficient coverage.
      */
     async function primeStaleOnly(): Promise<void> {
-      mockCallGatewayApi.mockResolvedValueOnce({
-        ok: true,
-        data: { personalities: mockPersonalities },
-      });
+      mockListPersonalities.mockResolvedValueOnce(makeOk({ personalities: mockPersonalities }));
       await getCachedPersonalities(testUser);
       _clearFreshCacheForTesting();
       expect(_getCacheSizeForTesting()).toBe(0);
@@ -482,11 +431,7 @@ describe('autocompleteCache', () => {
     it('serves stale data on transient error (5xx) after initial success', async () => {
       await primeStaleOnly();
 
-      mockCallGatewayApi.mockResolvedValueOnce({
-        ok: false,
-        error: 'Backend down',
-        status: 503,
-      });
+      mockListPersonalities.mockResolvedValueOnce(makeErr(503, 'Backend down'));
       const result = await getCachedPersonalities(testUser);
 
       expect(result).toEqual({ kind: 'ok', value: mockPersonalities });
@@ -495,11 +440,7 @@ describe('autocompleteCache', () => {
     it('does NOT serve stale on permanent error (4xx), returns error instead', async () => {
       await primeStaleOnly();
 
-      mockCallGatewayApi.mockResolvedValueOnce({
-        ok: false,
-        error: 'Forbidden',
-        status: 403,
-      });
+      mockListPersonalities.mockResolvedValueOnce(makeErr(403, 'Forbidden'));
       const result = await getCachedPersonalities(testUser);
 
       expect(result).toEqual({ kind: 'error', error: 'Forbidden' });
@@ -514,22 +455,14 @@ describe('autocompleteCache', () => {
     it('serves stale data on rate-limit error (429) after initial success', async () => {
       await primeStaleOnly();
 
-      mockCallGatewayApi.mockResolvedValueOnce({
-        ok: false,
-        error: 'Rate limited',
-        status: 429,
-      });
+      mockListPersonalities.mockResolvedValueOnce(makeErr(429, 'Rate limited'));
       const result = await getCachedPersonalities(testUser);
 
       expect(result).toEqual({ kind: 'ok', value: mockPersonalities });
     });
 
     it('returns error on transient error when no stale cache exists', async () => {
-      mockCallGatewayApi.mockResolvedValueOnce({
-        ok: false,
-        error: 'Backend down',
-        status: 503,
-      });
+      mockListPersonalities.mockResolvedValueOnce(makeErr(503, 'Backend down'));
       const result = await getCachedPersonalities(testUser);
 
       expect(result).toEqual({ kind: 'error', error: 'Backend down' });
@@ -538,7 +471,7 @@ describe('autocompleteCache', () => {
     it('falls back to stale on thrown fetch error (transient-by-default)', async () => {
       await primeStaleOnly();
 
-      mockCallGatewayApi.mockRejectedValueOnce(new Error('Network meltdown'));
+      mockListPersonalities.mockRejectedValueOnce(new Error('Network meltdown'));
       const result = await getCachedPersonalities(testUser);
 
       expect(result).toEqual({ kind: 'ok', value: mockPersonalities });
@@ -551,11 +484,7 @@ describe('autocompleteCache', () => {
       expect(_getStaleCacheSizeForTesting()).toBe(0);
 
       // Stale is gone, so transient error surfaces as error (no fallback)
-      mockCallGatewayApi.mockResolvedValueOnce({
-        ok: false,
-        error: 'Backend down',
-        status: 503,
-      });
+      mockListPersonalities.mockResolvedValueOnce(makeErr(503, 'Backend down'));
       const result = await getCachedPersonalities(testUser);
 
       expect(result).toEqual({ kind: 'error', error: 'Backend down' });
@@ -577,16 +506,10 @@ describe('autocompleteCache', () => {
       const mockShapes: ShapesSummary[] = [{ name: 'Shape', username: 'shape' }];
 
       // 1. Prime personalities + personas into fresh (and stale via commitFetchedField)
-      mockCallGatewayApi.mockResolvedValueOnce({
-        ok: true,
-        data: { personalities: mockPersonalities },
-      });
+      mockListPersonalities.mockResolvedValueOnce(makeOk({ personalities: mockPersonalities }));
       await getCachedPersonalities(testUser);
 
-      mockCallGatewayApi.mockResolvedValueOnce({
-        ok: true,
-        data: { personas: mockPersonas },
-      });
+      mockListPersonas.mockResolvedValueOnce(makeOk({ personas: mockPersonas }));
       await getCachedPersonas(testUser);
 
       // 2. Demote both to stale-only by clearing fresh
@@ -595,22 +518,21 @@ describe('autocompleteCache', () => {
       expect(_getStaleCacheSizeForTesting()).toBe(1);
 
       // 3. Fetch shapes — carry-over should pull personalities + personas into fresh
-      mockCallGatewayApi.mockResolvedValueOnce({
-        ok: true,
-        data: { shapes: mockShapes },
-      });
+      mockListShapes.mockResolvedValueOnce(makeOk({ shapes: mockShapes }));
       await getCachedShapes(testUser);
 
       // 4. Behavioral proof: subsequent reads of the carried-over fields
       //    must not trigger a gateway call (they're now in fresh).
-      mockCallGatewayApi.mockClear();
+      mockListPersonalities.mockClear();
+      mockListPersonas.mockClear();
 
       const personalitiesResult = await getCachedPersonalities(testUser);
       const personasResult = await getCachedPersonas(testUser);
 
       expect(personalitiesResult).toEqual({ kind: 'ok', value: mockPersonalities });
       expect(personasResult).toEqual({ kind: 'ok', value: mockPersonas });
-      expect(mockCallGatewayApi).not.toHaveBeenCalled();
+      expect(mockListPersonalities).not.toHaveBeenCalled();
+      expect(mockListPersonas).not.toHaveBeenCalled();
     });
   });
 });

--- a/services/bot-client/src/utils/autocomplete/autocompleteCache.ts
+++ b/services/bot-client/src/utils/autocomplete/autocompleteCache.ts
@@ -40,8 +40,12 @@
  *     empty list.
  */
 
-import { createLogger, TTLCache, type PersonalitySummary } from '@tzurot/common-types';
-import { callGatewayApi, type GatewayUser } from '../userGatewayClient.js';
+import {
+  createLogger,
+  TTLCache,
+  type PersonalitySummary,
+  type UserClient,
+} from '@tzurot/common-types';
 import { isTransientHttpStatus, type ApiCheck } from '../apiCheck.js';
 
 const logger = createLogger('autocomplete-cache');
@@ -181,9 +185,9 @@ function fallbackToStale<K extends keyof UserAutocompleteData>(
  * Get cached personalities for a user. Cache miss triggers a gateway fetch.
  */
 export async function getCachedPersonalities(
-  user: GatewayUser
+  userClient: UserClient
 ): Promise<ApiCheck<PersonalitySummary[]>> {
-  const userId = user.discordId;
+  const userId = userClient.actor;
   const cached = freshCache.get(userId);
   if (cached?.personalities !== undefined) {
     logger.debug({ userId }, 'Personality cache hit');
@@ -193,10 +197,7 @@ export async function getCachedPersonalities(
   logger.debug({ userId }, 'Personality cache miss, fetching');
 
   try {
-    const result = await callGatewayApi<{ personalities: PersonalitySummary[] }>(
-      '/user/personality',
-      { user }
-    );
+    const result = await userClient.listPersonalities();
 
     if (result.ok) {
       commitFetchedField(userId, 'personalities', result.data.personalities);
@@ -223,8 +224,10 @@ export async function getCachedPersonalities(
 /**
  * Get cached personas for a user. Cache miss triggers a gateway fetch.
  */
-export async function getCachedPersonas(user: GatewayUser): Promise<ApiCheck<PersonaSummary[]>> {
-  const userId = user.discordId;
+export async function getCachedPersonas(
+  userClient: UserClient
+): Promise<ApiCheck<PersonaSummary[]>> {
+  const userId = userClient.actor;
   const cached = freshCache.get(userId);
   if (cached?.personas !== undefined) {
     logger.debug({ userId }, 'Persona cache hit');
@@ -234,9 +237,7 @@ export async function getCachedPersonas(user: GatewayUser): Promise<ApiCheck<Per
   logger.debug({ userId }, 'Persona cache miss, fetching');
 
   try {
-    const result = await callGatewayApi<{ personas: PersonaSummary[] }>('/user/persona', {
-      user,
-    });
+    const result = await userClient.listPersonas();
 
     if (result.ok) {
       commitFetchedField(userId, 'personas', result.data.personas);
@@ -260,9 +261,12 @@ export async function getCachedPersonas(user: GatewayUser): Promise<ApiCheck<Per
 
 /**
  * Get cached shapes for a user. Cache miss triggers a gateway fetch.
+ *
+ * Default route timeout (AUTOCOMPLETE = 2500ms) fits inside Discord's
+ * 3-second autocomplete budget.
  */
-export async function getCachedShapes(user: GatewayUser): Promise<ApiCheck<ShapesSummary[]>> {
-  const userId = user.discordId;
+export async function getCachedShapes(userClient: UserClient): Promise<ApiCheck<ShapesSummary[]>> {
+  const userId = userClient.actor;
   const cached = freshCache.get(userId);
   if (cached?.shapes !== undefined) {
     logger.debug({ userId }, 'Shapes cache hit');
@@ -272,11 +276,7 @@ export async function getCachedShapes(user: GatewayUser): Promise<ApiCheck<Shape
   logger.debug({ userId }, 'Shapes cache miss, fetching');
 
   try {
-    const result = await callGatewayApi<{ shapes: ShapesSummary[] }>('/user/shapes/list', {
-      user,
-      // Implicit: callGatewayApi defaults to AUTOCOMPLETE timeout (2500ms),
-      // which fits inside Discord's 3-second autocomplete budget.
-    });
+    const result = await userClient.listShapes();
 
     if (result.ok) {
       commitFetchedField(userId, 'shapes', result.data.shapes);

--- a/services/bot-client/src/utils/autocomplete/personaAutocomplete.test.ts
+++ b/services/bot-client/src/utils/autocomplete/personaAutocomplete.test.ts
@@ -19,6 +19,12 @@ vi.mock('./autocompleteCache.js', () => ({
   getCachedPersonas: (...args: unknown[]) => mockGetCachedPersonas(...args),
 }));
 
+// Mock clientsFor — the cache mock above doesn't care about the userClient
+// identity, so a structurally-empty stub suffices.
+vi.mock('../gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: {} })),
+}));
+
 vi.mock('@tzurot/common-types', async () => {
   const actual = await vi.importActual('@tzurot/common-types');
   return {
@@ -107,17 +113,16 @@ describe('handlePersonaAutocomplete', () => {
   });
 
   describe('cache usage', () => {
-    it('should call cache with correct user ID', async () => {
+    it('should fetch cached personas via the bound userClient', async () => {
+      // Identity is now carried at the `clientsFor` boundary, not the cache
+      // call signature. See `gatewayClients.test.ts` for the brand-binding
+      // contract.
       mockGetCachedPersonas.mockResolvedValue({ kind: 'ok', value: [] });
 
       const interaction = createMockInteraction('profile', '');
       await handlePersonaAutocomplete(interaction);
 
-      expect(mockGetCachedPersonas).toHaveBeenCalledWith({
-        discordId: '123456789',
-        username: 'testuser',
-        displayName: 'Test User',
-      });
+      expect(mockGetCachedPersonas).toHaveBeenCalledWith(expect.any(Object));
     });
 
     it('should return empty array when cache returns empty', async () => {

--- a/services/bot-client/src/utils/autocomplete/personaAutocomplete.ts
+++ b/services/bot-client/src/utils/autocomplete/personaAutocomplete.ts
@@ -13,7 +13,7 @@ import {
   formatAutocompleteOption,
 } from '@tzurot/common-types';
 import { getCachedPersonas } from './autocompleteCache.js';
-import { toGatewayUser } from '../userGatewayClient.js';
+import { clientsFor } from '../gatewayClients.js';
 import { AUTOCOMPLETE_ERROR_SENTINEL } from '../apiCheck.js';
 
 const logger = createLogger('persona-autocomplete');
@@ -62,7 +62,8 @@ export async function handlePersonaAutocomplete(
 
   try {
     // Use cached data to avoid HTTP requests on every keystroke
-    const result = await getCachedPersonas(toGatewayUser(interaction.user));
+    const { userClient } = clientsFor(interaction);
+    const result = await getCachedPersonas(userClient);
     if (result.kind === 'error') {
       // Backend failed AND no stale cache to fall back on — render a visible
       // error choice rather than an empty list that reads as "you have no personas."

--- a/services/bot-client/src/utils/autocomplete/personalityAutocomplete.test.ts
+++ b/services/bot-client/src/utils/autocomplete/personalityAutocomplete.test.ts
@@ -14,6 +14,12 @@ vi.mock('./autocompleteCache.js', () => ({
   getCachedPersonalities: (...args: unknown[]) => mockGetCachedPersonalities(...args),
 }));
 
+// Mock the clientsFor factory — the cache mock above doesn't care about the
+// userClient identity, so a structurally-empty stub suffices.
+vi.mock('../gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: {} })),
+}));
+
 vi.mock('@tzurot/common-types', async () => {
   const actual = await vi.importActual('@tzurot/common-types');
   return {
@@ -130,17 +136,16 @@ describe('handlePersonalityAutocomplete', () => {
   });
 
   describe('cache usage', () => {
-    it('should call cache with correct user ID', async () => {
+    it('should fetch cached personalities via the bound userClient', async () => {
+      // Identity is now carried at the `clientsFor` boundary, not the cache
+      // call signature. The cache receives the typed `userClient` directly;
+      // see `gatewayClients.test.ts` for the brand-binding contract.
       mockGetCachedPersonalities.mockResolvedValue({ kind: 'ok', value: [] });
 
       const interaction = createMockInteraction('personality', '');
       await handlePersonalityAutocomplete(interaction);
 
-      expect(mockGetCachedPersonalities).toHaveBeenCalledWith({
-        discordId: '123456789',
-        username: 'testuser',
-        displayName: 'Test User',
-      });
+      expect(mockGetCachedPersonalities).toHaveBeenCalledWith(expect.any(Object));
     });
 
     it('should return empty array when cache returns empty', async () => {

--- a/services/bot-client/src/utils/autocomplete/personalityAutocomplete.ts
+++ b/services/bot-client/src/utils/autocomplete/personalityAutocomplete.ts
@@ -18,7 +18,7 @@ import {
   formatAutocompleteOption,
 } from '@tzurot/common-types';
 import { getCachedPersonalities } from './autocompleteCache.js';
-import { toGatewayUser } from '../userGatewayClient.js';
+import { clientsFor } from '../gatewayClients.js';
 import { AUTOCOMPLETE_ERROR_SENTINEL } from '../apiCheck.js';
 
 const logger = createLogger('personality-autocomplete');
@@ -76,7 +76,8 @@ export async function handlePersonalityAutocomplete(
 
   try {
     // Use cached data to avoid HTTP requests on every keystroke
-    const result = await getCachedPersonalities(toGatewayUser(interaction.user));
+    const { userClient } = clientsFor(interaction);
+    const result = await getCachedPersonalities(userClient);
     if (result.kind === 'error') {
       // Backend failed AND no stale cache to fall back on — render a visible
       // error choice rather than an empty list that reads as "you have no personalities."

--- a/services/bot-client/src/utils/dashboard/settings/settingsUpdateFactory.test.ts
+++ b/services/bot-client/src/utils/dashboard/settings/settingsUpdateFactory.test.ts
@@ -1,19 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { UserClient } from '@tzurot/common-types';
 
-const { mockCallGatewayApi, mockMapSettingToApiUpdate } = vi.hoisted(() => ({
-  mockCallGatewayApi: vi.fn(),
+const { mockPatchFn, mockResolveFn, mockMapSettingToApiUpdate } = vi.hoisted(() => ({
+  mockPatchFn: vi.fn(),
+  mockResolveFn: vi.fn(),
   mockMapSettingToApiUpdate: vi.fn(),
 }));
 
-vi.mock('../../userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../userGatewayClient.js')>(
-    '../../userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: mockCallGatewayApi,
-  };
-});
+const stubUserClient = {} as unknown as UserClient;
+
+vi.mock('../../gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: stubUserClient })),
+}));
 
 vi.mock('./settingsUpdate.js', () => ({
   mapSettingToApiUpdate: mockMapSettingToApiUpdate,
@@ -26,8 +24,8 @@ import {
 } from './settingsUpdateFactory.js';
 
 const TEST_CONFIG: SettingUpdateConfig = {
-  patchEndpoint: id => `/test/patch/${id}`,
-  resolveEndpoint: id => `/test/resolve/${id}`,
+  patchFn: mockPatchFn,
+  resolveFn: mockResolveFn,
   sourceTier: 'personality',
   logContext: '[Test]',
 };
@@ -87,35 +85,25 @@ describe('createSettingsUpdateHandler', () => {
     mockMapSettingToApiUpdate.mockReturnValue({ maxMessages: 50 });
   });
 
-  it('uses the configured patch endpoint', async () => {
-    mockCallGatewayApi
-      .mockResolvedValueOnce({ ok: true, status: 200, data: {} })
-      .mockResolvedValueOnce({ ok: true, status: 200, data: fullResolvedCascade });
+  it('forwards the entityId and mapped body to patchFn', async () => {
+    mockPatchFn.mockResolvedValueOnce({ ok: true, status: 200, data: {} });
+    mockResolveFn.mockResolvedValueOnce({ ok: true, status: 200, data: fullResolvedCascade });
 
     const handler = createSettingsUpdateHandler(TEST_ENTITY_ID, TEST_CONFIG);
     const result = await handler(mockInteraction, mockSession, 'maxMessages', 50);
 
     expect(result.success).toBe(true);
-    expect(mockCallGatewayApi).toHaveBeenNthCalledWith(
-      1,
-      `/test/patch/${TEST_ENTITY_ID}`,
-      expect.objectContaining({ method: 'PATCH', body: { maxMessages: 50 } })
-    );
+    expect(mockPatchFn).toHaveBeenCalledWith(stubUserClient, TEST_ENTITY_ID, { maxMessages: 50 });
   });
 
-  it('uses the configured resolve endpoint on success', async () => {
-    mockCallGatewayApi
-      .mockResolvedValueOnce({ ok: true, status: 200, data: {} })
-      .mockResolvedValueOnce({ ok: true, status: 200, data: fullResolvedCascade });
+  it('forwards the entityId to resolveFn on successful PATCH', async () => {
+    mockPatchFn.mockResolvedValueOnce({ ok: true, status: 200, data: {} });
+    mockResolveFn.mockResolvedValueOnce({ ok: true, status: 200, data: fullResolvedCascade });
 
     const handler = createSettingsUpdateHandler(TEST_ENTITY_ID, TEST_CONFIG);
     await handler(mockInteraction, mockSession, 'maxMessages', 50);
 
-    expect(mockCallGatewayApi).toHaveBeenNthCalledWith(
-      2,
-      `/test/resolve/${TEST_ENTITY_ID}`,
-      expect.objectContaining({ method: 'GET' })
-    );
+    expect(mockResolveFn).toHaveBeenCalledWith(stubUserClient, TEST_ENTITY_ID);
   });
 
   it('returns error when mapSettingToApiUpdate returns null (unknown setting)', async () => {
@@ -125,24 +113,24 @@ describe('createSettingsUpdateHandler', () => {
     const result = await handler(mockInteraction, mockSession, 'bogus-setting', 'value');
 
     expect(result).toEqual({ success: false, error: 'Unknown setting' });
-    expect(mockCallGatewayApi).not.toHaveBeenCalled();
+    expect(mockPatchFn).not.toHaveBeenCalled();
+    expect(mockResolveFn).not.toHaveBeenCalled();
   });
 
   it('returns error when PATCH call fails', async () => {
-    mockCallGatewayApi.mockResolvedValueOnce({ ok: false, status: 500, error: 'Server error' });
+    mockPatchFn.mockResolvedValueOnce({ ok: false, status: 500, error: 'Server error' });
 
     const handler = createSettingsUpdateHandler(TEST_ENTITY_ID, TEST_CONFIG);
     const result = await handler(mockInteraction, mockSession, 'maxMessages', 50);
 
     expect(result).toEqual({ success: false, error: 'Server error' });
     // Should not have called resolve endpoint
-    expect(mockCallGatewayApi).toHaveBeenCalledTimes(1);
+    expect(mockResolveFn).not.toHaveBeenCalled();
   });
 
   it('returns error when resolve call fails after successful PATCH', async () => {
-    mockCallGatewayApi
-      .mockResolvedValueOnce({ ok: true, status: 200, data: {} })
-      .mockResolvedValueOnce({ ok: false, status: 500, error: 'Resolve error' });
+    mockPatchFn.mockResolvedValueOnce({ ok: true, status: 200, data: {} });
+    mockResolveFn.mockResolvedValueOnce({ ok: false, status: 500, error: 'Resolve error' });
 
     const handler = createSettingsUpdateHandler(TEST_ENTITY_ID, TEST_CONFIG);
     const result = await handler(mockInteraction, mockSession, 'maxMessages', 50);
@@ -151,8 +139,8 @@ describe('createSettingsUpdateHandler', () => {
     expect(result).toMatchObject({ error: 'Failed to fetch updated settings' });
   });
 
-  it('handles unexpected exceptions', async () => {
-    mockCallGatewayApi.mockRejectedValueOnce(new Error('Network down'));
+  it('handles unexpected exceptions thrown from patchFn', async () => {
+    mockPatchFn.mockRejectedValueOnce(new Error('Network down'));
 
     const handler = createSettingsUpdateHandler(TEST_ENTITY_ID, TEST_CONFIG);
     const result = await handler(mockInteraction, mockSession, 'maxMessages', 50);
@@ -161,9 +149,8 @@ describe('createSettingsUpdateHandler', () => {
   });
 
   it('returns newData derived from the configured sourceTier', async () => {
-    mockCallGatewayApi
-      .mockResolvedValueOnce({ ok: true, status: 200, data: {} })
-      .mockResolvedValueOnce({ ok: true, status: 200, data: fullResolvedCascade });
+    mockPatchFn.mockResolvedValueOnce({ ok: true, status: 200, data: {} });
+    mockResolveFn.mockResolvedValueOnce({ ok: true, status: 200, data: fullResolvedCascade });
 
     const handler = createSettingsUpdateHandler(TEST_ENTITY_ID, TEST_CONFIG);
     const result = await handler(mockInteraction, mockSession, 'maxMessages', 50);

--- a/services/bot-client/src/utils/dashboard/settings/settingsUpdateFactory.ts
+++ b/services/bot-client/src/utils/dashboard/settings/settingsUpdateFactory.ts
@@ -8,20 +8,26 @@
  *
  * Flow:
  * 1. Map setting ID to API patch body via mapSettingToApiUpdate
- * 2. PATCH to the configured endpoint
- * 3. Re-resolve the cascade via the configured resolve endpoint
+ * 2. PATCH via the configured typed-client method
+ * 3. Re-resolve the cascade via the configured typed-client method
  * 4. Convert resolved cascade back to SettingsData (filtering by source tier)
+ *
+ * Per-route `timeoutMs` on the manifest entries for `updatePersonalityOverrides`,
+ * `updatePersonalityConfigDefaults`, `resolveCascade`, and `resolvePersonalityCascade`
+ * carries `GATEWAY_TIMEOUTS.DEFERRED`, so the factory itself doesn't need to
+ * thread a timeout — it flows through the generated client.
  */
 
 import type { ButtonInteraction, ModalSubmitInteraction } from 'discord.js';
 import {
   createLogger,
-  GATEWAY_TIMEOUTS,
   type ConfigOverrides,
   type ConfigOverrideSource,
+  type GatewayResult,
   type ResolvedConfigOverrides,
+  type UserClient,
 } from '@tzurot/common-types';
-import { callGatewayApi, toGatewayUser } from '../../userGatewayClient.js';
+import { clientsFor } from '../../gatewayClients.js';
 import type {
   SettingsData,
   SettingsDashboardSession,
@@ -35,10 +41,17 @@ const logger = createLogger('settingsUpdateFactory');
 
 /** Configuration for a settings update handler */
 export interface SettingUpdateConfig {
-  /** Function to build the PATCH endpoint from entityId (e.g., personalityId) */
-  patchEndpoint: (entityId: string) => string;
-  /** Function to build the GET resolve endpoint from entityId */
-  resolveEndpoint: (entityId: string) => string;
+  /** Apply the PATCH via a typed-client method bound at config time */
+  patchFn: (
+    userClient: UserClient,
+    entityId: string,
+    body: ConfigOverrides
+  ) => Promise<GatewayResult<unknown>>;
+  /** Re-resolve the cascade via a typed-client method bound at config time */
+  resolveFn: (
+    userClient: UserClient,
+    entityId: string
+  ) => Promise<GatewayResult<ResolvedConfigOverrides>>;
   /** Source tier to treat as "local" when converting the resolved cascade */
   sourceTier: ConfigOverrideSource;
   /** Log context prefix (e.g., '[Character Settings]') */
@@ -86,7 +99,7 @@ export function createSettingsUpdateHandler(
     newValue: unknown
   ): Promise<SettingUpdateResult> => {
     const userId = interaction.user.id;
-    const user = toGatewayUser(interaction.user);
+    const { userClient } = clientsFor(interaction);
 
     logger.debug(
       { settingId, newValue, entityId, userId },
@@ -100,13 +113,8 @@ export function createSettingsUpdateHandler(
         return { success: false, error: 'Unknown setting' };
       }
 
-      // Write the patch to the configured endpoint
-      const result = await callGatewayApi(config.patchEndpoint(entityId), {
-        method: 'PATCH',
-        body,
-        user,
-        timeout: GATEWAY_TIMEOUTS.DEFERRED,
-      });
+      // Write the patch via the typed-client method
+      const result = await config.patchFn(userClient, entityId, body);
 
       if (!result.ok) {
         logger.warn(
@@ -117,10 +125,7 @@ export function createSettingsUpdateHandler(
       }
 
       // Re-resolve cascade to get updated effective values
-      const cascadeResult = await callGatewayApi<ResolvedConfigOverrides>(
-        config.resolveEndpoint(entityId),
-        { method: 'GET', user, timeout: GATEWAY_TIMEOUTS.DEFERRED }
-      );
+      const cascadeResult = await config.resolveFn(userClient, entityId);
 
       if (!cascadeResult.ok) {
         return { success: false, error: 'Failed to fetch updated settings' };

--- a/services/bot-client/src/utils/gatewayClients.ts
+++ b/services/bot-client/src/utils/gatewayClients.ts
@@ -19,6 +19,7 @@
  */
 
 import type {
+  AutocompleteInteraction,
   ChatInputCommandInteraction,
   MessageComponentInteraction,
   ModalSubmitInteraction,
@@ -44,6 +45,7 @@ import { toGatewayUser } from './userGatewayClient.js';
  * defined on the base.
  */
 export type ClientCarryingInteraction =
+  | AutocompleteInteraction
   | ChatInputCommandInteraction
   | MessageComponentInteraction
   | ModalSubmitInteraction;


### PR DESCRIPTION
## Summary

PR-2j is the penultimate slice of the typed-client epic. Migrates two shared-infra modules and the voice command domain from `callGatewayApi` to the typed `userClient` pattern.

**Bundled scope** (per user preference for one review surface):
- **autocompleteCache.ts** (3 fns × 6 consumers) — Phase 1
- **settingsUpdateFactory.ts** (2 character consumers) — Phase 2
- **voice commands** (13 source + 13 test files, 30 callsites) — Phase 3

## Key changes

### Phase 1 — autocompleteCache (commit a99a5419e)
- `getCachedPersonalities/Personas/Shapes` now take `UserClient` instead of `GatewayUser`. Cache key reads from `userClient.actor` brand.
- Generated client classes expose `readonly actor` and `readonly user` (was `private readonly`) so callers can introspect identity without re-deriving from interaction.
- `AutocompleteInteraction` added to `ClientCarryingInteraction` union — autocomplete consumers can now use `clientsFor(interaction)` at the boundary.
- `memory/{autocomplete,resolveHelpers}` helper signatures take `UserClient`; all 6 memory command callers updated.
- Consumer threading simplified: drop `toGatewayUser` import, drop `const user = ...` local, pass `userClient` directly.

### Phase 2 — settingsUpdateFactory (commit 8dd173c4d)
- Factory config restructured: `patchFn`/`resolveFn` callbacks bound to typed-client methods, replacing URL-builder callbacks.
- `CHARACTER_SETTINGS`: `updatePersonalityConfigDefaults` + `resolvePersonalityCascade`
- `CHARACTER_OVERRIDES`: `updatePersonalityOverrides` + `resolveCascade`
- Dual-transport mock pattern eliminated: tests collapse from mocking both `userClient` (init) AND `callGatewayApi` (factory) to a single `userClient` stub.

### Phase 3 — voice domain (commit 47bfebd8f)
- Migrated all 13 voice command files + `guestModeValidation` helper.
- **Manifest timeout additions** on deferred-context routes mirroring prior explicit `GATEWAY_TIMEOUTS.DEFERRED`: `listTtsOverrides`, `setTtsOverride`, `deleteTtsOverride`, `setTtsDefaultConfig`, `clearTtsDefaultConfig`, `setSttDefaultProvider`, `clearSttDefaultProvider`, `getVoiceResolution`, `deleteVoice`. `clearVoices` gets `BULK_OPERATION` (30s) since it iterates per-voice DELETEs.
- Local `voiceCache.ts` unchanged — it's client-side state, not transport.

## Burn-down

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| `callGatewayApi` | 93 | 55 | **-38** |
| `adminFetch` | 15 | 15 | 0 |

## Verification

- `pnpm test` — all 4982 bot-client tests green (no count change net; voice tests rewritten, count preserved)
- `pnpm quality` — clean (lint + cpd + depcruise + typecheck + typecheck:spec)
- `pnpm ops legacy:count` — confirms burn-down

## Out-of-scope tracking

No new defects expected from this migration. Three deferred items remain attached to PR-2k (legacy deletion final pass): `adminApiClient.ts` deletion, `userGatewayClient.ts` deletion, and removing `**/_generated/**` from `knip.json` ignore.

## Test plan

- [ ] `pnpm test` passes across all packages
- [ ] `pnpm quality` clean
- [ ] CI green
- [ ] Reviewer confirms no manifest-route gaps
- [ ] Manual smoke against dev (post-deploy): `/voice view <character>`, `/voice tts list`, `/character settings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)