### PR TITLE
chore(ci): collect services/** in integration coverage

### DIFF
--- a/vitest.int.config.ts
+++ b/vitest.int.config.ts
@@ -57,7 +57,11 @@ export default defineConfig({
       reporter: ['text', 'json', 'lcov'],
       reportsDirectory: './coverage/integration',
       enabled: false, // Enable with --coverage flag
-      include: ['src/**/*.ts', 'packages/**/src/**/*.ts'],
+      // All three roots must be listed: this config runs from the repo root,
+      // so a bare 'src/**' matches nothing — without the services glob, no
+      // services/*/src file ever appeared in the integration coverage upload
+      // (the 'integration' codecov flag claimed services/ but received no data).
+      include: ['src/**/*.ts', 'packages/**/src/**/*.ts', 'services/**/src/**/*.ts'],
       exclude: ['**/*.test.ts', '**/*.int.test.ts', '**/node_modules/**'],
     },
   },


### PR DESCRIPTION
Quick-win from the backlog (surfaced during the beta.128 codecov/patch failure). The integration coverage `include` list was `['src/**/*.ts', 'packages/**/src/**/*.ts']` — both root-relative, so no `services/*/src` file has **ever** appeared in the integration coverage upload. The `integration` codecov flag claims `services/` in its paths but received no matching data; every service line exercised only by int tests reads as uncovered.

Fix: add `services/**/src/**/*.ts` to the include list (with a comment explaining the root-relative trap).

**Standalone PR by design** (per the backlog entry): real integration coverage landing for three services will shift the global coverage numbers — watch this PR's codecov report for the delta rather than burying it in a feature PR. Coverage union with the existing unit-flag uploads should move numbers up or flat, not down, but the reading deserves its own diff. Conformance fixtures remain codecov-ignored (intentional test infrastructure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)