### PR TITLE
fix: gate cross-channel history on persona presence, not weigh-in framing

### DIFF
--- a/services/ai-worker/src/services/context/ContextAssembler.test.ts
+++ b/services/ai-worker/src/services/context/ContextAssembler.test.ts
@@ -494,7 +494,10 @@ describe('ContextAssembler.assembleCore', () => {
     expect(deps.dataSource.getCrossChannelHistory).not.toHaveBeenCalled();
   });
 
-  it('skips cross-channel for weigh-in jobs even when enabled', async () => {
+  it('skips cross-channel for a default weigh-in (incognito → null persona) even when enabled', async () => {
+    // A bare weigh-in defaults to incognito, which nulls the persona; cross-channel
+    // is persona-scoped, so it's skipped — because of the null persona, NOT the
+    // weigh-in framing (a personal weigh-in still gets it — see below).
     const deps = makeDeps();
     const assembler = new ContextAssembler(deps);
     const core = await assembler.assembleCore(makeJobContext({ isWeighIn: true }), PERSONALITY, {
@@ -503,6 +506,37 @@ describe('ContextAssembler.assembleCore', () => {
     } as ResolvedConfigOverrides);
     expect(core.crossChannelHistory).toBeUndefined();
     expect(deps.dataSource.getCrossChannelHistory).not.toHaveBeenCalled();
+  });
+
+  it('skips cross-channel for an incognito chat (persona nulled) even when enabled', async () => {
+    // Regression: /character random with a message + incognito:true has
+    // isWeighIn=false (a real chat turn) but incognito nulls the persona.
+    // Cross-channel is persona-scoped, so it must be skipped rather than throwing
+    // "[ContextAssembler] cross-channel enabled with a null persona".
+    const deps = makeDeps();
+    const assembler = new ContextAssembler(deps);
+    const core = await assembler.assembleCore(makeJobContext({ incognito: true }), PERSONALITY, {
+      maxMessages: 30,
+      crossChannelHistoryEnabled: true,
+    } as ResolvedConfigOverrides);
+    expect(core.activePersonaId).toBeNull();
+    expect(core.crossChannelHistory).toBeUndefined();
+    expect(deps.dataSource.getCrossChannelHistory).not.toHaveBeenCalled();
+  });
+
+  it('enables cross-channel for a PERSONAL weigh-in (incognito=false keeps the persona)', async () => {
+    // Cross-channel and the persona are a unit: a personal weigh-in
+    // (isWeighIn=true, incognito=false) keeps its persona, so cross-channel runs.
+    // The weigh-in framing does NOT disable it.
+    const deps = makeDeps();
+    const assembler = new ContextAssembler(deps);
+    const core = await assembler.assembleCore(
+      makeJobContext({ isWeighIn: true, incognito: false }),
+      PERSONALITY,
+      { maxMessages: 30, crossChannelHistoryEnabled: true } as ResolvedConfigOverrides
+    );
+    expect(core.activePersonaId).not.toBeNull();
+    expect(deps.dataSource.getCrossChannelHistory).toHaveBeenCalled();
   });
 
   it('decorates cross-channel groups from the env map, falling back for cache misses', async () => {

--- a/services/ai-worker/src/services/context/ContextAssembler.ts
+++ b/services/ai-worker/src/services/context/ContextAssembler.ts
@@ -224,8 +224,14 @@ export class ContextAssembler {
     // bot-side fetchCrossChannelIfEnabled gate (disabled or weigh-in →
     // undefined, matching the payload's absent field).
     const crossChannelHistory = await this.assembleCrossChannel(jobContext, personality, {
-      enabled:
-        configOverrides?.crossChannelHistoryEnabled === true && jobContext.isWeighIn !== true,
+      // Cross-channel history and the persona are a unit: it's persona-scoped, so
+      // it's enabled for ANY personal summon (persona present) — including a
+      // personal weigh-in (incognito:false) — and disabled only when there's no
+      // persona to scope it to. `incognito` nulls the persona (whether it's a
+      // chime-in, a message-less random, or /character random with a message +
+      // incognito:true), so `activePersonaId !== null` is the single gate.
+      // Framing (`isWeighIn`) is deliberately NOT checked here.
+      enabled: configOverrides?.crossChannelHistoryEnabled === true && activePersonaId !== null,
       personaId: activePersonaId,
       excludeChannelId: channelId,
       limit,
@@ -353,7 +359,7 @@ export class ContextAssembler {
     personality: LoadedPersonality,
     opts: {
       enabled: boolean;
-      /** Null only in weigh-in mode, where `enabled` is always false. */
+      /** Null in weigh-in OR incognito mode; `enabled` requires a non-null persona. */
       personaId: string | null;
       /** The narrowed current-channel id from assembleCore's guard. */
       excludeChannelId: string;
@@ -365,10 +371,9 @@ export class ContextAssembler {
     if (!opts.enabled) {
       return undefined;
     }
-    // Invariant: cross-channel is disabled for weigh-in (the `enabled` flag
-    // gates on isWeighIn), so a non-null persona always reaches here. Fail loud
-    // if a future change decouples the two, rather than silently querying with
-    // a bad id.
+    // Invariant: the `enabled` gate is `activePersonaId !== null`, so a non-null
+    // persona always reaches here. Fail loud if a future change decouples
+    // cross-channel from the persona, rather than silently querying with a bad id.
     if (opts.personaId === null) {
       throw new Error('[ContextAssembler] cross-channel enabled with a null persona');
     }

--- a/services/bot-client/src/services/MessageContextBuilder.test.ts
+++ b/services/bot-client/src/services/MessageContextBuilder.test.ts
@@ -1547,6 +1547,66 @@ describe('MessageContextBuilder', () => {
       );
     });
 
+    it('should suppress cross-channel history when incognito is true (chat with a message)', async () => {
+      vi.mocked(mockUserService.getOrCreateUser).mockResolvedValue({
+        userId: 'user-uuid-123',
+        defaultPersonaId: 'test-persona-id',
+      });
+      vi.mocked(mockUserService.getUserTimezone).mockResolvedValue('UTC');
+      vi.mocked(mockHistoryService.getChannelHistory).mockResolvedValue([]);
+      mockExtractReferencesWithReplacement.mockResolvedValue({
+        references: [],
+        updatedContent: 'Hello',
+      });
+      mockResolveAllMentions.mockResolvedValue({
+        processedContent: 'Hello',
+        mentionedUsers: [],
+        mentionedChannels: [],
+      });
+
+      // incognito with a message: isWeighInMode is false, but incognito nulls the
+      // persona, so the persona-scoped cross-channel fetch must still be skipped.
+      await builder.buildContext(mockMessage, mockPersonality, 'Hello', {
+        crossChannelHistoryEnabled: true,
+        incognito: true,
+      });
+
+      expect(mockFetchCrossChannelIfEnabled).toHaveBeenCalledWith(
+        expect.objectContaining({ enabled: false })
+      );
+    });
+
+    it('enables cross-channel history for a PERSONAL weigh-in (incognito=false)', async () => {
+      vi.mocked(mockUserService.getOrCreateUser).mockResolvedValue({
+        userId: 'user-uuid-123',
+        defaultPersonaId: 'test-persona-id',
+      });
+      vi.mocked(mockUserService.getUserTimezone).mockResolvedValue('UTC');
+      vi.mocked(mockHistoryService.getChannelHistory).mockResolvedValue([]);
+      mockExtractReferencesWithReplacement.mockResolvedValue({
+        references: [],
+        updatedContent: 'Hello',
+      });
+      mockResolveAllMentions.mockResolvedValue({
+        processedContent: 'Hello',
+        mentionedUsers: [],
+        mentionedChannels: [],
+      });
+
+      // Cross-channel and the persona are a unit: a personal weigh-in keeps its
+      // persona (incognito=false overrides the isWeighInMode default), so the
+      // fetch must be enabled even though it's a weigh-in.
+      await builder.buildContext(mockMessage, mockPersonality, 'Hello', {
+        crossChannelHistoryEnabled: true,
+        isWeighInMode: true,
+        incognito: false,
+      });
+
+      expect(mockFetchCrossChannelIfEnabled).toHaveBeenCalledWith(
+        expect.objectContaining({ enabled: true })
+      );
+    });
+
     it('wires the our-webhook registry into the fetch via getOurPersonalityId', async () => {
       vi.mocked(mockUserService.getOrCreateUser).mockResolvedValue({
         userId: 'user-uuid-123',

--- a/services/bot-client/src/services/MessageContextBuilder.ts
+++ b/services/bot-client/src/services/MessageContextBuilder.ts
@@ -433,10 +433,16 @@ export class MessageContextBuilder {
     });
     const history = extendedContext.history;
 
-    // Step 4b: Fetch cross-channel history. Disabled in weigh-in mode (anonymous
-    // poke that skips LTM and other-channel history for a fresh-perspective response).
+    // Step 4b: Fetch cross-channel history. Cross-channel and the persona are a
+    // unit — it's persona-scoped, so a personal summon (incognito:false),
+    // INCLUDING a personal weigh-in, gets it; only an incognito (anonymous)
+    // summon is disabled, since there's no persona to scope it to. Gated on the
+    // effective incognito (`incognito ?? isWeighInMode`), mirroring the epoch
+    // gate above and the worker-side ContextAssembler.
     const crossChannelGroups = await fetchCrossChannelIfEnabled({
-      enabled: options.crossChannelHistoryEnabled === true && options.isWeighInMode !== true,
+      enabled:
+        options.crossChannelHistoryEnabled === true &&
+        (options.incognito ?? options.isWeighInMode) !== true,
       channelId: message.channel.id,
       personaId,
       personalityId: personality.id,


### PR DESCRIPTION
## Bug (from prod — screenshot)

`/character random message:… incognito:True` rendered an error inside the character's reply:

```
[ContextAssembler] cross-channel enabled with a null persona
```

## Root cause

#1252 split the conflated `isWeighIn` flag into **framing** (`isWeighIn`) vs **anonymity** (`incognito`). Persona-clearing moved to `incognito`, but the **cross-channel gate stayed on `isWeighIn`**. An incognito *chat* (message present → `isWeighIn=false`) nulls the persona yet left cross-channel enabled — and cross-channel is persona-scoped, so the assembler's fail-loud guard tripped.

## Fix — cross-channel and the persona are a unit

Gate cross-channel purely on **persona presence**, dropping the `isWeighIn` clause entirely:

- **ai-worker `ContextAssembler`**: `enabled = crossChannelHistoryEnabled && activePersonaId !== null`. This fixes the incognito crash **and** enables cross-channel for a **personal weigh-in** (`incognito:false`), which the old `isWeighIn`-only gate wrongly suppressed (per maintainer: cross-channel should work for any personal summon).
- **bot-client `MessageContextBuilder`**: gate on `(incognito ?? isWeighInMode) !== true` (effective personal mode), mirroring the epoch gate just above it.

The persona (`activePersonaId`) is now the single signal for "personal mode," so all persona-coupled behaviors (cross-channel, LTM, epoch) key off the same thing — no independent re-derivation to drift.

## Behavior matrix

| Summon | persona | cross-channel |
|---|---|---|
| personal chat | present | ✅ on |
| **personal weigh-in** (`incognito:false`) | present | ✅ **on (was wrongly off)** |
| incognito chat (`random msg + incognito:true`) | null | ✅ off (was the crash) |
| default chime-in / weigh-in (incognito) | null | ✅ off |

## Tests

Flag-matrix tests on both sides: incognito → disabled (crash regression), personal weigh-in → enabled (corrected coupling), default weigh-in → disabled. Closes part of the #1252 review's flagged test-coverage gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)