### PR TITLE
fix: support GLM-5 on z.ai coding plan + make config validation z.ai-aware

### DIFF
--- a/packages/common-types/src/constants/ai.test.ts
+++ b/packages/common-types/src/constants/ai.test.ts
@@ -3,7 +3,13 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { isFreeModel, GUEST_MODE, buildModelInfoUrl, isZaiCodingPlanModel } from './ai.js';
+import {
+  isFreeModel,
+  GUEST_MODE,
+  buildModelInfoUrl,
+  isZaiCodingPlanModel,
+  getZaiCodingPlanContextLength,
+} from './ai.js';
 
 describe('isFreeModel', () => {
   it('should return true for models ending with :free', () => {
@@ -49,9 +55,19 @@ describe('GUEST_MODE', () => {
 
 describe('buildModelInfoUrl', () => {
   describe('z.ai-coding direct route', () => {
+    it('should map glm-5 to its dedicated docs page', () => {
+      expect(buildModelInfoUrl('glm-5', 'zai-coding')).toBe('https://docs.z.ai/guides/llm/glm-5');
+    });
+
     it('should map glm-5.1 to its dedicated docs page', () => {
       expect(buildModelInfoUrl('glm-5.1', 'zai-coding')).toBe(
         'https://docs.z.ai/guides/llm/glm-5.1'
+      );
+    });
+
+    it('should map glm-5.2 to its dedicated docs page', () => {
+      expect(buildModelInfoUrl('glm-5.2', 'zai-coding')).toBe(
+        'https://docs.z.ai/guides/llm/glm-5.2'
       );
     });
 
@@ -153,8 +169,10 @@ describe('buildModelInfoUrl', () => {
 });
 
 describe('isZaiCodingPlanModel', () => {
-  it('should accept all four current coding-plan catalog entries', () => {
+  it('should accept all current coding-plan catalog entries', () => {
+    expect(isZaiCodingPlanModel('glm-5')).toBe(true);
     expect(isZaiCodingPlanModel('glm-5.1')).toBe(true);
+    expect(isZaiCodingPlanModel('glm-5.2')).toBe(true);
     expect(isZaiCodingPlanModel('glm-5-turbo')).toBe(true);
     expect(isZaiCodingPlanModel('glm-4.7')).toBe(true);
     expect(isZaiCodingPlanModel('glm-4.5-air')).toBe(true);
@@ -174,5 +192,40 @@ describe('isZaiCodingPlanModel', () => {
     expect(isZaiCodingPlanModel('glm-4.5-flash')).toBe(false); // hallucinated name from PR #921
     expect(isZaiCodingPlanModel('claude-sonnet-4')).toBe(false);
     expect(isZaiCodingPlanModel('')).toBe(false);
+  });
+});
+
+describe('getZaiCodingPlanContextLength', () => {
+  it('should return the catalog context length for bare model names', () => {
+    expect(getZaiCodingPlanContextLength('glm-5')).toBe(200_000);
+    expect(getZaiCodingPlanContextLength('glm-5.1')).toBe(200_000);
+    expect(getZaiCodingPlanContextLength('glm-5-turbo')).toBe(262_144);
+    expect(getZaiCodingPlanContextLength('glm-4.7')).toBe(200_000);
+    expect(getZaiCodingPlanContextLength('glm-4.5-air')).toBe(131_072);
+  });
+
+  it('should return 1M for glm-5.2 (z.ai-only flagship, not on OpenRouter)', () => {
+    // This is the load-bearing case: glm-5.2 never appears in the OpenRouter
+    // model cache, so the catalog is the ONLY context-length source for it.
+    expect(getZaiCodingPlanContextLength('glm-5.2')).toBe(1_000_000);
+  });
+
+  it('should strip the z-ai/ prefix before lookup', () => {
+    // Config validation and the runtime clamp pass the prefixed form; the
+    // catalog keys are bare.
+    expect(getZaiCodingPlanContextLength('z-ai/glm-5')).toBe(200_000);
+    expect(getZaiCodingPlanContextLength('z-ai/glm-5.2')).toBe(1_000_000);
+  });
+
+  it('should case-normalize before lookup', () => {
+    expect(getZaiCodingPlanContextLength('GLM-5')).toBe(200_000);
+    expect(getZaiCodingPlanContextLength('Z-AI/GLM-5.2')).toBe(1_000_000);
+  });
+
+  it('should return null for models not in the catalog', () => {
+    expect(getZaiCodingPlanContextLength('glm-99-future')).toBeNull();
+    expect(getZaiCodingPlanContextLength('z-ai/glm-99-future')).toBeNull();
+    expect(getZaiCodingPlanContextLength('anthropic/claude-sonnet-4')).toBeNull();
+    expect(getZaiCodingPlanContextLength('')).toBeNull();
   });
 });

--- a/packages/common-types/src/constants/ai.ts
+++ b/packages/common-types/src/constants/ai.ts
@@ -206,7 +206,7 @@ export const ZAI_VALIDATION_MODEL = 'glm-4.5-air';
 
 /**
  * Catalog of models served by z.ai's GLM Coding Plan endpoint
- * (`api.z.ai/api/coding/paas/v4`). Single source of truth for two things:
+ * (`api.z.ai/api/coding/paas/v4`). Single source of truth for three things:
  *
  * 1. **Membership** — `isZaiCodingPlanModel()` checks if a model exists on
  *    the plan. Used by `ProviderRouter` as a guardrail before auto-promoting
@@ -217,21 +217,46 @@ export const ZAI_VALIDATION_MODEL = 'glm-4.5-air';
  *    `docsUrl` for the response footer link. Most models have a dedicated
  *    docs page at `docs.z.ai/guides/llm/<model>`; `glm-4.5-air` is the
  *    exception — z.ai docs that variant on the parent `glm-4.5` page, so we
- *    link there instead. (Confirmed 2026-04-28 via z.ai docs check.)
+ *    link there instead.
  *
- * Source of truth for membership: docs.z.ai/devpack/overview. Source of
- * truth for docs URLs: docs.z.ai/llms.txt. Keys must stay lowercase to
- * match the case-normalized lookups; user-typed preset configs may use any
- * case so callers normalize before lookup.
+ * 3. **Context length** — `getZaiCodingPlanContextLength()` reads the
+ *    `contextLength` for the context-window cap. This is load-bearing: once
+ *    config validation accepts a z.ai model via the z.ai path (bypassing the
+ *    OpenRouter model cache), the catalog is the ONLY source for the model's
+ *    real context limit at both save-time validation and runtime clamp. A
+ *    z.ai-only model (`glm-5.2`, not on OpenRouter) would otherwise run
+ *    unclamped and overflow at the provider. Values are from OpenRouter's
+ *    live model cards (glm-5/5.1/4.7 = 200K, turbo = 262K, air = 131K) and
+ *    z.ai's GLM-5.2 announcement (1M); slightly conservative is safe because
+ *    the cap formula errs small.
+ *
+ * Source of truth for membership + context lengths: docs.z.ai/devpack/overview
+ * and the per-model cards. Source of truth for docs URLs: docs.z.ai/llms.txt.
+ * Keys must stay lowercase to match the case-normalized lookups; user-typed
+ * preset configs may use any case so callers normalize before lookup.
  */
-const ZAI_MODEL_CATALOG: Readonly<Record<string, { docsUrl: string }>> = {
-  'glm-5.1': { docsUrl: 'https://docs.z.ai/guides/llm/glm-5.1' },
-  'glm-5-turbo': { docsUrl: 'https://docs.z.ai/guides/llm/glm-5-turbo' },
-  'glm-4.7': { docsUrl: 'https://docs.z.ai/guides/llm/glm-4.7' },
+const ZAI_MODEL_CATALOG: Readonly<Record<string, { docsUrl: string; contextLength: number }>> = {
+  'glm-5': { docsUrl: 'https://docs.z.ai/guides/llm/glm-5', contextLength: 200_000 },
+  'glm-5.1': { docsUrl: 'https://docs.z.ai/guides/llm/glm-5.1', contextLength: 200_000 },
+  // glm-5.2 is z.ai's flagship and is NOT on OpenRouter yet — the catalog is
+  // its only context-length source, so the cap depends on this value.
+  'glm-5.2': { docsUrl: 'https://docs.z.ai/guides/llm/glm-5.2', contextLength: 1_000_000 },
+  'glm-5-turbo': { docsUrl: 'https://docs.z.ai/guides/llm/glm-5-turbo', contextLength: 262_144 },
+  'glm-4.7': { docsUrl: 'https://docs.z.ai/guides/llm/glm-4.7', contextLength: 200_000 },
   // glm-4.5-air uses the parent family page — z.ai docs the Air variant on
   // the same page as the regular glm-4.5; no per-model URL exists.
-  'glm-4.5-air': { docsUrl: 'https://docs.z.ai/guides/llm/glm-4.5' },
+  'glm-4.5-air': { docsUrl: 'https://docs.z.ai/guides/llm/glm-4.5', contextLength: 131_072 },
 };
+
+/**
+ * Prefix that marks an OpenRouter model as belonging to the z.ai namespace
+ * (e.g. `z-ai/glm-5`). Both runtime routing (`ProviderRouter`) and config
+ * validation key off this prefix to decide whether a model is a z.ai
+ * coding-plan candidate — the `provider` field is not present in the
+ * llm-config request schemas, so the prefix is the only signal available at
+ * validation time.
+ */
+export const ZAI_MODEL_PREFIX = 'z-ai/';
 
 /**
  * Fallback URL for z.ai-coding requests where the model name isn't in the
@@ -248,6 +273,24 @@ const ZAI_CODING_OVERVIEW_URL = 'https://docs.z.ai/devpack/overview';
  */
 export function isZaiCodingPlanModel(model: string): boolean {
   return model.toLowerCase() in ZAI_MODEL_CATALOG;
+}
+
+/**
+ * Look up a z.ai coding-plan model's context length from the catalog, in
+ * tokens. Strips an optional `z-ai/` prefix (validation and runtime both pass
+ * the prefixed form `z-ai/glm-5`, while ProviderRouter promotes to the bare
+ * `glm-5`) and case-normalizes before lookup. Returns `null` for any model not
+ * in the catalog — callers treat that as "not a z.ai coding-plan model" and
+ * fall back to their OpenRouter-based context source.
+ *
+ * This is the cap source for z.ai-only models (e.g. `glm-5.2`) that never
+ * appear in the OpenRouter model cache: without it they'd be saved and run
+ * with no context-window clamp.
+ */
+export function getZaiCodingPlanContextLength(model: string): number | null {
+  const lower = model.toLowerCase();
+  const bare = lower.startsWith(ZAI_MODEL_PREFIX) ? lower.slice(ZAI_MODEL_PREFIX.length) : lower;
+  return ZAI_MODEL_CATALOG[bare]?.contextLength ?? null;
 }
 
 /**

--- a/packages/common-types/src/constants/index.ts
+++ b/packages/common-types/src/constants/index.ts
@@ -14,7 +14,9 @@ export {
   GUEST_MODE,
   isFreeModel,
   ZAI_VALIDATION_MODEL,
+  ZAI_MODEL_PREFIX,
   isZaiCodingPlanModel,
+  getZaiCodingPlanContextLength,
   buildModelInfoUrl,
 } from './ai.js';
 

--- a/services/ai-worker/src/services/ProviderRouter.ts
+++ b/services/ai-worker/src/services/ProviderRouter.ts
@@ -34,10 +34,13 @@
  * deterministically without needing to know about the routing logic.
  */
 
-import { createLogger, AIProvider, isZaiCodingPlanModel } from '@tzurot/common-types';
+import {
+  createLogger,
+  AIProvider,
+  isZaiCodingPlanModel,
+  ZAI_MODEL_PREFIX,
+} from '@tzurot/common-types';
 import type { ApiKeyResolver } from './ApiKeyResolver.js';
-
-const ZAI_PREFIX = 'z-ai/';
 
 const logger = createLogger('ProviderRouter');
 
@@ -200,9 +203,9 @@ export class ProviderRouter {
     // with an already-namespaced model like `z-ai/glm-4.7` — concatenating would
     // produce `z-ai/z-ai/glm-4.7` and fail silently at the API. If the model is
     // already prefixed, use it verbatim.
-    const fallthroughModel = configuredModel.startsWith(ZAI_PREFIX)
+    const fallthroughModel = configuredModel.startsWith(ZAI_MODEL_PREFIX)
       ? configuredModel
-      : `${ZAI_PREFIX}${configuredModel}`;
+      : `${ZAI_MODEL_PREFIX}${configuredModel}`;
     const fallthroughResult = await this.apiKeyResolver.resolveApiKey(
       userId,
       AIProvider.OpenRouter
@@ -242,10 +245,10 @@ export class ProviderRouter {
     configuredModel: string,
     userId: string | undefined
   ): Promise<ResolvedRoute | null> {
-    if (!configuredModel.startsWith(ZAI_PREFIX)) {
+    if (!configuredModel.startsWith(ZAI_MODEL_PREFIX)) {
       return null;
     }
-    const bareModel = configuredModel.slice(ZAI_PREFIX.length).toLowerCase();
+    const bareModel = configuredModel.slice(ZAI_MODEL_PREFIX.length).toLowerCase();
     if (!isZaiCodingPlanModel(bareModel)) {
       logger.debug(
         { userId, configuredModel, reason: 'whitelist-miss' },
@@ -348,7 +351,7 @@ export class ProviderRouter {
  * explicit case before the OpenRouter default.
  */
 export function detectVisionProvider(modelName: string): AIProvider {
-  if (modelName.startsWith(ZAI_PREFIX)) {
+  if (modelName.startsWith(ZAI_MODEL_PREFIX)) {
     return AIProvider.ZaiCoding;
   }
   // Bare GLM names (no slash). The `glm-` prefix is z.ai's direct API

--- a/services/ai-worker/src/services/contextWindowResolver.test.ts
+++ b/services/ai-worker/src/services/contextWindowResolver.test.ts
@@ -51,4 +51,41 @@ describe('resolveEffectiveContextWindow', () => {
     // is ModelCapabilityChecker's responsibility, not the resolver's
     expect(checkModelContextLength).toHaveBeenCalledWith('some/model:free');
   });
+
+  describe('z.ai coding-plan models', () => {
+    it('clamps a z.ai-only model from the catalog even on a cache miss', async () => {
+      // glm-5.2 (1M context) is NOT on OpenRouter, so checkModelContextLength
+      // returns null. Without the catalog-first lookup this would resolve to
+      // "unknown" and run unclamped — the exact overflow Fix C guards against.
+      vi.mocked(checkModelContextLength).mockResolvedValue(null);
+
+      const result = await resolveEffectiveContextWindow(
+        personality({ model: 'z-ai/glm-5.2', contextWindowTokens: 900_000 })
+      );
+
+      expect(result).toBe(500_000); // computeContextCap(1_000_000) = 50%
+      // The catalog short-circuits before any Redis lookup.
+      expect(checkModelContextLength).not.toHaveBeenCalled();
+    });
+
+    it('passes through a within-cap configured value for a z.ai model', async () => {
+      const result = await resolveEffectiveContextWindow(
+        personality({ model: 'z-ai/glm-5', contextWindowTokens: 50_000 })
+      );
+
+      expect(result).toBe(50_000);
+      expect(checkModelContextLength).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the OpenRouter cache for non-catalog models', async () => {
+      vi.mocked(checkModelContextLength).mockResolvedValue(200000);
+
+      const result = await resolveEffectiveContextWindow(
+        personality({ model: 'anthropic/claude-sonnet-4', contextWindowTokens: 150000 })
+      );
+
+      expect(result).toBe(100000); // 50% of 200k
+      expect(checkModelContextLength).toHaveBeenCalledWith('anthropic/claude-sonnet-4');
+    });
+  });
 });

--- a/services/ai-worker/src/services/contextWindowResolver.ts
+++ b/services/ai-worker/src/services/contextWindowResolver.ts
@@ -8,7 +8,12 @@
  * default) that exceed what the model can actually hold.
  */
 
-import { createLogger, clampContextWindow, type LoadedPersonality } from '@tzurot/common-types';
+import {
+  createLogger,
+  clampContextWindow,
+  getZaiCodingPlanContextLength,
+  type LoadedPersonality,
+} from '@tzurot/common-types';
 import { checkModelContextLength } from '../redis.js';
 
 const logger = createLogger('ContextWindowResolver');
@@ -19,12 +24,27 @@ const logger = createLogger('ContextWindowResolver');
  * Unknown models (non-OpenRouter providers, model-cache miss) degrade
  * gracefully to the configured value. Logs when the clamp engages — that's
  * the "this preset is configured above the model's limit" signal.
+ *
+ * z.ai coding-plan models are resolved from the static catalog FIRST: a
+ * z.ai-only model (e.g. glm-5.2) never lands in the OpenRouter model cache, so
+ * without the catalog lookup it would resolve to "unknown" and run unclamped —
+ * exactly the overflow the gateway cap exists to prevent. The catalog matches
+ * whether the configured model is the prefixed `z-ai/glm-5` form or a bare
+ * promoted name.
  */
 export async function resolveEffectiveContextWindow(
   personality: LoadedPersonality
 ): Promise<number> {
   const configured = personality.contextWindowTokens;
-  const modelContextLength = await checkModelContextLength(personality.model);
+  // Intentional asymmetry with the gateway's save-time validation: that path
+  // gates the catalog lookup on the `z-ai/` prefix (a bare `glm-5` must NOT be
+  // saveable, since ProviderRouter only promotes prefixed models). Here we let
+  // `getZaiCodingPlanContextLength` accept a bare name too — a clamp only ever
+  // *reduces* the budget, so recognizing a stale bare-name config and capping
+  // it is strictly safer than leaving it unclamped. Save-correctness needs the
+  // guard; runtime-safety doesn't.
+  const zaiContextLength = getZaiCodingPlanContextLength(personality.model);
+  const modelContextLength = zaiContextLength ?? (await checkModelContextLength(personality.model));
   const effective = clampContextWindow(configured, modelContextLength);
   if (effective < configured) {
     // warn, not info: this fires on every generation until the stored config

--- a/services/api-gateway/src/routes/admin/llm-config.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.ts
@@ -91,7 +91,11 @@ function createCreateConfigHandler(
       return;
     }
 
-    if (!(await validateLlmConfigModelFields({ res, modelCache, body }))) {
+    // Global presets have no specific saving user — pass hasZaiCodingKey:true so
+    // z.ai-catalog models (incl. z.ai-only ones like glm-5.2) are validatable as
+    // global configs. Users with a z.ai key promote at runtime; users without
+    // one fall through to OpenRouter.
+    if (!(await validateLlmConfigModelFields({ res, modelCache, body, hasZaiCodingKey: true }))) {
       return;
     }
 
@@ -138,6 +142,7 @@ function createEditConfigHandler(
         modelCache,
         body,
         fallback: { service, configId: configId },
+        hasZaiCodingKey: true,
       }))
     ) {
       return;

--- a/services/api-gateway/src/routes/user/llm-config.test.ts
+++ b/services/api-gateway/src/routes/user/llm-config.test.ts
@@ -127,6 +127,9 @@ const mockPrisma = {
   personalityDefaultConfig: {
     count: vi.fn(),
   },
+  userApiKey: {
+    findFirst: vi.fn(),
+  },
   $executeRaw: vi.fn().mockResolvedValue(1),
   $transaction: vi.fn().mockImplementation(async (callback: (tx: unknown) => Promise<void>) => {
     const mockTx = {
@@ -195,6 +198,9 @@ describe('/user/llm-config routes', () => {
     mockPrisma.llmConfig.findFirst.mockResolvedValue(null);
     mockPrisma.llmConfig.findUnique.mockResolvedValue(null);
     mockPrisma.userPersonalityConfig.count.mockResolvedValue(0);
+    // Default: no z.ai-coding key (the common case). z.ai-specific tests
+    // override this to return a row.
+    mockPrisma.userApiKey.findFirst.mockResolvedValue(null);
   });
 
   describe('route factory', () => {
@@ -494,6 +500,40 @@ describe('/user/llm-config routes', () => {
           }),
         })
       );
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    it('should save a z.ai-only model (z-ai/glm-5.2) when the user has a z.ai-coding key', async () => {
+      // End-to-end route wiring: resolveProvisionedUserId → userHasActiveApiKey
+      // (returns a key) → validation takes the z.ai catalog path, so glm-5.2
+      // (absent from OpenRouter) saves instead of being rejected. No model
+      // cache is wired, proving validation succeeds from the catalog alone.
+      mockPrisma.userApiKey.findFirst.mockResolvedValue({ id: 'zai-key-1' });
+      mockPrisma.llmConfig.create.mockResolvedValue({
+        id: 'new-config',
+        name: 'GLM Config',
+        description: null,
+        model: 'z-ai/glm-5.2',
+        provider: 'openrouter',
+        visionModel: null,
+        isGlobal: false,
+        isDefault: false,
+        memoryScoreThreshold: { toNumber: () => 0.5 },
+        memoryLimit: 20,
+      });
+
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
+      const handler = getHandler(router, 'post', '/');
+      const { req, res } = createMockReqRes({ name: 'GLM Config', model: 'z-ai/glm-5.2' });
+
+      await handler(req, res);
+
+      expect(mockPrisma.userApiKey.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ provider: 'zai-coding', isActive: true }),
+        })
+      );
+      expect(mockPrisma.llmConfig.create).toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(201);
     });
 
@@ -844,6 +884,84 @@ describe('/user/llm-config routes', () => {
           }),
         })
       );
+    });
+
+    it('should wire the z.ai-coding key check into the update path', async () => {
+      // Proves createUpdateHandler runs userHasActiveApiKey → hasZaiCodingKey →
+      // validation (mirrors the create-path test). If that wiring were dropped,
+      // userApiKey.findFirst would not be called and this fails — the regression
+      // guard the reviewer asked for on the update handler specifically.
+      mockPrisma.userApiKey.findFirst.mockResolvedValue({ id: 'zai-key-1' });
+      mockPrisma.llmConfig.findUnique.mockResolvedValue({
+        id: 'config-123',
+        ownerId: 'user-uuid-123',
+        isGlobal: false,
+        name: 'My Config',
+        memoryScoreThreshold: { toNumber: () => 0.5 },
+        memoryLimit: 20,
+      });
+      mockPrisma.llmConfig.update.mockResolvedValue({
+        id: 'config-123',
+        name: 'My Config',
+        description: null,
+        model: 'z-ai/glm-5.2',
+        provider: 'openrouter',
+        visionModel: null,
+        isGlobal: false,
+        isDefault: false,
+        isFreeDefault: false,
+        ownerId: 'user-uuid-123',
+        advancedParameters: null,
+        memoryScoreThreshold: { toNumber: () => 0.5 },
+        memoryLimit: 20,
+      });
+
+      const router = createLlmConfigRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        llmConfigCacheInvalidation: mockCacheInvalidation,
+      });
+      const handler = getHandler(router, 'put', '/:id');
+      const { req, res } = createMockReqRes({ model: 'z-ai/glm-5.2' }, { id: 'config-123' });
+
+      await handler(req, res);
+
+      expect(mockPrisma.userApiKey.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ provider: 'zai-coding', isActive: true }),
+        })
+      );
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('should reject an update whose new name collides in the owner namespace', async () => {
+      // Covers buildUpdatePatchOrSendCollision's collision branch: the helper
+      // sends a 400 and returns null, so the handler returns without updating.
+      mockPrisma.llmConfig.findUnique.mockResolvedValue({
+        id: 'config-123',
+        ownerId: 'user-uuid-123',
+        isGlobal: false,
+        name: 'My Config',
+        memoryScoreThreshold: { toNumber: () => 0.5 },
+        memoryLimit: 20,
+      });
+      mockPrisma.llmConfig.findFirst.mockResolvedValue({ id: 'other-existing' });
+
+      const router = createLlmConfigRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        llmConfigCacheInvalidation: mockCacheInvalidation,
+      });
+      const handler = getHandler(router, 'put', '/:id');
+      const { req, res } = createMockReqRes({ name: 'Taken Name' }, { id: 'config-123' });
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('Taken Name'),
+        })
+      );
+      expect(mockPrisma.llmConfig.update).not.toHaveBeenCalled();
     });
 
     it('should invalidate cache on update', async () => {

--- a/services/api-gateway/src/routes/user/llm-config.ts
+++ b/services/api-gateway/src/routes/user/llm-config.ts
@@ -16,7 +16,9 @@ import {
   createLogger,
   isBotOwner,
   type LlmConfigSummary,
+  type PrismaClient,
   computeLlmConfigPermissions,
+  AIProvider,
   // Shared schemas from common-types - single source of truth
   LlmConfigCreateSchema,
   LlmConfigUpdateSchema,
@@ -43,6 +45,7 @@ import {
 import type { OpenRouterModelCache } from '../../services/OpenRouterModelCache.js';
 import { enrichWithModelContext } from '../../utils/modelValidation.js';
 import { validateLlmConfigModelFields } from '../../utils/llmConfigValidation.js';
+import { userHasActiveApiKey } from '../../utils/userHasActiveApiKey.js';
 import {
   applyOwnerNamePromotion,
   buildCollisionMessage,
@@ -130,7 +133,11 @@ function createGetHandler(service: LlmConfigService, modelCache?: OpenRouterMode
   };
 }
 
-function createCreateHandler(service: LlmConfigService, modelCache?: OpenRouterModelCache) {
+function createCreateHandler(
+  service: LlmConfigService,
+  prisma: PrismaClient,
+  modelCache?: OpenRouterModelCache
+) {
   return async (req: ProvisionedRequest, res: Response) => {
     const discordUserId = req.userId;
 
@@ -139,11 +146,15 @@ function createCreateHandler(service: LlmConfigService, modelCache?: OpenRouterM
       return;
     }
 
-    if (!(await validateLlmConfigModelFields({ res, modelCache, body }))) {
+    // resolveProvisionedUserId is a pure req-reader, free to run before
+    // validation — needed here so the z.ai key check can gate z.ai-catalog
+    // model validation.
+    const userId = resolveProvisionedUserId(req);
+    const hasZaiCodingKey = await userHasActiveApiKey(prisma, userId, AIProvider.ZaiCoding);
+
+    if (!(await validateLlmConfigModelFields({ res, modelCache, body, hasZaiCodingKey }))) {
       return;
     }
-
-    const userId = resolveProvisionedUserId(req);
 
     // Duplicate-name check is skipped when the client opts into
     // autoSuffixOnCollision (the preset clone flow): the service will bump
@@ -220,7 +231,68 @@ function createCreateHandler(service: LlmConfigService, modelCache?: OpenRouterM
   };
 }
 
-function createUpdateHandler(service: LlmConfigService, modelCache?: OpenRouterModelCache) {
+/**
+ * Build the update patch (applying owner-name promotion on owner edits) and
+ * verify the resulting name doesn't collide in the owner's namespace. Returns
+ * the patch on success, or `null` when a collision error has already been sent
+ * to `res` (caller returns immediately). Generic over the body type so the
+ * full update payload (advancedParameters, contextWindowTokens, …) survives —
+ * only the name/isGlobal fields drive promotion + collision logic.
+ */
+async function buildUpdatePatchOrSendCollision<
+  TBody extends { name?: string; isGlobal?: boolean },
+>(opts: {
+  res: Response;
+  service: LlmConfigService;
+  req: ProvisionedRequest;
+  body: TBody;
+  config: { name: string; isGlobal: boolean; ownerId: string };
+  configId: string;
+  isOwnedByRequester: boolean;
+}): Promise<TBody | null> {
+  const { res, service, req, body, config, configId, isOwnedByRequester } = opts;
+  const discordUserId = req.userId;
+
+  // Owner edits run the promotion helper; admin edits on non-owned configs
+  // apply the name verbatim (suffixing would mis-attribute provenance).
+  const user = { discordId: req.userId, discordUsername: getDiscordUsernameFromRequest(req) };
+  const patch = isOwnedByRequester ? applyOwnerNamePromotion(body, config, user) : { ...body };
+
+  // Compute post-update isGlobal so the collision check covers the cross-
+  // user global-namespace case when the user is promoting (or already
+  // promoted) their config.
+  const postIsGlobal = body.isGlobal ?? config.isGlobal;
+
+  // Check for duplicate name if a name is being applied (either user-supplied
+  // or normalized by the promotion helper). Bot-owner-editing-others uses
+  // the OWNER's userId for namespace scoping (the name lives in the
+  // owner's namespace, not the requester's).
+  if (
+    patch.name !== undefined &&
+    !(await ensureNoNameCollision(res, service, {
+      name: patch.name,
+      scope: { type: 'USER', userId: config.ownerId, discordId: discordUserId },
+      excludeId: configId,
+      postIsGlobal,
+      formatCollisionMessage: n =>
+        buildCollisionMessage({
+          effectiveName: n,
+          requestedName: body.name,
+          configKind: 'config',
+        }),
+    }))
+  ) {
+    return null;
+  }
+
+  return patch;
+}
+
+function createUpdateHandler(
+  service: LlmConfigService,
+  prisma: PrismaClient,
+  modelCache?: OpenRouterModelCache
+) {
   return async (req: ProvisionedRequest, res: Response) => {
     const discordUserId = req.userId;
     const configId = getRequiredParam(req.params.id, 'id');
@@ -230,18 +302,22 @@ function createUpdateHandler(service: LlmConfigService, modelCache?: OpenRouterM
       return;
     }
 
+    // Resolve userId before validation so the z.ai key check can gate
+    // z.ai-catalog model validation (mirrors the create handler).
+    const userId = resolveProvisionedUserId(req);
+    const hasZaiCodingKey = await userHasActiveApiKey(prisma, userId, AIProvider.ZaiCoding);
+
     if (
       !(await validateLlmConfigModelFields({
         res,
         modelCache,
         body,
         fallback: { service, configId: configId },
+        hasZaiCodingKey,
       }))
     ) {
       return;
     }
-
-    const userId = resolveProvisionedUserId(req);
 
     const config = await findConfigOrSendNotFound(
       res,
@@ -273,35 +349,16 @@ function createUpdateHandler(service: LlmConfigService, modelCache?: OpenRouterM
       return sendError(res, ErrorResponses.validationError('No fields to update'));
     }
 
-    // Owner edits run the promotion helper; admin edits on non-owned configs
-    // apply the name verbatim (suffixing would mis-attribute provenance).
-    const user = { discordId: req.userId, discordUsername: getDiscordUsernameFromRequest(req) };
-    const patch = isOwnedByRequester ? applyOwnerNamePromotion(body, config, user) : { ...body };
-
-    // Compute post-update isGlobal so the collision check covers the cross-
-    // user global-namespace case when the user is promoting (or already
-    // promoted) their config.
-    const postIsGlobal = body.isGlobal ?? config.isGlobal;
-
-    // Check for duplicate name if a name is being applied (either user-supplied
-    // or normalized by the promotion helper). Bot-owner-editing-others uses
-    // the OWNER's userId for namespace scoping (the name lives in the
-    // owner's namespace, not the requester's).
-    if (
-      patch.name !== undefined &&
-      !(await ensureNoNameCollision(res, service, {
-        name: patch.name,
-        scope: { type: 'USER', userId: config.ownerId, discordId: discordUserId },
-        excludeId: configId,
-        postIsGlobal,
-        formatCollisionMessage: n =>
-          buildCollisionMessage({
-            effectiveName: n,
-            requestedName: body.name,
-            configKind: 'config',
-          }),
-      }))
-    ) {
+    const patch = await buildUpdatePatchOrSendCollision({
+      res,
+      service,
+      req,
+      body,
+      config,
+      configId,
+      isOwnedByRequester,
+    });
+    if (patch === null) {
       return;
     }
 
@@ -424,13 +481,13 @@ export const handleGetUserLlmConfig = (deps: RouteDeps): RequestHandler =>
   asyncHandler(createGetHandler(buildService(deps), deps.modelCache));
 
 export const handleCreateUserLlmConfig = (deps: RouteDeps): RequestHandler =>
-  asyncHandler(createCreateHandler(buildService(deps), deps.modelCache));
+  asyncHandler(createCreateHandler(buildService(deps), deps.prisma, deps.modelCache));
 
 export const handleResolveUserLlmConfig = (deps: RouteDeps): RequestHandler =>
   asyncHandler(createResolveHandler(deps.prisma, deps.cascadeResolver));
 
 export const handleUpdateUserLlmConfig = (deps: RouteDeps): RequestHandler =>
-  asyncHandler(createUpdateHandler(buildService(deps), deps.modelCache));
+  asyncHandler(createUpdateHandler(buildService(deps), deps.prisma, deps.modelCache));
 
 export const handleDeleteUserLlmConfig = (deps: RouteDeps): RequestHandler =>
   asyncHandler(createDeleteHandler(buildService(deps)));

--- a/services/api-gateway/src/utils/llmConfigValidation.test.ts
+++ b/services/api-gateway/src/utils/llmConfigValidation.test.ts
@@ -48,8 +48,32 @@ describe('validateLlmConfigModelFields', () => {
       });
 
       expect(result).toBe(true);
-      expect(mockValidateModelAndContextWindow).toHaveBeenCalledWith(mockModelCache, 'gpt-4', 8000);
+      expect(mockValidateModelAndContextWindow).toHaveBeenCalledWith(
+        mockModelCache,
+        'gpt-4',
+        8000,
+        false
+      );
       expect(mockSendError).not.toHaveBeenCalled();
+    });
+
+    it('threads hasZaiCodingKey through to validateModelAndContextWindow', async () => {
+      mockValidateModelAndContextWindow.mockResolvedValue({});
+
+      const result = await validateLlmConfigModelFields({
+        res: mockRes,
+        modelCache: mockModelCache,
+        body: { model: 'z-ai/glm-5.2', contextWindowTokens: 100000 },
+        hasZaiCodingKey: true,
+      });
+
+      expect(result).toBe(true);
+      expect(mockValidateModelAndContextWindow).toHaveBeenCalledWith(
+        mockModelCache,
+        'z-ai/glm-5.2',
+        100000,
+        true
+      );
     });
 
     it('returns false and sends error when validation fails', async () => {
@@ -96,7 +120,8 @@ describe('validateLlmConfigModelFields', () => {
       expect(mockValidateModelAndContextWindow).toHaveBeenCalledWith(
         mockModelCache,
         undefined,
-        8000
+        8000,
+        false
       );
       expect(mockSendError).not.toHaveBeenCalled();
     });
@@ -131,7 +156,8 @@ describe('validateLlmConfigModelFields', () => {
       expect(mockValidateModelAndContextWindow).toHaveBeenCalledWith(
         mockModelCache,
         'claude-3-opus',
-        undefined
+        undefined,
+        false
       );
     });
 
@@ -151,7 +177,8 @@ describe('validateLlmConfigModelFields', () => {
       expect(mockValidateModelAndContextWindow).toHaveBeenCalledWith(
         mockModelCache,
         'existing-model',
-        16000
+        16000,
+        false
       );
     });
 
@@ -171,7 +198,8 @@ describe('validateLlmConfigModelFields', () => {
       expect(mockValidateModelAndContextWindow).toHaveBeenCalledWith(
         mockModelCache,
         'new-model',
-        32000
+        32000,
+        false
       );
     });
 
@@ -209,7 +237,8 @@ describe('validateLlmConfigModelFields', () => {
       expect(mockValidateModelAndContextWindow).toHaveBeenCalledWith(
         mockModelCache,
         undefined,
-        8000
+        8000,
+        false
       );
     });
   });

--- a/services/api-gateway/src/utils/llmConfigValidation.ts
+++ b/services/api-gateway/src/utils/llmConfigValidation.ts
@@ -55,6 +55,15 @@ export interface ValidateLlmConfigModelFieldsOptions {
     contextWindowTokens?: number;
   };
   /**
+   * Whether the saving user has an active z.ai-coding API key. Gates the z.ai
+   * catalog validation path in `validateModelAndContextWindow`: a user with a
+   * key gets `z-ai/<model>` requests promoted to z.ai-direct at runtime, so
+   * the model must be validated against z.ai's catalog (not OpenRouter). Admin
+   * /global configs pass `true` (any user with a key can use the preset; users
+   * without one fall through to OpenRouter at runtime). Defaults to `false`.
+   */
+  hasZaiCodingKey?: boolean;
+  /**
    * Only present on update-path calls. Lets the helper fetch the current
    * model if the update body omits `model` but changes `contextWindowTokens`.
    */
@@ -76,7 +85,7 @@ export interface ValidateLlmConfigModelFieldsOptions {
 export async function validateLlmConfigModelFields(
   opts: ValidateLlmConfigModelFieldsOptions
 ): Promise<boolean> {
-  const { res, modelCache, body, fallback } = opts;
+  const { res, modelCache, body, fallback, hasZaiCodingKey = false } = opts;
 
   // Update path: skip entirely when neither model nor contextWindowTokens is present.
   // A no-op update doesn't need model validation.
@@ -100,7 +109,8 @@ export async function validateLlmConfigModelFields(
   const result = await validateModelAndContextWindow(
     modelCache,
     effectiveModel,
-    body.contextWindowTokens
+    body.contextWindowTokens,
+    hasZaiCodingKey
   );
 
   if (result.error !== undefined) {

--- a/services/api-gateway/src/utils/modelValidation.test.ts
+++ b/services/api-gateway/src/utils/modelValidation.test.ts
@@ -133,6 +133,74 @@ describe('validateModelAndContextWindow', () => {
     const result = await validateModelAndContextWindow(cache, 'test/boundary', undefined);
     expect(result.contextWindowCap).toBe(32768); // Math.floor(65537 / 2)
   });
+
+  describe('z.ai coding-plan path (hasZaiCodingKey)', () => {
+    it('should validate z.ai-only models against the catalog without touching OpenRouter', async () => {
+      // glm-5.2 is NOT on OpenRouter — the cache returns null for it. With a
+      // z.ai key, validation must succeed from the catalog (1M context) and
+      // never consult the cache.
+      const cache = createMockModelCache(null);
+      const result = await validateModelAndContextWindow(cache, 'z-ai/glm-5.2', undefined, true);
+      expect(result.error).toBeUndefined();
+      expect(result.contextWindowCap).toBe(500_000); // 50% of 1M
+      expect(cache.getModelById).not.toHaveBeenCalled();
+    });
+
+    it('should cap (not skip) z.ai-accepted models — reject an oversized contextWindowTokens', async () => {
+      // Proves the z.ai path enforces the cap rather than waving the model
+      // through: 600k > the 500k cap on glm-5.2's 1M context.
+      const cache = createMockModelCache(null);
+      const result = await validateModelAndContextWindow(cache, 'z-ai/glm-5.2', 600_000, true);
+      expect(result.error).toContain("exceeds the safe limit for 'z-ai/glm-5.2'");
+      expect(result.error).toContain('1000K');
+      expect(result.error).toContain('500K');
+      expect(result.contextWindowCap).toBe(500_000);
+    });
+
+    it('should accept a within-cap contextWindowTokens for a z.ai model', async () => {
+      const cache = createMockModelCache(null);
+      const result = await validateModelAndContextWindow(cache, 'z-ai/glm-5', 100_000, true);
+      expect(result.error).toBeUndefined();
+      expect(result.contextWindowCap).toBe(100_000); // 50% of 200k
+    });
+
+    it('should fall through to OpenRouter when the user has no z.ai key', async () => {
+      // Without a key, a z.ai-only model is NOT promoted at runtime, so it must
+      // be validated against OpenRouter — where it is absent → rejected.
+      const cache = createMockModelCache(null);
+      const result = await validateModelAndContextWindow(cache, 'z-ai/glm-5.2', undefined, false);
+      expect(result.error).toContain("Model 'z-ai/glm-5.2' not found");
+      expect(cache.getModelById).toHaveBeenCalledWith('z-ai/glm-5.2');
+    });
+
+    it('should NOT take the z.ai path for a bare (unprefixed) catalog name', async () => {
+      // Regression guard: getZaiCodingPlanContextLength('glm-5') returns 200k
+      // (it accepts bare names for the runtime resolver), but ProviderRouter
+      // only promotes z-ai/-prefixed models. A saved bare `glm-5` must validate
+      // against OpenRouter — where it's absent → rejected — not short-circuit on
+      // the catalog and save a config runtime can't honor.
+      const cache = createMockModelCache(null);
+      const result = await validateModelAndContextWindow(cache, 'glm-5', undefined, true);
+      expect(result.error).toContain("Model 'glm-5' not found");
+      expect(cache.getModelById).toHaveBeenCalledWith('glm-5');
+    });
+
+    it('should fall through to OpenRouter for non-catalog models even with a key', async () => {
+      // hasZaiCodingKey:true must not short-circuit a non-z.ai model — it isn't
+      // in the catalog, so the OpenRouter path still owns it.
+      const model = createMockModel({ contextLength: 200000 });
+      const cache = createMockModelCache(model);
+      const result = await validateModelAndContextWindow(
+        cache,
+        'anthropic/claude-sonnet-4',
+        undefined,
+        true
+      );
+      expect(result.error).toBeUndefined();
+      expect(result.contextWindowCap).toBe(100000);
+      expect(cache.getModelById).toHaveBeenCalledWith('anthropic/claude-sonnet-4');
+    });
+  });
 });
 
 describe('enrichWithModelContext', () => {
@@ -196,5 +264,40 @@ describe('enrichWithModelContext', () => {
 
     expect(response.modelContextLength).toBe(32768);
     expect(response.contextWindowCap).toBe(24576); // 32768 * 0.75
+  });
+
+  it('should enrich z.ai-only models from the catalog without the cache', async () => {
+    // glm-5.2 is absent from OpenRouter; the dashboard cap must still resolve
+    // from the catalog (and not consult the cache).
+    const cache = createMockModelCache(null);
+    const response: { modelContextLength?: number; contextWindowCap?: number } = {};
+
+    await enrichWithModelContext(response, 'z-ai/glm-5.2', cache);
+
+    expect(response.modelContextLength).toBe(1_000_000);
+    expect(response.contextWindowCap).toBe(500_000);
+    expect(cache.getModelById).not.toHaveBeenCalled();
+  });
+
+  it('should enrich z.ai models even when the cache is undefined', async () => {
+    const response: { modelContextLength?: number; contextWindowCap?: number } = {};
+
+    await enrichWithModelContext(response, 'z-ai/glm-5', undefined);
+
+    expect(response.modelContextLength).toBe(200_000);
+    expect(response.contextWindowCap).toBe(100_000);
+  });
+
+  it('should NOT enrich a bare (unprefixed) catalog name from the z.ai catalog', async () => {
+    // Mirrors the validation prefix gate: bare `glm-5` runs on OpenRouter at
+    // runtime, so its cap must come from the cache (here a miss → no fields).
+    const cache = createMockModelCache(null);
+    const response: { modelContextLength?: number; contextWindowCap?: number } = {};
+
+    await enrichWithModelContext(response, 'glm-5', cache);
+
+    expect(response.modelContextLength).toBeUndefined();
+    expect(response.contextWindowCap).toBeUndefined();
+    expect(cache.getModelById).toHaveBeenCalledWith('glm-5');
   });
 });

--- a/services/api-gateway/src/utils/modelValidation.ts
+++ b/services/api-gateway/src/utils/modelValidation.ts
@@ -5,7 +5,11 @@
  * Used by both user and admin LLM config routes.
  */
 
-import { computeContextCap } from '@tzurot/common-types';
+import {
+  computeContextCap,
+  getZaiCodingPlanContextLength,
+  ZAI_MODEL_PREFIX,
+} from '@tzurot/common-types';
 import type { OpenRouterModelCache } from '../services/OpenRouterModelCache.js';
 
 /**
@@ -20,26 +24,90 @@ export interface ModelValidationResult {
 }
 
 /**
- * Validate a model ID against the OpenRouter model cache and enforce
+ * Compute the graduated context-window cap for a model and check the requested
+ * contextWindowTokens against it. Shared by the OpenRouter and z.ai validation
+ * paths so both produce identical cap math and error wording. The only
+ * difference between the two paths is where `contextLength` comes from
+ * (OpenRouter cache vs. z.ai catalog).
+ */
+function checkContextWindowCap(
+  modelId: string,
+  contextWindowTokens: number | undefined,
+  contextLength: number
+): ModelValidationResult {
+  const cap = computeContextCap(contextLength);
+  if (contextWindowTokens !== undefined && contextWindowTokens > cap) {
+    const contextK = Math.round(contextLength / 1000);
+    const capK = Math.round(cap / 1000);
+    return {
+      error:
+        `Context window setting (${contextWindowTokens} tokens) exceeds the safe limit for '${modelId}'. ` +
+        `Model supports ${contextK}K tokens; maximum allowed for this model is ${capK}K (${cap} tokens) ` +
+        `to leave room for the response. Reduce the Context Window value before saving.`,
+      contextWindowCap: cap,
+    };
+  }
+  return { contextWindowCap: cap };
+}
+
+/**
+ * Validate a model ID and enforce
  * contextWindowTokens <= computeContextCap(context_length) — the graduated
  * headroom cap shared with ai-worker's runtime clamp (see
  * common-types/utils/contextWindowCap.ts for the rationale).
  *
- * Gracefully degrades: if the model cache is unavailable (e.g., OpenRouter
- * is down), validation is skipped and the request proceeds.
+ * Two validation paths, mirroring runtime provider routing:
+ *
+ * 1. **z.ai catalog** (when `hasZaiCodingKey` and the model is a `z-ai/<model>`
+ *    in the coding-plan catalog): validate against the catalog's context
+ *    length. This mirrors `ProviderRouter.tryAutoPromoteToZai` — a user with a
+ *    z.ai-coding key will have the request promoted to z.ai-direct at runtime,
+ *    so it must be validated against z.ai's limits, not OpenRouter's. It also
+ *    unblocks z.ai-only models (e.g. `glm-5.2`) that aren't on OpenRouter at
+ *    all — while still capping them, so a bad config can't overflow at the
+ *    provider.
+ *
+ * 2. **OpenRouter cache** (everything else): validate against the cache and
+ *    reject on miss. Gracefully degrades: if the cache is unavailable (e.g.,
+ *    OpenRouter is down), validation is skipped and the request proceeds.
  *
  * @param modelCache - OpenRouter model cache (may be undefined if not wired)
  * @param modelId - The model ID to validate (e.g., "anthropic/claude-sonnet-4")
  * @param contextWindowTokens - Optional context window setting to validate
+ * @param hasZaiCodingKey - Whether the saving user has an active z.ai-coding
+ *   key (admin/global configs pass `true`). Gates the z.ai catalog path.
  * @returns Validation result with optional error message
  */
 export async function validateModelAndContextWindow(
   modelCache: OpenRouterModelCache | undefined,
   modelId: string | undefined,
-  contextWindowTokens: number | undefined
+  contextWindowTokens: number | undefined,
+  hasZaiCodingKey = false
 ): Promise<ModelValidationResult> {
+  if (modelId === undefined) {
+    return {};
+  }
+
+  // z.ai path first: a `z-ai/`-prefixed coding-plan model + a key means runtime
+  // will promote to z.ai-direct, so validate against the catalog (not
+  // OpenRouter). Falls through to the OpenRouter path for non-catalog models or
+  // when no key.
+  //
+  // The prefix guard is load-bearing: `getZaiCodingPlanContextLength` also
+  // accepts BARE names (`glm-5`) because the runtime resolver sees the promoted
+  // bare form. But ProviderRouter only promotes `z-ai/`-prefixed models, so a
+  // saved bare `glm-5` would NOT promote — it'd hit OpenRouter as a bare ID that
+  // doesn't exist there. Validation must mirror the router's prefix gate, or it
+  // accepts a config runtime can't honor.
+  if (hasZaiCodingKey && modelId.startsWith(ZAI_MODEL_PREFIX)) {
+    const zaiContextLength = getZaiCodingPlanContextLength(modelId);
+    if (zaiContextLength !== null) {
+      return checkContextWindowCap(modelId, contextWindowTokens, zaiContextLength);
+    }
+  }
+
   // No cache available — skip validation gracefully
-  if (modelCache === undefined || modelId === undefined) {
+  if (modelCache === undefined) {
     return {};
   }
 
@@ -55,20 +123,7 @@ export async function validateModelAndContextWindow(
     };
   }
 
-  const cap = computeContextCap(model.contextLength);
-  if (contextWindowTokens !== undefined && contextWindowTokens > cap) {
-    const contextK = Math.round(model.contextLength / 1000);
-    const capK = Math.round(cap / 1000);
-    return {
-      error:
-        `Context window setting (${contextWindowTokens} tokens) exceeds the safe limit for '${modelId}'. ` +
-        `Model supports ${contextK}K tokens; maximum allowed for this model is ${capK}K (${cap} tokens) ` +
-        `to leave room for the response. Reduce the Context Window value before saving.`,
-      contextWindowCap: cap,
-    };
-  }
-
-  return { contextWindowCap: cap };
+  return checkContextWindowCap(modelId, contextWindowTokens, model.contextLength);
 }
 
 /** Object with optional model context fields, set by enrichWithModelContext */
@@ -79,8 +134,12 @@ interface ModelContextEnrichable {
 
 /**
  * Enrich an API response object with model context window info.
- * Adds `modelContextLength` and `contextWindowCap` fields if the model
- * is found in the cache. Gracefully skips if cache or model is unavailable.
+ * Adds `modelContextLength` and `contextWindowCap` fields if the model's
+ * context length is resolvable. Gracefully skips if neither source has it.
+ *
+ * Two resolution sources, matching the validation paths: z.ai catalog first
+ * (so z.ai-only models like `glm-5.2` — absent from the OpenRouter cache —
+ * still show their cap in the dashboard), then the OpenRouter cache.
  *
  * Used by GET/create/update handlers so the bot-client can display
  * context window cap info in the preset dashboard.
@@ -90,7 +149,23 @@ export async function enrichWithModelContext(
   model: string | undefined,
   modelCache: OpenRouterModelCache | undefined
 ): Promise<void> {
-  if (modelCache === undefined || model === undefined) {
+  if (model === undefined) {
+    return;
+  }
+
+  // Mirror the validation path's prefix gate: only `z-ai/`-prefixed models
+  // resolve from the z.ai catalog. A bare `glm-5` runs on OpenRouter at
+  // runtime, so its dashboard cap must come from the OpenRouter cache too.
+  if (model.startsWith(ZAI_MODEL_PREFIX)) {
+    const zaiContextLength = getZaiCodingPlanContextLength(model);
+    if (zaiContextLength !== null) {
+      response.modelContextLength = zaiContextLength;
+      response.contextWindowCap = computeContextCap(zaiContextLength);
+      return;
+    }
+  }
+
+  if (modelCache === undefined) {
     return;
   }
   const modelInfo = await modelCache.getModelById(model);

--- a/services/api-gateway/src/utils/userHasActiveApiKey.test.ts
+++ b/services/api-gateway/src/utils/userHasActiveApiKey.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AIProvider, type PrismaClient } from '@tzurot/common-types';
+import { userHasActiveApiKey } from './userHasActiveApiKey.js';
+
+const mockFindFirst = vi.fn();
+const mockPrisma = {
+  userApiKey: { findFirst: mockFindFirst },
+} as unknown as PrismaClient;
+
+describe('userHasActiveApiKey', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns true when an active key row exists', async () => {
+    mockFindFirst.mockResolvedValue({ id: 'key-1' });
+
+    const result = await userHasActiveApiKey(mockPrisma, 'user-uuid', AIProvider.ZaiCoding);
+
+    expect(result).toBe(true);
+    expect(mockFindFirst).toHaveBeenCalledWith({
+      where: { userId: 'user-uuid', provider: AIProvider.ZaiCoding, isActive: true },
+      select: { id: true },
+    });
+  });
+
+  it('returns false when no active key row exists', async () => {
+    mockFindFirst.mockResolvedValue(null);
+
+    const result = await userHasActiveApiKey(mockPrisma, 'user-uuid', AIProvider.ZaiCoding);
+
+    expect(result).toBe(false);
+  });
+
+  it('filters on isActive: true (an inactive-only key reads as absent)', async () => {
+    // The query itself encodes the isActive filter; this asserts the where
+    // clause so a future refactor that drops the filter is caught.
+    mockFindFirst.mockResolvedValue(null);
+
+    await userHasActiveApiKey(mockPrisma, 'user-uuid', AIProvider.OpenRouter);
+
+    expect(mockFindFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ isActive: true }),
+      })
+    );
+  });
+});

--- a/services/api-gateway/src/utils/userHasActiveApiKey.ts
+++ b/services/api-gateway/src/utils/userHasActiveApiKey.ts
@@ -1,0 +1,34 @@
+/**
+ * Active-API-key presence check.
+ *
+ * Answers "does this user have an active key for provider X?" without ever
+ * loading the key material. Used by the LLM-config validation path to decide
+ * whether to validate a model against a provider-specific catalog (z.ai) — a
+ * user with an active z.ai-coding key has their `z-ai/<model>` requests
+ * promoted to z.ai-direct at runtime, so the model must be validated against
+ * z.ai's catalog rather than OpenRouter's.
+ */
+
+import type { AIProvider, PrismaClient } from '@tzurot/common-types';
+
+/**
+ * Return `true` if the user has an active API key for the given provider.
+ *
+ * `(userId, provider)` is unique in the schema, so at most one row matches —
+ * but we use `findFirst` rather than `findUnique` because the query also
+ * filters on `isActive`, which isn't part of the unique key (`findUnique`'s
+ * `where` only accepts the unique fields). The `@@index([userId, provider])`
+ * still makes this an indexed lookup. Selects only `id` — key material is
+ * never read.
+ */
+export async function userHasActiveApiKey(
+  prisma: PrismaClient,
+  userId: string,
+  provider: AIProvider
+): Promise<boolean> {
+  const key = await prisma.userApiKey.findFirst({
+    where: { userId, provider, isActive: true },
+    select: { id: true },
+  });
+  return key !== null;
+}


### PR DESCRIPTION
## Problem

Two coupled gaps stopped the z.ai GLM Coding Plan from working for newer GLM-5 models:

1. **`glm-5` / `glm-5.2` missing from the catalog.** `ZAI_MODEL_CATALOG` only listed `glm-5.1`/`glm-5-turbo`/`glm-4.7`/`glm-4.5-air`. `isZaiCodingPlanModel()` gates `ProviderRouter.tryAutoPromoteToZai`, so a `z-ai/glm-5` preset never auto-promoted onto the user's coding plan — it silently ran on OpenRouter instead. That's the observed "5.1 works, 5 doesn't" asymmetry.
2. **Config-save validation was provider-blind.** `validateModelAndContextWindow` validated **every** model against OpenRouter's cache and rejected on miss — so a z.ai-only model (`glm-5.2`, not on OpenRouter yet) couldn't be saved at all, even though z.ai serves it directly.

## Fix (one PR, three coordinated changes)

Both new paths **cap context at save-time AND runtime** from a single catalog source, so a bad config can't overflow at the provider (the beta.129 failure class).

### A — Catalog (`common-types`)
- Add `glm-5` (200K) and `glm-5.2` (1M, z.ai-only flagship).
- Every entry now carries a `contextLength` (load-bearing for the cap).
- New `getZaiCodingPlanContextLength(model)` helper + shared `ZAI_MODEL_PREFIX` constant (`ProviderRouter` now imports it instead of a local copy).

### B — z.ai-aware validation (`api-gateway`)
- `validateModelAndContextWindow` gains a z.ai catalog short-circuit gated on a new `hasZaiCodingKey` flag — mirrors `ProviderRouter.tryAutoPromoteToZai`. It **computes and enforces** the graduated cap from the catalog, unblocking z.ai-only models while still capping them.
- `enrichWithModelContext` resolves z.ai caps from the catalog too (dashboard display).
- New `userHasActiveApiKey` helper feeds the flag: user routes query the saving user's z.ai-coding key; admin/global routes pass `true`.

### C — z.ai-aware runtime clamp (`ai-worker`)
- `contextWindowResolver` consults the catalog **before** the OpenRouter cache, so a z.ai-only model (glm-5.2, cache miss) still clamps.

## Config form

Use the prefixed form `z-ai/glm-5` (matches runtime routing). Bare `glm-5` is intentionally not detected as z.ai — out of scope.

## Test plan

- [x] `pnpm quality` green
- [x] common-types / api-gateway / ai-worker suites green (catalog membership + `getZaiCodingPlanContextLength`; z.ai accept+cap with key, reject oversized, fall through without key; `userHasActiveApiKey`; runtime catalog-first clamp on cache miss)
- [ ] **Dev burn-in (needs the z.ai-coding key on dev):** save `z-ai/glm-5` → confirm it saves and a chat logs the promoted z.ai-direct path; save `z-ai/glm-5.2` → confirm it now saves and clamps at generation time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)