### PR TITLE
refactor(common-types): extract @tzurot/cache-invalidation (PR-2q) — closes epic extractions

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -36,6 +36,9 @@
     "packages/conversation-history": {
       "entry": ["src/**/*.test.ts", "src/**/*.int.test.ts"]
     },
+    "packages/cache-invalidation": {
+      "entry": ["src/**/*.test.ts"]
+    },
     "packages/tooling": {
       "entry": ["src/**/*.test.ts"],
       "ignoreDependencies": ["eslint"]

--- a/packages/cache-invalidation/package.json
+++ b/packages/cache-invalidation/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@tzurot/cache-invalidation",
+  "version": "3.0.0-beta.135",
+  "private": true,
+  "type": "module",
+  "description": "Redis pub/sub cache-invalidation services: a generic base + per-domain invalidators (personality, llm/tts/stt config, persona, api-key, channel-activation, denylist)",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "clean": "find src -name '*.js' -type f -delete && find src -name '*.js.map' -type f -delete",
+    "build": "tsc",
+    "pretest": "npm run clean",
+    "test": "vitest",
+    "test:watch": "vitest --watch",
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint src --max-warnings=0",
+    "lint:fix": "eslint src --fix",
+    "format": "prettier --write .",
+    "typecheck": "tsc --noEmit",
+    "typecheck:spec": "tsc --noEmit --project tsconfig.spec.json"
+  },
+  "dependencies": {
+    "@tzurot/common-types": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.3",
+    "ioredis": "^5.11.1",
+    "pino": "^10.3.1"
+  }
+}

--- a/packages/cache-invalidation/src/ApiKeyCacheInvalidationService.test.ts
+++ b/packages/cache-invalidation/src/ApiKeyCacheInvalidationService.test.ts
@@ -8,7 +8,7 @@ import {
   isValidApiKeyInvalidationEvent,
   type ApiKeyInvalidationEvent,
 } from './ApiKeyCacheInvalidationService.js';
-import { REDIS_CHANNELS } from '../constants/queue.js';
+import { REDIS_CHANNELS } from '@tzurot/common-types';
 
 describe('ApiKeyCacheInvalidationService', () => {
   let mockRedis: ReturnType<typeof createMockRedis>;

--- a/packages/cache-invalidation/src/ApiKeyCacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/ApiKeyCacheInvalidationService.ts
@@ -14,7 +14,7 @@
  * - { type: 'all' } - Invalidate all API key caches (e.g., for key rotation)
  */
 
-import { REDIS_CHANNELS } from '../constants/queue.js';
+import { REDIS_CHANNELS } from '@tzurot/common-types';
 import {
   BaseCacheInvalidationService,
   createStandardEventValidator,

--- a/packages/cache-invalidation/src/BaseCacheInvalidationService.test.ts
+++ b/packages/cache-invalidation/src/BaseCacheInvalidationService.test.ts
@@ -14,14 +14,18 @@ import {
 } from './BaseCacheInvalidationService.js';
 
 // Mock logger
-vi.mock('../utils/logger.js', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
 
 describe('createStandardEventValidator', () => {
   const validator = createStandardEventValidator<StandardInvalidationEvent>();

--- a/packages/cache-invalidation/src/BaseCacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/BaseCacheInvalidationService.ts
@@ -21,7 +21,7 @@
  * ```
  */
 
-import { createLogger } from '../utils/logger.js';
+import { createLogger } from '@tzurot/common-types';
 import type { Logger } from 'pino';
 import type { Redis } from 'ioredis';
 

--- a/packages/cache-invalidation/src/CacheInvalidationService.test.ts
+++ b/packages/cache-invalidation/src/CacheInvalidationService.test.ts
@@ -8,7 +8,7 @@ import {
   CacheInvalidationService,
   type PersonalityCacheTarget,
 } from './CacheInvalidationService.js';
-import { REDIS_CHANNELS } from '../constants/queue.js';
+import { REDIS_CHANNELS } from '@tzurot/common-types';
 import type { Redis } from 'ioredis';
 
 describe('CacheInvalidationService', () => {

--- a/packages/cache-invalidation/src/CacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/CacheInvalidationService.ts
@@ -13,8 +13,7 @@
  * - personality:invalidate:all - Invalidate all personality caches (global default changed)
  */
 
-import { createLogger } from '../utils/logger.js';
-import { REDIS_CHANNELS } from '../constants/queue.js';
+import { createLogger, REDIS_CHANNELS } from '@tzurot/common-types';
 import type { Redis } from 'ioredis';
 
 const logger = createLogger('CacheInvalidationService');

--- a/packages/cache-invalidation/src/ChannelActivationCacheInvalidationService.test.ts
+++ b/packages/cache-invalidation/src/ChannelActivationCacheInvalidationService.test.ts
@@ -8,17 +8,21 @@ import {
   isValidChannelActivationInvalidationEvent,
   type ChannelActivationInvalidationEvent,
 } from './ChannelActivationCacheInvalidationService.js';
-import { REDIS_CHANNELS } from '../constants/queue.js';
+import { REDIS_CHANNELS } from '@tzurot/common-types';
 
 // Mock logger
-vi.mock('../utils/logger.js', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
 
 describe('ChannelActivationCacheInvalidationService', () => {
   let mockRedis: ReturnType<typeof createMockRedis>;

--- a/packages/cache-invalidation/src/ChannelActivationCacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/ChannelActivationCacheInvalidationService.ts
@@ -20,7 +20,7 @@
  * - { type: 'all' } - Invalidate all channel activation caches (for edge cases)
  */
 
-import { REDIS_CHANNELS } from '../constants/queue.js';
+import { REDIS_CHANNELS } from '@tzurot/common-types';
 import {
   BaseCacheInvalidationService,
   createEventValidator,

--- a/packages/cache-invalidation/src/ConfigCascadeCacheInvalidationService.test.ts
+++ b/packages/cache-invalidation/src/ConfigCascadeCacheInvalidationService.test.ts
@@ -7,17 +7,21 @@ import {
   ConfigCascadeCacheInvalidationService,
   isValidConfigCascadeInvalidationEvent,
 } from './ConfigCascadeCacheInvalidationService.js';
-import { REDIS_CHANNELS } from '../constants/queue.js';
+import { REDIS_CHANNELS } from '@tzurot/common-types';
 
 // Mock logger
-vi.mock('../utils/logger.js', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
 
 describe('ConfigCascadeCacheInvalidationService', () => {
   let mockRedis: {

--- a/packages/cache-invalidation/src/ConfigCascadeCacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/ConfigCascadeCacheInvalidationService.ts
@@ -16,7 +16,7 @@
  * - { type: 'all' } - Full cache clear
  */
 
-import { REDIS_CHANNELS } from '../constants/queue.js';
+import { REDIS_CHANNELS } from '@tzurot/common-types';
 import {
   BaseCacheInvalidationService,
   createEventValidator,

--- a/packages/cache-invalidation/src/DenylistCacheInvalidationService.test.ts
+++ b/packages/cache-invalidation/src/DenylistCacheInvalidationService.test.ts
@@ -8,17 +8,21 @@ import {
   isValidDenylistInvalidationEvent,
   type DenylistInvalidationEvent,
 } from './DenylistCacheInvalidationService.js';
-import { REDIS_CHANNELS } from '../constants/queue.js';
+import { REDIS_CHANNELS } from '@tzurot/common-types';
 
 // Mock logger
-vi.mock('../utils/logger.js', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
 
 describe('DenylistCacheInvalidationService', () => {
   let mockRedis: ReturnType<typeof createMockRedis>;

--- a/packages/cache-invalidation/src/DenylistCacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/DenylistCacheInvalidationService.ts
@@ -15,7 +15,7 @@
  * - { type: 'all' } - Full cache reload (for migrations or bulk changes)
  */
 
-import { REDIS_CHANNELS } from '../constants/queue.js';
+import { REDIS_CHANNELS } from '@tzurot/common-types';
 import { BaseCacheInvalidationService } from './BaseCacheInvalidationService.js';
 import type { Redis } from 'ioredis';
 

--- a/packages/cache-invalidation/src/LlmConfigCacheInvalidationService.test.ts
+++ b/packages/cache-invalidation/src/LlmConfigCacheInvalidationService.test.ts
@@ -7,17 +7,21 @@ import {
   LlmConfigCacheInvalidationService,
   isValidLlmConfigInvalidationEvent,
 } from './LlmConfigCacheInvalidationService.js';
-import { REDIS_CHANNELS } from '../constants/queue.js';
+import { REDIS_CHANNELS } from '@tzurot/common-types';
 
 // Mock logger
-vi.mock('../utils/logger.js', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
 
 describe('LlmConfigCacheInvalidationService', () => {
   let mockRedis: {

--- a/packages/cache-invalidation/src/LlmConfigCacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/LlmConfigCacheInvalidationService.ts
@@ -15,7 +15,7 @@
  * - { type: 'all' } - Invalidate all LLM config caches (e.g., for global config changes)
  */
 
-import { REDIS_CHANNELS } from '../constants/queue.js';
+import { REDIS_CHANNELS } from '@tzurot/common-types';
 import {
   BaseCacheInvalidationService,
   createEventValidator,

--- a/packages/cache-invalidation/src/PersonaCacheInvalidationService.test.ts
+++ b/packages/cache-invalidation/src/PersonaCacheInvalidationService.test.ts
@@ -8,17 +8,21 @@ import {
   isValidPersonaInvalidationEvent,
   type PersonaInvalidationEvent,
 } from './PersonaCacheInvalidationService.js';
-import { REDIS_CHANNELS } from '../constants/queue.js';
+import { REDIS_CHANNELS } from '@tzurot/common-types';
 
 // Mock logger
-vi.mock('../utils/logger.js', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
 
 describe('PersonaCacheInvalidationService', () => {
   let mockRedis: ReturnType<typeof createMockRedis>;

--- a/packages/cache-invalidation/src/PersonaCacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/PersonaCacheInvalidationService.ts
@@ -14,7 +14,7 @@
  * - { type: 'all' } - Invalidate all persona caches (e.g., for migrations)
  */
 
-import { REDIS_CHANNELS } from '../constants/queue.js';
+import { REDIS_CHANNELS } from '@tzurot/common-types';
 import {
   BaseCacheInvalidationService,
   createStandardEventValidator,

--- a/packages/cache-invalidation/src/SttResolverCacheInvalidationService.test.ts
+++ b/packages/cache-invalidation/src/SttResolverCacheInvalidationService.test.ts
@@ -11,17 +11,21 @@ import {
   SttResolverCacheInvalidationService,
   isValidSttResolverInvalidationEvent,
 } from './SttResolverCacheInvalidationService.js';
-import { REDIS_CHANNELS } from '../constants/queue.js';
+import { REDIS_CHANNELS } from '@tzurot/common-types';
 import type { Redis } from 'ioredis';
 
-vi.mock('../utils/logger.js', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
 
 describe('isValidSttResolverInvalidationEvent', () => {
   it('accepts user event', () => {

--- a/packages/cache-invalidation/src/SttResolverCacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/SttResolverCacheInvalidationService.ts
@@ -17,7 +17,7 @@
  * a config row — there's no per-config invalidation surface to model.
  */
 
-import { REDIS_CHANNELS } from '../constants/queue.js';
+import { REDIS_CHANNELS } from '@tzurot/common-types';
 import {
   BaseCacheInvalidationService,
   createEventValidator,

--- a/packages/cache-invalidation/src/TtsConfigCacheInvalidationService.test.ts
+++ b/packages/cache-invalidation/src/TtsConfigCacheInvalidationService.test.ts
@@ -12,17 +12,21 @@ import {
   TtsConfigCacheInvalidationService,
   isValidTtsConfigInvalidationEvent,
 } from './TtsConfigCacheInvalidationService.js';
-import { REDIS_CHANNELS } from '../constants/queue.js';
+import { REDIS_CHANNELS } from '@tzurot/common-types';
 import type { Redis } from 'ioredis';
 
-vi.mock('../utils/logger.js', () => ({
-  createLogger: () => ({
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  }),
-}));
+vi.mock('@tzurot/common-types', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+  return {
+    ...actual,
+    createLogger: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  };
+});
 
 describe('isValidTtsConfigInvalidationEvent', () => {
   it('accepts user event', () => {

--- a/packages/cache-invalidation/src/TtsConfigCacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/TtsConfigCacheInvalidationService.ts
@@ -16,7 +16,7 @@
  *   - { type: 'all' } — invalidate everything (global config changes)
  */
 
-import { REDIS_CHANNELS } from '../constants/queue.js';
+import { REDIS_CHANNELS } from '@tzurot/common-types';
 import {
   BaseCacheInvalidationService,
   createEventValidator,

--- a/packages/cache-invalidation/src/index.ts
+++ b/packages/cache-invalidation/src/index.ts
@@ -1,0 +1,25 @@
+/**
+ * @tzurot/cache-invalidation
+ *
+ * Redis pub/sub cache-invalidation infrastructure, extracted from
+ * `@tzurot/common-types` so the shared type package stays types/schemas/utils.
+ * A generic `BaseCacheInvalidationService<TEvent>` (publish + subscribe + the
+ * event-validator helpers) plus one concrete invalidator per cached domain.
+ *
+ * This is stateful runtime infra (each instance owns a Redis subscriber
+ * connection), genuinely shared by all three services — every service both
+ * publishes (when it mutates data) and subscribes (to invalidate its local
+ * caches). Consumers inject a `Redis` client; the channel-name constants live
+ * in `@tzurot/common-types` (`REDIS_CHANNELS`, alongside the BullMQ queue names).
+ */
+
+export * from './BaseCacheInvalidationService.js';
+export * from './CacheInvalidationService.js';
+export * from './ApiKeyCacheInvalidationService.js';
+export * from './LlmConfigCacheInvalidationService.js';
+export * from './PersonaCacheInvalidationService.js';
+export * from './ChannelActivationCacheInvalidationService.js';
+export * from './ConfigCascadeCacheInvalidationService.js';
+export * from './DenylistCacheInvalidationService.js';
+export * from './TtsConfigCacheInvalidationService.js';
+export * from './SttResolverCacheInvalidationService.js';

--- a/packages/cache-invalidation/tsconfig.json
+++ b/packages/cache-invalidation/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true
+  },
+  "references": [{ "path": "../common-types" }],
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/cache-invalidation/tsconfig.spec.json
+++ b/packages/cache-invalidation/tsconfig.spec.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/common-types/src/constants/index.ts
+++ b/packages/common-types/src/constants/index.ts
@@ -41,6 +41,7 @@ export {
   JOB_PREFIXES,
   JOB_REQUEST_SUFFIXES,
   REDIS_KEY_PREFIXES,
+  REDIS_CHANNELS,
   JobStatus,
   JobType,
 } from './queue.js';

--- a/packages/common-types/src/index.ts
+++ b/packages/common-types/src/index.ts
@@ -89,12 +89,14 @@ export * from './services/poolConfig.js';
 // ConfigCascadeResolver — the cascade-resolution logic) live in
 // `@tzurot/config-resolver`. The config MAPPERS + tts provider TYPES stay here:
 // they're data shapes consumed by common-types schemas + personality loading,
-// so moving them would cycle. The cache-invalidation siblings stay too pending
-// the pub/sub publisher/subscriber split.
+// so moving them would cycle. The Redis pub/sub cache-invalidation cluster
+// (BaseCacheInvalidationService + 9 invalidators + the event validators) now
+// lives in `@tzurot/cache-invalidation` — it's stateful runtime infra (each
+// instance owns a Redis subscriber), not types. Only the REDIS_CHANNELS
+// constant stays here (a pure constant bundled with the BullMQ queue names in
+// constants/queue.ts; the package imports the cache-channel subset from it).
 export * from './services/LlmConfigMapper.js';
 export * from './services/TtsConfigMapper.js';
-export * from './services/TtsConfigCacheInvalidationService.js';
-export * from './services/SttResolverCacheInvalidationService.js';
 export * from './services/tts/TtsProvider.js';
 export * from './services/tts/TtsProviderError.js';
 // Prisma-backed conversation persistence (ConversationHistoryService,
@@ -111,14 +113,6 @@ export * from './utils/referenceEnrichment.js';
 export * from './utils/messageLinkParser.js';
 export * from './utils/mentionRewriter.js';
 export * from './utils/crossChannelEnvironment.js';
-export * from './services/BaseCacheInvalidationService.js';
-export * from './services/CacheInvalidationService.js';
-export * from './services/ApiKeyCacheInvalidationService.js';
-export * from './services/LlmConfigCacheInvalidationService.js';
-export * from './services/PersonaCacheInvalidationService.js';
-export * from './services/ChannelActivationCacheInvalidationService.js';
-export * from './services/ConfigCascadeCacheInvalidationService.js';
-export * from './services/DenylistCacheInvalidationService.js';
 export { VoiceTranscriptCache } from './services/VoiceTranscriptCache.js';
 
 // NOTE: validated mock factories live in `@tzurot/test-factories` — they're

--- a/packages/common-types/src/structure.test.ts
+++ b/packages/common-types/src/structure.test.ts
@@ -190,6 +190,7 @@ describe('Project Structure', () => {
       'packages/config-resolver/src',
       'packages/identity/src',
       'packages/conversation-history/src',
+      'packages/cache-invalidation/src',
       'packages/embeddings/src',
       'packages/test-factories/src',
       'packages/test-utils/src',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,22 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
+  packages/cache-invalidation:
+    dependencies:
+      '@tzurot/common-types':
+        specifier: workspace:*
+        version: link:../common-types
+    devDependencies:
+      '@types/node':
+        specifier: ^25.9.3
+        version: 25.9.3
+      ioredis:
+        specifier: ^5.10.0
+        version: 5.11.1
+      pino:
+        specifier: ^10.3.1
+        version: 10.3.1
+
   packages/clients:
     dependencies:
       '@tzurot/common-types':
@@ -393,6 +409,9 @@ importers:
       '@langchain/openai':
         specifier: ^1.4.7
         version: 1.4.7(@langchain/core@1.1.49(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(ws@8.21.0)
+      '@tzurot/cache-invalidation':
+        specifier: workspace:*
+        version: link:../../packages/cache-invalidation
       '@tzurot/common-types':
         specifier: workspace:*
         version: link:../../packages/common-types
@@ -445,6 +464,9 @@ importers:
       '@prisma/adapter-pg':
         specifier: ^7.8.0
         version: 7.8.0
+      '@tzurot/cache-invalidation':
+        specifier: workspace:*
+        version: link:../../packages/cache-invalidation
       '@tzurot/common-types':
         specifier: workspace:*
         version: link:../../packages/common-types
@@ -518,6 +540,9 @@ importers:
 
   services/bot-client:
     dependencies:
+      '@tzurot/cache-invalidation':
+        specifier: workspace:*
+        version: link:../../packages/cache-invalidation
       '@tzurot/clients':
         specifier: workspace:*
         version: link:../../packages/clients

--- a/services/ai-worker/Dockerfile
+++ b/services/ai-worker/Dockerfile
@@ -90,6 +90,7 @@ COPY --from=builder /app/packages/common-types/dist ./packages/common-types/dist
 COPY --from=builder /app/packages/config-resolver/dist ./packages/config-resolver/dist
 COPY --from=builder /app/packages/identity/dist ./packages/identity/dist
 COPY --from=builder /app/packages/conversation-history/dist ./packages/conversation-history/dist
+COPY --from=builder /app/packages/cache-invalidation/dist ./packages/cache-invalidation/dist
 COPY --from=builder /app/packages/embeddings/dist ./packages/embeddings/dist
 COPY --from=builder /app/services/ai-worker/dist ./services/ai-worker/dist
 

--- a/services/ai-worker/package.json
+++ b/services/ai-worker/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@langchain/core": "^1.1.49",
     "@langchain/openai": "^1.4.7",
+    "@tzurot/cache-invalidation": "workspace:*",
     "@tzurot/common-types": "workspace:*",
     "@tzurot/config-resolver": "workspace:*",
     "@tzurot/conversation-history": "workspace:*",

--- a/services/ai-worker/src/cacheInvalidation.test.ts
+++ b/services/ai-worker/src/cacheInvalidation.test.ts
@@ -43,54 +43,57 @@ vi.mock('@tzurot/common-types', async () => {
       warn: vi.fn(),
       error: vi.fn(),
     }),
-    CacheInvalidationService: class {
-      subscribe = vi.fn().mockResolvedValue(undefined);
-      unsubscribe = mockUnsubscribe;
-    },
-    ApiKeyCacheInvalidationService: class {
-      subscribe = vi.fn().mockImplementation((cb: SubscribeCallback) => {
-        capturedCallbacks.apiKey = cb;
-        return Promise.resolve();
-      });
-      unsubscribe = mockUnsubscribe;
-    },
-    LlmConfigCacheInvalidationService: class {
-      subscribe = vi.fn().mockImplementation((cb: SubscribeCallback) => {
-        capturedCallbacks.llmConfig = cb;
-        return Promise.resolve();
-      });
-      unsubscribe = mockUnsubscribe;
-    },
-    TtsConfigCacheInvalidationService: class {
-      subscribe = vi.fn().mockImplementation((cb: SubscribeCallback) => {
-        capturedCallbacks.ttsConfig = cb;
-        return Promise.resolve();
-      });
-      unsubscribe = mockUnsubscribe;
-    },
-    PersonaCacheInvalidationService: class {
-      subscribe = vi.fn().mockImplementation((cb: SubscribeCallback) => {
-        capturedCallbacks.persona = cb;
-        return Promise.resolve();
-      });
-      unsubscribe = mockUnsubscribe;
-    },
-    ConfigCascadeCacheInvalidationService: class {
-      subscribe = vi.fn().mockImplementation((cb: SubscribeCallback) => {
-        capturedCallbacks.cascade = cb;
-        return Promise.resolve();
-      });
-      unsubscribe = mockUnsubscribe;
-    },
-    SttResolverCacheInvalidationService: class {
-      subscribe = vi.fn().mockImplementation((cb: SubscribeCallback) => {
-        capturedCallbacks.stt = cb;
-        return Promise.resolve();
-      });
-      unsubscribe = mockUnsubscribe;
-    },
   };
 });
+
+vi.mock('@tzurot/cache-invalidation', () => ({
+  CacheInvalidationService: class {
+    subscribe = vi.fn().mockResolvedValue(undefined);
+    unsubscribe = mockUnsubscribe;
+  },
+  ApiKeyCacheInvalidationService: class {
+    subscribe = vi.fn().mockImplementation((cb: SubscribeCallback) => {
+      capturedCallbacks.apiKey = cb;
+      return Promise.resolve();
+    });
+    unsubscribe = mockUnsubscribe;
+  },
+  LlmConfigCacheInvalidationService: class {
+    subscribe = vi.fn().mockImplementation((cb: SubscribeCallback) => {
+      capturedCallbacks.llmConfig = cb;
+      return Promise.resolve();
+    });
+    unsubscribe = mockUnsubscribe;
+  },
+  TtsConfigCacheInvalidationService: class {
+    subscribe = vi.fn().mockImplementation((cb: SubscribeCallback) => {
+      capturedCallbacks.ttsConfig = cb;
+      return Promise.resolve();
+    });
+    unsubscribe = mockUnsubscribe;
+  },
+  PersonaCacheInvalidationService: class {
+    subscribe = vi.fn().mockImplementation((cb: SubscribeCallback) => {
+      capturedCallbacks.persona = cb;
+      return Promise.resolve();
+    });
+    unsubscribe = mockUnsubscribe;
+  },
+  ConfigCascadeCacheInvalidationService: class {
+    subscribe = vi.fn().mockImplementation((cb: SubscribeCallback) => {
+      capturedCallbacks.cascade = cb;
+      return Promise.resolve();
+    });
+    unsubscribe = mockUnsubscribe;
+  },
+  SttResolverCacheInvalidationService: class {
+    subscribe = vi.fn().mockImplementation((cb: SubscribeCallback) => {
+      capturedCallbacks.stt = cb;
+      return Promise.resolve();
+    });
+    unsubscribe = mockUnsubscribe;
+  },
+}));
 
 vi.mock('@tzurot/config-resolver', () => ({
   ConfigCascadeResolver: class {

--- a/services/ai-worker/src/cacheInvalidation.ts
+++ b/services/ai-worker/src/cacheInvalidation.ts
@@ -7,8 +7,8 @@
  */
 
 import { Redis } from 'ioredis';
+import { createLogger, type PrismaClient } from '@tzurot/common-types';
 import {
-  createLogger,
   CacheInvalidationService,
   ApiKeyCacheInvalidationService,
   LlmConfigCacheInvalidationService,
@@ -16,8 +16,7 @@ import {
   ConfigCascadeCacheInvalidationService,
   TtsConfigCacheInvalidationService,
   SttResolverCacheInvalidationService,
-  type PrismaClient,
-} from '@tzurot/common-types';
+} from '@tzurot/cache-invalidation';
 import { PersonalityService } from '@tzurot/identity';
 import {
   ConfigCascadeResolver,

--- a/services/ai-worker/tsconfig.json
+++ b/services/ai-worker/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../../packages/common-types" },
     { "path": "../../packages/config-resolver" },
     { "path": "../../packages/identity" },
-    { "path": "../../packages/conversation-history" }
+    { "path": "../../packages/conversation-history" },
+    { "path": "../../packages/cache-invalidation" }
   ]
 }

--- a/services/api-gateway/Dockerfile
+++ b/services/api-gateway/Dockerfile
@@ -82,6 +82,7 @@ COPY --from=builder /app/packages/common-types/dist ./packages/common-types/dist
 COPY --from=builder /app/packages/config-resolver/dist ./packages/config-resolver/dist
 COPY --from=builder /app/packages/identity/dist ./packages/identity/dist
 COPY --from=builder /app/packages/conversation-history/dist ./packages/conversation-history/dist
+COPY --from=builder /app/packages/cache-invalidation/dist ./packages/cache-invalidation/dist
 COPY --from=builder /app/packages/embeddings/dist ./packages/embeddings/dist
 COPY --from=builder /app/services/api-gateway/dist ./services/api-gateway/dist
 

--- a/services/api-gateway/package.json
+++ b/services/api-gateway/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@prisma/adapter-pg": "^7.8.0",
+    "@tzurot/cache-invalidation": "workspace:*",
     "@tzurot/common-types": "workspace:*",
     "@tzurot/config-resolver": "workspace:*",
     "@tzurot/conversation-history": "workspace:*",

--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -20,6 +20,9 @@ import {
   createLogger,
   getConfig,
   createPrismaClient,
+  type PrismaClient,
+} from '@tzurot/common-types';
+import {
   CacheInvalidationService,
   ApiKeyCacheInvalidationService,
   LlmConfigCacheInvalidationService,
@@ -27,8 +30,7 @@ import {
   SttResolverCacheInvalidationService,
   DenylistCacheInvalidationService,
   ConfigCascadeCacheInvalidationService,
-  type PrismaClient,
-} from '@tzurot/common-types';
+} from '@tzurot/cache-invalidation';
 import { PersonalityService } from '@tzurot/identity';
 import { ConfigCascadeResolver, LlmConfigResolver } from '@tzurot/config-resolver';
 import { ConversationRetentionService } from './services/ConversationRetentionService.js';

--- a/services/api-gateway/src/routes/admin/createPersonality.test.ts
+++ b/services/api-gateway/src/routes/admin/createPersonality.test.ts
@@ -6,7 +6,8 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import express, { type Express } from 'express';
 import request from 'supertest';
 import { createCreatePersonalityRoute } from './createPersonality.js';
-import type { PrismaClient, CacheInvalidationService } from '@tzurot/common-types';
+import type { PrismaClient } from '@tzurot/common-types';
+import type { CacheInvalidationService } from '@tzurot/cache-invalidation';
 
 // Mock AuthMiddleware
 vi.mock('../../services/AuthMiddleware.js', () => ({

--- a/services/api-gateway/src/routes/admin/createPersonality.ts
+++ b/services/api-gateway/src/routes/admin/createPersonality.ts
@@ -9,11 +9,11 @@ import {
   AdminPersonalityResponseSchema,
   createLogger,
   generatePersonalityUuid,
-  type CacheInvalidationService,
   PersonalityCreateSchema,
   type PersonalityCreateInput,
   Prisma,
 } from '@tzurot/common-types';
+import { type CacheInvalidationService } from '@tzurot/cache-invalidation';
 import { requireOwnerAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendError, sendContractSuccess } from '../../utils/responseHelpers.js';

--- a/services/api-gateway/src/routes/admin/denylist.ts
+++ b/services/api-gateway/src/routes/admin/denylist.ts
@@ -17,8 +17,8 @@ import {
   denylistEntityTypeSchema,
   denylistScopeSchema,
   type PrismaClient,
-  type DenylistCacheInvalidationService,
 } from '@tzurot/common-types';
+import { type DenylistCacheInvalidationService } from '@tzurot/cache-invalidation';
 import { extractOwnerId, requireOwnerAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendCustomSuccess, sendError } from '../../utils/responseHelpers.js';

--- a/services/api-gateway/src/routes/admin/llm-config.test.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.test.ts
@@ -6,7 +6,8 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import express, { type Express } from 'express';
 import request from 'supertest';
 import { createAdminLlmConfigRoutes } from './llm-config.js';
-import type { PrismaClient, LlmConfigCacheInvalidationService } from '@tzurot/common-types';
+import type { PrismaClient } from '@tzurot/common-types';
+import type { LlmConfigCacheInvalidationService } from '@tzurot/cache-invalidation';
 import { getAllRoutes } from '../../test/expressRouterUtils.js';
 
 // Mock the admin auth middleware

--- a/services/api-gateway/src/routes/admin/settings.ts
+++ b/services/api-gateway/src/routes/admin/settings.ts
@@ -24,8 +24,8 @@ import {
   AdminSettingsSchema,
   ADMIN_SETTINGS_SINGLETON_ID,
   createLogger,
-  type ConfigCascadeCacheInvalidationService,
 } from '@tzurot/common-types';
+import { type ConfigCascadeCacheInvalidationService } from '@tzurot/cache-invalidation';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { mergeConfigOverrides } from '../../utils/configOverrideMerge.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';

--- a/services/api-gateway/src/routes/admin/updatePersonality.test.ts
+++ b/services/api-gateway/src/routes/admin/updatePersonality.test.ts
@@ -6,7 +6,8 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import express, { type Express } from 'express';
 import request from 'supertest';
 import { createUpdatePersonalityRoute } from './updatePersonality.js';
-import type { PrismaClient, CacheInvalidationService } from '@tzurot/common-types';
+import type { PrismaClient } from '@tzurot/common-types';
+import type { CacheInvalidationService } from '@tzurot/cache-invalidation';
 import { optimizeAvatar } from '../../utils/imageProcessor.js';
 
 // Mock AuthMiddleware

--- a/services/api-gateway/src/routes/admin/updatePersonality.ts
+++ b/services/api-gateway/src/routes/admin/updatePersonality.ts
@@ -7,10 +7,10 @@ import { Router, type Request, type RequestHandler, type Response } from 'expres
 import {
   AdminPersonalityResponseSchema,
   createLogger,
-  type CacheInvalidationService,
   PersonalityUpdateSchema,
   type PersonalityUpdateInput,
 } from '@tzurot/common-types';
+import { type CacheInvalidationService } from '@tzurot/cache-invalidation';
 import { requireOwnerAuth } from '../../services/AuthMiddleware.js';
 import type { RouteDeps } from '../routeDeps.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';

--- a/services/api-gateway/src/routes/conformance/fixtures/harness.ts
+++ b/services/api-gateway/src/routes/conformance/fixtures/harness.ts
@@ -14,12 +14,11 @@
 
 import express, { type Express } from 'express';
 import request from 'supertest';
+import { PrismaClient, resetConfig } from '@tzurot/common-types';
 import {
   CacheInvalidationService,
   DenylistCacheInvalidationService,
-  PrismaClient,
-  resetConfig,
-} from '@tzurot/common-types';
+} from '@tzurot/cache-invalidation';
 import type { PGlite } from '@electric-sql/pglite';
 import { PrismaPGlite } from 'pglite-prisma-adapter';
 import {

--- a/services/api-gateway/src/routes/routeDeps.ts
+++ b/services/api-gateway/src/routes/routeDeps.ts
@@ -28,16 +28,16 @@
 
 import type { Queue, QueueEvents } from 'bullmq';
 import type { Redis } from 'ioredis';
+import type { PrismaClient } from '@tzurot/common-types';
 import type {
   ApiKeyCacheInvalidationService,
   CacheInvalidationService,
   ConfigCascadeCacheInvalidationService,
   DenylistCacheInvalidationService,
   LlmConfigCacheInvalidationService,
-  PrismaClient,
   SttResolverCacheInvalidationService,
   TtsConfigCacheInvalidationService,
-} from '@tzurot/common-types';
+} from '@tzurot/cache-invalidation';
 import type { ConfigCascadeResolver, LlmConfigResolver } from '@tzurot/config-resolver';
 import type { ConversationRetentionService } from '../services/ConversationRetentionService.js';
 import type { OpenRouterModelCache } from '../services/OpenRouterModelCache.js';

--- a/services/api-gateway/src/routes/user/llm-config.test.ts
+++ b/services/api-gateway/src/routes/user/llm-config.test.ts
@@ -154,7 +154,7 @@ const mockPrisma = {
 const mockCacheInvalidation = {
   invalidateUserLlmConfig: vi.fn().mockResolvedValue(undefined),
   invalidateAll: vi.fn().mockResolvedValue(undefined),
-} as unknown as import('@tzurot/common-types').LlmConfigCacheInvalidationService;
+} as unknown as import('@tzurot/cache-invalidation').LlmConfigCacheInvalidationService;
 
 import { createLlmConfigRoutes } from './llm-config.js';
 import { getRouteHandler, findRoute } from '../../test/expressRouterUtils.js';

--- a/services/api-gateway/src/routes/user/model-override.test.ts
+++ b/services/api-gateway/src/routes/user/model-override.test.ts
@@ -564,7 +564,7 @@ describe('/user/model-override routes', () => {
       const router = createModelOverrideRoutes({
         prisma: mockPrisma as unknown as PrismaClient,
         llmConfigCacheInvalidation:
-          mockInvalidation as unknown as import('@tzurot/common-types').LlmConfigCacheInvalidationService,
+          mockInvalidation as unknown as import('@tzurot/cache-invalidation').LlmConfigCacheInvalidationService,
       });
       const handler = getHandler(router, 'put', '/default');
       const { req, res } = createMockReqRes({ configId: '22222222-2222-4222-a222-222222222222' });
@@ -587,7 +587,7 @@ describe('/user/model-override routes', () => {
       const router = createModelOverrideRoutes({
         prisma: mockPrisma as unknown as PrismaClient,
         llmConfigCacheInvalidation:
-          mockInvalidation as unknown as import('@tzurot/common-types').LlmConfigCacheInvalidationService,
+          mockInvalidation as unknown as import('@tzurot/cache-invalidation').LlmConfigCacheInvalidationService,
       });
       const handler = getHandler(router, 'put', '/default');
       const { req, res } = createMockReqRes({ configId: '22222222-2222-4222-a222-222222222222' });
@@ -744,7 +744,7 @@ describe('/user/model-override routes', () => {
       const router = createModelOverrideRoutes({
         prisma: mockPrisma as unknown as PrismaClient,
         llmConfigCacheInvalidation:
-          mockInvalidation as unknown as import('@tzurot/common-types').LlmConfigCacheInvalidationService,
+          mockInvalidation as unknown as import('@tzurot/cache-invalidation').LlmConfigCacheInvalidationService,
       });
       const handler = getHandler(router, 'delete', '/default');
       const { req, res } = createMockReqRes();
@@ -767,7 +767,7 @@ describe('/user/model-override routes', () => {
       const router = createModelOverrideRoutes({
         prisma: mockPrisma as unknown as PrismaClient,
         llmConfigCacheInvalidation:
-          mockInvalidation as unknown as import('@tzurot/common-types').LlmConfigCacheInvalidationService,
+          mockInvalidation as unknown as import('@tzurot/cache-invalidation').LlmConfigCacheInvalidationService,
       });
       const handler = getHandler(router, 'delete', '/default');
       const { req, res } = createMockReqRes();

--- a/services/api-gateway/src/routes/user/personality/delete.test.ts
+++ b/services/api-gateway/src/routes/user/personality/delete.test.ts
@@ -412,7 +412,7 @@ describe('DELETE /user/personality/:slug', () => {
     it('should call cache invalidation service when provided', async () => {
       const mockCacheInvalidationService = {
         invalidatePersonality: vi.fn().mockResolvedValue(undefined),
-      } as unknown as import('@tzurot/common-types').CacheInvalidationService;
+      } as unknown as import('@tzurot/cache-invalidation').CacheInvalidationService;
 
       const router = createPersonalityRoutes({
         prisma: mockPrisma as unknown as PrismaClient,
@@ -432,7 +432,7 @@ describe('DELETE /user/personality/:slug', () => {
     it('should not fail when cache invalidation throws error', async () => {
       const mockCacheInvalidationService = {
         invalidatePersonality: vi.fn().mockRejectedValue(new Error('Redis connection failed')),
-      } as unknown as import('@tzurot/common-types').CacheInvalidationService;
+      } as unknown as import('@tzurot/cache-invalidation').CacheInvalidationService;
 
       const router = createPersonalityRoutes({
         prisma: mockPrisma as unknown as PrismaClient,

--- a/services/api-gateway/src/routes/user/personality/delete.ts
+++ b/services/api-gateway/src/routes/user/personality/delete.ts
@@ -8,9 +8,9 @@ import { StatusCodes } from 'http-status-codes';
 import {
   createLogger,
   type PrismaClient,
-  type CacheInvalidationService,
   DeletePersonalityResponseSchema,
 } from '@tzurot/common-types';
+import { type CacheInvalidationService } from '@tzurot/cache-invalidation';
 import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendCustomSuccess, sendError } from '../../../utils/responseHelpers.js';

--- a/services/api-gateway/src/routes/user/personality/update.test.ts
+++ b/services/api-gateway/src/routes/user/personality/update.test.ts
@@ -492,7 +492,7 @@ describe('PUT /user/personality/:slug (update)', () => {
     it('should call cache invalidation service when avatar is updated', async () => {
       const mockCacheInvalidationService = {
         invalidatePersonality: vi.fn().mockResolvedValue(undefined),
-      } as unknown as import('@tzurot/common-types').CacheInvalidationService;
+      } as unknown as import('@tzurot/cache-invalidation').CacheInvalidationService;
 
       const router = createPersonalityRoutes({
         prisma: mockPrisma as unknown as PrismaClient,
@@ -515,7 +515,7 @@ describe('PUT /user/personality/:slug (update)', () => {
     it('should not fail when cache invalidation throws error', async () => {
       const mockCacheInvalidationService = {
         invalidatePersonality: vi.fn().mockRejectedValue(new Error('Cache service unavailable')),
-      } as unknown as import('@tzurot/common-types').CacheInvalidationService;
+      } as unknown as import('@tzurot/cache-invalidation').CacheInvalidationService;
 
       const router = createPersonalityRoutes({
         prisma: mockPrisma as unknown as PrismaClient,
@@ -537,7 +537,7 @@ describe('PUT /user/personality/:slug (update)', () => {
     it('should not call cache invalidation when no avatar update', async () => {
       const mockCacheInvalidationService = {
         invalidatePersonality: vi.fn().mockResolvedValue(undefined),
-      } as unknown as import('@tzurot/common-types').CacheInvalidationService;
+      } as unknown as import('@tzurot/cache-invalidation').CacheInvalidationService;
 
       const router = createPersonalityRoutes({
         prisma: mockPrisma as unknown as PrismaClient,
@@ -808,7 +808,7 @@ describe('PUT /user/personality/:slug (update)', () => {
 
       const mockCacheInvalidationService = {
         invalidatePersonality: vi.fn().mockResolvedValue(undefined),
-      } as unknown as import('@tzurot/common-types').CacheInvalidationService;
+      } as unknown as import('@tzurot/cache-invalidation').CacheInvalidationService;
 
       const router = createPersonalityRoutes({
         prisma: mockPrisma as unknown as PrismaClient,

--- a/services/api-gateway/src/routes/user/personality/update.ts
+++ b/services/api-gateway/src/routes/user/personality/update.ts
@@ -9,12 +9,12 @@ import {
   GetPersonalityResponseSchema,
   isBotOwner,
   type PrismaClient,
-  type CacheInvalidationService,
   PersonalityUpdateSchema,
   type PersonalityUpdateInput,
   PERSONALITY_DETAIL_SELECT,
   Prisma,
 } from '@tzurot/common-types';
+import { type CacheInvalidationService } from '@tzurot/cache-invalidation';
 import { requireUserAuth, requireProvisionedUser } from '../../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { sendContractSuccess, sendError } from '../../../utils/responseHelpers.js';

--- a/services/api-gateway/src/routes/wallet/removeKey.ts
+++ b/services/api-gateway/src/routes/wallet/removeKey.ts
@@ -4,12 +4,8 @@
  */
 
 import { type Response, type RequestHandler } from 'express';
-import {
-  createLogger,
-  AIProvider,
-  type PrismaClient,
-  type ApiKeyCacheInvalidationService,
-} from '@tzurot/common-types';
+import { createLogger, AIProvider, type PrismaClient } from '@tzurot/common-types';
+import { type ApiKeyCacheInvalidationService } from '@tzurot/cache-invalidation';
 import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';

--- a/services/api-gateway/src/routes/wallet/setKey.ts
+++ b/services/api-gateway/src/routes/wallet/setKey.ts
@@ -15,10 +15,10 @@ import {
   encryptApiKey,
   WALLET_ERROR_MESSAGES,
   type PrismaClient,
-  type ApiKeyCacheInvalidationService,
   generateUserApiKeyUuid,
   SetWalletKeySchema,
 } from '@tzurot/common-types';
+import { type ApiKeyCacheInvalidationService } from '@tzurot/cache-invalidation';
 import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';

--- a/services/api-gateway/src/services/DatabaseNotificationListener.test.ts
+++ b/services/api-gateway/src/services/DatabaseNotificationListener.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import type { CacheInvalidationService } from '@tzurot/common-types';
+import type { CacheInvalidationService } from '@tzurot/cache-invalidation';
 
 // Mock pg Client - must be at module scope BEFORE importing the service
 vi.mock('pg', () => {
@@ -52,7 +52,9 @@ describe('DatabaseNotificationListener', () => {
     });
 
     listener = new DatabaseNotificationListener(
-      'postgresql://test:test@localhost:5432/test',
+      // No credentials in the literal — the pg Client is mocked, so the value is
+      // opaque; a `user:pass@` form only trips secretlint's connection-string rule.
+      'postgresql://localhost:5432/test',
       mockCacheService as unknown as CacheInvalidationService
     );
   });

--- a/services/api-gateway/src/services/DatabaseNotificationListener.ts
+++ b/services/api-gateway/src/services/DatabaseNotificationListener.ts
@@ -12,12 +12,11 @@
  */
 
 import { Client } from 'pg';
+import { createLogger, DATABASE_RECONNECT } from '@tzurot/common-types';
 import {
-  createLogger,
   isValidInvalidationEvent,
-  DATABASE_RECONNECT,
   type CacheInvalidationService,
-} from '@tzurot/common-types';
+} from '@tzurot/cache-invalidation';
 
 const logger = createLogger('DatabaseNotificationListener');
 

--- a/services/api-gateway/src/services/LlmConfigService.test.ts
+++ b/services/api-gateway/src/services/LlmConfigService.test.ts
@@ -11,7 +11,8 @@ import {
   CloneNameExhaustedError,
   type LlmConfigScope,
 } from './LlmConfigService.js';
-import type { PrismaClient, LlmConfigCacheInvalidationService } from '@tzurot/common-types';
+import type { PrismaClient } from '@tzurot/common-types';
+import type { LlmConfigCacheInvalidationService } from '@tzurot/cache-invalidation';
 
 // Mock logger
 vi.mock('@tzurot/common-types', async () => {

--- a/services/api-gateway/src/services/LlmConfigService.ts
+++ b/services/api-gateway/src/services/LlmConfigService.ts
@@ -14,7 +14,6 @@
 
 import {
   type PrismaClient,
-  type LlmConfigCacheInvalidationService,
   type LlmConfigCreateInput,
   type LlmConfigUpdateInput,
   LLM_CONFIG_LIST_SELECT,
@@ -26,6 +25,7 @@ import {
   createLogger,
   safeValidateAdvancedParams,
 } from '@tzurot/common-types';
+import { type LlmConfigCacheInvalidationService } from '@tzurot/cache-invalidation';
 
 import { isPrismaUniqueConstraintErrorOn } from '../utils/prismaErrors.js';
 import { CloneNameExhaustedError, AutoSuffixCollisionError } from './LlmConfigErrors.js';

--- a/services/api-gateway/src/services/TtsConfigService.test.ts
+++ b/services/api-gateway/src/services/TtsConfigService.test.ts
@@ -17,7 +17,8 @@ import {
   TtsInvalidProviderError,
   type TtsConfigScope,
 } from './TtsConfigService.js';
-import type { PrismaClient, TtsConfigCacheInvalidationService } from '@tzurot/common-types';
+import type { PrismaClient } from '@tzurot/common-types';
+import type { TtsConfigCacheInvalidationService } from '@tzurot/cache-invalidation';
 
 // Mock logger to keep test output clean
 vi.mock('@tzurot/common-types', async () => {

--- a/services/api-gateway/src/services/TtsConfigService.ts
+++ b/services/api-gateway/src/services/TtsConfigService.ts
@@ -28,7 +28,6 @@
 import {
   Prisma,
   type PrismaClient,
-  type TtsConfigCacheInvalidationService,
   type TtsConfigCreateInput,
   type TtsConfigUpdateInput,
   TTS_CONFIG_LIST_SELECT,
@@ -40,6 +39,7 @@ import {
   isTtsProviderId,
   createLogger,
 } from '@tzurot/common-types';
+import { type TtsConfigCacheInvalidationService } from '@tzurot/cache-invalidation';
 
 import { isPrismaUniqueConstraintErrorOn } from '../utils/prismaErrors.js';
 import { bootstrapTtsSystemGlobalsIfNeeded } from './TtsConfigBootstrap.js';

--- a/services/api-gateway/tsconfig.json
+++ b/services/api-gateway/tsconfig.json
@@ -12,6 +12,7 @@
     { "path": "../../packages/config-resolver" },
     { "path": "../../packages/identity" },
     { "path": "../../packages/conversation-history" },
+    { "path": "../../packages/cache-invalidation" },
     { "path": "../../packages/clients" }
   ]
 }

--- a/services/bot-client/Dockerfile
+++ b/services/bot-client/Dockerfile
@@ -86,6 +86,7 @@ COPY --from=builder /app/node_modules/.pnpm ./node_modules/.pnpm
 # or the runtime image will be missing it (ERR_MODULE_NOT_FOUND at startup).
 # Keep in sync with the prod `dependencies` in services/bot-client/package.json.
 COPY --from=builder /app/packages/common-types/dist ./packages/common-types/dist
+COPY --from=builder /app/packages/cache-invalidation/dist ./packages/cache-invalidation/dist
 COPY --from=builder /app/packages/clients/dist ./packages/clients/dist
 COPY --from=builder /app/services/bot-client/dist ./services/bot-client/dist
 

--- a/services/bot-client/package.json
+++ b/services/bot-client/package.json
@@ -23,6 +23,7 @@
     "deploy-commands:railway": "railway run --service bot-client pnpm deploy-commands"
   },
   "dependencies": {
+    "@tzurot/cache-invalidation": "workspace:*",
     "@tzurot/clients": "workspace:*",
     "@tzurot/common-types": "workspace:*",
     "bullmq": "^5.78.1",

--- a/services/bot-client/src/index.ts
+++ b/services/bot-client/src/index.ts
@@ -11,13 +11,15 @@ import { Redis } from 'ioredis';
 import {
   createLogger,
   isBotOwner,
-  CacheInvalidationService,
-  ChannelActivationCacheInvalidationService,
-  DenylistCacheInvalidationService,
   getConfig,
   parseRedisUrl,
   createBullMQRedisConfig,
 } from '@tzurot/common-types';
+import {
+  CacheInvalidationService,
+  ChannelActivationCacheInvalidationService,
+  DenylistCacheInvalidationService,
+} from '@tzurot/cache-invalidation';
 import {
   invalidateChannelSettingsCache,
   clearAllChannelSettingsCache,

--- a/services/bot-client/src/services/DenylistCache.ts
+++ b/services/bot-client/src/services/DenylistCache.ts
@@ -17,12 +17,8 @@
  * - personalityUsers: Map of userId → Map of personalityId → DenylistMode
  */
 
-import {
-  createLogger,
-  type DenylistInvalidationEvent,
-  type DenylistCacheResponse,
-  type DenylistMode,
-} from '@tzurot/common-types';
+import { createLogger, type DenylistCacheResponse, type DenylistMode } from '@tzurot/common-types';
+import { type DenylistInvalidationEvent } from '@tzurot/cache-invalidation';
 import { getServiceClient } from '../utils/gatewayClients.js';
 
 const logger = createLogger('DenylistCache');

--- a/services/bot-client/src/services/HttpPersonalityLoader.ts
+++ b/services/bot-client/src/services/HttpPersonalityLoader.ts
@@ -22,13 +22,8 @@
  *   routing for 60 s.
  */
 
-import {
-  createLogger,
-  TIMEOUTS,
-  TTLCache,
-  type LoadedPersonality,
-  type PersonalityCacheTarget,
-} from '@tzurot/common-types';
+import { createLogger, TIMEOUTS, TTLCache, type LoadedPersonality } from '@tzurot/common-types';
+import { type PersonalityCacheTarget } from '@tzurot/cache-invalidation';
 import type { IPersonalityLoader } from '../types/IPersonalityLoader.js';
 import { getServiceClient } from '../utils/gatewayClients.js';
 

--- a/services/bot-client/src/services/serviceRegistry.test.ts
+++ b/services/bot-client/src/services/serviceRegistry.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import type { ChannelActivationCacheInvalidationService } from '@tzurot/common-types';
+import type { ChannelActivationCacheInvalidationService } from '@tzurot/cache-invalidation';
 import type { IPersonalityLoader } from '../types/IPersonalityLoader.js';
 import type { JobTracker } from './JobTracker.js';
 import type { WebhookManager } from '../utils/WebhookManager.js';

--- a/services/bot-client/src/services/serviceRegistry.ts
+++ b/services/bot-client/src/services/serviceRegistry.ts
@@ -10,7 +10,7 @@
  * - Import getJobTracker(), getWebhookManager(), etc. in commands
  */
 
-import type { ChannelActivationCacheInvalidationService } from '@tzurot/common-types';
+import type { ChannelActivationCacheInvalidationService } from '@tzurot/cache-invalidation';
 import type { IPersonalityLoader } from '../types/IPersonalityLoader.js';
 import type { JobTracker } from './JobTracker.js';
 import type { WebhookManager } from '../utils/WebhookManager.js';

--- a/services/bot-client/tsconfig.json
+++ b/services/bot-client/tsconfig.json
@@ -7,5 +7,9 @@
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"],
-  "references": [{ "path": "../../packages/common-types" }, { "path": "../../packages/clients" }]
+  "references": [
+    { "path": "../../packages/common-types" },
+    { "path": "../../packages/cache-invalidation" },
+    { "path": "../../packages/clients" }
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,7 @@
     { "path": "./packages/config-resolver" },
     { "path": "./packages/identity" },
     { "path": "./packages/conversation-history" },
+    { "path": "./packages/cache-invalidation" },
     { "path": "./packages/clients" },
     { "path": "./packages/test-factories" },
     { "path": "./tests" },

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -5,6 +5,7 @@ export default defineWorkspace([
   'packages/config-resolver',
   'packages/identity',
   'packages/conversation-history',
+  'packages/cache-invalidation',
   'packages/clients',
   'packages/test-factories',
   'services/ai-worker',


### PR DESCRIPTION
## What

Final extraction of the **"Slim `@tzurot/common-types`"** epic. Moves the Redis pub/sub **cache-invalidation cluster** (`BaseCacheInvalidationService` + 9 concrete invalidators + the event interfaces/validators, ~20 files) out of the shared types package into a dedicated **`@tzurot/cache-invalidation`** package.

## Shape — settled by council (GLM-5.2 / Kimi-K2.7 / Qwen-3.7, unanimous)

The Phase-2 plan sketched "split publisher→api-gateway / subscriber→ai-worker." The **topology falsified that**: the cluster is a **many-to-many mesh** — all three services both instantiate the invalidators AND `.subscribe()` for their local caches (bot-client 3, api-gateway 3 + publishes, ai-worker 6). The subscriber half can't relocate to one service.

Council verdict: it's **stateful runtime infra** (each instance owns a Redis subscriber connection), genuinely shared → a dedicated package is the right home (consistent with the prior 3 extractions; more consumers = stronger extraction case, not weaker). Leaving it in a *types* package re-fuzzes the boundary the epic exists to fix.

## Boundary specifics

- **Event contracts move WITH the cluster** — nothing outside it consumes the `InvalidationEvent` types as pure types, so no contract-stay gymnastics (cleaner than 2p-3a/b).
- **`REDIS_CHANNELS` stays** in `common-types/constants/queue.ts` (a pure constant bundled with the BullMQ queue names) — now **barrel-exported** so the package imports the cache-channel subset.
- **bot-client depends on the package** — Redis ≠ Prisma, so **no boundary ban**; but bot-client's tsconfig/Dockerfile/package.json wire it in (a first among the four extractions).
- No cycle: `cache-invalidation → common-types` one-way; common-types stays a leaf.

## Notable

- Repointed 26 consumer files (incl. the inline `import('@tzurot/common-types').X` type-assertion form) + migrated ai-worker's `cacheInvalidation.test.ts` service stubs to a `@tzurot/cache-invalidation` mock.
- Fixed a pre-existing secretlint false positive (fake Postgres connection string in `DatabaseNotificationListener.test.ts`) surfaced when the repoint staged the file — dropped the opaque `user:pass@` per repo convention.

## Verification

- Build: 13 packages green
- Units: cache-invalidation 244, common-types 2237, ai-worker 3258, api-gateway 2142, bot-client 5037
- `pnpm quality` green (lint, typecheck, typecheck:spec, knip, depcruise, cpd, backlog:lint)
- `guard:dockerfile-dist` (×3), `structure.test.ts`, grep gates — green

## Epic status

After this merges, **common-types holds only types/schemas/constants/utils** — the epic's extraction work is COMPLETE. What remains is the three follow-up sweep clusters (gated in `epic-log.md`'s close-out tracker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)