### PR TITLE
chore(repo): drop vitest to 1 worker under LOW_RESOURCE_MODE to stop Deck OOM

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -73,6 +73,11 @@ if [ -n "$LOW_RESOURCE_MODE" ]; then
     TURBO_ARGS="$TURBO_ARGS --concurrency=1"
     # Cap Node.js memory to 2GB per process
     export NODE_OPTIONS="--max-old-space-size=2048"
+    # Export the flag itself so the vitest subprocess (turbo → pnpm → vitest)
+    # sees it and drops maxWorkers to 1 (see vitest.config.ts). Sourced from
+    # .env above as a local shell var; without this export child processes
+    # never see it and the intra-package thread count stays at 3.
+    export LOW_RESOURCE_MODE
 fi
 
 # 5. Determine filter scope for Turbo

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:int": "vitest run --config vitest.int.config.ts",
     "test:e2e": "vitest run --config vitest.e2e.config.ts",
     "test:all": "pnpm test && pnpm test:int",
-    "test:low-mem": "pnpm --workspace-concurrency=1 --filter './services/*' --filter './packages/*' test",
+    "test:low-mem": "LOW_RESOURCE_MODE=1 NODE_OPTIONS=--max-old-space-size=2048 pnpm --workspace-concurrency=1 --filter './services/*' --filter './packages/*' test",
     "test:failures": "turbo run test --output-logs=errors-only -- --reporter=verbose",
     "test:summary": "pnpm ops dev:test-summary",
     "lint": "turbo run lint",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,12 +4,20 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    // Limit worker threads to reduce memory usage (default uses all CPU cores)
-    // With heavy mocking, each worker can consume 500MB-1GB
-    // 3 workers × ~700MB = ~2.1GB (safe for 5GB available RAM)
-    // Note: Vitest 4 moved poolOptions to top-level options
+    // Limit worker threads to reduce memory usage (default uses all CPU cores).
+    // With heavy mocking each worker can consume 500MB-1GB (v8 coverage pushes
+    // higher). On CI / capable machines we run 3 workers (~2.1GB).
+    //
+    // Under LOW_RESOURCE_MODE=1 (Steam Deck — set via .env or shell, exported by
+    // .husky/pre-push) we drop to a SINGLE worker. This is the piece the other
+    // throttles miss: `turbo --concurrency=1` serializes packages and
+    // NODE_OPTIONS caps each process heap at 2GB, but neither reduces vitest's
+    // intra-package thread count — so 3 workers × up to 2GB = ~6GB still OOM'd
+    // the Deck (repeated IDE crashes). One worker keeps a package's run near the
+    // 2GB heap cap. Trades speed for stability; only engages when the flag is set.
+    // Note: Vitest 4 moved poolOptions to top-level options.
     pool: 'threads',
-    maxWorkers: 3,
+    maxWorkers: process.env.LOW_RESOURCE_MODE === '1' ? 1 : 3,
     minWorkers: 1,
     // Note: mockReset/restoreMocks were attempted but broke 57+ tests across
     // api-gateway and bot-client that rely on module-level mock persistence.


### PR DESCRIPTION
## Problem

The Steam Deck repeatedly OOM-crashed the IDE during local test runs, despite `LOW_RESOURCE_MODE` already existing. Root cause: the existing throttles never reduced vitest's **intra-package worker count**.

Under `LOW_RESOURCE_MODE`, the pre-push hook does:
- `turbo --concurrency=1` — serializes *packages* (one at a time)
- `NODE_OPTIONS=--max-old-space-size=2048` — caps each Node process heap at 2GB

But vitest still ran `maxWorkers: 3` *within* each package → 3 workers × up to 2GB = **~6GB**, past the Deck's ~5GB available. And the hook set `LOW_RESOURCE_MODE` as a local shell var without `export`ing it, so a vitest subprocess couldn't see it anyway.

## Fix (3 coordinated changes)

| File | Change |
|------|--------|
| `vitest.config.ts` | `maxWorkers = LOW_RESOURCE_MODE === '1' ? 1 : 3`. CI / capable machines unchanged at 3; the Deck drops to a single worker (~2GB, near the heap cap). Only engages with the flag. |
| `.husky/pre-push` | `export LOW_RESOURCE_MODE` so the vitest subprocess actually sees it (previously only `NODE_OPTIONS` was exported). |
| `package.json` | `test:low-mem` now sets `LOW_RESOURCE_MODE=1` + the 2GB heap cap inline; previously it only serialized pnpm workspaces, leaving 3 workers each. |

## Scope note

This does **not** fix `test:int` OOM — the integration config already uses `singleFork: true` (one process), so worker-count tuning can't help it. That remains best-handled by running integration tests on CI (existing guidance). Filing nothing new; this PR is scoped to the unit-test path.

Verified: config loads + tests pass under both `LOW_RESOURCE_MODE=1` and default; full pre-push suite green.