### PR TITLE
refactor(common-types): extract @tzurot/conversation-history package (PR-2p-3b)

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -26,6 +26,14 @@ module.exports = {
       to: { path: '(^|/)@tzurot/identity|^packages/identity/' },
     },
     {
+      name: 'bot-client-no-conversation-history',
+      comment:
+        'bot-client must NEVER import @tzurot/conversation-history — it is Prisma-backed (conversation persistence); use gateway APIs. The ConversationMessage data shapes + conversationSyncDiff util stay in @tzurot/common-types for bot-client.',
+      severity: 'error',
+      from: { path: '^services/bot-client/' },
+      to: { path: '(^|/)@tzurot/conversation-history|^packages/conversation-history/' },
+    },
+    {
       name: 'no-prod-import-test-factories',
       comment:
         '@tzurot/test-factories is a test-fixture package — production code must never import it',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -428,7 +428,7 @@ export default tseslint.config(
       'services/bot-client/src/index.ts', // Entrypoint/composition root
       'services/bot-client/src/utils/dashboard/SessionManager.ts', // Exemplary single-class design
       'services/bot-client/src/utils/GatewayClient.ts', // Clean API wrapper, all methods share context
-      'packages/common-types/src/services/ConversationHistoryService.ts', // Single-class CRUD/query service; retention/sync/mapping already split out
+      'packages/conversation-history/src/ConversationHistoryService.ts', // Single-class CRUD/query service; retention/sync/mapping already split out
     ],
     rules: {
       'max-lines': ['error', { max: 600, skipBlankLines: true, skipComments: true }],

--- a/knip.json
+++ b/knip.json
@@ -33,6 +33,9 @@
     "packages/identity": {
       "entry": ["src/**/*.test.ts", "src/**/*.int.test.ts"]
     },
+    "packages/conversation-history": {
+      "entry": ["src/**/*.test.ts", "src/**/*.int.test.ts"]
+    },
     "packages/tooling": {
       "entry": ["src/**/*.test.ts"],
       "ignoreDependencies": ["eslint"]

--- a/packages/common-types/src/index.ts
+++ b/packages/common-types/src/index.ts
@@ -9,6 +9,7 @@ export * from './types/ai.js';
 export * from './types/audio-provider.js';
 export * from './types/configResolution.js';
 export * from './types/personaResolution.js';
+export * from './types/conversationMessage.js';
 export * from './types/sttProvider.js';
 export * from './types/diagnostic.js';
 export * from './types/incognito.js';
@@ -96,9 +97,13 @@ export * from './services/TtsConfigCacheInvalidationService.js';
 export * from './services/SttResolverCacheInvalidationService.js';
 export * from './services/tts/TtsProvider.js';
 export * from './services/tts/TtsProviderError.js';
-export * from './services/ConversationHistoryService.js';
+// Prisma-backed conversation persistence (ConversationHistoryService,
+// ConversationSyncService, ConversationMessageMapper, referenceImageDescriptions)
+// lives in `@tzurot/conversation-history`. The data SHAPES it produces
+// (ConversationMessage / CrossChannelHistoryGroup) stay here in
+// types/conversationMessage.ts, and the PURE sync-diff util stays too — both are
+// consumed by bot-client, which can't depend on the Prisma-backed package.
 export * from './services/historyCutoff.js';
-export * from './services/ConversationSyncService.js';
 export * from './services/conversationSyncDiff.js';
 export * from './utils/historyMerger.js';
 export * from './utils/extendedContextPersonaResolver.js';

--- a/packages/common-types/src/structure.test.ts
+++ b/packages/common-types/src/structure.test.ts
@@ -189,6 +189,7 @@ describe('Project Structure', () => {
       'packages/common-types/src',
       'packages/config-resolver/src',
       'packages/identity/src',
+      'packages/conversation-history/src',
       'packages/embeddings/src',
       'packages/test-factories/src',
       'packages/test-utils/src',

--- a/packages/common-types/src/types/conversationMessage.ts
+++ b/packages/common-types/src/types/conversationMessage.ts
@@ -1,0 +1,43 @@
+/**
+ * Conversation message data shapes.
+ *
+ * These are pure domain shapes consumed across services (bot-client's
+ * DiscordChannelFetcher, ai-worker context assembly, and common-types' own
+ * history/cross-channel utils), so they live in the shared type package while
+ * the Prisma-backed mapping logic that PRODUCES them lives in
+ * `@tzurot/conversation-history` (`ConversationMessageMapper`).
+ */
+
+import type { MessageRole } from '../constants/index.js';
+import type { MessageMetadata } from './schemas/index.js';
+
+export interface ConversationMessage {
+  id: string;
+  role: MessageRole;
+  content: string;
+  tokenCount?: number; // Cached token count (computed once, reused on every request)
+  createdAt: Date;
+  personaId: string;
+  personaName?: string; // The user's persona name for display in context
+  discordUsername?: string; // Discord username for disambiguation when persona name matches personality name
+  discordMessageId: string[]; // Discord snowflake IDs for chunked messages (deduplication)
+  isForwarded?: boolean; // Whether this message was forwarded from another channel
+  messageMetadata?: MessageMetadata; // Structured metadata (referenced messages, attachments)
+  // AI personality info (for multi-AI channel attribution)
+  personalityId?: string; // The AI personality this message belongs to
+  personalityName?: string; // The AI personality's display name (for assistant messages)
+  // Channel info (always populated — used for cross-channel history grouping)
+  channelId: string; // Discord channel ID
+  guildId: string | null; // Discord guild ID (null for DMs)
+}
+
+/**
+ * A group of messages from a single channel, used for cross-channel history results.
+ * Groups are ordered by most recent activity (most recent channel first).
+ * Messages within each group are in chronological order (oldest first).
+ */
+export interface CrossChannelHistoryGroup {
+  channelId: string;
+  guildId: string | null;
+  messages: ConversationMessage[];
+}

--- a/packages/common-types/src/utils/crossChannelEnvironment.test.ts
+++ b/packages/common-types/src/utils/crossChannelEnvironment.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { MessageRole } from '../constants/index.js';
-import type { CrossChannelHistoryGroup } from '../services/ConversationMessageMapper.js';
+import type { CrossChannelHistoryGroup } from '../types/conversationMessage.js';
 import { buildFallbackEnvironment, mapCrossChannelToApiFormat } from './crossChannelEnvironment.js';
 
 describe('buildFallbackEnvironment', () => {

--- a/packages/common-types/src/utils/crossChannelEnvironment.ts
+++ b/packages/common-types/src/utils/crossChannelEnvironment.ts
@@ -13,7 +13,7 @@
  * built here when resolution fails.
  */
 
-import type { ConversationMessage } from '../services/ConversationMessageMapper.js';
+import type { ConversationMessage } from '../types/conversationMessage.js';
 import type { DiscordEnvironment } from '../types/schemas/discord.js';
 import type { CrossChannelHistoryGroupEntry } from '../types/schemas/message.js';
 

--- a/packages/common-types/src/utils/extendedContextPersonaResolver.ts
+++ b/packages/common-types/src/utils/extendedContextPersonaResolver.ts
@@ -30,7 +30,7 @@
 
 import { createLogger } from './logger.js';
 import type { PersonaResolverLike } from '../types/personaResolution.js';
-import type { ConversationMessage } from '../services/ConversationMessageMapper.js';
+import type { ConversationMessage } from '../types/conversationMessage.js';
 import type { ReactionReactor } from '../types/schemas/message.js';
 import { INTERNAL_DISCORD_ID_PREFIX } from '../constants/personaId.js';
 

--- a/packages/common-types/src/utils/historyMerger.ts
+++ b/packages/common-types/src/utils/historyMerger.ts
@@ -7,7 +7,7 @@
 
 import { createLogger } from './logger.js';
 import { NO_TEXT_CONTENT_PLACEHOLDER } from '../constants/message.js';
-import type { ConversationMessage } from '../services/ConversationMessageMapper.js';
+import type { ConversationMessage } from '../types/conversationMessage.js';
 
 const logger = createLogger('HistoryMerger');
 

--- a/packages/conversation-history/package.json
+++ b/packages/conversation-history/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@tzurot/conversation-history",
+  "version": "3.0.0-beta.135",
+  "private": true,
+  "type": "module",
+  "description": "Prisma-backed conversation persistence: history retrieval, channel sync, and reference-image-description writes",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "clean": "find src -name '*.js' -type f -delete && find src -name '*.js.map' -type f -delete",
+    "build": "tsc",
+    "pretest": "npm run clean",
+    "test": "vitest",
+    "test:watch": "vitest --watch",
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint src --max-warnings=0",
+    "lint:fix": "eslint src --fix",
+    "format": "prettier --write .",
+    "typecheck": "tsc --noEmit",
+    "typecheck:spec": "tsc --noEmit --project tsconfig.spec.json"
+  },
+  "dependencies": {
+    "@tzurot/common-types": "workspace:*"
+  },
+  "devDependencies": {
+    "@tzurot/test-utils": "workspace:*",
+    "@types/node": "^25.9.3"
+  }
+}

--- a/packages/conversation-history/src/ConversationHistoryService.int.test.ts
+++ b/packages/conversation-history/src/ConversationHistoryService.int.test.ts
@@ -11,12 +11,11 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
-import { PrismaClient } from './prisma.js';
 import type { PGlite } from '@electric-sql/pglite';
 import { PrismaPGlite } from 'pglite-prisma-adapter';
 import { createTestPGlite, loadPGliteSchema, seedUserWithPersona } from '@tzurot/test-utils';
 import { ConversationHistoryService } from './ConversationHistoryService.js';
-import { MessageRole } from '../constants/index.js';
+import { PrismaClient, MessageRole } from '@tzurot/common-types';
 
 describe('ConversationHistoryService Component Test', () => {
   let prisma: PrismaClient;

--- a/packages/conversation-history/src/ConversationHistoryService.test.ts
+++ b/packages/conversation-history/src/ConversationHistoryService.test.ts
@@ -3,10 +3,17 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { PrismaClient } from './prisma.js';
 import { ConversationHistoryService } from './ConversationHistoryService.js';
-import { MessageRole } from '../constants/index.js';
-import * as tokenCounter from '../utils/tokenCounter.js';
+import { MessageRole, type PrismaClient } from '@tzurot/common-types';
+
+// countTextTokens now lives in @tzurot/common-types (consumed by the production
+// service via the barrel), so intercept it through a partial mock rather than a
+// namespace spy — the latter doesn't reliably catch a re-exported binding.
+const { mockCountTextTokens } = vi.hoisted(() => ({ mockCountTextTokens: vi.fn() }));
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return { ...actual, countTextTokens: mockCountTextTokens };
+});
 
 // Create mock Prisma client
 const createMockPrismaClient = () => {
@@ -39,8 +46,6 @@ describe('ConversationHistoryService - Token Count Caching', () => {
     // Create fresh mocks for each test
     mockPrismaClient = createMockPrismaClient();
     service = new ConversationHistoryService(mockPrismaClient as unknown as PrismaClient);
-    // Create fresh spy for each test
-    vi.spyOn(tokenCounter, 'countTextTokens');
   });
 
   describe('addMessage - Token Count Computation', () => {
@@ -49,7 +54,7 @@ describe('ConversationHistoryService - Token Count Caching', () => {
       const expectedTokenCount = 8; // Mocked value
 
       // Mock token counter to return predictable value
-      (tokenCounter.countTextTokens as any).mockReturnValue(expectedTokenCount);
+      mockCountTextTokens.mockReturnValue(expectedTokenCount);
 
       mockPrismaClient.conversationHistory.create.mockResolvedValue({
         id: 'msg-123',
@@ -68,7 +73,7 @@ describe('ConversationHistoryService - Token Count Caching', () => {
       });
 
       // Verify token counter was called
-      expect(tokenCounter.countTextTokens).toHaveBeenCalledWith(content);
+      expect(mockCountTextTokens).toHaveBeenCalledWith(content);
 
       // Verify token count was stored in database
       expect(mockPrismaClient.conversationHistory.create).toHaveBeenCalledWith({
@@ -83,7 +88,7 @@ describe('ConversationHistoryService - Token Count Caching', () => {
       const content = 'This is an AI response with more tokens than the user message!';
       const expectedTokenCount = 15;
 
-      (tokenCounter.countTextTokens as any).mockReturnValue(expectedTokenCount);
+      mockCountTextTokens.mockReturnValue(expectedTokenCount);
 
       mockPrismaClient.conversationHistory.create.mockResolvedValue({
         id: 'msg-456',
@@ -101,7 +106,7 @@ describe('ConversationHistoryService - Token Count Caching', () => {
         discordMessageId: ['discord-msg-1', 'discord-msg-2'], // Chunked message
       });
 
-      expect(tokenCounter.countTextTokens).toHaveBeenCalledWith(content);
+      expect(mockCountTextTokens).toHaveBeenCalledWith(content);
       expect(mockPrismaClient.conversationHistory.create).toHaveBeenCalledWith({
         data: expect.objectContaining({
           content,
@@ -114,7 +119,7 @@ describe('ConversationHistoryService - Token Count Caching', () => {
       const longContent = 'A'.repeat(10000); // Very long message
       const expectedTokenCount = 2500; // Approximate tokens
 
-      (tokenCounter.countTextTokens as any).mockReturnValue(expectedTokenCount);
+      mockCountTextTokens.mockReturnValue(expectedTokenCount);
 
       mockPrismaClient.conversationHistory.create.mockResolvedValue({
         id: 'msg-long',
@@ -131,7 +136,7 @@ describe('ConversationHistoryService - Token Count Caching', () => {
         guildId: null,
       });
 
-      expect(tokenCounter.countTextTokens).toHaveBeenCalledWith(longContent);
+      expect(mockCountTextTokens).toHaveBeenCalledWith(longContent);
       expect(mockPrismaClient.conversationHistory.create).toHaveBeenCalledWith({
         data: expect.objectContaining({
           tokenCount: expectedTokenCount,
@@ -143,7 +148,7 @@ describe('ConversationHistoryService - Token Count Caching', () => {
       const content = '';
       const expectedTokenCount = 0;
 
-      (tokenCounter.countTextTokens as any).mockReturnValue(expectedTokenCount);
+      mockCountTextTokens.mockReturnValue(expectedTokenCount);
 
       mockPrismaClient.conversationHistory.create.mockResolvedValue({
         id: 'msg-empty',
@@ -160,7 +165,7 @@ describe('ConversationHistoryService - Token Count Caching', () => {
         guildId: null,
       });
 
-      expect(tokenCounter.countTextTokens).toHaveBeenCalledWith(content);
+      expect(mockCountTextTokens).toHaveBeenCalledWith(content);
       expect(mockPrismaClient.conversationHistory.create).toHaveBeenCalledWith({
         data: expect.objectContaining({
           tokenCount: 0,
@@ -426,7 +431,7 @@ describe('ConversationHistoryService - Token Count Caching', () => {
         discordMessageId: ['discord-123'],
       });
 
-      (tokenCounter.countTextTokens as any).mockReturnValue(enrichedTokenCount);
+      mockCountTextTokens.mockReturnValue(enrichedTokenCount);
 
       mockPrismaClient.conversationHistory.update.mockResolvedValue({
         id: 'msg-123',
@@ -442,7 +447,7 @@ describe('ConversationHistoryService - Token Count Caching', () => {
       );
 
       expect(result).toBe(true);
-      expect(tokenCounter.countTextTokens).toHaveBeenCalledWith(enrichedContent);
+      expect(mockCountTextTokens).toHaveBeenCalledWith(enrichedContent);
       expect(mockPrismaClient.conversationHistory.update).toHaveBeenCalledWith({
         where: { id: 'msg-123' },
         data: {
@@ -464,7 +469,7 @@ describe('ConversationHistoryService - Token Count Caching', () => {
         tokenCount: 4,
       });
 
-      (tokenCounter.countTextTokens as any).mockReturnValue(largeTokenCount);
+      mockCountTextTokens.mockReturnValue(largeTokenCount);
 
       mockPrismaClient.conversationHistory.update.mockResolvedValue({
         id: 'msg-456',
@@ -479,7 +484,7 @@ describe('ConversationHistoryService - Token Count Caching', () => {
         enrichedContent
       );
 
-      expect(tokenCounter.countTextTokens).toHaveBeenCalledWith(enrichedContent);
+      expect(mockCountTextTokens).toHaveBeenCalledWith(enrichedContent);
       expect(mockPrismaClient.conversationHistory.update).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({
@@ -501,7 +506,7 @@ describe('ConversationHistoryService - Token Count Caching', () => {
           embedsXml: ['<embed>keep me</embed>'],
         },
       });
-      (tokenCounter.countTextTokens as any).mockReturnValue(9);
+      mockCountTextTokens.mockReturnValue(9);
       mockPrismaClient.conversationHistory.update.mockResolvedValue({});
 
       await service.updateLastUserMessage('channel-123', 'personality-456', 'persona-789', 'new', {
@@ -714,10 +719,7 @@ describe('ConversationHistoryService - Token Count Caching', () => {
       const content2 = 'Second message';
       const content3 = 'Third message';
 
-      (tokenCounter.countTextTokens as any)
-        .mockReturnValueOnce(3)
-        .mockReturnValueOnce(3)
-        .mockReturnValueOnce(3);
+      mockCountTextTokens.mockReturnValueOnce(3).mockReturnValueOnce(3).mockReturnValueOnce(3);
 
       mockPrismaClient.conversationHistory.create.mockResolvedValue({
         id: 'msg-123',
@@ -750,10 +752,10 @@ describe('ConversationHistoryService - Token Count Caching', () => {
       });
 
       // Verify token counter was called exactly 3 times (once per message)
-      expect(tokenCounter.countTextTokens).toHaveBeenCalledTimes(3);
-      expect(tokenCounter.countTextTokens).toHaveBeenNthCalledWith(1, content1);
-      expect(tokenCounter.countTextTokens).toHaveBeenNthCalledWith(2, content2);
-      expect(tokenCounter.countTextTokens).toHaveBeenNthCalledWith(3, content3);
+      expect(mockCountTextTokens).toHaveBeenCalledTimes(3);
+      expect(mockCountTextTokens).toHaveBeenNthCalledWith(1, content1);
+      expect(mockCountTextTokens).toHaveBeenNthCalledWith(2, content2);
+      expect(mockCountTextTokens).toHaveBeenNthCalledWith(3, content3);
     });
 
     it('should NOT call countTextTokens when retrieving messages', async () => {
@@ -781,7 +783,7 @@ describe('ConversationHistoryService - Token Count Caching', () => {
       await service.getChannelHistory('channel-123', 20);
 
       // Token counter should NOT be called during retrieval
-      expect(tokenCounter.countTextTokens).not.toHaveBeenCalled();
+      expect(mockCountTextTokens).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/conversation-history/src/ConversationHistoryService.ts
+++ b/packages/conversation-history/src/ConversationHistoryService.ts
@@ -8,25 +8,24 @@
  * - ConversationMessageMapper: Data transformation
  */
 
-import type { PrismaClient } from './prisma.js';
-import { createLogger } from '../utils/logger.js';
-import { MessageRole } from '../constants/index.js';
-import { countTextTokens } from '../utils/tokenCounter.js';
-import type { MessageMetadata } from '../types/schemas/index.js';
+import {
+  createLogger,
+  MessageRole,
+  countTextTokens,
+  generateConversationHistoryUuid,
+  computeHistoryCutoff,
+  type PrismaClient,
+  type MessageMetadata,
+  type ConversationMessage,
+  type CrossChannelHistoryGroup,
+} from '@tzurot/common-types';
 import {
   conversationHistorySelect,
   conversationRecencyOrderBy,
   mapToConversationMessage,
   mapToConversationMessages,
-  type ConversationMessage,
-  type CrossChannelHistoryGroup,
 } from './ConversationMessageMapper.js';
-import { generateConversationHistoryUuid } from '../utils/deterministicUuid.js';
-import { computeHistoryCutoff } from './historyCutoff.js';
 import { writeReferenceImageDescriptions } from './referenceImageDescriptions.js';
-
-// Re-export types for consumers that import from this module
-export type { ConversationMessage, CrossChannelHistoryGroup } from './ConversationMessageMapper.js';
 
 const logger = createLogger('ConversationHistoryService');
 

--- a/packages/conversation-history/src/ConversationMessageMapper.test.ts
+++ b/packages/conversation-history/src/ConversationMessageMapper.test.ts
@@ -6,17 +6,21 @@ import {
   conversationHistorySelect,
   type ConversationHistoryQueryResult,
 } from './ConversationMessageMapper.js';
-import { MessageRole } from '../constants/index.js';
+import { MessageRole } from '@tzurot/common-types';
 
-// Suppress logger warnings in tests
-vi.mock('../utils/logger.js', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
+// Suppress logger warnings in tests (createLogger now comes from the barrel)
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
 
 describe('ConversationMessageMapper', () => {
   describe('conversationHistorySelect', () => {

--- a/packages/conversation-history/src/ConversationMessageMapper.ts
+++ b/packages/conversation-history/src/ConversationMessageMapper.ts
@@ -6,43 +6,16 @@
  * of select objects and mapping logic used in 3+ query methods.
  */
 
-import { Prisma } from './prisma.js';
-import { createLogger } from '../utils/logger.js';
-import { MessageRole } from '../constants/index.js';
-import { messageMetadataSchema, type MessageMetadata } from '../types/schemas/index.js';
+import {
+  Prisma,
+  createLogger,
+  MessageRole,
+  messageMetadataSchema,
+  type MessageMetadata,
+  type ConversationMessage,
+} from '@tzurot/common-types';
 
 const logger = createLogger('ConversationMessageMapper');
-
-export interface ConversationMessage {
-  id: string;
-  role: MessageRole;
-  content: string;
-  tokenCount?: number; // Cached token count (computed once, reused on every request)
-  createdAt: Date;
-  personaId: string;
-  personaName?: string; // The user's persona name for display in context
-  discordUsername?: string; // Discord username for disambiguation when persona name matches personality name
-  discordMessageId: string[]; // Discord snowflake IDs for chunked messages (deduplication)
-  isForwarded?: boolean; // Whether this message was forwarded from another channel
-  messageMetadata?: MessageMetadata; // Structured metadata (referenced messages, attachments)
-  // AI personality info (for multi-AI channel attribution)
-  personalityId?: string; // The AI personality this message belongs to
-  personalityName?: string; // The AI personality's display name (for assistant messages)
-  // Channel info (always populated — used for cross-channel history grouping)
-  channelId: string; // Discord channel ID
-  guildId: string | null; // Discord guild ID (null for DMs)
-}
-
-/**
- * A group of messages from a single channel, used for cross-channel history results.
- * Groups are ordered by most recent activity (most recent channel first).
- * Messages within each group are in chronological order (oldest first).
- */
-export interface CrossChannelHistoryGroup {
-  channelId: string;
-  guildId: string | null;
-  messages: ConversationMessage[];
-}
 
 /**
  * Prisma select object for conversation history queries

--- a/packages/conversation-history/src/ConversationSyncService.int.test.ts
+++ b/packages/conversation-history/src/ConversationSyncService.int.test.ts
@@ -10,13 +10,12 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
-import { PrismaClient } from './prisma.js';
 import type { PGlite } from '@electric-sql/pglite';
 import { PrismaPGlite } from 'pglite-prisma-adapter';
 import { createTestPGlite, loadPGliteSchema, seedUserWithPersona } from '@tzurot/test-utils';
 import { ConversationSyncService } from './ConversationSyncService.js';
 import { ConversationHistoryService } from './ConversationHistoryService.js';
-import { MessageRole } from '../constants/index.js';
+import { PrismaClient, MessageRole } from '@tzurot/common-types';
 
 describe('ConversationSyncService Integration Test', () => {
   let prisma: PrismaClient;

--- a/packages/conversation-history/src/ConversationSyncService.test.ts
+++ b/packages/conversation-history/src/ConversationSyncService.test.ts
@@ -3,9 +3,17 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { PrismaClient } from './prisma.js';
 import { ConversationSyncService } from './ConversationSyncService.js';
-import * as tokenCounter from '../utils/tokenCounter.js';
+import { type PrismaClient } from '@tzurot/common-types';
+
+// countTextTokens now lives in @tzurot/common-types (consumed by the production
+// service via the barrel), so intercept it through a partial mock rather than a
+// namespace spy — the latter doesn't reliably catch a re-exported binding.
+const { mockCountTextTokens } = vi.hoisted(() => ({ mockCountTextTokens: vi.fn() }));
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return { ...actual, countTextTokens: mockCountTextTokens };
+});
 
 // Create mock Prisma client
 const createMockPrismaClient = () => {
@@ -31,11 +39,12 @@ describe('ConversationSyncService', () => {
   let mockPrismaClient: ReturnType<typeof createMockPrismaClient>;
 
   beforeEach(() => {
+    // Clear mock call history / return values between tests (matches the
+    // ConversationHistoryService test; mockCountTextTokens is hoisted module-wide)
+    vi.clearAllMocks();
     // Create fresh mocks for each test
     mockPrismaClient = createMockPrismaClient();
     service = new ConversationSyncService(mockPrismaClient as unknown as PrismaClient);
-    // Create fresh spy for each test
-    vi.spyOn(tokenCounter, 'countTextTokens');
   });
 
   describe('softDeleteMessage', () => {
@@ -122,7 +131,7 @@ describe('ConversationSyncService', () => {
       const newContent = 'Updated content from Discord';
       const expectedTokens = 5;
 
-      (tokenCounter.countTextTokens as ReturnType<typeof vi.fn>).mockReturnValue(expectedTokens);
+      mockCountTextTokens.mockReturnValue(expectedTokens);
       mockPrismaClient.conversationHistory.update.mockResolvedValue({
         id: 'msg-123',
         content: newContent,
@@ -132,7 +141,7 @@ describe('ConversationSyncService', () => {
       const result = await service.updateMessageContent('msg-123', newContent);
 
       expect(result).toBe(true);
-      expect(tokenCounter.countTextTokens).toHaveBeenCalledWith(newContent);
+      expect(mockCountTextTokens).toHaveBeenCalledWith(newContent);
       expect(mockPrismaClient.conversationHistory.update).toHaveBeenCalledWith({
         where: { id: 'msg-123' },
         data: {

--- a/packages/conversation-history/src/ConversationSyncService.ts
+++ b/packages/conversation-history/src/ConversationSyncService.ts
@@ -9,16 +9,16 @@
  * Uses tombstones to prevent db-sync from restoring deleted messages.
  */
 
-import type { PrismaClient } from './prisma.js';
-import { createLogger } from '../utils/logger.js';
-import { countTextTokens } from '../utils/tokenCounter.js';
-import { SYNC_LIMITS } from '../constants/index.js';
 import {
+  createLogger,
+  countTextTokens,
+  SYNC_LIMITS,
   collateChunksForSync,
   contentsDiffer,
   getOldestObservedTimestamp,
+  type PrismaClient,
   type ObservedSyncMessage,
-} from './conversationSyncDiff.js';
+} from '@tzurot/common-types';
 
 const logger = createLogger('ConversationSyncService');
 

--- a/packages/conversation-history/src/index.ts
+++ b/packages/conversation-history/src/index.ts
@@ -1,0 +1,21 @@
+/**
+ * @tzurot/conversation-history
+ *
+ * Prisma-backed conversation persistence, extracted from `@tzurot/common-types`
+ * so the shared type package stays types/schemas/utils:
+ *   - `ConversationHistoryService` — channel + cross-channel history retrieval/writes
+ *   - `ConversationSyncService` — Discord-edit/delete reconciliation against the DB
+ *   - `referenceImageDescriptions` — vision-description persistence on referenced messages
+ *   - `ConversationMessageMapper` — Prisma select + row→domain mapping
+ *
+ * Per the epic's boundary principle, the LOGIC lives here; shared data SHAPES
+ * (`ConversationMessage`, `CrossChannelHistoryGroup`) stay in `@tzurot/common-types`,
+ * as does the pure `conversationSyncDiff` util (bot-client consumes it). Consumers
+ * construct these services with an injected `PrismaClient` (the apps own their
+ * client — see `createPrismaClient` in `@tzurot/common-types`).
+ */
+
+export * from './ConversationHistoryService.js';
+export * from './ConversationSyncService.js';
+export * from './ConversationMessageMapper.js';
+export * from './referenceImageDescriptions.js';

--- a/packages/conversation-history/src/referenceImageDescriptions.test.ts
+++ b/packages/conversation-history/src/referenceImageDescriptions.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { collectRefImageDescriptions } from './referenceImageDescriptions.js';
-import type { StoredReferencedMessage } from '../types/schemas/index.js';
+import type { StoredReferencedMessage } from '@tzurot/common-types';
 
 function makeRef(attachments?: StoredReferencedMessage['attachments']): StoredReferencedMessage {
   return {

--- a/packages/conversation-history/src/referenceImageDescriptions.ts
+++ b/packages/conversation-history/src/referenceImageDescriptions.ts
@@ -16,14 +16,14 @@
  * max-lines ceiling; the service exposes a thin delegating method.
  */
 
-import type { PrismaClient } from './prisma.js';
-import { createLogger } from '../utils/logger.js';
-import { MessageRole } from '../constants/index.js';
-import type {
-  MessageMetadata,
-  ResolvedImageDescription,
-  StoredReferencedMessage,
-} from '../types/schemas/index.js';
+import {
+  createLogger,
+  MessageRole,
+  type PrismaClient,
+  type MessageMetadata,
+  type ResolvedImageDescription,
+  type StoredReferencedMessage,
+} from '@tzurot/common-types';
 
 const logger = createLogger('ReferenceImageDescriptions');
 

--- a/packages/conversation-history/tsconfig.json
+++ b/packages/conversation-history/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "references": [{ "path": "../common-types" }],
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/conversation-history/tsconfig.spec.json
+++ b/packages/conversation-history/tsconfig.spec.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,19 @@ importers:
         specifier: ^10.3.1
         version: 10.3.1
 
+  packages/conversation-history:
+    dependencies:
+      '@tzurot/common-types':
+        specifier: workspace:*
+        version: link:../common-types
+    devDependencies:
+      '@types/node':
+        specifier: ^25.9.3
+        version: 25.9.3
+      '@tzurot/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+
   packages/embeddings:
     dependencies:
       '@huggingface/transformers':
@@ -386,6 +399,9 @@ importers:
       '@tzurot/config-resolver':
         specifier: workspace:*
         version: link:../../packages/config-resolver
+      '@tzurot/conversation-history':
+        specifier: workspace:*
+        version: link:../../packages/conversation-history
       '@tzurot/embeddings':
         specifier: workspace:*
         version: link:../../packages/embeddings
@@ -435,6 +451,9 @@ importers:
       '@tzurot/config-resolver':
         specifier: workspace:*
         version: link:../../packages/config-resolver
+      '@tzurot/conversation-history':
+        specifier: workspace:*
+        version: link:../../packages/conversation-history
       '@tzurot/embeddings':
         specifier: workspace:*
         version: link:../../packages/embeddings

--- a/services/ai-worker/Dockerfile
+++ b/services/ai-worker/Dockerfile
@@ -89,6 +89,7 @@ COPY --from=builder /app/node_modules/.pnpm ./node_modules/.pnpm
 COPY --from=builder /app/packages/common-types/dist ./packages/common-types/dist
 COPY --from=builder /app/packages/config-resolver/dist ./packages/config-resolver/dist
 COPY --from=builder /app/packages/identity/dist ./packages/identity/dist
+COPY --from=builder /app/packages/conversation-history/dist ./packages/conversation-history/dist
 COPY --from=builder /app/packages/embeddings/dist ./packages/embeddings/dist
 COPY --from=builder /app/services/ai-worker/dist ./services/ai-worker/dist
 

--- a/services/ai-worker/package.json
+++ b/services/ai-worker/package.json
@@ -25,6 +25,7 @@
     "@langchain/openai": "^1.4.7",
     "@tzurot/common-types": "workspace:*",
     "@tzurot/config-resolver": "workspace:*",
+    "@tzurot/conversation-history": "workspace:*",
     "@tzurot/embeddings": "workspace:*",
     "@tzurot/identity": "workspace:*",
     "bullmq": "^5.78.1",

--- a/services/ai-worker/src/jobs/handlers/LLMGenerationHandler.ts
+++ b/services/ai-worker/src/jobs/handlers/LLMGenerationHandler.ts
@@ -22,7 +22,6 @@ import { randomUUID } from 'node:crypto';
 import { ConversationalRAGService } from '../../services/ConversationalRAGService.js';
 import {
   createLogger,
-  ConversationHistoryService,
   ApiErrorCategory,
   ApiErrorType,
   USER_ERROR_MESSAGES,
@@ -30,6 +29,7 @@ import {
   type LLMGenerationResult,
   type PrismaClient,
 } from '@tzurot/common-types';
+import { ConversationHistoryService } from '@tzurot/conversation-history';
 import { PersonaResolver, UserService } from '@tzurot/identity';
 import type {
   LlmConfigResolver,

--- a/services/ai-worker/src/services/DuplicateDetectionFlow.int.test.ts
+++ b/services/ai-worker/src/services/DuplicateDetectionFlow.int.test.ts
@@ -20,13 +20,13 @@ import type { PGlite } from '@electric-sql/pglite';
 import { PrismaPGlite } from 'pglite-prisma-adapter';
 import {
   PrismaClient,
-  ConversationHistoryService,
   MessageRole,
   generatePersonalityUuid,
   generateSystemPromptUuid,
   generatePersonaUuid,
   generateUserUuid,
 } from '@tzurot/common-types';
+import { ConversationHistoryService } from '@tzurot/conversation-history';
 import { isRecentDuplicate } from '../utils/crossTurnDetection.js';
 import { getRecentAssistantMessages } from '../utils/conversationHistoryUtils.js';
 import { createTestPGlite, loadPGliteSchema, seedUserWithPersona } from '@tzurot/test-utils';

--- a/services/ai-worker/src/services/context/PrismaContextDataSource.test.ts
+++ b/services/ai-worker/src/services/context/PrismaContextDataSource.test.ts
@@ -10,13 +10,16 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   return {
     ...actual,
     createLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
-    ConversationHistoryService: class {
-      getChannelHistory = mockGetChannelHistory;
-      getCrossChannelHistory = mockGetCrossChannelHistory;
-      getMessageByDiscordId = mockGetMessageByDiscordId;
-    },
   };
 });
+
+vi.mock('@tzurot/conversation-history', () => ({
+  ConversationHistoryService: class {
+    getChannelHistory = mockGetChannelHistory;
+    getCrossChannelHistory = mockGetCrossChannelHistory;
+    getMessageByDiscordId = mockGetMessageByDiscordId;
+  },
+}));
 
 vi.mock('@tzurot/identity', () => ({
   UserService: class {

--- a/services/ai-worker/src/services/context/PrismaContextDataSource.ts
+++ b/services/ai-worker/src/services/context/PrismaContextDataSource.ts
@@ -11,11 +11,11 @@
  */
 
 import {
-  ConversationHistoryService,
   type ConversationMessage,
   type CrossChannelHistoryGroup,
   type PrismaClient,
 } from '@tzurot/common-types';
+import { ConversationHistoryService } from '@tzurot/conversation-history';
 import { UserService } from '@tzurot/identity';
 import type { ContextDataSource, CrossChannelHistoryParams } from './types.js';
 

--- a/services/ai-worker/src/services/context/visionDescriptionWriter.ts
+++ b/services/ai-worker/src/services/context/visionDescriptionWriter.ts
@@ -17,12 +17,8 @@
  * acceptable degradation the bot-side path had.
  */
 
-import {
-  createLogger,
-  AttachmentType,
-  type ConversationHistoryService,
-  type JobContext,
-} from '@tzurot/common-types';
+import { createLogger, AttachmentType, type JobContext } from '@tzurot/common-types';
+import { type ConversationHistoryService } from '@tzurot/conversation-history';
 import { buildAttachmentDescriptions } from '../RAGUtils.js';
 import type { ProcessedAttachment } from '../MultimodalProcessor.js';
 

--- a/services/ai-worker/tsconfig.json
+++ b/services/ai-worker/tsconfig.json
@@ -10,6 +10,7 @@
   "references": [
     { "path": "../../packages/common-types" },
     { "path": "../../packages/config-resolver" },
-    { "path": "../../packages/identity" }
+    { "path": "../../packages/identity" },
+    { "path": "../../packages/conversation-history" }
   ]
 }

--- a/services/api-gateway/Dockerfile
+++ b/services/api-gateway/Dockerfile
@@ -81,6 +81,7 @@ COPY --from=builder /app/node_modules/.pnpm ./node_modules/.pnpm
 COPY --from=builder /app/packages/common-types/dist ./packages/common-types/dist
 COPY --from=builder /app/packages/config-resolver/dist ./packages/config-resolver/dist
 COPY --from=builder /app/packages/identity/dist ./packages/identity/dist
+COPY --from=builder /app/packages/conversation-history/dist ./packages/conversation-history/dist
 COPY --from=builder /app/packages/embeddings/dist ./packages/embeddings/dist
 COPY --from=builder /app/services/api-gateway/dist ./services/api-gateway/dist
 

--- a/services/api-gateway/package.json
+++ b/services/api-gateway/package.json
@@ -24,6 +24,7 @@
     "@prisma/adapter-pg": "^7.8.0",
     "@tzurot/common-types": "workspace:*",
     "@tzurot/config-resolver": "workspace:*",
+    "@tzurot/conversation-history": "workspace:*",
     "@tzurot/embeddings": "workspace:*",
     "@tzurot/identity": "workspace:*",
     "bullmq": "^5.78.1",

--- a/services/api-gateway/src/routes/internal/conversationAssistantMessage.ts
+++ b/services/api-gateway/src/routes/internal/conversationAssistantMessage.ts
@@ -22,11 +22,11 @@ import { type Response, type RequestHandler } from 'express';
 import {
   createLogger,
   generateConversationHistoryUuid,
-  ConversationHistoryService,
   MessageRole,
   PersistAssistantMessageRequestSchema,
   type PersistAssistantMessageResponse,
 } from '@tzurot/common-types';
+import { ConversationHistoryService } from '@tzurot/conversation-history';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { sendZodError } from '../../utils/zodHelpers.js';

--- a/services/api-gateway/src/routes/internal/conversationSync.test.ts
+++ b/services/api-gateway/src/routes/internal/conversationSync.test.ts
@@ -9,7 +9,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import express from 'express';
 import request from 'supertest';
-import { ConversationSyncService, type PrismaClient } from '@tzurot/common-types';
+import { type PrismaClient } from '@tzurot/common-types';
+import { ConversationSyncService } from '@tzurot/conversation-history';
 import { handleSyncConversation } from './conversationSync.js';
 
 vi.mock('@tzurot/common-types', async () => {

--- a/services/api-gateway/src/routes/internal/conversationSync.ts
+++ b/services/api-gateway/src/routes/internal/conversationSync.ts
@@ -18,11 +18,8 @@
  */
 
 import { type Response, type RequestHandler } from 'express';
-import {
-  ConversationSyncService,
-  ConversationSyncRequestSchema,
-  type ConversationSyncResponse,
-} from '@tzurot/common-types';
+import { ConversationSyncRequestSchema, type ConversationSyncResponse } from '@tzurot/common-types';
+import { ConversationSyncService } from '@tzurot/conversation-history';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { sendZodError } from '../../utils/zodHelpers.js';

--- a/services/api-gateway/src/routes/internal/conversationUserMessage.ts
+++ b/services/api-gateway/src/routes/internal/conversationUserMessage.ts
@@ -22,11 +22,11 @@ import { type Response, type RequestHandler } from 'express';
 import {
   createLogger,
   generateConversationHistoryUuid,
-  ConversationHistoryService,
   MessageRole,
   PersistUserMessageRequestSchema,
   type PersistUserMessageResponse,
 } from '@tzurot/common-types';
+import { ConversationHistoryService } from '@tzurot/conversation-history';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { sendZodError } from '../../utils/zodHelpers.js';

--- a/services/api-gateway/src/routes/user/conversationLookup.test.ts
+++ b/services/api-gateway/src/routes/user/conversationLookup.test.ts
@@ -12,11 +12,6 @@ const mockGetMessageByDiscordId = vi.fn();
 vi.mock('@tzurot/common-types', async () => {
   const actual = await vi.importActual('@tzurot/common-types');
 
-  // Create a mock class that returns our mock methods
-  class MockConversationHistoryService {
-    getMessageByDiscordId = mockGetMessageByDiscordId;
-  }
-
   return {
     ...actual,
     createLogger: () => ({
@@ -25,9 +20,14 @@ vi.mock('@tzurot/common-types', async () => {
       warn: vi.fn(),
       error: vi.fn(),
     }),
-    ConversationHistoryService: MockConversationHistoryService,
   };
 });
+
+vi.mock('@tzurot/conversation-history', () => ({
+  ConversationHistoryService: class {
+    getMessageByDiscordId = mockGetMessageByDiscordId;
+  },
+}));
 
 vi.mock('../../utils/asyncHandler.js', () => ({
   asyncHandler: vi.fn(fn => fn),

--- a/services/api-gateway/src/routes/user/conversationLookup.ts
+++ b/services/api-gateway/src/routes/user/conversationLookup.ts
@@ -7,7 +7,8 @@
 
 import { Router, type Request, type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
-import { createLogger, ConversationHistoryService } from '@tzurot/common-types';
+import { createLogger } from '@tzurot/common-types';
+import { ConversationHistoryService } from '@tzurot/conversation-history';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
 import { ErrorResponses } from '../../utils/errorResponses.js';

--- a/services/api-gateway/src/routes/user/history.test.ts
+++ b/services/api-gateway/src/routes/user/history.test.ts
@@ -21,11 +21,6 @@ const mockResolve = vi.fn();
 vi.mock('@tzurot/common-types', async () => {
   const actual = await vi.importActual('@tzurot/common-types');
 
-  // Create a mock class that returns our mock methods
-  class MockConversationHistoryService {
-    getHistoryStats = mockGetHistoryStats;
-  }
-
   return {
     ...actual,
     createLogger: () => ({
@@ -34,9 +29,14 @@ vi.mock('@tzurot/common-types', async () => {
       warn: vi.fn(),
       error: vi.fn(),
     }),
-    ConversationHistoryService: MockConversationHistoryService,
   };
 });
+
+vi.mock('@tzurot/conversation-history', () => ({
+  ConversationHistoryService: class {
+    getHistoryStats = mockGetHistoryStats;
+  },
+}));
 
 vi.mock('@tzurot/identity', () => {
   class MockPersonaResolver {

--- a/services/api-gateway/src/routes/user/history.ts
+++ b/services/api-gateway/src/routes/user/history.ts
@@ -15,13 +15,13 @@ import { StatusCodes } from 'http-status-codes';
 import {
   createLogger,
   type PrismaClient,
-  ConversationHistoryService,
   generateUserPersonaHistoryConfigUuid,
   ClearHistorySchema,
   UndoHistorySchema,
   HardDeleteHistorySchema,
   HistoryStatsQuerySchema,
 } from '@tzurot/common-types';
+import { ConversationHistoryService } from '@tzurot/conversation-history';
 import { ConversationRetentionService } from '../../services/ConversationRetentionService.js';
 import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';

--- a/services/api-gateway/tsconfig.json
+++ b/services/api-gateway/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../../packages/common-types" },
     { "path": "../../packages/config-resolver" },
     { "path": "../../packages/identity" },
+    { "path": "../../packages/conversation-history" },
     { "path": "../../packages/clients" }
   ]
 }

--- a/services/bot-client/src/services/MessageContextBuilder.test.ts
+++ b/services/bot-client/src/services/MessageContextBuilder.test.ts
@@ -26,9 +26,6 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   const actual = await importOriginal<typeof import('@tzurot/common-types')>();
   return {
     ...actual,
-    ConversationHistoryService: class {
-      getChannelHistory = vi.fn();
-    },
     createLogger: () => ({
       info: vi.fn(),
       debug: vi.fn(),
@@ -119,25 +116,28 @@ vi.mock('./CrossChannelHistoryFetcher.js', () => ({
 }));
 
 // Import after mocks
-import { ConversationHistoryService } from '@tzurot/common-types';
 import { extractDiscordEnvironment } from '../utils/discordContext.js';
 import { extractAttachments } from '../utils/attachmentExtractor.js';
 import { MessageReferenceExtractor as _MessageReferenceExtractor } from '../handlers/MessageReferenceExtractor.js';
 
-// UserService now lives in @tzurot/identity, which bot-client cannot import
-// (Prisma-backed). This vestigial mock is no longer wired into the builder;
-// the local structural type keeps the legacy per-test setups compiling.
+// UserService + ConversationHistoryService now live in @tzurot/identity and
+// @tzurot/conversation-history — both Prisma-backed, so bot-client cannot import
+// them. These vestigial mocks are no longer wired into the builder; the local
+// structural types keep the legacy per-test setups compiling.
 type MockUserService = {
   getOrCreateUser: ReturnType<typeof vi.fn>;
   getOrCreateUsersInBatch: ReturnType<typeof vi.fn>;
   getPersonaName: ReturnType<typeof vi.fn>;
   getUserTimezone: ReturnType<typeof vi.fn>;
 };
+type MockConversationHistoryService = {
+  getChannelHistory: ReturnType<typeof vi.fn>;
+};
 
 describe('MessageContextBuilder', () => {
   let builder: MessageContextBuilder;
   let mockPrisma: PrismaClient;
-  let mockHistoryService: ConversationHistoryService;
+  let mockHistoryService: MockConversationHistoryService;
   let mockUserService: MockUserService;
   let mockPersonality: LoadedPersonality;
   let mockMessage: Message;
@@ -176,7 +176,7 @@ describe('MessageContextBuilder', () => {
     // mockUserService handling below; see the backlog cleanup item.
     mockHistoryService = {
       getChannelHistory: vi.fn().mockResolvedValue([]),
-    } as unknown as ConversationHistoryService;
+    } as unknown as MockConversationHistoryService;
     // userService is no longer a builder field — the author path resolves via
     // the routing-context endpoint and the extended-context batch moved
     // worker-side. A standalone mock keeps legacy per-test setups inert (they

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
     { "path": "./packages/common-types" },
     { "path": "./packages/config-resolver" },
     { "path": "./packages/identity" },
+    { "path": "./packages/conversation-history" },
     { "path": "./packages/clients" },
     { "path": "./packages/test-factories" },
     { "path": "./tests" },

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -4,6 +4,7 @@ export default defineWorkspace([
   'packages/common-types',
   'packages/config-resolver',
   'packages/identity',
+  'packages/conversation-history',
   'packages/clients',
   'packages/test-factories',
   'services/ai-worker',


### PR DESCRIPTION
## What

Extracts the Prisma-backed **conversation-persistence** cluster out of `@tzurot/common-types` into a dedicated **`@tzurot/conversation-history`** package. This is **PR-2p-3b** — the final extraction of the "Slim common-types" epic (PR-2q, the Redis pub/sub split, closes it).

Moved (history-preserving `git mv`):
- `ConversationHistoryService` (+ tests, int test)
- `ConversationSyncService` (+ tests, int test)
- `referenceImageDescriptions` (Prisma-backed; + test)
- The **Prisma half** of `ConversationMessageMapper` (`conversationHistorySelect`, the `GetPayload` type, `conversationRecencyOrderBy`, `parseMessageMetadata`, `mapToConversationMessage(s)`)

## Boundary correction (the reverse-dependency scan)

The original epic plan listed "5 files move." The bidirectional scan changed that — **two listed files STAY** because bot-client consumes them and can't depend on a Prisma-backed package:

- **`conversationSyncDiff.ts`** — pure (no Prisma; deps are `createLogger` + `normalizeMessageForContext`), and bot-client's `SyncExecutor` imports its functions. Not a cluster member.
- **`ConversationMessage` + `CrossChannelHistoryGroup`** — widely-consumed data shapes (bot-client `DiscordChannelFetcher`/`types.ts`, 8 ai-worker files, common-types' own `historyMerger`/`extendedContextPersonaResolver`/`crossChannelEnvironment`). Extracted to a new **`common-types/types/conversationMessage.ts`** and kept barrel-exported.

So `ConversationMessageMapper` is **split** (types stay, Prisma logic moves) rather than moved whole. Same `service LOGIC → package; data SHAPES → common-types` principle as #1295 / #1299. No `common-types → conversation-history` cycle (depcruise + build order confirm).

## Wiring (mirrors #1299)

- Project references: root + ai-worker + api-gateway `tsconfig.json`
- `vitest.workspace.ts`, `knip.json` entry
- depcruise: **`bot-client-no-conversation-history` ban**
- `structure.test.ts` dirs += `packages/conversation-history/src`
- ai-worker + api-gateway Dockerfile dist copies + workspace deps
- `ConversationHistoryService` `max-lines: 600` override (cohesive single-class CRUD/query service) repointed to the new path

## Notable test-mock migration

The two moved service tests spied on `tokenCounter.countTextTokens` via a namespace import. After the move, production imports `countTextTokens` from the common-types barrel — a namespace spy doesn't reliably catch a re-exported binding, so those became partial `vi.mock('@tzurot/common-types', …)` mocks. bot-client's vestigial `mockHistoryService` got a local structural type (bot-client can't import the package).

## Verification

- Build: 12 packages green
- Unit: conversation-history 115, common-types 2481, ai-worker 3258, api-gateway 2142, bot-client 5037
- `pnpm quality` green (lint, typecheck, typecheck:spec, knip, depcruise, cpd, backlog:lint)
- `guard:dockerfile-dist`, `structure.test.ts`, 62 affected integration tests, grep gates — green

## Follow-up

- 2p-3a left a stale `UserService.ts` eslint exemption path (`packages/common-types/src/services/` → should be `packages/identity/src/`) — dead config (identity isn't in the prisma-create-ban scope); will track in `backlog/cold/follow-ups.md`.
- After this merges, the only Prisma-backed code left in common-types is the cache-invalidation cluster → **PR-2q** closes the epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)