### PR TITLE
refactor(ai-worker): type-enforce the personal/incognito context coupling

### DIFF
--- a/packages/common-types/src/index.ts
+++ b/packages/common-types/src/index.ts
@@ -18,6 +18,7 @@ export * from './types/discord.js';
 export * from './types/discord-types.js';
 export * from './types/gateway-context.js';
 export * from './types/jobs.js';
+export * from './types/summon-anonymity.js';
 export * from './types/shapes-import.js';
 export * from './types/schemas/index.js';
 

--- a/packages/common-types/src/types/summon-anonymity.test.ts
+++ b/packages/common-types/src/types/summon-anonymity.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { resolveSummonAnonymity, type SummonAnonymity } from './summon-anonymity.js';
+
+const PERSONA = { activePersonaId: 'persona-1', activePersonaName: 'Vee' };
+
+describe('resolveSummonAnonymity', () => {
+  it('explicit incognito=true → incognito (regardless of framing)', () => {
+    expect(resolveSummonAnonymity({ incognito: true, isWeighIn: true }, PERSONA)).toEqual({
+      kind: 'incognito',
+    });
+    expect(resolveSummonAnonymity({ incognito: true, isWeighIn: false }, PERSONA)).toEqual({
+      kind: 'incognito',
+    });
+  });
+
+  it('explicit incognito=false → personal even when isWeighIn=true (a personal weigh-in)', () => {
+    expect(resolveSummonAnonymity({ incognito: false, isWeighIn: true }, PERSONA)).toEqual({
+      kind: 'personal',
+      activePersonaId: 'persona-1',
+      activePersonaName: 'Vee',
+    });
+  });
+
+  it('incognito unset → defaults to the framing: isWeighIn=true is anonymous', () => {
+    expect(resolveSummonAnonymity({ isWeighIn: true }, PERSONA)).toEqual({ kind: 'incognito' });
+  });
+
+  it('incognito unset + isWeighIn=false/unset → personal', () => {
+    expect(resolveSummonAnonymity({ isWeighIn: false }, PERSONA).kind).toBe('personal');
+    expect(resolveSummonAnonymity({}, PERSONA).kind).toBe('personal');
+  });
+
+  it('carries a null persona name through the personal arm', () => {
+    const result = resolveSummonAnonymity(
+      { incognito: false },
+      { activePersonaId: 'p', activePersonaName: null }
+    );
+    expect(result).toEqual({ kind: 'personal', activePersonaId: 'p', activePersonaName: null });
+  });
+
+  it('fail-safes to incognito when a personal summon has no resolved persona id', () => {
+    // The invalid state `{ kind: 'personal', activePersonaId: '' }` must never be
+    // constructed — a personal arm with empty/null/undefined id collapses to
+    // incognito (the safe, observable direction).
+    for (const missing of ['', null, undefined] as const) {
+      expect(
+        resolveSummonAnonymity(
+          { incognito: false },
+          { activePersonaId: missing, activePersonaName: 'Vee' }
+        )
+      ).toEqual({ kind: 'incognito' });
+    }
+  });
+});
+
+describe('SummonAnonymity (compile-time invariants)', () => {
+  it('makes "incognito with a persona" unrepresentable', () => {
+    // @ts-expect-error — the incognito arm has no activePersonaId; bundling a
+    // persona into an anonymous summon is exactly the drift this prevents.
+    const invalid: SummonAnonymity = { kind: 'incognito', activePersonaId: 'x' };
+    expect(invalid.kind).toBe('incognito');
+  });
+
+  it('cannot read activePersonaId without narrowing to the personal arm', () => {
+    const mode = resolveSummonAnonymity({ incognito: false }, PERSONA);
+    // @ts-expect-error — activePersonaId is only present on the personal arm;
+    // reading it off the bare union is rejected until `kind === 'personal'`.
+    const _id: string = mode.activePersonaId;
+    if (mode.kind === 'personal') {
+      // narrowed → access is allowed and the type is non-null `string`
+      const id: string = mode.activePersonaId;
+      expect(id).toBe('persona-1');
+    }
+  });
+});

--- a/packages/common-types/src/types/summon-anonymity.ts
+++ b/packages/common-types/src/types/summon-anonymity.ts
@@ -1,0 +1,58 @@
+/**
+ * Summon anonymity — the personal-vs-incognito distinction as a discriminated union.
+ *
+ * A summon is either **personal** (carries the invoking user's persona) or
+ * **incognito** (anonymous — no persona, and therefore no long-term-memory
+ * read/write, no context epoch, no cross-channel history, no mention-upserts).
+ * Anonymity and persona-presence are the SAME fact, so they share one
+ * discriminant rather than living in separate, independently-drifting fields:
+ * `activePersonaId` is non-null BY TYPE in the `personal` arm. That makes
+ * "incognito with a persona" and "cross-channel enabled with a null persona"
+ * unrepresentable at compile time, replacing the runtime guard that previously
+ * caught the drift.
+ *
+ * NOT to be confused with the Redis `/memory incognito` *session*
+ * (`IncognitoSession` in `./incognito.ts`): that is a user-toggled, time-bounded
+ * "don't remember this conversation" mode checked separately at write time. This
+ * union is the per-summon framing decided when a `/character` command runs.
+ *
+ * `isWeighIn` (read-the-room FRAMING) is deliberately NOT part of this union — it
+ * is orthogonal to anonymity. A *personal weigh-in* (incognito off, weigh-in
+ * framing on) is a valid, supported state, so framing stays an independent flag.
+ */
+export type SummonAnonymity =
+  | { kind: 'personal'; activePersonaId: string; activePersonaName: string | null }
+  | { kind: 'incognito' };
+
+/**
+ * Resolve the per-summon anonymity from the wire flags + the already-resolved
+ * persona. This is the single home of the `incognito ?? Boolean(isWeighIn)`
+ * default: `incognito` is the explicit anonymity choice; when it is unset, a
+ * weigh-in framing (`isWeighIn`) implies anonymity so existing weigh-in payloads
+ * stay anonymous. Every consumer switches on the returned `kind` instead of
+ * re-deriving the default, which is what let the decision drift across sites.
+ *
+ * Fail-safe: a personal summon with no resolved persona id degrades to incognito
+ * rather than constructing `{ kind: 'personal', activePersonaId: '' }` — a
+ * persona-less personal summon is exactly the invalid state this union forbids.
+ * Anonymity is the safe direction (no LTM/persona leak), and it's observable (the
+ * response shows incognito where personal was expected), so an upstream
+ * resolution bug surfaces instead of hiding behind a blank id.
+ *
+ * @param flags   the summon's anonymity (`incognito`) + framing (`isWeighIn`) flags
+ * @param persona the resolved persona — used only to populate the `personal` arm;
+ *                a missing id collapses the result to incognito (see above)
+ */
+export function resolveSummonAnonymity(
+  flags: { incognito?: boolean; isWeighIn?: boolean },
+  persona: { activePersonaId: string | null | undefined; activePersonaName: string | null }
+): SummonAnonymity {
+  if (flags.incognito ?? Boolean(flags.isWeighIn)) {
+    return { kind: 'incognito' };
+  }
+  const { activePersonaId } = persona;
+  if (activePersonaId === null || activePersonaId === undefined || activePersonaId.length === 0) {
+    return { kind: 'incognito' };
+  }
+  return { kind: 'personal', activePersonaId, activePersonaName: persona.activePersonaName };
+}

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/conversationContextBuilder.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/conversationContextBuilder.test.ts
@@ -115,4 +115,74 @@ describe('buildConversationContext', () => {
     expect(result.crossChannelHistory?.[0].channelEnvironment.type).toBe('dm');
     expect(result.crossChannelHistory?.[0].messages[0].content).toBe('DM message');
   });
+
+  // This is the single resolution boundary for the memory consumers: the wire
+  // flags (incognito/isWeighIn) become a SummonAnonymity union exactly once here,
+  // so MemoryRetriever/ConversationalRAGService can't re-derive it differently.
+  describe('summonAnonymity resolution', () => {
+    it('resolves a personal summon when no anonymity flags are set', () => {
+      const jobContext = createMinimalJobContext();
+      jobContext.activePersonaId = 'persona-1';
+      jobContext.activePersonaName = 'Vee';
+
+      const result = buildConversationContext(
+        jobContext,
+        createMinimalPreparedContext(),
+        undefined
+      );
+
+      expect(result.summonAnonymity).toEqual({
+        kind: 'personal',
+        activePersonaId: 'persona-1',
+        activePersonaName: 'Vee',
+      });
+    });
+
+    it('defaults to incognito when isWeighIn is set and incognito is unset', () => {
+      const jobContext = createMinimalJobContext();
+      jobContext.isWeighIn = true;
+
+      const result = buildConversationContext(
+        jobContext,
+        createMinimalPreparedContext(),
+        undefined
+      );
+
+      expect(result.summonAnonymity).toEqual({ kind: 'incognito' });
+    });
+
+    it('resolves personal when incognito=false overrides weigh-in framing', () => {
+      const jobContext = createMinimalJobContext();
+      jobContext.isWeighIn = true;
+      jobContext.incognito = false;
+      jobContext.activePersonaId = 'persona-1';
+      jobContext.activePersonaName = 'Vee';
+
+      const result = buildConversationContext(
+        jobContext,
+        createMinimalPreparedContext(),
+        undefined
+      );
+
+      expect(result.summonAnonymity).toEqual({
+        kind: 'personal',
+        activePersonaId: 'persona-1',
+        activePersonaName: 'Vee',
+      });
+    });
+
+    it('resolves incognito when incognito=true regardless of persona fields on the wire', () => {
+      const jobContext = createMinimalJobContext();
+      jobContext.incognito = true;
+      jobContext.activePersonaId = 'persona-1';
+
+      const result = buildConversationContext(
+        jobContext,
+        createMinimalPreparedContext(),
+        undefined
+      );
+
+      expect(result.summonAnonymity).toEqual({ kind: 'incognito' });
+    });
+  });
 });

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/conversationContextBuilder.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/conversationContextBuilder.ts
@@ -5,7 +5,7 @@
  * Extracted from GenerationStep to keep file under max-lines limit.
  */
 
-import type { LLMGenerationJobData } from '@tzurot/common-types';
+import { resolveSummonAnonymity, type LLMGenerationJobData } from '@tzurot/common-types';
 import type { ConversationContext } from '../../../../services/ConversationalRAGTypes.js';
 import type { PreparedContext, PreprocessingResults } from '../types.js';
 
@@ -15,6 +15,24 @@ export function buildConversationContext(
   preparedContext: PreparedContext,
   preprocessing: PreprocessingResults | undefined
 ): ConversationContext {
+  // Resolve the personal-vs-incognito union once here so the memory consumers
+  // (LTM read/write skip) switch on `summonAnonymity.kind` instead of each
+  // re-deriving `incognito ?? isWeighIn`. A personal summon always carries its
+  // persona (the bot or the worker assembler resolved it); if the wire id is
+  // somehow absent, the resolver fail-safes to incognito rather than building a
+  // persona-less personal arm.
+  //
+  // This agrees with the assembler's own resolveSummonAnonymity call by
+  // construction: in service mode ContextStep.applyAssembledContext writes the
+  // assembler's resolved activePersonaId onto jobContext BEFORE this step runs,
+  // so both see the same id; in legacy mode the assembler never runs, so this is
+  // the sole resolution point. The fail-safe therefore never fires for a real
+  // personal summon — it can't diverge from the assembler. (If that writeback is
+  // ever removed, the two calls could disagree on kind — keep them in sync.)
+  const summonAnonymity = resolveSummonAnonymity(jobContext, {
+    activePersonaId: jobContext.activePersonaId,
+    activePersonaName: jobContext.activePersonaName ?? null,
+  });
   return {
     userId: jobContext.userId,
     userName: jobContext.userName,
@@ -24,7 +42,7 @@ export function buildConversationContext(
     sessionId: jobContext.sessionId,
     isProxyMessage: jobContext.isProxyMessage,
     isWeighIn: jobContext.isWeighIn,
-    incognito: jobContext.incognito,
+    summonAnonymity,
     activePersonaId: jobContext.activePersonaId,
     activePersonaName: jobContext.activePersonaName,
     // Guild-specific info for participants (roles, color, join date)

--- a/services/ai-worker/src/services/ConversationalRAGService.test.ts
+++ b/services/ai-worker/src/services/ConversationalRAGService.test.ts
@@ -541,32 +541,32 @@ describe('ConversationalRAGService', () => {
       expect(result.deferredMemoryData).toBeUndefined();
     });
 
-    it('should skip LTM storage when isWeighIn is true (weigh-in mode)', async () => {
+    it('should skip LTM storage when the summon is incognito', async () => {
       const personality = createMockPersonality();
-      const context = createMockContext({ isWeighIn: true });
+      const context = createMockContext({ summonAnonymity: { kind: 'incognito' } });
 
       const result = await service.generateResponse(personality, 'Test', context);
 
       // LTM storage should NOT have been called
       expect(getLongTermMemoryServiceMock().storeInteraction).not.toHaveBeenCalled();
-      // Response should indicate incognito mode was active (weigh-in reuses incognito pipeline)
+      // Response should indicate incognito mode was active
       expect(result.incognitoModeActive).toBe(true);
     });
 
-    it('should not return deferredMemoryData when isWeighIn is true', async () => {
+    it('should not return deferredMemoryData when the summon is incognito', async () => {
       getMemoryRetrieverMock().resolvePersonaForMemory.mockResolvedValue({
         personaId: 'persona-123',
         focusModeEnabled: false,
       });
 
       const personality = createMockPersonality();
-      const context = createMockContext({ isWeighIn: true });
+      const context = createMockContext({ summonAnonymity: { kind: 'incognito' } });
 
       const result = await service.generateResponse(personality, 'Test', context, {
         skipMemoryStorage: true,
       });
 
-      // Even with skipMemoryStorage, no deferredMemoryData when weigh-in
+      // Even with skipMemoryStorage, no deferredMemoryData for an incognito summon
       expect(result.deferredMemoryData).toBeUndefined();
       expect(result.incognitoModeActive).toBe(true);
     });

--- a/services/ai-worker/src/services/ConversationalRAGService.ts
+++ b/services/ai-worker/src/services/ConversationalRAGService.ts
@@ -468,9 +468,10 @@ export class ConversationalRAGService {
 
       // Step 6: Check incognito mode and handle memory storage.
       // A chime-in/random summon is incognito by default (skip storage, set the
-      // footer flag); a personal (incognito=false) summon records memories. The
-      // user's own /memory incognito session still forces incognito regardless.
-      const summonIncognito = context.incognito ?? Boolean(context.isWeighIn);
+      // footer flag); a personal summon records memories. The summon's anonymity
+      // was resolved once in buildConversationContext. The user's own /memory
+      // incognito Redis session still forces incognito regardless.
+      const summonIncognito = context.summonAnonymity?.kind === 'incognito';
       const incognitoModeActive =
         summonIncognito || (await redisService.isIncognitoActive(context.userId, personality.id));
 

--- a/services/ai-worker/src/services/ConversationalRAGTypes.ts
+++ b/services/ai-worker/src/services/ConversationalRAGTypes.ts
@@ -14,6 +14,7 @@ import type {
   ResolvedConfigOverrides,
   SttDispatch,
   AIProvider,
+  SummonAnonymity,
 } from '@tzurot/common-types';
 import type { ProcessedAttachment } from './MultimodalProcessor.js';
 
@@ -73,9 +74,16 @@ export interface ConversationContext {
   isProxyMessage?: boolean;
   /** Weigh-in mode: read-the-room framing (controls framing, not anonymity). */
   isWeighIn?: boolean;
-  /** Anonymity for chime-in/random: skip persona + LTM read/write + epoch when
-   *  true (defaults to `isWeighIn` when unset). See JobContext.incognito. */
-  incognito?: boolean;
+  /**
+   * Personal-vs-incognito union, resolved once in `buildConversationContext`
+   * from the wire flags (always populated on the production path). Memory
+   * consumers switch on `summonAnonymity?.kind` rather than re-deriving
+   * `incognito ?? isWeighIn`, which is what let the anonymity decision drift
+   * across sites. Optional so unrelated tests need not declare it —
+   * absent reads as a personal summon (the safe default: memory works). Distinct
+   * from the Redis `/memory incognito` session checked separately at write time.
+   */
+  summonAnonymity?: SummonAnonymity;
   activePersonaId?: string;
   activePersonaName?: string;
   discordUsername?: string;

--- a/services/ai-worker/src/services/MemoryRetriever.test.ts
+++ b/services/ai-worker/src/services/MemoryRetriever.test.ts
@@ -522,16 +522,16 @@ describe('MemoryRetriever', () => {
       expect(mockMemoryManager.queryMemories).not.toHaveBeenCalled();
     });
 
-    it('should return empty memories when isWeighIn is true', async () => {
-      const weighInContext: ConversationContext = {
+    it('should return empty memories for an incognito summon', async () => {
+      const incognitoContext: ConversationContext = {
         userId: 'discord-user-123',
-        isWeighIn: true,
+        summonAnonymity: { kind: 'incognito' },
       };
 
       const result = await retriever.retrieveRelevantMemories(
         mockPersonality,
         'test query',
-        weighInContext
+        incognitoContext
       );
 
       expect(result).toEqual({ memories: [], focusModeEnabled: false });
@@ -540,7 +540,7 @@ describe('MemoryRetriever', () => {
       expect(mockMemoryManager.queryMemories).not.toHaveBeenCalled();
     });
 
-    it('retrieves LTM when incognito=false even if isWeighIn is true (personal summon)', async () => {
+    it('retrieves LTM for a personal summon (even with weigh-in framing)', async () => {
       mockPersonaResolver.resolveForMemory.mockResolvedValue({
         personaId: 'persona-123',
         focusModeEnabled: false,
@@ -548,12 +548,16 @@ describe('MemoryRetriever', () => {
       const mockMemories = [{ pageContent: 'Memory content', metadata: { id: 'mem-1' } }];
       (mockMemoryManager.queryMemories as any).mockResolvedValue(mockMemories);
 
-      // isWeighIn drives framing only; incognito=false makes the summon personal,
-      // so LTM retrieval proceeds instead of short-circuiting on the weigh-in flag.
+      // The summon is personal, so LTM retrieval proceeds. isWeighIn is framing
+      // only and does not force anonymity — the persona-presence union decides.
       const personalWeighIn: ConversationContext = {
         userId: 'discord-user-123',
         isWeighIn: true,
-        incognito: false,
+        summonAnonymity: {
+          kind: 'personal',
+          activePersonaId: 'persona-123',
+          activePersonaName: 'Vee',
+        },
       };
 
       const result = await retriever.retrieveRelevantMemories(

--- a/services/ai-worker/src/services/MemoryRetriever.ts
+++ b/services/ai-worker/src/services/MemoryRetriever.ts
@@ -128,9 +128,10 @@ export class MemoryRetriever {
     configOverrides?: ResolvedConfigOverrides
   ): Promise<MemoryRetrievalResult> {
     // Incognito (anonymous chime-in/random) — skip LTM retrieval entirely (no
-    // past memories injected). Defaults to isWeighIn so existing weigh-in jobs
-    // stay anonymous; a personal (incognito=false) summon reads memories.
-    if (context.incognito ?? Boolean(context.isWeighIn)) {
+    // past memories injected). The personal-vs-incognito decision was resolved
+    // once in buildConversationContext; absent (test contexts) reads as personal,
+    // so a personal summon reads memories.
+    if (context.summonAnonymity?.kind === 'incognito') {
       logger.info(
         { userId: context.userId, personalityId: personality.id },
         'Incognito mode - skipping LTM retrieval'

--- a/services/ai-worker/src/services/context/ContextAssembler.ts
+++ b/services/ai-worker/src/services/context/ContextAssembler.ts
@@ -30,10 +30,12 @@ import {
   type LoadedPersonality,
   type MentionedPersona,
   type PersonaResolver,
+  resolveSummonAnonymity,
   type RawAssemblyInputs,
   type ReferencedChannel,
   type ReferencedMessage,
   type ResolvedConfigOverrides,
+  type SummonAnonymity,
   type UserService,
 } from '@tzurot/common-types';
 import { rewriteRawContent, type RewrittenContent } from './contentRewriter.js';
@@ -45,7 +47,7 @@ const logger = createLogger('ContextAssembler');
 /** The core surfaces the assembler re-derives. */
 export interface AssembledCore {
   userInternalId: string;
-  /** Null in weigh-in mode — an anonymous poke has no invoking-user persona. */
+  /** Null for an incognito summon — an anonymous poke has no invoking-user persona. */
   activePersonaId: string | null;
   activePersonaName: string | null;
   userTimezone: string;
@@ -61,8 +63,8 @@ export interface AssembledCore {
   referencedMessages: ReferencedMessage[] | undefined;
   /**
    * The rewritten message content ([Reference N] links + mention names).
-   * In weigh-in mode this is the raw content untouched — the bot skips all
-   * rewriting there, and mirroring that also avoids upserting mention users
+   * For an incognito summon this is the raw content untouched — the bot skips
+   * all rewriting there, and mirroring that also avoids upserting mention users
    * for anonymous pokes.
    */
   messageContent: string;
@@ -74,7 +76,7 @@ export interface AssembledCore {
    * Cross-channel history groups, decorated from the envelope's
    * knownChannelEnvironments (fallback env for cache misses) and serialized
    * through the shared wire mapper. Undefined when the feature is disabled
-   * or the job is a weigh-in (payload parity with the bot path); [] when
+   * or the summon is incognito (payload parity with the bot path); [] when
    * enabled but nothing eligible was found.
    */
   crossChannelHistory: CrossChannelHistoryGroupEntry[] | undefined;
@@ -173,14 +175,17 @@ export class ContextAssembler {
     if (user === null) {
       throw new Error('[ContextAssembler] getOrCreateUser returned null (bot author?)');
     }
-    // Step 2: persona + timezone + context epoch. Weigh-in nulls the OUTPUT
-    // persona AND skips the epoch — a channel-scoped summon must not be bound
-    // by the invoking user's persona-scoped STM reset (see helper).
-    const { activePersonaId, activePersonaName, contextEpoch } = await this.resolvePersonaContext(
+    // Step 2: persona + timezone + context epoch. An incognito summon has no
+    // persona arm, so the OUTPUT persona is null and the epoch is skipped — a
+    // channel-scoped anonymous poke must not be bound by the invoking user's
+    // persona-scoped STM reset (see helper).
+    const { summon, contextEpoch } = await this.resolvePersonaContext(
       jobContext,
       personality.id,
       user.userId
     );
+    const activePersonaId = summon.kind === 'personal' ? summon.activePersonaId : null;
+    const activePersonaName = summon.kind === 'personal' ? summon.activePersonaName : null;
     const userTimezone = await this.deps.dataSource.getUserTimezone(user.userId);
 
     // Step 3: hydrate channel history — same limit derivation as the
@@ -215,24 +220,16 @@ export class ContextAssembler {
     const referencedMessages = await this.enrichReferences(raw, history, options);
 
     // Step 6: content rewriting (links → user mentions → channels → roles),
-    // skipped wholesale in weigh-in mode to mirror the bot-side early return.
-    const rewritten = await this.rewriteContent(jobContext, raw, personality);
+    // skipped wholesale for an incognito summon to mirror the bot-side early
+    // return (also avoids upserting mention users for an anonymous poke).
+    const rewritten = await this.rewriteContent(summon, raw, personality);
 
-    // Step 7: cross-channel history — own DB fetch, environment names from
-    // the envelope's cache map (the worker can't ask Discord), shared wire
-    // mapper. Same budget as the channel-history dbLimit, mirroring the
-    // bot-side fetchCrossChannelIfEnabled gate (disabled or weigh-in →
-    // undefined, matching the payload's absent field).
-    const crossChannelHistory = await this.assembleCrossChannel(jobContext, personality, {
-      // Cross-channel history and the persona are a unit: it's persona-scoped, so
-      // it's enabled for ANY personal summon (persona present) — including a
-      // personal weigh-in (incognito:false) — and disabled only when there's no
-      // persona to scope it to. `incognito` nulls the persona (whether it's a
-      // chime-in, a message-less random, or /character random with a message +
-      // incognito:true), so `activePersonaId !== null` is the single gate.
-      // Framing (`isWeighIn`) is deliberately NOT checked here.
-      enabled: configOverrides?.crossChannelHistoryEnabled === true && activePersonaId !== null,
-      personaId: activePersonaId,
+    // Step 7: cross-channel history — own DB fetch, environment names from the
+    // envelope's cache map (the worker can't ask Discord), shared wire mapper,
+    // same budget as the channel-history dbLimit. The persona-scoping gate lives
+    // in the helper, which narrows on the summon union (see its doc).
+    const crossChannelHistory = await this.assembleCrossChannel(jobContext, personality, summon, {
+      crossChannelEnabled: configOverrides?.crossChannelHistoryEnabled === true,
       excludeChannelId: channelId,
       limit,
       maxAgeSeconds: configOverrides?.maxAge ?? undefined,
@@ -277,51 +274,47 @@ export class ContextAssembler {
    * (`/conversation reset`), which is the wrong granularity to bound a SHARED
    * channel the personality is asked to comment on. A recent personal reset
    * would otherwise silently truncate the channel history; there is no coarser
-   * channel/server epoch to fall back to, so weigh-in applies none (maxAge is
+   * channel/server epoch to fall back to, so incognito applies none (maxAge is
    * the only bound). The persona is still resolved (its cache-populating read
-   * is harmless), but its epoch lookup is skipped. Memory read/write skip is
-   * gated separately by isWeighIn.
+   * is harmless), but the OUTPUT persona + its epoch lookup are bundled into
+   * the returned `SummonAnonymity` — an incognito summon has no persona arm, so
+   * the epoch is skipped and downstream can't read a persona that isn't there.
    */
   private async resolvePersonaContext(
     jobContext: JobContext,
     personalityId: string,
     internalUserId: string
-  ): Promise<{
-    activePersonaId: string | null;
-    activePersonaName: string | null;
-    contextEpoch: Date | undefined;
-  }> {
+  ): Promise<{ summon: SummonAnonymity; contextEpoch: Date | undefined }> {
     const personaResult = await this.deps.personaResolver.resolve(jobContext.userId, personalityId);
-    const resolvedPersonaId = personaResult.config.personaId;
-    // Anonymity (incognito), not framing (isWeighIn): a personal summon keeps
-    // its persona + STM epoch even though it uses the weigh-in framing. Defaults
-    // to isWeighIn so existing weigh-in jobs stay anonymous.
-    const incognito = jobContext.incognito ?? Boolean(jobContext.isWeighIn);
-    const contextEpoch = incognito
-      ? undefined
-      : await this.deps.dataSource.getContextEpoch(
-          internalUserId,
-          personalityId,
-          resolvedPersonaId
-        );
-    return {
-      activePersonaId: incognito ? null : resolvedPersonaId,
-      activePersonaName: incognito ? null : personaResult.config.preferredName,
-      contextEpoch,
-    };
+    // Anonymity (incognito), not framing (isWeighIn): a personal summon keeps its
+    // persona + STM epoch even with weigh-in framing. The resolver owns the
+    // `incognito ?? isWeighIn` default so it lives in exactly one place.
+    const summon = resolveSummonAnonymity(jobContext, {
+      activePersonaId: personaResult.config.personaId,
+      activePersonaName: personaResult.config.preferredName,
+    });
+    const contextEpoch =
+      summon.kind === 'personal'
+        ? await this.deps.dataSource.getContextEpoch(
+            internalUserId,
+            personalityId,
+            summon.activePersonaId
+          )
+        : undefined;
+    return { summon, contextEpoch };
   }
 
   /**
-   * Content rewriting through the shared kernels — incognito (anonymous) jobs
-   * pass the raw content through untouched, avoiding mention-user upserts. A
-   * personal summon (incognito=false) rewrites mentions like a normal chat.
+   * Content rewriting through the shared kernels — an incognito summon passes
+   * the raw content through untouched, avoiding mention-user upserts. A personal
+   * summon rewrites mentions like a normal chat.
    */
   private async rewriteContent(
-    jobContext: JobContext,
+    summon: SummonAnonymity,
     raw: RawAssemblyInputs,
     personality: LoadedPersonality
   ): Promise<RewrittenContent> {
-    if (jobContext.incognito ?? Boolean(jobContext.isWeighIn)) {
+    if (summon.kind === 'incognito') {
       return {
         messageContent: raw.rawMessageContent,
         mentionedPersonas: undefined,
@@ -357,10 +350,9 @@ export class ContextAssembler {
   private async assembleCrossChannel(
     jobContext: JobContext,
     personality: LoadedPersonality,
+    summon: SummonAnonymity,
     opts: {
-      enabled: boolean;
-      /** Null in weigh-in OR incognito mode; `enabled` requires a non-null persona. */
-      personaId: string | null;
+      crossChannelEnabled: boolean;
       /** The narrowed current-channel id from assembleCore's guard. */
       excludeChannelId: string;
       limit: number;
@@ -368,19 +360,19 @@ export class ContextAssembler {
       contextEpoch: Date | undefined;
     }
   ): Promise<CrossChannelHistoryGroupEntry[] | undefined> {
-    if (!opts.enabled) {
+    // Cross-channel history and the persona are a unit: it's persona-scoped, so
+    // it's enabled for ANY personal summon (including a personal weigh-in) and
+    // impossible for an incognito one (no persona to scope it to). Narrowing on
+    // `summon.kind === 'personal'` makes `summon.activePersonaId` non-null BY
+    // TYPE below — "cross-channel with a null persona" is unrepresentable by
+    // type, no runtime guard needed. Framing (`isWeighIn`) is
+    // deliberately not part of this decision. Undefined when disabled/incognito
+    // (payload parity with the bot path); [] when enabled but nothing eligible.
+    if (!opts.crossChannelEnabled || summon.kind !== 'personal') {
       return undefined;
     }
-    // Invariant: the `enabled` gate is `activePersonaId !== null`, so a non-null
-    // persona always reaches here. Fail loud if a future change decouples
-    // cross-channel from the persona, rather than silently querying with a bad id.
-    if (opts.personaId === null) {
-      throw new Error('[ContextAssembler] cross-channel enabled with a null persona');
-    }
-    const personaId = opts.personaId;
-
     const groups = await this.deps.dataSource.getCrossChannelHistory({
-      personaId,
+      personaId: summon.activePersonaId,
       personalityId: personality.id,
       excludeChannelId: opts.excludeChannelId,
       limit: opts.limit,

--- a/services/ai-worker/src/test/mocks/fixtures/context.ts
+++ b/services/ai-worker/src/test/mocks/fixtures/context.ts
@@ -24,6 +24,14 @@ export function createMockContext(overrides?: Partial<ConversationContext>): Con
     channelId: 'channel-456',
     serverId: 'server-789',
     userName: 'TestUser',
+    // Default to a personal summon (matches the old default: no incognito/isWeighIn
+    // flags → `incognito ?? Boolean(isWeighIn)` resolved false). Tests exercising
+    // anonymity override with `summonAnonymity: { kind: 'incognito' }`.
+    summonAnonymity: {
+      kind: 'personal',
+      activePersonaId: 'persona-default',
+      activePersonaName: 'TestUser',
+    },
     ...overrides,
   };
 }


### PR DESCRIPTION
## Problem

Anonymity and persona-presence are **the same fact** — `incognito=true ⟺ activePersonaId=null ⟺ no LTM/epoch/cross-channel/mention-upserts` — but they lived as **separate fields**, with the `incognito ?? Boolean(isWeighIn)` default re-derived independently at ~4 worker sites and a runtime `throw` as the only guard. Bug #1254 was exactly that drift: cross-channel gated on the wrong flag, reaching assembly with a null persona.

## Approach

New `SummonAnonymity` discriminated union (common-types) bundles the persona into the anonymity discriminant:

```ts
type SummonAnonymity =
  | { kind: 'personal'; activePersonaId: string; activePersonaName: string | null }
  | { kind: 'incognito' };
```

`activePersonaId` is non-null **by type** in the `personal` arm, so "incognito with a persona" and "cross-channel with a null persona" (#1254) are **unrepresentable at compile time**. A single `resolveSummonAnonymity` owns the `incognito ?? isWeighIn` default.

- **`ContextAssembler`** resolves the union once; the cross-channel gate narrows on `summon.kind === 'personal'`, making the persona non-null inside the call — **the runtime throw is deleted** (provably unreachable).
- **`buildConversationContext`** resolves once for the memory consumers; **`MemoryRetriever`** + **`ConversationalRAGService`** switch on `summonAnonymity.kind` instead of re-deriving. The Redis `/memory incognito` session check is separate and untouched.
- **`isWeighIn` stays an independent boolean** — framing ≠ anonymity; a personal weigh-in is valid.

## Scope & deliberate boundaries

- **Worker-side only.** The bot's `MessageContextBuilder` (2 re-derivation sites) is the legacy path epic 2.5d deletes wholesale — refactoring it now is throwaway + conflict risk. The bot already resolves the flags once at the command layer, so it isn't a drift source.
- **Wire shape unchanged.** `JobContext`'s two optional booleans stay (no BullMQ contract change → no in-flight-job risk across a deploy); the union is internal, resolved once per boundary.

## Two refinements vs the approved plan (same intent, less blast radius)

1. **`AssembledCore`/`ContextStep` left unchanged**, union re-resolved in `buildConversationContext`. The only `AssembledCore.activePersonaId` reader is the wire-writeback, and the legacy path forces re-resolution there anyway — carrying the union on `AssembledCore` would save no resolution. The two resolution points (assembler + builder) call the same resolver, so they can't disagree on identical input.
2. **`ConversationContext.summonAnonymity` is optional** (absent → personal, the safe default). Required would have forced anonymity boilerplate onto ~25 `ConversationContext` literals across 8 unrelated test files (PromptBuilder, ContentBudgetManager, …). The production constructor always sets it, so the drift is still killed.

## Tests

- New `summonAnonymity.test.ts`: resolver default-matrix + `@ts-expect-error` compile-time unrepresentability (can't build `{ kind: 'incognito', activePersonaId }`, can't read `.activePersonaId` without narrowing).
- `conversationContextBuilder.test.ts`: the resolution boundary (isWeighIn → incognito, incognito=false → personal).
- `MemoryRetriever`/`ConversationalRAGService` tests shifted from flag-based to mode-based.

common-types (2837) + ai-worker (3292) suites green, both typechecks clean, `pnpm quality` 16/16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)