### PR TITLE
feat(ai-worker): PR 2.5c-iii-a3-ii-3 — cross-channel decoration + full-diff wrap-up

### DIFF
--- a/packages/common-types/src/index.ts
+++ b/packages/common-types/src/index.ts
@@ -92,6 +92,7 @@ export * from './utils/extendedContextPersonaResolver.js';
 export * from './utils/referenceEnrichment.js';
 export * from './utils/messageLinkParser.js';
 export * from './utils/mentionRewriter.js';
+export * from './utils/crossChannelEnvironment.js';
 export * from './services/UserService.js';
 export * from './services/BaseCacheInvalidationService.js';
 export * from './services/CacheInvalidationService.js';

--- a/packages/common-types/src/utils/crossChannelEnvironment.test.ts
+++ b/packages/common-types/src/utils/crossChannelEnvironment.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { MessageRole } from '../constants/index.js';
+import type { CrossChannelHistoryGroup } from '../services/ConversationMessageMapper.js';
+import { buildFallbackEnvironment, mapCrossChannelToApiFormat } from './crossChannelEnvironment.js';
+
+describe('buildFallbackEnvironment', () => {
+  it('builds a DM environment when guildId is null', () => {
+    expect(buildFallbackEnvironment('chan-1', null)).toEqual({
+      type: 'dm',
+      channel: { id: 'chan-1', name: 'Direct Message', type: 'dm' },
+    });
+  });
+
+  it('builds an unknown guild environment when guildId is present', () => {
+    expect(buildFallbackEnvironment('chan-1', 'guild-1')).toEqual({
+      type: 'guild',
+      guild: { id: 'guild-1', name: 'unknown-server' },
+      channel: { id: 'chan-1', name: 'unknown-channel', type: 'text' },
+    });
+  });
+});
+
+describe('mapCrossChannelToApiFormat', () => {
+  it('should map groups to API format with ISO date strings', () => {
+    const date = new Date('2026-02-26T10:00:00Z');
+    const groups = [
+      {
+        channelEnvironment: {
+          type: 'dm' as const,
+          channel: { id: 'ch-1', name: 'DM', type: 'dm' },
+        },
+        messages: [
+          {
+            id: 'msg-1',
+            role: MessageRole.User,
+            content: 'Hello',
+            tokenCount: 5,
+            createdAt: date,
+            personaId: 'p-1',
+            personaName: 'User',
+            channelId: 'ch-1',
+            guildId: null,
+            discordMessageId: ['d-1'],
+          } as CrossChannelHistoryGroup['messages'][0],
+        ],
+      },
+    ];
+
+    const result = mapCrossChannelToApiFormat(groups);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].channelEnvironment.type).toBe('dm');
+    const msg = result[0].messages[0];
+    expect(msg.id).toBe('msg-1');
+    expect(msg.role).toBe(MessageRole.User);
+    expect(msg.content).toBe('Hello');
+    expect(msg.tokenCount).toBe(5);
+    expect(msg.createdAt).toBe('2026-02-26T10:00:00.000Z');
+    expect(msg.personaId).toBe('p-1');
+    expect(msg.personaName).toBe('User');
+  });
+
+  it('should pass through optional disambiguation fields', () => {
+    const date = new Date('2026-02-26T10:00:00Z');
+    const groups = [
+      {
+        channelEnvironment: {
+          type: 'guild' as const,
+          guild: { id: 'g-1', name: 'Server' },
+          channel: { id: 'ch-1', name: 'general', type: 'text' },
+        },
+        messages: [
+          {
+            id: 'msg-2',
+            role: MessageRole.Assistant,
+            content: 'Response',
+            tokenCount: 10,
+            createdAt: date,
+            personaId: 'p-1',
+            personaName: 'User',
+            discordUsername: 'alice#1234',
+            personalityId: 'pers-1',
+            personalityName: 'TestBot',
+            channelId: 'ch-1',
+            guildId: 'g-1',
+            discordMessageId: ['d-2'],
+          } as CrossChannelHistoryGroup['messages'][0],
+        ],
+      },
+    ];
+
+    const result = mapCrossChannelToApiFormat(groups);
+
+    const msg = result[0].messages[0];
+    expect(msg.discordUsername).toBe('alice#1234');
+    expect(msg.personalityId).toBe('pers-1');
+    expect(msg.personalityName).toBe('TestBot');
+  });
+});

--- a/packages/common-types/src/utils/crossChannelEnvironment.ts
+++ b/packages/common-types/src/utils/crossChannelEnvironment.ts
@@ -1,0 +1,67 @@
+/**
+ * Cross-channel environment + wire-format kernels, shared by bot-client's
+ * CrossChannelHistoryFetcher and ai-worker's context assembler.
+ *
+ * Shared-implementation guarantee: the wire serialization
+ * (`mapCrossChannelToApiFormat`) and the fallback environment shape are the
+ * SAME functions on both sides, so cross-channel payload entries cannot
+ * drift between the legacy bot path and the worker-side re-derivation.
+ *
+ * What stays caller-side: HOW a channel id resolves to a DiscordEnvironment.
+ * Bot-client live-fetches the channel from Discord; ai-worker looks it up in
+ * the envelope's knownChannelEnvironments map. Both degrade to the fallback
+ * built here when resolution fails.
+ */
+
+import type { ConversationMessage } from '../services/ConversationMessageMapper.js';
+import type { DiscordEnvironment } from '../types/schemas/discord.js';
+import type { CrossChannelHistoryGroupEntry } from '../types/schemas/message.js';
+
+/** A single cross-channel group with its resolved Discord environment. */
+export interface ResolvedCrossChannelGroup {
+  channelEnvironment: DiscordEnvironment;
+  messages: ConversationMessage[];
+}
+
+/** Build a minimal fallback environment when channel resolution fails. */
+export function buildFallbackEnvironment(
+  channelId: string,
+  guildId: string | null
+): DiscordEnvironment {
+  if (guildId === null) {
+    return {
+      type: 'dm',
+      channel: { id: channelId, name: 'Direct Message', type: 'dm' },
+    };
+  }
+  return {
+    type: 'guild',
+    guild: { id: guildId, name: 'unknown-server' },
+    channel: { id: channelId, name: 'unknown-channel', type: 'text' },
+  };
+}
+
+/**
+ * Map resolved cross-channel groups to the API/job payload format (Date→string serialization).
+ * Note: `discordMessageId` is intentionally omitted — it's only used for current-channel
+ * quote deduplication and is not relevant for cross-channel historical context.
+ */
+export function mapCrossChannelToApiFormat(
+  groups: ResolvedCrossChannelGroup[]
+): CrossChannelHistoryGroupEntry[] {
+  return groups.map(group => ({
+    channelEnvironment: group.channelEnvironment,
+    messages: group.messages.map(msg => ({
+      id: msg.id,
+      role: msg.role,
+      content: msg.content,
+      tokenCount: msg.tokenCount,
+      createdAt: msg.createdAt.toISOString(),
+      personaId: msg.personaId,
+      personaName: msg.personaName,
+      discordUsername: msg.discordUsername,
+      personalityId: msg.personalityId,
+      personalityName: msg.personalityName,
+    })),
+  }));
+}

--- a/packages/common-types/src/utils/extendedContextPersonaResolver.ts
+++ b/packages/common-types/src/utils/extendedContextPersonaResolver.ts
@@ -21,11 +21,11 @@
  *
  * Postcondition of resolveExtendedContextPersonaIds: no message or reactor
  * exits with a `discord:XXXX` personaId — resolved outputs carry UUIDs (or
- * the empty-string sentinel for unregistered users). Note: since the raw
- * assembly envelope (CONTEXT_RAW_ENVELOPE), PRE-resolution snapshots — with
- * placeholders intact — deliberately cross to ai-worker so its context
- * assembler can re-run this exact resolution; that is why this module lives
- * in common-types and is shared by both sides.
+ * the empty-string sentinel for unregistered users). Note: the raw assembly
+ * envelope (CONTEXT_RAW_ENVELOPE) carries PRE-resolution snapshots — with
+ * placeholders intact — across to ai-worker so its context assembler can
+ * re-run this exact resolution; that is why this module lives in
+ * common-types and is shared by both sides.
  */
 
 import { createLogger } from './logger.js';

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/ContextStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/ContextStep.test.ts
@@ -144,7 +144,7 @@ describe('ContextStep', () => {
       expect(mockShadowHydrateAndDiff).not.toHaveBeenCalled();
     });
 
-    it('routes to the ASSEMBLY shadow when the raw envelope is present and an assembler is wired', () => {
+    it('routes to the assembly shadow when the raw envelope is present and an assembler is wired', () => {
       mockIsShadowHydrationEnabled.mockReturnValue(true);
       const fakeAssembler = { assembleCore: vi.fn() };
       const gatedStep = new ContextStep(fakeDataSource, fakeAssembler as never);

--- a/services/ai-worker/src/services/context/ContextAssembler.test.ts
+++ b/services/ai-worker/src/services/context/ContextAssembler.test.ts
@@ -8,7 +8,12 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   return { ...actual, createLogger: () => mockLogger };
 });
 
-import { MessageRole, type JobContext, type LoadedPersonality } from '@tzurot/common-types';
+import {
+  MessageRole,
+  type JobContext,
+  type LoadedPersonality,
+  type ResolvedConfigOverrides,
+} from '@tzurot/common-types';
 import { ContextAssembler, type ContextAssemblerDeps } from './ContextAssembler.js';
 import type { ContextDataSource } from './types.js';
 
@@ -95,7 +100,7 @@ describe('ContextAssembler.assembleCore', () => {
         rawAssemblyInputs: { rawMessageContent: 'hello', rawAuthorDisplayName: 'Vladlena' },
       }),
       PERSONALITY,
-      { maxMessages: 30, maxAge: 7200 } as never
+      { maxMessages: 30, maxAge: 7200 } as ResolvedConfigOverrides
     );
 
     expect(deps.userService.getOrCreateUser).toHaveBeenCalledWith(
@@ -201,6 +206,11 @@ describe('ContextAssembler.assembleCore', () => {
     const ext = core.history.find(m => m.id === 'd-ext');
     expect(ext?.personaId).toBe('persona-555');
     expect(ext?.createdAt).toBeInstanceOf(Date);
+    // Wire shape lacks channelId/guildId; the assembler fills them from the
+    // job (same-channel by construction) so assembled rows are structurally
+    // complete ConversationMessages.
+    expect(ext?.channelId).toBe('chan-1');
+    expect(ext?.guildId).toBeNull();
   });
 
   it('leaves referencedMessages undefined when the envelope carries no raw references', async () => {
@@ -342,6 +352,86 @@ describe('ContextAssembler.assembleCore', () => {
     // The anonymous-poke path must not create users for mentioned people —
     // only the author upsert from step 1 runs.
     expect(deps.userService.getOrCreateUser).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves crossChannelHistory undefined when the feature is disabled', async () => {
+    const deps = makeDeps();
+    const assembler = new ContextAssembler(deps);
+    const core = await assembler.assembleCore(makeJobContext(), PERSONALITY, {
+      maxMessages: 30,
+      crossChannelHistoryEnabled: false,
+    } as ResolvedConfigOverrides);
+    expect(core.crossChannelHistory).toBeUndefined();
+    expect(deps.dataSource.getCrossChannelHistory).not.toHaveBeenCalled();
+  });
+
+  it('skips cross-channel for weigh-in jobs even when enabled', async () => {
+    const deps = makeDeps();
+    const assembler = new ContextAssembler(deps);
+    const core = await assembler.assembleCore(makeJobContext({ isWeighIn: true }), PERSONALITY, {
+      maxMessages: 30,
+      crossChannelHistoryEnabled: true,
+    } as ResolvedConfigOverrides);
+    expect(core.crossChannelHistory).toBeUndefined();
+    expect(deps.dataSource.getCrossChannelHistory).not.toHaveBeenCalled();
+  });
+
+  it('decorates cross-channel groups from the env map, falling back for cache misses', async () => {
+    const knownEnv = {
+      type: 'guild' as const,
+      guild: { id: 'g1', name: 'Guild' },
+      channel: { id: 'other-1', name: 'general', type: 'text' },
+    };
+    const row = {
+      id: 'cc-1',
+      role: MessageRole.User,
+      content: 'cross msg',
+      createdAt: new Date('2026-06-01T00:00:00Z'),
+      personaId: 'p1',
+      channelId: 'other-1',
+      guildId: 'g1',
+      discordMessageId: ['d-cc'],
+    };
+    const deps = makeDeps({
+      dataSource: {
+        getCrossChannelHistory: vi.fn().mockResolvedValue([
+          { channelId: 'other-1', guildId: 'g1', messages: [row] },
+          { channelId: 'uncached-2', guildId: 'g1', messages: [] },
+        ]),
+      },
+    });
+    const assembler = new ContextAssembler(deps);
+
+    const core = await assembler.assembleCore(
+      makeJobContext({
+        rawAssemblyInputs: {
+          rawMessageContent: 'hello',
+          knownChannelEnvironments: { 'other-1': knownEnv },
+        },
+      }),
+      PERSONALITY,
+      { maxMessages: 30, maxAge: 7200, crossChannelHistoryEnabled: true } as ResolvedConfigOverrides
+    );
+
+    expect(deps.dataSource.getCrossChannelHistory).toHaveBeenCalledWith({
+      personaId: 'persona-1',
+      personalityId: 'pers-1',
+      excludeChannelId: 'chan-1',
+      limit: 30,
+      maxAgeSeconds: 7200,
+      contextEpoch: undefined,
+    });
+    expect(core.crossChannelHistory).toHaveLength(2);
+    // Cached channel: decorated with the envelope's environment.
+    expect(core.crossChannelHistory?.[0].channelEnvironment).toEqual(knownEnv);
+    // Wire serialization via the SHARED mapper (Date → ISO string).
+    expect(core.crossChannelHistory?.[0].messages[0].createdAt).toBe('2026-06-01T00:00:00.000Z');
+    // Cache miss: shared fallback environment.
+    expect(core.crossChannelHistory?.[1].channelEnvironment).toEqual({
+      type: 'guild',
+      guild: { id: 'g1', name: 'unknown-server' },
+      channel: { id: 'uncached-2', name: 'unknown-channel', type: 'text' },
+    });
   });
 
   it('returns plain DB history when the envelope carries no extended context', async () => {

--- a/services/ai-worker/src/services/context/ContextAssembler.ts
+++ b/services/ai-worker/src/services/context/ContextAssembler.ts
@@ -17,11 +17,14 @@
  */
 
 import {
+  buildFallbackEnvironment,
   createLogger,
+  mapCrossChannelToApiFormat,
   mergeWithHistory,
   resolveExtendedContextPersonaIds,
   MESSAGE_LIMITS,
   type ConversationMessage,
+  type CrossChannelHistoryGroupEntry,
   type JobContext,
   type LoadedPersonality,
   type MentionedPersona,
@@ -32,7 +35,7 @@ import {
   type ResolvedConfigOverrides,
   type UserService,
 } from '@tzurot/common-types';
-import { rewriteRawContent } from './contentRewriter.js';
+import { rewriteRawContent, type RewrittenContent } from './contentRewriter.js';
 import { enrichRawReferences } from './referenceEnricher.js';
 import type { ContextDataSource } from './types.js';
 
@@ -65,6 +68,14 @@ export interface AssembledCore {
   mentionedPersonas: MentionedPersona[] | undefined;
   /** Channels resolved from channel mentions; undefined when none (payload parity). */
   referencedChannels: ReferencedChannel[] | undefined;
+  /**
+   * Cross-channel history groups, decorated from the envelope's
+   * knownChannelEnvironments (fallback env for cache misses) and serialized
+   * through the shared wire mapper. Undefined when the feature is disabled
+   * or the job is a weigh-in (payload parity with the bot path); [] when
+   * enabled but nothing eligible was found.
+   */
+  crossChannelHistory: CrossChannelHistoryGroupEntry[] | undefined;
 }
 
 /** Per-call assembly options (job-scoped values the deps can't carry). */
@@ -87,23 +98,29 @@ export interface ContextAssemblerDeps {
  * the ConversationMessage shape the shared merge/resolution functions
  * operate on. Inverse of bot-client's toApiConversationMessage.
  *
- * The cast bridges a known wire-shape gap: the envelope does not carry
- * channelId/guildId (extended context is same-channel by construction, so
- * they're derivable from the job). Nothing in the shadow path reads them —
- * the merge dedups on discordMessageId, the resolver touches personaId, and
- * the diff compares ids/content/personaIds — but the cutover slice must fill
- * them from job context before the assembled history feeds prompt building.
+ * The wire shape omits channelId/guildId (extended context is same-channel
+ * by construction), so both are filled from the job here — `satisfies`
+ * keeps the mapping structurally checked against ConversationMessage.
  */
 function fromApiMessage(
-  msg: NonNullable<RawAssemblyInputs['rawExtendedContextMessages']>[number]
+  msg: NonNullable<RawAssemblyInputs['rawExtendedContextMessages']>[number],
+  channelId: string,
+  guildId: string | null
 ): ConversationMessage {
   return {
     ...msg,
+    channelId,
+    guildId,
+    // id/personaId are schema-optional on the wire but always populated by
+    // the bot-side fetcher; '' mirrors the shadow diff's own normalization
+    // ('' ids are excluded from id-keyed diffs, personaIds compare via ?? '').
+    id: msg.id ?? '',
+    personaId: msg.personaId ?? '',
     // Discord messages always carry timestamps; epoch-0 is a defensive
     // fallback that sorts such a row first rather than crashing assembly.
     createdAt: msg.createdAt !== undefined ? new Date(msg.createdAt) : new Date(0),
     discordMessageId: msg.discordMessageId ?? [],
-  } as ConversationMessage;
+  } satisfies ConversationMessage;
 }
 
 export class ContextAssembler {
@@ -171,7 +188,10 @@ export class ContextAssembler {
     // Step 4: envelope-carried extended context — batch-upsert the observed
     // users, resolve placeholder personaIds (shared impl), merge (shared
     // impl). ABSENT raw messages = the fetch didn't run bot-side.
-    const history = await this.mergeExtendedContext(raw, dbHistory, personality.id);
+    const history = await this.mergeExtendedContext(raw, dbHistory, personality.id, {
+      channelId,
+      guildId: jobContext.serverId ?? null,
+    });
 
     // Step 5: re-derive reference enrichment from the raw snapshots —
     // dedup against the just-assembled history, transcripts from OWN DB.
@@ -179,30 +199,22 @@ export class ContextAssembler {
 
     // Step 6: content rewriting (links → user mentions → channels → roles),
     // skipped wholesale in weigh-in mode to mirror the bot-side early return.
-    const rewritten =
-      jobContext.isWeighIn === true
-        ? {
-            messageContent: raw.rawMessageContent,
-            mentionedPersonas: undefined,
-            referencedChannels: undefined,
-          }
-        : await rewriteRawContent({
-            raw,
-            rawReferences: raw.rawReferencedMessages,
-            personalityId: personality.id,
-            deps: {
-              getOrCreateUser: (discordId, username, displayName, bio, isBot) =>
-                this.deps.userService.getOrCreateUser(discordId, username, displayName, bio, isBot),
-              resolvePersona: async (discordUserId, pid) => {
-                const result = await this.deps.personaResolver.resolve(discordUserId, pid);
-                return {
-                  personaId: result.config.personaId,
-                  preferredName: result.config.preferredName,
-                };
-              },
-              findUserByDiscordId: discordId => this.deps.dataSource.findUserByDiscordId(discordId),
-            },
-          });
+    const rewritten = await this.rewriteContent(jobContext, raw, personality);
+
+    // Step 7: cross-channel history — own DB fetch, environment names from
+    // the envelope's cache map (the worker can't ask Discord), shared wire
+    // mapper. Same budget as the channel-history dbLimit, mirroring the
+    // bot-side fetchCrossChannelIfEnabled gate (disabled or weigh-in →
+    // undefined, matching the payload's absent field).
+    const crossChannelHistory = await this.assembleCrossChannel(jobContext, personality, {
+      enabled:
+        configOverrides?.crossChannelHistoryEnabled === true && jobContext.isWeighIn !== true,
+      personaId: activePersonaId,
+      excludeChannelId: channelId,
+      limit,
+      maxAgeSeconds: configOverrides?.maxAge ?? undefined,
+      contextEpoch,
+    });
 
     logger.debug(
       {
@@ -211,6 +223,7 @@ export class ContextAssembler {
         dbCount: dbHistory.length,
         mergedCount: history.length,
         referenceCount: referencedMessages?.length,
+        crossChannelGroups: crossChannelHistory?.length,
       },
       'Core context assembled'
     );
@@ -226,7 +239,88 @@ export class ContextAssembler {
       messageContent: rewritten.messageContent,
       mentionedPersonas: rewritten.mentionedPersonas,
       referencedChannels: rewritten.referencedChannels,
+      crossChannelHistory,
     };
+  }
+
+  /**
+   * Content rewriting through the shared kernels — weigh-in jobs pass the
+   * raw content through untouched (mirrors the bot's early return and
+   * avoids upserting mention users for anonymous pokes).
+   */
+  private async rewriteContent(
+    jobContext: JobContext,
+    raw: RawAssemblyInputs,
+    personality: LoadedPersonality
+  ): Promise<RewrittenContent> {
+    if (jobContext.isWeighIn === true) {
+      return {
+        messageContent: raw.rawMessageContent,
+        mentionedPersonas: undefined,
+        referencedChannels: undefined,
+      };
+    }
+    return rewriteRawContent({
+      raw,
+      rawReferences: raw.rawReferencedMessages,
+      personalityId: personality.id,
+      deps: {
+        getOrCreateUser: (discordId, username, displayName, bio, isBot) =>
+          this.deps.userService.getOrCreateUser(discordId, username, displayName, bio, isBot),
+        resolvePersona: async (discordUserId, pid) => {
+          const result = await this.deps.personaResolver.resolve(discordUserId, pid);
+          return {
+            personaId: result.config.personaId,
+            preferredName: result.config.preferredName,
+          };
+        },
+        findUserByDiscordId: discordId => this.deps.dataSource.findUserByDiscordId(discordId),
+      },
+    });
+  }
+
+  /**
+   * Fetch + decorate + serialize cross-channel history. Environment names
+   * come from the envelope's knownChannelEnvironments map; channels missing
+   * from it (lazily-cached threads, post-capture renames) degrade to the
+   * shared fallback environment — an accepted divergence vs the bot's
+   * live-fetch decoration.
+   */
+  private async assembleCrossChannel(
+    jobContext: JobContext,
+    personality: LoadedPersonality,
+    opts: {
+      enabled: boolean;
+      personaId: string;
+      /** The narrowed current-channel id from assembleCore's guard. */
+      excludeChannelId: string;
+      limit: number;
+      maxAgeSeconds: number | undefined;
+      contextEpoch: Date | undefined;
+    }
+  ): Promise<CrossChannelHistoryGroupEntry[] | undefined> {
+    if (!opts.enabled) {
+      return undefined;
+    }
+
+    const groups = await this.deps.dataSource.getCrossChannelHistory({
+      personaId: opts.personaId,
+      personalityId: personality.id,
+      excludeChannelId: opts.excludeChannelId,
+      limit: opts.limit,
+      maxAgeSeconds: opts.maxAgeSeconds,
+      contextEpoch: opts.contextEpoch,
+    });
+
+    const envByChannelId = jobContext.rawAssemblyInputs?.knownChannelEnvironments ?? {};
+    return mapCrossChannelToApiFormat(
+      groups.map(group => ({
+        channelEnvironment:
+          envByChannelId[group.channelId] ??
+          buildFallbackEnvironment(group.channelId, group.guildId),
+        messages: group.messages,
+      }))
+    );
   }
 
   /**
@@ -262,7 +356,8 @@ export class ContextAssembler {
   private async mergeExtendedContext(
     raw: RawAssemblyInputs,
     dbHistory: ConversationMessage[],
-    personalityId: string
+    personalityId: string,
+    location: { channelId: string; guildId: string | null }
   ): Promise<ConversationMessage[]> {
     const rawMessages = raw.rawExtendedContextMessages;
     if (rawMessages === undefined || rawMessages.length === 0) {
@@ -282,7 +377,7 @@ export class ContextAssembler {
       isBot: u.isBot ?? false,
     }));
 
-    const messages = rawMessages.map(fromApiMessage);
+    const messages = rawMessages.map(m => fromApiMessage(m, location.channelId, location.guildId));
 
     if (usersToResolve.length > 0) {
       const userMap = await this.deps.userService.getOrCreateUsersInBatch(usersToResolve);

--- a/services/ai-worker/src/services/context/contentRewriter.ts
+++ b/services/ai-worker/src/services/context/contentRewriter.ts
@@ -137,14 +137,11 @@ export async function rewriteRawContent(
             personaName: u.personaName,
           }))
         : undefined,
+    // RawMentionedChannel is structurally identical to ReferencedChannel —
+    // pass the kernel's list through rather than re-mapping (an explicit
+    // mapping would write `topic: undefined` props that could false-diverge
+    // a future deep-equality diff).
     referencedChannels:
-      channelResult.mentionedChannels.length > 0
-        ? channelResult.mentionedChannels.map(c => ({
-            channelId: c.channelId,
-            channelName: c.channelName,
-            topic: c.topic,
-            guildId: c.guildId,
-          }))
-        : undefined,
+      channelResult.mentionedChannels.length > 0 ? channelResult.mentionedChannels : undefined,
   };
 }

--- a/services/ai-worker/src/services/context/referenceEnricher.ts
+++ b/services/ai-worker/src/services/context/referenceEnricher.ts
@@ -75,38 +75,37 @@ export async function enrichRawReferences(
   const { rawReferences, history, retrieveTranscript, nowMs } = params;
   const dedupHistory = buildDedupHistory(history);
 
-  const enriched: ReferencedMessage[] = [];
-  for (const raw of rawReferences) {
-    const duplicate = isDuplicateReference(
-      {
+  // Promise.all preserves input order, so wire order (and the adopted
+  // reference numbers) survive the parallel enrichment.
+  return Promise.all(
+    rawReferences.map(async (raw): Promise<ReferencedMessage> => {
+      const duplicate = isDuplicateReference(
+        {
+          discordMessageId: raw.discordMessageId,
+          timestampMs: new Date(raw.timestamp).getTime(),
+          isWebhookOrBotAuthored:
+            (raw.webhookId !== undefined && raw.webhookId.length > 0) || raw.authorIsBot === true,
+        },
+        dedupHistory,
+        nowMs
+      );
+
+      if (duplicate) {
+        return buildDedupedReferenceStub(raw);
+      }
+
+      if (raw.isForwarded === true) {
+        // Snapshot/container references: raw == enriched by contract.
+        return { ...raw };
+      }
+
+      const content = await appendVoiceTranscripts({
+        content: raw.content,
+        attachments: raw.attachments ?? [],
         discordMessageId: raw.discordMessageId,
-        timestampMs: new Date(raw.timestamp).getTime(),
-        isWebhookOrBotAuthored:
-          (raw.webhookId !== undefined && raw.webhookId.length > 0) || raw.authorIsBot === true,
-      },
-      dedupHistory,
-      nowMs
-    );
-
-    if (duplicate) {
-      enriched.push(buildDedupedReferenceStub(raw));
-      continue;
-    }
-
-    if (raw.isForwarded === true) {
-      // Snapshot/container references: raw == enriched by contract.
-      enriched.push({ ...raw });
-      continue;
-    }
-
-    const content = await appendVoiceTranscripts({
-      content: raw.content,
-      attachments: raw.attachments ?? [],
-      discordMessageId: raw.discordMessageId,
-      retrieve: retrieveTranscript,
-    });
-    enriched.push({ ...raw, content });
-  }
-
-  return enriched;
+        retrieve: retrieveTranscript,
+      });
+      return { ...raw, content };
+    })
+  );
 }

--- a/services/ai-worker/src/services/context/shadowAssembly.test.ts
+++ b/services/ai-worker/src/services/context/shadowAssembly.test.ts
@@ -27,6 +27,7 @@ function makeAssembler(core: Partial<AssembledCore>): ContextAssembler {
       messageContent: 'hello',
       mentionedPersonas: undefined,
       referencedChannels: undefined,
+      crossChannelHistory: undefined,
       ...core,
     }),
   } as unknown as ContextAssembler;
@@ -52,6 +53,12 @@ const msg = (id: string, content: string, personaId = 'persona-1') => ({
   createdAt: new Date('2026-06-01T00:00:00Z'),
   personaId,
   discordMessageId: [id],
+});
+
+const env = (channelId: string, name = 'chan') => ({
+  type: 'guild' as const,
+  guild: { id: 'g1', name: 'Guild' },
+  channel: { id: channelId, name, type: 'text' },
 });
 
 const ref = () => ({
@@ -415,6 +422,89 @@ describe('shadowAssembleAndDiff', () => {
         }),
       }),
       expect.stringContaining('DIVERGED')
+    );
+  });
+
+  it('flags cross-channel presence disagreement (gate divergence)', async () => {
+    await shadowAssembleAndDiff({
+      jobId: 'j1',
+      jobContext: makeJobContext({ crossChannelHistory: undefined }),
+      personality: PERSONALITY,
+      configOverrides: undefined,
+      jobTimestampMs: undefined,
+      payloadMessage: 'hello',
+      assembler: makeAssembler({
+        crossChannelHistory: [{ channelEnvironment: env('other-1'), messages: [] }] as never,
+      }),
+    });
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        matches: expect.objectContaining({ crossChannelHistory: false }),
+        crossChannelDiff: expect.objectContaining({ presenceMismatch: true }),
+      }),
+      expect.stringContaining('DIVERGED')
+    );
+  });
+
+  it('tolerates env-name drift but flags missing cross-channel messages', async () => {
+    const payloadGroup = {
+      channelEnvironment: env('other-1', 'real-name'),
+      messages: [
+        { id: 'x1', role: MessageRole.User, content: 'cross msg' },
+        { id: 'x2', role: MessageRole.User, content: 'second' },
+      ],
+    };
+    const assembledGroup = {
+      // Same channel id, fallback name (cache miss) — tolerated but counted.
+      channelEnvironment: env('other-1', 'unknown-channel'),
+      messages: [{ id: 'x1', role: MessageRole.User, content: 'cross msg' }],
+    };
+    await shadowAssembleAndDiff({
+      jobId: 'j1',
+      jobContext: makeJobContext({ crossChannelHistory: [payloadGroup] as never }),
+      personality: PERSONALITY,
+      configOverrides: undefined,
+      jobTimestampMs: undefined,
+      payloadMessage: 'hello',
+      assembler: makeAssembler({ crossChannelHistory: [assembledGroup] as never }),
+    });
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        crossChannelDiff: expect.objectContaining({
+          envNameMismatches: 1,
+          missingMessages: 1,
+          matched: false,
+        }),
+      }),
+      expect.stringContaining('DIVERGED')
+    );
+  });
+
+  it('matches cross-channel groups by key with identical messages despite name drift', async () => {
+    const messages = [{ id: 'x1', role: MessageRole.User, content: 'cross msg' }];
+    await shadowAssembleAndDiff({
+      jobId: 'j1',
+      jobContext: makeJobContext({
+        crossChannelHistory: [
+          { channelEnvironment: env('other-1', 'live-name'), messages },
+        ] as never,
+      }),
+      personality: PERSONALITY,
+      configOverrides: undefined,
+      jobTimestampMs: undefined,
+      payloadMessage: 'hello',
+      assembler: makeAssembler({
+        crossChannelHistory: [
+          { channelEnvironment: env('other-1', 'cached-name'), messages: [...messages] },
+        ] as never,
+      }),
+    });
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allMatched: true,
+        crossChannelDiff: expect.objectContaining({ envNameMismatches: 1, matched: true }),
+      }),
+      expect.stringContaining('matched')
     );
   });
 

--- a/services/ai-worker/src/services/context/shadowAssembly.ts
+++ b/services/ai-worker/src/services/context/shadowAssembly.ts
@@ -13,10 +13,15 @@
  * booleans and an aggregate `allMatched`. Match rate over a burn-in window =
  * grep `ShadowAssembly` / count `allMatched:true` — the go/no-go gate for
  * the envelope cutover.
+ *
+ * Reading note: contextEpoch is diffed only INDIRECTLY (a differing epoch
+ * fetches different history rows), so `allMatched: true` means "epoch
+ * effects on history agree," not "the epochs themselves were compared."
  */
 
 import {
   createLogger,
+  type CrossChannelHistoryGroupEntry,
   type JobContext,
   type LoadedPersonality,
   type MentionedPersona,
@@ -65,6 +70,111 @@ interface SurfaceMatches {
   mentionedPersonas: boolean;
   /** Set comparison over channel ids (payload omits the field when empty). */
   referencedChannels: boolean;
+  /**
+   * Cross-channel groups: strict on presence (one side undefined while the
+   * other carries groups = gate disagreement, likely config divergence) and
+   * on group-key sets; tolerant on extra assembled messages within a group
+   * (timing drift); environment NAMES are counted but excluded from the
+   * match (the worker decorates from the envelope's cache map while the bot
+   * live-fetches — name drift is an accepted divergence).
+   */
+  crossChannelHistory: boolean;
+}
+
+/** Stable key for a cross-channel group (thread id when present, else channel id). */
+function crossChannelGroupKey(group: CrossChannelHistoryGroupEntry): string {
+  return group.channelEnvironment.thread?.id ?? group.channelEnvironment.channel.id;
+}
+
+/**
+ * Cross-channel comparison. Presence-strict, group-key-strict,
+ * message-tolerant (same tolerance shape as diffHistory).
+ */
+function diffCrossChannel(
+  payload: CrossChannelHistoryGroupEntry[] | undefined,
+  assembled: CrossChannelHistoryGroupEntry[] | undefined
+): {
+  matched: boolean;
+  payloadGroups: number;
+  assembledGroups: number;
+  presenceMismatch: boolean;
+  groupKeyMismatches: number;
+  missingMessages: number;
+  contentMismatches: number;
+  envNameMismatches: number;
+} {
+  const result = {
+    matched: true,
+    payloadGroups: payload?.length ?? 0,
+    assembledGroups: assembled?.length ?? 0,
+    presenceMismatch: false,
+    groupKeyMismatches: 0,
+    missingMessages: 0,
+    contentMismatches: 0,
+    envNameMismatches: 0,
+  };
+
+  if (payload === undefined || assembled === undefined) {
+    // Both absent = the feature was off on both sides — agreement.
+    result.presenceMismatch = (payload === undefined) !== (assembled === undefined);
+    result.matched = !result.presenceMismatch;
+    return result;
+  }
+
+  const assembledByKey = new Map(assembled.map(g => [crossChannelGroupKey(g), g]));
+  for (const payloadGroup of payload) {
+    const assembledGroup = assembledByKey.get(crossChannelGroupKey(payloadGroup));
+    if (assembledGroup === undefined) {
+      result.groupKeyMismatches++;
+      continue;
+    }
+    if (
+      assembledGroup.channelEnvironment.channel.name !==
+      payloadGroup.channelEnvironment.channel.name
+    ) {
+      result.envNameMismatches++;
+    }
+    const groupDiff = diffGroupMessages(payloadGroup, assembledGroup);
+    result.missingMessages += groupDiff.missing;
+    result.contentMismatches += groupDiff.content;
+  }
+  // Worker-only groups are also key mismatches (symmetric strictness).
+  const payloadKeys = new Set(payload.map(crossChannelGroupKey));
+  for (const key of assembledByKey.keys()) {
+    if (!payloadKeys.has(key)) {
+      result.groupKeyMismatches++;
+    }
+  }
+
+  result.matched =
+    result.groupKeyMismatches === 0 &&
+    result.missingMessages === 0 &&
+    result.contentMismatches === 0;
+  return result;
+}
+
+/** Per-group message comparison: id-keyed, missing flagged, extra tolerated. */
+function diffGroupMessages(
+  payloadGroup: CrossChannelHistoryGroupEntry,
+  assembledGroup: CrossChannelHistoryGroupEntry
+): { missing: number; content: number } {
+  const assembledById = new Map(
+    assembledGroup.messages.filter(m => m.id !== undefined && m.id.length > 0).map(m => [m.id, m])
+  );
+  let missing = 0;
+  let content = 0;
+  for (const msg of payloadGroup.messages) {
+    if (msg.id === undefined || msg.id.length === 0) {
+      continue;
+    }
+    const assembledMsg = assembledById.get(msg.id);
+    if (assembledMsg === undefined) {
+      missing++;
+    } else if (assembledMsg.content !== msg.content) {
+      content++;
+    }
+  }
+  return { missing, content };
 }
 
 /** Compare two optional id-bearing lists as sets (payload-parity: undefined ≡ []). */
@@ -263,9 +373,14 @@ export async function shadowAssembleAndDiff(params: ShadowAssemblyParams): Promi
     const contentDiff = {
       compared: contentCompared,
       matched: contentCompared ? assembled.messageContent === params.payloadMessage : true,
-      payloadLength: params.payloadMessage?.length ?? 0,
+      // Left undefined (not 0) when there was no payload string to measure.
+      payloadLength: params.payloadMessage?.length,
       assembledLength: assembled.messageContent.length,
     };
+    const crossChannelDiff = diffCrossChannel(
+      jobContext.crossChannelHistory,
+      assembled.crossChannelHistory
+    );
 
     const matches: SurfaceMatches = {
       userInternalId: assembled.userInternalId === jobContext.userInternalId,
@@ -290,6 +405,7 @@ export async function shadowAssembleAndDiff(params: ShadowAssemblyParams): Promi
         assembled.referencedChannels,
         (c: ReferencedChannel) => c.channelId
       ),
+      crossChannelHistory: crossChannelDiff.matched,
     };
     const allMatched = Object.values(matches).every(Boolean);
 
@@ -307,6 +423,7 @@ export async function shadowAssembleAndDiff(params: ShadowAssemblyParams): Promi
       },
       referenceDiff,
       contentDiff,
+      crossChannelDiff,
     };
 
     if (allMatched) {

--- a/services/bot-client/src/services/CrossChannelHistoryFetcher.test.ts
+++ b/services/bot-client/src/services/CrossChannelHistoryFetcher.test.ts
@@ -9,7 +9,6 @@ import {
   clearKnownChannelEnvironmentsCache,
   fetchCrossChannelHistory,
   fetchCrossChannelIfEnabled,
-  mapCrossChannelToApiFormat,
 } from './CrossChannelHistoryFetcher.js';
 import type { CrossChannelHistoryGroup } from '@tzurot/common-types';
 import { MessageRole } from '@tzurot/common-types';
@@ -563,91 +562,6 @@ describe('fetchCrossChannelIfEnabled', () => {
       conversationHistoryService: createMockConversationHistoryService([]),
     });
     expect(result).toEqual([]);
-  });
-});
-
-describe('mapCrossChannelToApiFormat', () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-  });
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it('should map groups to API format with ISO date strings', () => {
-    const date = new Date('2026-02-26T10:00:00Z');
-    const groups = [
-      {
-        channelEnvironment: {
-          type: 'dm' as const,
-          channel: { id: 'ch-1', name: 'DM', type: 'dm' },
-        },
-        messages: [
-          {
-            id: 'msg-1',
-            role: MessageRole.User,
-            content: 'Hello',
-            tokenCount: 5,
-            createdAt: date,
-            personaId: 'p-1',
-            personaName: 'User',
-            channelId: 'ch-1',
-            guildId: null,
-            discordMessageId: ['d-1'],
-          } as CrossChannelHistoryGroup['messages'][0],
-        ],
-      },
-    ];
-
-    const result = mapCrossChannelToApiFormat(groups);
-
-    expect(result).toHaveLength(1);
-    expect(result[0].channelEnvironment.type).toBe('dm');
-    const msg = result[0].messages[0];
-    expect(msg.id).toBe('msg-1');
-    expect(msg.role).toBe(MessageRole.User);
-    expect(msg.content).toBe('Hello');
-    expect(msg.tokenCount).toBe(5);
-    expect(msg.createdAt).toBe('2026-02-26T10:00:00.000Z');
-    expect(msg.personaId).toBe('p-1');
-    expect(msg.personaName).toBe('User');
-  });
-
-  it('should pass through optional disambiguation fields', () => {
-    const date = new Date('2026-02-26T10:00:00Z');
-    const groups = [
-      {
-        channelEnvironment: {
-          type: 'guild' as const,
-          guild: { id: 'g-1', name: 'Server' },
-          channel: { id: 'ch-1', name: 'general', type: 'text' },
-        },
-        messages: [
-          {
-            id: 'msg-2',
-            role: MessageRole.Assistant,
-            content: 'Response',
-            tokenCount: 10,
-            createdAt: date,
-            personaId: 'p-1',
-            personaName: 'User',
-            discordUsername: 'alice#1234',
-            personalityId: 'pers-1',
-            personalityName: 'TestBot',
-            channelId: 'ch-1',
-            guildId: 'g-1',
-            discordMessageId: ['d-2'],
-          } as CrossChannelHistoryGroup['messages'][0],
-        ],
-      },
-    ];
-
-    const result = mapCrossChannelToApiFormat(groups);
-
-    const msg = result[0].messages[0];
-    expect(msg.discordUsername).toBe('alice#1234');
-    expect(msg.personalityId).toBe('pers-1');
-    expect(msg.personalityName).toBe('TestBot');
   });
 });
 

--- a/services/bot-client/src/services/CrossChannelHistoryFetcher.ts
+++ b/services/bot-client/src/services/CrossChannelHistoryFetcher.ts
@@ -9,19 +9,17 @@
 import { type Client, ChannelType } from 'discord.js';
 import {
   ConversationHistoryService,
+  buildFallbackEnvironment,
   createLogger,
-  type CrossChannelHistoryGroup,
-  type CrossChannelHistoryGroupEntry,
   type DiscordEnvironment,
+  type ResolvedCrossChannelGroup,
 } from '@tzurot/common-types';
 
 const logger = createLogger('CrossChannelHistoryFetcher');
 
-/** A single cross-channel group with resolved Discord environment */
-export interface ResolvedCrossChannelGroup {
-  channelEnvironment: DiscordEnvironment;
-  messages: CrossChannelHistoryGroup['messages'];
-}
+// The wire mapping (mapCrossChannelToApiFormat) and the group/environment
+// shapes live in common-types (crossChannelEnvironment.ts) — shared with
+// ai-worker's assembler. Import them from '@tzurot/common-types' directly.
 
 /** Options for fetching cross-channel history */
 interface FetchOptions {
@@ -154,21 +152,6 @@ function buildGuildEnvironment(
   }
 
   return env;
-}
-
-/** Build a minimal fallback environment when Discord channel fetch fails */
-function buildFallbackEnvironment(channelId: string, guildId: string | null): DiscordEnvironment {
-  if (guildId === null) {
-    return {
-      type: 'dm',
-      channel: { id: channelId, name: 'Direct Message', type: 'dm' },
-    };
-  }
-  return {
-    type: 'guild',
-    guild: { id: guildId, name: 'unknown-server' },
-    channel: { id: channelId, name: 'unknown-channel', type: 'text' },
-  };
 }
 
 /** Convert Discord ChannelType to human-readable name */
@@ -307,29 +290,4 @@ export async function fetchCrossChannelIfEnabled(opts: {
     maxAge: opts.maxAge,
     contextEpoch: opts.contextEpoch,
   });
-}
-
-/**
- * Map resolved cross-channel groups to the API/job payload format (Date→string serialization).
- * Note: `discordMessageId` is intentionally omitted — it's only used for current-channel
- * quote deduplication and is not relevant for cross-channel historical context.
- */
-export function mapCrossChannelToApiFormat(
-  groups: ResolvedCrossChannelGroup[]
-): CrossChannelHistoryGroupEntry[] {
-  return groups.map(group => ({
-    channelEnvironment: group.channelEnvironment,
-    messages: group.messages.map(msg => ({
-      id: msg.id,
-      role: msg.role,
-      content: msg.content,
-      tokenCount: msg.tokenCount,
-      createdAt: msg.createdAt.toISOString(),
-      personaId: msg.personaId,
-      personaName: msg.personaName,
-      discordUsername: msg.discordUsername,
-      personalityId: msg.personalityId,
-      personalityName: msg.personalityName,
-    })),
-  }));
 }

--- a/services/bot-client/src/services/MessageContextBuilder.ts
+++ b/services/bot-client/src/services/MessageContextBuilder.ts
@@ -16,6 +16,7 @@ import {
   ConversationSyncService,
   UserService,
   createLogger,
+  mapCrossChannelToApiFormat,
   MESSAGE_LIMITS,
   isTypingChannel,
 } from '@tzurot/common-types';
@@ -47,10 +48,7 @@ import {
   extractReferencesAndMentions,
   type ReferencesAndMentionsResult,
 } from './contextBuilder/ReferenceExtractor.js';
-import {
-  fetchCrossChannelIfEnabled,
-  mapCrossChannelToApiFormat,
-} from './CrossChannelHistoryFetcher.js';
+import { fetchCrossChannelIfEnabled } from './CrossChannelHistoryFetcher.js';
 
 const logger = createLogger('MessageContextBuilder');
 
@@ -500,7 +498,7 @@ export class MessageContextBuilder {
       rawReferencedMessages: refsAndMentions.rawReferencedMessages,
       rawMentionedChannels: refsAndMentions.rawMentionedChannels,
       rawMentionedRoles: refsAndMentions.rawMentionedRoles,
-      authorDisplayName: displayName,
+      rawAuthorDisplayName: displayName,
     });
 
     // Build complete context

--- a/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.test.ts
+++ b/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.test.ts
@@ -133,7 +133,7 @@ describe('buildRawAssemblyInputs', () => {
   it('carries the author display name for worker-side getOrCreateUser parity', () => {
     process.env.CONTEXT_RAW_ENVELOPE = 'true';
     const raw = buildRawAssemblyInputs(makeMessage(), 'plain', undefined, {
-      authorDisplayName: 'Vladlena',
+      rawAuthorDisplayName: 'Vladlena',
     });
     expect(raw?.rawAuthorDisplayName).toBe('Vladlena');
   });

--- a/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.ts
+++ b/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.ts
@@ -113,7 +113,7 @@ export function buildRawAssemblyInputs(
     rawMentionedChannels?: RawMentionedChannel[];
     rawMentionedRoles?: RawMentionedRole[];
     /** The author's effective display name from buildContext step 1. */
-    authorDisplayName?: string;
+    rawAuthorDisplayName?: string;
   }
 ): RawAssemblyInputs | undefined {
   if (!isRawEnvelopeEnabled()) {
@@ -121,7 +121,7 @@ export function buildRawAssemblyInputs(
   }
   return {
     rawMessageContent: content,
-    rawAuthorDisplayName: refs?.authorDisplayName,
+    rawAuthorDisplayName: refs?.rawAuthorDisplayName,
     rawReferencedMessages: refs?.rawReferencedMessages,
     rawMentionedChannels: refs?.rawMentionedChannels,
     rawMentionedRoles: refs?.rawMentionedRoles,


### PR DESCRIPTION
## Summary

Final slice of **a3-ii** — the assembler's last re-derivation surface, plus the accumulated fold-forwards from the #1161–#1163 review cycles. Two commits:

### Commit 1 — relocations + scrub pass (`refactor(common-types)`)

- **`crossChannelEnvironment.ts`**: `mapCrossChannelToApiFormat` (the wire serializer) + `buildFallbackEnvironment` move to common-types — cross-channel payload entries serialize through the SAME functions on both sides. The mapper's tests move with it; bot consumers import from the package directly (no re-export wrapper).
- **Scrub-pass fold-forwards** (#1156/#1161-d): envelope builder's `refs.authorDisplayName` → `rawAuthorDisplayName` (consistency with its `raw*` siblings), the relocated persona resolver's module-doc sentence fragment repaired, shouty test name lowercased.

### Commit 2 — worker cross-channel + fold-forward batch (`feat(ai-worker)`)

- **`assembleCrossChannel`**: own-DB fetch (same `dbLimit` budget; gated on the resolved `crossChannelHistoryEnabled` flag and skipped for weigh-ins, mirroring `fetchCrossChannelIfEnabled`), decorated from the envelope's `knownChannelEnvironments` (cache misses → shared fallback env — the worker can't ask Discord), serialized via the shared mapper.
- **Shadow surface 12 closes the 2.5a count-only caveat**: presence-strict (one-sided groups = gate/config divergence), group-key-strict (thread id ?? channel id, symmetric), message-tolerant (id-keyed, missing flagged, extra tolerated), **env-NAME drift counted but excluded from the match** — cache-vs-live decoration is the accepted divergence the council priced in ("lazily-loaded threads degrade to ID-only blocks").
- **Fold-forwards applied** (#1161 a–c, #1162, #1163):
  - `fromApiMessage` fills `channelId`/`guildId` from the job → the mapping is **`satisfies`-checked instead of cast**. The satisfies experiment surfaced two more optional-wire fields (`id`, `personaId`) — filled with the diff's own `''` normalization sentinels.
  - `enrichRawReferences` parallelizes across references (`Promise.all` preserves wire order)
  - `contentRewriter` passes the kernel's channel list through (kills the explicit-`undefined`-props shape)
  - `contentDiff.payloadLength` stays `undefined` when nothing was compared
  - epoch-telemetry reading note (`allMatched` ≠ "epochs compared")
  - test polish: typed configOverrides casts, channelId/guildId fill assertions

### State after this PR

The shadow diffs **12 surfaces** and the assembler re-derives every payload surface the envelope is designed to replace. Remaining before iii-b: Fork C vision-description relocation + the voice content story decision.

## Testing

- `crossChannelEnvironment.test.ts` (4 + 2 relocated mapper tests, common-types)
- `ContextAssembler` 15 (+3: disabled-gate, weigh-in skip, env-map decoration with fallback + shared-mapper ISO assertion), `shadowAssembly` 21 (+3: presence mismatch, env-name-tolerated + missing-message flagged, name-drift-only match)
- Full suites green: ai-worker 3194, bot-client 4956, common-types 2746; `pnpm quality` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)