### PR TITLE
feat(bot-client): PR 2.5c-iii-a2 — complete the raw assembly envelope

### DIFF
--- a/packages/common-types/src/types/api-types.test.ts
+++ b/packages/common-types/src/types/api-types.test.ts
@@ -19,6 +19,8 @@ import {
   requestContextSchema,
   rawAssemblyInputsSchema,
   rawDiscordUserSchema,
+  rawMentionedChannelSchema,
+  rawMentionedRoleSchema,
   loadedPersonalitySchema,
   referencedMessageSchema,
   type GenerateRequest,
@@ -493,6 +495,34 @@ describe('API Endpoint Contract Tests', () => {
         },
       });
       expect(result.success).toBe(true);
+    });
+
+    it('should validate rawMentionedChannel and rawMentionedRole shapes', () => {
+      expect(
+        rawMentionedChannelSchema.safeParse({
+          channelId: '423456789012345678',
+          channelName: 'general',
+          topic: 'chat',
+          guildId: 'guild-123',
+        }).success
+      ).toBe(true);
+      expect(rawMentionedChannelSchema.safeParse({ channelId: 'x' }).success).toBe(false);
+      expect(
+        rawMentionedRoleSchema.safeParse({ roleId: '1', roleName: 'mods', mentionable: true })
+          .success
+      ).toBe(true);
+      expect(rawMentionedRoleSchema.safeParse({ roleId: '1' }).success).toBe(false);
+    });
+
+    it('should accept rawAssemblyInputs carrying channel/role mentions and raw references', () => {
+      expect(
+        rawAssemblyInputsSchema.safeParse({
+          rawMessageContent: '<#423456789012345678> <@&1> see msg',
+          rawMentionedChannels: [{ channelId: '423456789012345678', channelName: 'general' }],
+          rawMentionedRoles: [{ roleId: '1', roleName: 'mods' }],
+          rawReferencedMessages: [],
+        }).success
+      ).toBe(true);
     });
 
     it('should accept requestContext carrying rawAssemblyInputs', () => {

--- a/packages/common-types/src/types/api-types.ts
+++ b/packages/common-types/src/types/api-types.ts
@@ -32,6 +32,8 @@ export {
   requestContextSchema,
   rawAssemblyInputsSchema,
   rawDiscordUserSchema,
+  rawMentionedChannelSchema,
+  rawMentionedRoleSchema,
   referencedMessageSchema,
 } from './schemas/index.js';
 

--- a/packages/common-types/src/types/schemas/index.ts
+++ b/packages/common-types/src/types/schemas/index.ts
@@ -8,4 +8,5 @@
 export * from './discord.js';
 export * from './message.js';
 export * from './personality.js';
+export * from './rawEnvelope.js';
 export * from './generation.js';

--- a/packages/common-types/src/types/schemas/personality.ts
+++ b/packages/common-types/src/types/schemas/personality.ts
@@ -7,6 +7,7 @@
 
 import { z } from 'zod';
 import { discordEnvironmentSchema, attachmentMetadataSchema } from './discord.js';
+import { rawAssemblyInputsSchema } from './rawEnvelope.js';
 import {
   apiConversationMessageSchema,
   crossChannelHistoryGroupSchema,
@@ -170,65 +171,6 @@ export const guildMemberInfoSchema = z.object({
  * Request context schema
  * Includes all contextual information about a message
  */
-/**
- * A Discord user observed in raw assembly inputs (mention targets,
- * extended-context authors, reactors) — the minimal fields the worker-side
- * assembler needs to re-run user upserts and persona resolution.
- */
-export const rawDiscordUserSchema = z.object({
-  discordId: z.string(),
-  username: z.string(),
-  displayName: z.string(),
-  isBot: z.boolean().optional(),
-});
-
-/**
- * Raw (pre-assembly) Discord-origin inputs for worker-side context assembly.
- *
- * The legacy payload carries the ASSEMBLED context (rewritten content, merged
- * history, enriched references) — fine for generation, but the worker-side
- * assembler can't be verified against it without the raw inputs it would
- * assemble FROM. When bot-client's `CONTEXT_RAW_ENVELOPE=true`, these ride
- * alongside the legacy fields so ai-worker's shadow assembler can re-derive
- * the context and diff it against the bot-built one. This object IS the
- * future thin-envelope payload: at cutover the legacy assembled fields stop
- * shipping and this (plus the always-Discord fields like attachments and
- * environment) becomes the job's context source.
- *
- * Everything in here is Discord-origin or pure-computed — no DB-derived data.
- */
-export const rawAssemblyInputsSchema = z.object({
-  /** message.content verbatim — before mention replacement and [Reference N] link rewriting. */
-  rawMessageContent: z.string(),
-  /** message.mentions.users — targets for worker-side persona resolution + content rewriting. */
-  rawMentionedUsers: z.array(rawDiscordUserSchema).optional(),
-  /**
-   * Discord-fetched reply/link reference snapshots BEFORE DB enrichment
-   * (no voice transcripts appended, no dedup-vs-history applied,
-   * referenceNumber = extraction order). Reuses the enriched wire shape —
-   * the raw snapshot is the same fields minus the DB-derived additions.
-   */
-  rawReferencedMessages: z.array(referencedMessageSchema).optional(),
-  /**
-   * Discord-fetched extended-context messages BEFORE the merge with DB
-   * history. Array-field semantics (also for the two user lists below):
-   * ABSENT = the extended-context fetch didn't run for this message;
-   * EMPTY = the fetch ran and observed nothing. The shadow assembler treats
-   * the two differently, so producers must not collapse [] to undefined.
-   */
-  rawExtendedContextMessages: z.array(apiConversationMessageSchema).optional(),
-  /** Authors observed in extended context — inputs to the batch user upsert. */
-  rawExtendedContextUsers: z.array(rawDiscordUserSchema).optional(),
-  /** Users who reacted to extended-context messages (separate upsert batch). */
-  rawReactorUsers: z.array(rawDiscordUserSchema).optional(),
-  /**
-   * Guild→channel environment map from the Discord.js cache, for decorating
-   * worker-fetched cross-channel groups with names the worker can't resolve.
-   * Keyed by channelId. Missing entries degrade to id-only location blocks.
-   */
-  knownChannelEnvironments: z.record(z.string(), discordEnvironmentSchema).optional(),
-});
-
 export const requestContextSchema = z.object({
   userId: z.string(), // Discord ID (for BYOK API key resolution)
   userInternalId: z.string().optional(), // Internal UUID (for usage logging)
@@ -292,5 +234,3 @@ export type MentionedPersona = z.infer<typeof mentionedPersonaSchema>;
 export type ReferencedChannel = z.infer<typeof referencedChannelSchema>;
 export type GuildMemberInfo = z.infer<typeof guildMemberInfoSchema>;
 export type RequestContext = z.infer<typeof requestContextSchema>;
-export type RawDiscordUser = z.infer<typeof rawDiscordUserSchema>;
-export type RawAssemblyInputs = z.infer<typeof rawAssemblyInputsSchema>;

--- a/packages/common-types/src/types/schemas/rawEnvelope.ts
+++ b/packages/common-types/src/types/schemas/rawEnvelope.ts
@@ -1,0 +1,100 @@
+/**
+ * Raw assembly envelope schemas.
+ *
+ * The raw Discord-origin inputs bot-client ships so ai-worker's context
+ * assembler can re-derive the LLM context worker-side. During burn-in these
+ * ride ALONGSIDE the legacy assembled payload (behind CONTEXT_RAW_ENVELOPE);
+ * at cutover the legacy assembled fields stop shipping and this object (plus
+ * the always-Discord fields like attachments and environment) becomes the
+ * job's context source.
+ *
+ * Everything in here is Discord-origin or pure-computed — no DB-derived data.
+ */
+
+import { z } from 'zod';
+import { discordEnvironmentSchema } from './discord.js';
+import { apiConversationMessageSchema, referencedMessageSchema } from './message.js';
+
+/**
+ * A Discord user observed in raw assembly inputs (mention targets,
+ * extended-context authors, reactors) — the minimal fields the worker-side
+ * assembler needs to re-run user upserts and persona resolution.
+ */
+export const rawDiscordUserSchema = z.object({
+  discordId: z.string(),
+  username: z.string(),
+  displayName: z.string(),
+  isBot: z.boolean().optional(),
+});
+
+/**
+ * A channel referenced via `<#id>` in the message content — name (and topic,
+ * for the referencedChannels context block) resolved from the guild cache at
+ * capture time, since the worker cannot resolve Discord names itself.
+ */
+export const rawMentionedChannelSchema = z.object({
+  channelId: z.string(),
+  channelName: z.string(),
+  topic: z.string().optional(),
+  guildId: z.string().optional(),
+});
+
+/**
+ * A role referenced via `<@&id>` in the message content — resolved from the
+ * guild cache at capture time. Roles have no other envelope source (unlike
+ * channels, which the environment map also covers).
+ */
+export const rawMentionedRoleSchema = z.object({
+  roleId: z.string(),
+  roleName: z.string(),
+  mentionable: z.boolean().optional(),
+});
+
+export const rawAssemblyInputsSchema = z.object({
+  /** message.content verbatim — before mention replacement and [Reference N] link rewriting. */
+  rawMessageContent: z.string(),
+  /**
+   * message.mentions.users — targets for worker-side persona resolution +
+   * content rewriting. Absent when the message mentions no users (mentions
+   * are always observed on a Discord message, so unlike the extended-context
+   * arrays below there is no ABSENT/EMPTY distinction here).
+   */
+  rawMentionedUsers: z.array(rawDiscordUserSchema).optional(),
+  /** `<#id>` channel references found in the raw content, names from guild cache. */
+  rawMentionedChannels: z.array(rawMentionedChannelSchema).optional(),
+  /** `<@&id>` role references found in the raw content, names from guild cache. */
+  rawMentionedRoles: z.array(rawMentionedRoleSchema).optional(),
+  /**
+   * Discord-fetched reply/link reference snapshots BEFORE DB enrichment:
+   * no voice transcripts appended, no dedup-vs-history stubbing applied
+   * (full content always), referenceNumber = crawl order (dedup-independent,
+   * so the worker's own dedup decisions never renumber). Reuses the enriched
+   * wire shape — the raw snapshot is the same fields minus DB additions.
+   * ABSENT = reference extraction didn't run (weigh-in mode) or the sender
+   * predates this field; EMPTY = extraction ran and found no references.
+   */
+  rawReferencedMessages: z.array(referencedMessageSchema).optional(),
+  /**
+   * Discord-fetched extended-context messages BEFORE the merge with DB
+   * history. Array-field semantics (also for the two user lists below):
+   * ABSENT = the extended-context fetch didn't run for this message;
+   * EMPTY = the fetch ran and observed nothing. The shadow assembler treats
+   * the two differently, so producers must not collapse [] to undefined.
+   */
+  rawExtendedContextMessages: z.array(apiConversationMessageSchema).optional(),
+  /** Authors observed in extended context — inputs to the batch user upsert. */
+  rawExtendedContextUsers: z.array(rawDiscordUserSchema).optional(),
+  /** Users who reacted to extended-context messages (separate upsert batch). */
+  rawReactorUsers: z.array(rawDiscordUserSchema).optional(),
+  /**
+   * Guild→channel environment map from the Discord.js cache, for decorating
+   * worker-fetched cross-channel groups with names the worker can't resolve.
+   * Keyed by channelId. Missing entries degrade to id-only location blocks.
+   */
+  knownChannelEnvironments: z.record(z.string(), discordEnvironmentSchema).optional(),
+});
+
+export type RawDiscordUser = z.infer<typeof rawDiscordUserSchema>;
+export type RawMentionedChannel = z.infer<typeof rawMentionedChannelSchema>;
+export type RawMentionedRole = z.infer<typeof rawMentionedRoleSchema>;
+export type RawAssemblyInputs = z.infer<typeof rawAssemblyInputsSchema>;

--- a/services/bot-client/src/handlers/MessageReferenceExtractor.ts
+++ b/services/bot-client/src/handlers/MessageReferenceExtractor.ts
@@ -16,6 +16,7 @@ import {
   ConversationHistoryService,
 } from '@tzurot/common-types';
 import { Message } from 'discord.js';
+import { isRawEnvelopeEnabled } from '../utils/contextWritePath.js';
 import { TranscriptRetriever } from './references/TranscriptRetriever.js';
 import { SnapshotFormatter } from './references/SnapshotFormatter.js';
 import { MessageFormatter } from './references/MessageFormatter.js';
@@ -35,6 +36,12 @@ interface ReferenceExtractionResult {
   references: ReferencedMessage[];
   /** Updated message content with Discord links replaced by [Reference N] */
   updatedContent: string;
+  /**
+   * Raw pre-enrichment reference snapshots for the assembly envelope —
+   * present only when CONTEXT_RAW_ENVELOPE=true. Full content always (no
+   * transcripts, no dedup stubs), same numbering as `references`.
+   */
+  rawReferences?: ReferencedMessage[];
 }
 
 /**
@@ -157,12 +164,16 @@ export class MessageReferenceExtractor {
     const formattedResult = await this.formatter.format(
       updatedMessage.content,
       crawlResult.messages,
-      this.maxReferences
+      this.maxReferences,
+      { collectRaw: isRawEnvelopeEnabled() }
     );
 
     return {
       references: formattedResult.references,
       updatedContent: formattedResult.updatedContent,
+      ...(formattedResult.rawReferences !== undefined && {
+        rawReferences: formattedResult.rawReferences,
+      }),
     };
   }
 

--- a/services/bot-client/src/handlers/references/MessageFormatter.ts
+++ b/services/bot-client/src/handlers/references/MessageFormatter.ts
@@ -95,6 +95,66 @@ export class MessageFormatter {
   }
 
   /**
+   * Build the RAW referenced message — every Discord-origin field, with
+   * content BEFORE the voice-transcript append (the one DB/Redis-derived
+   * enrichment in this formatter). Pure and synchronous; this is the shape
+   * the raw assembly envelope ships so the worker-side assembler can re-run
+   * the transcript enrichment itself.
+   */
+  buildRawReference(
+    message: Message,
+    referenceNumber: number,
+    isForwardedFlag?: boolean
+  ): { reference: ReferencedMessage; attachments: AttachmentList } {
+    const environment = extractDiscordEnvironment(message);
+    const locationContext = formatLocationAsXml(environment);
+    const messageIsForwarded = isForwardedFlag ?? isForwardedMessage(message);
+
+    const { content, attachments } = this.resolveMessageContent(message, messageIsForwarded);
+
+    return {
+      attachments,
+      reference: {
+        referenceNumber,
+        discordMessageId: message.id,
+        webhookId: message.webhookId ?? undefined,
+        discordUserId: message.author.id,
+        authorUsername: message.author.username,
+        authorDisplayName: message.author.displayName ?? message.author.username,
+        content,
+        embeds: EmbedParser.parseMessageEmbeds(message),
+        timestamp: message.createdAt.toISOString(),
+        locationContext,
+        attachments: attachments.length > 0 ? attachments : undefined,
+        isForwarded: messageIsForwarded || undefined,
+      },
+    };
+  }
+
+  /**
+   * Format a Discord message as a referenced message, returning both the
+   * enriched form (voice transcripts appended) and the raw pre-enrichment
+   * snapshot for the assembly envelope.
+   */
+  async formatMessageWithRaw(
+    message: Message,
+    referenceNumber: number,
+    isForwardedFlag?: boolean
+  ): Promise<{ enriched: ReferencedMessage; raw: ReferencedMessage }> {
+    const { reference: raw, attachments } = this.buildRawReference(
+      message,
+      referenceNumber,
+      isForwardedFlag
+    );
+    const contentWithTranscript = await this.appendVoiceTranscripts(
+      raw.content,
+      attachments,
+      message.id
+    );
+    return { raw, enriched: { ...raw, content: contentWithTranscript } };
+  }
+
+  /**
    * Format a Discord message as a referenced message
    * @param message - Discord message
    * @param referenceNumber - Reference number
@@ -106,30 +166,7 @@ export class MessageFormatter {
     referenceNumber: number,
     isForwardedFlag?: boolean
   ): Promise<ReferencedMessage> {
-    const environment = extractDiscordEnvironment(message);
-    const locationContext = formatLocationAsXml(environment);
-    const messageIsForwarded = isForwardedFlag ?? isForwardedMessage(message);
-
-    const { content, attachments } = this.resolveMessageContent(message, messageIsForwarded);
-    const contentWithTranscript = await this.appendVoiceTranscripts(
-      content,
-      attachments,
-      message.id
-    );
-
-    return {
-      referenceNumber,
-      discordMessageId: message.id,
-      webhookId: message.webhookId ?? undefined,
-      discordUserId: message.author.id,
-      authorUsername: message.author.username,
-      authorDisplayName: message.author.displayName ?? message.author.username,
-      content: contentWithTranscript,
-      embeds: EmbedParser.parseMessageEmbeds(message),
-      timestamp: message.createdAt.toISOString(),
-      locationContext,
-      attachments: attachments.length > 0 ? attachments : undefined,
-      isForwarded: messageIsForwarded || undefined,
-    };
+    const { enriched } = await this.formatMessageWithRaw(message, referenceNumber, isForwardedFlag);
+    return enriched;
   }
 }

--- a/services/bot-client/src/handlers/references/ReferenceFormatter.test.ts
+++ b/services/bot-client/src/handlers/references/ReferenceFormatter.test.ts
@@ -18,22 +18,50 @@ describe('ReferenceFormatter', () => {
 
   beforeEach(() => {
     // Mock MessageFormatter
+    const buildRef = (message: Message, refNum: number) => ({
+      referenceNumber: refNum,
+      discordMessageId: message.id,
+      discordUserId: message.author.id,
+      authorUsername: message.author.username,
+      authorDisplayName: message.author.displayName ?? message.author.username,
+      content: message.content,
+      embeds: '',
+      timestamp: message.createdAt.toISOString(),
+      locationContext: 'this channel',
+    });
     mockMessageFormatter = {
-      formatMessage: vi.fn().mockImplementation(async (message: Message, refNum: number) => ({
-        referenceNumber: refNum,
-        discordMessageId: message.id,
-        discordUserId: message.author.id,
-        authorUsername: message.author.username,
-        authorDisplayName: message.author.displayName ?? message.author.username,
-        content: message.content,
-        embeds: '',
-        timestamp: message.createdAt.toISOString(),
-        locationContext: 'this channel',
+      formatMessage: vi
+        .fn()
+        .mockImplementation(async (message: Message, refNum: number) => buildRef(message, refNum)),
+      formatMessageWithRaw: vi
+        .fn()
+        .mockImplementation(async (message: Message, refNum: number) => ({
+          enriched: buildRef(message, refNum),
+          raw: buildRef(message, refNum),
+        })),
+      buildRawReference: vi.fn().mockImplementation((message: Message, refNum: number) => ({
+        reference: buildRef(message, refNum),
+        attachments: [],
       })),
     } as unknown as MessageFormatter;
 
     // Mock SnapshotFormatter
-    mockSnapshotFormatter = {} as any;
+    mockSnapshotFormatter = {
+      formatSnapshot: vi
+        .fn()
+        .mockImplementation((snapshot: { content?: string }, refNum: number) => ({
+          referenceNumber: refNum,
+          discordMessageId: `snapshot-msg-${refNum}`,
+          discordUserId: 'fwd-user',
+          authorUsername: 'fwd',
+          authorDisplayName: 'Fwd',
+          content: snapshot.content ?? '',
+          embeds: '',
+          timestamp: new Date('2025-01-01T12:00:00Z').toISOString(),
+          locationContext: '',
+          isForwarded: true,
+        })),
+    } as any;
 
     formatter = new ReferenceFormatter(mockMessageFormatter, mockSnapshotFormatter);
   });
@@ -516,6 +544,123 @@ describe('ReferenceFormatter', () => {
 
       // Should limit to 10
       expect(result.references).toHaveLength(10);
+    });
+  });
+
+  describe('collectRaw (raw assembly envelope)', () => {
+    it('returns full pre-dedup raw snapshots alongside stubbed enriched references', async () => {
+      const longContent = 'B'.repeat(200);
+      const crawledMessages = new Map<string, { message: Message; metadata: ReferenceMetadata }>([
+        [
+          'deduped-1',
+          {
+            message: createMockMessage({ id: 'deduped-1', content: longContent }),
+            metadata: {
+              messageId: 'deduped-1',
+              depth: 1,
+              timestamp: new Date('2025-01-01T00:00:00Z'),
+              isDeduplicated: true,
+            },
+          },
+        ],
+      ]);
+
+      const result = await formatter.format('content', crawledMessages, 10, { collectRaw: true });
+
+      // Enriched side: stubbed (truncated, isDeduplicated).
+      expect(result.references[0].isDeduplicated).toBe(true);
+      expect(result.references[0].content.length).toBeLessThan(longContent.length);
+      // Raw side: FULL content, same reference number — the worker re-derives
+      // dedup against its own hydrated history.
+      expect(result.rawReferences).toHaveLength(1);
+      expect(result.rawReferences?.[0].content).toBe(longContent);
+      expect(result.rawReferences?.[0].referenceNumber).toBe(result.references[0].referenceNumber);
+    });
+
+    it('collects the raw snapshot for regular messages (raw = pre-transcript content)', async () => {
+      const crawledMessages = new Map<string, { message: Message; metadata: ReferenceMetadata }>([
+        [
+          'regular-raw',
+          {
+            message: createMockMessage({ id: 'regular-raw', content: 'plain message' }),
+            metadata: {
+              messageId: 'regular-raw',
+              depth: 1,
+              timestamp: new Date('2025-01-01T00:00:00Z'),
+            },
+          },
+        ],
+      ]);
+
+      const result = await formatter.format('content', crawledMessages, 10, { collectRaw: true });
+
+      expect(result.rawReferences).toHaveLength(1);
+      expect(result.rawReferences?.[0].content).toBe('plain message');
+      expect(result.rawReferences?.[0].referenceNumber).toBe(result.references[0].referenceNumber);
+    });
+
+    it('collects one raw entry per forwarded snapshot with consistent numbering', async () => {
+      const snapshotsMap = new Map();
+      snapshotsMap.set('s0', { content: 'first snapshot', attachments: new Map(), embeds: [] });
+      snapshotsMap.set('s1', { content: 'second snapshot', attachments: new Map(), embeds: [] });
+      const messageSnapshots = {
+        size: snapshotsMap.size,
+        values: () => snapshotsMap.values(),
+        first: () => snapshotsMap.values().next().value,
+      } as unknown as Collection<string, MessageSnapshot>;
+
+      const forwardedMessage = createMockMessage({
+        id: 'forwarded-raw',
+        content: '',
+        createdAt: new Date('2025-01-01T12:00:00Z'),
+        reference: { type: MessageReferenceType.Forward } as Message['reference'],
+        messageSnapshots,
+      });
+
+      const crawledMessages = new Map<string, { message: Message; metadata: ReferenceMetadata }>([
+        [
+          'forwarded-raw',
+          {
+            message: forwardedMessage,
+            metadata: {
+              messageId: 'forwarded-raw',
+              depth: 1,
+              timestamp: new Date('2025-01-01T12:00:00Z'),
+            },
+          },
+        ],
+      ]);
+
+      const result = await formatter.format('', crawledMessages, 10, { collectRaw: true });
+
+      // Each snapshot expands to its own enriched AND raw entry, numbers aligned.
+      expect(result.references).toHaveLength(2);
+      expect(result.rawReferences).toHaveLength(2);
+      expect(result.rawReferences?.map(r => r.referenceNumber)).toEqual(
+        result.references.map(r => r.referenceNumber)
+      );
+      expect(result.rawReferences?.[1].content).toBe('second snapshot');
+    });
+
+    it('omits rawReferences entirely when collectRaw is not requested', async () => {
+      const crawledMessages = new Map<string, { message: Message; metadata: ReferenceMetadata }>([
+        [
+          'regular-1',
+          {
+            message: createMockMessage({ id: 'regular-1', content: 'hello' }),
+            metadata: {
+              messageId: 'regular-1',
+              depth: 1,
+              timestamp: new Date('2025-01-01T00:00:00Z'),
+            },
+          },
+        ],
+      ]);
+
+      const result = await formatter.format('content', crawledMessages, 10);
+
+      expect(result.rawReferences).toBeUndefined();
+      expect(result.references).toHaveLength(1);
     });
   });
 });

--- a/services/bot-client/src/handlers/references/ReferenceFormatter.ts
+++ b/services/bot-client/src/handlers/references/ReferenceFormatter.ts
@@ -23,6 +23,22 @@ interface FormattedResult {
   references: ReferencedMessage[];
   /** Updated message content with links replaced by [Reference N] */
   updatedContent: string;
+  /**
+   * Raw pre-enrichment snapshots (only when `collectRaw` was requested):
+   * same numbering as `references`, but full content always — no transcript
+   * append, no dedup stubbing — so the worker-side assembler can re-run both
+   * enrichments itself.
+   */
+  rawReferences?: ReferencedMessage[];
+}
+
+/** Mutable accumulation state threaded through the per-message branch handlers. */
+interface FormatState {
+  references: ReferencedMessage[];
+  rawReferences: ReferencedMessage[];
+  collectRaw: boolean;
+  linkMap: Map<string, number>;
+  nextNumber: number;
 }
 
 /**
@@ -44,8 +60,11 @@ export class ReferenceFormatter {
   async format(
     originalContent: string,
     crawledMessages: Map<string, { message: Message; metadata: ReferenceMetadata }>,
-    maxReferences: number
+    maxReferences: number,
+    options: { collectRaw?: boolean } = {}
   ): Promise<FormattedResult> {
+    const collectRaw = options.collectRaw === true;
+    const rawReferences: ReferencedMessage[] = [];
     // Convert to array for sorting
     const messagesArray = Array.from(crawledMessages.values());
 
@@ -74,45 +93,15 @@ export class ReferenceFormatter {
     // Format messages and assign reference numbers
     const references: ReferencedMessage[] = [];
     const linkMap = new Map<string, number>(); // Map Discord URL to reference number
-    let currentNumber = 1;
 
+    const state: FormatState = { references, rawReferences, collectRaw, linkMap, nextNumber: 1 };
     for (const { message, metadata } of selected) {
-      // Deduped stubs: minimal ReferencedMessage with truncated content
       if (metadata.isDeduplicated === true) {
-        references.push(this.buildDedupedStub(message, currentNumber));
-        this.trackLink(metadata, currentNumber, linkMap);
-        currentNumber++;
-        continue;
-      }
-
-      // Check if this is a forwarded message with snapshots
-      if (isForwardedMessage(message)) {
-        // Extract each snapshot from the forward as a separate reference
-        for (const snapshot of message.messageSnapshots.values()) {
-          const snapshotReference = this.snapshotFormatter.formatSnapshot(
-            snapshot,
-            currentNumber,
-            message
-          );
-          references.push(snapshotReference);
-          this.trackLink(metadata, currentNumber, linkMap);
-          currentNumber++;
-
-          logger.debug(
-            {
-              messageId: message.id,
-              snapshotContent: snapshot.content?.substring(0, 50),
-              referenceNumber: currentNumber - 1,
-            },
-            'Added snapshot from forwarded message'
-          );
-        }
+        this.appendDedupedStub(message, metadata, state);
+      } else if (isForwardedMessage(message)) {
+        this.appendForwardedSnapshots(message, metadata, state);
       } else {
-        // Regular message (not a forward)
-        const formattedMessage = await this.messageFormatter.formatMessage(message, currentNumber);
-        references.push(formattedMessage);
-        this.trackLink(metadata, currentNumber, linkMap);
-        currentNumber++;
+        await this.appendRegular(message, metadata, state);
       }
     }
 
@@ -130,7 +119,73 @@ export class ReferenceFormatter {
     return {
       references,
       updatedContent,
+      ...(collectRaw && { rawReferences }),
     };
+  }
+
+  /** Deduped: enriched side gets a stub; raw side gets the full snapshot. */
+  private appendDedupedStub(message: Message, metadata: ReferenceMetadata, s: FormatState): void {
+    s.references.push(this.buildDedupedStub(message, s.nextNumber));
+    if (s.collectRaw) {
+      // The raw side never stubs: the worker re-derives dedup against its
+      // OWN hydrated history, so it needs the full pre-dedup snapshot.
+      s.rawReferences.push(
+        this.messageFormatter.buildRawReference(message, s.nextNumber).reference
+      );
+    }
+    this.trackLink(metadata, s.nextNumber, s.linkMap);
+    s.nextNumber++;
+  }
+
+  /** Forwarded: each snapshot becomes a reference; raw = enriched (no DB enrichment). */
+  private appendForwardedSnapshots(
+    message: Message & { messageSnapshots: NonNullable<Message['messageSnapshots']> },
+    metadata: ReferenceMetadata,
+    s: FormatState
+  ): void {
+    for (const snapshot of message.messageSnapshots.values()) {
+      const snapshotReference = this.snapshotFormatter.formatSnapshot(
+        snapshot,
+        s.nextNumber,
+        message
+      );
+      s.references.push(snapshotReference);
+      if (s.collectRaw) {
+        s.rawReferences.push({ ...snapshotReference });
+      }
+      // All snapshots of one forward share the crawled entry's discordUrl, and
+      // trackLink uses Map.set — so the LAST snapshot's number wins and the
+      // [Reference N] link resolves to the forward's final snapshot.
+      this.trackLink(metadata, s.nextNumber, s.linkMap);
+      s.nextNumber++;
+
+      logger.debug(
+        {
+          messageId: message.id,
+          snapshotContent: snapshot.content?.substring(0, 50),
+          referenceNumber: s.nextNumber - 1,
+        },
+        'Added snapshot from forwarded message'
+      );
+    }
+  }
+
+  /** Regular: enriched (transcripts appended) + raw pre-enrichment snapshot. */
+  private async appendRegular(
+    message: Message,
+    metadata: ReferenceMetadata,
+    s: FormatState
+  ): Promise<void> {
+    const { enriched, raw } = await this.messageFormatter.formatMessageWithRaw(
+      message,
+      s.nextNumber
+    );
+    s.references.push(enriched);
+    if (s.collectRaw) {
+      s.rawReferences.push(raw);
+    }
+    this.trackLink(metadata, s.nextNumber, s.linkMap);
+    s.nextNumber++;
   }
 
   /** Build a minimal ReferencedMessage for a deduped reference */

--- a/services/bot-client/src/services/MessageContextBuilder.ts
+++ b/services/bot-client/src/services/MessageContextBuilder.ts
@@ -496,7 +496,11 @@ export class MessageContextBuilder {
 
     // Raw-envelope assembly inputs (worker-side shadow assembler burn-in);
     // undefined unless CONTEXT_RAW_ENVELOPE=true.
-    const rawAssemblyInputs = buildRawAssemblyInputs(message, content, extendedContext.raw);
+    const rawAssemblyInputs = buildRawAssemblyInputs(message, content, extendedContext.raw, {
+      rawReferencedMessages: refsAndMentions.rawReferencedMessages,
+      rawMentionedChannels: refsAndMentions.rawMentionedChannels,
+      rawMentionedRoles: refsAndMentions.rawMentionedRoles,
+    });
 
     // Build complete context
     // Note: userId is the Discord ID (for BYOK resolution)

--- a/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.test.ts
+++ b/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.test.ts
@@ -130,6 +130,20 @@ describe('buildRawAssemblyInputs', () => {
     });
   });
 
+  it('passes reference and channel/role mention raws through', () => {
+    process.env.CONTEXT_RAW_ENVELOPE = 'true';
+    const raw = buildRawAssemblyInputs(makeMessage(), 'plain', undefined, {
+      rawReferencedMessages: [],
+      rawMentionedChannels: [{ channelId: '1', channelName: 'general', guildId: 'g1' }],
+      rawMentionedRoles: [{ roleId: '2', roleName: 'mods', mentionable: false }],
+    });
+
+    // Empty array preserved (extraction ran, found nothing) — not collapsed.
+    expect(raw?.rawReferencedMessages).toEqual([]);
+    expect(raw?.rawMentionedChannels?.[0].channelName).toBe('general');
+    expect(raw?.rawMentionedRoles?.[0].roleName).toBe('mods');
+  });
+
   it('omits rawMentionedUsers when the mentions collection is empty', () => {
     process.env.CONTEXT_RAW_ENVELOPE = 'true';
     const raw = buildRawAssemblyInputs(makeMessage(), 'plain', undefined);

--- a/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.ts
+++ b/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.ts
@@ -17,6 +17,9 @@ import {
   type ConversationMessage,
   type RawAssemblyInputs,
   type RawDiscordUser,
+  type ReferencedMessage,
+  type RawMentionedChannel,
+  type RawMentionedRole,
 } from '@tzurot/common-types';
 import type { z } from 'zod';
 import type { ExtendedContextUser, FetchResult } from '../channelFetcher/types.js';
@@ -104,13 +107,21 @@ export function toApiConversationMessage(msg: ConversationMessage): ApiConversat
 export function buildRawAssemblyInputs(
   message: Message,
   content: string,
-  raw: RawExtendedContextSnapshot | undefined
+  raw: RawExtendedContextSnapshot | undefined,
+  refs?: {
+    rawReferencedMessages?: ReferencedMessage[];
+    rawMentionedChannels?: RawMentionedChannel[];
+    rawMentionedRoles?: RawMentionedRole[];
+  }
 ): RawAssemblyInputs | undefined {
   if (!isRawEnvelopeEnabled()) {
     return undefined;
   }
   return {
     rawMessageContent: content,
+    rawReferencedMessages: refs?.rawReferencedMessages,
+    rawMentionedChannels: refs?.rawMentionedChannels,
+    rawMentionedRoles: refs?.rawMentionedRoles,
     rawMentionedUsers:
       message.mentions.users.size > 0
         ? [...message.mentions.users.values()].map(u => ({

--- a/services/bot-client/src/services/contextBuilder/ReferenceExtractor.test.ts
+++ b/services/bot-client/src/services/contextBuilder/ReferenceExtractor.test.ts
@@ -72,7 +72,65 @@ describe('extractReferencesAndMentions', () => {
       processedContent: 'Hello world',
       mentionedUsers: [],
       mentionedChannels: [],
+      mentionedRoles: [],
     });
+  });
+
+  it('captures raw envelope fields when CONTEXT_RAW_ENVELOPE=true', async () => {
+    process.env.CONTEXT_RAW_ENVELOPE = 'true';
+    try {
+      mockExtractReferences.mockResolvedValue({
+        references: [],
+        updatedContent: undefined,
+        rawReferences: [{ referenceNumber: 1, content: 'raw snapshot' }],
+      });
+      mockResolveAllMentions.mockResolvedValue({
+        processedContent: 'rewritten',
+        mentionedUsers: [],
+        mentionedChannels: [
+          { channelId: '1', channelName: 'general', topic: 'chat', guildId: 'g1' },
+        ],
+        mentionedRoles: [{ roleId: '2', roleName: 'mods', mentionable: true }],
+      });
+
+      const result = await extractReferencesAndMentions({
+        prisma: mockPrisma,
+        mentionResolver: mockMentionResolver as unknown as MentionResolver,
+        message: createMockMessage(),
+        content: 'Hello world',
+        personality: mockPersonality,
+        history: [],
+        maxReferences: 50,
+      });
+
+      expect(result.rawReferencedMessages).toEqual([
+        { referenceNumber: 1, content: 'raw snapshot' },
+      ]);
+      expect(result.rawMentionedChannels).toEqual([
+        { channelId: '1', channelName: 'general', topic: 'chat', guildId: 'g1' },
+      ]);
+      expect(result.rawMentionedRoles).toEqual([
+        { roleId: '2', roleName: 'mods', mentionable: true },
+      ]);
+    } finally {
+      delete process.env.CONTEXT_RAW_ENVELOPE;
+    }
+  });
+
+  it('omits raw envelope fields when the flag is off', async () => {
+    const result = await extractReferencesAndMentions({
+      prisma: mockPrisma,
+      mentionResolver: mockMentionResolver as unknown as MentionResolver,
+      message: createMockMessage(),
+      content: 'Hello world',
+      personality: mockPersonality,
+      history: [],
+      maxReferences: 50,
+    });
+
+    expect(result.rawReferencedMessages).toBeUndefined();
+    expect(result.rawMentionedChannels).toBeUndefined();
+    expect(result.rawMentionedRoles).toBeUndefined();
   });
 
   it('should return empty results in weigh-in mode', async () => {

--- a/services/bot-client/src/services/contextBuilder/ReferenceExtractor.ts
+++ b/services/bot-client/src/services/contextBuilder/ReferenceExtractor.ts
@@ -17,8 +17,11 @@ import {
   type ReferencedChannel,
   type ReferencedMessage,
   type ConversationMessage,
+  type RawMentionedChannel,
+  type RawMentionedRole,
 } from '@tzurot/common-types';
 import { MessageReferenceExtractor } from '../../handlers/MessageReferenceExtractor.js';
+import { isRawEnvelopeEnabled } from '../../utils/contextWritePath.js';
 import type { MentionResolver } from '../MentionResolver.js';
 
 const logger = createLogger('MessageContextBuilder');
@@ -29,6 +32,14 @@ export interface ReferencesAndMentionsResult {
   referencedMessages: ReferencedMessage[];
   mentionedPersonas?: MentionedPersona[];
   referencedChannels?: ReferencedChannel[];
+  /**
+   * Raw-envelope fields (present only when CONTEXT_RAW_ENVELOPE=true):
+   * pre-enrichment reference snapshots plus the guild-cache-resolved channel
+   * and role mention data the worker needs to re-run content rewriting.
+   */
+  rawReferencedMessages?: ReferencedMessage[];
+  rawMentionedChannels?: RawMentionedChannel[];
+  rawMentionedRoles?: RawMentionedRole[];
 }
 
 /** Options for reference extraction */
@@ -77,30 +88,7 @@ export async function extractReferencesAndMentions(
     .filter((id): id is string => id !== undefined && id !== null);
   const conversationHistoryTimestamps = history.map(msg => msg.createdAt);
 
-  // Debug logging for voice message replies
-  if (
-    message.attachments.some(
-      a =>
-        (a.contentType?.startsWith(CONTENT_TYPES.AUDIO_PREFIX) ?? false) ||
-        (a.duration !== null && a.duration !== undefined)
-    )
-  ) {
-    const mostRecentAssistant = history.filter(m => m.role === MessageRole.Assistant).slice(-1)[0];
-    const mostRecentAssistantIds = mostRecentAssistant?.discordMessageId ?? [];
-
-    logger.debug(
-      {
-        isReply: message.reference !== null,
-        replyToMessageId: message.reference?.messageId,
-        messageContent: content ?? '(empty - voice only)',
-        historyCount: history.length,
-        replyMatchesRecentAssistant: mostRecentAssistantIds.includes(
-          message.reference?.messageId ?? ''
-        ),
-      },
-      '[MessageContextBuilder] Processing voice message reply - deduplication data'
-    );
-  }
+  logVoiceReplyDiagnostics(message, content, history);
 
   // Extract referenced messages
   logger.debug('Extracting referenced messages with deduplication');
@@ -112,8 +100,11 @@ export async function extractReferencesAndMentions(
     conversationHistoryTimestamps,
   });
 
-  const { references: referencedMessages, updatedContent } =
-    await referenceExtractor.extractReferencesWithReplacement(message);
+  const {
+    references: referencedMessages,
+    updatedContent,
+    rawReferences,
+  } = await referenceExtractor.extractReferencesWithReplacement(message);
 
   if (referencedMessages.length > 0) {
     logger.info(
@@ -164,5 +155,80 @@ export async function extractReferencesAndMentions(
     );
   }
 
-  return { messageContent, referencedMessages, mentionedPersonas, referencedChannels };
+  const rawEnvelopeFields = captureRawEnvelopeFields(rawReferences, mentionResult);
+
+  return {
+    messageContent,
+    referencedMessages,
+    mentionedPersonas,
+    referencedChannels,
+    ...rawEnvelopeFields,
+  };
+}
+
+/** Voice-message-reply dedup diagnostics (debug-only). */
+function logVoiceReplyDiagnostics(
+  message: Message,
+  content: string,
+  history: ConversationMessage[]
+): void {
+  const hasVoiceAttachment = message.attachments.some(
+    a =>
+      (a.contentType?.startsWith(CONTENT_TYPES.AUDIO_PREFIX) ?? false) ||
+      (a.duration !== null && a.duration !== undefined)
+  );
+  if (!hasVoiceAttachment) {
+    return;
+  }
+  const mostRecentAssistant = history.filter(m => m.role === MessageRole.Assistant).slice(-1)[0];
+  const mostRecentAssistantIds = mostRecentAssistant?.discordMessageId ?? [];
+
+  logger.debug(
+    {
+      isReply: message.reference !== null,
+      replyToMessageId: message.reference?.messageId,
+      messageContent: content ?? '(empty - voice only)',
+      historyCount: history.length,
+      replyMatchesRecentAssistant: mostRecentAssistantIds.includes(
+        message.reference?.messageId ?? ''
+      ),
+    },
+    '[MessageContextBuilder] Processing voice message reply - deduplication data'
+  );
+}
+
+/**
+ * Raw-envelope capture: the mention resolver already produced the
+ * guild-cache-pure channel/role data — reuse it rather than re-scanning.
+ * Undefined unless CONTEXT_RAW_ENVELOPE=true.
+ */
+type RawEnvelopeFields = Pick<
+  ReferencesAndMentionsResult,
+  'rawReferencedMessages' | 'rawMentionedChannels' | 'rawMentionedRoles'
+>;
+
+function captureRawEnvelopeFields(
+  rawReferences: ReferencedMessage[] | undefined,
+  mentionResult: Awaited<ReturnType<MentionResolver['resolveAllMentions']>>
+): RawEnvelopeFields | undefined {
+  if (!isRawEnvelopeEnabled()) {
+    return undefined;
+  }
+  return {
+    // No `?? []` fallback: when the envelope flag is on the extractor always
+    // produced an array, and if a future path legitimately passes undefined,
+    // ABSENT is the accurate signal to propagate (see schema semantics).
+    rawReferencedMessages: rawReferences,
+    rawMentionedChannels: mentionResult.mentionedChannels.map(ch => ({
+      channelId: ch.channelId,
+      channelName: ch.channelName,
+      topic: ch.topic,
+      guildId: ch.guildId,
+    })),
+    rawMentionedRoles: mentionResult.mentionedRoles.map(r => ({
+      roleId: r.roleId,
+      roleName: r.roleName,
+      mentionable: r.mentionable,
+    })),
+  };
 }


### PR DESCRIPTION
## Summary

Second slice of iii-a: the raw assembly envelope is now **complete** — every Discord-origin input the worker-side context assembler needs ships when `CONTEXT_RAW_ENVELOPE=true`. The remaining iii-a work (a3: the assembler + extended shadow) is pure ai-worker against a finished, documented input contract.

### Raw reference snapshots (the iii-a1 deferral, shaped by its consumer)

- **`MessageFormatter` split**: a pure synchronous `buildRawReference` (every Discord field, pre-transcript content) + `formatMessageWithRaw` layering the one DB/Redis enrichment (voice transcripts) on top. `formatMessage` delegates — zero caller churn.
- **`ReferenceFormatter` collects the raw side** when asked (`collectRaw`, driven by the envelope flag): full content always — no transcript append, no dedup stubbing. Two properties make worker-side re-derivation sound:
  - **Numbering is dedup-independent** (stubs consume numbers too), so the worker's own dedup decisions against its hydrated history never renumber references or break `[Reference N]` links.
  - **The raw side never stubs** — deduped messages get a full pure-format snapshot, because the worker re-decides dedup itself.
- `format()` decomposed into three branch handlers (`appendDedupedStub` / `appendForwardedSnapshots` / `appendRegular`) around a threaded `FormatState` — the collectRaw branches pushed cognitive complexity over the cap, and the decomposition reads better anyway.

### Channel/role mention raws (the uncoverable gap)

Worker-side content rewriting needs guild-cache names. Channels were partially covered by the env map (sans topic); **roles had no envelope source at all**. Both now captured from the mention resolver's existing guild-cache-pure output — no re-scanning, no new regex.

### Schemas in their own home

`types/schemas/rawEnvelope.ts` (the reviewer-suggested extraction, done at the shape-stabilizing moment) with the iii-a1 fold-forward docs landed: ABSENT/EMPTY semantics per field class, including `rawMentionedUsers`'s no-distinction-needed note and `rawReferencedMessages`'s ABSENT = sender-predates-field contract.

### Test plan

- 2 collectRaw tests (full-content raw for stubbed references with matching numbers; absent when not requested), refs-passthrough + empty-array-preserved test, 2 schema contract tests, MessageFormatter suite green through the split
- Full suites: bot-client 5008, common-types 2645; `pnpm quality` clean

### Next

iii-a3: the worker-side assembler + extended shadow (real-DB hydration, match-rate telemetry gating iii-b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)