### PR TITLE
feat(ai-worker): ContextDataSource + shadow context hydration (PR-2.5a)

### DIFF
--- a/services/ai-worker/src/jobs/handlers/LLMGenerationHandler.ts
+++ b/services/ai-worker/src/jobs/handlers/LLMGenerationHandler.ts
@@ -22,6 +22,7 @@ import { randomUUID } from 'node:crypto';
 import { ConversationalRAGService } from '../../services/ConversationalRAGService.js';
 import {
   createLogger,
+  getPrismaClient,
   ApiErrorCategory,
   ApiErrorType,
   USER_ERROR_MESSAGES,
@@ -32,6 +33,7 @@ import {
   type ConfigCascadeResolver,
   type SttResolver,
 } from '@tzurot/common-types';
+import { PrismaContextDataSource } from '../../services/context/PrismaContextDataSource.js';
 import { ApiKeyResolver } from '../../services/ApiKeyResolver.js';
 import type { EmbeddingServiceInterface } from '../../utils/duplicateDetection.js';
 import { storeDiagnosticLog } from './pipeline/steps/diagnosticStorage.js';
@@ -137,7 +139,10 @@ export class LLMGenerationHandler {
       new AuthStep(apiKeyResolver, configResolver, undefined, sttResolver),
       new DownloadAttachmentsStep(),
       new DependencyStep(apiKeyResolver),
-      new ContextStep(),
+      // Handler (and thus this pipeline) is constructed once at worker
+      // startup — the data source and its wrapped services are singletons,
+      // not per-job allocations.
+      new ContextStep(new PrismaContextDataSource(getPrismaClient())),
       new GenerationStep(ragService, embeddingService),
       new TTSStep(ttsConfigResolver),
     ];

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/ContextStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/ContextStep.test.ts
@@ -37,6 +37,15 @@ vi.mock('../../../utils/conversationUtils.js', () => ({
   convertConversationHistory: mockConvertConversationHistory,
 }));
 
+const { mockShadowHydrateAndDiff, mockIsShadowHydrationEnabled } = vi.hoisted(() => ({
+  mockShadowHydrateAndDiff: vi.fn().mockResolvedValue(undefined),
+  mockIsShadowHydrationEnabled: vi.fn().mockReturnValue(false),
+}));
+vi.mock('../../../../services/context/shadowHydration.js', () => ({
+  shadowHydrateAndDiff: mockShadowHydrateAndDiff,
+  isShadowHydrationEnabled: mockIsShadowHydrationEnabled,
+}));
+
 const TEST_PERSONALITY: LoadedPersonality = {
   id: 'personality-123',
   name: 'TestBot',
@@ -94,6 +103,48 @@ describe('ContextStep', () => {
 
   it('should have correct name', () => {
     expect(step.name).toBe('ContextPreparation');
+  });
+
+  describe('shadow hydration gate', () => {
+    const config: ResolvedConfig = {
+      effectivePersonality: TEST_PERSONALITY,
+      configSource: 'personality',
+    };
+    const fakeDataSource = {
+      getChannelHistory: vi.fn(),
+      getCrossChannelHistory: vi.fn(),
+      getUserTimezone: vi.fn(),
+      getContextEpoch: vi.fn(),
+    };
+
+    it('invokes shadow hydration when a data source is provided and the flag is on', () => {
+      mockIsShadowHydrationEnabled.mockReturnValue(true);
+      const gatedStep = new ContextStep(fakeDataSource);
+
+      gatedStep.process({ job: createMockJob(), startTime: Date.now(), config });
+
+      expect(mockShadowHydrateAndDiff).toHaveBeenCalledWith(
+        expect.objectContaining({ jobId: 'job-123', dataSource: fakeDataSource })
+      );
+    });
+
+    it('does NOT invoke shadow hydration when the flag is off', () => {
+      mockIsShadowHydrationEnabled.mockReturnValue(false);
+      const gatedStep = new ContextStep(fakeDataSource);
+
+      gatedStep.process({ job: createMockJob(), startTime: Date.now(), config });
+
+      expect(mockShadowHydrateAndDiff).not.toHaveBeenCalled();
+    });
+
+    it('does NOT invoke shadow hydration without a data source, even with the flag on', () => {
+      mockIsShadowHydrationEnabled.mockReturnValue(true);
+      const ungatedStep = new ContextStep();
+
+      ungatedStep.process({ job: createMockJob(), startTime: Date.now(), config });
+
+      expect(mockShadowHydrateAndDiff).not.toHaveBeenCalled();
+    });
   });
 
   describe('process', () => {

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/ContextStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/ContextStep.ts
@@ -10,6 +10,11 @@ import {
   extractParticipants,
   convertConversationHistory,
 } from '../../../utils/conversationUtils.js';
+import type { ContextDataSource } from '../../../../services/context/types.js';
+import {
+  isShadowHydrationEnabled,
+  shadowHydrateAndDiff,
+} from '../../../../services/context/shadowHydration.js';
 import type { IPipelineStep, GenerationContext, Participant, PreparedContext } from '../types.js';
 
 const logger = createLogger('ContextStep');
@@ -45,12 +50,39 @@ function extractTimestamp(timestamp: string | Date | undefined | null): number |
 export class ContextStep implements IPipelineStep {
   readonly name = 'ContextPreparation';
 
+  /**
+   * @param contextDataSource - When provided AND `CONTEXT_SHADOW_HYDRATION=true`,
+   * each job's DB-derived context is re-hydrated worker-side and diffed
+   * against the bot-client payload (fire-and-forget, log-only). Burn-in
+   * instrumentation for the context-assembly relocation; the payload
+   * remains the source of truth for generation. Remove alongside the flag.
+   */
+  constructor(private readonly contextDataSource?: ContextDataSource) {}
+
+  /**
+   * Resolved once per step instance (pipeline is built at startup) — the
+   * flag only changes via a redeploy, so a per-job process.env read buys
+   * nothing.
+   */
+  private readonly shadowEnabled = isShadowHydrationEnabled();
+
   process(context: GenerationContext): GenerationContext {
     const { job, config } = context;
     const { personality, context: jobContext } = job.data;
 
     if (!config) {
       throw new Error('[ContextStep] ConfigStep must run before ContextStep');
+    }
+
+    if (this.contextDataSource !== undefined && this.shadowEnabled) {
+      // Intentionally not awaited — see constructor JSDoc.
+      void shadowHydrateAndDiff({
+        jobId: job.id,
+        jobContext,
+        personalityId: personality.id,
+        configOverrides: context.configOverrides,
+        dataSource: this.contextDataSource,
+      });
     }
 
     // Calculate oldest timestamp from conversation history AND referenced messages

--- a/services/ai-worker/src/services/context/PrismaContextDataSource.test.ts
+++ b/services/ai-worker/src/services/context/PrismaContextDataSource.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetChannelHistory = vi.hoisted(() => vi.fn());
+const mockGetCrossChannelHistory = vi.hoisted(() => vi.fn());
+const mockGetUserTimezone = vi.hoisted(() => vi.fn());
+
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+    ConversationHistoryService: class {
+      getChannelHistory = mockGetChannelHistory;
+      getCrossChannelHistory = mockGetCrossChannelHistory;
+    },
+    UserService: class {
+      getUserTimezone = mockGetUserTimezone;
+    },
+  };
+});
+
+import { PrismaContextDataSource } from './PrismaContextDataSource.js';
+import type { PrismaClient } from '@tzurot/common-types';
+
+const mockFindUnique = vi.fn();
+const fakePrisma = {
+  userPersonaHistoryConfig: { findUnique: mockFindUnique },
+} as unknown as PrismaClient;
+
+describe('PrismaContextDataSource', () => {
+  let source: PrismaContextDataSource;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    source = new PrismaContextDataSource(fakePrisma);
+  });
+
+  it('delegates getChannelHistory with identical argument order', async () => {
+    const epoch = new Date('2026-01-01T00:00:00Z');
+    mockGetChannelHistory.mockResolvedValue([{ id: 'm1' }]);
+
+    const result = await source.getChannelHistory('chan-1', 25, epoch, 3600);
+
+    expect(mockGetChannelHistory).toHaveBeenCalledWith('chan-1', 25, epoch, 3600);
+    expect(result).toEqual([{ id: 'm1' }]);
+  });
+
+  it('maps cross-channel params onto the positional service signature', async () => {
+    const epoch = new Date('2026-01-01T00:00:00Z');
+    mockGetCrossChannelHistory.mockResolvedValue([]);
+
+    await source.getCrossChannelHistory({
+      personaId: 'persona-1',
+      personalityId: 'pers-1',
+      excludeChannelId: 'chan-1',
+      limit: 25,
+      maxAgeSeconds: 3600,
+      contextEpoch: epoch,
+    });
+
+    expect(mockGetCrossChannelHistory).toHaveBeenCalledWith('persona-1', 'pers-1', 'chan-1', 25, {
+      maxAgeSeconds: 3600,
+      contextEpoch: epoch,
+    });
+  });
+
+  it('normalizes null maxAgeSeconds to undefined for the time filter', async () => {
+    mockGetCrossChannelHistory.mockResolvedValue([]);
+
+    await source.getCrossChannelHistory({
+      personaId: 'persona-1',
+      personalityId: 'pers-1',
+      excludeChannelId: 'chan-1',
+      limit: 25,
+      maxAgeSeconds: null,
+    });
+
+    expect(mockGetCrossChannelHistory).toHaveBeenCalledWith('persona-1', 'pers-1', 'chan-1', 25, {
+      maxAgeSeconds: undefined,
+      contextEpoch: undefined,
+    });
+  });
+
+  it('delegates getUserTimezone', async () => {
+    mockGetUserTimezone.mockResolvedValue('America/New_York');
+
+    await expect(source.getUserTimezone('internal-1')).resolves.toBe('America/New_York');
+    expect(mockGetUserTimezone).toHaveBeenCalledWith('internal-1');
+  });
+
+  it('reads the context epoch via the composite-key lookup', async () => {
+    const reset = new Date('2026-05-01T00:00:00Z');
+    mockFindUnique.mockResolvedValue({ lastContextReset: reset });
+
+    const epoch = await source.getContextEpoch('internal-1', 'pers-1', 'persona-1');
+
+    expect(mockFindUnique).toHaveBeenCalledWith({
+      where: {
+        userId_personalityId_personaId: {
+          userId: 'internal-1',
+          personalityId: 'pers-1',
+          personaId: 'persona-1',
+        },
+      },
+      select: { lastContextReset: true },
+    });
+    expect(epoch).toEqual(reset);
+  });
+
+  it('returns undefined when no history config row exists', async () => {
+    mockFindUnique.mockResolvedValue(null);
+
+    await expect(
+      source.getContextEpoch('internal-1', 'pers-1', 'persona-1')
+    ).resolves.toBeUndefined();
+  });
+
+  it('returns undefined when lastContextReset is null', async () => {
+    mockFindUnique.mockResolvedValue({ lastContextReset: null });
+
+    await expect(
+      source.getContextEpoch('internal-1', 'pers-1', 'persona-1')
+    ).resolves.toBeUndefined();
+  });
+});

--- a/services/ai-worker/src/services/context/PrismaContextDataSource.ts
+++ b/services/ai-worker/src/services/context/PrismaContextDataSource.ts
@@ -1,0 +1,73 @@
+/**
+ * Prisma-backed ContextDataSource.
+ *
+ * Deliberately thin: every read delegates to the SAME shared services the
+ * bot-client pipeline uses today (`ConversationHistoryService`,
+ * `UserService`) so hydrated results are comparable row-for-row with the
+ * bot-client-assembled payload during the shadow-verification window. The
+ * context-epoch lookup replicates bot-client's raw
+ * `userPersonaHistoryConfig` query (the one read that never had a service
+ * wrapper).
+ */
+
+import {
+  ConversationHistoryService,
+  UserService,
+  type ConversationMessage,
+  type CrossChannelHistoryGroup,
+  type PrismaClient,
+} from '@tzurot/common-types';
+import type { ContextDataSource, CrossChannelHistoryParams } from './types.js';
+
+export class PrismaContextDataSource implements ContextDataSource {
+  private readonly history: ConversationHistoryService;
+  private readonly users: UserService;
+
+  constructor(private readonly prisma: PrismaClient) {
+    this.history = new ConversationHistoryService(prisma);
+    this.users = new UserService(prisma);
+  }
+
+  async getChannelHistory(
+    channelId: string,
+    limit: number,
+    contextEpoch?: Date,
+    maxAgeSeconds?: number | null
+  ): Promise<ConversationMessage[]> {
+    return this.history.getChannelHistory(channelId, limit, contextEpoch, maxAgeSeconds);
+  }
+
+  async getCrossChannelHistory(
+    params: CrossChannelHistoryParams
+  ): Promise<CrossChannelHistoryGroup[]> {
+    return this.history.getCrossChannelHistory(
+      params.personaId,
+      params.personalityId,
+      params.excludeChannelId,
+      params.limit,
+      { maxAgeSeconds: params.maxAgeSeconds ?? undefined, contextEpoch: params.contextEpoch }
+    );
+  }
+
+  async getUserTimezone(internalUserId: string): Promise<string> {
+    return this.users.getUserTimezone(internalUserId);
+  }
+
+  async getContextEpoch(
+    internalUserId: string,
+    personalityId: string,
+    personaId: string
+  ): Promise<Date | undefined> {
+    const historyConfig = await this.prisma.userPersonaHistoryConfig.findUnique({
+      where: {
+        userId_personalityId_personaId: {
+          userId: internalUserId,
+          personalityId,
+          personaId,
+        },
+      },
+      select: { lastContextReset: true },
+    });
+    return historyConfig?.lastContextReset ?? undefined;
+  }
+}

--- a/services/ai-worker/src/services/context/shadowHydration.test.ts
+++ b/services/ai-worker/src/services/context/shadowHydration.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return { ...actual, createLogger: () => mockLogger };
+});
+
+import { isShadowHydrationEnabled, shadowHydrateAndDiff } from './shadowHydration.js';
+import type { ContextDataSource } from './types.js';
+import type { JobContext, ResolvedConfigOverrides } from '@tzurot/common-types';
+
+function makeDataSource(overrides: Partial<ContextDataSource> = {}): ContextDataSource {
+  return {
+    getChannelHistory: vi.fn().mockResolvedValue([]),
+    getCrossChannelHistory: vi.fn().mockResolvedValue([]),
+    getUserTimezone: vi.fn().mockResolvedValue('UTC'),
+    getContextEpoch: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function makeOverrides(partial: Partial<ResolvedConfigOverrides> = {}): ResolvedConfigOverrides {
+  return {
+    maxMessages: 20,
+    maxAge: null,
+    maxImages: 5,
+    memoryScoreThreshold: 0.3,
+    memoryLimit: 20,
+    focusModeEnabled: false,
+    crossChannelHistoryEnabled: false,
+    shareLtmAcrossPersonalities: false,
+    showModelFooter: false,
+    voiceResponseMode: 'never',
+    voiceTranscriptionEnabled: false,
+    ...partial,
+  } as ResolvedConfigOverrides;
+}
+
+function makeJobContext(partial: Partial<JobContext> = {}): JobContext {
+  return {
+    userId: 'discord-user-1',
+    userInternalId: 'internal-1',
+    channelId: 'chan-1',
+    activePersonaId: 'persona-1',
+    conversationHistory: [
+      { id: 'm1', role: 'user', content: 'hi' },
+      { id: 'm2', role: 'assistant', content: 'hello' },
+    ],
+    ...partial,
+  } as JobContext;
+}
+
+describe('isShadowHydrationEnabled', () => {
+  it('is enabled only by the exact string "true"', () => {
+    expect(
+      isShadowHydrationEnabled({ CONTEXT_SHADOW_HYDRATION: 'true' } as NodeJS.ProcessEnv)
+    ).toBe(true);
+    expect(isShadowHydrationEnabled({ CONTEXT_SHADOW_HYDRATION: '1' } as NodeJS.ProcessEnv)).toBe(
+      false
+    );
+    expect(isShadowHydrationEnabled({} as NodeJS.ProcessEnv)).toBe(false);
+  });
+});
+
+describe('shadowHydrateAndDiff', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('logs a matched summary when hydration agrees with the payload', async () => {
+    const dataSource = makeDataSource({
+      getChannelHistory: vi.fn().mockResolvedValue([{ id: 'm1' }, { id: 'm2' }]),
+    });
+
+    await shadowHydrateAndDiff({
+      jobId: 'job-1',
+      jobContext: makeJobContext(),
+      personalityId: 'pers-1',
+      configOverrides: makeOverrides(),
+      dataSource,
+    });
+
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: 'job-1',
+        historyDiff: expect.objectContaining({ missingFromHydrated: 0, extraInHydrated: 0 }),
+        timezoneMatch: true,
+      }),
+      expect.stringContaining('matched')
+    );
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it('tolerates extra hydrated rows (post-fetch persistence drift) as a match', async () => {
+    const dataSource = makeDataSource({
+      getChannelHistory: vi.fn().mockResolvedValue([{ id: 'm1' }, { id: 'm2' }, { id: 'm3-new' }]),
+    });
+
+    await shadowHydrateAndDiff({
+      jobId: 'job-1',
+      jobContext: makeJobContext(),
+      personalityId: 'pers-1',
+      configOverrides: makeOverrides(),
+      dataSource,
+    });
+
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        historyDiff: expect.objectContaining({ extraInHydrated: 1, missingFromHydrated: 0 }),
+      }),
+      expect.stringContaining('matched')
+    );
+  });
+
+  it('warns when payload rows are missing from hydration', async () => {
+    const dataSource = makeDataSource({
+      getChannelHistory: vi.fn().mockResolvedValue([{ id: 'm1' }]),
+    });
+
+    await shadowHydrateAndDiff({
+      jobId: 'job-1',
+      jobContext: makeJobContext(),
+      personalityId: 'pers-1',
+      configOverrides: makeOverrides(),
+      dataSource,
+    });
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        historyDiff: expect.objectContaining({ missingFromHydrated: 1 }),
+      }),
+      expect.stringContaining('DIVERGED')
+    );
+  });
+
+  it('warns on a timezone mismatch', async () => {
+    const dataSource = makeDataSource({
+      getChannelHistory: vi.fn().mockResolvedValue([{ id: 'm1' }, { id: 'm2' }]),
+      getUserTimezone: vi.fn().mockResolvedValue('America/New_York'),
+    });
+
+    await shadowHydrateAndDiff({
+      jobId: 'job-1',
+      jobContext: makeJobContext({ userTimezone: undefined }),
+      personalityId: 'pers-1',
+      configOverrides: makeOverrides(),
+      dataSource,
+    });
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ timezoneMatch: false }),
+      expect.stringContaining('DIVERGED')
+    );
+  });
+
+  it('passes the hydrated epoch into the history query', async () => {
+    const epoch = new Date('2026-05-01T00:00:00Z');
+    const getChannelHistory = vi.fn().mockResolvedValue([{ id: 'm1' }, { id: 'm2' }]);
+    const dataSource = makeDataSource({
+      getContextEpoch: vi.fn().mockResolvedValue(epoch),
+      getChannelHistory,
+    });
+
+    await shadowHydrateAndDiff({
+      jobId: 'job-1',
+      jobContext: makeJobContext(),
+      personalityId: 'pers-1',
+      configOverrides: makeOverrides({ maxMessages: 30, maxAge: 7200 }),
+      dataSource,
+    });
+
+    expect(getChannelHistory).toHaveBeenCalledWith('chan-1', 30, epoch, 7200);
+  });
+
+  it('hydrates cross-channel groups only when enabled and not weigh-in', async () => {
+    const getCrossChannelHistory = vi.fn().mockResolvedValue([{ channelId: 'other' }]);
+    const dataSource = makeDataSource({
+      getChannelHistory: vi.fn().mockResolvedValue([{ id: 'm1' }, { id: 'm2' }]),
+      getCrossChannelHistory,
+    });
+
+    await shadowHydrateAndDiff({
+      jobId: 'job-1',
+      jobContext: makeJobContext({ isWeighIn: true }),
+      personalityId: 'pers-1',
+      configOverrides: makeOverrides({ crossChannelHistoryEnabled: true }),
+      dataSource,
+    });
+    expect(getCrossChannelHistory).not.toHaveBeenCalled();
+
+    await shadowHydrateAndDiff({
+      jobId: 'job-2',
+      jobContext: makeJobContext(),
+      personalityId: 'pers-1',
+      configOverrides: makeOverrides({ crossChannelHistoryEnabled: true }),
+      dataSource,
+    });
+    expect(getCrossChannelHistory).toHaveBeenCalledWith(
+      expect.objectContaining({ personaId: 'persona-1', excludeChannelId: 'chan-1' })
+    );
+  });
+
+  it('warns when hydration sees FEWER cross-channel groups than the payload', async () => {
+    const dataSource = makeDataSource({
+      getChannelHistory: vi.fn().mockResolvedValue([{ id: 'm1' }, { id: 'm2' }]),
+      getCrossChannelHistory: vi.fn().mockResolvedValue([]),
+    });
+
+    await shadowHydrateAndDiff({
+      jobId: 'job-1',
+      jobContext: makeJobContext({
+        crossChannelHistory: [
+          {
+            channelEnvironment: {
+              type: 'guild',
+              channel: { id: 'other-1', name: 'general', type: 'text' },
+            },
+            messages: [],
+          },
+          {
+            channelEnvironment: {
+              type: 'guild',
+              channel: { id: 'other-2', name: 'random', type: 'text' },
+            },
+            messages: [],
+          },
+        ],
+      }),
+      personalityId: 'pers-1',
+      configOverrides: makeOverrides({ crossChannelHistoryEnabled: true }),
+      dataSource,
+    });
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        crossChannelDiff: { payloadGroups: 2, hydratedGroups: 0 },
+      }),
+      expect.stringContaining('DIVERGED')
+    );
+  });
+
+  it('tolerates hydration seeing MORE cross-channel groups (timing drift)', async () => {
+    const dataSource = makeDataSource({
+      getChannelHistory: vi.fn().mockResolvedValue([{ id: 'm1' }, { id: 'm2' }]),
+      getCrossChannelHistory: vi.fn().mockResolvedValue([{ channelId: 'other-1' }]),
+    });
+
+    await shadowHydrateAndDiff({
+      jobId: 'job-1',
+      jobContext: makeJobContext(),
+      personalityId: 'pers-1',
+      configOverrides: makeOverrides({ crossChannelHistoryEnabled: true }),
+      dataSource,
+    });
+
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        crossChannelDiff: { payloadGroups: 0, hydratedGroups: 1 },
+      }),
+      expect.stringContaining('matched')
+    );
+  });
+
+  it('excludes id-less hydrated rows from the diff (symmetric filtering)', async () => {
+    const dataSource = makeDataSource({
+      getChannelHistory: vi.fn().mockResolvedValue([{ id: 'm1' }, { id: 'm2' }, { id: undefined }]),
+    });
+
+    await shadowHydrateAndDiff({
+      jobId: 'job-1',
+      jobContext: makeJobContext(),
+      personalityId: 'pers-1',
+      configOverrides: makeOverrides(),
+      dataSource,
+    });
+
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        historyDiff: expect.objectContaining({ hydratedCount: 2, extraInHydrated: 0 }),
+      }),
+      expect.stringContaining('matched')
+    );
+  });
+
+  it('no-ops without a channelId', async () => {
+    const dataSource = makeDataSource();
+
+    await shadowHydrateAndDiff({
+      jobId: 'job-1',
+      jobContext: makeJobContext({ channelId: undefined }),
+      personalityId: 'pers-1',
+      configOverrides: makeOverrides(),
+      dataSource,
+    });
+
+    expect(dataSource.getChannelHistory).not.toHaveBeenCalled();
+    expect(mockLogger.info).not.toHaveBeenCalled();
+  });
+
+  it('swallows hydration errors into a debug log (never throws)', async () => {
+    const dataSource = makeDataSource({
+      getChannelHistory: vi.fn().mockRejectedValue(new Error('db down')),
+    });
+
+    await expect(
+      shadowHydrateAndDiff({
+        jobId: 'job-1',
+        jobContext: makeJobContext(),
+        personalityId: 'pers-1',
+        configOverrides: makeOverrides(),
+        dataSource,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: 'job-1' }),
+      expect.stringContaining('ignored')
+    );
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+});

--- a/services/ai-worker/src/services/context/shadowHydration.ts
+++ b/services/ai-worker/src/services/context/shadowHydration.ts
@@ -1,0 +1,220 @@
+/**
+ * Shadow context hydration — burn-in instrumentation for the context-assembly
+ * relocation. Remove when `CONTEXT_SHADOW_HYDRATION` is retired.
+ *
+ * When `CONTEXT_SHADOW_HYDRATION=true`, every LLM job ALSO hydrates the
+ * DB-derived context via ContextDataSource and diffs it against the
+ * bot-client-assembled payload, logging a structured summary. Generation is
+ * never affected: the payload remains the source of truth, hydration runs
+ * fire-and-forget, and every failure is swallowed into a debug log.
+ *
+ * Diff tolerance is deliberate — exact equality is NOT expected:
+ * - The payload's conversationHistory merges DB rows with Discord-fetched
+ *   extended-context messages; only entries carrying a DB `id` are compared.
+ * - Time passes between bot-client's fetch and job processing, so hydration
+ *   may see rows the payload predates (`extraInHydrated` — expected for the
+ *   newest messages, including the triggering message itself once persisted).
+ * - Limit derivation differs subtly today: bot-client uses
+ *   `extendedContext?.maxMessages ?? DEFAULT` while hydration uses the
+ *   resolved cascade value directly. The summary logs the limit used so
+ *   burn-in analysis can attribute count differences. Surfacing this class
+ *   of divergence is the point of the shadow window.
+ */
+
+import {
+  createLogger,
+  MESSAGE_LIMITS,
+  type JobContext,
+  type ResolvedConfigOverrides,
+} from '@tzurot/common-types';
+import type { ContextDataSource } from './types.js';
+
+const logger = createLogger('ShadowHydration');
+
+export function isShadowHydrationEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.CONTEXT_SHADOW_HYDRATION === 'true';
+}
+
+interface ShadowParams {
+  jobId: string | number | undefined;
+  jobContext: JobContext;
+  personalityId: string;
+  configOverrides: ResolvedConfigOverrides | undefined;
+  dataSource: ContextDataSource;
+}
+
+interface HistoryDiff {
+  payloadDbCount: number;
+  hydratedCount: number;
+  missingFromHydrated: number;
+  extraInHydrated: number;
+}
+
+function diffHistoryIds(payloadIds: Set<string>, hydratedIds: Set<string>): HistoryDiff {
+  let missingFromHydrated = 0;
+  for (const id of payloadIds) {
+    if (!hydratedIds.has(id)) {
+      missingFromHydrated++;
+    }
+  }
+  let extraInHydrated = 0;
+  for (const id of hydratedIds) {
+    if (!payloadIds.has(id)) {
+      extraInHydrated++;
+    }
+  }
+  return {
+    payloadDbCount: payloadIds.size,
+    hydratedCount: hydratedIds.size,
+    missingFromHydrated,
+    extraInHydrated,
+  };
+}
+
+/** Payload omits the field for UTC users; treat undefined as 'UTC'. */
+async function compareTimezone(
+  dataSource: ContextDataSource,
+  jobContext: JobContext,
+  userInternalId: string | undefined
+): Promise<boolean | undefined> {
+  if (userInternalId === undefined) {
+    return undefined;
+  }
+  const hydratedTimezone = await dataSource.getUserTimezone(userInternalId);
+  return hydratedTimezone === (jobContext.userTimezone ?? 'UTC');
+}
+
+interface CrossChannelCompareParams {
+  dataSource: ContextDataSource;
+  jobContext: JobContext;
+  personalityId: string;
+  configOverrides: ResolvedConfigOverrides | undefined;
+  channelId: string;
+  activePersonaId: string | undefined;
+  limit: number;
+  maxAgeSeconds: number | undefined;
+  contextEpoch: Date | undefined;
+}
+
+/**
+ * Count-only comparison BY DESIGN: the payload carries
+ * `CrossChannelHistoryGroupEntry[]` (Discord wire format, keyed by
+ * `channelEnvironment`) while hydration returns `CrossChannelHistoryGroup[]`
+ * (DB service format, keyed by `channelId`) — structurally unrelated types.
+ * The cutover slice must unify these shapes before any deep diff is possible;
+ * until then, group counts are the comparable signal.
+ */
+async function compareCrossChannel(
+  params: CrossChannelCompareParams
+): Promise<{ payloadGroups: number; hydratedGroups: number } | undefined> {
+  const { dataSource, jobContext, configOverrides, activePersonaId } = params;
+  if (
+    configOverrides?.crossChannelHistoryEnabled !== true ||
+    jobContext.isWeighIn === true ||
+    activePersonaId === undefined
+  ) {
+    return undefined;
+  }
+  const hydratedGroups = await dataSource.getCrossChannelHistory({
+    personaId: activePersonaId,
+    personalityId: params.personalityId,
+    excludeChannelId: params.channelId,
+    limit: params.limit,
+    maxAgeSeconds: params.maxAgeSeconds,
+    contextEpoch: params.contextEpoch,
+  });
+  return {
+    payloadGroups: jobContext.crossChannelHistory?.length ?? 0,
+    hydratedGroups: hydratedGroups.length,
+  };
+}
+
+/**
+ * Hydrate the DB-derived context and log a comparison summary.
+ * Fire-and-forget: never throws, never blocks the pipeline.
+ */
+export async function shadowHydrateAndDiff(params: ShadowParams): Promise<void> {
+  try {
+    const { jobContext, personalityId, configOverrides, dataSource } = params;
+    const { channelId, userInternalId, activePersonaId } = jobContext;
+    if (channelId === undefined || channelId.length === 0) {
+      return;
+    }
+
+    // Mirror the bot-client dbLimit derivation as closely as the resolved
+    // cascade allows (see module JSDoc for the known divergence).
+    const limit = Math.min(
+      configOverrides?.maxMessages ?? MESSAGE_LIMITS.DEFAULT_MAX_MESSAGES,
+      MESSAGE_LIMITS.MAX_EXTENDED_CONTEXT
+    );
+    const maxAgeSeconds = configOverrides?.maxAge ?? undefined;
+
+    // Epoch is an INPUT to history filtering (the payload doesn't carry it);
+    // hydrating it exercises the same lookup bot-client performs.
+    const contextEpoch =
+      userInternalId !== undefined && activePersonaId !== undefined
+        ? await dataSource.getContextEpoch(userInternalId, personalityId, activePersonaId)
+        : undefined;
+
+    const hydratedHistory = await dataSource.getChannelHistory(
+      channelId,
+      limit,
+      contextEpoch,
+      maxAgeSeconds
+    );
+
+    const payloadDbIds = new Set(
+      (jobContext.conversationHistory ?? [])
+        .map(msg => msg.id)
+        .filter((id): id is string => id !== undefined && id.length > 0)
+    );
+    // Filter symmetrically with the payload side — a hypothetical id-less DB
+    // row must not inflate extraInHydrated.
+    const hydratedIds = new Set(
+      hydratedHistory.map(m => m.id).filter((id): id is string => id !== undefined && id.length > 0)
+    );
+    const historyDiff = diffHistoryIds(payloadDbIds, hydratedIds);
+
+    const timezoneMatch = await compareTimezone(dataSource, jobContext, userInternalId);
+    const crossChannelDiff = await compareCrossChannel({
+      dataSource,
+      jobContext,
+      personalityId,
+      configOverrides,
+      channelId,
+      activePersonaId,
+      limit,
+      maxAgeSeconds,
+      contextEpoch,
+    });
+
+    // `extraInHydrated` alone is the expected-drift case (new rows persisted
+    // since the bot-client fetch); anything missing from hydration, a
+    // timezone mismatch, or hydration seeing FEWER cross-channel groups than
+    // the payload (more is timing drift, fewer is a lost-data regression) is
+    // a real divergence worth a warn.
+    const crossChannelRegressed =
+      crossChannelDiff !== undefined &&
+      crossChannelDiff.hydratedGroups < crossChannelDiff.payloadGroups;
+    const diverged =
+      historyDiff.missingFromHydrated > 0 || timezoneMatch === false || crossChannelRegressed;
+    const summary = {
+      jobId: params.jobId,
+      limit,
+      maxAgeSeconds: maxAgeSeconds ?? null,
+      contextEpoch: contextEpoch?.toISOString() ?? null,
+      historyDiff,
+      timezoneMatch,
+      crossChannelDiff,
+    };
+
+    if (diverged) {
+      logger.warn(summary, 'Shadow hydration DIVERGED from bot-client payload');
+    } else {
+      logger.info(summary, 'Shadow hydration matched bot-client payload');
+    }
+  } catch (error) {
+    // Shadow instrumentation must never surface as a pipeline failure.
+    logger.debug({ err: error, jobId: params.jobId }, 'Shadow hydration failed (ignored)');
+  }
+}

--- a/services/ai-worker/src/services/context/types.ts
+++ b/services/ai-worker/src/services/context/types.ts
@@ -1,0 +1,66 @@
+/**
+ * ContextDataSource
+ *
+ * The seam through which ai-worker hydrates the DB-derived parts of a job's
+ * message context itself, instead of trusting the bot-client-assembled
+ * payload. Exists because bot-client must be Prisma-free: context assembly
+ * relocates into ai-worker, which owns the AI/memory domain and therefore
+ * owns context hydration.
+ *
+ * Scope boundary: only DB-DERIVED context comes through this interface
+ * (conversation history, cross-channel history, user timezone, context
+ * epoch). Discord-derived context (attachments, guild member info,
+ * environment, live channel fetches) stays in the job envelope forever —
+ * only bot-client can see Discord.
+ *
+ * All methods are READ-ONLY. Persona resolution and user upserts are
+ * deliberately excluded until the cutover phase — the shadow-verification
+ * mode (see shadowHydration.ts) runs against production traffic and must
+ * not write.
+ */
+
+import type { ConversationMessage, CrossChannelHistoryGroup } from '@tzurot/common-types';
+
+export interface CrossChannelHistoryParams {
+  /** Active persona whose other-channel conversations to fetch */
+  personaId: string;
+  /** Personality scope for the conversations */
+  personalityId: string;
+  /** Channel to exclude (the current conversation's channel) */
+  excludeChannelId: string;
+  /** Per-fetch message budget (mirrors the channel-history dbLimit) */
+  limit: number;
+  /** Optional staleness cutoff in seconds */
+  maxAgeSeconds?: number | null;
+  /** Optional context-reset epoch — messages before it are excluded */
+  contextEpoch?: Date;
+}
+
+export interface ContextDataSource {
+  /**
+   * Channel conversation history, newest-window semantics identical to the
+   * bot-client fetch (limit + epoch + maxAge filters applied DB-side).
+   */
+  getChannelHistory(
+    channelId: string,
+    limit: number,
+    contextEpoch?: Date,
+    maxAgeSeconds?: number | null
+  ): Promise<ConversationMessage[]>;
+
+  /** Cross-channel history groups for the active persona+personality. */
+  getCrossChannelHistory(params: CrossChannelHistoryParams): Promise<CrossChannelHistoryGroup[]>;
+
+  /** IANA timezone for an INTERNAL user id ('UTC' fallback). */
+  getUserTimezone(internalUserId: string): Promise<string>;
+
+  /**
+   * Context-reset epoch for a user+personality+persona triple, or undefined
+   * when the user never reset context for that pairing.
+   */
+  getContextEpoch(
+    internalUserId: string,
+    personalityId: string,
+    personaId: string
+  ): Promise<Date | undefined>;
+}


### PR DESCRIPTION
## Summary

First slice of the **Phase 2.5 context-assembly relocation** (council verdict 2026-06-04, unanimous: ai-worker owns context hydration; bot-client goes Prisma-free). **Zero behavior change** — the bot-client-assembled payload remains the source of truth for generation; this PR builds the worker-side hydration capability and the shadow-verification instrumentation the cutover will be judged by.

### What's here

- **`ContextDataSource`** (`services/context/types.ts`) — the seam for worker-side hydration of DB-derived context (channel history, cross-channel history, user timezone, context epoch). **Read-only by design**: persona resolution and `getOrCreateUser` upserts are deliberately excluded until the cutover slice, because shadow verification runs against production traffic and must not write.
- **`PrismaContextDataSource`** — deliberately thin: delegates to the *same* shared services bot-client uses today (`ConversationHistoryService`, `UserService`) so hydrated results are comparable row-for-row, plus the context-epoch composite-key lookup bot-client performs as a raw query.
- **Shadow hydration** — `CONTEXT_SHADOW_HYDRATION=true` makes every LLM job *also* hydrate DB context and diff it against the payload, logging one structured summary per job. Fire-and-forget; a hydration failure can never become a pipeline failure.
- **Wiring** — `ContextStep` gains an optional constructor param; `LLMGenerationHandler` supplies the Prisma-backed source. Default-off everywhere until the burn-in window.

### Diff tolerance is deliberate

| Signal | Verdict | Why |
|--------|---------|-----|
| `extraInHydrated` only | matched (info) | Rows persisted after bot-client's fetch — expected timing drift |
| `missingFromHydrated` > 0 | **DIVERGED (warn)** | Hydration lost something the payload had — real gap |
| timezone mismatch | **DIVERGED (warn)** | Deterministic read, must agree |
| Discord-sourced history entries (no DB id) | excluded | Only bot-client can see Discord; those stay envelope-side forever |

The known **limit-derivation divergence** (bot-client uses `extendedContext?.maxMessages ?? DEFAULT` while hydration uses the resolved cascade value directly) is documented in the module JSDoc and the summary logs the limit used — surfacing exactly that class of subtle difference is what the shadow window is *for*.

## Verification

- 16 new unit tests (delegation + epoch lookup; matched / tolerated-drift / diverged / timezone / epoch-threading / cross-channel-gating / no-op / never-throws)
- ContextStep + structure tests green (89 across the touched surface); `pnpm quality` 16/16; direct ai-worker `tsc` build verified

## Next slices

2.5b: gateway write endpoints (delivery confirmation, edit/delete sync) + cached routing-read route → 2.5c: cutover behind `CONTEXT_MODE` → 2.5d: delete legacy + tighten the depcruise guard. Per `backlog/active-epic.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)