### PR TITLE
refactor(bot-client): extract shared replyError + narrow incognito timeframe via schema

### DIFF
--- a/.claude/rules/04-discord.md
+++ b/.claude/rules/04-discord.md
@@ -173,25 +173,26 @@ MUST go through CommandHandler.
 
 **ALWAYS check for existing utilities before implementing:**
 
-| Pattern               | Shared Utility                  | Location                                      |
-| --------------------- | ------------------------------- | --------------------------------------------- |
-| Browse pagination     | `createBrowseCustomIdHelpers`   | `utils/browse/customIdFactory.ts`             |
-| Browse buttons        | `buildBrowseButtons`            | `utils/browse/buttonBuilder.ts`               |
-| Browse truncation     | `truncateForSelect`             | `utils/browse/truncation.ts`                  |
-| Dashboard builder     | `buildDashboardEmbed`           | `utils/dashboard/DashboardBuilder.ts`         |
-| Dashboard modals      | `buildSectionModal`             | `utils/dashboard/ModalFactory.ts`             |
-| Dashboard sessions    | `initSessionManager`            | `utils/dashboard/SessionManager.ts`           |
-| Dashboard messages    | `DASHBOARD_MESSAGES`            | `utils/dashboard/messages.ts`                 |
-| Dashboard close       | `handleDashboardClose`          | `utils/dashboard/closeHandler.ts`             |
-| Dashboard refresh     | `createRefreshHandler`          | `utils/dashboard/refreshHandler.ts`           |
-| Dashboard delete      | `buildDeleteConfirmation`       | `utils/dashboard/deleteConfirmation.ts`       |
-| Dashboard perms       | `checkEditPermission`           | `utils/dashboard/permissionChecks.ts`         |
-| Session helpers       | `fetchOrCreateSession`          | `utils/dashboard/sessionHelpers.ts`           |
-| Dashboard select menu | `handleDashboardSectionSelect`  | `utils/dashboard/genericSelectMenuHandler.ts` |
-| Dashboard modal merge | `extractAndMergeSectionValues`  | `utils/dashboard/modalHelpers.ts`             |
-| Personality autocomp  | `handlePersonalityAutocomplete` | `utils/autocomplete/`                         |
-| Persona autocomplete  | `handlePersonaAutocomplete`     | `utils/autocomplete/`                         |
-| List sorting          | `createListComparator`          | `utils/listSorting.ts`                        |
+| Pattern                 | Shared Utility                  | Location                                      |
+| ----------------------- | ------------------------------- | --------------------------------------------- |
+| Browse pagination       | `createBrowseCustomIdHelpers`   | `utils/browse/customIdFactory.ts`             |
+| Browse buttons          | `buildBrowseButtons`            | `utils/browse/buttonBuilder.ts`               |
+| Browse truncation       | `truncateForSelect`             | `utils/browse/truncation.ts`                  |
+| Dashboard builder       | `buildDashboardEmbed`           | `utils/dashboard/DashboardBuilder.ts`         |
+| Dashboard modals        | `buildSectionModal`             | `utils/dashboard/ModalFactory.ts`             |
+| Dashboard sessions      | `initSessionManager`            | `utils/dashboard/SessionManager.ts`           |
+| Dashboard messages      | `DASHBOARD_MESSAGES`            | `utils/dashboard/messages.ts`                 |
+| Dashboard close         | `handleDashboardClose`          | `utils/dashboard/closeHandler.ts`             |
+| Dashboard refresh       | `createRefreshHandler`          | `utils/dashboard/refreshHandler.ts`           |
+| Dashboard delete        | `buildDeleteConfirmation`       | `utils/dashboard/deleteConfirmation.ts`       |
+| Dashboard perms         | `checkEditPermission`           | `utils/dashboard/permissionChecks.ts`         |
+| Session helpers         | `fetchOrCreateSession`          | `utils/dashboard/sessionHelpers.ts`           |
+| Dashboard select menu   | `handleDashboardSectionSelect`  | `utils/dashboard/genericSelectMenuHandler.ts` |
+| Dashboard modal merge   | `extractAndMergeSectionValues`  | `utils/dashboard/modalHelpers.ts`             |
+| Interaction error reply | `replyError`                    | `utils/dashboard/replyError.ts`               |
+| Personality autocomp    | `handlePersonalityAutocomplete` | `utils/autocomplete/`                         |
+| Persona autocomplete    | `handlePersonaAutocomplete`     | `utils/autocomplete/`                         |
+| List sorting            | `createListComparator`          | `utils/listSorting.ts`                        |
 
 **Never reimplement these patterns locally.**
 

--- a/services/bot-client/src/commands/character/sectionContext.ts
+++ b/services/bot-client/src/commands/character/sectionContext.ts
@@ -23,7 +23,7 @@
  * rule-of-three until those dashboards actually hit the same pattern.
  */
 
-import { MessageFlags } from 'discord.js';
+import { replyError } from '../../utils/dashboard/replyError.js';
 import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
 import { isBotOwner, type EnvConfig } from '@tzurot/common-types';
 import {
@@ -143,40 +143,4 @@ export async function resolveCharacterSectionContext(
     return null;
   }
   return loadCharacterSectionData(interaction, entityId, config, sync);
-}
-
-/**
- * Reply with an ephemeral error, adapting to the interaction's ack state.
- *
- * Three states map to three response APIs:
- * - `deferred && !replied` (caller did `deferReply`, hasn't sent the
- *   actual response yet) → `editReply` fills the deferred slot. This
- *   replaces the "Thinking…" loading indicator with the error message
- *   instead of leaving the indicator dangling + spawning a separate
- *   followUp.
- * - `replied` (caller already sent a response) → `followUp` for an
- *   additional ephemeral message.
- * - fresh (neither deferred nor replied) → `reply`.
- *
- * **PRECONDITION (deferred path)**: Callers that take the
- * `deferred && !replied` path must have called `deferReply({ flags:
- * MessageFlags.Ephemeral })`. `editReply` inherits whatever flags were
- * set by `deferReply` — passing flags here has no effect. A caller that
- * defers without ephemeral and then hits this helper would expose the
- * error message publicly.
- *
- * The deferred slot's ephemeral flag is what makes the error message
- * private; the other two paths pass `flags: Ephemeral` explicitly.
- */
-async function replyError(
-  interaction: ButtonInteraction | StringSelectMenuInteraction,
-  content: string
-): Promise<void> {
-  if (interaction.deferred && !interaction.replied) {
-    await interaction.editReply({ content });
-  } else if (interaction.replied) {
-    await interaction.followUp({ content, flags: MessageFlags.Ephemeral });
-  } else {
-    await interaction.reply({ content, flags: MessageFlags.Ephemeral });
-  }
 }

--- a/services/bot-client/src/commands/memory/incognito.ts
+++ b/services/bot-client/src/commands/memory/incognito.ts
@@ -14,6 +14,7 @@ import { escapeMarkdown } from 'discord.js';
 import {
   createLogger,
   getDurationLabel,
+  IncognitoForgetRequestSchema,
   memoryIncognitoEnableOptions,
   memoryIncognitoDisableOptions,
   memoryIncognitoForgetOptions,
@@ -266,12 +267,23 @@ export async function handleIncognitoForget(context: DeferredCommandContext): Pr
       return;
     }
 
-    // Discord slash-command `choices` constrains the runtime value to one of
-    // these three; the generated `commandOptions` typing is plain `string`,
-    // so we narrow at the boundary to match the schema's enum.
+    // Discord slash-command `choices` constrains the runtime value, but the
+    // generated `commandOptions` typing is plain `string`. Narrow via the API
+    // schema itself (the single source of truth) rather than an unchecked cast:
+    // if Discord's choices ever drift from the enum, this fails closed with a
+    // clear error instead of forwarding an invalid value to a 400.
+    const timeframeParse = IncognitoForgetRequestSchema.shape.timeframe.safeParse(timeframe);
+    if (!timeframeParse.success) {
+      logger.warn({ userId, personalityInput, timeframe }, 'Invalid incognito timeframe');
+      await context.editReply({
+        content: '❌ Invalid timeframe. Please pick one of the provided choices.',
+      });
+      return;
+    }
+
     const result = await userClient.incognitoForget({
       personalityId: resolved.id,
-      timeframe: timeframe as '5m' | '15m' | '1h',
+      timeframe: timeframeParse.data,
     });
 
     if (!result.ok) {

--- a/services/bot-client/src/commands/persona/sectionContext.ts
+++ b/services/bot-client/src/commands/persona/sectionContext.ts
@@ -19,7 +19,7 @@
  *   path for over-length legacy content
  */
 
-import { MessageFlags } from 'discord.js';
+import { replyError } from '../../utils/dashboard/replyError.js';
 import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
 import { type DashboardConfig, type SectionDefinition } from '../../utils/dashboard/types.js';
 import { fetchOrCreateSession } from '../../utils/dashboard/sessionHelpers.js';
@@ -114,32 +114,4 @@ export async function resolvePersonaSectionContext(
     return null;
   }
   return loadPersonaSectionData(interaction, entityId, sync);
-}
-
-/**
- * Reply with an ephemeral error, adapting to the interaction's ack state.
- *
- * - `deferred && !replied` → `editReply` fills the deferred slot (replaces
- *   the loading indicator instead of leaving it dangling + spawning a
- *   separate followUp).
- * - `replied` → `followUp` for an additional ephemeral message.
- * - fresh → `reply`.
- *
- * **PRECONDITION (deferred path)**: Callers must have called
- * `deferReply({ flags: MessageFlags.Ephemeral })`. `editReply` inherits
- * the deferred slot's flags; a non-ephemeral defer would expose the
- * error publicly. See `commands/character/sectionContext.ts` for the
- * canonical longer rationale.
- */
-async function replyError(
-  interaction: ButtonInteraction | StringSelectMenuInteraction,
-  content: string
-): Promise<void> {
-  if (interaction.deferred && !interaction.replied) {
-    await interaction.editReply({ content });
-  } else if (interaction.replied) {
-    await interaction.followUp({ content, flags: MessageFlags.Ephemeral });
-  } else {
-    await interaction.reply({ content, flags: MessageFlags.Ephemeral });
-  }
 }

--- a/services/bot-client/src/utils/dashboard/index.ts
+++ b/services/bot-client/src/utils/dashboard/index.ts
@@ -103,3 +103,6 @@ export { buildDeleteConfirmation } from './deleteConfirmation.js';
 
 // Permission Checks
 export { checkOwnership } from './permissionChecks.js';
+
+// Interaction error reply (ack-state-adaptive ephemeral error responder)
+export { replyError } from './replyError.js';

--- a/services/bot-client/src/utils/dashboard/replyError.test.ts
+++ b/services/bot-client/src/utils/dashboard/replyError.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import { MessageFlags } from 'discord.js';
+import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
+import { replyError } from './replyError.js';
+
+type AckState = { deferred: boolean; replied: boolean };
+
+function makeInteraction(state: AckState): {
+  interaction: ButtonInteraction | StringSelectMenuInteraction;
+  editReply: ReturnType<typeof vi.fn>;
+  followUp: ReturnType<typeof vi.fn>;
+  reply: ReturnType<typeof vi.fn>;
+} {
+  const editReply = vi.fn().mockResolvedValue(undefined);
+  const followUp = vi.fn().mockResolvedValue(undefined);
+  const reply = vi.fn().mockResolvedValue(undefined);
+  const interaction = {
+    deferred: state.deferred,
+    replied: state.replied,
+    editReply,
+    followUp,
+    reply,
+  } as unknown as ButtonInteraction | StringSelectMenuInteraction;
+  return { interaction, editReply, followUp, reply };
+}
+
+describe('replyError', () => {
+  it('deferred & not replied → editReply (fills the deferred slot, inherits its flags)', async () => {
+    const { interaction, editReply, followUp, reply } = makeInteraction({
+      deferred: true,
+      replied: false,
+    });
+
+    await replyError(interaction, 'boom');
+
+    // No explicit flags: the deferred slot's ephemeral flag is what keeps it private.
+    expect(editReply).toHaveBeenCalledWith({ content: 'boom' });
+    expect(followUp).not.toHaveBeenCalled();
+    expect(reply).not.toHaveBeenCalled();
+  });
+
+  it('replied → followUp with explicit ephemeral flag', async () => {
+    const { interaction, editReply, followUp, reply } = makeInteraction({
+      deferred: false,
+      replied: true,
+    });
+
+    await replyError(interaction, 'boom');
+
+    expect(followUp).toHaveBeenCalledWith({ content: 'boom', flags: MessageFlags.Ephemeral });
+    expect(editReply).not.toHaveBeenCalled();
+    expect(reply).not.toHaveBeenCalled();
+  });
+
+  it('fresh (neither deferred nor replied) → reply with explicit ephemeral flag', async () => {
+    const { interaction, editReply, followUp, reply } = makeInteraction({
+      deferred: false,
+      replied: false,
+    });
+
+    await replyError(interaction, 'boom');
+
+    expect(reply).toHaveBeenCalledWith({ content: 'boom', flags: MessageFlags.Ephemeral });
+    expect(editReply).not.toHaveBeenCalled();
+    expect(followUp).not.toHaveBeenCalled();
+  });
+
+  it('replied takes precedence when both deferred and replied are true', async () => {
+    // A deferred interaction that has since sent its real reply: the `replied`
+    // branch must win so we followUp rather than overwrite the sent message.
+    const { interaction, editReply, followUp } = makeInteraction({
+      deferred: true,
+      replied: true,
+    });
+
+    await replyError(interaction, 'boom');
+
+    expect(followUp).toHaveBeenCalledWith({ content: 'boom', flags: MessageFlags.Ephemeral });
+    expect(editReply).not.toHaveBeenCalled();
+  });
+});

--- a/services/bot-client/src/utils/dashboard/replyError.ts
+++ b/services/bot-client/src/utils/dashboard/replyError.ts
@@ -1,0 +1,38 @@
+import { MessageFlags } from 'discord.js';
+import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
+
+/**
+ * Reply with an ephemeral error, adapting to the interaction's ack state.
+ *
+ * Three states map to three response APIs:
+ * - `deferred && !replied` (caller did `deferReply`, hasn't sent the
+ *   actual response yet) → `editReply` fills the deferred slot. This
+ *   replaces the "Thinking…" loading indicator with the error message
+ *   instead of leaving the indicator dangling + spawning a separate
+ *   followUp.
+ * - `replied` (caller already sent a response) → `followUp` for an
+ *   additional ephemeral message.
+ * - fresh (neither deferred nor replied) → `reply`.
+ *
+ * **PRECONDITION (deferred path)**: Callers that take the
+ * `deferred && !replied` path must have called `deferReply({ flags:
+ * MessageFlags.Ephemeral })`. `editReply` inherits whatever flags were
+ * set by `deferReply` — passing flags here has no effect. A caller that
+ * defers without ephemeral and then hits this helper would expose the
+ * error message publicly.
+ *
+ * The deferred slot's ephemeral flag is what makes the error message
+ * private; the other two paths pass `flags: Ephemeral` explicitly.
+ */
+export async function replyError(
+  interaction: ButtonInteraction | StringSelectMenuInteraction,
+  content: string
+): Promise<void> {
+  if (interaction.deferred && !interaction.replied) {
+    await interaction.editReply({ content });
+  } else if (interaction.replied) {
+    await interaction.followUp({ content, flags: MessageFlags.Ephemeral });
+  } else {
+    await interaction.reply({ content, flags: MessageFlags.Ephemeral });
+  }
+}


### PR DESCRIPTION
Two bot-client cleanups promoted from backlog (`deferred.md` #46 + `quick-wins.md` QW9).

### #46 — extract duplicated `replyError`

`character/sectionContext.ts` and `persona/sectionContext.ts` had **byte-identical** private `replyError` helpers — the 3-branch ack-state-adaptive ephemeral-error responder with a load-bearing deferred-path ephemeral PRECONDITION (the persona copy literally deferred to the character one as "the canonical longer rationale"). Any fix had to land in both.

- Extracted to `utils/dashboard/replyError.ts` with the full rationale JSDoc.
- New colocated `replyError.test.ts` covers all three ack states + the both-`deferred`-and-`replied` precedence case (4 tests).
- Dropped the now-unused `MessageFlags` import from both callers.

### QW9 — narrow `incognito` timeframe via the schema, not a cast

`incognito.ts` narrowed the slash `timeframe` (typed plain `string`) to the API enum via an unchecked `as '5m' | '15m' | '1h'`. Replaced with `IncognitoForgetRequestSchema.shape.timeframe.safeParse(...)`:
- The schema is the **single source of truth** — no manual literal list to drift (a `satisfies` array wouldn't even catch the enum *growing*).
- Validates at runtime and **fails closed** with a clear user error if Discord's `choices` ever diverge from the enum, instead of forwarding an invalid value to a 400.

Verified: 49 affected tests pass (incl. 4 new `replyError`); bot-client typecheck + lint exit 0.