### PR TITLE
feat(bot-client): PR 2.5c-iii-a1 — raw assembly inputs ride the legacy payload

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -145,6 +145,14 @@ CONTEXT_MODE=legacy
 # comparison. Burn-in instrumentation; ignored when CONTEXT_MODE=service.
 CONTEXT_DUAL_WRITE=false
 
+# Raw assembly envelope (bot-client): attaches rawAssemblyInputs (raw Discord-
+# origin inputs: pre-rewrite content, mention list, pre-merge extended-context
+# messages + users, channel-environment cache map) ALONGSIDE the legacy
+# assembled payload, so ai-worker's shadow context assembler can re-derive the
+# context and diff it. Burn-in companion to CONTEXT_SHADOW_HYDRATION; adds
+# payload bytes per message, so default off.
+CONTEXT_RAW_ENVELOPE=false
+
 # ============================================
 # Security - BYOK (Bring Your Own Key)
 # ============================================

--- a/packages/common-types/src/types/api-types.test.ts
+++ b/packages/common-types/src/types/api-types.test.ts
@@ -17,6 +17,8 @@ import {
   generateRequestSchema,
   attachmentMetadataSchema,
   requestContextSchema,
+  rawAssemblyInputsSchema,
+  rawDiscordUserSchema,
   loadedPersonalitySchema,
   referencedMessageSchema,
   type GenerateRequest,
@@ -415,6 +417,89 @@ describe('API Endpoint Contract Tests', () => {
       };
 
       const result = requestContextSchema.safeParse(validContext);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate rawDiscordUser with and without the isBot flag', () => {
+      expect(
+        rawDiscordUserSchema.safeParse({
+          discordId: '123456789012345678',
+          username: 'lbds137',
+          displayName: 'Vladlena',
+        }).success
+      ).toBe(true);
+      expect(
+        rawDiscordUserSchema.safeParse({
+          discordId: '123456789012345678',
+          username: 'somebot',
+          displayName: 'Some Bot',
+          isBot: true,
+        }).success
+      ).toBe(true);
+      expect(rawDiscordUserSchema.safeParse({ discordId: 'x', username: 'y' }).success).toBe(false);
+    });
+
+    it('should validate rawAssemblyInputs with only rawMessageContent (minimal)', () => {
+      expect(
+        rawAssemblyInputsSchema.safeParse({ rawMessageContent: '<@123> hi there' }).success
+      ).toBe(true);
+      // rawMessageContent is the one required field
+      expect(rawAssemblyInputsSchema.safeParse({}).success).toBe(false);
+    });
+
+    it('should validate a fully-populated rawAssemblyInputs', () => {
+      const result = rawAssemblyInputsSchema.safeParse({
+        rawMessageContent: '<@123> check https://discord.com/channels/1/2/3',
+        rawMentionedUsers: [
+          { discordId: '123456789012345678', username: 'other', displayName: 'Other' },
+        ],
+        rawReferencedMessages: [
+          {
+            referenceNumber: 1,
+            discordMessageId: 'msg-123',
+            discordUserId: 'user-456',
+            authorUsername: 'testuser',
+            authorDisplayName: 'Test User',
+            content: 'Referenced content (pre-transcript)',
+            embeds: '',
+            timestamp: new Date().toISOString(),
+            locationContext: 'Test Server / #general',
+          },
+        ],
+        rawExtendedContextMessages: [
+          {
+            role: MessageRole.User,
+            content: 'extended msg',
+            createdAt: new Date().toISOString(),
+          },
+        ],
+        rawExtendedContextUsers: [
+          { discordId: '223456789012345678', username: 'ext', displayName: 'Ext User' },
+        ],
+        rawReactorUsers: [
+          {
+            discordId: '323456789012345678',
+            username: 'reactor',
+            displayName: 'Reactor',
+            isBot: true,
+          },
+        ],
+        knownChannelEnvironments: {
+          '423456789012345678': {
+            type: 'guild',
+            guild: { id: 'guild-123', name: 'Test Guild' },
+            channel: { id: '423456789012345678', name: 'general', type: 'GUILD_TEXT' },
+          },
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should accept requestContext carrying rawAssemblyInputs', () => {
+      const result = requestContextSchema.safeParse({
+        userId: 'user-123',
+        rawAssemblyInputs: { rawMessageContent: 'hello' },
+      });
       expect(result.success).toBe(true);
     });
   });

--- a/packages/common-types/src/types/api-types.ts
+++ b/packages/common-types/src/types/api-types.ts
@@ -30,6 +30,8 @@ export {
   generateRequestSchema,
   loadedPersonalitySchema,
   requestContextSchema,
+  rawAssemblyInputsSchema,
+  rawDiscordUserSchema,
   referencedMessageSchema,
 } from './schemas/index.js';
 

--- a/packages/common-types/src/types/jobs.ts
+++ b/packages/common-types/src/types/jobs.ts
@@ -19,6 +19,7 @@ import {
   type DiscordEnvironment,
   type LLMGenerationResult,
   type GuildMemberInfo,
+  type RawAssemblyInputs,
   loadedPersonalitySchema,
   mentionedPersonaSchema,
   referencedChannelSchema,
@@ -28,6 +29,7 @@ import {
   discordEnvironmentSchema,
   guildMemberInfoSchema,
   crossChannelHistoryGroupSchema,
+  rawAssemblyInputsSchema,
 } from './schemas/index.js';
 import { JobType, JobStatus } from '../constants/queue.js';
 import { MessageRole } from '../constants/message.js';
@@ -104,6 +106,12 @@ export interface JobContext {
   crossChannelHistory?: CrossChannelHistoryGroupEntry[];
   /** Whether the triggering message was a voice message (used for voice-only TTS mode) */
   isVoiceMessage?: boolean;
+  /**
+   * Raw Discord-origin assembly inputs for worker-side context assembly
+   * (burn-in instrumentation; present only when bot-client ships them via
+   * CONTEXT_RAW_ENVELOPE=true). See rawAssemblyInputsSchema.
+   */
+  rawAssemblyInputs?: RawAssemblyInputs;
 }
 
 /**
@@ -345,6 +353,7 @@ const jobContextSchema = z.object({
   referencedChannels: z.array(referencedChannelSchema).optional(),
   crossChannelHistory: z.array(crossChannelHistoryGroupSchema).optional(),
   isVoiceMessage: z.boolean().optional(),
+  rawAssemblyInputs: rawAssemblyInputsSchema.optional(),
 });
 
 /**

--- a/packages/common-types/src/types/schemas/personality.ts
+++ b/packages/common-types/src/types/schemas/personality.ts
@@ -170,6 +170,65 @@ export const guildMemberInfoSchema = z.object({
  * Request context schema
  * Includes all contextual information about a message
  */
+/**
+ * A Discord user observed in raw assembly inputs (mention targets,
+ * extended-context authors, reactors) — the minimal fields the worker-side
+ * assembler needs to re-run user upserts and persona resolution.
+ */
+export const rawDiscordUserSchema = z.object({
+  discordId: z.string(),
+  username: z.string(),
+  displayName: z.string(),
+  isBot: z.boolean().optional(),
+});
+
+/**
+ * Raw (pre-assembly) Discord-origin inputs for worker-side context assembly.
+ *
+ * The legacy payload carries the ASSEMBLED context (rewritten content, merged
+ * history, enriched references) — fine for generation, but the worker-side
+ * assembler can't be verified against it without the raw inputs it would
+ * assemble FROM. When bot-client's `CONTEXT_RAW_ENVELOPE=true`, these ride
+ * alongside the legacy fields so ai-worker's shadow assembler can re-derive
+ * the context and diff it against the bot-built one. This object IS the
+ * future thin-envelope payload: at cutover the legacy assembled fields stop
+ * shipping and this (plus the always-Discord fields like attachments and
+ * environment) becomes the job's context source.
+ *
+ * Everything in here is Discord-origin or pure-computed — no DB-derived data.
+ */
+export const rawAssemblyInputsSchema = z.object({
+  /** message.content verbatim — before mention replacement and [Reference N] link rewriting. */
+  rawMessageContent: z.string(),
+  /** message.mentions.users — targets for worker-side persona resolution + content rewriting. */
+  rawMentionedUsers: z.array(rawDiscordUserSchema).optional(),
+  /**
+   * Discord-fetched reply/link reference snapshots BEFORE DB enrichment
+   * (no voice transcripts appended, no dedup-vs-history applied,
+   * referenceNumber = extraction order). Reuses the enriched wire shape —
+   * the raw snapshot is the same fields minus the DB-derived additions.
+   */
+  rawReferencedMessages: z.array(referencedMessageSchema).optional(),
+  /**
+   * Discord-fetched extended-context messages BEFORE the merge with DB
+   * history. Array-field semantics (also for the two user lists below):
+   * ABSENT = the extended-context fetch didn't run for this message;
+   * EMPTY = the fetch ran and observed nothing. The shadow assembler treats
+   * the two differently, so producers must not collapse [] to undefined.
+   */
+  rawExtendedContextMessages: z.array(apiConversationMessageSchema).optional(),
+  /** Authors observed in extended context — inputs to the batch user upsert. */
+  rawExtendedContextUsers: z.array(rawDiscordUserSchema).optional(),
+  /** Users who reacted to extended-context messages (separate upsert batch). */
+  rawReactorUsers: z.array(rawDiscordUserSchema).optional(),
+  /**
+   * Guild→channel environment map from the Discord.js cache, for decorating
+   * worker-fetched cross-channel groups with names the worker can't resolve.
+   * Keyed by channelId. Missing entries degrade to id-only location blocks.
+   */
+  knownChannelEnvironments: z.record(z.string(), discordEnvironmentSchema).optional(),
+});
+
 export const requestContextSchema = z.object({
   userId: z.string(), // Discord ID (for BYOK API key resolution)
   userInternalId: z.string().optional(), // Internal UUID (for usage logging)
@@ -212,6 +271,9 @@ export const requestContextSchema = z.object({
   crossChannelHistory: z.array(crossChannelHistoryGroupSchema).optional(),
   // Whether the triggering message was a voice message (for voice-only TTS mode)
   isVoiceMessage: z.boolean().optional(),
+  // Raw Discord-origin assembly inputs (worker-side context assembly burn-in;
+  // present only when bot-client's CONTEXT_RAW_ENVELOPE=true)
+  rawAssemblyInputs: rawAssemblyInputsSchema.optional(),
 });
 
 // Infer TypeScript types from schemas
@@ -230,3 +292,5 @@ export type MentionedPersona = z.infer<typeof mentionedPersonaSchema>;
 export type ReferencedChannel = z.infer<typeof referencedChannelSchema>;
 export type GuildMemberInfo = z.infer<typeof guildMemberInfoSchema>;
 export type RequestContext = z.infer<typeof requestContextSchema>;
+export type RawDiscordUser = z.infer<typeof rawDiscordUserSchema>;
+export type RawAssemblyInputs = z.infer<typeof rawAssemblyInputsSchema>;

--- a/services/bot-client/src/services/CrossChannelHistoryFetcher.test.ts
+++ b/services/bot-client/src/services/CrossChannelHistoryFetcher.test.ts
@@ -3,8 +3,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { ChannelType } from 'discord.js';
+import { ChannelType, type Client } from 'discord.js';
 import {
+  buildKnownChannelEnvironments,
+  clearKnownChannelEnvironmentsCache,
   fetchCrossChannelHistory,
   fetchCrossChannelIfEnabled,
   mapCrossChannelToApiFormat,
@@ -646,5 +648,55 @@ describe('mapCrossChannelToApiFormat', () => {
     expect(msg.discordUsername).toBe('alice#1234');
     expect(msg.personalityId).toBe('pers-1');
     expect(msg.personalityName).toBe('TestBot');
+  });
+});
+
+describe('buildKnownChannelEnvironments', () => {
+  const makeClient = (channels: Map<string, unknown>): Client =>
+    ({ channels: { cache: channels } }) as unknown as Client;
+
+  const guildTextChannel = (id: string, name: string) => ({
+    id,
+    name,
+    type: ChannelType.GuildText,
+    guild: { id: 'guild-1', name: 'Test Guild' },
+    isThread: () => false,
+    parent: null,
+  });
+
+  beforeEach(() => {
+    clearKnownChannelEnvironmentsCache();
+  });
+
+  it('builds an env entry per cached guild channel and skips non-guild channels', () => {
+    const channels = new Map<string, unknown>([
+      ['111', guildTextChannel('111', 'general')],
+      ['222', guildTextChannel('222', 'random')],
+      // DM channel: no guild — skipped
+      ['333', { id: '333', type: ChannelType.DM, isThread: () => false }],
+    ]);
+
+    const map = buildKnownChannelEnvironments(makeClient(channels));
+
+    expect(Object.keys(map).sort()).toEqual(['111', '222']);
+    expect(map['111']).toMatchObject({
+      type: 'guild',
+      guild: { id: 'guild-1', name: 'Test Guild' },
+      channel: { id: '111', name: 'general' },
+    });
+  });
+
+  it('serves the cached map within the TTL window (one cache walk)', () => {
+    const channels = new Map<string, unknown>([['111', guildTextChannel('111', 'general')]]);
+    const client = makeClient(channels);
+
+    const first = buildKnownChannelEnvironments(client);
+    channels.set('999', guildTextChannel('999', 'late-arrival'));
+    const second = buildKnownChannelEnvironments(client);
+
+    // Same object back — the late-arriving channel is invisible until the
+    // TTL expires (channel renames/additions are rare; this is by design).
+    expect(second).toBe(first);
+    expect(second['999']).toBeUndefined();
   });
 });

--- a/services/bot-client/src/services/CrossChannelHistoryFetcher.ts
+++ b/services/bot-client/src/services/CrossChannelHistoryFetcher.ts
@@ -71,6 +71,42 @@ async function resolveChannelEnvironment(
   }
 }
 
+/** Channel renames are rare; one cache walk per TTL window is plenty. */
+const ENV_MAP_TTL_MS = 5 * 60 * 1000;
+let envMapCache: { map: Record<string, DiscordEnvironment>; builtAt: number } | null = null;
+
+/** @internal Exported for tests only — call `buildKnownChannelEnvironments` normally. */
+export function clearKnownChannelEnvironmentsCache(): void {
+  envMapCache = null;
+}
+
+/**
+ * Build the channelId → DiscordEnvironment map from the Discord.js cache —
+ * no fetches. Ships in the raw assembly envelope so the worker-side context
+ * assembler can decorate its cross-channel groups with names it cannot
+ * resolve itself. Coverage gaps (e.g. lazily-cached threads) are expected;
+ * consumers degrade to id-only location blocks.
+ *
+ * Cached for ENV_MAP_TTL_MS: the cache walk runs per message while the raw
+ * envelope is enabled, and channel/guild renames are rare.
+ */
+export function buildKnownChannelEnvironments(client: Client): Record<string, DiscordEnvironment> {
+  const now = Date.now();
+  if (envMapCache !== null && now - envMapCache.builtAt < ENV_MAP_TTL_MS) {
+    return envMapCache.map;
+  }
+
+  const map: Record<string, DiscordEnvironment> = {};
+  for (const channel of client.channels.cache.values()) {
+    if ('guild' in channel && channel.guild !== null && channel.guild !== undefined) {
+      map[channel.id] = buildGuildEnvironment(channel);
+    }
+  }
+
+  envMapCache = { map, builtAt: now };
+  return map;
+}
+
 /** Build a DiscordEnvironment for a guild channel (text, thread, forum, etc.) */
 function buildGuildEnvironment(
   channel: Extract<Awaited<ReturnType<Client['channels']['fetch']>>, { guild: unknown }>

--- a/services/bot-client/src/services/MessageContextBuilder.test.ts
+++ b/services/bot-client/src/services/MessageContextBuilder.test.ts
@@ -108,6 +108,13 @@ const mockFetchCrossChannelIfEnabled = vi.fn().mockResolvedValue(undefined);
 vi.mock('./CrossChannelHistoryFetcher.js', () => ({
   fetchCrossChannelIfEnabled: (...args: unknown[]) => mockFetchCrossChannelIfEnabled(...args),
   mapCrossChannelToApiFormat: vi.fn(() => []),
+  buildKnownChannelEnvironments: vi.fn(() => ({
+    '999888777666555444': {
+      type: 'guild',
+      guild: { id: 'guild-1', name: 'Cached Guild' },
+      channel: { id: '999888777666555444', name: 'cached-channel', type: 'GUILD_TEXT' },
+    },
+  })),
 }));
 
 // Import after mocks
@@ -228,6 +235,66 @@ describe('MessageContextBuilder', () => {
   });
 
   describe('buildContext', () => {
+    it('omits rawAssemblyInputs by default (CONTEXT_RAW_ENVELOPE off)', async () => {
+      vi.mocked(mockUserService.getOrCreateUser).mockResolvedValue({
+        userId: 'user-uuid-123',
+        defaultPersonaId: 'test-persona-id',
+      });
+      vi.mocked(mockHistoryService.getChannelHistory).mockResolvedValue([]);
+      mockExtractReferencesWithReplacement.mockResolvedValue({
+        references: [],
+        updatedContent: 'Hello world',
+      });
+
+      const result = await builder.buildContext(mockMessage, mockPersonality, 'Hello world');
+
+      expect(result.context.rawAssemblyInputs).toBeUndefined();
+    });
+
+    it('attaches rawAssemblyInputs alongside the assembled payload when CONTEXT_RAW_ENVELOPE=true', async () => {
+      process.env.CONTEXT_RAW_ENVELOPE = 'true';
+      try {
+        vi.mocked(mockUserService.getOrCreateUser).mockResolvedValue({
+          userId: 'user-uuid-123',
+          defaultPersonaId: 'test-persona-id',
+        });
+        vi.mocked(mockHistoryService.getChannelHistory).mockResolvedValue([]);
+        mockExtractReferencesWithReplacement.mockResolvedValue({
+          references: [],
+          updatedContent: 'REWRITTEN content',
+        });
+        // The mention resolver is the LAST rewriter — its output is the
+        // assembled messageContent.
+        mockResolveAllMentions.mockResolvedValue({
+          processedContent: 'REWRITTEN content',
+          mentionedUsers: [],
+          mentionedChannels: [],
+          mentionedRoles: [],
+        });
+
+        const result = await builder.buildContext(
+          mockMessage,
+          mockPersonality,
+          '<@123> raw content'
+        );
+
+        const raw = result.context.rawAssemblyInputs;
+        expect(raw).toBeDefined();
+        // The raw side carries the PRE-rewrite content; the assembled side
+        // carries the rewritten one — both in the same payload during burn-in.
+        expect(raw?.rawMessageContent).toBe('<@123> raw content');
+        expect(result.context.messageContent).toBe('REWRITTEN content');
+        // Empty mentions collection → field omitted, not [].
+        expect(raw?.rawMentionedUsers).toBeUndefined();
+        // Channel-environment map comes from the Discord.js cache walk.
+        expect(raw?.knownChannelEnvironments?.['999888777666555444']).toMatchObject({
+          type: 'guild',
+        });
+      } finally {
+        delete process.env.CONTEXT_RAW_ENVELOPE;
+      }
+    });
+
     it('should build complete context with user lookup and history', async () => {
       // Setup mocks
       vi.mocked(mockUserService.getOrCreateUser).mockResolvedValue({

--- a/services/bot-client/src/services/MessageContextBuilder.ts
+++ b/services/bot-client/src/services/MessageContextBuilder.ts
@@ -38,6 +38,12 @@ import {
 } from './contextBuilder/index.js';
 import type { ContextBuildOptions } from './contextBuilder/ContextBuildOptions.js';
 import {
+  buildRawAssemblyInputs,
+  captureRawExtendedContext,
+  toApiConversationMessage,
+  type RawExtendedContextSnapshot,
+} from './contextBuilder/RawEnvelopeBuilder.js';
+import {
   extractReferencesAndMentions,
   type ReferencesAndMentionsResult,
 } from './contextBuilder/ReferenceExtractor.js';
@@ -78,6 +84,13 @@ interface ExtendedContextResult {
   history: ConversationMessage[];
   attachments?: AttachmentMetadata[];
   participantGuildInfo?: ParticipantGuildInfo;
+  /**
+   * Raw-envelope snapshot (present only when CONTEXT_RAW_ENVELOPE=true):
+   * the Discord-fetched messages BEFORE persona-ID resolution mutates them
+   * in place, plus the user lists feeding the batch upsert — exactly what
+   * the worker-side shadow assembler needs to re-run that resolution.
+   */
+  raw?: RawExtendedContextSnapshot;
 }
 
 /** Parameters for extended context fetching */
@@ -219,6 +232,10 @@ export class MessageContextBuilder {
       }
     );
 
+    // Snapshot must happen HERE — resolveExtendedContextPersonaIds below
+    // mutates fetchResult.messages in place. See captureRawExtendedContext.
+    const rawSnapshot = captureRawExtendedContext(fetchResult);
+
     // Create personas for extended context users AND reactor users
     // Combine both arrays to handle in a single batch (reactors are users who reacted to messages)
     const usersToResolve = [
@@ -260,7 +277,7 @@ export class MessageContextBuilder {
     }
 
     if (fetchResult.messages.length === 0) {
-      return { history: mergedHistory };
+      return { history: mergedHistory, raw: rawSnapshot };
     }
 
     // Merge Discord messages with DB history
@@ -324,7 +341,7 @@ export class MessageContextBuilder {
         });
     }
 
-    return { history: mergedHistory, attachments, participantGuildInfo };
+    return { history: mergedHistory, attachments, participantGuildInfo, raw: rawSnapshot };
   }
 
   /** Extract referenced messages and resolve mentions - delegates to ReferenceExtractor */
@@ -463,23 +480,7 @@ export class MessageContextBuilder {
     // Include tokenCount for accurate token budget calculations (avoids chars/4 fallback)
     // Include discordUsername for disambiguation when persona name matches personality name
     // Include discordMessageId for quote deduplication (prevents duplicating quoted content in history)
-    const conversationHistory = history.map(msg => ({
-      id: msg.id,
-      role: msg.role,
-      content: msg.content,
-      tokenCount: msg.tokenCount, // Pre-computed with tiktoken at message save time
-      createdAt: msg.createdAt.toISOString(),
-      isForwarded: msg.isForwarded, // For XML attribute (forwarded="true")
-      personaId: msg.personaId,
-      personaName: msg.personaName,
-      discordUsername: msg.discordUsername, // For collision detection in prompt building
-      discordMessageId: msg.discordMessageId, // For quote deduplication in prompt building
-      // AI personality info for multi-AI channel attribution
-      // Allows correct attribution when multiple AI personalities respond in the same channel
-      personalityId: msg.personalityId,
-      personalityName: msg.personalityName,
-      messageMetadata: msg.messageMetadata,
-    }));
+    const conversationHistory = history.map(toApiConversationMessage);
 
     // Extract attachments using unified buildMessageContent
     // This ensures forwarded message snapshot attachments are included (DRY principle)
@@ -492,6 +493,10 @@ export class MessageContextBuilder {
 
     // Extract Discord environment context
     const environment = extractDiscordEnvironment(message);
+
+    // Raw-envelope assembly inputs (worker-side shadow assembler burn-in);
+    // undefined unless CONTEXT_RAW_ENVELOPE=true.
+    const rawAssemblyInputs = buildRawAssemblyInputs(message, content, extendedContext.raw);
 
     // Build complete context
     // Note: userId is the Discord ID (for BYOK resolution)
@@ -524,6 +529,7 @@ export class MessageContextBuilder {
           : undefined,
       // Detect voice messages for TTS voice-only mode
       isVoiceMessage: hasVoiceAttachments(message),
+      rawAssemblyInputs,
     };
 
     logger.debug(

--- a/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.test.ts
+++ b/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { MessageRole, type ConversationMessage } from '@tzurot/common-types';
+import type { Message } from 'discord.js';
+
+vi.mock('../CrossChannelHistoryFetcher.js', () => ({
+  buildKnownChannelEnvironments: vi.fn(() => ({
+    '999888777666555444': {
+      type: 'guild',
+      guild: { id: 'guild-1', name: 'Cached Guild' },
+      channel: { id: '999888777666555444', name: 'cached-channel', type: 'GUILD_TEXT' },
+    },
+  })),
+}));
+
+import {
+  buildRawAssemblyInputs,
+  captureRawExtendedContext,
+  toApiConversationMessage,
+  toRawDiscordUser,
+} from './RawEnvelopeBuilder.js';
+
+const makeMessage = (mentions: { id: string; username: string; globalName?: string }[] = []) =>
+  ({
+    client: {},
+    mentions: {
+      users: new Map(mentions.map(m => [m.id, m])),
+    },
+  }) as unknown as Message;
+
+const makeConversationMessage = (overrides: Partial<ConversationMessage> = {}) =>
+  ({
+    id: 'm1',
+    role: MessageRole.User,
+    content: 'hello',
+    createdAt: new Date('2026-06-01T00:00:00Z'),
+    personaId: 'discord:111',
+    discordUsername: 'alice',
+    discordMessageId: ['m1'],
+    channelId: 'chan-1',
+    guildId: 'guild-1',
+    ...overrides,
+  }) as ConversationMessage;
+
+afterEach(() => {
+  delete process.env.CONTEXT_RAW_ENVELOPE;
+});
+
+describe('captureRawExtendedContext', () => {
+  it('returns undefined when the envelope flag is off (no clone cost)', () => {
+    expect(captureRawExtendedContext({ messages: [makeConversationMessage()] })).toBeUndefined();
+  });
+
+  it('deep-clones messages so later in-place persona resolution cannot leak in', () => {
+    process.env.CONTEXT_RAW_ENVELOPE = 'true';
+    const original = makeConversationMessage({ personaId: 'discord:111' });
+
+    const snapshot = captureRawExtendedContext({
+      messages: [original],
+      extendedContextUsers: [{ discordId: '111', username: 'alice', isBot: false }],
+      reactorUsers: undefined,
+    });
+
+    // Simulate resolveExtendedContextPersonaIds mutating the fetched message.
+    original.personaId = 'resolved-uuid';
+
+    expect(snapshot?.messages[0].personaId).toBe('discord:111');
+    expect(snapshot?.extendedContextUsers).toHaveLength(1);
+    expect(snapshot?.reactorUsers).toEqual([]);
+  });
+});
+
+describe('toRawDiscordUser', () => {
+  it('falls back to username when displayName is absent and omits falsy isBot', () => {
+    expect(toRawDiscordUser({ discordId: '1', username: 'alice', isBot: false })).toEqual({
+      discordId: '1',
+      username: 'alice',
+      displayName: 'alice',
+    });
+    expect(
+      toRawDiscordUser({ discordId: '2', username: 'bot', displayName: 'Bot', isBot: true })
+    ).toEqual({ discordId: '2', username: 'bot', displayName: 'Bot', isBot: true });
+  });
+});
+
+describe('toApiConversationMessage', () => {
+  it('serializes createdAt to ISO and preserves attribution fields', () => {
+    const api = toApiConversationMessage(
+      makeConversationMessage({ personalityId: 'pers-1', personalityName: 'Lila' })
+    );
+    expect(api.createdAt).toBe('2026-06-01T00:00:00.000Z');
+    expect(api.personalityId).toBe('pers-1');
+    expect(api.discordMessageId).toEqual(['m1']);
+  });
+});
+
+describe('buildRawAssemblyInputs', () => {
+  it('returns undefined when the envelope flag is off', () => {
+    expect(buildRawAssemblyInputs(makeMessage(), 'raw content', undefined)).toBeUndefined();
+  });
+
+  it('assembles the envelope: raw content, mention mapping, snapshot serialization, env map', () => {
+    process.env.CONTEXT_RAW_ENVELOPE = 'true';
+    const snapshot = {
+      messages: [makeConversationMessage()],
+      extendedContextUsers: [
+        { discordId: '111', username: 'alice', displayName: 'Alice', isBot: false },
+      ],
+      reactorUsers: [{ discordId: '222', username: 'rea', isBot: true }],
+    };
+
+    const raw = buildRawAssemblyInputs(
+      makeMessage([{ id: '333', username: 'mention-target', globalName: 'Mention Target' }]),
+      '<@333> raw content',
+      snapshot
+    );
+
+    expect(raw?.rawMessageContent).toBe('<@333> raw content');
+    expect(raw?.rawMentionedUsers).toEqual([
+      { discordId: '333', username: 'mention-target', displayName: 'Mention Target' },
+    ]);
+    expect(raw?.rawExtendedContextMessages?.[0].createdAt).toBe('2026-06-01T00:00:00.000Z');
+    expect(raw?.rawExtendedContextUsers).toEqual([
+      { discordId: '111', username: 'alice', displayName: 'Alice' },
+    ]);
+    expect(raw?.rawReactorUsers).toEqual([
+      { discordId: '222', username: 'rea', displayName: 'rea', isBot: true },
+    ]);
+    expect(raw?.knownChannelEnvironments?.['999888777666555444']).toMatchObject({
+      type: 'guild',
+    });
+  });
+
+  it('omits rawMentionedUsers when the mentions collection is empty', () => {
+    process.env.CONTEXT_RAW_ENVELOPE = 'true';
+    const raw = buildRawAssemblyInputs(makeMessage(), 'plain', undefined);
+    expect(raw?.rawMentionedUsers).toBeUndefined();
+    expect(raw?.rawExtendedContextMessages).toBeUndefined();
+  });
+});

--- a/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.ts
+++ b/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.ts
@@ -1,0 +1,128 @@
+/**
+ * Raw assembly envelope construction.
+ *
+ * When CONTEXT_RAW_ENVELOPE=true, bot-client attaches the raw Discord-origin
+ * assembly inputs ALONGSIDE the legacy assembled payload so ai-worker's
+ * shadow context assembler can re-derive the context and diff it against the
+ * bot-built one. Everything here is Discord-origin or pure mapping — no DB.
+ *
+ * This module's output IS the future thin-envelope payload: at cutover the
+ * legacy assembled fields stop shipping and this becomes the job's context
+ * source.
+ */
+
+import type { Message } from 'discord.js';
+import {
+  apiConversationMessageSchema,
+  type ConversationMessage,
+  type RawAssemblyInputs,
+  type RawDiscordUser,
+} from '@tzurot/common-types';
+import type { z } from 'zod';
+import type { ExtendedContextUser, FetchResult } from '../channelFetcher/types.js';
+import { isRawEnvelopeEnabled } from '../../utils/contextWritePath.js';
+import { buildKnownChannelEnvironments } from '../CrossChannelHistoryFetcher.js';
+
+/** The pre-resolution extended-context snapshot threaded out of the fetch. */
+export interface RawExtendedContextSnapshot {
+  messages: ConversationMessage[];
+  extendedContextUsers: ExtendedContextUser[];
+  reactorUsers: ExtendedContextUser[];
+}
+
+/**
+ * Capture the raw extended-context snapshot from a fetch result. Must be
+ * called BEFORE resolveExtendedContextPersonaIds, which mutates the fetched
+ * messages in place (placeholder personaIds → UUIDs) — the worker-side
+ * shadow assembler needs the pre-resolution shape to verify its own batch
+ * upsert + persona resolution. Returns undefined when the envelope is off
+ * (structuredClone of up to 100 messages isn't free).
+ */
+export function captureRawExtendedContext(
+  fetchResult: Pick<FetchResult, 'messages' | 'extendedContextUsers' | 'reactorUsers'>
+): RawExtendedContextSnapshot | undefined {
+  if (!isRawEnvelopeEnabled()) {
+    return undefined;
+  }
+  return {
+    // Messages are deep-cloned because resolveExtendedContextPersonaIds
+    // rewrites msg.personaId in place. The user arrays only need shallow
+    // copies — resolution reads them but never mutates the user objects. If
+    // that ever changes, upgrade these to structuredClone too.
+    messages: structuredClone(fetchResult.messages),
+    extendedContextUsers: [...(fetchResult.extendedContextUsers ?? [])],
+    reactorUsers: [...(fetchResult.reactorUsers ?? [])],
+  };
+}
+
+/** Map a locally-observed Discord user to the raw-envelope wire shape. */
+export function toRawDiscordUser(u: ExtendedContextUser): RawDiscordUser {
+  return {
+    discordId: u.discordId,
+    username: u.username,
+    displayName: u.displayName ?? u.username,
+    ...(u.isBot && { isBot: true }),
+  };
+}
+
+/**
+ * The wire (API) serialization of a ConversationMessage — derived from the
+ * schema so the type cannot drift from what the worker validates against.
+ */
+export type ApiConversationMessage = z.infer<typeof apiConversationMessageSchema>;
+
+/**
+ * Serialize a ConversationMessage to the wire (API) shape. Shared by the
+ * assembled conversationHistory and the raw-envelope extended-context
+ * snapshot so the two serializations cannot drift.
+ */
+export function toApiConversationMessage(msg: ConversationMessage): ApiConversationMessage {
+  return {
+    id: msg.id,
+    role: msg.role,
+    content: msg.content,
+    tokenCount: msg.tokenCount, // Pre-computed with tiktoken at message save time
+    createdAt: msg.createdAt.toISOString(),
+    isForwarded: msg.isForwarded, // For XML attribute (forwarded="true")
+    personaId: msg.personaId,
+    personaName: msg.personaName,
+    discordUsername: msg.discordUsername, // For collision detection in prompt building
+    discordMessageId: msg.discordMessageId, // For quote deduplication in prompt building
+    // AI personality info for multi-AI channel attribution
+    // Allows correct attribution when multiple AI personalities respond in the same channel
+    personalityId: msg.personalityId,
+    personalityName: msg.personalityName,
+    messageMetadata: msg.messageMetadata,
+  };
+}
+
+/**
+ * Assemble the raw envelope. `content` is the pre-rewrite text (raw message
+ * content + any upstream voice transcript) — exactly what the worker-side
+ * rewriter starts from. Returns undefined when the envelope is off.
+ */
+export function buildRawAssemblyInputs(
+  message: Message,
+  content: string,
+  raw: RawExtendedContextSnapshot | undefined
+): RawAssemblyInputs | undefined {
+  if (!isRawEnvelopeEnabled()) {
+    return undefined;
+  }
+  return {
+    rawMessageContent: content,
+    rawMentionedUsers:
+      message.mentions.users.size > 0
+        ? [...message.mentions.users.values()].map(u => ({
+            discordId: u.id,
+            username: u.username,
+            displayName: u.globalName ?? u.username,
+            ...(u.bot && { isBot: true }),
+          }))
+        : undefined,
+    rawExtendedContextMessages: raw?.messages.map(toApiConversationMessage),
+    rawExtendedContextUsers: raw?.extendedContextUsers.map(toRawDiscordUser),
+    rawReactorUsers: raw?.reactorUsers.map(toRawDiscordUser),
+    knownChannelEnvironments: buildKnownChannelEnvironments(message.client),
+  };
+}

--- a/services/bot-client/src/utils/contextWritePath.test.ts
+++ b/services/bot-client/src/utils/contextWritePath.test.ts
@@ -14,6 +14,7 @@ vi.mock('./gatewayClients.js', () => ({
 
 import {
   isContextDualWriteEnabled,
+  isRawEnvelopeEnabled,
   dualWritePersistAssistantMessage,
   dualWritePersistUserMessage,
   dualWriteConversationSync,
@@ -157,6 +158,14 @@ describe('dualWriteConversationSync', () => {
 
     const sent = mockServiceClient.syncConversation.mock.calls[0][0].observedMessages;
     expect(sent).toHaveLength(SYNC_LIMITS.MAX_DISCORD_ID_LOOKUP);
+  });
+});
+
+describe('isRawEnvelopeEnabled', () => {
+  it('is enabled only by the exact string "true"', () => {
+    expect(isRawEnvelopeEnabled({ CONTEXT_RAW_ENVELOPE: 'true' } as NodeJS.ProcessEnv)).toBe(true);
+    expect(isRawEnvelopeEnabled({ CONTEXT_RAW_ENVELOPE: '1' } as NodeJS.ProcessEnv)).toBe(false);
+    expect(isRawEnvelopeEnabled({} as NodeJS.ProcessEnv)).toBe(false);
   });
 });
 

--- a/services/bot-client/src/utils/contextWritePath.ts
+++ b/services/bot-client/src/utils/contextWritePath.ts
@@ -36,6 +36,17 @@ export function isContextDualWriteEnabled(env: NodeJS.ProcessEnv = process.env):
   return env.CONTEXT_DUAL_WRITE === 'true';
 }
 
+/**
+ * When true, bot-client attaches `rawAssemblyInputs` (raw Discord-origin
+ * assembly inputs) ALONGSIDE the legacy assembled payload, so ai-worker's
+ * shadow context assembler can re-derive the context and diff it against
+ * the bot-built one. Burn-in companion to ai-worker's
+ * CONTEXT_SHADOW_HYDRATION; adds payload bytes per message, so default off.
+ */
+export function isRawEnvelopeEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.CONTEXT_RAW_ENVELOPE === 'true';
+}
+
 interface AssistantMessageWriteParams {
   channelId: string;
   guildId: string | null;


### PR DESCRIPTION
## Summary

First slice of iii-a (the worker-side context assembler), implementing the council's burn-in prerequisite (Kimi's catch): the legacy payload only carries the ASSEMBLED context, so the shadow assembler has nothing to assemble *from*. This PR adds **`rawAssemblyInputs`** — the raw Discord-origin inputs — as an optional rider on the existing payload, populated behind **`CONTEXT_RAW_ENVELOPE`** (default off; raw extended context can double payload size, so it's burn-in-only).

This object IS the future thin envelope: at iii-b cutover the legacy assembled fields stop shipping and this becomes the job's context source.

### The envelope fields

- **`rawMessageContent`** — `message.content` pre-rewrite (before mention replacement and `[Reference N]` link rewriting)
- **`rawMentionedUsers`** — `message.mentions.users` mapped to the minimal upsert/resolution shape
- **`rawExtendedContextMessages` / `rawExtendedContextUsers` / `rawReactorUsers`** — the Discord fetch result **snapshotted BEFORE `resolveExtendedContextPersonaIds` mutates it in place** (placeholder personaIds → UUIDs). Without that timing, the shadow assembler would be verifying against its own answers. Deep-cloned; gated so the clone cost is burn-in-only.
- **`knownChannelEnvironments`** — the Fork A guild→channel name map from the Discord.js **cache** (no fetches), TTL-cached 5 min so the walk doesn't repeat per message
- **`rawReferencedMessages`** — schema present, population deferred to the assembler slice (threading pre-enrichment snapshots out of `ReferenceCrawler` should be shaped by its consumer, not guessed at now)

### Structure

- `rawAssemblyInputsSchema` + `rawDiscordUserSchema` in common-types (wire-safe: `requestContextSchema` is non-strict, all fields optional); mirrored into the BullMQ `jobContextSchema` twin and `JobContext`
- Envelope construction extracted to `contextBuilder/RawEnvelopeBuilder.ts` — also moves the shared `toApiConversationMessage` serializer there so the assembled history and raw snapshot can't drift in wire shape (and keeps `MessageContextBuilder` under its lint caps)

### Test plan

- 8 RawEnvelopeBuilder tests incl. the mutation-leak guard (clone → mutate original → snapshot unchanged) and flag gating
- 2 env-map tests (per-channel entries, TTL cache identity), flag test, 2 MessageContextBuilder integration tests (flag off → absent; flag on → raw + assembled coexist), 5 schema contract tests
- Full suites green: bot-client 5005, common-types 2643, ai-worker 3135; `pnpm quality` (now incl. `test:audit`) clean

### Next

iii-a2: the worker-side assembler + extended shadow mode consuming these fields (real-DB hydration + match-rate telemetry per the council's catches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)