### PR TITLE
chore: apply beta.126 PR #1120 review nits (4 optional clarifications)

### DIFF
--- a/packages/common-types/src/clients/transport.ts
+++ b/packages/common-types/src/clients/transport.ts
@@ -70,6 +70,12 @@ export interface TransportOptions {
    * Optional Zod schema for the success-path response. When supplied,
    * `data` is validated and any failure surfaces as `{ ok: false, ... }`
    * with status 0 (no HTTP error, just contract drift).
+   *
+   * WARNING: when omitted, the response body is returned as `data` via an
+   * unchecked `as T` cast — there is NO runtime contract enforcement. Generated
+   * clients always pass `routeDef.output`, so this only bites direct callers of
+   * `callGateway` / `callGatewayOrThrow` that skip the schema. Omit only when
+   * the body is genuinely opaque (e.g. a passthrough proxy); otherwise pass one.
    */
   outputSchema?: z.ZodTypeAny;
   /** Optional logger callback for diagnostics. Avoids hard dep on pino. */

--- a/packages/common-types/src/routes/types.ts
+++ b/packages/common-types/src/routes/types.ts
@@ -276,6 +276,11 @@ export interface RouteDef<
    * `cleanup`, the shapes import/export routes). Typically
    * `GATEWAY_TIMEOUTS.DEFERRED` (10s) or `BULK_OPERATION` (30s).
    *
+   * Upper bound: a value above ~60s is a design smell, not a valid config —
+   * a sync gateway request that needs more than a minute should be a BullMQ
+   * job with push-based result delivery, not a blocking HTTP call. The
+   * manifest invariant test caps timeoutMs at 60_000 to enforce this.
+   *
    * If a route comfortably fits the 2500ms default, do NOT just omit this
    * field — also register its id in `DEFAULT_TIMEOUT_OK` in `manifest.test.ts`.
    * That test enforces that relying on the default is a conscious "this op is

--- a/services/api-gateway/src/routes/user/memoryBatchHelpers.ts
+++ b/services/api-gateway/src/routes/user/memoryBatchHelpers.ts
@@ -1,9 +1,9 @@
 /**
  * Private helpers for memoryBatch.ts handlers.
  *
- * Extracted to a sibling file purely to keep memoryBatch.ts under the
- * max-lines threshold — these helpers are not part of the public API and
- * only have one caller each (the corresponding batch handler).
+ * Extracted to a sibling file to keep memoryBatch.ts under the max-lines
+ * threshold — these helpers are not part of the public API and have exactly
+ * one caller each (the corresponding batch handler).
  */
 
 import type { Response } from 'express';
@@ -61,6 +61,10 @@ export async function resolvePersonaIdForBatch(
     select: { id: true, ownerId: true },
   });
 
+  // Intentional 403/404 conflation: a missing persona (`persona` is null) and a
+  // persona owned by someone else both return the same `forbidden` response.
+  // Distinguishing them would let a caller probe which persona IDs exist
+  // (existence enumeration), so we deliberately collapse both into one 403.
   if (persona?.ownerId !== userId) {
     sendError(res, ErrorResponses.forbidden('Persona not found or does not belong to you'));
     return null;

--- a/services/api-gateway/src/services/MemoryActionTokenService.ts
+++ b/services/api-gateway/src/services/MemoryActionTokenService.ts
@@ -124,7 +124,7 @@ export class MemoryActionTokenService {
       const payload = JSON.parse(raw) as PreviewTokenPayload;
       return payload.filter;
     } catch (error) {
-      logger.warn({ err: error, userId }, 'Failed to parse preview token payload on peek');
+      logger.error({ err: error, userId }, 'Failed to parse preview token payload on peek');
       return null;
     }
   }
@@ -150,7 +150,7 @@ export class MemoryActionTokenService {
       const payload = JSON.parse(raw) as PreviewTokenPayload;
       return payload.filter;
     } catch (error) {
-      logger.warn({ err: error, userId }, 'Failed to parse preview token payload');
+      logger.error({ err: error, userId }, 'Failed to parse preview token payload');
       return null;
     }
   }
@@ -192,7 +192,7 @@ export class MemoryActionTokenService {
       const payload = JSON.parse(raw) as PurgeTokenPayload;
       return { personalityId: payload.personalityId };
     } catch (error) {
-      logger.warn({ err: error, userId }, 'Failed to parse purge token payload on peek');
+      logger.error({ err: error, userId }, 'Failed to parse purge token payload on peek');
       return null;
     }
   }
@@ -216,7 +216,7 @@ export class MemoryActionTokenService {
       const payload = JSON.parse(raw) as PurgeTokenPayload;
       return { personalityId: payload.personalityId };
     } catch (error) {
-      logger.warn({ err: error, userId }, 'Failed to parse purge token payload');
+      logger.error({ err: error, userId }, 'Failed to parse purge token payload');
       return null;
     }
   }


### PR DESCRIPTION
Applies the four non-blocking observations from the beta.126 release-PR (#1120) claude-review. All documentation/observability, no behavior change except a log-level bump.

| # | File | Change |
|---|------|--------|
| 1 | `transport.ts` | JSDoc warning on `TransportOptions.outputSchema`: omitting it returns the body via an unchecked `as T` cast (no runtime contract enforcement). Generated clients always pass `output`; only direct `callGateway`/`callGatewayOrThrow` callers can hit the gap. |
| 2 | `routes/types.ts` | Document the `RouteDef.timeoutMs` upper bound: a value >~60s is a design smell (use a BullMQ job, not a blocking HTTP call); the manifest invariant test caps at 60_000. |
| 3 | `memoryBatchHelpers.ts` | Comment the intentional 403/404 conflation in `resolvePersonaIdForBatch` (collapsing missing-vs-not-yours prevents persona existence enumeration); drop "purely" from the extraction header. |
| 4 | `MemoryActionTokenService.ts` | Parse-failure catches now log at `error` (was `warn`). The `try` wraps **only** `JSON.parse` (the Redis call is awaited outside it), so a hit means genuine payload corruption — distinct from the normal `debug`-level miss path. No test asserts the level. |

Verified: `MemoryActionTokenService.test.ts` (21) passes; lint + typecheck green on both touched packages; codegen-routes regenerated to a no-op (the `types.ts` JSDoc change doesn't alter generated output).