### PR TITLE
fix: scope the LLM free-default resolver to kind:text (vision-leak)

### DIFF
--- a/packages/config-resolver/src/LlmConfigResolver.test.ts
+++ b/packages/config-resolver/src/LlmConfigResolver.test.ts
@@ -621,9 +621,34 @@ describe('LlmConfigResolver', () => {
 
       expect(result).toBeNull();
       expect(mockPrisma.llmConfig.findFirst).toHaveBeenCalledWith({
-        where: { isFreeDefault: true },
+        where: { isFreeDefault: true, kind: 'text' },
         select: expect.any(Object),
       });
+    });
+
+    it('scopes the free-default lookup to kind:text (ignores a vision free-default)', async () => {
+      // Behavioral guard for the vision free-default leak: llm_configs is shared
+      // with kind='vision' rows that also set isFreeDefault=true. The mock returns
+      // null for the kind:'text' query but a vision row otherwise — so a regression
+      // dropping the kind filter would resolve the vision row (non-null) and fail.
+      mockPrisma.llmConfig.findFirst.mockImplementation(
+        ({ where }: { where: Record<string, unknown> }) =>
+          where.kind === 'text'
+            ? null
+            : {
+                name: 'Vision Free Default',
+                model: 'qwen/qwen3-vl-30b-a3b-instruct',
+                provider: 'openrouter',
+                advancedParameters: null,
+                memoryScoreThreshold: null,
+                memoryLimit: null,
+                contextWindowTokens: null,
+              }
+      );
+
+      const result = await resolver.getFreeDefaultConfig();
+
+      expect(result).toBeNull();
     });
 
     it('should return config when isFreeDefault config exists', async () => {

--- a/packages/config-resolver/src/LlmConfigResolver.ts
+++ b/packages/config-resolver/src/LlmConfigResolver.ts
@@ -177,8 +177,11 @@ export class LlmConfigResolver extends BaseConfigResolver<
     }
 
     try {
+      // Scope to kind:'text' — llm_configs is shared with kind='vision' rows that
+      // also set isFreeDefault=true, so without this the text free-default read
+      // could return the vision one. Mirrors VisionConfigResolver's kind:'vision'.
       const freeConfig = await this.prisma.llmConfig.findFirst({
-        where: { isFreeDefault: true },
+        where: { isFreeDefault: true, kind: 'text' },
         select: LLM_CONFIG_SELECT_WITH_NAME,
       });
 


### PR DESCRIPTION
## What

`LlmConfigResolver.getFreeDefaultConfig()` queried `findFirst({ where: { isFreeDefault: true } })` with **no `kind` filter**. Adds `kind: 'text'`.

## Why

Since Phase 1 of the Model-Config-Overhaul, vision configs share the `llm_configs` table via a `kind` discriminator, and `VisionConfigBootstrap` seeds a `kind='vision'` row with `isFreeDefault=true`. So a free-tier **text** resolution falling through to this tier could return the **vision** free-default model (`findFirst`, no `orderBy` → nondeterministic). Latent bug, armed in every env where Phase 1 deployed. The DB partial-unique indexes are already kind-scoped (one text + one vision free-default coexist) — this fixes the **read** side that wasn't.

## Scope (audited)

`VisionConfigResolver` scopes correctly; `TtsConfigResolver`'s similar query is fine (`tts_configs` is a separate table); the text resolver's other tiers join via text-specific FK columns. `getFreeDefaultConfig` was the only leak. `getById` (#4) is intentionally out — it's the Phase-2 editing-surface gate, not the runtime resolution bug.

## Test plan

- Updated the existing `getFreeDefaultConfig` null-case assertion to expect `kind: 'text'`, plus a **behavioral isolation test** (`scopes the free-default lookup to kind:text…`) that mocks `findFirst` to return `null` for the `kind:'text'` query but a vision row otherwise — so a regression dropping the kind filter resolves the vision row (non-null) and fails. 109 config-resolver tests green; `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)