### PR TITLE
fix(clients): enforce a 20s write-timeout floor on mutation routes

### DIFF
--- a/packages/clients/src/clients/_generated/service-client.ts
+++ b/packages/clients/src/clients/_generated/service-client.ts
@@ -88,7 +88,6 @@ export class ServiceClient {
       method: 'POST',
       path: fullPath,
       outputSchema: ROUTE_MANIFEST.aiConfirmDelivery.output,
-      timeoutMs: ROUTE_MANIFEST.aiConfirmDelivery.timeoutMs,
     });
   }
 
@@ -101,7 +100,6 @@ export class ServiceClient {
       path: fullPath,
       body: input,
       outputSchema: ROUTE_MANIFEST.setDmSession.output,
-      timeoutMs: ROUTE_MANIFEST.setDmSession.timeoutMs,
     });
   }
 
@@ -129,7 +127,6 @@ export class ServiceClient {
       path: fullPath,
       body: input,
       outputSchema: ROUTE_MANIFEST.persistAssistantMessage.output,
-      timeoutMs: ROUTE_MANIFEST.persistAssistantMessage.timeoutMs,
     });
   }
 
@@ -142,7 +139,6 @@ export class ServiceClient {
       path: fullPath,
       body: input,
       outputSchema: ROUTE_MANIFEST.persistUserMessage.output,
-      timeoutMs: ROUTE_MANIFEST.persistUserMessage.timeoutMs,
     });
   }
 
@@ -155,7 +151,6 @@ export class ServiceClient {
       path: fullPath,
       body: input,
       outputSchema: ROUTE_MANIFEST.syncConversation.output,
-      timeoutMs: ROUTE_MANIFEST.syncConversation.timeoutMs,
     });
   }
 
@@ -183,7 +178,6 @@ export class ServiceClient {
       path: fullPath,
       body: input,
       outputSchema: ROUTE_MANIFEST.routingContextCreate.output,
-      timeoutMs: ROUTE_MANIFEST.routingContextCreate.timeoutMs,
     });
   }
 
@@ -240,7 +234,6 @@ export class ServiceClient {
       path: fullPath,
       body: input,
       outputSchema: ROUTE_MANIFEST.updateDiagnosticResponseIds.output,
-      timeoutMs: ROUTE_MANIFEST.updateDiagnosticResponseIds.timeoutMs,
     });
   }
 

--- a/packages/clients/src/clients/_generated/user-client.ts
+++ b/packages/clients/src/clients/_generated/user-client.ts
@@ -1818,6 +1818,7 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.storeShapesAuth.output,
+      timeoutMs: ROUTE_MANIFEST.storeShapesAuth.timeoutMs,
     });
   }
 

--- a/packages/clients/src/clients/_generated/user-client.ts
+++ b/packages/clients/src/clients/_generated/user-client.ts
@@ -88,7 +88,6 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.setTimezone.output,
-      timeoutMs: ROUTE_MANIFEST.setTimezone.timeoutMs,
     });
   }
 
@@ -335,7 +334,6 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.setTtsOverride.output,
-      timeoutMs: ROUTE_MANIFEST.setTtsOverride.timeoutMs,
     });
   }
 
@@ -352,7 +350,6 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.deleteTtsOverride.output,
-      timeoutMs: ROUTE_MANIFEST.deleteTtsOverride.timeoutMs,
     });
   }
 
@@ -392,7 +389,6 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.setTtsDefaultConfig.output,
-      timeoutMs: ROUTE_MANIFEST.setTtsDefaultConfig.timeoutMs,
     });
   }
 
@@ -409,7 +405,6 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.clearTtsDefaultConfig.output,
-      timeoutMs: ROUTE_MANIFEST.clearTtsDefaultConfig.timeoutMs,
     });
   }
 
@@ -449,7 +444,6 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.setSttDefaultProvider.output,
-      timeoutMs: ROUTE_MANIFEST.setSttDefaultProvider.timeoutMs,
     });
   }
 
@@ -466,7 +460,6 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.clearSttDefaultProvider.output,
-      timeoutMs: ROUTE_MANIFEST.clearSttDefaultProvider.timeoutMs,
     });
   }
 
@@ -507,7 +500,6 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.setModelOverride.output,
-      timeoutMs: ROUTE_MANIFEST.setModelOverride.timeoutMs,
     });
   }
 
@@ -524,7 +516,6 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.deleteModelOverride.output,
-      timeoutMs: ROUTE_MANIFEST.deleteModelOverride.timeoutMs,
     });
   }
 
@@ -565,7 +556,6 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.setDefaultModelConfig.output,
-      timeoutMs: ROUTE_MANIFEST.setDefaultModelConfig.timeoutMs,
     });
   }
 
@@ -582,7 +572,6 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.clearDefaultModelConfig.output,
-      timeoutMs: ROUTE_MANIFEST.clearDefaultModelConfig.timeoutMs,
     });
   }
 
@@ -750,7 +739,6 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.createPersona.output,
-      timeoutMs: ROUTE_MANIFEST.createPersona.timeoutMs,
     });
   }
 
@@ -771,7 +759,6 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.updatePersona.output,
-      timeoutMs: ROUTE_MANIFEST.updatePersona.timeoutMs,
     });
   }
 
@@ -788,7 +775,6 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.deletePersona.output,
-      timeoutMs: ROUTE_MANIFEST.deletePersona.timeoutMs,
     });
   }
 
@@ -805,7 +791,6 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.setPersonaDefault.output,
-      timeoutMs: ROUTE_MANIFEST.setPersonaDefault.timeoutMs,
     });
   }
 
@@ -866,7 +851,6 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.setPersonaOverride.output,
-      timeoutMs: ROUTE_MANIFEST.setPersonaOverride.timeoutMs,
     });
   }
 
@@ -883,7 +867,6 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.clearPersonaOverride.output,
-      timeoutMs: ROUTE_MANIFEST.clearPersonaOverride.timeoutMs,
     });
   }
 
@@ -901,7 +884,6 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.createPersonaOverride.output,
-      timeoutMs: ROUTE_MANIFEST.createPersonaOverride.timeoutMs,
     });
   }
 
@@ -1227,7 +1209,6 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.removeWalletKey.output,
-      timeoutMs: ROUTE_MANIFEST.removeWalletKey.timeoutMs,
     });
   }
 
@@ -1339,7 +1320,6 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.deleteVoice.output,
-      timeoutMs: ROUTE_MANIFEST.deleteVoice.timeoutMs,
     });
   }
 
@@ -1715,7 +1695,6 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.updateUserDefaults.output,
-      timeoutMs: ROUTE_MANIFEST.updateUserDefaults.timeoutMs,
     });
   }
 
@@ -1732,7 +1711,6 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.clearUserDefaults.output,
-      timeoutMs: ROUTE_MANIFEST.clearUserDefaults.timeoutMs,
     });
   }
 
@@ -1770,7 +1748,6 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.updatePersonalityOverrides.output,
-      timeoutMs: ROUTE_MANIFEST.updatePersonalityOverrides.timeoutMs,
     });
   }
 
@@ -1824,7 +1801,6 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.updatePersonalityConfigDefaults.output,
-      timeoutMs: ROUTE_MANIFEST.updatePersonalityConfigDefaults.timeoutMs,
     });
   }
 
@@ -1842,7 +1818,6 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.storeShapesAuth.output,
-      timeoutMs: ROUTE_MANIFEST.storeShapesAuth.timeoutMs,
     });
   }
 
@@ -1859,7 +1834,6 @@ export class UserClient {
         'X-User-DisplayName': encodeURIComponent(this.user.displayName),
       },
       outputSchema: ROUTE_MANIFEST.deleteShapesAuth.output,
-      timeoutMs: ROUTE_MANIFEST.deleteShapesAuth.timeoutMs,
     });
   }
 
@@ -1917,7 +1891,6 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.startShapesImport.output,
-      timeoutMs: ROUTE_MANIFEST.startShapesImport.timeoutMs,
     });
   }
 
@@ -1955,7 +1928,6 @@ export class UserClient {
       },
       body: input,
       outputSchema: ROUTE_MANIFEST.startShapesExport.output,
-      timeoutMs: ROUTE_MANIFEST.startShapesExport.timeoutMs,
     });
   }
 

--- a/packages/clients/src/routes/internal.ts
+++ b/packages/clients/src/routes/internal.ts
@@ -114,7 +114,6 @@ export const internalRoutes = {
     params: { jobId: z.string() },
     output: AiConfirmDeliveryResponseSchema,
     serviceOnly: true,
-    timeoutMs: TIMEOUTS.GATEWAY_RPC,
   },
 
   /**
@@ -130,7 +129,6 @@ export const internalRoutes = {
     input: DmSessionSetRequestSchema,
     output: DmSessionSetResponseSchema,
     serviceOnly: true,
-    timeoutMs: TIMEOUTS.GATEWAY_RPC,
   },
 
   /**
@@ -170,7 +168,6 @@ export const internalRoutes = {
     input: PersistAssistantMessageRequestSchema,
     output: PersistAssistantMessageResponseSchema,
     serviceOnly: true,
-    timeoutMs: TIMEOUTS.GATEWAY_RPC,
   },
 
   /**
@@ -189,7 +186,6 @@ export const internalRoutes = {
     input: PersistUserMessageRequestSchema,
     output: PersistUserMessageResponseSchema,
     serviceOnly: true,
-    timeoutMs: TIMEOUTS.GATEWAY_RPC,
   },
 
   /**
@@ -207,7 +203,6 @@ export const internalRoutes = {
     input: ConversationSyncRequestSchema,
     output: ConversationSyncResponseSchema,
     serviceOnly: true,
-    timeoutMs: TIMEOUTS.GATEWAY_RPC,
   },
 
   /**
@@ -250,7 +245,6 @@ export const internalRoutes = {
     input: RoutingContextRequestSchema,
     output: RoutingContextResponseSchema,
     serviceOnly: true,
-    timeoutMs: TIMEOUTS.GATEWAY_PROVISIONING,
   },
 
   /**
@@ -337,7 +331,6 @@ export const internalRoutes = {
     input: DiagnosticUpdateSchema,
     output: DiagnosticUpdateResponseSchema,
     serviceOnly: true,
-    timeoutMs: TIMEOUTS.GATEWAY_RPC,
   },
 
   /**

--- a/packages/clients/src/routes/manifest.test.ts
+++ b/packages/clients/src/routes/manifest.test.ts
@@ -204,9 +204,12 @@ describe('central route manifest', () => {
   });
 
   it('mutation routes allow at least the WRITE budget (20s) — no sub-floor writes', () => {
-    // Pool acquisition alone can block up to DATABASE_POOL_CONN_TIMEOUT_MS (10s),
-    // so a write timeout below ~10s aborts client-side while the gateway is still
-    // acquiring a connection — let alone executing. The method-aware default
+    // Pool acquisition alone can block up to DATABASE_POOL_CONN_TIMEOUT_MS (10s —
+    // env-tunable, default in `@tzurot/common-types` poolConfig.ts), so a write
+    // timeout below ~10s aborts client-side while the gateway is still acquiring a
+    // connection — let alone executing. (Load-bearing assumption: if that pool
+    // ceiling is ever raised toward WRITE (20s), this floor must rise with it.)
+    // The method-aware default
     // already gives mutations the WRITE budget (20s); the failure mode is a route
     // that EXPLICITLY overrides to a tighter read budget (GATEWAY_RPC 5s, DEFERRED
     // 10s). That is the class behind the user-message-persist "character

--- a/packages/clients/src/routes/manifest.test.ts
+++ b/packages/clients/src/routes/manifest.test.ts
@@ -209,11 +209,10 @@ describe('central route manifest', () => {
     // timeout below ~10s aborts client-side while the gateway is still acquiring a
     // connection — let alone executing. (Load-bearing assumption: if that pool
     // ceiling is ever raised toward WRITE (20s), this floor must rise with it.)
-    // The method-aware default
-    // already gives mutations the WRITE budget (20s); the failure mode is a route
-    // that EXPLICITLY overrides to a tighter read budget (GATEWAY_RPC 5s, DEFERRED
-    // 10s). That is the class behind the user-message-persist "character
-    // unavailable" prod incident — a transient DB spike outran a 5s persist budget.
+    // The method-aware default already gives mutations the WRITE budget (20s); the
+    // failure mode is a route that EXPLICITLY overrides to a tighter read budget
+    // (GATEWAY_RPC 5s, DEFERRED 10s) — a sub-floor write that aborts client-side
+    // before the gateway finishes acquiring a connection.
     //
     // EXEMPTION: a POST that is semantically a READ (resolves/looks-up, never
     // mutates) may carry a tighter budget IF it is in AUTOCOMPLETE_TIER — those are

--- a/packages/clients/src/routes/manifest.test.ts
+++ b/packages/clients/src/routes/manifest.test.ts
@@ -203,6 +203,46 @@ describe('central route manifest', () => {
     }
   });
 
+  it('mutation routes allow at least the WRITE budget (20s) — no sub-floor writes', () => {
+    // Pool acquisition alone can block up to DATABASE_POOL_CONN_TIMEOUT_MS (10s),
+    // so a write timeout below ~10s aborts client-side while the gateway is still
+    // acquiring a connection — let alone executing. The method-aware default
+    // already gives mutations the WRITE budget (20s); the failure mode is a route
+    // that EXPLICITLY overrides to a tighter read budget (GATEWAY_RPC 5s, DEFERRED
+    // 10s). That is the class behind the user-message-persist "character
+    // unavailable" prod incident — a transient DB spike outran a 5s persist budget.
+    //
+    // EXEMPTION: a POST that is semantically a READ (resolves/looks-up, never
+    // mutates) may carry a tighter budget IF it is in AUTOCOMPLETE_TIER — those are
+    // the deliberate tight-read routes (e.g. resolveUserLlmConfig, which fast-fails
+    // to personality defaults on timeout). A genuine write is never in that set.
+    //
+    // Unlike the opt-in externalCallBudgetMs check, this covers EVERY route by
+    // default: a new write cannot slip through simply by not declaring a field.
+    const MUTATION_METHODS = new Set<string>(['post', 'put', 'patch', 'delete']);
+    const violations: string[] = [];
+    for (const [key, route] of entries) {
+      if (!MUTATION_METHODS.has(route.method)) {
+        continue; // GET = read; reads have their own DEFERRED/AUTOCOMPLETE budget
+      }
+      if (AUTOCOMPLETE_TIER.has(key)) {
+        continue; // POST-shaped read, deliberately tight (registered + justified above)
+      }
+      const effective = route.timeoutMs ?? GATEWAY_TIMEOUTS.WRITE;
+      if (effective < GATEWAY_TIMEOUTS.WRITE) {
+        violations.push(`${key} (${route.method.toUpperCase()}): ${effective}ms`);
+      }
+    }
+    expect(
+      violations,
+      `These mutation routes have an effective timeout below the ${GATEWAY_TIMEOUTS.WRITE}ms WRITE ` +
+        `floor. A mutation must tolerate a transient pool-acquisition wait (up to 10s) plus the ` +
+        `write itself. Fix: delete the explicit timeoutMs so each inherits the WRITE default — ` +
+        `or, if a POST is truly a read, add it to AUTOCOMPLETE_TIER with a justification.\n  ` +
+        violations.join('\n  ')
+    ).toEqual([]);
+  });
+
   it('GET routes do not declare an input body schema', () => {
     // GET-with-body is broken in the field — Node's fetch (and many
     // intermediaries) drop the body, so a manifest entry like

--- a/packages/clients/src/routes/user/config-overrides.ts
+++ b/packages/clients/src/routes/user/config-overrides.ts
@@ -85,8 +85,6 @@ export const userConfigOverrideRoutes = {
     input: ConfigOverridesSchema,
     output: UpdateConfigDefaultsResponseSchema,
     requiresProvisionedUser: true,
-    // PATCH + resolve handshake (paired with resolveUserDefaults).
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   clearUserDefaults: {
@@ -96,10 +94,6 @@ export const userConfigOverrideRoutes = {
     id: 'clearUserDefaults',
     output: ClearUserConfigDefaultsResponseSchema,
     requiresProvisionedUser: true,
-    // DEFERRED budget: clear-then-resolve handshake in the settings dashboard;
-    // consistent budget with the GET/PATCH on the same /defaults path prevents
-    // the follow-up resolve from timing out.
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   resolveCascade: {
@@ -128,9 +122,6 @@ export const userConfigOverrideRoutes = {
     input: ConfigOverridesSchema,
     output: UpdatePersonalityConfigOverridesResponseSchema,
     requiresProvisionedUser: true,
-    // PATCH + resolve form a paired handshake; consistent budget across
-    // both prevents the resolve from timing out after a successful PATCH.
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   clearPersonalityOverrides: {
@@ -179,7 +170,5 @@ export const userConfigOverrideRoutes = {
     input: ConfigOverridesSchema,
     output: UpdateConfigDefaultsResponseSchema,
     requiresProvisionedUser: true,
-    // Same PATCH + resolve handshake invariant as updatePersonalityOverrides.
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 } as const satisfies Record<string, RouteDef>;

--- a/packages/clients/src/routes/user/configs.ts
+++ b/packages/clients/src/routes/user/configs.ts
@@ -89,7 +89,6 @@ export const userConfigRoutes = {
     output: SetTimezoneResponseSchema,
     requiresProvisionedUser: true,
     meta: { idempotent: true },
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   // ============================================================================
@@ -248,12 +247,6 @@ export const userConfigRoutes = {
     timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
-  // Override writes (this and the model/stt overrides below) deliberately keep
-  // DEFERRED (10s) rather than WRITE: they're single-row upserts with no
-  // validation cascade or cache-invalidation fan-out, so 10s is ample. The
-  // method-aware transport default backstops any future write route that omits
-  // a timeout (it gets WRITE), so leaving these at DEFERRED is a conscious
-  // shorter-budget choice, not an oversight.
   setTtsOverride: {
     audience: 'user',
     method: 'put',
@@ -263,7 +256,6 @@ export const userConfigRoutes = {
     output: SetTtsOverrideResponseSchema,
     requiresProvisionedUser: true,
     meta: { idempotent: true },
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   deleteTtsOverride: {
@@ -274,7 +266,6 @@ export const userConfigRoutes = {
     params: { personalityId: z.string() },
     output: DeleteTtsOverrideResponseSchema,
     requiresProvisionedUser: true,
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   getTtsDefaultConfig: {
@@ -296,7 +287,6 @@ export const userConfigRoutes = {
     output: SetTtsDefaultConfigResponseSchema,
     requiresProvisionedUser: true,
     meta: { idempotent: true },
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   clearTtsDefaultConfig: {
@@ -306,7 +296,6 @@ export const userConfigRoutes = {
     id: 'clearTtsDefaultConfig',
     output: ClearTtsDefaultConfigResponseSchema,
     requiresProvisionedUser: true,
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   // ============================================================================
@@ -335,7 +324,6 @@ export const userConfigRoutes = {
     output: SetSttDefaultProviderResponseSchema,
     requiresProvisionedUser: true,
     meta: { idempotent: true },
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   clearSttDefaultProvider: {
@@ -345,7 +333,6 @@ export const userConfigRoutes = {
     id: 'clearSttDefaultProvider',
     output: ClearSttDefaultProviderResponseSchema,
     requiresProvisionedUser: true,
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   // ============================================================================
@@ -372,7 +359,6 @@ export const userConfigRoutes = {
     output: SetModelOverrideResponseSchema,
     requiresProvisionedUser: true,
     meta: { idempotent: true },
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   deleteModelOverride: {
@@ -383,7 +369,6 @@ export const userConfigRoutes = {
     params: { personalityId: z.string() },
     output: DeleteModelOverrideResponseSchema,
     requiresProvisionedUser: true,
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   getDefaultModelConfig: {
@@ -409,7 +394,6 @@ export const userConfigRoutes = {
     output: SetDefaultConfigResponseSchema,
     requiresProvisionedUser: true,
     meta: { idempotent: true },
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   clearDefaultModelConfig: {
@@ -419,6 +403,5 @@ export const userConfigRoutes = {
     id: 'clearDefaultModelConfig',
     output: ClearDefaultConfigResponseSchema,
     requiresProvisionedUser: true,
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 } as const satisfies Record<string, RouteDef>;

--- a/packages/clients/src/routes/user/ownership.ts
+++ b/packages/clients/src/routes/user/ownership.ts
@@ -161,9 +161,6 @@ export const userOwnershipRoutes = {
     input: PersonaCreateSchema,
     output: CreatePersonaResponseSchema,
     requiresProvisionedUser: true,
-    // DEFERRED budget: persona create runs from a post-defer
-    // modal submit, not the autocomplete hot path.
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   updatePersona: {
@@ -176,9 +173,6 @@ export const userOwnershipRoutes = {
     output: UpdatePersonaResponseSchema,
     requiresProvisionedUser: true,
     meta: { idempotent: true },
-    // DEFERRED budget: persona edit runs from a post-defer modal
-    // submit, not the autocomplete hot path.
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   deletePersona: {
@@ -189,9 +183,6 @@ export const userOwnershipRoutes = {
     params: { id: z.string() },
     output: DeletePersonaResponseSchema,
     requiresProvisionedUser: true,
-    // DEFERRED budget: persona delete runs from a post-defer
-    // confirmation, not the autocomplete hot path.
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   setPersonaDefault: {
@@ -202,9 +193,6 @@ export const userOwnershipRoutes = {
     params: { id: z.string() },
     output: SetDefaultPersonaResponseSchema,
     requiresProvisionedUser: true,
-    // DEFERRED budget: set-default runs from a post-defer
-    // dashboard action, not the autocomplete hot path.
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   // ============================================================================
@@ -248,9 +236,6 @@ export const userOwnershipRoutes = {
     output: SetOverrideResponseSchema,
     requiresProvisionedUser: true,
     meta: { idempotent: true },
-    // DEFERRED budget: override pinning runs from a post-defer
-    // dashboard action, not the autocomplete hot path.
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   clearPersonaOverride: {
@@ -261,9 +246,6 @@ export const userOwnershipRoutes = {
     params: { personalitySlug: z.string() },
     output: ClearOverrideResponseSchema,
     requiresProvisionedUser: true,
-    // DEFERRED budget: override clearing runs from a post-defer
-    // dashboard action, not the autocomplete hot path.
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   // Create a new persona AND set it as override for a personality in a single
@@ -282,9 +264,5 @@ export const userOwnershipRoutes = {
     input: PersonaCreateSchema,
     output: CreateOverrideResponseSchema,
     requiresProvisionedUser: true,
-    // DEFERRED budget: create-persona-and-pin runs in a single
-    // server-side transaction from a post-defer modal submit, not the
-    // autocomplete hot path; the transaction work needs the longer budget.
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 } as const satisfies Record<string, RouteDef>;

--- a/packages/clients/src/routes/user/resources.ts
+++ b/packages/clients/src/routes/user/resources.ts
@@ -275,7 +275,6 @@ export const userResourceRoutes = {
     params: { provider: z.string() },
     output: RemoveWalletKeyResponseSchema,
     requiresProvisionedUser: true,
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   testWalletKey: {
@@ -370,6 +369,5 @@ export const userResourceRoutes = {
     params: { provider: z.string(), voiceId: z.string() },
     output: DeleteVoiceResponseSchema,
     requiresProvisionedUser: true,
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 } as const satisfies Record<string, RouteDef>;

--- a/packages/clients/src/routes/user/shapes.ts
+++ b/packages/clients/src/routes/user/shapes.ts
@@ -43,6 +43,12 @@ export const userShapesRoutes = {
     input: StoreShapesAuthInputSchema,
     output: StoreShapesAuthResponseSchema,
     requiresProvisionedUser: true,
+    // Preflights the cookie against shapes.inc before persisting (handler's
+    // probeShapesSession), so this POST blocks on a synchronous external
+    // round-trip — same shape as listShapes. EXTERNAL_PROVIDER (40s) outwaits
+    // the EXTERNAL_SHAPES_API_CALL budget; the manifest guard enforces the gap.
+    timeoutMs: GATEWAY_TIMEOUTS.EXTERNAL_PROVIDER,
+    externalCallBudgetMs: VALIDATION_TIMEOUTS.EXTERNAL_SHAPES_API_CALL,
   },
 
   deleteShapesAuth: {

--- a/packages/clients/src/routes/user/shapes.ts
+++ b/packages/clients/src/routes/user/shapes.ts
@@ -43,10 +43,6 @@ export const userShapesRoutes = {
     input: StoreShapesAuthInputSchema,
     output: StoreShapesAuthResponseSchema,
     requiresProvisionedUser: true,
-    // DEFERRED budget: the gateway validates the supplied
-    // shapes.inc session cookie against the external service before storing,
-    // so the gateway's own response is slow — well past the 2500ms default.
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   deleteShapesAuth: {
@@ -56,9 +52,6 @@ export const userShapesRoutes = {
     id: 'deleteShapesAuth',
     output: DeleteShapesAuthResponseSchema,
     requiresProvisionedUser: true,
-    // DEFERRED budget: post-defer credential-management action,
-    // consistent with the store/status siblings on the same /auth path.
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   getShapesAuthStatus: {
@@ -107,10 +100,6 @@ export const userShapesRoutes = {
     input: StartShapesImportInputSchema,
     output: StartShapesImportResponseSchema,
     requiresProvisionedUser: true,
-    // DEFERRED budget: the start handler fetches shape data from
-    // the external shapes.inc service before enqueueing the import job, so the
-    // submit response is slow — past the 2500ms autocomplete default.
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   listShapesImportJobs: {
@@ -139,10 +128,6 @@ export const userShapesRoutes = {
     input: StartShapesExportInputSchema,
     output: StartShapesExportResponseSchema,
     requiresProvisionedUser: true,
-    // DEFERRED budget: export submit runs from a post-defer
-    // dashboard action and may do non-trivial setup before enqueueing the
-    // job — past the 2500ms autocomplete default.
-    timeoutMs: GATEWAY_TIMEOUTS.DEFERRED,
   },
 
   listShapesExportJobs: {

--- a/packages/common-types/src/constants/timing.ts
+++ b/packages/common-types/src/constants/timing.ts
@@ -50,17 +50,6 @@ export const TIMEOUTS = {
    * Short enough that a hung gateway surfaces quickly; long enough to
    * cover Railway internal-network latency under normal load. */
   GATEWAY_RPC: 5_000,
-  /** Timeout for the routing-context provisioning RPC (15 s). Unlike the light
-   *  read RPCs on GATEWAY_RPC (5 s), this POST provisions the user + default
-   *  persona on first contact — a multi-table write transaction, then a persona
-   *  cascade resolve and an STM epoch lookup, all sequential on the hottest
-   *  path. Under cold-start or pool contention (a single connection acquisition
-   *  can block up to DATABASE_POOL_CONN_TIMEOUT_MS = 10 s) the 5 s read budget
-   *  falsely aborts a still-succeeding first-contact write, dropping a new
-   *  user's first message. 15 s absorbs that while staying tighter than the 20 s
-   *  user-facing WRITE budget — a hung internal RPC should surface faster than a
-   *  user-initiated mutation. */
-  GATEWAY_PROVISIONING: 15_000,
   /** Timeout for bot-client → api-gateway bulk-payload reads (10 s).
    * Used for endpoints that return larger payloads — currently the
    * denylist cache bootstrap. Distinct from GATEWAY_RPC because the


### PR DESCRIPTION
**beta.137 sweep — PR 1 (headliner).** The structural fix for the gateway-timeout class we'd been patching one prod incident at a time.

## The recurring bug

Mutation routes (POST/PUT/PATCH/DELETE) explicitly overrode `timeoutMs` to a tight *read* budget (5s `GATEWAY_RPC`, 10s `DEFERRED`). The Postgres pool acquisition can block up to `DATABASE_POOL_CONN_TIMEOUT_MS` (10s), so a sub-20s write aborts client-side **while the gateway is still acquiring a connection** — let alone executing. That's the class behind today's `persistUserMessage` *"None of the tagged characters are currently available"* prod incident: a transient DB spike outran a 5s persist budget.

We'd fixed these individually (#1323 external-call routes, #1325 routing-context). The prior guard was **opt-in** (`externalCallBudgetMs`), so plain DB writes were never checked. **Opt-in is the bug.**

## The fix (council-designed)

Designed with GLM-5.2 / Kimi-K2.7 / Qwen-3.7 — unanimous on the floor, the delete-overrides approach, and (after a refinement round) **allowlist-only** over a new `semantics` field:

- **New manifest guard** covering *every* route by default: a mutation's effective timeout must be ≥ `GATEWAY_TIMEOUTS.WRITE` (20s). Floor rationale is concrete — pool acquisition alone is 10s, so a write needs >10s of headroom.
- **Exemption:** a POST that's a deliberate tight-*read* (registered in the existing `AUTOCOMPLETE_TIER` — e.g. `resolveUserLlmConfig`, which fast-fails to personality defaults). That exemption is **data-verified**: the fallback fired **1 time in 882 messages over ~4 days** in prod — a genuine exceptional fallback, not silent degradation. A genuine write is never in that set.
- **Fixed 35 mutation routes** by *deleting* the wrong override so each inherits the method-aware WRITE default. The transport already defaulted mutations to WRITE — the bug was the explicit too-tight overrides.
- **Folded `GATEWAY_PROVISIONING`** (15s, #1325) into WRITE.
- Regenerated the typed clients (their `timeoutMs` lines track the manifest).

A new too-tight write can no longer slip through — unlike the opt-in field, the guard checks all routes.

## Verification

- `manifest.test.ts`: 22 passed incl. the new write-floor guard (0 violations) · clients suite 163 ✓
- `tsc` clean · `codegen:routes --check` green · `pnpm quality` green
- Net −80 lines (deleting overrides + stale comments, adding one guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)