### PR TITLE
refactor(bot-client): resolve /character persona via routing-context

### DIFF
--- a/services/bot-client/src/commands/character/chat.test.ts
+++ b/services/bot-client/src/commands/character/chat.test.ts
@@ -43,19 +43,33 @@ const mockConversationPersistence = {
   saveUserMessageFromFields: vi.fn().mockResolvedValue(undefined),
 };
 
-const mockPersonaResolver = {
-  resolve: vi.fn().mockResolvedValue({
-    config: { personaId: 'persona-123', preferredName: null },
-  }),
-};
+const mockResolveUserContext = vi.fn();
 
 vi.mock('../../services/serviceRegistry.js', () => ({
   getPersonalityLoader: () => mockPersonalityService,
   getMessageContextBuilder: () => mockMessageContextBuilder,
   getConversationPersistence: () => mockConversationPersistence,
-  getPersonaResolver: () => mockPersonaResolver,
   getJobTracker: () => mockJobTracker,
 }));
+
+// chat.ts resolves the invoker's persona (id + display name) through the
+// routing-context helper — bot-client never touches Prisma. Mocking the helper
+// directly means the getServiceClient() stub it's handed is never exercised.
+vi.mock('../../services/contextBuilder/UserContextResolver.js', () => ({
+  resolveUserContext: (...args: unknown[]) => mockResolveUserContext(...args),
+}));
+
+/** Build a routing-context result; override `personaName`/`personaId` per case. */
+const buildUserContext = (overrides: Record<string, unknown> = {}) => ({
+  internalUserId: 'internal-user-1',
+  discordUserId: 'user-123',
+  personaId: 'persona-123',
+  personaName: null,
+  userTimezone: undefined,
+  contextEpoch: undefined,
+  history: [],
+  ...overrides,
+});
 
 // `generate` moved off GatewayClient to the gatewayServiceCalls module; route
 // it to the same holder so the existing assertions keep working unchanged.
@@ -69,9 +83,12 @@ vi.mock('../../utils/autocomplete/autocompleteCache.js', () => ({
 }));
 
 // Mock clientsFor — the cache + persona resolution mocks return data
-// directly, so a structurally empty userClient stub suffices.
+// directly, so a structurally empty userClient stub suffices. getServiceClient
+// is what chat.ts hands to the (mocked) resolveUserContext, so a bare stub is
+// enough — the helper ignores it.
 vi.mock('../../utils/gatewayClients.js', () => ({
   clientsFor: vi.fn(() => ({ userClient: {} })),
+  getServiceClient: vi.fn(() => ({})),
 }));
 
 vi.mock('../../redis.js', () => ({
@@ -202,9 +219,7 @@ describe('Character Chat Handler (push delivery)', () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     mockMessageContextBuilder.buildContext.mockResolvedValue(createMockContextBuildResult());
-    mockPersonaResolver.resolve.mockResolvedValue({
-      config: { personaId: 'persona-123', preferredName: null },
-    });
+    mockResolveUserContext.mockResolvedValue(buildUserContext());
   });
 
   afterEach(() => {
@@ -316,9 +331,7 @@ describe('Character Chat Handler (push delivery)', () => {
       const ctx = createMockContext('test-char', 'Hi', channel);
       mockPersonalityService.loadPersonality.mockResolvedValue(createMockPersonality());
       mockGatewayClient.generate.mockResolvedValue({ jobId: 'job-1', requestId: 'req-1' });
-      mockPersonaResolver.resolve.mockResolvedValueOnce({
-        config: { personaId: 'persona-123', preferredName: 'Cool Name' },
-      });
+      mockResolveUserContext.mockResolvedValueOnce(buildUserContext({ personaName: 'Cool Name' }));
 
       await handleChat(ctx, mockConfig);
 

--- a/services/bot-client/src/commands/character/chat.ts
+++ b/services/bot-client/src/commands/character/chat.ts
@@ -39,9 +39,10 @@ import {
   getPersonalityLoader,
   getMessageContextBuilder,
   getConversationPersistence,
-  getPersonaResolver,
   getJobTracker,
 } from '../../services/serviceRegistry.js';
+import { resolveUserContext } from '../../services/contextBuilder/UserContextResolver.js';
+import { getServiceClient } from '../../utils/gatewayClients.js';
 import { generate } from '../../utils/gatewayServiceCalls.js';
 import type { MessageContext } from '../../types.js';
 import { resolveCharacterSlug, finalizeDeferredReply } from './randomPick.js';
@@ -449,9 +450,13 @@ async function runCharacterTurn(
       return;
     }
 
-    // 3. Resolve persona to get display name (quick lookup before sending message)
-    const personaResult = await getPersonaResolver().resolve(userId, personality.id);
-    const displayName = personaResult.config.preferredName ?? discordDisplayName;
+    // 3. Resolve persona (id + display name) via routing-context. bot-client
+    //    never touches Prisma — the gateway runs provisioning + the persona
+    //    cascade server-side and returns the resolved id + display name.
+    const userContext = await resolveUserContext(context.user, personality, discordDisplayName, {
+      serviceClient: getServiceClient(),
+    });
+    const displayName = userContext.personaName ?? discordDisplayName;
 
     // 4. Build extended context settings from personality
     const extendedContextSettings = buildExtendedContextSettings(personality);
@@ -473,7 +478,7 @@ async function runCharacterTurn(
             displayName,
             message,
             personality,
-            personaId: personaResult.config.personaId,
+            personaId: userContext.personaId,
             guildId: context.guild?.id ?? null,
             timestamp: userMessageTime,
           }


### PR DESCRIPTION
## What

`chat.ts` resolved the `/character chat|random|chime-in` invoker's persona
(display name + id) through `getPersonaResolver().resolve(...)` — the **last
live Prisma read in bot-client**. This swaps it for `resolveUserContext`, which
runs provisioning + the persona cascade server-side via the gateway's
`routing-context` endpoint, exactly as the @mention path already does.

Both consumers move over:
- `personaName` → the display name (with the Discord display-name fallback)
- `personaId` → the anchor-message persistence

## Why

Epic 2.5d: bot-client must **never** touch Prisma — the gateway/worker own all
DB-derived context. This is the final runtime Prisma read in the service.

## Scope

This PR is the read migration only. The now-vestigial `PersonaResolver` wiring,
`getPrismaClient` import, dead `PersonalityService`/`ConversationHistoryService`,
`verifyDatabaseConnection`/`tempPrisma`, and the tightened `bot-client-no-prisma`
depcruise rule are the **Phase 4 teardown** follow-up (the resolver getter is now
referenced only by its own test, kept alive until teardown).

## Verification

- `pnpm --filter @tzurot/bot-client test` — 5041/5041 green (16/16 in `chat.test.ts`)
- `pnpm quality` — green (lint, knip, cpd, depcruise, typecheck, audit, taxonomy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)