### PR TITLE
fix(api-gateway): referenced-attachment jobs under thin payload

### DIFF
--- a/services/api-gateway/src/utils/jobChainOrchestrator.test.ts
+++ b/services/api-gateway/src/utils/jobChainOrchestrator.test.ts
@@ -570,6 +570,96 @@ describe('jobChainOrchestrator (FlowProducer)', () => {
       expect(flowCall.data.dependencies).toHaveLength(1);
     });
 
+    it('should create the referenced-image job from the raw envelope when referencedMessages is dropped (thin payload)', async () => {
+      // Thin (kind:'envelope') payload: the bot omits context.referencedMessages
+      // and ships the same snapshot on rawAssemblyInputs.rawReferencedMessages.
+      // The gateway must still spawn the referenced image's vision job — without
+      // this, a reply/link to an image goes undescribed under thin (regression
+      // that shipped because this case wasn't covered).
+      const context: JobContext = {
+        kind: 'envelope',
+        userId: 'user-123',
+        channelId: 'channel-123',
+        rawAssemblyInputs: {
+          rawMessageContent: 'What is in this image?',
+          rawReferencedMessages: [
+            createReferencedMessage(1, {
+              content: 'Check out this image!',
+              attachments: [
+                {
+                  url: 'https://example.com/ref-image.png',
+                  name: 'ref-image.png',
+                  contentType: CONTENT_TYPES.IMAGE_PNG,
+                  size: 2048,
+                },
+              ],
+            }),
+          ],
+        },
+      } as JobContext;
+
+      await createJobChain({
+        requestId: 'req-ref-img-thin',
+        personality: mockPersonality,
+        message: 'What is in this image?',
+        context,
+        responseDestination: mockResponseDestination,
+      });
+
+      expect(flowProducer.add).toHaveBeenCalledTimes(1);
+      const flowCall = (flowProducer.add as any).mock.calls[0][0];
+      expect(flowCall.children).toHaveLength(1);
+      expect(flowCall.children[0].name).toBe(JobType.ImageDescription);
+      expect(flowCall.children[0].data.sourceReferenceNumber).toBe(1);
+      expect(flowCall.children[0].data.attachments).toHaveLength(1);
+      expect(flowCall.data.dependencies).toHaveLength(1);
+    });
+
+    it('should create the referenced-audio job from the raw envelope under thin payload', async () => {
+      // Same fallback as the image case — the ?? in createJobChain is
+      // attachment-type-agnostic, so referenced voice messages must also
+      // transcribe under thin (kind:'envelope', referencedMessages dropped).
+      const context: JobContext = {
+        kind: 'envelope',
+        userId: 'user-123',
+        channelId: 'channel-123',
+        rawAssemblyInputs: {
+          rawMessageContent: 'What did they say?',
+          rawReferencedMessages: [
+            createReferencedMessage(1, {
+              content: 'Listen to this!',
+              attachments: [
+                {
+                  url: 'https://example.com/ref-voice.ogg',
+                  name: 'ref-voice.ogg',
+                  contentType: CONTENT_TYPES.AUDIO_OGG,
+                  size: 1024,
+                  isVoiceMessage: true,
+                  duration: 5,
+                },
+              ],
+            }),
+          ],
+        },
+      } as JobContext;
+
+      await createJobChain({
+        requestId: 'req-ref-audio-thin',
+        personality: mockPersonality,
+        message: 'What did they say?',
+        context,
+        responseDestination: mockResponseDestination,
+      });
+
+      expect(flowProducer.add).toHaveBeenCalledTimes(1);
+      const flowCall = (flowProducer.add as any).mock.calls[0][0];
+      expect(flowCall.children).toHaveLength(1);
+      expect(flowCall.children[0].name).toBe(JobType.AudioTranscription);
+      expect(flowCall.children[0].data.sourceReferenceNumber).toBe(1);
+      expect(flowCall.children[0].data.attachment.isVoiceMessage).toBe(true);
+      expect(flowCall.data.dependencies).toHaveLength(1);
+    });
+
     it('should create audio preprocessing job for referenced message voice messages', async () => {
       const context: JobContext = {
         userId: 'user-123',

--- a/services/api-gateway/src/utils/jobChainOrchestrator.ts
+++ b/services/api-gateway/src/utils/jobChainOrchestrator.ts
@@ -337,9 +337,16 @@ export async function createJobChain(params: {
     );
   }
 
-  // Process attachments from referenced messages
-  if (context.referencedMessages && context.referencedMessages.length > 0) {
-    for (const refMsg of context.referencedMessages) {
+  // Process attachments from referenced messages. In thin (kind:'envelope')
+  // mode the bot drops context.referencedMessages, so fall back to the raw
+  // envelope's snapshots: they carry the same attachments + referenceNumber
+  // (buildRawReference), and the worker preserves raw reference numbers, so the
+  // dep jobs' sourceReferenceNumber keys still line up with the assembled refs.
+  // Without this fallback, a reply/link to an image goes undescribed under thin.
+  const referencedMessages =
+    context.referencedMessages ?? context.rawAssemblyInputs?.rawReferencedMessages ?? [];
+  if (referencedMessages.length > 0) {
+    for (const refMsg of referencedMessages) {
       if (!refMsg.attachments || refMsg.attachments.length === 0) {
         continue;
       }
@@ -356,7 +363,7 @@ export async function createJobChain(params: {
     logger.info(
       {
         requestId,
-        referencedMessageCount: context.referencedMessages.length,
+        referencedMessageCount: referencedMessages.length,
         totalChildren: children.length,
       },
       'Built preprocessing child jobs including referenced messages'


### PR DESCRIPTION
## What

iii-b-2 thin payload regression, **runtime-confirmed on dev**: a reply or link to a message containing an **image/voice attachment** went undescribed under `CONTEXT_THIN_PAYLOAD=true`.

## Root cause (a cross-service seam, not a unit-level bug)

Thin drops `context.referencedMessages`, but the gateway's `createJobChain` read *only* that field to spawn the vision/transcription dependency jobs for attachments inside replied-to/linked messages. Each service's unit tests passed — the bot correctly omits the field, the worker correctly re-derives the ref *text* — but the **gateway↔worker job-chain seam** broke for the new payload shape.

Dev evidence:
```
DependencyStep  referencedAttachmentCount=0  extendedContextAttachmentCount=1
ContextStep     kind="envelope"  referencedCount=1   ← ref text re-derived, but no vision job
```

## Fix

`createJobChain` falls back to `context.rawAssemblyInputs.rawReferencedMessages`:
```ts
const referencedMessages =
  context.referencedMessages ?? context.rawAssemblyInputs?.rawReferencedMessages ?? [];
```
The raw snapshot carries the same `attachments` + `referenceNumber` (`buildRawReference`, MessageFormatter.ts:124), and the worker preserves raw reference numbers, so the dep jobs' `sourceReferenceNumber` keys still line up with the assembled refs. The `??` leaves legacy/fat deploys untouched.

## Test

The existing `jobChainOrchestrator.test.ts` covered referenced attachments **only for the fat shape** — that's precisely why this slipped through. Added the thin (`kind:'envelope'`) case asserting the referenced-image job spawns from the envelope. Without the fix, the new test fails (`children` empty).

## Follow-up (not this PR)
The deeper gap is the absence of a **job-payload contract test** at the bot→gateway→worker seam — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)