### PR TITLE
feat(bot-client): personality loader distinguishes infra failure from "not found"

### DIFF
--- a/services/bot-client/src/commands/character/chat.test.ts
+++ b/services/bot-client/src/commands/character/chat.test.ts
@@ -21,6 +21,7 @@ import { handleChat, handleRandom, handleChimeIn } from './chat.js';
 import type { GuildMember } from 'discord.js';
 import { ChannelType } from 'discord.js';
 import type { EnvConfig } from '@tzurot/common-types';
+import { InfraError } from '@tzurot/clients';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 
 const mockGatewayClient = {
@@ -33,6 +34,7 @@ const mockJobTracker = {
 
 const mockPersonalityService = {
   loadPersonality: vi.fn(),
+  loadPersonalityStrict: vi.fn(),
 };
 
 const mockMessageContextBuilder = {
@@ -217,6 +219,11 @@ describe('Character Chat Handler (push delivery)', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // chat.ts calls loadPersonalityStrict; mirror loadPersonality so each test's
+    // loadPersonality.mockResolvedValue(...) applies to both (override for infra).
+    mockPersonalityService.loadPersonalityStrict.mockImplementation((...args) =>
+      mockPersonalityService.loadPersonality(...args)
+    );
     vi.useFakeTimers();
     mockMessageContextBuilder.buildContext.mockResolvedValue(createMockContextBuildResult());
     mockResolveUserContext.mockResolvedValue(buildUserContext());
@@ -235,6 +242,25 @@ describe('Character Chat Handler (push delivery)', () => {
       await handleChat(ctx, mockConfig);
 
       expect(ctx.editReply).toHaveBeenCalledWith({
+        content: expect.stringContaining('not found'),
+      });
+    });
+
+    it('shows "try again" (not "not found") when loadPersonalityStrict throws an InfraError', async () => {
+      const ctx = createMockContext('test-char', 'Hello!');
+      // STRICT path: an infra failure must surface as "try again", never a false
+      // "not found". The generic runCharacterTurn catch handles it.
+      mockPersonalityService.loadPersonalityStrict.mockRejectedValueOnce(
+        new InfraError({ ok: false, kind: 'timeout', status: 0, error: 'boom' })
+      );
+
+      await handleChat(ctx, mockConfig);
+
+      expect(ctx.editReply).toHaveBeenCalledWith({
+        content: expect.stringContaining('Please try again'),
+      });
+      // Must NOT show the false "not found".
+      expect(ctx.editReply).not.toHaveBeenCalledWith({
         content: expect.stringContaining('not found'),
       });
     });

--- a/services/bot-client/src/commands/character/chat.ts
+++ b/services/bot-client/src/commands/character/chat.ts
@@ -436,8 +436,10 @@ async function runCharacterTurn(
   );
 
   try {
-    // 1. Load and validate personality
-    const personality = await getPersonalityLoader().loadPersonality(characterSlug, userId);
+    // 1. Load and validate personality. STRICT: a gateway failure throws (caught
+    // below → "try again"); `null` means the character genuinely doesn't exist /
+    // isn't accessible. A transient failure must not surface as a false "not found".
+    const personality = await getPersonalityLoader().loadPersonalityStrict(characterSlug, userId);
     if (!personality) {
       await context.editReply({ content: `❌ Character "${characterSlug}" not found.` });
       return;

--- a/services/bot-client/src/processors/DMSessionProcessor.test.ts
+++ b/services/bot-client/src/processors/DMSessionProcessor.test.ts
@@ -9,6 +9,7 @@ import { ChannelType, Collection } from 'discord.js';
 import { DMSessionProcessor } from './DMSessionProcessor.js';
 import type { Message, DMChannel, Client } from 'discord.js';
 import type { LoadedPersonality } from '@tzurot/common-types';
+import { InfraError } from '@tzurot/clients';
 import type { IPersonalityLoader } from '../types/IPersonalityLoader.js';
 import type { PersonalityMessageHandler } from '../services/PersonalityMessageHandler.js';
 
@@ -133,6 +134,7 @@ describe('DMSessionProcessor', () => {
   };
   let mockPersonalityService: {
     loadPersonality: ReturnType<typeof vi.fn>;
+    loadPersonalityStrict: ReturnType<typeof vi.fn>;
   };
   let mockPersonalityHandler: {
     handleMessage: ReturnType<typeof vi.fn>;
@@ -170,7 +172,13 @@ describe('DMSessionProcessor', () => {
 
     mockPersonalityService = {
       loadPersonality: vi.fn(),
+      loadPersonalityStrict: vi.fn(),
     };
+    // DMSessionProcessor's active-session path uses loadPersonalityStrict;
+    // mirror loadPersonality so each test's mockResolvedValue applies to both.
+    mockPersonalityService.loadPersonalityStrict.mockImplementation((...args: unknown[]) =>
+      (mockPersonalityService.loadPersonality as (...a: unknown[]) => unknown)(...args)
+    );
 
     mockPersonalityHandler = {
       handleMessage: vi.fn(),
@@ -720,6 +728,58 @@ describe('DMSessionProcessor', () => {
         'follow-up',
         { isAutoResponse: true }
       );
+    });
+
+    it('surfaces "try again" (not the help message) when an active-session load hits an infra failure', async () => {
+      const channel = createMockDMChannel();
+      const message = createMockMessage({ channel, botId: 'bot-123', content: 'follow-up' });
+      vi.mocked(isDMChannel).mockReturnValue(true);
+
+      vi.mocked(getChannelSettingsCached).mockResolvedValue({
+        hasSettings: true,
+        settings: {
+          activatedPersonalityId: 'lilith-id',
+          personalitySlug: 'lilith',
+          personalityName: 'Lilith',
+          autoRespond: true,
+        },
+      } as Awaited<ReturnType<typeof getChannelSettingsCached>>);
+
+      // The session IS active, but the strict load fails for an infra reason. The
+      // user must see "try again", NOT the "no active conversation" help message.
+      mockPersonalityService.loadPersonalityStrict.mockRejectedValueOnce(
+        new InfraError({ ok: false, kind: 'timeout', status: 0, error: 'boom' })
+      );
+
+      const result = await processor.process(message);
+
+      expect(result).toBe(true);
+      expect(message.reply).toHaveBeenCalledWith(expect.stringContaining('try again'));
+      // Must NOT fall through to the help path (that's the false-"no session" bug).
+      expect(mockPersonalityHandler.handleMessage).not.toHaveBeenCalled();
+    });
+
+    it('re-throws a non-infra error from an active-session load (not swallowed as a miss)', async () => {
+      const channel = createMockDMChannel();
+      const message = createMockMessage({ channel, botId: 'bot-123', content: 'follow-up' });
+      vi.mocked(isDMChannel).mockReturnValue(true);
+
+      vi.mocked(getChannelSettingsCached).mockResolvedValue({
+        hasSettings: true,
+        settings: {
+          activatedPersonalityId: 'lilith-id',
+          personalitySlug: 'lilith',
+          personalityName: 'Lilith',
+          autoRespond: true,
+        },
+      } as Awaited<ReturnType<typeof getChannelSettingsCached>>);
+
+      // A thrown error that is neither InfraError nor GatewayClientError is a real
+      // bug — it must propagate, not get silently turned into the help path.
+      mockPersonalityService.loadPersonalityStrict.mockRejectedValueOnce(new Error('unexpected'));
+
+      await expect(processor.process(message)).rejects.toThrow('unexpected');
+      expect(mockPersonalityHandler.handleMessage).not.toHaveBeenCalled();
     });
   });
 

--- a/services/bot-client/src/processors/DMSessionProcessor.ts
+++ b/services/bot-client/src/processors/DMSessionProcessor.ts
@@ -17,6 +17,7 @@ import type { Message, DMChannel } from 'discord.js';
 import { createLogger, type LoadedPersonality } from '@tzurot/common-types';
 import type { IMessageProcessor } from './IMessageProcessor.js';
 import type { IPersonalityLoader } from '../types/IPersonalityLoader.js';
+import { InfraError, GatewayClientError } from '@tzurot/clients';
 import {
   getChannelSettingsCached,
   setDmSessionPersonality,
@@ -116,9 +117,28 @@ export class DMSessionProcessor implements IMessageProcessor {
     // already loaded it (uses the same userId as access scope) — reuse the
     // cached object in that case to avoid a redundant DB roundtrip. The
     // fast-path returns only the ID (cheap to re-load via TTLCache).
-    const personality =
-      resolved.personality ??
-      (await this.personalityService.loadPersonality(resolved.personalityId, userId));
+    // STRICT: the session IS active, so a gateway FAILURE must not read as
+    // "no active conversation". loadPersonalityStrict throws on infra/4xx →
+    // surface "try again"; `null` means the persona was genuinely deleted /
+    // access revoked → the help path below.
+    let personality: LoadedPersonality | null;
+    try {
+      personality =
+        resolved.personality ??
+        (await this.personalityService.loadPersonalityStrict(resolved.personalityId, userId));
+    } catch (error) {
+      if (error instanceof InfraError || error instanceof GatewayClientError) {
+        logger.warn(
+          { err: error, userId, personalityId: resolved.personalityId },
+          'Persona load failed for an active DM session; surfacing retry'
+        );
+        await message.reply(
+          "⏳ Couldn't reach the server just now — please try again in a moment."
+        );
+        return true;
+      }
+      throw error;
+    }
 
     if (!personality) {
       // Personality deleted or access revoked - send help

--- a/services/bot-client/src/processors/PersonalityTriggerProcessor.test.ts
+++ b/services/bot-client/src/processors/PersonalityTriggerProcessor.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ChannelType, type Message } from 'discord.js';
 import { type LoadedPersonality, MULTI_TAG } from '@tzurot/common-types';
+import { InfraError, GatewayClientError } from '@tzurot/clients';
 import { PersonalityTriggerProcessor } from './PersonalityTriggerProcessor.js';
 
 vi.mock('@tzurot/common-types', async importOriginal => {
@@ -78,14 +79,22 @@ function buildMessage(overrides: Record<string, unknown> = {}): Message {
 }
 
 describe('PersonalityTriggerProcessor', () => {
-  let personalityService: { loadPersonality: ReturnType<typeof vi.fn> };
+  let personalityService: {
+    loadPersonality: ReturnType<typeof vi.fn>;
+    loadPersonalityStrict: ReturnType<typeof vi.fn>;
+  };
   let replyResolver: { resolvePersonality: ReturnType<typeof vi.fn> };
   let coordinator: { startFanOut: ReturnType<typeof vi.fn> };
   let processor: PersonalityTriggerProcessor;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    personalityService = { loadPersonality: vi.fn() };
+    personalityService = { loadPersonality: vi.fn(), loadPersonalityStrict: vi.fn() };
+    // PTP's activated-channel resolution uses loadPersonalityStrict; mirror
+    // loadPersonality so each test's mockResolvedValue applies to both.
+    personalityService.loadPersonalityStrict.mockImplementation((...args: unknown[]) =>
+      (personalityService.loadPersonality as (...a: unknown[]) => unknown)(...args)
+    );
     replyResolver = { resolvePersonality: vi.fn().mockResolvedValue(null) };
     vi.mocked(getChannelSettingsCached).mockResolvedValue({
       hasSettings: false,
@@ -249,6 +258,69 @@ describe('PersonalityTriggerProcessor', () => {
         source: 'mention',
         isAutoResponse: false,
       });
+    });
+
+    it('swallows an infra failure silently (resilience catch, NOT the private-character notice)', async () => {
+      // Behaviour change: an infra failure loading the activated personality
+      // previously returned null → the "private character" notice. Now it THROWS
+      // → resolveActivatedPersonality's resilience catch → no slot, no notice.
+      vi.mocked(getChannelSettingsCached).mockResolvedValue({
+        hasSettings: true,
+        settings: { personalitySlug: 'ambient', personalityName: 'Ambient' },
+      } as Awaited<ReturnType<typeof getChannelSettingsCached>>);
+      personalityService.loadPersonalityStrict.mockRejectedValueOnce(
+        new InfraError({ ok: false, kind: 'network', status: 0, error: 'boom' })
+      );
+      vi.mocked(findPersonalityMentions).mockResolvedValue([]);
+
+      const message = buildMessage({ content: 'just chatting' });
+      const result = await processor.process(message);
+
+      // No slots → processor declines (chain continues), and crucially:
+      expect(result).toBe(false);
+      expect(coordinator.startFanOut).not.toHaveBeenCalled();
+      // The private-character notice must NOT fire on an infra failure.
+      expect(message.reply).not.toHaveBeenCalled();
+    });
+
+    it('swallows a GatewayClientError (non-404 4xx, e.g. 403) silently too — same resilience path', async () => {
+      // A non-404 4xx is also a thrown failure, not a genuine miss — it must reach
+      // the resilience catch (no slot, no notice), same as the InfraError case.
+      vi.mocked(getChannelSettingsCached).mockResolvedValue({
+        hasSettings: true,
+        settings: { personalitySlug: 'ambient', personalityName: 'Ambient' },
+      } as Awaited<ReturnType<typeof getChannelSettingsCached>>);
+      personalityService.loadPersonalityStrict.mockRejectedValueOnce(
+        new GatewayClientError({ ok: false, kind: 'http', status: 403, error: 'forbidden' })
+      );
+      vi.mocked(findPersonalityMentions).mockResolvedValue([]);
+
+      const message = buildMessage({ content: 'just chatting' });
+      const result = await processor.process(message);
+
+      expect(result).toBe(false);
+      expect(coordinator.startFanOut).not.toHaveBeenCalled();
+      expect(message.reply).not.toHaveBeenCalled();
+    });
+
+    it('still shows the private-character notice on a GENUINE miss (200 null, not infra)', async () => {
+      // The inverse of the test above: a genuine null (personality deleted /
+      // access revoked) must STILL reach the private-character notice path.
+      vi.mocked(getChannelSettingsCached).mockResolvedValue({
+        hasSettings: true,
+        settings: { personalitySlug: 'ambient', personalityName: 'Ambient' },
+      } as Awaited<ReturnType<typeof getChannelSettingsCached>>);
+      personalityService.loadPersonalityStrict.mockResolvedValue(null);
+      vi.mocked(findPersonalityMentions).mockResolvedValue([]);
+
+      const message = buildMessage({ content: 'just chatting' });
+      const result = await processor.process(message);
+
+      expect(result).toBe(false);
+      expect(coordinator.startFanOut).not.toHaveBeenCalled();
+      expect(message.reply).toHaveBeenCalledWith(
+        expect.objectContaining({ content: expect.stringContaining('private character') })
+      );
     });
 
     it('dedupes when activation and mention resolve to the same personality (first occurrence wins)', async () => {

--- a/services/bot-client/src/processors/PersonalityTriggerProcessor.ts
+++ b/services/bot-client/src/processors/PersonalityTriggerProcessor.ts
@@ -217,7 +217,14 @@ export class PersonalityTriggerProcessor implements IMessageProcessor {
 
     const { personalitySlug, personalityName } = channelSettings.settings;
 
-    const personality = await this.deps.personalityService.loadPersonality(personalitySlug, userId);
+    // STRICT: a gateway FAILURE throws → caught by resolveActivatedPersonality's
+    // resilience catch → no activation slot (silent), NOT the "private character"
+    // notice below. `null` means the activated persona genuinely isn't accessible
+    // to this user (200 with personality:null) → the notice is correct.
+    const personality = await this.deps.personalityService.loadPersonalityStrict(
+      personalitySlug,
+      userId
+    );
 
     if (personality === null) {
       logger.debug(

--- a/services/bot-client/src/services/HttpPersonalityLoader.test.ts
+++ b/services/bot-client/src/services/HttpPersonalityLoader.test.ts
@@ -9,13 +9,20 @@ vi.mock('../utils/gatewayClients.js', () => ({
 }));
 
 import { TIMEOUTS } from '@tzurot/common-types';
+import { InfraError, GatewayClientError } from '@tzurot/clients';
 import { HttpPersonalityLoader, NEGATIVE_TTL_MS } from './HttpPersonalityLoader.js';
 
 const PERSONALITY = { id: 'pers-1', name: 'Lila', slug: 'lila' };
 
 const ok = <T>(data: T): { ok: true; data: T } => ({ ok: true, data });
-const err = (status: number): { ok: false; error: string; status: number } => ({
+// `kind` mirrors the real GatewayResult invariant (status>0 ⟺ 'http') so the
+// strict helpers classify correctly: a 5xx / non-http → InfraError, a non-404
+// 4xx → GatewayClientError.
+const err = (
+  status: number
+): { ok: false; kind: 'http' | 'network'; error: string; status: number } => ({
   ok: false,
+  kind: status > 0 ? 'http' : 'network',
   error: 'boom',
   status,
 });
@@ -96,6 +103,52 @@ describe('HttpPersonalityLoader', () => {
 
     expect(retry?.id).toBe('pers-1');
     expect(mockServiceClient.loadPersonalityInternal).toHaveBeenCalledTimes(2);
+  });
+
+  it('loadPersonalityStrict throws InfraError on an infra failure (5xx) — not a silent null', async () => {
+    mockServiceClient.loadPersonalityInternal.mockResolvedValue(err(503));
+    await expect(loader.loadPersonalityStrict('lila', 'user-1')).rejects.toThrow(InfraError);
+  });
+
+  it('loadPersonalityStrict throws GatewayClientError on a non-404 4xx', async () => {
+    mockServiceClient.loadPersonalityInternal.mockResolvedValue(err(403));
+    await expect(loader.loadPersonalityStrict('lila', 'user-1')).rejects.toThrow(
+      GatewayClientError
+    );
+  });
+
+  it('loadPersonalityStrict returns null ONLY for a genuine miss (200 with personality:null)', async () => {
+    mockServiceClient.loadPersonalityInternal.mockResolvedValue(ok({ personality: null }));
+    expect(await loader.loadPersonalityStrict('ghost', 'user-1')).toBeNull();
+  });
+
+  it('loadPersonalityStrict does NOT negative-cache an infra failure (throw happens first)', async () => {
+    mockServiceClient.loadPersonalityInternal.mockResolvedValueOnce(err(503));
+    await expect(loader.loadPersonalityStrict('lila', 'user-1')).rejects.toThrow(InfraError);
+    mockServiceClient.loadPersonalityInternal.mockResolvedValueOnce(
+      ok({ personality: PERSONALITY })
+    );
+    expect((await loader.loadPersonalityStrict('lila', 'user-1'))?.id).toBe('pers-1');
+    expect(mockServiceClient.loadPersonalityInternal).toHaveBeenCalledTimes(2);
+  });
+
+  it('loadPersonalityStrict throws InfraError on a NETWORK failure (status 0, kind network)', async () => {
+    // A network/timeout failure carries status 0 / kind!=='http' — still infra,
+    // never a 404. Documents that "network failure ≠ not found" like the 5xx case.
+    mockServiceClient.loadPersonalityInternal.mockResolvedValue(err(0));
+    await expect(loader.loadPersonalityStrict('lila', 'user-1')).rejects.toThrow(InfraError);
+  });
+
+  it('loadPersonality (lenient wrapper) collapses an infra failure to null for routing', async () => {
+    mockServiceClient.loadPersonalityInternal.mockResolvedValue(err(503));
+    expect(await loader.loadPersonality('lila', 'user-1')).toBeNull();
+  });
+
+  it('loadPersonality (lenient wrapper) re-throws a non-gateway error (not an infra failure)', async () => {
+    // A thrown error that is neither InfraError nor GatewayClientError is a real
+    // bug, not a transient miss — the wrapper must propagate it, not swallow it.
+    mockServiceClient.loadPersonalityInternal.mockRejectedValue(new Error('unexpected boom'));
+    await expect(loader.loadPersonality('lila', 'user-1')).rejects.toThrow('unexpected boom');
   });
 
   it('keys the cache by userId — access control results are not shared across users', async () => {

--- a/services/bot-client/src/services/HttpPersonalityLoader.ts
+++ b/services/bot-client/src/services/HttpPersonalityLoader.ts
@@ -26,6 +26,7 @@ import { createLogger, TIMEOUTS, TTLCache, type LoadedPersonality } from '@tzuro
 import { type PersonalityCacheTarget } from '@tzurot/cache-invalidation';
 import type { IPersonalityLoader } from '../types/IPersonalityLoader.js';
 import { getServiceClient } from '../utils/gatewayClients.js';
+import { InfraError, GatewayClientError, nullOn404 } from '@tzurot/clients';
 
 const logger = createLogger('HttpPersonalityLoader');
 
@@ -75,7 +76,18 @@ export class HttpPersonalityLoader implements IPersonalityLoader, PersonalityCac
     return `${userId ?? ''}\x00${nameOrId.toLowerCase()}`;
   }
 
-  async loadPersonality(nameOrId: string, userId?: string): Promise<LoadedPersonality | null> {
+  /**
+   * Strict load: returns `null` ONLY for a genuine miss (the endpoint responds
+   * 200 with `personality: null` — not found / access denied), and THROWS on a
+   * gateway FAILURE (`nullOn404` → `InfraError` for infra, `GatewayClientError`
+   * for a non-404 4xx). An infra failure is NOT negative-cached — a blip must
+   * not blind future loads for the negative TTL. User-facing callers use this so
+   * a transient failure surfaces as "try again" rather than a false "not found".
+   */
+  async loadPersonalityStrict(
+    nameOrId: string,
+    userId?: string
+  ): Promise<LoadedPersonality | null> {
     const key = this.cacheKey(nameOrId, userId);
 
     const cached = this.positiveCache.get(key);
@@ -86,16 +98,14 @@ export class HttpPersonalityLoader implements IPersonalityLoader, PersonalityCac
       return null;
     }
 
-    const result = await getServiceClient().loadPersonalityInternal({ nameOrId, userId });
-    if (!result.ok) {
-      // Transport/server error — NOT a definitive miss. Return null for this
-      // call (routing treats unknown as no-match, same as legacy DB errors)
-      // but don't cache it.
-      logger.warn({ status: result.status }, 'Personality load via gateway failed');
-      return null;
-    }
-
-    const personality = result.data.personality;
+    // This endpoint signals "not found" as a 200 with personality:null, never a
+    // 404 — so every non-404 `!ok` is a real gateway error: nullOn404 throws it
+    // (infra → InfraError, non-404 4xx → GatewayClientError) WITHOUT caching. A
+    // stray 404 (contract violation) is the one error code nullOn404 collapses to
+    // null instead of throwing — it then falls through to the defensive
+    // genuine-miss path below (negative-cached), converging with the 200-null case.
+    const data = nullOn404(await getServiceClient().loadPersonalityInternal({ nameOrId, userId }));
+    const personality = data?.personality ?? null;
     if (personality === null) {
       this.negativeCache.set(key, true);
       return null;
@@ -103,6 +113,28 @@ export class HttpPersonalityLoader implements IPersonalityLoader, PersonalityCac
 
     this.positiveCache.set(key, personality);
     return personality;
+  }
+
+  /**
+   * Lenient load for ROUTING / mention-parsing: collapses every gateway failure
+   * to `null` ("treat unknown as no-match"). A transient blip must not blind
+   * routing, so the failure is swallowed and — crucially — NOT negative-cached
+   * (`loadPersonalityStrict` throws before the negative-cache write). Wraps
+   * {@link loadPersonalityStrict}; only re-classifies its thrown failures.
+   */
+  async loadPersonality(nameOrId: string, userId?: string): Promise<LoadedPersonality | null> {
+    try {
+      return await this.loadPersonalityStrict(nameOrId, userId);
+    } catch (error) {
+      if (error instanceof InfraError || error instanceof GatewayClientError) {
+        logger.warn(
+          { status: error.status },
+          'Personality load via gateway failed; treating as no-match for routing'
+        );
+        return null;
+      }
+      throw error;
+    }
   }
 
   /**

--- a/services/bot-client/src/test/mocks/PersonalityService.mock.ts
+++ b/services/bot-client/src/test/mocks/PersonalityService.mock.ts
@@ -39,33 +39,37 @@ interface MockPersonality {
 export function createMockPersonalityService(personalities: MockPersonality[]): IPersonalityLoader {
   const personalityMap = new Map(personalities.map(p => [p.name.toLowerCase(), p]));
 
-  // The mock implements only loadPersonality — the single method
-  // IPersonalityLoader (and its consumers, e.g. findPersonalityMentions) need —
-  // so the object satisfies the interface directly, no cast required.
-  return {
-    loadPersonality: vi.fn().mockImplementation((name: string) => {
-      const personality = personalityMap.get(name.toLowerCase());
-      if (!personality) {
-        return Promise.resolve(null);
-      }
+  // Shared resolve impl backs BOTH loadPersonality (routing) and
+  // loadPersonalityStrict (user-facing) with the same lookup, so the object
+  // satisfies the interface directly. A test that needs the strict path to
+  // THROW overrides `loadPersonalityStrict` with `mockRejectedValue`.
+  const resolve = (name: string): Promise<LoadedPersonality | null> => {
+    const personality = personalityMap.get(name.toLowerCase());
+    if (!personality) {
+      return Promise.resolve(null);
+    }
 
-      // Return a minimal mock personality object.
-      // In real code this would be a full LoadedPersonality from the gateway.
-      return Promise.resolve({
-        id: `mock-id-${personality.name.toLowerCase()}`,
-        name: personality.name,
-        displayName: personality.displayName,
-        systemPrompt: personality.systemPrompt,
-        avatarUrl: personality.avatarUrl ?? null,
-        slug: personality.name.toLowerCase(),
-        model: 'mock-model',
-        temperature: 0.8,
-        maxTokens: 1000,
-        contextWindowTokens: 131072,
-        characterInfo: '',
-        personalityTraits: '',
-        voiceEnabled: false,
-      } as unknown as LoadedPersonality);
-    }),
+    // Return a minimal mock personality object.
+    // In real code this would be a full LoadedPersonality from the gateway.
+    return Promise.resolve({
+      id: `mock-id-${personality.name.toLowerCase()}`,
+      name: personality.name,
+      displayName: personality.displayName,
+      systemPrompt: personality.systemPrompt,
+      avatarUrl: personality.avatarUrl ?? null,
+      slug: personality.name.toLowerCase(),
+      model: 'mock-model',
+      temperature: 0.8,
+      maxTokens: 1000,
+      contextWindowTokens: 131072,
+      characterInfo: '',
+      personalityTraits: '',
+      voiceEnabled: false,
+    } as unknown as LoadedPersonality);
+  };
+
+  return {
+    loadPersonality: vi.fn().mockImplementation(resolve),
+    loadPersonalityStrict: vi.fn().mockImplementation(resolve),
   };
 }

--- a/services/bot-client/src/types/IPersonalityLoader.ts
+++ b/services/bot-client/src/types/IPersonalityLoader.ts
@@ -19,4 +19,17 @@ export interface IPersonalityLoader {
    * @returns LoadedPersonality or null if not found or access denied
    */
   loadPersonality(nameOrId: string, userId?: string): Promise<LoadedPersonality | null>;
+
+  /**
+   * Like {@link loadPersonality}, but distinguishes a genuine miss from a
+   * gateway FAILURE: returns `null` ONLY when the personality genuinely does not
+   * exist / access is denied, and THROWS `InfraError` (infra) /
+   * `GatewayClientError` (non-404 4xx) on a failed load.
+   *
+   * Use from USER-FACING command/interaction paths so a transient blip surfaces
+   * as "try again" rather than a false "not found". Routing / mention-parsing
+   * paths keep using the lenient {@link loadPersonality}, which collapses every
+   * failure to `null` ("treat unknown as no-match") and never throws.
+   */
+  loadPersonalityStrict(nameOrId: string, userId?: string): Promise<LoadedPersonality | null>;
 }


### PR DESCRIPTION
## What

Loader 3/4 of the infra-vs-negative bug-class sweep. The user-facing personality loaders collapsed a gateway **failure** (timeout / network / 5xx) into the same `null` sentinel as a genuine miss, so a transient blip surfaced as a definitive **"Character not found"** — the original prod bug this sweep is chasing.

## Change

Split `HttpPersonalityLoader` into two methods (the council's strict-primitive + routing-wrapper design):

- **`loadPersonalityStrict`** (primitive): returns `null` **only** for a genuine `200`-with-`personality:null` miss; **throws** `InfraError` (infra) / `GatewayClientError` (non-404 4xx) on a failed load. The endpoint signals "not found" as a 200, never a 404, so every `!ok` is a real gateway error. Infra failures are **not** negative-cached — a blip can't blind future loads for the negative TTL.
- **`loadPersonality`** (wrapper): the lenient routing path — catches the throw and collapses to `null` ("treat unknown as no-match").

### Caller migration

| Caller | Variant | Rationale |
| --- | --- | --- |
| `chat.ts` (`/character chat`) | **strict** | false "not found" → "try again" (caught → existing retry text) |
| `DMSessionProcessor` active-session load | **strict** | active session must not read a blip as "no conversation"; throws → "⏳ try again" |
| `PersonalityTriggerProcessor` activated-channel | **strict** | resilience catch swallows infra (silent, no slot); `null` → genuine private-character notice |
| `DMSessionProcessor` history backfill | lenient | routing/backfill — unknown is fine |
| mention parsing | lenient | routing |

## Tests

- `HttpPersonalityLoader.test.ts`: strict throws `InfraError` on 5xx, `GatewayClientError` on non-404 4xx, `null` only on genuine 200-null miss, and does **not** negative-cache an infra failure. `err` helper now carries `kind` so it classifies like the real `GatewayResult`.
- The 3 caller test mocks delegate `loadPersonalityStrict` → `loadPersonality` so existing setups flow through; per-test `mockRejectedValue` still overrides for infra cases.

`pnpm quality` green; 73 bot-client tests across the 4 affected files pass.