### PR TITLE
debug: remove beta.133 context-assembly probes

### DIFF
--- a/packages/common-types/src/utils/historyMerger.test.ts
+++ b/packages/common-types/src/utils/historyMerger.test.ts
@@ -556,27 +556,5 @@ describe('HistoryMerger', () => {
       expect(result[0].content).toBe('First');
       expect(result[1].content).toBe('Second');
     });
-
-    // TEMPORARY (debug PR): the CTX_MERGE_PROBE diagnostic is logging-only and
-    // must not alter merge behavior. Remove with the probe cleanup commit.
-    it('CTX_MERGE_PROBE logging does not change the merged result', () => {
-      const dbHistory = [createMockMessage({ discordMessageId: ['db-1'], content: 'DB one' })];
-      const extendedMessages = [
-        createMockMessage({ discordMessageId: ['live-2'], content: 'Live two' }),
-      ];
-
-      const prev = process.env.CTX_MERGE_PROBE;
-      process.env.CTX_MERGE_PROBE = '1';
-      try {
-        const result = mergeWithHistory(extendedMessages, dbHistory);
-        expect(result.map(m => m.content)).toEqual(['DB one', 'Live two']);
-      } finally {
-        if (prev === undefined) {
-          delete process.env.CTX_MERGE_PROBE;
-        } else {
-          process.env.CTX_MERGE_PROBE = prev;
-        }
-      }
-    });
   });
 });

--- a/packages/common-types/src/utils/historyMerger.ts
+++ b/packages/common-types/src/utils/historyMerger.ts
@@ -113,41 +113,6 @@ export function enrichDbMessagesWithExtendedMetadata(
 }
 
 /**
- * TEMPORARY diagnostic (debug PR): build a PII-safe descriptor of a message
- * for the context-merge probe. Logs derived booleans/lengths/IDs only — never
- * raw content (per the no-PII-in-logs rule). Used to root-cause the beta.133
- * context-assembly trio (footer leak / chime-in role+order / blank image msgs):
- * which copy of a message survives the live-vs-DB merge, and with what shape.
- * Gated behind CTX_MERGE_PROBE=1; remove with the cleanup commit once read.
- */
-function ctxProbeDescriptor(
-  m: ConversationMessage,
-  dbIds: { has: (id: string) => boolean }
-): Record<string, unknown> {
-  const content = m.content ?? '';
-  const id = m.discordMessageId[0];
-  const meta = m.messageMetadata;
-  return {
-    id: id ?? null,
-    role: String(m.role),
-    pName: m.personalityName ?? null,
-    len: content.length,
-    ph: content === NO_TEXT_CONTENT_PLACEHOLDER,
-    ftr: content.includes('-# '), // Discord subtext footer (Bug A)
-    relay: /^\*\*[^*]+:\*\*\s/.test(content), // "**Name:** …" relay-echo shape (Bug B)
-    fwd: m.isForwarded === true,
-    // metadata presence (Bug C — is there ANY attachment description to render?)
-    aDesc: meta?.attachmentDescriptions?.length ?? 0,
-    emb: meta?.embedsXml?.length ?? 0,
-    voc: meta?.voiceTranscripts?.length ?? 0,
-    fAtt: meta?.forwardedAttachmentLines?.length ?? 0,
-    rx: meta?.reactions?.length ?? 0,
-    // for live messages: does a DB row already cover this id (→ deduped out)?
-    inDb: id !== undefined ? dbIds.has(id) : false,
-  };
-}
-
-/**
  * Collapse DB-history rows that represent the SAME Discord message.
  *
  * `conversation_history` rows are personality-scoped and there is no unique
@@ -262,29 +227,6 @@ export function mergeWithHistory(
       b.createdAt instanceof Date ? b.createdAt.getTime() : new Date(b.createdAt).getTime();
     return timeA - timeB;
   });
-
-  // TEMPORARY diagnostic (debug PR, CTX_MERGE_PROBE=1): dump PII-safe descriptors for
-  // the most-recent slice of the FINAL merged result — i.e. exactly the recent window
-  // the prompt will render. Logging `merged` (which IS sorted oldest-first) rather than
-  // the raw `extendedMessages` array (newest-first from the Discord fetch) avoids the
-  // window-direction trap. `inDb` reveals whether each entry is DB-sourced (clean) or a
-  // unique live copy that leaked through dedup. This is the single boundary where the
-  // beta.133 context trio converges (footer leak / chime-in role+order / blank image
-  // msgs). Remove with the cleanup commit once the mechanism is read.
-  if (process.env.CTX_MERGE_PROBE === '1') {
-    const TAIL = 25;
-    logger.info(
-      {
-        probe: 'ctx-merge',
-        dbCount: dbHistory.length,
-        liveCount: extendedMessages.length,
-        survivedLive: uniqueExtendedMessages.length,
-        mergedCount: merged.length,
-        recent: merged.slice(-TAIL).map(m => ctxProbeDescriptor(m, dbMessageMap)),
-      },
-      '[CTX-MERGE-PROBE]'
-    );
-  }
 
   return merged;
 }

--- a/services/ai-worker/src/services/ModelFactory.test.ts
+++ b/services/ai-worker/src/services/ModelFactory.test.ts
@@ -96,24 +96,6 @@ describe('ModelFactory', () => {
       );
     });
 
-    it('runs the gated vision-auth probe when VISION_AUTH_PROBE=1 (debug instrumentation)', () => {
-      process.env.VISION_AUTH_PROBE = '1';
-      try {
-        const config: ModelConfig = {
-          modelName: 'google/gemma-4-31b-it',
-          apiKey: 'test-api-key',
-        };
-        // The env-gated probe block runs inside buildOpenRouterModel; assert the
-        // model still builds normally (covers the diagnostic path).
-        createChatModel(config);
-        expect(mockChatOpenAI).toHaveBeenCalledWith(
-          expect.objectContaining({ modelName: 'google/gemma-4-31b-it' })
-        );
-      } finally {
-        delete process.env.VISION_AUTH_PROBE;
-      }
-    });
-
     it('should always set __includeRawResponse:true so the OpenRouter reasoning extractor has access to the raw API response', () => {
       // Required for extractAndPopulateOpenRouterReasoning() in LLMInvoker to read
       // additional_kwargs.__raw_response. If this assertion ever fails, also check

--- a/services/ai-worker/src/services/ModelFactory.ts
+++ b/services/ai-worker/src/services/ModelFactory.ts
@@ -375,26 +375,6 @@ function buildOpenRouterModel(
     throw new Error('OPENROUTER_API_KEY is required for AI generation');
   }
 
-  // TEMPORARY diagnostic (debug, VISION_AUTH_PROBE=1): pin the cross-provider
-  // vision 401 — logs the FINAL key length handed to ChatOpenAI (never the key)
-  // and whether the per-request key or the system fallback was used, for the
-  // failing model. Noisy (fires for every OpenRouter build while enabled) but
-  // env-gated + short-lived. Remove with the vision-auth fix once read.
-  if (process.env.VISION_AUTH_PROBE === '1') {
-    const perRequestKeyLen = modelConfig.apiKey?.length ?? 0;
-    logger.info(
-      {
-        probe: 'vision-auth',
-        site: 'buildOpenRouterModel',
-        modelName,
-        perRequestKeyLen,
-        usedSystemFallback: perRequestKeyLen === 0,
-        finalApiKeyLen: apiKey.length,
-      },
-      '[VISION-AUTH-PROBE]'
-    );
-  }
-
   const extraParams = buildOpenRouterExtraParams(modelConfig);
   const hasExtraParams = Object.keys(extraParams).length > 0;
   const hasReasoning =

--- a/services/ai-worker/src/services/multimodal/VisionProcessor.test.ts
+++ b/services/ai-worker/src/services/multimodal/VisionProcessor.test.ts
@@ -193,19 +193,6 @@ describe('VisionProcessor', () => {
         );
       });
 
-      it('runs the gated vision-auth probe when VISION_AUTH_PROBE=1 (debug instrumentation)', async () => {
-        process.env.VISION_AUTH_PROBE = '1';
-        try {
-          const personality = createMockPersonality({ visionModel: 'gpt-4-vision-preview' });
-          // The env-gated probe (logVisionAuthProbe) runs in invokeVisionModel; the
-          // call still returns its description (covers the diagnostic path).
-          const result = await describeImage(mockAttachment, personality);
-          expect(result).toBe('Mocked image description');
-        } finally {
-          delete process.env.VISION_AUTH_PROBE;
-        }
-      });
-
       it('should use main model when it has vision support', async () => {
         mockCheckModelVisionSupport.mockResolvedValue(true);
 

--- a/services/ai-worker/src/services/multimodal/VisionProcessor.ts
+++ b/services/ai-worker/src/services/multimodal/VisionProcessor.ts
@@ -32,19 +32,6 @@ const logger = createLogger('VisionProcessor');
 const config = getConfig();
 
 /**
- * TEMPORARY diagnostic (debug, VISION_AUTH_PROBE=1): PII-safe vision-auth probe to
- * pin the cross-provider vision 401 ("Missing Authentication header" despite a real
- * system key). Logs key LENGTHS/provider/source only — never the key itself — so we
- * can tell an empty resolved key from a non-empty-but-rejected one. Remove with the
- * vision-auth fix once read.
- */
-function logVisionAuthProbe(fields: Record<string, unknown>): void {
-  if (process.env.VISION_AUTH_PROBE === '1') {
-    logger.info({ probe: 'vision-auth', ...fields }, '[VISION-AUTH-PROBE]');
-  }
-}
-
-/**
  * User-friendly labels for the ATTACHMENT-BOUND error categories that actually reach
  * `FAILURE_LABELS` via `buildFailureFallback`. Other categories (auth, quota, rate-limit,
  * server-error, timeout, network, etc.) return the generic "temporarily unavailable"
@@ -248,16 +235,6 @@ async function invokeVisionModel(
       'invokeVisionModel called without explicit provider — misrouting risk for cross-provider personalities'
     );
   }
-
-  // TEMPORARY diagnostic (debug, VISION_AUTH_PROBE=1) — see logVisionAuthProbe.
-  logVisionAuthProbe({
-    site: 'invokeVisionModel',
-    modelName,
-    provider: provider ?? null,
-    userApiKeyLen: userApiKey?.length ?? 0,
-    apiKeySource: loggingContext.apiKeySource ?? null,
-    personalityName,
-  });
 
   const { model } = createChatModel({
     modelName,

--- a/services/bot-client/src/services/ConversationPersistence.ts
+++ b/services/bot-client/src/services/ConversationPersistence.ts
@@ -198,29 +198,6 @@ export class ConversationPersistence {
       embedsXml = buildResult.embedsXml;
     }
 
-    // TEMPORARY diagnostic (debug, EMBED_PERSIST_PROBE=1): confirm the embed-only
-    // blank-history mechanism. embedsXml is currently only built for FORWARDED
-    // messages (above), so a regular link-embed message never persists it — and
-    // once it ages out of the live-fetch window it renders blank. This probe
-    // answers the one remaining question for the fix: at persist time, does a
-    // non-forwarded message ALREADY carry its embed (so "persist embedsXml for
-    // all" suffices) or not yet (Discord async embed resolution → also needs a
-    // re-capture on messageUpdate)? PII-safe: ids/booleans/counts only, no
-    // content. Remove with the embed fix once read.
-    if (process.env.EMBED_PERSIST_PROBE === '1') {
-      logger.info(
-        {
-          probe: 'embed-persist',
-          messageId: message.id,
-          isForwarded,
-          embedCountAtPersist: message.embeds.length,
-          embedsXmlPersisted: embedsXml !== undefined && embedsXml.length > 0,
-          contentLength: messageContent.length,
-        },
-        '[EMBED-PERSIST-PROBE]'
-      );
-    }
-
     // Delegate to field-based implementation with Message fields extracted.
     // Pass `message.createdAt` as the explicit timestamp so the user row's
     // `createdAt` matches the Discord post time. Without this, the row used


### PR DESCRIPTION
## What

Removes the three env-gated diagnostic probes from the beta.133 context-assembly investigation. Each has served its purpose:

| Probe | Location | Outcome |
|---|---|---|
| `VISION_AUTH_PROBE` | ai-worker `ModelFactory` + `VisionProcessor` | Pinned the cross-provider vision 401 → fixed by #1240, dev-verified |
| `CTX_MERGE_PROBE` | common-types `historyMerger` | Pinned the multi-personality dedup duplication → fixed by `a344b4650`, dev-verified |
| `EMBED_PERSIST_PROBE` | bot-client `ConversationPersistence` | Answered the embed-only-blank question: `embedCountAtPersist=1` (embed present at persist) → the deferred fix is "persist `embedsXml` for non-forwarded too", **not** a `messageUpdate` re-capture |

## Removed

- The gated `if (process.env.*_PROBE === '1')` log blocks.
- The `logVisionAuthProbe` (VisionProcessor) and `ctxProbeDescriptor` (historyMerger) helpers.
- The three colocated probe tests.

## Safety

Pure removal — **no production behavior change** (the probes were logging-only and env-gated off in normal operation). `git log --grep '^debug[:(]' origin/develop..HEAD` is empty after this lands. Affected tests pass (historyMerger 21, ModelFactory + VisionProcessor 120, ConversationPersistence 19); `pnpm quality` green.

Post-merge: the three `*_PROBE=1` dev env vars get flipped off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)