### PR TITLE
refactor(bot-client): iii-cleanup — six carried fold-forwards before 2.5d

### DIFF
--- a/services/ai-worker/src/jobs/handlers/LLMGenerationHandler.ts
+++ b/services/ai-worker/src/jobs/handlers/LLMGenerationHandler.ts
@@ -271,9 +271,9 @@ export class LLMGenerationHandler {
   }
 
   /**
-   * Construct the ContextStep with its shadow instrumentation: the 2.5a
-   * hydration data source plus the iii-a context assembler (user/persona
-   * re-derivation + shared history merge against the raw envelope).
+   * Construct the ContextStep with its shadow instrumentation: the hydration
+   * data source plus the context assembler (user/persona re-derivation +
+   * shared history merge against the raw envelope).
    */
   private buildContextStep(): ContextStep {
     const prisma = getPrismaClient();

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/ContextStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/ContextStep.ts
@@ -17,10 +17,51 @@ import {
 } from '../../../../services/context/shadowHydration.js';
 import { isAssemblyPromoteEnabled } from '../../../../services/context/contextFlags.js';
 import { shadowAssembleAndDiff } from '../../../../services/context/shadowAssembly.js';
-import type { ContextAssembler } from '../../../../services/context/ContextAssembler.js';
+import type {
+  AssembledCore,
+  ContextAssembler,
+} from '../../../../services/context/ContextAssembler.js';
 import type { IPipelineStep, GenerationContext, Participant, PreparedContext } from '../types.js';
 
 const logger = createLogger('ContextStep');
+
+/**
+ * Apply the assembler's output onto the worker's local job.data in place. This
+ * is the propagation mechanism: the downstream conversationContextBuilder reads
+ * these surfaces straight off jobContext, so the assembled values must land
+ * there for the later pipeline step to see them (there is no shared return
+ * channel between steps). Mutating the worker's local copy is safe — it's a
+ * deserialized per-job object, not shared state (precedent: DownloadAttachmentsStep).
+ *
+ * Idempotent by construction: every write is a pure overwrite, and assembleCore
+ * derives its output solely from rawAssemblyInputs + the job's scalar identity
+ * fields (userId/channelId/serverId/isWeighIn) — NONE of the fields written
+ * here. So re-running assemble+apply yields the same result regardless of a
+ * prior application (verified against ContextAssembler's reads).
+ */
+function applyAssembledContext(job: GenerationContext['job'], assembled: AssembledCore): void {
+  const jobContext = job.data.context;
+  jobContext.referencedMessages = assembled.referencedMessages;
+  jobContext.referencedChannels = assembled.referencedChannels;
+  jobContext.mentionedPersonas = assembled.mentionedPersonas;
+  jobContext.activePersonaId = assembled.activePersonaId ?? undefined;
+  jobContext.activePersonaName = assembled.activePersonaName ?? undefined;
+  jobContext.userTimezone = assembled.userTimezone;
+  jobContext.userInternalId = assembled.userInternalId;
+  jobContext.crossChannelHistory = assembled.crossChannelHistory;
+  // Guild surfaces adopt the assembled value only when the envelope carried the
+  // raw source — an envelope from a sender predating the raw guild fields must
+  // keep its payload copy (overwriting with the assembler's undefined would
+  // silently clobber valid data, the forward-bug class). The guard is removed
+  // once every producer ships the raw forms (no legacy fallback to protect).
+  if (jobContext.rawAssemblyInputs?.rawParticipantGuildInfo !== undefined) {
+    jobContext.participantGuildInfo = assembled.participantGuildInfo;
+  }
+  if (jobContext.rawAssemblyInputs?.rawActiveGuildMemberInfo !== undefined) {
+    jobContext.activePersonaGuildInfo = assembled.activePersonaGuildInfo;
+  }
+  job.data.message = assembled.messageContent;
+}
 
 /**
  * The shared history shape both the legacy payload (`ApiConversationMessage`)
@@ -272,7 +313,7 @@ export class ContextStep implements IPipelineStep {
    *    fields, so there is nothing to fall back to. Assemble regardless of the
    *    promote flag, and fail loud if no assembler is wired.
    *  - canPromote: a TRANSITIONAL fat-envelope job (envelope present, kind still
-   *    'legacy'/absent) — gated on CONTEXT_ASSEMBLY_PROMOTE so iii-b-1's
+   *    'legacy'/absent) — gated on CONTEXT_ASSEMBLY_PROMOTE so the flag-driven
    *    reversibility holds for these.
    * `kind` is read with `?? 'legacy'`: ValidationStep discards its parsed copy,
    * so the schema default never materializes on the raw job.data.
@@ -301,13 +342,10 @@ export class ContextStep implements IPipelineStep {
    * Source the prompt's conversation history. In promoted mode the
    * worker-assembled context replaces the bot's legacy payload: `historyEntries`
    * comes from the assembler (createdAt normalized Date → ISO for the
-   * string-typed consumers), and the surfaces the downstream
-   * conversationContextBuilder reads straight from jobContext (refs / channels /
-   * mentions / persona / timezone / cross-channel) are overwritten in place —
-   * mutating the worker's local job.data copy is safe (precedent:
-   * DownloadAttachmentsStep). The bot still ships these legacy fields, so the
-   * promotion is reversible by flag; a later cleanup removes them and this
-   * re-sourcing once the bot stops shipping them.
+   * string-typed consumers), and the assembled surfaces are applied onto
+   * jobContext by {@link applyAssembledContext}. The bot still ships these
+   * legacy fields, so the promotion is reversible by flag; once the legacy
+   * fallback is removed the in-place application becomes the only path.
    */
   private async sourceHistory(
     context: GenerationContext,
@@ -328,25 +366,7 @@ export class ContextStep implements IPipelineStep {
       context.configOverrides,
       { referenceDedupNowMs: job.timestamp }
     );
-    jobContext.referencedMessages = assembled.referencedMessages;
-    jobContext.referencedChannels = assembled.referencedChannels;
-    jobContext.mentionedPersonas = assembled.mentionedPersonas;
-    jobContext.activePersonaId = assembled.activePersonaId ?? undefined;
-    jobContext.activePersonaName = assembled.activePersonaName ?? undefined;
-    jobContext.userTimezone = assembled.userTimezone;
-    jobContext.userInternalId = assembled.userInternalId;
-    jobContext.crossChannelHistory = assembled.crossChannelHistory;
-    // Guild surfaces adopt the assembled value only when the envelope carried
-    // the raw source — an envelope from a sender predating the raw guild
-    // fields must keep its payload copy (overwriting with the assembler's
-    // undefined would silently clobber valid data, the forward-bug class).
-    if (jobContext.rawAssemblyInputs?.rawParticipantGuildInfo !== undefined) {
-      jobContext.participantGuildInfo = assembled.participantGuildInfo;
-    }
-    if (jobContext.rawAssemblyInputs?.rawActiveGuildMemberInfo !== undefined) {
-      jobContext.activePersonaGuildInfo = assembled.activePersonaGuildInfo;
-    }
-    job.data.message = assembled.messageContent;
+    applyAssembledContext(job, assembled);
 
     // Permanent observability: which path drove this prompt. Counts + kind
     // only — NO content/PII (per the no-PII logging rule). Without this, the

--- a/services/ai-worker/src/services/context/ContextAssembler.test.ts
+++ b/services/ai-worker/src/services/context/ContextAssembler.test.ts
@@ -559,4 +559,44 @@ describe('ContextAssembler.assembleCore', () => {
     expect(core.history).toEqual([dbRow]);
     expect(deps.userService.getOrCreateUsersInBatch).not.toHaveBeenCalled();
   });
+
+  it('does not read the fields applyAssembledContext writes (idempotency invariant)', async () => {
+    // applyAssembledContext (ContextStep) overwrites jobContext.referencedMessages /
+    // mentionedPersonas / activePersonaId / userTimezone / etc. with assembled
+    // output IN PLACE. That's only safe — and assemble+apply only idempotent —
+    // if assembleCore never reads those written fields back. Guard it: poison
+    // every written field with junk, then assert the assembled output is
+    // byte-identical to a clean run. A future read-set expansion breaks here.
+    const dbRow = {
+      id: 'db-1',
+      role: MessageRole.User,
+      content: 'hi',
+      createdAt: new Date('2026-06-01T00:00:00Z'),
+      discordMessageId: ['d1'],
+    };
+    const deps = makeDeps({
+      dataSource: { getChannelHistory: vi.fn().mockResolvedValue([dbRow]) },
+    });
+    const assembler = new ContextAssembler(deps);
+
+    const clean = await assembler.assembleCore(makeJobContext(), PERSONALITY, undefined);
+    const poisoned = await assembler.assembleCore(
+      makeJobContext({
+        referencedMessages: [{ referenceNumber: 99, content: 'JUNK', authorName: 'X' }] as never,
+        referencedChannels: [{ channelId: 'junk', channelName: 'junk' }] as never,
+        mentionedPersonas: [{ personaId: 'junk', personaName: 'JUNK' }] as never,
+        activePersonaId: 'JUNK-PERSONA',
+        activePersonaName: 'JUNK',
+        userTimezone: 'Junk/Zone',
+        userInternalId: 'junk-internal',
+        crossChannelHistory: [{ channelEnvironment: {}, messages: [] }] as never,
+        participantGuildInfo: { junk: { roles: ['JUNK'] } } as never,
+        activePersonaGuildInfo: { roles: ['JUNK'] } as never,
+      }),
+      PERSONALITY,
+      undefined
+    );
+
+    expect(poisoned).toEqual(clean);
+  });
 });

--- a/services/ai-worker/src/services/context/ContextAssembler.ts
+++ b/services/ai-worker/src/services/context/ContextAssembler.ts
@@ -184,7 +184,7 @@ export class ContextAssembler {
     const userTimezone = await this.deps.dataSource.getUserTimezone(user.userId);
 
     // Step 3: hydrate channel history — same limit derivation as the
-    // bot-side dbLimit (and as the 2.5a hydration shadow).
+    // bot-side dbLimit (and as the hydration shadow).
     const limit = Math.min(
       configOverrides?.maxMessages ?? MESSAGE_LIMITS.DEFAULT_MAX_MESSAGES,
       MESSAGE_LIMITS.MAX_EXTENDED_CONTEXT

--- a/services/ai-worker/src/services/context/shadowAssembly.ts
+++ b/services/ai-worker/src/services/context/shadowAssembly.ts
@@ -204,8 +204,8 @@ function idSetsMatch<T>(
 }
 
 /**
- * History comparison over the DB-id-bearing subset (mirrors the 2.5a shadow's
- * tolerance): rows the assembler sees that the payload predates are expected
+ * History comparison over the DB-id-bearing subset (mirrors the hydration
+ * shadow's tolerance): rows the assembler sees that the payload predates are expected
  * timing drift; rows the payload has that assembly lacks are real divergence.
  * Content/personaId compare only on the id-intersection.
  *

--- a/services/api-gateway/src/routes/internal/personalityLoad.ts
+++ b/services/api-gateway/src/routes/internal/personalityLoad.ts
@@ -53,8 +53,8 @@ export const handleLoadPersonalityInternal = (deps: RouteDeps): RequestHandler =
 
     const personality = await personalityService.loadPersonality(nameOrId, userId);
 
-    // nameOrId is a personality name/slug, not user PII — logged so burn-in
-    // analysis can correlate miss patterns for the 2.5c negative-caching work.
+    // nameOrId is a personality name/slug, not user PII — logged so analysis
+    // can correlate miss patterns for the loader's negative-caching tier.
     logger.debug(
       { nameOrId, found: personality !== null, hasUserId: userId !== undefined },
       'Personality load'

--- a/services/bot-client/src/commands/character/chat.test.ts
+++ b/services/bot-client/src/commands/character/chat.test.ts
@@ -50,7 +50,7 @@ const mockPersonaResolver = {
 };
 
 vi.mock('../../services/serviceRegistry.js', () => ({
-  getPersonalityService: () => mockPersonalityService,
+  getPersonalityLoader: () => mockPersonalityService,
   getMessageContextBuilder: () => mockMessageContextBuilder,
   getConversationPersistence: () => mockConversationPersistence,
   getPersonaResolver: () => mockPersonaResolver,

--- a/services/bot-client/src/commands/character/chat.ts
+++ b/services/bot-client/src/commands/character/chat.ts
@@ -34,7 +34,7 @@ import {
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import {
-  getPersonalityService,
+  getPersonalityLoader,
   getMessageContextBuilder,
   getConversationPersistence,
   getPersonaResolver,
@@ -375,7 +375,7 @@ export async function handleChat(
 
   try {
     // 1. Load and validate personality
-    const personality = await getPersonalityService().loadPersonality(characterSlug, userId);
+    const personality = await getPersonalityLoader().loadPersonality(characterSlug, userId);
     if (!personality) {
       await context.editReply({ content: `❌ Character "${characterSlug}" not found.` });
       return;

--- a/services/bot-client/src/index.ts
+++ b/services/bot-client/src/index.ts
@@ -210,7 +210,7 @@ function createServices(): Services {
   const personalityIdCache = new PersonalityIdCache(personalityService); // Optimizes name→ID lookups
   const userService = new UserService(prisma);
 
-  // Routing-read loader (Phase 2.5c-ii): in service mode, personality
+  // Routing-read loader: in service mode, personality
   // resolution for routing (mention parsing, reply resolution, activation,
   // multi-tag recovery, /character chat) goes through the gateway's internal
   // endpoint with positive/negative caching instead of direct Prisma. The two

--- a/services/bot-client/src/services/HttpPersonalityLoader.test.ts
+++ b/services/bot-client/src/services/HttpPersonalityLoader.test.ts
@@ -113,6 +113,24 @@ describe('HttpPersonalityLoader', () => {
     expect(mockServiceClient.loadPersonalityInternal).toHaveBeenCalledTimes(2);
   });
 
+  it('keys an undefined userId distinctly from a user-scoped key (no cross-bleed)', async () => {
+    // Internal/no-userId loads (the `\x00`-prefixed key, since the userId
+    // portion is empty) must NOT collide with a real user's scoped result,
+    // and vice versa — each is its own hop.
+    mockServiceClient.loadPersonalityInternal
+      .mockResolvedValueOnce(ok({ personality: PERSONALITY }))
+      .mockResolvedValueOnce(ok({ personality: null }));
+
+    expect(await loader.loadPersonality('lila')).not.toBeNull(); // no userId → key '\x00lila'
+    expect(await loader.loadPersonality('lila', 'user-1')).toBeNull(); // key 'user-1\x00lila'
+    // Each side stays cached independently — no third hop.
+    expect(await loader.loadPersonality('lila')).not.toBeNull();
+    expect(await loader.loadPersonality('lila', 'user-1')).toBeNull();
+
+    expect(mockServiceClient.loadPersonalityInternal).toHaveBeenCalledTimes(2);
+    expect(mockServiceClient.loadPersonalityInternal).toHaveBeenCalledWith({ nameOrId: 'lila' });
+  });
+
   it('keys case-insensitively on the name', async () => {
     mockServiceClient.loadPersonalityInternal.mockResolvedValue(ok({ personality: PERSONALITY }));
 

--- a/services/bot-client/src/services/HttpPersonalityLoader.ts
+++ b/services/bot-client/src/services/HttpPersonalityLoader.ts
@@ -1,5 +1,5 @@
 /**
- * HTTP-backed personality loader (Phase 2.5c-ii).
+ * HTTP-backed personality loader.
  *
  * Implements IPersonalityLoader over the gateway's internal
  * `GET /api/internal/personality/load` route — the service-mode replacement
@@ -72,10 +72,13 @@ export class HttpPersonalityLoader implements IPersonalityLoader, PersonalityCac
    * Access control happens server-side (the endpoint applies
    * loadPersonality's public-or-owned semantics), so the cache key must
    * carry the userId — the same nameOrId can legitimately resolve for one
-   * user and miss for another.
+   * user and miss for another. The delimiter is `\x00` (NUL): it cannot
+   * appear in a Discord snowflake or a personality name/slug/alias, so two
+   * distinct (userId, nameOrId) pairs can never collide into one key (which
+   * a printable delimiter like `::` could, e.g. a name containing `::`).
    */
   private cacheKey(nameOrId: string, userId?: string): string {
-    return `${userId ?? ''}::${nameOrId.toLowerCase()}`;
+    return `${userId ?? ''}\x00${nameOrId.toLowerCase()}`;
   }
 
   async loadPersonality(nameOrId: string, userId?: string): Promise<LoadedPersonality | null> {

--- a/services/bot-client/src/services/serviceRegistry.test.ts
+++ b/services/bot-client/src/services/serviceRegistry.test.ts
@@ -43,10 +43,10 @@ describe('serviceRegistry', () => {
       );
     });
 
-    it('should throw when getting PersonalityService before registration', async () => {
-      const { getPersonalityService } = await import('./serviceRegistry.js');
-      expect(() => getPersonalityService()).toThrow(
-        'PersonalityService not registered. Call registerServices() first.'
+    it('should throw when getting the personality loader before registration', async () => {
+      const { getPersonalityLoader } = await import('./serviceRegistry.js');
+      expect(() => getPersonalityLoader()).toThrow(
+        'Personality loader not registered. Call registerServices() first.'
       );
     });
 
@@ -145,8 +145,8 @@ describe('serviceRegistry', () => {
       expect(getWebhookManager()).toBe(mockWebhookManager);
     });
 
-    it('should return registered PersonalityService', async () => {
-      const { registerServices, getPersonalityService } = await import('./serviceRegistry.js');
+    it('should return the registered personality loader', async () => {
+      const { registerServices, getPersonalityLoader } = await import('./serviceRegistry.js');
 
       registerServices({
         jobTracker: mockJobTracker,
@@ -160,7 +160,7 @@ describe('serviceRegistry', () => {
         denylistCache: mockDenylistCache,
       });
 
-      expect(getPersonalityService()).toBe(mockPersonalityService);
+      expect(getPersonalityLoader()).toBe(mockPersonalityService);
     });
 
     it('should return registered ConversationHistoryService', async () => {

--- a/services/bot-client/src/services/serviceRegistry.ts
+++ b/services/bot-client/src/services/serviceRegistry.ts
@@ -91,11 +91,13 @@ export function getWebhookManager(): WebhookManager {
 /**
  * Get the routing personality loader. Prisma-backed PersonalityService in
  * legacy mode; the gateway-backed HttpPersonalityLoader in CONTEXT_MODE=service.
+ * Named "loader" not "service" because it returns an IPersonalityLoader — the
+ * caller must not assume the Prisma-backed implementation.
  * @throws Error if services not registered
  */
-export function getPersonalityService(): IPersonalityLoader {
+export function getPersonalityLoader(): IPersonalityLoader {
   if (personalityService === undefined) {
-    throw new Error('PersonalityService not registered. Call registerServices() first.');
+    throw new Error('Personality loader not registered. Call registerServices() first.');
   }
   return personalityService;
 }

--- a/services/bot-client/src/types/IPersonalityLoader.ts
+++ b/services/bot-client/src/types/IPersonalityLoader.ts
@@ -1,6 +1,6 @@
 /**
- * Interface for services that can load personalities
- * Implemented by both PersonalityService and PersonalityIdCache
+ * Interface for services that can load personalities.
+ * Implemented by PersonalityService, PersonalityIdCache, and HttpPersonalityLoader.
  */
 
 import type { LoadedPersonality } from '@tzurot/common-types';

--- a/services/bot-client/src/utils/contextWritePath.ts
+++ b/services/bot-client/src/utils/contextWritePath.ts
@@ -1,11 +1,11 @@
 /**
- * Context write path (Phase 2.5).
+ * Context write path.
  *
  * Everything governing WHO owns bot-client's Discord-event conversation
  * writes (assistant persist, edit/delete sync) lives here: the CONTEXT_MODE
  * toggle, the authoritative gateway-write helpers used in service mode, and
  * the legacy-mode dual-write mirrors. This module is deleted (along with the
- * legacy path and both flags) in 2.5d once service mode has burned in.
+ * legacy path and both flags) once service mode has fully burned in.
  */
 
 import { createLogger, SYNC_LIMITS, type MessageMetadata } from '@tzurot/common-types';


### PR DESCRIPTION
Context-relocation epic, **iii-cleanup** — the carried hygiene fold-forwards, closing out the slice before 2.5d. Six items (spans bot-client + ai-worker + api-gateway); items 1-5 are comment/test/rename hygiene, #6 is a contained extraction.

## The six

1. **Temporal-marker scrub.** Removed epic-slice labels (`Phase 2.5x` / `2.5a-d` / `iii-*`) from context-relocation module comments per `02-code-standards.md`, keeping the invariant each described. Confirmed no slice markers remain in non-test source (the `2.5s` matches are *seconds* of latency, left alone).
2. **Undefined-userId cache test** (`HttpPersonalityLoader`): the internal/no-userId key (`'\x00…'`) must not collide with a user-scoped result — added a test proving each is its own independent hop.
3. **`IPersonalityLoader` docstring**: "implemented by both" → the three real implementors (`PersonalityService`, `PersonalityIdCache`, `HttpPersonalityLoader`).
4. **Cache-key delimiter `::` → `\x00`** (NUL): collision-proof — NUL can't appear in a Discord snowflake or a personality name/slug/alias, so two distinct `(userId, nameOrId)` pairs can never collapse into one key.
5. **Rename `getPersonalityService()` → `getPersonalityLoader()`** (+ all 5 call/test sites): it returns an `IPersonalityLoader` — possibly the HTTP loader, not the Prisma service — so the name shouldn't promise the Prisma implementation.
6. **Extract `applyAssembledContext()`** from `ContextStep.sourceHistory`.

## On item 6 — correcting the review premise

The beta.129 release-review item that seeded this said the mutation is *"not idempotent — a second assembler invocation reads already-mutated input."* **That premise is false on inspection** (verified per the "verify reviewer claims before echoing" rule): `assembleCore` reads only `rawAssemblyInputs` + the scalar identity fields (`userId/channelId/serverId/isWeighIn/userName`) — *none* of the fields `sourceHistory` writes. Every write is a pure overwrite, so assemble+apply is **idempotent by construction**.

The mutation is also **load-bearing**: it's the cross-step propagation mechanism (the downstream `conversationContextBuilder` reads these surfaces straight off `jobContext`; there's no shared return channel between pipeline steps). A true "return-value pattern" needs a dataflow restructure that belongs in **2.5d**, where the legacy fallback is deleted and the path is revisited anyway.

So the proportionate fix here: extract the 11 writes into a named, documented `applyAssembledContext()` helper — isolating and explaining the side effect (the reviewer's *real* testability concern) — and document the idempotency + propagation invariants correctly. The full restructure is tracked for 2.5d.

## Verification

- `pnpm test` 18/18 green; `pnpm quality` green. No behavior change (renames, comments, one extracted helper, one new test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)