### PR TITLE
feat(bot-client): /models command — user-aware model browser

### DIFF
--- a/packages/common-types/src/constants/ai.test.ts
+++ b/packages/common-types/src/constants/ai.test.ts
@@ -9,6 +9,7 @@ import {
   buildModelInfoUrl,
   isZaiCodingPlanModel,
   getZaiCodingPlanContextLength,
+  listZaiCodingPlanModels,
 } from './ai.js';
 
 describe('isFreeModel', () => {
@@ -228,5 +229,31 @@ describe('getZaiCodingPlanContextLength', () => {
     expect(getZaiCodingPlanContextLength('z-ai/glm-99-future')).toBeNull();
     expect(getZaiCodingPlanContextLength('anthropic/claude-sonnet-4')).toBeNull();
     expect(getZaiCodingPlanContextLength('')).toBeNull();
+  });
+});
+
+describe('listZaiCodingPlanModels', () => {
+  it('returns every catalog model with its metadata', () => {
+    const models = listZaiCodingPlanModels();
+    const byName = new Map(models.map(m => [m.model, m]));
+    // The catalog lineup per docs.z.ai/devpack/overview.
+    expect([...byName.keys()].sort()).toEqual(
+      ['glm-4.5-air', 'glm-4.7', 'glm-5', 'glm-5-turbo', 'glm-5.1', 'glm-5.2'].sort()
+    );
+    expect(byName.get('glm-5.2')?.contextLength).toBe(1_000_000);
+    expect(byName.get('glm-4.5-air')?.contextLength).toBe(128_000);
+  });
+
+  it('returns bare keys (no z-ai/ prefix) and a docs URL per model', () => {
+    for (const entry of listZaiCodingPlanModels()) {
+      expect(entry.model.startsWith('z-ai/')).toBe(false);
+      expect(entry.docsUrl).toMatch(/^https:\/\/docs\.z\.ai\//);
+    }
+  });
+
+  it('is consistent with getZaiCodingPlanContextLength for each entry', () => {
+    for (const entry of listZaiCodingPlanModels()) {
+      expect(getZaiCodingPlanContextLength(entry.model)).toBe(entry.contextLength);
+    }
   });
 });

--- a/packages/common-types/src/constants/ai.ts
+++ b/packages/common-types/src/constants/ai.ts
@@ -307,6 +307,25 @@ export function getZaiCodingPlanContextLength(model: string): number | null {
   return ZAI_MODEL_CATALOG[bare]?.contextLength ?? null;
 }
 
+/** One z.ai coding-plan model with its catalog metadata. */
+export interface ZaiCodingPlanModelInfo {
+  /** Bare catalog key, e.g. `glm-5.2` (no `z-ai/` prefix). */
+  model: string;
+  docsUrl: string;
+  contextLength: number;
+}
+
+/**
+ * The full z.ai coding-plan lineup, for surfaces that enumerate the catalog
+ * rather than look up a single model — notably the `/models` browser, which
+ * merges these into the OpenRouter list so z.ai-only models (e.g. `glm-5.2`,
+ * never present in the OpenRouter cache) are still discoverable. Returns bare
+ * catalog keys; prefix with `ZAI_MODEL_PREFIX` for the routable slug form.
+ */
+export function listZaiCodingPlanModels(): ZaiCodingPlanModelInfo[] {
+  return Object.entries(ZAI_MODEL_CATALOG).map(([model, meta]) => ({ model, ...meta }));
+}
+
 /**
  * Build a model-info URL for the response footer based on which provider
  * was actually used. For z.ai-coding direct routes, link to z.ai's docs

--- a/packages/common-types/src/constants/index.ts
+++ b/packages/common-types/src/constants/index.ts
@@ -17,8 +17,10 @@ export {
   ZAI_MODEL_PREFIX,
   isZaiCodingPlanModel,
   getZaiCodingPlanContextLength,
+  listZaiCodingPlanModels,
   buildModelInfoUrl,
 } from './ai.js';
+export type { ZaiCodingPlanModelInfo } from './ai.js';
 
 // Timing constants
 export {

--- a/packages/common-types/src/generated/commandOptions.ts
+++ b/packages/common-types/src/generated/commandOptions.ts
@@ -353,6 +353,25 @@ export const memoryPurgeOptions = defineTypedOptions({
 });
 
 // =============================================================================
+// MODELS COMMAND
+// =============================================================================
+
+/**
+ * /models browse <capability, search>
+ */
+export const modelsBrowseOptions = defineTypedOptions({
+  capability: { type: 'string', required: false },
+  search: { type: 'string', required: false },
+});
+
+/**
+ * /models view <model>
+ */
+export const modelsViewOptions = defineTypedOptions({
+  model: { type: 'string', required: true },
+});
+
+// =============================================================================
 // PERSONA COMMAND
 // =============================================================================
 

--- a/services/api-gateway/src/routes/models/index.test.ts
+++ b/services/api-gateway/src/routes/models/index.test.ts
@@ -202,7 +202,21 @@ describe('/models routes', () => {
       );
     });
 
-    it('should cap limit at 100', async () => {
+    it('should cap limit at 1000 (full-catalog ceiling for /models browse)', async () => {
+      const router = createModelsRouter(mockCache);
+      const handler = getHandler(router, 'get', '/');
+      const { req, res } = createMockReqRes({ limit: '5000' });
+
+      await handler(req, res);
+
+      expect(mockCache.getFilteredModels).toHaveBeenCalledWith(
+        expect.objectContaining({
+          limit: 1000,
+        })
+      );
+    });
+
+    it('allows a limit between the old 100 and the new 1000 ceiling', async () => {
       const router = createModelsRouter(mockCache);
       const handler = getHandler(router, 'get', '/');
       const { req, res } = createMockReqRes({ limit: '500' });
@@ -210,9 +224,7 @@ describe('/models routes', () => {
       await handler(req, res);
 
       expect(mockCache.getFilteredModels).toHaveBeenCalledWith(
-        expect.objectContaining({
-          limit: 100,
-        })
+        expect.objectContaining({ limit: 500 })
       );
     });
 

--- a/services/api-gateway/src/routes/models/index.ts
+++ b/services/api-gateway/src/routes/models/index.ts
@@ -36,8 +36,12 @@ const logger = createLogger('models-routes');
 
 /** Default limit for autocomplete results */
 const DEFAULT_LIMIT = 25;
-/** Maximum allowed limit */
-const MAX_LIMIT = 100;
+/**
+ * Maximum allowed limit. High enough for the full OpenRouter catalog (~340
+ * models) so the `/models browse` command can page through everything; the
+ * autocomplete callers still pass small limits (25).
+ */
+const MAX_LIMIT = 1000;
 /** Valid modality values */
 const VALID_MODALITIES: ModelModality[] = ['text', 'image', 'audio', 'video', 'file'];
 

--- a/services/bot-client/command-manifest.json
+++ b/services/bot-client/command-manifest.json
@@ -11,6 +11,7 @@
     "History",
     "Channel",
     "Inspect",
+    "Models",
     "Deny",
     "Admin",
     "Help",
@@ -1202,6 +1203,75 @@
         ],
         "name": "memory",
         "description": "Manage your long-term memories",
+        "type": 1
+      }
+    },
+    {
+      "name": "models",
+      "category": "Models",
+      "description": "Browse and inspect available AI models",
+      "handlers": {
+        "execute": true,
+        "autocomplete": true,
+        "selectMenu": true,
+        "button": true,
+        "modal": false
+      },
+      "componentPrefixes": [
+        "models"
+      ],
+      "data": {
+        "options": [
+          {
+            "type": 1,
+            "name": "browse",
+            "description": "Browse available models, filtered by capability or search",
+            "options": [
+              {
+                "type": 3,
+                "choices": [
+                  {
+                    "name": "Vision",
+                    "value": "vision"
+                  },
+                  {
+                    "name": "Image generation",
+                    "value": "image-gen"
+                  },
+                  {
+                    "name": "Text only",
+                    "value": "text"
+                  }
+                ],
+                "name": "capability",
+                "description": "Filter by capability",
+                "required": false
+              },
+              {
+                "type": 3,
+                "name": "search",
+                "description": "Search by model name or ID",
+                "required": false
+              }
+            ]
+          },
+          {
+            "type": 1,
+            "name": "view",
+            "description": "View the detail card for a specific model",
+            "options": [
+              {
+                "autocomplete": true,
+                "type": 3,
+                "name": "model",
+                "description": "Model name or ID",
+                "required": true
+              }
+            ]
+          }
+        ],
+        "name": "models",
+        "description": "Browse and inspect available AI models",
         "type": 1
       }
     },

--- a/services/bot-client/src/commands/help/index.ts
+++ b/services/bot-client/src/commands/help/index.ts
@@ -39,9 +39,10 @@ export const CATEGORY_CONFIG: Record<string, { emoji: string; order: number }> =
   History: { emoji: '📜', order: 8 },
   Channel: { emoji: '#️⃣', order: 9 },
   Inspect: { emoji: '🔍', order: 10 },
-  Deny: { emoji: '🚫', order: 11 },
-  Admin: { emoji: '🛡️', order: 12 },
-  Help: { emoji: '❓', order: 13 },
+  Models: { emoji: '🤖', order: 11 },
+  Deny: { emoji: '🚫', order: 12 },
+  Admin: { emoji: '🛡️', order: 13 },
+  Help: { emoji: '❓', order: 14 },
   Other: { emoji: '📦', order: 99 },
 };
 

--- a/services/bot-client/src/commands/models/autocomplete.test.ts
+++ b/services/bot-client/src/commands/models/autocomplete.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for /models view autocomplete.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { AutocompleteInteraction } from 'discord.js';
+import type { CatalogModel } from '../../utils/modelCatalog.js';
+
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  };
+});
+
+const catalogMock = { fetchModelCatalog: vi.fn() };
+vi.mock('../../utils/modelCatalog.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../utils/modelCatalog.js')>();
+  return {
+    ...actual,
+    fetchModelCatalog: (...args: unknown[]) => catalogMock.fetchModelCatalog(...args),
+  };
+});
+
+import { handleAutocomplete } from './autocomplete.js';
+
+function catalogModel(overrides: Partial<CatalogModel> & { id: string }): CatalogModel {
+  return {
+    name: overrides.id,
+    contextLength: 200_000,
+    supportsVision: false,
+    supportsImageGeneration: false,
+    supportsAudioInput: false,
+    supportsAudioOutput: false,
+    promptPricePerMillion: 3,
+    completionPricePerMillion: 15,
+    isZaiCoding: overrides.id.startsWith('z-ai/'),
+    docsUrl: null,
+    source: 'openrouter',
+    hasPricing: true,
+    ...overrides,
+  };
+}
+
+function interaction(focused: string): AutocompleteInteraction {
+  return {
+    options: { getFocused: () => focused },
+    respond: vi.fn(),
+  } as unknown as AutocompleteInteraction;
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('handleAutocomplete', () => {
+  it('returns choices with name+value and a z.ai marker', async () => {
+    catalogMock.fetchModelCatalog.mockResolvedValue([
+      catalogModel({ id: 'anthropic/claude-sonnet-4', name: 'Claude Sonnet 4' }),
+      catalogModel({ id: 'z-ai/glm-5.2', name: 'GLM-5.2', contextLength: 1_000_000 }),
+    ]);
+    const ix = interaction('glm');
+    await handleAutocomplete(ix);
+    const choices = vi.mocked(ix.respond).mock.calls[0][0] as { name: string; value: string }[];
+    expect(choices).toHaveLength(2);
+    expect(choices[1].value).toBe('z-ai/glm-5.2');
+    expect(choices[1].name).toContain('⚡');
+    expect(choices[1].name).toContain('1M');
+  });
+
+  it('caps choice name/value at 100 chars', async () => {
+    catalogMock.fetchModelCatalog.mockResolvedValue([
+      catalogModel({ id: `vendor/${'x'.repeat(120)}`, name: 'y'.repeat(120) }),
+    ]);
+    const ix = interaction('');
+    await handleAutocomplete(ix);
+    const choices = vi.mocked(ix.respond).mock.calls[0][0] as { name: string; value: string }[];
+    expect(choices[0].name.length).toBeLessThanOrEqual(100);
+    expect(choices[0].value.length).toBeLessThanOrEqual(100);
+  });
+
+  it('responds with an empty list on error', async () => {
+    catalogMock.fetchModelCatalog.mockRejectedValue(new Error('boom'));
+    const ix = interaction('x');
+    await handleAutocomplete(ix);
+    expect(ix.respond).toHaveBeenCalledWith([]);
+  });
+});

--- a/services/bot-client/src/commands/models/autocomplete.ts
+++ b/services/bot-client/src/commands/models/autocomplete.ts
@@ -1,0 +1,41 @@
+/**
+ * Models Autocomplete Handler
+ *
+ * Autocomplete for `/models view <model>`. Uses the merged catalog so z.ai-only
+ * models (e.g. `glm-5.2`, absent from OpenRouter) are suggestable too.
+ */
+
+import type { AutocompleteInteraction } from 'discord.js';
+import { createLogger, DISCORD_LIMITS } from '@tzurot/common-types';
+import { formatContextLength } from '../../utils/modelAutocomplete.js';
+import { fetchModelCatalog } from '../../utils/modelCatalog.js';
+
+const logger = createLogger('models-autocomplete');
+
+/** Discord caps choice name/value at 100 chars. */
+const MAX_CHOICE_LEN = 100;
+
+export async function handleAutocomplete(interaction: AutocompleteInteraction): Promise<void> {
+  const query = interaction.options.getFocused();
+
+  try {
+    const catalog = await fetchModelCatalog({
+      search: query.length > 0 ? query : undefined,
+      limit: DISCORD_LIMITS.AUTOCOMPLETE_MAX_CHOICES,
+    });
+
+    // Re-cap after the catalog merge: the fetch limit bounds only the OpenRouter
+    // half, and fetchModelCatalog adds up to ~6 z.ai entries on top, so the
+    // merged list can exceed Discord's 25-choice ceiling.
+    const choices = catalog.slice(0, DISCORD_LIMITS.AUTOCOMPLETE_MAX_CHOICES).map(model => {
+      const zai = model.isZaiCoding ? '⚡ ' : '';
+      const label = `${zai}${model.name} · ${formatContextLength(model.contextLength)}`;
+      return { name: label.slice(0, MAX_CHOICE_LEN), value: model.id.slice(0, MAX_CHOICE_LEN) };
+    });
+
+    await interaction.respond(choices);
+  } catch (error) {
+    logger.error({ err: error, query }, 'Model autocomplete failed');
+    await interaction.respond([]);
+  }
+}

--- a/services/bot-client/src/commands/models/browse.test.ts
+++ b/services/bot-client/src/commands/models/browse.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for /models browse handlers.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type {
+  ButtonInteraction,
+  ChatInputCommandInteraction,
+  StringSelectMenuInteraction,
+} from 'discord.js';
+import type { UserClient } from '@tzurot/clients';
+import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
+import type { CatalogModel } from '../../utils/modelCatalog.js';
+import { makeOk } from '../../test/gatewayClientStubs.js';
+import { mockListWalletKeysResponse } from '@tzurot/test-factories';
+
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+    modelsBrowseOptions: vi.fn(() => ({
+      capability: () => undefined,
+      search: () => null,
+    })),
+  };
+});
+
+const catalogMock = {
+  fetchModelCatalog: vi.fn(),
+  fetchCatalogModelById: vi.fn(),
+};
+vi.mock('../../utils/modelCatalog.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../utils/modelCatalog.js')>();
+  return {
+    ...actual,
+    fetchModelCatalog: (...args: unknown[]) => catalogMock.fetchModelCatalog(...args),
+    fetchCatalogModelById: (...args: unknown[]) => catalogMock.fetchCatalogModelById(...args),
+  };
+});
+
+const walletStub = { listWalletKeys: vi.fn() };
+vi.mock('../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: walletStub as unknown as UserClient })),
+}));
+
+import {
+  handleBrowse,
+  handleBrowsePagination,
+  handleBrowseSelect,
+  isModelsBrowseInteraction,
+  isModelsBrowseSelectInteraction,
+} from './browse.js';
+
+function catalogModel(overrides: Partial<CatalogModel> & { id: string }): CatalogModel {
+  return {
+    name: overrides.id,
+    contextLength: 200_000,
+    supportsVision: false,
+    supportsImageGeneration: false,
+    supportsAudioInput: false,
+    supportsAudioOutput: false,
+    promptPricePerMillion: 3,
+    completionPricePerMillion: 15,
+    isZaiCoding: overrides.id.startsWith('z-ai/'),
+    docsUrl: null,
+    source: 'openrouter',
+    hasPricing: true,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  walletStub.listWalletKeys.mockResolvedValue(makeOk(mockListWalletKeysResponse([])));
+});
+
+describe('customId predicates', () => {
+  it('recognizes models browse + select customIds', () => {
+    expect(isModelsBrowseInteraction('models::browse::0::all::')).toBe(true);
+    expect(isModelsBrowseSelectInteraction('models::browse-select::0::all::')).toBe(true);
+    expect(isModelsBrowseInteraction('character::browse::0::all::date::')).toBe(false);
+  });
+});
+
+describe('handleBrowse', () => {
+  function ctx(): DeferredCommandContext {
+    const editReply = vi.fn();
+    const interaction = { user: { id: 'u1' }, editReply } as unknown as ChatInputCommandInteraction;
+    return {
+      interaction,
+      user: interaction.user,
+      editReply,
+    } as unknown as DeferredCommandContext;
+  }
+
+  it('renders the browser embed with a select menu', async () => {
+    catalogMock.fetchModelCatalog.mockResolvedValue([
+      catalogModel({ id: 'anthropic/claude-sonnet-4', name: 'Claude Sonnet 4' }),
+    ]);
+    const context = ctx();
+    await handleBrowse(context);
+
+    const call = vi.mocked(context.editReply).mock.calls[0][0] as {
+      embeds: { data: { title: string } }[];
+      components: unknown[];
+    };
+    expect(call.embeds[0].data.title).toBe('🤖 Model Browser');
+    expect(call.components.length).toBeGreaterThan(0);
+  });
+
+  it('reports a friendly error when the fetch throws', async () => {
+    catalogMock.fetchModelCatalog.mockRejectedValue(new Error('boom'));
+    const context = ctx();
+    await handleBrowse(context);
+    expect(context.editReply).toHaveBeenCalledWith('❌ Failed to load models. Please try again.');
+  });
+});
+
+describe('handleBrowsePagination', () => {
+  it('defers and re-renders the requested page', async () => {
+    catalogMock.fetchModelCatalog.mockResolvedValue([catalogModel({ id: 'openai/gpt-5' })]);
+    const deferUpdate = vi.fn();
+    const editReply = vi.fn();
+    const interaction = {
+      customId: 'models::browse::0::all::',
+      user: { id: 'u1' },
+      deferUpdate,
+      editReply,
+    } as unknown as ButtonInteraction;
+
+    await handleBrowsePagination(interaction);
+    expect(deferUpdate).toHaveBeenCalled();
+    expect(editReply).toHaveBeenCalled();
+  });
+
+  it('ignores an unparseable customId', async () => {
+    const deferUpdate = vi.fn();
+    const interaction = {
+      customId: 'not-a-models-browse',
+      deferUpdate,
+    } as unknown as ButtonInteraction;
+    await handleBrowsePagination(interaction);
+    expect(deferUpdate).not.toHaveBeenCalled();
+  });
+
+  it('notifies the user (followUp) when page load fails', async () => {
+    catalogMock.fetchModelCatalog.mockRejectedValue(new Error('boom'));
+    const followUp = vi.fn();
+    const interaction = {
+      customId: 'models::browse::0::all::',
+      user: { id: 'u1' },
+      deferUpdate: vi.fn(),
+      editReply: vi.fn(),
+      followUp,
+    } as unknown as ButtonInteraction;
+
+    await handleBrowsePagination(interaction);
+    const call = followUp.mock.calls[0][0] as { content: string };
+    expect(call.content).toContain('Failed to load that page');
+  });
+});
+
+describe('handleBrowseSelect', () => {
+  function selectInteraction(value: string): StringSelectMenuInteraction {
+    return {
+      values: [value],
+      user: { id: 'u1' },
+      deferUpdate: vi.fn(),
+      followUp: vi.fn(),
+    } as unknown as StringSelectMenuInteraction;
+  }
+
+  it('renders the card for the selected model', async () => {
+    catalogMock.fetchCatalogModelById.mockResolvedValue(
+      catalogModel({ id: 'anthropic/claude-sonnet-4', name: 'Claude Sonnet 4' })
+    );
+    const interaction = selectInteraction('anthropic/claude-sonnet-4');
+    await handleBrowseSelect(interaction);
+
+    const call = vi.mocked(interaction.followUp).mock.calls[0][0] as {
+      embeds: { data: { title: string } }[];
+    };
+    expect(call.embeds[0].data.title).toBe('Claude Sonnet 4');
+  });
+
+  it('reports not-found when the model is missing', async () => {
+    catalogMock.fetchCatalogModelById.mockResolvedValue(null);
+    const interaction = selectInteraction('ghost/model');
+    await handleBrowseSelect(interaction);
+    const call = vi.mocked(interaction.followUp).mock.calls[0][0] as { content: string };
+    expect(call.content).toContain('not found');
+  });
+});

--- a/services/bot-client/src/commands/models/browse.ts
+++ b/services/bot-client/src/commands/models/browse.ts
@@ -1,0 +1,294 @@
+/**
+ * Models Browse Handler
+ *
+ * `/models browse [capability?] [search?]` — paginated, user-aware list of
+ * models. Selecting one opens its detail card. Filtering (capability + search)
+ * is applied at fetch time; the customId encodes capability (as the browse
+ * "filter") + search (as the "query") + page so pagination can rebuild the
+ * same view statelessly.
+ */
+
+import {
+  EmbedBuilder,
+  MessageFlags,
+  escapeMarkdown,
+  type ButtonInteraction,
+  type StringSelectMenuInteraction,
+} from 'discord.js';
+import { createLogger, DISCORD_COLORS, modelsBrowseOptions } from '@tzurot/common-types';
+import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
+import { type ClientCarryingInteraction, clientsFor } from '../../utils/gatewayClients.js';
+import {
+  buildBrowseButtons,
+  buildBrowseSelectMenu,
+  createBrowseCustomIdHelpers,
+  joinFooter,
+  pluralize,
+  type BrowseActionRow,
+} from '../../utils/browse/index.js';
+import { formatContextLength } from '../../utils/modelAutocomplete.js';
+import {
+  fetchModelCatalog,
+  fetchCatalogModelById,
+  annotateUsability,
+  type CapabilityFilter,
+  type UsableCatalogModel,
+} from '../../utils/modelCatalog.js';
+import { buildModelCard } from './card.js';
+
+const logger = createLogger('models-browse');
+
+/** Models per page. Discord select menus cap at 25 options. */
+const MODELS_PER_PAGE = 20;
+
+/**
+ * How many models to fetch for browse. High enough for the whole catalog
+ * (~340 + the z.ai entries); the footer flags it only in the unlikely event
+ * the catalog ever outgrows this ceiling.
+ */
+const BROWSE_FETCH_LIMIT = 1000;
+
+const VALID_FILTERS: readonly CapabilityFilter[] = ['all', 'text', 'vision', 'image-gen'];
+
+const browseHelpers = createBrowseCustomIdHelpers<CapabilityFilter>({
+  prefix: 'models',
+  validFilters: VALID_FILTERS,
+  includeSort: false,
+});
+
+export function isModelsBrowseInteraction(customId: string): boolean {
+  return browseHelpers.isBrowse(customId);
+}
+
+export function isModelsBrowseSelectInteraction(customId: string): boolean {
+  return browseHelpers.isBrowseSelect(customId);
+}
+
+/** Usable-first, then alphabetical by name. */
+function compareModels(a: UsableCatalogModel, b: UsableCatalogModel): number {
+  if (a.canUse !== b.canUse) {
+    return a.canUse ? -1 : 1;
+  }
+  return a.name.localeCompare(b.name);
+}
+
+/** Per-model usability marker for the list/select. */
+function usabilityIcon(model: UsableCatalogModel): string {
+  if (model.usability === 'free') {
+    return '🆓';
+  }
+  return model.canUse ? '✅' : '🔒';
+}
+
+/** A single description line for a model in the browse list. */
+function formatModelLine(model: UsableCatalogModel, displayIndex: number): string {
+  const zai = model.isZaiCoding ? ' ⚡' : '';
+  const caps = [model.supportsVision ? '👁️' : '', model.supportsImageGeneration ? '🎨' : '']
+    .filter(Boolean)
+    .join('');
+  const capsSuffix = caps.length > 0 ? ` ${caps}` : '';
+  return (
+    `**${displayIndex}.** ${usabilityIcon(model)} ${model.name}${zai}${capsSuffix}\n` +
+    `   └ \`${model.id}\` • ${formatContextLength(model.contextLength)}`
+  );
+}
+
+interface BrowseView {
+  items: UsableCatalogModel[];
+  page: number;
+  capability: CapabilityFilter;
+  search: string | null;
+  capped: boolean;
+}
+
+function buildBrowseEmbed(view: BrowseView, pageItems: UsableCatalogModel[]): EmbedBuilder {
+  const { items, page, capability, search, capped } = view;
+  const startIdx = page * MODELS_PER_PAGE;
+
+  const lines: string[] = [];
+  if (search !== null || capability !== 'all') {
+    const filterBits = [
+      capability !== 'all' ? `capability: ${capability}` : '',
+      search !== null ? `search: "${search}"` : '',
+    ].filter(Boolean);
+    lines.push(`_Filters — ${filterBits.join(', ')}_`);
+  }
+  if (items.length === 0) {
+    lines.push('_No models match your filters._');
+  } else {
+    lines.push(...pageItems.map((m, i) => formatModelLine(m, startIdx + i + 1)));
+  }
+
+  const embed = new EmbedBuilder()
+    .setTitle('🤖 Model Browser')
+    .setColor(DISCORD_COLORS.BLURPLE)
+    .setDescription(lines.join('\n'))
+    .setTimestamp();
+
+  embed.setFooter({
+    text: joinFooter(
+      pluralize(items.length, { singular: 'model', plural: 'models' }),
+      capped && `first ${BROWSE_FETCH_LIMIT} — refine with search for more`,
+      '🆓 free  ✅ you can use  🔒 needs a key  ⚡ z.ai'
+    ),
+  });
+  return embed;
+}
+
+function buildBrowseComponents(
+  view: BrowseView,
+  pageItems: UsableCatalogModel[],
+  totalPages: number
+): BrowseActionRow[] {
+  const { page, capability, search } = view;
+  const startIdx = page * MODELS_PER_PAGE;
+  const components: BrowseActionRow[] = [];
+
+  const selectRow = buildBrowseSelectMenu<UsableCatalogModel>({
+    items: pageItems,
+    customId: browseHelpers.buildSelect(page, capability, 'name', search),
+    placeholder: 'Select a model to view its card...',
+    startIndex: startIdx,
+    formatItem: model => ({
+      label: `${usabilityIcon(model)} ${model.name}`,
+      value: model.id,
+      description: model.id,
+    }),
+  });
+  if (selectRow !== null) {
+    components.push(selectRow);
+  }
+
+  if (totalPages > 1 || view.items.length > 0) {
+    components.push(
+      buildBrowseButtons({
+        currentPage: page,
+        totalPages,
+        filter: capability,
+        currentSort: 'name',
+        query: search,
+        buildCustomId: browseHelpers.build,
+        buildInfoId: browseHelpers.buildInfo,
+      })
+    );
+  }
+  return components;
+}
+
+function buildBrowsePage(view: BrowseView): { embed: EmbedBuilder; components: BrowseActionRow[] } {
+  const totalPages = Math.max(1, Math.ceil(view.items.length / MODELS_PER_PAGE));
+  const safePage = Math.min(Math.max(0, view.page), totalPages - 1);
+  const startIdx = safePage * MODELS_PER_PAGE;
+  const pageItems = view.items.slice(startIdx, startIdx + MODELS_PER_PAGE);
+  const safeView: BrowseView = { ...view, page: safePage };
+  return {
+    embed: buildBrowseEmbed(safeView, pageItems),
+    components: buildBrowseComponents(safeView, pageItems, totalPages),
+  };
+}
+
+/** Fetch the merged catalog + the user's active key providers, then annotate + sort. */
+async function loadAnnotatedModels(
+  interaction: ClientCarryingInteraction,
+  capability: CapabilityFilter,
+  search: string | null
+): Promise<UsableCatalogModel[]> {
+  const { userClient } = clientsFor(interaction);
+  const [catalog, walletResult] = await Promise.all([
+    fetchModelCatalog({ capability, search: search ?? undefined, limit: BROWSE_FETCH_LIMIT }),
+    userClient.listWalletKeys(),
+  ]);
+  const activeProviders = new Set(
+    walletResult.ok ? walletResult.data.keys.filter(k => k.isActive).map(k => k.provider) : []
+  );
+  return annotateUsability(catalog, activeProviders).sort(compareModels);
+}
+
+/**
+ * Handle /models browse
+ */
+export async function handleBrowse(context: DeferredCommandContext): Promise<void> {
+  const options = modelsBrowseOptions(context.interaction);
+  const capability = (options.capability() ?? 'all') as CapabilityFilter;
+  const search = options.search();
+
+  try {
+    const models = await loadAnnotatedModels(context.interaction, capability, search);
+    const { embed, components } = buildBrowsePage({
+      items: models,
+      page: 0,
+      capability,
+      search,
+      capped: models.length >= BROWSE_FETCH_LIMIT,
+    });
+    await context.editReply({ embeds: [embed], components });
+    logger.info({ count: models.length, capability, search }, 'Browse models');
+  } catch (error) {
+    logger.error({ err: error }, 'Failed to browse models');
+    await context.editReply('❌ Failed to load models. Please try again.');
+  }
+}
+
+/**
+ * Handle browse pagination button clicks.
+ */
+export async function handleBrowsePagination(interaction: ButtonInteraction): Promise<void> {
+  const parsed = browseHelpers.parse(interaction.customId);
+  if (parsed === null) {
+    return;
+  }
+  await interaction.deferUpdate();
+  try {
+    const models = await loadAnnotatedModels(interaction, parsed.filter, parsed.query);
+    const { embed, components } = buildBrowsePage({
+      items: models,
+      page: parsed.page,
+      capability: parsed.filter,
+      search: parsed.query,
+      capped: models.length >= BROWSE_FETCH_LIMIT,
+    });
+    await interaction.editReply({ embeds: [embed], components });
+  } catch (error) {
+    logger.error({ err: error, ...parsed }, 'Failed to load model browse page');
+    await interaction.followUp({
+      content: '❌ Failed to load that page. Please try again.',
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+}
+
+/**
+ * Handle browse select — render the chosen model's card.
+ */
+export async function handleBrowseSelect(interaction: StringSelectMenuInteraction): Promise<void> {
+  const modelId = interaction.values[0];
+  await interaction.deferUpdate();
+  try {
+    const { userClient } = clientsFor(interaction);
+    const [model, walletResult] = await Promise.all([
+      fetchCatalogModelById(modelId),
+      userClient.listWalletKeys(),
+    ]);
+    if (model === null) {
+      await interaction.followUp({
+        content: `❌ Model \`${escapeMarkdown(modelId)}\` not found.`,
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+    const activeProviders = new Set(
+      walletResult.ok ? walletResult.data.keys.filter(k => k.isActive).map(k => k.provider) : []
+    );
+    const [annotated] = annotateUsability([model], activeProviders);
+    await interaction.followUp({
+      embeds: [buildModelCard(annotated)],
+      flags: MessageFlags.Ephemeral,
+    });
+  } catch (error) {
+    logger.error({ err: error, modelId }, 'Failed to render model card from browse');
+    await interaction.followUp({
+      content: '❌ Failed to load that model.',
+      flags: MessageFlags.Ephemeral,
+    });
+  }
+}

--- a/services/bot-client/src/commands/models/card.test.ts
+++ b/services/bot-client/src/commands/models/card.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for the model detail card embed builder.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildModelCard } from './card.js';
+import type { UsableCatalogModel } from '../../utils/modelCatalog.js';
+
+function usable(overrides: Partial<UsableCatalogModel> & { id: string }): UsableCatalogModel {
+  return {
+    name: overrides.id,
+    contextLength: 200_000,
+    supportsVision: false,
+    supportsImageGeneration: false,
+    supportsAudioInput: false,
+    supportsAudioOutput: false,
+    promptPricePerMillion: 3,
+    completionPricePerMillion: 15,
+    isZaiCoding: false,
+    docsUrl: null,
+    source: 'openrouter',
+    hasPricing: true,
+    usability: 'usable',
+    canUse: true,
+    ...overrides,
+  };
+}
+
+describe('buildModelCard', () => {
+  it('renders an OpenRouter model with slug, context, pricing, and OpenRouter link', () => {
+    const embed = buildModelCard(
+      usable({ id: 'anthropic/claude-sonnet-4', name: 'Claude Sonnet 4' })
+    );
+    const json = embed.toJSON();
+    expect(json.title).toBe('Claude Sonnet 4');
+    expect(json.description).toContain('`anthropic/claude-sonnet-4`');
+    expect(json.description).toContain('✅ You can use this');
+    const fields = json.fields ?? [];
+    expect(fields.find(f => f.name === 'Context')?.value).toContain('200K');
+    expect(fields.find(f => f.name === 'Pricing')?.value).toContain('$3.00 in / $15.00 out');
+    expect(fields.find(f => f.name === 'Links')?.value).toContain('OpenRouter model page');
+  });
+
+  it('renders a z.ai-only model with BYOK pricing, z.ai field, and docs link', () => {
+    const embed = buildModelCard(
+      usable({
+        id: 'z-ai/glm-5.2',
+        name: 'GLM-5.2',
+        contextLength: 1_000_000,
+        isZaiCoding: true,
+        docsUrl: 'https://docs.z.ai/guides/llm/glm-5.2',
+        source: 'zai-catalog',
+        hasPricing: false,
+        usability: 'needs-zai-key',
+        canUse: false,
+      })
+    );
+    const json = embed.toJSON();
+    const fields = json.fields ?? [];
+    expect(fields.find(f => f.name === 'Context')?.value).toContain('1M');
+    expect(fields.find(f => f.name === 'Pricing')?.value).toContain('bring your own key');
+    expect(fields.some(f => f.name === 'z.ai coding plan')).toBe(true);
+    expect(fields.find(f => f.name === 'Links')?.value).toContain('z.ai docs');
+    expect(fields.find(f => f.name === 'Links')?.value).not.toContain('OpenRouter');
+    expect(json.description).toContain('🔒 Needs a z.ai');
+  });
+
+  it('renders "Variable" pricing for a negative-priced auto-router', () => {
+    const embed = buildModelCard(
+      usable({
+        id: 'openrouter/auto',
+        name: 'Auto Router',
+        promptPricePerMillion: -1_000_000,
+        completionPricePerMillion: -1_000_000,
+        hasPricing: false,
+        source: 'openrouter',
+        usability: 'needs-openrouter-key',
+        canUse: false,
+      })
+    );
+    const fields = embed.toJSON().fields ?? [];
+    expect(fields.find(f => f.name === 'Pricing')?.value).toContain('Variable');
+    expect(fields.find(f => f.name === 'Pricing')?.value).not.toContain('-');
+  });
+
+  it('names both key paths for a both-source model with no keys', () => {
+    const embed = buildModelCard(
+      usable({
+        id: 'z-ai/glm-5',
+        name: 'GLM-5',
+        isZaiCoding: true,
+        source: 'both',
+        usability: 'needs-either-key',
+        canUse: false,
+      })
+    );
+    expect(embed.toJSON().description).toContain('OpenRouter or z.ai');
+  });
+
+  it('shows the free usability line for free models', () => {
+    const embed = buildModelCard(
+      usable({ id: 'google/gemma:free', usability: 'free', canUse: true })
+    );
+    expect(embed.toJSON().description).toContain('🆓 Free');
+  });
+
+  it('renders capability emojis for a vision model', () => {
+    const embed = buildModelCard(usable({ id: 'x/vision', supportsVision: true }));
+    expect(embed.toJSON().description).toContain('👁️ vision');
+  });
+});

--- a/services/bot-client/src/commands/models/card.ts
+++ b/services/bot-client/src/commands/models/card.ts
@@ -1,0 +1,87 @@
+/**
+ * Model Card
+ *
+ * Builds the detail embed for a single model, shown by `/models view` and by
+ * selecting an item in `/models browse`. Pure (no I/O) so it's directly
+ * unit-testable.
+ */
+
+import { EmbedBuilder } from 'discord.js';
+import { DISCORD_COLORS, buildModelInfoUrl, AIProvider } from '@tzurot/common-types';
+import { formatContextLength } from '../../utils/modelAutocomplete.js';
+import {
+  formatCapabilities,
+  type ModelUsability,
+  type UsableCatalogModel,
+} from '../../utils/modelCatalog.js';
+
+/** One-line usability summary keyed by status. */
+const USABILITY_LINE: Record<ModelUsability, string> = {
+  free: '🆓 Free — available to everyone',
+  usable: '✅ You can use this',
+  'needs-openrouter-key': '🔒 Needs an OpenRouter key — add one with `/settings apikey set`',
+  'needs-zai-key': '🔒 Needs a z.ai coding-plan key — add one with `/settings apikey set`',
+  'needs-either-key':
+    '🔒 Needs an OpenRouter or z.ai coding-plan key — add one with `/settings apikey set`',
+};
+
+/** Format the pricing field, or the BYOK note when no per-token figures exist. */
+function formatPricing(model: UsableCatalogModel): string {
+  if (!model.hasPricing) {
+    // z.ai-only catalog entries have no $ figures; OpenRouter meta/auto-routers
+    // have negative pricing because the cost depends on the routed model.
+    return model.source === 'zai-catalog'
+      ? 'z.ai coding plan — bring your own key'
+      : 'Variable — depends on the routed model';
+  }
+  const inPrice = model.promptPricePerMillion.toFixed(2);
+  const outPrice = model.completionPricePerMillion.toFixed(2);
+  return `$${inPrice} in / $${outPrice} out (per 1M tokens)`;
+}
+
+/** Build the markdown links line (z.ai docs and/or OpenRouter model page). */
+function formatLinks(model: UsableCatalogModel): string | null {
+  const links: string[] = [];
+  if (model.docsUrl !== null) {
+    links.push(`[z.ai docs](${model.docsUrl})`);
+  }
+  if (model.source !== 'zai-catalog') {
+    links.push(`[OpenRouter model page](${buildModelInfoUrl(model.id, AIProvider.OpenRouter)})`);
+  }
+  return links.length > 0 ? links.join(' • ') : null;
+}
+
+/**
+ * Build the model detail card.
+ */
+export function buildModelCard(model: UsableCatalogModel): EmbedBuilder {
+  const embed = new EmbedBuilder()
+    .setTitle(model.name)
+    .setColor(model.canUse ? DISCORD_COLORS.SUCCESS : DISCORD_COLORS.BLURPLE)
+    .setDescription(
+      [`\`${model.id}\``, '', formatCapabilities(model), USABILITY_LINE[model.usability]].join('\n')
+    )
+    .addFields(
+      {
+        name: 'Context',
+        value: `${formatContextLength(model.contextLength)} tokens`,
+        inline: true,
+      },
+      { name: 'Pricing', value: formatPricing(model), inline: true }
+    );
+
+  if (model.isZaiCoding) {
+    embed.addFields({
+      name: 'z.ai coding plan',
+      value: '⚡ Available on the z.ai GLM coding plan',
+      inline: false,
+    });
+  }
+
+  const links = formatLinks(model);
+  if (links !== null) {
+    embed.addFields({ name: 'Links', value: links, inline: false });
+  }
+
+  return embed;
+}

--- a/services/bot-client/src/commands/models/index.ts
+++ b/services/bot-client/src/commands/models/index.ts
@@ -1,0 +1,97 @@
+/**
+ * Models Command Group
+ *
+ * `/models` — browse and inspect available AI models with a user-aware card
+ * (shows whether the requesting user can actually run each model, given their
+ * configured API keys). Merges the OpenRouter model list with the static z.ai
+ * coding-plan catalog so z.ai-only models are discoverable too.
+ */
+
+import {
+  SlashCommandBuilder,
+  type AutocompleteInteraction,
+  type ButtonInteraction,
+  type StringSelectMenuInteraction,
+} from 'discord.js';
+import { createLogger } from '@tzurot/common-types';
+import { defineCommand } from '../../utils/defineCommand.js';
+import type { SafeCommandContext } from '../../utils/commandContext/types.js';
+import { createMixedModeSubcommandRouter } from '../../utils/mixedModeSubcommandRouter.js';
+import { handleAutocomplete } from './autocomplete.js';
+import { handleView } from './view.js';
+import {
+  handleBrowse,
+  handleBrowsePagination,
+  handleBrowseSelect,
+  isModelsBrowseInteraction,
+  isModelsBrowseSelectInteraction,
+} from './browse.js';
+
+const logger = createLogger('models-command');
+
+async function execute(context: SafeCommandContext): Promise<void> {
+  const router = createMixedModeSubcommandRouter(
+    { deferred: { browse: handleBrowse, view: handleView } },
+    { logger, logPrefix: '[Models]' }
+  );
+  await router(context);
+}
+
+async function autocomplete(interaction: AutocompleteInteraction): Promise<void> {
+  await handleAutocomplete(interaction);
+}
+
+async function handleButton(interaction: ButtonInteraction): Promise<void> {
+  if (isModelsBrowseInteraction(interaction.customId)) {
+    await handleBrowsePagination(interaction);
+  }
+}
+
+async function handleSelectMenu(interaction: StringSelectMenuInteraction): Promise<void> {
+  if (isModelsBrowseSelectInteraction(interaction.customId)) {
+    await handleBrowseSelect(interaction);
+  }
+}
+
+export default defineCommand({
+  deferralMode: 'ephemeral',
+  data: new SlashCommandBuilder()
+    .setName('models')
+    .setDescription('Browse and inspect available AI models')
+    .addSubcommand(subcommand =>
+      subcommand
+        .setName('browse')
+        .setDescription('Browse available models, filtered by capability or search')
+        .addStringOption(option =>
+          option
+            .setName('capability')
+            .setDescription('Filter by capability')
+            .setRequired(false)
+            .addChoices(
+              { name: 'Vision', value: 'vision' },
+              { name: 'Image generation', value: 'image-gen' },
+              { name: 'Text only', value: 'text' }
+            )
+        )
+        .addStringOption(option =>
+          option.setName('search').setDescription('Search by model name or ID').setRequired(false)
+        )
+    )
+    .addSubcommand(subcommand =>
+      subcommand
+        .setName('view')
+        .setDescription('View the detail card for a specific model')
+        .addStringOption(option =>
+          option
+            .setName('model')
+            .setDescription('Model name or ID')
+            .setRequired(true)
+            .setAutocomplete(true)
+        )
+    ),
+  execute,
+  autocomplete,
+  handleButton,
+  handleSelectMenu,
+  componentPrefixes: ['models'],
+});

--- a/services/bot-client/src/commands/models/view.test.ts
+++ b/services/bot-client/src/commands/models/view.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for /models view handler.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ChatInputCommandInteraction } from 'discord.js';
+import type { UserClient } from '@tzurot/clients';
+import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
+import type { CatalogModel } from '../../utils/modelCatalog.js';
+import { makeOk } from '../../test/gatewayClientStubs.js';
+import { mockListWalletKeysResponse } from '@tzurot/test-factories';
+
+let viewModelId = 'anthropic/claude-sonnet-4';
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+    modelsViewOptions: vi.fn(() => ({ model: () => viewModelId })),
+  };
+});
+
+const catalogMock = { fetchCatalogModelById: vi.fn() };
+vi.mock('../../utils/modelCatalog.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../utils/modelCatalog.js')>();
+  return {
+    ...actual,
+    fetchCatalogModelById: (...args: unknown[]) => catalogMock.fetchCatalogModelById(...args),
+  };
+});
+
+const walletStub = { listWalletKeys: vi.fn() };
+vi.mock('../../utils/gatewayClients.js', () => ({
+  clientsFor: vi.fn(() => ({ userClient: walletStub as unknown as UserClient })),
+}));
+
+import { handleView } from './view.js';
+
+function catalogModel(overrides: Partial<CatalogModel> & { id: string }): CatalogModel {
+  return {
+    name: overrides.id,
+    contextLength: 200_000,
+    supportsVision: false,
+    supportsImageGeneration: false,
+    supportsAudioInput: false,
+    supportsAudioOutput: false,
+    promptPricePerMillion: 3,
+    completionPricePerMillion: 15,
+    isZaiCoding: false,
+    docsUrl: null,
+    source: 'openrouter',
+    hasPricing: true,
+    ...overrides,
+  };
+}
+
+function ctx(): DeferredCommandContext {
+  const editReply = vi.fn();
+  const interaction = { user: { id: 'u1' }, editReply } as unknown as ChatInputCommandInteraction;
+  return { interaction, user: interaction.user, editReply } as unknown as DeferredCommandContext;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  viewModelId = 'anthropic/claude-sonnet-4';
+  walletStub.listWalletKeys.mockResolvedValue(makeOk(mockListWalletKeysResponse([])));
+});
+
+describe('handleView', () => {
+  it('renders the card for an existing model', async () => {
+    catalogMock.fetchCatalogModelById.mockResolvedValue(
+      catalogModel({ id: 'anthropic/claude-sonnet-4', name: 'Claude Sonnet 4' })
+    );
+    const context = ctx();
+    await handleView(context);
+    const call = vi.mocked(context.editReply).mock.calls[0][0] as {
+      embeds: { data: { title: string } }[];
+    };
+    expect(call.embeds[0].data.title).toBe('Claude Sonnet 4');
+  });
+
+  it('reports a not-found message for an unknown slug', async () => {
+    viewModelId = 'ghost/model';
+    catalogMock.fetchCatalogModelById.mockResolvedValue(null);
+    const context = ctx();
+    await handleView(context);
+    expect(context.editReply).toHaveBeenCalledWith(expect.stringContaining('No model found'));
+  });
+
+  it('reports a friendly error when the lookup throws', async () => {
+    catalogMock.fetchCatalogModelById.mockRejectedValue(new Error('boom'));
+    const context = ctx();
+    await handleView(context);
+    expect(context.editReply).toHaveBeenCalledWith(
+      '❌ Failed to load that model. Please try again.'
+    );
+  });
+});

--- a/services/bot-client/src/commands/models/view.ts
+++ b/services/bot-client/src/commands/models/view.ts
@@ -1,0 +1,46 @@
+/**
+ * Models View Handler
+ *
+ * `/models view <model>` — render the detail card for one model by slug.
+ */
+
+import { escapeMarkdown } from 'discord.js';
+import { createLogger, modelsViewOptions } from '@tzurot/common-types';
+import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
+import { clientsFor } from '../../utils/gatewayClients.js';
+import { fetchCatalogModelById, annotateUsability } from '../../utils/modelCatalog.js';
+import { buildModelCard } from './card.js';
+
+const logger = createLogger('models-view');
+
+/**
+ * Handle /models view <model>
+ */
+export async function handleView(context: DeferredCommandContext): Promise<void> {
+  const modelId = modelsViewOptions(context.interaction).model();
+
+  try {
+    const { userClient } = clientsFor(context.interaction);
+    const [model, walletResult] = await Promise.all([
+      fetchCatalogModelById(modelId),
+      userClient.listWalletKeys(),
+    ]);
+
+    if (model === null) {
+      await context.editReply(
+        `❌ No model found matching \`${escapeMarkdown(modelId)}\`. Try \`/models browse\` to discover what's available.`
+      );
+      return;
+    }
+
+    const activeProviders = new Set(
+      walletResult.ok ? walletResult.data.keys.filter(k => k.isActive).map(k => k.provider) : []
+    );
+    const [annotated] = annotateUsability([model], activeProviders);
+    await context.editReply({ embeds: [buildModelCard(annotated)] });
+    logger.info({ modelId, usability: annotated.usability }, 'Viewed model card');
+  } catch (error) {
+    logger.error({ err: error, modelId }, 'Failed to view model');
+    await context.editReply('❌ Failed to load that model. Please try again.');
+  }
+}

--- a/services/bot-client/src/handlers/__snapshots__/CommandHandler.int.test.ts.snap
+++ b/services/bot-client/src/handlers/__snapshots__/CommandHandler.int.test.ts.snap
@@ -1357,4 +1357,4 @@ exports[`CommandHandler (component) > command structure snapshots > should have 
 ]
 `;
 
-exports[`CommandHandler (component) > command structure snapshots > should have stable command count > total-command-count 1`] = `13`;
+exports[`CommandHandler (component) > command structure snapshots > should have stable command count > total-command-count 1`] = `14`;

--- a/services/bot-client/src/utils/modelAutocomplete.ts
+++ b/services/bot-client/src/utils/modelAutocomplete.ts
@@ -185,7 +185,7 @@ export function formatModelChoice(model: ModelAutocompleteOption): { name: strin
 /**
  * Format context length for display
  */
-function formatContextLength(tokens: number): string {
+export function formatContextLength(tokens: number): string {
   if (tokens >= 1_000_000) {
     const millions = tokens / 1_000_000;
     return millions % 1 === 0 ? `${millions}M` : `${millions.toFixed(1)}M`;

--- a/services/bot-client/src/utils/modelCatalog.test.ts
+++ b/services/bot-client/src/utils/modelCatalog.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for the model catalog merge + usability annotation.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ModelAutocompleteOption } from '@tzurot/common-types';
+
+// Mock the OpenRouter fetch layer so tests control the OpenRouter side of the
+// merge; the z.ai catalog half comes from the real listZaiCodingPlanModels().
+vi.mock('./modelAutocomplete.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('./modelAutocomplete.js')>();
+  return { ...actual, fetchModels: vi.fn() };
+});
+
+import { fetchModels } from './modelAutocomplete.js';
+import {
+  fetchModelCatalog,
+  fetchCatalogModelById,
+  annotateUsability,
+  formatCapabilities,
+  type CatalogModel,
+} from './modelCatalog.js';
+
+const fetchModelsMock = vi.mocked(fetchModels);
+
+function model(
+  overrides: Partial<ModelAutocompleteOption> & { id: string }
+): ModelAutocompleteOption {
+  return {
+    name: overrides.id,
+    contextLength: 128_000,
+    supportsVision: false,
+    supportsImageGeneration: false,
+    supportsAudioInput: false,
+    supportsAudioOutput: false,
+    promptPricePerMillion: 1,
+    completionPricePerMillion: 2,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  fetchModelsMock.mockReset();
+});
+
+describe('fetchModelCatalog', () => {
+  it('merges z.ai-only models (e.g. glm-5.2) absent from OpenRouter', async () => {
+    fetchModelsMock.mockResolvedValue([
+      model({ id: 'anthropic/claude-sonnet-4', name: 'Claude Sonnet 4' }),
+    ]);
+    const catalog = await fetchModelCatalog();
+    const glm52 = catalog.find(m => m.id === 'z-ai/glm-5.2');
+    expect(glm52).toBeDefined();
+    expect(glm52?.source).toBe('zai-catalog');
+    expect(glm52?.isZaiCoding).toBe(true);
+    expect(glm52?.hasPricing).toBe(false);
+    expect(glm52?.contextLength).toBe(1_000_000);
+    expect(glm52?.docsUrl).toMatch(/docs\.z\.ai/);
+  });
+
+  it('dedups a z.ai model present in both sources to source=both, keeping OpenRouter pricing', async () => {
+    fetchModelsMock.mockResolvedValue([
+      model({
+        id: 'z-ai/glm-5',
+        name: 'GLM 5',
+        promptPricePerMillion: 0.5,
+        completionPricePerMillion: 1.5,
+      }),
+    ]);
+    const catalog = await fetchModelCatalog();
+    const glm5 = catalog.filter(m => m.id.toLowerCase() === 'z-ai/glm-5');
+    expect(glm5).toHaveLength(1); // deduped, not duplicated
+    expect(glm5[0].source).toBe('both');
+    expect(glm5[0].hasPricing).toBe(true);
+    expect(glm5[0].promptPricePerMillion).toBe(0.5);
+    expect(glm5[0].docsUrl).toMatch(/docs\.z\.ai/); // z.ai docs attached
+  });
+
+  it('annotates an OpenRouter model with isZaiCoding=false and source=openrouter', async () => {
+    fetchModelsMock.mockResolvedValue([model({ id: 'openai/gpt-5' })]);
+    const catalog = await fetchModelCatalog();
+    const gpt = catalog.find(m => m.id === 'openai/gpt-5');
+    expect(gpt?.isZaiCoding).toBe(false);
+    expect(gpt?.source).toBe('openrouter');
+    expect(gpt?.hasPricing).toBe(true);
+  });
+
+  it('marks negative-priced meta/auto-routers as hasPricing=false', async () => {
+    // openrouter/auto et al. carry -1 pricing (cost depends on what they route to).
+    fetchModelsMock.mockResolvedValue([
+      model({
+        id: 'openrouter/auto',
+        name: 'Auto Router',
+        promptPricePerMillion: -1_000_000,
+        completionPricePerMillion: -1_000_000,
+      }),
+    ]);
+    const auto = (await fetchModelCatalog()).find(m => m.id === 'openrouter/auto');
+    expect(auto?.hasPricing).toBe(false);
+    expect(auto?.source).toBe('openrouter');
+  });
+
+  it('excludes z.ai (text-only) models from the vision capability view', async () => {
+    fetchModelsMock.mockResolvedValue([
+      model({ id: 'anthropic/claude-sonnet-4', supportsVision: true }),
+    ]);
+    const catalog = await fetchModelCatalog({ capability: 'vision' });
+    expect(catalog.some(m => m.id.startsWith('z-ai/'))).toBe(false);
+    // and it requests the vision endpoint
+    expect(fetchModelsMock).toHaveBeenCalledWith(expect.objectContaining({ visionOnly: true }));
+  });
+
+  it('filters z.ai models by search term', async () => {
+    fetchModelsMock.mockResolvedValue([]);
+    const matching = await fetchModelCatalog({ search: 'glm-5.2' });
+    expect(matching.some(m => m.id === 'z-ai/glm-5.2')).toBe(true);
+    const nonMatching = await fetchModelCatalog({ search: 'nonexistent-xyz' });
+    expect(nonMatching.some(m => m.id.startsWith('z-ai/'))).toBe(false);
+  });
+});
+
+describe('fetchCatalogModelById', () => {
+  it('returns the exact-id match', async () => {
+    fetchModelsMock.mockResolvedValue([
+      model({ id: 'anthropic/claude-sonnet-4', name: 'Claude Sonnet 4' }),
+      model({ id: 'anthropic/claude-haiku-4' }),
+    ]);
+    const found = await fetchCatalogModelById('anthropic/claude-sonnet-4');
+    expect(found?.name).toBe('Claude Sonnet 4');
+  });
+
+  it('finds a z.ai-only model by id', async () => {
+    fetchModelsMock.mockResolvedValue([]);
+    const found = await fetchCatalogModelById('z-ai/glm-5.2');
+    expect(found?.contextLength).toBe(1_000_000);
+  });
+
+  it('returns null when nothing matches exactly', async () => {
+    fetchModelsMock.mockResolvedValue([model({ id: 'anthropic/claude-sonnet-4' })]);
+    expect(await fetchCatalogModelById('anthropic/claude')).toBeNull();
+  });
+});
+
+describe('annotateUsability', () => {
+  const cat = (overrides: Partial<CatalogModel> & { id: string }): CatalogModel => ({
+    ...model(overrides),
+    isZaiCoding: overrides.id.startsWith('z-ai/'),
+    docsUrl: null,
+    source: 'openrouter',
+    hasPricing: true,
+    ...overrides,
+  });
+
+  it('marks free models usable regardless of keys', () => {
+    const [r] = annotateUsability([cat({ id: 'google/gemma:free' })], new Set());
+    expect(r.usability).toBe('free');
+    expect(r.canUse).toBe(true);
+  });
+
+  it('marks an OpenRouter model usable when the user has an openrouter key', () => {
+    const [r] = annotateUsability(
+      [cat({ id: 'anthropic/claude-sonnet-4' })],
+      new Set(['openrouter'])
+    );
+    expect(r.usability).toBe('usable');
+    expect(r.canUse).toBe(true);
+  });
+
+  it('flags needs-openrouter-key when the user has no key', () => {
+    const [r] = annotateUsability([cat({ id: 'anthropic/claude-sonnet-4' })], new Set());
+    expect(r.usability).toBe('needs-openrouter-key');
+    expect(r.canUse).toBe(false);
+  });
+
+  it('flags needs-zai-key for a z.ai-ONLY model (zai-catalog) without a z.ai key', () => {
+    const [r] = annotateUsability(
+      [cat({ id: 'z-ai/glm-5.2', isZaiCoding: true, source: 'zai-catalog', hasPricing: false })],
+      new Set(['openrouter']) // an OpenRouter key does NOT unlock a z.ai-only model
+    );
+    expect(r.usability).toBe('needs-zai-key');
+    expect(r.canUse).toBe(false);
+  });
+
+  it('marks a z.ai-only model usable with a zai-coding key', () => {
+    const [r] = annotateUsability(
+      [cat({ id: 'z-ai/glm-5.2', isZaiCoding: true, source: 'zai-catalog', hasPricing: false })],
+      new Set(['zai-coding'])
+    );
+    expect(r.canUse).toBe(true);
+  });
+
+  it('treats a coding-plan model on BOTH sources as usable via EITHER key', () => {
+    // z-ai/glm-5 lives on OpenRouter too — an OR key (fallthrough) or a z.ai key
+    // (direct) both unlock it.
+    const both = cat({ id: 'z-ai/glm-5', isZaiCoding: true, source: 'both' });
+    expect(annotateUsability([both], new Set(['openrouter']))[0].canUse).toBe(true);
+    expect(annotateUsability([both], new Set(['zai-coding']))[0].canUse).toBe(true);
+    // Neither key → name BOTH paths, not just one.
+    expect(annotateUsability([both], new Set())[0].usability).toBe('needs-either-key');
+  });
+
+  it('a z-ai/ model NOT on the coding plan needs an OpenRouter key (routes via OR)', () => {
+    // e.g. z-ai/glm-4.6 — on OpenRouter, not in the coding-plan catalog, so
+    // source is plain 'openrouter' and the z-ai/ prefix must NOT imply z.ai.
+    const [r] = annotateUsability(
+      [cat({ id: 'z-ai/glm-4.6', isZaiCoding: false, source: 'openrouter' })],
+      new Set(['zai-coding']) // a z.ai key does NOT unlock it
+    );
+    expect(r.usability).toBe('needs-openrouter-key');
+    expect(r.canUse).toBe(false);
+  });
+});
+
+describe('formatCapabilities', () => {
+  it('always includes text and appends present capabilities', () => {
+    const out = formatCapabilities(
+      model({ id: 'x', supportsVision: true, supportsAudioInput: true })
+    );
+    expect(out).toContain('text');
+    expect(out).toContain('vision');
+    expect(out).toContain('audio-in');
+    expect(out).not.toContain('image-gen');
+  });
+});

--- a/services/bot-client/src/utils/modelCatalog.ts
+++ b/services/bot-client/src/utils/modelCatalog.ts
@@ -1,0 +1,246 @@
+/**
+ * Model Catalog
+ *
+ * Builds the unified model list behind the `/models` command by merging two
+ * sources:
+ *  1. The OpenRouter model list (via the gateway `/models` endpoints).
+ *  2. The static z.ai coding-plan catalog (`listZaiCodingPlanModels`) — which
+ *     includes z.ai-only models like `glm-5.2` that never appear in OpenRouter.
+ *
+ * It also annotates each model with whether the requesting user can actually
+ * use it, computed client-side from their configured API-key providers (no
+ * server round-trip beyond the wallet list the caller already fetched).
+ */
+
+import {
+  AIProvider,
+  ZAI_MODEL_PREFIX,
+  isFreeModel,
+  isZaiCodingPlanModel,
+  listZaiCodingPlanModels,
+  type ModelAutocompleteOption,
+} from '@tzurot/common-types';
+import { fetchModels } from './modelAutocomplete.js';
+
+/** Where a catalog entry's data came from. */
+export type ModelSource = 'openrouter' | 'zai-catalog' | 'both';
+
+/** A model plus the metadata the `/models` card/list needs. */
+export interface CatalogModel extends ModelAutocompleteOption {
+  /** True if the model is on the z.ai coding plan (by prefix or catalog membership). */
+  isZaiCoding: boolean;
+  /** z.ai docs URL when known (z.ai models only); null otherwise. */
+  docsUrl: string | null;
+  /** Origin of the data — drives pricing display (zai-catalog has no $ figures). */
+  source: ModelSource;
+  /** Whether per-token pricing is known (false for z.ai-only catalog entries). */
+  hasPricing: boolean;
+}
+
+/** Why a user can or can't use a model. */
+export type ModelUsability =
+  | 'free'
+  | 'usable'
+  | 'needs-openrouter-key'
+  | 'needs-zai-key'
+  | 'needs-either-key';
+
+export interface UsableCatalogModel extends CatalogModel {
+  usability: ModelUsability;
+  canUse: boolean;
+}
+
+/** Capability filter for browse/fetch — mirrors the `/models browse` choices. */
+export type CapabilityFilter = 'all' | 'text' | 'vision' | 'image-gen';
+
+export interface FetchCatalogOptions {
+  capability?: CapabilityFilter;
+  search?: string;
+  /** OpenRouter fetch cap (gateway max is 1000). */
+  limit?: number;
+}
+
+/** Render a z.ai catalog key as a display name, e.g. `glm-5.2` → `GLM-5.2`. */
+function zaiDisplayName(model: string): string {
+  return model.toUpperCase();
+}
+
+/** Build a CatalogModel from an OpenRouter option. */
+function fromOpenRouter(m: ModelAutocompleteOption): CatalogModel {
+  // Meta/auto-routers (e.g. openrouter/auto) carry negative pricing because
+  // their cost depends on what they route to — no concrete per-token figure.
+  const hasPricing = m.promptPricePerMillion >= 0 && m.completionPricePerMillion >= 0;
+  return {
+    ...m,
+    isZaiCoding: isZaiCodingPlanModel(m.id),
+    docsUrl: null,
+    source: 'openrouter',
+    hasPricing,
+  };
+}
+
+/**
+ * Whether a z.ai catalog entry passes the active capability/search filter.
+ * z.ai coding-plan models are text-only, so they're excluded from the
+ * vision/image-gen capability views.
+ */
+function zaiPassesFilter(
+  slug: string,
+  displayName: string,
+  capability: CapabilityFilter,
+  searchLower: string
+): boolean {
+  if (capability === 'vision' || capability === 'image-gen') {
+    return false;
+  }
+  if (searchLower.length === 0) {
+    return true;
+  }
+  return (
+    slug.toLowerCase().includes(searchLower) || displayName.toLowerCase().includes(searchLower)
+  );
+}
+
+/**
+ * Fetch the merged model catalog (OpenRouter + z.ai), deduped by slug.
+ *
+ * A z.ai model that ALSO appears in OpenRouter (e.g. a `z-ai/glm-*` mirror)
+ * merges to `source: 'both'` — OpenRouter pricing/capabilities are kept and the
+ * z.ai docs URL is attached. z.ai-only models become synthetic `zai-catalog`
+ * entries with no per-token pricing.
+ */
+export async function fetchModelCatalog(
+  options: FetchCatalogOptions = {}
+): Promise<CatalogModel[]> {
+  const capability = options.capability ?? 'all';
+  const search = options.search;
+  const openRouterModels = await fetchModels({
+    textOnly: capability === 'text',
+    visionOnly: capability === 'vision',
+    imageGenOnly: capability === 'image-gen',
+    search,
+    limit: options.limit ?? 100,
+  });
+
+  const byKey = new Map<string, CatalogModel>();
+  for (const m of openRouterModels) {
+    byKey.set(m.id.toLowerCase(), fromOpenRouter(m));
+  }
+
+  const searchLower = (search ?? '').toLowerCase();
+  for (const z of listZaiCodingPlanModels()) {
+    const slug = `${ZAI_MODEL_PREFIX}${z.model}`;
+    const key = slug.toLowerCase();
+    const existing = byKey.get(key);
+    if (existing !== undefined) {
+      // Present in both sources — keep OpenRouter pricing/caps, add z.ai docs.
+      byKey.set(key, { ...existing, isZaiCoding: true, docsUrl: z.docsUrl, source: 'both' });
+      continue;
+    }
+    if (!zaiPassesFilter(slug, zaiDisplayName(z.model), capability, searchLower)) {
+      continue;
+    }
+    byKey.set(key, {
+      id: slug,
+      name: zaiDisplayName(z.model),
+      contextLength: z.contextLength,
+      supportsVision: false,
+      supportsImageGeneration: false,
+      supportsAudioInput: false,
+      supportsAudioOutput: false,
+      promptPricePerMillion: 0,
+      completionPricePerMillion: 0,
+      isZaiCoding: true,
+      docsUrl: z.docsUrl,
+      source: 'zai-catalog',
+      hasPricing: false,
+    });
+  }
+
+  return [...byKey.values()];
+}
+
+/**
+ * Look up a single model by its exact slug, across both sources. Returns null
+ * when no model matches. Used by `/models view` and the browse-select card.
+ */
+export async function fetchCatalogModelById(id: string): Promise<CatalogModel | null> {
+  // The gateway `search` is a substring match over name/id, and the z.ai merge
+  // filters its catalog by the same term, so searching the exact slug surfaces
+  // the model from whichever source(s) it lives in. We then pin the exact id.
+  const candidates = await fetchModelCatalog({ search: id });
+  const target = id.toLowerCase();
+  return candidates.find(m => m.id.toLowerCase() === target) ?? null;
+}
+
+/**
+ * Annotate each model with the requesting user's usability, given the set of
+ * provider strings they have an ACTIVE key for. The required key follows the
+ * model's actual routing, keyed off `source` (NOT the `z-ai/` id prefix):
+ *
+ * - **free** (`:free`) — always usable on the system key.
+ * - **zai-catalog** (z.ai-only, e.g. `glm-5.2`) — only reachable via z.ai-direct,
+ *   so it needs a z.ai coding-plan key.
+ * - **both** (a coding-plan model that ALSO lives on OpenRouter, e.g. `z-ai/glm-5`)
+ *   — a z.ai key routes direct, an OpenRouter key routes via the OR fallthrough;
+ *   either unlocks it.
+ * - **openrouter** (everything else, including `z-ai/*` models NOT on the coding
+ *   plan, which only route via OpenRouter) — needs an OpenRouter key.
+ *
+ * The system OpenRouter key is assumed present (bot-client can't probe it), so a
+ * free model never reports "needs key".
+ */
+export function annotateUsability(
+  models: CatalogModel[],
+  activeProviders: ReadonlySet<string>
+): UsableCatalogModel[] {
+  const hasOpenRouter = activeProviders.has(AIProvider.OpenRouter);
+  const hasZai = activeProviders.has(AIProvider.ZaiCoding);
+
+  return models.map(model => {
+    if (isFreeModel(model.id)) {
+      return { ...model, usability: 'free', canUse: true };
+    }
+    if (model.source === 'zai-catalog') {
+      return { ...model, usability: hasZai ? 'usable' : 'needs-zai-key', canUse: hasZai };
+    }
+    if (model.source === 'both') {
+      // Reachable via either an OpenRouter key (OR fallthrough) or a z.ai key
+      // (direct), so when neither is present, name both paths — not just one.
+      const canUse = hasOpenRouter || hasZai;
+      return { ...model, usability: canUse ? 'usable' : 'needs-either-key', canUse };
+    }
+    return {
+      ...model,
+      usability: hasOpenRouter ? 'usable' : 'needs-openrouter-key',
+      canUse: hasOpenRouter,
+    };
+  });
+}
+
+/** Emoji per capability, in display order. */
+export const CAPABILITY_EMOJI = {
+  text: '💬',
+  vision: '👁️',
+  imageGen: '🎨',
+  audioIn: '🔊',
+  audioOut: '🗣️',
+} as const;
+
+/** Render a model's capabilities as an emoji+label string (text is implicit/always present). */
+export function formatCapabilities(model: ModelAutocompleteOption): string {
+  const parts = [`${CAPABILITY_EMOJI.text} text`];
+  if (model.supportsVision) {
+    parts.push(`${CAPABILITY_EMOJI.vision} vision`);
+  }
+  if (model.supportsImageGeneration) {
+    parts.push(`${CAPABILITY_EMOJI.imageGen} image-gen`);
+  }
+  if (model.supportsAudioInput) {
+    parts.push(`${CAPABILITY_EMOJI.audioIn} audio-in`);
+  }
+  if (model.supportsAudioOutput) {
+    parts.push(`${CAPABILITY_EMOJI.audioOut} audio-out`);
+  }
+  return parts.join('  ');
+}


### PR DESCRIPTION
## Summary

Adds `/models` — a browsable, searchable AI-model catalog with a per-model detail card. Closes the icebox `/models` feature; it's the capstone of the `commands:audit` thread (the audit was built to make a new command like this safe to add).

- **`/models browse [capability?] [search?]`** — paginated, user-aware list (usable-first), select a row → detail card.
- **`/models view <model>`** — autocomplete → detail card directly.

## User-aware

Each card/list entry shows whether the **requesting user** can actually run the model, computed client-side from their configured API-key providers — no new gateway endpoint:
- 🆓 free (`:free`) → always usable on the system key
- ✅ usable → user has the model's provider key
- 🔒 needs an OpenRouter / z.ai key

Composed from two existing endpoints: `userClient.listWalletKeys()` (providers only, no secrets) + the public `/models` list.

## z.ai merge

Unions the OpenRouter list with the static z.ai coding-plan catalog so z.ai-only models (e.g. `glm-5.2`, 1M context, absent from OpenRouter) are discoverable. A z.ai model present in **both** sources dedups to one entry (OpenRouter pricing/caps kept, z.ai docs link attached). z.ai-only entries show "z.ai coding plan — BYOK" instead of per-token pricing.

## Changes

| Area | What |
|------|------|
| `common-types` | Export `listZaiCodingPlanModels()` — the catalog was module-private; the merge needs to enumerate it. (+ test) |
| `bot-client` `utils/modelCatalog.ts` | fetch + merge + dedup + usability annotation + capability formatting (+ test) |
| `bot-client` `commands/models/` | `index` (router), `browse`, `view`, `card`, `autocomplete` (+ colocated tests) |
| `bot-client` `commands/help` | new **Models** `/help` category (the audit's category-coverage check enforces it) |
| `bot-client` `utils/modelAutocomplete.ts` | export `formatContextLength` for reuse |
| generated | `commandOptions.ts` + `command-manifest.json` + `CommandHandler.int` snapshot regenerated |

## Verification

- `commands:audit`: `models` present under **Models**, **0 errors**, no new warnings (browse/view canonical; descriptions non-stub)
- bot-client suite green (5005), common-types green (2778, incl. structure.test.ts), `pnpm quality` green (lint/knip/depcruise/cpd/codegen-drift/typecheck)
- `CommandHandler.int` snapshot updated (new command in routing)

## Follow-ups (backlogged)

- gateway `/api/user/models/availability` endpoint — only if client-side usability composition proves limiting (e.g. needs true guest-mode/system-key probing). v1 composes client-side from existing endpoints.
- richer card fields (tokenizer, max output tokens) — not exposed to bot-client today; would need the gateway `ModelAutocompleteOption` widened.
- browse currently fetches up to the gateway's 100-model cap (footer notes it; refine with search) — widen if it matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)