### PR TITLE
fix(bot-client): silently skip STT for forwarded own-bot voice

### DIFF
--- a/services/bot-client/src/services/VoiceTranscriptionService.test.ts
+++ b/services/bot-client/src/services/VoiceTranscriptionService.test.ts
@@ -1049,7 +1049,10 @@ describe('VoiceTranscriptionService', () => {
         );
       });
 
-      it('posts a visible Discord reply for channel acknowledgment', async () => {
+      it('does NOT post a visible reply — the skip is silent (log-only)', async () => {
+        // The "we didn't re-transcribe our own TTS" notice is an implementation
+        // detail; users shouldn't see it. We cache the placeholder for the
+        // model's context but post nothing to the channel.
         const message = createMockMessage({
           attachments: [],
           messageSnapshots: [
@@ -1070,10 +1073,7 @@ describe('VoiceTranscriptionService', () => {
         await service.transcribe(message, false, false);
 
         const replyMock = (message as unknown as { reply: ReturnType<typeof vi.fn> }).reply;
-        expect(replyMock).toHaveBeenCalledTimes(1);
-        const replyArg = replyMock.mock.calls[0]?.[0] as { content: string };
-        expect(replyArg.content).toContain('Forwarded voice message');
-        expect(replyArg.content).toContain('lila-zot-lilit');
+        expect(replyMock).not.toHaveBeenCalled();
       });
 
       it('preserves continueToPersonalityHandler when forward has a mention/reply', async () => {

--- a/services/bot-client/src/services/VoiceTranscriptionService.ts
+++ b/services/bot-client/src/services/VoiceTranscriptionService.ts
@@ -255,11 +255,11 @@ export class VoiceTranscriptionService {
     // reliable signal that the inner audio came from our own TTS is the
     // attachment filename, which we control at upload time. The classifier
     // check itself is synchronous (regex per attachment) — the async cache
-    // write + reply only fire on the matched branch, keeping the unmatched
+    // write only fires on the matched branch, keeping the unmatched
     // path microtask-equivalent to the pre-fix behavior.
     const ownAuthoredSlugs = this.classifyAsOwnBotAudio(message, attachments);
     if (ownAuthoredSlugs !== null) {
-      return this.handleOwnBotAudio(message, attachments, ownAuthoredSlugs, hasMention, isReply);
+      return this.handleOwnBotAudio(attachments, ownAuthoredSlugs, hasMention, isReply);
     }
 
     let typingInterval: NodeJS.Timeout | undefined;
@@ -421,12 +421,15 @@ export class VoiceTranscriptionService {
   }
 
   /**
-   * Async path for bot-authored audio: cache the placeholder, post a
-   * visible reply for channel acknowledgment, return placeholder as the
-   * transcript. Called only when `classifyAsOwnBotAudio` matched.
+   * Async path for bot-authored audio: cache the placeholder and return it as
+   * the transcript (model-facing context only), then bail. Deliberately
+   * silent — the skip is logged, never announced in-channel. "We didn't
+   * re-transcribe our own TTS" is an implementation detail the user shouldn't
+   * see; if the forward addresses the bot (mention/reply), the persona handler
+   * still produces a normal response using the cached placeholder as context.
+   * Called only when `classifyAsOwnBotAudio` matched.
    */
   private async handleOwnBotAudio(
-    message: Message,
     attachments: TranscriptionAttachment[],
     slugs: string[],
     hasMention: boolean,
@@ -445,20 +448,6 @@ export class VoiceTranscriptionService {
     for (const attachment of attachments) {
       await voiceTranscriptCache.store(attachment.originalUrl, placeholder);
     }
-    // Visible reply so the user (and channel) see acknowledgment of the
-    // forward. Without this, a forwarded voice message would produce no
-    // visible bot output, which reads as the bot ignoring the message.
-    await message
-      .reply({
-        content: placeholder,
-        allowedMentions: { parse: [], repliedUser: false },
-      })
-      .catch(replyError => {
-        logger.warn(
-          { err: replyError, messageId: message.id },
-          'Failed to send own-bot-audio placeholder reply'
-        );
-      });
     return {
       transcript: placeholder,
       continueToPersonalityHandler: hasMention || isReply,


### PR DESCRIPTION
## The nit (observed in prod)
When a user forwards one of the bot's **own** persona voice messages, the own-bot-audio short-circuit correctly skips re-transcribing our own TTS — but it also posted a visible reply to the channel:

> 🔁 *Forwarded voice message originally spoken by `lilith-tzel-shani` — original audio not re-transcribed.*

That notice leaks an implementation detail users don't need to see. The skip should be **silent**.

## The fix
Drop the visible `message.reply` (and the now-unused `message` param). Unchanged:
- the placeholder is still **cached** and **returned as the model-facing transcript**, so a mention/reply forward still produces a normal persona response using it as context;
- the skip is still **logged** (`'Skipping STT for own-bot forwarded voice message'`) — the user's "at most a log entry."

Net behavior: forwarding our own voice message no longer announces transcription internals. If the forward addresses the bot, it still responds normally; if it doesn't, it's fully silent.

## Tests
Flipped the `bot-authored audio` case that asserted a visible reply → now asserts `reply` is **not** called. Cache + transcript-content assertions unchanged. Full bot-client suite green (5060), `pnpm quality` 24/24.