### PR TITLE
feat(tooling): deferred-backlog tripwire — surface entries for staged files

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -126,6 +126,18 @@ $(echo "$FILE_VIOLATIONS" | sed 's/^/     /')
     fi
 fi
 
+# Surface deferred-backlog entries that reference staged files (informational).
+# Many backlog/deferred.md entries are gated on "opportunistic when next
+# touching <file>" — a trigger that only fires if the committer remembers the
+# entry exists. This makes the trigger structural: matches print as a reminder,
+# never block. `|| true` guards against tool failure breaking commits.
+# Scoped to commits touching services/, packages/, or prisma/ so doc-only
+# commits skip the tsx startup cost.
+STAGED_SRC_FOR_DEFERRED=$(git diff --cached --name-only | grep -E '^(services|packages|prisma)/' || true)
+if [ -n "$STAGED_SRC_FOR_DEFERRED" ]; then
+    pnpm ops dev:deferred-refs --staged || true
+fi
+
 # Check for dangerous Prisma migrations
 STAGED_MIGRATION_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^prisma/migrations/.*\.sql$' || true)
 

--- a/packages/tooling/src/commands/dev.ts
+++ b/packages/tooling/src/commands/dev.ts
@@ -86,6 +86,19 @@ export function registerDevCommands(cli: CAC): void {
       runFindDeadFiles();
     });
 
+  cli
+    .command(
+      'dev:deferred-refs [...files]',
+      'Surface deferred-backlog entries referencing the given (or staged) files — informational, never fails'
+    )
+    .option('--staged', 'Use the git staged file list')
+    .example('ops dev:deferred-refs --staged')
+    .example('ops dev:deferred-refs services/ai-worker/src/services/MemoryRetriever.ts')
+    .action(async (files: string[], options: { staged?: boolean }) => {
+      const { checkDeferredRefs } = await import('../dev/check-deferred-refs.js');
+      await checkDeferredRefs({ staged: options.staged, files });
+    });
+
   registerSchemaAuditCommand(cli);
   registerComplexityReportCommand(cli);
 }

--- a/packages/tooling/src/dev/check-deferred-refs.test.ts
+++ b/packages/tooling/src/dev/check-deferred-refs.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+}));
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+}));
+
+import { existsSync, readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import {
+  normalizePathToken,
+  extractDeferredRefs,
+  matchFiles,
+  checkDeferredRefs,
+} from './check-deferred-refs.js';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+const SAMPLE_MARKDOWN = [
+  '## ⏸️ Deferred',
+  '',
+  '_Decided not to do yet._',
+  '',
+  '| Item | Why |',
+  '| ---- | --- |',
+  '| `satisfies` constraint on `PgvectorMemoryDocument` | Works via widening at `services/ai-worker/src/services/MemoryRetriever.ts:~221` today. **Promote when**: metadata gains a required field. |',
+  '| Temporal-marker hook for `.py` files | **Start**: extend the filter; test against `services/voice-engine/*.py` for false positives. |',
+  '| Smart per-user cache invalidation | Upgrade `LlmConfigService` and the mirror together. No file path here. |',
+  '| Memory retrieval mystery | Trace `MemoryService.retrieveRelevant()` flow in `services/ai-worker/src/services/` and add structured logs. |',
+].join('\n');
+
+describe('normalizePathToken', () => {
+  it('strips line-number suffixes from file tokens', () => {
+    expect(normalizePathToken('services/api-gateway/src/routes/settings.ts:231-234')).toEqual({
+      pathToken: 'services/api-gateway/src/routes/settings.ts',
+      isPrefix: false,
+    });
+  });
+
+  it('strips tilde-prefixed line refs', () => {
+    expect(normalizePathToken('services/ai-worker/src/MemoryRetriever.ts:~221')).toEqual({
+      pathToken: 'services/ai-worker/src/MemoryRetriever.ts',
+      isPrefix: false,
+    });
+  });
+
+  it('treats globs as prefixes', () => {
+    expect(normalizePathToken('services/voice-engine/*.py')).toEqual({
+      pathToken: 'services/voice-engine/',
+      isPrefix: true,
+    });
+  });
+
+  it('treats extension-less tokens as directory prefixes', () => {
+    expect(normalizePathToken('services/ai-worker/src/services')).toEqual({
+      pathToken: 'services/ai-worker/src/services/',
+      isPrefix: true,
+    });
+  });
+
+  it('rejects tokens that are too shallow to be real paths', () => {
+    expect(normalizePathToken('services/ai-worker')).toBeNull();
+  });
+
+  it('strips trailing prose punctuation', () => {
+    expect(normalizePathToken('packages/tooling/src/dev/thing.ts.')).toEqual({
+      pathToken: 'packages/tooling/src/dev/thing.ts',
+      isPrefix: false,
+    });
+  });
+
+  it('accepts prisma/ paths (schema + migration entries reference them)', () => {
+    expect(normalizePathToken('prisma/schema.prisma:26-27')).toEqual({
+      pathToken: 'prisma/schema.prisma',
+      isPrefix: false,
+    });
+  });
+});
+
+describe('extractDeferredRefs', () => {
+  it('extracts file refs with entry titles and line numbers', () => {
+    const refs = extractDeferredRefs(SAMPLE_MARKDOWN);
+
+    const memoryRef = refs.find(
+      r => r.pathToken === 'services/ai-worker/src/services/MemoryRetriever.ts'
+    );
+    expect(memoryRef).toBeDefined();
+    expect(memoryRef?.title).toContain('satisfies');
+    expect(memoryRef?.line).toBe(7);
+    expect(memoryRef?.isPrefix).toBe(false);
+  });
+
+  it('extracts directory-prefix refs', () => {
+    const refs = extractDeferredRefs(SAMPLE_MARKDOWN);
+    const dirRef = refs.find(r => r.pathToken === 'services/ai-worker/src/services/');
+    expect(dirRef).toBeDefined();
+    expect(dirRef?.isPrefix).toBe(true);
+  });
+
+  it('skips entries with no path tokens', () => {
+    const refs = extractDeferredRefs(SAMPLE_MARKDOWN);
+    expect(refs.some(r => r.title.includes('Smart per-user'))).toBe(false);
+  });
+
+  it('skips the header and separator rows', () => {
+    const refs = extractDeferredRefs(SAMPLE_MARKDOWN);
+    expect(refs.some(r => r.title === 'Item' || r.title.startsWith('-'))).toBe(false);
+  });
+});
+
+describe('matchFiles', () => {
+  const refs = extractDeferredRefs(SAMPLE_MARKDOWN);
+
+  it('matches exact file refs', () => {
+    const matches = matchFiles(['services/ai-worker/src/services/MemoryRetriever.ts'], refs);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].refs.some(r => r.title.includes('satisfies'))).toBe(true);
+  });
+
+  it('matches files under a directory-prefix ref', () => {
+    const matches = matchFiles(['services/voice-engine/app/main.py'], refs);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].refs[0].title).toContain('Temporal-marker');
+  });
+
+  it('returns no matches for unrelated files', () => {
+    const matches = matchFiles(['services/bot-client/src/index.ts'], refs);
+    expect(matches).toEqual([]);
+  });
+
+  it('a file under the prefix AND exactly referenced collects both refs', () => {
+    const matches = matchFiles(['services/ai-worker/src/services/MemoryRetriever.ts'], refs);
+    // exact ref from row 7 + directory prefix ref from row 10
+    expect(matches[0].refs.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('checkDeferredRefs (CLI entry)', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  it('prints matches for staged files and never throws', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(SAMPLE_MARKDOWN);
+    vi.mocked(execFileSync).mockReturnValue(
+      'services/ai-worker/src/services/MemoryRetriever.ts\nREADME.md\n'
+    );
+
+    await expect(checkDeferredRefs({ staged: true })).resolves.toBeUndefined();
+
+    const output = logSpy.mock.calls.flat().join('\n');
+    expect(output).toContain('Deferred backlog entries reference files');
+    expect(output).toContain('MemoryRetriever.ts');
+    expect(output).toContain('backlog/deferred.md:7');
+  });
+
+  it('swallows git failures and logs to stderr (the never-blocks contract)', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(SAMPLE_MARKDOWN);
+    vi.mocked(execFileSync).mockImplementation(() => {
+      throw new Error('not a git repository');
+    });
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(checkDeferredRefs({ staged: true })).resolves.toBeUndefined();
+
+    expect(errSpy.mock.calls.flat().join('\n')).toContain('not a git repository');
+    expect(logSpy).not.toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it('prints nothing when no staged file matches', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(SAMPLE_MARKDOWN);
+    vi.mocked(execFileSync).mockReturnValue('README.md\n');
+
+    await checkDeferredRefs({ staged: true });
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when deferred.md does not exist', async () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    await checkDeferredRefs({ staged: true });
+
+    expect(readFileSync).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('no-ops with an empty or absent file list', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+
+    await checkDeferredRefs({});
+    await checkDeferredRefs({ files: [] });
+
+    expect(readFileSync).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('accepts an explicit file list without touching git', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(SAMPLE_MARKDOWN);
+
+    await checkDeferredRefs({ files: ['services/voice-engine/app/main.py'] });
+
+    expect(execFileSync).not.toHaveBeenCalled();
+    const output = logSpy.mock.calls.flat().join('\n');
+    expect(output).toContain('Temporal-marker');
+  });
+});

--- a/packages/tooling/src/dev/check-deferred-refs.ts
+++ b/packages/tooling/src/dev/check-deferred-refs.ts
@@ -1,0 +1,221 @@
+/**
+ * Deferred-Backlog Tripwire
+ *
+ * A large share of `backlog/deferred.md` entries are gated on "opportunistic
+ * when next touching <file>" — a trigger that only fires if whoever is editing
+ * the file REMEMBERS the entry exists. In practice that means it never fires:
+ * entries with concrete, cheap fix shapes sit for months while the referenced
+ * files get edited around them.
+ *
+ * This tool makes those triggers structural: given a set of files (typically
+ * the staged set at commit time), it greps deferred.md for entries whose text
+ * references any of them and prints the matches INFORMATIONALLY. It never
+ * fails — this is a reminder surface, not a gate, so a developer who decides
+ * "not this PR" loses nothing. Wired into .husky/pre-commit.
+ *
+ * Entries with no file path in their text (the genuinely event-gated ones)
+ * are invisible to this tool by design.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import chalk from 'chalk';
+
+const DEFERRED_PATH = 'backlog/deferred.md';
+
+/** Max characters of the entry title shown per match */
+const TITLE_PREVIEW_LENGTH = 90;
+
+/** @internal Exported for testing */
+export interface DeferredRef {
+  /** Normalized path token from the entry text, e.g. 'services/x/src/y.ts' or 'services/x/' */
+  pathToken: string;
+  /** True when the token is a directory/glob prefix rather than an exact file */
+  isPrefix: boolean;
+  /** First-cell entry title (truncated) */
+  title: string;
+  /** 1-based line number of the entry row in deferred.md */
+  line: number;
+}
+
+/** @internal Exported for testing */
+export interface DeferredMatch {
+  file: string;
+  refs: DeferredRef[];
+}
+
+/**
+ * Path-like tokens inside entry prose: `services/...`, `packages/...`, or
+ * `prisma/...` (schema + migration entries reference it), optionally wrapped
+ * in backticks, possibly carrying `:123`-style line refs or globs. Captured
+ * liberally, then normalized.
+ */
+const PATH_TOKEN_PATTERN = /(?:services|packages|prisma)\/[\w.\-/*]+/g;
+
+/**
+ * Normalize a raw path token from prose into a matchable form.
+ * Returns null for tokens too short to be meaningful (bare 'services/x').
+ */
+/** @internal Exported for testing */
+export function normalizePathToken(raw: string): { pathToken: string; isPrefix: boolean } | null {
+  // Strip trailing punctuation that prose attaches (periods, commas, colons
+  // with line numbers like `file.ts:231-234` keep only the path part).
+  // Char-by-char trim instead of a `+$` quantifier — appeases the
+  // regexp/no-super-linear-move ReDoS rule on prose-derived input.
+  let token = raw.replace(/:[\d~,-]*$/, '');
+  while (token.length > 0 && '.,;)'.includes(token[token.length - 1])) {
+    token = token.slice(0, -1);
+  }
+
+  let isPrefix = false;
+  const starIndex = token.indexOf('*');
+  if (starIndex !== -1) {
+    // Glob like services/voice-engine/*.py → prefix match on the static part
+    token = token.slice(0, starIndex);
+    isPrefix = true;
+  }
+  if (token.endsWith('/')) {
+    isPrefix = true;
+  }
+
+  const segments = token.split('/').filter(s => s.length > 0);
+  if (segments.length < 2) {
+    return null;
+  }
+
+  // Extension-bearing tokens are exact files — 2 segments is enough
+  // (`prisma/schema.prisma` is a real path at that depth).
+  const last = segments[segments.length - 1];
+  if (!isPrefix && last.includes('.')) {
+    return { pathToken: token, isPrefix: false };
+  }
+
+  // Everything else is directory-ish. Globs and trailing slashes already
+  // declared themselves prefixes; bare extension-less prose tokens need
+  // group/package/sub depth so a passing mention of 'services/ai-worker'
+  // doesn't become a match-everything prefix.
+  if (!isPrefix) {
+    if (segments.length < 3) {
+      return null;
+    }
+    isPrefix = true;
+    token = `${token}/`;
+  }
+
+  return { pathToken: token, isPrefix };
+}
+
+/**
+ * Parse deferred.md table rows into path-keyed references.
+ */
+/** @internal Exported for testing */
+export function extractDeferredRefs(markdown: string): DeferredRef[] {
+  const refs: DeferredRef[] = [];
+  const lines = markdown.split('\n');
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Table rows only; skip the header and the separator row. The separator
+    // test requires the full `| --- |` cell shape so a future entry whose
+    // title happens to start with a dash isn't misclassified.
+    if (!line.startsWith('|') || /^\|\s*[-:]+\s*\|/.test(line) || /^\|\s*Item\s*\|/i.test(line)) {
+      continue;
+    }
+
+    const title = line.split('|')[1]?.replace(/`/g, '').trim().slice(0, TITLE_PREVIEW_LENGTH);
+    if (title === undefined || title.length === 0) {
+      continue;
+    }
+
+    const seen = new Set<string>();
+    for (const raw of line.match(PATH_TOKEN_PATTERN) ?? []) {
+      const normalized = normalizePathToken(raw);
+      if (normalized === null || seen.has(normalized.pathToken)) {
+        continue;
+      }
+      seen.add(normalized.pathToken);
+      refs.push({ ...normalized, title, line: i + 1 });
+    }
+  }
+
+  return refs;
+}
+
+/**
+ * Match a set of files against the parsed references.
+ */
+/** @internal Exported for testing */
+export function matchFiles(files: string[], refs: DeferredRef[]): DeferredMatch[] {
+  const matches: DeferredMatch[] = [];
+
+  for (const file of files) {
+    const hits = refs.filter(ref =>
+      ref.isPrefix ? file.startsWith(ref.pathToken) : file === ref.pathToken
+    );
+    if (hits.length > 0) {
+      matches.push({ file, refs: hits });
+    }
+  }
+
+  return matches;
+}
+
+/** Resolve the staged file list from git */
+function getStagedFiles(): string[] {
+  const output = execFileSync('git', ['diff', '--cached', '--name-only'], {
+    encoding: 'utf-8',
+  });
+  return output.split('\n').filter(line => line.length > 0);
+}
+
+interface CheckOptions {
+  /** Read the file list from git's staged set */
+  staged?: boolean;
+  /** Explicit file list (used when staged is false) */
+  files?: string[];
+}
+
+/**
+ * CLI entry point. ALWAYS exits 0 — informational, never a gate. The
+ * catch-all makes that contract hold even when git or the filesystem
+ * misbehaves: errors are logged to stderr and swallowed, because a broken
+ * reminder tool must never break a commit or a script that calls it.
+ */
+export async function checkDeferredRefs(options: CheckOptions = {}): Promise<void> {
+  try {
+    const rootDir = process.cwd();
+    const deferredFile = join(rootDir, DEFERRED_PATH);
+    if (!existsSync(deferredFile)) {
+      return;
+    }
+
+    const files = options.staged === true ? getStagedFiles() : (options.files ?? []);
+    if (files.length === 0) {
+      return;
+    }
+
+    const refs = extractDeferredRefs(readFileSync(deferredFile, 'utf-8'));
+    const matches = matchFiles(files, refs);
+    if (matches.length === 0) {
+      return;
+    }
+
+    console.log('');
+    console.log(chalk.yellow.bold('📌 Deferred backlog entries reference files in this change:'));
+    for (const match of matches) {
+      console.log(chalk.white(`   ${match.file}`));
+      for (const ref of match.refs) {
+        console.log(chalk.dim(`     • ${ref.title} (${DEFERRED_PATH}:${ref.line})`));
+      }
+    }
+    console.log(chalk.dim('   Reminder only — fold one in if it fits, or carry on. Never blocks.'));
+    console.log('');
+  } catch (error) {
+    console.error(
+      chalk.dim(
+        `deferred-refs check skipped (${error instanceof Error ? error.message : String(error)})`
+      )
+    );
+  }
+}


### PR DESCRIPTION
## Summary

~A third of `backlog/deferred.md` entries are gated on **"opportunistic when next touching `<file>`"** — a trigger that only fires if the committer remembers the entry exists. Empirically it never fires: this week's ack-hygiene entries sat for a month with concrete ~15-LOC fix shapes while their files were edited around them.

`pnpm ops dev:deferred-refs` makes the trigger structural:

- Parses `deferred.md` table rows for `services/`/`packages/` path tokens — exact files (line-ref suffixes like `:231-234` and `:~221` stripped), directory prefixes, and globs (`*.py` → prefix)
- Matches against a file list — `--staged` (via `execFileSync` git) or explicit args
- Prints matches **informationally** with entry title + `deferred.md` line number; **always exits 0**. Deliberately not a `guard:*` — it's a reminder surface, not a gate

Wired into `.husky/pre-commit`, scoped to commits touching `services/` or `packages/` (doc-only commits skip the tsx startup). The output lands in the committer's terminal — and in the agent's tool-result context — at exactly the moment the "opportunistic" trigger was supposed to fire.

Entries with no file path (the genuinely event-gated ones) are invisible to the tool by design.

## Verification

- 18 unit tests: token normalization (line refs, globs, extension-less dirs, shallow-path rejection, punctuation trim), row parsing (titles, line numbers, header/separator skip), matching (exact, prefix, both-at-once), CLI behavior (staged mode, explicit files, missing-file no-op, never-throws)
- **Liveness against the real backlog**: `dev:deferred-refs MemoryRetriever.ts JobTracker.ts` correctly surfaced 4 entries, including one found via a directory-prefix reference
- `pnpm --filter @tzurot/tooling test` — 76 files / 1006 tests green; quality 16/16; direct `tsc` build verified (not trusting turbo cache after tonight's poisoning incident)

🤖 Generated with [Claude Code](https://claude.com/claude-code)