### PR TITLE
debug(bot-client): probe applicationId on webhook references

### DIFF
--- a/services/bot-client/src/handlers/references/MessageFormatter.ts
+++ b/services/bot-client/src/handlers/references/MessageFormatter.ts
@@ -106,6 +106,23 @@ export class MessageFormatter {
 
     const { content, attachments } = this.resolveMessageContent(message, messageIsForwarded);
 
+    // Temporary probe: capture the owning applicationId for webhook references, to
+    // verify whether proxy webhooks (PluralKit/Tupperbox) carry one — the signal the
+    // authorship classifier needs to tell a proxied human from a non-persona bot.
+    // Logged at info so it surfaces on dev's default level. Remove after capture.
+    if (message.webhookId !== null) {
+      logger.info(
+        {
+          probe: 'applicationId',
+          refMsgId: message.id,
+          webhookId: message.webhookId,
+          applicationId: message.applicationId,
+          authorIsBot: message.author.bot,
+        },
+        '[PROBE] webhook reference authorship signals'
+      );
+    }
+
     return {
       attachments,
       reference: {


### PR DESCRIPTION
**Temporary diagnostic** for PR #81 (applicationId-based authorship classifier).

Verifies whether proxy webhooks (PluralKit / TupperBox) carry an owning `applicationId` in our message data — the load-bearing unknown for tagging proxied-human messages as `role="user"` vs other bots as `role="bot"`. Logs `webhookId` + `applicationId` + `authorIsBot` at **info** level (dev's default) for every webhook-authored reference, in `MessageFormatter.buildRawReference`.

**How to read it:** deploy to dev → reply to (or reference) a PluralKit message in the test server → grep dev logs for `[PROBE]`. Our own persona refs should log `applicationId = <our bot id>`; a PK ref logs PK's app id if Discord populates it, or `null` if not.

**Lifecycle:** remove in the actual #81 fix PR once the data is captured (`git log --grep '^debug[:(]'` surfaces it until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)