### PR TITLE
refactor(common-types): add createPrismaClient factory; api-gateway owns its client

### DIFF
--- a/packages/common-types/src/services/prisma.ts
+++ b/packages/common-types/src/services/prisma.ts
@@ -1,9 +1,12 @@
 /**
  * Prisma Client Service
- * Provides a singleton Prisma client for database access across services
  *
- * Prisma 7.0 uses driver adapters for database connections.
- * The PrismaClient is generated to packages/common-types/src/generated/prisma/
+ * `createPrismaClient()` is the supported entry point — it builds an app-owned
+ * client the caller injects + disposes. `getPrismaClient()` is the deprecated
+ * cross-package singleton, retained only until its remaining consumers migrate.
+ *
+ * Prisma 7.0 uses driver adapters for database connections; the generated
+ * PrismaClient lives in packages/common-types/src/generated/prisma/.
  */
 
 import { Pool } from 'pg';
@@ -25,8 +28,89 @@ let prismaClient: PrismaClient | null = null;
 let stopPoolStatsGauge: (() => void) | null = null;
 
 /**
+ * A constructed Prisma client paired with its disposer. Each app constructs
+ * exactly one of these at its composition root, injects `prisma` into the
+ * services that need it, and calls `dispose()` in its shutdown handler.
+ */
+export interface PrismaClientHandle {
+  prisma: PrismaClient;
+  /** Stop the pool-stats gauge and disconnect the client (closes the pool). */
+  dispose: () => Promise<void>;
+}
+
+/**
+ * Construct a fresh PrismaClient over a configured pg.Pool. NOT a singleton —
+ * each call builds an independent client + pool. The caller owns the lifecycle:
+ * inject `prisma`, call `dispose()` on shutdown. An app-owned client (vs. a
+ * shared cross-package singleton) keeps lifecycle ownership explicit.
+ *
+ * @param opts.max - Pool size override. Defaults to `resolvePoolMax()` (the
+ *   long-running app size); pass `DB_POOL_DEFAULTS.TRANSIENT_MAX` for one-shot
+ *   scripts/migrations that don't warrant the full pool.
+ */
+export function createPrismaClient(opts?: { max?: number }): PrismaClientHandle {
+  const dbUrl = process.env.DATABASE_URL;
+
+  // Prisma 7.0 driver adapter over an EXPLICIT pg.Pool. The adapter ignores
+  // `?connection_limit=` on DATABASE_URL, so the pool MUST be sized here —
+  // otherwise it silently uses pg's defaults (max=10, wait-forever acquisition)
+  // and starves under load. See poolConfig.ts for the full rationale.
+  const max = opts?.max ?? resolvePoolMax();
+  const connectionTimeoutMillis = resolveConnectionTimeoutMs();
+  const pool = new Pool({ connectionString: dbUrl, max, connectionTimeoutMillis });
+  pool.on('error', err => {
+    logger.error({ err }, 'pg.Pool idle-client error');
+  });
+  const stopGauge = startPoolStatsGauge(pool, logger, resolvePoolStatsIntervalMs(), max);
+
+  // The pool + stats gauge are now live; if client construction throws past
+  // this point, tear them down before rethrowing so we don't leak the interval
+  // or pool connections (callers can't dispose a handle they never received).
+  let prisma: PrismaClient;
+  try {
+    // disposeExternalPool: true so prisma.$disconnect() closes the pool we created
+    // (external pools are otherwise left open on disconnect).
+    const adapter = new PrismaPg(pool, { disposeExternalPool: true });
+    prisma = new PrismaClient({
+      adapter,
+      log: config.NODE_ENV === 'development' ? ['query', 'error', 'warn'] : ['error'],
+    });
+  } catch (err) {
+    stopGauge();
+    void pool.end();
+    throw err;
+  }
+
+  logger.info(
+    { max, connectionTimeoutMillis },
+    'Prisma client initialized with configured pg.Pool'
+  );
+
+  let disposed = false;
+  const dispose = async (): Promise<void> => {
+    // Idempotent — the lifecycle pattern spreads to ai-worker (2p-1b), so a
+    // double-call (shutdown + a stray finally) must not $disconnect twice.
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    // Stop the gauge before disconnecting so no stale interval polls the closed
+    // pool. `startPoolStatsGauge` always returns a function, so no `?.` needed.
+    stopGauge();
+    await prisma.$disconnect();
+    logger.info('Prisma client disconnected');
+  };
+
+  return { prisma, dispose };
+}
+
+/**
  * Get or create the Prisma client singleton
  * Uses the Prisma 7.0 driver adapter pattern with @prisma/adapter-pg
+ *
+ * @deprecated Being evicted. Use `createPrismaClient()` at the app composition
+ * root and inject the client. This singleton is removed once its remaining
+ * consumers (ai-worker, the tooling db commands) are migrated off it.
  */
 export function getPrismaClient(): PrismaClient {
   if (!prismaClient) {
@@ -64,6 +148,9 @@ export function getPrismaClient(): PrismaClient {
 
 /**
  * Disconnect the Prisma client (for graceful shutdown)
+ *
+ * @deprecated Paired with `getPrismaClient()` — being evicted. Use the
+ * `dispose()` returned by `createPrismaClient()` instead.
  */
 export async function disconnectPrisma(): Promise<void> {
   if (prismaClient) {

--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -19,7 +19,7 @@ import { createRequire } from 'module';
 import {
   createLogger,
   getConfig,
-  getPrismaClient,
+  createPrismaClient,
   PersonalityService,
   CacheInvalidationService,
   ApiKeyCacheInvalidationService,
@@ -366,7 +366,8 @@ function registerRoutes(app: Express, prisma: PrismaClient, services: ServicesCo
  */
 function createShutdownHandler(
   server: ReturnType<Express['listen']>,
-  services: ServicesContext
+  services: ServicesContext,
+  disposePrisma: () => Promise<void>
 ): () => Promise<void> {
   const {
     cacheRedis,
@@ -399,6 +400,9 @@ function createShutdownHandler(
     logger.info('Embedding service shut down');
 
     await closeQueue();
+
+    // dispose() logs 'Prisma client disconnected' itself — no second line here.
+    await disposePrisma();
 
     logger.info('Shutdown complete');
     process.exit(0);
@@ -433,7 +437,9 @@ async function main(): Promise<void> {
 
   // Create Express app with base middleware
   const app = express();
-  const prisma = getPrismaClient();
+  // api-gateway owns its PrismaClient (no cross-package singleton). Disposed in
+  // the shutdown handler below.
+  const { prisma, dispose: disposePrisma } = createPrismaClient();
   await prisma.$connect();
   logger.info('Database connection established');
 
@@ -481,7 +487,7 @@ async function main(): Promise<void> {
   });
 
   // Setup graceful shutdown
-  const shutdown = createShutdownHandler(server, services);
+  const shutdown = createShutdownHandler(server, services, disposePrisma);
   process.on('SIGTERM', () => void shutdown());
   process.on('SIGINT', () => void shutdown());
   process.on('uncaughtException', error => {

--- a/services/api-gateway/src/migrations/sync-avatars.test.ts
+++ b/services/api-gateway/src/migrations/sync-avatars.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Use vi.hoisted to create mock functions before they're used in vi.mock
-const { mockWriteFile, mockAccess, mockUnlink, mockGlob, mockMkdir, mockFindMany, mockDisconnect } =
+const { mockWriteFile, mockAccess, mockUnlink, mockGlob, mockMkdir, mockFindMany, mockDispose } =
   vi.hoisted(() => ({
     mockWriteFile: vi.fn(),
     mockAccess: vi.fn(),
@@ -13,7 +13,7 @@ const { mockWriteFile, mockAccess, mockUnlink, mockGlob, mockMkdir, mockFindMany
     mockGlob: vi.fn(),
     mockMkdir: vi.fn(),
     mockFindMany: vi.fn(),
-    mockDisconnect: vi.fn(),
+    mockDispose: vi.fn(),
   }));
 
 // Mock fs/promises
@@ -27,12 +27,15 @@ vi.mock('fs/promises', () => ({
 
 // Mock Prisma client
 vi.mock('@tzurot/common-types', () => ({
-  getPrismaClient: () => ({
-    personality: {
-      findMany: mockFindMany,
+  createPrismaClient: () => ({
+    prisma: {
+      personality: {
+        findMany: mockFindMany,
+      },
     },
-    $disconnect: mockDisconnect,
+    dispose: mockDispose,
   }),
+  DB_POOL_DEFAULTS: { TRANSIENT_MAX: 5 },
   createLogger: () => ({
     info: vi.fn(),
     warn: vi.fn(),
@@ -75,7 +78,7 @@ describe('syncAvatars', () => {
       })
     );
     expect(mockWriteFile).not.toHaveBeenCalled();
-    expect(mockDisconnect).toHaveBeenCalled();
+    expect(mockDispose).toHaveBeenCalled();
   });
 
   it('should sync avatar from database when file does not exist', async () => {
@@ -99,7 +102,7 @@ describe('syncAvatars', () => {
       `/data/avatars/t/test-bot-${timestamp}.png`,
       avatarBuffer
     );
-    expect(mockDisconnect).toHaveBeenCalled();
+    expect(mockDispose).toHaveBeenCalled();
   });
 
   it('should skip syncing when versioned file already exists', async () => {
@@ -114,7 +117,7 @@ describe('syncAvatars', () => {
     await syncAvatars();
 
     expect(mockWriteFile).not.toHaveBeenCalled();
-    expect(mockDisconnect).toHaveBeenCalled();
+    expect(mockDispose).toHaveBeenCalled();
   });
 
   it('should skip personalities with invalid slugs', async () => {
@@ -129,7 +132,7 @@ describe('syncAvatars', () => {
 
     expect(mockWriteFile).not.toHaveBeenCalled();
     expect(mockMkdir).not.toHaveBeenCalled();
-    expect(mockDisconnect).toHaveBeenCalled();
+    expect(mockDispose).toHaveBeenCalled();
   });
 
   it('should cleanup old versions after syncing new avatar', async () => {
@@ -156,7 +159,7 @@ describe('syncAvatars', () => {
     // Should delete the old version, not the current one
     expect(mockUnlink).toHaveBeenCalledTimes(1);
     expect(mockUnlink).toHaveBeenCalledWith(`/data/avatars/t/test-bot-${oldTimestamp}.png`);
-    expect(mockDisconnect).toHaveBeenCalled();
+    expect(mockDispose).toHaveBeenCalled();
   });
 
   it('should cleanup legacy files without timestamps', async () => {
@@ -226,7 +229,7 @@ describe('syncAvatars', () => {
 
     // Should still write the file
     expect(mockWriteFile).toHaveBeenCalled();
-    expect(mockDisconnect).toHaveBeenCalled();
+    expect(mockDispose).toHaveBeenCalled();
   });
 
   it('should rethrow non-ENOENT glob errors', async () => {
@@ -246,7 +249,7 @@ describe('syncAvatars', () => {
     });
 
     await expect(syncAvatars()).rejects.toThrow('EACCES');
-    expect(mockDisconnect).toHaveBeenCalled();
+    expect(mockDispose).toHaveBeenCalled();
   });
 
   it('should handle unlink errors gracefully for cleanup', async () => {
@@ -271,7 +274,7 @@ describe('syncAvatars', () => {
 
     // Should still complete successfully
     expect(mockWriteFile).toHaveBeenCalled();
-    expect(mockDisconnect).toHaveBeenCalled();
+    expect(mockDispose).toHaveBeenCalled();
   });
 
   it('should ignore ENOENT errors during unlink (file already deleted)', async () => {
@@ -295,7 +298,7 @@ describe('syncAvatars', () => {
     await syncAvatars();
 
     expect(mockWriteFile).toHaveBeenCalled();
-    expect(mockDisconnect).toHaveBeenCalled();
+    expect(mockDispose).toHaveBeenCalled();
   });
 
   it('should sync multiple personalities', async () => {
@@ -324,14 +327,14 @@ describe('syncAvatars', () => {
       `/data/avatars/b/beta-${date2.getTime()}.png`,
       avatar2
     );
-    expect(mockDisconnect).toHaveBeenCalled();
+    expect(mockDispose).toHaveBeenCalled();
   });
 
   it('should handle database error and still disconnect', async () => {
     mockFindMany.mockRejectedValue(new Error('Database connection failed'));
 
     await expect(syncAvatars()).rejects.toThrow('Database connection failed');
-    expect(mockDisconnect).toHaveBeenCalled();
+    expect(mockDispose).toHaveBeenCalled();
   });
 
   it('should use correct subdirectory based on slug first character', async () => {
@@ -389,6 +392,6 @@ describe('syncAvatars', () => {
         skip: 1,
       })
     );
-    expect(mockDisconnect).toHaveBeenCalled();
+    expect(mockDispose).toHaveBeenCalled();
   });
 });

--- a/services/api-gateway/src/migrations/sync-avatars.ts
+++ b/services/api-gateway/src/migrations/sync-avatars.ts
@@ -20,7 +20,7 @@
 
 import { writeFile, access, unlink } from 'fs/promises';
 import { basename } from 'path';
-import { getPrismaClient, createLogger } from '@tzurot/common-types';
+import { createPrismaClient, createLogger, DB_POOL_DEFAULTS } from '@tzurot/common-types';
 import {
   extractSlugFromFilename,
   extractTimestampFromFilename,
@@ -33,7 +33,6 @@ import {
 } from '../utils/avatarPaths.js';
 
 const logger = createLogger('avatar-sync');
-const prisma = getPrismaClient();
 
 /**
  * Attempts to delete a single avatar file, returning true on success
@@ -172,6 +171,11 @@ async function syncPersonalityAvatar(personality: {
 export async function syncAvatars(): Promise<void> {
   logger.info('Starting avatar sync from database...');
 
+  // One-off sequential startup migration: a small transient pool (not the
+  // full app size) so it doesn't compete with the main API pool. Disposed in
+  // `finally`.
+  const { prisma, dispose } = createPrismaClient({ max: DB_POOL_DEFAULTS.TRANSIENT_MAX });
+
   try {
     let syncedCount = 0;
     let skippedCount = 0;
@@ -227,6 +231,6 @@ export async function syncAvatars(): Promise<void> {
     logger.error({ err: error }, 'Failed to sync avatars');
     throw error;
   } finally {
-    await prisma.$disconnect();
+    await dispose();
   }
 }


### PR DESCRIPTION
## What

First slice of **PR-2p-1** (evict the `prisma.ts` cross-package singleton — part of the "slim common-types" epic). Introduces **`createPrismaClient()`**: a stateless factory that builds an independent `PrismaClient` over a configured `pg.Pool` and returns it paired with a `dispose()`. Each app constructs exactly one at its composition root, injects `prisma`, and disposes it on shutdown.

**api-gateway is converted** to own its client:
- `index.ts` constructs via the factory and disposes in the graceful-shutdown handler.
- The `sync-avatars` startup migration owns a short-lived client (disposed in `finally`).

## Why

The `getPrismaClient()` singleton hid lifecycle ownership and re-exported Prisma broadly (it's how the bot-client drift went uncaught). An app-owned client makes ownership explicit and is the prerequisite for extracting the Prisma-backed services out of `common-types` (PR-2p-2/2p-3).

## Scope

`getPrismaClient`/`disconnectPrisma` **stay** (now `@deprecated`) — still used by ai-worker + the 7 tooling db commands. Those, plus the ai-worker **job-pipeline threading** (AIJobProcessor already holds `this.prisma`; the ~6 deep sites that re-fetch the singleton get it passed down), are the follow-up **2p-1b**, after which the singleton is deleted. ai-worker is split out deliberately: it's all-or-nothing (a partial conversion would run two pools) and touches the AI generation path, so it deserves a focused PR.

## Verification

- `pnpm --filter @tzurot/api-gateway test` — **2142 green** (incl. the updated `sync-avatars` mock).
- `pnpm quality` — green (typecheck, knip, cpd, depcruise, audit). The cpd report transiently shows the factory duplicating the singleton's construction — that vanishes in 2p-1b when the singleton is deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)