### PR TITLE
feat(tooling): add guard:dockerfile-dist for runner-stage dist copies

### DIFF
--- a/.claude/rules/05-tooling.md
+++ b/.claude/rules/05-tooling.md
@@ -115,13 +115,14 @@ pnpm ops cpd:update-baseline --dry-run  # Preview without writing
 ```bash
 pnpm ops guard:boundaries            # Service-boundary imports (bot-client/Prisma, etc.)
 pnpm ops guard:duplicate-exports     # Same name exported from multiple files
+pnpm ops guard:dockerfile-dist       # Dockerfile runner stages copy every runtime workspace dep's dist
 pnpm ops guard:proposal-links        # docs/proposals/backlog/*.md must have inbound link
 pnpm ops guard:audit-tool-docs       # Every registered audit tool has a non-stub WHY.md
 ```
 
-All four run in the CI `lint` job and hard-fail on findings (including `guard:boundaries` — its `--summary` mode is still pending per `backlog/quick-wins.md`, but hard-fail is independent of `--summary`). `guard:proposal-links` and `guard:audit-tool-docs` also support `--summary` for the future aggregator. `guard:audit-tool-docs` self-registers and runs the bidirectional check (every registered tool has a WHY.md AND every `*.WHY.md` is either registered or on `UNREGISTERED_WHY_PATHS`).
+All five run in the CI `lint` job and hard-fail on findings (including `guard:boundaries` — its `--summary` mode is still pending per `backlog/quick-wins.md`, but hard-fail is independent of `--summary`). `guard:proposal-links` and `guard:audit-tool-docs` also support `--summary` for the future aggregator. `guard:audit-tool-docs` self-registers and runs the bidirectional check (every registered tool has a WHY.md AND every `*.WHY.md` is either registered or on `UNREGISTERED_WHY_PATHS`).
 
-**Note on `guard:duplicate-exports`**: it's a CI gate but intentionally NOT registered as an audit-class tool (no WHY.md, no canary, no `--summary` mode). The criteria for "audit-class" require a measurement with a threshold — duplicate-exports is a binary "does this exist?" check, not a measurement. Same framing as `memory:analyze` (one-shot remediation, not periodic audit). See [`docs/reference/audit-enforcement.md`](../../docs/reference/audit-enforcement.md) for the registry criteria.
+**Note on `guard:duplicate-exports` and `guard:dockerfile-dist`**: both are CI gates but intentionally NOT registered as audit-class tools (no WHY.md, no canary, no `--summary` mode). The criteria for "audit-class" require a measurement with a threshold — duplicate-exports and dockerfile-dist are binary "is this in sync?" checks, not measurements. Same framing as `memory:analyze` (one-shot remediation, not periodic audit). See [`docs/reference/audit-enforcement.md`](../../docs/reference/audit-enforcement.md) for the registry criteria.
 
 ### Audit-tool infrastructure (Layers 1-3)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,9 @@ jobs:
       - name: Check for duplicate export names
         run: pnpm ops guard:duplicate-exports
 
+      - name: Check Dockerfile runner-stage dist copies
+        run: pnpm ops guard:dockerfile-dist
+
       - name: Check for orphan proposal docs
         run: pnpm ops guard:proposal-links
 

--- a/packages/tooling/src/audits/check-claude-content-refs.test.ts
+++ b/packages/tooling/src/audits/check-claude-content-refs.test.ts
@@ -339,6 +339,7 @@ describe('findContentRefs (against real repo)', () => {
       'guard:audit-tool-docs',
       'guard:boundaries',
       'guard:claude-content-refs',
+      'guard:dockerfile-dist',
       'guard:duplicate-exports',
       'guard:proposal-links',
       'inspect:dlq',

--- a/packages/tooling/src/commands/guard.ts
+++ b/packages/tooling/src/commands/guard.ts
@@ -39,6 +39,19 @@ export function registerGuardCommands(cli: CAC): void {
 
   cli
     .command(
+      'guard:dockerfile-dist',
+      'Check service Dockerfile runner stages copy every runtime workspace dep dist'
+    )
+    .option('--verbose', 'Show per-service results including skips')
+    .example('ops guard:dockerfile-dist')
+    .example('ops guard:dockerfile-dist --verbose')
+    .action(async (options: { verbose?: boolean }) => {
+      const { checkDockerfileDist } = await import('../dev/check-dockerfile-dist.js');
+      await checkDockerfileDist(options);
+    });
+
+  cli
+    .command(
       'guard:proposal-links',
       'Check that every docs/proposals/backlog/*.md has at least one inbound link'
     )

--- a/packages/tooling/src/dev/check-dockerfile-dist.test.ts
+++ b/packages/tooling/src/dev/check-dockerfile-dist.test.ts
@@ -1,0 +1,386 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  readdirSync: vi.fn(),
+}));
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import {
+  loadWorkspacePackages,
+  collectTransitiveDeps,
+  extractRunnerDistCopies,
+  checkService,
+  type WorkspacePackage,
+} from './check-dockerfile-dist.js';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+/** Build a packages map from a terse spec: { name: [dir, deps] } */
+function packagesMap(spec: Record<string, [string, string[]]>): Map<string, WorkspacePackage> {
+  return new Map(
+    Object.entries(spec).map(([name, [dir, workspaceDeps]]) => [name, { dir, workspaceDeps }])
+  );
+}
+
+const BASE_PACKAGES = packagesMap({
+  '@tzurot/common-types': ['packages/common-types', []],
+  '@tzurot/clients': ['packages/clients', ['@tzurot/common-types']],
+  '@tzurot/embeddings': ['packages/embeddings', ['@tzurot/common-types']],
+  '@tzurot/bot-client': ['services/bot-client', ['@tzurot/clients', '@tzurot/common-types']],
+  '@tzurot/api-gateway': ['services/api-gateway', ['@tzurot/common-types', '@tzurot/embeddings']],
+});
+
+describe('extractRunnerDistCopies', () => {
+  it('extracts dist copies from the final stage only', () => {
+    const dockerfile = [
+      'FROM node:25-slim AS builder',
+      'COPY --from=pruner /app/packages/common-types/dist ./packages/common-types/dist',
+      'FROM node:25-slim AS runner',
+      'COPY --from=builder /app/packages/common-types/dist ./packages/common-types/dist',
+      'COPY --from=builder /app/packages/clients/dist ./packages/clients/dist',
+      'COPY --from=builder /app/services/bot-client/dist ./services/bot-client/dist',
+      'CMD ["node", "services/bot-client/dist/index.js"]',
+    ].join('\n');
+
+    expect(extractRunnerDistCopies(dockerfile)).toEqual([
+      'packages/common-types',
+      'packages/clients',
+      'services/bot-client',
+    ]);
+  });
+
+  it('ignores non-dist copies in the runner stage', () => {
+    const dockerfile = [
+      'FROM node:25-slim AS runner',
+      'COPY --from=pruner /app/out/json/ .',
+      'COPY --from=builder /app/node_modules/.pnpm ./node_modules/.pnpm',
+      'COPY prisma ./prisma',
+      'COPY --from=builder /app/packages/common-types/dist ./packages/common-types/dist',
+    ].join('\n');
+
+    expect(extractRunnerDistCopies(dockerfile)).toEqual(['packages/common-types']);
+  });
+
+  it('treats a single-stage Dockerfile as all-runner', () => {
+    const dockerfile = [
+      'FROM node:25-slim',
+      'COPY --from=builder /app/packages/embeddings/dist ./packages/embeddings/dist',
+    ].join('\n');
+
+    expect(extractRunnerDistCopies(dockerfile)).toEqual(['packages/embeddings']);
+  });
+
+  it('matches dist copies with subpaths after /dist', () => {
+    const dockerfile = [
+      'FROM node:25-slim AS runner',
+      'COPY --from=builder /app/packages/common-types/dist/index.js ./packages/common-types/dist/index.js',
+    ].join('\n');
+
+    expect(extractRunnerDistCopies(dockerfile)).toEqual(['packages/common-types']);
+  });
+});
+
+describe('collectTransitiveDeps', () => {
+  it('returns direct deps', () => {
+    expect(collectTransitiveDeps('@tzurot/embeddings', BASE_PACKAGES)).toEqual(
+      new Set(['@tzurot/common-types'])
+    );
+  });
+
+  it('follows transitive edges', () => {
+    const packages = packagesMap({
+      '@tzurot/common-types': ['packages/common-types', []],
+      '@tzurot/clients': ['packages/clients', ['@tzurot/common-types']],
+      // service deps ONLY on clients — common-types must still be reached
+      '@tzurot/bot-client': ['services/bot-client', ['@tzurot/clients']],
+    });
+
+    expect(collectTransitiveDeps('@tzurot/bot-client', packages)).toEqual(
+      new Set(['@tzurot/clients', '@tzurot/common-types'])
+    );
+  });
+
+  it('does not include the starting package itself', () => {
+    expect(
+      collectTransitiveDeps('@tzurot/bot-client', BASE_PACKAGES).has('@tzurot/bot-client')
+    ).toBe(false);
+  });
+
+  it('handles dependency cycles without hanging', () => {
+    const packages = packagesMap({
+      a: ['packages/a', ['b']],
+      b: ['packages/b', ['a']],
+    });
+
+    expect(collectTransitiveDeps('a', packages)).toEqual(new Set(['b', 'a']));
+  });
+
+  it('returns empty set for unknown package', () => {
+    expect(collectTransitiveDeps('@tzurot/nope', BASE_PACKAGES)).toEqual(new Set());
+  });
+});
+
+describe('checkService', () => {
+  const IN_SYNC_DOCKERFILE = [
+    'FROM node:25-slim AS builder',
+    'FROM node:25-slim AS runner',
+    'COPY --from=builder /app/packages/common-types/dist ./packages/common-types/dist',
+    'COPY --from=builder /app/packages/clients/dist ./packages/clients/dist',
+    'COPY --from=builder /app/services/bot-client/dist ./services/bot-client/dist',
+  ].join('\n');
+
+  it('returns no findings when copies match the dependency closure', () => {
+    expect(checkService('@tzurot/bot-client', IN_SYNC_DOCKERFILE, BASE_PACKAGES)).toEqual([]);
+  });
+
+  it('flags a missing dep COPY (the PR #1145 regression shape)', () => {
+    const missingClients = [
+      'FROM node:25-slim AS runner',
+      'COPY --from=builder /app/packages/common-types/dist ./packages/common-types/dist',
+      'COPY --from=builder /app/services/bot-client/dist ./services/bot-client/dist',
+    ].join('\n');
+
+    const findings = checkService('@tzurot/bot-client', missingClients, BASE_PACKAGES);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      service: '@tzurot/bot-client',
+      kind: 'missing-copy',
+      packageDir: 'packages/clients',
+    });
+  });
+
+  it('flags a missing COPY for a TRANSITIVE dep of a direct dep', () => {
+    const packages = packagesMap({
+      '@tzurot/common-types': ['packages/common-types', []],
+      '@tzurot/clients': ['packages/clients', ['@tzurot/common-types']],
+      '@tzurot/bot-client': ['services/bot-client', ['@tzurot/clients']],
+    });
+    const dockerfile = [
+      'FROM node:25-slim AS runner',
+      'COPY --from=builder /app/packages/clients/dist ./packages/clients/dist',
+      'COPY --from=builder /app/services/bot-client/dist ./services/bot-client/dist',
+    ].join('\n');
+
+    const findings = checkService('@tzurot/bot-client', dockerfile, packages);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      kind: 'missing-copy',
+      packageDir: 'packages/common-types',
+    });
+  });
+
+  it("does not flag a transitive-only dep's COPY as stale", () => {
+    const packages = packagesMap({
+      '@tzurot/common-types': ['packages/common-types', []],
+      '@tzurot/clients': ['packages/clients', ['@tzurot/common-types']],
+      '@tzurot/bot-client': ['services/bot-client', ['@tzurot/clients']],
+    });
+    const dockerfile = [
+      'FROM node:25-slim AS runner',
+      'COPY --from=builder /app/packages/clients/dist ./packages/clients/dist',
+      'COPY --from=builder /app/packages/common-types/dist ./packages/common-types/dist',
+      'COPY --from=builder /app/services/bot-client/dist ./services/bot-client/dist',
+    ].join('\n');
+
+    expect(checkService('@tzurot/bot-client', dockerfile, packages)).toEqual([]);
+  });
+
+  it('flags a stale COPY for a removed dependency', () => {
+    const staleEmbeddings = [
+      'FROM node:25-slim AS runner',
+      'COPY --from=builder /app/packages/common-types/dist ./packages/common-types/dist',
+      'COPY --from=builder /app/packages/clients/dist ./packages/clients/dist',
+      'COPY --from=builder /app/packages/embeddings/dist ./packages/embeddings/dist',
+      'COPY --from=builder /app/services/bot-client/dist ./services/bot-client/dist',
+    ].join('\n');
+
+    const findings = checkService('@tzurot/bot-client', staleEmbeddings, BASE_PACKAGES);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      kind: 'stale-copy',
+      packageDir: 'packages/embeddings',
+    });
+  });
+
+  it("flags a missing COPY of the service's own dist", () => {
+    const noOwnDist = [
+      'FROM node:25-slim AS runner',
+      'COPY --from=builder /app/packages/common-types/dist ./packages/common-types/dist',
+      'COPY --from=builder /app/packages/clients/dist ./packages/clients/dist',
+    ].join('\n');
+
+    const findings = checkService('@tzurot/bot-client', noOwnDist, BASE_PACKAGES);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      kind: 'missing-copy',
+      packageDir: 'services/bot-client',
+    });
+  });
+
+  it('returns no findings for a service not in the workspace map', () => {
+    expect(checkService('@tzurot/unknown', IN_SYNC_DOCKERFILE, BASE_PACKAGES)).toEqual([]);
+  });
+});
+
+describe('loadWorkspacePackages', () => {
+  it('builds the name → dir/deps map from packages/ and services/', () => {
+    vi.mocked(readdirSync).mockImplementation(dir => {
+      if (String(dir).endsWith('packages')) {
+        return ['common-types'] as never;
+      }
+      return ['bot-client'] as never;
+    });
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockImplementation(path => {
+      if (String(path).includes('common-types')) {
+        return JSON.stringify({ name: '@tzurot/common-types', dependencies: { zod: '^4' } });
+      }
+      return JSON.stringify({
+        name: '@tzurot/bot-client',
+        dependencies: { '@tzurot/common-types': 'workspace:*', 'discord.js': '^14' },
+      });
+    });
+
+    const packages = loadWorkspacePackages('/repo');
+
+    expect(packages.get('@tzurot/common-types')).toEqual({
+      dir: 'packages/common-types',
+      workspaceDeps: [],
+    });
+    expect(packages.get('@tzurot/bot-client')).toEqual({
+      dir: 'services/bot-client',
+      workspaceDeps: ['@tzurot/common-types'],
+    });
+  });
+
+  it('skips dirs without package.json (e.g. voice-engine)', () => {
+    vi.mocked(readdirSync).mockImplementation(dir =>
+      String(dir).endsWith('services') ? (['voice-engine'] as never) : ([] as never)
+    );
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    expect(loadWorkspacePackages('/repo').size).toBe(0);
+    expect(readFileSync).not.toHaveBeenCalled();
+  });
+
+  it('tolerates a missing workspace group dir', () => {
+    vi.mocked(readdirSync).mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+
+    expect(loadWorkspacePackages('/repo').size).toBe(0);
+  });
+
+  it('reports the offending path when a package.json is malformed', () => {
+    vi.mocked(readdirSync).mockImplementation(dir =>
+      String(dir).endsWith('packages') ? (['broken'] as never) : ([] as never)
+    );
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('{ not json');
+
+    expect(() => loadWorkspacePackages('/repo')).toThrow(/Failed to parse .*broken.*package\.json/);
+  });
+});
+
+describe('checkDockerfileDist (orchestration)', () => {
+  const PKG_JSON: Record<string, object> = {
+    'packages/common-types/package.json': { name: '@tzurot/common-types', dependencies: {} },
+    'services/bot-client/package.json': {
+      name: '@tzurot/bot-client',
+      dependencies: { '@tzurot/common-types': 'workspace:*' },
+    },
+  };
+
+  const IN_SYNC_DOCKERFILE = [
+    'FROM node:25-slim AS runner',
+    'COPY --from=builder /app/packages/common-types/dist ./packages/common-types/dist',
+    'COPY --from=builder /app/services/bot-client/dist ./services/bot-client/dist',
+  ].join('\n');
+
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let savedExitCode: typeof process.exitCode;
+
+  /** Wire the fs mocks to present the fake workspace above */
+  function mockWorkspace(options: { dockerfile?: string | null } = {}) {
+    const dockerfile = options.dockerfile === undefined ? IN_SYNC_DOCKERFILE : options.dockerfile;
+
+    vi.mocked(readdirSync).mockImplementation(dir => {
+      if (String(dir).endsWith('packages')) {
+        return ['common-types'] as never;
+      }
+      return ['bot-client'] as never;
+    });
+    vi.mocked(existsSync).mockImplementation(path => {
+      const p = String(path);
+      if (p.endsWith('package.json')) {
+        return Object.keys(PKG_JSON).some(key => p.endsWith(key));
+      }
+      // Dockerfile existence
+      return dockerfile !== null;
+    });
+    vi.mocked(readFileSync).mockImplementation(path => {
+      const p = String(path);
+      const pkgKey = Object.keys(PKG_JSON).find(key => p.endsWith(key));
+      if (pkgKey !== undefined) {
+        return JSON.stringify(PKG_JSON[pkgKey]);
+      }
+      return dockerfile ?? '';
+    });
+  }
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    savedExitCode = process.exitCode;
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    process.exitCode = savedExitCode;
+  });
+
+  it('passes (no exit code) when runner copies match the dependency closure', async () => {
+    mockWorkspace();
+
+    const { checkDockerfileDist } = await import('./check-dockerfile-dist.js');
+    await checkDockerfileDist();
+
+    expect(process.exitCode).toBeUndefined();
+    const output = logSpy.mock.calls.flat().join('\n');
+    expect(output).toContain('Checked 1 service Dockerfile(s)');
+    expect(output).toContain('All runner-stage dist copies match');
+  });
+
+  it('sets exit code 1 and reports MISSING when a dep COPY is absent', async () => {
+    mockWorkspace({
+      dockerfile: [
+        'FROM node:25-slim AS runner',
+        'COPY --from=builder /app/services/bot-client/dist ./services/bot-client/dist',
+      ].join('\n'),
+    });
+
+    const { checkDockerfileDist } = await import('./check-dockerfile-dist.js');
+    await checkDockerfileDist();
+
+    expect(process.exitCode).toBe(1);
+    const output = logSpy.mock.calls.flat().join('\n');
+    expect(output).toContain('packages/common-types/dist');
+    expect(output).toContain('1 dist-copy issue');
+  });
+
+  it('skips services without a Dockerfile and logs the skip in verbose mode', async () => {
+    mockWorkspace({ dockerfile: null });
+
+    const { checkDockerfileDist } = await import('./check-dockerfile-dist.js');
+    await checkDockerfileDist({ verbose: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const output = logSpy.mock.calls.flat().join('\n');
+    expect(output).toContain('Checked 0 service Dockerfile(s)');
+    expect(output).toContain('no Dockerfile, skipped');
+  });
+});

--- a/packages/tooling/src/dev/check-dockerfile-dist.ts
+++ b/packages/tooling/src/dev/check-dockerfile-dist.ts
@@ -1,0 +1,312 @@
+/**
+ * Dockerfile dist-COPY Guard
+ *
+ * Each service Dockerfile's final (runner) stage copies workspace-package
+ * `dist` dirs MANUALLY — one COPY line per runtime `@tzurot/*` dependency.
+ * `turbo prune` handles sources and node_modules automatically, but the
+ * runner-stage dist copies are hand-maintained: a package extraction that
+ * adds a new runtime dep without its COPY line ships an image that crashes
+ * at startup with ERR_MODULE_NOT_FOUND, and standard CI never builds the
+ * Docker image, so nothing catches it before deploy.
+ *
+ * This guard statically cross-checks each service Dockerfile's runner-stage
+ * COPY set against the TRANSITIVE workspace prod-dependency closure from
+ * package.json (transitive because e.g. @tzurot/clients itself imports
+ * @tzurot/common-types at runtime — direct-deps-only would both miss needed
+ * copies and false-flag legitimate ones as stale). No Docker build needed.
+ */
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import chalk from 'chalk';
+
+interface CheckOptions {
+  verbose?: boolean;
+}
+
+/** @internal Exported for testing */
+export interface WorkspacePackage {
+  /** Repo-relative dir, e.g. 'packages/common-types' */
+  dir: string;
+  /** Prod `@tzurot/*` dependency names */
+  workspaceDeps: string[];
+}
+
+/** @internal Exported for testing */
+export interface DistCopyFinding {
+  service: string;
+  kind: 'missing-copy' | 'stale-copy';
+  /** Repo-relative package dir the finding is about */
+  packageDir: string;
+  detail: string;
+}
+
+const SEPARATOR = chalk.cyan.bold('═══════════════════════════════════════════════════════');
+
+/** Workspace groups that can host `@tzurot/*` packages */
+const WORKSPACE_GROUPS = ['packages', 'services'];
+
+/**
+ * Matches a runner-stage dist COPY, capturing the repo-relative package dir:
+ *   COPY --from=builder /app/packages/common-types/dist ./packages/common-types/dist
+ *
+ * Assumes single-line, multi-stage COPY instructions: backslash-continuation
+ * COPYs and stage-less `COPY <src> <dest>` forms (no `--from=`) are not
+ * matched. Both are outside the project's Dockerfile style — every service
+ * uses turbo-prune multi-stage builds with short single-line copies.
+ */
+const DIST_COPY_PATTERN =
+  /^\s*COPY\s+--from=\S+\s+\/app\/((?:packages|services)\/[^/\s]+)\/dist(?:[/\s]|$)/;
+
+/** Matches any Dockerfile stage start, e.g. `FROM node:25-slim AS runner` */
+const STAGE_START_PATTERN = /^\s*FROM\s/i;
+
+/**
+ * Parse a package.json, failing loudly WITH path context — a bare
+ * SyntaxError doesn't say which package.json is malformed.
+ */
+function readPackageJson(pkgJsonPath: string): {
+  name?: string;
+  dependencies?: Record<string, string>;
+} {
+  try {
+    return JSON.parse(readFileSync(pkgJsonPath, 'utf-8')) as {
+      name?: string;
+      dependencies?: Record<string, string>;
+    };
+  } catch (error) {
+    throw new Error(
+      `Failed to parse ${pkgJsonPath}: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error }
+    );
+  }
+}
+
+/**
+ * Scan packages/* and services/* for package.json files and build a map of
+ * package name → { dir, workspaceDeps }.
+ *
+ * Reads `dependencies` only — the project convention declares workspace deps
+ * as `workspace:*` prod dependencies. A `@tzurot/*` package declared via
+ * peerDependencies would not be seen by this guard.
+ *
+ * @internal Exported for testing
+ */
+export function loadWorkspacePackages(rootDir: string): Map<string, WorkspacePackage> {
+  const result = new Map<string, WorkspacePackage>();
+
+  for (const group of WORKSPACE_GROUPS) {
+    const groupDir = join(rootDir, group);
+    let entries: string[];
+    try {
+      entries = readdirSync(groupDir);
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      // Entries aren't filtered to directories on purpose: a stray file in
+      // packages/ or services/ yields a non-existent package.json path and
+      // falls through this existsSync guard — silent skip is the intent.
+      const pkgJsonPath = join(groupDir, entry, 'package.json');
+      if (!existsSync(pkgJsonPath)) {
+        continue;
+      }
+
+      const parsed = readPackageJson(pkgJsonPath);
+      if (parsed.name === undefined) {
+        continue;
+      }
+
+      // NOTE: only reads `dependencies` — a workspace peerDependency would
+      // not be checked (see function JSDoc).
+      const workspaceDeps = Object.keys(parsed.dependencies ?? {}).filter(dep =>
+        dep.startsWith('@tzurot/')
+      );
+      result.set(parsed.name, { dir: `${group}/${entry}`, workspaceDeps });
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Compute the transitive closure of workspace prod dependencies for a package.
+ * The starting package itself is not included in the acyclic case; a dependency
+ * cycle that reaches back to the start node will include it, which is harmless —
+ * checkService always adds the service's own dir to the expected set anyway.
+ *
+ * @internal Exported for testing
+ */
+export function collectTransitiveDeps(
+  name: string,
+  packages: Map<string, WorkspacePackage>
+): Set<string> {
+  const visited = new Set<string>();
+  const queue = [...(packages.get(name)?.workspaceDeps ?? [])];
+
+  while (queue.length > 0) {
+    const dep = queue.shift();
+    if (dep === undefined || visited.has(dep)) {
+      continue;
+    }
+    visited.add(dep);
+    queue.push(...(packages.get(dep)?.workspaceDeps ?? []));
+  }
+
+  return visited;
+}
+
+/**
+ * Extract the repo-relative package dirs whose `dist` is copied in the
+ * Dockerfile's FINAL stage (the runner). Earlier stages (pruner, installer,
+ * builder) are ignored — only the runner's copies reach the runtime image.
+ *
+ * @internal Exported for testing
+ */
+export function extractRunnerDistCopies(dockerfileContent: string): string[] {
+  const lines = dockerfileContent.split('\n');
+  const lastStageStart = lines.reduce(
+    (last, line, i) => (STAGE_START_PATTERN.test(line) ? i : last),
+    -1
+  );
+
+  const copies: string[] = [];
+  for (const line of lines.slice(lastStageStart + 1)) {
+    const match = DIST_COPY_PATTERN.exec(line);
+    if (match !== null) {
+      copies.push(match[1]);
+    }
+  }
+  return copies;
+}
+
+/**
+ * Cross-check one service's Dockerfile runner-stage copies against its
+ * transitive workspace dependency closure.
+ *
+ * @internal Exported for testing
+ */
+export function checkService(
+  serviceName: string,
+  dockerfileContent: string,
+  packages: Map<string, WorkspacePackage>
+): DistCopyFinding[] {
+  const pkg = packages.get(serviceName);
+  if (pkg === undefined) {
+    return [];
+  }
+
+  // Runtime image needs: every transitive workspace dep's dist + the service's own dist
+  const expectedDirs = new Set<string>([pkg.dir]);
+  for (const dep of collectTransitiveDeps(serviceName, packages)) {
+    const depPkg = packages.get(dep);
+    if (depPkg !== undefined) {
+      expectedDirs.add(depPkg.dir);
+    }
+  }
+
+  const copiedDirs = new Set(extractRunnerDistCopies(dockerfileContent));
+  const findings: DistCopyFinding[] = [];
+
+  for (const dir of expectedDirs) {
+    if (!copiedDirs.has(dir)) {
+      findings.push({
+        service: serviceName,
+        kind: 'missing-copy',
+        packageDir: dir,
+        detail: `runner stage is missing \`COPY --from=builder /app/${dir}/dist ./${dir}/dist\` — runtime image will crash with ERR_MODULE_NOT_FOUND`,
+      });
+    }
+  }
+
+  for (const dir of copiedDirs) {
+    if (!expectedDirs.has(dir)) {
+      findings.push({
+        service: serviceName,
+        kind: 'stale-copy',
+        packageDir: dir,
+        detail: `runner stage copies ${dir}/dist but it is not in the service's transitive workspace prod-dependency closure — remove the COPY (or add the missing dependency)`,
+      });
+    }
+  }
+
+  return findings;
+}
+
+/**
+ * Scan every service that has a Dockerfile and collect findings.
+ */
+function scanServices(
+  packages: Map<string, WorkspacePackage>,
+  rootDir: string,
+  verbose: boolean
+): { findings: DistCopyFinding[]; servicesChecked: number } {
+  const findings: DistCopyFinding[] = [];
+  let servicesChecked = 0;
+
+  for (const [name, pkg] of packages) {
+    if (!pkg.dir.startsWith('services/')) {
+      continue;
+    }
+
+    const dockerfilePath = join(rootDir, pkg.dir, 'Dockerfile');
+    if (!existsSync(dockerfilePath)) {
+      if (verbose) {
+        console.log(chalk.dim(`  ${name}: no Dockerfile, skipped`));
+      }
+      continue;
+    }
+
+    servicesChecked++;
+    const serviceFindings = checkService(name, readFileSync(dockerfilePath, 'utf-8'), packages);
+    findings.push(...serviceFindings);
+
+    if (verbose && serviceFindings.length === 0) {
+      console.log(chalk.green(`  ✅ ${name}: runner-stage dist copies in sync`));
+    }
+  }
+
+  return { findings, servicesChecked };
+}
+
+function displayFindings(findings: DistCopyFinding[]): void {
+  for (const finding of findings) {
+    const badge =
+      finding.kind === 'missing-copy' ? chalk.red.bold('MISSING') : chalk.yellow.bold('STALE');
+    console.log(`  ${badge} ${chalk.white(finding.service)}: ${finding.detail}`);
+  }
+  console.log('');
+}
+
+/**
+ * Check every service Dockerfile's runner-stage dist copies.
+ */
+export async function checkDockerfileDist(options: CheckOptions = {}): Promise<void> {
+  const { verbose = false } = options;
+  const rootDir = process.cwd();
+
+  console.log(SEPARATOR);
+  console.log(chalk.cyan.bold('           DOCKERFILE DIST-COPY GUARD                   '));
+  console.log(SEPARATOR);
+  console.log('');
+
+  const packages = loadWorkspacePackages(rootDir);
+  const { findings, servicesChecked } = scanServices(packages, rootDir, verbose);
+
+  if (findings.length > 0) {
+    displayFindings(findings);
+  }
+
+  console.log(chalk.dim(`Checked ${servicesChecked} service Dockerfile(s)\n`));
+
+  if (findings.length === 0) {
+    console.log(chalk.green.bold('✅ All runner-stage dist copies match workspace dependencies!'));
+  } else {
+    console.log(chalk.red.bold(`Found ${findings.length} dist-copy issue(s).`));
+    process.exitCode = 1;
+  }
+
+  console.log('');
+  console.log(SEPARATOR);
+}


### PR DESCRIPTION
## Summary

New `pnpm ops guard:dockerfile-dist` check, closing the gap that crash-looped bot-client in dev after the `@tzurot/clients` extraction (PR #1145): service Dockerfiles copy workspace-package `dist` dirs **manually** in the runner stage, standard CI never builds the image, so a missing COPY ships an image that dies at startup with `ERR_MODULE_NOT_FOUND`. This bug class recurs on every package extraction.

## How it works

- Static check, no Docker build: parses each `services/*/Dockerfile`'s **final stage** for `COPY --from=… /app/<pkg>/dist` lines and cross-checks against the workspace dependency graph from `package.json`.
- **Transitive closure**, not just direct deps — `@tzurot/clients` itself imports `@tzurot/common-types` at runtime, so direct-deps-only would both miss needed copies and false-flag legitimate ones as stale.
- Flags **missing** copies (runtime crash) and **stale** copies (removed deps still being shipped).
- Services without a `package.json` (voice-engine, Python) are skipped.
- Wired into the CI `lint` job alongside the other `guard:*` steps.
- Deliberately NOT registered as an audit-class tool (no WHY.md/canary/`--summary`) — binary "is this in sync?" check, same framing as `guard:duplicate-exports`.

## Verification

- `pnpm ops guard:dockerfile-dist --verbose` — all 3 service Dockerfiles in sync, voice-engine skipped
- **Liveness check**: temporarily deleting bot-client's `packages/clients/dist` COPY (the exact #1145 regression) → `MISSING` finding, exit code 1; restored cleanly
- 19 new unit tests covering stage parsing, transitive closure (incl. cycle safety), missing/stale/own-dist findings, and workspace map loading
- `pnpm --filter @tzurot/tooling test` — 75 files / 984+ tests green
- `pnpm quality` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)