### PR TITLE
fix(api-gateway): z.ai-key-required message + admin-route z.ai-only coverage

### DIFF
--- a/services/api-gateway/src/routes/admin/llm-config.test.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.test.ts
@@ -433,6 +433,75 @@ describe('Admin LLM Config Routes', () => {
     });
   });
 
+  describe('z.ai-only model acceptance (hasZaiCodingKey wiring)', () => {
+    // The catalog-path validation logic lives in modelValidation.test.ts; these
+    // close the *route-level* story: the admin routes pass hasZaiCodingKey:true
+    // unconditionally (global presets), which is what lets a z.ai-only model like
+    // z-ai/glm-5.2 (absent from OpenRouter) reach the catalog path and be saved.
+    it('should accept a z.ai-only model (z-ai/glm-5.2) on create', async () => {
+      prisma.llmConfig.findFirst.mockResolvedValue(null);
+      prisma.llmConfig.create.mockResolvedValue({
+        id: 'new-config-id',
+        name: 'GLM Global',
+        model: 'z-ai/glm-5.2',
+        provider: 'openrouter',
+        isGlobal: true,
+        isDefault: false,
+        memoryScoreThreshold: { toNumber: () => 0.5 },
+        memoryLimit: 20,
+      });
+
+      const response = await request(app).post('/admin/llm-config').send({
+        name: 'GLM Global',
+        model: 'z-ai/glm-5.2',
+        provider: 'openrouter',
+      });
+
+      expect(response.status).toBe(201);
+      expect(response.body.config.model).toBe('z-ai/glm-5.2');
+      expect(mockValidateLlmConfigModelFields).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hasZaiCodingKey: true,
+          body: expect.objectContaining({ model: 'z-ai/glm-5.2' }),
+        })
+      );
+    });
+
+    it('should accept a z.ai-only model (z-ai/glm-5.2) on update', async () => {
+      prisma.llmConfig.findUnique.mockResolvedValue({
+        id: 'config-id',
+        name: 'Old Name',
+        isGlobal: true,
+        memoryScoreThreshold: { toNumber: () => 0.5 },
+        memoryLimit: 20,
+      });
+      prisma.llmConfig.findFirst.mockResolvedValue(null);
+      prisma.llmConfig.update.mockResolvedValue({
+        id: 'config-id',
+        name: 'Old Name',
+        model: 'z-ai/glm-5.2',
+        provider: 'openrouter',
+        isGlobal: true,
+        isDefault: false,
+        memoryScoreThreshold: { toNumber: () => 0.5 },
+        memoryLimit: 20,
+      });
+
+      const response = await request(app)
+        .put('/admin/llm-config/config-id')
+        .send({ model: 'z-ai/glm-5.2' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.config.model).toBe('z-ai/glm-5.2');
+      expect(mockValidateLlmConfigModelFields).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hasZaiCodingKey: true,
+          body: expect.objectContaining({ model: 'z-ai/glm-5.2' }),
+        })
+      );
+    });
+  });
+
   describe('PUT /admin/llm-config/:id', () => {
     it('should return 400 when model validation fails on update', async () => {
       mockValidateLlmConfigModelFields.mockImplementationOnce(

--- a/services/api-gateway/src/utils/modelValidation.test.ts
+++ b/services/api-gateway/src/utils/modelValidation.test.ts
@@ -164,13 +164,47 @@ describe('validateModelAndContextWindow', () => {
       expect(result.contextWindowCap).toBe(100_000); // 50% of 200k
     });
 
-    it('should fall through to OpenRouter when the user has no z.ai key', async () => {
-      // Without a key, a z.ai-only model is NOT promoted at runtime, so it must
-      // be validated against OpenRouter — where it is absent → rejected.
+    it('should return the z.ai-key-required message for a z.ai-only model with no key', async () => {
+      // Without a key, a z.ai-only model is NOT promoted at runtime, so it falls
+      // through to OpenRouter — where glm-5.2 is absent. Rather than the generic
+      // "not found" (which implies a bad model id), surface the real constraint:
+      // this model needs a z.ai-coding key. Still consults the cache first so an
+      // OpenRouter-available z.ai model isn't pre-empted.
       const cache = createMockModelCache(null);
       const result = await validateModelAndContextWindow(cache, 'z-ai/glm-5.2', undefined, false);
-      expect(result.error).toContain("Model 'z-ai/glm-5.2' not found");
+      expect(result.error).toContain("Model 'z-ai/glm-5.2' is served by the z.ai Coding Plan");
+      expect(result.error).toContain('/settings apikey set');
+      expect(result.error).not.toContain('not found');
       expect(cache.getModelById).toHaveBeenCalledWith('z-ai/glm-5.2');
+    });
+
+    it('should NOT falsely reject an OpenRouter-available z.ai model with no key', async () => {
+      // Regression guard for the subtlety: glm-5.1 (unlike glm-5.2) IS on
+      // OpenRouter, so a no-key user saving it runs on OpenRouter at runtime and
+      // the config is valid. The z.ai-key-required message must only replace the
+      // generic not-found message, never pre-empt the cache lookup — so a cache
+      // hit validates normally.
+      const cache = createMockModelCache(
+        createMockModel({ id: 'z-ai/glm-5.1', contextLength: 202752 })
+      );
+      const result = await validateModelAndContextWindow(cache, 'z-ai/glm-5.1', undefined, false);
+      expect(result.error).toBeUndefined();
+      expect(result.contextWindowCap).toBe(101376); // Math.floor(202752 / 2)
+      expect(cache.getModelById).toHaveBeenCalledWith('z-ai/glm-5.1');
+    });
+
+    it('should keep the generic not-found message for a genuinely unknown z-ai model', async () => {
+      // A `z-ai/`-prefixed id that isn't in the catalog is just an unknown model;
+      // the z.ai-key hint would be wrong, so it keeps the generic message.
+      const cache = createMockModelCache(null);
+      const result = await validateModelAndContextWindow(
+        cache,
+        'z-ai/glm-nonexistent',
+        undefined,
+        false
+      );
+      expect(result.error).toContain("Model 'z-ai/glm-nonexistent' not found");
+      expect(result.error).not.toContain('z.ai Coding Plan');
     });
 
     it('should NOT take the z.ai path for a bare (unprefixed) catalog name', async () => {

--- a/services/api-gateway/src/utils/modelValidation.ts
+++ b/services/api-gateway/src/utils/modelValidation.ts
@@ -116,6 +116,24 @@ export async function validateModelAndContextWindow(
   // Model not found in cache — could be a new model or cache is stale
   // Reject with a helpful message
   if (model === null) {
+    // A `z-ai/`-prefixed catalog model that reached the OpenRouter lookup means
+    // the saving user has no z.ai-coding key (the keyed path returns earlier) AND
+    // this model isn't carried on OpenRouter either — i.e. a z.ai-only model like
+    // `z-ai/glm-5.2`. The generic "not found / check the model ID" message
+    // misdescribes the fix: the id is valid, the constraint is the missing key.
+    // z.ai models that DO exist on OpenRouter (glm-5.1, glm-4.7, …) are found by
+    // the lookup above and never reach here, so they keep validating normally.
+    if (
+      !hasZaiCodingKey &&
+      modelId.startsWith(ZAI_MODEL_PREFIX) &&
+      getZaiCodingPlanContextLength(modelId) !== null
+    ) {
+      return {
+        error:
+          `Model '${modelId}' is served by the z.ai Coding Plan. ` +
+          'Add a z.ai-coding API key with /settings apikey set to use it.',
+      };
+    }
     return {
       error:
         `Model '${modelId}' not found in the available models list. ` +


### PR DESCRIPTION
Two small follow-ups from the **#1200 release review**, both in the api-gateway model-validation layer. Smallest of the open z.ai backlog items (quick-win CHORE + inbox FIX), bundled because they're the same subsystem and same review origin.

### Bug Fixes
- **api-gateway:** misleading "model not found" when a user without a z.ai-coding key saves a z.ai-only model (e.g. `z-ai/glm-5.2`, absent from OpenRouter). The model id is valid — the real constraint is the missing key. Now returns a dedicated message pointing at `/settings apikey set`.

### Tests
- **api-gateway:** admin-route coverage asserting create/update forward `hasZaiCodingKey:true` with a `z-ai/glm-5.2` body (the wiring that lets z.ai-only global presets reach the catalog path).

### Notes
- The dedicated message is scoped to the **not-found branch**, so z.ai models that *do* exist on OpenRouter (`z-ai/glm-5.1`, `z-ai/glm-4.7`, …) are still found by the cache lookup and validated normally — a no-key user saving one runs it on OpenRouter at runtime, which is valid. Added a regression guard test for exactly that (`should NOT falsely reject an OpenRouter-available z.ai model with no key`).
- Updated the existing `should fall through to OpenRouter when the user has no z.ai key` test to assert the new dedicated message (intended behavior change, not test-gaming).
- Backlog: clears the quick-wins CHORE and the inbox FIX (`Misleading "model not found"…`). Removals will be swept at session end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)