### PR TITLE
chore(api-gateway): add @tzurot/clients tsconfig project reference

### DIFF
--- a/services/api-gateway/tsconfig.json
+++ b/services/api-gateway/tsconfig.json
@@ -7,5 +7,5 @@
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"],
-  "references": [{ "path": "../../packages/common-types" }]
+  "references": [{ "path": "../../packages/common-types" }, { "path": "../../packages/clients" }]
 }


### PR DESCRIPTION
Closes the one in-scope follow-up from the PR-2m extraction (PR #1139 review): api-gateway's `configResponseContract.test.ts` imports `ROUTE_MANIFEST` from `@tzurot/clients` (devDependency), but `api-gateway/tsconfig.json` only referenced `common-types`. Adds `{ "path": "../../packages/clients" }` to complete the project-references graph for incremental-build correctness (mirrors bot-client). `typecheck:spec` already resolved it via the workspace symlink — this just makes the graph explicit.

## Note on the other two backlogged follow-ups

This PR is **only** the tsconfig reference. The other two "follow-ups" turned out to be much larger than backlog one-liners suggested — see PR discussion / backlog for the re-scoping:

- **`import/no-duplicates` enforcement**: the eslint autofix is fragile (needs `prefer-inline` or it folds value imports into `import type` blocks → invalid TS) and installing `eslint-plugin-import` churned the lockfile in a way that destabilized the Prisma-client regen lint. Re-scoped to a dedicated effort.
- **common-types barrel-kill**: ~1,021 import sites — a major epic, not a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)