### PR TITLE
fix(context): history dedup + weigh-in persistence + vision misroute (beta.133 bundle)

### DIFF
--- a/packages/common-types/src/constants/ai.ts
+++ b/packages/common-types/src/constants/ai.ts
@@ -256,10 +256,9 @@ const ZAI_MODEL_CATALOG: Readonly<
 > = {
   'glm-5': { docsUrl: 'https://docs.z.ai/guides/llm/glm-5', contextLength: 200_000 },
   'glm-5.1': { docsUrl: 'https://docs.z.ai/guides/llm/glm-5.1', contextLength: 200_000 },
-  // glm-5.2 is z.ai's flagship and is NOT on OpenRouter yet — the catalog is
-  // its only source for context length AND release date (so `/models` can rank
-  // it by recency). Its docs page isn't published yet (the URL follows the
-  // established pattern and will resolve once z.ai adds it).
+  // glm-5.2 is z.ai's flagship and is NOT on OpenRouter — the catalog is its
+  // only source for context length AND release date (so `/models` can rank it
+  // by recency). The docs URL follows z.ai's established per-model pattern.
   'glm-5.2': {
     docsUrl: 'https://docs.z.ai/guides/llm/glm-5.2',
     contextLength: 1_000_000,

--- a/packages/common-types/src/utils/historyMerger.test.ts
+++ b/packages/common-types/src/utils/historyMerger.test.ts
@@ -390,6 +390,66 @@ describe('HistoryMerger', () => {
       expect(result.some(m => m.content === 'Extended content')).toBe(false);
     });
 
+    it('collapses duplicate DB rows sharing a Discord id (multi-personality user turn)', () => {
+      // A user @-pinged two characters: the trigger is persisted once per
+      // responding personality → two rows, SAME discordMessageId. The
+      // channel-scoped fetch returns both; the merge must surface it once.
+      const dbHistory = [
+        createMockMessage({
+          id: 'db-cold',
+          discordMessageId: ['user-msg-1'],
+          content: 'ping both of you',
+          createdAt: new Date('2024-01-01T12:00:00Z'),
+        }),
+        createMockMessage({
+          id: 'db-weaver',
+          discordMessageId: ['user-msg-1'], // same Discord id, different personality row
+          content: 'ping both of you',
+          createdAt: new Date('2024-01-01T12:00:00Z'),
+        }),
+        createMockMessage({
+          id: 'db-cold-reply',
+          discordMessageId: ['cold-reply-1'],
+          content: 'COLD replies',
+          createdAt: new Date('2024-01-01T12:00:30Z'),
+        }),
+        createMockMessage({
+          id: 'db-weaver-reply',
+          discordMessageId: ['weaver-reply-1'],
+          content: 'Weaver replies',
+          createdAt: new Date('2024-01-01T12:00:31Z'),
+        }),
+      ];
+
+      const result = mergeWithHistory([], dbHistory);
+
+      // Shared user turn appears exactly once...
+      expect(result.filter(m => m.content === 'ping both of you')).toHaveLength(1);
+      // ...each character's distinct reply (distinct id) is untouched.
+      expect(result.some(m => m.content === 'COLD replies')).toBe(true);
+      expect(result.some(m => m.content === 'Weaver replies')).toBe(true);
+      expect(result).toHaveLength(3);
+    });
+
+    it('does not collapse distinct DB messages with different Discord ids', () => {
+      const dbHistory = [
+        createMockMessage({
+          discordMessageId: ['a'],
+          content: 'first',
+          createdAt: new Date('2024-01-01T12:00:00Z'),
+        }),
+        createMockMessage({
+          discordMessageId: ['b'],
+          content: 'second',
+          createdAt: new Date('2024-01-01T12:01:00Z'),
+        }),
+      ];
+
+      const result = mergeWithHistory([], dbHistory);
+
+      expect(result).toHaveLength(2);
+    });
+
     it('should sort by timestamp (oldest first)', () => {
       const extendedMessages = [
         createMockMessage({

--- a/packages/common-types/src/utils/historyMerger.ts
+++ b/packages/common-types/src/utils/historyMerger.ts
@@ -148,6 +148,46 @@ function ctxProbeDescriptor(
 }
 
 /**
+ * Collapse DB-history rows that represent the SAME Discord message.
+ *
+ * `conversation_history` rows are personality-scoped and there is no unique
+ * constraint on `discordMessageId`, so a single Discord message that triggered
+ * N personalities (a user's @-ping to multiple characters in one channel) is
+ * stored as N rows sharing the same `discordMessageId`. `getChannelHistory` is
+ * channel-scoped — it fetches ALL personalities' rows — so every duplicate
+ * comes back, and the merge would otherwise surface that one user turn N times
+ * in the model context.
+ *
+ * Collapsing by shared id only ever removes TRUE duplicates: distinct Discord
+ * messages never share a snowflake, and each character's own reply is its own
+ * Discord message with its own id, so assistant turns are never collapsed —
+ * only a shared trigger that was fanned out across personalities. Keeps the
+ * first occurrence (the caller supplies rows already in chronological order).
+ */
+function dedupeDbHistoryByMessageId(dbHistory: ConversationMessage[]): ConversationMessage[] {
+  const seenIds = new Set<string>();
+  const deduped: ConversationMessage[] = [];
+  let droppedCount = 0;
+  for (const msg of dbHistory) {
+    if (msg.discordMessageId.some(id => seenIds.has(id))) {
+      droppedCount++;
+      continue;
+    }
+    for (const id of msg.discordMessageId) {
+      seenIds.add(id);
+    }
+    deduped.push(msg);
+  }
+  if (droppedCount > 0) {
+    logger.debug(
+      { droppedCount, originalCount: dbHistory.length },
+      'Collapsed duplicate channel-history rows sharing a Discord message id'
+    );
+  }
+  return deduped;
+}
+
+/**
  * Merge extended context messages with database conversation history
  *
  * This handles deduplication when the same message appears in both sources.
@@ -161,9 +201,16 @@ export function mergeWithHistory(
   extendedMessages: ConversationMessage[],
   dbHistory: ConversationMessage[]
 ): ConversationMessage[] {
+  // Collapse same-Discord-message duplicate rows FIRST. A user's @-ping to
+  // multiple characters is persisted once per responding personality (rows are
+  // personality-scoped, no unique constraint on discordMessageId), and the
+  // channel-scoped getChannelHistory returns all of them — without this the
+  // merge would surface that one user turn N times. See dedupeDbHistoryByMessageId.
+  const dedupedDbHistory = dedupeDbHistoryByMessageId(dbHistory);
+
   // Build map of message IDs to DB messages for deduplication and content comparison
   const dbMessageMap = new Map<string, ConversationMessage>();
-  for (const msg of dbHistory) {
+  for (const msg of dedupedDbHistory) {
     for (const id of msg.discordMessageId) {
       dbMessageMap.set(id, msg);
     }
@@ -179,10 +226,10 @@ export function mergeWithHistory(
   }
 
   // Recover empty DB content from extended context
-  const recoveredCount = recoverEmptyDbContent(dbHistory, extendedMessageMap);
+  const recoveredCount = recoverEmptyDbContent(dedupedDbHistory, extendedMessageMap);
 
   // Enrich DB messages with extended context metadata (reactions, embeds)
-  enrichDbMessagesWithExtendedMetadata(dbHistory, extendedMessageMap);
+  enrichDbMessagesWithExtendedMetadata(dedupedDbHistory, extendedMessageMap);
 
   // Filter extended messages to exclude those already in DB history
   const uniqueExtendedMessages = extendedMessages.filter(msg => {
@@ -193,7 +240,8 @@ export function mergeWithHistory(
   logger.debug(
     {
       extendedCount: extendedMessages.length,
-      dbHistoryCount: dbHistory.length,
+      dbHistoryCount: dedupedDbHistory.length,
+      dbHistoryDuplicatesDropped: dbHistory.length - dedupedDbHistory.length,
       uniqueExtendedCount: uniqueExtendedMessages.length,
       deduplicatedCount: extendedMessages.length - uniqueExtendedMessages.length,
       recoveredCount,
@@ -202,7 +250,7 @@ export function mergeWithHistory(
   );
 
   // Combine: DB history (chronological, richer metadata) + unique extended messages
-  const merged = [...dbHistory, ...uniqueExtendedMessages];
+  const merged = [...dedupedDbHistory, ...uniqueExtendedMessages];
 
   // Sort by timestamp ascending (oldest first = chronological order)
   // This ensures newest messages appear last in the prompt, getting

--- a/services/ai-worker/src/services/multimodal/VisionProcessor.test.ts
+++ b/services/ai-worker/src/services/multimodal/VisionProcessor.test.ts
@@ -164,6 +164,35 @@ describe('VisionProcessor', () => {
         expect(mockCheckModelVisionSupport).not.toHaveBeenCalled();
       });
 
+      it('derives the z.ai provider from a glm vision model when caller omits provider', async () => {
+        const personality = createMockPersonality({
+          model: 'gpt-4',
+          visionModel: 'z-ai/glm-5.2',
+        });
+
+        await describeImage(mockAttachment, personality);
+
+        // Provider must be derived from the RESOLVED vision model — not left
+        // undefined, which would fall back to the env-default AI_PROVIDER and
+        // misroute this cross-provider call (→ 401 Missing Authentication).
+        expect(mockCreateChatModel).toHaveBeenCalledWith(
+          expect.objectContaining({ modelName: 'z-ai/glm-5.2', provider: 'zai-coding' })
+        );
+      });
+
+      it('derives the OpenRouter provider from a slash-form vision model', async () => {
+        const personality = createMockPersonality({
+          model: 'gpt-4',
+          visionModel: 'google/gemma-4-31b-it',
+        });
+
+        await describeImage(mockAttachment, personality);
+
+        expect(mockCreateChatModel).toHaveBeenCalledWith(
+          expect.objectContaining({ modelName: 'google/gemma-4-31b-it', provider: 'openrouter' })
+        );
+      });
+
       it('should use main model when it has vision support', async () => {
         mockCheckModelVisionSupport.mockResolvedValue(true);
 

--- a/services/ai-worker/src/services/multimodal/VisionProcessor.ts
+++ b/services/ai-worker/src/services/multimodal/VisionProcessor.ts
@@ -23,6 +23,7 @@ import {
   type LoadedPersonality,
 } from '@tzurot/common-types';
 import { createChatModel } from '../ModelFactory.js';
+import { detectVisionProvider } from '../ProviderRouter.js';
 import { parseApiError } from '../../utils/apiErrorParser.js';
 import { checkModelVisionSupport, visionDescriptionCache } from '../../redis.js';
 import { isDataUrl } from '../../utils/attachmentFetch.js';
@@ -136,16 +137,14 @@ export interface DescribeImageOptions {
   /** Diagnostic context for failure logging + source-aware fallback strings */
   loggingContext?: VisionLoggingContext;
   /**
-   * Explicit provider for the vision call, derived from the vision model name
-   * by the caller (typically via `detectVisionProvider` in `ProviderRouter`).
-   *
-   * **WARNING — all new callers MUST provide this.** Omitting it makes
-   * `createChatModel` fall back to the env-default `config.AI_PROVIDER`,
-   * which silently misroutes cross-provider personalities (e.g., main=z.ai-coding
-   * + vision=OpenRouter) and reproduces the exact 401 bug this resolver exists
-   * to prevent. The `?` is retained ONLY for backward compat with legacy tests
-   * predating the cross-provider fix; tracked in `backlog/inbox.md` as
-   * "Make `visionProvider` required in vision-pipeline option bags."
+   * Explicit provider for the vision call. When omitted, `describeImage` derives
+   * it from the RESOLVED vision model via `detectVisionProvider`, so an omitted
+   * provider no longer misroutes — the derivation is the safety net that keeps
+   * cross-provider personalities (e.g. main=z.ai-coding + vision=OpenRouter) on
+   * the right route instead of the env-default `config.AI_PROVIDER`. Still prefer
+   * passing it when the caller already knows the provider (e.g. a registry/
+   * resolver that also drives BYOK key routing); an explicit value wins over the
+   * derivation.
    */
   provider?: AIProvider;
   /**
@@ -468,10 +467,7 @@ export async function selectVisionModel(
     personality.visionModel !== null &&
     personality.visionModel.length > 0
   ) {
-    logger.info(
-      { visionModel: personality.visionModel },
-      'Using configured vision model (personality override)'
-    );
+    logger.info({ visionModel: personality.visionModel }, 'Using configured vision model');
     return personality.visionModel;
   }
 
@@ -579,10 +575,17 @@ export async function describeImage(
     options.model !== undefined && options.model.length > 0
       ? options.model
       : await selectVisionModel(personality, isGuestMode);
+  // Derive the provider from the RESOLVED vision model when the caller didn't
+  // supply one. An undefined provider makes createChatModel fall back to the
+  // env-default AI_PROVIDER, which misroutes cross-provider personalities (e.g.
+  // an OpenRouter vision model paired with a z.ai-coding main model) → wrong
+  // route → 401 Missing Authentication. detectVisionProvider maps the actual
+  // model name to its route, so key resolution and routing stay aligned.
+  const provider = options.provider ?? detectVisionProvider(usedModel);
   const description = await invokeVisionModel(attachment, usedModel, {
     systemPrompt,
     userApiKey,
-    provider: options.provider,
+    provider,
     loggingContext,
     personalityName: personality.name,
   });

--- a/services/bot-client/src/handlers/MessageHandler.test.ts
+++ b/services/bot-client/src/handlers/MessageHandler.test.ts
@@ -1068,7 +1068,11 @@ describe('MessageHandler', () => {
       expect(mockPersistence.saveAssistantMessage).not.toHaveBeenCalled();
     });
 
-    it('skips assistant persistence in weigh-in mode', async () => {
+    it('persists assistant response in weigh-in mode (history-only; memory stays gated in ai-worker)', async () => {
+      // Weigh-in/chime-in responses ARE persisted to conversation history so they
+      // survive past the live-fetch window and stay in cross-turn continuity.
+      // Long-term memory creation is gated separately on isWeighIn in the
+      // ai-worker, so persisting here does not violate incognito semantics.
       const ctx = createSlashContext({ isWeighInMode: true });
       mockJobTracker.getContext.mockReturnValue(ctx);
       mockResponseSender.sendResponse.mockResolvedValue({ chunkMessageIds: ['m-1'] });
@@ -1079,7 +1083,9 @@ describe('MessageHandler', () => {
         content: 'Weighing in',
       } as unknown as LLMGenerationResult);
 
-      expect(mockPersistence.saveAssistantMessageFromFields).not.toHaveBeenCalled();
+      expect(mockPersistence.saveAssistantMessageFromFields).toHaveBeenCalledWith(
+        expect.objectContaining({ content: 'Weighing in', chunkMessageIds: ['m-1'] })
+      );
     });
 
     it('updates diagnostic response IDs with the slash requestId', async () => {

--- a/services/bot-client/src/handlers/MessageHandler.ts
+++ b/services/bot-client/src/handlers/MessageHandler.ts
@@ -432,20 +432,21 @@ export class MessageHandler {
         ttsNotices: result.metadata?.ttsNotices,
       });
 
-      // Persist assistant message; skip in weigh-in mode (ai-worker also skips
-      // LTM storage, and the response wasn't anchored to a user prompt the
-      // history would meaningfully reference).
-      if (!isWeighInMode) {
-        await this.persistence.saveAssistantMessageFromFields({
-          channelId: channel.id,
-          guildId,
-          personality,
-          personaId,
-          content,
-          chunkMessageIds,
-          userMessageTime,
-        });
-      }
+      // Persist the assistant response to conversation history — including
+      // weigh-in/chime-in responses, so they survive once they age out of the
+      // live-fetch window and stay part of cross-turn continuity. This is a
+      // history-only write: long-term MEMORY creation is gated separately on
+      // isWeighIn in the ai-worker (ConversationalRAGService), so persisting
+      // here keeps the incognito "no memories" semantics intact.
+      await this.persistence.saveAssistantMessageFromFields({
+        channelId: channel.id,
+        guildId,
+        personality,
+        personaId,
+        content,
+        chunkMessageIds,
+        userMessageTime,
+      });
 
       if (chunkMessageIds.length > 0) {
         void updateDiagnosticResponseIds(result.requestId, chunkMessageIds).catch(err => {

--- a/services/bot-client/src/services/ConversationPersistence.ts
+++ b/services/bot-client/src/services/ConversationPersistence.ts
@@ -198,6 +198,29 @@ export class ConversationPersistence {
       embedsXml = buildResult.embedsXml;
     }
 
+    // TEMPORARY diagnostic (debug, EMBED_PERSIST_PROBE=1): confirm the embed-only
+    // blank-history mechanism. embedsXml is currently only built for FORWARDED
+    // messages (above), so a regular link-embed message never persists it — and
+    // once it ages out of the live-fetch window it renders blank. This probe
+    // answers the one remaining question for the fix: at persist time, does a
+    // non-forwarded message ALREADY carry its embed (so "persist embedsXml for
+    // all" suffices) or not yet (Discord async embed resolution → also needs a
+    // re-capture on messageUpdate)? PII-safe: ids/booleans/counts only, no
+    // content. Remove with the embed fix once read.
+    if (process.env.EMBED_PERSIST_PROBE === '1') {
+      logger.info(
+        {
+          probe: 'embed-persist',
+          messageId: message.id,
+          isForwarded,
+          embedCountAtPersist: message.embeds.length,
+          embedsXmlPersisted: embedsXml !== undefined && embedsXml.length > 0,
+          contentLength: messageContent.length,
+        },
+        '[EMBED-PERSIST-PROBE]'
+      );
+    }
+
     // Delegate to field-based implementation with Message fields extracted.
     // Pass `message.createdAt` as the explicit timestamp so the user row's
     // `createdAt` matches the Discord post time. Without this, the row used

--- a/services/bot-client/src/services/DiscordChannelFetcher.test.ts
+++ b/services/bot-client/src/services/DiscordChannelFetcher.test.ts
@@ -420,6 +420,77 @@ describe('DiscordChannelFetcher', () => {
       expect(msg.personalityName).toBeUndefined();
       // The "**Name:** " prefix is stripped from the content seen by the model.
       expect(msg.content).toBe('poke');
+      // The bot (relay author) must NOT be registered as a participant — the
+      // isRealUser guard excludes bot-authored messages from user collection.
+      expect(result.extendedContextUsers ?? []).not.toContainEqual(
+        expect.objectContaining({ discordId: botUserId })
+      );
+    });
+
+    it('classifies a primary-bot relay-echo with no prefix as a user message (bot name fallback)', async () => {
+      const botUserId = 'bot123';
+
+      const messages = [
+        createMockMessage({
+          id: '1',
+          // Edge case: a primary-bot message not in the registry and with no
+          // "**Name:** " prefix (e.g. an error fallback). It's still user-role
+          // (not our assistant), and personaName falls back to the author name.
+          content: 'plain bot-authored text, no prefix',
+          authorId: botUserId,
+          authorUsername: 'Rotzot',
+          isBot: true,
+        }),
+      ];
+
+      const channel = createMockChannel(messages);
+
+      const result = await fetcher.fetchRecentMessages(channel, {
+        botUserId,
+        getOurPersonalityId: async () => null, // not registered
+      });
+
+      const msg = result.messages[0];
+      expect(msg.role).toBe(MessageRole.User);
+      // No prefix to parse → personaName falls back to the author display name.
+      expect(msg.personaName).toBe('Rotzot');
+      expect(msg.content).toBe('plain bot-authored text, no prefix');
+      // Still excluded from participant collection (bot-authored).
+      expect(result.extendedContextUsers ?? []).not.toContainEqual(
+        expect.objectContaining({ discordId: botUserId })
+      );
+    });
+
+    it('classifies a primary-bot DM response as a relay-echo when the registry misses (documented degradation)', async () => {
+      // Documents the registry-miss degradation: a real DM personality response
+      // whose registry key expired/never-stored is classified as a relay-echo
+      // (user role) on the LIVE copy. In production this is dedup-mitigated — the
+      // DM response is persisted as role=assistant and the live copy dedups
+      // against the DB row, so the misclassification never reaches the model.
+      const botUserId = 'bot123';
+
+      const messages = [
+        createMockMessage({
+          id: '1',
+          content: '**Lila:** hello there',
+          authorId: botUserId,
+          authorUsername: 'Rotzot',
+          isBot: true,
+        }),
+      ];
+
+      const channel = createMockChannel(messages);
+
+      const result = await fetcher.fetchRecentMessages(channel, {
+        botUserId,
+        getOurPersonalityId: async () => null, // registry miss (TTL expired / never stored)
+      });
+
+      const msg = result.messages[0];
+      // Degrades to user-role relay-echo (the documented, dedup-mitigated path).
+      expect(msg.role).toBe(MessageRole.User);
+      expect(msg.personaName).toBe('Lila');
+      expect(msg.content).toBe('hello there');
     });
 
     it('classifies a primary-bot DM personality response as an assistant message', async () => {

--- a/services/bot-client/src/services/DiscordChannelFetcher.ts
+++ b/services/bot-client/src/services/DiscordChannelFetcher.ts
@@ -430,18 +430,14 @@ export class DiscordChannelFetcher {
     // content is theirs — `-#`/`**…:**` text there is user-authored, left
     // intact. Single source of truth shared with the DB-sync path
     // (conversationSyncDiff) via normalizeMessageForContext so the two can't drift.
-    const content =
-      isOurMessage && rawContent !== undefined
-        ? normalizeMessageForContext(rawContent)
-        : rawContent;
+    const content = isOurMessage ? normalizeMessageForContext(rawContent) : rawContent;
 
     // Recover the attribution carried in our `**Name:** ` prefix before it's
     // stripped: for an assistant DM response it's the personality's display
     // name; for a relay-echo of user input it's the USER's display name. Scoped
     // to OUR messages so a real user typing literal `**foo:** bar` isn't
     // mis-attributed.
-    const prefixName =
-      isOurMessage && rawContent !== undefined ? extractMessagePrefixName(rawContent) : null;
+    const prefixName = isOurMessage ? extractMessagePrefixName(rawContent) : null;
     const hasMetadata = embedsXml !== undefined || voiceTranscripts !== undefined;
     let messageMetadata: ConversationMessage['messageMetadata'] = hasMetadata
       ? { embedsXml, voiceTranscripts }

--- a/services/bot-client/src/services/contextBuilder/blockDeniedChecker.test.ts
+++ b/services/bot-client/src/services/contextBuilder/blockDeniedChecker.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import { ChannelType } from 'discord.js';
 import type { Message } from 'discord.js';
 import type { DenylistCache } from '../DenylistCache.js';
 import { buildBlockDeniedChecker } from './blockDeniedChecker.js';
@@ -34,5 +35,23 @@ describe('buildBlockDeniedChecker', () => {
     const predicate = buildBlockDeniedChecker(cache, mockMessage({ guildId: null }), 'p-2');
     expect(predicate!('user-1')).toBe(false);
     expect(isBlocked).toHaveBeenCalledWith('user-1', undefined, 'channel-1', 'p-2', undefined);
+  });
+
+  it('passes the thread parent id to cache.isBlocked for thread channels', () => {
+    const isBlocked = vi.fn().mockReturnValue(false);
+    const cache = { isBlocked } as unknown as DenylistCache;
+
+    const predicate = buildBlockDeniedChecker(
+      cache,
+      mockMessage({
+        channelId: 'thread-1',
+        channel: { id: 'thread-1', type: ChannelType.PublicThread, parentId: 'parent-1' },
+      }),
+      'p-3'
+    );
+    predicate!('user-1');
+    // 5th arg is the thread's PARENT id (denylist applies at the parent scope),
+    // not undefined as for a top-level text channel.
+    expect(isBlocked).toHaveBeenCalledWith('user-1', 'guild-1', 'thread-1', 'p-3', 'parent-1');
   });
 });

--- a/services/bot-client/src/services/contextBuilder/blockDeniedChecker.ts
+++ b/services/bot-client/src/services/contextBuilder/blockDeniedChecker.ts
@@ -24,12 +24,14 @@ export function buildBlockDeniedChecker(
   message: Message,
   personalityId: string
 ): ((discordUserId: string) => boolean) | undefined {
-  const cache = denylistCache;
-  if (cache === undefined) {
+  if (denylistCache === undefined) {
     return undefined;
   }
+  // `denylistCache` is a never-reassigned parameter, so TS keeps the
+  // non-undefined narrowing inside the returned closure (unlike the class
+  // field this was extracted from, which needed a local alias).
   return (discordUserId: string): boolean =>
-    cache.isBlocked(
+    denylistCache.isBlocked(
       discordUserId,
       message.guildId ?? undefined,
       message.channelId,


### PR DESCRIPTION
## What

The contained half of the beta.133 context-assembly bundle (Bug C's image fix is a follow-up PR). Six commits, each independently tested.

### 1. Merge-layer dedup — `mergeWithHistory`
A user's @-ping to multiple characters persists the trigger **once per responding personality** (`conversation_history` rows are personality-scoped, no unique constraint on `discordMessageId`). The channel-scoped `getChannelHistory` returns all of them, and `mergeWithHistory` deduped live-vs-DB but **never within `dbHistory`** — so that one user turn surfaced N times in model context (confirmed in dev system-prompt dumps). Fix: `dedupeDbHistoryByMessageId` collapses rows sharing any `discordMessageId` (keep first). Distinct messages never share a snowflake and each character's reply is its own message, so only a fanned-out shared trigger collapses. Heals existing history at read time.

### 2. Weigh-in/chime-in persistence — `MessageHandler`
Weigh-in responses were skipped at persistence, so they evaporated once they aged out of the live-fetch window. Now persisted (success path). History-only: long-term memory creation is gated **independently** on `isWeighIn` in the ai-worker (`ConversationalRAGService`), verified decoupled — so incognito "no memories" semantics are intact. Error path stays guarded (a failed generation isn't a "response").

### 3. Vision misroute + log-label — `VisionProcessor`
Cross-provider personalities (e.g. OpenRouter vision model under a z.ai-coding main model) misrouted to the env-default `AI_PROVIDER` → 401, because `describeImage` passed an undefined `provider`. Fix: derive it from the **resolved** vision model via `detectVisionProvider(usedModel)` when the caller omits it. Also drop the misleading "(personality override)" from the `selectVisionModel` log.

### 4. GLM-5.2 docs comment refresh — `common-types`
z.ai launched GLM 5.2; the docs URL resolves now. Stale "not published yet" note dropped.

### 5. Folded #1236 review nits
Dead `rawContent` guards removed (`content` is typed `string`); `blockDeniedChecker` `cache` alias dropped (param narrows in the closure); + tests: relay-echo excluded from `extendedContextUsers`, no-prefix relay echo, DM registry-miss degradation, thread-scoped `isBlockDenied`.

### 6. Embed-persist probe (`debug`, gated `EMBED_PERSIST_PROBE=1`)
`embedsXml` is only persisted for **forwarded** messages (`ConversationPersistence:193`), so a regular link-embed message never persists it → blank once aged out. The probe confirms whether the fix is "persist for all" or also needs `messageUpdate` re-capture (Discord async embed resolution).

## Not in this PR (beta.133 follow-ups)
- **Bug C image fix** — image-only messages blank in history (`imageDescriptions` never persisted). 5-layer change (persist markers + serialization placeholder + ai-worker write-back); its own focused PR.
- **Embed fix** — once the probe data is read.

## Test
Per-area targeted suites green; `pnpm quality` green. Full suite via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)