### PR TITLE
feat(bot-client): models loader distinguishes infra failure from "not found"

### DIFF
--- a/packages/clients/src/clients/resultHelpers.test.ts
+++ b/packages/clients/src/clients/resultHelpers.test.ts
@@ -41,6 +41,18 @@ const forbidden = <T>(): GatewayResult<T> => ({
   error: 'Forbidden',
   status: 403,
 });
+const configError = <T>(): GatewayResult<T> => ({
+  ok: false,
+  kind: 'config',
+  error: 'Missing baseUrl',
+  status: 0,
+});
+const schemaError = <T>(): GatewayResult<T> => ({
+  ok: false,
+  kind: 'schema',
+  error: 'Response failed Zod validation',
+  status: 0,
+});
 
 describe('InfraError', () => {
   it('is an Error carrying the failure kind + status', () => {
@@ -83,6 +95,8 @@ describe('nullOn404', () => {
   it.each([
     ['timeout', timeout()],
     ['network', network()],
+    ['config', configError()],
+    ['schema', schemaError()],
     ['5xx', serverError()],
   ])('throws InfraError on an infra failure (%s) — never a silent null', (_label, failure) => {
     expect(() => nullOn404(failure)).toThrow(InfraError);
@@ -106,6 +120,8 @@ describe('emptyOn404', () => {
   it.each([
     ['timeout', timeout<number[]>()],
     ['network', network<number[]>()],
+    ['config', configError<number[]>()],
+    ['schema', schemaError<number[]>()],
     ['5xx', serverError<number[]>()],
   ])('throws InfraError on an infra failure (%s)', (_label, failure) => {
     expect(() => emptyOn404(failure)).toThrow(InfraError);

--- a/packages/clients/src/clients/resultHelpers.ts
+++ b/packages/clients/src/clients/resultHelpers.ts
@@ -70,6 +70,11 @@ export class InfraError extends Error {
  * command framework shows its generic error text, not the "try again" message;
  * a caller wanting a resource-specific message (e.g. "you don't have access")
  * can catch this type.
+ *
+ * Distinct from {@link GatewayApiError}: that one is thrown by the transport
+ * layer (the `callGatewayOrThrow` promise-based path); `GatewayClientError` is
+ * thrown by these result-collapse helpers when a `GatewayResult` carries a
+ * non-404 4xx.
  */
 export class GatewayClientError extends Error {
   /** The 4xx status the gateway returned (e.g. 401/403/409). */

--- a/services/bot-client/src/commands/models/browse.ts
+++ b/services/bot-client/src/commands/models/browse.ts
@@ -374,7 +374,7 @@ export async function handleBrowseSelect(interaction: StringSelectMenuInteractio
   } catch (error) {
     logger.error({ err: error, modelId }, 'Failed to render model card from browse');
     await interaction.followUp({
-      content: '❌ Failed to load that model.',
+      content: '❌ Failed to load that model. Please try again.',
       flags: MessageFlags.Ephemeral,
     });
   }

--- a/services/bot-client/src/utils/modelAutocomplete.test.ts
+++ b/services/bot-client/src/utils/modelAutocomplete.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ModelAutocompleteOption } from '@tzurot/common-types';
 import type { ServiceClient } from '@tzurot/clients';
+import { InfraError, GatewayClientError } from '@tzurot/clients';
 import { makeOk, makeErr } from '../test/gatewayClientStubs.js';
 
 vi.mock('@tzurot/common-types', async () => {
@@ -105,6 +106,26 @@ describe('modelAutocomplete', () => {
     it('returns [] when the client throws', async () => {
       getModelsMock.mockRejectedValue(new Error('Network error'));
       expect(await fetchModels()).toEqual([]);
+    });
+
+    it('strict: throws InfraError on an infra failure (5xx) — not a silent []', async () => {
+      getModelsMock.mockResolvedValue(makeErr(503, 'Bad Gateway'));
+      await expect(fetchModels({ strict: true })).rejects.toThrow(InfraError);
+    });
+
+    it('strict: throws InfraError on a transport failure (status 0)', async () => {
+      getModelsMock.mockResolvedValue(makeErr(0, 'timed out', undefined, 'timeout'));
+      await expect(fetchModels({ strict: true })).rejects.toThrow(InfraError);
+    });
+
+    it('strict: throws GatewayClientError (not "try again") on a non-404 4xx', async () => {
+      getModelsMock.mockResolvedValue(makeErr(403, 'Forbidden'));
+      await expect(fetchModels({ strict: true })).rejects.toThrow(GatewayClientError);
+    });
+
+    it('strict: returns the model list on success', async () => {
+      getModelsMock.mockResolvedValue(okModels(sampleTextModels));
+      expect(await fetchModels({ strict: true })).toEqual(sampleTextModels);
     });
   });
 

--- a/services/bot-client/src/utils/modelAutocomplete.ts
+++ b/services/bot-client/src/utils/modelAutocomplete.ts
@@ -12,6 +12,7 @@ import {
   type ModelAutocompleteOption,
 } from '@tzurot/common-types';
 import { getServiceClient } from './gatewayClients.js';
+import { nullOn404 } from '@tzurot/clients';
 
 const logger = createLogger('model-autocomplete-client');
 
@@ -29,6 +30,14 @@ interface FetchModelsOptions {
   search?: string;
   /** Maximum number of results */
   limit?: number;
+  /**
+   * When true, a non-404 failure THROWS (`InfraError` for infra / `GatewayClientError`
+   * for a 4xx) instead of returning `[]` — so a transient gateway failure surfaces
+   * as "try again", not as an empty catalog that reads to the user as "model not
+   * found". Used by the catalog lookup that feeds `/models view` + browse-select.
+   * Omit (lenient `[]`-on-error) for autocomplete, where an empty dropdown is fine.
+   */
+  strict?: boolean;
 }
 
 /**
@@ -69,6 +78,18 @@ export async function fetchModels(
     query.limit = String(options.limit);
   }
 
+  if (options.strict === true) {
+    // Strict path (catalog → /models view + browse-select): a transient/infra
+    // failure must surface as "try again", NOT as an empty catalog that reads
+    // to the user as "model not found". nullOn404 throws InfraError (5xx /
+    // timeout / network) or GatewayClientError (non-404 4xx); getModels has no
+    // meaningful 404, so a 404 maps to empty.
+    const data = nullOn404(await getServiceClient().getModels(query));
+    return data?.models ?? [];
+  }
+
+  // Lenient path (autocomplete): never throw — an empty dropdown beats an
+  // error popup for a transient blip.
   try {
     const result = await getServiceClient().getModels(query);
     if (!result.ok) {

--- a/services/bot-client/src/utils/modelCatalog.test.ts
+++ b/services/bot-client/src/utils/modelCatalog.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ModelAutocompleteOption } from '@tzurot/common-types';
+import { InfraError } from '@tzurot/clients';
 
 // Mock the OpenRouter fetch layer so tests control the OpenRouter side of the
 // merge; the z.ai catalog half comes from the real listZaiCodingPlanModels().
@@ -154,6 +155,19 @@ describe('fetchCatalogModelById', () => {
   it('returns null when nothing matches exactly', async () => {
     fetchModelsMock.mockResolvedValue([model({ id: 'anthropic/claude-sonnet-4' })]);
     expect(await fetchCatalogModelById('anthropic/claude')).toBeNull();
+  });
+
+  it('uses strict mode so a gateway failure surfaces as "try again", not a false "not found"', async () => {
+    fetchModelsMock.mockResolvedValue([model({ id: 'anthropic/claude-sonnet-4' })]);
+    await fetchCatalogModelById('anthropic/claude-sonnet-4');
+    expect(fetchModelsMock).toHaveBeenCalledWith(expect.objectContaining({ strict: true }));
+  });
+
+  it('propagates an InfraError instead of swallowing it into a null "not found"', async () => {
+    fetchModelsMock.mockRejectedValue(
+      new InfraError({ ok: false, kind: 'timeout', error: 'timed out', status: 0 })
+    );
+    await expect(fetchCatalogModelById('anthropic/claude-sonnet-4')).rejects.toThrow(InfraError);
   });
 });
 

--- a/services/bot-client/src/utils/modelCatalog.ts
+++ b/services/bot-client/src/utils/modelCatalog.ts
@@ -61,6 +61,14 @@ export interface FetchCatalogOptions {
   search?: string;
   /** OpenRouter fetch cap (gateway max is 1000). */
   limit?: number;
+  /**
+   * Propagated to the OpenRouter `fetchModels` call: when true, a transient/infra
+   * failure THROWS (so a single-model lookup surfaces "try again") instead of
+   * silently returning a partial catalog (z.ai-only) that reads as "model not
+   * found". The z.ai static entries are still merged in; only the OpenRouter
+   * fetch can fail. Used by {@link fetchCatalogModelById}; omit for autocomplete.
+   */
+  strict?: boolean;
 }
 
 /**
@@ -149,6 +157,7 @@ export async function fetchModelCatalog(
     imageGenOnly: capability === 'image-gen',
     search,
     limit: options.limit ?? 100,
+    strict: options.strict,
   });
 
   const byKey = new Map<string, CatalogModel>();
@@ -195,7 +204,10 @@ export async function fetchModelCatalog(
 
 /**
  * Look up a single model by its exact slug, across both sources. Returns null
- * when no model matches. Used by `/models view` and the browse-select card.
+ * ONLY when no model genuinely matches; THROWS `InfraError` / `GatewayClientError`
+ * on a gateway failure, so the caller's try/catch can show "try again" rather
+ * than a false "not found" (the OpenRouter half could be absent only because the
+ * fetch failed). Used by `/models view` and the browse-select card.
  */
 export async function fetchCatalogModelById(id: string): Promise<CatalogModel | null> {
   // The gateway `search` is a substring match over name/id, and the z.ai merge
@@ -203,7 +215,7 @@ export async function fetchCatalogModelById(id: string): Promise<CatalogModel | 
   // the model from whichever source(s) it lives in. A high limit ensures the
   // exact match isn't truncated out when the slug is a substring of many models
   // (e.g. "gpt"). We then pin the exact id.
-  const candidates = await fetchModelCatalog({ search: id, limit: 1000 });
+  const candidates = await fetchModelCatalog({ search: id, limit: 1000, strict: true });
   const target = id.toLowerCase();
   return candidates.find(m => m.id.toLowerCase() === target) ?? null;
 }


### PR DESCRIPTION
## What

**Loader 1/4 of the infra-vs-negative class fix** (adopts the #1331 Foundation helpers).

`/models view` and the browse-select card look a model up via `fetchCatalogModelById`, which returned `null` for **both** "no such model" **and** "the OpenRouter fetch failed." So a transient gateway failure read to the user as **"❌ Model not found"** — the exact bug class this epic fixes.

## Changes

- **`fetchModels`** gains a `strict` mode: instead of `[]`-on-any-error, it uses `nullOn404` → throws `InfraError` (5xx/timeout/network) or `GatewayClientError` (non-404 4xx). Threaded through `fetchModelCatalog` → `fetchCatalogModelById` (`strict: true`). **Autocomplete keeps the lenient `[]`-on-error path** — an empty dropdown beats an error popup for a transient blip.
- The view + browse-select callers already wrap the lookup in try/catch, so a thrown `InfraError` now surfaces as **"Failed to load that model. Please try again."** (browse's message gains the "try again" wording), while a genuine miss still returns `null` → "model not found."
- **Tests:** `fetchModels` strict (5xx/timeout → `InfraError`; 403 → `GatewayClientError`; success → models); `fetchCatalogModelById` strict-wiring + `InfraError`-propagation (it does NOT swallow the throw into a null "not found").

## Folded in (Foundation #1331 review nits)

- `config`/`schema` rows added to the `nullOn404`/`emptyOn404` infra-failure test matrices (a `schema` parse-failure surfacing as "try again" rather than "doesn't exist" is exactly the class this guards).
- A `GatewayClientError` ↔ `GatewayApiError` JSDoc cross-reference (they're easy to conflate).

## Verification
`modelAutocomplete` (18) + `modelCatalog` (25) + `resultHelpers` (24) tests pass; `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)