### PR TITLE
test+refactor(bot-client): view.ts coverage gaps + typed preset unflatten pipeline

### DIFF
--- a/packages/common-types/src/schemas/api/shared.ts
+++ b/packages/common-types/src/schemas/api/shared.ts
@@ -78,10 +78,14 @@ export function emptyToNull<T extends z.ZodTypeAny>(schema: T): z.ZodType<z.infe
  * });
  * ```
  */
-export function optionalString(maxLength = 100): z.ZodType<string | undefined> {
+export function optionalString(maxLength = 100): z.ZodOptional<z.ZodType<string | undefined>> {
   // Use union: either undefined (from empty), or a valid string
-  // The preprocess converts empty → undefined, then union accepts either
-  return z.preprocess(
+  // The preprocess converts empty → undefined, then union accepts either.
+  // The outer .optional() doesn't change runtime behavior (undefined already
+  // passes the union) — it marks the KEY optional in z.infer'd object types,
+  // so update-payload types allow omitting fields instead of requiring
+  // explicit `name: undefined` entries.
+  const inner: z.ZodType<string | undefined> = z.preprocess(
     val => {
       if (typeof val === 'string') {
         const trimmed = val.trim();
@@ -99,6 +103,7 @@ export function optionalString(maxLength = 100): z.ZodType<string | undefined> {
     },
     z.union([z.undefined(), z.string().min(1).max(maxLength)])
   );
+  return inner.optional();
 }
 
 /**
@@ -118,9 +123,13 @@ export function optionalString(maxLength = 100): z.ZodType<string | undefined> {
  * });
  * ```
  */
-export function nullableString(maxLength = 500): z.ZodType<string | null | undefined> {
-  // Preprocess converts empty → null, then schema accepts string|null|undefined
-  return z.preprocess(
+export function nullableString(
+  maxLength = 500
+): z.ZodOptional<z.ZodType<string | null | undefined>> {
+  // Preprocess converts empty → null, then schema accepts string|null|undefined.
+  // The outer .optional() marks the KEY optional in z.infer'd object types —
+  // see optionalString above for the rationale; runtime behavior is unchanged.
+  const inner: z.ZodType<string | null | undefined> = z.preprocess(
     val => {
       if (typeof val === 'string') {
         const trimmed = val.trim();
@@ -139,6 +148,7 @@ export function nullableString(maxLength = 500): z.ZodType<string | null | undef
     },
     z.union([z.null(), z.undefined(), z.string().min(1).max(maxLength)])
   );
+  return inner.optional();
 }
 
 // ===========================================

--- a/services/bot-client/src/commands/character/import.ts
+++ b/services/bot-client/src/commands/character/import.ts
@@ -343,10 +343,7 @@ async function saveCharacter(
   isUpdate: boolean
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   const result = isUpdate
-    ? await userClient.updatePersonality(
-        slug,
-        payload as Parameters<UserClient['updatePersonality']>[1]
-      )
+    ? await userClient.updatePersonality(slug, payload)
     : await userClient.createPersonality(payload as Parameters<UserClient['createPersonality']>[0]);
 
   if (!result.ok) {

--- a/services/bot-client/src/commands/character/view.test.ts
+++ b/services/bot-client/src/commands/character/view.test.ts
@@ -3,10 +3,12 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { _testExports, handleView, handleViewPagination } from './view.js';
+import { MessageFlags } from 'discord.js';
+import { _testExports, handleView, handleViewPagination, handleExpandField } from './view.js';
 import type { CharacterData } from './characterTypes.js';
 import { DISCORD_LIMITS, TEXT_LIMITS } from '@tzurot/common-types';
 import { makeOk, makeErr, asUserClient } from '../../test/gatewayClientStubs.js';
+import { sendChunkedReply } from '../../utils/chunkedReply.js';
 
 // Configurable slug for the mocked characterViewOptions; reset per test.
 const slugMock = vi.hoisted(() => ({ value: 'test-character' }));
@@ -22,6 +24,7 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 });
 
 vi.mock('../../utils/gatewayClients.js', () => ({ clientsFor: clientsForMock }));
+vi.mock('../../utils/chunkedReply.js', () => ({ sendChunkedReply: vi.fn() }));
 
 const {
   buildCharacterViewPage,
@@ -538,5 +541,85 @@ describe('handleView / handleViewPagination', () => {
     expect(editReply).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('Character not found') })
     );
+  });
+
+  it('keeps the existing view (no editReply) when pagination re-fetch fails with a non-404', async () => {
+    // fetchCharacterForView throws on 500 → the catch logs and intentionally
+    // leaves the current page in place so the user can retry.
+    stub.getPersonality.mockResolvedValue(makeErr(500, 'boom'));
+
+    await handleViewPagination(paginationInteraction(), 'test-character', 1, config);
+
+    expect(deferUpdate).toHaveBeenCalled();
+    expect(editReply).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleExpandField', () => {
+  const editReply = vi.fn();
+  const deferReply = vi.fn();
+  const stub = { getPersonality: vi.fn() };
+  const config = {} as unknown as Parameters<typeof handleExpandField>[3];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clientsForMock.mockReturnValue({ userClient: asUserClient(stub) });
+  });
+
+  function expandInteraction() {
+    return { deferReply, editReply } as unknown as Parameters<typeof handleExpandField>[0];
+  }
+
+  it('defers ephemerally and sends the full field content via chunked reply', async () => {
+    const character = createTestCharacter({ characterInfo: 'Full unabridged background text' });
+    stub.getPersonality.mockResolvedValue(makeOk({ personality: character }));
+
+    await handleExpandField(expandInteraction(), 'test-character', 'characterInfo', config);
+
+    expect(deferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    expect(sendChunkedReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: 'Full unabridged background text',
+        header: expect.stringContaining(EXPANDABLE_FIELDS.characterInfo.label),
+      })
+    );
+    expect(editReply).not.toHaveBeenCalled();
+  });
+
+  it('shows "not found" when the character fetch 404s', async () => {
+    stub.getPersonality.mockResolvedValue(makeErr(404, 'gone'));
+
+    await handleExpandField(expandInteraction(), 'test-character', 'characterInfo', config);
+
+    expect(editReply).toHaveBeenCalledWith(expect.stringContaining('Character not found'));
+    expect(sendChunkedReply).not.toHaveBeenCalled();
+  });
+
+  it('shows "Unknown field" for a field name with no expandable definition', async () => {
+    stub.getPersonality.mockResolvedValue(makeOk({ personality: createTestCharacter() }));
+
+    await handleExpandField(expandInteraction(), 'test-character', 'noSuchField', config);
+
+    expect(editReply).toHaveBeenCalledWith(expect.stringContaining('Unknown field'));
+    expect(sendChunkedReply).not.toHaveBeenCalled();
+  });
+
+  it('shows "_Not set_" when the field exists but has no content', async () => {
+    const character = createTestCharacter({ personalityLikes: null });
+    stub.getPersonality.mockResolvedValue(makeOk({ personality: character }));
+
+    await handleExpandField(expandInteraction(), 'test-character', 'personalityLikes', config);
+
+    expect(editReply).toHaveBeenCalledWith(expect.stringContaining('_Not set_'));
+    expect(sendChunkedReply).not.toHaveBeenCalled();
+  });
+
+  it('shows a generic error when the fetch fails with a non-404 status', async () => {
+    stub.getPersonality.mockResolvedValue(makeErr(500, 'boom'));
+
+    await handleExpandField(expandInteraction(), 'test-character', 'characterInfo', config);
+
+    expect(editReply).toHaveBeenCalledWith(expect.stringContaining('Failed to load field content'));
+    expect(sendChunkedReply).not.toHaveBeenCalled();
   });
 });

--- a/services/bot-client/src/commands/persona/dashboard.ts
+++ b/services/bot-client/src/commands/persona/dashboard.ts
@@ -13,7 +13,7 @@ import {
   type ButtonInteraction,
   type ModalSubmitInteraction,
 } from 'discord.js';
-import { createLogger, type PersonaUpdateInput } from '@tzurot/common-types';
+import { createLogger } from '@tzurot/common-types';
 import { buildDeleteConfirmation } from '../../utils/dashboard/deleteConfirmation.js';
 import { handleDashboardClose } from '../../utils/dashboard/closeHandler.js';
 import { createRefreshHandler, refreshDashboardUI } from '../../utils/dashboard/refreshHandler.js';
@@ -122,10 +122,7 @@ async function handleSectionModalSubmit(
     const { userClient } = clientsFor(interaction);
     const updatedPersona = await updatePersona(
       entityId,
-      // Cast: unflattenPersonaData omits fields the user didn't touch
-      // (signals "preserve") while PersonaUpdateInput's shape allows
-      // undefined for each field — semantically equivalent on the wire.
-      updatePayload as PersonaUpdateInput,
+      updatePayload,
       userClient,
       interaction.user.id
     );

--- a/services/bot-client/src/commands/preset/api.ts
+++ b/services/bot-client/src/commands/preset/api.ts
@@ -6,7 +6,7 @@
  * operations go through `ownerClient`.
  */
 
-import { type LlmConfigDetail } from '@tzurot/common-types';
+import { type LlmConfigDetail, type LlmConfigUpdateInput } from '@tzurot/common-types';
 import { GatewayApiError, type OwnerClient, type UserClient } from '@tzurot/clients';
 import type { PresetData } from './types.js';
 
@@ -93,13 +93,10 @@ export async function fetchGlobalPreset(
  */
 export async function updatePreset(
   presetId: string,
-  data: Record<string, unknown>,
+  data: LlmConfigUpdateInput,
   userClient: UserClient
 ): Promise<PresetData> {
-  const result = await userClient.updateUserLlmConfig(
-    presetId,
-    data as Parameters<UserClient['updateUserLlmConfig']>[1]
-  );
+  const result = await userClient.updateUserLlmConfig(presetId, data);
 
   if (!result.ok) {
     throw new Error(`Failed to update preset: ${result.status} - ${result.error ?? 'Unknown'}`);
@@ -115,13 +112,10 @@ export async function updatePreset(
  */
 export async function updateGlobalPreset(
   presetId: string,
-  data: Record<string, unknown>,
+  data: LlmConfigUpdateInput,
   ownerClient: OwnerClient
 ): Promise<PresetData> {
-  const result = await ownerClient.updateGlobalLlmConfig(
-    presetId,
-    data as Parameters<OwnerClient['updateGlobalLlmConfig']>[1]
-  );
+  const result = await ownerClient.updateGlobalLlmConfig(presetId, data);
 
   if (!result.ok) {
     throw new Error(

--- a/services/bot-client/src/commands/preset/config.ts
+++ b/services/bot-client/src/commands/preset/config.ts
@@ -5,9 +5,12 @@
  * Uses the Dashboard Framework pattern for consistent UX.
  */
 
+import type { LlmConfigUpdateInput, AdvancedParams } from '@tzurot/common-types';
 import type { DashboardConfig, FieldDefinition } from '../../utils/dashboard/types.js';
 import type { ActionButtonOptions } from '../../utils/dashboard/index.js';
 import type { PresetData, FlattenedPresetData } from './types.js';
+
+type ReasoningConfig = NonNullable<AdvancedParams['reasoning']>;
 
 // Re-export types for backward compatibility
 export type { PresetData, FlattenedPresetData } from './types.js';
@@ -55,31 +58,37 @@ export function flattenPresetData(data: PresetData): FlattenedPresetData {
   };
 }
 
-/** Add string field to result if non-empty */
-function addStringField(
-  result: Record<string, unknown>,
-  key: string,
-  value: string | undefined,
-  nullable = false
-): void {
-  if (value === undefined) {
-    return;
-  }
-  result[key] = value.length > 0 ? value : nullable ? null : undefined;
-  if (result[key] === undefined) {
-    delete result[key];
-  }
-}
+/** Form fields where empty string means "preserve existing value" (omit from payload) */
+const OMIT_WHEN_EMPTY_FIELDS = ['name', 'provider', 'model'] as const;
+
+/** Form fields where empty string means "clear the value" (send null) */
+const NULL_WHEN_EMPTY_FIELDS = ['description', 'visionModel'] as const;
+
+/** Numeric sampling/output params; FlattenedPresetData holds them as form strings */
+const NUMERIC_PARAMS = [
+  'temperature',
+  'top_p',
+  'top_k',
+  'max_tokens',
+  'seed',
+  'frequency_penalty',
+  'presence_penalty',
+  'repetition_penalty',
+  'min_p',
+  'top_a',
+] as const;
+
+type NumericParamKey = (typeof NUMERIC_PARAMS)[number];
 
 /** Parse numeric params from flat data */
-function parseNumericParams(
-  flat: Partial<FlattenedPresetData>,
-  params: readonly string[]
-): { values: Record<string, number>; hasAny: boolean } {
-  const values: Record<string, number> = {};
+function parseNumericParams(flat: Partial<FlattenedPresetData>): {
+  values: Partial<Record<NumericParamKey, number>>;
+  hasAny: boolean;
+} {
+  const values: Partial<Record<NumericParamKey, number>> = {};
   let hasAny = false;
-  for (const param of params) {
-    const value = flat[param as keyof FlattenedPresetData] as string | undefined;
+  for (const param of NUMERIC_PARAMS) {
+    const value = flat[param];
     if (value !== undefined && value.length > 0) {
       const num = parseFloat(value);
       if (!isNaN(num)) {
@@ -91,14 +100,23 @@ function parseNumericParams(
   return { values, hasAny };
 }
 
+const VALID_EFFORTS: readonly NonNullable<ReasoningConfig['effort']>[] = [
+  'xhigh',
+  'high',
+  'medium',
+  'low',
+  'minimal',
+  'none',
+];
+
 /** Parse reasoning params from flat data */
-function parseReasoningParams(flat: Partial<FlattenedPresetData>): Record<string, unknown> | null {
-  const reasoning: Record<string, unknown> = {};
-  const validEfforts = ['xhigh', 'high', 'medium', 'low', 'minimal', 'none'];
+function parseReasoningParams(flat: Partial<FlattenedPresetData>): ReasoningConfig | null {
+  const reasoning: ReasoningConfig = {};
 
   if (flat.reasoning_effort !== undefined && flat.reasoning_effort.length > 0) {
-    const effort = flat.reasoning_effort.toLowerCase();
-    if (validEfforts.includes(effort)) {
+    const effortInput = flat.reasoning_effort.toLowerCase();
+    const effort = VALID_EFFORTS.find(e => e === effortInput);
+    if (effort !== undefined) {
       reasoning.effort = effort;
     }
   }
@@ -127,26 +145,11 @@ function parseOptionalInt(value: string | undefined): number | undefined {
 }
 
 /** Build advancedParameters object from flattened data */
-function buildAdvancedParameters(
-  flat: Partial<FlattenedPresetData>
-): Record<string, unknown> | null {
-  const numericParams = [
-    'temperature',
-    'top_p',
-    'top_k',
-    'max_tokens',
-    'seed',
-    'frequency_penalty',
-    'presence_penalty',
-    'repetition_penalty',
-    'min_p',
-    'top_a',
-  ] as const;
-
-  const { values: samplingParams, hasAny: hasSampling } = parseNumericParams(flat, numericParams);
+function buildAdvancedParameters(flat: Partial<FlattenedPresetData>): AdvancedParams | null {
+  const { values: samplingParams, hasAny: hasSampling } = parseNumericParams(flat);
   const reasoning = parseReasoningParams(flat);
 
-  const advancedParameters: Record<string, unknown> = { ...samplingParams };
+  const advancedParameters: AdvancedParams = { ...samplingParams };
   if (reasoning !== null) {
     advancedParameters.reasoning = reasoning;
   }
@@ -160,15 +163,24 @@ function buildAdvancedParameters(
 }
 
 /** Convert flattened form data back to API update payload */
-export function unflattenPresetData(flat: Partial<FlattenedPresetData>): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
+export function unflattenPresetData(flat: Partial<FlattenedPresetData>): LlmConfigUpdateInput {
+  const result: LlmConfigUpdateInput = {};
 
-  // Basic fields
-  addStringField(result, 'name', flat.name);
-  addStringField(result, 'description', flat.description, true);
-  addStringField(result, 'provider', flat.provider);
-  addStringField(result, 'model', flat.model);
-  addStringField(result, 'visionModel', flat.visionModel, true);
+  // Basic fields — empty string preserves the existing value (field omitted)
+  for (const key of OMIT_WHEN_EMPTY_FIELDS) {
+    const value = flat[key];
+    if (value !== undefined && value.length > 0) {
+      result[key] = value;
+    }
+  }
+
+  // Nullable fields — empty string clears the value (send null)
+  for (const key of NULL_WHEN_EMPTY_FIELDS) {
+    const value = flat[key];
+    if (value !== undefined) {
+      result[key] = value.length > 0 ? value : null;
+    }
+  }
 
   // Context window (model-coupled, stays in LlmConfig)
   const contextWindowTokens = parseOptionalInt(flat.contextWindowTokens);


### PR DESCRIPTION
## Summary

The remaining two bot-client quick wins, plus one structural type fix they surfaced:

### 1. `view.ts` coverage gaps (test commit)

- `handleExpandField` — all 5 branches now covered: chunked-reply happy path, character not found, unknown field, empty content → `_Not set_`, fetch-failure catch
- `handleViewPagination` catch block — non-404 error → deliberately keeps the existing page (no `editReply`), now asserted

### 2. Typed preset modal-unflatten pipeline (refactor commit)

- `unflattenPresetData` returns `LlmConfigUpdateInput` instead of `Record<string, unknown>`; `parseNumericParams` keys off a const tuple of `AdvancedParams` keys; `parseReasoningParams` returns the schema's reasoning config with the effort enum validated without casts
- `updatePreset` / `updateGlobalPreset` params retyped to `LlmConfigUpdateInput`; both `Parameters<...>` casts removed

### 3. The wart underneath: `optionalString()` / `nullableString()` key-requiredness

Typing the pipeline surfaced why the casts existed at all: both helpers were annotated as plain `z.ZodType<...>`, which made every key **required** in `z.infer`'d update-payload types (`{ name: string | undefined }`, not `{ name?: string }`). Callers had to either write `name: undefined` explicitly or cast — which is exactly what the preset/persona/import call sites were doing.

Both helpers now wrap in `.optional()`. **Runtime parse behavior is identical** — `undefined` short-circuits to `undefined` in `ZodOptional` exactly as the inner unions already accepted it; empty-string transforms are unchanged. Only the inferred key optionality changes. Affected schemas (all update-payload semantics where optional keys are correct): `LlmConfigUpdateSchema`, `PersonalityUpdateSchema` + character-fields, `PersonaUpdateSchema`, `TtsConfigUpdateSchema`.

The cascade made two more casts redundant — `persona/dashboard.ts` (`as PersonaUpdateInput` + its justification comment) and `character/import.ts` (`as Parameters<UserClient['updatePersonality']>[1]`) — both removed via the `no-unnecessary-type-assertion` lint rule that started flagging them.

## Verification

- Common-types schema tests: 30 files / 881 tests green
- Clients + bot-client preset/persona/character suites: green (742 + 677)
- `pnpm quality` — 16/16 green (includes typecheck + typecheck:spec across packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)