### PR TITLE
feat(bot-client): memory resolver distinguishes infra failure from "not found"

### DIFF
--- a/services/bot-client/src/commands/memory/autocomplete.test.ts
+++ b/services/bot-client/src/commands/memory/autocomplete.test.ts
@@ -64,26 +64,26 @@ describe('Memory Autocomplete', () => {
       const user = mkUser();
       const result = await resolvePersonalityId(user, 'lilith');
 
-      expect(result).toBe('uuid-1');
+      expect(result).toEqual({ kind: 'found', id: 'uuid-1' });
       expect(mockGetCachedPersonalities).toHaveBeenCalledWith(user);
     });
 
     it('should resolve personality by ID', async () => {
       const result = await resolvePersonalityId(mkUser(), 'uuid-2');
 
-      expect(result).toBe('uuid-2');
+      expect(result).toEqual({ kind: 'found', id: 'uuid-2' });
     });
 
     it('should resolve personality by name (case-insensitive)', async () => {
       const result = await resolvePersonalityId(mkUser(), 'ZEPHYR');
 
-      expect(result).toBe('uuid-3');
+      expect(result).toEqual({ kind: 'found', id: 'uuid-3' });
     });
 
-    it('should return null for unknown personality', async () => {
+    it('should return not-found for an unknown personality (list loaded, no match)', async () => {
       const result = await resolvePersonalityId(mkUser(), 'unknown');
 
-      expect(result).toBeNull();
+      expect(result).toEqual({ kind: 'not-found' });
     });
 
     it('should prefer slug match over name match', async () => {
@@ -97,15 +97,15 @@ describe('Memory Autocomplete', () => {
       const result = await resolvePersonalityId(mkUser(), 'aria');
 
       // Should find the original 'aria' by slug first
-      expect(result).toBe('uuid-2');
+      expect(result).toEqual({ kind: 'found', id: 'uuid-2' });
     });
 
-    it('should return null when cache returns error', async () => {
+    it('should return unavailable when the personality list can not be fetched (infra)', async () => {
       mockGetCachedPersonalities.mockResolvedValue({ kind: 'error', error: 'Backend down' });
 
       const result = await resolvePersonalityId(mkUser(), 'lilith');
 
-      expect(result).toBeNull();
+      expect(result).toEqual({ kind: 'unavailable' });
     });
   });
 

--- a/services/bot-client/src/commands/memory/autocomplete.ts
+++ b/services/bot-client/src/commands/memory/autocomplete.ts
@@ -25,42 +25,62 @@ export async function handlePersonalityAutocomplete(
 }
 
 /**
- * Resolve a personality slug to its UUID
- * Uses the autocomplete cache for performance
+ * Tri-state result of resolving a personality slug/ID/name to a UUID.
+ *
+ * The `not-found` vs `unavailable` split is the whole point: a genuine miss
+ * (the personality list loaded fine but the slug isn't in it) must surface a
+ * definitive "not found", while an infra failure fetching the list must surface
+ * "try again". Collapsing both to `null` was the infra-vs-negative bug — an
+ * unreachable gateway told the user their character "doesn't exist".
+ */
+export type ResolvedPersonality =
+  | { kind: 'found'; id: string }
+  | { kind: 'not-found' }
+  | { kind: 'unavailable' };
+
+/**
+ * Resolve a personality slug/ID/name to its UUID via the autocomplete cache.
  *
  * @param userClient - Typed gateway client bound to the caller (for cache lookup)
  * @param slugOrId - Personality slug or ID from user input
- * @returns Personality UUID or null if not found
+ * @returns a {@link ResolvedPersonality} — `found` with the UUID, `not-found`
+ *   when the list loaded but the input matched nothing, or `unavailable` when
+ *   the personality list itself couldn't be fetched (infra failure).
  */
 export async function resolvePersonalityId(
   userClient: UserClient,
   slugOrId: string
-): Promise<string | null> {
+): Promise<ResolvedPersonality> {
   const result = await getCachedPersonalities(userClient);
   if (result.kind === 'error') {
-    return null;
+    // Fetching the personality list FAILED (network/5xx/etc.) — this is NOT a
+    // genuine miss. Signal "unavailable" so callers show "try again" rather than
+    // a false "not found". (getCachedPersonalities only returns `error` on a
+    // fetch failure; a successful fetch returns `ok` with a possibly-empty list.)
+    return { kind: 'unavailable' };
   }
   const personalities = result.value;
 
   // Try to find by slug first (most common case from autocomplete)
   const bySlug = personalities.find(p => p.slug === slugOrId);
   if (bySlug !== undefined) {
-    return bySlug.id;
+    return { kind: 'found', id: bySlug.id };
   }
 
   // Try to find by ID (in case user pasted an ID directly)
   const byId = personalities.find(p => p.id === slugOrId);
   if (byId !== undefined) {
-    return byId.id;
+    return { kind: 'found', id: byId.id };
   }
 
   // Try to find by name (fuzzy match for user convenience)
   const byName = personalities.find(p => p.name.toLowerCase() === slugOrId.toLowerCase());
   if (byName !== undefined) {
-    return byName.id;
+    return { kind: 'found', id: byName.id };
   }
 
-  return null;
+  // List loaded fine, input genuinely matched nothing.
+  return { kind: 'not-found' };
 }
 
 /**

--- a/services/bot-client/src/commands/memory/batchDelete.test.ts
+++ b/services/bot-client/src/commands/memory/batchDelete.test.ts
@@ -109,7 +109,7 @@ describe('handleBatchDelete', () => {
 
   describe('validation', () => {
     it('should show error when personality not found', async () => {
-      mockResolvePersonalityId.mockResolvedValue(null);
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'not-found' });
       const context = createMockContext('unknown-personality');
 
       await handleBatchDelete(context);
@@ -119,8 +119,20 @@ describe('handleBatchDelete', () => {
       });
     });
 
+    it('shows "try again" (unavailable), not "not found", when the personality list is unavailable', async () => {
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'unavailable' });
+      const context = createMockContext('lilith');
+
+      await handleBatchDelete(context);
+
+      expect(mockEditReply).toHaveBeenCalledWith({
+        content: expect.stringContaining('Autocomplete was unavailable'),
+      });
+      expect(stub.batchDeletePreview).not.toHaveBeenCalled();
+    });
+
     it('should resolve personality slug to ID', async () => {
-      mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
       stub.batchDeletePreview.mockResolvedValue(
         makeOk({
           wouldDelete: 0,
@@ -146,7 +158,7 @@ describe('handleBatchDelete', () => {
 
   describe('preview', () => {
     beforeEach(() => {
-      mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
     });
 
     it('should show error when preview API fails', async () => {
@@ -214,7 +226,7 @@ describe('handleBatchDelete', () => {
 
   describe('confirmation dialog', () => {
     beforeEach(() => {
-      mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
       stub.batchDeletePreview.mockResolvedValue(
         makeOk({
           wouldDelete: 5,
@@ -271,7 +283,7 @@ describe('handleBatchDelete', () => {
 
   describe('deletion', () => {
     beforeEach(() => {
-      mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
     });
 
     it('should perform deletion using the previewToken when user confirms', async () => {

--- a/services/bot-client/src/commands/memory/batchDelete.ts
+++ b/services/bot-client/src/commands/memory/batchDelete.ts
@@ -19,13 +19,9 @@ import {
   memoryDeleteOptions,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
-import {
-  AUTOCOMPLETE_UNAVAILABLE_MESSAGE,
-  isAutocompleteErrorSentinel,
-} from '../../utils/apiCheck.js';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import { createWarningEmbed, createSuccessEmbed } from '../../utils/commandHelpers.js';
-import { resolvePersonalityId } from './autocomplete.js';
+import { resolveRequiredPersonality } from './resolveHelpers.js';
 
 const logger = createLogger('memory-batch-delete');
 
@@ -62,19 +58,12 @@ export async function handleBatchDelete(context: DeferredCommandContext): Promis
   const personalityInput = options.character();
   const timeframe = options.timeframe();
 
-  if (isAutocompleteErrorSentinel(personalityInput)) {
-    await context.editReply({ content: AUTOCOMPLETE_UNAVAILABLE_MESSAGE });
-    return;
-  }
-
   try {
-    // Resolve personality slug to ID
-    const personalityId = await resolvePersonalityId(userClient, personalityInput);
-
+    // resolveRequiredPersonality handles the sentinel, genuine-miss ("not found"),
+    // and infra-failure ("try again") cases — replying + returning null for each.
+    // Kept inside the try so an unexpected throw still reaches the catch below.
+    const personalityId = await resolveRequiredPersonality(context, userClient, personalityInput);
     if (personalityId === null) {
-      await context.editReply({
-        content: `❌ Character "${personalityInput}" not found. Use autocomplete to select a valid character.`,
-      });
       return;
     }
 

--- a/services/bot-client/src/commands/memory/focus.test.ts
+++ b/services/bot-client/src/commands/memory/focus.test.ts
@@ -80,7 +80,7 @@ describe('Memory Focus Handlers', () => {
 
   describe('handleFocusEnable', () => {
     it('should enable focus mode successfully', async () => {
-      mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
       stub.setFocus.mockResolvedValue(
         makeOk({
           personalityId: 'personality-uuid-123',
@@ -105,7 +105,7 @@ describe('Memory Focus Handlers', () => {
     });
 
     it('should handle personality not found', async () => {
-      mockResolvePersonalityId.mockResolvedValue(null);
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'not-found' });
 
       const context = createMockContext('unknown');
       await handleFocusEnable(context);
@@ -116,8 +116,20 @@ describe('Memory Focus Handlers', () => {
       expect(stub.setFocus).not.toHaveBeenCalled();
     });
 
+    it('shows "try again" (unavailable), not "not found", when the personality list is unavailable', async () => {
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'unavailable' });
+
+      const context = createMockContext('lilith');
+      await handleFocusEnable(context);
+
+      expect(mockEditReply).toHaveBeenCalledWith({
+        content: expect.stringContaining('Autocomplete was unavailable'),
+      });
+      expect(stub.setFocus).not.toHaveBeenCalled();
+    });
+
     it('should handle API error', async () => {
-      mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
       stub.setFocus.mockResolvedValue(makeErr(500, 'Server error'));
 
       const context = createMockContext();
@@ -142,7 +154,7 @@ describe('Memory Focus Handlers', () => {
 
   describe('handleFocusDisable', () => {
     it('should disable focus mode successfully', async () => {
-      mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
       stub.setFocus.mockResolvedValue(
         makeOk({
           personalityId: 'personality-uuid-123',
@@ -166,7 +178,7 @@ describe('Memory Focus Handlers', () => {
     });
 
     it('should handle personality not found', async () => {
-      mockResolvePersonalityId.mockResolvedValue(null);
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'not-found' });
 
       const context = createMockContext('unknown');
       await handleFocusDisable(context);
@@ -180,7 +192,7 @@ describe('Memory Focus Handlers', () => {
 
   describe('handleFocusStatus', () => {
     it('should show status when focus mode is enabled', async () => {
-      mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
       mockGetPersonalityName.mockResolvedValue('Lilith');
       stub.getFocus.mockResolvedValue(
         makeOk({
@@ -200,7 +212,7 @@ describe('Memory Focus Handlers', () => {
     });
 
     it('should show status when focus mode is disabled', async () => {
-      mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
       mockGetPersonalityName.mockResolvedValue('Lilith');
       stub.getFocus.mockResolvedValue(
         makeOk({
@@ -219,7 +231,7 @@ describe('Memory Focus Handlers', () => {
     });
 
     it('should use personality slug when name not found', async () => {
-      mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
       mockGetPersonalityName.mockResolvedValue(null);
       stub.getFocus.mockResolvedValue(
         makeOk({
@@ -238,7 +250,7 @@ describe('Memory Focus Handlers', () => {
     });
 
     it('should handle personality not found', async () => {
-      mockResolvePersonalityId.mockResolvedValue(null);
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'not-found' });
 
       const context = createMockContext('unknown');
       await handleFocusStatus(context);
@@ -250,7 +262,7 @@ describe('Memory Focus Handlers', () => {
     });
 
     it('should handle API error', async () => {
-      mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
       stub.getFocus.mockResolvedValue(makeErr(500, 'Server error'));
 
       const context = createMockContext();

--- a/services/bot-client/src/commands/memory/incognito.test.ts
+++ b/services/bot-client/src/commands/memory/incognito.test.ts
@@ -103,7 +103,7 @@ describe('Memory Incognito Handlers', () => {
 
   describe('handleIncognitoEnable', () => {
     it('should enable incognito mode for specific personality', async () => {
-      mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
       mockGetPersonalityName.mockResolvedValue('Lilith');
       stub.enableIncognito.mockResolvedValue(
         makeOk({
@@ -171,7 +171,7 @@ describe('Memory Incognito Handlers', () => {
     });
 
     it('should show info embed when already active', async () => {
-      mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
       mockGetPersonalityName.mockResolvedValue('Lilith');
       stub.enableIncognito.mockResolvedValue(
         makeOk({
@@ -202,7 +202,7 @@ describe('Memory Incognito Handlers', () => {
     });
 
     it('should handle personality not found', async () => {
-      mockResolvePersonalityId.mockResolvedValue(null);
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'not-found' });
 
       const context = createMockContext({ character: 'unknown' });
       await handleIncognitoEnable(context);
@@ -213,8 +213,22 @@ describe('Memory Incognito Handlers', () => {
       expect(stub.enableIncognito).not.toHaveBeenCalled();
     });
 
+    it('shows "try again" (unavailable), not "not found", on an infra failure', async () => {
+      // The personality list couldn't be fetched — must NOT claim the character
+      // doesn't exist.
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'unavailable' });
+
+      const context = createMockContext({ character: 'lilith' });
+      await handleIncognitoEnable(context);
+
+      expect(mockEditReply).toHaveBeenCalledWith({
+        content: expect.stringContaining('Autocomplete was unavailable'),
+      });
+      expect(stub.enableIncognito).not.toHaveBeenCalled();
+    });
+
     it('should handle API error', async () => {
-      mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
       mockGetPersonalityName.mockResolvedValue('Lilith');
       stub.enableIncognito.mockResolvedValue(makeErr(500, 'Server error'));
 
@@ -252,7 +266,7 @@ describe('Memory Incognito Handlers', () => {
 
   describe('handleIncognitoDisable', () => {
     it('should disable incognito mode successfully', async () => {
-      mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
       mockGetPersonalityName.mockResolvedValue('Lilith');
       stub.disableIncognito.mockResolvedValue(
         makeOk({
@@ -289,7 +303,7 @@ describe('Memory Incognito Handlers', () => {
     });
 
     it('should show info when incognito was not active', async () => {
-      mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
       mockGetPersonalityName.mockResolvedValue('Lilith');
       stub.disableIncognito.mockResolvedValue(
         makeOk({
@@ -308,7 +322,7 @@ describe('Memory Incognito Handlers', () => {
     });
 
     it('should handle personality not found', async () => {
-      mockResolvePersonalityId.mockResolvedValue(null);
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'not-found' });
 
       const context = createMockContext({ character: 'unknown' });
       await handleIncognitoDisable(context);
@@ -318,8 +332,20 @@ describe('Memory Incognito Handlers', () => {
       });
     });
 
+    it('shows "try again" (unavailable), not "not found", on an infra failure', async () => {
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'unavailable' });
+
+      const context = createMockContext({ character: 'lilith' });
+      await handleIncognitoDisable(context);
+
+      expect(mockEditReply).toHaveBeenCalledWith({
+        content: expect.stringContaining('Autocomplete was unavailable'),
+      });
+      expect(stub.disableIncognito).not.toHaveBeenCalled();
+    });
+
     it('should handle API error', async () => {
-      mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
       stub.disableIncognito.mockResolvedValue(makeErr(500, 'Server error'));
 
       const context = createMockContext({ character: 'lilith' });
@@ -502,7 +528,7 @@ describe('Memory Incognito Handlers', () => {
 
   describe('handleIncognitoForget', () => {
     it('should delete recent memories successfully', async () => {
-      mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
       mockGetPersonalityName.mockResolvedValue('Lilith');
       stub.incognitoForget.mockResolvedValue(
         makeOk({
@@ -545,7 +571,7 @@ describe('Memory Incognito Handlers', () => {
     });
 
     it('should show info when no memories found', async () => {
-      mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
       mockGetPersonalityName.mockResolvedValue('Lilith');
       stub.incognitoForget.mockResolvedValue(
         makeOk({
@@ -565,7 +591,7 @@ describe('Memory Incognito Handlers', () => {
     });
 
     it('should handle personality not found', async () => {
-      mockResolvePersonalityId.mockResolvedValue(null);
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'not-found' });
 
       const context = createMockContext({ character: 'unknown' });
       await handleIncognitoForget(context);
@@ -576,8 +602,20 @@ describe('Memory Incognito Handlers', () => {
       expect(stub.incognitoForget).not.toHaveBeenCalled();
     });
 
+    it('shows "try again" (unavailable), not "not found", on an infra failure', async () => {
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'unavailable' });
+
+      const context = createMockContext({ character: 'lilith', timeframe: '5m' });
+      await handleIncognitoForget(context);
+
+      expect(mockEditReply).toHaveBeenCalledWith({
+        content: expect.stringContaining('Autocomplete was unavailable'),
+      });
+      expect(stub.incognitoForget).not.toHaveBeenCalled();
+    });
+
     it('should handle API error', async () => {
-      mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
       stub.incognitoForget.mockResolvedValue(makeErr(500, 'Server error'));
 
       const context = createMockContext({ character: 'lilith' });

--- a/services/bot-client/src/commands/memory/incognito.ts
+++ b/services/bot-client/src/commands/memory/incognito.ts
@@ -56,24 +56,52 @@ function formatSessionInfo(session: SessionWithTime, personalityName?: string): 
 }
 
 /**
- * Resolve personality input to ID, handling 'all' specially
- * @returns { id: personality UUID or 'all', name: display name or null }
+ * Resolve the incognito `character` option (a slug/ID, or the literal "all") to
+ * a target, replying with the right error and returning `null` on the failure
+ * shapes. Shared by enable / disable / forget, which all accept the same
+ * "or all" input. Distinguishes a genuine miss ("not found") from an infra
+ * failure fetching the personality list ("try again") — collapsing both to a
+ * false "not found" was the infra-vs-negative bug.
+ *
+ * @returns the resolved `{ id, name }` (id is a UUID or the literal `'all'`), or
+ *   `null` after having ALREADY replied (sentinel / not-found / unavailable).
+ *   Callers MUST return early on `null` to avoid a double Discord reply.
  */
-async function resolvePersonalityOrAll(
+async function resolveIncognitoTargetOrReply(
+  context: DeferredCommandContext,
   userClient: UserClient,
   personalityInput: string
 ): Promise<{ id: string; name: string | null } | null> {
+  if (isAutocompleteErrorSentinel(personalityInput)) {
+    await context.editReply({ content: AUTOCOMPLETE_UNAVAILABLE_MESSAGE });
+    return null;
+  }
+
   if (personalityInput.toLowerCase() === 'all') {
     return { id: 'all', name: ALL_PERSONALITIES_LABEL };
   }
 
-  const personalityId = await resolvePersonalityId(userClient, personalityInput);
-  if (personalityId === null) {
-    return null;
+  const resolved = await resolvePersonalityId(userClient, personalityInput);
+  switch (resolved.kind) {
+    case 'found': {
+      const name = await getPersonalityName(userClient, resolved.id);
+      return { id: resolved.id, name };
+    }
+    case 'unavailable':
+      // Infra failure fetching the personality list — "try again", not "not found".
+      await context.editReply({ content: AUTOCOMPLETE_UNAVAILABLE_MESSAGE });
+      return null;
+    case 'not-found':
+      await context.editReply({
+        content: `❌ Character "${escapeMarkdown(personalityInput)}" not found. Use autocomplete to select a valid character, or type "all" for all characters.`,
+      });
+      return null;
+    default: {
+      // Exhaustiveness guard: a new ResolvedPersonality kind fails to compile here.
+      const _exhaustive: never = resolved;
+      return _exhaustive;
+    }
   }
-
-  const name = await getPersonalityName(userClient, personalityId);
-  return { id: personalityId, name };
 }
 
 /**
@@ -86,18 +114,9 @@ export async function handleIncognitoEnable(context: DeferredCommandContext): Pr
   const personalityInput = options.character();
   const duration = options.duration() as IncognitoDuration;
 
-  if (isAutocompleteErrorSentinel(personalityInput)) {
-    await context.editReply({ content: AUTOCOMPLETE_UNAVAILABLE_MESSAGE });
-    return;
-  }
-
   try {
-    const resolved = await resolvePersonalityOrAll(userClient, personalityInput);
-
+    const resolved = await resolveIncognitoTargetOrReply(context, userClient, personalityInput);
     if (resolved === null) {
-      await context.editReply({
-        content: `❌ Character "${personalityInput}" not found. Use autocomplete to select a valid character, or type "all" for all characters.`,
-      });
       return;
     }
 
@@ -142,18 +161,9 @@ export async function handleIncognitoDisable(context: DeferredCommandContext): P
   const options = memoryIncognitoDisableOptions(context.interaction);
   const personalityInput = options.character();
 
-  if (isAutocompleteErrorSentinel(personalityInput)) {
-    await context.editReply({ content: AUTOCOMPLETE_UNAVAILABLE_MESSAGE });
-    return;
-  }
-
   try {
-    const resolved = await resolvePersonalityOrAll(userClient, personalityInput);
-
+    const resolved = await resolveIncognitoTargetOrReply(context, userClient, personalityInput);
     if (resolved === null) {
-      await context.editReply({
-        content: `❌ Character "${personalityInput}" not found. Use autocomplete to select a valid character, or type "all" for all characters.`,
-      });
       return;
     }
 
@@ -252,18 +262,9 @@ export async function handleIncognitoForget(context: DeferredCommandContext): Pr
   const personalityInput = options.character();
   const timeframe = options.timeframe();
 
-  if (isAutocompleteErrorSentinel(personalityInput)) {
-    await context.editReply({ content: AUTOCOMPLETE_UNAVAILABLE_MESSAGE });
-    return;
-  }
-
   try {
-    const resolved = await resolvePersonalityOrAll(userClient, personalityInput);
-
+    const resolved = await resolveIncognitoTargetOrReply(context, userClient, personalityInput);
     if (resolved === null) {
-      await context.editReply({
-        content: `❌ Character "${personalityInput}" not found. Use autocomplete to select a valid character, or type "all" for all characters.`,
-      });
       return;
     }
 

--- a/services/bot-client/src/commands/memory/purge.test.ts
+++ b/services/bot-client/src/commands/memory/purge.test.ts
@@ -164,7 +164,7 @@ beforeEach(() => {
 
 describe('handlePurge (slash command entry)', () => {
   it('shows error when personality not found', async () => {
-    mockResolvePersonalityId.mockResolvedValue(null);
+    mockResolvePersonalityId.mockResolvedValue({ kind: 'not-found' });
     const context = createMockContext('unknown-personality');
 
     await handlePurge(context);
@@ -174,8 +174,20 @@ describe('handlePurge (slash command entry)', () => {
     });
   });
 
+  it('shows "try again" (unavailable), not "not found", when the personality list is unavailable', async () => {
+    mockResolvePersonalityId.mockResolvedValue({ kind: 'unavailable' });
+    const context = createMockContext('lilith');
+
+    await handlePurge(context);
+
+    expect(context.editReply).toHaveBeenCalledWith({
+      content: expect.stringContaining('Autocomplete was unavailable'),
+    });
+    expect(stub.getStats).not.toHaveBeenCalled();
+  });
+
   it('shows error when stats API fails', async () => {
-    mockResolvePersonalityId.mockResolvedValue(PERSONALITY_ID);
+    mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: PERSONALITY_ID });
     stub.getStats.mockResolvedValue(makeErr(500, 'Server error'));
     const context = createMockContext();
 
@@ -187,7 +199,7 @@ describe('handlePurge (slash command entry)', () => {
   });
 
   it('shows 404 message when personality not in stats', async () => {
-    mockResolvePersonalityId.mockResolvedValue(PERSONALITY_ID);
+    mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: PERSONALITY_ID });
     stub.getStats.mockResolvedValue(makeErr(404, 'Not found'));
     const context = createMockContext();
 
@@ -199,7 +211,7 @@ describe('handlePurge (slash command entry)', () => {
   });
 
   it('shows "no memories" message when nothing to purge', async () => {
-    mockResolvePersonalityId.mockResolvedValue(PERSONALITY_ID);
+    mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: PERSONALITY_ID });
     stub.getStats.mockResolvedValue(
       makeOk({
         personalityId: PERSONALITY_ID,
@@ -222,7 +234,7 @@ describe('handlePurge (slash command entry)', () => {
   });
 
   it('renders warning embed + buttons (does NOT awaitMessageComponent)', async () => {
-    mockResolvePersonalityId.mockResolvedValue(PERSONALITY_ID);
+    mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: PERSONALITY_ID });
     stub.getStats.mockResolvedValue(
       makeOk({
         personalityId: PERSONALITY_ID,

--- a/services/bot-client/src/commands/memory/resolveHelpers.test.ts
+++ b/services/bot-client/src/commands/memory/resolveHelpers.test.ts
@@ -60,7 +60,7 @@ describe('resolveOptionalPersonality', () => {
   });
 
   it('should return resolved ID when personality is found', async () => {
-    mockResolvePersonalityId.mockResolvedValue('personality-uuid');
+    mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid' });
 
     const user = mkUser();
     const result = await resolveOptionalPersonality(context, user, 'my-persona');
@@ -69,13 +69,21 @@ describe('resolveOptionalPersonality', () => {
   });
 
   it('should return null and send error reply when personality is not found', async () => {
-    mockResolvePersonalityId.mockResolvedValue(null);
+    mockResolvePersonalityId.mockResolvedValue({ kind: 'not-found' });
 
     const result = await resolveOptionalPersonality(context, mkUser(), 'unknown');
     expect(result).toBeNull();
     expect(mockEditReply).toHaveBeenCalledWith({
       content: '❌ Character "unknown" not found. Use autocomplete to select a valid character.',
     });
+  });
+
+  it('returns null and sends autocomplete-unavailable reply when the list is unavailable (infra)', async () => {
+    mockResolvePersonalityId.mockResolvedValue({ kind: 'unavailable' });
+
+    const result = await resolveOptionalPersonality(context, mkUser(), 'my-persona');
+    expect(result).toBeNull();
+    expect(mockEditReply).toHaveBeenCalledWith({ content: AUTOCOMPLETE_UNAVAILABLE_MESSAGE });
   });
 
   // Guards the sentinel path so the user gets "autocomplete unavailable"
@@ -106,7 +114,7 @@ describe('resolveRequiredPersonality', () => {
   });
 
   it('should return resolved ID when personality is found', async () => {
-    mockResolvePersonalityId.mockResolvedValue('personality-uuid');
+    mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid' });
 
     const user = mkUser();
     const result = await resolveRequiredPersonality(context, user, 'my-persona');
@@ -115,7 +123,7 @@ describe('resolveRequiredPersonality', () => {
   });
 
   it('should return null and send error reply when personality is not found', async () => {
-    mockResolvePersonalityId.mockResolvedValue(null);
+    mockResolvePersonalityId.mockResolvedValue({ kind: 'not-found' });
 
     const result = await resolveRequiredPersonality(context, mkUser(), 'unknown');
     expect(result).toBeNull();
@@ -124,8 +132,16 @@ describe('resolveRequiredPersonality', () => {
     });
   });
 
+  it('returns null and sends autocomplete-unavailable reply when the list is unavailable (infra)', async () => {
+    mockResolvePersonalityId.mockResolvedValue({ kind: 'unavailable' });
+
+    const result = await resolveRequiredPersonality(context, mkUser(), 'my-persona');
+    expect(result).toBeNull();
+    expect(mockEditReply).toHaveBeenCalledWith({ content: AUTOCOMPLETE_UNAVAILABLE_MESSAGE });
+  });
+
   it('should not send error reply on success', async () => {
-    mockResolvePersonalityId.mockResolvedValue('personality-uuid');
+    mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid' });
 
     await resolveRequiredPersonality(context, mkUser(), 'my-persona');
     expect(mockEditReply).not.toHaveBeenCalled();

--- a/services/bot-client/src/commands/memory/resolveHelpers.ts
+++ b/services/bot-client/src/commands/memory/resolveHelpers.ts
@@ -5,6 +5,7 @@
  * used across browse, search, stats, purge, and focus commands.
  */
 
+import { escapeMarkdown } from 'discord.js';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import {
   AUTOCOMPLETE_UNAVAILABLE_MESSAGE,
@@ -14,15 +15,58 @@ import type { UserClient } from '@tzurot/clients';
 import { resolvePersonalityId } from './autocomplete.js';
 
 /**
+ * Shared resolve-or-reply core. Maps a {@link ResolvedPersonality} to either the
+ * UUID or a user-facing error reply (returning `null`). Distinguishes the two
+ * failure shapes the infra-vs-negative fix introduced:
+ *   - `not-found` → definitive "❌ Character X not found"
+ *   - `unavailable` → "try again" ({@link AUTOCOMPLETE_UNAVAILABLE_MESSAGE}) —
+ *     the personality list couldn't be fetched, so we must NOT claim the
+ *     character doesn't exist.
+ *
+ * The `switch` is exhaustive by design: adding a new `ResolvedPersonality` kind
+ * makes this fail to compile (no trailing return), forcing the caller wording
+ * to be considered. Both wrappers below delegate here; they differ only in how
+ * they treat empty input.
+ */
+async function resolveOrReply(
+  context: DeferredCommandContext,
+  userClient: UserClient,
+  personalityInput: string
+): Promise<string | null> {
+  if (isAutocompleteErrorSentinel(personalityInput)) {
+    await context.editReply({ content: AUTOCOMPLETE_UNAVAILABLE_MESSAGE });
+    return null;
+  }
+
+  const resolved = await resolvePersonalityId(userClient, personalityInput);
+  switch (resolved.kind) {
+    case 'found':
+      return resolved.id;
+    case 'unavailable':
+      await context.editReply({ content: AUTOCOMPLETE_UNAVAILABLE_MESSAGE });
+      return null;
+    case 'not-found':
+      await context.editReply({
+        content: `❌ Character "${escapeMarkdown(personalityInput)}" not found. Use autocomplete to select a valid character.`,
+      });
+      return null;
+    default: {
+      // Exhaustiveness guard: a new ResolvedPersonality kind fails to compile here.
+      const _exhaustive: never = resolved;
+      return _exhaustive;
+    }
+  }
+}
+
+/**
  * Resolve an optional personality input to an ID.
  *
  * **Important contract**: on resolution failure, this function calls
- * `context.editReply` itself to surface the "not found" error to the
- * user, then returns `null`. Callers MUST return early when they see
- * `null` — sending a second reply via `editReply` would cause Discord
- * to reject the duplicate and the user would see "This interaction
- * failed." The error reply is handled here to centralize the
- * user-facing wording across browse, search, stats, purge, and focus.
+ * `context.editReply` itself to surface the error to the user, then returns
+ * `null`. Callers MUST return early when they see `null` — sending a second
+ * reply via `editReply` would cause Discord to reject the duplicate and the user
+ * would see "This interaction failed." The error reply is handled here to
+ * centralize the user-facing wording across browse, search, stats, purge, and focus.
  *
  * @returns one of:
  *   - `undefined` — input was null/empty, no filter to apply
@@ -40,48 +84,27 @@ export async function resolveOptionalPersonality(
     return undefined;
   }
 
-  if (isAutocompleteErrorSentinel(personalityInput)) {
-    await context.editReply({ content: AUTOCOMPLETE_UNAVAILABLE_MESSAGE });
-    return null;
-  }
-
-  const resolved = await resolvePersonalityId(userClient, personalityInput);
-  if (resolved === null) {
-    await context.editReply({
-      content: `❌ Character "${personalityInput}" not found. Use autocomplete to select a valid character.`,
-    });
-    return null;
-  }
-
-  return resolved;
+  return resolveOrReply(context, userClient, personalityInput);
 }
 
 /**
  * Resolve a required personality input to an ID.
  *
  * Same null-means-replied contract as {@link resolveOptionalPersonality}:
- * on failure, this function sends an error reply via `context.editReply`
- * and returns `null`. Callers MUST return early without sending any
- * further reply to avoid Discord's double-reply rejection.
+ * on failure, this function sends an error reply via `context.editReply` and
+ * returns `null`. The reply distinguishes a genuine miss ("not found") from an
+ * infra failure ("try again") — see {@link resolveOrReply}. Callers MUST return
+ * early on `null` without sending any further reply to avoid Discord's
+ * double-reply rejection.
  *
- * @returns The resolved personality UUID on success, or `null` if
- *   resolution failed (in which case the error reply has already been sent).
+ * @returns The resolved personality UUID on success, or `null` if resolution
+ *   failed (in which case the error reply — "not found" or "try again" — has
+ *   already been sent).
  */
 export async function resolveRequiredPersonality(
   context: DeferredCommandContext,
   userClient: UserClient,
   personalityInput: string
 ): Promise<string | null> {
-  if (isAutocompleteErrorSentinel(personalityInput)) {
-    await context.editReply({ content: AUTOCOMPLETE_UNAVAILABLE_MESSAGE });
-    return null;
-  }
-
-  const resolved = await resolvePersonalityId(userClient, personalityInput);
-  if (resolved === null) {
-    await context.editReply({
-      content: `❌ Character "${personalityInput}" not found. Use autocomplete to select a valid character.`,
-    });
-  }
-  return resolved;
+  return resolveOrReply(context, userClient, personalityInput);
 }

--- a/services/bot-client/src/commands/memory/stats.test.ts
+++ b/services/bot-client/src/commands/memory/stats.test.ts
@@ -75,7 +75,7 @@ describe('handleStats', () => {
   }
 
   it('should get stats successfully', async () => {
-    mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
+    mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
     stub.getStats.mockResolvedValue(
       makeOk({
         personalityId: 'personality-uuid-123',
@@ -106,7 +106,7 @@ describe('handleStats', () => {
   it('should show focus mode active indicator', async () => {
     const mockEmbed = { addFields: vi.fn().mockReturnThis() };
     mockCreateInfoEmbed.mockReturnValue(mockEmbed);
-    mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
+    mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
 
     stub.getStats.mockResolvedValue(
       makeOk({
@@ -133,7 +133,7 @@ describe('handleStats', () => {
   it('should show no profile message when personaId is null', async () => {
     const mockEmbed = { addFields: vi.fn().mockReturnThis() };
     mockCreateInfoEmbed.mockReturnValue(mockEmbed);
-    mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
+    mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
 
     stub.getStats.mockResolvedValue(
       makeOk({
@@ -167,7 +167,7 @@ describe('handleStats', () => {
   });
 
   it('should handle personality not found from resolver', async () => {
-    mockResolvePersonalityId.mockResolvedValue(null);
+    mockResolvePersonalityId.mockResolvedValue({ kind: 'not-found' });
 
     const context = createMockContext('unknown');
     await handleStats(context);
@@ -178,8 +178,20 @@ describe('handleStats', () => {
     expect(stub.getStats).not.toHaveBeenCalled();
   });
 
+  it('shows "try again" (unavailable), not "not found", when the personality list is unavailable', async () => {
+    mockResolvePersonalityId.mockResolvedValue({ kind: 'unavailable' });
+
+    const context = createMockContext('lilith');
+    await handleStats(context);
+
+    expect(mockEditReply).toHaveBeenCalledWith({
+      content: expect.stringContaining('Autocomplete was unavailable'),
+    });
+    expect(stub.getStats).not.toHaveBeenCalled();
+  });
+
   it('should handle personality not found (404)', async () => {
-    mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
+    mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
     stub.getStats.mockResolvedValue(makeErr(404, 'Not found'));
 
     const context = createMockContext('unknown');
@@ -191,7 +203,7 @@ describe('handleStats', () => {
   });
 
   it('should handle generic API error', async () => {
-    mockResolvePersonalityId.mockResolvedValue('personality-uuid-123');
+    mockResolvePersonalityId.mockResolvedValue({ kind: 'found', id: 'personality-uuid-123' });
     stub.getStats.mockResolvedValue(makeErr(500, 'Server error'));
 
     const context = createMockContext();


### PR DESCRIPTION
## What

Loader **4/4** (final) of the infra-vs-negative bug-class sweep. `resolvePersonalityId` collapsed a gateway **failure** fetching the personality list into the same `null` as a genuine miss, so every `/memory` subcommand (browse/search/stats/purge/focus/incognito/delete) showed **"Character not found"** when the gateway was unreachable.

## Why this one is different from loaders 1–3

The earlier loaders had to *create* the infra/negative distinction from a bare `!ok` collapse. Here it **already existed** one layer down — `getCachedPersonalities` returns an `ApiCheck` whose `error` variant *is* an infra failure (a successful fetch returns `ok` with a possibly-empty list). The bug was a lossy **re-flattening** in `resolvePersonalityId`. So this fix adds **zero new error infrastructure** — it just stops discarding the distinction.

## Change

`resolvePersonalityId` now returns a compiler-forced tri-state:

```ts
type ResolvedPersonality =
  | { kind: 'found'; id: string }
  | { kind: 'not-found' }    // list loaded, input matched nothing → "❌ not found"
  | { kind: 'unavailable' }; // list fetch failed → AUTOCOMPLETE_UNAVAILABLE_MESSAGE ("try again")
```

Callers switch exhaustively (a new kind fails to compile). `getPersonalityName` stays **lenient** — display-only, a null name is acceptable.

### Duplication cleanup (bundled)

The three failure shapes (sentinel / not-found / unavailable) are handled once, not per-caller:
- **`resolveOrReply`** in `resolveHelpers.ts` — used by browse/search/stats/purge/focus, and **`batchDelete` now uses it too** (it had duplicated the sentinel + not-found block).
- **`resolveIncognitoTargetOrReply`** in `incognito.ts` — folds the sentinel + "or all" + 3-way reply shared by enable/disable/forget.

## Tests

- `autocomplete.test` — `resolvePersonalityId` producer tests assert the tri-state (found/not-found/**unavailable** on cache error).
- `resolveHelpers.test` — added `unavailable` → "try again" for both wrappers.
- `incognito.test` — added `unavailable` for its own helper.
- `batchDelete`/`focus`/`stats`/`purge` — mock shapes updated to the tri-state; `batchDelete` keeps the resolve inside its try so an unexpected throw still degrades gracefully.

277 memory-package tests pass; `pnpm quality` green (incl. cpd — the shared helpers *reduce* duplication).