### PR TITLE
test(ai-worker): lock the 2.5d envelope contract (producer→schema→consumer)

### DIFF
--- a/services/ai-worker/src/services/context/ContextAssembler.int.test.ts
+++ b/services/ai-worker/src/services/context/ContextAssembler.int.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Component test: `ContextAssembler.assembleCore` against REAL PGLite.
+ *
+ * This un-stubs what `AIJobProcessor.int.test.ts` deliberately skips — that test
+ * stubs the ENTIRE ContextStep because the real assembler reads Prisma, which its
+ * harness didn't wire. Here we wire the REAL `PrismaContextDataSource` +
+ * `UserService` + `PersonaResolver` over PGLite, seed real users/personas/history,
+ * and assert the assembler re-derives the core surfaces from actual DB state.
+ *
+ * This is the real-data third of the producer→schema→consumer contract that the
+ * 2.5d Prisma-eviction epic deleted bot-client code against on the claim "the
+ * worker re-derives identical context from rawAssemblyInputs":
+ *  - producer half  → RawEnvelopeBuilder.test.ts (real builder conforms to schema)
+ *  - mocked consumer → ContextAssembler.test.ts (assembleCore over faithful doubles)
+ *  - real consumer   → THIS FILE (assembleCore over real PGLite)
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  MessageRole,
+  PrismaClient,
+  UserService,
+  PersonaResolver,
+  generateUserUuid,
+  generatePersonaUuid,
+  generatePersonalityUuid,
+  generateSystemPromptUuid,
+  generateConversationHistoryUuid,
+  rawAssemblyInputsSchema,
+  type JobContext,
+  type LoadedPersonality,
+} from '@tzurot/common-types';
+import type { PGlite } from '@electric-sql/pglite';
+import { PrismaPGlite } from 'pglite-prisma-adapter';
+import { createTestPGlite, loadPGliteSchema, seedUserWithPersona } from '@tzurot/test-utils';
+import { ContextAssembler } from './ContextAssembler.js';
+import { PrismaContextDataSource } from './PrismaContextDataSource.js';
+
+const DISCORD_USER_ID = '123456789012345678';
+const CHANNEL_ID = 'test-channel-987';
+const GUILD_ID = 'test-guild-654';
+
+describe('ContextAssembler.assembleCore — PGLite component', () => {
+  let prisma: PrismaClient;
+  let pglite: PGlite;
+  let assembler: ContextAssembler;
+  let userId: string;
+  let personaId: string;
+  let personalityId: string;
+  let personality: LoadedPersonality;
+
+  beforeAll(async () => {
+    pglite = createTestPGlite();
+    await pglite.exec(loadPGliteSchema());
+    prisma = new PrismaClient({ adapter: new PrismaPGlite(pglite) }) as PrismaClient;
+
+    // User + default persona (Phase 5b: the pair must be created atomically).
+    userId = generateUserUuid(DISCORD_USER_ID);
+    personaId = generatePersonaUuid('test-user', userId);
+    await seedUserWithPersona(prisma, {
+      userId,
+      personaId,
+      discordId: DISCORD_USER_ID,
+      username: 'test-user',
+      personaName: 'test-user',
+    });
+    // A non-default timezone so the assembled `userTimezone` proves a REAL read,
+    // not the 'UTC' fallback.
+    await prisma.user.update({ where: { id: userId }, data: { timezone: 'America/New_York' } });
+
+    const systemPrompt = await prisma.systemPrompt.create({
+      data: {
+        id: generateSystemPromptUuid('assembler-int-prompt'),
+        name: 'assembler-int-prompt',
+        content: 'You are a test assistant.',
+      },
+    });
+    personalityId = generatePersonalityUuid('assembler-int');
+    await prisma.personality.create({
+      data: {
+        id: personalityId,
+        name: 'AssemblerIntBot',
+        slug: 'assembler-int',
+        displayName: 'Assembler Int Bot',
+        systemPromptId: systemPrompt.id,
+        ownerId: userId,
+        characterInfo: 'A test bot',
+        personalityTraits: 'Helpful and deterministic',
+      },
+    });
+    personality = { id: personalityId, name: 'AssemblerIntBot' } as LoadedPersonality;
+
+    // Two channel-history rows (chronological); getChannelHistory reads them by
+    // channelId. discordMessageId lets the trigger-exclusion test target one.
+    const seedTurn = async (
+      content: string,
+      role: MessageRole,
+      createdAt: Date,
+      discordMessageId: string
+    ): Promise<void> => {
+      await prisma.conversationHistory.create({
+        data: {
+          id: generateConversationHistoryUuid(CHANNEL_ID, personalityId, personaId, createdAt),
+          channelId: CHANNEL_ID,
+          guildId: GUILD_ID,
+          personalityId,
+          personaId,
+          role,
+          content,
+          discordMessageId: [discordMessageId],
+          createdAt,
+        },
+      });
+    };
+    await seedTurn('first user turn', MessageRole.User, new Date('2026-06-01T10:00:00Z'), 'dm-1');
+    await seedTurn(
+      'assistant reply',
+      MessageRole.Assistant,
+      new Date('2026-06-01T10:01:00Z'),
+      'dm-2'
+    );
+
+    assembler = new ContextAssembler({
+      dataSource: new PrismaContextDataSource(prisma),
+      userService: new UserService(prisma),
+      personaResolver: new PersonaResolver(prisma),
+    });
+  }, 30000);
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+    await pglite.close();
+  }, 30000);
+
+  function jobContext(partial: Partial<JobContext> = {}): JobContext {
+    return {
+      userId: DISCORD_USER_ID,
+      userName: 'test-user',
+      channelId: CHANNEL_ID,
+      serverId: GUILD_ID,
+      rawAssemblyInputs: rawAssemblyInputsSchema.parse({ rawMessageContent: 'live trigger' }),
+      ...partial,
+    } as JobContext;
+  }
+
+  it('re-derives core surfaces from real DB state (user, timezone, history, persona)', async () => {
+    const core = await assembler.assembleCore(jobContext(), personality, undefined);
+
+    // User upsert resolved to the SEEDED internal user row.
+    expect(core.userInternalId).toBe(userId);
+    // Timezone read from the real user row (proves it's not the UTC fallback).
+    expect(core.userTimezone).toBe('America/New_York');
+    // History hydrated from the two seeded rows.
+    const contents = core.history.map(m => m.content);
+    expect(contents).toContain('first user turn');
+    expect(contents).toContain('assistant reply');
+    // A personal summon resolves SOME persona from the DB (the seeded default).
+    expect(core.activePersonaId).not.toBeNull();
+    // Raw message content passes through (no mentions to rewrite).
+    expect(core.messageContent).toBe('live trigger');
+  });
+
+  it('excludes the trigger message from the assembled history', async () => {
+    // dm-1 is a seeded row; naming it as the trigger drops it from the assembled
+    // history (the worker filters the just-persisted trigger to avoid a double).
+    const core = await assembler.assembleCore(
+      jobContext({ triggerMessageId: 'dm-1' }),
+      personality,
+      undefined
+    );
+    const contents = core.history.map(m => m.content);
+    expect(contents).not.toContain('first user turn'); // dm-1 excluded
+    expect(contents).toContain('assistant reply'); // dm-2 retained
+  });
+});

--- a/services/ai-worker/src/services/context/ContextAssembler.test.ts
+++ b/services/ai-worker/src/services/context/ContextAssembler.test.ts
@@ -10,6 +10,7 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 
 import {
   MessageRole,
+  rawAssemblyInputsSchema,
   type JobContext,
   type LoadedPersonality,
   type ResolvedConfigOverrides,
@@ -759,5 +760,80 @@ describe('ContextAssembler.assembleCore', () => {
     );
 
     expect(poisoned).toEqual(clean);
+  });
+});
+
+describe('ContextAssembler.assembleCore — schema-coupled re-derivation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // The cases above feed hand-built envelope objects. This one first round-trips a
+  // realistic envelope through `rawAssemblyInputsSchema` (the EXACT wire shape
+  // bot-client ships) and assembles from the PARSED result — proving the consumer
+  // re-derives correctly from a schema-valid envelope, not just from ad-hoc TS
+  // objects whose fields the schema might strip or coerce. Consumer half of the
+  // producer↔schema↔consumer contract (producer half: RawEnvelopeBuilder.test.ts;
+  // real-data half: ContextAssembler.int.test.ts).
+  it('assembles core surfaces from a schema-validated envelope', async () => {
+    const envelope = rawAssemblyInputsSchema.parse({
+      rawMessageContent: 'hello from the wire',
+      rawAuthorDisplayName: 'Vladlena',
+      rawParticipantGuildInfo: { 'discord:111': { roles: ['Admin'] } },
+      rawExtendedContextMessages: [
+        {
+          role: MessageRole.User,
+          content: 'earlier message',
+          createdAt: '2026-06-01T00:00:00.000Z',
+          personaId: 'discord:111',
+          discordUsername: 'alice',
+          discordMessageId: ['m-ext-1'],
+        },
+      ],
+      rawExtendedContextUsers: [{ discordId: '111', username: 'alice', displayName: 'Alice' }],
+    });
+
+    const deps = makeDeps({
+      dataSource: {
+        getChannelHistory: vi.fn().mockResolvedValue([]),
+        getUserTimezone: vi.fn().mockResolvedValue('America/New_York'),
+      },
+      userService: {
+        getOrCreateUser: vi.fn().mockResolvedValue({ userId: 'internal-1' }),
+        getOrCreateUsersInBatch: vi.fn().mockResolvedValue(new Map([['111', { userId: 'u-111' }]])),
+      },
+    });
+    const assembler = new ContextAssembler(deps);
+
+    const core = await assembler.assembleCore(
+      makeJobContext({ rawAssemblyInputs: envelope }),
+      PERSONALITY,
+      undefined
+    );
+
+    // Surfaces re-derived from the schema-valid envelope + faithful doubles.
+    expect(core.userTimezone).toBe('America/New_York');
+    expect(core.messageContent).toBe('hello from the wire');
+    expect(core.activePersonaId).toBe('persona-1');
+    // The extended-context message merged into the assembled history.
+    expect(core.history.some(m => m.content === 'earlier message')).toBe(true);
+    // The guild map survived re-keying (shared resolver remaps discord:* keys).
+    expect(core.participantGuildInfo).toBeDefined();
+    expect(Object.keys(core.participantGuildInfo ?? {})).toHaveLength(1);
+  });
+
+  it('assembles from a MINIMAL schema-valid envelope (content only)', async () => {
+    // The leanest legal envelope: only rawMessageContent. The schema accepts it;
+    // the consumer must too (history comes from DB alone, no extended context).
+    const envelope = rawAssemblyInputsSchema.parse({ rawMessageContent: 'just text' });
+    const core = await new ContextAssembler(makeDeps()).assembleCore(
+      makeJobContext({ rawAssemblyInputs: envelope }),
+      PERSONALITY,
+      undefined
+    );
+    expect(core.messageContent).toBe('just text');
+    expect(core.history).toEqual([]);
+    expect(core.participantGuildInfo).toBeUndefined();
+    expect(core.referencedMessages).toBeUndefined();
   });
 });

--- a/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.test.ts
+++ b/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
-import { MessageRole, type ConversationMessage } from '@tzurot/common-types';
+import {
+  MessageRole,
+  rawAssemblyInputsSchema,
+  type ConversationMessage,
+  type RawAssemblyInputs,
+} from '@tzurot/common-types';
 import type { Message } from 'discord.js';
 
 const { mockGetVoiceTranscript } = vi.hoisted(() => ({
@@ -228,5 +233,63 @@ describe('buildRawAssemblyInputs', () => {
     const raw = buildRawAssemblyInputs(makeMessage([], 'plain'), undefined);
     expect(raw?.rawMentionedUsers).toBeUndefined();
     expect(raw?.rawExtendedContextMessages).toBeUndefined();
+  });
+});
+
+describe('buildRawAssemblyInputs — producer↔schema conformance', () => {
+  // `rawAssemblyInputsSchema` IS the wire contract between this producer
+  // (bot-client) and the worker's ContextAssembler consumer. These cases run the
+  // REAL builder and assert its output is ACCEPTED by the schema — so a field the
+  // builder emits (or a shape it changes) can never silently diverge from what the
+  // worker validates against. This is the producer half of the consumer-driven
+  // contract; the consumer half is ContextAssembler.test.ts / .int.test.ts.
+  // Returns the Zod error message verbatim on failure (it names the offending
+  // field), or null on conformance — the caller asserts `.toBeNull()` so the
+  // assertion lives in the test body (vitest/expect-expect) AND failures stay legible.
+  const conformanceError = (raw: RawAssemblyInputs): string | null => {
+    const result = rawAssemblyInputsSchema.safeParse(raw);
+    return result.success ? null : result.error.message;
+  };
+
+  it('minimal envelope (plain text, no extended context) conforms', () => {
+    expect(
+      conformanceError(buildRawAssemblyInputs(makeMessage([], 'just text'), undefined))
+    ).toBeNull();
+  });
+
+  it('full envelope (mentions + extended context + reactors + env map) conforms', () => {
+    const snapshot = {
+      messages: [makeConversationMessage()],
+      extendedContextUsers: [
+        { discordId: '111', username: 'alice', displayName: 'Alice', isBot: false },
+      ],
+      reactorUsers: [{ discordId: '222', username: 'rea', isBot: true }],
+    };
+    const raw = buildRawAssemblyInputs(
+      makeMessage(
+        [{ id: '333', username: 'mention-target', globalName: 'Mention Target' }],
+        '<@333> raw content'
+      ),
+      snapshot
+    );
+    expect(conformanceError(raw)).toBeNull();
+  });
+
+  it('envelope with guild surfaces + refs + channel/role mentions conforms', () => {
+    const snapshot = {
+      messages: [],
+      extendedContextUsers: [],
+      reactorUsers: [],
+      participantGuildInfo: { 'discord:111': { roles: ['Admin'], displayColor: '#FF00FF' } },
+      imageAttachments: [{ url: 'https://cdn/img.png', contentType: 'image/png', id: 'a1' }],
+    };
+    const raw = buildRawAssemblyInputs(makeMessage([], 'plain'), snapshot, {
+      rawReferencedMessages: [],
+      rawMentionedChannels: [{ channelId: '1', channelName: 'general', guildId: 'g1' }],
+      rawMentionedRoles: [{ roleId: '2', roleName: 'mods', mentionable: false }],
+      rawActiveGuildMemberInfo: { roles: ['Mod'], joinedAt: '2024-01-01T00:00:00.000Z' },
+      rawAuthorDisplayName: 'Vladlena',
+    });
+    expect(conformanceError(raw)).toBeNull();
   });
 });


### PR DESCRIPTION
## What

**Phase 1.5 pilot audit** of the 2.5d Prisma-eviction epic. The audit surfaced the epic's highest-risk, least-covered surface: the "worker re-derives identical context from `rawAssemblyInputs`" claim — that **every slice deleted bot-client code against** — was verified only by *mocked unit tests on each side independently*, with **no test connecting the real producer output to the real consumer derivation**. The one component test that could catch a real-data divergence (`AIJobProcessor.int`) explicitly stubs assembly out.

This PR fills that gap with three tests that lock the contract end-to-end at the shared-schema boundary (consumer-driven — each side verified against `rawAssemblyInputsSchema`).

## The gap matrix (what the audit found)

| Surface | Before |
|---|---|
| Envelope **shape** | ✅ already schema-locked (`rawEnvelope.test` / `jobs.test`) |
| Real `buildRawAssemblyInputs` output conforms to schema | ❌ only helper-level units + one spot-check |
| Worker re-derives from real envelope **against real data** | ❌ `ContextAssembler.test` mocks the dataSource; `AIJobProcessor.int` **stubs the entire ContextStep** |
| Cross-service envelope contract | ❌ `tests/e2e/contracts/BullMQJob*` predate the envelope, don't touch it |

## The three tests

1. **`RawEnvelopeBuilder.test.ts`** (producer, +3) — run the REAL `buildRawAssemblyInputs` and assert its output conforms to `rawAssemblyInputsSchema`. Catches a builder field/shape drift from what the worker validates against.
2. **`ContextAssembler.test.ts`** (consumer, +2) — feed a schema-**parsed** envelope into the real `assembleCore` over faithful doubles; asserts re-derived surfaces. Ties the consumer to the schema's output, not ad-hoc TS objects.
3. **`ContextAssembler.int.test.ts`** (NEW, component/PGLite) — **un-stub assembly**: wire the REAL `PrismaContextDataSource` + `UserService` + `PersonaResolver` over PGLite, seed users/personas/history, and assert `assembleCore` re-derives core surfaces (user, timezone, history hydration, persona, trigger-exclusion) from real DB state.

## Design notes

- **Placement is colocated-per-side**, not `tests/e2e/contracts/`, to avoid cross-service imports (a single test importing both bot-client and ai-worker internals). The shared schema **is** the contract artifact each side verifies against — the consumer-driven-contract pattern.
- Tier-wise: tests 1–2 are unit (real code, no external deps); test 3 is **component** (`.int.test.ts`, PGLite) per the [taxonomy](https://github.com/lbds137/tzurot/blob/develop/docs/reference/guides/TESTING.md#test-tier-taxonomy) just reconciled in #1284.

## Verification

- `pnpm --filter @tzurot/bot-client test` (RawEnvelopeBuilder: 15) · `ContextAssembler.test` (29) · `ContextAssembler.int.test` via int config (2) — all green.
- `pnpm quality` green.

Part of the [test-pyramid-coverage-audit theme](https://github.com/lbds137/tzurot/blob/develop/backlog/cold/themes/test-pyramid-coverage-audit.md) (Phase 1.5 pilot). Next: finish the 2.5d epic (full `getChannelHistory` eviction + Phase 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)