### PR TITLE
fix(api-gateway): converge the two gateway LlmConfigResolver instances + pub/sub

### DIFF
--- a/backlog/now.md
+++ b/backlog/now.md
@@ -24,7 +24,7 @@ _Active bugs observed in production. Fix before new features. Cleared issues are
 
 _Small tasks that can be done between major features. Good for momentum._
 
-- `[LIFT]` **Converge the two gateway `LlmConfigResolver` instances (+ optional pub/sub)** — Surfaced by PR #1239 (Bug X) review. The gateway constructs **two** `LlmConfigResolver` instances: the process-lifetime one wired into `RouteDeps` for `/ai/generate` job-chain model stamping (`services/api-gateway/src/index.ts`, no pub/sub, 10s TTL), and the request-scoped one in `services/api-gateway/src/routes/user/llmConfigResolve.ts`. Same DB cascade; the only cost is a second non-shared cache. The job-chain instance has **no pub/sub invalidation**, so for up to 10s after a user changes their LLM config an image-description job could be stamped with the stale model. **Action**: refactor `createResolveHandler` to accept the injected `LlmConfigResolver` from `RouteDeps` (it already accepts an injected `ConfigCascadeResolver`), construct one shared instance in `index.ts`, optionally wire `LlmConfigCacheInvalidationService` pub/sub to it. Low risk; closes the staleness gap.
+_(empty)_
 
 ---
 

--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -183,14 +183,24 @@ async function initializeServices(prisma: PrismaClient): Promise<ServicesContext
   });
   logger.info('ConfigCascadeResolver initialized with cache invalidation');
 
-  // LLM model-config cascade resolver for the /ai/generate handler. Resolves
-  // {model, visionModel} once at job-chain build so the image-description child
-  // job uses the user-cascaded model rather than the personality seed (the
-  // global paid default). No pub/sub invalidation is wired here — it relies on
-  // the built-in 10s TTL, matching the staleness window the cascade already
-  // carries elsewhere. Converging this instance with the one in
-  // routes/user/llmConfigResolve.ts (and adding pub/sub) is a tracked backlog item.
+  // Long-lived LLM model-config resolver with pub/sub invalidation. One shared
+  // instance, one cache: it resolves {model, visionModel} for the /ai/generate
+  // job-chain (so the image-description child job uses the user-cascaded model,
+  // not the personality seed — the global paid default) AND backs the
+  // /user/llm-config/resolve endpoint. The subscription clears stale entries the
+  // moment a user's LLM config changes, closing the cache-TTL window where a job
+  // could otherwise be stamped with the pre-change model.
   const llmConfigResolver = new LlmConfigResolver(prisma);
+  await llmConfigCacheInvalidation.subscribe(event => {
+    if (event.type === 'user') {
+      llmConfigResolver.invalidateUserCache(event.discordId);
+    } else {
+      // 'all' and 'config' aren't user-keyed — a preset edit can touch any
+      // cached user (and the free-default entry), so clear the whole cache.
+      llmConfigResolver.clearCache();
+    }
+  });
+  logger.info('LlmConfigResolver initialized with cache invalidation');
 
   const modelCache = new OpenRouterModelCache(cacheRedis);
 

--- a/services/api-gateway/src/routes/user/llm-config.ts
+++ b/services/api-gateway/src/routes/user/llm-config.ts
@@ -500,7 +500,7 @@ export const handleCreateUserLlmConfig = (deps: RouteDeps): RequestHandler =>
   asyncHandler(createCreateHandler(buildService(deps), deps.prisma, deps.modelCache));
 
 export const handleResolveUserLlmConfig = (deps: RouteDeps): RequestHandler =>
-  asyncHandler(createResolveHandler(deps.prisma, deps.cascadeResolver));
+  asyncHandler(createResolveHandler(deps.prisma, deps.cascadeResolver, deps.llmConfigResolver));
 
 export const handleUpdateUserLlmConfig = (deps: RouteDeps): RequestHandler =>
   asyncHandler(createUpdateHandler(buildService(deps), deps.prisma, deps.modelCache));

--- a/services/api-gateway/src/routes/user/llmConfigResolve.test.ts
+++ b/services/api-gateway/src/routes/user/llmConfigResolve.test.ts
@@ -5,8 +5,11 @@
  * Handler integration is tested via llm-config.test.ts (route-level tests).
  */
 
-import { describe, it, expect } from 'vitest';
-import { resolveConfigBodySchema } from './llmConfigResolve.js';
+import { describe, it, expect, vi } from 'vitest';
+import type { Response } from 'express';
+import type { PrismaClient, LlmConfigResolver, ConfigCascadeResolver } from '@tzurot/common-types';
+import { createResolveHandler, resolveConfigBodySchema } from './llmConfigResolve.js';
+import type { AuthenticatedRequest } from '../../types.js';
 
 describe('resolveConfigBodySchema', () => {
   const validBody = {
@@ -59,5 +62,36 @@ describe('resolveConfigBodySchema', () => {
       },
     });
     expect(result.success).toBe(true);
+  });
+});
+
+describe('createResolveHandler injection', () => {
+  it('resolves through the injected (shared) LlmConfigResolver, not a fresh one', async () => {
+    // The convergence guard: when index.ts passes the shared, pub/sub-invalidated
+    // resolver, the handler must use THAT instance — otherwise the endpoint would
+    // silently fall back to a second, un-invalidated cache (the bug this closes).
+    const resolveConfig = vi
+      .fn()
+      .mockResolvedValue({ config: { model: 'm' }, source: 'user-default' });
+    const resolveOverrides = vi.fn().mockResolvedValue({});
+    const injectedLlm = { resolveConfig } as unknown as LlmConfigResolver;
+    const injectedCascade = { resolveOverrides } as unknown as ConfigCascadeResolver;
+
+    const handler = createResolveHandler({} as PrismaClient, injectedCascade, injectedLlm);
+
+    const req = {
+      userId: 'discord-123',
+      body: { personalityId: 'p1', personalityConfig: { id: 'p1', name: 'Test', model: 'm' } },
+    } as unknown as AuthenticatedRequest;
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() } as unknown as Response;
+
+    await handler(req, res);
+
+    expect(resolveConfig).toHaveBeenCalledWith(
+      'discord-123',
+      'p1',
+      expect.objectContaining({ model: 'm' })
+    );
+    expect(resolveOverrides).toHaveBeenCalledWith('discord-123', 'p1', undefined);
   });
 });

--- a/services/api-gateway/src/routes/user/llmConfigResolve.ts
+++ b/services/api-gateway/src/routes/user/llmConfigResolve.ts
@@ -49,13 +49,16 @@ export const resolveConfigBodySchema = z.object({
 
 export function createResolveHandler(
   prisma: PrismaClient,
-  injectedCascadeResolver?: ConfigCascadeResolver
+  injectedCascadeResolver?: ConfigCascadeResolver,
+  injectedLlmResolver?: LlmConfigResolver
 ) {
-  // LlmConfigResolver is request-scoped (no cross-request caching needed for model resolution).
-  // ConfigCascadeResolver should be the long-lived, pub/sub-subscribed instance from index.ts
-  // so channel/user/personality config changes are reflected immediately (not after 30s TTL).
-  // Falls back to a local instance if not injected (e.g., in tests).
-  const resolver = new LlmConfigResolver(prisma, { enableCleanup: false });
+  // Both resolvers should be the long-lived, pub/sub-subscribed instances from
+  // index.ts so user/channel/personality config changes are reflected immediately
+  // (not after the cache-TTL window). The shared LlmConfigResolver is the same
+  // instance the /ai/generate job-chain uses, so a user's model change invalidates
+  // one cache, not two. Each falls back to a local instance when not injected
+  // (e.g. in tests).
+  const resolver = injectedLlmResolver ?? new LlmConfigResolver(prisma, { enableCleanup: false });
   const cascadeResolver =
     injectedCascadeResolver ?? new ConfigCascadeResolver(prisma, { enableCleanup: false });
 


### PR DESCRIPTION
## Problem

The gateway constructed **two** long-lived `LlmConfigResolver` instances, each with its own TTL cache:

- the `RouteDeps` one wired into `/ai/generate` job-chain model stamping (`index.ts`), and
- a second one built inside `createResolveHandler` for the `/user/llm-config/resolve` endpoint.

Neither subscribed to LLM-config cache invalidation, so for up to the cache-TTL window after a user changed their LLM config, an image-description child job (or a resolve call) could be stamped with the **pre-change model**. Surfaced by PR #1239 (Bug X) review.

## Fix

Converge to one shared instance and wire pub/sub:

- **`createResolveHandler`** now accepts an injected `LlmConfigResolver` (mirroring the existing injected `ConfigCascadeResolver`), falling back to a local instance for tests. The resolve route passes `deps.llmConfigResolver` — the same instance the job-chain uses, so a user's model change invalidates **one** cache, not two.
- **`index.ts`** subscribes the shared resolver to `LlmConfigCacheInvalidationService`:
  - `user` events → `invalidateUserCache(discordId)` (the cache is keyed `${discordId}-${personalityId}`),
  - `all` / `config` events → `clearCache()` (not user-keyed — a preset edit can touch any cached user plus the `__free_default__` entry).

## Tests

Adds a colocated injection test asserting the handler resolves through the **injected** resolver — guards against silently falling back to a second, un-invalidated cache (the bug this closes).

Full api-gateway suite green (2139 tests), `tsc --noEmit` clean, `pnpm quality` 16/16.

## Backlog

Closes the `[LIFT]` Quick Win in `backlog/now.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)