### PR TITLE
refactor(bot-client): evict vestigial Prisma wiring from the composition root

### DIFF
--- a/services/bot-client/src/index.ts
+++ b/services/bot-client/src/index.ts
@@ -11,15 +11,9 @@ import { Redis } from 'ioredis';
 import {
   createLogger,
   isBotOwner,
-  PersonalityService,
   CacheInvalidationService,
-  PersonaResolver,
-  PersonaCacheInvalidationService,
   ChannelActivationCacheInvalidationService,
   DenylistCacheInvalidationService,
-  ConversationHistoryService,
-  disconnectPrisma,
-  getPrismaClient,
   getConfig,
   parseRedisUrl,
   createBullMQRedisConfig,
@@ -139,11 +133,8 @@ interface Services {
   jobFailureListener: JobFailureListener;
   responseOrderingService: ResponseOrderingService;
   webhookManager: WebhookManager;
-  personalityService: PersonalityService;
-  personaResolver: PersonaResolver;
   cacheRedis: Redis;
   cacheInvalidationService: CacheInvalidationService;
-  personaCacheInvalidationService: PersonaCacheInvalidationService;
   channelActivationCacheInvalidationService: ChannelActivationCacheInvalidationService;
   denylistCache: DenylistCache;
   denylistCacheInvalidationService: DenylistCacheInvalidationService;
@@ -181,11 +172,10 @@ function buildCacheRedis(): Redis {
  * This is where all dependencies are instantiated and wired together.
  * Full dependency injection - no service creates its own dependencies.
  */
-// eslint-disable-next-line max-lines-per-function -- composition root: every line is `const X = new Foo(...)` or a `buildY({...})` helper call. Length tracks the total service count, not branching complexity. Each block already extracts the cohesive wiring into helpers (`buildPersonalityChatPipeline`, `buildMultiTagStack`, `buildProcessorChain`); further splitting would fragment the top-down readability that composition roots want.
 function createServices(): Services {
-  // Composition Root: Create Prisma client for dependency injection
-  const prisma = getPrismaClient();
-  logger.info('Prisma client initialized');
+  // Composition Root. bot-client never touches Prisma — all DB-backed work
+  // goes through the gateway's internal endpoints (HTTP), so there is no
+  // PrismaClient here.
 
   // Initialize Redis for cache invalidation
   const cacheRedis = buildCacheRedis();
@@ -200,10 +190,6 @@ function createServices(): Services {
   // through `handleJobResult` instead of leaving them to the 10-min safety
   // timeout. See its module-level docstring for the dual-routing story.
 
-  // Shared services (used by multiple processors)
-  const personalityService = new PersonalityService(prisma);
-  const conversationHistoryService = new ConversationHistoryService(prisma);
-
   // Routing-read loader: personality resolution for routing (mention parsing,
   // reply resolution, activation, multi-tag recovery, /character chat) goes
   // through the gateway's internal endpoint with positive/negative caching
@@ -215,10 +201,6 @@ function createServices(): Services {
     cacheRedis,
     routingPersonalityLoader
   );
-
-  // Persona resolution with proper cache invalidation via Redis pub/sub
-  const personaResolver = new PersonaResolver(prisma, { enableCleanup: true });
-  const personaCacheInvalidationService = new PersonaCacheInvalidationService(cacheRedis);
 
   // Channel activation cache invalidation for horizontal scaling
   const channelActivationCacheInvalidationService = new ChannelActivationCacheInvalidationService(
@@ -317,8 +299,6 @@ function createServices(): Services {
     jobTracker,
     webhookManager,
     personalityService: routingPersonalityLoader,
-    conversationHistoryService,
-    personaResolver,
     channelActivationCacheInvalidationService,
     messageContextBuilder: contextBuilder,
     conversationPersistence: persistence,
@@ -332,11 +312,8 @@ function createServices(): Services {
     jobFailureListener,
     responseOrderingService,
     webhookManager,
-    personalityService,
-    personaResolver,
     cacheRedis,
     cacheInvalidationService,
-    personaCacheInvalidationService,
     channelActivationCacheInvalidationService,
     denylistCache,
     denylistCacheInvalidationService,
@@ -600,7 +577,6 @@ function handleShutdownSignal(signal: NodeJS.Signals): void {
     services.webhookManager.destroy();
     stopNotificationCacheCleanup();
     stopVerificationCleanupScheduler();
-    services.personaResolver.stopCleanup();
     // ioredis Redis#disconnect is synchronous (returns void) — kept outside
     // the awaited Promise.all because there's no Promise to await.
     services.cacheRedis.disconnect();
@@ -609,19 +585,17 @@ function handleShutdownSignal(signal: NodeJS.Signals): void {
     // block shutdown. Railway will SIGKILL after its grace window anyway;
     // better to exit cleanly when we can. Without the await, voided promises
     // returned ~immediately and process.exit ran before Discord WebSocket
-    // close handshake / Redis disconnect / Prisma cleanup completed.
+    // close handshake / Redis disconnect completed.
     const SHUTDOWN_TIMEOUT_MS = 5000;
     try {
       await Promise.race([
         Promise.all([
           services.cacheInvalidationService.unsubscribe(),
-          services.personaCacheInvalidationService.unsubscribe(),
           services.channelActivationCacheInvalidationService.unsubscribe(),
           services.denylistCacheInvalidationService.unsubscribe(),
           services.multiTagRecoveryQueue.close(),
           closeRedis(),
           client.destroy(),
-          disconnectPrisma(),
         ]),
         new Promise<never>((_resolve, reject) =>
           setTimeout(
@@ -640,17 +614,6 @@ function handleShutdownSignal(signal: NodeJS.Signals): void {
 }
 process.on('SIGTERM', handleShutdownSignal);
 process.on('SIGINT', handleShutdownSignal);
-
-/**
- * Verify database connection and log personality count
- */
-async function verifyDatabaseConnection(): Promise<void> {
-  logger.info('Verifying database connection...');
-  const tempPrisma = getPrismaClient();
-  const tempPersonalityService = new PersonalityService(tempPrisma);
-  const personalityList = await tempPersonalityService.loadAllPersonalities();
-  logger.info({ count: personalityList.length }, 'Found personalities in database');
-}
 
 /**
  * Start listening for job results and handle delivery to Discord
@@ -699,22 +662,11 @@ async function startResultsListener(): Promise<void> {
 }
 
 /**
- * Subscribe to all cache invalidation events (personality, persona, channel activation, denylist)
+ * Subscribe to all cache invalidation events (personality, channel activation, denylist)
  */
 async function subscribeToCacheInvalidation(): Promise<void> {
   await services.cacheInvalidationService.subscribe();
   logger.info('Subscribed to personality cache invalidation events');
-
-  await services.personaCacheInvalidationService.subscribe(event => {
-    if (event.type === 'user') {
-      services.personaResolver.invalidateUserCache(event.discordId);
-      logger.debug({ discordId: event.discordId }, 'Invalidated persona cache for user');
-    } else if (event.type === 'all') {
-      services.personaResolver.clearCache();
-      logger.debug('Invalidated all persona caches');
-    }
-  });
-  logger.info('Subscribed to persona cache invalidation events');
 
   await services.channelActivationCacheInvalidationService.subscribe(event => {
     if (event.type === 'channel') {
@@ -763,9 +715,6 @@ async function start(): Promise<void> {
       },
       'Configuration:'
     );
-
-    // Verify database connection
-    await verifyDatabaseConnection();
 
     // Auto-deploy commands if enabled
     if (envConfig.AUTO_DEPLOY_COMMANDS === 'true') {

--- a/services/bot-client/src/services/serviceRegistry.test.ts
+++ b/services/bot-client/src/services/serviceRegistry.test.ts
@@ -7,8 +7,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type {
   PersonalityService,
-  ConversationHistoryService,
-  PersonaResolver,
   ChannelActivationCacheInvalidationService,
 } from '@tzurot/common-types';
 import type { JobTracker } from './JobTracker.js';
@@ -50,20 +48,6 @@ describe('serviceRegistry', () => {
       );
     });
 
-    it('should throw when getting ConversationHistoryService before registration', async () => {
-      const { getConversationHistoryService } = await import('./serviceRegistry.js');
-      expect(() => getConversationHistoryService()).toThrow(
-        'ConversationHistoryService not registered. Call registerServices() first.'
-      );
-    });
-
-    it('should throw when getting PersonaResolver before registration', async () => {
-      const { getPersonaResolver } = await import('./serviceRegistry.js');
-      expect(() => getPersonaResolver()).toThrow(
-        'PersonaResolver not registered. Call registerServices() first.'
-      );
-    });
-
     it('should throw when getting ChannelActivationCacheInvalidationService before registration', async () => {
       const { getChannelActivationCacheInvalidationService } = await import('./serviceRegistry.js');
       expect(() => getChannelActivationCacheInvalidationService()).toThrow(
@@ -95,10 +79,6 @@ describe('serviceRegistry', () => {
     const mockJobTracker = { track: vi.fn() } as unknown as JobTracker;
     const mockWebhookManager = { send: vi.fn() } as unknown as WebhookManager;
     const mockPersonalityService = { loadPersonality: vi.fn() } as unknown as PersonalityService;
-    const mockConversationHistoryService = {
-      getChannelHistory: vi.fn(),
-    } as unknown as ConversationHistoryService;
-    const mockPersonaResolver = { resolve: vi.fn() } as unknown as PersonaResolver;
     const mockChannelActivationCacheInvalidationService = {
       invalidateChannel: vi.fn(),
     } as unknown as ChannelActivationCacheInvalidationService;
@@ -116,8 +96,6 @@ describe('serviceRegistry', () => {
         jobTracker: mockJobTracker,
         webhookManager: mockWebhookManager,
         personalityService: mockPersonalityService,
-        conversationHistoryService: mockConversationHistoryService,
-        personaResolver: mockPersonaResolver,
         channelActivationCacheInvalidationService: mockChannelActivationCacheInvalidationService,
         messageContextBuilder: mockMessageContextBuilder,
         conversationPersistence: mockConversationPersistence,
@@ -134,8 +112,6 @@ describe('serviceRegistry', () => {
         jobTracker: mockJobTracker,
         webhookManager: mockWebhookManager,
         personalityService: mockPersonalityService,
-        conversationHistoryService: mockConversationHistoryService,
-        personaResolver: mockPersonaResolver,
         channelActivationCacheInvalidationService: mockChannelActivationCacheInvalidationService,
         messageContextBuilder: mockMessageContextBuilder,
         conversationPersistence: mockConversationPersistence,
@@ -152,8 +128,6 @@ describe('serviceRegistry', () => {
         jobTracker: mockJobTracker,
         webhookManager: mockWebhookManager,
         personalityService: mockPersonalityService,
-        conversationHistoryService: mockConversationHistoryService,
-        personaResolver: mockPersonaResolver,
         channelActivationCacheInvalidationService: mockChannelActivationCacheInvalidationService,
         messageContextBuilder: mockMessageContextBuilder,
         conversationPersistence: mockConversationPersistence,
@@ -161,43 +135,6 @@ describe('serviceRegistry', () => {
       });
 
       expect(getPersonalityLoader()).toBe(mockPersonalityService);
-    });
-
-    it('should return registered ConversationHistoryService', async () => {
-      const { registerServices, getConversationHistoryService } =
-        await import('./serviceRegistry.js');
-
-      registerServices({
-        jobTracker: mockJobTracker,
-        webhookManager: mockWebhookManager,
-        personalityService: mockPersonalityService,
-        conversationHistoryService: mockConversationHistoryService,
-        personaResolver: mockPersonaResolver,
-        channelActivationCacheInvalidationService: mockChannelActivationCacheInvalidationService,
-        messageContextBuilder: mockMessageContextBuilder,
-        conversationPersistence: mockConversationPersistence,
-        denylistCache: mockDenylistCache,
-      });
-
-      expect(getConversationHistoryService()).toBe(mockConversationHistoryService);
-    });
-
-    it('should return registered PersonaResolver', async () => {
-      const { registerServices, getPersonaResolver } = await import('./serviceRegistry.js');
-
-      registerServices({
-        jobTracker: mockJobTracker,
-        webhookManager: mockWebhookManager,
-        personalityService: mockPersonalityService,
-        conversationHistoryService: mockConversationHistoryService,
-        personaResolver: mockPersonaResolver,
-        channelActivationCacheInvalidationService: mockChannelActivationCacheInvalidationService,
-        messageContextBuilder: mockMessageContextBuilder,
-        conversationPersistence: mockConversationPersistence,
-        denylistCache: mockDenylistCache,
-      });
-
-      expect(getPersonaResolver()).toBe(mockPersonaResolver);
     });
 
     it('should return registered ChannelActivationCacheInvalidationService', async () => {
@@ -208,8 +145,6 @@ describe('serviceRegistry', () => {
         jobTracker: mockJobTracker,
         webhookManager: mockWebhookManager,
         personalityService: mockPersonalityService,
-        conversationHistoryService: mockConversationHistoryService,
-        personaResolver: mockPersonaResolver,
         channelActivationCacheInvalidationService: mockChannelActivationCacheInvalidationService,
         messageContextBuilder: mockMessageContextBuilder,
         conversationPersistence: mockConversationPersistence,
@@ -228,8 +163,6 @@ describe('serviceRegistry', () => {
         jobTracker: mockJobTracker,
         webhookManager: mockWebhookManager,
         personalityService: mockPersonalityService,
-        conversationHistoryService: mockConversationHistoryService,
-        personaResolver: mockPersonaResolver,
         channelActivationCacheInvalidationService: mockChannelActivationCacheInvalidationService,
         messageContextBuilder: mockMessageContextBuilder,
         conversationPersistence: mockConversationPersistence,
@@ -246,8 +179,6 @@ describe('serviceRegistry', () => {
         jobTracker: mockJobTracker,
         webhookManager: mockWebhookManager,
         personalityService: mockPersonalityService,
-        conversationHistoryService: mockConversationHistoryService,
-        personaResolver: mockPersonaResolver,
         channelActivationCacheInvalidationService: mockChannelActivationCacheInvalidationService,
         messageContextBuilder: mockMessageContextBuilder,
         conversationPersistence: mockConversationPersistence,
@@ -264,8 +195,6 @@ describe('serviceRegistry', () => {
         jobTracker: mockJobTracker,
         webhookManager: mockWebhookManager,
         personalityService: mockPersonalityService,
-        conversationHistoryService: mockConversationHistoryService,
-        personaResolver: mockPersonaResolver,
         channelActivationCacheInvalidationService: mockChannelActivationCacheInvalidationService,
         messageContextBuilder: mockMessageContextBuilder,
         conversationPersistence: mockConversationPersistence,
@@ -286,8 +215,6 @@ describe('serviceRegistry', () => {
         jobTracker: { track: vi.fn() } as unknown as JobTracker,
         webhookManager: undefined,
         personalityService: undefined,
-        conversationHistoryService: undefined,
-        personaResolver: undefined,
         channelActivationCacheInvalidationService: undefined,
         messageContextBuilder: undefined,
         conversationPersistence: undefined,
@@ -296,8 +223,6 @@ describe('serviceRegistry', () => {
         jobTracker: JobTracker;
         webhookManager: WebhookManager;
         personalityService: PersonalityService;
-        conversationHistoryService: ConversationHistoryService;
-        personaResolver: PersonaResolver;
         channelActivationCacheInvalidationService: ChannelActivationCacheInvalidationService;
         messageContextBuilder: MessageContextBuilder;
         conversationPersistence: ConversationPersistence;
@@ -318,10 +243,6 @@ describe('serviceRegistry', () => {
       const mockJobTracker = { track: vi.fn() } as unknown as JobTracker;
       const mockWebhookManager = { send: vi.fn() } as unknown as WebhookManager;
       const mockPersonalityService = { loadPersonality: vi.fn() } as unknown as PersonalityService;
-      const mockConversationHistoryService = {
-        getChannelHistory: vi.fn(),
-      } as unknown as ConversationHistoryService;
-      const mockPersonaResolver = { resolve: vi.fn() } as unknown as PersonaResolver;
       const mockChannelActivationCacheInvalidationService = {
         invalidateChannel: vi.fn(),
       } as unknown as ChannelActivationCacheInvalidationService;
@@ -340,8 +261,6 @@ describe('serviceRegistry', () => {
         jobTracker: mockJobTracker,
         webhookManager: mockWebhookManager,
         personalityService: mockPersonalityService,
-        conversationHistoryService: mockConversationHistoryService,
-        personaResolver: mockPersonaResolver,
         channelActivationCacheInvalidationService: mockChannelActivationCacheInvalidationService,
         messageContextBuilder: localMockMessageContextBuilder,
         conversationPersistence: localMockConversationPersistence,

--- a/services/bot-client/src/services/serviceRegistry.ts
+++ b/services/bot-client/src/services/serviceRegistry.ts
@@ -10,11 +10,7 @@
  * - Import getJobTracker(), getWebhookManager(), etc. in commands
  */
 
-import type {
-  ConversationHistoryService,
-  PersonaResolver,
-  ChannelActivationCacheInvalidationService,
-} from '@tzurot/common-types';
+import type { ChannelActivationCacheInvalidationService } from '@tzurot/common-types';
 import type { IPersonalityLoader } from '../types/IPersonalityLoader.js';
 import type { JobTracker } from './JobTracker.js';
 import type { WebhookManager } from '../utils/WebhookManager.js';
@@ -26,8 +22,6 @@ import type { DenylistCache } from './DenylistCache.js';
 let jobTracker: JobTracker | undefined;
 let webhookManager: WebhookManager | undefined;
 let personalityService: IPersonalityLoader | undefined;
-let conversationHistoryService: ConversationHistoryService | undefined;
-let personaResolver: PersonaResolver | undefined;
 let channelActivationCacheInvalidationService:
   | ChannelActivationCacheInvalidationService
   | undefined;
@@ -42,8 +36,6 @@ interface RegisteredServices {
   jobTracker: JobTracker;
   webhookManager: WebhookManager;
   personalityService: IPersonalityLoader;
-  conversationHistoryService: ConversationHistoryService;
-  personaResolver: PersonaResolver;
   channelActivationCacheInvalidationService: ChannelActivationCacheInvalidationService;
   messageContextBuilder: MessageContextBuilder;
   conversationPersistence: ConversationPersistence;
@@ -58,8 +50,6 @@ export function registerServices(services: RegisteredServices): void {
   jobTracker = services.jobTracker;
   webhookManager = services.webhookManager;
   personalityService = services.personalityService;
-  conversationHistoryService = services.conversationHistoryService;
-  personaResolver = services.personaResolver;
   channelActivationCacheInvalidationService = services.channelActivationCacheInvalidationService;
   messageContextBuilder = services.messageContextBuilder;
   conversationPersistence = services.conversationPersistence;
@@ -99,28 +89,6 @@ export function getPersonalityLoader(): IPersonalityLoader {
     throw new Error('Personality loader not registered. Call registerServices() first.');
   }
   return personalityService;
-}
-
-/**
- * Get the ConversationHistoryService instance
- * @throws Error if services not registered
- */
-export function getConversationHistoryService(): ConversationHistoryService {
-  if (conversationHistoryService === undefined) {
-    throw new Error('ConversationHistoryService not registered. Call registerServices() first.');
-  }
-  return conversationHistoryService;
-}
-
-/**
- * Get the PersonaResolver instance
- * @throws Error if services not registered
- */
-export function getPersonaResolver(): PersonaResolver {
-  if (personaResolver === undefined) {
-    throw new Error('PersonaResolver not registered. Call registerServices() first.');
-  }
-  return personaResolver;
 }
 
 /**
@@ -169,8 +137,6 @@ export function areServicesRegistered(): boolean {
     jobTracker !== undefined &&
     webhookManager !== undefined &&
     personalityService !== undefined &&
-    conversationHistoryService !== undefined &&
-    personaResolver !== undefined &&
     channelActivationCacheInvalidationService !== undefined &&
     messageContextBuilder !== undefined &&
     conversationPersistence !== undefined &&
@@ -191,8 +157,6 @@ export function resetServices(): void {
   jobTracker = undefined;
   webhookManager = undefined;
   personalityService = undefined;
-  conversationHistoryService = undefined;
-  personaResolver = undefined;
   channelActivationCacheInvalidationService = undefined;
   messageContextBuilder = undefined;
   conversationPersistence = undefined;


### PR DESCRIPTION
## What

PR #1289 removed bot-client's **last live Prisma read** (`chat.ts` persona resolution → `routing-context`). This deletes the now-dead Prisma wiring that remained in the composition root, so **bot-client has zero Prisma usage**.

Net: **6 insertions, 174 deletions** — pure removal of dead wiring.

| Removed | Why it's dead |
| --- | --- |
| `PersonalityService(prisma)` + `ConversationHistoryService(prisma)` | The registered loader is the HTTP `routingPersonalityLoader`; neither prisma service had a live consumer. |
| `PersonaResolver` + its `PersonaCacheInvalidationService` subscription | Vestigial once `chat.ts` stopped calling `.resolve()` — the cache it invalidated was never populated. The whole persona-cache-invalidation path goes. |
| `verifyDatabaseConnection()` startup probe | The one remaining forced Prisma read at boot. |
| `getPrismaClient()` / `const prisma` / `disconnectPrisma()` | The root handle + its shutdown disconnect, removable once the above are gone. |
| `getPersonaResolver` / `getConversationHistoryService` registry getters (+ lanes + tests) | Zero production callers. |

**Kept:** the HTTP `routingPersonalityLoader` registration (`personalityService` lane), `cacheRedis` (still used by the other invalidation services), and all non-Prisma wiring.

## Why

Epic 2.5d: **bot-client must NEVER use Prisma** — it calls gateway APIs; the worker re-derives all DB-backed context.

## Scope

Teardown only. The structural guard preventing re-introduction is a **separate follow-up PR** (Phase 4 PR-B): harden `guard:boundaries` to catch a future `getPrismaClient` re-import. Note: the epic notes said "tighten the depcruise rule," but depcruise matches module paths and **cannot** see symbols re-exported through the `@tzurot/common-types` barrel — `guard:boundaries` (symbol-level) is the correct tool, and needs a multi-line-aware scanner. That's why it's split out.

## Verification

- `pnpm --filter @tzurot/bot-client test` — 5037/5037 green (16/16 in `serviceRegistry.test.ts`).
- `pnpm quality` — green (typecheck, lint, knip, depcruise, cpd, audit, taxonomy).
- Grep gate: zero Prisma-symbol hits in `services/bot-client/src` production code.
- Behavior-neutral — PR #1289 already moved the only live read; this removes dead wiring only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)