### PR TITLE
fix(clients): give gateway writes a 20s budget (method-aware timeout default)

### DIFF
--- a/packages/clients/src/clients/transport.test.ts
+++ b/packages/clients/src/clients/transport.test.ts
@@ -7,6 +7,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
+import { GATEWAY_TIMEOUTS } from '@tzurot/common-types';
 import { callGateway, callGatewayOrThrow } from './transport.js';
 import { GatewayApiError } from './errors.js';
 
@@ -102,6 +103,30 @@ describe('callGateway', () => {
     await callGateway({ ...baseOpts, baseUrl: 'https://example.test/' });
     const [url] = fetchSpy.mock.calls[0] as [string];
     expect(url).toBe('https://example.test/api/user/timezone');
+  });
+
+  it('defaults write methods (POST/PUT/PATCH/DELETE) to the WRITE timeout', async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+    for (const method of ['POST', 'PUT', 'PATCH', 'DELETE'] as const) {
+      timeoutSpy.mockClear();
+      fetchSpy.mockResolvedValueOnce(jsonResponse({ ok: true }));
+      await callGateway({ ...baseOpts, method });
+      expect(timeoutSpy).toHaveBeenCalledWith(GATEWAY_TIMEOUTS.WRITE);
+    }
+  });
+
+  it('defaults read methods (GET) to the short AUTOCOMPLETE timeout', async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ ok: true }));
+    await callGateway(baseOpts);
+    expect(timeoutSpy).toHaveBeenCalledWith(GATEWAY_TIMEOUTS.AUTOCOMPLETE);
+  });
+
+  it('lets an explicit timeoutMs override the method-aware default', async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ ok: true }));
+    await callGateway({ ...baseOpts, method: 'POST', timeoutMs: 1234 });
+    expect(timeoutSpy).toHaveBeenCalledWith(1234);
   });
 
   it('returns ok: true with the parsed data on 2xx', async () => {

--- a/packages/clients/src/clients/transport.ts
+++ b/packages/clients/src/clients/transport.ts
@@ -100,10 +100,18 @@ export async function callGateway<T>(options: TransportOptions): Promise<Gateway
     path,
     headers: extraHeaders,
     body,
-    timeoutMs = GATEWAY_TIMEOUTS.AUTOCOMPLETE,
+    timeoutMs,
     outputSchema,
     onWarn,
   } = options;
+
+  // Method-aware default: mutations default to the WRITE budget, reads to the
+  // short AUTOCOMPLETE budget. This stops a write route that forgets `timeoutMs`
+  // from silently inheriting the 2.5s read default and aborting a slow-but-fine
+  // write. An explicit `timeoutMs` on the route always wins.
+  const isWriteMethod = ['post', 'put', 'patch', 'delete'].includes(method.toLowerCase());
+  const effectiveTimeoutMs =
+    timeoutMs ?? (isWriteMethod ? GATEWAY_TIMEOUTS.WRITE : GATEWAY_TIMEOUTS.AUTOCOMPLETE);
 
   if (baseUrl.length === 0) {
     return { ok: false, error: 'baseUrl is empty', status: 0 };
@@ -129,7 +137,7 @@ export async function callGateway<T>(options: TransportOptions): Promise<Gateway
       method,
       headers,
       body: body !== undefined ? JSON.stringify(body) : undefined,
-      signal: AbortSignal.timeout(timeoutMs),
+      signal: AbortSignal.timeout(effectiveTimeoutMs),
     });
 
     if (!response.ok) {

--- a/packages/clients/src/routes/admin.ts
+++ b/packages/clients/src/routes/admin.ts
@@ -270,7 +270,7 @@ export const adminRoutes = {
     input: LlmConfigUpdateSchema,
     output: UpdateLlmConfigResponseSchema,
     meta: { idempotent: true },
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
+    timeoutMs: GATEWAY_TIMEOUTS.WRITE,
   },
 
   /** PUT /api/admin/llm-config/:id/set-default — Promote to paid default. */

--- a/packages/clients/src/routes/manifest.test.ts
+++ b/packages/clients/src/routes/manifest.test.ts
@@ -14,16 +14,18 @@ import type { AnyRouteDef } from './types.js';
 const entries = Object.entries(ROUTE_MANIFEST) as [string, AnyRouteDef][];
 
 /**
- * Route IDs asserting "this op is fast, the 2500ms transport default is fine"
- * (single-row CRUD, toggles, single lookups). Slow / external / bulk /
- * aggregate routes must NOT be listed — they declare an explicit `timeoutMs`
- * (DEFERRED/BULK), else they silently fall back to 2500ms and false-timeout.
+ * Route IDs asserting "this op is fast enough for the method-aware transport
+ * default" (single-row CRUD, toggles, single lookups). The default is method-
+ * aware: GET routes get AUTOCOMPLETE (2.5s), write methods get WRITE (20s).
+ * Slow / external / bulk / aggregate routes must NOT be listed — they declare
+ * an explicit `timeoutMs` (DEFERRED/BULK) to make their budget a conscious
+ * decision rather than leaning on the default.
  */
 const DEFAULT_TIMEOUT_OK = new Set<string>([
   // ---- internal (service-to-service single lookups / job introspection) ----
   // aiTranscribe is a sync STT wait (up to 240s) but is invoked via the raw-fetch
   // path in gatewayServiceCalls.ts (its own AbortSignal/retry), never the typed
-  // service-client — so the 2500ms manifest default is never applied to it.
+  // service-client — so the transport's manifest default is never applied to it.
   'aiTranscribe',
   'aiJobStatus',
   'recentUsers',
@@ -216,15 +218,16 @@ describe('central route manifest', () => {
   });
 
   it('every route either declares timeoutMs or is registered as default-timeout-OK', () => {
-    // Forcing function against the "silent 2500ms regression" class: the
-    // typed-client transport defaults `timeoutMs` to GATEWAY_TIMEOUTS.AUTOCOMPLETE
-    // (2500ms). A migrated route that legitimately needs more (external
-    // round-trips, multi-tier cascade, bulk work) but forgets an explicit
-    // `timeoutMs` silently falls back to 2500ms and reports false
+    // Forcing function against the "silent default-timeout regression" class:
+    // the typed-client transport applies a method-aware default when a route
+    // omits `timeoutMs` — AUTOCOMPLETE (2.5s) for GET, WRITE (20s) for write
+    // methods. A route that legitimately needs more than its method default
+    // (external round-trips, multi-tier cascade, bulk work) but forgets an
+    // explicit `timeoutMs` can silently fall back and report false
     // "Request timeout (HTTP 0)" failures on operations that actually
     // completed server-side. This test makes the fall-back a CONSCIOUS
     // decision: a route with no explicit timeoutMs must be registered in
-    // DEFAULT_TIMEOUT_OK above (asserting "this op is fast, 2500ms is fine").
+    // DEFAULT_TIMEOUT_OK above (asserting "the method-aware default suffices").
     for (const [key, route] of entries) {
       const ok = route.timeoutMs !== undefined || DEFAULT_TIMEOUT_OK.has(key);
       expect(
@@ -234,7 +237,7 @@ describe('central route manifest', () => {
           `(e.g. GATEWAY_TIMEOUTS.DEFERRED). If it is genuinely fast (single-row ` +
           `CRUD by indexed key, toggle, single lookup, simple insert), register ` +
           `its id in DEFAULT_TIMEOUT_OK. Do NOT leave it to silently fall back ` +
-          `to the 2500ms transport default.`
+          `to the method-aware transport default (AUTOCOMPLETE for GET, WRITE for mutations).`
       ).toBe(true);
     }
   });

--- a/packages/clients/src/routes/user/configs.ts
+++ b/packages/clients/src/routes/user/configs.ts
@@ -130,7 +130,7 @@ export const userConfigRoutes = {
     input: LlmConfigCreateSchema,
     output: CreateLlmConfigResponseSchema,
     requiresProvisionedUser: true,
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
+    timeoutMs: GATEWAY_TIMEOUTS.WRITE,
   },
 
   updateUserLlmConfig: {
@@ -143,7 +143,7 @@ export const userConfigRoutes = {
     output: UpdateLlmConfigResponseSchema,
     requiresProvisionedUser: true,
     meta: { idempotent: true },
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
+    timeoutMs: GATEWAY_TIMEOUTS.WRITE,
   },
 
   deleteUserLlmConfig: {
@@ -154,7 +154,7 @@ export const userConfigRoutes = {
     params: { id: z.string() },
     output: DeleteLlmConfigResponseSchema,
     requiresProvisionedUser: true,
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
+    timeoutMs: GATEWAY_TIMEOUTS.WRITE,
   },
 
   resolveUserLlmConfig: {
@@ -248,6 +248,12 @@ export const userConfigRoutes = {
     timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
+  // Override writes (this and the model/stt overrides below) deliberately keep
+  // DEFERRED (10s) rather than WRITE: they're single-row upserts with no
+  // validation cascade or cache-invalidation fan-out, so 10s is ample. The
+  // method-aware transport default backstops any future write route that omits
+  // a timeout (it gets WRITE), so leaving these at DEFERRED is a conscious
+  // shorter-budget choice, not an oversight.
   setTtsOverride: {
     audience: 'user',
     method: 'put',

--- a/packages/common-types/src/constants/discord.ts
+++ b/packages/common-types/src/constants/discord.ts
@@ -82,6 +82,14 @@ export const DISCORD_LIMITS = {
  * After deferral (deferReply), we have up to 15 minutes.
  * These timeouts are for gateway API calls that must complete
  * within Discord's interaction windows.
+ *
+ * Read/write policy: GET routes set AUTOCOMPLETE (3s-budget reads) or DEFERRED
+ * (post-defer reads). Mutations (POST/PUT/PATCH/DELETE) get WRITE — they can run
+ * validation + multi-table transactions + cache-invalidation cascades, which
+ * legitimately exceed the read budgets. The transport applies WRITE as the
+ * default for write methods when a route declares no timeout (see
+ * `callGateway`), so a new write route can't silently inherit a too-short read
+ * default. BULK_OPERATION is the explicit ceiling for batched external-API ops.
  */
 export const GATEWAY_TIMEOUTS = {
   /** Timeout for autocomplete handlers (Discord 3s limit) */
@@ -90,6 +98,13 @@ export const GATEWAY_TIMEOUTS = {
    *  10s is generous for warmed DB connections — the api-gateway now calls
    *  prisma.$connect() at startup to eliminate cold-start latency. */
   DEFERRED: 10000,
+  /** Default for mutations (POST/PUT/PATCH/DELETE). Writes can touch validation +
+   *  multi-table transactions + cache-invalidation cascades; 20s absorbs that
+   *  without falsely aborting a slow-but-succeeding write (the failure mode
+   *  behind the llm-config PUT timeouts). Still well within the 15-min
+   *  post-defer window. Applied automatically by the transport for write
+   *  methods that declare no explicit timeout. */
+  WRITE: 20_000,
   /** Extended timeout for bulk operations (e.g., clearing all cloned voices).
    *  These involve multiple sequential/batched external API calls. */
   BULK_OPERATION: 30_000,

--- a/packages/common-types/src/constants/timing.ts
+++ b/packages/common-types/src/constants/timing.ts
@@ -44,12 +44,6 @@ export const TIMEOUTS = {
   STT_GATEWAY: 240_000,
   /** BullMQ worker lock duration - maximum time a job can run before being considered stalled (20 minutes - safety net for hung jobs) */
   WORKER_LOCK_DURATION: 20 * 60 * 1000,
-  /** Client-side timeout for admin slash command → api-gateway requests (10 s).
-   * Well inside Discord's 15-minute interaction expiry — covers a healthy
-   * gateway response plus generous headroom, but short enough that a hung
-   * gateway surfaces as "Gateway unreachable" rather than letting the slash
-   * command sit in "Thinking…" until Discord's deferReply window expires. */
-  ADMIN_GATEWAY: 10_000,
   /** Default timeout for bot-client → api-gateway internal RPC calls (5 s).
    * Covers small JSON request/response shapes (channel lookups, session
    * writes, confirm-delivery acks, settings reads, diagnostic patches).


### PR DESCRIPTION
Part of the pre-beta.133 batch (slash-command timeout audit, item #4 + open prod issue).

## Problem
Config-mutation routes shared the 10s `DEFERRED` read budget, or silently fell back to the **2.5s `AUTOCOMPLETE`** default when a route omitted `timeoutMs`. The admin/user **llm-config PUT** path runs >10s under load in prod, so bot-client's `AbortSignal` fired and the user saw a false "gateway slow or unavailable" — even though the write would have succeeded. (Open production issue.)

## Fix
- **`GATEWAY_TIMEOUTS.WRITE` (20s)** — covers validation + multi-table transactions + cache-invalidation cascades; still well inside the 15-min post-defer window.
- **Method-aware transport default**: `POST/PUT/PATCH/DELETE` without an explicit `timeoutMs` now default to `WRITE`, not the 2.5s read default — a new write route can't silently inherit a too-short budget. Explicit timeouts still win.
- **llm-config CRUD writes** (the proven-slow, prod-bug class) bumped to `WRITE`. Fast single-row override writes (tts/model/stt) keep `DEFERRED` — 10s is ample, and the method-aware default backstops future routes. Documented as the read/write policy on `GATEWAY_TIMEOUTS`.
- Removed dead `TIMEOUTS.ADMIN_GATEWAY` (no source references).

## Scope note
This **mitigates** the prod llm-config PUT timeout (stops the false client-side abort). The gateway-side *why is it >10s* root cause stays under investigation in `production-issues.md`; the timing instrumentation (validate/DB-write/cache-invalidation breakdown) is a separate small follow-up rather than bundled here.

## Test plan
- New transport tests: write methods default to `WRITE`, reads to `AUTOCOMPLETE`, explicit `timeoutMs` overrides both. Full transport suite green (21).
- `pnpm quality` green.
- Behavioral (dev): a slow llm-config PUT (>10s, <20s) now completes instead of aborting at 10s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)