### PR TITLE
test: enable ESLint on test files + deflake timing tests

### DIFF
--- a/backlog/inbox.md
+++ b/backlog/inbox.md
@@ -2,21 +2,6 @@
 
 _New items go here. Triage to appropriate section weekly._
 
-### `[LIFT]` Enforce fake-timers in unit tests — sweep real-timer flakes + add a lint gate
-
-**Surfaced 2026-06-15 (user)** after two distinct timing-flakes in one session (both on deps-only PRs, both rerun-green): `ReferencedMessageFormatter.test.ts › "transcribe voice messages in parallel"` (asserted `Date.now() - start < 250` over real `setTimeout(100)`s) and `ConversationHistoryService.int.test.ts › "exclude older channels when limit is smaller"` (rapid inserts tie on `createdAt`, no ORDER BY tiebreak). `02-code-standards.md` already mandates "Fake Timers — ALWAYS Use," but nothing enforces it, so real-timer tests slip in.
-
-**Scope** (measured): ~10 `*.test.ts` use real `setTimeout` delays (`new Promise(r => setTimeout(r, N))`); 9 of those already use fake timers elsewhere in the same file (stray real delays). Some real delays in `*.int.test.ts` are legitimate (real Redis/PGLite I/O waits). The `Date.now()`-elapsed-assertion anti-pattern (the actual flake source) is separate and not cleanly greppable.
-
-**Action**:
-1. Sweep the ~10 real-delay offenders — convert unit-test cases to fake timers + advance-time assertions; confirm `*.int.test.ts` delays are genuine I/O waits and leave them.
-2. Add an ESLint `no-restricted-syntax` rule banning `setTimeout`-with-numeric-delay in `*.test.ts`, allowlisting `*.int.test.ts` — turns the existing "always use fake timers" convention into an enforced gate (same pattern as `gatewayAccessGuard`).
-3. The harder `Date.now()`-elapsed-as-proxy assertions: fix in the sweep (replace with logical assertions); not lint-enforceable.
-
-**Why out of scope of the immediate fix**: the 2 tests that actually flaked today get a focused deflake PR; this `[LIFT]` is the systemic sweep + enforcement so it can't recur.
-
-**Note**: the 2 known offenders' fixes ship in the deflake PR; do NOT re-fix them here.
-
 ### `[FEAT]` Multimodal input: file (PDF/doc) + video forwarding, then surface in `/models`
 
 **Surfaced 2026-06-15 (user)** while reviewing `/models browse` modality coverage. OpenRouter's `ModelModality` is `text | image | audio | video | file`, but we only capture/route **text, image, audio**. `video` and `file` (PDF/doc) input modalities are dropped from `ModelAutocompleteOption` (`OpenRouterModelCache.toAutocompleteOption`), and — more fundamentally — the bot can't *send* them: `MessageContentBuilder` renders every non-voice/non-image attachment as a **text description** (`[Attachments: [application/pdf: doc.pdf]]`), never as native model input. So surfacing `supportsFileInput`/`supportsVideoInput` today would over-promise.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,7 @@ import sonarjs from 'eslint-plugin-sonarjs';
 import * as regexpPlugin from 'eslint-plugin-regexp';
 import importPlugin from 'eslint-plugin-import-x';
 import tzurotPlugin from './packages/tooling/dist/eslint/index.js';
+import vitest from '@vitest/eslint-plugin';
 
 // Get the directory name of the current module (monorepo root)
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -166,8 +167,10 @@ export default tseslint.config(
       '**/*.mjs',
       '**/*.d.ts',
       '**/*.tsbuildinfo',
-      '**/*.test.ts',
-      '**/*.spec.ts',
+      // Test files are NO LONGER globally ignored — they get a dedicated,
+      // type-checking-disabled config block below (vitest correctness rules +
+      // a fake-timer ban). The main `**/*.ts` block excludes them so its
+      // type-aware/size rules don't apply.
       'coverage/**',
       '.pnpm-store/**',
       '**/vitest.config.ts',
@@ -226,9 +229,12 @@ export default tseslint.config(
     },
   },
 
-  // Configuration for TypeScript files
+  // Configuration for TypeScript files (production + tooling source).
+  // Test files are excluded here and handled by the dedicated test block below
+  // (type-checking disabled, size/complexity off, vitest correctness rules on).
   {
     files: ['**/*.ts'],
+    ignores: ['**/*.test.ts', '**/*.spec.ts'],
     plugins: {
       '@tzurot': tzurotPlugin,
       sonarjs,
@@ -477,6 +483,97 @@ export default tseslint.config(
       'max-depth': ['warn', { max: 5 }], // ESLint rules can be deeply nested
       curly: 'off', // Allow compact conditional returns in CLI
       'no-restricted-syntax': 'off', // console.error is fine in CLI tools (not pino logger)
+    },
+  },
+
+  // ── Test files ───────────────────────────────────────────────────────────
+  // Tests were historically excluded from ESLint entirely (to dodge max-lines
+  // noise), which also dropped correctness signal. Per council review we lint
+  // them WITHOUT type-checking (the type-project cost over ~800 test files isn't
+  // worth it; vitest/node already fail on unhandled rejections) and WITHOUT the
+  // size/complexity family (handled by excluding tests from the main block).
+  // What we DO enforce: vitest correctness rules + a fake-timer ban.
+  {
+    files: ['**/*.test.ts', '**/*.spec.ts'],
+    plugins: { vitest },
+    languageOptions: {
+      // No type-aware project — these rules are all syntactic.
+      parserOptions: { projectService: false, project: false },
+    },
+    rules: {
+      // Turn off every type-aware rule pulled in by the global
+      // recommendedTypeChecked/stylisticTypeChecked spreads (they'd error with
+      // no project). Keeps the syntactic js.configs.recommended rules on.
+      ...tseslint.configs.disableTypeChecked.rules,
+      // Syntactic rules that are legitimate in tests but noise as errors —
+      // disabled per council review (mocks/fixtures need `any`, `!`, empty
+      // stubs; Array<T> vs T[] and inferrable types are pure style).
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'off',
+      '@typescript-eslint/no-empty-function': 'off',
+      '@typescript-eslint/array-type': 'off',
+      '@typescript-eslint/no-inferrable-types': 'off',
+      '@typescript-eslint/consistent-type-definitions': 'off',
+      '@typescript-eslint/ban-ts-comment': 'off', // tests legitimately use @ts-expect-error
+      // High-signal, low-false-positive vitest rules. no-unused-vars stays ON
+      // (dead test imports are real).
+      //
+      // vitest/valid-expect is deliberately NOT enabled: it flags the deferred
+      // fake-timer rejection idiom this codebase uses heavily (assign the
+      // unawaited assertion, advance timers, then await it — see 02-code-standards.md
+      // "Promise rejections with fake timers"), and its autofix rewrites that to
+      // `await expect(...)` BEFORE the timer advance, deadlocking the test. The
+      // rule cannot see the later await, so it's a false-positive generator whose
+      // --fix actively breaks correct code.
+      //
+      // expect-expect: a test() with no assertion. assertFunctionNames teaches it
+      // the project's custom assertion helpers + vitest's type-level matcher so
+      // tests that assert through them aren't false-flagged.
+      'vitest/expect-expect': [
+        'error',
+        {
+          assertFunctionNames: [
+            'expect',
+            'expectTypeOf',
+            'assertValidCustomId',
+            'assertParentBeforeChild',
+          ],
+        },
+      ],
+      // Match the project's `_`-prefix escape hatch (intentional unused
+      // params/vars in mock signatures) so it doesn't flood with false positives.
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
+    },
+  },
+  // Unit tests only: ban real wall-clock delays. Integration tests
+  // (*.int.test.ts) legitimately wait on real Redis/PGLite I/O, so they're
+  // exempt. The Date.now() ban was evaluated and dropped — 279 legitimate
+  // non-timing uses (ID/timestamp generation) made it pure noise.
+  {
+    files: ['**/*.test.ts', '**/*.spec.ts'],
+    ignores: ['**/*.int.test.ts'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          // Enforcement boundary: matches a *literal* positive delay only
+          // (`setTimeout(fn, 100)`). It cannot catch `setTimeout(fn, TIMEOUT_MS)`
+          // where the delay is an identifier — static analysis can't evaluate the
+          // runtime value. The literal form is the common flake source; the
+          // identifier form is rare in tests and accepted as a gap.
+          selector:
+            "CallExpression[callee.name='setTimeout'][arguments.1.type='Literal'][arguments.1.value>0]",
+          message:
+            'Real setTimeout delay in a unit test causes flakes — use vi.useFakeTimers() + vi.advanceTimersByTimeAsync(). Real delays are allowed in *.int.test.ts.',
+        },
+      ],
     },
   }
 );

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@typescript-eslint/eslint-plugin": "^8.61.0",
     "@typescript-eslint/parser": "^8.61.0",
     "@vitest/coverage-v8": "^4.1.9",
+    "@vitest/eslint-plugin": "^1.6.20",
     "dependency-cruiser": "^17.4.3",
     "dotenv": "^17.4.2",
     "eslint": "^10.5.0",

--- a/packages/clients/src/routes/types.test.ts
+++ b/packages/clients/src/routes/types.test.ts
@@ -159,6 +159,7 @@ describe('createPaginationSchema', () => {
   });
 
   it('preserves typed sortFields at the type level', () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- used below in `typeof schema`; the non-type-aware test lint can't see type-position usage
     const schema = createPaginationSchema(['createdAt', 'updatedAt']);
     // Type-level assertion: sort is narrowed to the tuple, not generic string
     expectTypeOf<z.infer<typeof schema>['sort']>().toEqualTypeOf<

--- a/packages/common-types/src/schemas/api/internal.test.ts
+++ b/packages/common-types/src/schemas/api/internal.test.ts
@@ -48,7 +48,9 @@ describe('DiscordSnowflakeSchema', () => {
   });
 
   it('rejects non-string inputs (numbers)', () => {
-    expect(DiscordSnowflakeSchema.safeParse(123456789012345678).success).toBe(false);
+    // Value is arbitrary — the schema rejects all non-string input. Kept within
+    // Number.MAX_SAFE_INTEGER so the literal carries no precision-loss surprise.
+    expect(DiscordSnowflakeSchema.safeParse(1234567890123456).success).toBe(false);
   });
 });
 

--- a/packages/common-types/src/services/ConversationHistoryService.int.test.ts
+++ b/packages/common-types/src/services/ConversationHistoryService.int.test.ts
@@ -768,7 +768,9 @@ describe('ConversationHistoryService Component Test', () => {
       const chExclude = 'cross-limit-ch1';
       const chOther = 'cross-limit-ch2';
 
-      // Add 5 messages to other channel
+      // Add 5 messages to other channel with strictly-increasing timestamps so the
+      // "3 most recent" assertion is deterministic regardless of insert-time ties.
+      const base = new Date('2026-01-01T00:00:00Z').getTime();
       for (let i = 0; i < 5; i++) {
         await service.addMessage({
           channelId: chOther,
@@ -777,6 +779,7 @@ describe('ConversationHistoryService Component Test', () => {
           role: MessageRole.User,
           content: `Cross-channel message ${i}`,
           guildId: testGuildId,
+          timestamp: new Date(base + i * 1000),
         });
       }
 
@@ -800,6 +803,11 @@ describe('ConversationHistoryService Component Test', () => {
       const chOlder = 'cross-exclude-ch2';
       const chNewer = 'cross-exclude-ch3';
 
+      // Explicit strictly-increasing timestamps: every chNewer message is newer than
+      // every chOlder one, so the limit=3 cutoff deterministically keeps only chNewer.
+      // Without this the inserts could share a timestamp and the cutoff would be arbitrary.
+      const base = new Date('2026-01-01T00:00:00Z').getTime();
+
       // Add 2 older messages to chOlder
       for (let i = 0; i < 2; i++) {
         await service.addMessage({
@@ -809,10 +817,11 @@ describe('ConversationHistoryService Component Test', () => {
           role: MessageRole.User,
           content: `Channel 2 older ${i}`,
           guildId: testGuildId,
+          timestamp: new Date(base + i * 1000),
         });
       }
 
-      // Add 3 newer messages to chNewer
+      // Add 3 newer messages to chNewer (all strictly after the chOlder pair)
       for (let i = 0; i < 3; i++) {
         await service.addMessage({
           channelId: chNewer,
@@ -821,6 +830,7 @@ describe('ConversationHistoryService Component Test', () => {
           role: MessageRole.User,
           content: `Channel 3 recent ${i}`,
           guildId: testGuildId,
+          timestamp: new Date(base + 10_000 + i * 1000),
         });
       }
 

--- a/packages/common-types/src/services/ConversationHistoryService.test.ts
+++ b/packages/common-types/src/services/ConversationHistoryService.test.ts
@@ -1123,7 +1123,7 @@ describe('ConversationHistoryService - Token Count Caching', () => {
             channelId: { not: 'current-channel' },
             deletedAt: null,
           },
-          orderBy: { createdAt: 'desc' },
+          orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
           take: 50,
           select: expect.objectContaining({
             channelId: true,

--- a/packages/common-types/src/services/ConversationHistoryService.ts
+++ b/packages/common-types/src/services/ConversationHistoryService.ts
@@ -15,6 +15,7 @@ import { countTextTokens } from '../utils/tokenCounter.js';
 import type { MessageMetadata } from '../types/schemas/index.js';
 import {
   conversationHistorySelect,
+  conversationRecencyOrderBy,
   mapToConversationMessage,
   mapToConversationMessages,
   type ConversationMessage,
@@ -249,9 +250,7 @@ export class ConversationHistoryService {
             },
           }),
         },
-        orderBy: {
-          createdAt: 'desc',
-        },
+        orderBy: conversationRecencyOrderBy,
         take: safeLimit + 1, // Fetch one extra to check if there are more
         ...(cursor !== undefined && cursor.length > 0 ? { cursor: { id: cursor }, skip: 1 } : {}),
         select: conversationHistorySelect,
@@ -400,9 +399,7 @@ export class ConversationHistoryService {
           deletedAt: null,
           ...(cutoff !== undefined ? { createdAt: { gte: cutoff } } : {}),
         },
-        orderBy: {
-          createdAt: 'desc',
-        },
+        orderBy: conversationRecencyOrderBy,
         take: limit,
         select: conversationHistorySelect,
       });
@@ -461,9 +458,7 @@ export class ConversationHistoryService {
           deletedAt: null,
           ...(cutoff !== undefined ? { createdAt: { gte: cutoff } } : {}),
         },
-        orderBy: {
-          createdAt: 'desc',
-        },
+        orderBy: conversationRecencyOrderBy,
         take: safeLimit,
         select: conversationHistorySelect,
       });

--- a/packages/common-types/src/services/ConversationMessageMapper.ts
+++ b/packages/common-types/src/services/ConversationMessageMapper.ts
@@ -88,6 +88,20 @@ export type ConversationHistoryQueryResult = Prisma.ConversationHistoryGetPayloa
 }>;
 
 /**
+ * Default ordering for conversation-history queries: by createdAt (newest first),
+ * with a *stable* `id` tiebreak so the order — and therefore which rows survive a
+ * `take` limit — is deterministic when multiple rows share a createdAt timestamp.
+ * The tiebreak is for stability, not recency: ids are deterministic UUIDs, not
+ * monotonic, so among equal-timestamp rows the order is consistent-but-arbitrary.
+ * Without the tiebreak the database breaks ties however it likes, which makes
+ * `take`-bounded queries (channel history, cross-channel history) flaky.
+ */
+export const conversationRecencyOrderBy: Prisma.ConversationHistoryOrderByWithRelationInput[] = [
+  { createdAt: 'desc' },
+  { id: 'desc' },
+];
+
+/**
  * Safely parse messageMetadata from database JSONB column
  * Returns undefined if validation fails (logs warning)
  */

--- a/packages/common-types/src/services/UserService.test.ts
+++ b/packages/common-types/src/services/UserService.test.ts
@@ -107,7 +107,7 @@ describe('UserService', () => {
       // need to configure it per-test.
       $executeRaw: vi.fn().mockResolvedValue(1),
     };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Test mock for Prisma client
+
     userService = new UserService(mockPrisma as any);
   });
 

--- a/packages/tooling/src/codegen/routes.test.ts
+++ b/packages/tooling/src/codegen/routes.test.ts
@@ -81,7 +81,7 @@ describe('generateAllClients', () => {
     const summary = summarizeManifest();
     const totalMethods = Object.values(files).reduce((acc, src) => {
       // Count `async <id>(` occurrences (excluding the helper line)
-      const matches = src.matchAll(/^  async (\w+)\(/gm);
+      const matches = src.matchAll(/^ {2}async (\w+)\(/gm);
       return acc + [...matches].length;
     }, 0);
     expect(totalMethods).toBe(summary.total);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.9
         version: 4.1.9(vitest@4.1.9)
+      '@vitest/eslint-plugin':
+        specifier: ^1.6.20
+        version: 1.6.20(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9)
       dependency-cruiser:
         specifier: ^17.4.3
         version: 17.4.3
@@ -2504,6 +2507,22 @@ packages:
       vitest: 4.1.9
     peerDependenciesMeta:
       '@vitest/browser':
+        optional: true
+
+  '@vitest/eslint-plugin@1.6.20':
+    resolution: {integrity: sha512-xRwWHFG0Utp6hXtbGiWk4VdKXCGdExD8kbWrrmFEiG5dk8anOJ+vbWbeOa8EbkocKQRTsx7JAWETccZiBgFp/Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': '*'
+      eslint: '>=8.57.0'
+      typescript: '>=5.0.0'
+      vitest: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+      typescript:
+        optional: true
+      vitest:
         optional: true
 
   '@vitest/expect@4.1.9':
@@ -7061,6 +7080,18 @@ snapshots:
       std-env: 4.1.0
       tinyrainbow: 3.1.0
       vitest: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+
+  '@vitest/eslint-plugin@1.6.20(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.61.0
+      '@typescript-eslint/utils': 8.61.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.5.0(jiti@2.7.0)
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      typescript: 6.0.3
+      vitest: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/expect@4.1.9':
     dependencies:

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/generationStepValidation.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/generationStepValidation.test.ts
@@ -37,7 +37,6 @@ describe('validatePrerequisites', () => {
         job: fakeJob,
         startTime: 0,
         config: {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- intentionally minimal for the validation-only test
           effectivePersonality: {} as any,
           configSource: 'personality',
         },
@@ -52,7 +51,6 @@ describe('validatePrerequisites', () => {
         job: fakeJob,
         startTime: 0,
         config: {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- intentionally minimal for the validation-only test
           effectivePersonality: {} as any,
           configSource: 'personality',
         },
@@ -72,7 +70,6 @@ describe('validatePrerequisites', () => {
         job: fakeJob,
         startTime: 0,
         config: {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- intentionally minimal for the validation-only test
           effectivePersonality: {} as any,
           configSource: 'personality',
         },

--- a/services/ai-worker/src/services/AttachmentProcessor.test.ts
+++ b/services/ai-worker/src/services/AttachmentProcessor.test.ts
@@ -139,16 +139,23 @@ describe('AttachmentProcessor', () => {
     });
 
     it('should process multiple attachments in parallel', async () => {
-      mockDescribeImage.mockImplementation(async () => {
-        await new Promise(resolve => setTimeout(resolve, 50));
-        return 'Image description';
-      });
-      mockTranscribeAudio.mockImplementation(async () => {
-        await new Promise(resolve => setTimeout(resolve, 50));
-        return 'Voice transcription';
-      });
+      // Prove concurrency directly instead of via wall-clock timing: track how many
+      // processing callbacks are in-flight simultaneously. Promise.allSettled dispatch
+      // means both the image and voice mocks enter before either resolves, so the peak
+      // overlap is > 1. Sequential processing would never exceed 1. This is deterministic
+      // (no real delays), so it can't flake under load.
+      let inFlight = 0;
+      let maxInFlight = 0;
+      const trackOverlap = async <T>(value: T): Promise<T> => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await Promise.resolve(); // suspend so concurrently-dispatched callbacks overlap
+        inFlight--;
+        return value;
+      };
+      mockDescribeImage.mockImplementation(() => trackOverlap('Image description'));
+      mockTranscribeAudio.mockImplementation(() => trackOverlap('Voice transcription'));
 
-      const startTime = Date.now();
       const result = await processAttachmentsParallel({
         attachments: [
           {
@@ -176,15 +183,14 @@ describe('AttachmentProcessor', () => {
         personality: mockPersonality,
         isGuestMode: false,
       });
-      const duration = Date.now() - startTime;
 
       expect(result).toHaveLength(3);
       expect(result[0]).toContain('- Image (photo.png)');
       expect(result[1]).toContain('- Voice Message (5s)');
       expect(result[2]).toBe('- File: doc.pdf (application/pdf)');
 
-      // Should be parallel, not sequential
-      expect(duration).toBeLessThan(200);
+      // Image + voice callbacks were in-flight at the same time → concurrent dispatch.
+      expect(maxInFlight).toBeGreaterThan(1);
     });
 
     it('should handle image processing failures gracefully', async () => {

--- a/services/ai-worker/src/services/DiagnosticCollector.test.ts
+++ b/services/ai-worker/src/services/DiagnosticCollector.test.ts
@@ -733,15 +733,14 @@ describe('DiagnosticCollector', () => {
   });
 
   describe('timing', () => {
-    it('should calculate total duration', async () => {
-      vi.useRealTimers(); // Need real timers for this test
-
+    it('should calculate total duration', () => {
+      // Fake timers (from beforeEach) make the elapsed-time math deterministic: advancing
+      // the clock by 15ms also advances Date.now(), so the measured duration is exactly 15.
       const startCollector = new DiagnosticCollector(defaultOptions);
-      await new Promise(resolve => setTimeout(resolve, 15));
+      vi.advanceTimersByTime(15);
       const payload = startCollector.finalize();
 
-      // Use slightly lower threshold than sleep time to account for timer imprecision
-      expect(payload.timing.totalDurationMs).toBeGreaterThanOrEqual(10);
+      expect(payload.timing.totalDurationMs).toBe(15);
     });
 
     it('should calculate memory retrieval timing', () => {

--- a/services/ai-worker/src/services/LLMInvoker.test.ts
+++ b/services/ai-worker/src/services/LLMInvoker.test.ts
@@ -517,6 +517,7 @@ describe('LLMInvoker', () => {
           invoke: vi.fn().mockImplementation(
             () =>
               new Promise((_, reject) => {
+                // eslint-disable-next-line no-restricted-syntax -- Mocked 70s model latency under vi.useFakeTimers(); flushed by runAllTimersAsync below, not a real delay
                 setTimeout(() => reject({ code: 'ETIMEDOUT', message: 'Timeout' }), 70000);
               })
           ),

--- a/services/ai-worker/src/services/RAGUtils.test.ts
+++ b/services/ai-worker/src/services/RAGUtils.test.ts
@@ -352,9 +352,10 @@ describe('RAGUtils', () => {
         ['discord-msg-1', [{ filename: 'img.png', description: 'A photo' }]],
       ]);
 
-      // Should not throw
-      injectImageDescriptions([], imageMap);
-      injectImageDescriptions(undefined, imageMap);
+      expect(() => {
+        injectImageDescriptions([], imageMap);
+        injectImageDescriptions(undefined, imageMap);
+      }).not.toThrow();
     });
 
     it('should handle empty imageMap', () => {

--- a/services/ai-worker/src/services/ReferencedMessageFormatter.test.ts
+++ b/services/ai-worker/src/services/ReferencedMessageFormatter.test.ts
@@ -380,9 +380,18 @@ describe('ReferencedMessageFormatter', () => {
 
   describe('Image attachment processing', () => {
     it('should process image attachments in parallel', async () => {
+      // Prove concurrency directly rather than via wall-clock timing: count how many
+      // describeImage callbacks overlap. Attachment processing dispatches via
+      // Promise.allSettled, so all three enter before any resolves (peak overlap = 3);
+      // sequential processing would never exceed 1. Deterministic — no real delays to flake.
+      let inFlight = 0;
+      let maxInFlight = 0;
       // Use hoisted mock directly (mockDescribeImage from vi.hoisted())
       mockDescribeImage.mockImplementation(async (attachment: { name: string }) => {
-        await new Promise(resolve => setTimeout(resolve, 100)); // Simulate processing time
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await Promise.resolve(); // suspend so concurrently-dispatched callbacks overlap
+        inFlight--;
         return `Description of ${attachment.name}`;
       });
 
@@ -421,9 +430,7 @@ describe('ReferencedMessageFormatter', () => {
         },
       ];
 
-      const startTime = Date.now();
       const result = await formatter.formatReferencedMessages(references, mockPersonality);
-      const duration = Date.now() - startTime;
 
       // Verify all images were processed
       expect(mockDescribeImage).toHaveBeenCalledTimes(3);
@@ -431,9 +438,8 @@ describe('ReferencedMessageFormatter', () => {
       expect(result).toContain('- Image (image2.png): Description of image2.png');
       expect(result).toContain('- Image (image3.png): Description of image3.png');
 
-      // Verify parallel processing (should take ~100ms not ~300ms)
-      // Allow some overhead but ensure it's significantly faster than sequential
-      expect(duration).toBeLessThan(250);
+      // All three describeImage callbacks were in-flight simultaneously → parallel processing.
+      expect(maxInFlight).toBe(3);
     });
 
     it('should handle image processing failures gracefully', async () => {
@@ -530,9 +536,17 @@ describe('ReferencedMessageFormatter', () => {
 
   describe('Voice message processing', () => {
     it('should transcribe voice messages in parallel', async () => {
+      // Prove concurrency directly rather than via wall-clock timing: count overlapping
+      // transcribe callbacks. Both voice messages dispatch via Promise.allSettled, so peak
+      // overlap = 2; sequential would never exceed 1. Deterministic — no real delays.
+      let inFlight = 0;
+      let maxInFlight = 0;
       // Use hoisted mock directly
       mockTranscribeAudio.mockImplementation(async (attachment: { duration: number }) => {
-        await new Promise(resolve => setTimeout(resolve, 100));
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await Promise.resolve(); // suspend so concurrently-dispatched callbacks overlap
+        inFlight--;
         return {
           text: `Transcription of voice ${attachment.duration}s`,
           actualProvider: 'voice-engine',
@@ -572,16 +586,14 @@ describe('ReferencedMessageFormatter', () => {
         },
       ];
 
-      const startTime = Date.now();
       const result = await formatter.formatReferencedMessages(references, mockPersonality);
-      const duration = Date.now() - startTime;
 
       expect(mockTranscribeAudio).toHaveBeenCalledTimes(2);
       expect(result).toContain('- Voice Message (5s): "Transcription of voice 5s"');
       expect(result).toContain('- Voice Message (10s): "Transcription of voice 10s"');
 
-      // Verify parallel processing
-      expect(duration).toBeLessThan(250);
+      // Both transcribe callbacks were in-flight simultaneously → parallel processing.
+      expect(maxInFlight).toBe(2);
     });
 
     it('should handle voice transcription failures gracefully', async () => {

--- a/services/ai-worker/src/services/StopSequenceTracker.test.ts
+++ b/services/ai-worker/src/services/StopSequenceTracker.test.ts
@@ -122,18 +122,22 @@ describe('StopSequenceTracker', () => {
       expect(Object.keys(stats.byModel)).toHaveLength(0);
     });
 
-    it('should reset the startedAt timestamp', async () => {
-      const beforeReset = getStopSequenceStats().startedAt;
+    it('should reset the startedAt timestamp', () => {
+      // Fake timers make the timestamp advance deterministic — no real wait to flake.
+      vi.useFakeTimers();
+      try {
+        resetStopSequenceStats();
+        const beforeReset = getStopSequenceStats().startedAt;
 
-      // Wait a small amount of real time to ensure different timestamp
-      await new Promise(resolve => setTimeout(resolve, 5));
-      resetStopSequenceStats();
+        vi.advanceTimersByTime(5); // move the clock forward so the next reset differs
+        resetStopSequenceStats();
 
-      const afterReset = getStopSequenceStats().startedAt;
-      // After reset, startedAt should be >= the previous value
-      expect(new Date(afterReset).getTime()).toBeGreaterThanOrEqual(
-        new Date(beforeReset).getTime()
-      );
+        const afterReset = getStopSequenceStats().startedAt;
+        // After reset, startedAt tracks the advanced clock.
+        expect(new Date(afterReset).getTime()).toBeGreaterThan(new Date(beforeReset).getTime());
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/services/ai-worker/src/services/UserReferenceResolver.test.ts
+++ b/services/ai-worker/src/services/UserReferenceResolver.test.ts
@@ -775,8 +775,6 @@ describe('UserReferenceResolver', () => {
     });
 
     it('should process fields in parallel', async () => {
-      vi.useFakeTimers();
-
       const shapesUserId = '98a94b95-cbd0-430b-8be2-602e1c75d8b0';
       const personality = createMockPersonality({
         systemPrompt: `@[user](user:${shapesUserId})`,
@@ -784,11 +782,19 @@ describe('UserReferenceResolver', () => {
         conversationalExamples: `@[user](user:${shapesUserId})`,
       });
 
+      // Prove concurrency directly rather than via timer advancement: the three field
+      // lookups dispatch via Promise.allSettled, so all three enter findMany before any
+      // resolves (peak overlap = 3). Sequential resolution would never exceed 1.
+      // Deterministic — no real or fake delays needed.
       let callCount = 0;
+      let inFlight = 0;
+      let maxInFlight = 0;
       mockPrisma.shapesPersonaMapping.findMany.mockImplementation(async () => {
         callCount++;
-        // Simulate async delay
-        await new Promise(resolve => setTimeout(resolve, 10));
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await Promise.resolve(); // suspend so concurrently-dispatched lookups overlap
+        inFlight--;
         return [
           {
             shapesUserId,
@@ -803,21 +809,12 @@ describe('UserReferenceResolver', () => {
         ];
       });
 
-      // Start the resolution (don't await yet)
-      const resultPromise = resolver.resolvePersonalityReferences(personality);
+      const result = await resolver.resolvePersonalityReferences(personality);
 
-      // Advance timers - if parallel, one tick of 10ms should resolve all
-      // If sequential, would need 30ms (3 * 10ms)
-      await vi.advanceTimersByTimeAsync(15);
-
-      // Should complete with parallel execution
-      const result = await resultPromise;
-
-      // Should have made 3 DB calls (one per field with reference)
+      // Should have made 3 DB calls (one per field with reference), all in-flight at once.
       expect(callCount).toBe(3);
+      expect(maxInFlight).toBe(3);
       expect(result.resolvedPersonality.systemPrompt).toBe('Resolved');
-
-      vi.useRealTimers();
     });
   });
 });

--- a/services/ai-worker/src/services/voice/providers/ElevenLabsTtsProvider.test.ts
+++ b/services/ai-worker/src/services/voice/providers/ElevenLabsTtsProvider.test.ts
@@ -37,7 +37,7 @@ describe('ElevenLabsTtsProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     voiceService = makeService();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Test double for ElevenLabsVoiceService
+
     provider = new ElevenLabsTtsProvider(voiceService as any);
   });
 
@@ -188,7 +188,6 @@ describe('ElevenLabsTtsProvider', () => {
     });
 
     it('rejects inlineAudio handles', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Hand-built handle for test
       const stateless: any = {
         _brand: 'prepared',
         kind: 'inlineAudio',

--- a/services/ai-worker/src/services/voice/providers/MistralTtsProvider.test.ts
+++ b/services/ai-worker/src/services/voice/providers/MistralTtsProvider.test.ts
@@ -676,7 +676,7 @@ describe('MistralTtsProvider', () => {
         mimeType: 'audio/wav',
         provider: 'mistral',
       };
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Hand-built handle for test
+
       await expect(
         provider.synthesize('x', stateless as any, { slug: 's', byokKey: 'k' })
       ).rejects.toThrow(/inlineAudio/);

--- a/services/ai-worker/src/services/voice/providers/SelfHostedTtsProvider.test.ts
+++ b/services/ai-worker/src/services/voice/providers/SelfHostedTtsProvider.test.ts
@@ -36,7 +36,7 @@ describe('SelfHostedTtsProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     regService = makeService();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Test double for VoiceRegistrationService
+
     provider = new SelfHostedTtsProvider(regService as any);
   });
 
@@ -141,7 +141,6 @@ describe('SelfHostedTtsProvider', () => {
     });
 
     it('rejects inlineAudio handles', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Hand-built handle for test
       const stateless: any = {
         _brand: 'prepared',
         kind: 'inlineAudio',

--- a/services/api-gateway/src/routes/admin/invalidateCache.test.ts
+++ b/services/api-gateway/src/routes/admin/invalidateCache.test.ts
@@ -38,7 +38,7 @@ describe('POST /admin/invalidate-cache', () => {
     // Create Express app with invalidate cache router
     const deps: RouteDeps = {
       prisma: {} as PrismaClient,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock service satisfies the interface at the call sites the handler exercises
+
       cacheInvalidationService: cacheInvalidationService as any,
     };
     app = express();

--- a/services/api-gateway/src/routes/user/conversationLookup.test.ts
+++ b/services/api-gateway/src/routes/user/conversationLookup.test.ts
@@ -64,9 +64,7 @@ describe('conversationLookup routes', () => {
   describe('GET /conversation/message-personality', () => {
     // Helper to get the route handler directly
     function getHandler() {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Test utility accessing router internals
       const layer = (router as any).stack.find(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Test utility accessing router internals
         (l: any) => l.route?.path === '/message-personality'
       );
       return layer?.route?.stack[0]?.handle;

--- a/services/api-gateway/src/routes/user/llm-config.int.test.ts
+++ b/services/api-gateway/src/routes/user/llm-config.int.test.ts
@@ -99,12 +99,14 @@ describe('LLM Config Resolution Integration', () => {
     // NULL, so we can't "unlink" the default persona before deleting — instead,
     // deleting the user cascades to its personas via the reverse owner FK.
     const testUser = await prisma.user.findFirst({
+      // eslint-disable-next-line no-restricted-syntax -- Integration-test fixture teardown, not a route handler: there is no req.provisionedUserId during DB cleanup, so looking up by discordId is correct here
       where: { discordId: TEST_DISCORD_ID },
     });
     if (testUser) {
       await prisma.llmConfig.deleteMany({ where: { ownerId: testUser.id } });
     }
 
+    // eslint-disable-next-line no-restricted-syntax -- Integration-test fixture teardown, not a route handler: deleting the seeded test user by discordId is correct here
     await prisma.user.deleteMany({ where: { discordId: TEST_DISCORD_ID } });
 
     // Create test user + default persona atomically. The bare Discord ID would

--- a/services/api-gateway/src/routes/user/memoryBatch.test.ts
+++ b/services/api-gateway/src/routes/user/memoryBatch.test.ts
@@ -58,7 +58,7 @@ vi.mock('../../services/MemoryActionTokenService.js', () => ({
   // shared mockTokenService — every handler in a single test sees the same
   // instance, so configuring mockTokenService.method.mockResolvedValue(...)
   // controls all 4 handlers' behavior in lockstep.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   MemoryActionTokenService: vi.fn().mockImplementation(function (this: any) {
     return mockTokenService;
   }),

--- a/services/api-gateway/src/routes/user/persona/crud.test.ts
+++ b/services/api-gateway/src/routes/user/persona/crud.test.ts
@@ -106,7 +106,6 @@ describe('persona CRUD routes', () => {
       const { req, res } = createMockReqRes();
       await handler(req, res, vi.fn());
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- Accessing vitest mock internals for response extraction
       const response = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0] as unknown;
 
       // Validate response against the shared Zod schema - this is the contract test
@@ -147,7 +146,7 @@ describe('persona CRUD routes', () => {
       });
 
       // Also validate against schema to ensure null values pass contract
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- Accessing vitest mock internals for response extraction
+
       const response = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0] as unknown;
       const parseResult = ListPersonasResponseSchema.safeParse(response);
       expect(parseResult.success).toBe(true);

--- a/services/api-gateway/src/utils/zodHelpers.test.ts
+++ b/services/api-gateway/src/utils/zodHelpers.test.ts
@@ -69,7 +69,6 @@ describe('zodHelpers', () => {
       const result = schema.safeParse({ name: '' });
       expect(result.success).toBe(false);
       if (!result.success) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Mock Express response for testing
         sendZodError(mockRes as any, result.error);
         expect(mockRes.status).toHaveBeenCalledWith(400);
         expect(mockRes.json).toHaveBeenCalledWith(

--- a/services/bot-client/src/commands/memory/index.test.ts
+++ b/services/bot-client/src/commands/memory/index.test.ts
@@ -142,7 +142,6 @@ describe('Memory Command', () => {
       const focusGroup = json.options?.find((opt: { name: string }) => opt.name === 'focus');
       expect(focusGroup).toBeDefined();
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Discord.js command builder JSON lacks typed subcommand groups
       const focusOptions = (focusGroup as any)?.options ?? [];
       const subcommandNames = focusOptions.map((s: { name: string }) => s.name);
       expect(subcommandNames).toContain('enable');
@@ -157,7 +156,6 @@ describe('Memory Command', () => {
       );
       expect(incognitoGroup).toBeDefined();
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Discord.js command builder JSON lacks typed subcommand groups
       const incognitoOptions = (incognitoGroup as any)?.options ?? [];
       const subcommandNames = incognitoOptions.map((s: { name: string }) => s.name);
       expect(subcommandNames).toContain('enable');

--- a/services/bot-client/src/commands/settings/index.test.ts
+++ b/services/bot-client/src/commands/settings/index.test.ts
@@ -408,8 +408,8 @@ describe('Settings Command Index', () => {
         customId: 'unknown-entity::action::id',
       } as any;
 
-      // Should not throw
-      await handleButton(interaction);
+      // Unknown custom IDs are logged and ignored — the handler resolves without throwing.
+      await expect(handleButton(interaction)).resolves.toBeUndefined();
     });
   });
 
@@ -431,8 +431,8 @@ describe('Settings Command Index', () => {
         customId: 'unknown-entity::select::id',
       } as any;
 
-      // Should not throw
-      await handleSelectMenu(interaction);
+      // Unknown custom IDs are logged and ignored — the handler resolves without throwing.
+      await expect(handleSelectMenu(interaction)).resolves.toBeUndefined();
     });
   });
 

--- a/services/bot-client/src/services/DenylistCache.test.ts
+++ b/services/bot-client/src/services/DenylistCache.test.ts
@@ -586,17 +586,22 @@ describe('DenylistCache', () => {
         },
       });
 
-      // Removing a non-existent entry from the now-cleaned user should not throw
-      cache.handleEvent({
-        type: 'remove',
-        entry: {
-          type: 'USER',
-          discordId: 'user1',
-          scope: 'CHANNEL',
-          scopeId: 'chan2',
-          mode: 'BLOCK',
-        },
-      });
+      // The user's channel denial is gone after the matching removal.
+      expect(cache.isChannelDenied('user1', 'chan1')).toBe(false);
+
+      // Removing a non-existent entry from the now-cleaned user must not throw.
+      expect(() =>
+        cache.handleEvent({
+          type: 'remove',
+          entry: {
+            type: 'USER',
+            discordId: 'user1',
+            scope: 'CHANNEL',
+            scopeId: 'chan2',
+            mode: 'BLOCK',
+          },
+        })
+      ).not.toThrow();
     });
 
     it('should update mode when re-adding with different mode', () => {

--- a/services/bot-client/src/services/MultiTagCoordinator.test.ts
+++ b/services/bot-client/src/services/MultiTagCoordinator.test.ts
@@ -689,7 +689,8 @@ describe('MultiTagCoordinator', () => {
           },
         ],
         createdAt: Date.now(),
-        timeoutHandle: setTimeout(() => undefined, 100000),
+        // Throwaway handle; the coordinator clears it. 0ms leaves no real timer pending.
+        timeoutHandle: setTimeout(() => undefined, 0),
         truncated: false,
       };
 
@@ -730,7 +731,8 @@ describe('MultiTagCoordinator', () => {
           },
         ],
         createdAt: Date.now(),
-        timeoutHandle: setTimeout(() => undefined, 100000),
+        // Throwaway handle; the coordinator clears it. 0ms leaves no real timer pending.
+        timeoutHandle: setTimeout(() => undefined, 0),
         truncated: false,
       };
 

--- a/services/bot-client/src/services/VoiceTranscriptionService.test.ts
+++ b/services/bot-client/src/services/VoiceTranscriptionService.test.ts
@@ -705,7 +705,7 @@ describe('VoiceTranscriptionService', () => {
       vi.mocked(transcribe).mockImplementation(
         () =>
           new Promise(resolve => {
-            // Resolve after timers advance
+            // eslint-disable-next-line no-restricted-syntax -- Mocked 20s transcription latency under vi.useFakeTimers(); driven by advanceTimersByTimeAsync below to prove the typing-refresh interval fires during a long transcription, not a real delay
             setTimeout(() => resolve({ content: 'Transcript' }), 20000);
           })
       );

--- a/services/bot-client/src/services/multiTagCoordinatorHelpers.test.ts
+++ b/services/bot-client/src/services/multiTagCoordinatorHelpers.test.ts
@@ -52,7 +52,8 @@ function buildEntry(overrides: Partial<RuntimeEntry> = {}): RuntimeEntry {
     userMessageContent: 'hi everyone',
     slots: [buildSlot('Alice')],
     createdAt: 1737900000000,
-    timeoutHandle: setTimeout(() => undefined, 1_000_000),
+    // Throwaway handle for the fixture; never armed for real. 0ms leaves no timer pending.
+    timeoutHandle: setTimeout(() => undefined, 0),
     truncated: false,
     ...overrides,
   };

--- a/services/bot-client/src/services/multiTagDeliveryFlow.test.ts
+++ b/services/bot-client/src/services/multiTagDeliveryFlow.test.ts
@@ -69,7 +69,8 @@ function buildEntry(overrides: Partial<RuntimeEntry> = {}): RuntimeEntry {
     userMessageContent: 'hi everyone',
     slots: [buildSlot('Alice')],
     createdAt: Date.now(),
-    timeoutHandle: setTimeout(() => undefined, 100000),
+    // Throwaway handle for the fixture; never armed for real. 0ms leaves no timer pending.
+    timeoutHandle: setTimeout(() => undefined, 0),
     truncated: false,
     ...overrides,
   };

--- a/services/bot-client/src/utils/WebhookManager.test.ts
+++ b/services/bot-client/src/utils/WebhookManager.test.ts
@@ -154,18 +154,22 @@ describe('WebhookManager', () => {
   });
 
   describe('getBotSuffix (via getStandardizedUsername)', () => {
-    it('should extract suffix from tag with delimiter', () => {
+    it('should extract suffix from tag with delimiter', async () => {
       const client = createMockClient('Tzurot · Dev#0000');
       manager = new WebhookManager(client);
 
       const personality = createMockPersonality('Lilith');
-      // Access via sendAsPersonality which calls getStandardizedUsername internally
       const channel = createMockTextChannel('channel-123', 'bot-123');
 
-      // We can test the suffix by checking what username is passed to webhook.send
-      manager.getWebhook(channel).then(_webhook => {
-        manager.sendAsPersonality(channel, personality, 'Test');
-      });
+      const webhook = await manager.getWebhook(channel);
+      await manager.sendAsPersonality(channel, personality, 'Test');
+
+      // The bot tag's delimiter suffix ("Dev") is appended: "Lilith · Dev".
+      expect(webhook.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          username: 'Lilith · Dev',
+        })
+      );
     });
 
     it('should use full username when no delimiter in tag', async () => {

--- a/services/bot-client/src/utils/dashboard/ModalFactory.test.ts
+++ b/services/bot-client/src/utils/dashboard/ModalFactory.test.ts
@@ -55,10 +55,9 @@ function getModalComponents(modal: ReturnType<typeof buildSectionModal>) {
   return json.components ?? [];
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Discord.js modal component structure is untyped in test context
 function getTextInput(modal: ReturnType<typeof buildSectionModal>, index: number): any {
   const components = getModalComponents(modal);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Discord.js modal component structure is untyped in test context
+
   return (components[index] as any)?.components?.[0];
 }
 

--- a/services/bot-client/src/utils/dashboard/settings/SettingsModalFactory.test.ts
+++ b/services/bot-client/src/utils/dashboard/settings/SettingsModalFactory.test.ts
@@ -17,10 +17,9 @@ function getModalComponents(modal: ReturnType<typeof buildSettingEditModal>) {
   return json.components ?? [];
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Discord.js modal component structure is untyped in test context
 function getTextInput(modal: ReturnType<typeof buildSettingEditModal>): any {
   const components = getModalComponents(modal);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Discord.js modal component structure is untyped in test context
+
   return (components[0] as any)?.components?.[0];
 }
 

--- a/services/bot-client/src/utils/dashboard/types.test.ts
+++ b/services/bot-client/src/utils/dashboard/types.test.ts
@@ -60,7 +60,6 @@ describe('resolveContextAware', () => {
 
   describe('edge cases', () => {
     it('should handle function returning undefined', () => {
-      // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
       const fn = () => undefined as unknown as boolean;
       expect(resolveContextAware(fn, adminContext, true)).toBeUndefined();
     });

--- a/services/bot-client/src/utils/pendingVerificationMessages.test.ts
+++ b/services/bot-client/src/utils/pendingVerificationMessages.test.ts
@@ -178,7 +178,9 @@ describe('Pending Verification Messages', () => {
     });
 
     it('should return empty array on Redis error', async () => {
-      // Create an async generator that throws
+      // Create an async generator that throws on iteration to simulate a Redis
+      // scan failure. It deliberately yields nothing before throwing.
+      // eslint-disable-next-line require-yield -- intentionally throws on first iteration; no value is ever yielded
       async function* throwingStream(): AsyncGenerator<string[], void, unknown> {
         throw new Error('Redis error');
       }


### PR DESCRIPTION
## Summary

Tests were entirely excluded from ESLint (originally to dodge `max-lines` noise), which also silently dropped real correctness signal. This PR lints test files for the first time — surfacing and fixing a class of timing flakes — and fixes a real production ordering bug found via one of those flakes.

### Production fix (`fix(common-types)`)
Channel-history / paginated-history / cross-channel-history queries ordered only by `createdAt desc`. On timestamp ties (rapid inserts) the DB breaks ties arbitrarily, so a `take` limit could drop different rows run-to-run — a flaky cross-channel-history int test. Added an `id desc` tiebreak, hoisted to a shared `conversationRecencyOrderBy` constant. Int test now seeds explicit strictly-increasing timestamps.

### Test-lint enablement (`test(repo)`)
Lint test files **without** type-checking (the type-project cost over ~800 files isn't worth it) and **without** the size/complexity family, but **with**:
- `vitest/expect-expect` — configured via `assertFunctionNames` to recognize the project's custom assertion helpers (`assertValidCustomId`, `assertParentBeforeChild`) + `expectTypeOf`. This clears 46 of 51 false positives at the source — no opaque baseline files.
- `@typescript-eslint/no-unused-vars` (with the `_`-prefix escape hatch).
- A new `no-restricted-syntax` ban on real `setTimeout(_, >0)` delays in unit tests (`*.int.test.ts` exempt — they wait on real Redis/PGLite I/O).

`vitest/valid-expect` is **deliberately not enabled**: its autofix rewrites this codebase's deferred fake-timer rejection idiom (assign unawaited assertion → advance timers → await) into `await expect(...)` *before* the advance, deadlocking the test. An earlier `--fix` had already done exactly this across 8 files / 40 sites; all reverted here.

### Deflaking
- **Parallelism proofs** (AttachmentProcessor, ReferencedMessageFormatter, UserReferenceResolver) now assert peak concurrent in-flight callbacks instead of wall-clock `Date.now()` deltas — deterministic, can't flake under load.
- **Duration tests** (DiagnosticCollector, StopSequenceTracker) advance fake clocks.
- **Fixture timeout handles** (MultiTag*) use a 0ms throwaway — no lingering real timer.
- **LLMInvoker / VoiceTranscriptionService** keep their fake-timer-driven mock latency, now with justified `eslint-disable` (flushed by `runAllTimers`/`advanceTimers`).

### Genuine gaps fixed (the 5 real `expect-expect` hits)
Real assertions added to 5 assertion-free tests, including a broken fire-and-forget WebhookManager test that never awaited or asserted anything. Plus 3 lint stragglers (no-loss-of-precision, require-yield, type-only-used const) and 2 int-test `discordId` lookups with justified disables. Removed the now-implemented fake-timer-enforcement LIFT from the inbox.

## Test plan
- `pnpm quality` green (lint now covers test files).
- Targeted vitest runs green for every converted/fixed file + the ConversationHistory int suite (35/35).
- Pre-push hook (full suite) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)