### PR TITLE
refactor(common-types): remove the vestigial conversationHistory wire field

### DIFF
--- a/packages/common-types/src/types/jobs.test.ts
+++ b/packages/common-types/src/types/jobs.test.ts
@@ -35,7 +35,6 @@ import {
   shapesExportResultSchema,
 } from './shapes-import.js';
 import { JobType, JobStatus } from '../constants/queue.js';
-import { MessageRole } from '../constants/message.js';
 import {
   MINIMAL_CONTEXT,
   AUDIO_ATTACHMENT,
@@ -328,14 +327,6 @@ describe('BullMQ Job Contract Tests', () => {
           sessionId: 'session-123',
           activePersonaId: 'persona-123',
           activePersonaName: 'TestPersona',
-          conversationHistory: [
-            {
-              role: MessageRole.User,
-              content: 'Previous message',
-              tokenCount: 10,
-              createdAt: new Date().toISOString(),
-            },
-          ],
           attachments: [
             {
               url: 'https://example.com/file.pdf',

--- a/packages/common-types/src/types/jobs.ts
+++ b/packages/common-types/src/types/jobs.ts
@@ -24,7 +24,6 @@ import {
   mentionedPersonaSchema,
   referencedChannelSchema,
   attachmentMetadataSchema,
-  apiConversationMessageSchema,
   referencedMessageSchema,
   discordEnvironmentSchema,
   guildMemberInfoSchema,
@@ -34,7 +33,6 @@ import {
   type ConfigSourceId,
 } from './schemas/index.js';
 import { JobType, JobStatus } from '../constants/queue.js';
-import { MessageRole } from '../constants/message.js';
 import type { SttProvider } from './sttProvider.js';
 
 /**
@@ -57,9 +55,9 @@ export interface JobDependency {
 export interface JobContext {
   /**
    * Context-payload variant discriminant. `'envelope'` means the producer
-   * (bot-client) omitted the re-derivable legacy fields (conversationHistory,
-   * referencedMessages, mentionedPersonas, referencedChannels) and the worker
-   * MUST assemble them from `rawAssemblyInputs`. `'legacy'` (the default for
+   * (bot-client) omitted the re-derivable legacy fields (referencedMessages,
+   * mentionedPersonas, referencedChannels) and the worker MUST assemble them
+   * from `rawAssemblyInputs`. `'legacy'` (the default for
    * absent — i.e. in-flight jobs from an older bot) means the legacy fields are
    * authoritative. See jobContextBaseSchema.
    *
@@ -90,23 +88,6 @@ export interface JobContext {
    * @example { 'discord:user-123': { roles: ['Admin', 'Developer'], displayColor: '#FF5733' } }
    */
   participantGuildInfo?: Record<string, GuildMemberInfo>;
-  conversationHistory?: {
-    id?: string;
-    role: MessageRole;
-    content: string;
-    tokenCount?: number;
-    createdAt?: string;
-    /** User's persona ID */
-    personaId?: string;
-    /** User's persona display name */
-    personaName?: string;
-    /** Discord username for disambiguation when persona name matches personality name */
-    discordUsername?: string;
-    /** AI personality ID (for multi-AI channel attribution) */
-    personalityId?: string;
-    /** AI personality's display name (for multi-AI channel attribution) */
-    personalityName?: string;
-  }[];
   /** Attachments from triggering message */
   attachments?: AttachmentMetadata[];
   /** Image attachments from extended context (limited by maxImages setting) */
@@ -384,7 +365,6 @@ const jobContextBaseSchema = z.object({
   activePersonaName: z.string().optional(),
   activePersonaGuildInfo: guildMemberInfoSchema.optional(),
   participantGuildInfo: z.record(z.string(), guildMemberInfoSchema).optional(),
-  conversationHistory: z.array(apiConversationMessageSchema).optional(),
   attachments: z.array(attachmentMetadataSchema).optional(),
   extendedContextAttachments: z.array(attachmentMetadataSchema).optional(),
   environment: discordEnvironmentSchema.optional(),

--- a/packages/common-types/src/types/schemas/personality.ts
+++ b/packages/common-types/src/types/schemas/personality.ts
@@ -12,11 +12,7 @@ import {
   guildMemberInfoSchema,
 } from './discord.js';
 import { rawAssemblyInputsSchema } from './rawEnvelope.js';
-import {
-  apiConversationMessageSchema,
-  crossChannelHistoryGroupSchema,
-  referencedMessageSchema,
-} from './message.js';
+import { crossChannelHistoryGroupSchema, referencedMessageSchema } from './message.js';
 
 /**
  * Custom Fields Schema
@@ -167,9 +163,9 @@ export const referencedChannelSchema = z.object({
  */
 export const requestContextSchema = z.object({
   // Context-payload variant. 'envelope' means the producer omitted the
-  // re-derivable legacy fields (conversationHistory, referencedMessages,
-  // mentionedPersonas, referencedChannels) and the worker MUST assemble them
-  // from rawAssemblyInputs. Optional here (kept off the inferred type's
+  // re-derivable legacy fields (referencedMessages, mentionedPersonas,
+  // referencedChannels) and the worker MUST assemble them from
+  // rawAssemblyInputs. Optional here (kept off the inferred type's
   // required set so existing RequestContext construction sites don't all need
   // it); absent is treated as legacy by consumers (worker reads `?? 'legacy'`,
   // jobContextBaseSchema defaults it). The envelope-requires-rawAssemblyInputs
@@ -196,8 +192,6 @@ export const requestContextSchema = z.object({
   // Guild info for other participants (from extended context, keyed by personaId)
   // Note: Only available for extended context participants; DB history doesn't store guild info
   participantGuildInfo: z.record(z.string(), guildMemberInfoSchema).optional(),
-  // Conversation history
-  conversationHistory: z.array(apiConversationMessageSchema).optional(),
   // Attachments (from triggering message)
   attachments: z.array(attachmentMetadataSchema).optional(),
   // Extended context attachments (proactively fetched images, limited by maxImages setting)

--- a/packages/common-types/src/types/test/fixtures.ts
+++ b/packages/common-types/src/types/test/fixtures.ts
@@ -6,7 +6,6 @@
  * to maintain DRY principle and ensure consistency in test data.
  */
 
-import { MessageRole } from '../../constants/message.js';
 import type { LoadedPersonality, RequestContext, AttachmentMetadata } from '../api-types.js';
 import type { ResponseDestination } from '../jobs.js';
 
@@ -48,13 +47,6 @@ export const FULL_CONTEXT: RequestContext = {
   sessionId: 'session-123',
   activePersonaId: 'persona-123',
   activePersonaName: 'TestPersona',
-  conversationHistory: [
-    {
-      role: MessageRole.User,
-      content: 'Previous message',
-      createdAt: new Date().toISOString(),
-    },
-  ],
   attachments: [
     {
       url: 'https://example.com/file.pdf',

--- a/services/ai-worker/src/jobs/handlers/LLMGenerationHandler.test.ts
+++ b/services/ai-worker/src/jobs/handlers/LLMGenerationHandler.test.ts
@@ -650,13 +650,6 @@ describe('LLMGenerationHandler', () => {
             channelId: 'channel-789',
             serverId: 'server-012',
             sessionId: 'session-xyz',
-            conversationHistory: [
-              {
-                role: 'user' as any,
-                content: 'Previous message',
-                createdAt: '2025-01-01T12:00:00Z',
-              },
-            ],
           },
         });
         const job = { id: 'job-rag', data: jobData } as Job<LLMGenerationJobData>;

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/NormalizationStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/NormalizationStep.test.ts
@@ -6,9 +6,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Job } from 'bullmq';
 import {
   JobType,
-  MessageRole,
   type LLMGenerationJobData,
   type LoadedPersonality,
+  type ReferencedMessage,
 } from '@tzurot/common-types';
 import { NormalizationStep } from './NormalizationStep.js';
 import type { GenerationContext } from '../types.js';
@@ -80,6 +80,21 @@ function createMockJob(overrides: Partial<LLMGenerationJobData> = {}): Job<LLMGe
   } as Job<LLMGenerationJobData>;
 }
 
+function refMessage(overrides: Partial<ReferencedMessage> = {}): ReferencedMessage {
+  return {
+    referenceNumber: 1,
+    discordMessageId: 'msg-123',
+    discordUserId: 'user-789',
+    authorUsername: 'Alice',
+    authorDisplayName: 'Alice Smith',
+    content: 'Referenced content',
+    embeds: '',
+    timestamp: '2024-01-15T10:30:00.000Z',
+    locationContext: '#general',
+    ...overrides,
+  };
+}
+
 describe('NormalizationStep', () => {
   let step: NormalizationStep;
 
@@ -92,164 +107,13 @@ describe('NormalizationStep', () => {
     expect(step.name).toBe('Normalization');
   });
 
-  describe('role normalization', () => {
-    it('should normalize capitalized roles to lowercase', () => {
-      const job = createMockJob({
-        context: {
-          userId: 'user-456',
-          conversationHistory: [
-            { role: 'User' as unknown as MessageRole, content: 'Hello' },
-            { role: 'Assistant' as unknown as MessageRole, content: 'Hi!' },
-            { role: 'System' as unknown as MessageRole, content: 'System message' },
-          ],
-        },
-      });
-
-      const context: GenerationContext = { job, startTime: Date.now() };
-      step.process(context);
-
-      // Check that roles were normalized in place
-      const history = job.data.context.conversationHistory!;
-      expect(history[0].role).toBe('user');
-      expect(history[1].role).toBe('assistant');
-      expect(history[2].role).toBe('system');
-    });
-
-    it('should leave already-lowercase roles unchanged', () => {
-      const job = createMockJob({
-        context: {
-          userId: 'user-456',
-          conversationHistory: [
-            { role: MessageRole.User, content: 'Hello' },
-            { role: MessageRole.Assistant, content: 'Hi!' },
-          ],
-        },
-      });
-
-      const context: GenerationContext = { job, startTime: Date.now() };
-      step.process(context);
-
-      const history = job.data.context.conversationHistory!;
-      expect(history[0].role).toBe('user');
-      expect(history[1].role).toBe('assistant');
-    });
-
-    it('should handle mixed case roles', () => {
-      const job = createMockJob({
-        context: {
-          userId: 'user-456',
-          conversationHistory: [
-            { role: 'USER' as unknown as MessageRole, content: 'Loud user' },
-            { role: 'AsSiStAnT' as unknown as MessageRole, content: 'Weird assistant' },
-          ],
-        },
-      });
-
-      const context: GenerationContext = { job, startTime: Date.now() };
-      step.process(context);
-
-      const history = job.data.context.conversationHistory!;
-      expect(history[0].role).toBe('user');
-      expect(history[1].role).toBe('assistant');
-    });
-
-    it('should log warning for invalid roles but not throw', () => {
-      const job = createMockJob({
-        context: {
-          userId: 'user-456',
-          conversationHistory: [
-            { role: 'invalid-role' as unknown as MessageRole, content: 'Bad message' },
-          ],
-        },
-      });
-
-      const context: GenerationContext = { job, startTime: Date.now() };
-
-      // Should not throw - logs warning and leaves role as-is
-      expect(() => step.process(context)).not.toThrow();
-
-      // Role should be unchanged (couldn't normalize it)
-      const history = job.data.context.conversationHistory!;
-      expect(history[0].role).toBe('invalid-role');
-    });
-  });
-
-  describe('timestamp normalization', () => {
-    it('should convert Date objects to ISO strings', () => {
+  describe('referenced message timestamp normalization', () => {
+    it('converts a Date object that bypassed serialization to an ISO string', () => {
       const date = new Date('2024-01-15T10:30:00.000Z');
       const job = createMockJob({
         context: {
           userId: 'user-456',
-          conversationHistory: [
-            {
-              role: MessageRole.User,
-              content: 'Hello',
-              createdAt: date as unknown as string, // Simulating Date that bypassed serialization
-            },
-          ],
-        },
-      });
-
-      const context: GenerationContext = { job, startTime: Date.now() };
-      step.process(context);
-
-      const history = job.data.context.conversationHistory!;
-      expect(history[0].createdAt).toBe('2024-01-15T10:30:00.000Z');
-    });
-
-    it('should leave ISO string timestamps unchanged', () => {
-      const isoString = '2024-01-15T10:30:00.000Z';
-      const job = createMockJob({
-        context: {
-          userId: 'user-456',
-          conversationHistory: [{ role: MessageRole.User, content: 'Hello', createdAt: isoString }],
-        },
-      });
-
-      const context: GenerationContext = { job, startTime: Date.now() };
-      step.process(context);
-
-      const history = job.data.context.conversationHistory!;
-      expect(history[0].createdAt).toBe(isoString);
-    });
-
-    it('should handle undefined timestamps', () => {
-      const job = createMockJob({
-        context: {
-          userId: 'user-456',
-          conversationHistory: [
-            { role: MessageRole.User, content: 'Hello' }, // No createdAt
-          ],
-        },
-      });
-
-      const context: GenerationContext = { job, startTime: Date.now() };
-      step.process(context);
-
-      const history = job.data.context.conversationHistory!;
-      expect(history[0].createdAt).toBeUndefined();
-    });
-  });
-
-  describe('referenced messages normalization', () => {
-    it('should normalize timestamps in referenced messages', () => {
-      const date = new Date('2024-01-15T10:30:00.000Z');
-      const job = createMockJob({
-        context: {
-          userId: 'user-456',
-          referencedMessages: [
-            {
-              referenceNumber: 1,
-              discordMessageId: 'msg-123',
-              discordUserId: 'user-789',
-              authorUsername: 'Alice',
-              authorDisplayName: 'Alice Smith',
-              content: 'Referenced content',
-              embeds: '',
-              timestamp: date as unknown as string, // Date bypassing serialization
-              locationContext: '#general',
-            },
-          ],
+          referencedMessages: [refMessage({ timestamp: date as unknown as string })],
         },
       });
 
@@ -259,48 +123,40 @@ describe('NormalizationStep', () => {
       const refs = job.data.context.referencedMessages!;
       expect(refs[0].timestamp).toBe('2024-01-15T10:30:00.000Z');
     });
+
+    it('leaves an ISO string timestamp unchanged', () => {
+      const isoString = '2024-01-15T10:30:00.000Z';
+      const job = createMockJob({
+        context: {
+          userId: 'user-456',
+          referencedMessages: [refMessage({ timestamp: isoString })],
+        },
+      });
+
+      const context: GenerationContext = { job, startTime: Date.now() };
+      step.process(context);
+
+      const refs = job.data.context.referencedMessages!;
+      expect(refs[0].timestamp).toBe(isoString);
+    });
   });
 
   describe('empty data handling', () => {
-    it('should handle empty conversation history', () => {
+    it('handles an empty referencedMessages array', () => {
       const job = createMockJob({
-        context: {
-          userId: 'user-456',
-          conversationHistory: [],
-        },
+        context: { userId: 'user-456', referencedMessages: [] },
       });
-
       const context: GenerationContext = { job, startTime: Date.now() };
 
-      // Should not throw
       expect(() => step.process(context)).not.toThrow();
     });
 
-    it('should handle undefined conversation history', () => {
+    it('handles undefined referencedMessages', () => {
       const job = createMockJob({
-        context: {
-          userId: 'user-456',
-          conversationHistory: undefined,
-        },
+        context: { userId: 'user-456', referencedMessages: undefined },
       });
-
       const context: GenerationContext = { job, startTime: Date.now() };
 
-      // Should not throw
-      expect(() => step.process(context)).not.toThrow();
-    });
-
-    it('should handle undefined referenced messages', () => {
-      const job = createMockJob({
-        context: {
-          userId: 'user-456',
-          referencedMessages: undefined,
-        },
-      });
-
-      const context: GenerationContext = { job, startTime: Date.now() };
-
-      // Should not throw
       expect(() => step.process(context)).not.toThrow();
     });
   });

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/NormalizationStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/NormalizationStep.ts
@@ -1,54 +1,32 @@
 /**
  * Normalization Step
  *
- * Normalizes job data types after validation passes.
- * Handles legacy data formats and ensures consistent types for downstream steps.
+ * Normalizes job data types after validation passes, ensuring consistent types
+ * for downstream steps.
  *
- * This step addresses type contract mismatches across service boundaries:
- * - Roles: Legacy "User"/"Assistant" → lowercase "user"/"assistant"
- * - Timestamps: Date objects (from Discord.js) → ISO strings (after BullMQ serialization)
+ * Normalizes referenced-message timestamps: Date objects (from Discord.js) → ISO
+ * strings (after BullMQ serialization).
  *
  * Runs after ValidationStep to ensure the data structure is valid before normalization.
  */
 
-import { createLogger, normalizeRole, normalizeTimestamp, MessageRole } from '@tzurot/common-types';
+import { createLogger, normalizeTimestamp } from '@tzurot/common-types';
 import type { IPipelineStep, GenerationContext } from '../types.js';
 
 const logger = createLogger('NormalizationStep');
-
-/** Stats returned by normalization helpers */
-interface NormalizationStats {
-  roleNormalizations: number;
-  timestampNormalizations: number;
-}
 
 export class NormalizationStep implements IPipelineStep {
   readonly name = 'Normalization';
 
   process(context: GenerationContext): GenerationContext {
     const { job } = context;
-    const { conversationHistory, referencedMessages } = job.data.context;
+    const { referencedMessages } = job.data.context;
 
-    // Normalize conversation history and referenced messages
-    const historyStats = this.normalizeConversationHistory(conversationHistory, job.id);
-    const refStats = this.normalizeReferencedMessages(referencedMessages);
-
-    // Combine stats
-    const roleNormalizations = historyStats.roleNormalizations;
-    const timestampNormalizations =
-      historyStats.timestampNormalizations + refStats.timestampNormalizations;
+    const timestampNormalizations = this.normalizeReferencedMessages(referencedMessages);
 
     // Log if any normalizations occurred (helps track legacy data)
-    if (roleNormalizations > 0 || timestampNormalizations > 0) {
-      logger.info(
-        {
-          jobId: job.id,
-          roleNormalizations,
-          timestampNormalizations,
-          historyLength: conversationHistory?.length ?? 0,
-        },
-        'Normalized legacy data formats'
-      );
+    if (timestampNormalizations > 0) {
+      logger.info({ jobId: job.id, timestampNormalizations }, 'Normalized legacy data formats');
     } else {
       logger.debug({ jobId: job.id }, 'No normalization needed');
     }
@@ -57,101 +35,26 @@ export class NormalizationStep implements IPipelineStep {
   }
 
   /**
-   * Normalize conversation history messages in place.
-   * Handles role capitalization and timestamp format variations.
-   */
-  private normalizeConversationHistory(
-    conversationHistory: GenerationContext['job']['data']['context']['conversationHistory'],
-    jobId: string | undefined
-  ): NormalizationStats {
-    const stats: NormalizationStats = { roleNormalizations: 0, timestampNormalizations: 0 };
-
-    if (!conversationHistory || conversationHistory.length === 0) {
-      return stats;
-    }
-
-    for (const msg of conversationHistory) {
-      // Normalize role
-      const roleResult = this.normalizeMessageRole(msg, jobId);
-      stats.roleNormalizations += roleResult;
-
-      // Normalize timestamp
-      const timestampResult = this.normalizeMessageTimestamp(msg);
-      stats.timestampNormalizations += timestampResult;
-    }
-
-    return stats;
-  }
-
-  /**
-   * Normalize a single message's role, returning 1 if normalized, 0 otherwise.
-   */
-  private normalizeMessageRole(
-    msg: { role: string | MessageRole },
-    jobId: string | undefined
-  ): number {
-    try {
-      const originalRole = String(msg.role);
-      const normalizedRole = normalizeRole(originalRole);
-      // Compare as strings to avoid unsafe enum comparison lint error
-      if (originalRole !== String(normalizedRole)) {
-        (msg as { role: MessageRole }).role = normalizedRole;
-        return 1;
-      }
-    } catch (error) {
-      logger.warn(
-        {
-          jobId,
-          originalRole: msg.role,
-          error: error instanceof Error ? error.message : String(error),
-        },
-        'Failed to normalize role, leaving as-is'
-      );
-    }
-    return 0;
-  }
-
-  /**
-   * Normalize a single message's timestamp, returning 1 if normalized, 0 otherwise.
-   */
-  private normalizeMessageTimestamp(msg: { createdAt?: string }): number {
-    if (msg.createdAt === undefined) {
-      return 0;
-    }
-
-    const originalValue = msg.createdAt;
-    const normalizedTimestamp = normalizeTimestamp(originalValue);
-
-    if (normalizedTimestamp !== undefined && originalValue !== normalizedTimestamp) {
-      msg.createdAt = normalizedTimestamp;
-      return 1;
-    }
-
-    return 0;
-  }
-
-  /**
-   * Normalize referenced message timestamps in place.
+   * Normalize referenced message timestamps in place. Returns the count normalized.
    */
   private normalizeReferencedMessages(
     referencedMessages: GenerationContext['job']['data']['context']['referencedMessages']
-  ): NormalizationStats {
-    const stats: NormalizationStats = { roleNormalizations: 0, timestampNormalizations: 0 };
-
+  ): number {
     if (!referencedMessages || referencedMessages.length === 0) {
-      return stats;
+      return 0;
     }
 
+    let timestampNormalizations = 0;
     for (const ref of referencedMessages) {
       if (ref.timestamp !== undefined) {
         const normalizedTimestamp = normalizeTimestamp(ref.timestamp);
         if (normalizedTimestamp !== undefined && ref.timestamp !== normalizedTimestamp) {
           ref.timestamp = normalizedTimestamp;
-          stats.timestampNormalizations++;
+          timestampNormalizations++;
         }
       }
     }
 
-    return stats;
+    return timestampNormalizations;
   }
 }

--- a/services/bot-client/src/services/MessageContextBuilder.test.ts
+++ b/services/bot-client/src/services/MessageContextBuilder.test.ts
@@ -314,8 +314,7 @@ describe('MessageContextBuilder', () => {
       });
 
       expect(result.context.kind).toBe('envelope');
-      // The four core re-derivable fields are omitted; the worker assembles them.
-      expect(result.context.conversationHistory).toBeUndefined();
+      // The three core re-derivable fields are omitted; the worker assembles them.
       expect(result.context.referencedMessages).toBeUndefined();
       expect(result.context.mentionedPersonas).toBeUndefined();
       expect(result.context.referencedChannels).toBeUndefined();

--- a/services/bot-client/src/services/character/PersonalityChatManager.ts
+++ b/services/bot-client/src/services/character/PersonalityChatManager.ts
@@ -268,7 +268,6 @@ export class PersonalityChatManager {
       {
         jobId,
         personalityName: personality.displayName,
-        historyLength: context.conversationHistory?.length ?? 0,
       },
       'Job submitted successfully, awaiting async result'
     );

--- a/services/bot-client/src/types.ts
+++ b/services/bot-client/src/types.ts
@@ -20,7 +20,6 @@ import {
   type LoadedPersonality,
   type RequestContext,
   type TranscribeResponse,
-  MessageRole,
 } from '@tzurot/common-types';
 import type { DeferralMode, SafeCommandContext } from './utils/commandContext/index.js';
 
@@ -32,17 +31,8 @@ export type { GenerateResponse, LoadedPersonality, TranscribeResponse };
  * Bot-specific context that gets sent to api-gateway
  * Extends RequestContext from common-types with bot-specific messageContent field
  */
-export interface MessageContext extends Omit<RequestContext, 'conversationHistory'> {
+export interface MessageContext extends RequestContext {
   messageContent: string;
-  conversationHistory?: {
-    id?: string; // Internal UUID for deduplication
-    role: MessageRole;
-    content: string;
-    createdAt?: string;
-    personaId?: string; // Which persona said this message
-    personaName?: string; // Persona's name for context
-    discordUsername?: string; // Discord username for disambiguation when persona name matches personality name
-  }[];
   crossChannelHistory?: CrossChannelHistoryGroupEntry[];
 }
 

--- a/services/bot-client/src/utils/gatewayServiceCalls.test.ts
+++ b/services/bot-client/src/utils/gatewayServiceCalls.test.ts
@@ -179,16 +179,16 @@ describe('generate', () => {
       { slug: 'lila' } as never,
       {
         messageContent: 'hi',
-        conversationHistory: undefined,
+        userId: 'u-1',
       } as never
     );
     expect(result).toEqual({ jobId: 'j-1', requestId: 'r-1' });
-    // `message` is hoisted from context.messageContent; conversationHistory is
-    // defaulted to [] and nested inside the context payload.
+    // `message` is hoisted from context.messageContent; the context object is
+    // forwarded as the nested `context` payload.
     expect(mockServiceClient.aiGenerate).toHaveBeenCalledWith(
       expect.objectContaining({
         message: 'hi',
-        context: expect.objectContaining({ conversationHistory: [] }),
+        context: expect.objectContaining({ userId: 'u-1' }),
       })
     );
   });

--- a/services/bot-client/src/utils/gatewayServiceCalls.ts
+++ b/services/bot-client/src/utils/gatewayServiceCalls.ts
@@ -231,10 +231,7 @@ export async function generate(
   const result = await getServiceClient().aiGenerate({
     personality,
     message: context.messageContent,
-    context: {
-      ...context,
-      conversationHistory: context.conversationHistory ?? [],
-    },
+    context,
   });
   if (!result.ok) {
     logger.error({ status: result.status, error: result.error }, 'Failed to submit job');


### PR DESCRIPTION
## What

Cluster B close-out (PR-2p epic) — remove the **vestigial `conversationHistory` wire field** from the job/request context. No behaviour change: after the 2.5d cutover bot-client ships a thin envelope (always `[]`, nothing ever populated it) and the ai-worker re-derives history into its own `PreparedContext`/`ConversationContext`.

The backlog billed this as "remove a field + the ship-site." A writer/reader scan showed it's a **multi-service wire-contract removal** with one dead worker path riding on it.

## Changes

**common-types** — drop the field from all 3 definitions + fixture:
- `JobContext` interface, `jobContextBaseSchema` (`jobs.ts`), `requestContextSchema` (`schemas/personality.ts`), the `test/fixtures.ts` `FULL_CONTEXT`, and the now-orphaned `apiConversationMessageSchema` / `MessageRole` imports.

**bot-client**:
- `MessageContext` drops `Omit<RequestContext, 'conversationHistory'>` + its own redefinition → plain `extends RequestContext`.
- the `?? []` ship-site in `gatewayServiceCalls`.
- the always-`0` `historyLength` job-submit log field in `PersonalityChatManager`.

**ai-worker `NormalizationStep`**:
- `normalizeConversationHistory` operated only on the always-empty field (dead) — removed, along with its sole-consumer role normalization (`normalizeMessageRole` + the `normalizeRole` import). Kept `normalizeReferencedMessages` (live referencedMessages timestamp normalization), simplified the stats/log to timestamps only.

## Not touched (same name, different objects)
- `PreparedContext` / `ConversationContext.conversationHistory` (`BaseMessage[]`, the worker's *built* history) — incl. the `MemoryRetriever`/`PromptLogger` telemetry reads (verified they're on the built context, not the wire field).
- The Prisma `conversationHistory` model.
- `apiConversationMessageSchema` (still used by cross-channel history etc.).

## Test plan
- `pnpm quality` — 24/24 (typecheck + **typecheck:spec** caught every test fixture that set the field on the wire context; all fixed).
- common-types unit suite — 2249 pass; ai-worker `NormalizationStep`/`LLMGenerationHandler` + bot-client `MessageContextBuilder`/`PersonalityChatManager`/`gatewayServiceCalls` suites green.
- Full unit + `test:int` deferred to CI (Steam Deck OOM).
- Grep gate: zero `conversationHistory` references remain on the wire path; surviving matches are all `preparedContext`/`ConversationContext`/`BaseMessage[]`/the Prisma model.
