### PR TITLE
fix(common-types): bound the transient PrismaPg pools (dbSync, prisma-env)

### DIFF
--- a/packages/common-types/src/index.ts
+++ b/packages/common-types/src/index.ts
@@ -75,6 +75,7 @@ export { normalizeRole, normalizeTimestamp } from './utils/messageNormalization.
 
 // Export services
 export * from './services/prisma.js';
+export * from './services/poolConfig.js';
 export * from './services/personality/index.js';
 export * from './services/BaseConfigResolver.js';
 export * from './services/LlmConfigMapper.js';

--- a/packages/common-types/src/services/poolConfig.test.ts
+++ b/packages/common-types/src/services/poolConfig.test.ts
@@ -9,6 +9,7 @@ import {
   resolveConnectionTimeoutMs,
   resolvePoolStatsIntervalMs,
   startPoolStatsGauge,
+  transientPoolOptions,
   type PoolStatsSource,
 } from './poolConfig.js';
 
@@ -37,11 +38,30 @@ describe('resolveConnectionTimeoutMs', () => {
     expect(resolveConnectionTimeoutMs({ DATABASE_POOL_CONN_TIMEOUT_MS: '0' })).toBe(0);
   });
 
-  it('reads a valid override and falls back on garbage', () => {
+  it('reads a valid override and falls back on garbage or negative values', () => {
     expect(resolveConnectionTimeoutMs({ DATABASE_POOL_CONN_TIMEOUT_MS: '3000' })).toBe(3000);
     expect(resolveConnectionTimeoutMs({ DATABASE_POOL_CONN_TIMEOUT_MS: 'soon' })).toBe(
       DB_POOL_DEFAULTS.CONNECTION_TIMEOUT_MS
     );
+    expect(resolveConnectionTimeoutMs({ DATABASE_POOL_CONN_TIMEOUT_MS: '-1' })).toBe(
+      DB_POOL_DEFAULTS.CONNECTION_TIMEOUT_MS
+    );
+  });
+});
+
+describe('transientPoolOptions', () => {
+  it('uses the small transient max and the resolved (finite) acquisition timeout', () => {
+    expect(transientPoolOptions({})).toEqual({
+      max: DB_POOL_DEFAULTS.TRANSIENT_MAX,
+      connectionTimeoutMillis: DB_POOL_DEFAULTS.CONNECTION_TIMEOUT_MS,
+    });
+  });
+
+  it('honors a DATABASE_POOL_CONN_TIMEOUT_MS override for the timeout', () => {
+    expect(transientPoolOptions({ DATABASE_POOL_CONN_TIMEOUT_MS: '2000' })).toEqual({
+      max: DB_POOL_DEFAULTS.TRANSIENT_MAX,
+      connectionTimeoutMillis: 2000,
+    });
   });
 });
 

--- a/packages/common-types/src/services/poolConfig.ts
+++ b/packages/common-types/src/services/poolConfig.ts
@@ -24,6 +24,9 @@ export const DB_POOL_DEFAULTS = {
   /** Saturation-gauge interval. Logs WARN only when connections are queued, so
    *  the next incident is captured automatically. 0 disables the gauge. */
   STATS_INTERVAL_MS: 30_000,
+  /** Max for transient/short-lived clients (CLI scripts, cross-env sync) — small
+   *  on purpose; these aren't the long-running request pool. */
+  TRANSIENT_MAX: 5,
 } as const;
 
 /** Parse a non-negative integer env var, falling back when unset/invalid. */
@@ -45,6 +48,23 @@ export function resolveConnectionTimeoutMs(env: NodeJS.ProcessEnv = process.env)
 /** Resolve the saturation-gauge interval in ms (0 = disabled). */
 export function resolvePoolStatsIntervalMs(env: NodeJS.ProcessEnv = process.env): number {
   return parseIntEnv(env.DATABASE_POOL_STATS_INTERVAL_MS, DB_POOL_DEFAULTS.STATS_INTERVAL_MS, 0);
+}
+
+/**
+ * Pool options for transient/short-lived `PrismaPg` clients (CLI scripts,
+ * cross-env sync) that don't warrant the full singleton pool: a small `max` plus
+ * the same finite acquisition timeout, so they fail loudly instead of hanging
+ * forever on a saturated/unreachable database. Spread into a `PrismaPg` config:
+ * `new PrismaPg({ connectionString, ...transientPoolOptions() })`.
+ */
+export function transientPoolOptions(env: NodeJS.ProcessEnv = process.env): {
+  max: number;
+  connectionTimeoutMillis: number;
+} {
+  return {
+    max: DB_POOL_DEFAULTS.TRANSIENT_MAX,
+    connectionTimeoutMillis: resolveConnectionTimeoutMs(env),
+  };
 }
 
 /** The pool stats the gauge reads (subset of `pg.Pool`). */

--- a/packages/tooling/src/memory/prisma-env.test.ts
+++ b/packages/tooling/src/memory/prisma-env.test.ts
@@ -9,6 +9,7 @@ vi.mock('@tzurot/common-types', () => ({
   PrismaClient: class MockPrismaClient {
     $disconnect = vi.fn().mockResolvedValue(undefined);
   },
+  transientPoolOptions: () => ({ max: 5, connectionTimeoutMillis: 10_000 }),
 }));
 
 vi.mock('@prisma/adapter-pg', () => ({

--- a/packages/tooling/src/memory/prisma-env.ts
+++ b/packages/tooling/src/memory/prisma-env.ts
@@ -7,7 +7,7 @@
  */
 
 import { type Environment, getRailwayDatabaseUrl } from '../utils/env-runner.js';
-import { type PrismaClient } from '@tzurot/common-types';
+import { type PrismaClient, transientPoolOptions } from '@tzurot/common-types';
 
 export interface PrismaEnvConnection {
   prisma: PrismaClient;
@@ -33,7 +33,7 @@ export async function getPrismaForEnv(env: Environment): Promise<PrismaEnvConnec
     databaseUrl = getRailwayDatabaseUrl(env);
   }
 
-  const adapter = new PrismaPg({ connectionString: databaseUrl });
+  const adapter = new PrismaPg({ connectionString: databaseUrl, ...transientPoolOptions() });
   const prisma = new PrismaClientClass({ adapter, log: ['error'] });
 
   return {

--- a/services/api-gateway/src/routes/admin/dbSync.ts
+++ b/services/api-gateway/src/routes/admin/dbSync.ts
@@ -4,7 +4,13 @@
  */
 
 import { Router, type Request, type RequestHandler, type Response } from 'express';
-import { createLogger, getConfig, DbSyncSchema, PrismaClient } from '@tzurot/common-types';
+import {
+  createLogger,
+  getConfig,
+  DbSyncSchema,
+  PrismaClient,
+  transientPoolOptions,
+} from '@tzurot/common-types';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { DatabaseSyncService } from '../../services/DatabaseSyncService.js';
 import { requireOwnerAuth } from '../../services/AuthMiddleware.js';
@@ -50,11 +56,19 @@ export const handleDbSync = (_deps: RouteDeps): RequestHandler =>
 
     logger.info({ dryRun }, 'Starting database sync');
 
-    // Create Prisma clients for dev and prod databases using driver adapters
-    const devAdapter = new PrismaPg({ connectionString: config.DEV_DATABASE_URL });
+    // Create Prisma clients for dev and prod databases using driver adapters.
+    // transientPoolOptions caps these short-lived cross-env sync pools and gives
+    // them a finite acquisition timeout (the adapter ignores connection_limit).
+    const devAdapter = new PrismaPg({
+      connectionString: config.DEV_DATABASE_URL,
+      ...transientPoolOptions(),
+    });
     const devClient = new PrismaClient({ adapter: devAdapter });
 
-    const prodAdapter = new PrismaPg({ connectionString: config.PROD_DATABASE_URL });
+    const prodAdapter = new PrismaPg({
+      connectionString: config.PROD_DATABASE_URL,
+      ...transientPoolOptions(),
+    });
     const prodClient = new PrismaClient({ adapter: prodAdapter });
 
     // Execute sync - the service handles connect/disconnect internally


### PR DESCRIPTION
Follow-up to #1250 (the DB pool root-cause fix). Two stray `PrismaPg` clients still constructed with no pool options — the same unbounded pg defaults (`max=10`, wait-forever acquisition) #1250 removed from the main singleton:

- `services/api-gateway/src/routes/admin/dbSync.ts` — the dev + prod cross-env sync adapters
- `packages/tooling/src/memory/prisma-env.ts` — the memory-CLI client

Both are short-lived / admin-only (lower risk than the request pool), but they should still **fail loudly instead of hanging** on a saturated/unreachable DB. Adds a `transientPoolOptions()` helper (small `max` + the finite acquisition timeout) and applies it to all three sites. Also folds in the negative-value `resolveConnectionTimeoutMs` test the #1250 review flagged.

## Verification
- `pnpm quality` green; `poolConfig` tests (12, +2) + `prisma-env`/`dbSync` tests pass; pre-push full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)