### PR TITLE
fix(common-types): stop redacting numeric token counts in logs

### DIFF
--- a/packages/common-types/src/utils/logSanitizer.test.ts
+++ b/packages/common-types/src/utils/logSanitizer.test.ts
@@ -109,6 +109,25 @@ describe('logSanitizer', () => {
       expect(result.normalField).toBe('visible');
     });
 
+    it('should NOT redact numeric token COUNT fields (metrics, not secrets)', () => {
+      // Auth tokens are string secrets; token COUNTS are numbers. Blanking the
+      // counts was over-redaction that blinded context-budget/perf debugging.
+      const obj = {
+        tokensUsed: 4096,
+        contextWindowTokens: 32768,
+        historyTokensUsed: 1200,
+        maxTokens: 2000,
+        // A string 'token' value is still a possible secret → stays redacted.
+        accessToken: 'secret-abc',
+      };
+      const result = sanitizeObject(obj) as Record<string, unknown>;
+      expect(result.tokensUsed).toBe(4096);
+      expect(result.contextWindowTokens).toBe(32768);
+      expect(result.historyTokensUsed).toBe(1200);
+      expect(result.maxTokens).toBe(2000);
+      expect(result.accessToken).toBe('[REDACTED]');
+    });
+
     it('should NOT redact apiKeySource metadata field — it carries no key value', () => {
       // Regression test for an over-redaction bug discovered 2026-04-29:
       // the broad `lowerKey.includes('apikey')` check matched `apiKeySource`

--- a/packages/common-types/src/utils/logSanitizer.ts
+++ b/packages/common-types/src/utils/logSanitizer.ts
@@ -133,10 +133,17 @@ export function sanitizeObject(obj: unknown, depth = 0): unknown {
       // a substring but reveal nothing sensitive. Add explicit names here when
       // adding new metadata fields with `apikey`-prefixed names.
       const isApiKeyMetadata = matchesApiKeyPattern && API_KEY_METADATA_FIELDS.has(lowerKey);
+      // 'token'-named fields: redact only STRING values. Auth/access/bearer
+      // tokens are string SECRETS; token COUNTS (tokensUsed, contextWindowTokens,
+      // historyTokensUsed, maxTokens, …) are numeric METRICS that carry no
+      // sensitive material — blanking them was over-redaction that blinded us to
+      // context-budget/perf debugging. A numeric value can't be a secret token,
+      // so this stays fail-safe while un-redacting the counts.
+      const isSensitiveTokenField = lowerKey.includes('token') && typeof value === 'string';
       const isSensitiveKey =
         (matchesApiKeyPattern && !isApiKeyMetadata) ||
         lowerKey.includes('secret') ||
-        lowerKey.includes('token') ||
+        isSensitiveTokenField ||
         lowerKey.includes('password') ||
         lowerKey.includes('authorization');
       if (isSensitiveKey) {


### PR DESCRIPTION
## What

`logSanitizer.sanitizeObject` redacted any field whose name contained `"token"` (`logSanitizer.ts:139` — `lowerKey.includes('token')`). That swept up **token counts** — `tokensUsed`, `contextWindowTokens`, `historyTokensUsed`, `memoryTokensUsed`, `maxTokens`, … — alongside actual auth tokens, blanking pure metrics that carry no sensitive data.

This actively blinded debugging: it's why the small-context-model overflow investigation couldn't read the budget numbers from prod logs (`tokensUsed="[REDACTED]"`, `contextWindowTokens="[REDACTED]"`).

## Fix

Auth/access/bearer tokens are **string secrets**; token counts are **numbers**. So redact a `token`-named field only when its value is a **string** — fail-safe (a number can't be a secret token) while letting the counts through. Scoped to the `token` check only; `secret`/`password`/`apikey`/`authorization` are unambiguous and unchanged.

## Test

Added a `sanitizeObject` case asserting numeric `tokensUsed`/`contextWindowTokens`/`historyTokensUsed`/`maxTokens` pass through while a **string** `accessToken` still redacts. The existing "string `token` value redacts" test still passes (no leak risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)