### PR TITLE
feat(clients): InfraError + result-collapse helpers (infra-vs-negative foundation)

### DIFF
--- a/packages/clients/src/clients/resultHelpers.test.ts
+++ b/packages/clients/src/clients/resultHelpers.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import {
+  InfraError,
+  GatewayClientError,
+  nullOn404,
+  emptyOn404,
+  nullOnAnyError,
+} from './resultHelpers.js';
+import type { GatewayResult } from './transport.js';
+
+// Builders for the two GatewayResult arms. The failure arm is kind-independent
+// of T, so a single set of fixtures covers every helper.
+const ok = <T>(data: T): GatewayResult<T> => ({ ok: true, data });
+const notFound = <T>(): GatewayResult<T> => ({
+  ok: false,
+  kind: 'http',
+  error: 'Not Found',
+  status: 404,
+});
+const serverError = <T>(): GatewayResult<T> => ({
+  ok: false,
+  kind: 'http',
+  error: 'Internal Server Error',
+  status: 500,
+});
+const timeout = <T>(): GatewayResult<T> => ({
+  ok: false,
+  kind: 'timeout',
+  error: 'request timed out',
+  status: 0,
+});
+const network = <T>(): GatewayResult<T> => ({
+  ok: false,
+  kind: 'network',
+  error: 'ECONNRESET',
+  status: 0,
+});
+const forbidden = <T>(): GatewayResult<T> => ({
+  ok: false,
+  kind: 'http',
+  error: 'Forbidden',
+  status: 403,
+});
+
+describe('InfraError', () => {
+  it('is an Error carrying the failure kind + status', () => {
+    const err = new InfraError({ ok: false, kind: 'timeout', error: 'boom', status: 0 });
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(InfraError);
+    expect(err.name).toBe('InfraError');
+    expect(err.kind).toBe('timeout');
+    expect(err.status).toBe(0);
+    expect(err.message).toContain('timeout');
+    expect(err.message).toContain('boom');
+  });
+});
+
+describe('GatewayClientError', () => {
+  it('is an Error carrying the 4xx status, distinct from InfraError', () => {
+    const err = new GatewayClientError({
+      ok: false,
+      kind: 'http',
+      error: 'Forbidden',
+      status: 403,
+    });
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(GatewayClientError);
+    expect(err).not.toBeInstanceOf(InfraError);
+    expect(err.status).toBe(403);
+    expect(err.message).toContain('403');
+  });
+});
+
+describe('nullOn404', () => {
+  it('returns the data on success', () => {
+    expect(nullOn404(ok({ id: 'x' }))).toEqual({ id: 'x' });
+  });
+
+  it('returns null ONLY on a genuine 404', () => {
+    expect(nullOn404(notFound())).toBeNull();
+  });
+
+  it.each([
+    ['timeout', timeout()],
+    ['network', network()],
+    ['5xx', serverError()],
+  ])('throws InfraError on an infra failure (%s) — never a silent null', (_label, failure) => {
+    expect(() => nullOn404(failure)).toThrow(InfraError);
+  });
+
+  it('throws GatewayClientError (not InfraError) on a non-404 4xx — no "try again"', () => {
+    expect(() => nullOn404(forbidden())).toThrow(GatewayClientError);
+    expect(() => nullOn404(forbidden())).not.toThrow(InfraError);
+  });
+});
+
+describe('emptyOn404', () => {
+  it('returns the array on success', () => {
+    expect(emptyOn404(ok([1, 2, 3]))).toEqual([1, 2, 3]);
+  });
+
+  it('returns [] ONLY on a genuine 404', () => {
+    expect(emptyOn404(notFound<number[]>())).toEqual([]);
+  });
+
+  it.each([
+    ['timeout', timeout<number[]>()],
+    ['network', network<number[]>()],
+    ['5xx', serverError<number[]>()],
+  ])('throws InfraError on an infra failure (%s)', (_label, failure) => {
+    expect(() => emptyOn404(failure)).toThrow(InfraError);
+  });
+
+  it('throws GatewayClientError on a non-404 4xx', () => {
+    expect(() => emptyOn404(forbidden<number[]>())).toThrow(GatewayClientError);
+  });
+});
+
+describe('nullOnAnyError', () => {
+  it('returns the data on success', () => {
+    expect(nullOnAnyError(ok('value'))).toBe('value');
+  });
+
+  it.each([
+    ['404', notFound<string>()],
+    ['403', forbidden<string>()],
+    ['timeout', timeout<string>()],
+    ['network', network<string>()],
+    ['5xx', serverError<string>()],
+  ])('collapses every failure (%s) to null and never throws', (_label, failure) => {
+    expect(nullOnAnyError(failure)).toBeNull();
+  });
+});

--- a/packages/clients/src/clients/resultHelpers.ts
+++ b/packages/clients/src/clients/resultHelpers.ts
@@ -1,0 +1,141 @@
+/**
+ * Result-collapse helpers + `InfraError` — the foundation for distinguishing a
+ * genuine negative result (a real 404 / empty set) from an INFRASTRUCTURE
+ * failure (timeout / network / 5xx / config / schema) when consuming a
+ * `GatewayResult`.
+ *
+ * The bug class these prevent: a loader returns the SAME sentinel (`null` / `[]`)
+ * for "the resource genuinely does not exist" AND "the gateway call failed", and
+ * a user-facing command then asserts a definitive "X not found" on what was
+ * really a transient blip. (Runtime-confirmed in prod: a `status: 0` transport
+ * failure surfaced to a user as "Character not found".)
+ *
+ * Two collapse strategies, picked by the CALLER's needs:
+ *
+ *   - **Pattern B** (`nullOn404` / `emptyOn404`): for code that feeds a
+ *     user-facing message. `null` / `[]` means DEFINITIVELY absent (a real 404).
+ *     An infra failure (5xx / timeout / network) THROWS `InfraError` → the
+ *     command framework's "try again" message; a non-404 4xx (the request was
+ *     rejected — retrying won't help) THROWS `GatewayClientError` → the generic
+ *     error message. The default for terminal command paths.
+ *   - **Pattern A** (`nullOnAnyError`): for routing / mention-parsing paths that
+ *     intentionally treat "unknown" as "no match" — a transient blip must not
+ *     blind routing, so EVERY failure collapses to `null`. Use ONLY where a
+ *     definitive negative is not surfaced to the user (and the caller does not
+ *     negative-cache the `null`).
+ *
+ * Decision rule: result feeds a user message → Pattern B; result feeds further
+ * logic / routing / aggregation → Pattern A, or thread the `GatewayResult`
+ * through and branch on it explicitly.
+ *
+ * The `status > 0 ⟺ kind === 'http'` invariant (see `GatewayResult`) is what
+ * makes `status === 404` an unambiguous "genuine miss": a `status: 0` infra
+ * failure can never look like a 404.
+ */
+
+import type { GatewayFailureKind } from './errors.js';
+import type { GatewayResult } from './transport.js';
+
+/** The failure arm of a `GatewayResult` (kind-independent of the success type). */
+type GatewayFailure = Extract<GatewayResult<unknown>, { ok: false }>;
+
+/**
+ * A gateway call failed for an INFRASTRUCTURE reason (timeout / network / 5xx /
+ * config / schema) — distinct from a genuine 404. Thrown by the Pattern-B
+ * collapse helpers so a transient failure surfaces to the user as "try again",
+ * never as a definitive "doesn't exist". The command framework's top-level
+ * catch recognises it (see bot-client `CommandHandler`).
+ */
+export class InfraError extends Error {
+  /** Failure category — `'http'` (a 5xx; a 4xx becomes {@link GatewayClientError}), else `network`/`timeout`/`config`/`schema`. */
+  readonly kind: GatewayFailureKind;
+  /** HTTP status for a `'http'` failure (a 5xx); `0` for non-HTTP kinds. */
+  readonly status: number;
+
+  constructor(failure: GatewayFailure) {
+    super(
+      `Gateway infrastructure failure (${failure.kind}, status ${failure.status}): ${failure.error}`
+    );
+    this.name = 'InfraError';
+    this.kind = failure.kind;
+    this.status = failure.status;
+  }
+}
+
+/**
+ * A gateway call returned a CLIENT error — a non-404 4xx (400/401/403/409): the
+ * request itself was rejected (bad input, no permission, conflict), so retrying
+ * the SAME request will NOT help. Distinct from {@link InfraError} (a transient
+ * infra failure — retryable, "try again") and from a 404 (genuine absence). The
+ * command framework shows its generic error text, not the "try again" message;
+ * a caller wanting a resource-specific message (e.g. "you don't have access")
+ * can catch this type.
+ */
+export class GatewayClientError extends Error {
+  /** The 4xx status the gateway returned (e.g. 401/403/409). */
+  readonly status: number;
+
+  constructor(failure: GatewayFailure) {
+    super(`Gateway client error (status ${failure.status}): ${failure.error}`);
+    this.name = 'GatewayClientError';
+    this.status = failure.status;
+  }
+}
+
+/**
+ * True when a gateway failure is INFRASTRUCTURE (transient / retryable): any
+ * non-HTTP kind (`network`/`timeout`/`config`/`schema`, `status: 0`) or an HTTP
+ * 5xx. An HTTP 4xx is a CLIENT error — the request was rejected, so retrying the
+ * same request won't help; those become {@link GatewayClientError}.
+ */
+function isInfraFailure(failure: GatewayFailure): boolean {
+  return failure.kind !== 'http' || failure.status >= 500;
+}
+
+/**
+ * Pattern B for single-resource reads. Returns the data on success, `null` ONLY
+ * on a genuine 404 — so `null` unambiguously means "the resource does not
+ * exist". Other failures throw: {@link InfraError} for an infra failure (5xx /
+ * timeout / network — "try again"), {@link GatewayClientError} for a non-404
+ * 4xx (the request was rejected — retrying won't help).
+ */
+export function nullOn404<T>(result: GatewayResult<T>): T | null {
+  if (result.ok) {
+    return result.data;
+  }
+  if (result.status === 404) {
+    return null;
+  }
+  if (isInfraFailure(result)) {
+    throw new InfraError(result);
+  }
+  throw new GatewayClientError(result);
+}
+
+/**
+ * Pattern B for list reads. Returns the array on success, `[]` ONLY on a genuine
+ * 404. Other failures throw: {@link InfraError} for an infra failure,
+ * {@link GatewayClientError} for a non-404 4xx.
+ */
+export function emptyOn404<T>(result: GatewayResult<T[]>): T[] {
+  if (result.ok) {
+    return result.data;
+  }
+  if (result.status === 404) {
+    return [];
+  }
+  if (isInfraFailure(result)) {
+    throw new InfraError(result);
+  }
+  throw new GatewayClientError(result);
+}
+
+/**
+ * Pattern A for routing / mention-parsing. Collapses EVERY failure (including
+ * infra) to `null` — "treat unknown as no match". Never throws. Use ONLY where a
+ * transient failure must not surface a definitive negative to the user and the
+ * caller does not negative-cache the `null`.
+ */
+export function nullOnAnyError<T>(result: GatewayResult<T>): T | null {
+  return result.ok ? result.data : null;
+}

--- a/packages/clients/src/index.ts
+++ b/packages/clients/src/index.ts
@@ -22,6 +22,9 @@ export * from './routes/manifest.js';
 // Shared gateway client transport + error helpers.
 export * from './clients/errors.js';
 export * from './clients/transport.js';
+// InfraError + result-collapse helpers (distinguish a genuine 404 from an
+// infrastructure failure when consuming a GatewayResult).
+export * from './clients/resultHelpers.js';
 // Generated client classes — re-exported from the package entry point so
 // downstream consumers (bot-client) can import them without reaching into
 // _generated/ paths.

--- a/packages/clients/src/routes/types.ts
+++ b/packages/clients/src/routes/types.ts
@@ -46,8 +46,8 @@ export type SubjectDiscordId = string & { readonly [SubjectBrand]: true };
  * @param id The raw Discord snowflake (e.g., `interaction.user.id`)
  */
 export function asActor(id: string): ActorDiscordId {
-  // Defense in depth: the brand is currently only minted from
-  // `interaction.user.id` (always a non-empty snowflake), but an empty string
+  // Defense in depth: the brand is minted at the Discord interaction boundary
+  // (`interaction.user.id`, always a non-empty snowflake); an empty string
   // would silently satisfy the cast and forward as a blank `X-User-Id`.
   if (id.length === 0) {
     throw new TypeError('asActor: id must be non-empty');

--- a/services/bot-client/src/handlers/CommandHandler.test.ts
+++ b/services/bot-client/src/handlers/CommandHandler.test.ts
@@ -5,7 +5,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { CommandHandler } from './CommandHandler.js';
+import { CommandHandler, infraAwareErrorText } from './CommandHandler.js';
+import { InfraError } from '@tzurot/clients';
 import { Collection, MessageFlags, SlashCommandBuilder } from 'discord.js';
 import type {
   ChatInputCommandInteraction,
@@ -37,6 +38,24 @@ vi.mock('node:fs', () => ({
 }));
 
 import { readdirSync, statSync } from 'node:fs';
+
+describe('infraAwareErrorText', () => {
+  const fallback = 'There was an error executing this command!';
+
+  it('returns a "try again" message for an InfraError (transient gateway failure)', () => {
+    const err = new InfraError({ ok: false, kind: 'timeout', error: 'timed out', status: 0 });
+    expect(infraAwareErrorText(err, fallback)).toContain('try again');
+    expect(infraAwareErrorText(err, fallback)).not.toBe(fallback);
+  });
+
+  it('returns the command-specific fallback for a non-infra Error', () => {
+    expect(infraAwareErrorText(new Error('boom'), fallback)).toBe(fallback);
+  });
+
+  it('returns the fallback for a non-Error throwable', () => {
+    expect(infraAwareErrorText('string error', fallback)).toBe(fallback);
+  });
+});
 
 describe('CommandHandler', () => {
   let handler: CommandHandler;

--- a/services/bot-client/src/handlers/CommandHandler.ts
+++ b/services/bot-client/src/handlers/CommandHandler.ts
@@ -6,6 +6,7 @@
  */
 
 import { createLogger } from '@tzurot/common-types';
+import { InfraError } from '@tzurot/clients';
 import {
   Collection,
   ChatInputCommandInteraction,
@@ -25,6 +26,20 @@ import { getCommandFiles } from '../utils/commandFileUtils.js';
 const logger = createLogger('CommandHandler');
 const ERROR_REPLY_FAILED_MSG =
   '[CommandHandler] Could not send error reply (interaction likely already acknowledged)';
+
+/**
+ * User-facing text for a top-level command/interaction error. An `InfraError`
+ * (a gateway call failed for an infrastructure reason — timeout/network/5xx,
+ * surfaced via the Pattern-B result helpers in `@tzurot/clients`) gets a
+ * "try again" message, so a transient blip never reads to the user as a
+ * definitive failure of the command. Everything else keeps the
+ * command-specific fallback.
+ */
+export function infraAwareErrorText(error: unknown, fallback: string): string {
+  return error instanceof InfraError
+    ? "⚠️ Couldn't reach the server right now — please try again in a moment."
+    : fallback;
+}
 
 // Get directory name for ESM
 const __filename = fileURLToPath(import.meta.url);
@@ -207,7 +222,10 @@ export class CommandHandler {
     } catch (error) {
       logger.error({ err: error, commandName }, 'Error executing command');
       try {
-        await this.sendErrorReply(interaction, 'There was an error executing this command!');
+        await this.sendErrorReply(
+          interaction,
+          infraAwareErrorText(error, 'There was an error executing this command!')
+        );
       } catch (replyError) {
         logger.debug({ err: replyError }, ERROR_REPLY_FAILED_MSG);
       }
@@ -255,7 +273,10 @@ export class CommandHandler {
     } catch (error) {
       logger.error({ err: error, customId }, `Error in modal: ${commandName}`);
       try {
-        await this.sendErrorReply(interaction, 'There was an error processing this interaction!');
+        await this.sendErrorReply(
+          interaction,
+          infraAwareErrorText(error, 'There was an error processing this interaction!')
+        );
       } catch (replyError) {
         logger.debug({ err: replyError, customId }, ERROR_REPLY_FAILED_MSG);
       }
@@ -335,7 +356,10 @@ export class CommandHandler {
     } catch (error) {
       logger.error({ err: error, customId, commandName }, 'Error in component interaction');
       try {
-        await this.sendErrorReply(interaction, 'There was an error processing this interaction!');
+        await this.sendErrorReply(
+          interaction,
+          infraAwareErrorText(error, 'There was an error processing this interaction!')
+        );
       } catch (replyError) {
         logger.debug({ err: replyError, customId }, ERROR_REPLY_FAILED_MSG);
       }


### PR DESCRIPTION
## What

**Foundation PR for the beta.137 class-fix centerpiece.** Runtime-confirmed prod bug: a `status=0` transport failure surfaced to a user as `❌ Character "stolas-yenshuf-rakh" not found` — because `HttpPersonalityLoader.loadPersonality` returns `null` for *both* a genuine 404 *and* an infra failure, and `chat.ts` maps `null` → "not found." An audit found ~9 such sites across 4 loaders. Council (GLM-5.2 / Kimi-K2.7 / Qwen-3.7) converged on this fix.

This PR adds the **primitives only** — additive, zero behavior change for existing flows. Loaders adopt them in the follow-on PRs.

## Changes

**`@tzurot/clients` — `resultHelpers.ts`:**
- **`InfraError`** — thrown when a `GatewayResult` fails for an infrastructure reason (timeout/network/5xx/config/schema; `status:0` for non-HTTP kinds).
- **`nullOn404<T>` / `emptyOn404<T>`** (Pattern B) — return `null`/`[]` **only** on a genuine 404, **throw `InfraError`** on any other failure. For code feeding a user-facing message: `null` now unambiguously means "genuinely absent."
- **`nullOnAnyError<T>`** (Pattern A) — collapse *every* failure to `null`. For routing / mention-parsing paths that intentionally treat unknown as no-match.
- 15 colocated tests covering ok / 404 / timeout / network / 5xx for each helper.

**`bot-client` — `CommandHandler`:** a thrown `InfraError` now surfaces **"⚠️ Couldn't reach the server right now — please try again in a moment"** instead of the generic command-error text, at all three interaction catch sites (execute / modal / component). Shared `infraAwareErrorText(error, fallback)` picker + 3 tests.

**Drive-by:** folds in #1330's `asActor`-comment nit (drop the temporal "currently" → positive framing).

## Why this shape

`GatewayResult`'s `status > 0 ⟺ kind === 'http'` invariant makes `status === 404` an unambiguous "genuine miss" (a `status:0` infra failure can never look like a 404). The decision rule (per council): **feeds a user message → Pattern B (throw); feeds logic/routing → Pattern A.**

## Not in this PR (phased into the loader PRs)

- Loader adoption: Models → Persona → PersonalityLoader → MemoryResolver (low→high risk), all before the release so prod never sees a half-fixed state.
- Enforcement (a per-loader `status=0` regression registry + a `no-restricted-syntax` nudge once the inline `if(!ok)return null` pattern is gone) — a coarse rule is too noisy before then (repo has no type-aware custom-ESLint infra).

## Verification
`@tzurot/clients` (180 tests) + `CommandHandler` (35 tests) pass; `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)