### PR TITLE
ci: sync Claude review workflows to main (unblock PR claude-review)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## Why

`claude-review` skips on **every** PR right now with a *"workflow validation failed — the workflow file must have identical content to the default branch"* error (green 10-15s no-op, no review posted).

**Cause:** #1296 bumped `actions/checkout` 6→7 in `claude-code-review.yml` and `claude.yml` on develop. claude-review's security guard requires the running workflow (develop's, on a `feature→develop` PR) to be byte-identical to the **default branch (main)**, which still has `@v6`. So it skips.

**Chicken-and-egg:** the bump would normally reach main only when the next release (beta.136) merges — but that release PR's own claude-review would *also* skip, and so would every feature PR going into it. This carries just the two Claude workflow files to main now so the validation passes again.

## Scope

Two files, one-line each (`@v6` → `@v7`). `ci.yml`'s identical bump is left to ride the next release (claude-review doesn't validate against it). At release, these two files are already identical develop↔main, so the merge is a no-op for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)