### PR TITLE
fix: vision-heavy job timeout — raise budget + late-result recovery

### DIFF
--- a/packages/common-types/src/constants/message.ts
+++ b/packages/common-types/src/constants/message.ts
@@ -108,17 +108,34 @@ export const MULTI_TAG = {
    */
   MAX_TAGS: 5,
   /**
-   * Safety-net timeout for the multi-tag coordinator. Per-job timeouts
-   * (TIMEOUTS.JOB_WAIT) dominate; this fires only if a slot's result is
-   * truly lost (gateway disconnect, worker crash without error result).
-   * On fire, the coordinator flushes the slots that did complete and
-   * synthesizes timeout content for the rest.
+   * Safety-net timeout for the multi-tag coordinator. On fire, the
+   * coordinator flushes the slots that did complete and synthesizes
+   * timeout content for the rest.
+   *
+   * Sized at 18 min: vision-heavy jobs (many extended-context images +
+   * a slow model) legitimately run 10–15 min, and the worker lock
+   * (TIMEOUTS.WORKER_LOCK_DURATION) is 20 min — so this sits below the
+   * worker ceiling with headroom while no longer firing on jobs that are
+   * still genuinely processing. A late result that lands after this fires
+   * is recovered (not dropped) by the synthetic-timeout recovery path in
+   * MessageHandler. Keep this >= ORDERING_MAX_WAIT_MS so the per-channel
+   * ordering buffer never force-processes a group before this backstop.
    */
-  COORDINATOR_TIMEOUT_MS: 10 * 60 * 1000,
+  COORDINATOR_TIMEOUT_MS: 18 * 60 * 1000,
+  /**
+   * Max time the per-channel ResponseOrderingService buffers a pending
+   * group before force-processing it. Decoupled from TIMEOUTS.JOB_WAIT
+   * (which is shared with the STT-transcription gateway wait and must stay
+   * short) so the chat ordering buffer can wait as long as the coordinator.
+   * Held equal to COORDINATOR_TIMEOUT_MS: the coordinator is the authoritative
+   * give-up point; the ordering buffer must not fire first.
+   */
+  ORDERING_MAX_WAIT_MS: 18 * 60 * 1000,
   /**
    * TTL for persisted coordinator entries in Redis. Longer than
    * COORDINATOR_TIMEOUT_MS so restart-recovery has a window even if a
-   * timeout was about to fire pre-restart.
+   * timeout was about to fire pre-restart. Also bounds the
+   * synthetic-timeout recovery marker's lifetime.
    */
   REDIS_TTL_SEC: 30 * 60,
 } as const;

--- a/packages/common-types/src/constants/queue.ts
+++ b/packages/common-types/src/constants/queue.ts
@@ -90,6 +90,13 @@ export const REDIS_KEY_PREFIXES = {
   /** Prefix for per-slot "already delivered" dedup marker (recovery skips dispatch when present) */
   MULTI_TAG_SLOT_DELIVERED: 'multitag:slot-delivered:',
   /**
+   * Prefix for the synthetic-timeout recovery marker, keyed by jobId. Written
+   * when the coordinator gives up on a slot and delivers a synthetic timeout;
+   * value is JSON delivery context so a late-arriving real result can be sent
+   * as a follow-up instead of dropped. TTL: MULTI_TAG.REDIS_TTL_SEC.
+   */
+  MULTI_TAG_SYNTHETIC_TIMEOUT: 'multitag:synthetic-timeout:',
+  /**
    * Prefix for batch-delete preview tokens. Key: `memory:preview:{userId}:{token}`.
    * Value: JSON-encoded filter that produced the preview. TTL: 5 min.
    * Consumer: `api-gateway/MemoryActionTokenService`.

--- a/services/bot-client/src/composition.ts
+++ b/services/bot-client/src/composition.ts
@@ -39,6 +39,8 @@ import { SlotDeliveryService } from './services/SlotDeliveryService.js';
 import { MultiTagCoordinator } from './services/MultiTagCoordinator.js';
 import { MultiTagPersistence } from './services/MultiTagPersistence.js';
 import { MultiTagRecovery } from './services/MultiTagRecovery.js';
+import { MessageHandler } from './handlers/MessageHandler.js';
+import { DiscordResponseSender } from './services/DiscordResponseSender.js';
 import type { Queue } from 'bullmq';
 import type { Redis } from 'ioredis';
 import type { Client } from 'discord.js';
@@ -205,4 +207,51 @@ export function buildProcessorChain(deps: {
     ),
     new BotMentionProcessor(),
   ];
+}
+
+/**
+ * Build the full message-handling stack: the Chain-of-Responsibility processor
+ * chain + the MessageHandler that drives it and delivers async job results
+ * (including late-result recovery, which needs the personality loader + Discord
+ * client to reconstruct a follow-up send). Bundles both because the processor
+ * chain has exactly one consumer — the handler — so they're a single concern.
+ */
+export function buildMessageHandler(deps: {
+  // Processor-chain deps
+  denylistCache: DenylistCache;
+  voiceTranscription: VoiceTranscriptionService;
+  personalityIdCache: PersonalityIdCache;
+  gatewayClient: GatewayClient;
+  replyResolver: ReplyResolutionService;
+  personalityHandler: PersonalityMessageHandler;
+  multiTagPersistence: MultiTagPersistence;
+  // Handler deps
+  responseSender: DiscordResponseSender;
+  persistence: ConversationPersistence;
+  jobTracker: JobTracker;
+  slotDelivery: SlotDeliveryService;
+  coordinator: MultiTagCoordinator;
+  personalityService: IPersonalityLoader;
+  client: Client;
+}): MessageHandler {
+  const processors = buildProcessorChain({
+    denylistCache: deps.denylistCache,
+    voiceTranscription: deps.voiceTranscription,
+    personalityIdCache: deps.personalityIdCache,
+    gatewayClient: deps.gatewayClient,
+    replyResolver: deps.replyResolver,
+    coordinator: deps.coordinator,
+    personalityHandler: deps.personalityHandler,
+    multiTagPersistence: deps.multiTagPersistence,
+  });
+  return new MessageHandler({
+    processors,
+    responseSender: deps.responseSender,
+    persistence: deps.persistence,
+    jobTracker: deps.jobTracker,
+    slotDelivery: deps.slotDelivery,
+    coordinator: deps.coordinator,
+    personalityService: deps.personalityService,
+    client: deps.client,
+  });
 }

--- a/services/bot-client/src/handlers/MessageHandler.test.ts
+++ b/services/bot-client/src/handlers/MessageHandler.test.ts
@@ -14,11 +14,13 @@ import type { DiscordResponseSender } from '../services/DiscordResponseSender.js
 import type { ConversationPersistence } from '../services/ConversationPersistence.js';
 import type { JobTracker } from '../services/JobTracker.js';
 import type { SlotDeliveryService } from '../services/SlotDeliveryService.js';
+import type { IPersonalityLoader } from '../types/IPersonalityLoader.js';
 import type { MultiTagCoordinator } from '../services/MultiTagCoordinator.js';
 
 // Mock serviceRegistry to provide getGatewayClient
 const mockGatewayClient = {
   updateDiagnosticResponseIds: vi.fn().mockResolvedValue(undefined),
+  confirmDelivery: vi.fn().mockResolvedValue(undefined),
 };
 
 vi.mock('../services/serviceRegistry.js', () => ({
@@ -62,9 +64,20 @@ const mockCoordinator = {
   isStale: vi.fn().mockResolvedValue(false),
   handleJobResult: vi.fn().mockResolvedValue(undefined),
   clearStale: vi.fn().mockResolvedValue(undefined),
+  // Late-result recovery: default to "no marker" so unknown jobs drop as before.
+  getSyntheticTimeout: vi.fn().mockResolvedValue(null),
+  clearSyntheticTimeout: vi.fn().mockResolvedValue(undefined),
   get staleCheckNeeded() {
     return mockCoordinatorState.staleCheckNeeded;
   },
+};
+
+const mockPersonalityService = {
+  loadPersonality: vi.fn().mockResolvedValue(null),
+};
+
+const mockClient = {
+  channels: { fetch: vi.fn().mockResolvedValue(null) },
 };
 
 describe('MessageHandler', () => {
@@ -98,6 +111,8 @@ describe('MessageHandler', () => {
       jobTracker: mockJobTracker as unknown as JobTracker,
       slotDelivery: mockSlotDelivery as unknown as SlotDeliveryService,
       coordinator: mockCoordinator as unknown as MultiTagCoordinator,
+      personalityService: mockPersonalityService as unknown as IPersonalityLoader,
+      client: mockClient as unknown as import('discord.js').Client,
     });
 
     // Direct mocks — no threading-through. Tests assert on
@@ -391,7 +406,161 @@ describe('MessageHandler', () => {
       expect(mockSlotDelivery.deliverSuccess).not.toHaveBeenCalled();
       expect(mockSlotDelivery.deliverError).not.toHaveBeenCalled();
     });
+  });
 
+  describe('handleJobResult - late-result recovery (synthetic-timeout marker)', () => {
+    const recoveryCtx = {
+      channelId: 'channel-late',
+      guildId: 'guild-1',
+      clientId: 'bot-1',
+      personalitySlug: 'lila',
+      recipientUserId: 'user-1',
+      isAutoResponse: false,
+    };
+    const lateResult = {
+      requestId: 'req-late',
+      success: true,
+      content: 'The real reply that arrived late',
+      metadata: { modelUsed: 'anthropic/claude-sonnet-4' },
+    } as LLMGenerationResult;
+
+    beforeEach(() => {
+      mockJobTracker.getContext.mockReturnValue(null); // not tracked → recovery path
+    });
+
+    it('delivers a late successful result as a follow-up, then confirms + clears', async () => {
+      mockCoordinator.getSyntheticTimeout.mockResolvedValue(recoveryCtx);
+      mockPersonalityService.loadPersonality.mockResolvedValue({
+        id: 'p-lila',
+        slug: 'lila',
+        displayName: 'Lila',
+      });
+      mockClient.channels.fetch.mockResolvedValue({
+        id: 'channel-late',
+        isTextBased: () => true,
+        isThread: () => false,
+        type: 0, // GuildText — passes isTypingChannel
+      });
+      mockResponseSender.sendResponse.mockResolvedValue({ chunkMessageIds: ['m1'] });
+
+      await messageHandler.handleJobResult('job-late', lateResult);
+
+      expect(mockResponseSender.sendResponse).toHaveBeenCalledTimes(1);
+      const opts = mockResponseSender.sendResponse.mock.calls[0][0];
+      expect(opts.content).toContain('took longer than expected');
+      expect(opts.content).toContain('The real reply that arrived late');
+      expect(opts.personality.slug).toBe('lila');
+      expect(mockGatewayClient.confirmDelivery).toHaveBeenCalledWith('job-late');
+      expect(mockCoordinator.clearSyntheticTimeout).toHaveBeenCalledWith('job-late');
+    });
+
+    it('clears the marker without a second message when the late result failed', async () => {
+      mockCoordinator.getSyntheticTimeout.mockResolvedValue(recoveryCtx);
+      const failedLate = {
+        requestId: 'req-late',
+        success: false,
+        error: 'boom',
+      } as LLMGenerationResult;
+
+      await messageHandler.handleJobResult('job-late', failedLate);
+
+      expect(mockResponseSender.sendResponse).not.toHaveBeenCalled();
+      expect(mockPersonalityService.loadPersonality).not.toHaveBeenCalled();
+      expect(mockGatewayClient.confirmDelivery).toHaveBeenCalledWith('job-late');
+      expect(mockCoordinator.clearSyntheticTimeout).toHaveBeenCalledWith('job-late');
+    });
+
+    it('clears the marker (no follow-up) when the personality is no longer loadable', async () => {
+      mockCoordinator.getSyntheticTimeout.mockResolvedValue(recoveryCtx);
+      mockPersonalityService.loadPersonality.mockResolvedValue(null);
+
+      await messageHandler.handleJobResult('job-late', lateResult);
+
+      expect(mockResponseSender.sendResponse).not.toHaveBeenCalled();
+      expect(mockGatewayClient.confirmDelivery).toHaveBeenCalledWith('job-late');
+      expect(mockCoordinator.clearSyntheticTimeout).toHaveBeenCalledWith('job-late');
+    });
+
+    it('clears the marker (no follow-up) when the channel is no longer fetchable', async () => {
+      mockCoordinator.getSyntheticTimeout.mockResolvedValue(recoveryCtx);
+      mockPersonalityService.loadPersonality.mockResolvedValue({
+        id: 'p-lila',
+        slug: 'lila',
+        displayName: 'Lila',
+      });
+      mockClient.channels.fetch.mockResolvedValue(null); // channel deleted/inaccessible
+
+      await messageHandler.handleJobResult('job-late', lateResult);
+
+      expect(mockResponseSender.sendResponse).not.toHaveBeenCalled();
+      expect(mockGatewayClient.confirmDelivery).toHaveBeenCalledWith('job-late');
+      expect(mockCoordinator.clearSyntheticTimeout).toHaveBeenCalledWith('job-late');
+    });
+
+    it('drops normally (no recovery) when there is no marker', async () => {
+      mockCoordinator.getSyntheticTimeout.mockResolvedValue(null);
+
+      await messageHandler.handleJobResult('job-late', lateResult);
+
+      expect(mockResponseSender.sendResponse).not.toHaveBeenCalled();
+      expect(mockGatewayClient.confirmDelivery).not.toHaveBeenCalled();
+      expect(mockCoordinator.clearSyntheticTimeout).not.toHaveBeenCalled();
+    });
+
+    it('still confirms + clears when the follow-up send throws (finalize is unconditional)', async () => {
+      mockCoordinator.getSyntheticTimeout.mockResolvedValue(recoveryCtx);
+      mockPersonalityService.loadPersonality.mockResolvedValue({
+        id: 'p-lila',
+        slug: 'lila',
+        displayName: 'Lila',
+      });
+      mockClient.channels.fetch.mockResolvedValue({
+        id: 'channel-late',
+        isTextBased: () => true,
+        isThread: () => false,
+        type: 0,
+      });
+      mockResponseSender.sendResponse.mockRejectedValue(new Error('rate limited'));
+
+      await messageHandler.handleJobResult('job-late', lateResult);
+
+      // Send threw, but finalize() runs anyway: confirmDelivery is an idempotent
+      // status flip with no retry consumer, and the marker must not linger.
+      expect(mockResponseSender.sendResponse).toHaveBeenCalledTimes(1);
+      expect(mockGatewayClient.confirmDelivery).toHaveBeenCalledWith('job-late');
+      expect(mockCoordinator.clearSyntheticTimeout).toHaveBeenCalledWith('job-late');
+    });
+
+    it('recovers once, then drops a duplicate result (marker cleared after first)', async () => {
+      // First call sees the marker; the recovery path clears it, so the second
+      // call sees null and falls through to the normal unknown-job drop.
+      mockCoordinator.getSyntheticTimeout
+        .mockResolvedValueOnce(recoveryCtx)
+        .mockResolvedValue(null);
+      mockPersonalityService.loadPersonality.mockResolvedValue({
+        id: 'p-lila',
+        slug: 'lila',
+        displayName: 'Lila',
+      });
+      mockClient.channels.fetch.mockResolvedValue({
+        id: 'channel-late',
+        isTextBased: () => true,
+        isThread: () => false,
+        type: 0,
+      });
+      mockResponseSender.sendResponse.mockResolvedValue({ chunkMessageIds: ['m1'] });
+
+      await messageHandler.handleJobResult('job-late', lateResult);
+      await messageHandler.handleJobResult('job-late', lateResult);
+
+      // Delivered exactly once; the duplicate produced no second follow-up.
+      expect(mockResponseSender.sendResponse).toHaveBeenCalledTimes(1);
+      expect(mockGatewayClient.confirmDelivery).toHaveBeenCalledTimes(1);
+      expect(mockCoordinator.clearSyntheticTimeout).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('handleJobResult - Async Job Completion (single-personality path)', () => {
     it('should handle job result without metadata', async () => {
       const jobId = 'job-456';
       const result = {

--- a/services/bot-client/src/handlers/MessageHandler.ts
+++ b/services/bot-client/src/handlers/MessageHandler.ts
@@ -6,11 +6,12 @@
  * Implements full dependency injection for testability and flexibility.
  */
 
-import { MessageType, type Message } from 'discord.js';
+import { MessageType, type Client, type Message } from 'discord.js';
 import { createLogger, type LLMGenerationResult, stripErrorSpoiler } from '@tzurot/common-types';
 import { buildErrorContent } from '../utils/buildErrorContent.js';
 import type { IMessageProcessor } from '../processors/IMessageProcessor.js';
 import { isUserContentMessage } from '../utils/messageTypeUtils.js';
+import { fetchTypingChannel } from '../utils/fetchTypingChannel.js';
 import { DiscordResponseSender } from '../services/DiscordResponseSender.js';
 import { ConversationPersistence } from '../services/ConversationPersistence.js';
 import {
@@ -21,6 +22,10 @@ import {
 import { getGatewayClient } from '../services/serviceRegistry.js';
 import type { SlotDeliveryService, SlotDeliveryContext } from '../services/SlotDeliveryService.js';
 import type { MultiTagCoordinator } from '../services/MultiTagCoordinator.js';
+import type { IPersonalityLoader } from '../types/IPersonalityLoader.js';
+
+/** Notice prepended to a late-recovered reply so the user knows why it's late. */
+const LATE_RECOVERY_NOTICE = '-# ⏰ This reply took longer than expected to generate.\n\n';
 
 const logger = createLogger('MessageHandler');
 
@@ -34,6 +39,10 @@ export interface MessageHandlerDeps {
   jobTracker: JobTracker;
   slotDelivery: SlotDeliveryService;
   coordinator: MultiTagCoordinator;
+  /** Loads personalities by slug for late-result recovery (access-scoped). */
+  personalityService: IPersonalityLoader;
+  /** Discord client — re-fetches the channel for a late-recovered delivery. */
+  client: Client;
 }
 
 export class MessageHandler {
@@ -43,6 +52,8 @@ export class MessageHandler {
   private readonly jobTracker: JobTracker;
   private readonly slotDelivery: SlotDeliveryService;
   private readonly coordinator: MultiTagCoordinator;
+  private readonly personalityService: IPersonalityLoader;
+  private readonly client: Client;
 
   constructor(deps: MessageHandlerDeps) {
     this.processors = deps.processors;
@@ -51,6 +62,8 @@ export class MessageHandler {
     this.jobTracker = deps.jobTracker;
     this.slotDelivery = deps.slotDelivery;
     this.coordinator = deps.coordinator;
+    this.personalityService = deps.personalityService;
+    this.client = deps.client;
     logger.info({ processorCount: deps.processors.length }, 'Initialized with processor chain');
   }
 
@@ -162,6 +175,12 @@ export class MessageHandler {
     // Single-personality path: JobTracker has the context.
     const jobContext = this.jobTracker.getContext(jobId);
     if (!jobContext) {
+      // Before dropping: a multi-tag slot we already synthetic-timed-out may
+      // have a recovery marker. If so, deliver the real result as a late
+      // follow-up rather than silently dropping it.
+      if (await this.tryRecoverLateResult(jobId, result)) {
+        return;
+      }
       logger.warn({ jobId }, 'Received result for unknown job - ignoring');
       return;
     }
@@ -175,6 +194,117 @@ export class MessageHandler {
     }
 
     await this.handleMessageJobResult(jobId, result, jobContext);
+  }
+
+  /**
+   * Late-result recovery for multi-tag slots that were synthetic-timed-out.
+   * Returns true if this jobId had a recovery marker (i.e. we own the outcome
+   * — delivered, or determined unrecoverable), false if it's a genuinely
+   * unknown job that should drop as before.
+   *
+   * On a marker hit we always confirm delivery + clear the marker so the
+   * Redis stream entry clears and the marker doesn't linger. A successful
+   * result is re-sent as a personality follow-up (prefixed with a "took
+   * longer than expected" notice); a failed/empty late result is dropped
+   * silently since the user already received the synthetic timeout message.
+   *
+   * Note: the follow-up is NOT persisted to conversation history — the marker
+   * deliberately carries minimal context (no personaId/userMessageTime) and
+   * this is a rare >18-min-job edge case. The user sees the reply; it just
+   * won't anchor a subsequent turn's memory. Acceptable for the recovery path.
+   */
+  private async tryRecoverLateResult(jobId: string, result: LLMGenerationResult): Promise<boolean> {
+    const ctx = await this.coordinator.getSyntheticTimeout(jobId);
+    if (ctx === null) {
+      return false; // not a synthetic-timeout job — let the caller drop it
+    }
+
+    // From here we own the outcome. Always confirm + clear (best-effort) so
+    // the stream entry clears and the marker doesn't outlive its usefulness.
+    const finalize = async (): Promise<void> => {
+      // confirmDelivery is fire-and-forget: stream-entry cleanup is best-effort,
+      // and the gateway entry expires on its own TTL if this call never lands.
+      // clearSyntheticTimeout is awaited so the recovery marker doesn't linger
+      // if we crash right after the follow-up send but before its TTL elapses.
+      void getGatewayClient()
+        .confirmDelivery(jobId)
+        .catch(err => logger.warn({ err, jobId }, 'late-recovery: confirmDelivery failed'));
+      await this.coordinator.clearSyntheticTimeout(jobId);
+    };
+
+    // Failed/empty late result: the user already saw the synthetic timeout
+    // error — don't send a second (error) message. Just clean up.
+    if (
+      result.success === false ||
+      typeof result.content !== 'string' ||
+      result.content.length === 0
+    ) {
+      logger.info(
+        { jobId },
+        'Late result for synthetic-timed-out job was unusable — clearing marker, no follow-up'
+      );
+      await finalize();
+      return true;
+    }
+
+    const personality = await this.personalityService.loadPersonality(
+      ctx.personalitySlug,
+      ctx.recipientUserId
+    );
+    if (personality === null) {
+      logger.warn(
+        { jobId, slug: ctx.personalitySlug },
+        'Late recovery: personality no longer loadable — dropping follow-up'
+      );
+      await finalize();
+      return true;
+    }
+
+    const channel = await fetchTypingChannel(this.client, ctx.channelId);
+    if (channel === null) {
+      logger.warn(
+        { jobId, channelId: ctx.channelId },
+        'Late recovery: channel missing or not a typing channel — dropping follow-up'
+      );
+      await finalize();
+      return true;
+    }
+
+    try {
+      await this.responseSender.sendResponse({
+        content: LATE_RECOVERY_NOTICE + result.content,
+        personality,
+        channel,
+        guildId: ctx.guildId,
+        clientId: ctx.clientId,
+        recipientUserId: ctx.recipientUserId,
+        isAutoResponse: ctx.isAutoResponse,
+        modelUsed: result.metadata?.modelUsed,
+        providerUsed: result.metadata?.providerUsed,
+        isGuestMode: result.metadata?.isGuestMode,
+        focusModeEnabled: result.metadata?.focusModeEnabled,
+        incognitoModeActive: result.metadata?.incognitoModeActive,
+        thinkingContent: result.metadata?.thinkingContent,
+        showThinking: result.metadata?.showThinking,
+        showModelFooter: result.metadata?.showModelFooter,
+        ttsAudioKey: result.metadata?.ttsAudioKey,
+        ttsAudioContentType: result.metadata?.ttsAudioContentType,
+        ttsNotices: result.metadata?.ttsNotices,
+      });
+      logger.info(
+        { jobId, personalityId: personality.id },
+        'Late result recovered and delivered as a follow-up'
+      );
+    } catch (err) {
+      logger.error({ err, jobId }, 'Late recovery: follow-up send failed');
+    }
+    // finalize() runs even when the send threw. confirmDelivery is an idempotent
+    // job_results status flip (PENDING_DELIVERY → DELIVERED), and nothing sweeps
+    // PENDING_DELIVERY rows for retry — so confirming after a failed send is
+    // cosmetically imprecise but functionally inert. We still finalize so the
+    // recovery marker clears rather than lingering until its TTL.
+    await finalize();
+    return true;
   }
 
   /**

--- a/services/bot-client/src/index.ts
+++ b/services/bot-client/src/index.ts
@@ -31,7 +31,7 @@ import {
   clearAllChannelSettingsCache,
 } from './utils/GatewayClient.js';
 import { WebhookManager } from './utils/WebhookManager.js';
-import { MessageHandler } from './handlers/MessageHandler.js';
+import type { MessageHandler } from './handlers/MessageHandler.js';
 import { CommandHandler } from './handlers/CommandHandler.js';
 import { redis as botRedis, closeRedis } from './redis.js';
 import { deployCommands } from './utils/deployCommands.js';
@@ -59,7 +59,7 @@ import { registerServices } from './services/serviceRegistry.js';
 import {
   buildPersonalityChatPipeline,
   buildMultiTagStack,
-  buildProcessorChain,
+  buildMessageHandler,
 } from './composition.js';
 import {
   startNotificationCacheCleanup,
@@ -294,26 +294,22 @@ function createServices(): Services {
     multiTagCoordinator
   );
 
-  // Processor chain (order matters — see buildProcessorChain doc).
-  const processors = buildProcessorChain({
+  // Message-handling stack: processor chain (order matters) + MessageHandler.
+  const messageHandler = buildMessageHandler({
     denylistCache,
     voiceTranscription,
     personalityIdCache,
     gatewayClient,
     replyResolver,
-    coordinator: multiTagCoordinator,
     personalityHandler,
     multiTagPersistence,
-  });
-
-  // Create MessageHandler with full dependency injection
-  const messageHandler = new MessageHandler({
-    processors,
     responseSender,
     persistence,
     jobTracker,
     slotDelivery,
     coordinator: multiTagCoordinator,
+    personalityService,
+    client,
   });
 
   // Register services for global access (used by slash commands)

--- a/services/bot-client/src/services/MultiTagCoordinator.test.ts
+++ b/services/bot-client/src/services/MultiTagCoordinator.test.ts
@@ -90,6 +90,7 @@ describe('MultiTagCoordinator', () => {
     markStale: ReturnType<typeof vi.fn>;
     isStale: ReturnType<typeof vi.fn>;
     clearDMBackfillTried: ReturnType<typeof vi.fn>;
+    markSyntheticTimeout: ReturnType<typeof vi.fn>;
   };
 
   let coordinator: MultiTagCoordinator;
@@ -121,6 +122,7 @@ describe('MultiTagCoordinator', () => {
       markStale: vi.fn().mockResolvedValue(undefined),
       isStale: vi.fn().mockResolvedValue(false),
       clearDMBackfillTried: vi.fn().mockResolvedValue(undefined),
+      markSyntheticTimeout: vi.fn().mockResolvedValue(undefined),
     };
 
     coordinator = new MultiTagCoordinator({
@@ -529,6 +531,31 @@ describe('MultiTagCoordinator', () => {
       // Group flushed: Alice via success path, Bob via error path
       expect(slotDelivery.deliverSuccess).toHaveBeenCalledOnce();
       expect(slotDelivery.deliverError).toHaveBeenCalledOnce();
+    });
+
+    it('writes a synthetic-timeout recovery marker for each timed-out slot', async () => {
+      const a = buildPersonality('Alice');
+      const b = buildPersonality('Bob');
+      const { input } = fanOut([buildResolvedSlot(a), buildResolvedSlot(b)]);
+      await coordinator.startFanOut(input);
+
+      // Only Alice resolves; Bob times out.
+      await coordinator.handleJobResult('job-Alice', {
+        requestId: 'ra',
+        success: true,
+        content: 'A',
+      });
+      await vi.advanceTimersByTimeAsync(MULTI_TAG.COORDINATOR_TIMEOUT_MS + 100);
+
+      // Marker written for the timed-out slot (Bob), not the delivered one (Alice).
+      expect(persistence.markSyntheticTimeout).toHaveBeenCalledTimes(1);
+      const [jobId, ctx] = persistence.markSyntheticTimeout.mock.calls[0];
+      expect(jobId).toBe('job-Bob');
+      expect(ctx).toMatchObject({
+        personalitySlug: b.slug,
+        recipientUserId: 'user-1', // buildMessage author id → entry.userId
+        isAutoResponse: false,
+      });
     });
   });
 

--- a/services/bot-client/src/services/MultiTagCoordinator.ts
+++ b/services/bot-client/src/services/MultiTagCoordinator.ts
@@ -40,7 +40,7 @@ import type { PersonalityChatManager } from './character/PersonalityChatManager.
 import type { JobTracker } from './JobTracker.js';
 import type { ResponseOrderingService } from './ResponseOrderingService.js';
 import type { SlotDeliveryService } from './SlotDeliveryService.js';
-import type { MultiTagPersistence } from './MultiTagPersistence.js';
+import type { MultiTagPersistence, SyntheticTimeoutContext } from './MultiTagPersistence.js';
 import { type ResolvedSlot, type SlotSource } from './SlotResolver.js';
 import type { GatewayClient } from '../utils/GatewayClient.js';
 
@@ -622,8 +622,38 @@ export class MultiTagCoordinator {
     for (const slot of stillPending) {
       slot.status = 'timedout';
       this.deps.jobTracker.completeJob(slot.jobId);
+      // Persist a late-result recovery marker BEFORE flush (deleteEntry wipes
+      // the snapshot + jobId index). If the real result lands within the TTL,
+      // MessageHandler delivers it as a follow-up instead of dropping it.
+      // Best-effort — the helper never throws into this path. The write is not
+      // awaited, so a result arriving in the sub-millisecond window before the
+      // marker lands would miss recovery — identical to pre-fix drop behavior,
+      // and implausible in practice (a late result is seconds-to-minutes late).
+      void this.deps.persistence.markSyntheticTimeout(slot.jobId, {
+        channelId: entry.channel.id,
+        guildId: entry.guildId,
+        clientId: entry.clientId,
+        personalitySlug: slot.personality.slug,
+        recipientUserId: entry.userId,
+        isAutoResponse: slot.isAutoResponse,
+      });
     }
     await this.flushEntry(entry);
+  }
+
+  /**
+   * Read the synthetic-timeout recovery context for a jobId (or null). Proxy
+   * to the persistence layer so MessageHandler can check for a late-result
+   * recovery without taking a direct persistence dependency — mirrors the
+   * `isStale`/`clearStale` proxy pattern.
+   */
+  async getSyntheticTimeout(jobId: string): Promise<SyntheticTimeoutContext | null> {
+    return this.deps.persistence.getSyntheticTimeout(jobId);
+  }
+
+  /** Clear a synthetic-timeout marker after a late result is handled. Proxy. */
+  async clearSyntheticTimeout(jobId: string): Promise<void> {
+    await this.deps.persistence.clearSyntheticTimeout(jobId);
   }
 }
 

--- a/services/bot-client/src/services/MultiTagPersistence.test.ts
+++ b/services/bot-client/src/services/MultiTagPersistence.test.ts
@@ -60,6 +60,7 @@ describe('MultiTagPersistence', () => {
     multi: ReturnType<typeof vi.fn>;
     set: ReturnType<typeof vi.fn>;
     get: ReturnType<typeof vi.fn>;
+    del: ReturnType<typeof vi.fn>;
     scan: ReturnType<typeof vi.fn>;
     mget: ReturnType<typeof vi.fn>;
     sadd: ReturnType<typeof vi.fn>;
@@ -94,6 +95,7 @@ describe('MultiTagPersistence', () => {
       multi: vi.fn(() => fakePipeline),
       set: vi.fn().mockResolvedValue('OK'),
       get: vi.fn(),
+      del: vi.fn().mockResolvedValue(1),
       scan: vi.fn(),
       mget: vi.fn(),
       sadd: vi.fn().mockResolvedValue(1),
@@ -372,6 +374,52 @@ describe('MultiTagPersistence', () => {
       // message. Duplicate is the better failure mode.
       mockRedis.get.mockRejectedValue(new Error('Redis down'));
       expect(await persistence.isSlotDelivered('job-abc')).toBe(false);
+    });
+  });
+
+  describe('synthetic-timeout recovery marker', () => {
+    const ctx = {
+      channelId: 'chan-1',
+      guildId: 'guild-1',
+      clientId: 'bot-1',
+      personalitySlug: 'lila',
+      recipientUserId: 'user-1',
+      isAutoResponse: false,
+    };
+
+    it('markSyntheticTimeout writes the JSON context with a TTL', async () => {
+      await persistence.markSyntheticTimeout('job-1', ctx);
+      expect(mockRedis.set).toHaveBeenCalledWith(
+        'multitag:synthetic-timeout:job-1',
+        JSON.stringify(ctx),
+        'EX',
+        expect.any(Number)
+      );
+    });
+
+    it('getSyntheticTimeout round-trips the context', async () => {
+      mockRedis.get.mockResolvedValue(JSON.stringify(ctx));
+      expect(await persistence.getSyntheticTimeout('job-1')).toEqual(ctx);
+    });
+
+    it('getSyntheticTimeout returns null when no marker exists', async () => {
+      mockRedis.get.mockResolvedValue(null);
+      expect(await persistence.getSyntheticTimeout('job-1')).toBeNull();
+    });
+
+    it('getSyntheticTimeout fails soft (null) on malformed JSON', async () => {
+      mockRedis.get.mockResolvedValue('not-json{');
+      expect(await persistence.getSyntheticTimeout('job-1')).toBeNull();
+    });
+
+    it('clearSyntheticTimeout deletes the marker key', async () => {
+      await persistence.clearSyntheticTimeout('job-1');
+      expect(mockRedis.del).toHaveBeenCalledWith('multitag:synthetic-timeout:job-1');
+    });
+
+    it('markSyntheticTimeout fails soft on Redis error (no throw)', async () => {
+      mockRedis.set.mockRejectedValue(new Error('Redis down'));
+      await expect(persistence.markSyntheticTimeout('job-1', ctx)).resolves.toBeUndefined();
     });
   });
 });

--- a/services/bot-client/src/services/MultiTagPersistence.ts
+++ b/services/bot-client/src/services/MultiTagPersistence.ts
@@ -71,6 +71,27 @@ const SCAN_COUNT = 100;
 const MAX_ENTRY_BYTES = 64 * 1024;
 
 /**
+ * Delivery context persisted when the coordinator gives up on a slot and
+ * delivers a synthetic timeout. Enough to reconstruct a follow-up send if
+ * the real result lands late — after `deleteEntry` has wiped the snapshot +
+ * jobId index. The personality is re-loaded by slug (access-scoped to
+ * `recipientUserId`) and the channel re-fetched by id; everything else here
+ * feeds `DiscordResponseSender.sendResponse` directly.
+ */
+export interface SyntheticTimeoutContext {
+  channelId: string;
+  guildId: string | null;
+  // `string | undefined` matches the codebase-wide clientId convention (JobTracker,
+  // SlotDeliveryService, DiscordResponseSender). JSON.stringify drops an undefined
+  // key, so it reads back absent rather than null — harmless here, since the consumer
+  // (sendResponse) also takes `string | undefined` and treats both the same.
+  clientId: string | undefined;
+  personalitySlug: string;
+  recipientUserId: string;
+  isAutoResponse: boolean;
+}
+
+/**
  * Serializable snapshot of a single slot. Strips runtime-only fields
  * (personality object, result, timeoutHandle) — the coordinator rehydrates
  * those during recovery.
@@ -276,6 +297,66 @@ export class MultiTagPersistence {
       await this.redis.srem(REDIS_KEY_PREFIXES.MULTI_TAG_STALE_JOBS, jobId);
     } catch (err) {
       logger.warn({ err, jobId }, 'clearStale Redis call failed — stale entry will expire via TTL');
+    }
+  }
+
+  /**
+   * Record that a slot was synthetically timed out, with the delivery context
+   * needed to send the real result as a follow-up if it lands late. Keyed by
+   * jobId, TTL `MULTI_TAG.REDIS_TTL_SEC` (30 min) — past that, a late result
+   * is dropped as before (the observed real-world lateness was ~1 min).
+   *
+   * Fails soft: if the marker write blips, we simply lose late-recovery for
+   * that one job (it drops as it did pre-fix). Never throws into the
+   * safety-timeout path.
+   */
+  async markSyntheticTimeout(jobId: string, ctx: SyntheticTimeoutContext): Promise<void> {
+    const key = `${REDIS_KEY_PREFIXES.MULTI_TAG_SYNTHETIC_TIMEOUT}${jobId}`;
+    try {
+      await this.redis.set(key, JSON.stringify(ctx), 'EX', MULTI_TAG.REDIS_TTL_SEC);
+    } catch (err) {
+      logger.warn(
+        { err, jobId },
+        'markSyntheticTimeout Redis call failed — a late result for this job will be dropped, not recovered'
+      );
+    }
+  }
+
+  /**
+   * Read the synthetic-timeout recovery context for a jobId, or null if none
+   * (not a synthetic-timeout job, or marker expired). Fails soft → null.
+   */
+  async getSyntheticTimeout(jobId: string): Promise<SyntheticTimeoutContext | null> {
+    const key = `${REDIS_KEY_PREFIXES.MULTI_TAG_SYNTHETIC_TIMEOUT}${jobId}`;
+    try {
+      const raw = await this.redis.get(key);
+      // No deep schema validation: we wrote this marker ourselves minutes earlier and
+      // the 30-min TTL keeps any cross-deploy shape drift transient. A structurally
+      // valid but wrong-shaped marker would surface downstream (e.g. sendResponse),
+      // not here — acceptable for a best-effort recovery path.
+      return raw === null ? null : (JSON.parse(raw) as SyntheticTimeoutContext);
+    } catch (err) {
+      logger.warn(
+        { err, jobId },
+        'getSyntheticTimeout failed (Redis or JSON) — treating as no recovery marker'
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Delete the synthetic-timeout marker once a late result has been recovered
+   * (or determined unrecoverable). Fails soft — the marker self-expires via TTL.
+   */
+  async clearSyntheticTimeout(jobId: string): Promise<void> {
+    const key = `${REDIS_KEY_PREFIXES.MULTI_TAG_SYNTHETIC_TIMEOUT}${jobId}`;
+    try {
+      await this.redis.del(key);
+    } catch (err) {
+      logger.warn(
+        { err, jobId },
+        'clearSyntheticTimeout Redis call failed — marker will expire via TTL'
+      );
     }
   }
 

--- a/services/bot-client/src/services/MultiTagRecovery.ts
+++ b/services/bot-client/src/services/MultiTagRecovery.ts
@@ -60,17 +60,17 @@
  * completes — channel/message fetches require an authenticated client.
  */
 
-import type { Client, Message, Channel } from 'discord.js';
+import type { Client, Message } from 'discord.js';
 import type { Queue } from 'bullmq';
 import {
   createLogger,
-  isTypingChannel,
   type LLMGenerationResult,
   type LoadedPersonality,
   type PersonaResolver,
   type TypingChannel,
   MULTI_TAG,
 } from '@tzurot/common-types';
+import { fetchTypingChannel } from '../utils/fetchTypingChannel.js';
 import type { MultiTagCoordinator } from './MultiTagCoordinator.js';
 import type {
   MultiTagPersistence,
@@ -569,21 +569,7 @@ export class MultiTagRecovery {
   }
 
   private async fetchTypingChannel(channelId: string): Promise<TypingChannel | null> {
-    try {
-      const channel: Channel | null = await this.deps.discordClient.channels.fetch(channelId);
-      if (channel === null) {
-        return null;
-      }
-      // `isTypingChannel` expects a Message['channel']-typed value but the
-      // type guard's predicate works structurally — cast through unknown.
-      if (!isTypingChannel(channel as unknown as Message['channel'])) {
-        return null;
-      }
-      return channel as unknown as TypingChannel;
-    } catch (err) {
-      logger.warn({ err, channelId }, 'Recovery: channel fetch failed');
-      return null;
-    }
+    return fetchTypingChannel(this.deps.discordClient, channelId);
   }
 
   private async fetchSourceMessage(

--- a/services/bot-client/src/services/ResponseOrderingService.test.ts
+++ b/services/bot-client/src/services/ResponseOrderingService.test.ts
@@ -4,7 +4,13 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ResponseOrderingService } from './ResponseOrderingService.js';
-import type { LLMGenerationResult } from '@tzurot/common-types';
+import { MULTI_TAG, type LLMGenerationResult } from '@tzurot/common-types';
+
+/** Comfortably past the ordering buffer's safety timeout. */
+const PAST_ORDERING_TIMEOUT_MS = MULTI_TAG.ORDERING_MAX_WAIT_MS + 60 * 1000;
+/** Stale threshold is 1.5x MAX_WAIT; these straddle it. */
+const WITHIN_STALE_MS = MULTI_TAG.ORDERING_MAX_WAIT_MS; // < 1.5x → fresh
+const PAST_STALE_MS = MULTI_TAG.ORDERING_MAX_WAIT_MS * 1.5 + 60 * 1000; // > 1.5x → stale
 
 describe('ResponseOrderingService', () => {
   let service: ResponseOrderingService;
@@ -283,8 +289,8 @@ describe('ResponseOrderingService', () => {
       expect(deliveredResults).toHaveLength(0);
       expect(service.getStats().totalBuffered).toBe(1);
 
-      // Advance time past timeout (10 minutes = 600000ms, + buffer)
-      vi.advanceTimersByTime(11 * 60 * 1000); // 660000ms
+      // Advance time past the ordering buffer's safety timeout
+      vi.advanceTimersByTime(PAST_ORDERING_TIMEOUT_MS);
 
       // Cancel job-1 to trigger queue reprocessing with the new time
       // (In production, this happens when job-1 times out and returns an error)
@@ -309,8 +315,8 @@ describe('ResponseOrderingService', () => {
       await service.handleResult(channelId, 'job-2', createResult('Second'), time2, deliverFn);
       expect(deliveredResults).toHaveLength(0);
 
-      // Advance time past timeout (11 minutes > 10 minute MAX_WAIT_MS = 600000ms)
-      vi.advanceTimersByTime(11 * 60 * 1000);
+      // Advance time past the ordering buffer's safety timeout
+      vi.advanceTimersByTime(PAST_ORDERING_TIMEOUT_MS);
 
       // Register and complete job 3 - this triggers reprocessing
       service.registerJob(channelId, 'job-3', time3);
@@ -559,8 +565,8 @@ describe('ResponseOrderingService', () => {
 
       service.registerJob(channelId, 'job-1', time);
 
-      // Advance time but stay within threshold (10 min * 1.5 = 15 min)
-      vi.advanceTimersByTime(14 * 60 * 1000); // 14 minutes
+      // Advance time but stay within the 1.5x-MAX_WAIT stale threshold
+      vi.advanceTimersByTime(WITHIN_STALE_MS);
 
       const result = service.cleanupStaleJobs();
 
@@ -576,7 +582,7 @@ describe('ResponseOrderingService', () => {
       service.registerJob(channelId, 'job-1', time);
 
       // Advance time past threshold (10 min * 1.5 = 15 min)
-      vi.advanceTimersByTime(16 * 60 * 1000); // 16 minutes
+      vi.advanceTimersByTime(PAST_STALE_MS);
 
       const result = service.cleanupStaleJobs();
 
@@ -593,7 +599,7 @@ describe('ResponseOrderingService', () => {
       service.registerJob('channel-3', 'job-3', time);
 
       // Advance time past threshold
-      vi.advanceTimersByTime(16 * 60 * 1000);
+      vi.advanceTimersByTime(PAST_STALE_MS);
 
       const result = service.cleanupStaleJobs();
 
@@ -610,7 +616,7 @@ describe('ResponseOrderingService', () => {
       service.registerJob(channelId, 'job-old', time);
 
       // Advance time past threshold
-      vi.advanceTimersByTime(16 * 60 * 1000);
+      vi.advanceTimersByTime(PAST_STALE_MS);
 
       // Register new job (after advancing time)
       const newTime = new Date('2024-01-01T10:20:00Z');
@@ -629,7 +635,7 @@ describe('ResponseOrderingService', () => {
       service.registerJob(channelId, 'job-1', time);
 
       // Advance time past threshold
-      vi.advanceTimersByTime(16 * 60 * 1000);
+      vi.advanceTimersByTime(PAST_STALE_MS);
 
       service.cleanupStaleJobs();
 
@@ -651,7 +657,7 @@ describe('ResponseOrderingService', () => {
       expect(deliveredResults).toHaveLength(0);
 
       // Advance time past threshold
-      vi.advanceTimersByTime(16 * 60 * 1000);
+      vi.advanceTimersByTime(PAST_STALE_MS);
 
       // Clean up stale job-1
       service.cleanupStaleJobs();

--- a/services/bot-client/src/services/ResponseOrderingService.ts
+++ b/services/bot-client/src/services/ResponseOrderingService.ts
@@ -9,10 +9,11 @@
  * 1. When a job is registered, we record its userMessageTime (chronological order)
  * 2. When a result arrives, we buffer it if older jobs are still pending
  * 3. We deliver results in userMessageTime order, waiting for predecessors
- * 4. Safety timeout (10 min) prevents indefinite blocking if a job is lost
+ * 4. Safety timeout (MULTI_TAG.ORDERING_MAX_WAIT_MS) prevents indefinite
+ *    blocking if a job is lost
  */
 
-import { createLogger, TIMEOUTS, type LLMGenerationResult } from '@tzurot/common-types';
+import { createLogger, MULTI_TAG, type LLMGenerationResult } from '@tzurot/common-types';
 
 const logger = createLogger('ResponseOrderingService');
 
@@ -63,8 +64,13 @@ export class ResponseOrderingService {
   /** Channel-scoped queues (different channels are independent) */
   private channelQueues = new Map<string, ChannelQueue>();
 
-  /** Safety timeout - matches TIMEOUTS.JOB_WAIT (10 min = 600000ms) */
-  private readonly MAX_WAIT_MS = TIMEOUTS.JOB_WAIT;
+  /**
+   * Safety timeout — held equal to MULTI_TAG.COORDINATOR_TIMEOUT_MS (18 min).
+   * Decoupled from TIMEOUTS.JOB_WAIT (shared with the short STT-transcription
+   * gateway wait) so this buffer can wait as long as the coordinator without
+   * force-processing a group before the coordinator's backstop fires.
+   */
+  private readonly MAX_WAIT_MS = MULTI_TAG.ORDERING_MAX_WAIT_MS;
 
   /** Periodic cleanup interval handle */
   private cleanupInterval: ReturnType<typeof setInterval> | null = null;
@@ -353,8 +359,8 @@ export class ResponseOrderingService {
    * Without cleanup, these orphaned jobs would stay in pendingJobs forever,
    * causing a slow memory leak over long uptimes.
    *
-   * Stale threshold: 1.5x MAX_WAIT_MS (15 minutes when MAX_WAIT is 10 min)
-   * This gives plenty of time for normal processing + retries.
+   * Stale threshold: 1.5x MAX_WAIT_MS (27 minutes at the current 18-min
+   * MAX_WAIT). This gives plenty of time for normal processing + retries.
    */
   cleanupStaleJobs(): { cleanedCount: number; channelsCleaned: string[] } {
     const staleThreshold = Date.now() - this.MAX_WAIT_MS * 1.5;

--- a/services/bot-client/src/services/multiTagDeliveryFlow.test.ts
+++ b/services/bot-client/src/services/multiTagDeliveryFlow.test.ts
@@ -158,6 +158,23 @@ describe('deliverGroup', () => {
     expect(synthetic.errorInfo.referenceId).toBe(entry.groupId);
   });
 
+  it('skips confirmDelivery for timed-out slots but confirms completed ones', async () => {
+    const entry = buildEntry({
+      slots: [
+        buildSlot('Alice', { slotIndex: 0, jobId: 'job-Alice', status: 'completed' }),
+        buildSlot('Bob', { slotIndex: 1, jobId: 'job-Bob', status: 'timedout', result: undefined }),
+      ],
+    });
+
+    await deliverGroup(entry, deps);
+
+    // Completed slot gets confirmed; timed-out slot does NOT (ai-worker never
+    // wrote its JobResult row → confirmDelivery would be a guaranteed 404).
+    expect(gatewayClient.confirmDelivery).toHaveBeenCalledTimes(1);
+    expect(gatewayClient.confirmDelivery).toHaveBeenCalledWith('job-Alice');
+    expect(gatewayClient.confirmDelivery).not.toHaveBeenCalledWith('job-Bob');
+  });
+
   it('renders the personality error message on safety timeout when configured', async () => {
     const entry = buildEntry({
       slots: [

--- a/services/bot-client/src/services/multiTagDeliveryFlow.ts
+++ b/services/bot-client/src/services/multiTagDeliveryFlow.ts
@@ -189,15 +189,21 @@ export async function deliverGroup(entry: RuntimeEntry, deps: DeliveryFlowDeps):
   }
 
   // Best-effort delivery confirmation (clears Redis stream entries).
+  // Skip slots synthesized on safety-timeout (`status === 'timedout'`):
+  // ai-worker never wrote a JobResult row for them, so confirmDelivery is a
+  // guaranteed 404. Their real confirmation happens via the late-result
+  // recovery path in MessageHandler if/when the result eventually lands.
   await Promise.all(
-    entry.slots.map(slot =>
-      deps.gatewayClient.confirmDelivery(slot.jobId).catch(err => {
-        logger.warn(
-          { err, jobId: slot.jobId, groupId: entry.groupId },
-          'confirmDelivery failed after multi-tag flush'
-        );
-      })
-    )
+    entry.slots
+      .filter(slot => slot.status !== 'timedout')
+      .map(slot =>
+        deps.gatewayClient.confirmDelivery(slot.jobId).catch(err => {
+          logger.warn(
+            { err, jobId: slot.jobId, groupId: entry.groupId },
+            'confirmDelivery failed after multi-tag flush'
+          );
+        })
+      )
   );
 
   // For DM channels, record the new active personality so the next bare

--- a/services/bot-client/src/utils/fetchTypingChannel.test.ts
+++ b/services/bot-client/src/utils/fetchTypingChannel.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Client } from 'discord.js';
+import { fetchTypingChannel } from './fetchTypingChannel.js';
+
+function makeClient(fetchImpl: () => Promise<unknown>): Client {
+  return { channels: { fetch: vi.fn(fetchImpl) } } as unknown as Client;
+}
+
+// A GuildText-shaped channel passes isTypingChannel (type 0 + text-based).
+const typingChannel = {
+  id: 'chan-1',
+  type: 0,
+  isTextBased: () => true,
+  isThread: () => false,
+};
+
+describe('fetchTypingChannel', () => {
+  it('returns the channel when it is a typing channel', async () => {
+    const client = makeClient(async () => typingChannel);
+    const result = await fetchTypingChannel(client, 'chan-1');
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe('chan-1');
+  });
+
+  it('returns null when the channel is not found', async () => {
+    const client = makeClient(async () => null);
+    expect(await fetchTypingChannel(client, 'missing')).toBeNull();
+  });
+
+  it('returns null for a non-typing channel (e.g. category)', async () => {
+    // type 4 = GuildCategory — not text-based, fails isTypingChannel
+    const category = { id: 'cat-1', type: 4, isTextBased: () => false };
+    const client = makeClient(async () => category);
+    expect(await fetchTypingChannel(client, 'cat-1')).toBeNull();
+  });
+
+  it('returns null (fails soft) when the fetch throws', async () => {
+    const client = makeClient(async () => {
+      throw new Error('Unknown Channel');
+    });
+    expect(await fetchTypingChannel(client, 'boom')).toBeNull();
+  });
+});

--- a/services/bot-client/src/utils/fetchTypingChannel.ts
+++ b/services/bot-client/src/utils/fetchTypingChannel.ts
@@ -1,0 +1,35 @@
+/**
+ * Fetch a Discord channel by ID and narrow it to a {@link TypingChannel}
+ * (a channel the bot can send/typing-indicate in).
+ *
+ * Used by paths that reconstruct a delivery target after the in-memory
+ * Discord objects are gone — multi-tag restart recovery and late-result
+ * recovery. Returns null on fetch failure, missing channel, or a channel
+ * type the bot can't deliver to (category, stage, etc.).
+ */
+
+import type { Channel, Client, Message } from 'discord.js';
+import { createLogger, isTypingChannel, type TypingChannel } from '@tzurot/common-types';
+
+const logger = createLogger('fetchTypingChannel');
+
+export async function fetchTypingChannel(
+  client: Client,
+  channelId: string
+): Promise<TypingChannel | null> {
+  try {
+    const channel: Channel | null = await client.channels.fetch(channelId);
+    if (channel === null) {
+      return null;
+    }
+    // `isTypingChannel` expects a `Message['channel']`-typed value, but the
+    // type guard's predicate works structurally — cast through unknown.
+    if (!isTypingChannel(channel as unknown as Message['channel'])) {
+      return null;
+    }
+    return channel as unknown as TypingChannel;
+  } catch (err) {
+    logger.warn({ err, channelId }, 'fetchTypingChannel: channel fetch failed');
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the production bug gated as pre-beta.126 in `production-issues.md`: a multi-tag chat job with 10 extended-context images ran **11m38s**, but the coordinator's **10-min** safety timeout fired first → bot delivered a synthetic timeout error → ~1min later the real reply arrived and was **silently dropped**, plus `confirmDelivery` 404 noise.

### Tier 1 — raise the budget
- `MULTI_TAG.COORDINATOR_TIMEOUT_MS` 10 → **18 min** (under the 20-min `WORKER_LOCK_DURATION`). The observed job no longer times out.
- New `MULTI_TAG.ORDERING_MAX_WAIT_MS` (18 min); `ResponseOrderingService.MAX_WAIT_MS` uses it instead of the **shared** `TIMEOUTS.JOB_WAIT` — so the chat ordering buffer waits as long as the coordinator without lengthening the STT-transcription wait. Held `>= COORDINATOR` so the buffer never force-processes before the backstop.

### Tier 2 — stop confirming synthetic slots
- `deliverGroup` skips `confirmDelivery` for `status === 'timedout'` slots (guaranteed 404; ai-worker never wrote their JobResult row).

### Tier 3 — late-result recovery
- `handleSafetyTimeout` writes a per-jobId recovery marker (`MultiTagPersistence.markSyntheticTimeout`/`get`/`clear`, 30-min TTL) before `deleteEntry` wipes the snapshot.
- `MessageHandler.tryRecoverLateResult` intercepts at the unknown-job drop: reloads personality + re-fetches channel + re-sends the real result as a follow-up (notice-prefixed), then confirms + clears. Failed/empty → clear, no second message; miss → drop as before.
- Extracted shared `fetchTypingChannel` util; `MultiTagRecovery` delegates to it.

### Composition
- `buildMessageHandler` bundles the processor chain + handler (its only consumer) to keep `index.ts` under max-lines while wiring the two new deps.

## Test plan
- [x] common-types 2802 + bot-client 4963 green (incl. new recovery/marker/skip tests)
- [x] `pnpm quality` green
- [ ] CI integration-tests (skipped locally — `pnpm test:int` OOMs the Deck)

Ships in **beta.126** with the typed-client epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)