### PR TITLE
chore: enforce import/no-duplicates (eslint-plugin-import-x, prefer-inline)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import sonarjs from 'eslint-plugin-sonarjs';
 import * as regexpPlugin from 'eslint-plugin-regexp';
+import importPlugin from 'eslint-plugin-import-x';
 import tzurotPlugin from './packages/tooling/dist/eslint/index.js';
 
 // Get the directory name of the current module (monorepo root)
@@ -232,6 +233,7 @@ export default tseslint.config(
       '@tzurot': tzurotPlugin,
       sonarjs,
       regexp: regexpPlugin,
+      import: importPlugin,
     },
     languageOptions: {
       ecmaVersion: 2022,
@@ -246,6 +248,12 @@ export default tseslint.config(
       },
     },
     rules: {
+      // Merge multiple imports from the same module into one statement. The core
+      // `no-duplicate-imports` rule can't merge a type-only and a value import
+      // from the same module; `prefer-inline` makes this one do so with inline
+      // `type` markers (without it, the autofix folds the value import into an
+      // `import type {}` block and emits invalid code).
+      'import/no-duplicates': ['error', { 'prefer-inline': true }],
       // TypeScript specific rules
       '@typescript-eslint/explicit-function-return-type': [
         'error',

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "dotenv": "^17.4.2",
     "eslint": "^10.4.0",
     "eslint-formatter-pretty": "^7.1.0",
+    "eslint-plugin-import-x": "^4.16.2",
     "eslint-plugin-regexp": "^3.1.0",
     "eslint-plugin-sonarjs": "^4.0.3",
     "globals": "^17.6.0",

--- a/packages/common-types/src/services/ConversationRetentionService.ts
+++ b/packages/common-types/src/services/ConversationRetentionService.ts
@@ -9,8 +9,7 @@
  * Uses tombstones to prevent db-sync from restoring deleted messages.
  */
 
-import type { PrismaClient } from './prisma.js';
-import { Prisma } from './prisma.js';
+import { type PrismaClient, Prisma } from './prisma.js';
 import { createLogger } from '../utils/logger.js';
 import { CLEANUP_DEFAULTS, SYNC_LIMITS } from '../constants/index.js';
 

--- a/packages/common-types/src/services/TtsConfigMapper.ts
+++ b/packages/common-types/src/services/TtsConfigMapper.ts
@@ -7,8 +7,7 @@
  * JSONB and are validated per-provider.
  */
 
-import { isTtsProviderId } from './tts/TtsProvider.js';
-import type { TtsAdvancedParams, TtsProviderId } from './tts/TtsProvider.js';
+import { isTtsProviderId, type TtsAdvancedParams, type TtsProviderId } from './tts/TtsProvider.js';
 
 /**
  * Prisma `select` shape used to load a TtsConfig with all fields the resolver

--- a/packages/common-types/src/services/UserService.ts
+++ b/packages/common-types/src/services/UserService.ts
@@ -12,8 +12,7 @@
  *   placeholder persona in the same maintenance pass
  */
 
-import type { PrismaClient } from './prisma.js';
-import { Prisma } from './prisma.js';
+import { type PrismaClient, Prisma } from './prisma.js';
 import { createLogger } from '../utils/logger.js';
 import { TTLCache } from '../utils/TTLCache.js';
 import { generateUserUuid, generatePersonaUuid } from '../utils/deterministicUuid.js';

--- a/packages/common-types/src/types/jobs.ts
+++ b/packages/common-types/src/types/jobs.ts
@@ -9,18 +9,16 @@
  */
 
 import { z } from 'zod';
-import type {
-  LoadedPersonality,
-  MentionedPersona,
-  ReferencedChannel,
-  ReferencedMessage,
-  AttachmentMetadata,
-  CrossChannelHistoryGroupEntry,
-  DiscordEnvironment,
-  LLMGenerationResult,
-  GuildMemberInfo,
-} from './schemas/index.js';
 import {
+  type LoadedPersonality,
+  type MentionedPersona,
+  type ReferencedChannel,
+  type ReferencedMessage,
+  type AttachmentMetadata,
+  type CrossChannelHistoryGroupEntry,
+  type DiscordEnvironment,
+  type LLMGenerationResult,
+  type GuildMemberInfo,
   loadedPersonalitySchema,
   mentionedPersonaSchema,
   referencedChannelSchema,

--- a/packages/common-types/src/utils/logger.ts
+++ b/packages/common-types/src/utils/logger.ts
@@ -1,5 +1,4 @@
-import { pino } from 'pino';
-import type { Logger, LoggerOptions } from 'pino';
+import { pino, type Logger, type LoggerOptions } from 'pino';
 import { sanitizeLogMessage, sanitizeObject } from './logSanitizer.js';
 
 /**

--- a/packages/tooling/src/codegen/routes.ts
+++ b/packages/tooling/src/codegen/routes.ts
@@ -19,8 +19,14 @@
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
-import { ROUTE_MANIFEST, adminRoutes, internalRoutes, userRoutes } from '@tzurot/clients';
-import type { Audience, RouteDef } from '@tzurot/clients';
+import {
+  ROUTE_MANIFEST,
+  adminRoutes,
+  internalRoutes,
+  userRoutes,
+  type Audience,
+  type RouteDef,
+} from '@tzurot/clients';
 
 import { buildClientClass } from './client-builder.js';
 import { buildMountsFile } from './mounts-builder.js';

--- a/packages/tooling/src/inspect/tts-configs.ts
+++ b/packages/tooling/src/inspect/tts-configs.ts
@@ -10,8 +10,7 @@
 import chalk from 'chalk';
 import { execFileSync } from 'node:child_process';
 
-import type { Environment } from '../utils/env-runner.js';
-import { getRailwayDatabaseUrl, getRailwayEnvName } from '../utils/env-runner.js';
+import { type Environment, getRailwayDatabaseUrl, getRailwayEnvName } from '../utils/env-runner.js';
 
 interface InspectTtsConfigsOptions {
   env: Environment;

--- a/packages/tooling/src/memory/prisma-env.ts
+++ b/packages/tooling/src/memory/prisma-env.ts
@@ -6,8 +6,7 @@
  * Shared by memory CLI scripts.
  */
 
-import type { Environment } from '../utils/env-runner.js';
-import { getRailwayDatabaseUrl } from '../utils/env-runner.js';
+import { type Environment, getRailwayDatabaseUrl } from '../utils/env-runner.js';
 import { type PrismaClient } from '@tzurot/common-types';
 
 export interface PrismaEnvConnection {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
       eslint-formatter-pretty:
         specifier: ^7.1.0
         version: 7.1.0
+      eslint-plugin-import-x:
+        specifier: ^4.16.2
+        version: 4.16.2(@typescript-eslint/utils@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))
       eslint-plugin-regexp:
         specifier: ^3.1.0
         version: 3.1.0(eslint@10.4.0(jiti@2.7.0))
@@ -1670,6 +1673,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@package-json/types@0.0.12':
+    resolution: {integrity: sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==}
+
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
 
@@ -2236,6 +2242,126 @@ packages:
   '@typescript-eslint/visitor-keys@8.60.0':
     resolution: {integrity: sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@unrs/resolver-binding-android-arm-eabi@1.12.2':
+    resolution: {integrity: sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==}
+    cpu: [arm]
+    os: [android]
+
+  '@unrs/resolver-binding-android-arm64@1.12.2':
+    resolution: {integrity: sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==}
+    cpu: [arm64]
+    os: [android]
+
+  '@unrs/resolver-binding-darwin-arm64@1.12.2':
+    resolution: {integrity: sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-darwin-x64@1.12.2':
+    resolution: {integrity: sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-freebsd-x64@1.12.2':
+    resolution: {integrity: sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.12.2':
+    resolution: {integrity: sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.12.2':
+    resolution: {integrity: sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.12.2':
+    resolution: {integrity: sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
+    resolution: {integrity: sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
+    resolution: {integrity: sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
+    resolution: {integrity: sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
+    resolution: {integrity: sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
+    resolution: {integrity: sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
+    resolution: {integrity: sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
+    resolution: {integrity: sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
+    resolution: {integrity: sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-x64-musl@1.12.2':
+    resolution: {integrity: sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@unrs/resolver-binding-openharmony-arm64@1.12.2':
+    resolution: {integrity: sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@unrs/resolver-binding-wasm32-wasi@1.12.2':
+    resolution: {integrity: sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.12.2':
+    resolution: {integrity: sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.12.2':
+    resolution: {integrity: sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
+    resolution: {integrity: sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==}
+    cpu: [x64]
+    os: [win32]
 
   '@vitest/coverage-v8@4.1.7':
     resolution: {integrity: sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==}
@@ -2821,6 +2947,28 @@ packages:
   eslint-formatter-pretty@7.1.0:
     resolution: {integrity: sha512-iyPrgpwKC3MMM75Wxn0VouD89HolpG+BL95NOxgwOWO0R+Omapo7gFX2xcGVsUDS7KiXLtDuynLbNbOARSE7YA==}
     engines: {node: '>=18'}
+
+  eslint-import-context@0.1.9:
+    resolution: {integrity: sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      unrs-resolver: ^1.0.0
+    peerDependenciesMeta:
+      unrs-resolver:
+        optional: true
+
+  eslint-plugin-import-x@4.16.2:
+    resolution: {integrity: sha512-rM9K8UBHcWKpzQzStn1YRN2T5NvdeIfSVoKu/lKF41znQXHAUcBbYXe5wd6GNjZjTrP7viQ49n1D83x/2gYgIw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/utils': ^8.56.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      eslint-import-resolver-node: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/utils':
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
 
   eslint-plugin-regexp@3.1.0:
     resolution: {integrity: sha512-qGXIC3DIKZHcK1H9A9+Byz9gmndY6TTSRkSMTZpNXdyCw2ObSehRgccJv35n9AdUakEjQp5VFNLas6BMXizCZg==}
@@ -3766,6 +3914,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-postinstall@0.3.4:
+    resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+    hasBin: true
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -4510,6 +4663,10 @@ packages:
     resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
     engines: {node: '>= 0.6'}
 
+  stable-hash-x@0.2.0:
+    resolution: {integrity: sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==}
+    engines: {node: '>=12.0.0'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -4773,6 +4930,9 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  unrs-resolver@1.12.2:
+    resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -6089,6 +6249,8 @@ snapshots:
   '@oxc-resolver/binding-win32-x64-msvc@11.19.1':
     optional: true
 
+  '@package-json/types@0.0.12': {}
+
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
       '@noble/hashes': 1.8.0
@@ -6679,6 +6841,76 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.60.0
       eslint-visitor-keys: 5.0.1
+
+  '@unrs/resolver-binding-android-arm-eabi@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-android-arm64@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-arm64@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-x64@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-freebsd-x64@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-musl@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-openharmony-arm64@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-wasm32-wasi@1.12.2':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
+    optional: true
 
   '@vitest/coverage-v8@4.1.7(vitest@4.1.7)':
     dependencies:
@@ -7279,6 +7511,31 @@ snapshots:
       plur: 5.1.0
       string-width: 8.2.0
       supports-hyperlinks: 4.4.0
+
+  eslint-import-context@0.1.9(unrs-resolver@1.12.2):
+    dependencies:
+      get-tsconfig: 4.14.0
+      stable-hash-x: 0.2.0
+    optionalDependencies:
+      unrs-resolver: 1.12.2
+
+  eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0)):
+    dependencies:
+      '@package-json/types': 0.0.12
+      '@typescript-eslint/types': 8.60.0
+      comment-parser: 1.4.6
+      debug: 4.4.3
+      eslint: 10.4.0(jiti@2.7.0)
+      eslint-import-context: 0.1.9(unrs-resolver@1.12.2)
+      is-glob: 4.0.3
+      minimatch: 10.2.5
+      semver: 7.8.1
+      stable-hash-x: 0.2.0
+      unrs-resolver: 1.12.2
+    optionalDependencies:
+      '@typescript-eslint/utils': 8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-regexp@3.1.0(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
@@ -8290,6 +8547,8 @@ snapshots:
 
   nanoid@3.3.12: {}
 
+  napi-postinstall@0.3.4: {}
+
   natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
@@ -9169,6 +9428,8 @@ snapshots:
 
   sqlstring@2.3.3: {}
 
+  stable-hash-x@0.2.0: {}
+
   stackback@0.0.2: {}
 
   standard-as-callback@2.1.0: {}
@@ -9409,6 +9670,33 @@ snapshots:
   universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
+
+  unrs-resolver@1.12.2:
+    dependencies:
+      napi-postinstall: 0.3.4
+    optionalDependencies:
+      '@unrs/resolver-binding-android-arm-eabi': 1.12.2
+      '@unrs/resolver-binding-android-arm64': 1.12.2
+      '@unrs/resolver-binding-darwin-arm64': 1.12.2
+      '@unrs/resolver-binding-darwin-x64': 1.12.2
+      '@unrs/resolver-binding-freebsd-x64': 1.12.2
+      '@unrs/resolver-binding-linux-arm-gnueabihf': 1.12.2
+      '@unrs/resolver-binding-linux-arm-musleabihf': 1.12.2
+      '@unrs/resolver-binding-linux-arm64-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-arm64-musl': 1.12.2
+      '@unrs/resolver-binding-linux-loong64-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-loong64-musl': 1.12.2
+      '@unrs/resolver-binding-linux-ppc64-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-riscv64-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-riscv64-musl': 1.12.2
+      '@unrs/resolver-binding-linux-s390x-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-x64-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-x64-musl': 1.12.2
+      '@unrs/resolver-binding-openharmony-arm64': 1.12.2
+      '@unrs/resolver-binding-wasm32-wasi': 1.12.2
+      '@unrs/resolver-binding-win32-arm64-msvc': 1.12.2
+      '@unrs/resolver-binding-win32-ia32-msvc': 1.12.2
+      '@unrs/resolver-binding-win32-x64-msvc': 1.12.2
 
   uri-js@4.4.1:
     dependencies:

--- a/services/ai-worker/src/jobs/AIJobProcessor.ts
+++ b/services/ai-worker/src/jobs/AIJobProcessor.ts
@@ -16,9 +16,6 @@ import {
   TtsConfigResolver,
   SttResolver,
   type ConfigCascadeResolver,
-} from '@tzurot/common-types';
-import { PersonaResolver } from '../services/resolvers/index.js';
-import {
   createLogger,
   AIProvider,
   type AnyJobData,
@@ -35,8 +32,10 @@ import {
   type ShapesExportJobResult,
   generateUsageLogUuid,
   JobType,
+  type PrismaClient,
+  type Prisma,
 } from '@tzurot/common-types';
-import type { PrismaClient, Prisma } from '@tzurot/common-types';
+import { PersonaResolver } from '../services/resolvers/index.js';
 import { redisService } from '../redis.js';
 import { cleanupOldJobResults } from './CleanupJobResults.js';
 import { processAudioTranscriptionJob } from './AudioTranscriptionJob.js';

--- a/services/ai-worker/src/jobs/CleanupJobResults.ts
+++ b/services/ai-worker/src/jobs/CleanupJobResults.ts
@@ -7,8 +7,7 @@
  * Called occasionally when publishing new job results (probabilistic approach).
  */
 
-import { type PrismaClient } from '@tzurot/common-types';
-import { createLogger } from '@tzurot/common-types';
+import { type PrismaClient, createLogger } from '@tzurot/common-types';
 
 const logger = createLogger('CleanupJobResults');
 

--- a/services/ai-worker/src/jobs/PendingMemoryProcessor.ts
+++ b/services/ai-worker/src/jobs/PendingMemoryProcessor.ts
@@ -5,9 +5,8 @@
  * Runs as a scheduled job to retry failed memory storage operations.
  */
 
-import type { PrismaClient } from '@tzurot/common-types';
+import { type PrismaClient, createLogger } from '@tzurot/common-types';
 import { PgvectorMemoryAdapter, MemoryMetadataSchema } from '../services/PgvectorMemoryAdapter.js';
-import { createLogger } from '@tzurot/common-types';
 
 const logger = createLogger('PendingMemoryProcessor');
 

--- a/services/ai-worker/src/jobs/ShapesExportFormatters.ts
+++ b/services/ai-worker/src/jobs/ShapesExportFormatters.ts
@@ -6,12 +6,12 @@
  * happens in the async job processor, not the Discord command.
  */
 
-import { formatDateOnly } from '@tzurot/common-types';
-import type {
-  ShapesIncPersonalityConfig,
-  ShapesIncMemory,
-  ShapesIncStory,
-  ShapesIncUserPersonalization,
+import {
+  formatDateOnly,
+  type ShapesIncPersonalityConfig,
+  type ShapesIncMemory,
+  type ShapesIncStory,
+  type ShapesIncUserPersonalization,
 } from '@tzurot/common-types';
 
 // ============================================================================

--- a/services/ai-worker/src/jobs/ShapesImportHelpers.ts
+++ b/services/ai-worker/src/jobs/ShapesImportHelpers.ts
@@ -10,8 +10,8 @@ import {
   type PrismaClient,
   type ShapesIncPersonalityConfig,
   SHAPES_USER_AGENT,
+  type Prisma,
 } from '@tzurot/common-types';
-import type { Prisma } from '@tzurot/common-types';
 import {
   mapShapesConfigToPersonality,
   type MappedPersonalityData,

--- a/services/ai-worker/src/jobs/handlers/LLMGenerationHandler.ts
+++ b/services/ai-worker/src/jobs/handlers/LLMGenerationHandler.ts
@@ -27,14 +27,12 @@ import {
   USER_ERROR_MESSAGES,
   type LLMGenerationJobData,
   type LLMGenerationResult,
+  type LlmConfigResolver,
+  type TtsConfigResolver,
+  type ConfigCascadeResolver,
+  type SttResolver,
 } from '@tzurot/common-types';
 import { ApiKeyResolver } from '../../services/ApiKeyResolver.js';
-import type {
-  LlmConfigResolver,
-  TtsConfigResolver,
-  ConfigCascadeResolver,
-  SttResolver,
-} from '@tzurot/common-types';
 import type { EmbeddingServiceInterface } from '../../utils/duplicateDetection.js';
 import { storeDiagnosticLog } from './pipeline/steps/diagnosticStorage.js';
 import {

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.ts
@@ -13,10 +13,10 @@ import {
   type AudioProviderId,
   type SttDispatch,
   type SttResolver,
+  type LlmConfigResolver,
 } from '@tzurot/common-types';
 import type { ApiKeyResolver } from '../../../../services/ApiKeyResolver.js';
 import { ProviderRouter } from '../../../../services/ProviderRouter.js';
-import type { LlmConfigResolver } from '@tzurot/common-types';
 import type { IPipelineStep, GenerationContext } from '../types.js';
 
 const logger = createLogger('AuthStep');

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/ConfigStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/ConfigStep.ts
@@ -11,12 +11,10 @@ import {
   HARDCODED_CONFIG_DEFAULTS,
   type LoadedPersonality,
   type ConfigOverrideSource,
-} from '@tzurot/common-types';
-import type {
-  LlmConfigResolver,
-  ResolvedLlmConfig,
-  ResolvedConfigOverrides,
-  ConfigCascadeResolver,
+  type LlmConfigResolver,
+  type ResolvedLlmConfig,
+  type ResolvedConfigOverrides,
+  type ConfigCascadeResolver,
 } from '@tzurot/common-types';
 import type { IPipelineStep, GenerationContext, ResolvedConfig } from '../types.js';
 

--- a/services/ai-worker/src/services/LLMInvoker.ts
+++ b/services/ai-worker/src/services/LLMInvoker.ts
@@ -40,8 +40,7 @@ import {
   ApiError,
 } from '../utils/apiErrorParser.js';
 import { recordStopSequenceActivation, inferNonXmlStop } from './StopSequenceTracker.js';
-import type { RateLimitCache } from './RateLimitCache.js';
-import { assertValidCacheKeyId } from './RateLimitCache.js';
+import { type RateLimitCache, assertValidCacheKeyId } from './RateLimitCache.js';
 import type { CreditExhaustionCache } from './CreditExhaustionCache.js';
 import { rateLimitCache, creditExhaustionCache } from '../redis.js';
 import {

--- a/services/ai-worker/src/services/ModelFactory.ts
+++ b/services/ai-worker/src/services/ModelFactory.ts
@@ -17,8 +17,10 @@ import {
   AI_ENDPOINTS,
 } from '@tzurot/common-types';
 import { isReasoningModel } from '../utils/reasoningModelUtils.js';
-import { createOpenRouterFetch } from './modelFactory/OpenRouterFetch.js';
-import type { OpenRouterExtraParams } from './modelFactory/OpenRouterFetch.js';
+import {
+  createOpenRouterFetch,
+  type OpenRouterExtraParams,
+} from './modelFactory/OpenRouterFetch.js';
 
 // Re-export extracted modules for backward compatibility
 export { getModelCacheKey } from './modelFactory/CacheKeyBuilder.js';

--- a/services/ai-worker/src/services/PgvectorMemoryAdapter.ts
+++ b/services/ai-worker/src/services/PgvectorMemoryAdapter.ts
@@ -3,8 +3,8 @@
  * PostgreSQL + pgvector adapter for memory retrieval and storage
  */
 
-import { type PrismaClient } from '@tzurot/common-types';
 import {
+  type PrismaClient,
   createLogger,
   AI_DEFAULTS,
   splitTextByTokens,

--- a/services/ai-worker/src/services/RAGUtils.ts
+++ b/services/ai-worker/src/services/RAGUtils.ts
@@ -5,12 +5,14 @@
  * These functions have no dependencies on class instances and can be used standalone.
  */
 
-import { createLogger, AttachmentType, AI_DEFAULTS } from '@tzurot/common-types';
-import type {
-  PrismaClient,
-  VisionDescriptionCache,
-  AttachmentMetadata,
-  StoredReferencedMessage,
+import {
+  createLogger,
+  AttachmentType,
+  AI_DEFAULTS,
+  type PrismaClient,
+  type VisionDescriptionCache,
+  type AttachmentMetadata,
+  type StoredReferencedMessage,
 } from '@tzurot/common-types';
 import type { ProcessedAttachment } from './MultimodalProcessor.js';
 import type { InlineImageDescription } from '../jobs/utils/conversationUtils.js';

--- a/services/ai-worker/src/services/UserReferenceResolver.ts
+++ b/services/ai-worker/src/services/UserReferenceResolver.ts
@@ -14,8 +14,7 @@
  *   live participants come from the chat-log scan and current-message @mentions)
  */
 
-import type { PrismaClient, LoadedPersonality } from '@tzurot/common-types';
-import { createLogger } from '@tzurot/common-types';
+import { type PrismaClient, type LoadedPersonality, createLogger } from '@tzurot/common-types';
 import {
   RESOLVABLE_PERSONALITY_FIELDS,
   setPersonalityField,

--- a/services/ai-worker/src/services/context/MemoryBudgetManager.ts
+++ b/services/ai-worker/src/services/context/MemoryBudgetManager.ts
@@ -14,8 +14,10 @@
 import { countTextTokens, createLogger, AI_DEFAULTS } from '@tzurot/common-types';
 import { formatSingleMemory, getMemoryWrapperOverheadText } from '../prompt/MemoryFormatter.js';
 import type { MemoryDocument } from '../ConversationalRAGTypes.js';
-import type { RawHistoryEntry } from '../../jobs/utils/conversationUtils.js';
-import { formatSingleHistoryEntryAsXml } from '../../jobs/utils/conversationUtils.js';
+import {
+  type RawHistoryEntry,
+  formatSingleHistoryEntryAsXml,
+} from '../../jobs/utils/conversationUtils.js';
 
 const logger = createLogger('MemoryBudgetManager');
 

--- a/services/ai-worker/src/services/reference/BatchResolvers.ts
+++ b/services/ai-worker/src/services/reference/BatchResolvers.ts
@@ -7,8 +7,7 @@
  * Extracted from UserReferenceResolver to reduce file size.
  */
 
-import type { PrismaClient } from '@tzurot/common-types';
-import { createLogger } from '@tzurot/common-types';
+import { type PrismaClient, createLogger } from '@tzurot/common-types';
 import type { ResolvedPersona } from './UserReferencePatterns.js';
 
 const logger = createLogger('UserReferenceResolver');

--- a/services/ai-worker/src/services/storedReferenceHydrator.ts
+++ b/services/ai-worker/src/services/storedReferenceHydrator.ts
@@ -8,8 +8,12 @@
  * Follows the same mutation pattern as injectImageDescriptions() in RAGUtils.ts.
  */
 
-import type { PrismaClient, StoredReferencedMessage } from '@tzurot/common-types';
-import { createLogger, type VisionDescriptionCache } from '@tzurot/common-types';
+import {
+  type PrismaClient,
+  type StoredReferencedMessage,
+  createLogger,
+  type VisionDescriptionCache,
+} from '@tzurot/common-types';
 import { batchResolveByDiscordIds } from './reference/BatchResolvers.js';
 import type { RawHistoryEntry } from '../jobs/utils/conversationTypes.js';
 

--- a/services/ai-worker/src/services/voice/ElevenLabsVoiceService.ts
+++ b/services/ai-worker/src/services/voice/ElevenLabsVoiceService.ts
@@ -21,8 +21,8 @@ import {
   elevenLabsListVoices,
   elevenLabsDeleteVoice,
   ElevenLabsApiError,
+  type ElevenLabsVoiceInfo,
 } from './ElevenLabsClient.js';
-import type { ElevenLabsVoiceInfo } from './ElevenLabsClient.js';
 import { fetchVoiceReference } from './voiceReferenceHelper.js';
 
 const logger = createLogger('ElevenLabsVoiceService');

--- a/services/ai-worker/src/services/voice/VoiceRegistrationService.ts
+++ b/services/ai-worker/src/services/voice/VoiceRegistrationService.ts
@@ -8,8 +8,7 @@
  */
 
 import { createLogger, TTLCache, isTransientNetworkError } from '@tzurot/common-types';
-import { VoiceEngineError } from './VoiceEngineClient.js';
-import type { VoiceEngineClient } from './VoiceEngineClient.js';
+import { VoiceEngineError, type VoiceEngineClient } from './VoiceEngineClient.js';
 import { fetchVoiceReference } from './voiceReferenceHelper.js';
 
 const logger = createLogger('VoiceRegistrationService');

--- a/services/ai-worker/src/services/voice/ttsProviderRegistry.ts
+++ b/services/ai-worker/src/services/voice/ttsProviderRegistry.ts
@@ -14,8 +14,7 @@
  * each test starts with a fresh registry. Use it in `beforeEach`.
  */
 
-import type { TtsProvider, TtsProviderId } from '@tzurot/common-types';
-import { createLogger } from '@tzurot/common-types';
+import { type TtsProvider, type TtsProviderId, createLogger } from '@tzurot/common-types';
 import type { TtsProviderRegistry } from './TtsDispatcher.js';
 import { ElevenLabsTtsProvider } from './providers/ElevenLabsTtsProvider.js';
 import { MistralTtsProvider } from './providers/MistralTtsProvider.js';

--- a/services/api-gateway/src/routes/admin/createPersonality.ts
+++ b/services/api-gateway/src/routes/admin/createPersonality.ts
@@ -11,8 +11,8 @@ import {
   type CacheInvalidationService,
   PersonalityCreateSchema,
   type PersonalityCreateInput,
+  Prisma,
 } from '@tzurot/common-types';
-import { Prisma } from '@tzurot/common-types';
 import { requireOwnerAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';

--- a/services/api-gateway/src/routes/admin/dbSync.ts
+++ b/services/api-gateway/src/routes/admin/dbSync.ts
@@ -4,8 +4,7 @@
  */
 
 import { Router, type Request, type RequestHandler, type Response } from 'express';
-import { createLogger, getConfig, DbSyncSchema } from '@tzurot/common-types';
-import { PrismaClient } from '@tzurot/common-types';
+import { createLogger, getConfig, DbSyncSchema, PrismaClient } from '@tzurot/common-types';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { DatabaseSyncService } from '../../services/DatabaseSyncService.js';
 import { requireOwnerAuth } from '../../services/AuthMiddleware.js';

--- a/services/api-gateway/src/routes/user/personality/update.ts
+++ b/services/api-gateway/src/routes/user/personality/update.ts
@@ -13,8 +13,8 @@ import {
   PersonalityUpdateSchema,
   type PersonalityUpdateInput,
   PERSONALITY_DETAIL_SELECT,
+  Prisma,
 } from '@tzurot/common-types';
-import { Prisma } from '@tzurot/common-types';
 import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendCustomSuccess, sendError } from '../../../utils/responseHelpers.js';

--- a/services/api-gateway/src/routes/user/voices.ts
+++ b/services/api-gateway/src/routes/user/voices.ts
@@ -19,12 +19,11 @@ import {
   type AudioProviderId,
   type PrismaClient,
 } from '@tzurot/common-types';
-import { ErrorCode } from '../../types.js';
-import type { ErrorResponse } from '../../utils/errorResponses.js';
+import { ErrorCode, type AuthenticatedRequest } from '../../types.js';
+import { type ErrorResponse, ErrorResponses } from '../../utils/errorResponses.js';
 import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendCustomSuccess, sendError } from '../../utils/responseHelpers.js';
-import { ErrorResponses } from '../../utils/errorResponses.js';
 import { resolveAudioProviderKeys } from '../../utils/audioProviderKeyResolver.js';
 import {
   listElevenLabsTzurotVoices,
@@ -37,7 +36,6 @@ import {
   deleteMistralVoice,
   type MistralCloned,
 } from '../../utils/mistralVoicesClient.js';
-import type { AuthenticatedRequest } from '../../types.js';
 import { handleListModels as listModelsImpl } from './voiceModels.js';
 import type { RouteDeps } from '../routeDeps.js';
 

--- a/services/api-gateway/src/services/DatabaseNotificationListener.ts
+++ b/services/api-gateway/src/services/DatabaseNotificationListener.ts
@@ -12,8 +12,12 @@
  */
 
 import { Client } from 'pg';
-import { createLogger, isValidInvalidationEvent, DATABASE_RECONNECT } from '@tzurot/common-types';
-import type { CacheInvalidationService } from '@tzurot/common-types';
+import {
+  createLogger,
+  isValidInvalidationEvent,
+  DATABASE_RECONNECT,
+  type CacheInvalidationService,
+} from '@tzurot/common-types';
 
 const logger = createLogger('DatabaseNotificationListener');
 

--- a/services/api-gateway/src/services/DatabaseSyncService.ts
+++ b/services/api-gateway/src/services/DatabaseSyncService.ts
@@ -43,8 +43,7 @@
  * running again picks up where it left off.
  */
 
-import { type PrismaClient } from '@tzurot/common-types';
-import { createLogger } from '@tzurot/common-types';
+import { type PrismaClient, createLogger } from '@tzurot/common-types';
 import { SYNC_CONFIG, SYNC_TABLE_ORDER, type TableSyncConfig } from './sync/config/syncTables.js';
 import { checkSchemaVersions, validateSyncConfig } from './sync/utils/syncValidation.js';
 import { loadTombstoneIds, deleteMessagesWithTombstones } from './sync/utils/tombstoneUtils.js';

--- a/services/api-gateway/src/services/sync/utils/syncValidation.ts
+++ b/services/api-gateway/src/services/sync/utils/syncValidation.ts
@@ -4,8 +4,7 @@
  * Validates database sync configuration and schema versions.
  */
 
-import { type PrismaClient } from '@tzurot/common-types';
-import { createLogger } from '@tzurot/common-types';
+import { type PrismaClient, createLogger } from '@tzurot/common-types';
 import {
   SYNC_CONFIG,
   EXCLUDED_TABLES,

--- a/services/api-gateway/src/services/sync/utils/tombstoneUtils.ts
+++ b/services/api-gateway/src/services/sync/utils/tombstoneUtils.ts
@@ -5,8 +5,7 @@
  * to prevent db-sync from restoring hard-deleted conversation history.
  */
 
-import { type PrismaClient } from '@tzurot/common-types';
-import { createLogger } from '@tzurot/common-types';
+import { type PrismaClient, createLogger } from '@tzurot/common-types';
 
 const logger = createLogger('db-sync-tombstones');
 

--- a/services/api-gateway/src/utils/audioProviderKeyResolver.ts
+++ b/services/api-gateway/src/utils/audioProviderKeyResolver.ts
@@ -19,8 +19,7 @@ import {
   type AudioProviderId,
   type PrismaClient,
 } from '@tzurot/common-types';
-import type { ErrorResponse } from './errorResponses.js';
-import { ErrorResponses } from './errorResponses.js';
+import { type ErrorResponse, ErrorResponses } from './errorResponses.js';
 
 const logger = createLogger('AudioProviderKeyResolver');
 

--- a/services/api-gateway/src/utils/elevenLabsFetch.ts
+++ b/services/api-gateway/src/utils/elevenLabsFetch.ts
@@ -8,8 +8,7 @@
 
 import { z } from 'zod';
 import { createLogger, VALIDATION_TIMEOUTS, AI_ENDPOINTS } from '@tzurot/common-types';
-import type { ErrorResponse } from './errorResponses.js';
-import { ErrorResponses } from './errorResponses.js';
+import { type ErrorResponse, ErrorResponses } from './errorResponses.js';
 
 const logger = createLogger('ElevenLabsFetch');
 

--- a/services/api-gateway/src/utils/elevenLabsKeyResolver.ts
+++ b/services/api-gateway/src/utils/elevenLabsKeyResolver.ts
@@ -7,8 +7,7 @@
  */
 
 import { createLogger, decryptApiKey, AIProvider, type PrismaClient } from '@tzurot/common-types';
-import type { ErrorResponse } from './errorResponses.js';
-import { ErrorResponses } from './errorResponses.js';
+import { type ErrorResponse, ErrorResponses } from './errorResponses.js';
 
 const logger = createLogger('ElevenLabsKeyResolver');
 

--- a/services/api-gateway/src/utils/elevenLabsVoicesClient.ts
+++ b/services/api-gateway/src/utils/elevenLabsVoicesClient.ts
@@ -17,8 +17,7 @@ import {
   VALIDATION_TIMEOUTS,
   createLogger,
 } from '@tzurot/common-types';
-import type { ErrorResponse } from './errorResponses.js';
-import { ErrorResponses } from './errorResponses.js';
+import { type ErrorResponse, ErrorResponses } from './errorResponses.js';
 import { fetchFromElevenLabs } from './elevenLabsFetch.js';
 
 const logger = createLogger('ElevenLabsVoicesClient');

--- a/services/api-gateway/src/utils/mistralVoicesClient.ts
+++ b/services/api-gateway/src/utils/mistralVoicesClient.ts
@@ -14,8 +14,7 @@
 
 import { z } from 'zod';
 import { AI_ENDPOINTS, VALIDATION_TIMEOUTS, createLogger } from '@tzurot/common-types';
-import type { ErrorResponse } from './errorResponses.js';
-import { ErrorResponses } from './errorResponses.js';
+import { type ErrorResponse, ErrorResponses } from './errorResponses.js';
 
 const logger = createLogger('MistralVoicesClient');
 

--- a/services/bot-client/src/commands/admin/index.ts
+++ b/services/bot-client/src/commands/admin/index.ts
@@ -9,12 +9,12 @@
  * Note: LLM config management has been moved to /preset global commands
  */
 
-import { SlashCommandBuilder } from 'discord.js';
-import type {
-  AutocompleteInteraction,
-  StringSelectMenuInteraction,
-  ButtonInteraction,
-  ModalSubmitInteraction,
+import {
+  SlashCommandBuilder,
+  type AutocompleteInteraction,
+  type StringSelectMenuInteraction,
+  type ButtonInteraction,
+  type ModalSubmitInteraction,
 } from 'discord.js';
 import { createLogger, DISCORD_LIMITS } from '@tzurot/common-types';
 import { defineCommand } from '../../utils/defineCommand.js';

--- a/services/bot-client/src/commands/admin/presence.ts
+++ b/services/bot-client/src/commands/admin/presence.ts
@@ -6,11 +6,10 @@
  * Redis key: bot:presence → JSON { type: ActivityType, text: string }
  */
 
-import { ActivityType } from 'discord.js';
+import { ActivityType, type Client } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
 import { redis } from '../../redis.js';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import type { Client } from 'discord.js';
 
 const logger = createLogger('admin-presence');
 

--- a/services/bot-client/src/commands/admin/servers.ts
+++ b/services/bot-client/src/commands/admin/servers.ts
@@ -17,8 +17,10 @@ import {
   ButtonBuilder,
   ButtonStyle,
   ActionRowBuilder,
+  type ButtonInteraction,
+  type StringSelectMenuInteraction,
+  type Guild,
 } from 'discord.js';
-import type { ButtonInteraction, StringSelectMenuInteraction, Guild } from 'discord.js';
 import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import {

--- a/services/bot-client/src/commands/channel/browse.ts
+++ b/services/bot-client/src/commands/channel/browse.ts
@@ -10,8 +10,15 @@
  * because the parent command uses deferralMode: 'ephemeral'.
  */
 
-import type { ButtonInteraction, TextChannel, Client } from 'discord.js';
-import { EmbedBuilder, ButtonBuilder, ActionRowBuilder, escapeMarkdown } from 'discord.js';
+import {
+  type ButtonInteraction,
+  type TextChannel,
+  type Client,
+  EmbedBuilder,
+  ButtonBuilder,
+  ActionRowBuilder,
+  escapeMarkdown,
+} from 'discord.js';
 import {
   buildBrowseButtons as buildSharedBrowseButtons,
   createBrowseCustomIdHelpers,

--- a/services/bot-client/src/commands/channel/index.ts
+++ b/services/bot-client/src/commands/channel/index.ts
@@ -14,12 +14,12 @@
  * - TypeScript prevents accidental deferReply() calls at compile time
  */
 
-import { SlashCommandBuilder } from 'discord.js';
-import type {
-  AutocompleteInteraction,
-  StringSelectMenuInteraction,
-  ButtonInteraction,
-  ModalSubmitInteraction,
+import {
+  SlashCommandBuilder,
+  type AutocompleteInteraction,
+  type StringSelectMenuInteraction,
+  type ButtonInteraction,
+  type ModalSubmitInteraction,
 } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
 import {

--- a/services/bot-client/src/commands/channel/settings.ts
+++ b/services/bot-client/src/commands/channel/settings.ts
@@ -12,8 +12,11 @@
  * because the parent command uses deferralMode: 'ephemeral'.
  */
 
-import type { ButtonInteraction, ModalSubmitInteraction } from 'discord.js';
-import { PermissionFlagsBits } from 'discord.js';
+import {
+  type ButtonInteraction,
+  type ModalSubmitInteraction,
+  PermissionFlagsBits,
+} from 'discord.js';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import { createLogger, DISCORD_COLORS, type ResolvedConfigOverrides } from '@tzurot/common-types';
 import { type UserClient } from '@tzurot/clients';

--- a/services/bot-client/src/commands/character/browse.ts
+++ b/services/bot-client/src/commands/character/browse.ts
@@ -9,8 +9,7 @@
  * - Groups characters by owner for better organization
  */
 
-import { EmbedBuilder } from 'discord.js';
-import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
+import { EmbedBuilder, type ButtonInteraction, type StringSelectMenuInteraction } from 'discord.js';
 import {
   createLogger,
   type EnvConfig,

--- a/services/bot-client/src/commands/character/chat.ts
+++ b/services/bot-client/src/commands/character/chat.ts
@@ -29,8 +29,9 @@ import {
   MESSAGE_LIMITS,
   characterChatOptions,
   type TypingChannel,
+  type EnvConfig,
+  type LoadedPersonality,
 } from '@tzurot/common-types';
-import type { EnvConfig, LoadedPersonality } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import {
   getPersonalityService,

--- a/services/bot-client/src/commands/character/create.ts
+++ b/services/bot-client/src/commands/character/create.ts
@@ -14,8 +14,8 @@ import {
   ActionRowBuilder,
   type ModalActionRowComponentBuilder,
   MessageFlags,
+  type ModalSubmitInteraction,
 } from 'discord.js';
-import type { ModalSubmitInteraction } from 'discord.js';
 import {
   createLogger,
   isBotOwner,

--- a/services/bot-client/src/commands/character/dashboard.ts
+++ b/services/bot-client/src/commands/character/dashboard.ts
@@ -7,11 +7,11 @@
  * - Modal submissions for section edits
  */
 
-import { MessageFlags } from 'discord.js';
-import type {
-  StringSelectMenuInteraction,
-  ButtonInteraction,
-  ModalSubmitInteraction,
+import {
+  MessageFlags,
+  type StringSelectMenuInteraction,
+  type ButtonInteraction,
+  type ModalSubmitInteraction,
 } from 'discord.js';
 import { createLogger, getConfig, isBotOwner, type EnvConfig } from '@tzurot/common-types';
 import {
@@ -23,6 +23,7 @@ import {
   getSessionManager,
   parseDashboardCustomId,
   isDashboardInteraction,
+  handleSharedBackButton,
 } from '../../utils/dashboard/index.js';
 import { showModalWithTimeoutCatch } from '../../utils/dashboard/showModalWithTimeoutCatch.js';
 import { CharacterCustomIds } from '../../utils/customIds.js';
@@ -39,7 +40,6 @@ import { handleDeleteAction, handleDeleteButton } from './dashboardDeleteHandler
 // Note: Browse pagination is handled in index.ts via handleBrowsePagination
 import { handleViewPagination, handleExpandField } from './view.js';
 import { handleRefreshButton, handleCloseButton } from './dashboardButtons.js';
-import { handleSharedBackButton } from '../../utils/dashboard/index.js';
 // Side-effect import: registers the character browse rebuilder used by
 // renderPostActionScreen + handleSharedBackButton.
 import './browse.js';

--- a/services/bot-client/src/commands/character/dashboardActions.ts
+++ b/services/bot-client/src/commands/character/dashboardActions.ts
@@ -10,8 +10,7 @@
  * Extracted from dashboard.ts to keep files under the max-lines limit.
  */
 
-import { MessageFlags } from 'discord.js';
-import type { StringSelectMenuInteraction } from 'discord.js';
+import { MessageFlags, type StringSelectMenuInteraction } from 'discord.js';
 import { createLogger, isBotOwner, type EnvConfig } from '@tzurot/common-types';
 import {
   buildDashboardEmbed,

--- a/services/bot-client/src/commands/character/dashboardDeleteHandlers.ts
+++ b/services/bot-client/src/commands/character/dashboardDeleteHandlers.ts
@@ -6,8 +6,7 @@
  * - Process confirm/cancel responses
  */
 
-import { MessageFlags } from 'discord.js';
-import type { ButtonInteraction } from 'discord.js';
+import { MessageFlags, type ButtonInteraction } from 'discord.js';
 import { createLogger, type EnvConfig } from '@tzurot/common-types';
 import { buildDeleteConfirmation } from '../../utils/dashboard/deleteConfirmation.js';
 import { DASHBOARD_MESSAGES, formatSuccessBanner } from '../../utils/dashboard/messages.js';

--- a/services/bot-client/src/commands/character/index.ts
+++ b/services/bot-client/src/commands/character/index.ts
@@ -9,12 +9,12 @@
  * 4. On submit → Dashboard refreshes with updated data
  */
 
-import { SlashCommandBuilder } from 'discord.js';
-import type {
-  ModalSubmitInteraction,
-  AutocompleteInteraction,
-  StringSelectMenuInteraction,
-  ButtonInteraction,
+import {
+  SlashCommandBuilder,
+  type ModalSubmitInteraction,
+  type AutocompleteInteraction,
+  type StringSelectMenuInteraction,
+  type ButtonInteraction,
 } from 'discord.js';
 import { createLogger, getConfig } from '@tzurot/common-types';
 import { defineCommand } from '../../utils/defineCommand.js';

--- a/services/bot-client/src/commands/character/truncationWarning.ts
+++ b/services/bot-client/src/commands/character/truncationWarning.ts
@@ -14,8 +14,12 @@
  * committing.
  */
 
-import { AttachmentBuilder, MessageFlags } from 'discord.js';
-import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
+import {
+  AttachmentBuilder,
+  MessageFlags,
+  type ButtonInteraction,
+  type StringSelectMenuInteraction,
+} from 'discord.js';
 import { createLogger, getConfig, type EnvConfig } from '@tzurot/common-types';
 import { type SectionDefinition } from '../../utils/dashboard/types.js';
 import { buildSectionModal } from '../../utils/dashboard/ModalFactory.js';

--- a/services/bot-client/src/commands/character/view.ts
+++ b/services/bot-client/src/commands/character/view.ts
@@ -9,8 +9,8 @@ import {
   ActionRowBuilder,
   MessageFlags,
   escapeMarkdown,
+  type ButtonInteraction,
 } from 'discord.js';
-import type { ButtonInteraction } from 'discord.js';
 import {
   createLogger,
   type EnvConfig,

--- a/services/bot-client/src/commands/deny/browse.ts
+++ b/services/bot-client/src/commands/deny/browse.ts
@@ -6,8 +6,12 @@
  * Includes a select menu for viewing entry details.
  */
 
-import { EmbedBuilder, escapeMarkdown } from 'discord.js';
-import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
+import {
+  EmbedBuilder,
+  escapeMarkdown,
+  type ButtonInteraction,
+  type StringSelectMenuInteraction,
+} from 'discord.js';
 import { createLogger, isBotOwner, DISCORD_COLORS, formatDateShort } from '@tzurot/common-types';
 import { type OwnerClient } from '@tzurot/clients';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';

--- a/services/bot-client/src/commands/deny/detail.ts
+++ b/services/bot-client/src/commands/deny/detail.ts
@@ -27,14 +27,17 @@ import { createLogger, isBotOwner } from '@tzurot/common-types';
 import { getSessionManager } from '../../utils/dashboard/SessionManager.js';
 import { buildDeleteConfirmation } from '../../utils/dashboard/deleteConfirmation.js';
 import { DASHBOARD_MESSAGES, formatSuccessBanner } from '../../utils/dashboard/messages.js';
-import { parseDashboardCustomId } from '../../utils/dashboard/types.js';
+import { parseDashboardCustomId, type BrowseContext } from '../../utils/dashboard/types.js';
 import { renderPostActionScreen } from '../../utils/dashboard/postActionScreen.js';
 import { handleSharedBackButton } from '../../utils/dashboard/sharedBackButtonHandler.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
-import type { BrowseContext } from '../../utils/dashboard/types.js';
 import type { DenylistEntryResponse } from './browseTypes.js';
-import type { DenyDetailSession } from './detailTypes.js';
-import { ENTITY_TYPE, buildDetailEmbed, buildDetailButtons } from './detailTypes.js';
+import {
+  type DenyDetailSession,
+  ENTITY_TYPE,
+  buildDetailEmbed,
+  buildDetailButtons,
+} from './detailTypes.js';
 import { handleEdit, handleEditModal } from './detailEdit.js';
 
 const logger = createLogger('deny-detail');

--- a/services/bot-client/src/commands/deny/detailEdit.ts
+++ b/services/bot-client/src/commands/deny/detailEdit.ts
@@ -12,8 +12,9 @@ import {
   TextInputStyle,
   ActionRowBuilder,
   MessageFlags,
+  type ButtonInteraction,
+  type ModalSubmitInteraction,
 } from 'discord.js';
-import type { ButtonInteraction, ModalSubmitInteraction } from 'discord.js';
 import { createLogger, type DenylistScope } from '@tzurot/common-types';
 import { getSessionManager } from '../../utils/dashboard/SessionManager.js';
 import { showModalWithTimeoutCatch } from '../../utils/dashboard/showModalWithTimeoutCatch.js';
@@ -21,8 +22,13 @@ import { DASHBOARD_MESSAGES } from '../../utils/dashboard/messages.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import type { DenylistEntryResponse } from './browseTypes.js';
 import type { OwnerClient } from '@tzurot/clients';
-import type { DenyDetailSession } from './detailTypes.js';
-import { ENTITY_TYPE, VALID_SCOPES, buildDetailEmbed, buildDetailButtons } from './detailTypes.js';
+import {
+  type DenyDetailSession,
+  ENTITY_TYPE,
+  VALID_SCOPES,
+  buildDetailEmbed,
+  buildDetailButtons,
+} from './detailTypes.js';
 
 const logger = createLogger('deny-detail-edit');
 

--- a/services/bot-client/src/commands/deny/index.ts
+++ b/services/bot-client/src/commands/deny/index.ts
@@ -13,12 +13,13 @@
  * - /deny view — Look up denylist entries by Discord ID (owner only)
  */
 
-import { ChannelType, SlashCommandBuilder } from 'discord.js';
-import type {
-  AutocompleteInteraction,
-  ButtonInteraction,
-  StringSelectMenuInteraction,
-  ModalSubmitInteraction,
+import {
+  ChannelType,
+  SlashCommandBuilder,
+  type AutocompleteInteraction,
+  type ButtonInteraction,
+  type StringSelectMenuInteraction,
+  type ModalSubmitInteraction,
 } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
 import {

--- a/services/bot-client/src/commands/history/index.ts
+++ b/services/bot-client/src/commands/history/index.ts
@@ -9,11 +9,11 @@
  * - /history hard-delete <personality> - Permanently delete conversation history
  */
 
-import { SlashCommandBuilder } from 'discord.js';
-import type {
-  AutocompleteInteraction,
-  ButtonInteraction,
-  ModalSubmitInteraction,
+import {
+  SlashCommandBuilder,
+  type AutocompleteInteraction,
+  type ButtonInteraction,
+  type ModalSubmitInteraction,
 } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
 import { defineCommand } from '../../utils/defineCommand.js';

--- a/services/bot-client/src/commands/inspect/index.ts
+++ b/services/bot-client/src/commands/inspect/index.ts
@@ -10,8 +10,12 @@
  * - Regular users: see only their own logs
  */
 
-import { SlashCommandBuilder, MessageFlags } from 'discord.js';
-import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
+import {
+  SlashCommandBuilder,
+  MessageFlags,
+  type ButtonInteraction,
+  type StringSelectMenuInteraction,
+} from 'discord.js';
 import { createLogger, inspectOptions } from '@tzurot/common-types';
 import { defineCommand } from '../../utils/defineCommand.js';
 import type {

--- a/services/bot-client/src/commands/memory/browse.ts
+++ b/services/bot-client/src/commands/memory/browse.ts
@@ -15,8 +15,13 @@
  * because UUIDs can't fit in the filter enum slot.
  */
 
-import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
-import { EmbedBuilder, escapeMarkdown, MessageFlags } from 'discord.js';
+import {
+  type ButtonInteraction,
+  type StringSelectMenuInteraction,
+  EmbedBuilder,
+  escapeMarkdown,
+  MessageFlags,
+} from 'discord.js';
 import {
   createLogger,
   DISCORD_COLORS,

--- a/services/bot-client/src/commands/memory/detail.ts
+++ b/services/bot-client/src/commands/memory/detail.ts
@@ -12,14 +12,19 @@ import {
   MessageFlags,
   escapeMarkdown,
   AttachmentBuilder,
+  type ButtonInteraction,
+  type StringSelectMenuInteraction,
 } from 'discord.js';
-import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
-import { createLogger, DISCORD_COLORS, formatDateTimeCompact } from '@tzurot/common-types';
+import {
+  createLogger,
+  DISCORD_COLORS,
+  formatDateTimeCompact,
+  type MemoryItem,
+} from '@tzurot/common-types';
 import { CUSTOM_ID_DELIMITER } from '../../utils/customIds.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
 
 import { fetchMemory, setMemoryLock, deleteMemory } from './detailApi.js';
-import type { MemoryItem } from '@tzurot/common-types';
 import { EMBED_DESCRIPTION_SAFE_LIMIT } from './formatters.js';
 
 const logger = createLogger('memory-detail');

--- a/services/bot-client/src/commands/memory/detailModals.ts
+++ b/services/bot-client/src/commands/memory/detailModals.ts
@@ -12,14 +12,14 @@ import {
   EmbedBuilder,
   ButtonBuilder,
   ButtonStyle,
+  type ButtonInteraction,
+  type ModalSubmitInteraction,
 } from 'discord.js';
-import type { ButtonInteraction, ModalSubmitInteraction } from 'discord.js';
-import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
+import { createLogger, DISCORD_COLORS, type MemoryItem } from '@tzurot/common-types';
 import { buildMemoryActionId, buildDetailEmbed, buildDetailButtons } from './detail.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import { showModalWithTimeoutCatch } from '../../utils/dashboard/showModalWithTimeoutCatch.js';
 import { fetchMemory, updateMemory } from './detailApi.js';
-import type { MemoryItem } from '@tzurot/common-types';
 
 const logger = createLogger('memory-detail-modals');
 

--- a/services/bot-client/src/commands/memory/index.ts
+++ b/services/bot-client/src/commands/memory/index.ts
@@ -17,8 +17,7 @@
  * - /memory incognito forget <personality> <timeframe> - Retroactively delete recent memories
  */
 
-import { SlashCommandBuilder } from 'discord.js';
-import type { AutocompleteInteraction } from 'discord.js';
+import { SlashCommandBuilder, type AutocompleteInteraction } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
 import { defineCommand } from '../../utils/defineCommand.js';
 import type {

--- a/services/bot-client/src/commands/memory/interactionHandlers.ts
+++ b/services/bot-client/src/commands/memory/interactionHandlers.ts
@@ -11,11 +11,11 @@
  * custom IDs themselves — no inline collectors, fully restart-safe.
  */
 
-import { MessageFlags } from 'discord.js';
-import type {
-  ButtonInteraction,
-  ModalSubmitInteraction,
-  StringSelectMenuInteraction,
+import {
+  MessageFlags,
+  type ButtonInteraction,
+  type ModalSubmitInteraction,
+  type StringSelectMenuInteraction,
 } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
 import { parseMemoryActionId, handleMemorySelect } from './detail.js';

--- a/services/bot-client/src/commands/memory/search.ts
+++ b/services/bot-client/src/commands/memory/search.ts
@@ -11,14 +11,16 @@
  * - If hasMore is false: current page is the last page
  */
 
-import type {
-  ActionRowBuilder,
-  ButtonBuilder,
-  ButtonInteraction,
-  StringSelectMenuBuilder,
-  StringSelectMenuInteraction,
+import {
+  type ActionRowBuilder,
+  type ButtonBuilder,
+  type ButtonInteraction,
+  type StringSelectMenuBuilder,
+  type StringSelectMenuInteraction,
+  escapeMarkdown,
+  EmbedBuilder,
+  MessageFlags,
 } from 'discord.js';
-import { escapeMarkdown, EmbedBuilder, MessageFlags } from 'discord.js';
 import {
   createLogger,
   DISCORD_COLORS,

--- a/services/bot-client/src/commands/persona/browse.ts
+++ b/services/bot-client/src/commands/persona/browse.ts
@@ -5,8 +5,7 @@
  * Shows a paginated list of user's personas with select menu to edit
  */
 
-import { EmbedBuilder } from 'discord.js';
-import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
+import { EmbedBuilder, type ButtonInteraction, type StringSelectMenuInteraction } from 'discord.js';
 import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
 import { type UserClient } from '@tzurot/clients';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';

--- a/services/bot-client/src/commands/persona/create.ts
+++ b/services/bot-client/src/commands/persona/create.ts
@@ -11,8 +11,7 @@
  * Uses gateway API for all data access (no direct Prisma).
  */
 
-import { MessageFlags, ModalBuilder } from 'discord.js';
-import type { ModalSubmitInteraction } from 'discord.js';
+import { MessageFlags, ModalBuilder, type ModalSubmitInteraction } from 'discord.js';
 import { createLogger, API_ERROR_SUBCODE } from '@tzurot/common-types';
 import type { ModalCommandContext } from '../../utils/commandContext/types.js';
 import { buildPersonaModalFields } from './utils/modalBuilder.js';

--- a/services/bot-client/src/commands/persona/dashboard.ts
+++ b/services/bot-client/src/commands/persona/dashboard.ts
@@ -7,11 +7,11 @@
  * - Modal submissions for section edits
  */
 
-import { MessageFlags } from 'discord.js';
-import type {
-  StringSelectMenuInteraction,
-  ButtonInteraction,
-  ModalSubmitInteraction,
+import {
+  MessageFlags,
+  type StringSelectMenuInteraction,
+  type ButtonInteraction,
+  type ModalSubmitInteraction,
 } from 'discord.js';
 import { createLogger, type PersonaUpdateInput } from '@tzurot/common-types';
 import { buildDeleteConfirmation } from '../../utils/dashboard/deleteConfirmation.js';

--- a/services/bot-client/src/commands/persona/index.ts
+++ b/services/bot-client/src/commands/persona/index.ts
@@ -18,12 +18,12 @@
  * needing componentPrefixes (unlike the old /me command which needed 'profile').
  */
 
-import { SlashCommandBuilder } from 'discord.js';
-import type {
-  ModalSubmitInteraction,
-  AutocompleteInteraction,
-  ButtonInteraction,
-  StringSelectMenuInteraction,
+import {
+  SlashCommandBuilder,
+  type ModalSubmitInteraction,
+  type AutocompleteInteraction,
+  type ButtonInteraction,
+  type StringSelectMenuInteraction,
 } from 'discord.js';
 import { createLogger, personaEditOptions } from '@tzurot/common-types';
 import { defineCommand } from '../../utils/defineCommand.js';

--- a/services/bot-client/src/commands/persona/override/set.ts
+++ b/services/bot-client/src/commands/persona/override/set.ts
@@ -12,8 +12,7 @@
  * Uses gateway API for all data access (no direct Prisma).
  */
 
-import { MessageFlags, ModalBuilder } from 'discord.js';
-import type { ModalSubmitInteraction } from 'discord.js';
+import { MessageFlags, ModalBuilder, type ModalSubmitInteraction } from 'discord.js';
 import {
   createLogger,
   DISCORD_LIMITS,

--- a/services/bot-client/src/commands/persona/truncationWarning.ts
+++ b/services/bot-client/src/commands/persona/truncationWarning.ts
@@ -14,8 +14,12 @@
  * gate necessary on the persona side.
  */
 
-import { AttachmentBuilder, MessageFlags } from 'discord.js';
-import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
+import {
+  AttachmentBuilder,
+  MessageFlags,
+  type ButtonInteraction,
+  type StringSelectMenuInteraction,
+} from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
 import { type SectionDefinition } from '../../utils/dashboard/types.js';
 import { buildSectionModal } from '../../utils/dashboard/ModalFactory.js';

--- a/services/bot-client/src/commands/persona/view.ts
+++ b/services/bot-client/src/commands/persona/view.ts
@@ -17,8 +17,8 @@ import {
   ButtonStyle,
   ActionRowBuilder,
   type MessageActionRowComponentBuilder,
+  type ButtonInteraction,
 } from 'discord.js';
-import type { ButtonInteraction } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import { PersonaCustomIds } from '../../utils/customIds.js';

--- a/services/bot-client/src/commands/preset/browse.ts
+++ b/services/bot-client/src/commands/preset/browse.ts
@@ -8,8 +8,12 @@
  * - Pagination support for larger lists
  */
 
-import { EmbedBuilder, escapeMarkdown } from 'discord.js';
-import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
+import {
+  EmbedBuilder,
+  escapeMarkdown,
+  type ButtonInteraction,
+  type StringSelectMenuInteraction,
+} from 'discord.js';
 import {
   createLogger,
   DISCORD_COLORS,

--- a/services/bot-client/src/commands/preset/create.ts
+++ b/services/bot-client/src/commands/preset/create.ts
@@ -14,8 +14,8 @@ import {
   ActionRowBuilder,
   type ModalActionRowComponentBuilder,
   MessageFlags,
+  type ModalSubmitInteraction,
 } from 'discord.js';
-import type { ModalSubmitInteraction } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
 import type { ModalCommandContext } from '../../utils/commandContext/types.js';
 import {

--- a/services/bot-client/src/commands/preset/dashboard.ts
+++ b/services/bot-client/src/commands/preset/dashboard.ts
@@ -9,11 +9,11 @@
  * Button handlers are extracted to dashboardButtons.ts to keep file under 500 lines.
  */
 
-import { MessageFlags } from 'discord.js';
-import type {
-  StringSelectMenuInteraction,
-  ButtonInteraction,
-  ModalSubmitInteraction,
+import {
+  MessageFlags,
+  type StringSelectMenuInteraction,
+  type ButtonInteraction,
+  type ModalSubmitInteraction,
 } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
 import {
@@ -21,6 +21,7 @@ import {
   getSessionManager,
   parseDashboardCustomId,
   isDashboardInteraction,
+  handleSharedBackButton,
 } from '../../utils/dashboard/index.js';
 import { handleDashboardSectionSelect } from '../../utils/dashboard/genericSelectMenuHandler.js';
 import { refreshDashboardUI } from '../../utils/dashboard/refreshHandler.js';
@@ -49,7 +50,6 @@ import {
   handleCancelDeleteButton,
   handleCloneButton,
 } from './dashboardButtons.js';
-import { handleSharedBackButton } from '../../utils/dashboard/index.js';
 // Side-effect import: registers the preset browse rebuilder used by
 // renderPostActionScreen + handleSharedBackButton.
 import './browse.js';

--- a/services/bot-client/src/commands/preset/dashboardButtons.ts
+++ b/services/bot-client/src/commands/preset/dashboardButtons.ts
@@ -8,8 +8,7 @@
  * - Delete confirmation flow
  */
 
-import { MessageFlags } from 'discord.js';
-import type { ButtonInteraction } from 'discord.js';
+import { MessageFlags, type ButtonInteraction } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import {

--- a/services/bot-client/src/commands/preset/index.ts
+++ b/services/bot-client/src/commands/preset/index.ts
@@ -16,12 +16,12 @@
  * Note: Delete functionality is integrated into the dashboard (Edit command)
  */
 
-import { SlashCommandBuilder } from 'discord.js';
-import type {
-  AutocompleteInteraction,
-  StringSelectMenuInteraction,
-  ButtonInteraction,
-  ModalSubmitInteraction,
+import {
+  SlashCommandBuilder,
+  type AutocompleteInteraction,
+  type StringSelectMenuInteraction,
+  type ButtonInteraction,
+  type ModalSubmitInteraction,
 } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
 import { defineCommand } from '../../utils/defineCommand.js';

--- a/services/bot-client/src/commands/settings/apikey/modal.ts
+++ b/services/bot-client/src/commands/settings/apikey/modal.ts
@@ -9,8 +9,7 @@
  * - Never logs or displays the actual API key
  */
 
-import type { ModalSubmitInteraction } from 'discord.js';
-import { MessageFlags, EmbedBuilder } from 'discord.js';
+import { type ModalSubmitInteraction, MessageFlags, EmbedBuilder } from 'discord.js';
 import { createLogger, DISCORD_COLORS, AIProvider, API_KEY_FORMATS } from '@tzurot/common-types';
 import { getProviderDisplayName } from '../../../utils/providers.js';
 import { clientsFor } from '../../../utils/gatewayClients.js';

--- a/services/bot-client/src/commands/settings/index.ts
+++ b/services/bot-client/src/commands/settings/index.ts
@@ -12,12 +12,12 @@
  * - Consolidated from former /me timezone, /wallet, and /me preset commands
  */
 
-import { SlashCommandBuilder } from 'discord.js';
-import type {
-  ModalSubmitInteraction,
-  AutocompleteInteraction,
-  ButtonInteraction,
-  StringSelectMenuInteraction,
+import {
+  SlashCommandBuilder,
+  type ModalSubmitInteraction,
+  type AutocompleteInteraction,
+  type ButtonInteraction,
+  type StringSelectMenuInteraction,
 } from 'discord.js';
 import {
   createLogger,

--- a/services/bot-client/src/commands/shapes/detailHandlers.ts
+++ b/services/bot-client/src/commands/shapes/detailHandlers.ts
@@ -8,8 +8,14 @@
  * within the ESLint max-lines limit.
  */
 
-import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
-import { EmbedBuilder, ButtonBuilder, ButtonStyle, ActionRowBuilder } from 'discord.js';
+import {
+  type ButtonInteraction,
+  type StringSelectMenuInteraction,
+  EmbedBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ActionRowBuilder,
+} from 'discord.js';
 import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
 import { ShapesCustomIds } from '../../utils/customIds.js';
 import type { BrowseSortType } from '../../utils/browse/constants.js';

--- a/services/bot-client/src/commands/shapes/index.ts
+++ b/services/bot-client/src/commands/shapes/index.ts
@@ -11,8 +11,7 @@
  * - /shapes status - View credential status and import history
  */
 
-import { SlashCommandBuilder } from 'discord.js';
-import type { ModalSubmitInteraction } from 'discord.js';
+import { SlashCommandBuilder, type ModalSubmitInteraction } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
 import { defineCommand } from '../../utils/defineCommand.js';
 import { createMixedModeSubcommandRouter } from '../../utils/mixedModeSubcommandRouter.js';

--- a/services/bot-client/src/commands/shapes/interactionHandlers.ts
+++ b/services/bot-client/src/commands/shapes/interactionHandlers.ts
@@ -16,8 +16,12 @@
  * in detailHandlers.ts to keep this router under ESLint max-lines.
  */
 
-import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
-import { ButtonBuilder, ActionRowBuilder } from 'discord.js';
+import {
+  type ButtonInteraction,
+  type StringSelectMenuInteraction,
+  ButtonBuilder,
+  ActionRowBuilder,
+} from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
 import { ShapesCustomIds } from '../../utils/customIds.js';
 import { clientsFor } from '../../utils/gatewayClients.js';

--- a/services/bot-client/src/commands/shapes/modal.ts
+++ b/services/bot-client/src/commands/shapes/modal.ts
@@ -10,8 +10,7 @@
  * - Never logged or displayed
  */
 
-import type { ModalSubmitInteraction } from 'discord.js';
-import { MessageFlags, EmbedBuilder } from 'discord.js';
+import { type ModalSubmitInteraction, MessageFlags, EmbedBuilder } from 'discord.js';
 import { createLogger, DISCORD_COLORS, parseShapesSessionCookieInput } from '@tzurot/common-types';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import { ShapesCustomIds } from '../../utils/customIds.js';

--- a/services/bot-client/src/commands/voice/index.ts
+++ b/services/bot-client/src/commands/voice/index.ts
@@ -9,12 +9,12 @@
  * - /voice view <character> — unified TTS+STT+voices dashboard
  */
 
-import { SlashCommandBuilder } from 'discord.js';
-import type {
-  AutocompleteInteraction,
-  ButtonInteraction,
-  ModalSubmitInteraction,
-  StringSelectMenuInteraction,
+import {
+  SlashCommandBuilder,
+  type AutocompleteInteraction,
+  type ButtonInteraction,
+  type ModalSubmitInteraction,
+  type StringSelectMenuInteraction,
 } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
 import { defineCommand } from '../../utils/defineCommand.js';

--- a/services/bot-client/src/commands/voice/voices/browse.ts
+++ b/services/bot-client/src/commands/voice/voices/browse.ts
@@ -4,8 +4,12 @@
  * providers (ElevenLabs, Mistral) with paginated slot summary.
  */
 
-import { EmbedBuilder } from 'discord.js';
-import type { ButtonInteraction, ActionRowBuilder, ButtonBuilder } from 'discord.js';
+import {
+  EmbedBuilder,
+  type ButtonInteraction,
+  type ActionRowBuilder,
+  type ButtonBuilder,
+} from 'discord.js';
 import { createLogger, DISCORD_COLORS, type AudioProviderId } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
 import { clientsFor } from '../../../utils/gatewayClients.js';

--- a/services/bot-client/src/commands/voice/voices/clear.ts
+++ b/services/bot-client/src/commands/voice/voices/clear.ts
@@ -9,8 +9,7 @@
  * no longer dispatches voice-clear after the /voice consolidation.
  */
 
-import { EmbedBuilder } from 'discord.js';
-import type { ButtonInteraction, ModalSubmitInteraction } from 'discord.js';
+import { EmbedBuilder, type ButtonInteraction, type ModalSubmitInteraction } from 'discord.js';
 import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
 import { clientsFor } from '../../../utils/gatewayClients.js';

--- a/services/bot-client/src/commands/voice/voices/delete.ts
+++ b/services/bot-client/src/commands/voice/voices/delete.ts
@@ -7,8 +7,7 @@
  * extra round-trip. Gateway accepts `DELETE /user/voices/:provider/:voiceId`.
  */
 
-import { EmbedBuilder } from 'discord.js';
-import type { AutocompleteInteraction } from 'discord.js';
+import { EmbedBuilder, type AutocompleteInteraction } from 'discord.js';
 import {
   createLogger,
   DISCORD_COLORS,

--- a/services/bot-client/src/handlers/MessageReferenceExtractor.ts
+++ b/services/bot-client/src/handlers/MessageReferenceExtractor.ts
@@ -8,10 +8,14 @@
  * This facade maintains the original public API for backwards compatibility
  */
 
-import type { PrismaClient } from '@tzurot/common-types';
+import {
+  type PrismaClient,
+  createLogger,
+  INTERVALS,
+  type ReferencedMessage,
+  ConversationHistoryService,
+} from '@tzurot/common-types';
 import { Message } from 'discord.js';
-import { createLogger, INTERVALS, type ReferencedMessage } from '@tzurot/common-types';
-import { ConversationHistoryService } from '@tzurot/common-types';
 import { TranscriptRetriever } from './references/TranscriptRetriever.js';
 import { SnapshotFormatter } from './references/SnapshotFormatter.js';
 import { MessageFormatter } from './references/MessageFormatter.js';

--- a/services/bot-client/src/handlers/references/LinkExtractor.ts
+++ b/services/bot-client/src/handlers/references/LinkExtractor.ts
@@ -4,18 +4,18 @@
  * Extracts referenced messages from Discord message links
  */
 
-import type {
-  Message,
-  Channel,
-  TextChannel,
-  ThreadChannel,
-  DMChannel,
-  NewsChannel,
-  GuildMember,
+import {
+  type Message,
+  type Channel,
+  type TextChannel,
+  type ThreadChannel,
+  type DMChannel,
+  type NewsChannel,
+  type GuildMember,
+  ChannelType,
+  PermissionsBitField,
 } from 'discord.js';
-import { ChannelType, PermissionsBitField } from 'discord.js';
-import { createLogger, INTERVALS } from '@tzurot/common-types';
-import type { ReferencedMessage } from '@tzurot/common-types';
+import { createLogger, INTERVALS, type ReferencedMessage } from '@tzurot/common-types';
 import { MessageLinkParser, type ParsedMessageLink } from '../../utils/MessageLinkParser.js';
 import { MessageFormatter } from './MessageFormatter.js';
 import { SnapshotFormatter } from './SnapshotFormatter.js';

--- a/services/bot-client/src/handlers/references/ReferenceCrawler.ts
+++ b/services/bot-client/src/handlers/references/ReferenceCrawler.ts
@@ -8,8 +8,7 @@
 import type { Message } from 'discord.js';
 import { createLogger, INTERVALS } from '@tzurot/common-types';
 import type { IReferenceStrategy } from './strategies/IReferenceStrategy.js';
-import type { ReferenceMetadata, ReferenceResult } from './types.js';
-import { ReferenceType } from './types.js';
+import { type ReferenceMetadata, type ReferenceResult, ReferenceType } from './types.js';
 import { LinkExtractor } from './LinkExtractor.js';
 
 const logger = createLogger('ReferenceCrawler');

--- a/services/bot-client/src/handlers/references/strategies/LinkReferenceStrategy.ts
+++ b/services/bot-client/src/handlers/references/strategies/LinkReferenceStrategy.ts
@@ -8,8 +8,7 @@ import type { Message } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
 import { MessageLinkParser } from '../../../utils/MessageLinkParser.js';
 import type { IReferenceStrategy } from './IReferenceStrategy.js';
-import type { ReferenceResult } from '../types.js';
-import { ReferenceType } from '../types.js';
+import { type ReferenceResult, ReferenceType } from '../types.js';
 
 const logger = createLogger('LinkReferenceStrategy');
 

--- a/services/bot-client/src/handlers/references/strategies/ReplyReferenceStrategy.ts
+++ b/services/bot-client/src/handlers/references/strategies/ReplyReferenceStrategy.ts
@@ -7,8 +7,7 @@
 import { type Message, MessageReferenceType } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
 import type { IReferenceStrategy } from './IReferenceStrategy.js';
-import type { ReferenceResult } from '../types.js';
-import { ReferenceType } from '../types.js';
+import { type ReferenceResult, ReferenceType } from '../types.js';
 
 const logger = createLogger('ReplyReferenceStrategy');
 

--- a/services/bot-client/src/processors/PersonalityTriggerProcessor.ts
+++ b/services/bot-client/src/processors/PersonalityTriggerProcessor.ts
@@ -23,7 +23,12 @@
  */
 
 import type { Message } from 'discord.js';
-import { createLogger, getConfig, type LoadedPersonality } from '@tzurot/common-types';
+import {
+  createLogger,
+  getConfig,
+  type LoadedPersonality,
+  isTypingChannel,
+} from '@tzurot/common-types';
 import type { IMessageProcessor } from './IMessageProcessor.js';
 import type { IPersonalityLoader } from '../types/IPersonalityLoader.js';
 import type { ReplyResolutionService } from '../services/ReplyResolutionService.js';
@@ -35,7 +40,6 @@ import { VoiceMessageProcessor } from './VoiceMessageProcessor.js';
 import { isForwardedMessage } from '../utils/forwardedMessageUtils.js';
 import { getEffectiveContent } from '../utils/messageTypeUtils.js';
 import { getThreadParentId } from '../utils/discordChannelTypes.js';
-import { isTypingChannel } from '@tzurot/common-types';
 import { shouldNotifyUser } from './notificationCache.js';
 
 const logger = createLogger('PersonalityTriggerProcessor');

--- a/services/bot-client/src/services/ConversationPersistence.ts
+++ b/services/bot-client/src/services/ConversationPersistence.ts
@@ -10,15 +10,17 @@
  * - XML formatting happens only at prompt-building time, NOT in storage
  */
 
-import type { PrismaClient } from '@tzurot/common-types';
-import type { Message } from 'discord.js';
-import { ConversationHistoryService, createLogger, MessageRole } from '@tzurot/common-types';
-import type {
-  LoadedPersonality,
-  ReferencedMessage,
-  MessageMetadata,
-  StoredReferencedMessage,
+import {
+  type PrismaClient,
+  ConversationHistoryService,
+  createLogger,
+  MessageRole,
+  type LoadedPersonality,
+  type ReferencedMessage,
+  type MessageMetadata,
+  type StoredReferencedMessage,
 } from '@tzurot/common-types';
+import type { Message } from 'discord.js';
 import { generateAttachmentPlaceholders } from '../utils/attachmentPlaceholders.js';
 import { isForwardedMessage } from '../utils/forwardedMessageUtils.js';
 import { buildMessageContent } from '../utils/MessageContentBuilder.js';

--- a/services/bot-client/src/services/CrossChannelHistoryFetcher.ts
+++ b/services/bot-client/src/services/CrossChannelHistoryFetcher.ts
@@ -6,8 +6,7 @@
  * has fewer messages than maxMessages.
  */
 
-import type { Client } from 'discord.js';
-import { ChannelType } from 'discord.js';
+import { type Client, ChannelType } from 'discord.js';
 import {
   ConversationHistoryService,
   createLogger,

--- a/services/bot-client/src/services/DiscordChannelFetcher.ts
+++ b/services/bot-client/src/services/DiscordChannelFetcher.ts
@@ -13,14 +13,12 @@ import {
   ConversationSyncService,
   computeHistoryCutoff,
   stripBotFooters,
+  type ConversationMessage,
+  type AttachmentMetadata,
+  type MessageReaction,
+  type StoredReferencedMessage,
 } from '@tzurot/common-types';
 import { INTERNAL_DISCORD_ID_PREFIX } from '../constants/personaId.js';
-import type {
-  ConversationMessage,
-  AttachmentMetadata,
-  MessageReaction,
-  StoredReferencedMessage,
-} from '@tzurot/common-types';
 import { buildMessageContent, hasMessageContent } from '../utils/MessageContentBuilder.js';
 import { isUserContentMessage } from '../utils/messageTypeUtils.js';
 import { resolveHistoryLinks } from '../utils/HistoryLinkResolver.js';

--- a/services/bot-client/src/services/DiscordResponseSender.ts
+++ b/services/bot-client/src/services/DiscordResponseSender.ts
@@ -5,8 +5,13 @@
  * Manages message chunking, model indicators, and webhook storage.
  */
 
-import type { DMChannel } from 'discord.js';
-import { NewsChannel, TextChannel, ThreadChannel, escapeMarkdown } from 'discord.js';
+import {
+  type DMChannel,
+  NewsChannel,
+  TextChannel,
+  ThreadChannel,
+  escapeMarkdown,
+} from 'discord.js';
 import {
   splitMessage,
   createLogger,
@@ -17,8 +22,8 @@ import {
   buildModelInfoUrl,
   isBotOwner,
   type TypingChannel,
+  type LoadedPersonality,
 } from '@tzurot/common-types';
-import type { LoadedPersonality } from '@tzurot/common-types';
 import { WebhookManager } from '../utils/WebhookManager.js';
 import { redisService } from '../redis.js';
 import { buildBotAudioFilename } from '../utils/botAudioClassifier.js';

--- a/services/bot-client/src/services/JobTracker.ts
+++ b/services/bot-client/src/services/JobTracker.ts
@@ -6,8 +6,7 @@
  * Stores all context needed to handle async results (moved from MessageHandler).
  */
 
-import { createLogger, type TypingChannel } from '@tzurot/common-types';
-import type { LoadedPersonality } from '@tzurot/common-types';
+import { createLogger, type TypingChannel, type LoadedPersonality } from '@tzurot/common-types';
 import type { Message } from 'discord.js';
 import { sendTypingIndicator } from '../utils/typingErrorClassifier.js';
 import type { ResponseOrderingService } from './ResponseOrderingService.js';

--- a/services/bot-client/src/services/MentionResolver.ts
+++ b/services/bot-client/src/services/MentionResolver.ts
@@ -2,14 +2,15 @@
  * MentionResolver - Resolves Discord mentions (users, channels, roles) in message content.
  */
 
-import type { PrismaClient, PersonaResolver } from '@tzurot/common-types';
-import type { Collection, User, Guild, Message } from 'discord.js';
 import {
+  type PrismaClient,
+  type PersonaResolver,
   UserService,
   createLogger,
   DISCORD_MENTIONS,
   isValidDiscordId,
 } from '@tzurot/common-types';
+import type { Collection, User, Guild, Message } from 'discord.js';
 import type {
   MentionedUserInfo,
   MentionResolutionResult,

--- a/services/bot-client/src/services/MessageContextBuilder.ts
+++ b/services/bot-client/src/services/MessageContextBuilder.ts
@@ -5,16 +5,13 @@
  * Helper modules extracted to contextBuilder/ subdirectory.
  */
 
-import type {
-  PrismaClient,
-  PersonaResolver,
-  LoadedPersonality,
-  ReferencedMessage,
-  ConversationMessage,
-  AttachmentMetadata,
-} from '@tzurot/common-types';
-import type { Message } from 'discord.js';
 import {
+  type PrismaClient,
+  type PersonaResolver,
+  type LoadedPersonality,
+  type ReferencedMessage,
+  type ConversationMessage,
+  type AttachmentMetadata,
   ConversationHistoryService,
   ConversationSyncService,
   UserService,
@@ -22,6 +19,7 @@ import {
   MESSAGE_LIMITS,
   isTypingChannel,
 } from '@tzurot/common-types';
+import type { Message } from 'discord.js';
 import type { MessageContext } from '../types.js';
 import { extractDiscordEnvironment } from '../utils/discordContext.js';
 import { buildMessageContent } from '../utils/MessageContentBuilder.js';

--- a/services/bot-client/src/services/PersonalityMessageHandler.ts
+++ b/services/bot-client/src/services/PersonalityMessageHandler.ts
@@ -12,8 +12,7 @@
  */
 
 import type { Message } from 'discord.js';
-import { createLogger } from '@tzurot/common-types';
-import type { LoadedPersonality } from '@tzurot/common-types';
+import { createLogger, type LoadedPersonality } from '@tzurot/common-types';
 import { JobTracker } from './JobTracker.js';
 import { PersonalityChatManager } from './character/PersonalityChatManager.js';
 

--- a/services/bot-client/src/services/ReferenceEnrichmentService.ts
+++ b/services/bot-client/src/services/ReferenceEnrichmentService.ts
@@ -5,8 +5,13 @@
  * Pure data transformation service with no side effects.
  */
 
-import { UserService, createLogger } from '@tzurot/common-types';
-import type { ConversationMessage, ReferencedMessage, PersonaResolver } from '@tzurot/common-types';
+import {
+  UserService,
+  createLogger,
+  type ConversationMessage,
+  type ReferencedMessage,
+  type PersonaResolver,
+} from '@tzurot/common-types';
 import { redisService } from '../redis.js';
 
 const logger = createLogger('ReferenceEnrichmentService');

--- a/services/bot-client/src/services/ReplyResolutionService.ts
+++ b/services/bot-client/src/services/ReplyResolutionService.ts
@@ -18,8 +18,7 @@
  */
 
 import { ChannelType, type Message } from 'discord.js';
-import { createLogger, isUuidFormat } from '@tzurot/common-types';
-import type { LoadedPersonality } from '@tzurot/common-types';
+import { createLogger, isUuidFormat, type LoadedPersonality } from '@tzurot/common-types';
 import type { IPersonalityLoader } from '../types/IPersonalityLoader.js';
 import { lookupPersonalityFromMessage } from '../utils/gatewayServiceCalls.js';
 import { redisService } from '../redis.js';

--- a/services/bot-client/src/services/SlotResolver.ts
+++ b/services/bot-client/src/services/SlotResolver.ts
@@ -15,8 +15,7 @@
  * Capped at MULTI_TAG.MAX_TAGS.
  */
 
-import type { LoadedPersonality } from '@tzurot/common-types';
-import { MULTI_TAG } from '@tzurot/common-types';
+import { type LoadedPersonality, MULTI_TAG } from '@tzurot/common-types';
 
 /** What kind of trigger produced this slot. Drives isAutoResponse and DM-activation behavior. */
 export type SlotSource = 'reply' | 'activation' | 'dm-session' | 'mention';

--- a/services/bot-client/src/services/channelFetcher/ReactionProcessor.ts
+++ b/services/bot-client/src/services/channelFetcher/ReactionProcessor.ts
@@ -6,8 +6,12 @@
  */
 
 import type { Message } from 'discord.js';
-import { createLogger, MESSAGE_LIMITS, type MessageReaction } from '@tzurot/common-types';
-import type { ConversationMessage } from '@tzurot/common-types';
+import {
+  createLogger,
+  MESSAGE_LIMITS,
+  type MessageReaction,
+  type ConversationMessage,
+} from '@tzurot/common-types';
 import type { ExtendedContextUser } from './types.js';
 import { collectReactorUsers } from './ParticipantContextCollector.js';
 import { INTERNAL_DISCORD_ID_PREFIX } from '../../constants/personaId.js';

--- a/services/bot-client/src/services/contextBuilder/ReferenceExtractor.ts
+++ b/services/bot-client/src/services/contextBuilder/ReferenceExtractor.ts
@@ -6,14 +6,17 @@
  */
 
 import type { Message } from 'discord.js';
-import { createLogger, MessageRole, CONTENT_TYPES, INTERVALS } from '@tzurot/common-types';
-import type {
-  PrismaClient,
-  LoadedPersonality,
-  MentionedPersona,
-  ReferencedChannel,
-  ReferencedMessage,
-  ConversationMessage,
+import {
+  createLogger,
+  MessageRole,
+  CONTENT_TYPES,
+  INTERVALS,
+  type PrismaClient,
+  type LoadedPersonality,
+  type MentionedPersona,
+  type ReferencedChannel,
+  type ReferencedMessage,
+  type ConversationMessage,
 } from '@tzurot/common-types';
 import { MessageReferenceExtractor } from '../../handlers/MessageReferenceExtractor.js';
 import type { MentionResolver } from '../MentionResolver.js';
@@ -44,7 +47,7 @@ interface ExtractReferencesOptions {
 /**
  * Extract referenced messages and resolve mentions.
  */
- 
+
 export async function extractReferencesAndMentions(
   opts: ExtractReferencesOptions
 ): Promise<ReferencesAndMentionsResult> {

--- a/services/bot-client/src/services/multiTagDeliveryFlow.ts
+++ b/services/bot-client/src/services/multiTagDeliveryFlow.ts
@@ -28,8 +28,12 @@ import {
 } from '@tzurot/common-types';
 import { buildErrorContent } from '../utils/buildErrorContent.js';
 import { pickNewDMActivePersonality } from './SlotResolver.js';
-import { buildSlotContext, toSnapshot } from './multiTagCoordinatorHelpers.js';
-import type { RuntimeEntry, RuntimeSlot } from './multiTagCoordinatorHelpers.js';
+import {
+  buildSlotContext,
+  toSnapshot,
+  type RuntimeEntry,
+  type RuntimeSlot,
+} from './multiTagCoordinatorHelpers.js';
 import type { SlotDeliveryService } from './SlotDeliveryService.js';
 import { confirmDelivery, setDmSessionPersonality } from '../utils/gatewayServiceCalls.js';
 import type { MultiTagPersistence } from './MultiTagPersistence.js';

--- a/services/bot-client/src/test/mocks/Discord.mock.ts
+++ b/services/bot-client/src/test/mocks/Discord.mock.ts
@@ -37,20 +37,21 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access -- Mock factory uses any types intentionally for flexible Discord.js test doubles */
 
 import { vi } from 'vitest';
-import { ChannelType, Collection } from 'discord.js';
-import type {
-  Message,
-  TextChannel,
-  DMChannel,
-  ThreadChannel,
-  Guild,
-  User,
-  GuildMember,
-  CategoryChannel,
-  Snowflake,
-  Role,
-  MessageMentions,
-  GuildTextBasedChannel,
+import {
+  ChannelType,
+  Collection,
+  type Message,
+  type TextChannel,
+  type DMChannel,
+  type ThreadChannel,
+  type Guild,
+  type User,
+  type GuildMember,
+  type CategoryChannel,
+  type Snowflake,
+  type Role,
+  type MessageMentions,
+  type GuildTextBasedChannel,
 } from 'discord.js';
 
 /**

--- a/services/bot-client/src/types.ts
+++ b/services/bot-client/src/types.ts
@@ -14,14 +14,14 @@ import type {
   SlashCommandSubcommandsOnlyBuilder,
   SlashCommandOptionsOnlyBuilder,
 } from 'discord.js';
-import type {
-  CrossChannelHistoryGroupEntry,
-  GenerateResponse,
-  LoadedPersonality,
-  RequestContext,
-  TranscribeResponse,
+import {
+  type CrossChannelHistoryGroupEntry,
+  type GenerateResponse,
+  type LoadedPersonality,
+  type RequestContext,
+  type TranscribeResponse,
+  MessageRole,
 } from '@tzurot/common-types';
-import { MessageRole } from '@tzurot/common-types';
 import type { DeferralMode, SafeCommandContext } from './utils/commandContext/index.js';
 
 // Re-export shared API types

--- a/services/bot-client/src/utils/HistoryLinkResolver.ts
+++ b/services/bot-client/src/utils/HistoryLinkResolver.ts
@@ -18,8 +18,11 @@
  */
 
 import type { Message, Client } from 'discord.js';
-import { createLogger } from '@tzurot/common-types';
-import type { StoredReferencedMessage, AttachmentMetadata } from '@tzurot/common-types';
+import {
+  createLogger,
+  type StoredReferencedMessage,
+  type AttachmentMetadata,
+} from '@tzurot/common-types';
 import { MessageLinkParser, type ParsedMessageLink } from './MessageLinkParser.js';
 import { buildMessageContent } from './MessageContentBuilder.js';
 

--- a/services/bot-client/src/utils/MessageContentBuilder.ts
+++ b/services/bot-client/src/utils/MessageContentBuilder.ts
@@ -24,8 +24,7 @@
  */
 
 import type { Message, APIEmbed } from 'discord.js';
-import { createLogger } from '@tzurot/common-types';
-import type { AttachmentMetadata } from '@tzurot/common-types';
+import { createLogger, type AttachmentMetadata } from '@tzurot/common-types';
 import { extractAttachments } from './attachmentExtractor.js';
 import { extractEmbedImages } from './embedImageExtractor.js';
 import { EmbedParser } from './EmbedParser.js';

--- a/services/bot-client/src/utils/WebhookManager.ts
+++ b/services/bot-client/src/utils/WebhookManager.ts
@@ -6,16 +6,17 @@
  */
 
 import { createLogger, INTERVALS, DISCORD_LIMITS } from '@tzurot/common-types';
-import { ChannelType, Client } from 'discord.js';
-import { deriveBotSuffix } from './webhookNaming.js';
-import type {
-  TextChannel,
-  ThreadChannel,
-  ForumChannel,
-  NewsChannel,
-  Webhook,
-  Message,
+import {
+  ChannelType,
+  Client,
+  type TextChannel,
+  type ThreadChannel,
+  type ForumChannel,
+  type NewsChannel,
+  type Webhook,
+  type Message,
 } from 'discord.js';
+import { deriveBotSuffix } from './webhookNaming.js';
 import type { LoadedPersonality } from '../types.js';
 
 const logger = createLogger('WebhookManager');

--- a/services/bot-client/src/utils/attachmentExtractor.ts
+++ b/services/bot-client/src/utils/attachmentExtractor.ts
@@ -6,8 +6,7 @@
  */
 
 import { Collection, Snowflake, Attachment } from 'discord.js';
-import type { AttachmentMetadata } from '@tzurot/common-types';
-import { CONTENT_TYPES } from '@tzurot/common-types';
+import { type AttachmentMetadata, CONTENT_TYPES } from '@tzurot/common-types';
 
 /**
  * Extract attachment metadata from a Discord message's attachments collection

--- a/services/bot-client/src/utils/attachmentPlaceholders.ts
+++ b/services/bot-client/src/utils/attachmentPlaceholders.ts
@@ -6,8 +6,7 @@
  * then updated with rich descriptions after vision/transcription processing.
  */
 
-import type { AttachmentMetadata } from '@tzurot/common-types';
-import { CONTENT_TYPES } from '@tzurot/common-types';
+import { type AttachmentMetadata, CONTENT_TYPES } from '@tzurot/common-types';
 
 /**
  * Generate placeholder description for a single attachment

--- a/services/bot-client/src/utils/chunkedReply.ts
+++ b/services/bot-client/src/utils/chunkedReply.ts
@@ -5,8 +5,7 @@
  * sending the first as an editReply and the rest as follow-ups.
  */
 
-import { MessageFlags } from 'discord.js';
-import type { ButtonInteraction } from 'discord.js';
+import { MessageFlags, type ButtonInteraction } from 'discord.js';
 import { DISCORD_LIMITS, splitMessage } from '@tzurot/common-types';
 
 export interface ChunkedReplyOptions {

--- a/services/bot-client/src/utils/commandHelpers.ts
+++ b/services/bot-client/src/utils/commandHelpers.ts
@@ -8,8 +8,7 @@
  * - Common interaction utilities
  */
 
-import { EmbedBuilder } from 'discord.js';
-import type { ChatInputCommandInteraction } from 'discord.js';
+import { EmbedBuilder, type ChatInputCommandInteraction } from 'discord.js';
 import { createLogger, DISCORD_COLORS } from '@tzurot/common-types';
 import { isGatewayConfigured } from './gatewayClients.js';
 

--- a/services/bot-client/src/utils/dashboard/genericSelectMenuHandler.ts
+++ b/services/bot-client/src/utils/dashboard/genericSelectMenuHandler.ts
@@ -14,8 +14,7 @@
  * before the modal opens; only preset still uses it.
  */
 
-import type { StringSelectMenuInteraction } from 'discord.js';
-import { MessageFlags } from 'discord.js';
+import { type StringSelectMenuInteraction, MessageFlags } from 'discord.js';
 import type { UserClient } from '@tzurot/clients';
 import { clientsFor } from '../gatewayClients.js';
 import { parseDashboardCustomId, type DashboardConfig } from './types.js';

--- a/services/bot-client/src/utils/dashboard/permissionChecks.ts
+++ b/services/bot-client/src/utils/dashboard/permissionChecks.ts
@@ -4,8 +4,7 @@
  * Shared utilities for checking and handling permissions in dashboard interactions.
  */
 
-import { MessageFlags } from 'discord.js';
-import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
+import { MessageFlags, type ButtonInteraction, type StringSelectMenuInteraction } from 'discord.js';
 import { DASHBOARD_MESSAGES } from './messages.js';
 
 /**

--- a/services/bot-client/src/utils/dashboard/replyError.ts
+++ b/services/bot-client/src/utils/dashboard/replyError.ts
@@ -1,5 +1,4 @@
-import { MessageFlags } from 'discord.js';
-import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
+import { MessageFlags, type ButtonInteraction, type StringSelectMenuInteraction } from 'discord.js';
 
 /**
  * Reply with an ephemeral error, adapting to the interaction's ack state.

--- a/services/bot-client/src/utils/dashboard/sessionHelpers.ts
+++ b/services/bot-client/src/utils/dashboard/sessionHelpers.ts
@@ -5,11 +5,11 @@
  * and handling session state across dashboard interactions.
  */
 
-import { MessageFlags } from 'discord.js';
-import type {
-  ButtonInteraction,
-  StringSelectMenuInteraction,
-  ModalSubmitInteraction,
+import {
+  MessageFlags,
+  type ButtonInteraction,
+  type StringSelectMenuInteraction,
+  type ModalSubmitInteraction,
 } from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
 import { getSessionManager } from './SessionManager.js';

--- a/services/bot-client/src/utils/dashboard/showModalWithTimeoutCatch.ts
+++ b/services/bot-client/src/utils/dashboard/showModalWithTimeoutCatch.ts
@@ -16,8 +16,13 @@
  * On any other error: rethrow so the global handler can surface it.
  */
 
-import { DiscordAPIError, MessageFlags, type ModalBuilder } from 'discord.js';
-import type { ButtonInteraction, StringSelectMenuInteraction } from 'discord.js';
+import {
+  DiscordAPIError,
+  MessageFlags,
+  type ModalBuilder,
+  type ButtonInteraction,
+  type StringSelectMenuInteraction,
+} from 'discord.js';
 import { createLogger } from '@tzurot/common-types';
 
 const logger = createLogger('show-modal-with-timeout-catch');

--- a/services/bot-client/src/utils/discordContext.ts
+++ b/services/bot-client/src/utils/discordContext.ts
@@ -5,8 +5,12 @@
  * This helps the AI understand the environment of the conversation.
  */
 
-import type { Message, GuildBasedChannel, AnyThreadChannel } from 'discord.js';
-import { ChannelType } from 'discord.js';
+import {
+  type Message,
+  type GuildBasedChannel,
+  type AnyThreadChannel,
+  ChannelType,
+} from 'discord.js';
 import { createLogger, type DiscordEnvironment } from '@tzurot/common-types';
 
 const logger = createLogger('DiscordContext');

--- a/services/bot-client/src/utils/embedImageExtractor.ts
+++ b/services/bot-client/src/utils/embedImageExtractor.ts
@@ -6,8 +6,7 @@
  */
 
 import { Embed } from 'discord.js';
-import type { AttachmentMetadata } from '@tzurot/common-types';
-import { CONTENT_TYPES, EMBED_NAMING } from '@tzurot/common-types';
+import { type AttachmentMetadata, CONTENT_TYPES, EMBED_NAMING } from '@tzurot/common-types';
 
 /**
  * Extract image and thumbnail URLs from Discord embeds as attachment metadata

--- a/services/bot-client/src/utils/forwardedMessageUtils.ts
+++ b/services/bot-client/src/utils/forwardedMessageUtils.ts
@@ -18,8 +18,13 @@
  * This module handles both cases gracefully.
  */
 
-import type { Message, MessageSnapshot, Collection, APIEmbed } from 'discord.js';
-import { MessageReferenceType } from 'discord.js';
+import {
+  type Message,
+  type MessageSnapshot,
+  type Collection,
+  type APIEmbed,
+  MessageReferenceType,
+} from 'discord.js';
 import type { AttachmentMetadata } from '@tzurot/common-types';
 import { extractAttachments } from './attachmentExtractor.js';
 import { extractEmbedImages } from './embedImageExtractor.js';

--- a/services/bot-client/src/utils/jsonFileUtils.ts
+++ b/services/bot-client/src/utils/jsonFileUtils.ts
@@ -5,9 +5,8 @@
  * Used by character and preset import/export commands.
  */
 
-import { AttachmentBuilder } from 'discord.js';
+import { AttachmentBuilder, type Attachment } from 'discord.js';
 import { createLogger, DISCORD_LIMITS } from '@tzurot/common-types';
-import type { Attachment } from 'discord.js';
 import { validateDiscordCdnUrl } from './discordCdnGuard.js';
 
 const logger = createLogger('json-file-utils');

--- a/services/bot-client/src/utils/messageTypeUtils.ts
+++ b/services/bot-client/src/utils/messageTypeUtils.ts
@@ -13,8 +13,7 @@
  * use the centralized utilities in forwardedMessageUtils.ts
  */
 
-import type { Message } from 'discord.js';
-import { MessageType } from 'discord.js';
+import { type Message, MessageType } from 'discord.js';
 import { isForwardedMessage as isForwarded } from './forwardedMessageUtils.js';
 
 /**

--- a/services/bot-client/src/utils/permissions.ts
+++ b/services/bot-client/src/utils/permissions.ts
@@ -8,8 +8,12 @@
  * control over channels in servers where they may not have admin rights.
  */
 
-import { MessageFlags, PermissionFlagsBits } from 'discord.js';
-import type { ChatInputCommandInteraction, GuildMember } from 'discord.js';
+import {
+  MessageFlags,
+  PermissionFlagsBits,
+  type ChatInputCommandInteraction,
+  type GuildMember,
+} from 'discord.js';
 import { isBotOwner } from '@tzurot/common-types';
 import type { DeferredCommandContext } from './commandContext/types.js';
 

--- a/services/bot-client/src/utils/subcommandRouter.ts
+++ b/services/bot-client/src/utils/subcommandRouter.ts
@@ -11,8 +11,11 @@
  * - Consistent: All commands handle unknown subcommands the same way
  */
 
-import { MessageFlags } from 'discord.js';
-import type { ChatInputCommandInteraction, ModalSubmitInteraction } from 'discord.js';
+import {
+  MessageFlags,
+  type ChatInputCommandInteraction,
+  type ModalSubmitInteraction,
+} from 'discord.js';
 import type { Logger } from 'pino';
 
 /**


### PR DESCRIPTION
## Summary

Enables `import/no-duplicates` (via `eslint-plugin-import`) with `{ prefer-inline: true }` and autofixes the **130 source files** that had multiple imports from the same module — merged into one statement using inline `type` markers. Test files are eslint-ignored, so they're untouched.

This is the backlogged follow-up from the `@tzurot/clients` extraction (where the codemod briefly introduced duplicate imports that lint didn't catch).

## Two non-obvious gotchas (documented in the backlog, hit + solved here)

1. **`prefer-inline: true` is mandatory.** Without it, the autofix folds a value import into a same-module `import type {}` block → invalid TS (`createLogger cannot be used as a value`). With it, separate type+value imports from the same module merge into `import { type X, value }`.

2. **The autofix must run scoped to ONLY this rule, with `reportUnusedDisableDirectives: 'off'`.** A minimal flat config makes every *other* rule's `eslint-disable` directive look "unused" (its target rule isn't loaded), and `eslint --fix` strips unused directives by default — silently un-suppressing real `complexity` / `no-restricted-syntax` warnings across ~13 files. Caught it (a removed `// eslint-disable-next-line complexity` in `preset/config.ts`), root-caused it, and disabled directive-removal in the fix config. The committed diff removes **zero** eslint-disable comments.

## Verification
- Full pre-push gate green (build + lint + test + typecheck + typecheck:spec + depcruise + knip:dead)
- `bot-client` lint (the canary that surfaced gotcha #2) exits 0
- The rule is now enforced in CI; future duplicate imports fail lint with an autofix available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)