### PR TITLE
refactor(common-types): relocate memory token schemas out of routes/types (PR-2m step 1)

### DIFF
--- a/packages/common-types/src/routes/types.test.ts
+++ b/packages/common-types/src/routes/types.test.ts
@@ -10,14 +10,7 @@
 
 import { describe, it, expect, expectTypeOf } from 'vitest';
 import { z } from 'zod';
-import {
-  asActor,
-  asSubject,
-  resolveQueryShape,
-  createPaginationSchema,
-  PreviewTokenSchema,
-  PurgeTokenSchema,
-} from './types.js';
+import { asActor, asSubject, resolveQueryShape, createPaginationSchema } from './types.js';
 import type { ActorDiscordId, SubjectDiscordId } from './types.js';
 
 describe('asActor', () => {
@@ -171,38 +164,5 @@ describe('createPaginationSchema', () => {
     expectTypeOf<z.infer<typeof schema>['sort']>().toEqualTypeOf<
       'createdAt' | 'updatedAt' | undefined
     >();
-  });
-});
-
-describe('PreviewTokenSchema', () => {
-  it('accepts a properly-formatted token', () => {
-    expect(PreviewTokenSchema.safeParse('preview_test0000test0000test0000').success).toBe(true);
-  });
-
-  it('rejects an arbitrary string', () => {
-    expect(PreviewTokenSchema.safeParse('not-a-token').success).toBe(false);
-    expect(PreviewTokenSchema.safeParse('').success).toBe(false);
-  });
-
-  it('rejects a string lacking the preview_ prefix', () => {
-    expect(PreviewTokenSchema.safeParse('purge_test0000test0000test0000').success).toBe(false);
-  });
-
-  it('rejects a token that is too short (no payload)', () => {
-    expect(PreviewTokenSchema.safeParse('preview_x').success).toBe(false);
-  });
-});
-
-describe('PurgeTokenSchema', () => {
-  it('accepts a properly-formatted token', () => {
-    expect(PurgeTokenSchema.safeParse('purge_test0000test0000test0000').success).toBe(true);
-  });
-
-  it('rejects a preview-prefixed token (distinct brand)', () => {
-    expect(PurgeTokenSchema.safeParse('preview_test0000test0000test0000').success).toBe(false);
-  });
-
-  it('rejects unbranded raw strings', () => {
-    expect(PurgeTokenSchema.safeParse('test0000test0000test0000').success).toBe(false);
   });
 });

--- a/packages/common-types/src/routes/types.ts
+++ b/packages/common-types/src/routes/types.ts
@@ -356,36 +356,3 @@ export function createPaginationSchema<const TSort extends readonly [string, ...
     order: z.enum(['asc', 'desc'] as const).optional(),
   });
 }
-
-// ============================================================================
-// Branded token types (preview / purge confirmation)
-// ============================================================================
-
-/**
- * Branded type for previewed-then-execute batch operations.
- *
- * `GET /memory/delete/preview` issues a `PreviewToken` (short-lived,
- * server-side Redis-backed) along with the impact summary. `POST
- * /memory/delete` consumes the token — the filter that produced the
- * preview is stored server-side under the token key, so the execute path
- * can't drift from the preview path.
- *
- * Branding means callers can't accidentally pass an arbitrary string —
- * they must obtain a real token from the preview endpoint first.
- */
-export const PreviewTokenSchema = z
-  .string()
-  .regex(/^preview_[A-Za-z0-9_-]{16,64}$/, 'Invalid preview token format')
-  .brand<'PreviewToken'>();
-export type PreviewToken = z.infer<typeof PreviewTokenSchema>;
-
-/**
- * Branded type for purge confirmation. Same shape as `PreviewToken` but
- * a distinct brand so callers can't pass a delete-preview token to a
- * purge endpoint (or vice versa) by accident.
- */
-export const PurgeTokenSchema = z
-  .string()
-  .regex(/^purge_[A-Za-z0-9_-]{16,64}$/, 'Invalid purge token format')
-  .brand<'PurgeToken'>();
-export type PurgeToken = z.infer<typeof PurgeTokenSchema>;

--- a/packages/common-types/src/schemas/api/memory.test.ts
+++ b/packages/common-types/src/schemas/api/memory.test.ts
@@ -6,6 +6,8 @@
 
 import { describe, it, expect } from 'vitest';
 import {
+  PreviewTokenSchema,
+  PurgeTokenSchema,
   FocusModeSchema,
   SetMemoryLockSchema,
   MemoryUpdateSchema,
@@ -596,6 +598,39 @@ describe('Memory API Input Schema Tests', () => {
 
     it('rejects { success: "true" }', () => {
       expect(DeleteMemoryResponseSchema.safeParse({ success: 'true' }).success).toBe(false);
+    });
+  });
+
+  describe('PreviewTokenSchema', () => {
+    it('accepts a properly-formatted token', () => {
+      expect(PreviewTokenSchema.safeParse('preview_test0000test0000test0000').success).toBe(true);
+    });
+
+    it('rejects an arbitrary string', () => {
+      expect(PreviewTokenSchema.safeParse('not-a-token').success).toBe(false);
+      expect(PreviewTokenSchema.safeParse('').success).toBe(false);
+    });
+
+    it('rejects a string lacking the preview_ prefix', () => {
+      expect(PreviewTokenSchema.safeParse('purge_test0000test0000test0000').success).toBe(false);
+    });
+
+    it('rejects a token that is too short (no payload)', () => {
+      expect(PreviewTokenSchema.safeParse('preview_x').success).toBe(false);
+    });
+  });
+
+  describe('PurgeTokenSchema', () => {
+    it('accepts a properly-formatted token', () => {
+      expect(PurgeTokenSchema.safeParse('purge_test0000test0000test0000').success).toBe(true);
+    });
+
+    it('rejects a preview-prefixed token (distinct brand)', () => {
+      expect(PurgeTokenSchema.safeParse('preview_test0000test0000test0000').success).toBe(false);
+    });
+
+    it('rejects unbranded raw strings', () => {
+      expect(PurgeTokenSchema.safeParse('test0000test0000test0000').success).toBe(false);
     });
   });
 });

--- a/packages/common-types/src/schemas/api/memory.ts
+++ b/packages/common-types/src/schemas/api/memory.ts
@@ -5,9 +5,41 @@
  */
 
 import { z } from 'zod';
-import { PreviewTokenSchema, PurgeTokenSchema } from '../../routes/types.js';
 
 const PERSONALITY_ID_REQUIRED = 'personalityId is required';
+
+// ============================================================================
+// Branded token types (preview / purge confirmation)
+// ============================================================================
+
+/**
+ * Branded type for previewed-then-execute batch operations.
+ *
+ * `GET /memory/delete/preview` issues a `PreviewToken` (short-lived,
+ * server-side Redis-backed) along with the impact summary. `POST
+ * /memory/delete` consumes the token — the filter that produced the
+ * preview is stored server-side under the token key, so the execute path
+ * can't drift from the preview path.
+ *
+ * Branding means callers can't accidentally pass an arbitrary string —
+ * they must obtain a real token from the preview endpoint first.
+ */
+export const PreviewTokenSchema = z
+  .string()
+  .regex(/^preview_[A-Za-z0-9_-]{16,64}$/, 'Invalid preview token format')
+  .brand<'PreviewToken'>();
+export type PreviewToken = z.infer<typeof PreviewTokenSchema>;
+
+/**
+ * Branded type for purge confirmation. Same shape as `PreviewToken` but
+ * a distinct brand so callers can't pass a delete-preview token to a
+ * purge endpoint (or vice versa) by accident.
+ */
+export const PurgeTokenSchema = z
+  .string()
+  .regex(/^purge_[A-Za-z0-9_-]{16,64}$/, 'Invalid purge token format')
+  .brand<'PurgeToken'>();
+export type PurgeToken = z.infer<typeof PurgeTokenSchema>;
 
 // ============================================================================
 // POST /user/memory/focus


### PR DESCRIPTION
## Summary

**Step 1 of the api-contract / api-client extraction epic (PR-2m).** Pure back-edge fix, zero package churn.

`PreviewTokenSchema` / `PurgeTokenSchema` were defined in `routes/types.ts` but their only consumer is `schemas/api/memory.ts` — a domain→routes back-edge (`schemas → routes`). They're branded Zod schemas for memory preview/purge tokens: domain contract, not route infrastructure (which is what the rest of `routes/types.ts` holds — `RouteDef`, `Audience`, the actor/subject brands).

Moved them (and their colocated tests) into `schemas/api/memory.ts`, restoring the strict one-way `routes → schemas` direction.

## Why now

The council design pass (GLM 5.1 / Kimi K2.6 / Qwen 3.7 Max, unanimous) for the package extraction flagged this back-edge as the one thing that turns into a **circular package dependency** once `routes/` and `schemas/` are split. Fixing it first — as an isolated, fully-internal, reversible change — de-risks the subsequent package-bootstrap PRs.

Verified no consumer imports these symbols directly (only `schemas/api/memory.ts`), so the move is transparent to all services.

## Test plan
- Token-schema tests relocated to `memory.test.ts` (same assertions); `pnpm --filter @tzurot/common-types test` green (2814)
- `pnpm quality` green (11/11 — incl. codegen-drift, depcruise, typecheck:spec)

Epic plan tracked in `backlog/inbox.md` (PR-2m).

🤖 Generated with [Claude Code](https://claude.com/claude-code)