### PR TITLE
test: force IPv4 (127.0.0.1) in .env.test connection strings

### DIFF
--- a/services/ai-worker/.env.test
+++ b/services/ai-worker/.env.test
@@ -1,13 +1,15 @@
 # AI Worker Test Environment Variables
 
-# Redis
-REDIS_URL="redis://localhost:6379"
-REDIS_HOST="localhost"
+# Redis — use 127.0.0.1 (not localhost) so Node resolves IPv4 directly.
+# `localhost` resolves to IPv6 ::1 first on many systems, but the local
+# podman Redis maps only IPv4 127.0.0.1:6379 → ECONNREFUSED noise in tests.
+REDIS_URL="redis://127.0.0.1:6379"
+REDIS_HOST="127.0.0.1"
 REDIS_PORT="6379"
 
-# Database
-DATABASE_URL="postgresql://testuser:testpass@localhost:5432/testdb"
-PROD_DATABASE_URL="postgresql://testuser:testpass@localhost:5432/testdb"
+# Database — 127.0.0.1 for the same IPv4-loopback reason as Redis above.
+DATABASE_URL="postgresql://testuser:testpass@127.0.0.1:5432/testdb"
+PROD_DATABASE_URL="postgresql://testuser:testpass@127.0.0.1:5432/testdb"
 
 # AI Providers (dummy values for testing)
 AI_PROVIDER="openrouter"

--- a/services/api-gateway/.env.test
+++ b/services/api-gateway/.env.test
@@ -1,13 +1,15 @@
 # API Gateway Test Environment Variables
 
-# Redis
-REDIS_URL="redis://localhost:6379"
-REDIS_HOST="localhost"
+# Redis — use 127.0.0.1 (not localhost) so Node resolves IPv4 directly.
+# `localhost` resolves to IPv6 ::1 first on many systems, but the local
+# podman Redis maps only IPv4 127.0.0.1:6379 → ECONNREFUSED noise in tests.
+REDIS_URL="redis://127.0.0.1:6379"
+REDIS_HOST="127.0.0.1"
 REDIS_PORT="6379"
 
-# Database
-DATABASE_URL="postgresql://testuser:testpass@localhost:5432/testdb"
-PROD_DATABASE_URL="postgresql://testuser:testpass@localhost:5432/testdb"
+# Database — 127.0.0.1 for the same IPv4-loopback reason as Redis above.
+DATABASE_URL="postgresql://testuser:testpass@127.0.0.1:5432/testdb"
+PROD_DATABASE_URL="postgresql://testuser:testpass@127.0.0.1:5432/testdb"
 
 # Node Environment
 NODE_ENV="test"

--- a/services/bot-client/.env.test
+++ b/services/bot-client/.env.test
@@ -3,17 +3,20 @@
 # Discord
 DISCORD_TOKEN="test-discord-token-dummy-value"
 
-# API Gateway
+# API Gateway (mock target — bot-client tests stub the typed clients, so this
+# URL is never actually connected to; kept as localhost for parity with dev).
 GATEWAY_URL="http://localhost:3000"
 
-# Redis
-REDIS_URL="redis://localhost:6379"
-REDIS_HOST="localhost"
+# Redis — use 127.0.0.1 (not localhost) so Node resolves IPv4 directly.
+# `localhost` resolves to IPv6 ::1 first on many systems, but the local
+# podman Redis maps only IPv4 127.0.0.1:6379 → ECONNREFUSED noise in tests.
+REDIS_URL="redis://127.0.0.1:6379"
+REDIS_HOST="127.0.0.1"
 REDIS_PORT="6379"
 
-# Database
-DATABASE_URL="postgresql://testuser:testpass@localhost:5432/testdb"
-PROD_DATABASE_URL="postgresql://testuser:testpass@localhost:5432/testdb"
+# Database — 127.0.0.1 for the same IPv4-loopback reason as Redis above.
+DATABASE_URL="postgresql://testuser:testpass@127.0.0.1:5432/testdb"
+PROD_DATABASE_URL="postgresql://testuser:testpass@127.0.0.1:5432/testdb"
 
 # Node Environment
 NODE_ENV="test"


### PR DESCRIPTION
## Summary

Kills the recurring `ECONNREFUSED ::1:6379` uncaught-rejection noise in `pnpm test:int`. Node resolves `localhost` → IPv6 `::1` first on many systems, but the local podman Redis/Postgres containers map only IPv4 (`127.0.0.1:6379` / `:5432`). The mismatch produces async connection-refusal noise that vitest misattributes to whatever test file is running when the late rejection lands (e.g. `mounts.int.test.ts`, which doesn't even use Redis).

Forcing IPv4 in `REDIS_URL` / `REDIS_HOST` + `DATABASE_URL` / `PROD_DATABASE_URL` across the three tracked `.env.test` files removes it.

## Changes

- `services/{ai-worker,api-gateway,bot-client}/.env.test`: `localhost` → `127.0.0.1` on the Redis + Postgres connection strings, with a comment explaining the IPv4-loopback reason.
- `GATEWAY_URL` left as `localhost` — it's a mock target the typed-client stubs never connect to.

## Why this is safe

- `127.0.0.1` is correct in CI too — GitHub Actions service containers bind the runner's IPv4 loopback.
- Unit tests mock all I/O; only integration tests touch real Redis/PG, so this is purely a test-env connection fix.
- No production code or config touched.

## Test plan

- [x] `.env.test`-only change; unit suites unaffected (they mock all transport)
- [ ] CI `integration-tests` job confirms the `::1` noise is gone and routes still connect (verified there rather than locally — `pnpm test:int` OOMs the Steam Deck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)