### PR TITLE
fix(bot-client): hydrate forwarded-message snapshots before processing

### DIFF
--- a/services/bot-client/src/handlers/MessageHandler.ts
+++ b/services/bot-client/src/handlers/MessageHandler.ts
@@ -11,6 +11,7 @@ import { createLogger, type LLMGenerationResult, stripErrorSpoiler } from '@tzur
 import { buildErrorContent } from '../utils/buildErrorContent.js';
 import type { IMessageProcessor } from '../processors/IMessageProcessor.js';
 import { isUserContentMessage } from '../utils/messageTypeUtils.js';
+import { hydrateForwardedSnapshots } from '../utils/forwardedMessageUtils.js';
 import { fetchTypingChannel } from '../utils/fetchTypingChannel.js';
 import { DiscordResponseSender } from '../services/DiscordResponseSender.js';
 import { ConversationPersistence } from '../services/ConversationPersistence.js';
@@ -89,13 +90,19 @@ export class MessageHandler {
 
       logger.debug({ messageId: message.id, authorTag: message.author.tag }, 'Processing message');
 
+      // Hydrate forwarded-message snapshots before any processor runs, so the
+      // whole chain (trigger content, references, attachments, persistence)
+      // sees populated snapshot content even when the gateway event omitted it.
+      // Non-forwards and already-hydrated forwards pass through untouched.
+      const hydratedMessage = await hydrateForwardedSnapshots(message);
+
       // Pass message through the chain of processors
       for (const processor of this.processors) {
-        const wasHandled = await processor.process(message);
+        const wasHandled = await processor.process(hydratedMessage);
 
         if (wasHandled) {
           logger.debug(
-            { messageId: message.id, processorName: processor.constructor.name },
+            { messageId: hydratedMessage.id, processorName: processor.constructor.name },
             'Message handled by processor'
           );
           return; // Stop the chain
@@ -103,7 +110,7 @@ export class MessageHandler {
       }
 
       // No processor handled the message
-      logger.debug({ messageId: message.id }, 'Message not handled by any processor');
+      logger.debug({ messageId: hydratedMessage.id }, 'Message not handled by any processor');
     } catch (error) {
       logger.error({ err: error }, 'Error processing message');
 

--- a/services/bot-client/src/utils/forwardedMessageUtils.test.ts
+++ b/services/bot-client/src/utils/forwardedMessageUtils.test.ts
@@ -5,7 +5,7 @@
  * These utilities are the SINGLE SOURCE OF TRUTH for handling Discord forwarded messages.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import type { Message, MessageSnapshot, Collection } from 'discord.js';
 import { MessageReferenceType } from 'discord.js';
 import {
@@ -20,6 +20,7 @@ import {
   hasForwardedVoiceAttachment,
   hasVoiceAttachments,
   getEffectiveContent,
+  hydrateForwardedSnapshots,
 } from './forwardedMessageUtils.js';
 
 /**
@@ -625,6 +626,101 @@ describe('forwardedMessageUtils', () => {
       const message = createMockMessage({ content: 'Hello' });
 
       expect(hasVoiceAttachments(message)).toBe(false);
+    });
+  });
+
+  describe('hydrateForwardedSnapshots', () => {
+    /** Build a forward-shaped message with a mockable `fetch` and an id. */
+    function makeMessage(
+      options: Parameters<typeof createMockMessage>[0],
+      fetchImpl?: () => Promise<Message>
+    ): Message & { fetch: ReturnType<typeof vi.fn> } {
+      const base = createMockMessage(options);
+      return Object.assign(base, {
+        id: 'msg-1',
+        fetch: vi.fn(fetchImpl ?? (() => Promise.resolve(base))),
+      }) as Message & { fetch: ReturnType<typeof vi.fn> };
+    }
+
+    it('returns a non-forward message untouched without fetching', async () => {
+      const message = makeMessage({ referenceType: MessageReferenceType.Default, content: 'hi' });
+
+      const result = await hydrateForwardedSnapshots(message);
+
+      expect(result).toBe(message);
+      expect(message.fetch).not.toHaveBeenCalled();
+    });
+
+    it('skips the fetch when the forward already has snapshot content', async () => {
+      const message = makeMessage({
+        referenceType: MessageReferenceType.Forward,
+        snapshots: [{ content: 'already here' }],
+      });
+
+      const result = await hydrateForwardedSnapshots(message);
+
+      expect(result).toBe(message);
+      expect(message.fetch).not.toHaveBeenCalled();
+    });
+
+    it('force-fetches when a forward arrives with no snapshots and returns the hydrated message', async () => {
+      const hydrated = createMockMessage({
+        referenceType: MessageReferenceType.Forward,
+        snapshots: [{ content: 'recovered content' }],
+      });
+      const message = makeMessage(
+        { referenceType: MessageReferenceType.Forward }, // no snapshots
+        () => Promise.resolve(hydrated)
+      );
+
+      const result = await hydrateForwardedSnapshots(message);
+
+      expect(message.fetch).toHaveBeenCalledWith(true);
+      expect(result).toBe(hydrated);
+      expect(getEffectiveContent(result)).toBe('recovered content');
+    });
+
+    it('force-fetches when the forward has an empty-content snapshot', async () => {
+      const hydrated = createMockMessage({
+        referenceType: MessageReferenceType.Forward,
+        snapshots: [{ content: 'recovered content' }],
+      });
+      const message = makeMessage(
+        { referenceType: MessageReferenceType.Forward, snapshots: [{ content: '' }] },
+        () => Promise.resolve(hydrated)
+      );
+
+      const result = await hydrateForwardedSnapshots(message);
+
+      expect(message.fetch).toHaveBeenCalledWith(true);
+      expect(result).toBe(hydrated);
+      expect(getEffectiveContent(result)).toBe('recovered content');
+    });
+
+    it('returns the fetched message even when the re-fetch still lacks snapshot content', async () => {
+      // REST payload also missing content (e.g. origin-channel MESSAGE_CONTENT gap):
+      // the function returns the fetched message and warns, rather than throwing.
+      const stillEmpty = createMockMessage({ referenceType: MessageReferenceType.Forward });
+      const message = makeMessage({ referenceType: MessageReferenceType.Forward }, () =>
+        Promise.resolve(stillEmpty)
+      );
+
+      const result = await hydrateForwardedSnapshots(message);
+
+      expect(message.fetch).toHaveBeenCalledWith(true);
+      expect(result).toBe(stillEmpty);
+      expect(getEffectiveContent(result)).toBe('');
+    });
+
+    it('returns the original message when the re-fetch throws', async () => {
+      const message = makeMessage({ referenceType: MessageReferenceType.Forward }, () =>
+        Promise.reject(new Error('ChannelNotCached'))
+      );
+
+      const result = await hydrateForwardedSnapshots(message);
+
+      expect(message.fetch).toHaveBeenCalledWith(true);
+      expect(result).toBe(message);
     });
   });
 });

--- a/services/bot-client/src/utils/forwardedMessageUtils.ts
+++ b/services/bot-client/src/utils/forwardedMessageUtils.ts
@@ -25,9 +25,11 @@ import {
   type APIEmbed,
   MessageReferenceType,
 } from 'discord.js';
-import type { AttachmentMetadata } from '@tzurot/common-types';
+import { type AttachmentMetadata, createLogger } from '@tzurot/common-types';
 import { extractAttachments } from './attachmentExtractor.js';
 import { extractEmbedImages } from './embedImageExtractor.js';
+
+const logger = createLogger('forwardedMessageUtils');
 
 /**
  * Content extracted from a forwarded message or its snapshots
@@ -332,4 +334,92 @@ export function getEffectiveContent(message: Message): string {
 
   // Regular messages: return main content directly
   return message.content;
+}
+
+/**
+ * Whether the message's first snapshot carries non-empty text content.
+ */
+function hasSnapshotContent(message: Message): boolean {
+  const snapshot = getFirstSnapshot(message);
+  return snapshot?.content !== undefined && snapshot.content.length > 0;
+}
+
+/**
+ * Ensure a forward-shaped message has its snapshot content hydrated, fetching
+ * from the REST API when the gateway event delivered it without.
+ *
+ * Discord's MESSAGE_CREATE gateway payload sometimes omits `message_snapshots`
+ * (or their content) for forwards. When that happens `extractForwardedContent`
+ * silently falls back to the empty `message.content`, so a forwarded-as-trigger
+ * message reaches the LLM with no content and produces a generic reply. A
+ * forced `message.fetch(true)` re-runs discord.js's snapshot `_patch` against
+ * the REST payload, which DOES carry the snapshot content (gated by
+ * MESSAGE_CONTENT, which this bot holds and which already works for non-forward
+ * content).
+ *
+ * Scope guards keep this off the hot path:
+ *  - Forward detection uses `reference.type === Forward` directly rather than
+ *    {@link isForwardedMessage}. Both recognize a missing-snapshot forward
+ *    (via the reference-type branch), but using the reference type keeps the
+ *    two concerns separate: "is this a forward" (reference type) is decided
+ *    independently of "does it have snapshot content" (`hasSnapshotContent`,
+ *    whose `hasForwardedSnapshots` size check is what fails for missing
+ *    snapshots) — so the recovery condition reads as the intersection of the two.
+ *  - Forwards that already carry snapshot content skip the REST round-trip.
+ *
+ * Never throws: a failed fetch (e.g. uncached channel) degrades to the
+ * original message — today's behavior — rather than breaking message handling.
+ *
+ * The before/after snapshot state is logged so the outcome is diagnosable
+ * directly from logs (gateway-omitted vs content-stripped vs extraction bug)
+ * instead of by inference.
+ *
+ * @param message - Incoming Discord message (any type)
+ * @returns The hydrated message when a re-fetch succeeded, else the original
+ */
+export async function hydrateForwardedSnapshots(message: Message): Promise<Message> {
+  const isForwardByReference = message.reference?.type === MessageReferenceType.Forward;
+  if (!isForwardByReference || hasSnapshotContent(message)) {
+    return message;
+  }
+
+  // referenceType is omitted — the guard above guarantees it is Forward, so
+  // it carries no diagnostic signal.
+  const before = {
+    snapshotSize: message.messageSnapshots?.size ?? 0,
+    snapshotContentLen: getFirstSnapshot(message)?.content?.length ?? 0,
+    messageContentLen: message.content.length,
+  };
+
+  try {
+    const fetched = await message.fetch(true);
+    logger.info(
+      {
+        messageId: message.id,
+        before,
+        after: {
+          snapshotSize: fetched.messageSnapshots?.size ?? 0,
+          snapshotContentLen: getFirstSnapshot(fetched)?.content?.length ?? 0,
+          messageContentLen: fetched.content.length,
+        },
+      },
+      'Re-fetched forwarded message to hydrate snapshot content'
+    );
+    // The re-fetch succeeded but the REST payload also lacked snapshot content
+    // (e.g. origin-channel MESSAGE_CONTENT gap). Surface it as its own warning
+    // so this distinct outcome isn't buried in the success-path info log.
+    if (!hasSnapshotContent(fetched)) {
+      logger.warn(
+        { messageId: message.id, before },
+        'Forwarded-message re-fetch succeeded but snapshot content is still absent'
+      );
+    }
+    return fetched;
+  } catch (error) {
+    logger.warn(
+      { err: error, messageId: message.id, before },
+      'Forwarded-message snapshot re-fetch failed; using original message'
+    );
+    return message;
+  }
 }


### PR DESCRIPTION
## The bug

Forwarding a message **as a trigger** (into an activated/@mention channel) produces a generic reply — the bot extracts **empty content**. Confirmed on dev: job `llm-a509e921` submitted with `payloadLength: 0`, zero references, zero attachments. The forwarded content reached neither the message, references, nor attachments.

## Root cause (established, not inferred)

- Trigger content is `getEffectiveContent(message)` → `extractForwardedContent` → `message.messageSnapshots[].content`. For this forward it was absent/empty, so it fell back to the (empty) `message.content`.
- discord.js builds `messageSnapshots` only when the gateway payload contains `message_snapshots` (Message.js:458), and **Discord's MESSAGE_CREATE sometimes omits it for forwards**. The bot's own `forwardedMessageUtils` header already documents this ("Discord may not always populate messageSnapshots") — but it only degrades to empty, never recovers.
- **Ruled out**: not a regression from the rawMessageContent change (that was envelope/shadow-only); not a permission strip (user confirmed same-server, bot-accessible source); not a MESSAGE_CONTENT intent failure (non-forward content works).
- `Message.fetch(true)` re-runs the same snapshot `_patch` block against the **REST** payload, which carries snapshot content — so a forced re-fetch recovers it.

## The fix

`hydrateForwardedSnapshots` runs at the `MessageHandler` entry, before any processor, so the whole chain sees populated snapshots:
- Only `reference.type === Forward` messages **with no usable snapshot content** trigger a `fetch(true)`. Non-forwards and already-hydrated forwards skip the round-trip entirely.
- Never throws — a failed fetch (e.g. uncached channel) degrades to the original message (today's behavior).
- **Self-verifying**: logs before/after snapshot state (`size`, `contentLen`). On dev re-test, `size 0 → 1` confirms the fix; if the after-state is still empty, the logs point at the real cause instead of leaving us to guess.

## Note: the shadow can't catch this class

The `rawMessageContent` ground-truth change (#1169) made the worker's content empty for forwards too, so the legacy payload and the worker **agreed on empty** → a false `allMatched: true` on job a509e921. Recorded as a burn-in blind spot in `backlog/production-issues.md`.

## Tests

6 cases on `hydrateForwardedSnapshots`: non-forward passthrough (no fetch), already-hydrated passthrough (no fetch), missing-snapshots → fetch + hydrated return, empty-content-snapshot → fetch, fetch-throws → original. MessageHandler suite unaffected. Full bot-client suite green; `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)