### PR TITLE
fix(bot-client): show ❔ unverified instead of false 🔒 when keys can't be fetched

### DIFF
--- a/services/bot-client/src/commands/models/browse.test.ts
+++ b/services/bot-client/src/commands/models/browse.test.ts
@@ -374,6 +374,17 @@ describe('global-preset pinning + router badge', () => {
     expect(description).toContain('a/model');
     expect(description).not.toContain('📌');
   });
+
+  it('shows ❔ unverified + a notice when the wallet fetch fails (no false 🔒)', async () => {
+    walletStub.listWalletKeys.mockResolvedValue(makeErr(429, 'rate limited'));
+    catalogMock.fetchModelCatalog.mockResolvedValue([
+      catalogModel({ id: 'anthropic/claude-sonnet-4', name: 'Claude' }),
+    ]);
+    const description = await renderViaPagination('models::browse::0::all::default::');
+    expect(description).toContain('❔');
+    expect(description).toContain("Couldn't verify your API keys");
+    expect(description).not.toContain('🔒');
+  });
 });
 
 describe('handleBrowseSelect', () => {

--- a/services/bot-client/src/commands/models/browse.ts
+++ b/services/bot-client/src/commands/models/browse.ts
@@ -127,6 +127,9 @@ function usabilityIcon(model: UsableCatalogModel): string {
   if (model.usability === 'free') {
     return '🆓';
   }
+  if (model.usability === 'unknown') {
+    return '❔';
+  }
   return model.canUse ? '✅' : '🔒';
 }
 
@@ -175,6 +178,13 @@ function buildBrowseEmbed(view: BrowseView, pageItems: BrowseModel[]): EmbedBuil
     `sorted: ${ACTIVE_SORT_LABEL[sort]}`,
   ].filter(Boolean);
   lines.push(`_${filterBits.join(' · ')}_`);
+  // When the wallet fetch failed, every non-free model is `unknown` — explain
+  // the ❔ rather than leaving the user guessing why nothing shows ✅/🔒.
+  if (items.some(m => m.usability === 'unknown')) {
+    lines.push(
+      "⚠️ _Couldn't verify your API keys right now — usability shown as ❔. Try again shortly._"
+    );
+  }
   if (items.length === 0) {
     lines.push('_No models match your filters._');
   } else {
@@ -191,7 +201,7 @@ function buildBrowseEmbed(view: BrowseView, pageItems: BrowseModel[]): EmbedBuil
     text: joinFooter(
       pluralize(items.length, { singular: 'model', plural: 'models' }),
       capped && `first ${BROWSE_FETCH_LIMIT} — refine with search for more`,
-      '🆓 free  ✅ you can use  🔒 needs a key  📌 global preset  🔀 router  ⚡ z.ai'
+      '🆓 free  ✅ you can use  🔒 needs a key  ❔ unverified  📌 global preset  🔀 router  ⚡ z.ai'
     ),
   });
   return embed;
@@ -253,9 +263,10 @@ function buildBrowsePage(view: BrowseView): { embed: EmbedBuilder; components: B
 /**
  * Fetch the merged catalog + the user's active key providers + the global
  * presets, then annotate usability, flag global-preset models, and apply the
- * pinned two-tier sort. All three gateway reads run concurrently; the wallet
- * and preset reads degrade to empty on failure (no usability/pin info rather
- * than a failed browse).
+ * pinned two-tier sort. All three gateway reads run concurrently. A failed
+ * WALLET read yields `null` providers → non-free models render `unknown` (❔)
+ * rather than a misleading "needs a key"; a failed PRESET read degrades to no
+ * pinning. Neither fails the browse.
  */
 async function loadAnnotatedModels(
   interaction: ClientCarryingInteraction,
@@ -269,9 +280,10 @@ async function loadAnnotatedModels(
     userClient.listWalletKeys(),
     userClient.listUserLlmConfigs(),
   ]);
-  const activeProviders = new Set(
-    walletResult.ok ? walletResult.data.keys.filter(k => k.isActive).map(k => k.provider) : []
-  );
+  // null = wallet fetch failed (can't determine keys) → usability 'unknown'.
+  const activeProviders = walletResult.ok
+    ? new Set(walletResult.data.keys.filter(k => k.isActive).map(k => k.provider))
+    : null;
   const globalPresetModelIds = new Set(
     configsResult.ok
       ? configsResult.data.configs.filter(c => c.isGlobal).map(c => c.model.toLowerCase())
@@ -359,9 +371,10 @@ export async function handleBrowseSelect(interaction: StringSelectMenuInteractio
       });
       return;
     }
-    const activeProviders = new Set(
-      walletResult.ok ? walletResult.data.keys.filter(k => k.isActive).map(k => k.provider) : []
-    );
+    // null = wallet fetch failed → card shows 'unknown' rather than false "needs key".
+    const activeProviders = walletResult.ok
+      ? new Set(walletResult.data.keys.filter(k => k.isActive).map(k => k.provider))
+      : null;
     const [annotated] = annotateUsability([model], activeProviders);
     await interaction.followUp({
       embeds: [buildModelCard(annotated)],

--- a/services/bot-client/src/commands/models/card.test.ts
+++ b/services/bot-client/src/commands/models/card.test.ts
@@ -128,6 +128,20 @@ describe('buildModelCard', () => {
     expect(json.description).toContain('🔀 meta-router');
   });
 
+  it('renders the unverified (unknown) state without claiming a key is needed', () => {
+    const json = buildModelCard(
+      usable({
+        id: 'anthropic/claude-sonnet-4',
+        name: 'Claude Sonnet 4',
+        usability: 'unknown',
+        canUse: false,
+      })
+    ).toJSON();
+    expect(json.description).toContain("❔ **Couldn't verify your keys**");
+    expect(json.description).not.toContain('Needs');
+    expect((json.fields ?? []).find(f => f.name === 'Access')?.value).toBe('Unverified');
+  });
+
   it('shows the free usability line for free models', () => {
     expect(
       buildModelCard(usable({ id: 'google/gemma:free', usability: 'free', canUse: true })).toJSON()

--- a/services/bot-client/src/commands/models/card.ts
+++ b/services/bot-client/src/commands/models/card.ts
@@ -28,6 +28,7 @@ const USABILITY_LINE: Record<ModelUsability, string> = {
   'needs-zai-key': '🔑 **Needs a z.ai coding-plan key** — add one with `/settings apikey set`',
   'needs-either-key':
     '🔑 **Needs an OpenRouter or z.ai key** — add one with `/settings apikey set`',
+  unknown: "❔ **Couldn't verify your keys** — try again in a moment",
 };
 
 /** Short one-word(ish) access category for the inline field. */
@@ -37,6 +38,7 @@ const ACCESS_LABEL: Record<ModelUsability, string> = {
   'needs-openrouter-key': 'OpenRouter key',
   'needs-zai-key': 'z.ai key',
   'needs-either-key': 'OpenRouter / z.ai',
+  unknown: 'Unverified',
 };
 
 /** Inline separator shared by the capability line and the links line. */

--- a/services/bot-client/src/commands/settings/apikey/test.test.ts
+++ b/services/bot-client/src/commands/settings/apikey/test.test.ts
@@ -162,6 +162,27 @@ describe('handleTestKey', () => {
     });
   });
 
+  it('should map a 429 rate-limit to a retry message, not "API Key Invalid"', async () => {
+    stub.testWalletKey.mockResolvedValue(makeErr(429, 'Too many API key operations'));
+
+    const context = createMockContext('openrouter');
+    await handleTestKey(context);
+
+    expect(mockEditReply).toHaveBeenCalledWith({
+      content: expect.stringContaining('Too many key operations'),
+    });
+    // Must NOT render the alarming validation-failure embed for a mere throttle.
+    expect(mockEditReply).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        embeds: expect.arrayContaining([
+          expect.objectContaining({
+            data: expect.objectContaining({ title: '❌ API Key Invalid' }),
+          }),
+        ]),
+      })
+    );
+  });
+
   it('should handle exceptions', async () => {
     stub.testWalletKey.mockRejectedValue(new Error('Network error'));
 

--- a/services/bot-client/src/commands/settings/apikey/test.ts
+++ b/services/bot-client/src/commands/settings/apikey/test.ts
@@ -44,6 +44,15 @@ export async function handleTestKey(context: DeferredCommandContext): Promise<vo
         return;
       }
 
+      // Rate-limited (429): our own wallet limiter, NOT a bad key. Saying
+      // "API Key Invalid" here is wrong and alarming — tell the user to retry.
+      if (result.status === 429) {
+        await context.editReply({
+          content: `⏳ Too many key operations in a short window. Your **${getProviderDisplayName(provider)}** key wasn't tested — please wait a moment and try again.`,
+        });
+        return;
+      }
+
       // Handle validation errors - need to try parsing the error response for details
       const embed = new EmbedBuilder()
         .setColor(DISCORD_COLORS.ERROR)

--- a/services/bot-client/src/utils/modelCatalog.test.ts
+++ b/services/bot-client/src/utils/modelCatalog.test.ts
@@ -213,6 +213,18 @@ describe('annotateUsability', () => {
     expect(annotateUsability([both], new Set())[0].usability).toBe('needs-either-key');
   });
 
+  it('marks non-free models unknown when keys could not be fetched (null providers)', () => {
+    const [r] = annotateUsability([cat({ id: 'anthropic/claude-sonnet-4' })], null);
+    expect(r.usability).toBe('unknown');
+    expect(r.canUse).toBe(false);
+  });
+
+  it('keeps free models usable even when keys could not be fetched (null providers)', () => {
+    const [r] = annotateUsability([cat({ id: 'google/gemma:free' })], null);
+    expect(r.usability).toBe('free');
+    expect(r.canUse).toBe(true);
+  });
+
   it('a z-ai/ model NOT on the coding plan needs an OpenRouter key (routes via OR)', () => {
     // e.g. z-ai/glm-4.6 — on OpenRouter, not in the coding-plan catalog, so
     // source is plain 'openrouter' and the z-ai/ prefix must NOT imply z.ai.

--- a/services/bot-client/src/utils/modelCatalog.ts
+++ b/services/bot-client/src/utils/modelCatalog.ts
@@ -43,7 +43,10 @@ export type ModelUsability =
   | 'usable'
   | 'needs-openrouter-key'
   | 'needs-zai-key'
-  | 'needs-either-key';
+  | 'needs-either-key'
+  // Couldn't determine the user's keys (wallet fetch failed/rate-limited) — we
+  // genuinely don't know, so we show this rather than a misleading "needs key".
+  | 'unknown';
 
 export interface UsableCatalogModel extends CatalogModel {
   usability: ModelUsability;
@@ -195,17 +198,26 @@ export async function fetchCatalogModelById(id: string): Promise<CatalogModel | 
  *
  * The system OpenRouter key is assumed present (bot-client can't probe it), so a
  * free model never reports "needs key".
+ *
+ * `activeProviders === null` means the wallet fetch FAILED (timeout, error,
+ * rate-limit) — we couldn't determine the user's keys. Non-free models are then
+ * marked `'unknown'` rather than falsely reporting "needs a key"; free models
+ * stay usable (they need no key regardless).
  */
 export function annotateUsability(
   models: CatalogModel[],
-  activeProviders: ReadonlySet<string>
+  activeProviders: ReadonlySet<string> | null
 ): UsableCatalogModel[] {
-  const hasOpenRouter = activeProviders.has(AIProvider.OpenRouter);
-  const hasZai = activeProviders.has(AIProvider.ZaiCoding);
+  const keysUnknown = activeProviders === null;
+  const hasOpenRouter = activeProviders?.has(AIProvider.OpenRouter) ?? false;
+  const hasZai = activeProviders?.has(AIProvider.ZaiCoding) ?? false;
 
   return models.map(model => {
     if (isFreeModel(model.id)) {
       return { ...model, usability: 'free', canUse: true };
+    }
+    if (keysUnknown) {
+      return { ...model, usability: 'unknown', canUse: false };
     }
     if (model.source === 'zai-catalog') {
       return { ...model, usability: hasZai ? 'usable' : 'needs-zai-key', canUse: hasZai };


### PR DESCRIPTION
## Why

Paired with #1219. When `listWalletKeys()` fails (timeout/error/our own rate-limit), `/models browse` collapsed the empty result to `activeProviders = []` and rendered **every non-free model as 🔒 "needs a key"** — a lie (the user has keys; we just couldn't read them). And `/settings apikey test` rendered a 429 throttle as **"❌ API Key Invalid"** (also a lie — the key is fine).

## Changes

- **`annotateUsability` accepts `null` providers** = "couldn't determine keys." Non-free models become a new `'unknown'` usability state; free models stay usable (no key needed).
- **Browse** renders `unknown` as **❔**, adds a one-line `⚠️ Couldn't verify your API keys…` notice, and an `❔ unverified` legend entry. Both the list and the select→card path pass `null` on wallet-fetch failure.
- **Card** renders the same state (`❔ Couldn't verify your keys` / Access: `Unverified`) — no false "Needs … key".
- **`/settings apikey test`** maps a 429 to "Too many key operations — try again," not "API Key Invalid."

## Design note

Chosen UX (per discussion): a real `unknown` state (❔) rather than a banner-over-stale-icons or optimistic-✅ — the honest answer when we can't verify is "don't know," not a guess in either direction.

## Tests

`annotateUsability(null)` → non-free `unknown`/`canUse:false`, free stays usable; browse shows ❔ + notice + no 🔒 on wallet failure; card renders the unknown state; apikey-test 429 → retry message (and explicitly *not* the "API Key Invalid" embed).

Local: 58 model/apikey tests ✅, `turbo run typecheck` ✅, `pnpm quality` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)