### PR TITLE
refactor(ai-worker): narrow ContextStep assembler + document invariants

### DIFF
--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/ContextStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/ContextStep.ts
@@ -53,6 +53,10 @@ function applyAssembledContext(job: GenerationContext['job'], assembled: Assembl
   if (jobContext.rawAssemblyInputs?.rawActiveGuildMemberInfo !== undefined) {
     jobContext.activePersonaGuildInfo = assembled.activePersonaGuildInfo;
   }
+  // Unconditionally overwrites bot-client's raw message content (which may still
+  // carry unresolved user mentions) with the worker's re-derivation. The entire
+  // bot-client Prisma eviction rests on this running for every job — there is no
+  // legacy fallback, and skipping it would ship the unrewritten content.
   job.data.message = assembled.messageContent;
 }
 
@@ -111,8 +115,8 @@ export class ContextStep implements IPipelineStep {
       throw new Error('[ContextStep] ConfigStep must run before ContextStep');
     }
 
-    this.assertEnvelopeJob(jobContext);
-    const historyEntries = await this.sourceHistory(context);
+    const assembler = this.assertEnvelopeJob(jobContext);
+    const historyEntries = await this.sourceHistory(context, assembler);
 
     // Calculate oldest timestamp from conversation history AND referenced messages
     // (for LTM deduplication - prevents verbatim repetition when replying to AI messages)
@@ -224,8 +228,14 @@ export class ContextStep implements IPipelineStep {
    * rather than silently mis-assemble. `kind` is read with `?? 'legacy'`
    * because ValidationStep discards its parsed copy, so the schema default
    * never materializes on the raw job.data.
+   *
+   * Returns the (now narrowed, non-undefined) assembler so the caller threads it
+   * into {@link sourceHistory} explicitly — making the "assembler is wired" proof
+   * a value dependency rather than an implicit call-order coupling.
    */
-  private assertEnvelopeJob(jobContext: GenerationContext['job']['data']['context']): void {
+  private assertEnvelopeJob(
+    jobContext: GenerationContext['job']['data']['context']
+  ): ContextAssembler {
     if ((jobContext.kind ?? 'legacy') !== 'envelope') {
       throw new Error(
         "[ContextStep] every job must carry context.kind 'envelope'; legacy job " +
@@ -235,6 +245,7 @@ export class ContextStep implements IPipelineStep {
     if (this.contextAssembler === undefined) {
       throw new Error("[ContextStep] context.kind 'envelope' requires a wired ContextAssembler");
     }
+    return this.contextAssembler;
   }
 
   /**
@@ -242,14 +253,15 @@ export class ContextStep implements IPipelineStep {
    * `historyEntries` comes from `assembleCore` (createdAt normalized Date → ISO
    * for the string-typed consumers), and the assembled surfaces are applied
    * onto jobContext by {@link applyAssembledContext} so the downstream
-   * conversationContextBuilder reads them. The assembler is guaranteed wired by
-   * {@link assertEnvelopeJob}, run earlier in {@link process}.
+   * conversationContextBuilder reads them. The `assembler` is the non-undefined
+   * value returned by {@link assertEnvelopeJob}, threaded in by {@link process}.
    */
-  private async sourceHistory(context: GenerationContext): Promise<PromptHistorySource> {
+  private async sourceHistory(
+    context: GenerationContext,
+    assembler: ContextAssembler
+  ): Promise<PromptHistorySource> {
     const { job } = context;
     const jobContext = job.data.context;
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- assertEnvelopeJob (run in process() before this) throws when the assembler is unwired
-    const assembler = this.contextAssembler!;
 
     const assembled = await assembler.assembleCore(
       jobContext,

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/conversationContextBuilder.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/conversationContextBuilder.ts
@@ -18,17 +18,17 @@ export function buildConversationContext(
   // Resolve the personal-vs-incognito union once here so the memory consumers
   // (LTM read/write skip) switch on `summonAnonymity.kind` instead of each
   // re-deriving `incognito ?? isWeighIn`. A personal summon always carries its
-  // persona (the bot or the worker assembler resolved it); if the wire id is
-  // somehow absent, the resolver fail-safes to incognito rather than building a
-  // persona-less personal arm.
+  // persona (the worker assembler resolved it); if the wire id is somehow absent,
+  // the resolver fail-safes to incognito rather than building a persona-less
+  // personal arm.
   //
   // This agrees with the assembler's own resolveSummonAnonymity call by
-  // construction: in service mode ContextStep.applyAssembledContext writes the
-  // assembler's resolved activePersonaId onto jobContext BEFORE this step runs,
-  // so both see the same id; in legacy mode the assembler never runs, so this is
-  // the sole resolution point. The fail-safe therefore never fires for a real
-  // personal summon — it can't diverge from the assembler. (If that writeback is
-  // ever removed, the two calls could disagree on kind — keep them in sync.)
+  // construction: ContextStep.applyAssembledContext writes the assembler's
+  // resolved activePersonaId onto jobContext BEFORE this step runs, so both see
+  // the same id and resolve the same `kind`. The fail-safe therefore never fires
+  // for a real personal summon — it can't diverge from the assembler. (If that
+  // writeback is ever removed, the two calls could disagree on kind — keep them
+  // in sync.)
   const summonAnonymity = resolveSummonAnonymity(jobContext, {
     activePersonaId: jobContext.activePersonaId,
     activePersonaName: jobContext.activePersonaName ?? null,


### PR DESCRIPTION
## What

Cluster B close-out (PR-2p epic) — three follow-ups for the ai-worker context-assembly step. All **pure refactor / documentation, no behaviour change.**

### 1. `assertEnvelopeJob` returns the narrowed assembler
It now returns the (non-undefined) `ContextAssembler`, and `process()` threads it into `sourceHistory` as a parameter. This drops the `@typescript-eslint/no-non-null-assertion` eslint-disable and converts the "assembler is wired" proof from an *implicit call-order coupling* (`sourceHistory` trusting that `assertEnvelopeJob` ran first) into an *explicit value dependency*.

### 2. Worker-overwrite invariant documented
Added a comment at `job.data.message = assembled.messageContent` naming what it guards: it runs **unconditionally** (no legacy fallback) and overwrites bot-client's raw content — which may still carry unresolved user mentions — with the worker's re-derivation. The whole bot-client Prisma eviction rests on this assignment.

### 3. `resolveSummonAnonymity` agreement audit (trigger fired)
beta.135 deleted legacy mode — the follow-up's promote-trigger ("legacy path deleted → re-verify both calls resolve the same `kind`"). Verified: the assembler's call and `buildConversationContext`'s call still agree by construction, now *unconditionally* (the assembler always runs, so `applyAssembledContext` always writes `activePersonaId` before the builder reads it). Dropped the now-stale "in legacy mode the assembler never runs" clause from the comment. The coupling is already pinned by existing tests — the writeback at `ContextStep.test.ts:220` (personal) / `:278` (weigh-in→undefined) plus the builder's 4 `summonAnonymity` cases — so no new test was needed.

## Backlog

Removes three rows from `backlog/cold/follow-ups.md` (done in a follow-up develop doc-commit after merge): `assertEnvelopeJob`-return, worker-overwrite-invariant, `resolveSummonAnonymity`-audit.

## Test plan

- `pnpm --filter @tzurot/ai-worker exec vitest run` ContextStep + conversationContextBuilder suites — 44 pass
- `pnpm quality` — 24/24 (incl. the dropped eslint-disable now lints clean)
