### PR TITLE
feat(tooling): extend test:audit to cover extracted-package Prisma services

### DIFF
--- a/.github/baselines/test-coverage-baseline.json
+++ b/.github/baselines/test-coverage-baseline.json
@@ -1,8 +1,11 @@
 {
-  "version": 10,
-  "lastUpdated": "2026-06-22T19:30:31.634Z",
+  "version": 11,
+  "lastUpdated": "2026-06-25T21:36:40.265Z",
   "services": {
     "detectedPrismaServices": [
+      "packages/conversation-history/src/ConversationHistoryService.ts",
+      "packages/conversation-history/src/ConversationSyncService.ts",
+      "packages/identity/src/UserService.ts",
       "services/ai-worker/src/services/LongTermMemoryService.ts",
       "services/api-gateway/src/services/ConversationRetentionService.ts",
       "services/api-gateway/src/services/LlmConfigService.ts",
@@ -19,9 +22,9 @@
   },
   "meta": {
     "toolVersion": "test-audit/1.0",
-    "configHash": "718cedf41ddc",
+    "configHash": "d3f26f6a5928",
     "nodeVersion": "v24.11.1",
-    "generatedFromSha": "2fc7eeba264c3b7c949ce66aaa07540d085bc5b2",
-    "generatedAt": "2026-06-22T19:30:31.634Z"
+    "generatedFromSha": "018f535fb0a9ae40d1cadfd29714e12a62b793e3",
+    "generatedAt": "2026-06-25T21:36:40.265Z"
   }
 }

--- a/packages/tooling/src/test/audit-unified.test.ts
+++ b/packages/tooling/src/test/audit-unified.test.ts
@@ -346,6 +346,58 @@ export class SimpleService {
       expect(result).toBe(false);
     });
 
+    // Parameterized over EACH new serviceDirs entry independently: a Prisma
+    // service under the extracted package, with no component test and not in the
+    // baseline, must be flagged. If the dir weren't scanned (a path typo in
+    // serviceDirs), findServiceFiles would miss it and the audit would wrongly
+    // pass — so a `false` result proves THAT package is in scope. One case per
+    // dir so a typo in either entry fails its own case.
+    it.each(['packages/identity/src', 'packages/conversation-history/src'])(
+      'scans extracted package %s so its Prisma services are ratcheted',
+      async (pkgDir: string) => {
+        mockExistsSync.mockImplementation((path: string) => {
+          if (path.includes('.component.test.ts')) return false;
+          if (path.includes('test-coverage-baseline')) return true;
+          if (path.includes(pkgDir)) return true;
+          return false;
+        });
+
+        mockReaddirSync.mockImplementation((dir: string) =>
+          dir.includes(pkgDir) ? ['ExtractedService.ts'] : []
+        );
+
+        mockStatSync.mockImplementation((path: string) => ({
+          isDirectory: () => !path.includes('.ts'),
+          isFile: () => path.includes('.ts'),
+        }));
+
+        mockReadFileSync.mockImplementation((path: string) => {
+          if (path.includes('test-coverage-baseline')) {
+            return JSON.stringify({
+              version: 1,
+              lastUpdated: '2024-01-01',
+              services: { knownGaps: [] }, // ExtractedService NOT in baseline → new gap
+              contracts: { knownGaps: [] },
+              notes: {
+                serviceExemptionCriteria: 'Services are auto-detected for Prisma usage',
+                contractExemptionCriteria: 'None',
+              },
+              meta: VALID_BASELINE_META,
+            });
+          }
+          if (path.includes('ExtractedService.ts')) {
+            return createServiceWithPrisma();
+          }
+          return '';
+        });
+
+        const { auditUnified } = await import('./audit-unified.js');
+        const result = await auditUnified();
+
+        expect(result).toBe(false);
+      }
+    );
+
     it('should auto-exempt services without Prisma usage', async () => {
       mockExistsSync.mockImplementation((path: string) => {
         if (path.includes('.component.test.ts')) return false;

--- a/packages/tooling/src/test/audit-unified.ts
+++ b/packages/tooling/src/test/audit-unified.ts
@@ -64,6 +64,12 @@ function findServiceFiles(projectRoot: string): string[] {
     join(projectRoot, 'services/api-gateway/src'),
     join(projectRoot, 'services/bot-client/src'),
     join(projectRoot, 'packages/common-types/src'),
+    // Packages outside `services/` that hold Prisma-backed services. Scanned so
+    // their component-test coverage is ratcheted too — otherwise deleting one of
+    // their component tests would silently drop the gate. Add a package here when
+    // it gains a Prisma-using `*Service.ts`.
+    join(projectRoot, 'packages/identity/src'),
+    join(projectRoot, 'packages/conversation-history/src'),
   ];
 
   for (const dir of serviceDirs) {

--- a/packages/tooling/src/test/audit-version.ts
+++ b/packages/tooling/src/test/audit-version.ts
@@ -16,5 +16,8 @@
  *   v2 — PRISMA_PATTERNS: replaced the dead `getPrismaClient(` matcher
  *        (deleted in the singleton eviction) with `createPrismaClient(`,
  *        the post-eviction Prisma entry point.
+ *   v3 — serviceDirs: added `packages/identity` + `packages/conversation-history`
+ *        (Prisma-service packages extracted into standalone packages, previously
+ *        outside the scan scope) so their component-test coverage is ratcheted.
  */
-export const TEST_AUDIT_IMPL_VERSION = 2;
+export const TEST_AUDIT_IMPL_VERSION = 3;


### PR DESCRIPTION
## What

`test:audit`'s `serviceDirs` only scanned `ai-worker` / `api-gateway` / `bot-client` / `common-types`. The common-types **slimming epic** extracted Prisma-backed services into new packages that the audit never learned about:

- `packages/identity` — `UserService`, `PersonalityService`
- `packages/conversation-history` — `ConversationHistoryService`, `ConversationSyncService`

So their component-test coverage **wasn't ratcheted** — deleting one of their component tests would have silently dropped the gate (the exact hole the extraction opened). This adds those two `src` dirs to `serviceDirs`.

All 4 services **already have component tests**, so the refreshed baseline records **zero new gaps**: 7 Prisma services covered / 0 gaps; 222 schemas / 0 gaps. `TEST_AUDIT_IMPL_VERSION` bumped 2→3 (the measurement changed) and the baseline meta refreshed via `test:audit --update`.

## Why this and not the planned `test:tier-audit` ratchet

This is the "one small enforcement extension" chosen after a 3-model council pass (GLM-5.2 / Kimi-K2.7 / Qwen-3.7) on the test-pyramid epic's planned standalone `test:tier-audit` ratchet. The council **unanimously** recommended **not** building that broad per-area tier-matrix tool:

- It would **duplicate** `test:audit` (artifact→tier) + `topology:check` (154 cross-service surfaces) — the high-value enforcement already exists.
- With `integration=1` / `e2e=0`, a "every area needs every tier" ratchet would baseline almost the whole repo as a gap — *"guarding an empty room."*

Instead: keep `test:tiers` report-only as the dashboard, and **complete the existing tools' coverage**. This PR is that completion. The epic's enforcement-bulk item is retired (recorded in the epic docs post-merge); the real remaining work is **Phase 3 gap-fill** (writing the near-zero integration/contract coverage).

## Verification
`test:audit` passes (0 gaps); `audit-unified.test.ts` 16/16; `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)