### PR TITLE
feat(bot-client): /models v2 part 3 — global-preset-first + 🔀 router badge

### DIFF
--- a/packages/common-types/src/schemas/api/models.ts
+++ b/packages/common-types/src/schemas/api/models.ts
@@ -34,6 +34,8 @@ export const ModelAutocompleteOptionSchema = z.object({
   completionPricePerMillion: z.number(),
   /** Release time (Unix seconds); absent for z.ai-catalog-only models. */
   created: z.number().optional(),
+  /** True for OpenRouter meta-routers. Optional to tolerate cache entries written before this field existed. */
+  isRouter: z.boolean().optional(),
 });
 
 /** Response shape for `GET /api/internal/models`. */

--- a/packages/common-types/src/types/ai.ts
+++ b/packages/common-types/src/types/ai.ts
@@ -60,8 +60,12 @@ export interface OpenRouterModelPricing {
  * OpenRouter model top provider information
  */
 export interface OpenRouterModelTopProvider {
-  /** Maximum context length for this provider */
-  context_length: number;
+  /**
+   * Maximum context length for this provider. `null` for meta-routers
+   * (e.g. `openrouter/auto`), whose effective context depends on the
+   * model the request is routed to.
+   */
+  context_length: number | null;
   /** Maximum completion tokens */
   max_completion_tokens: number;
   /** Whether the model is moderated */
@@ -135,4 +139,12 @@ export interface ModelAutocompleteOption {
    * Used to sort the `/models` browser by recency.
    */
   created?: number;
+  /**
+   * True for OpenRouter meta-routers (e.g. `openrouter/auto`, `fusion`) —
+   * detected via `top_provider.context_length === null`. Their cost and
+   * context depend on the model a request is routed to, so the `/models`
+   * browser flags them with a 🔀 badge. Optional/absent for z.ai-catalog-only
+   * models, which are never routers.
+   */
+  isRouter?: boolean;
 }

--- a/services/api-gateway/src/services/OpenRouterModelCache.test.ts
+++ b/services/api-gateway/src/services/OpenRouterModelCache.test.ts
@@ -124,6 +124,41 @@ const sampleImageGenModel: OpenRouterModel = {
   default_parameters: {},
 };
 
+// Meta-router: reports a null top-provider context length (cost/context depend
+// on what it routes to). Drives the `isRouter` flag.
+const sampleRouterModel: OpenRouterModel = {
+  id: 'openrouter/auto',
+  canonical_slug: 'openrouter/auto',
+  hugging_face_id: null,
+  name: 'Auto Router',
+  created: 1700000000,
+  description: 'Routes to the best available model',
+  context_length: 2000000,
+  architecture: {
+    modality: 'text->text',
+    input_modalities: ['text'],
+    output_modalities: ['text'],
+    tokenizer: 'router',
+    instruct_type: null,
+  },
+  pricing: {
+    prompt: '-1',
+    completion: '-1',
+    request: '0',
+    image: '0',
+    web_search: '0',
+    internal_reasoning: '0',
+  },
+  top_provider: {
+    context_length: null,
+    max_completion_tokens: 0,
+    is_moderated: false,
+  },
+  per_request_limits: null,
+  supported_parameters: [],
+  default_parameters: {},
+};
+
 const sampleModels = [sampleTextModel, sampleVisionModel, sampleImageGenModel];
 
 // Create mock Redis
@@ -309,6 +344,7 @@ describe('OpenRouterModelCache', () => {
         promptPricePerMillion: 3,
         completionPricePerMillion: 15,
         created: 1700000000,
+        isRouter: false,
       });
     });
 
@@ -316,6 +352,16 @@ describe('OpenRouterModelCache', () => {
       const results = await cache.getFilteredModels({ search: 'gpt-4o' });
 
       expect(results[0].supportsVision).toBe(true);
+    });
+
+    it('flags meta-routers (null top-provider context length) as isRouter', async () => {
+      (mockRedis.get as ReturnType<typeof vi.fn>).mockResolvedValue(
+        JSON.stringify([sampleRouterModel, sampleTextModel])
+      );
+      const router = await cache.getModelById('openrouter/auto');
+      const concrete = await cache.getModelById('anthropic/claude-sonnet-4');
+      expect(router?.isRouter).toBe(true);
+      expect(concrete?.isRouter).toBe(false);
     });
 
     it('should correctly identify image generation support', async () => {

--- a/services/api-gateway/src/services/OpenRouterModelCache.ts
+++ b/services/api-gateway/src/services/OpenRouterModelCache.ts
@@ -259,6 +259,9 @@ export class OpenRouterModelCache {
       promptPricePerMillion: isNaN(promptPrice) ? 0 : promptPrice,
       completionPricePerMillion: isNaN(completionPrice) ? 0 : completionPrice,
       created: model.created,
+      // Meta-routers (openrouter/auto, fusion, …) report a null top-provider
+      // context length — their effective context depends on what they route to.
+      isRouter: model.top_provider.context_length === null,
     };
   }
 }

--- a/services/bot-client/src/commands/models/browse.test.ts
+++ b/services/bot-client/src/commands/models/browse.test.ts
@@ -11,8 +11,8 @@ import type {
 import type { UserClient } from '@tzurot/clients';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import type { CatalogModel } from '../../utils/modelCatalog.js';
-import { makeOk } from '../../test/gatewayClientStubs.js';
-import { mockListWalletKeysResponse } from '@tzurot/test-factories';
+import { makeOk, makeErr } from '../../test/gatewayClientStubs.js';
+import { mockListWalletKeysResponse, mockListLlmConfigsResponse } from '@tzurot/test-factories';
 
 vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal<typeof import('@tzurot/common-types')>();
@@ -39,7 +39,7 @@ vi.mock('../../utils/modelCatalog.js', async importOriginal => {
   };
 });
 
-const walletStub = { listWalletKeys: vi.fn() };
+const walletStub = { listWalletKeys: vi.fn(), listUserLlmConfigs: vi.fn() };
 vi.mock('../../utils/gatewayClients.js', () => ({
   clientsFor: vi.fn(() => ({ userClient: walletStub as unknown as UserClient })),
 }));
@@ -74,6 +74,7 @@ function catalogModel(overrides: Partial<CatalogModel> & { id: string }): Catalo
 beforeEach(() => {
   vi.clearAllMocks();
   walletStub.listWalletKeys.mockResolvedValue(makeOk(mockListWalletKeysResponse([])));
+  walletStub.listUserLlmConfigs.mockResolvedValue(makeOk(mockListLlmConfigsResponse([])));
 });
 
 describe('customId predicates', () => {
@@ -253,6 +254,125 @@ describe('sort modes', () => {
     } as unknown as ButtonInteraction;
     await handleBrowsePagination(interaction);
     expect(deferUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe('global-preset pinning + router badge', () => {
+  function renderViaPagination(customId: string): Promise<string> {
+    const editReply = vi.fn();
+    const interaction = {
+      customId,
+      user: { id: 'u1' },
+      deferUpdate: vi.fn(),
+      editReply,
+    } as unknown as ButtonInteraction;
+    return handleBrowsePagination(interaction).then(() => {
+      const call = editReply.mock.calls[0][0] as { embeds: { data: { description: string } }[] };
+      return call.embeds[0].data.description;
+    });
+  }
+
+  it('pins global-preset models to the top with a 📌 marker, overriding sort', async () => {
+    // 'zzz/pinned' would sort LAST alphabetically, but being a global preset
+    // pins it ahead of 'aaa/model'.
+    walletStub.listUserLlmConfigs.mockResolvedValue(
+      makeOk(mockListLlmConfigsResponse([{ model: 'zzz/pinned', isGlobal: true }]))
+    );
+    catalogMock.fetchModelCatalog.mockResolvedValue([
+      catalogModel({ id: 'aaa/model', name: 'Aaa' }),
+      catalogModel({ id: 'zzz/pinned', name: 'Zzz Pinned' }),
+    ]);
+    const description = await renderViaPagination('models::browse::0::all::default::');
+    expect(description.indexOf('zzz/pinned')).toBeLessThan(description.indexOf('aaa/model'));
+    // The pinned model's line carries the 📌 badge.
+    const pinnedLine = description.split('\n').find(l => l.includes('Zzz Pinned'));
+    expect(pinnedLine).toContain('📌');
+  });
+
+  it('only pins GLOBAL presets, not user-owned ones', async () => {
+    walletStub.listUserLlmConfigs.mockResolvedValue(
+      makeOk(mockListLlmConfigsResponse([{ model: 'owned/model', isGlobal: false }]))
+    );
+    catalogMock.fetchModelCatalog.mockResolvedValue([
+      catalogModel({ id: 'aaa/model', name: 'Aaa' }),
+      catalogModel({ id: 'owned/model', name: 'Owned' }),
+    ]);
+    const description = await renderViaPagination('models::browse::0::all::default::');
+    // No global preset → alphabetical, owned model not pinned.
+    expect(description.indexOf('aaa/model')).toBeLessThan(description.indexOf('owned/model'));
+    expect(description.split('\n').find(l => l.includes('Owned'))).not.toContain('📌');
+  });
+
+  it('applies the active sort within both the pinned and non-pinned tiers', async () => {
+    walletStub.listUserLlmConfigs.mockResolvedValue(
+      makeOk(
+        mockListLlmConfigsResponse([
+          { model: 'p/cheap', isGlobal: true },
+          { model: 'p/exp', isGlobal: true },
+        ])
+      )
+    );
+    catalogMock.fetchModelCatalog.mockResolvedValue([
+      catalogModel({ id: 'p/exp', name: 'PinnedExpensive', promptPricePerMillion: 100 }),
+      catalogModel({ id: 'u/cheap', name: 'UnpinnedCheap', promptPricePerMillion: 2 }),
+      catalogModel({ id: 'p/cheap', name: 'PinnedCheap', promptPricePerMillion: 1 }),
+      catalogModel({ id: 'u/exp', name: 'UnpinnedExpensive', promptPricePerMillion: 200 }),
+    ]);
+    const d = await renderViaPagination('models::browse::0::all::price::');
+    // Pinned tier (price-sorted) entirely precedes the rest (price-sorted).
+    expect(d.indexOf('p/cheap')).toBeLessThan(d.indexOf('p/exp'));
+    expect(d.indexOf('p/exp')).toBeLessThan(d.indexOf('u/cheap'));
+    expect(d.indexOf('u/cheap')).toBeLessThan(d.indexOf('u/exp'));
+  });
+
+  it('applies the recent sort within both tiers (pinned newest-first, then rest)', async () => {
+    walletStub.listUserLlmConfigs.mockResolvedValue(
+      makeOk(
+        mockListLlmConfigsResponse([
+          { model: 'p/new', isGlobal: true },
+          { model: 'p/old', isGlobal: true },
+        ])
+      )
+    );
+    catalogMock.fetchModelCatalog.mockResolvedValue([
+      catalogModel({ id: 'p/old', name: 'PinnedOld', created: 1_000 }),
+      catalogModel({ id: 'u/new', name: 'UnpinnedNew', created: 8_000 }),
+      catalogModel({ id: 'p/new', name: 'PinnedNew', created: 9_000 }),
+      catalogModel({ id: 'u/old', name: 'UnpinnedOld', created: 500 }),
+    ]);
+    const d = await renderViaPagination('models::browse::0::all::recent::');
+    // Pinned tier (newest-first) entirely precedes the rest (newest-first).
+    expect(d.indexOf('p/new')).toBeLessThan(d.indexOf('p/old'));
+    expect(d.indexOf('p/old')).toBeLessThan(d.indexOf('u/new'));
+    expect(d.indexOf('u/new')).toBeLessThan(d.indexOf('u/old'));
+  });
+
+  it('renders the 🔀 badge for meta-routers', async () => {
+    catalogMock.fetchModelCatalog.mockResolvedValue([
+      catalogModel({ id: 'openrouter/auto', name: 'Auto Router', isRouter: true }),
+    ]);
+    const description = await renderViaPagination('models::browse::0::all::default::');
+    expect(description).toContain('🔀');
+  });
+
+  it('orders badges pin-before-router for a pinned meta-router (📌 🔀)', async () => {
+    walletStub.listUserLlmConfigs.mockResolvedValue(
+      makeOk(mockListLlmConfigsResponse([{ model: 'openrouter/auto', isGlobal: true }]))
+    );
+    catalogMock.fetchModelCatalog.mockResolvedValue([
+      catalogModel({ id: 'openrouter/auto', name: 'Auto Router', isRouter: true }),
+    ]);
+    const description = await renderViaPagination('models::browse::0::all::default::');
+    expect(description).toContain('📌 🔀');
+  });
+
+  it('degrades gracefully (no pinning) when the preset fetch fails', async () => {
+    // Exercises the `configsResult.ok ? … : []` fallback — the list still renders.
+    walletStub.listUserLlmConfigs.mockResolvedValue(makeErr(500, 'Server error'));
+    catalogMock.fetchModelCatalog.mockResolvedValue([catalogModel({ id: 'a/model', name: 'A' })]);
+    const description = await renderViaPagination('models::browse::0::all::default::');
+    expect(description).toContain('a/model');
+    expect(description).not.toContain('📌');
   });
 });
 

--- a/services/bot-client/src/commands/models/browse.ts
+++ b/services/bot-client/src/commands/models/browse.ts
@@ -82,25 +82,44 @@ export function isModelsBrowseSelectInteraction(customId: string): boolean {
   return browseHelpers.isBrowseSelect(customId);
 }
 
+/**
+ * A catalog model annotated for the browse list. `isGlobalPreset` flags models
+ * used by one of Tzurot's global presets — these pin to the top of every sort.
+ */
+type BrowseModel = UsableCatalogModel & { isGlobalPreset: boolean };
+
 /** Price rank for the `price` sort: free/cheapest first, no-$ (z.ai/router) last. */
 function priceRank(model: UsableCatalogModel): number {
   return model.hasPricing ? model.promptPricePerMillion : Number.POSITIVE_INFINITY;
 }
 
 /** Sort the annotated models by the active sort mode (stable, name tie-break). */
-function sortModels(models: UsableCatalogModel[], sort: ModelSort): UsableCatalogModel[] {
-  const byName = (a: UsableCatalogModel, b: UsableCatalogModel): number =>
-    a.name.localeCompare(b.name);
+function sortModels<T extends UsableCatalogModel>(models: T[], sort: ModelSort): T[] {
+  const byName = (a: T, b: T): number => a.name.localeCompare(b.name);
   if (sort === 'price') {
     return [...models].sort((a, b) => priceRank(a) - priceRank(b) || byName(a, b));
   }
   if (sort === 'recent') {
     // Newest first; models without a `created` timestamp (z.ai-catalog-only) last.
-    const at = (m: UsableCatalogModel): number => m.created ?? Number.NEGATIVE_INFINITY;
+    const at = (m: T): number => m.created ?? Number.NEGATIVE_INFINITY;
     return [...models].sort((a, b) => at(b) - at(a) || byName(a, b));
   }
   // default: usable-first, then alphabetical.
   return [...models].sort((a, b) => (a.canUse === b.canUse ? byName(a, b) : a.canUse ? -1 : 1));
+}
+
+/**
+ * Two-tier sort: global-preset models first, the rest after — with the active
+ * sort applied independently WITHIN each tier (per product spec). With no
+ * pinned models this collapses to a plain `sortModels`.
+ */
+function sortModelsPinned(models: BrowseModel[], sort: ModelSort): BrowseModel[] {
+  const pinned: BrowseModel[] = [];
+  const rest: BrowseModel[] = [];
+  for (const m of models) {
+    (m.isGlobalPreset ? pinned : rest).push(m);
+  }
+  return [...sortModels(pinned, sort), ...sortModels(rest, sort)];
 }
 
 /** Per-model usability marker for the list/select. */
@@ -112,20 +131,25 @@ function usabilityIcon(model: UsableCatalogModel): string {
 }
 
 /** A single description line for a model in the browse list. */
-function formatModelLine(model: UsableCatalogModel, displayIndex: number): string {
-  const zai = model.isZaiCoding ? ' ⚡' : '';
-  const caps = [model.supportsVision ? '👁️' : '', model.supportsImageGeneration ? '🎨' : '']
+function formatModelLine(model: BrowseModel, displayIndex: number): string {
+  const badges = [
+    model.isGlobalPreset ? '📌' : '',
+    model.isRouter === true ? '🔀' : '',
+    model.isZaiCoding ? '⚡' : '',
+    model.supportsVision ? '👁️' : '',
+    model.supportsImageGeneration ? '🎨' : '',
+  ]
     .filter(Boolean)
-    .join('');
-  const capsSuffix = caps.length > 0 ? ` ${caps}` : '';
+    .join(' ');
+  const badgeSuffix = badges.length > 0 ? ` ${badges}` : '';
   return (
-    `**${displayIndex}.** ${usabilityIcon(model)} ${model.name}${zai}${capsSuffix}\n` +
+    `**${displayIndex}.** ${usabilityIcon(model)} ${model.name}${badgeSuffix}\n` +
     `   └ \`${model.id}\` • ${formatContextLength(model.contextLength)}`
   );
 }
 
 interface BrowseView {
-  items: UsableCatalogModel[];
+  items: BrowseModel[];
   page: number;
   capability: CapabilityFilter;
   sort: ModelSort;
@@ -140,7 +164,7 @@ const ACTIVE_SORT_LABEL: Record<ModelSort, string> = {
   recent: 'newest first',
 };
 
-function buildBrowseEmbed(view: BrowseView, pageItems: UsableCatalogModel[]): EmbedBuilder {
+function buildBrowseEmbed(view: BrowseView, pageItems: BrowseModel[]): EmbedBuilder {
   const { items, page, capability, sort, search, capped } = view;
   const startIdx = page * MODELS_PER_PAGE;
 
@@ -167,7 +191,7 @@ function buildBrowseEmbed(view: BrowseView, pageItems: UsableCatalogModel[]): Em
     text: joinFooter(
       pluralize(items.length, { singular: 'model', plural: 'models' }),
       capped && `first ${BROWSE_FETCH_LIMIT} — refine with search for more`,
-      '🆓 free  ✅ you can use  🔒 needs a key  ⚡ z.ai'
+      '🆓 free  ✅ you can use  🔒 needs a key  📌 global preset  🔀 router  ⚡ z.ai'
     ),
   });
   return embed;
@@ -175,14 +199,14 @@ function buildBrowseEmbed(view: BrowseView, pageItems: UsableCatalogModel[]): Em
 
 function buildBrowseComponents(
   view: BrowseView,
-  pageItems: UsableCatalogModel[],
+  pageItems: BrowseModel[],
   totalPages: number
 ): BrowseActionRow[] {
   const { page, capability, sort, search } = view;
   const startIdx = page * MODELS_PER_PAGE;
   const components: BrowseActionRow[] = [];
 
-  const selectRow = buildBrowseSelectMenu<UsableCatalogModel>({
+  const selectRow = buildBrowseSelectMenu<BrowseModel>({
     items: pageItems,
     customId: browseHelpers.buildSelect(page, capability, sort, search),
     placeholder: 'Select a model to view its card...',
@@ -226,22 +250,38 @@ function buildBrowsePage(view: BrowseView): { embed: EmbedBuilder; components: B
   };
 }
 
-/** Fetch the merged catalog + the user's active key providers, then annotate + sort. */
+/**
+ * Fetch the merged catalog + the user's active key providers + the global
+ * presets, then annotate usability, flag global-preset models, and apply the
+ * pinned two-tier sort. All three gateway reads run concurrently; the wallet
+ * and preset reads degrade to empty on failure (no usability/pin info rather
+ * than a failed browse).
+ */
 async function loadAnnotatedModels(
   interaction: ClientCarryingInteraction,
   capability: CapabilityFilter,
   search: string | null,
   sort: ModelSort
-): Promise<UsableCatalogModel[]> {
+): Promise<BrowseModel[]> {
   const { userClient } = clientsFor(interaction);
-  const [catalog, walletResult] = await Promise.all([
+  const [catalog, walletResult, configsResult] = await Promise.all([
     fetchModelCatalog({ capability, search: search ?? undefined, limit: BROWSE_FETCH_LIMIT }),
     userClient.listWalletKeys(),
+    userClient.listUserLlmConfigs(),
   ]);
   const activeProviders = new Set(
     walletResult.ok ? walletResult.data.keys.filter(k => k.isActive).map(k => k.provider) : []
   );
-  return sortModels(annotateUsability(catalog, activeProviders), sort);
+  const globalPresetModelIds = new Set(
+    configsResult.ok
+      ? configsResult.data.configs.filter(c => c.isGlobal).map(c => c.model.toLowerCase())
+      : []
+  );
+  const annotated = annotateUsability(catalog, activeProviders).map<BrowseModel>(m => ({
+    ...m,
+    isGlobalPreset: globalPresetModelIds.has(m.id.toLowerCase()),
+  }));
+  return sortModelsPinned(annotated, sort);
 }
 
 /**

--- a/services/bot-client/src/commands/models/card.test.ts
+++ b/services/bot-client/src/commands/models/card.test.ts
@@ -109,8 +109,23 @@ describe('buildModelCard', () => {
     ).toJSON();
     expect(json.description).toContain('OpenRouter or z.ai');
     expect(json.color).toBe(0xffa500); // can't use (no keys) → orange
-    // 'both' source → still routes via OpenRouter, so the title links there
-    expect(json.footer?.text).toContain('via OpenRouter');
+    // 'both' source routes via OpenRouter (shown pricing) OR a z.ai key — the
+    // footer names both so a z.ai-key-only viewer isn't misled.
+    expect(json.footer?.text).toContain('via OpenRouter (also z.ai coding-plan)');
+  });
+
+  it('renders the meta-router marker in the capability line', () => {
+    const json = buildModelCard(
+      usable({
+        id: 'openrouter/auto',
+        name: 'Auto Router',
+        isRouter: true,
+        hasPricing: false,
+        usability: 'needs-openrouter-key',
+        canUse: false,
+      })
+    ).toJSON();
+    expect(json.description).toContain('🔀 meta-router');
   });
 
   it('shows the free usability line for free models', () => {

--- a/services/bot-client/src/commands/models/card.ts
+++ b/services/bot-client/src/commands/models/card.ts
@@ -76,10 +76,16 @@ function formatPriceShort(model: UsableCatalogModel): string {
   return `$${model.promptPricePerMillion.toFixed(2)} / $${model.completionPricePerMillion.toFixed(2)}`;
 }
 
-/** Capability emoji line, with a z.ai-coding marker appended when applicable. */
+/** Capability emoji line, with meta-router and z.ai-coding markers appended when applicable. */
 function capabilityLine(model: UsableCatalogModel): string {
-  const caps = formatCapabilities(model);
-  return model.isZaiCoding ? `${caps}${SEP}⚡ z.ai coding-plan` : caps;
+  const parts = [formatCapabilities(model)];
+  if (model.isRouter === true) {
+    parts.push('🔀 meta-router');
+  }
+  if (model.isZaiCoding) {
+    parts.push('⚡ z.ai coding-plan');
+  }
+  return parts.join(SEP);
 }
 
 /** Masked-markdown links (z.ai docs and/or the OpenRouter model page). */
@@ -99,7 +105,14 @@ function formatLinks(model: UsableCatalogModel): string | null {
  */
 export function buildModelCard(model: UsableCatalogModel): EmbedBuilder {
   const { provider, title } = splitName(model);
-  const source = isZaiOnly(model) ? 'z.ai coding plan' : 'OpenRouter';
+  // `both`-source models route via either OpenRouter (the shown pricing) or a
+  // z.ai coding-plan key, so name both — footering "via OpenRouter" alone
+  // misleads a z.ai-key-only viewer.
+  const source = isZaiOnly(model)
+    ? 'z.ai coding plan'
+    : model.source === 'both'
+      ? 'OpenRouter (also z.ai coding-plan)'
+      : 'OpenRouter';
 
   const embed = new EmbedBuilder()
     .setColor(model.canUse ? DISCORD_COLORS.SUCCESS : DISCORD_COLORS.WARNING)

--- a/services/bot-client/src/utils/modelCatalog.test.ts
+++ b/services/bot-client/src/utils/modelCatalog.test.ts
@@ -58,6 +58,18 @@ describe('fetchModelCatalog', () => {
     expect(glm52?.docsUrl).toMatch(/docs\.z\.ai/);
     // Display name title-cases each dash segment, keeping GLM fully uppercase.
     expect(glm52?.name).toBe('GLM-5.2');
+    // z.ai-catalog-only entries are never meta-routers.
+    expect(glm52?.isRouter).toBe(false);
+  });
+
+  it('passes the OpenRouter isRouter flag through to the catalog entry', async () => {
+    fetchModelsMock.mockResolvedValue([
+      model({ id: 'openrouter/auto', name: 'Auto Router', isRouter: true }),
+      model({ id: 'openai/gpt-5', isRouter: false }),
+    ]);
+    const catalog = await fetchModelCatalog();
+    expect(catalog.find(m => m.id === 'openrouter/auto')?.isRouter).toBe(true);
+    expect(catalog.find(m => m.id === 'openai/gpt-5')?.isRouter).toBe(false);
   });
 
   it('dedups a z.ai model present in both sources to source=both, keeping OpenRouter pricing', async () => {

--- a/services/bot-client/src/utils/modelCatalog.ts
+++ b/services/bot-client/src/utils/modelCatalog.ts
@@ -153,6 +153,7 @@ export async function fetchModelCatalog(
       supportsAudioOutput: false,
       promptPricePerMillion: 0,
       completionPricePerMillion: 0,
+      isRouter: false,
       isZaiCoding: true,
       docsUrl: z.docsUrl,
       source: 'zai-catalog',


### PR DESCRIPTION
## Part 3 of `/models` v2: curation

Surfaces the models Tzurot's **global presets** actually use at the top of `/models browse`, so users discover the "blessed" models instead of scrolling ~340 entries.

### Global-preset-first (core)
- `loadAnnotatedModels` now also fetches `listUserLlmConfigs()` (3-way concurrent read alongside the catalog + wallet). The pinned set = `configs.filter(isGlobal).map(model)`. Degrades to no-pinning if the fetch fails — the list still renders.
- New `BrowseModel = UsableCatalogModel & { isGlobalPreset }` (scoped to browse; the card path is untouched).
- `sortModelsPinned` is a **two-tier** sort: pinned models first, the rest after, with the **active sort applied independently within each tier** (per your spec — pin in every sort, sort both tiers). `sortModels<T>` genericized to preserve the flag.
- Pinned models carry a 📌 marker; footer legend updated.

### Folds in two carried v2 nits
- **🔀 meta-router badge** — meta-routers (`openrouter/auto`, etc.) report `top_provider.context_length === null` at runtime, but the type said `number` → fixed to `number | null`. Plumbed `isRouter` through `OpenRouterModelCache.toAutocompleteOption` → `ModelAutocompleteOption` (+ Zod schema) → `CatalogModel`, rendered in the list and on the card.
- **`both`-source card footer** now reads `via OpenRouter (also z.ai coding-plan)` instead of `via OpenRouter` alone, so a z.ai-key-only viewer reading a `z-ai/glm-5` card isn't misled.

### Tests
- browse: pinning overrides sort + 📌 marker; global-only (not owned) pinning; active sort applied within both tiers; 🔀 router badge; graceful degrade on preset-fetch failure
- card: both-source footer names both routes; 🔀 meta-router marker
- cache: `isRouter` in the transform + a null-context-length router fixture
- catalog: `isRouter` passthrough (OR) + `false` for z.ai-only

Local: `turbo run typecheck` ✅, `pnpm quality` ✅, all targeted suites ✅ (52 bot-client model + 30 cache + 9 conformance/handler).

This completes the `/models` v2 arc (Parts 1–3). No new gateway route, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)