### PR TITLE
chore(tooling): merge stacked JSDoc blocks in check-duplicate-exports

### DIFF
--- a/packages/tooling/src/dev/check-duplicate-exports.ts
+++ b/packages/tooling/src/dev/check-duplicate-exports.ts
@@ -126,8 +126,9 @@ export function isAllowed(name: string, packageName: string): boolean {
 
 /**
  * Check if a file entry should be included in the scan
+ *
+ * @internal Exported for testing
  */
-/** @internal Exported for testing */
 export function isSourceFile(entry: string): boolean {
   return (
     entry.endsWith('.ts') &&
@@ -184,8 +185,9 @@ const REEXPORT_PATTERN = /^export\s*\{([^}]+)\}\s*from\s/;
 
 /**
  * Parse a single re-export name spec (e.g., "name as alias" or just "name")
+ *
+ * @internal Exported for testing
  */
-/** @internal Exported for testing */
 export function parseReExportName(nameSpec: string): string | null {
   const trimmed = nameSpec.trim();
   if (trimmed.startsWith('type ')) {
@@ -198,8 +200,9 @@ export function parseReExportName(nameSpec: string): string | null {
 
 /**
  * Extract declaration exports from a single line
+ *
+ * @internal Exported for testing
  */
-/** @internal Exported for testing */
 export function matchDeclarations(line: string, filePath: string, lineNum: number): ExportInfo[] {
   const results: ExportInfo[] = [];
   for (const { pattern, kind } of EXPORT_PATTERNS) {
@@ -213,8 +216,9 @@ export function matchDeclarations(line: string, filePath: string, lineNum: numbe
 
 /**
  * Extract re-exports from a single line
+ *
+ * @internal Exported for testing
  */
-/** @internal Exported for testing */
 export function matchReExports(line: string, filePath: string, lineNum: number): ExportInfo[] {
   const reexportMatch = REEXPORT_PATTERN.exec(line);
   if (reexportMatch === null) {
@@ -232,8 +236,9 @@ export function matchReExports(line: string, filePath: string, lineNum: number):
 
 /**
  * Extract exported names from a TypeScript file
+ *
+ * @internal Exported for testing
  */
-/** @internal Exported for testing */
 export function extractExports(filePath: string): ExportInfo[] {
   const results: ExportInfo[] = [];
   const lines = readFileSync(filePath, 'utf-8').split('\n');
@@ -254,8 +259,9 @@ export function extractExports(filePath: string): ExportInfo[] {
 /**
  * Find duplicate export names within a package, filtering out allowlisted
  * names and cases where one definition has re-exports (intentional pattern).
+ *
+ * @internal Exported for testing
  */
-/** @internal Exported for testing */
 export function findDuplicates(allExports: ExportInfo[], packageName: string): DuplicateGroup[] {
   const byName = new Map<string, ExportInfo[]>();
   for (const exp of allExports) {


### PR DESCRIPTION
Quick-win from the backlog (surfaced by PR #1148 claude-review). TypeScript/TSDoc reads only the JSDoc block immediately preceding a declaration, so the stacked pattern (`/** description */` + `/** @internal Exported for testing */`) orphaned the description blocks — invisible in IDE hover. Folded the `@internal` tag into each description block (6 functions), same fix already applied to `check-dockerfile-dist.ts`.

Comment-only diff. Grep confirms no other file in `packages/tooling/src` carries the stacked form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)