### PR TITLE
fix(ai-worker): exclude the trigger message from assembled history

### DIFF
--- a/services/ai-worker/src/services/context/ContextAssembler.test.ts
+++ b/services/ai-worker/src/services/context/ContextAssembler.test.ts
@@ -173,6 +173,111 @@ describe('ContextAssembler.assembleCore', () => {
     expect(core.history).toHaveLength(1);
   });
 
+  it('excludes the trigger message from the assembled history (it ships as the live turn)', async () => {
+    // bot-client persists the trigger before submitting the job, so the channel
+    // history fetch includes it. The worker must drop it so the message does not
+    // appear both in the assembled history and as the current user turn.
+    const deps = makeDeps({
+      dataSource: {
+        getChannelHistory: vi.fn().mockResolvedValue([
+          {
+            id: 'm-prior',
+            role: MessageRole.User,
+            content: 'earlier message',
+            createdAt: new Date('2026-05-01T00:00:00Z'),
+            discordMessageId: ['d-prior'],
+          },
+          {
+            id: 'm-trigger',
+            role: MessageRole.User,
+            content: 'the message being answered',
+            createdAt: new Date('2026-05-01T00:01:00Z'),
+            discordMessageId: ['d-trigger'],
+          },
+        ]),
+      },
+    });
+    const assembler = new ContextAssembler(deps);
+
+    const core = await assembler.assembleCore(
+      makeJobContext({ triggerMessageId: 'd-trigger' }),
+      PERSONALITY,
+      { maxMessages: 30, maxAge: 7200 } as ResolvedConfigOverrides
+    );
+
+    // Over-fetches limit+1 (31) so dropping the trigger still leaves a full
+    // limit-deep window rather than limit-1.
+    expect(deps.dataSource.getChannelHistory).toHaveBeenCalledWith('chan-1', 31, undefined, 7200);
+    // Only the prior message survives; the trigger row is filtered out.
+    expect(core.history).toHaveLength(1);
+    expect(core.history[0].content).toBe('earlier message');
+  });
+
+  it('keeps history intact when the trigger is set but matches no row (no-match passthrough)', async () => {
+    const deps = makeDeps({
+      dataSource: {
+        getChannelHistory: vi.fn().mockResolvedValue([
+          {
+            id: 'm-x',
+            role: MessageRole.User,
+            content: 'unrelated',
+            createdAt: new Date('2026-05-01T00:00:00Z'),
+            discordMessageId: ['d-other'],
+          },
+        ]),
+      },
+    });
+    const assembler = new ContextAssembler(deps);
+
+    const core = await assembler.assembleCore(
+      makeJobContext({ triggerMessageId: 'd-trigger-not-present' }),
+      PERSONALITY,
+      undefined
+    );
+
+    // triggerMessageId is set but matches no row → nothing is filtered.
+    expect(core.history).toHaveLength(1);
+    expect(core.history[0].content).toBe('unrelated');
+  });
+
+  it('does not over-fetch (no limit+1) when no triggerMessageId is present', async () => {
+    const deps = makeDeps();
+    const assembler = new ContextAssembler(deps);
+
+    await assembler.assembleCore(makeJobContext({ triggerMessageId: undefined }), PERSONALITY, {
+      maxMessages: 30,
+      maxAge: 7200,
+    } as ResolvedConfigOverrides);
+
+    // No trigger → plain `limit`, no +1.
+    expect(deps.dataSource.getChannelHistory).toHaveBeenCalledWith('chan-1', 30, undefined, 7200);
+  });
+
+  it('keeps all history when no triggerMessageId is present', async () => {
+    const deps = makeDeps({
+      dataSource: {
+        getChannelHistory: vi.fn().mockResolvedValue([
+          {
+            id: 'm-a',
+            role: MessageRole.User,
+            content: 'a',
+            createdAt: new Date('2026-05-01T00:00:00Z'),
+            discordMessageId: ['d-a'],
+          },
+        ]),
+      },
+    });
+    const assembler = new ContextAssembler(deps);
+
+    const core = await assembler.assembleCore(
+      makeJobContext({ triggerMessageId: undefined }),
+      PERSONALITY,
+      undefined
+    );
+
+    expect(core.history).toHaveLength(1);
+  });
+
   it('falls back to the username when rawAuthorDisplayName is absent', async () => {
     const deps = makeDeps();
     const assembler = new ContextAssembler(deps);

--- a/services/ai-worker/src/services/context/ContextAssembler.ts
+++ b/services/ai-worker/src/services/context/ContextAssembler.ts
@@ -194,11 +194,31 @@ export class ContextAssembler {
       configOverrides?.maxMessages ?? MESSAGE_LIMITS.DEFAULT_MAX_MESSAGES,
       MESSAGE_LIMITS.MAX_EXTENDED_CONTEXT
     );
-    const dbHistory = await this.deps.dataSource.getChannelHistory(
-      channelId,
-      limit,
-      contextEpoch,
-      configOverrides?.maxAge ?? undefined
+    // Exclude the trigger message from the assembled history. bot-client
+    // persists it to the gateway BEFORE submitting this job (durability for the
+    // next turn), and this hydration runs after — so the just-sent message is
+    // already in the channel history. It is also delivered as the live user
+    // turn, so without this filter it appears twice: once in the assembled
+    // history and again as the current message. (The bot-side history fetch
+    // reads before the persist and never saw it; the worker must drop it here.)
+    //
+    // Fetch one extra row when a trigger is present: it's always the newest row
+    // in the window (just persisted), so filtering it from a plain `limit`
+    // fetch would shrink history to limit-1 and drop the oldest message. The +1
+    // keeps a full limit-deep window after the filter. (A rare no-match — the
+    // trigger isn't in the DB — leaves limit+1, which is harmless.)
+    const triggerMessageId = jobContext.triggerMessageId;
+    const fetchLimit = triggerMessageId !== undefined ? limit + 1 : limit;
+    const dbHistory = (
+      await this.deps.dataSource.getChannelHistory(
+        channelId,
+        fetchLimit,
+        contextEpoch,
+        configOverrides?.maxAge ?? undefined
+      )
+    ).filter(
+      msg =>
+        triggerMessageId === undefined || !(msg.discordMessageId ?? []).includes(triggerMessageId)
     );
 
     // Step 4: envelope-carried extended context — batch-upsert the observed


### PR DESCRIPTION
## Summary

Fixes a duplication regression: the user's current message appears **twice** in the LLM call — once baked into the system-prompt `<chat_log>` and again as the live user turn.

## Mechanism (runtime-confirmed)

bot-client orders the flow: `buildContext` → `persist trigger` → `submit job`. The worker's `ContextAssembler` hydrates channel history **after** the persist, so the just-sent message is already in the history — and the assembler never filtered it out, even though it has `jobContext.triggerMessageId`.

- **Legacy flow**: the bot assembled history during `buildContext` (before the persist) → trigger excluded.
- **Service mode**: the worker re-reads history after the persist → trigger included → duplicated.

This was confirmed from a prod `/inspect`: the trigger was the last `<message>` in the assembled chat log **and** the separate user turn. It also violates the prompt's own `<constraint>Never repeat or parrot back…</constraint>`. Regression introduced by the 2.5d service-mode cutover; affects every message with history.

## Fix

Filter `dbHistory` by `jobContext.triggerMessageId` in `ContextAssembler` (the persisted trigger row carries it in `discordMessageId`, normalized to `string[]` on read). Localized to the assembler — the right layer, since only the worker reads *after* the persist; cross-channel history already excludes this channel.

## Testing

- New `ContextAssembler` tests: trigger row excluded from `core.history`; no-`triggerMessageId` passthrough unchanged.
- Full ai-worker suite green (3241), typecheck + `pnpm quality` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)