### PR TITLE
refactor(common-types): tighten LlmConfig + DbSync response contracts; fix ownerId leak

### DIFF
--- a/packages/common-types/src/factories/llm-config.ts
+++ b/packages/common-types/src/factories/llm-config.ts
@@ -14,6 +14,7 @@
 
 import {
   LlmConfigSummarySchema,
+  LlmConfigDetailSchema,
   ListLlmConfigsResponseSchema,
   CreateLlmConfigResponseSchema,
   DeleteLlmConfigResponseSchema,
@@ -24,6 +25,7 @@ import {
 import { z } from 'zod';
 
 type LlmConfigSummary = z.infer<typeof LlmConfigSummarySchema>;
+type LlmConfigDetail = z.infer<typeof LlmConfigDetailSchema>;
 
 import { type DeepPartial } from './factoryUtils.js';
 
@@ -47,6 +49,7 @@ const defaultLlmConfigSummary: LlmConfigSummary = {
   visionModel: null,
   isGlobal: true,
   isDefault: true,
+  isFreeDefault: false,
   isOwned: false,
   permissions: { canEdit: false, canDelete: false },
 };
@@ -80,6 +83,35 @@ export function mockLlmConfigSummary(
     permissions,
   };
   return LlmConfigSummarySchema.parse(merged);
+}
+
+/**
+ * Create a validated mock LLM config DETAIL (GET-by-id / POST / PUT shape).
+ *
+ * Extends the summary with the model-coupled `contextWindowTokens` and the
+ * `params` object the dashboard edits. `params` defaults to `{}` (the gateway's
+ * empty-advanced-parameters case).
+ */
+export function mockLlmConfigDetail(overrides: DeepPartial<LlmConfigDetail> = {}): LlmConfigDetail {
+  // Reuse the summary factory for the shared fields + permission derivation,
+  // then layer the detail-only fields on top.
+  const {
+    params: paramsOverride,
+    contextWindowTokens,
+    modelContextLength,
+    contextWindowCap,
+    ...summaryOverrides
+  } = overrides;
+  const summary = mockLlmConfigSummary(summaryOverrides);
+
+  const merged: LlmConfigDetail = {
+    ...summary,
+    contextWindowTokens: contextWindowTokens ?? 8000,
+    ...(modelContextLength !== undefined ? { modelContextLength } : {}),
+    ...(contextWindowCap !== undefined ? { contextWindowCap } : {}),
+    params: (paramsOverride ?? {}) as LlmConfigDetail['params'],
+  };
+  return LlmConfigDetailSchema.parse(merged);
 }
 
 // ============================================================================
@@ -120,10 +152,10 @@ export function mockListLlmConfigsResponse(
  * @throws ZodError if the resulting object doesn't match the schema
  */
 export function mockCreateLlmConfigResponse(
-  overrides: DeepPartial<LlmConfigSummary> = {}
+  overrides: DeepPartial<LlmConfigDetail> = {}
 ): CreateLlmConfigResponse {
   const response: CreateLlmConfigResponse = {
-    config: mockLlmConfigSummary({
+    config: mockLlmConfigDetail({
       isGlobal: false,
       isDefault: false,
       isOwned: true,

--- a/packages/common-types/src/schemas/api/admin-operations.test.ts
+++ b/packages/common-types/src/schemas/api/admin-operations.test.ts
@@ -6,32 +6,41 @@ import {
 } from './admin-operations.js';
 
 describe('DbSyncResponseSchema', () => {
-  it('accepts the minimal success shape', () => {
-    expect(
-      DbSyncResponseSchema.safeParse({ success: true, timestamp: '2026-05-23T12:00:00Z' }).success
-    ).toBe(true);
+  const validResponse = {
+    success: true,
+    timestamp: '2026-05-23T12:00:00Z',
+    schemaVersion: '20260523120000',
+    stats: { users: { devToProd: 2, prodToDev: 0, conflicts: 1 } },
+    warnings: ['table foo skipped'],
+    info: ['table bar excluded by config'],
+  };
+
+  it('accepts the full enumerated sync result', () => {
+    expect(DbSyncResponseSchema.safeParse(validResponse).success).toBe(true);
   });
 
-  it('accepts arbitrary extra fields (passthrough)', () => {
-    const withExtras = {
-      success: true,
-      timestamp: '2026-05-23T12:00:00Z',
-      tablesCreated: 3,
-      indexesCreated: 5,
-      arbitraryFutureField: { nested: 'stuff' },
-    };
-    const parsed = DbSyncResponseSchema.safeParse(withExtras);
-    expect(parsed.success).toBe(true);
-    if (parsed.success) {
-      // Extras survive parsing (passthrough)
-      expect(parsed.data).toMatchObject({ tablesCreated: 3, indexesCreated: 5 });
-    }
+  it('accepts an optional dry-run changes preview', () => {
+    const withChanges = { ...validResponse, changes: { users: { willInsert: 2 } } };
+    expect(DbSyncResponseSchema.safeParse(withChanges).success).toBe(true);
+  });
+
+  it('rejects the old minimal shape (stats/warnings/info now required)', () => {
+    // The schema is tightened: the gateway always spreads the full SyncResult,
+    // so the bare { success, timestamp } shape is no longer a valid contract.
+    expect(
+      DbSyncResponseSchema.safeParse({ success: true, timestamp: '2026-05-23T12:00:00Z' }).success
+    ).toBe(false);
+  });
+
+  it('rejects malformed stats entries', () => {
+    const badStats = { ...validResponse, stats: { users: { devToProd: 'two' } } };
+    expect(DbSyncResponseSchema.safeParse(badStats).success).toBe(false);
   });
 
   it('rejects success: false (literal true required)', () => {
-    expect(
-      DbSyncResponseSchema.safeParse({ success: false, timestamp: '2026-05-23T12:00:00Z' }).success
-    ).toBe(false);
+    expect(DbSyncResponseSchema.safeParse({ ...validResponse, success: false }).success).toBe(
+      false
+    );
   });
 });
 

--- a/packages/common-types/src/schemas/api/admin-operations.ts
+++ b/packages/common-types/src/schemas/api/admin-operations.ts
@@ -17,19 +17,30 @@
 import { z } from 'zod';
 
 /**
- * Response for POST /admin/db-sync — schema sync between Prisma and PostgreSQL.
- * The `result` spread carries fields like `tablesCreated`, `indexesCreated`,
- * etc., which vary per migration. We don't lock down the exact shape because
- * the operation is single-caller (bot owner via /admin db-sync command) and
- * the bot-client just displays the summary; no programmatic decision branches
- * on individual result fields.
+ * Response for POST /admin/db-sync — schema/data sync between dev and prod.
+ *
+ * The gateway spreads a `SyncResult` into the body: per-table `stats`,
+ * `warnings`/`info` string lists, the `schemaVersion`, and (dry-run only) a
+ * `changes` preview of arbitrary shape. The bot-client renders these into an
+ * embed. Enumerated explicitly so the consumer reads a typed shape instead of
+ * casting; `changes` stays `unknown` (dry-run-only, free-form preview).
  */
-export const DbSyncResponseSchema = z
-  .object({
-    success: z.literal(true),
-    timestamp: z.string(),
-  })
-  .passthrough();
+export const DbSyncResponseSchema = z.object({
+  success: z.literal(true),
+  timestamp: z.string(),
+  schemaVersion: z.string(),
+  stats: z.record(
+    z.string(),
+    z.object({
+      devToProd: z.number(),
+      prodToDev: z.number(),
+      conflicts: z.number(),
+    })
+  ),
+  warnings: z.array(z.string()),
+  info: z.array(z.string()),
+  changes: z.unknown().optional(),
+});
 export type DbSyncResponse = z.infer<typeof DbSyncResponseSchema>;
 
 /**

--- a/packages/common-types/src/schemas/api/llm-config.test.ts
+++ b/packages/common-types/src/schemas/api/llm-config.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   LlmConfigSummarySchema,
+  LlmConfigDetailSchema,
   ListLlmConfigsResponseSchema,
   CreateLlmConfigResponseSchema,
   DeleteLlmConfigResponseSchema,
@@ -34,6 +35,7 @@ describe('LLM Config API Contract Tests', () => {
       visionModel: 'openai/gpt-4o',
       isGlobal: true,
       isDefault: true,
+      isFreeDefault: false,
       isOwned: false,
       permissions: { canEdit: false, canDelete: false },
     };
@@ -125,6 +127,51 @@ describe('LLM Config API Contract Tests', () => {
     });
   });
 
+  describe('LlmConfigDetailSchema', () => {
+    const validDetail = {
+      id: '00000000-0000-4000-8000-000000000009',
+      name: 'Detail Config',
+      description: null,
+      provider: 'openrouter',
+      model: 'openai/gpt-4o-mini',
+      visionModel: null,
+      isGlobal: true,
+      isDefault: false,
+      isFreeDefault: false,
+      isOwned: false,
+      permissions: { canEdit: false, canDelete: false },
+      contextWindowTokens: 8000,
+      params: { temperature: 0.7, reasoning: { effort: 'high' } },
+    };
+
+    it('validates a full detail config', () => {
+      expect(LlmConfigDetailSchema.safeParse(validDetail).success).toBe(true);
+    });
+
+    it('allows optional modelContextLength / contextWindowCap', () => {
+      const withModelContext = {
+        ...validDetail,
+        modelContextLength: 128000,
+        contextWindowCap: 64000,
+      };
+      expect(LlmConfigDetailSchema.safeParse(withModelContext).success).toBe(true);
+    });
+
+    it('requires contextWindowTokens', () => {
+      const { contextWindowTokens: _c, ...withoutCwt } = validDetail;
+      expect(LlmConfigDetailSchema.safeParse(withoutCwt).success).toBe(false);
+    });
+
+    it('requires params', () => {
+      const { params: _p, ...withoutParams } = validDetail;
+      expect(LlmConfigDetailSchema.safeParse(withoutParams).success).toBe(false);
+    });
+
+    it('accepts empty params object (gateway emits {} for no advanced params)', () => {
+      expect(LlmConfigDetailSchema.safeParse({ ...validDetail, params: {} }).success).toBe(true);
+    });
+  });
+
   describe('ListLlmConfigsResponseSchema', () => {
     it('should validate empty configs list', () => {
       const response = { configs: [] };
@@ -145,6 +192,7 @@ describe('LLM Config API Contract Tests', () => {
             visionModel: null,
             isGlobal: true,
             isDefault: true,
+            isFreeDefault: false,
             isOwned: false,
             permissions: { canEdit: false, canDelete: false },
           },
@@ -157,6 +205,7 @@ describe('LLM Config API Contract Tests', () => {
             visionModel: 'anthropic/claude-sonnet-4',
             isGlobal: false,
             isDefault: false,
+            isFreeDefault: false,
             isOwned: true,
             permissions: { canEdit: true, canDelete: true },
           },
@@ -187,8 +236,12 @@ describe('LLM Config API Contract Tests', () => {
           visionModel: null,
           isGlobal: false,
           isDefault: false,
+          isFreeDefault: false,
           isOwned: true,
           permissions: { canEdit: true, canDelete: true },
+          // Detail shape (POST returns the full preset)
+          contextWindowTokens: 8000,
+          params: { temperature: 0.7 },
         },
       };
 
@@ -557,8 +610,8 @@ describe('LLM Config API Contract Tests', () => {
   });
 
   describe('GetLlmConfigResponseSchema', () => {
-    // Mirrors LlmConfigSummarySchema's actual fields (id, name, description,
-    // provider, model, visionModel, isGlobal, isDefault, isOwned, permissions).
+    // GET-by-id returns the DETAIL shape: the summary fields plus the
+    // model-coupled context-window fields and the `params` object.
     const validConfig = {
       id: '00000000-0000-4000-8000-000000000001',
       name: 'cfg',
@@ -568,12 +621,20 @@ describe('LLM Config API Contract Tests', () => {
       visionModel: null,
       isGlobal: true,
       isDefault: false,
+      isFreeDefault: false,
       isOwned: false,
       permissions: { canEdit: false, canDelete: false },
+      contextWindowTokens: 8000,
+      params: {},
     };
 
     it('accepts a single-config wrapper', () => {
       expect(GetLlmConfigResponseSchema.safeParse({ config: validConfig }).success).toBe(true);
+    });
+
+    it('rejects a summary-only config (missing detail fields)', () => {
+      const { contextWindowTokens: _c, params: _p, ...summaryOnly } = validConfig;
+      expect(GetLlmConfigResponseSchema.safeParse({ config: summaryOnly }).success).toBe(false);
     });
 
     it('rejects missing config field', () => {
@@ -582,7 +643,7 @@ describe('LLM Config API Contract Tests', () => {
   });
 
   describe('UpdateLlmConfigResponseSchema', () => {
-    it('mirrors GetLlmConfigResponseSchema (same { config } shape)', () => {
+    it('mirrors GetLlmConfigResponseSchema (same detail { config } shape)', () => {
       const validConfig = {
         id: '00000000-0000-4000-8000-000000000001',
         name: 'cfg',
@@ -592,8 +653,11 @@ describe('LLM Config API Contract Tests', () => {
         visionModel: null,
         isGlobal: true,
         isDefault: false,
+        isFreeDefault: false,
         isOwned: false,
         permissions: { canEdit: false, canDelete: false },
+        contextWindowTokens: 8000,
+        params: {},
       };
       expect(UpdateLlmConfigResponseSchema.safeParse({ config: validConfig }).success).toBe(true);
     });

--- a/packages/common-types/src/schemas/api/llm-config.ts
+++ b/packages/common-types/src/schemas/api/llm-config.ts
@@ -224,26 +224,40 @@ export const LLM_CONFIG_DEFAULTS = {
  * boundary prevents the "DB accepts, gateway rejects, user stuck"
  * failure class.
  */
-// `.passthrough()` preserves the additional preset fields the gateway
-// emits on GET / PUT / POST (contextWindowTokens, params, modelContextLength,
-// etc.) that the bot-client dashboard reads but the schema doesn't yet
-// declare. Tighten by enumerating those fields explicitly; the dashboard
-// then becomes the authoritative consumer surface.
-export const LlmConfigSummarySchema = z
-  .object({
-    id: z.string().uuid(),
-    name: z.string(),
-    description: z.string().nullable(),
-    provider: z.string(),
-    model: z.string(),
-    visionModel: z.string().nullable(),
-    isGlobal: z.boolean(),
-    isDefault: z.boolean(),
-    isOwned: z.boolean(),
-    permissions: EntityPermissionsSchema,
-  })
-  .passthrough();
+// The LIST shape: the lean projection the gateway emits for `GET /…/llm-config`
+// (one row per visible config). Strict (no `.passthrough()`) — list rows must
+// NOT carry internal columns like `ownerId`; the gateway projects only these
+// public fields via `LlmConfigService.formatConfigSummary`.
+export const LlmConfigSummarySchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  description: z.string().nullable(),
+  provider: z.string(),
+  model: z.string(),
+  visionModel: z.string().nullable(),
+  isGlobal: z.boolean(),
+  isDefault: z.boolean(),
+  isFreeDefault: z.boolean(),
+  isOwned: z.boolean(),
+  permissions: EntityPermissionsSchema,
+});
 export type LlmConfigSummary = z.infer<typeof LlmConfigSummarySchema>;
+
+// The DETAIL shape: GET-by-id / POST / PUT return the full preset the dashboard
+// edits. Extends the list shape with the model-coupled context-window fields and
+// the sampling/reasoning `params` object (validated by the same
+// `AdvancedParamsSchema` the gateway formats it with). `contextWindowTokens` is
+// required (always emitted by `formatConfigDetail`); `modelContextLength` /
+// `contextWindowCap` are present only when the OpenRouter model lookup resolves,
+// so they're optional. Strict, like the summary — the gateway's extra
+// memory/context-history columns are intentionally not part of this contract.
+export const LlmConfigDetailSchema = LlmConfigSummarySchema.extend({
+  contextWindowTokens: z.number().int(),
+  modelContextLength: z.number().int().optional(),
+  contextWindowCap: z.number().int().optional(),
+  params: AdvancedParamsSchema,
+});
+export type LlmConfigDetail = z.infer<typeof LlmConfigDetailSchema>;
 
 // ============================================================================
 // GET /user/llm-config
@@ -261,7 +275,7 @@ export type ListLlmConfigsResponse = z.infer<typeof ListLlmConfigsResponseSchema
 // ============================================================================
 
 export const CreateLlmConfigResponseSchema = z.object({
-  config: LlmConfigSummarySchema,
+  config: LlmConfigDetailSchema,
 });
 export type CreateLlmConfigResponse = z.infer<typeof CreateLlmConfigResponseSchema>;
 
@@ -281,7 +295,7 @@ export type DeleteLlmConfigResponse = z.infer<typeof DeleteLlmConfigResponseSche
 // ============================================================================
 
 export const GetLlmConfigResponseSchema = z.object({
-  config: LlmConfigSummarySchema,
+  config: LlmConfigDetailSchema,
 });
 export type GetLlmConfigResponse = z.infer<typeof GetLlmConfigResponseSchema>;
 
@@ -291,7 +305,7 @@ export type GetLlmConfigResponse = z.infer<typeof GetLlmConfigResponseSchema>;
 // ============================================================================
 
 export const UpdateLlmConfigResponseSchema = z.object({
-  config: LlmConfigSummarySchema,
+  config: LlmConfigDetailSchema,
 });
 export type UpdateLlmConfigResponse = z.infer<typeof UpdateLlmConfigResponseSchema>;
 

--- a/services/api-gateway/src/routes/admin/configResponseContract.test.ts
+++ b/services/api-gateway/src/routes/admin/configResponseContract.test.ts
@@ -119,6 +119,8 @@ describe('Admin LLM config response contract', () => {
     expect(res.status).toBe(200);
     expectSatisfiesContract('listGlobalLlmConfigs', res.body);
     expectAdminOwnership(res.body.configs[0]);
+    // Internal column must not leak into the list response.
+    expect(res.body.configs[0].ownerId).toBeUndefined();
   });
 
   it('GET /admin/llm-config/:id satisfies getGlobalLlmConfig output schema', async () => {
@@ -185,6 +187,7 @@ describe('Admin TTS config response contract', () => {
     expect(res.status).toBe(200);
     expectSatisfiesContract('listGlobalTtsConfigs', res.body);
     expectAdminOwnership(res.body.configs[0]);
+    expect(res.body.configs[0].ownerId).toBeUndefined();
   });
 
   it('GET /admin/tts-config/:id satisfies getGlobalTtsConfig output schema', async () => {
@@ -197,7 +200,7 @@ describe('Admin TTS config response contract', () => {
   it('POST /admin/tts-config satisfies createGlobalTtsConfig output schema', async () => {
     const res = await request(app)
       .post('/admin/tts-config')
-      .send({ name: 'New Voice', provider: 'mistral' });
+      .send({ name: 'New Voice', provider: 'elevenlabs' });
     expect(res.status).toBe(201);
     expectSatisfiesContract('createGlobalTtsConfig', res.body);
     expectAdminOwnership(res.body.config);

--- a/services/api-gateway/src/routes/admin/llm-config.test.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.test.ts
@@ -140,7 +140,10 @@ describe('Admin LLM Config Routes', () => {
       expect(response.body.configs).toHaveLength(2);
       expect(response.body.configs[0].name).toBe('Default Config');
       expect(response.body.configs[1].name).toBe('User Config');
-      expect(response.body.configs[1].ownerId).toBe('user-id');
+      // ownerId is an internal column; the list response projects only public
+      // fields via formatConfigSummary, so it must NOT be exposed.
+      expect(response.body.configs[1].ownerId).toBeUndefined();
+      expect(response.body.configs[1].isOwned).toBe(true);
     });
   });
 

--- a/services/api-gateway/src/routes/admin/llm-config.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.ts
@@ -52,7 +52,9 @@ const CONFIG_LABEL = 'configs';
 
 function createListHandler(service: LlmConfigService) {
   return async (_req: Request, res: Response) => {
-    const configs = (await service.list({ type: 'GLOBAL' })).map(withAdminOwnership);
+    const configs = (await service.list({ type: 'GLOBAL' })).map(raw =>
+      withAdminOwnership(service.formatConfigSummary(raw))
+    );
 
     logger.info({ count: configs.length }, 'Listed all configs');
     sendCustomSuccess(res, { configs }, StatusCodes.OK);

--- a/services/api-gateway/src/routes/user/llm-config.ts
+++ b/services/api-gateway/src/routes/user/llm-config.ts
@@ -76,9 +76,12 @@ function createListHandler(service: LlmConfigService) {
 
     const rawConfigs = await service.list(scope);
 
-    // Enrich with ownership and permissions (user-specific)
+    // Enrich with ownership and permissions (user-specific). `formatConfigSummary`
+    // projects only public fields — `c.ownerId` is read here for the ownership
+    // computation but must not leak into the response (it would expose other
+    // users' internal IDs in the global-config rows).
     const configs: LlmConfigSummary[] = rawConfigs.map(c => ({
-      ...c,
+      ...service.formatConfigSummary(c),
       isOwned: c.ownerId === userId,
       permissions: computeLlmConfigPermissions(
         { ownerId: c.ownerId, isGlobal: c.isGlobal },

--- a/services/api-gateway/src/routes/user/tts-config.ts
+++ b/services/api-gateway/src/routes/user/tts-config.ts
@@ -79,12 +79,15 @@ function createListHandler(service: TtsConfigService) {
 
     const rawConfigs = await service.list(scope);
 
-    // The DB column is VARCHAR(40); writes are guarded by TtsConfigCreateSchema
-    // (TtsProviderIdSchema refinement) on create and isTtsProviderId at the
-    // service layer on update, so any value reaching this point is a valid
-    // TtsProviderId. The cast bridges the schema/runtime gap.
+    // `formatConfigDetail` projects only public fields (drops the internal
+    // `ownerId` the list select carries; `c.ownerId` is read below for the
+    // ownership computation but must not leak into the response). Same pattern
+    // as the admin TTS list. The DB column is VARCHAR(40); writes are guarded by
+    // TtsConfigCreateSchema (TtsProviderIdSchema refinement) on create and
+    // isTtsProviderId at the service layer on update, so any value reaching this
+    // point is a valid TtsProviderId — the cast bridges the schema/runtime gap.
     const configs: TtsConfigSummary[] = rawConfigs.map(c => ({
-      ...c,
+      ...service.formatConfigDetail({ ...c, advancedParameters: null }),
       provider: c.provider as TtsProviderId,
       isOwned: c.ownerId === userId,
       permissions: computeLlmConfigPermissions(

--- a/services/api-gateway/src/services/LlmConfigErrors.test.ts
+++ b/services/api-gateway/src/services/LlmConfigErrors.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Tests for LlmConfigService typed errors. These are thin classes — the
+ * tests exist to lock the message format the route layer relies on, since
+ * the route translates these into specific user-facing error responses.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { CloneNameExhaustedError, AutoSuffixCollisionError } from './LlmConfigErrors.js';
+
+describe('CloneNameExhaustedError', () => {
+  it('carries baseName and attempts in the message', () => {
+    const err = new CloneNameExhaustedError('Preset', 20);
+    expect(err.message).toContain('Preset');
+    expect(err.message).toContain('20');
+    expect(err.name).toBe('CloneNameExhaustedError');
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it('exposes baseName and attempts as readable properties', () => {
+    const err = new CloneNameExhaustedError('Preset', 20);
+    expect(err.baseName).toBe('Preset');
+    expect(err.attempts).toBe(20);
+  });
+});
+
+describe('AutoSuffixCollisionError', () => {
+  it('carries effectiveName in the message and chains the underlying cause', () => {
+    const cause = new Error('Unique constraint failed');
+    const err = new AutoSuffixCollisionError('Preset (Copy 5)', cause);
+    expect(err.message).toContain('Preset (Copy 5)');
+    expect(err.cause).toBe(cause);
+    expect(err.name).toBe('AutoSuffixCollisionError');
+  });
+
+  it('exposes effectiveName as a readable property', () => {
+    const err = new AutoSuffixCollisionError('Preset (Copy 5)', new Error());
+    expect(err.effectiveName).toBe('Preset (Copy 5)');
+  });
+});

--- a/services/api-gateway/src/services/LlmConfigErrors.ts
+++ b/services/api-gateway/src/services/LlmConfigErrors.ts
@@ -1,0 +1,48 @@
+/**
+ * LlmConfigService typed errors
+ *
+ * Service-layer errors that the route layer translates into specific HTTP
+ * error responses. Kept in a separate module so `LlmConfigService.ts` stays
+ * focused on business logic + stays under the ESLint max-lines limit.
+ */
+
+/**
+ * Thrown when {@link LlmConfigService.resolveNonCollidingName} walks its full
+ * `MAX_CLONE_NAME_ATTEMPTS` budget without finding a free name. Pathological
+ * case (user has ~20 copies of the same base name). The route translates this
+ * to a `NAME_COLLISION` with a distinct message so the client sees an
+ * actionable error instead of an opaque 500.
+ */
+export class CloneNameExhaustedError extends Error {
+  constructor(
+    public readonly baseName: string,
+    public readonly attempts: number
+  ) {
+    super(
+      `Could not resolve a unique clone name starting from "${baseName}" after ${attempts} attempts`
+    );
+    this.name = 'CloneNameExhaustedError';
+  }
+}
+
+/**
+ * Thrown when a concurrent insert races past the `resolveNonCollidingName`
+ * SELECT and claims the `effectiveName` before our INSERT lands. Carries the
+ * bumped name so the caller can surface an accurate error message (the route
+ * previously echoed `body.name`, which is wrong when the suffix was bumped).
+ *
+ * The underlying Prisma P2002 is chained via the ES2022 `cause` option so
+ * structured loggers and error aggregators (Sentry, etc.) pick it up through
+ * the standard `error.cause` chain rather than a custom property.
+ */
+export class AutoSuffixCollisionError extends Error {
+  constructor(
+    public readonly effectiveName: string,
+    cause: unknown
+  ) {
+    super(`Name "${effectiveName}" was taken by a concurrent request after suffix resolution`, {
+      cause,
+    });
+    this.name = 'AutoSuffixCollisionError';
+  }
+}

--- a/services/api-gateway/src/services/LlmConfigService.ts
+++ b/services/api-gateway/src/services/LlmConfigService.ts
@@ -28,6 +28,11 @@ import {
 } from '@tzurot/common-types';
 
 import { isPrismaUniqueConstraintErrorOn } from '../utils/prismaErrors.js';
+import { CloneNameExhaustedError, AutoSuffixCollisionError } from './LlmConfigErrors.js';
+
+// Re-exported so route/test importers keep a stable `from './LlmConfigService.js'`
+// path (mirrors TtsConfigService's re-export of its error classes).
+export { CloneNameExhaustedError, AutoSuffixCollisionError };
 
 const logger = createLogger('LlmConfigService');
 
@@ -81,6 +86,22 @@ interface RawConfigDetail extends RawConfigList {
 }
 
 /**
+ * Formatted config for the LIST (summary) response — public fields only,
+ * no internal `ownerId`.
+ */
+interface FormattedConfigSummary {
+  id: string;
+  name: string;
+  description: string | null;
+  provider: string;
+  model: string;
+  visionModel: string | null;
+  isGlobal: boolean;
+  isDefault: boolean;
+  isFreeDefault: boolean;
+}
+
+/**
  * Formatted config for API responses.
  */
 interface FormattedConfigDetail {
@@ -104,51 +125,6 @@ interface FormattedConfigDetail {
   modelContextLength?: number;
   /** 50% cap for contextWindowTokens, set by enrichWithModelContext */
   contextWindowCap?: number;
-}
-
-// ============================================================================
-// Typed errors for the auto-suffix clone path
-// ============================================================================
-
-/**
- * Thrown when {@link LlmConfigService.resolveNonCollidingName} walks its full
- * `MAX_CLONE_NAME_ATTEMPTS` budget without finding a free name. Pathological
- * case (user has ~20 copies of the same base name). The route translates this
- * to a `NAME_COLLISION` with a distinct message so the client sees an
- * actionable error instead of an opaque 500.
- */
-export class CloneNameExhaustedError extends Error {
-  constructor(
-    public readonly baseName: string,
-    public readonly attempts: number
-  ) {
-    super(
-      `Could not resolve a unique clone name starting from "${baseName}" after ${attempts} attempts`
-    );
-    this.name = 'CloneNameExhaustedError';
-  }
-}
-
-/**
- * Thrown when a concurrent insert races past the `resolveNonCollidingName`
- * SELECT and claims the `effectiveName` before our INSERT lands. Carries the
- * bumped name so the caller can surface an accurate error message (the route
- * previously echoed `body.name`, which is wrong when the suffix was bumped).
- *
- * The underlying Prisma P2002 is chained via the ES2022 `cause` option so
- * structured loggers and error aggregators (Sentry, etc.) pick it up through
- * the standard `error.cause` chain rather than a custom property.
- */
-export class AutoSuffixCollisionError extends Error {
-  constructor(
-    public readonly effectiveName: string,
-    cause: unknown
-  ) {
-    super(`Name "${effectiveName}" was taken by a concurrent request after suffix resolution`, {
-      cause,
-    });
-    this.name = 'AutoSuffixCollisionError';
-  }
 }
 
 // ============================================================================
@@ -656,6 +632,30 @@ export class LlmConfigService {
       maxAge: raw.maxAge,
       maxImages: raw.maxImages,
       params: safeValidateAdvancedParams(raw.advancedParameters) ?? {},
+    };
+  }
+
+  /**
+   * Format a raw list row for the summary (list) response.
+   *
+   * Projects only the public list fields and — crucially — EXCLUDES the
+   * internal `ownerId` column that `LLM_CONFIG_LIST_SELECT` carries. Callers
+   * use `raw.ownerId` to compute `isOwned`/`permissions` before formatting,
+   * but `ownerId` must not travel into the HTTP response body (it's an internal
+   * UUID, and the user-facing list would otherwise expose other users' owner
+   * IDs). Mirrors `formatConfigDetail`'s explicit-projection discipline.
+   */
+  formatConfigSummary(raw: RawConfigList): FormattedConfigSummary {
+    return {
+      id: raw.id,
+      name: raw.name,
+      description: raw.description,
+      provider: raw.provider,
+      model: raw.model,
+      visionModel: raw.visionModel,
+      isGlobal: raw.isGlobal,
+      isDefault: raw.isDefault,
+      isFreeDefault: raw.isFreeDefault,
     };
   }
 

--- a/services/bot-client/src/commands/admin/db-sync.ts
+++ b/services/bot-client/src/commands/admin/db-sync.ts
@@ -143,8 +143,11 @@ export async function handleDbSync(context: DeferredCommandContext): Promise<voi
       return;
     }
 
-    // Cast until DbSyncResponseSchema is tightened (deferred: backlog/deferred.md).
-    const result = apiResult.data as SyncResult;
+    // `DbSyncResponse` (now a tightened, enumerated schema) is structurally
+    // assignable to the lenient display interface below — annotated assignment,
+    // no type assertion. SyncResult keeps every field optional so the truthy
+    // guards in buildSyncSummary read naturally.
+    const result: SyncResult = apiResult.data;
 
     // Build result embed
     const embed = new EmbedBuilder()

--- a/services/bot-client/src/commands/preset/api.test.ts
+++ b/services/bot-client/src/commands/preset/api.test.ts
@@ -101,25 +101,21 @@ describe('fetchGlobalPreset', () => {
   });
 
   it('should fetch global preset successfully', async () => {
-    // Admin endpoint returns config without isOwned/permissions
-    const adminResponseConfig = { ...mockPresetData };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Simulating admin response that lacks user-scoped fields
-    delete (adminResponseConfig as any).isOwned;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Simulating admin response that lacks user-scoped fields
-    delete (adminResponseConfig as any).permissions;
+    // The gateway now emits isOwned/permissions on admin/global responses
+    // (withAdminOwnership), so fetchGlobalPreset returns the typed detail
+    // verbatim — no client-side patching.
+    const adminResponseConfig = {
+      ...mockPresetData,
+      isOwned: true, // Admin owns global presets
+      permissions: { canEdit: true, canDelete: true },
+    };
 
     stub.getGlobalLlmConfig.mockResolvedValue(makeOk({ config: adminResponseConfig }));
 
     const result = await fetchGlobalPreset('preset-123', asOwnerClient(stub));
 
     expect(stub.getGlobalLlmConfig).toHaveBeenCalledWith('preset-123');
-    // fetchGlobalPreset adds isOwned: true (admin owns global presets) and permissions
-    // Admin always has full permissions on global presets
-    expect(result).toEqual({
-      ...mockPresetData,
-      isOwned: true, // Admin owns global presets
-      permissions: { canEdit: true, canDelete: true },
-    });
+    expect(result).toEqual(adminResponseConfig);
   });
 
   it('should return null on 404', async () => {

--- a/services/bot-client/src/commands/preset/api.ts
+++ b/services/bot-client/src/commands/preset/api.ts
@@ -6,7 +6,12 @@
  * operations go through `ownerClient`.
  */
 
-import { GatewayApiError, type OwnerClient, type UserClient } from '@tzurot/common-types';
+import {
+  GatewayApiError,
+  type LlmConfigDetail,
+  type OwnerClient,
+  type UserClient,
+} from '@tzurot/common-types';
 import type { PresetData } from './types.js';
 
 /** Conservative limit — leaves room for the "❌ " prefix and Discord's 2000-char cap */
@@ -32,23 +37,18 @@ export function extractApiErrorMessage(error: unknown): string | null {
   return msg.length > MAX_DISCORD_CONTENT ? msg.slice(0, MAX_DISCORD_CONTENT) + '…' : msg;
 }
 
-/** Adapt the user-scoped LlmConfig payload to the dashboard's PresetData shape.
- * Cast bridges the schema-vs-PresetData drift — the schema's `.passthrough()`
- * preserves the extra fields at runtime, but TS-level the inferred type only
- * carries the explicitly-declared properties. Full schema tightening is
- * tracked in backlog/inbox.md.
+/**
+ * Adapt a fetched LlmConfig detail payload to the dashboard's PresetData shape.
+ *
+ * `LlmConfigDetailSchema` now enumerates every field the dashboard reads
+ * (`contextWindowTokens`, `params`, `modelContextLength`, `contextWindowCap`,
+ * plus the ownership fields the gateway emits for both user and admin scopes),
+ * so the typed response IS structurally a `PresetData` — no cast needed. Admin
+ * and user responses share this shape: the gateway attaches `isOwned`/
+ * `permissions` on both, so there's no longer a separate admin adapter.
  */
-function toPresetData(config: { id: string; name: string }): PresetData {
-  return config as PresetData;
-}
-
-/** Adapt the admin-scoped LlmConfig payload — gateway omits caller-scoped fields. */
-function toAdminPresetData(config: { id: string; name: string }): PresetData {
-  return {
-    ...(config as PresetData),
-    isOwned: true, // Admin owns global presets
-    permissions: { canEdit: true, canDelete: true }, // Admin always has full permissions
-  };
+function toPresetData(config: LlmConfigDetail): PresetData {
+  return config;
 }
 
 /**
@@ -89,7 +89,7 @@ export async function fetchGlobalPreset(
     throw new Error(`Failed to fetch global preset: ${result.status}`);
   }
 
-  return toAdminPresetData(result.data.config);
+  return toPresetData(result.data.config);
 }
 
 /**
@@ -133,7 +133,7 @@ export async function updateGlobalPreset(
     );
   }
 
-  return toAdminPresetData(result.data.config);
+  return toPresetData(result.data.config);
 }
 
 /**


### PR DESCRIPTION
## Summary

Tightens the config response contracts that PR #1134 exposed as too loose, and fixes the pre-existing `ownerId` leak the #1134 review surfaced (folded in here per the agreed plan — this is the schema-tightening PR that makes the leak structurally guardable).

## Schema split (drops `.passthrough()`)

The single `LlmConfigSummarySchema` was validating two different runtime shapes (lean list vs. rich detail), forcing `.passthrough()` + client-side casts. Split:

- **`LlmConfigSummarySchema`** (LIST) — strict, enumerates `isFreeDefault`, public fields only (no internal `ownerId`).
- **`LlmConfigDetailSchema`** (GET/POST/PUT) — extends summary with required `contextWindowTokens`, optional `modelContextLength`/`contextWindowCap`, and `params` (`AdvancedParamsSchema`). GET/POST/PUT responses now wrap Detail; List stays Summary.

Because the typed responses now carry every field the dashboard reads, the bot-client casts disappear: `toPresetData` returns the response verbatim, the admin-specific adapter is gone (gateway emits `isOwned`/`permissions` for both scopes after #1134), and `as PresetData` / `as SyncResult` are removed.

## `ownerId` leak fix (the #1134 review finding)

The admin + user LLM list handlers and the user TTS list spread raw `LIST_SELECT` rows (`...c`), leaking the internal `ownerId` UUID (cross-user on the user list). New `LlmConfigService.formatConfigSummary` projects only public fields; the TTS lists route through `formatConfigDetail` (already omits `ownerId`). The response-contract test now asserts `ownerId` is **absent**, and dropping `.passthrough()` means the schema enforces it.

## `DbSyncResponseSchema`

Enumerates `schemaVersion`/`stats`/`warnings`/`info`/`changes`, drops `.passthrough()`; removes the `as SyncResult` cast in the bot-client db-sync command.

## Housekeeping

Extracted the two LlmConfig typed-error classes to `LlmConfigErrors.ts` (mirrors `TtsConfigErrors.ts`) to keep `LlmConfigService.ts` under the max-lines limit; re-exported for a stable import path.

## Out of scope (tracked)

The input-side `Parameters<>` casts in `updatePreset`/`updateGlobalPreset` stay — removing them requires typing the dynamic `unflattenPresetData` modal pipeline, a distinct refactor. Filed to backlog.

## Test plan

- `pnpm test` (common-types 2814, api-gateway 2057, bot-client 4947) — green
- `pnpm quality` (lint, codegen-drift, knip, cpd, depcruise, typecheck, typecheck:spec) — green (11/11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)