### PR TITLE
refactor(tooling): move db commands off the prisma singleton; delete disconnectPrisma

### DIFF
--- a/packages/common-types/src/services/prisma.ts
+++ b/packages/common-types/src/services/prisma.ts
@@ -25,7 +25,6 @@ const logger = createLogger('PrismaService');
 const config = getConfig();
 
 let prismaClient: PrismaClient | null = null;
-let stopPoolStatsGauge: (() => void) | null = null;
 
 /**
  * A constructed Prisma client paired with its disposer. Each app constructs
@@ -126,7 +125,9 @@ export function getPrismaClient(): PrismaClient {
     pool.on('error', err => {
       logger.error({ err }, 'pg.Pool idle-client error');
     });
-    stopPoolStatsGauge = startPoolStatsGauge(pool, logger, resolvePoolStatsIntervalMs(), max);
+    // No stop handle kept: this client is never disposed, so the gauge runs for
+    // the process lifetime.
+    startPoolStatsGauge(pool, logger, resolvePoolStatsIntervalMs(), max);
 
     // disposeExternalPool: true so prismaClient.$disconnect() closes the pool we
     // created (external pools are otherwise left open on disconnect).
@@ -144,24 +145,6 @@ export function getPrismaClient(): PrismaClient {
   }
 
   return prismaClient;
-}
-
-/**
- * Disconnect the Prisma client (for graceful shutdown)
- *
- * @deprecated Paired with `getPrismaClient()` — being evicted. Use the
- * `dispose()` returned by `createPrismaClient()` instead.
- */
-export async function disconnectPrisma(): Promise<void> {
-  if (prismaClient) {
-    // Stop the gauge before disconnecting so a reconnect doesn't leave a stale
-    // interval polling the now-closed pool alongside the new one.
-    stopPoolStatsGauge?.();
-    stopPoolStatsGauge = null;
-    await prismaClient.$disconnect();
-    prismaClient = null;
-    logger.info('Prisma client disconnected');
-  }
 }
 
 // Re-export PrismaClient class and Prisma namespace for use by other services

--- a/packages/tooling/src/db/check-migration-drift.test.ts
+++ b/packages/tooling/src/db/check-migration-drift.test.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
-import { getPrismaClient, disconnectPrisma } from '@tzurot/common-types';
+import { createPrismaClient } from '@tzurot/common-types';
+
+const mockDispose = vi.fn();
 
 // Mock common-types
 vi.mock('@tzurot/common-types', () => ({
-  getPrismaClient: vi.fn(),
-  disconnectPrisma: vi.fn(),
+  createPrismaClient: vi.fn(),
+  DB_POOL_DEFAULTS: { TRANSIENT_MAX: 5 },
 }));
 
 // Mock chalk
@@ -46,8 +48,9 @@ describe('checkMigrationDrift', () => {
     vi.clearAllMocks();
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     mockQueryRaw = vi.fn();
-    vi.mocked(getPrismaClient).mockReturnValue({
-      $queryRaw: mockQueryRaw,
+    vi.mocked(createPrismaClient).mockReturnValue({
+      prisma: { $queryRaw: mockQueryRaw },
+      dispose: mockDispose,
     } as never);
   });
 
@@ -71,7 +74,7 @@ describe('checkMigrationDrift', () => {
     await checkMigrationDrift();
 
     expect(mockQueryRaw).toHaveBeenCalled();
-    expect(disconnectPrisma).toHaveBeenCalled();
+    expect(mockDispose).toHaveBeenCalled();
   });
 
   it('should report drift when checksums differ', async () => {

--- a/packages/tooling/src/db/check-migration-drift.ts
+++ b/packages/tooling/src/db/check-migration-drift.ts
@@ -9,7 +9,7 @@ import fs from 'node:fs';
 import crypto from 'node:crypto';
 import path from 'node:path';
 import chalk from 'chalk';
-import { getPrismaClient, disconnectPrisma } from '@tzurot/common-types';
+import { createPrismaClient, DB_POOL_DEFAULTS } from '@tzurot/common-types';
 import {
   type Environment,
   validateEnvironment,
@@ -42,7 +42,7 @@ export async function checkMigrationDrift(options: CheckDriftOptions = {}): Prom
   validateEnvironment(env);
   showEnvironmentBanner(env);
 
-  const prisma = getPrismaClient();
+  const { prisma, dispose } = createPrismaClient({ max: DB_POOL_DEFAULTS.TRANSIENT_MAX });
   // Default to prisma/migrations relative to cwd (monorepo root)
   const migrationsDir = options.migrationsPath ?? path.join(process.cwd(), 'prisma', 'migrations');
 
@@ -92,6 +92,6 @@ export async function checkMigrationDrift(options: CheckDriftOptions = {}): Prom
       console.log(chalk.cyan(`  pnpm ops db:fix-drift ${driftedMigrations.join(' ')}`));
     }
   } finally {
-    await disconnectPrisma();
+    await dispose();
   }
 }

--- a/packages/tooling/src/db/create-safe-migration.test.ts
+++ b/packages/tooling/src/db/create-safe-migration.test.ts
@@ -5,12 +5,14 @@ import {
   computeFileChecksum,
   reconcileMigrationChecksum,
 } from './create-safe-migration.js';
-import { getPrismaClient, disconnectPrisma } from '@tzurot/common-types';
+import { createPrismaClient } from '@tzurot/common-types';
+
+const mockDispose = vi.fn();
 
 // Mock common-types for reconcileMigrationChecksum tests
 vi.mock('@tzurot/common-types', () => ({
-  getPrismaClient: vi.fn(),
-  disconnectPrisma: vi.fn(),
+  createPrismaClient: vi.fn(),
+  DB_POOL_DEFAULTS: { TRANSIENT_MAX: 5 },
 }));
 
 /**
@@ -291,8 +293,11 @@ describe('reconcileMigrationChecksum', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockExecuteRaw = vi.fn();
-    vi.mocked(getPrismaClient).mockReturnValue({ $executeRaw: mockExecuteRaw } as never);
-    vi.mocked(disconnectPrisma).mockResolvedValue(undefined as never);
+    vi.mocked(createPrismaClient).mockReturnValue({
+      prisma: { $executeRaw: mockExecuteRaw },
+      dispose: mockDispose,
+    } as never);
+    mockDispose.mockResolvedValue(undefined as never);
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
   });
 
@@ -305,7 +310,7 @@ describe('reconcileMigrationChecksum', () => {
 
     await reconcileMigrationChecksum('/migrations/20260228015810_test_migration', 'sanitized SQL');
 
-    expect(getPrismaClient).toHaveBeenCalled();
+    expect(createPrismaClient).toHaveBeenCalled();
     expect(mockExecuteRaw).toHaveBeenCalled();
     expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('Checksum reconciled'));
   });
@@ -336,12 +341,12 @@ describe('reconcileMigrationChecksum', () => {
 
     await reconcileMigrationChecksum('/migrations/20260228015810_test_migration', 'SQL content');
 
-    expect(disconnectPrisma).toHaveBeenCalled();
+    expect(mockDispose).toHaveBeenCalled();
   });
 
-  it('should handle disconnectPrisma failure silently', async () => {
+  it('should handle dispose failure silently', async () => {
     mockExecuteRaw.mockResolvedValue(1);
-    vi.mocked(disconnectPrisma).mockRejectedValue(new Error('Already disconnected'));
+    mockDispose.mockRejectedValue(new Error('Already disconnected'));
 
     // Should not throw
     await reconcileMigrationChecksum('/migrations/20260228015810_test_migration', 'SQL content');

--- a/packages/tooling/src/db/create-safe-migration.ts
+++ b/packages/tooling/src/db/create-safe-migration.ts
@@ -24,7 +24,7 @@ import { readFileSync, writeFileSync, readdirSync, statSync, mkdirSync } from 'n
 import { join, basename } from 'node:path';
 import { createInterface } from 'node:readline';
 import chalk from 'chalk';
-import { getPrismaClient, disconnectPrisma } from '@tzurot/common-types';
+import { createPrismaClient, DB_POOL_DEFAULTS } from '@tzurot/common-types';
 import {
   type Environment,
   validateEnvironment,
@@ -243,9 +243,13 @@ export async function reconcileMigrationChecksum(
   const migrationName = basename(migrationDir);
   const checksum = computeFileChecksum(sanitizedContent);
 
+  // `dispose` is hoisted so the `finally` can reach it; constructing inside the
+  // try keeps a construction failure on the non-fatal "could not reconcile" path.
+  let dispose: (() => Promise<void>) | undefined;
   try {
-    const prisma = getPrismaClient();
-    await prisma.$executeRaw`
+    const handle = createPrismaClient({ max: DB_POOL_DEFAULTS.TRANSIENT_MAX });
+    dispose = handle.dispose;
+    await handle.prisma.$executeRaw`
       UPDATE _prisma_migrations
       SET checksum = ${checksum}
       WHERE migration_name = ${migrationName}
@@ -259,7 +263,7 @@ export async function reconcileMigrationChecksum(
     console.log(chalk.dim(`   (Could not reconcile checksum: ${String(error)})`));
   } finally {
     // Best-effort disconnect — may already be disconnected
-    await disconnectPrisma().catch(() => undefined);
+    await dispose?.().catch(() => undefined);
   }
 }
 

--- a/packages/tooling/src/db/fix-migration-drift.test.ts
+++ b/packages/tooling/src/db/fix-migration-drift.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
-import { getPrismaClient, disconnectPrisma } from '@tzurot/common-types';
+import { createPrismaClient } from '@tzurot/common-types';
+
+const mockDispose = vi.fn();
 
 // Mock common-types
 vi.mock('@tzurot/common-types', () => ({
-  getPrismaClient: vi.fn(),
-  disconnectPrisma: vi.fn(),
+  createPrismaClient: vi.fn(),
+  DB_POOL_DEFAULTS: { TRANSIENT_MAX: 5 },
 }));
 
 // Mock chalk
@@ -47,8 +49,9 @@ describe('fixMigrationDrift', () => {
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     mockExecuteRaw = vi.fn();
-    vi.mocked(getPrismaClient).mockReturnValue({
-      $executeRaw: mockExecuteRaw,
+    vi.mocked(createPrismaClient).mockReturnValue({
+      prisma: { $executeRaw: mockExecuteRaw },
+      dispose: mockDispose,
     } as never);
   });
 
@@ -79,7 +82,7 @@ describe('fixMigrationDrift', () => {
     await fixMigrationDrift(['test_migration']);
 
     expect(mockExecuteRaw).toHaveBeenCalled();
-    expect(disconnectPrisma).toHaveBeenCalled();
+    expect(mockDispose).toHaveBeenCalled();
 
     const output = consoleLogSpy.mock.calls.flat().join(' ');
     expect(output).toContain('Updated successfully');

--- a/packages/tooling/src/db/fix-migration-drift.ts
+++ b/packages/tooling/src/db/fix-migration-drift.ts
@@ -9,7 +9,7 @@ import fs from 'node:fs';
 import crypto from 'node:crypto';
 import path from 'node:path';
 import chalk from 'chalk';
-import { getPrismaClient, disconnectPrisma } from '@tzurot/common-types';
+import { createPrismaClient, DB_POOL_DEFAULTS } from '@tzurot/common-types';
 import {
   type Environment,
   validateEnvironment,
@@ -42,7 +42,7 @@ export async function fixMigrationDrift(
   validateEnvironment(env);
   showEnvironmentBanner(env);
 
-  const prisma = getPrismaClient();
+  const { prisma, dispose } = createPrismaClient({ max: DB_POOL_DEFAULTS.TRANSIENT_MAX });
   // Default to prisma/migrations relative to cwd (monorepo root)
   const migrationsDir = options.migrationsPath ?? path.join(process.cwd(), 'prisma', 'migrations');
 
@@ -93,6 +93,6 @@ export async function fixMigrationDrift(
 
     console.log(chalk.green('Done!') + ' Run `npx prisma migrate status` to verify.');
   } finally {
-    await disconnectPrisma();
+    await dispose();
   }
 }

--- a/packages/tooling/src/db/inspect-database.test.ts
+++ b/packages/tooling/src/db/inspect-database.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { getPrismaClient, disconnectPrisma } from '@tzurot/common-types';
+import { createPrismaClient } from '@tzurot/common-types';
+
+const mockDispose = vi.fn();
 
 // Mock common-types before importing
 vi.mock('@tzurot/common-types', () => ({
-  getPrismaClient: vi.fn(),
-  disconnectPrisma: vi.fn(),
+  createPrismaClient: vi.fn(),
+  DB_POOL_DEFAULTS: { TRANSIENT_MAX: 5 },
 }));
 
 // Mock chalk to simplify output testing
@@ -60,8 +62,9 @@ describe('getDatabaseHost', () => {
     const { inspectDatabase } = await import('./inspect-database.js');
 
     // Mock Prisma for the call
-    vi.mocked(getPrismaClient).mockReturnValue({
-      $queryRaw: vi.fn().mockResolvedValue([]),
+    vi.mocked(createPrismaClient).mockReturnValue({
+      prisma: { $queryRaw: vi.fn().mockResolvedValue([]) },
+      dispose: mockDispose,
     } as never);
 
     await inspectDatabase({ indexes: true });
@@ -81,8 +84,9 @@ describe('inspectDatabase', () => {
     vi.clearAllMocks();
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     mockQueryRaw = vi.fn();
-    vi.mocked(getPrismaClient).mockReturnValue({
-      $queryRaw: mockQueryRaw,
+    vi.mocked(createPrismaClient).mockReturnValue({
+      prisma: { $queryRaw: mockQueryRaw },
+      dispose: mockDispose,
     } as never);
   });
 
@@ -102,7 +106,7 @@ describe('inspectDatabase', () => {
     await inspectDatabase({ table: 'users' });
 
     expect(mockQueryRaw).toHaveBeenCalled();
-    expect(disconnectPrisma).toHaveBeenCalled();
+    expect(mockDispose).toHaveBeenCalled();
   });
 
   it('should exit with code 1 when table not found', async () => {
@@ -155,7 +159,7 @@ describe('inspectDatabase', () => {
 
     // Should have made multiple queries
     expect(mockQueryRaw).toHaveBeenCalledTimes(4);
-    expect(disconnectPrisma).toHaveBeenCalled();
+    expect(mockDispose).toHaveBeenCalled();
   });
 
   it('should report failed migrations', async () => {

--- a/packages/tooling/src/db/inspect-database.ts
+++ b/packages/tooling/src/db/inspect-database.ts
@@ -9,7 +9,7 @@
  */
 
 import chalk from 'chalk';
-import { getPrismaClient, disconnectPrisma } from '@tzurot/common-types';
+import { createPrismaClient, DB_POOL_DEFAULTS } from '@tzurot/common-types';
 import {
   type Environment,
   validateEnvironment,
@@ -79,7 +79,7 @@ interface MigrationRow {
   applied_steps_count: number;
 }
 
-type PrismaClient = ReturnType<typeof getPrismaClient>;
+type PrismaClient = ReturnType<typeof createPrismaClient>['prisma'];
 
 async function inspectIndexes(prisma: PrismaClient): Promise<void> {
   console.log(chalk.bold('\n📊 DATABASE INDEXES'));
@@ -252,7 +252,7 @@ export async function inspectDatabase(options: InspectOptions = {}): Promise<voi
     process.env.DATABASE_URL = databaseUrl;
   }
 
-  const prisma = getPrismaClient();
+  const { prisma, dispose } = createPrismaClient({ max: DB_POOL_DEFAULTS.TRANSIENT_MAX });
 
   console.log(chalk.bold('🔍 DATABASE INSPECTOR'));
   console.log('═'.repeat(70));
@@ -276,6 +276,6 @@ export async function inspectDatabase(options: InspectOptions = {}): Promise<voi
     console.log(chalk.dim('   pnpm ops db:inspect --indexes       Show only indexes'));
     console.log('');
   } finally {
-    await disconnectPrisma();
+    await dispose();
   }
 }

--- a/packages/tooling/src/db/migration-status.test.ts
+++ b/packages/tooling/src/db/migration-status.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
-import { getPrismaClient, disconnectPrisma } from '@tzurot/common-types';
+import { createPrismaClient } from '@tzurot/common-types';
+
+const mockDispose = vi.fn();
 
 // Mock common-types
 vi.mock('@tzurot/common-types', () => ({
-  getPrismaClient: vi.fn(),
-  disconnectPrisma: vi.fn(),
+  createPrismaClient: vi.fn(),
+  DB_POOL_DEFAULTS: { TRANSIENT_MAX: 5 },
 }));
 
 // Mock chalk
@@ -49,8 +51,9 @@ describe('getMigrationStatus', () => {
     vi.clearAllMocks();
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     mockQueryRaw = vi.fn();
-    vi.mocked(getPrismaClient).mockReturnValue({
-      $queryRaw: mockQueryRaw,
+    vi.mocked(createPrismaClient).mockReturnValue({
+      prisma: { $queryRaw: mockQueryRaw },
+      dispose: mockDispose,
     } as never);
   });
 
@@ -86,7 +89,7 @@ describe('getMigrationStatus', () => {
     await getMigrationStatus({ env: 'local' });
 
     expect(mockQueryRaw).toHaveBeenCalled();
-    expect(disconnectPrisma).toHaveBeenCalled();
+    expect(mockDispose).toHaveBeenCalled();
   });
 
   it('should use runPrismaCommand for dev environment', async () => {

--- a/packages/tooling/src/db/migration-status.ts
+++ b/packages/tooling/src/db/migration-status.ts
@@ -10,7 +10,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import chalk from 'chalk';
-import { getPrismaClient, disconnectPrisma } from '@tzurot/common-types';
+import { createPrismaClient, DB_POOL_DEFAULTS } from '@tzurot/common-types';
 import {
   type Environment,
   validateEnvironment,
@@ -53,7 +53,7 @@ function getLocalMigrations(migrationsPath: string): string[] {
  * Show migration status using direct database query (for local env)
  */
 async function showStatusDirect(migrationsPath: string): Promise<void> {
-  const prisma = getPrismaClient();
+  const { prisma, dispose } = createPrismaClient({ max: DB_POOL_DEFAULTS.TRANSIENT_MAX });
 
   try {
     // Get migrations from database
@@ -117,7 +117,7 @@ async function showStatusDirect(migrationsPath: string): Promise<void> {
 
     console.log('\n' + '═'.repeat(60));
   } finally {
-    await disconnectPrisma();
+    await dispose();
   }
 }
 

--- a/packages/tooling/src/inspect/tts-configs.test.ts
+++ b/packages/tooling/src/inspect/tts-configs.test.ts
@@ -48,10 +48,10 @@ describe('buildInspectorScript', () => {
     expect(buildInspectorScript(100)).not.toBe(buildInspectorScript(200));
   });
 
-  it('imports the prisma helpers from common-types', () => {
+  it('imports the prisma factory from common-types', () => {
     const script = buildInspectorScript(200);
     expect(script).toContain(
-      "import { getPrismaClient, disconnectPrisma } from '@tzurot/common-types';"
+      "import { createPrismaClient, DB_POOL_DEFAULTS } from '@tzurot/common-types';"
     );
   });
 

--- a/packages/tooling/src/inspect/tts-configs.ts
+++ b/packages/tooling/src/inspect/tts-configs.ts
@@ -77,10 +77,10 @@ export async function inspectTtsConfigs(options: InspectTtsConfigsOptions): Prom
  */
 export function buildInspectorScript(takeLimit: number): string {
   return `
-import { getPrismaClient, disconnectPrisma } from '@tzurot/common-types';
+import { createPrismaClient, DB_POOL_DEFAULTS } from '@tzurot/common-types';
 
 async function main() {
-  const prisma = getPrismaClient();
+  const { prisma, dispose } = createPrismaClient({ max: DB_POOL_DEFAULTS.TRANSIENT_MAX });
   try {
     const rows = await prisma.ttsConfig.findMany({
       select: { id: true, ownerId: true, name: true, isGlobal: true, provider: true },
@@ -98,7 +98,7 @@ async function main() {
       console.warn('⚠️  Result may be truncated at the ' + ${takeLimit} + '-row take limit — re-run with a higher limit if you need to see all rows');
     }
   } finally {
-    await disconnectPrisma();
+    await dispose();
   }
 }
 

--- a/packages/tooling/src/voice/audit-references.ts
+++ b/packages/tooling/src/voice/audit-references.ts
@@ -23,7 +23,7 @@ import { writeFile, unlink, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import chalk from 'chalk';
-import { getPrismaClient, disconnectPrisma } from '@tzurot/common-types';
+import { createPrismaClient, DB_POOL_DEFAULTS } from '@tzurot/common-types';
 import {
   type Environment,
   validateEnvironment,
@@ -183,7 +183,7 @@ export async function auditReferences(options: AuditReferencesOptions = {}): Pro
     process.env.DATABASE_URL = databaseUrl;
   }
 
-  const prisma = getPrismaClient();
+  const { prisma, dispose } = createPrismaClient({ max: DB_POOL_DEFAULTS.TRANSIENT_MAX });
   const tmpDir = await mkdtemp(join(tmpdir(), 'voice-refs-audit-'));
   try {
     const rawRows = await prisma.personality.findMany({
@@ -253,7 +253,7 @@ export async function auditReferences(options: AuditReferencesOptions = {}): Pro
       }
     }
   } finally {
-    await disconnectPrisma();
+    await dispose();
     // rm with recursive+force handles the case where any per-probe unlink
     // silently failed and left a file behind (rmdir would fail in that case).
     await rm(tmpDir, { recursive: true, force: true }).catch(() => {


### PR DESCRIPTION
## What

Part of **PR-2p-1b** (evicting the `getPrismaClient` singleton from `@tzurot/common-types`). The 7 tooling **db / inspect / audit** commands each constructed the shared singleton and called `disconnectPrisma`. They now build their own short-lived client via `createPrismaClient({ max: DB_POOL_DEFAULTS.TRANSIENT_MAX })` and dispose it.

**`disconnectPrisma` is deleted** — it was tooling-only, so once the commands migrated it became dead. Its paired `getPrismaClient` **survives** until ai-worker migrates (the next slice, 2p-1b-ii).

## Changes

- **6 db/inspect commands** — in-place `getPrismaClient`→`createPrismaClient`, `disconnectPrisma`→`dispose`. `inspect-database`'s `type PrismaClient = ReturnType<typeof getPrismaClient>` retargets to the factory's `prisma`.
- **`create-safe-migration`** — `dispose` hoisted above the `try` (the destructured local was out of scope in the `finally` — a real bug the swap exposed), keeping a construction failure on the non-fatal "could not reconcile" path.
- **`tts-configs`** — the generated inspector-script *template string* imports the factory.
- **Command test mocks** updated: `createPrismaClient` → `{ prisma, dispose }`, assert `dispose` (not `disconnectPrisma`) called.
- The deprecated singleton drops its now-orphaned pool-stats stop-handle (it never disposes, so long-running-app behavior is unchanged).

## Verification

- `pnpm --filter @tzurot/tooling test` — **1094 green**.
- `pnpm quality` — green (typecheck, knip — `disconnectPrisma` gone with no dead export, `getPrismaClient` still live via ai-worker; cpd, depcruise, lint).

## Next

**2p-1b-ii** threads an app-owned client through ai-worker's job pipeline (the ~7 deep sites that re-fetch the singleton) and **deletes `getPrismaClient`** — a focused generation-path PR, fully mapped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)