### PR TITLE
feat(ai-worker): raise system-fallback vision cap 20→100/day

### DIFF
--- a/backlog/inbox.md
+++ b/backlog/inbox.md
@@ -105,4 +105,12 @@ _New items go here. Triage to appropriate section weekly._
 
 **Why inbox (not scheduled)**: explicitly NOT for beta.126; it's a UX-restructure with an unresolved design question, so it needs triage + a design pass before becoming a committed task. Touches `services/bot-client/src/commands/character/chat.ts` (mode branching), the slash-command definition, and `randomPick.ts`. Command-structure change → integration snapshots need updating (`pnpm test:int`).
 
-_Shipped 2026-06-14 (#1205): per-user daily cap on system-key free-vision fallback (`VisionFallbackQuota`, 20/day, fail-open) — the fast-follow guard for the #1204 broad fallback._
+_Shipped 2026-06-14 (#1205): per-user daily cap on system-key free-vision fallback (`VisionFallbackQuota`, fail-open) — the fast-follow guard for the #1204 broad fallback._
+
+### `[FEAT]` Make the vision system-fallback daily cap a runtime admin-settings knob
+
+**Surfaced 2026-06-14** (user), tuning the #1205 guard. The per-user daily cap on system-key free-vision fallback (`VISION_SYSTEM_FALLBACK_DAILY_LIMIT`, currently a code constant = 100) should eventually be a runtime **admin-settings** config item so the owner can tune it without a code change + redeploy — the same way other admin settings are managed. Gemma is `$0`, so the cap is purely a shared-rate-limit-pool protector; the right value depends on observed traffic, which argues for runtime tunability.
+
+**Action**: thread the limit through the admin-settings layer (DB-backed `adminSettings` + the gateway admin config surface + the bot-client admin UI if one exposes it), falling back to the `VISION_SYSTEM_FALLBACK_DAILY_LIMIT` constant as the default. `VisionFallbackQuota` already takes `dailyLimit` as a constructor param, so the wiring is "resolve the configured value and pass it in" rather than a logic change. **Start**: `services/ai-worker/src/services/VisionFallbackQuota.ts` (already param-driven); the `adminSettings` resolution path in ai-worker.
+
+**Why inbox**: a real follow-up but not urgent — the constant default (100) is a sensible starting value; promote when the owner wants to tune it from observed traffic without a deploy.

--- a/services/ai-worker/src/services/VisionFallbackQuota.test.ts
+++ b/services/ai-worker/src/services/VisionFallbackQuota.test.ts
@@ -52,12 +52,12 @@ describe('VisionFallbackQuota', () => {
     expect(expire).not.toHaveBeenCalled();
   });
 
-  it('defaults to the council-suggested daily limit', async () => {
+  it('defaults to the configured daily limit', async () => {
     const { redis } = createMockRedis(() =>
       Promise.resolve(VISION_SYSTEM_FALLBACK_DAILY_LIMIT + 1)
     );
     const quota = new VisionFallbackQuota(redis); // no explicit limit
     expect(await quota.tryConsume('123')).toBe(false);
-    expect(VISION_SYSTEM_FALLBACK_DAILY_LIMIT).toBe(20);
+    expect(VISION_SYSTEM_FALLBACK_DAILY_LIMIT).toBe(100);
   });
 });

--- a/services/ai-worker/src/services/VisionFallbackQuota.ts
+++ b/services/ai-worker/src/services/VisionFallbackQuota.ts
@@ -39,11 +39,13 @@ const logger = createLogger('VisionFallbackQuota');
 const KEY_PREFIX = CACHE_KEY_PREFIXES.VISION_SYSTEM_FALLBACK_QUOTA;
 
 /**
- * Default per-user daily ceiling on system-key free-vision fallbacks. Council
- * (GLM-5.1 + Qwen-3.7-Max) suggested ~20/day as a starting point; tune here if
- * abuse or legitimate-heavy-use signal emerges.
+ * Default per-user daily ceiling on system-key free-vision fallbacks. The free
+ * model (gemma) costs $0, so this cap exists only to stop one user draining the
+ * shared OpenRouter free-tier request pool — it can be generous. 100/day leaves
+ * comfortable headroom for legitimate image-heavy use while still bounding a
+ * single abuser. Intended to become a runtime admin-settings knob.
  */
-export const VISION_SYSTEM_FALLBACK_DAILY_LIMIT = 20;
+export const VISION_SYSTEM_FALLBACK_DAILY_LIMIT = 100;
 
 /** TTL for the per-day counter key — 25h gives margin past the UTC-day rollover. */
 const QUOTA_KEY_TTL_SECONDS = 25 * 60 * 60;


### PR DESCRIPTION
Follow-up to #1205. The per-user daily cap on system-key free-vision fallback was 20/day — too tight on reflection.

**Why raise it:** the free model (gemma) costs **\$0**, so the cap's only job is to stop one user draining the **shared** OpenRouter free-tier request pool. It doesn't need to be tight — just bound a single abuser. 20/day would bite a legitimate image-heavy chatter; **100/day** leaves comfortable headroom while still capping abuse. (Council floated ~20 as a starting point; raised after review since there's no per-call dollar cost.)

## Changes
- `VISION_SYSTEM_FALLBACK_DAILY_LIMIT`: 20 → **100** (+ updated comment + default-assertion test).
- Backlog (`inbox.md`): file a `[FEAT]` to make the cap a runtime **admin-settings** knob — `VisionFallbackQuota` already takes `dailyLimit` as a constructor param, so it's a wiring task, not a logic change. Per your call: code constant now, admin-settings config later.

Targeted test + `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)