### PR TITLE
feat(bot-client): author cutover to routing-context endpoint (2.5d Phase 2)

### DIFF
--- a/packages/common-types/src/schemas/api/internal.test.ts
+++ b/packages/common-types/src/schemas/api/internal.test.ts
@@ -453,7 +453,7 @@ describe('RoutingContextRequestSchema', () => {
     discordId: '278863839632818186',
     username: 'lila',
     displayName: 'Lila',
-    personalityId: 'personality-uuid',
+    personalityId: '550e8400-e29b-41d4-a716-446655440002',
   };
 
   it('accepts a minimal valid request (isBot omitted)', () => {
@@ -464,8 +464,22 @@ describe('RoutingContextRequestSchema', () => {
     expect(RoutingContextRequestSchema.safeParse({ ...valid, isBot: true }).success).toBe(true);
   });
 
+  it('accepts a blank displayName (user without a global display name)', () => {
+    expect(RoutingContextRequestSchema.safeParse({ ...valid, displayName: '' }).success).toBe(true);
+  });
+
   it('rejects an empty discordId', () => {
     expect(RoutingContextRequestSchema.safeParse({ ...valid, discordId: '' }).success).toBe(false);
+  });
+
+  it('rejects an empty username', () => {
+    expect(RoutingContextRequestSchema.safeParse({ ...valid, username: '' }).success).toBe(false);
+  });
+
+  it('rejects a non-UUID personalityId', () => {
+    expect(
+      RoutingContextRequestSchema.safeParse({ ...valid, personalityId: 'not-a-uuid' }).success
+    ).toBe(false);
   });
 
   it('rejects a missing personalityId', () => {
@@ -477,7 +491,7 @@ describe('RoutingContextRequestSchema', () => {
 describe('RoutingContextResponseSchema', () => {
   const valid = {
     userId: '550e8400-e29b-41d4-a716-446655440000',
-    personaId: 'persona-uuid',
+    personaId: '550e8400-e29b-41d4-a716-446655440003',
     personaName: 'Nyx',
     timezone: 'UTC',
     contextEpoch: '2026-06-20T00:00:00.000Z',
@@ -485,6 +499,10 @@ describe('RoutingContextResponseSchema', () => {
 
   it('accepts a fully-populated bundle', () => {
     expect(RoutingContextResponseSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it('accepts an empty-string personaId (system-default fallback)', () => {
+    expect(RoutingContextResponseSchema.safeParse({ ...valid, personaId: '' }).success).toBe(true);
   });
 
   it('accepts null personaName and null contextEpoch', () => {
@@ -498,6 +516,12 @@ describe('RoutingContextResponseSchema', () => {
     expect(RoutingContextResponseSchema.safeParse({ ...valid, userId: 'not-a-uuid' }).success).toBe(
       false
     );
+  });
+
+  it('rejects a non-UUID, non-empty personaId', () => {
+    expect(
+      RoutingContextResponseSchema.safeParse({ ...valid, personaId: 'not-a-uuid' }).success
+    ).toBe(false);
   });
 
   it('rejects a non-ISO contextEpoch', () => {

--- a/packages/common-types/src/schemas/api/internal.ts
+++ b/packages/common-types/src/schemas/api/internal.ts
@@ -216,11 +216,12 @@ export const RoutingContextRequestSchema = z.object({
   /** Message author's Discord snowflake — the provisioning + cascade key. */
   discordId: z.string().min(1).max(32),
   /**
-   * Discord username, for provisioning the user shell on first contact. Not
-   * `.min(1)`-constrained: Discord usernames are always non-empty at the
-   * call-site, so the cap is the only real bound.
+   * Discord username, for provisioning the user shell on first contact.
+   * `.min(1)` enforces the caller contract — Discord usernames are always
+   * non-empty, and an empty one would be stored verbatim as the user shell's
+   * username.
    */
-  username: z.string().max(255),
+  username: z.string().min(1).max(255),
   /**
    * Display name, for seeding the default persona's name on first contact.
    * May legitimately be blank (a user without a global display name), so it is
@@ -229,8 +230,12 @@ export const RoutingContextRequestSchema = z.object({
   displayName: z.string().max(255),
   /** True for bot authors; provisioning rejects them (returns 400). */
   isBot: z.boolean().optional(),
-  /** Target personality whose persona cascade to resolve (deterministic UUID). */
-  personalityId: z.string().min(1).max(64),
+  /**
+   * Target personality whose persona cascade to resolve. Always a deterministic
+   * v5 UUID (`generatePersonalityUuid`), so the `.uuid()` constraint is exact —
+   * the call-site (bot-client `MessageContextBuilder`) passes `personality.id`.
+   */
+  personalityId: z.string().uuid(),
 });
 export type RoutingContextRequest = z.infer<typeof RoutingContextRequestSchema>;
 
@@ -238,11 +243,12 @@ export const RoutingContextResponseSchema = z.object({
   /** Internal user UUID (FK for everything downstream). */
   userId: z.string().uuid(),
   /**
-   * Resolved active persona UUID (override → default cascade). Not `.uuid()`-
-   * constrained: the system-default fallback carries an empty string, which the
-   * epoch lookup treats as a non-matching key.
+   * Resolved active persona (override → default cascade): a UUID, OR the empty
+   * string for the system-default fallback (which the epoch lookup treats as a
+   * non-matching key). The union encodes both cases so a malformed non-UUID,
+   * non-empty id can't slip through.
    */
-  personaId: z.string(),
+  personaId: z.union([z.string().uuid(), z.literal('')]),
   /** Persona display name; null when the cascade has no preferred name. */
   personaName: z.string().nullable(),
   /** IANA timezone; `getUserTimezone` falls back to 'UTC', so always present. */

--- a/services/api-gateway/src/routes/internal/routingContextCreate.test.ts
+++ b/services/api-gateway/src/routes/internal/routingContextCreate.test.ts
@@ -19,8 +19,9 @@ vi.mock('@tzurot/common-types', async () => {
   return {
     ...actual,
     createLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
-    // Stub the service constructors so the handler factory doesn't touch Prisma.
-    UserService: vi.fn(),
+    // Stub PersonaResolver (the handler constructs it directly) so the factory
+    // doesn't start its real cache-cleanup interval. UserService is reached via
+    // getOrCreateUserService, not a direct import, so it needs no stub here.
     PersonaResolver: vi.fn(),
     resolveRoutingContext: (...args: unknown[]) => mockResolveRoutingContext(...args),
   };
@@ -32,12 +33,12 @@ const VALID_BODY = {
   discordId: '278863839632818186',
   username: 'lila',
   displayName: 'Lila',
-  personalityId: 'personality-uuid',
+  personalityId: '550e8400-e29b-41d4-a716-446655440002',
 };
 
 const RESOLVED = {
   userId: '11111111-1111-1111-1111-111111111111',
-  personaId: 'persona-uuid',
+  personaId: '550e8400-e29b-41d4-a716-446655440003',
   personaName: 'Nyx',
   timezone: 'UTC',
   contextEpoch: '2026-06-20T00:00:00.000Z',
@@ -71,7 +72,7 @@ describe('POST /internal/v1/routing-context', () => {
       expect.anything(),
       expect.objectContaining({
         discordId: '278863839632818186',
-        personalityId: 'personality-uuid',
+        personalityId: '550e8400-e29b-41d4-a716-446655440002',
       })
     );
   });

--- a/services/bot-client/src/index.ts
+++ b/services/bot-client/src/index.ts
@@ -32,6 +32,7 @@ import {
   healthCheck,
 } from './utils/gatewayServiceCalls.js';
 import { WebhookManager } from './utils/WebhookManager.js';
+import { getServiceClient } from './utils/gatewayClients.js';
 import type { MessageHandler } from './handlers/MessageHandler.js';
 import { CommandHandler } from './handlers/CommandHandler.js';
 import { redis as botRedis, closeRedis } from './redis.js';
@@ -239,7 +240,12 @@ function createServices(): Services {
 
   // Message handling services
   const responseSender = new DiscordResponseSender(webhookManager);
-  const contextBuilder = new MessageContextBuilder(prisma, personaResolver, denylistCache);
+  const contextBuilder = new MessageContextBuilder(
+    prisma,
+    personaResolver,
+    getServiceClient(),
+    denylistCache
+  );
   const persistence = new ConversationPersistence();
   const voiceTranscription = new VoiceTranscriptionService();
   const referenceEnricher = new ReferenceEnrichmentService(userService, personaResolver);

--- a/services/bot-client/src/services/MessageContextBuilder.test.ts
+++ b/services/bot-client/src/services/MessageContextBuilder.test.ts
@@ -94,6 +94,20 @@ vi.mock('./MentionResolver.js', () => ({
   },
 }));
 
+// The author's routing facts (internal id, persona, timezone, epoch) are now
+// resolved by `resolveUserContext` (which calls the gateway `routing-context`
+// endpoint — tested in UserContextResolver.test.ts). Mock it here so these
+// tests exercise buildContext's ORCHESTRATION given a resolved author bundle,
+// not the resolution mechanism. Override per-test for epoch / persona variants.
+const mockResolveUserContext = vi.fn();
+vi.mock('./contextBuilder/index.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('./contextBuilder/index.js')>();
+  return {
+    ...actual,
+    resolveUserContext: (...args: unknown[]) => mockResolveUserContext(...args),
+  };
+});
+
 // Mock for DiscordChannelFetcher
 const mockFetchRecentMessages = vi.fn();
 const mockMergeWithHistory = vi.fn();
@@ -144,8 +158,22 @@ describe('MessageContextBuilder', () => {
       },
     } as unknown as PrismaClient;
 
-    // Create builder instance with mock PersonaResolver
-    builder = new MessageContextBuilder(mockPrisma, mockPersonaResolver as any);
+    // Default author bundle (resolveUserContext is mocked above). Mirrors the
+    // values the old userService/personaResolver/epoch mocks produced for the
+    // author, so the envelope-shape assertions stay stable.
+    mockResolveUserContext.mockResolvedValue({
+      internalUserId: 'internal-user-uuid',
+      discordUserId: 'user-123',
+      personaId: 'persona-123',
+      personaName: 'Test Persona',
+      userTimezone: undefined,
+      contextEpoch: undefined,
+      history: [],
+    });
+
+    // Create builder instance — serviceClient is a stub since resolveUserContext
+    // (the only consumer) is mocked.
+    builder = new MessageContextBuilder(mockPrisma, mockPersonaResolver as any, {} as any);
 
     // Get service instances to access mocks
     mockHistoryService = (builder as any).conversationHistory;
@@ -349,13 +377,16 @@ describe('MessageContextBuilder', () => {
     });
 
     it('should build complete context with user lookup and history', async () => {
-      // Setup mocks
-      vi.mocked(mockUserService.getOrCreateUser).mockResolvedValue({
-        userId: 'user-uuid-123',
-        defaultPersonaId: 'test-persona-id',
+      // The author bundle is resolved by the (mocked) routing-context call.
+      mockResolveUserContext.mockResolvedValue({
+        internalUserId: 'user-uuid-123',
+        discordUserId: 'user-123',
+        personaId: 'persona-123',
+        personaName: 'Test Persona',
+        userTimezone: undefined,
+        contextEpoch: undefined,
+        history: [],
       });
-      // PersonaResolver.resolve is already mocked in beforeEach
-      // PersonaResolver.resolve returns preferredName directly
       vi.mocked(mockHistoryService.getChannelHistory).mockResolvedValue([
         {
           id: 'history-1',
@@ -378,18 +409,13 @@ describe('MessageContextBuilder', () => {
       // Execute
       const result = await builder.buildContext(mockMessage, mockPersonality, 'Hello world');
 
-      // Verify user service calls
-      expect(mockUserService.getOrCreateUser).toHaveBeenCalledWith(
-        'user-123',
-        'testuser',
+      // Author resolution is delegated to resolveUserContext (the routing-context
+      // call) with the effective user + personality + resolved display name.
+      expect(mockResolveUserContext).toHaveBeenCalledWith(
+        { id: 'user-123', username: 'testuser', bot: false },
+        mockPersonality,
         'Test Display Name',
-        undefined, // bio
-        false // isBot
-      );
-      // PersonaResolver uses Discord ID (not internal UUID)
-      expect(mockPersonaResolver.resolve).toHaveBeenCalledWith(
-        'user-123', // Discord ID
-        'personality-123'
+        expect.anything()
       );
 
       // Verify history retrieval. Args: (channelId, limit, contextEpoch, maxAge).
@@ -437,19 +463,15 @@ describe('MessageContextBuilder', () => {
       // Mock fetch to also return null (simulates member not fetchable)
       vi.mocked(mockMessage.guild!.members.fetch).mockResolvedValue(null as any);
 
-      vi.mocked(mockUserService.getOrCreateUser).mockResolvedValue({
-        userId: 'user-uuid-123',
-        defaultPersonaId: 'test-persona-id',
-      });
-      // Override to return null preferredName
-      mockPersonaResolver.resolve.mockResolvedValue({
-        config: {
-          personaId: 'persona-123',
-          preferredName: null,
-          pronouns: null,
-          content: '',
-        },
-        source: 'user-default',
+      // Author bundle with a null persona name (no preferred name resolved).
+      mockResolveUserContext.mockResolvedValue({
+        internalUserId: 'user-uuid-123',
+        discordUserId: 'user-123',
+        personaId: 'persona-123',
+        personaName: null,
+        userTimezone: undefined,
+        contextEpoch: undefined,
+        history: [],
       });
       vi.mocked(mockHistoryService.getChannelHistory).mockResolvedValue([]);
       mockExtractReferencesWithReplacement.mockResolvedValue({
@@ -459,12 +481,13 @@ describe('MessageContextBuilder', () => {
 
       const result = await builder.buildContext(mockMessage, mockPersonality, 'Hello');
 
-      expect(mockUserService.getOrCreateUser).toHaveBeenCalledWith(
-        'user-123',
+      // With no member + no globalName, the display name falls back to username
+      // and is forwarded to the routing-context resolution.
+      expect(mockResolveUserContext).toHaveBeenCalledWith(
+        { id: 'user-123', username: 'testuser', bot: false },
+        mockPersonality,
         'testuser',
-        'testuser', // Falls back to username
-        undefined, // bio
-        false // isBot
+        expect.anything()
       );
       expect(result.context.activePersonaName).toBeUndefined();
     });
@@ -797,16 +820,16 @@ describe('MessageContextBuilder', () => {
     it('should apply context epoch filter when user has cleared history (STM)', async () => {
       const contextEpoch = new Date('2025-01-15T12:00:00Z');
 
-      // Set up the epoch in UserPersonaHistoryConfig
-      vi.mocked(mockPrisma.userPersonaHistoryConfig.findUnique).mockResolvedValue({
-        lastContextReset: contextEpoch,
-      } as any);
-
-      vi.mocked(mockUserService.getOrCreateUser).mockResolvedValue({
-        userId: 'user-uuid-123',
-        defaultPersonaId: 'test-persona-id',
+      // The epoch is now resolved server-side and returned in the author bundle.
+      mockResolveUserContext.mockResolvedValue({
+        internalUserId: 'user-uuid-123',
+        discordUserId: 'user-123',
+        personaId: 'persona-123',
+        personaName: 'Test Persona',
+        userTimezone: 'UTC',
+        contextEpoch,
+        history: [],
       });
-      vi.mocked(mockUserService.getUserTimezone).mockResolvedValue('UTC');
       vi.mocked(mockHistoryService.getChannelHistory).mockResolvedValue([]);
       mockExtractReferencesWithReplacement.mockResolvedValue({
         references: [],
@@ -821,20 +844,6 @@ describe('MessageContextBuilder', () => {
 
       await builder.buildContext(mockMessage, mockPersonality, 'Hello after clear');
 
-      // Verify the epoch was looked up
-      expect(mockPrisma.userPersonaHistoryConfig.findUnique).toHaveBeenCalledWith({
-        where: {
-          userId_personalityId_personaId: {
-            userId: 'user-uuid-123',
-            personalityId: 'personality-123',
-            personaId: 'persona-123',
-          },
-        },
-        select: {
-          lastContextReset: true,
-        },
-      });
-
       // Verify history was fetched WITH the context epoch (and no maxAge)
       expect(mockHistoryService.getChannelHistory).toHaveBeenCalledWith(
         'channel-123',
@@ -847,16 +856,16 @@ describe('MessageContextBuilder', () => {
     it('should NOT apply the per-user epoch in weigh-in mode even when one is set', async () => {
       const contextEpoch = new Date('2025-01-15T12:00:00Z');
 
-      // The invoking user HAS a recent STM reset...
-      vi.mocked(mockPrisma.userPersonaHistoryConfig.findUnique).mockResolvedValue({
-        lastContextReset: contextEpoch,
-      } as any);
-
-      vi.mocked(mockUserService.getOrCreateUser).mockResolvedValue({
-        userId: 'user-uuid-123',
-        defaultPersonaId: 'test-persona-id',
+      // The invoking user HAS a recent STM reset (returned in the author bundle)...
+      mockResolveUserContext.mockResolvedValue({
+        internalUserId: 'user-uuid-123',
+        discordUserId: 'user-123',
+        personaId: 'persona-123',
+        personaName: 'Test Persona',
+        userTimezone: 'UTC',
+        contextEpoch,
+        history: [],
       });
-      vi.mocked(mockUserService.getUserTimezone).mockResolvedValue('UTC');
       vi.mocked(mockHistoryService.getChannelHistory).mockResolvedValue([]);
       mockExtractReferencesWithReplacement.mockResolvedValue({
         references: [],

--- a/services/bot-client/src/services/MessageContextBuilder.ts
+++ b/services/bot-client/src/services/MessageContextBuilder.ts
@@ -20,6 +20,7 @@ import {
   isTypingChannel,
 } from '@tzurot/common-types';
 import type { Message } from 'discord.js';
+import type { ServiceClient } from '@tzurot/clients';
 import type { MessageContext } from '../types.js';
 import { extractDiscordEnvironment } from '../utils/discordContext.js';
 import { buildMessageContent } from '../utils/MessageContentBuilder.js';
@@ -137,6 +138,7 @@ export class MessageContextBuilder {
   constructor(
     private prisma: PrismaClient,
     personaResolver: PersonaResolver,
+    private serviceClient: ServiceClient,
     denylistCache?: DenylistCache
   ) {
     this.conversationHistory = new ConversationHistoryService(prisma);
@@ -380,11 +382,7 @@ export class MessageContextBuilder {
       { id: effectiveUser.id, username: effectiveUser.username, bot: effectiveUser.bot },
       personality,
       displayName,
-      {
-        userService: this.userService,
-        personaResolver: this.personaResolver,
-        prisma: this.prisma,
-      }
+      { serviceClient: this.serviceClient }
     );
     const { internalUserId, discordUserId, personaId, personaName, userTimezone } = userContext;
     // An incognito (anonymous) summon must NOT bound the shared channel history

--- a/services/bot-client/src/services/contextBuilder/UserContextResolver.test.ts
+++ b/services/bot-client/src/services/contextBuilder/UserContextResolver.test.ts
@@ -1,248 +1,168 @@
 /**
  * Tests for UserContextResolver
  *
- * Unit tests for user identity resolution and context epoch lookup.
+ * The resolver now delegates provisioning + persona cascade + epoch to the
+ * gateway's `routing-context` endpoint; these tests mock the `ServiceClient`
+ * and assert the request shape + response→`UserContextResult` mapping.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { lookupContextEpoch, resolveUserContext } from './UserContextResolver.js';
-import type {
-  UserService,
-  PersonaResolver,
-  PrismaClient,
-  LoadedPersonality,
-} from '@tzurot/common-types';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { resolveUserContext } from './UserContextResolver.js';
+import type { LoadedPersonality } from '@tzurot/common-types';
+import type { ServiceClient } from '@tzurot/clients';
 
-describe('UserContextResolver', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+const createMockPersonality = (): LoadedPersonality =>
+  ({
+    id: '550e8400-e29b-41d4-a716-446655440002',
+    name: 'TestBot',
+    displayName: 'Test Bot',
+    slug: 'testbot',
+    ownerId: 'owner-uuid-test',
+    systemPrompt: 'Test prompt',
+    model: 'test-model',
+    provider: 'openrouter',
+    temperature: 0.7,
+    maxTokens: 2000,
+    contextWindowTokens: 131072,
+    characterInfo: '',
+    personalityTraits: '',
+    voiceEnabled: false,
+  }) as LoadedPersonality;
 
-  describe('lookupContextEpoch', () => {
-    it('should return context epoch when found', async () => {
-      const epochDate = new Date('2024-01-15T10:00:00Z');
-      const mockPrisma = {
-        userPersonaHistoryConfig: {
-          findUnique: vi.fn().mockResolvedValue({ lastContextReset: epochDate }),
-        },
-      } as unknown as PrismaClient;
+const OK_DATA = {
+  userId: '550e8400-e29b-41d4-a716-446655440000',
+  personaId: '550e8400-e29b-41d4-a716-446655440003',
+  personaName: 'Alice',
+  timezone: 'America/New_York',
+  contextEpoch: null as string | null,
+};
 
-      const result = await lookupContextEpoch(
-        mockPrisma,
-        'user-123',
-        'personality-456',
-        'persona-789'
-      );
+function depsWith(routingContextCreate: ReturnType<typeof vi.fn>): {
+  serviceClient: ServiceClient;
+} {
+  return { serviceClient: { routingContextCreate } as unknown as ServiceClient };
+}
 
-      expect(result).toBe(epochDate);
-      expect(mockPrisma.userPersonaHistoryConfig.findUnique).toHaveBeenCalledWith({
-        where: {
-          userId_personalityId_personaId: {
-            userId: 'user-123',
-            personalityId: 'personality-456',
-            personaId: 'persona-789',
-          },
-        },
-        select: { lastContextReset: true },
-      });
-    });
+describe('resolveUserContext', () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.restoreAllMocks());
 
-    it('should return undefined when no config found', async () => {
-      const mockPrisma = {
-        userPersonaHistoryConfig: {
-          findUnique: vi.fn().mockResolvedValue(null),
-        },
-      } as unknown as PrismaClient;
+  it('maps a successful response to the UserContextResult shape', async () => {
+    const deps = depsWith(vi.fn().mockResolvedValue({ ok: true, data: OK_DATA }));
+    const user = { id: 'discord-user-123', username: 'alice', bot: false };
 
-      const result = await lookupContextEpoch(
-        mockPrisma,
-        'user-123',
-        'personality-456',
-        'persona-789'
-      );
+    const result = await resolveUserContext(user, createMockPersonality(), 'Alice Display', deps);
 
-      expect(result).toBeUndefined();
-    });
-
-    it('should return undefined when lastContextReset is null', async () => {
-      const mockPrisma = {
-        userPersonaHistoryConfig: {
-          findUnique: vi.fn().mockResolvedValue({ lastContextReset: null }),
-        },
-      } as unknown as PrismaClient;
-
-      const result = await lookupContextEpoch(
-        mockPrisma,
-        'user-123',
-        'personality-456',
-        'persona-789'
-      );
-
-      expect(result).toBeUndefined();
+    expect(result).toEqual({
+      internalUserId: '550e8400-e29b-41d4-a716-446655440000',
+      discordUserId: 'discord-user-123',
+      personaId: '550e8400-e29b-41d4-a716-446655440003',
+      personaName: 'Alice',
+      userTimezone: 'America/New_York',
+      contextEpoch: undefined,
+      history: [],
     });
   });
 
-  describe('resolveUserContext', () => {
-    const createMockPersonality = (): LoadedPersonality => ({
-      id: 'personality-123',
-      name: 'TestBot',
-      displayName: 'Test Bot',
-      slug: 'testbot',
-      ownerId: 'owner-uuid-test',
-      systemPrompt: 'Test prompt',
-      model: 'test-model',
-      provider: 'openrouter',
-      temperature: 0.7,
-      maxTokens: 2000,
-      contextWindowTokens: 131072,
-      characterInfo: '',
-      personalityTraits: '',
-      voiceEnabled: false,
+  it('calls routingContextCreate with the author + personality facts', async () => {
+    const routingContextCreate = vi.fn().mockResolvedValue({ ok: true, data: OK_DATA });
+    const user = { id: 'discord-123', username: 'bob', bot: false };
+
+    await resolveUserContext(
+      user,
+      createMockPersonality(),
+      'Bob Display',
+      depsWith(routingContextCreate)
+    );
+
+    expect(routingContextCreate).toHaveBeenCalledWith({
+      discordId: 'discord-123',
+      username: 'bob',
+      displayName: 'Bob Display',
+      isBot: false,
+      personalityId: '550e8400-e29b-41d4-a716-446655440002',
     });
+  });
 
-    const createMockDeps = () => ({
-      userService: {
-        getOrCreateUser: vi.fn().mockResolvedValue({
-          userId: 'internal-user-uuid',
-          defaultPersonaId: 'persona-uuid-123',
-        }),
-        getUserTimezone: vi.fn().mockResolvedValue('America/New_York'),
-      } as unknown as UserService,
-      personaResolver: {
-        resolve: vi.fn().mockResolvedValue({
-          config: {
-            personaId: 'persona-uuid-123',
-            personaName: 'AlicePersona',
-            preferredName: 'Alice',
-            pronouns: null,
-            content: '',
-          },
-          source: 'system-default',
-        }),
-      } as unknown as PersonaResolver,
-      prisma: {
-        userPersonaHistoryConfig: {
-          findUnique: vi.fn().mockResolvedValue(null),
-        },
-      } as unknown as PrismaClient,
-    });
+  it('parses an ISO contextEpoch into a Date', async () => {
+    const deps = depsWith(
+      vi.fn().mockResolvedValue({
+        ok: true,
+        data: { ...OK_DATA, contextEpoch: '2024-06-01T00:00:00.000Z' },
+      })
+    );
+    const user = { id: 'discord-123', username: 'alice' };
 
-    it('should resolve user context with all fields', async () => {
-      const deps = createMockDeps();
-      const personality = createMockPersonality();
-      const user = { id: 'discord-user-123', username: 'alice#1234', bot: false };
+    const result = await resolveUserContext(user, createMockPersonality(), 'Alice', deps);
 
-      const result = await resolveUserContext(user, personality, 'Alice Display', deps);
+    expect(result.contextEpoch).toEqual(new Date('2024-06-01T00:00:00.000Z'));
+  });
 
-      expect(result).toEqual({
-        internalUserId: 'internal-user-uuid',
-        discordUserId: 'discord-user-123',
-        personaId: 'persona-uuid-123',
-        personaName: 'Alice',
-        userTimezone: 'America/New_York',
-        contextEpoch: undefined,
-        history: [],
-      });
-    });
+  it('maps a null contextEpoch to undefined', async () => {
+    const deps = depsWith(
+      vi.fn().mockResolvedValue({ ok: true, data: { ...OK_DATA, contextEpoch: null } })
+    );
+    const user = { id: 'discord-123', username: 'alice' };
 
-    it('should call userService.getOrCreateUser with correct args', async () => {
-      const deps = createMockDeps();
-      const personality = createMockPersonality();
-      const user = { id: 'discord-123', username: 'bob', bot: false };
+    const result = await resolveUserContext(user, createMockPersonality(), 'Alice', deps);
 
-      await resolveUserContext(user, personality, 'Bob Display', deps);
+    expect(result.contextEpoch).toBeUndefined();
+  });
 
-      expect(deps.userService.getOrCreateUser).toHaveBeenCalledWith(
-        'discord-123',
-        'bob',
-        'Bob Display',
-        undefined,
-        false
-      );
-    });
+  it('passes a null personaName through', async () => {
+    const deps = depsWith(
+      vi.fn().mockResolvedValue({ ok: true, data: { ...OK_DATA, personaName: null } })
+    );
+    const user = { id: 'discord-123', username: 'alice' };
 
-    it('should handle bot user flag', async () => {
-      const deps = createMockDeps();
-      const personality = createMockPersonality();
-      const user = { id: 'bot-123', username: 'botname', bot: true };
+    const result = await resolveUserContext(user, createMockPersonality(), 'Alice', deps);
 
-      await resolveUserContext(user, personality, 'Bot Display', deps);
+    expect(result.personaName).toBeNull();
+  });
 
-      expect(deps.userService.getOrCreateUser).toHaveBeenCalledWith(
-        'bot-123',
-        'botname',
-        'Bot Display',
-        undefined,
-        true
-      );
-    });
+  it('returns an empty history array (deferred to the caller)', async () => {
+    const deps = depsWith(vi.fn().mockResolvedValue({ ok: true, data: OK_DATA }));
+    const user = { id: 'discord-123', username: 'alice' };
 
-    it('should throw when userService returns null (bot rejection)', async () => {
-      const deps = createMockDeps();
-      vi.mocked(deps.userService.getOrCreateUser).mockResolvedValue(null);
-      const personality = createMockPersonality();
-      const user = { id: 'bot-123', username: 'bot', bot: true };
+    const result = await resolveUserContext(user, createMockPersonality(), 'Alice', deps);
 
-      await expect(resolveUserContext(user, personality, 'Bot', deps)).rejects.toThrow(
-        'Cannot process messages from bots'
-      );
-    });
+    expect(result.history).toEqual([]);
+  });
 
-    it('should include context epoch when set', async () => {
-      const deps = createMockDeps();
-      const epochDate = new Date('2024-06-01T00:00:00Z');
-      // Cast through unknown since we only need lastContextReset for the test
-      (
-        deps.prisma.userPersonaHistoryConfig.findUnique as ReturnType<typeof vi.fn>
-      ).mockResolvedValue({ lastContextReset: epochDate });
-      const personality = createMockPersonality();
-      const user = { id: 'discord-123', username: 'alice' };
+  it('throws the bot-author message only for a bot 400', async () => {
+    const deps = depsWith(
+      vi.fn().mockResolvedValue({ ok: false, error: 'bot author', status: 400 })
+    );
+    const user = { id: 'bot-123', username: 'bot', bot: true };
 
-      const result = await resolveUserContext(user, personality, 'Alice', deps);
+    await expect(resolveUserContext(user, createMockPersonality(), 'Bot', deps)).rejects.toThrow(
+      'Cannot process messages from bots'
+    );
+  });
 
-      expect(result.contextEpoch).toBe(epochDate);
-    });
+  it('surfaces the real status for a bot author whose request fails non-400', async () => {
+    // A bot reaching the endpoint AND a non-400 failure must not be masked as a
+    // bot-rejection — the operator needs the real cause. status:0 is the
+    // transport's sentinel for a non-HTTP failure (timeout / network error /
+    // response-contract drift); a real 5xx carries its own HTTP status instead.
+    const deps = depsWith(
+      vi.fn().mockResolvedValue({ ok: false, error: 'upstream timeout', status: 0 })
+    );
+    const user = { id: 'bot-123', username: 'bot', bot: true };
 
-    it('should handle null preferred name', async () => {
-      const deps = createMockDeps();
-      vi.mocked(deps.personaResolver.resolve).mockResolvedValue({
-        config: {
-          personaId: 'persona-uuid',
-          personaName: 'TestPersona',
-          preferredName: null,
-          pronouns: null,
-          content: '',
-        },
-        source: 'system-default',
-      });
-      const personality = createMockPersonality();
-      const user = { id: 'discord-123', username: 'alice' };
+    await expect(resolveUserContext(user, createMockPersonality(), 'Bot', deps)).rejects.toThrow(
+      /status 0.*upstream timeout/
+    );
+  });
 
-      const result = await resolveUserContext(user, personality, 'Alice', deps);
+  it('throws a status-bearing error when a non-bot request fails', async () => {
+    const deps = depsWith(
+      vi.fn().mockResolvedValue({ ok: false, error: 'gateway exploded', status: 503 })
+    );
+    const user = { id: 'discord-123', username: 'alice', bot: false };
 
-      // personaName in result comes from preferredName (user's chosen name)
-      expect(result.personaName).toBeNull();
-    });
-
-    it('should handle undefined timezone', async () => {
-      const deps = createMockDeps();
-      vi.mocked(deps.userService.getUserTimezone).mockResolvedValue(undefined as unknown as string);
-      const personality = createMockPersonality();
-      const user = { id: 'discord-123', username: 'alice' };
-
-      const result = await resolveUserContext(user, personality, 'Alice', deps);
-
-      expect(result.userTimezone).toBeUndefined();
-    });
-
-    it('should return empty history array (deferred to caller)', async () => {
-      const deps = createMockDeps();
-      const personality = createMockPersonality();
-      const user = { id: 'discord-123', username: 'alice' };
-
-      const result = await resolveUserContext(user, personality, 'Alice', deps);
-
-      expect(result.history).toEqual([]);
-    });
+    await expect(resolveUserContext(user, createMockPersonality(), 'Alice', deps)).rejects.toThrow(
+      /status 503.*gateway exploded/
+    );
   });
 });

--- a/services/bot-client/src/services/contextBuilder/UserContextResolver.ts
+++ b/services/bot-client/src/services/contextBuilder/UserContextResolver.ts
@@ -1,21 +1,24 @@
 /**
  * User Context Resolver
  *
- * Handles resolving user identity, persona lookup, and context epoch.
+ * Resolves the message author's routing facts — internal user id, active
+ * persona, persona name, timezone, and the STM context-epoch — via the
+ * gateway's `routing-context` endpoint. The provisioning + persona cascade +
+ * epoch reads run server-side (where Prisma is legal) in one round-trip; this
+ * module is now a thin adapter that maps the response into the shape
+ * `MessageContextBuilder` expects.
  */
 
 import {
   createLogger,
-  type UserService,
-  type PersonaResolver,
-  type PrismaClient,
   type LoadedPersonality,
   type ConversationMessage,
 } from '@tzurot/common-types';
+import type { ServiceClient } from '@tzurot/clients';
 
 const logger = createLogger('UserContextResolver');
 
-/** Result of resolving user, persona, and history */
+/** Result of resolving user, persona, and (deferred) history. */
 interface UserContextResult {
   internalUserId: string;
   discordUserId: string;
@@ -26,56 +29,26 @@ interface UserContextResult {
   history: ConversationMessage[];
 }
 
-/** User info for context resolution */
+/** User info for context resolution. */
 interface UserInfo {
   id: string;
   username: string;
   bot?: boolean;
 }
 
-/** Dependencies for user context resolution */
+/** Dependencies for user context resolution. */
 interface UserContextDeps {
-  userService: UserService;
-  personaResolver: PersonaResolver;
-  prisma: PrismaClient;
+  serviceClient: ServiceClient;
 }
 
 /**
- * Look up the context epoch for STM clear feature.
- * Returns undefined if no epoch is set.
- *
- * @param prisma - Prisma client
- * @param internalUserId - Internal user UUID
- * @param personalityId - Personality ID
- * @param personaId - Persona ID
- * @returns Context epoch date or undefined
- */
-export async function lookupContextEpoch(
-  prisma: PrismaClient,
-  internalUserId: string,
-  personalityId: string,
-  personaId: string
-): Promise<Date | undefined> {
-  const historyConfig = await prisma.userPersonaHistoryConfig.findUnique({
-    where: {
-      userId_personalityId_personaId: {
-        userId: internalUserId,
-        personalityId,
-        personaId,
-      },
-    },
-    select: { lastContextReset: true },
-  });
-  return historyConfig?.lastContextReset ?? undefined;
-}
-
-/**
- * Resolve user identity, persona, and fetch context epoch.
+ * Resolve user identity, persona, timezone, and context epoch for the message
+ * author against the target personality.
  *
  * @param user - User info (from overrideUser or message.author)
  * @param personality - Target AI personality
- * @param displayName - Display name for persona creation
- * @param deps - Dependencies (userService, personaResolver, prisma)
+ * @param displayName - Display name for persona creation (provisioning seed)
+ * @param deps - Dependencies (the internal-gateway ServiceClient)
  * @returns Resolved user context info
  */
 export async function resolveUserContext(
@@ -84,62 +57,61 @@ export async function resolveUserContext(
   displayName: string,
   deps: UserContextDeps
 ): Promise<UserContextResult> {
-  const { userService, personaResolver, prisma } = deps;
+  const { serviceClient } = deps;
 
-  // Get internal user ID for database operations.
-  //
-  // `provisioned.defaultPersonaId` is available here but currently unused —
-  // PersonaResolver below re-resolves because Priority 1 (per-personality
-  // override in UserPersonalityConfig) can't be short-circuited from the
-  // provisioned value. If we ever split "resolve override vs fall back to
-  // default" into separate calls, this is the point where the default side
-  // could skip a query.
-  const provisioned = await userService.getOrCreateUser(
-    user.id,
-    user.username,
+  const result = await serviceClient.routingContextCreate({
+    discordId: user.id,
+    username: user.username,
     displayName,
-    undefined,
-    user.bot ?? false
-  );
+    isBot: user.bot ?? false,
+    personalityId: personality.id,
+  });
 
-  if (provisioned === null) {
-    throw new Error('Cannot process messages from bots');
+  if (!result.ok) {
+    // The bot-author rejection is the endpoint's 400; keep the original wording
+    // ONLY for that exact case (a defensive backstop — bots are filtered
+    // upstream). Any other failure for a bot author (network timeout, gateway
+    // 5xx) must surface its real status, not a misleading bot-rejection.
+    if (user.bot === true && result.status === 400) {
+      throw new Error('Cannot process messages from bots');
+    }
+    throw new Error(`Failed to resolve routing context (status ${result.status}): ${result.error}`);
   }
 
-  const internalUserId = provisioned.userId;
-
-  const discordUserId = user.id;
-  const personaResult = await personaResolver.resolve(discordUserId, personality.id);
-  const personaId = personaResult.config.personaId;
-  const personaName = personaResult.config.preferredName;
-  const userTimezone = await userService.getUserTimezone(internalUserId);
+  const { userId, personaId, personaName, timezone, contextEpoch } = result.data;
+  // contextEpoch is the STM-reset timestamp; the gateway returns it as an ISO
+  // string (or null). History filtering downstream still wants a Date.
+  const resolvedEpoch = contextEpoch !== null ? new Date(contextEpoch) : undefined;
 
   logger.debug(
-    { personaId, personaName, internalUserId, discordUserId, personalityId: personality.id },
-    'User persona lookup complete'
+    {
+      personaId,
+      personaName,
+      internalUserId: userId,
+      discordUserId: user.id,
+      personalityId: personality.id,
+    },
+    'User persona lookup complete (via routing-context)'
   );
-
-  // Look up context epoch (STM clear feature)
-  const contextEpoch = await lookupContextEpoch(prisma, internalUserId, personality.id, personaId);
-  if (contextEpoch !== undefined) {
+  if (resolvedEpoch !== undefined) {
+    // Grep anchor: the STM-clear epoch silently bounds the downstream history
+    // window, which is non-obvious — an explicit trace of when one is applied is
+    // worth keeping for operators debugging history truncation.
     logger.debug(
-      { personaId, contextEpoch: contextEpoch.toISOString() },
-      'Applying context epoch filter (STM clear)'
+      { personaId, contextEpoch: resolvedEpoch.toISOString() },
+      'Resolved STM context-epoch (history will be bounded by it)'
     );
   }
 
-  // Note: History fetching is deferred to buildContext which has access to options
-  // This allows choosing between personality-filtered or full channel history
-  // based on whether extended context is enabled.
-  const history: ConversationMessage[] = [];
-
   return {
-    internalUserId,
-    discordUserId,
+    internalUserId: userId,
+    discordUserId: user.id,
     personaId,
     personaName,
-    userTimezone,
-    contextEpoch,
-    history,
+    userTimezone: timezone,
+    contextEpoch: resolvedEpoch,
+    // History is fetched later in buildContext (it chooses personality-filtered
+    // vs full channel history based on options), so this stays empty here.
+    history: [],
   };
 }


### PR DESCRIPTION
## Context

Phase 2 of evicting Prisma from `bot-client` (the work that unblocks **PR-2p**). Phase 1 (#1278) stood up the `routing-context` endpoint inert; this cuts the **message-author** resolution over to it.

## What it does

`resolveUserContext` (the author's internal-id / persona / timezone / STM-epoch resolution) stops doing local Prisma — it calls `serviceClient.routingContextCreate` instead. The provisioning + persona cascade + epoch now run server-side in one round-trip, where Prisma is legal. `MessageContextBuilder` takes a `ServiceClient` (composition root passes `getServiceClient()`); the local `lookupContextEpoch` is deleted.

**This is the validation-sensitive cutover** — it changes the live message path. It does NOT yet remove Prisma from bot-client: the mention + history consumers still use it (Phase 3), and the `getPrismaClient` eviction + depcruise-guard tightening land in Phase 4.

## Consumer scope (from Phase-2 recon)

The author path was the one clean 1:1 live cutover. `MentionResolver` (partially-live, feeds persisted content) is deferred to Phase 3. `ReferenceEnrichmentService` turned out to be **vestigial** (its enrichment is never shipped or persisted — `PersonalityChatManager:267` passes an always-`undefined` field) — surfaced as a delete-vs-fix decision, filed for Phase 4, deliberately NOT bundled here.

## Schema fold-ins (the 4 deferred #1278 items, now verifiable at the call-site)

- `personalityId` → `z.string().uuid()` — confirmed `personality.id` is always a `uuidv5` (`generatePersonalityUuid`), so the constraint is exact
- `username` → `.min(1)` (schema-enforce the non-empty caller contract)
- response `personaId` → `z.union([z.string().uuid(), z.literal('')])` (encode the system-default empty-string case)
- drop the dead `UserService: vi.fn()` mock in the handler test

## Tests

- `UserContextResolver.test` rewritten to mock the `ServiceClient` (asserts request shape + response→`UserContextResult` mapping, incl. epoch parse, null personaName, bot/non-bot failure paths)
- `MessageContextBuilder.test` mocks `resolveUserContext` at the seam — author resolution is now `UserContextResolver`'s unit; orchestration / epoch / weigh-in coverage retained (the weigh-in test now genuinely exercises the epoch-drop)
- new schema contract tests for the tightened constraints

## Verification

- Unit: common-types 2856 · api-gateway 2142 · bot-client 5087 — all green
- `pnpm quality`: 16/16 (typecheck, lint, depcruise, knip, cpd, audit, codegen-drift, backlog)
- `pnpm test:int`: 433 passed — conformance replay validates the route against a real uuidv5 personality

## Post-merge

Dev round-trip: reply/mention a personality on dev; confirm the author's persona + timezone resolve via the endpoint and the message gets a normal reply (the mention/history paths still hit Prisma — expected until Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)