### PR TITLE
feat(bot-client): PR 2.5c-ii — routing-read cutover behind CONTEXT_MODE

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,11 +129,12 @@ ENABLE_FREE_WILL=false  # LangGraph orchestrator (not yet implemented)
 # once at worker startup).
 CONTEXT_SHADOW_HYDRATION=false
 
-# Context write-path mode (bot-client): "legacy" (default) = local Prisma
-# writes own the Discord-event surface (assistant persist, edit/delete sync);
-# "service" = the api-gateway internal endpoints own those writes and
-# bot-client performs no local Prisma conversation writes for them.
-# Rollback = flip back to legacy + restart.
+# Context-path mode (bot-client): "legacy" (default) = local Prisma owns the
+# Discord-event writes (assistant persist, edit/delete sync) AND the routing
+# personality reads (mention parsing, reply resolution, activation);
+# "service" = the api-gateway internal endpoints own both — writes go to the
+# conversation endpoints, routing reads go through /internal/personality/load
+# with positive/negative caching. Rollback = flip back to legacy + restart.
 CONTEXT_MODE=legacy
 
 # Context dual-write (bot-client, legacy mode only): mirrors conversation

--- a/packages/common-types/src/services/CacheInvalidationService.ts
+++ b/packages/common-types/src/services/CacheInvalidationService.ts
@@ -16,9 +16,20 @@
 import { createLogger } from '../utils/logger.js';
 import { REDIS_CHANNELS } from '../constants/queue.js';
 import type { Redis } from 'ioredis';
-import type { PersonalityService } from './personality/index.js';
 
 const logger = createLogger('CacheInvalidationService');
+
+/**
+ * The minimal cache surface this service drives. PersonalityService
+ * satisfies it structurally; so does any other personality cache that needs
+ * pub/sub-driven invalidation (e.g. bot-client's HttpPersonalityLoader in
+ * CONTEXT_MODE=service).
+ */
+export interface PersonalityCacheTarget {
+  /** Invalidation events always carry the personality UUID, never a name. */
+  invalidatePersonality(personalityId: string): void;
+  invalidateAll(): void;
+}
 
 type InvalidationEvent = { type: 'personality'; personalityId: string } | { type: 'all' };
 
@@ -49,7 +60,7 @@ export class CacheInvalidationService {
 
   constructor(
     private redis: Redis,
-    private personalityService: PersonalityService
+    private personalityService: PersonalityCacheTarget
   ) {}
 
   /**

--- a/services/bot-client/src/composition.ts
+++ b/services/bot-client/src/composition.ts
@@ -25,7 +25,6 @@ import { DMSessionProcessor } from './processors/DMSessionProcessor.js';
 import { BotMentionProcessor } from './processors/BotMentionProcessor.js';
 import { DenylistCache } from './services/DenylistCache.js';
 import { VoiceTranscriptionService } from './services/VoiceTranscriptionService.js';
-import { PersonalityIdCache } from './services/PersonalityIdCache.js';
 import { ReplyResolutionService } from './services/ReplyResolutionService.js';
 import { PersonalityMessageHandler } from './services/PersonalityMessageHandler.js';
 import { PersonalityChatManager } from './services/character/PersonalityChatManager.js';
@@ -174,7 +173,7 @@ export function buildMultiTagStack(deps: {
 export function buildProcessorChain(deps: {
   denylistCache: DenylistCache;
   voiceTranscription: VoiceTranscriptionService;
-  personalityIdCache: PersonalityIdCache;
+  personalityLoader: IPersonalityLoader;
   replyResolver: ReplyResolutionService;
   coordinator: MultiTagCoordinator;
   personalityHandler: PersonalityMessageHandler;
@@ -184,14 +183,14 @@ export function buildProcessorChain(deps: {
     new BotMessageFilter(),
     new DenylistFilter(deps.denylistCache),
     new EmptyMessageFilter(),
-    new VoiceMessageProcessor(deps.voiceTranscription, deps.personalityIdCache),
+    new VoiceMessageProcessor(deps.voiceTranscription, deps.personalityLoader),
     new PersonalityTriggerProcessor({
-      personalityService: deps.personalityIdCache,
+      personalityService: deps.personalityLoader,
       replyResolver: deps.replyResolver,
       coordinator: deps.coordinator,
     }),
     new DMSessionProcessor(
-      deps.personalityIdCache,
+      deps.personalityLoader,
       deps.personalityHandler,
       deps.multiTagPersistence
     ),
@@ -210,7 +209,7 @@ export function buildMessageHandler(deps: {
   // Processor-chain deps
   denylistCache: DenylistCache;
   voiceTranscription: VoiceTranscriptionService;
-  personalityIdCache: PersonalityIdCache;
+  personalityLoader: IPersonalityLoader;
   replyResolver: ReplyResolutionService;
   personalityHandler: PersonalityMessageHandler;
   multiTagPersistence: MultiTagPersistence;
@@ -226,7 +225,7 @@ export function buildMessageHandler(deps: {
   const processors = buildProcessorChain({
     denylistCache: deps.denylistCache,
     voiceTranscription: deps.voiceTranscription,
-    personalityIdCache: deps.personalityIdCache,
+    personalityLoader: deps.personalityLoader,
     replyResolver: deps.replyResolver,
     coordinator: deps.coordinator,
     personalityHandler: deps.personalityHandler,

--- a/services/bot-client/src/index.ts
+++ b/services/bot-client/src/index.ts
@@ -51,6 +51,9 @@ import { MultiTagCoordinator } from './services/MultiTagCoordinator.js';
 import type { MultiTagPersistence } from './services/MultiTagPersistence.js';
 import type { MultiTagRecovery } from './services/MultiTagRecovery.js';
 import { PersonalityIdCache } from './services/PersonalityIdCache.js';
+import { HttpPersonalityLoader } from './services/HttpPersonalityLoader.js';
+import { getContextMode } from './utils/contextWritePath.js';
+import type { IPersonalityLoader } from './types/IPersonalityLoader.js';
 import { DenylistCache } from './services/DenylistCache.js';
 import { DMCacheWarmer } from './services/DMCacheWarmer.js';
 import { StartupDMPrewarmer } from './services/StartupDMPrewarmer.js';
@@ -204,9 +207,27 @@ function createServices(): Services {
   // Shared services (used by multiple processors)
   const personalityService = new PersonalityService(prisma);
   const conversationHistoryService = new ConversationHistoryService(prisma);
-  const cacheInvalidationService = new CacheInvalidationService(cacheRedis, personalityService);
   const personalityIdCache = new PersonalityIdCache(personalityService); // Optimizes name→ID lookups
   const userService = new UserService(prisma);
+
+  // Routing-read loader (Phase 2.5c-ii): in service mode, personality
+  // resolution for routing (mention parsing, reply resolution, activation,
+  // multi-tag recovery, /character chat) goes through the gateway's internal
+  // endpoint with positive/negative caching instead of direct Prisma. The two
+  // legacy variables preserve today's wiring exactly: some sites get the
+  // name→ID cache wrapper, others the raw service.
+  const httpPersonalityLoader = getContextMode() === 'service' ? new HttpPersonalityLoader() : null;
+  // Legacy fallback: PersonalityIdCache wrapping PersonalityService (extra name→ID cache layer).
+  const routingLoaderCached: IPersonalityLoader = httpPersonalityLoader ?? personalityIdCache;
+  // Legacy fallback: raw PersonalityService ("direct" = no wrapper; it still has its own TTL cache).
+  const routingLoaderDirect: IPersonalityLoader = httpPersonalityLoader ?? personalityService;
+
+  // Pub/sub invalidation drives whichever cache is live for routing: the
+  // HTTP loader's tiers in service mode, PersonalityService's cache in legacy.
+  const cacheInvalidationService = new CacheInvalidationService(
+    cacheRedis,
+    httpPersonalityLoader ?? personalityService
+  );
 
   // Persona resolution with proper cache invalidation via Redis pub/sub
   const personaResolver = new PersonaResolver(prisma, { enableCleanup: true });
@@ -233,7 +254,7 @@ function createServices(): Services {
   const persistence = new ConversationPersistence(prisma);
   const voiceTranscription = new VoiceTranscriptionService();
   const referenceEnricher = new ReferenceEnrichmentService(userService, personaResolver);
-  const replyResolver = new ReplyResolutionService(personalityIdCache);
+  const replyResolver = new ReplyResolutionService(routingLoaderCached);
 
   // Personality chat pipeline (manager + Discord-shape adapter).
   const { personalityChatManager, personalityHandler } = buildPersonalityChatPipeline({
@@ -274,7 +295,7 @@ function createServices(): Services {
     jobTracker,
     orderingService: responseOrderingService,
     slotDelivery,
-    personalityService,
+    personalityService: routingLoaderDirect,
     personaResolver,
     discordClient: client,
     recoveryQueue: multiTagRecoveryQueue,
@@ -294,7 +315,7 @@ function createServices(): Services {
   const messageHandler = buildMessageHandler({
     denylistCache,
     voiceTranscription,
-    personalityIdCache,
+    personalityLoader: routingLoaderCached,
     replyResolver,
     personalityHandler,
     multiTagPersistence,
@@ -303,7 +324,7 @@ function createServices(): Services {
     jobTracker,
     slotDelivery,
     coordinator: multiTagCoordinator,
-    personalityService,
+    personalityService: routingLoaderDirect,
     client,
   });
 
@@ -311,7 +332,7 @@ function createServices(): Services {
   registerServices({
     jobTracker,
     webhookManager,
-    personalityService,
+    personalityService: routingLoaderDirect,
     conversationHistoryService,
     personaResolver,
     channelActivationCacheInvalidationService,

--- a/services/bot-client/src/services/HttpPersonalityLoader.test.ts
+++ b/services/bot-client/src/services/HttpPersonalityLoader.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockServiceClient = {
+  loadPersonalityInternal: vi.fn(),
+};
+
+vi.mock('../utils/gatewayClients.js', () => ({
+  getServiceClient: () => mockServiceClient,
+}));
+
+import { TIMEOUTS } from '@tzurot/common-types';
+import { HttpPersonalityLoader, NEGATIVE_TTL_MS } from './HttpPersonalityLoader.js';
+
+const PERSONALITY = { id: 'pers-1', name: 'Lila', slug: 'lila' };
+
+const ok = <T>(data: T): { ok: true; data: T } => ({ ok: true, data });
+const err = (status: number): { ok: false; error: string; status: number } => ({
+  ok: false,
+  error: 'boom',
+  status,
+});
+
+describe('HttpPersonalityLoader', () => {
+  let loader: HttpPersonalityLoader;
+  let clock: number;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    // Nonzero start: lru-cache stores entry start times from perf.now() and
+    // treats 0 as "no TTL recorded", which would make entries immortal.
+    clock = 1_000_000;
+    // lru-cache snapshots performance.now at module load — fake timers can't
+    // advance its TTLs, so the loader takes an injectable clock instead.
+    loader = new HttpPersonalityLoader({ now: () => clock });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches on miss and serves subsequent hits from the positive cache', async () => {
+    mockServiceClient.loadPersonalityInternal.mockResolvedValue(ok({ personality: PERSONALITY }));
+
+    const first = await loader.loadPersonality('lila', 'user-1');
+    const second = await loader.loadPersonality('lila', 'user-1');
+
+    expect(first?.id).toBe('pers-1');
+    expect(second?.id).toBe('pers-1');
+    expect(mockServiceClient.loadPersonalityInternal).toHaveBeenCalledTimes(1);
+    expect(mockServiceClient.loadPersonalityInternal).toHaveBeenCalledWith({
+      nameOrId: 'lila',
+      userId: 'user-1',
+    });
+  });
+
+  it('caches definitive misses (negative cache) — no repeat hop per probe', async () => {
+    mockServiceClient.loadPersonalityInternal.mockResolvedValue(ok({ personality: null }));
+
+    expect(await loader.loadPersonality('everyone', 'user-1')).toBeNull();
+    expect(await loader.loadPersonality('everyone', 'user-1')).toBeNull();
+
+    expect(mockServiceClient.loadPersonalityInternal).toHaveBeenCalledTimes(1);
+  });
+
+  it('expires positive entries after the 5-minute TTL and re-fetches', async () => {
+    mockServiceClient.loadPersonalityInternal.mockResolvedValue(ok({ personality: PERSONALITY }));
+    await loader.loadPersonality('lila', 'user-1');
+
+    clock += TIMEOUTS.CACHE_TTL + 1000;
+    await loader.loadPersonality('lila', 'user-1');
+
+    expect(mockServiceClient.loadPersonalityInternal).toHaveBeenCalledTimes(2);
+  });
+
+  it('expires negative entries after 60s so new personalities appear quickly', async () => {
+    mockServiceClient.loadPersonalityInternal.mockResolvedValue(ok({ personality: null }));
+    await loader.loadPersonality('soon-to-exist', 'user-1');
+
+    clock += NEGATIVE_TTL_MS + 1000;
+    mockServiceClient.loadPersonalityInternal.mockResolvedValue(ok({ personality: PERSONALITY }));
+
+    const result = await loader.loadPersonality('soon-to-exist', 'user-1');
+    expect(result?.id).toBe('pers-1');
+    expect(mockServiceClient.loadPersonalityInternal).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT negative-cache transport errors (a gateway blip must not blind routing)', async () => {
+    mockServiceClient.loadPersonalityInternal.mockResolvedValueOnce(err(503));
+    expect(await loader.loadPersonality('lila', 'user-1')).toBeNull();
+
+    mockServiceClient.loadPersonalityInternal.mockResolvedValueOnce(
+      ok({ personality: PERSONALITY })
+    );
+    const retry = await loader.loadPersonality('lila', 'user-1');
+
+    expect(retry?.id).toBe('pers-1');
+    expect(mockServiceClient.loadPersonalityInternal).toHaveBeenCalledTimes(2);
+  });
+
+  it('keys the cache by userId — access control results are not shared across users', async () => {
+    // user-1 can see it; user-2 cannot (server-side access control).
+    mockServiceClient.loadPersonalityInternal
+      .mockResolvedValueOnce(ok({ personality: PERSONALITY }))
+      .mockResolvedValueOnce(ok({ personality: null }));
+
+    expect(await loader.loadPersonality('lila', 'user-1')).not.toBeNull();
+    expect(await loader.loadPersonality('lila', 'user-2')).toBeNull();
+    // And the cached answers stay per-user:
+    expect(await loader.loadPersonality('lila', 'user-1')).not.toBeNull();
+    expect(await loader.loadPersonality('lila', 'user-2')).toBeNull();
+
+    expect(mockServiceClient.loadPersonalityInternal).toHaveBeenCalledTimes(2);
+  });
+
+  it('keys case-insensitively on the name', async () => {
+    mockServiceClient.loadPersonalityInternal.mockResolvedValue(ok({ personality: PERSONALITY }));
+
+    await loader.loadPersonality('Lila', 'user-1');
+    await loader.loadPersonality('lila', 'user-1');
+
+    expect(mockServiceClient.loadPersonalityInternal).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidatePersonality clears both tiers (pub/sub-driven)', async () => {
+    mockServiceClient.loadPersonalityInternal.mockResolvedValue(ok({ personality: PERSONALITY }));
+    await loader.loadPersonality('lila', 'user-1');
+
+    loader.invalidatePersonality('pers-1');
+    await loader.loadPersonality('lila', 'user-1');
+
+    expect(mockServiceClient.loadPersonalityInternal).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidateAll clears negative entries too', async () => {
+    mockServiceClient.loadPersonalityInternal.mockResolvedValue(ok({ personality: null }));
+    await loader.loadPersonality('ghost', 'user-1');
+
+    loader.invalidateAll();
+    mockServiceClient.loadPersonalityInternal.mockResolvedValue(ok({ personality: PERSONALITY }));
+
+    const result = await loader.loadPersonality('ghost', 'user-1');
+    expect(result?.id).toBe('pers-1');
+  });
+});

--- a/services/bot-client/src/services/HttpPersonalityLoader.ts
+++ b/services/bot-client/src/services/HttpPersonalityLoader.ts
@@ -1,0 +1,131 @@
+/**
+ * HTTP-backed personality loader (Phase 2.5c-ii).
+ *
+ * Implements IPersonalityLoader over the gateway's internal
+ * `GET /api/internal/personality/load` route — the service-mode replacement
+ * for the Prisma-backed PersonalityService/PersonalityIdCache stack on
+ * bot-client's routing paths (mention parsing, reply resolution, channel
+ * activation, multi-tag recovery, /character chat).
+ *
+ * Caching is load-bearing here, not an optimization: PersonalityService
+ * skips its own cache whenever a userId is present (access control is
+ * re-checked per load), so every routing probe is a fresh lookup. Over HTTP
+ * that would mean one gateway hop per mention-parse candidate per message.
+ * Two cache tiers, keyed by (userId, nameOrId):
+ *
+ * - **Positive** (5 min): resolved personalities. Same TTL the legacy
+ *   PersonalityIdCache tolerates for renames. Config changes invalidate
+ *   eagerly via the personality pub/sub channel (see invalidate methods).
+ * - **Negative** (60 s): definitive misses — the common case during mention
+ *   parsing, where most `@word` candidates are not personalities. Shorter
+ *   TTL so newly-created or renamed personalities appear quickly. Transport
+ *   errors are NEVER negative-cached — a gateway blip must not blind
+ *   routing for 60 s.
+ */
+
+import {
+  createLogger,
+  TIMEOUTS,
+  TTLCache,
+  type LoadedPersonality,
+  type PersonalityCacheTarget,
+} from '@tzurot/common-types';
+import type { IPersonalityLoader } from '../types/IPersonalityLoader.js';
+import { getServiceClient } from '../utils/gatewayClients.js';
+
+const logger = createLogger('HttpPersonalityLoader');
+
+/**
+ * Definitive misses expire fast so new/renamed personalities appear quickly.
+ * Exported so tests advance the injected clock against the real value rather
+ * than a duplicated literal.
+ */
+export const NEGATIVE_TTL_MS = 60 * 1000;
+/** Distinct (user, personality) pairs actively routing at once. */
+const POSITIVE_MAX_SIZE = 500;
+/** Misses dominate (most mention candidates aren't personalities) — bigger cap. */
+const NEGATIVE_MAX_SIZE = 2000;
+
+export class HttpPersonalityLoader implements IPersonalityLoader, PersonalityCacheTarget {
+  private readonly positiveCache: TTLCache<LoadedPersonality>;
+  private readonly negativeCache: TTLCache<true>;
+
+  /**
+   * @param options.now - Test-only clock injection, threaded into TTLCache
+   * (lru-cache snapshots performance.now at module load, so vitest fake
+   * timers can't advance cache TTLs without it).
+   */
+  constructor(options: { now?: () => number } = {}) {
+    this.positiveCache = new TTLCache<LoadedPersonality>({
+      ttl: TIMEOUTS.CACHE_TTL,
+      maxSize: POSITIVE_MAX_SIZE,
+      now: options.now,
+    });
+    this.negativeCache = new TTLCache<true>({
+      ttl: NEGATIVE_TTL_MS,
+      maxSize: NEGATIVE_MAX_SIZE,
+      now: options.now,
+    });
+  }
+
+  /**
+   * Access control happens server-side (the endpoint applies
+   * loadPersonality's public-or-owned semantics), so the cache key must
+   * carry the userId — the same nameOrId can legitimately resolve for one
+   * user and miss for another.
+   */
+  private cacheKey(nameOrId: string, userId?: string): string {
+    return `${userId ?? ''}::${nameOrId.toLowerCase()}`;
+  }
+
+  async loadPersonality(nameOrId: string, userId?: string): Promise<LoadedPersonality | null> {
+    const key = this.cacheKey(nameOrId, userId);
+
+    const cached = this.positiveCache.get(key);
+    if (cached !== null) {
+      return cached;
+    }
+    if (this.negativeCache.get(key) !== null) {
+      return null;
+    }
+
+    const result = await getServiceClient().loadPersonalityInternal({ nameOrId, userId });
+    if (!result.ok) {
+      // Transport/server error — NOT a definitive miss. Return null for this
+      // call (routing treats unknown as no-match, same as legacy DB errors)
+      // but don't cache it.
+      logger.warn({ status: result.status }, 'Personality load via gateway failed');
+      return null;
+    }
+
+    const personality = result.data.personality;
+    if (personality === null) {
+      this.negativeCache.set(key, true);
+      return null;
+    }
+
+    this.positiveCache.set(key, personality);
+    return personality;
+  }
+
+  /**
+   * Invalidation drops BOTH tiers entirely rather than hunting matching
+   * entries: the caches are keyed by (userId, nameOrId) while invalidation
+   * events carry a personality id, so a precise mapping isn't available.
+   * The caches are small and rebuild in one round-trip per active probe.
+   */
+  invalidatePersonality(personalityId: string): void {
+    this.positiveCache.clear();
+    this.negativeCache.clear();
+    logger.debug(
+      { personalityId },
+      'Personality invalidation event received; full routing-cache clear applied'
+    );
+  }
+
+  invalidateAll(): void {
+    this.positiveCache.clear();
+    this.negativeCache.clear();
+    logger.debug('Full personality invalidation; routing caches cleared');
+  }
+}

--- a/services/bot-client/src/services/serviceRegistry.ts
+++ b/services/bot-client/src/services/serviceRegistry.ts
@@ -11,11 +11,11 @@
  */
 
 import type {
-  PersonalityService,
   ConversationHistoryService,
   PersonaResolver,
   ChannelActivationCacheInvalidationService,
 } from '@tzurot/common-types';
+import type { IPersonalityLoader } from '../types/IPersonalityLoader.js';
 import type { JobTracker } from './JobTracker.js';
 import type { WebhookManager } from '../utils/WebhookManager.js';
 import type { MessageContextBuilder } from './MessageContextBuilder.js';
@@ -25,7 +25,7 @@ import type { DenylistCache } from './DenylistCache.js';
 // Service references - set during app initialization
 let jobTracker: JobTracker | undefined;
 let webhookManager: WebhookManager | undefined;
-let personalityService: PersonalityService | undefined;
+let personalityService: IPersonalityLoader | undefined;
 let conversationHistoryService: ConversationHistoryService | undefined;
 let personaResolver: PersonaResolver | undefined;
 let channelActivationCacheInvalidationService:
@@ -41,7 +41,7 @@ let denylistCache: DenylistCache | undefined;
 interface RegisteredServices {
   jobTracker: JobTracker;
   webhookManager: WebhookManager;
-  personalityService: PersonalityService;
+  personalityService: IPersonalityLoader;
   conversationHistoryService: ConversationHistoryService;
   personaResolver: PersonaResolver;
   channelActivationCacheInvalidationService: ChannelActivationCacheInvalidationService;
@@ -89,10 +89,11 @@ export function getWebhookManager(): WebhookManager {
 }
 
 /**
- * Get the PersonalityService instance
+ * Get the routing personality loader. Prisma-backed PersonalityService in
+ * legacy mode; the gateway-backed HttpPersonalityLoader in CONTEXT_MODE=service.
  * @throws Error if services not registered
  */
-export function getPersonalityService(): PersonalityService {
+export function getPersonalityService(): IPersonalityLoader {
   if (personalityService === undefined) {
     throw new Error('PersonalityService not registered. Call registerServices() first.');
   }


### PR DESCRIPTION
## Summary

Second slice of the 2.5c cutover. In `CONTEXT_MODE=service`, all routing-path personality resolution — mention parsing, reply resolution, channel activation, multi-tag recovery, and `/character chat` — goes through the new **`HttpPersonalityLoader`** over the 2.5b `GET /internal/personality/load` endpoint instead of direct Prisma. Legacy mode preserves today's wiring exactly (two distinct injection variables keep the name→ID-cached sites and raw-service sites on their current paths).

### Why the cache design is load-bearing, not an optimization

`PersonalityService` skips its TTL cache whenever a `userId` is present (access control is re-checked per load) — so **every routing probe is a fresh lookup today**, and mention parsing probes every `@word` candidate per message. Over HTTP that's a gateway hop per candidate. The loader carries two tiers keyed by `(userId, nameOrId.toLowerCase())`:

- **Positive, 5 min** — same staleness the legacy `PersonalityIdCache` already tolerates; config changes invalidate eagerly (below)
- **Negative, 60 s** — definitive misses only (the dominant case in mention parsing); short so new/renamed personalities appear quickly
- **Transport errors are never negative-cached** — a gateway blip must not blind routing for 60s

### Invalidation

`CacheInvalidationService`'s target type widened from concrete `PersonalityService` to a minimal `PersonalityCacheTarget` interface (common-types; `PersonalityService` satisfies it structurally, zero behavior change for existing consumers). In service mode the pub/sub events drive the HTTP loader's tiers; in legacy mode, `PersonalityService`'s cache as today. Per-ID invalidation clears both tiers wholesale — the caches are name-keyed while events carry IDs, and they rebuild in one round-trip per active probe.

### Plumbing

- `composition.ts`: `buildProcessorChain`/`buildMessageHandler` widen `personalityIdCache: PersonalityIdCache` → `personalityLoader: IPersonalityLoader` (every downstream constructor already took the interface)
- `serviceRegistry`: `personalityService` slot widened to `IPersonalityLoader` (sole interface consumer: `/character chat`'s resolve)
- `index.ts`: mode-switched construction; legacy wiring byte-identical

### Test plan

- 8 loader tests: positive/negative caching, 60s negative expiry (injectable clock — lru-cache snapshots `performance.now`, fake timers can't reach it), error-no-cache, per-user keying, case-insensitive keying, both invalidation paths
- Full bot-client suite 4982 green, common-types 2630 green, `pnpm quality` clean

### Next

2.5c-iii: hydration cutover (thin envelopes, in-job context assembly) — gets its own scoping pass first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)