### PR TITLE
build(api-gateway): pre-deploy migration command to close the breaking-migration window

### DIFF
--- a/docs/reference/deployment/PREDEPLOY_MIGRATIONS.md
+++ b/docs/reference/deployment/PREDEPLOY_MIGRATIONS.md
@@ -1,0 +1,67 @@
+# Pre-deploy migrations (Railway)
+
+Eliminates the **breaking-migration deploy window**: Railway auto-deploys new code on
+merge, but Prisma migrations were applied manually afterward (`pnpm ops db:migrate`),
+so for a few minutes the new code ran against the old schema. The beta.140 incident was
+exactly this — `column llm_configs.kind does not exist` → personality-load failures →
+user-visible "No response received" for ~3 minutes.
+
+## How it works
+
+`services/api-gateway/railway.json` sets a [pre-deploy command](https://docs.railway.com/deployments/pre-deploy-command):
+
+```json
+{ "deploy": { "preDeployCommand": "npx -y prisma@7 migrate deploy" } }
+```
+
+Railway runs the pre-deploy command **between build and deploy**, in the service's
+private network (so `DATABASE_URL` is present), and **blocks the deploy if it exits
+non-zero**. So pending migrations are applied to that environment's DB _before_ the new
+api-gateway code serves traffic — no window, and a failed migration loudly blocks the
+deploy instead of silently breaking prod.
+
+It runs on **both** dev (push to `develop`) and prod (release merge to `main`), so the
+manual `pnpm ops db:migrate` step is no longer required for api-gateway deploys.
+
+### Runner-image prerequisites (all satisfied)
+
+`prisma migrate deploy` needs, in the api-gateway runtime image:
+
+1. **The prisma CLI** — supplied by `npx -y prisma@7` (fetched/cached at deploy; `-y`
+   auto-confirms the install). Pinned to major 7 to match `@prisma/client`/`prisma`
+   (`^7.8.0`); bump the `@7` when the project moves to Prisma 8.
+2. **`prisma.config.ts`** — the schema's datasource has **no `url`** (the runtime uses
+   the `@prisma/adapter-pg` driver adapter); `prisma.config.ts` feeds `DATABASE_URL` to
+   _migrate_. The Dockerfile now `COPY`s it into the runner.
+3. **`DATABASE_URL`** — already set on the Railway api-gateway service.
+4. **The migrations folder** — already copied (`COPY prisma ./prisma`).
+
+## ⚠️ Verify before relying on this (a failed pre-deploy blocks deploys)
+
+This could not be verified locally — it depends on Railway-side behavior. Before trusting
+it on prod:
+
+1. **Confirm Railway picks up the config.** The api-gateway service's _Config-as-Code_
+   path (dashboard → Settings) must resolve to `services/api-gateway/railway.json` (it
+   depends on the service's root directory). If the path is wrong, Railway silently
+   ignores the file (a safe no-op — but the window isn't fixed).
+2. **Dry-run the command in the dev Railway shell** for the api-gateway service:
+   `npx -y prisma@7 migrate deploy`. With no pending migrations it's a safe no-op
+   ("No pending migrations"). Confirm it connects + exits 0.
+3. **Then let a dev deploy exercise it** (push a no-op to `develop`) and confirm the
+   deploy succeeds with the pre-deploy step green.
+
+Only after dev is confirmed should this reach prod (the release merge to `main`).
+
+## Caveat — multi-service deploys (not fully closed by this alone)
+
+This gates **api-gateway**'s new code behind the migration. But a merge triggers **all**
+services' deploys in parallel, and **ai-worker** also reads new columns (e.g. vision
+`kind`) — its new code can still briefly hit the pre-migration schema during api-gateway's
+migrate. The complete fix pairs this with **backward-compatible (expand-contract)
+migrations** so every service tolerates the old schema during the window. Tracked as a
+follow-up; the pre-deploy command is the larger, structural half.
+
+Do **not** add a pre-deploy migrate to a second service — concurrent `migrate deploy`
+runs would race (it's advisory-locked, so safe, but redundant and confusing). Keep
+api-gateway as the single migration runner.

--- a/services/api-gateway/Dockerfile
+++ b/services/api-gateway/Dockerfile
@@ -70,6 +70,10 @@ WORKDIR /app
 COPY --from=pruner /app/out/json/ .
 COPY --from=pruner /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 COPY prisma ./prisma
+# prisma.config.ts feeds DATABASE_URL to `prisma migrate deploy` (the schema's
+# datasource has no url — the runtime uses the pg driver adapter). The runner
+# needs it for the Railway pre-deploy migration command (railway.json).
+COPY prisma.config.ts ./prisma.config.ts
 
 # Install production dependencies only
 RUN pnpm install --prod --frozen-lockfile

--- a/services/api-gateway/railway.json
+++ b/services/api-gateway/railway.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "deploy": {
+    "preDeployCommand": "npx -y prisma@7 migrate deploy"
+  }
+}


### PR DESCRIPTION
**Validated by merging to develop.** The Railway `preDeployCommand` only fires on an actual deploy, and dev auto-deploys on push to develop — so merge-to-dev IS the validation path (there is no local dry-run that exercises the pre-deploy hook).

## What

Closes the breaking-migration deploy window (the beta.140 `column llm_configs.kind does not exist` incident): Railway auto-deploys new code on merge, but Prisma migrations were applied manually afterward, so new code ran against the old schema for ~3 minutes.

`services/api-gateway/railway.json` adds a [Railway pre-deploy command](https://docs.railway.com/deployments/pre-deploy-command):
```json
{ "deploy": { "preDeployCommand": "npx -y prisma@7 migrate deploy" } }
```
Railway runs it **between build and deploy** (private network → `DATABASE_URL` present) and **blocks the deploy on non-zero exit** — so the schema migrates before api-gateway serves traffic, and a bad migration loudly blocks the deploy instead of silently breaking prod. Removes the manual `pnpm ops db:migrate` step for api-gateway.

The Dockerfile now `COPY`s `prisma.config.ts` (the schema datasource has no `url` — runtime uses the pg driver adapter — so the config feeds `DATABASE_URL` to *migrate*). CLI via `npx -y prisma@7` (which also pulls `jiti` for TS-config evaluation, sidestepping the "is prisma in deps" question).

## How to validate (on this dev deploy)

Per [PREDEPLOY_MIGRATIONS.md](docs/reference/deployment/PREDEPLOY_MIGRATIONS.md):
1. Confirm the api-gateway service's Config-as-Code path resolves to this `railway.json` (depends on the service root dir; wrong path = silent no-op).
2. Watch the dev api-gateway deploy logs for the `prisma migrate deploy` step running + succeeding before traffic switches.
3. Confirm `prisma.config.ts` is parsed correctly in the runner (jiti present).

A failed pre-deploy **blocks** the dev deploy (api-gateway stays on old code) — recoverable by pushing a corrected `railway.json` (or removing it) to develop.

## Follow-ups (post-validation, tracked in `cold/follow-ups.md`)
- Reflect api-gateway auto-migrate across the manual-migrate docs/rules/skill (`03-database.md`, `05-tooling.md`, `RAILWAY_OPERATIONS.md`, `tzurot-deployment` skill) + remove the now-closed deploy-window idea from `cold/ideas.md`.
- Multi-service breaking migrations still need expand/contract — the pre-deploy only closes the window for api-gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)