### PR TITLE
refactor(tooling): epic close-out sweep 2 — tooling/audit hygiene

### DIFF
--- a/.github/baselines/test-coverage-baseline.json
+++ b/.github/baselines/test-coverage-baseline.json
@@ -1,13 +1,10 @@
 {
-  "version": 9,
-  "lastUpdated": "2026-05-23T03:05:15.302Z",
+  "version": 10,
+  "lastUpdated": "2026-06-22T19:30:31.634Z",
   "services": {
     "detectedPrismaServices": [
-      "packages/common-types/src/services/ConversationHistoryService.ts",
-      "packages/common-types/src/services/ConversationRetentionService.ts",
-      "packages/common-types/src/services/ConversationSyncService.ts",
-      "packages/common-types/src/services/UserService.ts",
       "services/ai-worker/src/services/LongTermMemoryService.ts",
+      "services/api-gateway/src/services/ConversationRetentionService.ts",
       "services/api-gateway/src/services/LlmConfigService.ts",
       "services/api-gateway/src/services/TtsConfigService.ts"
     ],
@@ -22,9 +19,9 @@
   },
   "meta": {
     "toolVersion": "test-audit/1.0",
-    "configHash": "eef9df4af3ea",
+    "configHash": "718cedf41ddc",
     "nodeVersion": "v24.11.1",
-    "generatedFromSha": "5faa8f92bc4056b585a64ad8409ab0fb29df6942",
-    "generatedAt": "2026-05-23T03:05:15.302Z"
+    "generatedFromSha": "2fc7eeba264c3b7c949ce66aaa07540d085bc5b2",
+    "generatedAt": "2026-06-22T19:30:31.634Z"
   }
 }

--- a/packages/common-types/src/services/prisma.test.ts
+++ b/packages/common-types/src/services/prisma.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for createPrismaClient() — the post-singleton-eviction entry point.
+ *
+ * Mocks pg.Pool, the generated PrismaClient, the driver adapter, and poolConfig
+ * so we can assert the lifecycle contract without a real database: pool sizing,
+ * the dispose() order (stop the stats gauge BEFORE $disconnect so no stale
+ * interval polls a closed pool), dispose() idempotency, and construction-failure
+ * teardown (no leaked pool/interval if the client throws past gauge start).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockPool, mockPrisma, mockStopGauge, mockResolvePoolMax, mockStartGauge } = vi.hoisted(
+  () => ({
+    mockPool: { on: vi.fn(), end: vi.fn().mockResolvedValue(undefined) },
+    mockPrisma: { $disconnect: vi.fn().mockResolvedValue(undefined) },
+    mockStopGauge: vi.fn(),
+    mockResolvePoolMax: vi.fn(() => 20),
+    mockStartGauge: vi.fn(() => mockStopGauge),
+  })
+);
+
+// `new Pool()` / `new PrismaClient()` need constructor-capable mocks — a `function`
+// expression (not an arrow) so it's `new`-able and returns the mock instance.
+vi.mock('pg', () => ({
+  Pool: vi.fn(function () {
+    return mockPool;
+  }),
+}));
+vi.mock('../generated/prisma/client.js', () => ({
+  PrismaClient: vi.fn(function () {
+    return mockPrisma;
+  }),
+  Prisma: {},
+}));
+vi.mock('@prisma/adapter-pg', () => ({ PrismaPg: vi.fn() }));
+vi.mock('../utils/logger.js', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+vi.mock('../config/config.js', () => ({ getConfig: () => ({ NODE_ENV: 'test' }) }));
+vi.mock('./poolConfig.js', () => ({
+  resolvePoolMax: mockResolvePoolMax,
+  resolveConnectionTimeoutMs: vi.fn(() => 10_000),
+  resolvePoolStatsIntervalMs: vi.fn(() => 0),
+  startPoolStatsGauge: mockStartGauge,
+}));
+
+import { Pool } from 'pg';
+import { PrismaClient } from '../generated/prisma/client.js';
+import { createPrismaClient } from './prisma.js';
+
+describe('createPrismaClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResolvePoolMax.mockReturnValue(20);
+    mockStartGauge.mockReturnValue(mockStopGauge);
+  });
+
+  it('sizes the pool from resolvePoolMax() by default', () => {
+    createPrismaClient();
+    expect(Pool).toHaveBeenCalledWith(expect.objectContaining({ max: 20 }));
+  });
+
+  it('uses an explicit max override over resolvePoolMax()', () => {
+    createPrismaClient({ max: 5 });
+    expect(mockResolvePoolMax).not.toHaveBeenCalled();
+    expect(Pool).toHaveBeenCalledWith(expect.objectContaining({ max: 5 }));
+  });
+
+  it('dispose() stops the stats gauge BEFORE disconnecting', async () => {
+    const { dispose } = createPrismaClient();
+    await dispose();
+
+    expect(mockStopGauge).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.$disconnect).toHaveBeenCalledTimes(1);
+    // Order matters: a gauge polling a $disconnect-ed pool would throw.
+    expect(mockStopGauge.mock.invocationCallOrder[0]).toBeLessThan(
+      mockPrisma.$disconnect.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('dispose() is idempotent — a double call disconnects only once', async () => {
+    const { dispose } = createPrismaClient();
+    await dispose();
+    await dispose();
+
+    expect(mockPrisma.$disconnect).toHaveBeenCalledTimes(1);
+    expect(mockStopGauge).toHaveBeenCalledTimes(1);
+  });
+
+  it('tears down the pool + gauge and rethrows if PrismaClient construction throws', () => {
+    vi.mocked(PrismaClient).mockImplementationOnce(function () {
+      throw new Error('client construction failed');
+    });
+
+    expect(() => createPrismaClient()).toThrow('client construction failed');
+    // No leaked interval or pool connections — both torn down before rethrow.
+    expect(mockStopGauge).toHaveBeenCalledTimes(1);
+    expect(mockPool.end).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/tooling/src/db/check-migration-drift.test.ts
+++ b/packages/tooling/src/db/check-migration-drift.test.ts
@@ -3,7 +3,7 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import { createPrismaClient } from '@tzurot/common-types';
 
-const mockDispose = vi.fn();
+const mockDispose = vi.fn().mockResolvedValue(undefined);
 
 // Mock common-types
 vi.mock('@tzurot/common-types', () => ({

--- a/packages/tooling/src/db/check-migration-drift.ts
+++ b/packages/tooling/src/db/check-migration-drift.ts
@@ -92,6 +92,6 @@ export async function checkMigrationDrift(options: CheckDriftOptions = {}): Prom
       console.log(chalk.cyan(`  pnpm ops db:fix-drift ${driftedMigrations.join(' ')}`));
     }
   } finally {
-    await dispose();
+    await dispose().catch(() => undefined);
   }
 }

--- a/packages/tooling/src/db/fix-migration-drift.test.ts
+++ b/packages/tooling/src/db/fix-migration-drift.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import { createPrismaClient } from '@tzurot/common-types';
 
-const mockDispose = vi.fn();
+const mockDispose = vi.fn().mockResolvedValue(undefined);
 
 // Mock common-types
 vi.mock('@tzurot/common-types', () => ({

--- a/packages/tooling/src/db/fix-migration-drift.ts
+++ b/packages/tooling/src/db/fix-migration-drift.ts
@@ -93,6 +93,6 @@ export async function fixMigrationDrift(
 
     console.log(chalk.green('Done!') + ' Run `npx prisma migrate status` to verify.');
   } finally {
-    await dispose();
+    await dispose().catch(() => undefined);
   }
 }

--- a/packages/tooling/src/db/inspect-database.test.ts
+++ b/packages/tooling/src/db/inspect-database.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createPrismaClient } from '@tzurot/common-types';
 
-const mockDispose = vi.fn();
+const mockDispose = vi.fn().mockResolvedValue(undefined);
 
 // Mock common-types before importing
 vi.mock('@tzurot/common-types', () => ({

--- a/packages/tooling/src/db/inspect-database.ts
+++ b/packages/tooling/src/db/inspect-database.ts
@@ -276,6 +276,6 @@ export async function inspectDatabase(options: InspectOptions = {}): Promise<voi
     console.log(chalk.dim('   pnpm ops db:inspect --indexes       Show only indexes'));
     console.log('');
   } finally {
-    await dispose();
+    await dispose().catch(() => undefined);
   }
 }

--- a/packages/tooling/src/db/migration-status.test.ts
+++ b/packages/tooling/src/db/migration-status.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import { createPrismaClient } from '@tzurot/common-types';
 
-const mockDispose = vi.fn();
+const mockDispose = vi.fn().mockResolvedValue(undefined);
 
 // Mock common-types
 vi.mock('@tzurot/common-types', () => ({

--- a/packages/tooling/src/db/migration-status.ts
+++ b/packages/tooling/src/db/migration-status.ts
@@ -117,7 +117,7 @@ async function showStatusDirect(migrationsPath: string): Promise<void> {
 
     console.log('\n' + '═'.repeat(60));
   } finally {
-    await dispose();
+    await dispose().catch(() => undefined);
   }
 }
 

--- a/packages/tooling/src/dev/check-boundaries.test.ts
+++ b/packages/tooling/src/dev/check-boundaries.test.ts
@@ -19,7 +19,10 @@ vi.mock('node:fs', () => ({
 }));
 
 import { readFileSync, readdirSync, statSync } from 'node:fs';
-import { checkBoundaries } from './check-boundaries.js';
+import {
+  checkBoundaries,
+  BOT_CLIENT_BANNED_COMMON_TYPES_PRISMA_SYMBOLS,
+} from './check-boundaries.js';
 
 describe('checkBoundaries', () => {
   let consoleLogSpy: MockInstance;
@@ -136,7 +139,7 @@ const prisma = new PrismaClient();
         typeof statSync
       >);
       vi.mocked(readFileSync).mockReturnValue(
-        `import { getPrismaClient } from '@tzurot/common-types';`
+        `import { PrismaClient } from '@tzurot/common-types';`
       );
 
       await checkBoundaries();
@@ -169,7 +172,7 @@ const prisma = new PrismaClient();
 
     it('should detect a Prisma-backed symbol in a MULTI-LINE common-types import', async () => {
       // Regression guard: the old line-by-line scan skipped any line without the
-      // `import` keyword, so `getPrismaClient,` on its own line was invisible.
+      // `import` keyword, so `createPrismaClient,` on its own line was invisible.
       vi.mocked(readdirSync).mockImplementation(((dir: unknown) =>
         String(dir).includes('bot-client/src') ? ['test.ts'] : []) as typeof readdirSync);
       vi.mocked(statSync).mockReturnValue({ isDirectory: () => false } as ReturnType<
@@ -179,7 +182,7 @@ const prisma = new PrismaClient();
         [
           'import {',
           '  createLogger,',
-          '  getPrismaClient,',
+          '  createPrismaClient,',
           "} from '@tzurot/common-types';",
         ].join('\n')
       );
@@ -301,7 +304,7 @@ import { PersonalityConfig } from '@tzurot/common-types';
         typeof statSync
       >);
       vi.mocked(readFileSync).mockReturnValue(
-        `import { getPrismaClient } from './utils/localShim.js';`
+        `import { createPrismaClient } from './utils/localShim.js';`
       );
 
       await checkBoundaries();
@@ -382,5 +385,17 @@ import { formatMessage } from './utils/formatter.js';
       const output = consoleLogSpy.mock.calls.flat().join(' ');
       expect(output).toContain('Checking');
     });
+  });
+});
+
+describe('bot-client Prisma-symbol allowlist (drift guard)', () => {
+  it('every banned common-types Prisma symbol is still a real @tzurot/common-types export', async () => {
+    const commonTypes = await import('@tzurot/common-types');
+    for (const symbol of BOT_CLIENT_BANNED_COMMON_TYPES_PRISMA_SYMBOLS) {
+      expect(
+        symbol in commonTypes,
+        `"${symbol}" is in check-boundaries' bot-client ban list but is no longer exported from @tzurot/common-types — prune it from BOT_CLIENT_BANNED_COMMON_TYPES_PRISMA_SYMBOLS (the symbol was renamed, deleted, or moved to a dedicated package with its own depcruise ban).`
+      ).toBe(true);
+    }
   });
 });

--- a/packages/tooling/src/dev/check-boundaries.test.ts
+++ b/packages/tooling/src/dev/check-boundaries.test.ts
@@ -1,4 +1,13 @@
-import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  type MockInstance,
+} from 'vitest';
 
 // Mock chalk
 vi.mock('chalk', () => ({
@@ -389,8 +398,18 @@ import { formatMessage } from './utils/formatter.js';
 });
 
 describe('bot-client Prisma-symbol allowlist (drift guard)', () => {
-  it('every banned common-types Prisma symbol is still a real @tzurot/common-types export', async () => {
-    const commonTypes = await import('@tzurot/common-types');
+  // Loading the full @tzurot/common-types barrel pulls in the generated Prisma
+  // client, which is heavy to transform+load the first time. Done once in
+  // beforeAll (with a generous hook timeout) so the import cost lands in setup,
+  // not under the 5s per-test budget: when every package's vitest runs at once
+  // under concurrent CI load, the first-time barrel load can exceed the default
+  // test timeout even though the assertion itself is instant.
+  let commonTypes: typeof import('@tzurot/common-types');
+  beforeAll(async () => {
+    commonTypes = await import('@tzurot/common-types');
+  }, 30_000);
+
+  it('every banned common-types Prisma symbol is still a real @tzurot/common-types export', () => {
     for (const symbol of BOT_CLIENT_BANNED_COMMON_TYPES_PRISMA_SYMBOLS) {
       expect(
         symbol in commonTypes,

--- a/packages/tooling/src/dev/check-boundaries.ts
+++ b/packages/tooling/src/dev/check-boundaries.ts
@@ -28,6 +28,26 @@ interface Violation {
 }
 
 // Define boundary rules
+/**
+ * Prisma CLIENT symbols that still live in `@tzurot/common-types` and must not be
+ * imported by bot-client (they reach the database). The former Prisma-backed
+ * SERVICES (PersonaResolver, PersonalityService, ConversationHistoryService, the
+ * cache invalidators) were extracted to dedicated packages — each carries its own
+ * `bot-client → package` depcruise ban — and getPrismaClient/disconnectPrisma were
+ * deleted. Exported so the drift test in check-boundaries.test.ts asserts every
+ * entry is a real common-types export; a stale entry (a symbol that's since been
+ * renamed/deleted/moved) then fails CI instead of silently no-op-matching.
+ */
+export const BOT_CLIENT_BANNED_COMMON_TYPES_PRISMA_SYMBOLS = [
+  'createPrismaClient',
+  'PrismaClient',
+  'Prisma',
+] as const;
+
+const BOT_CLIENT_PRISMA_SYMBOL_PATTERN = new RegExp(
+  `\\b(${BOT_CLIENT_BANNED_COMMON_TYPES_PRISMA_SYMBOLS.join('|')})\\b[\\s\\S]*?from\\s+['"]@tzurot/common-types['"]`
+);
+
 const BOUNDARY_RULES: {
   service: string;
   forbiddenImports: { pattern: RegExp; reason: string; severity: 'error' | 'warning' }[];
@@ -44,12 +64,9 @@ const BOUNDARY_RULES: {
         // Prisma reaches bot-client via re-exports from the @tzurot/common-types
         // barrel, not a direct @prisma/client import — depcruise (module-path
         // matching) can't see the barrel re-export, so this symbol-level rule is
-        // the enforcement. Matches a forbidden DB-layer symbol in the same
-        // statement as a common-types `from`; every symbol in the alternation
-        // has a Prisma dependency chain. Keep the alternation in sync: add the
-        // export name of any new Prisma-backed @tzurot/common-types service here.
-        pattern:
-          /\b(getPrismaClient|createPrismaClient|disconnectPrisma|PrismaClient|PersonaResolver|PersonalityService|ConversationHistoryService|PersonaCacheInvalidationService|Prisma)\b[\s\S]*?from\s+['"]@tzurot\/common-types['"]/,
+        // the enforcement. Banned symbols + rationale live on
+        // BOT_CLIENT_BANNED_COMMON_TYPES_PRISMA_SYMBOLS above (drift-tested).
+        pattern: BOT_CLIENT_PRISMA_SYMBOL_PATTERN,
         reason:
           'bot-client must not import Prisma-backed code from @tzurot/common-types - these reach the database; use the gateway HTTP API (HttpPersonalityLoader, routing-context)',
         severity: 'error',

--- a/packages/tooling/src/inspect/tts-configs.ts
+++ b/packages/tooling/src/inspect/tts-configs.ts
@@ -98,7 +98,7 @@ async function main() {
       console.warn('⚠️  Result may be truncated at the ' + ${takeLimit} + '-row take limit — re-run with a higher limit if you need to see all rows');
     }
   } finally {
-    await dispose();
+    await dispose().catch(() => undefined);
   }
 }
 

--- a/packages/tooling/src/test/audit-utils.ts
+++ b/packages/tooling/src/test/audit-utils.ts
@@ -151,7 +151,7 @@ export function isReExportFile(filePath: string): boolean {
 const PRISMA_PATTERNS = [
   /from\s+['"]@prisma\/client['"]/, // import from @prisma/client
   /from\s+['"]\..*prisma['"]/i, // import from local prisma
-  /getPrismaClient\s*\(/, // getPrismaClient() call
+  /createPrismaClient\s*\(/, // createPrismaClient() factory (post-singleton-eviction entry point)
   /new\s+PrismaClient\s*\(/, // new PrismaClient()
   /this\.prisma\./, // this.prisma.* usage
   /prisma\.\w+\.(findMany|findUnique|findFirst|create|update|delete|upsert|count|aggregate)/,

--- a/packages/tooling/src/test/audit-version.ts
+++ b/packages/tooling/src/test/audit-version.ts
@@ -13,5 +13,8 @@
  * History:
  *   v1 — initial (Prisma auto-detection + `*.service.ts` glob +
  *        Zod schema enumeration).
+ *   v2 — PRISMA_PATTERNS: replaced the dead `getPrismaClient(` matcher
+ *        (deleted in the singleton eviction) with `createPrismaClient(`,
+ *        the post-eviction Prisma entry point.
  */
-export const TEST_AUDIT_IMPL_VERSION = 1;
+export const TEST_AUDIT_IMPL_VERSION = 2;

--- a/packages/tooling/src/voice/audit-references.ts
+++ b/packages/tooling/src/voice/audit-references.ts
@@ -253,7 +253,7 @@ export async function auditReferences(options: AuditReferencesOptions = {}): Pro
       }
     }
   } finally {
-    await dispose();
+    await dispose().catch(() => undefined);
     // rm with recursive+force handles the case where any per-probe unlink
     // silently failed and left a file behind (rmdir would fail in that case).
     await rm(tmpDir, { recursive: true, force: true }).catch(() => {


### PR DESCRIPTION
Second batch of the "Slim common-types" epic close-out sweep — completes **Cluster A** (all 8 PR-2p follow-ups). Four tooling/audit items:

- **`createPrismaClient()` unit test** (`common-types/services/prisma.test.ts`) — the post-eviction Prisma entry point was only covered indirectly. Asserts pool sizing (default vs `{ max }` override), the `dispose()` order (stop the stats gauge **before** `$disconnect`), idempotency, and construction-failure teardown (no leaked pool/interval).
- **`guard:boundaries` allowlist prune + drift backstop** — the bot-client Prisma-symbol ban listed 6 now-moved/deleted symbols (`getPrismaClient`/`disconnectPrisma` deleted; the 4 services moved to dedicated packages, each with its own `bot-client→package` depcruise ban). Pruned to `createPrismaClient`/`PrismaClient`/`Prisma`, extracted to an exported const, + a **drift test** asserting every entry is a real common-types export (so a future stale entry fails CI).
- **`PRISMA_PATTERNS` refresh** — replaced the dead `getPrismaClient(` matcher with `createPrismaClient(`; bumped `TEST_AUDIT_IMPL_VERSION` 1→2 and refreshed the baseline (which also dropped stale `knownGaps` for the now-extracted services).
- **`dispose()` error-handling alignment** — the 6 tooling db commands wrap `finally { await dispose() }` in `.catch(() => undefined)` (matching `create-safe-migration`) so a disposer throw can't mask the original error; test mocks return a resolved promise.

## Verification
- Build (13 pkgs), `pnpm quality` (lint/knip/depcruise/typecheck/cpd/backlog:lint/test:audit) — green
- tooling 1096, common-types 2242 — green

Closes Cluster A of the epic close-out (tracker in `backlog/cold/epic-log.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)