### PR TITLE
refactor(bot-client): remove dead extended-context assembly (Cluster B1)

### DIFF
--- a/services/bot-client/src/services/MessageContextBuilder.ts
+++ b/services/bot-client/src/services/MessageContextBuilder.ts
@@ -8,7 +8,6 @@
 import {
   type LoadedPersonality,
   type ConversationMessage,
-  type AttachmentMetadata,
   createLogger,
   MESSAGE_LIMITS,
   isTypingChannel,
@@ -60,16 +59,9 @@ interface ContextBuildResult {
   messageContent: string;
 }
 
-type ParticipantGuildInfo = Record<
-  string,
-  { roles: string[]; displayColor?: string; joinedAt?: string }
->;
-
 /** Result of fetching extended context from Discord */
 interface ExtendedContextResult {
   history: ConversationMessage[];
-  attachments?: AttachmentMetadata[];
-  participantGuildInfo?: ParticipantGuildInfo;
   /**
    * Raw-envelope snapshot (present only when CONTEXT_RAW_ENVELOPE=true):
    * the Discord-fetched messages BEFORE persona-ID resolution mutates them
@@ -154,8 +146,6 @@ export class MessageContextBuilder {
   ): Promise<ExtendedContextResult> {
     const { message, personality, history, contextEpoch, options } = params;
     let mergedHistory = history;
-    let attachments: AttachmentMetadata[] | undefined;
-    let participantGuildInfo: ExtendedContextResult['participantGuildInfo'];
 
     if (options.extendedContext === undefined || options.botUserId === undefined) {
       return { history: mergedHistory };
@@ -208,10 +198,10 @@ export class MessageContextBuilder {
 
     // Extended-context users/reactors are NOT provisioned or persona-resolved
     // here — the worker re-runs the batch upsert + persona remap from the raw
-    // snapshot (ContextAssembler.mergeExtendedContext), and it overwrites the
-    // shipped participantGuildInfo with its own re-keyed version (ContextStep).
-    // bot-client's local merged history keeps the raw author placeholders; only
-    // message ids + timestamps feed the reference-dedup that still reads it.
+    // snapshot (ContextAssembler.mergeExtendedContext) and re-derives guild info +
+    // image attachments from it, so bot-client ships neither. bot-client's local
+    // merged history keeps the raw author placeholders; only message ids +
+    // timestamps feed the reference-dedup that still reads it.
 
     if (fetchResult.messages.length === 0) {
       return { history: mergedHistory, raw: rawSnapshot };
@@ -230,33 +220,6 @@ export class MessageContextBuilder {
       'Extended context merged with conversation history'
     );
 
-    // Collect image attachments
-    const maxImages = options.extendedContext.maxImages ?? 0;
-    if (maxImages > 0 && fetchResult.imageAttachments && fetchResult.imageAttachments.length > 0) {
-      attachments = fetchResult.imageAttachments.slice(-maxImages);
-      logger.debug(
-        {
-          channelId: message.channel.id,
-          availableImages: fetchResult.imageAttachments.length,
-          maxImages,
-          selectedImages: attachments.length,
-        },
-        'Collected extended context images for processing'
-      );
-    }
-
-    // Capture participant guild info
-    if (fetchResult.participantGuildInfo) {
-      participantGuildInfo = fetchResult.participantGuildInfo;
-      logger.debug(
-        {
-          channelId: message.channel.id,
-          participantCount: Object.keys(participantGuildInfo).length,
-        },
-        'Collected participant guild info from extended context'
-      );
-    }
-
     // Opportunistic sync (fire and forget)
     // This is idempotent and safe for concurrent execution:
     // - Only updates EXISTING messages (no creates = no duplicate writes)
@@ -273,7 +236,7 @@ export class MessageContextBuilder {
         });
     }
 
-    return { history: mergedHistory, attachments, participantGuildInfo, raw: rawSnapshot };
+    return { history: mergedHistory, raw: rawSnapshot };
   }
 
   /** Extract referenced messages and resolve mentions - delegates to ReferenceExtractor */


### PR DESCRIPTION
## What

`MessageContextBuilder.fetchExtendedContext` computed and returned `attachments` (the `slice(-maxImages)` image list) and `participantGuildInfo` (the resolved guild map), but **`buildContext` never read either** off the result.

Exhaustively verified: the only `ExtendedContextResult` reads in the file are `.history` (line 360) and `.raw` (line 391). Everything at lines 175–234 is `options.extendedContext` (the *input* options), not the result.

Since PR 3b made the thin envelope unconditional, the worker re-derives both server-side from the raw envelope (`rawExtendedContextImageAttachments` uncapped + `rawParticipantGuildInfo` pre-resolution via `ContextAssembler.mergeExtendedContext`), so bot-client ships neither.

## Removed
- The two `ExtendedContextResult` fields (`attachments?`, `participantGuildInfo?`)
- The local vars + the image-collection (`slice(-maxImages)`) and guild-info-capture blocks
- The now-unused `AttachmentMetadata` import + local `ParticipantGuildInfo` type
- Updated the comment to reflect that the worker re-derives guild info + images (not "overwrites a shipped value")

## Untouched (verified)
- The **live** attachments path — `result.context.attachments` comes from `buildMessageContent` (trigger-message attachments), not extended context
- The raw snapshot (`.raw`) and merged history (`.history`)

## Verification
- `tsc --noEmit` clean (no consumer reads the removed fields)
- `MessageContextBuilder.test.ts` green (25/25); `participantGuildInfo`-undefined assertion still holds (it was never consumed)
- `pnpm quality` green

## Scope note
The sibling Cluster-B items — the vestigial `MessageContext.conversationHistory` wire field and the dead `mockUserService`/`mockHistoryService` test setups — stay tracked in `backlog/cold/epic-log.md`. They're a wire-shape change (touches `RequestContext` + the worker's logging reads) best done together, not folded into a dead-code removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)