### PR TITLE
debug(bot-client): log embed image URL raw vs proxy fields

### DIFF
--- a/services/bot-client/src/utils/embedImageExtractor.ts
+++ b/services/bot-client/src/utils/embedImageExtractor.ts
@@ -6,7 +6,14 @@
  */
 
 import { Embed } from 'discord.js';
-import { type AttachmentMetadata, CONTENT_TYPES, EMBED_NAMING } from '@tzurot/common-types';
+import {
+  createLogger,
+  type AttachmentMetadata,
+  CONTENT_TYPES,
+  EMBED_NAMING,
+} from '@tzurot/common-types';
+
+const logger = createLogger('embedImageExtractor');
 
 /**
  * Extract image and thumbnail URLs from Discord embeds as attachment metadata
@@ -21,6 +28,19 @@ export function extractEmbedImages(embeds: Embed[] | undefined): AttachmentMetad
   const imageAttachments: AttachmentMetadata[] = [];
 
   for (const embed of embeds) {
+    // DEBUG (temporary): capture the raw vs proxy URLs Discord hands us, to
+    // diagnose the &amp;-encoded Reddit/og:image embed URLs that 403 in the
+    // vision fetch. Remove once the embed→vision URL fix lands.
+    logger.info(
+      {
+        imageRawUrl: embed.image?.url,
+        imageProxyUrl: embed.image?.proxyURL,
+        thumbRawUrl: embed.thumbnail?.url,
+        thumbProxyUrl: embed.thumbnail?.proxyURL,
+        embedSourceUrl: embed.url,
+      },
+      'DEBUG embed image URL fields'
+    );
     // Prefer proxyURL: Discord re-hosts external embed images on media.discordapp.net,
     // which satisfies our strict CDN allowlist. `url` is the original source (e.g. Reddit,
     // Imgur) and will be rejected. Fall back to `url` only when proxyURL is absent —


### PR DESCRIPTION
## Purpose

Temporary diagnostic instrumentation (`debug` type — added now, removed in a cleanup PR once the fix lands) to confirm the mechanism behind the prod vision `bad_request` on Reddit/`og:image` embeds.

## Background

A prod `/inspect` + ai-worker log showed all 4 embed images from a vxReddit link failed: OpenRouter got a **403** fetching `images-ext-1.discordapp.net/external/<sig>/…%26amp%3B…/https/i.redd.it/…` — i.e. the proxied source URL carried HTML-encoded `&amp;` (`%26amp%3B`), which breaks Reddit's signed query and 403s.

Confirmed *not* a CDN-allowlist issue: the vision path (`VisionProcessor`) passes the URL straight to OpenRouter with no `ALLOWED_HOSTS` check, so the allowlist isn't in this path. The fix will be to HTML-decode the `&amp;` — but I want to see what `embed.image.url` (the original, non-proxy) actually contains before writing it, rather than assume.

## What this logs

In `extractEmbedImages`, one `logger.info` per embed with `embed.image.url`, `embed.image.proxyURL`, the thumbnail equivalents, and `embed.url`. A dev repro of the same vxReddit link will reveal exactly what Discord hands us → I write (and verify) the decode fix → remove this logging.

## Next steps

1. Merge → dev auto-deploys.
2. Repro the vxReddit link on dev.
3. Read the logged fields, write the decode fix (separate PR), remove this logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)