### PR TITLE
refactor(identity): bound resolver + capability caches via TTLCache

### DIFF
--- a/packages/identity/src/identityProvisioning.int.test.ts
+++ b/packages/identity/src/identityProvisioning.int.test.ts
@@ -83,11 +83,13 @@ describe('Identity provisioning integration (c88ae5b7 regression guard)', () => 
     `);
 
     userService = new UserService(prisma);
-    // cacheTtlMs: 0 disables PersonaResolver's in-memory cache so tests
-    // exercise the real resolution path every call. The cache is the
-    // safe-by-default for prod (hit rate > 95%) but hides the provisioning
-    // integration we want to pin here.
-    personaResolver = new PersonaResolver(prisma, { cacheTtlMs: 0 });
+    // cacheTtlMs: 1 (1ms) effectively disables PersonaResolver's in-memory
+    // cache so tests exercise the real resolution path every call — each PGLite
+    // round-trip exceeds 1ms, so an entry is always expired by the next call.
+    // NOTE: must be 1, not 0 — lru-cache treats ttl:0 as "no TTL" (never
+    // expire), which would cache forever and hide the provisioning integration
+    // we want to pin here. The cache is safe-by-default for prod (hit rate > 95%).
+    personaResolver = new PersonaResolver(prisma, { cacheTtlMs: 1 });
   }, 30000);
 
   afterAll(async () => {

--- a/packages/identity/src/resolvers/BaseConfigResolver.ts
+++ b/packages/identity/src/resolvers/BaseConfigResolver.ts
@@ -51,7 +51,7 @@
  * @see PersonaResolver - Switch strategy implementation
  */
 
-import { createLogger, INTERVALS, type PrismaClient } from '@tzurot/common-types';
+import { createLogger, INTERVALS, TTLCache, type PrismaClient } from '@tzurot/common-types';
 
 const logger = createLogger('BaseConfigResolver');
 
@@ -67,12 +67,21 @@ export interface ResolutionResult<T> {
   sourceName?: string;
 }
 
-/**
- * Cache entry with TTL
- */
-interface CacheEntry<T> {
-  result: ResolutionResult<T>;
-  expiresAt: number;
+/** Constructor options shared across all resolver subclasses. */
+export interface BaseConfigResolverOptions {
+  /**
+   * TTL for cache entries in milliseconds. Defaults to API_KEY_CACHE_TTL.
+   * NOTE: passing 0 does NOT disable the cache — lru-cache treats `ttl: 0` as
+   * "no TTL" (never expire). Use 1ms to effectively disable caching in tests.
+   */
+  cacheTtlMs?: number;
+  /**
+   * Test-only: inject a clock function for fake-timer compatibility with
+   * TTLCache. lru-cache's default `performance.now()` is NOT mocked by
+   * `vi.useFakeTimers`; passing `() => Date.now()` makes TTL respect them.
+   * @internal
+   */
+  now?: () => number;
 }
 
 /**
@@ -80,23 +89,24 @@ interface CacheEntry<T> {
  */
 export abstract class BaseConfigResolver<T> {
   protected prisma: PrismaClient;
-  protected cache = new Map<string, CacheEntry<T>>();
-  protected readonly cacheTtlMs: number;
-  private cleanupInterval: ReturnType<typeof setInterval> | null = null;
+  protected readonly cache: TTLCache<ResolutionResult<T>>;
 
   /**
    * Name of this resolver for logging purposes
    */
   protected abstract readonly resolverName: string;
 
-  constructor(prisma: PrismaClient, options?: { cacheTtlMs?: number; enableCleanup?: boolean }) {
+  constructor(prisma: PrismaClient, options?: BaseConfigResolverOptions) {
     this.prisma = prisma;
-    this.cacheTtlMs = options?.cacheTtlMs ?? INTERVALS.API_KEY_CACHE_TTL;
-
-    // Start periodic cleanup of expired cache entries
-    if (options?.enableCleanup !== false) {
-      this.startCleanupInterval();
-    }
+    this.cache = new TTLCache<ResolutionResult<T>>({
+      ttl: options?.cacheTtlMs ?? INTERVALS.API_KEY_CACHE_TTL,
+      // Persona/config resolution is on the memory-retrieval hot path and fans
+      // out per-(user, context); 1000 small entries bounds memory firmly while
+      // tolerating busy multi-user channels. Replaces an unbounded Map whose
+      // periodic setInterval sweep was a documented horizontal-scaling blocker.
+      maxSize: 1000,
+      now: options?.now,
+    });
   }
 
   /**
@@ -115,15 +125,15 @@ export abstract class BaseConfigResolver<T> {
       };
     }
 
-    // Check cache
+    // Check cache (TTLCache returns null on miss; expiry is enforced internally).
     const cacheKey = this.getCacheKey(userId, contextId);
     const cached = this.cache.get(cacheKey);
-    if (cached && cached.expiresAt > Date.now()) {
+    if (cached !== null) {
       logger.debug(
         { resolver: this.resolverName, userId, contextId, source: 'cache' },
         'Config resolved from cache'
       );
-      return cached.result;
+      return cached;
     }
 
     try {
@@ -186,10 +196,7 @@ export abstract class BaseConfigResolver<T> {
    * Cache a resolution result
    */
   protected cacheResult(key: string, result: ResolutionResult<T>): void {
-    this.cache.set(key, {
-      result,
-      expiresAt: Date.now() + this.cacheTtlMs,
-    });
+    this.cache.set(key, result);
   }
 
   /**
@@ -197,11 +204,9 @@ export abstract class BaseConfigResolver<T> {
    * Call when user updates their configuration
    */
   invalidateUserCache(userId: string): void {
-    for (const key of this.cache.keys()) {
-      if (key.startsWith(`${userId}:`)) {
-        this.cache.delete(key);
-      }
-    }
+    // Cache keys are `${userId}:${contextId}` — the trailing colon prevents a
+    // prefix collision (user "12" doesn't match "123:").
+    this.cache.invalidateByPrefix(`${userId}:`);
     logger.debug({ resolver: this.resolverName, userId }, 'Invalidated cache for user');
   }
 
@@ -211,52 +216,5 @@ export abstract class BaseConfigResolver<T> {
   clearCache(): void {
     this.cache.clear();
     logger.debug({ resolver: this.resolverName }, 'Cleared all cache');
-  }
-
-  /**
-   * Stop cleanup interval (call on shutdown)
-   */
-  stopCleanup(): void {
-    if (this.cleanupInterval) {
-      clearInterval(this.cleanupInterval);
-      this.cleanupInterval = null;
-    }
-  }
-
-  /**
-   * Start periodic cleanup of expired cache entries
-   *
-   * NOTE: This setInterval is a known horizontal scaling blocker (see CLAUDE.md).
-   * TODO: Migrate to BullMQ repeatable jobs for multi-instance deployments.
-   */
-  private startCleanupInterval(): void {
-    this.cleanupInterval = setInterval(() => {
-      this.cleanupExpiredEntries();
-    }, INTERVALS.CACHE_CLEANUP);
-
-    // Ensure interval doesn't prevent process exit
-    this.cleanupInterval.unref();
-  }
-
-  /**
-   * Remove expired entries from cache
-   */
-  private cleanupExpiredEntries(): void {
-    const now = Date.now();
-    let removedCount = 0;
-
-    for (const [key, entry] of this.cache) {
-      if (entry.expiresAt <= now) {
-        this.cache.delete(key);
-        removedCount++;
-      }
-    }
-
-    if (removedCount > 0) {
-      logger.debug(
-        { resolver: this.resolverName, removedCount, remaining: this.cache.size },
-        'Cleaned up expired cache entries'
-      );
-    }
   }
 }

--- a/packages/identity/src/resolvers/PersonaResolver.test.ts
+++ b/packages/identity/src/resolvers/PersonaResolver.test.ts
@@ -46,12 +46,7 @@ describe('PersonaResolver', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // Disable cleanup interval in tests
-    resolver = new PersonaResolver(mockPrismaClient as any, { enableCleanup: false });
-  });
-
-  afterEach(() => {
-    resolver.stopCleanup();
+    resolver = new PersonaResolver(mockPrismaClient as any);
   });
 
   describe('resolve (full configuration)', () => {
@@ -638,7 +633,7 @@ describe('PersonaResolver', () => {
     });
   });
 
-  describe('cleanup interval', () => {
+  describe('cache expiry (TTLCache)', () => {
     beforeEach(() => {
       vi.useFakeTimers();
     });
@@ -647,22 +642,12 @@ describe('PersonaResolver', () => {
       vi.useRealTimers();
     });
 
-    it('should start cleanup interval when enabled', () => {
-      const resolverWithCleanup = new PersonaResolver(mockPrismaClient as any, {
-        enableCleanup: true,
-      });
-
-      // Should have started the interval
-      expect(resolverWithCleanup).toBeDefined();
-
-      // Cleanup
-      resolverWithCleanup.stopCleanup();
-    });
-
-    it('should clean up expired entries when interval fires', async () => {
-      const resolverWithCleanup = new PersonaResolver(mockPrismaClient as any, {
-        enableCleanup: true,
+    it('expires cached entries after the TTL, then re-queries', async () => {
+      // Inject `now: () => Date.now()` so TTLCache (which uses performance.now()
+      // by default, NOT mocked by fake timers) respects vi.advanceTimersByTime.
+      const resolverWithTtl = new PersonaResolver(mockPrismaClient as any, {
         cacheTtlMs: 1000, // 1 second TTL for testing
+        now: () => Date.now(),
       });
 
       mockPrismaClient.user.findUnique.mockResolvedValue({
@@ -677,43 +662,18 @@ describe('PersonaResolver', () => {
         ownedPersonas: [],
       });
 
-      // Populate cache
-      await resolverWithCleanup.resolve('user-1', 'personality-1');
+      // Populate cache (1 query)
+      await resolverWithTtl.resolve('user-1', 'personality-1');
       expect(mockPrismaClient.user.findUnique).toHaveBeenCalledTimes(1);
 
-      // Should use cache
-      await resolverWithCleanup.resolve('user-1', 'personality-1');
+      // Within TTL → cache hit, no new query
+      await resolverWithTtl.resolve('user-1', 'personality-1');
       expect(mockPrismaClient.user.findUnique).toHaveBeenCalledTimes(1);
 
-      // Advance time past TTL
+      // Advance past the TTL → entry expired on next access, re-queries
       vi.advanceTimersByTime(2000);
-
-      // Advance time past cleanup interval (60s)
-      vi.advanceTimersByTime(60000);
-
-      // Now cache entry should be expired - next call should query again
-      await resolverWithCleanup.resolve('user-1', 'personality-1');
+      await resolverWithTtl.resolve('user-1', 'personality-1');
       expect(mockPrismaClient.user.findUnique).toHaveBeenCalledTimes(2);
-
-      // Cleanup
-      resolverWithCleanup.stopCleanup();
-    });
-
-    it('should handle stopCleanup when no interval is running', () => {
-      // Resolver created with cleanup disabled
-      expect(() => resolver.stopCleanup()).not.toThrow();
-    });
-
-    it('should be safe to call stopCleanup multiple times', () => {
-      const resolverWithCleanup = new PersonaResolver(mockPrismaClient as any, {
-        enableCleanup: true,
-      });
-
-      // Stop multiple times - should not throw
-      expect(() => {
-        resolverWithCleanup.stopCleanup();
-        resolverWithCleanup.stopCleanup();
-      }).not.toThrow();
     });
   });
 });

--- a/packages/identity/src/resolvers/PersonaResolver.ts
+++ b/packages/identity/src/resolvers/PersonaResolver.ts
@@ -38,7 +38,11 @@ import {
   type PrismaClient,
   type CorePersonaConfig,
 } from '@tzurot/common-types';
-import { BaseConfigResolver, type ResolutionResult } from './BaseConfigResolver.js';
+import {
+  BaseConfigResolver,
+  type BaseConfigResolverOptions,
+  type ResolutionResult,
+} from './BaseConfigResolver.js';
 
 const logger = createLogger('PersonaResolver');
 
@@ -102,7 +106,7 @@ const SYSTEM_DEFAULT_PERSONA: ResolvedPersona = {
 export class PersonaResolver extends BaseConfigResolver<ResolvedPersona> {
   protected readonly resolverName = 'PersonaResolver';
 
-  constructor(prisma: PrismaClient, options?: { cacheTtlMs?: number; enableCleanup?: boolean }) {
+  constructor(prisma: PrismaClient, options?: BaseConfigResolverOptions) {
     super(prisma, options);
   }
 

--- a/services/ai-worker/src/services/ModelCapabilityChecker.ts
+++ b/services/ai-worker/src/services/ModelCapabilityChecker.ts
@@ -13,6 +13,7 @@ import {
   createLogger,
   REDIS_KEY_PREFIXES,
   AI_DEFAULTS,
+  TTLCache,
   type OpenRouterModel,
 } from '@tzurot/common-types';
 
@@ -27,10 +28,15 @@ interface CachedCapabilities {
   supportsReasoning: boolean;
   /** The model's real context length in tokens; null when resolved via pattern fallback (Redis unavailable or model not in cache). */
   contextLength: number | null;
-  timestamp: number;
 }
 
-const capabilityCache = new Map<string, CachedCapabilities>();
+// TTLCache bounds memory (LRU) and expires entries on access, replacing an
+// unbounded Map + manual timestamp checks. maxSize 500 comfortably covers the
+// OpenRouter catalog (~300 models, plus `:free` variants) with headroom.
+const capabilityCache = new TTLCache<CachedCapabilities>({
+  ttl: AI_DEFAULTS.MODEL_CAPABILITY_CACHE_TTL_MS,
+  maxSize: 500,
+});
 
 /** Normalize model ID for cache key (strip :free suffix) */
 function normalizeModelId(modelId: string): string {
@@ -73,7 +79,6 @@ async function resolveFromRedis(
       supportsVision: model.architecture.input_modalities.includes('image'),
       supportsReasoning: model.supported_parameters.includes('reasoning'),
       contextLength: model.context_length,
-      timestamp: Date.now(),
     };
 
     capabilityCache.set(normalizedId, capabilities);
@@ -101,9 +106,9 @@ async function resolveFromRedis(
 async function getCapabilities(modelId: string, redis: Redis): Promise<CachedCapabilities> {
   const normalizedId = normalizeModelId(modelId);
 
-  // Check in-memory cache first
+  // Check in-memory cache first (TTLCache returns null on miss/expiry)
   const cached = capabilityCache.get(normalizedId);
-  if (cached && Date.now() - cached.timestamp < AI_DEFAULTS.MODEL_CAPABILITY_CACHE_TTL_MS) {
+  if (cached !== null) {
     return cached;
   }
 
@@ -118,7 +123,6 @@ async function getCapabilities(modelId: string, redis: Redis): Promise<CachedCap
     supportsVision: hasVisionSupportFallback(modelId),
     supportsReasoning: hasReasoningSupportFallback(modelId),
     contextLength: null,
-    timestamp: Date.now(),
   };
 
   capabilityCache.set(normalizedId, capabilities);


### PR DESCRIPTION
## Problem

The cache-duration audit (follow-up to #1315) found two in-memory caches that grow **unbounded**:

- **identity `BaseConfigResolver`** (used by `PersonaResolver`) — a raw `Map<string, CacheEntry>` with a periodic `setInterval` cleanup the code itself flags as a *"known horizontal scaling blocker."*
- **`ModelCapabilityChecker`** — a raw `Map` with manual `Date.now()`-timestamp expiry; flagged as a medium unbounded-growth risk on diverse model-id catalogs.

## Fix

Swap both onto the shared **`TTLCache`** (LRU `maxSize` + expiry-on-access).

- Bounds memory: `maxSize` 1000 (resolver) / 500 (capability).
- **Deletes the `setInterval` scaling blocker** entirely.
- Drops the vestigial `expiresAt` / `timestamp` bookkeeping.
- **Removes the dead `enableCleanup` option + `stopCleanup()` method** from the identity `BaseConfigResolver` outright (not no-ops): verified zero production callers, so per `00-critical.md` "No Backward Compatibility" the dead API goes. Per-user invalidation now uses `TTLCache.invalidateByPrefix`. (`config-resolver` keeps its no-op stubs — it has real `enableCleanup: false` callers.)

Shrinks the surface of the tracked "BaseConfigResolver dedup" follow-up.

## Regression fixed in-PR

`identityProvisioning.int.test.ts` passed `cacheTtlMs: 0` to disable the cache (old hand-rolled `expiresAt = now+0` = expire immediately). lru-cache treats `ttl: 0` as **"no TTL" (never expire)**, so the swap would have silently made it cache forever — changed to `cacheTtlMs: 1`, and the `cacheTtlMs` JSDoc now documents this footgun.

## Tests

- `PersonaResolver` (34) — old "cleanup interval" tests reworked to assert TTLCache expiry via an injected `now` clock.
- `ModelCapabilityChecker` (36) — unchanged.
- `pnpm quality` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)