### PR TITLE
feat: envelope contract (golden-fixture) + coverage-topology skeleton

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -28,3 +28,9 @@ backlog/
 # onto single lines, which would permanently break that comparison. Exclude so
 # the generator output stays the source of truth.
 services/bot-client/command-manifest.json
+
+# Cross-service contract fixtures. The producer test (`RawEnvelopeContract.producer.test.ts`,
+# `toMatchFileSnapshot`) compares its `JSON.stringify(…, 2)` output byte-for-byte
+# against these committed files; prettier collapses short arrays onto single lines,
+# breaking that comparison on every regeneration. Same rationale as the manifest above.
+packages/test-utils/fixtures/contracts/

--- a/packages/test-utils/fixtures/contracts/raw-assembly-inputs/base.json
+++ b/packages/test-utils/fixtures/contracts/raw-assembly-inputs/base.json
@@ -1,0 +1,18 @@
+{
+  "rawMessageContent": "hello from the contract test",
+  "rawAuthorDisplayName": "Contract User",
+  "knownChannelEnvironments": {
+    "channel-cross-1": {
+      "type": "guild",
+      "guild": {
+        "id": "guild-1",
+        "name": "Contract Guild"
+      },
+      "channel": {
+        "id": "channel-cross-1",
+        "name": "cross-channel",
+        "type": "GUILD_TEXT"
+      }
+    }
+  }
+}

--- a/packages/test-utils/fixtures/contracts/raw-assembly-inputs/with-extended-context.json
+++ b/packages/test-utils/fixtures/contracts/raw-assembly-inputs/with-extended-context.json
@@ -1,0 +1,46 @@
+{
+  "rawMessageContent": "<@333> with context",
+  "rawAuthorDisplayName": "Contract User",
+  "rawMentionedUsers": [
+    {
+      "discordId": "333",
+      "username": "target",
+      "displayName": "Target"
+    }
+  ],
+  "rawExtendedContextMessages": [
+    {
+      "id": "ext-1",
+      "role": "user",
+      "content": "an earlier message from the channel",
+      "createdAt": "2026-06-01T09:00:00.000Z",
+      "personaId": "discord:444",
+      "discordUsername": "earlier-user",
+      "discordMessageId": [
+        "ext-dm-1"
+      ]
+    }
+  ],
+  "rawExtendedContextUsers": [
+    {
+      "discordId": "444",
+      "username": "earlier-user",
+      "displayName": "Earlier"
+    }
+  ],
+  "rawReactorUsers": [],
+  "knownChannelEnvironments": {
+    "channel-cross-1": {
+      "type": "guild",
+      "guild": {
+        "id": "guild-1",
+        "name": "Contract Guild"
+      },
+      "channel": {
+        "id": "channel-cross-1",
+        "name": "cross-channel",
+        "type": "GUILD_TEXT"
+      }
+    }
+  }
+}

--- a/packages/test-utils/src/contractFixtures.test.ts
+++ b/packages/test-utils/src/contractFixtures.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { existsSync } from 'node:fs';
+import { isAbsolute } from 'node:path';
+import { contractFixtureFile } from './contractFixtures.js';
+
+describe('contractFixtureFile', () => {
+  it('resolves an absolute path to a real committed fixture', () => {
+    const p = contractFixtureFile('raw-assembly-inputs/base.json');
+    expect(p.endsWith('fixtures/contracts/raw-assembly-inputs/base.json')).toBe(true);
+    // Absolute (resolved from this module via import.meta.url), and the file is
+    // actually there — catches a `../fixtures/` path-resolution regression.
+    expect(isAbsolute(p)).toBe(true);
+    expect(existsSync(p)).toBe(true);
+  });
+});

--- a/packages/test-utils/src/contractFixtures.ts
+++ b/packages/test-utils/src/contractFixtures.ts
@@ -1,0 +1,33 @@
+/**
+ * Cross-service contract fixtures.
+ *
+ * A committed JSON fixture under `fixtures/contracts/` IS the contract artifact
+ * between two services that may not import each other (the depcruise
+ * service-boundary rule). The PRODUCER side asserts its real output equals the
+ * committed fixture (`toMatchFileSnapshot`, regenerate-on-purpose); the CONSUMER
+ * side reads the SAME fixture and feeds it to its real code. Neither service
+ * imports the other — they share only this data artifact via `@tzurot/test-utils`.
+ *
+ * Resolves relative to this module (the `loadPGliteSchema` pattern) so it works
+ * whether test-utils runs from `src` (aliased) or `dist`.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Absolute path to a committed contract fixture under
+ * `packages/test-utils/fixtures/contracts/`. `name` is the path beneath that
+ * directory, e.g. `raw-assembly-inputs/base.json`.
+ */
+export function contractFixtureFile(name: string): string {
+  return join(__dirname, '../fixtures/contracts', name);
+}
+
+/** Read + `JSON.parse` a committed contract fixture by its `name` (see above). */
+export function loadContractFixture<T = unknown>(name: string): T {
+  return JSON.parse(readFileSync(contractFixtureFile(name), 'utf-8')) as T;
+}

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -14,3 +14,4 @@ export {
   type TestEnvironment,
 } from './setup-pglite.js';
 export { seedUserWithPersona, type SeedUserWithPersonaOptions } from './seed.js';
+export { contractFixtureFile, loadContractFixture } from './contractFixtures.js';

--- a/packages/tooling/src/cli.ts
+++ b/packages/tooling/src/cli.ts
@@ -32,6 +32,7 @@ import { registerGuardCommands } from './commands/guard.js';
 import { registerVoiceCommands } from './commands/voice.js';
 import { registerCpdCommands } from './commands/cpd.js';
 import { registerCodegenCommands } from './commands/codegen.js';
+import { registerTopologyCommands } from './commands/topology.js';
 
 // Read version from package.json dynamically
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -57,6 +58,7 @@ registerGuardCommands(cli);
 registerVoiceCommands(cli);
 registerCpdCommands(cli);
 registerCodegenCommands(cli);
+registerTopologyCommands(cli);
 
 // Global options
 cli.help();

--- a/packages/tooling/src/commands/topology.ts
+++ b/packages/tooling/src/commands/topology.ts
@@ -1,0 +1,30 @@
+/**
+ * Coverage-topology commands (test-pyramid epic).
+ *
+ * Report-only skeleton: prints the cross-service coverage topology (which test
+ * tiers each surface should/does carry). The full code-derived enumeration +
+ * lockfile-diff + CI ratchet are Phase 2/4, not wired here.
+ */
+
+import type { CAC } from 'cac';
+
+export function registerTopologyCommands(cli: CAC): void {
+  cli
+    .command(
+      'topology:generate',
+      'Print the cross-service coverage topology (report-only skeleton)'
+    )
+    .example('pnpm ops topology:generate')
+    .action(async () => {
+      const { buildCoverageTopology, surfaceGap } = await import('../topology/coverageTopology.js');
+      const topology = buildCoverageTopology();
+      console.log(JSON.stringify(topology, null, 2));
+
+      const gaps = topology.surfaces.filter(s => surfaceGap(s).length > 0);
+      console.log(`\n${topology.surfaces.length} surface(s); ${gaps.length} with a tier gap.`);
+      console.log(
+        'NOTE: skeleton — seeded with 1 proven surface. The full ROUTE_MANIFEST + JobType walk ' +
+          '(deriving actualTiers from tests) is Phase 2 of the test-pyramid epic; report-only, no gate.'
+      );
+    });
+}

--- a/packages/tooling/src/topology/coverageTopology.test.ts
+++ b/packages/tooling/src/topology/coverageTopology.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { buildCoverageTopology, surfaceGap } from './coverageTopology.js';
+
+describe('buildCoverageTopology (skeleton)', () => {
+  it('seeds the context-assembly surface with the contract tier covered', () => {
+    const topology = buildCoverageTopology();
+    expect(topology.schema).toBe('coverage-topology/v0-skeleton');
+
+    const surface = topology.surfaces.find(s => s.id === 'bot-client:ai-worker:context-assembly');
+    expect(surface).toBeDefined();
+    expect(surface?.kind).toBe('context-envelope');
+    expect(surface?.producer).toBe('bot-client');
+    expect(surface?.consumer).toBe('ai-worker');
+    expect(surface?.requiredTiers).toContain('contract');
+    // The golden-fixture contract covers the required tier → no gap.
+    expect(surfaceGap(surface!)).toEqual([]);
+  });
+});
+
+describe('surfaceGap', () => {
+  it('lists required tiers not present in actual', () => {
+    expect(
+      surfaceGap({
+        id: 'x',
+        kind: 'bullmq-job',
+        producer: 'a',
+        consumer: 'b',
+        schemaRef: 's',
+        requiredTiers: ['contract', 'component'],
+        actualTiers: ['component'],
+      })
+    ).toEqual(['contract']);
+  });
+});

--- a/packages/tooling/src/topology/coverageTopology.ts
+++ b/packages/tooling/src/topology/coverageTopology.ts
@@ -1,0 +1,76 @@
+/**
+ * Coverage topology — SKELETON (test-pyramid epic, Phase-3 seed).
+ *
+ * The cross-service "surfaces" a tier-coverage audit should track — HTTP
+ * route-manifest entries + BullMQ job payloads + the context-assembly envelope —
+ * each with the test tiers it SHOULD carry vs. what it currently HAS. This is
+ * the data shape the eventual `test:tier-audit` ratchet (Phase 4) gates on and
+ * the lockfile the discovery generator (Phase 2) regenerates from code.
+ *
+ * This skeleton is REPORT-ONLY and hand-seeded with one proven surface
+ * (the bot-client→ai-worker context-assembly envelope) to prove the shape. The
+ * full enumeration — walking `ROUTE_MANIFEST` (@tzurot/clients) + every `JobType`
+ * (@tzurot/common-types) and deriving `actualTiers` from the test files — is
+ * Phase 2's discovery generator, not built here.
+ */
+
+import type { TestTier } from '../test/test-tiers.js';
+
+export type CoverageSurfaceKind = 'http-route' | 'bullmq-job' | 'context-envelope';
+
+export interface CoverageSurface {
+  /** Stable id, e.g. `bot-client:ai-worker:context-assembly`. */
+  id: string;
+  kind: CoverageSurfaceKind;
+  producer: string;
+  consumer: string;
+  /** The shared schema/type that IS the contract artifact. */
+  schemaRef: string;
+  /** Tiers this surface SHOULD carry. */
+  requiredTiers: TestTier[];
+  /** Tiers it currently HAS (Phase 2's generator will derive this from tests). */
+  actualTiers: TestTier[];
+}
+
+export interface CoverageTopology {
+  schema: 'coverage-topology/v0-skeleton';
+  surfaces: CoverageSurface[];
+}
+
+/** The required tiers a surface is MISSING (empty = fully covered). */
+export function surfaceGap(surface: CoverageSurface): TestTier[] {
+  return surface.requiredTiers.filter(tier => !surface.actualTiers.includes(tier));
+}
+
+/**
+ * Build the skeleton topology — seeded with one proven cross-service surface
+ * (the context-assembly envelope). NOTE: `actualTiers` is hand-coded for the
+ * skeleton; Phase 2 replaces this builder with code-derivation (deriving the
+ * tiers each surface HAS from the test files), so the seeded values are a
+ * placeholder to be regenerated, not a maintained source of truth.
+ */
+export function buildCoverageTopology(): CoverageTopology {
+  return {
+    schema: 'coverage-topology/v0-skeleton',
+    surfaces: [
+      {
+        id: 'bot-client:ai-worker:context-assembly',
+        kind: 'context-envelope',
+        producer: 'bot-client',
+        consumer: 'ai-worker',
+        schemaRef: 'rawAssemblyInputsSchema',
+        requiredTiers: ['contract'],
+        // The `contract` tier here is provided by the GOLDEN-FIXTURE mechanism —
+        // a producer guard (RawEnvelopeContract.producer.test.ts, a unit-suffix
+        // file) + consumer derivation over the committed fixture
+        // (RawEnvelopeContract.consumer.component.test.ts, a component-suffix
+        // file) — NOT a `*.contract.test.ts` file. So Phase 2's suffix-based
+        // classifyTestFile would naively derive ['unit', 'component'] and report
+        // a FALSE `contract` gap on this surface. Phase 2 must recognize
+        // golden-fixture contracts (e.g. a per-surface mechanism marker) instead
+        // of relying on the file suffix alone — see the builder doc above.
+        actualTiers: ['contract', 'component', 'unit'],
+      },
+    ],
+  };
+}

--- a/services/ai-worker/src/services/context/RawEnvelopeContract.consumer.component.test.ts
+++ b/services/ai-worker/src/services/context/RawEnvelopeContract.consumer.component.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Consumer half of the bot-client→ai-worker context-assembly contract.
+ *
+ * Reads the SAME committed fixtures the bot-client producer test
+ * (`RawEnvelopeContract.producer.test.ts`) generates, parses them through
+ * `rawAssemblyInputsSchema`, and feeds them to the REAL `ContextAssembler`
+ * over PGLite. The committed fixture IS the contract artifact: producer proves
+ * "real output === fixture"; this proves "real consumer derives correctly from
+ * that same fixture." Neither service imports the other — they share the data
+ * artifact via `@tzurot/test-utils` (see `contractFixtures.ts`). This closes the
+ * seam the isolated pilot tests don't cross: a field the producer emits in a
+ * shape the schema permits but the consumer mishandles now fails HERE.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  PrismaClient,
+  generateUserUuid,
+  generatePersonaUuid,
+  generatePersonalityUuid,
+  generateSystemPromptUuid,
+  rawAssemblyInputsSchema,
+  type JobContext,
+  type LoadedPersonality,
+} from '@tzurot/common-types';
+import { UserService, PersonaResolver } from '@tzurot/identity';
+import {
+  createTestPGlite,
+  loadPGliteSchema,
+  seedUserWithPersona,
+  loadContractFixture,
+} from '@tzurot/test-utils';
+import type { PGlite } from '@electric-sql/pglite';
+import { PrismaPGlite } from 'pglite-prisma-adapter';
+import { ContextAssembler } from './ContextAssembler.js';
+import { PrismaContextDataSource } from './PrismaContextDataSource.js';
+
+const DISCORD_USER_ID = '123456789012345678';
+const CHANNEL_ID = 'test-channel-987';
+const GUILD_ID = 'test-guild-654';
+
+/** Parse a committed contract fixture through the real wire schema. */
+const fixtureEnvelope = (name: string) =>
+  rawAssemblyInputsSchema.parse(loadContractFixture(`raw-assembly-inputs/${name}.json`));
+
+describe('RawEnvelope contract — consumer derivation over PGLite', () => {
+  let prisma: PrismaClient;
+  let pglite: PGlite;
+  let assembler: ContextAssembler;
+  let userId: string;
+  let personality: LoadedPersonality;
+
+  beforeAll(async () => {
+    pglite = createTestPGlite();
+    await pglite.exec(loadPGliteSchema());
+    prisma = new PrismaClient({ adapter: new PrismaPGlite(pglite) }) as PrismaClient;
+
+    userId = generateUserUuid(DISCORD_USER_ID);
+    await seedUserWithPersona(prisma, {
+      userId,
+      personaId: generatePersonaUuid('contract-user', userId),
+      discordId: DISCORD_USER_ID,
+      username: 'contract-user',
+      personaName: 'contract-user',
+    });
+    await prisma.user.update({ where: { id: userId }, data: { timezone: 'America/New_York' } });
+
+    const systemPrompt = await prisma.systemPrompt.create({
+      data: {
+        id: generateSystemPromptUuid('contract-prompt'),
+        name: 'contract-prompt',
+        content: 'You are a test assistant.',
+      },
+    });
+    const personalityId = generatePersonalityUuid('contract-bot');
+    await prisma.personality.create({
+      data: {
+        id: personalityId,
+        name: 'ContractBot',
+        slug: 'contract-bot',
+        displayName: 'Contract Bot',
+        systemPromptId: systemPrompt.id,
+        ownerId: userId,
+        characterInfo: 'A test bot',
+        personalityTraits: 'Deterministic',
+      },
+    });
+    // Only id/name are read by assembleCore here; the narrow cast is intentional
+    // (mirrors ContextAssembler.component.test.ts).
+    personality = { id: personalityId, name: 'ContractBot' } as LoadedPersonality;
+
+    assembler = new ContextAssembler({
+      dataSource: new PrismaContextDataSource(prisma),
+      userService: new UserService(prisma),
+      personaResolver: new PersonaResolver(prisma),
+    });
+  }, 30000);
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+    await pglite.close();
+  }, 30000);
+
+  const jobContext = (rawAssemblyInputs: JobContext['rawAssemblyInputs']): JobContext =>
+    ({
+      userId: DISCORD_USER_ID,
+      userName: 'contract-user',
+      channelId: CHANNEL_ID,
+      serverId: GUILD_ID,
+      rawAssemblyInputs,
+    }) as JobContext;
+
+  it('base fixture: trigger content passes through + identity resolves from DB', async () => {
+    const core = await assembler.assembleCore(
+      jobContext(fixtureEnvelope('base')),
+      personality,
+      undefined
+    );
+
+    // The producer's rawMessageContent drives the consumer's messageContent.
+    expect(core.messageContent).toBe('hello from the contract test');
+    // The consumer resolves the real seeded identity around the envelope.
+    expect(core.userInternalId).toBe(userId);
+    expect(core.userTimezone).toBe('America/New_York');
+  });
+
+  it('with-extended-context fixture: envelope extended-context merges into assembled history', async () => {
+    const core = await assembler.assembleCore(
+      jobContext(fixtureEnvelope('with-extended-context')),
+      personality,
+      undefined
+    );
+
+    // The producer's rawExtendedContextMessages are merged into the assembled
+    // history — the key derivation this envelope field enables.
+    expect(core.history.map(m => m.content)).toContain('an earlier message from the channel');
+    // The producer's rawMessageContent still drives the consumer's messageContent.
+    // (Mention-token REWRITING is summon-mode- and personality-dependent — the
+    // mention kernel's domain, covered by mentionRewriter's own tests — not the
+    // envelope→consumer seam this contract locks.)
+    expect(core.messageContent).toContain('with context');
+  });
+});

--- a/services/bot-client/src/services/contextBuilder/RawEnvelopeContract.producer.test.ts
+++ b/services/bot-client/src/services/contextBuilder/RawEnvelopeContract.producer.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Producer half of the bot-client→ai-worker context-assembly contract.
+ *
+ * Runs the REAL `buildRawAssemblyInputs` and snapshots its output to committed
+ * JSON fixtures under `@tzurot/test-utils` (`fixtures/contracts/raw-assembly-inputs/`).
+ * `--update` regenerates the fixtures; CI COMPARES (strict). Drift → CI fails →
+ * regenerate-on-purpose and commit the diff.
+ *
+ * The ai-worker consumer test (`RawEnvelopeContract.consumer.component.test.ts`)
+ * reads these SAME fixtures and feeds them to the real `ContextAssembler`. The
+ * committed fixture IS the contract artifact — the two services share data, not
+ * code, so neither imports the other (depcruise boundary stays intact). See
+ * `packages/test-utils/src/contractFixtures.ts` for the rationale.
+ *
+ * The two producer internals (`VoiceMessageProcessor.getVoiceTranscript`,
+ * `buildKnownChannelEnvironments`) are mocked deterministically — natural here,
+ * colocated in bot-client, exactly as the pilot `RawEnvelopeBuilder.test.ts` does.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { contractFixtureFile } from '@tzurot/test-utils';
+import { MessageRole, type ConversationMessage } from '@tzurot/common-types';
+import type { Message } from 'discord.js';
+
+const { mockGetVoiceTranscript } = vi.hoisted(() => ({
+  mockGetVoiceTranscript: vi.fn((): string | undefined => undefined),
+}));
+vi.mock('../../processors/VoiceMessageProcessor.js', () => ({
+  VoiceMessageProcessor: { getVoiceTranscript: mockGetVoiceTranscript },
+}));
+vi.mock('../CrossChannelHistoryFetcher.js', () => ({
+  buildKnownChannelEnvironments: vi.fn(() => ({
+    'channel-cross-1': {
+      type: 'guild',
+      guild: { id: 'guild-1', name: 'Contract Guild' },
+      channel: { id: 'channel-cross-1', name: 'cross-channel', type: 'GUILD_TEXT' },
+    },
+  })),
+}));
+
+import { buildRawAssemblyInputs } from './RawEnvelopeBuilder.js';
+
+const makeMessage = (
+  mentions: { id: string; username: string; globalName?: string }[],
+  content: string
+): Message =>
+  ({
+    client: {},
+    content,
+    mentions: { users: new Map(mentions.map(m => [m.id, m])) },
+  }) as unknown as Message;
+
+/** Stable, pretty JSON (trailing newline) so the committed fixture is diff-clean. */
+const stableJson = (v: unknown): string => `${JSON.stringify(v, null, 2)}\n`;
+
+describe('RawEnvelope contract — producer fixture generation', () => {
+  // Per 02-code-standards "Fake Timers (ALWAYS Use)". This test uses no timers
+  // and only an explicit fixed date string (not Date.now()/argless new Date()),
+  // so faking is a no-op on the output — present for rule-consistency.
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('base: plain text trigger (no extended context)', async () => {
+    const envelope = buildRawAssemblyInputs(
+      makeMessage([], 'hello from the contract test'),
+      undefined,
+      { rawAuthorDisplayName: 'Contract User' }
+    );
+    await expect(stableJson(envelope)).toMatchFileSnapshot(
+      contractFixtureFile('raw-assembly-inputs/base.json')
+    );
+  });
+
+  it('with-extended-context: mention + one prior extended-context turn', async () => {
+    const extendedMessage = {
+      id: 'ext-1',
+      role: MessageRole.User,
+      content: 'an earlier message from the channel',
+      createdAt: new Date('2026-06-01T09:00:00Z'),
+      personaId: 'discord:444',
+      discordUsername: 'earlier-user',
+      discordMessageId: ['ext-dm-1'],
+      channelId: 'test-channel-987',
+      guildId: 'test-guild-654',
+    } as ConversationMessage;
+
+    const envelope = buildRawAssemblyInputs(
+      makeMessage([{ id: '333', username: 'target', globalName: 'Target' }], '<@333> with context'),
+      {
+        messages: [extendedMessage],
+        extendedContextUsers: [
+          { discordId: '444', username: 'earlier-user', displayName: 'Earlier', isBot: false },
+        ],
+        reactorUsers: [],
+      },
+      { rawAuthorDisplayName: 'Contract User' }
+    );
+    await expect(stableJson(envelope)).toMatchFileSnapshot(
+      contractFixtureFile('raw-assembly-inputs/with-extended-context.json')
+    );
+  });
+});


### PR DESCRIPTION
## What

Test-Pyramid epic Phase 3 — locks the **bot-client→ai-worker context-assembly contract** + seeds the coverage-topology.

### Golden-fixture flagship
The plan's "real-producer→real-consumer in one process" test was **structurally blocked** (services can't import each other; `tests/e2e/` can't reach service internals without exposing them; the producer needs cross-package mocks). Council (GLM-5.2 / Kimi-K2.7 / Qwen-3.7) unanimously rejected exposing service internals (boundary erosion) and extracting the producer (it reads discord.js `message.client`, not pure). The clean answer routes around the boundary with a shared **data artifact**, not shared code:

- **Committed fixtures** = the contract artifact: `@tzurot/test-utils` `fixtures/contracts/raw-assembly-inputs/{base,with-extended-context}.json` + a `contractFixtureFile`/`loadContractFixture` helper (resolves like `loadPGliteSchema`).
- **Producer guard** (bot-client): real `buildRawAssemblyInputs` → `toMatchFileSnapshot` vs the committed fixture (`--update` regenerates; CI compares strict). Drift → CI fails → regenerate-on-purpose.
- **Consumer derivation** (ai-worker, PGLite): real `assembleCore` over the *same* parsed fixture asserts `rawMessageContent` passthrough + `rawExtendedContextMessages` merged into history.

Neither service imports the other — depcruise stays fully intact. Fixtures are `.prettierignore`d (same as `command-manifest.json`: a byte-compared `JSON.stringify` artifact).

### Coverage-topology skeleton (report-only)
`CoverageSurface`/`CoverageTopology` types + `buildCoverageTopology` seeded with the locked context-assembly surface + `pnpm ops topology:generate`. The full `ROUTE_MANIFEST` + `JobType` walk (deriving `actualTiers` from tests) and the `test:tier-audit` ratchet are Phase 2/4 — not built here.

## Verification
`pnpm quality` green; producer guard matches the committed fixtures in compare mode; consumer derivation passes over PGLite; topology command + tests pass.

## Note
The mention-rewrite producer→consumer path surfaced as summon-mode-dependent (anonymous summon passes raw content through by design) — it's the mention kernel's domain, not this envelope seam, so it's not asserted here. A personal-summon mention scenario is a possible future fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)