### PR TITLE
test: extend the envelope contract to cross-channel, voice, and mention seams

### DIFF
--- a/packages/test-utils/fixtures/contracts/raw-assembly-inputs/personal-summon-mention.json
+++ b/packages/test-utils/fixtures/contracts/raw-assembly-inputs/personal-summon-mention.json
@@ -1,0 +1,25 @@
+{
+  "rawMessageContent": "hey <@700700700700700700> check this out",
+  "rawAuthorDisplayName": "Contract User",
+  "rawMentionedUsers": [
+    {
+      "discordId": "700700700700700700",
+      "username": "mentioned",
+      "displayName": "Mentioned User"
+    }
+  ],
+  "knownChannelEnvironments": {
+    "channel-cross-1": {
+      "type": "guild",
+      "guild": {
+        "id": "guild-1",
+        "name": "Contract Guild"
+      },
+      "channel": {
+        "id": "channel-cross-1",
+        "name": "cross-channel",
+        "type": "GUILD_TEXT"
+      }
+    }
+  }
+}

--- a/packages/test-utils/fixtures/contracts/raw-assembly-inputs/voice-trigger.json
+++ b/packages/test-utils/fixtures/contracts/raw-assembly-inputs/voice-trigger.json
@@ -1,0 +1,19 @@
+{
+  "rawMessageContent": "",
+  "rawRoutingTranscript": "the spoken words from a voice note",
+  "rawAuthorDisplayName": "Voice User",
+  "knownChannelEnvironments": {
+    "channel-cross-1": {
+      "type": "guild",
+      "guild": {
+        "id": "guild-1",
+        "name": "Contract Guild"
+      },
+      "channel": {
+        "id": "channel-cross-1",
+        "name": "cross-channel",
+        "type": "GUILD_TEXT"
+      }
+    }
+  }
+}

--- a/packages/test-utils/fixtures/contracts/raw-assembly-inputs/with-channel-environment.json
+++ b/packages/test-utils/fixtures/contracts/raw-assembly-inputs/with-channel-environment.json
@@ -1,0 +1,30 @@
+{
+  "rawMessageContent": "what is happening in the other channels",
+  "rawAuthorDisplayName": "Contract User",
+  "knownChannelEnvironments": {
+    "channel-cross-1": {
+      "type": "guild",
+      "guild": {
+        "id": "guild-1",
+        "name": "Contract Guild"
+      },
+      "channel": {
+        "id": "channel-cross-1",
+        "name": "cross-channel-one",
+        "type": "GUILD_TEXT"
+      }
+    },
+    "channel-cross-2": {
+      "type": "guild",
+      "guild": {
+        "id": "guild-1",
+        "name": "Contract Guild"
+      },
+      "channel": {
+        "id": "channel-cross-2",
+        "name": "cross-channel-two",
+        "type": "GUILD_TEXT"
+      }
+    }
+  }
+}

--- a/services/ai-worker/src/services/context/RawEnvelopeContract.consumer.contract.test.ts
+++ b/services/ai-worker/src/services/context/RawEnvelopeContract.consumer.contract.test.ts
@@ -15,13 +15,17 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import {
   PrismaClient,
+  MessageRole,
   generateUserUuid,
   generatePersonaUuid,
   generatePersonalityUuid,
   generateSystemPromptUuid,
+  generateConversationHistoryUuid,
   rawAssemblyInputsSchema,
   type JobContext,
   type LoadedPersonality,
+  type ResolvedConfigOverrides,
+  type DiscordEnvironment,
 } from '@tzurot/common-types';
 import { UserService, PersonaResolver } from '@tzurot/identity';
 import {
@@ -38,6 +42,9 @@ import { PrismaContextDataSource } from './PrismaContextDataSource.js';
 const DISCORD_USER_ID = '123456789012345678';
 const CHANNEL_ID = 'test-channel-987';
 const GUILD_ID = 'test-guild-654';
+// A real 18-digit snowflake — the mention rewriter drops ids that fail
+// isValidDiscordId, so the personal-summon-mention fixture must use a valid one.
+const MENTIONED_DISCORD_ID = '700700700700700700';
 
 /** Parse a committed contract fixture through the real wire schema. */
 const fixtureEnvelope = (name: string) =>
@@ -89,6 +96,52 @@ describe('RawEnvelope contract — consumer derivation over PGLite', () => {
     // (mirrors ContextAssembler.component.test.ts).
     personality = { id: personalityId, name: 'ContractBot' } as LoadedPersonality;
 
+    // Cross-channel rows for the with-channel-environment fixture: same
+    // persona+personality the trigger user resolves to (cross-channel history is
+    // persona-scoped), in OTHER channels. channel-cross-1 is in the fixture's env
+    // map (decorated by its name); channel-cross-3 is NOT (falls back to id-only).
+    // channel-cross-2 is in the env map but seeded with NO rows — the consumer
+    // must not emit a spurious group for it (asserted in the cross-channel test).
+    const contractPersonaId = generatePersonaUuid('contract-user', userId);
+    const seedCrossTurn = (chId: string, content: string, createdAt: Date, dmId: string) =>
+      prisma.conversationHistory.create({
+        data: {
+          id: generateConversationHistoryUuid(chId, personalityId, contractPersonaId, createdAt),
+          channelId: chId,
+          guildId: GUILD_ID,
+          personalityId,
+          personaId: contractPersonaId,
+          role: MessageRole.User,
+          content,
+          discordMessageId: [dmId],
+          createdAt,
+        },
+      });
+    await seedCrossTurn(
+      'channel-cross-1',
+      'cross turn in channel one',
+      new Date('2026-06-01T09:00:00Z'),
+      'xc-1'
+    );
+    await seedCrossTurn(
+      'channel-cross-3',
+      'cross turn in channel three',
+      new Date('2026-06-01T08:00:00Z'),
+      'xc-3'
+    );
+
+    // The @-mentioned user in the personal-summon-mention fixture, with a persona
+    // named 'Mentioned' — the rewrite resolves the mention to this name. The id is
+    // a real snowflake because resolveUserMentions drops toy ids via isValidDiscordId.
+    const mentionedUserId = generateUserUuid(MENTIONED_DISCORD_ID);
+    await seedUserWithPersona(prisma, {
+      userId: mentionedUserId,
+      personaId: generatePersonaUuid('mentioned', mentionedUserId),
+      discordId: MENTIONED_DISCORD_ID,
+      username: 'mentioned',
+      personaName: 'Mentioned',
+    });
+
     assembler = new ContextAssembler({
       dataSource: new PrismaContextDataSource(prisma),
       userService: new UserService(prisma),
@@ -135,9 +188,69 @@ describe('RawEnvelope contract — consumer derivation over PGLite', () => {
     // history — the key derivation this envelope field enables.
     expect(core.history.map(m => m.content)).toContain('an earlier message from the channel');
     // The producer's rawMessageContent still drives the consumer's messageContent.
-    // (Mention-token REWRITING is summon-mode- and personality-dependent — the
-    // mention kernel's domain, covered by mentionRewriter's own tests — not the
-    // envelope→consumer seam this contract locks.)
     expect(core.messageContent).toContain('with context');
+  });
+
+  it('voice-trigger fixture: the routing transcript stays telemetry-only (content empty)', async () => {
+    const core = await assembler.assembleCore(
+      jobContext(fixtureEnvelope('voice-trigger')),
+      personality,
+      undefined
+    );
+
+    // A voice trigger ships EMPTY rawMessageContent + the bot-side STT text on
+    // rawRoutingTranscript (telemetry). The worker derives its OWN transcript via
+    // the attachment path, so the assembled prompt content must stay empty here —
+    // the routing transcript must NOT leak into it. Locks the ground-truth
+    // content/transcript split end-to-end (producer emits the split; consumer
+    // respects it).
+    expect(core.messageContent).toBe('');
+  });
+
+  it('with-channel-environment fixture: cross-channel groups decorate from the envelope env map', async () => {
+    const core = await assembler.assembleCore(
+      jobContext(fixtureEnvelope('with-channel-environment')),
+      personality,
+      // Partial cast: the cross-channel path reads crossChannelHistoryEnabled and
+      // guards the other required fields (maxMessages/maxAge) with ?? fallbacks, so
+      // leaving them unset is safe here.
+      { crossChannelHistoryEnabled: true } as ResolvedConfigOverrides
+    );
+
+    expect(core.crossChannelHistory).toBeDefined();
+    const groups = core.crossChannelHistory ?? [];
+    const allContent = groups.flatMap(g => g.messages.map(m => m.content));
+    // The persona-scoped DB query returns both other channels' rows...
+    expect(allContent).toContain('cross turn in channel one');
+    expect(allContent).toContain('cross turn in channel three');
+
+    // ...decorated from the envelope's knownChannelEnvironments: channel-cross-1
+    // is in the map (named), channel-cross-3 is not (id-only fallback). This is
+    // the producer→consumer seam — the env names come from the REAL fixture map.
+    const byChannel = (id: string): DiscordEnvironment | undefined =>
+      groups.find(g => g.channelEnvironment.channel.id === id)?.channelEnvironment;
+    expect(byChannel('channel-cross-1')?.channel.name).toBe('cross-channel-one');
+    expect(byChannel('channel-cross-3')?.channel.name).toBe('unknown-channel');
+    // channel-cross-2 is in the env map but has no seeded rows → no group. The
+    // query is history-first (the env map only decorates fetched rows), so an
+    // in-map channel with no history must not produce a spurious group.
+    expect(byChannel('channel-cross-2')).toBeUndefined();
+  });
+
+  it('personal-summon-mention fixture: the mentioned user resolves + the token is rewritten', async () => {
+    const core = await assembler.assembleCore(
+      jobContext(fixtureEnvelope('personal-summon-mention')),
+      personality,
+      undefined
+    );
+
+    // The mention id rides the producer's rawMentionedUsers (the normal
+    // path, distinct from the component test's DB-fallback). A personal summon
+    // rewrites the token out and surfaces the resolved persona — locking that the
+    // consumer consumes rawMentionedUsers the producer actually emits.
+    expect(core.messageContent).not.toContain(`<@${MENTIONED_DISCORD_ID}>`);
+    expect(core.mentionedPersonas).toContainEqual(
+      expect.objectContaining({ personaName: 'Mentioned' })
+    );
   });
 });

--- a/services/bot-client/src/services/contextBuilder/RawEnvelopeContract.producer.test.ts
+++ b/services/bot-client/src/services/contextBuilder/RawEnvelopeContract.producer.test.ts
@@ -15,27 +15,47 @@
  * The two producer internals (`VoiceMessageProcessor.getVoiceTranscript`,
  * `buildKnownChannelEnvironments`) are mocked deterministically — natural here,
  * colocated in bot-client, exactly as the pilot `RawEnvelopeBuilder.test.ts` does.
+ * A scenario configures them per-case via `mockReturnValueOnce` for the seams
+ * (voice transcript, cross-channel env map) it exercises.
+ *
+ * Parameterization is intentionally ASYMMETRIC with the consumer half: the
+ * producer is a uniform build→snapshot, so a data-driven SCENARIOS table is the
+ * clean shape; the consumer's per-scenario assertions + DB seeding diverge too
+ * much for a table and stay explicit `it` blocks.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { contractFixtureFile, stableFixtureJson } from '@tzurot/test-utils';
-import { MessageRole, type ConversationMessage } from '@tzurot/common-types';
+import {
+  MessageRole,
+  type ConversationMessage,
+  type DiscordEnvironment,
+  type RawAssemblyInputs,
+} from '@tzurot/common-types';
 import type { Message } from 'discord.js';
 
-const { mockGetVoiceTranscript } = vi.hoisted(() => ({
+const { mockGetVoiceTranscript, mockBuildKnownChannelEnvironments } = vi.hoisted(() => ({
   mockGetVoiceTranscript: vi.fn((): string | undefined => undefined),
+  // Default mirrors the historical single-entry map so the base /
+  // with-extended-context fixtures regenerate byte-identical; the cross-channel
+  // scenario overrides it with `mockReturnValueOnce` for its own richer map. The
+  // explicit return type keeps `mockReturnValueOnce` open to any env-map shape
+  // (without it TS pins the type to this single-key literal).
+  mockBuildKnownChannelEnvironments: vi.fn(
+    (): Record<string, DiscordEnvironment> => ({
+      'channel-cross-1': {
+        type: 'guild',
+        guild: { id: 'guild-1', name: 'Contract Guild' },
+        channel: { id: 'channel-cross-1', name: 'cross-channel', type: 'GUILD_TEXT' },
+      },
+    })
+  ),
 }));
 vi.mock('../../processors/VoiceMessageProcessor.js', () => ({
   VoiceMessageProcessor: { getVoiceTranscript: mockGetVoiceTranscript },
 }));
 vi.mock('../CrossChannelHistoryFetcher.js', () => ({
-  buildKnownChannelEnvironments: vi.fn(() => ({
-    'channel-cross-1': {
-      type: 'guild',
-      guild: { id: 'guild-1', name: 'Contract Guild' },
-      channel: { id: 'channel-cross-1', name: 'cross-channel', type: 'GUILD_TEXT' },
-    },
-  })),
+  buildKnownChannelEnvironments: mockBuildKnownChannelEnvironments,
 }));
 
 import { buildRawAssemblyInputs } from './RawEnvelopeBuilder.js';
@@ -50,10 +70,117 @@ const makeMessage = (
     mentions: { users: new Map(mentions.map(m => [m.id, m])) },
   }) as unknown as Message;
 
+/**
+ * A contract scenario: a name (= fixture file stem) and a builder that runs the
+ * real producer (configuring the per-seam mocks it needs first) and returns the
+ * envelope to snapshot.
+ */
+interface ProducerScenario {
+  name: string;
+  build: () => RawAssemblyInputs;
+}
+
+const extendedMessage = {
+  id: 'ext-1',
+  role: MessageRole.User,
+  content: 'an earlier message from the channel',
+  createdAt: new Date('2026-06-01T09:00:00Z'),
+  personaId: 'discord:444',
+  discordUsername: 'earlier-user',
+  discordMessageId: ['ext-dm-1'],
+  channelId: 'test-channel-987',
+  guildId: 'test-guild-654',
+} as ConversationMessage;
+
+const SCENARIOS: ProducerScenario[] = [
+  {
+    name: 'base',
+    // Plain text trigger, no extended context.
+    build: () =>
+      buildRawAssemblyInputs(makeMessage([], 'hello from the contract test'), undefined, {
+        rawAuthorDisplayName: 'Contract User',
+      }),
+  },
+  {
+    name: 'with-extended-context',
+    // Mention + one prior extended-context turn.
+    build: () =>
+      buildRawAssemblyInputs(
+        makeMessage(
+          [{ id: '333', username: 'target', globalName: 'Target' }],
+          '<@333> with context'
+        ),
+        {
+          messages: [extendedMessage],
+          extendedContextUsers: [
+            { discordId: '444', username: 'earlier-user', displayName: 'Earlier', isBot: false },
+          ],
+          reactorUsers: [],
+        },
+        { rawAuthorDisplayName: 'Contract User' }
+      ),
+  },
+  {
+    name: 'voice-trigger',
+    // A voice trigger: Discord content is EMPTY (ground truth), the bot-side STT
+    // transcript rides rawRoutingTranscript as telemetry only. Locks the
+    // content/transcript split at the producer; the consumer half asserts the
+    // worker does NOT leak the transcript into the prompt content.
+    build: () => {
+      mockGetVoiceTranscript.mockReturnValueOnce('the spoken words from a voice note');
+      return buildRawAssemblyInputs(makeMessage([], ''), undefined, {
+        rawAuthorDisplayName: 'Voice User',
+      });
+    },
+  },
+  {
+    name: 'with-channel-environment',
+    // A trigger whose knownChannelEnvironments names two cross-channels. The
+    // consumer fetches cross-channel groups from its OWN DB and decorates them
+    // with these names; a third (unmapped) channel exercises the fallback.
+    build: () => {
+      mockBuildKnownChannelEnvironments.mockReturnValueOnce({
+        'channel-cross-1': {
+          type: 'guild',
+          guild: { id: 'guild-1', name: 'Contract Guild' },
+          channel: { id: 'channel-cross-1', name: 'cross-channel-one', type: 'GUILD_TEXT' },
+        },
+        'channel-cross-2': {
+          type: 'guild',
+          guild: { id: 'guild-1', name: 'Contract Guild' },
+          channel: { id: 'channel-cross-2', name: 'cross-channel-two', type: 'GUILD_TEXT' },
+        },
+      });
+      return buildRawAssemblyInputs(
+        makeMessage([], 'what is happening in the other channels'),
+        undefined,
+        { rawAuthorDisplayName: 'Contract User' }
+      );
+    },
+  },
+  {
+    name: 'personal-summon-mention',
+    // A mention the producer captures into rawMentionedUsers (the normal path,
+    // distinct from the component test's DB-fallback/absent path). The consumer
+    // resolves the mentioned user's persona and rewrites the token. The id must
+    // be a real 18-digit snowflake — resolveUserMentions filters mention ids
+    // through isValidDiscordId, so a toy id is silently dropped (never rewritten).
+    build: () =>
+      buildRawAssemblyInputs(
+        makeMessage(
+          [{ id: '700700700700700700', username: 'mentioned', globalName: 'Mentioned User' }],
+          'hey <@700700700700700700> check this out'
+        ),
+        undefined,
+        { rawAuthorDisplayName: 'Contract User' }
+      ),
+  },
+];
+
 describe('RawEnvelope contract — producer fixture generation', () => {
-  // Per 02-code-standards "Fake Timers (ALWAYS Use)". This test uses no timers
-  // and only an explicit fixed date string (not Date.now()/argless new Date()),
-  // so faking is a no-op on the output — present for rule-consistency.
+  // Per 02-code-standards "Fake Timers (ALWAYS Use)". These scenarios use no
+  // timers and only explicit fixed date strings (not Date.now()/argless new
+  // Date()), so faking is a no-op on the output — present for rule-consistency.
   beforeEach(() => {
     vi.useFakeTimers();
   });
@@ -61,43 +188,13 @@ describe('RawEnvelope contract — producer fixture generation', () => {
     vi.restoreAllMocks();
   });
 
-  it('base: plain text trigger (no extended context)', async () => {
-    const envelope = buildRawAssemblyInputs(
-      makeMessage([], 'hello from the contract test'),
-      undefined,
-      { rawAuthorDisplayName: 'Contract User' }
-    );
-    await expect(stableFixtureJson(envelope)).toMatchFileSnapshot(
-      contractFixtureFile('raw-assembly-inputs/base.json')
-    );
-  });
-
-  it('with-extended-context: mention + one prior extended-context turn', async () => {
-    const extendedMessage = {
-      id: 'ext-1',
-      role: MessageRole.User,
-      content: 'an earlier message from the channel',
-      createdAt: new Date('2026-06-01T09:00:00Z'),
-      personaId: 'discord:444',
-      discordUsername: 'earlier-user',
-      discordMessageId: ['ext-dm-1'],
-      channelId: 'test-channel-987',
-      guildId: 'test-guild-654',
-    } as ConversationMessage;
-
-    const envelope = buildRawAssemblyInputs(
-      makeMessage([{ id: '333', username: 'target', globalName: 'Target' }], '<@333> with context'),
-      {
-        messages: [extendedMessage],
-        extendedContextUsers: [
-          { discordId: '444', username: 'earlier-user', displayName: 'Earlier', isBot: false },
-        ],
-        reactorUsers: [],
-      },
-      { rawAuthorDisplayName: 'Contract User' }
-    );
-    await expect(stableFixtureJson(envelope)).toMatchFileSnapshot(
-      contractFixtureFile('raw-assembly-inputs/with-extended-context.json')
-    );
-  });
+  it.each(SCENARIOS)(
+    '$name: real producer output matches the committed fixture',
+    async ({ name, build }) => {
+      const envelope = build();
+      await expect(stableFixtureJson(envelope)).toMatchFileSnapshot(
+        contractFixtureFile(`raw-assembly-inputs/${name}.json`)
+      );
+    }
+  );
 });


### PR DESCRIPTION
## What

Test-Pyramid Phase 4, **PR4 — envelope scenarios**. Extends the bot-client→ai-worker golden-fixture envelope contract (the #1340 flagship) to the three seams it left untested — the seams where prod bugs have historically clustered. Test-only; no production code.

## Why

The #1340 contract locked the core content + extended-context envelope seam, but three remained uncovered (tracked in `active-epic.md`'s #1340 grab-bag): cross-channel env decoration, the voice ground-truth split, and mention rewriting via `rawMentionedUsers`.

## Scenarios added

| Fixture | Producer emits | Consumer locks |
| --- | --- | --- |
| `voice-trigger` | empty `rawMessageContent` + `rawRoutingTranscript` | `messageContent === ''` — the routing transcript stays **telemetry-only**, never leaking into the prompt (the ground-truth split, producer→consumer) |
| `with-channel-environment` | a 2-entry `knownChannelEnvironments` map | persona-scoped cross-channel groups decorate from the **envelope's** env names (named on a hit, id-only fallback on a miss) |
| `personal-summon-mention` | a `<@…>` mention + `rawMentionedUsers` | the consumer resolves the mentioned persona and rewrites the token — the **normal** path, distinct from the component test's DB-fallback/absent path |

## Shape

- **Producer half** refactored to a data-driven `SCENARIOS` table (`it.each`), snapshotting each through real `buildRawAssemblyInputs`. The two existing fixtures regenerate **byte-identical** (the default env mock is preserved), confirming no drift.
- **Consumer half** stays explicit `it` blocks over PGLite — per-scenario assertions + DB seeding diverge too much for a table. The asymmetry is documented in both files to pre-empt the "why not symmetric?" nit.
- Three committed fixtures under `@tzurot/test-utils` — the contract artifact; neither service imports the other (depcruise boundary intact).

## Verification

- bot-client full suite 5115 ✓ · ai-worker full suite 3262 ✓ · `pnpm quality` ✓
- Fixtures regenerated from real producer output (`--update`); the consumer parses + drives all five through the real `ContextAssembler`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
