### PR TITLE
fix(ci): install codecov CLI via PyPI (keybase GPG-key outage workaround + hardening)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,11 @@ jobs:
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v6
         with:
+          # PyPI install path: the default binary download verifies its GPG
+          # signature against a key fetched from keybase.io, which has gone
+          # unavailable before (keybase 404 body piped into gpg — see
+          # codecov/codecov-action#1955). pip keeps its own integrity checks.
+          use_pypi: true
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./services/ai-worker/coverage/lcov.info
           flags: ai-worker
@@ -219,6 +224,11 @@ jobs:
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v6
         with:
+          # PyPI install path: the default binary download verifies its GPG
+          # signature against a key fetched from keybase.io, which has gone
+          # unavailable before (keybase 404 body piped into gpg — see
+          # codecov/codecov-action#1955). pip keeps its own integrity checks.
+          use_pypi: true
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./services/api-gateway/coverage/lcov.info
           flags: api-gateway
@@ -229,6 +239,11 @@ jobs:
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v6
         with:
+          # PyPI install path: the default binary download verifies its GPG
+          # signature against a key fetched from keybase.io, which has gone
+          # unavailable before (keybase 404 body piped into gpg — see
+          # codecov/codecov-action#1955). pip keeps its own integrity checks.
+          use_pypi: true
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./services/bot-client/coverage/lcov.info
           flags: bot-client
@@ -239,6 +254,11 @@ jobs:
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v6
         with:
+          # PyPI install path: the default binary download verifies its GPG
+          # signature against a key fetched from keybase.io, which has gone
+          # unavailable before (keybase 404 body piped into gpg — see
+          # codecov/codecov-action#1955). pip keeps its own integrity checks.
+          use_pypi: true
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/common-types/coverage/lcov.info
           flags: common-types
@@ -249,6 +269,11 @@ jobs:
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v6
         with:
+          # PyPI install path: the default binary download verifies its GPG
+          # signature against a key fetched from keybase.io, which has gone
+          # unavailable before (keybase 404 body piped into gpg — see
+          # codecov/codecov-action#1955). pip keeps its own integrity checks.
+          use_pypi: true
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./services/*/junit.xml,./packages/*/junit.xml
           report_type: test_results
@@ -321,6 +346,11 @@ jobs:
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v6
         with:
+          # PyPI install path: the default binary download verifies its GPG
+          # signature against a key fetched from keybase.io, which has gone
+          # unavailable before (keybase 404 body piped into gpg — see
+          # codecov/codecov-action#1955). pip keeps its own integrity checks.
+          use_pypi: true
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/integration/lcov.info
           flags: integration
@@ -365,6 +395,11 @@ jobs:
         if: ${{ !cancelled() && steps.filter.outputs.voice-engine == 'true' }}
         uses: codecov/codecov-action@v6
         with:
+          # PyPI install path: the default binary download verifies its GPG
+          # signature against a key fetched from keybase.io, which has gone
+          # unavailable before (keybase 404 body piped into gpg — see
+          # codecov/codecov-action#1955). pip keeps its own integrity checks.
+          use_pypi: true
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./services/voice-engine/coverage.xml
           flags: voice-engine


### PR DESCRIPTION
## Summary

Every coverage upload is currently hard-failing globally: the codecov-action's default path downloads the CLI binary and verifies its GPG signature against a key fetched from `keybase.io/codecovsecurity/pgp_keys.asc` with a bare `curl -s` (no `--fail`, no retry, no fallback keyserver). That Keybase page started 404ing today; the 404 *body text* gets piped into `gpg --import`, producing "no valid OpenPGP data found" → "Can't check signature: No public key" → exit 1 on every upload step. Upstream: [codecov/codecov-action#1955](https://github.com/codecov/codecov-action/issues/1955) (filed today; also took down mozilla/pdf.js CI, [pdf.js#21394](https://github.com/mozilla/pdf.js/issues/21394)). Plausibly fallout from the Codecov→Harness transition announced this week.

**Fix**: `use_pypi: true` on all 7 codecov-action steps — installs the CLI through pip, which keeps PyPI's own integrity verification while removing the Keybase dependency entirely. This is the community-verified workaround from #1955 and a permanent hardening (chosen over `skip-validation: true`, which would drop verification altogether).

Blocks: PR #1163's final merge gate (its test suites pass; only the upload step dies).

## Testing

This PR's own CI runs the modified workflow — green coverage uploads here ARE the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)