### PR TITLE
test: fix the conversation-history UUID-collision flake + beta.139 review follow-ups

### DIFF
--- a/packages/conversation-history/src/ConversationHistoryService.component.test.ts
+++ b/packages/conversation-history/src/ConversationHistoryService.component.test.ts
@@ -299,7 +299,7 @@ describe('ConversationHistoryService Component Test', () => {
     });
 
     it('should indicate no more pages when exhausted', async () => {
-      // Add 2 messages
+      // Add 2 messages (explicit timestamps so the same-key rows can't collide)
       await service.addMessage({
         channelId: testChannelId,
         personalityId: testPersonalityId,
@@ -307,6 +307,7 @@ describe('ConversationHistoryService Component Test', () => {
         role: MessageRole.User,
         content: 'Only message 1',
         guildId: testGuildId,
+        timestamp: seededTimestamp(0),
       });
       await service.addMessage({
         channelId: testChannelId,
@@ -315,6 +316,7 @@ describe('ConversationHistoryService Component Test', () => {
         role: MessageRole.User,
         content: 'Only message 2',
         guildId: testGuildId,
+        timestamp: seededTimestamp(1),
       });
 
       // Request more than exist
@@ -491,7 +493,10 @@ describe('ConversationHistoryService Component Test', () => {
 
   describe('getChannelHistory with contextEpoch', () => {
     it('should filter out messages before epoch', async () => {
-      // Add first message
+      // Explicit seeded timestamps (not real-clock + setTimeout): the epoch sits at
+      // index 1, between the message at index 0 (before) and index 2 (after) — no
+      // message coincides with it, and the same-key rows can't collide on their
+      // deterministic UUID (see seededTimestamp note).
       await service.addMessage({
         channelId: testChannelId,
         personalityId: testPersonalityId,
@@ -499,14 +504,9 @@ describe('ConversationHistoryService Component Test', () => {
         role: MessageRole.User,
         content: 'Old message before epoch',
         guildId: testGuildId,
+        timestamp: seededTimestamp(0),
       });
-
-      // Wait a bit to ensure different timestamp
-      await new Promise(resolve => setTimeout(resolve, 50));
-      const epochTime = new Date();
-      await new Promise(resolve => setTimeout(resolve, 50));
-
-      // Add second message after epoch
+      const epochTime = seededTimestamp(1);
       await service.addMessage({
         channelId: testChannelId,
         personalityId: testPersonalityId,
@@ -514,6 +514,7 @@ describe('ConversationHistoryService Component Test', () => {
         role: MessageRole.User,
         content: 'New message after epoch',
         guildId: testGuildId,
+        timestamp: seededTimestamp(2),
       });
 
       // Without epoch - should see both
@@ -534,11 +535,11 @@ describe('ConversationHistoryService Component Test', () => {
         role: MessageRole.User,
         content: 'Old message',
         guildId: testGuildId,
+        timestamp: seededTimestamp(0),
       });
 
-      // Set epoch to future
-      const futureEpoch = new Date();
-      futureEpoch.setDate(futureEpoch.getDate() + 1);
+      // Epoch well after the seeded message — deterministic, no real clock.
+      const futureEpoch = seededTimestamp(100);
 
       const history = await service.getChannelHistory(testChannelId, 10, futureEpoch);
       expect(history).toEqual([]);
@@ -547,7 +548,10 @@ describe('ConversationHistoryService Component Test', () => {
 
   describe('getHistory (paginated) with contextEpoch', () => {
     it('should filter paginated results by epoch', async () => {
-      // Add messages before epoch
+      // Seeded timestamps: two "before" rows at indices 0,1 and two "after" rows at
+      // 2,3. The epoch sits strictly BETWEEN index 1 and 2 (a message coincides with
+      // index 1, so the boundary is t1+500ms — excludes "Before epoch 2", includes
+      // "After epoch 1"). Deterministic + collision-free (see seededTimestamp note).
       await service.addMessage({
         channelId: testChannelId,
         personalityId: testPersonalityId,
@@ -555,6 +559,7 @@ describe('ConversationHistoryService Component Test', () => {
         role: MessageRole.User,
         content: 'Before epoch 1',
         guildId: testGuildId,
+        timestamp: seededTimestamp(0),
       });
       await service.addMessage({
         channelId: testChannelId,
@@ -563,11 +568,10 @@ describe('ConversationHistoryService Component Test', () => {
         role: MessageRole.User,
         content: 'Before epoch 2',
         guildId: testGuildId,
+        timestamp: seededTimestamp(1),
       });
 
-      await new Promise(resolve => setTimeout(resolve, 50));
-      const epochTime = new Date();
-      await new Promise(resolve => setTimeout(resolve, 50));
+      const epochTime = new Date(seededTimestamp(1).getTime() + 500);
 
       // Add messages after epoch
       await service.addMessage({
@@ -577,6 +581,7 @@ describe('ConversationHistoryService Component Test', () => {
         role: MessageRole.User,
         content: 'After epoch 1',
         guildId: testGuildId,
+        timestamp: seededTimestamp(2),
       });
       await service.addMessage({
         channelId: testChannelId,
@@ -585,6 +590,7 @@ describe('ConversationHistoryService Component Test', () => {
         role: MessageRole.User,
         content: 'After epoch 2',
         guildId: testGuildId,
+        timestamp: seededTimestamp(3),
       });
 
       // Without epoch - should see all 4
@@ -659,7 +665,9 @@ describe('ConversationHistoryService Component Test', () => {
     });
 
     it('should filter stats by epoch', async () => {
-      // Add messages before epoch
+      // Seeded timestamps: two "before" rows at indices 0,1; the epoch sits strictly
+      // between index 1 and 2 (t1+500ms); one "after" row at index 2. Deterministic +
+      // collision-free for the same-key rows (see seededTimestamp note).
       await service.addMessage({
         channelId: testChannelId,
         personalityId: testPersonalityId,
@@ -667,6 +675,7 @@ describe('ConversationHistoryService Component Test', () => {
         role: MessageRole.User,
         content: 'Before epoch',
         guildId: testGuildId,
+        timestamp: seededTimestamp(0),
       });
       await service.addMessage({
         channelId: testChannelId,
@@ -675,11 +684,10 @@ describe('ConversationHistoryService Component Test', () => {
         role: MessageRole.Assistant,
         content: 'Before epoch response',
         guildId: testGuildId,
+        timestamp: seededTimestamp(1),
       });
 
-      await new Promise(resolve => setTimeout(resolve, 50));
-      const epochTime = new Date();
-      await new Promise(resolve => setTimeout(resolve, 50));
+      const epochTime = new Date(seededTimestamp(1).getTime() + 500);
 
       // Add messages after epoch
       await service.addMessage({
@@ -689,6 +697,7 @@ describe('ConversationHistoryService Component Test', () => {
         role: MessageRole.User,
         content: 'After epoch',
         guildId: testGuildId,
+        timestamp: seededTimestamp(2),
       });
 
       // Stats without epoch

--- a/packages/tooling/src/topology/importAssertions.ts
+++ b/packages/tooling/src/topology/importAssertions.ts
@@ -103,6 +103,12 @@ function namedImportsForFile(absPath: string): NamedImport[] {
  * `topology:generate` / `topology:check` invocation runs in a fresh `tsx` process,
  * so a file cannot change between two reads within one run. (Tests that rewrite a
  * fixture between assertions call `clearFileImportCache`.)
+ *
+ * **NOT concurrency-safe**: on a cache miss this parses via `parseNamedImports`,
+ * which reuses one shared in-memory source file (`overwrite: true`). Call it
+ * SERIALLY — a `Promise.all(symbols.map(s => fileImportsSymbol(..., s, ...)))`
+ * would clobber parses mid-flight and return wrong results. (The topology probe
+ * calls it serially.)
  */
 export function fileImportsSymbol(
   absPath: string,

--- a/services/ai-worker/src/services/context/relayEchoRecovery.test.ts
+++ b/services/ai-worker/src/services/context/relayEchoRecovery.test.ts
@@ -81,4 +81,51 @@ describe('recoverRelayEchoIdentities', () => {
 
     expect(dataSource.getUserIdentitiesByDiscordIds).not.toHaveBeenCalled();
   });
+
+  it('scans past a non-matching id to a later match (multi-part reply)', async () => {
+    // A long reply spans several Discord messages, so discordMessageId can hold
+    // multiple ids; the loop must skip a non-matching one and recover from a later one.
+    const messages = [relayEcho({ discordMessageId: ['d-miss', 'd-hit'] })];
+    const dataSource = {
+      getUserIdentitiesByDiscordIds: vi
+        .fn()
+        .mockResolvedValue(
+          new Map([
+            [
+              'd-hit',
+              { personaId: 'persona-uuid', personaName: 'Lila', discordUsername: 'lbds137' },
+            ],
+          ])
+        ),
+    };
+
+    await recoverRelayEchoIdentities(messages, dataSource);
+
+    expect(messages[0].personaId).toBe('persona-uuid');
+    expect(messages[0].personaName).toBe('Lila');
+    expect(messages[0].discordUsername).toBe('lbds137');
+  });
+
+  it('uses the FIRST matching id when several match (break wins)', async () => {
+    const messages = [relayEcho({ discordMessageId: ['d-first', 'd-second'] })];
+    const dataSource = {
+      getUserIdentitiesByDiscordIds: vi.fn().mockResolvedValue(
+        new Map([
+          [
+            'd-first',
+            { personaId: 'first-uuid', personaName: 'Lila', discordUsername: 'first-user' },
+          ],
+          [
+            'd-second',
+            { personaId: 'second-uuid', personaName: 'Lila', discordUsername: 'second-user' },
+          ],
+        ])
+      ),
+    };
+
+    await recoverRelayEchoIdentities(messages, dataSource);
+
+    expect(messages[0].personaId).toBe('first-uuid');
+    expect(messages[0].discordUsername).toBe('first-user');
+  });
 });

--- a/services/ai-worker/src/services/context/relayEchoRecovery.ts
+++ b/services/ai-worker/src/services/context/relayEchoRecovery.ts
@@ -40,6 +40,12 @@ function hasResolvedPersonaId(personaId: string | undefined): boolean {
  * place. Must run AFTER persona resolution (which strips the bot personaId to
  * ''). Messages with a resolved personaId, or with no matching persisted row,
  * are left untouched (graceful fallback to the bot-name attribution).
+ *
+ * MUTATES the `messages` elements in place (personaId / personaName /
+ * discordUsername); callers must not alias elements they need to keep pristine.
+ * Safe as long as callers always fetch fresh per-request rows; a caller passing
+ * objects from a shared cache (e.g. an L2 in-memory history layer) must clone them
+ * first.
  */
 export async function recoverRelayEchoIdentities(
   messages: ConversationMessage[],

--- a/services/ai-worker/src/services/voice/voiceEngineSchemas.test.ts
+++ b/services/ai-worker/src/services/voice/voiceEngineSchemas.test.ts
@@ -4,6 +4,7 @@ import {
   transcribeResponseSchema,
   healthResponseSchema,
   voicesResponseSchema,
+  errorDetailSchema,
 } from './voiceEngineSchemas.js';
 
 describe('voiceEngineSchemas', () => {
@@ -53,6 +54,26 @@ describe('voiceEngineSchemas', () => {
 
     it('rejects a voice item missing its id', () => {
       expect(() => voicesResponseSchema.parse({ voices: [{ type: 'cached' }] })).toThrow();
+    });
+  });
+
+  describe('errorDetailSchema', () => {
+    it('accepts a string detail', () => {
+      expect(errorDetailSchema.parse({ detail: 'Voice not found' })).toEqual({
+        detail: 'Voice not found',
+      });
+    });
+
+    it('accepts a missing detail (undefined)', () => {
+      expect(errorDetailSchema.parse({})).toEqual({});
+    });
+
+    it('accepts a null detail (FastAPI can send detail: null) — nullish, not a throw', () => {
+      expect(errorDetailSchema.parse({ detail: null })).toEqual({ detail: null });
+    });
+
+    it('rejects a non-string, non-null detail (type drift)', () => {
+      expect(() => errorDetailSchema.parse({ detail: 42 })).toThrow();
     });
   });
 });

--- a/services/ai-worker/src/services/voice/voiceEngineSchemas.ts
+++ b/services/ai-worker/src/services/voice/voiceEngineSchemas.ts
@@ -51,6 +51,9 @@ export const voicesResponseSchema = z.object({
 /**
  * FastAPI error body — `{ detail }`. `.parse()` is strict on object shape: a
  * non-object or non-JSON body throws a ZodError, which the caller's catch falls
- * back to the HTTP statusText. Only `detail` (the message) is read when present.
+ * back to the HTTP statusText. `detail` is `.nullish()` (string | null | undefined)
+ * so a `detail: null` body parses cleanly instead of throwing; the caller's
+ * `body.detail ?? response.statusText` covers both null and undefined. Only `detail`
+ * (the message) is read.
  */
-export const errorDetailSchema = z.object({ detail: z.string().optional() });
+export const errorDetailSchema = z.object({ detail: z.string().nullish() });


### PR DESCRIPTION
## Summary

Post-beta.139 cleanup: a **CI-reliability fix** (a deterministic-UUID test flake that re-surfaced on the beta.139 release CI) plus the **three non-blocking follow-ups** from the #1360 holistic release review. Four clean per-concern commits.

## Commits

**`test(conversation-history)` — fix the deterministic-UUID collision flake (the headline)**
The flake that #1358 *started* fixing re-surfaced: `component-tests` on the beta.139 release SHA failed on develop with `Unique constraint failed on (id)` in `ConversationHistoryService` (same SHA passed on main — pure timing flake). The row id is `generateConversationHistoryUuid(channelId, personalityId, personaId, createdAt)`; when a test inserts 2+ same-key rows with default `new Date()`, two in the same ms collide. #1358 seeded the loops but **missed four same-channel multi-insert sites** that used real-clock `new Date()` + `setTimeout` (which only spaced the *epoch*, not the messages): the two contextEpoch filter tests, the paginated-epoch test (the one that re-flaked), the "no more pages" test, and the stats-epoch test. Each now seeds explicit strictly-increasing timestamps with the epoch boundary placed deterministically between seeded indices. **Audited exhaustively this time** — every remaining untimestamped insert is a single-row test (can't collide; `beforeEach` truncates).

**`test(ai-worker)` — multi-ID relay-echo coverage + in-place-mutation doc** (review follow-up)
`recoverRelayEchoIdentities` loops `discordMessageId` and `break`s on first match; all existing tests used single-element arrays. Adds scan-past-miss + first-match-wins cases and documents the in-place mutation contract.

**`refactor(ai-worker)` — `errorDetailSchema.detail` → `.nullish()`** (review follow-up)
`.optional()` rejected a FastAPI `detail: null` (→ ZodError → statusText); `.nullish()` parses it cleanly. Adds errorDetailSchema schema tests.

**`docs(tooling)` — `fileImportsSymbol` not-concurrency-safe note** (review follow-up)
Moves the "call serially, not via Promise.all" constraint onto the exported function's JSDoc.

## Verification

- `pnpm test:component ConversationHistoryService.component` — 35 green (deterministic now)
- `pnpm --filter ai-worker` relayEchoRecovery (7) + voiceEngineSchemas (12) green
- `pnpm --filter @tzurot/tooling` importAssertions (11) green
- `pnpm quality` — fully green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
