### PR TITLE
feat(api-gateway): add POST /internal/v1/routing-context (2.5d Phase 1)

### DIFF
--- a/packages/clients/src/clients/_generated/service-client.ts
+++ b/packages/clients/src/clients/_generated/service-client.ts
@@ -174,6 +174,19 @@ export class ServiceClient {
     });
   }
 
+  async routingContextCreate(input: z.infer<typeof ROUTE_MANIFEST.routingContextCreate.input>): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.routingContextCreate.output>>> {
+    const fullPath = '/api/internal/v1/routing-context';
+    return callGateway({
+      baseUrl: this.baseUrl,
+      serviceSecret: this.serviceSecret,
+      method: 'POST',
+      path: fullPath,
+      body: input,
+      outputSchema: ROUTE_MANIFEST.routingContextCreate.output,
+      timeoutMs: ROUTE_MANIFEST.routingContextCreate.timeoutMs,
+    });
+  }
+
   /**
    * @safeRead Server-side has no observable mutation — safe to cache client-side.
    */

--- a/packages/clients/src/routes/internal.ts
+++ b/packages/clients/src/routes/internal.ts
@@ -37,6 +37,8 @@ import {
   PersistUserMessageRequestSchema,
   PersistUserMessageResponseSchema,
   RecentUsersResponseSchema,
+  RoutingContextRequestSchema,
+  RoutingContextResponseSchema,
   TIMEOUTS,
   TranscribeRequestSchema,
 } from '@tzurot/common-types';
@@ -227,6 +229,27 @@ export const internalRoutes = {
     output: LoadPersonalityInternalResponseSchema,
     serviceOnly: true,
     meta: { safeRead: true },
+    timeoutMs: TIMEOUTS.GATEWAY_RPC,
+  },
+
+  /**
+   * POST /api/internal/v1/routing-context
+   * Hot-path routing read: resolves the per-(user, personality) routing facts a
+   * message needs before job dispatch — internal user UUID, active persona
+   * (override → default cascade), persona display name, timezone, STM
+   * context-epoch — and provisions the user + default persona on first contact
+   * (idempotent upsert keyed on discordId, hence POST not GET). Consolidated
+   * because the reads are sequentially dependent; one round-trip replaces the
+   * ~4 serialized hops per-read routes would cost on the hottest path.
+   */
+  routingContextCreate: {
+    audience: 'internal',
+    method: 'post',
+    path: '/v1/routing-context',
+    id: 'routingContextCreate',
+    input: RoutingContextRequestSchema,
+    output: RoutingContextResponseSchema,
+    serviceOnly: true,
     timeoutMs: TIMEOUTS.GATEWAY_RPC,
   },
 

--- a/packages/common-types/src/index.ts
+++ b/packages/common-types/src/index.ts
@@ -99,6 +99,7 @@ export * from './utils/messageLinkParser.js';
 export * from './utils/mentionRewriter.js';
 export * from './utils/crossChannelEnvironment.js';
 export * from './services/UserService.js';
+export * from './services/RoutingContextResolver.js';
 export * from './services/BaseCacheInvalidationService.js';
 export * from './services/CacheInvalidationService.js';
 export * from './services/ApiKeyCacheInvalidationService.js';

--- a/packages/common-types/src/schemas/api/internal.test.ts
+++ b/packages/common-types/src/schemas/api/internal.test.ts
@@ -12,6 +12,8 @@ import {
   ConversationSyncRequestSchema,
   ConversationSyncResponseSchema,
   LoadPersonalityInternalResponseSchema,
+  RoutingContextRequestSchema,
+  RoutingContextResponseSchema,
 } from './internal.js';
 
 describe('DiscordSnowflakeSchema', () => {
@@ -442,6 +444,65 @@ describe('LoadPersonalityInternalResponseSchema', () => {
     expect(
       LoadPersonalityInternalResponseSchema.safeParse({ personality: { id: 'x', name: 'y' } })
         .success
+    ).toBe(false);
+  });
+});
+
+describe('RoutingContextRequestSchema', () => {
+  const valid = {
+    discordId: '278863839632818186',
+    username: 'lila',
+    displayName: 'Lila',
+    personalityId: 'personality-uuid',
+  };
+
+  it('accepts a minimal valid request (isBot omitted)', () => {
+    expect(RoutingContextRequestSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('accepts an explicit isBot flag', () => {
+    expect(RoutingContextRequestSchema.safeParse({ ...valid, isBot: true }).success).toBe(true);
+  });
+
+  it('rejects an empty discordId', () => {
+    expect(RoutingContextRequestSchema.safeParse({ ...valid, discordId: '' }).success).toBe(false);
+  });
+
+  it('rejects a missing personalityId', () => {
+    const { personalityId: _omit, ...withoutPersonality } = valid;
+    expect(RoutingContextRequestSchema.safeParse(withoutPersonality).success).toBe(false);
+  });
+});
+
+describe('RoutingContextResponseSchema', () => {
+  const valid = {
+    userId: '550e8400-e29b-41d4-a716-446655440000',
+    personaId: 'persona-uuid',
+    personaName: 'Nyx',
+    timezone: 'UTC',
+    contextEpoch: '2026-06-20T00:00:00.000Z',
+  };
+
+  it('accepts a fully-populated bundle', () => {
+    expect(RoutingContextResponseSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('accepts null personaName and null contextEpoch', () => {
+    expect(
+      RoutingContextResponseSchema.safeParse({ ...valid, personaName: null, contextEpoch: null })
+        .success
+    ).toBe(true);
+  });
+
+  it('rejects a non-UUID userId', () => {
+    expect(RoutingContextResponseSchema.safeParse({ ...valid, userId: 'not-a-uuid' }).success).toBe(
+      false
+    );
+  });
+
+  it('rejects a non-ISO contextEpoch', () => {
+    expect(
+      RoutingContextResponseSchema.safeParse({ ...valid, contextEpoch: 'yesterday' }).success
     ).toBe(false);
   });
 });

--- a/packages/common-types/src/schemas/api/internal.ts
+++ b/packages/common-types/src/schemas/api/internal.ts
@@ -195,3 +195,59 @@ export const LoadPersonalityInternalResponseSchema = z.object({
   personality: loadedPersonalitySchema.nullable(),
 });
 export type LoadPersonalityInternalResponse = z.infer<typeof LoadPersonalityInternalResponseSchema>;
+
+// ============================================================================
+// POST /internal/v1/routing-context
+// Hot-path routing read: resolves the per-(user, personality) routing facts a
+// message needs BEFORE the AI job is dispatched — internal user UUID, active
+// persona (override → default cascade), persona display name, user timezone,
+// and the STM context-epoch. Provisions the user + default persona on first
+// contact (idempotent upsert keyed on discordId). Consolidated into one
+// endpoint because the reads are sequentially dependent (UUID → cascade →
+// epoch); per-read routes would cost ~4 serialized HTTP hops on the single
+// most latency-sensitive path in the system. The persona cascade runs here,
+// where Prisma is legal, instead of being reimplemented in bot-client.
+//
+// Versioned (/v1/) — the response is the routing contract bot-client depends
+// on; evolve it additively only.
+// ============================================================================
+
+export const RoutingContextRequestSchema = z.object({
+  /** Message author's Discord snowflake — the provisioning + cascade key. */
+  discordId: z.string().min(1).max(32),
+  /**
+   * Discord username, for provisioning the user shell on first contact. Not
+   * `.min(1)`-constrained: Discord usernames are always non-empty at the
+   * call-site, so the cap is the only real bound.
+   */
+  username: z.string().max(255),
+  /**
+   * Display name, for seeding the default persona's name on first contact.
+   * May legitimately be blank (a user without a global display name), so it is
+   * intentionally NOT `.min(1)`-constrained.
+   */
+  displayName: z.string().max(255),
+  /** True for bot authors; provisioning rejects them (returns 400). */
+  isBot: z.boolean().optional(),
+  /** Target personality whose persona cascade to resolve (deterministic UUID). */
+  personalityId: z.string().min(1).max(64),
+});
+export type RoutingContextRequest = z.infer<typeof RoutingContextRequestSchema>;
+
+export const RoutingContextResponseSchema = z.object({
+  /** Internal user UUID (FK for everything downstream). */
+  userId: z.string().uuid(),
+  /**
+   * Resolved active persona UUID (override → default cascade). Not `.uuid()`-
+   * constrained: the system-default fallback carries an empty string, which the
+   * epoch lookup treats as a non-matching key.
+   */
+  personaId: z.string(),
+  /** Persona display name; null when the cascade has no preferred name. */
+  personaName: z.string().nullable(),
+  /** IANA timezone; `getUserTimezone` falls back to 'UTC', so always present. */
+  timezone: z.string(),
+  /** STM context-epoch (last-reset) as ISO; null when no reset is recorded. */
+  contextEpoch: z.string().datetime().nullable(),
+});
+export type RoutingContextResponse = z.infer<typeof RoutingContextResponseSchema>;

--- a/packages/common-types/src/services/RoutingContextResolver.test.ts
+++ b/packages/common-types/src/services/RoutingContextResolver.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { resolveRoutingContext, type RoutingContextDeps } from './RoutingContextResolver.js';
+import type { PrismaClient } from './prisma.js';
+import type { UserService } from './UserService.js';
+import type { PersonaResolver } from './resolvers/PersonaResolver.js';
+import type { RoutingContextRequest } from '../schemas/api/internal.js';
+
+const REQUEST: RoutingContextRequest = {
+  discordId: '278863839632818186',
+  username: 'lila',
+  displayName: 'Lila',
+  personalityId: 'personality-uuid',
+};
+
+function buildDeps(overrides?: {
+  getOrCreateUser?: ReturnType<typeof vi.fn>;
+  getUserTimezone?: ReturnType<typeof vi.fn>;
+  resolve?: ReturnType<typeof vi.fn>;
+  findUnique?: ReturnType<typeof vi.fn>;
+}): {
+  deps: RoutingContextDeps;
+  getOrCreateUser: ReturnType<typeof vi.fn>;
+  resolve: ReturnType<typeof vi.fn>;
+  findUnique: ReturnType<typeof vi.fn>;
+} {
+  const getOrCreateUser =
+    overrides?.getOrCreateUser ??
+    vi.fn().mockResolvedValue({ userId: 'user-uuid', defaultPersonaId: 'default-persona' });
+  const getUserTimezone = overrides?.getUserTimezone ?? vi.fn().mockResolvedValue('UTC');
+  const resolve =
+    overrides?.resolve ??
+    vi.fn().mockResolvedValue({
+      config: { personaId: 'persona-uuid', preferredName: 'Nyx' },
+      source: 'user-default',
+    });
+  const findUnique = overrides?.findUnique ?? vi.fn().mockResolvedValue(null);
+
+  const userService = { getOrCreateUser, getUserTimezone } as unknown as UserService;
+  const personaResolver = { resolve } as unknown as PersonaResolver;
+  const prisma = {
+    userPersonaHistoryConfig: { findUnique },
+  } as unknown as PrismaClient;
+
+  return { deps: { userService, personaResolver, prisma }, getOrCreateUser, resolve, findUnique };
+}
+
+describe('resolveRoutingContext', () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it('resolves the full routing bundle for a provisioned user', async () => {
+    const { deps, resolve, findUnique } = buildDeps({
+      findUnique: vi.fn().mockResolvedValue({ lastContextReset: new Date('2026-06-20T00:00:00Z') }),
+    });
+
+    const result = await resolveRoutingContext(deps, REQUEST);
+
+    expect(result).toEqual({
+      userId: 'user-uuid',
+      personaId: 'persona-uuid',
+      personaName: 'Nyx',
+      timezone: 'UTC',
+      contextEpoch: '2026-06-20T00:00:00.000Z',
+    });
+    // Cascade is keyed on the DISCORD id + personalityId, not the internal UUID.
+    expect(resolve).toHaveBeenCalledWith('278863839632818186', 'personality-uuid');
+    // Epoch lookup keys on the resolved internal UUID + persona, not the discord id.
+    expect(findUnique).toHaveBeenCalledWith({
+      where: {
+        userId_personalityId_personaId: {
+          userId: 'user-uuid',
+          personalityId: 'personality-uuid',
+          personaId: 'persona-uuid',
+        },
+      },
+      select: { lastContextReset: true },
+    });
+  });
+
+  it('returns null when the author is a bot (provisioning refuses)', async () => {
+    const { deps, resolve } = buildDeps({ getOrCreateUser: vi.fn().mockResolvedValue(null) });
+
+    const result = await resolveRoutingContext(deps, { ...REQUEST, isBot: true });
+
+    expect(result).toBeNull();
+    // Short-circuits before the cascade — no persona work for a rejected bot.
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it('returns null contextEpoch when no reset is recorded', async () => {
+    const { deps } = buildDeps(); // findUnique defaults to null
+
+    const result = await resolveRoutingContext(deps, REQUEST);
+
+    expect(result?.contextEpoch).toBeNull();
+  });
+
+  it('passes a null preferredName through as personaName', async () => {
+    const { deps } = buildDeps({
+      resolve: vi.fn().mockResolvedValue({
+        config: { personaId: 'persona-uuid', preferredName: null },
+        source: 'system-default',
+      }),
+    });
+
+    const result = await resolveRoutingContext(deps, REQUEST);
+
+    expect(result?.personaName).toBeNull();
+  });
+
+  it('forwards isBot=false default to provisioning', async () => {
+    const { deps, getOrCreateUser } = buildDeps();
+
+    await resolveRoutingContext(deps, REQUEST); // no isBot in REQUEST
+
+    expect(getOrCreateUser).toHaveBeenCalledWith(
+      '278863839632818186',
+      'lila',
+      'Lila',
+      undefined,
+      false
+    );
+  });
+});

--- a/packages/common-types/src/services/RoutingContextResolver.ts
+++ b/packages/common-types/src/services/RoutingContextResolver.ts
@@ -1,0 +1,104 @@
+/**
+ * Routing-context resolver
+ *
+ * The server-side orchestration behind `POST /api/internal/v1/routing-context`.
+ * Resolves the per-(user, personality) routing facts a Discord message needs
+ * before the AI job is dispatched: internal user UUID (provisioning the user +
+ * default persona on first contact), the active persona via the override →
+ * default cascade, the persona display name, the user timezone, and the STM
+ * context-epoch.
+ *
+ * This is the relocation of bot-client's former `resolveUserContext` — the
+ * cascade now runs where Prisma is legal (the gateway) instead of being
+ * reimplemented behind a `PrismaClient` injected into bot-client. The reads are
+ * sequentially dependent (UUID → cascade → epoch), so consolidating them here
+ * collapses ~4 serialized HTTP hops on the hot path into one round-trip.
+ */
+
+import { type PrismaClient } from './prisma.js';
+import type { UserService } from './UserService.js';
+import type { PersonaResolver } from './resolvers/PersonaResolver.js';
+import { createLogger } from '../utils/logger.js';
+import type { RoutingContextRequest, RoutingContextResponse } from '../schemas/api/internal.js';
+
+const logger = createLogger('RoutingContextResolver');
+
+/** Collaborators for {@link resolveRoutingContext}. */
+export interface RoutingContextDeps {
+  userService: UserService;
+  personaResolver: PersonaResolver;
+  prisma: PrismaClient;
+}
+
+/**
+ * Look up the STM context-epoch (last-reset timestamp) for a
+ * (user, personality, persona) triple. Returns `undefined` when no reset has
+ * been recorded — the common case. A system-default persona (`personaId === ''`)
+ * never matches a row, which mirrors the pre-relocation behaviour.
+ */
+async function lookupContextEpoch(
+  prisma: PrismaClient,
+  userId: string,
+  personalityId: string,
+  personaId: string
+): Promise<Date | undefined> {
+  const historyConfig = await prisma.userPersonaHistoryConfig.findUnique({
+    where: {
+      userId_personalityId_personaId: { userId, personalityId, personaId },
+    },
+    select: { lastContextReset: true },
+  });
+  return historyConfig?.lastContextReset ?? undefined;
+}
+
+/**
+ * Resolve the routing context for a message author + target personality.
+ *
+ * Returns `null` when the author is a bot — `getOrCreateUser` refuses to
+ * provision bots, and the caller returns 400. Otherwise provisioning is
+ * idempotent (upsert keyed on `discordId`), so retries and concurrent
+ * first-messages are safe.
+ */
+export async function resolveRoutingContext(
+  deps: RoutingContextDeps,
+  request: RoutingContextRequest
+): Promise<RoutingContextResponse | null> {
+  const { userService, personaResolver, prisma } = deps;
+  const { discordId, username, displayName, isBot, personalityId } = request;
+
+  const provisioned = await userService.getOrCreateUser(
+    discordId,
+    username,
+    displayName,
+    undefined,
+    isBot ?? false
+  );
+  if (provisioned === null) {
+    return null; // bot author — caller returns 400
+  }
+  const userId = provisioned.userId;
+
+  const personaResult = await personaResolver.resolve(discordId, personalityId);
+  const personaId = personaResult.config.personaId;
+  const personaName = personaResult.config.preferredName;
+
+  // Independent reads — neither depends on the other, so parallelize to save a
+  // serial round-trip on the hot path.
+  const [timezone, contextEpoch] = await Promise.all([
+    userService.getUserTimezone(userId),
+    lookupContextEpoch(prisma, userId, personalityId, personaId),
+  ]);
+
+  logger.debug(
+    { userId, personaId, personalityId, hasEpoch: contextEpoch !== undefined },
+    'Resolved routing context'
+  );
+
+  return {
+    userId,
+    personaId,
+    personaName,
+    timezone,
+    contextEpoch: contextEpoch?.toISOString() ?? null,
+  };
+}

--- a/packages/tooling/src/codegen/handler-paths.ts
+++ b/packages/tooling/src/codegen/handler-paths.ts
@@ -126,6 +126,7 @@ const PATH_MAP: Readonly<Record<string, string>> = {
   persistUserMessage: '../internal/conversationUserMessage.js',
   syncConversation: '../internal/conversationSync.js',
   loadPersonalityInternal: '../internal/personalityLoad.js',
+  routingContextCreate: '../internal/routingContextCreate.js',
 
   // User LLM config
   createUserLlmConfig: USER_LLM_CONFIG,

--- a/services/api-gateway/src/routes/_generated/mounts.ts
+++ b/services/api-gateway/src/routes/_generated/mounts.ts
@@ -41,6 +41,7 @@ import { handlePersistAssistantMessage } from '../internal/conversationAssistant
 import { handlePersistUserMessage } from '../internal/conversationUserMessage.js';
 import { handleSyncConversation } from '../internal/conversationSync.js';
 import { handleLoadPersonalityInternal } from '../internal/personalityLoad.js';
+import { handleRoutingContextCreate } from '../internal/routingContextCreate.js';
 import { handleRecentUsers } from '../internal/usersRecent.js';
 import { handleGetModels } from '../internal/models.js';
 import { handleGetDenylistCache, handleAddDenylistEntry, handleListDenylistEntries, handleRemoveDenylistEntry } from '../admin/denylist.js';
@@ -107,6 +108,7 @@ export function mountInternalRoutes(app: Express, deps: RouteDeps): void {
   app.post('/api/internal/conversation/user-message', handlePersistUserMessage(deps));
   app.post('/api/internal/conversation/sync', handleSyncConversation(deps));
   app.get('/api/internal/personality/load', handleLoadPersonalityInternal(deps));
+  app.post('/api/internal/v1/routing-context', handleRoutingContextCreate(deps));
   app.get('/api/internal/users/recent', handleRecentUsers(deps));
   app.get('/api/internal/models', handleGetModels(deps));
   app.get('/api/internal/denylist/cache', handleGetDenylistCache(deps));

--- a/services/api-gateway/src/routes/conformance/fixtures/internal.ts
+++ b/services/api-gateway/src/routes/conformance/fixtures/internal.ts
@@ -218,6 +218,24 @@ export const internalFixtures: Record<string, ConformanceEntry> = {
     query: { nameOrId: 'conf-load-personality' },
   },
 
+  routingContextCreate: {
+    // Uses the already-provisioned actor's discordId so getOrCreateUser hits
+    // the existing-user path; the cascade resolves the actor's persona for the
+    // freshly-created personality and the bundle (userId/persona/timezone/epoch)
+    // is shaped against RoutingContextResponseSchema.
+    seed: async ctx => {
+      const personality = await createPersonality(ctx, 'conf-routing-context');
+      return {
+        body: {
+          discordId: ctx.actorDiscordId,
+          username: 'conf-routing-user',
+          displayName: 'Conf Routing User',
+          personalityId: personality.id,
+        },
+      };
+    },
+  },
+
   recentUsers: {
     // The provisioned actor row itself is the "recent user" — zero extra seed.
   },

--- a/services/api-gateway/src/routes/internal/routingContextCreate.test.ts
+++ b/services/api-gateway/src/routes/internal/routingContextCreate.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for POST /internal/v1/routing-context
+ *
+ * Isolates the HTTP layer: the orchestration (`resolveRoutingContext`) is
+ * unit-tested in common-types, so here it's mocked to exercise the parse →
+ * resolve → respond wiring plus the bot-author and validation error paths.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { type PrismaClient } from '@tzurot/common-types';
+
+const mockResolveRoutingContext = vi.fn();
+
+vi.mock('@tzurot/common-types', async () => {
+  const actual =
+    await vi.importActual<typeof import('@tzurot/common-types')>('@tzurot/common-types');
+  return {
+    ...actual,
+    createLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+    // Stub the service constructors so the handler factory doesn't touch Prisma.
+    UserService: vi.fn(),
+    PersonaResolver: vi.fn(),
+    resolveRoutingContext: (...args: unknown[]) => mockResolveRoutingContext(...args),
+  };
+});
+
+import { handleRoutingContextCreate } from './routingContextCreate.js';
+
+const VALID_BODY = {
+  discordId: '278863839632818186',
+  username: 'lila',
+  displayName: 'Lila',
+  personalityId: 'personality-uuid',
+};
+
+const RESOLVED = {
+  userId: '11111111-1111-1111-1111-111111111111',
+  personaId: 'persona-uuid',
+  personaName: 'Nyx',
+  timezone: 'UTC',
+  contextEpoch: '2026-06-20T00:00:00.000Z',
+};
+
+function buildApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.post(
+    '/internal/v1/routing-context',
+    handleRoutingContextCreate({ prisma: {} as unknown as PrismaClient })
+  );
+  return app;
+}
+
+describe('POST /internal/v1/routing-context', () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it('resolves and returns the routing bundle', async () => {
+    mockResolveRoutingContext.mockResolvedValue(RESOLVED);
+
+    const response = await request(buildApp())
+      .post('/internal/v1/routing-context')
+      .send(VALID_BODY);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject(RESOLVED);
+    // The parsed request is forwarded verbatim to the resolver.
+    expect(mockResolveRoutingContext).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        discordId: '278863839632818186',
+        personalityId: 'personality-uuid',
+      })
+    );
+  });
+
+  it('returns 400 for a bot author (resolver returns null)', async () => {
+    mockResolveRoutingContext.mockResolvedValue(null);
+
+    const response = await request(buildApp())
+      .post('/internal/v1/routing-context')
+      .send({ ...VALID_BODY, isBot: true });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBeDefined();
+  });
+
+  it('returns 400 when the request body is invalid', async () => {
+    const response = await request(buildApp())
+      .post('/internal/v1/routing-context')
+      .send({ discordId: '', username: 'x' }); // missing displayName + personalityId, empty discordId
+
+    expect(response.status).toBe(400);
+    expect(mockResolveRoutingContext).not.toHaveBeenCalled();
+  });
+});

--- a/services/api-gateway/src/routes/internal/routingContextCreate.ts
+++ b/services/api-gateway/src/routes/internal/routingContextCreate.ts
@@ -1,0 +1,74 @@
+/**
+ * POST /internal/v1/routing-context
+ *
+ * Hot-path routing read: resolves the per-(user, personality) routing facts a
+ * Discord message needs BEFORE its AI job is dispatched — internal user UUID,
+ * active persona (override → default cascade), persona display name, user
+ * timezone, and the STM context-epoch. Provisions the user + default persona on
+ * first contact (idempotent upsert keyed on discordId).
+ *
+ * Consolidated into one endpoint because the reads are sequentially dependent
+ * (UUID → cascade → epoch); per-read routes would cost ~4 serialized HTTP hops
+ * on the single most latency-sensitive path in the system. The persona cascade
+ * runs here, where Prisma is legal, instead of being reimplemented in
+ * bot-client. The orchestration lives in `resolveRoutingContext` (common-types)
+ * so it is unit-tested independently of HTTP.
+ *
+ * **Authentication**: `X-Service-Auth` enforcement happens upstream via the
+ * global `requireServiceAuth()` on `/internal/*` in api-gateway's index.
+ */
+
+import { type Response, type RequestHandler } from 'express';
+import {
+  createLogger,
+  PersonaResolver,
+  resolveRoutingContext,
+  RoutingContextRequestSchema,
+  type RoutingContextResponse,
+} from '@tzurot/common-types';
+import { asyncHandler } from '../../utils/asyncHandler.js';
+import { sendCustomSuccess, sendError } from '../../utils/responseHelpers.js';
+import { ErrorResponses } from '../../utils/errorResponses.js';
+import { sendZodError } from '../../utils/zodHelpers.js';
+import { getOrCreateUserService } from '../../services/AuthMiddleware.js';
+import type { RouteDeps } from '../routeDeps.js';
+
+const logger = createLogger('internal-routing-context');
+
+/** POST /api/internal/v1/routing-context — hot-path routing-fact resolution. */
+export const handleRoutingContextCreate = (deps: RouteDeps): RequestHandler => {
+  // Shared per-PrismaClient UserService (registry-wide cache + invalidation).
+  // PersonaResolver is constructed once at mount time (matching
+  // historyContextResolver) so its cache + cleanup interval span the process.
+  const userService = getOrCreateUserService(deps.prisma);
+  const personaResolver = new PersonaResolver(deps.prisma);
+
+  return asyncHandler(async (req, res: Response) => {
+    const parseResult = RoutingContextRequestSchema.safeParse(req.body);
+    if (!parseResult.success) {
+      sendZodError(res, parseResult.error);
+      return;
+    }
+
+    const result = await resolveRoutingContext(
+      { userService, personaResolver, prisma: deps.prisma },
+      parseResult.data
+    );
+
+    if (result === null) {
+      // Bot author. bot-client filters bots before dispatch, so this is a
+      // defensive guard rather than an expected path.
+      sendError(
+        res,
+        ErrorResponses.validationError('Cannot resolve routing context for a bot author')
+      );
+      return;
+    }
+
+    logger.debug(
+      { userId: result.userId, personaId: result.personaId },
+      'Routing context resolved'
+    );
+    sendCustomSuccess(res, result satisfies RoutingContextResponse);
+  });
+};


### PR DESCRIPTION
## Context

Phase 1 of evicting Prisma from `bot-client` — the work that unblocks **PR-2p** (the active `PR-2n` epic can't evict the `prisma.ts` singleton while bot-client constructs a `PrismaClient`). beta.135 shipped the context-assembly half of 2.5d; this is the Prisma-eviction half.

This PR **stands up the endpoint only** — it's unused until Phase 2's bot-client cutover, so it ships zero behavior change.

## What it does

`POST /api/internal/v1/routing-context` resolves, in one round-trip, the per-(user, personality) routing facts a Discord message needs **before** its AI job is dispatched: internal user UUID, active persona (override → default cascade), persona display name, timezone, and the STM context-epoch. It provisions the user + default persona on first contact (idempotent, keyed on `discordId` — hence POST).

## Design

Consolidated per a **unanimous council pass** (GLM-5.2 + Kimi-K2.7-code + Qwen-3.7-max): the reads are sequentially dependent (UUID → cascade → epoch), so per-read routes would cost ~4 serialized HTTP hops on the hottest path in the system. One endpoint = one hop, and the persona cascade runs server-side where Prisma is legal instead of being reimplemented in bot-client. History was deliberately kept **out** (large, mutates every message, kills cacheability) — it's a later phase.

The contract was trimmed from the council's idealized shape to what the actual consumer (`resolveUserContext`) reads: dropped speculative `focusMode`/`provisioned` (`resolveUserContext` never fetches focus-mode; `getOrCreateUser` doesn't surface "was created").

## Changes

- **common-types**: `RoutingContext{Request,Response}Schema` (+ contract tests); `resolveRoutingContext` orchestration (+ unit tests: bot-author→null, epoch-absent, null-personaName, provisioning args)
- **api-gateway**: `handleRoutingContextCreate` handler (+ tests); conformance fixture; shared `getOrCreateUserService` for cache coherence
- route manifest entry → regenerated typed `ServiceClient.routingContextCreate`

## Verification

- `pnpm quality`: 16/16 (typecheck, lint, depcruise, knip, cpd, test-audit, backlog)
- Unit: resolver (5) + handler (3) + schema contract (8) all green
- `pnpm test:int`: 433 passed incl. the conformance replay of this route against PGLite

## Follow-on phases (this epic)

- Phase 2: cut bot-client's routing reads over to this endpoint (the behavioral cutover)
- Phase 3: migrate history reads to a separate internal route
- Phase 4: teardown + tighten the `bot-client-no-prisma` depcruise guard → **PR-2p unblocked**

🤖 Generated with [Claude Code](https://claude.com/claude-code)