### PR TITLE
feat(tooling): upgrade coverage topology from presence to execution check

### DIFF
--- a/packages/tooling/src/topology/coverageTopology.test.ts
+++ b/packages/tooling/src/topology/coverageTopology.test.ts
@@ -12,6 +12,7 @@ import {
   COVERAGE_TOPOLOGY_PATH,
   EXEMPT_ROUTE_IDS,
 } from './coverageTopology.js';
+import { clearFileImportCache } from './importAssertions.js';
 
 describe('generateCoverageTopology', () => {
   // Default root resolves to the repo root, so presence checks run against the
@@ -77,6 +78,57 @@ describe('generateCoverageTopology', () => {
     expect(empty.surfaces.length).toBe(topology.surfaces.length);
     expect(empty.surfaces.every(s => s.actualTiers.length === 0)).toBe(true);
     expect(empty.surfaces.every(s => surfaceGap(s).length === 1)).toBe(true);
+  });
+
+  it('flags a CIRCULAR bullmq test (schemas referenced, but producer never imports createJobChain) as a gap', () => {
+    // The execution-check's whole point: the OLD presence check ("a schema
+    // safeParse appears") marks the jobs covered even for a circular test that
+    // hand-rolls its payload. The producer-import requirement closes that — schema
+    // present AND producer imports the REAL createJobChain.
+    const tmpRoot = mkdtempSync(join(tmpdir(), 'topo-circular-'));
+    const bullmqJobs = (root: string) =>
+      generateCoverageTopology(root).surfaces.filter(s => s.kind === 'bullmq-job');
+    const producerPath = join(
+      tmpRoot,
+      'services/api-gateway/src/utils/BullMQJobChainContract.producer.test.ts'
+    );
+    // Clear before the try (not in finally) for a known-empty starting state. No
+    // finally-clear needed: tmpRoot paths are distinct from real project paths, so
+    // the entries left here don't interfere with checkCoverageTopology's real-path
+    // reads (those cache-miss and re-read fresh).
+    clearFileImportCache();
+    try {
+      // A consumer-side contract test referencing all three job schemas — enough
+      // for the old presence check to consider the jobs covered.
+      const contractDir = join(tmpRoot, 'tests/e2e/contracts');
+      mkdirSync(contractDir, { recursive: true });
+      writeFileSync(
+        join(contractDir, 'jobs.contract.test.ts'),
+        'audioTranscriptionJobDataSchema.safeParse(x);\n' +
+          'imageDescriptionJobDataSchema.safeParse(x);\n' +
+          'llmGenerationJobDataSchema.parse(x);\n'
+      );
+      mkdirSync(dirname(producerPath), { recursive: true });
+
+      // Circular: the producer hand-rolls a payload, importing the SCHEMA but never
+      // the real createJobChain. All three job surfaces must still gap.
+      writeFileSync(
+        producerPath,
+        "import { llmGenerationJobDataSchema } from '@tzurot/common-types';\n"
+      );
+      expect(bullmqJobs(tmpRoot).every(s => surfaceGap(s).length === 1)).toBe(true);
+
+      // Contrast: import the real producer → the jobs are now covered. (Clear the
+      // per-path import cache between the two reads of the same file.)
+      clearFileImportCache();
+      writeFileSync(
+        producerPath,
+        "import { createJobChain } from './jobChainOrchestrator.js';\ncreateJobChain();\n"
+      );
+      expect(bullmqJobs(tmpRoot).every(s => s.actualTiers.length === 1)).toBe(true);
+    } finally {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/tooling/src/topology/coverageTopology.ts
+++ b/packages/tooling/src/topology/coverageTopology.ts
@@ -10,7 +10,11 @@
  *
  * Coverage is **mechanism-based per surface class** (NOT a fuzzy global
  * schema-grep): each class has exactly one coverage mechanism, and a surface is
- * "covered" iff that mechanism's test is present on disk —
+ * "covered" iff that mechanism's test EXERCISES the real producer/consumer —
+ * proven statically by the test IMPORTING the real symbol (`REAL_IMPORTS`), not
+ * merely by a file existing or a schema string appearing. A circular test (a
+ * hand-written payload validated against its own schema, importing neither the
+ * real producer nor consumer) fails this and is reported as a gap —
  *  - http-route       → the route-conformance harness (component tier)
  *  - bullmq-job       → the BullMQ producer/consumer contract tests (contract tier)
  *  - context-envelope → the golden-fixture contract (contract tier)
@@ -29,6 +33,7 @@ import { JobType } from '@tzurot/common-types';
 
 import { findFiles, fileExists, readFile } from '../test/audit-utils.js';
 import type { TestTier } from '../test/test-tiers.js';
+import { fileImportsSymbol } from './importAssertions.js';
 
 /** How a surface's contract coverage is provided. */
 export type CoverageSurfaceMechanism = 'route-conformance' | 'bullmq-contract' | 'golden-fixture';
@@ -110,31 +115,90 @@ const JOB_PAYLOAD_SCHEMAS: readonly { jobType: JobType; schemaRef: string }[] = 
  */
 export const EXEMPT_ROUTE_IDS: readonly string[] = [];
 
-/** Files whose existence proves each mechanism is live (repo-relative). */
+/** The contract test files whose REAL imports prove each mechanism is live (repo-relative). */
 const CONFORMANCE_HARNESS =
   'services/api-gateway/src/routes/conformance/conformance.component.test.ts';
 const GOLDEN_FIXTURE_PRODUCER =
   'services/bot-client/src/services/contextBuilder/RawEnvelopeContract.producer.test.ts';
 const GOLDEN_FIXTURE_CONSUMER =
   'services/ai-worker/src/services/context/RawEnvelopeContract.consumer.contract.test.ts';
+const BULLMQ_PRODUCER_TEST =
+  'services/api-gateway/src/utils/BullMQJobChainContract.producer.test.ts';
 const BULLMQ_CONTRACT_DIR = 'tests/e2e/contracts';
 
+/**
+ * The REAL producer/consumer symbol each mechanism's test must import — the
+ * execution-check that tells a real contract test apart from a CIRCULAR one
+ * (which imports its own schema but neither the real producer nor consumer).
+ * Each entry is (file, exported symbol, module-specifier fragment). `noUnusedLocals`
+ * (root tsconfig) guarantees a present import is USED, so importing the symbol is
+ * sufficient proof the test exercises it — no call-site analysis needed.
+ *
+ * Maintenance: renaming a source module (or moving a test file) requires updating
+ * the matching `from`/`file` here. The check fails CLOSED — the surface shows as
+ * uncovered and `topology:check` fires — so a stale entry is loud, never silent.
+ */
+const REAL_IMPORTS = {
+  /** The harness drives the real route replay from the manifest + the per-route registry. */
+  conformanceRegistry: {
+    file: CONFORMANCE_HARNESS,
+    symbol: 'CONFORMANCE_REGISTRY',
+    // Leading `/` anchors to the path separator: a sibling whose name merely
+    // contains "registry" without a preceding slash won't match. (Scoped to one
+    // file anyway, so this is defense-in-depth against a careless future entry.)
+    from: '/fixtures/registry',
+  },
+  conformanceManifest: {
+    file: CONFORMANCE_HARNESS,
+    symbol: 'ROUTE_MANIFEST',
+    from: '@tzurot/clients',
+  },
+  /** The envelope golden-fixture: producer runs the real builder, consumer runs the real assembler. */
+  envelopeProducer: {
+    file: GOLDEN_FIXTURE_PRODUCER,
+    symbol: 'buildRawAssemblyInputs',
+    from: '/RawEnvelopeBuilder',
+  },
+  envelopeConsumer: {
+    file: GOLDEN_FIXTURE_CONSUMER,
+    symbol: 'ContextAssembler',
+    // Leading `/` so a sibling like `./PrismaContextAssembler.js` can't match by substring.
+    from: '/ContextAssembler',
+  },
+  /**
+   * The BullMQ golden-fixture producer runs the real job-chain orchestrator. ONE
+   * check covers all three job surfaces: the producer test exercises all three job
+   * types (its audio+image and text-only scenarios emit audio/image/llm payloads),
+   * and per-job discrimination is the consumer-side `bullmqSchemas` scan — so a
+   * future payload-bearing job added without a contract test still gaps via that
+   * gate, even though this coarse producer-import boolean stays true.
+   */
+  bullmqProducer: {
+    file: BULLMQ_PRODUCER_TEST,
+    symbol: 'createJobChain',
+    from: '/jobChainOrchestrator',
+  },
+} as const;
+
 interface MechanismPresence {
-  /** The route-conformance harness exists (covers all manifest routes via its registry bijection). */
-  routeConformance: boolean;
-  /** Both halves of the golden-fixture envelope contract exist. */
-  goldenFixture: boolean;
+  /** The conformance harness imports the real route manifest + per-route registry (drives the replay). */
+  routeImportsReal: boolean;
+  /** Producer imports the real envelope builder AND consumer imports the real assembler. */
+  envelopeImportsReal: boolean;
+  /** The BullMQ producer test imports the real `createJobChain` (so the fixture is real output). */
+  bullmqProducerImportsReal: boolean;
   /** Job schema names referenced by a `.safeParse(`/`.parse(` call in a BullMQ contract test. */
   bullmqSchemas: Set<string>;
 }
 
 /**
- * Probe the filesystem ONCE for each mechanism's presence. Route + envelope are
- * mechanism-level (one harness covers every route via its registry bijection; the
- * two envelope tests are the single golden-fixture contract); BullMQ is per-job
- * (each schema name must appear in a contract test). Schema references are matched
- * with the same `(\w+Schema)\.(safeParse|parse)` primitive the unified test-audit
- * uses.
+ * Probe the filesystem ONCE for each mechanism. The EXECUTION check is whether the
+ * mechanism's test IMPORTS the real producer/consumer symbol (`REAL_IMPORTS`) — a
+ * circular test (hand-written payload vs. its own schema, importing neither side)
+ * fails it. The import probe returns false for an absent file, so it also subsumes
+ * the old file-existence check. BullMQ additionally keeps the per-job schema scan
+ * (the real consumer-validation gate), matched with the same
+ * `(\w+Schema)\.(safeParse|parse)` primitive the unified test-audit uses.
  */
 function buildMechanismPresence(projectRoot: string): MechanismPresence {
   const bullmqSchemas = new Set<string>();
@@ -145,11 +209,14 @@ function buildMechanismPresence(projectRoot: string): MechanismPresence {
       bullmqSchemas.add(match[1]);
     }
   }
+  const imports = (spec: { file: string; symbol: string; from: string }): boolean =>
+    fileImportsSymbol(join(projectRoot, spec.file), spec.symbol, spec.from);
   return {
-    routeConformance: fileExists(join(projectRoot, CONFORMANCE_HARNESS)),
-    goldenFixture:
-      fileExists(join(projectRoot, GOLDEN_FIXTURE_PRODUCER)) &&
-      fileExists(join(projectRoot, GOLDEN_FIXTURE_CONSUMER)),
+    routeImportsReal:
+      imports(REAL_IMPORTS.conformanceRegistry) && imports(REAL_IMPORTS.conformanceManifest),
+    envelopeImportsReal:
+      imports(REAL_IMPORTS.envelopeProducer) && imports(REAL_IMPORTS.envelopeConsumer),
+    bullmqProducerImportsReal: imports(REAL_IMPORTS.bullmqProducer),
     bullmqSchemas,
   };
 }
@@ -166,9 +233,10 @@ const MECHANISM_PRESENT: Record<
   CoverageSurfaceMechanism,
   (seed: SurfaceSeed, presence: MechanismPresence) => boolean
 > = {
-  'route-conformance': (_seed, presence) => presence.routeConformance,
-  'golden-fixture': (_seed, presence) => presence.goldenFixture,
-  'bullmq-contract': (seed, presence) => presence.bullmqSchemas.has(seed.schemaRef),
+  'route-conformance': (_seed, presence) => presence.routeImportsReal,
+  'golden-fixture': (_seed, presence) => presence.envelopeImportsReal,
+  'bullmq-contract': (seed, presence) =>
+    presence.bullmqSchemas.has(seed.schemaRef) && presence.bullmqProducerImportsReal,
 };
 
 /** Resolve a seed to a full surface: requiredTiers from its mechanism, actualTiers iff present. */

--- a/packages/tooling/src/topology/importAssertions.test.ts
+++ b/packages/tooling/src/topology/importAssertions.test.ts
@@ -1,0 +1,124 @@
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, vi } from 'vitest';
+
+// ts-morph has a cold-start cost (~500ms locally, 10-15s on slow CI runners under
+// load) that can exceed the default 5s timeout. 30s gives sufficient headroom.
+vi.setConfig({ testTimeout: 30_000 });
+
+import {
+  parseNamedImports,
+  contentImportsSymbol,
+  fileImportsSymbol,
+  clearFileImportCache,
+} from './importAssertions.js';
+
+describe('parseNamedImports', () => {
+  it('extracts each VALUE named import with its module specifier', () => {
+    const code = `
+import { createJobChain } from './jobChainOrchestrator.js';
+import { ContextAssembler, type Foo } from './ContextAssembler.js';
+`;
+    // `type Foo` is an inline type-only specifier → excluded (it doesn't exercise
+    // the runtime value, so it can't prove the test runs the real symbol).
+    expect(parseNamedImports(code)).toEqual([
+      { symbol: 'createJobChain', source: './jobChainOrchestrator.js' },
+      { symbol: 'ContextAssembler', source: './ContextAssembler.js' },
+    ]);
+  });
+
+  it('excludes a type-only import declaration (`import type {...}`)', () => {
+    // The bypass this guards: a circular test could `import type` the real producer
+    // and use it in a type annotation to satisfy a value-import check.
+    const code = `import type { createJobChain } from './jobChainOrchestrator.js';`;
+    expect(parseNamedImports(code)).toEqual([]);
+  });
+
+  it('handles multi-line named imports', () => {
+    const code = `
+import {
+  audioTranscriptionJobDataSchema,
+  llmGenerationJobDataSchema,
+} from '@tzurot/common-types';
+`;
+    expect(parseNamedImports(code).map(i => i.symbol)).toEqual([
+      'audioTranscriptionJobDataSchema',
+      'llmGenerationJobDataSchema',
+    ]);
+  });
+
+  it('returns the ORIGINAL exported name for an aliased import (not the local alias)', () => {
+    const code = `import { createJobChain as cjc } from './jobChainOrchestrator.js';`;
+    expect(parseNamedImports(code)).toEqual([
+      { symbol: 'createJobChain', source: './jobChainOrchestrator.js' },
+    ]);
+  });
+
+  it('ignores default and namespace imports (named imports only)', () => {
+    const code = `
+import request from 'supertest';
+import * as orch from './jobChainOrchestrator.js';
+import { ROUTE_MANIFEST } from '@tzurot/clients';
+`;
+    expect(parseNamedImports(code)).toEqual([
+      { symbol: 'ROUTE_MANIFEST', source: '@tzurot/clients' },
+    ]);
+  });
+});
+
+describe('contentImportsSymbol', () => {
+  const code = `import { createJobChain } from './jobChainOrchestrator.js';`;
+
+  it('matches a named import of the symbol from a module containing the fragment', () => {
+    expect(contentImportsSymbol(code, 'createJobChain', 'jobChainOrchestrator')).toBe(true);
+  });
+
+  it('rejects when the symbol is absent (the circular-test shape)', () => {
+    // A circular test that hand-writes a payload imports only the SCHEMA, never
+    // the real producer — this is the regression the upgrade catches.
+    const circular = `import { llmGenerationJobDataSchema } from '@tzurot/common-types';`;
+    expect(contentImportsSymbol(circular, 'createJobChain', 'jobChainOrchestrator')).toBe(false);
+  });
+
+  it('rejects when the symbol is imported from the WRONG module', () => {
+    const fake = `import { createJobChain } from './fake-shim.js';`;
+    expect(contentImportsSymbol(fake, 'createJobChain', 'jobChainOrchestrator')).toBe(false);
+  });
+
+  it('rejects a TYPE-ONLY import of the real symbol (the type-import bypass)', () => {
+    const typeOnly = `import type { createJobChain } from './jobChainOrchestrator.js';`;
+    expect(contentImportsSymbol(typeOnly, 'createJobChain', 'jobChainOrchestrator')).toBe(false);
+  });
+});
+
+describe('fileImportsSymbol', () => {
+  it('returns false for an absent file (a missing contract half, not a crash)', () => {
+    expect(
+      fileImportsSymbol(
+        '/tmp/__no_such_import_assert__.ts',
+        'createJobChain',
+        'jobChainOrchestrator'
+      )
+    ).toBe(false);
+  });
+
+  it('reads + matches a real file, and re-reads after the cache is cleared', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'import-assert-'));
+    const file = join(dir, 'probe.ts');
+    try {
+      // Circular shape: imports only the schema, not the real producer.
+      writeFileSync(file, "import { llmGenerationJobDataSchema } from '@tzurot/common-types';\n");
+      expect(fileImportsSymbol(file, 'createJobChain', 'jobChainOrchestrator')).toBe(false);
+
+      // Without a cache clear the stale (false) result would persist; clearing
+      // forces a re-read, so the rewritten file now matches.
+      clearFileImportCache();
+      writeFileSync(file, "import { createJobChain } from './jobChainOrchestrator.js';\n");
+      expect(fileImportsSymbol(file, 'createJobChain', 'jobChainOrchestrator')).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      clearFileImportCache();
+    }
+  });
+});

--- a/packages/tooling/src/topology/importAssertions.ts
+++ b/packages/tooling/src/topology/importAssertions.ts
@@ -1,0 +1,137 @@
+/**
+ * Import-assertion helper for the coverage topology.
+ *
+ * The topology's coverage signal is upgraded from "a contract test FILE exists /
+ * a schema string APPEARS" to "the contract test IMPORTS the real
+ * producer/consumer symbol." A circular test — one that hand-writes a payload and
+ * validates it against its own schema, importing NEITHER the real producer nor
+ * the real consumer — imports no real symbol and is therefore reported as a gap.
+ *
+ * Why an import check is enough (no call-site/witness analysis): the repo's root
+ * tsconfig sets `noUnusedLocals: true`, so an imported symbol that is never used
+ * is a `tsc` error. A *present* import is therefore necessarily *used* — detecting
+ * the import alone proves the test exercises the real symbol. This guarantee holds
+ * end-to-end only because CI runs `typecheck` alongside `test` (vitest/esbuild
+ * transpile away an unused import; tsc is what rejects it).
+ *
+ * Named imports only (the convention across the contract tests, enforced by
+ * `02-code-standards.md` "import from source modules"). Two shapes the substring
+ * match would miss — both unused here: a namespace import (`import * as x`, which
+ * has no named bindings) and a barrel re-export (`import { createJobChain } from
+ * './index.js'`, whose specifier wouldn't include the source-module fragment).
+ * `getName()` returns the original exported name, so an aliased import
+ * (`import { createJobChain as cjc }`) still matches `createJobChain`.
+ *
+ * Uses ts-morph in in-memory mode — the proven `xray/file-parser.ts` pattern.
+ */
+
+import { Project } from 'ts-morph';
+
+import { fileExists, readFile } from '../test/audit-utils.js';
+
+/** A named import paired with the module specifier it came from. */
+export interface NamedImport {
+  /** The original exported name (not the local alias). */
+  symbol: string;
+  /** The raw module specifier, e.g. `./jobChainOrchestrator.js` or `@tzurot/clients`. */
+  source: string;
+}
+
+// One shared in-memory project — ts-morph cold-start is ~500ms, so reuse it
+// across calls (same rationale as xray/file-parser.ts). Callers must be SERIAL:
+// createSourceFile reuses a fixed filename with `overwrite: true`, so a concurrent
+// (e.g. Promise.all) caller would clobber another's source mid-parse. The topology
+// probe calls these serially.
+const project = new Project({ useInMemoryFileSystem: true });
+
+/**
+ * Parse the named imports (symbol + module specifier) from TypeScript source
+ * content. Pure over its input — the unit-test entry point.
+ *
+ * @remarks Not concurrency-safe: reuses one shared in-memory source file
+ * (`overwrite: true`), so a `Promise.all` over multiple calls would clobber one
+ * another mid-parse. Call serially (the topology probe does).
+ */
+export function parseNamedImports(content: string): NamedImport[] {
+  const sourceFile = project.createSourceFile('__import_assert__.ts', content, { overwrite: true });
+  const result: NamedImport[] = [];
+  for (const decl of sourceFile.getImportDeclarations()) {
+    // Type-only imports don't exercise the runtime value, so they don't prove the
+    // test runs the real producer/consumer — a circular test could `import type`
+    // the real symbol (using it only in a type annotation) and fake coverage. Skip
+    // both the `import type {...}` declaration form and the inline `import { type X }`.
+    if (decl.isTypeOnly()) {
+      continue;
+    }
+    const source = decl.getModuleSpecifierValue();
+    for (const named of decl.getNamedImports()) {
+      if (named.isTypeOnly()) {
+        continue;
+      }
+      result.push({ symbol: named.getName(), source });
+    }
+  }
+  return result;
+}
+
+/**
+ * True iff `content` has a named import of `symbol` whose module specifier
+ * includes `fromModuleMatch` (a substring match — the producer/consumer modules
+ * are imported by relative path or package name, both stable enough to match on).
+ *
+ * Anchor `fromModuleMatch` with a leading `/` for a relative module (e.g.
+ * `/ContextAssembler`) so a sibling like `./PrismaContextAssembler.js` can't
+ * satisfy the check by substring; a distinctive package name (`@tzurot/clients`)
+ * needs no anchor.
+ *
+ * @remarks Serial-only — delegates to {@link parseNamedImports} (see its remarks).
+ */
+export function contentImportsSymbol(
+  content: string,
+  symbol: string,
+  fromModuleMatch: string
+): boolean {
+  return parseNamedImports(content).some(
+    i => i.symbol === symbol && i.source.includes(fromModuleMatch)
+  );
+}
+
+// The probe queries the same file for multiple symbols (e.g. the conformance
+// harness for both CONFORMANCE_REGISTRY and ROUTE_MANIFEST), so cache the parsed
+// imports per absolute path. An absent file caches an empty list (→ uncovered).
+const fileImportCache = new Map<string, NamedImport[]>();
+
+function namedImportsForFile(absPath: string): NamedImport[] {
+  const cached = fileImportCache.get(absPath);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const imports = fileExists(absPath) ? parseNamedImports(readFile(absPath)) : [];
+  fileImportCache.set(absPath, imports);
+  return imports;
+}
+
+/**
+ * True iff the file at `absPath` imports `symbol` from a module matching
+ * `fromModuleMatch`. False when the file is absent (a missing contract half is an
+ * uncovered surface, not a crash).
+ *
+ * Results are cached per path for the PROCESS lifetime — safe because every
+ * `topology:generate` / `topology:check` invocation runs in a fresh `tsx` process,
+ * so a file cannot change between two reads within one run. (Tests that rewrite a
+ * fixture between assertions call `clearFileImportCache`.)
+ */
+export function fileImportsSymbol(
+  absPath: string,
+  symbol: string,
+  fromModuleMatch: string
+): boolean {
+  return namedImportsForFile(absPath).some(
+    i => i.symbol === symbol && i.source.includes(fromModuleMatch)
+  );
+}
+
+/** Clear the per-path cache (for tests that rewrite fixture files between cases). */
+export function clearFileImportCache(): void {
+  fileImportCache.clear();
+}


### PR DESCRIPTION
## What

Test-Pyramid Phase 4, **PR5 — execution-check ratchet**. The coverage topology marked a cross-service surface "covered" when its test *file existed* or a schema string *appeared* in a `safeParse` call. This upgrades the signal to **"the contract test imports the REAL producer/consumer symbol"** — a circular test (hand-written payload validated against its own schema, importing neither side) imports neither and flips `actualTiers` to `[]`, which the existing `topology:check` byte-compare catches.

## Why

"A `safeParse` call appears" is *exactly* what a circular test satisfies — the kind PR3 deleted. The presence check couldn't tell a real producer→consumer contract from a self-satisfying stub. This structurally prevents that regression class (the original motivation for the whole epic).

> `noUnusedLocals: true` (root tsconfig) makes a present-but-unused import a `tsc` error, so **import-detection ⇒ "imported AND used"** — no call-site/witness AST needed.

## Design — council-unanimous (GLM-5.2 / Kimi-K2.7-code / Qwen-3.7-max)

**Option A** (fold the import-assertion into the topology probe so the existing byte-compare *is* the ratchet — no new baseline, no new CI gate) **+ AST over regex** (via ts-morph, reusing the `xray/file-parser.ts` pattern). The council's compile-time-harness third framing was declined (collides with the depcruise boundary that splits the golden-fixture halves; additive, not a replacement) → filed as a follow-up.

## Changes

| File | Change |
| --- | --- |
| `importAssertions.ts` (NEW) | ts-morph named-import extraction (`fileImportsSymbol`); + colocated 7-test unit suite |
| `coverageTopology.ts` | per-mechanism `REAL_IMPORTS`; probe asserts harness→`ROUTE_MANIFEST`+`CONFORMANCE_REGISTRY`, envelope→`buildRawAssemblyInputs`+`ContextAssembler`, BullMQ producer→`createJobChain` (AND the existing schema scan) |
| `coverageTopology.test.ts` | a test proving the exact circular regression (schemas referenced, producer never imports `createJobChain` → gap) |

## Verification

- `pnpm --filter @tzurot/tooling test` — 1116 green (incl. the new files); `pnpm quality` green.
- **Correctness:** `pnpm ops topology:generate --write` → `git diff` on `coverage-topology.json` is **empty** (the stronger check regresses no current surface).
- **Negative proof:** stripping the `createJobChain` import → `topology:check` reports "out of sync with code" (the bullmq surfaces flip to gaps). The ratchet bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)