### PR TITLE
feat(bot-client): redesign /models card — spec-sheet layout (v2 part 1)

### DIFF
--- a/services/bot-client/src/commands/models/card.test.ts
+++ b/services/bot-client/src/commands/models/card.test.ts
@@ -27,22 +27,34 @@ function usable(overrides: Partial<UsableCatalogModel> & { id: string }): Usable
 }
 
 describe('buildModelCard', () => {
-  it('renders an OpenRouter model with slug, context, pricing, and OpenRouter link', () => {
+  it('renders an OpenRouter model: provider author, slug, short price, access, link', () => {
     const embed = buildModelCard(
       usable({ id: 'anthropic/claude-sonnet-4', name: 'Claude Sonnet 4' })
     );
     const json = embed.toJSON();
     expect(json.title).toBe('Claude Sonnet 4');
+    expect(json.author?.name).toBe('anthropic'); // from slug (no "Provider: " prefix in name)
+    expect(json.color).toBe(0x00ff00); // usable → green
     expect(json.description).toContain('`anthropic/claude-sonnet-4`');
-    expect(json.description).toContain('✅ You can use this');
+    expect(json.description).toContain('✅ **You can use this**');
     const fields = json.fields ?? [];
-    expect(fields.find(f => f.name === 'Context')?.value).toContain('200K');
-    expect(fields.find(f => f.name === 'Pricing')?.value).toContain('$3.00 in / $15.00 out');
+    expect(fields.find(f => f.name === 'Context')?.value).toBe('200K tokens');
+    expect(fields.find(f => f.name === 'Price')?.value).toBe('$3.00 / $15.00');
+    expect(fields.find(f => f.name === 'Access')?.value).toBe('Ready');
     expect(fields.find(f => f.name === 'Links')?.value).toContain('OpenRouter model page');
+    expect(json.footer?.text).toContain('per 1M tokens');
   });
 
-  it('renders a z.ai-only model with BYOK pricing, z.ai field, and docs link', () => {
-    const embed = buildModelCard(
+  it('splits a "Provider: Model" name into author + bare title', () => {
+    const json = buildModelCard(
+      usable({ id: 'ai21/jamba-large-1.7', name: 'AI21: Jamba Large 1.7' })
+    ).toJSON();
+    expect(json.author?.name).toBe('AI21');
+    expect(json.title).toBe('Jamba Large 1.7');
+  });
+
+  it('renders a z.ai-only model: z.ai-plan price, z.ai marker, docs link, orange (needs key)', () => {
+    const json = buildModelCard(
       usable({
         id: 'z-ai/glm-5.2',
         name: 'GLM-5.2',
@@ -54,58 +66,63 @@ describe('buildModelCard', () => {
         usability: 'needs-zai-key',
         canUse: false,
       })
-    );
-    const json = embed.toJSON();
+    ).toJSON();
     const fields = json.fields ?? [];
-    expect(fields.find(f => f.name === 'Context')?.value).toContain('1M');
-    expect(fields.find(f => f.name === 'Pricing')?.value).toContain('bring your own key');
-    expect(fields.some(f => f.name === 'z.ai coding plan')).toBe(true);
+    expect(json.color).toBe(0xffa500); // needs key → orange
+    expect(fields.find(f => f.name === 'Context')?.value).toBe('1M tokens');
+    expect(fields.find(f => f.name === 'Price')?.value).toBe('z.ai plan');
+    expect(fields.find(f => f.name === 'Access')?.value).toBe('z.ai key');
+    expect(json.description).toContain('⚡ z.ai coding-plan');
+    expect(json.description).toContain('🔑 **Needs a z.ai');
     expect(fields.find(f => f.name === 'Links')?.value).toContain('z.ai docs');
     expect(fields.find(f => f.name === 'Links')?.value).not.toContain('OpenRouter');
-    expect(json.description).toContain('🔒 Needs a z.ai');
+    expect(json.footer?.text).toBe('via z.ai coding plan');
   });
 
-  it('renders "Variable" pricing for a negative-priced auto-router', () => {
-    const embed = buildModelCard(
-      usable({
-        id: 'openrouter/auto',
-        name: 'Auto Router',
-        promptPricePerMillion: -1_000_000,
-        completionPricePerMillion: -1_000_000,
-        hasPricing: false,
-        source: 'openrouter',
-        usability: 'needs-openrouter-key',
-        canUse: false,
-      })
-    );
-    const fields = embed.toJSON().fields ?? [];
-    expect(fields.find(f => f.name === 'Pricing')?.value).toContain('Variable');
-    expect(fields.find(f => f.name === 'Pricing')?.value).not.toContain('-');
+  it('renders "Variable" price (not a negative number) for an auto-router', () => {
+    const fields =
+      buildModelCard(
+        usable({
+          id: 'openrouter/auto',
+          name: 'Auto Router',
+          promptPricePerMillion: -1_000_000,
+          completionPricePerMillion: -1_000_000,
+          hasPricing: false,
+          source: 'openrouter',
+          usability: 'needs-openrouter-key',
+          canUse: false,
+        })
+      ).toJSON().fields ?? [];
+    expect(fields.find(f => f.name === 'Price')?.value).toBe('Variable');
   });
 
   it('names both key paths for a both-source model with no keys', () => {
-    const embed = buildModelCard(
+    const json = buildModelCard(
       usable({
         id: 'z-ai/glm-5',
-        name: 'GLM-5',
+        name: 'Z.ai: GLM 5',
         isZaiCoding: true,
         source: 'both',
         usability: 'needs-either-key',
         canUse: false,
       })
-    );
-    expect(embed.toJSON().description).toContain('OpenRouter or z.ai');
+    ).toJSON();
+    expect(json.description).toContain('OpenRouter or z.ai');
+    expect(json.color).toBe(0xffa500); // can't use (no keys) → orange
+    // 'both' source → still routes via OpenRouter, so the title links there
+    expect(json.footer?.text).toContain('via OpenRouter');
   });
 
   it('shows the free usability line for free models', () => {
-    const embed = buildModelCard(
-      usable({ id: 'google/gemma:free', usability: 'free', canUse: true })
-    );
-    expect(embed.toJSON().description).toContain('🆓 Free');
+    expect(
+      buildModelCard(usable({ id: 'google/gemma:free', usability: 'free', canUse: true })).toJSON()
+        .description
+    ).toContain('🆓 **Free**');
   });
 
   it('renders capability emojis for a vision model', () => {
-    const embed = buildModelCard(usable({ id: 'x/vision', supportsVision: true }));
-    expect(embed.toJSON().description).toContain('👁️ vision');
+    expect(
+      buildModelCard(usable({ id: 'x/vision', supportsVision: true })).toJSON().description
+    ).toContain('👁️ vision');
   });
 });

--- a/services/bot-client/src/commands/models/card.ts
+++ b/services/bot-client/src/commands/models/card.ts
@@ -4,6 +4,11 @@
  * Builds the detail embed for a single model, shown by `/models view` and by
  * selecting an item in `/models browse`. Pure (no I/O) so it's directly
  * unit-testable.
+ *
+ * Layout: a usability-coded color bar (green = can run, orange = key needed),
+ * a provider author line, a hyperlinked title, a compact slug + capabilities +
+ * status description, and a single short inline field row (Context · Price ·
+ * Access). No thumbnail — pure text/emoji, so there are no image assets to host.
  */
 
 import { EmbedBuilder } from 'discord.js';
@@ -15,51 +20,90 @@ import {
   type UsableCatalogModel,
 } from '../../utils/modelCatalog.js';
 
-/** One-line usability summary keyed by status. */
+/** Bold, emoji-prefixed status line for the description. */
 const USABILITY_LINE: Record<ModelUsability, string> = {
-  free: '🆓 Free — available to everyone',
-  usable: '✅ You can use this',
-  'needs-openrouter-key': '🔒 Needs an OpenRouter key — add one with `/settings apikey set`',
-  'needs-zai-key': '🔒 Needs a z.ai coding-plan key — add one with `/settings apikey set`',
+  free: '🆓 **Free** — available to everyone',
+  usable: '✅ **You can use this**',
+  'needs-openrouter-key': '🔑 **Needs an OpenRouter key** — add one with `/settings apikey set`',
+  'needs-zai-key': '🔑 **Needs a z.ai coding-plan key** — add one with `/settings apikey set`',
   'needs-either-key':
-    '🔒 Needs an OpenRouter or z.ai coding-plan key — add one with `/settings apikey set`',
+    '🔑 **Needs an OpenRouter or z.ai key** — add one with `/settings apikey set`',
 };
 
-/** Format the pricing field, or the BYOK note when no per-token figures exist. */
-function formatPricing(model: UsableCatalogModel): string {
-  if (!model.hasPricing) {
-    // z.ai-only catalog entries have no $ figures; OpenRouter meta/auto-routers
-    // have negative pricing because the cost depends on the routed model.
-    return model.source === 'zai-catalog'
-      ? 'z.ai coding plan — bring your own key'
-      : 'Variable — depends on the routed model';
-  }
-  const inPrice = model.promptPricePerMillion.toFixed(2);
-  const outPrice = model.completionPricePerMillion.toFixed(2);
-  return `$${inPrice} in / $${outPrice} out (per 1M tokens)`;
+/** Short one-word(ish) access category for the inline field. */
+const ACCESS_LABEL: Record<ModelUsability, string> = {
+  free: 'Free',
+  usable: 'Ready',
+  'needs-openrouter-key': 'OpenRouter key',
+  'needs-zai-key': 'z.ai key',
+  'needs-either-key': 'OpenRouter / z.ai',
+};
+
+/** A z.ai-only model (z.ai catalog, not on OpenRouter) — no $ pricing, no OR page. */
+function isZaiOnly(model: UsableCatalogModel): boolean {
+  return model.source === 'zai-catalog';
 }
 
-/** Build the markdown links line (z.ai docs and/or OpenRouter model page). */
+/** Split the OpenRouter "Provider: Model" name into a provider + bare title. */
+function splitName(model: UsableCatalogModel): { provider: string; title: string } {
+  const sep = model.name.indexOf(': ');
+  if (sep > 0) {
+    return { provider: model.name.slice(0, sep), title: model.name.slice(sep + 2) };
+  }
+  return { provider: model.id.split('/')[0], title: model.name };
+}
+
+/**
+ * Where the title links: OpenRouter page, or the z.ai docs for z.ai-only models.
+ * Every ZAI_MODEL_CATALOG entry has a docsUrl today, so the `?? undefined`
+ * fallback (title renders unlinked) only fires if a future catalog entry omits it.
+ */
+function titleUrl(model: UsableCatalogModel): string | undefined {
+  if (isZaiOnly(model)) {
+    return model.docsUrl ?? undefined;
+  }
+  return buildModelInfoUrl(model.id, AIProvider.OpenRouter);
+}
+
+/** Short pricing value for the inline field (unit is clarified in the footer). */
+function formatPriceShort(model: UsableCatalogModel): string {
+  if (!model.hasPricing) {
+    return isZaiOnly(model) ? 'z.ai plan' : 'Variable';
+  }
+  return `$${model.promptPricePerMillion.toFixed(2)} / $${model.completionPricePerMillion.toFixed(2)}`;
+}
+
+/** Capability emoji line, with a z.ai-coding marker appended when applicable. */
+function capabilityLine(model: UsableCatalogModel): string {
+  const caps = formatCapabilities(model);
+  return model.isZaiCoding ? `${caps}  ·  ⚡ z.ai coding-plan` : caps;
+}
+
+/** Masked-markdown links (z.ai docs and/or the OpenRouter model page). */
 function formatLinks(model: UsableCatalogModel): string | null {
   const links: string[] = [];
   if (model.docsUrl !== null) {
     links.push(`[z.ai docs](${model.docsUrl})`);
   }
-  if (model.source !== 'zai-catalog') {
+  if (!isZaiOnly(model)) {
     links.push(`[OpenRouter model page](${buildModelInfoUrl(model.id, AIProvider.OpenRouter)})`);
   }
-  return links.length > 0 ? links.join(' • ') : null;
+  return links.length > 0 ? links.join('  ·  ') : null;
 }
 
 /**
  * Build the model detail card.
  */
 export function buildModelCard(model: UsableCatalogModel): EmbedBuilder {
+  const { provider, title } = splitName(model);
+  const source = isZaiOnly(model) ? 'z.ai coding plan' : 'OpenRouter';
+
   const embed = new EmbedBuilder()
-    .setTitle(model.name)
-    .setColor(model.canUse ? DISCORD_COLORS.SUCCESS : DISCORD_COLORS.BLURPLE)
+    .setColor(model.canUse ? DISCORD_COLORS.SUCCESS : DISCORD_COLORS.WARNING)
+    .setAuthor({ name: provider })
+    .setTitle(title)
     .setDescription(
-      [`\`${model.id}\``, '', formatCapabilities(model), USABILITY_LINE[model.usability]].join('\n')
+      [`\`${model.id}\``, capabilityLine(model), USABILITY_LINE[model.usability]].join('\n')
     )
     .addFields(
       {
@@ -67,21 +111,23 @@ export function buildModelCard(model: UsableCatalogModel): EmbedBuilder {
         value: `${formatContextLength(model.contextLength)} tokens`,
         inline: true,
       },
-      { name: 'Pricing', value: formatPricing(model), inline: true }
+      { name: 'Price', value: formatPriceShort(model), inline: true },
+      { name: 'Access', value: ACCESS_LABEL[model.usability], inline: true }
     );
 
-  if (model.isZaiCoding) {
-    embed.addFields({
-      name: 'z.ai coding plan',
-      value: '⚡ Available on the z.ai GLM coding plan',
-      inline: false,
-    });
+  const url = titleUrl(model);
+  if (url !== undefined) {
+    embed.setURL(url);
   }
 
   const links = formatLinks(model);
   if (links !== null) {
     embed.addFields({ name: 'Links', value: links, inline: false });
   }
+
+  embed.setFooter({
+    text: model.hasPricing ? `via ${source} · prices: in / out per 1M tokens` : `via ${source}`,
+  });
 
   return embed;
 }


### PR DESCRIPTION
## Summary

Redesigns the `/models` detail card. You flagged the v1 card as "not terribly visually appealing"; this is the council-reviewed redesign (GLM 5.1 / Kimi K2.6 / Qwen 3.7 Max), consensus **"spec sheet"** with **no thumbnail** (Qwen's call — pure text/emoji, zero image assets to host).

Part 1 of `/models` v2 (card-only, self-contained). Sort modes + global-presets-first follow in separate PRs.

## What changed

| | Before | After |
|---|---|---|
| Color bar | green / blurple | **usability traffic light** — 🟢 green = you can run it, 🟠 orange = a key is needed |
| Author | — | provider (from `Provider: Model` name, or slug) |
| Title | `Provider: Model` (plain) | bare model name, **hyperlinked** (OpenRouter page; z.ai docs for z.ai-only) |
| Description | slug + caps + status | slug (copy-paste) + capability emoji line (+ `⚡ z.ai` marker) + **bold** status |
| Fields | Context, Pricing (long), z.ai block, Links block | **Context · Price · Access** (short inline, mobile-safe) + Links |
| Pricing | `$3.00 in / $15.00 out (per 1M tokens)` | `$3.00 / $15.00` (unit moved to footer) |
| Footer | — | `via {OpenRouter\|z.ai coding plan} · prices: in / out per 1M tokens` |

All three reviewers flagged **mobile inline-field wrapping** as the main risk; mitigated by keeping field values short (`256K`, `$3 / $15`, `Ready`).

## Verification

- bot-client suite green (5010); card/browse/view tests updated for the new layout. `pnpm quality` exit 0.
- No command-structure/manifest change (card-only) — no codegen needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)