### PR TITLE
fix(bot-client): honest partial-failure surfacing in deny-edit + shapes-status

### DIFF
--- a/services/bot-client/src/commands/deny/detailEdit.test.ts
+++ b/services/bot-client/src/commands/deny/detailEdit.test.ts
@@ -181,6 +181,9 @@ describe('handleEditModal', () => {
     );
     // Should NOT call removeDenylistEntry since scope didn't change
     expect(stub.removeDenylistEntry).not.toHaveBeenCalled();
+    // A clean edit must null the content to clear any stale partial-failure
+    // warning a prior edit left on the message (editReply leaves omitted fields).
+    expect(interaction.editReply).toHaveBeenCalledWith(expect.objectContaining({ content: null }));
   });
 
   it('should handle scope change — create new + delete old', async () => {
@@ -202,6 +205,31 @@ describe('handleEditModal', () => {
       expect.objectContaining({ scope: 'CHANNEL', scopeId: 'chan-999' })
     );
     expect(stub.removeDenylistEntry).toHaveBeenCalledWith('USER', '111222333444555666', 'BOT', '*');
+  });
+
+  it('should warn about a stale entry when old-scope removal fails after scope change', async () => {
+    mockSessionManager.get.mockResolvedValue(sampleSession);
+    mockSessionManager.update.mockResolvedValue(sampleSession);
+    stub.addDenylistEntry.mockResolvedValue(
+      makeOk({ entry: { ...sampleEntry, scope: 'CHANNEL', scopeId: 'chan-999' } })
+    );
+    // New-scope upsert succeeds, but removing the old-scope entry fails — both
+    // now exist. The user must be told instead of seeing clean success.
+    stub.removeDenylistEntry.mockResolvedValue(makeErr(500, 'gateway down'));
+    const interaction = createMockModalInteraction('deny::modal::entry-uuid-1234::edit', {
+      scope: 'CHANNEL',
+      scopeId: 'chan-999',
+      reason: 'Spamming',
+    });
+
+    await handleEditModal(interaction, 'entry-uuid-1234');
+
+    expect(stub.removeDenylistEntry).toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('old entry could not be removed'),
+      })
+    );
   });
 
   it('should reject invalid scope', async () => {

--- a/services/bot-client/src/commands/deny/detailEdit.ts
+++ b/services/bot-client/src/commands/deny/detailEdit.ts
@@ -20,7 +20,7 @@ import { showModalWithTimeoutCatch } from '../../utils/dashboard/showModalWithTi
 import { DASHBOARD_MESSAGES } from '../../utils/dashboard/messages.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import type { DenylistEntryResponse } from './browseTypes.js';
-import type { DenylistScope } from '@tzurot/common-types';
+import type { DenylistScope, OwnerClient } from '@tzurot/common-types';
 import type { DenyDetailSession } from './detailTypes.js';
 import { ENTITY_TYPE, VALID_SCOPES, buildDetailEmbed, buildDetailButtons } from './detailTypes.js';
 
@@ -112,6 +112,35 @@ function validateEditInput(scope: string, scopeId: string, reason: string | null
   return null;
 }
 
+/**
+ * After a scope change, remove the old-scope entry — the upsert already created
+ * the new-scope one. Returns a user-facing warning when removal fails: in that
+ * case BOTH entries now exist (new-scope created, old-scope orphaned), so the
+ * caller must surface it instead of reporting clean success.
+ */
+async function removeStaleEntryAfterScopeChange(
+  ownerClient: OwnerClient,
+  data: DenyDetailSession
+): Promise<string | undefined> {
+  const removeResult = await ownerClient.removeDenylistEntry(
+    data.type,
+    data.discordId,
+    data.scope,
+    data.scopeId
+  );
+  if (removeResult.ok) {
+    return undefined;
+  }
+  logger.warn(
+    { type: data.type, oldScope: data.scope, error: removeResult.error },
+    'Scope change left a stale denylist entry (old-scope removal failed)'
+  );
+  return (
+    '⚠️ Updated to the new scope, but the old entry could not be removed — ' +
+    'both may now exist. Use `/deny browse` to verify and remove the stale one.'
+  );
+}
+
 /** Handle edit modal submission */
 export async function handleEditModal(
   interaction: ModalSubmitInteraction,
@@ -176,11 +205,12 @@ export async function handleEditModal(
       return;
     }
 
-    // If scope changed, delete the old entry (the upsert created a new one
-    // at the new scope; this removes the stale entry at the prior scope).
-    if (scopeChanged) {
-      await ownerClient.removeDenylistEntry(data.type, data.discordId, data.scope, data.scopeId);
-    }
+    // If scope changed, delete the old entry (the upsert created a new one at
+    // the new scope; this removes the stale entry at the prior scope). Returns a
+    // warning when removal fails so we don't report clean success on a partial.
+    const staleEntryWarning = scopeChanged
+      ? await removeStaleEntryAfterScopeChange(ownerClient, data)
+      : undefined;
 
     const responseBody = upsertResult.data as { entry?: DenylistEntryResponse };
 
@@ -217,7 +247,14 @@ export async function handleEditModal(
       updatedEntry.mode,
       data.browseContext !== null
     );
-    await interaction.editReply({ embeds: [embed], components });
+    await interaction.editReply({
+      // `?? null` rather than omitting: editReply leaves omitted fields
+      // unchanged, so a clean edit must explicitly null the content to clear a
+      // stale partial-failure warning left on the message by a prior edit.
+      content: staleEntryWarning ?? null,
+      embeds: [embed],
+      components,
+    });
   } catch (error) {
     logger.error({ err: error }, 'Failed to edit entry');
     // Edit-exception terminal path; deny doesn't use the Back-to-Browse

--- a/services/bot-client/src/commands/shapes/status.test.ts
+++ b/services/bot-client/src/commands/shapes/status.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { handleStatus } from './status.js';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import type { GatewayResult } from '@tzurot/common-types';
-import { makeOk, asUserClient } from '../../test/gatewayClientStubs.js';
+import { makeOk, makeErr, asUserClient } from '../../test/gatewayClientStubs.js';
 
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal<typeof import('@tzurot/common-types')>();
@@ -243,6 +243,50 @@ describe('handleStatus', () => {
               expect.objectContaining({
                 name: 'Export History',
                 value: expect.stringContaining('No exports yet'),
+              }),
+            ]),
+          }),
+        }),
+      ],
+    });
+  });
+
+  it('should show a load-failed message (not "No imports") when import history fetch fails', async () => {
+    setupDefaultMocks({ imports: makeErr(503, 'service unavailable') });
+
+    const context = createMockContext();
+    await handleStatus(context);
+
+    expect(mockEditReply).toHaveBeenCalledWith({
+      embeds: [
+        expect.objectContaining({
+          data: expect.objectContaining({
+            fields: expect.arrayContaining([
+              expect.objectContaining({
+                name: 'Import History',
+                value: expect.stringContaining('Could not load import history'),
+              }),
+            ]),
+          }),
+        }),
+      ],
+    });
+  });
+
+  it('should show a load-failed message (not "No exports") when export history fetch fails', async () => {
+    setupDefaultMocks({ exports: makeErr(503, 'service unavailable') });
+
+    const context = createMockContext();
+    await handleStatus(context);
+
+    expect(mockEditReply).toHaveBeenCalledWith({
+      embeds: [
+        expect.objectContaining({
+          data: expect.objectContaining({
+            fields: expect.arrayContaining([
+              expect.objectContaining({
+                name: 'Export History',
+                value: expect.stringContaining('Could not load export history'),
               }),
             ]),
           }),

--- a/services/bot-client/src/commands/shapes/status.ts
+++ b/services/bot-client/src/commands/shapes/status.ts
@@ -46,8 +46,19 @@ export async function handleStatus(context: DeferredCommandContext): Promise<voi
       : '\u274C Not authenticated \u2014 use `/shapes auth` to connect';
     embed.addFields({ name: 'Credentials', value: credentialStatus });
 
-    // Import history
-    if (importJobsResult.ok && importJobsResult.data.jobs.length > 0) {
+    // Import history — distinguish "fetch failed" from "genuinely empty" so a
+    // transient gateway error (503/auth drop) doesn't masquerade as "no imports
+    // yet" and make a user think their history vanished.
+    if (!importJobsResult.ok) {
+      logger.warn(
+        { userId, status: importJobsResult.status, error: importJobsResult.error },
+        'Failed to load shapes import history'
+      );
+      embed.addFields({
+        name: 'Import History',
+        value: '⚠️ Could not load import history right now. Please try again in a moment.',
+      });
+    } else if (importJobsResult.data.jobs.length > 0) {
       const jobLines = importJobsResult.data.jobs
         .slice(0, 5)
         .map(adaptImportJob)
@@ -63,8 +74,17 @@ export async function handleStatus(context: DeferredCommandContext): Promise<voi
       });
     }
 
-    // Export history
-    if (exportJobsResult.ok && exportJobsResult.data.jobs.length > 0) {
+    // Export history — same fetch-failed vs. empty distinction as imports.
+    if (!exportJobsResult.ok) {
+      logger.warn(
+        { userId, status: exportJobsResult.status, error: exportJobsResult.error },
+        'Failed to load shapes export history'
+      );
+      embed.addFields({
+        name: 'Export History',
+        value: '⚠️ Could not load export history right now. Please try again in a moment.',
+      });
+    } else if (exportJobsResult.data.jobs.length > 0) {
       const jobLines = exportJobsResult.data.jobs
         .slice(0, 5)
         .map(adaptExportJob)


### PR DESCRIPTION
**Wave 1 / PR B** — two "silent failure looks like success/empty" bugs from inbox.

### deny scope-change partial-failure
`deny/detailEdit` upserts the new-scope entry, then removes the old-scope one — but never checked the removal result. If removal failed, **both** entries persisted while the user saw clean success (duplicate denials). Now captures the result and, on failure, shows a warning to reconcile via `/deny browse`. Extracted `removeStaleEntryAfterScopeChange` to keep `handleEditModal` under the max-lines limit.

### /shapes status empty-vs-fail
Import/export history used `result.ok && jobs.length > 0`, so a transient gateway error (503 / auth drop) fell into the **same** "No imports yet" branch as a genuinely empty history — a user with prior imports thought they vanished. Now branches on `!result.ok` first (logs a `warn` + shows "Could not load … try again") distinct from the empty case.

Tests: partial-failure warning (deny) + load-failed-vs-empty for both shapes import and export. 21 tests green; lint + typecheck clean.