### PR TITLE
fix(ai-worker): clarify how the model reads quoted references (self-reply confusion)

### DIFF
--- a/packages/common-types/src/utils/referenceEnrichment.test.ts
+++ b/packages/common-types/src/utils/referenceEnrichment.test.ts
@@ -5,6 +5,7 @@ import type { ReferencedMessage } from '../types/schemas/message.js';
 import {
   appendVoiceTranscripts,
   buildDedupedReferenceStub,
+  isBotAuthoredReference,
   isDuplicateReference,
   stripBotVoiceAttachments,
   type ReferenceDedupCandidate,
@@ -98,12 +99,13 @@ describe('isDuplicateReference', () => {
   });
 });
 
-function fullReference(content: string): ReferencedMessage {
+// Defaults to non-bot: bot-authored stubs are now marker-only (empty content), so the
+// dedup-content assertions below need a user-authored reference to keep their text.
+function fullReference(content: string, botAuthored = false): ReferencedMessage {
   return {
     referenceNumber: 3,
     discordMessageId: 'msg-9',
-    webhookId: 'wh-1',
-    authorIsBot: true,
+    ...(botAuthored ? { webhookId: 'wh-1', authorIsBot: true } : {}),
     discordUserId: 'user-1',
     authorUsername: 'someone',
     authorDisplayName: 'Someone',
@@ -187,6 +189,47 @@ describe('buildDedupedReferenceStub', () => {
     const stub = buildDedupedReferenceStub(ref);
     // Every marker survives untruncated, markers-first, with the short text after.
     expect(stub.content).toBe(`${expectedMarkers}\n\nhi`);
+  });
+
+  it('emits a marker-only stub (empty content) for the bot’s own reply-target', () => {
+    // A snippet of the bot's own prior text is the "continue this fragment" trigger;
+    // the full message is in <chat_log> regardless, so bot-authored stubs carry no
+    // preview and no attachment markers. The marker is prepended downstream.
+    const stub = buildDedupedReferenceStub(fullReference('the bot said this earlier', true));
+    expect(stub.content).toBe('');
+  });
+
+  it('preserves authorIsBot/webhookId so the formatter can derive role="assistant"', () => {
+    const stub = buildDedupedReferenceStub(fullReference('x', true));
+    expect(stub.authorIsBot).toBe(true);
+    expect(stub.webhookId).toBe('wh-1');
+  });
+});
+
+describe('isBotAuthoredReference', () => {
+  const base: ReferencedMessage = {
+    referenceNumber: 1,
+    discordMessageId: 'm1',
+    discordUserId: 'u1',
+    authorUsername: 'someone',
+    authorDisplayName: 'Someone',
+    content: 'hi',
+    embeds: '',
+    timestamp: '2026-06-01T11:59:00.000Z',
+    locationContext: '',
+  };
+
+  it('is true when authorIsBot is set', () => {
+    expect(isBotAuthoredReference({ ...base, authorIsBot: true })).toBe(true);
+  });
+  it('is true for a non-empty webhookId (authorIsBot unset)', () => {
+    expect(isBotAuthoredReference({ ...base, webhookId: 'wh-1' })).toBe(true);
+  });
+  it('is false for a plain user reference', () => {
+    expect(isBotAuthoredReference(base)).toBe(false);
+  });
+  it('is false for an empty webhookId', () => {
+    expect(isBotAuthoredReference({ ...base, webhookId: '' })).toBe(false);
   });
 });
 

--- a/packages/common-types/src/utils/referenceEnrichment.ts
+++ b/packages/common-types/src/utils/referenceEnrichment.ts
@@ -85,6 +85,23 @@ export function isDuplicateReference(
 }
 
 /**
+ * Whether a reference was posted by a bot account or webhook (as opposed to a
+ * human Discord user) — true for `authorIsBot` or any non-empty `webhookId`.
+ * This is the broad "machine-authored" signal; it does NOT identify *which* bot,
+ * so it intentionally matches PluralKit / other webhooks too. Callers that need
+ * "is this OUR persona's own line" (e.g. the `role="assistant"` quote signal)
+ * must additionally name-match the active persona — this predicate alone is only
+ * safe where any bot/webhook is the right scope (stripping the bot's own TTS
+ * audio, building marker-only dedup stubs).
+ */
+export function isBotAuthoredReference(reference: ReferencedMessage): boolean {
+  return (
+    reference.authorIsBot === true ||
+    (reference.webhookId !== undefined && reference.webhookId.length > 0)
+  );
+}
+
+/**
  * Drop a bot/webhook-authored reference's own audio attachments.
  *
  * A personality reply is delivered via webhook with its TTS rendered as an
@@ -98,10 +115,7 @@ export function isDuplicateReference(
  * `audio/*` is dropped, so a bot-posted image (real content) still survives.
  */
 export function stripBotVoiceAttachments(reference: ReferencedMessage): ReferencedMessage {
-  const isBotAuthored =
-    reference.authorIsBot === true ||
-    (reference.webhookId !== undefined && reference.webhookId.length > 0);
-  if (!isBotAuthored || reference.attachments === undefined) {
+  if (!isBotAuthoredReference(reference) || reference.attachments === undefined) {
     return reference;
   }
   const kept = reference.attachments.filter(
@@ -130,26 +144,36 @@ export function stripBotVoiceAttachments(reference: ReferencedMessage): Referenc
  * already does, via `formatDedupedQuote`.
  */
 export function buildDedupedReferenceStub(reference: ReferencedMessage): ReferencedMessage {
-  const limit = TEXT_LIMITS.DEDUP_STUB_CONTENT;
-  const truncatedContent =
-    reference.content.length > limit
-      ? reference.content.substring(0, limit) + '...'
-      : reference.content;
-  // Markers go FIRST so they survive downstream re-truncation: formatDedupedQuote
-  // applies DEDUP_STUB_CONTENT to the COMBINED (markers + text) string and trims
-  // from the end, so the effective text budget there is DEDUP_STUB_CONTENT minus
-  // the marker length. Squeezing the text hint is acceptable — the full message
-  // (the thing the stub points at) is in history regardless; the marker is not.
-  const attachmentMarkers = (reference.attachments ?? [])
-    .map(att => `[${att.contentType}: ${att.name ?? 'attachment'}]`)
-    .join('\n');
-  const content = [attachmentMarkers, truncatedContent].filter(s => s.length > 0).join('\n\n');
+  // Bot-authored stubs carry NO preview. A snippet of the model's own prior text
+  // is exactly the "continue this fragment" trigger; the full message is in
+  // <chat_log> regardless, so the marker (added downstream) is enough. User
+  // reply-targets keep a short preview — genuine content the model may need.
+  let content = '';
+  if (!isBotAuthoredReference(reference)) {
+    const limit = TEXT_LIMITS.DEDUP_STUB_CONTENT;
+    const truncatedContent =
+      reference.content.length > limit
+        ? reference.content.substring(0, limit) + '...'
+        : reference.content;
+    // Markers go FIRST so they survive downstream re-truncation: formatDedupedQuote
+    // applies DEDUP_STUB_CONTENT to the COMBINED (markers + text) string and trims
+    // from the end, so the effective text budget there is DEDUP_STUB_CONTENT minus
+    // the marker length. Squeezing the text hint is acceptable — the full message
+    // (the thing the stub points at) is in history regardless; the marker is not.
+    const attachmentMarkers = (reference.attachments ?? [])
+      .map(att => `[${att.contentType}: ${att.name ?? 'attachment'}]`)
+      .join('\n');
+    content = [attachmentMarkers, truncatedContent].filter(s => s.length > 0).join('\n\n');
+  }
   return {
     referenceNumber: reference.referenceNumber,
     discordMessageId: reference.discordMessageId,
     discordUserId: reference.discordUserId,
     authorUsername: reference.authorUsername,
     authorDisplayName: reference.authorDisplayName,
+    // Preserved so the formatter can derive the role="assistant" quote signal.
+    authorIsBot: reference.authorIsBot,
+    webhookId: reference.webhookId,
     content,
     embeds: '',
     timestamp: reference.timestamp,

--- a/services/ai-worker/src/jobs/utils/conversationUtils.test.ts
+++ b/services/ai-worker/src/jobs/utils/conversationUtils.test.ts
@@ -868,7 +868,7 @@ describe('Conversation Utilities', () => {
 
       // Deduped refs are now preserved as lightweight stubs (not dropped)
       expect(result).toContain('<quoted_messages>');
-      expect(result).toContain('[Reply target — full message is in conversation above]');
+      expect(result).toContain('[Referenced message — full text in <chat_log>]');
       expect(result).toContain('from="Bob"');
       expect(result).toContain('from="Alice"');
       expect(result).toContain('Replying to your earlier message');

--- a/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.test.ts
+++ b/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.test.ts
@@ -63,7 +63,7 @@ const { mockFormatQuoteElement, mockFormatDedupedQuote } = vi.hoisted(() => {
       return fqe({
         from: opts.from,
         timeFormatted: opts.timeFormatted,
-        content: `[Reply target — full message is in conversation above]\n\n${truncated}`,
+        content: `[Referenced message — full text in <chat_log>]\n\n${truncated}`,
       });
     });
 
@@ -284,7 +284,7 @@ describe('xmlMetadataFormatters', () => {
       const historyIds = new Set(['already-in-history']);
       const result = formatQuotedSection(msg, 'user', personalityName, historyIds, undefined);
       expect(result).toContain('<quoted_messages>');
-      expect(result).toContain('[Reply target — full message is in conversation above]');
+      expect(result).toContain('[Referenced message — full text in <chat_log>]');
       expect(result).toContain('Duplicated message that is in history');
       expect(result).toContain('from="User One"');
     });
@@ -344,7 +344,7 @@ describe('xmlMetadataFormatters', () => {
       expect(result).toContain('from="User Two"');
       expect(result).toContain('Not in history');
       // Deduped stub for User One
-      expect(result).toContain('[Reply target — full message is in conversation above]');
+      expect(result).toContain('[Referenced message — full text in <chat_log>]');
       expect(result).toContain('In history');
     });
 

--- a/services/ai-worker/src/services/ReferencedMessageFormatter.test.ts
+++ b/services/ai-worker/src/services/ReferencedMessageFormatter.test.ts
@@ -205,7 +205,9 @@ describe('ReferencedMessageFormatter', () => {
 
       const result = await formatter.formatReferencedMessages(references, mockPersonality);
 
-      expect(result).toContain('<quote number="1" from="Test User" username="testuser">');
+      expect(result).toContain(
+        '<quote number="1" from="Test User" username="testuser" role="user">'
+      );
       expect(result).toContain('</quote>');
       // Location is now pre-formatted XML from bot-client (DRY with current message context)
       expect(result).toContain('<location type="guild">');
@@ -258,7 +260,9 @@ describe('ReferencedMessageFormatter', () => {
 
       const result = await formatter.formatReferencedMessages(references, mockPersonality);
 
-      expect(result).toContain('<quote number="1" from="Test User" username="testuser">');
+      expect(result).toContain(
+        '<quote number="1" from="Test User" username="testuser" role="user">'
+      );
       // Empty content should not generate <content> tag
       expect(result).not.toContain('<content>');
     });
@@ -292,11 +296,69 @@ describe('ReferencedMessageFormatter', () => {
 
       const result = await formatter.formatReferencedMessages(references, mockPersonality);
 
-      expect(result).toContain('<quote number="1" from="User One" username="user1">');
+      expect(result).toContain('<quote number="1" from="User One" username="user1" role="user">');
       expect(result).toContain('First message');
 
-      expect(result).toContain('<quote number="2" from="User Two" username="user2">');
+      expect(result).toContain('<quote number="2" from="User Two" username="user2" role="user">');
       expect(result).toContain('Second message');
+    });
+
+    it('marks a non-deduped reference from the current persona role="assistant"', async () => {
+      // A non-deduped reference from the CURRENT persona (bot/webhook AND a display
+      // name matching the persona — here carrying a webhook suffix) reads as the
+      // model's own prior line. Prefix-match on displayName absorbs the suffix.
+      const references: ReferencedMessage[] = [
+        {
+          referenceNumber: 1,
+          discordMessageId: 'msg-bot-1',
+          discordUserId: 'bot-user-id',
+          authorUsername: 'Test Bot 🤖',
+          authorDisplayName: 'Test Bot 🤖',
+          content: 'Something I said earlier',
+          embeds: '',
+          timestamp: '2025-11-04T00:00:00Z',
+          locationContext:
+            '<location type="guild">\n<server name="Test Guild"/>\n<channel name="general" type="text"/>\n</location>',
+          authorIsBot: true,
+          webhookId: 'wh-1',
+        },
+      ];
+
+      const result = await formatter.formatReferencedMessages(references, mockPersonality);
+
+      expect(result).toContain(
+        '<quote number="1" from="Test Bot 🤖" username="Test Bot 🤖" role="assistant">'
+      );
+      expect(result).toContain('<content>Something I said earlier</content>');
+    });
+
+    it('marks a non-deduped third-party bot/webhook reference role="user"', async () => {
+      // A bot/webhook message NOT from our persona (a PluralKit-proxied human,
+      // another bot) must read as role="user" — the model should respond to it,
+      // not treat it as its own line. The persona name-match scopes this; bot
+      // authorship alone is not enough — that breadth is the misfire to avoid.
+      const references: ReferencedMessage[] = [
+        {
+          referenceNumber: 1,
+          discordMessageId: 'msg-pk-1',
+          discordUserId: 'pk-user-id',
+          authorUsername: 'SomeoneElse',
+          authorDisplayName: 'SomeoneElse',
+          content: 'a proxied human message',
+          embeds: '',
+          timestamp: '2025-11-04T00:00:00Z',
+          locationContext:
+            '<location type="guild">\n<server name="Test Guild"/>\n<channel name="general" type="text"/>\n</location>',
+          authorIsBot: true,
+          webhookId: 'pk-webhook',
+        },
+      ];
+
+      const result = await formatter.formatReferencedMessages(references, mockPersonality);
+
+      expect(result).toContain(
+        '<quote number="1" from="SomeoneElse" username="SomeoneElse" role="user">'
+      );
     });
   });
 
@@ -319,10 +381,76 @@ describe('ReferencedMessageFormatter', () => {
 
       const result = await formatter.formatReferencedMessages(references, mockPersonality);
 
-      expect(result).toContain('<quote number="1" from="Alice" username="alice123">');
-      expect(result).toContain('[Reply target — full message is in conversation above]');
+      expect(result).toContain('<quote number="1" from="Alice" username="alice123" role="user">');
+      expect(result).toContain('[Referenced message — full text in <chat_log>]');
       expect(result).toContain('Some truncated content...');
       expect(result).toContain('</quote>');
+    });
+
+    it('includes a <contextual_references> instruction on how to read quotes', async () => {
+      const references: ReferencedMessage[] = [
+        {
+          referenceNumber: 1,
+          discordMessageId: 'm',
+          discordUserId: 'u',
+          authorUsername: 'a',
+          authorDisplayName: 'A',
+          content: 'hi',
+          embeds: '',
+          timestamp: '2025-12-06T00:00:00Z',
+          locationContext: '',
+        },
+      ];
+      const result = await formatter.formatReferencedMessages(references, mockPersonality);
+      expect(result).toContain('<instruction>');
+      expect(result).toContain('role="assistant" is one of your own earlier lines');
+    });
+
+    it('marks a deduped reply-target from the current persona role="assistant" (marker-only)', async () => {
+      // The stub builder empties the current persona's content (no self-preview);
+      // the formatter derives role="assistant" from the bot-gate + persona match.
+      const references: ReferencedMessage[] = [
+        {
+          referenceNumber: 1,
+          discordMessageId: 'm',
+          discordUserId: 'u',
+          authorUsername: 'Test Bot 🤖',
+          authorDisplayName: 'Test Bot 🤖',
+          webhookId: 'wh-1',
+          authorIsBot: true,
+          content: '',
+          embeds: '',
+          timestamp: '2025-12-06T00:00:00Z',
+          locationContext: '',
+          isDeduplicated: true,
+        },
+      ];
+      const result = await formatter.formatReferencedMessages(references, mockPersonality);
+      expect(result).toContain('role="assistant"');
+      expect(result).toContain('[Referenced message — full text in <chat_log>]');
+    });
+
+    it('marks a deduped third-party bot/webhook reply-target role="user"', async () => {
+      // A deduped stub from a non-persona bot/webhook (PluralKit, another bot) is
+      // role="user" — same persona-scoping as the non-deduped path.
+      const references: ReferencedMessage[] = [
+        {
+          referenceNumber: 1,
+          discordMessageId: 'm',
+          discordUserId: 'u',
+          authorUsername: 'SomeoneElse',
+          authorDisplayName: 'SomeoneElse',
+          webhookId: 'pk-webhook',
+          authorIsBot: true,
+          content: 'proxied text',
+          embeds: '',
+          timestamp: '2025-12-06T00:00:00Z',
+          locationContext: '',
+          isDeduplicated: true,
+        },
+      ];
+      const result = await formatter.formatReferencedMessages(references, mockPersonality);
+      expect(result).toContain('role="user"');
     });
 
     it('should not process attachments for deduped stubs', async () => {
@@ -751,7 +879,9 @@ describe('ReferencedMessageFormatter', () => {
 
       const result = await formatter.formatReferencedMessages(references, mockPersonality);
 
-      expect(result).toContain('<quote number="1" from="Test User" username="testuser">');
+      expect(result).toContain(
+        '<quote number="1" from="Test User" username="testuser" role="user">'
+      );
       expect(result).toContain('Just text');
       expect(result).not.toContain('<attachments>');
     });
@@ -774,7 +904,9 @@ describe('ReferencedMessageFormatter', () => {
 
       const result = await formatter.formatReferencedMessages(references, mockPersonality);
 
-      expect(result).toContain('<quote number="1" from="Test User" username="testuser">');
+      expect(result).toContain(
+        '<quote number="1" from="Test User" username="testuser" role="user">'
+      );
       expect(result).toContain('Just text');
       expect(result).not.toContain('<attachments>');
     });
@@ -823,7 +955,9 @@ describe('ReferencedMessageFormatter', () => {
       const result = await formatter.formatReferencedMessages(references, mockPersonality);
 
       // Should NOT have forwarded attribute
-      expect(result).toContain('<quote number="1" from="Test User" username="testuser">');
+      expect(result).toContain(
+        '<quote number="1" from="Test User" username="testuser" role="user">'
+      );
       expect(result).not.toContain('forwarded="true"');
       expect(result).not.toContain('type="forward"');
     });
@@ -859,7 +993,9 @@ describe('ReferencedMessageFormatter', () => {
       const result = await formatter.formatReferencedMessages(references, mockPersonality);
 
       // First reference - regular
-      expect(result).toContain('<quote number="1" from="Test User" username="testuser">');
+      expect(result).toContain(
+        '<quote number="1" from="Test User" username="testuser" role="user">'
+      );
 
       // Second reference - forwarded (uses shared QuoteFormatter format)
       expect(result).toContain('<quote type="forward" from="Unknown">');

--- a/services/ai-worker/src/services/ReferencedMessageFormatter.ts
+++ b/services/ai-worker/src/services/ReferencedMessageFormatter.ts
@@ -14,6 +14,7 @@ import {
   type AIProvider,
   TEXT_LIMITS,
   formatTimestampWithDelta,
+  isBotAuthoredReference,
 } from '@tzurot/common-types';
 import type { ProcessedAttachment } from './MultimodalProcessor.js';
 import {
@@ -26,6 +27,46 @@ import { processAttachmentsParallel } from './AttachmentProcessor.js';
 import { extractXmlTextContent } from '../utils/xmlTextExtractor.js';
 
 const logger = createLogger('ReferencedMessageFormatter');
+
+/**
+ * Instruction prepended inside <contextual_references> (mirrors the
+ * <participants>/<memory_archive> instruction pattern). Order-agnostic, positive,
+ * role-aware: the self-authored reply-target is the structural trap — a quote of the
+ * bot's own words read as a turn to continue. Kept as a named constant so the wording
+ * is visible alongside the other prompt-text constants instead of buried inline.
+ */
+const CONTEXTUAL_REFERENCES_INSTRUCTION = `<instruction>Messages the user's current message is replying to or quoting — read them only to understand what the user is responding to. A quote marked role="assistant" is one of your own earlier lines that the user is now addressing; treat it as context and respond to the user's current message. A stubbed quote's full text appears in <chat_log>.</instruction>`;
+
+/**
+ * True when a reference is the CURRENT persona's own prior message: posted by a
+ * bot/webhook AND with an author name matching the active persona. This is the
+ * signal for role="assistant" on a quote — only the persona's own lines should
+ * read as "your own earlier output" (so the model treats them as context, not a
+ * turn to continue).
+ *
+ * Prefix-match on displayName because the bot posts persona replies under the
+ * webhook username `${displayName}${botSuffix}` (see WebhookManager), and the
+ * worker can't reconstruct that runtime suffix — a startsWith on displayName is
+ * the robust match. The bot-authored gate is what keeps a human who merely
+ * shares the persona's name classified as role="user": a PluralKit-proxied human
+ * is bot-authored but the name won't match; a real user named like the persona
+ * isn't bot-authored. Scope is the CURRENT persona only — a sibling persona's
+ * message reads as role="user" so the model responds to it.
+ */
+function isCurrentPersonaReference(
+  ref: ReferencedMessage,
+  personality: LoadedPersonality
+): boolean {
+  if (!isBotAuthoredReference(ref)) {
+    return false;
+  }
+  const personaName = personality.displayName.toLowerCase();
+  if (personaName.length === 0) {
+    return false;
+  }
+  const authorName = (ref.authorDisplayName ?? ref.authorUsername ?? '').toLowerCase();
+  return authorName.startsWith(personaName);
+}
 
 /**
  * Auth context for reference-attachment processing. `userApiKey` is the key for
@@ -93,6 +134,7 @@ export class ReferencedMessageFormatter {
             number: ref.referenceNumber,
             from: ref.authorDisplayName,
             username: ref.authorUsername,
+            role: isCurrentPersonaReference(ref, personality) ? 'assistant' : 'user',
             timestamp:
               absolute.length > 0 && relative.length > 0 ? { absolute, relative } : undefined,
             content: ref.content,
@@ -140,8 +182,8 @@ export class ReferencedMessageFormatter {
       '[ReferencedMessageFormatter] Formatted referenced messages for prompt'
     );
 
-    // Wrap in outer XML tag
-    return `<contextual_references>\n${formattedText}\n</contextual_references>`;
+    // Wrap in outer XML tag.
+    return `<contextual_references>\n${CONTEXTUAL_REFERENCES_INSTRUCTION}\n${formattedText}\n</contextual_references>`;
   }
 
   /**
@@ -176,6 +218,7 @@ export class ReferencedMessageFormatter {
       number: ref.referenceNumber,
       from: ref.authorDisplayName,
       username: ref.authorUsername,
+      role: isCurrentPersonaReference(ref, personality) ? 'assistant' : 'user',
       timestamp: absolute.length > 0 && relative.length > 0 ? { absolute, relative } : undefined,
       content: ref.content || undefined,
       locationContext: ref.locationContext,

--- a/services/ai-worker/src/services/__snapshots__/PromptBuilder.test.ts.snap
+++ b/services/ai-worker/src/services/__snapshots__/PromptBuilder.test.ts.snap
@@ -36,7 +36,8 @@ You are a helpful assistant. Always be kind and helpful.
 <output_constraints>
 <constraint>Output the raw response text only; do not include name labels, timestamps, or speaker prefixes.</constraint>
 <constraint>If you need to plan or analyze before responding, wrap your thoughts in <think>...</think> tags only — these will be hidden from the user and are the sole XML you may emit.</constraint>
-<constraint>Never emit input-format scaffolding in your output: tags like <from_id>, <user>, or <message> are assembly artifacts from the conversation context and must never appear in your response.</constraint>
+<constraint>Never emit input-format scaffolding in your output: tags like <from_id>, <user>, <message>, <quote>, or <contextual_references> are assembly artifacts from the conversation context and must never appear in your response.</constraint>
+<constraint>Respond to the user's current message. The conversation history and quoted references may include your own earlier messages — treat those as context, never as an unfinished turn to continue or extend.</constraint>
 <constraint>Never repeat or parrot back what was just said. Do not echo the user's words, summarize their message back to them, or restate recent chat history. Advance the conversation with original thoughts and reactions.</constraint>
 </output_constraints>"
 `;
@@ -95,7 +96,8 @@ You are a helpful assistant. Always be kind and helpful.
 <output_constraints>
 <constraint>Output the raw response text only; do not include name labels, timestamps, or speaker prefixes.</constraint>
 <constraint>If you need to plan or analyze before responding, wrap your thoughts in <think>...</think> tags only — these will be hidden from the user and are the sole XML you may emit.</constraint>
-<constraint>Never emit input-format scaffolding in your output: tags like <from_id>, <user>, or <message> are assembly artifacts from the conversation context and must never appear in your response.</constraint>
+<constraint>Never emit input-format scaffolding in your output: tags like <from_id>, <user>, <message>, <quote>, or <contextual_references> are assembly artifacts from the conversation context and must never appear in your response.</constraint>
+<constraint>Respond to the user's current message. The conversation history and quoted references may include your own earlier messages — treat those as context, never as an unfinished turn to continue or extend.</constraint>
 <constraint>Never repeat or parrot back what was just said. Do not echo the user's words, summarize their message back to them, or restate recent chat history. Advance the conversation with original thoughts and reactions.</constraint>
 </output_constraints>"
 `;
@@ -173,7 +175,8 @@ You are a helpful assistant. Always be kind and helpful.
 <output_constraints>
 <constraint>Output the raw response text only; do not include name labels, timestamps, or speaker prefixes.</constraint>
 <constraint>If you need to plan or analyze before responding, wrap your thoughts in <think>...</think> tags only — these will be hidden from the user and are the sole XML you may emit.</constraint>
-<constraint>Never emit input-format scaffolding in your output: tags like <from_id>, <user>, or <message> are assembly artifacts from the conversation context and must never appear in your response.</constraint>
+<constraint>Never emit input-format scaffolding in your output: tags like <from_id>, <user>, <message>, <quote>, or <contextual_references> are assembly artifacts from the conversation context and must never appear in your response.</constraint>
+<constraint>Respond to the user's current message. The conversation history and quoted references may include your own earlier messages — treat those as context, never as an unfinished turn to continue or extend.</constraint>
 <constraint>Never repeat or parrot back what was just said. Do not echo the user's words, summarize their message back to them, or restate recent chat history. Advance the conversation with original thoughts and reactions.</constraint>
 </output_constraints>"
 `;
@@ -220,7 +223,8 @@ You are a helpful assistant. Always be kind and helpful.
 <output_constraints>
 <constraint>Output the raw response text only; do not include name labels, timestamps, or speaker prefixes.</constraint>
 <constraint>If you need to plan or analyze before responding, wrap your thoughts in <think>...</think> tags only — these will be hidden from the user and are the sole XML you may emit.</constraint>
-<constraint>Never emit input-format scaffolding in your output: tags like <from_id>, <user>, or <message> are assembly artifacts from the conversation context and must never appear in your response.</constraint>
+<constraint>Never emit input-format scaffolding in your output: tags like <from_id>, <user>, <message>, <quote>, or <contextual_references> are assembly artifacts from the conversation context and must never appear in your response.</constraint>
+<constraint>Respond to the user's current message. The conversation history and quoted references may include your own earlier messages — treat those as context, never as an unfinished turn to continue or extend.</constraint>
 <constraint>Never repeat or parrot back what was just said. Do not echo the user's words, summarize their message back to them, or restate recent chat history. Advance the conversation with original thoughts and reactions.</constraint>
 </output_constraints>"
 `;

--- a/services/ai-worker/src/services/context/referenceEnricher.test.ts
+++ b/services/ai-worker/src/services/context/referenceEnricher.test.ts
@@ -81,7 +81,7 @@ describe('enrichRawReferences', () => {
     expect(result[0].content).toBe('[image/png: board.png]');
   });
 
-  it('strips the bot’s own TTS audio marker when stubbing a duplicate voice reply-target', async () => {
+  it('emits a marker-only stub for the bot’s own deduped voice reply-target', async () => {
     const result = await enrichRawReferences({
       rawReferences: [
         rawRef({
@@ -97,9 +97,11 @@ describe('enrichRawReferences', () => {
       nowMs: NOW,
     });
     expect(result[0].isDeduplicated).toBe(true);
-    // The bot's own audio is delivery of its own text, not an attachment the model
-    // should reason about — only the text survives, no [audio/ogg: …] marker.
-    expect(result[0].content).toBe('You are allowed to be furious about this');
+    // A bot-authored reply-target is the model's own prior line; a snippet of it is a
+    // "continue this fragment" trigger, and the full message is in <chat_log>. So the
+    // bot's deduped stub is marker-only — no audio marker AND no text preview. (The
+    // audio-strip still applies to non-deduped bot quotes, which keep their text.)
+    expect(result[0].content).toBe('');
   });
 
   it('stubs a recent webhook reference via the time fallback', async () => {

--- a/services/ai-worker/src/services/prompt/HardcodedConstraints.test.ts
+++ b/services/ai-worker/src/services/prompt/HardcodedConstraints.test.ts
@@ -60,7 +60,17 @@ describe('HardcodedConstraints', () => {
       expect(OUTPUT_CONSTRAINTS).toContain('<from_id>');
       expect(OUTPUT_CONSTRAINTS).toContain('<user>');
       expect(OUTPUT_CONSTRAINTS).toContain('<message>');
+      // <quote> and <contextual_references> are prompt-structure tags the model
+      // must never reproduce in its output — same class as <from_id>/<user>/<message>.
+      expect(OUTPUT_CONSTRAINTS).toContain('<quote>');
+      expect(OUTPUT_CONSTRAINTS).toContain('<contextual_references>');
       expect(OUTPUT_CONSTRAINTS).toContain('assembly artifacts');
+    });
+
+    it('should anchor the model to the user’s current message, not continuing its own prior text', () => {
+      // Defuses the self-reply / chat-log-ends-with-bot continuation trigger.
+      expect(OUTPUT_CONSTRAINTS).toContain("Respond to the user's current message");
+      expect(OUTPUT_CONSTRAINTS).toContain('never as an unfinished turn to continue or extend');
     });
 
     it('should prohibit parroting', () => {

--- a/services/ai-worker/src/services/prompt/HardcodedConstraints.ts
+++ b/services/ai-worker/src/services/prompt/HardcodedConstraints.ts
@@ -60,6 +60,7 @@ export function buildIdentityConstraints(
 export const OUTPUT_CONSTRAINTS = `<output_constraints>
 <constraint>Output the raw response text only; do not include name labels, timestamps, or speaker prefixes.</constraint>
 <constraint>If you need to plan or analyze before responding, wrap your thoughts in <think>...</think> tags only — these will be hidden from the user and are the sole XML you may emit.</constraint>
-<constraint>Never emit input-format scaffolding in your output: tags like <from_id>, <user>, or <message> are assembly artifacts from the conversation context and must never appear in your response.</constraint>
+<constraint>Never emit input-format scaffolding in your output: tags like <from_id>, <user>, <message>, <quote>, or <contextual_references> are assembly artifacts from the conversation context and must never appear in your response.</constraint>
+<constraint>Respond to the user's current message. The conversation history and quoted references may include your own earlier messages — treat those as context, never as an unfinished turn to continue or extend.</constraint>
 <constraint>Never repeat or parrot back what was just said. Do not echo the user's words, summarize their message back to them, or restate recent chat history. Advance the conversation with original thoughts and reactions.</constraint>
 </output_constraints>`;

--- a/services/ai-worker/src/services/prompt/QuoteFormatter.test.ts
+++ b/services/ai-worker/src/services/prompt/QuoteFormatter.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  formatDedupedQuote,
   formatForwardedQuote,
   formatQuoteElement,
   type ForwardedMessageContent,
@@ -396,6 +397,22 @@ describe('QuoteFormatter', () => {
       expect(result).toContain('<image filename="a.png">Image A</image>');
       expect(result).toContain('<image filename="b.png">Image B</image>');
       expect(result).toContain('<image filename="c.png">Image C</image>');
+    });
+  });
+
+  describe('formatDedupedQuote', () => {
+    it('prepends the referenced-message marker before a user reply-target preview', () => {
+      const result = formatDedupedQuote({ from: 'Alice', role: 'user', content: 'some text' });
+      expect(result).toContain('[Referenced message — full text in <chat_log>]');
+      expect(result).toContain('some text');
+      expect(result).toContain('role="user"');
+    });
+
+    it('renders a marker-only stub (no preview) when content is empty', () => {
+      // The bot's-own-reply-target case: no self-preview to invite continuation.
+      const result = formatDedupedQuote({ from: 'Lilith', role: 'assistant', content: '' });
+      expect(result).toContain('<content>[Referenced message — full text in <chat_log>]</content>');
+      expect(result).toContain('role="assistant"');
     });
   });
 });

--- a/services/ai-worker/src/services/prompt/QuoteFormatter.ts
+++ b/services/ai-worker/src/services/prompt/QuoteFormatter.ts
@@ -166,8 +166,12 @@ export function formatForwardedQuote(content: ForwardedMessageContent): string {
   });
 }
 
-/** Prefix for deduplicated reference stubs */
-const DEDUP_REPLY_TARGET_PREFIX = '[Reply target — full message is in conversation above]';
+/**
+ * Prefix for deduplicated reference stubs. Order-agnostic (points to <chat_log>
+ * rather than "above" — references are assembled BEFORE <chat_log>) and drops
+ * the "reply target" Discord-UI jargon, which read as a task to the model.
+ */
+const DEDUP_REPLY_TARGET_PREFIX = '[Referenced message — full text in <chat_log>]';
 
 /**
  * Options for formatting a deduplicated reference stub.
@@ -180,11 +184,13 @@ export interface DedupedQuoteOptions {
   from: string;
   /** Author username (real-time refs only) */
   username?: string;
+  /** Speaker role — `assistant` marks one of the bot's own prior messages. */
+  role?: 'user' | 'assistant';
   /** Structured timestamp as child element */
   timestamp?: { absolute: string; relative: string };
   /** Pre-formatted timestamp as attribute */
   timeFormatted?: string;
-  /** Original message content (will be truncated) */
+  /** Original message content (will be truncated). Empty → marker-only stub. */
   content: string;
 }
 
@@ -197,12 +203,19 @@ export function formatDedupedQuote(opts: DedupedQuoteOptions): string {
   const truncated =
     opts.content.length > limit ? opts.content.substring(0, limit) + '...' : opts.content;
 
+  // Empty content (e.g. a bot's own reply-target) → marker only, no trailing blank.
+  const content =
+    truncated.length > 0
+      ? `${DEDUP_REPLY_TARGET_PREFIX}\n\n${truncated}`
+      : DEDUP_REPLY_TARGET_PREFIX;
+
   return formatQuoteElement({
     number: opts.number,
     from: opts.from,
     username: opts.username,
+    role: opts.role,
     timestamp: opts.timestamp,
     timeFormatted: opts.timeFormatted,
-    content: `${DEDUP_REPLY_TARGET_PREFIX}\n\n${truncated}`,
+    content,
   });
 }


### PR DESCRIPTION
## Problem

A production reasoning trace showed the model spiralling when a user used Discord's **reply** feature to reply to one of the bot's **own** prior messages. That message had been delivered as TTS, so the `<contextual_references>` stub showed the bot's prior text plus a `[audio/ogg: …]` marker — and the model reasoned *"this might be a response I gave that included audio … my previous response I need to continue from."* It recovered, but burned reasoning; a soft failure that could go hard on a weaker model.

The audio marker is already fixed (#1312, `stripBotVoiceAttachments`). The residual was structural: `<contextual_references>` was the one major prompt section with **no instruction**, and nothing told the model that a quote attributed to *itself* is context, not a turn to continue.

## Council

Vetted by GLM-5.2 / Kimi-K2.7-code / Qwen-3.7-max. They caught a real bug in the first-draft wording — `<contextual_references>` is assembled **before** `<chat_log>`, so "full message above" was backwards — and converged on a structural (not just instructional) fix. One council premise was wrong and corrected by verification: the current user message is a **separate API turn**, not the last `<chat_log>` entry (so the anti-continuation guidance lives in `<output_constraints>`, not a chat-log instruction).

## Changes

- **`<contextual_references>` instruction** — order-agnostic, positively framed, role-aware (mirrors the `<participants>`/`<memory_archive>` pattern).
- **`role="assistant"|"user"` on every `<quote>`** — the strongest signal; the model shouldn't have to infer authorship from the name. Extracts `isBotAuthoredReference` and preserves `authorIsBot`/`webhookId` through `buildDedupedReferenceStub` so the dedup path derives it.
- **Bot's own dedup stubs are marker-only** — a snippet of the bot's own text is the "continue this fragment" trigger; the full message is in `<chat_log>` anyway. (The #1312 audio-strip still applies to non-deduped bot quotes, which keep their text.)
- **Neutral dedup marker** — `[Referenced message — full text in <chat_log>]` (drops the "reply target" Discord jargon and the wrong "above").
- **`<output_constraints>`** — extend the scaffolding-ban to `<quote>`/`<contextual_references>`, and add a positive anti-continuation anchor (high recency; also covers the chat-log-ends-with-bot-message trigger).

## Deferred to backlog
- Inline `reply_to=` on `<chat_log>` messages (dissolve the separate references section for in-window targets) — architecture work → `cold/ideas.md`.
- Reframe the `Meta-Awareness` / `System Prompt Primacy` directive *names* (may invite meta-cognition) → `cold/follow-ups.md`.

## Tests
- New: `isBotAuthoredReference`, bot-authored marker-only stub, `<contextual_references>` instruction present, `role="assistant"` on self-quotes, `formatDedupedQuote` empty-content path, the new output-constraints.
- Updated: dedup-marker assertions, the `referenceEnricher` bot-voice dedup test (now marker-only), and the PromptBuilder prompt snapshots (output_constraints). `pnpm quality` + full ai-worker suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)