### PR TITLE
docs(rules): code-reading is not runtime verification

### DIFF
--- a/.claude/rules/00-critical.md
+++ b/.claude/rules/00-critical.md
@@ -271,6 +271,8 @@ When making claims about causation, origin, intent, or history, distinguish betw
 - Root-cause statements issued before verification has exhausted its scope
 - Dismissals like "just user error" or "just a typo" without proof
 
+**Code-reading is not runtime verification.** Reading a code path tells you what it _could_ do given an input; it does NOT tell you which input actually occurred, or which branch actually ran, at runtime. A claim that _a specific execution did X_ — "the root cause is", "it returns empty here", "this branch runs" — requires a runtime observation (a log line, a test result, a repro) before it is stated as fact. "I read the code and it would do X" is a hypothesis; label it one ("code-reading suggests X; not yet runtime-confirmed") until a tool confirms it. Do NOT build or ship a fix on a code-read mechanism that hasn't been runtime-confirmed — ship the one diagnostic that produces the observation first. The pull to give a satisfying "found it!" is the tell: confident fact-framing on an unverified mechanism is exactly the failure this guards against.
+
 **Why this matters:** Users rely on assertions to decide what to do next. Speculation-as-fact produces wasted work when the real cause turns out to be different, and erodes trust when the pattern repeats. Prefer "the evidence shows X; the remaining candidates for why Y are A / B / C — here's how to narrow it" over "it was Z."
 
 ### Mandatory Global Discovery ("Grep Rule")


### PR DESCRIPTION
## Why

`00-critical.md`'s "Don't Present Speculation as Fact" rule is loaded every session, yet a debugging session produced **three** wrong root-cause claims, each stated as fact and one of them shipped as a fix (PR #1170):

1. "snapshots are missing" → built/shipped #1170 on it; snapshots were present
2. "REST loses snapshots" → written into the backlog as fact; Discord docs say the opposite
3. "the sync self-heals" → confident yes from code-reading; user had already observed it doesn't

Every one was a plausible code path that runtime observation later contradicted. The rule being loaded wasn't enough because it's general ("distinguish observed from inferred"); the *specific* failure is sharper and more catchable.

## The addition

One paragraph naming the exact failure mode:

> **Code-reading is not runtime verification.** Reading a code path tells you what it *could* do given an input; it does NOT tell you which input actually occurred, or which branch ran, at runtime. A claim that *a specific execution did X* requires a runtime observation (log/test/repro) before it's stated as fact… Do NOT build or ship a fix on a code-read mechanism that hasn't been runtime-confirmed — ship the diagnostic first.

This converts a general "be careful" into a concrete, checkable discipline: runtime claims need a runtime observation, and fixes don't get built on unconfirmed code-reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)