### PR TITLE
feat(bot-client): PR-2k — migrate settings/preset/services to typed clients

### DIFF
--- a/packages/common-types/src/clients/_generated/owner-client.ts
+++ b/packages/common-types/src/clients/_generated/owner-client.ts
@@ -183,6 +183,7 @@ export class OwnerClient {
         'X-User-Id': this.actor,
       },
       outputSchema: ROUTE_MANIFEST.listGlobalLlmConfigs.output,
+      timeoutMs: ROUTE_MANIFEST.listGlobalLlmConfigs.timeoutMs,
     });
   }
 
@@ -200,6 +201,7 @@ export class OwnerClient {
         'X-User-Id': this.actor,
       },
       outputSchema: ROUTE_MANIFEST.getGlobalLlmConfig.output,
+      timeoutMs: ROUTE_MANIFEST.getGlobalLlmConfig.timeoutMs,
     });
   }
 
@@ -233,6 +235,7 @@ export class OwnerClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.updateGlobalLlmConfig.output,
+      timeoutMs: ROUTE_MANIFEST.updateGlobalLlmConfig.timeoutMs,
     });
   }
 

--- a/packages/common-types/src/clients/_generated/user-client.ts
+++ b/packages/common-types/src/clients/_generated/user-client.ts
@@ -202,6 +202,7 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.resolveUserLlmConfig.output,
+      timeoutMs: ROUTE_MANIFEST.resolveUserLlmConfig.timeoutMs,
     });
   }
 

--- a/packages/common-types/src/clients/_generated/user-client.ts
+++ b/packages/common-types/src/clients/_generated/user-client.ts
@@ -67,6 +67,7 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.getTimezone.output,
+      timeoutMs: ROUTE_MANIFEST.getTimezone.timeoutMs,
     });
   }
 
@@ -87,6 +88,7 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.setTimezone.output,
+      timeoutMs: ROUTE_MANIFEST.setTimezone.timeoutMs,
     });
   }
 
@@ -1168,6 +1170,7 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.listWalletKeys.output,
+      timeoutMs: ROUTE_MANIFEST.listWalletKeys.timeoutMs,
     });
   }
 
@@ -1185,6 +1188,7 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.setWalletKey.output,
+      timeoutMs: ROUTE_MANIFEST.setWalletKey.timeoutMs,
     });
   }
 
@@ -1201,6 +1205,7 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.removeWalletKey.output,
+      timeoutMs: ROUTE_MANIFEST.removeWalletKey.timeoutMs,
     });
   }
 
@@ -1218,6 +1223,7 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.testWalletKey.output,
+      timeoutMs: ROUTE_MANIFEST.testWalletKey.timeoutMs,
     });
   }
 
@@ -1648,6 +1654,7 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.resolveUserDefaults.output,
+      timeoutMs: ROUTE_MANIFEST.resolveUserDefaults.timeoutMs,
     });
   }
 
@@ -1684,6 +1691,7 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.updateUserDefaults.output,
+      timeoutMs: ROUTE_MANIFEST.updateUserDefaults.timeoutMs,
     });
   }
 

--- a/packages/common-types/src/clients/_generated/user-client.ts
+++ b/packages/common-types/src/clients/_generated/user-client.ts
@@ -108,6 +108,7 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.listUserLlmConfigs.output,
+      timeoutMs: ROUTE_MANIFEST.listUserLlmConfigs.timeoutMs,
     });
   }
 
@@ -480,6 +481,7 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.listModelOverrides.output,
+      timeoutMs: ROUTE_MANIFEST.listModelOverrides.timeoutMs,
     });
   }
 
@@ -500,6 +502,7 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.setModelOverride.output,
+      timeoutMs: ROUTE_MANIFEST.setModelOverride.timeoutMs,
     });
   }
 
@@ -516,6 +519,7 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.deleteModelOverride.output,
+      timeoutMs: ROUTE_MANIFEST.deleteModelOverride.timeoutMs,
     });
   }
 
@@ -555,6 +559,7 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.setDefaultModelConfig.output,
+      timeoutMs: ROUTE_MANIFEST.setDefaultModelConfig.timeoutMs,
     });
   }
 
@@ -571,6 +576,7 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.clearDefaultModelConfig.output,
+      timeoutMs: ROUTE_MANIFEST.clearDefaultModelConfig.timeoutMs,
     });
   }
 

--- a/packages/common-types/src/clients/_generated/user-client.ts
+++ b/packages/common-types/src/clients/_generated/user-client.ts
@@ -128,6 +128,7 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.getUserLlmConfig.output,
+      timeoutMs: ROUTE_MANIFEST.getUserLlmConfig.timeoutMs,
     });
   }
 
@@ -145,6 +146,7 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.createUserLlmConfig.output,
+      timeoutMs: ROUTE_MANIFEST.createUserLlmConfig.timeoutMs,
     });
   }
 
@@ -165,6 +167,7 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.updateUserLlmConfig.output,
+      timeoutMs: ROUTE_MANIFEST.updateUserLlmConfig.timeoutMs,
     });
   }
 
@@ -181,6 +184,7 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.deleteUserLlmConfig.output,
+      timeoutMs: ROUTE_MANIFEST.deleteUserLlmConfig.timeoutMs,
     });
   }
 

--- a/packages/common-types/src/routes/admin.ts
+++ b/packages/common-types/src/routes/admin.ts
@@ -222,6 +222,12 @@ export const adminRoutes = {
     id: 'listGlobalLlmConfigs',
     output: ListLlmConfigsResponseSchema,
     meta: { safeRead: true },
+    // Dual-context: bot-owner autocomplete (3s Discord deadline) and
+    // bot-owner dashboard refresh (post-defer). DEFERRED wins because the
+    // dashboard path needs the longer budget; the autocomplete caller already
+    // caches results, so the rare cold-path call tolerating a slow gateway is
+    // an acceptable trade for not splitting this into two routes.
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   /** GET /api/admin/llm-config/:id — Fetch one global config. */
@@ -233,6 +239,7 @@ export const adminRoutes = {
     params: { id: z.string() },
     output: GetLlmConfigResponseSchema,
     meta: { safeRead: true },
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   /** POST /api/admin/llm-config — Create a new global config. */
@@ -255,6 +262,7 @@ export const adminRoutes = {
     input: LlmConfigUpdateSchema,
     output: UpdateLlmConfigResponseSchema,
     meta: { idempotent: true },
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   /** PUT /api/admin/llm-config/:id/set-default — Promote to paid default. */

--- a/packages/common-types/src/routes/user/config-overrides.ts
+++ b/packages/common-types/src/routes/user/config-overrides.ts
@@ -56,6 +56,9 @@ export const userConfigOverrideRoutes = {
     output: ResolveUserConfigDefaultsResponseSchema,
     requiresProvisionedUser: true,
     meta: { safeRead: true },
+    // 2-tier user-default cascade resolve; same multi-read cost as
+    // the personality cascades.
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   getUserDefaults: {
@@ -76,6 +79,8 @@ export const userConfigOverrideRoutes = {
     input: ConfigOverridesSchema,
     output: UpdateConfigDefaultsResponseSchema,
     requiresProvisionedUser: true,
+    // PATCH + resolve handshake (paired with resolveUserDefaults).
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   clearUserDefaults: {

--- a/packages/common-types/src/routes/user/configs.ts
+++ b/packages/common-types/src/routes/user/configs.ts
@@ -110,6 +110,10 @@ export const userConfigRoutes = {
     output: ListLlmConfigsResponseSchema,
     requiresProvisionedUser: true,
     meta: { safeRead: true },
+    // Dual-context route: autocomplete callers bounded by Discord's 3s
+    // deadline; deferred-context callers (guestModeValidation) need the
+    // longer budget.
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   getUserLlmConfig: {
@@ -344,6 +348,7 @@ export const userConfigRoutes = {
     output: ListModelOverridesResponseSchema,
     requiresProvisionedUser: true,
     meta: { safeRead: true },
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   setModelOverride: {
@@ -355,6 +360,7 @@ export const userConfigRoutes = {
     output: SetModelOverrideResponseSchema,
     requiresProvisionedUser: true,
     meta: { idempotent: true },
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   deleteModelOverride: {
@@ -365,6 +371,7 @@ export const userConfigRoutes = {
     params: { personalityId: z.string() },
     output: DeleteModelOverrideResponseSchema,
     requiresProvisionedUser: true,
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   getDefaultModelConfig: {
@@ -386,6 +393,7 @@ export const userConfigRoutes = {
     output: SetDefaultConfigResponseSchema,
     requiresProvisionedUser: true,
     meta: { idempotent: true },
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   clearDefaultModelConfig: {
@@ -395,5 +403,6 @@ export const userConfigRoutes = {
     id: 'clearDefaultModelConfig',
     output: ClearDefaultConfigResponseSchema,
     requiresProvisionedUser: true,
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 } as const satisfies Record<string, RouteDef>;

--- a/packages/common-types/src/routes/user/configs.ts
+++ b/packages/common-types/src/routes/user/configs.ts
@@ -81,6 +81,9 @@ export const userConfigRoutes = {
     output: GetTimezoneResponseSchema,
     requiresProvisionedUser: true,
     meta: { safeRead: true },
+    // Read post-defer in the settings dashboard; the autocomplete budget
+    // is too tight for the slowest paths.
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   setTimezone: {
@@ -92,6 +95,7 @@ export const userConfigRoutes = {
     output: SetTimezoneResponseSchema,
     requiresProvisionedUser: true,
     meta: { idempotent: true },
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   // ============================================================================

--- a/packages/common-types/src/routes/user/configs.ts
+++ b/packages/common-types/src/routes/user/configs.ts
@@ -171,6 +171,11 @@ export const userConfigRoutes = {
     input: ResolveLlmConfigInputSchema,
     output: ResolveLlmConfigResponseSchema,
     requiresProvisionedUser: true,
+    // Called in the message-handling hot path (before any deferReply), so the
+    // budget is the tight 2500ms AUTOCOMPLETE cap rather than DEFERRED — a slow
+    // gateway must degrade to personality defaults fast, not stall the pipeline.
+    // (This was the transport default already; declaring it pins the intent.)
+    timeoutMs: GATEWAY_TIMEOUTS.AUTOCOMPLETE,
   },
 
   // ============================================================================

--- a/packages/common-types/src/routes/user/configs.ts
+++ b/packages/common-types/src/routes/user/configs.ts
@@ -125,6 +125,7 @@ export const userConfigRoutes = {
     output: GetLlmConfigResponseSchema,
     requiresProvisionedUser: true,
     meta: { safeRead: true },
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   createUserLlmConfig: {
@@ -135,6 +136,7 @@ export const userConfigRoutes = {
     input: LlmConfigCreateSchema,
     output: CreateLlmConfigResponseSchema,
     requiresProvisionedUser: true,
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   updateUserLlmConfig: {
@@ -147,6 +149,7 @@ export const userConfigRoutes = {
     output: UpdateLlmConfigResponseSchema,
     requiresProvisionedUser: true,
     meta: { idempotent: true },
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   deleteUserLlmConfig: {
@@ -157,6 +160,7 @@ export const userConfigRoutes = {
     params: { id: z.string() },
     output: DeleteLlmConfigResponseSchema,
     requiresProvisionedUser: true,
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   resolveUserLlmConfig: {

--- a/packages/common-types/src/routes/user/resources.ts
+++ b/packages/common-types/src/routes/user/resources.ts
@@ -254,6 +254,7 @@ export const userResourceRoutes = {
     output: ListWalletKeysResponseSchema,
     requiresProvisionedUser: true,
     meta: { safeRead: true },
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   setWalletKey: {
@@ -264,6 +265,7 @@ export const userResourceRoutes = {
     input: SetWalletKeySchema,
     output: SetWalletKeyResponseSchema,
     requiresProvisionedUser: true,
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   removeWalletKey: {
@@ -274,6 +276,7 @@ export const userResourceRoutes = {
     params: { provider: z.string() },
     output: RemoveWalletKeyResponseSchema,
     requiresProvisionedUser: true,
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   testWalletKey: {
@@ -284,6 +287,11 @@ export const userResourceRoutes = {
     input: TestWalletKeySchema,
     output: TestWalletKeyResponseSchema,
     requiresProvisionedUser: true,
+    // Post-defer dashboard action (not a slash-command hot path), and the
+    // gateway handler synchronously probes the provider's auth/credits
+    // endpoint before responding — so the gateway's own response is slow.
+    // DEFERRED gives the bot→gateway hop enough headroom for that probe.
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   // ============================================================================

--- a/packages/common-types/src/schemas/api/llm-config.ts
+++ b/packages/common-types/src/schemas/api/llm-config.ts
@@ -224,18 +224,25 @@ export const LLM_CONFIG_DEFAULTS = {
  * boundary prevents the "DB accepts, gateway rejects, user stuck"
  * failure class.
  */
-export const LlmConfigSummarySchema = z.object({
-  id: z.string().uuid(),
-  name: z.string(),
-  description: z.string().nullable(),
-  provider: z.string(),
-  model: z.string(),
-  visionModel: z.string().nullable(),
-  isGlobal: z.boolean(),
-  isDefault: z.boolean(),
-  isOwned: z.boolean(),
-  permissions: EntityPermissionsSchema,
-});
+// `.passthrough()` preserves the additional preset fields the gateway
+// emits on GET / PUT / POST (contextWindowTokens, params, modelContextLength,
+// etc.) that the bot-client dashboard reads but the schema doesn't yet
+// declare. Tighten by enumerating those fields explicitly; the dashboard
+// then becomes the authoritative consumer surface.
+export const LlmConfigSummarySchema = z
+  .object({
+    id: z.string().uuid(),
+    name: z.string(),
+    description: z.string().nullable(),
+    provider: z.string(),
+    model: z.string(),
+    visionModel: z.string().nullable(),
+    isGlobal: z.boolean(),
+    isDefault: z.boolean(),
+    isOwned: z.boolean(),
+    permissions: EntityPermissionsSchema,
+  })
+  .passthrough();
 export type LlmConfigSummary = z.infer<typeof LlmConfigSummarySchema>;
 
 // ============================================================================

--- a/packages/common-types/src/schemas/api/model-override.ts
+++ b/packages/common-types/src/schemas/api/model-override.ts
@@ -91,7 +91,9 @@ export type ClearDefaultConfigResponse = z.infer<typeof ClearDefaultConfigRespon
 
 export const DeleteModelOverrideResponseSchema = z.object({
   deleted: z.literal(true),
-  /** Handler emits `false` when no override existed; omitted when one was removed. */
+  /** `true` when an override existed and was deleted; `false` on idempotent
+   *  no-op (no override to delete). Optional on the schema for forward-compat
+   *  with hypothetical older clients — current handlers always emit it. */
   wasSet: z.boolean().optional(),
 });
 export type DeleteModelOverrideResponse = z.infer<typeof DeleteModelOverrideResponseSchema>;

--- a/packages/common-types/src/schemas/api/model-override.ts
+++ b/packages/common-types/src/schemas/api/model-override.ts
@@ -91,6 +91,8 @@ export type ClearDefaultConfigResponse = z.infer<typeof ClearDefaultConfigRespon
 
 export const DeleteModelOverrideResponseSchema = z.object({
   deleted: z.literal(true),
+  /** Handler emits `false` when no override existed; omitted when one was removed. */
+  wasSet: z.boolean().optional(),
 });
 export type DeleteModelOverrideResponse = z.infer<typeof DeleteModelOverrideResponseSchema>;
 

--- a/services/bot-client/src/commands/preset/api.test.ts
+++ b/services/bot-client/src/commands/preset/api.test.ts
@@ -11,29 +11,35 @@ import {
   extractApiErrorMessage,
   createPreset,
 } from './api.js';
-import { GatewayApiError } from '../../utils/userGatewayClient.js';
+import { GatewayApiError } from '@tzurot/common-types';
+import { makeOk, makeErr, asUserClient, asOwnerClient } from '../../test/gatewayClientStubs.js';
 import type { PresetData } from './config.js';
 
-// Mock userGatewayClient. importActual preserves GatewayApiError so the
-// createPreset error-path test can assert on `instanceof GatewayApiError`.
-const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
-    '../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  };
-});
+interface UserClientStub {
+  getUserLlmConfig: ReturnType<typeof vi.fn>;
+  updateUserLlmConfig: ReturnType<typeof vi.fn>;
+  createUserLlmConfig: ReturnType<typeof vi.fn>;
+}
 
-// Mock adminApiClient
-const mockAdminFetch = vi.fn();
-const mockAdminPutJson = vi.fn();
-vi.mock('../../utils/adminApiClient.js', () => ({
-  adminFetch: (...args: unknown[]) => mockAdminFetch(...args),
-  adminPutJson: (...args: unknown[]) => mockAdminPutJson(...args),
-}));
+interface OwnerClientStub {
+  getGlobalLlmConfig: ReturnType<typeof vi.fn>;
+  updateGlobalLlmConfig: ReturnType<typeof vi.fn>;
+}
+
+function createUserStub(): UserClientStub {
+  return {
+    getUserLlmConfig: vi.fn(),
+    updateUserLlmConfig: vi.fn(),
+    createUserLlmConfig: vi.fn(),
+  };
+}
+
+function createOwnerStub(): OwnerClientStub {
+  return {
+    getGlobalLlmConfig: vi.fn(),
+    updateGlobalLlmConfig: vi.fn(),
+  };
+}
 
 const mockPresetData: PresetData = {
   id: 'preset-123',
@@ -53,85 +59,45 @@ const mockPresetData: PresetData = {
 };
 
 describe('fetchPreset', () => {
+  let stub: UserClientStub;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    stub = createUserStub();
   });
 
   it('should fetch preset successfully', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: { config: mockPresetData },
-    });
+    stub.getUserLlmConfig.mockResolvedValue(makeOk({ config: mockPresetData }));
 
-    const result = await fetchPreset('preset-123', {
-      discordId: 'user-456',
-      username: 'testuser',
-      displayName: 'testuser',
-    });
+    const result = await fetchPreset('preset-123', asUserClient(stub));
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/llm-config/preset-123', {
-      user: {
-        discordId: 'user-456',
-        username: 'testuser',
-        displayName: 'testuser',
-      },
-    });
+    expect(stub.getUserLlmConfig).toHaveBeenCalledWith('preset-123');
     expect(result).toEqual(mockPresetData);
   });
 
   it('should return null on 404', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: false,
-      status: 404,
-    });
+    stub.getUserLlmConfig.mockResolvedValue(makeErr(404));
 
-    const result = await fetchPreset('missing', {
-      discordId: 'user-456',
-      username: 'testuser',
-      displayName: 'testuser',
-    });
+    const result = await fetchPreset('missing', asUserClient(stub));
 
     expect(result).toBeNull();
   });
 
   it('should throw on other errors', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: false,
-      status: 500,
-    });
+    stub.getUserLlmConfig.mockResolvedValue(makeErr(500));
 
-    await expect(
-      fetchPreset('preset-123', {
-        discordId: 'user-456',
-        username: 'testuser',
-        displayName: 'testuser',
-      })
-    ).rejects.toThrow('Failed to fetch preset: 500');
-  });
-
-  // Defense in depth for the SSRF-prevention encoding: if someone removes the
-  // encodeURIComponent() from the URL construction, this test fails. Asserts
-  // that slashes + reserved chars in the presetId are percent-encoded before
-  // being interpolated into the path.
-  it('URL-encodes the presetId in the gateway path', async () => {
-    mockCallGatewayApi.mockResolvedValue({ ok: true, data: { config: mockPresetData } });
-
-    await fetchPreset('preset/with/slash?x=1', {
-      discordId: 'user-456',
-      username: 'testuser',
-      displayName: 'testuser',
-    });
-
-    expect(mockCallGatewayApi).toHaveBeenCalledWith(
-      '/user/llm-config/preset%2Fwith%2Fslash%3Fx%3D1',
-      expect.any(Object)
+    await expect(fetchPreset('preset-123', asUserClient(stub))).rejects.toThrow(
+      'Failed to fetch preset: 500'
     );
   });
 });
 
 describe('fetchGlobalPreset', () => {
+  let stub: OwnerClientStub;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    stub = createOwnerStub();
   });
 
   it('should fetch global preset successfully', async () => {
@@ -142,14 +108,11 @@ describe('fetchGlobalPreset', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Simulating admin response that lacks user-scoped fields
     delete (adminResponseConfig as any).permissions;
 
-    mockAdminFetch.mockResolvedValue({
-      ok: true,
-      json: async () => ({ config: adminResponseConfig }),
-    });
+    stub.getGlobalLlmConfig.mockResolvedValue(makeOk({ config: adminResponseConfig }));
 
-    const result = await fetchGlobalPreset('preset-123');
+    const result = await fetchGlobalPreset('preset-123', asOwnerClient(stub));
 
-    expect(mockAdminFetch).toHaveBeenCalledWith('/admin/llm-config/preset-123');
+    expect(stub.getGlobalLlmConfig).toHaveBeenCalledWith('preset-123');
     // fetchGlobalPreset adds isOwned: true (admin owns global presets) and permissions
     // Admin always has full permissions on global presets
     expect(result).toEqual({
@@ -160,200 +123,95 @@ describe('fetchGlobalPreset', () => {
   });
 
   it('should return null on 404', async () => {
-    mockAdminFetch.mockResolvedValue({
-      ok: false,
-      status: 404,
-    });
+    stub.getGlobalLlmConfig.mockResolvedValue(makeErr(404));
 
-    const result = await fetchGlobalPreset('nonexistent');
+    const result = await fetchGlobalPreset('nonexistent', asOwnerClient(stub));
 
     expect(result).toBeNull();
   });
 
   it('should throw on other errors', async () => {
-    mockAdminFetch.mockResolvedValue({
-      ok: false,
-      status: 500,
-    });
+    stub.getGlobalLlmConfig.mockResolvedValue(makeErr(500));
 
-    await expect(fetchGlobalPreset('preset-123')).rejects.toThrow(
+    await expect(fetchGlobalPreset('preset-123', asOwnerClient(stub))).rejects.toThrow(
       'Failed to fetch global preset: 500'
     );
-  });
-
-  it('URL-encodes the presetId in the admin path', async () => {
-    mockAdminFetch.mockResolvedValue({
-      ok: true,
-      json: async () => ({ config: mockPresetData }),
-    });
-
-    await fetchGlobalPreset('preset/with/slash?x=1');
-
-    expect(mockAdminFetch).toHaveBeenCalledWith('/admin/llm-config/preset%2Fwith%2Fslash%3Fx%3D1');
   });
 });
 
 describe('updatePreset', () => {
+  let stub: UserClientStub;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    stub = createUserStub();
   });
 
   it('should update preset successfully', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: { config: mockPresetData },
-    });
+    stub.updateUserLlmConfig.mockResolvedValue(makeOk({ config: mockPresetData }));
 
     const updateData = { name: 'Updated Name' };
-    const result = await updatePreset('preset-123', updateData, {
-      discordId: 'user-456',
-      username: 'testuser',
-      displayName: 'testuser',
-    });
+    const result = await updatePreset('preset-123', updateData, asUserClient(stub));
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/llm-config/preset-123', {
-      method: 'PUT',
-      user: {
-        discordId: 'user-456',
-        username: 'testuser',
-        displayName: 'testuser',
-      },
-      body: updateData,
-    });
+    expect(stub.updateUserLlmConfig).toHaveBeenCalledWith('preset-123', updateData);
     expect(result).toEqual(mockPresetData);
   });
 
   it('should throw on error with message', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: false,
-      status: 400,
-      error: 'Invalid data',
-    });
+    stub.updateUserLlmConfig.mockResolvedValue(makeErr(400, 'Invalid data'));
 
-    await expect(
-      updatePreset(
-        'preset-123',
-        {},
-        { discordId: 'user-456', username: 'testuser', displayName: 'testuser' }
-      )
-    ).rejects.toThrow('Failed to update preset: 400 - Invalid data');
+    await expect(updatePreset('preset-123', {}, asUserClient(stub))).rejects.toThrow(
+      'Failed to update preset: 400 - Invalid data'
+    );
   });
 
   it('should throw on error without message', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: false,
-      status: 500,
-    });
+    stub.updateUserLlmConfig.mockResolvedValue({ ok: false, status: 500 } as never);
 
-    await expect(
-      updatePreset(
-        'preset-123',
-        {},
-        { discordId: 'user-456', username: 'testuser', displayName: 'testuser' }
-      )
-    ).rejects.toThrow('Failed to update preset: 500 - Unknown');
-  });
-
-  it('URL-encodes the presetId in the PUT path', async () => {
-    mockCallGatewayApi.mockResolvedValue({ ok: true, data: { config: mockPresetData } });
-
-    await updatePreset(
-      'preset/with/slash',
-      { name: 'x' },
-      { discordId: 'user-456', username: 'testuser', displayName: 'testuser' }
-    );
-
-    expect(mockCallGatewayApi).toHaveBeenCalledWith(
-      '/user/llm-config/preset%2Fwith%2Fslash',
-      expect.objectContaining({ method: 'PUT' })
+    await expect(updatePreset('preset-123', {}, asUserClient(stub))).rejects.toThrow(
+      'Failed to update preset: 500 - Unknown'
     );
   });
 });
 
 describe('updateGlobalPreset', () => {
+  let stub: OwnerClientStub;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    stub = createOwnerStub();
   });
 
   it('should update global preset successfully', async () => {
     // Admin API doesn't return isOwned/permissions, so function adds them
     const apiResponse = { ...mockPresetData };
-    mockAdminPutJson.mockResolvedValue({
-      ok: true,
-      json: async () => ({ config: apiResponse }),
-    });
+    stub.updateGlobalLlmConfig.mockResolvedValue(makeOk({ config: apiResponse }));
 
     const updateData = { name: 'Updated Name' };
-    const result = await updateGlobalPreset('preset-123', updateData);
+    const result = await updateGlobalPreset('preset-123', updateData, asOwnerClient(stub));
 
-    expect(mockAdminPutJson).toHaveBeenCalledWith('/admin/llm-config/preset-123', updateData);
-    // Function adds isOwned: true (admin owns global presets) and permissions for dashboard
+    expect(stub.updateGlobalLlmConfig).toHaveBeenCalledWith('preset-123', updateData);
     expect(result).toEqual({
       ...mockPresetData,
-      isOwned: true, // Admin owns global presets
+      isOwned: true,
       permissions: { canEdit: true, canDelete: true },
     });
   });
 
-  it('should extract message from JSON error response', async () => {
-    mockAdminPutJson.mockResolvedValue({
-      ok: false,
-      status: 400,
-      text: async () => JSON.stringify({ message: 'Context window too large' }),
-    });
+  it('throws on failure with gateway error message', async () => {
+    stub.updateGlobalLlmConfig.mockResolvedValue(makeErr(400, 'Context window too large'));
 
-    await expect(updateGlobalPreset('preset-123', {})).rejects.toThrow(
+    await expect(updateGlobalPreset('preset-123', {}, asOwnerClient(stub))).rejects.toThrow(
       'Failed to update global preset: 400 - Context window too large'
     );
   });
 
-  it('should extract error field from JSON error response', async () => {
-    mockAdminPutJson.mockResolvedValue({
-      ok: false,
-      status: 422,
-      text: async () => JSON.stringify({ error: 'VALIDATION_ERROR' }),
-    });
+  it('throws with Unknown when gateway has no error message', async () => {
+    stub.updateGlobalLlmConfig.mockResolvedValue({ ok: false, status: 500 } as never);
 
-    await expect(updateGlobalPreset('preset-123', {})).rejects.toThrow(
-      'Failed to update global preset: 422 - VALIDATION_ERROR'
+    await expect(updateGlobalPreset('preset-123', {}, asOwnerClient(stub))).rejects.toThrow(
+      'Failed to update global preset: 500 - Unknown'
     );
-  });
-
-  it('should fall back to raw text for non-JSON error response', async () => {
-    mockAdminPutJson.mockResolvedValue({
-      ok: false,
-      status: 502,
-      text: async () => '<html>Bad Gateway</html>',
-    });
-
-    await expect(updateGlobalPreset('preset-123', {})).rejects.toThrow(
-      'Failed to update global preset: 502 - <html>Bad Gateway</html>'
-    );
-  });
-
-  it('should use Unknown when JSON has no message or error field', async () => {
-    mockAdminPutJson.mockResolvedValue({
-      ok: false,
-      status: 400,
-      text: async () => JSON.stringify({ detail: 'some other field' }),
-    });
-
-    await expect(updateGlobalPreset('preset-123', {})).rejects.toThrow(
-      'Failed to update global preset: 400 - Unknown'
-    );
-  });
-
-  it('URL-encodes the presetId in the admin PUT path', async () => {
-    mockAdminPutJson.mockResolvedValue({
-      ok: true,
-      json: async () => ({ config: mockPresetData }),
-    });
-
-    await updateGlobalPreset('preset/with/slash', { name: 'x' });
-
-    expect(mockAdminPutJson).toHaveBeenCalledWith('/admin/llm-config/preset%2Fwith%2Fslash', {
-      name: 'x',
-    });
   });
 });
 
@@ -393,46 +251,42 @@ describe('extractApiErrorMessage', () => {
 });
 
 describe('createPreset', () => {
+  let stub: UserClientStub;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    stub = createUserStub();
   });
 
   it('returns the created preset config on success', async () => {
-    mockCallGatewayApi.mockResolvedValueOnce({
-      ok: true,
-      data: { config: mockPresetData },
-    });
+    stub.createUserLlmConfig.mockResolvedValue(makeOk({ config: mockPresetData }));
 
     const result = await createPreset(
       { name: 'Foo', model: 'm', provider: 'p' },
-      { discordId: 'user-1', username: 'testuser', displayName: 'testuser' }
+      asUserClient(stub)
     );
 
-    expect(result).toBe(mockPresetData);
-    expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/llm-config', {
-      method: 'POST',
-      user: {
-        discordId: 'user-1',
-        username: 'testuser',
-        displayName: 'testuser',
-      },
-      body: { name: 'Foo', model: 'm', provider: 'p' },
+    expect(result).toEqual(mockPresetData);
+    expect(stub.createUserLlmConfig).toHaveBeenCalledWith({
+      name: 'Foo',
+      model: 'm',
+      provider: 'p',
     });
   });
 
   it('throws GatewayApiError carrying status + code on failure', async () => {
-    mockCallGatewayApi.mockResolvedValueOnce({
+    stub.createUserLlmConfig.mockResolvedValue({
       ok: false,
       error: 'You already have a config named "Foo"',
       status: 400,
       code: 'NAME_COLLISION',
-    });
+    } as never);
 
     // Catch the rejection once so we can inspect class + shape without
     // re-invoking createPreset (which would re-consume the one-shot mock).
     const err = await createPreset(
       { name: 'Foo', model: 'm', provider: 'p' },
-      { discordId: 'user-1', username: 'testuser', displayName: 'testuser' }
+      asUserClient(stub)
     ).catch(e => e);
 
     expect(err).toBeInstanceOf(GatewayApiError);
@@ -441,17 +295,14 @@ describe('createPreset', () => {
   });
 
   it('throws GatewayApiError with undefined code when gateway sends no sub-code', async () => {
-    mockCallGatewayApi.mockResolvedValueOnce({
+    stub.createUserLlmConfig.mockResolvedValue({
       ok: false,
       error: 'Some other failure',
       status: 500,
-    });
+    } as never);
 
     await expect(
-      createPreset(
-        { name: 'Foo', model: 'm', provider: 'p' },
-        { discordId: 'user-1', username: 'testuser', displayName: 'testuser' }
-      )
+      createPreset({ name: 'Foo', model: 'm', provider: 'p' }, asUserClient(stub))
     ).rejects.toMatchObject({
       status: 500,
       code: undefined,

--- a/services/bot-client/src/commands/preset/api.ts
+++ b/services/bot-client/src/commands/preset/api.ts
@@ -2,16 +2,12 @@
  * Preset Command - API Client Functions
  *
  * Handles communication with the API gateway for preset operations.
- * Uses callGatewayApi for user endpoints and adminFetch for admin endpoints.
+ * User-scoped operations go through `userClient`; bot-owner global-preset
+ * operations go through `ownerClient`.
  */
 
-import {
-  callGatewayApi,
-  GatewayApiError,
-  type GatewayUser,
-} from '../../utils/userGatewayClient.js';
-import { adminFetch, adminPutJson } from '../../utils/adminApiClient.js';
-import type { PresetData, PresetResponse } from './types.js';
+import { GatewayApiError, type OwnerClient, type UserClient } from '@tzurot/common-types';
+import type { PresetData } from './types.js';
 
 /** Conservative limit — leaves room for the "❌ " prefix and Discord's 2000-char cap */
 const MAX_DISCORD_CONTENT = 1800;
@@ -36,16 +32,33 @@ export function extractApiErrorMessage(error: unknown): string | null {
   return msg.length > MAX_DISCORD_CONTENT ? msg.slice(0, MAX_DISCORD_CONTENT) + '…' : msg;
 }
 
+/** Adapt the user-scoped LlmConfig payload to the dashboard's PresetData shape.
+ * Cast bridges the schema-vs-PresetData drift — the schema's `.passthrough()`
+ * preserves the extra fields at runtime, but TS-level the inferred type only
+ * carries the explicitly-declared properties. Full schema tightening is
+ * tracked in backlog/inbox.md.
+ */
+function toPresetData(config: { id: string; name: string }): PresetData {
+  return config as PresetData;
+}
+
+/** Adapt the admin-scoped LlmConfig payload — gateway omits caller-scoped fields. */
+function toAdminPresetData(config: { id: string; name: string }): PresetData {
+  return {
+    ...(config as PresetData),
+    isOwned: true, // Admin owns global presets
+    permissions: { canEdit: true, canDelete: true }, // Admin always has full permissions
+  };
+}
+
 /**
  * Fetch a preset by ID (user endpoint)
  */
-export async function fetchPreset(presetId: string, user: GatewayUser): Promise<PresetData | null> {
-  const result = await callGatewayApi<PresetResponse>(
-    `/user/llm-config/${encodeURIComponent(presetId)}`,
-    {
-      user,
-    }
-  );
+export async function fetchPreset(
+  presetId: string,
+  userClient: UserClient
+): Promise<PresetData | null> {
+  const result = await userClient.getUserLlmConfig(presetId);
 
   if (!result.ok) {
     if (result.status === 404) {
@@ -54,38 +67,29 @@ export async function fetchPreset(presetId: string, user: GatewayUser): Promise<
     throw new Error(`Failed to fetch preset: ${result.status}`);
   }
 
-  return result.data.config;
+  return toPresetData(result.data.config);
 }
 
 /**
  * Fetch a global preset by ID (admin endpoint)
  *
- * IMPORTANT: This function is ONLY callable by bot owners because:
- * 1. It uses adminFetch which requires admin credentials
- * 2. The /preset global edit command is restricted to bot owners via isBotOwner check
- *
- * Therefore, we can safely hardcode full permissions - only admins reach this code path.
- * The admin endpoint doesn't return permissions (it assumes admin access), so we add them
- * for dashboard compatibility.
+ * Only reachable when the caller is a bot owner — the slash command is
+ * gated upstream.
  */
-export async function fetchGlobalPreset(presetId: string): Promise<PresetData | null> {
-  const response = await adminFetch(`/admin/llm-config/${encodeURIComponent(presetId)}`);
+export async function fetchGlobalPreset(
+  presetId: string,
+  ownerClient: OwnerClient
+): Promise<PresetData | null> {
+  const result = await ownerClient.getGlobalLlmConfig(presetId);
 
-  if (!response.ok) {
-    if (response.status === 404) {
+  if (!result.ok) {
+    if (result.status === 404) {
       return null;
     }
-    throw new Error(`Failed to fetch global preset: ${response.status}`);
+    throw new Error(`Failed to fetch global preset: ${result.status}`);
   }
 
-  const data = (await response.json()) as PresetResponse;
-  // Admin endpoint doesn't include isOwned/permissions - add for dashboard compatibility
-  // Safe to hardcode: this function is only reachable by bot owners (see JSDoc above)
-  return {
-    ...data.config,
-    isOwned: true, // Admin owns global presets
-    permissions: { canEdit: true, canDelete: true }, // Admin always has full permissions
-  };
+  return toAdminPresetData(result.data.config);
 }
 
 /**
@@ -94,62 +98,42 @@ export async function fetchGlobalPreset(presetId: string): Promise<PresetData | 
 export async function updatePreset(
   presetId: string,
   data: Record<string, unknown>,
-  user: GatewayUser
+  userClient: UserClient
 ): Promise<PresetData> {
-  const result = await callGatewayApi<PresetResponse>(
-    `/user/llm-config/${encodeURIComponent(presetId)}`,
-    {
-      method: 'PUT',
-      user,
-      body: data,
-    }
+  const result = await userClient.updateUserLlmConfig(
+    presetId,
+    data as Parameters<UserClient['updateUserLlmConfig']>[1]
   );
 
   if (!result.ok) {
     throw new Error(`Failed to update preset: ${result.status} - ${result.error ?? 'Unknown'}`);
   }
 
-  return result.data.config;
+  return toPresetData(result.data.config);
 }
 
 /**
  * Update a global preset (admin endpoint)
  *
- * IMPORTANT: Like fetchGlobalPreset, this function is ONLY callable by bot owners.
- * The admin endpoint doesn't return permissions, so we add them for dashboard compatibility.
+ * Only reachable when the caller is a bot owner.
  */
 export async function updateGlobalPreset(
   presetId: string,
-  data: Record<string, unknown>
+  data: Record<string, unknown>,
+  ownerClient: OwnerClient
 ): Promise<PresetData> {
-  const response = await adminPutJson(`/admin/llm-config/${encodeURIComponent(presetId)}`, data);
+  const result = await ownerClient.updateGlobalLlmConfig(
+    presetId,
+    data as Parameters<OwnerClient['updateGlobalLlmConfig']>[1]
+  );
 
-  if (!response.ok) {
-    // Read body once, then try parsing as JSON (structured API error).
-    // Falls back to raw text. Avoids surfacing garbled HTML from gateway errors.
-    let detail: string;
-    try {
-      const text = await response.text();
-      try {
-        const json = JSON.parse(text) as { message?: string; error?: string };
-        detail = json.message ?? json.error ?? 'Unknown';
-      } catch {
-        detail = text;
-      }
-    } catch {
-      detail = 'Unknown';
-    }
-    throw new Error(`Failed to update global preset: ${response.status} - ${detail}`);
+  if (!result.ok) {
+    throw new Error(
+      `Failed to update global preset: ${result.status} - ${result.error ?? 'Unknown'}`
+    );
   }
 
-  const result = (await response.json()) as PresetResponse;
-  // Admin endpoint doesn't include isOwned/permissions - add for dashboard compatibility
-  // Safe to hardcode: this function is only reachable by bot owners (see JSDoc above)
-  return {
-    ...result.config,
-    isOwned: true, // Admin owns global presets
-    permissions: { canEdit: true, canDelete: true }, // Admin always has full permissions
-  };
+  return toAdminPresetData(result.data.config);
 }
 
 /**
@@ -169,13 +153,9 @@ export async function createPreset(
      */
     autoSuffixOnCollision?: boolean;
   },
-  user: GatewayUser
+  userClient: UserClient
 ): Promise<PresetData> {
-  const result = await callGatewayApi<PresetResponse>('/user/llm-config', {
-    method: 'POST',
-    user,
-    body: data,
-  });
+  const result = await userClient.createUserLlmConfig(data);
 
   if (!result.ok) {
     // Use GatewayApiError so retry/branching logic can match on `code`
@@ -187,5 +167,5 @@ export async function createPreset(
     );
   }
 
-  return result.data.config;
+  return toPresetData(result.data.config);
 }

--- a/services/bot-client/src/commands/preset/autocomplete.test.ts
+++ b/services/bot-client/src/commands/preset/autocomplete.test.ts
@@ -3,11 +3,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { handleAutocomplete } from './autocomplete.js';
 import type { AutocompleteInteraction, User } from 'discord.js';
 import { mockListLlmConfigsResponse, mockLlmConfigSummary } from '@tzurot/common-types';
+import { makeOk, makeErr, asUserClient } from '../../test/gatewayClientStubs.js';
 
-// Mock logger - use importOriginal pattern for async mock factories
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal<typeof import('@tzurot/common-types')>();
   return {
@@ -21,25 +20,38 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
-// Mock the gateway client
-vi.mock('../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
-    '../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: vi.fn(),
-  };
-});
+const clientsForMock = vi.hoisted(() => vi.fn());
+vi.mock('../../utils/gatewayClients.js', () => ({
+  clientsFor: clientsForMock,
+}));
 
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+const { handleAutocomplete, __resetGlobalConfigCacheForTests } = await import('./autocomplete.js');
+
+interface UserClientStub {
+  listUserLlmConfigs: ReturnType<typeof vi.fn>;
+}
+
+interface OwnerClientStub {
+  listGlobalLlmConfigs: ReturnType<typeof vi.fn>;
+}
+
+function createStub(): UserClientStub {
+  return { listUserLlmConfigs: vi.fn() };
+}
+
+function createOwnerStub(): OwnerClientStub {
+  return { listGlobalLlmConfigs: vi.fn() };
+}
 
 describe('handleAutocomplete', () => {
   let mockInteraction: AutocompleteInteraction;
   let mockUser: User;
+  let stub: UserClientStub;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    stub = createStub();
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
 
     mockUser = {
       id: 'user-123',
@@ -69,33 +81,32 @@ describe('handleAutocomplete', () => {
         name: 'preset',
         value: '',
       } as unknown as string);
-      vi.mocked(callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: mockListLlmConfigsResponse([
-          mockLlmConfigSummary({
-            id: '00000000-0000-4000-8000-0000000000c1',
-            name: 'My Preset',
-            model: 'anthropic/claude-sonnet-4',
-            provider: 'openrouter',
-            isGlobal: false,
-            isOwned: true,
-          }),
-          mockLlmConfigSummary({
-            id: '00000000-0000-4000-8000-0000000000c2',
-            name: 'Global Preset',
-            model: 'openai/gpt-4',
-            provider: 'openrouter',
-            isGlobal: true,
-            isOwned: false,
-          }),
-        ]),
-      });
+      stub.listUserLlmConfigs.mockResolvedValue(
+        makeOk(
+          mockListLlmConfigsResponse([
+            mockLlmConfigSummary({
+              id: '00000000-0000-4000-8000-0000000000c1',
+              name: 'My Preset',
+              model: 'anthropic/claude-sonnet-4',
+              provider: 'openrouter',
+              isGlobal: false,
+              isOwned: true,
+            }),
+            mockLlmConfigSummary({
+              id: '00000000-0000-4000-8000-0000000000c2',
+              name: 'Global Preset',
+              model: 'openai/gpt-4',
+              provider: 'openrouter',
+              isGlobal: true,
+              isOwned: false,
+            }),
+          ])
+        )
+      );
 
       await handleAutocomplete(mockInteraction);
 
-      expect(callGatewayApi).toHaveBeenCalledWith('/user/llm-config', {
-        user: { discordId: 'user-123', username: 'testuser', displayName: 'testuser' },
-      });
+      expect(stub.listUserLlmConfigs).toHaveBeenCalledWith();
       // Should only return owned presets
       expect(mockInteraction.respond).toHaveBeenCalledWith([
         { name: 'My Preset · claude-sonnet-4', value: '00000000-0000-4000-8000-0000000000c1' },
@@ -107,27 +118,28 @@ describe('handleAutocomplete', () => {
         name: 'preset',
         value: 'fast',
       } as unknown as string);
-      vi.mocked(callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: mockListLlmConfigsResponse([
-          mockLlmConfigSummary({
-            id: '00000000-0000-4000-8000-0000000000c1',
-            name: 'Fast Preset',
-            model: 'anthropic/claude-sonnet-4',
-            provider: 'openrouter',
-            isGlobal: false,
-            isOwned: true,
-          }),
-          mockLlmConfigSummary({
-            id: '00000000-0000-4000-8000-0000000000c2',
-            name: 'Slow Preset',
-            model: 'openai/gpt-4',
-            provider: 'openrouter',
-            isGlobal: false,
-            isOwned: true,
-          }),
-        ]),
-      });
+      stub.listUserLlmConfigs.mockResolvedValue(
+        makeOk(
+          mockListLlmConfigsResponse([
+            mockLlmConfigSummary({
+              id: '00000000-0000-4000-8000-0000000000c1',
+              name: 'Fast Preset',
+              model: 'anthropic/claude-sonnet-4',
+              provider: 'openrouter',
+              isGlobal: false,
+              isOwned: true,
+            }),
+            mockLlmConfigSummary({
+              id: '00000000-0000-4000-8000-0000000000c2',
+              name: 'Slow Preset',
+              model: 'openai/gpt-4',
+              provider: 'openrouter',
+              isGlobal: false,
+              isOwned: true,
+            }),
+          ])
+        )
+      );
 
       await handleAutocomplete(mockInteraction);
 
@@ -141,27 +153,28 @@ describe('handleAutocomplete', () => {
         name: 'preset',
         value: 'gpt',
       } as unknown as string);
-      vi.mocked(callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: mockListLlmConfigsResponse([
-          mockLlmConfigSummary({
-            id: '00000000-0000-4000-8000-0000000000c1',
-            name: 'Claude Preset',
-            model: 'anthropic/claude-sonnet-4',
-            provider: 'openrouter',
-            isGlobal: false,
-            isOwned: true,
-          }),
-          mockLlmConfigSummary({
-            id: '00000000-0000-4000-8000-0000000000c2',
-            name: 'GPT Preset',
-            model: 'openai/gpt-4',
-            provider: 'openrouter',
-            isGlobal: false,
-            isOwned: true,
-          }),
-        ]),
-      });
+      stub.listUserLlmConfigs.mockResolvedValue(
+        makeOk(
+          mockListLlmConfigsResponse([
+            mockLlmConfigSummary({
+              id: '00000000-0000-4000-8000-0000000000c1',
+              name: 'Claude Preset',
+              model: 'anthropic/claude-sonnet-4',
+              provider: 'openrouter',
+              isGlobal: false,
+              isOwned: true,
+            }),
+            mockLlmConfigSummary({
+              id: '00000000-0000-4000-8000-0000000000c2',
+              name: 'GPT Preset',
+              model: 'openai/gpt-4',
+              provider: 'openrouter',
+              isGlobal: false,
+              isOwned: true,
+            }),
+          ])
+        )
+      );
 
       await handleAutocomplete(mockInteraction);
 
@@ -175,29 +188,30 @@ describe('handleAutocomplete', () => {
         name: 'preset',
         value: 'cheap',
       } as unknown as string);
-      vi.mocked(callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: mockListLlmConfigsResponse([
-          mockLlmConfigSummary({
-            id: '00000000-0000-4000-8000-0000000000c1',
-            name: 'Preset A',
-            description: 'Fast and cheap',
-            model: 'anthropic/claude-sonnet-4',
-            provider: 'openrouter',
-            isGlobal: false,
-            isOwned: true,
-          }),
-          mockLlmConfigSummary({
-            id: '00000000-0000-4000-8000-0000000000c2',
-            name: 'Preset B',
-            description: 'Expensive but good',
-            model: 'openai/gpt-4',
-            provider: 'openrouter',
-            isGlobal: false,
-            isOwned: true,
-          }),
-        ]),
-      });
+      stub.listUserLlmConfigs.mockResolvedValue(
+        makeOk(
+          mockListLlmConfigsResponse([
+            mockLlmConfigSummary({
+              id: '00000000-0000-4000-8000-0000000000c1',
+              name: 'Preset A',
+              description: 'Fast and cheap',
+              model: 'anthropic/claude-sonnet-4',
+              provider: 'openrouter',
+              isGlobal: false,
+              isOwned: true,
+            }),
+            mockLlmConfigSummary({
+              id: '00000000-0000-4000-8000-0000000000c2',
+              name: 'Preset B',
+              description: 'Expensive but good',
+              model: 'openai/gpt-4',
+              provider: 'openrouter',
+              isGlobal: false,
+              isOwned: true,
+            }),
+          ])
+        )
+      );
 
       await handleAutocomplete(mockInteraction);
 
@@ -211,11 +225,7 @@ describe('handleAutocomplete', () => {
         name: 'preset',
         value: 'test',
       } as unknown as string);
-      vi.mocked(callGatewayApi).mockResolvedValue({
-        ok: false,
-        error: 'API error',
-        status: 500,
-      });
+      stub.listUserLlmConfigs.mockResolvedValue(makeErr(500, 'API error'));
 
       await handleAutocomplete(mockInteraction);
 
@@ -237,10 +247,7 @@ describe('handleAutocomplete', () => {
           isOwned: true,
         })
       );
-      vi.mocked(callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: { configs: manyPresets },
-      });
+      stub.listUserLlmConfigs.mockResolvedValue(makeOk({ configs: manyPresets }));
 
       await handleAutocomplete(mockInteraction);
 
@@ -262,13 +269,105 @@ describe('handleAutocomplete', () => {
     });
   });
 
+  describe('global config autocomplete (owner-only)', () => {
+    // `handleGlobalConfigAutocomplete` reads through a module-level TTLCache
+    // that survives `vi.clearAllMocks()` (it's module state, not a vi mock).
+    // Each test resets it via the test-only `__resetGlobalConfigCacheForTests`
+    // export so every case exercises the cold-fetch path independently — no
+    // ordering dependency between `it()` blocks (per 02-code-standards.md).
+    let ownerStub: OwnerClientStub;
+    const cacheableFixture = makeOk({
+      configs: [
+        {
+          id: 'g-claude',
+          name: 'Global Claude',
+          model: 'anthropic/claude-sonnet-4',
+          isGlobal: true,
+          isDefault: true,
+        },
+        {
+          id: 'g-gpt',
+          name: 'Global GPT',
+          model: 'openai/gpt-4',
+          isGlobal: true,
+          isDefault: false,
+        },
+        {
+          id: 'g-free',
+          name: 'Global Free',
+          model: 'x-ai/grok-4.1-fast:free',
+          isGlobal: true,
+          isDefault: false,
+        },
+      ],
+    });
+
+    beforeEach(() => {
+      __resetGlobalConfigCacheForTests();
+      ownerStub = createOwnerStub();
+      clientsForMock.mockReturnValue({
+        userClient: asUserClient(stub),
+        ownerClient: ownerStub as never,
+      });
+      vi.mocked(mockInteraction.options.getSubcommandGroup).mockReturnValue('global');
+    });
+
+    it('responds with empty list when the admin endpoint fails', async () => {
+      vi.mocked(mockInteraction.options.getFocused).mockReturnValue({
+        name: 'config',
+        value: '',
+      } as unknown as string);
+      vi.mocked(mockInteraction.options.getSubcommand).mockReturnValue('set-default');
+      ownerStub.listGlobalLlmConfigs.mockResolvedValue(makeErr(403, 'forbidden'));
+
+      await handleAutocomplete(mockInteraction);
+
+      expect(mockInteraction.respond).toHaveBeenCalledWith([]);
+    });
+
+    it('lists global presets filtered by query, attaches GLOBAL + DEFAULT badges', async () => {
+      vi.mocked(mockInteraction.options.getFocused).mockReturnValue({
+        name: 'config',
+        value: 'claude',
+      } as unknown as string);
+      vi.mocked(mockInteraction.options.getSubcommand).mockReturnValue('set-default');
+      ownerStub.listGlobalLlmConfigs.mockResolvedValue(cacheableFixture);
+
+      await handleAutocomplete(mockInteraction);
+
+      const respondCall = vi.mocked(mockInteraction.respond).mock.calls[0][0];
+      expect(respondCall).toEqual([
+        expect.objectContaining({
+          value: 'g-claude',
+          // Owner-only autocomplete attaches scope (🌐) + default (⭐) badges
+          name: expect.stringContaining('Global Claude'),
+        }),
+      ]);
+    });
+
+    it('restricts to free models when subcommand is free-default', async () => {
+      vi.mocked(mockInteraction.options.getFocused).mockReturnValue({
+        name: 'config',
+        value: '',
+      } as unknown as string);
+      vi.mocked(mockInteraction.options.getSubcommand).mockReturnValue('free-default');
+      ownerStub.listGlobalLlmConfigs.mockResolvedValue(cacheableFixture);
+
+      await handleAutocomplete(mockInteraction);
+
+      const respondCall = vi.mocked(mockInteraction.respond).mock.calls[0][0];
+      // Only the :free-suffixed model survives the freeOnly filter
+      expect(respondCall).toEqual([expect.objectContaining({ value: 'g-free' })]);
+    });
+  });
+
   describe('error handling', () => {
     it('should respond with empty array on exception', async () => {
       vi.mocked(mockInteraction.options.getFocused).mockReturnValue({
         name: 'preset',
         value: 'test',
       } as unknown as string);
-      vi.mocked(callGatewayApi).mockRejectedValue(new Error('Network error'));
+      stub.listUserLlmConfigs.mockRejectedValue(new Error('Network error'));
 
       await handleAutocomplete(mockInteraction);
 

--- a/services/bot-client/src/commands/preset/autocomplete.ts
+++ b/services/bot-client/src/commands/preset/autocomplete.ts
@@ -15,8 +15,7 @@ import {
   type LlmConfigSummary,
   type AutocompleteBadge,
 } from '@tzurot/common-types';
-import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
-import { adminFetch } from '../../utils/adminApiClient.js';
+import { clientsFor } from '../../utils/gatewayClients.js';
 import {
   fetchTextModels,
   fetchVisionModels,
@@ -50,6 +49,15 @@ function getGlobalConfigCache(): TTLCache<GlobalConfigEntry[]> {
     maxSize: 1, // Only one entry needed
   });
   return globalConfigCache;
+}
+
+/**
+ * Reset the module-level global-config cache. Test-only — lets each test
+ * exercise the cold-fetch path without ordering dependencies on prior tests
+ * that may have populated the cache.
+ */
+export function __resetGlobalConfigCacheForTests(): void {
+  globalConfigCache = null;
 }
 
 /**
@@ -158,9 +166,8 @@ async function handlePresetAutocomplete(
 ): Promise<void> {
   const subcommand = interaction.options.getSubcommand(false);
 
-  const result = await callGatewayApi<{ configs: LlmConfigSummary[] }>('/user/llm-config', {
-    user: toGatewayUser(interaction.user),
-  });
+  const { userClient } = clientsFor(interaction);
+  const result = await userClient.listUserLlmConfigs();
 
   if (!result.ok) {
     logger.warn({ userId, error: result.error }, 'Failed to fetch presets');
@@ -226,7 +233,9 @@ const GLOBAL_CONFIG_CACHE_KEY = 'global-configs';
 /**
  * Fetch global configs from API or cache
  */
-async function fetchGlobalConfigs(): Promise<GlobalConfigEntry[] | null> {
+async function fetchGlobalConfigs(
+  interaction: AutocompleteInteraction
+): Promise<GlobalConfigEntry[] | null> {
   const cache = getGlobalConfigCache();
 
   // Check cache first
@@ -236,20 +245,20 @@ async function fetchGlobalConfigs(): Promise<GlobalConfigEntry[] | null> {
     return cached;
   }
 
-  // Cache miss - fetch from API
-  const response = await adminFetch('/admin/llm-config');
+  // Cache miss - fetch via typed admin client
+  const { ownerClient } = clientsFor(interaction);
+  const result = await ownerClient.listGlobalLlmConfigs();
 
-  if (!response.ok) {
+  if (!result.ok) {
     return null;
   }
 
-  const data = (await response.json()) as { configs: GlobalConfigEntry[] };
+  const configs = result.data.configs as GlobalConfigEntry[];
 
-  // Store in cache
-  cache.set(GLOBAL_CONFIG_CACHE_KEY, data.configs);
-  logger.debug({ count: data.configs.length }, 'Cached global configs');
+  cache.set(GLOBAL_CONFIG_CACHE_KEY, configs);
+  logger.debug({ count: configs.length }, 'Cached global configs');
 
-  return data.configs;
+  return configs;
 }
 
 /**
@@ -262,7 +271,7 @@ async function handleGlobalConfigAutocomplete(
   freeOnly = false
 ): Promise<void> {
   try {
-    const configs = await fetchGlobalConfigs();
+    const configs = await fetchGlobalConfigs(interaction);
 
     if (configs === null) {
       await interaction.respond([]);

--- a/services/bot-client/src/commands/preset/browse.test.ts
+++ b/services/bot-client/src/commands/preset/browse.test.ts
@@ -3,19 +3,11 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { ButtonInteraction } from 'discord.js';
-import {
-  handleBrowse,
-  handleBrowsePagination,
-  handleBrowseSelect,
-  isPresetBrowseInteraction,
-  isPresetBrowseSelectInteraction,
-} from './browse.js';
-import { registerBrowseRebuilder } from '../../utils/dashboard/index.js';
-import type { StringSelectMenuInteraction } from 'discord.js';
+import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
 import { mockListLlmConfigsResponse, mockListWalletKeysResponse } from '@tzurot/common-types';
+import { makeOk, makeErr, asUserClient } from '../../test/gatewayClientStubs.js';
+import { registerBrowseRebuilder } from '../../utils/dashboard/index.js';
 
-// Mock common-types
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal<typeof import('@tzurot/common-types')>();
   return {
@@ -29,17 +21,10 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
-// Mock userGatewayClient
-const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
-    '../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  };
-});
+const clientsForMock = vi.hoisted(() => vi.fn());
+vi.mock('../../utils/gatewayClients.js', () => ({
+  clientsFor: clientsForMock,
+}));
 
 // Mock dashboard utilities
 const mockBuildDashboardEmbed = vi.fn(() => ({ toJSON: () => ({ title: 'Dashboard' }) }));
@@ -75,11 +60,42 @@ vi.mock('./config.js', () => ({
   }),
 }));
 
+const {
+  handleBrowse,
+  handleBrowsePagination,
+  handleBrowseSelect,
+  isPresetBrowseInteraction,
+  isPresetBrowseSelectInteraction,
+} = await import('./browse.js');
+
+interface UserClientStub {
+  listUserLlmConfigs: ReturnType<typeof vi.fn>;
+  listWalletKeys: ReturnType<typeof vi.fn>;
+}
+
+function createStub(): UserClientStub {
+  return { listUserLlmConfigs: vi.fn(), listWalletKeys: vi.fn() };
+}
+
+function configurePresets(
+  stub: UserClientStub,
+  presets: Parameters<typeof mockListLlmConfigsResponse>[0],
+  hasWallet = true
+): void {
+  stub.listUserLlmConfigs.mockResolvedValue(makeOk(mockListLlmConfigsResponse(presets)));
+  stub.listWalletKeys.mockResolvedValue(
+    makeOk(mockListWalletKeysResponse(hasWallet ? [{ isActive: true }] : []))
+  );
+}
+
 describe('handleBrowse', () => {
   const mockEditReply = vi.fn();
+  let stub: UserClientStub;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    stub = createStub();
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
   });
 
   function createMockContext(query: string | null = null, filter: string | null = null) {
@@ -98,29 +114,8 @@ describe('handleBrowse', () => {
     } as unknown as Parameters<typeof handleBrowse>[0];
   }
 
-  function mockPresetApis(
-    presets: Parameters<typeof mockListLlmConfigsResponse>[0],
-    hasWallet = true
-  ) {
-    mockCallGatewayApi.mockImplementation((path: string) => {
-      if (path === '/user/llm-config') {
-        return Promise.resolve({
-          ok: true,
-          data: mockListLlmConfigsResponse(presets),
-        });
-      }
-      if (path === '/wallet/list') {
-        return Promise.resolve({
-          ok: true,
-          data: mockListWalletKeysResponse(hasWallet ? [{ isActive: true }] : []),
-        });
-      }
-      return Promise.resolve({ ok: false, error: 'Unknown path' });
-    });
-  }
-
   it('should browse presets with default settings (no filter, no query)', async () => {
-    mockPresetApis([
+    configurePresets(stub, [
       {
         id: '00000000-0000-4000-8000-000000000001',
         name: 'Default',
@@ -144,14 +139,7 @@ describe('handleBrowse', () => {
     const context = createMockContext();
     await handleBrowse(context);
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/llm-config', {
-      user: {
-        discordId: '123456789',
-        username: 'testuser',
-        displayName: 'testuser',
-      },
-      timeout: 10000,
-    });
+    expect(stub.listUserLlmConfigs).toHaveBeenCalled();
     expect(mockEditReply).toHaveBeenCalledWith({
       embeds: [
         expect.objectContaining({
@@ -163,15 +151,13 @@ describe('handleBrowse', () => {
       components: expect.any(Array), // Select menu for choosing preset
     });
 
-    // Verify components include select menu (no pagination buttons for small lists)
     const components = mockEditReply.mock.calls[0][0].components;
     expect(components).toHaveLength(1); // Just select menu, no pagination
-    // Custom ID now includes browse context: preset::browse-select::page::filter::query
     expect(components[0].components[0].data.custom_id).toBe('preset::browse-select::0::all::');
   });
 
   it('should filter by global presets', async () => {
-    mockPresetApis([
+    configurePresets(stub, [
       {
         id: '00000000-0000-4000-8000-000000000001',
         name: 'Default',
@@ -194,13 +180,12 @@ describe('handleBrowse', () => {
     await handleBrowse(context);
 
     const embedData = mockEditReply.mock.calls[0][0].embeds[0].data;
-    // Should only show global presets
     expect(embedData.description).toContain('Default');
     expect(embedData.description).not.toContain('MyPreset');
   });
 
   it('should filter by owned presets', async () => {
-    mockPresetApis([
+    configurePresets(stub, [
       {
         id: '00000000-0000-4000-8000-000000000001',
         name: 'Default',
@@ -223,13 +208,12 @@ describe('handleBrowse', () => {
     await handleBrowse(context);
 
     const embedData = mockEditReply.mock.calls[0][0].embeds[0].data;
-    // Should only show owned presets
     expect(embedData.description).not.toContain('Default');
     expect(embedData.description).toContain('MyPreset');
   });
 
   it('should filter by free presets', async () => {
-    mockPresetApis([
+    configurePresets(stub, [
       {
         id: '00000000-0000-4000-8000-000000000001',
         name: 'Paid Model',
@@ -252,13 +236,12 @@ describe('handleBrowse', () => {
     await handleBrowse(context);
 
     const embedData = mockEditReply.mock.calls[0][0].embeds[0].data;
-    // Should only show free presets
     expect(embedData.description).not.toContain('Paid Model');
     expect(embedData.description).toContain('Free Model');
   });
 
   it('should search by query', async () => {
-    mockPresetApis([
+    configurePresets(stub, [
       {
         id: '00000000-0000-4000-8000-000000000001',
         name: 'Claude Default',
@@ -281,14 +264,14 @@ describe('handleBrowse', () => {
     await handleBrowse(context);
 
     const embedData = mockEditReply.mock.calls[0][0].embeds[0].data;
-    // Should only show matching presets
     expect(embedData.description).toContain('Claude Default');
     expect(embedData.description).not.toContain('GPT Config');
     expect(embedData.description).toContain('Searching: "claude"');
   });
 
   it('should show guest mode warning when no active wallet', async () => {
-    mockPresetApis(
+    configurePresets(
+      stub,
       [
         {
           id: '00000000-0000-4000-8000-000000000001',
@@ -299,7 +282,7 @@ describe('handleBrowse', () => {
           isOwned: false,
         },
       ],
-      false // No wallet
+      false
     );
 
     const context = createMockContext();
@@ -310,7 +293,7 @@ describe('handleBrowse', () => {
   });
 
   it('should show no results message when filter produces empty results', async () => {
-    mockPresetApis([
+    configurePresets(stub, [
       {
         id: '00000000-0000-4000-8000-000000000001',
         name: 'Global Only',
@@ -329,11 +312,8 @@ describe('handleBrowse', () => {
   });
 
   it('should handle API error', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: false,
-      status: 500,
-      error: 'Server error',
-    });
+    stub.listUserLlmConfigs.mockResolvedValue(makeErr(500, 'Server error'));
+    stub.listWalletKeys.mockResolvedValue(makeErr(500, 'Server error'));
 
     const context = createMockContext();
     await handleBrowse(context);
@@ -344,7 +324,8 @@ describe('handleBrowse', () => {
   });
 
   it('should handle exceptions', async () => {
-    mockCallGatewayApi.mockRejectedValue(new Error('Network error'));
+    stub.listUserLlmConfigs.mockRejectedValue(new Error('Network error'));
+    stub.listWalletKeys.mockRejectedValue(new Error('Network error'));
 
     const context = createMockContext();
     await handleBrowse(context);
@@ -358,9 +339,12 @@ describe('handleBrowse', () => {
 describe('handleBrowsePagination', () => {
   const mockDeferUpdate = vi.fn();
   const mockEditReply = vi.fn();
+  let stub: UserClientStub;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    stub = createStub();
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
   });
 
   function createMockButtonInteraction(customId: string) {
@@ -372,37 +356,16 @@ describe('handleBrowsePagination', () => {
     } as unknown as ButtonInteraction;
   }
 
-  function mockPresetApis(
-    presets: Parameters<typeof mockListLlmConfigsResponse>[0],
-    hasWallet = true
-  ) {
-    mockCallGatewayApi.mockImplementation((path: string) => {
-      if (path === '/user/llm-config') {
-        return Promise.resolve({
-          ok: true,
-          data: mockListLlmConfigsResponse(presets),
-        });
-      }
-      if (path === '/wallet/list') {
-        return Promise.resolve({
-          ok: true,
-          data: mockListWalletKeysResponse(hasWallet ? [{ isActive: true }] : []),
-        });
-      }
-      return Promise.resolve({ ok: false, error: 'Unknown path' });
-    });
-  }
-
   it('should return early for invalid custom ID', async () => {
     const mockInteraction = createMockButtonInteraction('invalid::custom::id');
     await handleBrowsePagination(mockInteraction);
 
     expect(mockDeferUpdate).not.toHaveBeenCalled();
-    expect(mockCallGatewayApi).not.toHaveBeenCalled();
+    expect(stub.listUserLlmConfigs).not.toHaveBeenCalled();
   });
 
   it('should defer update on pagination', async () => {
-    mockPresetApis([
+    configurePresets(stub, [
       {
         id: '00000000-0000-4000-8000-000000000001',
         name: 'Default',
@@ -419,7 +382,7 @@ describe('handleBrowsePagination', () => {
   });
 
   it('should refresh data and update reply', async () => {
-    mockPresetApis([
+    configurePresets(stub, [
       {
         id: '00000000-0000-4000-8000-000000000001',
         name: 'Default',
@@ -432,14 +395,7 @@ describe('handleBrowsePagination', () => {
     const mockInteraction = createMockButtonInteraction('preset::browse::0::all::');
     await handleBrowsePagination(mockInteraction);
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/llm-config', {
-      user: {
-        discordId: '123456789',
-        username: 'testuser',
-        displayName: 'testuser',
-      },
-      timeout: 10000,
-    });
+    expect(stub.listUserLlmConfigs).toHaveBeenCalled();
     expect(mockEditReply).toHaveBeenCalledWith({
       embeds: expect.any(Array),
       components: expect.any(Array),
@@ -447,7 +403,7 @@ describe('handleBrowsePagination', () => {
   });
 
   it('should apply filter from custom ID', async () => {
-    mockPresetApis([
+    configurePresets(stub, [
       {
         id: '00000000-0000-4000-8000-000000000001',
         name: 'Global',
@@ -475,7 +431,7 @@ describe('handleBrowsePagination', () => {
   });
 
   it('should apply query from custom ID', async () => {
-    mockPresetApis([
+    configurePresets(stub, [
       {
         id: '00000000-0000-4000-8000-000000000001',
         name: 'Claude Config',
@@ -501,11 +457,8 @@ describe('handleBrowsePagination', () => {
   });
 
   it('should handle API error silently (keep existing content)', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: false,
-      status: 500,
-      error: 'Server error',
-    });
+    stub.listUserLlmConfigs.mockResolvedValue(makeErr(500, 'Server error'));
+    stub.listWalletKeys.mockResolvedValue(makeErr(500, 'Server error'));
 
     const mockInteraction = createMockButtonInteraction('preset::browse::1::all::');
     await handleBrowsePagination(mockInteraction);
@@ -515,11 +468,11 @@ describe('handleBrowsePagination', () => {
   });
 
   it('should handle exceptions gracefully', async () => {
-    mockCallGatewayApi.mockRejectedValue(new Error('Network error'));
+    stub.listUserLlmConfigs.mockRejectedValue(new Error('Network error'));
+    stub.listWalletKeys.mockRejectedValue(new Error('Network error'));
 
     const mockInteraction = createMockButtonInteraction('preset::browse::1::all::');
 
-    // Should not throw
     await expect(handleBrowsePagination(mockInteraction)).resolves.not.toThrow();
     expect(mockEditReply).not.toHaveBeenCalled();
   });
@@ -552,9 +505,12 @@ describe('isPresetBrowseSelectInteraction', () => {
 describe('handleBrowseSelect', () => {
   const mockDeferUpdate = vi.fn();
   const mockEditReply = vi.fn();
+  let stub: UserClientStub;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    stub = createStub();
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
   });
 
   function createMockSelectInteraction(presetId: string) {
@@ -583,11 +539,7 @@ describe('handleBrowseSelect', () => {
     await handleBrowseSelect(mockInteraction);
 
     expect(mockDeferUpdate).toHaveBeenCalled();
-    expect(mockFetchPreset).toHaveBeenCalledWith('preset-123', {
-      discordId: '123456789',
-      username: 'testuser',
-      displayName: 'testuser',
-    });
+    expect(mockFetchPreset).toHaveBeenCalledWith('preset-123', expect.anything());
     expect(mockBuildDashboardEmbed).toHaveBeenCalled();
     expect(mockBuildDashboardComponents).toHaveBeenCalled();
     expect(mockEditReply).toHaveBeenCalled();
@@ -640,6 +592,14 @@ if (presetRebuilderCall === undefined) {
 const presetRebuilder = presetRebuilderCall[1];
 
 describe('registered browse rebuilder', () => {
+  let stub: UserClientStub;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stub = createStub();
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
+  });
+
   function createMockInteraction() {
     return { user: { id: '123456789', username: 'testuser' } } as unknown as Parameters<
       typeof presetRebuilder
@@ -647,30 +607,16 @@ describe('registered browse rebuilder', () => {
   }
 
   it('returns rebuilt view with banner on success', async () => {
-    mockCallGatewayApi.mockImplementation((path: string) => {
-      if (path === '/user/llm-config') {
-        return Promise.resolve({
-          ok: true,
-          data: mockListLlmConfigsResponse([
-            {
-              id: '00000000-0000-4000-8000-000000000001',
-              name: 'Default',
-              model: 'anthropic/claude-sonnet-4',
-              provider: 'openrouter',
-              isGlobal: true,
-              isOwned: false,
-            },
-          ]),
-        });
-      }
-      if (path === '/wallet/list') {
-        return Promise.resolve({
-          ok: true,
-          data: mockListWalletKeysResponse([{ isActive: true }]),
-        });
-      }
-      return Promise.resolve({ ok: false, error: 'Unknown' });
-    });
+    configurePresets(stub, [
+      {
+        id: '00000000-0000-4000-8000-000000000001',
+        name: 'Default',
+        model: 'anthropic/claude-sonnet-4',
+        provider: 'openrouter',
+        isGlobal: true,
+        isOwned: false,
+      },
+    ]);
 
     const result = await presetRebuilder(
       createMockInteraction(),
@@ -687,7 +633,8 @@ describe('registered browse rebuilder', () => {
   });
 
   it('returns null when gateway fetch fails', async () => {
-    mockCallGatewayApi.mockResolvedValue({ ok: false, error: 'Server error' });
+    stub.listUserLlmConfigs.mockResolvedValue(makeErr(500, 'Server error'));
+    stub.listWalletKeys.mockResolvedValue(makeErr(500, 'Server error'));
 
     const result = await presetRebuilder(
       createMockInteraction(),

--- a/services/bot-client/src/commands/preset/browse.ts
+++ b/services/bot-client/src/commands/preset/browse.ts
@@ -16,15 +16,10 @@ import {
   isFreeModel,
   presetBrowseOptions,
   type LlmConfigSummary,
-  type ListWalletKeysResponse,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import {
-  callGatewayApi,
-  GATEWAY_TIMEOUTS,
-  toGatewayUser,
-  type GatewayUser,
-} from '../../utils/userGatewayClient.js';
+import type { UserClient } from '@tzurot/common-types';
+import { clientsFor } from '../../utils/gatewayClients.js';
 import {
   buildDashboardEmbed,
   buildDashboardComponents,
@@ -63,10 +58,6 @@ const browseHelpers = createBrowseCustomIdHelpers<PresetBrowseFilter>({
   validFilters: VALID_FILTERS,
   includeSort: false,
 });
-
-interface ListResponse {
-  configs: LlmConfigSummary[];
-}
 
 /**
  * Check if custom ID is a preset browse interaction
@@ -317,17 +308,10 @@ export async function handleBrowse(context: DeferredCommandContext): Promise<voi
 
   try {
     // Fetch presets and wallet status in parallel
-    // Use longer timeout since this is a deferred operation
-    const user = toGatewayUser(context.user);
+    const { userClient } = clientsFor(context.interaction);
     const [presetResult, walletResult] = await Promise.all([
-      callGatewayApi<ListResponse>('/user/llm-config', {
-        user,
-        timeout: GATEWAY_TIMEOUTS.DEFERRED,
-      }),
-      callGatewayApi<ListWalletKeysResponse>('/wallet/list', {
-        user,
-        timeout: GATEWAY_TIMEOUTS.DEFERRED,
-      }),
+      userClient.listUserLlmConfigs(),
+      userClient.listWalletKeys(),
     ]);
 
     if (!presetResult.ok) {
@@ -372,7 +356,7 @@ export async function handleBrowse(context: DeferredCommandContext): Promise<voi
  * Reusable for pagination and back-from-dashboard navigation
  */
 export async function buildBrowseResponse(
-  user: GatewayUser,
+  userClient: UserClient,
   browseContext: {
     page: number;
     filter: PresetBrowseFilter;
@@ -381,16 +365,10 @@ export async function buildBrowseResponse(
 ): Promise<{ embed: EmbedBuilder; components: BrowseActionRow[] } | null> {
   const { page, filter, query } = browseContext;
 
-  // Re-fetch data (use longer timeout since this is a deferred operation)
+  // Re-fetch data via typed client
   const [presetResult, walletResult] = await Promise.all([
-    callGatewayApi<ListResponse>('/user/llm-config', {
-      user,
-      timeout: GATEWAY_TIMEOUTS.DEFERRED,
-    }),
-    callGatewayApi<ListWalletKeysResponse>('/wallet/list', {
-      user,
-      timeout: GATEWAY_TIMEOUTS.DEFERRED,
-    }),
+    userClient.listUserLlmConfigs(),
+    userClient.listWalletKeys(),
   ]);
 
   if (!presetResult.ok) {
@@ -408,7 +386,8 @@ export async function buildBrowseResponse(
 // load time. Consumed by `renderPostActionScreen` (destructive-action success
 // → direct re-render) and `handleSharedBackButton` (Back-to-Browse click).
 registerBrowseRebuilder('preset', async (interaction, browseContext, successBanner) => {
-  const result = await buildBrowseResponse(toGatewayUser(interaction.user), {
+  const { userClient } = clientsFor(interaction);
+  const result = await buildBrowseResponse(userClient, {
     page: browseContext.page,
     filter: browseContext.filter as PresetBrowseFilter,
     query: browseContext.query ?? null,
@@ -435,7 +414,8 @@ export async function handleBrowsePagination(interaction: ButtonInteraction): Pr
   await interaction.deferUpdate();
 
   try {
-    const result = await buildBrowseResponse(toGatewayUser(interaction.user), parsed);
+    const { userClient } = clientsFor(interaction);
+    const result = await buildBrowseResponse(userClient, parsed);
 
     if (result === null) {
       logger.warn({ userId: interaction.user.id }, 'Failed to fetch presets for pagination');
@@ -466,7 +446,8 @@ export async function handleBrowseSelect(interaction: StringSelectMenuInteractio
 
   try {
     // Fetch the preset
-    const preset = await fetchPreset(presetId, toGatewayUser(interaction.user));
+    const { userClient } = clientsFor(interaction);
+    const preset = await fetchPreset(presetId, userClient);
 
     if (!preset) {
       await interaction.editReply({

--- a/services/bot-client/src/commands/preset/cloneName.test.ts
+++ b/services/bot-client/src/commands/preset/cloneName.test.ts
@@ -9,12 +9,11 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { GatewayApiError } from '../../utils/userGatewayClient.js';
-import type { GatewayUser } from '../../utils/userGatewayClient.js';
+import { GatewayApiError, type UserClient } from '@tzurot/common-types';
 import type { FlattenedPresetData } from './config.js';
 
-function mkUser(discordId = 'user-1'): GatewayUser {
-  return { discordId, username: 'test-user', displayName: 'Test User' };
+function mkUserClient(discordId = 'user-1'): UserClient {
+  return { actor: discordId } as unknown as UserClient;
 }
 
 const mockCreatePreset = vi.fn();
@@ -61,8 +60,8 @@ describe('createClonedPreset', () => {
     const resultPreset = { id: 'new-id', name: 'My Preset (Copy)' };
     mockCreatePreset.mockResolvedValueOnce(resultPreset);
 
-    const user = mkUser();
-    const result = await createClonedPreset(sourceData, user);
+    const userClient = mkUserClient();
+    const result = await createClonedPreset(sourceData, userClient);
 
     expect(result).toBe(resultPreset);
     expect(mockCreatePreset).toHaveBeenCalledTimes(1);
@@ -71,7 +70,7 @@ describe('createClonedPreset', () => {
         name: 'My Preset (Copy)',
         autoSuffixOnCollision: true,
       }),
-      user
+      userClient
     );
   });
 
@@ -82,21 +81,21 @@ describe('createClonedPreset', () => {
     const collision = new GatewayApiError('still colliding', 400, 'NAME_COLLISION');
     mockCreatePreset.mockRejectedValueOnce(collision);
 
-    await expect(createClonedPreset(sourceData, mkUser())).rejects.toBe(collision);
+    await expect(createClonedPreset(sourceData, mkUserClient())).rejects.toBe(collision);
     expect(mockCreatePreset).toHaveBeenCalledTimes(1);
   });
 
   it('propagates GatewayApiErrors with no sub-code immediately', async () => {
     mockCreatePreset.mockRejectedValueOnce(new GatewayApiError('Bad request', 400));
 
-    await expect(createClonedPreset(sourceData, mkUser())).rejects.toThrow('Bad request');
+    await expect(createClonedPreset(sourceData, mkUserClient())).rejects.toThrow('Bad request');
     expect(mockCreatePreset).toHaveBeenCalledTimes(1);
   });
 
   it('propagates plain Errors immediately', async () => {
     mockCreatePreset.mockRejectedValueOnce(new Error('network blip'));
 
-    await expect(createClonedPreset(sourceData, mkUser())).rejects.toThrow('network blip');
+    await expect(createClonedPreset(sourceData, mkUserClient())).rejects.toThrow('network blip');
     expect(mockCreatePreset).toHaveBeenCalledTimes(1);
   });
 });

--- a/services/bot-client/src/commands/preset/cloneName.ts
+++ b/services/bot-client/src/commands/preset/cloneName.ts
@@ -13,8 +13,7 @@
  * (shown to the user in confirmation UX).
  */
 
-import { generateClonedName } from '@tzurot/common-types';
-import type { GatewayUser } from '../../utils/userGatewayClient.js';
+import { generateClonedName, type UserClient } from '@tzurot/common-types';
 import { createPreset } from './api.js';
 import type { FlattenedPresetData } from './config.js';
 import type { PresetData } from './types.js';
@@ -36,7 +35,7 @@ export { generateClonedName };
  */
 export async function createClonedPreset(
   sourceData: FlattenedPresetData,
-  user: GatewayUser
+  userClient: UserClient
 ): Promise<PresetData> {
   const initialName = generateClonedName(sourceData.name);
   return createPreset(
@@ -54,6 +53,6 @@ export async function createClonedPreset(
           : undefined,
       autoSuffixOnCollision: true,
     },
-    user
+    userClient
   );
 }

--- a/services/bot-client/src/commands/preset/create.test.ts
+++ b/services/bot-client/src/commands/preset/create.test.ts
@@ -31,6 +31,12 @@ vi.mock('./api.js', async () => {
   };
 });
 
+// Sentinel userClient flowing from `clientsFor(interaction)` into `createPreset`.
+const TEST_USER_CLIENT = { actor: 'user-123' };
+vi.mock('../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: TEST_USER_CLIENT, ownerClient: { actor: 'owner' } })),
+}));
+
 vi.mock('../../utils/dashboard/index.js', () => ({
   buildDashboardEmbed: vi.fn().mockReturnValue({ data: {} }),
   buildDashboardComponents: vi.fn().mockReturnValue([]),
@@ -204,7 +210,7 @@ describe('Preset Create', () => {
           model: 'anthropic/claude-sonnet-4',
           provider: 'openrouter',
         },
-        expect.objectContaining({ discordId: 'user-123' })
+        TEST_USER_CLIENT
       );
 
       // Dashboard should be built

--- a/services/bot-client/src/commands/preset/create.ts
+++ b/services/bot-client/src/commands/preset/create.ts
@@ -31,7 +31,7 @@ import {
   presetSeedFields,
   buildPresetDashboardOptions,
 } from './config.js';
-import { toGatewayUser } from '../../utils/userGatewayClient.js';
+import { clientsFor } from '../../utils/gatewayClients.js';
 import { createPreset, extractApiErrorMessage } from './api.js';
 
 const logger = createLogger('preset-create');
@@ -87,13 +87,14 @@ export async function handleSeedModalSubmit(interaction: ModalSubmitInteraction)
 
   try {
     // Create preset via API (API uses AI_DEFAULTS for sensible defaults)
+    const { userClient } = clientsFor(interaction);
     const preset = await createPreset(
       {
         name: values.name.trim(),
         model: values.model.trim(),
         provider: 'openrouter', // Default provider
       },
-      toGatewayUser(interaction.user)
+      userClient
     );
 
     // Flatten the data for dashboard display

--- a/services/bot-client/src/commands/preset/dashboard.test.ts
+++ b/services/bot-client/src/commands/preset/dashboard.test.ts
@@ -13,13 +13,19 @@ import {
 import { handleDashboardClose } from '../../utils/dashboard/closeHandler.js';
 import { DASHBOARD_MESSAGES, formatSessionExpiredMessage } from '../../utils/dashboard/messages.js';
 import type { PresetData } from './config.js';
-import { GatewayApiError } from '../../utils/userGatewayClient.js';
+import { GatewayApiError } from '@tzurot/common-types';
 
-const TEST_USER = {
-  discordId: 'user-456',
-  username: 'testuser',
-  displayName: 'testuser',
-} as const;
+// Sentinel passed by the migrated dashboard handler — `clientsFor(interaction)`
+// returns this stub, which then flows into the mocked api.ts helpers (fetchPreset,
+// updatePreset, etc.). Tests assert calls receive the same sentinel rather than
+// the legacy GatewayUser shape.
+const TEST_USER_CLIENT = { actor: 'user-456' };
+const TEST_OWNER_CLIENT = { actor: 'bot-owner' };
+const TEST_USER = TEST_USER_CLIENT;
+
+vi.mock('../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: TEST_USER_CLIENT, ownerClient: TEST_OWNER_CLIENT })),
+}));
 
 // Mock common-types logger
 vi.mock('@tzurot/common-types', async importOriginal => {
@@ -385,7 +391,11 @@ describe('handleModalSubmit', () => {
 
     await handleModalSubmit(createMockModalInteraction('preset::modal::preset-123::identity'));
 
-    expect(mockUpdateGlobalPreset).toHaveBeenCalledWith('preset-123', expect.any(Object));
+    expect(mockUpdateGlobalPreset).toHaveBeenCalledWith(
+      'preset-123',
+      expect.any(Object),
+      TEST_OWNER_CLIENT
+    );
     expect(mockUpdatePreset).not.toHaveBeenCalled();
   });
 
@@ -697,7 +707,7 @@ describe('handleButton', () => {
     await handleButton(createMockButtonInteraction('preset::refresh::preset-123'));
 
     expect(mockFetchPreset).toHaveBeenCalledWith('preset-123', TEST_USER);
-    expect(mockFetchGlobalPreset).toHaveBeenCalledWith('preset-123');
+    expect(mockFetchGlobalPreset).toHaveBeenCalledWith('preset-123', TEST_OWNER_CLIENT);
   });
 
   it('should show error when preset not found on refresh', async () => {

--- a/services/bot-client/src/commands/preset/dashboard.ts
+++ b/services/bot-client/src/commands/preset/dashboard.ts
@@ -24,7 +24,7 @@ import {
 } from '../../utils/dashboard/index.js';
 import { handleDashboardSectionSelect } from '../../utils/dashboard/genericSelectMenuHandler.js';
 import { refreshDashboardUI } from '../../utils/dashboard/refreshHandler.js';
-import { toGatewayUser } from '../../utils/userGatewayClient.js';
+import { clientsFor } from '../../utils/gatewayClients.js';
 import {
   PRESET_DASHBOARD_CONFIG,
   type FlattenedPresetData,
@@ -150,9 +150,10 @@ async function handleSectionModalSubmit(
     const isGlobal = session?.data.isGlobal ?? false;
 
     // Update preset via appropriate API
+    const { userClient, ownerClient } = clientsFor(interaction);
     const updatedPreset = isGlobal
-      ? await updateGlobalPreset(entityId, updatePayload)
-      : await updatePreset(entityId, updatePayload, toGatewayUser(interaction.user));
+      ? await updateGlobalPreset(entityId, updatePayload, ownerClient)
+      : await updatePreset(entityId, updatePayload, userClient);
 
     // Flatten the response for dashboard display
     const flattenedData = flattenPresetData(updatedPreset);

--- a/services/bot-client/src/commands/preset/dashboardButtons.test.ts
+++ b/services/bot-client/src/commands/preset/dashboardButtons.test.ts
@@ -20,11 +20,19 @@ import { refreshDashboardUI } from '../../utils/dashboard/refreshHandler.js';
 import { DASHBOARD_MESSAGES, formatSessionExpiredMessage } from '../../utils/dashboard/messages.js';
 import type { FlattenedPresetData } from './config.js';
 
-const TEST_USER = {
-  discordId: 'user-123',
-  username: 'testuser',
-  displayName: 'testuser',
-} as const;
+// Sentinel returned by mocked `clientsFor`; flows through to mocked api.ts helpers
+// so tests assert calls receive the same sentinel rather than a legacy GatewayUser.
+const mockDeleteUserLlmConfig = vi.fn();
+const TEST_USER_CLIENT = {
+  actor: 'user-123',
+  deleteUserLlmConfig: mockDeleteUserLlmConfig,
+};
+const TEST_OWNER_CLIENT = { actor: 'bot-owner' };
+const TEST_USER = TEST_USER_CLIENT;
+
+vi.mock('../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: TEST_USER_CLIENT, ownerClient: TEST_OWNER_CLIENT })),
+}));
 
 // Mock dependencies
 const mockFetchPreset = vi.fn();
@@ -43,17 +51,6 @@ const mockBuildBrowseResponse = vi.fn();
 vi.mock('./browse.js', () => ({
   buildBrowseResponse: (...args: unknown[]) => mockBuildBrowseResponse(...args),
 }));
-
-const mockCallGatewayApi = vi.fn();
-vi.mock('../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
-    '../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  };
-});
 
 const mockSessionManager = {
   get: vi.fn(),
@@ -434,7 +431,7 @@ describe('Preset Dashboard Buttons', () => {
       // Should try user endpoint first
       expect(mockFetchPreset).toHaveBeenCalledWith('preset-123', TEST_USER);
       // Should fall back to global endpoint
-      expect(mockFetchGlobalPreset).toHaveBeenCalledWith('preset-123');
+      expect(mockFetchGlobalPreset).toHaveBeenCalledWith('preset-123', TEST_OWNER_CLIENT);
     });
 
     it('routes not-found through renderTerminalScreen (preserves back-to-browse)', async () => {
@@ -614,15 +611,12 @@ describe('Preset Dashboard Buttons', () => {
       mockSessionManager.get.mockResolvedValue({
         data: createMockFlattenedPreset({ name: 'Preset To Delete' }),
       });
-      mockCallGatewayApi.mockResolvedValue({ ok: true });
+      mockDeleteUserLlmConfig.mockResolvedValue({ ok: true, data: {} });
 
       await handleConfirmDeleteButton(mockInteraction, 'preset-123');
 
       expect(mockInteraction.deferUpdate).toHaveBeenCalled();
-      expect(mockCallGatewayApi).toHaveBeenCalledWith(
-        '/user/llm-config/preset-123',
-        expect.objectContaining({ method: 'DELETE' })
-      );
+      expect(mockDeleteUserLlmConfig).toHaveBeenCalledWith('preset-123');
       // The helper decides success-with-rebuild vs clean-terminal based on
       // the session's browseContext; this suite verifies the handler routes
       // through it with the right outcome shape.
@@ -648,7 +642,7 @@ describe('Preset Dashboard Buttons', () => {
       mockSessionManager.get.mockResolvedValue({
         data: createMockFlattenedPreset({ browseContext: browseCtx }),
       });
-      mockCallGatewayApi.mockResolvedValue({ ok: true });
+      mockDeleteUserLlmConfig.mockResolvedValue({ ok: true, data: {} });
 
       await handleConfirmDeleteButton(mockInteraction, 'preset-123');
 
@@ -665,7 +659,11 @@ describe('Preset Dashboard Buttons', () => {
       mockSessionManager.get.mockResolvedValue({
         data: createMockFlattenedPreset(),
       });
-      mockCallGatewayApi.mockResolvedValue({ ok: false, error: 'Database error' });
+      mockDeleteUserLlmConfig.mockResolvedValue({
+        ok: false,
+        error: 'Database error',
+        status: 500,
+      });
 
       await handleConfirmDeleteButton(mockInteraction, 'preset-123');
 

--- a/services/bot-client/src/commands/preset/dashboardButtons.ts
+++ b/services/bot-client/src/commands/preset/dashboardButtons.ts
@@ -11,7 +11,7 @@
 import { MessageFlags } from 'discord.js';
 import type { ButtonInteraction } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
-import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
+import { clientsFor } from '../../utils/gatewayClients.js';
 import {
   buildDeleteConfirmation,
   handleDashboardClose,
@@ -80,12 +80,13 @@ export async function handleRefreshButton(
   const existingBrowseContext = existingSession?.data.browseContext;
 
   // Try user endpoint first (works for owned presets AND accessible global presets)
-  let preset = await fetchPreset(entityId, toGatewayUser(interaction.user));
+  const { userClient, ownerClient } = clientsFor(interaction);
+  let preset = await fetchPreset(entityId, userClient);
 
   // Fallback: if null and session indicated global, try admin endpoint
   // This handles edge case where preset is still global but user endpoint failed
   if (preset === null && cachedIsGlobal) {
-    preset = await fetchGlobalPreset(entityId);
+    preset = await fetchGlobalPreset(entityId, ownerClient);
   }
 
   if (preset === null) {
@@ -159,7 +160,8 @@ export async function handleToggleGlobalButton(
 
   try {
     // Fetch fresh data to prevent race condition with stale session.data.isGlobal
-    const freshPreset = await fetchPreset(entityId, toGatewayUser(interaction.user));
+    const { userClient } = clientsFor(interaction);
+    const freshPreset = await fetchPreset(entityId, userClient);
     if (freshPreset === null) {
       await interaction.followUp({
         content: DASHBOARD_MESSAGES.NOT_FOUND('Preset'),
@@ -169,11 +171,7 @@ export async function handleToggleGlobalButton(
     }
 
     const newIsGlobal = !freshPreset.isGlobal;
-    const updatedPreset = await updatePreset(
-      entityId,
-      { isGlobal: newIsGlobal },
-      toGatewayUser(interaction.user)
-    );
+    const updatedPreset = await updatePreset(entityId, { isGlobal: newIsGlobal }, userClient);
 
     const flattenedData = flattenPresetData(updatedPreset);
     const sessionManager = getSessionManager();
@@ -280,10 +278,8 @@ export async function handleConfirmDeleteButton(
   };
 
   try {
-    const result = await callGatewayApi<void>(`/user/llm-config/${encodeURIComponent(entityId)}`, {
-      method: 'DELETE',
-      user: toGatewayUser(interaction.user),
-    });
+    const { userClient } = clientsFor(interaction);
+    const result = await userClient.deleteUserLlmConfig(entityId);
 
     if (!result.ok) {
       logger.warn(
@@ -370,7 +366,8 @@ export async function handleCloneButton(
     // exists in the user's library, so cloning the original twice produces
     // the same "(Copy)" candidate both times. Retry with a bumped suffix on
     // the gateway's name-collision validation error; surface anything else.
-    const newPreset = await createClonedPreset(sourceData, toGatewayUser(interaction.user));
+    const { userClient } = clientsFor(interaction);
+    const newPreset = await createClonedPreset(sourceData, userClient);
 
     // Build update payload with all non-basic fields from source
     const updatePayload = unflattenPresetData(sourceData);
@@ -389,11 +386,11 @@ export async function handleCloneButton(
 
     // Apply updates if needed
     if (Object.keys(updatePayload).length > 0) {
-      await updatePreset(newPreset.id, updatePayload, toGatewayUser(interaction.user));
+      await updatePreset(newPreset.id, updatePayload, userClient);
     }
 
     // Fetch the complete cloned preset to get all fields
-    const clonedPreset = await fetchPreset(newPreset.id, toGatewayUser(interaction.user));
+    const clonedPreset = await fetchPreset(newPreset.id, userClient);
     if (clonedPreset === null) {
       throw new Error('Failed to fetch cloned preset');
     }

--- a/services/bot-client/src/commands/preset/edit.test.ts
+++ b/services/bot-client/src/commands/preset/edit.test.ts
@@ -30,6 +30,12 @@ vi.mock('./api.js', () => ({
   fetchPreset: (...args: unknown[]) => mockFetchPreset(...args),
 }));
 
+// Sentinel userClient flowing from `clientsFor(interaction)` into `fetchPreset`.
+const TEST_USER_CLIENT = { actor: 'user-456' };
+vi.mock('../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: TEST_USER_CLIENT, ownerClient: { actor: 'owner' } })),
+}));
+
 // Mock dashboard utilities
 const mockBuildDashboardEmbed = vi.fn().mockReturnValue({ title: 'Test Embed' });
 const mockBuildDashboardComponents = vi.fn().mockReturnValue([]);
@@ -90,11 +96,7 @@ describe('handleEdit', () => {
     await handleEdit(createMockContext());
 
     // Note: deferReply is now called at the framework level, not in the handler
-    expect(mockFetchPreset).toHaveBeenCalledWith('preset-123', {
-      discordId: 'user-456',
-      username: 'testuser',
-      displayName: 'testuser',
-    });
+    expect(mockFetchPreset).toHaveBeenCalledWith('preset-123', TEST_USER_CLIENT);
     expect(mockBuildDashboardEmbed).toHaveBeenCalled();
     // Uses buildPresetDashboardOptions for consistent button configuration
     expect(mockBuildDashboardComponents).toHaveBeenCalledWith(

--- a/services/bot-client/src/commands/preset/edit.ts
+++ b/services/bot-client/src/commands/preset/edit.ts
@@ -19,7 +19,7 @@ import {
   flattenPresetData,
   buildPresetDashboardOptions,
 } from './config.js';
-import { toGatewayUser } from '../../utils/userGatewayClient.js';
+import { clientsFor } from '../../utils/gatewayClients.js';
 import { fetchPreset } from './api.js';
 
 const logger = createLogger('preset-edit');
@@ -35,7 +35,8 @@ export async function handleEdit(context: DeferredCommandContext): Promise<void>
 
   try {
     // Fetch the preset
-    const preset = await fetchPreset(presetId, toGatewayUser(context.user));
+    const { userClient } = clientsFor(context.interaction);
+    const preset = await fetchPreset(presetId, userClient);
 
     if (!preset) {
       await context.editReply({ content: '❌ Preset not found.' });

--- a/services/bot-client/src/commands/preset/export.test.ts
+++ b/services/bot-client/src/commands/preset/export.test.ts
@@ -9,20 +9,8 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { AttachmentBuilder } from 'discord.js';
-import { handleExport } from './export.js';
-import * as userGatewayClient from '../../utils/userGatewayClient.js';
+import { makeOk, makeErr, asUserClient } from '../../test/gatewayClientStubs.js';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-
-// Mock dependencies
-vi.mock('../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
-    '../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: vi.fn(),
-  };
-});
 
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal();
@@ -47,7 +35,24 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
+const clientsForMock = vi.hoisted(() => vi.fn());
+vi.mock('../../utils/gatewayClients.js', () => ({
+  clientsFor: clientsForMock,
+}));
+
+const { handleExport } = await import('./export.js');
+
+interface UserClientStub {
+  getUserLlmConfig: ReturnType<typeof vi.fn>;
+}
+
+function createStub(): UserClientStub {
+  return { getUserLlmConfig: vi.fn() };
+}
+
 describe('Preset Export', () => {
+  let stub: UserClientStub;
+
   const createMockContext = (userId = 'user-123') =>
     ({
       user: { id: userId, username: 'testuser' },
@@ -79,6 +84,8 @@ describe('Preset Export', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    stub = createStub();
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
   });
 
   afterEach(() => {
@@ -87,10 +94,7 @@ describe('Preset Export', () => {
 
   describe('handleExport', () => {
     it('should export preset as JSON attachment', async () => {
-      vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: { config: mockPresetData },
-      });
+      stub.getUserLlmConfig.mockResolvedValue(makeOk({ config: mockPresetData }));
 
       const mockContext = createMockContext();
 
@@ -105,10 +109,7 @@ describe('Preset Export', () => {
     });
 
     it('should include only non-null fields in exported JSON', async () => {
-      vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: { config: mockPresetData },
-      });
+      stub.getUserLlmConfig.mockResolvedValue(makeOk({ config: mockPresetData }));
 
       const mockContext = createMockContext();
 
@@ -136,10 +137,7 @@ describe('Preset Export', () => {
         },
       };
 
-      vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: { config: presetWithAdvancedParams },
-      });
+      stub.getUserLlmConfig.mockResolvedValue(makeOk({ config: presetWithAdvancedParams }));
 
       const mockContext = createMockContext();
 
@@ -154,10 +152,7 @@ describe('Preset Export', () => {
         contextWindowTokens: 65536,
       };
 
-      vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: { config: presetWithCustomCtx },
-      });
+      stub.getUserLlmConfig.mockResolvedValue(makeOk({ config: presetWithCustomCtx }));
 
       const mockContext = createMockContext();
 
@@ -171,11 +166,7 @@ describe('Preset Export', () => {
     });
 
     it('should handle preset not found (404)', async () => {
-      vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue({
-        ok: false,
-        status: 404,
-        error: 'Not found',
-      });
+      stub.getUserLlmConfig.mockResolvedValue(makeErr(404, 'Not found'));
 
       const mockContext = createMockContext();
 
@@ -185,11 +176,7 @@ describe('Preset Export', () => {
     });
 
     it('should handle access denied (403)', async () => {
-      vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue({
-        ok: false,
-        status: 403,
-        error: 'Forbidden',
-      });
+      stub.getUserLlmConfig.mockResolvedValue(makeErr(403, 'Forbidden'));
 
       const mockContext = createMockContext();
 
@@ -207,10 +194,7 @@ describe('Preset Export', () => {
         permissions: { canEdit: false, canDelete: false },
       };
 
-      vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: { config: presetNotOwned },
-      });
+      stub.getUserLlmConfig.mockResolvedValue(makeOk({ config: presetNotOwned }));
 
       const mockContext = createMockContext();
 
@@ -228,10 +212,7 @@ describe('Preset Export', () => {
         permissions: { canEdit: false, canDelete: false },
       };
 
-      vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: { config: presetNotOwned },
-      });
+      stub.getUserLlmConfig.mockResolvedValue(makeOk({ config: presetNotOwned }));
 
       const mockContext = createMockContext('bot-owner-id');
 
@@ -246,11 +227,7 @@ describe('Preset Export', () => {
     });
 
     it('should handle API errors gracefully', async () => {
-      vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue({
-        ok: false,
-        status: 500,
-        error: 'Internal server error',
-      });
+      stub.getUserLlmConfig.mockResolvedValue(makeErr(500, 'Internal server error'));
 
       const mockContext = createMockContext();
 
@@ -262,7 +239,7 @@ describe('Preset Export', () => {
     });
 
     it('should handle network errors gracefully', async () => {
-      vi.mocked(userGatewayClient.callGatewayApi).mockRejectedValue(new Error('Network error'));
+      stub.getUserLlmConfig.mockRejectedValue(new Error('Network error'));
 
       const mockContext = createMockContext();
 
@@ -273,27 +250,18 @@ describe('Preset Export', () => {
       );
     });
 
-    it('should fetch preset using correct API call', async () => {
-      vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: { config: mockPresetData },
-      });
+    it('should fetch preset using typed client', async () => {
+      stub.getUserLlmConfig.mockResolvedValue(makeOk({ config: mockPresetData }));
 
       const mockContext = createMockContext();
 
       await handleExport(mockContext);
 
-      expect(userGatewayClient.callGatewayApi).toHaveBeenCalledWith(
-        '/user/llm-config/test-preset-id',
-        { user: { discordId: 'user-123', username: 'testuser', displayName: 'testuser' } }
-      );
+      expect(stub.getUserLlmConfig).toHaveBeenCalledWith('test-preset-id');
     });
 
     it('should include import instructions in response', async () => {
-      vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: { config: mockPresetData },
-      });
+      stub.getUserLlmConfig.mockResolvedValue(makeOk({ config: mockPresetData }));
 
       const mockContext = createMockContext();
 
@@ -312,10 +280,7 @@ describe('Preset Export', () => {
         name: 'Test **Bold** Preset',
       };
 
-      vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: { config: presetWithMarkdown },
-      });
+      stub.getUserLlmConfig.mockResolvedValue(makeOk({ config: presetWithMarkdown }));
 
       const mockContext = createMockContext();
 

--- a/services/bot-client/src/commands/preset/export.ts
+++ b/services/bot-client/src/commands/preset/export.ts
@@ -6,9 +6,9 @@
 import { escapeMarkdown } from 'discord.js';
 import { createLogger, isBotOwner, presetExportOptions } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi, toGatewayUser } from '../../utils/userGatewayClient.js';
+import { clientsFor } from '../../utils/gatewayClients.js';
 import { createJsonAttachment } from '../../utils/jsonFileUtils.js';
-import type { PresetData, PresetResponse } from './types.js';
+import type { PresetData } from './types.js';
 
 const logger = createLogger('preset-export');
 
@@ -124,12 +124,8 @@ export async function handleExport(context: DeferredCommandContext): Promise<voi
 
   try {
     // Fetch preset data
-    const result = await callGatewayApi<PresetResponse>(
-      `/user/llm-config/${encodeURIComponent(presetId)}`,
-      {
-        user: toGatewayUser(context.user),
-      }
-    );
+    const { userClient } = clientsFor(context.interaction);
+    const result = await userClient.getUserLlmConfig(presetId);
 
     if (!result.ok) {
       if (result.status === 404) {
@@ -143,7 +139,10 @@ export async function handleExport(context: DeferredCommandContext): Promise<voi
       throw new Error(`API error: ${result.status}`);
     }
 
-    const preset = result.data.config;
+    // Schema-vs-PresetData drift bridge (mirrors api.ts:toPresetData). The
+    // schema's `.passthrough()` preserves the extra fields at runtime, but
+    // TS narrowing only carries the explicitly-declared properties.
+    const preset = result.data.config as unknown as PresetData;
 
     // Check ownership - only preset owner or bot owner can export
     if (!preset.permissions.canEdit && !isBotOwner(userId)) {

--- a/services/bot-client/src/commands/preset/import.test.ts
+++ b/services/bot-client/src/commands/preset/import.test.ts
@@ -10,22 +10,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { handleImport, REQUIRED_IMPORT_FIELDS, PRESET_JSON_TEMPLATE } from './import.js';
-import * as userGatewayClient from '../../utils/userGatewayClient.js';
 import * as jsonFileUtils from '../../utils/jsonFileUtils.js';
+import { makeOk, makeErr, asUserClient } from '../../test/gatewayClientStubs.js';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import type { Attachment } from 'discord.js';
-
-// Mock dependencies
-vi.mock('../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
-    '../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: vi.fn(),
-  };
-});
 
 vi.mock('../../utils/jsonFileUtils.js', () => ({
   validateAndParseJsonFile: vi.fn(),
@@ -56,7 +44,24 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
+const clientsForMock = vi.hoisted(() => vi.fn());
+vi.mock('../../utils/gatewayClients.js', () => ({
+  clientsFor: clientsForMock,
+}));
+
+const { handleImport, REQUIRED_IMPORT_FIELDS, PRESET_JSON_TEMPLATE } = await import('./import.js');
+
+interface UserClientStub {
+  createUserLlmConfig: ReturnType<typeof vi.fn>;
+}
+
+function createStub(): UserClientStub {
+  return { createUserLlmConfig: vi.fn() };
+}
+
 describe('Preset Import', () => {
+  let stub: UserClientStub;
+
   const createMockAttachment = (): Attachment =>
     ({
       contentType: 'application/json',
@@ -86,6 +91,8 @@ describe('Preset Import', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    stub = createStub();
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
   });
 
   afterEach(() => {
@@ -111,10 +118,7 @@ describe('Preset Import', () => {
       vi.mocked(jsonFileUtils.validateAndParseJsonFile).mockResolvedValue({
         data: createValidPresetData(),
       });
-      vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: { id: 'new-preset-id' },
-      });
+      stub.createUserLlmConfig.mockResolvedValue(makeOk({ config: { id: 'new-preset-id' } }));
 
       const mockContext = createMockContext();
 
@@ -193,22 +197,16 @@ describe('Preset Import', () => {
           visionModel: 'anthropic/claude-sonnet-4',
         }),
       });
-      vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: { id: 'new-preset-id' },
-      });
+      stub.createUserLlmConfig.mockResolvedValue(makeOk({ config: { id: 'new-preset-id' } }));
 
       const mockContext = createMockContext();
 
       await handleImport(mockContext);
 
-      expect(userGatewayClient.callGatewayApi).toHaveBeenCalledWith(
-        '/user/llm-config',
+      expect(stub.createUserLlmConfig).toHaveBeenCalledWith(
         expect.objectContaining({
-          body: expect.objectContaining({
-            description: 'A description',
-            visionModel: 'anthropic/claude-sonnet-4',
-          }),
+          description: 'A description',
+          visionModel: 'anthropic/claude-sonnet-4',
         })
       );
     });
@@ -226,29 +224,22 @@ describe('Preset Import', () => {
           },
         }),
       });
-      vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: { id: 'new-preset-id' },
-      });
+      stub.createUserLlmConfig.mockResolvedValue(makeOk({ config: { id: 'new-preset-id' } }));
 
       const mockContext = createMockContext();
 
       await handleImport(mockContext);
 
       // Should make single API call with all fields including advancedParameters
-      expect(userGatewayClient.callGatewayApi).toHaveBeenCalledTimes(1);
-      expect(userGatewayClient.callGatewayApi).toHaveBeenCalledWith(
-        '/user/llm-config',
+      expect(stub.createUserLlmConfig).toHaveBeenCalledTimes(1);
+      expect(stub.createUserLlmConfig).toHaveBeenCalledWith(
         expect.objectContaining({
-          method: 'POST',
-          body: expect.objectContaining({
-            advancedParameters: expect.objectContaining({
-              temperature: 0.8,
-              max_tokens: 4096,
-              reasoning: expect.objectContaining({
-                effort: 'high',
-                enabled: true,
-              }),
+          advancedParameters: expect.objectContaining({
+            temperature: 0.8,
+            max_tokens: 4096,
+            reasoning: expect.objectContaining({
+              effort: 'high',
+              enabled: true,
             }),
           }),
         })
@@ -259,11 +250,7 @@ describe('Preset Import', () => {
       vi.mocked(jsonFileUtils.validateAndParseJsonFile).mockResolvedValue({
         data: createValidPresetData(),
       });
-      vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue({
-        ok: false as const,
-        error: 'Duplicate name',
-        status: 400,
-      });
+      stub.createUserLlmConfig.mockResolvedValue(makeErr(400, 'Duplicate name'));
 
       const mockContext = createMockContext();
 
@@ -280,21 +267,15 @@ describe('Preset Import', () => {
           contextWindowTokens: 65536,
         }),
       });
-      vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: { id: 'new-preset-id' },
-      });
+      stub.createUserLlmConfig.mockResolvedValue(makeOk({ config: { id: 'new-preset-id' } }));
 
       const mockContext = createMockContext();
 
       await handleImport(mockContext);
 
-      expect(userGatewayClient.callGatewayApi).toHaveBeenCalledWith(
-        '/user/llm-config',
+      expect(stub.createUserLlmConfig).toHaveBeenCalledWith(
         expect.objectContaining({
-          body: expect.objectContaining({
-            contextWindowTokens: 65536,
-          }),
+          contextWindowTokens: 65536,
         })
       );
     });

--- a/services/bot-client/src/commands/preset/import.ts
+++ b/services/bot-client/src/commands/preset/import.ts
@@ -6,7 +6,8 @@
 import { EmbedBuilder, escapeMarkdown } from 'discord.js';
 import { createLogger, DISCORD_COLORS, presetImportOptions } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import { callGatewayApi, toGatewayUser, type GatewayUser } from '../../utils/userGatewayClient.js';
+import type { UserClient } from '@tzurot/common-types';
+import { clientsFor } from '../../utils/gatewayClients.js';
 import { validateAndParseJsonFile } from '../../utils/jsonFileUtils.js';
 import {
   getImportedFieldsList,
@@ -173,30 +174,26 @@ function buildImportPayload(data: ImportedPresetData): Record<string, unknown> {
  * Create preset via API
  */
 async function createPresetFromImport(
-  user: GatewayUser,
+  userClient: UserClient,
   payload: Record<string, unknown>
 ): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
   // Create preset with all fields - API supports all fields in create endpoint
-  const createResult = await callGatewayApi<{ id: string }>('/user/llm-config', {
-    user,
-    method: 'POST',
-    body: {
-      name: payload.name,
-      model: payload.model,
-      provider: payload.provider,
-      description: payload.description,
-      visionModel: payload.visionModel,
-      contextWindowTokens: payload.contextWindowTokens,
-      advancedParameters: payload.advancedParameters,
-    },
-  });
+  const createResult = await userClient.createUserLlmConfig({
+    name: payload.name,
+    model: payload.model,
+    provider: payload.provider,
+    description: payload.description,
+    visionModel: payload.visionModel,
+    contextWindowTokens: payload.contextWindowTokens,
+    advancedParameters: payload.advancedParameters,
+  } as Parameters<UserClient['createUserLlmConfig']>[0]);
 
   if (!createResult.ok) {
     logger.error({ error: createResult.error }, 'Failed to create preset');
     return { ok: false, error: createResult.error };
   }
 
-  return { ok: true, id: createResult.data.id };
+  return { ok: true, id: createResult.data.config.id };
 }
 
 /**
@@ -248,7 +245,8 @@ export async function handleImport(context: DeferredCommandContext): Promise<voi
     const payload = buildImportPayload(parseResult.data);
 
     // Step 4: Create preset
-    const createResult = await createPresetFromImport(toGatewayUser(context.user), payload);
+    const { userClient } = clientsFor(context.interaction);
+    const createResult = await createPresetFromImport(userClient, payload);
     if (!createResult.ok) {
       await context.editReply(
         `❌ Failed to import preset:\n\`\`\`\n${createResult.error.slice(0, 1500)}\n\`\`\``

--- a/services/bot-client/src/commands/preset/types.ts
+++ b/services/bot-client/src/commands/preset/types.ts
@@ -9,14 +9,6 @@ import type { EntityPermissions } from '@tzurot/common-types';
 import type { BrowseContext } from '../../utils/dashboard/types.js';
 
 /**
- * API response wrapper for single preset endpoint
- * Used by GET /user/llm-config/:id
- */
-export interface PresetResponse {
-  config: PresetData;
-}
-
-/**
  * Preset data structure returned by API
  * Includes all LLM configuration params from advancedParameters
  */

--- a/services/bot-client/src/commands/settings/apikey/browse.test.ts
+++ b/services/bot-client/src/commands/settings/apikey/browse.test.ts
@@ -7,6 +7,8 @@ import type { ChatInputCommandInteraction } from 'discord.js';
 import { handleBrowse } from './browse.js';
 import { mockListWalletKeysResponse, AIProvider } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
+import { makeOk, makeErr } from '../../../test/gatewayClientStubs.js';
+import type { UserClient } from '@tzurot/common-types';
 
 // Mock common-types
 vi.mock('@tzurot/common-types', async importOriginal => {
@@ -22,19 +24,13 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
-// Mock userGatewayClient
-// Note: Tests use objectContaining for API call assertions to focus on the essential
-// userId parameter while ignoring implementation details like timeout values.
-const mockCallGatewayApi = vi.fn();
-vi.mock('../../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
-    '../../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  };
-});
+const stub = {
+  listWalletKeys: vi.fn(),
+};
+
+vi.mock('../../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
+}));
 
 // Mock providers
 vi.mock('../../../utils/providers.js', () => ({
@@ -80,27 +76,23 @@ describe('handleBrowse', () => {
   }
 
   it('should browse keys successfully', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: mockListWalletKeysResponse([
-        {
-          provider: AIProvider.OpenRouter,
-          isActive: true,
-          createdAt: '2025-01-01T00:00:00Z',
-          lastUsedAt: '2025-01-15T12:00:00Z',
-        },
-      ]),
-    });
+    stub.listWalletKeys.mockResolvedValue(
+      makeOk(
+        mockListWalletKeysResponse([
+          {
+            provider: AIProvider.OpenRouter,
+            isActive: true,
+            createdAt: '2025-01-01T00:00:00Z',
+            lastUsedAt: '2025-01-15T12:00:00Z',
+          },
+        ])
+      )
+    );
 
     const context = createMockContext();
     await handleBrowse(context);
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith(
-      '/wallet/list',
-      expect.objectContaining({
-        user: { discordId: '123456789', username: 'testuser', displayName: 'testuser' },
-      })
-    );
+    expect(stub.listWalletKeys).toHaveBeenCalled();
     expect(mockEditReply).toHaveBeenCalledWith({
       embeds: [
         expect.objectContaining({
@@ -113,10 +105,7 @@ describe('handleBrowse', () => {
   });
 
   it('should show empty state when no keys configured', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: mockListWalletKeysResponse([]),
-    });
+    stub.listWalletKeys.mockResolvedValue(makeOk(mockListWalletKeysResponse([])));
 
     const context = createMockContext();
     await handleBrowse(context);
@@ -134,11 +123,7 @@ describe('handleBrowse', () => {
   });
 
   it('should handle API error', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: false,
-      status: 500,
-      error: 'Server error',
-    });
+    stub.listWalletKeys.mockResolvedValue(makeErr(500, 'Server error'));
 
     const context = createMockContext();
     await handleBrowse(context);
@@ -149,8 +134,7 @@ describe('handleBrowse', () => {
   });
 
   it('should handle exceptions', async () => {
-    const error = new Error('Network error');
-    mockCallGatewayApi.mockRejectedValue(error);
+    stub.listWalletKeys.mockRejectedValue(new Error('Network error'));
 
     const context = createMockContext();
     await handleBrowse(context);
@@ -161,17 +145,18 @@ describe('handleBrowse', () => {
   });
 
   it('should show active badge for active keys', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: mockListWalletKeysResponse([
-        {
-          provider: AIProvider.OpenRouter,
-          isActive: true,
-          createdAt: '2025-01-01T00:00:00Z',
-          lastUsedAt: '2025-01-15T12:00:00Z',
-        },
-      ]),
-    });
+    stub.listWalletKeys.mockResolvedValue(
+      makeOk(
+        mockListWalletKeysResponse([
+          {
+            provider: AIProvider.OpenRouter,
+            isActive: true,
+            createdAt: '2025-01-01T00:00:00Z',
+            lastUsedAt: '2025-01-15T12:00:00Z',
+          },
+        ])
+      )
+    );
 
     const context = createMockContext();
     await handleBrowse(context);

--- a/services/bot-client/src/commands/settings/apikey/browse.ts
+++ b/services/bot-client/src/commands/settings/apikey/browse.ts
@@ -17,15 +17,10 @@ import {
   createLogger,
   DISCORD_COLORS,
   AUTOCOMPLETE_BADGES,
-  type ListWalletKeysResponse,
   type WalletKey,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import {
-  callGatewayApi,
-  GATEWAY_TIMEOUTS,
-  toGatewayUser,
-} from '../../../utils/userGatewayClient.js';
+import { clientsFor } from '../../../utils/gatewayClients.js';
 import { getProviderDisplayName } from '../../../utils/providers.js';
 
 const logger = createLogger('settings-apikey-browse');
@@ -103,10 +98,8 @@ export async function handleBrowse(context: DeferredCommandContext): Promise<voi
   const userId = context.user.id;
 
   try {
-    const result = await callGatewayApi<ListWalletKeysResponse>('/wallet/list', {
-      user: toGatewayUser(context.user),
-      timeout: GATEWAY_TIMEOUTS.DEFERRED,
-    });
+    const { userClient } = clientsFor(context.interaction);
+    const result = await userClient.listWalletKeys();
 
     if (!result.ok) {
       await context.editReply({ content: `❌ Failed to retrieve wallet info: ${result.error}` });

--- a/services/bot-client/src/commands/settings/apikey/modal.test.ts
+++ b/services/bot-client/src/commands/settings/apikey/modal.test.ts
@@ -5,6 +5,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MessageFlags } from 'discord.js';
 import { handleApikeyModalSubmit } from './modal.js';
+import { makeOk, makeErr } from '../../../test/gatewayClientStubs.js';
+import type { UserClient } from '@tzurot/common-types';
 
 // Mock common-types
 vi.mock('@tzurot/common-types', async importOriginal => {
@@ -23,6 +25,14 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
+const stub = {
+  setWalletKey: vi.fn(),
+};
+
+vi.mock('../../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
+}));
+
 // Mock providers utility
 vi.mock('../../../utils/providers.js', () => ({
   getProviderDisplayName: (provider: string) => {
@@ -31,10 +41,6 @@ vi.mock('../../../utils/providers.js', () => ({
   },
 }));
 
-// Mock global fetch
-const mockFetch = vi.fn();
-global.fetch = mockFetch;
-
 describe('handleApikeyModalSubmit', () => {
   const mockReply = vi.fn();
   const mockDeferReply = vi.fn();
@@ -42,6 +48,7 @@ describe('handleApikeyModalSubmit', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    stub.setWalletKey.mockReset();
   });
 
   function createMockInteraction(customId: string, apiKey: string = 'sk-or-valid-key') {
@@ -118,7 +125,7 @@ describe('handleApikeyModalSubmit', () => {
       // z.ai keys have no documented strict prefix, so the client-side
       // validateKeyFormat returns null. Validation happens server-side via
       // the chat-completions probe in api-gateway.
-      mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+      stub.setWalletKey.mockResolvedValue(makeOk({ success: true }));
 
       const interaction = createMockInteraction(
         'settings::apikey::set::zai-coding',
@@ -128,25 +135,16 @@ describe('handleApikeyModalSubmit', () => {
 
       // Should NOT show a client-side format error — request flows through to gateway
       expect(mockEditReply).not.toHaveBeenCalledWith(expect.stringContaining('Invalid'));
-      expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:3000/wallet/set',
-        expect.objectContaining({
-          method: 'POST',
-          body: JSON.stringify({
-            provider: 'zai-coding',
-            apiKey: 'arbitrary-zai-key-format',
-          }),
-        })
-      );
+      expect(stub.setWalletKey).toHaveBeenCalledWith({
+        provider: 'zai-coding',
+        apiKey: 'arbitrary-zai-key-format',
+      });
     });
   });
 
   describe('Gateway API interaction', () => {
     it('should send valid key to gateway', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({}),
-      });
+      stub.setWalletKey.mockResolvedValue(makeOk({ success: true }));
 
       const interaction = createMockInteraction(
         'settings::apikey::set::openrouter',
@@ -154,23 +152,14 @@ describe('handleApikeyModalSubmit', () => {
       );
       await handleApikeyModalSubmit(interaction);
 
-      expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:3000/wallet/set',
-        expect.objectContaining({
-          method: 'POST',
-          body: JSON.stringify({
-            provider: 'openrouter',
-            apiKey: 'sk-or-valid-key-here',
-          }),
-        })
-      );
+      expect(stub.setWalletKey).toHaveBeenCalledWith({
+        provider: 'openrouter',
+        apiKey: 'sk-or-valid-key-here',
+      });
     });
 
     it('should trim whitespace from API key before sending', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({}),
-      });
+      stub.setWalletKey.mockResolvedValue(makeOk({ success: true }));
 
       const interaction = createMockInteraction(
         'settings::apikey::set::openrouter',
@@ -178,22 +167,14 @@ describe('handleApikeyModalSubmit', () => {
       );
       await handleApikeyModalSubmit(interaction);
 
-      expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:3000/wallet/set',
-        expect.objectContaining({
-          body: JSON.stringify({
-            provider: 'openrouter',
-            apiKey: 'sk-or-valid-key-here',
-          }),
-        })
-      );
+      expect(stub.setWalletKey).toHaveBeenCalledWith({
+        provider: 'openrouter',
+        apiKey: 'sk-or-valid-key-here',
+      });
     });
 
     it('should handle successful key storage', async () => {
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({}),
-      });
+      stub.setWalletKey.mockResolvedValue(makeOk({ success: true }));
 
       const interaction = createMockInteraction(
         'settings::apikey::set::openrouter',
@@ -213,11 +194,7 @@ describe('handleApikeyModalSubmit', () => {
     });
 
     it('should handle 401 invalid key error', async () => {
-      mockFetch.mockResolvedValue({
-        ok: false,
-        status: 401,
-        json: () => Promise.resolve({ error: 'Invalid API key' }),
-      });
+      stub.setWalletKey.mockResolvedValue(makeErr(401, 'Invalid API key'));
 
       const interaction = createMockInteraction(
         'settings::apikey::set::openrouter',
@@ -229,11 +206,7 @@ describe('handleApikeyModalSubmit', () => {
     });
 
     it('should handle 402 insufficient credits error', async () => {
-      mockFetch.mockResolvedValue({
-        ok: false,
-        status: 402,
-        json: () => Promise.resolve({ error: 'Insufficient credits' }),
-      });
+      stub.setWalletKey.mockResolvedValue(makeErr(402, 'Insufficient credits'));
 
       const interaction = createMockInteraction(
         'settings::apikey::set::openrouter',
@@ -245,11 +218,7 @@ describe('handleApikeyModalSubmit', () => {
     });
 
     it('should handle generic gateway error', async () => {
-      mockFetch.mockResolvedValue({
-        ok: false,
-        status: 500,
-        json: () => Promise.resolve({ error: 'Internal error' }),
-      });
+      stub.setWalletKey.mockResolvedValue(makeErr(500, 'Internal error'));
 
       const interaction = createMockInteraction(
         'settings::apikey::set::openrouter',
@@ -261,7 +230,7 @@ describe('handleApikeyModalSubmit', () => {
     });
 
     it('should handle network errors', async () => {
-      mockFetch.mockRejectedValue(new Error('Network error'));
+      stub.setWalletKey.mockRejectedValue(new Error('Network error'));
 
       const interaction = createMockInteraction(
         'settings::apikey::set::openrouter',
@@ -273,15 +242,9 @@ describe('handleApikeyModalSubmit', () => {
     });
 
     it('should show descriptive error for missing permissions (400)', async () => {
-      mockFetch.mockResolvedValue({
-        ok: false,
-        status: 400,
-        json: () =>
-          Promise.resolve({
-            error: 'VALIDATION_ERROR',
-            message: 'Your ElevenLabs API key is valid but missing required permissions.',
-          }),
-      });
+      stub.setWalletKey.mockResolvedValue(
+        makeErr(400, 'Your ElevenLabs API key is valid but missing required permissions.')
+      );
 
       const interaction = createMockInteraction(
         'settings::apikey::set::elevenlabs',

--- a/services/bot-client/src/commands/settings/apikey/modal.ts
+++ b/services/bot-client/src/commands/settings/apikey/modal.ts
@@ -13,7 +13,7 @@ import type { ModalSubmitInteraction } from 'discord.js';
 import { MessageFlags, EmbedBuilder } from 'discord.js';
 import { createLogger, DISCORD_COLORS, AIProvider, API_KEY_FORMATS } from '@tzurot/common-types';
 import { getProviderDisplayName } from '../../../utils/providers.js';
-import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
+import { clientsFor } from '../../../utils/gatewayClients.js';
 import { ApikeyCustomIds } from '../../../utils/customIds.js';
 
 const logger = createLogger('settings-apikey-modal');
@@ -72,11 +72,8 @@ async function handleSetKeySubmit(
 
   try {
     // Send to api-gateway for validation and storage
-    const result = await callGatewayApi<{ success: boolean }>('/wallet/set', {
-      method: 'POST',
-      user: toGatewayUser(interaction.user),
-      body: { provider, apiKey },
-    });
+    const { userClient } = clientsFor(interaction);
+    const result = await userClient.setWalletKey({ provider, apiKey });
 
     if (!result.ok) {
       logger.error(

--- a/services/bot-client/src/commands/settings/apikey/remove.test.ts
+++ b/services/bot-client/src/commands/settings/apikey/remove.test.ts
@@ -7,6 +7,8 @@ import type { ChatInputCommandInteraction } from 'discord.js';
 import { handleRemoveKey } from './remove.js';
 import { mockRemoveWalletKeyResponse, AIProvider } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
+import { makeOk, makeErr } from '../../../test/gatewayClientStubs.js';
+import type { UserClient } from '@tzurot/common-types';
 
 // Mock common-types
 vi.mock('@tzurot/common-types', async importOriginal => {
@@ -22,17 +24,13 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
-// Mock userGatewayClient
-const mockCallGatewayApi = vi.fn();
-vi.mock('../../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
-    '../../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  };
-});
+const stub = {
+  removeWalletKey: vi.fn(),
+};
+
+vi.mock('../../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
+}));
 
 // Mock providers
 vi.mock('../../../utils/providers.js', () => ({
@@ -49,6 +47,7 @@ describe('handleRemoveKey', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    stub.removeWalletKey.mockReset();
   });
 
   function createMockContext(provider: string = 'openrouter'): DeferredCommandContext {
@@ -84,24 +83,14 @@ describe('handleRemoveKey', () => {
   }
 
   it('should remove key successfully', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: mockRemoveWalletKeyResponse({
-        provider: AIProvider.OpenRouter,
-      }),
-    });
+    stub.removeWalletKey.mockResolvedValue(
+      makeOk(mockRemoveWalletKeyResponse({ provider: AIProvider.OpenRouter }))
+    );
 
     const context = createMockContext('openrouter');
     await handleRemoveKey(context);
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith('/wallet/openrouter', {
-      method: 'DELETE',
-      user: {
-        discordId: '123456789',
-        username: 'testuser',
-        displayName: 'testuser',
-      },
-    });
+    expect(stub.removeWalletKey).toHaveBeenCalledWith('openrouter');
     expect(mockEditReply).toHaveBeenCalledWith({
       embeds: [
         expect.objectContaining({
@@ -115,11 +104,7 @@ describe('handleRemoveKey', () => {
   });
 
   it('should handle 404 key not found', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: false,
-      status: 404,
-      error: 'Not found',
-    });
+    stub.removeWalletKey.mockResolvedValue(makeErr(404, 'Not found'));
 
     const context = createMockContext('openrouter');
     await handleRemoveKey(context);
@@ -130,11 +115,7 @@ describe('handleRemoveKey', () => {
   });
 
   it('should handle generic API error', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: false,
-      status: 500,
-      error: 'Internal error',
-    });
+    stub.removeWalletKey.mockResolvedValue(makeErr(500, 'Internal error'));
 
     const context = createMockContext('openrouter');
     await handleRemoveKey(context);
@@ -145,8 +126,7 @@ describe('handleRemoveKey', () => {
   });
 
   it('should handle exceptions', async () => {
-    const error = new Error('Network error');
-    mockCallGatewayApi.mockRejectedValue(error);
+    stub.removeWalletKey.mockRejectedValue(new Error('Network error'));
 
     const context = createMockContext();
     await handleRemoveKey(context);

--- a/services/bot-client/src/commands/settings/apikey/remove.ts
+++ b/services/bot-client/src/commands/settings/apikey/remove.ts
@@ -15,7 +15,7 @@ import {
   settingsApikeyRemoveOptions,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
+import { clientsFor } from '../../../utils/gatewayClients.js';
 import { getProviderDisplayName } from '../../../utils/providers.js';
 
 const logger = createLogger('settings-apikey-remove');
@@ -33,10 +33,8 @@ export async function handleRemoveKey(context: DeferredCommandContext): Promise<
   const provider = options.provider() as AIProvider;
 
   try {
-    const result = await callGatewayApi<void>(`/wallet/${encodeURIComponent(provider)}`, {
-      method: 'DELETE',
-      user: toGatewayUser(context.user),
-    });
+    const { userClient } = clientsFor(context.interaction);
+    const result = await userClient.removeWalletKey(provider);
 
     if (!result.ok) {
       if (result.status === 404) {

--- a/services/bot-client/src/commands/settings/apikey/test.test.ts
+++ b/services/bot-client/src/commands/settings/apikey/test.test.ts
@@ -7,6 +7,8 @@ import type { ChatInputCommandInteraction } from 'discord.js';
 import { handleTestKey } from './test.js';
 import { mockTestWalletKeyResponse, AIProvider } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
+import { makeOk, makeErr } from '../../../test/gatewayClientStubs.js';
+import type { UserClient } from '@tzurot/common-types';
 
 // Mock common-types
 vi.mock('@tzurot/common-types', async importOriginal => {
@@ -22,17 +24,13 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
-// Mock userGatewayClient
-const mockCallGatewayApi = vi.fn();
-vi.mock('../../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
-    '../../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  };
-});
+const stub = {
+  testWalletKey: vi.fn(),
+};
+
+vi.mock('../../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
+}));
 
 // Mock providers
 vi.mock('../../../utils/providers.js', () => ({
@@ -49,6 +47,7 @@ describe('handleTestKey', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    stub.testWalletKey.mockReset();
   });
 
   function createMockContext(provider: string = 'openrouter'): DeferredCommandContext {
@@ -84,27 +83,20 @@ describe('handleTestKey', () => {
   }
 
   it('should test key successfully with credits', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: mockTestWalletKeyResponse({
-        valid: true,
-        provider: AIProvider.OpenRouter,
-        credits: 12.5,
-      }),
-    });
+    stub.testWalletKey.mockResolvedValue(
+      makeOk(
+        mockTestWalletKeyResponse({
+          valid: true,
+          provider: AIProvider.OpenRouter,
+          credits: 12.5,
+        })
+      )
+    );
 
     const context = createMockContext('openrouter');
     await handleTestKey(context);
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith('/wallet/test', {
-      method: 'POST',
-      user: {
-        discordId: '123456789',
-        username: 'testuser',
-        displayName: 'testuser',
-      },
-      body: { provider: 'openrouter' },
-    });
+    expect(stub.testWalletKey).toHaveBeenCalledWith({ provider: 'openrouter' });
     expect(mockEditReply).toHaveBeenCalledWith({
       embeds: [
         expect.objectContaining({
@@ -118,13 +110,14 @@ describe('handleTestKey', () => {
   });
 
   it('should test key successfully without credits info', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: mockTestWalletKeyResponse({
-        valid: true,
-        provider: AIProvider.OpenRouter,
-      }),
-    });
+    stub.testWalletKey.mockResolvedValue(
+      makeOk(
+        mockTestWalletKeyResponse({
+          valid: true,
+          provider: AIProvider.OpenRouter,
+        })
+      )
+    );
 
     const context = createMockContext('openrouter');
     await handleTestKey(context);
@@ -141,11 +134,7 @@ describe('handleTestKey', () => {
   });
 
   it('should handle 404 key not found', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: false,
-      status: 404,
-      error: 'Not found',
-    });
+    stub.testWalletKey.mockResolvedValue(makeErr(404, 'Not found'));
 
     const context = createMockContext('openrouter');
     await handleTestKey(context);
@@ -156,11 +145,7 @@ describe('handleTestKey', () => {
   });
 
   it('should handle validation failure', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: false,
-      status: 401,
-      error: 'Invalid API key',
-    });
+    stub.testWalletKey.mockResolvedValue(makeErr(401, 'Invalid API key'));
 
     const context = createMockContext('openrouter');
     await handleTestKey(context);
@@ -177,8 +162,7 @@ describe('handleTestKey', () => {
   });
 
   it('should handle exceptions', async () => {
-    const error = new Error('Network error');
-    mockCallGatewayApi.mockRejectedValue(error);
+    stub.testWalletKey.mockRejectedValue(new Error('Network error'));
 
     const context = createMockContext();
     await handleTestKey(context);

--- a/services/bot-client/src/commands/settings/apikey/test.ts
+++ b/services/bot-client/src/commands/settings/apikey/test.ts
@@ -15,18 +15,10 @@ import {
   settingsApikeyTestOptions,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
+import { clientsFor } from '../../../utils/gatewayClients.js';
 import { getProviderDisplayName } from '../../../utils/providers.js';
 
 const logger = createLogger('settings-apikey-test');
-
-interface WalletTestResponse {
-  valid: boolean;
-  provider: AIProvider;
-  credits?: number;
-  error?: string;
-  errorCode?: string;
-}
 
 /**
  * Handle /wallet test <provider> subcommand
@@ -41,11 +33,8 @@ export async function handleTestKey(context: DeferredCommandContext): Promise<vo
   const provider = options.provider() as AIProvider;
 
   try {
-    const result = await callGatewayApi<WalletTestResponse>('/wallet/test', {
-      method: 'POST',
-      user: toGatewayUser(context.user),
-      body: { provider },
-    });
+    const { userClient } = clientsFor(context.interaction);
+    const result = await userClient.testWalletKey({ provider });
 
     if (!result.ok) {
       if (result.status === 404) {

--- a/services/bot-client/src/commands/settings/defaults/edit.test.ts
+++ b/services/bot-client/src/commands/settings/defaults/edit.test.ts
@@ -32,16 +32,16 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
-const mockCallGatewayApi = vi.fn();
-vi.mock('../../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
-    '../../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  };
-});
+const stub = {
+  resolveUserDefaults: vi.fn(),
+  updateUserDefaults: vi.fn(),
+};
+
+vi.mock('../../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({
+    userClient: stub as unknown as import('@tzurot/common-types').UserClient,
+  })),
+}));
 
 // Mock the session manager
 const mockSessionManager = {
@@ -172,22 +172,11 @@ describe('User Default Settings Dashboard', () => {
   describe('handleDefaultsEdit', () => {
     it('should display settings dashboard embed', async () => {
       const context = createMockContext();
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: mockResolveDefaultsResponse,
-      });
+      stub.resolveUserDefaults.mockResolvedValue({ ok: true, data: mockResolveDefaultsResponse });
 
       await handleDefaultsEdit(context);
 
-      expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/config-overrides/resolve-defaults', {
-        method: 'GET',
-        user: {
-          discordId: 'user-456',
-          username: 'testuser',
-          displayName: 'testuser',
-        },
-        timeout: 10000,
-      });
+      expect(stub.resolveUserDefaults).toHaveBeenCalled();
       expect(context.editReply).toHaveBeenCalledWith(
         expect.objectContaining({
           embeds: expect.any(Array),
@@ -198,10 +187,7 @@ describe('User Default Settings Dashboard', () => {
 
     it('should include "Your Default Settings" title in embed', async () => {
       const context = createMockContext();
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: mockResolveDefaultsResponse,
-      });
+      stub.resolveUserDefaults.mockResolvedValue({ ok: true, data: mockResolveDefaultsResponse });
 
       await handleDefaultsEdit(context);
 
@@ -214,10 +200,7 @@ describe('User Default Settings Dashboard', () => {
 
     it('should include all 10 settings fields', async () => {
       const context = createMockContext();
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: mockResolveDefaultsResponse,
-      });
+      stub.resolveUserDefaults.mockResolvedValue({ ok: true, data: mockResolveDefaultsResponse });
 
       await handleDefaultsEdit(context);
 
@@ -243,10 +226,7 @@ describe('User Default Settings Dashboard', () => {
 
     it('should include select menu and close button', async () => {
       const context = createMockContext();
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: mockResolveDefaultsResponse,
-      });
+      stub.resolveUserDefaults.mockResolvedValue({ ok: true, data: mockResolveDefaultsResponse });
 
       await handleDefaultsEdit(context);
 
@@ -256,10 +236,7 @@ describe('User Default Settings Dashboard', () => {
 
     it('should display description note about defaults', async () => {
       const context = createMockContext();
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: mockResolveDefaultsResponse,
-      });
+      stub.resolveUserDefaults.mockResolvedValue({ ok: true, data: mockResolveDefaultsResponse });
 
       await handleDefaultsEdit(context);
 
@@ -272,11 +249,7 @@ describe('User Default Settings Dashboard', () => {
 
     it('should handle API failure with fallback data', async () => {
       const context = createMockContext();
-      mockCallGatewayApi.mockResolvedValue({
-        ok: false,
-        error: 'Server error',
-        status: 500,
-      });
+      stub.resolveUserDefaults.mockResolvedValue({ ok: false, error: 'Server error', status: 500 });
 
       await handleDefaultsEdit(context);
 
@@ -291,7 +264,7 @@ describe('User Default Settings Dashboard', () => {
 
     it('should handle unexpected errors gracefully', async () => {
       const context = createMockContext();
-      mockCallGatewayApi.mockRejectedValue(new Error('Network error'));
+      stub.resolveUserDefaults.mockRejectedValue(new Error('Network error'));
 
       await handleDefaultsEdit(context);
 
@@ -306,7 +279,7 @@ describe('User Default Settings Dashboard', () => {
         get: () => true,
         configurable: true,
       });
-      mockCallGatewayApi.mockRejectedValue(new Error('Network error'));
+      stub.resolveUserDefaults.mockRejectedValue(new Error('Network error'));
 
       await handleDefaultsEdit(context);
 
@@ -315,7 +288,7 @@ describe('User Default Settings Dashboard', () => {
 
     it('should correctly map user overrides to localValue', async () => {
       const context = createMockContext();
-      mockCallGatewayApi.mockResolvedValue({
+      stub.resolveUserDefaults.mockResolvedValue({
         ok: true,
         data: {
           ...mockResolveDefaultsResponse,
@@ -392,11 +365,7 @@ describe('User Default Settings Dashboard', () => {
         },
       });
 
-      mockCallGatewayApi.mockResolvedValue({
-        ok: false,
-        error: 'Server error',
-        status: 500,
-      });
+      stub.updateUserDefaults.mockResolvedValue({ ok: false, error: 'Server error', status: 500 });
 
       await handleUserDefaultsButton(interaction as unknown as ButtonInteraction);
 
@@ -500,22 +469,18 @@ describe('User Default Settings Dashboard', () => {
       );
 
       mockSessionManager.get.mockReturnValue(createSessionWithSetting('maxMessages'));
-      mockCallGatewayApi
-        .mockResolvedValueOnce({ ok: true, data: { configDefaults: { maxMessages: 30 } } })
-        .mockResolvedValueOnce({ ok: true, data: mockResolveDefaultsResponse });
+      stub.updateUserDefaults.mockResolvedValueOnce({
+        ok: true,
+        data: { configDefaults: { maxMessages: 30 } },
+      });
+      stub.resolveUserDefaults.mockResolvedValueOnce({
+        ok: true,
+        data: mockResolveDefaultsResponse,
+      });
 
       await handleUserDefaultsModal(interaction as never);
 
-      expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/config-overrides/defaults', {
-        method: 'PATCH',
-        body: { maxMessages: 30 },
-        user: {
-          discordId: 'user-456',
-          username: 'testuser',
-          displayName: 'testuser',
-        },
-        timeout: 10000,
-      });
+      expect(stub.updateUserDefaults).toHaveBeenCalledWith({ maxMessages: 30 });
     });
 
     it('should update maxAge setting with duration string', async () => {
@@ -525,22 +490,18 @@ describe('User Default Settings Dashboard', () => {
       );
 
       mockSessionManager.get.mockReturnValue(createSessionWithSetting('maxAge'));
-      mockCallGatewayApi
-        .mockResolvedValueOnce({ ok: true, data: { configDefaults: { maxAge: 7200 } } })
-        .mockResolvedValueOnce({ ok: true, data: mockResolveDefaultsResponse });
+      stub.updateUserDefaults.mockResolvedValueOnce({
+        ok: true,
+        data: { configDefaults: { maxAge: 7200 } },
+      });
+      stub.resolveUserDefaults.mockResolvedValueOnce({
+        ok: true,
+        data: mockResolveDefaultsResponse,
+      });
 
       await handleUserDefaultsModal(interaction as never);
 
-      expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/config-overrides/defaults', {
-        method: 'PATCH',
-        body: { maxAge: 7200 },
-        user: {
-          discordId: 'user-456',
-          username: 'testuser',
-          displayName: 'testuser',
-        },
-        timeout: 10000,
-      });
+      expect(stub.updateUserDefaults).toHaveBeenCalledWith({ maxAge: 7200 });
     });
 
     it('should clear override when set to "auto"', async () => {
@@ -550,22 +511,15 @@ describe('User Default Settings Dashboard', () => {
       );
 
       mockSessionManager.get.mockReturnValue(createSessionWithSetting('maxMessages'));
-      mockCallGatewayApi
-        .mockResolvedValueOnce({ ok: true, data: { configDefaults: null } })
-        .mockResolvedValueOnce({ ok: true, data: mockResolveDefaultsResponse });
+      stub.updateUserDefaults.mockResolvedValueOnce({ ok: true, data: { configDefaults: null } });
+      stub.resolveUserDefaults.mockResolvedValueOnce({
+        ok: true,
+        data: mockResolveDefaultsResponse,
+      });
 
       await handleUserDefaultsModal(interaction as never);
 
-      expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/config-overrides/defaults', {
-        method: 'PATCH',
-        body: { maxMessages: null },
-        user: {
-          discordId: 'user-456',
-          username: 'testuser',
-          displayName: 'testuser',
-        },
-        timeout: 10000,
-      });
+      expect(stub.updateUserDefaults).toHaveBeenCalledWith({ maxMessages: null });
     });
 
     it('should handle network error gracefully', async () => {
@@ -575,12 +529,12 @@ describe('User Default Settings Dashboard', () => {
       );
 
       mockSessionManager.get.mockReturnValue(createSessionWithSetting('maxMessages'));
-      mockCallGatewayApi.mockRejectedValue(new Error('Network error'));
+      stub.updateUserDefaults.mockRejectedValue(new Error('Network error'));
 
       // Should not throw
       await handleUserDefaultsModal(interaction as never);
 
-      expect(mockCallGatewayApi).toHaveBeenCalled();
+      expect(stub.updateUserDefaults).toHaveBeenCalled();
       expect(interaction.editReply).not.toHaveBeenCalled();
     });
   });

--- a/services/bot-client/src/commands/settings/defaults/edit.ts
+++ b/services/bot-client/src/commands/settings/defaults/edit.ts
@@ -18,18 +18,13 @@ import type {
   ModalSubmitInteraction,
 } from 'discord.js';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import { createLogger, DISCORD_COLORS, GATEWAY_TIMEOUTS } from '@tzurot/common-types';
-import {
-  callGatewayApi,
-  toGatewayUser,
-  type GatewayUser,
-} from '../../../utils/userGatewayClient.js';
+import { createLogger, DISCORD_COLORS, type UserClient } from '@tzurot/common-types';
+import { clientsFor } from '../../../utils/gatewayClients.js';
 import {
   type SettingsDashboardConfig,
   type SettingsDashboardSession,
   type SettingUpdateResult,
   type SettingsData,
-  type ResolveDefaultsResponse,
   createSettingsDashboard,
   handleSettingsSelectMenu,
   handleSettingsButton,
@@ -80,7 +75,8 @@ export async function handleDefaultsEdit(context: DeferredCommandContext): Promi
   logger.debug({ userId }, 'Opening dashboard');
 
   try {
-    const data = await fetchAndConvertSettingsData(toGatewayUser(context.user));
+    const { userClient } = clientsFor(context.interaction);
+    const data = await fetchAndConvertSettingsData(userClient);
 
     await createSettingsDashboard(context.interaction, {
       config: USER_DEFAULTS_CONFIG,
@@ -148,11 +144,8 @@ export function isUserDefaultsInteraction(customId: string): boolean {
 /**
  * Fetch resolved config from API and convert to dashboard SettingsData format.
  */
-async function fetchAndConvertSettingsData(user: GatewayUser): Promise<SettingsData> {
-  const result = await callGatewayApi<ResolveDefaultsResponse>(
-    '/user/config-overrides/resolve-defaults',
-    { method: 'GET', user, timeout: GATEWAY_TIMEOUTS.DEFERRED }
-  );
+async function fetchAndConvertSettingsData(userClient: UserClient): Promise<SettingsData> {
+  const result = await userClient.resolveUserDefaults();
 
   if (!result.ok) {
     logger.warn({ error: result.error }, 'Failed to fetch resolve-defaults');
@@ -184,13 +177,8 @@ async function handleSettingUpdate(
       return { success: false, error: 'Unknown setting' };
     }
 
-    const user = toGatewayUser(interaction.user);
-    const result = await callGatewayApi('/user/config-overrides/defaults', {
-      method: 'PATCH',
-      body,
-      user,
-      timeout: GATEWAY_TIMEOUTS.DEFERRED,
-    });
+    const { userClient } = clientsFor(interaction);
+    const result = await userClient.updateUserDefaults(body);
 
     if (!result.ok) {
       logger.warn({ settingId, error: result.error }, 'Update failed');
@@ -198,7 +186,7 @@ async function handleSettingUpdate(
     }
 
     // Re-fetch resolved data to get updated effective values and sources
-    const newData = await fetchAndConvertSettingsData(user);
+    const newData = await fetchAndConvertSettingsData(userClient);
 
     logger.info({ settingId, newValue, userId }, 'Setting updated');
 

--- a/services/bot-client/src/commands/settings/preset/autocomplete.test.ts
+++ b/services/bot-client/src/commands/settings/preset/autocomplete.test.ts
@@ -21,30 +21,23 @@ vi.mock('@tzurot/common-types', async () => {
   };
 });
 
-// Mock the gateway client
-vi.mock('../../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
-    '../../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: vi.fn(),
-  };
-});
-
 // Mock the autocomplete cache
 const mockGetCachedPersonalities = vi.fn();
 vi.mock('../../../utils/autocomplete/autocompleteCache.js', () => ({
   getCachedPersonalities: (...args: unknown[]) => mockGetCachedPersonalities(...args),
 }));
 
-// Mock clientsFor — the cache mock returns ok directly, so a structurally
-// empty userClient stub suffices.
+const stub = {
+  listUserLlmConfigs: vi.fn(),
+  listWalletKeys: vi.fn(),
+};
+
 vi.mock('../../../utils/gatewayClients.js', () => ({
-  clientsFor: vi.fn(() => ({ userClient: {} })),
+  clientsFor: vi.fn(() => ({
+    userClient: stub as unknown as import('@tzurot/common-types').UserClient,
+  })),
 }));
 
-import { callGatewayApi } from '../../../utils/userGatewayClient.js';
 import { UNLOCK_MODELS_VALUE } from './autocomplete.js';
 import type { PersonalitySummary } from '@tzurot/common-types';
 
@@ -70,17 +63,10 @@ function mockConfigApis(
   configs: ReturnType<typeof mockLlmConfigSummary>[],
   hasActiveWallet: boolean
 ) {
-  vi.mocked(callGatewayApi).mockImplementation((path: string) => {
-    if (path === '/user/llm-config') {
-      return Promise.resolve({ ok: true, data: { configs } });
-    }
-    if (path === '/wallet/list') {
-      return Promise.resolve({
-        ok: true,
-        data: mockListWalletKeysResponse(hasActiveWallet ? [{ isActive: true }] : []),
-      });
-    }
-    return Promise.resolve({ ok: false, error: 'Unknown path', status: 404 });
+  stub.listUserLlmConfigs.mockResolvedValue({ ok: true, data: { configs } });
+  stub.listWalletKeys.mockResolvedValue({
+    ok: true,
+    data: mockListWalletKeysResponse(hasActiveWallet ? [{ isActive: true }] : []),
   });
 }
 
@@ -311,9 +297,7 @@ describe('handleAutocomplete', () => {
 
       await handleAutocomplete(mockInteraction);
 
-      expect(callGatewayApi).toHaveBeenCalledWith('/user/llm-config', {
-        user: { discordId: 'user-123', username: 'testuser', displayName: 'testuser' },
-      });
+      expect(stub.listUserLlmConfigs).toHaveBeenCalled();
       expect(mockInteraction.respond).toHaveBeenCalledWith([
         {
           name: '🌐⭐ Claude Config · claude-sonnet-4',
@@ -400,11 +384,8 @@ describe('handleAutocomplete', () => {
         name: 'preset',
         value: 'test',
       } as unknown as string);
-      vi.mocked(callGatewayApi).mockResolvedValue({
-        ok: false,
-        error: 'API error',
-        status: 500,
-      });
+      stub.listUserLlmConfigs.mockResolvedValue({ ok: false, error: 'API error', status: 500 });
+      stub.listWalletKeys.mockResolvedValue({ ok: true, data: { keys: [] } });
 
       await handleAutocomplete(mockInteraction);
 
@@ -525,37 +506,30 @@ describe('handleAutocomplete', () => {
         name: 'preset',
         value: '',
       } as unknown as string);
-      vi.mocked(callGatewayApi).mockImplementation((path: string) => {
-        if (path === '/user/llm-config') {
-          return Promise.resolve({
-            ok: true,
-            data: {
-              configs: [
-                mockLlmConfigSummary({
-                  id: '00000000-0000-4000-8000-0000000000c1',
-                  name: 'Claude Pro',
-                  model: 'anthropic/claude-sonnet-4',
-                  provider: 'openrouter',
-                  isGlobal: true,
-                  isOwned: false,
-                }),
-                mockLlmConfigSummary({
-                  id: '00000000-0000-4000-8000-0000000000c2',
-                  name: 'Grok Free',
-                  model: 'x-ai/grok-4.1-fast:free',
-                  provider: 'openrouter',
-                  isGlobal: true,
-                  isOwned: false,
-                }),
-              ],
-            },
-          });
-        }
-        if (path === '/wallet/list') {
-          return Promise.resolve({ ok: false, error: 'Gateway timeout', status: 504 });
-        }
-        return Promise.resolve({ ok: false, error: 'Unknown path', status: 404 });
+      stub.listUserLlmConfigs.mockResolvedValue({
+        ok: true,
+        data: {
+          configs: [
+            mockLlmConfigSummary({
+              id: '00000000-0000-4000-8000-0000000000c1',
+              name: 'Claude Pro',
+              model: 'anthropic/claude-sonnet-4',
+              provider: 'openrouter',
+              isGlobal: true,
+              isOwned: false,
+            }),
+            mockLlmConfigSummary({
+              id: '00000000-0000-4000-8000-0000000000c2',
+              name: 'Grok Free',
+              model: 'x-ai/grok-4.1-fast:free',
+              provider: 'openrouter',
+              isGlobal: true,
+              isOwned: false,
+            }),
+          ],
+        },
       });
+      stub.listWalletKeys.mockResolvedValue({ ok: false, error: 'Gateway timeout', status: 504 });
 
       await handleAutocomplete(mockInteraction);
 
@@ -618,7 +592,7 @@ describe('handleAutocomplete', () => {
         name: 'character',
         value: 'test',
       } as unknown as string);
-      vi.mocked(callGatewayApi).mockRejectedValue(new Error('Network error'));
+      mockGetCachedPersonalities.mockRejectedValue(new Error('Network error'));
 
       await handleAutocomplete(mockInteraction);
 

--- a/services/bot-client/src/commands/settings/preset/autocomplete.ts
+++ b/services/bot-client/src/commands/settings/preset/autocomplete.ts
@@ -10,11 +10,9 @@ import {
   isFreeModel,
   AUTOCOMPLETE_BADGES,
   formatAutocompleteOption,
-  type LlmConfigSummary,
-  type ListWalletKeysResponse,
   type AutocompleteBadge,
 } from '@tzurot/common-types';
-import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
+import { clientsFor } from '../../../utils/gatewayClients.js';
 import { handlePersonalityAutocomplete } from '../../../utils/autocomplete/index.js';
 
 /**
@@ -73,10 +71,10 @@ async function handlePresetAutocomplete(
   userId: string
 ): Promise<void> {
   // Fetch configs and wallet status in parallel
-  const user = toGatewayUser(interaction.user);
+  const { userClient } = clientsFor(interaction);
   const [configResult, walletResult] = await Promise.all([
-    callGatewayApi<{ configs: LlmConfigSummary[] }>('/user/llm-config', { user }),
-    callGatewayApi<ListWalletKeysResponse>('/wallet/list', { user }),
+    userClient.listUserLlmConfigs(),
+    userClient.listWalletKeys(),
   ]);
 
   if (!configResult.ok) {

--- a/services/bot-client/src/commands/settings/preset/clear-default.test.ts
+++ b/services/bot-client/src/commands/settings/preset/clear-default.test.ts
@@ -8,19 +8,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { handleClearDefault } from './clear-default.js';
 import { mockClearDefaultConfigResponse } from '@tzurot/common-types';
+import { makeOk, makeErr } from '../../../test/gatewayClientStubs.js';
+import type { UserClient } from '@tzurot/common-types';
 
-// Mock userGatewayClient
-vi.mock('../../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
-    '../../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: vi.fn(),
-  };
-});
+const stub = {
+  clearDefaultModelConfig: vi.fn(),
+};
 
-import { callGatewayApi } from '../../../utils/userGatewayClient.js';
+vi.mock('../../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
+}));
 
 // Mock logger
 vi.mock('@tzurot/common-types', async () => {
@@ -41,39 +38,28 @@ describe('handleClearDefault', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    stub.clearDefaultModelConfig.mockReset();
     mockEditReply.mockResolvedValue(undefined);
   });
 
   function createMockContext() {
     return {
       user: { id: '123456789', username: 'testuser' },
+      interaction: {} as never,
       editReply: mockEditReply,
     } as unknown as Parameters<typeof handleClearDefault>[0];
   }
 
-  it('should call gateway API with DELETE method', async () => {
-    vi.mocked(callGatewayApi).mockResolvedValue({
-      ok: true,
-      data: mockClearDefaultConfigResponse(),
-    });
+  it('should call clearDefaultModelConfig on the typed client', async () => {
+    stub.clearDefaultModelConfig.mockResolvedValue(makeOk(mockClearDefaultConfigResponse()));
 
     await handleClearDefault(createMockContext());
 
-    expect(callGatewayApi).toHaveBeenCalledWith('/user/model-override/default', {
-      method: 'DELETE',
-      user: {
-        discordId: '123456789',
-        username: 'testuser',
-        displayName: 'testuser',
-      },
-    });
+    expect(stub.clearDefaultModelConfig).toHaveBeenCalled();
   });
 
   it('should show success embed when config cleared', async () => {
-    vi.mocked(callGatewayApi).mockResolvedValue({
-      ok: true,
-      data: mockClearDefaultConfigResponse(),
-    });
+    stub.clearDefaultModelConfig.mockResolvedValue(makeOk(mockClearDefaultConfigResponse()));
 
     await handleClearDefault(createMockContext());
 
@@ -89,12 +75,13 @@ describe('handleClearDefault', () => {
   });
 
   it('should render the new effective default name when one exists', async () => {
-    vi.mocked(callGatewayApi).mockResolvedValue({
-      ok: true,
-      data: mockClearDefaultConfigResponse({
-        newEffectiveDefault: { id: 'free-id', name: 'gpt-4-free' },
-      }),
-    });
+    stub.clearDefaultModelConfig.mockResolvedValue(
+      makeOk(
+        mockClearDefaultConfigResponse({
+          newEffectiveDefault: { id: 'free-id', name: 'gpt-4-free' },
+        })
+      )
+    );
 
     await handleClearDefault(createMockContext());
 
@@ -110,10 +97,9 @@ describe('handleClearDefault', () => {
   });
 
   it('should render hardcoded-fallback notice when no system default is configured', async () => {
-    vi.mocked(callGatewayApi).mockResolvedValue({
-      ok: true,
-      data: mockClearDefaultConfigResponse({ newEffectiveDefault: null }),
-    });
+    stub.clearDefaultModelConfig.mockResolvedValue(
+      makeOk(mockClearDefaultConfigResponse({ newEffectiveDefault: null }))
+    );
 
     await handleClearDefault(createMockContext());
 
@@ -129,11 +115,7 @@ describe('handleClearDefault', () => {
   });
 
   it('should show error when API fails', async () => {
-    vi.mocked(callGatewayApi).mockResolvedValue({
-      ok: false,
-      status: 500,
-      error: 'Internal server error',
-    });
+    stub.clearDefaultModelConfig.mockResolvedValue(makeErr(500, 'Internal server error'));
 
     await handleClearDefault(createMockContext());
 
@@ -143,7 +125,7 @@ describe('handleClearDefault', () => {
   });
 
   it('should handle exceptions', async () => {
-    vi.mocked(callGatewayApi).mockRejectedValue(new Error('Network error'));
+    stub.clearDefaultModelConfig.mockRejectedValue(new Error('Network error'));
 
     await handleClearDefault(createMockContext());
 

--- a/services/bot-client/src/commands/settings/preset/clear-default.ts
+++ b/services/bot-client/src/commands/settings/preset/clear-default.ts
@@ -5,13 +5,9 @@
  */
 
 import { EmbedBuilder } from 'discord.js';
-import {
-  createLogger,
-  DISCORD_COLORS,
-  type ClearDefaultConfigResponse,
-} from '@tzurot/common-types';
+import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
+import { clientsFor } from '../../../utils/gatewayClients.js';
 
 const logger = createLogger('settings-preset-clear-default');
 
@@ -22,13 +18,8 @@ export async function handleClearDefault(context: DeferredCommandContext): Promi
   const userId = context.user.id;
 
   try {
-    const result = await callGatewayApi<ClearDefaultConfigResponse>(
-      '/user/model-override/default',
-      {
-        method: 'DELETE',
-        user: toGatewayUser(context.user),
-      }
-    );
+    const { userClient } = clientsFor(context.interaction);
+    const result = await userClient.clearDefaultModelConfig();
 
     if (!result.ok) {
       logger.warn({ userId, status: result.status }, 'Failed to clear default');

--- a/services/bot-client/src/commands/settings/preset/clear.test.ts
+++ b/services/bot-client/src/commands/settings/preset/clear.test.ts
@@ -7,17 +7,16 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { handleClear } from './clear.js';
+import { makeOk, makeErr } from '../../../test/gatewayClientStubs.js';
+import type { UserClient } from '@tzurot/common-types';
 
-// Mock dependencies
-vi.mock('../../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
-    '../../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: vi.fn(),
-  };
-});
+const stub = {
+  deleteModelOverride: vi.fn(),
+};
+
+vi.mock('../../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
+}));
 
 // Create mock EmbedBuilder-like objects
 function createMockEmbed(title: string, description?: string) {
@@ -53,13 +52,12 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
-import { callGatewayApi } from '../../../utils/userGatewayClient.js';
-
 describe('Preset Clear Handler', () => {
   const mockEditReply = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
+    stub.deleteModelOverride.mockReset();
     mockCreateSuccessEmbed.mockImplementation((title: string, description: string) =>
       createMockEmbed(title, description)
     );
@@ -82,21 +80,11 @@ describe('Preset Clear Handler', () => {
 
   describe('handleClear', () => {
     it('should successfully clear model override when one exists', async () => {
-      vi.mocked(callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: { deleted: true }, // wasSet defaults to true when not specified
-      });
+      stub.deleteModelOverride.mockResolvedValue(makeOk({ deleted: true }));
 
       await handleClear(createMockContext('personality-123'));
 
-      expect(callGatewayApi).toHaveBeenCalledWith('/user/model-override/personality-123', {
-        method: 'DELETE',
-        user: {
-          discordId: 'user-123',
-          username: 'testuser',
-          displayName: 'testuser',
-        },
-      });
+      expect(stub.deleteModelOverride).toHaveBeenCalledWith('personality-123');
 
       expect(mockCreateSuccessEmbed).toHaveBeenCalledWith(
         '🔄 Preset Override Removed',
@@ -109,10 +97,7 @@ describe('Preset Clear Handler', () => {
     });
 
     it('should show info message when no override was set', async () => {
-      vi.mocked(callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: { deleted: true, wasSet: false },
-      });
+      stub.deleteModelOverride.mockResolvedValue(makeOk({ deleted: true, wasSet: false }));
 
       await handleClear(createMockContext('personality-123'));
 
@@ -127,11 +112,7 @@ describe('Preset Clear Handler', () => {
     });
 
     it('should handle API error', async () => {
-      vi.mocked(callGatewayApi).mockResolvedValue({
-        ok: false,
-        status: 404,
-        error: 'Override not found',
-      });
+      stub.deleteModelOverride.mockResolvedValue(makeErr(404, 'Override not found'));
 
       await handleClear(createMockContext('nonexistent'));
 
@@ -141,7 +122,7 @@ describe('Preset Clear Handler', () => {
     });
 
     it('should handle network errors', async () => {
-      vi.mocked(callGatewayApi).mockRejectedValue(new Error('Connection refused'));
+      stub.deleteModelOverride.mockRejectedValue(new Error('Connection refused'));
 
       await handleClear(createMockContext('personality-123'));
 
@@ -153,7 +134,7 @@ describe('Preset Clear Handler', () => {
     it('rejects the autocomplete-error sentinel before calling the gateway', async () => {
       await handleClear(createMockContext('__autocomplete_error__'));
 
-      expect(callGatewayApi).not.toHaveBeenCalled();
+      expect(stub.deleteModelOverride).not.toHaveBeenCalled();
       expect(mockEditReply).toHaveBeenCalledWith({
         content: expect.stringContaining('Autocomplete was unavailable'),
       });

--- a/services/bot-client/src/commands/settings/preset/clear.ts
+++ b/services/bot-client/src/commands/settings/preset/clear.ts
@@ -9,15 +9,10 @@ import {
   AUTOCOMPLETE_UNAVAILABLE_MESSAGE,
   isAutocompleteErrorSentinel,
 } from '../../../utils/apiCheck.js';
-import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
+import { clientsFor } from '../../../utils/gatewayClients.js';
 import { createSuccessEmbed, createInfoEmbed } from '../../../utils/commandHelpers.js';
 
 const logger = createLogger('settings-preset-clear');
-
-interface ClearResponse {
-  deleted: boolean;
-  wasSet?: boolean; // false if no override existed
-}
 
 /**
  * Handle /settings preset clear
@@ -33,13 +28,8 @@ export async function handleClear(context: DeferredCommandContext): Promise<void
   }
 
   try {
-    const result = await callGatewayApi<ClearResponse>(
-      `/user/model-override/${encodeURIComponent(personalityId)}`,
-      {
-        method: 'DELETE',
-        user: toGatewayUser(context.user),
-      }
-    );
+    const { userClient } = clientsFor(context.interaction);
+    const result = await userClient.deleteModelOverride(personalityId);
 
     if (!result.ok) {
       logger.warn({ userId, status: result.status, personalityId }, 'Failed to clear override');

--- a/services/bot-client/src/commands/settings/preset/guestModeValidation.test.ts
+++ b/services/bot-client/src/commands/settings/preset/guestModeValidation.test.ts
@@ -1,22 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import * as gatewayClient from '../../../utils/userGatewayClient.js';
 import { handleUnlockModelsUpsell, checkGuestModePremiumAccess } from './guestModeValidation.js';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import type { GatewayUser } from '../../../utils/userGatewayClient.js';
+import { makeOk, makeErr, asUserClient } from '../../../test/gatewayClientStubs.js';
 
-function mkUser(discordId = 'user-1'): GatewayUser {
-  return { discordId, username: 'test-user', displayName: 'Test User' };
+const stub = {
+  actor: 'user-1',
+  listWalletKeys: vi.fn(),
+  listUserLlmConfigs: vi.fn(),
+};
+
+function userClient(actorId = 'user-1') {
+  return asUserClient({ ...stub, actor: actorId });
 }
-
-vi.mock('../../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
-    '../../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: vi.fn(),
-  };
-});
 
 vi.mock('./autocomplete.js', () => ({
   UNLOCK_MODELS_VALUE: '__UNLOCK_ALL_MODELS__',
@@ -48,12 +43,8 @@ describe('guestModeValidation', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // Reset the queue — after the serial-fetch refactor, the paid-user path
-    // consumes only one `callGatewayApi` mock (wallet) instead of two
-    // (wallet + configs). Without a full reset between tests, leftover
-    // `mockResolvedValueOnce` entries would bleed across tests and mis-mock
-    // later calls. `mockReset()` clears both call history and the queue.
-    vi.mocked(gatewayClient.callGatewayApi).mockReset();
+    stub.listWalletKeys.mockReset();
+    stub.listUserLlmConfigs.mockReset();
   });
 
   describe('handleUnlockModelsUpsell', () => {
@@ -76,103 +67,88 @@ describe('guestModeValidation', () => {
 
   describe('checkGuestModePremiumAccess', () => {
     it('should not block when user has active wallet keys', async () => {
-      vi.mocked(gatewayClient.callGatewayApi).mockResolvedValueOnce({
-        ok: true,
-        data: { keys: [{ provider: 'openrouter', isActive: true }] },
-      } as never);
+      stub.listWalletKeys.mockResolvedValue(
+        makeOk({ keys: [{ provider: 'openrouter', isActive: true }] })
+      );
 
-      const result = await checkGuestModePremiumAccess(createMockContext(), 'config-1', mkUser());
+      const result = await checkGuestModePremiumAccess(
+        createMockContext(),
+        'config-1',
+        userClient()
+      );
       expect(result.blocked).toBe(false);
       expect(result).toMatchObject({ blocked: false, reason: 'paid' });
-      // Guard against accidental revert to Promise.all — paid path should
-      // short-circuit after wallet fetch and never call `/user/llm-config`.
-      expect(vi.mocked(gatewayClient.callGatewayApi)).toHaveBeenCalledTimes(1);
+      // Paid path: configs not fetched
+      expect(stub.listUserLlmConfigs).not.toHaveBeenCalled();
     });
 
     it('should not block guest user selecting free model', async () => {
-      vi.mocked(gatewayClient.callGatewayApi)
-        .mockResolvedValueOnce({ ok: true, data: { keys: [] } } as never)
-        .mockResolvedValueOnce({
-          ok: true,
-          data: { configs: [{ id: 'config-1', name: 'Free Config', model: 'free-gpt' }] },
-        } as never);
+      stub.listWalletKeys.mockResolvedValue(makeOk({ keys: [] }));
+      stub.listUserLlmConfigs.mockResolvedValue(
+        makeOk({ configs: [{ id: 'config-1', name: 'Free Config', model: 'free-gpt' }] })
+      );
 
-      const result = await checkGuestModePremiumAccess(createMockContext(), 'config-1', mkUser());
+      const result = await checkGuestModePremiumAccess(
+        createMockContext(),
+        'config-1',
+        userClient()
+      );
       expect(result.blocked).toBe(false);
       expect(result).toMatchObject({ blocked: false, reason: 'guest-free-model' });
     });
 
     it('should block guest user selecting premium model', async () => {
-      vi.mocked(gatewayClient.callGatewayApi)
-        .mockResolvedValueOnce({ ok: true, data: { keys: [] } } as never)
-        .mockResolvedValueOnce({
-          ok: true,
-          data: {
-            configs: [{ id: 'config-1', name: 'Premium Config', model: 'claude-sonnet' }],
-          },
-        } as never);
+      stub.listWalletKeys.mockResolvedValue(makeOk({ keys: [] }));
+      stub.listUserLlmConfigs.mockResolvedValue(
+        makeOk({ configs: [{ id: 'config-1', name: 'Premium Config', model: 'claude-sonnet' }] })
+      );
 
-      const result = await checkGuestModePremiumAccess(createMockContext(), 'config-1', mkUser());
+      const result = await checkGuestModePremiumAccess(
+        createMockContext(),
+        'config-1',
+        userClient()
+      );
       expect(result.blocked).toBe(true);
       expect(mockEditReply).toHaveBeenCalled();
     });
 
     it('should not block when config is not found', async () => {
-      vi.mocked(gatewayClient.callGatewayApi)
-        .mockResolvedValueOnce({ ok: true, data: { keys: [] } } as never)
-        .mockResolvedValueOnce({
-          ok: true,
-          data: { configs: [{ id: 'other-config', name: 'Other', model: 'claude-sonnet' }] },
-        } as never);
+      stub.listWalletKeys.mockResolvedValue(makeOk({ keys: [] }));
+      stub.listUserLlmConfigs.mockResolvedValue(
+        makeOk({ configs: [{ id: 'other-config', name: 'Other', model: 'claude-sonnet' }] })
+      );
 
       const result = await checkGuestModePremiumAccess(
         createMockContext(),
         'config-not-found',
-        mkUser()
+        userClient()
       );
       expect(result.blocked).toBe(false);
       expect(result).toMatchObject({ blocked: false, reason: 'guest-free-model' });
     });
 
     it('should fail-open with reason=check-failed when configs API fails in guest mode', async () => {
-      // Wallet succeeded as "no keys" → we're in guest mode. But configs
-      // endpoint failed, so we can't decide if the selected config is
-      // premium or free. Fail-open with the accurate `check-failed` reason,
-      // not the misleading `guest-free-model` that the fallthrough used to
-      // produce.
-      vi.mocked(gatewayClient.callGatewayApi)
-        .mockResolvedValueOnce({ ok: true, data: { keys: [] } } as never)
-        .mockResolvedValueOnce({
-          ok: false,
-          error: 'Gateway timeout',
-          status: 504,
-        } as never);
+      stub.listWalletKeys.mockResolvedValue(makeOk({ keys: [] }));
+      stub.listUserLlmConfigs.mockResolvedValue(makeErr(504, 'Gateway timeout'));
 
-      const result = await checkGuestModePremiumAccess(createMockContext(), 'config-1', mkUser());
+      const result = await checkGuestModePremiumAccess(
+        createMockContext(),
+        'config-1',
+        userClient()
+      );
       expect(result.blocked).toBe(false);
       expect(result).toMatchObject({ blocked: false, reason: 'check-failed' });
       expect(mockEditReply).not.toHaveBeenCalled();
     });
 
     it('should fail-open when wallet API fails (ai-worker will enforce authoritatively)', async () => {
-      // Simulate a transient /wallet/list failure. The historic bug was that
-      // this was treated identically to "no keys", locking out users with
-      // active paid keys. Fix: fail-open with a warn log, trust the
-      // downstream ai-worker gate.
-      vi.mocked(gatewayClient.callGatewayApi)
-        .mockResolvedValueOnce({
-          ok: false,
-          error: 'Gateway timeout',
-          status: 504,
-        } as never)
-        .mockResolvedValueOnce({
-          ok: true,
-          data: {
-            configs: [{ id: 'config-1', name: 'Premium Config', model: 'claude-sonnet' }],
-          },
-        } as never);
+      stub.listWalletKeys.mockResolvedValue(makeErr(504, 'Gateway timeout'));
 
-      const result = await checkGuestModePremiumAccess(createMockContext(), 'config-1', mkUser());
+      const result = await checkGuestModePremiumAccess(
+        createMockContext(),
+        'config-1',
+        userClient()
+      );
       expect(result.blocked).toBe(false);
       expect(result).toMatchObject({ blocked: false, reason: 'check-failed' });
       // Critically: we must NOT have shown the "Premium Model Not Available"

--- a/services/bot-client/src/commands/settings/preset/guestModeValidation.ts
+++ b/services/bot-client/src/commands/settings/preset/guestModeValidation.ts
@@ -7,26 +7,11 @@
  */
 
 import { EmbedBuilder } from 'discord.js';
-import {
-  createLogger,
-  DISCORD_COLORS,
-  isFreeModel,
-  type ListWalletKeysResponse,
-  type LlmConfigSummary,
-} from '@tzurot/common-types';
+import { createLogger, DISCORD_COLORS, isFreeModel, type UserClient } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import {
-  callGatewayApi,
-  GATEWAY_TIMEOUTS,
-  type GatewayUser,
-} from '../../../utils/userGatewayClient.js';
 import { UNLOCK_MODELS_VALUE } from './autocomplete.js';
 
 const logger = createLogger('settings-preset-guest-mode');
-
-interface ConfigListResponse {
-  configs: LlmConfigSummary[];
-}
 
 /**
  * Show the "Unlock All Models" upsell embed when a guest user selects the upsell option.
@@ -85,20 +70,18 @@ export type GuestModeCheckOutcome =
 export async function checkGuestModePremiumAccess(
   context: DeferredCommandContext,
   configId: string,
-  user: GatewayUser
+  userClient: UserClient
 ): Promise<GuestModeCheckOutcome> {
+  const userId = userClient.actor;
   // Serial fetch: paid users (the common path) return early after only the
   // wallet check. The configs endpoint is only needed on the guest-mode
   // branch to decide free-vs-premium, so fetching it upfront in parallel
   // wasted a gateway round-trip per paid-user interaction.
-  const walletResult = await callGatewayApi<ListWalletKeysResponse>('/wallet/list', {
-    user,
-    timeout: GATEWAY_TIMEOUTS.DEFERRED,
-  });
+  const walletResult = await userClient.listWalletKeys();
 
   if (!walletResult.ok) {
     logger.warn(
-      { userId: user.discordId, configId, error: walletResult.error },
+      { userId, configId, error: walletResult.error },
       'Wallet check failed — failing open, ai-worker will enforce'
     );
     return { blocked: false, reason: 'check-failed' };
@@ -115,14 +98,11 @@ export async function checkGuestModePremiumAccess(
   // unable to decide free-vs-premium — fail-open with an accurate
   // `check-failed` reason rather than mislabeling the outcome as
   // `guest-free-model`.
-  const configsResult = await callGatewayApi<ConfigListResponse>('/user/llm-config', {
-    user,
-    timeout: GATEWAY_TIMEOUTS.DEFERRED,
-  });
+  const configsResult = await userClient.listUserLlmConfigs();
 
   if (!configsResult.ok) {
     logger.warn(
-      { userId: user.discordId, configId, error: configsResult.error },
+      { userId, configId, error: configsResult.error },
       'Config list check failed — failing open, ai-worker will enforce'
     );
     return { blocked: false, reason: 'check-failed' };
@@ -143,7 +123,7 @@ export async function checkGuestModePremiumAccess(
 
     await context.editReply({ embeds: [embed] });
     logger.info(
-      { userId: user.discordId, configId, configName: selectedConfig.name },
+      { userId, configId, configName: selectedConfig.name },
       'Guest mode user tried to select premium model'
     );
     return { blocked: true, reason: 'guest-premium' };

--- a/services/bot-client/src/commands/settings/preset/handlers.test.ts
+++ b/services/bot-client/src/commands/settings/preset/handlers.test.ts
@@ -16,6 +16,8 @@ import {
   mockListWalletKeysResponse,
   mockListLlmConfigsResponse,
 } from '@tzurot/common-types';
+import { makeOk, makeErr } from '../../../test/gatewayClientStubs.js';
+import type { UserClient } from '@tzurot/common-types';
 
 // Test UUIDs (RFC 4122 compliant)
 const PERSONALITY_ID_1 = '11111111-1111-5111-8111-111111111111';
@@ -37,19 +39,17 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
-// Mock userGatewayClient
-// Note: Tests use objectContaining for API call assertions to focus on the essential
-// userId parameter while ignoring implementation details like timeout values.
-const mockCallGatewayApi = vi.fn();
-vi.mock('../../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
-    '../../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  };
-});
+const stub = {
+  listModelOverrides: vi.fn(),
+  listWalletKeys: vi.fn(),
+  listUserLlmConfigs: vi.fn(),
+  setModelOverride: vi.fn(),
+  deleteModelOverride: vi.fn(),
+};
+
+vi.mock('../../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
+}));
 
 // Mock commandHelpers (only used by reset for createSuccessEmbed/createInfoEmbed)
 const mockCreateSuccessEmbed = vi.fn().mockReturnValue({ data: { title: 'Success' } });
@@ -64,43 +64,45 @@ describe('Preset Command Handlers', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    stub.listModelOverrides.mockReset();
+    stub.listWalletKeys.mockReset();
+    stub.listUserLlmConfigs.mockReset();
+    stub.setModelOverride.mockReset();
+    stub.deleteModelOverride.mockReset();
   });
 
   describe('handleListOverrides', () => {
     function createMockContext() {
       return {
         user: { id: '123456789', username: 'testuser' },
+        interaction: {} as never,
         editReply: mockEditReply,
       } as unknown as Parameters<typeof handleListOverrides>[0];
     }
 
     it('should list overrides', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: mockListModelOverridesResponse([
-          {
-            personalityId: PERSONALITY_ID_1,
-            personalityName: 'Lilith',
-            configId: CONFIG_ID_1,
-            configName: 'Fast',
-          },
-          {
-            personalityId: PERSONALITY_ID_2,
-            personalityName: 'Sarcastic',
-            configId: CONFIG_ID_2,
-            configName: 'GPT-4',
-          },
-        ]),
-      });
+      stub.listModelOverrides.mockResolvedValue(
+        makeOk(
+          mockListModelOverridesResponse([
+            {
+              personalityId: PERSONALITY_ID_1,
+              personalityName: 'Lilith',
+              configId: CONFIG_ID_1,
+              configName: 'Fast',
+            },
+            {
+              personalityId: PERSONALITY_ID_2,
+              personalityName: 'Sarcastic',
+              configId: CONFIG_ID_2,
+              configName: 'GPT-4',
+            },
+          ])
+        )
+      );
 
       await handleListOverrides(createMockContext());
 
-      expect(mockCallGatewayApi).toHaveBeenCalledWith(
-        '/user/model-override',
-        expect.objectContaining({
-          user: { discordId: '123456789', username: 'testuser', displayName: 'testuser' },
-        })
-      );
+      expect(stub.listModelOverrides).toHaveBeenCalled();
       expect(mockEditReply).toHaveBeenCalledWith({
         embeds: [
           expect.objectContaining({
@@ -114,10 +116,7 @@ describe('Preset Command Handlers', () => {
     });
 
     it('should show empty message when no overrides', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: mockListModelOverridesResponse([]),
-      });
+      stub.listModelOverrides.mockResolvedValue(makeOk(mockListModelOverridesResponse([])));
 
       await handleListOverrides(createMockContext());
 
@@ -133,7 +132,7 @@ describe('Preset Command Handlers', () => {
     });
 
     it('should handle API error', async () => {
-      mockCallGatewayApi.mockResolvedValue({ ok: false, status: 500, error: 'Error' });
+      stub.listModelOverrides.mockResolvedValue(makeErr(500, 'Error'));
 
       await handleListOverrides(createMockContext());
 
@@ -161,52 +160,35 @@ describe('Preset Command Handlers', () => {
     }
 
     it('should set model override', async () => {
-      // Mock responses based on API path
-      mockCallGatewayApi.mockImplementation((path: string, options?: { method?: string }) => {
-        if (path === '/wallet/list') {
-          return Promise.resolve({
-            ok: true,
-            data: mockListWalletKeysResponse([{ isActive: true }]),
-          });
-        }
-        if (path === '/user/llm-config') {
-          return Promise.resolve({
-            ok: true,
-            data: mockListLlmConfigsResponse([
-              { id: CONFIG_ID_1, name: 'Fast', model: 'openai/gpt-4o-mini' },
-            ]),
-          });
-        }
-        if (path === '/user/model-override' && options?.method === 'PUT') {
-          return Promise.resolve({
-            ok: true,
-            data: mockSetModelOverrideResponse({
-              override: {
-                personalityId: PERSONALITY_ID_1,
-                personalityName: 'Lilith',
-                configId: CONFIG_ID_1,
-                configName: 'Fast',
-              },
-            }),
-          });
-        }
-        return Promise.resolve({ ok: false, error: 'Unknown path' });
-      });
+      stub.listWalletKeys.mockResolvedValue(
+        makeOk(mockListWalletKeysResponse([{ isActive: true }]))
+      );
+      stub.listUserLlmConfigs.mockResolvedValue(
+        makeOk(
+          mockListLlmConfigsResponse([
+            { id: CONFIG_ID_1, name: 'Fast', model: 'openai/gpt-4o-mini' },
+          ])
+        )
+      );
+      stub.setModelOverride.mockResolvedValue(
+        makeOk(
+          mockSetModelOverrideResponse({
+            override: {
+              personalityId: PERSONALITY_ID_1,
+              personalityName: 'Lilith',
+              configId: CONFIG_ID_1,
+              configName: 'Fast',
+            },
+          })
+        )
+      );
 
       await handleSet(createMockContext());
 
-      expect(mockCallGatewayApi).toHaveBeenCalledWith(
-        '/user/model-override',
-        expect.objectContaining({
-          method: 'PUT',
-          user: {
-            discordId: '123456789',
-            username: 'testuser',
-            displayName: 'testuser',
-          },
-          body: { personalityId: PERSONALITY_ID_1, configId: CONFIG_ID_1 },
-        })
-      );
+      expect(stub.setModelOverride).toHaveBeenCalledWith({
+        personalityId: PERSONALITY_ID_1,
+        configId: CONFIG_ID_1,
+      });
       expect(mockEditReply).toHaveBeenCalledWith({
         embeds: [
           expect.objectContaining({
@@ -219,11 +201,10 @@ describe('Preset Command Handlers', () => {
     });
 
     it('should handle not found error', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: false,
-        status: 404,
-        error: 'Personality not found',
-      });
+      stub.listWalletKeys.mockResolvedValue(
+        makeOk(mockListWalletKeysResponse([{ isActive: true }]))
+      );
+      stub.setModelOverride.mockResolvedValue(makeErr(404, 'Personality not found'));
 
       await handleSet(createMockContext('invalid', 'c1'));
 
@@ -250,24 +231,11 @@ describe('Preset Command Handlers', () => {
     }
 
     it('should clear model override', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: true,
-        data: mockDeleteModelOverrideResponse(),
-      });
+      stub.deleteModelOverride.mockResolvedValue(makeOk(mockDeleteModelOverrideResponse()));
 
       await handleClear(createMockContext());
 
-      expect(mockCallGatewayApi).toHaveBeenCalledWith(
-        `/user/model-override/${PERSONALITY_ID_1}`,
-        expect.objectContaining({
-          method: 'DELETE',
-          user: {
-            discordId: '123456789',
-            username: 'testuser',
-            displayName: 'testuser',
-          },
-        })
-      );
+      expect(stub.deleteModelOverride).toHaveBeenCalledWith(PERSONALITY_ID_1);
       expect(mockCreateSuccessEmbed).toHaveBeenCalledWith(
         '🔄 Preset Override Removed',
         'The personality will now use its default preset.'
@@ -275,11 +243,7 @@ describe('Preset Command Handlers', () => {
     });
 
     it('should handle not found error', async () => {
-      mockCallGatewayApi.mockResolvedValue({
-        ok: false,
-        status: 404,
-        error: 'No override found',
-      });
+      stub.deleteModelOverride.mockResolvedValue(makeErr(404, 'No override found'));
 
       await handleClear(createMockContext());
 
@@ -289,7 +253,7 @@ describe('Preset Command Handlers', () => {
     });
 
     it('should handle exceptions', async () => {
-      mockCallGatewayApi.mockRejectedValue(new Error('Network error'));
+      stub.deleteModelOverride.mockRejectedValue(new Error('Network error'));
 
       await handleClear(createMockContext());
 

--- a/services/bot-client/src/commands/settings/preset/list.test.ts
+++ b/services/bot-client/src/commands/settings/preset/list.test.ts
@@ -8,17 +8,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { handleListOverrides } from './list.js';
 import { EmbedBuilder } from 'discord.js';
+import { makeOk, makeErr } from '../../../test/gatewayClientStubs.js';
+import type { UserClient } from '@tzurot/common-types';
 
-// Mock dependencies
-vi.mock('../../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
-    '../../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: vi.fn(),
-  };
-});
+const stub = {
+  listModelOverrides: vi.fn(),
+};
+
+vi.mock('../../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
+}));
 
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal();
@@ -33,28 +32,25 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
-import { callGatewayApi } from '../../../utils/userGatewayClient.js';
-
 describe('Settings Preset Browse Handler', () => {
   const mockEditReply = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
+    stub.listModelOverrides.mockReset();
   });
 
   function createMockContext() {
     return {
       user: { id: 'user-123' },
+      interaction: {} as never,
       editReply: mockEditReply,
     } as unknown as Parameters<typeof handleListOverrides>[0];
   }
 
   describe('handleListOverrides', () => {
     it('should show empty state when no overrides', async () => {
-      vi.mocked(callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: { overrides: [] },
-      });
+      stub.listModelOverrides.mockResolvedValue(makeOk({ overrides: [] }));
 
       await handleListOverrides(createMockContext());
 
@@ -71,15 +67,14 @@ describe('Settings Preset Browse Handler', () => {
     });
 
     it('should list overrides when present', async () => {
-      vi.mocked(callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: {
+      stub.listModelOverrides.mockResolvedValue(
+        makeOk({
           overrides: [
             { personalityName: 'Lilith', configName: 'Fast Claude' },
             { personalityName: 'Bob', configName: 'GPT-4 Turbo' },
           ],
-        },
-      });
+        })
+      );
 
       await handleListOverrides(createMockContext());
 
@@ -95,12 +90,11 @@ describe('Settings Preset Browse Handler', () => {
     });
 
     it('should handle unknown config name', async () => {
-      vi.mocked(callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: {
+      stub.listModelOverrides.mockResolvedValue(
+        makeOk({
           overrides: [{ personalityName: 'Test', configName: null }],
-        },
-      });
+        })
+      );
 
       await handleListOverrides(createMockContext());
 
@@ -112,11 +106,7 @@ describe('Settings Preset Browse Handler', () => {
     });
 
     it('should handle API error', async () => {
-      vi.mocked(callGatewayApi).mockResolvedValue({
-        ok: false,
-        status: 500,
-        error: 'Internal error',
-      });
+      stub.listModelOverrides.mockResolvedValue(makeErr(500, 'Internal error'));
 
       await handleListOverrides(createMockContext());
 
@@ -126,7 +116,7 @@ describe('Settings Preset Browse Handler', () => {
     });
 
     it('should handle network errors', async () => {
-      vi.mocked(callGatewayApi).mockRejectedValue(new Error('Network error'));
+      stub.listModelOverrides.mockRejectedValue(new Error('Network error'));
 
       await handleListOverrides(createMockContext());
 

--- a/services/bot-client/src/commands/settings/preset/list.ts
+++ b/services/bot-client/src/commands/settings/preset/list.ts
@@ -4,19 +4,11 @@
  */
 
 import { EmbedBuilder, escapeMarkdown } from 'discord.js';
-import { createLogger, DISCORD_COLORS, type ModelOverrideSummary } from '@tzurot/common-types';
+import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import {
-  callGatewayApi,
-  GATEWAY_TIMEOUTS,
-  toGatewayUser,
-} from '../../../utils/userGatewayClient.js';
+import { clientsFor } from '../../../utils/gatewayClients.js';
 
 const logger = createLogger('settings-preset-browse');
-
-interface ListResponse {
-  overrides: ModelOverrideSummary[];
-}
 
 /**
  * Handle /settings preset list
@@ -25,10 +17,8 @@ export async function handleListOverrides(context: DeferredCommandContext): Prom
   const userId = context.user.id;
 
   try {
-    const result = await callGatewayApi<ListResponse>('/user/model-override', {
-      user: toGatewayUser(context.user),
-      timeout: GATEWAY_TIMEOUTS.DEFERRED,
-    });
+    const { userClient } = clientsFor(context.interaction);
+    const result = await userClient.listModelOverrides();
 
     if (!result.ok) {
       logger.warn({ userId, status: result.status }, 'Failed to list overrides');

--- a/services/bot-client/src/commands/settings/preset/set-default.test.ts
+++ b/services/bot-client/src/commands/settings/preset/set-default.test.ts
@@ -12,6 +12,8 @@ import {
   mockListWalletKeysResponse,
   mockListLlmConfigsResponse,
 } from '@tzurot/common-types';
+import { makeOk, makeErr } from '../../../test/gatewayClientStubs.js';
+import type { UserClient } from '@tzurot/common-types';
 
 // Mock logger
 vi.mock('@tzurot/common-types', async () => {
@@ -27,24 +29,24 @@ vi.mock('@tzurot/common-types', async () => {
   };
 });
 
-// Mock the gateway client
-vi.mock('../../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
-    '../../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: vi.fn(),
-  };
-});
+const stub = {
+  listWalletKeys: vi.fn(),
+  listUserLlmConfigs: vi.fn(),
+  setDefaultModelConfig: vi.fn(),
+};
 
-import { callGatewayApi } from '../../../utils/userGatewayClient.js';
+vi.mock('../../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
+}));
 
 describe('handleSetDefault', () => {
   const mockEditReply = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
+    stub.listWalletKeys.mockReset();
+    stub.listUserLlmConfigs.mockReset();
+    stub.setDefaultModelConfig.mockReset();
     mockEditReply.mockResolvedValue(undefined);
   });
 
@@ -60,48 +62,28 @@ describe('handleSetDefault', () => {
     } as unknown as Parameters<typeof handleSetDefault>[0];
   }
 
-  // Helper to mock all API calls for a non-guest user with free config
+  // Helper to mock all stubs for a non-guest user with free config
   function mockNonGuestUserApis(configId: string, configName: string) {
-    vi.mocked(callGatewayApi).mockImplementation(((path: string) => {
-      if (path === '/wallet/list') {
-        return Promise.resolve({
-          ok: true as const,
-          data: mockListWalletKeysResponse([{ isActive: true }]),
-        });
-      }
-      if (path === '/user/llm-config') {
-        return Promise.resolve({
-          ok: true as const,
-          data: mockListLlmConfigsResponse([
-            { id: configId, name: configName, model: 'openai/gpt-4o-mini' },
-          ]),
-        });
-      }
-      if (path === '/user/model-override/default') {
-        return Promise.resolve({
-          ok: true as const,
-          data: mockSetDefaultConfigResponse({
-            default: { configId, configName },
-          }),
-        });
-      }
-      return Promise.resolve({ ok: false as const, error: 'Unknown path' });
-    }) as never);
+    stub.listWalletKeys.mockResolvedValue(makeOk(mockListWalletKeysResponse([{ isActive: true }])));
+    stub.listUserLlmConfigs.mockResolvedValue(
+      makeOk(
+        mockListLlmConfigsResponse([
+          { id: configId, name: configName, model: 'openai/gpt-4o-mini' },
+        ])
+      )
+    );
+    stub.setDefaultModelConfig.mockResolvedValue(
+      makeOk(mockSetDefaultConfigResponse({ default: { configId, configName } }))
+    );
   }
 
-  it('should call API with correct parameters', async () => {
+  it('should call setDefaultModelConfig with correct parameters', async () => {
     mockNonGuestUserApis('00000000-0000-4000-8000-000000000456', 'Test Config');
 
     await handleSetDefault(createMockContext('00000000-0000-4000-8000-000000000456'));
 
-    expect(callGatewayApi).toHaveBeenCalledWith('/user/model-override/default', {
-      method: 'PUT',
-      user: {
-        discordId: 'user-123',
-        username: 'testuser',
-        displayName: 'testuser',
-      },
-      body: { configId: '00000000-0000-4000-8000-000000000456' },
+    expect(stub.setDefaultModelConfig).toHaveBeenCalledWith({
+      configId: '00000000-0000-4000-8000-000000000456',
     });
   });
 
@@ -122,35 +104,20 @@ describe('handleSetDefault', () => {
   });
 
   it('should show error when API returns error', async () => {
-    vi.mocked(callGatewayApi).mockImplementation(((path: string) => {
-      if (path === '/wallet/list') {
-        return Promise.resolve({
-          ok: true as const,
-          data: mockListWalletKeysResponse([{ isActive: true }]),
-        });
-      }
-      if (path === '/user/llm-config') {
-        return Promise.resolve({
-          ok: true as const,
-          data: mockListLlmConfigsResponse([
-            {
-              id: '00000000-0000-4000-8000-000000000123',
-              name: 'Test',
-              model: 'openai/gpt-4o-mini',
-              provider: 'openrouter',
-            },
-          ]),
-        });
-      }
-      if (path === '/user/model-override/default') {
-        return Promise.resolve({
-          ok: false,
-          error: 'Config not found',
-          status: 404,
-        });
-      }
-      return Promise.resolve({ ok: false as const, error: 'Unknown path' });
-    }) as never);
+    stub.listWalletKeys.mockResolvedValue(makeOk(mockListWalletKeysResponse([{ isActive: true }])));
+    stub.listUserLlmConfigs.mockResolvedValue(
+      makeOk(
+        mockListLlmConfigsResponse([
+          {
+            id: '00000000-0000-4000-8000-000000000123',
+            name: 'Test',
+            model: 'openai/gpt-4o-mini',
+            provider: 'openrouter',
+          },
+        ])
+      )
+    );
+    stub.setDefaultModelConfig.mockResolvedValue(makeErr(404, 'Config not found'));
 
     await handleSetDefault(createMockContext('00000000-0000-4000-8000-000000000123'));
 
@@ -160,7 +127,7 @@ describe('handleSetDefault', () => {
   });
 
   it('should handle network errors', async () => {
-    vi.mocked(callGatewayApi).mockRejectedValue(new Error('Network error'));
+    stub.listWalletKeys.mockRejectedValue(new Error('Network error'));
 
     await handleSetDefault(createMockContext('00000000-0000-4000-8000-000000000123'));
 
@@ -170,39 +137,23 @@ describe('handleSetDefault', () => {
   });
 
   it('should show error when guest user tries to set premium model as default', async () => {
-    vi.mocked(callGatewayApi).mockImplementation(((path: string) => {
-      if (path === '/wallet/list') {
-        // No active wallet keys = guest mode
-        return Promise.resolve({
-          ok: true as const,
-          data: mockListWalletKeysResponse([]),
-        });
-      }
-      if (path === '/user/llm-config') {
-        return Promise.resolve({
-          ok: true as const,
-          data: mockListLlmConfigsResponse([
-            {
-              id: '00000000-0000-4000-8000-000000000100',
-              name: 'Premium Config',
-              model: 'openai/gpt-4o',
-              provider: 'openrouter',
-            },
-          ]),
-        });
-      }
-      return Promise.resolve({ ok: false as const, error: 'Should not be called' });
-    }) as never);
+    stub.listWalletKeys.mockResolvedValue(makeOk(mockListWalletKeysResponse([])));
+    stub.listUserLlmConfigs.mockResolvedValue(
+      makeOk(
+        mockListLlmConfigsResponse([
+          {
+            id: '00000000-0000-4000-8000-000000000100',
+            name: 'Premium Config',
+            model: 'openai/gpt-4o',
+            provider: 'openrouter',
+          },
+        ])
+      )
+    );
 
     await handleSetDefault(createMockContext('00000000-0000-4000-8000-000000000100'));
 
-    // Should NOT call the set-default API
-    expect(callGatewayApi).not.toHaveBeenCalledWith(
-      '/user/model-override/default',
-      expect.anything()
-    );
-
-    // Should show error embed
+    expect(stub.setDefaultModelConfig).not.toHaveBeenCalled();
     expect(mockEditReply).toHaveBeenCalledWith({
       embeds: [
         expect.objectContaining({
@@ -215,55 +166,32 @@ describe('handleSetDefault', () => {
   });
 
   it('should allow guest user to set free model as default', async () => {
-    vi.mocked(callGatewayApi).mockImplementation(((path: string) => {
-      if (path === '/wallet/list') {
-        // No active wallet keys = guest mode
-        return Promise.resolve({
-          ok: true as const,
-          data: mockListWalletKeysResponse([]),
-        });
-      }
-      if (path === '/user/llm-config') {
-        return Promise.resolve({
-          ok: true as const,
-          data: mockListLlmConfigsResponse([
-            {
-              id: '00000000-0000-4000-8000-000000000f00',
-              name: 'Free Config',
-              model: 'meta-llama/llama-3.3-70b-instruct:free',
-              provider: 'openrouter',
-            },
-          ]),
-        });
-      }
-      if (path === '/user/model-override/default') {
-        return Promise.resolve({
-          ok: true as const,
-          data: mockSetDefaultConfigResponse({
-            default: {
-              configId: '00000000-0000-4000-8000-000000000f00',
-              configName: 'Free Config',
-            },
-          }),
-        });
-      }
-      return Promise.resolve({ ok: false as const, error: 'Unknown path' });
-    }) as never);
+    stub.listWalletKeys.mockResolvedValue(makeOk(mockListWalletKeysResponse([])));
+    stub.listUserLlmConfigs.mockResolvedValue(
+      makeOk(
+        mockListLlmConfigsResponse([
+          {
+            id: '00000000-0000-4000-8000-000000000f00',
+            name: 'Free Config',
+            model: 'meta-llama/llama-3.3-70b-instruct:free',
+            provider: 'openrouter',
+          },
+        ])
+      )
+    );
+    stub.setDefaultModelConfig.mockResolvedValue(
+      makeOk(
+        mockSetDefaultConfigResponse({
+          default: { configId: '00000000-0000-4000-8000-000000000f00', configName: 'Free Config' },
+        })
+      )
+    );
 
     await handleSetDefault(createMockContext('00000000-0000-4000-8000-000000000f00'));
 
-    // Should call the set-default API
-    expect(callGatewayApi).toHaveBeenCalledWith('/user/model-override/default', {
-      method: 'PUT',
-      user: {
-        discordId: 'user-123',
-        username: 'testuser',
-        displayName: 'testuser',
-      },
-      body: { configId: '00000000-0000-4000-8000-000000000f00' },
+    expect(stub.setDefaultModelConfig).toHaveBeenCalledWith({
+      configId: '00000000-0000-4000-8000-000000000f00',
     });
-
-    // Should show success embed
     expect(mockEditReply).toHaveBeenCalledWith({
       embeds: [
         expect.objectContaining({

--- a/services/bot-client/src/commands/settings/preset/set-default.ts
+++ b/services/bot-client/src/commands/settings/preset/set-default.ts
@@ -11,17 +11,10 @@ import {
   settingsPresetSetDefaultOptions,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
+import { clientsFor } from '../../../utils/gatewayClients.js';
 import { handleUnlockModelsUpsell, checkGuestModePremiumAccess } from './guestModeValidation.js';
 
 const logger = createLogger('settings-preset-set-default');
-
-interface SetDefaultResponse {
-  default: {
-    configId: string;
-    configName: string;
-  };
-}
 
 /**
  * Handle /settings preset set-default
@@ -36,21 +29,14 @@ export async function handleSetDefault(context: DeferredCommandContext): Promise
   }
 
   try {
-    const outcome = await checkGuestModePremiumAccess(
-      context,
-      configId,
-      toGatewayUser(context.user)
-    );
+    const { userClient } = clientsFor(context.interaction);
+    const outcome = await checkGuestModePremiumAccess(context, configId, userClient);
     if (outcome.blocked) {
       return;
     }
     const { reason } = outcome;
 
-    const result = await callGatewayApi<SetDefaultResponse>('/user/model-override/default', {
-      method: 'PUT',
-      user: toGatewayUser(context.user),
-      body: { configId },
-    });
+    const result = await userClient.setDefaultModelConfig({ configId });
 
     if (!result.ok) {
       logger.warn({ userId, status: result.status, configId }, 'Failed to set default');

--- a/services/bot-client/src/commands/settings/preset/set.test.ts
+++ b/services/bot-client/src/commands/settings/preset/set.test.ts
@@ -8,17 +8,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { handleSet } from './set.js';
 import { EmbedBuilder } from 'discord.js';
+import { makeOk, makeErr } from '../../../test/gatewayClientStubs.js';
+import type { UserClient } from '@tzurot/common-types';
 
-// Mock dependencies
-vi.mock('../../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
-    '../../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: vi.fn(),
-  };
-});
+const stub = {
+  listWalletKeys: vi.fn(),
+  listUserLlmConfigs: vi.fn(),
+  setModelOverride: vi.fn(),
+};
+
+vi.mock('../../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
+}));
 
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal();
@@ -33,18 +34,14 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
-import { callGatewayApi } from '../../../utils/userGatewayClient.js';
-
 describe('Me Preset Set Handler', () => {
   const mockEditReply = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // Fully reset the callGatewayApi mock queue — the paid-user path now
-    // consumes only wallet (serial fetch), so leftover `.mockResolvedValueOnce`
-    // entries from prior tests would mis-mock later calls. `mockReset()`
-    // clears both call history and the queue.
-    vi.mocked(callGatewayApi).mockReset();
+    stub.listWalletKeys.mockReset();
+    stub.listUserLlmConfigs.mockReset();
+    stub.setModelOverride.mockReset();
   });
 
   function createMockContext(personalityId: string, presetId: string) {
@@ -79,43 +76,33 @@ describe('Me Preset Set Handler', () => {
       expect(embedData.description).toContain('Guest Mode');
       expect(embedData.description).toContain('/settings apikey set');
 
-      // Should not call any API
-      expect(callGatewayApi).not.toHaveBeenCalled();
+      // Should not call the gateway
+      expect(stub.listWalletKeys).not.toHaveBeenCalled();
+      expect(stub.setModelOverride).not.toHaveBeenCalled();
     });
 
-    it('should successfully set model override', async () => {
-      // Paid user: serial fetch skips the configs call, so only wallet + set-override mocks queued.
-      vi.mocked(callGatewayApi)
-        .mockResolvedValueOnce({
-          ok: true,
-          data: { keys: [{ provider: 'openrouter', isActive: true }] },
-        }) // wallet
-        .mockResolvedValueOnce({
-          ok: true,
-          data: {
-            override: {
-              personalityId: 'personality-1',
-              personalityName: 'Test Bot',
-              configId: 'config-1',
-              configName: 'Fast Claude',
-            },
+    it('should successfully set model override (paid user, short-circuits config fetch)', async () => {
+      stub.listWalletKeys.mockResolvedValue(
+        makeOk({ keys: [{ provider: 'openrouter', isActive: true }] })
+      );
+      stub.setModelOverride.mockResolvedValue(
+        makeOk({
+          override: {
+            personalityId: 'personality-1',
+            personalityName: 'Test Bot',
+            configId: 'config-1',
+            configName: 'Fast Claude',
           },
-        });
+        })
+      );
 
       await handleSet(createMockContext('personality-1', 'config-1'));
 
-      // Verify set override API call
-      expect(callGatewayApi).toHaveBeenCalledWith('/user/model-override', {
-        method: 'PUT',
-        user: {
-          discordId: 'user-123',
-          username: 'testuser',
-          displayName: 'testuser',
-        },
-        body: { personalityId: 'personality-1', configId: 'config-1' },
+      expect(stub.setModelOverride).toHaveBeenCalledWith({
+        personalityId: 'personality-1',
+        configId: 'config-1',
       });
 
-      // Verify success embed
       const embedCall = mockEditReply.mock.calls[0][0] as { embeds: EmbedBuilder[] };
       const embed = embedCall.embeds[0];
       const embedData = embed.toJSON();
@@ -124,34 +111,28 @@ describe('Me Preset Set Handler', () => {
       expect(embedData.description).toContain('Test Bot');
       expect(embedData.description).toContain('Fast Claude');
 
-      // Guard against accidental revert to Promise.all in guestModeValidation:
-      // paid path should short-circuit after wallet, so only wallet + the
-      // set-override PUT should fire (2 calls total, not 3).
-      expect(callGatewayApi).toHaveBeenCalledTimes(2);
+      // Paid path: wallet check short-circuits, configs not fetched
+      expect(stub.listUserLlmConfigs).not.toHaveBeenCalled();
     });
 
     it('should block guest mode users from using premium models', async () => {
-      vi.mocked(callGatewayApi)
-        .mockResolvedValueOnce({ ok: true, data: { keys: [] } }) // wallet - no active keys = guest mode
-        .mockResolvedValueOnce({
-          ok: true,
-          data: {
-            configs: [
-              {
-                id: 'premium-config',
-                name: 'Premium Config',
-                model: 'anthropic/claude-sonnet-4', // Not a free model
-              },
-            ],
-          },
-        }); // configs
+      stub.listWalletKeys.mockResolvedValue(makeOk({ keys: [] }));
+      stub.listUserLlmConfigs.mockResolvedValue(
+        makeOk({
+          configs: [
+            {
+              id: 'premium-config',
+              name: 'Premium Config',
+              model: 'anthropic/claude-sonnet-4', // Not a free model
+            },
+          ],
+        })
+      );
 
       await handleSet(createMockContext('personality-1', 'premium-config'));
 
-      // Should NOT call the set override API
-      expect(callGatewayApi).toHaveBeenCalledTimes(2); // Only wallet and configs
+      expect(stub.setModelOverride).not.toHaveBeenCalled();
 
-      // Should show error embed
       const embedCall = mockEditReply.mock.calls[0][0] as { embeds: EmbedBuilder[] };
       const embed = embedCall.embeds[0];
       const embedData = embed.toJSON();
@@ -162,58 +143,42 @@ describe('Me Preset Set Handler', () => {
     });
 
     it('should allow guest mode users to use free models', async () => {
-      vi.mocked(callGatewayApi)
-        .mockResolvedValueOnce({ ok: true, data: { keys: [] } }) // wallet - guest mode
-        .mockResolvedValueOnce({
-          ok: true,
-          data: {
-            configs: [
-              {
-                id: 'free-config',
-                name: 'Free Config',
-                model: 'google/gemini-2.0-flash-exp:free', // Free model
-              },
-            ],
-          },
-        }) // configs
-        .mockResolvedValueOnce({
-          ok: true,
-          data: {
-            override: {
-              personalityId: 'personality-1',
-              personalityName: 'Test Bot',
-              configId: 'free-config',
-              configName: 'Free Config',
+      stub.listWalletKeys.mockResolvedValue(makeOk({ keys: [] }));
+      stub.listUserLlmConfigs.mockResolvedValue(
+        makeOk({
+          configs: [
+            {
+              id: 'free-config',
+              name: 'Free Config',
+              model: 'google/gemini-2.0-flash-exp:free',
             },
+          ],
+        })
+      );
+      stub.setModelOverride.mockResolvedValue(
+        makeOk({
+          override: {
+            personalityId: 'personality-1',
+            personalityName: 'Test Bot',
+            configId: 'free-config',
+            configName: 'Free Config',
           },
-        });
+        })
+      );
 
       await handleSet(createMockContext('personality-1', 'free-config'));
 
-      // Should call the set override API
-      expect(callGatewayApi).toHaveBeenCalledWith('/user/model-override', {
-        method: 'PUT',
-        user: {
-          discordId: 'user-123',
-          username: 'testuser',
-          displayName: 'testuser',
-        },
-        body: { personalityId: 'personality-1', configId: 'free-config' },
+      expect(stub.setModelOverride).toHaveBeenCalledWith({
+        personalityId: 'personality-1',
+        configId: 'free-config',
       });
     });
 
     it('should handle API error when setting override', async () => {
-      // Paid user (has active keys): serial fetch skips configs. Wallet + set-override only.
-      vi.mocked(callGatewayApi)
-        .mockResolvedValueOnce({
-          ok: true,
-          data: { keys: [{ provider: 'openrouter', isActive: true }] },
-        })
-        .mockResolvedValueOnce({
-          ok: false,
-          status: 404,
-          error: 'Personality not found',
-        });
+      stub.listWalletKeys.mockResolvedValue(
+        makeOk({ keys: [{ provider: 'openrouter', isActive: true }] })
+      );
+      stub.setModelOverride.mockResolvedValue(makeErr(404, 'Personality not found'));
 
       await handleSet(createMockContext('personality-1', 'config-1'));
 
@@ -223,7 +188,7 @@ describe('Me Preset Set Handler', () => {
     });
 
     it('should handle generic errors', async () => {
-      vi.mocked(callGatewayApi).mockRejectedValue(new Error('Network error'));
+      stub.listWalletKeys.mockRejectedValue(new Error('Network error'));
 
       await handleSet(createMockContext('personality-1', 'config-1'));
 
@@ -233,28 +198,24 @@ describe('Me Preset Set Handler', () => {
     });
 
     it('should handle wallet having inactive keys as guest mode', async () => {
-      vi.mocked(callGatewayApi)
-        .mockResolvedValueOnce({
-          ok: true,
-          data: { keys: [{ provider: 'openrouter', isActive: false }] }, // Key exists but inactive
+      stub.listWalletKeys.mockResolvedValue(
+        makeOk({ keys: [{ provider: 'openrouter', isActive: false }] })
+      );
+      stub.listUserLlmConfigs.mockResolvedValue(
+        makeOk({
+          configs: [
+            {
+              id: 'premium-config',
+              name: 'Premium Config',
+              model: 'anthropic/claude-sonnet-4',
+              provider: 'openrouter',
+            },
+          ],
         })
-        .mockResolvedValueOnce({
-          ok: true,
-          data: {
-            configs: [
-              {
-                id: 'premium-config',
-                name: 'Premium Config',
-                model: 'anthropic/claude-sonnet-4',
-                provider: 'openrouter',
-              },
-            ],
-          },
-        });
+      );
 
       await handleSet(createMockContext('personality-1', 'premium-config'));
 
-      // Should block premium model (user is in guest mode despite having key)
       const embedCall = mockEditReply.mock.calls[0][0] as { embeds: EmbedBuilder[] };
       const embed = embedCall.embeds[0];
       const embedData = embed.toJSON();
@@ -262,33 +223,29 @@ describe('Me Preset Set Handler', () => {
       expect(embedData.title).toContain('Premium Model Not Available');
     });
 
-    it('should handle wallet API failure gracefully', async () => {
-      vi.mocked(callGatewayApi)
-        .mockResolvedValueOnce({ ok: false, status: 500, error: 'Internal error' }) // wallet fails
-        .mockResolvedValueOnce({ ok: true, data: { configs: [] } }) // configs
-        .mockResolvedValueOnce({
-          ok: true,
-          data: {
-            override: {
-              personalityId: 'personality-1',
-              personalityName: 'Test Bot',
-              configId: 'config-1',
-              configName: 'Test Config',
-            },
+    it('should handle wallet API failure gracefully (fail-open)', async () => {
+      stub.listWalletKeys.mockResolvedValue(makeErr(500, 'Internal error'));
+      stub.setModelOverride.mockResolvedValue(
+        makeOk({
+          override: {
+            personalityId: 'personality-1',
+            personalityName: 'Test Bot',
+            configId: 'config-1',
+            configName: 'Test Config',
           },
-        });
+        })
+      );
 
       await handleSet(createMockContext('personality-1', 'config-1'));
 
-      // When wallet check fails, hasActiveWallet will be false (treated as guest mode)
-      // But since config check also needs to find the config, it will proceed
+      // When wallet check fails, we fail-open — setModelOverride is invoked.
       expect(mockEditReply).toHaveBeenCalled();
     });
 
     it('rejects the autocomplete-error sentinel before calling the gateway', async () => {
       await handleSet(createMockContext('__autocomplete_error__', 'config-1'));
 
-      expect(callGatewayApi).not.toHaveBeenCalled();
+      expect(stub.setModelOverride).not.toHaveBeenCalled();
       expect(mockEditReply).toHaveBeenCalledWith({
         content: expect.stringContaining('Autocomplete was unavailable'),
       });

--- a/services/bot-client/src/commands/settings/preset/set.ts
+++ b/services/bot-client/src/commands/settings/preset/set.ts
@@ -10,19 +10,10 @@ import {
   AUTOCOMPLETE_UNAVAILABLE_MESSAGE,
   isAutocompleteErrorSentinel,
 } from '../../../utils/apiCheck.js';
-import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
+import { clientsFor } from '../../../utils/gatewayClients.js';
 import { handleUnlockModelsUpsell, checkGuestModePremiumAccess } from './guestModeValidation.js';
 
 const logger = createLogger('settings-preset-set');
-
-interface SetResponse {
-  override: {
-    personalityId: string;
-    personalityName: string;
-    configId: string | null;
-    configName: string | null;
-  };
-}
 
 /**
  * Handle /settings preset set
@@ -43,18 +34,14 @@ export async function handleSet(context: DeferredCommandContext): Promise<void> 
   }
 
   try {
-    const user = toGatewayUser(context.user);
-    const outcome = await checkGuestModePremiumAccess(context, configId, user);
+    const { userClient } = clientsFor(context.interaction);
+    const outcome = await checkGuestModePremiumAccess(context, configId, userClient);
     if (outcome.blocked) {
       return;
     }
     const { reason } = outcome;
 
-    const result = await callGatewayApi<SetResponse>('/user/model-override', {
-      method: 'PUT',
-      user,
-      body: { personalityId, configId },
-    });
+    const result = await userClient.setModelOverride({ personalityId, configId });
 
     if (!result.ok) {
       logger.warn(

--- a/services/bot-client/src/commands/settings/timezone/get.test.ts
+++ b/services/bot-client/src/commands/settings/timezone/get.test.ts
@@ -8,6 +8,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { handleTimezoneGet } from './get.js';
 import { mockGetTimezoneResponse } from '@tzurot/common-types';
+import { makeOk, makeErr } from '../../../test/gatewayClientStubs.js';
+import type { UserClient } from '@tzurot/common-types';
 
 // Mock common-types
 vi.mock('@tzurot/common-types', async importOriginal => {
@@ -23,19 +25,13 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
-// Mock userGatewayClient
-// Note: Tests use objectContaining for API call assertions to focus on the essential
-// userId parameter while ignoring implementation details like timeout values.
-const mockCallGatewayApi = vi.fn();
-vi.mock('../../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
-    '../../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  };
-});
+const stub = {
+  getTimezone: vi.fn(),
+};
+
+vi.mock('../../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
+}));
 
 // Create mock EmbedBuilder-like objects
 function createMockEmbed(title: string, description?: string) {
@@ -74,6 +70,7 @@ describe('handleTimezoneGet', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    stub.getTimezone.mockReset();
     mockCreateInfoEmbed.mockImplementation((title: string, description?: string) =>
       createMockEmbed(title, description)
     );
@@ -82,24 +79,19 @@ describe('handleTimezoneGet', () => {
   function createMockContext() {
     return {
       user: { id: '123456789', username: 'testuser' },
+      interaction: {} as never,
       editReply: mockEditReply,
     } as unknown as Parameters<typeof handleTimezoneGet>[0];
   }
 
   it('should get timezone successfully', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: mockGetTimezoneResponse({ timezone: 'America/New_York', isDefault: false }),
-    });
+    stub.getTimezone.mockResolvedValue(
+      makeOk(mockGetTimezoneResponse({ timezone: 'America/New_York', isDefault: false }))
+    );
 
     await handleTimezoneGet(createMockContext());
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith(
-      '/user/timezone',
-      expect.objectContaining({
-        user: { discordId: '123456789', username: 'testuser', displayName: 'testuser' },
-      })
-    );
+    expect(stub.getTimezone).toHaveBeenCalled();
     expect(mockEditReply).toHaveBeenCalledWith({
       embeds: [
         expect.objectContaining({ data: expect.objectContaining({ title: '⏰ Your Timezone' }) }),
@@ -108,10 +100,9 @@ describe('handleTimezoneGet', () => {
   });
 
   it('should show default timezone message when using default', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: mockGetTimezoneResponse({ timezone: 'UTC', isDefault: true }),
-    });
+    stub.getTimezone.mockResolvedValue(
+      makeOk(mockGetTimezoneResponse({ timezone: 'UTC', isDefault: true }))
+    );
 
     await handleTimezoneGet(createMockContext());
 
@@ -127,11 +118,7 @@ describe('handleTimezoneGet', () => {
   });
 
   it('should handle API error', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: false,
-      status: 500,
-      error: 'Server error',
-    });
+    stub.getTimezone.mockResolvedValue(makeErr(500, 'Server error'));
 
     await handleTimezoneGet(createMockContext());
 
@@ -141,7 +128,7 @@ describe('handleTimezoneGet', () => {
   });
 
   it('should handle exceptions', async () => {
-    mockCallGatewayApi.mockRejectedValue(new Error('Network error'));
+    stub.getTimezone.mockRejectedValue(new Error('Network error'));
 
     await handleTimezoneGet(createMockContext());
 

--- a/services/bot-client/src/commands/settings/timezone/get.ts
+++ b/services/bot-client/src/commands/settings/timezone/get.ts
@@ -5,13 +5,9 @@
 
 import { createLogger, TIMEZONE_DISCORD_CHOICES } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import {
-  callGatewayApi,
-  GATEWAY_TIMEOUTS,
-  toGatewayUser,
-} from '../../../utils/userGatewayClient.js';
+import { clientsFor } from '../../../utils/gatewayClients.js';
 import { createInfoEmbed } from '../../../utils/commandHelpers.js';
-import { getCurrentTimeInTimezone, type TimezoneResponse } from './utils.js';
+import { getCurrentTimeInTimezone } from './utils.js';
 
 const logger = createLogger('timezone-get');
 
@@ -22,10 +18,8 @@ export async function handleTimezoneGet(context: DeferredCommandContext): Promis
   const userId = context.user.id;
 
   try {
-    const result = await callGatewayApi<TimezoneResponse>('/user/timezone', {
-      user: toGatewayUser(context.user),
-      timeout: GATEWAY_TIMEOUTS.DEFERRED,
-    });
+    const { userClient } = clientsFor(context.interaction);
+    const result = await userClient.getTimezone();
 
     if (!result.ok) {
       logger.warn({ userId, status: result.status }, 'Failed to get timezone');

--- a/services/bot-client/src/commands/settings/timezone/set.test.ts
+++ b/services/bot-client/src/commands/settings/timezone/set.test.ts
@@ -8,6 +8,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { handleTimezoneSet } from './set.js';
 import { mockSetTimezoneResponse } from '@tzurot/common-types';
+import { makeOk, makeErr } from '../../../test/gatewayClientStubs.js';
+import type { UserClient } from '@tzurot/common-types';
 
 // Mock common-types
 vi.mock('@tzurot/common-types', async importOriginal => {
@@ -23,17 +25,13 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
-// Mock userGatewayClient
-const mockCallGatewayApi = vi.fn();
-vi.mock('../../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../../utils/userGatewayClient.js')>(
-    '../../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: (...args: unknown[]) => mockCallGatewayApi(...args),
-  };
-});
+const stub = {
+  setTimezone: vi.fn(),
+};
+
+vi.mock('../../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
+}));
 
 // Create mock EmbedBuilder-like objects
 function createMockEmbed(title: string, description?: string) {
@@ -71,6 +69,7 @@ describe('handleTimezoneSet', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    stub.setTimezone.mockReset();
     mockCreateSuccessEmbed.mockImplementation((title: string, description: string) =>
       createMockEmbed(title, description)
     );
@@ -92,22 +91,13 @@ describe('handleTimezoneSet', () => {
   }
 
   it('should set timezone successfully', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: true,
-      data: mockSetTimezoneResponse({ timezone: 'America/New_York' }),
-    });
+    stub.setTimezone.mockResolvedValue(
+      makeOk(mockSetTimezoneResponse({ timezone: 'America/New_York' }))
+    );
 
     await handleTimezoneSet(createMockContext({ timezone: 'America/New_York' }));
 
-    expect(mockCallGatewayApi).toHaveBeenCalledWith('/user/timezone', {
-      method: 'PUT',
-      user: {
-        discordId: '123456789',
-        username: 'testuser',
-        displayName: 'testuser',
-      },
-      body: { timezone: 'America/New_York' },
-    });
+    expect(stub.setTimezone).toHaveBeenCalledWith({ timezone: 'America/New_York' });
     expect(mockEditReply).toHaveBeenCalledWith({
       embeds: [
         expect.objectContaining({
@@ -118,11 +108,7 @@ describe('handleTimezoneSet', () => {
   });
 
   it('should handle API error', async () => {
-    mockCallGatewayApi.mockResolvedValue({
-      ok: false,
-      status: 500,
-      error: 'Server error',
-    });
+    stub.setTimezone.mockResolvedValue(makeErr(500, 'Server error'));
 
     await handleTimezoneSet(createMockContext());
 
@@ -132,7 +118,7 @@ describe('handleTimezoneSet', () => {
   });
 
   it('should handle exceptions', async () => {
-    mockCallGatewayApi.mockRejectedValue(new Error('Network error'));
+    stub.setTimezone.mockRejectedValue(new Error('Network error'));
 
     await handleTimezoneSet(createMockContext());
 

--- a/services/bot-client/src/commands/settings/timezone/set.ts
+++ b/services/bot-client/src/commands/settings/timezone/set.ts
@@ -9,9 +9,9 @@ import {
   settingsTimezoneSetOptions,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
-import { callGatewayApi, toGatewayUser } from '../../../utils/userGatewayClient.js';
+import { clientsFor } from '../../../utils/gatewayClients.js';
 import { createSuccessEmbed } from '../../../utils/commandHelpers.js';
-import { getCurrentTimeInTimezone, type TimezoneResponse } from './utils.js';
+import { getCurrentTimeInTimezone } from './utils.js';
 
 const logger = createLogger('timezone-set');
 
@@ -24,11 +24,8 @@ export async function handleTimezoneSet(context: DeferredCommandContext): Promis
   const timezone = options.timezone();
 
   try {
-    const result = await callGatewayApi<TimezoneResponse>('/user/timezone', {
-      method: 'PUT',
-      user: toGatewayUser(context.user),
-      body: { timezone },
-    });
+    const { userClient } = clientsFor(context.interaction);
+    const result = await userClient.setTimezone({ timezone });
 
     if (!result.ok) {
       logger.warn({ userId, timezone, status: result.status }, 'Failed to set timezone');

--- a/services/bot-client/src/commands/settings/timezone/utils.ts
+++ b/services/bot-client/src/commands/settings/timezone/utils.ts
@@ -6,15 +6,6 @@
 import { formatFullDateTime } from '@tzurot/common-types';
 
 /**
- * Response type for timezone API calls
- */
-export interface TimezoneResponse {
-  timezone: string;
-  label?: string;
-  isDefault?: boolean;
-}
-
-/**
  * Get the current time in a timezone using centralized formatting
  */
 export function getCurrentTimeInTimezone(timezone: string): string {

--- a/services/bot-client/src/processors/DMSessionProcessor.test.ts
+++ b/services/bot-client/src/processors/DMSessionProcessor.test.ts
@@ -30,6 +30,16 @@ vi.mock('../utils/nsfwVerification.js', () => ({
   NSFW_VERIFICATION_CHECK_FAILED_MESSAGE: "⚠️ Couldn't verify your age status right now.",
 }));
 
+// The processor mints a UserClient via `clientsForUser(message.author)` to pass
+// into checkNsfwVerification. The real factory needs INTERNAL_SERVICE_SECRET
+// from startup config; the test stubs it with a sentinel.
+vi.mock('../utils/gatewayClients.js', () => ({
+  clientsForUser: vi.fn(() => ({
+    userClient: { actor: 'mock-user' },
+    ownerClient: { actor: 'mock-owner' },
+  })),
+}));
+
 import { VoiceMessageProcessor } from './VoiceMessageProcessor.js';
 import {
   isDMChannel,

--- a/services/bot-client/src/processors/DMSessionProcessor.ts
+++ b/services/bot-client/src/processors/DMSessionProcessor.ts
@@ -26,7 +26,7 @@ import {
   checkNsfwVerification,
   NSFW_VERIFICATION_CHECK_FAILED_MESSAGE,
 } from '../utils/nsfwVerification.js';
-import { toGatewayUser } from '../utils/userGatewayClient.js';
+import { clientsForUser } from '../utils/gatewayClients.js';
 import { getEffectiveContent } from '../utils/messageTypeUtils.js';
 import type { MultiTagPersistence } from '../services/MultiTagPersistence.js';
 
@@ -72,7 +72,7 @@ export class DMSessionProcessor implements IMessageProcessor {
     // Tri-state: verified / unverified / check-failed. Fail-closed on
     // check-failed with a distinct "try again" message so a transient gateway
     // blip doesn't re-onboard previously-verified users.
-    const check = await checkNsfwVerification(toGatewayUser(message.author));
+    const check = await checkNsfwVerification(clientsForUser(message.author).userClient);
     if (check.kind === 'error') {
       logger.warn({ userId, error: check.error }, 'NSFW check failed — surfacing retry message');
       try {

--- a/services/bot-client/src/services/StartupDMPrewarmer.test.ts
+++ b/services/bot-client/src/services/StartupDMPrewarmer.test.ts
@@ -3,9 +3,9 @@ import type { Client, User } from 'discord.js';
 import { StartupDMPrewarmer } from './StartupDMPrewarmer.js';
 import type { DMCacheWarmer } from './DMCacheWarmer.js';
 
-const mockAdminFetch = vi.fn();
-vi.mock('../utils/adminApiClient.js', () => ({
-  adminFetch: (...args: unknown[]) => mockAdminFetch(...args),
+const mockRecentUsers = vi.fn();
+vi.mock('../utils/gatewayClients.js', () => ({
+  getServiceClient: () => ({ recentUsers: mockRecentUsers }),
 }));
 
 vi.mock('@tzurot/common-types', async () => {
@@ -16,12 +16,12 @@ vi.mock('@tzurot/common-types', async () => {
   };
 });
 
-function mockJsonResponse(body: unknown, ok = true, status = 200): Response {
-  return {
-    ok,
-    status,
-    json: () => Promise.resolve(body),
-  } as unknown as Response;
+function okResult(body: { discordIds: string[]; sinceDays: number }) {
+  return { ok: true, data: body };
+}
+
+function errResult(status: number) {
+  return { ok: false, error: 'fail', status };
 }
 
 function mockUser(id: string): User {
@@ -36,7 +36,7 @@ describe('StartupDMPrewarmer', () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
-    mockAdminFetch.mockReset();
+    mockRecentUsers.mockReset();
     mockClient = { users: { fetch: vi.fn() } };
     mockWarmer = { warm: vi.fn() };
     mockSleep = vi.fn<(ms: number) => Promise<void>>().mockResolvedValue(undefined);
@@ -52,8 +52,8 @@ describe('StartupDMPrewarmer', () => {
   });
 
   it('warms each user returned by the recent-users endpoint', async () => {
-    mockAdminFetch.mockResolvedValue(
-      mockJsonResponse({
+    mockRecentUsers.mockResolvedValue(
+      okResult({
         discordIds: ['111111111111111111', '222222222222222222'],
         sinceDays: 30,
       })
@@ -72,8 +72,8 @@ describe('StartupDMPrewarmer', () => {
   });
 
   it('rate-limits with 1000ms sleep between fetches (N-1 sleeps for N users)', async () => {
-    mockAdminFetch.mockResolvedValue(
-      mockJsonResponse({
+    mockRecentUsers.mockResolvedValue(
+      okResult({
         discordIds: ['111111111111111111', '222222222222222222', '333333333333333333'],
         sinceDays: 30,
       })
@@ -88,8 +88,8 @@ describe('StartupDMPrewarmer', () => {
   });
 
   it('does not sleep at all for a single-user list', async () => {
-    mockAdminFetch.mockResolvedValue(
-      mockJsonResponse({ discordIds: ['111111111111111111'], sinceDays: 30 })
+    mockRecentUsers.mockResolvedValue(
+      okResult({ discordIds: ['111111111111111111'], sinceDays: 30 })
     );
     mockClient.users.fetch.mockResolvedValue(mockUser('111111111111111111'));
 
@@ -100,8 +100,8 @@ describe('StartupDMPrewarmer', () => {
   });
 
   it('continues when a single user fetch fails (e.g. deleted account)', async () => {
-    mockAdminFetch.mockResolvedValue(
-      mockJsonResponse({
+    mockRecentUsers.mockResolvedValue(
+      okResult({
         discordIds: ['111111111111111111', '222222222222222222', '333333333333333333'],
         sinceDays: 30,
       })
@@ -118,61 +118,57 @@ describe('StartupDMPrewarmer', () => {
   });
 
   it('skips warming entirely when api-gateway fetch fails on every retry (network errors)', async () => {
-    mockAdminFetch.mockRejectedValue(new Error('connect ECONNREFUSED'));
+    mockRecentUsers.mockRejectedValue(new Error('connect ECONNREFUSED'));
 
     await prewarmer.run();
 
     expect(mockClient.users.fetch).not.toHaveBeenCalled();
     expect(mockWarmer.warm).not.toHaveBeenCalled();
     // 1 initial attempt + 3 retries = 4 total calls
-    expect(mockAdminFetch).toHaveBeenCalledTimes(4);
+    expect(mockRecentUsers).toHaveBeenCalledTimes(4);
   });
 
   it('skips warming entirely when api-gateway returns 404 on every retry (status-based exhaustion)', async () => {
     // Different code path from network-error exhaustion: this exercises the
     // status-based retry branch in fetchOnce() rather than the catch block.
-    mockAdminFetch.mockResolvedValue(mockJsonResponse({}, false, 404));
+    mockRecentUsers.mockResolvedValue(errResult(404));
 
     await prewarmer.run();
 
     expect(mockClient.users.fetch).not.toHaveBeenCalled();
     expect(mockWarmer.warm).not.toHaveBeenCalled();
-    expect(mockAdminFetch).toHaveBeenCalledTimes(4);
+    expect(mockRecentUsers).toHaveBeenCalledTimes(4);
     // Sleep called once per retry delay (3 retries → 3 sleeps; no sleep
     // before the initial attempt or after the final failure).
     expect(mockSleep).toHaveBeenCalledTimes(3);
   });
 
   it('retries on 404 and succeeds when api-gateway becomes ready', async () => {
-    // Simulates the empirical race observed on first dev deploy of PR #917:
+    // Simulates the empirical race observed on first dev deploy:
     // api-gateway routes weren't yet mounted when bot-client's ClientReady
     // fired, so the first call got 404. With retry-with-backoff, the second
     // call (after the api-gateway finishes startup) succeeds.
-    mockAdminFetch
-      .mockResolvedValueOnce(mockJsonResponse({}, false, 404))
-      .mockResolvedValueOnce(
-        mockJsonResponse({ discordIds: ['111111111111111111'], sinceDays: 30 })
-      );
+    mockRecentUsers
+      .mockResolvedValueOnce(errResult(404))
+      .mockResolvedValueOnce(okResult({ discordIds: ['111111111111111111'], sinceDays: 30 }));
     mockClient.users.fetch.mockResolvedValue(mockUser('111111111111111111'));
 
     await prewarmer.run();
 
-    expect(mockAdminFetch).toHaveBeenCalledTimes(2);
+    expect(mockRecentUsers).toHaveBeenCalledTimes(2);
     expect(mockWarmer.warm).toHaveBeenCalledTimes(1);
     expect(mockSleep).toHaveBeenCalledWith(5000); // first retry delay
   });
 
   it('retries on 5xx responses (gateway still starting)', async () => {
-    mockAdminFetch
-      .mockResolvedValueOnce(mockJsonResponse({}, false, 503))
-      .mockResolvedValueOnce(
-        mockJsonResponse({ discordIds: ['111111111111111111'], sinceDays: 30 })
-      );
+    mockRecentUsers
+      .mockResolvedValueOnce(errResult(503))
+      .mockResolvedValueOnce(okResult({ discordIds: ['111111111111111111'], sinceDays: 30 }));
     mockClient.users.fetch.mockResolvedValue(mockUser('111111111111111111'));
 
     await prewarmer.run();
 
-    expect(mockAdminFetch).toHaveBeenCalledTimes(2);
+    expect(mockRecentUsers).toHaveBeenCalledTimes(2);
     expect(mockWarmer.warm).toHaveBeenCalledTimes(1);
   });
 
@@ -181,19 +177,11 @@ describe('StartupDMPrewarmer', () => {
     [403, 'forbidden'],
     [400, 'bad request'],
   ])("does NOT retry on %d (%s — won't fix itself)", async (status: number) => {
-    mockAdminFetch.mockResolvedValue(mockJsonResponse({}, false, status));
+    mockRecentUsers.mockResolvedValue(errResult(status));
 
     await prewarmer.run();
 
-    expect(mockAdminFetch).toHaveBeenCalledTimes(1);
-    expect(mockClient.users.fetch).not.toHaveBeenCalled();
-  });
-
-  it('skips warming when api-gateway returns malformed body', async () => {
-    mockAdminFetch.mockResolvedValue(mockJsonResponse({ wrong: 'shape' }));
-
-    await prewarmer.run();
-
+    expect(mockRecentUsers).toHaveBeenCalledTimes(1);
     expect(mockClient.users.fetch).not.toHaveBeenCalled();
   });
 
@@ -213,7 +201,7 @@ describe('StartupDMPrewarmer', () => {
   });
 
   it('returns silently when the recent-users list is empty', async () => {
-    mockAdminFetch.mockResolvedValue(mockJsonResponse({ discordIds: [], sinceDays: 30 }));
+    mockRecentUsers.mockResolvedValue(okResult({ discordIds: [], sinceDays: 30 }));
 
     await prewarmer.run();
 
@@ -222,10 +210,10 @@ describe('StartupDMPrewarmer', () => {
   });
 
   it('calls the recent-users endpoint with sinceDays=30', async () => {
-    mockAdminFetch.mockResolvedValue(mockJsonResponse({ discordIds: [], sinceDays: 30 }));
+    mockRecentUsers.mockResolvedValue(okResult({ discordIds: [], sinceDays: 30 }));
 
     await prewarmer.run();
 
-    expect(mockAdminFetch).toHaveBeenCalledWith('/internal/users/recent?sinceDays=30');
+    expect(mockRecentUsers).toHaveBeenCalledWith({ sinceDays: '30' });
   });
 });

--- a/services/bot-client/src/services/StartupDMPrewarmer.test.ts
+++ b/services/bot-client/src/services/StartupDMPrewarmer.test.ts
@@ -197,6 +197,21 @@ describe('StartupDMPrewarmer', () => {
     expect(mockClient.users.fetch).not.toHaveBeenCalled();
   });
 
+  it('skips warming when api-gateway returns malformed body (status 0, treated as fatal)', async () => {
+    // The typed client's outputSchema.safeParse failure returns
+    // { ok: false, status: 0 } — not 404, not >= 500, so fetchOnce()
+    // routes it through the fatal branch. Equivalent to the pre-migration
+    // RecentUsersResponseSchema.safeParse path that returned kind: 'fatal'.
+    // Guards against a future change where transport.ts starts throwing
+    // instead of returning {ok:false} on schema validation failure.
+    mockRecentUsers.mockResolvedValue({ ok: false, status: 0, error: 'schema failed' });
+
+    await prewarmer.run();
+
+    expect(mockClient.users.fetch).not.toHaveBeenCalled();
+    expect(mockRecentUsers).toHaveBeenCalledTimes(1); // no retry
+  });
+
   it('returns silently when the recent-users list is empty', async () => {
     mockAdminFetch.mockResolvedValue(mockJsonResponse({ discordIds: [], sinceDays: 30 }));
 

--- a/services/bot-client/src/services/StartupDMPrewarmer.ts
+++ b/services/bot-client/src/services/StartupDMPrewarmer.ts
@@ -23,8 +23,8 @@
  */
 
 import type { Client } from 'discord.js';
-import { createLogger, RecentUsersResponseSchema } from '@tzurot/common-types';
-import { adminFetch } from '../utils/adminApiClient.js';
+import { createLogger } from '@tzurot/common-types';
+import { getServiceClient } from '../utils/gatewayClients.js';
 import type { DMCacheWarmer } from './DMCacheWarmer.js';
 
 const logger = createLogger('StartupDMPrewarmer');
@@ -162,25 +162,17 @@ export class StartupDMPrewarmer {
     | { kind: 'fatal'; err: Error }
   > {
     try {
-      const response = await adminFetch(`/internal/users/recent?sinceDays=${SINCE_DAYS}`);
-      if (response.ok) {
-        const json: unknown = await response.json();
-        const parsed = RecentUsersResponseSchema.safeParse(json);
-        if (!parsed.success) {
-          return {
-            kind: 'fatal',
-            err: new Error(`Invalid recent-users response: ${parsed.error.message}`),
-          };
-        }
-        return { kind: 'success', ids: parsed.data.discordIds };
+      const result = await getServiceClient().recentUsers({ sinceDays: String(SINCE_DAYS) });
+      if (result.ok) {
+        return { kind: 'success', ids: result.data.discordIds };
       }
-      if (response.status === 404 || response.status >= 500) {
+      if (result.status === 404 || result.status >= 500) {
         return {
           kind: 'retry',
-          err: new Error(`api-gateway returned ${response.status} (transient)`),
+          err: new Error(`api-gateway returned ${result.status} (transient)`),
         };
       }
-      return { kind: 'fatal', err: new Error(`api-gateway returned ${response.status}`) };
+      return { kind: 'fatal', err: new Error(`api-gateway returned ${result.status}`) };
     } catch (err) {
       // Network errors (ECONNREFUSED, DNS failures, etc.) are retry-able.
       return { kind: 'retry', err: err instanceof Error ? err : new Error(String(err)) };

--- a/services/bot-client/src/services/character/PersonalityChatManager.test.ts
+++ b/services/bot-client/src/services/character/PersonalityChatManager.test.ts
@@ -19,30 +19,31 @@ vi.mock('../../utils/nsfwVerification.js', () => ({
     .mockResolvedValue({ kind: 'ok', value: { nsfwVerified: true, nsfwVerifiedAt: null } }),
 }));
 
-// Mock the gateway-config-resolve API; defaults to LlmConfig defaults
-vi.mock('../../utils/userGatewayClient.js', async () => {
-  const actual = await vi.importActual<typeof import('../../utils/userGatewayClient.js')>(
-    '../../utils/userGatewayClient.js'
-  );
-  return {
-    ...actual,
-    callGatewayApi: vi.fn().mockResolvedValue({
-      ok: true,
-      data: {
-        config: {
-          model: 'test-model',
-          provider: 'openrouter',
-          maxMessages: 50,
-          maxAge: null,
-          maxImages: 10,
-        },
-        source: 'personality',
-      },
-    }),
-  };
+// Stub the resolveUserLlmConfig method on userClient; defaults to LlmConfig defaults.
+const mockResolveUserLlmConfig = vi.fn().mockResolvedValue({
+  ok: true,
+  data: {
+    config: {
+      model: 'test-model',
+      provider: 'openrouter',
+      maxMessages: 50,
+      maxAge: null,
+      maxImages: 10,
+    },
+    source: 'personality',
+  },
 });
 
-import { callGatewayApi } from '../../utils/userGatewayClient.js';
+vi.mock('../../utils/gatewayClients.js', () => ({
+  clientsForUser: vi.fn(() => ({
+    userClient: {
+      actor: 'user-123',
+      resolveUserLlmConfig: mockResolveUserLlmConfig,
+    },
+    ownerClient: { actor: 'mock-owner' },
+  })),
+}));
+
 import * as nsfwVerification from '../../utils/nsfwVerification.js';
 
 describe('PersonalityChatManager', () => {
@@ -220,7 +221,7 @@ describe('PersonalityChatManager', () => {
 
   describe('submitChatJob - config resolve fallback', () => {
     it('falls back to personality defaults on resolve failure', async () => {
-      vi.mocked(callGatewayApi).mockResolvedValueOnce({
+      mockResolveUserLlmConfig.mockResolvedValueOnce({
         ok: false,
         error: 'resolve unavailable',
       } as never);
@@ -279,7 +280,7 @@ describe('PersonalityChatManager', () => {
     });
 
     it('prefers cascade overrides over LlmConfig values', async () => {
-      vi.mocked(callGatewayApi).mockResolvedValueOnce({
+      mockResolveUserLlmConfig.mockResolvedValueOnce({
         ok: true,
         data: {
           config: { model: 'm', maxMessages: 50, maxAge: null, maxImages: 10 },
@@ -324,7 +325,7 @@ describe('PersonalityChatManager', () => {
     });
 
     it('threads crossChannelHistoryEnabled through from cascade override', async () => {
-      vi.mocked(callGatewayApi).mockResolvedValueOnce({
+      mockResolveUserLlmConfig.mockResolvedValueOnce({
         ok: true,
         data: {
           config: { model: 'm', maxMessages: 50, maxAge: null, maxImages: 10 },
@@ -364,11 +365,8 @@ describe('PersonalityChatManager', () => {
         content: 'Hi',
       });
 
-      expect(callGatewayApi).toHaveBeenCalledWith(
-        '/user/llm-config/resolve',
-        expect.objectContaining({
-          body: expect.objectContaining({ channelId: 'channel-123' }),
-        })
+      expect(mockResolveUserLlmConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ channelId: 'channel-123' })
       );
     });
   });

--- a/services/bot-client/src/services/character/PersonalityChatManager.ts
+++ b/services/bot-client/src/services/character/PersonalityChatManager.ts
@@ -21,8 +21,9 @@ import type {
   SettingSource,
 } from '@tzurot/common-types';
 import { createLogger, isBotOwner, isTypingChannel, MESSAGE_LIMITS } from '@tzurot/common-types';
+import type { UserClient } from '@tzurot/common-types';
 import { GatewayClient } from '../../utils/GatewayClient.js';
-import { callGatewayApi, GATEWAY_TIMEOUTS, toGatewayUser } from '../../utils/userGatewayClient.js';
+import { clientsForUser } from '../../utils/gatewayClients.js';
 import { MessageContextBuilder } from '../MessageContextBuilder.js';
 import { ConversationPersistence } from '../ConversationPersistence.js';
 import { ReferenceEnrichmentService } from '../ReferenceEnrichmentService.js';
@@ -86,24 +87,19 @@ export class PersonalityChatManager {
    * blip degrades gracefully rather than failing the request.
    */
   private async resolveConfig(
-    user: ReturnType<typeof toGatewayUser>,
+    userClient: UserClient,
     personality: LoadedPersonality,
     channelId?: string
   ): Promise<ConfigResolutionResult> {
-    const result = await callGatewayApi<ConfigResolutionResult>('/user/llm-config/resolve', {
-      method: 'POST',
-      user,
-      body: {
-        personalityId: personality.id,
-        personalityConfig: personality,
-        channelId,
-      },
-      timeout: GATEWAY_TIMEOUTS.AUTOCOMPLETE,
+    const result = await userClient.resolveUserLlmConfig({
+      personalityId: personality.id,
+      personalityConfig: personality,
+      channelId,
     });
 
     if (!result.ok) {
       logger.warn(
-        { userId: user.discordId, personalityId: personality.id, error: result.error },
+        { userId: userClient.actor, personalityId: personality.id, error: result.error },
         'Failed to resolve config, using personality defaults'
       );
       return {
@@ -117,7 +113,10 @@ export class PersonalityChatManager {
       };
     }
 
-    return result.data;
+    // Cast bridges the runtime ConfigResolutionResult shape (declared on the
+    // server, in services/LlmConfigResolver.ts) and the schema's narrower
+    // declared response (only required fields, rest .passthrough()).
+    return result.data as unknown as ConfigResolutionResult;
   }
 
   /**
@@ -222,11 +221,8 @@ export class PersonalityChatManager {
       return { kind: 'denied', reason: 'unsupported-channel' };
     }
 
-    const resolvedConfig = await this.resolveConfig(
-      toGatewayUser(message.author),
-      personality,
-      message.channel.id
-    );
+    const { userClient } = clientsForUser(message.author);
+    const resolvedConfig = await this.resolveConfig(userClient, personality, message.channel.id);
 
     const extendedContextSettings = this.buildExtendedContextSettings(resolvedConfig);
 

--- a/services/bot-client/src/utils/dashboard/genericSelectMenuHandler.test.ts
+++ b/services/bot-client/src/utils/dashboard/genericSelectMenuHandler.test.ts
@@ -31,6 +31,16 @@ vi.mock('./messages.js', () => ({
   },
 }));
 
+// The handler calls `clientsFor(interaction)` to mint a typed userClient before
+// invoking fetchFn. The real factory pulls INTERNAL_SERVICE_SECRET from startup
+// config; tests stub it out with an empty sentinel.
+vi.mock('../gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({
+    userClient: { actor: 'user-123' },
+    ownerClient: { actor: 'owner' },
+  })),
+}));
+
 import { handleDashboardSectionSelect } from './genericSelectMenuHandler.js';
 import type { DashboardConfig } from './types.js';
 

--- a/services/bot-client/src/utils/dashboard/genericSelectMenuHandler.ts
+++ b/services/bot-client/src/utils/dashboard/genericSelectMenuHandler.ts
@@ -16,7 +16,8 @@
 
 import type { StringSelectMenuInteraction } from 'discord.js';
 import { MessageFlags } from 'discord.js';
-import { toGatewayUser, type GatewayUser } from '../userGatewayClient.js';
+import type { UserClient } from '@tzurot/common-types';
+import { clientsFor } from '../gatewayClients.js';
 import { parseDashboardCustomId, type DashboardConfig } from './types.js';
 import { fetchOrCreateSession } from './sessionHelpers.js';
 import { buildSectionModal } from './ModalFactory.js';
@@ -29,8 +30,8 @@ export interface GenericSelectMenuConfig<TFlat extends Record<string, unknown>, 
   entityType: string;
   /** Dashboard config defining the sections and modal fields */
   dashboardConfig: DashboardConfig<TFlat>;
-  /** Fetch the raw entity data from the API */
-  fetchFn: (entityId: string, user: GatewayUser) => Promise<TRaw | null>;
+  /** Fetch the raw entity data via the typed user client */
+  fetchFn: (entityId: string, userClient: UserClient) => Promise<TRaw | null>;
   /** Transform raw API data to the flattened session format */
   transformFn: (raw: TRaw) => TFlat;
   /** Entity name used in user-facing error messages (e.g., 'Persona', 'Preset') */
@@ -77,11 +78,12 @@ export async function handleDashboardSectionSelect<TFlat extends Record<string, 
   }
 
   // Fetch or create the session
+  const { userClient } = clientsFor(interaction);
   const result = await fetchOrCreateSession<TFlat, TRaw>({
     userId: interaction.user.id,
     entityType: config.entityType,
     entityId,
-    fetchFn: () => config.fetchFn(entityId, toGatewayUser(interaction.user)),
+    fetchFn: () => config.fetchFn(entityId, userClient),
     transformFn: config.transformFn,
     interaction,
   });

--- a/services/bot-client/src/utils/gatewayClients.test.ts
+++ b/services/bot-client/src/utils/gatewayClients.test.ts
@@ -28,7 +28,7 @@ vi.mock('../startup.js', () => ({
   getValidatedServiceSecret: () => 'test-service-secret',
 }));
 
-import { clientsFor } from './gatewayClients.js';
+import { clientsFor, clientsForUser, getServiceClient } from './gatewayClients.js';
 
 function makeUser(overrides: Record<string, unknown> = {}): DiscordUser {
   // Cast through unknown — DiscordUser has a template-literal `toString()`
@@ -99,6 +99,46 @@ describe('clientsFor', () => {
     }));
     const mod = await import('./gatewayClients.js');
     expect(() => mod.clientsFor(makeInteraction(makeUser()))).toThrow('GATEWAY_URL');
+    vi.doUnmock('@tzurot/common-types');
+    vi.doUnmock('../startup.js');
+  });
+});
+
+describe('clientsForUser', () => {
+  // Used by message-handler / startup contexts where there's no interaction
+  // to read `.user` from — caller passes the DiscordUser directly.
+  it('builds the same shape as clientsFor when given the same user', () => {
+    const user = makeUser({ id: 'u-direct', username: 'direct', globalName: 'Direct' });
+
+    const fromInteraction = clientsFor(makeInteraction(user));
+    const direct = clientsForUser(user);
+
+    expect(direct.actor).toBe(fromInteraction.actor);
+    expect(direct.user).toEqual(fromInteraction.user);
+    expect(direct.serviceClient).toBeInstanceOf(ServiceClient);
+    expect(direct.ownerClient).toBeInstanceOf(OwnerClient);
+    expect(direct.userClient).toBeInstanceOf(UserClient);
+  });
+});
+
+describe('getServiceClient', () => {
+  // No-actor factory for startup services (e.g., DM prewarmer) that hit
+  // `/api/internal/*` before any Discord interaction exists.
+  it('returns a ServiceClient without requiring a Discord user', () => {
+    expect(getServiceClient()).toBeInstanceOf(ServiceClient);
+  });
+
+  it('throws when GATEWAY_URL is missing (same defense as clientsFor)', async () => {
+    vi.resetModules();
+    vi.doMock('@tzurot/common-types', async () => {
+      const actual = await vi.importActual('@tzurot/common-types');
+      return { ...actual, getConfig: () => ({ GATEWAY_URL: '' }) };
+    });
+    vi.doMock('../startup.js', () => ({
+      getValidatedServiceSecret: () => 'test-service-secret',
+    }));
+    const mod = await import('./gatewayClients.js');
+    expect(() => mod.getServiceClient()).toThrow('GATEWAY_URL');
     vi.doUnmock('@tzurot/common-types');
     vi.doUnmock('../startup.js');
   });

--- a/services/bot-client/src/utils/gatewayClients.ts
+++ b/services/bot-client/src/utils/gatewayClients.ts
@@ -99,3 +99,25 @@ function buildClients(discordUser: DiscordUser): BoundGatewayClients {
 export function clientsFor(interaction: ClientCarryingInteraction): BoundGatewayClients {
   return buildClients(interaction.user);
 }
+
+/**
+ * Build the typed clients for a Discord user directly. Use this in
+ * non-interaction contexts (message handlers, processors, startup
+ * services) where there is no `interaction.user` to read from but the
+ * Discord user is available some other way.
+ */
+export function clientsForUser(discordUser: DiscordUser): BoundGatewayClients {
+  return buildClients(discordUser);
+}
+
+/**
+ * Build a `ServiceClient` for `/api/internal/*` calls that don't carry
+ * a Discord actor. Used by startup services (e.g., DM prewarmer) and
+ * other infrastructure paths where there's no user context yet.
+ */
+export function getServiceClient(): ServiceClient {
+  return new ServiceClient({
+    baseUrl: getGatewayBaseUrl(),
+    serviceSecret: getValidatedServiceSecret(),
+  });
+}

--- a/services/bot-client/src/utils/nsfwVerification.test.ts
+++ b/services/bot-client/src/utils/nsfwVerification.test.ts
@@ -4,7 +4,28 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ChannelType, GuildNSFWLevel } from 'discord.js';
-import {
+import { makeOk, makeErr, asUserClient } from '../test/gatewayClientStubs.js';
+
+interface UserClientStub {
+  actor: string;
+  getNsfwStatus: ReturnType<typeof vi.fn>;
+  verifyNsfw: ReturnType<typeof vi.fn>;
+}
+
+function createStub(discordId = 'user123'): UserClientStub {
+  return {
+    actor: discordId,
+    getNsfwStatus: vi.fn(),
+    verifyNsfw: vi.fn(),
+  };
+}
+
+const clientsForUserMock = vi.hoisted(() => vi.fn());
+vi.mock('./gatewayClients.js', () => ({
+  clientsForUser: clientsForUserMock,
+}));
+
+const {
   checkNsfwVerification,
   verifyNsfwUser,
   isNsfwChannel,
@@ -14,22 +35,15 @@ import {
   handleNsfwVerification,
   sendNsfwVerificationMessage,
   sendVerificationConfirmation,
-} from './nsfwVerification.js';
-import * as userGatewayClient from './userGatewayClient.js';
-
-// Mock the gateway client
-vi.mock('./userGatewayClient.js', async () => {
-  const actual =
-    await vi.importActual<typeof import('./userGatewayClient.js')>('./userGatewayClient.js');
-  return {
-    ...actual,
-    callGatewayApi: vi.fn(),
-  };
-});
+} = await import('./nsfwVerification.js');
 
 describe('NSFW Verification Utilities', () => {
+  let stub: UserClientStub;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    stub = createStub('user-123');
+    clientsForUserMock.mockReturnValue({ userClient: asUserClient(stub) });
   });
 
   afterEach(() => {
@@ -38,19 +52,14 @@ describe('NSFW Verification Utilities', () => {
 
   describe('checkNsfwVerification', () => {
     it('should return kind=ok with verified status when API returns success', async () => {
-      vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: {
+      stub.getNsfwStatus.mockResolvedValue(
+        makeOk({
           nsfwVerified: true,
           nsfwVerifiedAt: '2024-01-15T10:00:00.000Z',
-        },
-      });
+        })
+      );
 
-      const result = await checkNsfwVerification({
-        discordId: 'user123',
-        username: 'testuser',
-        displayName: 'testuser',
-      });
+      const result = await checkNsfwVerification(asUserClient(stub));
 
       expect(result).toEqual({
         kind: 'ok',
@@ -59,28 +68,13 @@ describe('NSFW Verification Utilities', () => {
           nsfwVerifiedAt: '2024-01-15T10:00:00.000Z',
         },
       });
-      expect(userGatewayClient.callGatewayApi).toHaveBeenCalledWith('/user/nsfw', {
-        method: 'GET',
-        user: {
-          discordId: 'user123',
-          username: 'testuser',
-          displayName: 'testuser',
-        },
-      });
+      expect(stub.getNsfwStatus).toHaveBeenCalled();
     });
 
     it('should return kind=error when API fails (distinguishable from unverified)', async () => {
-      vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue({
-        ok: false,
-        error: 'Server error',
-        status: 500,
-      });
+      stub.getNsfwStatus.mockResolvedValue(makeErr(500, 'Server error'));
 
-      const result = await checkNsfwVerification({
-        discordId: 'user123',
-        username: 'testuser',
-        displayName: 'testuser',
-      });
+      const result = await checkNsfwVerification(asUserClient(stub));
 
       expect(result).toEqual({
         kind: 'error',
@@ -91,48 +85,28 @@ describe('NSFW Verification Utilities', () => {
 
   describe('verifyNsfwUser', () => {
     it('should return verification response on success', async () => {
-      vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: {
+      stub.verifyNsfw.mockResolvedValue(
+        makeOk({
           nsfwVerified: true,
           nsfwVerifiedAt: '2024-01-15T10:00:00.000Z',
           alreadyVerified: false,
-        },
-      });
+        })
+      );
 
-      const result = await verifyNsfwUser({
-        discordId: 'user123',
-        username: 'testuser',
-        displayName: 'testuser',
-      });
+      const result = await verifyNsfwUser(asUserClient(stub));
 
       expect(result).toEqual({
         nsfwVerified: true,
         nsfwVerifiedAt: '2024-01-15T10:00:00.000Z',
         alreadyVerified: false,
       });
-      expect(userGatewayClient.callGatewayApi).toHaveBeenCalledWith('/user/nsfw/verify', {
-        method: 'POST',
-        user: {
-          discordId: 'user123',
-          username: 'testuser',
-          displayName: 'testuser',
-        },
-      });
+      expect(stub.verifyNsfw).toHaveBeenCalled();
     });
 
     it('should return null when API fails', async () => {
-      vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue({
-        ok: false,
-        error: 'Server error',
-        status: 500,
-      });
+      stub.verifyNsfw.mockResolvedValue(makeErr(500, 'Server error'));
 
-      const result = await verifyNsfwUser({
-        discordId: 'user123',
-        username: 'testuser',
-        displayName: 'testuser',
-      });
+      const result = await verifyNsfwUser(asUserClient(stub));
 
       expect(result).toBeNull();
     });
@@ -165,7 +139,6 @@ describe('NSFW Verification Utilities', () => {
       });
 
       it('should return false for channel in server with Explicit nsfwLevel (content filter, not age gate)', () => {
-        // GuildNSFWLevel.Explicit is about content filtering, NOT age restriction
         const channel = {
           type: ChannelType.GuildText,
           nsfw: false,
@@ -358,8 +331,8 @@ describe('NSFW Verification Utilities', () => {
       expect(NSFW_VERIFICATION_MESSAGE).toContain('@personality_name');
       expect(NSFW_VERIFICATION_MESSAGE).toContain('18+');
       // Both verification paths must be documented: personality ping AND direct bot ping.
-      // The direct-ping path was added 2026-04-16 when BotMentionProcessor started
-      // wiring handleNsfwVerification, making the bot-ping flow viable.
+      // The direct-ping path is what BotMentionProcessor's handleNsfwVerification wiring
+      // produces; the personality ping is the original webhook trigger.
       expect(NSFW_VERIFICATION_MESSAGE).toContain('ping me directly');
     });
   });
@@ -392,14 +365,13 @@ describe('NSFW Verification Utilities', () => {
 
   describe('handleNsfwVerification', () => {
     it('should auto-verify in NSFW channel and return allowed=true', async () => {
-      vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: {
+      stub.verifyNsfw.mockResolvedValue(
+        makeOk({
           nsfwVerified: true,
           nsfwVerifiedAt: '2024-01-15T10:00:00.000Z',
           alreadyVerified: false,
-        },
-      });
+        })
+      );
 
       const mockMessage = {
         author: { id: 'user-123', username: 'testuser' },
@@ -413,25 +385,17 @@ describe('NSFW Verification Utilities', () => {
       const result = await handleNsfwVerification(mockMessage);
 
       expect(result).toEqual({ allowed: true, wasNewVerification: true });
-      expect(userGatewayClient.callGatewayApi).toHaveBeenCalledWith('/user/nsfw/verify', {
-        method: 'POST',
-        user: {
-          discordId: 'user-123',
-          username: 'testuser',
-          displayName: 'testuser',
-        },
-      });
+      expect(stub.verifyNsfw).toHaveBeenCalled();
     });
 
     it('should return wasNewVerification=false when already verified', async () => {
-      vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: {
+      stub.verifyNsfw.mockResolvedValue(
+        makeOk({
           nsfwVerified: true,
           nsfwVerifiedAt: '2024-01-15T10:00:00.000Z',
           alreadyVerified: true,
-        },
-      });
+        })
+      );
 
       const mockMessage = {
         author: { id: 'user-123', username: 'testuser' },
@@ -448,13 +412,12 @@ describe('NSFW Verification Utilities', () => {
     });
 
     it('should allow verified user in non-NSFW channel', async () => {
-      vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: {
+      stub.getNsfwStatus.mockResolvedValue(
+        makeOk({
           nsfwVerified: true,
           nsfwVerifiedAt: '2024-01-15T10:00:00.000Z',
-        },
-      });
+        })
+      );
 
       const mockMessage = {
         author: { id: 'user-123', username: 'testuser' },
@@ -468,22 +431,11 @@ describe('NSFW Verification Utilities', () => {
       const result = await handleNsfwVerification(mockMessage);
 
       expect(result).toEqual({ allowed: true, wasNewVerification: false });
-      expect(userGatewayClient.callGatewayApi).toHaveBeenCalledWith('/user/nsfw', {
-        method: 'GET',
-        user: {
-          discordId: 'user-123',
-          username: 'testuser',
-          displayName: 'testuser',
-        },
-      });
+      expect(stub.getNsfwStatus).toHaveBeenCalled();
     });
 
     it('should block with distinct retry message when NSFW check fails (fail-closed)', async () => {
-      vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue({
-        ok: false,
-        error: 'Gateway timeout',
-        status: 504,
-      });
+      stub.getNsfwStatus.mockResolvedValue(makeErr(504, 'Gateway timeout'));
 
       const mockReply = { id: 'reply-retry', channelId: 'channel-789' };
       const mockMessage = {
@@ -505,13 +457,12 @@ describe('NSFW Verification Utilities', () => {
     });
 
     it('should block unverified user in non-NSFW channel and send message', async () => {
-      vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: {
+      stub.getNsfwStatus.mockResolvedValue(
+        makeOk({
           nsfwVerified: false,
           nsfwVerifiedAt: null,
-        },
-      });
+        })
+      );
 
       const mockReply = { id: 'reply-123', channelId: 'channel-456' };
       const mockMessage = {
@@ -530,14 +481,13 @@ describe('NSFW Verification Utilities', () => {
     });
 
     it('should auto-verify in thread with NSFW parent', async () => {
-      vi.mocked(userGatewayClient.callGatewayApi).mockResolvedValue({
-        ok: true,
-        data: {
+      stub.verifyNsfw.mockResolvedValue(
+        makeOk({
           nsfwVerified: true,
           nsfwVerifiedAt: '2024-01-15T10:00:00.000Z',
           alreadyVerified: false,
-        },
-      });
+        })
+      );
 
       const mockMessage = {
         author: { id: 'user-123', username: 'testuser' },

--- a/services/bot-client/src/utils/nsfwVerification.ts
+++ b/services/bot-client/src/utils/nsfwVerification.ts
@@ -13,8 +13,8 @@ import {
   type Message,
   type SendableChannels,
 } from 'discord.js';
-import { createLogger } from '@tzurot/common-types';
-import { callGatewayApi, toGatewayUser, type GatewayUser } from './userGatewayClient.js';
+import { createLogger, type UserClient } from '@tzurot/common-types';
+import { clientsForUser } from './gatewayClients.js';
 import { redis } from '../redis.js';
 import { storePendingVerificationMessage } from './pendingVerificationMessages.js';
 import { cleanupVerificationMessagesForUser } from '../services/VerificationCleanupService.js';
@@ -42,15 +42,12 @@ interface NsfwVerifyResponse {
  * transient gateway failure into `{ nsfwVerified: false }` would falsely
  * block previously-verified users from DMs during gateway outages.
  */
-export async function checkNsfwVerification(user: GatewayUser): Promise<ApiCheck<NsfwStatus>> {
-  const result = await callGatewayApi<NsfwStatus>('/user/nsfw', {
-    method: 'GET',
-    user,
-  });
+export async function checkNsfwVerification(userClient: UserClient): Promise<ApiCheck<NsfwStatus>> {
+  const result = await userClient.getNsfwStatus();
 
   if (!result.ok) {
     logger.warn(
-      { userId: user.discordId, error: result.error },
+      { userId: userClient.actor, error: result.error },
       'Failed to check verification status'
     );
     return { kind: 'error', error: result.error };
@@ -63,12 +60,9 @@ export async function checkNsfwVerification(user: GatewayUser): Promise<ApiCheck
  * Mark a user as NSFW verified
  * Called when user interacts with the bot in an NSFW Discord channel
  */
-export async function verifyNsfwUser(user: GatewayUser): Promise<NsfwVerifyResponse | null> {
-  const userId = user.discordId;
-  const result = await callGatewayApi<NsfwVerifyResponse>('/user/nsfw/verify', {
-    method: 'POST',
-    user,
-  });
+export async function verifyNsfwUser(userClient: UserClient): Promise<NsfwVerifyResponse | null> {
+  const userId = userClient.actor;
+  const result = await userClient.verifyNsfw();
 
   if (!result.ok) {
     logger.warn({ userId, error: result.error }, 'Failed to verify user');
@@ -230,19 +224,19 @@ export async function sendNsfwVerificationMessage(message: Message): Promise<voi
  */
 export async function handleNsfwVerification(message: Message): Promise<NsfwVerificationResult> {
   const userId = message.author.id;
-  const user = toGatewayUser(message.author);
+  const { userClient } = clientsForUser(message.author);
   const { channel } = message;
 
   // If in NSFW channel, auto-verify and continue
   if (isNsfwChannel(channel)) {
-    const verifyResult = await verifyNsfwUser(user);
+    const verifyResult = await verifyNsfwUser(userClient);
     // wasNewVerification is true if verify succeeded AND user wasn't already verified
     const wasNewVerification = verifyResult !== null && !verifyResult.alreadyVerified;
     return { allowed: true, wasNewVerification };
   }
 
   // For all other channels (DMs and non-NSFW guild channels), check verification
-  const check = await checkNsfwVerification(user);
+  const check = await checkNsfwVerification(userClient);
   if (check.kind === 'error') {
     // Fail-closed with a DISTINCT message: NSFW is a compliance gate, so we
     // can't let the user through, but we also shouldn't re-onboard a


### PR DESCRIPTION
## Summary

Second-to-last slice of the typed-client epic. Migrates the remaining bot-client callsites off `callGatewayApi` / `adminFetch` to the generated `userClient` / `ownerClient` / `serviceClient`. Production code is now fully on the typed clients; the legacy clients are deletable in PR-2l.

**Burn-down vs the PR-2j baseline:**
- `callGatewayApi`: 24 → 1 (one stub stays inside `userGatewayClient.ts` itself, which PR-2l deletes)
- `adminFetch`: 15 → 7 (remaining counts are all inside `adminApiClient.ts`)

## What's in this PR

Six phased commits, each test-green before the next:

1. **Phase 1 — `settings/timezone`** (`257d0e184`): two commands migrated to `userClient.getTimezone()` / `setTimezone()`. Manifest gains `timeoutMs: DEFERRED` on both.
2. **Phase 2 — `settings/apikey` + `settings/defaults`** (`257d0e184`, bundled with Phase 1): apikey CRUD goes through `listWalletKeys` / `setWalletKey` / `removeWalletKey` / `testWalletKey`. Defaults dashboard uses `resolveUserDefaults` / `updateUserDefaults`.
3. **Phase 3 — `settings/preset`** (`61a847833`): the modern preset entrypoint (7 source files) including the `guestModeValidation` helper that now reads `userClient.actor` directly.
4. **Phase 4 — `commands/preset`** (`c5fa218f4`, `0e9d7cf11`): the older preset domain (6 source files + 10 test files). User-scoped CRUD via `userClient.{get,create,update,delete}UserLlmConfig`; bot-owner global-preset CRUD via `ownerClient.{list,get,update}GlobalLlmConfig`. `genericSelectMenuHandler` updated to take a `UserClient` instead of a `GatewayUser`.
5. **Phase 5 — services + nsfwVerification** (`6f064448b`): three remaining production callsites:
   - `utils/nsfwVerification.ts` — `checkNsfwVerification` / `verifyNsfwUser` now take `UserClient` (`getNsfwStatus` / `verifyNsfw`).
   - `services/character/PersonalityChatManager.ts` — `resolveConfig` calls `userClient.resolveUserLlmConfig`.
   - `services/StartupDMPrewarmer.ts` — `serviceClient.recentUsers` via the new `getServiceClient()` factory.

   `utils/gatewayClients.ts` gains `clientsForUser(discordUser)` (message-handler contexts) and `getServiceClient()` (startup services with no actor).
6. **Phase 6 — cleanup** (`42a94ff67`): drops `PresetResponse` / `TimezoneResponse` interfaces that wrapped the old `{ config }` envelopes — they're dead now that the generated client schemas supply the types.

## Schema notes

- `LlmConfigSummarySchema` gains `.passthrough()` to keep the runtime fields the gateway emits but the schema doesn't yet declare (`contextWindowTokens`, `params`, `modelContextLength`). Tightening that to an explicit enumeration is a deferred backlog item.
- `DeleteModelOverrideResponseSchema` gains an optional `wasSet` field to match what the server actually returns.
- Pre-existing bug fixed in `preset/import.ts`: was reading `result.data.id` from POST `/llm-config`, gateway actually returns `{ config: {...} }` — now reads `result.data.config.id`.

## Test plan

- [x] `pnpm test` — full repo, all packages green (4976 bot-client tests pass)
- [x] `pnpm quality` — lint + codegen-drift + knip + cpd + cpd:check + depcruise + typecheck + typecheck:spec all clean
- [x] `pnpm ops legacy:count` shows `callGatewayApi=1, adminFetch=7` (both within the legacy clients themselves)
- [ ] Manual smoke on dev: `/timezone get` / `/timezone set`, `/settings apikey browse`, `/preset browse`, `/character chat` (covers PersonalityChatManager.resolveConfig), DM to verify NSFW check path

🤖 Generated with [Claude Code](https://claude.com/claude-code)