### PR TITLE
chore(deps): bump undici override to ^6.27.0 (clears 4 CVEs)

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
       "*eslint*"
     ],
     "overrides": {
-      "undici": "~6.24.0",
+      "undici": "^6.27.0",
       "path-to-regexp@>=8.0.0 <8.4.0": ">=8.4.0",
       "ioredis": "^5.10.0",
       "minimatch@<3.1.4": ">=3.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  undici: ~6.24.0
+  undici: ^6.27.0
   path-to-regexp@>=8.0.0 <8.4.0: '>=8.4.0'
   ioredis: ^5.10.0
   minimatch@<3.1.4: '>=3.1.4'
@@ -5012,8 +5012,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@6.24.1:
-    resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
   unicorn-magic@0.4.0:
@@ -5582,7 +5582,7 @@ snapshots:
       discord-api-types: 0.38.48
       magic-bytes.js: 1.13.0
       tslib: 2.8.1
-      undici: 6.24.1
+      undici: 6.27.0
 
   '@discordjs/util@1.2.0':
     dependencies:
@@ -7551,7 +7551,7 @@ snapshots:
       lodash.snakecase: 4.1.1
       magic-bytes.js: 1.13.0
       tslib: 2.8.1
-      undici: 6.24.1
+      undici: 6.27.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -9770,7 +9770,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@6.24.1: {}
+  undici@6.27.0: {}
 
   unicorn-magic@0.4.0: {}
 


### PR DESCRIPTION
## What

Bumps the root `pnpm.overrides` entry `"undici": "~6.24.0"` → `"^6.27.0"` and relocks. undici resolves to exactly **6.27.0** (single version, no fragmentation).

## Why

GitHub Dependabot flagged 4 undici advisories — all fixed in 6.27.0:

| Severity | Advisory |
|---|---|
| High | GHSA-vxpw-j846-p89q |
| Medium | GHSA-p88m-4jfj-68fv |
| Low | GHSA-35p6-xmwp-9g52 |
| Low | GHSA-g8m3-5g58-fq7m |

undici is transitive, but the existing `~6.24.0` override (itself a security floor added 2026-04-05 to fix 5 WebSocket CVEs) was *holding* it at the vulnerable 6.24.1 — the tight `~` pin is exactly why the new advisories couldn't auto-resolve.

## The `~` → `^` change

Switched from the tight `~6.24.0` to `^6.27.0` (`>=6.27.0 <7.0.0`) so future undici **6.x** security patches resolve automatically rather than needing a manual override bump each CVE cycle. This is the second such manual bump; the `~` pin is the reason we were back here. Staying in v6 keeps it semver-compatible with the transitive consumer.

## Verification

- `pnpm install` relocks cleanly (`+1 -1`), undici → 6.27.0 in all 4 lockfile spots.
- `pnpm quality` green (16/16 — full typecheck + typecheck:spec, lint, depcruise, knip, cpd, backlog:lint). Confirms API compatibility + clean build.
- Deps-only change (no source edits); unit tests mock all external HTTP, so undici isn't exercised at runtime by them — typecheck is the meaningful local signal, full suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)