### PR TITLE
fix(api-gateway): admin config responses missing isOwned/permissions (broke /preset global + tts global)

### DIFF
--- a/services/api-gateway/src/routes/admin/configResponseContract.test.ts
+++ b/services/api-gateway/src/routes/admin/configResponseContract.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Admin config response-contract tests.
+ *
+ * These guard the class of regression where an admin/global config handler
+ * emits a response body that VIOLATES its own declared output schema — and the
+ * violation stays invisible because the per-handler unit tests mock the typed
+ * client (or assert only individual fields), never validating the whole body
+ * against the contract the bot-client actually enforces at the transport layer.
+ *
+ * The concrete failure this was written to catch: the admin LLM/TTS routes
+ * formatted a config WITHOUT `isOwned`/`permissions`, both REQUIRED by
+ * `LlmConfigSummarySchema`/`TtsConfigSummarySchema`. The owner-client's
+ * `safeParse` rejected the body (→ `{ok:false}`), breaking `/preset global`
+ * and the TTS-global flows — but every unit test mocked above the validation
+ * boundary, so nothing failed.
+ *
+ * Strategy: mount the REAL route aggregators with a mocked Prisma (so the real
+ * service + formatter run), drive each endpoint through supertest, and assert
+ * the emitted body parses against `ROUTE_MANIFEST[id].output` — the same schema
+ * the generated client validates with. LIST / GET / CREATE / UPDATE — every
+ * config-emitting admin verb — is covered for both resources.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express, { type Express } from 'express';
+import request from 'supertest';
+import { ROUTE_MANIFEST } from '@tzurot/common-types';
+import type { PrismaClient } from '@tzurot/common-types';
+
+// Owner-gate passthrough: set an admin Discord ID and continue.
+vi.mock('../../services/AuthMiddleware.js', () => ({
+  requireOwnerAuth: () => (req: { userId?: string }, _res: unknown, next: () => void) => {
+    req.userId = 'admin-discord-id';
+    next();
+  },
+}));
+
+// Force model-field validation to pass so the LLM create/update paths reach
+// the response-shaping step without orchestrating a model cache.
+vi.mock('../../utils/llmConfigValidation.js', () => ({
+  validateLlmConfigModelFields: vi.fn().mockResolvedValue(true),
+}));
+
+import { createAdminLlmConfigRoutes } from './llm-config.js';
+import { createAdminTtsConfigRoutes } from './tts-config.js';
+
+// A valid RFC-4122 UUID — `LlmConfigSummarySchema.id` / `TtsConfigSummarySchema.id`
+// validate with `.uuid()`, so fixtures MUST use a conformant value (the existing
+// per-handler tests use `config-1`, which would trip the uuid check here).
+const UUID = '550e8400-e29b-41d4-a716-446655440000';
+
+/** Assert a captured body parses cleanly against a route's declared output schema. */
+function expectSatisfiesContract(routeId: keyof typeof ROUTE_MANIFEST, body: unknown): void {
+  const schema = ROUTE_MANIFEST[routeId].output;
+  if (schema === undefined) {
+    throw new Error(`Route ${String(routeId)} has no output schema to validate against`);
+  }
+  const result = schema.safeParse(body);
+  if (!result.success) {
+    const issues = result.error.issues.map(i => `${i.path.join('.')}: ${i.message}`).join('; ');
+    throw new Error(`${String(routeId)} response violates its output schema → ${issues}`);
+  }
+}
+
+/** Every admin config response must carry the owner-gated ownership fields. */
+function expectAdminOwnership(config: { isOwned?: unknown; permissions?: unknown }): void {
+  expect(config.isOwned).toBe(true);
+  expect(config.permissions).toEqual({ canEdit: true, canDelete: true });
+}
+
+describe('Admin LLM config response contract', () => {
+  const llmListRow = {
+    id: UUID,
+    name: 'Default Config',
+    description: 'System default',
+    provider: 'openrouter',
+    model: 'anthropic/claude-sonnet-4',
+    visionModel: null,
+    isGlobal: true,
+    isDefault: true,
+    isFreeDefault: false,
+    ownerId: 'admin-user-id',
+  };
+
+  const llmDetailRow = {
+    ...llmListRow,
+    advancedParameters: { temperature: 0.7, reasoning: { effort: 'high', max_tokens: 8000 } },
+    maxMessages: 50,
+    maxAge: null,
+    maxImages: 10,
+    contextWindowTokens: 8000,
+    memoryScoreThreshold: { toNumber: () => 0.5 },
+    memoryLimit: 20,
+  };
+
+  let app: Express;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const prisma = {
+      user: { findUnique: vi.fn().mockResolvedValue({ id: 'admin-user-id' }) },
+      llmConfig: {
+        findMany: vi.fn().mockResolvedValue([llmListRow]),
+        // update's existing-guard selects {id,name,isGlobal}; the detail row is a superset.
+        findUnique: vi.fn().mockResolvedValue(llmDetailRow),
+        findFirst: vi.fn().mockResolvedValue(null), // no name collision
+        create: vi.fn().mockResolvedValue(llmDetailRow),
+        update: vi.fn().mockResolvedValue(llmDetailRow),
+      },
+    } as unknown as PrismaClient;
+
+    app = express();
+    app.use(express.json());
+    app.use('/admin/llm-config', createAdminLlmConfigRoutes({ prisma }));
+  });
+
+  it('GET /admin/llm-config satisfies listGlobalLlmConfigs output schema', async () => {
+    const res = await request(app).get('/admin/llm-config');
+    expect(res.status).toBe(200);
+    expectSatisfiesContract('listGlobalLlmConfigs', res.body);
+    expectAdminOwnership(res.body.configs[0]);
+  });
+
+  it('GET /admin/llm-config/:id satisfies getGlobalLlmConfig output schema', async () => {
+    const res = await request(app).get(`/admin/llm-config/${UUID}`);
+    expect(res.status).toBe(200);
+    expectSatisfiesContract('getGlobalLlmConfig', res.body);
+    expectAdminOwnership(res.body.config);
+  });
+
+  it('POST /admin/llm-config satisfies createGlobalLlmConfig output schema', async () => {
+    const res = await request(app)
+      .post('/admin/llm-config')
+      .send({ name: 'New Config', model: 'anthropic/claude-sonnet-4' });
+    expect(res.status).toBe(201);
+    expectSatisfiesContract('createGlobalLlmConfig', res.body);
+    expectAdminOwnership(res.body.config);
+  });
+
+  it('PUT /admin/llm-config/:id satisfies updateGlobalLlmConfig output schema', async () => {
+    const res = await request(app).put(`/admin/llm-config/${UUID}`).send({ name: 'Renamed' });
+    expect(res.status).toBe(200);
+    expectSatisfiesContract('updateGlobalLlmConfig', res.body);
+    expectAdminOwnership(res.body.config);
+  });
+});
+
+describe('Admin TTS config response contract', () => {
+  const ttsListRow = {
+    id: UUID,
+    name: 'My Voice',
+    description: null,
+    provider: 'elevenlabs' as const,
+    modelId: 'eleven_multilingual_v2',
+    isGlobal: true,
+    isDefault: false,
+    isFreeDefault: false,
+    ownerId: 'admin-user-id',
+  };
+
+  const ttsDetailRow = { ...ttsListRow, advancedParameters: null };
+
+  let app: Express;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const prisma = {
+      user: { findUnique: vi.fn().mockResolvedValue({ id: 'admin-user-id' }) },
+      ttsConfig: {
+        findMany: vi.fn().mockResolvedValue([ttsListRow]),
+        findUnique: vi.fn().mockResolvedValue(ttsDetailRow),
+        findFirst: vi.fn().mockResolvedValue(null), // no name collision
+        create: vi.fn().mockResolvedValue(ttsDetailRow),
+        update: vi.fn().mockResolvedValue(ttsDetailRow),
+      },
+    } as unknown as PrismaClient;
+
+    app = express();
+    app.use(express.json());
+    app.use('/admin/tts-config', createAdminTtsConfigRoutes({ prisma }));
+  });
+
+  it('GET /admin/tts-config satisfies listGlobalTtsConfigs output schema', async () => {
+    const res = await request(app).get('/admin/tts-config');
+    expect(res.status).toBe(200);
+    expectSatisfiesContract('listGlobalTtsConfigs', res.body);
+    expectAdminOwnership(res.body.configs[0]);
+  });
+
+  it('GET /admin/tts-config/:id satisfies getGlobalTtsConfig output schema', async () => {
+    const res = await request(app).get(`/admin/tts-config/${UUID}`);
+    expect(res.status).toBe(200);
+    expectSatisfiesContract('getGlobalTtsConfig', res.body);
+    expectAdminOwnership(res.body.config);
+  });
+
+  it('POST /admin/tts-config satisfies createGlobalTtsConfig output schema', async () => {
+    const res = await request(app)
+      .post('/admin/tts-config')
+      .send({ name: 'New Voice', provider: 'mistral' });
+    expect(res.status).toBe(201);
+    expectSatisfiesContract('createGlobalTtsConfig', res.body);
+    expectAdminOwnership(res.body.config);
+  });
+
+  it('PUT /admin/tts-config/:id satisfies updateGlobalTtsConfig output schema', async () => {
+    const res = await request(app).put(`/admin/tts-config/${UUID}`).send({ name: 'Renamed Voice' });
+    expect(res.status).toBe(200);
+    expectSatisfiesContract('updateGlobalTtsConfig', res.body);
+    expectAdminOwnership(res.body.config);
+  });
+});

--- a/services/api-gateway/src/routes/admin/llm-config.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.ts
@@ -37,6 +37,7 @@ import {
   findAdminUserOrSendError,
   ensureNoNameCollision,
   shapeDeleteResponse,
+  withAdminOwnership,
 } from '../../utils/configRouteHelpers.js';
 import type { RouteDeps } from '../routeDeps.js';
 
@@ -51,7 +52,7 @@ const CONFIG_LABEL = 'configs';
 
 function createListHandler(service: LlmConfigService) {
   return async (_req: Request, res: Response) => {
-    const configs = await service.list({ type: 'GLOBAL' });
+    const configs = (await service.list({ type: 'GLOBAL' })).map(withAdminOwnership);
 
     logger.info({ count: configs.length }, 'Listed all configs');
     sendCustomSuccess(res, { configs }, StatusCodes.OK);
@@ -71,7 +72,7 @@ function createGetHandler(service: LlmConfigService, modelCache?: OpenRouterMode
     await enrichWithModelContext(formatted, config.model, modelCache);
 
     logger.debug({ configId }, 'Fetched config');
-    sendCustomSuccess(res, { config: formatted }, StatusCodes.OK);
+    sendCustomSuccess(res, { config: withAdminOwnership(formatted) }, StatusCodes.OK);
   };
 }
 
@@ -112,7 +113,7 @@ function createCreateConfigHandler(
     await enrichWithModelContext(formatted, config.model, modelCache);
 
     logger.info({ configId: config.id, name: config.name }, 'Created global config');
-    sendCustomSuccess(res, { config: formatted }, StatusCodes.CREATED);
+    sendCustomSuccess(res, { config: withAdminOwnership(formatted) }, StatusCodes.CREATED);
   };
 }
 
@@ -177,7 +178,7 @@ function createEditConfigHandler(
       { configId, name: config.name, updates: Object.keys(body) },
       'Updated global config'
     );
-    sendCustomSuccess(res, { config: formatted }, StatusCodes.OK);
+    sendCustomSuccess(res, { config: withAdminOwnership(formatted) }, StatusCodes.OK);
   };
 }
 

--- a/services/api-gateway/src/routes/admin/tts-config.ts
+++ b/services/api-gateway/src/routes/admin/tts-config.ts
@@ -43,6 +43,7 @@ import {
   findAdminUserOrSendError,
   ensureNoNameCollision,
   shapeDeleteResponse,
+  withAdminOwnership,
 } from '../../utils/configRouteHelpers.js';
 import type { RouteDeps } from '../routeDeps.js';
 
@@ -64,7 +65,7 @@ function createListHandler(service: TtsConfigService) {
     // `params: {}` for list rows. Detail endpoints surface populated
     // params from the wider DETAIL_SELECT.
     const configs = rawConfigs.map(c =>
-      service.formatConfigDetail({ ...c, advancedParameters: null })
+      withAdminOwnership(service.formatConfigDetail({ ...c, advancedParameters: null }))
     );
     logger.info({ count: configs.length }, 'Listed all TTS configs');
     sendCustomSuccess(res, { configs }, StatusCodes.OK);
@@ -80,7 +81,7 @@ function createGetHandler(service: TtsConfigService) {
     }
     const formatted = service.formatConfigDetail(config);
     logger.debug({ configId }, 'Fetched TTS config');
-    sendCustomSuccess(res, { config: formatted }, StatusCodes.OK);
+    sendCustomSuccess(res, { config: withAdminOwnership(formatted) }, StatusCodes.OK);
   };
 }
 
@@ -115,7 +116,7 @@ function createCreateHandler(service: TtsConfigService, prisma: PrismaClient) {
       { configId: config.id, name: config.name, provider: config.provider },
       'Created global TTS config'
     );
-    sendCustomSuccess(res, { config: formatted }, StatusCodes.CREATED);
+    sendCustomSuccess(res, { config: withAdminOwnership(formatted) }, StatusCodes.CREATED);
   };
 }
 
@@ -177,7 +178,7 @@ function createEditHandler(service: TtsConfigService, prisma: PrismaClient) {
       { configId, name: config.name, updates: Object.keys(body) },
       'Updated global TTS config'
     );
-    sendCustomSuccess(res, { config: formatted }, StatusCodes.OK);
+    sendCustomSuccess(res, { config: withAdminOwnership(formatted) }, StatusCodes.OK);
   };
 }
 

--- a/services/api-gateway/src/utils/configRouteHelpers.test.ts
+++ b/services/api-gateway/src/utils/configRouteHelpers.test.ts
@@ -34,6 +34,7 @@ import {
   findAdminUserOrSendError,
   ensureNoNameCollision,
   shapeDeleteResponse,
+  withAdminOwnership,
 } from './configRouteHelpers.js';
 
 const mockRes = {} as Response;
@@ -390,5 +391,32 @@ describe('shapeDeleteResponse', () => {
 
     expect(result.responseBody).toEqual({ deleted: true, warning: '' });
     expect(result.logFields).toEqual({ configId: 'c1', warning: '' });
+  });
+});
+
+describe('withAdminOwnership', () => {
+  it('attaches isOwned:true and full permissions to a formatted config', () => {
+    const result = withAdminOwnership({ id: 'abc', name: 'Global Preset' });
+
+    expect(result).toEqual({
+      id: 'abc',
+      name: 'Global Preset',
+      isOwned: true,
+      permissions: { canEdit: true, canDelete: true },
+    });
+  });
+
+  it('preserves all formatted fields alongside the ownership fields', () => {
+    const result = withAdminOwnership({
+      id: 'abc',
+      name: 'X',
+      model: 'm',
+      isDefault: true,
+      params: { temperature: 0.7 },
+    });
+
+    expect(result).toMatchObject({ id: 'abc', name: 'X', model: 'm', isDefault: true });
+    expect(result.params).toEqual({ temperature: 0.7 });
+    expect(result.isOwned).toBe(true);
   });
 });

--- a/services/api-gateway/src/utils/configRouteHelpers.ts
+++ b/services/api-gateway/src/utils/configRouteHelpers.ts
@@ -15,7 +15,7 @@
 
 import type { Response } from 'express';
 import type { z } from 'zod';
-import type { PrismaClient } from '@tzurot/common-types';
+import type { PrismaClient, EntityPermissions } from '@tzurot/common-types';
 import { sendError } from './responseHelpers.js';
 import { sendZodError } from './zodHelpers.js';
 import { ErrorResponses } from './errorResponses.js';
@@ -245,4 +245,24 @@ export function shapeDeleteResponse(
     responseBody: { deleted: true, warning },
     logFields: { ...baseLogFields, warning },
   };
+}
+
+/**
+ * Attach the ownership/permission fields that the shared config-summary
+ * contract (LlmConfigSummarySchema / TtsConfigSummarySchema) requires on every
+ * config response.
+ *
+ * The admin/global config routes are owner-gated (`requireOwnerAuth`), so the
+ * caller always "owns" the global config and has full edit/delete rights —
+ * these fields are therefore constant rather than per-user computed. They must
+ * still be emitted: the response schema marks `isOwned` and `permissions` as
+ * required, and a config body that omits them fails response validation at the
+ * typed-client boundary. Emitting them here keeps the gateway response honest
+ * against the declared contract instead of relying on the consumer to patch
+ * them in after the fetch.
+ */
+export function withAdminOwnership<T>(
+  formatted: T
+): T & { isOwned: true; permissions: EntityPermissions } {
+  return { ...formatted, isOwned: true, permissions: { canEdit: true, canDelete: true } };
 }


### PR DESCRIPTION
## Summary

The admin/global **LLM and TTS** config routes (`list`/`get`/`create`/`update`) formatted each config **without `isOwned`/`permissions`** — both *required* by the shared `LlmConfigSummarySchema` / `TtsConfigSummarySchema`.

This was invisible before the typed-client migration: the raw `GatewayClient` did **no** response validation, and the bot-client patched the fields in post-fetch (`toAdminPresetData`). After `b863d0d42` ("pr-2k phase 4 → ownerClient"), the generated owner-client `safeParse`s every response against those schemas, so the admin bodies were **rejected** (`{ok:false, status:200}`).

### Confirmed impact (owner-only flows)
- `/preset global` — view / edit / create open + autocomplete
- TTS-global equivalents (same shape via `TtsConfigSummarySchema`)

Verified empirically — the admin shape fails the actual schema:
```
admin-shape valid? false
["config.isOwned: expected boolean, received undefined",
 "config.permissions: expected object, received undefined"]
```

### Why CI missed it
Every per-handler unit test mocks the client (or asserts individual fields) **above** the transport validation boundary, so a body that violates the declared output schema was structurally undetectable.

## The fix
Admin routes are owner-gated → the caller always owns the global config with full edit/delete. New `withAdminOwnership()` helper attaches `isOwned: true` + `{ canEdit: true, canDelete: true }` at all 8 sites (4 LLM + 4 TTS), making the gateway response honest against the contract — instead of relying on the client to patch it.

## The durable guard (not deferred)
`configResponseContract.test.ts` drives the **real** admin handlers (mocked Prisma, real service + formatter) through supertest and asserts each body parses against `ROUTE_MANIFEST[id].output` — the same schema the client validates with. Covers GET + LIST for both resources; CREATE/UPDATE share the identical shaping path (documented in the test).

## Follow-up
The client-side `toAdminPresetData` injection is now redundant but harmless; it's removed as part of the queued schema-tightening PR (PR F), alongside dropping `.passthrough()` and the `as PresetData` casts.

## Test plan
- `pnpm --filter api-gateway test` — green (incl. new contract test)
- `pnpm quality` — green (11/11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)