### PR TITLE
feat(tooling): coverage-topology presence verification + drift gate (Phase 2b)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,14 @@ jobs:
         # produce. To fix locally: `pnpm ops codegen:routes` then commit.
         run: pnpm ops codegen:routes --check
 
+      - name: Enforce coverage-topology drift
+        # Byte-compares the committed coverage-topology.json against what the
+        # current code (ROUTE_MANIFEST + JobType payload schemas + the context
+        # envelope) would generate. Fails if a new or newly-uncovered
+        # cross-service surface isn't reflected in the committed artifact.
+        # To fix locally: `pnpm ops topology:generate --write` then commit.
+        run: pnpm ops topology:check
+
       - name: Check for duplicate export names
         run: pnpm ops guard:duplicate-exports
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -34,3 +34,9 @@ services/bot-client/command-manifest.json
 # against these committed files; prettier collapses short arrays onto single lines,
 # breaking that comparison on every regeneration. Same rationale as the manifest above.
 packages/test-utils/fixtures/contracts/
+
+# Auto-generated coverage topology. `topology:check` byte-compares the committed
+# file against `JSON.stringify(…, 2)` output; prettier collapses the short tier
+# arrays onto single lines, breaking that comparison on every regeneration. Same
+# rationale as the command manifest and contract fixtures above.
+packages/tooling/coverage-topology.json

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "commands:audit": "tsx packages/tooling/src/cli.ts commands:audit",
     "backlog:lint": "tsx packages/tooling/src/cli.ts backlog",
     "test:tiers": "tsx packages/tooling/src/cli.ts test:tiers",
-    "quality": "pnpm lint && pnpm ops codegen:routes --check && pnpm knip && pnpm cpd && pnpm ops cpd:check && pnpm ops test:audit && pnpm depcruise && pnpm typecheck && pnpm typecheck:spec && pnpm backlog:lint && pnpm ops guard:test-taxonomy",
+    "quality": "pnpm lint && pnpm ops codegen:routes --check && pnpm ops topology:check && pnpm knip && pnpm cpd && pnpm ops cpd:check && pnpm ops test:audit && pnpm depcruise && pnpm typecheck && pnpm typecheck:spec && pnpm backlog:lint && pnpm ops guard:test-taxonomy",
     "focus:lint": "pnpm ops dev:lint",
     "focus:test": "pnpm ops dev:test",
     "focus:build": "pnpm ops dev:focus build",

--- a/packages/tooling/coverage-topology.json
+++ b/packages/tooling/coverage-topology.json
@@ -1,0 +1,2161 @@
+{
+  "schema": "coverage-topology/v1",
+  "surfaces": [
+    {
+      "id": "api-gateway:ai-worker:audio-transcription",
+      "kind": "bullmq-job",
+      "producer": "api-gateway",
+      "consumer": "ai-worker",
+      "schemaRef": "audioTranscriptionJobDataSchema",
+      "mechanism": "bullmq-contract",
+      "requiredTiers": [
+        "contract"
+      ],
+      "actualTiers": [
+        "contract"
+      ]
+    },
+    {
+      "id": "api-gateway:ai-worker:image-description",
+      "kind": "bullmq-job",
+      "producer": "api-gateway",
+      "consumer": "ai-worker",
+      "schemaRef": "imageDescriptionJobDataSchema",
+      "mechanism": "bullmq-contract",
+      "requiredTiers": [
+        "contract"
+      ],
+      "actualTiers": [
+        "contract"
+      ]
+    },
+    {
+      "id": "api-gateway:ai-worker:llm-generation",
+      "kind": "bullmq-job",
+      "producer": "api-gateway",
+      "consumer": "ai-worker",
+      "schemaRef": "llmGenerationJobDataSchema",
+      "mechanism": "bullmq-contract",
+      "requiredTiers": [
+        "contract"
+      ],
+      "actualTiers": [
+        "contract"
+      ]
+    },
+    {
+      "id": "bot-client:ai-worker:context-assembly",
+      "kind": "context-envelope",
+      "producer": "bot-client",
+      "consumer": "ai-worker",
+      "schemaRef": "rawAssemblyInputsSchema",
+      "mechanism": "golden-fixture",
+      "requiredTiers": [
+        "contract"
+      ],
+      "actualTiers": [
+        "contract"
+      ]
+    },
+    {
+      "id": "client:api-gateway:activateChannel",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /channel/activate",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:addDenylistEntry",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /denylist",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:aiConfirmDelivery",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /ai/job/:jobId/confirm-delivery",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:aiGenerate",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /ai/generate",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:aiJobStatus",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /ai/job/:jobId",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:aiTranscribe",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /ai/transcribe",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:batchDelete",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /memory/delete",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:batchDeletePreview",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /memory/delete/preview",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:cleanup",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /cleanup",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:clearAdminSettings",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "DELETE /settings/config-defaults",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:clearChannelConfigOverrides",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "DELETE /channel/:channelId/config-overrides",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:clearDefaultModelConfig",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "DELETE /model-override/default",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:clearHistory",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /history/clear",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:clearPersonalityOverrides",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "DELETE /config-overrides/:personalityId",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:clearPersonaOverride",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "DELETE /persona/override/:personalitySlug",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:clearSttDefaultProvider",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "DELETE /stt-override",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:clearTtsDefaultConfig",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "DELETE /tts-override/default",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:clearUserDefaults",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "DELETE /config-overrides/defaults",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:clearVoices",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /voices/clear",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:createGlobalLlmConfig",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /llm-config",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:createGlobalPersonality",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /personality",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:createGlobalTtsConfig",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /tts-config",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:createPersona",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /persona",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:createPersonality",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /personality",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:createPersonaOverride",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /persona/override/by-id/:personalityId",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:createUserLlmConfig",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /llm-config",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:createUserTtsConfig",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /tts-config",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:dbSync",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /db-sync",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:deactivateChannel",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "DELETE /channel/deactivate",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:deleteGlobalLlmConfig",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "DELETE /llm-config/:id",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:deleteGlobalTtsConfig",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "DELETE /tts-config/:id",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:deleteMemory",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "DELETE /memory/:id",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:deleteModelOverride",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "DELETE /model-override/:personalityId",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:deletePersona",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "DELETE /persona/:id",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:deletePersonality",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "DELETE /personality/:slug",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:deleteShapesAuth",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "DELETE /shapes/auth",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:deleteTtsOverride",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "DELETE /tts-override/:personalityId",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:deleteUserLlmConfig",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "DELETE /llm-config/:id",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:deleteUserTtsConfig",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "DELETE /tts-config/:id",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:deleteVoice",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "DELETE /voices/:provider/:voiceId",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:disableIncognito",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "DELETE /memory/incognito",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:enableIncognito",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /memory/incognito",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getAdminSettings",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /settings",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getAdminSettingsInternal",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /admin-settings",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getAdminUsageStats",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /usage",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getChannelConfigOverrides",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /channel/:channelId/config-overrides",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getChannelSettings",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /channel/:channelId",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getDefaultModelConfig",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /model-override/default",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getDenylistCache",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /denylist/cache",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getDiagnosticByMessage",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /diagnostic/by-message/:messageId",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getDiagnosticByRequestId",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /diagnostic/:requestId",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getDiagnosticByResponse",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /diagnostic/by-response/:messageId",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getFocus",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /memory/focus",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getGlobalLlmConfig",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /llm-config/:id",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getGlobalTtsConfig",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /tts-config/:id",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getHistoryStats",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /history/stats",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getIncognitoStatus",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /memory/incognito",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getMemory",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /memory/:id",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getModels",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /models",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getNsfwStatus",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /nsfw",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getPersona",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /persona/:id",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getPersonality",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /personality/:slug",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getPersonaOverride",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /persona/override/:personalitySlug",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getRecentDiagnostics",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /diagnostic/recent",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getShapesAuthStatus",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /shapes/auth/status",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getStats",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /memory/stats",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getSttDefaultProvider",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /stt-override",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getTimezone",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /timezone",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getTtsDefaultConfig",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /tts-override/default",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getUserChannel",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /channel/:channelId",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getUserDefaults",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /config-overrides/defaults",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getUserLlmConfig",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /llm-config/:id",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getUserTtsConfig",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /tts-config/:id",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getUserUsage",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /usage",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:getVoiceResolution",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /voice-resolution",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:hardDeleteHistory",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "DELETE /history/hard-delete",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:incognitoForget",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /memory/incognito/forget",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:invalidateCache",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /invalidate-cache",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:issuePurgeToken",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /memory/purge/token",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:list",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /memory/list",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:listDenylistEntries",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /denylist",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:listGlobalLlmConfigs",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /llm-config",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:listGlobalTtsConfigs",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /tts-config",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:listModelOverrides",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /model-override",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:listPersonalities",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /personality",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:listPersonaOverrides",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /persona/override",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:listPersonas",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /persona",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:listShapes",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /shapes/list",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:listShapesExportJobs",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /shapes/export/jobs",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:listShapesImportJobs",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /shapes/import/jobs",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:listTtsOverrides",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /tts-override",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:listUserChannels",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /channel/list",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:listUserLlmConfigs",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /llm-config",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:listUserTtsConfigs",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /tts-config",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:listVoiceModels",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /voices/models",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:listVoices",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /voices",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:listWalletKeys",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /wallet/list",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:loadPersonalityInternal",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /personality/load",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:lookupPersonalityFromMessage",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /conversation/message-personality",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:persistAssistantMessage",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /conversation/assistant-message",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:persistUserMessage",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /conversation/user-message",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:purge",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /memory/purge",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:recentUsers",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /users/recent",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:removeDenylistEntry",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "DELETE /denylist/:type/:discordId/:scope/:scopeId",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:removeWalletKey",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "DELETE /wallet/:provider",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:resolveCascade",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /config-overrides/resolve/:personalityId",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:resolvePersonalityCascade",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /config-overrides/resolve-personality/:personalityId",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:resolveUserDefaults",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "GET /config-overrides/resolve-defaults",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:resolveUserLlmConfig",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /llm-config/resolve",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:routingContextCreate",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /v1/routing-context",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:search",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /memory/search",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:setDefaultModelConfig",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PUT /model-override/default",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:setDmSession",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /channel/dm-session/set",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:setFocus",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /memory/focus",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:setGlobalLlmConfigDefault",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PUT /llm-config/:id/set-default",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:setGlobalLlmConfigFreeDefault",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PUT /llm-config/:id/set-free-default",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:setGlobalTtsConfigDefault",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PUT /tts-config/:id/set-default",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:setGlobalTtsConfigFreeDefault",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PUT /tts-config/:id/set-free-default",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:setMemoryLock",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PUT /memory/:id/lock",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:setModelOverride",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PUT /model-override",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:setPersonaDefault",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PATCH /persona/:id/default",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:setPersonalityVisibility",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PATCH /personality/:slug/visibility",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:setPersonaOverride",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PUT /persona/override/:personalitySlug",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:setSttDefaultProvider",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PUT /stt-override",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:setTimezone",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PUT /timezone",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:setTtsDefaultConfig",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PUT /tts-override/default",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:setTtsOverride",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PUT /tts-override",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:setWalletKey",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /wallet/set",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:startShapesExport",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /shapes/export",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:startShapesImport",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /shapes/import",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:storeShapesAuth",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /shapes/auth",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:syncConversation",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /conversation/sync",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:testWalletKey",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /wallet/test",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:undoHistory",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /history/undo",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:updateAdminSettings",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PATCH /settings/config-defaults",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:updateChannelConfigOverrides",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PATCH /channel/:channelId/config-overrides",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:updateChannelGuild",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PATCH /channel/update-guild",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:updateDiagnosticResponseIds",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PATCH /diagnostic/:requestId/response-ids",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:updateGlobalLlmConfig",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PUT /llm-config/:id",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:updateGlobalPersonality",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PATCH /personality/:slug",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:updateGlobalTtsConfig",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PUT /tts-config/:id",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:updateMemory",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PATCH /memory/:id",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:updatePersona",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PUT /persona/:id",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:updatePersonality",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PUT /personality/:slug",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:updatePersonalityConfigDefaults",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PATCH /config-overrides/personality/:personalityId",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:updatePersonalityOverrides",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PATCH /config-overrides/:personalityId",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:updateUserDefaults",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PATCH /config-overrides/defaults",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:updateUserLlmConfig",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PUT /llm-config/:id",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:updateUserTtsConfig",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "PUT /tts-config/:id",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    },
+    {
+      "id": "client:api-gateway:verifyNsfw",
+      "kind": "http-route",
+      "producer": "client",
+      "consumer": "api-gateway",
+      "schemaRef": "POST /nsfw/verify",
+      "mechanism": "route-conformance",
+      "requiredTiers": [
+        "component"
+      ],
+      "actualTiers": [
+        "component"
+      ]
+    }
+  ]
+}

--- a/packages/tooling/src/commands/topology.ts
+++ b/packages/tooling/src/commands/topology.ts
@@ -1,33 +1,70 @@
 /**
  * Coverage-topology commands (test-pyramid epic).
  *
- * Report-only skeleton: prints the cross-service coverage topology (which test
- * tiers each surface should/does carry). The full code-derived enumeration +
- * lockfile-diff + CI ratchet are Phase 2/4, not wired here.
+ * `topology:generate` prints the code-derived cross-service coverage topology
+ * (which test tiers each surface should/does carry); `--write` emits the
+ * committed `coverage-topology.json`. `topology:check` regenerates and
+ * byte-compares against the committed file — the CI drift gate (same shape as
+ * `codegen:routes --check`). The hard ratchet that fails on a missing required
+ * tier is a separate, later tool (`test:tier-audit`).
  */
 
 import type { CAC } from 'cac';
+import chalk from 'chalk';
 
 export function registerTopologyCommands(cli: CAC): void {
   cli
-    .command(
-      'topology:generate',
-      'Print the cross-service coverage topology (report-only skeleton)'
-    )
+    .command('topology:generate', 'Print (or --write) the cross-service coverage topology')
+    .option('--write', 'Write the committed coverage-topology.json instead of printing')
     .example('pnpm ops topology:generate')
-    .action(async () => {
-      const { generateCoverageTopology, surfaceGap } =
-        await import('../topology/coverageTopology.js');
+    .example('pnpm ops topology:generate --write')
+    .action(async (options: { write?: boolean }) => {
+      const {
+        generateCoverageTopology,
+        surfaceGap,
+        writeCoverageTopology,
+        COVERAGE_TOPOLOGY_PATH,
+      } = await import('../topology/coverageTopology.js');
+
+      if (options.write === true) {
+        writeCoverageTopology();
+        console.log(chalk.green(`✓ Wrote ${COVERAGE_TOPOLOGY_PATH}`));
+        return;
+      }
+
       const topology = generateCoverageTopology();
       console.log(JSON.stringify(topology, null, 2));
 
       const gaps = topology.surfaces.filter(s => surfaceGap(s).length > 0);
-      console.log(`\n${topology.surfaces.length} surface(s); ${gaps.length} with a tier gap.`);
       console.log(
-        'NOTE: report-only. Surfaces are enumerated from ROUTE_MANIFEST + JobType payload ' +
-          'schemas + the context-assembly envelope; actualTiers is optimistic-from-mechanism. ' +
-          'Phase 2b adds --write (commit the artifact), mechanism-presence verification, and the ' +
-          'lockfile-diff CI gate; the test:tier-audit ratchet is Phase 4.'
+        `\n${topology.surfaces.length} surface(s); ${gaps.length} with a tier gap ` +
+          `(coverage mechanism absent).`
       );
+    });
+
+  cli
+    .command('topology:check', 'Fail if the committed coverage-topology.json is stale (CI mode)')
+    .example('pnpm ops topology:check')
+    .action(async () => {
+      const { checkCoverageTopology, COVERAGE_TOPOLOGY_PATH } =
+        await import('../topology/coverageTopology.js');
+
+      const result = checkCoverageTopology();
+      if (result.upToDate) {
+        console.log(chalk.green(`✓ ${COVERAGE_TOPOLOGY_PATH} up-to-date`));
+        return;
+      }
+
+      console.error(
+        chalk.red(
+          result.missing
+            ? `✗ ${COVERAGE_TOPOLOGY_PATH} is missing`
+            : `✗ ${COVERAGE_TOPOLOGY_PATH} is out of sync with code`
+        )
+      );
+      console.error(
+        chalk.yellow('\nRun `pnpm ops topology:generate --write`, then commit the result.')
+      );
+      process.exit(1);
     });
 }

--- a/packages/tooling/src/topology/coverageTopology.test.ts
+++ b/packages/tooling/src/topology/coverageTopology.test.ts
@@ -1,9 +1,21 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
 import { describe, it, expect } from 'vitest';
 import { ROUTE_MANIFEST } from '@tzurot/clients';
 import { JobType } from '@tzurot/common-types';
-import { generateCoverageTopology, surfaceGap } from './coverageTopology.js';
+import {
+  generateCoverageTopology,
+  surfaceGap,
+  checkCoverageTopology,
+  writeCoverageTopology,
+  COVERAGE_TOPOLOGY_PATH,
+  EXEMPT_ROUTE_IDS,
+} from './coverageTopology.js';
 
 describe('generateCoverageTopology', () => {
+  // Default root resolves to the repo root, so presence checks run against the
+  // real mechanism files (all shipped) — see the gap tests below.
   const topology = generateCoverageTopology();
 
   it('is the v1 schema with surfaces sorted by id', () => {
@@ -12,10 +24,11 @@ describe('generateCoverageTopology', () => {
     expect(ids).toEqual([...ids].sort((a, b) => a.localeCompare(b)));
   });
 
-  it('enumerates one surface per ROUTE_MANIFEST route (http-route / route-conformance)', () => {
+  it('enumerates one surface per non-exempt ROUTE_MANIFEST route (route-conformance)', () => {
     const routeSurfaces = topology.surfaces.filter(s => s.kind === 'http-route');
-    expect(routeSurfaces.length).toBe(Object.keys(ROUTE_MANIFEST).length);
+    expect(routeSurfaces.length).toBe(Object.keys(ROUTE_MANIFEST).length - EXEMPT_ROUTE_IDS.length);
     expect(routeSurfaces.every(s => s.mechanism === 'route-conformance')).toBe(true);
+    expect(routeSurfaces.every(s => s.producer === 'client')).toBe(true);
     expect(routeSurfaces.every(s => s.consumer === 'api-gateway')).toBe(true);
   });
 
@@ -29,13 +42,18 @@ describe('generateCoverageTopology', () => {
     ].sort();
     expect(jobSurfaces.map(s => s.id).sort()).toEqual(expected);
     expect(jobSurfaces.every(s => s.mechanism === 'bullmq-contract')).toBe(true);
+    expect(jobSurfaces.every(s => s.producer === 'api-gateway' && s.consumer === 'ai-worker')).toBe(
+      true
+    );
   });
 
-  it('includes the context-assembly envelope (golden-fixture)', () => {
+  it('includes the context-assembly envelope (golden-fixture, bot-client→ai-worker)', () => {
     const envelope = topology.surfaces.find(s => s.kind === 'context-envelope');
     expect(envelope?.id).toBe('bot-client:ai-worker:context-assembly');
     expect(envelope?.mechanism).toBe('golden-fixture');
     expect(envelope?.schemaRef).toBe('rawAssemblyInputsSchema');
+    expect(envelope?.producer).toBe('bot-client');
+    expect(envelope?.consumer).toBe('ai-worker');
   });
 
   it('requires each surface the tier its mechanism provides (route→component, job/envelope→contract)', () => {
@@ -45,10 +63,51 @@ describe('generateCoverageTopology', () => {
     }
   });
 
-  it('reports no gaps in the optimistic 2a topology (mechanism assumed present)', () => {
-    // 2a is optimistic — actualTiers === requiredTiers per mechanism. The real
-    // gap signal (mechanism-test absent) arrives with 2b's presence verification.
+  it('verifies mechanism presence: every surface is covered in this repo', () => {
+    // The conformance harness, BullMQ contract tests, and golden-fixture all
+    // exist, so actualTiers === requiredTiers and no surface shows a gap.
+    expect(topology.surfaces.every(s => s.actualTiers.length === 1)).toBe(true);
     expect(topology.surfaces.filter(s => surfaceGap(s).length > 0)).toEqual([]);
+  });
+
+  it('downgrades actualTiers to empty (a real gap) when a mechanism test is absent', () => {
+    // A root with none of the mechanism files → every surface gaps. Proves the
+    // presence verification (not an optimistic assumption) drives actualTiers.
+    const empty = generateCoverageTopology('/tmp/__no_such_tzurot_root__');
+    expect(empty.surfaces.length).toBe(topology.surfaces.length);
+    expect(empty.surfaces.every(s => s.actualTiers.length === 0)).toBe(true);
+    expect(empty.surfaces.every(s => surfaceGap(s).length === 1)).toBe(true);
+  });
+});
+
+describe('checkCoverageTopology', () => {
+  it('reports up-to-date for the committed artifact (the real CI-gate happy path)', () => {
+    // Default root = repo root → compares the committed coverage-topology.json
+    // against a fresh generation. This is the exact assertion the CI gate makes,
+    // so a drifted committed artifact fails here as well as in CI.
+    expect(checkCoverageTopology()).toMatchObject({ upToDate: true, missing: false });
+  });
+
+  it('reports missing when the committed artifact is absent', () => {
+    expect(checkCoverageTopology('/tmp/__no_such_tzurot_root__')).toMatchObject({
+      upToDate: false,
+      missing: true,
+    });
+  });
+
+  it('round-trips writeCoverageTopology → check, and flags a tampered (stale) artifact', () => {
+    const tmpRoot = mkdtempSync(join(tmpdir(), 'topo-'));
+    try {
+      mkdirSync(join(tmpRoot, dirname(COVERAGE_TOPOLOGY_PATH)), { recursive: true });
+      const written = writeCoverageTopology(tmpRoot);
+      // A fresh write byte-matches a re-generation against the same root.
+      expect(checkCoverageTopology(tmpRoot)).toMatchObject({ upToDate: true, missing: false });
+      // Tampering makes it stale: present, but no longer matching.
+      writeFileSync(written, 'tampered\n');
+      expect(checkCoverageTopology(tmpRoot)).toMatchObject({ upToDate: false, missing: false });
+    } finally {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/tooling/src/topology/coverageTopology.ts
+++ b/packages/tooling/src/topology/coverageTopology.ts
@@ -1,27 +1,33 @@
 /**
- * Coverage topology — code-derived registry of cross-service surfaces (Phase 2).
+ * Coverage topology — code-derived registry of cross-service surfaces.
  *
- * Enumerates every cross-service "surface" from code — HTTP routes (`ROUTE_MANIFEST`),
- * BullMQ job payloads (`JobType` + `*JobDataSchema`), and the context-assembly
- * envelope — and records, per surface, the test tiers it SHOULD carry
- * (`requiredTiers`) vs. what it HAS (`actualTiers`), plus the coverage MECHANISM
- * that provides it. This is the discovery artifact the eventual `test:tier-audit`
- * ratchet (Phase 4) gates on; committed + lockfile-diffed in CI (Phase 2b).
+ * Enumerates every cross-service "surface" from code — HTTP routes
+ * (`ROUTE_MANIFEST`), payload-bearing BullMQ jobs (`JobType` + `*JobDataSchema`),
+ * and the bot-client→worker context-assembly envelope — and records, per surface,
+ * the test tiers it SHOULD carry (`requiredTiers`) vs. the tiers it actually HAS
+ * (`actualTiers`), plus the coverage MECHANISM that provides it. A surface whose
+ * mechanism's test is absent has empty `actualTiers`, so `surfaceGap` reports it.
  *
  * Coverage is **mechanism-based per surface class** (NOT a fuzzy global
- * schema-grep): each class has one known coverage mechanism —
- *  - http-route      → the route-conformance harness (component tier)
- *  - bullmq-job      → the BullMQ producer/consumer contract tests (contract tier)
+ * schema-grep): each class has exactly one coverage mechanism, and a surface is
+ * "covered" iff that mechanism's test is present on disk —
+ *  - http-route       → the route-conformance harness (component tier)
+ *  - bullmq-job       → the BullMQ producer/consumer contract tests (contract tier)
  *  - context-envelope → the golden-fixture contract (contract tier)
  *
- * Phase 2a (this) enumerates surfaces + assigns each its mechanism + an OPTIMISTIC
- * mechanism-implied `actualTiers` (assumes the mechanism's test is present).
- * Phase 2b VERIFIES presence (downgrades `actualTiers` when a mechanism's test is
- * missing) and adds the lockfile-diff CI gate.
+ * The generated topology is committed (`packages/tooling/coverage-topology.json`)
+ * and byte-compared in CI via `topology:check` — a new or newly-uncovered surface
+ * shows up as a one-line diff a reviewer closes or exempts. The hard ratchet that
+ * FAILS on a missing required tier is a separate, later tool (`test:tier-audit`).
  */
+
+import { writeFileSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
 
 import { ROUTE_MANIFEST } from '@tzurot/clients';
 import { JobType } from '@tzurot/common-types';
+
+import { findFiles, fileExists, readFile } from '../test/audit-utils.js';
 import type { TestTier } from '../test/test-tiers.js';
 
 /** How a surface's contract coverage is provided. */
@@ -41,7 +47,7 @@ export interface CoverageSurface {
   mechanism: CoverageSurfaceMechanism;
   /** Tiers this surface SHOULD carry. */
   requiredTiers: TestTier[];
-  /** Tiers it currently HAS (Phase 2a: optimistic from mechanism; 2b verifies). */
+  /** Tiers it actually HAS (= its mechanism's tier iff that mechanism's test is present). */
   actualTiers: TestTier[];
 }
 
@@ -50,24 +56,21 @@ export interface CoverageTopology {
   surfaces: CoverageSurface[];
 }
 
+/** Repo-relative path of the committed topology artifact (byte-compared in CI). */
+export const COVERAGE_TOPOLOGY_PATH = 'packages/tooling/coverage-topology.json';
+
 /** The required tiers a surface is MISSING (empty = fully covered). */
 export function surfaceGap(surface: CoverageSurface): TestTier[] {
   return surface.requiredTiers.filter(tier => !surface.actualTiers.includes(tier));
 }
 
 /**
- * The tier each mechanism provides — and which therefore IS the surface's
- * required coverage. A cross-service surface's contract is verified by its
- * mechanism, NOT necessarily by a literal `*.contract.test.ts`:
- *  - the route-conformance harness is a **component**-tier test that verifies
- *    each route's request↔response against its declared schema (contract-level
- *    verification, component-tier file) — so a route requires `component`, not a
- *    separate contract-tier file;
- *  - the BullMQ + golden-fixture mechanisms are **contract**-tier.
- *
- * `requiredTiers` = `actualTiers` = [this tier] in Phase 2a (optimistic: the
- * mechanism's test is assumed present). Phase 2b verifies presence and empties
- * `actualTiers` when the mechanism's test is missing, surfacing a real gap.
+ * The tier each mechanism provides — which IS the surface's required coverage. A
+ * cross-service contract is verified by its mechanism, NOT necessarily by a
+ * literal `*.contract.test.ts`: the route-conformance harness is a
+ * **component**-tier test that checks each route's request↔response against its
+ * declared schema, so a route requires `component`; the BullMQ and golden-fixture
+ * mechanisms are **contract**-tier.
  */
 const MECHANISM_TIER: Record<CoverageSurfaceMechanism, TestTier> = {
   'route-conformance': 'component',
@@ -76,86 +79,214 @@ const MECHANISM_TIER: Record<CoverageSurfaceMechanism, TestTier> = {
 };
 
 /**
- * BullMQ job types that carry a cross-service payload schema (the producer↔consumer
- * contract). Shapes import/export have no `*JobDataSchema` (no discriminated payload
- * contract), so they are not BullMQ-contract surfaces.
+ * Every JobType, classified: a payload-bearing job maps to its cross-service
+ * `*JobDataSchema` name (the producer↔consumer contract); a job with no
+ * discriminated payload schema (Shapes import/export) maps to `null`. The
+ * `Record<JobType, …>` is the exhaustiveness guard — a newly-added JobType will
+ * not compile until it is classified here, so a future payload-bearing job can't
+ * be silently omitted from the topology.
  */
-const JOB_PAYLOAD_SCHEMAS: Record<
-  JobType.AudioTranscription | JobType.ImageDescription | JobType.LLMGeneration,
-  string
-> = {
+const JOB_SCHEMA_BY_TYPE: Record<JobType, string | null> = {
   [JobType.AudioTranscription]: 'audioTranscriptionJobDataSchema',
   [JobType.ImageDescription]: 'imageDescriptionJobDataSchema',
   [JobType.LLMGeneration]: 'llmGenerationJobDataSchema',
+  [JobType.ShapesImport]: null,
+  [JobType.ShapesExport]: null,
 };
+
+/** The payload-bearing subset (non-null entries) — one BullMQ-contract surface each. */
+const JOB_PAYLOAD_SCHEMAS: readonly { jobType: JobType; schemaRef: string }[] = Object.entries(
+  JOB_SCHEMA_BY_TYPE
+)
+  .filter((entry): entry is [JobType, string] => entry[1] !== null)
+  .map(([jobType, schemaRef]) => ({ jobType, schemaRef }));
 
 /**
  * Route ids exempt from the cross-service contract requirement (not real
  * contracts: static asset serving, liveness). Capped — NOT a growable knownGaps;
- * each future entry carries an inline-comment reason. Empty for now.
+ * each future entry carries an inline reason. Exported as an array (the test reads
+ * `.length`); `generateCoverageTopology` derives a local Set for O(1) per-route
+ * lookup. Empty for now.
  */
-const EXEMPT_ROUTE_IDS = new Set<string>();
+export const EXEMPT_ROUTE_IDS: readonly string[] = [];
+
+/** Files whose existence proves each mechanism is live (repo-relative). */
+const CONFORMANCE_HARNESS =
+  'services/api-gateway/src/routes/conformance/conformance.component.test.ts';
+const GOLDEN_FIXTURE_PRODUCER =
+  'services/bot-client/src/services/contextBuilder/RawEnvelopeContract.producer.test.ts';
+const GOLDEN_FIXTURE_CONSUMER =
+  'services/ai-worker/src/services/context/RawEnvelopeContract.consumer.component.test.ts';
+const BULLMQ_CONTRACT_DIR = 'tests/e2e/contracts';
+
+interface MechanismPresence {
+  /** The route-conformance harness exists (covers all manifest routes via its registry bijection). */
+  routeConformance: boolean;
+  /** Both halves of the golden-fixture envelope contract exist. */
+  goldenFixture: boolean;
+  /** Job schema names referenced by a `.safeParse(`/`.parse(` call in a BullMQ contract test. */
+  bullmqSchemas: Set<string>;
+}
+
+/**
+ * Probe the filesystem ONCE for each mechanism's presence. Route + envelope are
+ * mechanism-level (one harness covers every route via its registry bijection; the
+ * two envelope tests are the single golden-fixture contract); BullMQ is per-job
+ * (each schema name must appear in a contract test). Schema references are matched
+ * with the same `(\w+Schema)\.(safeParse|parse)` primitive the unified test-audit
+ * uses.
+ */
+function buildMechanismPresence(projectRoot: string): MechanismPresence {
+  const bullmqSchemas = new Set<string>();
+  const contractFiles = findFiles(join(projectRoot, BULLMQ_CONTRACT_DIR), /\.contract\.test\.ts$/);
+  for (const file of contractFiles) {
+    // eslint-disable-next-line regexp/no-super-linear-move -- Input is developer-authored TS source (trusted, bounded by file size); ReDoS not a real attack surface
+    for (const match of readFile(file).matchAll(/(\w+Schema)\.(?:safeParse|parse)\(/g)) {
+      bullmqSchemas.add(match[1]);
+    }
+  }
+  return {
+    routeConformance: fileExists(join(projectRoot, CONFORMANCE_HARNESS)),
+    goldenFixture:
+      fileExists(join(projectRoot, GOLDEN_FIXTURE_PRODUCER)) &&
+      fileExists(join(projectRoot, GOLDEN_FIXTURE_CONSUMER)),
+    bullmqSchemas,
+  };
+}
+
+type SurfaceSeed = Omit<CoverageSurface, 'requiredTiers' | 'actualTiers'>;
+
+/**
+ * Whether each mechanism's coverage is present for a given surface. Keyed by
+ * mechanism (a `Record`, like `MECHANISM_TIER`) so a newly-added
+ * `CoverageSurfaceMechanism` is a compile error here rather than a silent
+ * fall-through to the wrong branch.
+ */
+const MECHANISM_PRESENT: Record<
+  CoverageSurfaceMechanism,
+  (seed: SurfaceSeed, presence: MechanismPresence) => boolean
+> = {
+  'route-conformance': (_seed, presence) => presence.routeConformance,
+  'golden-fixture': (_seed, presence) => presence.goldenFixture,
+  'bullmq-contract': (seed, presence) => presence.bullmqSchemas.has(seed.schemaRef),
+};
+
+/** Resolve a seed to a full surface: requiredTiers from its mechanism, actualTiers iff present. */
+function buildSurface(seed: SurfaceSeed, presence: MechanismPresence): CoverageSurface {
+  const tier = MECHANISM_TIER[seed.mechanism];
+  const present = MECHANISM_PRESENT[seed.mechanism](seed, presence);
+  return { ...seed, requiredTiers: [tier], actualTiers: present ? [tier] : [] };
+}
 
 /**
  * Build the code-derived coverage topology by walking `ROUTE_MANIFEST` + the
- * BullMQ payload schemas + the context-assembly envelope. Surfaces are sorted by
- * id for a stable, diff-clean committed artifact.
+ * payload-bearing BullMQ jobs + the context-assembly envelope, verifying each
+ * surface's coverage mechanism against `projectRoot`. Surfaces are sorted by id
+ * for a stable, diff-clean committed artifact.
  */
-export function generateCoverageTopology(): CoverageTopology {
+export function generateCoverageTopology(projectRoot: string = defaultRootDir()): CoverageTopology {
+  const presence = buildMechanismPresence(projectRoot);
+  const exempt = new Set(EXEMPT_ROUTE_IDS);
   const surfaces: CoverageSurface[] = [];
 
   // HTTP routes — each manifest entry is a cross-service surface (typed client →
   // api-gateway handler), covered by the route-conformance harness.
   for (const [id, route] of Object.entries(ROUTE_MANIFEST)) {
-    if (EXEMPT_ROUTE_IDS.has(id)) continue;
-    surfaces.push({
-      id: `client:api-gateway:${id}`,
-      kind: 'http-route',
-      // 'client' = the typed-client layer, not a single service: routes are
-      // called via the generated typed client by whichever service holds it
-      // (internal routes are service-to-service; user/admin are bot-client), so
-      // there's no single producer. The mechanism (route-conformance), not the
-      // producer, drives coverage.
-      producer: 'client',
-      consumer: 'api-gateway',
-      // The route's input/output Zod schemas are named consts in the manifest;
-      // the route id is the stable surface identifier (the conformance harness,
-      // not a schema-grep, is the coverage mechanism).
-      schemaRef: `${route.method.toUpperCase()} ${route.path}`,
-      mechanism: 'route-conformance',
-      requiredTiers: [MECHANISM_TIER['route-conformance']],
-      actualTiers: [MECHANISM_TIER['route-conformance']],
-    });
+    if (exempt.has(id)) continue;
+    surfaces.push(
+      buildSurface(
+        {
+          id: `client:api-gateway:${id}`,
+          kind: 'http-route',
+          // 'client' = the typed-client layer (no single producer service; internal
+          // routes are service-to-service, user/admin are bot-client). The
+          // mechanism, not the producer, drives coverage.
+          producer: 'client',
+          consumer: 'api-gateway',
+          schemaRef: `${route.method.toUpperCase()} ${route.path}`,
+          mechanism: 'route-conformance',
+        },
+        presence
+      )
+    );
   }
 
   // BullMQ jobs — api-gateway produces, ai-worker consumes; the payload schema is
   // the contract, covered by the BullMQ producer/consumer contract tests.
-  for (const [jobType, schemaRef] of Object.entries(JOB_PAYLOAD_SCHEMAS)) {
-    surfaces.push({
-      id: `api-gateway:ai-worker:${jobType}`,
-      kind: 'bullmq-job',
-      producer: 'api-gateway',
-      consumer: 'ai-worker',
-      schemaRef,
-      mechanism: 'bullmq-contract',
-      requiredTiers: [MECHANISM_TIER['bullmq-contract']],
-      actualTiers: [MECHANISM_TIER['bullmq-contract']],
-    });
+  for (const { jobType, schemaRef } of JOB_PAYLOAD_SCHEMAS) {
+    surfaces.push(
+      buildSurface(
+        {
+          id: `api-gateway:ai-worker:${jobType}`,
+          kind: 'bullmq-job',
+          producer: 'api-gateway',
+          consumer: 'ai-worker',
+          schemaRef,
+          mechanism: 'bullmq-contract',
+        },
+        presence
+      )
+    );
   }
 
-  // The bot-client→ai-worker context-assembly envelope (locked by the
-  // golden-fixture contract).
-  surfaces.push({
-    id: 'bot-client:ai-worker:context-assembly',
-    kind: 'context-envelope',
-    producer: 'bot-client',
-    consumer: 'ai-worker',
-    schemaRef: 'rawAssemblyInputsSchema',
-    mechanism: 'golden-fixture',
-    requiredTiers: [MECHANISM_TIER['golden-fixture']],
-    actualTiers: [MECHANISM_TIER['golden-fixture']],
-  });
+  // The bot-client→ai-worker context-assembly envelope (golden-fixture contract).
+  surfaces.push(
+    buildSurface(
+      {
+        id: 'bot-client:ai-worker:context-assembly',
+        kind: 'context-envelope',
+        producer: 'bot-client',
+        consumer: 'ai-worker',
+        schemaRef: 'rawAssemblyInputsSchema',
+        mechanism: 'golden-fixture',
+      },
+      presence
+    )
+  );
 
   surfaces.sort((a, b) => a.id.localeCompare(b.id));
   return { schema: 'coverage-topology/v1', surfaces };
+}
+
+/**
+ * Serialize for the committed artifact: `JSON.stringify(…, 2)` + trailing
+ * newline. The file is byte-compared by `topology:check`, so it MUST be
+ * `.prettierignore`d (prettier collapses short arrays and breaks the compare) —
+ * same contract as `command-manifest.json` and the contract fixtures.
+ */
+function serializeCoverageTopology(topology: CoverageTopology): string {
+  return `${JSON.stringify(topology, null, 2)}\n`;
+}
+
+/** Generate + write the committed topology artifact. Returns the absolute path. */
+export function writeCoverageTopology(projectRoot: string = defaultRootDir()): string {
+  const path = join(projectRoot, COVERAGE_TOPOLOGY_PATH);
+  writeFileSync(path, serializeCoverageTopology(generateCoverageTopology(projectRoot)));
+  return path;
+}
+
+interface TopologyCheckResult {
+  /** True when the committed file matches freshly-generated output byte-for-byte. */
+  upToDate: boolean;
+  /** Absolute path of the committed artifact. */
+  path: string;
+  /** True when the committed file is absent entirely (never generated/committed). */
+  missing: boolean;
+}
+
+/** Regenerate the topology and byte-compare it against the committed artifact (CI drift gate). */
+export function checkCoverageTopology(projectRoot: string = defaultRootDir()): TopologyCheckResult {
+  const path = join(projectRoot, COVERAGE_TOPOLOGY_PATH);
+  if (!fileExists(path)) return { upToDate: false, path, missing: true };
+  const expected = serializeCoverageTopology(generateCoverageTopology(projectRoot));
+  return { upToDate: readFile(path) === expected, path, missing: false };
+}
+
+/**
+ * The monorepo root, resolved from this module's location. The layout mirrors
+ * between src/ (dev, tsx) and dist/ (built), so the same step count reaches root
+ * in either context:  topology/ → {src|dist}/ → tooling/ → packages/ → root.
+ */
+function defaultRootDir(): string {
+  return resolve(dirname(new URL(import.meta.url).pathname), '..', '..', '..', '..');
 }


### PR DESCRIPTION
## Phase 2b — Test-Pyramid epic

Builds on the 2a topology generator (#1341). 2a enumerated cross-service surfaces and **assumed** each one's coverage mechanism present. 2b **verifies** presence against the filesystem and adds the CI drift gate.

### What changed

- **Mechanism-presence verification** — `generateCoverageTopology` now probes the repo for each surface's coverage mechanism and sets `actualTiers` accordingly (empty → a real `surfaceGap`):
  - **routes** → the route-conformance harness exists (`conformance.component.test.ts`; its registry bijection already covers every `ROUTE_MANIFEST` route);
  - **jobs** → the job's `*JobDataSchema` appears in a `.safeParse(`/`.parse(` call under `tests/e2e/contracts/` (per-job, using the same grep primitive as `test:audit`);
  - **envelope** → both halves of the golden-fixture contract exist.
- **`topology:generate --write`** commits `packages/tooling/coverage-topology.json` (`.prettierignore`d like `command-manifest.json` — the `JSON.stringify(…, 2)` tier-arrays would otherwise be collapsed).
- **`topology:check`** — a byte-compare drift gate mirroring `codegen:routes --check`, wired into `pnpm quality` + the CI `lint` job. A new or newly-uncovered surface shows as a one-line diff.

### Folds in the #1341 review items

- Exported `EXEMPT_ROUTE_IDS` (the count assertion now subtracts its length).
- A `Record<JobType, string | null>` exhaustiveness guard — a future payload-bearing `JobType` won't compile until it's classified, so it can't be silently omitted.
- `producer` assertions in the test (route→`client`, job→`api-gateway`, envelope→`bot-client`).
- Trimmed phase-narration prose from the module JSDoc / `MECHANISM_TIER` doc / CLI note; condensed the `producer:'client'` comment.

### Verification

- 154 surfaces, 0 gaps in this repo (all mechanisms shipped); empty-root generation → all surfaces gap (proves presence drives `actualTiers`).
- `pnpm quality` green (includes the new `topology:check`); 8/8 topology unit tests.

The hard ratchet that **fails** on a missing required tier remains a separate, later tool (`test:tier-audit`, Phase 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)