### PR TITLE
feat(ai-worker): re-resolve aged-out extended-context voice transcripts (DB-first, STT-fallback)

### DIFF
--- a/packages/common-types/src/types/schemas/rawEnvelope.ts
+++ b/packages/common-types/src/types/schemas/rawEnvelope.ts
@@ -137,6 +137,18 @@ export const rawAssemblyInputsSchema = z.object({
    */
   rawExtendedContextImageAttachments: z.array(attachmentMetadataSchema).optional(),
   /**
+   * Voice attachments from extended-context messages whose transcript the bot
+   * could NOT resolve at fetch time (aged out of the 5-min Redis cache, and no
+   * bot transcript-reply was in the window). Each carries `sourceDiscordMessageId`
+   * so the worker can re-resolve and inject the transcript: DB-first via
+   * getMessageByDiscordId (the row content IS the transcript for persisted voice),
+   * STT-fallback on the attachment url for never-persisted ambient voice. Shipped
+   * only for the messages that need re-resolution — a cache HIT ships its
+   * transcript on the message itself. ABSENT = fetch didn't run; EMPTY = fetch ran
+   * and every voice message already had its transcript.
+   */
+  rawExtendedContextVoiceMessages: z.array(attachmentMetadataSchema).optional(),
+  /**
    * Guild member info for the TRIGGERING user (message.member), the raw form
    * of activePersonaGuildInfo. Keyless scalar — no persona re-keying needed.
    * ABSENT = DM or member data unavailable.

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/ContextStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/ContextStep.test.ts
@@ -18,16 +18,19 @@ import {
   type LoadedPersonality,
 } from '@tzurot/common-types';
 import { HumanMessage, AIMessage } from '@langchain/core/messages';
-import { ContextStep } from './ContextStep.js';
+import { ContextStep, reTranscribeExtendedContextVoice } from './ContextStep.js';
+import type { AttachmentMetadata } from '@tzurot/common-types';
 import type { GenerationContext, ResolvedConfig } from '../types.js';
 
 // Use vi.hoisted to create mock functions before they're used in vi.mock
-const { mockExtractParticipants, mockConvertConversationHistory, mockLogger } = vi.hoisted(() => ({
-  mockExtractParticipants: vi.fn(),
-  mockConvertConversationHistory: vi.fn(),
-  // Module-level mock logger so tests can assert call shape on warn/info
-  mockLogger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
-}));
+const { mockExtractParticipants, mockConvertConversationHistory, mockTranscribeAudio, mockLogger } =
+  vi.hoisted(() => ({
+    mockExtractParticipants: vi.fn(),
+    mockConvertConversationHistory: vi.fn(),
+    mockTranscribeAudio: vi.fn(),
+    // Module-level mock logger so tests can assert call shape on warn/info
+    mockLogger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  }));
 
 // Mock common-types logger — use the hoisted mockLogger so tests can inspect
 // log calls for race-window telemetry assertions.
@@ -42,6 +45,10 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 vi.mock('../../../utils/conversationUtils.js', () => ({
   extractParticipants: mockExtractParticipants,
   convertConversationHistory: mockConvertConversationHistory,
+}));
+
+vi.mock('../../../../services/multimodal/AudioProcessor.js', () => ({
+  transcribeAudio: mockTranscribeAudio,
 }));
 
 const TEST_PERSONALITY: LoadedPersonality = {
@@ -862,5 +869,39 @@ describe('ContextStep', () => {
         expect.stringContaining('Race-window telemetry')
       );
     });
+  });
+});
+
+describe('reTranscribeExtendedContextVoice', () => {
+  const attachment = {
+    url: 'https://cdn/v.ogg',
+    originalUrl: 'https://cdn/v.ogg',
+    contentType: 'audio/ogg',
+    isVoiceMessage: true,
+  } as AttachmentMetadata;
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns the transcribed text on success', async () => {
+    mockTranscribeAudio.mockResolvedValue({ text: 'a transcript' });
+    expect(await reTranscribeExtendedContextVoice(attachment, { provider: 'mistral' })).toBe(
+      'a transcript'
+    );
+  });
+
+  it('defaults to the voice-engine dispatch when no STT was resolved', async () => {
+    mockTranscribeAudio.mockResolvedValue({ text: 'voice-engine transcript' });
+    await reTranscribeExtendedContextVoice(attachment, undefined);
+    expect(mockTranscribeAudio).toHaveBeenCalledWith(attachment, { provider: 'voice-engine' });
+  });
+
+  it('returns null on empty text', async () => {
+    mockTranscribeAudio.mockResolvedValue({ text: '' });
+    expect(await reTranscribeExtendedContextVoice(attachment, undefined)).toBeNull();
+  });
+
+  it('returns null (graceful) when transcription throws', async () => {
+    mockTranscribeAudio.mockRejectedValue(new Error('expired CDN url'));
+    expect(await reTranscribeExtendedContextVoice(attachment, undefined)).toBeNull();
   });
 });

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/ContextStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/ContextStep.ts
@@ -5,7 +5,12 @@
  * and oldest timestamp calculation for LTM deduplication.
  */
 
-import { createLogger, type MessageRole } from '@tzurot/common-types';
+import {
+  createLogger,
+  type MessageRole,
+  type AttachmentMetadata,
+  type SttDispatch,
+} from '@tzurot/common-types';
 import {
   extractParticipants,
   convertConversationHistory,
@@ -14,9 +19,34 @@ import type {
   AssembledCore,
   ContextAssembler,
 } from '../../../../services/context/ContextAssembler.js';
+import { transcribeAudio } from '../../../../services/multimodal/AudioProcessor.js';
 import type { IPipelineStep, GenerationContext, Participant, PreparedContext } from '../types.js';
 
 const logger = createLogger('ContextStep');
+
+/**
+ * STT fallback for an extended-context voice transcript the assembler's DB-first
+ * lookup misses (never-persisted ambient voice). `transcribeAudio` is itself
+ * Redis-cache-first, so a still-cached transcript costs no STT call. Failures
+ * (expired Discord CDN url, no provider) degrade to null — the message simply
+ * keeps no transcript, same as before this feature. Defaults to the self-hosted
+ * voice-engine dispatch when no BYOK STT was resolved (mirrors AttachmentProcessor).
+ */
+export async function reTranscribeExtendedContextVoice(
+  attachment: AttachmentMetadata,
+  sttDispatch: SttDispatch | undefined
+): Promise<string | null> {
+  try {
+    const result = await transcribeAudio(attachment, sttDispatch ?? { provider: 'voice-engine' });
+    return result.text.length > 0 ? result.text : null;
+  } catch (err) {
+    logger.warn(
+      { err, originalUrl: attachment.originalUrl ?? attachment.url },
+      'Extended-context voice re-transcription failed; keeping the message transcript-less'
+    );
+    return null;
+  }
+}
 
 /**
  * Apply the assembler's output onto the worker's local job.data in place. This
@@ -263,11 +293,16 @@ export class ContextStep implements IPipelineStep {
     const { job } = context;
     const jobContext = job.data.context;
 
+    const sttDispatch = context.auth?.sttDispatch;
     const assembled = await assembler.assembleCore(
       jobContext,
       job.data.personality,
       context.configOverrides,
-      { referenceDedupNowMs: job.timestamp }
+      {
+        referenceDedupNowMs: job.timestamp,
+        reTranscribeVoiceViaStt: attachment =>
+          reTranscribeExtendedContextVoice(attachment, sttDispatch),
+      }
     );
     applyAssembledContext(job, assembled);
 

--- a/services/ai-worker/src/services/context/ContextAssembler.test.ts
+++ b/services/ai-worker/src/services/context/ContextAssembler.test.ts
@@ -11,6 +11,7 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 import {
   MessageRole,
   rawAssemblyInputsSchema,
+  type ConversationMessage,
   type JobContext,
   type LoadedPersonality,
   type ResolvedConfigOverrides,
@@ -835,5 +836,171 @@ describe('ContextAssembler.assembleCore — schema-coupled re-derivation', () =>
     expect(core.history).toEqual([]);
     expect(core.participantGuildInfo).toBeUndefined();
     expect(core.referencedMessages).toBeUndefined();
+  });
+});
+
+describe('ContextAssembler — extended-context voice transcript re-resolution', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const voiceRef = {
+    url: 'https://cdn/v.ogg',
+    originalUrl: 'https://cdn/v.ogg',
+    contentType: 'audio/ogg',
+    isVoiceMessage: true,
+    sourceDiscordMessageId: 'd-voice',
+  };
+
+  // An extended-context voice message (id d-voice) shipped with its voice ref;
+  // `shipped` sets the transcript the bot already resolved (a cache HIT), absent
+  // = the aged-out case the worker re-resolves.
+  function voiceJobContext(shipped?: string[]): JobContext {
+    return makeJobContext({
+      rawAssemblyInputs: {
+        rawMessageContent: 'hello',
+        rawExtendedContextMessages: [
+          {
+            role: MessageRole.User,
+            content: '[voice message]',
+            discordMessageId: ['d-voice'],
+            ...(shipped !== undefined ? { messageMetadata: { voiceTranscripts: shipped } } : {}),
+          },
+        ],
+        rawExtendedContextVoiceMessages: [voiceRef],
+      },
+    });
+  }
+
+  function transcriptsOf(core: { history: ConversationMessage[] }): string[] | undefined {
+    const msg = core.history.find(m => (m.discordMessageId ?? []).includes('d-voice'));
+    return msg?.messageMetadata?.voiceTranscripts;
+  }
+
+  it('passes the transcript through from the DB row content without calling STT', async () => {
+    const deps = makeDeps({
+      dataSource: {
+        getMessageByDiscordId: vi.fn().mockResolvedValue({ content: 'db transcript' }),
+      },
+    });
+    const stt = vi.fn().mockResolvedValue('stt transcript');
+    const core = await new ContextAssembler(deps).assembleCore(
+      voiceJobContext(),
+      PERSONALITY,
+      undefined,
+      {
+        reTranscribeVoiceViaStt: stt,
+      }
+    );
+    expect(transcriptsOf(core)).toEqual(['db transcript']);
+    expect(stt).not.toHaveBeenCalled();
+  });
+
+  it('falls back to STT when the message is not in the DB', async () => {
+    const deps = makeDeps({
+      dataSource: { getMessageByDiscordId: vi.fn().mockResolvedValue(null) },
+    });
+    const stt = vi.fn().mockResolvedValue('stt transcript');
+    const core = await new ContextAssembler(deps).assembleCore(
+      voiceJobContext(),
+      PERSONALITY,
+      undefined,
+      {
+        reTranscribeVoiceViaStt: stt,
+      }
+    );
+    expect(transcriptsOf(core)).toEqual(['stt transcript']);
+    expect(stt).toHaveBeenCalledOnce();
+  });
+
+  it('leaves a message that already shipped a transcript untouched (no DB/STT lookup)', async () => {
+    const getMessageByDiscordId = vi.fn().mockResolvedValue({ content: 'db transcript' });
+    const deps = makeDeps({ dataSource: { getMessageByDiscordId } });
+    const stt = vi.fn();
+    const core = await new ContextAssembler(deps).assembleCore(
+      voiceJobContext(['already here']),
+      PERSONALITY,
+      undefined,
+      { reTranscribeVoiceViaStt: stt }
+    );
+    expect(transcriptsOf(core)).toEqual(['already here']);
+    expect(getMessageByDiscordId).not.toHaveBeenCalled();
+    expect(stt).not.toHaveBeenCalled();
+  });
+
+  it('degrades gracefully (no transcript) when both DB and STT miss', async () => {
+    const deps = makeDeps({
+      dataSource: { getMessageByDiscordId: vi.fn().mockResolvedValue(null) },
+    });
+    const stt = vi.fn().mockResolvedValue(null);
+    const core = await new ContextAssembler(deps).assembleCore(
+      voiceJobContext(),
+      PERSONALITY,
+      undefined,
+      {
+        reTranscribeVoiceViaStt: stt,
+      }
+    );
+    expect(transcriptsOf(core)).toBeUndefined();
+  });
+
+  it('caps re-resolution to the newest refs when the count exceeds the cap', async () => {
+    const N = 12; // > EXTENDED_CONTEXT_VOICE_REDERIVE_CAP (10)
+    const ids = Array.from({ length: N }, (_, i) => `d-voice-${i}`); // collector order: oldest-first
+    const deps = makeDeps({
+      dataSource: {
+        getMessageByDiscordId: vi.fn(async (id: string) => ({ content: `db-${id}` })),
+      },
+    });
+    const core = await new ContextAssembler(deps).assembleCore(
+      makeJobContext({
+        rawAssemblyInputs: {
+          rawMessageContent: 'hello',
+          rawExtendedContextMessages: ids.map(id => ({
+            role: MessageRole.User,
+            content: '[voice message]',
+            discordMessageId: [id],
+          })),
+          rawExtendedContextVoiceMessages: ids.map(id => ({
+            ...voiceRef,
+            sourceDiscordMessageId: id,
+          })),
+        },
+      }),
+      PERSONALITY,
+      undefined,
+      { reTranscribeVoiceViaStt: vi.fn() }
+    );
+    const transcriptFor = (id: string): string[] | undefined =>
+      core.history.find(m => (m.discordMessageId ?? []).includes(id))?.messageMetadata
+        ?.voiceTranscripts;
+    // The two OLDEST refs are dropped by the cap...
+    expect(transcriptFor('d-voice-0')).toBeUndefined();
+    expect(transcriptFor('d-voice-1')).toBeUndefined();
+    // ...the newest 10 are re-resolved.
+    expect(transcriptFor('d-voice-2')).toEqual(['db-d-voice-2']);
+    expect(transcriptFor('d-voice-11')).toEqual(['db-d-voice-11']);
+  });
+
+  it('skips a voice ref with no sourceDiscordMessageId (no DB/STT lookup)', async () => {
+    const getMessageByDiscordId = vi.fn();
+    const deps = makeDeps({ dataSource: { getMessageByDiscordId } });
+    const stt = vi.fn();
+    await new ContextAssembler(deps).assembleCore(
+      makeJobContext({
+        rawAssemblyInputs: {
+          rawMessageContent: 'hello',
+          rawExtendedContextMessages: [
+            { role: MessageRole.User, content: 'x', discordMessageId: ['d1'] },
+          ],
+          rawExtendedContextVoiceMessages: [
+            { url: 'https://cdn/v.ogg', contentType: 'audio/ogg', isVoiceMessage: true }, // no sourceDiscordMessageId
+          ],
+        },
+      }),
+      PERSONALITY,
+      undefined,
+      { reTranscribeVoiceViaStt: stt }
+    );
+    expect(getMessageByDiscordId).not.toHaveBeenCalled();
+    expect(stt).not.toHaveBeenCalled();
   });
 });

--- a/services/ai-worker/src/services/context/ContextAssembler.ts
+++ b/services/ai-worker/src/services/context/ContextAssembler.ts
@@ -23,6 +23,7 @@ import {
   mergeWithHistory,
   resolveExtendedContextPersonaIds,
   MESSAGE_LIMITS,
+  type AttachmentMetadata,
   type ConversationMessage,
   type CrossChannelHistoryGroupEntry,
   type GuildMemberInfo,
@@ -102,7 +103,26 @@ export interface AssembleCoreOptions {
    * timestamp. Undefined disables the time fallback (exact-id dedup only).
    */
   referenceDedupNowMs?: number;
+  /**
+   * STT fallback for extended-context voice transcripts the DB-first lookup
+   * misses (never-persisted ambient voice). Returns the transcript text, or
+   * null on failure (expired CDN url, no usable provider). Built by ContextStep
+   * with the resolved `sttDispatch`; passing it as a callback keeps the
+   * assembler decoupled from the audio/STT machinery (mirrors how the reference
+   * retriever is a callback). Absent ⇒ DB-only re-resolution.
+   */
+  reTranscribeVoiceViaStt?: (attachment: AttachmentMetadata) => Promise<string | null>;
 }
+
+/**
+ * Upper bound on extended-context voice transcripts re-resolved per turn. The
+ * DB-first tier makes most resolutions cheap lookups, but this caps the
+ * worst-case fan-out (incl. the STT fallback) so it can't dominate assembly
+ * latency on a channel with many aged-out voice messages. 10 is ~2× headroom
+ * over the typical extended-context voice count (a handful per window); raise it
+ * only if real rooms routinely exceed that and lose tail transcripts.
+ */
+const EXTENDED_CONTEXT_VOICE_REDERIVE_CAP = 10;
 
 export interface ContextAssemblerDeps {
   dataSource: ContextDataSource;
@@ -232,6 +252,17 @@ export class ContextAssembler {
         channelId,
         guildId: jobContext.serverId ?? null,
       }
+    );
+
+    // Step 4.5: re-resolve transcripts for extended-context voice messages the
+    // bot couldn't transcribe at fetch time (aged out of its Redis cache). The
+    // transcript text the bot already produced lives in the DB for persisted
+    // voice; STT only re-runs for never-persisted ambient voice. Mutates the
+    // matching history messages in place before reference enrichment reads them.
+    await this.injectExtendedContextVoiceTranscripts(
+      history,
+      raw.rawExtendedContextVoiceMessages,
+      options
     );
 
     // Step 5: re-derive reference enrichment from the raw snapshots —
@@ -502,5 +533,82 @@ export class ContextAssembler {
     }
 
     return { history: mergeWithHistory(messages, dbHistory), participantGuildInfo };
+  }
+
+  /**
+   * Re-resolve transcripts for extended-context voice messages the bot shipped
+   * unresolved (`rawExtendedContextVoiceMessages` — cache miss at fetch time),
+   * and inject them onto the matching history messages in place. Bounded +
+   * parallelized; skips any message that already carries a transcript (a cache
+   * HIT shipped its text on the message itself).
+   */
+  private async injectExtendedContextVoiceTranscripts(
+    history: ConversationMessage[],
+    voiceRefs: AttachmentMetadata[] | undefined,
+    options: AssembleCoreOptions | undefined
+  ): Promise<void> {
+    if (voiceRefs === undefined || voiceRefs.length === 0) {
+      return;
+    }
+    // The refs arrive in collector order — OLDEST-first (bot-client reverses only
+    // the `messages` array before shipping, not the attachment lists). Take the
+    // newest TAIL so the cap, when it bites, keeps the most-recent unresolved voice
+    // — the right priority for room awareness. (slice(-n) returns the whole array
+    // when there are fewer than n, so no length guard is needed.)
+    if (voiceRefs.length > EXTENDED_CONTEXT_VOICE_REDERIVE_CAP) {
+      // Operational signal: a high-activity voice channel silently loses the
+      // oldest transcripts under the cap; log so it's traceable.
+      logger.info(
+        { total: voiceRefs.length, cap: EXTENDED_CONTEXT_VOICE_REDERIVE_CAP },
+        'Extended-context voice cap reached; oldest unresolved transcripts dropped'
+      );
+    }
+    const capped = voiceRefs.slice(-EXTENDED_CONTEXT_VOICE_REDERIVE_CAP);
+    await Promise.all(
+      capped.map(async ref => {
+        const sourceId = ref.sourceDiscordMessageId;
+        if (sourceId === undefined || sourceId.length === 0) {
+          return;
+        }
+        const target = history.find(m => (m.discordMessageId ?? []).includes(sourceId));
+        // Only re-resolve when the message lacks a transcript — a cache HIT
+        // shipped its transcript on the message metadata already. The pre-await
+        // guard is race-safe because Discord allows one audio attachment per voice
+        // message, so the collector ships at most one ref per sourceDiscordMessageId
+        // — no two concurrent tasks target the same message.
+        if (target === undefined || (target.messageMetadata?.voiceTranscripts?.length ?? 0) > 0) {
+          return;
+        }
+        // resolveVoiceTranscript never returns an empty string (both tiers guard
+        // length), so a non-null result is always a usable transcript.
+        const transcript = await this.resolveVoiceTranscript(sourceId, ref, options);
+        if (transcript !== null) {
+          target.messageMetadata = { ...target.messageMetadata, voiceTranscripts: [transcript] };
+        }
+      })
+    );
+  }
+
+  /**
+   * DB-first, STT-fallback transcript resolution for one extended-context voice
+   * message. The persisted row's content IS the transcript (identical to the
+   * reference retriever) — cheap and always preferred; STT only re-runs for
+   * never-persisted ambient voice the bot transcribed for display but never
+   * stored. Returns null when neither yields text (graceful: no transcript).
+   */
+  private async resolveVoiceTranscript(
+    discordMessageId: string,
+    attachment: AttachmentMetadata,
+    options: AssembleCoreOptions | undefined
+  ): Promise<string | null> {
+    // Same DB tier as the reference retriever (the `retrieveTranscript` closure in
+    // enrichReferences): both do getMessageByDiscordId → row.content. Kept as
+    // separate sites because that closure binds its own dedup window; if the DB
+    // access pattern changes, update both.
+    const row = await this.deps.dataSource.getMessageByDiscordId(discordMessageId);
+    if (row?.content !== undefined && row.content.length > 0) {
+      return row.content;
+    }
+    return (await options?.reTranscribeVoiceViaStt?.(attachment)) ?? null;
   }
 }

--- a/services/bot-client/src/services/DiscordChannelFetcher.test.ts
+++ b/services/bot-client/src/services/DiscordChannelFetcher.test.ts
@@ -1460,6 +1460,48 @@ describe('DiscordChannelFetcher', () => {
       expect(result.messages[0].messageMetadata?.voiceTranscripts?.join('') ?? '').not.toContain(
         'Fallback transcript'
       );
+      // Resolved transcript ⇒ no re-resolution ref shipped to the worker.
+      expect(result.voiceAttachments ?? []).toHaveLength(0);
+    });
+
+    it('ships a voice attachment ref when the transcript could not be resolved', async () => {
+      const voiceMessageId = 'voice-unresolved-1';
+      const messages = [
+        createMockMessage({
+          id: voiceMessageId,
+          content: '',
+          authorId: 'user1',
+          authorUsername: 'alice',
+          createdAt: new Date('2024-01-01T12:00:00Z'),
+          attachments: new Map([
+            [
+              'att1',
+              {
+                id: 'att1',
+                url: 'https://cdn.discord.com/voice-message.ogg',
+                contentType: 'audio/ogg',
+                name: 'voice-message.ogg',
+                duration: 5,
+                waveform: 'abc',
+              },
+            ],
+          ]),
+        }),
+      ];
+      const channel = createMockChannel(messages);
+      // No DB transcript, no bot reply in window ⇒ unresolved.
+      const getTranscript = vi.fn().mockResolvedValue(null);
+
+      const result = await fetcher.fetchRecentMessages(channel, {
+        botUserId: 'bot123',
+        getTranscript,
+      });
+
+      expect(result.messages[0].messageMetadata?.voiceTranscripts ?? []).toHaveLength(0);
+      // The worker re-resolves these (DB-first, STT-fallback).
+      expect(result.voiceAttachments).toHaveLength(1);
+      expect(result.voiceAttachments?.[0].sourceDiscordMessageId).toBe(voiceMessageId);
+      expect(result.voiceAttachments?.[0].isVoiceMessage).toBe(true);
     });
 
     it('should fall back to bot reply when DB returns null', async () => {

--- a/services/bot-client/src/services/DiscordChannelFetcher.ts
+++ b/services/bot-client/src/services/DiscordChannelFetcher.ts
@@ -22,6 +22,7 @@ import {
 } from '@tzurot/common-types';
 import { buildMessageContent, hasMessageContent } from '../utils/MessageContentBuilder.js';
 import { isUserContentMessage } from '../utils/messageTypeUtils.js';
+import { collectExtendedContextAttachments } from './channelFetcher/extendedContextAttachmentCollector.js';
 import { resolveHistoryLinks } from '../utils/HistoryLinkResolver.js';
 import { extractPersonalityName, stripBotSuffix } from '../utils/webhookNaming.js';
 
@@ -138,6 +139,8 @@ export class DiscordChannelFetcher {
         rawMessages: discordMessages, // For opportunistic sync
         imageAttachments:
           processResult.imageAttachments.length > 0 ? processResult.imageAttachments : undefined,
+        voiceAttachments:
+          processResult.voiceAttachments.length > 0 ? processResult.voiceAttachments : undefined,
         participantGuildInfo: participantCount > 0 ? processResult.participantGuildInfo : undefined,
         extendedContextUsers: userCount > 0 ? processResult.extendedContextUsers : undefined,
         reactorUsers: reactorCount > 0 ? processResult.reactorUsers : undefined,
@@ -171,12 +174,14 @@ export class DiscordChannelFetcher {
   ): Promise<{
     messages: ConversationMessage[];
     imageAttachments: AttachmentMetadata[];
+    voiceAttachments: AttachmentMetadata[];
     participantGuildInfo: Record<string, ParticipantGuildInfo>;
     extendedContextUsers: ExtendedContextUser[];
     reactorUsers: ExtendedContextUser[];
   }> {
     const result: ConversationMessage[] = [];
     const collectedImageAttachments: AttachmentMetadata[] = [];
+    const collectedVoiceAttachments: AttachmentMetadata[] = [];
     const participantGuildInfo: Record<string, ParticipantGuildInfo> = {};
     const uniqueUsers = new Map<string, ExtendedContextUser>();
     const messageIdToIndex = new Map<string, number>();
@@ -263,13 +268,12 @@ export class DiscordChannelFetcher {
         messageIdToIndex.set(msg.id, result.length);
         result.push(conversionResult.message);
 
-        // Collect image attachments
-        if (conversionResult.attachments.length > 0) {
-          const images = conversionResult.attachments
-            .filter(a => a.contentType?.startsWith('image/') && a.isVoiceMessage !== true)
-            .map(img => ({ ...img, sourceDiscordMessageId: msg.id }));
-          collectedImageAttachments.push(...images);
-        }
+        collectExtendedContextAttachments(
+          conversionResult,
+          msg.id,
+          collectedImageAttachments,
+          collectedVoiceAttachments
+        );
 
         // Collect guild info + unique user info for participant/persona
         // resolution — but ONLY for messages authored by a real (non-bot) user.
@@ -320,6 +324,7 @@ export class DiscordChannelFetcher {
     return {
       messages: result.reverse(),
       imageAttachments: collectedImageAttachments,
+      voiceAttachments: collectedVoiceAttachments,
       participantGuildInfo: limitedParticipantGuildInfo,
       extendedContextUsers,
       reactorUsers,

--- a/services/bot-client/src/services/channelFetcher/extendedContextAttachmentCollector.test.ts
+++ b/services/bot-client/src/services/channelFetcher/extendedContextAttachmentCollector.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MessageRole,
+  type AttachmentMetadata,
+  type ConversationMessage,
+} from '@tzurot/common-types';
+import { collectExtendedContextAttachments } from './extendedContextAttachmentCollector.js';
+
+const image: AttachmentMetadata = {
+  url: 'https://cdn/x.png',
+  contentType: 'image/png',
+  name: 'x.png',
+};
+const voice: AttachmentMetadata = {
+  url: 'https://cdn/v.ogg',
+  contentType: 'audio/ogg',
+  name: 'v.ogg',
+  isVoiceMessage: true,
+};
+
+function conv(
+  attachments: AttachmentMetadata[],
+  voiceTranscripts?: string[]
+): { message: ConversationMessage; attachments: AttachmentMetadata[] } {
+  return {
+    message: {
+      role: MessageRole.User,
+      content: 'hi',
+      ...(voiceTranscripts !== undefined ? { messageMetadata: { voiceTranscripts } } : {}),
+    } as ConversationMessage,
+    attachments,
+  };
+}
+
+describe('collectExtendedContextAttachments', () => {
+  it('collects images and stamps the source message id', () => {
+    const images: AttachmentMetadata[] = [];
+    const voiceOut: AttachmentMetadata[] = [];
+    collectExtendedContextAttachments(conv([image]), 'm1', images, voiceOut);
+    expect(images).toHaveLength(1);
+    expect(images[0].sourceDiscordMessageId).toBe('m1');
+    expect(voiceOut).toHaveLength(0);
+  });
+
+  it('ships a voice ref when the transcript is unresolved (empty voiceTranscripts)', () => {
+    const images: AttachmentMetadata[] = [];
+    const voiceOut: AttachmentMetadata[] = [];
+    collectExtendedContextAttachments(conv([voice]), 'm2', images, voiceOut);
+    expect(voiceOut).toHaveLength(1);
+    expect(voiceOut[0].sourceDiscordMessageId).toBe('m2');
+    expect(voiceOut[0].isVoiceMessage).toBe(true);
+  });
+
+  it('does NOT ship a voice ref when the transcript already resolved', () => {
+    const images: AttachmentMetadata[] = [];
+    const voiceOut: AttachmentMetadata[] = [];
+    collectExtendedContextAttachments(conv([voice], ['resolved']), 'm3', images, voiceOut);
+    expect(voiceOut).toHaveLength(0);
+  });
+
+  it('strips voice from images and only ships the unresolved voice ref for a mixed message', () => {
+    const images: AttachmentMetadata[] = [];
+    const voiceOut: AttachmentMetadata[] = [];
+    collectExtendedContextAttachments(conv([image, voice]), 'm4', images, voiceOut);
+    expect(images).toHaveLength(1);
+    expect(images[0].contentType).toBe('image/png');
+    expect(voiceOut).toHaveLength(1);
+    expect(voiceOut[0].contentType).toBe('audio/ogg');
+  });
+
+  it('is a no-op when there are no attachments', () => {
+    const images: AttachmentMetadata[] = [];
+    const voiceOut: AttachmentMetadata[] = [];
+    collectExtendedContextAttachments(conv([]), 'm5', images, voiceOut);
+    expect(images).toHaveLength(0);
+    expect(voiceOut).toHaveLength(0);
+  });
+});

--- a/services/bot-client/src/services/channelFetcher/extendedContextAttachmentCollector.ts
+++ b/services/bot-client/src/services/channelFetcher/extendedContextAttachmentCollector.ts
@@ -1,0 +1,46 @@
+import type { AttachmentMetadata, ConversationMessage } from '@tzurot/common-types';
+
+/**
+ * Fan a converted extended-context message's attachments into the two flat
+ * worker-bound lists (each ref stamped with its source message id):
+ * - images → always (the worker re-derives vision descriptions);
+ * - voice → only when the bot couldn't transcribe it at fetch time (empty
+ *   `voiceTranscripts`: aged out of the Redis cache, no bot reply in window).
+ *   The worker re-resolves those (DB-first, STT-fallback). A resolved transcript
+ *   already rides on the message metadata, so it needs no ref.
+ *
+ * Mutates `images`/`voice` in place (push). No-op when the message has no
+ * attachments.
+ *
+ * IMPORTANT — ordering invariant: callers push in iteration order, which is
+ * OLDEST-first (the fetcher reverses only the `messages` array, not these
+ * attachment lists). The worker caps both lists from the TAIL — images via
+ * `slice(-maxImages)` and voice via `slice(-cap)` in
+ * `ContextAssembler.injectExtendedContextVoiceTranscripts` — to keep the NEWEST
+ * when a window exceeds the cap. Do NOT reverse these lists to match `messages`
+ * without flipping those slices, or the cap would silently keep the stalest
+ * attachments (no test fails on the bot side — the assumption is cross-file).
+ */
+export function collectExtendedContextAttachments(
+  conversionResult: { message: ConversationMessage; attachments: AttachmentMetadata[] },
+  sourceDiscordMessageId: string,
+  images: AttachmentMetadata[],
+  voice: AttachmentMetadata[]
+): void {
+  if (conversionResult.attachments.length === 0) {
+    return;
+  }
+  images.push(
+    ...conversionResult.attachments
+      .filter(a => a.contentType?.startsWith('image/') && a.isVoiceMessage !== true)
+      .map(img => ({ ...img, sourceDiscordMessageId }))
+  );
+  const resolvedTranscripts = conversionResult.message.messageMetadata?.voiceTranscripts;
+  if (resolvedTranscripts === undefined || resolvedTranscripts.length === 0) {
+    voice.push(
+      ...conversionResult.attachments
+        .filter(a => a.isVoiceMessage === true)
+        .map(v => ({ ...v, sourceDiscordMessageId }))
+    );
+  }
+}

--- a/services/bot-client/src/services/channelFetcher/types.ts
+++ b/services/bot-client/src/services/channelFetcher/types.ts
@@ -43,8 +43,18 @@ export interface FetchResult {
   filteredCount: number;
   /** Raw Discord messages for opportunistic sync (if needed) */
   rawMessages?: Collection<string, Message>;
-  /** Image attachments collected from extended context messages (newest first) */
+  /** Image attachments collected from extended context messages, in collection
+   * order (OLDEST-first — only the `messages` array is reversed to newest-first).
+   * The worker caps with slice(-maxImages) to keep the newest. */
   imageAttachments?: AttachmentMetadata[];
+  /**
+   * Voice attachments from extended-context messages whose transcript the bot
+   * could NOT resolve at fetch time (cache miss + no bot-reply in window). The
+   * worker re-resolves these (DB-first, STT-fallback). Each carries
+   * `sourceDiscordMessageId` so the worker can match it to its message. Same
+   * OLDEST-first collection order as imageAttachments (worker takes the newest tail).
+   */
+  voiceAttachments?: AttachmentMetadata[];
   /** Guild info for participants (keyed by personaId, e.g., 'discord:123456789') */
   participantGuildInfo?: Record<string, ParticipantGuildInfo>;
   /** Unique users from extended context for batch persona creation */

--- a/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.ts
+++ b/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.ts
@@ -35,6 +35,9 @@ export interface RawExtendedContextSnapshot {
   participantGuildInfo?: Record<string, GuildMemberInfo>;
   /** Uncapped extended-context image list (each carries sourceDiscordMessageId). */
   imageAttachments?: AttachmentMetadata[];
+  /** Extended-context voice attachments the bot couldn't transcribe at fetch time
+   * (each carries sourceDiscordMessageId); the worker re-resolves them. */
+  voiceAttachments?: AttachmentMetadata[];
 }
 
 /**
@@ -52,6 +55,7 @@ export function captureRawExtendedContext(
     | 'reactorUsers'
     | 'participantGuildInfo'
     | 'imageAttachments'
+    | 'voiceAttachments'
   >
 ): RawExtendedContextSnapshot {
   return {
@@ -69,6 +73,8 @@ export function captureRawExtendedContext(
         : undefined,
     imageAttachments:
       fetchResult.imageAttachments !== undefined ? [...fetchResult.imageAttachments] : undefined,
+    voiceAttachments:
+      fetchResult.voiceAttachments !== undefined ? [...fetchResult.voiceAttachments] : undefined,
   };
 }
 
@@ -157,6 +163,7 @@ export function buildRawAssemblyInputs(
     rawReactorUsers: raw?.reactorUsers.map(toRawDiscordUser),
     rawParticipantGuildInfo: raw?.participantGuildInfo,
     rawExtendedContextImageAttachments: raw?.imageAttachments,
+    rawExtendedContextVoiceMessages: raw?.voiceAttachments,
     knownChannelEnvironments: buildKnownChannelEnvironments(message.client),
   };
 }


### PR DESCRIPTION
## Bug (silent correctness)

After the 2.5d cutover, bot-client's voice-transcript retrieval is **Redis-cache-only** (5-min TTL). An **extended-context** voice message whose transcript aged out of that cache shipped to the worker **without its text**, and the worker trusted the empty value. So a voice message older than ~5 min in the room **lost its transcript** from the AI's context.

## Design — DB-first, STT-fallback

The transcript already exists somewhere durable, so pass it through before re-deriving (this challenged the original council "STT-only" plan — re-transcribing re-does work that's already in the DB):

1. **DB-first** — `ContextAssembler.mergeExtendedContext` re-resolves a missing transcript via `getMessageByDiscordId` → `row.content` (the row content *is* the transcript for persisted voice — identical to the reference retriever at `ContextAssembler.ts:435`). Cheap, no STT.
2. **STT-fallback** — on a DB miss (never-persisted ambient / display-only voice the bot transcribed but never stored), `transcribeAudio` on the shipped attachment URL (itself Redis-cache-first). Graceful → null on failure (expired CDN url, no provider): the message just keeps no transcript, same as before.

## Changes
- **common-types**: `rawExtendedContextVoiceMessages` on the raw envelope (reuses `attachmentMetadataSchema`) — voice attachment refs (url + `sourceDiscordMessageId`) needed for the STT fallback's URL.
- **bot-client**: `DiscordChannelFetcher` ships a ref **only** for extended-context voice whose transcript stayed unresolved (a cache HIT already rides its transcript on the message). Collection extracted to a colocated `extendedContextAttachmentCollector` module (keeps `processMessages` under the statement/line limits).
- **ai-worker**: the re-resolve+inject step (DB-first → STT-fallback), keyed by `discordMessageId`, **parallelized + capped** (`EXTENDED_CONTEXT_VOICE_REDERIVE_CAP = 10`); the STT callback (with the resolved `sttDispatch`) is threaded from `ContextStep` so the assembler stays decoupled from the audio machinery.

bot-client stays Prisma-free. Worker telemetry untouched (reads the built `ConversationContext`, not the wire field).

## Test plan
- ai-worker `ContextAssembler.test.ts`: DB pass-through (no STT), STT fallback on DB miss, skip-if-already-shipped (no lookup), graceful on total miss.
- bot-client `extendedContextAttachmentCollector.test.ts` (5 cases) + `DiscordChannelFetcher.test.ts`: ships a ref only when unresolved.
- `pnpm quality` 24/24; full unit + `test:int` in CI (Steam Deck OOM).

## Risks
- STT in the assembly hot path is bounded: DB-first handles the common case, only aged-out refs are shipped, cache-first inside `transcribeAudio`, capped + parallelized.
- Discord CDN signed-URL expiry (~24h): older-than-validity voice can't be re-fetched → graceful no-transcript (logged).
