### PR TITLE
fix(common-types): stable Discord attachment cache key for voice transcripts

### DIFF
--- a/packages/common-types/src/constants/timing.ts
+++ b/packages/common-types/src/constants/timing.ts
@@ -96,8 +96,17 @@ export const INTERVALS = {
   MESSAGE_TIMESTAMP_TOLERANCE: 15000,
   /** Webhook message tracking TTL in Redis (7 days in seconds) */
   WEBHOOK_MESSAGE_TTL: 7 * 24 * 60 * 60,
-  /** Voice transcript cache TTL in Redis (5 minutes in seconds) */
-  VOICE_TRANSCRIPT_TTL: 5 * 60,
+  /**
+   * Voice transcript cache TTL in Redis (1 hour in seconds). Matches
+   * VISION_DESCRIPTION_TTL: the cache key is derived from the immutable
+   * attachment id / query-stripped CDN path (see `deriveAttachmentCacheKey`),
+   * so a transcript stays valid as long as the attachment exists — a generous
+   * TTL is pure upside and the value is a small string. Re-derivation for
+   * aged-out extended-context voice no longer depends on this cache (the worker
+   * falls back to the DB row), so this is a hot-path optimization, not a
+   * correctness dependency.
+   */
+  VOICE_TRANSCRIPT_TTL: 60 * 60,
   /** Vision description cache TTL in Redis (1 hour in seconds - image URLs are stable for a while) */
   VISION_DESCRIPTION_TTL: 60 * 60,
   /**

--- a/packages/common-types/src/index.ts
+++ b/packages/common-types/src/index.ts
@@ -49,6 +49,7 @@ export * from './utils/dateFormatting.js';
 export * from './utils/errors.js';
 export * from './utils/timeout.js';
 export * from './utils/deterministicUuid.js';
+export * from './utils/attachmentCacheKey.js';
 export * from './utils/tokenCounter.js';
 export * from './utils/contextWindowCap.js';
 export * from './utils/textChunker.js';

--- a/packages/common-types/src/services/VoiceTranscriptCache.test.ts
+++ b/packages/common-types/src/services/VoiceTranscriptCache.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { Redis } from 'ioredis';
+import { VoiceTranscriptCache } from './VoiceTranscriptCache.js';
+import { REDIS_KEY_PREFIXES, INTERVALS } from '../constants/index.js';
+
+/**
+ * Minimal in-memory Redis stub honoring the two methods the cache uses.
+ * TTL is captured but not enforced (the tests don't exercise expiry).
+ */
+function makeRedisStub(): {
+  redis: Redis;
+  store: Map<string, string>;
+  lastSetexTtl: () => number | undefined;
+} {
+  const store = new Map<string, string>();
+  let lastTtl: number | undefined;
+  const redis = {
+    async setex(key: string, ttl: number, value: string): Promise<'OK'> {
+      lastTtl = ttl;
+      store.set(key, value);
+      return 'OK';
+    },
+    async get(key: string): Promise<string | null> {
+      return store.get(key) ?? null;
+    },
+  } as unknown as Redis;
+  return { redis, store, lastSetexTtl: () => lastTtl };
+}
+
+describe('VoiceTranscriptCache', () => {
+  const base = 'https://cdn.discordapp.com/attachments/111/222/voice.ogg';
+  let stub: ReturnType<typeof makeRedisStub>;
+  let cache: VoiceTranscriptCache;
+
+  beforeEach(() => {
+    stub = makeRedisStub();
+    cache = new VoiceTranscriptCache(stub.redis);
+  });
+
+  it('round-trips a transcript stored and read under the same URL', async () => {
+    await cache.store(`${base}?ex=AAAA&is=BBBB&hs=CCCC`, 'hello world');
+    const got = await cache.get(`${base}?ex=AAAA&is=BBBB&hs=CCCC`);
+    expect(got).toBe('hello world');
+  });
+
+  it('HITS when stored and read under DIFFERENT signatures of the same attachment', async () => {
+    // The core bug fix: Discord re-signs ex/is/hs on every re-fetch, so the
+    // store-side URL and the lookup-side URL differ — but must resolve to one key.
+    await cache.store(`${base}?ex=AAAA&is=BBBB&hs=CCCC`, 'transcribed text');
+    const got = await cache.get(`${base}?ex=ZZZZ&is=YYYY&hs=XXXX`);
+    expect(got).toBe('transcribed text');
+  });
+
+  it('stores under a query-stripped, hashed key (not the raw signed URL)', async () => {
+    await cache.store(`${base}?ex=AAAA`, 'text');
+    const keys = [...stub.store.keys()];
+    expect(keys).toHaveLength(1);
+    expect(keys[0].startsWith(`${REDIS_KEY_PREFIXES.VOICE_TRANSCRIPT}url:`)).toBe(true);
+    expect(keys[0]).not.toContain('ex=AAAA');
+    expect(keys[0]).not.toContain(base);
+  });
+
+  it('MISSES for a different attachment path', async () => {
+    await cache.store(`${base}?ex=AAAA`, 'text');
+    const got = await cache.get('https://cdn.discordapp.com/attachments/111/333/other.ogg?ex=AAAA');
+    expect(got).toBeNull();
+  });
+
+  it('defaults the store TTL to VOICE_TRANSCRIPT_TTL', async () => {
+    await cache.store(base, 'text');
+    expect(stub.lastSetexTtl()).toBe(INTERVALS.VOICE_TRANSCRIPT_TTL);
+  });
+
+  it('honors an explicit ttlSeconds override', async () => {
+    await cache.store(base, 'text', 120);
+    expect(stub.lastSetexTtl()).toBe(120);
+  });
+
+  it('returns null (not the empty string) for an empty cached value', async () => {
+    await cache.store(base, '');
+    expect(await cache.get(base)).toBeNull();
+  });
+});

--- a/packages/common-types/src/services/VoiceTranscriptCache.ts
+++ b/packages/common-types/src/services/VoiceTranscriptCache.ts
@@ -9,6 +9,7 @@
 
 import type { Redis } from 'ioredis';
 import { createLogger } from '../utils/logger.js';
+import { deriveAttachmentCacheKey } from '../utils/attachmentCacheKey.js';
 import { REDIS_KEY_PREFIXES, INTERVALS } from '../constants/index.js';
 
 const logger = createLogger('VoiceTranscriptCache');
@@ -17,10 +18,21 @@ export class VoiceTranscriptCache {
   constructor(private redis: Redis) {}
 
   /**
+   * Derive the stable Redis key for an attachment URL. Strips the volatile
+   * Discord CDN signature query (`?ex=&is=&hs=`) so the same audio resolves to
+   * one key across re-fetches — otherwise every re-signed URL was a cache miss.
+   * Voice supplies no attachment id store-side, so this always takes the
+   * query-stripped url-hash branch (the path embeds the immutable attachment id).
+   */
+  private keyFor(attachmentUrl: string): string {
+    return deriveAttachmentCacheKey(REDIS_KEY_PREFIXES.VOICE_TRANSCRIPT, { url: attachmentUrl });
+  }
+
+  /**
    * Store voice transcript in cache
    * @param attachmentUrl Discord CDN attachment URL (originalUrl)
    * @param transcript Transcribed text
-   * @param ttlSeconds Time to live in seconds (default: 5 minutes)
+   * @param ttlSeconds Time to live in seconds (default: VOICE_TRANSCRIPT_TTL, 1 hour)
    */
   async store(
     attachmentUrl: string,
@@ -29,11 +41,7 @@ export class VoiceTranscriptCache {
   ): Promise<void> {
     try {
       // ioredis uses lowercase method names: setex instead of setEx
-      await this.redis.setex(
-        `${REDIS_KEY_PREFIXES.VOICE_TRANSCRIPT}${attachmentUrl}`,
-        ttlSeconds,
-        transcript
-      );
+      await this.redis.setex(this.keyFor(attachmentUrl), ttlSeconds, transcript);
       logger.debug(
         { urlPreview: attachmentUrl.substring(0, 50) },
         '[VoiceTranscriptCache] Stored transcript'
@@ -50,9 +58,7 @@ export class VoiceTranscriptCache {
    */
   async get(attachmentUrl: string): Promise<string | null> {
     try {
-      const transcript = await this.redis.get(
-        `${REDIS_KEY_PREFIXES.VOICE_TRANSCRIPT}${attachmentUrl}`
-      );
+      const transcript = await this.redis.get(this.keyFor(attachmentUrl));
 
       if (transcript !== null && transcript.length > 0) {
         logger.debug(

--- a/packages/common-types/src/utils/attachmentCacheKey.test.ts
+++ b/packages/common-types/src/utils/attachmentCacheKey.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { deriveAttachmentCacheKey } from './attachmentCacheKey.js';
+
+describe('deriveAttachmentCacheKey', () => {
+  const PREFIX = 'transcript:';
+
+  describe('id-preferred path', () => {
+    it('uses the attachment id when present', () => {
+      expect(deriveAttachmentCacheKey(PREFIX, { id: '12345', url: 'https://x/y' })).toBe(
+        'transcript:id:12345'
+      );
+    });
+
+    it('ignores the url entirely when an id is supplied', () => {
+      const withQuery = deriveAttachmentCacheKey(PREFIX, { id: '999', url: 'https://x/y?ex=AAA' });
+      const withoutQuery = deriveAttachmentCacheKey(PREFIX, { id: '999', url: 'https://z/w' });
+      expect(withQuery).toBe(withoutQuery);
+      expect(withQuery).toBe('transcript:id:999');
+    });
+
+    it('falls back to the url path when id is an empty string', () => {
+      const key = deriveAttachmentCacheKey(PREFIX, { id: '', url: 'https://cdn/file.ogg' });
+      expect(key.startsWith('transcript:url:')).toBe(true);
+    });
+  });
+
+  describe('url-hash fallback (the volatile-signature fix)', () => {
+    const base = 'https://cdn.discordapp.com/attachments/111/222/voice.ogg';
+
+    it('produces the same key for the same base url regardless of signature query', () => {
+      // Discord re-signs ex/is/hs on every re-fetch — these must collapse to one key.
+      const signedA = `${base}?ex=AAAA&is=BBBB&hs=CCCC`;
+      const signedB = `${base}?ex=DDDD&is=EEEE&hs=FFFF`;
+      const keyA = deriveAttachmentCacheKey(PREFIX, { url: signedA });
+      const keyB = deriveAttachmentCacheKey(PREFIX, { url: signedB });
+      expect(keyA).toBe(keyB);
+    });
+
+    it('treats a query-less url and its signed form as the same key', () => {
+      const bare = deriveAttachmentCacheKey(PREFIX, { url: base });
+      const signed = deriveAttachmentCacheKey(PREFIX, { url: `${base}?ex=AAAA&is=BBBB&hs=CCCC` });
+      expect(bare).toBe(signed);
+    });
+
+    it('produces different keys for different base paths', () => {
+      const a = deriveAttachmentCacheKey(PREFIX, { url: `${base}?ex=AAAA` });
+      const b = deriveAttachmentCacheKey(PREFIX, {
+        url: 'https://cdn.discordapp.com/attachments/111/333/other.ogg?ex=AAAA',
+      });
+      expect(a).not.toBe(b);
+    });
+
+    it('namespaces the hash under `url:` and the given prefix', () => {
+      const key = deriveAttachmentCacheKey('vision:', { url: base });
+      expect(key.startsWith('vision:url:')).toBe(true);
+      // sha256 hex digest is 64 chars
+      expect(key.slice('vision:url:'.length)).toHaveLength(64);
+    });
+  });
+});

--- a/packages/common-types/src/utils/attachmentCacheKey.ts
+++ b/packages/common-types/src/utils/attachmentCacheKey.ts
@@ -1,0 +1,45 @@
+/**
+ * Attachment cache-key derivation
+ *
+ * Discord CDN URLs carry volatile signature query params (`?ex=&is=&hs=`) that
+ * Discord re-signs on every re-fetch — so the *same* attachment yields a
+ * *different* URL each time. Keying a cache on the full signed URL therefore
+ * misses on every re-fetch, defeating the cache. This derives a STABLE key:
+ *
+ *   - prefer the Discord attachment `id` (an immutable snowflake), else
+ *   - hash the query-stripped base URL — the path itself already embeds the
+ *     immutable attachment id
+ *     (`/attachments/{channelId}/{attachmentId}/{filename}`), so stripping the
+ *     signature query is sufficient for stability even without an explicit id.
+ *
+ * Shared by `VoiceTranscriptCache` (transcripts) and `VisionDescriptionCache`
+ * (image descriptions) so the two normalization strategies can't drift.
+ */
+
+import crypto from 'crypto';
+
+/** The minimal attachment fields needed to derive a stable cache key. */
+export interface AttachmentCacheKeyParts {
+  /** Discord attachment id — an immutable snowflake. Preferred when present. */
+  id?: string;
+  /** Discord CDN URL. Query-stripped + hashed when no `id` is supplied. */
+  url: string;
+}
+
+/**
+ * Build a stable Redis cache key for a Discord attachment.
+ *
+ * @param prefix Redis key namespace (e.g. `transcript:`, `vision:`).
+ * @param parts  Attachment id (preferred) and/or url (fallback).
+ * @returns `${prefix}id:${id}` when an id is present, else
+ *   `${prefix}url:${sha256(baseUrl)}` with the signature query stripped.
+ */
+export function deriveAttachmentCacheKey(prefix: string, parts: AttachmentCacheKeyParts): string {
+  if (parts.id !== undefined && parts.id !== '') {
+    return `${prefix}id:${parts.id}`;
+  }
+
+  const baseUrl = parts.url.split('?')[0];
+  const urlHash = crypto.createHash('sha256').update(baseUrl).digest('hex');
+  return `${prefix}url:${urlHash}`;
+}

--- a/services/ai-worker/src/services/VisionDescriptionCache.ts
+++ b/services/ai-worker/src/services/VisionDescriptionCache.ts
@@ -20,10 +20,10 @@
  * See git history / release notes for the original vision negative-cache incident.
  */
 
-import { createHash } from 'node:crypto';
 import type { Redis } from 'ioredis';
 import {
   createLogger,
+  deriveAttachmentCacheKey,
   REDIS_KEY_PREFIXES,
   INTERVALS,
   TEXT_LIMITS,
@@ -182,35 +182,24 @@ export class VisionDescriptionCache {
   }
 
   /**
-   * Generate cache key from attachment ID (preferred) or URL (fallback).
-   *
-   * Priority:
-   * 1. If attachmentId is provided, use it directly (stable Discord snowflake)
-   * 2. Otherwise, hash the URL with query params stripped (for URL stability)
+   * Generate cache key from attachment ID (preferred) or query-stripped URL
+   * hash (fallback). Delegates to the shared `deriveAttachmentCacheKey` so the
+   * voice + vision caches share one normalization strategy.
    */
   private getCacheKey(options: VisionCacheKeyOptions): string {
-    if (options.attachmentId !== undefined && options.attachmentId !== '') {
-      return `${REDIS_KEY_PREFIXES.VISION_DESCRIPTION}id:${options.attachmentId}`;
-    }
-
-    // Fallback: Strip query params and hash the base URL
-    // Discord CDN URLs like: https://cdn.discordapp.com/attachments/123/456/image.png?ex=...&is=...&hm=...
-    // Becomes: https://cdn.discordapp.com/attachments/123/456/image.png
-    const baseUrl = options.url.split('?')[0];
-    const urlHash = createHash('sha256').update(baseUrl).digest('hex');
-    return `${REDIS_KEY_PREFIXES.VISION_DESCRIPTION}url:${urlHash}`;
+    return deriveAttachmentCacheKey(REDIS_KEY_PREFIXES.VISION_DESCRIPTION, {
+      id: options.attachmentId,
+      url: options.url,
+    });
   }
 
   /**
    * Generate failure cache key (separate namespace from success cache).
    */
   private getFailureKey(options: VisionCacheKeyOptions): string {
-    if (options.attachmentId !== undefined && options.attachmentId !== '') {
-      return `${REDIS_KEY_PREFIXES.VISION_FAILURE}id:${options.attachmentId}`;
-    }
-
-    const baseUrl = options.url.split('?')[0];
-    const urlHash = createHash('sha256').update(baseUrl).digest('hex');
-    return `${REDIS_KEY_PREFIXES.VISION_FAILURE}url:${urlHash}`;
+    return deriveAttachmentCacheKey(REDIS_KEY_PREFIXES.VISION_FAILURE, {
+      id: options.attachmentId,
+      url: options.url,
+    });
   }
 }

--- a/services/bot-client/src/services/VoiceTranscriptionService.ts
+++ b/services/bot-client/src/services/VoiceTranscriptionService.ts
@@ -308,8 +308,10 @@ export class VoiceTranscriptionService {
         'Transcription complete'
       );
 
-      // Cache BEFORE Discord replies (5-min TTL via voiceTranscriptCache default).
-      // Key by `originalUrl` — same field ai-worker reads in `lookupCachedTranscript`. Explicit field reference survives future refactors that might diverge `url` from `originalUrl`.
+      // Cache BEFORE Discord replies (default TTL via voiceTranscriptCache).
+      // Pass `originalUrl` — same field ai-worker reads in `lookupCachedTranscript`;
+      // the cache strips the volatile CDN signature query so store and lookup
+      // derive the same key regardless of which signed URL each side holds.
       const voiceAttachment = attachments[0]; // We know there's at least one
       if (voiceAttachment !== undefined && voiceAttachment !== null) {
         await voiceTranscriptCache.store(voiceAttachment.originalUrl, response.content);
@@ -436,11 +438,12 @@ export class VoiceTranscriptionService {
       { slugs, attachmentCount: attachments.length },
       'Skipping STT for own-bot forwarded voice message'
     );
-    // Cache the placeholder so a re-forward of the same attachment URL hits
-    // the cache instead of re-running this classifier (cheap, but consistent
-    // with the existing cache pattern for human-authored transcripts).
+    // Cache the placeholder so a re-forward of the same attachment hits the
+    // cache instead of re-running this classifier (cheap, but consistent with
+    // the existing cache pattern for human-authored transcripts). Pass
+    // `originalUrl` to match store-1 + the ai-worker lookup key.
     for (const attachment of attachments) {
-      await voiceTranscriptCache.store(attachment.url, placeholder);
+      await voiceTranscriptCache.store(attachment.originalUrl, placeholder);
     }
     // Visible reply so the user (and channel) see acknowledgment of the
     // forward. Without this, a forwarded voice message would produce no


### PR DESCRIPTION
## Problem

`VoiceTranscriptCache` keyed on the **full signed Discord CDN URL**. Discord re-signs the `?ex=&is=&hs=` signature query on every re-fetch, so the *same* audio produced a *different* cache key each time → near-total cache miss → the bot re-transcribed voice it had already transcribed. In a channel with frequent voice, the same message was re-transcribed over and over. The 5-min TTL compounded it.

`VisionDescriptionCache` already solved this exact class of bug (prefer the stable attachment `id`; else strip the query + hash the base URL) — voice just never adopted the pattern.

## Fix

- **New shared helper** `deriveAttachmentCacheKey(prefix, { id, url })` (common-types) — prefer the immutable attachment id, else `sha256` of the query-stripped CDN path (the path itself embeds the immutable attachment id, so stripping the signature is sufficient for stability).
- **`VoiceTranscriptCache`** derives the stable key internally — its string `store`/`get` API and **every call site stay unchanged**. (The store side carries no attachment id, so voice always takes the query-stripped url-hash branch; that's fully stable.)
- **`VisionDescriptionCache` converged onto the shared helper** (success + failure namespaces) so the two normalization strategies can't drift. Keys are byte-identical to before — 15 existing vision tests stay green; dropped the now-unused `createHash` import.
- **`VOICE_TRANSCRIPT_TTL` 5min → 1h** (parity with `VISION_DESCRIPTION_TTL`). The key is now content-stable (attachment id is immutable), so a generous TTL is pure upside and the value is a tiny string. #1314 already made this cache a hot-path optimization rather than a correctness dependency for aged-out extended-context voice.
- **Bot-authored-placeholder store aligned onto `originalUrl`** so store and lookup derive the same key.

## Tests

- New `deriveAttachmentCacheKey` unit tests (7) — id-preference, empty-id fallback, and the core assertion: two URLs differing only in signature collapse to one key.
- New `VoiceTranscriptCache` tests (6, none existed before) — round-trip, **HIT across different signatures of the same attachment**, query-stripped key shape, miss on a different path, 1h default TTL.
- `VisionDescriptionCache` (15) + `AudioProcessor` (36) + `VoiceTranscriptionService` (45) all green. `pnpm quality` clean.

## Follow-ups
Cache-duration audit (the full ~34-cache rationale doc) + bounding the two genuinely-unbounded in-memory caches land in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)