### PR TITLE
fix(bot-client): deny/permissions distinguishes infra failure from "not found"

### DIFF
--- a/packages/clients/src/clients/resultHelpers.ts
+++ b/packages/clients/src/clients/resultHelpers.ts
@@ -92,8 +92,13 @@ export class GatewayClientError extends Error {
  * non-HTTP kind (`network`/`timeout`/`config`/`schema`, `status: 0`) or an HTTP
  * 5xx. An HTTP 4xx is a CLIENT error — the request was rejected, so retrying the
  * same request won't help; those become {@link GatewayClientError}.
+ *
+ * Exported for non-throwing classification contexts (e.g. permission guards that
+ * return a result rather than throw): callers that can't use {@link nullOn404}'s
+ * throw semantics still need to split "can't reach the server → try again" from
+ * "rejected/absent → definitive error".
  */
-function isInfraFailure(failure: GatewayFailure): boolean {
+export function isInfraFailure(failure: GatewayFailure): boolean {
   return failure.kind !== 'http' || failure.status >= 500;
 }
 

--- a/services/bot-client/src/commands/deny/permissions.test.ts
+++ b/services/bot-client/src/commands/deny/permissions.test.ts
@@ -215,6 +215,20 @@ describe('checkDenyPermission', () => {
       expect(context.editReply).toHaveBeenCalledWith('❌ Character "missing-character" not found.');
     });
 
+    it('denies with a "try again" message (not "not found") on an infra failure', async () => {
+      // A gateway blip (5xx/network) must not read as "the character doesn't exist".
+      stub.getPersonality.mockResolvedValue(makeErr(503, 'Bad gateway'));
+      const context = createMockContext();
+
+      const result = await checkDenyPermission(context, 'PERSONALITY', null, 'lilith');
+
+      expect(result.allowed).toBe(false);
+      expect(context.editReply).toHaveBeenCalledWith(
+        expect.stringContaining('please try again in a moment')
+      );
+      expect(context.editReply).not.toHaveBeenCalledWith(expect.stringContaining('not found'));
+    });
+
     it('should deny when personality option missing', async () => {
       const context = createMockContext();
 

--- a/services/bot-client/src/commands/deny/permissions.ts
+++ b/services/bot-client/src/commands/deny/permissions.ts
@@ -7,7 +7,9 @@
  * 3. Character creators: PERSONALITY scope for characters they own
  */
 
+import { escapeMarkdown } from 'discord.js';
 import { isBotOwner } from '@tzurot/common-types';
+import { isInfraFailure } from '@tzurot/clients';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import { requireManageMessagesContext } from '../../utils/permissions.js';
 import {
@@ -102,7 +104,14 @@ async function checkPersonalityPermission(
   const result = await userClient.getPersonality(personalitySlug);
 
   if (!result.ok) {
-    await context.editReply(`❌ Character "${personalitySlug}" not found.`);
+    // Distinguish "can't reach the gateway" (transient, retryable) from a genuine
+    // not-found / access-denied. A blip must not read as "the character doesn't
+    // exist" — fail safe (still DENIED) but tell the user to retry.
+    await context.editReply(
+      isInfraFailure(result)
+        ? "⚠️ Couldn't reach the server right now — please try again in a moment."
+        : `❌ Character "${escapeMarkdown(personalitySlug)}" not found.`
+    );
     return DENIED;
   }
 

--- a/services/bot-client/src/commands/memory/focus.test.ts
+++ b/services/bot-client/src/commands/memory/focus.test.ts
@@ -188,6 +188,18 @@ describe('Memory Focus Handlers', () => {
       });
       expect(stub.setFocus).not.toHaveBeenCalled();
     });
+
+    it('shows "try again" (unavailable), not "not found", when the personality list is unavailable', async () => {
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'unavailable' });
+
+      const context = createMockContext('lilith');
+      await handleFocusDisable(context);
+
+      expect(mockEditReply).toHaveBeenCalledWith({
+        content: expect.stringContaining('Autocomplete was unavailable'),
+      });
+      expect(stub.setFocus).not.toHaveBeenCalled();
+    });
   });
 
   describe('handleFocusStatus', () => {
@@ -257,6 +269,18 @@ describe('Memory Focus Handlers', () => {
 
       expect(mockEditReply).toHaveBeenCalledWith({
         content: expect.stringContaining('unknown'),
+      });
+      expect(stub.getFocus).not.toHaveBeenCalled();
+    });
+
+    it('shows "try again" (unavailable), not "not found", when the personality list is unavailable', async () => {
+      mockResolvePersonalityId.mockResolvedValue({ kind: 'unavailable' });
+
+      const context = createMockContext('lilith');
+      await handleFocusStatus(context);
+
+      expect(mockEditReply).toHaveBeenCalledWith({
+        content: expect.stringContaining('Autocomplete was unavailable'),
       });
       expect(stub.getFocus).not.toHaveBeenCalled();
     });

--- a/services/bot-client/src/commands/persona/api.test.ts
+++ b/services/bot-client/src/commands/persona/api.test.ts
@@ -137,6 +137,14 @@ describe('fetchDefaultPersona', () => {
 
     await expect(fetchDefaultPersona(asUserClient(stub), TEST_USER_ID)).rejects.toThrow(InfraError);
   });
+
+  it('throws GatewayClientError on a non-404 4xx (request rejected) — not a silent "no personas"', async () => {
+    stub.listPersonas.mockResolvedValue(makeErr(403, 'Forbidden'));
+
+    await expect(fetchDefaultPersona(asUserClient(stub), TEST_USER_ID)).rejects.toThrow(
+      GatewayClientError
+    );
+  });
 });
 
 describe('updatePersona', () => {
@@ -303,5 +311,13 @@ describe('isDefaultPersona', () => {
     // Old behavior returned false → a transient blip let the default persona be
     // deleted. Now it throws so the delete aborts (caught upstream → "try again").
     await expect(isDefaultPersona(TEST_PERSONA_ID, asUserClient(stub))).rejects.toThrow(InfraError);
+  });
+
+  it('throws GatewayClientError on a non-404 4xx — also fail-CLOSED so the delete aborts', async () => {
+    stub.listPersonas.mockResolvedValue(makeErr(403, 'Forbidden'));
+
+    await expect(isDefaultPersona(TEST_PERSONA_ID, asUserClient(stub))).rejects.toThrow(
+      GatewayClientError
+    );
   });
 });


### PR DESCRIPTION
## What

The **last** user-facing instance of the infra-vs-negative bug class. `deny/permissions`' permission guard collapsed every `getPersonality` failure (infra **or** 404) into `❌ Character "X" not found`. A gateway blip during a `/deny` told the user their character doesn't exist.

## Change

`isInfraFailure` is now **exported** from `@tzurot/clients` — it's the non-throwing classifier for fail-safe guard contexts that can't use `nullOn404`'s throw semantics (a `PermissionResult`-returning guard, not a value-returning load). The guard splits:

- **infra** (5xx / network / timeout) → "⚠️ Couldn't reach the server right now — please try again in a moment."
- **404 / non-404 4xx** → `❌ Character "X" not found.`

Still `DENIED` either way (fail safe), but a transient blip is now retryable rather than a false "doesn't exist." The user-controlled slug is also `escapeMarkdown`'d (consistent with the #1335 fix).

> **Why `isInfraFailure` and not `nullOn404`**: the loaders throw on infra and let the command framework catch it. A permission guard returns a verdict — it can't throw a "try again" into a deny check. `isInfraFailure` is the classifier for that fail-safe posture: can't verify → deny + retryable message.

## Bundled cleanup (beta.137 class-fix loose ends)

- **`persona/api.test`** — `GatewayClientError` (non-404 4xx) coverage for `fetchDefaultPersona` + `isDefaultPersona` (both already covered `InfraError`; the 4xx path was untested).
- **`memory/focus.test`** — `unavailable`-path tests for `handleFocusDisable` / `handleFocusStatus` (symmetry with batchDelete/purge/stats; the non-blocking nit deferred from #1335's review).

## Notes (deliberate non-changes)

- `isDefaultPersona` returns `false` on a `listPersonas` **404** (fail-open) — but `listPersonas` has **no meaningful 404** (empty = `200 []`), so that path is unreachable for a provisioned user. Failing it closed would mean constructing a `GatewayClientError` with status 404, contradicting that type's "non-404 4xx" contract. Left as-is; the reachable 4xx/5xx paths fail closed (tested).

All affected tests green; `pnpm quality` green.