### PR TITLE
fix(bot-client): stop transcribing videos — extract shared isVoiceAttachment predicate

### DIFF
--- a/services/bot-client/src/services/VoiceTranscriptionService.test.ts
+++ b/services/bot-client/src/services/VoiceTranscriptionService.test.ts
@@ -55,12 +55,12 @@ describe('VoiceTranscriptionService', () => {
   });
 
   describe('hasVoiceAttachment', () => {
-    it('should detect voice attachment by audio content type', () => {
+    it('detects a voice message (audio content-type AND duration)', () => {
       const message = createMockMessage({
         attachments: [
           {
             contentType: 'audio/ogg',
-            duration: null,
+            duration: 5.2,
           },
         ],
       });
@@ -68,7 +68,9 @@ describe('VoiceTranscriptionService', () => {
       expect(service.hasVoiceAttachment(message)).toBe(true);
     });
 
-    it('should detect voice attachment by duration property', () => {
+    it('does NOT treat a duration on a non-audio attachment as voice (guards against video)', () => {
+      // A duration alone is not enough — a non-audio attachment that happens to
+      // carry a duration (video, binary) is not a voice message.
       const message = createMockMessage({
         attachments: [
           {
@@ -78,7 +80,23 @@ describe('VoiceTranscriptionService', () => {
         ],
       });
 
-      expect(service.hasVoiceAttachment(message)).toBe(true);
+      expect(service.hasVoiceAttachment(message)).toBe(false);
+    });
+
+    it('does NOT transcribe a video attachment despite its duration (the MP4 false-positive)', () => {
+      // Regression: a directly-uploaded MP4 (video/mp4 + duration) was treated as
+      // a voice message because the gate used `audio/* OR duration`; the bot then
+      // replied "Sorry, I couldn't transcribe that voice message." on videos.
+      const message = createMockMessage({
+        attachments: [
+          {
+            contentType: 'video/mp4',
+            duration: 30,
+          },
+        ],
+      });
+
+      expect(service.hasVoiceAttachment(message)).toBe(false);
     });
 
     it('should return false for non-voice attachments', () => {

--- a/services/bot-client/src/services/VoiceTranscriptionService.test.ts
+++ b/services/bot-client/src/services/VoiceTranscriptionService.test.ts
@@ -55,7 +55,7 @@ describe('VoiceTranscriptionService', () => {
   });
 
   describe('hasVoiceAttachment', () => {
-    it('detects a voice message (audio content-type AND duration)', () => {
+    it('detects a voice message (audio content-type + duration)', () => {
       const message = createMockMessage({
         attachments: [
           {
@@ -84,9 +84,8 @@ describe('VoiceTranscriptionService', () => {
     });
 
     it('does NOT transcribe a video attachment despite its duration (the MP4 false-positive)', () => {
-      // Regression: a directly-uploaded MP4 (video/mp4 + duration) was treated as
-      // a voice message because the gate used `audio/* OR duration`; the bot then
-      // replied "Sorry, I couldn't transcribe that voice message." on videos.
+      // A video carries a duration but a video/* content-type, so it must not be
+      // treated as a voice message — the gate requires audio content-type AND duration.
       const message = createMockMessage({
         attachments: [
           {
@@ -139,7 +138,7 @@ describe('VoiceTranscriptionService', () => {
       expect(service.hasVoiceAttachment(message)).toBe(true);
     });
 
-    it('should detect voice attachment in snapshot by duration', () => {
+    it('does NOT treat a forwarded duration-only (non-audio) snapshot attachment as voice', () => {
       const message = createMockMessage({
         attachments: [],
         messageSnapshots: [
@@ -157,7 +156,28 @@ describe('VoiceTranscriptionService', () => {
         ],
       });
 
-      expect(service.hasVoiceAttachment(message)).toBe(true);
+      expect(service.hasVoiceAttachment(message)).toBe(false);
+    });
+
+    it('does NOT treat a forwarded video snapshot attachment as voice (MP4 false-positive)', () => {
+      const message = createMockMessage({
+        attachments: [],
+        messageSnapshots: [
+          {
+            attachments: [
+              {
+                url: 'https://cdn.discord.com/video/forwarded.mp4',
+                contentType: 'video/mp4',
+                name: 'clip.mp4',
+                size: 500000,
+                duration: 30.0,
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(service.hasVoiceAttachment(message)).toBe(false);
     });
 
     it('should return false when forwarded snapshot has no audio', () => {

--- a/services/bot-client/src/services/VoiceTranscriptionService.ts
+++ b/services/bot-client/src/services/VoiceTranscriptionService.ts
@@ -19,6 +19,7 @@ import {
 } from '@tzurot/common-types';
 import { voiceTranscriptCache } from '../redis.js';
 import { hasForwardedSnapshots, getSnapshots } from '../utils/forwardedMessageUtils.js';
+import { isVoiceAttachment } from '../utils/voiceAttachment.js';
 import { sendTypingIndicator } from '../utils/typingErrorClassifier.js';
 import { classifyBotAudio } from '../utils/botAudioClassifier.js';
 
@@ -118,9 +119,7 @@ function extractAudioFromSnapshot(snapshot: {
   }
 
   return Array.from(snapshot.attachments.values())
-    .filter(
-      a => (a.contentType?.startsWith(CONTENT_TYPES.AUDIO_PREFIX) ?? false) || a.duration !== null
-    )
+    .filter(isVoiceAttachment)
     .map(attachment => ({
       url: attachment.url,
       originalUrl: attachment.url,
@@ -132,7 +131,10 @@ function extractAudioFromSnapshot(snapshot: {
           : CONTENT_TYPES.BINARY,
       name: attachment.name,
       size: attachment.size,
-      isVoiceMessage: attachment.duration !== null,
+      // Always true here (these attachments already passed the isVoiceAttachment
+      // filter above) — routed through the shared predicate so no duration-only
+      // copy of the heuristic survives to drift.
+      isVoiceMessage: isVoiceAttachment(attachment),
       duration: attachment.duration ?? undefined,
       waveform: attachment.waveform ?? undefined,
     }));
@@ -155,9 +157,7 @@ function snapshotHasAudio(snapshot: {
     return false;
   }
 
-  return Array.from(snapshot.attachments.values()).some(
-    a => (a.contentType?.startsWith(CONTENT_TYPES.AUDIO_PREFIX) ?? false) || a.duration !== null
-  );
+  return Array.from(snapshot.attachments.values()).some(isVoiceAttachment);
 }
 
 /**
@@ -199,14 +199,8 @@ export class VoiceTranscriptionService {
    * Uses centralized utilities from forwardedMessageUtils.ts for consistent forwarded message handling.
    */
   hasVoiceAttachment(message: Message): boolean {
-    // Check direct attachments. A Discord voice message has an audio content-type
-    // AND a duration — require BOTH (matching hasVoiceAttachments /
-    // hasForwardedVoiceAttachment in forwardedMessageUtils). The previous `||`
-    // false-positived on video attachments (MP4, GIF), which also carry a
-    // `duration`, so the bot tried to transcribe videos and apologized.
-    const hasDirectAudio = message.attachments.some(
-      a => (a.contentType?.startsWith(CONTENT_TYPES.AUDIO_PREFIX) ?? false) && a.duration !== null
-    );
+    // Direct attachments (forwarded snapshots handled below).
+    const hasDirectAudio = message.attachments.some(isVoiceAttachment);
 
     if (hasDirectAudio) {
       return true;

--- a/services/bot-client/src/services/VoiceTranscriptionService.ts
+++ b/services/bot-client/src/services/VoiceTranscriptionService.ts
@@ -199,9 +199,13 @@ export class VoiceTranscriptionService {
    * Uses centralized utilities from forwardedMessageUtils.ts for consistent forwarded message handling.
    */
   hasVoiceAttachment(message: Message): boolean {
-    // Check direct attachments
+    // Check direct attachments. A Discord voice message has an audio content-type
+    // AND a duration — require BOTH (matching hasVoiceAttachments /
+    // hasForwardedVoiceAttachment in forwardedMessageUtils). The previous `||`
+    // false-positived on video attachments (MP4, GIF), which also carry a
+    // `duration`, so the bot tried to transcribe videos and apologized.
     const hasDirectAudio = message.attachments.some(
-      a => (a.contentType?.startsWith(CONTENT_TYPES.AUDIO_PREFIX) ?? false) || a.duration !== null
+      a => (a.contentType?.startsWith(CONTENT_TYPES.AUDIO_PREFIX) ?? false) && a.duration !== null
     );
 
     if (hasDirectAudio) {

--- a/services/bot-client/src/services/contextBuilder/ReferenceExtractor.ts
+++ b/services/bot-client/src/services/contextBuilder/ReferenceExtractor.ts
@@ -9,7 +9,6 @@ import type { Message } from 'discord.js';
 import {
   createLogger,
   MessageRole,
-  CONTENT_TYPES,
   INTERVALS,
   type ReferencedMessage,
   type ConversationMessage,
@@ -17,6 +16,7 @@ import {
   type RawMentionedRole,
 } from '@tzurot/common-types';
 import { MessageReferenceExtractor } from '../../handlers/MessageReferenceExtractor.js';
+import { isVoiceAttachment } from '../../utils/voiceAttachment.js';
 import type { MentionResolver } from '../MentionResolver.js';
 
 const logger = createLogger('MessageContextBuilder');
@@ -121,11 +121,7 @@ function logVoiceReplyDiagnostics(
   content: string,
   history: ConversationMessage[]
 ): void {
-  const hasVoiceAttachment = message.attachments.some(
-    a =>
-      (a.contentType?.startsWith(CONTENT_TYPES.AUDIO_PREFIX) ?? false) ||
-      (a.duration !== null && a.duration !== undefined)
-  );
+  const hasVoiceAttachment = message.attachments.some(isVoiceAttachment);
   if (!hasVoiceAttachment) {
     return;
   }

--- a/services/bot-client/src/utils/attachmentExtractor.test.ts
+++ b/services/bot-client/src/utils/attachmentExtractor.test.ts
@@ -177,6 +177,36 @@ describe('extractAttachments', () => {
       expect(result![0].duration).toBeUndefined();
     });
 
+    it('should NOT mark a video as a voice message even when it carries a duration', () => {
+      // A video carries a duration but a video/* content-type, so isVoiceMessage must
+      // be false — duration alone is not a sufficient signal for a voice message.
+      const video = createMockAttachment('vid', {
+        contentType: 'video/mp4',
+        name: 'clip.mp4',
+        duration: 30,
+      });
+      const collection = createAttachmentCollection([video]);
+
+      const result = extractAttachments(collection);
+
+      expect(result![0].isVoiceMessage).toBe(false);
+    });
+
+    it('should fall back to duration when content-type is absent', () => {
+      // Discord omits content-type on some forwarded voice snapshots; the raw
+      // attachment is passed to isVoiceAttachment so the duration fallback still fires.
+      const voiceNoType = createMockAttachment('vmsg', {
+        contentType: null,
+        name: 'voice-message.ogg',
+        duration: 4.2,
+      });
+      const collection = createAttachmentCollection([voiceNoType]);
+
+      const result = extractAttachments(collection);
+
+      expect(result![0].isVoiceMessage).toBe(true);
+    });
+
     it('should set duration to undefined when null', () => {
       const attachment = createMockAttachment('123', { duration: null });
       const collection = createAttachmentCollection([attachment]);

--- a/services/bot-client/src/utils/attachmentExtractor.ts
+++ b/services/bot-client/src/utils/attachmentExtractor.ts
@@ -7,6 +7,7 @@
 
 import { Collection, Snowflake, Attachment } from 'discord.js';
 import { type AttachmentMetadata, CONTENT_TYPES } from '@tzurot/common-types';
+import { isVoiceAttachment } from './voiceAttachment.js';
 
 /**
  * Extract attachment metadata from a Discord message's attachments collection
@@ -29,8 +30,11 @@ export function extractAttachments(
     contentType: attachment.contentType ?? CONTENT_TYPES.BINARY,
     name: attachment.name,
     size: attachment.size,
-    // Discord.js v14 voice message metadata
-    isVoiceMessage: attachment.duration !== null,
+    // Discord.js v14 voice message metadata. Pass the RAW attachment (its
+    // contentType is still `string | null` here) so a genuine voice message with
+    // an omitted content-type hits isVoiceAttachment's duration fallback, while a
+    // video (which carries a duration but a `video/*` content-type) is rejected.
+    isVoiceMessage: isVoiceAttachment(attachment),
     duration: attachment.duration ?? undefined,
     waveform: attachment.waveform ?? undefined,
   }));

--- a/services/bot-client/src/utils/forwardedMessageUtils.test.ts
+++ b/services/bot-client/src/utils/forwardedMessageUtils.test.ts
@@ -33,7 +33,7 @@ function createMockMessage(options: {
     content?: string;
     attachments?: Array<{
       url: string;
-      contentType?: string;
+      contentType?: string | null;
       name?: string;
       size?: number;
       duration?: number;
@@ -79,7 +79,10 @@ function createMockMessage(options: {
         snap.attachments.forEach((att, attIndex) => {
           snapAttachments.set(`snap-att-${attIndex}`, {
             url: att.url,
-            contentType: att.contentType ?? 'application/octet-stream',
+            // Preserve an explicit null (Discord omits content-type on some
+            // forwarded snapshots) so the real extractAttachments normalization is
+            // exercised; default only when the key is absent.
+            contentType: 'contentType' in att ? att.contentType : 'application/octet-stream',
             name: att.name ?? `snap-file-${attIndex}`,
             size: att.size ?? 1000,
             duration: att.duration ?? null,
@@ -500,6 +503,29 @@ describe('forwardedMessageUtils', () => {
       });
 
       expect(hasForwardedVoiceAttachment(message)).toBe(false);
+    });
+
+    it('should detect a forwarded voice snapshot when Discord omits the content-type', () => {
+      // Reads the precomputed isVoiceMessage flag (set on the RAW attachment before
+      // extractAttachments normalizes null → octet-stream), so the duration fallback
+      // still applies. Calling isVoiceAttachment on the normalized metadata would
+      // miss this case.
+      const message = createMockMessage({
+        referenceType: MessageReferenceType.Forward,
+        snapshots: [
+          {
+            attachments: [
+              {
+                url: 'https://cdn.discord.com/voice/forwarded.ogg',
+                contentType: null,
+                duration: 6.5,
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(hasForwardedVoiceAttachment(message)).toBe(true);
     });
 
     it('should return false when forwarded message has no voice attachments', () => {

--- a/services/bot-client/src/utils/forwardedMessageUtils.ts
+++ b/services/bot-client/src/utils/forwardedMessageUtils.ts
@@ -28,6 +28,7 @@ import {
 import { type AttachmentMetadata } from '@tzurot/common-types';
 import { extractAttachments } from './attachmentExtractor.js';
 import { extractEmbedImages } from './embedImageExtractor.js';
+import { isVoiceAttachment } from './voiceAttachment.js';
 
 /**
  * Content extracted from a forwarded message or its snapshots
@@ -295,9 +296,13 @@ export function hasForwardedContent(message: Message): boolean {
 /**
  * Check if a forwarded message contains voice message attachments.
  *
- * Voice messages in forwarded content are detected by:
- * - contentType starting with 'audio/'
- * - duration property being present
+ * Reads the precomputed `AttachmentMetadata.isVoiceMessage` flag rather than
+ * re-running {@link isVoiceAttachment} here: `extractAllForwardedContent` →
+ * `extractAttachments` already evaluated the predicate against the RAW attachment
+ * (before normalizing a null content-type to `application/octet-stream`), so the
+ * flag preserves the duration fallback for content-type-absent voice snapshots.
+ * Calling `isVoiceAttachment` on the already-normalized metadata here would lose
+ * that fallback and disagree with the flag on the very same object.
  *
  * @param message - Discord message (should be a forwarded message)
  * @returns true if the forwarded message contains voice attachments
@@ -308,13 +313,7 @@ export function hasForwardedVoiceAttachment(message: Message): boolean {
   }
 
   const { attachments } = extractAllForwardedContent(message);
-
-  // Require audio contentType AND duration to avoid false positives from video attachments.
-  // Don't rely on isVoiceMessage alone — extractAttachments sets it based on duration !== null,
-  // which is also true for video attachments.
-  return attachments.some(
-    a => a.contentType?.startsWith('audio/') === true && a.duration !== undefined
-  );
+  return attachments.some(a => a.isVoiceMessage === true);
 }
 
 /**
@@ -322,12 +321,7 @@ export function hasForwardedVoiceAttachment(message: Message): boolean {
  * or within forwarded message snapshots.
  */
 export function hasVoiceAttachments(message: Message): boolean {
-  // Discord voice messages have both audio contentType AND a duration.
-  // Checking duration alone would false-positive on video attachments (MP4, GIF).
-  // Discord.js Attachment.duration is `number | null` → check !== null.
-  const hasDirectVoice = message.attachments.some(
-    a => (a.contentType?.startsWith('audio/') ?? false) && a.duration !== null
-  );
+  const hasDirectVoice = message.attachments.some(isVoiceAttachment);
   return hasDirectVoice || hasForwardedVoiceAttachment(message);
 }
 

--- a/services/bot-client/src/utils/voiceAttachment.test.ts
+++ b/services/bot-client/src/utils/voiceAttachment.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { isVoiceAttachment } from './voiceAttachment.js';
+
+describe('isVoiceAttachment', () => {
+  it('is true for an audio content-type with a duration (a voice message)', () => {
+    expect(isVoiceAttachment({ contentType: 'audio/ogg', duration: 5.2 })).toBe(true);
+  });
+
+  it('is false for an audio content-type without a duration (a plain audio file)', () => {
+    expect(isVoiceAttachment({ contentType: 'audio/mpeg', duration: null })).toBe(false);
+  });
+
+  it('is false for a video content-type even with a duration (the MP4 bug)', () => {
+    // The exact production false-positive: a video carries a duration, so the old
+    // `audio/* || duration` treated it as a voice message.
+    expect(isVoiceAttachment({ contentType: 'video/mp4', duration: 30 })).toBe(false);
+  });
+
+  it('is false for a non-audio binary content-type with a duration', () => {
+    expect(isVoiceAttachment({ contentType: 'application/octet-stream', duration: 5.2 })).toBe(
+      false
+    );
+  });
+
+  it('is false for an image', () => {
+    expect(isVoiceAttachment({ contentType: 'image/png', duration: null })).toBe(false);
+  });
+
+  it('falls back to duration when the content-type is absent (forwarded snapshot)', () => {
+    // Discord sometimes omits content-type in forwarded snapshots; a duration is
+    // then the only signal of a genuine voice message.
+    expect(isVoiceAttachment({ contentType: null, duration: 5.2 })).toBe(true);
+    expect(isVoiceAttachment({ contentType: undefined, duration: 5.2 })).toBe(true);
+  });
+
+  it('is false when both content-type and duration are absent', () => {
+    expect(isVoiceAttachment({ contentType: null, duration: null })).toBe(false);
+  });
+});

--- a/services/bot-client/src/utils/voiceAttachment.ts
+++ b/services/bot-client/src/utils/voiceAttachment.ts
@@ -1,0 +1,55 @@
+/**
+ * Voice-attachment predicate.
+ *
+ * Dependency-free leaf module so every voice-detection path can share one
+ * definition without forming an import cycle (it's consumed by both
+ * `attachmentExtractor` and `forwardedMessageUtils`, and `forwardedMessageUtils`
+ * already depends on `attachmentExtractor`).
+ */
+
+import { CONTENT_TYPES } from '@tzurot/common-types';
+
+/**
+ * Single source of truth for "is this attachment a voice message?".
+ *
+ * The discriminator that matters is the content-type, and it's checked
+ * authoritatively: when present, the attachment is a voice attachment iff it's
+ * `audio/*`. THIS is what excludes video (MP4/GIF), which also carries a
+ * `duration`; duration alone is not a sufficient signal for a voice message.
+ *
+ * Content-type can be ABSENT on either shape — Discord omits it on some forwarded
+ * snapshots, and Discord.js `Attachment.contentType` is `string | null`. When it's
+ * missing we fall back to the `duration` signal so genuine voice messages are still
+ * detected. Note this fallback only fires for callers that pass RAW attachments
+ * (direct `message.attachments`, the snapshot path, and `extractAttachments`'
+ * per-attachment `isVoiceMessage`); callers that pass already-`extractAttachments`-ed
+ * metadata never hit it, since that normalizes a null content-type to
+ * `application/octet-stream` first.
+ *
+ * Single definition shared by every voice-detection + transcription path (direct
+ * and forwarded) so the predicate can't drift out of sync the way the inlined
+ * copies did. Accepts both attachment shapes seen in practice: Discord.js
+ * `Attachment` (`duration: number | null`) and forwarded-snapshot attachments
+ * (`duration?: number`).
+ */
+export function isVoiceAttachment(attachment: {
+  contentType?: string | null;
+  duration?: number | null;
+}): boolean {
+  const { contentType, duration } = attachment;
+  const hasDuration = duration !== null && duration !== undefined;
+  if (contentType !== null && contentType !== undefined && contentType.length > 0) {
+    // Content-type present (always, for direct Discord.js attachments): a voice
+    // message is `audio/*` AND has a duration. The `audio/*` check excludes video
+    // (which also carries a duration); the duration check excludes plain audio-file
+    // uploads, which aren't voice messages.
+    return contentType.startsWith(CONTENT_TYPES.AUDIO_PREFIX) && hasDuration;
+  }
+  // No content-type (Discord omits it on some forwarded snapshots, and a direct
+  // Discord.js `Attachment.contentType` is `string | null`): fall back to the
+  // duration signal so genuine voice messages are still detected. Caveat: with no
+  // content-type there's no audio/video discriminator, so a content-type-less
+  // *video* with a duration would also pass here — unavoidable best-effort, but
+  // realistic only if Discord ever omits content-type on forwarded video clips.
+  return hasDuration;
+}


### PR DESCRIPTION
## Bug (production)

A directly-uploaded **MP4 video** (`video/mp4` + `duration`) triggered the voice transcriber, which failed and replied **"Sorry, I couldn't transcribe that voice message."** Reported with a real Discord attachment URL (`…/RDT_…mp4`).

## Root cause

The "is this a voice message?" predicate — *audio content-type AND a duration* — was inlined in **five** places that had **drifted apart**:

- **3 in `VoiceTranscriptionService`** (`hasVoiceAttachment`, `snapshotHasAudio`, `extractAudioFromSnapshot`) used `audio/* || duration` — the `||` is the bug: a video carries a `duration`, so it matched.
- **2 in `forwardedMessageUtils`** (`hasVoiceAttachments`, `hasForwardedVoiceAttachment`) used `&&`, with their own inconsistent null/`=== true`/`?? false` handling.

The drift is *why* the bug existed in some copies and not others — there was no single source of truth for "voice message."

## Fix — one predicate, all five sites

Extracted `isVoiceAttachment(attachment)` in `forwardedMessageUtils.ts` and routed all five call sites through it. The unified rule, derived from the real requirements across the sites:

- **content-type present** (always, for direct Discord.js attachments): voice **iff** `audio/*` **AND** has a duration. The `audio/*` check excludes video (the bug); the duration check excludes plain audio-file uploads — matching the forwarded-path siblings' long-standing behaviour (pinned by their tests).
- **content-type absent** (forwarded snapshots sometimes omit it): fall back to the duration signal so genuine forwarded voice messages are still detected (pinned by the existing "missing/null contentType" transcribe tests).

Single source of truth — the operators can't drift apart again.

## Tests

- New `describe('isVoiceAttachment')` unit block (7 cases incl. the `video/mp4` regression + the content-type-absent fallback).
- Direct-path MP4 regression + two forwarded-snapshot cases in `VoiceTranscriptionService.test.ts`.
- 109 voice/forwarded tests pass; `pnpm quality` green (24/24).
