### PR TITLE
feat(bot-client): "requires z.ai key" badge on preset dashboard

### DIFF
--- a/packages/common-types/src/schemas/api/llm-config.test.ts
+++ b/packages/common-types/src/schemas/api/llm-config.test.ts
@@ -170,6 +170,14 @@ describe('LLM Config API Contract Tests', () => {
     it('accepts empty params object (gateway emits {} for no advanced params)', () => {
       expect(LlmConfigDetailSchema.safeParse({ ...validDetail, params: {} }).success).toBe(true);
     });
+
+    it('allows and preserves the optional requiresZaiKey flag', () => {
+      // The gateway sets this for the dashboard's "requires z.ai key" badge; it
+      // must be part of the contract so client-side parsing doesn't strip it.
+      const parsed = LlmConfigDetailSchema.safeParse({ ...validDetail, requiresZaiKey: true });
+      expect(parsed.success).toBe(true);
+      expect(parsed.success && parsed.data.requiresZaiKey).toBe(true);
+    });
   });
 
   describe('ListLlmConfigsResponseSchema', () => {

--- a/packages/common-types/src/schemas/api/llm-config.ts
+++ b/packages/common-types/src/schemas/api/llm-config.ts
@@ -255,6 +255,14 @@ export const LlmConfigDetailSchema = LlmConfigSummarySchema.extend({
   contextWindowTokens: z.number().int(),
   modelContextLength: z.number().int().optional(),
   contextWindowCap: z.number().int().optional(),
+  // True when the model is a z.ai-only coding-plan model (absent from OpenRouter)
+  // AND the viewing user has no active z.ai-coding key — the preset can't run for
+  // them without one. Drives the dashboard "requires z.ai key" badge; see
+  // api-gateway `computeRequiresZaiKey`. `.optional()` because only the
+  // user-facing GET/create/update routes emit it (always — as `false` when the
+  // badge doesn't apply); the owner-only admin routes intentionally omit it (the
+  // owner provisions the keys, so the badge has no audience there).
+  requiresZaiKey: z.boolean().optional(),
   params: AdvancedParamsSchema,
 });
 export type LlmConfigDetail = z.infer<typeof LlmConfigDetailSchema>;

--- a/services/api-gateway/src/routes/user/llm-config.test.ts
+++ b/services/api-gateway/src/routes/user/llm-config.test.ts
@@ -348,6 +348,81 @@ describe('/user/llm-config routes', () => {
       );
     });
 
+    it('should set requiresZaiKey=true for a z.ai-only model viewed without a key', async () => {
+      // Global z.ai-only preset (glm-5.2, absent from OpenRouter) viewed by a user
+      // with no z.ai-coding key → the dashboard should badge it.
+      mockPrisma.llmConfig.findUnique.mockResolvedValue({
+        id: 'config-123',
+        name: 'GLM Global',
+        description: null,
+        model: 'z-ai/glm-5.2',
+        provider: 'openrouter',
+        visionModel: null,
+        isGlobal: true,
+        isDefault: false,
+        ownerId: 'someone-else',
+        advancedParameters: null,
+        memoryScoreThreshold: { toNumber: () => 0.5 },
+        memoryLimit: 20,
+      });
+      mockPrisma.userApiKey.findFirst.mockResolvedValue(null); // no z.ai-coding key
+      const modelCache = {
+        getModelById: vi.fn().mockResolvedValue(null), // glm-5.2 not on OpenRouter
+      } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
+
+      const router = createLlmConfigRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        modelCache,
+      });
+      const handler = getHandler(router, 'get', '/:id');
+      const { req, res } = createMockReqRes({}, { id: 'config-123' });
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({ requiresZaiKey: true }),
+        })
+      );
+    });
+
+    it('should set requiresZaiKey=false when the viewer has a z.ai-coding key', async () => {
+      mockPrisma.llmConfig.findUnique.mockResolvedValue({
+        id: 'config-123',
+        name: 'GLM Global',
+        description: null,
+        model: 'z-ai/glm-5.2',
+        provider: 'openrouter',
+        visionModel: null,
+        isGlobal: true,
+        isDefault: false,
+        ownerId: 'someone-else',
+        advancedParameters: null,
+        memoryScoreThreshold: { toNumber: () => 0.5 },
+        memoryLimit: 20,
+      });
+      mockPrisma.userApiKey.findFirst.mockResolvedValue({ id: 'zai-key-1' }); // has key
+      const modelCache = {
+        getModelById: vi.fn().mockResolvedValue(null),
+      } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
+
+      const router = createLlmConfigRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        modelCache,
+      });
+      const handler = getHandler(router, 'get', '/:id');
+      const { req, res } = createMockReqRes({}, { id: 'config-123' });
+
+      await handler(req, res);
+
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({ requiresZaiKey: false }),
+        })
+      );
+    });
+
     it('should return config with isOwned=false for other user global config', async () => {
       // Global config owned by another user - still visible but not owned
       mockPrisma.llmConfig.findUnique.mockResolvedValue({
@@ -535,6 +610,43 @@ describe('/user/llm-config routes', () => {
       );
       expect(mockPrisma.llmConfig.create).toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    it('should set requiresZaiKey=true in the create response for a z.ai-only model with no key', async () => {
+      // Guards the requiresZaiKey field against being dropped from the CREATE
+      // response spread. No z.ai key + z.ai-only model + OpenRouter cache miss
+      // → badge applies.
+      mockPrisma.userApiKey.findFirst.mockResolvedValue(null);
+      mockPrisma.llmConfig.create.mockResolvedValue({
+        id: 'new-config',
+        name: 'GLM Config',
+        description: null,
+        model: 'z-ai/glm-5.2',
+        provider: 'openrouter',
+        visionModel: null,
+        isGlobal: false,
+        isDefault: false,
+        memoryScoreThreshold: { toNumber: () => 0.5 },
+        memoryLimit: 20,
+      });
+      const modelCache = {
+        getModelById: vi.fn().mockResolvedValue(null),
+      } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
+
+      const router = createLlmConfigRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        modelCache,
+      });
+      const handler = getHandler(router, 'post', '/');
+      const { req, res } = createMockReqRes({ name: 'GLM Config', model: 'z-ai/glm-5.2' });
+
+      await handler(req, res);
+
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({ requiresZaiKey: true }),
+        })
+      );
     });
 
     it('should create config with advancedParameters', async () => {
@@ -931,6 +1043,54 @@ describe('/user/llm-config routes', () => {
         })
       );
       expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('should set requiresZaiKey=true in the update response for a z.ai-only model with no key', async () => {
+      // Guards the requiresZaiKey field against being dropped from the UPDATE
+      // response spread (companion to the create-path guard).
+      mockPrisma.userApiKey.findFirst.mockResolvedValue(null);
+      mockPrisma.llmConfig.findUnique.mockResolvedValue({
+        id: 'config-123',
+        ownerId: 'user-uuid-123',
+        isGlobal: false,
+        name: 'My Config',
+        memoryScoreThreshold: { toNumber: () => 0.5 },
+        memoryLimit: 20,
+      });
+      mockPrisma.llmConfig.update.mockResolvedValue({
+        id: 'config-123',
+        name: 'My Config',
+        description: null,
+        model: 'z-ai/glm-5.2',
+        provider: 'openrouter',
+        visionModel: null,
+        isGlobal: false,
+        isDefault: false,
+        isFreeDefault: false,
+        ownerId: 'user-uuid-123',
+        advancedParameters: null,
+        memoryScoreThreshold: { toNumber: () => 0.5 },
+        memoryLimit: 20,
+      });
+      const modelCache = {
+        getModelById: vi.fn().mockResolvedValue(null),
+      } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
+
+      const router = createLlmConfigRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        llmConfigCacheInvalidation: mockCacheInvalidation,
+        modelCache,
+      });
+      const handler = getHandler(router, 'put', '/:id');
+      const { req, res } = createMockReqRes({ model: 'z-ai/glm-5.2' }, { id: 'config-123' });
+
+      await handler(req, res);
+
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({ requiresZaiKey: true }),
+        })
+      );
     });
 
     it('should reject an update whose new name collides in the owner namespace', async () => {

--- a/services/api-gateway/src/routes/user/llm-config.ts
+++ b/services/api-gateway/src/routes/user/llm-config.ts
@@ -43,7 +43,7 @@ import {
   type LlmConfigScope,
 } from '../../services/LlmConfigService.js';
 import type { OpenRouterModelCache } from '../../services/OpenRouterModelCache.js';
-import { enrichWithModelContext } from '../../utils/modelValidation.js';
+import { enrichWithModelContext, computeRequiresZaiKey } from '../../utils/modelValidation.js';
 import { validateLlmConfigModelFields } from '../../utils/llmConfigValidation.js';
 import { userHasActiveApiKey } from '../../utils/userHasActiveApiKey.js';
 import {
@@ -98,7 +98,11 @@ function createListHandler(service: LlmConfigService) {
   };
 }
 
-function createGetHandler(service: LlmConfigService, modelCache?: OpenRouterModelCache) {
+function createGetHandler(
+  service: LlmConfigService,
+  prisma: PrismaClient,
+  modelCache?: OpenRouterModelCache
+) {
   return async (req: ProvisionedRequest, res: Response) => {
     const discordUserId = req.userId;
     const configId = getRequiredParam(req.params.id, 'id');
@@ -128,8 +132,18 @@ function createGetHandler(service: LlmConfigService, modelCache?: OpenRouterMode
     const formatted = service.formatConfigDetail(config);
     await enrichWithModelContext(formatted, config.model, modelCache);
 
+    // Badge the dashboard when this viewer can't run the model without a z.ai key
+    // (z.ai-only model + no z.ai-coding key). Keyed off the VIEWER, so the same
+    // global preset shows the badge to a keyless user but not to one with a key.
+    const hasZaiCodingKey = await userHasActiveApiKey(prisma, userId, AIProvider.ZaiCoding);
+    const requiresZaiKey = await computeRequiresZaiKey(config.model, hasZaiCodingKey, modelCache);
+
     logger.debug({ discordUserId, configId }, 'Fetched config');
-    sendCustomSuccess(res, { config: { ...formatted, isOwned, permissions } }, StatusCodes.OK);
+    sendCustomSuccess(
+      res,
+      { config: { ...formatted, isOwned, permissions, requiresZaiKey } },
+      StatusCodes.OK
+    );
   };
 }
 
@@ -221,11 +235,12 @@ function createCreateHandler(
     // Format with service helper, then add user-specific fields
     const formatted = service.formatConfigDetail(config);
     await enrichWithModelContext(formatted, config.model, modelCache);
+    const requiresZaiKey = await computeRequiresZaiKey(config.model, hasZaiCodingKey, modelCache);
 
     logger.info({ discordUserId, configId: config.id, name: config.name }, 'Created config');
     sendCustomSuccess(
       res,
-      { config: { ...formatted, isOwned: true, permissions } },
+      { config: { ...formatted, isOwned: true, permissions, requiresZaiKey } },
       StatusCodes.CREATED
     );
   };
@@ -393,6 +408,7 @@ function createUpdateHandler(
     // Format with service helper, then add user-specific fields
     const formatted = service.formatConfigDetail(updated);
     await enrichWithModelContext(formatted, updated.model, modelCache);
+    const requiresZaiKey = await computeRequiresZaiKey(updated.model, hasZaiCodingKey, modelCache);
 
     logger.info(
       {
@@ -407,7 +423,7 @@ function createUpdateHandler(
 
     sendCustomSuccess(
       res,
-      { config: { ...formatted, isOwned: isOwnedByRequester, permissions } },
+      { config: { ...formatted, isOwned: isOwnedByRequester, permissions, requiresZaiKey } },
       StatusCodes.OK
     );
   };
@@ -478,7 +494,7 @@ export const handleListUserLlmConfigs = (deps: RouteDeps): RequestHandler =>
   asyncHandler(createListHandler(buildService(deps)));
 
 export const handleGetUserLlmConfig = (deps: RouteDeps): RequestHandler =>
-  asyncHandler(createGetHandler(buildService(deps), deps.modelCache));
+  asyncHandler(createGetHandler(buildService(deps), deps.prisma, deps.modelCache));
 
 export const handleCreateUserLlmConfig = (deps: RouteDeps): RequestHandler =>
   asyncHandler(createCreateHandler(buildService(deps), deps.prisma, deps.modelCache));

--- a/services/api-gateway/src/utils/modelValidation.test.ts
+++ b/services/api-gateway/src/utils/modelValidation.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import { validateModelAndContextWindow, enrichWithModelContext } from './modelValidation.js';
+import {
+  validateModelAndContextWindow,
+  enrichWithModelContext,
+  computeRequiresZaiKey,
+} from './modelValidation.js';
 import type { OpenRouterModelCache } from '../services/OpenRouterModelCache.js';
 import type { ModelAutocompleteOption } from '@tzurot/common-types';
 
@@ -234,6 +238,58 @@ describe('validateModelAndContextWindow', () => {
       expect(result.contextWindowCap).toBe(100000);
       expect(cache.getModelById).toHaveBeenCalledWith('anthropic/claude-sonnet-4');
     });
+  });
+});
+
+describe('computeRequiresZaiKey', () => {
+  it('should badge a z.ai-only model (not on OpenRouter) for a keyless viewer', async () => {
+    // glm-5.2 is absent from OpenRouter → cache miss → a keyless viewer can't run
+    // it (OpenRouter fallthrough would 404), so the badge fires.
+    const cache = createMockModelCache(null);
+    expect(await computeRequiresZaiKey('z-ai/glm-5.2', false, cache)).toBe(true);
+    expect(cache.getModelById).toHaveBeenCalledWith('z-ai/glm-5.2');
+  });
+
+  it('should NOT badge a z.ai model that IS on OpenRouter for a keyless viewer', async () => {
+    // glm-5.1 is on OpenRouter, so a keyless viewer runs it there — preset works,
+    // no badge. This is the false-positive guard.
+    const cache = createMockModelCache(createMockModel({ id: 'z-ai/glm-5.1' }));
+    expect(await computeRequiresZaiKey('z-ai/glm-5.1', false, cache)).toBe(false);
+  });
+
+  it('should NOT badge when the viewer has a z.ai-coding key', async () => {
+    const cache = createMockModelCache(null);
+    expect(await computeRequiresZaiKey('z-ai/glm-5.2', true, cache)).toBe(false);
+    // Short-circuits on the key before any cache lookup.
+    expect(cache.getModelById).not.toHaveBeenCalled();
+  });
+
+  it('should NOT badge a non-z.ai model', async () => {
+    const cache = createMockModelCache(null);
+    expect(await computeRequiresZaiKey('anthropic/claude-sonnet-4', false, cache)).toBe(false);
+  });
+
+  it('should NOT badge a bare (unprefixed) catalog name', async () => {
+    // Mirrors the validation/runtime prefix gate: bare glm-5.2 wouldn't promote
+    // even with a key, so the z.ai-key hint would be wrong.
+    const cache = createMockModelCache(null);
+    expect(await computeRequiresZaiKey('glm-5.2', false, cache)).toBe(false);
+  });
+
+  it('should NOT badge a prefixed non-catalog model', async () => {
+    const cache = createMockModelCache(null);
+    expect(await computeRequiresZaiKey('z-ai/glm-nonexistent', false, cache)).toBe(false);
+    // Short-circuits on the catalog-membership check, before the cache lookup.
+    expect(cache.getModelById).not.toHaveBeenCalled();
+  });
+
+  it('should NOT badge when the cache is unavailable (cannot confirm absence)', async () => {
+    expect(await computeRequiresZaiKey('z-ai/glm-5.2', false, undefined)).toBe(false);
+  });
+
+  it('should NOT badge when model is undefined', async () => {
+    const cache = createMockModelCache(null);
+    expect(await computeRequiresZaiKey(undefined, false, cache)).toBe(false);
   });
 });
 

--- a/services/api-gateway/src/utils/modelValidation.ts
+++ b/services/api-gateway/src/utils/modelValidation.ts
@@ -144,6 +144,44 @@ export async function validateModelAndContextWindow(
   return checkContextWindowCap(modelId, contextWindowTokens, model.contextLength);
 }
 
+/**
+ * Decide whether a saved config's model should show a "requires z.ai key" badge
+ * for the viewing user — i.e. the preset references a z.ai coding-plan model the
+ * viewer cannot actually run without a z.ai-coding key.
+ *
+ * Mirrors the dedicated-error condition in `validateModelAndContextWindow`'s
+ * not-found branch, so the dashboard badge and the save-time error agree on what
+ * "needs a z.ai key" means:
+ *
+ * - viewer has a z.ai key → no badge (the model is promoted to z.ai-direct for them)
+ * - model isn't a `z-ai/`-prefixed catalog member → no badge (ordinary model)
+ * - model IS on OpenRouter (glm-5.1, glm-4.7, …) → no badge: a keyless viewer
+ *   runs it on OpenRouter at runtime, so the preset works for them
+ * - model is z.ai-only (absent from OpenRouter, e.g. glm-5.2) → BADGE: a keyless
+ *   viewer's OpenRouter fallthrough would 404 at runtime
+ *
+ * When the cache is unavailable we can't confirm OpenRouter absence, so we
+ * return `false` (no badge) rather than risk a false positive — same
+ * graceful-degrade stance as `enrichWithModelContext`.
+ */
+export async function computeRequiresZaiKey(
+  model: string | undefined,
+  hasZaiCodingKey: boolean,
+  modelCache: OpenRouterModelCache | undefined
+): Promise<boolean> {
+  if (model === undefined || hasZaiCodingKey) {
+    return false;
+  }
+  if (!model.startsWith(ZAI_MODEL_PREFIX) || getZaiCodingPlanContextLength(model) === null) {
+    return false;
+  }
+  if (modelCache === undefined) {
+    return false;
+  }
+  const onOpenRouter = (await modelCache.getModelById(model)) !== null;
+  return !onOpenRouter;
+}
+
 /** Object with optional model context fields, set by enrichWithModelContext */
 interface ModelContextEnrichable {
   modelContextLength?: number;

--- a/services/bot-client/src/commands/preset/config.test.ts
+++ b/services/bot-client/src/commands/preset/config.test.ts
@@ -175,6 +175,29 @@ describe('flattenPresetData', () => {
     expect(result.reasoning_effort).toBe('');
     expect(result.reasoning_enabled).toBe('');
   });
+
+  it('should pass requiresZaiKey through for the dashboard badge', () => {
+    const preset: PresetData = {
+      id: 'preset-123',
+      name: 'GLM Preset',
+      description: null,
+      model: 'z-ai/glm-5.2',
+      provider: 'openrouter',
+      visionModel: null,
+      isGlobal: true,
+      isOwned: false,
+      permissions: { canEdit: false, canDelete: false },
+      contextWindowTokens: 8192,
+      requiresZaiKey: true,
+      params: {},
+    };
+
+    expect(flattenPresetData(preset).requiresZaiKey).toBe(true);
+
+    // Absent on the source → absent on the flattened data (no badge).
+    const { requiresZaiKey: _omit, ...withoutFlag } = preset;
+    expect(flattenPresetData(withoutFlag).requiresZaiKey).toBeUndefined();
+  });
 });
 
 describe('unflattenPresetData', () => {

--- a/services/bot-client/src/commands/preset/config.ts
+++ b/services/bot-client/src/commands/preset/config.ts
@@ -55,6 +55,7 @@ export function flattenPresetData(data: PresetData): FlattenedPresetData {
     // Model context info (display-only, not editable)
     modelContextLength: data.modelContextLength,
     contextWindowCap: data.contextWindowCap,
+    requiresZaiKey: data.requiresZaiKey,
   };
 }
 

--- a/services/bot-client/src/commands/preset/presetSections.test.ts
+++ b/services/bot-client/src/commands/preset/presetSections.test.ts
@@ -85,6 +85,38 @@ describe('identitySection', () => {
     const data = { name: '', model: '', description: '' } as FlattenedPresetData;
     expect(identitySection.getPreview(data)).toBe('_Not configured_');
   });
+
+  it('should append the z.ai-key badge when requiresZaiKey is true', () => {
+    const data = {
+      name: 'GLM Preset',
+      model: 'z-ai/glm-5.2',
+      provider: 'openrouter',
+      description: '',
+      requiresZaiKey: true,
+    } as FlattenedPresetData;
+    const preview = identitySection.getPreview(data);
+    expect(preview).toContain('**Model:** `z-ai/glm-5.2`');
+    expect(preview).toContain('requires z.ai key');
+  });
+
+  it('should NOT show the z.ai-key badge when requiresZaiKey is false/undefined', () => {
+    const falseData = {
+      name: 'GLM Preset',
+      model: 'z-ai/glm-5.2',
+      provider: 'openrouter',
+      description: '',
+      requiresZaiKey: false,
+    } as FlattenedPresetData;
+    expect(identitySection.getPreview(falseData)).not.toContain('requires z.ai key');
+
+    const undefData = {
+      name: 'Regular Preset',
+      model: 'anthropic/claude-sonnet-4',
+      provider: 'openrouter',
+      description: '',
+    } as FlattenedPresetData;
+    expect(identitySection.getPreview(undefData)).not.toContain('requires z.ai key');
+  });
 });
 
 describe('coreSamplingSection', () => {

--- a/services/bot-client/src/commands/preset/presetSections.ts
+++ b/services/bot-client/src/commands/preset/presetSections.ts
@@ -81,7 +81,8 @@ export const identitySection: SectionDefinition<FlattenedPresetData> = {
       parts.push(`**Name:** ${data.name}`);
     }
     if (data.model) {
-      parts.push(`**Model:** \`${data.model}\``);
+      const zaiBadge = data.requiresZaiKey === true ? ' ⚠️ requires z.ai key' : '';
+      parts.push(`**Model:** \`${data.model}\`${zaiBadge}`);
     }
     if (data.visionModel) {
       parts.push(`**Vision:** \`${data.visionModel}\``);

--- a/services/bot-client/src/commands/preset/types.ts
+++ b/services/bot-client/src/commands/preset/types.ts
@@ -31,6 +31,12 @@ export interface PresetData {
   modelContextLength?: number;
   /** Model-derived cap for contextWindowTokens (computeContextCap), undefined if unknown */
   contextWindowCap?: number;
+  /**
+   * True when the model is a z.ai-only coding-plan model (absent from OpenRouter)
+   * AND the viewing user has no active z.ai-coding key — the preset can't run for
+   * them without one. Drives the "requires z.ai key" dashboard badge.
+   */
+  requiresZaiKey?: boolean;
   params: {
     temperature?: number;
     top_p?: number;
@@ -96,6 +102,8 @@ export interface FlattenedPresetData {
   modelContextLength?: number;
   /** Model-derived cap for contextWindowTokens (display-only, not editable) */
   contextWindowCap?: number;
+  /** True when the model needs a z.ai-coding key the viewer lacks (display-only) */
+  requiresZaiKey?: boolean;
   /** Browse context when opened from browse (for back navigation) */
   browseContext?: BrowseContext;
 }


### PR DESCRIPTION
Item 4 from the z.ai backlog sweep. A **global** preset on a z.ai-only model (e.g. `z-ai/glm-5.2`, absent from OpenRouter) looks available to every user, but a viewer **without** a z.ai-coding key can't run it — their OpenRouter fallthrough 404s at generation time. The dashboard now surfaces that up front.

### Features
- **bot-client:** `⚠️ requires z.ai key` badge next to the model in the preset dashboard's Identity section, shown only when the viewer can't actually run the model.

### How it works
- **api-gateway:** new `computeRequiresZaiKey()` mirrors the dedicated-error condition in `validateModelAndContextWindow`'s not-found branch — badge **only** when the model is a z.ai-only catalog member (cache-miss on OpenRouter) **AND** the viewer has no z.ai key. z.ai models that *do* exist on OpenRouter (`glm-5.1`, `glm-4.7`) never badge — a keyless viewer runs them on OpenRouter, so the preset works. Computed per-viewer on the user GET/create/update responses.
- **common-types:** `requiresZaiKey` added to `LlmConfigDetailSchema` (optional). Required because the schema strips unknown keys on client-side parse — without it the field would be dropped and the badge never show.
- **bot-client:** threaded `PresetData → flattenPresetData → identitySection` preview.

Keyed off the **viewer**: the same global preset badges for a keyless user but not for one with a z.ai-coding key.

### Tests
- `computeRequiresZaiKey` unit matrix (z.ai-only/no-key → badge; on-OpenRouter → no badge; has-key/non-z.ai/bare/unknown/cache-undefined → no badge).
- Route-level GET tests asserting `requiresZaiKey` true (keyless) and false (keyed).
- bot-client: `getPreview` renders/omits the badge; `flattenPresetData` passes the flag through.
- common-types: schema accepts + preserves the flag.

### Backlog
Promotes the icebox item 4. Note item 3 (the "do together" sibling) turned out moot — model selection is a modal, not an autocomplete; it was reframed into a separate `/models`-browser command backlog item (already on develop). Icebox removal of item 4 will be swept at session end after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)