### PR TITLE
fix(bot-client): tag @Name's typed with a typographic apostrophe

### DIFF
--- a/services/bot-client/src/utils/personalityMentionParser.test.ts
+++ b/services/bot-client/src/utils/personalityMentionParser.test.ts
@@ -246,6 +246,19 @@ describe('personalityMentionParser', () => {
       expect(result).toHaveLength(1);
       expect(result[0].personality.name).toBe('Lilith');
     });
+
+    it("handles @Lilith's typed with a typographic apostrophe (mobile autocorrect)", async () => {
+      const apos = String.fromCharCode(0x2019); // U+2019 RIGHT SINGLE QUOTATION MARK (not ASCII ')
+      const result = await findPersonalityMentions(
+        `@Lilith${apos}s hello`,
+        '@',
+        mockPersonalityService,
+        TEST_USER_ID
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].personality.name).toBe('Lilith');
+    });
   });
 
   describe('Trailing punctuation', () => {
@@ -266,6 +279,18 @@ describe('personalityMentionParser', () => {
       );
       expect(result).toHaveLength(1);
       expect(result[0].personality.name).toBe(expected);
+    });
+
+    it('strips a trailing typographic double-quote (mobile autocorrect)', async () => {
+      const rdquo = String.fromCharCode(0x201d); // U+201D RIGHT DOUBLE QUOTATION MARK
+      const result = await findPersonalityMentions(
+        `@Lilith${rdquo} hello`,
+        '@',
+        mockPersonalityService,
+        TEST_USER_ID
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].personality.name).toBe('Lilith');
     });
   });
 
@@ -371,6 +396,18 @@ describe('personalityMentionParser', () => {
     it("matches @O'Reilly", async () => {
       const result = await findPersonalityMentions(
         "@O'Reilly hello",
+        '@',
+        mockPersonalityService,
+        TEST_USER_ID
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].personality.name).toBe("O'Reilly");
+    });
+
+    it("matches @O'Reilly when typed with a typographic apostrophe", async () => {
+      const apos = String.fromCharCode(0x2019); // U+2019 — normalized to ASCII ' to match the stored name
+      const result = await findPersonalityMentions(
+        `@O${apos}Reilly hello`,
         '@',
         mockPersonalityService,
         TEST_USER_ID

--- a/services/bot-client/src/utils/personalityMentionParser.ts
+++ b/services/bot-client/src/utils/personalityMentionParser.ts
@@ -9,9 +9,10 @@
  * Handles:
  * - Multi-word personalities (`@Bambi Prime`, `@Angel Dust`)
  * - Abbreviation-style names with periods (`@Dr. Gregory House`)
- * - Possessive suffixes (`@Lilith's` → `Lilith`)
+ * - Possessive suffixes (`@Lilith's` → `Lilith`), straight OR typographic apostrophe
  * - Discord markdown wrapping (`*@X*`, `` `@X` ``, `||@X||`, etc.)
  * - Trailing punctuation (`@Lilith,` / `@Lilith?` / `@Lilith.`)
+ * - Typographic "smart" quotes from mobile autocorrect (U+2018/2019/201C/201D → ASCII)
  *
  * Performance: batches all candidate lookups into a single Promise.all() so a
  * message with N mention positions × M candidates each costs one parallel
@@ -30,6 +31,17 @@ const MAX_POTENTIAL_MENTIONS = 10; // Bound on positions scanned per message.
 
 /** Strip possessive suffix ('s) from a name candidate to also try the base form. */
 const POSSESSIVE_SUFFIX = /'s$/i;
+
+/**
+ * Typographic "smart" quotes that mobile keyboards auto-insert for apostrophes
+ * and quotes. Normalized to their ASCII equivalents on the raw capture so the
+ * straight-quote POSSESSIVE_SUFFIX + punctuation strips below also handle them
+ * (e.g. `@Lucifer's` typed on a phone arrives with U+2019, not `'`, so the
+ * possessive strip never produces the `Lucifer` candidate). Bonus: a
+ * smart-quote-typed apostrophe name (`@O'Brien`) then matches its straight-stored form.
+ */
+const SMART_SINGLE_QUOTES = /[\u2018\u2019]/g;
+const SMART_DOUBLE_QUOTES = /[\u201c\u201d]/g;
 
 /**
  * Strip trailing punctuation — full-strip variant. Strips sentence punctuation
@@ -189,7 +201,11 @@ function extractCandidatesByPosition(content: string, escapedChar: string): Cand
       break;
     }
 
-    const captureGroup = match[1] ?? '';
+    // Normalize "smart" quotes to ASCII first so the straight-quote possessive +
+    // punctuation strips below see e.g. `Lucifer's` (U+2019) as `Lucifer's`.
+    const captureGroup = (match[1] ?? '')
+      .replace(SMART_SINGLE_QUOTES, "'")
+      .replace(SMART_DOUBLE_QUOTES, '"');
     const startIndex = match.index ?? 0;
 
     // Strip trailing punctuation from the whole capture before splitting.


### PR DESCRIPTION
## What

Prod bug: a human typed `@Lucifer's` and it didn't tag Lucifer, despite a prior fix that made `@Lilith's` (straight apostrophe) and `@Dr. Helen Wong` (periods) work.

**Root cause (runtime-confirmed):** mobile keyboards auto-convert `'` to the **typographic apostrophe** `'` (U+2019). The mention parser's possessive strip (`POSSESSIVE_SUFFIX = /'s$/i`) and trailing-punctuation strips only contained the **straight ASCII apostrophe** (U+0027), so `Lucifer's` (curly) never got reduced to the `Lucifer` candidate. Confirmed against the actual reported message — the byte after `Lucifer` is U+2019 (charcode 8217).

`BotMessageFilter` is not involved: the message was human-authored (confirmed), so it reached the parser normally.

## Fix

Normalize smart single/double quotes (`U+2018/2019/201C/201D`) to their ASCII equivalents on the raw capture in `extractCandidatesByPosition`, before the existing strip/possessive logic. One preprocessing step rather than editing three regex character classes; the existing logic then handles curly inputs unchanged.

Beyond the reported case, this also fixes trailing curly quotes and lets a smart-quote-typed apostrophe *name* (`@O'Brien`) match its straight-stored form. Periods (`@Dr.`) are untouched. Single point of fix — both callers (`PersonalityTriggerProcessor`, `VoiceMessageProcessor`) route through `findPersonalityMentions`.

## Tests

- New: `@Lilith's` with U+2019 → resolves to Lilith.
- New: `@O'Reilly` typed with U+2019 → matches the straight-stored `O'Reilly`.
- Both built via `String.fromCharCode(0x2019)` (unambiguous, ASCII source).
- All 46 parser tests pass; `pnpm quality` green.

## Verify in prod after merge

Type `@Lucifer's` on mobile → Lucifer should tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)