### PR TITLE
fix(api-gateway): db-sync covers vision-config schema + guard against future gaps

### DIFF
--- a/services/api-gateway/src/services/DatabaseSyncService.component.test.ts
+++ b/services/api-gateway/src/services/DatabaseSyncService.component.test.ts
@@ -17,20 +17,20 @@
  *    that column NOT NULL.
  * 2. The conflict resolution case — both sides have data, last-write-wins
  *    still picks the right winner without losing the circular FK values.
- * 3. The DEFERRABLE precondition check — confirms the four circular FKs
- *    on both test DBs are in fact deferrable, so the Ouroboros pattern
- *    has something to defer. If the migration is ever reverted without
- *    updating this suite, this test fails first and the author knows
- *    before the pattern silently degrades.
+ * 3. The DEFERRABLE precondition check — confirms the circular FKs plus
+ *    the TTS and vision default FKs on both test DBs are in fact
+ *    deferrable, so the Ouroboros pattern has something to defer. If a
+ *    migration is ever reverted without updating this suite, this test
+ *    fails first and the author knows before the pattern silently degrades.
  * 4. The rollback case — a mid-flush throw aborts the transaction
  *    cleanly; dev remains untouched. Load-bearing for the Ouroboros
  *    pattern since deferred FKs only validate at COMMIT.
  *
  * Setup notes:
  * - `loadPGliteSchema()` returns SQL generated from `schema.prisma`, which
- *   cannot express DEFERRABLE. The DEFERRABLE ALTER statements from
- *   migration 20260418010642 are applied manually in `beforeAll` so the
- *   test environment matches production's constraint shape.
+ *   cannot express DEFERRABLE. The DEFERRABLE ALTER statements (from the
+ *   circular-FK, TTS, and vision migrations) are applied manually in
+ *   `beforeAll` so the test environment matches production's constraint shape.
  * - We spin up TWO PGLite instances — one acts as "dev", one as "prod".
  */
 
@@ -96,6 +96,33 @@ function loadTtsDefaultFkDeferrableMigration(): string {
     'migration.sql'
   );
   return readFileSync(migrationPath, 'utf-8');
+}
+
+/**
+ * Extract the DEFERRABLE clause for users.default_vision_config_id_fkey from the
+ * vision_config_kind migration.
+ *
+ * Unlike the pure-alter circular/TTS DEFERRABLE migrations (which can be replayed
+ * wholesale), 20260627040007 is a FULL schema migration — replaying it on top of
+ * loadPGliteSchema() would collide with the columns/indexes that schema already
+ * created. So we extract ONLY its `ALTER CONSTRAINT … DEFERRABLE` statement.
+ * Reading it from the migration FILE (not inlining the SQL) keeps the same
+ * invariant the other helpers protect: if a future migration drops the DEFERRABLE
+ * clause, the extraction throws and this test goes red.
+ */
+function loadVisionDefaultFkDeferrableClause(): string {
+  const migrationPath = join(migrationsDir(), '20260627040007_vision_config_kind', 'migration.sql');
+  const sql = readFileSync(migrationPath, 'utf-8');
+  const match = sql.match(
+    /ALTER TABLE "users"\s+ALTER CONSTRAINT "users_default_vision_config_id_fkey" DEFERRABLE INITIALLY IMMEDIATE;/
+  );
+  if (match === null) {
+    throw new Error(
+      'DEFERRABLE clause for users_default_vision_config_id_fkey not found in ' +
+        '20260627040007_vision_config_kind — did the migration drop it?'
+    );
+  }
+  return match[0];
 }
 
 /**
@@ -193,6 +220,7 @@ describe('DatabaseSyncService Integration (Ouroboros pattern)', () => {
     const schema = loadPGliteSchema();
     const deferrableFkMigration = loadDeferrableFkMigration();
     const ttsDefaultFkDeferrableMigration = loadTtsDefaultFkDeferrableMigration();
+    const visionDefaultFkDeferrableClause = loadVisionDefaultFkDeferrableClause();
     const alignTtsGlobalsMigration = loadAlignTtsGlobalsMigration();
 
     devPglite = createTestPGlite();
@@ -210,6 +238,11 @@ describe('DatabaseSyncService Integration (Ouroboros pattern)', () => {
     await prodPglite.exec(deferrableFkMigration);
     await devPglite.exec(ttsDefaultFkDeferrableMigration);
     await prodPglite.exec(ttsDefaultFkDeferrableMigration);
+    // Same for the vision-default FK (DEFERRABLE since 20260627040007). Only the
+    // ALTER clause is applied — the full vision migration can't be replayed on
+    // top of the generated schema (see loadVisionDefaultFkDeferrableClause).
+    await devPglite.exec(visionDefaultFkDeferrableClause);
+    await prodPglite.exec(visionDefaultFkDeferrableClause);
     // Recovery migration aligning TTS system-global rows to deterministic
     // UUIDs. Idempotent — these pglite instances have no TTS rows yet, so
     // the WHERE clauses match nothing on the first run. Loaded here for
@@ -364,11 +397,12 @@ describe('DatabaseSyncService Integration (Ouroboros pattern)', () => {
           'users_default_persona_id_fkey',
           'users_default_llm_config_id_fkey',
           'users_default_tts_config_id_fkey',
+          'users_default_vision_config_id_fkey',
           'personas_owner_id_fkey',
           'llm_configs_owner_id_fkey'
         )
       `);
-      expect(rows.length).toBe(5);
+      expect(rows.length).toBe(6);
       for (const r of rows) {
         expect(r.is_deferrable, `${r.constraint_name} should be DEFERRABLE`).toBe('YES');
       }

--- a/services/api-gateway/src/services/sync/config/syncTables.ts
+++ b/services/api-gateway/src/services/sync/config/syncTables.ts
@@ -24,6 +24,8 @@ export const EXCLUDED_TABLES: Record<string, string> = {
     'Character-level LLM preset defaults - dev/prod may use different models for testing',
   personality_default_tts_configs:
     'Character-level TTS preset defaults - dev/prod may use different voices for testing (mirrors personality_default_configs)',
+  personality_vision_default_configs:
+    'Character-level vision preset defaults - dev/prod may use different vision models for testing (mirrors personality_default_configs/tts)',
 
   // Transient/ephemeral data
   pending_memories: 'Transient queue data for memory processing',
@@ -89,12 +91,18 @@ export const SYNC_CONFIG: Record<SyncTableName, TableSyncConfig> = {
     pk: 'id',
     createdAt: 'created_at',
     updatedAt: 'updated_at',
-    uuidColumns: ['id', 'default_llm_config_id', 'default_persona_id', 'default_tts_config_id'],
+    uuidColumns: [
+      'id',
+      'default_llm_config_id',
+      'default_persona_id',
+      'default_tts_config_id',
+      'default_vision_config_id',
+    ],
     timestampColumns: ['created_at', 'updated_at'],
-    // Three FK columns on users reference rows in tables that come AFTER
+    // Four FK columns on users reference rows in tables that come AFTER
     // users in SYNC_TABLE_ORDER (personas, llm_configs, tts_configs are
     // all synced after users so their owner_id NOT-NULL FKs back to users
-    // can be satisfied). All three FKs are made DEFERRABLE so the sync
+    // can be satisfied). All four FKs are made DEFERRABLE so the sync
     // transaction can issue SET CONSTRAINTS … DEFERRED and let Postgres
     // validate the references at COMMIT time, when every cross-table
     // referenced row exists:
@@ -102,6 +110,8 @@ export const SYNC_CONFIG: Record<SyncTableName, TableSyncConfig> = {
     //     DEFERRABLE since migration 20260418010642 (the original circular-FK fix).
     //   - default_tts_config_id (nullable): DEFERRABLE since migration
     //     20260504065151 (added when the TTS feature shipped).
+    //   - default_vision_config_id (nullable, → llm_configs vision-kind row):
+    //     DEFERRABLE since migration 20260627040007 (the vision_config_kind migration).
     // Nullability is orthogonal to DEFERRABLE: deferral controls *when* the FK
     // reference is validated (at COMMIT, after the referenced row is synced),
     // not whether the column may be NULL. A non-NULL FK still needs deferral
@@ -181,6 +191,7 @@ export const SYNC_CONFIG: Record<SyncTableName, TableSyncConfig> = {
       'persona_id',
       'llm_config_id',
       'tts_config_id',
+      'vision_config_id',
     ],
     timestampColumns: ['created_at', 'updated_at'],
     // persona_id, llm_config_id, and tts_config_id are synced directly (not

--- a/services/api-gateway/src/services/sync/config/syncTables.ts
+++ b/services/api-gateway/src/services/sync/config/syncTables.ts
@@ -194,10 +194,11 @@ export const SYNC_CONFIG: Record<SyncTableName, TableSyncConfig> = {
       'vision_config_id',
     ],
     timestampColumns: ['created_at', 'updated_at'],
-    // persona_id, llm_config_id, and tts_config_id are synced directly (not
-    // deferred) — personas, llm_configs, and tts_configs all come before
-    // user_personality_configs in SYNC_TABLE_ORDER, so their rows exist by the
-    // time this table is synced; no circular-FK deferral needed.
+    // persona_id, llm_config_id, tts_config_id, and vision_config_id are synced
+    // directly (not deferred) — personas, llm_configs, and tts_configs all come
+    // before user_personality_configs in SYNC_TABLE_ORDER (vision_config_id also
+    // points to llm_configs), so their rows exist by the time this table is
+    // synced; no circular-FK deferral needed.
     // Previously excluded as "user preferences" but that orphaned per-character
     // persona/llm overrides for mirrored users on dev. Same trade-off as on users:
     // the dev user's own overrides will bleed across envs via last-write-wins.

--- a/services/api-gateway/src/services/sync/utils/syncValidation.component.test.ts
+++ b/services/api-gateway/src/services/sync/utils/syncValidation.component.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Deterministic guard: `validateSyncConfig` must produce ZERO warnings against the
+ * live (PGLite) schema.
+ *
+ * This turns the existing RUNTIME "table/UUID-column not in SYNC_CONFIG" warning — which
+ * only surfaces when someone actually runs `/admin db-sync` — into a BUILD-TIME failure.
+ * A migration that adds a table or a UUID FK column without updating `syncTables.ts`
+ * (SYNC_CONFIG / EXCLUDED_TABLES / uuidColumns) now fails CI instead of silently
+ * warning later. The beta.140 `vision_config_kind` migration shipped exactly this class
+ * of gap (an uncategorized `personality_vision_default_configs` table + two new
+ * `*_vision_config_id` UUID FKs); this guard would have caught it at build time.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { PrismaClient } from '@tzurot/common-types';
+import type { PGlite } from '@electric-sql/pglite';
+import { PrismaPGlite } from 'pglite-prisma-adapter';
+import { createTestPGlite, setupTestEnvironment, loadPGliteSchema } from '@tzurot/test-utils';
+import { validateSyncConfig } from './syncValidation.js';
+import { SYNC_CONFIG } from '../config/syncTables.js';
+
+describe('syncValidation guard — SYNC_CONFIG covers the live schema', () => {
+  let pglite: PGlite;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    setupTestEnvironment();
+    pglite = createTestPGlite();
+    await pglite.exec(loadPGliteSchema());
+    prisma = new PrismaClient({ adapter: new PrismaPGlite(pglite) }) as PrismaClient;
+  }, 30000);
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+    await pglite.close();
+  });
+
+  it('produces no warnings — every table is categorized and every UUID FK is in uuidColumns', async () => {
+    const { warnings } = await validateSyncConfig(prisma, SYNC_CONFIG);
+    // A failure here means a migration added a table or UUID FK column that
+    // syncTables.ts doesn't account for. Fix: categorize the table in SYNC_CONFIG or
+    // EXCLUDED_TABLES, or add the UUID FK column to that table's `uuidColumns`.
+    expect(
+      warnings,
+      `syncTables.ts is out of sync with the schema:\n  ${warnings.join('\n  ')}`
+    ).toEqual([]);
+  });
+});

--- a/services/api-gateway/src/services/sync/utils/syncValidation.component.test.ts
+++ b/services/api-gateway/src/services/sync/utils/syncValidation.component.test.ts
@@ -6,16 +6,14 @@
  * only surfaces when someone actually runs `/admin db-sync` — into a BUILD-TIME failure.
  * A migration that adds a table or a UUID FK column without updating `syncTables.ts`
  * (SYNC_CONFIG / EXCLUDED_TABLES / uuidColumns) now fails CI instead of silently
- * warning later. The beta.140 `vision_config_kind` migration shipped exactly this class
- * of gap (an uncategorized `personality_vision_default_configs` table + two new
- * `*_vision_config_id` UUID FKs); this guard would have caught it at build time.
+ * warning later.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { PrismaClient } from '@tzurot/common-types';
 import type { PGlite } from '@electric-sql/pglite';
 import { PrismaPGlite } from 'pglite-prisma-adapter';
-import { createTestPGlite, setupTestEnvironment, loadPGliteSchema } from '@tzurot/test-utils';
+import { createTestPGlite, loadPGliteSchema } from '@tzurot/test-utils';
 import { validateSyncConfig } from './syncValidation.js';
 import { SYNC_CONFIG } from '../config/syncTables.js';
 
@@ -23,8 +21,9 @@ describe('syncValidation guard — SYNC_CONFIG covers the live schema', () => {
   let pglite: PGlite;
   let prisma: PrismaClient;
 
+  // No setupTestEnvironment(): validateSyncConfig only queries
+  // information_schema over PGLite — it has zero Redis/env dependency.
   beforeAll(async () => {
-    setupTestEnvironment();
     pglite = createTestPGlite();
     await pglite.exec(loadPGliteSchema());
     prisma = new PrismaClient({ adapter: new PrismaPGlite(pglite) }) as PrismaClient;
@@ -36,7 +35,7 @@ describe('syncValidation guard — SYNC_CONFIG covers the live schema', () => {
   });
 
   it('produces no warnings — every table is categorized and every UUID FK is in uuidColumns', async () => {
-    const { warnings } = await validateSyncConfig(prisma, SYNC_CONFIG);
+    const { warnings, info } = await validateSyncConfig(prisma, SYNC_CONFIG);
     // A failure here means a migration added a table or UUID FK column that
     // syncTables.ts doesn't account for. Fix: categorize the table in SYNC_CONFIG or
     // EXCLUDED_TABLES, or add the UUID FK column to that table's `uuidColumns`.
@@ -44,5 +43,10 @@ describe('syncValidation guard — SYNC_CONFIG covers the live schema', () => {
       warnings,
       `syncTables.ts is out of sync with the schema:\n  ${warnings.join('\n  ')}`
     ).toEqual([]);
+    // `info` carries one line per EXCLUDED_TABLES entry that still exists in the
+    // schema. A non-empty array confirms the exclusion list matches real tables —
+    // a phantom entry (table dropped from the schema but left in EXCLUDED_TABLES)
+    // produces neither a warning nor an info line, so this guards that drift too.
+    expect(info.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## What

The beta.140 `vision_config_kind` migration added a table and two UUID FK columns that `syncTables.ts` didn't account for. As a result `/admin db-sync` logs three non-fatal `validateSyncConfig` warnings:

- `personality_vision_default_configs` — uncategorized table
- `users.default_vision_config_id` — uncategorized UUID FK
- `user_personality_configs.vision_config_id` — uncategorized UUID FK

This PR:

1. **Closes the config gaps** — categorizes `personality_vision_default_configs` in `EXCLUDED_TABLES` (character-level vision presets, mirroring the LLM/TTS preset-default tables) and registers the two UUID FK columns in their tables' `uuidColumns`.
2. **Adds a deterministic build-time guard** — `syncValidation.component.test.ts` runs `validateSyncConfig` against the live PGLite schema and asserts **zero** warnings. This turns the runtime db-sync warning into a CI failure: a future migration that adds an uncategorized table or UUID FK now fails the build instead of silently warning during db-sync. The vision migration itself would have tripped this guard.

## Why

db-sync still *works* with the warnings (they're non-fatal and the affected tables are excluded/handled), but the warnings are noise and — more importantly — the *next* schema change of this shape would silently reintroduce a real gap. The guard makes the class of oversight (migration adds table/FK, syncTables.ts not updated) impossible to ship silently.

## Testing

- `syncValidation.component.test.ts` — passes (zero warnings against the live schema, proving the config is now complete and no pre-existing gaps exist).
- `pnpm --filter @tzurot/api-gateway test` — 2162 unit tests green.
- `pnpm quality` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)