### PR TITLE
fix(ai-worker): stop re-storming dead image URLs on the reference path (+ pre-release hygiene)

### DIFF
--- a/packages/common-types/src/constants/discord.test.ts
+++ b/packages/common-types/src/constants/discord.test.ts
@@ -178,6 +178,17 @@ describe('Bot Footer Text Constants', () => {
       ).toBe('Model: [gpt-4](<https://example.com/m>)');
     });
 
+    it('never surfaces a VOICE provider as an LLM footer label (structural guard)', () => {
+      // elevenlabs / mistral are in DISCORD_PROVIDER_CHOICES but are voice providers; the
+      // LLM_FOOTER_PROVIDERS allowlist keeps them out of the model footer even if a future
+      // change wired one into the LLM `providerUsed` path.
+      for (const voiceProvider of ['elevenlabs', 'mistral']) {
+        expect(
+          buildModelFooterText('gpt-4', 'https://example.com/m', { provider: voiceProvider })
+        ).toBe('Model: [gpt-4](<https://example.com/m>)');
+      }
+    });
+
     it('should produce output that matches BOT_FOOTER_PATTERNS.MODEL', () => {
       // Every shape the builder can emit must be strippable by the footer regex,
       // or footers leak into stored history / duplicate-detection comparisons.

--- a/packages/common-types/src/constants/discord.ts
+++ b/packages/common-types/src/constants/discord.ts
@@ -265,13 +265,28 @@ export const BOT_FOOTER_TEXT = {
 } as const;
 
 /**
+ * Provider values that serve LLM (text) generation — the ONLY ones eligible for the
+ * model footer's "via <label>". `DISCORD_PROVIDER_CHOICES` deliberately mixes LLM
+ * (openrouter, zai-coding) and voice (elevenlabs, mistral) providers; only LLM providers
+ * ever populate the model footer's `providerUsed`, so this allowlist makes that
+ * constraint STRUCTURAL — a voice provider can never surface as "• via ElevenLabs (Voice)"
+ * on an LLM response even if a future change wired one into the LLM `providerUsed` path.
+ * Add a new entry here when a new LLM provider is added to `DISCORD_PROVIDER_CHOICES`.
+ */
+const LLM_FOOTER_PROVIDERS: ReadonlySet<(typeof DISCORD_PROVIDER_CHOICES)[number]['value']> =
+  new Set(['openrouter', 'zai-coding']);
+
+/**
  * Provider value → human-readable footer label, derived from the slash-command
- * choices so the two never drift. Used to make the served-by provider explicit
- * in the model footer (e.g. "via Z.AI Coding Plan" vs "via OpenRouter") rather
- * than leaving users to infer it from the `z-ai/` vendor-prefix on the model.
+ * choices (filtered to LLM providers) so the two never drift. Used to make the
+ * served-by provider explicit in the model footer (e.g. "via Z.AI Coding Plan" vs
+ * "via OpenRouter") rather than leaving users to infer it from the `z-ai/` vendor-prefix.
  */
 const PROVIDER_FOOTER_LABEL: Readonly<Record<string, string>> = Object.fromEntries(
-  DISCORD_PROVIDER_CHOICES.map(choice => [choice.value, choice.name])
+  DISCORD_PROVIDER_CHOICES.filter(choice => LLM_FOOTER_PROVIDERS.has(choice.value)).map(choice => [
+    choice.value,
+    choice.name,
+  ])
 );
 
 /** Options for {@link buildModelFooterText}. */

--- a/services/ai-worker/src/services/multimodal/VisionProcessor.test.ts
+++ b/services/ai-worker/src/services/multimodal/VisionProcessor.test.ts
@@ -944,7 +944,7 @@ describe('VisionProcessor', () => {
     });
 
     describe('skipNegativeCache option', () => {
-      it('should skip negative cache check when skipNegativeCache is true', async () => {
+      it('should re-attempt a TRANSIENT cached failure when skipNegativeCache is true', async () => {
         mockVisionCacheGetFailure.mockResolvedValue({
           category: 'rate_limit',
           cachedAt: '2026-04-28T18:22:42.000Z',
@@ -960,11 +960,37 @@ describe('VisionProcessor', () => {
           skipNegativeCache: true,
         });
 
-        // Should NOT check failure cache
-        expect(mockVisionCacheGetFailure).not.toHaveBeenCalled();
-        // Should call the vision API directly
+        // The check now always runs, but a TRANSIENT failure (rate_limit) is not honored on
+        // this path — it may have cleared, so we re-attempt the vision API rather than
+        // returning the cached fallback.
+        expect(mockVisionCacheGetFailure).toHaveBeenCalled();
         expect(mockModelInvoke).toHaveBeenCalledTimes(1);
         expect(result).toBe('Mocked image description');
+      });
+
+      it('should HONOR an attachment-bound cached failure even when skipNegativeCache is true', async () => {
+        // A permanently-dead image (e.g. expired Discord CDN URL → media_not_found) must
+        // NOT re-storm across providers every turn it sits in context. The reference path
+        // honors the attachment-bound cached failure and short-circuits to the fallback.
+        mockVisionCacheGetFailure.mockResolvedValue({
+          category: 'media_not_found',
+          cachedAt: '2026-04-28T18:22:42.000Z',
+        });
+        mockCheckModelVisionSupport.mockResolvedValue(true);
+
+        const personality = createMockPersonality({
+          model: 'gpt-4o',
+          visionModel: undefined,
+        });
+
+        const result = await describeImage(mockAttachment, personality, false, undefined, {
+          skipNegativeCache: true,
+        });
+
+        expect(mockVisionCacheGetFailure).toHaveBeenCalled();
+        // No vision call — the cross-provider storm is prevented.
+        expect(mockModelInvoke).not.toHaveBeenCalled();
+        expect(result).toBe('[Image unavailable: image unavailable]');
       });
 
       it('should still check negative cache when skipNegativeCache is false', async () => {
@@ -1306,9 +1332,11 @@ describe('VisionProcessor', () => {
           skipNegativeCache: true,
         });
 
-        // Should bypass both caches
+        // Positive cache is fully bypassed (skipCache); the negative cache is still
+        // CHECKED (always), but the cached failure here is TRANSIENT (rate_limit) so the
+        // skip path doesn't honor it — we re-attempt the vision API.
         expect(mockVisionCacheGet).not.toHaveBeenCalled();
-        expect(mockVisionCacheGetFailure).not.toHaveBeenCalled();
+        expect(mockVisionCacheGetFailure).toHaveBeenCalled();
         // Should call vision API directly
         expect(mockModelInvoke).toHaveBeenCalledTimes(1);
         expect(result).toBe('Mocked image description');

--- a/services/ai-worker/src/services/multimodal/VisionProcessor.ts
+++ b/services/ai-worker/src/services/multimodal/VisionProcessor.ts
@@ -131,7 +131,13 @@ export interface VisionLoggingContext {
  * Bundling these reduces param count (was 6 with separate `loggingContext`).
  */
 export interface DescribeImageOptions {
-  /** Skip negative cache check — set to true when called within a retry loop */
+  /**
+   * Skip the negative-cache check for TRANSIENT failures — set when called within a retry
+   * loop / on the reference path, so a just-cached transient failure can't defeat the
+   * retry. ATTACHMENT-BOUND failures (dead URL, removed model, content-policy, censored)
+   * are STILL honored even when this is true, so a permanently-dead image is suppressed
+   * instead of re-storming across providers every turn it sits in context.
+   */
   skipNegativeCache?: boolean;
   /** Skip positive cache check — set to true to force re-processing */
   skipCache?: boolean;
@@ -385,9 +391,10 @@ async function invokeVisionModel(
  * stay in sync. Enforced by the invariant test in `VisionProcessor.test.ts` so that
  * adding a category to one but not the other fails CI.
  *
- * Exported for the invariant test only — call sites should use
+ * Exported for the invariant test only — EXTERNAL call sites should use
  * `buildFailureFallback` / `VISION_FAILURE_CACHE_POLICY` rather than reading this set
- * directly.
+ * directly. (The in-module `checkNegativeCache` reads it as a membership predicate to
+ * decide which cached failures the retry-loop / reference path honors.)
  */
 // eslint-disable-next-line @tzurot/no-singleton-export -- Intentional: immutable lookup set used as a constant. Exported only to enable the cache-policy/fallback-set invariant test in VisionProcessor.test.ts.
 export const ATTACHMENT_BOUND_FAILURE_CATEGORIES: ReadonlySet<ApiErrorCategory> = new Set([
@@ -437,14 +444,28 @@ function buildFailureFallback(
 /**
  * Check negative cache for a previous failure.
  * Returns a fallback string if a failure is cached, or null to proceed with the API call.
+ *
+ * `attachmentBoundOnly` (the retry-loop / reference path) honors ONLY failures bound to
+ * the attachment itself (dead URL, removed model, content-policy, censored) — those can't
+ * recover for this attachment, so re-attempting every turn the image sits in context just
+ * re-storms across providers (observed adding ~100s of latency per turn). Transient
+ * failures (rate-limit, quota, server) are NOT honored in this mode: they may have
+ * cleared, and short-circuiting them would defeat the retry that exists to catch recovery.
  */
 async function checkNegativeCache(
   cacheKeyOptions: { attachmentId?: string; url: string },
   attachmentId: string | undefined,
-  apiKeySource: 'user' | 'system' | undefined
+  apiKeySource: 'user' | 'system' | undefined,
+  options: { attachmentBoundOnly?: boolean } = {}
 ): Promise<string | null> {
   const failureEntry = await visionDescriptionCache.getFailure(cacheKeyOptions);
   if (failureEntry === null) {
+    return null;
+  }
+  if (
+    options.attachmentBoundOnly === true &&
+    !ATTACHMENT_BOUND_FAILURE_CATEGORIES.has(failureEntry.category)
+  ) {
     return null;
   }
   logger.info(
@@ -613,17 +634,19 @@ export async function describeImage(
     }
   }
 
-  // Check negative cache to avoid re-hammering failed images
-  // Skip when called within a retry loop — the negative cache would defeat retries
-  if (options?.skipNegativeCache !== true) {
-    const failureFallback = await checkNegativeCache(
-      cacheKeyOptions,
-      attachment.id,
-      loggingContext.apiKeySource
-    );
-    if (failureFallback !== null) {
-      return failureFallback;
-    }
+  // Check the negative cache to avoid re-hammering failed images. On the retry-loop /
+  // reference path (`skipNegativeCache`) we still honor ATTACHMENT-BOUND failures (a dead
+  // URL / removed model won't recover for this attachment, so re-attempting every turn it
+  // sits in context just re-storms across providers) but skip transient ones so the retry
+  // can still catch recovery.
+  const failureFallback = await checkNegativeCache(
+    cacheKeyOptions,
+    attachment.id,
+    loggingContext.apiKeySource,
+    { attachmentBoundOnly: options?.skipNegativeCache === true }
+  );
+  if (failureFallback !== null) {
+    return failureFallback;
   }
 
   const systemPrompt =

--- a/services/bot-client/src/commands/models/browse.ts
+++ b/services/bot-client/src/commands/models/browse.ts
@@ -157,7 +157,7 @@ interface BrowseView {
   page: number;
   capability: CapabilityFilter;
   sort: ModelSort;
-  search: string | null;
+  query: string | null;
   capped: boolean;
 }
 
@@ -169,13 +169,13 @@ const ACTIVE_SORT_LABEL: Record<ModelSort, string> = {
 };
 
 function buildBrowseEmbed(view: BrowseView, pageItems: BrowseModel[]): EmbedBuilder {
-  const { items, page, capability, sort, search, capped } = view;
+  const { items, page, capability, sort, query, capped } = view;
   const startIdx = page * MODELS_PER_PAGE;
 
   const lines: string[] = [];
   const filterBits = [
     capability !== 'all' ? `capability: ${capability}` : '',
-    search !== null ? `search: "${search}"` : '',
+    query !== null ? `query: "${query}"` : '',
     `sorted: ${ACTIVE_SORT_LABEL[sort]}`,
   ].filter(Boolean);
   lines.push(`_${filterBits.join(' · ')}_`);
@@ -201,7 +201,7 @@ function buildBrowseEmbed(view: BrowseView, pageItems: BrowseModel[]): EmbedBuil
   embed.setFooter({
     text: joinFooter(
       pluralize(items.length, { singular: 'model', plural: 'models' }),
-      capped && `first ${BROWSE_FETCH_LIMIT} — refine with search for more`,
+      capped && `first ${BROWSE_FETCH_LIMIT} — refine with a query for more`,
       '🆓 free  ✅ you can use  🔒 needs a key  ❔ unverified  📌 global preset  🔀 router  ⚡ z.ai'
     ),
   });
@@ -213,13 +213,13 @@ function buildBrowseComponents(
   pageItems: BrowseModel[],
   totalPages: number
 ): BrowseActionRow[] {
-  const { page, capability, sort, search } = view;
+  const { page, capability, sort, query } = view;
   const startIdx = page * MODELS_PER_PAGE;
   const components: BrowseActionRow[] = [];
 
   const selectRow = buildBrowseSelectMenu<BrowseModel>({
     items: pageItems,
-    customId: browseHelpers.buildSelect(page, capability, sort, search),
+    customId: browseHelpers.buildSelect(page, capability, sort, query),
     placeholder: 'Select a model to view its card...',
     startIndex: startIdx,
     formatItem: model => ({
@@ -239,7 +239,7 @@ function buildBrowseComponents(
         totalPages,
         filter: capability,
         currentSort: sort,
-        query: search,
+        query,
         buildCustomId: browseHelpers.build,
         buildInfoId: browseHelpers.buildInfo,
         sortToggle,
@@ -273,12 +273,12 @@ function buildBrowsePage(view: BrowseView): { embed: EmbedBuilder; components: B
 async function loadAnnotatedModels(
   interaction: ClientCarryingInteraction,
   capability: CapabilityFilter,
-  search: string | null,
+  query: string | null,
   sort: ModelSort
 ): Promise<BrowseModel[]> {
   const { userClient } = clientsFor(interaction);
   const [catalog, activeProviders, globalPresetModelIds] = await Promise.all([
-    fetchModelCatalog({ capability, search: search ?? undefined, limit: BROWSE_FETCH_LIMIT }),
+    fetchModelCatalog({ capability, search: query ?? undefined, limit: BROWSE_FETCH_LIMIT }),
     getActiveProviders(userClient, interaction.user.id),
     getGlobalPresetModelIds(userClient),
   ]);
@@ -295,21 +295,21 @@ async function loadAnnotatedModels(
 export async function handleBrowse(context: DeferredCommandContext): Promise<void> {
   const options = modelsBrowseOptions(context.interaction);
   const capability = (options.capability() ?? 'all') as CapabilityFilter;
-  const search = options.query();
+  const query = options.query();
   const sort: ModelSort = 'default';
 
   try {
-    const models = await loadAnnotatedModels(context.interaction, capability, search, sort);
+    const models = await loadAnnotatedModels(context.interaction, capability, query, sort);
     const { embed, components } = buildBrowsePage({
       items: models,
       page: 0,
       capability,
       sort,
-      search,
+      query,
       capped: models.length >= BROWSE_FETCH_LIMIT,
     });
     await context.editReply({ embeds: [embed], components });
-    logger.info({ count: models.length, capability, search, sort }, 'Browse models');
+    logger.info({ count: models.length, capability, query, sort }, 'Browse models');
   } catch (error) {
     logger.error({ err: error }, 'Failed to browse models');
     await context.editReply('❌ Failed to load models. Please try again.');
@@ -332,7 +332,7 @@ export async function handleBrowsePagination(interaction: ButtonInteraction): Pr
       page: parsed.page,
       capability: parsed.filter,
       sort: parsed.sort,
-      search: parsed.query,
+      query: parsed.query,
       capped: models.length >= BROWSE_FETCH_LIMIT,
     });
     await interaction.editReply({ embeds: [embed], components });


### PR DESCRIPTION
## Summary

Three pre-release squeeze-ins (one real fix + two small hygiene items), separated into clean per-concern commits.

## Commits

**`fix(ai-worker)` — stop re-storming dead image URLs on the reference path** (the high-value one)
A permanently-dead image (expired Discord CDN URL sitting in a channel's extended-context window) was re-attempted **every turn**: the reference path passes `skipNegativeCache: true`, which skipped the negative-cache *check* entirely, so the already-cached `media_not_found` failure was ignored and vision re-fanned across OpenRouter's providers each turn — **observed ~100s of added latency per turn**, recurring because the reference path also bypassed the 1h negative-cache window.

`checkNegativeCache` gains an `attachmentBoundOnly` mode: on the retry-loop / reference path it now honors **attachment-bound** cached failures (`media_not_found`, `model_not_found`, `content_policy`, `censored` — can't recover for this attachment) while still skipping **transient** ones (rate-limit/quota/server may have cleared, so the retry must still run). Our own `withRetry` already respects `shouldRetry=false`, so the *first* storm is unchanged; this kills the per-turn **re**-storm. Tests cover both the transient (re-attempt) and attachment-bound (short-circuit) cases on the skip path.

**`refactor(common-types)` — constrain the model footer to LLM providers**
`PROVIDER_FOOTER_LABEL` derived from all of `DISCORD_PROVIDER_CHOICES` (which mixes LLM + voice providers), so a future change wiring a voice provider into the LLM path could render "• via ElevenLabs (Voice)" on an LLM response. An explicit `LLM_FOOTER_PROVIDERS` allowlist makes the constraint structural. Chosen over a `kind` marker (Discord.js `.addChoices` validation risk) or grouped sub-arrays (would reorder the dropdown). Test asserts voice providers never produce a footer label.

**`refactor(bot-client)` — rename internal `search`→`query` in `/models browse`**
After the Discord-option `search`→`query` rename, the command's local vars / `BrowseView` field / embed labels / log key still said `search` while the option, the shared browse helpers, and the customId slot said `query`. Renamed to align (the one exception: `fetchModelCatalog({ search })` is the catalog util's own API, left as-is). Behavior unchanged.

## Verification

- `pnpm --filter ai-worker` VisionProcessor + MultimodalProcessor + ImageDescriptionJob — 105 green (incl. 2 new dead-URL cases)
- `pnpm --filter @tzurot/common-types` discord — 109 green (incl. the voice-provider guard)
- `pnpm --filter bot-client` browse — 29 green
- `pnpm quality` — fully green

## Backlog

On merge, removes these now-shipped follow-ups: `cold/follow-ups.md` "PROVIDER_FOOTER_LABEL includes voice providers" + "/models browse internal search naming"; `cold/ideas.md` dead-image retry-storm item. (Also dropping the already-fixed `prisma.ts void pool.end()` follow-up — verified resolved in code.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
