### PR TITLE
fix(ai-worker): fast-fallback on z.ai overload + correct footer model-link

### DIFF
--- a/packages/common-types/src/constants/ai.test.ts
+++ b/packages/common-types/src/constants/ai.test.ts
@@ -99,6 +99,15 @@ describe('buildModelInfoUrl', () => {
       );
     });
 
+    it('should strip the z-ai/ prefix before the catalog lookup', () => {
+      // A `z-ai/`-prefixed model can reach the z.ai branch (e.g. an auto-promotion
+      // fallback whose model retains the prefix). The prefix must be stripped so
+      // the dedicated docs page resolves instead of the generic overview fallback.
+      expect(buildModelInfoUrl('z-ai/glm-5.2', 'zai-coding')).toBe(
+        'https://docs.z.ai/guides/llm/glm-5.2'
+      );
+    });
+
     it('should fall back to the coding-plan overview for unknown z.ai models', () => {
       // Defensive: shouldn't fire for promoted routes (promotion requires
       // catalog membership), but covers stale/manual `provider: 'zai-coding'`

--- a/packages/common-types/src/constants/ai.ts
+++ b/packages/common-types/src/constants/ai.ts
@@ -357,7 +357,14 @@ export function buildModelInfoUrl(model: string, provider: string | undefined): 
   // module evaluation — by the time any consumer calls this function, the
   // enum is fully populated.
   if (provider === AIProvider.ZaiCoding) {
-    return ZAI_MODEL_CATALOG[model.toLowerCase()]?.docsUrl ?? ZAI_CODING_OVERVIEW_URL;
+    // Strip the `z-ai/` namespace prefix before the catalog lookup: the catalog
+    // keys are bare (`glm-5.2`), but a prefixed `z-ai/glm-5.2` can reach here
+    // (e.g. an auto-promotion fallback whose model retains the prefix). Mirrors
+    // `getZaiCodingPlanContextLength`'s prefix tolerance so the docs link
+    // resolves instead of falling back to the generic overview page.
+    const lower = model.toLowerCase();
+    const bare = lower.startsWith(ZAI_MODEL_PREFIX) ? lower.slice(ZAI_MODEL_PREFIX.length) : lower;
+    return ZAI_MODEL_CATALOG[bare]?.docsUrl ?? ZAI_CODING_OVERVIEW_URL;
   }
   // OpenRouter (and any unknown provider — falls through to OpenRouter as
   // the historical default; ElevenLabs is voice-only and never hits this

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/GenerationStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/GenerationStep.ts
@@ -42,6 +42,7 @@ import {
   logRetrySuccess,
   selectBetterFallback,
   logFallbackUsed,
+  restoreThinking,
   type FallbackResponse,
 } from './RetryDecisionHelper.js';
 import { storeDiagnosticLog } from './diagnosticStorage.js';
@@ -59,17 +60,6 @@ export class GenerationStep implements IPipelineStep {
     private readonly prisma: PrismaClient,
     private readonly embeddingService?: EmbeddingServiceInterface
   ) {}
-
-  /** Inject preserved reasoning into a response that lacks its own */
-  private restoreThinking(response: RAGResponse, preserved: string | undefined): void {
-    if (
-      (response.thinkingContent === undefined || response.thinkingContent.length === 0) &&
-      preserved !== undefined &&
-      preserved.length > 0
-    ) {
-      response.thinkingContent = preserved;
-    }
-  }
 
   /**
    * Generate response with cross-turn duplication and empty response retry.
@@ -93,6 +83,7 @@ export class GenerationStep implements IPipelineStep {
     diagnosticCollector?: DiagnosticCollector;
     configOverrides?: ResolvedConfigOverrides;
     effectiveProvider?: AIProvider;
+    maxLlmAttempts?: number;
   }): Promise<{
     response: RAGResponse;
     duplicateRetries: number;
@@ -151,6 +142,9 @@ export class GenerationStep implements IPipelineStep {
           // Capped from the provider the request actually hits: z.ai-direct uses
           // z.ai's documented limit, OpenRouter fallthrough uses the OR cache.
           effectiveProvider,
+          // 1 for the auto-promotion primary attempt (fail fast → OpenRouter
+          // fallback on a z.ai transient/429); undefined elsewhere (default budget).
+          maxLlmAttempts: opts.maxLlmAttempts,
         });
       } catch (error) {
         // LLM invocation failed entirely. If we have a fallback from a prior
@@ -158,7 +152,7 @@ export class GenerationStep implements IPipelineStep {
         // instead of propagating the error and losing valid content.
         if (fallback !== undefined) {
           logFallbackUsed(fallback, jobId);
-          this.restoreThinking(fallback.response, preservedThinking);
+          restoreThinking(fallback.response, preservedThinking);
           return {
             response: fallback.response,
             duplicateRetries,
@@ -186,7 +180,7 @@ export class GenerationStep implements IPipelineStep {
       }
       if (emptyAction === 'return') {
         emptyRetries++;
-        this.restoreThinking(response, preservedThinking);
+        restoreThinking(response, preservedThinking);
         return { response, duplicateRetries, emptyRetries, leakedThinkingRetries };
       }
 
@@ -227,7 +221,7 @@ export class GenerationStep implements IPipelineStep {
             leakedThinkingRetries,
           });
         }
-        this.restoreThinking(response, preservedThinking);
+        restoreThinking(response, preservedThinking);
         return { response, duplicateRetries, emptyRetries, leakedThinkingRetries };
       }
 
@@ -243,7 +237,7 @@ export class GenerationStep implements IPipelineStep {
         isGuestMode,
       });
       if (dupAction === 'return') {
-        this.restoreThinking(response, preservedThinking);
+        restoreThinking(response, preservedThinking);
         return { response, duplicateRetries, emptyRetries, leakedThinkingRetries };
       }
     }
@@ -315,26 +309,31 @@ export class GenerationStep implements IPipelineStep {
       // request to z.ai-direct: if the z.ai call fails entirely (any error — most likely
       // catalog-drift 404 or auth issue from a stale whitelist), retry once via the
       // pre-computed OpenRouter fallback route. Defense in depth on the whitelist.
-      const { response, duplicateRetries, emptyRetries, leakedThinkingRetries } =
-        await runWithAutoPromotionFallback(
-          opts => this.generateWithDuplicateRetry(opts),
-          {
-            personality: effectivePersonality,
-            message: message as MessageContent,
-            conversationContext,
-            recentAssistantMessages,
-            apiKey,
-            sttDispatch: auth.sttDispatch,
-            isGuestMode,
-            jobId: job.id,
-            diagnosticCollector,
-            configOverrides: context.configOverrides,
-            // Primary attempt routes to the resolved provider; the fallback
-            // wrapper overrides this to OpenRouter if it swaps to the fallback.
-            effectiveProvider: provider,
-          },
-          auth.wasAutoPromoted === true ? auth.fallback : undefined
-        );
+      const {
+        response,
+        duplicateRetries,
+        emptyRetries,
+        leakedThinkingRetries,
+        effectiveProviderUsed,
+      } = await runWithAutoPromotionFallback(
+        opts => this.generateWithDuplicateRetry(opts),
+        {
+          personality: effectivePersonality,
+          message: message as MessageContent,
+          conversationContext,
+          recentAssistantMessages,
+          apiKey,
+          sttDispatch: auth.sttDispatch,
+          isGuestMode,
+          jobId: job.id,
+          diagnosticCollector,
+          configOverrides: context.configOverrides,
+          // Primary attempt routes to the resolved provider; the fallback
+          // wrapper overrides this to OpenRouter if it swaps to the fallback.
+          effectiveProvider: provider,
+        },
+        auth.wasAutoPromoted === true ? auth.fallback : undefined
+      );
 
       // Store memory ONCE after retry loop completes with a valid response.
       // This prevents duplicate memories when retries occur (the fix for the
@@ -412,7 +411,7 @@ export class GenerationStep implements IPipelineStep {
             metadata: {
               processingTimeMs,
               modelUsed: response.modelUsed,
-              providerUsed: provider,
+              providerUsed: effectiveProviderUsed ?? provider,
               configSource,
               isGuestMode,
               // Include thinking content so it can be shown even on failure
@@ -441,7 +440,9 @@ export class GenerationStep implements IPipelineStep {
             tokensOut: response.tokensOut,
             processingTimeMs,
             modelUsed: response.modelUsed,
-            providerUsed: provider,
+            // Effective provider after any auto-promotion fallback swap (OpenRouter
+            // when the promoted z.ai call failed), so the footer links correctly.
+            providerUsed: effectiveProviderUsed ?? provider,
             configSource,
             isGuestMode,
             crossTurnDuplicateDetected: duplicateRetries > 0,

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/RetryDecisionHelper.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/RetryDecisionHelper.ts
@@ -21,6 +21,23 @@ export interface FallbackResponse {
 }
 
 /**
+ * Inject preserved reasoning into a response that lacks its own. Some models
+ * don't reliably emit reasoning at escalated retry temperature, so the retry
+ * loop carries forward reasoning captured on an earlier attempt. Mutates the
+ * response in place. No-op when the response already has reasoning or there's
+ * nothing preserved to restore.
+ */
+export function restoreThinking(response: RAGResponse, preserved: string | undefined): void {
+  if (
+    (response.thinkingContent === undefined || response.thinkingContent.length === 0) &&
+    preserved !== undefined &&
+    preserved.length > 0
+  ) {
+    response.thinkingContent = preserved;
+  }
+}
+
+/**
  * Fallback quality ranking: duplicate > leaked-thinking > empty.
  * - duplicate: in-character content, just repeated
  * - leaked-thinking: has content, just wrong kind (raw CoT)

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/autoPromotionFallback.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/autoPromotionFallback.test.ts
@@ -110,11 +110,13 @@ describe('runWithAutoPromotionFallback', () => {
 
     expect(attempt).toHaveBeenCalledTimes(2);
     // First call: original opts (zai-coding personality + zai key); the cap
-    // source stays z.ai for the promoted attempt.
+    // source stays z.ai for the promoted attempt. Capped at a single LLM attempt
+    // so a z.ai transient/429 swaps to the fallback immediately (no 3×retry burn).
     expect(attempt.mock.calls[0]?.[0]).toMatchObject({
       personality: { provider: 'zai-coding', model: 'glm-5.1' },
       apiKey: 'zai-key',
       effectiveProvider: AIProvider.ZaiCoding,
+      maxLlmAttempts: 1,
     });
     // Second call: swapped to openrouter personality + fallback key, and the
     // cap source swaps to OpenRouter too (the fallback runs there).
@@ -124,7 +126,11 @@ describe('runWithAutoPromotionFallback', () => {
       isGuestMode: false,
       effectiveProvider: AIProvider.OpenRouter,
     });
-    expect(result).toBe(fallbackResult);
+    // The fallback keeps the default retry budget — only the primary fails fast.
+    expect(attempt.mock.calls[1]?.[0]?.maxLlmAttempts).toBeUndefined();
+    // Result is the fallback's, tagged with the effective provider (OpenRouter)
+    // so the response footer links to the OpenRouter model card, not z.ai docs.
+    expect(result).toEqual({ ...fallbackResult, effectiveProviderUsed: AIProvider.OpenRouter });
   });
 
   it('should propagate ORIGINAL error when fallback retry also fails', async () => {

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/autoPromotionFallback.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/autoPromotionFallback.ts
@@ -47,6 +47,8 @@ export interface GenerateAttemptOpts {
   configOverrides?: ResolvedConfigOverrides;
   /** Provider the attempt routes to — drives the context-window cap source. */
   effectiveProvider?: AIProvider;
+  /** LLM transient-retry budget override; set to 1 on the fail-fast primary attempt. */
+  maxLlmAttempts?: number;
 }
 
 export interface GenerateAttemptResult {
@@ -54,6 +56,15 @@ export interface GenerateAttemptResult {
   duplicateRetries: number;
   emptyRetries: number;
   leakedThinkingRetries: number;
+  /**
+   * The provider that actually served the request when it differs from the
+   * configured/promoted provider — set to `OpenRouter` only when the fallback
+   * swap fired. `undefined` on the happy path (no swap), where the caller's
+   * resolved provider is already the effective one. Drives the response
+   * footer's model-info link so an OpenRouter-served request links to the
+   * OpenRouter model card, not the z.ai docs page.
+   */
+  effectiveProviderUsed?: AIProvider;
 }
 
 type GenerateAttempt = (opts: GenerateAttemptOpts) => Promise<GenerateAttemptResult>;
@@ -85,7 +96,10 @@ export async function runWithAutoPromotionFallback(
   }
 
   try {
-    return await attempt(opts);
+    // Fail fast on the primary attempt: a fallback exists, so a transient z.ai
+    // failure (429/overload) should swap to OpenRouter immediately rather than
+    // burning the full ~3×retry budget (a z.ai 429 can take ~110s per attempt).
+    return await attempt({ ...opts, maxLlmAttempts: 1 });
   } catch (originalError) {
     logger.warn(
       {
@@ -106,7 +120,7 @@ export async function runWithAutoPromotionFallback(
     };
 
     try {
-      return await attempt({
+      const fallbackResult = await attempt({
         ...opts,
         personality: fallbackPersonality,
         apiKey: fallback.apiKey,
@@ -115,6 +129,9 @@ export async function runWithAutoPromotionFallback(
         // so the context-window cap must now derive from OpenRouter, not z.ai.
         effectiveProvider: AIProvider.OpenRouter,
       });
+      // OpenRouter actually served this request (the promoted z.ai call failed),
+      // so report it as the effective provider for the footer model-info link.
+      return { ...fallbackResult, effectiveProviderUsed: AIProvider.OpenRouter };
     } catch (fallbackError) {
       logger.error(
         { jobId: opts.jobId, err: originalError, fallbackErr: fallbackError },

--- a/services/ai-worker/src/services/ConversationalRAGService.ts
+++ b/services/ai-worker/src/services/ConversationalRAGService.ts
@@ -109,6 +109,7 @@ export class ConversationalRAGService {
       referencedMessagesDescriptions,
       userApiKey,
       retryConfig,
+      maxLlmAttempts,
       diagnosticCollector: diagnosticCollectorRef,
     } = opts;
     // Cast from opaque DiagnosticCollectorRef to concrete type (safe — callers always pass DiagnosticCollector)
@@ -204,6 +205,7 @@ export class ConversationalRAGService {
       cacheKeyId,
       imageCount,
       audioCount,
+      maxAttempts: maxLlmAttempts,
     });
 
     // Non-text parts (thinking blocks, images) are intentionally excluded —
@@ -424,6 +426,7 @@ export class ConversationalRAGService {
         referencedMessagesDescriptions: inputs.referencedMessagesDescriptions,
         userApiKey,
         retryConfig,
+        maxLlmAttempts: options.maxLlmAttempts,
         diagnosticCollector,
       });
 

--- a/services/ai-worker/src/services/ConversationalRAGTypes.ts
+++ b/services/ai-worker/src/services/ConversationalRAGTypes.ts
@@ -319,6 +319,14 @@ export interface ModelInvocationOptions {
   retryConfig?: DuplicateRetryConfig;
   /** Diagnostic collector for the "flight recorder" system */
   diagnosticCollector?: DiagnosticCollectorRef;
+  /**
+   * Override for the LLM transient-retry attempt count (default
+   * `RETRY_CONFIG.MAX_ATTEMPTS`). The auto-promotion fallback sets this to 1 for
+   * the primary (z.ai) attempt so a transient failure (e.g. a 429 overload)
+   * falls through to the OpenRouter fallback immediately instead of burning the
+   * full ~3×retry budget. The fallback attempt keeps the default.
+   */
+  maxLlmAttempts?: number;
 }
 
 /**
@@ -384,4 +392,11 @@ export interface GenerateResponseOptions {
    * catalog safety-net (see `resolveEffectiveContextWindow`).
    */
   effectiveProvider?: AIProvider;
+  /**
+   * Override for the LLM transient-retry attempt count (default
+   * `RETRY_CONFIG.MAX_ATTEMPTS`). Forwarded to `invokeWithRetry`. Set to 1 by the
+   * auto-promotion fallback for the primary (z.ai) attempt so a transient
+   * failure falls through to the OpenRouter fallback fast.
+   */
+  maxLlmAttempts?: number;
 }

--- a/services/ai-worker/src/services/LLMInvoker.ts
+++ b/services/ai-worker/src/services/LLMInvoker.ts
@@ -111,6 +111,13 @@ interface InvokeWithRetryOptions {
   imageCount?: number;
   /** Number of audio attachments in the request (for timeout calculation) */
   audioCount?: number;
+  /**
+   * Override for the transient-retry attempt count. Defaults to
+   * `RETRY_CONFIG.MAX_ATTEMPTS`. Callers set this to 1 to fail fast on the first
+   * error when a higher-level fallback (e.g. ProviderRouter's OpenRouter
+   * passthrough) is the intended recovery path rather than in-place retry.
+   */
+  maxAttempts?: number;
 }
 
 export class LLMInvoker {
@@ -148,7 +155,15 @@ export class LLMInvoker {
    * - Reasoning model support (o1, Claude 3.7+, Gemini Thinking)
    */
   async invokeWithRetry(options: InvokeWithRetryOptions): Promise<BaseMessage> {
-    const { model, messages, modelName, cacheKeyId = '', imageCount = 0, audioCount = 0 } = options;
+    const {
+      model,
+      messages,
+      modelName,
+      cacheKeyId = '',
+      imageCount = 0,
+      audioCount = 0,
+      maxAttempts = RETRY_CONFIG.MAX_ATTEMPTS,
+    } = options;
 
     if (cacheKeyId.length === 0) {
       // An empty `cacheKeyId` skips both caches entirely — currently used by
@@ -228,7 +243,7 @@ export class LLMInvoker {
       result = await withRetry(
         () => this.invokeSingleAttempt(model, transformedMessages, modelName),
         {
-          maxAttempts: RETRY_CONFIG.MAX_ATTEMPTS,
+          maxAttempts,
           globalTimeoutMs,
           logger,
           operationName: `LLM invocation (${modelName})`,


### PR DESCRIPTION
## What

Two production fixes for the z.ai-coding auto-promotion path, both surfaced when z.ai was transiently overloaded (HTTP 429 code 1305) earlier today.

### 1. Fast-fallback on z.ai overload (was ~5.5min → ~2min)

When `ProviderRouter` auto-promotes an OpenRouter `z-ai/<model>` request to z.ai-direct, `AuthStep` attaches a pre-computed OpenRouter fallback route. Confirmed in prod logs: the fallback *fired correctly*, but the promoted z.ai attempt burned the **full 3× transient-retry budget** first (each z.ai 429 takes ~110s to return) before the OpenRouter swap.

Fix: cap the **primary** attempt at `maxLlmAttempts: 1` when an auto-promotion fallback exists, so a z.ai transient/429 swaps to OpenRouter after one attempt (~2min). The OpenRouter fallback keeps the full retry budget. Side benefit: the rate-limit cache populates after 1 attempt instead of 3, so the fast 15-min cached-cooldown window starts sooner. Default-preserving — only the auto-promotion-with-fallback primary attempt changes.

### 2. Correct footer model-link after fallback

After the swap to OpenRouter serving `z-ai/glm-5.2`, the response metadata's `providerUsed` still read the *configured* `zai-coding` provider, so `buildModelInfoUrl` took the z.ai branch with the prefixed model, missed the bare-keyed catalog, and linked to the generic `docs.z.ai/devpack/overview`.

Fix (two layers):
- `autoPromotionFallback` now reports the effective post-swap provider (`OpenRouter`) via `effectiveProviderUsed` on its result; `GenerationStep` uses it for `providerUsed` → footer links to the OpenRouter model card.
- Defense-in-depth: `buildModelInfoUrl` strips the `z-ai/` prefix in the z.ai branch (mirrors `getZaiCodingPlanContextLength`), so a prefixed model still resolves the catalog.

## Why not catchable by a test before now

- **footer link (pure-function half)** — a unit gap in `buildModelInfoUrl`: existing tests covered bare names + OpenRouter, but not prefixed-model + z.ai provider. Test added.
- **footer link (cross-seam half)** — the `providerUsed`-across-fallback metadata contract between `autoPromotionFallback` (producer) and `GenerationStep` (consumer). Contract/component-tier. Now asserted in `autoPromotionFallback.test.ts`.
- **slowness** — an emergent performance behavior under an upstream failure mode (z.ai 429 overload); no standard tier catches "slow under overload" prophylactically. The new `maxLlmAttempts: 1` assertion is a regression lock, not something a test would have caught proactively.

## Verification

- `pnpm test` green (ai-worker 140 files / 3244 tests; common-types all pass)
- `pnpm quality` green
- `restoreThinking` extracted to `RetryDecisionHelper.ts` to keep `GenerationStep` under the 400-line cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eb3oUpB4jGi2sRDWMHtMKb