### PR TITLE
debug(common-types): fix context-merge probe window

### DIFF
--- a/packages/common-types/src/utils/historyMerger.ts
+++ b/packages/common-types/src/utils/historyMerger.ts
@@ -201,27 +201,6 @@ export function mergeWithHistory(
     'Merged extended context with DB history'
   );
 
-  // TEMPORARY diagnostic (debug PR, CTX_MERGE_PROBE=1): dump PII-safe per-message
-  // descriptors for both sides + the dedup result so we can read — at runtime, on
-  // dev — which copy of each message survives the merge and with what shape. This
-  // is the single boundary where the beta.133 context trio converges (footer leak,
-  // chime-in role/order, blank image msgs). Capped to the most recent 15 per side
-  // to bound log volume. Remove with the cleanup commit once the mechanism is read.
-  if (process.env.CTX_MERGE_PROBE === '1') {
-    const TAIL = 15;
-    logger.info(
-      {
-        probe: 'ctx-merge',
-        dbCount: dbHistory.length,
-        liveCount: extendedMessages.length,
-        survivedLive: uniqueExtendedMessages.length,
-        db: dbHistory.slice(-TAIL).map(m => ctxProbeDescriptor(m, dbMessageMap)),
-        live: extendedMessages.slice(-TAIL).map(m => ctxProbeDescriptor(m, dbMessageMap)),
-      },
-      '[CTX-MERGE-PROBE]'
-    );
-  }
-
   // Combine: DB history (chronological, richer metadata) + unique extended messages
   const merged = [...dbHistory, ...uniqueExtendedMessages];
 
@@ -235,6 +214,29 @@ export function mergeWithHistory(
       b.createdAt instanceof Date ? b.createdAt.getTime() : new Date(b.createdAt).getTime();
     return timeA - timeB;
   });
+
+  // TEMPORARY diagnostic (debug PR, CTX_MERGE_PROBE=1): dump PII-safe descriptors for
+  // the most-recent slice of the FINAL merged result — i.e. exactly the recent window
+  // the prompt will render. Logging `merged` (which IS sorted oldest-first) rather than
+  // the raw `extendedMessages` array (newest-first from the Discord fetch) avoids the
+  // window-direction trap. `inDb` reveals whether each entry is DB-sourced (clean) or a
+  // unique live copy that leaked through dedup. This is the single boundary where the
+  // beta.133 context trio converges (footer leak / chime-in role+order / blank image
+  // msgs). Remove with the cleanup commit once the mechanism is read.
+  if (process.env.CTX_MERGE_PROBE === '1') {
+    const TAIL = 25;
+    logger.info(
+      {
+        probe: 'ctx-merge',
+        dbCount: dbHistory.length,
+        liveCount: extendedMessages.length,
+        survivedLive: uniqueExtendedMessages.length,
+        mergedCount: merged.length,
+        recent: merged.slice(-TAIL).map(m => ctxProbeDescriptor(m, dbMessageMap)),
+      },
+      '[CTX-MERGE-PROBE]'
+    );
+  }
 
   return merged;
 }


### PR DESCRIPTION
## Summary

Follow-up to #1234. The first probe logged `slice(-15)` of both `dbHistory` and `extendedMessages` assuming both are oldest-first. `dbHistory` is — but the Discord-fetched `extendedMessages` array is **newest-first**, so `slice(-15)` returned the *oldest* live messages, missing the recent image (Bug C) and relay-echo (Bug B) the probe exists to capture. (Confirmed against a real dev log: it did surface Bug A — footers present on live copies, absent on DB rows — but the recent window was missing.)

**Fix**: log the most-recent 25 of the final **`merged`** result (which *is* sorted oldest-first), so the probe shows exactly the recent prompt window, with `inDb` marking DB-sourced (clean) vs leaked-live entries. Still env-gated (`CTX_MERGE_PROBE=1`), still PII-safe (derived values only), still removed in the cleanup commit.

## Already learned from the first run
- **Bug A confirmed**: DB content is clean (`ftr:false`), footers exist only on live-fetched copies → fix is to strip `-#` footers from live content.
- Every live extended-context message is `role:"user"` — so the screenshots' `role=assistant` relay-echo is likely a DB row, which this fixed window will confirm.

## Test plan
- `pnpm quality` green
- `historyMerger.test.ts` green (the probe-unchanged-result test still passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)