### PR TITLE
feat(bot-client): surface forwarded-message origin channel in context

### DIFF
--- a/services/bot-client/src/handlers/references/SnapshotFormatter.test.ts
+++ b/services/bot-client/src/handlers/references/SnapshotFormatter.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { SnapshotFormatter } from './SnapshotFormatter.js';
 import { createMockMessage } from '../../test/mocks/Discord.mock.js';
-import type { MessageSnapshot, APIEmbed } from 'discord.js';
+import { Collection, type Channel, type MessageSnapshot, type APIEmbed } from 'discord.js';
 
 // Mock the utility functions
 vi.mock('../../utils/discordContext.js', () => ({
@@ -290,6 +290,40 @@ describe('SnapshotFormatter', () => {
     it('should append "(forwarded message)" to location context', () => {
       const snapshot = createMockSnapshot();
       const forwardedFrom = createMockMessage();
+
+      const result = formatter.formatSnapshot(snapshot, 1, forwardedFrom);
+
+      expect(result.locationContext).toBe(
+        '<location type="guild"><server name="Test Guild"/></location> (forwarded message)'
+      );
+    });
+
+    it('surfaces the origin channel name when the bot can see it (cached)', () => {
+      const snapshot = createMockSnapshot();
+      const forwardedFrom = createMockMessage({
+        reference: { channelId: 'origin-chan-1' } as never,
+        client: {
+          channels: {
+            cache: new Collection<string, Channel>([
+              ['origin-chan-1', { name: 'announcements' } as unknown as Channel],
+            ]),
+          },
+        } as never,
+      });
+
+      const result = formatter.formatSnapshot(snapshot, 1, forwardedFrom);
+
+      expect(result.locationContext).toBe(
+        '<location type="guild"><server name="Test Guild"/></location> (forwarded from #announcements)'
+      );
+    });
+
+    it('degrades to the generic marker when the origin channel is not in cache (e.g. cross-server)', () => {
+      const snapshot = createMockSnapshot();
+      const forwardedFrom = createMockMessage({
+        reference: { channelId: 'origin-chan-unknown' } as never,
+        client: { channels: { cache: new Collection<string, Channel>() } } as never,
+      });
 
       const result = formatter.formatSnapshot(snapshot, 1, forwardedFrom);
 

--- a/services/bot-client/src/handlers/references/SnapshotFormatter.ts
+++ b/services/bot-client/src/handlers/references/SnapshotFormatter.ts
@@ -21,6 +21,35 @@ import { EmbedParser } from '../../utils/EmbedParser.js';
  */
 export class SnapshotFormatter {
   /**
+   * Build the forward marker appended to the snapshot's locationContext.
+   *
+   * Discord exposes the ORIGIN channel of a forward on `forwardedFrom.reference`
+   * (a FORWARD-type MessageReference). When the bot can see that channel we
+   * surface its name ("forwarded from #general"), matching what Discord's own
+   * client shows. We read the client's channel CACHE only — no network `fetch()`
+   * on the message-handling path: a name is meaningful exactly when the bot is a
+   * member, which is also when the channel is cached. Cross-server forwards (bot
+   * not a member) won't resolve and fall back to the generic "(forwarded
+   * message)" marker rather than leaking a bare ID or stalling on a doomed fetch.
+   */
+  private buildForwardMarker(forwardedFrom: Message): string {
+    const originChannelId = forwardedFrom.reference?.channelId;
+    if (originChannelId === undefined) {
+      return '(forwarded message)';
+    }
+    const channel = forwardedFrom.client?.channels?.cache?.get(originChannelId);
+    if (
+      channel !== undefined &&
+      'name' in channel &&
+      typeof channel.name === 'string' &&
+      channel.name.length > 0
+    ) {
+      return `(forwarded from #${channel.name})`;
+    }
+    return '(forwarded message)';
+  }
+
+  /**
    * Format a message snapshot into a referenced message
    * @param snapshot - Message snapshot from forwarded message
    * @param referenceNumber - Reference number for this message
@@ -77,7 +106,7 @@ export class SnapshotFormatter {
       timestamp: snapshot.createdTimestamp
         ? new Date(snapshot.createdTimestamp).toISOString()
         : forwardedFrom.createdAt.toISOString(),
-      locationContext: `${locationContext} (forwarded message)`,
+      locationContext: `${locationContext} ${this.buildForwardMarker(forwardedFrom)}`,
       attachments: allAttachments.length > 0 ? allAttachments : undefined,
       isForwarded: true,
     };


### PR DESCRIPTION
Part of the pre-beta.133 batch (forwarded-message items). Item #2.

## What
A forwarded snapshot was labelled only with the **forwarding** channel's location context + a generic "(forwarded message)" marker — the AI never saw which channel the message was originally forwarded **from**. Now, when the bot can see the origin channel, we surface its name: `(forwarded from #general)`, matching Discord's own client.

## How
- Read `forwardedFrom.reference.channelId` (Discord populates origin channel/guild on the FORWARD-type `MessageReference`).
- Resolve the name from the client's channel **cache only** — deliberately **not** `client.channels.fetch()`. A name is meaningful exactly when the bot is a member (which is when the channel is cached); cross-server forwards (bot not a member) wouldn't resolve via fetch either, and a network call on the message-handling path adds latency for no gain. Cache miss → graceful fallback to the generic marker.
- `formatSnapshot` stays **synchronous** — no caller ripple (its 2 call sites stay sync).

(Deviation from the plan, which suggested `fetch()`: cache-only is the better hot-path choice — same effective coverage, no network latency, no async ripple.)

## Test plan
- New tests: origin resolves when cached → `(forwarded from #announcements)`; not cached → degrades to `(forwarded message)`. Existing no-reference test still green (backward compatible). Full SnapshotFormatter suite green (17).
- `pnpm quality` green.
- Behavioral (dev): forward a message from a channel the bot shares → context shows "forwarded from #name"; cross-server forward → generic marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)