### PR TITLE
feat: code-derive the coverage topology from ROUTE_MANIFEST + jobs (Phase 2a)

### DIFF
--- a/packages/tooling/src/commands/topology.ts
+++ b/packages/tooling/src/commands/topology.ts
@@ -16,15 +16,18 @@ export function registerTopologyCommands(cli: CAC): void {
     )
     .example('pnpm ops topology:generate')
     .action(async () => {
-      const { buildCoverageTopology, surfaceGap } = await import('../topology/coverageTopology.js');
-      const topology = buildCoverageTopology();
+      const { generateCoverageTopology, surfaceGap } =
+        await import('../topology/coverageTopology.js');
+      const topology = generateCoverageTopology();
       console.log(JSON.stringify(topology, null, 2));
 
       const gaps = topology.surfaces.filter(s => surfaceGap(s).length > 0);
       console.log(`\n${topology.surfaces.length} surface(s); ${gaps.length} with a tier gap.`);
       console.log(
-        'NOTE: skeleton — seeded with 1 proven surface. The full ROUTE_MANIFEST + JobType walk ' +
-          '(deriving actualTiers from tests) is Phase 2 of the test-pyramid epic; report-only, no gate.'
+        'NOTE: report-only. Surfaces are enumerated from ROUTE_MANIFEST + JobType payload ' +
+          'schemas + the context-assembly envelope; actualTiers is optimistic-from-mechanism. ' +
+          'Phase 2b adds --write (commit the artifact), mechanism-presence verification, and the ' +
+          'lockfile-diff CI gate; the test:tier-audit ratchet is Phase 4.'
       );
     });
 }

--- a/packages/tooling/src/topology/coverageTopology.test.ts
+++ b/packages/tooling/src/topology/coverageTopology.test.ts
@@ -1,19 +1,54 @@
 import { describe, it, expect } from 'vitest';
-import { buildCoverageTopology, surfaceGap } from './coverageTopology.js';
+import { ROUTE_MANIFEST } from '@tzurot/clients';
+import { JobType } from '@tzurot/common-types';
+import { generateCoverageTopology, surfaceGap } from './coverageTopology.js';
 
-describe('buildCoverageTopology (skeleton)', () => {
-  it('seeds the context-assembly surface with the contract tier covered', () => {
-    const topology = buildCoverageTopology();
-    expect(topology.schema).toBe('coverage-topology/v0-skeleton');
+describe('generateCoverageTopology', () => {
+  const topology = generateCoverageTopology();
 
-    const surface = topology.surfaces.find(s => s.id === 'bot-client:ai-worker:context-assembly');
-    expect(surface).toBeDefined();
-    expect(surface?.kind).toBe('context-envelope');
-    expect(surface?.producer).toBe('bot-client');
-    expect(surface?.consumer).toBe('ai-worker');
-    expect(surface?.requiredTiers).toContain('contract');
-    // The golden-fixture contract covers the required tier → no gap.
-    expect(surfaceGap(surface!)).toEqual([]);
+  it('is the v1 schema with surfaces sorted by id', () => {
+    expect(topology.schema).toBe('coverage-topology/v1');
+    const ids = topology.surfaces.map(s => s.id);
+    expect(ids).toEqual([...ids].sort((a, b) => a.localeCompare(b)));
+  });
+
+  it('enumerates one surface per ROUTE_MANIFEST route (http-route / route-conformance)', () => {
+    const routeSurfaces = topology.surfaces.filter(s => s.kind === 'http-route');
+    expect(routeSurfaces.length).toBe(Object.keys(ROUTE_MANIFEST).length);
+    expect(routeSurfaces.every(s => s.mechanism === 'route-conformance')).toBe(true);
+    expect(routeSurfaces.every(s => s.consumer === 'api-gateway')).toBe(true);
+  });
+
+  it('enumerates the three payload-bearing BullMQ jobs (bullmq-contract)', () => {
+    const jobSurfaces = topology.surfaces.filter(s => s.kind === 'bullmq-job');
+    // Build expected ids from the enum so a JobType value rename is caught.
+    const expected = [
+      `api-gateway:ai-worker:${JobType.AudioTranscription}`,
+      `api-gateway:ai-worker:${JobType.ImageDescription}`,
+      `api-gateway:ai-worker:${JobType.LLMGeneration}`,
+    ].sort();
+    expect(jobSurfaces.map(s => s.id).sort()).toEqual(expected);
+    expect(jobSurfaces.every(s => s.mechanism === 'bullmq-contract')).toBe(true);
+  });
+
+  it('includes the context-assembly envelope (golden-fixture)', () => {
+    const envelope = topology.surfaces.find(s => s.kind === 'context-envelope');
+    expect(envelope?.id).toBe('bot-client:ai-worker:context-assembly');
+    expect(envelope?.mechanism).toBe('golden-fixture');
+    expect(envelope?.schemaRef).toBe('rawAssemblyInputsSchema');
+  });
+
+  it('requires each surface the tier its mechanism provides (route→component, job/envelope→contract)', () => {
+    for (const s of topology.surfaces) {
+      const expected = s.mechanism === 'route-conformance' ? 'component' : 'contract';
+      expect(s.requiredTiers).toEqual([expected]);
+    }
+  });
+
+  it('reports no gaps in the optimistic 2a topology (mechanism assumed present)', () => {
+    // 2a is optimistic — actualTiers === requiredTiers per mechanism. The real
+    // gap signal (mechanism-test absent) arrives with 2b's presence verification.
+    expect(topology.surfaces.filter(s => surfaceGap(s).length > 0)).toEqual([]);
   });
 });
 
@@ -26,6 +61,7 @@ describe('surfaceGap', () => {
         producer: 'a',
         consumer: 'b',
         schemaRef: 's',
+        mechanism: 'bullmq-contract',
         requiredTiers: ['contract', 'component'],
         actualTiers: ['component'],
       })

--- a/packages/tooling/src/topology/coverageTopology.ts
+++ b/packages/tooling/src/topology/coverageTopology.ts
@@ -1,39 +1,52 @@
 /**
- * Coverage topology — SKELETON (test-pyramid epic, Phase-3 seed).
+ * Coverage topology — code-derived registry of cross-service surfaces (Phase 2).
  *
- * The cross-service "surfaces" a tier-coverage audit should track — HTTP
- * route-manifest entries + BullMQ job payloads + the context-assembly envelope —
- * each with the test tiers it SHOULD carry vs. what it currently HAS. This is
- * the data shape the eventual `test:tier-audit` ratchet (Phase 4) gates on and
- * the lockfile the discovery generator (Phase 2) regenerates from code.
+ * Enumerates every cross-service "surface" from code — HTTP routes (`ROUTE_MANIFEST`),
+ * BullMQ job payloads (`JobType` + `*JobDataSchema`), and the context-assembly
+ * envelope — and records, per surface, the test tiers it SHOULD carry
+ * (`requiredTiers`) vs. what it HAS (`actualTiers`), plus the coverage MECHANISM
+ * that provides it. This is the discovery artifact the eventual `test:tier-audit`
+ * ratchet (Phase 4) gates on; committed + lockfile-diffed in CI (Phase 2b).
  *
- * This skeleton is REPORT-ONLY and hand-seeded with one proven surface
- * (the bot-client→ai-worker context-assembly envelope) to prove the shape. The
- * full enumeration — walking `ROUTE_MANIFEST` (@tzurot/clients) + every `JobType`
- * (@tzurot/common-types) and deriving `actualTiers` from the test files — is
- * Phase 2's discovery generator, not built here.
+ * Coverage is **mechanism-based per surface class** (NOT a fuzzy global
+ * schema-grep): each class has one known coverage mechanism —
+ *  - http-route      → the route-conformance harness (component tier)
+ *  - bullmq-job      → the BullMQ producer/consumer contract tests (contract tier)
+ *  - context-envelope → the golden-fixture contract (contract tier)
+ *
+ * Phase 2a (this) enumerates surfaces + assigns each its mechanism + an OPTIMISTIC
+ * mechanism-implied `actualTiers` (assumes the mechanism's test is present).
+ * Phase 2b VERIFIES presence (downgrades `actualTiers` when a mechanism's test is
+ * missing) and adds the lockfile-diff CI gate.
  */
 
+import { ROUTE_MANIFEST } from '@tzurot/clients';
+import { JobType } from '@tzurot/common-types';
 import type { TestTier } from '../test/test-tiers.js';
+
+/** How a surface's contract coverage is provided. */
+export type CoverageSurfaceMechanism = 'route-conformance' | 'bullmq-contract' | 'golden-fixture';
 
 export type CoverageSurfaceKind = 'http-route' | 'bullmq-job' | 'context-envelope';
 
 export interface CoverageSurface {
-  /** Stable id, e.g. `bot-client:ai-worker:context-assembly`. */
+  /** Stable id, e.g. `api-gateway:ai-worker:llm-generation`. */
   id: string;
   kind: CoverageSurfaceKind;
   producer: string;
   consumer: string;
-  /** The shared schema/type that IS the contract artifact. */
+  /** The shared schema/type (or route id) that identifies the contract artifact. */
   schemaRef: string;
+  /** How this surface's contract coverage is provided (the per-surface marker). */
+  mechanism: CoverageSurfaceMechanism;
   /** Tiers this surface SHOULD carry. */
   requiredTiers: TestTier[];
-  /** Tiers it currently HAS (Phase 2's generator will derive this from tests). */
+  /** Tiers it currently HAS (Phase 2a: optimistic from mechanism; 2b verifies). */
   actualTiers: TestTier[];
 }
 
 export interface CoverageTopology {
-  schema: 'coverage-topology/v0-skeleton';
+  schema: 'coverage-topology/v1';
   surfaces: CoverageSurface[];
 }
 
@@ -43,34 +56,106 @@ export function surfaceGap(surface: CoverageSurface): TestTier[] {
 }
 
 /**
- * Build the skeleton topology — seeded with one proven cross-service surface
- * (the context-assembly envelope). NOTE: `actualTiers` is hand-coded for the
- * skeleton; Phase 2 replaces this builder with code-derivation (deriving the
- * tiers each surface HAS from the test files), so the seeded values are a
- * placeholder to be regenerated, not a maintained source of truth.
+ * The tier each mechanism provides — and which therefore IS the surface's
+ * required coverage. A cross-service surface's contract is verified by its
+ * mechanism, NOT necessarily by a literal `*.contract.test.ts`:
+ *  - the route-conformance harness is a **component**-tier test that verifies
+ *    each route's request↔response against its declared schema (contract-level
+ *    verification, component-tier file) — so a route requires `component`, not a
+ *    separate contract-tier file;
+ *  - the BullMQ + golden-fixture mechanisms are **contract**-tier.
+ *
+ * `requiredTiers` = `actualTiers` = [this tier] in Phase 2a (optimistic: the
+ * mechanism's test is assumed present). Phase 2b verifies presence and empties
+ * `actualTiers` when the mechanism's test is missing, surfacing a real gap.
  */
-export function buildCoverageTopology(): CoverageTopology {
-  return {
-    schema: 'coverage-topology/v0-skeleton',
-    surfaces: [
-      {
-        id: 'bot-client:ai-worker:context-assembly',
-        kind: 'context-envelope',
-        producer: 'bot-client',
-        consumer: 'ai-worker',
-        schemaRef: 'rawAssemblyInputsSchema',
-        requiredTiers: ['contract'],
-        // The `contract` tier here is provided by the GOLDEN-FIXTURE mechanism —
-        // a producer guard (RawEnvelopeContract.producer.test.ts, a unit-suffix
-        // file) + consumer derivation over the committed fixture
-        // (RawEnvelopeContract.consumer.component.test.ts, a component-suffix
-        // file) — NOT a `*.contract.test.ts` file. So Phase 2's suffix-based
-        // classifyTestFile would naively derive ['unit', 'component'] and report
-        // a FALSE `contract` gap on this surface. Phase 2 must recognize
-        // golden-fixture contracts (e.g. a per-surface mechanism marker) instead
-        // of relying on the file suffix alone — see the builder doc above.
-        actualTiers: ['contract', 'component', 'unit'],
-      },
-    ],
-  };
+const MECHANISM_TIER: Record<CoverageSurfaceMechanism, TestTier> = {
+  'route-conformance': 'component',
+  'bullmq-contract': 'contract',
+  'golden-fixture': 'contract',
+};
+
+/**
+ * BullMQ job types that carry a cross-service payload schema (the producer↔consumer
+ * contract). Shapes import/export have no `*JobDataSchema` (no discriminated payload
+ * contract), so they are not BullMQ-contract surfaces.
+ */
+const JOB_PAYLOAD_SCHEMAS: Record<
+  JobType.AudioTranscription | JobType.ImageDescription | JobType.LLMGeneration,
+  string
+> = {
+  [JobType.AudioTranscription]: 'audioTranscriptionJobDataSchema',
+  [JobType.ImageDescription]: 'imageDescriptionJobDataSchema',
+  [JobType.LLMGeneration]: 'llmGenerationJobDataSchema',
+};
+
+/**
+ * Route ids exempt from the cross-service contract requirement (not real
+ * contracts: static asset serving, liveness). Capped — NOT a growable knownGaps;
+ * each future entry carries an inline-comment reason. Empty for now.
+ */
+const EXEMPT_ROUTE_IDS = new Set<string>();
+
+/**
+ * Build the code-derived coverage topology by walking `ROUTE_MANIFEST` + the
+ * BullMQ payload schemas + the context-assembly envelope. Surfaces are sorted by
+ * id for a stable, diff-clean committed artifact.
+ */
+export function generateCoverageTopology(): CoverageTopology {
+  const surfaces: CoverageSurface[] = [];
+
+  // HTTP routes — each manifest entry is a cross-service surface (typed client →
+  // api-gateway handler), covered by the route-conformance harness.
+  for (const [id, route] of Object.entries(ROUTE_MANIFEST)) {
+    if (EXEMPT_ROUTE_IDS.has(id)) continue;
+    surfaces.push({
+      id: `client:api-gateway:${id}`,
+      kind: 'http-route',
+      // 'client' = the typed-client layer, not a single service: routes are
+      // called via the generated typed client by whichever service holds it
+      // (internal routes are service-to-service; user/admin are bot-client), so
+      // there's no single producer. The mechanism (route-conformance), not the
+      // producer, drives coverage.
+      producer: 'client',
+      consumer: 'api-gateway',
+      // The route's input/output Zod schemas are named consts in the manifest;
+      // the route id is the stable surface identifier (the conformance harness,
+      // not a schema-grep, is the coverage mechanism).
+      schemaRef: `${route.method.toUpperCase()} ${route.path}`,
+      mechanism: 'route-conformance',
+      requiredTiers: [MECHANISM_TIER['route-conformance']],
+      actualTiers: [MECHANISM_TIER['route-conformance']],
+    });
+  }
+
+  // BullMQ jobs — api-gateway produces, ai-worker consumes; the payload schema is
+  // the contract, covered by the BullMQ producer/consumer contract tests.
+  for (const [jobType, schemaRef] of Object.entries(JOB_PAYLOAD_SCHEMAS)) {
+    surfaces.push({
+      id: `api-gateway:ai-worker:${jobType}`,
+      kind: 'bullmq-job',
+      producer: 'api-gateway',
+      consumer: 'ai-worker',
+      schemaRef,
+      mechanism: 'bullmq-contract',
+      requiredTiers: [MECHANISM_TIER['bullmq-contract']],
+      actualTiers: [MECHANISM_TIER['bullmq-contract']],
+    });
+  }
+
+  // The bot-client→ai-worker context-assembly envelope (locked by the
+  // golden-fixture contract).
+  surfaces.push({
+    id: 'bot-client:ai-worker:context-assembly',
+    kind: 'context-envelope',
+    producer: 'bot-client',
+    consumer: 'ai-worker',
+    schemaRef: 'rawAssemblyInputsSchema',
+    mechanism: 'golden-fixture',
+    requiredTiers: [MECHANISM_TIER['golden-fixture']],
+    actualTiers: [MECHANISM_TIER['golden-fixture']],
+  });
+
+  surfaces.sort((a, b) => a.id.localeCompare(b.id));
+  return { schema: 'coverage-topology/v1', surfaces };
 }


### PR DESCRIPTION
## What

Phase 2a of the Test-Pyramid epic. Replaces the hand-seeded coverage-topology skeleton (from the golden-fixture PR) with a **code-derived generator**: `generateCoverageTopology()` enumerates every cross-service surface from code.

- **HTTP routes** — one surface per `ROUTE_MANIFEST` entry (`@tzurot/clients`)
- **BullMQ jobs** — one per payload-bearing `JobType` (audio/image/llm; Shapes import/export have no payload schema)
- **Context envelope** — the bot-client→ai-worker assembly surface

## Mechanism-based coverage

Each surface carries a `mechanism` (the per-surface marker the prior golden-fixture review flagged Phase 2 needs):

| Kind | Mechanism | Tier |
|---|---|---|
| `http-route` | route-conformance harness | component |
| `bullmq-job` | BullMQ producer/consumer contract tests | contract |
| `context-envelope` | golden-fixture | contract |

A surface **requires the tier its mechanism provides** (route→component, since the conformance harness verifies the route's I/O contract at component tier; jobs+envelope→contract). This avoids the false "150 routes lack a contract test" gap — the component-tier conformance harness *is* the route's contract verification.

## Scope (2a only)

Report-only: `pnpm ops topology:generate` prints the topology (154 surfaces, 0 optimistic gaps). `actualTiers` is optimistic-from-mechanism (assumes the mechanism's test is present).

**Phase 2b** adds `--write` (commit the artifact + `.prettierignore`), mechanism-**presence** verification (empties `actualTiers` when a mechanism's test is absent → real gap), and the lockfile-diff CI gate. The `test:tier-audit` ratchet is Phase 4.

## Verification

`pnpm quality` green; `coverageTopology.test.ts` asserts the surface set (one per route, the 3 jobs, the envelope), mechanism assignment, and 0 optimistic gaps; route count cross-checks `Object.keys(ROUTE_MANIFEST).length`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)