### PR TITLE
fix(ai-worker): replace BaseMessage content-as-string casts with contentToText

### DIFF
--- a/services/ai-worker/src/services/ContentBudgetManager.ts
+++ b/services/ai-worker/src/services/ContentBudgetManager.ts
@@ -6,7 +6,9 @@
  * file size and separate concerns.
  */
 
+import type { HumanMessage } from '@langchain/core/messages';
 import { createLogger } from '@tzurot/common-types';
+import { contentToText } from '../utils/baseMessageContent.js';
 import type { PromptBuilder } from './PromptBuilder.js';
 import type { ContextWindowManager } from './context/ContextWindowManager.js';
 import type {
@@ -42,7 +44,9 @@ export class ContentBudgetManager {
     // Build current message and base system prompt
     const { currentMessage, contentForStorage, systemPromptBaseTokens } =
       this.buildBaseComponents(opts);
-    const currentMessageTokens = this.promptBuilder.countTokens(currentMessage.content as string);
+    const currentMessageTokens = this.promptBuilder.countTokens(
+      contentToText(currentMessage.content)
+    );
 
     // Select memories within budget
     const { relevantMemories, memoryTokensUsed, memoriesDroppedCount } = this.selectMemories(
@@ -103,7 +107,7 @@ export class ContentBudgetManager {
   }
 
   private buildBaseComponents(opts: BudgetAllocationOptions): {
-    currentMessage: { content: unknown };
+    currentMessage: HumanMessage;
     contentForStorage: string;
     systemPromptBaseTokens: number;
   } {
@@ -137,7 +141,7 @@ export class ContentBudgetManager {
     });
 
     const systemPromptBaseTokens = this.promptBuilder.countTokens(
-      systemPromptBaseOnly.content as string
+      contentToText(systemPromptBaseOnly.content)
     );
 
     return { currentMessage, contentForStorage, systemPromptBaseTokens };
@@ -224,7 +228,7 @@ export class ContentBudgetManager {
     });
 
     const systemPromptWithMemoriesTokens = this.promptBuilder.countTokens(
-      systemPromptWithMemories.content as string
+      contentToText(systemPromptWithMemories.content)
     );
 
     let historyBudget = this.contextWindowManager.calculateHistoryBudget(

--- a/services/ai-worker/src/services/ConversationalRAGService.ts
+++ b/services/ai-worker/src/services/ConversationalRAGService.ts
@@ -19,6 +19,7 @@ import {
   getPrismaClient,
   type LoadedPersonality,
 } from '@tzurot/common-types';
+import { contentToText } from '../utils/baseMessageContent.js';
 import { logAndThrow } from '../utils/errorHandling.js';
 import { validateAIProvider } from '../utils/providerValidation.js';
 import { ReferencedMessageFormatter } from './ReferencedMessageFormatter.js';
@@ -218,8 +219,8 @@ export class ConversationalRAGService {
     // Record assembled prompt and LLM config for diagnostics
     if (diagnosticCollector) {
       const totalTokenEstimate =
-        this.promptBuilder.countTokens(systemPrompt.content as string) +
-        this.promptBuilder.countTokens(currentMessage.content as string);
+        this.promptBuilder.countTokens(contentToText(systemPrompt.content)) +
+        this.promptBuilder.countTokens(contentToText(currentMessage.content));
 
       diagnosticCollector.recordAssembledPrompt(messages, totalTokenEstimate);
       recordLlmConfigDiagnostic({
@@ -245,7 +246,10 @@ export class ConversationalRAGService {
       audioCount,
     });
 
-    const rawContent = response.content as string;
+    // Non-text parts (thinking blocks, images) are intentionally excluded —
+    // thinking content arrives via reasoning_details and is handled by
+    // parseResponseMetadata/thinkingExtraction, not the content array.
+    const rawContent = contentToText(response.content);
 
     // Extract token usage, finish reason, and reasoning details
     const metadata = parseResponseMetadata(response);

--- a/services/ai-worker/src/services/diagnostics/DiagnosticRecorders.ts
+++ b/services/ai-worker/src/services/diagnostics/DiagnosticRecorders.ts
@@ -9,6 +9,7 @@ import type { DiagnosticCollector } from '../DiagnosticCollector.js';
 import { resolveFinishReason, type LoadedPersonality } from '@tzurot/common-types';
 import { inferNonXmlStop } from '../StopSequenceTracker.js';
 import { hasThinkingBlocks } from '../../utils/thinkingExtraction.js';
+import { contentToText } from '../../utils/baseMessageContent.js';
 import type { LlmResponseData } from './DiagnosticTypes.js';
 import type { BudgetAllocationResult, MemoryDocument } from '../ConversationalRAGTypes.js';
 
@@ -178,7 +179,7 @@ export function recordBudgetDiagnostics(opts: BudgetDiagnosticOptions): void {
   });
   collector.recordTokenBudget({
     contextWindowSize,
-    systemPromptTokens: opts.countTokens(budgetResult.systemPrompt.content as string),
+    systemPromptTokens: opts.countTokens(contentToText(budgetResult.systemPrompt.content)),
     memoryTokensUsed: budgetResult.memoryTokensUsed,
     historyTokensUsed: budgetResult.historyTokensUsed,
     memoriesDropped: budgetResult.memoriesDroppedCount,

--- a/services/ai-worker/src/utils/baseMessageContent.test.ts
+++ b/services/ai-worker/src/utils/baseMessageContent.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { contentToText } from './baseMessageContent.js';
+
+describe('contentToText', () => {
+  it('passes string content through unchanged', () => {
+    expect(contentToText('hello world')).toBe('hello world');
+    expect(contentToText('')).toBe('');
+  });
+
+  it('extracts text parts from array-form content', () => {
+    expect(
+      contentToText([
+        { type: 'text', text: 'first part' },
+        { type: 'text', text: 'second part' },
+      ])
+    ).toBe('first part\nsecond part');
+  });
+
+  it('handles mixed string and object elements in array content', () => {
+    // The current LangChain type doesn't admit bare strings as array elements,
+    // but older serializations produce them at runtime — the helper's string
+    // branch is deliberately defensive, so this test must cast past the type.
+    const mixed = [
+      'plain string part',
+      { type: 'text', text: 'object part' },
+    ] as unknown as Parameters<typeof contentToText>[0];
+    expect(contentToText(mixed)).toBe('plain string part\nobject part');
+  });
+
+  it('skips non-text parts (image blocks contribute no countable text)', () => {
+    expect(
+      contentToText([
+        { type: 'text', text: 'describe this image' },
+        { type: 'image_url', image_url: { url: 'https://example.com/img.png' } },
+      ])
+    ).toBe('describe this image');
+  });
+
+  it('excludes thinking blocks (no text property) — the rawContent contract', () => {
+    const parts = [
+      { type: 'thinking', thinking: 'internal reasoning' },
+      { type: 'text', text: 'final answer' },
+    ] as unknown as Parameters<typeof contentToText>[0];
+    const result = contentToText(parts);
+    expect(result).toBe('final answer');
+    expect(result).not.toContain('internal reasoning');
+  });
+
+  it('returns empty string for content with no text parts', () => {
+    expect(contentToText([{ type: 'image_url', image_url: { url: 'https://x/y.png' } }])).toBe('');
+    expect(contentToText([])).toBe('');
+  });
+
+  it('never produces [object Object] (the silent-cast failure mode)', () => {
+    const result = contentToText([{ type: 'text', text: 'real text' }]);
+    expect(result).not.toContain('[object Object]');
+    expect(result).toBe('real text');
+  });
+});

--- a/services/ai-worker/src/utils/baseMessageContent.ts
+++ b/services/ai-worker/src/utils/baseMessageContent.ts
@@ -1,0 +1,40 @@
+/**
+ * BaseMessage content extraction
+ *
+ * LangChain's `BaseMessage.content` is `string | MessageContentComplex[]`.
+ * Token-counting call sites used to cast it with `as string`, which silently
+ * produces a wrong count if a message ever carries array-form content blocks
+ * (the array's `.toString()` is not its text). This helper extracts the text
+ * deterministically for both shapes.
+ */
+
+import type { BaseMessage } from '@langchain/core/messages';
+
+/**
+ * Extract the text of a message's content for token counting.
+ *
+ * String content passes through unchanged. Array-form content yields the
+ * concatenated text parts; non-text parts (image blocks, etc.) contribute
+ * nothing — a text tokenizer can't price them anyway.
+ */
+export function contentToText(content: BaseMessage['content']): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+  return (
+    content
+      .map(part => {
+        if (typeof part === 'string') {
+          return part;
+        }
+        if ('text' in part && typeof part.text === 'string') {
+          return part.text;
+        }
+        return '';
+      })
+      .filter(text => text.length > 0)
+      // '\n' join slightly over-counts vs the wire shape — safe (conservative)
+      // for budgeting, but NOT a lossless round-trip of the original content
+      .join('\n')
+  );
+}


### PR DESCRIPTION
Quick-win from the backlog — the item claude-review re-raised across four rounds of #1186.

LangChain's `BaseMessage.content` is `string | MessageContentComplex[]`. Seven call sites cast it `as string`, which silently yields `[object Object]`-derived text if a message ever carries array-form content blocks. New `contentToText` helper (with colocated tests) extracts text parts deterministically:

- **Identical behavior for string content** — the only shape that occurs today.
- **Correct for the array case** — text parts joined; non-text parts (image blocks) contribute nothing, which is right for token counting.

Applied to all seven sites: six token-counting paths (`ContentBudgetManager` ×3, `ConversationalRAGService` ×2, `recordBudgetDiagnostics`) plus the LLM response `rawContent` read — behavior-preserving there too, and strictly better if a provider ever returns multi-part content. Also tightened `buildBaseComponents`' loose `{ content: unknown }` return to `HumanMessage` (the cast had been silencing that type hole — the typechecker caught it the moment the cast came out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)