### PR TITLE
fix(bot-client): crawl Discord links inside forwarded message snapshots

### DIFF
--- a/services/bot-client/src/handlers/references/strategies/LinkReferenceStrategy.test.ts
+++ b/services/bot-client/src/handlers/references/strategies/LinkReferenceStrategy.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
+import { Collection, type MessageSnapshot } from 'discord.js';
 import { LinkReferenceStrategy } from './LinkReferenceStrategy.js';
 import { ReferenceType } from '../types.js';
 import { createMockMessage } from '../../../test/mocks/Discord.mock.js';
@@ -92,6 +93,33 @@ describe('LinkReferenceStrategy', () => {
       guildId: '123',
       type: ReferenceType.LINK,
       discordUrl: 'https://ptb.discord.com/channels/123/456/789',
+    });
+  });
+
+  it('should extract links from a FORWARDED message snapshot (message.content is empty)', async () => {
+    // Forwards carry their text in messageSnapshots, not message.content. The
+    // strategy must read the snapshot so links inside forwarded text get crawled.
+    const message = createMockMessage({
+      content: '',
+      messageSnapshots: new Collection<string, MessageSnapshot>([
+        [
+          'snap-1',
+          {
+            content: 'Forwarded: see https://discord.com/channels/123/456/789',
+          } as unknown as MessageSnapshot,
+        ],
+      ]),
+    });
+
+    const result = await strategy.extract(message);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      messageId: '789',
+      channelId: '456',
+      guildId: '123',
+      type: ReferenceType.LINK,
+      discordUrl: 'https://discord.com/channels/123/456/789',
     });
   });
 });

--- a/services/bot-client/src/handlers/references/strategies/LinkReferenceStrategy.ts
+++ b/services/bot-client/src/handlers/references/strategies/LinkReferenceStrategy.ts
@@ -6,6 +6,7 @@
 
 import type { Message } from 'discord.js';
 import { createLogger, MessageLinkParser } from '@tzurot/common-types';
+import { extractForwardedContent } from '../../../utils/forwardedMessageUtils.js';
 import type { IReferenceStrategy } from './IReferenceStrategy.js';
 import { type ReferenceResult, ReferenceType } from '../types.js';
 
@@ -21,8 +22,11 @@ export class LinkReferenceStrategy implements IReferenceStrategy {
    * @returns Array of reference results from parsed links
    */
   extract(message: Message): Promise<ReferenceResult[]> {
-    // Parse message links from content
-    const links = MessageLinkParser.parseMessageLinks(message.content);
+    // Use the effective content so links embedded in a FORWARDED message's
+    // snapshot are detected — `message.content` is empty for forwards, which
+    // would otherwise drop their links from `[Reference N]` numbering.
+    // extractForwardedContent falls back to message.content for non-forwards.
+    const links = MessageLinkParser.parseMessageLinks(extractForwardedContent(message));
 
     if (links.length === 0) {
       return Promise.resolve([]);

--- a/services/bot-client/src/utils/forwardedMessageUtils.ts
+++ b/services/bot-client/src/utils/forwardedMessageUtils.ts
@@ -138,6 +138,24 @@ export function getSnapshots(message: Message): Collection<string, MessageSnapsh
  * Tries to extract content from snapshots first, falls back to main message content.
  * Handles the case where Discord doesn't populate snapshots.
  *
+ * **This is the single source of truth for a forward's text.** Any code that
+ * needs the *text a user would read* from a (possibly-forwarded) message must
+ * route through here (or accept already-extracted content as a parameter) —
+ * never re-derive from `message.content` directly, which is EMPTY for forwards.
+ * A direct read silently drops all forwarded text — the footgun behind both the
+ * forwarded-trigger-empty-content bug and forwarded links not being crawled.
+ * Safe for non-forwards: with no snapshot it returns `message.content` unchanged.
+ *
+ * Distinct, non-overlapping paths (do NOT merge them):
+ * - **raw text for rewriting** (this fn → mention/link rewriting, crawling)
+ * - **rendered content for display/history** (buildMessageContent → adds
+ *   attachment descriptions; running rewriting over it would corrupt those)
+ * - **persistence** (already-extracted `ConversationMessage.content`)
+ *
+ * Snapshot asymmetry caveat: forward snapshot content is present on the live
+ * `MESSAGE_CREATE` gateway event but ABSENT on a REST re-fetch — any refetch
+ * path that expects forward text will get empty. Capture it live, thread it.
+ *
  * @param message - Discord message (should be a forwarded message)
  * @returns Extracted content string
  */


### PR DESCRIPTION
First of the pre-beta.133 batch (forwarded-message + slash-command items).

## Problem
`LinkReferenceStrategy` detected Discord message links by scanning `message.content` — **empty for forwarded messages** (their text is in `messageSnapshots`). So links embedded inside forwarded text were never crawled, numbered, or given `[Reference N]` references.

## Fix
Route link detection through the shared `extractForwardedContent()` — snapshot content for forwards, `message.content` fallback for non-forwards. One-line change at the detection site; forwarded links now behave like inline ones.

## Audit (closes inbox #85 — message-content extraction)
Enumerated every content-extraction path and confirmed `extractForwardedContent` is the single source of truth they all route through. `LinkReferenceStrategy` was the **only** remaining re-derivation footgun (same class as the #1178 forwarded-trigger-empty-content prod bug).

**Verified NOT a footgun** (contrary to initial suspicion): `RawEnvelopeBuilder`'s `rawMessageContent = message.content` is the deliberate ground-truth field (empty-for-forwards by the context-relocation council decision; forwarded text rides the reference snapshots). Left untouched.

Documented the layering invariant (raw-text-for-rewriting vs rendered-for-display vs persistence) + the gateway-vs-REST snapshot asymmetry on `extractForwardedContent`'s JSDoc.

## Test plan
- New test: forwarded message whose snapshot contains a link → link extracted (was dropped before).
- Full reference-handler + forwarded-utils suites green (161 tests); `pnpm quality` green.
- Behavioral (dev): forward a message containing a Discord link → confirm `[Reference N]` numbering appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)