### PR TITLE
fix(bot-client): weigh-in anchors on synthetic message, not the latest channel message

### DIFF
--- a/services/bot-client/src/commands/character/chat.test.ts
+++ b/services/bot-client/src/commands/character/chat.test.ts
@@ -17,7 +17,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { handleChat, handleRandom, handleChimeIn } from './chat.js';
+import { handleChat, handleRandom, handleChimeIn, WEIGH_IN_MESSAGE } from './chat.js';
 import type { GuildMember } from 'discord.js';
 import { ChannelType } from 'discord.js';
 import type { EnvConfig } from '@tzurot/common-types';
@@ -135,6 +135,9 @@ describe('Character Chat Handler (push delivery)', () => {
       type,
       id: 'channel-123',
       name: 'test-channel',
+      // Real guild channels carry a `guild` (the synthetic anchor reads
+      // channel.guild.id for its guildId, used by denylist scoping).
+      guild: { id: 'guild-123', name: 'Test Guild' },
       // Real Discord channels always carry a back-reference to the client; the
       // empty-channel synthetic anchor reads `channel.client.user` via it.
       client: { user: { id: 'bot-user-123' } },
@@ -463,11 +466,16 @@ describe('Character Chat Handler (push delivery)', () => {
       const anchorArg = mockMessageContextBuilder.buildContext.mock.calls[0][0] as {
         id: string;
         content: string;
+        guildId: string | null;
+        channelId: string;
       };
       expect(anchorArg.id).toBe('synthetic-weigh-in-anchor');
-      expect(anchorArg.id).not.toBe('latest-msg');
       // The current turn is the read-the-room instruction, not a real message.
-      expect(anchorArg.content).toBe('[Reply naturally to the context above]');
+      expect(anchorArg.content).toBe(WEIGH_IN_MESSAGE);
+      // guildId/channelId must be populated (they're Discord.js getters, absent on
+      // the plain synthetic) so denylist scoping still works in weigh-in.
+      expect(anchorArg.guildId).toBe('guild-123');
+      expect(anchorArg.channelId).toBe('channel-123');
       // getAnchorMessage no longer reaches for the latest channel message at all.
       expect(channel.messages.fetch).not.toHaveBeenCalled();
     });

--- a/services/bot-client/src/commands/character/chat.test.ts
+++ b/services/bot-client/src/commands/character/chat.test.ts
@@ -421,9 +421,9 @@ describe('Character Chat Handler (push delivery)', () => {
     });
 
     it('weigh-in in a genuinely empty channel still submits (synthetic anchor, no error)', async () => {
-      // A channel with zero messages no longer aborts: getAnchorMessage falls
-      // back to a field-only synthetic anchor so the bot "reads an empty room"
-      // and generates rather than erroring out.
+      // Weigh-in always anchors on a field-only synthetic message regardless of
+      // channel contents, so an empty channel still submits — the bot "reads an
+      // empty room" and generates rather than erroring out.
       const channel = createMockChannel(ChannelType.GuildText);
       channel.messages.fetch = vi.fn().mockResolvedValue(createMockCollection([]));
       const ctx = createMockContext('test-char', null, channel);
@@ -440,6 +440,36 @@ describe('Character Chat Handler (push delivery)', () => {
         expect.any(String),
         expect.objectContaining({ kind: 'slash', isWeighInMode: true })
       );
+    });
+
+    it('anchors on a synthetic message — never the latest channel message (regression)', async () => {
+      // Regression: weigh-in (no message) used to anchor on the latest channel
+      // message, so the thin-envelope assembler re-derived the current turn from
+      // that message's content + voice transcript — feeding a DIFFERENT
+      // character's reply (and a TTS round-trip of it) back as the "user" turn.
+      // The fix anchors on a synthetic, content-only message; the latest message
+      // reaches the prompt as history instead. createMockChannel's default fetch
+      // returns a 'latest-msg' — the old code would have used it as the anchor;
+      // the fix must not touch it.
+      const channel = createMockChannel(ChannelType.GuildText);
+      const ctx = createMockContext('test-char', null, channel);
+      mockPersonalityService.loadPersonality.mockResolvedValue(createMockPersonality());
+      mockMessageContextBuilder.buildContext.mockResolvedValueOnce(createMockContextBuildResult());
+      mockGatewayClient.generate.mockResolvedValue({ jobId: 'job-1', requestId: 'req-1' });
+
+      await handleChimeIn(ctx, mockConfig);
+
+      expect(mockMessageContextBuilder.buildContext).toHaveBeenCalledTimes(1);
+      const anchorArg = mockMessageContextBuilder.buildContext.mock.calls[0][0] as {
+        id: string;
+        content: string;
+      };
+      expect(anchorArg.id).toBe('synthetic-weigh-in-anchor');
+      expect(anchorArg.id).not.toBe('latest-msg');
+      // The current turn is the read-the-room instruction, not a real message.
+      expect(anchorArg.content).toBe('[Reply naturally to the context above]');
+      // getAnchorMessage no longer reaches for the latest channel message at all.
+      expect(channel.messages.fetch).not.toHaveBeenCalled();
     });
   });
 

--- a/services/bot-client/src/commands/character/chat.ts
+++ b/services/bot-client/src/commands/character/chat.ts
@@ -66,8 +66,12 @@ function validateChannel(context: DeferredCommandContext): TypingChannel | null 
  * Weigh-in mode indicator message
  * Minimal prompt that tells the AI to respond to conversation context
  * without meta-awareness of being explicitly invoked.
+ *
+ * Exported so the synthetic-anchor test can assert against it rather than a
+ * fragile string literal (a wording change then surfaces at the import, not as
+ * a confusing value mismatch).
  */
-const WEIGH_IN_MESSAGE = '[Reply naturally to the context above]';
+export const WEIGH_IN_MESSAGE = '[Reply naturally to the context above]';
 
 /**
  * Result of getting the anchor message for context building
@@ -145,6 +149,12 @@ function createSyntheticWeighInAnchor(channel: TypingChannel): Message {
     channel,
     client: channel.client,
     guild: 'guild' in channel ? channel.guild : null,
+    // guildId/channelId are Discord.js prototype getters — absent on this plain
+    // object — but buildBlockDeniedChecker (via MessageContextBuilder) reads them
+    // to scope denylist lookups. Without them, guild- and channel-scoped blocks
+    // would silently no-op on every weigh-in; populate them from the channel.
+    guildId: 'guild' in channel ? channel.guild.id : null,
+    channelId: channel.id,
     // May be null pre-login, but that's safe: the weigh-in call passes
     // `overrideUser`, so MessageContextBuilder resolves the user identity from
     // that — never from this anchor's `author`.

--- a/services/bot-client/src/commands/character/chat.ts
+++ b/services/bot-client/src/commands/character/chat.ts
@@ -91,7 +91,7 @@ type GetAnchorMessageResult = AnchorMessageResult | AnchorMessageError;
 /**
  * Get an anchor message for context building.
  * Chat mode: send user message and return it.
- * Weigh-in mode: a synthetic, content-less anchor (see below).
+ * Weigh-in mode: a synthetic anchor carrying WEIGH_IN_MESSAGE (see below).
  */
 async function getAnchorMessage(
   channel: TypingChannel,

--- a/services/bot-client/src/commands/character/chat.ts
+++ b/services/bot-client/src/commands/character/chat.ts
@@ -87,7 +87,7 @@ type GetAnchorMessageResult = AnchorMessageResult | AnchorMessageError;
 /**
  * Get an anchor message for context building.
  * Chat mode: send user message and return it.
- * Weigh-in mode: fetch the latest message in channel.
+ * Weigh-in mode: a synthetic, content-less anchor (see below).
  */
 async function getAnchorMessage(
   channel: TypingChannel,
@@ -99,33 +99,42 @@ async function getAnchorMessage(
     return { success: true, message };
   }
 
-  // Weigh-in mode: anchor on the latest channel message. The anchor only
-  // supplies the channel/client/guild and (for chat mode) the `before` cursor;
-  // in weigh-in the extended-context fetch omits `before`, so the anchor's id
-  // is unused and the latest message is READ (it's part of the room).
-  const recentMessages = await channel.messages.fetch({ limit: 1 });
-  const latestMessage = recentMessages.first();
-  if (latestMessage !== undefined) {
-    return { success: true, message: latestMessage };
-  }
-  // Genuinely empty channel: no message to anchor on. Weigh-in still "just
-  // works" — the worker reads an empty room and greets. buildContext reads only
-  // FIELDS off the anchor (never methods — locked by tests), so a field-only
-  // synthetic anchor built from the channel is safe here.
+  // Weigh-in mode: the current turn carries NO real user message — the
+  // personality is asked to read the room and respond. Anchor on a synthetic,
+  // content-less message carrying only WEIGH_IN_MESSAGE.
+  //
+  // We must NOT anchor on the real latest channel message: the thin-envelope
+  // assembler re-derives the current turn from anchor.content + the anchor's
+  // voice transcript (RawEnvelopeBuilder's rawMessageContent / rawRoutingTranscript),
+  // so a real anchor leaks the latest message's text AND transcribes its voice
+  // attachment into the current turn — even when that message is from a
+  // different character. The latest message still reaches the prompt as
+  // HISTORY: the extended-context fetch omits `before` in weigh-in
+  // (MessageContextBuilder), so it includes the most recent N messages (the
+  // anchor's id is unused) where voice transcripts get the proper
+  // <voice_transcripts> wrapper.
   return { success: true, message: createSyntheticWeighInAnchor(channel) };
 }
 
 /**
- * Build a field-only synthetic `Message` for a weigh-in in an empty channel.
+ * Build a field-only synthetic `Message` — the anchor for EVERY weigh-in turn,
+ * not just empty channels.
+ *
+ * The anchor's `content` is WEIGH_IN_MESSAGE: the thin-envelope assembler
+ * re-derives the current turn from anchor.content, so this is what becomes the
+ * "read the room" user turn. We deliberately do NOT anchor on the real latest
+ * channel message — that would leak its text + voice transcript into the current
+ * turn (see getAnchorMessage). The real recent messages arrive as HISTORY via
+ * the extended-context fetch instead.
  *
  * buildContext only READS from the anchor — it never mutates it or calls Discord
  * API methods (no `.fetch`/`.reply`/`.react`). It DOES call Collection accessors
  * (`.some`/`.size`/`.values`) on the field VALUES (`attachments`, `mentions.users`),
  * so those carry real `Collection`s, not bare objects. For weigh-in the author/
- * member are overridden and the id is unused, so an empty channel needs nothing
- * real beyond the channel handle. MessageContextBuilder's field-only-anchor test
- * runs buildContext through this exact shape — if a field this synthetic omits
- * starts being read (as `mentions` once was), that test fails loudly rather than
+ * member are overridden and the id is unused, so nothing real beyond the channel
+ * handle is needed. MessageContextBuilder's field-only-anchor test runs
+ * buildContext through this exact shape — if a field this synthetic omits starts
+ * being read (as `mentions` once was), that test fails loudly rather than
  * crashing at runtime.
  */
 function createSyntheticWeighInAnchor(channel: TypingChannel): Message {
@@ -141,13 +150,15 @@ function createSyntheticWeighInAnchor(channel: TypingChannel): Message {
     // that — never from this anchor's `author`.
     author: channel.client?.user ?? null,
     member: null,
-    content: '',
+    // The read-the-room instruction IS the weigh-in current turn — the worker
+    // builds the turn from anchor.content. No real channel message is used.
+    content: WEIGH_IN_MESSAGE,
     attachments: new Collection(),
     embeds: [],
     messageSnapshots: new Collection(),
     reference: null,
-    // RawEnvelopeBuilder reads `mentions.users` (.size / .values()); an empty
-    // channel has no mentions, but the field must exist or the read throws.
+    // RawEnvelopeBuilder reads `mentions.users` (.size / .values()); the
+    // synthetic anchor has no mentions, but the field must exist or the read throws.
     mentions: { users: new Collection() },
   } as unknown as Message;
 }


### PR DESCRIPTION
## The bug (prod)

`/character random` with **no message** (and `/character chime-in`) is weigh-in mode — the personality should *read the room* and respond. But the code anchored on the **latest channel message**, and the thin-envelope assembler re-derives the current turn from `anchor.content` + the anchor's voice transcript (`RawEnvelopeBuilder`'s `rawMessageContent` / `rawRoutingTranscript`). So the latest message's text **and a transcription of its voice attachment** leaked into the current user turn — even when that message was from a *different character*.

Observed in prod: a `/character random` invocation fed a different character's reply (plus a TTS→STT round-trip of it) back to the picked character as the "user" message.

## Root cause

A regression from the thin-envelope refactor. `getAnchorMessage`'s weigh-in branch returned the real latest channel message; that anchor's content became the current turn. The `WEIGH_IN_MESSAGE` (`[Reply naturally to the context above]`) that `chat.ts` passes was effectively dead because the worker derives the turn from `rawMessageContent` (= anchor content), not `context.messageContent`.

## The fix

Weigh-in now anchors on the **synthetic, content-only** message (`createSyntheticWeighInAnchor`), carrying `WEIGH_IN_MESSAGE` as its content:

- No real channel message is used as the current turn → no text/voice leak.
- The latest channel message still reaches the prompt **as history** via the extended-context fetch (which omits `before` in weigh-in), where voice transcripts get the proper `<voice_transcripts>` wrapper.
- Drops the now-unnecessary `channel.messages.fetch({ limit: 1 })`.

Fixes both `/character random` (no message) and `/character chime-in`.

## Testing

- New regression test: weigh-in anchors on the synthetic message (`id === 'synthetic-weigh-in-anchor'`, content === the read-the-room instruction), never the latest channel message, and `channel.messages.fetch` is not called.
- `pnpm --filter @tzurot/bot-client test` — 5118 tests green.
- `pnpm quality` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)