### PR TITLE
fix(bot-client): rename /preset global config option → preset for naming consistency

### DIFF
--- a/packages/common-types/src/generated/commandOptions.ts
+++ b/packages/common-types/src/generated/commandOptions.ts
@@ -390,17 +390,17 @@ export const personaDefaultOptions = defineTypedOptions({
 // =============================================================================
 
 /**
- * /preset global default <config>
+ * /preset global default <preset>
  */
 export const presetGlobalDefaultOptions = defineTypedOptions({
-  config: { type: 'string', required: true },
+  preset: { type: 'string', required: true },
 });
 
 /**
- * /preset global free-default <config>
+ * /preset global free-default <preset>
  */
 export const presetGlobalFreeDefaultOptions = defineTypedOptions({
-  config: { type: 'string', required: true },
+  preset: { type: 'string', required: true },
 });
 
 /**

--- a/services/bot-client/command-manifest.json
+++ b/services/bot-client/command-manifest.json
@@ -1430,7 +1430,7 @@
                   {
                     "autocomplete": true,
                     "type": 3,
-                    "name": "config",
+                    "name": "preset",
                     "description": "Global preset to set as default",
                     "required": true
                   }
@@ -1444,7 +1444,7 @@
                   {
                     "autocomplete": true,
                     "type": 3,
-                    "name": "config",
+                    "name": "preset",
                     "description": "Global preset to set as free tier default",
                     "required": true
                   }

--- a/services/bot-client/src/commands/preset/autocomplete.test.ts
+++ b/services/bot-client/src/commands/preset/autocomplete.test.ts
@@ -314,7 +314,7 @@ describe('handleAutocomplete', () => {
 
     it('responds with empty list when the admin endpoint fails', async () => {
       vi.mocked(mockInteraction.options.getFocused).mockReturnValue({
-        name: 'config',
+        name: 'preset',
         value: '',
       } as unknown as string);
       vi.mocked(mockInteraction.options.getSubcommand).mockReturnValue('set-default');
@@ -327,7 +327,7 @@ describe('handleAutocomplete', () => {
 
     it('lists global presets filtered by query, attaches GLOBAL + DEFAULT badges', async () => {
       vi.mocked(mockInteraction.options.getFocused).mockReturnValue({
-        name: 'config',
+        name: 'preset',
         value: 'claude',
       } as unknown as string);
       vi.mocked(mockInteraction.options.getSubcommand).mockReturnValue('set-default');
@@ -347,7 +347,7 @@ describe('handleAutocomplete', () => {
 
     it('restricts to free models when subcommand is free-default', async () => {
       vi.mocked(mockInteraction.options.getFocused).mockReturnValue({
-        name: 'config',
+        name: 'preset',
         value: '',
       } as unknown as string);
       vi.mocked(mockInteraction.options.getSubcommand).mockReturnValue('free-default');

--- a/services/bot-client/src/commands/preset/autocomplete.ts
+++ b/services/bot-client/src/commands/preset/autocomplete.ts
@@ -71,17 +71,19 @@ export async function handleAutocomplete(interaction: AutocompleteInteraction): 
 
   try {
     if (focusedOption.name === 'preset') {
-      await handlePresetAutocomplete(interaction, focusedOption.value, userId);
+      // The 'preset' option appears in both user-scoped subcommands (suggest the
+      // user's own + global presets) and the owner-only 'global' group (suggest
+      // global presets only). Discriminate by subcommand group, not option name.
+      if (subcommandGroup === 'global') {
+        const freeOnly = subcommand === 'free-default';
+        await handleGlobalConfigAutocomplete(interaction, focusedOption.value, freeOnly);
+      } else {
+        await handlePresetAutocomplete(interaction, focusedOption.value, userId);
+      }
     } else if (focusedOption.name === 'model') {
       await handleModelAutocomplete(interaction, focusedOption.value);
     } else if (focusedOption.name === 'vision-model') {
       await handleVisionModelAutocomplete(interaction, focusedOption.value);
-    } else if (focusedOption.name === 'config' && subcommandGroup === 'global') {
-      // Global config autocomplete (for owner-only commands)
-      // Note: 'config' option is currently only used in the 'global' subcommand group.
-      // If future subcommands also use 'config', this condition will need updating.
-      const freeOnly = subcommand === 'free-default';
-      await handleGlobalConfigAutocomplete(interaction, focusedOption.value, freeOnly);
     } else {
       await interaction.respond([]);
     }

--- a/services/bot-client/src/commands/preset/global/free-default.ts
+++ b/services/bot-client/src/commands/preset/global/free-default.ts
@@ -13,7 +13,7 @@ import { handleGlobalPresetUpdate } from './globalPresetHelpers.js';
  */
 export async function handleGlobalSetFreeDefault(context: DeferredCommandContext): Promise<void> {
   const options = presetGlobalFreeDefaultOptions(context.interaction);
-  const configId = options.config();
+  const configId = options.preset();
 
   await handleGlobalPresetUpdate(context, configId, {
     promote: (ownerClient, id) => ownerClient.setGlobalLlmConfigFreeDefault(id),

--- a/services/bot-client/src/commands/preset/global/set-default.ts
+++ b/services/bot-client/src/commands/preset/global/set-default.ts
@@ -13,7 +13,7 @@ import { handleGlobalPresetUpdate } from './globalPresetHelpers.js';
  */
 export async function handleGlobalSetDefault(context: DeferredCommandContext): Promise<void> {
   const options = presetGlobalDefaultOptions(context.interaction);
-  const configId = options.config();
+  const configId = options.preset();
 
   await handleGlobalPresetUpdate(context, configId, {
     promote: (ownerClient, id) => ownerClient.setGlobalLlmConfigDefault(id),

--- a/services/bot-client/src/commands/preset/index.ts
+++ b/services/bot-client/src/commands/preset/index.ts
@@ -233,7 +233,7 @@ export default defineCommand({
             .setDescription('Set a global preset as the system default (Owner only)')
             .addStringOption(option =>
               option
-                .setName('config')
+                .setName('preset')
                 .setDescription('Global preset to set as default')
                 .setRequired(true)
                 .setAutocomplete(true)
@@ -245,7 +245,7 @@ export default defineCommand({
             .setDescription('Set a global preset as the free tier default (Owner only)')
             .addStringOption(option =>
               option
-                .setName('config')
+                .setName('preset')
                 .setDescription('Global preset to set as free tier default')
                 .setRequired(true)
                 .setAutocomplete(true)


### PR DESCRIPTION
## Summary

Resolves the `preset`/`config` option-name drift `commands:audit` flagged (the originally-flagged "preset/config worry"). Follow-up to the triage in #1210.

`/preset global default` and `/preset global free-default` named their option `config`, but it selects a **preset** (description: "Global preset to set as default"). Every other preset-selection option on the surface is named `preset` — this one was the outlier.

## Why it wasn't a pure find-replace

`preset/autocomplete.ts` discriminated user-presets vs global-presets **by the option name**:
- `name === 'preset'` → user's own presets (+ global, for `edit`)
- `name === 'config' && subcommandGroup === 'global'` → global presets only

Collapsing both to `preset` would route the global subcommands to the user-preset handler. So the autocomplete branch is restructured to key off `subcommandGroup === 'global'` instead — both option instances now share the `preset` name, discriminated by group.

## Changes

- `preset/index.ts` — two `setName('config')` → `setName('preset')`
- `preset/autocomplete.ts` — branch on subcommand group, not option name
- `preset/global/{set-default,free-default}.ts` — `options.config()` → `options.preset()`
- `commandOptions.ts` (generated via `generate:command-types`) + `command-manifest.json` (regenerated)
- `preset/autocomplete.test.ts` — updated the three global-autocomplete cases

## Verification

- `commands:audit`: **4 → 3 warnings** (preset/config gone; remaining: 2 `list`→browse backlogged, 1 `type` drift accepted)
- bot-client suite green (4973); int test (`CommandHandler.int`) green — int snapshot captures routing, not option names, so unaffected
- typecheck (confirms `options.preset()` resolves through regen'd types), lint, depcruise green

🤖 Generated with [Claude Code](https://claude.com/claude-code)