### PR TITLE
fix(bot-client): add 6 missing /help categories

### DIFF
--- a/backlog/inbox.md
+++ b/backlog/inbox.md
@@ -114,3 +114,16 @@ _Shipped 2026-06-14 (#1205): per-user daily cap on system-key free-vision fallba
 **Action**: thread the limit through the admin-settings layer (DB-backed `adminSettings` + the gateway admin config surface + the bot-client admin UI if one exposes it), falling back to the `VISION_SYSTEM_FALLBACK_DAILY_LIMIT` constant as the default. `VisionFallbackQuota` already takes `dailyLimit` as a constructor param, so the wiring is "resolve the configured value and pass it in" rather than a logic change. **Start**: `services/ai-worker/src/services/VisionFallbackQuota.ts` (already param-driven); the `adminSettings` resolution path in ai-worker.
 
 **Why inbox**: a real follow-up but not urgent — the constant default (100) is a sensible starting value; promote when the owner wants to tune it from observed traffic without a deploy.
+
+### `[FEAT]` `commands:audit` — slash-command surface inventory + consistency gate
+
+**Surfaced 2026-06-14** (user), while scoping a new `/models` command — "I almost feel like we need an automated way to get the full skeleton of our currently implemented slash commands… check consistency of naming, params, structure." Greenlit to build next (plan-first).
+
+**Two layers:**
+
+1. **Inventory** — load all commands via the existing registration path (skeleton source: `services/bot-client/src/utils/deployCommands.ts` already serializes every command to Discord JSON via `.toJSON()`) and emit a tree of: command → subcommand-groups → subcommands → options (name, type, required, autocomplete, choices) + wired handlers (execute/autocomplete/button/modal) + category. Output `--format tree|md|json` (mirrors `pnpm ops xray`). The `md` form is the "see the whole surface at once" artifact.
+2. **Consistency checks** against `.claude/rules/04-discord.md`: subcommand-name conventions (`browse`/`view`/`create`/`edit`/`delete`); **cross-command option-name drift** (same concept → same option name — the `preset`/`config`/`character` worry); description presence/quality (this IS the user-facing guidance `/help` renders); `::` customId delimiter; **category coverage** (every command's category must exist in `/help`'s `CATEGORY_CONFIG` or it silently buckets to "Other"). Ratchet-able later per the audit-tool infra (`docs/reference/audit-enforcement.md`) if it graduates to a gate.
+
+**Pairs with**: the `/help` category-scheme deliberate revisit (the audit's category-coverage check is the enforcement; the scheme is the design). The immediate 6-in-"Other" gap was quick-fixed (#fix/help-category-coverage) — this is the durable prevention + the broader consistency surface. Lives in `packages/tooling/`.
+
+**Then**: use the inventory + consistency output to design the `/models`-browser command (icebox) against the existing surface instead of guessing.

--- a/services/bot-client/src/commands/help/index.ts
+++ b/services/bot-client/src/commands/help/index.ts
@@ -25,14 +25,23 @@ const logger = createLogger('help-command');
 /**
  * Command category display order and emoji
  */
+// Category = the command's top-level folder name (Title-cased), injected by
+// CommandHandler. Every folder needs an entry here or it falls into "Other" —
+// keep this in sync with services/bot-client/src/commands/*.
 const CATEGORY_CONFIG: Record<string, { emoji: string; order: number }> = {
   Character: { emoji: '🎭', order: 1 },
   Persona: { emoji: '👤', order: 2 },
-  Settings: { emoji: '⚙️', order: 3 },
-  History: { emoji: '📜', order: 4 },
-  Memory: { emoji: '🧠', order: 5 },
-  Admin: { emoji: '🛡️', order: 6 },
-  Help: { emoji: '❓', order: 7 },
+  Preset: { emoji: '🎛️', order: 3 },
+  Settings: { emoji: '⚙️', order: 4 },
+  Voice: { emoji: '🔊', order: 5 },
+  Shapes: { emoji: '🧩', order: 6 },
+  Memory: { emoji: '🧠', order: 7 },
+  History: { emoji: '📜', order: 8 },
+  Channel: { emoji: '#️⃣', order: 9 },
+  Inspect: { emoji: '🔍', order: 10 },
+  Deny: { emoji: '🚫', order: 11 },
+  Admin: { emoji: '🛡️', order: 12 },
+  Help: { emoji: '❓', order: 13 },
   Other: { emoji: '📦', order: 99 },
 };
 


### PR DESCRIPTION
**Found while scoping a `commands:audit` tool** (the "does `/help` stay up to date?" worry). The command *list/descriptions/subcommands* in `/help` are auto-derived from the live registry — always current. But the **category grouping** uses a hand-maintained `CATEGORY_CONFIG` that named only 7 categories while there are **13 command folders** — so `channel`, `deny`, `inspect`, `preset`, `shapes`, `voice` all silently fell into "📦 Other". `/preset`, a major command, was in "Other".

## Fix
- Add the 6 with sensible emoji + a coherent order (preserves the tested Character < Settings < Help relative order).
- Comment ties `CATEGORY_CONFIG` to the command folders so the drift is visible next time.
- Backlog (`inbox.md`): the deliberate category-scheme revisit + a **`commands:audit`** consistency gate that would catch this class structurally (category coverage + cross-command option-name drift + description quality = the user-facing guidance). The audit is greenlit as the next thread.

## Tests
`help/index.test.ts` green (incl. the category-order assertion); `pnpm quality` green.

Rides beta.131 (per user — quick-fix the gap now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)