### PR TITLE
feat(ai-worker): broad free-vision fallback for cross-provider auth gaps

### DIFF
--- a/services/ai-worker/src/jobs/ImageDescriptionJob.test.ts
+++ b/services/ai-worker/src/jobs/ImageDescriptionJob.test.ts
@@ -3,14 +3,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import {
-  processImageDescriptionJob,
-  USER_AUTH_PROBE_PROVIDERS,
-  NON_LLM_PROVIDERS,
-} from './ImageDescriptionJob.js';
+import { processImageDescriptionJob } from './ImageDescriptionJob.js';
 import type { Job } from 'bullmq';
 import type { ImageDescriptionJobData, LoadedPersonality } from '@tzurot/common-types';
-import { JobType, CONTENT_TYPES, AIProvider, TIMEOUTS } from '@tzurot/common-types';
+import { JobType, CONTENT_TYPES, AIProvider, TIMEOUTS, MODEL_DEFAULTS } from '@tzurot/common-types';
 
 // Mirrors the module-level constant in ImageDescriptionJob.ts. Intentionally
 // kept as a copy so the test asserts the expected *contract* (vision uses 2
@@ -35,11 +31,17 @@ vi.mock('../utils/apiErrorParser.js', () => ({
 // `buildFailFastResult` lazy-imports `visionDescriptionCache` from redis.js;
 // stub the cache method so the dynamic import resolves without hitting a real
 // Redis client at test time. Thunks defer reference resolution past hoisting.
+// `checkModelVisionSupport` is reached transitively now that resolveVisionConfig
+// calls the real `selectVisionModel` — default it to false so the
+// no-visionModel-override tests fall through to the fallback model without a
+// real Redis call.
 const mockStoreFailure = vi.fn();
+const mockCheckModelVisionSupport = vi.fn().mockResolvedValue(false);
 vi.mock('../redis.js', () => ({
   visionDescriptionCache: {
     storeFailure: (...args: unknown[]) => mockStoreFailure(...args),
   },
+  checkModelVisionSupport: (...args: unknown[]) => mockCheckModelVisionSupport(...args),
 }));
 
 // Import the mocked modules
@@ -457,7 +459,7 @@ describe('ImageDescriptionJob', () => {
       expect(result.metadata!.failedCount).toBe(1); // Track failures
     });
 
-    it('should pass isGuestMode=true to describeImage for guest users', async () => {
+    it('resolves a genuine guest to the free model on the system key', async () => {
       const jobData: ImageDescriptionJobData = {
         requestId: 'test-req-guest-mode',
         jobType: JobType.ImageDescription,
@@ -485,41 +487,46 @@ describe('ImageDescriptionJob', () => {
         data: jobData,
       } as Job<ImageDescriptionJobData>;
 
-      // Mock ApiKeyResolver: genuine guest — no user keys for any provider.
-      // tryResolveUserKey returns null for both probe providers, then
-      // resolveApiKey returns the system key with isGuestMode: true.
+      // Genuine guest — no user keys for any provider. ImageDescriptionJob has
+      // no upstream isGuestMode signal, so resolveVisionConfig is called with
+      // isGuestMode=false; a user with no vision-provider key flows through the
+      // broad free-fallback branch and gets the free model on the system key.
+      // tryResolveUserKey returns null; resolveApiKey returns the system key.
       const mockApiKeyResolver = {
         tryResolveUserKey: vi.fn().mockResolvedValue(null),
         resolveApiKey: vi.fn().mockResolvedValue({
-          apiKey: null,
-          source: 'fallback',
+          apiKey: 'system-or-key',
+          source: 'system',
+          provider: AIProvider.OpenRouter,
           isGuestMode: true,
         }),
       } as unknown as ApiKeyResolver;
 
       await processImageDescriptionJob(job, mockApiKeyResolver);
 
-      // Verify resolveApiKey was called with the detected vision provider
-      // (OpenRouter, since mockPersonality.visionModel='gpt-4-vision-preview').
-      // Only fires for the guest path — auth check happens via tryResolveUserKey.
+      // resolveApiKey is called for the free-fallback provider (OpenRouter,
+      // where the free gemma model lives).
       expect(mockApiKeyResolver.resolveApiKey).toHaveBeenCalledWith(
         'guest-user-123',
         AIProvider.OpenRouter
       );
 
-      // Verify describeImage was called with isGuestMode=true
-      // describeImage is called inside withRetry, so check the mockWithRetry call
       expect(mockWithRetry).toHaveBeenCalledTimes(1);
-      // Execute the retry function to verify describeImage receives correct params
+      // describeImage receives the forced free model on the system key. Note
+      // isGuestMode is `false` here — the broad-fallback branch preserves the
+      // "no keys anywhere" meaning of isGuestMode for the genuine-guest signal,
+      // but since the model is passed explicitly, isGuestMode no longer drives
+      // model selection in this path.
       const retryFn = mockWithRetry.mock.calls[0][0];
       await retryFn();
       expect(mockDescribeImage).toHaveBeenCalledWith(
         expect.objectContaining({ url: 'https://example.com/image1.png' }),
         mockPersonality,
-        true, // isGuestMode
-        undefined, // userApiKey (guests don't have one)
+        false, // isGuestMode — broad-fallback branch sets false; model is forced explicitly
+        'system-or-key', // system key
         expect.objectContaining({
           skipNegativeCache: true,
+          model: MODEL_DEFAULTS.VISION_FALLBACK_FREE,
           loggingContext: expect.objectContaining({ userId: expect.any(String) }),
         })
       );
@@ -635,13 +642,12 @@ describe('ImageDescriptionJob', () => {
       );
     });
 
-    it('falls back to main model when visionModel is empty and main is a glm-* z.ai model', async () => {
-      // The visionModel→main fallback chain mirrors selectVisionModel's logic:
-      // when no explicit override, we use the main model name to detect the
-      // vision provider (since the main model would also be used for vision
-      // if it has native support). Schema validation rejects null on this
-      // job-data field, so we use the empty-string sentinel which the
-      // resolveVisionApiKey fallback also accepts.
+    it('detects vision provider from the fallback model when visionModel and main both lack vision', async () => {
+      // With no visionModel override and a main model (glm-5.1) that has no
+      // native vision support, `selectVisionModel` falls through to the paid
+      // OpenRouter fallback model. The unified `resolveVisionConfig` detects the
+      // provider from THAT model (OpenRouter), fixing the old ImageDescriptionJob
+      // bug where the provider was detected from the main model name (ZaiCoding).
       const noOverridePersonality = {
         ...mockPersonality,
         visionModel: '',
@@ -663,31 +669,96 @@ describe('ImageDescriptionJob', () => {
         responseDestination: { type: 'discord', channelId: 'channel-1' },
       };
       const job = { id: 'image-fb', data: jobData } as Job<ImageDescriptionJobData>;
+      // main has no native vision → selectVisionModel falls to the paid
+      // OpenRouter fallback model.
+      mockCheckModelVisionSupport.mockResolvedValue(false);
       const mockApiKeyResolver = {
-        tryResolveUserKey: vi.fn().mockResolvedValue('zai-key'),
-        resolveApiKey: vi
-          .fn()
-          .mockRejectedValue(
-            new Error('resolveApiKey should not be called — fail-fast bypass expected')
-          ),
+        tryResolveUserKey: vi.fn().mockResolvedValue('or-user-key'),
+        resolveApiKey: vi.fn(),
       } as unknown as ApiKeyResolver;
 
       await processImageDescriptionJob(job, mockApiKeyResolver);
 
-      // Provider detected from main model (visionModel was empty); user has
-      // the ZaiCoding key, so tryResolveUserKey returns it.
+      // Provider detected from the fallback model (OpenRouter), NOT the main
+      // model's ZaiCoding — this is the bug the unified resolver fixes.
       expect(mockApiKeyResolver.tryResolveUserKey).toHaveBeenCalledWith(
         'user-fallback',
-        AIProvider.ZaiCoding
+        AIProvider.OpenRouter
       );
     });
 
-    it('fails fast when authenticated user lacks key for vision provider (matches DependencyStep policy)', async () => {
-      // Regression for the asymmetry the round-10 reviewer flagged: an
-      // authenticated user (has SOME user key) but no key for the personality's
-      // vision provider must NOT silently fall back to the system key here —
-      // they should get the same "configure your key" fallback that
-      // DependencyStep produces via buildVisionAuthFailureResults.
+    it('downgrades authenticated user without vision-provider key to free model on system key', async () => {
+      // BROAD FREE FALLBACK: an authenticated user (has SOME user key) but no
+      // key for the personality's vision provider no longer fails fast — they
+      // downgrade to the free vision model on the system OpenRouter key.
+      const jobData: ImageDescriptionJobData = {
+        requestId: 'test-req-free-fallback',
+        jobType: JobType.ImageDescription,
+        attachments: [
+          {
+            url: 'https://example.com/image1.png',
+            name: 'image1.png',
+            contentType: CONTENT_TYPES.IMAGE_PNG,
+            size: 1024,
+          },
+        ],
+        // visionModel is a z.ai model → vision provider is ZaiCoding, which the
+        // user lacks a key for.
+        personality: { ...mockPersonality, visionModel: 'glm-5v' },
+        context: { userId: 'auth-user-no-zai-key', channelId: 'channel-1' },
+        responseDestination: { type: 'discord', channelId: 'channel-1' },
+      };
+      const job = {
+        id: 'image-free-fallback',
+        data: jobData,
+      } as Job<ImageDescriptionJobData>;
+
+      // No user key for the ZaiCoding vision provider; resolveApiKey for the
+      // FREE provider (OpenRouter) returns the system key.
+      const mockApiKeyResolver = {
+        tryResolveUserKey: vi.fn().mockResolvedValue(null),
+        resolveApiKey: vi.fn().mockResolvedValue({
+          apiKey: 'system-or-key',
+          source: 'system',
+          provider: AIProvider.OpenRouter,
+          isGuestMode: true,
+          userId: 'auth-user-no-zai-key',
+        }),
+      } as unknown as ApiKeyResolver;
+
+      const result = await processImageDescriptionJob(job, mockApiKeyResolver);
+
+      // resolveApiKey IS called now (for the free provider) — no fail-fast.
+      expect(mockApiKeyResolver.resolveApiKey).toHaveBeenCalledWith(
+        'auth-user-no-zai-key',
+        AIProvider.OpenRouter
+      );
+      // The vision call runs (not short-circuited) and succeeds.
+      expect(result.success).toBe(true);
+      expect(result.descriptions).toHaveLength(1);
+      expect(mockWithRetry).toHaveBeenCalled();
+
+      // describeImage receives the forced free model + system key, isGuestMode=false.
+      const retryFn = mockWithRetry.mock.calls[0][0];
+      await retryFn();
+      expect(mockDescribeImage).toHaveBeenCalledWith(
+        expect.objectContaining({ url: 'https://example.com/image1.png' }),
+        expect.anything(),
+        false, // isGuestMode — they ARE authenticated, only the vision model is downgraded
+        'system-or-key', // system key
+        expect.objectContaining({
+          model: MODEL_DEFAULTS.VISION_FALLBACK_FREE, // forced free model
+          provider: AIProvider.OpenRouter,
+          loggingContext: expect.objectContaining({ apiKeySource: 'system' }),
+        })
+      );
+    });
+
+    it('fails fast when the free-model system fallback is also unavailable', async () => {
+      // Fallback-of-fallback: authenticated user lacks the vision-provider key
+      // AND no system OpenRouter key is configured (resolveApiKey throws). The
+      // job emits the "configure your key" placeholder against the original
+      // vision provider.
       const jobData: ImageDescriptionJobData = {
         requestId: 'test-req-fail-fast',
         jobType: JobType.ImageDescription,
@@ -700,7 +771,7 @@ describe('ImageDescriptionJob', () => {
           },
         ],
         personality: mockPersonality, // visionModel='gpt-4-vision-preview' → OpenRouter
-        context: { userId: 'auth-user-no-or-key', channelId: 'channel-1' },
+        context: { userId: 'auth-user-no-keys-at-all', channelId: 'channel-1' },
         responseDestination: { type: 'discord', channelId: 'channel-1' },
       };
       const job = {
@@ -708,28 +779,16 @@ describe('ImageDescriptionJob', () => {
         data: jobData,
       } as Job<ImageDescriptionJobData>;
 
-      // tryResolveUserKey returns null for OpenRouter (vision provider) but
-      // returns a user key for ZaiCoding — i.e., user IS authenticated, just
-      // not for the vision provider.
-      const tryResolveUserKey = vi
-        .fn()
-        .mockImplementation(async (_userId: string, provider: AIProvider) =>
-          provider === AIProvider.ZaiCoding ? 'zai-user-key' : null
-        );
       const mockApiKeyResolver = {
-        tryResolveUserKey,
+        tryResolveUserKey: vi.fn().mockResolvedValue(null),
+        // No system OpenRouter key configured → resolveApiKey throws.
         resolveApiKey: vi
           .fn()
-          .mockRejectedValue(
-            new Error('resolveApiKey should not be called — fail-fast bypass expected')
-          ),
+          .mockRejectedValue(new Error('No API key available for provider openrouter')),
       } as unknown as ApiKeyResolver;
 
       const result = await processImageDescriptionJob(job, mockApiKeyResolver);
 
-      // resolveApiKey is NOT called — fail-fast bypasses the system fallback
-      // entirely for authenticated users without the vision-provider key.
-      expect(mockApiKeyResolver.resolveApiKey).not.toHaveBeenCalled();
       // Each image gets the source-aware fallback description.
       expect(result.success).toBe(true);
       expect(result.descriptions).toHaveLength(1);
@@ -740,7 +799,7 @@ describe('ImageDescriptionJob', () => {
       expect(mockDescribeImage).not.toHaveBeenCalled();
     });
 
-    it('should default to guest mode when ApiKeyResolver fails', async () => {
+    it('fails fast (graceful degrade) when ApiKeyResolver throws transiently', async () => {
       const jobData: ImageDescriptionJobData = {
         requestId: 'test-req-resolver-fail',
         jobType: JobType.ImageDescription,
@@ -768,26 +827,19 @@ describe('ImageDescriptionJob', () => {
         data: jobData,
       } as Job<ImageDescriptionJobData>;
 
-      // Mock ApiKeyResolver throwing an error
+      // tryResolveUserKey throws → resolveVisionConfig's try/catch returns
+      // failFast (graceful degrade to the "configure your key" placeholder).
       const mockApiKeyResolver = {
-        resolveApiKey: vi.fn().mockRejectedValue(new Error('Database connection failed')),
+        tryResolveUserKey: vi.fn().mockRejectedValue(new Error('Database connection failed')),
+        resolveApiKey: vi.fn(),
       } as unknown as ApiKeyResolver;
 
-      await processImageDescriptionJob(job, mockApiKeyResolver);
+      const result = await processImageDescriptionJob(job, mockApiKeyResolver);
 
-      // Execute the retry function to verify describeImage receives isGuestMode=true (fallback)
-      const retryFn = mockWithRetry.mock.calls[0][0];
-      await retryFn();
-      expect(mockDescribeImage).toHaveBeenCalledWith(
-        expect.objectContaining({ url: 'https://example.com/image1.png' }),
-        mockPersonality,
-        true, // isGuestMode defaults to true on error
-        undefined, // userApiKey is undefined on error (no key resolved)
-        expect.objectContaining({
-          skipNegativeCache: true,
-          loggingContext: expect.objectContaining({ userId: 'user-error' }),
-        })
-      );
+      expect(result.success).toBe(true);
+      expect(result.descriptions?.[0]?.description).toContain('check /settings apikey set');
+      expect(mockWithRetry).not.toHaveBeenCalled();
+      expect(mockDescribeImage).not.toHaveBeenCalled();
     });
 
     it('should pass skipNegativeCache: true to describeImage within retry loop', async () => {
@@ -872,36 +924,5 @@ describe('ImageDescriptionJob', () => {
         })
       );
     });
-  });
-});
-
-describe('USER_AUTH_PROBE_PROVIDERS', () => {
-  it('excludes every provider tagged in NON_LLM_PROVIDERS', () => {
-    // Locks in the contract that drove the refactor: NON_LLM_PROVIDERS is the
-    // single source of truth for "which providers should NOT make a user
-    // count as LLM-authenticated." If a future contributor removes a tag
-    // from NON_LLM_PROVIDERS without intending to, this test fires.
-    for (const nonLlm of NON_LLM_PROVIDERS) {
-      expect(USER_AUTH_PROBE_PROVIDERS).not.toContain(nonLlm);
-    }
-  });
-
-  it('includes every AIProvider variant that is not in NON_LLM_PROVIDERS', () => {
-    // The inverse: a new LLM provider added to AIProvider must auto-include
-    // in the probe list. If someone refactors USER_AUTH_PROBE_PROVIDERS back
-    // to a hardcoded array and forgets to update it when a new provider lands,
-    // this test fires.
-    const nonLlmSet = new Set<AIProvider>(NON_LLM_PROVIDERS);
-    const expected = Object.values(AIProvider).filter(p => !nonLlmSet.has(p));
-    expect([...USER_AUTH_PROBE_PROVIDERS].sort()).toEqual([...expected].sort());
-  });
-
-  it('currently includes OpenRouter and ZaiCoding, excludes ElevenLabs', () => {
-    // Snapshot of the current concrete state — supplements the structural
-    // assertions above with a value-level check so a reader of the test file
-    // can see at a glance which providers are in scope today.
-    expect(USER_AUTH_PROBE_PROVIDERS).toContain(AIProvider.OpenRouter);
-    expect(USER_AUTH_PROBE_PROVIDERS).toContain(AIProvider.ZaiCoding);
-    expect(USER_AUTH_PROBE_PROVIDERS).not.toContain(AIProvider.ElevenLabs);
   });
 });

--- a/services/ai-worker/src/jobs/ImageDescriptionJob.ts
+++ b/services/ai-worker/src/jobs/ImageDescriptionJob.ts
@@ -21,8 +21,11 @@ import { describeImage } from '../services/MultimodalProcessor.js';
 import { withRetry } from '../utils/retry.js';
 import { shouldRetryError, getErrorLogContext } from '../utils/apiErrorParser.js';
 import type { ApiKeyResolver } from '../services/ApiKeyResolver.js';
-import { detectVisionProvider, effectiveVisionModelName } from '../services/ProviderRouter.js';
-import { VISION_AUTH_FAIL_FAST_DESCRIPTION } from '../services/multimodal/visionAuthResolver.js';
+import {
+  resolveVisionConfig,
+  VISION_AUTH_FAIL_FAST_DESCRIPTION,
+  type VisionConfigResult,
+} from '../services/multimodal/visionAuthResolver.js';
 
 const logger = createLogger('ImageDescriptionJob');
 
@@ -43,163 +46,53 @@ interface ImageProcessResult {
 }
 
 /**
- * Result of API key resolution for vision processing.
+ * Resolve auth + model for vision processing via the unified `resolveVisionConfig`.
  *
- * Discriminated union: a normal `proceed` result with the resolved auth context,
- * or a `failFast` signal when the user is authenticated for some provider but
- * lacks a key for the vision provider — matches the policy enforced in
- * `DependencyStep` via `resolveVisionAuth` so a Discord user gets the same
- * fallback string regardless of which path serves their image (direct upload
- * vs. channel-history extended context).
- */
-type VisionApiKeyResult =
-  | {
-      kind: 'proceed';
-      isGuestMode: boolean;
-      userApiKey?: string;
-      apiKeySource?: 'user' | 'system';
-      visionProvider?: AIProvider;
-    }
-  | {
-      kind: 'failFast';
-      visionProvider: AIProvider;
-    };
-
-/**
- * Providers explicitly excluded from "is this user authenticated for LLM/vision
- * purposes?" probing. ElevenLabs is voice-only; a user with only an ElevenLabs
- * key isn't an LLM-authenticated user and should not bypass system fallback.
+ * `ImageDescriptionJob` runs as a standalone preprocessing job at upload time,
+ * so it has no upstream main-model auth context — `mainProvider`/`mainApiKey`
+ * are undefined (the same-provider fast path is skipped; per-provider resolution
+ * always runs). `isGuestMode` is passed as `false`: the resolver discriminates
+ * genuine-guest-vs-authenticated by probing the vision provider's user key, and
+ * a genuine guest with no keys anywhere still resolves correctly to the system
+ * key + free model via the broad free-fallback branch.
  *
- * Exported as a readonly tuple so any future non-LLM provider added to
- * `AIProvider` (e.g., a dedicated TTS or STT provider) has a single canonical
- * place to opt out of authentication probing.
- */
-export const NON_LLM_PROVIDERS = [AIProvider.ElevenLabs] as const;
-
-const NON_LLM_PROVIDER_SET: ReadonlySet<AIProvider> = new Set(NON_LLM_PROVIDERS);
-
-/**
- * Providers checked when determining whether a user is "authenticated" — i.e.
- * has at least one user-configured key for SOME provider. Drives the
- * fail-fast vs system-fallback discriminator inside `resolveVisionApiKey`.
- *
- * Derived from `AIProvider` (minus `NON_LLM_PROVIDERS`) so that adding a new
- * LLM provider to the enum auto-includes it in the probe list. The previous
- * hardcoded form went stale with z.ai and was a documented drift risk —
- * future-us would have silently misclassified new-provider-only users as
- * guests until someone noticed.
- *
- * Order doesn't matter for correctness — `userHasAnyKey` short-circuits on
- * first hit.
- */
-export const USER_AUTH_PROBE_PROVIDERS: readonly AIProvider[] = Object.values(AIProvider).filter(
-  (p): p is AIProvider => !NON_LLM_PROVIDER_SET.has(p)
-);
-
-/**
- * Determine whether a user has at least one user-configured key for any LLM
- * provider. Used as the "authenticated vs genuine guest" discriminator
- * inside this job, since (unlike DependencyStep) ImageDescriptionJob has no
- * upstream `auth.isGuestMode` signal — it runs as a standalone preprocessing
- * job at upload time.
- *
- * Each call hits ApiKeyResolver's internal cache after the first lookup per
- * `userId × provider` pair, so the cost is bounded.
- */
-async function userHasAnyKey(apiKeyResolver: ApiKeyResolver, userId: string): Promise<boolean> {
-  for (const provider of USER_AUTH_PROBE_PROVIDERS) {
-    const key = await apiKeyResolver.tryResolveUserKey(userId, provider);
-    if (key !== null) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
- * Resolve API key for vision processing via BYOK lookup.
- *
- * Decision tree (matches `resolveVisionAuth` policy in `DependencyStep`):
- * - User has key for vision provider → use user key
- * - User has no key for vision provider, but is authenticated for some other
- *   provider → fail fast (no silent system-key fallback for authenticated users)
- * - User has no keys anywhere → genuine guest, system-key fallback
- *
- * Detects the vision provider from the personality's vision model (vs the
- * old hardcoded `AIProvider.OpenRouter`) so that personalities with z.ai
- * vision models route to z.ai instead of mistakenly looking up the user's
- * OpenRouter key.
+ * Returns the unified `VisionConfigResult` directly. When `apiKeyResolver` is
+ * undefined (legacy test-fixture path; production always wires it via the
+ * worker bootstrap), we synthesize a `resolved` result that proceeds with no
+ * user key — matching the pre-unification legacy behavior.
  */
 async function resolveVisionApiKey(
   apiKeyResolver: ApiKeyResolver | undefined,
   userId: string,
   personality: ImageDescriptionJobData['personality']
-): Promise<VisionApiKeyResult> {
+): Promise<VisionConfigResult> {
   if (!apiKeyResolver) {
-    return { kind: 'proceed', isGuestMode: false };
-  }
-
-  // Provider detection runs against the actual vision-model name. The fallback
-  // chain (visionModel → main model → env default) mirrors `selectVisionModel`
-  // in VisionProcessor, but we don't have hasVisionSupport access here, so we
-  // take the explicit visionModel override if set, else default to the main
-  // model's provider (which is what selectVisionModel would also pick when
-  // the main model has native vision).
-  const visionProvider = detectVisionProvider(effectiveVisionModelName(personality));
-
-  try {
-    // First: try user's key for the vision provider directly. No system
-    // fallback here — that would silently consume the system key for an
-    // authenticated user, contradicting the user-confirmed policy.
-    const userKey = await apiKeyResolver.tryResolveUserKey(userId, visionProvider);
-    if (userKey !== null) {
-      logger.debug(
-        { userId, visionProvider, source: 'user' },
-        'Resolved user API key for vision processing'
-      );
-      return {
-        kind: 'proceed',
-        isGuestMode: false,
-        userApiKey: userKey,
-        apiKeySource: 'user',
-        visionProvider,
-      };
-    }
-
-    // No user key for vision provider. Discriminate: authenticated user
-    // missing this provider's key (fail fast) vs. genuine guest (system
-    // fallback).
-    const isAuthenticatedForSomeProvider = await userHasAnyKey(apiKeyResolver, userId);
-    if (isAuthenticatedForSomeProvider) {
-      logger.info(
-        { userId, visionProvider },
-        'Authenticated user lacks key for vision provider — failing fast (no system fallback)'
-      );
-      return { kind: 'failFast', visionProvider };
-    }
-
-    // Genuine guest — no user keys configured anywhere. System fallback is
-    // the only path that works for them; consistent with main-model auth
-    // resolution for guests.
-    const guestResult = await apiKeyResolver.resolveApiKey(userId, visionProvider);
-    logger.debug(
-      { userId, visionProvider, source: guestResult.source },
-      'Guest path — using system key fallback for vision'
-    );
+    // Legacy/no-resolver path: proceed with no user key. `describeImage`
+    // self-selects the model (model omitted) and `createChatModel` falls back
+    // to the env-default provider — same as the pre-unification behavior for
+    // this branch.
     return {
-      kind: 'proceed',
-      isGuestMode: guestResult.isGuestMode,
-      userApiKey: guestResult.source === 'user' ? guestResult.apiKey : undefined,
-      apiKeySource: guestResult.source,
-      visionProvider,
+      kind: 'resolved',
+      config: {
+        apiKey: '',
+        provider: AIProvider.OpenRouter,
+        model: '',
+        source: 'system',
+        isGuestMode: false,
+      },
     };
-  } catch (error) {
-    logger.warn(
-      { err: error, userId, visionProvider },
-      'Failed to resolve API key, defaulting to guest mode'
-    );
-    return { kind: 'proceed', isGuestMode: true, visionProvider };
   }
+
+  return resolveVisionConfig({
+    personality,
+    // No upstream main-model context at upload time — skip the same-provider
+    // fast path so per-provider resolution always runs.
+    mainProvider: undefined,
+    mainApiKey: undefined,
+    isGuestMode: false,
+    userId,
+    apiKeyResolver,
+  });
 }
 
 /**
@@ -212,6 +105,12 @@ interface ProcessSingleImageOptions {
   isGuestMode: boolean;
   userApiKey: string | undefined;
   visionProvider: AIProvider | undefined;
+  /**
+   * Pre-resolved vision model from `resolveVisionConfig`. Forwarded to
+   * `describeImage` so a forced free-tier downgrade is honored rather than
+   * re-selected. `undefined` falls back to `describeImage`'s self-selection.
+   */
+  model: string | undefined;
   loggingContext: {
     userId?: string;
     apiKeySource?: 'user' | 'system';
@@ -223,14 +122,22 @@ interface ProcessSingleImageOptions {
  * Process a single image attachment with retry logic
  */
 async function processSingleImage(options: ProcessSingleImageOptions): Promise<ImageProcessResult> {
-  const { attachment, personality, isGuestMode, userApiKey, visionProvider, loggingContext } =
-    options;
+  const {
+    attachment,
+    personality,
+    isGuestMode,
+    userApiKey,
+    visionProvider,
+    model,
+    loggingContext,
+  } = options;
   try {
     const result = await withRetry(
       () =>
         describeImage(attachment, personality, isGuestMode, userApiKey, {
           skipNegativeCache: true,
           provider: visionProvider,
+          model,
           loggingContext: { ...loggingContext, provider: visionProvider },
         }),
       {
@@ -371,23 +278,35 @@ export async function processImageDescriptionJob(
     'Processing image description job'
   );
 
-  // Fail-fast: authenticated user has no key for the vision provider. Mirrors
-  // DependencyStep's `buildVisionAuthFailureResults` behavior so direct upload
-  // and channel-history paths produce the same fallback shape for the same
-  // user setup. Each image gets the source-aware "configure your key"
+  // Fail-fast: even the free-model system fallback is unavailable (no system
+  // OpenRouter key configured) for an authenticated user lacking a vision key.
+  // Mirrors DependencyStep's `buildVisionAuthFailureResults` behavior so direct
+  // upload and channel-history paths produce the same fallback shape for the
+  // same user setup. Each image gets the source-aware "configure your key"
   // description and a synthetic AUTH cache entry so retries within the 5-min
   // window hit cache instead of repeating the resolution + failing again.
   if (authResult.kind === 'failFast') {
     return buildFailFastResult({
       requestId,
       attachments,
-      visionProvider: authResult.visionProvider,
+      visionProvider: authResult.provider,
       sourceReferenceNumber,
       startTime,
     });
   }
 
-  const { isGuestMode, userApiKey, apiKeySource, visionProvider } = authResult;
+  const { config } = authResult;
+  // The no-resolver legacy path synthesizes empty apiKey/model sentinels —
+  // normalize them back to `undefined` so `describeImage` self-selects the model
+  // and `createChatModel` doesn't receive an empty Authorization header.
+  const isGuestMode = config.isGuestMode;
+  const userApiKey = config.apiKey.length > 0 ? config.apiKey : undefined;
+  const visionModel = config.model.length > 0 ? config.model : undefined;
+  const apiKeySource = config.source;
+  // The legacy no-resolver path resolves to provider=OpenRouter with an empty
+  // apiKey; in that case leave `visionProvider` undefined so `createChatModel`
+  // falls back to the env default exactly as the pre-unification path did.
+  const visionProvider = userApiKey !== undefined ? config.provider : undefined;
   const loggingContext = {
     userId: context.userId,
     apiKeySource,
@@ -411,6 +330,7 @@ export async function processImageDescriptionJob(
           isGuestMode,
           userApiKey,
           visionProvider,
+          model: visionModel,
           loggingContext,
         })
       )

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/DependencyStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/DependencyStep.test.ts
@@ -10,6 +10,7 @@ import {
   AttachmentType,
   AIProvider,
   ApiErrorCategory,
+  MODEL_DEFAULTS,
   REDIS_KEY_PREFIXES,
   type LLMGenerationJobData,
   type LoadedPersonality,
@@ -969,14 +970,13 @@ describe('DependencyStep', () => {
       expect(result.preprocessing?.extendedContextAttachments).toHaveLength(1);
     });
 
-    it('degrades gracefully when apiKeyResolver throws (e.g., transient Redis failure)', async () => {
-      // Outer try/catch in processExtendedContextImages must catch resolver
-      // exceptions thrown OUTSIDE the processAttachments try (e.g., during
-      // `tryResolveUserKey` or `resolveApiKey`). Without that wrapping, a
-      // transient blip in apiKeyResolver would propagate up through the
-      // pipeline step and skip the graceful fallback the legacy path already
-      // has. This test pins the wrap so a future refactor can't quietly
-      // remove it.
+    it('degrades to fail-fast placeholder when apiKeyResolver throws (e.g., transient Redis failure)', async () => {
+      // `resolveVisionConfig` wraps its resolver calls in a try/catch that
+      // returns `failFast` on a transient throw, so a Redis blip during
+      // `tryResolveUserKey`/`resolveApiKey` no longer propagates up the pipeline.
+      // DependencyStep then emits the fail-fast placeholder (1 synthetic-failure
+      // entry) rather than silently dropping the images. This test pins that the
+      // throw is contained AND surfaces a user-visible placeholder.
       const tryResolveUserKey = vi.fn().mockRejectedValue(new Error('Redis blip'));
       const apiKeyResolver = {
         tryResolveUserKey,
@@ -990,8 +990,10 @@ describe('DependencyStep', () => {
 
       expect(tryResolveUserKey).toHaveBeenCalled();
       expect(mockProcessAttachments).not.toHaveBeenCalled();
-      // Empty array signals "couldn't process, but pipeline continues."
-      expect(result.preprocessing?.extendedContextAttachments).toEqual([]);
+      // Fail-fast placeholder: 1 attachment → 1 synthetic-failure entry.
+      const synthetic = result.preprocessing?.extendedContextAttachments;
+      expect(synthetic).toHaveLength(1);
+      expect(synthetic?.[0]?.description).toContain('check /settings apikey set');
     });
 
     it('routes guest-mode cross-provider through resolveApiKey (system fallback path)', async () => {
@@ -1094,11 +1096,69 @@ describe('DependencyStep', () => {
       expect(result.preprocessing?.extendedContextAttachments).toHaveLength(1);
     });
 
-    it('builds synthetic-failure entries when authenticated user lacks vision-provider key (fail-fast)', async () => {
+    it('downgrades to the free model on the system key when authenticated user lacks vision-provider key', async () => {
+      // BROAD FREE FALLBACK: authenticated user with no key for the vision
+      // provider (OpenRouter) no longer fails fast — they downgrade to the free
+      // vision model on the system key. processAttachments IS called, with the
+      // forced free model + system key threaded through.
       const tryResolveUserKey = vi.fn().mockResolvedValue(null);
+      const resolveApiKey = vi.fn().mockResolvedValue({
+        apiKey: 'system-or-key',
+        source: 'system',
+        provider: AIProvider.OpenRouter,
+        isGuestMode: true,
+        userId: 'cross-provider-user',
+      });
       const apiKeyResolver = {
         tryResolveUserKey,
-        resolveApiKey: vi.fn(),
+        resolveApiKey,
+      } as unknown as ConstructorParameters<typeof DependencyStep>[0];
+      const stepWithResolver = new DependencyStep(apiKeyResolver);
+
+      mockProcessAttachments.mockResolvedValueOnce([
+        {
+          type: AttachmentType.Image,
+          description: 'free-fallback success',
+          originalUrl: 'https://example.com/cp.jpg',
+          metadata: {
+            url: 'https://example.com/cp.jpg',
+            name: 'cp.jpg',
+            contentType: 'image/jpeg',
+            size: 1024,
+          },
+        },
+      ]);
+
+      const result = await stepWithResolver.process(buildCrossProviderContext());
+
+      // resolveApiKey was called for the free-fallback provider (OpenRouter).
+      expect(resolveApiKey).toHaveBeenCalledWith('cross-provider-user', AIProvider.OpenRouter);
+      // processAttachments received the forced free model + system key, isGuestMode=false.
+      expect(mockProcessAttachments).toHaveBeenCalledWith(
+        [expect.objectContaining({ url: 'https://example.com/cp.jpg' })],
+        CROSS_PROVIDER_PERSONALITY,
+        expect.objectContaining({
+          isGuestMode: false,
+          userApiKey: 'system-or-key',
+          visionProvider: AIProvider.OpenRouter,
+          model: MODEL_DEFAULTS.VISION_FALLBACK_FREE,
+          loggingContext: expect.objectContaining({ apiKeySource: 'system' }),
+        })
+      );
+      expect(result.preprocessing?.extendedContextAttachments).toHaveLength(1);
+    });
+
+    it('builds synthetic-failure entries when even the free-model system fallback is unavailable', async () => {
+      // Fallback-of-fallback: authenticated user lacks the vision-provider key
+      // AND no system OpenRouter key is configured (resolveApiKey throws). The
+      // step emits the source-aware "configure your key" placeholder.
+      const tryResolveUserKey = vi.fn().mockResolvedValue(null);
+      const resolveApiKey = vi
+        .fn()
+        .mockRejectedValue(new Error('No API key available for provider openrouter'));
+      const apiKeyResolver = {
+        tryResolveUserKey,
+        resolveApiKey,
       } as unknown as ConstructorParameters<typeof DependencyStep>[0];
       const stepWithResolver = new DependencyStep(apiKeyResolver);
 
@@ -1111,8 +1171,6 @@ describe('DependencyStep', () => {
       // Asserting the full argument shape (not just call count) self-documents
       // that `attachmentId: undefined` is intentional — fixtures don't include
       // an `id` field, and `getFailureKey` falls through to URL-hash keying.
-      // A future refactor that breaks the storeFailure contract would fail
-      // this assertion instead of slipping past on the count alone.
       expect(mockStoreFailure).toHaveBeenCalledTimes(1);
       expect(mockStoreFailure).toHaveBeenCalledWith({
         attachmentId: undefined,

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/DependencyStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/DependencyStep.ts
@@ -21,11 +21,7 @@ import type { ProcessedAttachment } from '../../../../services/MultimodalProcess
 import type { IPipelineStep, GenerationContext, PreprocessingResults } from '../types.js';
 import type { ApiKeyResolver } from '../../../../services/ApiKeyResolver.js';
 import type { VisionDescriptionWriter } from '../../../../services/context/visionDescriptionWriter.js';
-import {
-  resolveVisionAuth,
-  buildVisionAuthFailureResults,
-} from '../../../../services/multimodal/visionAuthResolver.js';
-import { selectVisionModel } from '../../../../services/multimodal/VisionProcessor.js';
+import { processCrossProviderVisionImages } from './extendedContextVisionProcessor.js';
 
 const logger = createLogger('DependencyStep');
 
@@ -346,66 +342,18 @@ export class DependencyStep implements IPipelineStep {
     // for that case rather than falling through to the legacy path that lacks
     // explicit `provider` plumbing.
     if (this.apiKeyResolver !== undefined && mainProvider !== undefined) {
-      // Outer try/catch covers the entire cross-provider block — including
-      // `selectVisionModel`, `resolveVisionAuth`, and `processAttachments`.
-      // A transient Redis blip inside `apiKeyResolver.resolveApiKey` (guest
-      // path) or `tryResolveUserKey` (authenticated path) would otherwise
-      // throw out of `processExtendedContextImages` entirely, skipping the
-      // graceful "continuing without them" degradation that the legacy path
-      // already had. Wrapping at this scope keeps the failure UX consistent
-      // across all branches: a resolver throw degrades the same as a
-      // `processAttachments` throw — return empty, log, let the chat
-      // continue without the images.
-      try {
-        // Pre-compute the effective vision model with the same selection logic
-        // `describeImage` uses internally — so when `selectVisionModel` falls
-        // through to `VISION_FALLBACK_MODEL` (main lacks native vision and no
-        // override), provider detection sees the actual model rather than the
-        // main model. Without this, a personality with main=glm-5.1 (no vision)
-        // would have its provider detected as ZaiCoding even though the
-        // fallback model is on OpenRouter.
-        const effectiveVisionModel = await selectVisionModel(personality, isGuestMode);
-        const visionAuth = await resolveVisionAuth({
-          personality,
-          mainProvider,
-          mainApiKey: userApiKey,
-          isGuestMode,
-          userId,
-          apiKeyResolver: this.apiKeyResolver,
-          effectiveVisionModel,
-        });
-        if (visionAuth === null) {
-          // Authenticated user with no key for the vision provider. Fail-fast
-          // with synthetic-failure entries; the negative cache absorbs retries
-          // for 5min so the user sees a stable fallback string until they fix
-          // the key.
-          return buildVisionAuthFailureResults(imageAttachments);
-        }
-        const processed = await processAttachments(imageAttachments, personality, {
-          isGuestMode,
-          userApiKey: visionAuth.apiKey,
-          sttDispatch,
-          visionProvider: visionAuth.provider,
-          loggingContext: {
-            userId,
-            apiKeySource: visionAuth.source,
-            provider: visionAuth.provider,
-          },
-        });
-
-        logger.info(
-          { jobId, processedCount: processed.length, visionProvider: visionAuth.provider },
-          'Extended context images processed successfully'
-        );
-
-        return processed;
-      } catch (error) {
-        logger.error(
-          { err: error, jobId },
-          'Failed to process extended context images - continuing without them'
-        );
-        return [];
-      }
+      return processCrossProviderVisionImages({
+        imageAttachments,
+        personality,
+        jobId,
+        userId,
+        isGuestMode,
+        userApiKey,
+        sttDispatch,
+        mainProvider,
+        apiKeyResolver: this.apiKeyResolver,
+        processAttachments,
+      });
     }
 
     // Fallback path — reached when EITHER apiKeyResolver is undefined (legacy

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/extendedContextVisionProcessor.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/extendedContextVisionProcessor.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for processCrossProviderVisionImages
+ *
+ * Covers the cross-provider vision path extracted from DependencyStep:
+ * - authenticated user with vision-provider key → processAttachments runs
+ * - broad free fallback (no vision key, system key available) → free model
+ * - fail-fast (free-model system key unavailable) → synthetic-failure entries
+ * - transient resolver throw → fail-fast placeholder
+ * - processAttachments throw → empty array (graceful degrade)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  AIProvider,
+  AttachmentType,
+  MODEL_DEFAULTS,
+  type LoadedPersonality,
+  type AttachmentMetadata,
+} from '@tzurot/common-types';
+import { processCrossProviderVisionImages } from './extendedContextVisionProcessor.js';
+import type { ApiKeyResolver } from '../../../../services/ApiKeyResolver.js';
+import type { GenerationContext } from '../types.js';
+
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
+
+// resolveVisionConfig (real) calls selectVisionModel → checkModelVisionSupport
+// and buildVisionAuthFailureResults → visionDescriptionCache. Stub redis.js so
+// neither reaches a live client. The CROSS_PROVIDER personality sets a
+// visionModel override, so selectVisionModel returns it without consulting
+// checkModelVisionSupport — but stub it for safety.
+const mockStoreFailure = vi.fn();
+vi.mock('../../../../redis.js', () => ({
+  visionDescriptionCache: {
+    storeFailure: (...args: unknown[]) => mockStoreFailure(...args),
+  },
+  checkModelVisionSupport: vi.fn().mockResolvedValue(false),
+}));
+
+const CROSS_PROVIDER_PERSONALITY = {
+  id: 'pers-1',
+  ownerId: 'owner-1',
+  name: 'TestPersona',
+  slug: 'test',
+  model: 'glm-5.1', // → ZaiCoding
+  visionModel: 'qwen/qwen3.5-397b-a17b', // → OpenRouter
+  systemPrompt: '',
+  temperature: 0.7,
+} as unknown as LoadedPersonality;
+
+const IMAGE: AttachmentMetadata = {
+  id: 'att-1',
+  url: 'https://example.com/cp.jpg',
+  name: 'cp.jpg',
+  contentType: 'image/jpeg',
+  size: 1024,
+} as AttachmentMetadata;
+
+const mockProcessAttachments = vi.fn();
+
+function buildOpts(resolver: ApiKeyResolver) {
+  return {
+    imageAttachments: [IMAGE],
+    personality: CROSS_PROVIDER_PERSONALITY as GenerationContext['job']['data']['personality'],
+    jobId: 'job-1',
+    userId: 'user-1',
+    isGuestMode: false,
+    userApiKey: 'user-zai-key',
+    sttDispatch: undefined,
+    mainProvider: AIProvider.ZaiCoding,
+    apiKeyResolver: resolver,
+    processAttachments: mockProcessAttachments,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('processCrossProviderVisionImages', () => {
+  it('processes with the user key when authenticated user has the vision-provider key', async () => {
+    const resolver = {
+      tryResolveUserKey: vi.fn().mockResolvedValue('user-or-key'),
+      resolveApiKey: vi.fn(),
+    } as unknown as ApiKeyResolver;
+    mockProcessAttachments.mockResolvedValueOnce([
+      {
+        type: AttachmentType.Image,
+        description: 'ok',
+        originalUrl: IMAGE.url,
+        metadata: IMAGE,
+      },
+    ]);
+
+    const result = await processCrossProviderVisionImages(buildOpts(resolver));
+
+    expect(mockProcessAttachments).toHaveBeenCalledWith(
+      [expect.objectContaining({ url: IMAGE.url })],
+      CROSS_PROVIDER_PERSONALITY,
+      expect.objectContaining({
+        userApiKey: 'user-or-key',
+        visionProvider: AIProvider.OpenRouter,
+        model: 'qwen/qwen3.5-397b-a17b',
+      })
+    );
+    expect(result).toHaveLength(1);
+  });
+
+  it('downgrades to the free model on the system key when user lacks the vision-provider key', async () => {
+    const resolver = {
+      tryResolveUserKey: vi.fn().mockResolvedValue(null),
+      resolveApiKey: vi.fn().mockResolvedValue({
+        apiKey: 'system-or-key',
+        source: 'system',
+        provider: AIProvider.OpenRouter,
+        isGuestMode: true,
+        userId: 'user-1',
+      }),
+    } as unknown as ApiKeyResolver;
+    mockProcessAttachments.mockResolvedValueOnce([]);
+
+    await processCrossProviderVisionImages(buildOpts(resolver));
+
+    expect(mockProcessAttachments).toHaveBeenCalledWith(
+      expect.any(Array),
+      CROSS_PROVIDER_PERSONALITY,
+      expect.objectContaining({
+        isGuestMode: false,
+        userApiKey: 'system-or-key',
+        model: MODEL_DEFAULTS.VISION_FALLBACK_FREE,
+        visionProvider: AIProvider.OpenRouter,
+      })
+    );
+  });
+
+  it('returns fail-fast placeholder when the free-model system fallback is unavailable', async () => {
+    const resolver = {
+      tryResolveUserKey: vi.fn().mockResolvedValue(null),
+      resolveApiKey: vi.fn().mockRejectedValue(new Error('No API key available')),
+    } as unknown as ApiKeyResolver;
+
+    const result = await processCrossProviderVisionImages(buildOpts(resolver));
+
+    expect(mockProcessAttachments).not.toHaveBeenCalled();
+    expect(result).toHaveLength(1);
+    expect(result[0]?.description).toContain('check /settings apikey set');
+    expect(mockStoreFailure).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns fail-fast placeholder when the resolver throws transiently', async () => {
+    const resolver = {
+      tryResolveUserKey: vi.fn().mockRejectedValue(new Error('Redis blip')),
+      resolveApiKey: vi.fn(),
+    } as unknown as ApiKeyResolver;
+
+    const result = await processCrossProviderVisionImages(buildOpts(resolver));
+
+    expect(mockProcessAttachments).not.toHaveBeenCalled();
+    expect(result).toHaveLength(1);
+    expect(result[0]?.description).toContain('check /settings apikey set');
+  });
+
+  it('returns empty array when processAttachments itself throws (hard degrade)', async () => {
+    const resolver = {
+      tryResolveUserKey: vi.fn().mockResolvedValue('user-or-key'),
+      resolveApiKey: vi.fn(),
+    } as unknown as ApiKeyResolver;
+    mockProcessAttachments.mockRejectedValueOnce(new Error('processing exploded'));
+
+    const result = await processCrossProviderVisionImages(buildOpts(resolver));
+
+    expect(result).toEqual([]);
+  });
+});

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/extendedContextVisionProcessor.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/extendedContextVisionProcessor.ts
@@ -1,0 +1,120 @@
+/**
+ * Extended-context cross-provider vision processing.
+ *
+ * Extracted from `DependencyStep` so the cross-provider vision path (resolve
+ * auth + model atomically via `resolveVisionConfig`, then process) lives in its
+ * own testable unit. The split is along the apiKeyResolver-present boundary —
+ * DependencyStep keeps the legacy fallback inline and delegates the
+ * cross-provider case here.
+ */
+
+import {
+  createLogger,
+  type AIProvider,
+  type AttachmentMetadata,
+  type SttDispatch,
+} from '@tzurot/common-types';
+import type { ApiKeyResolver } from '../../../../services/ApiKeyResolver.js';
+import type { GenerationContext } from '../types.js';
+import type { ProcessedAttachment } from '../../../../services/MultimodalProcessor.js';
+import {
+  resolveVisionConfig,
+  buildVisionAuthFailureResults,
+} from '../../../../services/multimodal/visionAuthResolver.js';
+
+const logger = createLogger('ExtendedContextVisionProcessor');
+
+/**
+ * Inputs for `processCrossProviderVisionImages`. `processAttachments` is passed
+ * in (rather than imported) because the caller lazy-imports it to break a
+ * circular dependency with MultimodalProcessor.
+ */
+export interface CrossProviderVisionOptions {
+  imageAttachments: AttachmentMetadata[];
+  personality: GenerationContext['job']['data']['personality'];
+  jobId: string | undefined;
+  userId: string;
+  isGuestMode: boolean;
+  userApiKey?: string;
+  sttDispatch?: SttDispatch;
+  mainProvider: AIProvider;
+  apiKeyResolver: ApiKeyResolver;
+  processAttachments: (typeof import('../../../../services/MultimodalProcessor.js'))['processAttachments'];
+}
+
+/**
+ * Cross-provider vision path: resolve auth + model atomically via
+ * `resolveVisionConfig`, then process.
+ *
+ * The single try/catch covers the whole block (resolution + processing) so a
+ * transient resolver throw degrades the same as a `processAttachments` throw —
+ * return the fail-fast placeholder (or empty on a hard processing error), log,
+ * and let the chat continue. `resolveVisionConfig` may force a free-tier
+ * downgrade for an authenticated user who can't auth the vision provider — that
+ * forced model is threaded through `processAttachments.model` so `describeImage`
+ * honors it rather than re-selecting the paid fallback.
+ */
+export async function processCrossProviderVisionImages(
+  opts: CrossProviderVisionOptions
+): Promise<ProcessedAttachment[]> {
+  const {
+    imageAttachments,
+    personality,
+    jobId,
+    userId,
+    isGuestMode,
+    userApiKey,
+    sttDispatch,
+    mainProvider,
+    apiKeyResolver,
+    processAttachments,
+  } = opts;
+  try {
+    const visionResult = await resolveVisionConfig({
+      personality,
+      mainProvider,
+      mainApiKey: userApiKey,
+      isGuestMode,
+      userId,
+      apiKeyResolver,
+    });
+    if (visionResult.kind === 'failFast') {
+      // Even the free-model system fallback is unavailable (no system
+      // OpenRouter key). Fail-fast with synthetic-failure entries; the
+      // negative cache absorbs retries for 5min so the user sees a stable
+      // fallback string until they fix the key.
+      return await buildVisionAuthFailureResults(imageAttachments);
+    }
+    const { config } = visionResult;
+    const processed = await processAttachments(imageAttachments, personality, {
+      isGuestMode: config.isGuestMode,
+      userApiKey: config.apiKey,
+      sttDispatch,
+      visionProvider: config.provider,
+      model: config.model,
+      loggingContext: {
+        userId,
+        apiKeySource: config.source,
+        provider: config.provider,
+      },
+    });
+
+    logger.info(
+      {
+        jobId,
+        processedCount: processed.length,
+        visionProvider: config.provider,
+        visionModel: config.model,
+      },
+      'Extended context images processed successfully'
+    );
+
+    return processed;
+  } catch (error) {
+    logger.error(
+      { err: error, jobId },
+      'Failed to process extended context images - continuing without them'
+    );
+    return [];
+  }
+}

--- a/services/ai-worker/src/services/MultimodalProcessor.ts
+++ b/services/ai-worker/src/services/MultimodalProcessor.ts
@@ -70,6 +70,14 @@ export interface ProcessAttachmentOptions {
    * Threaded down to `createChatModel` so cross-provider personalities route correctly.
    */
   visionProvider?: AIProvider;
+  /**
+   * Pre-resolved vision model name from `resolveVisionConfig`. Forwarded to
+   * `describeImage` so the unified resolver's chosen model (which may be a
+   * forced free-tier downgrade for a downgraded authenticated user) flows
+   * through instead of being re-selected by `selectVisionModel`. Optional; when
+   * omitted, `describeImage` self-selects (legacy behavior).
+   */
+  model?: string;
 }
 
 /**
@@ -80,12 +88,20 @@ async function processSingleAttachment(
   personality: LoadedPersonality,
   options: ProcessAttachmentOptions
 ): Promise<ProcessedAttachment | null> {
-  const { isGuestMode, userApiKey, sttDispatch, loggingContext = {}, visionProvider } = options;
+  const {
+    isGuestMode,
+    userApiKey,
+    sttDispatch,
+    loggingContext = {},
+    visionProvider,
+    model,
+  } = options;
   if (attachment.contentType.startsWith(CONTENT_TYPES.IMAGE_PREFIX)) {
     const description = await describeImage(attachment, personality, isGuestMode, userApiKey, {
       skipNegativeCache: true,
       loggingContext,
       provider: visionProvider,
+      model,
     });
     logger.info({ name: attachment.name }, 'Processed image attachment');
     return {
@@ -132,7 +148,14 @@ export async function processAttachments(
   personality: LoadedPersonality,
   options: ProcessAttachmentOptions
 ): Promise<ProcessedAttachment[]> {
-  const { isGuestMode, userApiKey, sttDispatch, loggingContext = {}, visionProvider } = options;
+  const {
+    isGuestMode,
+    userApiKey,
+    sttDispatch,
+    loggingContext = {},
+    visionProvider,
+    model,
+  } = options;
   logger.info(
     {
       attachmentCount: attachments.length,
@@ -143,6 +166,7 @@ export async function processAttachments(
       userId: loggingContext.userId,
       apiKeySource: loggingContext.apiKeySource,
       visionProvider,
+      visionModel: model,
     },
     'Processing attachments in parallel'
   );
@@ -157,6 +181,7 @@ export async function processAttachments(
         sttDispatch,
         loggingContext,
         visionProvider,
+        model,
       }),
     {
       maxAttempts: RETRY_CONFIG.MAX_ATTEMPTS,

--- a/services/ai-worker/src/services/multimodal/VisionProcessor.test.ts
+++ b/services/ai-worker/src/services/multimodal/VisionProcessor.test.ts
@@ -214,6 +214,48 @@ describe('VisionProcessor', () => {
         expect(mockModelInvoke).toHaveBeenCalledTimes(1);
         expect(mockCheckModelVisionSupport).not.toHaveBeenCalled();
       });
+
+      it('uses options.model directly and SKIPS selectVisionModel when provided', async () => {
+        // The unified `resolveVisionConfig` may force a free-tier model that
+        // selectVisionModel would not reproduce for an authenticated user. When
+        // a pre-resolved model is passed, describeImage must honor it verbatim
+        // and not re-run the (Redis-touching) selection logic.
+        const personality = createMockPersonality({
+          // Both fields would normally drive selection; neither should be
+          // consulted because options.model wins.
+          model: 'gpt-4o',
+          visionModel: 'claude-3-opus',
+        });
+
+        await describeImage(mockAttachment, personality, false, undefined, {
+          model: 'google/gemma-4-31b-it:free',
+        });
+
+        expect(mockCreateChatModel).toHaveBeenCalledWith(
+          expect.objectContaining({
+            modelName: 'google/gemma-4-31b-it:free',
+          })
+        );
+        expect(mockModelInvoke).toHaveBeenCalledTimes(1);
+        // selectVisionModel's only I/O is checkModelVisionSupport — it must not
+        // be reached. (visionModel override would also short-circuit it, but
+        // asserting it here locks in that options.model bypasses selection.)
+        expect(mockCheckModelVisionSupport).not.toHaveBeenCalled();
+      });
+
+      it('falls back to selectVisionModel when options.model is an empty string', async () => {
+        mockCheckModelVisionSupport.mockResolvedValue(false);
+        const personality = createMockPersonality({
+          model: 'gpt-4',
+          visionModel: undefined,
+        });
+
+        await describeImage(mockAttachment, personality, false, undefined, { model: '' });
+
+        // Empty model is treated as "not provided" → self-selection runs.
+        expect(mockCheckModelVisionSupport).toHaveBeenCalledWith('gpt-4');
+        expect(mockModelInvoke).toHaveBeenCalledTimes(1);
+      });
     });
 
     describe('createChatModel configuration', () => {

--- a/services/ai-worker/src/services/multimodal/VisionProcessor.ts
+++ b/services/ai-worker/src/services/multimodal/VisionProcessor.ts
@@ -148,6 +148,17 @@ export interface DescribeImageOptions {
    * "Make `visionProvider` required in vision-pipeline option bags."
    */
   provider?: AIProvider;
+  /**
+   * Pre-resolved vision model name. When provided, `describeImage` uses it
+   * directly and SKIPS the internal `selectVisionModel` call. This lets the
+   * unified `resolveVisionConfig` decision flow through — critically, when an
+   * authenticated user is downgraded to the free vision model, that forced
+   * model must reach `createChatModel` rather than being re-selected (which
+   * would pick the PAID fallback for `isGuestMode === false` and bill the
+   * system key for it). Optional for backward compat; omitting it preserves the
+   * legacy self-selection behavior.
+   */
+  model?: string;
 }
 
 /**
@@ -561,7 +572,13 @@ export async function describeImage(
       ? personality.systemPrompt
       : undefined;
 
-  const usedModel = await selectVisionModel(personality, isGuestMode);
+  // Honor a caller-supplied model (from `resolveVisionConfig`) over internal
+  // selection — the unified resolver may have forced a free-tier downgrade that
+  // `selectVisionModel` would not reproduce for an authenticated user.
+  const usedModel =
+    options.model !== undefined && options.model.length > 0
+      ? options.model
+      : await selectVisionModel(personality, isGuestMode);
   const description = await invokeVisionModel(attachment, usedModel, {
     systemPrompt,
     userApiKey,

--- a/services/ai-worker/src/services/multimodal/visionAuthResolver.test.ts
+++ b/services/ai-worker/src/services/multimodal/visionAuthResolver.test.ts
@@ -1,14 +1,18 @@
 /**
  * Tests for visionAuthResolver
  *
- * Covers the cross-provider vision-auth decision tree:
+ * Covers the unified `resolveVisionConfig` decision tree:
  * - Same-provider fast path → reuse main key, no resolver call
- * - Cross-provider, guest mode → resolveApiKey (system fallback OK)
- * - Cross-provider, authenticated, has user vision key → user key
- * - Cross-provider, authenticated, no user vision key → null (fail-fast)
+ * - Genuine guest → system key + free model
+ * - Authenticated user with a vision-provider key → user key + natural model
+ * - Authenticated user with NO vision-provider key → BROAD FREE FALLBACK
+ *   (free gemma model on the system key, source 'system', isGuestMode false)
+ * - Authenticated user, no vision key AND no system key → failFast
+ *   (fallback-of-fallback)
+ * - Transient resolver throw → graceful failFast degrade
  *
  * Plus the buildVisionAuthFailureResults helper that produces the
- * synthetic-failure batch when the resolver returns null.
+ * synthetic-failure batch when the resolver returns failFast.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -16,10 +20,12 @@ import {
   AIProvider,
   AttachmentType,
   ApiErrorCategory,
+  MODEL_DEFAULTS,
   type LoadedPersonality,
   type AttachmentMetadata,
 } from '@tzurot/common-types';
-import { resolveVisionAuth, buildVisionAuthFailureResults } from './visionAuthResolver.js';
+import { resolveVisionConfig, buildVisionAuthFailureResults } from './visionAuthResolver.js';
+import { selectVisionModel } from './VisionProcessor.js';
 import type { ApiKeyResolver } from '../ApiKeyResolver.js';
 
 // Logger mock — visionAuthResolver imports createLogger from common-types
@@ -36,6 +42,13 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
+// selectVisionModel is now called internally by resolveVisionConfig. Mock it so
+// each test controls the "natural" model the resolver derives the provider from,
+// without reaching into Redis (hasVisionSupport).
+vi.mock('./VisionProcessor.js', () => ({
+  selectVisionModel: vi.fn(),
+}));
+
 // VisionDescriptionCache singleton mock — buildVisionAuthFailureResults writes
 // to it; we just verify the call shape.
 const mockStoreFailure = vi.fn();
@@ -44,6 +57,8 @@ vi.mock('../../redis.js', () => ({
     storeFailure: (...args: unknown[]) => mockStoreFailure(...args),
   },
 }));
+
+const mockSelectVisionModel = vi.mocked(selectVisionModel);
 
 const personality: LoadedPersonality = {
   id: 'pers-1',
@@ -55,18 +70,6 @@ const personality: LoadedPersonality = {
   systemPrompt: '',
   temperature: 0.7,
   topP: 1,
-} as unknown as LoadedPersonality;
-
-const personalitySameProvider: LoadedPersonality = {
-  ...personality,
-  model: 'qwen/qwen3-72b',
-  visionModel: 'qwen/qwen3.5-397b-a17b',
-} as unknown as LoadedPersonality;
-
-const personalityNoVisionOverride: LoadedPersonality = {
-  ...personality,
-  visionModel: null,
-  model: 'glm-5.1',
 } as unknown as LoadedPersonality;
 
 const mockResolveApiKey = vi.fn();
@@ -81,11 +84,14 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe('resolveVisionAuth', () => {
+describe('resolveVisionConfig', () => {
   describe('same-provider fast path', () => {
-    it('reuses main key without calling resolver when vision and main share provider', async () => {
-      const auth = await resolveVisionAuth({
-        personality: personalitySameProvider,
+    it('reuses main key + natural model when vision and main share provider', async () => {
+      // Natural model is on OpenRouter; mainProvider is OpenRouter → fast path.
+      mockSelectVisionModel.mockResolvedValue('qwen/qwen3.5-397b-a17b');
+
+      const result = await resolveVisionConfig({
+        personality,
         mainProvider: AIProvider.OpenRouter,
         mainApiKey: 'main-or-key',
         isGuestMode: false,
@@ -93,18 +99,25 @@ describe('resolveVisionAuth', () => {
         apiKeyResolver: mockResolver,
       });
 
-      expect(auth).toEqual({
-        apiKey: 'main-or-key',
-        source: 'user',
-        provider: AIProvider.OpenRouter,
+      expect(result).toEqual({
+        kind: 'resolved',
+        config: {
+          apiKey: 'main-or-key',
+          provider: AIProvider.OpenRouter,
+          model: 'qwen/qwen3.5-397b-a17b',
+          source: 'user',
+          isGuestMode: false,
+        },
       });
       expect(mockResolveApiKey).not.toHaveBeenCalled();
       expect(mockTryResolveUserKey).not.toHaveBeenCalled();
     });
 
     it('marks source as "system" on the fast path when main was guest-mode', async () => {
-      const auth = await resolveVisionAuth({
-        personality: personalitySameProvider,
+      mockSelectVisionModel.mockResolvedValue('qwen/qwen3.5-397b-a17b');
+
+      const result = await resolveVisionConfig({
+        personality,
         mainProvider: AIProvider.OpenRouter,
         mainApiKey: 'system-or-key',
         isGuestMode: true,
@@ -112,58 +125,57 @@ describe('resolveVisionAuth', () => {
         apiKeyResolver: mockResolver,
       });
 
-      // Null guard explicit: the fast path can never return null (only the
-      // cross-provider authenticated-no-key branch returns null), so a null
-      // here would be a real regression. Asserting it explicitly prevents the
-      // optional-chain `auth?.source` from masking a null with a passing test.
-      expect(auth).not.toBeNull();
-      expect(auth?.source).toBe('system');
+      expect(result.kind).toBe('resolved');
+      if (result.kind === 'resolved') {
+        expect(result.config.source).toBe('system');
+        expect(result.config.isGuestMode).toBe(true);
+      }
     });
-  });
 
-  describe('cross-provider, authenticated user', () => {
-    it('returns user key for vision provider when available (user has both keys)', async () => {
+    it('skips fast path when mainApiKey is empty (AuthStep degraded path)', async () => {
+      // main+vision both OpenRouter, but mainApiKey empty → per-provider resolution.
+      mockSelectVisionModel.mockResolvedValue('qwen/qwen3-72b');
       mockTryResolveUserKey.mockResolvedValue('user-or-key');
 
-      const auth = await resolveVisionAuth({
-        personality, // main=glm-5.1 (z.ai), vision=qwen/... (OpenRouter)
-        mainProvider: AIProvider.ZaiCoding,
-        mainApiKey: 'user-zai-key',
+      const result = await resolveVisionConfig({
+        personality,
+        mainProvider: AIProvider.OpenRouter,
+        mainApiKey: '',
         isGuestMode: false,
         userId: 'user-1',
         apiKeyResolver: mockResolver,
       });
 
-      expect(auth).toEqual({
-        apiKey: 'user-or-key',
-        source: 'user',
-        provider: AIProvider.OpenRouter,
-      });
       expect(mockTryResolveUserKey).toHaveBeenCalledWith('user-1', AIProvider.OpenRouter);
-      // Authenticated path uses tryResolveUserKey (no system fallback), not resolveApiKey.
-      expect(mockResolveApiKey).not.toHaveBeenCalled();
+      expect(result.kind).toBe('resolved');
+      if (result.kind === 'resolved') {
+        expect(result.config.apiKey).toBe('user-or-key');
+      }
     });
 
-    it('returns null (fail-fast) when authenticated user has no key for vision provider', async () => {
-      mockTryResolveUserKey.mockResolvedValue(null);
+    it('skips fast path when mainProvider is undefined (upload-time job)', async () => {
+      mockSelectVisionModel.mockResolvedValue('qwen/qwen3.5-397b-a17b');
+      mockTryResolveUserKey.mockResolvedValue('user-or-key');
 
-      const auth = await resolveVisionAuth({
-        personality, // main=z.ai, vision=OpenRouter
-        mainProvider: AIProvider.ZaiCoding,
-        mainApiKey: 'user-zai-key',
+      const result = await resolveVisionConfig({
+        personality,
+        mainProvider: undefined,
+        mainApiKey: undefined,
         isGuestMode: false,
         userId: 'user-1',
         apiKeyResolver: mockResolver,
       });
 
-      expect(auth).toBeNull();
-      // Critically: resolveApiKey is NOT called (no system fallback for auth users)
-      expect(mockResolveApiKey).not.toHaveBeenCalled();
+      // No fast path → per-provider authenticated lookup runs.
+      expect(mockTryResolveUserKey).toHaveBeenCalledWith('user-1', AIProvider.OpenRouter);
+      expect(result.kind).toBe('resolved');
     });
   });
 
-  describe('cross-provider, guest mode', () => {
-    it('falls back to system key via resolveApiKey when isGuestMode=true', async () => {
+  describe('genuine guest', () => {
+    it('resolves system key + free model via resolveApiKey when isGuestMode=true', async () => {
+      // selectVisionModel returns the free model for guests.
+      mockSelectVisionModel.mockResolvedValue(MODEL_DEFAULTS.VISION_FALLBACK_FREE);
       mockResolveApiKey.mockResolvedValue({
         apiKey: 'system-or-key',
         source: 'system',
@@ -172,7 +184,7 @@ describe('resolveVisionAuth', () => {
         userId: undefined,
       });
 
-      const auth = await resolveVisionAuth({
+      const result = await resolveVisionConfig({
         personality,
         mainProvider: AIProvider.ZaiCoding,
         mainApiKey: 'system-zai-key',
@@ -181,63 +193,28 @@ describe('resolveVisionAuth', () => {
         apiKeyResolver: mockResolver,
       });
 
-      expect(auth).toEqual({
-        apiKey: 'system-or-key',
-        source: 'system',
-        provider: AIProvider.OpenRouter,
+      expect(result).toEqual({
+        kind: 'resolved',
+        config: {
+          apiKey: 'system-or-key',
+          provider: AIProvider.OpenRouter,
+          model: MODEL_DEFAULTS.VISION_FALLBACK_FREE,
+          source: 'system',
+          isGuestMode: true,
+        },
       });
       expect(mockResolveApiKey).toHaveBeenCalledWith(undefined, AIProvider.OpenRouter);
       expect(mockTryResolveUserKey).not.toHaveBeenCalled();
     });
   });
 
-  describe('degraded upstream auth (AuthStep error-recovery case)', () => {
-    it('skips fast path and resolves per-provider when mainApiKey is undefined', async () => {
-      // AuthStep's catch branch returns `resolvedApiKey: undefined` when
-      // ProviderRouter.resolveRoute throws. Same provider fast path would
-      // otherwise hand createChatModel an empty Authorization header,
-      // reproducing the original bug. We force per-provider resolution so
-      // the user's actual keys (if any) get picked up.
+  describe('authenticated user with vision-provider key', () => {
+    it('returns user key + natural model when the user has the vision-provider key', async () => {
+      mockSelectVisionModel.mockResolvedValue('qwen/qwen3.5-397b-a17b'); // OpenRouter
       mockTryResolveUserKey.mockResolvedValue('user-or-key');
 
-      const auth = await resolveVisionAuth({
-        personality: personalitySameProvider, // main+vision both OpenRouter
-        mainProvider: AIProvider.OpenRouter,
-        mainApiKey: undefined, // ← AuthStep failure
-        isGuestMode: false,
-        userId: 'user-1',
-        apiKeyResolver: mockResolver,
-      });
-
-      expect(auth?.apiKey).toBe('user-or-key');
-      // Same-provider fast path was bypassed → tryResolveUserKey was called.
-      expect(mockTryResolveUserKey).toHaveBeenCalledWith('user-1', AIProvider.OpenRouter);
-    });
-
-    it('skips fast path and resolves per-provider when mainApiKey is empty string', async () => {
-      // Defensive: a future caller might pass `auth.apiKey ?? ''` and end up
-      // with an empty string. The empty-string check guards against that
-      // exactly the same way as undefined.
-      mockTryResolveUserKey.mockResolvedValue('user-or-key');
-
-      const auth = await resolveVisionAuth({
-        personality: personalitySameProvider,
-        mainProvider: AIProvider.OpenRouter,
-        mainApiKey: '',
-        isGuestMode: false,
-        userId: 'user-1',
-        apiKeyResolver: mockResolver,
-      });
-
-      expect(auth?.apiKey).toBe('user-or-key');
-      expect(mockTryResolveUserKey).toHaveBeenCalled();
-    });
-  });
-
-  describe('vision-model fallback when no override', () => {
-    it('uses main model name to detect provider when personality.visionModel is null', async () => {
-      const auth = await resolveVisionAuth({
-        personality: personalityNoVisionOverride, // main=glm-5.1, vision=null
+      const result = await resolveVisionConfig({
+        personality, // main=glm-5.1 (z.ai), vision=qwen/... (OpenRouter)
         mainProvider: AIProvider.ZaiCoding,
         mainApiKey: 'user-zai-key',
         isGuestMode: false,
@@ -245,30 +222,119 @@ describe('resolveVisionAuth', () => {
         apiKeyResolver: mockResolver,
       });
 
-      // glm-5.1 → ZaiCoding, matches mainProvider → fast path
-      expect(auth?.provider).toBe(AIProvider.ZaiCoding);
-      expect(auth?.apiKey).toBe('user-zai-key');
-      expect(mockTryResolveUserKey).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        kind: 'resolved',
+        config: {
+          apiKey: 'user-or-key',
+          provider: AIProvider.OpenRouter,
+          model: 'qwen/qwen3.5-397b-a17b',
+          source: 'user',
+          isGuestMode: false,
+        },
+      });
+      expect(mockTryResolveUserKey).toHaveBeenCalledWith('user-1', AIProvider.OpenRouter);
+      // No system fallback was consulted for the natural provider.
+      expect(mockResolveApiKey).not.toHaveBeenCalledWith('user-1', AIProvider.OpenRouter);
     });
   });
 
-  describe('effectiveVisionModel override', () => {
-    it('uses caller-provided effectiveVisionModel over personality fields', async () => {
-      mockTryResolveUserKey.mockResolvedValue('user-or-key');
+  describe('BROAD FREE FALLBACK — authenticated user, no vision-provider key', () => {
+    it('downgrades to the free gemma model on the system key (source system, isGuestMode false)', async () => {
+      // Natural model is on OpenRouter; user has NO OpenRouter key.
+      mockSelectVisionModel.mockResolvedValue('qwen/qwen3.5-397b-a17b');
+      mockTryResolveUserKey.mockResolvedValue(null);
+      // resolveApiKey for the FREE provider returns the system key.
+      mockResolveApiKey.mockResolvedValue({
+        apiKey: 'system-or-key',
+        source: 'system',
+        provider: AIProvider.OpenRouter,
+        isGuestMode: true,
+        userId: 'user-1',
+      });
 
-      const auth = await resolveVisionAuth({
-        personality: personalityNoVisionOverride, // says ZaiCoding model
+      const result = await resolveVisionConfig({
+        personality,
         mainProvider: AIProvider.ZaiCoding,
         mainApiKey: 'user-zai-key',
         isGuestMode: false,
         userId: 'user-1',
         apiKeyResolver: mockResolver,
-        effectiveVisionModel: 'anthropic/claude-3.5-sonnet', // overrides
       });
 
-      // The override should make it OpenRouter, triggering cross-provider lookup
-      expect(auth?.provider).toBe(AIProvider.OpenRouter);
-      expect(mockTryResolveUserKey).toHaveBeenCalledWith('user-1', AIProvider.OpenRouter);
+      expect(result.kind).toBe('resolved');
+      if (result.kind === 'resolved') {
+        // Headline assertions: free model forced, system key, NOT guest.
+        expect(result.config.model).toBe(MODEL_DEFAULTS.VISION_FALLBACK_FREE);
+        expect(result.config.apiKey).toBe('system-or-key');
+        expect(result.config.source).toBe('system');
+        expect(result.config.isGuestMode).toBe(false);
+        expect(result.config.provider).toBe(AIProvider.OpenRouter);
+      }
+      // The free model lives on OpenRouter — resolveApiKey was asked for that provider.
+      expect(mockResolveApiKey).toHaveBeenCalledWith('user-1', AIProvider.OpenRouter);
+    });
+  });
+
+  describe('fallback-of-fallback — no system key for the free provider', () => {
+    it('fails fast against the ORIGINAL vision provider when resolveApiKey throws', async () => {
+      mockSelectVisionModel.mockResolvedValue('qwen/qwen3.5-397b-a17b'); // OpenRouter
+      mockTryResolveUserKey.mockResolvedValue(null);
+      // No system OpenRouter key configured → resolveApiKey throws.
+      mockResolveApiKey.mockRejectedValue(
+        new Error('No API key available for provider openrouter')
+      );
+
+      const result = await resolveVisionConfig({
+        personality,
+        mainProvider: AIProvider.ZaiCoding,
+        mainApiKey: 'user-zai-key',
+        isGuestMode: false,
+        userId: 'user-1',
+        apiKeyResolver: mockResolver,
+      });
+
+      expect(result).toEqual({ kind: 'failFast', provider: AIProvider.OpenRouter });
+    });
+
+    it('fails fast when resolveApiKey returns an empty key (defense in depth)', async () => {
+      mockSelectVisionModel.mockResolvedValue('qwen/qwen3.5-397b-a17b');
+      mockTryResolveUserKey.mockResolvedValue(null);
+      mockResolveApiKey.mockResolvedValue({
+        apiKey: '',
+        source: 'system',
+        provider: AIProvider.OpenRouter,
+        isGuestMode: true,
+        userId: 'user-1',
+      });
+
+      const result = await resolveVisionConfig({
+        personality,
+        mainProvider: AIProvider.ZaiCoding,
+        mainApiKey: 'user-zai-key',
+        isGuestMode: false,
+        userId: 'user-1',
+        apiKeyResolver: mockResolver,
+      });
+
+      expect(result).toEqual({ kind: 'failFast', provider: AIProvider.OpenRouter });
+    });
+  });
+
+  describe('transient resolver throw', () => {
+    it('degrades to failFast when tryResolveUserKey throws (authenticated path)', async () => {
+      mockSelectVisionModel.mockResolvedValue('qwen/qwen3.5-397b-a17b');
+      mockTryResolveUserKey.mockRejectedValue(new Error('Redis blip'));
+
+      const result = await resolveVisionConfig({
+        personality,
+        mainProvider: AIProvider.ZaiCoding,
+        mainApiKey: 'user-zai-key',
+        isGuestMode: false,
+        userId: 'user-1',
+        apiKeyResolver: mockResolver,
+      });
+
+      expect(result).toEqual({ kind: 'failFast', provider: AIProvider.OpenRouter });
     });
   });
 });
@@ -316,5 +382,28 @@ describe('buildVisionAuthFailureResults', () => {
       url: 'https://cdn.discordapp.com/img2.png',
       category: ApiErrorCategory.AUTHENTICATION,
     });
+  });
+
+  it('returns placeholders even when the negative-cache write throws (best-effort)', async () => {
+    // Redis blip at fail-fast emission must NOT drop the user-facing placeholders.
+    // The cache write is best-effort; the caller's outer catch would otherwise
+    // turn a thrown cache error into an empty result (silently dropped images).
+    mockStoreFailure.mockRejectedValue(new Error('redis down'));
+
+    const attachments: AttachmentMetadata[] = [
+      {
+        id: 'att-1',
+        url: 'https://cdn.discordapp.com/img1.png',
+        contentType: 'image/png',
+        name: 'img1.png',
+        size: 100,
+      } as AttachmentMetadata,
+    ];
+
+    const results = await buildVisionAuthFailureResults(attachments);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.description).toContain('check /settings apikey set');
+    expect(mockStoreFailure).toHaveBeenCalledTimes(1);
   });
 });

--- a/services/ai-worker/src/services/multimodal/visionAuthResolver.ts
+++ b/services/ai-worker/src/services/multimodal/visionAuthResolver.ts
@@ -1,23 +1,30 @@
 /**
- * Vision Auth Resolver
+ * Vision Config Resolver
  *
- * Resolves the API key + provider for a vision call **independently** from the
- * main-model auth resolution. The personality's vision model may live on a
- * different provider than its main model (e.g., main=`glm-5.1` on z.ai-coding,
- * vision=`qwen/qwen3.5-...` on OpenRouter); using the main-model key for the
- * vision call results in a 401 from the vision provider's API.
+ * Resolves the API key + provider + model for a vision call **independently**
+ * from the main-model auth resolution. The personality's vision model may live
+ * on a different provider than its main model (e.g., main=`glm-5.1` on
+ * z.ai-coding, vision=`qwen/qwen3.5-...` on OpenRouter); using the main-model
+ * key for the vision call results in a 401 from the vision provider's API.
  *
- * Returns either:
- * - A `VisionAuth` triple — caller proceeds with the vision call normally
- * - `null` — caller MUST short-circuit (do NOT pass `undefined` to
- *   `createChatModel`, which would silently fall back to the system key and
- *   contradict the user-confirmed "no system fallback for authenticated users
- *   without a vision-provider key" policy)
+ * `resolveVisionConfig` returns a discriminated union:
+ * - `{ kind: 'resolved', config }` — caller proceeds with the vision call,
+ *   passing `config.model` through so the chosen model (which may be a forced
+ *   free-tier downgrade) is honored rather than re-selected.
+ * - `{ kind: 'failFast', provider }` — caller MUST short-circuit. Only happens
+ *   when even the free-model system fallback is unavailable (no system
+ *   OpenRouter key configured).
+ *
+ * Policy: an authenticated user lacking a key for the vision provider does NOT
+ * fail-fast; they downgrade to the free vision model
+ * (`MODEL_DEFAULTS.VISION_FALLBACK_FREE`) on the system OpenRouter key. This is
+ * the BROAD free-fallback behavior — it applies to ALL authenticated users who
+ * can't auth the vision provider, not a specific provider's users.
  *
  * Use `buildVisionAuthFailureResults` to construct the synthetic-failure
- * `ProcessedAttachment[]` when the resolver returns null. That helper writes
- * to the negative cache so subsequent retries within the 5-min window hit
- * cache instead of re-resolving and re-failing.
+ * `ProcessedAttachment[]` when the resolver returns `failFast`. That helper
+ * writes to the negative cache so subsequent retries within the 5-min window
+ * hit cache instead of re-resolving and re-failing.
  */
 
 import {
@@ -25,24 +32,17 @@ import {
   AIProvider,
   AttachmentType,
   ApiErrorCategory,
+  MODEL_DEFAULTS,
   type AttachmentMetadata,
   type LoadedPersonality,
 } from '@tzurot/common-types';
-import { detectVisionProvider, effectiveVisionModelName } from '../ProviderRouter.js';
+import { detectVisionProvider } from '../ProviderRouter.js';
+import { selectVisionModel } from './VisionProcessor.js';
 import { visionDescriptionCache } from '../../redis.js';
 import type { ApiKeyResolver } from '../ApiKeyResolver.js';
 import type { ProcessedAttachment } from '../MultimodalProcessor.js';
 
 const logger = createLogger('VisionAuthResolver');
-
-/**
- * Resolved auth context for a vision call.
- */
-export interface VisionAuth {
-  apiKey: string;
-  source: 'user' | 'system';
-  provider: AIProvider;
-}
 
 /**
  * Source-aware fallback description shown to the LLM when an authenticated
@@ -60,18 +60,56 @@ export const VISION_AUTH_FAIL_FAST_DESCRIPTION =
   '[Image unavailable: your API key was rejected — check /settings apikey set for the vision provider key]';
 
 /**
- * Inputs for `resolveVisionAuth` — bundled into an options object to keep the
+ * Resolved auth + model context for a vision call. Unifies the auth decision
+ * (which key, which provider) with the model decision (which vision model) so a
+ * downgraded authenticated user gets the system key AND the free model together —
+ * resolving them in separate functions risks handing the system key to a paid
+ * model (`selectVisionModel` returns the PAID fallback for `isGuestMode === false`).
+ */
+export interface VisionConfig {
+  apiKey: string;
+  provider: AIProvider;
+  /** Final resolved vision model — what `describeImage` should actually invoke. */
+  model: string;
+  source: 'user' | 'system';
+  /**
+   * PRESERVED meaning: "no keys anywhere" (genuine guest). A downgraded
+   * authenticated user (no vision-provider key, falling back to the free model
+   * on the system key) is NOT a guest — `isGuestMode` stays `false` for them.
+   * Downstream consumers that branch on `isGuestMode` must not conflate it with
+   * "using the system key."
+   */
+  isGuestMode: boolean;
+}
+
+/**
+ * Result of `resolveVisionConfig`.
+ * - `resolved` — caller proceeds with the vision call using `config`
+ * - `failFast` — even the free-model system fallback is unavailable (no system
+ *   OpenRouter key configured); caller short-circuits with the
+ *   `buildVisionAuthFailureResults` synthetic-failure batch. `provider` is the
+ *   ORIGINAL vision provider the user actually lacked, so telemetry/placeholders
+ *   reflect what they were missing rather than the free-fallback provider.
+ */
+export type VisionConfigResult =
+  | { kind: 'resolved'; config: VisionConfig }
+  | { kind: 'failFast'; provider: AIProvider };
+
+/**
+ * Inputs for `resolveVisionConfig` — bundled into an options object to keep the
  * call site readable when threaded through pipeline steps.
  */
-export interface ResolveVisionAuthOptions {
-  /** Personality whose vision model determines the target provider */
+export interface ResolveVisionConfigOptions {
+  /** Personality whose vision model determines the target provider + model. */
   personality: LoadedPersonality;
   /**
    * Provider that the main-model resolution landed on (typically `auth.provider`
    * from the upstream `AuthStep`). Drives the "is this same-provider, can we
-   * reuse the main key?" decision.
+   * reuse the main key?" decision. `undefined` for callers with no upstream
+   * main-model context (e.g., `ImageDescriptionJob`), in which case the
+   * same-provider fast path is skipped and per-provider resolution always runs.
    */
-  mainProvider: AIProvider;
+  mainProvider?: AIProvider;
   /**
    * API key the upstream resolution returned for the main model. Optional
    * because `AuthStep`'s resolution-failure recovery branch returns
@@ -87,145 +125,233 @@ export interface ResolveVisionAuthOptions {
   userId: string | undefined;
   /** Resolver instance for cross-provider lookups. */
   apiKeyResolver: ApiKeyResolver;
-  /**
-   * Override for the vision model name. Normally `resolveVisionAuth` derives
-   * the provider from `personality.visionModel ?? personality.model`. Callers
-   * with a precomputed effective model name (e.g., `selectVisionModel` already
-   * ran) may pass it here to keep the two decisions consistent.
-   */
-  effectiveVisionModel?: string;
 }
 
 /**
- * Resolve the API key + provider for a vision call, given main-model auth context.
+ * Resolve the API key + provider + model for a vision call atomically.
  *
- * Returns `null` ONLY when the user is authenticated and has no key for the
- * vision provider — caller must short-circuit. Genuine guests (no main-model
- * user key either) get the system key for the vision provider via the standard
- * `resolveApiKey` fallback path.
+ * Branch order:
+ * 1. Compute the natural vision model + provider via `selectVisionModel`.
+ * 2. Same-provider fast path — reuse the upstream main-model key.
+ * 3. Genuine guest (or unknown user) — system key for the vision provider.
+ * 4. Authenticated user with a vision-provider key — use it.
+ * 5. BROAD FREE FALLBACK — authenticated user lacking a vision-provider key
+ *    downgrades to the free vision model on the system OpenRouter key (instead
+ *    of fail-fasting). Forces BOTH the free model AND its provider's system key
+ *    so the system key never gets billed for a paid model.
+ * 6. Fallback-of-fallback — if even the free-model system key is unavailable
+ *    (no system OpenRouter key configured), `failFast` so the caller emits the
+ *    "configure your key" placeholder against the ORIGINAL vision provider.
  */
-export async function resolveVisionAuth(
-  options: ResolveVisionAuthOptions
-): Promise<VisionAuth | null> {
+export async function resolveVisionConfig(
+  options: ResolveVisionConfigOptions
+): Promise<VisionConfigResult> {
   const { personality, mainProvider, mainApiKey, isGuestMode, userId, apiKeyResolver } = options;
 
-  const visionModelName = options.effectiveVisionModel ?? effectiveVisionModelName(personality);
+  // Compute the natural model with the same selection logic `describeImage`
+  // uses internally, so provider detection sees the actual model rather than
+  // the main model (e.g. main=glm-5.1 with no native vision falls through to
+  // the OpenRouter fallback model — its provider is OpenRouter, not z.ai).
+  const naturalModel = await selectVisionModel(personality, isGuestMode);
+  const visionProvider = detectVisionProvider(naturalModel);
 
-  const visionProvider = detectVisionProvider(visionModelName);
-
-  // Same-provider fast path — reuse the upstream-resolved key without a
-  // second resolver call. Avoids redundant DB reads for the common case where
-  // main and vision share a provider.
+  // Same-provider fast path — reuse the upstream-resolved key without a second
+  // resolver call. Avoids redundant DB reads for the common case where main and
+  // vision share a provider.
   //
   // Gated on a non-empty `mainApiKey` because AuthStep's resolution-failure
-  // catch branch returns `resolvedApiKey: undefined` regardless of whether
-  // the failing user was authenticated or guest (it's the rare error path
-  // where ProviderRouter.resolveRoute throws — see AuthStep.ts:192-197).
-  // Reusing an empty key would silently reach `createChatModel` with no
-  // Authorization header and reproduce the exact bug this resolver exists
-  // to prevent. Falling through to per-provider resolution lets the user's
-  // actual keys (if any) be picked up via apiKeyResolver, rather than
-  // blindly trusting a degraded upstream context.
+  // catch branch returns `resolvedApiKey: undefined` regardless of whether the
+  // failing user was authenticated or guest (the rare error path where
+  // ProviderRouter.resolveRoute throws). Reusing an empty key would silently
+  // reach `createChatModel` with no Authorization header and reproduce the exact
+  // bug this resolver exists to prevent. Falling through to per-provider
+  // resolution lets the user's actual keys (if any) be picked up instead.
   if (visionProvider === mainProvider && mainApiKey !== undefined && mainApiKey.length > 0) {
     logger.debug(
       { userId, visionProvider, isGuestMode },
-      'Vision auth same-provider fast path — reusing main-model key'
+      'Vision config same-provider fast path — reusing main-model key'
     );
     return {
-      apiKey: mainApiKey,
-      source: isGuestMode ? 'system' : 'user',
-      provider: visionProvider,
+      kind: 'resolved',
+      config: {
+        apiKey: mainApiKey,
+        provider: visionProvider,
+        model: naturalModel,
+        source: isGuestMode ? 'system' : 'user',
+        isGuestMode,
+      },
     };
   }
 
-  // Defensive guard: an authenticated context (`isGuestMode === false`)
-  // that nonetheless has no userId is contradictory — `tryResolveUserKey`
-  // requires a userId to look up wallet entries. In practice the upstream
-  // pipeline only sets `isGuestMode: false` after a successful user-key
-  // resolution (which requires userId), so this branch isn't reachable from
-  // production code. Logging at warn level + degrading to the guest path
-  // surfaces a regression if any future caller violates the invariant
-  // without crashing the request.
+  // Defensive guard: an authenticated context (`isGuestMode === false`) that
+  // nonetheless has no userId is contradictory — `tryResolveUserKey` requires a
+  // userId to look up wallet entries. In practice the upstream pipeline only
+  // sets `isGuestMode: false` after a successful user-key resolution (which
+  // requires userId), so this branch isn't reachable from production code.
+  // Logging at warn level + degrading to the guest path surfaces a regression
+  // if any future caller violates the invariant without crashing the request.
   if (!isGuestMode && userId === undefined) {
     logger.warn(
       { mainProvider, visionProvider },
-      'Vision auth: !isGuestMode but userId undefined — degrading to guest path'
+      'Vision config: !isGuestMode but userId undefined — degrading to guest path'
     );
   }
   const treatAsGuest = isGuestMode || userId === undefined;
 
-  // Cross-provider: re-resolve for the vision provider.
-  if (treatAsGuest) {
-    // Genuine guest — system key is the only path that works for them. Vision
-    // requests in guest mode are restricted to free models by the provider
-    // anyway, so this is consistent with main-model auth behavior.
-    const result = await apiKeyResolver.resolveApiKey(userId, visionProvider);
+  // Wrap the resolver calls so a transient throw (e.g. Redis blip inside the
+  // resolver) degrades to a fail-fast placeholder rather than propagating out of
+  // the caller's vision pipeline. Mirrors the try/catch the upload-time path
+  // historically had in `resolveVisionApiKey`. (Model selection runs before this
+  // block intentionally — `selectVisionModel`'s Redis reads already degrade to a
+  // pattern-matching fallback, so a genuine throw there is a real error worth
+  // surfacing, not masking as a placeholder.)
+  try {
+    if (treatAsGuest) {
+      // Genuine guest — system key is the only path that works for them.
+      // `selectVisionModel` already returned the free model for guests, so
+      // `naturalModel` is correct here.
+      const result = await apiKeyResolver.resolveApiKey(userId, visionProvider);
+      logger.info(
+        { userId, visionProvider, mainProvider, source: result.source },
+        'Cross-provider vision config resolved (guest path)'
+      );
+      return {
+        kind: 'resolved',
+        config: {
+          apiKey: result.apiKey,
+          provider: visionProvider,
+          model: naturalModel,
+          source: result.source,
+          isGuestMode: result.isGuestMode,
+        },
+      };
+    }
+
+    // Authenticated user — try their key for the vision provider first.
+    const userKey = await apiKeyResolver.tryResolveUserKey(userId, visionProvider);
+    if (userKey !== null) {
+      logger.info(
+        { userId, visionProvider, mainProvider, source: 'user' },
+        'Cross-provider vision config resolved (authenticated user key)'
+      );
+      return {
+        kind: 'resolved',
+        config: {
+          apiKey: userKey,
+          provider: visionProvider,
+          model: naturalModel,
+          source: 'user',
+          isGuestMode: false,
+        },
+      };
+    }
+
+    // BROAD FREE FALLBACK — authenticated user with no key for the vision
+    // provider. Instead of fail-fasting, downgrade to the free vision model on
+    // the system key. MUST force BOTH the free model AND its provider's key:
+    // `selectVisionModel` returns the PAID fallback for authenticated users
+    // (isGuestMode=false), so handing the system key to `naturalModel` would
+    // bill the system key for a paid model.
+    const freeModel = MODEL_DEFAULTS.VISION_FALLBACK_FREE;
+    const freeProvider = detectVisionProvider(freeModel);
+    const sys = await apiKeyResolver.resolveApiKey(userId, freeProvider);
+    // `apiKey` is typed `string`, but guard against a null/empty result too —
+    // resolveApiKey normally throws when no key is available, so reaching here
+    // with no usable key is a defense-in-depth case. `sys.apiKey ?? ''` keeps
+    // the length check from throwing on a null returned by a misbehaving resolver.
+    if ((sys.apiKey ?? '').length === 0) {
+      // Fail-fast against the ORIGINAL vision provider so the placeholder
+      // reflects what they lacked.
+      logger.info(
+        { userId, visionProvider, freeProvider },
+        'Vision free-fallback unavailable (no system key) — failing fast'
+      );
+      return { kind: 'failFast', provider: visionProvider };
+    }
     logger.info(
-      { userId, visionProvider, mainProvider, source: result.source },
-      'Cross-provider vision auth resolved (guest path)'
+      { userId, visionProvider, freeProvider, freeModel, source: sys.source },
+      'Authenticated user lacks vision-provider key — downgrading to free vision model on system key'
     );
     return {
-      apiKey: result.apiKey,
-      source: result.source,
-      provider: visionProvider,
+      kind: 'resolved',
+      config: {
+        apiKey: sys.apiKey,
+        provider: freeProvider,
+        model: freeModel,
+        // `source` is whatever resolveApiKey returned — normally 'system'; if
+        // the user happens to have an OpenRouter key it'd be 'user', which is
+        // fine (they ARE authenticated, just downgraded for the vision model).
+        source: sys.source,
+        // NOT a guest — they're authenticated, only the vision model is downgraded.
+        isGuestMode: false,
+      },
     };
-  }
-
-  // Authenticated user — user key only, no system fallback. If user has no
-  // key for the vision provider, return null so caller can short-circuit
-  // with a "configure your key" fallback string.
-  const userKey = await apiKeyResolver.tryResolveUserKey(userId, visionProvider);
-  if (userKey === null) {
-    logger.info(
-      { userId, visionProvider, mainProvider },
-      'Cross-provider vision auth: authenticated user has no key for vision provider — failing fast'
+  } catch (error) {
+    // Fallback-of-fallback unavailable path: `resolveApiKey` throws when no key
+    // (user or system) is available for the requested provider. For the
+    // authenticated free-fallback branch that means no system OpenRouter key is
+    // configured → fail-fast against the original vision provider. For the guest
+    // branch a throw is genuinely unrecoverable too, so fail-fast is consistent.
+    logger.warn(
+      { err: error, userId, visionProvider },
+      'Vision config resolution failed — failing fast (no usable key for vision or free-fallback provider)'
     );
-    return null;
+    return { kind: 'failFast', provider: visionProvider };
   }
-  logger.info(
-    { userId, visionProvider, mainProvider, source: 'user' },
-    'Cross-provider vision auth resolved (authenticated user key)'
-  );
-  return {
-    apiKey: userKey,
-    source: 'user',
-    provider: visionProvider,
-  };
 }
 
 /**
  * Build synthetic AUTHENTICATION-failure ProcessedAttachment entries for a
- * batch of image attachments when `resolveVisionAuth` returned null. Writes
- * each entry to the negative cache so subsequent retries within the 5-min
- * window hit cache instead of re-resolving — same UX as a real auth rejection
- * by the upstream API.
+ * batch of image attachments when `resolveVisionConfig` returns `failFast`
+ * (no usable key for the vision provider AND no system free-fallback key).
+ * Writes each entry to the negative cache so subsequent retries within the
+ * 5-min window hit cache instead of re-resolving — same UX as a real auth
+ * rejection by the upstream API.
+ *
+ * The cache write is **best-effort**: the placeholder results are built and
+ * returned regardless of whether the cache write succeeds. A Redis blip at the
+ * moment we emit the fail-fast must NOT drop the user-facing placeholders (the
+ * caller's outer catch would otherwise turn the throw into an empty result —
+ * silently dropping the images instead of showing "[Image unavailable…]").
  */
 export async function buildVisionAuthFailureResults(
   attachments: AttachmentMetadata[]
 ): Promise<ProcessedAttachment[]> {
-  // Synthetic failures use AUTHENTICATION category so the source-aware fallback
-  // string fires. apiKeySource is 'user' here because the caller is an
-  // authenticated user (only path that returns null from resolveVisionAuth).
-  // Cache writes parallelize because they're independent — each attachment has
-  // a distinct cache key.
-  await Promise.all(
-    attachments.map(attachment =>
-      visionDescriptionCache.storeFailure({
-        attachmentId: attachment.id,
-        url: attachment.url,
-        category: ApiErrorCategory.AUTHENTICATION,
-      })
-    )
-  );
+  // Build the user-facing placeholders first so they're returned no matter what
+  // happens to the cache. The fail-fast path is reachable by an authenticated
+  // user lacking both the vision-provider key and the system free-fallback key,
+  // OR by a transient resolver throw — so this is not exclusively authenticated.
   const results: ProcessedAttachment[] = attachments.map(attachment => ({
     type: AttachmentType.Image,
     description: VISION_AUTH_FAIL_FAST_DESCRIPTION,
     originalUrl: attachment.url,
     metadata: attachment,
   }));
+
+  // Negative-cache writes are best-effort. Synthetic failures use the
+  // AUTHENTICATION category so the source-aware fallback string fires on cache
+  // hits. Writes parallelize (independent keys); a failure here is logged and
+  // swallowed so it can't drop the placeholders above.
+  try {
+    await Promise.all(
+      attachments.map(attachment =>
+        visionDescriptionCache.storeFailure({
+          attachmentId: attachment.id,
+          url: attachment.url,
+          category: ApiErrorCategory.AUTHENTICATION,
+        })
+      )
+    );
+  } catch (error) {
+    logger.warn(
+      { err: error, count: attachments.length },
+      'Failed to write vision fail-fast entries to negative cache — returning placeholders anyway'
+    );
+  }
+
   logger.info(
     { count: attachments.length },
-    'Built synthetic vision-auth-failure results (no user key for vision provider)'
+    'Built synthetic vision-auth-failure results (no usable key for vision or free-fallback provider)'
   );
   return results;
 }


### PR DESCRIPTION
Item 5 from the z.ai backlog sweep — the production-critical one. **Council-reviewed** (GLM-5.1 + Qwen-3.7-Max) and traced end-to-end before building.

## Problem
An authenticated user who can't auth their **vision** provider (e.g. a z.ai-coding user with no OpenRouter key, whose preset's vision model is on OpenRouter) currently fail-fasts — the image is replaced with `[Image unavailable: check /settings apikey set]`. They can't do vision at all.

## Fix
They now **degrade to the free vision model** (`google/gemma-4-31b-it:free`) on the system OpenRouter key instead of fail-fasting. Vision works.

### The unify (council's recommendation)
Two parallel resolvers implemented the same policy: `resolveVisionAuth` (DependencyStep) and `resolveVisionApiKey` (ImageDescriptionJob). They're unified into one **`resolveVisionConfig`** that resolves auth **and model atomically**.

> **Why atomic matters:** `selectVisionModel` only returns the free model when `isGuestMode=true`. An authenticated user is `isGuestMode=false`, so resolving auth and model *separately* would hand the system key to the **paid** fallback (qwen). `resolveVisionConfig` forces the free model **and** its provider's system key together on downgrade.

## Changes
- **New `resolveVisionConfig`** → `{ kind: 'resolved', config } | { kind: 'failFast', provider }`; config carries `apiKey / provider / model / source / isGuestMode`.
- **`describeImage` / `processAttachments`** accept a pre-resolved `model` so the forced downgrade flows through instead of being re-selected.
- **Cross-provider DependencyStep path extracted** to `extendedContextVisionProcessor.ts` (keeps DependencyStep under `max-lines`).
- **`isGuestMode` preserved** as "no keys anywhere" — a downgraded authenticated user stays `isGuestMode=false` (council: don't conflate with "using system key").
- **Fallback-of-fallback** (your decision): when even the system OpenRouter key is absent, fail-fast against the *original* vision provider (existing placeholder UX).
- **Side-effect fix:** a genuine guest with a z.ai vision model previously hit `resolveApiKey` against z.ai (no system key); now correctly routes to the OpenRouter free path.

## Scope + follow-up
Scope is **BROAD** (all cross-provider auth gaps) per your decision. Council flagged that this lets any authenticated user (incl. throwaway accounts) consume the system key's shared free-tier rate limit → a **per-user rate-limit guard is filed as a HIGH-priority fast-follow** in `backlog/inbox.md`.

## Tests
- `resolveVisionConfig`: 11-case matrix (fast path ×3, guest, authed-with-key, **the downgrade case**, both fail-fast paths, transient-throw degrade).
- `describeImage` honors `options.model` (skips selectVisionModel).
- ImageDescriptionJob + DependencyStep + extracted processor + MultimodalProcessor updated. 141 targeted tests green; `pnpm quality` green. (Full ai-worker suite runs in CI — OOMs locally.)

## Audits (council-requested, behavior unchanged — reporting)
- **Placeholder consumers:** only `isValidVisionDescription` (rejects placeholder from cache) matches; `RAGUtils.BARE_PLACEHOLDERS` intentionally doesn't match the fail-fast string. No suppress/count consumer broken.
- **isGuestMode downstream:** in the vision path it only feeds `selectVisionModel` (now bypassed when model is pre-resolved) + logging. Meaning preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)