### PR TITLE
refactor(api-gateway): remove dead body-ownerId fallback from extractOwnerId

### DIFF
--- a/services/api-gateway/src/services/AuthMiddleware.test.ts
+++ b/services/api-gateway/src/services/AuthMiddleware.test.ts
@@ -53,16 +53,18 @@ describe('authMiddleware', () => {
       expect(extractOwnerId(req)).toBe('123456789');
     });
 
-    it('should extract owner ID from body when header not present', () => {
+    it('should ignore a body ownerId', () => {
+      // A body `{ ownerId }` is not a credential: with no X-User-Id header,
+      // extractOwnerId resolves to undefined regardless of the body contents.
       const req = {
         headers: {},
         body: { ownerId: '987654321' },
       } as unknown as Request;
 
-      expect(extractOwnerId(req)).toBe('987654321');
+      expect(extractOwnerId(req)).toBeUndefined();
     });
 
-    it('should prefer header over body when both present', () => {
+    it('should read only the header, ignoring any body ownerId', () => {
       const req = {
         headers: { 'x-user-id': 'header-id' },
         body: { ownerId: 'body-id' },
@@ -116,13 +118,13 @@ describe('authMiddleware', () => {
       expect(extractOwnerId(req)).toBe('');
     });
 
-    it('should handle empty string in body', () => {
+    it('should ignore an empty-string body ownerId', () => {
       const req = {
         headers: {},
         body: { ownerId: '' },
       } as unknown as Request;
 
-      expect(extractOwnerId(req)).toBe('');
+      expect(extractOwnerId(req)).toBeUndefined();
     });
   });
 
@@ -274,17 +276,19 @@ describe('authMiddleware', () => {
       );
     });
 
-    it('should work with owner ID in body', () => {
+    it('should NOT authenticate via a body ownerId', () => {
       vi.mocked(commonTypes.getConfig).mockReturnValue({
         BOT_OWNER_ID: 'valid-owner',
       } as any);
 
+      // Only the X-User-Id header authenticates; a body `{ ownerId }`, even the
+      // correct owner's, is not a credential and must be rejected.
       mockReq.body = { ownerId: 'valid-owner' };
 
       const middleware = requireOwnerAuth();
       middleware(mockReq as Request, mockRes as Response, mockNext);
 
-      expect(mockNext).toHaveBeenCalledOnce();
+      expect(mockNext).not.toHaveBeenCalled();
     });
 
     it('should include timestamp in error response', () => {

--- a/services/api-gateway/src/services/AuthMiddleware.ts
+++ b/services/api-gateway/src/services/AuthMiddleware.ts
@@ -19,32 +19,22 @@ import type { AuthenticatedRequest, ProvisionedRequest } from '../types.js';
 const logger = createLogger('auth-middleware');
 
 /**
- * Extract owner ID from request (checks both header and body)
+ * Extract the caller's Discord ID from the `X-User-Id` request header.
  *
  * @param req - Express request
- * @returns Owner ID if found, undefined otherwise
+ * @returns Owner ID if the header is present, undefined otherwise
  */
 export function extractOwnerId(req: Request): string | undefined {
-  // `X-User-Id` carries the caller's Discord ID. The `requireOwnerAuth`
-  // wrapper downstream (`verifyBotOwner`) gates that only the configured
-  // bot-owner ID passes; this header just identifies the caller. Set
-  // uniformly by `requireUserAuth` middleware and by bot-client's
-  // `adminFetch` for admin-route invocations.
+  // `X-User-Id` carries the caller's Discord ID and is the ONLY accepted
+  // source. The `requireOwnerAuth` wrapper downstream (`verifyBotOwner`)
+  // gates that only the configured bot-owner ID passes; this header just
+  // identifies the caller. Set uniformly by `requireUserAuth` middleware and
+  // by the generated typed clients (every OwnerClient method sends
+  // `X-User-Id: actor`). A request body is never consulted — a body value is
+  // not a credential.
   const headerUserId = req.headers['x-user-id'];
   if (typeof headerUserId === 'string') {
     return headerUserId;
-  }
-
-  // Body fallback for endpoints that POST `{ ownerId }` directly
-  // (e.g., `/admin/db-sync`, `/admin/cleanup`) — these routes predate
-  // the unified header convention and still surface ownerId in payload
-  // shape rather than relying on the request header.
-  if (
-    req.body !== null &&
-    req.body !== undefined &&
-    typeof (req.body as Record<string, unknown>).ownerId === 'string'
-  ) {
-    return (req.body as Record<string, string>).ownerId;
   }
 
   return undefined;


### PR DESCRIPTION
QW3 (reframed). `extractOwnerId` had a `{ ownerId }` request-body fallback for `/admin/db-sync` and `/admin/cleanup`, which "predated the unified header convention." The typed-client migration moved **both** commands to `ownerClient.dbSync()` / `ownerClient.cleanup()` (which send `X-User-Id`), so the fallback became unreachable.

### Verified dead (global discovery)

- `db-sync.ts` → `ownerClient.dbSync({ dryRun })`; `cleanup.ts` → `ownerClient.cleanup({ daysToKeep, target })` — both header-based, no body `ownerId`.
- No service (bot-client or ai-worker) sends `ownerId` in a gateway request body — the only repo `ownerId:` hits are a Prisma `select` and a display-object field.
- Every generated `OwnerClient` method sends `X-User-Id: actor`.
- Neither route handler reads `req.body.ownerId` directly.

### Changes

- Remove the body fallback — `extractOwnerId` is now header-only.
- Refresh the stale comment (it referenced the dissolved `adminFetch`).
- **Security tightening**: a body `ownerId`, even the correct owner's, is no longer a credential under any path. Tests updated to assert the new contract (body `ownerId` ignored / `requireOwnerAuth` rejects body-only) rather than the removed behavior.

This was kept separate from the trivial quick-wins sweep precisely because it touches an auth path — verification-gated, not blind.

Verified: `AuthMiddleware.test.ts` (69) passes; api-gateway typecheck + lint exit 0; full pre-push suite green.