### PR TITLE
fix(bot-client): copy @tzurot/clients dist into Docker runtime stage

### DIFF
--- a/services/bot-client/Dockerfile
+++ b/services/bot-client/Dockerfile
@@ -1,8 +1,11 @@
 # =============================================================================
 # Bot Client Dockerfile - Using turbo prune for automatic dependency handling
 # =============================================================================
-# When adding new workspace packages as dependencies, turbo prune automatically
-# includes them - no manual Dockerfile updates needed.
+# `turbo prune` automatically includes new workspace packages in the pruned
+# SOURCE and the build step. BUT the runtime stage copies each package's built
+# `dist` MANUALLY (one COPY per runtime dependency, see Stage 4). When adding a
+# new `@tzurot/*` runtime dependency, you MUST add its dist COPY there too, or
+# the runtime image will be missing it and crash with ERR_MODULE_NOT_FOUND.
 # =============================================================================
 
 # -----------------------------------------------------------------------------
@@ -77,8 +80,13 @@ RUN pnpm install --prod --frozen-lockfile
 # Copy Prisma client from builder (generated in node_modules/.pnpm)
 COPY --from=builder /app/node_modules/.pnpm ./node_modules/.pnpm
 
-# Copy built artifacts from all workspace packages
+# Copy built artifacts from all workspace packages.
+# NOTE: these dist copies are MANUAL — one line per runtime workspace dependency.
+# When bot-client gains a new `@tzurot/*` runtime dependency, add its dist here
+# or the runtime image will be missing it (ERR_MODULE_NOT_FOUND at startup).
+# Keep in sync with the prod `dependencies` in services/bot-client/package.json.
 COPY --from=builder /app/packages/common-types/dist ./packages/common-types/dist
+COPY --from=builder /app/packages/clients/dist ./packages/clients/dist
 COPY --from=builder /app/services/bot-client/dist ./services/bot-client/dist
 
 CMD ["node", "services/bot-client/dist/index.js"]


### PR DESCRIPTION
## Incident

bot-client **crash-looped in dev** (Railway deployment `3a2a9404`, 2026-06-03 16:09 EDT):

```
Error: Cannot find package '/app/services/bot-client/node_modules/@tzurot/clients/dist/index.js'
  imported from /app/services/bot-client/dist/utils/gatewayClients.js
ERR_MODULE_NOT_FOUND
```

## Root cause

bot-client's `Dockerfile` runner stage copies each workspace package's built `dist` **manually**, one COPY per runtime dependency. It copied `common-types/dist` + `bot-client/dist` but **never `packages/clients/dist`**. When `@tzurot/clients` was extracted (PR-2m) and bot-client started importing it at runtime (`gatewayClients.ts`, a value import), the COPY list was never updated. The builder *does* build clients (`turbo run build --filter=@tzurot/bot-client...`), but it never reached the runtime image.

It surfaced **now** because #1144's lockfile change busted the Docker layer cache → clean rebuild → latent gap became a crash loop. The dep bumps themselves were not the cause.

The header comment actively misled here: *"turbo prune automatically includes them — no manual Dockerfile updates needed."* True for source; **false** for the runtime dist copies.

## Fix

- Add `COPY --from=builder /app/packages/clients/dist ./packages/clients/dist`.
- Rewrite the header comment to state the dist copies are manual and must be updated per runtime dep.

## Audit (grep rule)

api-gateway + ai-worker Dockerfiles checked — both copy exactly their runtime workspace deps (`common-types` + `embeddings`). Only bot-client had the mismatch (`@tzurot/clients` is api-gateway's *dev*-only dep, so not affected).

## Validation

⚠️ **Standard CI does not build the Docker image** — it runs TS build/lint/test, which are unaffected. This fix is validated by the **dev redeploy after merge** (bot-client should start cleanly). Recommend watching the dev deployment post-merge.

Structural follow-up (prevent recurrence of this class) filed to backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)