### PR TITLE
fix(voice-engine): _merge_overlap matches on content tokens, not empty punctuation

### DIFF
--- a/services/voice-engine/server.py
+++ b/services/voice-engine/server.py
@@ -459,13 +459,31 @@ def _merge_overlap(left: str, right: str, max_words: int = STT_OVERLAP_DEDUP_MAX
         return left
     left_norm = [_normalize_token(w) for w in left_words]
     right_norm = [_normalize_token(w) for w in right_words]
-    overlap = 0
-    max_k = min(max_words, len(left_words), len(right_words))
+    # Match on CONTENT tokens only. A purely-punctuation token normalizes to ""
+    # (e.g. ".", "--", "?"); leaving empties in the comparison breaks it two ways:
+    #   - two empties compare equal → a false overlap anchored on non-content, which
+    #     silently drops a real word at the seam; and
+    #   - an empty inside a genuine overlap blocks the match → the whole overlap
+    #     region is duplicated.
+    # So we compare the non-empty subsequences and map the matched length back to
+    # ORIGINAL right-token positions for the drop (carrying along any punctuation
+    # interspersed within the matched overlap).
+    left_real = [t for t in left_norm if t]
+    right_real_idx = [i for i, t in enumerate(right_norm) if t]
+    right_real = [right_norm[i] for i in right_real_idx]
+    overlap_words = 0
+    max_k = min(max_words, len(left_real), len(right_real))
     for k in range(max_k, 0, -1):
-        if left_norm[-k:] == right_norm[:k]:
-            overlap = k
+        if left_real[-k:] == right_real[:k]:
+            overlap_words = k
             break
-    surviving = right_words[overlap:]
+    if overlap_words == 0:
+        surviving = right_words
+    else:
+        # Drop original right tokens up to and including the last matched content
+        # token (so leading + interspersed punctuation in the overlap goes too).
+        drop_until = right_real_idx[overlap_words - 1] + 1
+        surviving = right_words[drop_until:]
     if not surviving:
         return left
     return f"{left} {' '.join(surviving)}"

--- a/services/voice-engine/tests/test_transcribe.py
+++ b/services/voice-engine/tests/test_transcribe.py
@@ -304,6 +304,32 @@ def test_merge_overlap_fully_duplicate_right() -> None:
     assert server._merge_overlap("one two three", "two three") == "one two three"
 
 
+def test_merge_overlap_standalone_punct_no_false_drop() -> None:
+    # Standalone punctuation tokens normalize to "" and must NOT anchor an overlap.
+    # No real words are shared here, so nothing is dropped (both dots survive).
+    assert (
+        server._merge_overlap("first window ends here .", ". second window begins")
+        == "first window ends here . . second window begins"
+    )
+
+
+def test_merge_overlap_standalone_punct_keeps_right_word() -> None:
+    # The empty-token false match used to drop right's leading "!"; it must survive.
+    assert server._merge_overlap("we paused ?", "! brand new sentence") == "we paused ? ! brand new sentence"
+
+
+def test_merge_overlap_dedups_through_leading_punct() -> None:
+    # Real overlap is "sure"; right's leading "--" must not block the dedup, and the
+    # "--" is dropped along with the duplicated "sure" (no "sure -- sure").
+    assert server._merge_overlap("i think -- sure", "-- sure thing buddy") == "i think -- sure thing buddy"
+
+
+def test_merge_overlap_dedups_multiword_overlap_with_interspersed_punct() -> None:
+    # Overlap is "foo . bar" with punctuation INSIDE it. The match is on the content
+    # tokens (foo, bar); the whole overlap region — punctuation included — is dropped.
+    assert server._merge_overlap("alpha foo . bar", "foo . bar gamma") == "alpha foo . bar gamma"
+
+
 def test_join_chunk_texts_skips_empty_windows() -> None:
     assert server._join_chunk_texts(["hello", "", "   ", "world"]) == "hello world"
 


### PR DESCRIPTION
## What

Chunked long-audio transcription (beta.139) merges overlapping windows by detecting the shared word run at the seam (`_merge_overlap`). `_normalize_token` maps a punctuation-only token (`.`, `--`, `?`) to `""`, and the overlap match compared the normalized token lists directly — so an empty token at a window seam:

- **anchored a false overlap** on non-content → silently dropped a real word, or
- when punctuation sat **inside** a genuine overlap, **blocked** the match → duplicated the whole overlap region.

This was beta.140 release-review finding #1.

## Fix

Match on the **non-empty (content) subsequences**, then map the matched length back to original right-token positions for the drop — so punctuation interspersed within the overlap is carried along (dropped with its overlap), not left to block or false-anchor the match.

> Note: I went with the content-subsequence approach rather than the simpler "skip any compared slice containing an empty token" guard, because the simple guard *regresses* — when punctuation sits inside a real overlap region (common in long audio), it skips every `k` that includes the punct position and **duplicates the whole ~2s overlap**. The content-subsequence match handles that case correctly (covered by the last test below).

## Tests

`tests/test_transcribe.py`, 4 new pure-function tests:
- standalone punctuation seam → no false drop (both dots survive)
- leading punctuation on `right` → kept
- dedup through a leading punct token (no `sure -- sure` duplication)
- multi-word overlap with interspersed punctuation → whole overlap dropped, content deduped

Local: 10/10 merge/join tests pass; `ruff` + `mypy --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)