### PR TITLE
fix(bot-client): update context-window UI text for the graduated cap

### DIFF
--- a/services/api-gateway/src/services/LlmConfigService.ts
+++ b/services/api-gateway/src/services/LlmConfigService.ts
@@ -123,7 +123,7 @@ interface FormattedConfigDetail {
   params: Record<string, unknown>;
   /** Model's full context window (from OpenRouter), set by enrichWithModelContext */
   modelContextLength?: number;
-  /** 50% cap for contextWindowTokens, set by enrichWithModelContext */
+  /** Model-derived cap for contextWindowTokens (computeContextCap), set by enrichWithModelContext */
   contextWindowCap?: number;
 }
 

--- a/services/bot-client/src/commands/preset/presetSections.ts
+++ b/services/bot-client/src/commands/preset/presetSections.ts
@@ -212,7 +212,7 @@ export const contextWindowSection: SectionDefinition<FlattenedPresetData> = {
   fields: [
     {
       id: 'contextWindowTokens',
-      label: 'Context Window Tokens (max 50% of model)',
+      label: 'Context Window Tokens (capped per model)',
       placeholder: '131072',
       required: false,
       style: 'short',

--- a/services/bot-client/src/commands/preset/types.ts
+++ b/services/bot-client/src/commands/preset/types.ts
@@ -29,7 +29,7 @@ export interface PresetData {
   contextWindowTokens: number;
   /** Model's full context window (from OpenRouter), undefined if unknown */
   modelContextLength?: number;
-  /** 50% cap for contextWindowTokens, undefined if unknown */
+  /** Model-derived cap for contextWindowTokens (computeContextCap), undefined if unknown */
   contextWindowCap?: number;
   params: {
     temperature?: number;
@@ -94,7 +94,7 @@ export interface FlattenedPresetData {
   contextWindowTokens: string;
   /** Model's full context window (display-only, not editable) */
   modelContextLength?: number;
-  /** 50% cap for contextWindowTokens (display-only, not editable) */
+  /** Model-derived cap for contextWindowTokens (display-only, not editable) */
   contextWindowCap?: number;
   /** Browse context when opened from browse (for back navigation) */
   browseContext?: BrowseContext;


### PR DESCRIPTION
Follow-up to #1186. The preset edit modal's label still said **"max 50% of model"**, but the cap is now graduated (75% for ≤64k models, 50% above) — a user editing a small-model preset would be told the wrong limit.

- Modal label → `Context Window Tokens (capped per model)` — points at the mechanism rather than a percentage; the dashboard preview (`ctx=32K (max 24K ⚠️)`) and the gateway rejection message both surface the exact per-model number.
- Refreshed three `/** 50% cap ... */` doc comments on `contextWindowCap` fields (bot-client types ×2, LlmConfigService).

Text/comment-only diff, no behavior change. Rides into beta.129 with #1186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)