### PR TITLE
chore: /models follow-up cleanup — caches, z.ai data, safe-by-default limiter

### DIFF
--- a/packages/common-types/src/constants/ai.ts
+++ b/packages/common-types/src/constants/ai.ts
@@ -247,14 +247,24 @@ export const ZAI_VALIDATION_MODEL = 'glm-4.5-air';
  * lowercase to match the case-normalized lookups; user-typed preset configs
  * may use any case so callers normalize before lookup.
  */
-const ZAI_MODEL_CATALOG: Readonly<Record<string, { docsUrl: string; contextLength: number }>> = {
+// `released` (ISO date) is only consumed for z.ai-EXCLUSIVE models: it becomes
+// the synthetic catalog entry's `created` so `/models` can sort them by recency.
+// Models that also live on OpenRouter take OpenRouter's `created` via the merge,
+// so `released` is optional and only worth setting for z.ai-only entries.
+const ZAI_MODEL_CATALOG: Readonly<
+  Record<string, { docsUrl: string; contextLength: number; released?: string }>
+> = {
   'glm-5': { docsUrl: 'https://docs.z.ai/guides/llm/glm-5', contextLength: 200_000 },
   'glm-5.1': { docsUrl: 'https://docs.z.ai/guides/llm/glm-5.1', contextLength: 200_000 },
   // glm-5.2 is z.ai's flagship and is NOT on OpenRouter yet — the catalog is
-  // its only context-length source, so the cap depends on this value. Its
-  // docs page isn't published yet (the URL follows the established pattern and
-  // will resolve once z.ai adds it).
-  'glm-5.2': { docsUrl: 'https://docs.z.ai/guides/llm/glm-5.2', contextLength: 1_000_000 },
+  // its only source for context length AND release date (so `/models` can rank
+  // it by recency). Its docs page isn't published yet (the URL follows the
+  // established pattern and will resolve once z.ai adds it).
+  'glm-5.2': {
+    docsUrl: 'https://docs.z.ai/guides/llm/glm-5.2',
+    contextLength: 1_000_000,
+    released: '2026-06-13',
+  },
   'glm-5-turbo': { docsUrl: 'https://docs.z.ai/guides/llm/glm-5-turbo', contextLength: 200_000 },
   'glm-4.7': { docsUrl: 'https://docs.z.ai/guides/llm/glm-4.7', contextLength: 200_000 },
   // glm-4.5-air uses the parent family page — z.ai docs the Air variant on
@@ -313,6 +323,8 @@ export interface ZaiCodingPlanModelInfo {
   model: string;
   docsUrl: string;
   contextLength: number;
+  /** ISO release date; only set for z.ai-exclusive models (see catalog comment). */
+  released?: string;
 }
 
 /**

--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -310,17 +310,24 @@ function registerRoutes(app: Express, prisma: PrismaClient, services: ServicesCo
     queueEvents,
   };
 
-  // Wallet rate limiting, scoped by method+path (registered before the codegen
-  // mounts below so these pass-through limiters run ahead of the handlers).
-  // Mutations + key validation make external calls / are sensitive → strict
-  // budget. The read path (`GET /wallet/list`) is hot (the /models browser reads
-  // keys on every interaction) → a generous per-minute bucket, so browsing can't
-  // exhaust the mutation budget and falsely flip models to "needs a key".
+  // Wallet rate limiting (registered before the codegen mounts so these
+  // pass-through limiters run ahead of the handlers). Two layers:
+  //   1. A LENIENT baseline on the whole `/api/user/wallet` prefix — keeps the
+  //      old blanket's safe-by-default property: any wallet route (incl. ones
+  //      added later) is throttled even if nobody updates this block.
+  //   2. The STRICT mutation budget layered on top of the sensitive/external
+  //      routes (set / test / delete). On a mutation both run in registration
+  //      order — lenient (60/min) first, then strict (10/15min) — but strict is
+  //      the EFFECTIVE ceiling: mutations hit 10/15min long before the lenient
+  //      limit, so they stay tightly capped. The hot read (`GET /wallet/list`,
+  //      hit by the /models browser on every interaction) only ever pays the
+  //      generous 60/min baseline — browsing can't exhaust the mutation budget
+  //      and falsely flip models to "needs a key".
+  app.use('/api/user/wallet', createRedisWalletReadRateLimiter(cacheRedis));
   const walletWriteLimiter = createRedisWalletRateLimiter(cacheRedis);
   app.post('/api/user/wallet/set', walletWriteLimiter);
   app.post('/api/user/wallet/test', walletWriteLimiter);
   app.delete('/api/user/wallet/:provider', walletWriteLimiter);
-  app.get('/api/user/wallet/list', createRedisWalletReadRateLimiter(cacheRedis));
   mountInternalRoutes(app, routeDeps);
   mountAdminRoutes(app, routeDeps);
   mountUserRoutes(app, routeDeps);

--- a/services/bot-client/src/commands/models/browse.test.ts
+++ b/services/bot-client/src/commands/models/browse.test.ts
@@ -52,6 +52,7 @@ import {
   isModelsBrowseInteraction,
   isModelsBrowseSelectInteraction,
 } from './browse.js';
+import { __resetBrowseUserCachesForTests } from './browseUserCache.js';
 
 function catalogModel(overrides: Partial<CatalogModel> & { id: string }): CatalogModel {
   return {
@@ -73,6 +74,9 @@ function catalogModel(overrides: Partial<CatalogModel> & { id: string }): Catalo
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Caches persist across tests — reset so per-test wallet/preset mocks aren't
+  // masked by a warm entry from a prior test.
+  __resetBrowseUserCachesForTests();
   walletStub.listWalletKeys.mockResolvedValue(makeOk(mockListWalletKeysResponse([])));
   walletStub.listUserLlmConfigs.mockResolvedValue(makeOk(mockListLlmConfigsResponse([])));
 });

--- a/services/bot-client/src/commands/models/browse.ts
+++ b/services/bot-client/src/commands/models/browse.ts
@@ -36,6 +36,7 @@ import {
   type UsableCatalogModel,
 } from '../../utils/modelCatalog.js';
 import { buildModelCard } from './card.js';
+import { getActiveProviders, getGlobalPresetModelIds } from './browseUserCache.js';
 
 const logger = createLogger('models-browse');
 
@@ -263,10 +264,11 @@ function buildBrowsePage(view: BrowseView): { embed: EmbedBuilder; components: B
 /**
  * Fetch the merged catalog + the user's active key providers + the global
  * presets, then annotate usability, flag global-preset models, and apply the
- * pinned two-tier sort. All three gateway reads run concurrently. A failed
- * WALLET read yields `null` providers → non-free models render `unknown` (❔)
- * rather than a misleading "needs a key"; a failed PRESET read degrades to no
- * pinning. Neither fails the browse.
+ * pinned two-tier sort. All three reads run concurrently; the wallet + preset
+ * reads are short-TTL cached (see `browseUserCache`) so paging doesn't re-hit
+ * the gateway every press. A failed WALLET read yields `null` providers →
+ * non-free models render `unknown` (❔), not a false "needs a key"; a failed
+ * PRESET read degrades to no pinning. Neither fails the browse.
  */
 async function loadAnnotatedModels(
   interaction: ClientCarryingInteraction,
@@ -275,20 +277,11 @@ async function loadAnnotatedModels(
   sort: ModelSort
 ): Promise<BrowseModel[]> {
   const { userClient } = clientsFor(interaction);
-  const [catalog, walletResult, configsResult] = await Promise.all([
+  const [catalog, activeProviders, globalPresetModelIds] = await Promise.all([
     fetchModelCatalog({ capability, search: search ?? undefined, limit: BROWSE_FETCH_LIMIT }),
-    userClient.listWalletKeys(),
-    userClient.listUserLlmConfigs(),
+    getActiveProviders(userClient, interaction.user.id),
+    getGlobalPresetModelIds(userClient),
   ]);
-  // null = wallet fetch failed (can't determine keys) → usability 'unknown'.
-  const activeProviders = walletResult.ok
-    ? new Set(walletResult.data.keys.filter(k => k.isActive).map(k => k.provider))
-    : null;
-  const globalPresetModelIds = new Set(
-    configsResult.ok
-      ? configsResult.data.configs.filter(c => c.isGlobal).map(c => c.model.toLowerCase())
-      : []
-  );
   const annotated = annotateUsability(catalog, activeProviders).map<BrowseModel>(m => ({
     ...m,
     isGlobalPreset: globalPresetModelIds.has(m.id.toLowerCase()),
@@ -360,9 +353,9 @@ export async function handleBrowseSelect(interaction: StringSelectMenuInteractio
   await interaction.deferUpdate();
   try {
     const { userClient } = clientsFor(interaction);
-    const [model, walletResult] = await Promise.all([
+    const [model, activeProviders] = await Promise.all([
       fetchCatalogModelById(modelId),
-      userClient.listWalletKeys(),
+      getActiveProviders(userClient, interaction.user.id),
     ]);
     if (model === null) {
       await interaction.followUp({
@@ -371,10 +364,8 @@ export async function handleBrowseSelect(interaction: StringSelectMenuInteractio
       });
       return;
     }
-    // null = wallet fetch failed → card shows 'unknown' rather than false "needs key".
-    const activeProviders = walletResult.ok
-      ? new Set(walletResult.data.keys.filter(k => k.isActive).map(k => k.provider))
-      : null;
+    // activeProviders === null = wallet fetch failed → card shows 'unknown'
+    // (❔) rather than a false "needs key".
     const [annotated] = annotateUsability([model], activeProviders);
     await interaction.followUp({
       embeds: [buildModelCard(annotated)],

--- a/services/bot-client/src/commands/models/browseUserCache.test.ts
+++ b/services/bot-client/src/commands/models/browseUserCache.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for the /models browse user-context caches.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { UserClient } from '@tzurot/clients';
+import { AIProvider } from '@tzurot/common-types';
+import { makeOk, makeErr } from '../../test/gatewayClientStubs.js';
+import { mockListWalletKeysResponse, mockListLlmConfigsResponse } from '@tzurot/test-factories';
+import {
+  getGlobalPresetModelIds,
+  getActiveProviders,
+  __resetBrowseUserCachesForTests,
+} from './browseUserCache.js';
+
+const stub = {
+  listUserLlmConfigs: vi.fn(),
+  listWalletKeys: vi.fn(),
+};
+const client = stub as unknown as UserClient;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetBrowseUserCachesForTests();
+});
+
+describe('getGlobalPresetModelIds', () => {
+  it('returns lowercased model ids of global presets only', async () => {
+    stub.listUserLlmConfigs.mockResolvedValue(
+      makeOk(
+        mockListLlmConfigsResponse([
+          { model: 'Anthropic/Claude-Sonnet-4', isGlobal: true },
+          { model: 'owned/model', isGlobal: false },
+        ])
+      )
+    );
+    const ids = await getGlobalPresetModelIds(client);
+    expect(ids.has('anthropic/claude-sonnet-4')).toBe(true);
+    expect(ids.has('owned/model')).toBe(false);
+  });
+
+  it('caches the result (second call does not re-fetch)', async () => {
+    stub.listUserLlmConfigs.mockResolvedValue(makeOk(mockListLlmConfigsResponse([])));
+    await getGlobalPresetModelIds(client);
+    await getGlobalPresetModelIds(client);
+    expect(stub.listUserLlmConfigs).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns an empty set and does NOT cache on failure', async () => {
+    stub.listUserLlmConfigs.mockResolvedValue(makeErr(500, 'boom'));
+    const ids = await getGlobalPresetModelIds(client);
+    expect(ids.size).toBe(0);
+    // Next call retries (failure not cached).
+    stub.listUserLlmConfigs.mockResolvedValue(
+      makeOk(mockListLlmConfigsResponse([{ model: 'g/m', isGlobal: true }]))
+    );
+    const retried = await getGlobalPresetModelIds(client);
+    expect(retried.has('g/m')).toBe(true);
+    expect(stub.listUserLlmConfigs).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('getActiveProviders', () => {
+  it('returns the set of active providers', async () => {
+    stub.listWalletKeys.mockResolvedValue(
+      makeOk(
+        mockListWalletKeysResponse([
+          { provider: AIProvider.OpenRouter, isActive: true },
+          { provider: AIProvider.ZaiCoding, isActive: false },
+        ])
+      )
+    );
+    const providers = await getActiveProviders(client, 'user-1');
+    expect(providers).not.toBeNull();
+    expect(providers?.has('openrouter')).toBe(true);
+    expect(providers?.has('zai-coding')).toBe(false); // inactive excluded
+  });
+
+  it('caches per user (second call for same user does not re-fetch)', async () => {
+    stub.listWalletKeys.mockResolvedValue(makeOk(mockListWalletKeysResponse([])));
+    await getActiveProviders(client, 'user-1');
+    await getActiveProviders(client, 'user-1');
+    expect(stub.listWalletKeys).toHaveBeenCalledTimes(1);
+    // A different user is a cache miss → re-fetches.
+    await getActiveProviders(client, 'user-2');
+    expect(stub.listWalletKeys).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns null (and does NOT cache) on failure', async () => {
+    stub.listWalletKeys.mockResolvedValue(makeErr(429, 'rate limited'));
+    expect(await getActiveProviders(client, 'user-1')).toBeNull();
+    // Retries on next call (failure not cached).
+    stub.listWalletKeys.mockResolvedValue(
+      makeOk(mockListWalletKeysResponse([{ provider: AIProvider.OpenRouter, isActive: true }]))
+    );
+    const providers = await getActiveProviders(client, 'user-1');
+    expect(providers?.has('openrouter')).toBe(true);
+    expect(stub.listWalletKeys).toHaveBeenCalledTimes(2);
+  });
+});

--- a/services/bot-client/src/commands/models/browseUserCache.ts
+++ b/services/bot-client/src/commands/models/browseUserCache.ts
@@ -1,0 +1,98 @@
+/**
+ * Short-lived caches for `/models browse` user context.
+ *
+ * Browse reads two user-scoped things on EVERY interaction (initial render, page
+ * flip, filter change, search): the caller's active key providers (for the
+ * ✅/🔒/❔ usability marker) and the set of models used by global presets (for
+ * the 📌 pin). Neither changes meaningfully during a browse session, so a short
+ * TTL cache avoids re-hitting the gateway on every button press. Mirrors the
+ * single-key TTLCache pattern in `preset/autocomplete.ts`.
+ *
+ * TTL is deliberately short (30s, not the 5-min `TIMEOUTS.CACHE_TTL`): a user
+ * who just ran `/settings apikey set` should see updated usability within a page
+ * flip or two, not minutes later.
+ */
+
+import { TTLCache } from '@tzurot/common-types';
+import type { UserClient } from '@tzurot/clients';
+
+/** Browse caches refresh within ~a page flip or two of a key/preset change. */
+const BROWSE_CACHE_TTL_MS = 30_000;
+
+const GLOBAL_PRESETS_KEY = 'global-presets';
+
+// Global presets are user-INDEPENDENT (the same `isGlobal` rows for everyone),
+// so a single shared entry serves all users.
+let globalPresetCache: TTLCache<ReadonlySet<string>> | null = null;
+function presetCache(): TTLCache<ReadonlySet<string>> {
+  globalPresetCache ??= new TTLCache<ReadonlySet<string>>({ ttl: BROWSE_CACHE_TTL_MS, maxSize: 1 });
+  return globalPresetCache;
+}
+
+// Wallet providers are PER-USER, so the cache is keyed by user id (LRU-bounded).
+let walletProviderCache: TTLCache<ReadonlySet<string>> | null = null;
+function providerCache(): TTLCache<ReadonlySet<string>> {
+  walletProviderCache ??= new TTLCache<ReadonlySet<string>>({
+    ttl: BROWSE_CACHE_TTL_MS,
+    maxSize: 100,
+  });
+  return walletProviderCache;
+}
+
+/**
+ * Lowercased model ids used by any global preset (drives the 📌 pin). Returns an
+ * empty set — and does NOT cache — on fetch failure, so a transient error
+ * doesn't suppress pinning for the whole TTL window.
+ *
+ * Cross-user trust assumption: the single shared cache entry is seeded by
+ * whichever user calls first, which is SAFE only because `listUserLlmConfigs`
+ * returns the same `isGlobal` rows to every authenticated caller (we filter to
+ * those). If that endpoint ever scoped globals by caller identity, this cache
+ * would leak one user's view to others for the TTL window.
+ */
+export async function getGlobalPresetModelIds(
+  userClient: UserClient
+): Promise<ReadonlySet<string>> {
+  const cached = presetCache().get(GLOBAL_PRESETS_KEY);
+  if (cached !== null) {
+    return cached;
+  }
+  const result = await userClient.listUserLlmConfigs();
+  if (!result.ok) {
+    return new Set();
+  }
+  const ids = new Set(result.data.configs.filter(c => c.isGlobal).map(c => c.model.toLowerCase()));
+  presetCache().set(GLOBAL_PRESETS_KEY, ids);
+  return ids;
+}
+
+/**
+ * The caller's active key providers, or `null` if the wallet fetch failed
+ * (= "couldn't determine keys"; the browse/card path renders this as ❔ rather
+ * than a false 🔒). Failures are NOT cached so the next interaction retries.
+ */
+export async function getActiveProviders(
+  userClient: UserClient,
+  userId: string
+): Promise<ReadonlySet<string> | null> {
+  const cached = providerCache().get(userId);
+  if (cached !== null) {
+    return cached;
+  }
+  const result = await userClient.listWalletKeys();
+  if (!result.ok) {
+    return null;
+  }
+  const providers = new Set(result.data.keys.filter(k => k.isActive).map(k => k.provider));
+  providerCache().set(userId, providers);
+  return providers;
+}
+
+/**
+ * Reset both caches. Test-only — lets each test exercise the cold-fetch path
+ * without ordering dependencies on a prior test's populated cache.
+ */
+export function __resetBrowseUserCachesForTests(): void {
+  globalPresetCache = null;
+  walletProviderCache = null;
+}

--- a/services/bot-client/src/utils/modelCatalog.test.ts
+++ b/services/bot-client/src/utils/modelCatalog.test.ts
@@ -18,6 +18,8 @@ import {
   fetchCatalogModelById,
   annotateUsability,
   formatCapabilities,
+  zaiDisplayName,
+  zaiReleasedToUnix,
   type CatalogModel,
 } from './modelCatalog.js';
 
@@ -246,5 +248,26 @@ describe('formatCapabilities', () => {
     expect(out).toContain('vision');
     expect(out).toContain('audio-in');
     expect(out).not.toContain('image-gen');
+  });
+});
+
+describe('zaiDisplayName', () => {
+  it('upper-cases recognized acronyms and title-cases the rest', () => {
+    expect(zaiDisplayName('glm-5.2')).toBe('GLM-5.2');
+    expect(zaiDisplayName('glm-5-turbo')).toBe('GLM-5-Turbo');
+    // Acronym set covers more than GLM (forward-looking for future z.ai-only slugs).
+    expect(zaiDisplayName('glm-4-vl')).toBe('GLM-4-VL');
+    expect(zaiDisplayName('deepseek-r1')).toBe('Deepseek-R1');
+  });
+});
+
+describe('zaiReleasedToUnix', () => {
+  it('converts an ISO date to Unix seconds', () => {
+    expect(zaiReleasedToUnix('2026-06-13')).toBe(Math.floor(Date.parse('2026-06-13') / 1000));
+  });
+
+  it('returns undefined for a missing or malformed date (never NaN)', () => {
+    expect(zaiReleasedToUnix(undefined)).toBeUndefined();
+    expect(zaiReleasedToUnix('not-a-date')).toBeUndefined();
   });
 });

--- a/services/bot-client/src/utils/modelCatalog.ts
+++ b/services/bot-client/src/utils/modelCatalog.ts
@@ -63,12 +63,35 @@ export interface FetchCatalogOptions {
   limit?: number;
 }
 
+/**
+ * Conventional acronyms that should render fully upper-case in a z.ai display
+ * name (vs. the default title-case). Only matters for z.ai-catalog-ONLY models;
+ * on-OpenRouter models use OpenRouter's own `name`.
+ */
+const ZAI_NAME_ACRONYMS = new Set(['GLM', 'VL', 'VLM', 'R1', 'V1', 'MOE']);
+
 /** Render a z.ai catalog key as a display name: `glm-5-turbo` → `GLM-5-Turbo`. */
-function zaiDisplayName(model: string): string {
+export function zaiDisplayName(model: string): string {
   return model
     .split('-')
-    .map(seg => (seg.toLowerCase() === 'glm' ? 'GLM' : seg.charAt(0).toUpperCase() + seg.slice(1)))
+    .map(seg => {
+      const upper = seg.toUpperCase();
+      return ZAI_NAME_ACRONYMS.has(upper) ? upper : seg.charAt(0).toUpperCase() + seg.slice(1);
+    })
     .join('-');
+}
+
+/**
+ * Convert a catalog ISO release date to OpenRouter's `created` format (Unix
+ * seconds). Returns undefined for a missing OR malformed date — a bad string
+ * must NOT become `NaN`, which would corrupt the recency sort comparator.
+ */
+export function zaiReleasedToUnix(released: string | undefined): number | undefined {
+  if (released === undefined) {
+    return undefined;
+  }
+  const ms = Date.parse(released);
+  return Number.isNaN(ms) ? undefined : Math.floor(ms / 1000);
 }
 
 /** Build a CatalogModel from an OpenRouter option. */
@@ -156,6 +179,9 @@ export async function fetchModelCatalog(
       supportsAudioOutput: false,
       promptPricePerMillion: 0,
       completionPricePerMillion: 0,
+      // ISO release date → `created` (Unix seconds) so the recency sort ranks
+      // z.ai-only models correctly. Undefined when unknown/malformed → sorts last.
+      created: zaiReleasedToUnix(z.released),
       isRouter: false,
       isZaiCoding: true,
       docsUrl: z.docsUrl,


### PR DESCRIPTION
Bundles the queued `/models` follow-ups + the safe-by-default note from #1219's post-autosquash review.

## api-gateway — safe-by-default wallet rate limiting
#1219 split the read off the strict budget but, by enumerating routes explicitly, lost the old blanket's *safe-by-default* property (a future `/api/user/wallet/*` route would be unthrottled). Restored: a **lenient baseline** (`createRedisWalletReadRateLimiter`) now covers the whole `/api/user/wallet` prefix, with the **strict** mutation budget layered on `set`/`test`/`delete`. Strict binds first for mutations; the hot read `/list` only pays the 60/min baseline; any new route is throttled by default.

## common-types — z.ai release date
Added optional `released` (ISO date) to `ZAI_MODEL_CATALOG`; set **glm-5.2 = 2026-06-13** (its real launch date, [confirmed via z.ai coverage](https://aitoolly.com/ai-news/article/2026-06-14-zhipu-ai-releases-glm-52-a-fully-open-source-frontier-model-featuring-a-1m-context-window)). Only consumed for z.ai-**exclusive** models — on-OpenRouter models take OpenRouter's `created` via the merge.

## bot-client
- **Recency sort fix**: thread `released` → the synthetic model's `created` (Unix seconds) so glm-5.2 ranks correctly in "newest" instead of sinking last.
- **`zaiDisplayName` acronyms**: title-case via an acronym set (`GLM`/`VL`/`R1`/…) instead of only special-casing GLM.
- **Browse caches** (new `browseUserCache.ts`): 30s-TTL caches for the wallet-provider set (per-user) and the global-preset id set (global, single-key) so paging the browser doesn't re-hit the gateway on every press. Short TTL so a just-added key reflects within a flip or two. Failures aren't cached (wallet failure → `null` → ❔; preset failure → no pinning).

## Tests
New `browseUserCache.test.ts` (hit/miss/failure/per-user-keying for both caches); browse tests reset the caches in `beforeEach`. All model + cache suites green; `turbo run typecheck` + `pnpm quality` clean.

## Follow-up bookkeeping (post-merge, doc-only)
Remove the now-shipped preset-cache quick-win + `zaiDisplayName` deferred entry; re-scope the by-id-route deferred entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)