### PR TITLE
fix(api-gateway): split wallet read off the strict mutation rate limit

### DIFF
--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -63,6 +63,7 @@ import { requireServiceAuth } from './services/AuthMiddleware.js';
 import {
   createRedisPublicRouteRateLimiter,
   createRedisWalletRateLimiter,
+  createRedisWalletReadRateLimiter,
 } from './utils/RedisRateLimiter.js';
 import {
   initializeEmbeddingService,
@@ -309,7 +310,17 @@ function registerRoutes(app: Express, prisma: PrismaClient, services: ServicesCo
     queueEvents,
   };
 
-  app.use('/api/user/wallet', createRedisWalletRateLimiter(cacheRedis));
+  // Wallet rate limiting, scoped by method+path (registered before the codegen
+  // mounts below so these pass-through limiters run ahead of the handlers).
+  // Mutations + key validation make external calls / are sensitive → strict
+  // budget. The read path (`GET /wallet/list`) is hot (the /models browser reads
+  // keys on every interaction) → a generous per-minute bucket, so browsing can't
+  // exhaust the mutation budget and falsely flip models to "needs a key".
+  const walletWriteLimiter = createRedisWalletRateLimiter(cacheRedis);
+  app.post('/api/user/wallet/set', walletWriteLimiter);
+  app.post('/api/user/wallet/test', walletWriteLimiter);
+  app.delete('/api/user/wallet/:provider', walletWriteLimiter);
+  app.get('/api/user/wallet/list', createRedisWalletReadRateLimiter(cacheRedis));
   mountInternalRoutes(app, routeDeps);
   mountAdminRoutes(app, routeDeps);
   mountUserRoutes(app, routeDeps);

--- a/services/api-gateway/src/utils/RedisRateLimiter.test.ts
+++ b/services/api-gateway/src/utils/RedisRateLimiter.test.ts
@@ -9,6 +9,7 @@ import { StatusCodes } from 'http-status-codes';
 import {
   RedisRateLimiter,
   createRedisWalletRateLimiter,
+  createRedisWalletReadRateLimiter,
   createRedisPublicRouteRateLimiter,
 } from './RedisRateLimiter.js';
 
@@ -298,6 +299,54 @@ describe('createRedisWalletRateLimiter', () => {
     const middleware = createRedisWalletRateLimiter(mockRedis as never);
 
     expect(typeof middleware).toBe('function');
+  });
+});
+
+describe('createRedisWalletReadRateLimiter', () => {
+  let mockRes: Partial<Response>;
+  let mockNext: NextFunction;
+  const mockReq = { headers: { 'x-user-id': 'user-123' } } as unknown as Request;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRes = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+      set: vi.fn().mockReturnThis(),
+    };
+    mockNext = vi.fn();
+  });
+
+  it('uses the dedicated wallet-read key prefix', async () => {
+    mockRedis.eval.mockResolvedValue(1);
+    createRedisWalletReadRateLimiter(mockRedis as never)(mockReq, mockRes as Response, mockNext);
+    await new Promise(resolve => setImmediate(resolve));
+    expect(mockRedis.eval).toHaveBeenCalledWith(
+      expect.stringContaining('redis.call'),
+      1,
+      'ratelimit:wallet-read:user-123',
+      60
+    );
+  });
+
+  it('allows reads well past the strict 10-per-window mutation budget', async () => {
+    // The 11th read in a window would be blocked by the strict wallet limiter;
+    // the read limiter lets it through (limit is 60/min), so browsing the model
+    // list never falsely degrades usability to "needs a key".
+    mockRedis.eval.mockResolvedValue(11);
+    createRedisWalletReadRateLimiter(mockRedis as never)(mockReq, mockRes as Response, mockNext);
+    await new Promise(resolve => setImmediate(resolve));
+    expect(mockNext).toHaveBeenCalled();
+    expect(mockRes.status).not.toHaveBeenCalled();
+  });
+
+  it('blocks once the generous read budget is exceeded', async () => {
+    mockRedis.eval.mockResolvedValue(61);
+    mockRedis.ttl.mockResolvedValue(30);
+    createRedisWalletReadRateLimiter(mockRedis as never)(mockReq, mockRes as Response, mockNext);
+    await new Promise(resolve => setImmediate(resolve));
+    expect(mockNext).not.toHaveBeenCalled();
+    expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.TOO_MANY_REQUESTS);
   });
 });
 

--- a/services/api-gateway/src/utils/RedisRateLimiter.ts
+++ b/services/api-gateway/src/utils/RedisRateLimiter.ts
@@ -183,6 +183,28 @@ export function createRedisWalletRateLimiter(redis: Redis): RequestHandler {
 }
 
 /**
+ * Create rate limiter for the wallet READ path (`GET /wallet/list`).
+ *
+ * Reads are cheap (a masked-key DB lookup, no external call) and legitimately
+ * hot: the `/models` browser fetches the caller's keys on every interaction to
+ * compute per-model usability. They must NOT share the strict mutation budget
+ * (`createRedisWalletRateLimiter`, 10 per 15 min) — that throttle is sized for
+ * sensitive key writes + OpenRouter validation, and browsing would exhaust it,
+ * making every model falsely report "needs a key." A generous per-minute bucket
+ * (separate `keyPrefix`) still guards against an authenticated client hammering
+ * the endpoint.
+ */
+export function createRedisWalletReadRateLimiter(redis: Redis): RequestHandler {
+  const limiter = new RedisRateLimiter(redis, {
+    windowMs: 60 * 1000, // 1 minute
+    maxRequests: 60, // 60 reads per minute — ample for browsing, abuse-resistant
+    message: 'Too many wallet read requests. Please try again later.',
+    keyPrefix: 'ratelimit:wallet-read:',
+  });
+  return limiter.middleware();
+}
+
+/**
  * Create rate limiter for denylist admin operations (POST/DELETE)
  *
  * Denylist mutations are infrequent admin actions. Rate limit to


### PR DESCRIPTION
## Root cause (confirmed in dev logs)

`index.ts:312` blanketed the **entire** `/api/user/wallet` router with `createRedisWalletRateLimiter` (**10 requests / 15 minutes**) — a budget sized for sensitive key *writes* + OpenRouter *validation*. But the hot read `GET /wallet/list` sits under it too, and the `/models` browser reads the caller's keys on **every** interaction (initial + each page flip) to compute per-model usability.

Result, observed live:
```
[INFO] Rate limit exceeded  name="RedisRateLimiter"  rateLimitKey="<user>"  count=22  maxRequests=10
       url="/api/user/wallet/list"  res.statusCode: null
```
The rate-limited `/wallet/list` returns 429 → bot-client's `loadAnnotatedModels` degrades (`walletResult.ok ? keys : []`) to empty providers → **every non-free model falsely shows "needs a key"** (the user had 3 keys). The same limiter also throttled `POST /wallet/test`, which bot-client rendered as **"❌ API Key Invalid."**

## Fix

Re-scope by method+path (registered before the codegen mounts so they run ahead of the handlers):
- **Strict** `createRedisWalletRateLimiter` (10/15min) stays on `POST /set`, `POST /test`, `DELETE /:provider` — the sensitive/external-call ops.
- **New** `createRedisWalletReadRateLimiter` (60/min, own `ratelimit:wallet-read:` prefix) on `GET /wallet/list` — generous enough for browsing, still abuse-resistant.

Reads can no longer exhaust the mutation budget.

## Tests

`RedisRateLimiter.test.ts`: new factory uses the dedicated prefix; allows the 11th read in a window (the strict limiter would block it); still blocks past 60/min.

Local: `turbo run typecheck` ✅, `pnpm quality` ✅, `RedisRateLimiter` suite ✅ (29).

## Follow-up (PR B, bot-client)

The downstream resilience fixes ride separately: don't render false 🔒 on a failed wallet fetch; cache the wallet-provider + global-preset sets to cut per-page-flip calls; map a 429 from `apikey test` to "try again" instead of "API Key Invalid."

🤖 Generated with [Claude Code](https://claude.com/claude-code)