### PR TITLE
fix(ai-worker): resolve cross-provider vision key in the RAG path (Bug Y)

### DIFF
--- a/services/ai-worker/src/jobs/AIJobProcessor.ts
+++ b/services/ai-worker/src/jobs/AIJobProcessor.ts
@@ -98,13 +98,17 @@ export class AIJobProcessor {
     this.prisma = prisma;
     this.memoryManager = memoryManager;
 
+    // Use provided ApiKeyResolver (for testing) or create new one (for production)
+    // ApiKeyResolver handles BYOK - looking up and decrypting user API keys.
+    // Constructed before the RAG service so it can be injected for cross-provider
+    // vision-key resolution in the RAG history/reference paths.
+    this.apiKeyResolver = apiKeyResolver ?? new ApiKeyResolver(prisma);
+
     // Use provided RAGService (for testing) or create new one (for production)
     // Note: PersonaResolver is passed through to MemoryRetriever for persona-based memory retrieval
-    this.ragService = ragService ?? new ConversationalRAGService(memoryManager, personaResolver);
-
-    // Use provided ApiKeyResolver (for testing) or create new one (for production)
-    // ApiKeyResolver handles BYOK - looking up and decrypting user API keys
-    this.apiKeyResolver = apiKeyResolver ?? new ApiKeyResolver(prisma);
+    this.ragService =
+      ragService ??
+      new ConversationalRAGService(memoryManager, personaResolver, this.apiKeyResolver);
 
     // Use provided LlmConfigResolver (for testing) or create new one (for production)
     // LlmConfigResolver handles user config overrides (per-personality and global default)

--- a/services/ai-worker/src/services/AttachmentProcessor.test.ts
+++ b/services/ai-worker/src/services/AttachmentProcessor.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { AttachmentType, type LoadedPersonality } from '@tzurot/common-types';
+import { AttachmentType, AIProvider, type LoadedPersonality } from '@tzurot/common-types';
 import { processAttachmentsParallel } from './AttachmentProcessor.js';
 
 // Use vi.hoisted() to create mocks that persist across test resets
@@ -88,6 +88,40 @@ describe('AttachmentProcessor', () => {
       expect(result).toHaveLength(1);
       expect(result[0]).toContain('- Image (photo.png): A beautiful landscape');
       expect(mockDescribeImage).toHaveBeenCalledTimes(1);
+    });
+
+    it('forwards the resolved vision provider and model to describeImage (cross-provider key)', async () => {
+      mockDescribeImage.mockResolvedValue('A cross-provider description');
+
+      await processAttachmentsParallel({
+        attachments: [
+          {
+            url: 'https://example.com/image.png',
+            contentType: 'image/png',
+            name: 'photo.png',
+            size: 1000,
+          },
+        ],
+        referenceNumber: 1,
+        personality: mockPersonality,
+        isGuestMode: false,
+        userApiKey: 'vision-provider-key',
+        visionProvider: AIProvider.OpenRouter,
+        model: 'google/gemma-4-31b-it',
+      });
+
+      // The resolved vision key/provider/model must reach describeImage so the
+      // reference path doesn't 401 on a cross-provider vision model.
+      expect(mockDescribeImage).toHaveBeenCalledWith(
+        expect.objectContaining({ url: 'https://example.com/image.png' }),
+        mockPersonality,
+        false,
+        'vision-provider-key',
+        expect.objectContaining({
+          provider: AIProvider.OpenRouter,
+          model: 'google/gemma-4-31b-it',
+        })
+      );
     });
 
     it('should process voice message attachments', async () => {

--- a/services/ai-worker/src/services/AttachmentProcessor.ts
+++ b/services/ai-worker/src/services/AttachmentProcessor.ts
@@ -55,6 +55,8 @@ interface ProcessSingleAttachmentOptions {
   loggingContext?: VisionLoggingContext;
   /** Explicit provider for vision calls (from `detectVisionProvider` on the personality's vision model) */
   visionProvider?: AIProvider;
+  /** Pre-resolved vision model (from `resolveVisionConfig`); honored over `selectVisionModel`. */
+  model?: string;
 }
 
 /**
@@ -73,6 +75,8 @@ interface ProcessImageOptions {
   loggingContext?: VisionLoggingContext;
   /** Explicit provider for vision calls */
   visionProvider?: AIProvider;
+  /** Pre-resolved vision model (from `resolveVisionConfig`); honored over `selectVisionModel`. */
+  model?: string;
 }
 
 /**
@@ -92,6 +96,8 @@ export interface ProcessAttachmentsOptions {
   loggingContext?: VisionLoggingContext;
   /** Explicit provider for vision calls (from `detectVisionProvider` on the personality's vision model) */
   visionProvider?: AIProvider;
+  /** Pre-resolved vision model (from `resolveVisionConfig`); honored over `selectVisionModel`. */
+  model?: string;
 }
 
 /**
@@ -114,6 +120,7 @@ export async function processAttachmentsParallel(
     sttDispatch,
     loggingContext,
     visionProvider,
+    model,
   } = options;
   if (!attachments || attachments.length === 0) {
     return [];
@@ -131,6 +138,7 @@ export async function processAttachmentsParallel(
       sttDispatch,
       loggingContext,
       visionProvider,
+      model,
     })
   );
 
@@ -225,6 +233,7 @@ async function processImageAttachment(
     userApiKey,
     loggingContext = {},
     visionProvider,
+    model,
   } = options;
   if (preprocessed?.description !== undefined && preprocessed.description !== '') {
     logger.debug({ referenceNumber, url: attachment.url }, 'Using preprocessed image description');
@@ -247,6 +256,7 @@ async function processImageAttachment(
           skipNegativeCache: true,
           loggingContext,
           provider: visionProvider,
+          model,
         }),
       {
         maxAttempts: RETRY_CONFIG.MAX_ATTEMPTS,
@@ -279,6 +289,7 @@ async function processSingleAttachment(
     sttDispatch,
     loggingContext,
     visionProvider,
+    model,
   } = options;
   const preprocessed = findPreprocessedByUrl(attachment.url, preprocessedAttachments);
 
@@ -297,6 +308,7 @@ async function processSingleAttachment(
       userApiKey,
       loggingContext,
       visionProvider,
+      model,
     });
   }
 

--- a/services/ai-worker/src/services/ConversationInputProcessor.test.ts
+++ b/services/ai-worker/src/services/ConversationInputProcessor.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ConversationInputProcessor } from './ConversationInputProcessor.js';
 import {
   AttachmentType,
+  AIProvider,
   type LoadedPersonality,
   type MessageContent,
   type ReferencedMessage,
@@ -194,6 +195,72 @@ describe('ConversationInputProcessor', () => {
           isGuestMode: false,
           userApiKey: 'user-api-key',
           loggingContext: expect.objectContaining({ apiKeySource: 'user' }),
+        })
+      );
+    });
+
+    it('threads resolved visionAuth (key/provider/model) into the inline-fallback vision call', async () => {
+      const attachments = [{ url: 'http://example.com/cat.jpg', contentType: 'image/jpeg' }];
+      mockProcessAttachments.mockResolvedValue([]);
+      const context = createMockContext({ attachments });
+
+      await processor.processInputs(mockPersonality, mockMessage, context, {
+        isGuestMode: false,
+        userApiKey: 'main-model-key', // main key — must NOT be used for vision
+        visionAuth: {
+          userApiKey: 'vision-provider-key',
+          visionProvider: AIProvider.OpenRouter,
+          model: 'google/gemma-4-31b-it',
+        },
+      });
+
+      // Inline fallback must use the resolved vision key/provider/model, not the main key.
+      expect(mockProcessAttachments).toHaveBeenCalledWith(
+        attachments,
+        mockPersonality,
+        expect.objectContaining({
+          userApiKey: 'vision-provider-key',
+          visionProvider: AIProvider.OpenRouter,
+          model: 'google/gemma-4-31b-it',
+        })
+      );
+    });
+
+    it('threads resolved visionAuth into formatReferencedMessages', async () => {
+      const referencedMessages: ReferencedMessage[] = [
+        {
+          referenceNumber: 1,
+          discordMessageId: 'msg1',
+          discordUserId: 'user1',
+          authorUsername: 'user1',
+          authorDisplayName: 'User One',
+          content: 'Referenced content',
+          embeds: '',
+          timestamp: '2025-01-01T00:00:00Z',
+          locationContext: '<location/>',
+        },
+      ];
+      const context = createMockContext({ referencedMessages });
+
+      await processor.processInputs(mockPersonality, mockMessage, context, {
+        isGuestMode: false,
+        userApiKey: 'main-model-key',
+        visionAuth: {
+          userApiKey: 'vision-provider-key',
+          visionProvider: AIProvider.OpenRouter,
+          model: 'google/gemma-4-31b-it',
+        },
+      });
+
+      expect(mockReferencedMessageFormatter.formatReferencedMessages).toHaveBeenCalledWith(
+        referencedMessages,
+        mockPersonality,
+        false,
+        undefined,
+        expect.objectContaining({
+          userApiKey: 'vision-provider-key',
+          visionProvider: AIProvider.OpenRouter,
+          visionModel: 'google/gemma-4-31b-it',
         })
       );
     });

--- a/services/ai-worker/src/services/ConversationInputProcessor.ts
+++ b/services/ai-worker/src/services/ConversationInputProcessor.ts
@@ -23,7 +23,11 @@ import { extractRecentHistoryWindow } from './RAGUtils.js';
 import type { PromptBuilder } from './PromptBuilder.js';
 import type { ReferencedMessageFormatter } from './ReferencedMessageFormatter.js';
 import type { ResponsePostProcessor } from './ResponsePostProcessor.js';
-import type { ConversationContext, ProcessedInputs } from './ConversationalRAGTypes.js';
+import type {
+  ConversationContext,
+  ProcessedInputs,
+  ResolvedVisionAuth,
+} from './ConversationalRAGTypes.js';
 
 const logger = createLogger('ConversationInputProcessor');
 
@@ -67,9 +71,21 @@ export class ConversationInputProcessor {
       isGuestMode: boolean;
       userApiKey?: string;
       sttDispatch?: SttDispatch;
+      /**
+       * Cross-provider vision auth resolved once upstream (ConversationalRAGService).
+       * Used for image processing so the inline-fallback + reference paths send the
+       * vision-provider key instead of the raw main-model key. Absent in legacy
+       * callers/tests → fall back to `userApiKey` (no cross-provider resolution).
+       */
+      visionAuth?: ResolvedVisionAuth;
     }
   ): Promise<ProcessedInputs> {
-    const { isGuestMode, userApiKey, sttDispatch } = authOptions;
+    const { isGuestMode, userApiKey, sttDispatch, visionAuth } = authOptions;
+    // Vision-provider key/provider/model (resolved upstream); fall back to the
+    // main key when no visionAuth was threaded (legacy/test callers).
+    const visionApiKey = visionAuth?.userApiKey ?? userApiKey;
+    const visionProvider = visionAuth?.visionProvider;
+    const visionModel = visionAuth?.model;
     // Use pre-processed attachments from dependency jobs if available
     let processedAttachments: ProcessedAttachment[] = [];
     if (context.preprocessedAttachments && context.preprocessedAttachments.length > 0) {
@@ -82,11 +98,13 @@ export class ConversationInputProcessor {
       // Fallback: process attachments inline (shouldn't happen with job chain, but defensive)
       processedAttachments = await processAttachments(context.attachments, personality, {
         isGuestMode,
-        userApiKey,
+        userApiKey: visionApiKey,
         sttDispatch,
+        visionProvider,
+        model: visionModel,
         loggingContext: {
           userId: context.userId,
-          apiKeySource: deriveApiKeySource(isGuestMode, userApiKey),
+          apiKeySource: deriveApiKeySource(isGuestMode, visionApiKey),
         },
       });
       logger.info(
@@ -112,7 +130,7 @@ export class ConversationInputProcessor {
             personality,
             isGuestMode,
             context.preprocessedReferenceAttachments,
-            { userApiKey, sttDispatch }
+            { userApiKey: visionApiKey, sttDispatch, visionProvider, visionModel }
           )
         : undefined;
 

--- a/services/ai-worker/src/services/ConversationalRAGService.test.ts
+++ b/services/ai-worker/src/services/ConversationalRAGService.test.ts
@@ -16,7 +16,14 @@ import { ConversationalRAGService } from './ConversationalRAGService.js';
 import type { MemoryDocument } from './ConversationalRAGTypes.js';
 import type { AttachmentMetadata, ReferencedMessage } from '@tzurot/common-types';
 import type { ProcessedAttachment } from './MultimodalProcessor.js';
-import { CONTENT_TYPES, AttachmentType } from '@tzurot/common-types';
+import type { ApiKeyResolver } from './ApiKeyResolver.js';
+import { CONTENT_TYPES, AttachmentType, AIProvider } from '@tzurot/common-types';
+
+// Mock the cross-provider vision resolver so we can assert resolveVisionAuth wiring
+// without exercising the real key-resolution path.
+const { mockResolveVisionConfig } = vi.hoisted(() => ({
+  mockResolveVisionConfig: vi.fn(),
+}));
 
 // Set up mocks using async factories (vi.mock is hoisted before imports)
 vi.mock('./LLMInvoker.js', async () => {
@@ -77,6 +84,9 @@ vi.mock('../redis.js', () => ({
 vi.mock('./storedReferenceHydrator.js', () => ({
   hydrateStoredReferences: vi.fn().mockResolvedValue(undefined),
 }));
+vi.mock('./multimodal/visionAuthResolver.js', () => ({
+  resolveVisionConfig: mockResolveVisionConfig,
+}));
 
 // Import mock accessors and fixtures (after vi.mock declarations)
 import {
@@ -108,6 +118,56 @@ describe('ConversationalRAGService', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  describe('cross-provider vision auth', () => {
+    it('resolves vision config once with the effective main provider + key when an apiKeyResolver is wired', async () => {
+      mockResolveVisionConfig.mockResolvedValue({
+        kind: 'resolved',
+        config: {
+          apiKey: 'vision-provider-key',
+          provider: AIProvider.OpenRouter,
+          model: 'google/gemma-4-31b-it',
+          source: 'user',
+          isGuestMode: false,
+        },
+      });
+      const serviceWithResolver = new ConversationalRAGService(
+        undefined,
+        undefined,
+        {} as unknown as ApiKeyResolver
+      );
+      const personality = createMockPersonality();
+      const context = createMockContext();
+
+      await serviceWithResolver.generateResponse(personality, 'Hi', context, {
+        userApiKey: 'main-model-key', // z.ai main key — must NOT leak to the OpenRouter vision call
+        effectiveProvider: AIProvider.ZaiCoding,
+      });
+
+      expect(mockResolveVisionConfig).toHaveBeenCalledTimes(1);
+      expect(mockResolveVisionConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          personality,
+          mainProvider: AIProvider.ZaiCoding,
+          mainApiKey: 'main-model-key',
+          userId: context.userId,
+        })
+      );
+    });
+
+    it('does not resolve vision config when no apiKeyResolver is wired (legacy/degrade path)', async () => {
+      const personality = createMockPersonality();
+      const context = createMockContext();
+
+      // `service` (from beforeEach) is constructed without an apiKeyResolver.
+      await service.generateResponse(personality, 'Hi', context, {
+        userApiKey: 'main-model-key',
+        effectiveProvider: AIProvider.ZaiCoding,
+      });
+
+      expect(mockResolveVisionConfig).not.toHaveBeenCalled();
+    });
   });
 
   describe('RAG service orchestration', () => {

--- a/services/ai-worker/src/services/ConversationalRAGService.ts
+++ b/services/ai-worker/src/services/ConversationalRAGService.ts
@@ -31,18 +31,15 @@ import { ContextWindowManager } from './context/ContextWindowManager.js';
 import { PersonaResolver } from './resolvers/index.js';
 import { UserReferenceResolver } from './UserReferenceResolver.js';
 import { ContentBudgetManager } from './ContentBudgetManager.js';
-import {
-  buildAttachmentDescriptions,
-  enrichConversationHistory,
-  countMediaAttachments,
-} from './RAGUtils.js';
-import { redisService, visionDescriptionCache, checkModelReasoningSupport } from '../redis.js';
+import { buildAttachmentDescriptions, countMediaAttachments } from './RAGUtils.js';
+import { redisService, checkModelReasoningSupport } from '../redis.js';
 import { resolveEffectiveContextWindow } from './contextWindowResolver.js';
 import { deriveCacheKeyId } from './RateLimitCache.js';
 import { ResponsePostProcessor } from './ResponsePostProcessor.js';
 import { ConversationInputProcessor } from './ConversationInputProcessor.js';
 import { MemoryPersistenceService } from './MemoryPersistenceService.js';
-import { processAttachments, deriveApiKeySource } from './MultimodalProcessor.js';
+import { resolveRagVisionAuth, enrichRagHistory } from './multimodal/ragVisionAuth.js';
+import type { ApiKeyResolver } from './ApiKeyResolver.js';
 import {
   parseResponseMetadata,
   recordLlmConfigDiagnostic,
@@ -74,7 +71,11 @@ export class ConversationalRAGService {
   private inputProcessor: ConversationInputProcessor;
   private memoryPersistence: MemoryPersistenceService;
 
-  constructor(memoryManager?: PgvectorMemoryAdapter, personaResolver?: PersonaResolver) {
+  constructor(
+    memoryManager?: PgvectorMemoryAdapter,
+    personaResolver?: PersonaResolver,
+    private readonly apiKeyResolver?: ApiKeyResolver
+  ) {
     this.llmInvoker = new LLMInvoker();
     this.memoryRetriever = new MemoryRetriever(memoryManager, personaResolver);
     this.promptBuilder = new PromptBuilder();
@@ -358,11 +359,23 @@ export class ConversationalRAGService {
     const diagnosticCollector = diagnosticCollectorRef as DiagnosticCollector | undefined;
 
     try {
+      // Resolve the cross-provider vision key ONCE for this request; thread it to
+      // every vision call site below so none forwards the raw main-model key.
+      const visionAuth = await resolveRagVisionAuth({
+        personality,
+        userId: context.userId,
+        isGuestMode,
+        mainApiKey: userApiKey,
+        mainProvider: options.effectiveProvider,
+        apiKeyResolver: this.apiKeyResolver,
+      });
+
       // Step 1: Process inputs (attachments, messages, search query)
       const inputs = await this.inputProcessor.processInputs(personality, message, context, {
         isGuestMode,
         userApiKey,
         sttDispatch,
+        visionAuth,
       });
 
       // Record input processing for diagnostics
@@ -378,24 +391,9 @@ export class ConversationalRAGService {
         });
       }
 
-      // Step 1.5: Enrich history with inline image descriptions + hydrated stored references.
-      const visionLoggingContext = {
-        userId: context.userId,
-        apiKeySource: deriveApiKeySource(isGuestMode, userApiKey),
-      };
-      await enrichConversationHistory(
-        context.rawConversationHistory,
-        context.preprocessedExtendedContextAttachments,
-        getPrismaClient(),
-        visionDescriptionCache,
-        atts =>
-          processAttachments(atts, personality, {
-            isGuestMode,
-            userApiKey,
-            sttDispatch,
-            loggingContext: visionLoggingContext,
-          })
-      );
+      // Step 1.5: Enrich history with inline image descriptions + hydrated stored
+      // references, using the cross-provider-resolved vision auth.
+      await enrichRagHistory({ context, personality, visionAuth, isGuestMode, sttDispatch });
 
       // Step 2: Load personas and resolve user references
       const { participantPersonas, processedPersonality } =

--- a/services/ai-worker/src/services/ConversationalRAGTypes.ts
+++ b/services/ai-worker/src/services/ConversationalRAGTypes.ts
@@ -18,6 +18,22 @@ import type {
 import type { ProcessedAttachment } from './MultimodalProcessor.js';
 
 /**
+ * Cross-provider vision auth, resolved ONCE per request and threaded to every
+ * vision call site in the RAG path (history enrichment, current-message inline
+ * fallback, referenced-message attachments). Replaces forwarding the raw
+ * main-model key, which 401s when the vision model lives on a different provider
+ * than the main model. `userApiKey` is the key for the VISION provider (the
+ * system key on a free-tier downgrade); `visionProvider`/`model` come from
+ * `resolveVisionConfig`. All three sites share one personality + user per
+ * request, so a single resolution is correct for all of them.
+ */
+export interface ResolvedVisionAuth {
+  userApiKey?: string;
+  visionProvider?: AIProvider;
+  model?: string;
+}
+
+/**
  * Memory document structure from vector search
  */
 export interface MemoryDocument {

--- a/services/ai-worker/src/services/ReferencedMessageFormatter.ts
+++ b/services/ai-worker/src/services/ReferencedMessageFormatter.ts
@@ -11,6 +11,7 @@ import {
   type ReferencedMessage,
   type LoadedPersonality,
   type SttDispatch,
+  type AIProvider,
   TEXT_LIMITS,
   formatTimestampWithDelta,
 } from '@tzurot/common-types';
@@ -25,6 +26,20 @@ import { processAttachmentsParallel } from './AttachmentProcessor.js';
 import { extractXmlTextContent } from '../utils/xmlTextExtractor.js';
 
 const logger = createLogger('ReferencedMessageFormatter');
+
+/**
+ * Auth context for reference-attachment processing. `userApiKey` is the key for
+ * the VISION provider (resolved upstream), and `visionProvider`/`visionModel`
+ * carry the cross-provider vision resolution so reference images use the correct
+ * key+model instead of the raw main-model key. `sttDispatch` drives voice
+ * transcription independently. All fields optional — legacy callers degrade.
+ */
+interface ReferenceVisionAuth {
+  userApiKey?: string;
+  sttDispatch?: SttDispatch;
+  visionProvider?: AIProvider;
+  visionModel?: string;
+}
 
 /**
  * Referenced Message Formatter
@@ -64,10 +79,8 @@ export class ReferencedMessageFormatter {
     personality: LoadedPersonality,
     isGuestMode = false,
     preprocessedAttachments?: Record<number, ProcessedAttachment[]>,
-    apiKeys?: { userApiKey?: string; sttDispatch?: SttDispatch }
+    apiKeys?: ReferenceVisionAuth
   ): Promise<string> {
-    const userApiKey = apiKeys?.userApiKey;
-    const sttDispatch = apiKeys?.sttDispatch;
     const referenceElements: string[] = [];
 
     // Process each reference into XML
@@ -95,7 +108,7 @@ export class ReferencedMessageFormatter {
           personality,
           isGuestMode,
           preprocessedAttachments?.[ref.referenceNumber],
-          { userApiKey, sttDispatch }
+          apiKeys
         );
         referenceElements.push(forwardedElement);
         continue;
@@ -107,7 +120,7 @@ export class ReferencedMessageFormatter {
         personality,
         isGuestMode,
         preprocessedAttachments?.[ref.referenceNumber],
-        { userApiKey, sttDispatch }
+        apiKeys
       );
       referenceElements.push(standardElement);
     }
@@ -139,9 +152,9 @@ export class ReferencedMessageFormatter {
     personality: LoadedPersonality,
     isGuestMode: boolean,
     preprocessedForRef?: ProcessedAttachment[],
-    apiKeys?: { userApiKey?: string; sttDispatch?: SttDispatch }
+    apiKeys?: ReferenceVisionAuth
   ): Promise<string> {
-    const { userApiKey, sttDispatch } = apiKeys ?? {};
+    const { userApiKey, sttDispatch, visionProvider, visionModel } = apiKeys ?? {};
     const { absolute, relative } = formatTimestampWithDelta(ref.timestamp);
 
     let attachmentLines: string[] = [];
@@ -154,6 +167,8 @@ export class ReferencedMessageFormatter {
         preprocessedAttachments: preprocessedForRef,
         userApiKey,
         sttDispatch,
+        visionProvider,
+        model: visionModel,
       });
     }
 
@@ -178,9 +193,9 @@ export class ReferencedMessageFormatter {
     personality: LoadedPersonality,
     isGuestMode: boolean,
     preprocessedForRef?: ProcessedAttachment[],
-    apiKeys?: { userApiKey?: string; sttDispatch?: SttDispatch }
+    apiKeys?: ReferenceVisionAuth
   ): Promise<string> {
-    const { userApiKey, sttDispatch } = apiKeys ?? {};
+    const { userApiKey, sttDispatch, visionProvider, visionModel } = apiKeys ?? {};
     const { absolute, relative } = formatTimestampWithDelta(ref.timestamp);
 
     const forwardedContent: ForwardedMessageContent = {
@@ -199,6 +214,8 @@ export class ReferencedMessageFormatter {
         preprocessedAttachments: preprocessedForRef,
         userApiKey,
         sttDispatch,
+        visionProvider,
+        model: visionModel,
       });
 
       if (attachmentLines.length > 0) {

--- a/services/ai-worker/src/services/multimodal/ragVisionAuth.test.ts
+++ b/services/ai-worker/src/services/multimodal/ragVisionAuth.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for resolveRagVisionAuth — the RAG-path cross-provider vision-auth helper.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AIProvider, type LoadedPersonality } from '@tzurot/common-types';
+import { resolveRagVisionAuth } from './ragVisionAuth.js';
+import type { ApiKeyResolver } from '../ApiKeyResolver.js';
+
+const { mockResolveVisionConfig } = vi.hoisted(() => ({
+  mockResolveVisionConfig: vi.fn(),
+}));
+
+vi.mock('./visionAuthResolver.js', () => ({
+  resolveVisionConfig: mockResolveVisionConfig,
+}));
+
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    }),
+  };
+});
+
+const PERSONALITY = {
+  id: 'p1',
+  name: 'Bot',
+  model: 'z-ai/glm-5.2',
+} as unknown as LoadedPersonality;
+// A non-null sentinel — resolveVisionConfig is mocked, so the resolver is never actually invoked.
+const RESOLVER = {} as unknown as ApiKeyResolver;
+
+describe('resolveRagVisionAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the resolved vision key/provider/model on a resolved config', async () => {
+    mockResolveVisionConfig.mockResolvedValue({
+      kind: 'resolved',
+      config: {
+        apiKey: 'vision-key',
+        provider: AIProvider.OpenRouter,
+        model: 'google/gemma-4-31b-it',
+        source: 'user',
+        isGuestMode: false,
+      },
+    });
+
+    const result = await resolveRagVisionAuth({
+      personality: PERSONALITY,
+      userId: 'user-1',
+      isGuestMode: false,
+      mainApiKey: 'main-z.ai-key',
+      mainProvider: AIProvider.ZaiCoding,
+      apiKeyResolver: RESOLVER,
+    });
+
+    expect(result).toEqual({
+      userApiKey: 'vision-key',
+      visionProvider: AIProvider.OpenRouter,
+      model: 'google/gemma-4-31b-it',
+    });
+    expect(mockResolveVisionConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        personality: PERSONALITY,
+        mainProvider: AIProvider.ZaiCoding,
+        mainApiKey: 'main-z.ai-key',
+        userId: 'user-1',
+        isGuestMode: false,
+      })
+    );
+  });
+
+  it('degrades to the main key when the resolver fail-fasts', async () => {
+    mockResolveVisionConfig.mockResolvedValue({
+      kind: 'failFast',
+      provider: AIProvider.OpenRouter,
+    });
+
+    const result = await resolveRagVisionAuth({
+      personality: PERSONALITY,
+      userId: 'user-1',
+      isGuestMode: false,
+      mainApiKey: 'main-key',
+      mainProvider: AIProvider.ZaiCoding,
+      apiKeyResolver: RESOLVER,
+    });
+
+    expect(result).toEqual({ userApiKey: 'main-key' });
+  });
+
+  it('degrades to the main key when the resolver throws', async () => {
+    mockResolveVisionConfig.mockRejectedValue(new Error('redis blip'));
+
+    const result = await resolveRagVisionAuth({
+      personality: PERSONALITY,
+      userId: 'user-1',
+      isGuestMode: false,
+      mainApiKey: 'main-key',
+      mainProvider: AIProvider.ZaiCoding,
+      apiKeyResolver: RESOLVER,
+    });
+
+    expect(result).toEqual({ userApiKey: 'main-key' });
+  });
+
+  it('skips resolution and returns the main key when no apiKeyResolver is wired', async () => {
+    const result = await resolveRagVisionAuth({
+      personality: PERSONALITY,
+      userId: 'user-1',
+      isGuestMode: false,
+      mainApiKey: 'main-key',
+      mainProvider: AIProvider.ZaiCoding,
+      // apiKeyResolver omitted
+    });
+
+    expect(result).toEqual({ userApiKey: 'main-key' });
+    expect(mockResolveVisionConfig).not.toHaveBeenCalled();
+  });
+
+  it('skips resolution when there is no upstream main provider', async () => {
+    const result = await resolveRagVisionAuth({
+      personality: PERSONALITY,
+      userId: 'user-1',
+      isGuestMode: false,
+      mainApiKey: 'main-key',
+      mainProvider: undefined,
+      apiKeyResolver: RESOLVER,
+    });
+
+    expect(result).toEqual({ userApiKey: 'main-key' });
+    expect(mockResolveVisionConfig).not.toHaveBeenCalled();
+  });
+});

--- a/services/ai-worker/src/services/multimodal/ragVisionAuth.ts
+++ b/services/ai-worker/src/services/multimodal/ragVisionAuth.ts
@@ -1,0 +1,127 @@
+/**
+ * RAG-path vision helpers: cross-provider auth resolution + history enrichment.
+ *
+ * `resolveRagVisionAuth` resolves the vision-provider key + provider + model ONCE
+ * per request so every vision call site in the RAG path (history enrichment,
+ * current-message inline fallback, referenced-message attachments) uses the
+ * correct cross-provider key instead of the raw main-model key — which 401s when
+ * the vision model lives on a different provider than the main model. All sites
+ * share one personality + user per request, so a single resolution is correct.
+ *
+ * `enrichRagHistory` runs the history image-description / stored-reference
+ * enrichment using that resolved auth.
+ *
+ * Extracted from `ConversationalRAGService` so the orchestration file stays under
+ * the line cap and these branches are independently testable.
+ *
+ * Auth fails open: with no resolver wired (tests) or no upstream provider, or on
+ * a resolver fail-fast/throw, it degrades to the main key — the pre-existing
+ * behaviour (the cross-provider call then 401s to a placeholder description,
+ * reachable only when no system free-fallback key is configured).
+ */
+
+import {
+  createLogger,
+  getPrismaClient,
+  type AIProvider,
+  type LoadedPersonality,
+  type SttDispatch,
+} from '@tzurot/common-types';
+import { resolveVisionConfig } from './visionAuthResolver.js';
+import { processAttachments, deriveApiKeySource } from '../MultimodalProcessor.js';
+import { enrichConversationHistory } from '../RAGUtils.js';
+import { visionDescriptionCache } from '../../redis.js';
+import type { ApiKeyResolver } from '../ApiKeyResolver.js';
+import type { ConversationContext, ResolvedVisionAuth } from '../ConversationalRAGTypes.js';
+
+const logger = createLogger('RagVisionAuth');
+
+/** Inputs for {@link resolveRagVisionAuth}. */
+export interface ResolveRagVisionAuthOptions {
+  personality: LoadedPersonality;
+  userId: string | undefined;
+  isGuestMode: boolean;
+  /** Main-model key (auth.apiKey) — drives the same-provider fast path only. */
+  mainApiKey: string | undefined;
+  /** Effective post-promotion provider (auth.provider). */
+  mainProvider: AIProvider | undefined;
+  /** Absent in legacy/test callers → degrade to passing the main key through. */
+  apiKeyResolver?: ApiKeyResolver;
+}
+
+export async function resolveRagVisionAuth(
+  opts: ResolveRagVisionAuthOptions
+): Promise<ResolvedVisionAuth> {
+  const { personality, userId, isGuestMode, mainApiKey, mainProvider, apiKeyResolver } = opts;
+
+  if (apiKeyResolver === undefined || mainProvider === undefined) {
+    return { userApiKey: mainApiKey };
+  }
+
+  try {
+    const result = await resolveVisionConfig({
+      personality,
+      mainProvider,
+      mainApiKey,
+      isGuestMode,
+      userId,
+      apiKeyResolver,
+    });
+    if (result.kind === 'resolved') {
+      return {
+        userApiKey: result.config.apiKey,
+        visionProvider: result.config.provider,
+        model: result.config.model,
+      };
+    }
+    logger.warn(
+      { userId, visionProvider: result.provider },
+      'Vision config fail-fast in RAG path — degrading to main-model key'
+    );
+    return { userApiKey: mainApiKey };
+  } catch (error) {
+    logger.warn(
+      { err: error, userId },
+      'Vision config resolution threw in RAG path — degrading to main-model key'
+    );
+    return { userApiKey: mainApiKey };
+  }
+}
+
+/** Inputs for {@link enrichRagHistory}. */
+export interface EnrichRagHistoryOptions {
+  context: ConversationContext;
+  personality: LoadedPersonality;
+  /** Resolved cross-provider vision auth (from {@link resolveRagVisionAuth}). */
+  visionAuth: ResolvedVisionAuth;
+  isGuestMode: boolean;
+  sttDispatch?: SttDispatch;
+}
+
+/**
+ * Enrich conversation history with inline image descriptions + hydrated stored
+ * references, using the cross-provider-resolved vision auth so history images on
+ * a different provider than the main model don't 401.
+ */
+export async function enrichRagHistory(opts: EnrichRagHistoryOptions): Promise<void> {
+  const { context, personality, visionAuth, isGuestMode, sttDispatch } = opts;
+  const visionLoggingContext = {
+    userId: context.userId,
+    apiKeySource: deriveApiKeySource(isGuestMode, visionAuth.userApiKey),
+  };
+  await enrichConversationHistory(
+    context.rawConversationHistory,
+    context.preprocessedExtendedContextAttachments,
+    getPrismaClient(),
+    visionDescriptionCache,
+    atts =>
+      processAttachments(atts, personality, {
+        isGuestMode,
+        userApiKey: visionAuth.userApiKey,
+        sttDispatch,
+        visionProvider: visionAuth.visionProvider,
+        model: visionAuth.model,
+        loggingContext: visionLoggingContext,
+      })
+  );
+}


### PR DESCRIPTION
## What

Resolve the cross-provider vision key **once per request** in the RAG path and thread it to every vision call site, so none forwards the raw main-model key.

## Why (the bug)

The RAG service forwarded the main-model key (`auth.apiKey`) to vision calls for **history enrichment**, the **current-message inline fallback**, and **referenced-message attachments**. When the vision model lives on a different provider than the main model — e.g. main `glm-5.2` on z.ai-coding (key len 49), vision `gemma` on OpenRouter — the vision call got the z.ai key → `401 Missing Authentication header` → placeholder description. Confirmed in dev logs: `VISION-AUTH-PROBE perRequestKeyLen=49` on the failing gemma call.

`ImageDescriptionJob` and `DependencyStep` already resolve the vision key correctly via `resolveVisionConfig`; these three service-layer paths bypassed it.

## How

- **New `services/multimodal/ragVisionAuth.ts`**: `resolveRagVisionAuth` (wraps `resolveVisionConfig`, passing the effective post-promotion `mainProvider` + main key) and `enrichRagHistory` (history enrichment using the resolved auth). Extracted so `ConversationalRAGService` stays under the line cap.
- `ConversationalRAGService.generateResponse` resolves the vision auth once and threads `{key, provider, model}` to `processInputs` + history enrichment.
- `ConversationInputProcessor` + `ReferencedMessageFormatter` forward the resolved provider/model; `AttachmentProcessor` now forwards `model` to `describeImage` (it was dropped on the reference path → forced free-tier downgrades silently re-selected the paid fallback).
- Single resolution is correct: all sites share one personality + user per request.
- **Fails open**: no resolver wired (tests) or a resolver fail-fast/throw degrades to the main key (pre-existing behaviour). Keys are still resolved only in ai-worker — nothing new crosses BullMQ.

## Part of

The beta.133 config-resolution consolidation. Companion: **PR #1239** (model-resolution / Bug X, the visionMODEL fix); this is the vision-KEY fix (Bug Y). Independent of #1239 (disjoint files); the two together make the RAG vision path consistent with ImageDescriptionJob/DependencyStep.

## Tests

- New `ragVisionAuth.test.ts`: resolved / fail-fast / throw / no-resolver / no-mainProvider (5 cases).
- `ConversationalRAGService.test.ts`: resolves once with the effective provider + key; no resolution when no resolver wired.
- `ConversationInputProcessor.test.ts`: visionAuth threaded into inline-fallback + `formatReferencedMessages`.
- `AttachmentProcessor.test.ts`: `model`+`provider` forwarded to `describeImage`.
- Back-compat: existing 140+ tests across the touched files stay green. `pnpm quality` green.

## Note

The `VISION_AUTH_PROBE` instrumentation (currently on develop) is intentionally left in place for one more dev-verification pass; it'll be removed in the Bug C / probe-cleanup PR once the 401 is confirmed gone in dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)