### PR TITLE
fix(common-types): preserve attachment markers in deduped reference stubs

### DIFF
--- a/packages/common-types/src/utils/referenceEnrichment.test.ts
+++ b/packages/common-types/src/utils/referenceEnrichment.test.ts
@@ -115,7 +115,7 @@ function fullReference(content: string): ReferencedMessage {
 }
 
 describe('buildDedupedReferenceStub', () => {
-  it('keeps short content and strips embeds/location/attachments/flags', () => {
+  it('strips embeds/location/flags and folds the attachment marker into content', () => {
     const stub = buildDedupedReferenceStub(fullReference('short content'));
     expect(stub).toEqual({
       referenceNumber: 3,
@@ -123,7 +123,8 @@ describe('buildDedupedReferenceStub', () => {
       discordUserId: 'user-1',
       authorUsername: 'someone',
       authorDisplayName: 'Someone',
-      content: 'short content',
+      // marker first (truncation-safe), then the original text
+      content: '[image/png: x.png]\n\nshort content',
       embeds: '',
       timestamp: '2026-06-01T11:59:00.000Z',
       locationContext: '',
@@ -131,10 +132,34 @@ describe('buildDedupedReferenceStub', () => {
     });
   });
 
-  it('truncates content beyond the stub limit with an ellipsis', () => {
+  it('renders attachment markers alone for an image-only reply-target (empty text)', () => {
+    const stub = buildDedupedReferenceStub(fullReference(''));
+    expect(stub.content).toBe('[image/png: x.png]');
+  });
+
+  it('emits one marker per attachment, using contentType + name', () => {
+    const ref = fullReference('look at these');
+    ref.attachments = [
+      { url: 'https://cdn/a.jpg', contentType: 'image/jpeg', name: 'a.jpg' },
+      { url: 'https://cdn/v.ogg', contentType: 'audio/ogg' }, // no name → 'attachment'
+    ];
+    const stub = buildDedupedReferenceStub(ref);
+    expect(stub.content).toBe('[image/jpeg: a.jpg]\n[audio/ogg: attachment]\n\nlook at these');
+  });
+
+  it('leaves content untouched (no leading newlines) when there are no attachments', () => {
+    const ref = fullReference('plain text');
+    ref.attachments = undefined;
+    const stub = buildDedupedReferenceStub(ref);
+    expect(stub.content).toBe('plain text');
+  });
+
+  it('truncates the text portion but keeps the leading marker', () => {
     const long = 'x'.repeat(TEXT_LIMITS.DEDUP_STUB_CONTENT + 10);
     const stub = buildDedupedReferenceStub(fullReference(long));
-    expect(stub.content).toBe('x'.repeat(TEXT_LIMITS.DEDUP_STUB_CONTENT) + '...');
+    expect(stub.content).toBe(
+      '[image/png: x.png]\n\n' + 'x'.repeat(TEXT_LIMITS.DEDUP_STUB_CONTENT) + '...'
+    );
   });
 });
 

--- a/packages/common-types/src/utils/referenceEnrichment.ts
+++ b/packages/common-types/src/utils/referenceEnrichment.ts
@@ -85,9 +85,20 @@ export function isDuplicateReference(
 
 /**
  * Collapse a full reference into the minimal deduplicated stub: truncated
- * content, no embeds/location/attachments. The stub keeps the reference
- * number — numbering is assigned before the dedup decision, so stubs consume
- * numbers and downstream `[Reference N]` links stay stable.
+ * content (with attachment markers), no embeds/location. The stub keeps the
+ * reference number — numbering is assigned before the dedup decision, so stubs
+ * consume numbers and downstream `[Reference N]` links stay stable.
+ *
+ * Attachment markers (`[contentType: name]`) are folded into the content so an
+ * image-only reply-target doesn't collapse to an empty quote — without them the
+ * model sees nothing and reports "no image," even though the full message (with
+ * its rendered image description) is in the history the stub points at. The
+ * marker's filename lets the model correlate the stub with that history entry.
+ *
+ * Contract: with attachments present the returned `content` can exceed
+ * `DEDUP_STUB_CONTENT` (markers are prepended AFTER the text is truncated), so a
+ * caller that treats it as final output must re-apply the limit. The prompt path
+ * already does, via `formatDedupedQuote`.
  */
 export function buildDedupedReferenceStub(reference: ReferencedMessage): ReferencedMessage {
   const limit = TEXT_LIMITS.DEDUP_STUB_CONTENT;
@@ -95,13 +106,22 @@ export function buildDedupedReferenceStub(reference: ReferencedMessage): Referen
     reference.content.length > limit
       ? reference.content.substring(0, limit) + '...'
       : reference.content;
+  // Markers go FIRST so they survive downstream re-truncation: formatDedupedQuote
+  // applies DEDUP_STUB_CONTENT to the COMBINED (markers + text) string and trims
+  // from the end, so the effective text budget there is DEDUP_STUB_CONTENT minus
+  // the marker length. Squeezing the text hint is acceptable — the full message
+  // (the thing the stub points at) is in history regardless; the marker is not.
+  const attachmentMarkers = (reference.attachments ?? [])
+    .map(att => `[${att.contentType}: ${att.name ?? 'attachment'}]`)
+    .join('\n');
+  const content = [attachmentMarkers, truncatedContent].filter(s => s.length > 0).join('\n\n');
   return {
     referenceNumber: reference.referenceNumber,
     discordMessageId: reference.discordMessageId,
     discordUserId: reference.discordUserId,
     authorUsername: reference.authorUsername,
     authorDisplayName: reference.authorDisplayName,
-    content: truncatedContent,
+    content,
     embeds: '',
     timestamp: reference.timestamp,
     locationContext: '',

--- a/services/ai-worker/src/services/context/referenceEnricher.test.ts
+++ b/services/ai-worker/src/services/context/referenceEnricher.test.ts
@@ -63,6 +63,24 @@ describe('enrichRawReferences', () => {
     expect(result[0].locationContext).toBe('');
   });
 
+  it('keeps the image attachment marker when stubbing a duplicate image-only reply-target', async () => {
+    const result = await enrichRawReferences({
+      rawReferences: [
+        rawRef({
+          content: '', // image-only message — without the marker the stub is blank
+          attachments: [
+            { url: 'https://cdn/board.png', contentType: 'image/png', name: 'board.png' },
+          ],
+        }),
+      ],
+      history: [historyRow('ref-1', new Date(NOW - 5_000))],
+      retrieveTranscript: noTranscript,
+      nowMs: NOW,
+    });
+    expect(result[0].isDeduplicated).toBe(true);
+    expect(result[0].content).toBe('[image/png: board.png]');
+  });
+
   it('stubs a recent webhook reference via the time fallback', async () => {
     const result = await enrichRawReferences({
       rawReferences: [rawRef({ webhookId: 'wh-1' })],


### PR DESCRIPTION
## What

When a user replies to an image-only message that's **already in recent history**, the reference dedup (`isDuplicateReference` → `buildDedupedReferenceStub`) collapsed it to a stub that **dropped attachments entirely**. For an image-only message (empty text), the stub became blank — so the model saw an empty quote + an image-less trigger and answered **"no image detected,"** even though the image's description was rendered in the chat_log the stub points at.

## Evidence (dev, request `6b825048`)

Replying to a chess image (`Screenshot_20260616-003526.png`) that failed yesterday:
- Vision **succeeded** this time (Bug Y fix): description rendered in the chat_log.
- But the reply-target reference deduped to `[Reply target — full message is in conversation above]` with **empty content** (`referencedMessagesContent: [""]`).
- COLD's own thinking: *"the reply target quote is empty... no image filename, no image description... report no image."*

## Fix

Fold attachment markers (`[contentType: name]`) into the stub content, **markers-first** so they survive `formatDedupedQuote`'s end-truncation (`DEDUP_STUB_CONTENT = 100`). The filename lets the model correlate the stub with the described image already in history.

- Single-point change in the **shared** `buildDedupedReferenceStub` kernel → bot and worker render identically, so shadow-assembly parity holds automatically.
- Image-only stub → `[image/png: name]`; text+image → `[image/png: name]\n\n<text>`; no attachments → content unchanged.

## Scope notes

- **Distinct from the five beta.133 bugs** and pre-existing (the reply-dedup path), but it defeats the "reply to an image and ask about it" flow, so it ships in beta.133.
- **Residual uncertainty:** this gives the model the thread to correlate filename→history; whether it then reliably says "yes I see it" wants a dev re-test (not just unit tests).

## Tests

- `referenceEnrichment.test.ts`: marker-first content, image-only-empty-text, multi-attachment, no-attachments-untouched, truncation-keeps-marker.
- Verified no downstream breakage: ai-worker (referenceEnricher, ReferencedMessageFormatter, shadowAssembly, xmlMetadataFormatters — 94) + bot-client (ReferenceFormatter, MessageReferenceExtractor, ReferenceCrawler — 33) reference tests all green. `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)