### PR TITLE
fix(api-gateway): 404 for config-not-found race + phantom EXCLUDED_TABLES detection

### DIFF
--- a/services/api-gateway/src/services/LlmConfigService.test.ts
+++ b/services/api-gateway/src/services/LlmConfigService.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NotFoundError } from '../utils/appErrors.js';
 import {
   LlmConfigService,
   AutoSuffixCollisionError,
@@ -573,12 +574,15 @@ describe('LlmConfigService', () => {
       expect(cacheService.invalidateAll).toHaveBeenCalled();
     });
 
-    it('throws when the config no longer exists (delete-between-fetch-and-set race)', async () => {
+    it('throws NotFoundError when the config no longer exists (delete-between-fetch-and-set race)', async () => {
       prisma.llmConfig.findUnique.mockResolvedValue(null);
 
-      await expect(service.setAsDefault('nonexistent-id')).rejects.toThrow(
-        'setAsDefault: config nonexistent-id not found'
-      );
+      const error = await service.setAsDefault('nonexistent-id').catch((e: unknown) => e);
+      // Typed NotFoundError (not a plain Error) so asyncHandler maps it to a 404
+      // with a clean body; the message keeps the op + id for logs.
+      expect(error).toBeInstanceOf(NotFoundError);
+      expect((error as NotFoundError).resource).toBe('LLM config');
+      expect((error as Error).message).toBe('setAsDefault: config nonexistent-id not found');
       // A vanished config must never drive the clear+set transaction — an
       // unscoped clear there would wipe a still-valid kind's default.
       expect(prisma.$transaction).not.toHaveBeenCalled();
@@ -597,12 +601,13 @@ describe('LlmConfigService', () => {
       expect(cacheService.invalidateAll).toHaveBeenCalled();
     });
 
-    it('throws when the config no longer exists (delete-between-fetch-and-set race)', async () => {
+    it('throws NotFoundError when the config no longer exists (delete-between-fetch-and-set race)', async () => {
       prisma.llmConfig.findUnique.mockResolvedValue(null);
 
-      await expect(service.setAsFreeDefault('nonexistent-id')).rejects.toThrow(
-        'setAsFreeDefault: config nonexistent-id not found'
-      );
+      const error = await service.setAsFreeDefault('nonexistent-id').catch((e: unknown) => e);
+      expect(error).toBeInstanceOf(NotFoundError);
+      expect((error as NotFoundError).resource).toBe('LLM config');
+      expect((error as Error).message).toBe('setAsFreeDefault: config nonexistent-id not found');
       expect(prisma.$transaction).not.toHaveBeenCalled();
     });
   });

--- a/services/api-gateway/src/services/LlmConfigService.ts
+++ b/services/api-gateway/src/services/LlmConfigService.ts
@@ -31,6 +31,7 @@ import { type LlmConfigCacheInvalidationService } from '@tzurot/cache-invalidati
 
 import { isPrismaUniqueConstraintErrorOn } from '../utils/prismaErrors.js';
 import { CloneNameExhaustedError, AutoSuffixCollisionError } from './LlmConfigErrors.js';
+import { NotFoundError } from '../utils/appErrors.js';
 
 // Re-exported so route/test importers keep a stable `from './LlmConfigService.js'`
 // path (mirrors TtsConfigService's re-export of its error classes).
@@ -474,7 +475,10 @@ export class LlmConfigService {
       select: { kind: true },
     });
     if (target === null) {
-      throw new Error(`${op}: config ${configId} not found`);
+      // NotFoundError (not a plain Error): asyncHandler maps it to a 404 with a
+      // clean "LLM config not found" body instead of a 500 leaking the internal op
+      // string. The richer message keeps the op + id for server-side logs.
+      throw new NotFoundError('LLM config', `${op}: config ${configId} not found`);
     }
     return toConfigKind(target.kind);
   }

--- a/services/api-gateway/src/services/TtsConfigService.test.ts
+++ b/services/api-gateway/src/services/TtsConfigService.test.ts
@@ -19,6 +19,7 @@ import {
 } from './TtsConfigService.js';
 import type { PrismaClient } from '@tzurot/common-types';
 import type { TtsConfigCacheInvalidationService } from '@tzurot/cache-invalidation';
+import { NotFoundError } from '../utils/appErrors.js';
 
 // Mock logger to keep test output clean
 vi.mock('@tzurot/common-types', async () => {
@@ -466,6 +467,8 @@ describe('TtsConfigService', () => {
 
   describe('setAsDefault', () => {
     it('clears existing default in a transaction and sets the new one', async () => {
+      vi.mocked(prisma.ttsConfig.findUnique).mockResolvedValue(sampleConfig);
+
       await service.setAsDefault('cfg-uuid-1');
 
       expect(prisma.$transaction).toHaveBeenCalled();
@@ -479,10 +482,22 @@ describe('TtsConfigService', () => {
         data: { isDefault: true },
       });
     });
+
+    it('throws NotFoundError when the config no longer exists (delete-between-reads race)', async () => {
+      vi.mocked(prisma.ttsConfig.findUnique).mockResolvedValue(null);
+
+      const error = await service.setAsDefault('gone').catch((e: unknown) => e);
+      expect(error).toBeInstanceOf(NotFoundError);
+      expect((error as NotFoundError).resource).toBe('TTS config');
+      // A vanished config must never enter the clear+set transaction.
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
   });
 
   describe('setAsFreeDefault', () => {
     it('clears existing free-default and sets the new one', async () => {
+      vi.mocked(prisma.ttsConfig.findUnique).mockResolvedValue(sampleConfig);
+
       await service.setAsFreeDefault('cfg-uuid-1');
       expect(prisma.ttsConfig.updateMany).toHaveBeenCalledWith({
         where: { isFreeDefault: true },
@@ -492,6 +507,15 @@ describe('TtsConfigService', () => {
         where: { id: 'cfg-uuid-1' },
         data: { isFreeDefault: true },
       });
+    });
+
+    it('throws NotFoundError when the config no longer exists (delete-between-reads race)', async () => {
+      vi.mocked(prisma.ttsConfig.findUnique).mockResolvedValue(null);
+
+      const error = await service.setAsFreeDefault('gone').catch((e: unknown) => e);
+      expect(error).toBeInstanceOf(NotFoundError);
+      expect((error as NotFoundError).resource).toBe('TTS config');
+      expect(prisma.$transaction).not.toHaveBeenCalled();
     });
   });
 

--- a/services/api-gateway/src/services/TtsConfigService.ts
+++ b/services/api-gateway/src/services/TtsConfigService.ts
@@ -48,6 +48,7 @@ import {
   TtsAutoSuffixCollisionError,
   TtsInvalidProviderError,
 } from './TtsConfigErrors.js';
+import { NotFoundError } from '../utils/appErrors.js';
 
 const logger = createLogger('TtsConfigService');
 
@@ -374,8 +375,27 @@ export class TtsConfigService {
   // Admin-only Operations
   // --------------------------------------------------------------------------
 
+  /**
+   * Assert the config exists before a clear+set transaction. Routes guard with a
+   * fetch-or-404 helper first, so a null here is a delete-between-reads race —
+   * throw NotFoundError (→ 404 via asyncHandler) rather than letting the
+   * transaction's `update` raise a Prisma P2025 that surfaces as a 500 leaking
+   * the raw error. (Mirrors LlmConfigService.resolveTargetKindOrThrow, minus the
+   * kind — TTS configs have no kind discriminator.)
+   */
+  private async assertConfigExistsOrThrow(configId: string, op: string): Promise<void> {
+    const target = await this.prisma.ttsConfig.findUnique({
+      where: { id: configId },
+      select: { id: true },
+    });
+    if (target === null) {
+      throw new NotFoundError('TTS config', `${op}: config ${configId} not found`);
+    }
+  }
+
   /** Set a config as the system default. Clears any existing default first. */
   async setAsDefault(configId: string): Promise<void> {
+    await this.assertConfigExistsOrThrow(configId, 'setAsDefault');
     await this.prisma.$transaction(async tx => {
       await tx.ttsConfig.updateMany({
         where: { isDefault: true },
@@ -392,6 +412,7 @@ export class TtsConfigService {
 
   /** Set a config as the free tier default. Clears any existing free default first. */
   async setAsFreeDefault(configId: string): Promise<void> {
+    await this.assertConfigExistsOrThrow(configId, 'setAsFreeDefault');
     await this.prisma.$transaction(async tx => {
       await tx.ttsConfig.updateMany({
         where: { isFreeDefault: true },

--- a/services/api-gateway/src/services/sync/config/syncTables.ts
+++ b/services/api-gateway/src/services/sync/config/syncTables.ts
@@ -29,7 +29,6 @@ export const EXCLUDED_TABLES: Record<string, string> = {
 
   // Transient/ephemeral data
   pending_memories: 'Transient queue data for memory processing',
-  image_description_cache: 'Cache data that can be regenerated',
   llm_diagnostic_logs: 'Ephemeral debug logs (auto-deleted after 24h)',
   usage_logs: 'Environment-specific usage tracking',
   import_jobs: 'Transient import job tracking (environment-specific, retryable)',

--- a/services/api-gateway/src/services/sync/utils/syncValidation.component.test.ts
+++ b/services/api-gateway/src/services/sync/utils/syncValidation.component.test.ts
@@ -37,16 +37,18 @@ describe('syncValidation guard — SYNC_CONFIG covers the live schema', () => {
   it('produces no warnings — every table is categorized and every UUID FK is in uuidColumns', async () => {
     const { warnings, info } = await validateSyncConfig(prisma, SYNC_CONFIG);
     // A failure here means a migration added a table or UUID FK column that
-    // syncTables.ts doesn't account for. Fix: categorize the table in SYNC_CONFIG or
-    // EXCLUDED_TABLES, or add the UUID FK column to that table's `uuidColumns`.
+    // syncTables.ts doesn't account for — OR left a phantom EXCLUDED_TABLES entry
+    // (a table dropped from the schema but not from the exclusion list), which
+    // validateSyncConfig now reports as a warning. Fix: categorize the table in
+    // SYNC_CONFIG or EXCLUDED_TABLES, add the UUID FK column to `uuidColumns`, or
+    // remove the stale exclusion.
     expect(
       warnings,
       `syncTables.ts is out of sync with the schema:\n  ${warnings.join('\n  ')}`
     ).toEqual([]);
     // `info` carries one line per EXCLUDED_TABLES entry that still exists in the
-    // schema. A non-empty array confirms the exclusion list matches real tables —
-    // a phantom entry (table dropped from the schema but left in EXCLUDED_TABLES)
-    // produces neither a warning nor an info line, so this guards that drift too.
+    // schema. A non-empty array confirms the exclusion list isn't ENTIRELY phantom;
+    // individual phantom entries are caught by the zero-warnings assertion above.
     expect(info.length).toBeGreaterThan(0);
   });
 });

--- a/services/api-gateway/src/services/sync/utils/syncValidation.ts
+++ b/services/api-gateway/src/services/sync/utils/syncValidation.ts
@@ -94,9 +94,7 @@ export async function validateSyncConfig(
     const actualColumns = schemaMap.get(tableName);
 
     if (!actualColumns) {
-      warnings.push(
-        `⚠️  SYNC_CONFIG has table '${tableName}' but it doesn't exist in database schema`
-      );
+      warnings.push(`SYNC_CONFIG has table '${tableName}' but it doesn't exist in database schema`);
       continue;
     }
 
@@ -105,7 +103,7 @@ export async function validateSyncConfig(
     for (const actualColumn of actualColumns) {
       if (!configColumns.includes(actualColumn)) {
         warnings.push(
-          `⚠️  Table '${tableName}' has UUID column '${actualColumn}' in schema but not in SYNC_CONFIG.uuidColumns`
+          `Table '${tableName}' has UUID column '${actualColumn}' in schema but not in SYNC_CONFIG.uuidColumns`
         );
       }
     }
@@ -114,7 +112,7 @@ export async function validateSyncConfig(
     for (const configColumn of config.uuidColumns) {
       if (!actualColumns.has(configColumn)) {
         warnings.push(
-          `⚠️  Table '${tableName}' has '${configColumn}' in SYNC_CONFIG.uuidColumns but it's not a UUID column in schema (or doesn't exist)`
+          `Table '${tableName}' has '${configColumn}' in SYNC_CONFIG.uuidColumns but it's not a UUID column in schema (or doesn't exist)`
         );
       }
     }
@@ -132,10 +130,10 @@ export async function validateSyncConfig(
       // Check if it's an explicitly excluded table
       const exclusionReason = EXCLUDED_TABLES[tableName];
       if (exclusionReason !== undefined) {
-        info.push(`ℹ️  Table '${tableName}' excluded: ${exclusionReason}`);
+        info.push(`Table '${tableName}' excluded: ${exclusionReason}`);
       } else {
         warnings.push(
-          `⚠️  Table '${tableName}' exists in database but is not in SYNC_CONFIG or EXCLUDED_TABLES`
+          `Table '${tableName}' exists in database but is not in SYNC_CONFIG or EXCLUDED_TABLES`
         );
       }
     }
@@ -155,10 +153,14 @@ export async function validateSyncConfig(
   `;
   const schemaTableNames = new Set(allTables.map(r => r.table_name));
   for (const tableName of Object.keys(EXCLUDED_TABLES)) {
+    // Skip Prisma internal tables, mirroring the uncategorized-table loop above —
+    // they're never synced, so an `_prisma_*` exclusion (were one ever added) is a
+    // no-op, not a phantom to flag.
+    if (tableName.startsWith('_prisma')) {
+      continue;
+    }
     if (!schemaTableNames.has(tableName)) {
-      warnings.push(
-        `⚠️  Table '${tableName}' is in EXCLUDED_TABLES but doesn't exist in the schema`
-      );
+      warnings.push(`Table '${tableName}' is in EXCLUDED_TABLES but doesn't exist in the schema`);
     }
   }
 

--- a/services/api-gateway/src/services/sync/utils/syncValidation.ts
+++ b/services/api-gateway/src/services/sync/utils/syncValidation.ts
@@ -141,6 +141,27 @@ export async function validateSyncConfig(
     }
   }
 
+  // Phantom EXCLUDED_TABLES: an entry whose table no longer exists in the schema.
+  // It produces neither a warning (the exclusion suppresses the uncategorized-table
+  // check above) nor an info line (info only fires for excluded tables that DO exist),
+  // so a stale exclusion rots silently. Detect it against the FULL table list — not the
+  // UUID-only schemaMap, which would false-flag a real excluded table that happens to
+  // have no UUID column.
+  const allTables = await devClient.$queryRaw<{ table_name: string }[]>`
+    SELECT table_name
+    FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_type = 'BASE TABLE'
+  `;
+  const schemaTableNames = new Set(allTables.map(r => r.table_name));
+  for (const tableName of Object.keys(EXCLUDED_TABLES)) {
+    if (!schemaTableNames.has(tableName)) {
+      warnings.push(
+        `⚠️  Table '${tableName}' is in EXCLUDED_TABLES but doesn't exist in the schema`
+      );
+    }
+  }
+
   if (warnings.length > 0) {
     logger.warn({ warnings }, 'SYNC_CONFIG validation warnings detected');
   }

--- a/services/api-gateway/src/utils/appErrors.test.ts
+++ b/services/api-gateway/src/utils/appErrors.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { NotFoundError } from './appErrors.js';
+
+describe('NotFoundError', () => {
+  it('is an Error subclass exposing `resource` with a default `<resource> not found` message', () => {
+    const err = new NotFoundError('LLM config');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(NotFoundError);
+    expect(err.name).toBe('NotFoundError');
+    expect(err.resource).toBe('LLM config');
+    expect(err.message).toBe('LLM config not found');
+  });
+
+  it('uses logMessage for the (server-side) message while keeping resource body-safe', () => {
+    const err = new NotFoundError('LLM config', 'setAsDefault: config abc not found');
+    expect(err.resource).toBe('LLM config');
+    expect(err.message).toBe('setAsDefault: config abc not found');
+  });
+});

--- a/services/api-gateway/src/utils/appErrors.ts
+++ b/services/api-gateway/src/utils/appErrors.ts
@@ -1,0 +1,27 @@
+/**
+ * Application-level error classes that the HTTP layer (`asyncHandler`) translates
+ * into specific status codes. Throwing one of these from a service or handler lets
+ * the generic `asyncHandler` map it once, instead of every route re-implementing
+ * the same status/body shape.
+ */
+
+/**
+ * A requested resource doesn't exist. `asyncHandler` maps this to a 404 whose body
+ * is a clean `<resource> not found` — the optional `logMessage` carries richer
+ * context (ids, the operation) for server-side logs WITHOUT leaking it to the client.
+ *
+ * Use for the narrow race where a resource passes a route's existence pre-check but
+ * is deleted before a follow-up read: the correct status is 404 (client-caused), not
+ * 500 (server fault), and the internal operation string must not reach the response.
+ */
+export class NotFoundError extends Error {
+  constructor(
+    /** Public, body-safe label, e.g. `'LLM config'` → `"LLM config not found"`. */
+    public readonly resource: string,
+    /** Optional richer message for logs; defaults to `<resource> not found`. */
+    logMessage?: string
+  ) {
+    super(logMessage ?? `${resource} not found`);
+    this.name = 'NotFoundError';
+  }
+}

--- a/services/api-gateway/src/utils/asyncHandler.test.ts
+++ b/services/api-gateway/src/utils/asyncHandler.test.ts
@@ -16,6 +16,7 @@ vi.mock('@tzurot/common-types', async () => {
 
 import { asyncHandler } from './asyncHandler.js';
 import { ParameterError } from './requestParams.js';
+import { NotFoundError } from './appErrors.js';
 
 function createMockRes(): Response & {
   status: ReturnType<typeof vi.fn>;
@@ -61,6 +62,23 @@ describe('asyncHandler', () => {
 
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: 'VALIDATION_ERROR' }));
+  });
+
+  it('should send 404 with a clean body for NotFoundError', async () => {
+    const handler = vi
+      .fn()
+      .mockRejectedValue(new NotFoundError('LLM config', 'setAsDefault: config abc not found'));
+    const res = createMockRes();
+
+    const wrapped = asyncHandler(handler);
+    wrapped(mockReq, res);
+    await vi.waitFor(() => expect(res.status).toHaveBeenCalled());
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    // Only the clean `resource` reaches the body — not the internal op string.
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: 'NOT_FOUND', message: 'LLM config not found' })
+    );
   });
 
   it('should send 500 for generic errors', async () => {

--- a/services/api-gateway/src/utils/asyncHandler.ts
+++ b/services/api-gateway/src/utils/asyncHandler.ts
@@ -8,6 +8,7 @@ import { createLogger } from '@tzurot/common-types';
 import { ErrorResponses } from './errorResponses.js';
 import { sendError } from './responseHelpers.js';
 import { ParameterError } from './requestParams.js';
+import { NotFoundError } from './appErrors.js';
 
 const logger = createLogger('asyncHandler');
 
@@ -75,6 +76,15 @@ export function asyncHandler<R extends Request = Request>(
         if (error instanceof ParameterError) {
           logger.warn({ err: error }, 'Missing required route parameter');
           sendError(res, ErrorResponses.validationError(error.message));
+          return;
+        }
+
+        // A resource vanished (e.g. deleted between a route's existence pre-check
+        // and a follow-up read). Client-caused, not a server fault → 404. Only the
+        // clean `resource` reaches the body; the richer message stays in the log.
+        if (error instanceof NotFoundError) {
+          logger.warn({ err: error }, 'Resource not found');
+          sendError(res, ErrorResponses.notFound(error.resource));
           return;
         }
 


### PR DESCRIPTION
Two round-3 review follow-ups from the vision-config epic (#1366/#1367).

## 1. `resolveTargetKindOrThrow` not-found race → 404 (was 500)

`setAsDefault`/`setAsFreeDefault` threw a plain `Error` when a config vanished between the route's `findGlobalConfigOrSendError` pre-check and the service's `findUnique` (delete-between-reads race). `asyncHandler` mapped it to a **500 leaking the internal op string** (`"setAsDefault: config <id> not found"`).

Fix: a typed `NotFoundError` (carries a body-safe `resource` + an optional richer log message). `asyncHandler` maps it to a **404** with a clean `"LLM config not found"` body — mirroring the existing `ParameterError`→400 branch. The op + id stay in the server log only.

## 2. `validateSyncConfig` phantom-`EXCLUDED_TABLES` detection

A table dropped from the schema but left in `EXCLUDED_TABLES` produced **neither a warning nor an info line** — a stale exclusion that rots silently (the guard from #1367 couldn't catch individual phantoms). Added a full-table-list check (deliberately not the UUID-only `schemaMap`, which would false-flag a real excluded table with no UUID column) that warns on phantoms; the component guard's zero-warnings assertion now catches the class.

**This immediately surfaced a real stale entry**: `image_description_cache` — the table was dropped in migration `20260428200310_drop_image_description_cache` but the exclusion was left behind. Removed.

## Tests

- New `appErrors.test.ts` (NotFoundError shape), `asyncHandler.test.ts` 404-branch test, strengthened the two `LlmConfigService` null-path tests to assert the typed error.
- The `syncValidation` component guard now exercises phantom detection (and confirmed the `image_description_cache` removal clears it).
- Local: api-gateway unit (2167) green, component guards green, `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)