### PR TITLE
debug(ai-worker): probe vision-auth key resolution (cross-provider 401)

### DIFF
--- a/services/ai-worker/src/services/ModelFactory.test.ts
+++ b/services/ai-worker/src/services/ModelFactory.test.ts
@@ -96,6 +96,24 @@ describe('ModelFactory', () => {
       );
     });
 
+    it('runs the gated vision-auth probe when VISION_AUTH_PROBE=1 (debug instrumentation)', () => {
+      process.env.VISION_AUTH_PROBE = '1';
+      try {
+        const config: ModelConfig = {
+          modelName: 'google/gemma-4-31b-it',
+          apiKey: 'test-api-key',
+        };
+        // The env-gated probe block runs inside buildOpenRouterModel; assert the
+        // model still builds normally (covers the diagnostic path).
+        createChatModel(config);
+        expect(mockChatOpenAI).toHaveBeenCalledWith(
+          expect.objectContaining({ modelName: 'google/gemma-4-31b-it' })
+        );
+      } finally {
+        delete process.env.VISION_AUTH_PROBE;
+      }
+    });
+
     it('should always set __includeRawResponse:true so the OpenRouter reasoning extractor has access to the raw API response', () => {
       // Required for extractAndPopulateOpenRouterReasoning() in LLMInvoker to read
       // additional_kwargs.__raw_response. If this assertion ever fails, also check

--- a/services/ai-worker/src/services/ModelFactory.ts
+++ b/services/ai-worker/src/services/ModelFactory.ts
@@ -375,6 +375,26 @@ function buildOpenRouterModel(
     throw new Error('OPENROUTER_API_KEY is required for AI generation');
   }
 
+  // TEMPORARY diagnostic (debug, VISION_AUTH_PROBE=1): pin the cross-provider
+  // vision 401 — logs the FINAL key length handed to ChatOpenAI (never the key)
+  // and whether the per-request key or the system fallback was used, for the
+  // failing model. Noisy (fires for every OpenRouter build while enabled) but
+  // env-gated + short-lived. Remove with the vision-auth fix once read.
+  if (process.env.VISION_AUTH_PROBE === '1') {
+    const perRequestKeyLen = modelConfig.apiKey?.length ?? 0;
+    logger.info(
+      {
+        probe: 'vision-auth',
+        site: 'buildOpenRouterModel',
+        modelName,
+        perRequestKeyLen,
+        usedSystemFallback: perRequestKeyLen === 0,
+        finalApiKeyLen: apiKey.length,
+      },
+      '[VISION-AUTH-PROBE]'
+    );
+  }
+
   const extraParams = buildOpenRouterExtraParams(modelConfig);
   const hasExtraParams = Object.keys(extraParams).length > 0;
   const hasReasoning =

--- a/services/ai-worker/src/services/multimodal/VisionProcessor.test.ts
+++ b/services/ai-worker/src/services/multimodal/VisionProcessor.test.ts
@@ -193,6 +193,19 @@ describe('VisionProcessor', () => {
         );
       });
 
+      it('runs the gated vision-auth probe when VISION_AUTH_PROBE=1 (debug instrumentation)', async () => {
+        process.env.VISION_AUTH_PROBE = '1';
+        try {
+          const personality = createMockPersonality({ visionModel: 'gpt-4-vision-preview' });
+          // The env-gated probe (logVisionAuthProbe) runs in invokeVisionModel; the
+          // call still returns its description (covers the diagnostic path).
+          const result = await describeImage(mockAttachment, personality);
+          expect(result).toBe('Mocked image description');
+        } finally {
+          delete process.env.VISION_AUTH_PROBE;
+        }
+      });
+
       it('should use main model when it has vision support', async () => {
         mockCheckModelVisionSupport.mockResolvedValue(true);
 

--- a/services/ai-worker/src/services/multimodal/VisionProcessor.ts
+++ b/services/ai-worker/src/services/multimodal/VisionProcessor.ts
@@ -32,6 +32,19 @@ const logger = createLogger('VisionProcessor');
 const config = getConfig();
 
 /**
+ * TEMPORARY diagnostic (debug, VISION_AUTH_PROBE=1): PII-safe vision-auth probe to
+ * pin the cross-provider vision 401 ("Missing Authentication header" despite a real
+ * system key). Logs key LENGTHS/provider/source only — never the key itself — so we
+ * can tell an empty resolved key from a non-empty-but-rejected one. Remove with the
+ * vision-auth fix once read.
+ */
+function logVisionAuthProbe(fields: Record<string, unknown>): void {
+  if (process.env.VISION_AUTH_PROBE === '1') {
+    logger.info({ probe: 'vision-auth', ...fields }, '[VISION-AUTH-PROBE]');
+  }
+}
+
+/**
  * User-friendly labels for the ATTACHMENT-BOUND error categories that actually reach
  * `FAILURE_LABELS` via `buildFailureFallback`. Other categories (auth, quota, rate-limit,
  * server-error, timeout, network, etc.) return the generic "temporarily unavailable"
@@ -235,6 +248,16 @@ async function invokeVisionModel(
       'invokeVisionModel called without explicit provider — misrouting risk for cross-provider personalities'
     );
   }
+
+  // TEMPORARY diagnostic (debug, VISION_AUTH_PROBE=1) — see logVisionAuthProbe.
+  logVisionAuthProbe({
+    site: 'invokeVisionModel',
+    modelName,
+    provider: provider ?? null,
+    userApiKeyLen: userApiKey?.length ?? 0,
+    apiKeySource: loggingContext.apiKeySource ?? null,
+    personalityName,
+  });
 
   const { model } = createChatModel({
     modelName,


### PR DESCRIPTION
## What

Temporary diagnostic to pin the cross-provider vision 401 surfaced in beta.133 dev testing: a personality with a z.ai main model + an OpenRouter vision model gets `401 Missing Authentication header` even though the dev system OpenRouter key is real.

## Why a probe

The 401 is contradictory under code-reading: `buildOpenRouterModel` guarantees a **non-empty** key reaches the client (resolved key → system fallback → else *throws*; we got a real 401, not the throw), and vision calls don't use the custom-fetch path that could strip headers. So an empty/absent auth header "shouldn't" be possible — which means the cause is runtime state I can't see (cache, resolution path, etc.). Per the project's "code-reading is not runtime verification" rule, I'm not shipping a fix on a guess.

## The probe (gated `VISION_AUTH_PROBE=1`, PII-safe — lengths only)
- `invokeVisionModel`: key length + provider/source reaching `createChatModel`.
- `buildOpenRouterModel`: final key length handed to `ChatOpenAI` + whether the per-request key or the system fallback was used, per model.

One reproduction of the failing cross-provider image splits the diagnosis: empty resolved key (→ `resolveVisionConfig`/`tryResolveUserKey` bug) vs. non-empty-but-rejected key.

## Lifecycle
`debug` commit; removed with the vision-auth fix (tracked in `backlog/inbox.md` alongside the embed fix + probe removals). The contained vision fix is a beta.133 blocker per the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)