### PR TITLE
debug(common-types): context-merge probe for beta.133 assembly trio

### DIFF
--- a/packages/common-types/src/utils/historyMerger.test.ts
+++ b/packages/common-types/src/utils/historyMerger.test.ts
@@ -496,5 +496,27 @@ describe('HistoryMerger', () => {
       expect(result[0].content).toBe('First');
       expect(result[1].content).toBe('Second');
     });
+
+    // TEMPORARY (debug PR): the CTX_MERGE_PROBE diagnostic is logging-only and
+    // must not alter merge behavior. Remove with the probe cleanup commit.
+    it('CTX_MERGE_PROBE logging does not change the merged result', () => {
+      const dbHistory = [createMockMessage({ discordMessageId: ['db-1'], content: 'DB one' })];
+      const extendedMessages = [
+        createMockMessage({ discordMessageId: ['live-2'], content: 'Live two' }),
+      ];
+
+      const prev = process.env.CTX_MERGE_PROBE;
+      process.env.CTX_MERGE_PROBE = '1';
+      try {
+        const result = mergeWithHistory(extendedMessages, dbHistory);
+        expect(result.map(m => m.content)).toEqual(['DB one', 'Live two']);
+      } finally {
+        if (prev === undefined) {
+          delete process.env.CTX_MERGE_PROBE;
+        } else {
+          process.env.CTX_MERGE_PROBE = prev;
+        }
+      }
+    });
   });
 });

--- a/packages/common-types/src/utils/historyMerger.ts
+++ b/packages/common-types/src/utils/historyMerger.ts
@@ -113,6 +113,41 @@ export function enrichDbMessagesWithExtendedMetadata(
 }
 
 /**
+ * TEMPORARY diagnostic (debug PR): build a PII-safe descriptor of a message
+ * for the context-merge probe. Logs derived booleans/lengths/IDs only — never
+ * raw content (per the no-PII-in-logs rule). Used to root-cause the beta.133
+ * context-assembly trio (footer leak / chime-in role+order / blank image msgs):
+ * which copy of a message survives the live-vs-DB merge, and with what shape.
+ * Gated behind CTX_MERGE_PROBE=1; remove with the cleanup commit once read.
+ */
+function ctxProbeDescriptor(
+  m: ConversationMessage,
+  dbIds: { has: (id: string) => boolean }
+): Record<string, unknown> {
+  const content = m.content ?? '';
+  const id = m.discordMessageId[0];
+  const meta = m.messageMetadata;
+  return {
+    id: id ?? null,
+    role: String(m.role),
+    pName: m.personalityName ?? null,
+    len: content.length,
+    ph: content === NO_TEXT_CONTENT_PLACEHOLDER,
+    ftr: content.includes('-# '), // Discord subtext footer (Bug A)
+    relay: /^\*\*[^*]+:\*\*\s/.test(content), // "**Name:** …" relay-echo shape (Bug B)
+    fwd: m.isForwarded === true,
+    // metadata presence (Bug C — is there ANY attachment description to render?)
+    aDesc: meta?.attachmentDescriptions?.length ?? 0,
+    emb: meta?.embedsXml?.length ?? 0,
+    voc: meta?.voiceTranscripts?.length ?? 0,
+    fAtt: meta?.forwardedAttachmentLines?.length ?? 0,
+    rx: meta?.reactions?.length ?? 0,
+    // for live messages: does a DB row already cover this id (→ deduped out)?
+    inDb: id !== undefined ? dbIds.has(id) : false,
+  };
+}
+
+/**
  * Merge extended context messages with database conversation history
  *
  * This handles deduplication when the same message appears in both sources.
@@ -165,6 +200,27 @@ export function mergeWithHistory(
     },
     'Merged extended context with DB history'
   );
+
+  // TEMPORARY diagnostic (debug PR, CTX_MERGE_PROBE=1): dump PII-safe per-message
+  // descriptors for both sides + the dedup result so we can read — at runtime, on
+  // dev — which copy of each message survives the merge and with what shape. This
+  // is the single boundary where the beta.133 context trio converges (footer leak,
+  // chime-in role/order, blank image msgs). Capped to the most recent 15 per side
+  // to bound log volume. Remove with the cleanup commit once the mechanism is read.
+  if (process.env.CTX_MERGE_PROBE === '1') {
+    const TAIL = 15;
+    logger.info(
+      {
+        probe: 'ctx-merge',
+        dbCount: dbHistory.length,
+        liveCount: extendedMessages.length,
+        survivedLive: uniqueExtendedMessages.length,
+        db: dbHistory.slice(-TAIL).map(m => ctxProbeDescriptor(m, dbMessageMap)),
+        live: extendedMessages.slice(-TAIL).map(m => ctxProbeDescriptor(m, dbMessageMap)),
+      },
+      '[CTX-MERGE-PROBE]'
+    );
+  }
 
   // Combine: DB history (chronological, richer metadata) + unique extended messages
   const merged = [...dbHistory, ...uniqueExtendedMessages];


### PR DESCRIPTION
## Summary

**Temporary, env-gated diagnostic** (`debug` type — removed in a cleanup commit) to root-cause the three context-assembly bugs found in the beta.133 dev smoke (filed in `production-issues.md`): footer leak (A), chime-in trigger role/order (B), blank image/embed messages (C).

All three converge on one boundary: `mergeWithHistory` (live Discord-fetched messages vs DB history dedup). This probe logs, gated behind **`CTX_MERGE_PROBE=1`**, PII-safe per-message descriptors for both sides + the dedup outcome:

`{ id, role, pName, len, ph (placeholder), ftr (footer present), relay ("**Name:** …" echo shape), fwd, aDesc/emb/voc/fAtt/rx (attachment-metadata counts), inDb (live id covered by a DB row) }`

**No raw message content is logged** (per the no-PII-in-logs rule) — only derived booleans/lengths/IDs/roles.

### How it resolves each candidate
- **B**: a `live` entry with `relay:true, role:assistant` — is `inDb` true (should dedup) or false (DB row missing/race)? Is there a `db` entry for that id with `role:user`?
- **A**: is `ftr:true` on the DB copy, the live copy, or both?
- **C**: does the blank image/embed message carry any attachment metadata (`aDesc/emb/voc/fAtt > 0`) on either side, or is it empty everywhere?

### Use
Off by default (zero prod impact, no perf cost when unset). After merge + dev deploy: set `CTX_MERGE_PROBE=1` on the dev `ai-worker` service, reproduce one `/character random` (or chime-in), one image post + character reply, one footered/incognito response; read the `[CTX-MERGE-PROBE]` log lines. Then a follow-up fixes the trio at this boundary and a cleanup commit removes the probe.

## Test plan
- `pnpm quality` green (lint, typechecks, build)
- `historyMerger.test.ts` green (+1 test: probe logging doesn't change the merged result)

🤖 Generated with [Claude Code](https://claude.com/claude-code)