### PR TITLE
fix(api-gateway,bot-client): persona-name collision → NAME_COLLISION (was opaque 500)

### DIFF
--- a/services/api-gateway/src/routes/user/persona/crud.test.ts
+++ b/services/api-gateway/src/routes/user/persona/crud.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { PrismaClient } from '@tzurot/common-types';
-import { ListPersonasResponseSchema } from '@tzurot/common-types';
+import { ListPersonasResponseSchema, API_ERROR_SUBCODE } from '@tzurot/common-types';
 import {
   createMockPrisma,
   createMockReqRes,
@@ -231,6 +231,27 @@ describe('persona CRUD routes', () => {
         })
       );
       expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    it('should return NAME_COLLISION when the persona name is already taken', async () => {
+      // Deterministic persona UUID → a duplicate (name, owner) trips P2002 on
+      // the primary key. The handler translates it to a NAME_COLLISION rather
+      // than an opaque 500.
+      mockPrisma.persona.create.mockRejectedValue({ code: 'P2002' });
+
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
+      const handler = getHandler(router, 'post', '/');
+
+      const { req, res } = createMockReqRes({
+        name: 'Existing Persona',
+        content: 'whatever',
+      });
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ code: API_ERROR_SUBCODE.NAME_COLLISION })
+      );
     });
 
     it('should reject empty name', async () => {

--- a/services/api-gateway/src/routes/user/persona/crud.ts
+++ b/services/api-gateway/src/routes/user/persona/crud.ts
@@ -23,6 +23,7 @@ import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthM
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendCustomSuccess, sendError } from '../../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
+import { isPrismaUniqueConstraintError } from '../../../utils/prismaErrors.js';
 import { sendZodError } from '../../../utils/zodHelpers.js';
 import { validateUuid } from '../../../utils/validators.js';
 import { getParam } from '../../../utils/requestParams.js';
@@ -153,18 +154,33 @@ export const handleCreatePersona = (deps: RouteDeps): RequestHandler => {
 
     const user = getOrCreateInternalUser(req);
 
-    const persona = await prisma.persona.create({
-      data: {
-        id: generatePersonaUuid(name, user.id),
-        name,
-        preferredName: preferredName ?? null,
-        description: description ?? null,
-        content,
-        pronouns: pronouns ?? null,
-        ownerId: user.id,
-      },
-      select: PERSONA_SELECT,
-    });
+    // The persona ID is a deterministic UUID of (name, ownerId), so a duplicate
+    // name for the same owner collides on the primary key (P2002). Translate to
+    // a NAME_COLLISION rather than letting asyncHandler surface an opaque 500 —
+    // mirrors the llm-config create path so bot-client can branch on the subcode.
+    let persona;
+    try {
+      persona = await prisma.persona.create({
+        data: {
+          id: generatePersonaUuid(name, user.id),
+          name,
+          preferredName: preferredName ?? null,
+          description: description ?? null,
+          content,
+          pronouns: pronouns ?? null,
+          ownerId: user.id,
+        },
+        select: PERSONA_SELECT,
+      });
+    } catch (err) {
+      if (isPrismaUniqueConstraintError(err)) {
+        return sendError(
+          res,
+          ErrorResponses.nameCollision(`You already have a persona named "${name}".`)
+        );
+      }
+      throw err;
+    }
 
     logger.info({ userId: user.id, personaId: persona.id }, 'Created new persona');
 

--- a/services/api-gateway/src/routes/user/persona/override.test.ts
+++ b/services/api-gateway/src/routes/user/persona/override.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { PrismaClient } from '@tzurot/common-types';
+import { API_ERROR_SUBCODE } from '@tzurot/common-types';
 import {
   createMockPrisma,
   createMockReqRes,
@@ -392,6 +393,28 @@ describe('persona override routes', () => {
           persona: expect.objectContaining({ id: MOCK_PERSONA_ID_2, name: 'Override Persona' }),
           personality: { name: 'Lilith', displayName: 'Lilith the Succubus' },
         })
+      );
+    });
+
+    it('should return NAME_COLLISION when the override persona name is already taken', async () => {
+      // P2002 from the persona insert propagates out of $transaction (which
+      // rolls back), and the handler translates it to a NAME_COLLISION.
+      mockPrisma.personality.findUnique.mockResolvedValue({
+        id: MOCK_PERSONALITY_ID,
+        name: 'Lilith',
+        displayName: 'Lilith the Succubus',
+      });
+      mockPrisma.persona.create.mockRejectedValue({ code: 'P2002' });
+
+      const router = createPersonaRoutes({ prisma: mockPrisma as unknown as PrismaClient });
+      const handler = getHandler(router, 'post', '/override/by-id/:personalityId');
+
+      const { req, res } = createMockReqRes(validBody, { personalityId: MOCK_PERSONALITY_ID });
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ code: API_ERROR_SUBCODE.NAME_COLLISION })
       );
     });
 

--- a/services/api-gateway/src/routes/user/persona/override.ts
+++ b/services/api-gateway/src/routes/user/persona/override.ts
@@ -23,6 +23,7 @@ import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthM
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendCustomSuccess, sendError } from '../../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../../utils/errorResponses.js';
+import { isPrismaUniqueConstraintError } from '../../../utils/prismaErrors.js';
 import { sendZodError } from '../../../utils/zodHelpers.js';
 import { validateSlug, validateUuid } from '../../../utils/validators.js';
 import { getParam } from '../../../utils/requestParams.js';
@@ -262,33 +263,49 @@ export const handleCreatePersonaOverride = (deps: RouteDeps): RequestHandler => 
       return sendError(res, ErrorResponses.notFound('Personality'));
     }
 
-    const created = await prisma.$transaction(async tx => {
-      const persona = await tx.persona.create({
-        data: {
-          id: generatePersonaUuid(name, user.id),
-          name,
-          preferredName: preferredName ?? null,
-          description: description ?? null,
-          content,
-          pronouns: pronouns ?? null,
-          ownerId: user.id,
-        },
-        select: PERSONA_SELECT,
-      });
+    // Deterministic persona UUID of (name, ownerId): a duplicate name for the
+    // same owner trips P2002 on the persona insert. The whole transaction rolls
+    // back (no orphaned persona or override), and we translate to a
+    // NAME_COLLISION rather than an opaque 500 — same contract as the plain
+    // persona-create path.
+    let created;
+    try {
+      created = await prisma.$transaction(async tx => {
+        const persona = await tx.persona.create({
+          data: {
+            id: generatePersonaUuid(name, user.id),
+            name,
+            preferredName: preferredName ?? null,
+            description: description ?? null,
+            content,
+            pronouns: pronouns ?? null,
+            ownerId: user.id,
+          },
+          select: PERSONA_SELECT,
+        });
 
-      await tx.userPersonalityConfig.upsert({
-        where: { userId_personalityId: { userId: user.id, personalityId: personality.id } },
-        create: {
-          id: generateUserPersonalityConfigUuid(user.id, personality.id),
-          userId: user.id,
-          personalityId: personality.id,
-          personaId: persona.id,
-        },
-        update: { personaId: persona.id },
-      });
+        await tx.userPersonalityConfig.upsert({
+          where: { userId_personalityId: { userId: user.id, personalityId: personality.id } },
+          create: {
+            id: generateUserPersonalityConfigUuid(user.id, personality.id),
+            userId: user.id,
+            personalityId: personality.id,
+            personaId: persona.id,
+          },
+          update: { personaId: persona.id },
+        });
 
-      return persona;
-    });
+        return persona;
+      });
+    } catch (err) {
+      if (isPrismaUniqueConstraintError(err)) {
+        return sendError(
+          res,
+          ErrorResponses.nameCollision(`You already have a persona named "${name}".`)
+        );
+      }
+      throw err;
+    }
 
     logger.info(
       { userId: user.id, personalityId: personality.id, personaId: created.id },

--- a/services/bot-client/src/commands/persona/create.test.ts
+++ b/services/bot-client/src/commands/persona/create.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { handleCreatePersona, handleCreateModalSubmit } from './create.js';
 import { MessageFlags } from 'discord.js';
-import { mockCreatePersonaResponse } from '@tzurot/common-types';
+import { mockCreatePersonaResponse, API_ERROR_SUBCODE } from '@tzurot/common-types';
 import { makeOk, makeErr, asUserClient } from '../../test/gatewayClientStubs.js';
 
 const clientsForMock = vi.hoisted(() => vi.fn());
@@ -127,6 +127,24 @@ describe('handleCreateModalSubmit', () => {
     });
     expect(mockReply).toHaveBeenCalledWith({
       content: expect.stringContaining('Persona "Work Persona" created'),
+      flags: MessageFlags.Ephemeral,
+    });
+  });
+
+  it('should surface a name-collision message instead of a generic error', async () => {
+    stub.createPersona.mockResolvedValue(
+      makeErr(400, 'You already have a persona named "Dup".', API_ERROR_SUBCODE.NAME_COLLISION)
+    );
+
+    await handleCreateModalSubmit(
+      createMockModalInteraction({
+        personaName: 'Dup',
+        content: 'whatever',
+      })
+    );
+
+    expect(mockReply).toHaveBeenCalledWith({
+      content: expect.stringContaining('already have a persona named "Dup"'),
       flags: MessageFlags.Ephemeral,
     });
   });

--- a/services/bot-client/src/commands/persona/create.ts
+++ b/services/bot-client/src/commands/persona/create.ts
@@ -13,7 +13,7 @@
 
 import { MessageFlags, ModalBuilder } from 'discord.js';
 import type { ModalSubmitInteraction } from 'discord.js';
-import { createLogger } from '@tzurot/common-types';
+import { createLogger, API_ERROR_SUBCODE } from '@tzurot/common-types';
 import type { ModalCommandContext } from '../../utils/commandContext/types.js';
 import { buildPersonaModalFields } from './utils/modalBuilder.js';
 import { PersonaCustomIds } from '../../utils/customIds.js';
@@ -83,6 +83,13 @@ export async function handleCreateModalSubmit(interaction: ModalSubmitInteractio
     });
 
     if (!result.ok) {
+      if (result.code === API_ERROR_SUBCODE.NAME_COLLISION) {
+        await interaction.reply({
+          content: `❌ You already have a persona named "${personaName}". Pick a different name, or edit the existing one with \`/persona edit\`.`,
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
       logger.warn(
         { userId: discordId, error: result.error },
         'Failed to create persona via gateway'

--- a/services/bot-client/src/commands/persona/override/set.test.ts
+++ b/services/bot-client/src/commands/persona/override/set.test.ts
@@ -11,6 +11,7 @@ import {
   mockSetOverrideResponse,
   mockOverrideInfoResponse,
   mockCreateOverrideResponse,
+  API_ERROR_SUBCODE,
 } from '@tzurot/common-types';
 import { makeOk, makeErr, asUserClient } from '../../../test/gatewayClientStubs.js';
 
@@ -281,6 +282,28 @@ describe('handleOverrideCreateModalSubmit', () => {
 
     expect(mockReply).toHaveBeenCalledWith({
       content: expect.stringContaining('User not found'),
+      flags: MessageFlags.Ephemeral,
+    });
+  });
+
+  it('should surface a name-collision message instead of a generic error', async () => {
+    stub.createPersonaOverride.mockResolvedValue(
+      makeErr(400, 'You already have a persona named "Dup".', API_ERROR_SUBCODE.NAME_COLLISION)
+    );
+
+    await handleOverrideCreateModalSubmit(
+      createMockModalInteraction({
+        personaName: 'Dup',
+        description: '',
+        preferredName: '',
+        pronouns: '',
+        content: 'whatever',
+      }),
+      'personality-uuid'
+    );
+
+    expect(mockReply).toHaveBeenCalledWith({
+      content: expect.stringContaining('already have a persona named "Dup"'),
       flags: MessageFlags.Ephemeral,
     });
   });

--- a/services/bot-client/src/commands/persona/override/set.ts
+++ b/services/bot-client/src/commands/persona/override/set.ts
@@ -19,6 +19,7 @@ import {
   DISCORD_LIMITS,
   truncateText,
   personaOverrideSetOptions,
+  API_ERROR_SUBCODE,
 } from '@tzurot/common-types';
 import type { ModalCommandContext } from '../../../utils/commandContext/types.js';
 import { CREATE_NEW_PERSONA_VALUE } from '../autocomplete.js';
@@ -207,6 +208,14 @@ export async function handleOverrideCreateModalSubmit(
     });
 
     if (!result.ok) {
+      if (result.code === API_ERROR_SUBCODE.NAME_COLLISION) {
+        await interaction.reply({
+          content: `❌ You already have a persona named "${personaName}". Pick a different name, or edit the existing one with \`/persona edit\`.`,
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+
       if (result.error.includes('User not found')) {
         await interaction.reply({
           content: '❌ User not found.',

--- a/services/bot-client/src/test/gatewayClientStubs.ts
+++ b/services/bot-client/src/test/gatewayClientStubs.ts
@@ -8,16 +8,26 @@
  * exercise.
  */
 
-import type { GatewayResult, OwnerClient, ServiceClient, UserClient } from '@tzurot/common-types';
+import type {
+  ApiErrorSubcode,
+  GatewayResult,
+  OwnerClient,
+  ServiceClient,
+  UserClient,
+} from '@tzurot/common-types';
 
 /** Build an `ok` GatewayResult. */
 export function makeOk<T>(data: T): GatewayResult<T> {
   return { ok: true, data };
 }
 
-/** Build an `err` GatewayResult with HTTP status + optional message. */
-export function makeErr(status: number, message = 'fail'): GatewayResult<never> {
-  return { ok: false, error: message, status };
+/** Build an `err` GatewayResult with HTTP status + optional message and subcode. */
+export function makeErr(
+  status: number,
+  message = 'fail',
+  code?: ApiErrorSubcode
+): GatewayResult<never> {
+  return { ok: false, error: message, status, ...(code === undefined ? {} : { code }) };
 }
 
 /**


### PR DESCRIPTION
**Wave 1 / PR A** of the inbox + quick-wins + PR-2m batch.

## Bug

Creating a persona whose `(name, owner)` already exists tripped Prisma P2002 on the deterministic-UUID primary key → `asyncHandler` surfaced a generic **500** ("❌ Failed to create persona") with no hint the cause was a name clash. Surfaced by PR #1108 round-2 review.

## Fix

- **api-gateway** — `handleCreatePersona` + `handleCreatePersonaOverride` catch the P2002 (shared `isPrismaUniqueConstraintError` guard) and return `ErrorResponses.nameCollision` (`VALIDATION_ERROR` + `NAME_COLLISION` subcode). The override path wraps the `$transaction`, which rolls back — no orphaned persona/override.
- **bot-client** — `create.ts` + `override/set.ts` branch on the `NAME_COLLISION` subcode and show *"You already have a persona named X — pick a different name, or edit the existing one with `/persona edit`"*.

## Convention note (verify-before-accepting)

The inbox entry proposed a **409**. But the codebase's established pattern for "a user-owned named entity hits name-uniqueness" is `nameCollision` (400 + `NAME_COLLISION` subcode) — used by **llm-config**, the exact analog of persona, and bot-client already understands that subcode (preset flow). The 409 pattern in the repo is reserved for *personality-slug* collisions (different namespace). Matching llm-config keeps the contract consistent rather than introducing a divergent 409.

## Tests

NAME_COLLISION coverage at both layers (crud + override handler → 400/subcode; create + set bot-client → helpful message). `makeErr` test helper gains an optional subcode arg. 41 api-gateway + 22 bot-client persona tests green; both typecheck clean.