### PR TITLE
fix(bot-client): add missing error-reply prefix for consistency

### DIFF
--- a/services/bot-client/src/commands/admin/settings.test.ts
+++ b/services/bot-client/src/commands/admin/settings.test.ts
@@ -255,7 +255,7 @@ describe('Admin Settings Dashboard', () => {
       await handleSettings(context);
 
       expect(context.editReply).toHaveBeenCalledWith({
-        content: 'Failed to fetch admin settings.',
+        content: '❌ Failed to fetch admin settings.',
       });
     });
 

--- a/services/bot-client/src/commands/admin/settings.ts
+++ b/services/bot-client/src/commands/admin/settings.ts
@@ -84,7 +84,7 @@ export async function handleSettings(context: DeferredCommandContext): Promise<v
 
     if (settings === null) {
       await context.editReply({
-        content: 'Failed to fetch admin settings.',
+        content: '❌ Failed to fetch admin settings.',
       });
       return;
     }

--- a/services/bot-client/src/commands/character/chat.test.ts
+++ b/services/bot-client/src/commands/character/chat.test.ts
@@ -416,6 +416,18 @@ describe('Character Chat Handler (push delivery)', () => {
       });
       expect(mockJobTracker.trackJob).not.toHaveBeenCalled();
     });
+
+    it('falls back to channel.send when editReply throws during error handling', async () => {
+      const channel = createMockChannel(ChannelType.GuildText);
+      const ctx = createMockContext('test-char', 'Hi', channel);
+      mockPersonalityService.loadPersonality.mockRejectedValueOnce(new Error('boom'));
+      // editReply itself throws → handleChatError's catch falls back to the channel
+      vi.mocked(ctx.editReply).mockRejectedValueOnce(new Error('editReply unavailable'));
+
+      await handleChat(ctx, mockConfig);
+
+      expect(channel.send).toHaveBeenCalledWith(expect.stringContaining('something went wrong'));
+    });
   });
 
   describe('random-pick mode (/character random)', () => {

--- a/services/bot-client/src/commands/character/chat.ts
+++ b/services/bot-client/src/commands/character/chat.ts
@@ -549,12 +549,12 @@ async function handleChatError(context: DeferredCommandContext): Promise<void> {
   try {
     const { interaction } = context;
     if (interaction.replied || interaction.deferred) {
-      await context.editReply({ content: 'Sorry, something went wrong. Please try again.' });
+      await context.editReply({ content: '❌ Sorry, something went wrong. Please try again.' });
     }
   } catch {
     const ch = context.channel;
     if (ch && 'send' in ch && typeof ch.send === 'function') {
-      await ch.send('Sorry, something went wrong. Please try again.');
+      await ch.send('❌ Sorry, something went wrong. Please try again.');
     }
   }
 }

--- a/services/bot-client/src/commands/memory/batchDelete.ts
+++ b/services/bot-client/src/commands/memory/batchDelete.ts
@@ -173,7 +173,7 @@ export async function handleBatchDelete(context: DeferredCommandContext): Promis
 
       if (!deleteResult.ok) {
         await buttonInteraction.editReply({
-          content: `Failed to delete memories: ${deleteResult.error ?? 'Unknown error'}`,
+          content: `❌ Failed to delete memories: ${deleteResult.error ?? 'Unknown error'}`,
           embeds: [],
           components: [],
         });

--- a/services/bot-client/src/commands/memory/purge.ts
+++ b/services/bot-client/src/commands/memory/purge.ts
@@ -274,7 +274,7 @@ async function executePurgeHandshake(
 
   if (!tokenResult.ok) {
     await interaction.editReply({
-      content: `Failed to confirm purge: ${tokenResult.error ?? 'Unknown error'}`,
+      content: `❌ Failed to confirm purge: ${tokenResult.error ?? 'Unknown error'}`,
       embeds: [],
       components: [],
     });
@@ -285,7 +285,7 @@ async function executePurgeHandshake(
 
   if (!purgeResult.ok) {
     await interaction.editReply({
-      content: `Failed to purge memories: ${purgeResult.error ?? 'Unknown error'}`,
+      content: `❌ Failed to purge memories: ${purgeResult.error ?? 'Unknown error'}`,
       embeds: [],
       components: [],
     });


### PR DESCRIPTION
## What

Six user-facing error strings lacked the `❌` prefix that the rest of the command surface uses — purely visual inconsistency:

- `character/chat.ts` — generic chat-error reply (both the `editReply` path and the channel-send fallback)
- `memory/purge.ts` — confirm-purge + purge-memories failures
- `memory/batchDelete.ts` — batch-delete failure
- `admin/settings.ts` — fetch-admin-settings failure

## Scope (deliberately narrow)

From the full UX sweep's error-wording deferral. I **did not** do a wholesale not-found/try-again standardization — on inspection most of that variation is **intentional** (e.g. `Character not found` vs `not found or you do not have access` is a deliberate access-control distinction; `Persona not found. Use /persona browse` adds real guidance). Flattening those would lose meaning. The broader standardization + `replyError()` adoption stay backlogged for the same reason.

## Tests

- `admin/settings.test.ts` assertion updated to the new string.
- Affected suites green (memory/purge, memory/batchDelete, character/chat, admin/settings — 75 tests), `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)