### PR TITLE
fix(clients): external-call timeout budget as a tested route contract

### DIFF
--- a/packages/clients/src/routes/manifest.test.ts
+++ b/packages/clients/src/routes/manifest.test.ts
@@ -142,6 +142,32 @@ describe('central route manifest', () => {
     }
   });
 
+  it('routes declaring externalCallBudgetMs give the client enough timeout to outwait it', () => {
+    // The cross-layer timeout invariant. A route whose handler makes a synchronous
+    // external-provider call (key validation, voice-provider list, shapes fetch)
+    // declares that call's internal budget via externalCallBudgetMs. The CLIENT
+    // timeout must exceed it by an overhead margin (auth + provisioning + DB +
+    // network beyond the external call) — else the client aborts while the gateway
+    // is still succeeding and the user sees a spurious failure. The canonical case:
+    // a 30s provider validation probe behind a 10s client timeout.
+    const OVERHEAD_MS = 3000;
+    for (const [key, route] of entries) {
+      if (route.externalCallBudgetMs === undefined) {
+        continue;
+      }
+      expect(
+        route.timeoutMs,
+        `${key} declares externalCallBudgetMs but no timeoutMs`
+      ).toBeDefined();
+      expect(
+        route.timeoutMs,
+        `${key} timeoutMs (${String(route.timeoutMs)}) must be >= externalCallBudgetMs ` +
+          `(${route.externalCallBudgetMs}) + ${OVERHEAD_MS}ms overhead so the client outwaits ` +
+          `the handler's external call instead of aborting mid-success`
+      ).toBeGreaterThanOrEqual(route.externalCallBudgetMs + OVERHEAD_MS);
+    }
+  });
+
   it('only AUTOCOMPLETE_TIER routes use the tight AUTOCOMPLETE budget', () => {
     // The read default is DEFERRED (10s, safe). The AUTOCOMPLETE budget (2.5s) is
     // the dangerous tier — it aborts a read that takes >2.5s under load (the

--- a/packages/clients/src/routes/types.ts
+++ b/packages/clients/src/routes/types.ts
@@ -286,6 +286,21 @@ export interface RouteDef<
    * manifest invariant test caps timeoutMs at 60_000 to enforce this.
    */
   readonly timeoutMs?: number;
+  /**
+   * Worst-case internal timeout of any external-provider call this route's
+   * handler makes — the SAME constant the handler passes to its
+   * `AbortSignal.timeout`/`AbortController` (e.g. `VALIDATION_TIMEOUTS.API_KEY_VALIDATION`).
+   *
+   * Declaring it makes the cross-layer timeout invariant a tested contract term:
+   * the manifest test asserts `timeoutMs >= externalCallBudgetMs + overhead`, so a
+   * route that blocks on a slow third party can never be left with a CLIENT timeout
+   * shorter than the work it triggers. That mismatch is the failure class where a slow
+   * provider validation probe (e.g. a 30s key-save check) outruns a 10s client timeout
+   * and the client aborts while the gateway is still succeeding.
+   *
+   * Omit for routes that only touch the DB / local work (the overwhelming majority).
+   */
+  readonly externalCallBudgetMs?: number;
 }
 
 /**

--- a/packages/clients/src/routes/user/resources.ts
+++ b/packages/clients/src/routes/user/resources.ts
@@ -45,6 +45,7 @@ import {
   UpdateChannelGuildRequestSchema,
   UpdateChannelGuildResponseSchema,
   UsageStatsSchema,
+  VALIDATION_TIMEOUTS,
   VerifyNsfwResponseSchema,
 } from '@tzurot/common-types';
 
@@ -262,7 +263,8 @@ export const userResourceRoutes = {
     input: SetWalletKeySchema,
     output: SetWalletKeyResponseSchema,
     requiresProvisionedUser: true,
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
+    externalCallBudgetMs: VALIDATION_TIMEOUTS.API_KEY_VALIDATION,
+    timeoutMs: GATEWAY_TIMEOUTS.EXTERNAL_PROVIDER,
   },
 
   removeWalletKey: {
@@ -284,11 +286,12 @@ export const userResourceRoutes = {
     input: TestWalletKeySchema,
     output: TestWalletKeyResponseSchema,
     requiresProvisionedUser: true,
-    // Post-defer dashboard action (not a slash-command hot path), and the
-    // gateway handler synchronously probes the provider's auth/credits
-    // endpoint before responding — so the gateway's own response is slow.
-    // DEFERRED gives the bot→gateway hop enough headroom for that probe.
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
+    externalCallBudgetMs: VALIDATION_TIMEOUTS.API_KEY_VALIDATION,
+    // The gateway handler synchronously probes the provider's auth/credits
+    // endpoint (up to API_KEY_VALIDATION = 30s) before responding, so the
+    // bot→gateway hop must outwait that probe. DEFERRED (10s) aborted mid-probe
+    // while the gateway was still succeeding; EXTERNAL_PROVIDER gives the headroom.
+    timeoutMs: GATEWAY_TIMEOUTS.EXTERNAL_PROVIDER,
   },
 
   // ============================================================================
@@ -323,10 +326,12 @@ export const userResourceRoutes = {
     output: ListVoicesResponseSchema,
     requiresProvisionedUser: true,
     meta: { safeRead: true },
-    // Dual-context route: autocomplete callers are bounded by Discord's
-    // own 3s deadline, so the longer budget exists for the deferred-handler
-    // paths where a list fetch may run alongside other Prisma work.
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
+    externalCallBudgetMs: VALIDATION_TIMEOUTS.EXTERNAL_AUDIO_API_CALL,
+    // The handler fans out to the ElevenLabs/Mistral voices endpoints (parallel,
+    // up to EXTERNAL_AUDIO_API_CALL = 30s worst case), so the client must outwait
+    // it. Autocomplete callers are bounded by Discord's own 3s deadline
+    // regardless; this budget serves the deferred-handler path.
+    timeoutMs: GATEWAY_TIMEOUTS.EXTERNAL_PROVIDER,
   },
 
   listVoiceModels: {
@@ -337,10 +342,12 @@ export const userResourceRoutes = {
     output: ListVoiceModelsResponseSchema,
     requiresProvisionedUser: true,
     meta: { safeRead: true },
-    // DEFERRED budget: fetches the provider's available-models
-    // catalog (third-party round-trip) for the post-defer voice dashboard;
-    // the 2500ms autocomplete default is too tight for the upstream call.
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
+    externalCallBudgetMs: VALIDATION_TIMEOUTS.EXTERNAL_AUDIO_API_CALL,
+    // Fetches the provider's available-models catalog (third-party round-trip,
+    // up to EXTERNAL_AUDIO_API_CALL = 30s). Cached (5-min TTL) so hits are cheap,
+    // but a cache miss runs the full call — the client must outwait it, not abort
+    // at the 10s DEFERRED budget.
+    timeoutMs: GATEWAY_TIMEOUTS.EXTERNAL_PROVIDER,
   },
 
   clearVoices: {

--- a/packages/clients/src/routes/user/shapes.ts
+++ b/packages/clients/src/routes/user/shapes.ts
@@ -23,6 +23,7 @@ import {
   StartShapesImportResponseSchema,
   StoreShapesAuthInputSchema,
   StoreShapesAuthResponseSchema,
+  VALIDATION_TIMEOUTS,
 } from '@tzurot/common-types';
 
 import type { RouteDef } from '../types.js';
@@ -86,11 +87,12 @@ export const userShapesRoutes = {
     output: ListShapesResponseSchema,
     requiresProvisionedUser: true,
     meta: { safeRead: true },
-    // Dual-context route: the browse/import flows fetch this post-defer (it
-    // queries the external shapes.inc catalog and needs the longer budget),
-    // while autocomplete callers are bounded by Discord's own 3s deadline
-    // regardless of this value. DEFERRED serves the slower consumer.
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
+    externalCallBudgetMs: VALIDATION_TIMEOUTS.EXTERNAL_SHAPES_API_CALL,
+    // The handler queries the external shapes.inc catalog (up to
+    // EXTERNAL_SHAPES_API_CALL = 15s), so the client must outwait it.
+    // Autocomplete callers are bounded by Discord's own 3s deadline regardless;
+    // this budget serves the browse/import deferred-handler path.
+    timeoutMs: GATEWAY_TIMEOUTS.EXTERNAL_PROVIDER,
   },
 
   // ============================================================================

--- a/packages/common-types/src/constants/discord.ts
+++ b/packages/common-types/src/constants/discord.ts
@@ -110,6 +110,13 @@ export const GATEWAY_TIMEOUTS = {
   /** Extended timeout for bulk operations (e.g., clearing all cloned voices).
    *  These involve multiple sequential/batched external API calls. */
   BULK_OPERATION: 30_000,
+  /** Client timeout for a route whose handler makes a SINGLE synchronous
+   *  external-provider call (key validation, voice-provider list, shapes fetch).
+   *  Must exceed the handler's internal call budget (the VALIDATION_TIMEOUTS.* —
+   *  ≤30s today) plus auth/provisioning/DB/network overhead, so the client
+   *  outwaits the gateway instead of aborting while it's still succeeding. Pair
+   *  with a route's `externalCallBudgetMs`; the manifest test enforces the gap. */
+  EXTERNAL_PROVIDER: 40_000,
 } as const;
 
 /**

--- a/packages/common-types/src/constants/timing.ts
+++ b/packages/common-types/src/constants/timing.ts
@@ -242,6 +242,11 @@ export const VALIDATION_TIMEOUTS = {
    *  ElevenLabs and Mistral. 30 seconds covers slow networks and burst load
    *  on either provider's voices endpoints. */
   EXTERNAL_AUDIO_API_CALL: 30_000,
+  /** Timeout for the shapes.inc catalog fetch (`GET /shapes`). Shorter than the
+   *  others because the shapes list endpoint is a simple read, not an inference
+   *  or auth round-trip. Shared so the route's `externalCallBudgetMs` and the
+   *  handler's AbortController reference one value. */
+  EXTERNAL_SHAPES_API_CALL: 15_000,
 } as const;
 
 /**

--- a/services/api-gateway/src/routes/user/shapes/list.ts
+++ b/services/api-gateway/src/routes/user/shapes/list.ts
@@ -16,6 +16,7 @@ import {
   CREDENTIAL_TYPES,
   SHAPES_BASE_URL,
   SHAPES_USER_AGENT,
+  VALIDATION_TIMEOUTS,
 } from '@tzurot/common-types';
 import { asyncHandler } from '../../../utils/asyncHandler.js';
 import { resolveProvisionedUserId } from '../../../utils/resolveProvisionedUserId.js';
@@ -26,7 +27,7 @@ import type { RouteDeps } from '../../routeDeps.js';
 
 const logger = createLogger('shapes-list');
 
-const REQUEST_TIMEOUT_MS = 15_000;
+const REQUEST_TIMEOUT_MS = VALIDATION_TIMEOUTS.EXTERNAL_SHAPES_API_CALL;
 
 interface ShapesListItem {
   id: string;

--- a/services/bot-client/src/commands/settings/apikey/modal.test.ts
+++ b/services/bot-client/src/commands/settings/apikey/modal.test.ts
@@ -230,6 +230,26 @@ describe('handleApikeyModalSubmit', () => {
       });
     });
 
+    it('should handle a transport timeout (status 0) with a browse hint', async () => {
+      // status 0 = bot-client transport timeout/drop (a slow provider probe
+      // outlasting the client timeout). The gateway may have saved the key after
+      // the client gave up, so the message points at browse instead of the
+      // generic "Unable to Save".
+      stub.setWalletKey.mockResolvedValue(
+        makeErr(0, 'Request timeout (gateway slow or unavailable)')
+      );
+
+      const interaction = createMockInteraction(
+        'settings::apikey::set::zai-coding',
+        'zai-key-slow-probe'
+      );
+      await handleApikeyModalSubmit(interaction);
+
+      expect(mockEditReply).toHaveBeenCalledWith({
+        content: expect.stringContaining('Request Timed Out'),
+      });
+    });
+
     it('should handle generic gateway error', async () => {
       stub.setWalletKey.mockResolvedValue(makeErr(500, 'Internal error'));
 

--- a/services/bot-client/src/commands/settings/apikey/modal.ts
+++ b/services/bot-client/src/commands/settings/apikey/modal.ts
@@ -178,6 +178,17 @@ function getErrorMessage(
         'If the problem persists, contact support.'
       );
 
+    case 0:
+      // Transport-level failure (client timeout or dropped connection). A slow
+      // provider validation can outlast the client timeout while the gateway
+      // still completes the save, so point the user at browse to confirm rather
+      // than blindly retrying and creating churn.
+      return (
+        '⏳ **Request Timed Out**\n\n' +
+        "The request didn't complete in time. Your key may already have been saved —\n" +
+        'check `/settings apikey browse` before trying again.'
+      );
+
     default:
       // Unknown error - still provide friendly message
       return (


### PR DESCRIPTION
## The bug (z.ai apikey-save — runtime-confirmed in prod logs)
A user's `/settings apikey set` with a z.ai coding-plan key returned a generic **"Unable to Save API Key"** three times — but prod logs showed the gateway **stored the key successfully** each time. Root cause: the gateway's z.ai validation probe (`chat/completions`, 30s budget) ran behind a **10s** (`DEFERRED`) client timeout, so bot-client aborted (`status=0`) while the gateway was still succeeding. The same latent mismatch exists on `testWalletKey`, `listVoices`, and `listShapes` — all `DEFERRED` (10s), all making 30s/15s external calls.

## The fix — encode the invariant as a tested contract
- New **`RouteDef.externalCallBudgetMs`** — the worst-case internal timeout of any external-provider call a route's handler makes (the same constant the handler passes to its `AbortSignal.timeout`).
- New **`GATEWAY_TIMEOUTS.EXTERNAL_PROVIDER`** (40s) client tier.
- New shared **`VALIDATION_TIMEOUTS.EXTERNAL_SHAPES_API_CALL`** (15s) so the shapes route + handler reference one value (was a local const).
- A **manifest invariant test** asserts `timeoutMs >= externalCallBudgetMs + overhead` for every route declaring a budget — turning the cross-layer timeout into a tested contract term. **Confirmed RED** against today's `DEFERRED` (10s < 33s) before the fix, GREEN after.
- The four external-call routes (`setWalletKey`, `testWalletKey`, `listVoices`, `listShapes`) now declare their budget + use `EXTERNAL_PROVIDER`; their stale "DEFERRED is enough headroom" comments are corrected.

## Bonus UX
bot-client's `status=0` (transport timeout) now shows *"⏳ Request Timed Out — your key may already be saved; check `/settings apikey browse`"* instead of the generic "Unable to Save," since the gateway often completes after the client gives up.

## Tests
Manifest invariant (RED→GREEN proof) + a modal `status=0` test + the existing `shapes/list` test. `pnpm quality` 24/24.

## Follow-ups (filing to `backlog/cold/follow-ups.md`)
- `deleteVoice`/`clearVoices` chain sequential external calls that can exceed even 40s / the 60s cap — a BullMQ-job shape, distinct from the single-call class.
- A fetch-detecting guard so a future route doing external I/O can't omit `externalCallBudgetMs`.
- Gateway completes the DB write after the client aborts (the reason the key saved) — latent correctness; the timeout fix removes the happy-path abort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)