### PR TITLE
fix(bot-client): normalize our-authored messages in extended context (Bug A + Bug B)

### DIFF
--- a/packages/common-types/src/constants/discord.ts
+++ b/packages/common-types/src/constants/discord.ts
@@ -307,4 +307,11 @@ export const BOT_FOOTER_PATTERNS = {
   FOCUS_MODE: /(?:^|\n)-# 🔒 Focus Mode • LTM retrieval disabled/g,
   /** Incognito mode indicator (memories not saved) */
   INCOGNITO_MODE: /(?:^|\n)-# 👻 Incognito Mode • Memories not being saved/g,
+  /**
+   * Transcription attribution (dynamic provider name + URL). Mirrors the
+   * builder in bot-client `VoiceTranscriptionService.buildTranscriptionFooter`
+   * (`-# Transcribed by [${name}](<${url}>)`) — keep the two in sync. The
+   * `[..]` / `<..>` captures absorb the dynamic provider name and link.
+   */
+  TRANSCRIBED: /(?:^|\n)-# Transcribed by \[[^\]]+\]\(<[^>]+>\)/g,
 } as const;

--- a/packages/common-types/src/index.ts
+++ b/packages/common-types/src/index.ts
@@ -27,6 +27,8 @@ export {
   truncateText,
   stripBotFooters,
   stripDmPrefix,
+  normalizeMessageForContext,
+  extractMessagePrefixName,
   findLeadingMentionsEnd,
   stripLeadingMentions,
 } from './utils/discord.js';

--- a/packages/common-types/src/services/conversationSyncDiff.ts
+++ b/packages/common-types/src/services/conversationSyncDiff.ts
@@ -9,7 +9,7 @@
  */
 
 import { createLogger } from '../utils/logger.js';
-import { stripBotFooters, stripDmPrefix } from '../utils/discord.js';
+import { normalizeMessageForContext } from '../utils/discord.js';
 
 const logger = createLogger('conversationSyncDiff');
 
@@ -63,11 +63,11 @@ export function collateChunksForSync(
   // Concatenate all chunk contents
   let collatedContent = sortedChunks.map(c => c.content).join('');
 
-  // Strip bot-added display elements that are NOT stored in the database:
-  // 1. DM prefix: "**Display Name:** " added for DM messages (webhooks don't work in DMs)
-  // 2. Footer lines: model indicator, guest mode, auto-response notices
-  collatedContent = stripDmPrefix(collatedContent);
-  collatedContent = stripBotFooters(collatedContent);
+  // Strip bot-added display elements that are NOT stored in the database via the
+  // single canonical normalizer (DM/relay prefix, then `-#` footers). Routing
+  // through `normalizeMessageForContext` keeps this path in lockstep with the
+  // live Discord fetch (`DiscordChannelFetcher`) so the strip steps can't drift.
+  collatedContent = normalizeMessageForContext(collatedContent);
 
   // SAFEGUARD: Skip sync if stripping left us with significantly less content
   // This protects against cases where footer stripping is too aggressive

--- a/packages/common-types/src/utils/discord.test.ts
+++ b/packages/common-types/src/utils/discord.test.ts
@@ -8,6 +8,8 @@ import {
   splitMessage,
   stripBotFooters,
   stripDmPrefix,
+  normalizeMessageForContext,
+  extractMessagePrefixName,
   findLeadingMentionsEnd,
   stripLeadingMentions,
 } from './discord.js';
@@ -275,9 +277,20 @@ Another paragraph here with more content.`;
       expect(stripBotFooters(content)).toBe('');
     });
 
+    it('should strip transcription attribution footer', () => {
+      const content =
+        'Hello world!\n-# Transcribed by [Mistral](<https://mistral.ai/news/voxtral>)';
+      expect(stripBotFooters(content)).toBe('Hello world!');
+    });
+
+    it('should strip standalone transcription attribution footer', () => {
+      const content = '-# Transcribed by [Whisper](<https://example.com/stt>)';
+      expect(stripBotFooters(content)).toBe('');
+    });
+
     it('should strip all footer types combined', () => {
       const content =
-        'Hello world!\n-# Model: [gpt-4](<https://example.com>) • 📍 auto\n-# 🆓 Using free model (no API key required)\n-# 🔒 Focus Mode • LTM retrieval disabled\n-# 👻 Incognito Mode • Memories not being saved';
+        'Hello world!\n-# Model: [gpt-4](<https://example.com>) • 📍 auto\n-# 🆓 Using free model (no API key required)\n-# 🔒 Focus Mode • LTM retrieval disabled\n-# 👻 Incognito Mode • Memories not being saved\n-# Transcribed by [Mistral](<https://example.com/stt>)';
       expect(stripBotFooters(content)).toBe('Hello world!');
     });
   });
@@ -330,6 +343,56 @@ Another paragraph here with more content.`;
     it('should handle prefix-only content', () => {
       const content = '**Name:** ';
       expect(stripDmPrefix(content)).toBe('');
+    });
+  });
+
+  describe('extractMessagePrefixName', () => {
+    it('should extract the name from a single-word prefix', () => {
+      expect(extractMessagePrefixName('**Lila:** poke')).toBe('Lila');
+    });
+
+    it('should extract a multi-word display name', () => {
+      expect(extractMessagePrefixName('**Test Bot Name:** hello')).toBe('Test Bot Name');
+    });
+
+    it('should extract a name containing emoji and special characters', () => {
+      expect(extractMessagePrefixName('**🌙 Luna:** moonlit')).toBe('🌙 Luna');
+      expect(extractMessagePrefixName('**Test-Name_123:** x')).toBe('Test-Name_123');
+    });
+
+    it('should return null when there is no prefix', () => {
+      expect(extractMessagePrefixName('just normal content')).toBeNull();
+    });
+
+    it('should return null for bold text not at the start', () => {
+      expect(extractMessagePrefixName('Hello **Name:** mid')).toBeNull();
+    });
+
+    it('should return null for empty string', () => {
+      expect(extractMessagePrefixName('')).toBeNull();
+    });
+  });
+
+  describe('normalizeMessageForContext', () => {
+    it('should strip the relay/DM prefix and bot footers together', () => {
+      const content =
+        '**Lila:** The actual reply.\n-# Model: [glm-5.2](<https://example/model>)\n-# 👻 Incognito Mode • Memories not being saved';
+      expect(normalizeMessageForContext(content)).toBe('The actual reply.');
+    });
+
+    it('should strip the transcription footer along with the rest', () => {
+      const content = '**Adam:** Heard you.\n-# Transcribed by [Mistral](<https://example/stt>)';
+      expect(normalizeMessageForContext(content)).toBe('Heard you.');
+    });
+
+    it('should be a no-op for plain content with neither prefix nor footer', () => {
+      const content = 'Just a normal message.';
+      expect(normalizeMessageForContext(content)).toBe(content);
+    });
+
+    it('should strip footers even when there is no prefix', () => {
+      const content = 'Reply text\n-# Model: [m](<u>)';
+      expect(normalizeMessageForContext(content)).toBe('Reply text');
     });
   });
 

--- a/packages/common-types/src/utils/discord.ts
+++ b/packages/common-types/src/utils/discord.ts
@@ -290,6 +290,55 @@ export function stripDmPrefix(content: string): string {
 }
 
 /**
+ * Capturing variant of {@link DM_PREFIX_PATTERN} — the same `**Name:** ` shape
+ * but with the name captured so callers can recover the attribution.
+ */
+const DM_PREFIX_NAME_PATTERN = /^\*\*([^*]+):\*\*\s*/;
+
+/**
+ * Extract the display name from a bot-added `**Name:** ` prefix, or `null` if
+ * the content has no such prefix.
+ *
+ * The same `channel.send("**Name:** …")` shape is used by two distinct bot
+ * paths, so the recovered name means different things depending on the path —
+ * the caller knows which it is from the message's author/registry status:
+ *  - DM personality response → the name is the PERSONALITY's display name.
+ *  - slash-command / chime-in relay echo → the name is the USER's display name.
+ *
+ * Apply ONLY to messages WE authored (same contract as
+ * {@link normalizeMessageForContext}); a real user typing literal `**foo:** bar`
+ * would otherwise be mis-attributed.
+ */
+export function extractMessagePrefixName(content: string): string | null {
+  const match = DM_PREFIX_NAME_PATTERN.exec(content);
+  return match !== null ? match[1].trim() : null;
+}
+
+/**
+ * Canonical normalization for a message's content before it enters LLM context.
+ *
+ * This is the SINGLE source of truth for the content-cleaning every
+ * context-building path must apply — the live Discord fetch
+ * (`DiscordChannelFetcher`) and the DB-sync diff (`conversationSyncDiff`) both
+ * route through it so the steps can't drift between paths (the drift between
+ * those two is exactly what leaked footers / left relay prefixes in the model
+ * context). Apply ONLY to messages WE authored (our bot user or our personality
+ * webhooks); real users' `-#`/`**…:**` text is theirs and must be left intact.
+ *
+ * Steps, in order:
+ * 1. Strip the relay / DM `**Name:** ` prefix the bot adds for slash-command
+ *    and DM visibility (`stripDmPrefix`).
+ * 2. Strip our `-#` subtext footers — model indicator, incognito/focus mode,
+ *    auto-response, transcription attribution (`stripBotFooters`).
+ *
+ * Both sub-functions are pattern-specific (they match only our exact shapes),
+ * so this never mangles legitimate user content even if mis-applied.
+ */
+export function normalizeMessageForContext(content: string): string {
+  return stripBotFooters(stripDmPrefix(content));
+}
+
+/**
  * Find the first index of `s` that is NOT part of a leading Discord mention
  * or the whitespace surrounding one. Skips stacked mentions in a loop, so
  * `@Bot\n<@adminId> hello` returns the index of `h`.

--- a/services/bot-client/src/services/DiscordChannelFetcher.test.ts
+++ b/services/bot-client/src/services/DiscordChannelFetcher.test.ts
@@ -77,6 +77,7 @@ function createMockMessage(
     memberJoinedAt: Date | null;
     guildId: string | null;
     isBot: boolean;
+    webhookId: string | null;
     type: MessageType;
     createdAt: Date;
     attachments: Map<string, MockAttachment>;
@@ -96,6 +97,7 @@ function createMockMessage(
     memberJoinedAt: null,
     guildId: null,
     isBot: false,
+    webhookId: null,
     type: MessageType.Default,
     createdAt: new Date('2024-01-01T12:00:00Z'),
     attachments: new Map(),
@@ -133,6 +135,7 @@ function createMockMessage(
       bot: config.isBot,
     },
     member,
+    webhookId: config.webhookId,
     guild: config.guildId ? { id: config.guildId } : null,
     type: config.type,
     createdAt: config.createdAt,
@@ -250,7 +253,7 @@ describe('DiscordChannelFetcher', () => {
       expect(result.messages).toHaveLength(1);
     });
 
-    it('should identify bot messages as assistant role', async () => {
+    it('identifies our webhook character reply as assistant role (registry detection)', async () => {
       const botUserId = 'bot123';
 
       const messages = [
@@ -263,9 +266,13 @@ describe('DiscordChannelFetcher', () => {
         createMockMessage({
           id: '2',
           content: 'Bot response',
-          authorId: botUserId,
+          // Real webhook messages are authored by the WEBHOOK, not the primary
+          // bot user: author.id !== botUserId and webhookId is set. (The old
+          // tests modelled webhooks as authorId === botUserId, which never
+          // matched production — the root of the footer-strip-never-ran bug.)
+          authorId: 'webhook-2',
           authorUsername: 'TestBot',
-          isBot: true,
+          webhookId: 'webhook-2',
         }),
       ];
 
@@ -274,6 +281,8 @@ describe('DiscordChannelFetcher', () => {
       const result = await fetcher.fetchRecentMessages(channel, {
         botUserId,
         personalityName: 'TestPersonality',
+        // Registry resolves this webhook message to one of our personalities.
+        getOurPersonalityId: async id => (id === '2' ? 'personality-uuid' : null),
       });
 
       const userMsg = result.messages.find(m => m.role === MessageRole.User);
@@ -284,27 +293,30 @@ describe('DiscordChannelFetcher', () => {
 
       expect(assistantMsg).toBeDefined();
       expect(assistantMsg!.content).toBe('Bot response');
-      // Assistant messages use the webhook username as personalityName for multi-AI attribution
+      // personalityName is the webhook display name (the registry stores the
+      // UUID; the username carries the human-readable name). No suffix to strip.
       expect(assistantMsg!.personalityName).toBe('TestBot');
       expect(assistantMsg!.personaName).toBeUndefined();
     });
 
-    it('should extract personality name from webhook using canonical " · BotName" suffix', async () => {
+    it('extracts personality name from webhook " · BotName" suffix (registry-miss fallback)', async () => {
       const botUserId = 'bot123';
 
       const messages = [
         createMockMessage({
           id: '1',
           content: 'Bot response from webhook',
-          authorId: botUserId,
+          authorId: 'webhook-1',
           // Webhook name format: "DisplayName · BotName" (current canonical form)
           authorUsername: 'Lila · תשב',
-          isBot: true,
+          webhookId: 'webhook-1',
         }),
       ];
 
       const channel = createMockChannel(messages);
 
+      // No getOurPersonalityId → registry miss; the bot-suffix is the fallback
+      // ownership detector for guild webhooks whose registry key expired.
       const result = await fetcher.fetchRecentMessages(channel, {
         botUserId,
         botSuffix: ' · תשב',
@@ -317,19 +329,19 @@ describe('DiscordChannelFetcher', () => {
       expect(assistantMsg!.personalityName).toBe('Lila');
     });
 
-    it('should extract personality name from webhook using legacy " | BotName" suffix (back-compat)', async () => {
+    it('extracts personality name from webhook legacy " | BotName" suffix (back-compat)', async () => {
       const botUserId = 'bot123';
 
       const messages = [
         createMockMessage({
           id: '1',
           content: 'Bot response from legacy webhook',
-          authorId: botUserId,
+          authorId: 'webhook-1',
           // Legacy webhook name format: "DisplayName | BotName" — older
           // messages keep their original pipe separator and must still
           // parse correctly (backward-compat read path).
           authorUsername: 'Lila | תשב',
-          isBot: true,
+          webhookId: 'webhook-1',
         }),
       ];
 
@@ -346,15 +358,47 @@ describe('DiscordChannelFetcher', () => {
       expect(assistantMsg!.personalityName).toBe('Lila');
     });
 
-    it('falls back to raw webhook username when no botSuffix is supplied (back-compat)', async () => {
+    it('falls back to raw webhook username for personalityName when no botSuffix is supplied', async () => {
       const botUserId = 'bot123';
 
       const messages = [
         createMockMessage({
           id: '1',
           content: 'Bot response',
-          authorId: botUserId,
+          authorId: 'webhook-1',
           authorUsername: 'Lila · תשב',
+          webhookId: 'webhook-1',
+        }),
+      ];
+
+      const channel = createMockChannel(messages);
+
+      // Registry establishes ownership; with no botSuffix there's nothing to
+      // strip, so the raw webhook username is used as the personalityName
+      // (degraded but not broken — caller's choice to opt in to stripping).
+      const result = await fetcher.fetchRecentMessages(channel, {
+        botUserId,
+        personalityName: 'CurrentPersonality',
+        getOurPersonalityId: async () => 'personality-uuid',
+      });
+
+      const assistantMsg = result.messages.find(m => m.role === MessageRole.Assistant);
+      expect(assistantMsg).toBeDefined();
+      expect(assistantMsg!.personalityName).toBe('Lila · תשב');
+    });
+
+    it('classifies a primary-bot relay-echo of user input as a user message (Bug B)', async () => {
+      const botUserId = 'bot123';
+
+      const messages = [
+        createMockMessage({
+          id: '1',
+          // Chime-in / slash-command relay echo: sent by the PRIMARY bot user
+          // via channel.send("**Name:** message"). The Name is the USER's
+          // display name, and the message is USER content — not the bot's.
+          content: '**Lila:** poke',
+          authorId: botUserId,
+          authorUsername: 'Rotzot',
           isBot: true,
         }),
       ];
@@ -363,14 +407,141 @@ describe('DiscordChannelFetcher', () => {
 
       const result = await fetcher.fetchRecentMessages(channel, {
         botUserId,
-        personalityName: 'CurrentPersonality',
+        botSuffix: ' · תשב',
+        // Relay echoes are NOT in the our-webhook registry (it holds personality
+        // responses only), so the registry resolver returns null for them.
+        getOurPersonalityId: async () => null,
       });
 
-      const assistantMsg = result.messages.find(m => m.role === MessageRole.Assistant);
-      expect(assistantMsg).toBeDefined();
-      // No botSuffix in options → extractPersonalityName returns the raw username
-      // (degraded but not broken — caller's choice to opt in to stripping)
-      expect(assistantMsg!.personalityName).toBe('Lila · תשב');
+      const msg = result.messages[0];
+      expect(msg.role).toBe(MessageRole.User);
+      // Attributed to the user from the prefix, not to the bot/personality.
+      expect(msg.personaName).toBe('Lila');
+      expect(msg.personalityName).toBeUndefined();
+      // The "**Name:** " prefix is stripped from the content seen by the model.
+      expect(msg.content).toBe('poke');
+    });
+
+    it('classifies a primary-bot DM personality response as an assistant message', async () => {
+      const botUserId = 'bot123';
+
+      const messages = [
+        createMockMessage({
+          id: '1',
+          // DMs can't use webhooks, so personality responses are sent by the
+          // primary bot as "**Personality:** content" — and ARE registered.
+          content: '**Lila:** hello there',
+          authorId: botUserId,
+          authorUsername: 'Rotzot',
+          isBot: true,
+        }),
+      ];
+
+      const channel = createMockChannel(messages);
+
+      const result = await fetcher.fetchRecentMessages(channel, {
+        botUserId,
+        getOurPersonalityId: async () => 'personality-uuid',
+      });
+
+      const msg = result.messages[0];
+      expect(msg.role).toBe(MessageRole.Assistant);
+      // Personality display name comes from the "**Name:** " prefix in DMs.
+      expect(msg.personalityName).toBe('Lila');
+      expect(msg.content).toBe('hello there');
+    });
+
+    it('strips our -# footers (model / incognito / transcription) from webhook replies (Bug A)', async () => {
+      const botUserId = 'bot123';
+      const content = [
+        'The actual reply.',
+        '-# Model: [glm-5.2](<https://example/model>)',
+        '-# 👻 Incognito Mode • Memories not being saved',
+        '-# Transcribed by [Mistral](<https://example/stt>)',
+      ].join('\n');
+
+      const messages = [
+        createMockMessage({
+          id: '1',
+          content,
+          authorId: 'webhook-1',
+          authorUsername: 'Lila · תשב',
+          webhookId: 'webhook-1',
+        }),
+      ];
+
+      const channel = createMockChannel(messages);
+
+      const result = await fetcher.fetchRecentMessages(channel, {
+        botUserId,
+        botSuffix: ' · תשב',
+        getOurPersonalityId: async () => 'personality-uuid',
+      });
+
+      const msg = result.messages[0];
+      expect(msg.role).toBe(MessageRole.Assistant);
+      // All three footer kinds gone; only the real reply text reaches the model.
+      expect(msg.content).toBe('The actual reply.');
+      expect(msg.content).not.toContain('-#');
+      expect(msg.content).not.toContain('Incognito');
+      expect(msg.content).not.toContain('Transcribed by');
+    });
+
+    it('leaves a real user message containing footer/prefix-shaped text intact', async () => {
+      const botUserId = 'bot123';
+
+      const messages = [
+        createMockMessage({
+          id: '1',
+          // A human literally typing these shapes — must NOT be stripped or
+          // re-attributed; normalization is scoped to OUR messages only.
+          content: '**Important:** read this\n-# Model: not really a footer',
+          authorId: 'user1',
+          authorUsername: 'alice',
+        }),
+      ];
+
+      const channel = createMockChannel(messages);
+
+      const result = await fetcher.fetchRecentMessages(channel, {
+        botUserId,
+        getOurPersonalityId: async () => null,
+      });
+
+      const msg = result.messages[0];
+      expect(msg.role).toBe(MessageRole.User);
+      expect(msg.content).toBe('**Important:** read this\n-# Model: not really a footer');
+      expect(msg.personaName).toBe('alice');
+    });
+
+    it('treats a foreign webhook (registry miss + no suffix match) as a user message', async () => {
+      const botUserId = 'bot123';
+
+      const messages = [
+        createMockMessage({
+          id: '1',
+          // A non-ours webhook (e.g. PluralKit): has a webhookId, but the
+          // registry doesn't know it AND its username carries no bot-suffix.
+          content: 'proxied human message',
+          authorId: 'pk-webhook-1',
+          authorUsername: 'SomeSystemMember',
+          webhookId: 'pk-webhook-1',
+        }),
+      ];
+
+      const channel = createMockChannel(messages);
+
+      const result = await fetcher.fetchRecentMessages(channel, {
+        botUserId,
+        botSuffix: ' · תשב',
+        getOurPersonalityId: async () => null, // registry miss
+      });
+
+      const msg = result.messages[0];
+      // Not ours → user role, content untouched, no personality attribution.
+      expect(msg.role).toBe(MessageRole.User);
+      expect(msg.content).toBe('proxied human message');
+      expect(msg.personalityName).toBeUndefined();
     });
 
     it('should filter out system messages', async () => {

--- a/services/bot-client/src/services/DiscordChannelFetcher.ts
+++ b/services/bot-client/src/services/DiscordChannelFetcher.ts
@@ -12,7 +12,8 @@ import {
   MESSAGE_LIMITS,
   ConversationSyncService,
   computeHistoryCutoff,
-  stripBotFooters,
+  normalizeMessageForContext,
+  extractMessagePrefixName,
   type ConversationMessage,
   type AttachmentMetadata,
   type MessageReaction,
@@ -23,7 +24,7 @@ import {
 import { buildMessageContent, hasMessageContent } from '../utils/MessageContentBuilder.js';
 import { isUserContentMessage } from '../utils/messageTypeUtils.js';
 import { resolveHistoryLinks } from '../utils/HistoryLinkResolver.js';
-import { extractPersonalityName } from '../utils/webhookNaming.js';
+import { extractPersonalityName, stripBotSuffix } from '../utils/webhookNaming.js';
 
 import {
   isThinkingBlockMessage,
@@ -271,15 +272,23 @@ export class DiscordChannelFetcher {
           collectedImageAttachments.push(...images);
         }
 
+        // Collect guild info + unique user info for participant/persona
+        // resolution — but ONLY for messages authored by a real (non-bot) user.
+        // A relay-echo is now correctly role=User (Bug B), yet it's authored by
+        // the PRIMARY bot; the user it represents has no resolvable Discord
+        // identity on a bot-authored message, so sweeping `msg.author` here would
+        // register the bot (or a PluralKit webhook id) as a bogus participant.
+        const isRealUser = msg.author.bot !== true;
+
         // Collect guild info for user participants
         const personaId = conversionResult.message.personaId;
-        if (conversionResult.message.role === MessageRole.User && msg.member) {
+        if (conversionResult.message.role === MessageRole.User && isRealUser && msg.member) {
           delete participantGuildInfo[personaId];
           participantGuildInfo[personaId] = extractGuildInfo(msg);
         }
 
         // Collect unique user info
-        if (conversionResult.message.role === MessageRole.User) {
+        if (conversionResult.message.role === MessageRole.User && isRealUser) {
           const discordId = msg.author.id;
           if (!uniqueUsers.has(discordId)) {
             uniqueUsers.set(discordId, {
@@ -319,18 +328,71 @@ export class DiscordChannelFetcher {
   }
 
   /**
+   * Classify a message's authorship for role + normalization decisions.
+   *
+   * Mirrors the dual-detection in `ReferenceEnrichmentService.isWebhookMessage`
+   * (our-webhook registry primary, `webhookId` + bot-suffix as fallback). Three
+   * "ours" outcomes drive downstream handling:
+   *  - our guild webhook character reply → assistant
+   *  - our DM personality response (primary bot, registered; webhooks don't work
+   *    in DMs so it's sent as `**Personality:** …`) → assistant
+   *  - our primary-bot relay-echo of USER input (`channel.send("**Name:** …")`,
+   *    not registered) → user
+   *
+   * Everything else — real humans, PluralKit, unaffiliated webhooks — is not
+   * ours: role=user, content left untouched.
+   */
+  private async classifyAuthorship(
+    msg: Message,
+    options: FetchOptions,
+    authorName: string
+  ): Promise<{ isOurMessage: boolean; isOurAssistant: boolean }> {
+    const isPrimaryBot = msg.author.id === options.botUserId;
+    const hasWebhookId =
+      msg.webhookId !== undefined && msg.webhookId !== null && msg.webhookId.length > 0;
+
+    // Registry lookup only for potentially-ours messages; real human messages
+    // (the majority) skip the Redis round-trip entirely.
+    let registeredPersonalityId: string | null = null;
+    if (isPrimaryBot || hasWebhookId) {
+      registeredPersonalityId = (await options.getOurPersonalityId?.(msg.id)) ?? null;
+    }
+
+    // Bot-suffix fallback for guild webhooks whose registry key expired (TTL) or
+    // was never stored (transient failure) — same tier-down as reply resolution.
+    const suffixMatches =
+      hasWebhookId &&
+      options.botSuffix !== undefined &&
+      options.botSuffix.length > 0 &&
+      stripBotSuffix(authorName, options.botSuffix) !== null;
+
+    const isOurWebhook = hasWebhookId && (registeredPersonalityId !== null || suffixMatches);
+    const isOurDmResponse = isPrimaryBot && registeredPersonalityId !== null;
+    const isOurRelayEcho = isPrimaryBot && registeredPersonalityId === null;
+
+    return {
+      isOurMessage: isOurWebhook || isOurDmResponse || isOurRelayEcho,
+      isOurAssistant: isOurWebhook || isOurDmResponse,
+    };
+  }
+
+  /**
    * Convert a Discord message to ConversationMessage format
    */
-  // eslint-disable-next-line complexity, sonarjs/cognitive-complexity -- Message type conversion branches for role detection, content building, attachment handling, reference resolution, forwarded message extraction, and bot-footer stripping on prior assistant turns
+  // eslint-disable-next-line complexity, sonarjs/cognitive-complexity -- Message type conversion branches for content building, attachment handling, reference resolution, forwarded message extraction, and our-message normalization
   private async convertMessage(
     msg: Message,
     options: FetchOptions,
     resolvedReferences?: Map<string, StoredReferencedMessage[]>
   ): Promise<{ message: ConversationMessage; attachments: AttachmentMetadata[] } | null> {
-    const isBot = msg.author.id === options.botUserId;
-    const role = isBot ? MessageRole.Assistant : MessageRole.User;
     const authorName =
       msg.member?.displayName ?? msg.author.globalName ?? msg.author.username ?? 'Unknown';
+    const { isOurMessage, isOurAssistant } = await this.classifyAuthorship(
+      msg,
+      options,
+      authorName
+    );
+    const role = isOurAssistant ? MessageRole.Assistant : MessageRole.User;
 
     const {
       content: rawContent,
@@ -361,12 +423,25 @@ export class DiscordChannelFetcher {
       return null;
     }
 
-    // Strip bot-emitted footers (model indicator, incognito mode, auto-response,
-    // etc.) from prior assistant turns so the model doesn't see its own footers
-    // in extended context and roleplay around them. Mirrors the DB-persisted-
-    // history strip in channelFetcher/SyncValidator.ts. User messages are
-    // left untouched — footer-shaped text in user content is user-authored.
-    const content = isBot ? stripBotFooters(rawContent) : rawContent;
+    // Normalize ONLY messages WE authored: strip the bot-added `**Name:** `
+    // relay/DM prefix and our `-#` subtext footers (model indicator,
+    // incognito/focus mode, auto-response, transcription) so the model never
+    // sees them in extended context and roleplays around them. Real users'
+    // content is theirs — `-#`/`**…:**` text there is user-authored, left
+    // intact. Single source of truth shared with the DB-sync path
+    // (conversationSyncDiff) via normalizeMessageForContext so the two can't drift.
+    const content =
+      isOurMessage && rawContent !== undefined
+        ? normalizeMessageForContext(rawContent)
+        : rawContent;
+
+    // Recover the attribution carried in our `**Name:** ` prefix before it's
+    // stripped: for an assistant DM response it's the personality's display
+    // name; for a relay-echo of user input it's the USER's display name. Scoped
+    // to OUR messages so a real user typing literal `**foo:** bar` isn't
+    // mis-attributed.
+    const prefixName =
+      isOurMessage && rawContent !== undefined ? extractMessagePrefixName(rawContent) : null;
     const hasMetadata = embedsXml !== undefined || voiceTranscripts !== undefined;
     let messageMetadata: ConversationMessage['messageMetadata'] = hasMetadata
       ? { embedsXml, voiceTranscripts }
@@ -400,14 +475,14 @@ export class DiscordChannelFetcher {
       createdAt: msg.createdAt,
       personaId:
         role === MessageRole.User ? `${INTERNAL_DISCORD_ID_PREFIX}${msg.author.id}` : 'assistant',
-      personaName: role === MessageRole.User ? authorName : undefined,
+      personaName: role === MessageRole.User ? (prefixName ?? authorName) : undefined,
       discordUsername: msg.author.username,
       discordMessageId: [msg.id],
       isForwarded: isForwarded || undefined,
       messageMetadata,
       personalityName:
         role === MessageRole.Assistant
-          ? extractPersonalityName(authorName, options.botSuffix ?? '')
+          ? (prefixName ?? extractPersonalityName(authorName, options.botSuffix ?? ''))
           : undefined,
       channelId: msg.channelId,
       guildId: msg.guildId,

--- a/services/bot-client/src/services/MessageContextBuilder.test.ts
+++ b/services/bot-client/src/services/MessageContextBuilder.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MessageContextBuilder } from './MessageContextBuilder.js';
+import { redisService } from '../redis.js';
 import type { PrismaClient } from '@tzurot/common-types';
 import type {
   Message,
@@ -57,7 +58,8 @@ vi.mock('../utils/discordContext.js', () => ({
   })),
 }));
 
-// Mock redis since TranscriptRetriever imports it
+// Mock redis since TranscriptRetriever imports it and the extended-context
+// fetch wires redisService.getWebhookPersonality through as getOurPersonalityId.
 vi.mock('../redis.js', () => ({
   redisService: {
     get: vi.fn(),
@@ -66,6 +68,7 @@ vi.mock('../redis.js', () => ({
     exists: vi.fn(),
     expire: vi.fn(),
     setWithExpiry: vi.fn(),
+    getWebhookPersonality: vi.fn(),
   },
 }));
 
@@ -1542,6 +1545,51 @@ describe('MessageContextBuilder', () => {
       expect(mockFetchCrossChannelIfEnabled).toHaveBeenCalledWith(
         expect.objectContaining({ enabled: false })
       );
+    });
+
+    it('wires the our-webhook registry into the fetch via getOurPersonalityId', async () => {
+      vi.mocked(mockUserService.getOrCreateUser).mockResolvedValue({
+        userId: 'user-uuid-123',
+        defaultPersonaId: 'test-persona-id',
+      });
+      vi.mocked(mockHistoryService.getChannelHistory).mockResolvedValue([]);
+      mockFetchRecentMessages.mockResolvedValue({
+        messages: [],
+        fetchedCount: 0,
+        filteredCount: 0,
+      });
+      mockExtractReferencesWithReplacement.mockResolvedValue({
+        references: [],
+        updatedContent: 'content',
+      });
+      mockResolveAllMentions.mockResolvedValue({
+        processedContent: 'content',
+        mentionedUsers: [],
+        mentionedChannels: [],
+        mentionedRoles: [],
+      });
+      vi.mocked(redisService.getWebhookPersonality).mockResolvedValue('personality-uuid');
+
+      // extendedContext + botUserId are required for the fetch to run at all.
+      await builder.buildContext(mockMessage, mockPersonality, 'content', {
+        extendedContext: {
+          maxMessages: 20,
+          maxAge: null,
+          maxImages: 0,
+          sources: { maxMessages: 'personality', maxAge: 'personality', maxImages: 'personality' },
+        },
+        botUserId: 'bot-123',
+      });
+
+      // The fetch received a getOurPersonalityId callback that delegates to the
+      // registry — invoking it proves the registry is actually plumbed in (the
+      // crux of the Bug A/B classification fix), not just constructed.
+      const fetchOptions = mockFetchRecentMessages.mock.calls[0]?.[1] as {
+        getOurPersonalityId?: (id: string) => Promise<string | null>;
+      };
+      expect(fetchOptions.getOurPersonalityId).toBeTypeOf('function');
+      await expect(fetchOptions.getOurPersonalityId!('msg-id-1')).resolves.toBe('personality-uuid');
+      expect(redisService.getWebhookPersonality).toHaveBeenCalledWith('msg-id-1');
     });
   });
 });

--- a/services/bot-client/src/services/MessageContextBuilder.ts
+++ b/services/bot-client/src/services/MessageContextBuilder.ts
@@ -24,12 +24,13 @@ import type { Message } from 'discord.js';
 import type { MessageContext } from '../types.js';
 import { extractDiscordEnvironment } from '../utils/discordContext.js';
 import { buildMessageContent } from '../utils/MessageContentBuilder.js';
-import { getThreadParentId } from '../utils/discordChannelTypes.js';
+import { buildBlockDeniedChecker } from './contextBuilder/blockDeniedChecker.js';
 import { hasVoiceAttachments } from '../utils/forwardedMessageUtils.js';
 import { selectContextVariant } from './contextBuilder/contextVariant.js';
 import { MentionResolver } from './MentionResolver.js';
 import { DiscordChannelFetcher, type FetchableChannel } from './DiscordChannelFetcher.js';
 import { deriveBotSuffix } from '../utils/webhookNaming.js';
+import { redisService } from '../redis.js';
 import type { DenylistCache } from './DenylistCache.js';
 import { TranscriptRetriever } from '../handlers/references/TranscriptRetriever.js';
 import {
@@ -168,7 +169,7 @@ export class MessageContextBuilder {
   /**
    * Fetch extended context from Discord channel and merge with history.
    */
-  // eslint-disable-next-line max-lines-per-function, sonarjs/cognitive-complexity -- Cohesive extended context workflow with guard clauses and optional feature checks
+  // eslint-disable-next-line max-lines-per-function -- Cohesive extended context workflow with guard clauses and optional feature checks
   private async fetchExtendedContext(
     params: ExtendedContextParams
   ): Promise<ExtendedContextResult> {
@@ -210,24 +211,11 @@ export class MessageContextBuilder {
         personalityId: personality.id,
         getTranscript: (discordMessageId, attachmentUrl) =>
           this.transcriptRetriever.retrieveTranscript(discordMessageId, attachmentUrl),
+        getOurPersonalityId: (discordMessageId: string) =>
+          redisService.getWebhookPersonality(discordMessageId),
         contextEpoch,
         maxAge: options.extendedContext.maxAge,
-        isBlockDenied:
-          this.denylistCache !== undefined
-            ? (discordUserId: string) => {
-                const cache = this.denylistCache;
-                if (cache === undefined) {
-                  return false;
-                }
-                return cache.isBlocked(
-                  discordUserId,
-                  message.guildId ?? undefined,
-                  message.channelId,
-                  personality.id,
-                  getThreadParentId(message.channel) ?? undefined
-                );
-              }
-            : undefined,
+        isBlockDenied: buildBlockDeniedChecker(this.denylistCache, message, personality.id),
       }
     );
 

--- a/services/bot-client/src/services/channelFetcher/types.ts
+++ b/services/bot-client/src/services/channelFetcher/types.ts
@@ -77,6 +77,25 @@ export interface FetchOptions {
   personalityId?: string;
   /** Optional transcript retriever for voice messages */
   getTranscript?: (discordMessageId: string, attachmentUrl: string) => Promise<string | null>;
+  /**
+   * Optional resolver for "is this message one of OUR personality messages, and
+   * which personality?" — the authoritative our-webhook registry
+   * (`redisService.getWebhookPersonality`), returning the personality UUID or
+   * `null`. Used to classify message role/identity in `convertMessage`:
+   *  - A guild webhook message in the registry → our character reply (assistant).
+   *  - A primary-bot message in the registry → our DM personality response
+   *    (assistant; webhooks don't work in DMs).
+   *  - A primary-bot message NOT in the registry → a relay-echo / transcript of
+   *    USER content (`channel.send("**Name:** …")`), which is user-role content.
+   * Mirrors the dual-detection in `ReferenceEnrichmentService.isWebhookMessage`
+   * (registry primary, `webhookId` + bot-suffix as fallback). Optional, but the
+   * fallback only covers GUILD webhooks (bot-suffix on the webhook username): if
+   * this is omitted, primary-bot DM personality responses (no `webhookId`, no
+   * suffix) are misclassified as relay-echoes (user role). Production always
+   * wires it; the option exists for tests that classify by suffix or never
+   * exercise primary-bot DM messages.
+   */
+  getOurPersonalityId?: (messageId: string) => Promise<string | null>;
   /** Whether to resolve Discord message links in history (default: true) */
   resolveLinks?: boolean;
   /** Context epoch - ignore messages before this timestamp (from /history clear) */

--- a/services/bot-client/src/services/contextBuilder/blockDeniedChecker.test.ts
+++ b/services/bot-client/src/services/contextBuilder/blockDeniedChecker.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Message } from 'discord.js';
+import type { DenylistCache } from '../DenylistCache.js';
+import { buildBlockDeniedChecker } from './blockDeniedChecker.js';
+
+function mockMessage(overrides: Record<string, unknown> = {}): Message {
+  return {
+    guildId: 'guild-1',
+    channelId: 'channel-1',
+    channel: { id: 'channel-1', type: 0 },
+    ...overrides,
+  } as unknown as Message;
+}
+
+describe('buildBlockDeniedChecker', () => {
+  it('returns undefined when no denylist cache is configured', () => {
+    expect(buildBlockDeniedChecker(undefined, mockMessage(), 'p-1')).toBeUndefined();
+  });
+
+  it('returns a predicate that delegates to cache.isBlocked with full scope', () => {
+    const isBlocked = vi.fn().mockReturnValue(true);
+    const cache = { isBlocked } as unknown as DenylistCache;
+
+    const predicate = buildBlockDeniedChecker(cache, mockMessage(), 'p-1');
+    expect(predicate).toBeDefined();
+    expect(predicate!('user-9')).toBe(true);
+    expect(isBlocked).toHaveBeenCalledWith('user-9', 'guild-1', 'channel-1', 'p-1', undefined);
+  });
+
+  it('passes undefined guildId for DM messages', () => {
+    const isBlocked = vi.fn().mockReturnValue(false);
+    const cache = { isBlocked } as unknown as DenylistCache;
+
+    const predicate = buildBlockDeniedChecker(cache, mockMessage({ guildId: null }), 'p-2');
+    expect(predicate!('user-1')).toBe(false);
+    expect(isBlocked).toHaveBeenCalledWith('user-1', undefined, 'channel-1', 'p-2', undefined);
+  });
+});

--- a/services/bot-client/src/services/contextBuilder/blockDeniedChecker.ts
+++ b/services/bot-client/src/services/contextBuilder/blockDeniedChecker.ts
@@ -1,0 +1,39 @@
+/**
+ * Block-denied predicate factory for the extended-context fetch.
+ *
+ * Extracted from MessageContextBuilder so that file stays within the max-lines
+ * budget and the closure gets a colocated test. The predicate answers "is this
+ * Discord user BLOCK-denied for this personality, in this channel/thread?" and
+ * is handed to `DiscordChannelFetcher` to filter denied users out of context.
+ */
+
+import type { Message } from 'discord.js';
+import { getThreadParentId } from '../../utils/discordChannelTypes.js';
+import type { DenylistCache } from '../DenylistCache.js';
+
+/**
+ * Build the `isBlockDenied` predicate, or `undefined` when no denylist cache is
+ * configured (the fetcher treats an absent predicate as "filter nothing").
+ *
+ * @param denylistCache - the per-replica denylist cache, or undefined
+ * @param message - the trigger message (source of guild/channel/thread scope)
+ * @param personalityId - the responding personality's id (denylist is per-personality)
+ */
+export function buildBlockDeniedChecker(
+  denylistCache: DenylistCache | undefined,
+  message: Message,
+  personalityId: string
+): ((discordUserId: string) => boolean) | undefined {
+  const cache = denylistCache;
+  if (cache === undefined) {
+    return undefined;
+  }
+  return (discordUserId: string): boolean =>
+    cache.isBlocked(
+      discordUserId,
+      message.guildId ?? undefined,
+      message.channelId,
+      personalityId,
+      getThreadParentId(message.channel) ?? undefined
+    );
+}


### PR DESCRIPTION
## What

Fixes two beta.133-gating context-assembly bugs (found via `/inspect` in the dev smoke test), both rooted in how the **live Discord fetch** (`DiscordChannelFetcher.convertMessage`) classifies and cleans messages **we authored** — plus a consolidation of footer/prefix stripping so the live-fetch and DB-sync paths can no longer drift.

### Bug A — `-#` footers leaked into model context
Character (webhook) replies carried our human-facing footers verbatim into replayed `<message>` content sent to the LLM: `-# Model: …`, `-# 👻 Incognito Mode • Memories not being saved`, `-# Transcribed by …`. The incognito one is the worst — it told the model incognito state.

Root cause: the old `isBot = author.id === botUserId` check **never matched real webhook messages** (authored by the webhook, not the primary bot user), so footer-stripping silently never ran on character replies. The transcription footer pattern was also missing from `BOT_FOOTER_PATTERNS` entirely.

### Bug B — chime-in relay echo mis-roled / mis-attributed
A chime-in / slash-command relay echo (`channel.send("**Name:** …")`, sent by the primary bot) was classified `assistant` and attributed to the bot. It should be a `user`-role message attributed to the user via its prefix. (Probe-confirmed: the apparent "mis-ordering" was this attribution bug — the trigger legitimately follows the prior reply by timestamp but *read* as a bot message.)

## How

- **common-types**: `normalizeMessageForContext` (strip relay/DM prefix + `-#` footers) as the single source of truth; both `conversationSyncDiff` and the live fetch route through it. New `extractMessagePrefixName` for attribution recovery; added the missing `TRANSCRIBED` footer pattern.
- **DiscordChannelFetcher**: replaced the primary-bot-only `isBot` heuristic with registry-primary, bot-suffix-fallback authorship classification (`classifyAuthorship`), mirroring `ReferenceEnrichmentService.isWebhookMessage`. Our webhook replies + DM personality responses → assistant (footers/prefix stripped, personality attributed); primary-bot relay echoes → user (prefix stripped, user attributed). Real users' content (incl. PluralKit, literal `-#`/`**…:**` text) is left untouched. Bot-authored messages are excluded from participant/persona collection so a relay echo can't register the bot as a participant.
- Threaded the our-webhook registry lookup through `FetchOptions.getOurPersonalityId`.
- Extracted the `isBlockDenied` closure to `contextBuilder/blockDeniedChecker.ts` (keeps `MessageContextBuilder` under max-lines; colocated test added).

## Tests

- Rewrote the webhook tests to model **production reality** (`webhookId` set, `author.id !== botUserId`) instead of the prior fiction (`author.id === botUserId`) that masked Bug A.
- New cases: relay-echo → user, DM-response → assistant, footer-strip (model + incognito + transcription), real-user-content-preservation.
- common-types coverage for `normalizeMessageForContext`, `extractMessagePrefixName`, and the `TRANSCRIBED` pattern.

## Not in this PR (sibling fixes, same release)
- **Bug C** — image/embed-only messages blank in history (vision desc not persisted onto the image row).
- **dedup-miss** — live vs DB copies with mismatched `discordMessageId` → duplication (the "why the ids mismatch" is still unpinned).
- **cross-provider vision misroute** + the `selectVisionModel` log-label fix.

These are being bundled into the next PR before beta.133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)