### PR TITLE
feat(ai-worker): per-user daily cap on system-key free-vision fallback

### DIFF
--- a/packages/common-types/src/constants/redis-keys.test.ts
+++ b/packages/common-types/src/constants/redis-keys.test.ts
@@ -11,6 +11,10 @@ describe('CACHE_KEY_PREFIXES', () => {
     expect(CACHE_KEY_PREFIXES.CREDIT_EXHAUSTION_OPENROUTER).toBe('nocredits:openrouter:');
   });
 
+  it('exposes the vision system-fallback quota prefix matching ai-worker VisionFallbackQuota', () => {
+    expect(CACHE_KEY_PREFIXES.VISION_SYSTEM_FALLBACK_QUOTA).toBe('visionfallback:system:');
+  });
+
   it('every prefix ends with a colon (concatenation invariant)', () => {
     for (const prefix of Object.values(CACHE_KEY_PREFIXES)) {
       expect(prefix.endsWith(':')).toBe(true);

--- a/packages/common-types/src/constants/redis-keys.ts
+++ b/packages/common-types/src/constants/redis-keys.ts
@@ -21,4 +21,11 @@ export const CACHE_KEY_PREFIXES = {
    * Consumers: `ai-worker/CreditExhaustionCache`, `tooling/cache/clear-credit-exhaustion`.
    */
   CREDIT_EXHAUSTION_OPENROUTER: 'nocredits:openrouter:',
+  /**
+   * Per-(user, UTC-day) counter capping how many times an authenticated user may
+   * fall back to the free vision model on the SYSTEM OpenRouter key in a day.
+   * Bounds the freeloading surface opened by the broad vision free-fallback.
+   * Consumers: `ai-worker/VisionFallbackQuota`.
+   */
+  VISION_SYSTEM_FALLBACK_QUOTA: 'visionfallback:system:',
 } as const;

--- a/services/ai-worker/src/jobs/ImageDescriptionJob.test.ts
+++ b/services/ai-worker/src/jobs/ImageDescriptionJob.test.ts
@@ -41,6 +41,9 @@ vi.mock('../redis.js', () => ({
   visionDescriptionCache: {
     storeFailure: (...args: unknown[]) => mockStoreFailure(...args),
   },
+  visionFallbackQuota: {
+    tryConsume: () => Promise.resolve(true),
+  },
   checkModelVisionSupport: (...args: unknown[]) => mockCheckModelVisionSupport(...args),
 }));
 

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/DependencyStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/DependencyStep.test.ts
@@ -48,6 +48,9 @@ vi.mock('../../../../redis.js', () => ({
   visionDescriptionCache: {
     storeFailure: (...args: unknown[]) => mockStoreFailure(...args),
   },
+  visionFallbackQuota: {
+    tryConsume: () => Promise.resolve(true),
+  },
 }));
 
 // Mock MultimodalProcessor

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/extendedContextVisionProcessor.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/extendedContextVisionProcessor.test.ts
@@ -44,6 +44,9 @@ vi.mock('../../../../redis.js', () => ({
   visionDescriptionCache: {
     storeFailure: (...args: unknown[]) => mockStoreFailure(...args),
   },
+  visionFallbackQuota: {
+    tryConsume: () => Promise.resolve(true),
+  },
   checkModelVisionSupport: vi.fn().mockResolvedValue(false),
 }));
 

--- a/services/ai-worker/src/redis.ts
+++ b/services/ai-worker/src/redis.ts
@@ -15,6 +15,7 @@ import { VisionDescriptionCache } from './services/VisionDescriptionCache.js';
 import { RedisService } from './services/RedisService.js';
 import { RateLimitCache } from './services/RateLimitCache.js';
 import { CreditExhaustionCache } from './services/CreditExhaustionCache.js';
+import { VisionFallbackQuota } from './services/VisionFallbackQuota.js';
 import {
   modelSupportsVision,
   modelSupportsReasoning,
@@ -43,6 +44,11 @@ export const rateLimitCache = new RateLimitCache(redis);
 // when a BYOK account is known to be out of credits (per-account 402).
 // eslint-disable-next-line @tzurot/no-singleton-export -- Intentional: shared Redis client; multiple instances would each maintain a separate view of credit-exhaustion state and miss the short-circuit.
 export const creditExhaustionCache = new CreditExhaustionCache(redis);
+
+// Export singleton VisionFallbackQuota instance — per-user daily cap on
+// system-key free-vision fallbacks (bounds the broad-fallback freeloading surface).
+// eslint-disable-next-line @tzurot/no-singleton-export -- Intentional: shared Redis client; multiple instances would each maintain a separate per-user counter and undercount the shared cap.
+export const visionFallbackQuota = new VisionFallbackQuota(redis);
 
 /**
  * Check if a model supports vision input using OpenRouter's cached model data.

--- a/services/ai-worker/src/services/VisionFallbackQuota.test.ts
+++ b/services/ai-worker/src/services/VisionFallbackQuota.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Redis } from 'ioredis';
+import { VisionFallbackQuota, VISION_SYSTEM_FALLBACK_DAILY_LIMIT } from './VisionFallbackQuota.js';
+
+function createMockRedis(incrImpl: () => Promise<number>): {
+  redis: Redis;
+  incr: ReturnType<typeof vi.fn>;
+  expire: ReturnType<typeof vi.fn>;
+} {
+  const incr = vi.fn(incrImpl);
+  const expire = vi.fn().mockResolvedValue(1);
+  return { redis: { incr, expire } as unknown as Redis, incr, expire };
+}
+
+describe('VisionFallbackQuota', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('allows and counts a call under the cap, setting expiry', async () => {
+    const { redis, incr, expire } = createMockRedis(() => Promise.resolve(1));
+    const quota = new VisionFallbackQuota(redis, 20);
+
+    expect(await quota.tryConsume('123')).toBe(true);
+    expect(incr).toHaveBeenCalledTimes(1);
+    expect(expire).toHaveBeenCalledTimes(1);
+    // Key is per-user and per-UTC-day.
+    const key = incr.mock.calls[0]?.[0] as string;
+    expect(key).toMatch(/^visionfallback:system:123:\d{4}-\d{2}-\d{2}$/);
+    // Expiry uses the same key with a positive TTL.
+    expect(expire.mock.calls[0]?.[0]).toBe(key);
+    expect(expire.mock.calls[0]?.[1]).toBeGreaterThan(0);
+  });
+
+  it('allows the call exactly at the cap (inclusive)', async () => {
+    const { redis } = createMockRedis(() => Promise.resolve(20));
+    const quota = new VisionFallbackQuota(redis, 20);
+    expect(await quota.tryConsume('123')).toBe(true);
+  });
+
+  it('rejects the call once the count exceeds the cap', async () => {
+    const { redis } = createMockRedis(() => Promise.resolve(21));
+    const quota = new VisionFallbackQuota(redis, 20);
+    expect(await quota.tryConsume('123')).toBe(false);
+  });
+
+  it('fails open (allows) when Redis INCR throws', async () => {
+    const { redis, expire } = createMockRedis(() => Promise.reject(new Error('redis down')));
+    const quota = new VisionFallbackQuota(redis, 20);
+    expect(await quota.tryConsume('123')).toBe(true);
+    // INCR threw before EXPIRE, so EXPIRE is never reached.
+    expect(expire).not.toHaveBeenCalled();
+  });
+
+  it('defaults to the council-suggested daily limit', async () => {
+    const { redis } = createMockRedis(() =>
+      Promise.resolve(VISION_SYSTEM_FALLBACK_DAILY_LIMIT + 1)
+    );
+    const quota = new VisionFallbackQuota(redis); // no explicit limit
+    expect(await quota.tryConsume('123')).toBe(false);
+    expect(VISION_SYSTEM_FALLBACK_DAILY_LIMIT).toBe(20);
+  });
+});

--- a/services/ai-worker/src/services/VisionFallbackQuota.ts
+++ b/services/ai-worker/src/services/VisionFallbackQuota.ts
@@ -1,0 +1,94 @@
+/**
+ * Vision System-Fallback Quota
+ *
+ * Per-user daily cap on the **broad free-vision fallback** — the path where an
+ * authenticated user who can't auth their vision provider is downgraded to the
+ * free vision model on the bot's SYSTEM OpenRouter key (see
+ * `resolveVisionConfig`).
+ *
+ * **Why this exists**: the broad fallback lets any authenticated user (including
+ * a throwaway account that set a dummy key for any provider) route vision through
+ * the owner's system OpenRouter key. The forced free model means no *direct*
+ * dollar cost, but it consumes the shared OpenRouter free-tier rate limit — so a
+ * few heavy users could starve genuine guests. This cap bounds each user's daily
+ * consumption of that shared resource. Once a user exceeds the cap,
+ * `resolveVisionConfig` fail-fasts (the "[Image unavailable]" placeholder)
+ * instead of serving another free-fallback vision call.
+ *
+ * **Counted per resolution, not per image**: `resolveVisionConfig` is invoked
+ * once per vision-processing event (a message/batch may carry several images but
+ * counts once), and only when the resolved source is the SYSTEM key — a user
+ * downgrading onto their *own* OpenRouter key never touches this quota.
+ *
+ * **Fixed UTC-day window**: the Redis key embeds the UTC date, so the count
+ * auto-resets at UTC midnight (a fresh key). `EXPIRE` is set every call purely
+ * for cleanup; a missed `EXPIRE` self-heals on the next call and the date-scoped
+ * key expires regardless.
+ *
+ * **Fail-open**: any Redis error logs a warn and allows the call. A counter blip
+ * must not break vision for legitimate users — the abuse this guards against is a
+ * sustained-volume concern, not a single request, and the rest of the vision
+ * pipeline already degrades gracefully on Redis failure.
+ */
+
+import type { Redis } from 'ioredis';
+import { CACHE_KEY_PREFIXES, createLogger } from '@tzurot/common-types';
+
+const logger = createLogger('VisionFallbackQuota');
+
+const KEY_PREFIX = CACHE_KEY_PREFIXES.VISION_SYSTEM_FALLBACK_QUOTA;
+
+/**
+ * Default per-user daily ceiling on system-key free-vision fallbacks. Council
+ * (GLM-5.1 + Qwen-3.7-Max) suggested ~20/day as a starting point; tune here if
+ * abuse or legitimate-heavy-use signal emerges.
+ */
+export const VISION_SYSTEM_FALLBACK_DAILY_LIMIT = 20;
+
+/** TTL for the per-day counter key — 25h gives margin past the UTC-day rollover. */
+const QUOTA_KEY_TTL_SECONDS = 25 * 60 * 60;
+
+export class VisionFallbackQuota {
+  constructor(
+    private readonly redis: Redis,
+    private readonly dailyLimit: number = VISION_SYSTEM_FALLBACK_DAILY_LIMIT
+  ) {}
+
+  /**
+   * Atomically record one system-fallback vision use for `userId` and report
+   * whether they remain within the daily cap.
+   *
+   * @returns `true` if the user is allowed (under the cap, inclusive) — the call
+   *   has been counted. `false` if this use would exceed the cap (caller should
+   *   fail-fast). Fails OPEN: returns `true` on any Redis error.
+   */
+  async tryConsume(userId: string): Promise<boolean> {
+    const key = this.buildKey(userId);
+    try {
+      const count = await this.redis.incr(key);
+      // Set/refresh expiry every call (cheap; self-heals a missed EXPIRE). The
+      // date-scoped key resets the count at UTC midnight regardless.
+      await this.redis.expire(key, QUOTA_KEY_TTL_SECONDS);
+      const allowed = count <= this.dailyLimit;
+      if (!allowed) {
+        logger.info(
+          { userId, count, dailyLimit: this.dailyLimit },
+          'User exceeded daily system-fallback vision quota — failing fast'
+        );
+      }
+      return allowed;
+    } catch (error) {
+      logger.warn(
+        { err: error, userId },
+        'Vision fallback quota check failed — failing open (allowing the call)'
+      );
+      return true;
+    }
+  }
+
+  /** Build the per-(user, UTC-day) counter key. */
+  private buildKey(userId: string): string {
+    const utcDay = new Date().toISOString().slice(0, 10); // YYYY-MM-DD (UTC)
+    return `${KEY_PREFIX}${userId}:${utcDay}`;
+  }
+}

--- a/services/ai-worker/src/services/multimodal/visionAuthResolver.test.ts
+++ b/services/ai-worker/src/services/multimodal/visionAuthResolver.test.ts
@@ -52,9 +52,14 @@ vi.mock('./VisionProcessor.js', () => ({
 // VisionDescriptionCache singleton mock — buildVisionAuthFailureResults writes
 // to it; we just verify the call shape.
 const mockStoreFailure = vi.fn();
+// Default: quota allows (under cap). Over-cap tests override per-case.
+const mockTryConsume = vi.fn().mockResolvedValue(true);
 vi.mock('../../redis.js', () => ({
   visionDescriptionCache: {
     storeFailure: (...args: unknown[]) => mockStoreFailure(...args),
+  },
+  visionFallbackQuota: {
+    tryConsume: (...args: unknown[]) => mockTryConsume(...args),
   },
 }));
 
@@ -82,6 +87,8 @@ const mockResolver: ApiKeyResolver = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Default: under the daily fallback cap. Over-cap tests override per-case.
+  mockTryConsume.mockResolvedValue(true);
 });
 
 describe('resolveVisionConfig', () => {
@@ -272,6 +279,63 @@ describe('resolveVisionConfig', () => {
       }
       // The free model lives on OpenRouter — resolveApiKey was asked for that provider.
       expect(mockResolveApiKey).toHaveBeenCalledWith('user-1', AIProvider.OpenRouter);
+      // The system-key downgrade is counted against the per-user daily cap.
+      expect(mockTryConsume).toHaveBeenCalledWith('user-1');
+    });
+
+    it('fails fast when the user is over the daily system-fallback cap', async () => {
+      mockSelectVisionModel.mockResolvedValue('qwen/qwen3.5-397b-a17b');
+      mockTryResolveUserKey.mockResolvedValue(null);
+      mockResolveApiKey.mockResolvedValue({
+        apiKey: 'system-or-key',
+        source: 'system',
+        provider: AIProvider.OpenRouter,
+        isGuestMode: true,
+        userId: 'user-1',
+      });
+      mockTryConsume.mockResolvedValue(false); // over the cap
+
+      const result = await resolveVisionConfig({
+        personality,
+        mainProvider: AIProvider.ZaiCoding,
+        mainApiKey: 'user-zai-key',
+        isGuestMode: false,
+        userId: 'user-1',
+        apiKeyResolver: mockResolver,
+      });
+
+      expect(result).toEqual({ kind: 'failFast', provider: AIProvider.OpenRouter });
+    });
+
+    it('does NOT consume the cap when the user falls back onto their OWN OpenRouter key', async () => {
+      // User has no key for the vision provider but DOES have an OpenRouter key,
+      // so resolveApiKey returns source 'user' — their own key, not the owner's
+      // system key, so the freeloading cap must not apply.
+      mockSelectVisionModel.mockResolvedValue('qwen/qwen3.5-397b-a17b');
+      mockTryResolveUserKey.mockResolvedValue(null);
+      mockResolveApiKey.mockResolvedValue({
+        apiKey: 'user-or-key',
+        source: 'user',
+        provider: AIProvider.OpenRouter,
+        isGuestMode: false,
+        userId: 'user-1',
+      });
+
+      const result = await resolveVisionConfig({
+        personality,
+        mainProvider: AIProvider.ZaiCoding,
+        mainApiKey: 'user-zai-key',
+        isGuestMode: false,
+        userId: 'user-1',
+        apiKeyResolver: mockResolver,
+      });
+
+      expect(result.kind).toBe('resolved');
+      if (result.kind === 'resolved') {
+        expect(result.config.source).toBe('user');
+        expect(result.config.model).toBe(MODEL_DEFAULTS.VISION_FALLBACK_FREE);
+      }
+      expect(mockTryConsume).not.toHaveBeenCalled();
     });
   });
 

--- a/services/ai-worker/src/services/multimodal/visionAuthResolver.ts
+++ b/services/ai-worker/src/services/multimodal/visionAuthResolver.ts
@@ -38,7 +38,7 @@ import {
 } from '@tzurot/common-types';
 import { detectVisionProvider } from '../ProviderRouter.js';
 import { selectVisionModel } from './VisionProcessor.js';
-import { visionDescriptionCache } from '../../redis.js';
+import { visionDescriptionCache, visionFallbackQuota } from '../../redis.js';
 import type { ApiKeyResolver } from '../ApiKeyResolver.js';
 import type { ProcessedAttachment } from '../MultimodalProcessor.js';
 
@@ -125,6 +125,67 @@ export interface ResolveVisionConfigOptions {
   userId: string | undefined;
   /** Resolver instance for cross-provider lookups. */
   apiKeyResolver: ApiKeyResolver;
+}
+
+/**
+ * BROAD FREE FALLBACK — authenticated user with no key for the vision provider.
+ * Downgrade to the free vision model on the system key instead of fail-fasting.
+ * MUST force BOTH the free model AND its provider's key: `selectVisionModel`
+ * returns the PAID fallback for authenticated users (isGuestMode=false), so
+ * handing the system key to the natural model would bill the system key for a
+ * paid model.
+ *
+ * Only a SYSTEM-key downgrade spends the owner's shared free-tier quota, so only
+ * it counts against the per-user daily cap (a user on their OWN OpenRouter key
+ * doesn't). Over the cap → fail-fast. `resolveApiKey` throws propagate to the
+ * caller's catch (→ fail-fast). `originalVisionProvider` is carried so a
+ * fail-fast names what the user actually lacked, not the free-fallback provider.
+ */
+async function resolveBroadFreeFallback(
+  userId: string | undefined,
+  originalVisionProvider: AIProvider,
+  apiKeyResolver: ApiKeyResolver
+): Promise<VisionConfigResult> {
+  const freeModel = MODEL_DEFAULTS.VISION_FALLBACK_FREE;
+  const freeProvider = detectVisionProvider(freeModel);
+  const sys = await apiKeyResolver.resolveApiKey(userId, freeProvider);
+  // `sys.apiKey ?? ''` is defense-in-depth: resolveApiKey normally throws when
+  // no key is available, but a misbehaving resolver returning null would
+  // otherwise throw on `.length`.
+  if ((sys.apiKey ?? '').length === 0) {
+    logger.info(
+      { userId, originalVisionProvider, freeProvider },
+      'Vision free-fallback unavailable (no system key) — failing fast'
+    );
+    return { kind: 'failFast', provider: originalVisionProvider };
+  }
+  // `userId !== undefined` is always true here (the guest branch captured the
+  // undefined case) — the guard narrows the type and fails open.
+  if (
+    sys.source === 'system' &&
+    userId !== undefined &&
+    !(await visionFallbackQuota.tryConsume(userId))
+  ) {
+    return { kind: 'failFast', provider: originalVisionProvider };
+  }
+  logger.info(
+    { userId, originalVisionProvider, freeProvider, freeModel, source: sys.source },
+    'Authenticated user lacks vision-provider key — downgrading to free vision model on system key'
+  );
+  return {
+    kind: 'resolved',
+    config: {
+      apiKey: sys.apiKey,
+      provider: freeProvider,
+      model: freeModel,
+      // `source` is whatever resolveApiKey returned — normally 'system'; if the
+      // user happens to have an OpenRouter key it'd be 'user', which is fine
+      // (they ARE authenticated, just downgraded for the vision model).
+      source: sys.source,
+      // NOT a guest — they're authenticated, only the vision model is downgraded.
+      isGuestMode: false,
+    },
+  };
 }
 
 /**
@@ -246,46 +307,11 @@ export async function resolveVisionConfig(
       };
     }
 
-    // BROAD FREE FALLBACK — authenticated user with no key for the vision
-    // provider. Instead of fail-fasting, downgrade to the free vision model on
-    // the system key. MUST force BOTH the free model AND its provider's key:
-    // `selectVisionModel` returns the PAID fallback for authenticated users
-    // (isGuestMode=false), so handing the system key to `naturalModel` would
-    // bill the system key for a paid model.
-    const freeModel = MODEL_DEFAULTS.VISION_FALLBACK_FREE;
-    const freeProvider = detectVisionProvider(freeModel);
-    const sys = await apiKeyResolver.resolveApiKey(userId, freeProvider);
-    // `apiKey` is typed `string`, but guard against a null/empty result too —
-    // resolveApiKey normally throws when no key is available, so reaching here
-    // with no usable key is a defense-in-depth case. `sys.apiKey ?? ''` keeps
-    // the length check from throwing on a null returned by a misbehaving resolver.
-    if ((sys.apiKey ?? '').length === 0) {
-      // Fail-fast against the ORIGINAL vision provider so the placeholder
-      // reflects what they lacked.
-      logger.info(
-        { userId, visionProvider, freeProvider },
-        'Vision free-fallback unavailable (no system key) — failing fast'
-      );
-      return { kind: 'failFast', provider: visionProvider };
-    }
-    logger.info(
-      { userId, visionProvider, freeProvider, freeModel, source: sys.source },
-      'Authenticated user lacks vision-provider key — downgrading to free vision model on system key'
-    );
-    return {
-      kind: 'resolved',
-      config: {
-        apiKey: sys.apiKey,
-        provider: freeProvider,
-        model: freeModel,
-        // `source` is whatever resolveApiKey returned — normally 'system'; if
-        // the user happens to have an OpenRouter key it'd be 'user', which is
-        // fine (they ARE authenticated, just downgraded for the vision model).
-        source: sys.source,
-        // NOT a guest — they're authenticated, only the vision model is downgraded.
-        isGuestMode: false,
-      },
-    };
+    // Authenticated user with no key for the vision provider → broad free
+    // fallback (downgrade to the free vision model on the system key). Extracted
+    // to keep this function under the line limit; runs inside this try so its
+    // `resolveApiKey` throw still degrades to fail-fast via the catch below.
+    return await resolveBroadFreeFallback(userId, visionProvider, apiKeyResolver);
   } catch (error) {
     // Fallback-of-fallback unavailable path: `resolveApiKey` throws when no key
     // (user or system) is available for the requested provider. For the


### PR DESCRIPTION
The HIGH-priority fast-follow to #1204. The broad free-vision fallback lets any authenticated user — including a throwaway account with a dummy key for any provider — route vision through the owner's **system OpenRouter key** and consume its shared free-tier rate limit, starving genuine guests. Council (GLM-5.1 + Qwen-3.7-Max) flagged this; this PR bounds it.

## Changes
- **New `VisionFallbackQuota`** — per-`(user, UTC-day)` Redis `INCR` counter, default **20/day** (`VISION_SYSTEM_FALLBACK_DAILY_LIMIT`). **Fail-OPEN** on Redis error: a counter blip must not break vision; the exposure is sustained-volume, not a single request. UTC-day-scoped key auto-resets at midnight. Singleton in `redis.ts` alongside the other caches.
- **Guard in `resolveVisionConfig`'s broad-fallback branch** — only a **SYSTEM-key** downgrade spends the owner's quota, so only it counts against the cap. A user falling back onto their **OWN** OpenRouter key (`source: 'user'`) doesn't touch it. Over the cap → `failFast` (existing `[Image unavailable]` placeholder).
- Extracted `resolveBroadFreeFallback` (keeps `resolveVisionConfig` under `max-lines-per-function`).
- New `CACHE_KEY_PREFIXES.VISION_SYSTEM_FALLBACK_QUOTA`.

## Note on the spec
The backlog item said "reuse `RateLimitCache`." On inspection, `RateLimitCache`/`CreditExhaustionCache` are **reactive** (set when a provider returns 429/402), not per-user counters — there was no proactive-quota primitive. So this adds a small new INCR-based counter rather than reusing the wrong tool.

## Tests
- `VisionFallbackQuota`: under/at/over cap, fail-open on Redis throw, default limit, key shape.
- `resolveVisionConfig`: quota consumed on system-key downgrade; over-cap → failFast; own-OR-key downgrade does **not** consume the cap.
- Updated the 3 redis.js mocks (ImageDescriptionJob / DependencyStep / extendedContextVisionProcessor) for the new export. Targeted suites + `pnpm quality` green locally (full ai-worker suite runs in CI — OOMs locally).

Closes the rate-limit fast-follow in `backlog/inbox.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)