### PR TITLE
chore: close out the test-pyramid Phase-4 epic (deferred nits)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -69,7 +69,10 @@ fi
 # "caught in round N" inside JSDoc or `//` comments. These rot meaninglessly
 # (per feedback_no_temporal_refs_in_comments memory + 02-code-standards rule).
 # Backlog markdown is allowed — it tracks surfacing dates intentionally.
-STAGED_CODE_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(ts|tsx|js|jsx)$' || true)
+# Python (.py) is included: the comment-prefix match below is chosen per-language
+# (`#` / triple-quote for Python, `//` / `*` / `/*` otherwise) because a combined
+# regex would false-positive on TS private fields like `#count = new Date('2026…')`.
+STAGED_CODE_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(ts|tsx|js|jsx|py)$' || true)
 
 if [ -n "$STAGED_CODE_FILES" ]; then
     # Match ADDED lines that look like comments (start with // or * after whitespace
@@ -77,11 +80,15 @@ if [ -n "$STAGED_CODE_FILES" ]; then
     # Note on regex portability: `\+` is BRE GNU's one-or-more quantifier, not
     # a literal plus, so we use bracket form `[+]` for the line-prefix anchors.
     # Works in both BRE and ERE without warnings.
-    # Scope boundary: only catches full-line comments (`//`, JSDoc `*`, block
-    # `/*`). Inline comments after code (`doSomething(); // PR #X`) are
-    # intentionally NOT caught — robustly distinguishing string literals from
-    # inline comments needs a real lexer, not a grep chain. The full-line case
-    # is the dominant violation pattern in observed data; inline cases are rare.
+    # Scope boundary: only catches full-line comments — for TS/JS the prefixes
+    # `//`, JSDoc `*`, block `/*`; for Python `#` line comments and single-line
+    # triple-quoted docstrings (`"""…2026-…"""`). Inline comments after code
+    # (`doSomething(); // PR #X`) are intentionally NOT caught — robustly
+    # distinguishing string literals from inline comments needs a real lexer, not
+    # a grep chain. Two known Python gaps, both best-effort by design: a date on a
+    # CONTINUATION line of a multi-line docstring (the delimiter line is on a
+    # different line than the prose) and `# type:`-style stamps are not matched.
+    # The full-line case is the dominant violation pattern in observed data.
     # Date pattern is decade-scoped (`202[0-9]`) so RFC/spec date references
     # like "RFC 3339 (2002-07-15)" don't trip the hook.
     #
@@ -113,9 +120,17 @@ if [ -n "$STAGED_CODE_FILES" ]; then
         if [ -f "$file" ] && head -5 "$file" 2>/dev/null | grep -qE 'AUTO-GENERATED FILE|@generated'; then
             continue
         fi
+        # Comment-prefix match is per-language: Python comments start with `#` or a
+        # triple-quote docstring delimiter; everything else uses C-style `//`/`*`/`/*`.
+        # (The triple-single-quote alternative is spliced in via "'''" to escape the
+        # surrounding single-quoted string.)
+        case "$file" in
+            *.py) COMMENT_PREFIX='^[+][[:space:]]*(#|"""|'"'''"')' ;;
+            *)    COMMENT_PREFIX='^[+][[:space:]]*(//|\*|/\*)' ;;
+        esac
         FILE_VIOLATIONS=$(git diff --cached -- "$file" | \
             grep -E '^[+]' | grep -v '^[+][+][+]' | \
-            grep -E '^[+][[:space:]]*(//|\*|/\*)' | \
+            grep -E "$COMMENT_PREFIX" | \
             grep -Ei "$TEMPORAL_PATTERN" || true)
         if [ -n "$FILE_VIOLATIONS" ]; then
             HAS_VIOLATIONS=1

--- a/knip.json
+++ b/knip.json
@@ -8,18 +8,18 @@
       "ignoreDependencies": ["@typescript-eslint/eslint-plugin", "@typescript-eslint/parser"]
     },
     "services/bot-client": {
-      "entry": ["src/**/*.test.ts", "src/**/*.component.test.ts", "src/commands/*/index.ts"]
+      "entry": ["src/**/*.test.ts", "src/commands/*/index.ts"]
     },
     "services/api-gateway": {
-      "entry": ["src/**/*.test.ts", "src/**/*.component.test.ts"],
+      "entry": ["src/**/*.test.ts"],
       "ignoreDependencies": ["openai", "pino"]
     },
     "services/ai-worker": {
-      "entry": ["src/**/*.test.ts", "src/**/*.component.test.ts"],
+      "entry": ["src/**/*.test.ts"],
       "ignoreDependencies": ["langchain", "onnxruntime-node"]
     },
     "packages/common-types": {
-      "entry": ["src/**/*.test.ts", "src/**/*.component.test.ts"],
+      "entry": ["src/**/*.test.ts"],
       "includeEntryExports": true,
       "ignoreDependencies": ["openai", "pg", "@prisma/client", "prisma"],
       "ignoreMembers": ["ECONNRESET", "ETIMEDOUT", "ENOTFOUND", "ECONNREFUSED"]
@@ -31,10 +31,10 @@
       "entry": ["src/**/*.test.ts"]
     },
     "packages/identity": {
-      "entry": ["src/**/*.test.ts", "src/**/*.component.test.ts"]
+      "entry": ["src/**/*.test.ts"]
     },
     "packages/conversation-history": {
-      "entry": ["src/**/*.test.ts", "src/**/*.component.test.ts"]
+      "entry": ["src/**/*.test.ts"]
     },
     "packages/cache-invalidation": {
       "entry": ["src/**/*.test.ts"]
@@ -49,7 +49,7 @@
       "ignoreDependencies": ["onnxruntime-node"]
     },
     "packages/test-utils": {
-      "entry": ["src/**/*.test.ts", "src/**/*.component.test.ts"],
+      "entry": ["src/**/*.test.ts"],
       "includeEntryExports": true
     },
     "packages/test-factories": {

--- a/packages/conversation-history/src/ConversationHistoryService.component.test.ts
+++ b/packages/conversation-history/src/ConversationHistoryService.component.test.ts
@@ -29,6 +29,15 @@ describe('ConversationHistoryService Component Test', () => {
   const testChannelId = '123456789012345678';
   const testGuildId = '987654321098765432';
 
+  // A row's id is a DETERMINISTIC UUID over (channelId, personalityId, personaId,
+  // createdAt). When a loop inserts rows sharing the first three keys and lets
+  // createdAt default to `new Date()`, two inserts in the same millisecond collide
+  // on the id → `Unique constraint failed on (id)` (an intermittent CI flake). Seed a
+  // strictly-increasing explicit timestamp per row so each id is deterministic AND
+  // unique; the 1s spacing also pins the insertion order the assertions rely on.
+  const seededTimestamp = (i: number): Date =>
+    new Date(new Date('2026-06-01T00:00:00Z').getTime() + i * 1000);
+
   beforeAll(async () => {
     // Set up PGlite (in-memory Postgres via WASM) with pgvector extension
     // Note: PGlite initialization is CPU-intensive and may be slow when running
@@ -182,7 +191,10 @@ describe('ConversationHistoryService Component Test', () => {
 
   describe('getChannelHistory', () => {
     it('should return messages in chronological order (oldest first)', async () => {
-      // Sequential awaits ensure created_at timestamps preserve insertion order
+      // Explicit strictly-increasing timestamps pin insertion order AND keep each
+      // deterministic-UUID row distinct (relying on default `new Date()` is flaky:
+      // sub-ms inserts can both tie the ordering and collide the id — see the
+      // seededTimestamp note above).
       await service.addMessage({
         channelId: testChannelId,
         personalityId: testPersonalityId,
@@ -190,6 +202,7 @@ describe('ConversationHistoryService Component Test', () => {
         role: MessageRole.User,
         content: 'First message',
         guildId: testGuildId,
+        timestamp: seededTimestamp(0),
       });
       await service.addMessage({
         channelId: testChannelId,
@@ -198,6 +211,7 @@ describe('ConversationHistoryService Component Test', () => {
         role: MessageRole.Assistant,
         content: 'Second message',
         guildId: testGuildId,
+        timestamp: seededTimestamp(1),
       });
       await service.addMessage({
         channelId: testChannelId,
@@ -206,6 +220,7 @@ describe('ConversationHistoryService Component Test', () => {
         role: MessageRole.User,
         content: 'Third message',
         guildId: testGuildId,
+        timestamp: seededTimestamp(2),
       });
 
       const history = await service.getChannelHistory(testChannelId, 10);
@@ -226,6 +241,7 @@ describe('ConversationHistoryService Component Test', () => {
           role: MessageRole.User,
           content: `Message ${i}`,
           guildId: testGuildId,
+          timestamp: seededTimestamp(i),
         });
       }
 
@@ -271,6 +287,7 @@ describe('ConversationHistoryService Component Test', () => {
           role: MessageRole.User,
           content: `Page message ${i}`,
           guildId: testGuildId,
+          timestamp: seededTimestamp(i),
         });
       }
 
@@ -317,6 +334,7 @@ describe('ConversationHistoryService Component Test', () => {
           role: MessageRole.User,
           content: `Limit test ${i}`,
           guildId: testGuildId,
+          timestamp: seededTimestamp(i),
         });
       }
 
@@ -589,7 +607,8 @@ describe('ConversationHistoryService Component Test', () => {
 
   describe('getHistoryStats', () => {
     it('should return correct message counts', async () => {
-      // Add user messages
+      // Add user messages (explicit distinct timestamps keep the three same-key
+      // rows from colliding on their deterministic UUID — see seededTimestamp note)
       await service.addMessage({
         channelId: testChannelId,
         personalityId: testPersonalityId,
@@ -597,6 +616,7 @@ describe('ConversationHistoryService Component Test', () => {
         role: MessageRole.User,
         content: 'User message 1',
         guildId: testGuildId,
+        timestamp: seededTimestamp(0),
       });
       await service.addMessage({
         channelId: testChannelId,
@@ -605,6 +625,7 @@ describe('ConversationHistoryService Component Test', () => {
         role: MessageRole.User,
         content: 'User message 2',
         guildId: testGuildId,
+        timestamp: seededTimestamp(1),
       });
 
       // Add assistant messages
@@ -615,6 +636,7 @@ describe('ConversationHistoryService Component Test', () => {
         role: MessageRole.Assistant,
         content: 'Assistant message 1',
         guildId: testGuildId,
+        timestamp: seededTimestamp(2),
       });
 
       const stats = await service.getHistoryStats(testChannelId, testPersonalityId);
@@ -889,7 +911,9 @@ describe('ConversationHistoryService Component Test', () => {
       const chExclude = 'cross-chrono-ch1';
       const chOther = 'cross-chrono-ch2';
 
-      // Add messages in sequence
+      // Add messages in sequence — explicit distinct timestamps pin the order the
+      // assertions below rely on AND keep the same-key rows' deterministic UUIDs
+      // unique (see seededTimestamp note).
       await service.addMessage({
         channelId: chOther,
         personalityId: testPersonalityId,
@@ -897,6 +921,7 @@ describe('ConversationHistoryService Component Test', () => {
         role: MessageRole.User,
         content: 'First',
         guildId: testGuildId,
+        timestamp: seededTimestamp(0),
       });
       await service.addMessage({
         channelId: chOther,
@@ -905,6 +930,7 @@ describe('ConversationHistoryService Component Test', () => {
         role: MessageRole.Assistant,
         content: 'Second',
         guildId: testGuildId,
+        timestamp: seededTimestamp(1),
       });
       await service.addMessage({
         channelId: chOther,
@@ -913,6 +939,7 @@ describe('ConversationHistoryService Component Test', () => {
         role: MessageRole.User,
         content: 'Third',
         guildId: testGuildId,
+        timestamp: seededTimestamp(2),
       });
 
       const result = await service.getCrossChannelHistory(

--- a/packages/test-utils/src/contractFixtures.test.ts
+++ b/packages/test-utils/src/contractFixtures.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { existsSync } from 'node:fs';
 import { isAbsolute } from 'node:path';
-import { contractFixtureFile } from './contractFixtures.js';
+import { contractFixtureFile, loadContractFixture } from './contractFixtures.js';
 
 describe('contractFixtureFile', () => {
   it('resolves an absolute path to a real committed fixture', () => {
@@ -11,5 +11,23 @@ describe('contractFixtureFile', () => {
     // actually there — catches a `../fixtures/` path-resolution regression.
     expect(isAbsolute(p)).toBe(true);
     expect(existsSync(p)).toBe(true);
+  });
+
+  it('rejects a path-traversal name (`..` or leading `/`)', () => {
+    expect(() => contractFixtureFile('../../etc/passwd')).toThrow(/path traversal/);
+    expect(() => contractFixtureFile('/etc/passwd')).toThrow(/path traversal/);
+  });
+});
+
+describe('loadContractFixture', () => {
+  it('reads + JSON.parses a committed fixture', () => {
+    const fixture = loadContractFixture<{ rawMessageContent: string }>(
+      'raw-assembly-inputs/base.json'
+    );
+    expect(fixture.rawMessageContent).toBeTypeOf('string');
+  });
+
+  it('propagates the path-traversal guard from contractFixtureFile', () => {
+    expect(() => loadContractFixture('../../secret.json')).toThrow(/path traversal/);
   });
 });

--- a/packages/test-utils/src/contractFixtures.ts
+++ b/packages/test-utils/src/contractFixtures.ts
@@ -24,10 +24,24 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
  * directory, e.g. `raw-assembly-inputs/base.json`.
  */
 export function contractFixtureFile(name: string): string {
+  // Defense-in-depth (test-only infra, but per 00-critical's path rules): a `name`
+  // containing `..` or a leading `/` could resolve outside the committed fixtures
+  // dir. Reject it rather than silently reading an arbitrary file. The `..` check is
+  // position-agnostic — a hyphen-adjacent `old..new.json` is rejected too; committed
+  // fixture names are kebab-case path segments, so this never collides in practice.
+  if (name.includes('..') || name.startsWith('/')) {
+    throw new Error(`Invalid contract fixture name (path traversal rejected): ${name}`);
+  }
   return join(__dirname, '../fixtures/contracts', name);
 }
 
-/** Read + `JSON.parse` a committed contract fixture by its `name` (see above). */
+/**
+ * Read + `JSON.parse` a committed contract fixture by its `name` (see above). The
+ * `as T` is an UNVALIDATED convenience cast, not a guarantee — consumer contract
+ * tests are expected to feed the result through their real schema's `.parse()`
+ * (e.g. `rawAssemblyInputsSchema.parse(loadContractFixture(...))`), which is the
+ * actual drift check.
+ */
 export function loadContractFixture<T = unknown>(name: string): T {
   return JSON.parse(readFileSync(contractFixtureFile(name), 'utf-8')) as T;
 }

--- a/packages/tooling/src/test/audit-unified.ts
+++ b/packages/tooling/src/test/audit-unified.ts
@@ -75,8 +75,8 @@ function findServiceFiles(projectRoot: string): string[] {
   for (const dir of serviceDirs) {
     const files = findFiles(dir, /Service\.ts$/);
     for (const file of files) {
-      // Skip test files
-      if (file.endsWith('.test.ts') || file.endsWith('.component.test.ts')) continue;
+      // Skip test files (`.component.test.ts` ends with `.test.ts`, so one check covers both)
+      if (file.endsWith('.test.ts')) continue;
 
       // Skip re-export files
       if (isReExportFile(file)) continue;
@@ -235,23 +235,11 @@ function findTestedSchemas(projectRoot: string): string[] {
     }
   }
 
-  // Also check the real-dependency tiers (integration + contract) for schema usage
-  const e2eTestsDir = join(projectRoot, 'tests/e2e');
-  if (existsSync(e2eTestsDir)) {
-    const e2eFiles = readdirSync(e2eTestsDir).filter(
-      f => f.endsWith('.integration.test.ts') || f.endsWith('.contract.test.ts')
-    );
-
-    for (const file of e2eFiles) {
-      const content = readFile(join(e2eTestsDir, file));
-
-      // eslint-disable-next-line regexp/no-super-linear-move -- Input is developer-authored TS source (trusted, bounded by file size); ReDoS not a real attack surface
-      const schemaUsageMatches = content.matchAll(/(\w+Schema)\.safeParse/g);
-      for (const match of schemaUsageMatches) {
-        tested.push(`e2e:${match[1]}`);
-      }
-    }
-  }
+  // NOTE: there is intentionally no `tests/e2e/` scan here. That tier's tests live
+  // under subdirectories (`tests/e2e/contracts/`), which a non-recursive readdir
+  // never reached — and even recursed, those tests exercise job/envelope schemas,
+  // not the `schemas/api/` schemas this audit tracks. The colocated scan above is
+  // the whole signal.
 
   return [...new Set(tested)].sort();
 }

--- a/packages/tooling/src/topology/coverageTopology.ts
+++ b/packages/tooling/src/topology/coverageTopology.ts
@@ -50,7 +50,13 @@ export interface CoverageSurface {
   kind: CoverageSurfaceKind;
   producer: string;
   consumer: string;
-  /** The shared schema/type (or route id) that identifies the contract artifact. */
+  /**
+   * The shared schema/type that identifies the contract artifact — a `*Schema` name
+   * (bullmq/envelope), a module label (voice-engine), or the `METHOD /path` signature
+   * (http-route). NOT a unique key: several of the manifest's routes share a `METHOD
+   * /path` where global/user variants sit behind different auth middleware. `id` is the
+   * unique key; diff/dedupe on `id`, not `schemaRef`.
+   */
   schemaRef: string;
   /** How this surface's contract coverage is provided (the per-surface marker). */
   mechanism: CoverageSurfaceMechanism;
@@ -150,10 +156,10 @@ const REAL_IMPORTS = {
   conformanceRegistry: {
     file: CONFORMANCE_HARNESS,
     symbol: 'CONFORMANCE_REGISTRY',
-    // Leading `/` anchors to the path separator: a sibling whose name merely
-    // contains "registry" without a preceding slash won't match. (Scoped to one
-    // file anyway, so this is defense-in-depth against a careless future entry.)
-    from: '/fixtures/registry',
+    // Anchored both sides: leading `/` excludes a name-prefix sibling
+    // (`mock-fixtures/registry`); the trailing `.` (the extension dot) excludes a
+    // name-suffix sibling (`registry-v2.js`). Defense-in-depth — scoped to one file.
+    from: '/fixtures/registry.',
   },
   conformanceManifest: {
     file: CONFORMANCE_HARNESS,
@@ -164,13 +170,14 @@ const REAL_IMPORTS = {
   envelopeProducer: {
     file: GOLDEN_FIXTURE_PRODUCER,
     symbol: 'buildRawAssemblyInputs',
-    from: '/RawEnvelopeBuilder',
+    from: '/RawEnvelopeBuilder.',
   },
   envelopeConsumer: {
     file: GOLDEN_FIXTURE_CONSUMER,
     symbol: 'ContextAssembler',
-    // Leading `/` so a sibling like `./PrismaContextAssembler.js` can't match by substring.
-    from: '/ContextAssembler',
+    // Anchored both sides: leading `/` excludes `./PrismaContextAssembler.js`, the
+    // trailing `.` excludes `./ContextAssemblerV2.js`.
+    from: '/ContextAssembler.',
   },
   /**
    * The BullMQ golden-fixture producer runs the real job-chain orchestrator. ONE
@@ -183,7 +190,7 @@ const REAL_IMPORTS = {
   bullmqProducer: {
     file: BULLMQ_PRODUCER_TEST,
     symbol: 'createJobChain',
-    from: '/jobChainOrchestrator',
+    from: '/jobChainOrchestrator.',
   },
   /**
    * The voice-engine JSON contract is cross-LANGUAGE: the PRODUCER is the Python
@@ -195,7 +202,7 @@ const REAL_IMPORTS = {
   voiceEngineConsumer: {
     file: VOICE_ENGINE_CONSUMER_TEST,
     symbol: 'transcribeResponseSchema',
-    from: '/voiceEngineSchemas',
+    from: '/voiceEngineSchemas.',
   },
 } as const;
 

--- a/packages/tooling/src/topology/importAssertions.test.ts
+++ b/packages/tooling/src/topology/importAssertions.test.ts
@@ -7,12 +7,11 @@ import { describe, it, expect, vi } from 'vitest';
 // load) that can exceed the default 5s timeout. 30s gives sufficient headroom.
 vi.setConfig({ testTimeout: 30_000 });
 
-import {
-  parseNamedImports,
-  contentImportsSymbol,
-  fileImportsSymbol,
-  clearFileImportCache,
-} from './importAssertions.js';
+import { parseNamedImports, fileImportsSymbol, clearFileImportCache } from './importAssertions.js';
+
+/** The match `fileImportsSymbol` applies, over parsed content (no file I/O). */
+const contentImportsSymbol = (content: string, symbol: string, from: string): boolean =>
+  parseNamedImports(content).some(i => i.symbol === symbol && i.source.includes(from));
 
 describe('parseNamedImports', () => {
   it('extracts each VALUE named import with its module specifier', () => {

--- a/packages/tooling/src/topology/importAssertions.ts
+++ b/packages/tooling/src/topology/importAssertions.ts
@@ -8,9 +8,14 @@
  * the real consumer — imports no real symbol and is therefore reported as a gap.
  *
  * Why an import check is enough (no call-site/witness analysis): the repo's root
- * tsconfig sets `noUnusedLocals: true`, so an imported symbol that is never used
- * is a `tsc` error. A *present* import is therefore necessarily *used* — detecting
- * the import alone proves the test exercises the real symbol. This guarantee holds
+ * tsconfig sets `noUnusedLocals: true`, so an imported VALUE symbol that is never
+ * referenced is a `tsc` error. So a present import proves the binding is in scope
+ * and not dead-code-eliminated by esbuild — strictly, that much, not that the
+ * symbol is *invoked at runtime*. The residual gap: a `typeof RealProducer`
+ * reference satisfies `noUnusedLocals` from a type position without ever calling
+ * it. That's an ADVERSARIAL shape, not an accidental one (a contributor writing a
+ * real contract test calls the producer), so it's accepted — closing it would need
+ * call-witness AST, which the council judged gold-plating. The guarantee also holds
  * end-to-end only because CI runs `typecheck` alongside `test` (vitest/esbuild
  * transpile away an unused import; tsc is what rejects it).
  *
@@ -72,28 +77,6 @@ export function parseNamedImports(content: string): NamedImport[] {
     }
   }
   return result;
-}
-
-/**
- * True iff `content` has a named import of `symbol` whose module specifier
- * includes `fromModuleMatch` (a substring match — the producer/consumer modules
- * are imported by relative path or package name, both stable enough to match on).
- *
- * Anchor `fromModuleMatch` with a leading `/` for a relative module (e.g.
- * `/ContextAssembler`) so a sibling like `./PrismaContextAssembler.js` can't
- * satisfy the check by substring; a distinctive package name (`@tzurot/clients`)
- * needs no anchor.
- *
- * @remarks Serial-only — delegates to {@link parseNamedImports} (see its remarks).
- */
-export function contentImportsSymbol(
-  content: string,
-  symbol: string,
-  fromModuleMatch: string
-): boolean {
-  return parseNamedImports(content).some(
-    i => i.symbol === symbol && i.source.includes(fromModuleMatch)
-  );
 }
 
 // The probe queries the same file for multiple symbols (e.g. the conformance

--- a/scripts/audit-route-auth-matrix.ts
+++ b/scripts/audit-route-auth-matrix.ts
@@ -517,7 +517,7 @@ function main(): void {
   for (const file of project.getSourceFiles()) {
     const path = file.getFilePath();
     if (!path.includes('/services/api-gateway/src/routes/')) continue;
-    if (path.endsWith('.test.ts') || path.endsWith('.component.test.ts')) continue;
+    if (path.endsWith('.test.ts')) continue; // `.component.test.ts` ends with `.test.ts`
     routes.push(...collectRoutesFromFile(file, project));
   }
 

--- a/services/ai-worker/src/services/context/RawEnvelopeContract.consumer.contract.test.ts
+++ b/services/ai-worker/src/services/context/RawEnvelopeContract.consumer.contract.test.ts
@@ -205,6 +205,12 @@ describe('RawEnvelope contract — consumer derivation over PGLite', () => {
     // content/transcript split end-to-end (producer emits the split; consumer
     // respects it).
     expect(core.messageContent).toBe('');
+    // Secondary leak path: the telemetry transcript must not surface in the
+    // assembled HISTORY either (not just the current-message content). The fixture's
+    // routing transcript is "the spoken words from a voice note" — assert no history
+    // entry carries it, so a future regression that folds rawRoutingTranscript into
+    // history is caught here too.
+    expect(core.history.map(m => m.content)).not.toContain('the spoken words from a voice note');
   });
 
   it('with-channel-environment fixture: cross-channel groups decorate from the envelope env map', async () => {

--- a/services/ai-worker/src/services/voice/VoiceEngineClient.ts
+++ b/services/ai-worker/src/services/voice/VoiceEngineClient.ts
@@ -17,6 +17,7 @@ import {
   transcribeResponseSchema,
   healthResponseSchema,
   voicesResponseSchema,
+  errorDetailSchema,
 } from './voiceEngineSchemas.js';
 
 const logger = createLogger('VoiceEngineClient');
@@ -228,9 +229,10 @@ export class VoiceEngineClient {
 
   private async extractErrorDetail(response: globalThis.Response): Promise<string> {
     try {
-      const body = (await response.json()) as { detail?: string };
+      const body = errorDetailSchema.parse(await response.json());
       return body.detail ?? response.statusText;
     } catch {
+      // Non-`{detail}` / non-JSON error body — fall back to the HTTP status text.
       return response.statusText;
     }
   }

--- a/services/ai-worker/src/services/voice/VoiceRegistrationService.test.ts
+++ b/services/ai-worker/src/services/voice/VoiceRegistrationService.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ZodError } from 'zod';
 import { VoiceRegistrationService } from './VoiceRegistrationService.js';
 import { VoiceEngineError } from './VoiceEngineClient.js';
 import type { VoiceEngineClient } from './VoiceEngineClient.js';
@@ -112,6 +113,28 @@ describe('VoiceRegistrationService', () => {
     );
     expect(mockVoiceEngineClient.registerVoice).toHaveBeenCalledWith(
       'fallback-voice',
+      expect.any(Buffer),
+      'audio/wav'
+    );
+  });
+
+  it('should attempt registration when listVoices throws a ZodError (contract drift)', async () => {
+    // A drifted /v1/voices shape makes listVoices throw a ZodError. This takes the
+    // ERROR-log branch (contract drift is a programming error, not a transient) but
+    // still falls through to registration — so the observable behavior matches the
+    // generic-failure case above; the distinct branch is what this exercises.
+    mockVoiceEngineClient.listVoices.mockRejectedValue(new ZodError([]));
+    mockVoiceEngineClient.registerVoice.mockResolvedValue(undefined);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(50)),
+      headers: { get: vi.fn().mockReturnValue('audio/wav') },
+    });
+
+    await service.ensureVoiceRegistered('drift-voice');
+
+    expect(mockVoiceEngineClient.registerVoice).toHaveBeenCalledWith(
+      'drift-voice',
       expect.any(Buffer),
       'audio/wav'
     );

--- a/services/ai-worker/src/services/voice/VoiceRegistrationService.ts
+++ b/services/ai-worker/src/services/voice/VoiceRegistrationService.ts
@@ -7,6 +7,8 @@
  * status in-memory (TTLCache, 30 min) to avoid redundant registration calls.
  */
 
+import { ZodError } from 'zod';
+
 import { createLogger, TTLCache, isTransientNetworkError } from '@tzurot/common-types';
 import { VoiceEngineError, type VoiceEngineClient } from './VoiceEngineClient.js';
 import { fetchVoiceReference } from './voiceReferenceHelper.js';
@@ -98,7 +100,18 @@ export class VoiceRegistrationService {
         return;
       }
     } catch (error) {
-      logger.warn({ err: error, slug }, 'Failed to list voices, attempting registration');
+      // A ZodError means the voice-engine /v1/voices response drifted from its
+      // contract (a programming error, NOT a transient) — log at ERROR so it's
+      // distinguishable from a cold-start network failure (the warn case). Either
+      // way we fall through and attempt registration.
+      if (error instanceof ZodError) {
+        logger.error(
+          { err: error, slug },
+          'voice-engine /v1/voices response failed schema validation (contract drift)'
+        );
+      } else {
+        logger.warn({ err: error, slug }, 'Failed to list voices, attempting registration');
+      }
     }
 
     // Fetch reference audio from api-gateway

--- a/services/ai-worker/src/services/voice/voiceEngineSchemas.ts
+++ b/services/ai-worker/src/services/voice/voiceEngineSchemas.ts
@@ -47,3 +47,10 @@ export const healthResponseSchema = z.object({
 export const voicesResponseSchema = z.object({
   voices: z.array(z.object({ id: z.string(), type: z.string().optional() })),
 });
+
+/**
+ * FastAPI error body — `{ detail }`. `.parse()` is strict on object shape: a
+ * non-object or non-JSON body throws a ZodError, which the caller's catch falls
+ * back to the HTTP statusText. Only `detail` (the message) is read when present.
+ */
+export const errorDetailSchema = z.object({ detail: z.string().optional() });

--- a/services/bot-client/src/services/contextBuilder/RawEnvelopeContract.producer.test.ts
+++ b/services/bot-client/src/services/contextBuilder/RawEnvelopeContract.producer.test.ts
@@ -185,7 +185,14 @@ describe('RawEnvelope contract — producer fixture generation', () => {
     vi.useFakeTimers();
   });
   afterEach(() => {
-    vi.restoreAllMocks();
+    // resetAllMocks (not restoreAllMocks): these mocks are `vi.fn()`, not `vi.spyOn`
+    // spies, so restoreAllMocks is a no-op on them and — critically — leaves any
+    // queued `mockReturnValueOnce` in place. A scenario that throws before consuming
+    // its queued value would then leak it into the next scenario. reset clears the
+    // once-queue between cases. Vitest 4's mockReset preserves the original
+    // `vi.fn(factory)` implementation, so the default env-map / undefined-transcript
+    // impls survive (verified: fixtures regenerate byte-identical).
+    vi.resetAllMocks();
   });
 
   it.each(SCENARIOS)(


### PR DESCRIPTION
## Summary

Closes out the **Test-Pyramid Phase 4 "Seam Contract Coverage"** epic by clearing the deferred nits accumulated across PR1–PR6. No new seams — this is the grab-bag cleanup that lets the epic close cleanly. Two commits: the one production-behavior change (voice-engine error-path validation) is separated from the housekeeping.

## What's in it

**`refactor(ai-worker)` — voice-engine error + list response validation**
- `errorDetailSchema` replaces the unsafe `as { detail?: string }` cast in `VoiceEngineClient.extractErrorDetail`. A non-`{detail}`/non-JSON body still falls back to `statusText` (unchanged behavior); a drifted shape is now caught instead of silently typed.
- `VoiceRegistrationService.doRegister` distinguishes a `ZodError` (contract drift on `/v1/voices` — a programming error, logged at ERROR) from a cold-start network failure (logged at WARN). Both still fall through to registration. New test covers the branch.

**`chore` — Phase-4 close-out grab-bag**
- **tooling**: drop the dead `.component.test.ts` guards subsumed by the `.test.ts` check (`audit-unified`, `audit-route-auth-matrix`, `knip.json` — picomatch-verified that `src/**/*.test.ts` covers `*.component.test.ts`); remove the dead non-recursive `tests/e2e` schema-scan branch (contract tests live in `tests/e2e/contracts/`).
- **test-utils**: reject path-traversal names (`..` / leading `/`) in `contractFixtureFile`; add direct `loadContractFixture` unit tests; document the unvalidated `as T`.
- **topology**: tighten the import-assertion JSDoc (import-detection proves the binding isn't dead-code-eliminated, *not* that it's runtime-invoked — the `typeof X` residual); right-anchor the `from` suffix fragments against a `*V2` sibling fail-open; un-export the test-only `contentImportsSymbol`; clarify `schemaRef` is not a unique key (`id` is). Topology JSON regenerates **byte-identical**.
- **test**: harden the envelope contract tests (`resetAllMocks` clears the `mockReturnValueOnce` queue without losing the `vi.fn` factory impl — verified fixtures regenerate byte-identical; assert the voice routing transcript also stays out of history); fix the `ConversationHistoryService` component-test deterministic-UUID collision flake (seed strictly-increasing timestamps so same-key rows can't collide on their derived id).
- **hook**: extend the temporal-marker pre-commit check to Python (`#` comments + single-line docstrings), per-language prefix to avoid false-positives on TS private fields with date literals.

## Verification

- `pnpm --filter @tzurot/tooling test` — 1120 green
- `pnpm --filter ai-worker test` — 3270 green (incl. `VoiceRegistrationService` 21)
- `pnpm test:component ConversationHistoryService.component` — 35 green
- `pnpm test:integration` (RawEnvelope consumer contract) — 5 green
- bot-client suite (producer contract / `resetAllMocks`) — 5115 green
- `pnpm ops topology:check` — up-to-date (byte-identical)
- `pnpm quality` — fully green (lint, typecheck, knip, cpd, depcruise, backlog:lint, taxonomy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
