### PR TITLE
refactor(tooling): guard:boundaries catches barrel-re-exported Prisma in bot-client

### DIFF
--- a/packages/tooling/src/dev/check-boundaries.WHY.md
+++ b/packages/tooling/src/dev/check-boundaries.WHY.md
@@ -5,10 +5,13 @@
 Scans every source file across services and packages for forbidden imports defined in `BOUNDARY_RULES`. The current rules enforce:
 
 - `bot-client` never imports from `@prisma/client` directly (must go through `api-gateway` HTTP endpoints)
+- `bot-client` never imports Prisma-backed code (`getPrismaClient`, `PrismaClient`, `PersonaResolver`, `PersonalityService`, `ConversationHistoryService`, `PersonaCacheInvalidationService`, …) re-exported from the `@tzurot/common-types` barrel
 - No cross-service imports (services may only import from `@tzurot/common-types`)
 - `ai-worker` internals are not exposed outside the service
 
-Adds errors and warnings; CI fails on errors. Complementary to `pnpm depcruise` (the heavier dependency-cruiser config), but tighter and faster — runs in the lint job in under a second.
+The scanner matches **whole import statements**, not single lines — a multi-line `import {\n  getPrismaClient,\n} from '@tzurot/common-types'` is collapsed to one logical unit before the rule patterns run, so symbol names on their own lines are visible. (A symbol-level rule is meaningless against the older line-by-line scan, which never saw the symbols.)
+
+Adds errors and warnings; CI fails on errors. Complementary to `pnpm depcruise` (the heavier dependency-cruiser config), but tighter and faster — runs in the lint job in under a second. **This symbol-level reach is also why guard:boundaries, not depcruise, owns the Prisma re-export rule**: dependency-cruiser matches resolved module paths and tracks the import edge to the common-types barrel (`index.ts`), so it cannot distinguish a Prisma-backed re-export from any other common-types import.
 
 ## Why it was built
 

--- a/packages/tooling/src/dev/check-boundaries.test.ts
+++ b/packages/tooling/src/dev/check-boundaries.test.ts
@@ -129,6 +129,65 @@ const prisma = new PrismaClient();
       expect(process.exitCode).toBe(1);
     });
 
+    it('should detect bot-client importing Prisma-backed code from the common-types barrel', async () => {
+      vi.mocked(readdirSync).mockImplementation(((dir: unknown) =>
+        String(dir).includes('bot-client/src') ? ['test.ts'] : []) as typeof readdirSync);
+      vi.mocked(statSync).mockReturnValue({ isDirectory: () => false } as ReturnType<
+        typeof statSync
+      >);
+      vi.mocked(readFileSync).mockReturnValue(
+        `import { getPrismaClient } from '@tzurot/common-types';`
+      );
+
+      await checkBoundaries();
+
+      const output = consoleLogSpy.mock.calls.flat().join(' ');
+      expect(output).toContain('boundary violation');
+      expect(output).toContain('Prisma-backed');
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('should detect a Prisma-backed symbol in a MULTI-LINE common-types import', async () => {
+      // Regression guard: the old line-by-line scan skipped any line without the
+      // `import` keyword, so `getPrismaClient,` on its own line was invisible.
+      vi.mocked(readdirSync).mockImplementation(((dir: unknown) =>
+        String(dir).includes('bot-client/src') ? ['test.ts'] : []) as typeof readdirSync);
+      vi.mocked(statSync).mockReturnValue({ isDirectory: () => false } as ReturnType<
+        typeof statSync
+      >);
+      vi.mocked(readFileSync).mockReturnValue(
+        [
+          'import {',
+          '  createLogger,',
+          '  getPrismaClient,',
+          "} from '@tzurot/common-types';",
+        ].join('\n')
+      );
+
+      await checkBoundaries();
+
+      const output = consoleLogSpy.mock.calls.flat().join(' ');
+      expect(output).toContain('boundary violation');
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('should detect the Prisma namespace imported from the common-types barrel', async () => {
+      vi.mocked(readdirSync).mockImplementation(((dir: unknown) =>
+        String(dir).includes('bot-client/src') ? ['test.ts'] : []) as typeof readdirSync);
+      vi.mocked(statSync).mockReturnValue({ isDirectory: () => false } as ReturnType<
+        typeof statSync
+      >);
+      vi.mocked(readFileSync).mockReturnValue(
+        `import type { Prisma } from '@tzurot/common-types';`
+      );
+
+      await checkBoundaries();
+
+      const output = consoleLogSpy.mock.calls.flat().join(' ');
+      expect(output).toContain('boundary violation');
+      expect(process.exitCode).toBe(1);
+    });
+
     it('should detect api-gateway importing from bot-client', async () => {
       vi.mocked(readdirSync).mockImplementation(((dir: unknown) => {
         const dirStr = String(dir);
@@ -184,6 +243,46 @@ import { Client } from 'discord.js';
       vi.mocked(readFileSync).mockReturnValue(`
 import { PersonalityConfig } from '@tzurot/common-types';
 `);
+
+      await checkBoundaries();
+
+      const output = consoleLogSpy.mock.calls.flat().join(' ');
+      expect(output).toContain('No boundary violations found');
+    });
+
+    it('should allow a multi-line common-types import with no Prisma-backed symbols', async () => {
+      vi.mocked(readdirSync).mockImplementation(((dir: unknown) =>
+        String(dir).includes('bot-client/src') ? ['test.ts'] : []) as typeof readdirSync);
+      vi.mocked(statSync).mockReturnValue({ isDirectory: () => false } as ReturnType<
+        typeof statSync
+      >);
+      vi.mocked(readFileSync).mockReturnValue(
+        [
+          'import {',
+          '  createLogger,',
+          '  PersonalityConfig,',
+          '  LoadedPersonality,',
+          "} from '@tzurot/common-types';",
+        ].join('\n')
+      );
+
+      await checkBoundaries();
+
+      const output = consoleLogSpy.mock.calls.flat().join(' ');
+      expect(output).toContain('No boundary violations found');
+    });
+
+    it('should allow a Prisma-named symbol imported from a non-barrel (local) module', async () => {
+      // The rule is scoped to `from '@tzurot/common-types'` — a local module that
+      // happens to export a same-named symbol must NOT trip it (no false positive).
+      vi.mocked(readdirSync).mockImplementation(((dir: unknown) =>
+        String(dir).includes('bot-client/src') ? ['test.ts'] : []) as typeof readdirSync);
+      vi.mocked(statSync).mockReturnValue({ isDirectory: () => false } as ReturnType<
+        typeof statSync
+      >);
+      vi.mocked(readFileSync).mockReturnValue(
+        `import { getPrismaClient } from './utils/localShim.js';`
+      );
 
       await checkBoundaries();
 

--- a/packages/tooling/src/dev/check-boundaries.ts
+++ b/packages/tooling/src/dev/check-boundaries.ts
@@ -41,6 +41,20 @@ const BOUNDARY_RULES: {
         severity: 'error',
       },
       {
+        // Prisma reaches bot-client via re-exports from the @tzurot/common-types
+        // barrel, not a direct @prisma/client import — depcruise (module-path
+        // matching) can't see the barrel re-export, so this symbol-level rule is
+        // the enforcement. Matches a forbidden DB-layer symbol in the same
+        // statement as a common-types `from`; every symbol in the alternation
+        // has a Prisma dependency chain. Keep the alternation in sync: add the
+        // export name of any new Prisma-backed @tzurot/common-types service here.
+        pattern:
+          /\b(getPrismaClient|disconnectPrisma|PrismaClient|PersonaResolver|PersonalityService|ConversationHistoryService|PersonaCacheInvalidationService|Prisma)\b[\s\S]*?from\s+['"]@tzurot\/common-types['"]/,
+        reason:
+          'bot-client must not import Prisma-backed code from @tzurot/common-types - these reach the database; use the gateway HTTP API (HttpPersonalityLoader, routing-context)',
+        severity: 'error',
+      },
+      {
         pattern: /from ['"]\.\.\/\.\.\/\.\.\/services\/ai-worker/,
         reason: 'bot-client must not import from ai-worker internals',
         severity: 'error',
@@ -140,27 +154,54 @@ function findTypeScriptFiles(dir: string): string[] {
 }
 
 /**
+ * Match a complete import/require statement, spanning newlines. Three forms:
+ *   1. `import … from '…'`        (named/default/namespace; the `…` may wrap lines)
+ *   2. `import '…'`               (side-effect import)
+ *   3. `require('…')`             (CommonJS)
+ * The lazy `[\s\S]*?` in form 1 stops at the first `from '…'`, so each statement
+ * is bounded to its own specifier and never bleeds into the next. A bare `from`
+ * inside a comment between the braces is skipped: it has no following quote, so
+ * the trailing `['"]…['"]` fails there and the engine backtracks to the real
+ * `from '…'`.
+ */
+const IMPORT_STATEMENT_RE =
+  /\bimport\b[\s\S]*?\bfrom\b\s*['"][^'"]+['"]|\bimport\s+['"][^'"]+['"]|\brequire\s*\(\s*['"][^'"]+['"]\s*\)/g;
+
+/**
+ * Extract each import/require statement as one logical string anchored to the
+ * 1-based line where it begins.
+ *
+ * Collapsing multi-line imports is load-bearing: the imported symbol names in a
+ * multi-line `import {\n  getPrismaClient,\n} from '…'` sit on their own lines.
+ * A line-by-line scan that only inspects lines containing the `import` keyword
+ * never sees them, so a symbol-level rule (e.g. "no getPrismaClient") would
+ * silently miss every multi-line import. Joining the statement first makes the
+ * symbol list and the module specifier matchable as one unit.
+ */
+function extractImportStatements(content: string): { line: number; text: string }[] {
+  const statements: { line: number; text: string }[] = [];
+  for (const match of content.matchAll(IMPORT_STATEMENT_RE)) {
+    const line = content.slice(0, match.index ?? 0).split('\n').length;
+    statements.push({ line, text: match[0] });
+  }
+  return statements;
+}
+
+/**
  * Check a single file for boundary violations
  */
 function checkFile(filePath: string, rules: (typeof BOUNDARY_RULES)[number]): Violation[] {
   const violations: Violation[] = [];
   const content = readFileSync(filePath, 'utf-8');
-  const lines = content.split('\n');
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-
-    // Skip non-import lines
-    if (!line.includes('import') && !line.includes('require')) {
-      continue;
-    }
-
+  for (const statement of extractImportStatements(content)) {
     for (const rule of rules.forbiddenImports) {
-      if (rule.pattern.test(line)) {
+      if (rule.pattern.test(statement.text)) {
         violations.push({
           file: filePath,
-          line: i + 1,
-          import: line.trim(),
+          line: statement.line,
+          // Collapse a possibly multi-line statement to one line for display.
+          import: statement.text.replace(/\s+/g, ' ').trim(),
           rule: rule.reason,
           severity: rule.severity,
         });

--- a/services/bot-client/src/test/mocks/PersonalityService.mock.ts
+++ b/services/bot-client/src/test/mocks/PersonalityService.mock.ts
@@ -1,11 +1,16 @@
 /**
- * Mock PersonalityService for testing
+ * Mock personality loader for testing
  *
- * Provides a test double for PersonalityService that avoids database calls
+ * Provides a test double for the personality-loading dependency (an
+ * `IPersonalityLoader` — the interface consumers like `findPersonalityMentions`
+ * actually accept) that avoids any gateway/database calls. bot-client never
+ * touches the Prisma-backed `PersonalityService`, so the mock is typed to the
+ * interface, not the concrete class.
  */
 
 import { vi } from 'vitest';
-import type { PersonalityService, LoadedPersonality } from '@tzurot/common-types';
+import type { LoadedPersonality } from '@tzurot/common-types';
+import type { IPersonalityLoader } from '../../types/IPersonalityLoader.js';
 
 interface MockPersonality {
   name: string;
@@ -15,28 +20,28 @@ interface MockPersonality {
 }
 
 /**
- * Create a mock PersonalityService with predefined personalities
+ * Create a mock personality loader with predefined personalities.
  *
  * @param personalities - List of personalities the mock should "know about"
- * @returns Type-safe mock PersonalityService that returns these personalities
+ * @returns Type-safe IPersonalityLoader mock that returns these personalities
  *
  * @example
  * ```typescript
- * const service = createMockPersonalityService([
+ * const loader = createMockPersonalityService([
  *   { name: 'Lilith', displayName: 'Lilith', systemPrompt: '...' },
  *   { name: 'Bambi Prime', displayName: 'Bambi Prime', systemPrompt: '...' },
  * ]);
  *
- * const result = await service.loadPersonality('Lilith');
+ * const result = await loader.loadPersonality('Lilith');
  * // Returns the mock personality object
  * ```
  */
-export function createMockPersonalityService(personalities: MockPersonality[]): PersonalityService {
+export function createMockPersonalityService(personalities: MockPersonality[]): IPersonalityLoader {
   const personalityMap = new Map(personalities.map(p => [p.name.toLowerCase(), p]));
 
-  // Create a mock that implements the PersonalityService interface methods we need
-  // We use double type assertion (as unknown as PersonalityService) because this is a test mock
-  // that only implements the methods we need, not the full class with all properties
+  // The mock implements only loadPersonality — the single method
+  // IPersonalityLoader (and its consumers, e.g. findPersonalityMentions) need —
+  // so the object satisfies the interface directly, no cast required.
   return {
     loadPersonality: vi.fn().mockImplementation((name: string) => {
       const personality = personalityMap.get(name.toLowerCase());
@@ -44,8 +49,8 @@ export function createMockPersonalityService(personalities: MockPersonality[]): 
         return Promise.resolve(null);
       }
 
-      // Return a minimal mock personality object
-      // In real code this would be a full LoadedPersonality from the database
+      // Return a minimal mock personality object.
+      // In real code this would be a full LoadedPersonality from the gateway.
       return Promise.resolve({
         id: `mock-id-${personality.name.toLowerCase()}`,
         name: personality.name,
@@ -62,8 +67,5 @@ export function createMockPersonalityService(personalities: MockPersonality[]): 
         voiceEnabled: false,
       } as unknown as LoadedPersonality);
     }),
-
-    // Add other PersonalityService methods as needed for tests
-    loadAllPersonalities: vi.fn().mockResolvedValue(personalities),
-  } as unknown as PersonalityService;
+  };
 }

--- a/services/bot-client/src/utils/personalityMentionParser.test.ts
+++ b/services/bot-client/src/utils/personalityMentionParser.test.ts
@@ -8,13 +8,13 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { findPersonalityMentions } from './personalityMentionParser.js';
 import { createMockPersonalityService } from '../test/mocks/PersonalityService.mock.js';
-import type { PersonalityService } from '@tzurot/common-types';
+import type { IPersonalityLoader } from '../types/IPersonalityLoader.js';
 import { MULTI_TAG } from '@tzurot/common-types';
 
 const TEST_USER_ID = 'test-user-123';
 
 describe('personalityMentionParser', () => {
-  let mockPersonalityService: PersonalityService;
+  let mockPersonalityService: IPersonalityLoader;
 
   beforeEach(() => {
     mockPersonalityService = createMockPersonalityService([


### PR DESCRIPTION
## What

Phase 4 PR-B — the structural enforcement that locks in PR #1290's Prisma eviction. Extends `guard:boundaries` (`packages/tooling/src/dev/check-boundaries.ts`) so a future bot-client re-import of Prisma-backed code fails CI.

## Why guard:boundaries, not depcruise

The epic's original note said "tighten the depcruise rule." That's the **wrong mechanism**: bot-client imports `getPrismaClient` et al. through the `@tzurot/common-types` **barrel** (`export *`). dependency-cruiser matches resolved module paths and tracks the import edge to the barrel (`index.ts`) — it **cannot** distinguish a Prisma-backed re-export from any other common-types import (a `reachable` rule would flag *every* common-types import). `guard:boundaries` works at the symbol level, so it's the correct tool.

## Changes

**1. Import-statement-aware scanner.** The old `checkFile` scanned line-by-line and skipped any line without the `import` keyword — so in a multi-line `import {\n  getPrismaClient,\n} from '…'`, the symbol names (on their own lines) were **invisible**. A symbol-level rule would silently miss every multi-line import. The scanner now collapses each `import … from '…'` (and `import '…'` / `require('…')`) into one logical unit before matching. This also strengthens every existing boundary rule.

**2. New bot-client rule** — forbid importing `getPrismaClient` / `disconnectPrisma` / `PrismaClient` / `Prisma` / `PersonaResolver` / `PersonalityService` / `ConversationHistoryService` / `PersonaCacheInvalidationService` from `@tzurot/common-types` (scoped to that barrel; direct `@prisma/client` stays covered by the existing rule).

**3. Mock retype.** The bot-client personality-loader test mock was typed to the Prisma-backed `PersonalityService` out of habit — its only consumer (`findPersonalityMentions`) actually accepts `IPersonalityLoader`. Retyped to the interface, removing bot-client's **last** Prisma-type reference so the new rule runs clean on the real tree.

## Verification

- `pnpm ops guard:boundaries` — **clean on the real tree (701 files)**: bot-client now passes, and the stricter multi-line scanner surfaced no pre-existing hidden violations in other services.
- `pnpm --filter @tzurot/tooling test` — 1092 green (check-boundaries: +3 tests — single-line symbol, multi-line symbol, multi-line allowed).
- `pnpm --filter @tzurot/bot-client` `personalityMentionParser.test.ts` — 47 green (mock retype).
- `pnpm quality` — green.

This completes the **2.5d Prisma-eviction epic**: bot-client is Prisma-free and structurally guarded against regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)