### PR TITLE
refactor(ai-worker): remove dead vision fail-fast negative-cache writes

### DIFF
--- a/services/ai-worker/src/jobs/ImageDescriptionJob.test.ts
+++ b/services/ai-worker/src/jobs/ImageDescriptionJob.test.ts
@@ -28,13 +28,11 @@ vi.mock('../utils/apiErrorParser.js', () => ({
   getErrorLogContext: vi.fn((_error: unknown) => ({})),
 }));
 
-// `buildFailFastResult` lazy-imports `visionDescriptionCache` from redis.js;
-// stub the cache method so the dynamic import resolves without hitting a real
-// Redis client at test time. Thunks defer reference resolution past hoisting.
-// `checkModelVisionSupport` is reached transitively now that resolveVisionConfig
-// calls the real `selectVisionModel` — default it to false so the
-// no-visionModel-override tests fall through to the fallback model without a
-// real Redis call.
+// Stub redis.js so nothing in the tested path hits a real Redis client at test
+// time. `checkModelVisionSupport` is reached transitively now that
+// resolveVisionConfig calls the real `selectVisionModel` — default it to false so
+// the no-visionModel-override tests fall through to the fallback model. Thunks
+// defer reference resolution past hoisting.
 const mockStoreFailure = vi.fn();
 const mockCheckModelVisionSupport = vi.fn().mockResolvedValue(false);
 vi.mock('../redis.js', () => ({

--- a/services/ai-worker/src/jobs/ImageDescriptionJob.ts
+++ b/services/ai-worker/src/jobs/ImageDescriptionJob.ts
@@ -12,7 +12,6 @@ import {
   CONTENT_TYPES,
   TIMEOUTS,
   AIProvider,
-  ApiErrorCategory,
   type ImageDescriptionJobData,
   type ImageDescriptionResult,
   imageDescriptionJobDataSchema,
@@ -169,43 +168,19 @@ async function processSingleImage(options: ProcessSingleImageOptions): Promise<I
  * Build a fail-fast `ImageDescriptionResult` for the case where the user is
  * authenticated for some provider but lacks a key for the vision provider.
  *
- * Each image gets a "configure your key" description (visible to the LLM
- * when it consumes the dependency-job result) and a synthetic AUTHENTICATION
- * cache entry so subsequent retries within the 5-min window hit cache and
- * skip re-resolving + re-failing — same UX shape as a real auth-rejection
- * from the upstream provider's API.
- *
- * Mirrors `buildVisionAuthFailureResults` in `visionAuthResolver.ts` (the
- * channel-history path's equivalent helper). The two paths produce identical
- * fallback strings + cache shapes so the user sees consistent behavior
- * regardless of how the image arrived.
+ * Each image gets a "configure your key" description (visible to the LLM when it
+ * consumes the dependency-job result) — the same fallback string the
+ * channel-history path emits via `buildVisionAuthFailureResults`, so the user
+ * sees consistent behavior regardless of how the image arrived.
  */
-async function buildFailFastResult(opts: {
+function buildFailFastResult(opts: {
   requestId: string;
   attachments: ImageDescriptionJobData['attachments'];
   visionProvider: AIProvider;
   sourceReferenceNumber: number | undefined;
   startTime: number;
-}): Promise<ImageDescriptionResult> {
+}): ImageDescriptionResult {
   const { requestId, attachments, visionProvider, sourceReferenceNumber, startTime } = opts;
-
-  // Lazy import only for `visionDescriptionCache` — `redis.js` instantiates
-  // a Redis client singleton at module-load, which we want to defer past
-  // test-time imports. The other dependencies (`ApiErrorCategory` enum,
-  // `VISION_AUTH_FAIL_FAST_DESCRIPTION` string constant) have no init-time
-  // side effects and live in the static import block at the top.
-  const { visionDescriptionCache } = await import('../redis.js');
-
-  // Cache writes parallelize because each cache key is distinct (per attachment).
-  await Promise.all(
-    attachments.map(attachment =>
-      visionDescriptionCache.storeFailure({
-        attachmentId: attachment.id,
-        url: attachment.url,
-        category: ApiErrorCategory.AUTHENTICATION,
-      })
-    )
-  );
 
   const descriptions = attachments.map(attachment => ({
     url: attachment.url,
@@ -281,10 +256,8 @@ export async function processImageDescriptionJob(
   // Fail-fast: even the free-model system fallback is unavailable (no system
   // OpenRouter key configured) for an authenticated user lacking a vision key.
   // Mirrors DependencyStep's `buildVisionAuthFailureResults` behavior so direct
-  // upload and channel-history paths produce the same fallback shape for the
-  // same user setup. Each image gets the source-aware "configure your key"
-  // description and a synthetic AUTH cache entry so retries within the 5-min
-  // window hit cache instead of repeating the resolution + failing again.
+  // upload and channel-history paths produce the same "configure your key"
+  // fallback for the same user setup.
   if (authResult.kind === 'failFast') {
     return buildFailFastResult({
       requestId,

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/DependencyStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/DependencyStep.test.ts
@@ -9,7 +9,6 @@ import {
   JobStatus,
   AttachmentType,
   AIProvider,
-  ApiErrorCategory,
   MODEL_DEFAULTS,
   REDIS_KEY_PREFIXES,
   type LLMGenerationJobData,
@@ -1213,16 +1212,7 @@ describe('DependencyStep', () => {
       // Critically: processAttachments was NOT called — short-circuit fired.
       expect(mockProcessAttachments).not.toHaveBeenCalled();
       // Fail-fast result: 1 attachment → 1 synthetic-failure entry with the
-      // source-aware fallback string. Cache write happened via storeFailure.
-      // Asserting the full argument shape (not just call count) self-documents
-      // that `attachmentId: undefined` is intentional — fixtures don't include
-      // an `id` field, and `getFailureKey` falls through to URL-hash keying.
-      expect(mockStoreFailure).toHaveBeenCalledTimes(1);
-      expect(mockStoreFailure).toHaveBeenCalledWith({
-        attachmentId: undefined,
-        url: 'https://example.com/cp.jpg',
-        category: ApiErrorCategory.AUTHENTICATION,
-      });
+      // source-aware "configure your key" fallback string.
       const synthetic = result.preprocessing?.extendedContextAttachments;
       expect(synthetic).toHaveLength(1);
       expect(synthetic?.[0]?.description).toContain('check /settings apikey set');

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/extendedContextVisionProcessor.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/extendedContextVisionProcessor.test.ts
@@ -157,7 +157,6 @@ describe('processCrossProviderVisionImages', () => {
     expect(mockProcessAttachments).not.toHaveBeenCalled();
     expect(result).toHaveLength(1);
     expect(result[0]?.description).toContain('check /settings apikey set');
-    expect(mockStoreFailure).toHaveBeenCalledTimes(1);
   });
 
   it('returns fail-fast placeholder when the resolver throws transiently', async () => {

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/extendedContextVisionProcessor.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/extendedContextVisionProcessor.test.ts
@@ -34,11 +34,13 @@ vi.mock('@tzurot/common-types', async importOriginal => {
   };
 });
 
-// resolveVisionConfig (real) calls selectVisionModel → checkModelVisionSupport
-// and buildVisionAuthFailureResults → visionDescriptionCache. Stub redis.js so
-// neither reaches a live client. The CROSS_PROVIDER personality sets a
-// visionModel override, so selectVisionModel returns it without consulting
-// checkModelVisionSupport — but stub it for safety.
+// resolveVisionConfig (real) calls selectVisionModel → checkModelVisionSupport;
+// selectVisionModel lives in VisionProcessor.js, which imports visionDescriptionCache
+// from redis.js. Stub redis.js so none of that reaches a live client. The
+// CROSS_PROVIDER personality sets a visionModel override, so selectVisionModel
+// returns it without consulting checkModelVisionSupport — but stub it for safety.
+// (buildVisionAuthFailureResults no longer touches the cache, but the stub is kept
+// for VisionProcessor's transitive import above.)
 const mockStoreFailure = vi.fn();
 vi.mock('../../../../redis.js', () => ({
   visionDescriptionCache: {

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/extendedContextVisionProcessor.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/extendedContextVisionProcessor.ts
@@ -80,10 +80,9 @@ export async function processCrossProviderVisionImages(
     });
     if (visionResult.kind === 'failFast') {
       // Even the free-model system fallback is unavailable (no system
-      // OpenRouter key). Fail-fast with synthetic-failure entries; the
-      // negative cache absorbs retries for 5min so the user sees a stable
-      // fallback string until they fix the key.
-      return await buildVisionAuthFailureResults(imageAttachments);
+      // OpenRouter key). Return synthetic "configure your key" placeholders so
+      // the user sees a stable fallback string instead of dropped images.
+      return buildVisionAuthFailureResults(imageAttachments);
     }
     const { config } = visionResult;
     const processed = await processAttachments(imageAttachments, personality, {

--- a/services/ai-worker/src/services/multimodal/visionAuthResolver.test.ts
+++ b/services/ai-worker/src/services/multimodal/visionAuthResolver.test.ts
@@ -19,7 +19,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   AIProvider,
   AttachmentType,
-  ApiErrorCategory,
   MODEL_DEFAULTS,
   type LoadedPersonality,
   type AttachmentMetadata,
@@ -404,9 +403,7 @@ describe('resolveVisionConfig', () => {
 });
 
 describe('buildVisionAuthFailureResults', () => {
-  it('writes a synthetic AUTH-failure cache entry per attachment and returns fallback descriptions', async () => {
-    mockStoreFailure.mockResolvedValue(undefined);
-
+  it('returns a "configure your key" fallback description per attachment', () => {
     const attachments: AttachmentMetadata[] = [
       {
         id: 'att-1',
@@ -424,50 +421,12 @@ describe('buildVisionAuthFailureResults', () => {
       } as AttachmentMetadata,
     ];
 
-    const results = await buildVisionAuthFailureResults(attachments);
+    const results = buildVisionAuthFailureResults(attachments);
 
     expect(results).toHaveLength(2);
     expect(results[0]?.type).toBe(AttachmentType.Image);
     expect(results[0]?.description).toContain('check /settings apikey set');
     expect(results[0]?.originalUrl).toBe('https://cdn.discordapp.com/img1.png');
     expect(results[1]?.originalUrl).toBe('https://cdn.discordapp.com/img2.png');
-
-    expect(mockStoreFailure).toHaveBeenCalledTimes(2);
-    // Assert each call's argument shape explicitly — `toHaveBeenCalledTimes`
-    // alone wouldn't catch a future partial-application bug where the second
-    // call ends up with a stale or default category.
-    expect(mockStoreFailure).toHaveBeenNthCalledWith(1, {
-      attachmentId: 'att-1',
-      url: 'https://cdn.discordapp.com/img1.png',
-      category: ApiErrorCategory.AUTHENTICATION,
-    });
-    expect(mockStoreFailure).toHaveBeenNthCalledWith(2, {
-      attachmentId: 'att-2',
-      url: 'https://cdn.discordapp.com/img2.png',
-      category: ApiErrorCategory.AUTHENTICATION,
-    });
-  });
-
-  it('returns placeholders even when the negative-cache write throws (best-effort)', async () => {
-    // Redis blip at fail-fast emission must NOT drop the user-facing placeholders.
-    // The cache write is best-effort; the caller's outer catch would otherwise
-    // turn a thrown cache error into an empty result (silently dropped images).
-    mockStoreFailure.mockRejectedValue(new Error('redis down'));
-
-    const attachments: AttachmentMetadata[] = [
-      {
-        id: 'att-1',
-        url: 'https://cdn.discordapp.com/img1.png',
-        contentType: 'image/png',
-        name: 'img1.png',
-        size: 100,
-      } as AttachmentMetadata,
-    ];
-
-    const results = await buildVisionAuthFailureResults(attachments);
-
-    expect(results).toHaveLength(1);
-    expect(results[0]?.description).toContain('check /settings apikey set');
-    expect(mockStoreFailure).toHaveBeenCalledTimes(1);
   });
 });

--- a/services/ai-worker/src/services/multimodal/visionAuthResolver.ts
+++ b/services/ai-worker/src/services/multimodal/visionAuthResolver.ts
@@ -22,9 +22,8 @@
  * can't auth the vision provider, not a specific provider's users.
  *
  * Use `buildVisionAuthFailureResults` to construct the synthetic-failure
- * `ProcessedAttachment[]` when the resolver returns `failFast`. That helper
- * writes to the negative cache so subsequent retries within the 5-min window
- * hit cache instead of re-resolving and re-failing.
+ * `ProcessedAttachment[]` (the "configure your key" placeholders) when the
+ * resolver returns `failFast`.
  */
 
 import {

--- a/services/ai-worker/src/services/multimodal/visionAuthResolver.ts
+++ b/services/ai-worker/src/services/multimodal/visionAuthResolver.ts
@@ -31,14 +31,13 @@ import {
   createLogger,
   AIProvider,
   AttachmentType,
-  ApiErrorCategory,
   MODEL_DEFAULTS,
   type AttachmentMetadata,
   type LoadedPersonality,
 } from '@tzurot/common-types';
 import { detectVisionProvider } from '../ProviderRouter.js';
 import { selectVisionModel } from './VisionProcessor.js';
-import { visionDescriptionCache, visionFallbackQuota } from '../../redis.js';
+import { visionFallbackQuota } from '../../redis.js';
 import type { ApiKeyResolver } from '../ApiKeyResolver.js';
 import type { ProcessedAttachment } from '../MultimodalProcessor.js';
 
@@ -330,50 +329,24 @@ export async function resolveVisionConfig(
  * Build synthetic AUTHENTICATION-failure ProcessedAttachment entries for a
  * batch of image attachments when `resolveVisionConfig` returns `failFast`
  * (no usable key for the vision provider AND no system free-fallback key).
- * Writes each entry to the negative cache so subsequent retries within the
- * 5-min window hit cache instead of re-resolving — same UX as a real auth
- * rejection by the upstream API.
  *
- * The cache write is **best-effort**: the placeholder results are built and
- * returned regardless of whether the cache write succeeds. A Redis blip at the
- * moment we emit the fail-fast must NOT drop the user-facing placeholders (the
- * caller's outer catch would otherwise turn the throw into an empty result —
- * silently dropping the images instead of showing "[Image unavailable…]").
+ * Each entry gets the source-aware "configure your key" fallback description.
+ * The placeholders are always returned so the caller's outer catch can't turn
+ * the fail-fast into an empty result (which would silently drop the images
+ * instead of showing the "[Image unavailable…]" fallback). The fail-fast path is
+ * reachable by an authenticated user lacking both the vision-provider key and
+ * the system free-fallback key, OR by a transient resolver throw — so it is not
+ * exclusively an authentication condition.
  */
-export async function buildVisionAuthFailureResults(
+export function buildVisionAuthFailureResults(
   attachments: AttachmentMetadata[]
-): Promise<ProcessedAttachment[]> {
-  // Build the user-facing placeholders first so they're returned no matter what
-  // happens to the cache. The fail-fast path is reachable by an authenticated
-  // user lacking both the vision-provider key and the system free-fallback key,
-  // OR by a transient resolver throw — so this is not exclusively authenticated.
+): ProcessedAttachment[] {
   const results: ProcessedAttachment[] = attachments.map(attachment => ({
     type: AttachmentType.Image,
     description: VISION_AUTH_FAIL_FAST_DESCRIPTION,
     originalUrl: attachment.url,
     metadata: attachment,
   }));
-
-  // Negative-cache writes are best-effort. Synthetic failures use the
-  // AUTHENTICATION category so the source-aware fallback string fires on cache
-  // hits. Writes parallelize (independent keys); a failure here is logged and
-  // swallowed so it can't drop the placeholders above.
-  try {
-    await Promise.all(
-      attachments.map(attachment =>
-        visionDescriptionCache.storeFailure({
-          attachmentId: attachment.id,
-          url: attachment.url,
-          category: ApiErrorCategory.AUTHENTICATION,
-        })
-      )
-    );
-  } catch (error) {
-    logger.warn(
-      { err: error, count: attachments.length },
-      'Failed to write vision fail-fast entries to negative cache — returning placeholders anyway'
-    );
-  }
 
   logger.info(
     { count: attachments.length },


### PR DESCRIPTION
beta.140 release-review follow-up #2 — but the investigation reframed it.

## The finding

The fail-fast helpers (`buildFailFastResult` in `ImageDescriptionJob.ts`, `buildVisionAuthFailureResults` in `visionAuthResolver.ts`) wrote a negative-cache entry intended to suppress re-resolution on retry. The original review flagged a "missing `model`" bug. Tracing it showed the write is **dead**:

- The **sole reader** (`describeImage`'s `checkNegativeCache`) uses a **model-namespaced** key and sits on the **non-fail-fast** branch.
- The fail-fast writers **omit the model** (bare key) → never match the reader's key anyway.
- A fail-fast job returns `success: true` → BullMQ **never retries it**.

So nothing ever read these entries, and the JSDoc claiming "subsequent retries within the 5-min window hit cache and skip re-resolving" described a mechanism that **doesn't exist**.

## Change

- Remove the dead `storeFailure` writes from both fail-fast helpers + the misleading docs.
- Both helpers are now **synchronous** (no async work remains); their one caller each drops the `await`.
- The **real** failure-cache write (`VisionProcessor`, model-namespaced, with a live reader on the actual-failure path) is **untouched**.
- Tests drop the now-moot `storeFailure` assertions + the "best-effort redis-failure" test (there's no write left to fail). Unused `ApiErrorCategory` imports removed.

The reviewer's suggested `MODEL_DEFAULTS.VISION_FALLBACK_FREE` was declined: an auth failure isn't model-specific, and in the fail-fast state there's no resolved model to namespace by.

## Testing

- 6 affected ai-worker test files green (150 tests), incl. the real `VisionProcessor`/`MultimodalProcessor` failure-cache path (unchanged).
- `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)