### PR TITLE
feat(bot-client): /help autocomplete over leaf commands + all-command structure snapshots

### DIFF
--- a/services/bot-client/command-manifest.json
+++ b/services/bot-client/command-manifest.json
@@ -806,7 +806,7 @@
       "description": "Show all available commands",
       "handlers": {
         "execute": true,
-        "autocomplete": false,
+        "autocomplete": true,
         "selectMenu": false,
         "button": false,
         "modal": false
@@ -815,6 +815,7 @@
       "data": {
         "options": [
           {
+            "autocomplete": true,
             "type": 3,
             "name": "command",
             "description": "Get detailed help for a specific command",

--- a/services/bot-client/src/commands/help/commandPaths.test.ts
+++ b/services/bot-client/src/commands/help/commandPaths.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for /help command-path utilities (flatten + resolve).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { Command } from '../../types.js';
+import {
+  flattenCommandLeaves,
+  getCommandOptions,
+  resolveHelpTarget,
+  type CommandOptionNode,
+} from './commandPaths.js';
+
+/** Build a Command whose `data` is a plain object (no toJSON) — the test-fixture shape. */
+function plainCommand(name: string, description: string, options?: CommandOptionNode[]): Command {
+  return {
+    data: { name, description, ...(options !== undefined && { options }) },
+    execute: vi.fn(),
+  } as unknown as Command;
+}
+
+const CHARACTER = plainCommand('character', 'Manage AI characters', [
+  { type: 1, name: 'chat', description: 'Chat one-on-one' },
+  {
+    type: 1,
+    name: 'create',
+    description: 'Create a character',
+    options: [
+      { type: 3, name: 'name', description: 'Character name' },
+      { type: 3, name: 'slug', description: 'URL slug' },
+    ],
+  },
+]);
+
+const ADMIN = plainCommand('admin', 'Owner tools', [
+  {
+    type: 2,
+    name: 'presence',
+    description: 'Bot presence',
+    options: [
+      { type: 1, name: 'set', description: 'Set presence' },
+      { type: 1, name: 'clear', description: 'Clear presence' },
+    ],
+  },
+  { type: 1, name: 'status', description: 'Show status' },
+]);
+
+const HELP = plainCommand('help', 'Show all available commands');
+
+describe('flattenCommandLeaves', () => {
+  it('emits one leaf per subcommand as "name sub"', () => {
+    expect(flattenCommandLeaves(CHARACTER)).toEqual([
+      { path: 'character chat', description: 'Chat one-on-one' },
+      { path: 'character create', description: 'Create a character' },
+    ]);
+  });
+
+  it('expands subcommand groups as "name group sub" and keeps flat subcommands', () => {
+    expect(flattenCommandLeaves(ADMIN)).toEqual([
+      { path: 'admin presence set', description: 'Set presence' },
+      { path: 'admin presence clear', description: 'Clear presence' },
+      { path: 'admin status', description: 'Show status' },
+    ]);
+  });
+
+  it('yields a single leaf (the command name) for a flat command with no subcommands', () => {
+    expect(flattenCommandLeaves(HELP)).toEqual([
+      { path: 'help', description: 'Show all available commands' },
+    ]);
+  });
+
+  it('prefers toJSON() output over raw .options (live-builder type fix)', () => {
+    // Simulates the live SlashCommandBuilder: raw .options carry a name but NO
+    // numeric type (so reading them directly classifies nothing as a
+    // subcommand), while toJSON() populates type. The flatten must use toJSON.
+    const liveLike = {
+      data: {
+        name: 'voice',
+        description: 'Voice settings',
+        options: [{ name: 'tts' }], // no `type` → would be invisible if read raw
+        toJSON: () => ({
+          name: 'voice',
+          description: 'Voice settings',
+          options: [{ type: 1, name: 'tts', description: 'TTS settings' }],
+        }),
+      },
+      execute: vi.fn(),
+    } as unknown as Command;
+
+    expect(flattenCommandLeaves(liveLike)).toEqual([
+      { path: 'voice tts', description: 'TTS settings' },
+    ]);
+  });
+});
+
+describe('getCommandOptions', () => {
+  it('falls back to raw .options for plain fixtures without toJSON', () => {
+    expect(getCommandOptions(CHARACTER).map(o => o.name)).toEqual(['chat', 'create']);
+  });
+
+  it('returns [] when a command has no options', () => {
+    expect(getCommandOptions(HELP)).toEqual([]);
+  });
+});
+
+describe('resolveHelpTarget', () => {
+  const commands = new Map<string, Command>([
+    ['character', CHARACTER],
+    ['admin', ADMIN],
+    ['help', HELP],
+  ]);
+
+  it('resolves a bare command name to an overview', () => {
+    const target = resolveHelpTarget(commands, 'character');
+    expect(target).toEqual({ kind: 'overview', command: CHARACTER });
+  });
+
+  it('resolves "parent sub" to that single subcommand', () => {
+    const target = resolveHelpTarget(commands, 'character create');
+    expect(target.kind).toBe('subcommand');
+    if (target.kind === 'subcommand') {
+      expect(target.label).toBe('character create');
+      expect(target.option.name).toBe('create');
+      expect(target.option.options?.map(o => o.name)).toEqual(['name', 'slug']);
+    }
+  });
+
+  it('resolves "parent group sub" through a subcommand group', () => {
+    const target = resolveHelpTarget(commands, 'admin presence set');
+    expect(target.kind).toBe('subcommand');
+    if (target.kind === 'subcommand') {
+      expect(target.label).toBe('admin presence set');
+      expect(target.option.description).toBe('Set presence');
+    }
+  });
+
+  it('is case-insensitive and tolerates extra whitespace', () => {
+    expect(resolveHelpTarget(commands, '  Character   CREATE ').kind).toBe('subcommand');
+  });
+
+  it('returns unknown for an unregistered parent', () => {
+    expect(resolveHelpTarget(commands, 'nope')).toEqual({ kind: 'unknown' });
+  });
+
+  it('returns unknown for a nonexistent subcommand of a real parent', () => {
+    expect(resolveHelpTarget(commands, 'character fly')).toEqual({ kind: 'unknown' });
+  });
+
+  it('returns unknown for an empty value', () => {
+    expect(resolveHelpTarget(commands, '   ')).toEqual({ kind: 'unknown' });
+  });
+});

--- a/services/bot-client/src/commands/help/commandPaths.ts
+++ b/services/bot-client/src/commands/help/commandPaths.ts
@@ -1,0 +1,129 @@
+/**
+ * Command-path utilities for /help.
+ *
+ * Flattens a command's option tree into the discrete invocation paths users
+ * actually see in Discord's slash-command picker (e.g. "character chat",
+ * "admin presence set"), and resolves a typed/selected help value back to a
+ * command overview or a single subcommand.
+ *
+ * Option types are read via the builder's `toJSON()` output. The live
+ * `SlashCommandBuilder` exposes an option's `.name` but NOT a numeric `.type`
+ * on its raw `.options` entries — `type` is only populated by `toJSON()`. So
+ * reading the raw array would classify every subcommand as "not a subcommand"
+ * and the picker would surface nothing. Plain-object test fixtures that already
+ * carry `type` are read directly via the fallback.
+ */
+import type { Command } from '../../types.js';
+
+/** Discord application-command option-type discriminators. */
+const SUBCOMMAND = 1;
+const SUBCOMMAND_GROUP = 2;
+
+/** Normalized option node — the subset of the `toJSON()` shape we consume. */
+export interface CommandOptionNode {
+  type?: number;
+  name?: string;
+  description?: string;
+  options?: CommandOptionNode[];
+}
+
+/** One discrete, invocable command path plus its description. */
+export interface CommandLeaf {
+  /** Space-joined path, e.g. "character chat" or "admin presence set". */
+  path: string;
+  description: string;
+}
+
+/**
+ * Read a command's option tree, preferring `toJSON()` (which populates option
+ * `type`) and falling back to a raw `.options` array for plain-object fixtures.
+ */
+export function getCommandOptions(command: Command): CommandOptionNode[] {
+  const data = command.data as {
+    toJSON?: () => { options?: CommandOptionNode[] };
+    options?: CommandOptionNode[];
+  };
+  const source = typeof data.toJSON === 'function' ? data.toJSON() : data;
+  return Array.isArray(source.options) ? source.options : [];
+}
+
+/**
+ * Flatten a command into its leaf invocation paths — one per subcommand,
+ * expanding subcommand groups as "group sub". A command with no subcommands
+ * yields a single leaf: its own name (e.g. "help", "inspect").
+ */
+export function flattenCommandLeaves(command: Command): CommandLeaf[] {
+  const name = command.data.name;
+  const leaves: CommandLeaf[] = [];
+
+  for (const opt of getCommandOptions(command)) {
+    if (opt.type === SUBCOMMAND_GROUP && Array.isArray(opt.options)) {
+      for (const sub of opt.options) {
+        if (sub.type === SUBCOMMAND) {
+          leaves.push({
+            path: `${name} ${opt.name} ${sub.name}`,
+            description: sub.description ?? '',
+          });
+        }
+      }
+    } else if (opt.type === SUBCOMMAND) {
+      leaves.push({ path: `${name} ${opt.name}`, description: opt.description ?? '' });
+    }
+  }
+
+  if (leaves.length === 0) {
+    leaves.push({ path: name, description: command.data.description });
+  }
+  return leaves;
+}
+
+/** Result of resolving a /help command value. */
+export type HelpTarget =
+  | { kind: 'unknown' }
+  | { kind: 'overview'; command: Command }
+  | { kind: 'subcommand'; command: Command; label: string; option: CommandOptionNode };
+
+/**
+ * Resolve a /help value ("character", "character chat", "admin presence set")
+ * to a command overview, a single subcommand, or unknown. The value mirrors
+ * the leaf `path` emitted by {@link flattenCommandLeaves}, so an autocomplete
+ * pick always resolves to a concrete target.
+ */
+export function resolveHelpTarget(commands: Map<string, Command>, value: string): HelpTarget {
+  const parts = value
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(part => part.length > 0);
+  if (parts.length === 0) {
+    return { kind: 'unknown' };
+  }
+
+  const command = commands.get(parts[0]);
+  if (command === undefined) {
+    return { kind: 'unknown' };
+  }
+  if (parts.length === 1) {
+    return { kind: 'overview', command };
+  }
+
+  const options = getCommandOptions(command);
+  if (parts.length === 2) {
+    const sub = options.find(opt => opt.type === SUBCOMMAND && opt.name === parts[1]);
+    return sub === undefined
+      ? { kind: 'unknown' }
+      : { kind: 'subcommand', command, label: `${command.data.name} ${sub.name}`, option: sub };
+  }
+
+  // parent group sub
+  const group = options.find(opt => opt.type === SUBCOMMAND_GROUP && opt.name === parts[1]);
+  const sub = group?.options?.find(opt => opt.type === SUBCOMMAND && opt.name === parts[2]);
+  return group === undefined || sub === undefined
+    ? { kind: 'unknown' }
+    : {
+        kind: 'subcommand',
+        command,
+        label: `${command.data.name} ${group.name} ${sub.name}`,
+        option: sub,
+      };
+}

--- a/services/bot-client/src/commands/help/index.test.ts
+++ b/services/bot-client/src/commands/help/index.test.ts
@@ -8,11 +8,11 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { EmbedBuilder } from 'discord.js';
+import { EmbedBuilder, type AutocompleteInteraction } from 'discord.js';
 import helpCommand from './index.js';
 
 // Destructure from default export
-const { execute, data, deferralMode } = helpCommand;
+const { execute, data, deferralMode, autocomplete } = helpCommand;
 import type { Command } from '../../types.js';
 import type { SafeCommandContext } from '../../utils/commandContext/index.js';
 
@@ -212,6 +212,25 @@ describe('Help Command', () => {
       // A param-less subcommand still renders a field
       const editField = json.fields.find((f: { name: string }) => f.name.includes('edit'));
       expect(editField).toBeDefined();
+    });
+
+    it('shows a single subcommand detail when "parent sub" is requested', async () => {
+      const commands = createMockCommands();
+      const interaction = createMockContext('character create', commands);
+
+      await execute(interaction);
+
+      const embed = mockEditReply.mock.calls[0][0].embeds[0];
+      const json = embed.toJSON();
+
+      // Bounded to just the one subcommand — title is the full path, body lists
+      // only that subcommand's params (not every sibling subcommand).
+      expect(json.title).toBe('/character create');
+      expect(json.description).toBe('Create a character');
+      const paramsField = json.fields.find((f: { name: string }) => f.name === 'Parameters');
+      expect(paramsField?.value).toContain('`name`');
+      expect(paramsField?.value).toContain('*(required)*');
+      expect(paramsField?.value).toContain('`slug`');
     });
 
     it('shows parameters for a flat command (no subcommands)', async () => {
@@ -426,6 +445,139 @@ describe('Help Command', () => {
 
       expect(characterIndex).toBeLessThan(settingsIndex);
       expect(settingsIndex).toBeLessThan(helpIndex);
+    });
+  });
+
+  describe('autocomplete', () => {
+    interface CmdSpec {
+      name: string;
+      description: string;
+      subcommands?: Array<{ name: string; description: string }>;
+    }
+
+    function buildCommands(entries: CmdSpec[]): Map<string, Command> {
+      const commands = new Map<string, Command>();
+      for (const { name, description, subcommands } of entries) {
+        commands.set(name, {
+          data: {
+            name,
+            description,
+            ...(subcommands !== undefined && {
+              options: subcommands.map(s => ({
+                type: 1,
+                name: s.name,
+                description: s.description,
+              })),
+            }),
+          },
+          execute: vi.fn(),
+          category: 'Other',
+        } as unknown as Command);
+      }
+      return commands;
+    }
+
+    function createAutocompleteInteraction(
+      focusedValue: string,
+      commands?: Map<string, Command>,
+      focusedName = 'command'
+    ): { interaction: AutocompleteInteraction; respond: ReturnType<typeof vi.fn> } {
+      const respond = vi.fn();
+      const interaction = {
+        options: { getFocused: vi.fn(() => ({ name: focusedName, value: focusedValue })) },
+        client: { commands },
+        user: { id: 'user-123' },
+        guildId: null,
+        respond,
+      } as unknown as AutocompleteInteraction;
+      return { interaction, respond };
+    }
+
+    const sample: CmdSpec[] = [
+      {
+        name: 'character',
+        description: 'Manage AI characters',
+        subcommands: [
+          { name: 'chat', description: 'Chat one-on-one' },
+          { name: 'import', description: 'Import from JSON' },
+        ],
+      },
+      { name: 'help', description: 'Show all available commands' }, // flat command
+      {
+        name: 'voice',
+        description: 'Voice settings',
+        subcommands: [{ name: 'tts', description: 'TTS' }],
+      },
+    ];
+
+    function respondedValues(respond: ReturnType<typeof vi.fn>): string[] {
+      return (respond.mock.calls[0][0] as Array<{ value: string }>).map(choice => choice.value);
+    }
+
+    it('offers leaf subcommand paths matching the typed query (alphabetical)', async () => {
+      const { interaction, respond } = createAutocompleteInteraction('char', buildCommands(sample));
+      await autocomplete?.(interaction);
+      expect(respondedValues(respond)).toEqual(['character chat', 'character import']);
+    });
+
+    it('uses the leaf path as the value and shows "/path — description"', async () => {
+      const { interaction, respond } = createAutocompleteInteraction(
+        'voice tts',
+        buildCommands(sample)
+      );
+      await autocomplete?.(interaction);
+      expect(respond).toHaveBeenCalledWith([{ name: '/voice tts — TTS', value: 'voice tts' }]);
+    });
+
+    it('offers a flat (subcommand-less) command by its bare name', async () => {
+      const { interaction, respond } = createAutocompleteInteraction('help', buildCommands(sample));
+      await autocomplete?.(interaction);
+      expect(respond).toHaveBeenCalledWith([
+        { name: '/help — Show all available commands', value: 'help' },
+      ]);
+    });
+
+    it('returns every leaf (alphabetical) for an empty query', async () => {
+      const { interaction, respond } = createAutocompleteInteraction('', buildCommands(sample));
+      await autocomplete?.(interaction);
+      expect(respondedValues(respond)).toEqual([
+        'character chat',
+        'character import',
+        'help',
+        'voice tts',
+      ]);
+    });
+
+    it('caps choices at the Discord autocomplete limit', async () => {
+      const many: CmdSpec[] = [
+        {
+          name: 'big',
+          description: 'big',
+          subcommands: Array.from({ length: 30 }, (_, i) => ({
+            name: `s${String(i).padStart(2, '0')}`,
+            description: 'd',
+          })),
+        },
+      ];
+      const { interaction, respond } = createAutocompleteInteraction('big', buildCommands(many));
+      await autocomplete?.(interaction);
+      expect((respond.mock.calls[0][0] as unknown[]).length).toBe(25);
+    });
+
+    it('ignores a focused option other than `command`', async () => {
+      const { interaction, respond } = createAutocompleteInteraction(
+        'x',
+        buildCommands(sample),
+        'other'
+      );
+      await autocomplete?.(interaction);
+      expect(respond).not.toHaveBeenCalled();
+    });
+
+    it('responds with an empty list when no commands are registered', async () => {
+      const { interaction, respond } = createAutocompleteInteraction('any', undefined);
+      await autocomplete?.(interaction);
+      expect(respond).toHaveBeenCalledWith([]);
     });
   });
 });

--- a/services/bot-client/src/commands/help/index.ts
+++ b/services/bot-client/src/commands/help/index.ts
@@ -10,14 +10,26 @@
  * - TypeScript prevents accidental deferReply() calls at compile time
  */
 
-import { SlashCommandBuilder, EmbedBuilder } from 'discord.js';
-import { createLogger, DISCORD_COLORS, getConfig, helpOptions } from '@tzurot/common-types';
+import { SlashCommandBuilder, EmbedBuilder, type AutocompleteInteraction } from 'discord.js';
+import {
+  createLogger,
+  DISCORD_COLORS,
+  DISCORD_LIMITS,
+  getConfig,
+  helpOptions,
+} from '@tzurot/common-types';
 import {
   defineCommand,
   type DeferredCommandContext,
   type SafeCommandContext,
 } from '../../utils/defineCommand.js';
 import type { Command } from '../../types.js';
+import {
+  flattenCommandLeaves,
+  getCommandOptions,
+  resolveHelpTarget,
+  type CommandOptionNode,
+} from './commandPaths.js';
 // Note: Type augmentation for client.commands is in types/discord.d.ts
 
 const logger = createLogger('help-command');
@@ -167,25 +179,50 @@ function buildSubcommandFields(options: unknown[]): { name: string; value: strin
 async function showCommandDetails(
   context: DeferredCommandContext,
   commands: Map<string, Command>,
-  commandName: string
+  value: string
 ): Promise<void> {
-  const command = commands.get(commandName.toLowerCase());
+  const target = resolveHelpTarget(commands, value);
 
-  if (!command) {
+  if (target.kind === 'unknown') {
     await context.editReply({
-      content: `❌ Unknown command: \`/${commandName}\`\n\nUse \`/help\` to see all available commands.`,
+      content: `❌ Unknown command: \`/${value}\`\n\nUse \`/help\` to see all available commands.`,
     });
     return;
   }
 
+  const embed =
+    target.kind === 'subcommand'
+      ? buildSubcommandEmbed(target.label, target.option)
+      : buildOverviewEmbed(target.command);
+
+  await context.editReply({ embeds: [embed] });
+}
+
+/** Detail embed for a single subcommand: its description + parameter list. */
+function buildSubcommandEmbed(label: string, option: CommandOptionNode): EmbedBuilder {
+  const embed = new EmbedBuilder()
+    .setColor(DISCORD_COLORS.BLURPLE)
+    .setTitle(`/${label}`)
+    .setDescription(option.description ?? '');
+
+  const params = renderParams(option.options);
+  if (params !== '') {
+    embed.addFields({ name: 'Parameters', value: params.slice(0, FIELD_VALUE_LIMIT) });
+  }
+  return embed;
+}
+
+/** Overview embed for a command: one field per subcommand, or its own params. */
+function buildOverviewEmbed(command: Command): EmbedBuilder {
   const embed = new EmbedBuilder()
     .setColor(DISCORD_COLORS.BLURPLE)
     .setTitle(`/${command.data.name}`)
     .setDescription(command.data.description);
 
-  const options =
-    'options' in command.data && Array.isArray(command.data.options) ? command.data.options : [];
-
+  // Read via getCommandOptions (toJSON-backed): the live builder's raw
+  // `.options` don't expose a numeric `type`, so the subcommand classification
+  // below would otherwise find nothing in production.
+  const options = getCommandOptions(command);
   const subcommandFields = buildSubcommandFields(options);
 
   if (subcommandFields.length > 0) {
@@ -203,8 +240,7 @@ async function showCommandDetails(
       embed.addFields({ name: 'Parameters', value: params.slice(0, FIELD_VALUE_LIMIT) });
     }
   }
-
-  await context.editReply({ embeds: [embed] });
+  return embed;
 }
 
 /**
@@ -296,7 +332,57 @@ const commandData = new SlashCommandBuilder()
       .setName('command')
       .setDescription('Get detailed help for a specific command')
       .setRequired(false)
+      .setAutocomplete(true)
   );
+
+/** Discord caps an autocomplete choice's display name at 100 characters. */
+const AUTOCOMPLETE_NAME_LIMIT = 100;
+
+/**
+ * Autocomplete for the `command` option.
+ *
+ * Offers the discrete invocable command paths (subcommands like
+ * "character chat", group subcommands like "admin presence set") so users pick
+ * the exact thing they want help with — mirroring Discord's own slash-command
+ * picker. A freeform value that doesn't resolve lands on the "Unknown command"
+ * path, so steering users to real paths here is the whole point. Matches the
+ * typed query as a case-insensitive substring of the path, sorted
+ * alphabetically, capped at Discord's choice limit. The choice value is the
+ * path itself so `resolveHelpTarget` resolves it directly.
+ */
+async function autocomplete(interaction: AutocompleteInteraction): Promise<void> {
+  const focused = interaction.options.getFocused(true);
+  if (focused.name !== 'command') {
+    return;
+  }
+
+  try {
+    const commands = interaction.client.commands;
+    if (commands === undefined || commands.size === 0) {
+      await interaction.respond([]);
+      return;
+    }
+
+    const query = focused.value.toLowerCase();
+    const choices = [...commands.values()]
+      .flatMap(flattenCommandLeaves)
+      .filter(leaf => query.length === 0 || leaf.path.toLowerCase().includes(query))
+      .sort((a, b) => a.path.localeCompare(b.path))
+      .slice(0, DISCORD_LIMITS.AUTOCOMPLETE_MAX_CHOICES)
+      .map(leaf => ({
+        name: `/${leaf.path}${leaf.description.length > 0 ? ` — ${leaf.description}` : ''}`.slice(
+          0,
+          AUTOCOMPLETE_NAME_LIMIT
+        ),
+        value: leaf.path,
+      }));
+
+    await interaction.respond(choices);
+  } catch (error) {
+    logger.error({ err: error, query: focused.value }, 'Help command autocomplete failed');
+    await interaction.respond([]);
+  }
+}
 
 /**
  * Export command definition using defineCommand for type safety
@@ -311,4 +397,5 @@ export default defineCommand({
   data: commandData,
   deferralMode: 'ephemeral',
   execute,
+  autocomplete,
 });

--- a/services/bot-client/src/handlers/CommandHandler.int.test.ts
+++ b/services/bot-client/src/handlers/CommandHandler.int.test.ts
@@ -384,64 +384,31 @@ describe('CommandHandler (component)', () => {
    * Changes to command names, subcommands, or options should be intentional.
    */
   describe('command structure snapshots', () => {
-    it('should have stable /character command structure', () => {
-      const characterCommand = handler.getCommand('character');
-      expect(characterCommand).toBeDefined();
+    // These snapshots pin the FULL command surface, not a hardcoded subset.
+    // Previously only six commands were snapshotted by name, so a structural
+    // change to any of the other eight (channel, deny, help, history, inspect,
+    // memory, models, preset) would pass unnoticed. Iterating every registered
+    // command means adding a command auto-adds a snapshot, and changing any
+    // command's options (a new subcommand, param, or flag like autocomplete)
+    // breaks the matching snapshot. Pairs with 'command loading completeness'
+    // above, which asserts every command folder actually loads.
 
-      const data = characterCommand!.data.toJSON();
-      expect(data.name).toBe('character');
-      expect(data.options).toMatchSnapshot('character-command-options');
+    it('registers a stable set of command names (guards against silent drops)', () => {
+      // A per-command snapshot alone would still pass if a command silently
+      // failed to load — it just wouldn't snapshot the missing one. Pinning the
+      // name set makes an unexpected add or removal fail loudly instead.
+      const names = [...handler.getCommands().values()].map(command => command.data.name).sort();
+      expect(names).toMatchSnapshot('registered-command-names');
     });
 
-    it('should have stable /admin command structure', () => {
-      const adminCommand = handler.getCommand('admin');
-      expect(adminCommand).toBeDefined();
-
-      const data = adminCommand!.data.toJSON();
-      expect(data.name).toBe('admin');
-      expect(data.options).toMatchSnapshot('admin-command-options');
-    });
-
-    it('should have stable /persona command structure', () => {
-      const personaCommand = handler.getCommand('persona');
-      expect(personaCommand).toBeDefined();
-
-      const data = personaCommand!.data.toJSON();
-      expect(data.name).toBe('persona');
-      expect(data.options).toMatchSnapshot('persona-command-options');
-    });
-
-    it('should have stable /settings command structure', () => {
-      const settingsCommand = handler.getCommand('settings');
-      expect(settingsCommand).toBeDefined();
-
-      const data = settingsCommand!.data.toJSON();
-      expect(data.name).toBe('settings');
-      expect(data.options).toMatchSnapshot('settings-command-options');
-    });
-
-    it('should have stable /shapes command structure', () => {
-      const shapesCommand = handler.getCommand('shapes');
-      expect(shapesCommand).toBeDefined();
-
-      const data = shapesCommand!.data.toJSON();
-      expect(data.name).toBe('shapes');
-      expect(data.options).toMatchSnapshot('shapes-command-options');
-    });
-
-    it('should have stable /voice command structure', () => {
-      const voiceCommand = handler.getCommand('voice');
-      expect(voiceCommand).toBeDefined();
-
-      const data = voiceCommand!.data.toJSON();
-      expect(data.name).toBe('voice');
-      expect(data.options).toMatchSnapshot('voice-command-options');
-    });
-
-    it('should have stable command count', () => {
-      // Track total command count to catch accidental additions/removals
-      const commandCount = handler.getCommands().size;
-      expect(commandCount).toMatchSnapshot('total-command-count');
+    it('has a stable option structure for every registered command', () => {
+      const commands = [...handler.getCommands().values()].sort((a, b) =>
+        a.data.name.localeCompare(b.data.name)
+      );
+      for (const command of commands) {
+        const data = command.data.toJSON();
+        expect(data.options ?? []).toMatchSnapshot(`${data.name}-command-options`);
+      }
     });
   });
 });

--- a/services/bot-client/src/handlers/__snapshots__/CommandHandler.int.test.ts.snap
+++ b/services/bot-client/src/handlers/__snapshots__/CommandHandler.int.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`CommandHandler (component) > command structure snapshots > should have stable /admin command structure > admin-command-options 1`] = `
+exports[`CommandHandler (component) > command structure snapshots > has a stable option structure for every registered command > admin-command-options 1`] = `
 [
   {
     "description": "Check bot responsiveness and latency",
@@ -241,7 +241,93 @@ exports[`CommandHandler (component) > command structure snapshots > should have 
 ]
 `;
 
-exports[`CommandHandler (component) > command structure snapshots > should have stable /character command structure > character-command-options 1`] = `
+exports[`CommandHandler (component) > command structure snapshots > has a stable option structure for every registered command > channel-command-options 1`] = `
+[
+  {
+    "description": "Activate a character to auto-respond in this channel",
+    "description_localizations": undefined,
+    "name": "activate",
+    "name_localizations": undefined,
+    "options": [
+      {
+        "autocomplete": true,
+        "choices": undefined,
+        "description": "The character to activate",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "character",
+        "name_localizations": undefined,
+        "required": true,
+        "type": 3,
+      },
+    ],
+    "type": 1,
+  },
+  {
+    "description": "Deactivate the character from this channel",
+    "description_localizations": undefined,
+    "name": "deactivate",
+    "name_localizations": undefined,
+    "options": [],
+    "type": 1,
+  },
+  {
+    "description": "Browse activated channels",
+    "description_localizations": undefined,
+    "name": "browse",
+    "name_localizations": undefined,
+    "options": [
+      {
+        "autocomplete": undefined,
+        "choices": undefined,
+        "description": "Search by character name",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "query",
+        "name_localizations": undefined,
+        "required": false,
+        "type": 3,
+      },
+      {
+        "autocomplete": undefined,
+        "choices": [
+          {
+            "name": "This Server",
+            "name_localizations": undefined,
+            "value": "current",
+          },
+          {
+            "name": "All Servers (Owner only)",
+            "name_localizations": undefined,
+            "value": "all",
+          },
+        ],
+        "description": "Filter channels by scope",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "filter",
+        "name_localizations": undefined,
+        "required": false,
+        "type": 3,
+      },
+    ],
+    "type": 1,
+  },
+  {
+    "description": "Open extended context settings dashboard for this channel",
+    "description_localizations": undefined,
+    "name": "settings",
+    "name_localizations": undefined,
+    "options": [],
+    "type": 1,
+  },
+]
+`;
+
+exports[`CommandHandler (component) > command structure snapshots > has a stable option structure for every registered command > character-command-options 1`] = `
 [
   {
     "description": "Create a new AI character",
@@ -611,7 +697,951 @@ exports[`CommandHandler (component) > command structure snapshots > should have 
 ]
 `;
 
-exports[`CommandHandler (component) > command structure snapshots > should have stable /persona command structure > persona-command-options 1`] = `
+exports[`CommandHandler (component) > command structure snapshots > has a stable option structure for every registered command > deny-command-options 1`] = `
+[
+  {
+    "description": "Deny a user or server",
+    "description_localizations": undefined,
+    "name": "add",
+    "name_localizations": undefined,
+    "options": [
+      {
+        "autocomplete": undefined,
+        "choices": undefined,
+        "description": "Discord user or server ID",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "target",
+        "name_localizations": undefined,
+        "required": true,
+        "type": 3,
+      },
+      {
+        "autocomplete": undefined,
+        "choices": [
+          {
+            "name": "User",
+            "name_localizations": undefined,
+            "value": "USER",
+          },
+          {
+            "name": "Server",
+            "name_localizations": undefined,
+            "value": "GUILD",
+          },
+        ],
+        "description": "Entity type (default: User)",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "type",
+        "name_localizations": undefined,
+        "required": false,
+        "type": 3,
+      },
+      {
+        "autocomplete": undefined,
+        "choices": [
+          {
+            "name": "Bot (bot-wide)",
+            "name_localizations": undefined,
+            "value": "BOT",
+          },
+          {
+            "name": "Guild (this server)",
+            "name_localizations": undefined,
+            "value": "GUILD",
+          },
+          {
+            "name": "Channel",
+            "name_localizations": undefined,
+            "value": "CHANNEL",
+          },
+          {
+            "name": "Character",
+            "name_localizations": undefined,
+            "value": "PERSONALITY",
+          },
+        ],
+        "description": "Denial scope (default: Bot)",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "scope",
+        "name_localizations": undefined,
+        "required": false,
+        "type": 3,
+      },
+      {
+        "channel_types": [
+          0,
+          2,
+          15,
+        ],
+        "description": "Target channel (for Channel scope)",
+        "description_localizations": undefined,
+        "name": "channel",
+        "name_localizations": undefined,
+        "required": false,
+        "type": 7,
+      },
+      {
+        "autocomplete": true,
+        "choices": undefined,
+        "description": "Target character name (for Character scope)",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "character",
+        "name_localizations": undefined,
+        "required": false,
+        "type": 3,
+      },
+      {
+        "autocomplete": undefined,
+        "choices": undefined,
+        "description": "Reason for the denial",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "reason",
+        "name_localizations": undefined,
+        "required": false,
+        "type": 3,
+      },
+      {
+        "autocomplete": undefined,
+        "choices": [
+          {
+            "name": "Block (full deny, default)",
+            "name_localizations": undefined,
+            "value": "BLOCK",
+          },
+          {
+            "name": "Mute (ignore but keep in context)",
+            "name_localizations": undefined,
+            "value": "MUTE",
+          },
+        ],
+        "description": "Denial mode (default: Block)",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "mode",
+        "name_localizations": undefined,
+        "required": false,
+        "type": 3,
+      },
+    ],
+    "type": 1,
+  },
+  {
+    "description": "Remove a denial",
+    "description_localizations": undefined,
+    "name": "remove",
+    "name_localizations": undefined,
+    "options": [
+      {
+        "autocomplete": undefined,
+        "choices": undefined,
+        "description": "Discord user or server ID",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "target",
+        "name_localizations": undefined,
+        "required": true,
+        "type": 3,
+      },
+      {
+        "autocomplete": undefined,
+        "choices": [
+          {
+            "name": "User",
+            "name_localizations": undefined,
+            "value": "USER",
+          },
+          {
+            "name": "Server",
+            "name_localizations": undefined,
+            "value": "GUILD",
+          },
+        ],
+        "description": "Entity type (default: User)",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "type",
+        "name_localizations": undefined,
+        "required": false,
+        "type": 3,
+      },
+      {
+        "autocomplete": undefined,
+        "choices": [
+          {
+            "name": "Bot (bot-wide)",
+            "name_localizations": undefined,
+            "value": "BOT",
+          },
+          {
+            "name": "Guild (this server)",
+            "name_localizations": undefined,
+            "value": "GUILD",
+          },
+          {
+            "name": "Channel",
+            "name_localizations": undefined,
+            "value": "CHANNEL",
+          },
+          {
+            "name": "Character",
+            "name_localizations": undefined,
+            "value": "PERSONALITY",
+          },
+        ],
+        "description": "Denial scope (default: Bot)",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "scope",
+        "name_localizations": undefined,
+        "required": false,
+        "type": 3,
+      },
+      {
+        "channel_types": [
+          0,
+          2,
+          15,
+        ],
+        "description": "Target channel (for Channel scope)",
+        "description_localizations": undefined,
+        "name": "channel",
+        "name_localizations": undefined,
+        "required": false,
+        "type": 7,
+      },
+      {
+        "autocomplete": true,
+        "choices": undefined,
+        "description": "Target character name (for Character scope)",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "character",
+        "name_localizations": undefined,
+        "required": false,
+        "type": 3,
+      },
+    ],
+    "type": 1,
+  },
+  {
+    "description": "Browse denial entries (owner only)",
+    "description_localizations": undefined,
+    "name": "browse",
+    "name_localizations": undefined,
+    "options": [
+      {
+        "autocomplete": undefined,
+        "choices": [
+          {
+            "name": "All Types",
+            "name_localizations": undefined,
+            "value": "all",
+          },
+          {
+            "name": "Users Only",
+            "name_localizations": undefined,
+            "value": "user",
+          },
+          {
+            "name": "Servers Only",
+            "name_localizations": undefined,
+            "value": "guild",
+          },
+        ],
+        "description": "Filter by entity type",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "filter",
+        "name_localizations": undefined,
+        "required": false,
+        "type": 3,
+      },
+    ],
+    "type": 1,
+  },
+  {
+    "description": "Look up denial entries by Discord ID (owner only)",
+    "description_localizations": undefined,
+    "name": "view",
+    "name_localizations": undefined,
+    "options": [
+      {
+        "autocomplete": undefined,
+        "choices": undefined,
+        "description": "Discord user or server ID",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "target",
+        "name_localizations": undefined,
+        "required": true,
+        "type": 3,
+      },
+      {
+        "autocomplete": undefined,
+        "choices": [
+          {
+            "name": "User",
+            "name_localizations": undefined,
+            "value": "USER",
+          },
+          {
+            "name": "Server",
+            "name_localizations": undefined,
+            "value": "GUILD",
+          },
+        ],
+        "description": "Entity type filter",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "type",
+        "name_localizations": undefined,
+        "required": false,
+        "type": 3,
+      },
+    ],
+    "type": 1,
+  },
+]
+`;
+
+exports[`CommandHandler (component) > command structure snapshots > has a stable option structure for every registered command > help-command-options 1`] = `
+[
+  {
+    "autocomplete": true,
+    "choices": undefined,
+    "description": "Get detailed help for a specific command",
+    "description_localizations": undefined,
+    "max_length": undefined,
+    "min_length": undefined,
+    "name": "command",
+    "name_localizations": undefined,
+    "required": false,
+    "type": 3,
+  },
+]
+`;
+
+exports[`CommandHandler (component) > command structure snapshots > has a stable option structure for every registered command > history-command-options 1`] = `
+[
+  {
+    "description": "Clear conversation context (soft reset)",
+    "description_localizations": undefined,
+    "name": "clear",
+    "name_localizations": undefined,
+    "options": [
+      {
+        "autocomplete": true,
+        "choices": undefined,
+        "description": "The character to clear history for",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "character",
+        "name_localizations": undefined,
+        "required": true,
+        "type": 3,
+      },
+      {
+        "autocomplete": true,
+        "choices": undefined,
+        "description": "The persona to use (defaults to your active persona)",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "persona",
+        "name_localizations": undefined,
+        "required": false,
+        "type": 3,
+      },
+    ],
+    "type": 1,
+  },
+  {
+    "description": "Restore previously cleared context",
+    "description_localizations": undefined,
+    "name": "undo",
+    "name_localizations": undefined,
+    "options": [
+      {
+        "autocomplete": true,
+        "choices": undefined,
+        "description": "The character to restore history for",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "character",
+        "name_localizations": undefined,
+        "required": true,
+        "type": 3,
+      },
+      {
+        "autocomplete": true,
+        "choices": undefined,
+        "description": "The persona to use (defaults to your active persona)",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "persona",
+        "name_localizations": undefined,
+        "required": false,
+        "type": 3,
+      },
+    ],
+    "type": 1,
+  },
+  {
+    "description": "View conversation statistics",
+    "description_localizations": undefined,
+    "name": "stats",
+    "name_localizations": undefined,
+    "options": [
+      {
+        "autocomplete": true,
+        "choices": undefined,
+        "description": "The character to view stats for",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "character",
+        "name_localizations": undefined,
+        "required": true,
+        "type": 3,
+      },
+      {
+        "autocomplete": true,
+        "choices": undefined,
+        "description": "The persona to use (defaults to your active persona)",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "persona",
+        "name_localizations": undefined,
+        "required": false,
+        "type": 3,
+      },
+    ],
+    "type": 1,
+  },
+  {
+    "description": "PERMANENTLY delete conversation history (cannot be undone!)",
+    "description_localizations": undefined,
+    "name": "hard-delete",
+    "name_localizations": undefined,
+    "options": [
+      {
+        "autocomplete": true,
+        "choices": undefined,
+        "description": "The character to delete history for",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "character",
+        "name_localizations": undefined,
+        "required": true,
+        "type": 3,
+      },
+    ],
+    "type": 1,
+  },
+]
+`;
+
+exports[`CommandHandler (component) > command structure snapshots > has a stable option structure for every registered command > inspect-command-options 1`] = `
+[
+  {
+    "autocomplete": undefined,
+    "choices": undefined,
+    "description": "Message ID, message link, or request UUID (omit to browse recent)",
+    "description_localizations": undefined,
+    "max_length": undefined,
+    "min_length": undefined,
+    "name": "identifier",
+    "name_localizations": undefined,
+    "required": false,
+    "type": 3,
+  },
+]
+`;
+
+exports[`CommandHandler (component) > command structure snapshots > has a stable option structure for every registered command > memory-command-options 1`] = `
+[
+  {
+    "description": "View memory statistics",
+    "description_localizations": undefined,
+    "name": "stats",
+    "name_localizations": undefined,
+    "options": [
+      {
+        "autocomplete": true,
+        "choices": undefined,
+        "description": "The character to view stats for",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "character",
+        "name_localizations": undefined,
+        "required": true,
+        "type": 3,
+      },
+    ],
+    "type": 1,
+  },
+  {
+    "description": "Browse your memories with pagination",
+    "description_localizations": undefined,
+    "name": "browse",
+    "name_localizations": undefined,
+    "options": [
+      {
+        "autocomplete": true,
+        "choices": undefined,
+        "description": "Filter by character (optional)",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "character",
+        "name_localizations": undefined,
+        "required": false,
+        "type": 3,
+      },
+    ],
+    "type": 1,
+  },
+  {
+    "description": "Search your memories semantically",
+    "description_localizations": undefined,
+    "name": "search",
+    "name_localizations": undefined,
+    "options": [
+      {
+        "autocomplete": undefined,
+        "choices": undefined,
+        "description": "What to search for (natural language)",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "query",
+        "name_localizations": undefined,
+        "required": true,
+        "type": 3,
+      },
+      {
+        "autocomplete": true,
+        "choices": undefined,
+        "description": "Filter by character (optional)",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "character",
+        "name_localizations": undefined,
+        "required": false,
+        "type": 3,
+      },
+      {
+        "autocomplete": undefined,
+        "choices": undefined,
+        "description": "Number of results (1-10, default 5)",
+        "description_localizations": undefined,
+        "max_value": 10,
+        "min_value": 1,
+        "name": "limit",
+        "name_localizations": undefined,
+        "required": false,
+        "type": 4,
+      },
+    ],
+    "type": 1,
+  },
+  {
+    "description": "Batch delete memories with filters (skips locked)",
+    "description_localizations": undefined,
+    "name": "delete",
+    "name_localizations": undefined,
+    "options": [
+      {
+        "autocomplete": true,
+        "choices": undefined,
+        "description": "The character to delete memories for",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "character",
+        "name_localizations": undefined,
+        "required": true,
+        "type": 3,
+      },
+      {
+        "autocomplete": undefined,
+        "choices": [
+          {
+            "name": "Last 24 hours",
+            "name_localizations": undefined,
+            "value": "24h",
+          },
+          {
+            "name": "Last 7 days",
+            "name_localizations": undefined,
+            "value": "7d",
+          },
+          {
+            "name": "Last 30 days",
+            "name_localizations": undefined,
+            "value": "30d",
+          },
+          {
+            "name": "Last year",
+            "name_localizations": undefined,
+            "value": "1y",
+          },
+          {
+            "name": "All time",
+            "name_localizations": undefined,
+            "value": "all",
+          },
+        ],
+        "description": "Only delete memories from this time period (e.g., 7d, 30d, 1y)",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "timeframe",
+        "name_localizations": undefined,
+        "required": false,
+        "type": 3,
+      },
+    ],
+    "type": 1,
+  },
+  {
+    "description": "Delete ALL memories for a character (requires typed confirmation)",
+    "description_localizations": undefined,
+    "name": "purge",
+    "name_localizations": undefined,
+    "options": [
+      {
+        "autocomplete": true,
+        "choices": undefined,
+        "description": "The character to purge all memories for",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "character",
+        "name_localizations": undefined,
+        "required": true,
+        "type": 3,
+      },
+    ],
+    "type": 1,
+  },
+  {
+    "description": "Manage focus mode (disable LTM retrieval)",
+    "description_localizations": undefined,
+    "name": "focus",
+    "name_localizations": undefined,
+    "options": [
+      {
+        "description": "Enable focus mode - stop retrieving long-term memories",
+        "description_localizations": undefined,
+        "name": "enable",
+        "name_localizations": undefined,
+        "options": [
+          {
+            "autocomplete": true,
+            "choices": undefined,
+            "description": "The character to enable focus mode for",
+            "description_localizations": undefined,
+            "max_length": undefined,
+            "min_length": undefined,
+            "name": "character",
+            "name_localizations": undefined,
+            "required": true,
+            "type": 3,
+          },
+        ],
+        "type": 1,
+      },
+      {
+        "description": "Disable focus mode - resume retrieving long-term memories",
+        "description_localizations": undefined,
+        "name": "disable",
+        "name_localizations": undefined,
+        "options": [
+          {
+            "autocomplete": true,
+            "choices": undefined,
+            "description": "The character to disable focus mode for",
+            "description_localizations": undefined,
+            "max_length": undefined,
+            "min_length": undefined,
+            "name": "character",
+            "name_localizations": undefined,
+            "required": true,
+            "type": 3,
+          },
+        ],
+        "type": 1,
+      },
+      {
+        "description": "Check current focus mode status",
+        "description_localizations": undefined,
+        "name": "status",
+        "name_localizations": undefined,
+        "options": [
+          {
+            "autocomplete": true,
+            "choices": undefined,
+            "description": "The character to check status for",
+            "description_localizations": undefined,
+            "max_length": undefined,
+            "min_length": undefined,
+            "name": "character",
+            "name_localizations": undefined,
+            "required": true,
+            "type": 3,
+          },
+        ],
+        "type": 1,
+      },
+    ],
+    "type": 2,
+  },
+  {
+    "description": "Manage incognito mode (disable memory saving)",
+    "description_localizations": undefined,
+    "name": "incognito",
+    "name_localizations": undefined,
+    "options": [
+      {
+        "description": "Enable incognito mode - new memories will NOT be saved",
+        "description_localizations": undefined,
+        "name": "enable",
+        "name_localizations": undefined,
+        "options": [
+          {
+            "autocomplete": true,
+            "choices": undefined,
+            "description": "Character or "all" for global incognito",
+            "description_localizations": undefined,
+            "max_length": undefined,
+            "min_length": undefined,
+            "name": "character",
+            "name_localizations": undefined,
+            "required": true,
+            "type": 3,
+          },
+          {
+            "autocomplete": undefined,
+            "choices": [
+              {
+                "name": "30 minutes",
+                "name_localizations": undefined,
+                "value": "30m",
+              },
+              {
+                "name": "1 hour",
+                "name_localizations": undefined,
+                "value": "1h",
+              },
+              {
+                "name": "4 hours",
+                "name_localizations": undefined,
+                "value": "4h",
+              },
+              {
+                "name": "Until manually disabled",
+                "name_localizations": undefined,
+                "value": "forever",
+              },
+            ],
+            "description": "How long to stay in incognito mode",
+            "description_localizations": undefined,
+            "max_length": undefined,
+            "min_length": undefined,
+            "name": "duration",
+            "name_localizations": undefined,
+            "required": true,
+            "type": 3,
+          },
+        ],
+        "type": 1,
+      },
+      {
+        "description": "Disable incognito mode - resume saving memories",
+        "description_localizations": undefined,
+        "name": "disable",
+        "name_localizations": undefined,
+        "options": [
+          {
+            "autocomplete": true,
+            "choices": undefined,
+            "description": "Character or "all" to disable global incognito",
+            "description_localizations": undefined,
+            "max_length": undefined,
+            "min_length": undefined,
+            "name": "character",
+            "name_localizations": undefined,
+            "required": true,
+            "type": 3,
+          },
+        ],
+        "type": 1,
+      },
+      {
+        "description": "Check current incognito mode status",
+        "description_localizations": undefined,
+        "name": "status",
+        "name_localizations": undefined,
+        "options": [],
+        "type": 1,
+      },
+      {
+        "description": "Retroactively delete recent memories",
+        "description_localizations": undefined,
+        "name": "forget",
+        "name_localizations": undefined,
+        "options": [
+          {
+            "autocomplete": true,
+            "choices": undefined,
+            "description": "Character or "all" for all characters",
+            "description_localizations": undefined,
+            "max_length": undefined,
+            "min_length": undefined,
+            "name": "character",
+            "name_localizations": undefined,
+            "required": true,
+            "type": 3,
+          },
+          {
+            "autocomplete": undefined,
+            "choices": [
+              {
+                "name": "Last 5 minutes",
+                "name_localizations": undefined,
+                "value": "5m",
+              },
+              {
+                "name": "Last 15 minutes",
+                "name_localizations": undefined,
+                "value": "15m",
+              },
+              {
+                "name": "Last hour",
+                "name_localizations": undefined,
+                "value": "1h",
+              },
+            ],
+            "description": "How far back to delete memories",
+            "description_localizations": undefined,
+            "max_length": undefined,
+            "min_length": undefined,
+            "name": "timeframe",
+            "name_localizations": undefined,
+            "required": true,
+            "type": 3,
+          },
+        ],
+        "type": 1,
+      },
+    ],
+    "type": 2,
+  },
+]
+`;
+
+exports[`CommandHandler (component) > command structure snapshots > has a stable option structure for every registered command > models-command-options 1`] = `
+[
+  {
+    "description": "Browse available models, filtered by capability or search",
+    "description_localizations": undefined,
+    "name": "browse",
+    "name_localizations": undefined,
+    "options": [
+      {
+        "autocomplete": undefined,
+        "choices": [
+          {
+            "name": "Vision",
+            "name_localizations": undefined,
+            "value": "vision",
+          },
+          {
+            "name": "Image generation",
+            "name_localizations": undefined,
+            "value": "image-gen",
+          },
+          {
+            "name": "Text only",
+            "name_localizations": undefined,
+            "value": "text",
+          },
+        ],
+        "description": "Filter by capability",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "capability",
+        "name_localizations": undefined,
+        "required": false,
+        "type": 3,
+      },
+      {
+        "autocomplete": undefined,
+        "choices": undefined,
+        "description": "Search by model name or ID",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "search",
+        "name_localizations": undefined,
+        "required": false,
+        "type": 3,
+      },
+    ],
+    "type": 1,
+  },
+  {
+    "description": "View the detail card for a specific model",
+    "description_localizations": undefined,
+    "name": "view",
+    "name_localizations": undefined,
+    "options": [
+      {
+        "autocomplete": true,
+        "choices": undefined,
+        "description": "Model name or ID",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "model",
+        "name_localizations": undefined,
+        "required": true,
+        "type": 3,
+      },
+    ],
+    "type": 1,
+  },
+]
+`;
+
+exports[`CommandHandler (component) > command structure snapshots > has a stable option structure for every registered command > persona-command-options 1`] = `
 [
   {
     "description": "View your current persona",
@@ -745,7 +1775,192 @@ exports[`CommandHandler (component) > command structure snapshots > should have 
 ]
 `;
 
-exports[`CommandHandler (component) > command structure snapshots > should have stable /settings command structure > settings-command-options 1`] = `
+exports[`CommandHandler (component) > command structure snapshots > has a stable option structure for every registered command > preset-command-options 1`] = `
+[
+  {
+    "description": "Browse and search model presets",
+    "description_localizations": undefined,
+    "name": "browse",
+    "name_localizations": undefined,
+    "options": [
+      {
+        "autocomplete": undefined,
+        "choices": undefined,
+        "description": "Search by name or model",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "query",
+        "name_localizations": undefined,
+        "required": false,
+        "type": 3,
+      },
+      {
+        "autocomplete": undefined,
+        "choices": [
+          {
+            "name": "All Presets",
+            "name_localizations": undefined,
+            "value": "all",
+          },
+          {
+            "name": "Global Only",
+            "name_localizations": undefined,
+            "value": "global",
+          },
+          {
+            "name": "My Presets",
+            "name_localizations": undefined,
+            "value": "mine",
+          },
+          {
+            "name": "Free Models",
+            "name_localizations": undefined,
+            "value": "free",
+          },
+        ],
+        "description": "Filter presets by type",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "filter",
+        "name_localizations": undefined,
+        "required": false,
+        "type": 3,
+      },
+    ],
+    "type": 1,
+  },
+  {
+    "description": "Create a new model preset",
+    "description_localizations": undefined,
+    "name": "create",
+    "name_localizations": undefined,
+    "options": [],
+    "type": 1,
+  },
+  {
+    "description": "Edit one of your model presets",
+    "description_localizations": undefined,
+    "name": "edit",
+    "name_localizations": undefined,
+    "options": [
+      {
+        "autocomplete": true,
+        "choices": undefined,
+        "description": "Preset to edit",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "preset",
+        "name_localizations": undefined,
+        "required": true,
+        "type": 3,
+      },
+    ],
+    "type": 1,
+  },
+  {
+    "description": "Export a preset as JSON file",
+    "description_localizations": undefined,
+    "name": "export",
+    "name_localizations": undefined,
+    "options": [
+      {
+        "autocomplete": true,
+        "choices": undefined,
+        "description": "Preset to export",
+        "description_localizations": undefined,
+        "max_length": undefined,
+        "min_length": undefined,
+        "name": "preset",
+        "name_localizations": undefined,
+        "required": true,
+        "type": 3,
+      },
+    ],
+    "type": 1,
+  },
+  {
+    "description": "Import a preset from JSON file",
+    "description_localizations": undefined,
+    "name": "import",
+    "name_localizations": undefined,
+    "options": [
+      {
+        "description": "JSON file to import",
+        "description_localizations": undefined,
+        "name": "file",
+        "name_localizations": undefined,
+        "required": true,
+        "type": 11,
+      },
+    ],
+    "type": 1,
+  },
+  {
+    "description": "Download a JSON template for preset import",
+    "description_localizations": undefined,
+    "name": "template",
+    "name_localizations": undefined,
+    "options": [],
+    "type": 1,
+  },
+  {
+    "description": "Manage global presets (Owner only)",
+    "description_localizations": undefined,
+    "name": "global",
+    "name_localizations": undefined,
+    "options": [
+      {
+        "description": "Set a global preset as the system default (Owner only)",
+        "description_localizations": undefined,
+        "name": "default",
+        "name_localizations": undefined,
+        "options": [
+          {
+            "autocomplete": true,
+            "choices": undefined,
+            "description": "Global preset to set as default",
+            "description_localizations": undefined,
+            "max_length": undefined,
+            "min_length": undefined,
+            "name": "preset",
+            "name_localizations": undefined,
+            "required": true,
+            "type": 3,
+          },
+        ],
+        "type": 1,
+      },
+      {
+        "description": "Set a global preset as the free tier default (Owner only)",
+        "description_localizations": undefined,
+        "name": "free-default",
+        "name_localizations": undefined,
+        "options": [
+          {
+            "autocomplete": true,
+            "choices": undefined,
+            "description": "Global preset to set as free tier default",
+            "description_localizations": undefined,
+            "max_length": undefined,
+            "min_length": undefined,
+            "name": "preset",
+            "name_localizations": undefined,
+            "required": true,
+            "type": 3,
+          },
+        ],
+        "type": 1,
+      },
+    ],
+    "type": 2,
+  },
+]
+`;
+
+exports[`CommandHandler (component) > command structure snapshots > has a stable option structure for every registered command > settings-command-options 1`] = `
 [
   {
     "description": "Manage your timezone settings",
@@ -1048,7 +2263,7 @@ exports[`CommandHandler (component) > command structure snapshots > should have 
 ]
 `;
 
-exports[`CommandHandler (component) > command structure snapshots > should have stable /shapes command structure > shapes-command-options 1`] = `
+exports[`CommandHandler (component) > command structure snapshots > has a stable option structure for every registered command > shapes-command-options 1`] = `
 [
   {
     "description": "Authenticate with your shapes.inc session cookie",
@@ -1173,7 +2388,7 @@ exports[`CommandHandler (component) > command structure snapshots > should have 
 ]
 `;
 
-exports[`CommandHandler (component) > command structure snapshots > should have stable /voice command structure > voice-command-options 1`] = `
+exports[`CommandHandler (component) > command structure snapshots > has a stable option structure for every registered command > voice-command-options 1`] = `
 [
   {
     "description": "Show resolved TTS + STT + voices for a character",
@@ -1399,4 +2614,21 @@ exports[`CommandHandler (component) > command structure snapshots > should have 
 ]
 `;
 
-exports[`CommandHandler (component) > command structure snapshots > should have stable command count > total-command-count 1`] = `14`;
+exports[`CommandHandler (component) > command structure snapshots > registers a stable set of command names (guards against silent drops) > registered-command-names 1`] = `
+[
+  "admin",
+  "channel",
+  "character",
+  "deny",
+  "help",
+  "history",
+  "inspect",
+  "memory",
+  "models",
+  "persona",
+  "preset",
+  "settings",
+  "shapes",
+  "voice",
+]
+`;


### PR DESCRIPTION
## Why

`/help` had a `command` option with no autocomplete, so users typed freeform — a non-matching value (e.g. `character chat`) hit "❌ Unknown command". Discord's own picker treats subcommands (`character chat`, `character import`, …) as the discrete units users see, so `/help` should mirror that.

## Changes

**1. `feat` — leaf-command autocomplete + bounded detail**
- Autocomplete now offers the discrete invocable paths: subcommands (`character chat`) and group subcommands (`admin presence set`), plus flat commands by bare name (`help`, `inspect`). Filtered by substring of the path, alphabetical, capped at Discord's 25.
- `/help character chat` resolves to **just that subcommand's** detail (title + params), instead of dumping every subcommand of the parent. This matters: `voice` has 23 subcommands and `settings` 16 — the parent overview approaches the 25-field embed cap and silently truncates.
- Path logic extracted to `commandPaths.ts` (`flattenCommandLeaves` / `resolveHelpTarget`) with colocated tests.
- **Latent bug fixed along the way**: the overview read `command.data.options` directly, but the live `SlashCommandBuilder` only populates option `type` via `toJSON()` — so `/help <command>` rendered *no* subcommands in production (unit tests missed it because their mocks hard-code `type`). Now read through a `toJSON`-preferring accessor.

**2. `test` — structure snapshots cover every command, not a subset**
- The command-structure snapshots hard-coded 6 commands (admin, character, persona, settings, shapes, voice), leaving 8 unprotected (channel, deny, help, history, inspect, memory, models, preset). Now iterates the full registry — adding a command auto-adds a snapshot; changing any command's options breaks the matching one.
- Added a `registered-command-names` tripwire so a command that silently fails to load fails loudly (the per-command loop alone wouldn't notice a missing command). Replaces the weaker count snapshot.
- Regenerated `command-manifest.json` for the new `autocomplete: true` on `/help`.

## Verification
- `pnpm quality` green (typecheck/spec, lint, knip, cpd, depcruise, backlog:lint)
- help unit tests (37), `commandPaths` (13), structure test, and the regenerated `CommandHandler.int` snapshots all pass; pre-push full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)