### PR TITLE
chore: quick-wins sweep (orderBy, cpd msg, prettier-exempt, invariant test, stale comment)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,3 +16,9 @@ pnpm-lock.yaml
 # bodies that contain glob-pattern strings (the asterisks confuse the
 # JSDoc parser), so the codegen output is excluded from formatting.
 _generated/
+
+# Backlog section files are markdown tables whose column widths prettier
+# auto-widens to the longest cell — so a one-line entry addition triggers a
+# whole-table reformat, drowning the real change in alignment noise. Column
+# widths drift naturally and have zero review value, so exclude them.
+backlog/

--- a/packages/common-types/src/constants/message.test.ts
+++ b/packages/common-types/src/constants/message.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Tests for message constants.
+ *
+ * These assert the timing invariants the MULTI_TAG coordinator depends on.
+ * They previously lived only as JSDoc prose in message.ts — nothing failed if
+ * a future edit broke them. Locking them in here means a change to one constant
+ * that violates the relationship fails CI instead of misbehaving in production.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { MULTI_TAG } from './message.js';
+import { TIMEOUTS } from './timing.js';
+
+describe('MULTI_TAG timing invariants', () => {
+  it('coordinator timeout is at least the ordering buffer wait', () => {
+    // The per-channel ordering buffer must not force-process a group before the
+    // coordinator backstop fires; otherwise late slots get dropped. Keeping the
+    // coordinator budget >= the ordering wait guarantees the backstop is last.
+    expect(MULTI_TAG.COORDINATOR_TIMEOUT_MS).toBeGreaterThanOrEqual(MULTI_TAG.ORDERING_MAX_WAIT_MS);
+  });
+
+  it('coordinator timeout stays under the worker lock duration', () => {
+    // The bot-side coordinator wait must finish before the worker lock expires,
+    // or the lock can be reclaimed mid-coordination and two replicas race.
+    expect(MULTI_TAG.COORDINATOR_TIMEOUT_MS).toBeLessThan(TIMEOUTS.WORKER_LOCK_DURATION);
+  });
+});

--- a/packages/tooling/src/commands/cpd.ts
+++ b/packages/tooling/src/commands/cpd.ts
@@ -220,6 +220,12 @@ async function runCheckCommand(options: CheckCommandOptions): Promise<void> {
           '`pnpm ops cpd:update-baseline` to refresh against the current config.'
       )
     );
+    console.error(
+      chalk.dim(
+        'If you passed a non-default `--threshold`, that itself causes the drift — ' +
+          "confirm it matches the baseline's `threshold` field rather than refreshing."
+      )
+    );
     process.exit(1);
   }
 

--- a/services/api-gateway/src/routes/admin/diagnostic.test.ts
+++ b/services/api-gateway/src/routes/admin/diagnostic.test.ts
@@ -603,6 +603,7 @@ describe('Admin Diagnostic Routes', () => {
         where: {
           responseMessageIds: { has: '9999888877776666555' },
         },
+        orderBy: { createdAt: 'desc' },
       });
     });
 
@@ -638,6 +639,7 @@ describe('Admin Diagnostic Routes', () => {
       expect(response.status).toBe(200);
       expect(mockPrisma.llmDiagnosticLog.findFirst).toHaveBeenCalledWith({
         where: { responseMessageIds: { has: 'chunk-2' } },
+        orderBy: { createdAt: 'desc' },
       });
     });
   });
@@ -801,6 +803,7 @@ describe('Admin Diagnostic Routes', () => {
 
       expect(mockPrisma.llmDiagnosticLog.findFirst).toHaveBeenCalledWith({
         where: { responseMessageIds: { has: 'chunk-1' }, userId: 'regular-user-789' },
+        orderBy: { createdAt: 'desc' },
       });
     });
 
@@ -811,6 +814,7 @@ describe('Admin Diagnostic Routes', () => {
 
       expect(mockPrisma.llmDiagnosticLog.findFirst).toHaveBeenCalledWith({
         where: { responseMessageIds: { has: 'chunk-1' } },
+        orderBy: { createdAt: 'desc' },
       });
     });
 

--- a/services/api-gateway/src/routes/admin/diagnostic.ts
+++ b/services/api-gateway/src/routes/admin/diagnostic.ts
@@ -362,6 +362,9 @@ export const handleGetDiagnosticByResponse = (deps: RouteDeps): RequestHandler =
         responseMessageIds: { has: messageId },
         ...(ownerAccess ? {} : { userId: callerUserId }),
       },
+      // Deterministic tiebreak: if multiple rows ever share a response message
+      // ID, return the most recent — matches handleGetByMessage's ordering.
+      orderBy: { createdAt: 'desc' },
     });
 
     if (!log) {

--- a/services/api-gateway/src/services/sync/config/syncTables.ts
+++ b/services/api-gateway/src/services/sync/config/syncTables.ts
@@ -98,12 +98,15 @@ export const SYNC_CONFIG: Record<SyncTableName, TableSyncConfig> = {
     // transaction can issue SET CONSTRAINTS … DEFERRED and let Postgres
     // validate the references at COMMIT time, when every cross-table
     // referenced row exists:
-    //   - default_persona_id, default_llm_config_id: DEFERRABLE since
-    //     migration 20260418010642 (the original circular-FK fix).
-    //   - default_tts_config_id: DEFERRABLE since migration 20260504065151
-    //     (added when the TTS feature shipped — the column is NULLABLE
-    //     but that only relaxes the NOT NULL constraint, not the FK
-    //     reference check, so it still needed DEFERRABLE for sync).
+    //   - default_persona_id (NOT NULL), default_llm_config_id (nullable):
+    //     DEFERRABLE since migration 20260418010642 (the original circular-FK fix).
+    //   - default_tts_config_id (nullable): DEFERRABLE since migration
+    //     20260504065151 (added when the TTS feature shipped).
+    // Nullability is orthogonal to DEFERRABLE: deferral controls *when* the FK
+    // reference is validated (at COMMIT, after the referenced row is synced),
+    // not whether the column may be NULL. A non-NULL FK still needs deferral
+    // here because its target row is inserted later in SYNC_TABLE_ORDER; a
+    // nullable column simply skips the check when its value is NULL.
     // Last-write-wins on users.updated_at resolves cross-env conflicts.
   },
   personas: {
@@ -237,17 +240,18 @@ export const SYNC_CONFIG: Record<SyncTableName, TableSyncConfig> = {
  *
  * Dependencies:
  * - system_prompts: no FK deps
- * - users: default_persona_id → personas.id AND default_llm_config_id → llm_configs.id
- *   (both circular NOT NULL). The enclosing sync transaction uses DEFERRABLE
- *   constraints + SET CONSTRAINTS ALL DEFERRED (see migration 20260418010642)
- *   so users inserts can carry real FK values; Postgres validates at COMMIT.
+ * - users: default_persona_id → personas.id (NOT NULL) AND
+ *   default_llm_config_id → llm_configs.id (nullable), both circular. The
+ *   enclosing sync transaction uses DEFERRABLE constraints + SET CONSTRAINTS
+ *   ALL DEFERRED (see migration 20260418010642) so users inserts can carry
+ *   real FK values; Postgres validates at COMMIT.
  * - llm_configs: owner_id → users (NOT NULL, also circular; same deferred handling)
  * - tts_configs: owner_id → users (NOT NULL); users.default_tts_config_id is
- *   NULLABLE (unlike default_llm_config_id which is NOT NULL), but the FK
- *   users_default_tts_config_id_fkey is still DEFERRABLE (migration
- *   20260504065151) — NULLABLE only relaxes the NOT NULL check, not the FK
- *   reference check, so a user with a non-NULL default_tts_config_id would
- *   fail an immediate FK validation during users-sync without DEFERRABLE.
+ *   NULLABLE (like default_llm_config_id; only default_persona_id is NOT NULL),
+ *   but the FK users_default_tts_config_id_fkey is still DEFERRABLE (migration
+ *   20260504065151). Nullability only governs whether the column may be NULL,
+ *   not the FK reference check: a user with a non-NULL default_tts_config_id
+ *   would fail an immediate FK validation during users-sync without DEFERRABLE.
  *   Same deferred handling as the original four FKs.
  * - personas: owner_id → users (NOT NULL, also circular; same deferred handling)
  * - personalities: system_prompt_id → system_prompts, owner_id → users (NOT NULL)


### PR DESCRIPTION
Five independent trivial quick-wins batched (each ~1-15 LOC, no shared logic):

| Item | Change | Source |
|------|--------|--------|
| QW6 | `handleGetByResponse` findFirst gains `orderBy: { createdAt: 'desc' }` deterministic tiebreak (+ 4 test-assertion updates for the new call shape) | PR #1087 r8 |
| QW4 | `cpd:check` configHash-drift error now hints that a non-default `--threshold` is itself the drift cause (don't blindly refresh the baseline) | PR #1084 r7 |
| QW8 | `.prettierignore` exempts `backlog/` — table-column reformat noise on every entry has zero review value | PR #1110 |
| QW2 | New `message.test.ts` locks the MULTI_TAG timing invariants (`COORDINATOR >= ORDERING_MAX_WAIT`, `COORDINATOR < WORKER_LOCK`) that were JSDoc-only | PR #1117 |
| #91 | Two stale comment blocks in `syncTables.ts` claimed `default_llm_config_id` is NOT NULL — schema has it nullable (only `default_persona_id` is NOT NULL). Corrected both, clarified nullability is orthogonal to DEFERRABLE | promoted from `deferred.md` |

Verified: `pnpm quality` green; targeted `diagnostic.test.ts` (42) + `message.test.ts` (2) pass; full pre-push suite green.