### PR TITLE
refactor(bot-client): strip vestigial user-mention Prisma resolution

### DIFF
--- a/services/bot-client/src/index.ts
+++ b/services/bot-client/src/index.ts
@@ -237,12 +237,7 @@ function createServices(): Services {
 
   // Message handling services
   const responseSender = new DiscordResponseSender(webhookManager);
-  const contextBuilder = new MessageContextBuilder(
-    prisma,
-    personaResolver,
-    getServiceClient(),
-    denylistCache
-  );
+  const contextBuilder = new MessageContextBuilder(getServiceClient(), denylistCache);
   const persistence = new ConversationPersistence();
   const voiceTranscription = new VoiceTranscriptionService();
   const replyResolver = new ReplyResolutionService(routingPersonalityLoader);

--- a/services/bot-client/src/services/MentionResolver.test.ts
+++ b/services/bot-client/src/services/MentionResolver.test.ts
@@ -1,11 +1,15 @@
 /**
  * Tests for MentionResolver
+ *
+ * MentionResolver is now a stateless guild-cache rewriter: channel + role
+ * mentions only. User→persona resolution moved worker-side (the worker
+ * re-derives it from the envelope and overwrites the message content), so user
+ * mentions are left RAW here. The real `rewriteChannelMentions`/`rewriteRoleMentions`
+ * kernels run unmocked, so these stay genuine behavior tests.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { MentionResolver } from './MentionResolver.js';
-import type { PrismaClient } from '@tzurot/common-types';
-import type { Collection, User } from 'discord.js';
 
 // Valid Discord snowflake IDs for testing (17-19 digit numeric strings)
 const VALID_CHANNEL_ID = '123456789012345678';
@@ -14,469 +18,14 @@ const VALID_ROLE_ID = '345678901234567890';
 const VALID_ROLE_ID_2 = '456789012345678901';
 const VALID_USER_ID = '567890123456789012';
 
-// Mock PersonaResolver
-const mockPersonaResolver = {
-  resolve: vi.fn(),
-  resolveForMemory: vi.fn(),
-  getPersonaContentForPrompt: vi.fn(),
-  invalidateUserCache: vi.fn(),
-  clearCache: vi.fn(),
-  stopCleanup: vi.fn(),
-};
-
-// Partial mock: the REAL mention-rewriting kernels (and their constants) run
-// so these stay genuine behavior tests of the scan/cap/placeholder rules;
-// only the DB-backed UserService and the logger are stubbed.
-vi.mock('@tzurot/common-types', async importOriginal => {
-  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
-  return {
-    ...actual,
-    UserService: class {
-      getOrCreateUser = vi.fn();
-      getPersonaName = vi.fn();
-    },
-    createLogger: () => ({
-      info: vi.fn(),
-      debug: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    }),
-  };
-});
-
-// Import after mocks
-import { UserService } from '@tzurot/common-types';
-
 describe('MentionResolver', () => {
   let resolver: MentionResolver;
-  let mockPrisma: PrismaClient;
-  let mockUserService: UserService;
-  let mockMentionedUsers: Map<string, User>;
 
   beforeEach(() => {
-    vi.clearAllMocks();
-
-    // Create mock Prisma client
-    mockPrisma = {
-      user: {
-        findUnique: vi.fn(),
-      },
-    } as unknown as PrismaClient;
-
-    // Create resolver instance with mock PersonaResolver
-    resolver = new MentionResolver(mockPrisma, mockPersonaResolver as any);
-
-    // Get service instance to access mocks
-    mockUserService = (resolver as any).userService;
-
-    // Create mock mentioned users Collection
-    mockMentionedUsers = new Map();
-
-    // Default mock for PersonaResolver.resolve
-    mockPersonaResolver.resolve.mockResolvedValue({
-      config: {
-        personaId: 'persona-123',
-        preferredName: 'Test Persona',
-        pronouns: null,
-        content: '',
-      },
-      source: 'user-default',
-    });
-  });
-
-  /**
-   * Helper to create a mock Discord User
-   */
-  function createMockUser(id: string, username: string, globalName: string | null = null): User {
-    return {
-      id,
-      username,
-      globalName,
-    } as User;
-  }
-
-  describe('resolveMentions', () => {
-    it('should return unchanged content when no mentions present', async () => {
-      const result = await resolver.resolveMentions(
-        'Hello, this is a message without mentions',
-        mockMentionedUsers as Collection<string, User>,
-        'personality-123'
-      );
-
-      expect(result.processedContent).toBe('Hello, this is a message without mentions');
-      expect(result.mentionedUsers).toEqual([]);
-    });
-
-    it('should resolve a single mention when Discord user is available', async () => {
-      const mockUser = createMockUser('567890123456789012', 'testuser', 'Test User');
-      mockMentionedUsers.set('567890123456789012', mockUser);
-
-      vi.mocked(mockUserService.getOrCreateUser).mockResolvedValue({
-        userId: 'user-uuid-123',
-        defaultPersonaId: 'test-persona-id',
-      });
-      // PersonaResolver.resolve mock returns 'persona-123' and 'Test Persona' by default
-
-      const result = await resolver.resolveMentions(
-        'Hey <@567890123456789012>, how are you?',
-        mockMentionedUsers as Collection<string, User>,
-        'personality-123'
-      );
-
-      expect(result.processedContent).toBe('Hey @Test Persona, how are you?');
-      expect(result.mentionedUsers).toHaveLength(1);
-      expect(result.mentionedUsers[0]).toEqual({
-        discordId: '567890123456789012',
-        userId: 'user-uuid-123',
-        personaId: 'persona-123',
-        personaName: 'Test Persona',
-      });
-
-      expect(mockUserService.getOrCreateUser).toHaveBeenCalledWith(
-        '567890123456789012',
-        'testuser',
-        'Test User',
-        undefined, // bio
-        undefined // isBot
-      );
-      // PersonaResolver uses Discord ID directly
-      expect(mockPersonaResolver.resolve).toHaveBeenCalledWith(
-        '567890123456789012', // Discord ID
-        'personality-123'
-      );
-    });
-
-    it('should handle nickname mention format with exclamation mark', async () => {
-      const mockUser = createMockUser('567890123456789012', 'testuser', 'Test User');
-      mockMentionedUsers.set('567890123456789012', mockUser);
-
-      vi.mocked(mockUserService.getOrCreateUser).mockResolvedValue({
-        userId: 'user-uuid-123',
-        defaultPersonaId: 'test-persona-id',
-      });
-      // PersonaResolver.resolve mock returns 'persona-123' and 'Test Persona' by default
-
-      const result = await resolver.resolveMentions(
-        'Hey <@!567890123456789012>, how are you?',
-        mockMentionedUsers as Collection<string, User>,
-        'personality-123'
-      );
-
-      expect(result.processedContent).toBe('Hey @Test Persona, how are you?');
-      expect(result.mentionedUsers).toHaveLength(1);
-    });
-
-    it('should deduplicate multiple mentions of the same user', async () => {
-      const mockUser = createMockUser('567890123456789012', 'testuser', 'Test User');
-      mockMentionedUsers.set('567890123456789012', mockUser);
-
-      vi.mocked(mockUserService.getOrCreateUser).mockResolvedValue({
-        userId: 'user-uuid-123',
-        defaultPersonaId: 'test-persona-id',
-      });
-      // PersonaResolver.resolve mock returns 'persona-123' and 'Test Persona' by default
-
-      const result = await resolver.resolveMentions(
-        'Hey <@567890123456789012>! I was just talking to <@567890123456789012> about you, <@567890123456789012>',
-        mockMentionedUsers as Collection<string, User>,
-        'personality-123'
-      );
-
-      expect(result.processedContent).toBe(
-        'Hey @Test Persona! I was just talking to @Test Persona about you, @Test Persona'
-      );
-      expect(result.mentionedUsers).toHaveLength(1); // Only one entry
-
-      // Service should only be called once per unique user
-      expect(mockUserService.getOrCreateUser).toHaveBeenCalledTimes(1);
-    });
-
-    it('should resolve multiple different users', async () => {
-      const mockUser1 = createMockUser('611111111111111111', 'alice', 'Alice');
-      const mockUser2 = createMockUser('622222222222222222', 'bob', 'Bob');
-      mockMentionedUsers.set('611111111111111111', mockUser1);
-      mockMentionedUsers.set('622222222222222222', mockUser2);
-
-      vi.mocked(mockUserService.getOrCreateUser)
-        .mockResolvedValueOnce({ userId: 'alice-uuid', defaultPersonaId: 'alice-persona' })
-        .mockResolvedValueOnce({ userId: 'bob-uuid', defaultPersonaId: 'bob-persona' });
-      mockPersonaResolver.resolve
-        .mockResolvedValueOnce({
-          config: {
-            personaId: 'alice-persona',
-            preferredName: 'AlicePersona',
-            pronouns: null,
-            content: '',
-          },
-          source: 'user-default',
-        })
-        .mockResolvedValueOnce({
-          config: {
-            personaId: 'bob-persona',
-            preferredName: 'BobPersona',
-            pronouns: null,
-            content: '',
-          },
-          source: 'user-default',
-        });
-
-      const result = await resolver.resolveMentions(
-        'Hey <@611111111111111111> and <@622222222222222222>, lets chat!',
-        mockMentionedUsers as Collection<string, User>,
-        'personality-123'
-      );
-
-      expect(result.processedContent).toBe('Hey @AlicePersona and @BobPersona, lets chat!');
-      expect(result.mentionedUsers).toHaveLength(2);
-      expect(result.mentionedUsers[0].personaName).toBe('AlicePersona');
-      expect(result.mentionedUsers[1].personaName).toBe('BobPersona');
-    });
-
-    it('should fall back to database lookup when user not in mentions collection', async () => {
-      // User not in Discord mentions, but exists in our database
-      const mockDbUser = { id: 'db-user-uuid', username: 'existinguser' };
-      vi.mocked(mockPrisma.user.findUnique).mockResolvedValue(mockDbUser as any);
-      mockPersonaResolver.resolve.mockResolvedValue({
-        config: {
-          personaId: 'db-persona-uuid',
-          preferredName: 'ExistingPersona',
-          pronouns: null,
-          content: '',
-        },
-        source: 'user-default',
-      });
-
-      const result = await resolver.resolveMentions(
-        'Talking about <@699999999999999999> who is not online',
-        mockMentionedUsers as Collection<string, User>,
-        'personality-123'
-      );
-
-      expect(result.processedContent).toBe('Talking about @ExistingPersona who is not online');
-      expect(result.mentionedUsers).toHaveLength(1);
-      expect(result.mentionedUsers[0]).toEqual({
-        discordId: '699999999999999999',
-        userId: 'db-user-uuid',
-        personaId: 'db-persona-uuid',
-        personaName: 'ExistingPersona',
-      });
-
-      expect(mockPrisma.user.findUnique).toHaveBeenCalledWith({
-        where: { discordId: '699999999999999999' },
-        select: { id: true, username: true },
-      });
-    });
-
-    it('should leave mention as-is when user cannot be resolved', async () => {
-      // User not in Discord mentions AND not in database
-      vi.mocked(mockPrisma.user.findUnique).mockResolvedValue(null);
-
-      const result = await resolver.resolveMentions(
-        'Talking about <@699999999999999999> who is unknown',
-        mockMentionedUsers as Collection<string, User>,
-        'personality-123'
-      );
-
-      expect(result.processedContent).toBe('Talking about <@699999999999999999> who is unknown');
-      expect(result.mentionedUsers).toEqual([]);
-    });
-
-    it('should use username as fallback when globalName is null', async () => {
-      const mockUser = createMockUser('567890123456789012', 'testuser', null);
-      mockMentionedUsers.set('567890123456789012', mockUser);
-
-      vi.mocked(mockUserService.getOrCreateUser).mockResolvedValue({
-        userId: 'user-uuid-123',
-        defaultPersonaId: 'test-persona-id',
-      });
-      mockPersonaResolver.resolve.mockResolvedValue({
-        config: {
-          personaId: 'persona-uuid-123',
-          preferredName: null,
-          pronouns: null,
-          content: '',
-        },
-        source: 'user-default',
-      });
-
-      const result = await resolver.resolveMentions(
-        'Hey <@567890123456789012>!',
-        mockMentionedUsers as Collection<string, User>,
-        'personality-123'
-      );
-
-      // Should fall back to the display name (username in this case)
-      expect(result.processedContent).toBe('Hey @testuser!');
-      expect(result.mentionedUsers[0].personaName).toBe('testuser');
-
-      expect(mockUserService.getOrCreateUser).toHaveBeenCalledWith(
-        '567890123456789012',
-        'testuser',
-        'testuser', // Falls back to username
-        undefined, // bio
-        undefined // isBot
-      );
-    });
-
-    it('should handle error in user service gracefully', async () => {
-      const mockUser = createMockUser('567890123456789012', 'testuser', 'Test User');
-      mockMentionedUsers.set('567890123456789012', mockUser);
-
-      vi.mocked(mockUserService.getOrCreateUser).mockRejectedValue(new Error('Database error'));
-
-      const result = await resolver.resolveMentions(
-        'Hey <@567890123456789012>!',
-        mockMentionedUsers as Collection<string, User>,
-        'personality-123'
-      );
-
-      // Should leave mention as-is on error
-      expect(result.processedContent).toBe('Hey <@567890123456789012>!');
-      expect(result.mentionedUsers).toEqual([]);
-    });
-
-    it('should handle error in database lookup gracefully', async () => {
-      vi.mocked(mockPrisma.user.findUnique).mockRejectedValue(new Error('Database error'));
-
-      const result = await resolver.resolveMentions(
-        'Hey <@567890123456789012>!',
-        mockMentionedUsers as Collection<string, User>,
-        'personality-123'
-      );
-
-      // Should leave mention as-is on error
-      expect(result.processedContent).toBe('Hey <@567890123456789012>!');
-      expect(result.mentionedUsers).toEqual([]);
-    });
-
-    it('should handle mixed resolved and unresolved mentions', async () => {
-      const mockUser = createMockUser('611111111111111111', 'alice', 'Alice');
-      mockMentionedUsers.set('611111111111111111', mockUser);
-
-      vi.mocked(mockUserService.getOrCreateUser).mockResolvedValue({
-        userId: 'alice-uuid',
-        defaultPersonaId: 'alice-persona-id',
-      });
-      mockPersonaResolver.resolve.mockResolvedValue({
-        config: {
-          personaId: 'alice-persona',
-          preferredName: 'AlicePersona',
-          pronouns: null,
-          content: '',
-        },
-        source: 'user-default',
-      });
-      vi.mocked(mockPrisma.user.findUnique).mockResolvedValue(null);
-
-      const result = await resolver.resolveMentions(
-        'Hey <@611111111111111111> and <@699999999999999999>, lets chat!',
-        mockMentionedUsers as Collection<string, User>,
-        'personality-123'
-      );
-
-      // Alice resolved, unknown user left as-is
-      expect(result.processedContent).toBe(
-        'Hey @AlicePersona and <@699999999999999999>, lets chat!'
-      );
-      expect(result.mentionedUsers).toHaveLength(1);
-      expect(result.mentionedUsers[0].personaName).toBe('AlicePersona');
-    });
-
-    it('should use database username as fallback when persona name is null', async () => {
-      vi.mocked(mockPrisma.user.findUnique).mockResolvedValue({
-        id: 'db-user-uuid',
-        username: 'dbusername',
-      } as any);
-      mockPersonaResolver.resolve.mockResolvedValue({
-        config: {
-          personaId: 'persona-uuid',
-          preferredName: null,
-          pronouns: null,
-          content: '',
-        },
-        source: 'user-default',
-      });
-
-      const result = await resolver.resolveMentions(
-        'Hey <@567890123456789012>!',
-        mockMentionedUsers as Collection<string, User>,
-        'personality-123'
-      );
-
-      expect(result.processedContent).toBe('Hey @dbusername!');
-      expect(result.mentionedUsers[0].personaName).toBe('dbusername');
-    });
-
-    it('should handle both mention formats in the same message', async () => {
-      // Tests that both <@567890123456789012> and <@!567890123456789012> are replaced for the same user
-      const mockUser = createMockUser('567890123456789012', 'testuser', 'Test User');
-      mockMentionedUsers.set('567890123456789012', mockUser);
-
-      vi.mocked(mockUserService.getOrCreateUser).mockResolvedValue({
-        userId: 'user-uuid-123',
-        defaultPersonaId: 'test-persona-id',
-      });
-      // PersonaResolver.resolve mock returns 'persona-123' and 'Test Persona' by default
-
-      const result = await resolver.resolveMentions(
-        'Hey <@567890123456789012>! I was talking to <@!567890123456789012> about you, <@567890123456789012>',
-        mockMentionedUsers as Collection<string, User>,
-        'personality-123'
-      );
-
-      // All mention formats should be replaced
-      expect(result.processedContent).toBe(
-        'Hey @Test Persona! I was talking to @Test Persona about you, @Test Persona'
-      );
-      // Only one user entry (deduplicated)
-      expect(result.mentionedUsers).toHaveLength(1);
-      expect(result.mentionedUsers[0].personaName).toBe('Test Persona');
-
-      // Service should only be called once (deduplication)
-      expect(mockUserService.getOrCreateUser).toHaveBeenCalledTimes(1);
-    });
-
-    it('should respect max mentions limit for DoS prevention', async () => {
-      // Create 15 different users (more than the limit of 10) — valid
-      // snowflake ids, since non-snowflakes are filtered before the cap.
-      const manyIds = Array.from({ length: 15 }, (_, i) => `${700000000000000000n + BigInt(i)}`);
-      for (const id of manyIds) {
-        const mockUser = createMockUser(id, `user${id}`, `User ${id}`);
-        mockMentionedUsers.set(id, mockUser);
-      }
-
-      vi.mocked(mockUserService.getOrCreateUser).mockImplementation(async discordId => {
-        return { userId: `uuid-${discordId}`, defaultPersonaId: `persona-${discordId}` };
-      });
-      mockPersonaResolver.resolve.mockImplementation(async (discordId: string) => ({
-        config: {
-          personaId: `persona-${discordId}`,
-          preferredName: `Persona${discordId}`,
-          pronouns: null,
-          content: '',
-        },
-        source: 'user-default' as const,
-      }));
-
-      // Build a message with 15 mentions
-      const mentions = manyIds.map(id => `<@${id}>`).join(' ');
-      const result = await resolver.resolveMentions(
-        `Hello ${mentions}`,
-        mockMentionedUsers as Collection<string, User>,
-        'personality-123'
-      );
-
-      // Should only process MAX_PER_MESSAGE (10) users
-      expect(result.mentionedUsers.length).toBeLessThanOrEqual(10);
-      // User service should only be called up to 10 times
-      expect(mockUserService.getOrCreateUser).toHaveBeenCalledTimes(10);
-    });
+    resolver = new MentionResolver();
   });
 
   describe('resolveChannelMentions', () => {
-    /**
-     * Helper to create a mock Guild with channels
-     */
     function createMockGuild(channels: Map<string, { name: string; topic?: string }>) {
       return {
         id: 'guild-123',
@@ -485,10 +34,7 @@ describe('MentionResolver', () => {
             get: (id: string) => {
               const channel = channels.get(id);
               if (!channel) return undefined;
-              return {
-                name: channel.name,
-                topic: channel.topic,
-              };
+              return { name: channel.name, topic: channel.topic };
             },
           },
         },
@@ -541,7 +87,6 @@ describe('MentionResolver', () => {
 
     it('should handle unknown channel with placeholder', () => {
       const mockGuild = createMockGuild(new Map());
-      // Use a valid snowflake ID that's not in the cache
       const unknownChannelId = '999888777666555444';
 
       const result = resolver.resolveChannelMentions(`Check out <#${unknownChannelId}>`, mockGuild);
@@ -572,9 +117,6 @@ describe('MentionResolver', () => {
   });
 
   describe('resolveRoleMentions', () => {
-    /**
-     * Helper to create a mock Guild with roles
-     */
     function createMockGuild(roles: Map<string, { name: string; mentionable: boolean }>) {
       return {
         id: 'guild-123',
@@ -629,7 +171,6 @@ describe('MentionResolver', () => {
 
     it('should handle unknown role with placeholder', () => {
       const mockGuild = createMockGuild(new Map());
-      // Use a valid snowflake ID that's not in the cache
       const unknownRoleId = '888777666555444333';
 
       const result = resolver.resolveRoleMentions(`Hey <@&${unknownRoleId}>!`, mockGuild);
@@ -647,89 +188,63 @@ describe('MentionResolver', () => {
   });
 
   describe('resolveAllMentions', () => {
-    /**
-     * Helper to create a mock Message with all mention types
-     */
-    function createMockMessage(
-      _content: string,
-      users: Map<string, User>,
+    function createMockGuild(
       channels: Map<string, { name: string; topic?: string }>,
       roles: Map<string, { name: string; mentionable: boolean }>
     ) {
       return {
-        mentions: {
-          users: users as Collection<string, User>,
-        },
-        guild: {
-          id: 'guild-123',
-          channels: {
-            cache: {
-              get: (id: string) => {
-                const channel = channels.get(id);
-                if (!channel) return undefined;
-                return { name: channel.name, topic: channel.topic };
-              },
+        id: 'guild-123',
+        channels: {
+          cache: {
+            get: (id: string) => {
+              const channel = channels.get(id);
+              if (!channel) return undefined;
+              return { name: channel.name, topic: channel.topic };
             },
           },
-          roles: {
-            cache: {
-              get: (id: string) => roles.get(id),
-            },
+        },
+        roles: {
+          cache: {
+            get: (id: string) => roles.get(id),
           },
         },
       } as any;
     }
 
-    it('should resolve all mention types in a single message', async () => {
-      const mockUser = createMockUser(VALID_USER_ID, 'alice', 'Alice');
-      const mockUsers = new Map([[VALID_USER_ID, mockUser]]);
+    it('rewrites channel + role mentions but leaves USER mentions RAW (worker re-derives them)', () => {
       const mockChannels = new Map([[VALID_CHANNEL_ID, { name: 'general' }]]);
       const mockRoles = new Map([[VALID_ROLE_ID, { name: 'Mods', mentionable: true }]]);
+      const guild = createMockGuild(mockChannels, mockRoles);
 
-      const mockMessage = createMockMessage(
+      const result = resolver.resolveAllMentions(
         `Hey <@${VALID_USER_ID}>! Check <#${VALID_CHANNEL_ID}> or ask <@&${VALID_ROLE_ID}>`,
-        mockUsers,
-        mockChannels,
-        mockRoles
+        guild
       );
 
-      vi.mocked(mockUserService.getOrCreateUser).mockResolvedValue({
-        userId: 'alice-uuid',
-        defaultPersonaId: 'alice-persona-id',
-      });
-      mockPersonaResolver.resolve.mockResolvedValue({
-        config: {
-          personaId: 'alice-persona',
-          preferredName: 'AlicePersona',
-          pronouns: null,
-          content: '',
-        },
-        source: 'user-default',
-      });
-
-      const result = await resolver.resolveAllMentions(
-        `Hey <@${VALID_USER_ID}>! Check <#${VALID_CHANNEL_ID}> or ask <@&${VALID_ROLE_ID}>`,
-        mockMessage,
-        'personality-123'
-      );
-
-      expect(result.processedContent).toBe('Hey @AlicePersona! Check #general or ask @Mods');
-      expect(result.mentionedUsers).toHaveLength(1);
+      // The user mention is preserved verbatim — the worker rewrites it to a
+      // persona name from rawMentionedUsers. Channel + role are rewritten here.
+      expect(result.processedContent).toBe(`Hey <@${VALID_USER_ID}>! Check #general or ask @Mods`);
       expect(result.mentionedChannels).toHaveLength(1);
       expect(result.mentionedRoles).toHaveLength(1);
     });
 
-    it('should handle message with no mentions', async () => {
-      const mockMessage = createMockMessage('Hello world', new Map(), new Map(), new Map());
+    it('should handle content with no mentions', () => {
+      const guild = createMockGuild(new Map(), new Map());
 
-      const result = await resolver.resolveAllMentions(
-        'Hello world',
-        mockMessage,
-        'personality-123'
-      );
+      const result = resolver.resolveAllMentions('Hello world', guild);
 
       expect(result.processedContent).toBe('Hello world');
-      expect(result.mentionedUsers).toEqual([]);
+      expect(result.mentionedChannels).toEqual([]);
+      expect(result.mentionedRoles).toEqual([]);
+    });
+
+    it('handles a null guild (DM) — channel/role mentions degrade to placeholders', () => {
+      const result = resolver.resolveAllMentions(
+        `Check <#${VALID_CHANNEL_ID}> and <@&${VALID_ROLE_ID}>`,
+        null
+      );
+
+      expect(result.processedContent).toBe('Check #unknown-channel and @unknown-role');
       expect(result.mentionedChannels).toEqual([]);
       expect(result.mentionedRoles).toEqual([]);
     });

--- a/services/bot-client/src/services/MentionResolver.ts
+++ b/services/bot-client/src/services/MentionResolver.ts
@@ -1,123 +1,51 @@
 /**
- * MentionResolver - Resolves Discord mentions (users, channels, roles) in message content.
+ * MentionResolver - Resolves Discord channel/role mentions in message content.
  *
- * Thin Discord adapter over the shared mention-rewriting kernels in
- * common-types (`resolveUserMentions` / `rewriteChannelMentions` /
- * `rewriteRoleMentions`) — the scan/dedup/cap/placeholder rules live there
- * so ai-worker's content rewriter cannot drift from this path. This class
- * owns only the Discord-side lookups: the live mentions collection, the
- * guild cache, and the bot's DB fallback.
+ * Thin Discord adapter over the shared mention-rewriting kernels in common-types
+ * (`rewriteChannelMentions` / `rewriteRoleMentions`). It owns ONLY the
+ * guild-cache lookups the worker cannot re-derive: channel and role names live
+ * in the Discord guild cache, which only bot-client has.
+ *
+ * User-mention resolution (`<@id>` → persona name) is intentionally NOT done
+ * here. The worker's `ContextAssembler.rewriteRawContent` re-derives it from the
+ * shipped `rawMentionedUsers` against the worker's OWN Prisma, and `ContextStep`
+ * unconditionally overwrites the message content with that re-derivation
+ * (`job.data.message = assembled.messageContent`). Resolving user mentions
+ * bot-side would be a vestigial Prisma read — so it was stripped (the worker is
+ * the single source of truth for user→persona rewriting). User mentions are left
+ * RAW in the content here; the worker rewrites them.
  */
 
 import {
-  type PrismaClient,
-  type PersonaResolver,
-  type MentionTargetUser,
   type RawMentionedChannel,
   type RawMentionedRole,
-  UserService,
-  resolveUserMentions,
   rewriteChannelMentions,
   rewriteRoleMentions,
 } from '@tzurot/common-types';
-import type { Collection, User, Guild, Message } from 'discord.js';
+import type { Guild } from 'discord.js';
 import type {
-  MentionResolutionResult,
   FullMentionResolutionResult,
   ResolvedChannel,
   ResolvedRole,
 } from './MentionResolverTypes.js';
 
 /**
- * Resolves Discord user mentions to persona names
+ * Resolves Discord channel + role mentions to readable names (guild-cache only).
  */
 export class MentionResolver {
-  private userService: UserService;
-  private personaResolver: PersonaResolver;
-
-  constructor(
-    private prisma: PrismaClient,
-    personaResolver: PersonaResolver
-  ) {
-    this.userService = new UserService(prisma);
-    this.personaResolver = personaResolver;
-  }
-
   /**
-   * Resolve user mentions in message content
-   *
-   * @param content - Message content containing mentions like <@123456>
-   * @param mentionedUsers - Collection of User objects from message.mentions.users
-   * @param personalityId - The personality ID for persona lookup
-   * @returns Processed content and info about mentioned users
-   */
-  async resolveMentions(
-    content: string,
-    mentionedUsers: Collection<string, User>,
-    personalityId: string
-  ): Promise<MentionResolutionResult> {
-    // Adapt the live Discord collection to the kernel's plain target map —
-    // the SAME displayName derivation the raw envelope uses, so worker-side
-    // resolution from rawMentionedUsers starts from identical inputs.
-    const targets = new Map<string, MentionTargetUser>(
-      [...mentionedUsers.values()].map(u => [
-        u.id,
-        {
-          discordId: u.id,
-          username: u.username,
-          displayName: u.globalName ?? u.username,
-          isBot: u.bot,
-        },
-      ])
-    );
-
-    return resolveUserMentions(content, targets, personalityId, {
-      getOrCreateUser: (discordId, username, displayName, bio, isBot) =>
-        this.userService.getOrCreateUser(discordId, username, displayName, bio, isBot),
-      resolvePersona: async (discordUserId, pid) => {
-        const result = await this.personaResolver.resolve(discordUserId, pid);
-        return {
-          personaId: result.config.personaId,
-          preferredName: result.config.preferredName,
-        };
-      },
-      findUserByDiscordId: discordId =>
-        this.prisma.user.findUnique({
-          where: { discordId },
-          select: { id: true, username: true },
-        }),
-    });
-  }
-
-  /**
-   * Resolve all mention types in a message (users, channels, roles)
+   * Rewrite channel + role mentions in message content. User mentions (`<@id>`)
+   * are left raw — the worker rewrites them to persona names from the envelope.
    *
    * @param content - Message content containing mentions
-   * @param message - Discord message object (for guild/channel access)
-   * @param personalityId - The personality ID for persona lookup
-   * @returns Processed content and info about all mentioned entities
+   * @param guild - Discord guild (for channel/role cache lookup); null in DMs
    */
-  async resolveAllMentions(
-    content: string,
-    message: Message,
-    personalityId: string
-  ): Promise<FullMentionResolutionResult> {
-    // Start with user mentions (existing logic)
-    const userResult = await this.resolveMentions(content, message.mentions.users, personalityId);
-
-    let processedContent = userResult.processedContent;
-
-    // Resolve channel mentions
-    const channelResult = this.resolveChannelMentions(processedContent, message.guild);
-    processedContent = channelResult.processedContent;
-
-    // Resolve role mentions
-    const roleResult = this.resolveRoleMentions(processedContent, message.guild);
-    processedContent = roleResult.processedContent;
+  resolveAllMentions(content: string, guild: Guild | null): FullMentionResolutionResult {
+    const channelResult = this.resolveChannelMentions(content, guild);
+    const roleResult = this.resolveRoleMentions(channelResult.processedContent, guild);
 
     return {
-      processedContent,
-      mentionedUsers: userResult.mentionedUsers,
+      processedContent: roleResult.processedContent,
       mentionedChannels: channelResult.mentionedChannels,
       mentionedRoles: roleResult.mentionedRoles,
     };

--- a/services/bot-client/src/services/MentionResolverTypes.ts
+++ b/services/bot-client/src/services/MentionResolverTypes.ts
@@ -1,15 +1,10 @@
 /**
  * MentionResolver Types
- * Type definitions for Discord mention resolution
+ * Type definitions for Discord channel/role mention resolution.
+ *
+ * User-mention resolution is NOT done bot-side (the worker re-derives it from
+ * the envelope), so there is no `mentionedUsers` shape here.
  */
-
-import type { ResolvedUserMention } from '@tzurot/common-types';
-
-/**
- * Information about a mentioned user's persona — the kernel's resolved shape,
- * re-named for this adapter's public API (one definition, no parallel type).
- */
-export type MentionedUserInfo = ResolvedUserMention;
 
 /**
  * Information about a mentioned channel
@@ -38,19 +33,12 @@ export interface ResolvedRole {
 }
 
 /**
- * Result of resolving user mentions in a message
+ * Result of resolving channel + role mentions in a message. User mentions are
+ * left raw (the worker re-derives user→persona rewriting from the envelope).
  */
-export interface MentionResolutionResult {
-  /** Message content with mentions replaced by names */
+export interface FullMentionResolutionResult {
+  /** Message content with channel/role mentions replaced by names (user mentions left raw). */
   processedContent: string;
-  /** Information about mentioned users */
-  mentionedUsers: MentionedUserInfo[];
-}
-
-/**
- * Result of resolving all mention types in a message
- */
-export interface FullMentionResolutionResult extends MentionResolutionResult {
   /** Information about mentioned channels (for LTM scoping) */
   mentionedChannels: ResolvedChannel[];
   /** Information about mentioned roles */

--- a/services/bot-client/src/services/MessageContextBuilder.test.ts
+++ b/services/bot-client/src/services/MessageContextBuilder.test.ts
@@ -163,7 +163,7 @@ describe('MessageContextBuilder', () => {
 
     // Create builder instance — serviceClient is a stub since resolveUserContext
     // (the only consumer) is mocked.
-    builder = new MessageContextBuilder(mockPrisma, mockPersonaResolver as any, {} as any);
+    builder = new MessageContextBuilder({} as any);
 
     // conversationHistory is no longer a builder field — bot-client stopped
     // reading channel history from Postgres (the worker re-derives it from the
@@ -262,7 +262,7 @@ describe('MessageContextBuilder', () => {
     } as Message;
 
     // Default mock for resolveAllMentions - returns unchanged content with empty arrays
-    mockResolveAllMentions.mockResolvedValue({
+    mockResolveAllMentions.mockReturnValue({
       processedContent: 'Hello world',
       mentionedUsers: [],
       mentionedChannels: [],
@@ -283,7 +283,7 @@ describe('MessageContextBuilder', () => {
       });
       // The mention resolver is the LAST rewriter — its output is the
       // assembled messageContent.
-      mockResolveAllMentions.mockResolvedValue({
+      mockResolveAllMentions.mockReturnValue({
         processedContent: 'REWRITTEN content',
         mentionedUsers: [],
         mentionedChannels: [],
@@ -339,7 +339,7 @@ describe('MessageContextBuilder', () => {
         references: [],
         updatedContent: 'REWRITTEN content',
       });
-      mockResolveAllMentions.mockResolvedValue({
+      mockResolveAllMentions.mockReturnValue({
         processedContent: 'REWRITTEN content',
         mentionedUsers: [],
         mentionedChannels: [],
@@ -528,7 +528,7 @@ describe('MessageContextBuilder', () => {
         updatedContent: 'Check [Reference 1]',
         rawReferences: mockReferences,
       });
-      mockResolveAllMentions.mockResolvedValue({
+      mockResolveAllMentions.mockReturnValue({
         processedContent: 'Check [Reference 1]',
         mentionedUsers: [],
         mentionedChannels: [],
@@ -660,7 +660,7 @@ describe('MessageContextBuilder', () => {
         references: [],
         updatedContent: null,
       });
-      mockResolveAllMentions.mockResolvedValue({
+      mockResolveAllMentions.mockReturnValue({
         processedContent: '[no text content]',
         mentionedUsers: [],
         mentionedChannels: [],
@@ -723,7 +723,7 @@ describe('MessageContextBuilder', () => {
         references: [],
         updatedContent: 'Voice message',
       });
-      mockResolveAllMentions.mockResolvedValue({
+      mockResolveAllMentions.mockReturnValue({
         processedContent: 'Voice message',
         mentionedUsers: [],
         mentionedChannels: [],
@@ -758,10 +758,10 @@ describe('MessageContextBuilder', () => {
       expect(result.context.rawAssemblyInputs?.rawReferencedMessages).toBeUndefined();
     });
 
-    it('still resolves mentions (for rewriting) but the envelope omits mentionedPersonas', async () => {
-      // Add a mentioned user to the mock message — even with a real mention,
-      // the thin envelope ships no enriched mentionedPersonas (the worker
-      // re-derives them); resolution still runs to rewrite messageContent.
+    it('does NOT resolve user mentions bot-side (worker re-derives) — channel/role only', async () => {
+      // A real user mention stays RAW in the shipped content; the worker rewrites
+      // it to a persona name from rawMentionedUsers. resolveAllMentions runs only
+      // for channel/role (guild-cache), with the (content, guild) signature.
       const mockMentionedUser = {
         id: '123456',
         username: 'mentioneduser',
@@ -769,25 +769,13 @@ describe('MessageContextBuilder', () => {
       } as User;
       (mockMessage.mentions.users as Map<string, User>).set('123456', mockMentionedUser);
 
-      vi.mocked(mockUserService.getOrCreateUser).mockResolvedValue({
-        userId: 'user-uuid-123',
-        defaultPersonaId: 'test-persona-id',
-      });
-      vi.mocked(mockHistoryService.getChannelHistory).mockResolvedValue([]);
       mockExtractReferencesWithReplacement.mockResolvedValue({
         references: [],
         updatedContent: 'Hey <@123456>, how are you?',
       });
-      mockResolveAllMentions.mockResolvedValue({
-        processedContent: 'Hey @MentionedPersona, how are you?',
-        mentionedUsers: [
-          {
-            discordId: '123456',
-            userId: 'mentioned-user-uuid',
-            personaId: 'mentioned-persona-uuid',
-            personaName: 'MentionedPersona',
-          },
-        ],
+      // Channel/role rewriting leaves the user mention untouched.
+      mockResolveAllMentions.mockReturnValue({
+        processedContent: 'Hey <@123456>, how are you?',
         mentionedChannels: [],
         mentionedRoles: [],
       });
@@ -798,15 +786,15 @@ describe('MessageContextBuilder', () => {
         'Hey <@123456>, how are you?'
       );
 
-      // Resolution still runs (its output rewrites messageContent).
+      // Called with (content, guild) — no personalityId, no user resolution.
       expect(mockResolveAllMentions).toHaveBeenCalledWith(
         'Hey <@123456>, how are you?',
-        mockMessage,
-        'personality-123'
+        mockMessage.guild
       );
-      expect(result.context.messageContent).toBe('Hey @MentionedPersona, how are you?');
+      // The user mention ships RAW (the worker rewrites it).
+      expect(result.context.messageContent).toBe('Hey <@123456>, how are you?');
 
-      // ...but the enriched field never ships — the worker re-derives it.
+      // The enriched field never ships — the worker re-derives it.
       expect(result.context.mentionedPersonas).toBeUndefined();
     });
 
@@ -828,7 +816,7 @@ describe('MessageContextBuilder', () => {
         references: [],
         updatedContent: 'Hello after clear',
       });
-      mockResolveAllMentions.mockResolvedValue({
+      mockResolveAllMentions.mockReturnValue({
         processedContent: 'Hello after clear',
         mentionedUsers: [],
         mentionedChannels: [],
@@ -879,7 +867,7 @@ describe('MessageContextBuilder', () => {
         references: [],
         updatedContent: 'Weigh in',
       });
-      mockResolveAllMentions.mockResolvedValue({
+      mockResolveAllMentions.mockReturnValue({
         processedContent: 'Weigh in',
         mentionedUsers: [],
         mentionedChannels: [],
@@ -926,7 +914,7 @@ describe('MessageContextBuilder', () => {
         references: [],
         updatedContent: 'Hello',
       });
-      mockResolveAllMentions.mockResolvedValue({
+      mockResolveAllMentions.mockReturnValue({
         processedContent: 'Hello',
         mentionedUsers: [],
         mentionedChannels: [],
@@ -1005,7 +993,7 @@ describe('MessageContextBuilder', () => {
         references: [],
         updatedContent: 'Hello',
       });
-      mockResolveAllMentions.mockResolvedValue({
+      mockResolveAllMentions.mockReturnValue({
         processedContent: 'Hello',
         mentionedUsers: [],
         mentionedChannels: [],
@@ -1062,7 +1050,7 @@ describe('MessageContextBuilder', () => {
         references: [],
         updatedContent: 'hi',
       });
-      mockResolveAllMentions.mockResolvedValue({
+      mockResolveAllMentions.mockReturnValue({
         processedContent: 'hi',
         mentionedUsers: [],
         mentionedChannels: [],
@@ -1102,7 +1090,7 @@ describe('MessageContextBuilder', () => {
         references: [],
         updatedContent: '',
       });
-      mockResolveAllMentions.mockResolvedValue({
+      mockResolveAllMentions.mockReturnValue({
         processedContent: '',
         mentionedUsers: [],
         mentionedChannels: [],
@@ -1164,7 +1152,7 @@ describe('MessageContextBuilder', () => {
         references: [],
         updatedContent: 'Hello',
       });
-      mockResolveAllMentions.mockResolvedValue({
+      mockResolveAllMentions.mockReturnValue({
         processedContent: 'Hello',
         mentionedUsers: [],
         mentionedChannels: [],
@@ -1225,7 +1213,7 @@ describe('MessageContextBuilder', () => {
         references: [],
         updatedContent: 'Hello',
       });
-      mockResolveAllMentions.mockResolvedValue({
+      mockResolveAllMentions.mockReturnValue({
         processedContent: 'Hello',
         mentionedUsers: [],
         mentionedChannels: [],
@@ -1304,7 +1292,7 @@ describe('MessageContextBuilder', () => {
         references: [],
         updatedContent: 'Hello',
       });
-      mockResolveAllMentions.mockResolvedValue({
+      mockResolveAllMentions.mockReturnValue({
         processedContent: 'Hello',
         mentionedUsers: [],
         mentionedChannels: [],
@@ -1376,7 +1364,7 @@ describe('MessageContextBuilder', () => {
         references: [],
         updatedContent: 'Hello',
       });
-      mockResolveAllMentions.mockResolvedValue({
+      mockResolveAllMentions.mockReturnValue({
         processedContent: 'Hello',
         mentionedUsers: [],
         mentionedChannels: [],
@@ -1450,7 +1438,7 @@ describe('MessageContextBuilder', () => {
         references: [],
         updatedContent: 'Hello',
       });
-      mockResolveAllMentions.mockResolvedValue({
+      mockResolveAllMentions.mockReturnValue({
         processedContent: 'Hello',
         mentionedUsers: [],
         mentionedChannels: [],
@@ -1503,7 +1491,7 @@ describe('MessageContextBuilder', () => {
         references: [],
         updatedContent: 'content',
       });
-      mockResolveAllMentions.mockResolvedValue({
+      mockResolveAllMentions.mockReturnValue({
         processedContent: 'content',
         mentionedUsers: [],
         mentionedChannels: [],

--- a/services/bot-client/src/services/MessageContextBuilder.ts
+++ b/services/bot-client/src/services/MessageContextBuilder.ts
@@ -6,8 +6,6 @@
  */
 
 import {
-  type PrismaClient,
-  type PersonaResolver,
   type LoadedPersonality,
   type ConversationMessage,
   type AttachmentMetadata,
@@ -123,12 +121,12 @@ export class MessageContextBuilder {
   private cachedBotSuffix: string | null = null;
 
   constructor(
-    prisma: PrismaClient,
-    personaResolver: PersonaResolver,
     private serviceClient: ServiceClient,
     denylistCache?: DenylistCache
   ) {
-    this.mentionResolver = new MentionResolver(prisma, personaResolver);
+    // MentionResolver is now a stateless guild-cache rewriter (channel/role only);
+    // user→persona resolution moved worker-side, so no Prisma/PersonaResolver here.
+    this.mentionResolver = new MentionResolver();
     this.channelFetcher = new DiscordChannelFetcher();
     this.transcriptRetriever = new TranscriptRetriever();
     this.denylistCache = denylistCache;
@@ -282,7 +280,6 @@ export class MessageContextBuilder {
   private async extractRefsAndMentions(opts: {
     message: Message;
     content: string;
-    personality: LoadedPersonality;
     history: ConversationMessage[];
     isWeighInMode?: boolean;
     maxReferences?: number;
@@ -291,7 +288,6 @@ export class MessageContextBuilder {
       mentionResolver: this.mentionResolver,
       message: opts.message,
       content: opts.content,
-      personality: opts.personality,
       history: opts.history,
       isWeighInMode: opts.isWeighInMode ?? false,
       maxReferences: opts.maxReferences ?? MESSAGE_LIMITS.DEFAULT_MAX_MESSAGES,
@@ -373,7 +369,6 @@ export class MessageContextBuilder {
     const refsAndMentions = await this.extractRefsAndMentions({
       message,
       content,
-      personality,
       history,
       isWeighInMode: options.isWeighInMode,
       maxReferences: options.extendedContext?.maxMessages,

--- a/services/bot-client/src/services/contextBuilder/ReferenceExtractor.test.ts
+++ b/services/bot-client/src/services/contextBuilder/ReferenceExtractor.test.ts
@@ -8,7 +8,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Message } from 'discord.js';
 import { Collection } from 'discord.js';
-import type { ConversationMessage, LoadedPersonality } from '@tzurot/common-types';
+import type { ConversationMessage } from '@tzurot/common-types';
 
 // Hoist mock so it's available before module loading
 const { mockExtractReferences } = vi.hoisted(() => ({
@@ -51,8 +51,6 @@ import { extractReferencesAndMentions } from './ReferenceExtractor.js';
 import type { MentionResolver } from '../MentionResolver.js';
 
 describe('extractReferencesAndMentions', () => {
-  const mockPersonality = { id: 'personality-1' } as LoadedPersonality;
-
   function createMockMessage(overrides?: Partial<Message>): Message {
     return {
       reference: null,
@@ -70,7 +68,7 @@ describe('extractReferencesAndMentions', () => {
       references: [],
       updatedContent: 'Hello world',
     });
-    mockResolveAllMentions.mockResolvedValue({
+    mockResolveAllMentions.mockReturnValue({
       processedContent: 'Hello world',
       mentionedUsers: [],
       mentionedChannels: [],
@@ -84,7 +82,7 @@ describe('extractReferencesAndMentions', () => {
       updatedContent: 'Hello world',
       rawReferences: [{ referenceNumber: 1, content: 'raw snapshot' }],
     });
-    mockResolveAllMentions.mockResolvedValue({
+    mockResolveAllMentions.mockReturnValue({
       processedContent: 'rewritten',
       mentionedUsers: [],
       mentionedChannels: [{ channelId: '1', channelName: 'general', topic: 'chat', guildId: 'g1' }],
@@ -95,7 +93,6 @@ describe('extractReferencesAndMentions', () => {
       mentionResolver: mockMentionResolver as unknown as MentionResolver,
       message: createMockMessage(),
       content: 'Hello world',
-      personality: mockPersonality,
       history: [],
       maxReferences: 50,
     });
@@ -114,7 +111,6 @@ describe('extractReferencesAndMentions', () => {
       mentionResolver: mockMentionResolver as unknown as MentionResolver,
       message: createMockMessage(),
       content: 'Hello world',
-      personality: mockPersonality,
       history: [],
       isWeighInMode: true,
       maxReferences: 50,
@@ -131,7 +127,7 @@ describe('extractReferencesAndMentions', () => {
       references: [{ referenceNumber: 1, content: 'quoted text', authorName: 'User' }],
       updatedContent: 'Hello [1]',
     });
-    mockResolveAllMentions.mockResolvedValue({
+    mockResolveAllMentions.mockReturnValue({
       processedContent: 'Hello [1]',
       mentionedUsers: [],
       mentionedChannels: [],
@@ -142,7 +138,6 @@ describe('extractReferencesAndMentions', () => {
       mentionResolver: mockMentionResolver as unknown as MentionResolver,
       message: createMockMessage(),
       content: 'Hello <link>',
-      personality: mockPersonality,
       history: [],
       maxReferences: 50,
     });
@@ -156,7 +151,7 @@ describe('extractReferencesAndMentions', () => {
     // rewrite pipeline (link replacement → mention resolution) yields empty
     // processed content. Content dropped by mention resolution must surface as
     // empty messageContent, never silently fall back to the original content.
-    mockResolveAllMentions.mockResolvedValue({
+    mockResolveAllMentions.mockReturnValue({
       processedContent: '',
       mentionedUsers: [],
       mentionedChannels: [],
@@ -167,7 +162,6 @@ describe('extractReferencesAndMentions', () => {
       mentionResolver: mockMentionResolver as unknown as MentionResolver,
       message: createMockMessage({ id: 'msg-forward' } as Partial<Message>),
       content: 'Forwarded message with real content',
-      personality: mockPersonality,
       history: [],
       maxReferences: 50,
     });
@@ -186,7 +180,7 @@ describe('extractReferencesAndMentions', () => {
       references: [],
       updatedContent: effectiveContent, // no links → echoed unchanged
     });
-    mockResolveAllMentions.mockResolvedValue({
+    mockResolveAllMentions.mockReturnValue({
       processedContent: effectiveContent,
       mentionedUsers: [],
       mentionedChannels: [],
@@ -198,7 +192,6 @@ describe('extractReferencesAndMentions', () => {
       mentionResolver: mockMentionResolver as unknown as MentionResolver,
       message,
       content: effectiveContent,
-      personality: mockPersonality,
       history: [],
       maxReferences: 50,
     });
@@ -217,7 +210,6 @@ describe('extractReferencesAndMentions', () => {
       mentionResolver: mockMentionResolver as unknown as MentionResolver,
       message: createMockMessage(),
       content: 'Hello',
-      personality: mockPersonality,
       history,
       maxReferences: 50,
     });

--- a/services/bot-client/src/services/contextBuilder/ReferenceExtractor.ts
+++ b/services/bot-client/src/services/contextBuilder/ReferenceExtractor.ts
@@ -11,7 +11,6 @@ import {
   MessageRole,
   CONTENT_TYPES,
   INTERVALS,
-  type LoadedPersonality,
   type ReferencedMessage,
   type ConversationMessage,
   type RawMentionedChannel,
@@ -41,7 +40,6 @@ interface ExtractReferencesOptions {
   mentionResolver: MentionResolver;
   message: Message;
   content: string;
-  personality: LoadedPersonality;
   history: ConversationMessage[];
   isWeighInMode?: boolean;
   /** Maximum number of references to extract. Shares budget with maxMessages. */
@@ -55,15 +53,7 @@ interface ExtractReferencesOptions {
 export async function extractReferencesAndMentions(
   opts: ExtractReferencesOptions
 ): Promise<ReferencesAndMentionsResult> {
-  const {
-    mentionResolver,
-    message,
-    content,
-    personality,
-    history,
-    isWeighInMode = false,
-    maxReferences,
-  } = opts;
+  const { mentionResolver, message, content, history, isWeighInMode = false, maxReferences } = opts;
   // In weigh-in mode, the anchor message is the latest channel message (not from the invoking user).
   // Its reply references are irrelevant to the weigh-in prompt — skip extraction entirely.
   if (isWeighInMode) {
@@ -110,12 +100,9 @@ export async function extractReferencesAndMentions(
   // longer clobbers authoritative content with empty top-level message text.
   let messageContent = updatedContent;
 
-  // Resolve all mentions
-  const mentionResult = await mentionResolver.resolveAllMentions(
-    messageContent,
-    message,
-    personality.id
-  );
+  // Resolve channel/role mentions (guild-cache). User mentions are left raw —
+  // the worker re-derives user→persona rewriting from the envelope.
+  const mentionResult = mentionResolver.resolveAllMentions(messageContent, message.guild);
 
   messageContent = mentionResult.processedContent;
 


### PR DESCRIPTION
## What

bot-client's `MentionResolver` no longer resolves @user mentions to persona names. That resolution (`getOrCreateUser` + `PersonaResolver` + `prisma.user.findUnique`) was **vestigial**, and stripping it removes Prisma from the `MentionResolver` → `MessageContextBuilder` path entirely.

## Why it's vestigial (verified, not assumed)

The worker's `ContextAssembler.rewriteRawContent` re-runs the *identical* user→persona resolution against its **own** Prisma from the shipped `rawMentionedUsers`, and `ContextStep` **unconditionally overwrites** the message content with that re-derivation:

```ts
// ContextStep.ts:56  (already locked by ContextStep.test.ts:219,223)
job.data.message = assembled.messageContent;
```

`ContextStep.assertEnvelopeJob` makes envelope-mode the only path, so the overwrite always happens. Validated by a **council pass** (GLM-5.2 / Kimi-K2.7-code / Qwen-3.7-max — unanimous "strip, don't build a gateway") plus four gap-closing checks:

- No bot-side consumer reads `mentionedPersonas` / rewritten `messageContent` before enqueue (only the ship-site at `gatewayServiceCalls.ts:233`).
- `rawMentionedUsers` is built **independently** from `message.mentions.users` (`RawEnvelopeBuilder:146`) — stripping doesn't starve the worker's input.
- The worker has its own `findUserByDiscordId` out-of-guild fallback (`ContextAssembler:358`).
- `MultiTagRecovery`'s `PersonaResolver` use is the *one* load-bearing read (recovery persistence) — handled in the next PR, not here.

## What stays bot-side

`MentionResolver`'s channel/role rewriting is pure **guild-cache** (`rawMentionedChannels`/`rawMentionedRoles`) — the worker has no Discord guild cache, so it genuinely needs these. User mentions ship **raw**; the worker rewrites them.

## Cascade

MentionResolver drops its `prisma`/`PersonaResolver` ctor deps → `MessageContextBuilder` drops `prisma`/`personaResolver` too (getChannelHistory already gone) → `resolveAllMentions` becomes **sync** `(content, guild)` → `ReferenceExtractor` drops the now-unused `personality` param.

## Scope — Phase 3c, part 1 of 3

This strips the vestigial path. Remaining for the full "bot-client never uses Prisma" finish:
- **PR2**: migrate `MultiTagRecovery.resolvePersonaIdOnly` (the one live read) to a gateway call.
- **PR3**: delete the dead `PersonalityService`/`ConversationHistoryService` injections, evict `getPrismaClient`, tighten the depcruise guard to a structural CI failure.

## Verification

`pnpm quality` green (typecheck, typecheck:spec, knip, depcruise). Full bot-client suite: 5041 passing. The worker-overwrite invariant (`ContextStep.test.ts:219,223`) is the standing safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)