### PR TITLE
refactor(api-gateway): consolidate extractOwnerId onto extractUserId

### DIFF
--- a/services/api-gateway/src/services/AuthMiddleware.test.ts
+++ b/services/api-gateway/src/services/AuthMiddleware.test.ts
@@ -109,13 +109,16 @@ describe('authMiddleware', () => {
       expect(extractOwnerId(req)).toBeUndefined();
     });
 
-    it('should handle empty string in header', () => {
+    it('should return undefined for an empty-string header', () => {
+      // Consolidated with extractUserId: an empty header is not a caller ID, so
+      // it resolves to undefined (auth-equivalent — isValidOwner rejects both
+      // '' and undefined, but undefined is the single-sourced contract).
       const req = {
         headers: { 'x-user-id': '' },
         body: {},
       } as unknown as Request;
 
-      expect(extractOwnerId(req)).toBe('');
+      expect(extractOwnerId(req)).toBeUndefined();
     });
 
     it('should ignore an empty-string body ownerId', () => {

--- a/services/api-gateway/src/services/AuthMiddleware.ts
+++ b/services/api-gateway/src/services/AuthMiddleware.ts
@@ -19,25 +19,19 @@ import type { AuthenticatedRequest, ProvisionedRequest } from '../types.js';
 const logger = createLogger('auth-middleware');
 
 /**
- * Extract the caller's Discord ID from the `X-User-Id` request header.
+ * Extract the caller's Discord ID for owner-auth purposes.
+ *
+ * Owner identity uses the same `X-User-Id` header as any other user —
+ * `requireOwnerAuth` downstream (`verifyBotOwner`) is what gates that the value
+ * matches the configured bot owner; this just identifies the caller. Delegates
+ * to {@link extractUserId} so the header parsing and empty-header handling live
+ * in one place (a body value is never consulted — it is not a credential).
  *
  * @param req - Express request
- * @returns Owner ID if the header is present, undefined otherwise
+ * @returns Owner ID if the header is a non-empty string, undefined otherwise
  */
 export function extractOwnerId(req: Request): string | undefined {
-  // `X-User-Id` carries the caller's Discord ID and is the ONLY accepted
-  // source. The `requireOwnerAuth` wrapper downstream (`verifyBotOwner`)
-  // gates that only the configured bot-owner ID passes; this header just
-  // identifies the caller. Set uniformly by `requireUserAuth` middleware and
-  // by the generated typed clients (every OwnerClient method sends
-  // `X-User-Id: actor`). A request body is never consulted — a body value is
-  // not a credential.
-  const headerUserId = req.headers['x-user-id'];
-  if (typeof headerUserId === 'string') {
-    return headerUserId;
-  }
-
-  return undefined;
+  return extractUserId(req);
 }
 
 /**


### PR DESCRIPTION
**Wave 2 / PR C** — the quick-win #1126's review surfaced.

`extractOwnerId` and `extractUserId` both read the `X-User-Id` header and differed only in the empty-string guard (`extractUserId` checks `length > 0` → `undefined`; `extractOwnerId` returned `''`). Net auth behaviour was identical (`isValidOwner` / `requireUserAuth` both reject empty), so it was a readability hazard — two near-identical header parsers.

`extractOwnerId` now delegates to `extractUserId`, single-sourcing the parsing + empty-header handling. The owner-vs-user distinction lives in the function name + the `requireOwnerAuth` gate, not in duplicated logic.

**Behaviour delta:** `extractOwnerId` returns `undefined` (was `''`) for an empty header — auth-equivalent, and unreachable at the one `?? ''` call site (`denylist` `addedBy` runs only after `requireOwnerAuth` passed with a real ID). Test updated to the single-sourced contract.

69 AuthMiddleware tests green; typecheck + lint clean.