### PR TITLE
refactor(bot-client): rename contextWritePath → gatewayWriteHelpers + #1283 nits

### DIFF
--- a/services/bot-client/src/commands/character/chat.ts
+++ b/services/bot-client/src/commands/character/chat.ts
@@ -136,6 +136,9 @@ function createSyntheticWeighInAnchor(channel: TypingChannel): Message {
     channel,
     client: channel.client,
     guild: 'guild' in channel ? channel.guild : null,
+    // May be null pre-login, but that's safe: the weigh-in call passes
+    // `overrideUser`, so MessageContextBuilder resolves the user identity from
+    // that — never from this anchor's `author`.
     author: channel.client?.user ?? null,
     member: null,
     content: '',

--- a/services/bot-client/src/services/ConversationPersistence.test.ts
+++ b/services/bot-client/src/services/ConversationPersistence.test.ts
@@ -30,7 +30,7 @@ vi.mock('../utils/MessageContentBuilder.js', () => ({
 
 // The conversation write IS the gateway endpoint — bot-client performs no
 // local Prisma write for this surface.
-vi.mock('../utils/contextWritePath.js', () => ({
+vi.mock('../utils/gatewayWriteHelpers.js', () => ({
   persistAssistantMessageViaGateway: vi.fn().mockResolvedValue(undefined),
   persistUserMessageViaGateway: vi.fn().mockResolvedValue(undefined),
 }));
@@ -38,7 +38,7 @@ vi.mock('../utils/contextWritePath.js', () => ({
 import {
   persistAssistantMessageViaGateway,
   persistUserMessageViaGateway,
-} from '../utils/contextWritePath.js';
+} from '../utils/gatewayWriteHelpers.js';
 
 describe('ConversationPersistence', () => {
   let persistence: ConversationPersistence;

--- a/services/bot-client/src/services/ConversationPersistence.ts
+++ b/services/bot-client/src/services/ConversationPersistence.ts
@@ -25,7 +25,7 @@ import { buildMessageContent } from '../utils/MessageContentBuilder.js';
 import {
   persistAssistantMessageViaGateway,
   persistUserMessageViaGateway,
-} from '../utils/contextWritePath.js';
+} from '../utils/gatewayWriteHelpers.js';
 
 const logger = createLogger('ConversationPersistence');
 

--- a/services/bot-client/src/services/MessageContextBuilder.test.ts
+++ b/services/bot-client/src/services/MessageContextBuilder.test.ts
@@ -907,7 +907,7 @@ describe('MessageContextBuilder', () => {
 
       // Same shape createSyntheticWeighInAnchor produces: field-only, no methods.
       const syntheticAnchor = {
-        id: '',
+        id: 'synthetic-weigh-in-anchor',
         channel: mockMessage.channel,
         client: mockMessage.client,
         guild: mockMessage.guild,
@@ -933,7 +933,9 @@ describe('MessageContextBuilder', () => {
         overrideUser: mockMessage.author,
       });
 
-      expect(result.context).toBeDefined();
+      // Higher-confidence than a bare toBeDefined: the field-only anchor produced a
+      // usable context with the anchor's channel id propagated through.
+      expect(result.context.channelId).toBe('channel-123');
       expect(result.messageContent).toBeDefined();
     });
 

--- a/services/bot-client/src/services/channelFetcher/SyncExecutor.test.ts
+++ b/services/bot-client/src/services/channelFetcher/SyncExecutor.test.ts
@@ -10,12 +10,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Collection } from 'discord.js';
 import type { Message } from 'discord.js';
 
-vi.mock('../../utils/contextWritePath.js', () => ({
+vi.mock('../../utils/gatewayWriteHelpers.js', () => ({
   syncConversationViaGateway: vi.fn().mockResolvedValue({ updated: 0, deleted: 0 }),
 }));
 
 import { executeDatabaseSync, toObservedSyncMessages } from './SyncExecutor.js';
-import { syncConversationViaGateway } from '../../utils/contextWritePath.js';
+import { syncConversationViaGateway } from '../../utils/gatewayWriteHelpers.js';
 
 function createMockMessage(id: string, content: string, createdAt: Date): Message {
   return { id, content, createdAt } as unknown as Message;

--- a/services/bot-client/src/services/channelFetcher/SyncExecutor.ts
+++ b/services/bot-client/src/services/channelFetcher/SyncExecutor.ts
@@ -9,7 +9,7 @@
 
 import type { Message, Collection } from 'discord.js';
 import type { ObservedSyncMessage } from '@tzurot/common-types';
-import { syncConversationViaGateway } from '../../utils/contextWritePath.js';
+import { syncConversationViaGateway } from '../../utils/gatewayWriteHelpers.js';
 import type { SyncResult } from './types.js';
 
 /**

--- a/services/bot-client/src/utils/gatewayServiceCalls.test.ts
+++ b/services/bot-client/src/utils/gatewayServiceCalls.test.ts
@@ -3,7 +3,7 @@ import { JobStatus } from '@tzurot/common-types';
 
 // Mock the ServiceClient factory + the service-secret accessor so the helpers
 // run without real config/network. (The context write-path helpers live in
-// contextWritePath.ts with their own colocated tests.)
+// gatewayWriteHelpers.ts with their own colocated tests.)
 const mockServiceClient = {
   getChannelSettings: vi.fn(),
   getAdminSettingsInternal: vi.fn(),

--- a/services/bot-client/src/utils/gatewayWriteHelpers.test.ts
+++ b/services/bot-client/src/utils/gatewayWriteHelpers.test.ts
@@ -15,7 +15,7 @@ import {
   persistAssistantMessageViaGateway,
   persistUserMessageViaGateway,
   syncConversationViaGateway,
-} from './contextWritePath.js';
+} from './gatewayWriteHelpers.js';
 
 const ok = <T>(data: T): { ok: true; data: T } => ({ ok: true, data });
 const err = (status: number): { ok: false; error: string; status: number } => ({

--- a/services/bot-client/src/utils/gatewayWriteHelpers.ts
+++ b/services/bot-client/src/utils/gatewayWriteHelpers.ts
@@ -10,7 +10,7 @@
 import { createLogger, SYNC_LIMITS, type MessageMetadata } from '@tzurot/common-types';
 import { getServiceClient } from './gatewayClients.js';
 
-const logger = createLogger('contextWritePath');
+const logger = createLogger('gatewayWriteHelpers');
 
 interface AssistantMessageWriteParams {
   channelId: string;


### PR DESCRIPTION
## What

Two bot-client Cluster B close-out cleanups (PR-2p epic). No behaviour change.

### 1. Rename `contextWritePath` → `gatewayWriteHelpers`
beta.135 removed the mode-switching flags (`isRawEnvelopeEnabled`/`isThinPayloadEnabled`), leaving the module as exactly three gateway write helpers — `persistUserMessageViaGateway`, `persistAssistantMessageViaGateway`, `syncConversationViaGateway`. The old name described the deleted "write path" mode-switching; the new name names what it is now and joins the existing `gateway*` utility family (`gatewayServiceCalls`, `gatewayClients`, `gatewayFetchGuard`).

Pure rename via `git mv` (file + colocated test); logger label + the two production importers (`ConversationPersistence`, `SyncExecutor`) and their test imports/mocks repointed. Zero `contextWritePath` references remain.

### 2. PR #1283 weigh-in synthetic-anchor review nits
Three live nits (the fourth — an orphaned blank line — was already cleaned up by #1307/#1308, so it's marked obsolete):
- Match the field-only-anchor test fixture's `id` to production's `'synthetic-weigh-in-anchor'` (was `''`) so the "Same shape" comment is accurate.
- Strengthen the bare `expect(result.context).toBeDefined()` to assert the anchor's channel id propagated.
- Document on `createSyntheticWeighInAnchor`'s `author` why a null author is safe (the weigh-in call passes `overrideUser`).

## Backlog

Removes the `contextWritePath`-rename half of the "post-CONTEXT_MODE cleanup" follow-up and the `#1283 nits` follow-up (done post-merge). The `ConversationPersistence` flatten half stays parked — it's an injected, stateless service consistent with the project's constructor-injection DI approach, so flattening is a lateral style change rather than a clear defect.

## Test plan
- `pnpm --filter @tzurot/bot-client exec vitest run` (gatewayWriteHelpers, ConversationPersistence, SyncExecutor, gatewayServiceCalls, MessageContextBuilder, chat) — 89 pass
- `pnpm quality` — 24/24 (structure.test confirms the renamed file keeps its colocated test)
