### PR TITLE
feat(voice-engine): cross-language JSON-response contract (golden-fixture + TS Zod)

### DIFF
--- a/packages/test-utils/fixtures/contracts/voice-engine/health.json
+++ b/packages/test-utils/fixtures/contracts/voice-engine/health.json
@@ -1,0 +1,6 @@
+{
+  "status": "ok",
+  "asr_loaded": true,
+  "tts_loaded": true,
+  "voices_loaded": 0
+}

--- a/packages/test-utils/fixtures/contracts/voice-engine/transcribe.json
+++ b/packages/test-utils/fixtures/contracts/voice-engine/transcribe.json
@@ -1,0 +1,3 @@
+{
+  "text": "Hello, this is a test transcription."
+}

--- a/packages/test-utils/fixtures/contracts/voice-engine/voices.json
+++ b/packages/test-utils/fixtures/contracts/voice-engine/voices.json
@@ -1,0 +1,8 @@
+{
+  "voices": [
+    {
+      "id": "contract-voice",
+      "type": "cached"
+    }
+  ]
+}

--- a/packages/tooling/coverage-topology.json
+++ b/packages/tooling/coverage-topology.json
@@ -2156,6 +2156,20 @@
       "actualTiers": [
         "component"
       ]
+    },
+    {
+      "id": "voice-engine:ai-worker:json-responses",
+      "kind": "voice-engine",
+      "producer": "voice-engine",
+      "consumer": "ai-worker",
+      "schemaRef": "voiceEngineSchemas",
+      "mechanism": "voice-engine-contract",
+      "requiredTiers": [
+        "contract"
+      ],
+      "actualTiers": [
+        "contract"
+      ]
     }
   ]
 }

--- a/packages/tooling/src/topology/coverageTopology.ts
+++ b/packages/tooling/src/topology/coverageTopology.ts
@@ -36,9 +36,13 @@ import type { TestTier } from '../test/test-tiers.js';
 import { fileImportsSymbol } from './importAssertions.js';
 
 /** How a surface's contract coverage is provided. */
-export type CoverageSurfaceMechanism = 'route-conformance' | 'bullmq-contract' | 'golden-fixture';
+export type CoverageSurfaceMechanism =
+  | 'route-conformance'
+  | 'bullmq-contract'
+  | 'golden-fixture'
+  | 'voice-engine-contract';
 
-export type CoverageSurfaceKind = 'http-route' | 'bullmq-job' | 'context-envelope';
+export type CoverageSurfaceKind = 'http-route' | 'bullmq-job' | 'context-envelope' | 'voice-engine';
 
 export interface CoverageSurface {
   /** Stable id, e.g. `api-gateway:ai-worker:llm-generation`. */
@@ -81,6 +85,7 @@ const MECHANISM_TIER: Record<CoverageSurfaceMechanism, TestTier> = {
   'route-conformance': 'component',
   'bullmq-contract': 'contract',
   'golden-fixture': 'contract',
+  'voice-engine-contract': 'contract',
 };
 
 /**
@@ -125,6 +130,8 @@ const GOLDEN_FIXTURE_CONSUMER =
 const BULLMQ_PRODUCER_TEST =
   'services/api-gateway/src/utils/BullMQJobChainContract.producer.test.ts';
 const BULLMQ_CONTRACT_DIR = 'tests/e2e/contracts';
+const VOICE_ENGINE_CONSUMER_TEST =
+  'services/ai-worker/src/services/voice/VoiceEngineContract.consumer.contract.test.ts';
 
 /**
  * The REAL producer/consumer symbol each mechanism's test must import — the
@@ -178,6 +185,18 @@ const REAL_IMPORTS = {
     symbol: 'createJobChain',
     from: '/jobChainOrchestrator',
   },
+  /**
+   * The voice-engine JSON contract is cross-LANGUAGE: the PRODUCER is the Python
+   * service, enforced by the `voice-engine-test` CI job (a pytest asserts each real
+   * endpoint's output equals the committed fixture) — NOT topology-visible (this
+   * tool is TS-only). The topology tracks the TS CONSUMER half: the contract test
+   * imports the real response Zod schemas it validates the shared fixtures against.
+   */
+  voiceEngineConsumer: {
+    file: VOICE_ENGINE_CONSUMER_TEST,
+    symbol: 'transcribeResponseSchema',
+    from: '/voiceEngineSchemas',
+  },
 } as const;
 
 interface MechanismPresence {
@@ -187,6 +206,8 @@ interface MechanismPresence {
   envelopeImportsReal: boolean;
   /** The BullMQ producer test imports the real `createJobChain` (so the fixture is real output). */
   bullmqProducerImportsReal: boolean;
+  /** The voice-engine consumer test imports the real response Zod schemas (TS half; Python half is CI-enforced). */
+  voiceEngineImportsReal: boolean;
   /** Job schema names referenced by a `.safeParse(`/`.parse(` call in a BullMQ contract test. */
   bullmqSchemas: Set<string>;
 }
@@ -217,6 +238,7 @@ function buildMechanismPresence(projectRoot: string): MechanismPresence {
     envelopeImportsReal:
       imports(REAL_IMPORTS.envelopeProducer) && imports(REAL_IMPORTS.envelopeConsumer),
     bullmqProducerImportsReal: imports(REAL_IMPORTS.bullmqProducer),
+    voiceEngineImportsReal: imports(REAL_IMPORTS.voiceEngineConsumer),
     bullmqSchemas,
   };
 }
@@ -237,6 +259,7 @@ const MECHANISM_PRESENT: Record<
   'golden-fixture': (_seed, presence) => presence.envelopeImportsReal,
   'bullmq-contract': (seed, presence) =>
     presence.bullmqSchemas.has(seed.schemaRef) && presence.bullmqProducerImportsReal,
+  'voice-engine-contract': (_seed, presence) => presence.voiceEngineImportsReal,
 };
 
 /** Resolve a seed to a full surface: requiredTiers from its mechanism, actualTiers iff present. */
@@ -307,6 +330,25 @@ export function generateCoverageTopology(projectRoot: string = defaultRootDir())
         consumer: 'ai-worker',
         schemaRef: 'rawAssemblyInputsSchema',
         mechanism: 'golden-fixture',
+      },
+      presence
+    )
+  );
+
+  // The voice-engine JSON-response contract (cross-language: Python producer →
+  // ai-worker consumer). One aggregate surface for the JSON shapes; the Python
+  // producer is CI-enforced (voice-engine-test), the TS consumer is topology-tracked.
+  surfaces.push(
+    buildSurface(
+      {
+        id: 'voice-engine:ai-worker:json-responses',
+        kind: 'voice-engine',
+        producer: 'voice-engine',
+        consumer: 'ai-worker',
+        // The module that exports the response schemas (this mechanism checks the
+        // consumer's import, not schemaRef — so this is a label, not a key).
+        schemaRef: 'voiceEngineSchemas',
+        mechanism: 'voice-engine-contract',
       },
       presence
     )

--- a/services/ai-worker/src/services/voice/VoiceEngineClient.ts
+++ b/services/ai-worker/src/services/voice/VoiceEngineClient.ts
@@ -13,6 +13,12 @@ import {
   TimeoutError,
 } from '@tzurot/common-types';
 
+import {
+  transcribeResponseSchema,
+  healthResponseSchema,
+  voicesResponseSchema,
+} from './voiceEngineSchemas.js';
+
 const logger = createLogger('VoiceEngineClient');
 
 export interface TranscriptionResult {
@@ -74,8 +80,11 @@ export class VoiceEngineClient {
       throw new VoiceEngineError(response.status, detail);
     }
 
-    // Safe cast — we control the voice-engine response format (see server.py transcribe())
-    return (await response.json()) as TranscriptionResult;
+    // Runtime-validate the contract shape (voiceEngineSchemas + the cross-language
+    // contract fixtures). A drift throws a ZodError that PROPAGATES to the caller (a
+    // contract mismatch is a programming error, not a retryable transient) — far
+    // better than leaking undefined down the transcription path.
+    return transcribeResponseSchema.parse(await response.json());
   }
 
   /**
@@ -100,13 +109,18 @@ export class VoiceEngineClient {
       if (!response.ok) {
         return { asr: false, tts: false };
       }
-      // Safe cast — we control the voice-engine /health response (see server.py health())
-      const body = (await response.json()) as { asr_loaded?: boolean; tts_loaded?: boolean };
+      // Runtime-validate via the shared contract schema; a drift throws and is
+      // caught below (health degrades to false — never trusts a malformed response).
+      const body = healthResponseSchema.parse(await response.json());
       return {
-        asr: body.asr_loaded === true,
-        tts: body.tts_loaded === true,
+        asr: body.asr_loaded,
+        tts: body.tts_loaded,
       };
-    } catch {
+    } catch (err) {
+      // Degrade to unhealthy on ANY failure (timeout, network, or a ZodError from
+      // a drifted /health shape). Log so a schema drift is distinguishable from a
+      // transient — a silent `{ asr: false, tts: false }` otherwise looks identical.
+      logger.warn({ err }, 'Voice engine health check failed or returned an unexpected shape');
       return { asr: false, tts: false };
     }
   }
@@ -170,8 +184,10 @@ export class VoiceEngineClient {
       throw new VoiceEngineError(response.status, detail);
     }
 
-    // Safe cast — we control the voice-engine /v1/voices response (see server.py list_voices())
-    const body = (await response.json()) as { voices: { id: string }[] };
+    // Runtime-validate the contract shape (shared fixtures + voiceEngineSchemas). A
+    // drift throws a ZodError that propagates (programming error, not retryable);
+    // unlike getHealth, which swallows its parse error and degrades to unhealthy.
+    const body = voicesResponseSchema.parse(await response.json());
     return body.voices.map(v => v.id);
   }
 

--- a/services/ai-worker/src/services/voice/VoiceEngineContract.consumer.contract.test.ts
+++ b/services/ai-worker/src/services/voice/VoiceEngineContract.consumer.contract.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Consumer half of the voice-engine JSON contract (Python producer → TS consumer).
+ *
+ * Reads the SAME committed fixtures the Python PRODUCER test
+ * (`services/voice-engine/tests/test_contract.py`) asserts its real endpoint output
+ * against, and validates each against the Zod schema `VoiceEngineClient` parses
+ * responses with. The committed fixture is the shared cross-language artifact —
+ * neither side imports the other.
+ *
+ * Drift is caught on BOTH sides, structurally: a Python field rename breaks the
+ * Python fixture-equality assert; regenerating the fixture then breaks the Zod
+ * `.parse` here. Both CI jobs (`voice-engine-test` + `component-tests`, which runs
+ * `pnpm test:integration`) run on every PR, so a one-sided fixture change can't merge.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { loadContractFixture } from '@tzurot/test-utils';
+
+import {
+  transcribeResponseSchema,
+  healthResponseSchema,
+  voicesResponseSchema,
+} from './voiceEngineSchemas.js';
+
+describe('Contract: voice-engine JSON responses (Python producer fixtures → TS Zod schemas)', () => {
+  it('transcribe fixture validates + exposes the `text` the client reads', () => {
+    const parsed = transcribeResponseSchema.parse(
+      loadContractFixture('voice-engine/transcribe.json')
+    );
+    expect(parsed.text).toBeTypeOf('string');
+  });
+
+  it('health fixture validates against the health schema', () => {
+    const parsed = healthResponseSchema.parse(loadContractFixture('voice-engine/health.json'));
+    expect(parsed.asr_loaded).toBeTypeOf('boolean');
+    expect(parsed.tts_loaded).toBeTypeOf('boolean');
+  });
+
+  it('voices fixture validates + carries the { id, type } item shape', () => {
+    const parsed = voicesResponseSchema.parse(loadContractFixture('voice-engine/voices.json'));
+    expect(parsed.voices[0].id).toBeTypeOf('string');
+  });
+});

--- a/services/ai-worker/src/services/voice/voiceEngineSchemas.test.ts
+++ b/services/ai-worker/src/services/voice/voiceEngineSchemas.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  transcribeResponseSchema,
+  healthResponseSchema,
+  voicesResponseSchema,
+} from './voiceEngineSchemas.js';
+
+describe('voiceEngineSchemas', () => {
+  describe('transcribeResponseSchema', () => {
+    it('accepts the { text } shape', () => {
+      expect(transcribeResponseSchema.parse({ text: 'hello' })).toEqual({ text: 'hello' });
+    });
+
+    it('rejects a renamed/missing text field — the dangerous silent drift', () => {
+      expect(() => transcribeResponseSchema.parse({ transcription: 'hello' })).toThrow();
+    });
+
+    it('ignores a backward-compatible added field (non-strict — additions must not break the client)', () => {
+      expect(transcribeResponseSchema.parse({ text: 'hello', confidence: 0.9 })).toEqual({
+        text: 'hello',
+      });
+    });
+  });
+
+  describe('healthResponseSchema', () => {
+    it('accepts the full health shape', () => {
+      const h = { status: 'ok', asr_loaded: true, tts_loaded: false, voices_loaded: 2 };
+      expect(healthResponseSchema.parse(h)).toEqual(h);
+    });
+
+    it('rejects a non-boolean asr_loaded (type drift)', () => {
+      expect(() =>
+        healthResponseSchema.parse({
+          status: 'ok',
+          asr_loaded: 'yes',
+          tts_loaded: true,
+          voices_loaded: 0,
+        })
+      ).toThrow();
+    });
+  });
+
+  describe('voicesResponseSchema', () => {
+    it('accepts a populated voices list with the { id, type } item shape', () => {
+      const v = { voices: [{ id: 'alba', type: 'cached' }] };
+      expect(voicesResponseSchema.parse(v)).toEqual(v);
+    });
+
+    it('accepts an empty voices list', () => {
+      expect(voicesResponseSchema.parse({ voices: [] })).toEqual({ voices: [] });
+    });
+
+    it('rejects a voice item missing its id', () => {
+      expect(() => voicesResponseSchema.parse({ voices: [{ type: 'cached' }] })).toThrow();
+    });
+  });
+});

--- a/services/ai-worker/src/services/voice/voiceEngineSchemas.ts
+++ b/services/ai-worker/src/services/voice/voiceEngineSchemas.ts
@@ -1,0 +1,49 @@
+/**
+ * Zod schemas for the voice-engine JSON RESPONSE shapes.
+ *
+ * These are the CONSUMER half of the cross-language (Python ↔ TypeScript) contract:
+ * `VoiceEngineClient` validates real responses with `.parse()` (runtime safety —
+ * a Python field rename throws a clear error instead of silently producing
+ * `undefined` down the audio-transcription path), and the consumer contract test
+ * (`VoiceEngineContract.consumer.contract.test.ts`) validates the SAME committed
+ * fixtures (`packages/test-utils/fixtures/contracts/voice-engine/`) the Python
+ * PRODUCER test (`services/voice-engine/tests/test_contract.py`) asserts its real
+ * output against. The fixture is the shared artifact; neither side imports the other.
+ *
+ * Validation scope: each schema REQUIRES the fields the client actually reads and
+ * marks the rest OPTIONAL. A rename/removal of a read field is caught here (it goes
+ * missing → `parse` throws); the FULL response shape is locked separately by the
+ * Python producer test's fixture-equality assert. This keeps the running client
+ * robust — a benign Python change to a field we don't read can't break it — while
+ * still catching the drift that matters. (Extra/unknown fields are stripped, not
+ * rejected, so a backward-compatible addition is also non-breaking.)
+ *
+ * Future evolution: if voice-engine grows past ~5 JSON endpoints, migrate to FastAPI
+ * `response_model` → committed `openapi.json` → TS Zod codegen so the spec is the
+ * single source of truth, retiring this hand-maintained schema+fixture pair.
+ */
+
+import { z } from 'zod';
+
+/** POST /v1/transcribe → `{ text }` (the STT result that drives transcription). */
+export const transcribeResponseSchema = z.object({ text: z.string() });
+
+/**
+ * GET /health → `{ status, asr_loaded, tts_loaded, voices_loaded }`. The client
+ * reads only `asr_loaded` / `tts_loaded`; `status` / `voices_loaded` are validated
+ * when present but optional (the client doesn't depend on them).
+ */
+export const healthResponseSchema = z.object({
+  asr_loaded: z.boolean(),
+  tts_loaded: z.boolean(),
+  status: z.string().optional(),
+  voices_loaded: z.number().optional(),
+});
+
+/**
+ * GET /v1/voices → `{ voices: [{ id, type }] }`. The client reads only `id`; `type`
+ * is validated when present but optional.
+ */
+export const voicesResponseSchema = z.object({
+  voices: z.array(z.object({ id: z.string(), type: z.string().optional() })),
+});

--- a/services/voice-engine/tests/test_contract.py
+++ b/services/voice-engine/tests/test_contract.py
@@ -1,0 +1,80 @@
+"""Cross-language (Python <-> TypeScript) golden-fixture contract for the voice-engine JSON responses.
+
+The committed fixtures under ``packages/test-utils/fixtures/contracts/voice-engine/`` are the
+SHARED artifact: this PRODUCER test asserts each real endpoint's JSON output equals the fixture;
+the TS CONSUMER test (``services/ai-worker/src/services/voice/VoiceEngineContract.consumer.contract.test.ts``)
+validates the SAME fixtures against its Zod schemas. A Python field rename breaks the
+fixture-equality assert HERE and (after regeneration) the TS Zod ``.parse`` THERE -- drift caught
+on both sides, and both the ``voice-engine-test`` and ``component-tests`` CI jobs run on every PR.
+
+Only JSON RESPONSE shapes are contracted: binary TTS (audio/wav) has no JSON to drift, and
+multipart request bodies are validated loudly by FastAPI at the edge (422). The TS client consumes
+``/v1/transcribe``, ``/health`` and ``/v1/voices``; ``/v1/voices/register`` returns JSON the client
+ignores, so it is intentionally out of scope.
+
+Set ``UPDATE_CONTRACT_FIXTURES=1`` to regenerate the fixtures from real output (the ``--update`` analog).
+
+Future evolution: if voice-engine grows past ~5 JSON endpoints, migrate to FastAPI
+``response_model`` -> committed ``openapi.json`` -> TS Zod codegen, retiring this manual pair.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+
+# Repo-relative path to the shared fixture dir, resolved from THIS file so it is
+# cwd-independent (the voice-engine-test job runs `cd services/voice-engine`).
+# parents: [0]=tests [1]=voice-engine [2]=services [3]=repo root.
+_FIXTURE_DIR = (
+    Path(__file__).resolve().parents[3] / "packages" / "test-utils" / "fixtures" / "contracts" / "voice-engine"
+)
+
+
+def _assert_or_update(name: str, actual: dict[str, Any]) -> None:
+    """Assert ``actual`` equals the committed fixture, or rewrite it under UPDATE_CONTRACT_FIXTURES.
+
+    Compares PARSED dicts (not raw bytes) so key order / whitespace never makes the contract brittle.
+    """
+    path = _FIXTURE_DIR / name
+    if os.environ.get("UPDATE_CONTRACT_FIXTURES"):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(actual, indent=2) + "\n")
+        return
+    if not path.exists():
+        raise FileNotFoundError(
+            f"{name} contract fixture missing — regenerate with "
+            "UPDATE_CONTRACT_FIXTURES=1 pytest services/voice-engine/tests/test_contract.py"
+        )
+    expected = json.loads(path.read_text())
+    assert actual == expected, f"{name} drifted from the committed fixture (regenerate with UPDATE_CONTRACT_FIXTURES=1)"
+
+
+async def test_transcribe_response_contract(client: httpx.AsyncClient, mock_asr: MagicMock) -> None:
+    response = await client.post(
+        "/v1/transcribe",
+        files={"file": ("contract.wav", b"\x00" * 64, "audio/wav")},
+    )
+    assert response.status_code == 200
+    _assert_or_update("transcribe.json", response.json())
+
+
+async def test_health_response_contract(client: httpx.AsyncClient, mock_asr: MagicMock, mock_tts: MagicMock) -> None:
+    response = await client.get("/health")
+    assert response.status_code == 200
+    _assert_or_update("health.json", response.json())
+
+
+async def test_voices_response_contract(client: httpx.AsyncClient) -> None:
+    # Populate one voice so the fixture locks the per-item {id, type} shape, not just `[]`.
+    from server import voice_cache
+
+    voice_cache["contract-voice"] = MagicMock()  # list_voices reads keys only
+    response = await client.get("/v1/voices")
+    assert response.status_code == 200
+    _assert_or_update("voices.json", response.json())


### PR DESCRIPTION
## What

Test-Pyramid Phase 4, **PR6 — voice-engine schema-first** (the last cross-service slice). Locks the TS↔Python voice-engine boundary against silent drift.

## Why

The Python `voice-engine` (`server.py`) has **no Pydantic models** — endpoints return hand-built dicts — and the TS client (`VoiceEngineClient`) **`as`-cast every response**. A Python field rename on `/v1/transcribe` would silently produce `undefined` down the audio-transcription path (still HTTP 200). The plan's original "Pydantic→JSON-Schema" premise was invalidated by that finding.

## Design — council-unanimous Option A (golden-fixture + TS Zod)

GLM-5.2 / Kimi-K2.7 / Qwen-3.7 all picked A over refactoring `server.py` into Pydantic models (which would force the TS side onto `ajv` or a hand-synced mirror). All three named the same future evolution — FastAPI `response_model` → `openapi.json` → TS Zod codegen — as the right move *after* this proves value past ~5 endpoints (documented in-code).

| Piece | |
| --- | --- |
| **Committed fixtures** | `packages/test-utils/fixtures/contracts/voice-engine/{transcribe,health,voices}.json` — the shared artifact both languages read |
| **Python producer** | `services/voice-engine/tests/test_contract.py` — asserts each real endpoint's output equals the fixture (`UPDATE_CONTRACT_FIXTURES` regen mode) |
| **TS consumer** | `voiceEngineSchemas.ts` Zod schemas replace the unsafe casts in `VoiceEngineClient` (the audio-path safety win) + a `.contract.test.ts` validates the same fixtures |
| **Topology** | a `voice-engine` surface (PR5 execution-check on the consumer's schema import; the Python producer is CI-enforced by `voice-engine-test`) |

**Schema scope:** each schema *requires the fields the client reads* and marks the rest optional — the running client stays robust to benign Python additions, while the **full shape is locked by the Python fixture-equality assert**. (This came out of 5 existing client tests that feed the read-subset; the fix was the schema, not the mocks.)

**Contract scope:** JSON responses only. Binary TTS (audio/wav) has no JSON to drift; multipart requests get a loud FastAPI 422, not silent drift.

## The drift gate is structural + free

A Python field rename → its endpoint output ≠ the fixture → **Python test fails** → regenerate → the new fixture fails the **TS Zod parse** → **TS test fails**. Both `voice-engine-test` and `component-tests` run on every PR, so a one-sided fixture change can't merge — no new CI wiring.

## Verification

- Python 3/3 (+ ruff/mypy clean) · ai-worker 3270 · contract tier 16 · tooling 1120 · `pnpm quality` green.
- **Cross-language negative proof** (both reverted): renaming the Python `/v1/transcribe` key fails the pytest fixture-equality; corrupting `transcribe.json`'s key fails the TS Zod consumer test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)