### PR TITLE
feat(ai-worker): PR 2.5c-iii-a3-ii-1 — worker-side reference enrichment

### DIFF
--- a/packages/common-types/src/index.ts
+++ b/packages/common-types/src/index.ts
@@ -89,6 +89,7 @@ export * from './services/ConversationSyncService.js';
 export * from './services/conversationSyncDiff.js';
 export * from './utils/historyMerger.js';
 export * from './utils/extendedContextPersonaResolver.js';
+export * from './utils/referenceEnrichment.js';
 export * from './services/UserService.js';
 export * from './services/BaseCacheInvalidationService.js';
 export * from './services/CacheInvalidationService.js';

--- a/packages/common-types/src/types/schemas/message.test.ts
+++ b/packages/common-types/src/types/schemas/message.test.ts
@@ -9,6 +9,7 @@ import { MessageRole } from '../../constants/index.js';
 import {
   crossChannelMessageSchema,
   crossChannelHistoryGroupSchema,
+  referencedMessageSchema,
   type CrossChannelMessage,
   type CrossChannelHistoryGroupEntry,
 } from './message.js';
@@ -179,5 +180,41 @@ describe('crossChannelHistoryGroupSchema', () => {
 
     const result = crossChannelHistoryGroupSchema.safeParse(group);
     expect(result.success).toBe(true);
+  });
+});
+
+describe('referencedMessageSchema', () => {
+  const base = {
+    referenceNumber: 1,
+    discordMessageId: 'd1',
+    discordUserId: 'u1',
+    authorUsername: 'someone',
+    authorDisplayName: 'Someone',
+    content: 'referenced',
+    embeds: '',
+    timestamp: '2026-06-01T00:00:00.000Z',
+    locationContext: '',
+  };
+
+  it('accepts a minimal reference without authorIsBot (presence-encoded)', () => {
+    const result = referencedMessageSchema.safeParse(base);
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.authorIsBot).toBeUndefined();
+  });
+
+  it('accepts authorIsBot true for bot-authored references', () => {
+    const result = referencedMessageSchema.safeParse({ ...base, authorIsBot: true });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.authorIsBot).toBe(true);
+  });
+
+  it('rejects a non-boolean authorIsBot', () => {
+    const result = referencedMessageSchema.safeParse({ ...base, authorIsBot: 'yes' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an explicit false (presence-encoding enforced at parse time)', () => {
+    const result = referencedMessageSchema.safeParse({ ...base, authorIsBot: false });
+    expect(result.success).toBe(false);
   });
 });

--- a/packages/common-types/src/types/schemas/message.ts
+++ b/packages/common-types/src/types/schemas/message.ts
@@ -46,6 +46,11 @@ export const referencedMessageSchema = z.object({
   referenceNumber: z.number(),
   discordMessageId: z.string(), // Discord message ID (for webhook detection)
   webhookId: z.string().optional(), // Discord webhook ID if message was sent via webhook
+  // Presence-encoded (true or omitted — literal(true) rejects an accidental
+  // `false` at parse time). Together with webhookId this gates the time-based
+  // dedup fallback, which the worker-side assembler re-runs from raw
+  // reference snapshots — it cannot ask Discord about the author itself.
+  authorIsBot: z.literal(true).optional(),
   discordUserId: z.string(), // Discord user ID for persona lookup
   authorUsername: z.string(),
   authorDisplayName: z.string(),

--- a/packages/common-types/src/utils/referenceEnrichment.test.ts
+++ b/packages/common-types/src/utils/referenceEnrichment.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi } from 'vitest';
+import { INTERVALS } from '../constants/timing.js';
+import { TEXT_LIMITS } from '../constants/discord.js';
+import type { ReferencedMessage } from '../types/schemas/message.js';
+import {
+  appendVoiceTranscripts,
+  buildDedupedReferenceStub,
+  isDuplicateReference,
+  type ReferenceDedupCandidate,
+} from './referenceEnrichment.js';
+
+const NOW = new Date('2026-06-01T12:00:00Z').getTime();
+
+function candidate(partial: Partial<ReferenceDedupCandidate> = {}): ReferenceDedupCandidate {
+  return {
+    discordMessageId: 'msg-1',
+    timestampMs: NOW - 1_000,
+    isWebhookOrBotAuthored: false,
+    ...partial,
+  };
+}
+
+describe('isDuplicateReference', () => {
+  it('matches exactly on a history message id', () => {
+    expect(
+      isDuplicateReference(candidate(), { messageIds: new Set(['msg-1']), timestamps: [] }, NOW)
+    ).toBe(true);
+  });
+
+  it('does not match a human-authored message outside history', () => {
+    expect(
+      isDuplicateReference(
+        candidate(),
+        { messageIds: new Set(['other']), timestamps: [new Date(NOW - 1_000)] },
+        NOW
+      )
+    ).toBe(false);
+  });
+
+  it('time-fallback matches a recent webhook message within tolerance', () => {
+    expect(
+      isDuplicateReference(
+        candidate({ isWebhookOrBotAuthored: true }),
+        {
+          messageIds: new Set(['other']),
+          // Within MESSAGE_TIMESTAMP_TOLERANCE of the candidate's timestamp.
+          timestamps: [new Date(NOW - 1_000 + INTERVALS.MESSAGE_TIMESTAMP_TOLERANCE - 1)],
+        },
+        NOW
+      )
+    ).toBe(true);
+  });
+
+  it('time-fallback rejects when the timestamp gap exceeds tolerance', () => {
+    expect(
+      isDuplicateReference(
+        candidate({ isWebhookOrBotAuthored: true }),
+        {
+          messageIds: new Set(),
+          timestamps: [new Date(NOW - 1_000 + INTERVALS.MESSAGE_TIMESTAMP_TOLERANCE)],
+        },
+        NOW
+      )
+    ).toBe(false);
+  });
+
+  it('time-fallback skips messages older than the dedup window', () => {
+    const oldTimestamp = NOW - INTERVALS.MESSAGE_AGE_DEDUP_WINDOW;
+    expect(
+      isDuplicateReference(
+        candidate({ isWebhookOrBotAuthored: true, timestampMs: oldTimestamp }),
+        { messageIds: new Set(), timestamps: [new Date(oldTimestamp)] },
+        NOW
+      )
+    ).toBe(false);
+  });
+
+  it('skips the time fallback entirely when nowMs is undefined', () => {
+    expect(
+      isDuplicateReference(
+        candidate({ isWebhookOrBotAuthored: true }),
+        { messageIds: new Set(), timestamps: [new Date(NOW - 1_000)] },
+        undefined
+      )
+    ).toBe(false);
+  });
+
+  it('still exact-matches by id when nowMs is undefined', () => {
+    expect(
+      isDuplicateReference(
+        candidate(),
+        { messageIds: new Set(['msg-1']), timestamps: [] },
+        undefined
+      )
+    ).toBe(true);
+  });
+});
+
+function fullReference(content: string): ReferencedMessage {
+  return {
+    referenceNumber: 3,
+    discordMessageId: 'msg-9',
+    webhookId: 'wh-1',
+    authorIsBot: true,
+    discordUserId: 'user-1',
+    authorUsername: 'someone',
+    authorDisplayName: 'Someone',
+    content,
+    embeds: '<embed>stuff</embed>',
+    timestamp: '2026-06-01T11:59:00.000Z',
+    locationContext: '<location>here</location>',
+    attachments: [{ url: 'https://cdn/x.png', contentType: 'image/png', name: 'x.png' }],
+    isForwarded: true,
+  };
+}
+
+describe('buildDedupedReferenceStub', () => {
+  it('keeps short content and strips embeds/location/attachments/flags', () => {
+    const stub = buildDedupedReferenceStub(fullReference('short content'));
+    expect(stub).toEqual({
+      referenceNumber: 3,
+      discordMessageId: 'msg-9',
+      discordUserId: 'user-1',
+      authorUsername: 'someone',
+      authorDisplayName: 'Someone',
+      content: 'short content',
+      embeds: '',
+      timestamp: '2026-06-01T11:59:00.000Z',
+      locationContext: '',
+      isDeduplicated: true,
+    });
+  });
+
+  it('truncates content beyond the stub limit with an ellipsis', () => {
+    const long = 'x'.repeat(TEXT_LIMITS.DEDUP_STUB_CONTENT + 10);
+    const stub = buildDedupedReferenceStub(fullReference(long));
+    expect(stub.content).toBe('x'.repeat(TEXT_LIMITS.DEDUP_STUB_CONTENT) + '...');
+  });
+});
+
+describe('appendVoiceTranscripts', () => {
+  const voiceAttachment = {
+    url: 'https://cdn/voice.ogg',
+    contentType: 'audio/ogg',
+    name: 'voice.ogg',
+    isVoiceMessage: true,
+  };
+
+  it('returns content unchanged when there are no attachments', async () => {
+    const retrieve = vi.fn();
+    const result = await appendVoiceTranscripts({
+      content: 'hello',
+      attachments: [],
+      discordMessageId: 'm1',
+      retrieve,
+    });
+    expect(result).toBe('hello');
+    expect(retrieve).not.toHaveBeenCalled();
+  });
+
+  it('skips non-voice attachments', async () => {
+    const retrieve = vi.fn();
+    const result = await appendVoiceTranscripts({
+      content: 'hello',
+      attachments: [{ url: 'https://cdn/x.png', contentType: 'image/png', name: 'x.png' }],
+      discordMessageId: 'm1',
+      retrieve,
+    });
+    expect(result).toBe('hello');
+    expect(retrieve).not.toHaveBeenCalled();
+  });
+
+  it('appends a found transcript to existing content', async () => {
+    const retrieve = vi.fn().mockResolvedValue('the transcript');
+    const result = await appendVoiceTranscripts({
+      content: 'hello',
+      attachments: [voiceAttachment],
+      discordMessageId: 'm1',
+      retrieve,
+    });
+    expect(retrieve).toHaveBeenCalledWith('m1', 'https://cdn/voice.ogg');
+    expect(result).toBe('hello\n\n[Voice transcript]: the transcript');
+  });
+
+  it('uses the transcript as the whole content when content is empty', async () => {
+    const retrieve = vi.fn().mockResolvedValue('only words');
+    const result = await appendVoiceTranscripts({
+      content: '',
+      attachments: [voiceAttachment],
+      discordMessageId: 'm1',
+      retrieve,
+    });
+    expect(result).toBe('[Voice transcript]: only words');
+  });
+
+  it('returns content unchanged when no transcript is found', async () => {
+    const retrieve = vi.fn().mockResolvedValue(null);
+    const result = await appendVoiceTranscripts({
+      content: 'hello',
+      attachments: [voiceAttachment],
+      discordMessageId: 'm1',
+      retrieve,
+    });
+    expect(result).toBe('hello');
+  });
+
+  it('joins multiple transcripts into one block', async () => {
+    const retrieve = vi
+      .fn()
+      .mockResolvedValueOnce('first part')
+      .mockResolvedValueOnce('second part');
+    const result = await appendVoiceTranscripts({
+      content: '',
+      attachments: [voiceAttachment, { ...voiceAttachment, url: 'https://cdn/voice2.ogg' }],
+      discordMessageId: 'm1',
+      retrieve,
+    });
+    expect(result).toBe('[Voice transcript]: first part\n\nsecond part');
+  });
+});

--- a/packages/common-types/src/utils/referenceEnrichment.ts
+++ b/packages/common-types/src/utils/referenceEnrichment.ts
@@ -1,0 +1,153 @@
+/**
+ * Reference enrichment kernels — the pure decision/transform logic shared by
+ * bot-client's reference pipeline (crawler + formatter) and ai-worker's
+ * context assembler.
+ *
+ * Shared-implementation guarantee: both sides call these exact functions, so
+ * the dedup decision, the stub shape, and the transcript-append format cannot
+ * drift between the legacy bot-side path and the worker-side re-derivation.
+ *
+ * What stays caller-side: HOW the inputs are obtained. Bot-client derives
+ * candidates from live Discord `Message` objects and retrieves transcripts
+ * through its Redis-cache + DB tiers; ai-worker derives candidates from raw
+ * envelope reference snapshots and retrieves transcripts DB-only.
+ */
+
+import { TEXT_LIMITS } from '../constants/discord.js';
+import { INTERVALS } from '../constants/timing.js';
+import type { AttachmentMetadata } from '../types/schemas/discord.js';
+import type { ReferencedMessage } from '../types/schemas/message.js';
+
+/** The fields the dedup decision reads — derivable from either a live Discord message or a raw reference snapshot. */
+export interface ReferenceDedupCandidate {
+  /** Discord message id of the referenced message. */
+  discordMessageId: string;
+  /** Message creation time (epoch ms). */
+  timestampMs: number;
+  /**
+   * Whether the referenced message was authored by a webhook or a bot — the
+   * only authors eligible for the time-based fallback (personality replies
+   * arrive via webhook and may be persisted under a different Discord id).
+   */
+  isWebhookOrBotAuthored: boolean;
+}
+
+/** Conversation-history view the dedup decision compares against. */
+export interface ReferenceDedupHistory {
+  /** Every Discord message id present in the conversation history. */
+  messageIds: ReadonlySet<string>;
+  /** Creation timestamps of the history rows (for the time-based fallback). */
+  timestamps: readonly Date[];
+}
+
+/**
+ * Decide whether a referenced message duplicates conversation history.
+ *
+ * Exact match: the candidate's Discord id appears in history. Time-based
+ * fallback: webhook/bot-authored candidates created within the dedup window
+ * of `nowMs` whose timestamp matches a history row within tolerance (covers
+ * personality replies whose webhook message id differs from the persisted
+ * row's id).
+ *
+ * `nowMs` anchors the recency window: bot-client passes wall-clock at crawl
+ * time, ai-worker passes the job's enqueue timestamp (the closest available
+ * stand-in — re-running with the worker's wall clock would shrink the window
+ * by the queue latency). When undefined, the time-based fallback is skipped
+ * entirely and only exact-id matching applies.
+ */
+export function isDuplicateReference(
+  candidate: ReferenceDedupCandidate,
+  history: ReferenceDedupHistory,
+  nowMs: number | undefined
+): boolean {
+  if (history.messageIds.has(candidate.discordMessageId)) {
+    return true;
+  }
+
+  if (!candidate.isWebhookOrBotAuthored || nowMs === undefined) {
+    return false;
+  }
+
+  const ageMs = nowMs - candidate.timestampMs;
+  if (ageMs >= INTERVALS.MESSAGE_AGE_DEDUP_WINDOW) {
+    return false;
+  }
+
+  for (const historyTimestamp of history.timestamps) {
+    const timeDiff = Math.abs(candidate.timestampMs - historyTimestamp.getTime());
+    if (timeDiff < INTERVALS.MESSAGE_TIMESTAMP_TOLERANCE) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Collapse a full reference into the minimal deduplicated stub: truncated
+ * content, no embeds/location/attachments. The stub keeps the reference
+ * number — numbering is assigned before the dedup decision, so stubs consume
+ * numbers and downstream `[Reference N]` links stay stable.
+ */
+export function buildDedupedReferenceStub(reference: ReferencedMessage): ReferencedMessage {
+  const limit = TEXT_LIMITS.DEDUP_STUB_CONTENT;
+  const truncatedContent =
+    reference.content.length > limit
+      ? reference.content.substring(0, limit) + '...'
+      : reference.content;
+  return {
+    referenceNumber: reference.referenceNumber,
+    discordMessageId: reference.discordMessageId,
+    discordUserId: reference.discordUserId,
+    authorUsername: reference.authorUsername,
+    authorDisplayName: reference.authorDisplayName,
+    content: truncatedContent,
+    embeds: '',
+    timestamp: reference.timestamp,
+    locationContext: '',
+    isDeduplicated: true,
+  };
+}
+
+/** Retrieves the transcript for one voice attachment, or null when unavailable. */
+export type TranscriptRetrieveFn = (
+  discordMessageId: string,
+  attachmentUrl: string
+) => Promise<string | null>;
+
+/**
+ * Append voice transcripts to reference content. For each voice attachment,
+ * the retriever is consulted; found transcripts are joined and appended as a
+ * single `[Voice transcript]:` block. Content is returned unchanged when the
+ * message has no voice attachments or no transcripts are found.
+ */
+export async function appendVoiceTranscripts(opts: {
+  content: string;
+  attachments: readonly AttachmentMetadata[];
+  discordMessageId: string;
+  retrieve: TranscriptRetrieveFn;
+}): Promise<string> {
+  const { content, attachments, discordMessageId, retrieve } = opts;
+  if (attachments.length === 0) {
+    return content;
+  }
+
+  const voiceAttachments = attachments.filter(a => a.isVoiceMessage === true);
+  if (voiceAttachments.length === 0) {
+    return content;
+  }
+
+  // Parallel fetches; Promise.all preserves attachment order, so the joined
+  // transcript block reads in the same order the attachments appear.
+  const retrieved = await Promise.all(voiceAttachments.map(a => retrieve(discordMessageId, a.url)));
+  const transcripts = retrieved.filter((t): t is string => t !== null && t.length > 0);
+
+  if (transcripts.length === 0) {
+    return content;
+  }
+
+  const transcriptText = transcripts.join('\n\n');
+  return content
+    ? `${content}\n\n[Voice transcript]: ${transcriptText}`
+    : `[Voice transcript]: ${transcriptText}`;
+}

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/ContextStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/ContextStep.test.ts
@@ -120,6 +120,7 @@ describe('ContextStep', () => {
       getCrossChannelHistory: vi.fn(),
       getUserTimezone: vi.fn(),
       getContextEpoch: vi.fn(),
+      getMessageByDiscordId: vi.fn().mockResolvedValue(null),
     };
 
     it('invokes shadow hydration when a data source is provided and the flag is on', () => {

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/ContextStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/ContextStep.ts
@@ -79,24 +79,27 @@ export class ContextStep implements IPipelineStep {
    * per the constructor JSDoc.
    */
   private dispatchShadow(
-    jobId: string | number | undefined,
+    job: { id?: string | number; timestamp?: number },
     jobContext: GenerationContext['job']['data']['context'],
     personality: GenerationContext['job']['data']['personality'],
     configOverrides: GenerationContext['configOverrides']
   ): void {
     if (jobContext.rawAssemblyInputs !== undefined && this.contextAssembler !== undefined) {
       void shadowAssembleAndDiff({
-        jobId,
+        jobId: job.id,
         jobContext,
         personality,
         configOverrides,
         assembler: this.contextAssembler,
+        // Enqueue time stands in for the bot's crawl-time wall clock in the
+        // reference time-fallback dedup window.
+        jobTimestampMs: job.timestamp,
       });
       return;
     }
     if (this.contextDataSource !== undefined) {
       void shadowHydrateAndDiff({
-        jobId,
+        jobId: job.id,
         jobContext,
         personalityId: personality.id,
         configOverrides,
@@ -114,7 +117,7 @@ export class ContextStep implements IPipelineStep {
     }
 
     if (this.shadowEnabled) {
-      this.dispatchShadow(job.id, jobContext, personality, context.configOverrides);
+      this.dispatchShadow(job, jobContext, personality, context.configOverrides);
     }
 
     // Calculate oldest timestamp from conversation history AND referenced messages

--- a/services/ai-worker/src/services/context/ContextAssembler.test.ts
+++ b/services/ai-worker/src/services/context/ContextAssembler.test.ts
@@ -21,6 +21,7 @@ function makeDeps(overrides: Partial<Record<string, unknown>> = {}): ContextAsse
       getCrossChannelHistory: vi.fn().mockResolvedValue([]),
       getUserTimezone: vi.fn().mockResolvedValue('UTC'),
       getContextEpoch: vi.fn().mockResolvedValue(undefined),
+      getMessageByDiscordId: vi.fn().mockResolvedValue(null),
       ...(overrides.dataSource as object),
     } as unknown as ContextDataSource,
     userService: {
@@ -75,17 +76,15 @@ describe('ContextAssembler.assembleCore', () => {
     const deps = makeDeps({
       dataSource: {
         getContextEpoch: vi.fn().mockResolvedValue(epoch),
-        getChannelHistory: vi
-          .fn()
-          .mockResolvedValue([
-            {
-              id: 'm1',
-              role: MessageRole.User,
-              content: 'hi',
-              createdAt: new Date(),
-              discordMessageId: ['d1'],
-            },
-          ]),
+        getChannelHistory: vi.fn().mockResolvedValue([
+          {
+            id: 'm1',
+            role: MessageRole.User,
+            content: 'hi',
+            createdAt: new Date(),
+            discordMessageId: ['d1'],
+          },
+        ]),
       },
     });
     const assembler = new ContextAssembler(deps);
@@ -201,6 +200,73 @@ describe('ContextAssembler.assembleCore', () => {
     const ext = core.history.find(m => m.id === 'd-ext');
     expect(ext?.personaId).toBe('persona-555');
     expect(ext?.createdAt).toBeInstanceOf(Date);
+  });
+
+  it('leaves referencedMessages undefined when the envelope carries no raw references', async () => {
+    const assembler = new ContextAssembler(makeDeps());
+    const core = await assembler.assembleCore(makeJobContext(), PERSONALITY, undefined);
+    expect(core.referencedMessages).toBeUndefined();
+  });
+
+  it('enriches raw references: stubs against assembled history, DB transcripts for the rest', async () => {
+    const historyRow = {
+      id: 'db-1',
+      role: MessageRole.User,
+      content: 'already in history',
+      createdAt: new Date('2026-06-01T00:00:00Z'),
+      discordMessageId: ['d-in-history'],
+    };
+    const deps = makeDeps({
+      dataSource: {
+        getChannelHistory: vi.fn().mockResolvedValue([historyRow]),
+        // Transcript lookup for the voice reference.
+        getMessageByDiscordId: vi.fn().mockResolvedValue({ content: 'db transcript' }),
+      },
+    });
+    const assembler = new ContextAssembler(deps);
+
+    const baseRef = {
+      discordUserId: 'u1',
+      authorUsername: 'a',
+      authorDisplayName: 'A',
+      embeds: '',
+      timestamp: '2026-06-01T00:01:00.000Z',
+      locationContext: '',
+    };
+    const core = await assembler.assembleCore(
+      makeJobContext({
+        rawAssemblyInputs: {
+          rawMessageContent: 'hello',
+          rawReferencedMessages: [
+            { ...baseRef, referenceNumber: 1, discordMessageId: 'd-in-history', content: 'dup' },
+            {
+              ...baseRef,
+              referenceNumber: 2,
+              discordMessageId: 'd-voice',
+              content: 'voice msg',
+              attachments: [
+                {
+                  url: 'https://cdn/v.ogg',
+                  contentType: 'audio/ogg',
+                  name: 'v.ogg',
+                  isVoiceMessage: true,
+                },
+              ],
+            },
+          ],
+        },
+      }),
+      PERSONALITY,
+      undefined,
+      { referenceDedupNowMs: new Date('2026-06-01T00:01:30Z').getTime() }
+    );
+
+    expect(core.referencedMessages).toHaveLength(2);
+    expect(core.referencedMessages?.[0].isDeduplicated).toBe(true);
+    expect(core.referencedMessages?.[1].content).toBe(
+      'voice msg\n\n[Voice transcript]: db transcript'
+    );
+    expect(deps.dataSource.getMessageByDiscordId).toHaveBeenCalledWith('d-voice');
   });
 
   it('returns plain DB history when the envelope carries no extended context', async () => {

--- a/services/ai-worker/src/services/context/ContextAssembler.ts
+++ b/services/ai-worker/src/services/context/ContextAssembler.ts
@@ -5,13 +5,15 @@
  * envelope + the worker's own Prisma access, mirroring bot-client's
  * MessageContextBuilder steps 1–4: user upsert, persona resolution, timezone,
  * context epoch, channel-history hydration, extended-context user batch
- * upserts + placeholder persona resolution (shared implementation), and the
- * history merge (shared implementation). Content rewriting, reference
- * enrichment, and cross-channel decoration land in the follow-on slice.
+ * upserts + placeholder persona resolution (shared implementation), the
+ * history merge (shared implementation), and reference enrichment
+ * (dedup-vs-history + transcript append, shared kernels). Content rewriting
+ * and cross-channel decoration land in the follow-on slices.
  *
- * Shared-implementation guarantee: `resolveExtendedContextPersonaIds` and
- * `mergeWithHistory` are the SAME common-types functions the legacy bot-side
- * path calls, so the two paths cannot drift during burn-in.
+ * Shared-implementation guarantee: `resolveExtendedContextPersonaIds`,
+ * `mergeWithHistory`, and the reference-enrichment kernels are the SAME
+ * common-types functions the legacy bot-side path calls, so the two paths
+ * cannot drift during burn-in.
  */
 
 import {
@@ -24,14 +26,16 @@ import {
   type LoadedPersonality,
   type PersonaResolver,
   type RawAssemblyInputs,
+  type ReferencedMessage,
   type ResolvedConfigOverrides,
   type UserService,
 } from '@tzurot/common-types';
+import { enrichRawReferences } from './referenceEnricher.js';
 import type { ContextDataSource } from './types.js';
 
 const logger = createLogger('ContextAssembler');
 
-/** The core (a3-i) surfaces the assembler re-derives. */
+/** The core surfaces the assembler re-derives. */
 export interface AssembledCore {
   userInternalId: string;
   activePersonaId: string;
@@ -40,6 +44,22 @@ export interface AssembledCore {
   contextEpoch: Date | undefined;
   /** Hydrated DB history merged with envelope-carried extended context. */
   history: ConversationMessage[];
+  /**
+   * Enriched references re-derived from the envelope's raw snapshots
+   * (dedup-vs-OWN-history + DB transcript append). Undefined when the
+   * envelope carries no raw references (extraction didn't run bot-side —
+   * weigh-in mode or a sender predating the field).
+   */
+  referencedMessages: ReferencedMessage[] | undefined;
+}
+
+/** Per-call assembly options (job-scoped values the deps can't carry). */
+export interface AssembleCoreOptions {
+  /**
+   * Anchor for the reference time-fallback dedup window — the job's enqueue
+   * timestamp. Undefined disables the time fallback (exact-id dedup only).
+   */
+  referenceDedupNowMs?: number;
 }
 
 export interface ContextAssemblerDeps {
@@ -83,7 +103,8 @@ export class ContextAssembler {
   async assembleCore(
     jobContext: JobContext,
     personality: LoadedPersonality,
-    configOverrides: ResolvedConfigOverrides | undefined
+    configOverrides: ResolvedConfigOverrides | undefined,
+    options?: AssembleCoreOptions
   ): Promise<AssembledCore> {
     const raw = jobContext.rawAssemblyInputs;
     if (raw === undefined) {
@@ -138,12 +159,17 @@ export class ContextAssembler {
     // impl). ABSENT raw messages = the fetch didn't run bot-side.
     const history = await this.mergeExtendedContext(raw, dbHistory, personality.id);
 
+    // Step 5: re-derive reference enrichment from the raw snapshots —
+    // dedup against the just-assembled history, transcripts from OWN DB.
+    const referencedMessages = await this.enrichReferences(raw, history, options);
+
     logger.debug(
       {
         userInternalId: user.userId,
         activePersonaId,
         dbCount: dbHistory.length,
         mergedCount: history.length,
+        referenceCount: referencedMessages?.length,
       },
       'Core context assembled'
     );
@@ -155,7 +181,37 @@ export class ContextAssembler {
       userTimezone,
       contextEpoch,
       history,
+      referencedMessages,
     };
+  }
+
+  /**
+   * Enrich raw reference snapshots (shared kernels) — undefined when the
+   * envelope carries none (ABSENT = extraction didn't run bot-side).
+   */
+  private async enrichReferences(
+    raw: RawAssemblyInputs,
+    history: ConversationMessage[],
+    options: AssembleCoreOptions | undefined
+  ): Promise<ReferencedMessage[] | undefined> {
+    if (raw.rawReferencedMessages === undefined) {
+      return undefined;
+    }
+    return enrichRawReferences({
+      rawReferences: raw.rawReferencedMessages,
+      history,
+      // DB lookup is per-message, not per-URL — the shared kernel passes
+      // attachmentUrl but this retriever drops it (each voice message row
+      // stores one transcript as its content).
+      retrieveTranscript: async (discordMessageId: string) => {
+        // DB tier only — the bot-side Redis-cache tier has no worker
+        // equivalent (accepted burn-in divergence; the row IS the transcript
+        // for persisted voice messages).
+        const row = await this.deps.dataSource.getMessageByDiscordId(discordMessageId);
+        return row?.content !== undefined && row.content.length > 0 ? row.content : null;
+      },
+      nowMs: options?.referenceDedupNowMs,
+    });
   }
 
   /** Steps the envelope's extended context through upsert → resolve → merge. */

--- a/services/ai-worker/src/services/context/PrismaContextDataSource.test.ts
+++ b/services/ai-worker/src/services/context/PrismaContextDataSource.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockGetChannelHistory = vi.hoisted(() => vi.fn());
 const mockGetCrossChannelHistory = vi.hoisted(() => vi.fn());
+const mockGetMessageByDiscordId = vi.hoisted(() => vi.fn());
 const mockGetUserTimezone = vi.hoisted(() => vi.fn());
 
 vi.mock('@tzurot/common-types', async importOriginal => {
@@ -12,6 +13,7 @@ vi.mock('@tzurot/common-types', async importOriginal => {
     ConversationHistoryService: class {
       getChannelHistory = mockGetChannelHistory;
       getCrossChannelHistory = mockGetCrossChannelHistory;
+      getMessageByDiscordId = mockGetMessageByDiscordId;
     },
     UserService: class {
       getUserTimezone = mockGetUserTimezone;
@@ -79,6 +81,15 @@ describe('PrismaContextDataSource', () => {
       maxAgeSeconds: undefined,
       contextEpoch: undefined,
     });
+  });
+
+  it('delegates getMessageByDiscordId for the transcript DB tier', async () => {
+    mockGetMessageByDiscordId.mockResolvedValue({ id: 'm1', content: 'a transcript' });
+
+    const result = await source.getMessageByDiscordId('discord-1');
+
+    expect(mockGetMessageByDiscordId).toHaveBeenCalledWith('discord-1');
+    expect(result).toEqual({ id: 'm1', content: 'a transcript' });
   });
 
   it('delegates getUserTimezone', async () => {

--- a/services/ai-worker/src/services/context/PrismaContextDataSource.ts
+++ b/services/ai-worker/src/services/context/PrismaContextDataSource.ts
@@ -49,6 +49,10 @@ export class PrismaContextDataSource implements ContextDataSource {
     );
   }
 
+  async getMessageByDiscordId(discordMessageId: string): Promise<ConversationMessage | null> {
+    return this.history.getMessageByDiscordId(discordMessageId);
+  }
+
   async getUserTimezone(internalUserId: string): Promise<string> {
     return this.users.getUserTimezone(internalUserId);
   }

--- a/services/ai-worker/src/services/context/referenceEnricher.test.ts
+++ b/services/ai-worker/src/services/context/referenceEnricher.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  MessageRole,
+  TEXT_LIMITS,
+  type ConversationMessage,
+  type ReferencedMessage,
+} from '@tzurot/common-types';
+import { enrichRawReferences } from './referenceEnricher.js';
+
+const NOW = new Date('2026-06-01T12:00:00Z').getTime();
+
+function rawRef(partial: Partial<ReferencedMessage> = {}): ReferencedMessage {
+  return {
+    referenceNumber: 1,
+    discordMessageId: 'ref-1',
+    discordUserId: 'user-1',
+    authorUsername: 'someone',
+    authorDisplayName: 'Someone',
+    content: 'referenced content',
+    embeds: '',
+    timestamp: new Date(NOW - 5_000).toISOString(),
+    locationContext: '<location>here</location>',
+    ...partial,
+  };
+}
+
+function historyRow(discordMessageId: string, createdAt: Date): ConversationMessage {
+  return {
+    id: `db-${discordMessageId}`,
+    role: MessageRole.User,
+    content: 'history row',
+    createdAt,
+    discordMessageId: [discordMessageId],
+  } as ConversationMessage;
+}
+
+const noTranscript = vi.fn().mockResolvedValue(null);
+
+describe('enrichRawReferences', () => {
+  it('passes a non-duplicate regular reference through with its number intact', async () => {
+    const result = await enrichRawReferences({
+      rawReferences: [rawRef({ referenceNumber: 7 })],
+      history: [],
+      retrieveTranscript: noTranscript,
+      nowMs: NOW,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].referenceNumber).toBe(7);
+    expect(result[0].content).toBe('referenced content');
+    expect(result[0].isDeduplicated).toBeUndefined();
+  });
+
+  it('stubs a reference whose id is in the assembled history', async () => {
+    const result = await enrichRawReferences({
+      rawReferences: [rawRef({ content: 'x'.repeat(TEXT_LIMITS.DEDUP_STUB_CONTENT + 5) })],
+      history: [historyRow('ref-1', new Date(NOW - 5_000))],
+      retrieveTranscript: noTranscript,
+      nowMs: NOW,
+    });
+    expect(result[0].isDeduplicated).toBe(true);
+    expect(result[0].content).toBe('x'.repeat(TEXT_LIMITS.DEDUP_STUB_CONTENT) + '...');
+    expect(result[0].embeds).toBe('');
+    expect(result[0].locationContext).toBe('');
+  });
+
+  it('stubs a recent webhook reference via the time fallback', async () => {
+    const result = await enrichRawReferences({
+      rawReferences: [rawRef({ webhookId: 'wh-1' })],
+      history: [historyRow('different-id', new Date(NOW - 5_000))],
+      retrieveTranscript: noTranscript,
+      nowMs: NOW,
+    });
+    expect(result[0].isDeduplicated).toBe(true);
+  });
+
+  it('uses authorIsBot to gate the time fallback for non-webhook bot authors', async () => {
+    const result = await enrichRawReferences({
+      rawReferences: [rawRef({ authorIsBot: true })],
+      history: [historyRow('different-id', new Date(NOW - 5_000))],
+      retrieveTranscript: noTranscript,
+      nowMs: NOW,
+    });
+    expect(result[0].isDeduplicated).toBe(true);
+  });
+
+  it('skips the time fallback when nowMs is undefined', async () => {
+    const result = await enrichRawReferences({
+      rawReferences: [rawRef({ webhookId: 'wh-1' })],
+      history: [historyRow('different-id', new Date(NOW - 5_000))],
+      retrieveTranscript: noTranscript,
+      nowMs: undefined,
+    });
+    expect(result[0].isDeduplicated).toBeUndefined();
+  });
+
+  it('passes forwarded references through untouched (no transcripts by contract)', async () => {
+    const retrieve = vi.fn();
+    const forwarded = rawRef({
+      isForwarded: true,
+      attachments: [
+        { url: 'https://cdn/v.ogg', contentType: 'audio/ogg', name: 'v.ogg', isVoiceMessage: true },
+      ],
+    });
+    const result = await enrichRawReferences({
+      rawReferences: [forwarded],
+      history: [],
+      retrieveTranscript: retrieve,
+      nowMs: NOW,
+    });
+    expect(result[0]).toEqual(forwarded);
+    expect(result[0]).not.toBe(forwarded); // copy, not the same object
+    expect(retrieve).not.toHaveBeenCalled();
+  });
+
+  it('stubs a forwarded reference found in history (dedup precedes pass-through)', async () => {
+    const result = await enrichRawReferences({
+      rawReferences: [rawRef({ isForwarded: true, content: 'forwarded snapshot content' })],
+      history: [historyRow('ref-1', new Date(NOW - 60_000))],
+      retrieveTranscript: noTranscript,
+      nowMs: NOW,
+    });
+    // Mirrors the bot-side formatter loop: isDeduplicated branch wins over
+    // the forwarded branch, so the stub drops the isForwarded flag too.
+    expect(result[0].isDeduplicated).toBe(true);
+    expect(result[0].isForwarded).toBeUndefined();
+    expect(result[0].content).toBe('forwarded snapshot content');
+  });
+
+  it('appends DB transcripts to regular references with voice attachments', async () => {
+    const retrieve = vi.fn().mockResolvedValue('worker-side transcript');
+    const result = await enrichRawReferences({
+      rawReferences: [
+        rawRef({
+          attachments: [
+            {
+              url: 'https://cdn/v.ogg',
+              contentType: 'audio/ogg',
+              name: 'v.ogg',
+              isVoiceMessage: true,
+            },
+          ],
+        }),
+      ],
+      history: [],
+      retrieveTranscript: retrieve,
+      nowMs: NOW,
+    });
+    expect(retrieve).toHaveBeenCalledWith('ref-1', 'https://cdn/v.ogg');
+    expect(result[0].content).toBe(
+      'referenced content\n\n[Voice transcript]: worker-side transcript'
+    );
+  });
+
+  it('preserves wire order across mixed stub/full decisions', async () => {
+    const result = await enrichRawReferences({
+      rawReferences: [
+        rawRef({ referenceNumber: 1, discordMessageId: 'in-history' }),
+        rawRef({ referenceNumber: 2, discordMessageId: 'not-in-history' }),
+        rawRef({ referenceNumber: 3, discordMessageId: 'fwd', isForwarded: true }),
+      ],
+      history: [historyRow('in-history', new Date(NOW - 60_000))],
+      retrieveTranscript: noTranscript,
+      nowMs: NOW,
+    });
+    expect(result.map(r => r.referenceNumber)).toEqual([1, 2, 3]);
+    expect(result.map(r => r.isDeduplicated ?? false)).toEqual([true, false, false]);
+  });
+});

--- a/services/ai-worker/src/services/context/referenceEnricher.ts
+++ b/services/ai-worker/src/services/context/referenceEnricher.ts
@@ -1,0 +1,112 @@
+/**
+ * Worker-side reference enrichment.
+ *
+ * Re-derives the enriched `referencedMessages` payload surface from the raw
+ * envelope's pre-enrichment snapshots, mirroring bot-client's
+ * ReferenceFormatter loop. Reference numbers are adopted from the wire
+ * verbatim (numbering happened at crawl time and is dedup-independent for
+ * non-forwarded references), so this function only re-runs the two DB-coupled
+ * decisions:
+ *
+ * - dedup-vs-history (shared `isDuplicateReference` kernel, against the
+ *   WORKER's assembled history) → collapse to the shared stub shape
+ * - voice-transcript append (shared kernel, DB-only retrieval — the bot's
+ *   Redis-cache tier has no worker equivalent, an accepted burn-in
+ *   divergence source)
+ *
+ * Forwarded references are passed through untouched: snapshot expansion
+ * happened at capture, snapshots carry no transcripts by contract, and the
+ * raw==enriched property holds for them on the bot side too. Dedup takes
+ * precedence over the forwarded pass-through (a forwarded ref found in
+ * history gets stubbed) — the same ordering the bot-side formatter loop
+ * applies (isDeduplicated is checked before the forwarded branch).
+ *
+ * Known accepted divergence: dedup DISAGREEMENT. The worker dedups against
+ * its own assembled history, which can differ from the bot's by fetch-timing
+ * drift — a reference one side stubs and the other keeps full surfaces as a
+ * per-number dedup mismatch in the shadow diff. Counts always align by
+ * construction: a bot-deduped forward ships ONE raw container ref (the raw
+ * side never expanded it), a kept forward ships its per-snapshot refs, and
+ * the worker enriches exactly the list it received.
+ */
+
+import {
+  appendVoiceTranscripts,
+  buildDedupedReferenceStub,
+  isDuplicateReference,
+  type ConversationMessage,
+  type ReferencedMessage,
+  type TranscriptRetrieveFn,
+} from '@tzurot/common-types';
+
+export interface EnrichRawReferencesParams {
+  /** Pre-enrichment snapshots from the raw envelope, in wire order. */
+  rawReferences: ReferencedMessage[];
+  /** The worker-assembled conversation history to dedup against. */
+  history: ConversationMessage[];
+  /** DB-tier transcript lookup (typically dataSource.getMessageByDiscordId content). */
+  retrieveTranscript: TranscriptRetrieveFn;
+  /**
+   * Anchor for the time-based dedup window — the job's enqueue timestamp
+   * (the closest stand-in for the bot's crawl-time wall clock). Undefined
+   * disables the time fallback; exact-id dedup still applies.
+   */
+  nowMs: number | undefined;
+}
+
+/** Derive the dedup-history view once per enrichment run. */
+function buildDedupHistory(history: ConversationMessage[]): {
+  messageIds: Set<string>;
+  timestamps: Date[];
+} {
+  return {
+    messageIds: new Set(history.flatMap(m => m.discordMessageId ?? []).filter(id => id.length > 0)),
+    timestamps: history.map(m => m.createdAt),
+  };
+}
+
+/**
+ * Enrich raw reference snapshots into the final payload shape. Order and
+ * reference numbers are preserved from the wire.
+ */
+export async function enrichRawReferences(
+  params: EnrichRawReferencesParams
+): Promise<ReferencedMessage[]> {
+  const { rawReferences, history, retrieveTranscript, nowMs } = params;
+  const dedupHistory = buildDedupHistory(history);
+
+  const enriched: ReferencedMessage[] = [];
+  for (const raw of rawReferences) {
+    const duplicate = isDuplicateReference(
+      {
+        discordMessageId: raw.discordMessageId,
+        timestampMs: new Date(raw.timestamp).getTime(),
+        isWebhookOrBotAuthored:
+          (raw.webhookId !== undefined && raw.webhookId.length > 0) || raw.authorIsBot === true,
+      },
+      dedupHistory,
+      nowMs
+    );
+
+    if (duplicate) {
+      enriched.push(buildDedupedReferenceStub(raw));
+      continue;
+    }
+
+    if (raw.isForwarded === true) {
+      // Snapshot/container references: raw == enriched by contract.
+      enriched.push({ ...raw });
+      continue;
+    }
+
+    const content = await appendVoiceTranscripts({
+      content: raw.content,
+      attachments: raw.attachments ?? [],
+      discordMessageId: raw.discordMessageId,
+      retrieve: retrieveTranscript,
+    });
+    enriched.push({ ...raw, content });
+  }
+
+  return enriched;
+}

--- a/services/ai-worker/src/services/context/shadowAssembly.test.ts
+++ b/services/ai-worker/src/services/context/shadowAssembly.test.ts
@@ -23,6 +23,7 @@ function makeAssembler(core: Partial<AssembledCore>): ContextAssembler {
       userTimezone: 'UTC',
       contextEpoch: undefined,
       history: [],
+      referencedMessages: undefined,
       ...core,
     }),
   } as unknown as ContextAssembler;
@@ -50,6 +51,18 @@ const msg = (id: string, content: string, personaId = 'persona-1') => ({
   discordMessageId: [id],
 });
 
+const ref = () => ({
+  referenceNumber: 1,
+  discordMessageId: 'r1',
+  discordUserId: 'u1',
+  authorUsername: 'a',
+  authorDisplayName: 'A',
+  content: 'ref content',
+  embeds: '',
+  timestamp: '2026-06-01T00:00:00.000Z',
+  locationContext: '',
+});
+
 describe('shadowAssembleAndDiff', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -63,6 +76,7 @@ describe('shadowAssembleAndDiff', () => {
       personality: PERSONALITY,
       configOverrides: undefined,
       assembler,
+      jobTimestampMs: undefined,
     });
     expect(assembler.assembleCore).not.toHaveBeenCalled();
     expect(mockLogger.info).not.toHaveBeenCalled();
@@ -75,6 +89,7 @@ describe('shadowAssembleAndDiff', () => {
       jobContext: makeJobContext({ conversationHistory: history as never }),
       personality: PERSONALITY,
       configOverrides: undefined,
+      jobTimestampMs: undefined,
       assembler: makeAssembler({ history: history as never }),
     });
 
@@ -91,6 +106,7 @@ describe('shadowAssembleAndDiff', () => {
       jobContext: makeJobContext(),
       personality: PERSONALITY,
       configOverrides: undefined,
+      jobTimestampMs: undefined,
       assembler: makeAssembler({ activePersonaId: 'OTHER' }),
     });
 
@@ -112,6 +128,7 @@ describe('shadowAssembleAndDiff', () => {
       jobContext: makeJobContext({ conversationHistory: payloadHistory as never }),
       personality: PERSONALITY,
       configOverrides: undefined,
+      jobTimestampMs: undefined,
       assembler: makeAssembler({ history: assembledHistory as never }),
     });
 
@@ -137,6 +154,7 @@ describe('shadowAssembleAndDiff', () => {
       jobContext: makeJobContext({ conversationHistory: payloadHistory as never }),
       personality: PERSONALITY,
       configOverrides: undefined,
+      jobTimestampMs: undefined,
       assembler: makeAssembler({ history: assembledHistory as never }),
     });
 
@@ -158,6 +176,7 @@ describe('shadowAssembleAndDiff', () => {
       jobContext: makeJobContext({ conversationHistory: payloadHistory as never }),
       personality: PERSONALITY,
       configOverrides: undefined,
+      jobTimestampMs: undefined,
       assembler: makeAssembler({ history: assembledHistory as never }),
     });
 
@@ -176,12 +195,124 @@ describe('shadowAssembleAndDiff', () => {
       jobContext: makeJobContext({ userTimezone: undefined, activePersonaName: undefined }),
       personality: PERSONALITY,
       configOverrides: undefined,
+      jobTimestampMs: undefined,
       assembler: makeAssembler({ userTimezone: 'UTC', activePersonaName: null }),
     });
 
     expect(mockLogger.info).toHaveBeenCalledWith(
       expect.objectContaining({ allMatched: true }),
       expect.anything()
+    );
+  });
+
+  it('threads the job timestamp into the assembler as the dedup anchor', async () => {
+    const assembler = makeAssembler({});
+    await shadowAssembleAndDiff({
+      jobId: 'j1',
+      jobContext: makeJobContext(),
+      personality: PERSONALITY,
+      configOverrides: undefined,
+      assembler,
+      jobTimestampMs: 1_717_243_200_000,
+    });
+    expect(assembler.assembleCore).toHaveBeenCalledWith(expect.anything(), PERSONALITY, undefined, {
+      referenceDedupNowMs: 1_717_243_200_000,
+    });
+  });
+
+  it('treats the reference surface as skipped when assembly produced none', async () => {
+    await shadowAssembleAndDiff({
+      jobId: 'j1',
+      jobContext: makeJobContext({ referencedMessages: [ref()] as never }),
+      personality: PERSONALITY,
+      configOverrides: undefined,
+      jobTimestampMs: undefined,
+      assembler: makeAssembler({ referencedMessages: undefined }),
+    });
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allMatched: true,
+        referenceDiff: expect.objectContaining({ compared: false, payloadCount: 1 }),
+      }),
+      expect.stringContaining('matched')
+    );
+  });
+
+  it('matches when assembled references agree with the payload', async () => {
+    await shadowAssembleAndDiff({
+      jobId: 'j1',
+      jobContext: makeJobContext({ referencedMessages: [ref()] as never }),
+      personality: PERSONALITY,
+      configOverrides: undefined,
+      jobTimestampMs: undefined,
+      assembler: makeAssembler({ referencedMessages: [ref()] as never }),
+    });
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allMatched: true,
+        referenceDiff: expect.objectContaining({ compared: true, matched: true }),
+      }),
+      expect.anything()
+    );
+  });
+
+  it('flags payload reference numbers absent from the assembled set', async () => {
+    await shadowAssembleAndDiff({
+      jobId: 'j1',
+      jobContext: makeJobContext({ referencedMessages: [ref()] as never }),
+      personality: PERSONALITY,
+      configOverrides: undefined,
+      jobTimestampMs: undefined,
+      assembler: makeAssembler({
+        // Same count, disjoint number — should-be-impossible drift shape.
+        referencedMessages: [{ ...ref(), referenceNumber: 99 }] as never,
+      }),
+    });
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        matches: expect.objectContaining({ referencedMessages: false }),
+        referenceDiff: expect.objectContaining({ missingFromAssembled: 1, extraInAssembled: 1 }),
+      }),
+      expect.stringContaining('DIVERGED')
+    );
+  });
+
+  it('labels worker-produced surplus references as extraInAssembled', async () => {
+    await shadowAssembleAndDiff({
+      jobId: 'j1',
+      jobContext: makeJobContext({ referencedMessages: undefined }),
+      personality: PERSONALITY,
+      configOverrides: undefined,
+      jobTimestampMs: undefined,
+      assembler: makeAssembler({ referencedMessages: [ref()] as never }),
+    });
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        matches: expect.objectContaining({ referencedMessages: false }),
+        referenceDiff: expect.objectContaining({ extraInAssembled: 1, payloadCount: 0 }),
+      }),
+      expect.stringContaining('DIVERGED')
+    );
+  });
+
+  it('flags content and stub-decision mismatches on the reference surface', async () => {
+    await shadowAssembleAndDiff({
+      jobId: 'j1',
+      jobContext: makeJobContext({ referencedMessages: [ref()] as never }),
+      personality: PERSONALITY,
+      configOverrides: undefined,
+      jobTimestampMs: undefined,
+      assembler: makeAssembler({
+        referencedMessages: [{ ...ref(), content: 'STUBBED', isDeduplicated: true }] as never,
+      }),
+    });
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allMatched: false,
+        matches: expect.objectContaining({ referencedMessages: false }),
+        referenceDiff: expect.objectContaining({ contentMismatches: 1, dedupMismatches: 1 }),
+      }),
+      expect.stringContaining('DIVERGED')
     );
   });
 
@@ -197,6 +328,7 @@ describe('shadowAssembleAndDiff', () => {
         personality: PERSONALITY,
         configOverrides: undefined,
         assembler,
+        jobTimestampMs: undefined,
       })
     ).resolves.toBeUndefined();
 

--- a/services/ai-worker/src/services/context/shadowAssembly.ts
+++ b/services/ai-worker/src/services/context/shadowAssembly.ts
@@ -19,6 +19,7 @@ import {
   createLogger,
   type JobContext,
   type LoadedPersonality,
+  type ReferencedMessage,
   type ResolvedConfigOverrides,
 } from '@tzurot/common-types';
 import type { ContextAssembler, AssembledCore } from './ContextAssembler.js';
@@ -31,6 +32,8 @@ interface ShadowAssemblyParams {
   personality: LoadedPersonality;
   configOverrides: ResolvedConfigOverrides | undefined;
   assembler: ContextAssembler;
+  /** Job enqueue timestamp — anchors the reference time-fallback dedup window. */
+  jobTimestampMs: number | undefined;
 }
 
 interface SurfaceMatches {
@@ -41,6 +44,8 @@ interface SurfaceMatches {
   historyIds: boolean;
   historyContent: boolean;
   historyPersonaIds: boolean;
+  /** True when matched OR skipped (envelope carried no raw references to re-derive from). */
+  referencedMessages: boolean;
 }
 
 /**
@@ -111,6 +116,88 @@ function diffHistory(
 }
 
 /**
+ * Reference comparison, keyed by referenceNumber (adopted from the wire on
+ * both sides, so numbers align by construction). Compares content and the
+ * stub/full decision per number. Skipped (matched, compared:false) when the
+ * assembler produced nothing — the envelope carried no raw references
+ * (weigh-in mode or a sender predating the field).
+ *
+ * Dedup disagreement (one side stubs, the other keeps full) surfaces as
+ * dedupMismatches; a payload number absent from the assembled set should be
+ * impossible by construction and counts as missingFromAssembled.
+ */
+function diffReferences(
+  payload: ReferencedMessage[] | undefined,
+  assembled: ReferencedMessage[] | undefined
+): {
+  matched: boolean;
+  compared: boolean;
+  payloadCount: number;
+  assembledCount: number;
+  missingFromAssembled: number;
+  extraInAssembled: number;
+  contentMismatches: number;
+  dedupMismatches: number;
+} {
+  // Payload omits the field when extraction found nothing — normalize to [].
+  const payloadRefs = payload ?? [];
+  if (assembled === undefined) {
+    return {
+      matched: true,
+      compared: false,
+      payloadCount: payloadRefs.length,
+      assembledCount: 0,
+      missingFromAssembled: 0,
+      extraInAssembled: 0,
+      contentMismatches: 0,
+      dedupMismatches: 0,
+    };
+  }
+
+  const assembledByNumber = new Map(assembled.map(r => [r.referenceNumber, r]));
+  const payloadNumbers = new Set(payloadRefs.map(r => r.referenceNumber));
+  let missingFromAssembled = 0;
+  let contentMismatches = 0;
+  let dedupMismatches = 0;
+  for (const payloadRef of payloadRefs) {
+    const assembledRef = assembledByNumber.get(payloadRef.referenceNumber);
+    if (assembledRef === undefined) {
+      missingFromAssembled++;
+      continue;
+    }
+    if (assembledRef.content !== payloadRef.content) {
+      contentMismatches++;
+    }
+    if ((assembledRef.isDeduplicated ?? false) !== (payloadRef.isDeduplicated ?? false)) {
+      dedupMismatches++;
+    }
+  }
+
+  // Worker-produced reference numbers the payload lacks — true
+  // set-difference, so the metric stays accurate even when counts match
+  // but the number sets are disjoint.
+  const extraInAssembled = assembled.filter(r => !payloadNumbers.has(r.referenceNumber)).length;
+
+  return {
+    matched:
+      assembled.length === payloadRefs.length &&
+      missingFromAssembled === 0 &&
+      // Implied by the two checks above while numbers stay unique; explicit
+      // so the set-identity invariant survives future edits.
+      extraInAssembled === 0 &&
+      contentMismatches === 0 &&
+      dedupMismatches === 0,
+    compared: true,
+    payloadCount: payloadRefs.length,
+    assembledCount: assembled.length,
+    missingFromAssembled,
+    extraInAssembled,
+    contentMismatches,
+    dedupMismatches,
+  };
+}
+
+/**
  * Run the assembler against the job's raw envelope and diff the core
  * surfaces against the bot-assembled payload. Fire-and-forget: never throws.
  */
@@ -121,8 +208,14 @@ export async function shadowAssembleAndDiff(params: ShadowAssemblyParams): Promi
       return;
     }
 
-    const assembled = await assembler.assembleCore(jobContext, personality, configOverrides);
+    const assembled = await assembler.assembleCore(jobContext, personality, configOverrides, {
+      referenceDedupNowMs: params.jobTimestampMs,
+    });
     const historyDiff = diffHistory(jobContext.conversationHistory, assembled.history);
+    const referenceDiff = diffReferences(
+      jobContext.referencedMessages,
+      assembled.referencedMessages
+    );
 
     const matches: SurfaceMatches = {
       userInternalId: assembled.userInternalId === jobContext.userInternalId,
@@ -135,6 +228,7 @@ export async function shadowAssembleAndDiff(params: ShadowAssemblyParams): Promi
       historyIds: historyDiff.ids,
       historyContent: historyDiff.content,
       historyPersonaIds: historyDiff.personaIds,
+      referencedMessages: referenceDiff.matched,
     };
     const allMatched = Object.values(matches).every(Boolean);
 
@@ -150,6 +244,7 @@ export async function shadowAssembleAndDiff(params: ShadowAssemblyParams): Promi
         contentMismatches: historyDiff.contentMismatches,
         personaIdMismatches: historyDiff.personaIdMismatches,
       },
+      referenceDiff,
     };
 
     if (allMatched) {

--- a/services/ai-worker/src/services/context/shadowHydration.test.ts
+++ b/services/ai-worker/src/services/context/shadowHydration.test.ts
@@ -18,6 +18,7 @@ function makeDataSource(overrides: Partial<ContextDataSource> = {}): ContextData
     getCrossChannelHistory: vi.fn().mockResolvedValue([]),
     getUserTimezone: vi.fn().mockResolvedValue('UTC'),
     getContextEpoch: vi.fn().mockResolvedValue(undefined),
+    getMessageByDiscordId: vi.fn().mockResolvedValue(null),
     ...overrides,
   };
 }

--- a/services/ai-worker/src/services/context/types.ts
+++ b/services/ai-worker/src/services/context/types.ts
@@ -51,6 +51,15 @@ export interface ContextDataSource {
   /** Cross-channel history groups for the active persona+personality. */
   getCrossChannelHistory(params: CrossChannelHistoryParams): Promise<CrossChannelHistoryGroup[]>;
 
+  /**
+   * Single history row lookup by Discord message id — the DB tier of voice
+   * transcript retrieval (voice messages store their transcript as the row's
+   * content). The bot-side path also has a Redis-cache tier; the worker is
+   * DB-only, so cache-hit-only transcripts are an expected divergence source
+   * during burn-in.
+   */
+  getMessageByDiscordId(discordMessageId: string): Promise<ConversationMessage | null>;
+
   /** IANA timezone for an INTERNAL user id ('UTC' fallback). */
   getUserTimezone(internalUserId: string): Promise<string>;
 

--- a/services/bot-client/src/handlers/references/MessageFormatter.test.ts
+++ b/services/bot-client/src/handlers/references/MessageFormatter.test.ts
@@ -128,6 +128,32 @@ describe('MessageFormatter', () => {
       expect(result.isForwarded).toBe(true);
     });
 
+    it('should presence-encode authorIsBot for bot authors', async () => {
+      const message = createMockMessage({
+        content: 'Bot message',
+        author: createMockUser({ username: 'SomeBot', bot: true }),
+        attachments: new Map() as any,
+        embeds: [],
+      });
+
+      const result = await formatter.formatMessage(message, 1);
+
+      expect(result.authorIsBot).toBe(true);
+    });
+
+    it('should omit authorIsBot for human authors', async () => {
+      const message = createMockMessage({
+        content: 'Human message',
+        author: createMockUser({ username: 'Human', bot: false }),
+        attachments: new Map() as any,
+        embeds: [],
+      });
+
+      const result = await formatter.formatMessage(message, 1);
+
+      expect(result.authorIsBot).toBeUndefined();
+    });
+
     it('should use username as displayName when displayName is null', async () => {
       const message = createMockMessage({
         content: 'Test',

--- a/services/bot-client/src/handlers/references/MessageFormatter.ts
+++ b/services/bot-client/src/handlers/references/MessageFormatter.ts
@@ -6,7 +6,12 @@
  */
 
 import type { Message } from 'discord.js';
-import { type ReferencedMessage, formatLocationAsXml, createLogger } from '@tzurot/common-types';
+import {
+  type ReferencedMessage,
+  appendVoiceTranscripts,
+  formatLocationAsXml,
+  createLogger,
+} from '@tzurot/common-types';
 
 const logger = createLogger('MessageFormatter');
 import { extractDiscordEnvironment } from '../../utils/discordContext.js';
@@ -53,45 +58,34 @@ export class MessageFormatter {
   }
 
   /**
-   * Append voice transcripts to message content (from Redis cache or database)
+   * Append voice transcripts to message content — shared kernel drives the
+   * format; this wrapper supplies the bot-side retriever (Redis cache + DB
+   * tiers) and the not-found debug log.
    */
-  private async appendVoiceTranscripts(
+  private async appendTranscriptsWithRetriever(
     content: string,
     attachments: AttachmentList,
     messageId: string
   ): Promise<string> {
-    if (attachments.length === 0) {
-      return content;
-    }
-
-    const transcripts: string[] = [];
-    for (const attachment of attachments) {
-      if (attachment.isVoiceMessage !== true) {
-        continue;
-      }
-
-      const transcript = await this.transcriptRetriever.retrieveTranscript(
-        messageId,
-        attachment.url
-      );
-      if (transcript !== undefined && transcript !== null && transcript.length > 0) {
-        transcripts.push(transcript);
-      } else {
-        logger.debug(
-          { messageId, attachmentUrl: attachment.url },
-          'Voice transcript not found for attachment'
-        );
-      }
-    }
-
-    if (transcripts.length === 0) {
-      return content;
-    }
-
-    const transcriptText = transcripts.join('\n\n');
-    return content
-      ? `${content}\n\n[Voice transcript]: ${transcriptText}`
-      : `[Voice transcript]: ${transcriptText}`;
+    return appendVoiceTranscripts({
+      content,
+      attachments,
+      discordMessageId: messageId,
+      retrieve: async (discordMessageId, attachmentUrl) => {
+        // The retriever is typed `string | null`; `?? null` up front keeps
+        // this adapter total over `undefined` too should that ever drift.
+        const transcript =
+          (await this.transcriptRetriever.retrieveTranscript(discordMessageId, attachmentUrl)) ??
+          null;
+        if (transcript === null || transcript.length === 0) {
+          logger.debug(
+            { messageId: discordMessageId, attachmentUrl },
+            'Voice transcript not found for attachment'
+          );
+        }
+        return transcript;
+      },
+    });
   }
 
   /**
@@ -118,6 +112,8 @@ export class MessageFormatter {
         referenceNumber,
         discordMessageId: message.id,
         webhookId: message.webhookId ?? undefined,
+        // Presence-encoded: gates the worker-side time-fallback dedup re-run.
+        authorIsBot: message.author.bot === true || undefined,
         discordUserId: message.author.id,
         authorUsername: message.author.username,
         authorDisplayName: message.author.displayName ?? message.author.username,
@@ -146,7 +142,7 @@ export class MessageFormatter {
       referenceNumber,
       isForwardedFlag
     );
-    const contentWithTranscript = await this.appendVoiceTranscripts(
+    const contentWithTranscript = await this.appendTranscriptsWithRetriever(
       raw.content,
       attachments,
       message.id

--- a/services/bot-client/src/handlers/references/ReferenceCrawler.ts
+++ b/services/bot-client/src/handlers/references/ReferenceCrawler.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Message } from 'discord.js';
-import { createLogger, INTERVALS } from '@tzurot/common-types';
+import { createLogger, isDuplicateReference } from '@tzurot/common-types';
 import type { IReferenceStrategy } from './strategies/IReferenceStrategy.js';
 import { type ReferenceMetadata, type ReferenceResult, ReferenceType } from './types.js';
 import { LinkExtractor } from './LinkExtractor.js';
@@ -229,42 +229,28 @@ export class ReferenceCrawler {
   }
 
   /**
-   * Check if a referenced message should be included or excluded as duplicate
+   * Check if a referenced message should be included or excluded as duplicate.
+   * Delegates to the shared `isDuplicateReference` kernel (the same decision
+   * the worker-side assembler re-runs from raw reference snapshots).
    * @param message - Discord message to check
    * @returns True if message should be included, false if it's a duplicate
    */
   private shouldIncludeReference(message: Message): boolean {
-    // Exact match: Check if Discord message ID is in conversation history
-    if (this.conversationHistoryMessageIds.has(message.id)) {
-      return false;
-    }
-
-    // Time-based fallback: If message is from bot/webhook and very recent,
-    // check if timestamp matches any message in conversation history
-    if (
-      (message.webhookId !== undefined &&
-        message.webhookId !== null &&
-        message.webhookId.length > 0) ||
-      message.author.bot === true
-    ) {
-      const messageTime = message.createdAt.getTime();
-      const now = Date.now();
-      const ageMs = now - messageTime;
-
-      // Only check recent messages (within last 60 seconds)
-      if (ageMs < INTERVALS.MESSAGE_AGE_DEDUP_WINDOW) {
-        for (const historyTimestamp of this.conversationHistoryTimestamps) {
-          const historyTime = historyTimestamp.getTime();
-          const timeDiff = Math.abs(messageTime - historyTime);
-
-          // If timestamps match within tolerance, likely the same message
-          if (timeDiff < INTERVALS.MESSAGE_TIMESTAMP_TOLERANCE) {
-            return false;
-          }
-        }
-      }
-    }
-
-    return true;
+    return !isDuplicateReference(
+      {
+        discordMessageId: message.id,
+        timestampMs: message.createdAt.getTime(),
+        isWebhookOrBotAuthored:
+          (message.webhookId !== undefined &&
+            message.webhookId !== null &&
+            message.webhookId.length > 0) ||
+          message.author.bot === true,
+      },
+      {
+        messageIds: this.conversationHistoryMessageIds,
+        timestamps: this.conversationHistoryTimestamps,
+      },
+      Date.now()
+    );
   }
 }

--- a/services/bot-client/src/handlers/references/ReferenceFormatter.test.ts
+++ b/services/bot-client/src/handlers/references/ReferenceFormatter.test.ts
@@ -40,7 +40,17 @@ describe('ReferenceFormatter', () => {
           raw: buildRef(message, refNum),
         })),
       buildRawReference: vi.fn().mockImplementation((message: Message, refNum: number) => ({
-        reference: buildRef(message, refNum),
+        reference: {
+          ...buildRef(message, refNum),
+          // Mirror the real formatter's contract: forwarded messages resolve
+          // their content from snapshots (message.content is empty on them).
+          content:
+            message.messageSnapshots !== undefined &&
+            message.messageSnapshots !== null &&
+            message.messageSnapshots.size > 0
+              ? (message.messageSnapshots.values().next().value?.content ?? '')
+              : message.content,
+        },
         attachments: [],
       })),
     } as unknown as MessageFormatter;

--- a/services/bot-client/src/handlers/references/ReferenceFormatter.ts
+++ b/services/bot-client/src/handlers/references/ReferenceFormatter.ts
@@ -6,8 +6,11 @@
  */
 
 import type { Message } from 'discord.js';
-import { createLogger, type ReferencedMessage, TEXT_LIMITS } from '@tzurot/common-types';
-import { getEffectiveContent } from '../../utils/forwardedMessageUtils.js';
+import {
+  createLogger,
+  type ReferencedMessage,
+  buildDedupedReferenceStub,
+} from '@tzurot/common-types';
 import { MessageLinkParser } from '../../utils/MessageLinkParser.js';
 import { isForwardedMessage, type ReferenceMetadata } from './types.js';
 import { MessageFormatter } from './MessageFormatter.js';
@@ -125,13 +128,15 @@ export class ReferenceFormatter {
 
   /** Deduped: enriched side gets a stub; raw side gets the full snapshot. */
   private appendDedupedStub(message: Message, metadata: ReferenceMetadata, s: FormatState): void {
-    s.references.push(this.buildDedupedStub(message, s.nextNumber));
+    // Build the full raw snapshot first and derive the stub from it via the
+    // shared kernel — the same stub the worker-side assembler produces when
+    // its own dedup re-run agrees, so the two shapes cannot drift.
+    const raw = this.messageFormatter.buildRawReference(message, s.nextNumber).reference;
+    s.references.push(buildDedupedReferenceStub(raw));
     if (s.collectRaw) {
       // The raw side never stubs: the worker re-derives dedup against its
       // OWN hydrated history, so it needs the full pre-dedup snapshot.
-      s.rawReferences.push(
-        this.messageFormatter.buildRawReference(message, s.nextNumber).reference
-      );
+      s.rawReferences.push(raw);
     }
     this.trackLink(metadata, s.nextNumber, s.linkMap);
     s.nextNumber++;
@@ -186,26 +191,6 @@ export class ReferenceFormatter {
     }
     this.trackLink(metadata, s.nextNumber, s.linkMap);
     s.nextNumber++;
-  }
-
-  /** Build a minimal ReferencedMessage for a deduped reference */
-  private buildDedupedStub(message: Message, refNumber: number): ReferencedMessage {
-    const limit = TEXT_LIMITS.DEDUP_STUB_CONTENT;
-    // Use getEffectiveContent to handle forwarded messages (content is in snapshots)
-    const content = getEffectiveContent(message);
-    const truncatedContent = content.length > limit ? content.substring(0, limit) + '...' : content;
-    return {
-      referenceNumber: refNumber,
-      discordMessageId: message.id,
-      discordUserId: message.author.id,
-      authorUsername: message.author.username,
-      authorDisplayName: message.author.displayName ?? message.author.username,
-      content: truncatedContent,
-      embeds: '',
-      timestamp: message.createdAt.toISOString(),
-      locationContext: '',
-      isDeduplicated: true,
-    };
   }
 
   /** Track a Discord link for [Reference N] replacement if present */


### PR DESCRIPTION
## Summary

First slice of **a3-ii** (assembler second half): the worker re-derives the `referencedMessages` payload surface from the envelope's raw reference snapshots. Two commits:

### Commit 1 — shared kernels (`refactor(common-types)`)

`utils/referenceEnrichment.ts` extracts the three DB-coupled reference decisions; bot-client's pipeline now **delegates** to them (zero-drift pattern, same as the merge/resolver relocations):

- **`isDuplicateReference`** — exact-id + time-fallback dedup (from `ReferenceCrawler.shouldIncludeReference`), with an injectable now-anchor instead of a baked-in `Date.now()`
- **`buildDedupedReferenceStub`** — the truncated minimal stub shape (from `ReferenceFormatter.buildDedupedStub`), now derived from the raw reference snapshot on BOTH sides — bot's `appendDedupedStub` builds the raw snapshot first and stubs from it, so the stub the worker would produce on dedup-agreement is byte-identical by construction
- **`appendVoiceTranscripts`** — `[Voice transcript]:` formatting over an injected retriever (from `MessageFormatter`)

**Envelope gap fix**: `authorIsBot` added to `referencedMessageSchema` + `buildRawReference` (presence-encoded). The time-fallback dedup gates on webhook-or-bot authorship; `webhookId` was already on the wire but plain-bot authors weren't representable — the worker can't ask Discord.

### Commit 2 — worker enrichment (`feat(ai-worker)`)

- **`enrichRawReferences`** mirrors the ReferenceFormatter loop from raw snapshots: dedup against the **worker-assembled** history → shared stub; forwarded refs pass through (raw==enriched by contract); regular refs get DB transcripts. Reference numbers adopted from the wire verbatim.
- **`ContextDataSource.getMessageByDiscordId`** (new) — the DB tier of transcript retrieval. The bot's Redis-cache tier has no worker equivalent: cache-hit-only transcripts are a documented, accepted burn-in divergence source.
- **Dedup time-anchor**: the job's BullMQ enqueue timestamp threads through `ContextStep → shadowAssembleAndDiff → assembleCore` — the closest stand-in for the bot's crawl-time wall clock (worker wall-clock would shrink the 60s window by queue latency).
- **Shadow surface**: `referencedMessages` joins the diff — per-`referenceNumber` content + stub-decision comparison; skipped (`compared:false`) when the envelope carries no raw refs (weigh-in / legacy senders).

### Documented accepted divergences

1. **Dedup disagreement**: the worker dedups against its own assembled history (fetch-timing drift can differ from the bot's view) — surfaces as per-number dedup mismatches. Counts always align by construction: a bot-deduped forward ships ONE raw container ref, so both sides enrich the same list. (Corrected from an earlier count-asymmetry claim — caught while covering the diff's missing-number branch.)
2. **Redis-tier transcripts**: bot-side cache hits the worker DB can't see.
3. **Snapshot refs lack container authorship**: time-fallback can't fire on them worker-side (snapshot refs carry no webhookId/authorIsBot by construction; container-authored-by-webhook forwards are a rare edge).

## Testing

- `referenceEnrichment.test.ts` (15, common-types) — dedup window/tolerance boundaries, stub truncation + shape, transcript formatting
- `referenceEnricher.test.ts` (8, ai-worker) — stub/full/forwarded routing, authorIsBot gating, anchor-absent behavior, order preservation
- `ContextAssembler` 9, `shadowAssembly` 12 (4 new reference-surface tests), `PrismaContextDataSource` 8, `referencedMessageSchema` contract tests, bot-side `authorIsBot` capture tests
- One bot-side mock updated for fidelity: `ReferenceFormatter.test`'s `buildRawReference` stub now mirrors the real forwarded-content extraction (the deduped-forward stub test's behavior assertion is unchanged)
- Full suites green: ai-worker 3167, bot-client 4981, common-types 2698; `pnpm quality` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)