### PR TITLE
fix(ai-worker): don't surface the bot's own TTS audio in reply-target references

### DIFF
--- a/packages/common-types/src/utils/referenceEnrichment.test.ts
+++ b/packages/common-types/src/utils/referenceEnrichment.test.ts
@@ -6,8 +6,10 @@ import {
   appendVoiceTranscripts,
   buildDedupedReferenceStub,
   isDuplicateReference,
+  stripBotVoiceAttachments,
   type ReferenceDedupCandidate,
 } from './referenceEnrichment.js';
+import type { AttachmentMetadata } from '../types/schemas/discord.js';
 
 const NOW = new Date('2026-06-01T12:00:00Z').getTime();
 
@@ -185,6 +187,73 @@ describe('buildDedupedReferenceStub', () => {
     const stub = buildDedupedReferenceStub(ref);
     // Every marker survives untruncated, markers-first, with the short text after.
     expect(stub.content).toBe(`${expectedMarkers}\n\nhi`);
+  });
+});
+
+describe('stripBotVoiceAttachments', () => {
+  const audio: AttachmentMetadata = {
+    url: 'https://cdn/v.ogg',
+    contentType: 'audio/ogg',
+    name: 'lilith-tts.ogg',
+  };
+  const image: AttachmentMetadata = {
+    url: 'https://cdn/x.png',
+    contentType: 'image/png',
+    name: 'x.png',
+  };
+
+  function refWith(
+    partial: Partial<Pick<ReferencedMessage, 'authorIsBot' | 'webhookId' | 'attachments'>>
+  ): ReferencedMessage {
+    return {
+      referenceNumber: 1,
+      discordMessageId: 'msg-1',
+      discordUserId: 'user-1',
+      authorUsername: 'someone',
+      authorDisplayName: 'Someone',
+      content: 'hi',
+      embeds: '',
+      timestamp: '2026-06-01T11:59:00.000Z',
+      locationContext: '',
+      ...partial,
+    };
+  }
+
+  it('drops a bot-authored reply’s own audio attachment', () => {
+    const result = stripBotVoiceAttachments(refWith({ authorIsBot: true, attachments: [audio] }));
+    expect(result.attachments).toEqual([]);
+  });
+
+  it('drops audio on a webhook-authored reply (authorIsBot unset)', () => {
+    const result = stripBotVoiceAttachments(refWith({ webhookId: 'wh-1', attachments: [audio] }));
+    expect(result.attachments).toEqual([]);
+  });
+
+  it('keeps a bot-authored image (real content, not TTS delivery)', () => {
+    const result = stripBotVoiceAttachments(refWith({ authorIsBot: true, attachments: [image] }));
+    expect(result.attachments).toEqual([image]);
+  });
+
+  it('strips only the audio from a bot-authored mixed attachment set', () => {
+    const result = stripBotVoiceAttachments(
+      refWith({ authorIsBot: true, attachments: [audio, image] })
+    );
+    expect(result.attachments).toEqual([image]);
+  });
+
+  it('keeps a user-authored voice message (genuine content, transcribed elsewhere)', () => {
+    const ref = refWith({ attachments: [audio] }); // no authorIsBot, no webhookId
+    expect(stripBotVoiceAttachments(ref)).toBe(ref);
+  });
+
+  it('returns the same reference when a bot reply has no audio to strip', () => {
+    const ref = refWith({ authorIsBot: true, attachments: [image] });
+    expect(stripBotVoiceAttachments(ref)).toBe(ref);
+  });
+
+  it('returns the same reference when there are no attachments', () => {
+    const ref = refWith({ authorIsBot: true });
+    expect(stripBotVoiceAttachments(ref)).toBe(ref);
   });
 });
 

--- a/packages/common-types/src/utils/referenceEnrichment.ts
+++ b/packages/common-types/src/utils/referenceEnrichment.ts
@@ -14,6 +14,7 @@
  */
 
 import { TEXT_LIMITS } from '../constants/discord.js';
+import { CONTENT_TYPES } from '../constants/media.js';
 import { INTERVALS } from '../constants/timing.js';
 import type { AttachmentMetadata } from '../types/schemas/discord.js';
 import type { ReferencedMessage } from '../types/schemas/message.js';
@@ -81,6 +82,34 @@ export function isDuplicateReference(
   }
 
   return false;
+}
+
+/**
+ * Drop a bot/webhook-authored reference's own audio attachments.
+ *
+ * A personality reply is delivered via webhook with its TTS rendered as an
+ * `audio/*` file attachment. That audio is system-generated *delivery* of the
+ * bot's own text — not content the model "attached" — so surfacing it (folded as
+ * an `[audio/…]` marker into a dedup stub, or as an attachment line in a full
+ * quote) makes the model reason about "an audio message I sent". User voice
+ * messages (user-authored, transcribed) are genuine content and are untouched.
+ *
+ * Identity is by authorship (`authorIsBot`/`webhookId`), not filename; only
+ * `audio/*` is dropped, so a bot-posted image (real content) still survives.
+ */
+export function stripBotVoiceAttachments(reference: ReferencedMessage): ReferencedMessage {
+  const isBotAuthored =
+    reference.authorIsBot === true ||
+    (reference.webhookId !== undefined && reference.webhookId.length > 0);
+  if (!isBotAuthored || reference.attachments === undefined) {
+    return reference;
+  }
+  const kept = reference.attachments.filter(
+    att => !att.contentType.startsWith(CONTENT_TYPES.AUDIO_PREFIX)
+  );
+  return kept.length === reference.attachments.length
+    ? reference
+    : { ...reference, attachments: kept };
 }
 
 /**

--- a/services/ai-worker/src/services/context/referenceEnricher.test.ts
+++ b/services/ai-worker/src/services/context/referenceEnricher.test.ts
@@ -81,6 +81,27 @@ describe('enrichRawReferences', () => {
     expect(result[0].content).toBe('[image/png: board.png]');
   });
 
+  it('strips the bot’s own TTS audio marker when stubbing a duplicate voice reply-target', async () => {
+    const result = await enrichRawReferences({
+      rawReferences: [
+        rawRef({
+          webhookId: 'wh-1', // personality reply delivered via webhook
+          content: 'You are allowed to be furious about this',
+          attachments: [
+            { url: 'https://cdn/v.ogg', contentType: 'audio/ogg', name: 'lilith-tts.ogg' },
+          ],
+        }),
+      ],
+      history: [historyRow('ref-1', new Date(NOW - 5_000))],
+      retrieveTranscript: noTranscript,
+      nowMs: NOW,
+    });
+    expect(result[0].isDeduplicated).toBe(true);
+    // The bot's own audio is delivery of its own text, not an attachment the model
+    // should reason about — only the text survives, no [audio/ogg: …] marker.
+    expect(result[0].content).toBe('You are allowed to be furious about this');
+  });
+
   it('stubs a recent webhook reference via the time fallback', async () => {
     const result = await enrichRawReferences({
       rawReferences: [rawRef({ webhookId: 'wh-1' })],

--- a/services/ai-worker/src/services/context/referenceEnricher.ts
+++ b/services/ai-worker/src/services/context/referenceEnricher.ts
@@ -34,6 +34,7 @@ import {
   appendVoiceTranscripts,
   buildDedupedReferenceStub,
   isDuplicateReference,
+  stripBotVoiceAttachments,
   type ConversationMessage,
   type ReferencedMessage,
   type TranscriptRetrieveFn,
@@ -78,7 +79,11 @@ export async function enrichRawReferences(
   // Promise.all preserves input order, so wire order (and the adopted
   // reference numbers) survive the parallel enrichment.
   return Promise.all(
-    rawReferences.map(async (raw): Promise<ReferencedMessage> => {
+    rawReferences.map(async (rawInput): Promise<ReferencedMessage> => {
+      // Strip the personality's own TTS audio before either render branch: a
+      // bot-authored reply's `audio/*` attachment is delivery of its own text,
+      // not content the model should see as "an audio message I sent".
+      const raw = stripBotVoiceAttachments(rawInput);
       const duplicate = isDuplicateReference(
         {
           discordMessageId: raw.discordMessageId,


### PR DESCRIPTION
## Bug (production)

When a user replies to a personality's **voice message**, the AI sees its **own TTS audio file** as an attachment and reasons about *"an audio message I sent."* Captured from a real system prompt — a `<contextual_references>` quote (the reply target) rendered:

```
[Reply target — full message is in conversation above]

[audio/ogg: 1373420683580670023-lilith-tzel-shani-mqq634mq.ogg]

You're allowed to be furious about ...
```

That filename is Lilith's own TTS output. The screenshot of the AI's reasoning shows it puzzling over "an audio message I (as Lilith) apparently sent 5 minutes ago."

## Root cause

A personality reply is delivered via webhook with its TTS rendered as an `audio/*` **file** attachment. `buildDedupedReferenceStub` folds *every* attachment of a referenced message into the stub as a `[contentType: name]` marker (the full-render path emits attachment lines the same way), so the bot's own delivery audio leaks into the reply-target the AI sees.

The existing `isVoiceMessage` filter misses it: a webhook-attached file carries no Discord voice **duration**, so it's `isVoiceMessage: false` and renders as a plain `[audio/ogg: …]` file marker (not `[voice message: …]`).

## Fix

A shared `stripBotVoiceAttachments(ref)` kernel in `@tzurot/common-types` drops `audio/*` attachments when the reference is **bot/webhook-authored** (`authorIsBot === true || webhookId`), applied once at the top of the worker's `enrichRawReferences` map — so it covers **both** render branches (dedup stub + full quote) at a single point.

Design choices:
- **Identity by authorship, not filename** — `authorIsBot`/`webhookId` mark the personality's own delivery.
- **Audio only** — a bot-posted image would be real content, so only `audio/*` is dropped.
- **User voice messages untouched** — they're user-authored and genuinely transcribed (`<voice_transcripts>`).

The audio is system-generated *delivery* of the bot's own text, not content the model "attached."

## Test plan

- `referenceEnrichment.test.ts` — 7 unit cases for the kernel (bot audio stripped via `authorIsBot` and via `webhookId`; bot image kept; mixed set → only audio stripped; user audio kept; no-op identity returns).
- `referenceEnricher.test.ts` — end-to-end: a deduped webhook reply-target with an `audio/ogg` attachment stubs to text only, no `[audio/ogg: …]` marker (parallel to the existing image-marker-kept test).
- `pnpm quality` — 24/24.
