### PR TITLE
feat(bot-client): /help param details + "character" terminology audit

### DIFF
--- a/services/bot-client/src/commands/channel/activate.ts
+++ b/services/bot-client/src/commands/channel/activate.ts
@@ -85,8 +85,8 @@ export async function handleActivate(context: DeferredCommandContext): Promise<v
       // Handle specific error cases
       if (result.status === 404) {
         await context.editReply(
-          `❌ Personality **${personalitySlug}** not found.\n\n` +
-            'Use the autocomplete to select a valid personality.'
+          `❌ Character **${personalitySlug}** not found.\n\n` +
+            'Use the autocomplete to select a valid character.'
         );
         return;
       }
@@ -94,7 +94,7 @@ export async function handleActivate(context: DeferredCommandContext): Promise<v
       if (result.status === 403) {
         await context.editReply(
           `❌ You don't have access to **${personalitySlug}**.\n\n` +
-            'You can only activate personalities that are public or that you own.'
+            'You can only activate characters that are public or that you own.'
         );
         return;
       }
@@ -111,7 +111,7 @@ export async function handleActivate(context: DeferredCommandContext): Promise<v
 
     await context.editReply(
       `✅ Activated **${activation.personalityName}** in this channel${replacedNote}.\n\n` +
-        `All messages in <#${channelId}> will now get responses from this personality.`
+        `All messages in <#${channelId}> will now get responses from this character.`
     );
 
     logger.info(

--- a/services/bot-client/src/commands/channel/deactivate.test.ts
+++ b/services/bot-client/src/commands/channel/deactivate.test.ts
@@ -136,7 +136,7 @@ describe('/channel deactivate', () => {
     await handleDeactivate(context);
 
     expect(context.editReply).toHaveBeenCalledWith(
-      expect.stringContaining('No personality is currently activated')
+      expect.stringContaining('No character is currently activated')
     );
   });
 

--- a/services/bot-client/src/commands/channel/deactivate.ts
+++ b/services/bot-client/src/commands/channel/deactivate.ts
@@ -67,7 +67,7 @@ export async function handleDeactivate(context: DeferredCommandContext): Promise
 
     if (!deactivated) {
       await context.editReply(
-        '📍 No personality is currently activated in this channel.\n\n' +
+        '📍 No character is currently activated in this channel.\n\n' +
           'Use `/channel activate` to activate one.'
       );
       return;

--- a/services/bot-client/src/commands/channel/settings.test.ts
+++ b/services/bot-client/src/commands/channel/settings.test.ts
@@ -282,7 +282,7 @@ describe('Channel Settings Dashboard', () => {
 
     it('should show admin overrides via resolve-defaults when no personality activated', async () => {
       const context = createMockContext(true);
-      // No personality activated
+      // No character activated
       mockGetChannelSettings.mockResolvedValue({ settings: {} });
       // resolveUserDefaults returns admin-sourced maxMessages
       stub.resolveUserDefaults.mockResolvedValue(
@@ -340,7 +340,7 @@ describe('Channel Settings Dashboard', () => {
       expect(maxImgField.value).toContain('Auto');
 
       // Info note about no personality activated
-      expect(embedJson.description).toContain('No personality activated');
+      expect(embedJson.description).toContain('No character activated');
     });
 
     it('should use fallback values when resolve endpoint fails', async () => {

--- a/services/bot-client/src/commands/channel/settings.ts
+++ b/services/bot-client/src/commands/channel/settings.ts
@@ -104,7 +104,7 @@ export async function handleChannelSettings(context: DeferredCommandContext): Pr
         ? {
             ...CHANNEL_SETTINGS_CONFIG,
             descriptionNote:
-              'ℹ️ No personality activated — personality-level defaults not included in cascade.',
+              'ℹ️ No character activated — character-level defaults not included in cascade.',
           }
         : CHANNEL_SETTINGS_CONFIG;
 

--- a/services/bot-client/src/commands/character/autocomplete.ts
+++ b/services/bot-client/src/commands/character/autocomplete.ts
@@ -15,7 +15,7 @@ const logger = createLogger('character-autocomplete');
  * Handle autocomplete for /character commands
  *
  * - For 'edit', 'avatar', 'voice', 'voice-clear': only shows user-owned characters
- * - For 'view', 'chat', etc.: shows all accessible characters (owned + public)
+ * - For 'view', 'chat', 'chime-in', etc.: shows all accessible characters (owned + public)
  *
  * Note: Delete is now handled via the edit dashboard, not a standalone command.
  */

--- a/services/bot-client/src/commands/character/chat.ts
+++ b/services/bot-client/src/commands/character/chat.ts
@@ -430,8 +430,6 @@ async function runCharacterTurn(
     const anchorMessage = anchorResult.message;
 
     // 7. Build full context with command invoker's identity (not anchor message author)
-    // (TS narrows `message` to string in the else branch via the aliased
-    // `isWeighInMode` const, which already covers the null/empty case.)
     const messageContent = isWeighInMode ? WEIGH_IN_MESSAGE : message;
     const buildResult = await buildChatContext({
       anchorMessage,

--- a/services/bot-client/src/commands/help/index.test.ts
+++ b/services/bot-client/src/commands/help/index.test.ts
@@ -72,7 +72,15 @@ describe('Help Command', () => {
           name: 'character',
           description: 'Manage AI characters',
           options: [
-            { type: 1, name: 'create', description: 'Create a character' },
+            {
+              type: 1,
+              name: 'create',
+              description: 'Create a character',
+              options: [
+                { type: 3, name: 'name', description: 'Character name', required: true },
+                { type: 3, name: 'slug', description: 'URL slug', required: false },
+              ],
+            },
             { type: 1, name: 'edit', description: 'Edit a character' },
           ],
         },
@@ -192,6 +200,44 @@ describe('Help Command', () => {
 
       expect(json.title).toBe('/character');
       expect(json.description).toBe('Manage AI characters');
+
+      // Each subcommand becomes its own field, and `create`'s params are listed
+      const createField = json.fields.find((f: { name: string }) => f.name.includes('create'));
+      expect(createField).toBeDefined();
+      expect(createField?.value).toContain('Create a character');
+      expect(createField?.value).toContain('`name`');
+      expect(createField?.value).toContain('*(required)*');
+      expect(createField?.value).toContain('`slug`');
+
+      // A param-less subcommand still renders a field
+      const editField = json.fields.find((f: { name: string }) => f.name.includes('edit'));
+      expect(editField).toBeDefined();
+    });
+
+    it('shows parameters for a flat command (no subcommands)', async () => {
+      const commands = createMockCommands();
+      const interaction = createMockContext('help', commands);
+
+      // /help itself has a single `command` string option
+      commands.set('help', {
+        data: {
+          name: 'help',
+          description: 'Show all available commands',
+          options: [
+            { type: 3, name: 'command', description: 'Command to detail', required: false },
+          ],
+        },
+        execute: vi.fn(),
+        category: 'Help',
+      } as unknown as Command);
+
+      await execute(interaction);
+
+      const embed = mockEditReply.mock.calls[0][0].embeds[0];
+      const json = embed.toJSON();
+      const paramsField = json.fields?.find((f: { name: string }) => f.name === 'Parameters');
+      expect(paramsField).toBeDefined();
+      expect(paramsField?.value).toContain('`command`');
     });
 
     it('should show error for unknown command', async () => {
@@ -221,7 +267,7 @@ describe('Help Command', () => {
       expect(characterField?.value).toContain('2 subcommands');
     });
 
-    it('should include personality interaction info with configured mention char', async () => {
+    it('should include character interaction info with configured mention char', async () => {
       const commands = createMockCommands();
       const interaction = createMockContext(null, commands);
 
@@ -231,13 +277,13 @@ describe('Help Command', () => {
       const json = embed.toJSON();
 
       const interactionField = json.fields.find((f: { name: string }) =>
-        f.name.includes('Personality')
+        f.name.includes('Interactions')
       );
       expect(interactionField).toBeDefined();
-      expect(interactionField?.value).toContain(`${mockConfig.BOT_MENTION_CHAR}PersonalityName`);
+      expect(interactionField?.value).toContain(`${mockConfig.BOT_MENTION_CHAR}CharacterName`);
     });
 
-    it('should include /character chat reference in personality interactions', async () => {
+    it('should include /character chat reference in character interactions', async () => {
       const commands = createMockCommands();
       const interaction = createMockContext(null, commands);
 
@@ -247,7 +293,7 @@ describe('Help Command', () => {
       const json = embed.toJSON();
 
       const interactionField = json.fields.find((f: { name: string }) =>
-        f.name.includes('Personality')
+        f.name.includes('Interactions')
       );
       expect(interactionField?.value).toContain('/character chat');
     });
@@ -265,9 +311,9 @@ describe('Help Command', () => {
       const json = embed.toJSON();
 
       const interactionField = json.fields.find((f: { name: string }) =>
-        f.name.includes('Personality')
+        f.name.includes('Interactions')
       );
-      expect(interactionField?.value).toContain('&PersonalityName');
+      expect(interactionField?.value).toContain('&CharacterName');
 
       // Reset to default
       mockConfig.BOT_MENTION_CHAR = '@';
@@ -285,7 +331,7 @@ describe('Help Command', () => {
       // Get category names (stripping emojis)
       const categoryOrder = json.fields
         .map((f: { name: string }) => f.name)
-        .filter((name: string) => !name.includes('Personality'));
+        .filter((name: string) => !name.includes('Interactions'));
 
       // Character should come before Settings, Settings before Help
       const characterIndex = categoryOrder.findIndex((n: string) => n.includes('Character'));

--- a/services/bot-client/src/commands/help/index.ts
+++ b/services/bot-client/src/commands/help/index.ts
@@ -82,8 +82,87 @@ async function execute(ctx: SafeCommandContext): Promise<void> {
   }
 }
 
+/** Discord application-command option-type discriminators. */
+const OPTION_TYPE = { SUBCOMMAND: 1, SUBCOMMAND_GROUP: 2 } as const;
+
+/** Discord's hard cap is 25 embed fields; leave one for a truncation note. */
+const MAX_DETAIL_FIELDS = 24;
+
+/** Discord's per-field value limit. */
+const FIELD_VALUE_LIMIT = 1024;
+
 /**
- * Show detailed help for a specific command
+ * Minimal structural view of a command option as exposed by both the live
+ * SlashCommandBuilder tree and the plain objects used in tests.
+ */
+interface RawOption {
+  type?: number;
+  name?: string;
+  description?: string;
+  required?: boolean;
+  /**
+   * Child options: subcommands of a group, or parameters of a subcommand —
+   * the shape depends on the parent's `type`, so it stays `unknown[]` and is
+   * narrowed at each use site rather than modeled as a union here.
+   */
+  options?: unknown[];
+}
+
+/** An option is a user-supplied parameter (not a sub/group) when its type ≥ 3. */
+function isParam(type: number | undefined): boolean {
+  return (
+    type !== undefined && type !== OPTION_TYPE.SUBCOMMAND && type !== OPTION_TYPE.SUBCOMMAND_GROUP
+  );
+}
+
+/** Render an option's parameters as bullet lines; '' when it has none. */
+function renderParams(options: unknown[] | undefined): string {
+  if (!Array.isArray(options)) {
+    return '';
+  }
+  const lines = (options as RawOption[])
+    .filter(o => isParam(o.type))
+    .map(p => {
+      const name = p.name ?? '';
+      const desc = p.description ?? '';
+      const required = p.required === true ? ' *(required)*' : '';
+      return `• \`${name}\`${required}${desc !== '' ? ` — ${desc}` : ''}`;
+    });
+  return lines.join('\n');
+}
+
+/** Build a `{ name, value }` field for one (possibly group-prefixed) subcommand. */
+function subcommandField(sub: RawOption, groupName?: string): { name: string; value: string } {
+  const subName = sub.name ?? '';
+  const label = groupName !== undefined ? `${groupName} ${subName}` : subName;
+  const desc = sub.description ?? '';
+  const params = renderParams(sub.options);
+  const value = [desc, params].filter(part => part !== '').join('\n') || '_No parameters._';
+  return { name: `\`${label}\``, value: value.slice(0, FIELD_VALUE_LIMIT) };
+}
+
+/**
+ * Flatten a command's option tree into one field per subcommand, expanding
+ * subcommand groups (`group sub`) and listing each subcommand's parameters.
+ */
+function buildSubcommandFields(options: unknown[]): { name: string; value: string }[] {
+  const fields: { name: string; value: string }[] = [];
+  for (const opt of options as RawOption[]) {
+    if (opt.type === OPTION_TYPE.SUBCOMMAND_GROUP && Array.isArray(opt.options)) {
+      const groupName = opt.name ?? '';
+      for (const sub of opt.options as RawOption[]) {
+        fields.push(subcommandField(sub, groupName));
+      }
+    } else if (opt.type === OPTION_TYPE.SUBCOMMAND) {
+      fields.push(subcommandField(opt));
+    }
+  }
+  return fields;
+}
+
+/**
+ * Show detailed help for a specific command, including each subcommand's
+ * parameters (or, for a flat command, its own parameters).
  */
 async function showCommandDetails(
   context: DeferredCommandContext,
@@ -104,23 +183,24 @@ async function showCommandDetails(
     .setTitle(`/${command.data.name}`)
     .setDescription(command.data.description);
 
-  // Add subcommands if present
-  if ('options' in command.data && Array.isArray(command.data.options)) {
-    const subcommands = command.data.options.filter(
-      opt => 'type' in opt && (opt.type === 1 || opt.type === 2) // Subcommand or SubcommandGroup
-    );
+  const options =
+    'options' in command.data && Array.isArray(command.data.options) ? command.data.options : [];
 
-    if (subcommands.length > 0) {
-      const subcommandList = subcommands
-        .map(sub => {
-          const name = 'name' in sub ? String(sub.name) : '';
-          const desc = 'description' in sub ? String(sub.description) : '';
-          const type = 'type' in sub && sub.type === 2 ? ' (group)' : '';
-          return `\`${name}\`${type} - ${desc}`;
-        })
-        .join('\n');
+  const subcommandFields = buildSubcommandFields(options);
 
-      embed.addFields({ name: 'Subcommands', value: subcommandList });
+  if (subcommandFields.length > 0) {
+    embed.addFields(subcommandFields.slice(0, MAX_DETAIL_FIELDS));
+    if (subcommandFields.length > MAX_DETAIL_FIELDS) {
+      embed.addFields({
+        name: '…and more',
+        value: `${subcommandFields.length - MAX_DETAIL_FIELDS} more subcommand(s) not shown.`,
+      });
+    }
+  } else {
+    // Flat command (no subcommands) — list its own parameters, if any.
+    const params = renderParams(options);
+    if (params !== '') {
+      embed.addFields({ name: 'Parameters', value: params.slice(0, FIELD_VALUE_LIMIT) });
     }
   }
 
@@ -140,7 +220,7 @@ async function showAllCommands(
     .setTitle('📚 Available Commands')
     .setDescription(
       'Use `/help <command>` for detailed information about a specific command.\n\n' +
-        'You can also interact with AI personalities by @mentioning them!'
+        'You can also interact with AI characters by @mentioning them!'
     )
     .setTimestamp();
 
@@ -194,11 +274,11 @@ async function showAllCommands(
     });
   }
 
-  // Add personality mention info
+  // Add character mention info
   embed.addFields({
-    name: '💬 Personality Interactions',
+    name: '💬 Character Interactions',
     value:
-      `• \`${mentionChar}PersonalityName your message\` - Start a conversation\n` +
+      `• \`${mentionChar}CharacterName your message\` - Start a conversation\n` +
       '• Reply to their messages to continue chatting\n' +
       '• Use `/character chat` to start via slash command',
     inline: false,

--- a/services/bot-client/src/commands/history/clear.test.ts
+++ b/services/bot-client/src/commands/history/clear.test.ts
@@ -194,7 +194,7 @@ describe('handleClear', () => {
     await handleClear(context);
 
     expect(context.editReply).toHaveBeenCalledWith({
-      content: '❌ Personality "unknown" not found.',
+      content: '❌ Character "unknown" not found.',
     });
   });
 

--- a/services/bot-client/src/commands/history/clear.ts
+++ b/services/bot-client/src/commands/history/clear.ts
@@ -45,7 +45,7 @@ export async function handleClear(context: DeferredCommandContext): Promise<void
     if (!result.ok) {
       const errorMessage =
         result.status === 404
-          ? `Personality "${personalitySlug}" not found.`
+          ? `Character "${personalitySlug}" not found.`
           : 'Failed to clear history. Please try again later.';
       logger.warn({ userId, personalitySlug, status: result.status }, 'Clear failed');
       await context.editReply({ content: `❌ ${errorMessage}` });

--- a/services/bot-client/src/commands/history/hard-delete.ts
+++ b/services/bot-client/src/commands/history/hard-delete.ts
@@ -47,7 +47,7 @@ export async function handleHardDelete(context: DeferredCommandContext): Promise
       entityName: personalitySlug,
       additionalWarning:
         '**This action is PERMANENT and cannot be undone!**\n\n' +
-        'All messages in this channel with this personality will be deleted forever.\n' +
+        'All messages in this channel with this character will be deleted forever.\n' +
         'This includes:\n' +
         '• Your messages\n' +
         '• AI responses\n' +

--- a/services/bot-client/src/commands/history/index.test.ts
+++ b/services/bot-client/src/commands/history/index.test.ts
@@ -291,7 +291,7 @@ describe('handleModal', () => {
       const result = (await callback()) as { success: boolean; errorMessage?: string };
 
       expect(result.success).toBe(false);
-      expect(result.errorMessage).toContain('Personality "lilith" not found');
+      expect(result.errorMessage).toContain('Character "lilith" not found');
     });
 
     it('returns the generic failure message on other error statuses', async () => {

--- a/services/bot-client/src/commands/history/index.ts
+++ b/services/bot-client/src/commands/history/index.ts
@@ -88,7 +88,7 @@ function buildHardDeleteOperation(
         success: false,
         errorMessage:
           result.status === 404
-            ? `Personality "${personalitySlug}" not found.`
+            ? `Character "${personalitySlug}" not found.`
             : 'Failed to delete history. Please try again.',
       };
     }

--- a/services/bot-client/src/commands/history/stats.test.ts
+++ b/services/bot-client/src/commands/history/stats.test.ts
@@ -318,7 +318,7 @@ describe('handleStats', () => {
     await handleStats(context);
 
     expect(context.editReply).toHaveBeenCalledWith({
-      content: '❌ Personality "unknown" not found.',
+      content: '❌ Character "unknown" not found.',
     });
   });
 

--- a/services/bot-client/src/commands/history/stats.ts
+++ b/services/bot-client/src/commands/history/stats.ts
@@ -55,7 +55,7 @@ export async function handleStats(context: DeferredCommandContext): Promise<void
     if (!result.ok) {
       const errorMessage =
         result.status === 404
-          ? `Personality "${personalitySlug}" not found.`
+          ? `Character "${personalitySlug}" not found.`
           : 'Failed to get stats. Please try again later.';
       logger.warn({ userId, personalitySlug, status: result.status }, 'Stats failed');
       await context.editReply({ content: `❌ ${errorMessage}` });

--- a/services/bot-client/src/commands/history/undo.test.ts
+++ b/services/bot-client/src/commands/history/undo.test.ts
@@ -144,7 +144,7 @@ describe('handleUndo', () => {
     await handleUndo(context);
 
     expect(context.editReply).toHaveBeenCalledWith({
-      content: '❌ Personality "unknown" not found.',
+      content: '❌ Character "unknown" not found.',
     });
   });
 

--- a/services/bot-client/src/commands/history/undo.ts
+++ b/services/bot-client/src/commands/history/undo.ts
@@ -45,7 +45,7 @@ export async function handleUndo(context: DeferredCommandContext): Promise<void>
     if (!result.ok) {
       let errorMessage: string;
       if (result.status === 404) {
-        errorMessage = `Personality "${personalitySlug}" not found.`;
+        errorMessage = `Character "${personalitySlug}" not found.`;
       } else if (result.status === 400) {
         errorMessage =
           'No previous context to restore. Undo is only available after a clear operation.';

--- a/services/bot-client/src/commands/inspect/embed.ts
+++ b/services/bot-client/src/commands/inspect/embed.ts
@@ -204,7 +204,7 @@ export function buildDiagnosticEmbed(payload: DiagnosticPayload): EmbedBuilder {
         name: '📝 Request',
         value: [
           `**ID:** \`${meta.requestId}\``,
-          `**Personality:** ${meta.personalityName}`,
+          `**Character:** ${meta.personalityName}`,
           `**User:** <@${meta.userId}>`,
           `**Channel:** <#${meta.channelId}>`,
         ].join('\n'),

--- a/services/bot-client/src/commands/inspect/views.ts
+++ b/services/bot-client/src/commands/inspect/views.ts
@@ -159,7 +159,7 @@ export function buildSystemPromptView(
     // results inherit that automatically.
     return {
       content:
-        '🔒 **Character card hidden** — this personality is owned by another user.\n\n' +
+        '🔒 **Character card hidden** — this character is owned by another user.\n\n' +
         'Numeric and timing diagnostics remain visible above.',
     };
   }
@@ -266,7 +266,7 @@ function renderMemoryTable(
   ];
   if (!canViewCharacter) {
     lines.push('');
-    lines.push('🔒 _Memory previews redacted — this personality is owned by another user._');
+    lines.push('🔒 _Memory previews redacted — this character is owned by another user._');
   }
   lines.push('', '| # | Score | Status | Preview |', '|---|-------|--------|---------|');
   for (let i = 0; i < memories.length; i++) {

--- a/services/bot-client/src/commands/memory/batchDelete.ts
+++ b/services/bot-client/src/commands/memory/batchDelete.ts
@@ -73,7 +73,7 @@ export async function handleBatchDelete(context: DeferredCommandContext): Promis
 
     if (personalityId === null) {
       await context.editReply({
-        content: `❌ Personality "${personalityInput}" not found. Use autocomplete to select a valid personality.`,
+        content: `❌ Character "${personalityInput}" not found. Use autocomplete to select a valid character.`,
       });
       return;
     }
@@ -90,7 +90,7 @@ export async function handleBatchDelete(context: DeferredCommandContext): Promis
     if (!previewResult.ok) {
       const errorMessage =
         previewResult.status === 404
-          ? `Personality "${personalityInput}" not found.`
+          ? `Character "${personalityInput}" not found.`
           : (previewResult.error ?? 'Failed to preview deletion. Please try again later.');
       logger.warn(
         { userId, personalityInput, status: previewResult.status },

--- a/services/bot-client/src/commands/memory/browse.ts
+++ b/services/bot-client/src/commands/memory/browse.ts
@@ -107,8 +107,8 @@ function buildBrowseEmbed(options: BuildBrowseViewOptions): EmbedBuilder {
   if (memories.length === 0) {
     embed.setDescription(
       personalityId !== undefined
-        ? `No memories found for this personality.\n\nTry browsing all memories or check your search filters.`
-        : `You don't have any memories yet.\n\nMemories are created automatically when you chat with personalities.`
+        ? `No memories found for this character.\n\nTry browsing all memories or check your search filters.`
+        : `You don't have any memories yet.\n\nMemories are created automatically when you chat with characters.`
     );
     return embed;
   }

--- a/services/bot-client/src/commands/memory/incognito.ts
+++ b/services/bot-client/src/commands/memory/incognito.ts
@@ -230,7 +230,7 @@ export async function handleIncognitoStatus(context: DeferredCommandContext): Pr
 
     const embed = createWarningEmbed(
       '👻 Incognito Active',
-      `Incognito mode is currently **active**.\n\n**Active sessions:**\n${sessionLines.join('\n')}\n\nNew memories will NOT be saved for these personalities.`
+      `Incognito mode is currently **active**.\n\n**Active sessions:**\n${sessionLines.join('\n')}\n\nNew memories will NOT be saved for these characters.`
     );
 
     await context.editReply({ embeds: [embed] });
@@ -300,7 +300,7 @@ export async function handleIncognitoForget(context: DeferredCommandContext): Pr
       data.deletedCount > 0
         ? createSuccessEmbed(
             '🗑️ Memories Deleted',
-            `**${data.deletedCount} memories** from the last ${timeframe} have been deleted.\n\n${data.personalities.length > 0 ? `**Affected personalities:** ${data.personalities.map(p => escapeMarkdown(p)).join(', ')}` : ''}\n\n*Note: Locked memories are preserved.*`
+            `**${data.deletedCount} memories** from the last ${timeframe} have been deleted.\n\n${data.personalities.length > 0 ? `**Affected characters:** ${data.personalities.map(p => escapeMarkdown(p)).join(', ')}` : ''}\n\n*Note: Locked memories are preserved.*`
           )
         : createInfoEmbed(
             '🗑️ No Memories Found',

--- a/services/bot-client/src/commands/memory/purge.test.ts
+++ b/services/bot-client/src/commands/memory/purge.test.ts
@@ -95,7 +95,7 @@ function createMockButtonInteraction(
   const footerText: string | null =
     'footerText' in opts && opts.footerText !== undefined
       ? opts.footerText
-      : `Personality: ${PERSONALITY_NAME}`;
+      : `Character: ${PERSONALITY_NAME}`;
   return {
     customId,
     user: { id: opts.userId ?? 'user-123' },
@@ -128,7 +128,7 @@ function createMockModalInteraction(
   const footerText: string | null =
     'footerText' in opts && opts.footerText !== undefined
       ? opts.footerText
-      : `Personality: ${PERSONALITY_NAME}`;
+      : `Character: ${PERSONALITY_NAME}`;
   const messageEdit = vi.fn().mockResolvedValue(undefined);
   return {
     customId,

--- a/services/bot-client/src/commands/memory/purge.ts
+++ b/services/bot-client/src/commands/memory/purge.ts
@@ -42,8 +42,8 @@ const logger = createLogger('memory-purge');
  */
 export const MEMORY_PURGE_PREFIX = 'memory-purge';
 
-/** Footer marker that encodes the personality display name on the warning embed. */
-const FOOTER_PREFIX = 'Personality: ';
+/** Footer marker that encodes the character display name on the warning embed. */
+const FOOTER_PREFIX = 'Character: ';
 
 /** Buffer for confirmation phrase input to allow minor whitespace. */
 const CONFIRMATION_PHRASE_LENGTH_BUFFER = 5;
@@ -116,7 +116,7 @@ export async function handlePurge(context: DeferredCommandContext): Promise<void
     if (!statsResult.ok) {
       const errorMessage =
         statsResult.status === 404
-          ? `Personality "${personalityInput}" not found.`
+          ? `Character "${personalityInput}" not found.`
           : 'Failed to get memory stats. Please try again later.';
       logger.warn({ userId, personalityInput, status: statsResult.status }, 'Purge stats failed');
       await context.editReply({ content: `❌ ${errorMessage}` });
@@ -207,7 +207,7 @@ export async function handlePurgeButton(interaction: ButtonInteraction): Promise
   if (personalityId === undefined || personalityId === '') {
     logger.warn({ customId: interaction.customId }, 'Purge proceed button missing personalityId');
     await interaction.reply({
-      content: '❌ Malformed purge button (missing personality ID).',
+      content: '❌ Malformed purge button (missing character ID).',
       flags: MessageFlags.Ephemeral,
     });
     return;
@@ -305,7 +305,7 @@ export async function handlePurgeModal(interaction: ModalSubmitInteraction): Pro
   if (personalityId === undefined || personalityId === '') {
     logger.warn({ customId: interaction.customId }, 'Purge modal missing personalityId');
     await interaction.reply({
-      content: '❌ Malformed purge modal (missing personality ID).',
+      content: '❌ Malformed purge modal (missing character ID).',
       flags: MessageFlags.Ephemeral,
     });
     return;

--- a/services/bot-client/src/commands/memory/resolveHelpers.test.ts
+++ b/services/bot-client/src/commands/memory/resolveHelpers.test.ts
@@ -74,8 +74,7 @@ describe('resolveOptionalPersonality', () => {
     const result = await resolveOptionalPersonality(context, mkUser(), 'unknown');
     expect(result).toBeNull();
     expect(mockEditReply).toHaveBeenCalledWith({
-      content:
-        '❌ Personality "unknown" not found. Use autocomplete to select a valid personality.',
+      content: '❌ Character "unknown" not found. Use autocomplete to select a valid character.',
     });
   });
 
@@ -121,8 +120,7 @@ describe('resolveRequiredPersonality', () => {
     const result = await resolveRequiredPersonality(context, mkUser(), 'unknown');
     expect(result).toBeNull();
     expect(mockEditReply).toHaveBeenCalledWith({
-      content:
-        '❌ Personality "unknown" not found. Use autocomplete to select a valid personality.',
+      content: '❌ Character "unknown" not found. Use autocomplete to select a valid character.',
     });
   });
 

--- a/services/bot-client/src/commands/memory/resolveHelpers.ts
+++ b/services/bot-client/src/commands/memory/resolveHelpers.ts
@@ -48,7 +48,7 @@ export async function resolveOptionalPersonality(
   const resolved = await resolvePersonalityId(userClient, personalityInput);
   if (resolved === null) {
     await context.editReply({
-      content: `❌ Personality "${personalityInput}" not found. Use autocomplete to select a valid personality.`,
+      content: `❌ Character "${personalityInput}" not found. Use autocomplete to select a valid character.`,
     });
     return null;
   }
@@ -80,7 +80,7 @@ export async function resolveRequiredPersonality(
   const resolved = await resolvePersonalityId(userClient, personalityInput);
   if (resolved === null) {
     await context.editReply({
-      content: `❌ Personality "${personalityInput}" not found. Use autocomplete to select a valid personality.`,
+      content: `❌ Character "${personalityInput}" not found. Use autocomplete to select a valid character.`,
     });
   }
   return resolved;

--- a/services/bot-client/src/commands/memory/search.ts
+++ b/services/bot-client/src/commands/memory/search.ts
@@ -119,7 +119,7 @@ function buildSearchEmbed(options: BuildSearchEmbedOptions): EmbedBuilder {
 
   if (results.length === 0) {
     embed.setDescription(
-      `No memories found matching: **${escapeMarkdown(truncateContent(query, 50))}**\n\nTry a different search query or check if you have memories with this personality.`
+      `No memories found matching: **${escapeMarkdown(truncateContent(query, 50))}**\n\nTry a different search query or check if you have memories with this character.`
     );
     return embed;
   }

--- a/services/bot-client/src/commands/memory/stats.ts
+++ b/services/bot-client/src/commands/memory/stats.ts
@@ -38,7 +38,7 @@ export async function handleStats(context: DeferredCommandContext): Promise<void
     if (!result.ok) {
       const errorMessage =
         result.status === 404
-          ? `Personality "${personalityInput}" not found.`
+          ? `Character "${personalityInput}" not found.`
           : 'Failed to get stats. Please try again later.';
       logger.warn({ userId, personalityInput, status: result.status }, 'Stats failed');
       await context.editReply({ content: `❌ ${errorMessage}` });
@@ -55,8 +55,7 @@ export async function handleStats(context: DeferredCommandContext): Promise<void
     }
 
     if (data.personaId === null) {
-      description +=
-        '\n\n*No profile configured - you have no memories with this personality yet.*';
+      description += '\n\n*No profile configured - you have no memories with this character yet.*';
     }
 
     const embed = createInfoEmbed('Memory Statistics', description);

--- a/services/bot-client/src/commands/persona/dashboard.ts
+++ b/services/bot-client/src/commands/persona/dashboard.ts
@@ -277,7 +277,7 @@ async function handleDeleteButton(interaction: ButtonInteraction, entityId: stri
     entityName: data.name,
     confirmCustomId: PersonaCustomIds.confirmDelete(entityId),
     cancelCustomId: PersonaCustomIds.cancelDelete(entityId),
-    additionalWarning: 'Any personality-specific overrides using this persona will be cleared.',
+    additionalWarning: 'Any character-specific overrides using this persona will be cleared.',
   });
 
   await interaction.update({ embeds: [embed], components });

--- a/services/bot-client/src/commands/persona/default.ts
+++ b/services/bot-client/src/commands/persona/default.ts
@@ -62,7 +62,7 @@ export async function handleSetDefaultPersona(context: DeferredCommandContext): 
     logger.info({ userId: discordId, personaId, personaName: persona.name }, 'Set default');
 
     await context.editReply({
-      content: `⭐ **${displayName}** is now your default persona.\n\nThis persona will be used when talking to personalities that don't have a specific override set.`,
+      content: `⭐ **${displayName}** is now your default persona.\n\nThis persona will be used when talking to characters that don't have a specific override set.`,
     });
   } catch (error) {
     logger.error({ err: error, userId: discordId }, 'Failed to set default');

--- a/services/bot-client/src/commands/persona/override/clear.test.ts
+++ b/services/bot-client/src/commands/persona/override/clear.test.ts
@@ -109,7 +109,7 @@ describe('handleOverrideClear', () => {
     await handleOverrideClear(createMockContext('nonexistent'));
 
     expect(mockEditReply).toHaveBeenCalledWith({
-      content: expect.stringContaining('Personality "nonexistent" not found'),
+      content: expect.stringContaining('Character "nonexistent" not found'),
     });
   });
 

--- a/services/bot-client/src/commands/persona/override/clear.ts
+++ b/services/bot-client/src/commands/persona/override/clear.ts
@@ -37,7 +37,7 @@ export async function handleOverrideClear(context: DeferredCommandContext): Prom
     if (!result.ok) {
       if (result.error.includes('Personality not found') || result.error.includes('not found')) {
         await context.editReply({
-          content: `❌ Personality "${personalitySlug}" not found.`,
+          content: `❌ Character "${personalitySlug}" not found.`,
         });
         return;
       }
@@ -45,7 +45,7 @@ export async function handleOverrideClear(context: DeferredCommandContext): Prom
       if (result.error.includes('no account') || result.error.includes('User')) {
         await context.editReply({
           content:
-            "❌ You don't have an account yet. Send a message to any personality to create one!",
+            "❌ You don't have an account yet. Send a message to any character to create one!",
         });
         return;
       }

--- a/services/bot-client/src/commands/persona/override/set.test.ts
+++ b/services/bot-client/src/commands/persona/override/set.test.ts
@@ -123,7 +123,7 @@ describe('handleOverrideSet', () => {
     await handleOverrideSet(createMockContext('nonexistent', 'persona-123'));
 
     expect(mockReply).toHaveBeenCalledWith({
-      content: expect.stringContaining('Personality "nonexistent" not found'),
+      content: expect.stringContaining('Character "nonexistent" not found'),
       flags: MessageFlags.Ephemeral,
     });
   });

--- a/services/bot-client/src/commands/persona/override/set.ts
+++ b/services/bot-client/src/commands/persona/override/set.ts
@@ -42,10 +42,10 @@ function mapOverrideError(error: string | undefined, personalitySlug: string): s
     return '❌ Persona not found. Use `/persona browse` to see your personas.';
   }
   if (error.includes('Personality not found') || error.includes('personality not found')) {
-    return `❌ Personality "${personalitySlug}" not found.`;
+    return `❌ Character "${personalitySlug}" not found.`;
   }
   if (error.includes('no account') || error.includes('User not found')) {
-    return "❌ You don't have an account yet. Send a message to any personality to create one!";
+    return "❌ You don't have an account yet. Send a message to any character to create one!";
   }
   return null;
 }

--- a/services/bot-client/src/commands/preset/global/set-default.ts
+++ b/services/bot-client/src/commands/preset/global/set-default.ts
@@ -20,7 +20,7 @@ export async function handleGlobalSetDefault(context: DeferredCommandContext): P
     embedTitle: 'System Default Preset Updated',
     embedDescription: (configName: string) =>
       `**${configName}** is now the system default preset.\n\n` +
-      'Personalities without a specific config will use this default.',
+      'Characters without a specific config will use this default.',
     logMessage: '[Preset/Global] Set system default preset',
     errorLogMessage: '[Preset/Global] Error setting default',
   });

--- a/services/bot-client/src/commands/settings/preset/browse.test.ts
+++ b/services/bot-client/src/commands/settings/preset/browse.test.ts
@@ -27,6 +27,15 @@ vi.mock('../../../utils/gatewayClients.js', () => ({
   clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
 }));
 
+// Silence the real pino logger that browse.ts initializes at module load.
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  };
+});
+
 beforeEach(() => {
   vi.clearAllMocks();
   stub.listModelOverrides.mockReset();

--- a/services/bot-client/src/commands/settings/preset/clear.test.ts
+++ b/services/bot-client/src/commands/settings/preset/clear.test.ts
@@ -88,7 +88,7 @@ describe('Preset Clear Handler', () => {
 
       expect(mockCreateSuccessEmbed).toHaveBeenCalledWith(
         '🔄 Preset Override Removed',
-        'The personality will now use its default preset.'
+        'The character will now use its default preset.'
       );
 
       expect(mockEditReply).toHaveBeenCalledWith({
@@ -103,7 +103,7 @@ describe('Preset Clear Handler', () => {
 
       expect(mockCreateInfoEmbed).toHaveBeenCalledWith(
         'ℹ️ No Override Set',
-        'This personality was already using its default preset.'
+        'This character was already using its default preset.'
       );
 
       expect(mockEditReply).toHaveBeenCalledWith({

--- a/services/bot-client/src/commands/settings/preset/clear.ts
+++ b/services/bot-client/src/commands/settings/preset/clear.ts
@@ -43,11 +43,11 @@ export async function handleClear(context: DeferredCommandContext): Promise<void
     const embed = wasSet
       ? createSuccessEmbed(
           '🔄 Preset Override Removed',
-          'The personality will now use its default preset.'
+          'The character will now use its default preset.'
         )
       : createInfoEmbed(
           'ℹ️ No Override Set',
-          'This personality was already using its default preset.'
+          'This character was already using its default preset.'
         );
 
     await context.editReply({ embeds: [embed] });

--- a/services/bot-client/src/commands/settings/preset/handlers.test.ts
+++ b/services/bot-client/src/commands/settings/preset/handlers.test.ts
@@ -165,7 +165,7 @@ describe('Preset Command Handlers', () => {
       expect(stub.deleteModelOverride).toHaveBeenCalledWith(PERSONALITY_ID_1);
       expect(mockCreateSuccessEmbed).toHaveBeenCalledWith(
         '🔄 Preset Override Removed',
-        'The personality will now use its default preset.'
+        'The character will now use its default preset.'
       );
     });
 

--- a/services/bot-client/src/commands/shapes/detailHandlers.ts
+++ b/services/bot-client/src/commands/shapes/detailHandlers.ts
@@ -115,15 +115,15 @@ export async function handleDetailImport(
     )
     .setDescription(
       isMemoryOnly
-        ? `Ready to import memories from **${slug}** into the existing personality.\n\n` +
+        ? `Ready to import memories from **${slug}** into the existing character.\n\n` +
             'This will:\n' +
-            '\u2022 Look up the previously imported personality by slug\n' +
+            '\u2022 Look up the previously imported character by slug\n' +
             '\u2022 Fetch all conversation memories from shapes.inc\n' +
             '\u2022 Import them (deduplicating against existing memories)\n\n' +
-            'Existing personality config will not be changed.'
+            'Existing character config will not be changed.'
         : `Ready to import **${slug}** from shapes.inc.\n\n` +
             'This will:\n' +
-            '\u2022 Create a new personality with the character config\n' +
+            '\u2022 Create a new character with its config\n' +
             '\u2022 Download the character avatar\n' +
             '\u2022 Import all conversation memories\n' +
             '\u2022 Set up the LLM configuration\n\n' +

--- a/services/bot-client/src/commands/shapes/import.ts
+++ b/services/bot-client/src/commands/shapes/import.ts
@@ -137,15 +137,15 @@ export async function handleImport(context: DeferredCommandContext): Promise<voi
       .setTitle(isMemoryOnly ? '📥 Import Memories from Shapes.inc' : '📥 Import from Shapes.inc')
       .setDescription(
         isMemoryOnly
-          ? `Ready to import memories from **${slug}** into the existing personality.\n\n` +
+          ? `Ready to import memories from **${slug}** into the existing character.\n\n` +
               'This will:\n' +
-              '• Look up the previously imported personality by slug\n' +
+              '• Look up the previously imported character by slug\n' +
               '• Fetch all conversation memories from shapes.inc\n' +
               '• Import them (deduplicating against existing memories)\n\n' +
-              'Existing personality config will not be changed.'
+              'Existing character config will not be changed.'
           : `Ready to import **${slug}** from shapes.inc.\n\n` +
               'This will:\n' +
-              '• Create a new personality with the character config\n' +
+              '• Create a new character with its config\n' +
               '• Download the character avatar\n' +
               '• Import all conversation memories\n' +
               '• Set up the LLM configuration\n\n' +

--- a/services/bot-client/src/commands/voice/tts/browse.test.ts
+++ b/services/bot-client/src/commands/voice/tts/browse.test.ts
@@ -26,6 +26,15 @@ vi.mock('../../../utils/gatewayClients.js', () => ({
   clientsFor: vi.fn(() => ({ userClient: stub as unknown as UserClient })),
 }));
 
+// Silence the real pino logger that browse.ts initializes at module load.
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  };
+});
+
 beforeEach(() => {
   vi.clearAllMocks();
   stub.listTtsOverrides.mockReset();


### PR DESCRIPTION
## Summary

**PR F** of the pre-beta.133 batch — the last item. Two halves plus three folded nits.

### 1. `/help <command>` parameter details
`/help <command>` previously listed only subcommand names. It now renders **each subcommand's parameters** (name, `*(required)*` marker, description) by recursing the option tree, flattening subcommand groups as `group sub`. Flat commands (e.g. `/help help`) list their own parameters. Field count is capped at Discord's 25-field limit with a `…and more` note.

### 2. User-facing "character" terminology audit
Scrubbed `personality`/`personalities` → `character`/`characters` everywhere the word **names the AI entity** — ~30 message/embed strings across memory, history, channel, persona, inspect, shapes, preset, settings, plus the `/help` category label and mention hint (the original complaint: "/help still mixes 'personalities' and 'characters'").

**Deliberately kept** (per a classification pass — confirmed with the user):
- **"Personality Traits / Tone / Age / …"** — these name the character's personality *attribute* (a character *has* a personality) and mirror the `personalityTraits`/etc. schema keys.
- **"…interests, personality, context…"** — refers to the *user's own* traits, not the AI.
- **Internal cascade tiers** (`'personality'` / `'user-personality'`), identifiers, log messages, and gateway error-*match* strings (`.includes('Personality not found')`).
- **Denylist `PERSONALITY` enum** + its placeholder/validation text — locked stored value; the dropdown already shows "Character".

> Note: the slash-command **option/subcommand `.setDescription` surface was already clean** — only runtime message/embed strings had drifted.

### 3. Folded review nits from the prior batch
- drop the TS-narrowing comment in `character/chat.ts` (#1230)
- add `chime-in` to `character/autocomplete.ts` JSDoc (#1230)
- restore the `createLogger` mock in the preset/tts `browse.test.ts` files so they don't emit real pino lines in CI (#1231)

## Test plan
- `pnpm quality` green (lint incl. `no-base-to-string`, both typechecks, codegen-drift, knip, cpd, depcruise)
- 2052 command-dir tests green; help test extended with param-rendering + flat-command cases; ~12 colocated assertions updated for the rename
- No command-manifest/snapshot change (option descriptions untouched)
- Behavioral (dev, post-deploy): `/help character` shows per-subcommand params; `/help` reads "character" consistently; renamed error/embed strings render

🤖 Generated with [Claude Code](https://claude.com/claude-code)