### PR TITLE
chore(test-utils): bring @tzurot/test-utils up to quality parity

### DIFF
--- a/packages/common-types/src/structure.test.ts
+++ b/packages/common-types/src/structure.test.ts
@@ -79,6 +79,10 @@ const EXCLUDE_PATTERNS = [
   // per-resource builders are collectively tested by `factories.test.ts`.
   /\/factories\//,
   /\/test-factories\/src\//,
+  // `@tzurot/test-utils` is pure test infrastructure: `seed.ts` (exercised by
+  // `seed.int.test.ts`), `RedisClientMock.ts`, and `setup-pglite.ts` — mocks and
+  // PGLite/Redis setup that the colocated-unit-test rule doesn't apply to.
+  /\/test-utils\/src\//,
   // Service singletons and caches (thin wrappers around Prisma/Redis/external APIs)
   /Service\.ts$/,
   /Cache\.ts$/,
@@ -185,6 +189,7 @@ describe('Project Structure', () => {
       'packages/common-types/src',
       'packages/embeddings/src',
       'packages/test-factories/src',
+      'packages/test-utils/src',
       'packages/tooling/src',
     ];
 

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -14,7 +14,12 @@
   },
   "scripts": {
     "build": "tsc",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "lint": "eslint src --max-warnings=0",
+    "lint:fix": "eslint src --fix",
+    "format": "prettier --write .",
+    "typecheck": "tsc --noEmit",
+    "typecheck:spec": "tsc --noEmit --project tsconfig.spec.json"
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.4.6",

--- a/packages/test-utils/tsconfig.spec.json
+++ b/packages/test-utils/tsconfig.spec.json
@@ -1,0 +1,24 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
+    // Widen rootDir to the packages dir: the path mapping below resolves
+    // common-types source, which lives outside test-utils/src. Harmless under
+    // noEmit (no output layout to constrain).
+    "rootDir": "..",
+    // `seed.int.test.ts` instantiates the generated PrismaClient, which lives
+    // inside @tzurot/common-types. test-utils cannot declare common-types as a
+    // dependency without recreating the common-types ↔ test-utils Turbo build
+    // cycle (see seed.ts). This path mapping mirrors the runtime alias in
+    // vitest.int.config.ts so tsc can resolve the type for the spec typecheck
+    // only — it does not add a package-graph edge.
+    "paths": {
+      "@tzurot/common-types": ["../common-types/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Problem

`@tzurot/test-utils` had only `build` + `clean` scripts — **no `lint`, no `typecheck`**. Since `pnpm lint` / `pnpm typecheck` are `turbo run <task>` (per-package), turbo silently skipped test-utils entirely. It was also absent from `structure.test.ts`'s scanned dirs. So a whole shared package sat outside the quality net while every other package is enforced.

(test-factories, by contrast, was scaffolded with the full script set in #1142 — this closes the analogous gap for test-utils.)

## Changes

- **Scripts**: add `lint` / `lint:fix` / `format` / `typecheck` / `typecheck:spec` (parity with test-factories). No unit-test script — test-utils' only logic, `seed.ts`, is exercised by `seed.int.test.ts` via the repo-wide `vitest.int.config.ts`; the rest is mocks / PGLite-setup / barrel.
- **`tsconfig.spec.json`** (new). Adding `typecheck:spec` surfaced a latent gap: `seed.int.test.ts` imports `PrismaClient` from `@tzurot/common-types` (where the Prisma v7 generated client lives), but test-utils **can't declare common-types as a dependency** without recreating the `common-types ↔ test-utils` Turbo build cycle (documented in `seed.ts`). The int test only resolved at runtime via the `vitest.int.config.ts` alias. Fix: mirror that alias as a tsconfig `paths` mapping so tsc resolves the type for the spec typecheck **without adding a package-graph edge**. `depcruise` confirms no new cycle.
- **`structure.test.ts`**: add `packages/test-utils/src` to the scanned dirs with a matching exclusion (pure test infrastructure), consistent with how `test-factories` is handled.

## Verification

| Gate | Result |
|------|--------|
| test-utils lint / typecheck / typecheck:spec | ✓ (all new; typecheck:spec now type-checks the int test) |
| common-types tests (structure.test + new dirs) | 2619 ✓ |
| depcruise (no new cycle from the alias) | ✓ |
| knip | ✓ |

Surfaced from a standards-gap audit; related follow-ups (test-factories structure-growth gap, depcruise dev-only boundary rule) already tracked in `deferred.md` / `quick-wins.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)