### PR TITLE
feat(bot-client): persona loader fails closed on infra failure

### DIFF
--- a/services/bot-client/src/commands/persona/api.test.ts
+++ b/services/bot-client/src/commands/persona/api.test.ts
@@ -12,6 +12,7 @@ import {
 } from './api.js';
 import { mockGetPersonaResponse, mockListPersonasResponse } from '@tzurot/test-factories';
 import { makeOk, makeErr, asUserClient } from '../../test/gatewayClientStubs.js';
+import { InfraError, GatewayClientError } from '@tzurot/clients';
 
 const TEST_PERSONA_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
 const OTHER_PERSONA_ID = 'b2c3d4e5-f6a7-8901-bcde-f12345678901';
@@ -72,6 +73,22 @@ describe('fetchPersona', () => {
 
     expect(result).toBeNull();
   });
+
+  it('throws InfraError on an infra failure — never a silent null "not found"', async () => {
+    stub.getPersona.mockResolvedValue(makeErr(503, 'Bad Gateway'));
+
+    await expect(fetchPersona(TEST_PERSONA_ID, asUserClient(stub), TEST_USER_ID)).rejects.toThrow(
+      InfraError
+    );
+  });
+
+  it('throws GatewayClientError (not "try again") on a non-404 4xx', async () => {
+    stub.getPersona.mockResolvedValue(makeErr(403, 'Forbidden'));
+
+    await expect(fetchPersona(TEST_PERSONA_ID, asUserClient(stub), TEST_USER_ID)).rejects.toThrow(
+      GatewayClientError
+    );
+  });
 });
 
 describe('fetchDefaultPersona', () => {
@@ -115,12 +132,10 @@ describe('fetchDefaultPersona', () => {
     expect(result).toBeNull();
   });
 
-  it('should return null when list fails', async () => {
+  it('throws InfraError when the list fetch fails (infra) — not a silent "no personas"', async () => {
     stub.listPersonas.mockResolvedValue(makeErr(500, 'Failed to fetch'));
 
-    const result = await fetchDefaultPersona(asUserClient(stub), TEST_USER_ID);
-
-    expect(result).toBeNull();
+    await expect(fetchDefaultPersona(asUserClient(stub), TEST_USER_ID)).rejects.toThrow(InfraError);
   });
 });
 
@@ -282,11 +297,11 @@ describe('isDefaultPersona', () => {
     expect(result).toBe(false);
   });
 
-  it('should return false on API failure', async () => {
+  it('throws InfraError on an infra failure — fail-CLOSED so the delete guard cannot be bypassed', async () => {
     stub.listPersonas.mockResolvedValue(makeErr(500, 'Failed'));
 
-    const result = await isDefaultPersona(TEST_PERSONA_ID, asUserClient(stub));
-
-    expect(result).toBe(false);
+    // Old behavior returned false → a transient blip let the default persona be
+    // deleted. Now it throws so the delete aborts (caught upstream → "try again").
+    await expect(isDefaultPersona(TEST_PERSONA_ID, asUserClient(stub))).rejects.toThrow(InfraError);
   });
 });

--- a/services/bot-client/src/commands/persona/api.ts
+++ b/services/bot-client/src/commands/persona/api.ts
@@ -6,7 +6,7 @@
  */
 
 import { createLogger, type PersonaUpdateInput } from '@tzurot/common-types';
-import { type UserClient } from '@tzurot/clients';
+import { nullOn404, type UserClient } from '@tzurot/clients';
 import { DashboardUpdateError } from '../../utils/dashboard/saveError.js';
 import type { PersonaDetails, PersonaSummary } from './types.js';
 
@@ -22,12 +22,16 @@ export async function fetchPersona(
 ): Promise<PersonaDetails | null> {
   const result = await userClient.getPersona(personaId);
 
-  if (!result.ok) {
+  // A 404 is a normal miss (returned as null below, not logged); any other
+  // failure is real, worth a persona-scoped trace before nullOn404 throws it.
+  if (!result.ok && result.status !== 404) {
     logger.warn({ userId, personaId, error: result.error }, 'Failed to fetch persona');
-    return null;
   }
 
-  return result.data.persona;
+  // Pattern B: null ONLY on a genuine 404; nullOn404 throws InfraError (infra →
+  // "try again") / GatewayClientError (non-404 4xx), so a transient blip never
+  // reads to the user as "persona not found".
+  return nullOn404(result)?.persona ?? null;
 }
 
 /**
@@ -39,12 +43,15 @@ export async function fetchDefaultPersona(
 ): Promise<PersonaDetails | null> {
   const listResult = await userClient.listPersonas();
 
-  if (!listResult.ok) {
+  if (!listResult.ok && listResult.status !== 404) {
     logger.warn({ userId, error: listResult.error }, 'Failed to fetch persona list');
-    return null;
   }
 
-  const defaultPersona = listResult.data.personas.find((p: PersonaSummary) => p.isDefault);
+  // listPersonas has no meaningful 404 (an empty list is a 200 with []), so
+  // nullOn404 effectively throws on every infra/4xx failure — a transient blip
+  // can't read to the user as "you have no personas".
+  const data = nullOn404(listResult);
+  const defaultPersona = data?.personas.find((p: PersonaSummary) => p.isDefault);
   if (defaultPersona === undefined) {
     return null;
   }
@@ -103,12 +110,10 @@ export async function isDefaultPersona(
   personaId: string,
   userClient: UserClient
 ): Promise<boolean> {
-  const listResult = await userClient.listPersonas();
-
-  if (!listResult.ok) {
-    return false;
-  }
-
-  const persona = listResult.data.personas.find((p: PersonaSummary) => p.id === personaId);
+  // nullOn404 throws on infra/4xx so the delete guard fails CLOSED — a transient
+  // blip aborts the delete (the throw is caught upstream → "try again") rather
+  // than reading "not default" and letting the user's default persona be deleted.
+  const data = nullOn404(await userClient.listPersonas());
+  const persona = data?.personas.find((p: PersonaSummary) => p.id === personaId);
   return persona?.isDefault ?? false;
 }

--- a/services/bot-client/src/commands/persona/edit.test.ts
+++ b/services/bot-client/src/commands/persona/edit.test.ts
@@ -151,13 +151,25 @@ describe('handleEditPersona', () => {
       expect(mockEditReply).toHaveBeenCalled();
     });
 
-    it('should show error when user has no personas', async () => {
-      stub.listPersonas.mockResolvedValue(makeErr(500, 'No default persona'));
+    it('should show "no personas" when the user genuinely has none (empty list)', async () => {
+      stub.listPersonas.mockResolvedValue(makeOk(mockListPersonasResponse([])));
 
       await handleEditPersona(createMockContext(), null);
 
       expect(mockEditReply).toHaveBeenCalledWith({
         content: expect.stringContaining("don't have any personas"),
+      });
+    });
+
+    it('shows "try again" (not "no personas") when the persona-list fetch fails (infra)', async () => {
+      // Previously a 500 here read as "you have no personas" — the conflation
+      // this epic fixes. fetchDefaultPersona now throws → edit.ts catch.
+      stub.listPersonas.mockResolvedValue(makeErr(500, 'Gateway error'));
+
+      await handleEditPersona(createMockContext(), null);
+
+      expect(mockEditReply).toHaveBeenCalledWith({
+        content: expect.stringContaining('try again'),
       });
     });
   });


### PR DESCRIPTION
## What

**Loader 2/4 of the infra-vs-negative class fix.** `persona/api.ts` conflated infra failures with genuine negatives in three places.

## Changes

- **`fetchPersona` / `fetchDefaultPersona`** returned `null` on **any** `!ok` (no 404 check) → a transient gateway blip read to the user as "❌ Persona not found" / "you have no personas." Now use `nullOn404`: `null` ONLY on a real 404; throw `InfraError` (→ "try again") / `GatewayClientError` (non-404 4xx) otherwise.
- **`isDefaultPersona`** returned `false` on `!ok` — the **fail-OPEN delete guard** the audit flagged: a transient blip made the "can't delete your default persona" check return false, so the delete proceeded and **the default persona could be deleted on a gateway hiccup**. It now throws on infra → the delete flow aborts before the confirmation (caught upstream → "try again") = **fail-CLOSED**.

## No caller changes needed

- `edit.ts` + `browse.ts` catches already say "Failed to load persona. Please try again."
- The refresh path's `createRefreshHandler` already handles throwing fetchers (character/preset fetchers throw-on-infra).
- The delete flow's throw aborts before the confirmation dialog.

## Tests

Updated for the intentional behavior change — and the old `edit.test.ts` case was itself the conflation: it mocked a **500** and asserted **"no personas"** (the misnomer `makeErr(500, 'No default persona')` shows the original author conflated "list failed" with "no default"). Split into genuine-empty (→ "no personas") vs infra (→ "try again"). Added `fetchPersona`/`fetchDefaultPersona`/`isDefaultPersona` infra + 4xx throw tests + the fail-closed delete-guard test.

## Verification
227 persona tests pass; `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)