### PR TITLE
chore(tooling): triage commands:audit warnings — whitelist deliberate verbs, fix stub false-positive

### DIFF
--- a/packages/tooling/src/dev/commandsAuditChecks.test.ts
+++ b/packages/tooling/src/dev/commandsAuditChecks.test.ts
@@ -116,6 +116,46 @@ describe('commandsAuditChecks: description-presence', () => {
     expect(findings.some(f => f.severity === 'warn')).toBe(true);
   });
 
+  it('does not flag a real description that merely starts with a stub word', () => {
+    // "Test your API key validity" begins with "Test" but is a legitimate,
+    // long-enough description — the anchored stub regex must not flag it.
+    const findings = runChecks(
+      manifest([
+        command({
+          name: 'settings',
+          category: 'Character',
+          description: 'Manage your settings',
+          data: {
+            name: 'settings',
+            description: 'Manage your settings',
+            options: [{ type: 1, name: 'test', description: 'Test your API key validity' }],
+          },
+        }),
+      ])
+    ).filter(f => f.rule === 'description-presence');
+    expect(findings).toHaveLength(0);
+  });
+
+  it('still flags a long-enough meta-note placeholder (TODO: ...)', () => {
+    // Long enough to pass the minimum-length gate, so only the leading-word
+    // stub regex can catch it — the regex's real value over the length check.
+    const findings = runChecks(
+      manifest([
+        command({
+          name: 'settings',
+          category: 'Character',
+          description: 'Manage your settings',
+          data: {
+            name: 'settings',
+            description: 'Manage your settings',
+            options: [{ type: 1, name: 'wip', description: 'TODO: wire this up later' }],
+          },
+        }),
+      ])
+    ).filter(f => f.rule === 'description-presence');
+    expect(findings.some(f => f.severity === 'warn')).toBe(true);
+  });
+
   it('walks nested group → subcommand → leaf descriptions', () => {
     const findings = runChecks(
       manifest([

--- a/packages/tooling/src/dev/commandsAuditChecks.ts
+++ b/packages/tooling/src/dev/commandsAuditChecks.ts
@@ -34,10 +34,15 @@ const KNOWN_SUBCOMMAND_NAMES = new Set<string>([
   'edit',
   'delete',
   'list', // legacy — handled specially below (warns toward `browse`)
-  // config-route conventions (LLM/TTS settings)
+  // config-route conventions (LLM/TTS settings) + the config-cascade
+  // get/set/set-default/clear-default family used consistently by /settings
+  // and /voice (read a value, set the per-scope default, clear it).
   'default',
   'free-default',
   'settings',
+  'get',
+  'set-default',
+  'clear-default',
   // established add/remove pair (deny, etc.)
   'add',
   'remove',
@@ -74,9 +79,18 @@ const KNOWN_SUBCOMMAND_NAMES = new Set<string>([
   'hard-delete',
   'test',
   'set',
+  // domain-specific verbs with no canonical CRUD equivalent
+  'forget', // memory: retroactive/incognito deletion, distinct from `delete`
+  'auth', // shapes: third-party integration sign-in
+  'logout', // shapes: third-party integration sign-out
 ]);
 
-const STUB_DESCRIPTION_RE = /^(test|todo|tbd|xxx)/i;
+// Catches placeholder/meta-note descriptions. `todo`/`tbd`/`xxx` are virtually
+// never the start of a real description, so a leading-word match is safe and
+// still flags "TODO: fix later". `test`, by contrast, is a common imperative
+// verb ("Test your API key validity"), so it's only flagged as the WHOLE
+// description — a bare "test" — to avoid the false positive.
+const STUB_DESCRIPTION_RE = /^(todo|tbd|xxx)\b|^test$/i;
 const STUB_DESCRIPTION_MIN_LENGTH = 12;
 
 // Near-synonym option-name clusters: names that tend to denote the same concept.


### PR DESCRIPTION
## Summary

Triages all 13 warnings from `commands:audit`'s first real run (CHORE follow-up to #1209). Resolves 9; the remaining 4 are intentional standing signals with backlog/accept dispositions.

### Changes

**Fix stub-description false positive** — `/^(test|todo|tbd|xxx)/i` flagged `/settings apikey test`'s legitimate "Test your API key validity" because it starts with "test". Re-anchored: `todo`/`tbd`/`xxx` still match as leading words (so "TODO: fix later" meta-notes are caught), but `test` only matches as the entire description (a bare placeholder) — it's too common an imperative verb to leading-match.

**Whitelist deliberate domain verbs** — verified each against the actual command semantics; none has a canonical CRUD equivalent:
| Verb | Where | Why it's deliberate |
|------|-------|---------------------|
| `get` / `set-default` / `clear-default` | `/settings`, `/voice` | config-cascade read/set-default/clear ops |
| `forget` | `/memory` | retroactive/incognito deletion, distinct from `delete` |
| `auth` / `logout` | `/shapes` | third-party integration sign-in/out |

### Result

`commands:audit`: **13 → 4 warnings**. The 4 remaining:
- `settings preset list`, `voice list` — legacy `list` nudge (list→browse is a real UX change → backlog quick-win)
- `preset / config` option drift — your originally-flagged concern; needs the autocomplete branch restructured (it currently discriminates user-vs-global presets *by the option name*) + `test:int` → **separate focused PR**
- `type` int/string (`admin presence` vs `deny add`) — accepted: unrelated concepts, generic name is contextually clear

### Tests

Added two cases: a real "Test ..." description is not flagged; a ≥12-char "TODO: ..." meta-note still is (isolates the regex's value over the length gate). Tooling suite green (1044).

🤖 Generated with [Claude Code](https://claude.com/claude-code)