### PR TITLE
fix: accept null media fields on personality update (no-avatar edit 400)

### DIFF
--- a/packages/common-types/src/schemas/api/personality.test.ts
+++ b/packages/common-types/src/schemas/api/personality.test.ts
@@ -344,6 +344,15 @@ describe('Personality API Contract Tests', () => {
       expect(result.success).toBe(true);
     });
 
+    it('should accept null avatarData / voiceReferenceData (no media provided)', () => {
+      const result = PersonalityCreateSchema.safeParse({
+        ...validCreateInput,
+        avatarData: null,
+        voiceReferenceData: null,
+      });
+      expect(result.success).toBe(true);
+    });
+
     it('should reject missing required field: name', () => {
       const { name: _name, ...inputWithoutName } = validCreateInput;
       const result = PersonalityCreateSchema.safeParse(inputWithoutName);
@@ -449,6 +458,18 @@ describe('Personality API Contract Tests', () => {
 
       const result = PersonalityUpdateSchema.safeParse(fullUpdate);
       expect(result.success).toBe(true);
+    });
+
+    it('should accept avatarData as null (no-avatar round-trip)', () => {
+      // Regression: a character with no avatar has avatarData=null, and the
+      // dashboard round-trips it on every section save (it only fetches
+      // `hasAvatar`, never the base64). Rejecting null here 400'd every edit of
+      // a no-avatar character with "expected string, received null".
+      const result = PersonalityUpdateSchema.safeParse({ name: 'New Name', avatarData: null });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.avatarData).toBeNull();
+      }
     });
 
     it('should accept voiceReferenceData as string (set new)', () => {

--- a/packages/common-types/src/schemas/api/personality.ts
+++ b/packages/common-types/src/schemas/api/personality.ts
@@ -219,13 +219,17 @@ export const PersonalityCreateSchema = z.object({
   // Custom fields (JSONB) - accepts arbitrary nested JSON to match Prisma Json? type
   customFields: z.record(z.string(), z.unknown()).optional().nullable(),
 
-  // Avatar data (base64 encoded, processed separately)
-  avatarData: z.string().optional(),
+  // Avatar data (base64 encoded, processed separately).
+  // null = no avatar — the bot-client dashboard only fetches `hasAvatar`, never
+  // the base64, so it round-trips `avatarData: null` on every save. Accepting
+  // null (treated as "no change" by processAvatarData) is required or that
+  // round-trip 400s. See voiceReferenceData below for the same shape.
+  avatarData: z.string().nullable().optional(),
 
   // Voice reference audio (base64 data URI, processed by voiceReferenceProcessor).
-  // Schema only validates type — format/MIME/size validation is in the processor
-  // (same pattern as avatarData above).
-  voiceReferenceData: z.string().optional(),
+  // Schema only validates type — format/MIME/size validation is in the processor.
+  // null = no voice reference (same round-trip rationale as avatarData above).
+  voiceReferenceData: z.string().nullable().optional(),
 });
 
 export type PersonalityCreateInput = z.infer<typeof PersonalityCreateSchema>;
@@ -253,8 +257,12 @@ export const PersonalityUpdateSchema = z.object({
   // Custom fields (JSONB) - accepts arbitrary nested JSON to match Prisma Json? type
   customFields: z.record(z.string(), z.unknown()).optional().nullable(),
 
-  // Avatar data (base64 encoded, processed separately)
-  avatarData: z.string().optional(),
+  // Avatar data (base64 encoded, processed separately).
+  // null = the dashboard round-trips a no-avatar character (it only fetches
+  // `hasAvatar`, never the base64). processMediaUploads treats null as "no
+  // change" — it never clears an existing avatar — so editing an unrelated
+  // section is safe. Rejecting null here is the avatarData-class 400 bug.
+  avatarData: z.string().nullable().optional(),
 
   // Voice reference audio (base64 data URI, processed separately)
   // null = clear existing voice reference, undefined = don't change, string = set new

--- a/services/api-gateway/src/utils/avatarProcessor.test.ts
+++ b/services/api-gateway/src/utils/avatarProcessor.test.ts
@@ -20,6 +20,14 @@ describe('processAvatarData', () => {
     expect(mockOptimizeAvatar).not.toHaveBeenCalled();
   });
 
+  it('returns null when avatarData is null (no-avatar round-trip; no change, no crash)', async () => {
+    // The dashboard round-trips avatarData=null for a no-avatar character. null
+    // must be treated as "no media" — never optimized, never wiping an avatar.
+    const result = await processAvatarData(null, 'test-slug');
+    expect(result).toBeNull();
+    expect(mockOptimizeAvatar).not.toHaveBeenCalled();
+  });
+
   it('returns null when avatarData is empty string', async () => {
     const result = await processAvatarData('', 'test-slug');
     expect(result).toBeNull();

--- a/services/api-gateway/src/utils/avatarProcessor.ts
+++ b/services/api-gateway/src/utils/avatarProcessor.ts
@@ -30,10 +30,12 @@ export interface AvatarError {
  *          or `{ ok: false, error }` on processing failure.
  */
 export async function processAvatarData(
-  avatarData: string | undefined,
+  avatarData: string | null | undefined,
   slug: string
 ): Promise<AvatarSuccess | AvatarError | null> {
-  if (avatarData === undefined || avatarData.length === 0) {
+  // null = no avatar (the dashboard round-trips null for a no-avatar character);
+  // treat it like undefined/empty — no processing, no change to the stored avatar.
+  if (avatarData === undefined || avatarData === null || avatarData.length === 0) {
     return null;
   }
 

--- a/services/api-gateway/src/utils/voiceReferenceProcessor.test.ts
+++ b/services/api-gateway/src/utils/voiceReferenceProcessor.test.ts
@@ -39,6 +39,11 @@ describe('processVoiceReferenceData', () => {
     expect(result).toBeNull();
   });
 
+  it('returns null when data is null (no voice reference provided; no change)', () => {
+    const result = processVoiceReferenceData(null, 'test-slug');
+    expect(result).toBeNull();
+  });
+
   it('returns null when data is empty string', () => {
     const result = processVoiceReferenceData('', 'test-slug');
     expect(result).toBeNull();

--- a/services/api-gateway/src/utils/voiceReferenceProcessor.ts
+++ b/services/api-gateway/src/utils/voiceReferenceProcessor.ts
@@ -43,10 +43,17 @@ function extractMimeType(dataUri: string): string | null {
  *          or `{ ok: false, error }` on validation failure.
  */
 export function processVoiceReferenceData(
-  voiceReferenceData: string | undefined,
+  voiceReferenceData: string | null | undefined,
   slug: string
 ): VoiceReferenceSuccess | VoiceReferenceError | null {
-  if (voiceReferenceData === undefined || voiceReferenceData.length === 0) {
+  // null = no voice reference provided (parity with avatarData). The update
+  // route handles the explicit "clear existing" case before calling this; here
+  // null is simply "no data" — no processing.
+  if (
+    voiceReferenceData === undefined ||
+    voiceReferenceData === null ||
+    voiceReferenceData.length === 0
+  ) {
     return null;
   }
 

--- a/services/bot-client/src/commands/character/api.ts
+++ b/services/bot-client/src/commands/character/api.ts
@@ -7,21 +7,23 @@
  * all flow through the route manifest.
  *
  * Schema drift note: `CharacterData` is a bot-client display shape that
- * predates the typed client. Two fields don't round-trip cleanly with
- * `PersonalityFullSchema`:
+ * predates the typed client. `toCharacterData` coerces two fields so the shape
+ * assigns directly to the gateway's create/update input (no cast needed):
  *   - `characterInfo` / `personalityTraits` are non-nullable on
  *     `CharacterData` but nullable in the schema (the gateway can return
  *     null for newly-created characters before the user fills the modal).
  *     Coerced with `?? ''` at the spread boundary here.
  *   - `avatarData` is a bot-client convenience field (used during
  *     create/update flows in import.ts); the gateway response carries
- *     `hasAvatar: boolean` instead. Defaulted to `null` on incoming data
- *     and populated separately on the create/update paths.
+ *     `hasAvatar: boolean` instead. Defaulted to `null` on incoming data.
+ *     The create/update schemas accept `null` (= no avatar), so it round-trips
+ *     cleanly; the avatar itself is set separately via `/character avatar`.
  */
 
 import type { ChatInputCommandInteraction } from 'discord.js';
 import type { EnvConfig } from '@tzurot/common-types';
 import type { UserClient } from '@tzurot/clients';
+import { DashboardUpdateError } from '../../utils/dashboard/saveError.js';
 import type { CharacterData } from './characterTypes.js';
 
 /**
@@ -209,19 +211,23 @@ export async function createCharacter(
   userClient: UserClient,
   _config: EnvConfig
 ): Promise<CharacterData> {
-  const result = await userClient.createPersonality(
-    data as Parameters<UserClient['createPersonality']>[0]
-  );
+  const result = await userClient.createPersonality(data);
 
   if (!result.ok) {
-    throw new Error(`Failed to create character: ${result.status} - ${result.error}`);
+    // Consistent with updateCharacter: carry the status (so a create flow could
+    // surface the honest status-0 notice) and guard the message against an
+    // undefined gateway error.
+    throw new DashboardUpdateError(
+      `Failed to create character: ${result.status} - ${result.error ?? 'Unknown'}`,
+      result.status
+    );
   }
 
   return toCharacterData(result.data.personality);
 }
 
 /**
- * Update a character. Same boundary-cast rationale as `createCharacter`.
+ * Update a character.
  */
 export async function updateCharacter(
   slug: string,
@@ -229,13 +235,16 @@ export async function updateCharacter(
   userClient: UserClient,
   _config: EnvConfig
 ): Promise<CharacterData> {
-  const result = await userClient.updatePersonality(
-    slug,
-    data as Parameters<UserClient['updatePersonality']>[1]
-  );
+  const result = await userClient.updatePersonality(slug, data);
 
   if (!result.ok) {
-    throw new Error(`Failed to update character: ${result.status} - ${result.error}`);
+    // DashboardUpdateError carries the status so the dashboard can distinguish a
+    // client-side abort (0 → "still applying") from a real HTTP rejection (whose
+    // message it surfaces). The message format matches extractApiErrorMessage.
+    throw new DashboardUpdateError(
+      `Failed to update character: ${result.status} - ${result.error ?? 'Unknown'}`,
+      result.status
+    );
   }
 
   return toCharacterData(result.data.personality);

--- a/services/bot-client/src/commands/character/dashboard.test.ts
+++ b/services/bot-client/src/commands/character/dashboard.test.ts
@@ -11,6 +11,7 @@ import {
 } from './dashboard.js';
 import { handleDashboardClose } from '../../utils/dashboard/closeHandler.js';
 import * as api from './api.js';
+import { DashboardUpdateError } from '../../utils/dashboard/saveError.js';
 import * as createModule from './create.js';
 import * as viewModule from './view.js';
 import * as truncationWarning from './truncationWarning.js';
@@ -223,6 +224,35 @@ describe('Character Dashboard', () => {
       await handleModalSubmit(mockInteraction, mockConfig);
 
       expect(mockInteraction.deferUpdate).toHaveBeenCalled();
+    });
+
+    it('surfaces the real gateway error message when the section update fails', async () => {
+      vi.mocked(dashboardUtils.parseDashboardCustomId).mockReturnValue({
+        entityType: 'character',
+        action: 'modal',
+        entityId: 'test-char',
+        sectionId: 'identity',
+      });
+
+      const mockInteraction = createMockModalInteraction('character::modal::test-char::identity');
+      mockInteraction.deferUpdate = vi.fn();
+      mockInteraction.followUp = vi.fn();
+
+      // A 400 validation error is surfaced as the real gateway message, not
+      // masked behind a generic retry prompt.
+      vi.mocked(api.updateCharacter).mockRejectedValue(
+        new DashboardUpdateError(
+          'Failed to update character: 400 - avatarData: Invalid input: expected string, received null',
+          400
+        )
+      );
+
+      await handleModalSubmit(mockInteraction, mockConfig);
+
+      expect(mockInteraction.followUp).toHaveBeenCalledWith({
+        content: '❌ avatarData: Invalid input: expected string, received null',
+        flags: MessageFlags.Ephemeral,
+      });
     });
 
     it('should reply with error for unknown modal', async () => {

--- a/services/bot-client/src/commands/character/dashboard.ts
+++ b/services/bot-client/src/commands/character/dashboard.ts
@@ -26,6 +26,7 @@ import {
   handleSharedBackButton,
 } from '../../utils/dashboard/index.js';
 import { showModalWithTimeoutCatch } from '../../utils/dashboard/showModalWithTimeoutCatch.js';
+import { buildDashboardSaveErrorContent } from '../../utils/dashboard/saveError.js';
 import { CharacterCustomIds } from '../../utils/customIds.js';
 import {
   getCharacterDashboardConfig,
@@ -179,9 +180,11 @@ async function handleSectionModalSubmit(
     logger.info({ slug: entityId, sectionId, isAdmin }, 'Character section updated');
   } catch (error) {
     logger.error({ err: error, entityId, sectionId }, 'Failed to update character section');
-    // Notify user of failure via followUp (since we deferred update)
+    // Notify user of failure via followUp (since we deferred update). Surface the
+    // real gateway message (or the honest "still applying" notice on a status-0
+    // abort) instead of a generic retry prompt that masks 400 validation errors.
     await interaction.followUp({
-      content: '❌ Failed to update character. Please try again.',
+      content: buildDashboardSaveErrorContent(error, 'character'),
       flags: MessageFlags.Ephemeral,
     });
   }

--- a/services/bot-client/src/commands/persona/api.test.ts
+++ b/services/bot-client/src/commands/persona/api.test.ts
@@ -170,23 +170,46 @@ describe('updatePersona', () => {
     expect(result?.name).toBe('Updated Name');
   });
 
-  it('should return null on failure', async () => {
+  it('throws DashboardUpdateError carrying the gateway status on failure', async () => {
     stub.updatePersona.mockResolvedValue(makeErr(500, 'Update failed'));
 
-    const result = await updatePersona(
-      TEST_PERSONA_ID,
-      {
-        name: 'Test',
-        content: undefined,
-        preferredName: undefined,
-        description: undefined,
-        pronouns: undefined,
-      },
-      asUserClient(stub),
-      TEST_USER_ID
-    );
+    await expect(
+      updatePersona(
+        TEST_PERSONA_ID,
+        {
+          name: 'Test',
+          content: undefined,
+          preferredName: undefined,
+          description: undefined,
+          pronouns: undefined,
+        },
+        asUserClient(stub),
+        TEST_USER_ID
+      )
+    ).rejects.toMatchObject({
+      name: 'DashboardUpdateError',
+      status: 500,
+      message: 'Failed to update persona: 500 - Update failed',
+    });
+  });
 
-    expect(result).toBeNull();
+  it('throws with status 0 on a client-side abort', async () => {
+    stub.updatePersona.mockResolvedValue(makeErr(0, 'Request timeout'));
+
+    await expect(
+      updatePersona(
+        TEST_PERSONA_ID,
+        {
+          name: 'Test',
+          content: undefined,
+          preferredName: undefined,
+          description: undefined,
+          pronouns: undefined,
+        },
+        asUserClient(stub),
+        TEST_USER_ID
+      )
+    ).rejects.toMatchObject({ name: 'DashboardUpdateError', status: 0 });
   });
 });
 

--- a/services/bot-client/src/commands/persona/api.ts
+++ b/services/bot-client/src/commands/persona/api.ts
@@ -7,6 +7,7 @@
 
 import { createLogger, type PersonaUpdateInput } from '@tzurot/common-types';
 import { type UserClient } from '@tzurot/clients';
+import { DashboardUpdateError } from '../../utils/dashboard/saveError.js';
 import type { PersonaDetails, PersonaSummary } from './types.js';
 
 const logger = createLogger('persona-api');
@@ -59,12 +60,18 @@ export async function updatePersona(
   data: PersonaUpdateInput,
   userClient: UserClient,
   userId: string
-): Promise<PersonaDetails | null> {
+): Promise<PersonaDetails> {
   const result = await userClient.updatePersona(personaId, data);
 
   if (!result.ok) {
     logger.warn({ userId, personaId, error: result.error }, 'Failed to update persona');
-    return null;
+    // Throw (rather than return null) so the dashboard can surface the real
+    // gateway message and distinguish a status-0 client abort from an HTTP
+    // rejection — the same contract as updateCharacter / updatePreset.
+    throw new DashboardUpdateError(
+      `Failed to update persona: ${result.status} - ${result.error ?? 'Unknown'}`,
+      result.status
+    );
   }
 
   return result.data.persona;

--- a/services/bot-client/src/commands/persona/dashboard.test.ts
+++ b/services/bot-client/src/commands/persona/dashboard.test.ts
@@ -367,6 +367,27 @@ describe('handleModalSubmit', () => {
     expect(stub.updatePersona).toHaveBeenCalledWith(TEST_PERSONA_ID, expect.any(Object));
   });
 
+  it('surfaces the real gateway error message when the update fails', async () => {
+    mockSessionGet.mockResolvedValue({
+      data: { name: 'Test Persona', preferredName: 'Tester' },
+    });
+    mockExtractModalValues.mockReturnValue({ name: 'Updated Name' });
+    // updatePersona throws DashboardUpdateError; the dashboard surfaces the
+    // extracted gateway message instead of a generic "Please try again".
+    stub.updatePersona.mockResolvedValue(makeErr(400, 'pronouns: too long'));
+
+    await handleModalSubmit(
+      createMockModalInteraction(`persona::modal::${TEST_PERSONA_ID}::identity`, {
+        name: 'Updated Name',
+      })
+    );
+
+    expect(mockFollowUp).toHaveBeenCalledWith({
+      content: '❌ pronouns: too long',
+      flags: MessageFlags.Ephemeral,
+    });
+  });
+
   it('should handle unknown modal submissions', async () => {
     await handleModalSubmit(createMockModalInteraction('persona::unknown::action'));
 

--- a/services/bot-client/src/commands/persona/dashboard.ts
+++ b/services/bot-client/src/commands/persona/dashboard.ts
@@ -40,6 +40,7 @@ import { fetchPersona, updatePersona, deletePersona, isDefaultPersona } from './
 import { PersonaCustomIds } from '../../utils/customIds.js';
 import { buildSectionModal } from '../../utils/dashboard/ModalFactory.js';
 import { showModalWithTimeoutCatch } from '../../utils/dashboard/showModalWithTimeoutCatch.js';
+import { buildDashboardSaveErrorContent } from '../../utils/dashboard/saveError.js';
 import { detectOverLengthFields } from '../../utils/dashboard/truncationGate/index.js';
 import { resolvePersonaSectionContext } from './sectionContext.js';
 import {
@@ -120,20 +121,14 @@ async function handleSectionModalSubmit(
     const updatePayload = unflattenPersonaData(extracted.merged);
 
     const { userClient } = clientsFor(interaction);
+    // updatePersona throws DashboardUpdateError on failure (caught below);
+    // a resolved value is always a valid persona.
     const updatedPersona = await updatePersona(
       entityId,
       updatePayload,
       userClient,
       interaction.user.id
     );
-
-    if (!updatedPersona) {
-      await interaction.followUp({
-        content: '❌ Failed to save persona. Please try again.',
-        flags: MessageFlags.Ephemeral,
-      });
-      return;
-    }
 
     // Flatten the response for dashboard display
     const flattenedData = flattenPersonaData(updatedPersona);
@@ -165,9 +160,11 @@ async function handleSectionModalSubmit(
     logger.info({ personaId: entityId, sectionId }, 'Persona section updated');
   } catch (error) {
     logger.error({ err: error, entityId, sectionId }, 'Failed to update persona section');
-    // Notify user of failure via followUp (since we deferred update)
+    // Notify user of failure via followUp (since we deferred update). Surface the
+    // real gateway message (or the honest "still applying" notice on a status-0
+    // abort) instead of a generic retry prompt that masks 400 validation errors.
     await interaction.followUp({
-      content: '❌ Failed to update persona. Please try again.',
+      content: buildDashboardSaveErrorContent(error, 'persona'),
       flags: MessageFlags.Ephemeral,
     });
   }

--- a/services/bot-client/src/commands/preset/api.test.ts
+++ b/services/bot-client/src/commands/preset/api.test.ts
@@ -8,9 +8,6 @@ import {
   fetchGlobalPreset,
   updatePreset,
   updateGlobalPreset,
-  extractApiErrorMessage,
-  buildSaveErrorContent,
-  PresetUpdateError,
   createPreset,
 } from './api.js';
 import { GatewayApiError } from '@tzurot/clients';
@@ -171,11 +168,11 @@ describe('updatePreset', () => {
     );
   });
 
-  it('throws PresetUpdateError carrying the gateway status (0 on client-side timeout)', async () => {
+  it('throws DashboardUpdateError carrying the gateway status (0 on client-side timeout)', async () => {
     stub.updateUserLlmConfig.mockResolvedValue(makeErr(0, 'Request timeout'));
 
     await expect(updatePreset('preset-123', {}, asUserClient(stub))).rejects.toMatchObject({
-      name: 'PresetUpdateError',
+      name: 'DashboardUpdateError',
       status: 0,
     });
   });
@@ -221,69 +218,13 @@ describe('updateGlobalPreset', () => {
     );
   });
 
-  it('throws PresetUpdateError carrying the gateway status (0 on client-side timeout)', async () => {
+  it('throws DashboardUpdateError carrying the gateway status (0 on client-side timeout)', async () => {
     stub.updateGlobalLlmConfig.mockResolvedValue(makeErr(0, 'Request timeout'));
 
     await expect(updateGlobalPreset('preset-123', {}, asOwnerClient(stub))).rejects.toMatchObject({
-      name: 'PresetUpdateError',
+      name: 'DashboardUpdateError',
       status: 0,
     });
-  });
-});
-
-describe('buildSaveErrorContent', () => {
-  it('shows the honest "may still be applying" notice on a status-0 timeout', () => {
-    const error = new PresetUpdateError('Failed to update preset: 0 - Request timeout', 0);
-    const content = buildSaveErrorContent(error);
-    expect(content).toContain('may still be applying');
-    expect(content).toContain('Refresh');
-    expect(content).not.toContain('❌');
-  });
-
-  it('shows the extracted gateway message on a genuine HTTP rejection', () => {
-    const error = new PresetUpdateError('Failed to update preset: 400 - Context too large', 400);
-    expect(buildSaveErrorContent(error)).toBe('❌ Context too large');
-  });
-
-  it('falls back to a generic failure for a non-PresetUpdateError', () => {
-    expect(buildSaveErrorContent(new Error('boom'))).toBe(
-      '❌ Failed to update preset. Please try again.'
-    );
-  });
-});
-
-describe('extractApiErrorMessage', () => {
-  it('should extract API message from structured error', () => {
-    const error = new Error('Failed to update preset: 400 - Context window too large');
-    expect(extractApiErrorMessage(error)).toBe('Context window too large');
-  });
-
-  it('should return null for non-Error values', () => {
-    expect(extractApiErrorMessage('string error')).toBeNull();
-    expect(extractApiErrorMessage(null)).toBeNull();
-  });
-
-  it('should return null for errors without API format', () => {
-    expect(extractApiErrorMessage(new Error('Network error'))).toBeNull();
-  });
-
-  it('should return null for non-API errors containing dashes', () => {
-    expect(extractApiErrorMessage(new Error('Request timed out - after 30s'))).toBeNull();
-    expect(extractApiErrorMessage(new Error('TLS handshake failed - connection reset'))).toBeNull();
-  });
-
-  it('should preserve dashes in the API message portion', () => {
-    const error = new Error('Failed to update preset: 400 - limit is 4096 - not 131072');
-    expect(extractApiErrorMessage(error)).toBe('limit is 4096 - not 131072');
-  });
-
-  it('should truncate very long API messages', () => {
-    const longMessage = 'A'.repeat(2000);
-    const error = new Error(`Failed to update preset: 400 - ${longMessage}`);
-    const result = extractApiErrorMessage(error);
-    expect(result).not.toBeNull();
-    expect(result!.length).toBeLessThanOrEqual(1801); // 1800 + ellipsis
-    expect(result!.endsWith('…')).toBe(true);
   });
 });
 

--- a/services/bot-client/src/commands/preset/api.ts
+++ b/services/bot-client/src/commands/preset/api.ts
@@ -8,66 +8,8 @@
 
 import { type LlmConfigDetail, type LlmConfigUpdateInput } from '@tzurot/common-types';
 import { GatewayApiError, type OwnerClient, type UserClient } from '@tzurot/clients';
+import { DashboardUpdateError } from '../../utils/dashboard/saveError.js';
 import type { PresetData } from './types.js';
-
-/** Conservative limit — leaves room for the "❌ " prefix and Discord's 2000-char cap */
-const MAX_DISCORD_CONTENT = 1800;
-
-/**
- * Extract user-facing error message from API errors.
- *
- * API errors follow the format "Failed to X preset: HTTP_STATUS - api_message".
- * This extracts the api_message portion for display. Returns null for network
- * errors or unexpected formats, signaling callers to use a generic fallback.
- * Truncates to Discord's content limit to avoid silent send failures.
- */
-export function extractApiErrorMessage(error: unknown): string | null {
-  if (!(error instanceof Error)) {
-    return null;
-  }
-  const match = /: \d{3} - (.+)$/.exec(error.message);
-  if (match?.[1] === undefined) {
-    return null;
-  }
-  const msg = match[1];
-  return msg.length > MAX_DISCORD_CONTENT ? msg.slice(0, MAX_DISCORD_CONTENT) + '…' : msg;
-}
-
-// Notice shown when a preset write aborts client-side (transport status 0).
-// The gateway llm-config update path can exceed the 20s WRITE budget under
-// load and abort even though the write commits server-side a moment later — so
-// claiming outright failure (and nudging "try again", which risks a duplicate
-// write) is wrong. Tell the user the truth: it may still be applying.
-const SAVE_TIMEOUT_NOTICE =
-  '⏳ This is taking longer than usual — your change may still be applying. ' +
-  'Give it a moment, then tap **🔄 Refresh** to confirm before saving again.';
-
-/**
- * Error thrown by preset writes, carrying the gateway response status so the
- * caller can tell a genuine rejection (HTTP 4xx/5xx) apart from a client-side
- * network/timeout abort (status 0), whose server-side outcome is uncertain.
- */
-export class PresetUpdateError extends Error {
-  constructor(
-    message: string,
-    readonly status: number
-  ) {
-    super(message);
-    this.name = 'PresetUpdateError';
-  }
-}
-
-/**
- * Build the user-facing content for a failed preset save. A status-0 abort
- * (network/timeout) gets the honest "may still be applying" notice; everything
- * else falls through to the extracted API message or a generic failure.
- */
-export function buildSaveErrorContent(error: unknown): string {
-  if (error instanceof PresetUpdateError && error.status === 0) {
-    return SAVE_TIMEOUT_NOTICE;
-  }
-  return `❌ ${extractApiErrorMessage(error) ?? 'Failed to update preset. Please try again.'}`;
-}
 
 /**
  * Adapt a fetched LlmConfig detail payload to the dashboard's PresetData shape.
@@ -135,7 +77,7 @@ export async function updatePreset(
   const result = await userClient.updateUserLlmConfig(presetId, data);
 
   if (!result.ok) {
-    throw new PresetUpdateError(
+    throw new DashboardUpdateError(
       `Failed to update preset: ${result.status} - ${result.error ?? 'Unknown'}`,
       result.status
     );
@@ -157,7 +99,7 @@ export async function updateGlobalPreset(
   const result = await ownerClient.updateGlobalLlmConfig(presetId, data);
 
   if (!result.ok) {
-    throw new PresetUpdateError(
+    throw new DashboardUpdateError(
       `Failed to update global preset: ${result.status} - ${result.error ?? 'Unknown'}`,
       result.status
     );

--- a/services/bot-client/src/commands/preset/create.ts
+++ b/services/bot-client/src/commands/preset/create.ts
@@ -32,7 +32,8 @@ import {
   buildPresetDashboardOptions,
 } from './config.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
-import { createPreset, extractApiErrorMessage } from './api.js';
+import { createPreset } from './api.js';
+import { extractApiErrorMessage } from '../../utils/dashboard/saveError.js';
 
 const logger = createLogger('preset-create');
 

--- a/services/bot-client/src/commands/preset/dashboard.test.ts
+++ b/services/bot-client/src/commands/preset/dashboard.test.ts
@@ -13,7 +13,7 @@ import {
 import { handleDashboardClose } from '../../utils/dashboard/closeHandler.js';
 import { DASHBOARD_MESSAGES, formatSessionExpiredMessage } from '../../utils/dashboard/messages.js';
 import type { PresetData } from './config.js';
-import { PresetUpdateError } from './api.js';
+import { DashboardUpdateError } from '../../utils/dashboard/saveError.js';
 import { GatewayApiError } from '@tzurot/clients';
 
 // Sentinel passed by the migrated dashboard handler — `clientsFor(interaction)`
@@ -491,11 +491,11 @@ describe('handleModalSubmit', () => {
     mockSessionManagerGet.mockResolvedValue({
       data: { id: 'preset-123', name: 'Test', isGlobal: false, isOwned: true },
     });
-    // A client-side timeout surfaces as a PresetUpdateError with status 0 — the
+    // A client-side timeout surfaces as a DashboardUpdateError with status 0 — the
     // write may have committed server-side, so the user gets the honest notice
     // rather than a hard "Failed, try again".
     mockUpdatePreset.mockRejectedValue(
-      new PresetUpdateError('Failed to update preset: 0 - Request timeout', 0)
+      new DashboardUpdateError('Failed to update preset: 0 - Request timeout', 0)
     );
 
     await handleModalSubmit(createMockModalInteraction('preset::modal::preset-123::identity'));

--- a/services/bot-client/src/commands/preset/dashboard.ts
+++ b/services/bot-client/src/commands/preset/dashboard.ts
@@ -34,7 +34,8 @@ import {
   buildPresetDashboardOptions,
 } from './config.js';
 import type { PresetData } from './types.js';
-import { fetchPreset, updatePreset, updateGlobalPreset, buildSaveErrorContent } from './api.js';
+import { fetchPreset, updatePreset, updateGlobalPreset } from './api.js';
+import { buildDashboardSaveErrorContent } from '../../utils/dashboard/saveError.js';
 import { handleSeedModalSubmit } from './create.js';
 import { PresetCustomIds } from '../../utils/customIds.js';
 import { presetConfigValidator } from './presetValidation.js';
@@ -198,10 +199,11 @@ async function handleSectionModalSubmit(
     logger.error({ err: error, entityId, sectionId }, 'Failed to update preset section');
 
     // Use followUp (not editReply/reply) because the interaction was already deferred via deferUpdate.
-    // buildSaveErrorContent shows the honest "may still be applying" notice on a
-    // client-side timeout (status 0) instead of a misleading hard failure.
+    // buildDashboardSaveErrorContent shows the honest "may still be applying" notice on a
+    // client-side timeout (status 0), and the real gateway message on a genuine
+    // HTTP rejection, instead of a misleading hard failure.
     await interaction.followUp({
-      content: buildSaveErrorContent(error),
+      content: buildDashboardSaveErrorContent(error, 'preset'),
       flags: MessageFlags.Ephemeral,
     });
   }

--- a/services/bot-client/src/commands/preset/dashboardButtons.ts
+++ b/services/bot-client/src/commands/preset/dashboardButtons.ts
@@ -31,7 +31,8 @@ import {
   unflattenPresetData,
   buildPresetDashboardOptions,
 } from './config.js';
-import { fetchPreset, updatePreset, fetchGlobalPreset, extractApiErrorMessage } from './api.js';
+import { fetchPreset, updatePreset, fetchGlobalPreset } from './api.js';
+import { extractApiErrorMessage } from '../../utils/dashboard/saveError.js';
 import { createClonedPreset } from './cloneName.js';
 
 // Re-export for backward compatibility

--- a/services/bot-client/src/utils/dashboard/saveError.test.ts
+++ b/services/bot-client/src/utils/dashboard/saveError.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for shared dashboard save-error handling.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  DashboardUpdateError,
+  extractApiErrorMessage,
+  isSaveTimeout,
+  buildDashboardSaveErrorContent,
+  SAVE_TIMEOUT_NOTICE,
+} from './saveError.js';
+
+describe('DashboardUpdateError', () => {
+  it('carries the gateway status and is an Error subclass', () => {
+    const err = new DashboardUpdateError('Failed to update preset: 0 - Request timeout', 0);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('DashboardUpdateError');
+    expect(err.status).toBe(0);
+    expect(err.message).toContain('Request timeout');
+  });
+});
+
+describe('isSaveTimeout', () => {
+  it('is true only for a DashboardUpdateError with status 0', () => {
+    expect(isSaveTimeout(new DashboardUpdateError('boom', 0))).toBe(true);
+  });
+
+  it('is false for a DashboardUpdateError with a real HTTP status', () => {
+    expect(isSaveTimeout(new DashboardUpdateError('boom: 400 - bad', 400))).toBe(false);
+  });
+
+  it('is false for a plain Error or non-error value', () => {
+    expect(isSaveTimeout(new Error('boom'))).toBe(false);
+    expect(isSaveTimeout('string error')).toBe(false);
+    expect(isSaveTimeout(null)).toBe(false);
+  });
+});
+
+describe('extractApiErrorMessage', () => {
+  it('extracts the API message from a structured error', () => {
+    const error = new Error('Failed to update preset: 400 - Context window too large');
+    expect(extractApiErrorMessage(error)).toBe('Context window too large');
+  });
+
+  it('returns null for non-Error values', () => {
+    expect(extractApiErrorMessage('string error')).toBeNull();
+    expect(extractApiErrorMessage(null)).toBeNull();
+  });
+
+  it('returns null for errors without the API format', () => {
+    expect(extractApiErrorMessage(new Error('Network error'))).toBeNull();
+  });
+
+  it('returns null for non-API errors that merely contain dashes', () => {
+    expect(extractApiErrorMessage(new Error('Request timed out - after 30s'))).toBeNull();
+    expect(extractApiErrorMessage(new Error('TLS handshake failed - connection reset'))).toBeNull();
+  });
+
+  it('preserves dashes inside the API message portion', () => {
+    const error = new Error('Failed to update preset: 400 - limit is 4096 - not 131072');
+    expect(extractApiErrorMessage(error)).toBe('limit is 4096 - not 131072');
+  });
+
+  it('does not match a single-digit status (status-0 aborts fall through)', () => {
+    expect(extractApiErrorMessage(new Error('Failed to update character: 0 - timeout'))).toBeNull();
+  });
+
+  it('truncates very long API messages', () => {
+    const longMessage = 'A'.repeat(2000);
+    const error = new Error(`Failed to update preset: 400 - ${longMessage}`);
+    const result = extractApiErrorMessage(error);
+    expect(result).not.toBeNull();
+    expect(result!.length).toBeLessThanOrEqual(1801); // 1800 + ellipsis
+    expect(result!.endsWith('…')).toBe(true);
+  });
+});
+
+describe('buildDashboardSaveErrorContent', () => {
+  it('shows the honest "may still be applying" notice on a status-0 timeout', () => {
+    const error = new DashboardUpdateError('Failed to update character: 0 - Request timeout', 0);
+    const content = buildDashboardSaveErrorContent(error, 'character');
+    expect(content).toBe(SAVE_TIMEOUT_NOTICE);
+    expect(content).toContain('may still be applying');
+    expect(content).not.toContain('❌');
+  });
+
+  it('surfaces the real gateway message on a genuine HTTP rejection', () => {
+    const error = new DashboardUpdateError(
+      'Failed to update character: 400 - avatarData: Invalid input: expected string, received null',
+      400
+    );
+    expect(buildDashboardSaveErrorContent(error, 'character')).toBe(
+      '❌ avatarData: Invalid input: expected string, received null'
+    );
+  });
+
+  it('falls back to a per-resource generic failure for an unstructured error', () => {
+    expect(buildDashboardSaveErrorContent(new Error('boom'), 'persona')).toBe(
+      '❌ Failed to update persona. Please try again.'
+    );
+    expect(buildDashboardSaveErrorContent(new Error('boom'), 'preset')).toBe(
+      '❌ Failed to update preset. Please try again.'
+    );
+  });
+});

--- a/services/bot-client/src/utils/dashboard/saveError.ts
+++ b/services/bot-client/src/utils/dashboard/saveError.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared dashboard save-error handling.
+ *
+ * Every fetch-edit-PUT dashboard (preset, character, persona) shares two failure
+ * shapes that need honest user-facing messaging:
+ *
+ *  - **Client-side abort (transport status 0)** — the gateway exceeded its write
+ *    budget under load and the request aborted, even though the write frequently
+ *    commits server-side a moment later. Claiming outright failure (and nudging
+ *    "try again", which risks a duplicate write) is wrong; tell the user it may
+ *    still be applying.
+ *  - **Genuine HTTP rejection (4xx/5xx)** — surface the gateway's actual message
+ *    so the reason is visible instead of masked behind a generic "try again".
+ *    The masked-400 failure mode is exactly what hid the `avatarData` null
+ *    round-trip bug behind "Failed to update character. Please try again."
+ */
+
+/** Conservative limit — leaves room for the "❌ " prefix and Discord's 2000-char cap */
+const MAX_DISCORD_CONTENT = 1800;
+
+/**
+ * Notice shown when a dashboard write aborts client-side (transport status 0).
+ * Reused across dashboards so the honest "may still be applying" wording stays
+ * consistent. The **🔄 Refresh** label must stay in sync with the dashboards'
+ * refresh control (`buildBrowseButtons` / the dashboard refresh handlers); if
+ * that button's emoji/label changes, update this notice too.
+ */
+export const SAVE_TIMEOUT_NOTICE =
+  '⏳ This is taking longer than usual — your change may still be applying. ' +
+  'Give it a moment, then tap **🔄 Refresh** to confirm before saving again.';
+
+/**
+ * Error thrown by dashboard writes, carrying the gateway response status so the
+ * caller can tell a genuine rejection (HTTP 4xx/5xx) apart from a client-side
+ * network/timeout abort (status 0), whose server-side outcome is uncertain.
+ */
+export class DashboardUpdateError extends Error {
+  constructor(
+    message: string,
+    readonly status: number
+  ) {
+    super(message);
+    this.name = 'DashboardUpdateError';
+  }
+}
+
+/**
+ * Extract the user-facing message from a gateway error.
+ *
+ * Gateway write errors follow the format "Failed to X <resource>: HTTP_STATUS -
+ * api_message". This extracts the api_message portion for display. Returns null
+ * for network errors (status 0 has a single-digit status that doesn't match the
+ * 3-digit pattern) or unexpected formats, signaling callers to use a generic
+ * fallback. Truncates to Discord's content limit to avoid silent send failures.
+ */
+export function extractApiErrorMessage(error: unknown): string | null {
+  if (!(error instanceof Error)) {
+    return null;
+  }
+  const match = /: \d{3} - (.+)$/.exec(error.message);
+  if (match?.[1] === undefined) {
+    return null;
+  }
+  const msg = match[1];
+  return msg.length > MAX_DISCORD_CONTENT ? msg.slice(0, MAX_DISCORD_CONTENT) + '…' : msg;
+}
+
+/**
+ * True when the error is a dashboard write that aborted client-side (status 0):
+ * a network/timeout abort whose server-side outcome is uncertain, as opposed to
+ * a definitive HTTP rejection.
+ */
+export function isSaveTimeout(error: unknown): boolean {
+  return error instanceof DashboardUpdateError && error.status === 0;
+}
+
+/**
+ * Build the user-facing content for a failed dashboard save:
+ *  - status-0 abort (network/timeout) → the honest "may still be applying" notice
+ *  - genuine HTTP rejection → the extracted gateway message
+ *  - anything else → a generic per-resource failure
+ *
+ * @param error    the caught error
+ * @param resource the resource noun for the generic fallback, e.g. 'character'
+ */
+export function buildDashboardSaveErrorContent(error: unknown, resource: string): string {
+  if (isSaveTimeout(error)) {
+    return SAVE_TIMEOUT_NOTICE;
+  }
+  return `❌ ${extractApiErrorMessage(error) ?? `Failed to update ${resource}. Please try again.`}`;
+}

--- a/services/bot-client/src/utils/dashboard/updateSchemaRoundTrip.test.ts
+++ b/services/bot-client/src/utils/dashboard/updateSchemaRoundTrip.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Round-trip contract guard for fetch-edit-PUT dashboards.
+ *
+ * The bug class this guards against: a dashboard fetches an object, lets the user
+ * edit one section, then PUTs back fields it didn't change — including nullable
+ * fields fetched as `null`. If the gateway's update schema declares such a field
+ * `z.string().optional()` (which accepts `undefined` but REJECTS `null`), the
+ * round-trip 400s. The confirmed instance was personality `avatarData`: the
+ * dashboard force-nulls it (it fetches only `hasAvatar`, never the base64), so
+ * every no-avatar character's section save was rejected with "expected string,
+ * received null" — masked behind a generic "Failed to update character."
+ *
+ * **Every fetch-edit-PUT dashboard MUST register in `DASHBOARDS` below.** Each
+ * entry runs a realistic null-bearing fetched object through the dashboard's REAL
+ * payload builder and asserts the result validates against the gateway's update
+ * schema. A dashboard whose schema rejects a round-tripped null fails here —
+ * which is the point: it catches the avatarData class for current and future
+ * dashboards before it ships.
+ *
+ * Why a builder round-trip and not a schema-pairing check: the offending null is
+ * injected by the bot-client payload builder (`toCharacterData` force-nulls
+ * `avatarData`), not present in the gateway response schema. A "every nullable
+ * response field is nullable in the update schema" check would not see it. The
+ * guard must exercise the builder.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  PersonalityUpdateSchema,
+  PersonaUpdateSchema,
+  LlmConfigUpdateSchema,
+} from '@tzurot/common-types';
+import { toCharacterData } from '../../commands/character/api.js';
+import { flattenPersonaData, unflattenPersonaData } from '../../commands/persona/config.js';
+import { flattenPresetData, unflattenPresetData } from '../../commands/preset/config.js';
+import type { PersonaDetails } from '../../commands/persona/types.js';
+import type { PresetData } from '../../commands/preset/types.js';
+
+/** Structural shape of a Zod schema's safeParse — avoids a direct `zod` dep here. */
+interface ParseableSchema {
+  safeParse(data: unknown): { success: boolean; error?: { issues: unknown[] } };
+}
+
+interface DashboardRoundTrip {
+  /** Dashboard name (used for the test label). */
+  name: string;
+  /** Build the update payload the way the dashboard does, from a null-bearing fetched object. */
+  buildPayload: () => unknown;
+  /** The gateway update schema the payload is PUT against. */
+  updateSchema: ParseableSchema;
+}
+
+// A realistic established character: required text filled in, every optional and
+// media field null — the exact shape that 400'd on `avatarData` before the fix.
+const characterDetailWithNulls = {
+  id: 'pers-1',
+  name: 'Helen',
+  slug: 'helen',
+  displayName: null,
+  characterInfo: 'A detective who notices everything.',
+  personalityTraits: 'Sharp, dry, observant.',
+  personalityTone: null,
+  personalityAge: null,
+  personalityAppearance: null,
+  personalityLikes: null,
+  personalityDislikes: null,
+  conversationalGoals: null,
+  conversationalExamples: null,
+  errorMessage: null,
+  isPublic: false,
+  voiceEnabled: false,
+  // The gateway response carries `hasAvatar`, not the base64 — `toCharacterData`
+  // force-nulls `avatarData` regardless, so `false` here mirrors a real no-avatar
+  // detail without changing the round-tripped null.
+  hasAvatar: false,
+};
+
+const personaDetailWithNulls: PersonaDetails = {
+  id: 'persona-1',
+  name: 'Vee',
+  content: 'A traveler with a long memory.',
+  preferredName: null,
+  description: null,
+  pronouns: null,
+  isDefault: false,
+};
+
+const presetDetailWithNulls: PresetData = {
+  id: 'preset-1',
+  name: 'Test Preset',
+  description: null,
+  provider: 'openrouter',
+  model: 'anthropic/claude-sonnet-4',
+  visionModel: null,
+  isGlobal: false,
+  isOwned: true,
+  permissions: { canEdit: true, canDelete: true },
+  contextWindowTokens: 8192,
+  params: {},
+};
+
+const DASHBOARDS: DashboardRoundTrip[] = [
+  {
+    name: 'character',
+    buildPayload: () => toCharacterData(characterDetailWithNulls),
+    updateSchema: PersonalityUpdateSchema,
+  },
+  {
+    name: 'persona',
+    buildPayload: () => unflattenPersonaData(flattenPersonaData(personaDetailWithNulls)),
+    updateSchema: PersonaUpdateSchema,
+  },
+  {
+    name: 'preset',
+    buildPayload: () => unflattenPresetData(flattenPresetData(presetDetailWithNulls)),
+    updateSchema: LlmConfigUpdateSchema,
+  },
+];
+
+describe('dashboard update round-trip contract', () => {
+  it.each(DASHBOARDS)(
+    '$name: a null-bearing fetched object round-trips into a valid update payload',
+    ({ buildPayload, updateSchema }) => {
+      const payload = buildPayload();
+      const result = updateSchema.safeParse(payload);
+      // Surface the Zod issues so a regression points straight at the offending
+      // field (e.g. "avatarData: expected string, received null").
+      expect(result.success, JSON.stringify(result.error?.issues, null, 2)).toBe(true);
+    }
+  );
+});


### PR DESCRIPTION
## The bug (confirmed in dev logs)

A character with **no avatar** has `avatarData = null`. The edit dashboard fetches only `hasAvatar` (never the base64), so `toCharacterData` force-nulls `avatarData` and round-trips it on **every** section save. The gateway create/update schema declared `avatarData: z.string().optional()` — which accepts `undefined` but **rejects `null`** — so editing any no-avatar character 400'd with:

```
avatarData: Invalid input: expected string, received null
```

…masked behind a generic **"❌ Failed to update character. Please try again."** Dev logs confirmed it's a deterministic 400 (25ms, ownership SELECT then **no UPDATE query**) — **not** a timeout, contrary to the initial hypothesis.

## The fix (two parts that must ship together)

- **Schema** (`personality.ts`): `avatarData` / `voiceReferenceData` → `z.string().nullable().optional()` on create **and** update. `null` = no media.
- **Processors** (`avatarProcessor` / `voiceReferenceProcessor`): guard `null` → "no change". Without this the schema loosening would turn the 400 into a **500** (`null.length` crash). `null` never wipes an existing avatar — critical, since the dashboard *always* sends `null` for a no-avatar character.

## Surface the real error (was masking the 400)

- Hoisted preset's `PresetUpdateError` / `extractApiErrorMessage` / timeout-notice into shared **`utils/dashboard/saveError.ts`** (`DashboardUpdateError`, `buildDashboardSaveErrorContent`, `isSaveTimeout`); preset now consumes it (DRY).
- `character` / `persona` dashboards throw the status-carrying error and surface the **real gateway message** (or the honest "still applying" notice on a status-0 abort) instead of a generic retry prompt. `updatePersona` throws instead of returning `null`.

## Generalized guard (the part that catches the *class*)

New **`updateSchemaRoundTrip.test.ts`** registry runs a null-bearing fetched object through each fetch-edit-PUT dashboard's **real payload builder** and asserts it validates against the gateway update schema:

- `character` goes **RED → GREEN** across this fix (proven locally).
- `persona` / `preset` **pin** their by-construction safety so a future refactor can't silently reintroduce the class.

A schema-pairing check would *miss* `avatarData` (the null is injected by the bot-client builder, not present in the response schema), so the guard exercises the builder. **Every new fetch-edit-PUT dashboard must register here.**

## Audit result

`avatarData` is the **only** confirmed instance. A three-domain audit found persona/preset defend via the `nullableString` helper + flatten/unflatten laundering; config-overrides normalize `null → undefined` before Zod; tts-config has no edit dashboard. Personality media fields were the lone gap.

## Test plan

- `common-types` personality schema: +`avatarData: null` accepted (create + update) — 76 pass
- `api-gateway` processors: +`null` → skip (no crash, no wipe) — 17 pass
- `bot-client` round-trip contract: character RED→GREEN, persona/preset pinned — 3 pass
- `saveError` util + character/persona dashboard error-surfacing tests
- `pnpm quality` green (lint, knip, cpd, depcruise, typecheck, backlog:lint)
- Full vitest suite deferred to CI (Steam Deck OOM constraint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)