### PR TITLE
fix(ai-worker): clamp context budget to the model's real limit

### DIFF
--- a/packages/common-types/src/constants/ai.ts
+++ b/packages/common-types/src/constants/ai.ts
@@ -79,16 +79,11 @@ export const AI_DEFAULTS = {
   /**
    * Default context window token budget (128k tokens)
    *
-   * GUIDELINE: Set contextWindowTokens to ~50% of model's advertised max for safety.
-   * - 50% = Very conservative, always safe (recommended default)
-   * - 75% = Generally safe for well-tested, non-reasoning models
-   * - 90% = Aggressive, only if tested at that load
-   *
-   * Why not use 100%?
-   * - Token counting (tiktoken) may differ from provider's actual counting
-   * - Many models degrade in quality near their context limit ("lost in the middle")
-   * - Reasoning models (o1, Claude thinking) use tokens for internal reasoning
-   * - Leaves headroom for output tokens on shared-limit models
+   * The effective budget is automatically capped against the model's real
+   * context length at both config-save time (gateway validation) and
+   * generation time (worker runtime clamp) — see utils/contextWindowCap.ts
+   * for the formula and the rationale (output headroom + tokenizer mismatch).
+   * Operators don't need to derate this value manually.
    */
   CONTEXT_WINDOW_TOKENS: 131072,
   /**

--- a/packages/common-types/src/index.ts
+++ b/packages/common-types/src/index.ts
@@ -44,6 +44,7 @@ export * from './utils/errors.js';
 export * from './utils/timeout.js';
 export * from './utils/deterministicUuid.js';
 export * from './utils/tokenCounter.js';
+export * from './utils/contextWindowCap.js';
 export * from './utils/textChunker.js';
 export * from './utils/autocompleteFormat.js';
 export { Duration, DurationParseError } from './utils/Duration.js';

--- a/packages/common-types/src/utils/contextWindowCap.test.ts
+++ b/packages/common-types/src/utils/contextWindowCap.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeContextCap,
+  clampContextWindow,
+  SMALL_CONTEXT_THRESHOLD,
+} from './contextWindowCap.js';
+
+describe('computeContextCap', () => {
+  it('caps small models at 75% of context length', () => {
+    expect(computeContextCap(32768)).toBe(24576);
+    expect(computeContextCap(8192)).toBe(6144);
+  });
+
+  it('caps large models at 50% of context length', () => {
+    expect(computeContextCap(131072)).toBe(65536);
+    expect(computeContextCap(200000)).toBe(100000);
+  });
+
+  it('treats the threshold itself as small (75%)', () => {
+    expect(computeContextCap(SMALL_CONTEXT_THRESHOLD)).toBe(49152);
+  });
+
+  it('treats one token above the threshold as large (50%)', () => {
+    expect(computeContextCap(SMALL_CONTEXT_THRESHOLD + 1)).toBe(
+      Math.floor((SMALL_CONTEXT_THRESHOLD + 1) / 2)
+    );
+  });
+
+  it('floors fractional results', () => {
+    // 1001 * 0.75 = 750.75 → 750
+    expect(computeContextCap(1001)).toBe(750);
+  });
+
+  it('never returns the full context length', () => {
+    for (const len of [1000, 32768, 65536, 65537, 131072, 1048576]) {
+      expect(computeContextCap(len)).toBeLessThan(len);
+    }
+  });
+});
+
+describe('clampContextWindow', () => {
+  it('clamps a configured value above the cap', () => {
+    // The prod incident shape: 32768 configured on a 32k model
+    expect(clampContextWindow(32768, 32768)).toBe(24576);
+  });
+
+  it('passes through a configured value below the cap', () => {
+    expect(clampContextWindow(20000, 32768)).toBe(20000);
+    expect(clampContextWindow(65536, 200000)).toBe(65536);
+  });
+
+  it('uses the configured value as-is when the model context length is unknown', () => {
+    expect(clampContextWindow(131072, null)).toBe(131072);
+    expect(clampContextWindow(32768, null)).toBe(32768);
+  });
+
+  it('clamps the 128k default against a small model', () => {
+    // A preset created without contextWindowTokens gets the DB default 131072;
+    // the clamp must protect a small model from it.
+    expect(clampContextWindow(131072, 32768)).toBe(24576);
+  });
+});

--- a/packages/common-types/src/utils/contextWindowCap.ts
+++ b/packages/common-types/src/utils/contextWindowCap.ts
@@ -1,0 +1,67 @@
+/**
+ * Context Window Cap
+ *
+ * Shared formula for the maximum input-token budget allowed against a model's
+ * real context length. Used in two places that must agree:
+ * - api-gateway config validation (rejects oversized contextWindowTokens at save time)
+ * - ai-worker generation budgeting (clamps already-saved values at runtime)
+ *
+ * Why headroom exists at all: the input budget must leave room for (a) the
+ * model's generated output, which shares the context window, and (b) tokenizer
+ * mismatch — budgets are counted with tiktoken, but providers count with their
+ * own tokenizers, which can run 15-25% higher for the same text (Mistral-family
+ * models especially). An input budget equal to the full context length is
+ * guaranteed to overflow once either factor applies.
+ *
+ * Why the fraction is graduated: on large windows, 50% headroom costs little
+ * relative to the budget and is comfortably safe. On small windows every token
+ * matters, so the headroom shrinks to 25% — enough to absorb the known
+ * tokenizer-mismatch class plus a modest response, without halving an already
+ * small budget.
+ */
+
+/**
+ * Models with context length at or below this threshold get the smaller (25%)
+ * headroom; larger models reserve 50%.
+ *
+ * Note: this is a step function, not a gradient — a model at exactly this
+ * value gets 75% of its context as input budget; a model one token above
+ * gets 50% (49152 vs ~32768). Moving the threshold moves that cliff.
+ */
+export const SMALL_CONTEXT_THRESHOLD = 65536;
+
+/** Input-budget fraction for small-context models (≤ SMALL_CONTEXT_THRESHOLD). */
+const SMALL_CONTEXT_CAP_FRACTION = 0.75;
+
+/** Input-budget fraction for large-context models. */
+const LARGE_CONTEXT_CAP_FRACTION = 0.5;
+
+/**
+ * Compute the maximum allowed input-token budget for a model.
+ *
+ * @param contextLength - The model's real context length in tokens
+ * @returns The capped input budget (always strictly less than contextLength)
+ */
+export function computeContextCap(contextLength: number): number {
+  const fraction =
+    contextLength <= SMALL_CONTEXT_THRESHOLD
+      ? SMALL_CONTEXT_CAP_FRACTION
+      : LARGE_CONTEXT_CAP_FRACTION;
+  return Math.floor(contextLength * fraction);
+}
+
+/**
+ * Clamp a configured context-window setting against the model's real limit.
+ *
+ * @param configured - The user-configured contextWindowTokens
+ * @param modelContextLength - The model's real context length, or null when
+ *   unknown (non-OpenRouter providers, model-cache miss). Unknown degrades
+ *   gracefully: the configured value is used as-is.
+ * @returns The effective input budget to use for generation
+ */
+export function clampContextWindow(configured: number, modelContextLength: number | null): number {
+  if (modelContextLength === null) {
+    return configured;
+  }
+  return Math.min(configured, computeContextCap(modelContextLength));
+}

--- a/services/ai-worker/src/redis.ts
+++ b/services/ai-worker/src/redis.ts
@@ -15,7 +15,11 @@ import { VisionDescriptionCache } from './services/VisionDescriptionCache.js';
 import { RedisService } from './services/RedisService.js';
 import { RateLimitCache } from './services/RateLimitCache.js';
 import { CreditExhaustionCache } from './services/CreditExhaustionCache.js';
-import { modelSupportsVision, modelSupportsReasoning } from './services/ModelCapabilityChecker.js';
+import {
+  modelSupportsVision,
+  modelSupportsReasoning,
+  getModelContextLength,
+} from './services/ModelCapabilityChecker.js';
 
 const { redis, voiceTranscriptCache } = initCoreRedisServices('WorkerRedis');
 
@@ -60,4 +64,15 @@ export async function checkModelVisionSupport(modelId: string): Promise<boolean>
  */
 export async function checkModelReasoningSupport(modelId: string): Promise<boolean> {
   return modelSupportsReasoning(modelId, redis);
+}
+
+/**
+ * Get a model's real context length using OpenRouter's cached model data.
+ * This is a singleton wrapper that uses the shared ioredis client.
+ *
+ * @param modelId - The model ID to look up
+ * @returns The context length in tokens, or null when unknown (cache miss, non-OpenRouter model)
+ */
+export async function checkModelContextLength(modelId: string): Promise<number | null> {
+  return getModelContextLength(modelId, redis);
 }

--- a/services/ai-worker/src/services/ContentBudgetManager.test.ts
+++ b/services/ai-worker/src/services/ContentBudgetManager.test.ts
@@ -80,6 +80,7 @@ describe('ContentBudgetManager', () => {
       userMessage: 'Hello, how are you?',
       processedAttachments: [],
       referencedMessagesDescriptions: undefined,
+      effectiveContextWindowTokens: 8000,
     });
 
     it('should return budget allocation result with all required fields', () => {
@@ -116,15 +117,20 @@ describe('ContentBudgetManager', () => {
       );
     });
 
-    it('should use default context window tokens when not specified', () => {
+    it('should budget against the effective context window, not the personality setting', () => {
       const options = createBaseOptions();
-      // Force undefined to test the fallback behavior (use as never to bypass type check)
-      options.personality = { ...mockPersonality, contextWindowTokens: undefined as never };
+      // Personality says 8000 but the caller-resolved effective window (e.g.,
+      // clamped to the model's real limit) is what must drive the budget
+      options.effectiveContextWindowTokens = 6000;
 
       budgetManager.allocate(options);
 
-      // Should use AI_DEFAULTS.CONTEXT_WINDOW_TOKENS (128000)
-      expect(mockContextWindowManager.calculateMemoryBudget).toHaveBeenCalled();
+      expect(mockContextWindowManager.calculateMemoryBudget).toHaveBeenCalledWith(
+        6000,
+        expect.any(Number),
+        expect.any(Number),
+        expect.any(Number)
+      );
     });
 
     it('should select memories within budget', () => {

--- a/services/ai-worker/src/services/ContentBudgetManager.ts
+++ b/services/ai-worker/src/services/ContentBudgetManager.ts
@@ -6,7 +6,7 @@
  * file size and separate concerns.
  */
 
-import { createLogger, AI_DEFAULTS } from '@tzurot/common-types';
+import { createLogger } from '@tzurot/common-types';
 import type { PromptBuilder } from './PromptBuilder.js';
 import type { ContextWindowManager } from './context/ContextWindowManager.js';
 import type {
@@ -36,9 +36,8 @@ export class ContentBudgetManager {
    * 6. Build final system prompt with all content
    */
   allocate(opts: BudgetAllocationOptions): BudgetAllocationResult {
-    const { personality, processedPersonality, participantPersonas, context } = opts;
-    const contextWindowTokens =
-      personality.contextWindowTokens || AI_DEFAULTS.CONTEXT_WINDOW_TOKENS;
+    const { processedPersonality, participantPersonas, context } = opts;
+    const contextWindowTokens = opts.effectiveContextWindowTokens;
 
     // Build current message and base system prompt
     const { currentMessage, contentForStorage, systemPromptBaseTokens } =

--- a/services/ai-worker/src/services/ConversationalRAGService.test.ts
+++ b/services/ai-worker/src/services/ConversationalRAGService.test.ts
@@ -72,6 +72,7 @@ vi.mock('../redis.js', () => ({
     get: vi.fn().mockResolvedValue(null),
   },
   checkModelReasoningSupport: vi.fn().mockResolvedValue(true),
+  checkModelContextLength: vi.fn().mockResolvedValue(null),
 }));
 vi.mock('./storedReferenceHydrator.js', () => ({
   hydrateStoredReferences: vi.fn().mockResolvedValue(undefined),
@@ -92,6 +93,7 @@ import {
   createMockContext,
   resetAllMocks,
 } from '../test/mocks/index.js';
+import { checkModelContextLength } from '../redis.js';
 
 describe('ConversationalRAGService', () => {
   let service: ConversationalRAGService;
@@ -174,6 +176,60 @@ describe('ConversationalRAGService', () => {
       const result = await service.generateResponse(personality, 'Test', context);
 
       expect(result.modelUsed).toBe('test-model');
+    });
+  });
+
+  describe('context window clamping', () => {
+    afterEach(() => {
+      // Restore the suite-wide default (unknown model → no clamp)
+      vi.mocked(checkModelContextLength).mockResolvedValue(null);
+    });
+
+    it('should clamp the budget when the configured window exceeds the model cap', async () => {
+      // The prod-incident shape: configured at the model's full context length
+      vi.mocked(checkModelContextLength).mockResolvedValue(8192);
+      const personality = createMockPersonality({ contextWindowTokens: 8192 });
+      const context = createMockContext();
+
+      await service.generateResponse(personality, 'Test', context);
+
+      // computeContextCap(8192) = 6144 (75% small-model headroom)
+      expect(getContextWindowManagerMock().calculateMemoryBudget).toHaveBeenCalledWith(
+        6144,
+        expect.any(Number),
+        expect.any(Number),
+        expect.any(Number)
+      );
+    });
+
+    it('should not clamp when configured below the model cap', async () => {
+      vi.mocked(checkModelContextLength).mockResolvedValue(131072); // cap = 65536
+      const personality = createMockPersonality({ contextWindowTokens: 8192 });
+      const context = createMockContext();
+
+      await service.generateResponse(personality, 'Test', context);
+
+      expect(getContextWindowManagerMock().calculateMemoryBudget).toHaveBeenCalledWith(
+        8192,
+        expect.any(Number),
+        expect.any(Number),
+        expect.any(Number)
+      );
+    });
+
+    it('should use the configured window unchanged when the model limit is unknown', async () => {
+      vi.mocked(checkModelContextLength).mockResolvedValue(null);
+      const personality = createMockPersonality({ contextWindowTokens: 8192 });
+      const context = createMockContext();
+
+      await service.generateResponse(personality, 'Test', context);
+
+      expect(getContextWindowManagerMock().calculateMemoryBudget).toHaveBeenCalledWith(
+        8192,
+        expect.any(Number),
+        expect.any(Number),
+        expect.any(Number)
+      );
     });
   });
 

--- a/services/ai-worker/src/services/ConversationalRAGService.ts
+++ b/services/ai-worker/src/services/ConversationalRAGService.ts
@@ -36,6 +36,7 @@ import {
   countMediaAttachments,
 } from './RAGUtils.js';
 import { redisService, visionDescriptionCache, checkModelReasoningSupport } from '../redis.js';
+import { resolveEffectiveContextWindow } from './contextWindowResolver.js';
 import { deriveCacheKeyId } from './RateLimitCache.js';
 import { ResponsePostProcessor } from './ResponsePostProcessor.js';
 import { ConversationInputProcessor } from './ConversationInputProcessor.js';
@@ -45,6 +46,7 @@ import {
   parseResponseMetadata,
   recordLlmConfigDiagnostic,
   recordLlmResponseDiagnostic,
+  recordBudgetDiagnostics,
 } from './diagnostics/DiagnosticRecorders.js';
 import type { DiagnosticCollector } from './DiagnosticCollector.js';
 import type {
@@ -411,6 +413,7 @@ export class ConversationalRAGService {
       // Step 4: Allocate token budgets and select content
       // Note: Image descriptions and stored reference hydration are handled by
       // enrichConversationHistory (Step 1.5) — history is already enriched here
+      const effectiveContextWindowTokens = await resolveEffectiveContextWindow(personality);
       const budgetResult = this.contentBudgetManager.allocate({
         personality,
         processedPersonality,
@@ -421,25 +424,18 @@ export class ConversationalRAGService {
         processedAttachments: inputs.processedAttachments,
         referencedMessagesDescriptions: inputs.referencedMessagesDescriptions,
         historyReductionPercent: retryConfig?.historyReductionPercent,
+        effectiveContextWindowTokens,
       });
 
       // Record memory retrieval and token budget for diagnostics
       if (diagnosticCollector) {
-        diagnosticCollector.recordMemoryRetrieval({
+        recordBudgetDiagnostics({
+          collector: diagnosticCollector,
           retrievedMemories,
-          selectedMemories: budgetResult.relevantMemories,
           focusModeEnabled,
-        });
-        diagnosticCollector.recordTokenBudget({
-          contextWindowSize: personality.contextWindowTokens ?? 131072,
-          systemPromptTokens: this.promptBuilder.countTokens(
-            budgetResult.systemPrompt.content as string
-          ),
-          memoryTokensUsed: budgetResult.memoryTokensUsed,
-          historyTokensUsed: budgetResult.historyTokensUsed,
-          memoriesDropped: budgetResult.memoriesDroppedCount,
-          historyMessagesDropped: budgetResult.messagesDropped,
-          crossChannelMessagesIncluded: budgetResult.crossChannelMessagesIncluded,
+          budgetResult,
+          contextWindowSize: effectiveContextWindowTokens,
+          countTokens: text => this.promptBuilder.countTokens(text),
         });
       }
 

--- a/services/ai-worker/src/services/ConversationalRAGTypes.ts
+++ b/services/ai-worker/src/services/ConversationalRAGTypes.ts
@@ -260,6 +260,14 @@ export interface BudgetAllocationOptions {
    * by changing the context window.
    */
   historyReductionPercent?: number;
+  /**
+   * The input-token budget for this generation: the configured
+   * contextWindowTokens clamped to the model's real limit when known
+   * (see contextWindowResolver.ts).
+   * Required so the budget can never silently fall back to a window
+   * larger than the model supports.
+   */
+  effectiveContextWindowTokens: number;
 }
 
 /**

--- a/services/ai-worker/src/services/ModelCapabilityChecker.test.ts
+++ b/services/ai-worker/src/services/ModelCapabilityChecker.test.ts
@@ -8,6 +8,7 @@ import { REDIS_KEY_PREFIXES, type OpenRouterModel } from '@tzurot/common-types';
 import {
   modelSupportsVision,
   modelSupportsReasoning,
+  getModelContextLength,
   clearCapabilityCache,
 } from './ModelCapabilityChecker.js';
 
@@ -335,6 +336,52 @@ describe('ModelCapabilityChecker', () => {
         expect(await modelSupportsReasoning('qwen/qwen2.5-72b', mockRedis)).toBe(false);
         expect(await modelSupportsReasoning('openai/gpt-4o', mockRedis)).toBe(false);
       });
+    });
+  });
+
+  describe('getModelContextLength', () => {
+    it('should return the context length from the Redis cache', async () => {
+      const models = [
+        createMockModel('cognitivecomputations/dolphin-mistral-24b-venice-edition', ['text']),
+      ];
+      vi.mocked(mockRedis.get).mockResolvedValue(JSON.stringify(models));
+
+      const result = await getModelContextLength(
+        'cognitivecomputations/dolphin-mistral-24b-venice-edition',
+        mockRedis
+      );
+
+      expect(result).toBe(4096); // createMockModel's context_length
+    });
+
+    it('should resolve :free-suffixed model IDs', async () => {
+      const models = [
+        createMockModel('cognitivecomputations/dolphin-mistral-24b-venice-edition', ['text']),
+      ];
+      vi.mocked(mockRedis.get).mockResolvedValue(JSON.stringify(models));
+
+      const result = await getModelContextLength(
+        'cognitivecomputations/dolphin-mistral-24b-venice-edition:free',
+        mockRedis
+      );
+
+      expect(result).toBe(4096);
+    });
+
+    it('should return null when the model is not in the cache', async () => {
+      vi.mocked(mockRedis.get).mockResolvedValue(JSON.stringify([]));
+
+      const result = await getModelContextLength('unknown/model', mockRedis);
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null when Redis is unavailable (pattern fallback has no length)', async () => {
+      vi.mocked(mockRedis.get).mockRejectedValue(new Error('Redis down'));
+
+      const result = await getModelContextLength('openai/gpt-4o', mockRedis);
+
+      expect(result).toBeNull();
     });
   });
 

--- a/services/ai-worker/src/services/ModelCapabilityChecker.ts
+++ b/services/ai-worker/src/services/ModelCapabilityChecker.ts
@@ -25,6 +25,8 @@ const logger = createLogger('ModelCapabilityChecker');
 interface CachedCapabilities {
   supportsVision: boolean;
   supportsReasoning: boolean;
+  /** The model's real context length in tokens; null when resolved via pattern fallback (Redis unavailable or model not in cache). */
+  contextLength: number | null;
   timestamp: number;
 }
 
@@ -70,6 +72,7 @@ async function resolveFromRedis(
     const capabilities: CachedCapabilities = {
       supportsVision: model.architecture.input_modalities.includes('image'),
       supportsReasoning: model.supported_parameters.includes('reasoning'),
+      contextLength: model.context_length,
       timestamp: Date.now(),
     };
 
@@ -79,6 +82,7 @@ async function resolveFromRedis(
         modelId,
         supportsVision: capabilities.supportsVision,
         supportsReasoning: capabilities.supportsReasoning,
+        contextLength: capabilities.contextLength,
         source: 'redis-cache',
       },
       '[ModelCapabilityChecker] Resolved capabilities from cache'
@@ -109,10 +113,11 @@ async function getCapabilities(modelId: string, redis: Redis): Promise<CachedCap
     return fromRedis;
   }
 
-  // Fallback to pattern matching
+  // Fallback to pattern matching (no context-length knowledge on this path)
   const capabilities: CachedCapabilities = {
     supportsVision: hasVisionSupportFallback(modelId),
     supportsReasoning: hasReasoningSupportFallback(modelId),
+    contextLength: null,
     timestamp: Date.now(),
   };
 
@@ -171,6 +176,24 @@ export async function modelSupportsVision(modelId: string, redis: Redis): Promis
 export async function modelSupportsReasoning(modelId: string, redis: Redis): Promise<boolean> {
   const capabilities = await getCapabilities(modelId, redis);
   return capabilities.supportsReasoning;
+}
+
+/**
+ * Get a model's real context length from OpenRouter's cached model data.
+ *
+ * Same resolution order as the other capability checks (in-memory cache →
+ * Redis cache → fallback). The pattern fallback carries no context-length
+ * knowledge, so this returns null when the Redis cache is unavailable or the
+ * model isn't in it (e.g., non-OpenRouter providers) — callers must degrade
+ * gracefully rather than assume a limit.
+ *
+ * @param modelId - The model ID to look up
+ * @param redis - Redis client instance
+ * @returns The context length in tokens, or null when unknown
+ */
+export async function getModelContextLength(modelId: string, redis: Redis): Promise<number | null> {
+  const capabilities = await getCapabilities(modelId, redis);
+  return capabilities.contextLength;
 }
 
 // ===================================

--- a/services/ai-worker/src/services/contextWindowResolver.test.ts
+++ b/services/ai-worker/src/services/contextWindowResolver.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { LoadedPersonality } from '@tzurot/common-types';
+import { resolveEffectiveContextWindow } from './contextWindowResolver.js';
+import { checkModelContextLength } from '../redis.js';
+
+vi.mock('../redis.js', () => ({
+  checkModelContextLength: vi.fn().mockResolvedValue(null),
+}));
+
+const personality = (overrides?: Partial<LoadedPersonality>): LoadedPersonality =>
+  ({
+    model: 'test/model',
+    contextWindowTokens: 32768,
+    ...overrides,
+  }) as LoadedPersonality;
+
+describe('resolveEffectiveContextWindow', () => {
+  beforeEach(() => {
+    vi.mocked(checkModelContextLength).mockResolvedValue(null);
+  });
+
+  it('clamps a configured value above the model cap', async () => {
+    // The prod-incident shape: a 32k model configured at its full context length
+    vi.mocked(checkModelContextLength).mockResolvedValue(32768);
+
+    const result = await resolveEffectiveContextWindow(personality());
+
+    expect(result).toBe(24576); // computeContextCap(32768) = 75%
+  });
+
+  it('passes through a configured value below the cap', async () => {
+    vi.mocked(checkModelContextLength).mockResolvedValue(131072); // cap = 65536
+
+    const result = await resolveEffectiveContextWindow(personality({ contextWindowTokens: 20000 }));
+
+    expect(result).toBe(20000);
+  });
+
+  it('uses the configured value when the model limit is unknown', async () => {
+    vi.mocked(checkModelContextLength).mockResolvedValue(null);
+
+    const result = await resolveEffectiveContextWindow(personality());
+
+    expect(result).toBe(32768);
+  });
+
+  it('looks up the personality model id', async () => {
+    await resolveEffectiveContextWindow(personality({ model: 'some/model:free' }));
+
+    // The raw ID (including :free) is passed through — suffix normalization
+    // is ModelCapabilityChecker's responsibility, not the resolver's
+    expect(checkModelContextLength).toHaveBeenCalledWith('some/model:free');
+  });
+});

--- a/services/ai-worker/src/services/contextWindowResolver.ts
+++ b/services/ai-worker/src/services/contextWindowResolver.ts
@@ -1,0 +1,38 @@
+/**
+ * Context Window Resolver
+ *
+ * Resolves the input-token budget for a generation: the configured
+ * contextWindowTokens clamped to the model's real limit when known.
+ * Gateway validation rejects new oversized saves; this clamp protects
+ * generations driven by already-saved rows (and the schema's 131072
+ * default) that exceed what the model can actually hold.
+ */
+
+import { createLogger, clampContextWindow, type LoadedPersonality } from '@tzurot/common-types';
+import { checkModelContextLength } from '../redis.js';
+
+const logger = createLogger('ContextWindowResolver');
+
+/**
+ * Resolve the effective context window for a generation.
+ *
+ * Unknown models (non-OpenRouter providers, model-cache miss) degrade
+ * gracefully to the configured value. Logs when the clamp engages — that's
+ * the "this preset is configured above the model's limit" signal.
+ */
+export async function resolveEffectiveContextWindow(
+  personality: LoadedPersonality
+): Promise<number> {
+  const configured = personality.contextWindowTokens;
+  const modelContextLength = await checkModelContextLength(personality.model);
+  const effective = clampContextWindow(configured, modelContextLength);
+  if (effective < configured) {
+    // warn, not info: this fires on every generation until the stored config
+    // is corrected — it's a persistent misconfiguration signal, not routine flow
+    logger.warn(
+      { model: personality.model, configured, modelContextLength, effective },
+      'Clamped context window to model limit'
+    );
+  }
+  return effective;
+}

--- a/services/ai-worker/src/services/diagnostics/DiagnosticRecorders.test.ts
+++ b/services/ai-worker/src/services/diagnostics/DiagnosticRecorders.test.ts
@@ -25,8 +25,12 @@ import {
   parseResponseMetadata,
   recordLlmConfigDiagnostic,
   recordLlmResponseDiagnostic,
+  recordBudgetDiagnostics,
   type ParsedResponseMetadata,
 } from './DiagnosticRecorders.js';
+import { SystemMessage } from '@langchain/core/messages';
+import type { DiagnosticCollector } from '../DiagnosticCollector.js';
+import type { BudgetAllocationResult, MemoryDocument } from '../ConversationalRAGTypes.js';
 
 describe('DiagnosticRecorders', () => {
   describe('parseResponseMetadata', () => {
@@ -146,6 +150,51 @@ describe('DiagnosticRecorders', () => {
 
       const call = mockCollector.recordLlmConfig.mock.calls[0][0] as Record<string, unknown>;
       expect(call.provider).toBe('anthropic');
+    });
+  });
+
+  describe('recordBudgetDiagnostics', () => {
+    it('should record memory retrieval and token budget from the allocation result', () => {
+      const mockCollector = {
+        recordMemoryRetrieval: vi.fn(),
+        recordTokenBudget: vi.fn(),
+      } as unknown as DiagnosticCollector;
+      const memories: MemoryDocument[] = [{ pageContent: 'a memory', metadata: {} }];
+      const budgetResult: BudgetAllocationResult = {
+        relevantMemories: memories,
+        serializedHistory: '',
+        systemPrompt: new SystemMessage('system prompt text'),
+        memoryTokensUsed: 50,
+        historyTokensUsed: 200,
+        memoriesDroppedCount: 1,
+        messagesDropped: 2,
+        contentForStorage: '',
+        crossChannelMessagesIncluded: 3,
+      };
+
+      recordBudgetDiagnostics({
+        collector: mockCollector,
+        retrievedMemories: memories,
+        focusModeEnabled: true,
+        budgetResult,
+        contextWindowSize: 24576,
+        countTokens: text => text.length,
+      });
+
+      expect(mockCollector.recordMemoryRetrieval).toHaveBeenCalledWith({
+        retrievedMemories: memories,
+        selectedMemories: memories,
+        focusModeEnabled: true,
+      });
+      expect(mockCollector.recordTokenBudget).toHaveBeenCalledWith({
+        contextWindowSize: 24576,
+        systemPromptTokens: 'system prompt text'.length,
+        memoryTokensUsed: 50,
+        historyTokensUsed: 200,
+        memoriesDropped: 1,
+        historyMessagesDropped: 2,
+        crossChannelMessagesIncluded: 3,
+      });
     });
   });
 

--- a/services/ai-worker/src/services/diagnostics/DiagnosticRecorders.ts
+++ b/services/ai-worker/src/services/diagnostics/DiagnosticRecorders.ts
@@ -10,6 +10,7 @@ import { resolveFinishReason, type LoadedPersonality } from '@tzurot/common-type
 import { inferNonXmlStop } from '../StopSequenceTracker.js';
 import { hasThinkingBlocks } from '../../utils/thinkingExtraction.js';
 import type { LlmResponseData } from './DiagnosticTypes.js';
+import type { BudgetAllocationResult, MemoryDocument } from '../ConversationalRAGTypes.js';
 
 /** Parsed response metadata from LangChain's AIMessage */
 export interface ParsedResponseMetadata {
@@ -154,6 +155,36 @@ function buildReasoningDebug(
     apiMessageKeys: openrouter?.apiMessageKeys,
     apiReasoningLength: openrouter?.apiReasoningLength,
   };
+}
+
+/** Options for recordBudgetDiagnostics */
+interface BudgetDiagnosticOptions {
+  collector: DiagnosticCollector;
+  retrievedMemories: MemoryDocument[];
+  focusModeEnabled: boolean;
+  budgetResult: BudgetAllocationResult;
+  /** The effective (model-clamped) context window the budget ran against */
+  contextWindowSize: number;
+  countTokens: (text: string) => number;
+}
+
+/** Record memory retrieval and token budget allocation to the diagnostic collector */
+export function recordBudgetDiagnostics(opts: BudgetDiagnosticOptions): void {
+  const { collector, retrievedMemories, focusModeEnabled, budgetResult, contextWindowSize } = opts;
+  collector.recordMemoryRetrieval({
+    retrievedMemories,
+    selectedMemories: budgetResult.relevantMemories,
+    focusModeEnabled,
+  });
+  collector.recordTokenBudget({
+    contextWindowSize,
+    systemPromptTokens: opts.countTokens(budgetResult.systemPrompt.content as string),
+    memoryTokensUsed: budgetResult.memoryTokensUsed,
+    historyTokensUsed: budgetResult.historyTokensUsed,
+    memoriesDropped: budgetResult.memoriesDroppedCount,
+    historyMessagesDropped: budgetResult.messagesDropped,
+    crossChannelMessagesIncluded: budgetResult.crossChannelMessagesIncluded,
+  });
 }
 
 /** Record the LLM response to the diagnostic collector */

--- a/services/api-gateway/src/utils/modelValidation.test.ts
+++ b/services/api-gateway/src/utils/modelValidation.test.ts
@@ -101,28 +101,30 @@ describe('validateModelAndContextWindow', () => {
     expect(result.contextWindowCap).toBe(64000);
   });
 
-  it('should use full context for small models (<=65536 tokens)', async () => {
+  it('should cap small models (<=65536 tokens) at 75% of context length', async () => {
+    const model = createMockModel({ contextLength: 32768 });
+    const cache = createMockModelCache(model);
+    const result = await validateModelAndContextWindow(cache, 'test/small-model', 24576);
+    expect(result.error).toBeUndefined();
+    expect(result.contextWindowCap).toBe(24576);
+  });
+
+  it('should reject contextWindowTokens at the full context length for small models', async () => {
+    // The prod-incident shape: configuring a 32k model at its full 32768
+    // leaves no room for output or tokenizer mismatch and must be rejected.
     const model = createMockModel({ contextLength: 32768 });
     const cache = createMockModelCache(model);
     const result = await validateModelAndContextWindow(cache, 'test/small-model', 32768);
-    expect(result.error).toBeUndefined();
-    expect(result.contextWindowCap).toBe(32768);
-  });
-
-  it('should reject contextWindowTokens exceeding full context for small models', async () => {
-    const model = createMockModel({ contextLength: 32768 });
-    const cache = createMockModelCache(model);
-    const result = await validateModelAndContextWindow(cache, 'test/small-model', 40000);
-    expect(result.error).toContain("exceeds the full limit for 'test/small-model'");
+    expect(result.error).toContain("exceeds the safe limit for 'test/small-model'");
     expect(result.error).toContain('Reduce the Context Window value');
-    expect(result.contextWindowCap).toBe(32768);
+    expect(result.contextWindowCap).toBe(24576);
   });
 
-  it('should use full context at exactly 65536 boundary', async () => {
+  it('should apply the 75% cap at exactly the 65536 boundary', async () => {
     const model = createMockModel({ contextLength: 65536 });
     const cache = createMockModelCache(model);
     const result = await validateModelAndContextWindow(cache, 'test/boundary', undefined);
-    expect(result.contextWindowCap).toBe(65536);
+    expect(result.contextWindowCap).toBe(49152); // 65536 * 0.75
   });
 
   it('should halve context at 65537 (just above threshold)', async () => {
@@ -185,7 +187,7 @@ describe('enrichWithModelContext', () => {
     expect(response.contextWindowCap).toBe(65536); // Math.floor(131073 / 2)
   });
 
-  it('should use full context for small models', async () => {
+  it('should apply the 75% cap for small models', async () => {
     const model = createMockModel({ contextLength: 32768 });
     const cache = createMockModelCache(model);
     const response: { modelContextLength?: number; contextWindowCap?: number } = {};
@@ -193,6 +195,6 @@ describe('enrichWithModelContext', () => {
     await enrichWithModelContext(response, 'test/small-model', cache);
 
     expect(response.modelContextLength).toBe(32768);
-    expect(response.contextWindowCap).toBe(32768);
+    expect(response.contextWindowCap).toBe(24576); // 32768 * 0.75
   });
 });

--- a/services/api-gateway/src/utils/modelValidation.ts
+++ b/services/api-gateway/src/utils/modelValidation.ts
@@ -5,18 +5,8 @@
  * Used by both user and admin LLM config routes.
  */
 
+import { computeContextCap } from '@tzurot/common-types';
 import type { OpenRouterModelCache } from '../services/OpenRouterModelCache.js';
-
-/**
- * Models with context windows at or below this threshold use their full context
- * (no halving). Larger models are capped at 50% to leave room for generation.
- */
-const SMALL_CONTEXT_THRESHOLD = 65536;
-
-/** Compute the context window cap: full context for small models, 50% for large */
-function computeContextCap(contextLength: number): number {
-  return contextLength <= SMALL_CONTEXT_THRESHOLD ? contextLength : Math.floor(contextLength / 2);
-}
 
 /**
  * Result of model validation.
@@ -31,7 +21,9 @@ export interface ModelValidationResult {
 
 /**
  * Validate a model ID against the OpenRouter model cache and enforce
- * contextWindowTokens <= 50% of the model's context_length.
+ * contextWindowTokens <= computeContextCap(context_length) — the graduated
+ * headroom cap shared with ai-worker's runtime clamp (see
+ * common-types/utils/contextWindowCap.ts for the rationale).
  *
  * Gracefully degrades: if the model cache is unavailable (e.g., OpenRouter
  * is down), validation is skipped and the request proceeds.
@@ -67,14 +59,11 @@ export async function validateModelAndContextWindow(
   if (contextWindowTokens !== undefined && contextWindowTokens > cap) {
     const contextK = Math.round(model.contextLength / 1000);
     const capK = Math.round(cap / 1000);
-    // "full" when the cap equals contextLength (small model, no halving applied),
-    // "safe" when we're holding back 50% for generation room.
-    const scope = cap === model.contextLength ? 'full' : 'safe';
     return {
       error:
-        `Context window setting (${contextWindowTokens} tokens) exceeds the ${scope} limit for '${modelId}'. ` +
-        `Model supports ${contextK}K tokens; maximum allowed for this model is ${capK}K (${cap} tokens). ` +
-        `Reduce the Context Window value before saving.`,
+        `Context window setting (${contextWindowTokens} tokens) exceeds the safe limit for '${modelId}'. ` +
+        `Model supports ${contextK}K tokens; maximum allowed for this model is ${capK}K (${cap} tokens) ` +
+        `to leave room for the response. Reduce the Context Window value before saving.`,
       contextWindowCap: cap,
     };
   }


### PR DESCRIPTION
## Problem

Prod incident (2026-06-11): a 32k-context model correctly configured with `contextWindowTokens=32768` overflowed — the bot sent ~40k provider-side input tokens. Three layers compounded:

1. **Policy inversion** — `modelValidation.ts` exempted ≤64k models from the headroom cap entirely (validated against full `context_length`), while only >64k models got the 50% cap "to leave room for generation." Small models need headroom most: output is a far larger fraction of a small window.
2. **Zero output reserve** — the budget filled the entire configured window with input.
3. **Tokenizer mismatch** — budgets are counted with tiktoken; Mistral-family tokenizers count the same text ~15-25% higher. 32768 budgeted ≈ the observed ~40k.

## Fix

One shared cap formula (`computeContextCap` in common-types), applied at both ends so they can't drift:

- **≤64k models: 75% of context_length** (was 100%) — covers the tokenizer-mismatch class plus output room without halving an already-small budget. >64k models: 50%, unchanged.
- **Gateway validation** now rejects new oversized saves on small models (e.g., 32768 on a 32k model → max 24576).
- **Worker runtime clamp** (`contextWindowResolver`): `min(configured, cap(real context_length))` resolved before budget allocation, using the model's real limit from the OpenRouter Redis cache. Protects already-saved rows and the schema's 131072 default — no migration needed. Unknown models (non-OpenRouter providers, cache miss) degrade gracefully to the configured value. **Warn**-level log fires when the clamp engages (persistent misconfiguration signal, fires every generation until the stored config is corrected).
- `ContentBudgetManager.allocate` takes the effective window as a **required** option — the old `|| 131072` fallback is gone, so the budget can never silently run wider than the model supports.
- Budget diagnostic recording extracted to `recordBudgetDiagnostics` (max-lines headroom).
- The preset dashboard's existing over-cap warning (`formatContextWindow`: `ctx=32K (max 24K ⚠️)`) picks up the new cap automatically — it renders whatever `contextWindowCap` the gateway returns.

## Verification

- `pnpm test` green (18/18 packages), `pnpm quality` green.
- New tests: cap formula (common-types), validation expectations (gateway), context-length lookup (ModelCapabilityChecker), resolver clamp paths, RAG-level wiring (clamped / unclamped / unknown-model).
- Dev burn-in after merge: chat with the Dolphin 32k preset (still stored at 32768) — expect the clamp log (`configured=32768 → effective=24576`) and successful generation.

Resolves the small-context overflow entry in `backlog/production-issues.md`. Ships in beta.129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)