### PR TITLE
feat: applicationId-based 3-way reference authorship (assistant/user/bot)

### DIFF
--- a/packages/common-types/src/constants/index.ts
+++ b/packages/common-types/src/constants/index.ts
@@ -143,3 +143,6 @@ export { CACHE_KEY_PREFIXES } from './redis-keys.js';
 
 // Persona-ID placeholder prefix (pre-resolution extended-context records)
 export { INTERNAL_DISCORD_ID_PREFIX } from './personaId.js';
+
+// Known message-proxy application IDs (PluralKit/TupperBox) for authorship classification
+export { KNOWN_PROXY_APP_IDS } from './proxyBots.js';

--- a/packages/common-types/src/constants/proxyBots.ts
+++ b/packages/common-types/src/constants/proxyBots.ts
@@ -1,0 +1,17 @@
+/**
+ * Discord application IDs of message-proxy systems (PluralKit, TupperBox, …) that
+ * re-post HUMAN messages via webhooks. A referenced message whose owning
+ * `applicationId` is in this list is a proxied human → `role="user"`, not a
+ * non-persona bot → `role="bot"`.
+ *
+ * An `applicationId` NOT in this list (and not our own bot's) falls into the `bot`
+ * catch-all — correct by construction: not clearly our persona, not clearly an
+ * unproxied human. Each entry documents how its id was established; the bar for
+ * adding one is "this app proxies humans and we trust the id" — Discord doesn't
+ * reliably populate `application_id` on plain webhook executes, so a real sighting
+ * (or a strong public-knowledge basis) is what justifies an entry.
+ */
+export const KNOWN_PROXY_APP_IDS: readonly string[] = [
+  '466378653216014359', // PluralKit — confirmed present on a real proxied reference in our logs
+  '431544605209788416', // TupperBox — operator-confirmed public app id; same app-owned-webhook proxy behavior as PluralKit
+];

--- a/packages/common-types/src/types/schemas/message.test.ts
+++ b/packages/common-types/src/types/schemas/message.test.ts
@@ -10,6 +10,7 @@ import {
   crossChannelMessageSchema,
   crossChannelHistoryGroupSchema,
   referencedMessageSchema,
+  referenceAuthorRoleSchema,
   type CrossChannelMessage,
   type CrossChannelHistoryGroupEntry,
 } from './message.js';
@@ -216,5 +217,34 @@ describe('referencedMessageSchema', () => {
   it('rejects an explicit false (presence-encoding enforced at parse time)', () => {
     const result = referencedMessageSchema.safeParse({ ...base, authorIsBot: false });
     expect(result.success).toBe(false);
+  });
+
+  it('accepts a reference without authorRole (legacy / pre-classifier)', () => {
+    const result = referencedMessageSchema.safeParse(base);
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.authorRole).toBeUndefined();
+  });
+
+  it('accepts a valid authorRole', () => {
+    const result = referencedMessageSchema.safeParse({ ...base, authorRole: 'bot' });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.authorRole).toBe('bot');
+  });
+
+  it('rejects an invalid authorRole', () => {
+    const result = referencedMessageSchema.safeParse({ ...base, authorRole: 'system' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('referenceAuthorRoleSchema', () => {
+  it('accepts the three valid roles', () => {
+    for (const role of ['assistant', 'user', 'bot'] as const) {
+      expect(referenceAuthorRoleSchema.safeParse(role).success).toBe(true);
+    }
+  });
+
+  it('rejects an unknown role', () => {
+    expect(referenceAuthorRoleSchema.safeParse('system').success).toBe(false);
   });
 });

--- a/packages/common-types/src/types/schemas/message.ts
+++ b/packages/common-types/src/types/schemas/message.ts
@@ -39,6 +39,17 @@ export const apiConversationMessageSchema = z.object({
 });
 
 /**
+ * How a referenced message's author relates to the model — drives the
+ * `<quote role>` signal. `assistant` = one of our own personas (our bot's
+ * webhook); `user` = a human (incl. proxy-system-relayed humans); `bot` = a
+ * non-persona bot/webhook. Classified once in bot-client (which has the Discord
+ * message's `applicationId`) and carried to both the live prompt and the
+ * stored-history snapshot.
+ */
+export const referenceAuthorRoleSchema = z.enum(['assistant', 'user', 'bot']);
+export type ReferenceAuthorRole = z.infer<typeof referenceAuthorRoleSchema>;
+
+/**
  * Referenced message schema
  * Used when a user references other messages via replies or message links
  */
@@ -51,6 +62,9 @@ export const referencedMessageSchema = z.object({
   // dedup fallback, which the worker-side assembler re-runs from raw
   // reference snapshots — it cannot ask Discord about the author itself.
   authorIsBot: z.literal(true).optional(),
+  // Precomputed authorship role (bot-client classifies via applicationId, which the
+  // worker can't see). Absent on legacy refs → worker falls back to name-based role.
+  authorRole: referenceAuthorRoleSchema.optional(),
   discordUserId: z.string(), // Discord user ID for persona lookup
   authorUsername: z.string(),
   authorDisplayName: z.string(),
@@ -90,6 +104,9 @@ export const storedReferencedMessageSchema = z.object({
   isForwarded: z.boolean().optional(),
   // Persistent — set by bot-client when resolving links
   authorDiscordId: z.string().optional(),
+  // Persistent — carried from the live reference's classification (see
+  // referenceAuthorRoleSchema). Absent on pre-classifier history → name fallback.
+  authorRole: referenceAuthorRoleSchema.optional(),
   // Ephemeral — set by hydration in ai-worker before prompt formatting
   resolvedPersonaId: z.string().optional(),
   resolvedPersonaName: z.string().optional(),

--- a/packages/common-types/src/utils/referenceEnrichment.ts
+++ b/packages/common-types/src/utils/referenceEnrichment.ts
@@ -171,9 +171,11 @@ export function buildDedupedReferenceStub(reference: ReferencedMessage): Referen
     discordUserId: reference.discordUserId,
     authorUsername: reference.authorUsername,
     authorDisplayName: reference.authorDisplayName,
-    // Preserved so the formatter can derive the role="assistant" quote signal.
+    // authorIsBot/webhookId still gate the content-emptying above; authorRole is the
+    // carried-through classification the formatter renders as the <quote role> signal.
     authorIsBot: reference.authorIsBot,
     webhookId: reference.webhookId,
+    authorRole: reference.authorRole,
     content,
     embeds: '',
     timestamp: reference.timestamp,

--- a/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.test.ts
+++ b/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.test.ts
@@ -57,15 +57,18 @@ const { mockFormatQuoteElement, mockFormatDedupedQuote } = vi.hoisted(() => {
 
   const fdq = vi
     .fn()
-    .mockImplementation((opts: { from: string; timeFormatted?: string; content: string }) => {
-      const truncated =
-        opts.content.length > 100 ? opts.content.substring(0, 100) + '...' : opts.content;
-      return fqe({
-        from: opts.from,
-        timeFormatted: opts.timeFormatted,
-        content: `[Referenced message — full text in <chat_log>]\n\n${truncated}`,
-      });
-    });
+    .mockImplementation(
+      (opts: { from: string; role?: string; timeFormatted?: string; content: string }) => {
+        const truncated =
+          opts.content.length > 100 ? opts.content.substring(0, 100) + '...' : opts.content;
+        return fqe({
+          from: opts.from,
+          role: opts.role,
+          timeFormatted: opts.timeFormatted,
+          content: `[Referenced message — full text in <chat_log>]\n\n${truncated}`,
+        });
+      }
+    );
 
   return { mockFormatQuoteElement: fqe, mockFormatDedupedQuote: fdq };
 });
@@ -287,6 +290,30 @@ describe('xmlMetadataFormatters', () => {
       expect(result).toContain('[Referenced message — full text in <chat_log>]');
       expect(result).toContain('Duplicated message that is in history');
       expect(result).toContain('from="User One"');
+    });
+
+    it('renders role="bot" on a deduped stub from a non-persona bot reference', () => {
+      // Stored authorRole flows through the deduped path too — regression guard against
+      // the role attribute being dropped between deriveRefRole and formatDedupedQuote.
+      const msg = makeEntry({
+        messageMetadata: {
+          referencedMessages: [
+            {
+              discordMessageId: 'already-in-history',
+              authorUsername: 'somebot',
+              authorDisplayName: 'SomeBot',
+              authorRole: 'bot',
+              content: 'Automated webhook output',
+              timestamp: '2026-01-01T00:00:00.000Z',
+              locationContext: '',
+            },
+          ],
+        },
+      });
+
+      const historyIds = new Set(['already-in-history']);
+      const result = formatQuotedSection(msg, 'user', personalityName, historyIds, undefined);
+      expect(result).toContain('role="bot"');
     });
 
     it('truncates long content in deduped stubs to ~100 chars', () => {

--- a/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.ts
+++ b/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.ts
@@ -13,30 +13,8 @@ import {
   type StoredReferencedMessage,
 } from '@tzurot/common-types';
 import { formatQuoteElement, formatDedupedQuote } from '../../services/prompt/QuoteFormatter.js';
+import { deriveRefRole } from '../../services/prompt/referenceRole.js';
 import type { RawHistoryEntry } from './conversationTypes.js';
-
-/**
- * Check if author name matches any AI personality (for role inference)
- */
-function isAuthorAssistant(
-  authorName: string,
-  personalityName: string,
-  allPersonalityNames?: Set<string>
-): boolean {
-  const authorLower = authorName.toLowerCase();
-  if (authorLower.startsWith(personalityName.toLowerCase())) {
-    return true;
-  }
-  if (allPersonalityNames === undefined) {
-    return false;
-  }
-  for (const name of allPersonalityNames) {
-    if (authorLower.startsWith(name.toLowerCase())) {
-      return true;
-    }
-  }
-  return false;
-}
 
 /**
  * Format a single stored reference as a <quote> element.
@@ -56,9 +34,7 @@ function formatStoredReferencedMessage(
 ): string {
   // Use hydrated persona name if available, fall back to original Discord display name
   const authorName = ref.resolvedPersonaName ?? (ref.authorDisplayName || ref.authorUsername);
-  const role = isAuthorAssistant(authorName, personalityName, allPersonalityNames)
-    ? 'assistant'
-    : 'user';
+  const role = deriveRefRole(ref.authorRole, authorName, personalityName, allPersonalityNames);
 
   // Format location if present (should be XML formatted by bot-client using shared formatLocationAsXml)
   // Skip legacy Markdown format (from old stored data) - detectable by "**Server**" or
@@ -144,8 +120,10 @@ export function formatQuotedSection(
   // Deduped refs: lightweight stubs with truncated content and reply-target note
   const formattedDeduped = dedupedRefs.map(ref => {
     const authorName = ref.resolvedPersonaName ?? (ref.authorDisplayName || ref.authorUsername);
+    const role = deriveRefRole(ref.authorRole, authorName, personalityName, allPersonalityNames);
     return formatDedupedQuote({
       from: authorName,
+      role,
       timeFormatted:
         ref.timestamp !== undefined && ref.timestamp.length > 0
           ? formatPromptTimestamp(ref.timestamp)

--- a/services/ai-worker/src/services/ReferencedMessageFormatter.test.ts
+++ b/services/ai-worker/src/services/ReferencedMessageFormatter.test.ts
@@ -303,62 +303,105 @@ describe('ReferencedMessageFormatter', () => {
       expect(result).toContain('Second message');
     });
 
-    it('marks a non-deduped reference from the current persona role="assistant"', async () => {
-      // A non-deduped reference from the CURRENT persona (bot/webhook AND a display
-      // name matching the persona — here carrying a webhook suffix) reads as the
-      // model's own prior line. Prefix-match on displayName absorbs the suffix.
+    it('renders authorRole="assistant" on a non-deduped quote', async () => {
+      // The worker renders the role stamped at classification time (bot-client) — it
+      // no longer derives it. authorRole="assistant" = one of our own personas.
       const references: ReferencedMessage[] = [
         {
           referenceNumber: 1,
           discordMessageId: 'msg-bot-1',
           discordUserId: 'bot-user-id',
-          authorUsername: 'Test Bot 🤖',
-          authorDisplayName: 'Test Bot 🤖',
+          authorUsername: 'Lilith',
+          authorDisplayName: 'Lilith',
           content: 'Something I said earlier',
           embeds: '',
           timestamp: '2025-11-04T00:00:00Z',
           locationContext:
             '<location type="guild">\n<server name="Test Guild"/>\n<channel name="general" type="text"/>\n</location>',
-          authorIsBot: true,
-          webhookId: 'wh-1',
+          authorRole: 'assistant',
         },
       ];
 
       const result = await formatter.formatReferencedMessages(references, mockPersonality);
 
       expect(result).toContain(
-        '<quote number="1" from="Test Bot 🤖" username="Test Bot 🤖" role="assistant">'
+        '<quote number="1" from="Lilith" username="Lilith" role="assistant">'
       );
       expect(result).toContain('<content>Something I said earlier</content>');
     });
 
-    it('marks a non-deduped third-party bot/webhook reference role="user"', async () => {
-      // A bot/webhook message NOT from our persona (a PluralKit-proxied human,
-      // another bot) must read as role="user" — the model should respond to it,
-      // not treat it as its own line. The persona name-match scopes this; bot
-      // authorship alone is not enough — that breadth is the misfire to avoid.
+    it('renders authorRole="bot" on a non-deduped quote (non-persona automation)', async () => {
+      // A non-persona bot/webhook (e.g. MEE6, an unrecognized proxy) reads as
+      // role="bot": not us, not the human the user is addressing.
       const references: ReferencedMessage[] = [
         {
           referenceNumber: 1,
-          discordMessageId: 'msg-pk-1',
-          discordUserId: 'pk-user-id',
-          authorUsername: 'SomeoneElse',
-          authorDisplayName: 'SomeoneElse',
-          content: 'a proxied human message',
+          discordMessageId: 'msg-bot-2',
+          discordUserId: 'other-bot-id',
+          authorUsername: 'SomeBot',
+          authorDisplayName: 'SomeBot',
+          content: 'an automated message',
           embeds: '',
           timestamp: '2025-11-04T00:00:00Z',
           locationContext:
             '<location type="guild">\n<server name="Test Guild"/>\n<channel name="general" type="text"/>\n</location>',
-          authorIsBot: true,
-          webhookId: 'pk-webhook',
+          authorRole: 'bot',
         },
       ];
 
       const result = await formatter.formatReferencedMessages(references, mockPersonality);
 
-      expect(result).toContain(
-        '<quote number="1" from="SomeoneElse" username="SomeoneElse" role="user">'
-      );
+      expect(result).toContain('<quote number="1" from="SomeBot" username="SomeBot" role="bot">');
+    });
+
+    it('falls back to role="user" when authorRole is absent and the author is not a persona', async () => {
+      // Pre-classifier / deploy-window references carry no authorRole. The name-match
+      // fallback resolves a non-persona author to user — a missing signal never
+      // mislabels a human as our own line.
+      const references: ReferencedMessage[] = [
+        {
+          referenceNumber: 1,
+          discordMessageId: 'msg-legacy',
+          discordUserId: 'user-x',
+          authorUsername: 'someone',
+          authorDisplayName: 'Someone',
+          content: 'legacy message',
+          embeds: '',
+          timestamp: '2025-11-04T00:00:00Z',
+          locationContext:
+            '<location type="guild">\n<server name="Test Guild"/>\n<channel name="general" type="text"/>\n</location>',
+        },
+      ];
+
+      const result = await formatter.formatReferencedMessages(references, mockPersonality);
+
+      expect(result).toContain('<quote number="1" from="Someone" username="someone" role="user">');
+    });
+
+    it('falls back to role="assistant" when authorRole is absent but the author matches the active personality', async () => {
+      // Deploy-window safety: an old bot-client (pre-classifier) can send a live ref
+      // with no authorRole. Without the name-match fallback, our own personality's
+      // reply-target would read as role="user" until both services finish deploying,
+      // re-opening the self-reply confusion the classifier prevents. mockPersonality's
+      // displayName is 'Test Bot', so a 'Test Bot'-authored ref resolves to assistant.
+      const references: ReferencedMessage[] = [
+        {
+          referenceNumber: 1,
+          discordMessageId: 'msg-self',
+          discordUserId: 'bot-x',
+          authorUsername: 'test-bot',
+          authorDisplayName: 'Test Bot',
+          content: 'our own earlier line',
+          embeds: '',
+          timestamp: '2025-11-04T00:00:00Z',
+          locationContext:
+            '<location type="guild">\n<server name="Test Guild"/>\n<channel name="general" type="text"/>\n</location>',
+        },
+      ];
+
+      const result = await formatter.formatReferencedMessages(references, mockPersonality);
+
+      expect(result).toContain('role="assistant"');
     });
   });
 
@@ -403,21 +446,23 @@ describe('ReferencedMessageFormatter', () => {
       ];
       const result = await formatter.formatReferencedMessages(references, mockPersonality);
       expect(result).toContain('<instruction>');
+      // Assert all three role clauses — a future edit dropping one would otherwise
+      // pass undetected since the assistant clause's substring stays present.
       expect(result).toContain('role="assistant" is one of your own earlier lines');
+      expect(result).toContain('role="user" is a person');
+      expect(result).toContain('role="bot" is a different bot or automated webhook');
     });
 
-    it('marks a deduped reply-target from the current persona role="assistant" (marker-only)', async () => {
-      // The stub builder empties the current persona's content (no self-preview);
-      // the formatter derives role="assistant" from the bot-gate + persona match.
+    it('renders authorRole="assistant" on a deduped reply-target (marker-only)', async () => {
+      // Deduped stub from our own persona: role="assistant", marker-only content.
       const references: ReferencedMessage[] = [
         {
           referenceNumber: 1,
           discordMessageId: 'm',
           discordUserId: 'u',
-          authorUsername: 'Test Bot 🤖',
-          authorDisplayName: 'Test Bot 🤖',
-          webhookId: 'wh-1',
-          authorIsBot: true,
+          authorUsername: 'Lilith',
+          authorDisplayName: 'Lilith',
+          authorRole: 'assistant',
           content: '',
           embeds: '',
           timestamp: '2025-12-06T00:00:00Z',
@@ -426,23 +471,23 @@ describe('ReferencedMessageFormatter', () => {
         },
       ];
       const result = await formatter.formatReferencedMessages(references, mockPersonality);
-      expect(result).toContain('role="assistant"');
+      expect(result).toContain(
+        '<quote number="1" from="Lilith" username="Lilith" role="assistant">'
+      );
       expect(result).toContain('[Referenced message — full text in <chat_log>]');
     });
 
-    it('marks a deduped third-party bot/webhook reply-target role="user"', async () => {
-      // A deduped stub from a non-persona bot/webhook (PluralKit, another bot) is
-      // role="user" — same persona-scoping as the non-deduped path.
+    it('renders authorRole="bot" on a deduped third-party reply-target', async () => {
+      // A deduped stub from a non-persona bot/webhook reads as role="bot".
       const references: ReferencedMessage[] = [
         {
           referenceNumber: 1,
           discordMessageId: 'm',
           discordUserId: 'u',
-          authorUsername: 'SomeoneElse',
-          authorDisplayName: 'SomeoneElse',
-          webhookId: 'pk-webhook',
-          authorIsBot: true,
-          content: 'proxied text',
+          authorUsername: 'SomeBot',
+          authorDisplayName: 'SomeBot',
+          authorRole: 'bot',
+          content: 'automated text',
           embeds: '',
           timestamp: '2025-12-06T00:00:00Z',
           locationContext: '',
@@ -450,7 +495,7 @@ describe('ReferencedMessageFormatter', () => {
         },
       ];
       const result = await formatter.formatReferencedMessages(references, mockPersonality);
-      expect(result).toContain('role="user"');
+      expect(result).toContain('<quote number="1" from="SomeBot" username="SomeBot" role="bot">');
     });
 
     it('should not process attachments for deduped stubs', async () => {

--- a/services/ai-worker/src/services/ReferencedMessageFormatter.ts
+++ b/services/ai-worker/src/services/ReferencedMessageFormatter.ts
@@ -14,7 +14,6 @@ import {
   type AIProvider,
   TEXT_LIMITS,
   formatTimestampWithDelta,
-  isBotAuthoredReference,
 } from '@tzurot/common-types';
 import type { ProcessedAttachment } from './MultimodalProcessor.js';
 import {
@@ -23,6 +22,7 @@ import {
   formatDedupedQuote,
   type ForwardedMessageContent,
 } from './prompt/QuoteFormatter.js';
+import { deriveRefRole } from './prompt/referenceRole.js';
 import { processAttachmentsParallel } from './AttachmentProcessor.js';
 import { extractXmlTextContent } from '../utils/xmlTextExtractor.js';
 
@@ -35,38 +35,7 @@ const logger = createLogger('ReferencedMessageFormatter');
  * bot's own words read as a turn to continue. Kept as a named constant so the wording
  * is visible alongside the other prompt-text constants instead of buried inline.
  */
-const CONTEXTUAL_REFERENCES_INSTRUCTION = `<instruction>Messages the user's current message is replying to or quoting — read them only to understand what the user is responding to. A quote marked role="assistant" is one of your own earlier lines that the user is now addressing; treat it as context and respond to the user's current message. A stubbed quote's full text appears in <chat_log>.</instruction>`;
-
-/**
- * True when a reference is the CURRENT persona's own prior message: posted by a
- * bot/webhook AND with an author name matching the active persona. This is the
- * signal for role="assistant" on a quote — only the persona's own lines should
- * read as "your own earlier output" (so the model treats them as context, not a
- * turn to continue).
- *
- * Prefix-match on displayName because the bot posts persona replies under the
- * webhook username `${displayName}${botSuffix}` (see WebhookManager), and the
- * worker can't reconstruct that runtime suffix — a startsWith on displayName is
- * the robust match. The bot-authored gate is what keeps a human who merely
- * shares the persona's name classified as role="user": a PluralKit-proxied human
- * is bot-authored but the name won't match; a real user named like the persona
- * isn't bot-authored. Scope is the CURRENT persona only — a sibling persona's
- * message reads as role="user" so the model responds to it.
- */
-function isCurrentPersonaReference(
-  ref: ReferencedMessage,
-  personality: LoadedPersonality
-): boolean {
-  if (!isBotAuthoredReference(ref)) {
-    return false;
-  }
-  const personaName = personality.displayName.toLowerCase();
-  if (personaName.length === 0) {
-    return false;
-  }
-  const authorName = (ref.authorDisplayName ?? ref.authorUsername ?? '').toLowerCase();
-  return authorName.startsWith(personaName);
-}
+const CONTEXTUAL_REFERENCES_INSTRUCTION = `<instruction>Messages the user's current message is replying to or quoting — read them only to understand what the user is responding to. A quote's role says who wrote it: role="assistant" is one of your own earlier lines (context, never a turn to continue or extend); role="user" is a person; role="bot" is a different bot or automated webhook — not you, and not the human you're replying to. Respond to the user's current message. A stubbed quote's full text appears in <chat_log>.</instruction>`;
 
 /**
  * Auth context for reference-attachment processing. `userApiKey` is the key for
@@ -134,7 +103,11 @@ export class ReferencedMessageFormatter {
             number: ref.referenceNumber,
             from: ref.authorDisplayName,
             username: ref.authorUsername,
-            role: isCurrentPersonaReference(ref, personality) ? 'assistant' : 'user',
+            role: deriveRefRole(
+              ref.authorRole,
+              ref.authorDisplayName || ref.authorUsername,
+              personality.displayName
+            ),
             timestamp:
               absolute.length > 0 && relative.length > 0 ? { absolute, relative } : undefined,
             content: ref.content,
@@ -218,7 +191,11 @@ export class ReferencedMessageFormatter {
       number: ref.referenceNumber,
       from: ref.authorDisplayName,
       username: ref.authorUsername,
-      role: isCurrentPersonaReference(ref, personality) ? 'assistant' : 'user',
+      role: deriveRefRole(
+        ref.authorRole,
+        ref.authorDisplayName || ref.authorUsername,
+        personality.displayName
+      ),
       timestamp: absolute.length > 0 && relative.length > 0 ? { absolute, relative } : undefined,
       content: ref.content || undefined,
       locationContext: ref.locationContext,

--- a/services/ai-worker/src/services/context/referenceEnricher.ts
+++ b/services/ai-worker/src/services/context/referenceEnricher.ts
@@ -33,6 +33,7 @@
 import {
   appendVoiceTranscripts,
   buildDedupedReferenceStub,
+  isBotAuthoredReference,
   isDuplicateReference,
   stripBotVoiceAttachments,
   type ConversationMessage,
@@ -88,8 +89,7 @@ export async function enrichRawReferences(
         {
           discordMessageId: raw.discordMessageId,
           timestampMs: new Date(raw.timestamp).getTime(),
-          isWebhookOrBotAuthored:
-            (raw.webhookId !== undefined && raw.webhookId.length > 0) || raw.authorIsBot === true,
+          isWebhookOrBotAuthored: isBotAuthoredReference(raw),
         },
         dedupHistory,
         nowMs

--- a/services/ai-worker/src/services/prompt/QuoteFormatter.ts
+++ b/services/ai-worker/src/services/prompt/QuoteFormatter.ts
@@ -11,7 +11,12 @@
  * to provide context about the quote source.
  */
 
-import { escapeXml, escapeXmlContent, TEXT_LIMITS } from '@tzurot/common-types';
+import {
+  escapeXml,
+  escapeXmlContent,
+  TEXT_LIMITS,
+  type ReferenceAuthorRole,
+} from '@tzurot/common-types';
 
 /**
  * Options for formatting a single <quote> element.
@@ -28,8 +33,8 @@ export interface QuoteElementOptions {
   fromId?: string;
   /** Author username */
   username?: string;
-  /** Speaker role */
-  role?: 'user' | 'assistant';
+  /** Speaker role: assistant (our persona), user (a person), or bot (other automation) */
+  role?: ReferenceAuthorRole;
   /** Pre-formatted timestamp string (for t="" attribute on <quote>) */
   timeFormatted?: string;
   /** Structured timestamp (for <time> child element) */
@@ -184,8 +189,8 @@ export interface DedupedQuoteOptions {
   from: string;
   /** Author username (real-time refs only) */
   username?: string;
-  /** Speaker role — `assistant` marks one of the bot's own prior messages. */
-  role?: 'user' | 'assistant';
+  /** Speaker role — `assistant` (our persona), `user` (a person), `bot` (other automation). */
+  role?: ReferenceAuthorRole;
   /** Structured timestamp as child element */
   timestamp?: { absolute: string; relative: string };
   /** Pre-formatted timestamp as attribute */

--- a/services/ai-worker/src/services/prompt/referenceRole.test.ts
+++ b/services/ai-worker/src/services/prompt/referenceRole.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { isAuthorAssistant, deriveRefRole } from './referenceRole.js';
+
+describe('isAuthorAssistant', () => {
+  it('matches when the author name is prefixed by the active personality name', () => {
+    // Webhook usernames are `${displayName}${botSuffix}`, so the personality name is a prefix.
+    expect(isAuthorAssistant('Lilith ▽', 'Lilith')).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(isAuthorAssistant('lilith ▽', 'Lilith')).toBe(true);
+  });
+
+  it('does not match an unrelated author', () => {
+    expect(isAuthorAssistant('Some Human', 'Lilith')).toBe(false);
+  });
+
+  it('matches a sibling persona via allPersonalityNames', () => {
+    expect(isAuthorAssistant('Lila ▽', 'Lilith', new Set(['Lila', 'Lilith']))).toBe(true);
+  });
+
+  it('returns false for a non-persona author even with a personality set', () => {
+    expect(isAuthorAssistant('Some Human', 'Lilith', new Set(['Lila', 'Lilith']))).toBe(false);
+  });
+});
+
+describe('deriveRefRole', () => {
+  it('returns the stamped authorRole verbatim when present (assistant)', () => {
+    // The classifier is authoritative — name-matching is never consulted when set.
+    expect(deriveRefRole('assistant', 'irrelevant', 'Lilith')).toBe('assistant');
+  });
+
+  it('returns the stamped authorRole verbatim when present (user)', () => {
+    expect(deriveRefRole('user', 'Lilith', 'Lilith')).toBe('user');
+  });
+
+  it('returns the stamped authorRole verbatim when present (bot)', () => {
+    // Even though name-matching has no `bot` concept, an explicit bot role is honored.
+    expect(deriveRefRole('bot', 'Some Bot', 'Lilith')).toBe('bot');
+  });
+
+  it('falls back to assistant when authorRole is absent and the name matches the personality', () => {
+    // The deployment-transition / pre-classifier case: a reference produced before
+    // authorRole is stamped (old bot-client mid-rolling-deploy, or pre-classifier
+    // stored history) still resolves the personality's own message to assistant.
+    expect(deriveRefRole(undefined, 'Lilith ▽', 'Lilith')).toBe('assistant');
+  });
+
+  it('falls back to assistant for a sibling persona when allPersonalityNames is provided', () => {
+    expect(deriveRefRole(undefined, 'Lila ▽', 'Lilith', new Set(['Lila', 'Lilith']))).toBe(
+      'assistant'
+    );
+  });
+
+  it('falls back to user when authorRole is absent and the name does not match', () => {
+    expect(deriveRefRole(undefined, 'Some Human', 'Lilith')).toBe('user');
+  });
+
+  it('falls back to user for a sibling persona when allPersonalityNames is omitted', () => {
+    // Documented degraded behavior: without the full personality set, only the active
+    // personality's own messages resolve to assistant in the fallback window.
+    expect(deriveRefRole(undefined, 'Lila ▽', 'Lilith')).toBe('user');
+  });
+});

--- a/services/ai-worker/src/services/prompt/referenceRole.ts
+++ b/services/ai-worker/src/services/prompt/referenceRole.ts
@@ -1,0 +1,78 @@
+/**
+ * Reference author-role resolution.
+ *
+ * The authoritative role for a reference is the `authorRole` stamped at receive
+ * time in bot-client (where the Discord `applicationId` + `client.user.id` are
+ * available — see classifyReferenceAuthorRole). These helpers are the FALLBACK
+ * for when that stamp is absent, and are shared by both render paths so the two
+ * stay symmetric:
+ *
+ * - the stored-history path (`xmlMetadataFormatters`) — for references persisted
+ *   before the classifier shipped, which age out of the conversation-history
+ *   window over ~30 days; and
+ * - the live path (`ReferencedMessageFormatter`) — for a reference produced by an
+ *   old bot-client during a rolling deploy, before it stamps `authorRole`. Both
+ *   services deploy from the same merge but as independent Railway services, so
+ *   a brief window exists where ai-worker is new and bot-client is not.
+ *
+ * Without the fallback on the live path, a personality's own reply-target would
+ * read as `role="user"` during that window — the exact self-reply confusion the
+ * classifier exists to prevent.
+ */
+
+import type { ReferenceAuthorRole } from '@tzurot/common-types';
+
+/**
+ * Whether an author name matches an AI personality (assistant) by prefix.
+ * Prefix-match because webhook usernames are `${displayName}${botSuffix}`, so the
+ * personality's display name is a prefix of the author name, not the whole of it.
+ */
+export function isAuthorAssistant(
+  authorName: string,
+  personalityName: string,
+  allPersonalityNames?: Set<string>
+): boolean {
+  const authorLower = authorName.toLowerCase();
+  if (authorLower.startsWith(personalityName.toLowerCase())) {
+    return true;
+  }
+  if (allPersonalityNames === undefined) {
+    return false;
+  }
+  for (const name of allPersonalityNames) {
+    if (authorLower.startsWith(name.toLowerCase())) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Resolve a reference's quote role: prefer the classified `authorRole`; fall back
+ * to name-matching when it's absent (see module doc for the two absent-role cases).
+ *
+ * The fallback only distinguishes assistant vs user — it has no `bot` signal — so a
+ * legacy third-party bot (not one of our personalities) reads as `user` until its
+ * reference ages out (stored path) or both services finish deploying (live path).
+ * When `allPersonalityNames` is omitted, only the active personality's own messages
+ * resolve to `assistant`; a sibling personality's reference falls back to `user` in
+ * that window.
+ *
+ * The fallback is a pure name-match with no bot-authorship guard, so within the
+ * (bounded) fallback window a human whose display name prefixes a personality's would
+ * read as `assistant`. Accepted as a bounded edge — it needs a name collision AND the
+ * reference being in the window. The authoritative `authorRole` path has no such
+ * ambiguity, and the prior live-path guard (`isBotAuthoredReference`) is intentionally
+ * dropped here for symmetry with the stored path, which never had it.
+ */
+export function deriveRefRole(
+  authorRole: ReferenceAuthorRole | undefined,
+  authorName: string,
+  personalityName: string,
+  allPersonalityNames?: Set<string>
+): ReferenceAuthorRole {
+  return (
+    authorRole ??
+    (isAuthorAssistant(authorName, personalityName, allPersonalityNames) ? 'assistant' : 'user')
+  );
+}

--- a/services/bot-client/src/handlers/references/MessageFormatter.test.ts
+++ b/services/bot-client/src/handlers/references/MessageFormatter.test.ts
@@ -90,6 +90,7 @@ describe('MessageFormatter', () => {
         discordUserId: 'user-456',
         authorUsername: 'TestUser',
         authorDisplayName: 'TestUser', // Mock uses username when displayName not explicitly set
+        authorRole: 'user', // human author (no webhook, not a bot) → user
         content: 'Hello world',
         embeds: [],
         timestamp: '2025-01-01T12:00:00.000Z',
@@ -152,6 +153,36 @@ describe('MessageFormatter', () => {
       const result = await formatter.formatMessage(message, 1);
 
       expect(result.authorIsBot).toBeUndefined();
+    });
+
+    it('stamps authorRole="assistant" for our own bot webhook (applicationId === client id)', async () => {
+      // Wiring check: applicationId matching the mock's client.user.id classifies as
+      // our own persona. (Mock client.user.id is 'mock-client-bot-id'.)
+      const message = createMockMessage({
+        applicationId: 'mock-client-bot-id',
+        webhookId: 'wh-self',
+        author: createMockUser({ username: 'Lilith', bot: true }),
+        attachments: new Map() as any,
+        embeds: [],
+      });
+
+      const result = await formatter.formatMessage(message, 1);
+
+      expect(result.authorRole).toBe('assistant');
+    });
+
+    it('stamps authorRole="bot" for a non-persona webhook (different applicationId)', async () => {
+      const message = createMockMessage({
+        applicationId: 'some-other-app',
+        webhookId: 'wh-other',
+        author: createMockUser({ username: 'MEE6', bot: true }),
+        attachments: new Map() as any,
+        embeds: [],
+      });
+
+      const result = await formatter.formatMessage(message, 1);
+
+      expect(result.authorRole).toBe('bot');
     });
 
     it('should use username as displayName when displayName is null', async () => {

--- a/services/bot-client/src/handlers/references/MessageFormatter.ts
+++ b/services/bot-client/src/handlers/references/MessageFormatter.ts
@@ -19,6 +19,7 @@ import { extractAttachments } from '../../utils/attachmentExtractor.js';
 import { extractEmbedImages } from '../../utils/embedImageExtractor.js';
 import { EmbedParser } from '../../utils/EmbedParser.js';
 import { TranscriptRetriever } from './TranscriptRetriever.js';
+import { classifyReferenceAuthorRole } from './authorRole.js';
 import {
   isForwardedMessage,
   hasForwardedSnapshots,
@@ -106,23 +107,6 @@ export class MessageFormatter {
 
     const { content, attachments } = this.resolveMessageContent(message, messageIsForwarded);
 
-    // Temporary probe: capture the owning applicationId for webhook references, to
-    // verify whether proxy webhooks (PluralKit/Tupperbox) carry one — the signal the
-    // authorship classifier needs to tell a proxied human from a non-persona bot.
-    // Logged at info so it surfaces on dev's default level. Remove after capture.
-    if (message.webhookId !== null) {
-      logger.info(
-        {
-          probe: 'applicationId',
-          refMsgId: message.id,
-          webhookId: message.webhookId,
-          applicationId: message.applicationId,
-          authorIsBot: message.author.bot,
-        },
-        '[PROBE] webhook reference authorship signals'
-      );
-    }
-
     return {
       attachments,
       reference: {
@@ -131,6 +115,14 @@ export class MessageFormatter {
         webhookId: message.webhookId ?? undefined,
         // Presence-encoded: gates the worker-side time-fallback dedup re-run.
         authorIsBot: message.author.bot === true || undefined,
+        // Classified here (only bot-client has applicationId + our own id); carried to
+        // both the live prompt and the stored-history snapshot so role is decided once.
+        authorRole: classifyReferenceAuthorRole({
+          webhookId: message.webhookId,
+          authorIsBot: message.author.bot,
+          applicationId: message.applicationId,
+          clientUserId: message.client.user?.id,
+        }),
         discordUserId: message.author.id,
         authorUsername: message.author.username,
         authorDisplayName: message.author.displayName ?? message.author.username,

--- a/services/bot-client/src/handlers/references/SnapshotFormatter.ts
+++ b/services/bot-client/src/handlers/references/SnapshotFormatter.ts
@@ -94,6 +94,10 @@ export class SnapshotFormatter {
             .join('\n')
         : '';
 
+    // No authorRole: Discord message snapshots strip author identity (no applicationId
+    // or bot flags), so a forwarded reference can't be classified here and resolves to
+    // role="user" via the worker's name-match fallback. Known Discord-API limitation —
+    // a forwarded persona voice/text message reads as user, not assistant.
     return {
       referenceNumber,
       discordMessageId: forwardedFrom.id, // Use forward message ID (snapshot doesn't have its own)

--- a/services/bot-client/src/handlers/references/authorRole.test.ts
+++ b/services/bot-client/src/handlers/references/authorRole.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { classifyReferenceAuthorRole, type AuthorRoleSignals } from './authorRole.js';
+
+const OUR_BOT_ID = 'bot-app-123';
+const PROXY_ID = 'pluralkit-app-999';
+const PROXY_IDS: readonly string[] = [PROXY_ID];
+
+function signals(partial: Partial<AuthorRoleSignals> = {}): AuthorRoleSignals {
+  return {
+    webhookId: null,
+    authorIsBot: false,
+    applicationId: null,
+    clientUserId: OUR_BOT_ID,
+    ...partial,
+  };
+}
+
+describe('classifyReferenceAuthorRole', () => {
+  it('classifies a real human (no webhook, not a bot) as user', () => {
+    expect(classifyReferenceAuthorRole(signals())).toBe('user');
+  });
+
+  it('classifies our own bot webhook (applicationId === clientUserId) as assistant', () => {
+    expect(
+      classifyReferenceAuthorRole(signals({ webhookId: 'wh-1', applicationId: OUR_BOT_ID }))
+    ).toBe('assistant');
+  });
+
+  it('classifies our own persona regardless of authorIsBot flag shape', () => {
+    // Webhook messages carry author.bot=true and a webhookId; either gates "machine".
+    expect(
+      classifyReferenceAuthorRole(
+        signals({ webhookId: 'wh-1', authorIsBot: true, applicationId: OUR_BOT_ID })
+      )
+    ).toBe('assistant');
+  });
+
+  it('classifies a known proxy webhook (PluralKit/TupperBox) as user', () => {
+    expect(
+      classifyReferenceAuthorRole(
+        signals({ webhookId: 'wh-pk', applicationId: PROXY_ID }),
+        PROXY_IDS
+      )
+    ).toBe('user');
+  });
+
+  it('classifies a non-persona, non-proxy bot/webhook as bot', () => {
+    expect(
+      classifyReferenceAuthorRole(
+        signals({ webhookId: 'wh-other', applicationId: 'some-other-bot' }),
+        PROXY_IDS
+      )
+    ).toBe('bot');
+  });
+
+  it('classifies an unrecognized applicationId as bot (catch-all)', () => {
+    // An applicationId neither ours nor a known proxy falls into the bot catch-all.
+    expect(
+      classifyReferenceAuthorRole(signals({ webhookId: 'wh-x', applicationId: 'unrecognized-app' }))
+    ).toBe('bot');
+  });
+
+  it('promotes a known proxy (PluralKit) to user via the default allowlist', () => {
+    // PluralKit's real applicationId is in KNOWN_PROXY_APP_IDS → a proxied human reads
+    // as role="user", not bot. (No injected set — exercises the production default.)
+    expect(
+      classifyReferenceAuthorRole(
+        signals({ webhookId: 'wh-pk', applicationId: '466378653216014359' })
+      )
+    ).toBe('user');
+  });
+
+  it('promotes a known proxy (TupperBox) to user via the default allowlist', () => {
+    // TupperBox's real applicationId is in KNOWN_PROXY_APP_IDS → a proxied human reads
+    // as role="user". Guards against a typo silently dropping TupperBox to the bot path.
+    expect(
+      classifyReferenceAuthorRole(
+        signals({ webhookId: 'wh-tb', applicationId: '431544605209788416' })
+      )
+    ).toBe('user');
+  });
+
+  it('classifies a webhook with no applicationId as bot (not our persona, no proxy match)', () => {
+    expect(classifyReferenceAuthorRole(signals({ webhookId: 'wh-x', applicationId: null }))).toBe(
+      'bot'
+    );
+  });
+
+  it('does not crash or misclassify when clientUserId is undefined', () => {
+    // Degraded path (client.user not ready): a webhook can't be confirmed as ours.
+    expect(
+      classifyReferenceAuthorRole(
+        signals({ webhookId: 'wh-1', applicationId: OUR_BOT_ID, clientUserId: undefined })
+      )
+    ).toBe('bot');
+  });
+
+  it('treats an authorIsBot account with no webhook as machine-authored', () => {
+    // A classic bot account (not a webhook) is still not a human.
+    expect(
+      classifyReferenceAuthorRole(
+        signals({ authorIsBot: true, applicationId: 'mee6-app' }),
+        PROXY_IDS
+      )
+    ).toBe('bot');
+  });
+});

--- a/services/bot-client/src/handlers/references/authorRole.ts
+++ b/services/bot-client/src/handlers/references/authorRole.ts
@@ -1,0 +1,43 @@
+import { KNOWN_PROXY_APP_IDS, type ReferenceAuthorRole } from '@tzurot/common-types';
+
+/** The authorship signals a Discord message carries, narrowed for classification. */
+export interface AuthorRoleSignals {
+  /** `message.webhookId` — present (non-null) when the message was sent via a webhook. */
+  webhookId: string | null;
+  /** `message.author.bot` — true for any bot/webhook author. */
+  authorIsBot: boolean;
+  /** `message.applicationId` — the owning application's id, when Discord populates it. */
+  applicationId: string | null;
+  /** `message.client.user?.id` — the running bot's own user/app id. */
+  clientUserId: string | undefined;
+}
+
+/**
+ * Classify how a referenced message's author relates to the model — the `<quote role>`
+ * signal. Decided in bot-client because only here do we have the Discord message's
+ * `applicationId` (the owning bot/app) and our own `clientUserId`.
+ *
+ * - **assistant** — our own bot's webhook (`applicationId === clientUserId`). Covers
+ *   every one of our personas; rename-immune and collision-free (no name matching).
+ * - **user** — a real human (not webhook/bot), OR a message-proxy webhook (PluralKit /
+ *   TupperBox) re-posting a human, identified by a known proxy `applicationId`.
+ * - **bot** — any other webhook/bot: a non-persona automation. The catch-all for
+ *   "not clearly our persona, not clearly an unproxied human", which is also where
+ *   proxied messages land until their `applicationId` is added to KNOWN_PROXY_APP_IDS.
+ */
+export function classifyReferenceAuthorRole(
+  signals: AuthorRoleSignals,
+  knownProxyAppIds: readonly string[] = KNOWN_PROXY_APP_IDS
+): ReferenceAuthorRole {
+  const isMachineAuthored = signals.webhookId !== null || signals.authorIsBot;
+  if (!isMachineAuthored) {
+    return 'user';
+  }
+  if (signals.clientUserId !== undefined && signals.applicationId === signals.clientUserId) {
+    return 'assistant';
+  }
+  if (signals.applicationId !== null && knownProxyAppIds.includes(signals.applicationId)) {
+    return 'user';
+  }
+  return 'bot';
+}

--- a/services/bot-client/src/services/ConversationPersistence.test.ts
+++ b/services/bot-client/src/services/ConversationPersistence.test.ts
@@ -230,6 +230,48 @@ describe('ConversationPersistence', () => {
       });
     });
 
+    it('carries authorRole through to the stored reference snapshot', async () => {
+      // The classify-once link: bot-client classified the role; convertToStoredReferences
+      // must persist it so the stored-history quote renders the same role as the live one.
+      // Deleting `authorRole: ref.authorRole` there would make this assertion fail.
+      const mockMessage = createMockMessage({
+        id: 'discord-msg-role',
+        channelId: 'channel-123',
+        guildId: 'guild-123',
+      });
+
+      const referencedMessages: ReferencedMessage[] = [
+        {
+          referenceNumber: 1,
+          discordMessageId: 'ref-role-1',
+          discordUserId: 'user-456',
+          authorUsername: 'somebot',
+          authorDisplayName: 'SomeBot',
+          content: 'automated output',
+          embeds: '',
+          timestamp: '2025-01-01T10:00:00Z',
+          locationContext: 'Test Guild > #general',
+          authorRole: 'bot',
+        },
+      ];
+
+      await persistence.saveUserMessage({
+        message: mockMessage,
+        personality: mockPersonality,
+        personaId: 'persona-uuid-123',
+        messageContent: 'Replying to [Reference 1]',
+        referencedMessages,
+      });
+
+      expect(persistUserMessageViaGateway).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageMetadata: {
+            referencedMessages: [expect.objectContaining({ authorRole: 'bot' })],
+          },
+        })
+      );
+    });
+
     it('should persist isForwarded in messageMetadata for forwarded messages', async () => {
       const { isForwardedMessage } = await import('../utils/forwardedMessageUtils.js');
       vi.mocked(isForwardedMessage).mockReturnValueOnce(true);

--- a/services/bot-client/src/services/ConversationPersistence.ts
+++ b/services/bot-client/src/services/ConversationPersistence.ts
@@ -44,6 +44,9 @@ function convertToStoredReferences(references: ReferencedMessage[]): StoredRefer
     locationContext: ref.locationContext,
     attachments: ref.attachments,
     isForwarded: ref.isForwarded,
+    // Carry the classification forward so the stored-history quote renders the same
+    // role as the live one (classify-once in MessageFormatter, render in the worker).
+    authorRole: ref.authorRole,
   }));
 }
 

--- a/services/bot-client/src/test/mocks/Discord.mock.ts
+++ b/services/bot-client/src/test/mocks/Discord.mock.ts
@@ -292,6 +292,11 @@ export function createMockMessage(overrides: MockInput<Message> = EMPTY_OVERRIDE
     id,
     content: 'Test message',
     author: createMockUser(),
+    // Real Discord messages always carry these; mocks need them for authorship
+    // classification (applicationId vs the running bot's own client.user.id).
+    applicationId: null,
+    webhookId: null,
+    client: { user: { id: 'mock-client-bot-id' } } as unknown as Message['client'],
     channel: defaultChannel,
     guild: defaultGuild,
     // Add convenience getters that Discord.js Messages have


### PR DESCRIPTION
The **proper fix** for reference-author classification — replaces the #1317 name-match stopgap, and removes the #1320 probe.

## What changed
bot-client classifies each referenced message's author **once** (it has the Discord message's `applicationId` + our own `client.user.id`), stamps `authorRole` on the reference, and both the live prompt and the stored-history snapshot render it. The worker no longer derives the role.

| role | rule |
|---|---|
| `assistant` | our own bot's webhook (`applicationId === clientUserId`) — **rename-immune, collision-free** |
| `user` | a real human, OR a known proxy (`KNOWN_PROXY_APP_IDS`) re-posting a human |
| `bot` | any other webhook/bot (non-persona automation) — catch-all |

## Addresses the #1317 review
- **prefix-match collision** ("Alice" matched "Aliciana") — gone (exact app-id match, no names)
- **persona rename** — gone (`applicationId` is stable across renames)
- **history-path role gap (finding 2)** — the deduped `<quoted_messages>` path now carries a role; history unified on the stamped role with an `isAuthorAssistant` fallback for pre-classifier data (ages out in 30 days)
- **inline bot-check cleanup (finding 4)** — `referenceEnricher` now calls `isBotAuthoredReference`

Also extends `<quote role>` to `bot` + teaches the `<instruction>`.

## Proxy allowlist (KNOWN_PROXY_APP_IDS)
Ships populated, per the file's own policy ("a real sighting **or** a strong public-knowledge basis"):
- **PluralKit** \`466378653216014359\` — confirmed present on a real proxied reference in our logs (probe #1320 captured it).
- **TupperBox** \`431544605209788416\` — operator-confirmed app id, included on public-knowledge basis (same app-owned-webhook proxy behavior as PK); not yet observed in our data. A follow-up will confirm a real TupperBox message carries \`applicationId\`.

Both promote their proxied humans → \`user\`. Any unrecognized webhook app-id falls into the \`bot\` catch-all (safe by construction).

## Tests
New classifier unit tests (all branches) + wiring tests in MessageFormatter + 3-way render tests in the worker. Local: common-types 2269, bot-client 5071, ai-worker 3271, \`pnpm quality\` 24/24 all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)