### PR TITLE
fix: update stale /wallet command refs to /settings apikey set

### DIFF
--- a/services/ai-worker/src/jobs/ImageDescriptionJob.test.ts
+++ b/services/ai-worker/src/jobs/ImageDescriptionJob.test.ts
@@ -733,7 +733,7 @@ describe('ImageDescriptionJob', () => {
       // Each image gets the source-aware fallback description.
       expect(result.success).toBe(true);
       expect(result.descriptions).toHaveLength(1);
-      expect(result.descriptions?.[0]?.description).toContain('check /wallet');
+      expect(result.descriptions?.[0]?.description).toContain('check /settings apikey set');
       // describeImage / withRetry NOT invoked — the short-circuit fired before
       // any vision call.
       expect(mockWithRetry).not.toHaveBeenCalled();

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/DependencyStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/DependencyStep.test.ts
@@ -1121,7 +1121,7 @@ describe('DependencyStep', () => {
       });
       const synthetic = result.preprocessing?.extendedContextAttachments;
       expect(synthetic).toHaveLength(1);
-      expect(synthetic?.[0]?.description).toContain('check /wallet');
+      expect(synthetic?.[0]?.description).toContain('check /settings apikey set');
     });
   });
 });

--- a/services/ai-worker/src/services/multimodal/VisionProcessor.test.ts
+++ b/services/ai-worker/src/services/multimodal/VisionProcessor.test.ts
@@ -514,7 +514,9 @@ describe('VisionProcessor', () => {
           loggingContext: { apiKeySource: 'user' },
         });
 
-        expect(result).toBe('[Image unavailable: your API key was rejected — check /wallet]');
+        expect(result).toBe(
+          '[Image unavailable: your API key was rejected — check /settings apikey set for the vision provider key]'
+        );
       });
 
       it('should return system-key-specific message when apiKeySource is "system"', async () => {

--- a/services/ai-worker/src/services/multimodal/VisionProcessor.ts
+++ b/services/ai-worker/src/services/multimodal/VisionProcessor.ts
@@ -381,7 +381,7 @@ export const ATTACHMENT_BOUND_FAILURE_CATEGORIES: ReadonlySet<ApiErrorCategory> 
  *
  * AUTH gets a source-aware variant: a system-key failure shouldn't blame the user
  * for "API key issue" wording (they'd think their Discord account is broken),
- * while a user-key failure points them at `/wallet` to fix the underlying key.
+ * while a user-key failure points them at `/settings apikey set` to fix the underlying key.
  * Other categories use either `FAILURE_LABELS` (attachment-bound) or the generic
  * "temporarily unavailable" message.
  */
@@ -391,7 +391,7 @@ function buildFailureFallback(
 ): string {
   if (category === ApiErrorCategory.AUTHENTICATION) {
     if (apiKeySource === 'user') {
-      return '[Image unavailable: your API key was rejected — check /wallet]';
+      return '[Image unavailable: your API key was rejected — check /settings apikey set for the vision provider key]';
     }
     // Unknown source defaults to the system-side wording (same as `apiKeySource === 'system'`):
     // a user can't act on "API key issue" if they don't know whose key. Defaulting to the

--- a/services/ai-worker/src/services/multimodal/visionAuthResolver.test.ts
+++ b/services/ai-worker/src/services/multimodal/visionAuthResolver.test.ts
@@ -298,7 +298,7 @@ describe('buildVisionAuthFailureResults', () => {
 
     expect(results).toHaveLength(2);
     expect(results[0]?.type).toBe(AttachmentType.Image);
-    expect(results[0]?.description).toContain('check /wallet');
+    expect(results[0]?.description).toContain('check /settings apikey set');
     expect(results[0]?.originalUrl).toBe('https://cdn.discordapp.com/img1.png');
     expect(results[1]?.originalUrl).toBe('https://cdn.discordapp.com/img2.png');
 

--- a/services/ai-worker/src/services/multimodal/visionAuthResolver.ts
+++ b/services/ai-worker/src/services/multimodal/visionAuthResolver.ts
@@ -54,10 +54,10 @@ export interface VisionAuth {
  *
  * The wording is read by the LLM in the chat context, so it's phrased as a
  * description (not a UI error). The user sees the personality acknowledge
- * the missing image with the embedded "/wallet" hint.
+ * the missing image with the embedded "/settings apikey set" hint.
  */
 export const VISION_AUTH_FAIL_FAST_DESCRIPTION =
-  '[Image unavailable: your API key was rejected — check /wallet for the vision provider key]';
+  '[Image unavailable: your API key was rejected — check /settings apikey set for the vision provider key]';
 
 /**
  * Inputs for `resolveVisionAuth` — bundled into an options object to keep the

--- a/services/bot-client/src/commands/settings/apikey/remove.ts
+++ b/services/bot-client/src/commands/settings/apikey/remove.ts
@@ -21,7 +21,7 @@ import { getProviderDisplayName } from '../../../utils/providers.js';
 const logger = createLogger('settings-apikey-remove');
 
 /**
- * Handle /wallet remove <provider> subcommand
+ * Handle /settings apikey remove <provider> subcommand
  * Removes the API key for the specified provider
  *
  * Receives DeferredCommandContext (no deferReply method!)

--- a/services/bot-client/src/commands/settings/apikey/set.ts
+++ b/services/bot-client/src/commands/settings/apikey/set.ts
@@ -21,7 +21,7 @@ import { ApikeyCustomIds } from '../../../utils/customIds.js';
 const logger = createLogger('settings-apikey-set');
 
 /**
- * Handle /wallet set <provider> subcommand
+ * Handle /settings apikey set <provider> subcommand
  * Shows a modal for secure API key input
  *
  * Receives ModalCommandContext (has showModal method!)

--- a/services/bot-client/src/commands/settings/apikey/test.ts
+++ b/services/bot-client/src/commands/settings/apikey/test.ts
@@ -21,7 +21,7 @@ import { getProviderDisplayName } from '../../../utils/providers.js';
 const logger = createLogger('settings-apikey-test');
 
 /**
- * Handle /wallet test <provider> subcommand
+ * Handle /settings apikey test <provider> subcommand
  * Tests the API key validity
  *
  * Receives DeferredCommandContext (no deferReply method!)

--- a/services/bot-client/src/utils/defineCommand.ts
+++ b/services/bot-client/src/utils/defineCommand.ts
@@ -91,7 +91,7 @@ export interface CommandDefinition {
    * defineCommand({
    *   deferralMode: 'ephemeral', // Default for most subcommands
    *   subcommandDeferralModes: {
-   *     'set': 'modal', // /wallet set shows a modal
+   *     'set': 'modal', // /settings apikey set shows a modal
    *   },
    *   execute: async (context) => {
    *     // Context type varies based on which subcommand was invoked


### PR DESCRIPTION
The API-key management UX moved from `/wallet` to `/settings apikey` (`set|browse|remove|test`), but two **user-facing** vision fail-fast strings still tell users to "check /wallet" — a command that no longer exists. A z.ai-coding (or any cross-provider) user hitting the vision auth fail-fast in prod sees a dead command.

## Changes

**User-facing strings (the actual bug):**
- `VISION_AUTH_FAIL_FAST_DESCRIPTION` (`visionAuthResolver.ts`) — shown in chat when an authenticated user lacks a vision-provider key
- `buildFailureFallback` AUTH/user variant (`VisionProcessor.ts`)

Both now point at `/settings apikey set`.

**Accuracy follow-through:** the JSDoc/comments that *describe the current command* — the two vision docstrings, the `apikey/{set,remove,test}.ts` handler headers (still said "Handle /wallet …"), and the `defineCommand` example — plus the four tests asserting the old wording.

## Intentionally left as-is
- Backend route paths (`/api/user/wallet/*`, `/wallet/list`, etc.) — the REST route is named "wallet" internally; that's a separate concern from the Discord command.
- Historical provenance comments ("Consolidated from former /wallet", "moved from /wallet") — accurate migration notes.

Found via the grep rule — the verify sweep caught two refs (`DependencyStep.test.ts`, `apikey/test.ts`) the first pass missed.

`pnpm quality` green; the four affected vision test files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)