### PR TITLE
feat(ai-worker): re-derive guild info + extended-context images from the envelope (iii-b-3 PR-1)

### DIFF
--- a/packages/common-types/src/types/schemas/discord.ts
+++ b/packages/common-types/src/types/schemas/discord.ts
@@ -5,6 +5,7 @@
  */
 
 import { z } from 'zod';
+import { MESSAGE_LIMITS } from '../../constants/message.js';
 
 /**
  * Discord environment context schema
@@ -64,6 +65,21 @@ export const attachmentMetadataSchema = z.object({
   sourceDiscordMessageId: z.string().optional(),
 });
 
+/**
+ * Guild member info schema
+ * Discord server-specific information about a user
+ * Used for enriching participant context in prompts
+ */
+export const guildMemberInfoSchema = z.object({
+  /** User's top server roles (sorted by position, excluding @everyone). Limit: MESSAGE_LIMITS.MAX_GUILD_ROLES */
+  roles: z.array(z.string()).max(MESSAGE_LIMITS.MAX_GUILD_ROLES),
+  /** Display color from highest colored role (hex, e.g., '#FF00FF') */
+  displayColor: z.string().optional(),
+  /** When user joined the server (ISO 8601) */
+  joinedAt: z.string().optional(),
+});
+
 // Infer TypeScript types from schemas
 export type DiscordEnvironment = z.infer<typeof discordEnvironmentSchema>;
 export type AttachmentMetadata = z.infer<typeof attachmentMetadataSchema>;
+export type GuildMemberInfo = z.infer<typeof guildMemberInfoSchema>;

--- a/packages/common-types/src/types/schemas/personality.ts
+++ b/packages/common-types/src/types/schemas/personality.ts
@@ -6,7 +6,11 @@
  */
 
 import { z } from 'zod';
-import { discordEnvironmentSchema, attachmentMetadataSchema } from './discord.js';
+import {
+  discordEnvironmentSchema,
+  attachmentMetadataSchema,
+  guildMemberInfoSchema,
+} from './discord.js';
 import { rawAssemblyInputsSchema } from './rawEnvelope.js';
 import {
   apiConversationMessageSchema,
@@ -153,19 +157,9 @@ export const referencedChannelSchema = z.object({
   guildId: z.string().optional(),
 });
 
-/**
- * Guild member info schema
- * Discord server-specific information about a user
- * Used for enriching participant context in prompts
- */
-export const guildMemberInfoSchema = z.object({
-  /** User's top server roles (sorted by position, excluding @everyone). Limit: MESSAGE_LIMITS.MAX_GUILD_ROLES */
-  roles: z.array(z.string()).max(5),
-  /** Display color from highest colored role (hex, e.g., '#FF00FF') */
-  displayColor: z.string().optional(),
-  /** When user joined the server (ISO 8601) */
-  joinedAt: z.string().optional(),
-});
+// guildMemberInfoSchema lives in discord.ts (Discord member data; also needed
+// by rawEnvelope.ts, which personality.ts imports — defining it here would
+// create a schema-module cycle).
 
 /**
  * Request context schema
@@ -241,5 +235,4 @@ export function isVoiceEnabled(personality: LoadedPersonality): boolean {
 
 export type MentionedPersona = z.infer<typeof mentionedPersonaSchema>;
 export type ReferencedChannel = z.infer<typeof referencedChannelSchema>;
-export type GuildMemberInfo = z.infer<typeof guildMemberInfoSchema>;
 export type RequestContext = z.infer<typeof requestContextSchema>;

--- a/packages/common-types/src/types/schemas/rawEnvelope.test.ts
+++ b/packages/common-types/src/types/schemas/rawEnvelope.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { rawAssemblyInputsSchema } from './rawEnvelope.js';
+
+describe('rawAssemblyInputsSchema — guild/attachment raw forms', () => {
+  const base = { rawMessageContent: 'hello' };
+
+  it('parses an envelope without the raw guild/attachment fields (ABSENT)', () => {
+    const result = rawAssemblyInputsSchema.safeParse(base);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.rawParticipantGuildInfo).toBeUndefined();
+      expect(result.data.rawExtendedContextImageAttachments).toBeUndefined();
+      expect(result.data.rawActiveGuildMemberInfo).toBeUndefined();
+    }
+  });
+
+  it('parses the discord:-keyed guild map, the uncapped image list, and the active scalar', () => {
+    const result = rawAssemblyInputsSchema.safeParse({
+      ...base,
+      rawParticipantGuildInfo: {
+        'discord:111': { roles: ['Admin', 'Dev'], displayColor: '#FF00FF' },
+      },
+      rawExtendedContextImageAttachments: [
+        {
+          url: 'https://cdn/img.png',
+          contentType: 'image/png',
+          id: 'a1',
+          sourceDiscordMessageId: 'm1',
+        },
+      ],
+      rawActiveGuildMemberInfo: { roles: ['Mod'], joinedAt: '2024-01-01T00:00:00.000Z' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('preserves EMPTY guild map and image list (not collapsed to absent)', () => {
+    const result = rawAssemblyInputsSchema.safeParse({
+      ...base,
+      rawParticipantGuildInfo: {},
+      rawExtendedContextImageAttachments: [],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.rawParticipantGuildInfo).toEqual({});
+      expect(result.data.rawExtendedContextImageAttachments).toEqual([]);
+    }
+  });
+
+  it('rejects guild entries exceeding the role cap (shared guildMemberInfoSchema rule)', () => {
+    const result = rawAssemblyInputsSchema.safeParse({
+      ...base,
+      rawActiveGuildMemberInfo: { roles: ['a', 'b', 'c', 'd', 'e', 'f'] },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/common-types/src/types/schemas/rawEnvelope.ts
+++ b/packages/common-types/src/types/schemas/rawEnvelope.ts
@@ -12,7 +12,11 @@
  */
 
 import { z } from 'zod';
-import { discordEnvironmentSchema } from './discord.js';
+import {
+  attachmentMetadataSchema,
+  discordEnvironmentSchema,
+  guildMemberInfoSchema,
+} from './discord.js';
 import { apiConversationMessageSchema, referencedMessageSchema } from './message.js';
 
 /**
@@ -111,6 +115,33 @@ export const rawAssemblyInputsSchema = z.object({
   rawExtendedContextUsers: z.array(rawDiscordUserSchema).optional(),
   /** Users who reacted to extended-context messages (separate upsert batch). */
   rawReactorUsers: z.array(rawDiscordUserSchema).optional(),
+  /**
+   * Guild member info (roles, display color, join date) for extended-context
+   * participants, keyed by the PRE-resolution placeholder id
+   * (`discord:<authorId>`) exactly as the channel fetcher builds it — the
+   * worker re-keys to persona UUIDs during its own persona resolution.
+   * ABSENT = DM or the extended-context fetch didn't run; EMPTY = the fetch
+   * ran in a guild but observed no member data.
+   */
+  rawParticipantGuildInfo: z.record(z.string(), guildMemberInfoSchema).optional(),
+  /**
+   * Image attachments observed across extended-context messages, UNCAPPED
+   * (each carries sourceDiscordMessageId linking it to its message). The
+   * worker applies the maxImages cap from its own resolved config — raw
+   * inputs ship pre-decision. Deliberately a flat list rather than
+   * per-message attachments on rawExtendedContextMessages: both the producer
+   * (channel fetcher) and the consumer (vision preprocessing) use the flat
+   * shape, and the per-message alternative would mutate the shared
+   * conversation-history wire schema. ABSENT = fetch didn't run; EMPTY =
+   * fetch ran and observed no images.
+   */
+  rawExtendedContextImageAttachments: z.array(attachmentMetadataSchema).optional(),
+  /**
+   * Guild member info for the TRIGGERING user (message.member), the raw form
+   * of activePersonaGuildInfo. Keyless scalar — no persona re-keying needed.
+   * ABSENT = DM or member data unavailable.
+   */
+  rawActiveGuildMemberInfo: guildMemberInfoSchema.optional(),
   /**
    * Guild→channel environment map from the Discord.js cache, for decorating
    * worker-fetched cross-channel groups with names the worker can't resolve.

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/ContextStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/ContextStep.test.ts
@@ -293,6 +293,139 @@ describe('ContextStep', () => {
       expect(result.preparedContext).toBeDefined();
     });
 
+    it('adopts the assembled guild surfaces when the envelope carries the raw sources', async () => {
+      mockIsAssemblyPromoteEnabled.mockReturnValue(true);
+      const assembledGuildMap = { 'persona-555': { roles: ['Admin'] } };
+      const assembledActive = { roles: ['Mod'] };
+      const assembled = makeAssembled({
+        participantGuildInfo: assembledGuildMap,
+        activePersonaGuildInfo: assembledActive,
+      });
+      const fakeAssembler = { assembleCore: vi.fn().mockResolvedValue(assembled) };
+      const promoteStep = new ContextStep(fakeDataSource, fakeAssembler as never);
+      const job = createMockJob({
+        context: {
+          userId: 'u',
+          rawAssemblyInputs: {
+            rawMessageContent: 'raw',
+            rawParticipantGuildInfo: { 'discord:555': { roles: ['Admin'] } },
+            rawActiveGuildMemberInfo: { roles: ['Mod'] },
+          },
+          // Payload copies the bot still ships during burn-in.
+          participantGuildInfo: { 'persona-555': { roles: ['Admin'] } },
+          activePersonaGuildInfo: { roles: ['Mod'] },
+        } as never,
+      });
+
+      await promoteStep.process({ job, startTime: Date.now(), config });
+
+      expect(job.data.context.participantGuildInfo).toBe(assembledGuildMap);
+      expect(job.data.context.activePersonaGuildInfo).toBe(assembledActive);
+    });
+
+    it('preserves the payload guild surfaces when the envelope predates the raw sources', async () => {
+      mockIsAssemblyPromoteEnabled.mockReturnValue(true);
+      // Old envelope: no raw guild fields → assembler derives undefined.
+      const assembled = makeAssembled({
+        participantGuildInfo: undefined,
+        activePersonaGuildInfo: undefined,
+      });
+      const fakeAssembler = { assembleCore: vi.fn().mockResolvedValue(assembled) };
+      const promoteStep = new ContextStep(fakeDataSource, fakeAssembler as never);
+      const payloadGuild = { 'persona-9': { roles: ['Keeper'] } };
+      const payloadActive = { roles: ['Elder'] };
+      const job = createMockJob({
+        context: {
+          userId: 'u',
+          rawAssemblyInputs: { rawMessageContent: 'raw' },
+          participantGuildInfo: payloadGuild,
+          activePersonaGuildInfo: payloadActive,
+        } as never,
+      });
+
+      await promoteStep.process({ job, startTime: Date.now(), config });
+
+      // No raw source → the overwrite must NOT clobber the valid payload copies.
+      expect(job.data.context.participantGuildInfo).toBe(payloadGuild);
+      expect(job.data.context.activePersonaGuildInfo).toBe(payloadActive);
+    });
+
+    it('emits the guild/attachment burn-in diff with matched booleans', async () => {
+      mockIsAssemblyPromoteEnabled.mockReturnValue(true);
+      const assembled = makeAssembled({
+        participantGuildInfo: { 'persona-555': { roles: ['Admin'] } },
+        activePersonaGuildInfo: { roles: ['Mod'] },
+      });
+      const fakeAssembler = { assembleCore: vi.fn().mockResolvedValue(assembled) };
+      const promoteStep = new ContextStep(fakeDataSource, fakeAssembler as never);
+      const job = createMockJob({
+        context: {
+          userId: 'u',
+          rawAssemblyInputs: {
+            rawMessageContent: 'raw',
+            rawParticipantGuildInfo: { 'discord:555': { roles: ['Admin'] } },
+            rawActiveGuildMemberInfo: { roles: ['Mod'] },
+            rawExtendedContextImageAttachments: [
+              { url: 'https://cdn/a.png', contentType: 'image/png', id: 'a' },
+              { url: 'https://cdn/b.png', contentType: 'image/png', id: 'b' },
+            ],
+          },
+          participantGuildInfo: { 'persona-555': { roles: ['Admin'] } },
+          activePersonaGuildInfo: { roles: ['Mod'] },
+          extendedContextAttachments: [
+            { url: 'https://cdn/b.png', contentType: 'image/png', id: 'b' },
+          ],
+        } as never,
+      });
+
+      await promoteStep.process({ job, startTime: Date.now(), config });
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          guildKeysMatched: true,
+          guildRolesMatched: true,
+          activeGuildMatched: true,
+          attachmentsCovered: true,
+          payloadGuildCount: 1,
+          payloadAttachmentCount: 1,
+          rawAttachmentCount: 2,
+        }),
+        'Guild/attachment surface diff (iii-b-3 burn-in)'
+      );
+    });
+
+    it('warns on the burn-in diff when re-derivation diverges from the payload', async () => {
+      // The warn path is the whole point of the burn-in: a real divergence
+      // between the bot's payload copy and the worker's re-derivation must
+      // surface as warn, not blend into info traffic. Here the assembler
+      // re-keys to a DIFFERENT persona than the payload carries.
+      mockIsAssemblyPromoteEnabled.mockReturnValue(true);
+      const assembled = makeAssembled({
+        participantGuildInfo: { 'persona-OTHER': { roles: ['Admin'] } },
+        activePersonaGuildInfo: { roles: ['Mod'] },
+      });
+      const fakeAssembler = { assembleCore: vi.fn().mockResolvedValue(assembled) };
+      const promoteStep = new ContextStep(fakeDataSource, fakeAssembler as never);
+      const job = createMockJob({
+        context: {
+          userId: 'u',
+          rawAssemblyInputs: {
+            rawMessageContent: 'raw',
+            rawParticipantGuildInfo: { 'discord:555': { roles: ['Admin'] } },
+          },
+          // Payload says persona-555; assembler re-derived persona-OTHER → key mismatch.
+          participantGuildInfo: { 'persona-555': { roles: ['Admin'] } },
+        } as never,
+      });
+
+      await promoteStep.process({ job, startTime: Date.now(), config });
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ guildKeysMatched: false }),
+        'Guild/attachment surface diff (iii-b-3 burn-in)'
+      );
+    });
+
     it('nulls activePersonaId in jobContext when the assembler returns null (weigh-in)', async () => {
       mockIsAssemblyPromoteEnabled.mockReturnValue(true);
       const assembled = makeAssembled({ activePersonaId: null, activePersonaName: null });

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/ContextStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/ContextStep.ts
@@ -5,7 +5,7 @@
  * and oldest timestamp calculation for LTM deduplication.
  */
 
-import { createLogger, type MessageRole } from '@tzurot/common-types';
+import { createLogger, type JobContext, type MessageRole } from '@tzurot/common-types';
 import {
   extractParticipants,
   convertConversationHistory,
@@ -17,10 +17,98 @@ import {
 } from '../../../../services/context/shadowHydration.js';
 import { isAssemblyPromoteEnabled } from '../../../../services/context/contextFlags.js';
 import { shadowAssembleAndDiff } from '../../../../services/context/shadowAssembly.js';
-import type { ContextAssembler } from '../../../../services/context/ContextAssembler.js';
+import type {
+  AssembledCore,
+  ContextAssembler,
+} from '../../../../services/context/ContextAssembler.js';
 import type { IPipelineStep, GenerationContext, Participant, PreparedContext } from '../types.js';
 
 const logger = createLogger('ContextStep');
+
+/**
+ * Transitional burn-in diff: while the bot still ships the resolved
+ * guild/attachment surfaces alongside the raw envelope forms, compare the
+ * payload copies against the assembler's re-derivation. Counts and booleans
+ * only — no content/PII. Must run BEFORE sourceHistory's overwrites discard
+ * the payload copies. Removed when the thin payload drops the fields.
+ */
+function logGuildSurfaceDiff(
+  jobId: string | undefined,
+  jobContext: JobContext,
+  assembled: AssembledCore
+): void {
+  const raw = jobContext.rawAssemblyInputs;
+  const hasAnyRawSource =
+    raw?.rawParticipantGuildInfo !== undefined ||
+    raw?.rawActiveGuildMemberInfo !== undefined ||
+    raw?.rawExtendedContextImageAttachments !== undefined;
+  if (!hasAnyRawSource) {
+    return; // envelope predates the raw guild/attachment fields — nothing to verify
+  }
+
+  const { guildKeysMatched, guildRolesMatched, payloadGuildCount, assembledGuildCount } =
+    diffGuildMaps(jobContext.participantGuildInfo, assembled.participantGuildInfo);
+
+  const activeGuildMatched =
+    (jobContext.activePersonaGuildInfo?.roles.length ?? -1) ===
+    (assembled.activePersonaGuildInfo?.roles.length ?? -1);
+
+  // The payload list is the bot's maxImages-capped slice; the raw list is
+  // uncapped — every payload attachment must appear in the raw list. Identity
+  // key is `id ?? url`: the Discord attachment id is the stable snowflake when
+  // present, and the CDN url is a stable fallback for the same image when it's
+  // absent — both sides derive from the same fetch so the key matches across.
+  const rawAttachmentIds = new Set(
+    (raw.rawExtendedContextImageAttachments ?? []).map(a => a.id ?? a.url)
+  );
+  const payloadAttachments = jobContext.extendedContextAttachments ?? [];
+  const attachmentsCovered = payloadAttachments.every(a => rawAttachmentIds.has(a.id ?? a.url));
+
+  const allMatched =
+    guildKeysMatched && guildRolesMatched && activeGuildMatched && attachmentsCovered;
+  logger[allMatched ? 'info' : 'warn'](
+    {
+      jobId,
+      guildKeysMatched,
+      guildRolesMatched,
+      activeGuildMatched,
+      attachmentsCovered,
+      payloadGuildCount,
+      assembledGuildCount,
+      payloadAttachmentCount: payloadAttachments.length,
+      rawAttachmentCount: rawAttachmentIds.size,
+    },
+    'Guild/attachment surface diff (iii-b-3 burn-in)'
+  );
+}
+
+/** Key-set + per-key role-count comparison for the burn-in guild diff. */
+function diffGuildMaps(
+  payload: JobContext['participantGuildInfo'],
+  assembled: JobContext['participantGuildInfo']
+): {
+  guildKeysMatched: boolean;
+  guildRolesMatched: boolean;
+  payloadGuildCount: number;
+  assembledGuildCount: number;
+} {
+  const payloadGuild = payload ?? {};
+  const assembledGuild = assembled ?? {};
+  const payloadKeys = Object.keys(payloadGuild).sort();
+  const assembledKeys = Object.keys(assembledGuild).sort();
+  const guildKeysMatched =
+    payloadKeys.length === assembledKeys.length &&
+    payloadKeys.every((k, i) => k === assembledKeys[i]);
+  const guildRolesMatched =
+    guildKeysMatched &&
+    payloadKeys.every(k => payloadGuild[k].roles.length === assembledGuild[k]?.roles.length);
+  return {
+    guildKeysMatched,
+    guildRolesMatched,
+    payloadGuildCount: payloadKeys.length,
+    assembledGuildCount: assembledKeys.length,
+  };
+}
 
 /**
  * The shared history shape both the legacy payload (`ApiConversationMessage`)
@@ -328,6 +416,11 @@ export class ContextStep implements IPipelineStep {
       context.configOverrides,
       { referenceDedupNowMs: job.timestamp }
     );
+    // Transitional burn-in diff: while the bot still ships the resolved guild
+    // surfaces, compare them against the assembler's re-derivation before the
+    // overwrite below discards the payload copies. Removed once the thin
+    // payload drops the fields (the diff has nothing to compare then).
+    logGuildSurfaceDiff(job.id, jobContext, assembled);
     jobContext.referencedMessages = assembled.referencedMessages;
     jobContext.referencedChannels = assembled.referencedChannels;
     jobContext.mentionedPersonas = assembled.mentionedPersonas;
@@ -336,6 +429,16 @@ export class ContextStep implements IPipelineStep {
     jobContext.userTimezone = assembled.userTimezone;
     jobContext.userInternalId = assembled.userInternalId;
     jobContext.crossChannelHistory = assembled.crossChannelHistory;
+    // Guild surfaces adopt the assembled value only when the envelope carried
+    // the raw source — an envelope from a sender predating the raw guild
+    // fields must keep its payload copy (overwriting with the assembler's
+    // undefined would silently clobber valid data, the forward-bug class).
+    if (jobContext.rawAssemblyInputs?.rawParticipantGuildInfo !== undefined) {
+      jobContext.participantGuildInfo = assembled.participantGuildInfo;
+    }
+    if (jobContext.rawAssemblyInputs?.rawActiveGuildMemberInfo !== undefined) {
+      jobContext.activePersonaGuildInfo = assembled.activePersonaGuildInfo;
+    }
     job.data.message = assembled.messageContent;
 
     // Permanent observability: which path drove this prompt. Counts + kind

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/DependencyStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/DependencyStep.test.ts
@@ -16,7 +16,7 @@ import {
   type AudioTranscriptionResult,
   type ImageDescriptionResult,
 } from '@tzurot/common-types';
-import { DependencyStep } from './DependencyStep.js';
+import { DependencyStep, deriveExtendedContextImages } from './DependencyStep.js';
 import type { GenerationContext } from '../types.js';
 
 // Mock common-types logger
@@ -424,7 +424,76 @@ describe('DependencyStep', () => {
     });
   });
 
+  describe('deriveExtendedContextImages', () => {
+    const img = (id: string): { url: string; contentType: string; id: string } => ({
+      url: `https://cdn/${id}.png`,
+      contentType: 'image/png',
+      id,
+    });
+
+    it('returns undefined when the envelope carries no raw image list', () => {
+      expect(deriveExtendedContextImages(undefined, 10)).toBeUndefined();
+    });
+
+    it('returns undefined when maxImages disables the feature (bot parity)', () => {
+      // The bot ships undefined for maxImages <= 0, not [].
+      expect(deriveExtendedContextImages([img('a')], 0)).toBeUndefined();
+      expect(deriveExtendedContextImages([img('a')], undefined)).toBeUndefined();
+    });
+
+    it('caps to the most recent maxImages via slice(-cap), matching the bot rule', () => {
+      const result = deriveExtendedContextImages([img('a'), img('b'), img('c')], 2);
+      expect(result?.map(i => i.id)).toEqual(['b', 'c']);
+    });
+
+    it('passes the full list through when under the cap', () => {
+      const result = deriveExtendedContextImages([img('a')], 10);
+      expect(result?.map(i => i.id)).toEqual(['a']);
+    });
+  });
+
   describe('extended context attachments', () => {
+    it('derives the image list from the raw envelope when the payload field is absent (thin payload)', async () => {
+      const processedAttachment = {
+        type: AttachmentType.Image,
+        description: 'derived image',
+        originalUrl: 'https://cdn/raw1.png',
+        metadata: { url: 'https://cdn/raw1.png', contentType: 'image/png' },
+      };
+      mockProcessAttachments.mockResolvedValueOnce([processedAttachment]);
+
+      const context: GenerationContext = {
+        job: createMockJob({
+          context: {
+            userId: 'user-456',
+            userName: 'TestUser',
+            channelId: 'channel-789',
+            // No extendedContextAttachments — thin payload shape.
+            rawAssemblyInputs: {
+              rawMessageContent: 'hi',
+              rawExtendedContextImageAttachments: [
+                { url: 'https://cdn/raw0.png', contentType: 'image/png', id: 'raw0' },
+                { url: 'https://cdn/raw1.png', contentType: 'image/png', id: 'raw1' },
+              ],
+            },
+          },
+        }),
+        config: { effectivePersonality: TEST_PERSONALITY, configSource: 'personality' },
+        configOverrides: { maxImages: 1 } as never,
+        startTime: Date.now(),
+      };
+
+      const result = await step.process(context);
+
+      // Capped to the most recent 1 of the 2 raw images.
+      expect(mockProcessAttachments).toHaveBeenCalledWith(
+        [expect.objectContaining({ id: 'raw1' })],
+        TEST_PERSONALITY,
+        expect.anything()
+      );
+      expect(result.preprocessing?.extendedContextAttachments).toHaveLength(1);
+    });
+
     it('should process extended context image attachments using effective personality', async () => {
       const processedAttachment = {
         type: AttachmentType.Image,

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/DependencyStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/DependencyStep.ts
@@ -30,6 +30,51 @@ import { selectVisionModel } from '../../../../services/multimodal/VisionProcess
 const logger = createLogger('DependencyStep');
 
 /**
+ * Derive the extended-context image list from the raw envelope when the thin
+ * payload no longer ships `extendedContextAttachments`. The raw list is
+ * images-only and uncapped (the channel fetcher collects only images;
+ * raw inputs ship pre-decision) — apply the SAME cap rule the bot applied at
+ * ship time: most-recent-maxImages via slice(-cap), and maxImages <= 0 means
+ * the feature is off (the bot ships undefined then, not []).
+ *
+ * `rawImages` is oldest-first (the fetcher's collection order, preserved on
+ * the wire), so slice(-cap) keeps the most-recent cap items — matching the
+ * bot's own slice(-maxImages) on the same-ordered list.
+ */
+export function deriveExtendedContextImages(
+  rawImages: AttachmentMetadata[] | undefined,
+  maxImages: number | undefined
+): AttachmentMetadata[] | undefined {
+  if (rawImages === undefined) {
+    return undefined;
+  }
+  const cap = maxImages ?? 0;
+  if (cap <= 0) {
+    return undefined;
+  }
+  return rawImages.slice(-cap);
+}
+
+/**
+ * Prefer the payload's resolved image list; under the thin payload the bot
+ * stops shipping it and the raw envelope is the source of truth. Invariant:
+ * a payload field must never be the only carrier of data the envelope also
+ * holds (otherwise dropping it from the thin payload silently loses the data).
+ */
+function selectExtendedContextImages(
+  jobContext: GenerationContext['job']['data']['context'] | undefined,
+  maxImages: number | undefined
+): AttachmentMetadata[] | undefined {
+  return (
+    jobContext?.extendedContextAttachments ??
+    deriveExtendedContextImages(
+      jobContext?.rawAssemblyInputs?.rawExtendedContextImageAttachments,
+      maxImages
+    )
+  );
+}
+
+/**
  * Audio info from transcription job
  */
 interface AudioInfo {
@@ -114,13 +159,14 @@ export class DependencyStep implements IPipelineStep {
     }
 
     // Process extended context attachments inline (not from dependency jobs)
-    // Pass auth context for BYOK support (user's API key if available)
-    if (
-      jobContext?.extendedContextAttachments &&
-      jobContext.extendedContextAttachments.length > 0
-    ) {
+    // Pass auth context for BYOK support (user's API key if available).
+    const extendedContextImages = selectExtendedContextImages(
+      jobContext,
+      context.configOverrides?.maxImages
+    );
+    if (extendedContextImages && extendedContextImages.length > 0) {
       const extendedContextAttachments = await this.processExtendedContextAttachments(
-        jobContext.extendedContextAttachments,
+        extendedContextImages,
         personality,
         job.id,
         {

--- a/services/ai-worker/src/services/context/ContextAssembler.test.ts
+++ b/services/ai-worker/src/services/context/ContextAssembler.test.ts
@@ -244,6 +244,88 @@ describe('ContextAssembler.assembleCore', () => {
     expect(core.referencedMessages).toBeUndefined();
   });
 
+  it('re-keys the raw guild map to persona UUIDs without mutating the envelope copy', async () => {
+    // Models the real resolution chain the shared resolver walks:
+    //   discordId '555' --getOrCreateUsersInBatch--> internal UUID 'internal-555'
+    //   --personaResolver.resolve--> persona UUID 'persona-555'
+    // so the guild map's `discord:555` key remaps to `persona-555`.
+    const deps = makeDeps({
+      userService: {
+        getOrCreateUser: vi.fn().mockResolvedValue({ userId: 'internal-1' }),
+        getOrCreateUsersInBatch: vi.fn().mockResolvedValue(new Map([['555', 'internal-555']])),
+      },
+      personaResolver: {
+        resolve: vi
+          .fn()
+          .mockResolvedValue({ config: { personaId: 'persona-555', preferredName: 'Ext' } }),
+      },
+    });
+    const assembler = new ContextAssembler(deps);
+    const jobContext = makeJobContext({
+      rawAssemblyInputs: {
+        rawMessageContent: 'hello',
+        rawExtendedContextMessages: [
+          {
+            id: 'd-ext',
+            role: MessageRole.User,
+            content: 'extended message',
+            createdAt: '2026-06-02T00:00:00.000Z',
+            personaId: 'discord:555',
+            discordMessageId: ['d-ext'],
+          },
+        ],
+        rawExtendedContextUsers: [
+          { discordId: '555', username: 'extuser', displayName: 'Ext User' },
+        ],
+        rawParticipantGuildInfo: {
+          'discord:555': { roles: ['Admin', 'Dev'], displayColor: '#FF00FF' },
+        },
+        rawActiveGuildMemberInfo: { roles: ['Mod'], joinedAt: '2024-01-01T00:00:00.000Z' },
+      },
+    });
+
+    const core = await assembler.assembleCore(jobContext, PERSONALITY, undefined);
+
+    // The REAL shared resolver re-keyed discord:555 → the resolved persona UUID.
+    expect(core.participantGuildInfo).toEqual({
+      'persona-555': { roles: ['Admin', 'Dev'], displayColor: '#FF00FF' },
+    });
+    // The envelope's own copy stays pristine (clone isolation).
+    expect(jobContext.rawAssemblyInputs?.rawParticipantGuildInfo).toEqual({
+      'discord:555': { roles: ['Admin', 'Dev'], displayColor: '#FF00FF' },
+    });
+    // The trigger user's guild info passes through unchanged.
+    expect(core.activePersonaGuildInfo).toEqual({
+      roles: ['Mod'],
+      joinedAt: '2024-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('leaves the guild surfaces undefined when the envelope carries no raw forms', async () => {
+    const assembler = new ContextAssembler(makeDeps());
+    const core = await assembler.assembleCore(makeJobContext(), PERSONALITY, undefined);
+    expect(core.participantGuildInfo).toBeUndefined();
+    expect(core.activePersonaGuildInfo).toBeUndefined();
+  });
+
+  it('preserves an EMPTY guild map (not undefined) when no extended-context messages merge', async () => {
+    // ABSENT (undefined) vs EMPTY ({}) must survive the no-messages early
+    // return: the ContextStep adopt-guard keys off the raw field's presence,
+    // so collapsing {} → undefined here would clobber a valid empty payload.
+    const assembler = new ContextAssembler(makeDeps());
+    const core = await assembler.assembleCore(
+      makeJobContext({
+        rawAssemblyInputs: {
+          rawMessageContent: 'hello',
+          rawParticipantGuildInfo: {},
+        },
+      }),
+      PERSONALITY,
+      undefined
+    );
+    expect(core.participantGuildInfo).toEqual({});
+  });
+
   it('enriches raw references: stubs against assembled history, DB transcripts for the rest', async () => {
     const historyRow = {
       id: 'db-1',

--- a/services/ai-worker/src/services/context/ContextAssembler.ts
+++ b/services/ai-worker/src/services/context/ContextAssembler.ts
@@ -25,6 +25,7 @@ import {
   MESSAGE_LIMITS,
   type ConversationMessage,
   type CrossChannelHistoryGroupEntry,
+  type GuildMemberInfo,
   type JobContext,
   type LoadedPersonality,
   type MentionedPersona,
@@ -77,6 +78,20 @@ export interface AssembledCore {
    * enabled but nothing eligible was found.
    */
   crossChannelHistory: CrossChannelHistoryGroupEntry[] | undefined;
+  /**
+   * Extended-context participant guild info, re-keyed from the envelope's
+   * pre-resolution `discord:*` map to persona UUIDs by the SAME shared
+   * resolver call the bot uses. Undefined when the envelope carries no raw
+   * map (DM, fetch didn't run, or a sender predating the field).
+   */
+  participantGuildInfo: Record<string, GuildMemberInfo> | undefined;
+  /**
+   * The triggering user's guild info, passed through from the envelope's
+   * raw scalar. Unconditional (present even in weigh-in, mirroring the
+   * payload: the bot clears the persona fields for weigh-in but ships this
+   * one, where it's inert downstream because no active persona reads it).
+   */
+  activePersonaGuildInfo: GuildMemberInfo | undefined;
 }
 
 /** Per-call assembly options (job-scoped values the deps can't carry). */
@@ -182,12 +197,18 @@ export class ContextAssembler {
     );
 
     // Step 4: envelope-carried extended context — batch-upsert the observed
-    // users, resolve placeholder personaIds (shared impl), merge (shared
-    // impl). ABSENT raw messages = the fetch didn't run bot-side.
-    const history = await this.mergeExtendedContext(raw, dbHistory, personality.id, {
-      channelId,
-      guildId: jobContext.serverId ?? null,
-    });
+    // users, resolve placeholder personaIds (shared impl, which also re-keys
+    // the raw guild map to persona UUIDs), merge (shared impl). ABSENT raw
+    // messages = the fetch didn't run bot-side.
+    const { history, participantGuildInfo } = await this.mergeExtendedContext(
+      raw,
+      dbHistory,
+      personality.id,
+      {
+        channelId,
+        guildId: jobContext.serverId ?? null,
+      }
+    );
 
     // Step 5: re-derive reference enrichment from the raw snapshots —
     // dedup against the just-assembled history, transcripts from OWN DB.
@@ -236,6 +257,8 @@ export class ContextAssembler {
       mentionedPersonas: rewritten.mentionedPersonas,
       referencedChannels: rewritten.referencedChannels,
       crossChannelHistory,
+      participantGuildInfo,
+      activePersonaGuildInfo: raw.rawActiveGuildMemberInfo,
     };
   }
 
@@ -403,10 +426,25 @@ export class ContextAssembler {
     dbHistory: ConversationMessage[],
     personalityId: string,
     location: { channelId: string; guildId: string | null }
-  ): Promise<ConversationMessage[]> {
+  ): Promise<{
+    history: ConversationMessage[];
+    participantGuildInfo: Record<string, GuildMemberInfo> | undefined;
+  }> {
     const rawMessages = raw.rawExtendedContextMessages;
     if (rawMessages === undefined || rawMessages.length === 0) {
-      return dbHistory;
+      // No extended-context messages to merge, but the guild map can still be
+      // present (e.g. {} = fetch ran in a guild, observed no member data).
+      // Return the cloned unremapped map rather than undefined: with no
+      // messages there are no `discord:*` keys to remap, so unremapped IS the
+      // resolved form — and it preserves the ABSENT (undefined) vs EMPTY ({})
+      // distinction the ContextStep adopt-guard depends on.
+      return {
+        history: dbHistory,
+        participantGuildInfo:
+          raw.rawParticipantGuildInfo !== undefined
+            ? structuredClone(raw.rawParticipantGuildInfo)
+            : undefined,
+      };
     }
 
     const usersToResolve = [
@@ -424,21 +462,26 @@ export class ContextAssembler {
 
     const messages = rawMessages.map(m => fromApiMessage(m, location.channelId, location.guildId));
 
+    // The shared resolver remaps the guild map's `discord:*` keys to persona
+    // UUIDs IN PLACE — clone so the job's envelope object stays pristine.
+    // When no users resolve, the bot keeps its unremapped map; returning the
+    // clone unremapped mirrors that exactly (parity by construction).
+    const participantGuildInfo =
+      raw.rawParticipantGuildInfo !== undefined
+        ? structuredClone(raw.rawParticipantGuildInfo)
+        : undefined;
+
     if (usersToResolve.length > 0) {
       const userMap = await this.deps.userService.getOrCreateUsersInBatch(usersToResolve);
-      // participantGuildInfo intentionally omitted: the envelope does not yet
-      // carry the pre-resolution (discord:-keyed) map, so the payload's
-      // already-remapped copy is authoritative for that surface until the
-      // envelope grows the raw form (tracked for the cutover slice).
       await resolveExtendedContextPersonaIds(
         messages,
         userMap,
         personalityId,
         this.deps.personaResolver,
-        undefined
+        participantGuildInfo
       );
     }
 
-    return mergeWithHistory(messages, dbHistory);
+    return { history: mergeWithHistory(messages, dbHistory), participantGuildInfo };
   }
 }

--- a/services/bot-client/src/services/MessageContextBuilder.ts
+++ b/services/bot-client/src/services/MessageContextBuilder.ts
@@ -505,6 +505,7 @@ export class MessageContextBuilder {
       rawMentionedChannels: refsAndMentions.rawMentionedChannels,
       rawMentionedRoles: refsAndMentions.rawMentionedRoles,
       rawAuthorDisplayName: displayName,
+      rawActiveGuildMemberInfo: guildMemberInfo,
     });
 
     // Thin payload: kind:'envelope' omits the four fields the worker

--- a/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.test.ts
+++ b/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.test.ts
@@ -78,6 +78,39 @@ describe('captureRawExtendedContext', () => {
     expect(snapshot?.extendedContextUsers).toHaveLength(1);
     expect(snapshot?.reactorUsers).toEqual([]);
   });
+
+  it('deep-clones the guild map so later in-place key remapping cannot leak in', () => {
+    process.env.CONTEXT_RAW_ENVELOPE = 'true';
+    const liveGuildInfo: Record<string, { roles: string[] }> = {
+      'discord:111': { roles: ['Admin'] },
+    };
+
+    const snapshot = captureRawExtendedContext({
+      messages: [],
+      extendedContextUsers: [],
+      reactorUsers: [],
+      participantGuildInfo: liveGuildInfo,
+      imageAttachments: [{ url: 'https://cdn/img.png', contentType: 'image/png', id: 'a1' }],
+    });
+
+    // Simulate resolveExtendedContextPersonaIds remapping the live map's keys.
+    liveGuildInfo['resolved-uuid'] = liveGuildInfo['discord:111'];
+    delete liveGuildInfo['discord:111'];
+
+    expect(snapshot?.participantGuildInfo).toEqual({ 'discord:111': { roles: ['Admin'] } });
+    expect(snapshot?.imageAttachments).toHaveLength(1);
+  });
+
+  it('leaves guild map and attachments undefined when the fetch produced none', () => {
+    process.env.CONTEXT_RAW_ENVELOPE = 'true';
+    const snapshot = captureRawExtendedContext({
+      messages: [],
+      extendedContextUsers: [],
+      reactorUsers: [],
+    });
+    expect(snapshot?.participantGuildInfo).toBeUndefined();
+    expect(snapshot?.imageAttachments).toBeUndefined();
+  });
 });
 
 describe('toRawDiscordUser', () => {
@@ -149,6 +182,32 @@ describe('buildRawAssemblyInputs', () => {
       rawAuthorDisplayName: 'Vladlena',
     });
     expect(raw?.rawAuthorDisplayName).toBe('Vladlena');
+  });
+
+  it('ships the raw guild surfaces: participant map, image list, active member info', () => {
+    process.env.CONTEXT_RAW_ENVELOPE = 'true';
+    const snapshot = {
+      messages: [],
+      extendedContextUsers: [],
+      reactorUsers: [],
+      participantGuildInfo: { 'discord:111': { roles: ['Admin'], displayColor: '#FF00FF' } },
+      imageAttachments: [{ url: 'https://cdn/img.png', contentType: 'image/png', id: 'a1' }],
+    };
+
+    const raw = buildRawAssemblyInputs(makeMessage([], 'plain'), snapshot, {
+      rawActiveGuildMemberInfo: { roles: ['Mod'], joinedAt: '2024-01-01T00:00:00.000Z' },
+    });
+
+    expect(raw?.rawParticipantGuildInfo).toEqual({
+      'discord:111': { roles: ['Admin'], displayColor: '#FF00FF' },
+    });
+    expect(raw?.rawExtendedContextImageAttachments).toEqual([
+      { url: 'https://cdn/img.png', contentType: 'image/png', id: 'a1' },
+    ]);
+    expect(raw?.rawActiveGuildMemberInfo).toEqual({
+      roles: ['Mod'],
+      joinedAt: '2024-01-01T00:00:00.000Z',
+    });
   });
 
   it('passes reference and channel/role mention raws through', () => {

--- a/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.ts
+++ b/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.ts
@@ -14,7 +14,9 @@
 import type { Message } from 'discord.js';
 import {
   apiConversationMessageSchema,
+  type AttachmentMetadata,
   type ConversationMessage,
+  type GuildMemberInfo,
   type RawAssemblyInputs,
   type RawDiscordUser,
   type ReferencedMessage,
@@ -32,30 +34,49 @@ export interface RawExtendedContextSnapshot {
   messages: ConversationMessage[];
   extendedContextUsers: ExtendedContextUser[];
   reactorUsers: ExtendedContextUser[];
+  /** Pre-remap guild info, still keyed `discord:<authorId>`. */
+  participantGuildInfo?: Record<string, GuildMemberInfo>;
+  /** Uncapped extended-context image list (each carries sourceDiscordMessageId). */
+  imageAttachments?: AttachmentMetadata[];
 }
 
 /**
  * Capture the raw extended-context snapshot from a fetch result. Must be
  * called BEFORE resolveExtendedContextPersonaIds, which mutates the fetched
- * messages in place (placeholder personaIds → UUIDs) — the worker-side
- * shadow assembler needs the pre-resolution shape to verify its own batch
- * upsert + persona resolution. Returns undefined when the envelope is off
- * (structuredClone of up to 100 messages isn't free).
+ * messages in place (placeholder personaIds → UUIDs) AND remaps the
+ * participantGuildInfo keys — the worker-side assembler needs the
+ * pre-resolution shape to re-run its own batch upsert + persona resolution.
+ * Returns undefined when the envelope is off (structuredClone of up to 100
+ * messages isn't free).
  */
 export function captureRawExtendedContext(
-  fetchResult: Pick<FetchResult, 'messages' | 'extendedContextUsers' | 'reactorUsers'>
+  fetchResult: Pick<
+    FetchResult,
+    | 'messages'
+    | 'extendedContextUsers'
+    | 'reactorUsers'
+    | 'participantGuildInfo'
+    | 'imageAttachments'
+  >
 ): RawExtendedContextSnapshot | undefined {
   if (!isRawEnvelopeEnabled()) {
     return undefined;
   }
   return {
     // Messages are deep-cloned because resolveExtendedContextPersonaIds
-    // rewrites msg.personaId in place. The user arrays only need shallow
-    // copies — resolution reads them but never mutates the user objects. If
-    // that ever changes, upgrade these to structuredClone too.
+    // rewrites msg.personaId in place; the guild map is deep-cloned because
+    // the same resolution remaps its keys in place. The user and attachment
+    // arrays only need shallow copies — resolution reads them but never
+    // mutates the objects. If that ever changes, upgrade to structuredClone.
     messages: structuredClone(fetchResult.messages),
     extendedContextUsers: [...(fetchResult.extendedContextUsers ?? [])],
     reactorUsers: [...(fetchResult.reactorUsers ?? [])],
+    participantGuildInfo:
+      fetchResult.participantGuildInfo !== undefined
+        ? structuredClone(fetchResult.participantGuildInfo)
+        : undefined,
+    imageAttachments:
+      fetchResult.imageAttachments !== undefined ? [...fetchResult.imageAttachments] : undefined,
   };
 }
 
@@ -116,6 +137,8 @@ export function buildRawAssemblyInputs(
     rawMentionedRoles?: RawMentionedRole[];
     /** The author's effective display name from buildContext step 1. */
     rawAuthorDisplayName?: string;
+    /** The triggering user's guild member info (raw form of activePersonaGuildInfo). */
+    rawActiveGuildMemberInfo?: GuildMemberInfo;
   }
 ): RawAssemblyInputs | undefined {
   if (!isRawEnvelopeEnabled()) {
@@ -125,6 +148,10 @@ export function buildRawAssemblyInputs(
     rawMessageContent: message.content,
     rawRoutingTranscript: VoiceMessageProcessor.getVoiceTranscript(message),
     rawAuthorDisplayName: refs?.rawAuthorDisplayName,
+    // No clone needed (unlike the participant guild map): this scalar is a
+    // freshly-built extractGuildMemberInfo result with no in-place mutation
+    // path — nothing downstream remaps or edits the active speaker's roles.
+    rawActiveGuildMemberInfo: refs?.rawActiveGuildMemberInfo,
     rawReferencedMessages: refs?.rawReferencedMessages,
     rawMentionedChannels: refs?.rawMentionedChannels,
     rawMentionedRoles: refs?.rawMentionedRoles,
@@ -140,6 +167,8 @@ export function buildRawAssemblyInputs(
     rawExtendedContextMessages: raw?.messages.map(toApiConversationMessage),
     rawExtendedContextUsers: raw?.extendedContextUsers.map(toRawDiscordUser),
     rawReactorUsers: raw?.reactorUsers.map(toRawDiscordUser),
+    rawParticipantGuildInfo: raw?.participantGuildInfo,
+    rawExtendedContextImageAttachments: raw?.imageAttachments,
     knownChannelEnvironments: buildKnownChannelEnvironments(message.client),
   };
 }


### PR DESCRIPTION
Context-relocation epic, slice **iii-b-3, PR-1 of 2** (additive/inert — the drop PR follows after dev burn-in). The thin `kind:'envelope'` payload still ships three fields the worker can't re-derive; this PR grows the envelope with their raw forms and teaches the worker to derive them. The bot keeps shipping the resolved fields until PR-2 drops them.

## Envelope (3 new optional fields on `rawAssemblyInputs`)

- **`rawParticipantGuildInfo`** — guild member info keyed `discord:<authorId>` (the pre-remap keying exactly as `DiscordChannelFetcher` builds it). Captured in `captureRawExtendedContext` BEFORE `resolveExtendedContextPersonaIds` remaps the live map's keys in place (deep clone, same isolation contract as the message snapshot).
- **`rawExtendedContextImageAttachments`** — the UNCAPPED flat image list (images-only by construction; each item carries `sourceDiscordMessageId`). Deliberately flat rather than per-message attachments on `apiConversationMessageSchema` — that's the shared conversation-history wire shape, and both producer and consumer use the flat form.
- **`rawActiveGuildMemberInfo`** — the trigger user's guild scalar (raw form of `activePersonaGuildInfo`; included now so 2.5d doesn't need a stub slice for it).

`guildMemberInfoSchema` relocated `personality.ts → discord.ts` (Discord member data; defining it in personality.ts would cycle with rawEnvelope.ts). External imports unaffected (everything goes through the package entry / schemas index).

## Worker derivation

- **`ContextAssembler`**: the cloned raw map rides the SAME shared `resolveExtendedContextPersonaIds` call the bot uses (5th arg, previously hardcoded `undefined`) → re-keyed `discord:* → persona UUID`, parity by construction. The active scalar passes through unconditionally (mirroring the payload: the bot ships it even in weigh-in, where it's inert downstream).
- **`ContextStep`** (promoted path): adopts the assembled guild surfaces **only when the envelope carried the raw source** — an in-flight envelope from a pre-PR-1 bot must keep its payload copy (the forward-bug clobber class, guarded explicitly + tested).
- **`DependencyStep`**: `extendedContextAttachments ?? derive-from-envelope` (the #1184 fallback pattern), applying the bot's exact cap rule: `slice(-maxImages)`, `maxImages <= 0` → undefined (feature off), via `configOverrides` (ConfigStep precedes DependencyStep).
- **Transitional burn-in diff log**: while the bot ships both forms, one log line per promoted job compares payload vs assembled (key sets, role counts, attachment-id coverage — booleans + counts only, no PII). `warn` on mismatch. This substitutes for the shadow, which doesn't run when promoted. Removed in PR-2.

## Verification

- `pnpm test` 18/18 packages green; `pnpm quality` green.
- New tests: rawEnvelope schema (ABSENT/EMPTY semantics, role-cap rejection), capture-isolation for the guild map, real-shared-resolver re-keying + envelope-copy pristineness, ContextStep adopt/preserve guards + diff-log shape, `deriveExtendedContextImages` cap rules + the thin-payload fallback path.
- **Dev burn-in before PR-2**: multi-participant guild conversation (`guildKeysMatched:true`), extended-context images (`attachmentsCovered:true` + descriptions still injected), DM (absent-path), weigh-in smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)