### PR TITLE
feat(api-gateway): PR 2.5c-iii-0 — user-message persist endpoint + mode cutover

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,11 +130,13 @@ ENABLE_FREE_WILL=false  # LangGraph orchestrator (not yet implemented)
 CONTEXT_SHADOW_HYDRATION=false
 
 # Context-path mode (bot-client): "legacy" (default) = local Prisma owns the
-# Discord-event writes (assistant persist, edit/delete sync) AND the routing
-# personality reads (mention parsing, reply resolution, activation);
-# "service" = the api-gateway internal endpoints own both — writes go to the
-# conversation endpoints, routing reads go through /internal/personality/load
-# with positive/negative caching. Rollback = flip back to legacy + restart.
+# Discord-event writes (user-message persist, assistant persist, edit/delete
+# sync) AND the routing personality reads (mention parsing, reply resolution,
+# activation); "service" = the api-gateway internal endpoints own both —
+# writes go to the conversation endpoints, routing reads go through
+# /internal/personality/load with positive/negative caching. The vision-
+# description update is transitional local-Prisma in both modes until the
+# hydration cutover. Rollback = flip back to legacy + restart.
 CONTEXT_MODE=legacy
 
 # Context dual-write (bot-client, legacy mode only): mirrors conversation

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "knip": "knip",
     "knip:fix": "knip --fix",
     "knip:dead": "tsx packages/tooling/src/cli.ts dev:dead-files",
-    "quality": "pnpm lint && pnpm ops codegen:routes --check && pnpm knip && pnpm cpd && pnpm ops cpd:check && pnpm depcruise && pnpm typecheck && pnpm typecheck:spec",
+    "quality": "pnpm lint && pnpm ops codegen:routes --check && pnpm knip && pnpm cpd && pnpm ops cpd:check && pnpm ops test:audit && pnpm depcruise && pnpm typecheck && pnpm typecheck:spec",
     "focus:lint": "pnpm ops dev:lint",
     "focus:test": "pnpm ops dev:test",
     "focus:build": "pnpm ops dev:focus build",

--- a/packages/clients/src/clients/_generated/service-client.ts
+++ b/packages/clients/src/clients/_generated/service-client.ts
@@ -133,6 +133,19 @@ export class ServiceClient {
     });
   }
 
+  async persistUserMessage(input: z.infer<typeof ROUTE_MANIFEST.persistUserMessage.input>): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.persistUserMessage.output>>> {
+    const fullPath = '/api/internal/conversation/user-message';
+    return callGateway({
+      baseUrl: this.baseUrl,
+      serviceSecret: this.serviceSecret,
+      method: 'POST',
+      path: fullPath,
+      body: input,
+      outputSchema: ROUTE_MANIFEST.persistUserMessage.output,
+      timeoutMs: ROUTE_MANIFEST.persistUserMessage.timeoutMs,
+    });
+  }
+
   async syncConversation(input: z.infer<typeof ROUTE_MANIFEST.syncConversation.input>): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.syncConversation.output>>> {
     const fullPath = '/api/internal/conversation/sync';
     return callGateway({

--- a/packages/clients/src/routes/internal.ts
+++ b/packages/clients/src/routes/internal.ts
@@ -33,6 +33,8 @@ import {
   MessagePersonalityResponseSchema,
   PersistAssistantMessageRequestSchema,
   PersistAssistantMessageResponseSchema,
+  PersistUserMessageRequestSchema,
+  PersistUserMessageResponseSchema,
   RecentUsersResponseSchema,
   TIMEOUTS,
   TranscribeRequestSchema,
@@ -164,6 +166,25 @@ export const internalRoutes = {
     id: 'persistAssistantMessage',
     input: PersistAssistantMessageRequestSchema,
     output: PersistAssistantMessageResponseSchema,
+    serviceOnly: true,
+    timeoutMs: TIMEOUTS.GATEWAY_RPC,
+  },
+
+  /**
+   * POST /api/internal/conversation/user-message
+   * Bot-client persists the trigger user message synchronously BEFORE job
+   * submission (a user message is a Discord event — the gateway is the
+   * Discord-event data authority; pre-submission ordering means the next
+   * message's history query always sees this row). Idempotent
+   * upsert-with-compare, mirroring the assistant-message endpoint.
+   */
+  persistUserMessage: {
+    audience: 'internal',
+    method: 'post',
+    path: '/conversation/user-message',
+    id: 'persistUserMessage',
+    input: PersistUserMessageRequestSchema,
+    output: PersistUserMessageResponseSchema,
     serviceOnly: true,
     timeoutMs: TIMEOUTS.GATEWAY_RPC,
   },

--- a/packages/common-types/src/schemas/api/internal.test.ts
+++ b/packages/common-types/src/schemas/api/internal.test.ts
@@ -7,6 +7,8 @@ import {
   MessagePersonalityResponseSchema,
   PersistAssistantMessageRequestSchema,
   PersistAssistantMessageResponseSchema,
+  PersistUserMessageRequestSchema,
+  PersistUserMessageResponseSchema,
   ConversationSyncRequestSchema,
   ConversationSyncResponseSchema,
   LoadPersonalityInternalResponseSchema,
@@ -257,6 +259,99 @@ describe('PersistAssistantMessageResponseSchema', () => {
         matched: false,
       }).success
     ).toBe(true);
+  });
+});
+
+const VALID_USER_PERSIST_REQUEST = {
+  channelId: '123456789012345678',
+  guildId: '876543210987654321',
+  personalityId: '550e8400-e29b-41d4-a716-446655440000',
+  personaId: '550e8400-e29b-41d4-a716-446655440001',
+  content: 'Hello bot!\n\n[Image: cat.png]',
+  discordMessageId: '111111111111111111',
+  messageTime: '2026-06-04T12:00:00.000Z',
+};
+
+describe('PersistUserMessageRequestSchema', () => {
+  it('accepts a metadata-free request (plain text message)', () => {
+    expect(PersistUserMessageRequestSchema.safeParse(VALID_USER_PERSIST_REQUEST).success).toBe(
+      true
+    );
+  });
+
+  it('accepts structured messageMetadata (references + forwarded flag)', () => {
+    expect(
+      PersistUserMessageRequestSchema.safeParse({
+        ...VALID_USER_PERSIST_REQUEST,
+        messageMetadata: {
+          isForwarded: true,
+          referencedMessages: [
+            {
+              discordMessageId: '222222222222222222',
+              authorUsername: 'other',
+              authorDisplayName: 'Other User',
+              content: 'referenced text',
+              timestamp: '2026-06-04T11:59:00.000Z',
+              locationContext: 'same-channel',
+            },
+          ],
+        },
+      }).success
+    ).toBe(true);
+  });
+
+  it('accepts null guildId (DM messages)', () => {
+    expect(
+      PersistUserMessageRequestSchema.safeParse({ ...VALID_USER_PERSIST_REQUEST, guildId: null })
+        .success
+    ).toBe(true);
+  });
+
+  it('rejects empty content', () => {
+    expect(
+      PersistUserMessageRequestSchema.safeParse({ ...VALID_USER_PERSIST_REQUEST, content: '' })
+        .success
+    ).toBe(false);
+  });
+
+  it('rejects a non-snowflake discordMessageId', () => {
+    expect(
+      PersistUserMessageRequestSchema.safeParse({
+        ...VALID_USER_PERSIST_REQUEST,
+        discordMessageId: 'nope',
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects non-ISO messageTime', () => {
+    expect(
+      PersistUserMessageRequestSchema.safeParse({
+        ...VALID_USER_PERSIST_REQUEST,
+        messageTime: 'yesterday',
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe('PersistUserMessageResponseSchema', () => {
+  it('accepts a created response without matched', () => {
+    expect(
+      PersistUserMessageResponseSchema.safeParse({ id: 'row-uuid', created: true }).success
+    ).toBe(true);
+  });
+
+  it('accepts an existing-row response with matched', () => {
+    expect(
+      PersistUserMessageResponseSchema.safeParse({
+        id: 'row-uuid',
+        created: false,
+        matched: false,
+      }).success
+    ).toBe(true);
+  });
+
+  it('rejects a response missing created', () => {
+    expect(PersistUserMessageResponseSchema.safeParse({ id: 'row-uuid' }).success).toBe(false);
   });
 });
 

--- a/packages/common-types/src/schemas/api/internal.ts
+++ b/packages/common-types/src/schemas/api/internal.ts
@@ -7,6 +7,7 @@
 
 import { z } from 'zod';
 import { loadedPersonalitySchema } from '../../types/schemas/personality.js';
+import { messageMetadataSchema } from '../../types/schemas/message.js';
 import { SYNC_LIMITS } from '../../constants/timing.js';
 
 // ============================================================================
@@ -107,6 +108,43 @@ export const PersistAssistantMessageResponseSchema = z.object({
   matched: z.boolean().optional(),
 });
 export type PersistAssistantMessageResponse = z.infer<typeof PersistAssistantMessageResponseSchema>;
+
+// ============================================================================
+// POST /internal/conversation/user-message
+// Persists the trigger user message BEFORE job submission. A user message is
+// a Discord event, so the gateway (the Discord-event data authority) owns the
+// write — called synchronously by bot-client pre-submission, which preserves
+// strict ordering (the next message's history query always sees this row)
+// with no locks. Content arrives final (text + attachment placeholders —
+// placeholder assembly is Discord-domain and stays bot-side); the gateway
+// derives the deterministic row UUID and token count from what it persists.
+// Idempotent upsert-with-compare, same dual-write semantics as the
+// assistant-message endpoint.
+// ============================================================================
+
+export const PersistUserMessageRequestSchema = z.object({
+  channelId: z.string().min(1),
+  guildId: z.string().nullable(),
+  personalityId: z.string().uuid(),
+  personaId: z.string().uuid(),
+  /** Final content: user text + attachment placeholders, assembled bot-side. */
+  content: z.string().min(1),
+  /** The triggering Discord message ID. */
+  discordMessageId: DiscordSnowflakeSchema,
+  /** Structured references / forwarded flags / embed XML — the stored shape. */
+  messageMetadata: messageMetadataSchema.optional(),
+  /** ISO timestamp of the Discord message (becomes the row's createdAt). */
+  messageTime: z.string().datetime(),
+});
+export type PersistUserMessageRequest = z.infer<typeof PersistUserMessageRequestSchema>;
+
+/** Shape intentionally identical to the assistant-message response. */
+export const PersistUserMessageResponseSchema = z.object({
+  id: z.string(),
+  created: z.boolean(),
+  matched: z.boolean().optional(),
+});
+export type PersistUserMessageResponse = z.infer<typeof PersistUserMessageResponseSchema>;
 
 // ============================================================================
 // POST /internal/conversation/sync

--- a/packages/tooling/src/codegen/handler-paths.ts
+++ b/packages/tooling/src/codegen/handler-paths.ts
@@ -122,6 +122,7 @@ const PATH_MAP: Readonly<Record<string, string>> = {
   setDmSession: '../internal/dmSessionSet.js',
   lookupPersonalityFromMessage: '../user/conversationLookup.js',
   persistAssistantMessage: '../internal/conversationAssistantMessage.js',
+  persistUserMessage: '../internal/conversationUserMessage.js',
   syncConversation: '../internal/conversationSync.js',
   loadPersonalityInternal: '../internal/personalityLoad.js',
 

--- a/services/api-gateway/src/routes/_generated/mounts.ts
+++ b/services/api-gateway/src/routes/_generated/mounts.ts
@@ -38,6 +38,7 @@ import { handleAiConfirmDelivery } from '../ai/confirmDelivery.js';
 import { handleSetDmSession } from '../internal/dmSessionSet.js';
 import { handleLookupPersonalityFromMessage } from '../user/conversationLookup.js';
 import { handlePersistAssistantMessage } from '../internal/conversationAssistantMessage.js';
+import { handlePersistUserMessage } from '../internal/conversationUserMessage.js';
 import { handleSyncConversation } from '../internal/conversationSync.js';
 import { handleLoadPersonalityInternal } from '../internal/personalityLoad.js';
 import { handleRecentUsers } from '../internal/usersRecent.js';
@@ -102,6 +103,7 @@ export function mountInternalRoutes(app: Express, deps: RouteDeps): void {
   app.post('/api/internal/channel/dm-session/set', handleSetDmSession(deps));
   app.get('/api/internal/conversation/message-personality', handleLookupPersonalityFromMessage(deps));
   app.post('/api/internal/conversation/assistant-message', handlePersistAssistantMessage(deps));
+  app.post('/api/internal/conversation/user-message', handlePersistUserMessage(deps));
   app.post('/api/internal/conversation/sync', handleSyncConversation(deps));
   app.get('/api/internal/personality/load', handleLoadPersonalityInternal(deps));
   app.get('/api/internal/users/recent', handleRecentUsers(deps));

--- a/services/api-gateway/src/routes/internal/conversationUserMessage.test.ts
+++ b/services/api-gateway/src/routes/internal/conversationUserMessage.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for POST /internal/conversation/user-message
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import {
+  generateConversationHistoryUuid,
+  MessageRole,
+  type PrismaClient,
+} from '@tzurot/common-types';
+import { handlePersistUserMessage } from './conversationUserMessage.js';
+
+vi.mock('@tzurot/common-types', async () => {
+  const actual = await vi.importActual('@tzurot/common-types');
+  return {
+    ...actual,
+    createLogger: () => ({
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+const VALID_BODY = {
+  channelId: '123456789012345678',
+  guildId: '876543210987654321',
+  personalityId: '550e8400-e29b-41d4-a716-446655440000',
+  personaId: '550e8400-e29b-41d4-a716-446655440001',
+  content: 'Hello bot!\n\n[Image: cat.png]',
+  discordMessageId: '111111111111111111',
+  messageMetadata: {
+    referencedMessages: [
+      {
+        discordMessageId: '222222222222222222',
+        authorUsername: 'other',
+        authorDisplayName: 'Other User',
+        content: 'referenced text',
+        timestamp: '2026-06-04T11:59:00.000Z',
+        locationContext: 'same-channel',
+      },
+    ],
+  },
+  messageTime: '2026-06-04T12:00:00.000Z',
+};
+
+// The id the handler must derive: same generator, createdAt = messageTime.
+const EXPECTED_ID = generateConversationHistoryUuid(
+  VALID_BODY.channelId,
+  VALID_BODY.personalityId,
+  VALID_BODY.personaId,
+  new Date(VALID_BODY.messageTime)
+);
+
+describe('POST /internal/conversation/user-message', () => {
+  let mockPrisma: {
+    conversationHistory: {
+      findUnique: ReturnType<typeof vi.fn>;
+      create: ReturnType<typeof vi.fn>;
+    };
+  };
+  let app: express.Express;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma = {
+      conversationHistory: {
+        findUnique: vi.fn().mockResolvedValue(null),
+        create: vi.fn().mockResolvedValue({}),
+      },
+    };
+    app = express();
+    app.use(express.json());
+    app.post(
+      '/internal/conversation/user-message',
+      handlePersistUserMessage({ prisma: mockPrisma as unknown as PrismaClient })
+    );
+  });
+
+  it('creates the row with the deterministic id, message timestamp, and metadata', async () => {
+    const response = await request(app)
+      .post('/internal/conversation/user-message')
+      .send(VALID_BODY);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ id: EXPECTED_ID, created: true });
+
+    const createCall = mockPrisma.conversationHistory.create.mock.calls[0][0];
+    expect(createCall.data.id).toBe(EXPECTED_ID);
+    expect(createCall.data.role).toBe(MessageRole.User);
+    expect(createCall.data.discordMessageId).toEqual([VALID_BODY.discordMessageId]);
+    expect(createCall.data.createdAt).toEqual(new Date(VALID_BODY.messageTime));
+    expect(createCall.data.messageMetadata.referencedMessages).toHaveLength(1);
+    expect(createCall.data.tokenCount).toBeGreaterThan(0);
+  });
+
+  it('accepts a metadata-free request (plain text message)', async () => {
+    const { messageMetadata: _omitted, ...bare } = VALID_BODY;
+
+    const response = await request(app).post('/internal/conversation/user-message').send(bare);
+
+    expect(response.status).toBe(200);
+    expect(response.body.created).toBe(true);
+  });
+
+  it('reports matched=true without writing when an identical row exists (dual-write)', async () => {
+    mockPrisma.conversationHistory.findUnique.mockResolvedValue({
+      content: VALID_BODY.content,
+      discordMessageId: [VALID_BODY.discordMessageId],
+    });
+
+    const response = await request(app)
+      .post('/internal/conversation/user-message')
+      .send(VALID_BODY);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ id: EXPECTED_ID, created: false, matched: true });
+    expect(mockPrisma.conversationHistory.create).not.toHaveBeenCalled();
+  });
+
+  it('reports matched=false when the existing row diverges (burn-in signal)', async () => {
+    mockPrisma.conversationHistory.findUnique.mockResolvedValue({
+      content: 'different content',
+      discordMessageId: [VALID_BODY.discordMessageId],
+    });
+
+    const response = await request(app)
+      .post('/internal/conversation/user-message')
+      .send(VALID_BODY);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ id: EXPECTED_ID, created: false, matched: false });
+  });
+
+  it('recovers from a create race by comparing against the winner', async () => {
+    mockPrisma.conversationHistory.findUnique.mockResolvedValueOnce(null).mockResolvedValueOnce({
+      content: VALID_BODY.content,
+      discordMessageId: [VALID_BODY.discordMessageId],
+    });
+    mockPrisma.conversationHistory.create.mockRejectedValue(
+      Object.assign(new Error('Unique constraint failed'), { code: 'P2002' })
+    );
+
+    const response = await request(app)
+      .post('/internal/conversation/user-message')
+      .send(VALID_BODY);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ id: EXPECTED_ID, created: false, matched: true });
+  });
+
+  it('surfaces non-P2002 create failures as 500', async () => {
+    mockPrisma.conversationHistory.create.mockRejectedValue(
+      Object.assign(new Error('FK violation'), { code: 'P2003' })
+    );
+
+    const response = await request(app)
+      .post('/internal/conversation/user-message')
+      .send(VALID_BODY);
+
+    expect(response.status).toBe(500);
+    expect(mockPrisma.conversationHistory.findUnique).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects empty content with 400', async () => {
+    const response = await request(app)
+      .post('/internal/conversation/user-message')
+      .send({ ...VALID_BODY, content: '' });
+
+    expect(response.status).toBe(400);
+    expect(mockPrisma.conversationHistory.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-snowflake discordMessageId with 400', async () => {
+    const response = await request(app)
+      .post('/internal/conversation/user-message')
+      .send({ ...VALID_BODY, discordMessageId: 'nope' });
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/services/api-gateway/src/routes/internal/conversationUserMessage.ts
+++ b/services/api-gateway/src/routes/internal/conversationUserMessage.ts
@@ -1,0 +1,118 @@
+/**
+ * POST /internal/conversation/user-message
+ *
+ * Persists the trigger user message before job submission. A user message is
+ * a Discord event, so this gateway (the Discord-event data authority) owns
+ * the write — bot-client calls it synchronously pre-submission, preserving
+ * strict ordering (the next message's history query always sees this row)
+ * with no locks. Delegates to ConversationHistoryService.addMessage — the
+ * same code path bot-client's legacy direct write uses — so the two paths
+ * produce identical rows by construction during the dual-write window.
+ *
+ * Idempotent: when the row already exists (legacy write is authoritative
+ * during dual-write), compares instead of writing and reports `matched`;
+ * `matched: false` is the burn-in divergence signal. A create race against
+ * the legacy writer (P2002) falls back to compare; other errors surface.
+ *
+ * **Authentication**: `X-Service-Auth` enforcement happens upstream via the
+ * global `requireServiceAuth()` on `/internal/*` in api-gateway's index.
+ */
+
+import { type Response, type RequestHandler } from 'express';
+import {
+  createLogger,
+  generateConversationHistoryUuid,
+  ConversationHistoryService,
+  MessageRole,
+  PersistUserMessageRequestSchema,
+  type PersistUserMessageResponse,
+} from '@tzurot/common-types';
+import { asyncHandler } from '../../utils/asyncHandler.js';
+import { sendCustomSuccess } from '../../utils/responseHelpers.js';
+import { sendZodError } from '../../utils/zodHelpers.js';
+import type { RouteDeps } from '../routeDeps.js';
+
+const logger = createLogger('internal-conversation-user-message');
+
+/** POST /api/internal/conversation/user-message — persist the trigger user message. */
+export const handlePersistUserMessage = (deps: RouteDeps): RequestHandler => {
+  const { prisma } = deps;
+  const historyService = new ConversationHistoryService(prisma);
+
+  return asyncHandler(async (req, res: Response) => {
+    const parseResult = PersistUserMessageRequestSchema.safeParse(req.body);
+    if (!parseResult.success) {
+      sendZodError(res, parseResult.error);
+      return;
+    }
+    const { channelId, guildId, personalityId, personaId, content, discordMessageId } =
+      parseResult.data;
+    const messageMetadata = parseResult.data.messageMetadata;
+
+    // The row's createdAt is the Discord message timestamp (preserves the
+    // user < assistant(+1ms) ordering invariant); the deterministic UUID is
+    // a pure function of what the gateway persists.
+    const createdAt = new Date(parseResult.data.messageTime);
+    const id = generateConversationHistoryUuid(channelId, personalityId, personaId, createdAt);
+
+    const compareExisting = async (): Promise<PersistUserMessageResponse | null> => {
+      const existing = await prisma.conversationHistory.findUnique({
+        where: { id },
+        select: { content: true, discordMessageId: true },
+      });
+      if (existing === null) {
+        return null;
+      }
+      // Deliberately lightweight: content + trigger id only. Both write paths
+      // construct messageMetadata from the same bot-side object, so metadata
+      // divergence could only come from serialization differences — not worth
+      // a deep JSONB comparison for the burn-in signal.
+      const matched =
+        existing.content === content && existing.discordMessageId[0] === discordMessageId;
+      if (!matched) {
+        logger.warn(
+          { id, channelId, contentMatch: existing.content === content },
+          'User-message dual-write DIVERGED from existing row'
+        );
+      }
+      return { id, created: false, matched };
+    };
+
+    const preExisting = await compareExisting();
+    if (preExisting !== null) {
+      sendCustomSuccess(res, preExisting);
+      return;
+    }
+
+    try {
+      await historyService.addMessage({
+        channelId,
+        personalityId,
+        personaId,
+        role: MessageRole.User,
+        content,
+        guildId,
+        discordMessageId,
+        messageMetadata,
+        timestamp: createdAt,
+      });
+    } catch (error) {
+      // Only the unique-violation race gets the compare fallback (the legacy
+      // writer landed between our existence check and the create); any other
+      // failure must surface rather than be masked by a coincidental row.
+      const isRace = (error as { code?: string }).code === 'P2002';
+      if (!isRace) {
+        throw error;
+      }
+      const raced = await compareExisting();
+      if (raced !== null) {
+        sendCustomSuccess(res, raced);
+        return;
+      }
+      throw error;
+    }
+
+    logger.debug({ id, channelId }, 'User message persisted');
+    sendCustomSuccess(res, { id, created: true } satisfies PersistUserMessageResponse);
+  });
+};

--- a/services/bot-client/src/services/ConversationPersistence.test.ts
+++ b/services/bot-client/src/services/ConversationPersistence.test.ts
@@ -48,12 +48,16 @@ vi.mock('../utils/MessageContentBuilder.js', () => ({
 vi.mock('../utils/contextWritePath.js', () => ({
   dualWritePersistAssistantMessage: vi.fn().mockResolvedValue(undefined),
   persistAssistantMessageViaGateway: vi.fn().mockResolvedValue(undefined),
+  dualWritePersistUserMessage: vi.fn().mockResolvedValue(undefined),
+  persistUserMessageViaGateway: vi.fn().mockResolvedValue(undefined),
   getContextMode: vi.fn(() => 'legacy'),
 }));
 
 import {
   dualWritePersistAssistantMessage,
   persistAssistantMessageViaGateway,
+  dualWritePersistUserMessage,
+  persistUserMessageViaGateway,
   getContextMode,
 } from '../utils/contextWritePath.js';
 
@@ -113,7 +117,7 @@ describe('ConversationPersistence', () => {
         guildId: 'guild-123',
         discordMessageId: 'discord-msg-123',
         messageMetadata: undefined, // no references
-        timestamp: mockMessage.createdAt,
+        timestamp: expect.any(Date),
       });
     });
 
@@ -172,6 +176,7 @@ describe('ConversationPersistence', () => {
         guildId: null,
         discordMessageId: 'discord-msg-123',
         messageMetadata: undefined,
+        timestamp: expect.any(Date),
       });
     });
 
@@ -201,6 +206,7 @@ describe('ConversationPersistence', () => {
         guildId: 'guild-123',
         discordMessageId: 'discord-msg-123',
         messageMetadata: undefined, // no references
+        timestamp: expect.any(Date),
       });
     });
 
@@ -257,6 +263,7 @@ describe('ConversationPersistence', () => {
             },
           ],
         },
+        timestamp: expect.any(Date),
       });
     });
 
@@ -286,6 +293,7 @@ describe('ConversationPersistence', () => {
         guildId: 'guild-123',
         discordMessageId: 'discord-msg-fwd',
         messageMetadata: { isForwarded: true },
+        timestamp: expect.any(Date),
       });
     });
 
@@ -390,6 +398,7 @@ describe('ConversationPersistence', () => {
         messageMetadata: {
           referencedMessages: expect.any(Array), // References in metadata
         },
+        timestamp: expect.any(Date),
       });
     });
   });
@@ -477,6 +486,80 @@ describe('ConversationPersistence', () => {
         'persona-uuid-123',
         'Voice transcription'
       );
+    });
+  });
+
+  describe('saveUserMessage context-mode routing', () => {
+    it('legacy mode: fires the dual-write mirror with the SAME timestamp the local write used', async () => {
+      const mockMessage = createMockMessage({
+        id: 'discord-msg-123',
+        channelId: 'channel-123',
+        guildId: 'guild-123',
+      });
+
+      await persistence.saveUserMessage({
+        message: mockMessage,
+        personality: mockPersonality,
+        personaId: 'persona-uuid-123',
+        messageContent: 'Hello bot!',
+      });
+
+      expect(dualWritePersistUserMessage).toHaveBeenCalledTimes(1);
+      const mirrorParams = vi.mocked(dualWritePersistUserMessage).mock.calls[0][0];
+      const localCall = mockConversationHistory.addMessage.mock.calls[0][0];
+      // The deterministic row id derives from this timestamp — both paths
+      // must share one resolved value or dual-write produces false divergence.
+      expect(mirrorParams.messageTime).toBe(localCall.timestamp);
+      expect(persistUserMessageViaGateway).not.toHaveBeenCalled();
+    });
+
+    it('service mode: the gateway write is authoritative and the local write is skipped', async () => {
+      vi.mocked(getContextMode).mockReturnValueOnce('service');
+      const mockMessage = createMockMessage({
+        id: 'discord-msg-123',
+        channelId: 'channel-123',
+        guildId: 'guild-123',
+      });
+
+      await persistence.saveUserMessage({
+        message: mockMessage,
+        personality: mockPersonality,
+        personaId: 'persona-uuid-123',
+        messageContent: 'Hello bot!',
+      });
+
+      expect(persistUserMessageViaGateway).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channelId: 'channel-123',
+          guildId: 'guild-123',
+          personalityId: 'personality-123',
+          personaId: 'persona-uuid-123',
+          content: 'Hello bot!',
+          discordMessageId: 'discord-msg-123',
+          messageTime: expect.any(Date),
+        })
+      );
+      expect(mockConversationHistory.addMessage).not.toHaveBeenCalled();
+      expect(dualWritePersistUserMessage).not.toHaveBeenCalled();
+    });
+
+    it('service mode: gateway write failures propagate to the caller', async () => {
+      vi.mocked(getContextMode).mockReturnValueOnce('service');
+      vi.mocked(persistUserMessageViaGateway).mockRejectedValueOnce(new Error('gateway down'));
+      const mockMessage = createMockMessage({
+        id: 'discord-msg-123',
+        channelId: 'channel-123',
+        guildId: 'guild-123',
+      });
+
+      await expect(
+        persistence.saveUserMessage({
+          message: mockMessage,
+          personality: mockPersonality,
+          personaId: 'persona-uuid-123',
+          messageContent: 'Hello bot!',
+        })
+      ).rejects.toThrow('gateway down');
     });
   });
 

--- a/services/bot-client/src/services/ConversationPersistence.ts
+++ b/services/bot-client/src/services/ConversationPersistence.ts
@@ -26,8 +26,10 @@ import { isForwardedMessage } from '../utils/forwardedMessageUtils.js';
 import { buildMessageContent } from '../utils/MessageContentBuilder.js';
 import {
   dualWritePersistAssistantMessage,
+  dualWritePersistUserMessage,
   getContextMode,
   persistAssistantMessageViaGateway,
+  persistUserMessageViaGateway,
 } from '../utils/contextWritePath.js';
 
 const logger = createLogger('ConversationPersistence');
@@ -268,6 +270,12 @@ export class ConversationPersistence {
     );
 
     // Update the message content only (metadata with references is already saved)
+    //
+    // TRANSITIONAL: this vision-description update is the one conversation
+    // write that still goes through local Prisma in BOTH context modes. It
+    // relocates to ai-worker (which produces the descriptions and persists
+    // them itself post-vision) in the hydration-cutover slice — not to the
+    // gateway — so no endpoint is built for it here.
     await this.conversationHistory.updateLastUserMessage(
       message.channel.id,
       personality.id,
@@ -348,18 +356,45 @@ export class ConversationPersistence {
       metadata.embedsXml = embedsXml;
     }
 
-    // Save atomically with placeholder descriptions and structured metadata
-    await this.conversationHistory.addMessage({
+    // Resolve the timestamp ONCE and pass the same value to both the local
+    // write and the gateway path — the deterministic row UUID derives from
+    // it, so letting each side default to its own new Date() would produce
+    // divergent IDs and false dual-write divergence signals.
+    const effectiveTimestamp = timestamp ?? new Date();
+    const writeParams = {
       channelId,
+      guildId,
       personalityId: personality.id,
       personaId,
-      role: MessageRole.User,
       content: userMessageContent,
-      guildId,
       discordMessageId,
       messageMetadata: metadata,
-      timestamp,
-    });
+      messageTime: effectiveTimestamp,
+    };
+
+    if (getContextMode() === 'service') {
+      // Service mode: the gateway endpoint IS the write — synchronous before
+      // job submission, so the next message's history query sees this row.
+      // Throws on failure, matching the legacy local write's error semantics.
+      await persistUserMessageViaGateway(writeParams);
+    } else {
+      // Save atomically with placeholder descriptions and structured metadata
+      await this.conversationHistory.addMessage({
+        channelId,
+        personalityId: personality.id,
+        personaId,
+        role: MessageRole.User,
+        content: userMessageContent,
+        guildId,
+        discordMessageId,
+        messageMetadata: metadata,
+        timestamp: effectiveTimestamp,
+      });
+
+      // Legacy-mode burn-in mirror. Fire-and-forget, no-op unless
+      // CONTEXT_DUAL_WRITE=true.
+      void dualWritePersistUserMessage(writeParams);
+    }
 
     logger.debug(
       {

--- a/services/bot-client/src/utils/contextWritePath.test.ts
+++ b/services/bot-client/src/utils/contextWritePath.test.ts
@@ -4,6 +4,7 @@ import { SYNC_LIMITS } from '@tzurot/common-types';
 // Mock the ServiceClient factory so the helpers run without real config/network.
 const mockServiceClient = {
   persistAssistantMessage: vi.fn(),
+  persistUserMessage: vi.fn(),
   syncConversation: vi.fn(),
 };
 
@@ -14,9 +15,11 @@ vi.mock('./gatewayClients.js', () => ({
 import {
   isContextDualWriteEnabled,
   dualWritePersistAssistantMessage,
+  dualWritePersistUserMessage,
   dualWriteConversationSync,
   getContextMode,
   persistAssistantMessageViaGateway,
+  persistUserMessageViaGateway,
   syncConversationViaGateway,
 } from './contextWritePath.js';
 
@@ -253,5 +256,104 @@ describe('syncConversationViaGateway', () => {
       updated: 0,
       deleted: 0,
     });
+  });
+});
+
+describe('persistUserMessageViaGateway', () => {
+  const PARAMS = {
+    channelId: 'chan-1',
+    guildId: 'guild-1',
+    personalityId: 'pers-1',
+    personaId: 'persona-1',
+    content: 'Hello bot!\n\n[Image: cat.png]',
+    discordMessageId: '111111111111111111',
+    messageMetadata: { isForwarded: true },
+    messageTime: new Date('2026-06-04T12:00:00.000Z'),
+  };
+
+  it('POSTs the payload with ISO messageTime and metadata', async () => {
+    mockServiceClient.persistUserMessage.mockResolvedValue(ok({ id: 'row-1', created: true }));
+
+    await persistUserMessageViaGateway(PARAMS);
+
+    expect(mockServiceClient.persistUserMessage).toHaveBeenCalledWith({
+      channelId: 'chan-1',
+      guildId: 'guild-1',
+      personalityId: 'pers-1',
+      personaId: 'persona-1',
+      content: 'Hello bot!\n\n[Image: cat.png]',
+      discordMessageId: '111111111111111111',
+      messageMetadata: { isForwarded: true },
+      messageTime: '2026-06-04T12:00:00.000Z',
+    });
+  });
+
+  it('omits the messageMetadata key entirely when undefined', async () => {
+    mockServiceClient.persistUserMessage.mockResolvedValue(ok({ id: 'row-1', created: true }));
+
+    await persistUserMessageViaGateway({ ...PARAMS, messageMetadata: undefined });
+
+    const sent = mockServiceClient.persistUserMessage.mock.calls[0][0];
+    expect('messageMetadata' in sent).toBe(false);
+  });
+
+  it('THROWS on a request failure (authoritative write, caller owns the catch)', async () => {
+    mockServiceClient.persistUserMessage.mockResolvedValue(err(503));
+
+    await expect(persistUserMessageViaGateway(PARAMS)).rejects.toThrow(
+      'User-message persist failed via gateway: 503'
+    );
+  });
+
+  it('resolves (warn, not throw) on an idempotent replay that diverged', async () => {
+    mockServiceClient.persistUserMessage.mockResolvedValue(
+      ok({ id: 'row-1', created: false, matched: false })
+    );
+
+    await expect(persistUserMessageViaGateway(PARAMS)).resolves.toBeUndefined();
+  });
+
+  it('resolves quietly on an idempotent replay that matched', async () => {
+    mockServiceClient.persistUserMessage.mockResolvedValue(
+      ok({ id: 'row-1', created: false, matched: true })
+    );
+
+    await expect(persistUserMessageViaGateway(PARAMS)).resolves.toBeUndefined();
+  });
+});
+
+describe('dualWritePersistUserMessage', () => {
+  const PARAMS = {
+    channelId: 'chan-1',
+    guildId: null,
+    personalityId: 'pers-1',
+    personaId: 'persona-1',
+    content: 'hi',
+    discordMessageId: '111111111111111111',
+    messageTime: new Date('2026-06-04T12:00:00.000Z'),
+  };
+
+  afterEach(() => {
+    delete process.env.CONTEXT_DUAL_WRITE;
+  });
+
+  it('no-ops when the flag is off', async () => {
+    await dualWritePersistUserMessage(PARAMS);
+    expect(mockServiceClient.persistUserMessage).not.toHaveBeenCalled();
+  });
+
+  it('POSTs when the flag is on and never throws on errors', async () => {
+    process.env.CONTEXT_DUAL_WRITE = 'true';
+    mockServiceClient.persistUserMessage.mockResolvedValue(
+      ok({ id: 'row-1', created: false, matched: true })
+    );
+    await dualWritePersistUserMessage(PARAMS);
+    expect(mockServiceClient.persistUserMessage).toHaveBeenCalledTimes(1);
+
+    mockServiceClient.persistUserMessage.mockRejectedValue(new Error('network down'));
+    await expect(dualWritePersistUserMessage(PARAMS)).resolves.toBeUndefined();
+
+    mockServiceClient.persistUserMessage.mockResolvedValue(err(500));
+    await expect(dualWritePersistUserMessage(PARAMS)).resolves.toBeUndefined();
   });
 });

--- a/services/bot-client/src/utils/contextWritePath.ts
+++ b/services/bot-client/src/utils/contextWritePath.ts
@@ -8,7 +8,7 @@
  * legacy path and both flags) in 2.5d once service mode has burned in.
  */
 
-import { createLogger, SYNC_LIMITS } from '@tzurot/common-types';
+import { createLogger, SYNC_LIMITS, type MessageMetadata } from '@tzurot/common-types';
 import { getServiceClient } from './gatewayClients.js';
 
 const logger = createLogger('contextWritePath');
@@ -50,6 +50,97 @@ interface ObservedSyncSnapshotMessage {
   id: string;
   content: string;
   createdAt: Date;
+}
+
+interface UserMessageWriteParams {
+  channelId: string;
+  guildId: string | null;
+  personalityId: string;
+  personaId: string;
+  /** Final content: user text + attachment placeholders, assembled bot-side. */
+  content: string;
+  discordMessageId: string;
+  messageMetadata?: MessageMetadata;
+  /** Discord message timestamp — becomes the row's createdAt. */
+  messageTime: Date;
+}
+
+function buildUserMessagePayload(params: UserMessageWriteParams): {
+  channelId: string;
+  guildId: string | null;
+  personalityId: string;
+  personaId: string;
+  content: string;
+  discordMessageId: string;
+  messageMetadata?: MessageMetadata;
+  messageTime: string;
+} {
+  return {
+    channelId: params.channelId,
+    guildId: params.guildId,
+    personalityId: params.personalityId,
+    personaId: params.personaId,
+    content: params.content,
+    discordMessageId: params.discordMessageId,
+    ...(params.messageMetadata !== undefined && { messageMetadata: params.messageMetadata }),
+    messageTime: params.messageTime.toISOString(),
+  };
+}
+
+/**
+ * Persist the trigger user message via the gateway endpoint — the
+ * AUTHORITATIVE write in service mode, called synchronously BEFORE job
+ * submission so the next message's history query always sees this row.
+ * Throws on failure, matching the legacy local write's error semantics.
+ */
+export async function persistUserMessageViaGateway(params: UserMessageWriteParams): Promise<void> {
+  const result = await getServiceClient().persistUserMessage(buildUserMessagePayload(params));
+  if (!result.ok) {
+    throw new Error(`User-message persist failed via gateway: ${result.status} ${result.error}`);
+  }
+  if (result.data.created === false && result.data.matched === false) {
+    // Idempotent replay with divergent content — durable row wins; warn only.
+    logger.warn(
+      { ...result.data, channelId: params.channelId },
+      'User-message gateway persist hit an existing row with different content'
+    );
+    return;
+  }
+  logger.debug(
+    { id: result.data.id, created: result.data.created, channelId: params.channelId },
+    'User message persisted via gateway'
+  );
+}
+
+/**
+ * Mirror a just-persisted user message to the gateway endpoint (legacy-mode
+ * burn-in). Fire-and-forget: never throws. Expected outcome is
+ * `created: false, matched: true`; anything else logs as divergence.
+ */
+export async function dualWritePersistUserMessage(params: UserMessageWriteParams): Promise<void> {
+  if (!isContextDualWriteEnabled()) {
+    return;
+  }
+  try {
+    const result = await getServiceClient().persistUserMessage(buildUserMessagePayload(params));
+    if (!result.ok) {
+      logger.warn(
+        { status: result.status, channelId: params.channelId },
+        'User-message dual-write request failed'
+      );
+      return;
+    }
+    if (result.data.created || result.data.matched === false) {
+      logger.warn(
+        { ...result.data, channelId: params.channelId },
+        'User-message dual-write DIVERGED from local write'
+      );
+    } else {
+      logger.debug({ id: result.data.id }, 'User-message dual-write matched');
+    }
+  } catch (error) {
+    logger.warn({ err: error, channelId: params.channelId }, 'User-message dual-write error');
+  }
 }
 
 function buildAssistantMessagePayload(params: AssistantMessageWriteParams): {


### PR DESCRIPTION
## Summary

First slice of the 2.5c-iii hydration cutover, implementing the council's Fork B verdict (unanimous, and a premise correction): **the trigger user message is a Discord event, so the gateway — the Discord-event data authority — owns the write.** bot-client calls the new endpoint synchronously BEFORE job submission, which preserves strict history ordering (the next message's history query always sees this row) with zero locks, and keeps the worker out of trigger-message persistence entirely.

### Endpoint

`POST /api/internal/conversation/user-message` — same idempotent upsert-with-compare pattern as the assistant-message endpoint:
- Gateway derives the deterministic row UUID and token count from what it persists; `createdAt` = the Discord message's own timestamp (preserves the user < assistant(+1ms) ordering invariant)
- Existing row → compare + report `matched` (dual-write divergence signal), never overwrite
- P2002 create race → compare fallback; any other failure surfaces as 500
- `messageMetadata` (structured references / forwarded flag / embed XML) validated by the existing `messageMetadataSchema` — no new wire types

### bot-client

`saveUserMessageFromFields` gains the CONTEXT_MODE branch (the 2.5c-i pattern): service mode → gateway authoritative (throws on failure, legacy-identical error semantics); legacy mode → local Prisma + optional `CONTEXT_DUAL_WRITE` mirror.

**One subtle correctness detail**: the row timestamp is resolved ONCE and shared between the local write and the mirror. The deterministic row ID derives from it, so letting each side default to its own `new Date()` would have produced divergent IDs — and a false `created: true` divergence signal — on every message that arrives without an explicit timestamp.

### Transitional state (documented in code + .env.example)

The vision-description update (`updateLastUserMessage`) stays local-Prisma in BOTH modes: per the council's Fork C, it relocates to ai-worker (which produces the descriptions and will persist them itself post-vision) in the iii-a hydration slice — not to the gateway — so no stopgap endpoint is built here.

### Test plan

- 8 gateway handler tests (deterministic id + message timestamp + metadata, metadata-free, dual-write compare, divergence, P2002 race, non-P2002 500, validation)
- 7 write-path helper tests + 3 mode-routing tests incl. the shared-timestamp assertion
- Full suites green: api-gateway 2098, bot-client 4992, common-types 2630, clients 154; `pnpm quality` clean

### Next

iii-a: worker-side full context assembler + extended shadow mode (raw envelope fields alongside the legacy payload, real-DB hydration, match-rate telemetry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)