### PR TITLE
fix(clients): flip gateway read-timeout default to DEFERRED + invert the guard

### DIFF
--- a/packages/clients/src/clients/_generated/user-client.ts
+++ b/packages/clients/src/clients/_generated/user-client.ts
@@ -1995,6 +1995,7 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.getRecentDiagnostics.output,
+      timeoutMs: ROUTE_MANIFEST.getRecentDiagnostics.timeoutMs,
     });
   }
 

--- a/packages/clients/src/clients/transport.test.ts
+++ b/packages/clients/src/clients/transport.test.ts
@@ -115,11 +115,11 @@ describe('callGateway', () => {
     }
   });
 
-  it('defaults read methods (GET) to the short AUTOCOMPLETE timeout', async () => {
+  it('defaults read methods (GET) to the DEFERRED timeout (safe for post-defer reads)', async () => {
     const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
     fetchSpy.mockResolvedValueOnce(jsonResponse({ ok: true }));
     await callGateway(baseOpts);
-    expect(timeoutSpy).toHaveBeenCalledWith(GATEWAY_TIMEOUTS.AUTOCOMPLETE);
+    expect(timeoutSpy).toHaveBeenCalledWith(GATEWAY_TIMEOUTS.DEFERRED);
   });
 
   it('lets an explicit timeoutMs override the method-aware default', async () => {

--- a/packages/clients/src/clients/transport.ts
+++ b/packages/clients/src/clients/transport.ts
@@ -67,7 +67,7 @@ export interface TransportOptions {
   headers?: Record<string, string>;
   /** Request body — JSON-serialized if defined. */
   body?: unknown;
-  /** Request timeout in milliseconds (default: AUTOCOMPLETE). */
+  /** Request timeout in milliseconds (default: DEFERRED for reads, WRITE for writes). */
   timeoutMs?: number;
   /**
    * Optional Zod schema for the success-path response. When supplied,
@@ -105,13 +105,16 @@ export async function callGateway<T>(options: TransportOptions): Promise<Gateway
     onWarn,
   } = options;
 
-  // Method-aware default: mutations default to the WRITE budget, reads to the
-  // short AUTOCOMPLETE budget. This stops a write route that forgets `timeoutMs`
-  // from silently inheriting the 2.5s read default and aborting a slow-but-fine
-  // write. An explicit `timeoutMs` on the route always wins.
+  // Method-aware default: mutations default to the WRITE budget (20s), reads to
+  // the DEFERRED budget (10s). Reads default to DEFERRED — not the tight 2.5s
+  // AUTOCOMPLETE budget — because almost every read is invoked from a DEFERRED
+  // slash command (15-min window); the tight default silently aborted heavy
+  // deferred reads under load. The AUTOCOMPLETE budget is now an explicit opt-in
+  // for the few autocomplete-invoked routes (guarded in routes/manifest.test.ts).
+  // An explicit `timeoutMs` on the route always wins.
   const isWriteMethod = ['post', 'put', 'patch', 'delete'].includes(method.toLowerCase());
   const effectiveTimeoutMs =
-    timeoutMs ?? (isWriteMethod ? GATEWAY_TIMEOUTS.WRITE : GATEWAY_TIMEOUTS.AUTOCOMPLETE);
+    timeoutMs ?? (isWriteMethod ? GATEWAY_TIMEOUTS.WRITE : GATEWAY_TIMEOUTS.DEFERRED);
 
   if (baseUrl.length === 0) {
     return { ok: false, error: 'baseUrl is empty', status: 0 };

--- a/packages/clients/src/routes/admin.ts
+++ b/packages/clients/src/routes/admin.ts
@@ -85,10 +85,9 @@ export const adminRoutes = {
   /**
    * POST /api/admin/db-sync — Apply pending Prisma migrations.
    *
-   * Slow route (multi-second under load) — uses DEFERRED (10s) instead
-   * of the AUTOCOMPLETE default (2500ms). Matches the legacy
-   * `adminFetch('admin/db-sync')` budget so the typed-client cutover
-   * preserves the existing timeout headroom.
+   * Matches the legacy `adminFetch('admin/db-sync')` budget so the typed-client
+   * cutover preserves the existing timeout headroom (the explicit
+   * BULK_OPERATION tier is explained at the timeoutMs field below).
    */
   dbSync: {
     audience: 'admin',

--- a/packages/clients/src/routes/manifest.test.ts
+++ b/packages/clients/src/routes/manifest.test.ts
@@ -8,106 +8,31 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { GATEWAY_TIMEOUTS } from '@tzurot/common-types';
 import { ROUTE_MANIFEST, adminRoutes, internalRoutes, userRoutes } from './manifest.js';
 import type { AnyRouteDef } from './types.js';
 
 const entries = Object.entries(ROUTE_MANIFEST) as [string, AnyRouteDef][];
 
 /**
- * Route IDs asserting "this op is fast enough for the method-aware transport
- * default" (single-row CRUD, toggles, single lookups). The default is method-
- * aware: GET routes get AUTOCOMPLETE (2.5s), write methods get WRITE (20s).
- * Slow / external / bulk / aggregate routes must NOT be listed — they declare
- * an explicit `timeoutMs` (DEFERRED/BULK) to make their budget a conscious
- * decision rather than leaning on the default.
+ * Route IDs that deliberately use the tight AUTOCOMPLETE budget (2.5s).
+ *
+ * The transport read default is DEFERRED (10s) — safe for the common case where
+ * a call is invoked post-defer. The AUTOCOMPLETE budget is the DANGEROUS tier:
+ * it aborts a call that legitimately takes >2.5s under load (the class behind
+ * the /inspect diagnostic timeout). A route may only opt into it by being
+ * registered here, asserting "this call MUST fail fast at 2.5s."
+ *
+ * Currently only `resolveUserLlmConfig` — a fail-fast hot-path call that runs
+ * BEFORE deferReply and must degrade (fall back to personality defaults) rather
+ * than stall the message pipeline.
+ *
+ * Note: routes invoked from Discord autocomplete do NOT belong here despite the
+ * tier's name. Discord bounds the autocomplete side at 3s client-side regardless
+ * of the gateway budget, so they correctly sit on DEFERRED (and are typically
+ * dual-called from deferred browse anyway).
  */
-const DEFAULT_TIMEOUT_OK = new Set<string>([
-  // ---- internal (service-to-service single lookups / job introspection) ----
-  // aiTranscribe is a sync STT wait (up to 240s) but is invoked via the raw-fetch
-  // path in gatewayServiceCalls.ts (its own AbortSignal/retry), never the typed
-  // service-client — so the transport's manifest default is never applied to it.
-  'aiTranscribe',
-  'aiJobStatus',
-  'recentUsers',
-  // ---- admin (single-row CRUD / toggles / singleton reads) ----
-  'invalidateCache',
-  'createGlobalPersonality',
-  'updateGlobalPersonality',
-  'addDenylistEntry',
-  'listDenylistEntries',
-  'removeDenylistEntry',
-  'createGlobalLlmConfig',
-  'setGlobalLlmConfigDefault',
-  'setGlobalLlmConfigFreeDefault',
-  'deleteGlobalLlmConfig',
-  'listGlobalTtsConfigs',
-  'getGlobalTtsConfig',
-  'createGlobalTtsConfig',
-  'updateGlobalTtsConfig',
-  'setGlobalTtsConfigDefault',
-  'setGlobalTtsConfigFreeDefault',
-  'deleteGlobalTtsConfig',
-  'getAdminSettings',
-  'updateAdminSettings',
-  'clearAdminSettings',
-  'getStopSequencesStats',
-  'getAdminUsageStats',
-  // ---- user: TTS config / STT default (single-row CRUD by indexed key) ----
-  'getUserTtsConfig',
-  'createUserTtsConfig',
-  'updateUserTtsConfig',
-  'deleteUserTtsConfig',
-  'getTtsDefaultConfig',
-  'getSttDefaultProvider',
-  // ---- user: personality CRUD (single-row by slug) ----
-  'createPersonality',
-  'updatePersonality',
-  'setPersonalityVisibility',
-  'deletePersonality',
-  // ---- user: channel activation + per-channel overrides (single-row) ----
-  'activateChannel',
-  'deactivateChannel',
-  'listUserChannels',
-  'getUserChannel',
-  'updateChannelGuild',
-  'getChannelConfigOverrides',
-  'updateChannelConfigOverrides',
-  'clearChannelConfigOverrides',
-  // ---- user: usage + history (single-key reads / scoped deletes) ----
-  'getUserUsage',
-  'clearHistory',
-  'undoHistory',
-  'getHistoryStats',
-  'hardDeleteHistory',
-  // ---- user: NSFW verification (single-row toggle/read) ----
-  'getNsfwStatus',
-  'verifyNsfw',
-  // ---- user: memory CRUD + batch (single-row ops + token-gated batches) ----
-  'getStats',
-  'list',
-  'getFocus',
-  'setFocus',
-  'search',
-  'batchDeletePreview',
-  'batchDelete',
-  'issuePurgeToken',
-  'purge',
-  'getMemory',
-  'updateMemory',
-  'deleteMemory',
-  'setMemoryLock',
-  'getIncognitoStatus',
-  'enableIncognito',
-  'disableIncognito',
-  'incognitoForget',
-  // ---- user: single-tier config-override clear ----
-  'clearPersonalityOverrides',
-  // ---- user: diagnostic lookups (single-row by indexed key) ----
-  'getRecentDiagnostics',
-  'getDiagnosticByMessage',
-  'getDiagnosticByResponse',
-  'getDiagnosticByRequestId',
-]);
+const AUTOCOMPLETE_TIER = new Set<string>(['resolveUserLlmConfig']);
 
 describe('central route manifest', () => {
   it('has at least one entry from each audience', () => {
@@ -217,45 +142,38 @@ describe('central route manifest', () => {
     }
   });
 
-  it('every route either declares timeoutMs or is registered as default-timeout-OK', () => {
-    // Forcing function against the "silent default-timeout regression" class:
-    // the typed-client transport applies a method-aware default when a route
-    // omits `timeoutMs` — AUTOCOMPLETE (2.5s) for GET, WRITE (20s) for write
-    // methods. A route that legitimately needs more than its method default
-    // (external round-trips, multi-tier cascade, bulk work) but forgets an
-    // explicit `timeoutMs` can silently fall back and report false
-    // "Request timeout (HTTP 0)" failures on operations that actually
-    // completed server-side. This test makes the fall-back a CONSCIOUS
-    // decision: a route with no explicit timeoutMs must be registered in
-    // DEFAULT_TIMEOUT_OK above (asserting "the method-aware default suffices").
+  it('only AUTOCOMPLETE_TIER routes use the tight AUTOCOMPLETE budget', () => {
+    // The read default is DEFERRED (10s, safe). The AUTOCOMPLETE budget (2.5s) is
+    // the dangerous tier — it aborts a read that takes >2.5s under load (the
+    // class behind the /inspect prod timeout). A route may only opt into it by
+    // being registered in AUTOCOMPLETE_TIER above. Forgetting `timeoutMs` lands
+    // on the safe DEFERRED default; declaring AUTOCOMPLETE without registering
+    // fails here.
     for (const [key, route] of entries) {
-      const ok = route.timeoutMs !== undefined || DEFAULT_TIMEOUT_OK.has(key);
-      expect(
-        ok,
-        `${key} has neither an explicit timeoutMs nor an entry in DEFAULT_TIMEOUT_OK. ` +
-          `If this op is slow / external / bulk / multi-tier, add a timeoutMs ` +
-          `(e.g. GATEWAY_TIMEOUTS.DEFERRED). If it is genuinely fast (single-row ` +
-          `CRUD by indexed key, toggle, single lookup, simple insert), register ` +
-          `its id in DEFAULT_TIMEOUT_OK. Do NOT leave it to silently fall back ` +
-          `to the method-aware transport default (AUTOCOMPLETE for GET, WRITE for mutations).`
-      ).toBe(true);
+      if (route.timeoutMs === GATEWAY_TIMEOUTS.AUTOCOMPLETE) {
+        expect(
+          AUTOCOMPLETE_TIER.has(key),
+          `${key} declares timeoutMs: GATEWAY_TIMEOUTS.AUTOCOMPLETE (2.5s) but is not in ` +
+            `AUTOCOMPLETE_TIER. The tight autocomplete budget aborts slow-but-fine reads — ` +
+            `use GATEWAY_TIMEOUTS.DEFERRED unless this route is autocomplete-ONLY and a ` +
+            `slower response is useless.`
+        ).toBe(true);
+      }
     }
   });
 
-  it('DEFAULT_TIMEOUT_OK contains no stale entries (every id exists and lacks timeoutMs)', () => {
-    // Guard the inverse drift: an id removed from the manifest, or one that
-    // later gained an explicit timeoutMs, should not linger in the allowlist.
+  it('AUTOCOMPLETE_TIER contains no stale entries (every id exists and declares AUTOCOMPLETE)', () => {
     const manifestIds = new Set(entries.map(([key]) => key));
-    for (const id of DEFAULT_TIMEOUT_OK) {
+    for (const id of AUTOCOMPLETE_TIER) {
       expect(
         manifestIds.has(id),
-        `DEFAULT_TIMEOUT_OK lists "${id}" but it is not in the manifest`
+        `AUTOCOMPLETE_TIER lists "${id}" but it is not in the manifest`
       ).toBe(true);
       const route = ROUTE_MANIFEST[id as keyof typeof ROUTE_MANIFEST] as AnyRouteDef | undefined;
       expect(
         route?.timeoutMs,
-        `DEFAULT_TIMEOUT_OK lists "${id}" but it now declares an explicit timeoutMs — drop it from the allowlist`
-      ).toBeUndefined();
+        `AUTOCOMPLETE_TIER lists "${id}" but it does not declare timeoutMs: AUTOCOMPLETE`
+      ).toBe(GATEWAY_TIMEOUTS.AUTOCOMPLETE);
     }
   });
 

--- a/packages/clients/src/routes/types.ts
+++ b/packages/clients/src/routes/types.ts
@@ -266,26 +266,24 @@ export interface RouteDef<
    */
   readonly requiresProvisionedUser?: boolean;
   /**
-   * Request timeout in milliseconds. When set, the generated client
-   * method passes this value to `callGateway`'s `timeoutMs` parameter,
-   * overriding the transport default of `GATEWAY_TIMEOUTS.AUTOCOMPLETE`
-   * (2500ms — sized for Discord's 3-second autocomplete budget).
+   * Request timeout in milliseconds. When set, the generated client method
+   * passes this to `callGateway`'s `timeoutMs`, overriding the method-aware
+   * transport default: DEFERRED (10s) for reads, WRITE (20s) for writes.
    *
-   * Required for slow routes that legitimately exceed 2500ms — external
-   * round-trips, bulk/aggregate work, multi-second migrations (e.g. `dbSync`,
-   * `cleanup`, the shapes import/export routes). Typically
-   * `GATEWAY_TIMEOUTS.DEFERRED` (10s) or `BULK_OPERATION` (30s).
+   * Reads default to DEFERRED because almost every read is invoked post-defer
+   * (15-min window); the tight AUTOCOMPLETE budget (2.5s) is the DANGEROUS tier
+   * and is opt-in only — register the id in `AUTOCOMPLETE_TIER` in
+   * `manifest.test.ts`, for autocomplete-ONLY routes where a slower response is
+   * useless. Omitting `timeoutMs` is now safe (it lands on DEFERRED/WRITE).
+   *
+   * Set an explicit value to: (a) widen a known-heavy op past the 10s read
+   * default — `GATEWAY_TIMEOUTS.BULK_OPERATION` (30s) for batched/external work;
+   * or (b) pin a known-slow read's tier so it isn't coupled to the default.
    *
    * Upper bound: a value above ~60s is a design smell, not a valid config —
    * a sync gateway request that needs more than a minute should be a BullMQ
    * job with push-based result delivery, not a blocking HTTP call. The
    * manifest invariant test caps timeoutMs at 60_000 to enforce this.
-   *
-   * If a route comfortably fits the 2500ms default, do NOT just omit this
-   * field — also register its id in `DEFAULT_TIMEOUT_OK` in `manifest.test.ts`.
-   * That test enforces that relying on the default is a conscious "this op is
-   * fast" decision rather than a silent fallback. Omit + register, or set
-   * timeoutMs — never silently omit.
    */
   readonly timeoutMs?: number;
 }

--- a/packages/clients/src/routes/user/diagnostics.ts
+++ b/packages/clients/src/routes/user/diagnostics.ts
@@ -14,6 +14,7 @@ import { z } from 'zod';
 import {
   DiagnosticLogResponseSchema,
   DiagnosticLogsResponseSchema,
+  GATEWAY_TIMEOUTS,
   RecentDiagnosticLogsResponseSchema,
 } from '@tzurot/common-types';
 import type { RouteDef } from '../types.js';
@@ -34,6 +35,11 @@ export const userDiagnosticRoutes = {
     query: { personalityId: z.string().optional() },
     output: RecentDiagnosticLogsResponseSchema,
     acceptsSubject: true,
+    // Pinned to DEFERRED explicitly: this is a 100-row scan with a per-row JSONB
+    // extraction that can exceed a tight budget under load, so it stays at 10s
+    // even if the read default ever moves. The single-row sibling lookups below
+    // need no such pin — they ride the safe DEFERRED read default.
+    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
     meta: { safeRead: true },
   },
 

--- a/packages/common-types/src/constants/discord.ts
+++ b/packages/common-types/src/constants/discord.ts
@@ -83,13 +83,15 @@ export const DISCORD_LIMITS = {
  * These timeouts are for gateway API calls that must complete
  * within Discord's interaction windows.
  *
- * Read/write policy: GET routes set AUTOCOMPLETE (3s-budget reads) or DEFERRED
- * (post-defer reads). Mutations (POST/PUT/PATCH/DELETE) get WRITE — they can run
+ * Read/write policy: reads default to DEFERRED (10s) — almost every read is
+ * invoked post-defer, so the tight AUTOCOMPLETE budget is opt-in (only for the
+ * few autocomplete-invoked routes, guarded in the clients package's
+ * manifest.test.ts). Mutations (POST/PUT/PATCH/DELETE) get WRITE — they can run
  * validation + multi-table transactions + cache-invalidation cascades, which
- * legitimately exceed the read budgets. The transport applies WRITE as the
- * default for write methods when a route declares no timeout (see
- * `callGateway`), so a new write route can't silently inherit a too-short read
- * default. BULK_OPERATION is the explicit ceiling for batched external-API ops.
+ * legitimately exceed the read budgets. The transport (see `callGateway`)
+ * applies these method-aware defaults when a route declares no timeout, so a
+ * route can't silently inherit a too-short budget. BULK_OPERATION is the
+ * explicit ceiling for batched external-API ops.
  */
 export const GATEWAY_TIMEOUTS = {
   /** Timeout for autocomplete handlers (Discord 3s limit) */


### PR DESCRIPTION
## Problem

`/inspect` timed out in prod. Runtime-confirmed via Railway logs: `GET /api/user/diagnostic/recent` was **aborted by the bot-client at ~2499ms** (`statusCode=null`), then succeeded at 120ms moments later — load-correlated. The DB-pool fix (#1250) is deployed and the pool is **not** saturating; this was purely a **client read-timeout** problem — and a systemic one.

The transport defaulted reads that omit `timeoutMs` to `GATEWAY_TIMEOUTS.AUTOCOMPLETE` (**2500ms**). But almost every read is invoked from a **deferred** slash command (15-min window), not autocomplete — so the 2.5s default was the wrong tier for ~19 deferred reads, and `getRecentDiagnostics` was even allowlisted as "fast." **The dangerous tight budget was the silent default; the safe longer budget was opt-in — backwards.**

## Fix

- **Flip the transport read default** `AUTOCOMPLETE` → `DEFERRED` (10s); writes keep `WRITE` (20s). Monotonically safe: the only fast-deadline caller is autocomplete, already on DEFERRED + bounded by Discord at 3s client-side.
- **Pin `getRecentDiagnostics`** (the reported-bug 100-row JSONB read) to explicit `DEFERRED`; the three single-row sibling lookups ride the new safe default.
- **Invert the structural guard** (`manifest.test.ts`): drop the ~110-entry `DEFAULT_TIMEOUT_OK` allowlist + its two tests; add a small `AUTOCOMPLETE_TIER` set (`{ resolveUserLlmConfig }` — a fail-fast pre-defer hot-path call) + guards that the 2.5s budget is opt-in-only.
- Update stale timeout docs + regenerate the typed clients.

## How it fails safe now

| Scenario | Old (2.5s) | New (10s) |
|---|---|---|
| New deferred GET forgets `timeoutMs` | silent prod abort | works |
| `timeoutMs: AUTOCOMPLETE` on a slow route | no guard | CI fails |

Clients (157), tooling codegen (98), `pnpm quality` all green. Net −68 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)