### PR TITLE
feat(api-gateway): validate vision-config model capability (S1b)

### DIFF
--- a/packages/common-types/src/constants/ai.test.ts
+++ b/packages/common-types/src/constants/ai.test.ts
@@ -9,6 +9,7 @@ import {
   buildModelInfoUrl,
   isZaiCodingPlanModel,
   getZaiCodingPlanContextLength,
+  zaiCodingPlanModelCapabilities,
   listZaiCodingPlanModels,
 } from './ai.js';
 
@@ -264,5 +265,35 @@ describe('listZaiCodingPlanModels', () => {
     for (const entry of listZaiCodingPlanModels()) {
       expect(getZaiCodingPlanContextLength(entry.model)).toBe(entry.contextLength);
     }
+  });
+});
+
+describe('zaiCodingPlanModelCapabilities', () => {
+  it('returns a text-only capability shape for every current catalog model', () => {
+    // All z.ai coding-plan models are text-only today, so every flag is false
+    // and the vision gate fails closed for them.
+    for (const entry of listZaiCodingPlanModels()) {
+      const caps = zaiCodingPlanModelCapabilities(entry.model);
+      expect(caps).not.toBeNull();
+      expect(caps).toMatchObject({
+        supportsVision: false,
+        supportsImageGeneration: false,
+        supportsAudioInput: false,
+        supportsAudioOutput: false,
+        contextLength: entry.contextLength,
+        source: 'zai',
+      });
+    }
+  });
+
+  it('strips the z-ai/ prefix and case-normalizes before lookup', () => {
+    expect(zaiCodingPlanModelCapabilities('z-ai/glm-5.2')?.contextLength).toBe(1_000_000);
+    expect(zaiCodingPlanModelCapabilities('Z-AI/GLM-5.2')?.source).toBe('zai');
+  });
+
+  it('returns null for models not in the catalog', () => {
+    expect(zaiCodingPlanModelCapabilities('glm-99-future')).toBeNull();
+    expect(zaiCodingPlanModelCapabilities('anthropic/claude-sonnet-4')).toBeNull();
+    expect(zaiCodingPlanModelCapabilities('')).toBeNull();
   });
 });

--- a/packages/common-types/src/constants/ai.ts
+++ b/packages/common-types/src/constants/ai.ts
@@ -4,6 +4,8 @@
  * AI model configuration, providers, defaults, and endpoints.
  */
 
+import type { ModelCapabilities } from '../types/ai.js';
+
 /**
  * AI model default configuration
  */
@@ -267,8 +269,23 @@ export const ZAI_VALIDATION_MODEL = 'glm-4.5-air';
 // the synthetic catalog entry's `created` so `/models` can sort them by recency.
 // Models that also live on OpenRouter take OpenRouter's `created` via the merge,
 // so `released` is optional and only worth setting for z.ai-only entries.
+// Modality flags are OPTIONAL and omitted = false (text-only). Every current
+// z.ai coding-plan model is text-only, so none set them; the fields exist so a
+// future z.ai vision/audio model is a one-line value change, not a schema
+// change. `zaiCodingPlanModelCapabilities` reads them with `?? false`.
 const ZAI_MODEL_CATALOG: Readonly<
-  Record<string, { docsUrl: string; contextLength: number; released?: string }>
+  Record<
+    string,
+    {
+      docsUrl: string;
+      contextLength: number;
+      released?: string;
+      supportsVision?: boolean;
+      supportsImageGeneration?: boolean;
+      supportsAudioInput?: boolean;
+      supportsAudioOutput?: boolean;
+    }
+  >
 > = {
   'glm-5': { docsUrl: 'https://docs.z.ai/guides/llm/glm-5', contextLength: 200_000 },
   'glm-5.1': { docsUrl: 'https://docs.z.ai/guides/llm/glm-5.1', contextLength: 200_000 },
@@ -340,6 +357,47 @@ export interface ZaiCodingPlanModelInfo {
   contextLength: number;
   /** ISO release date; only set for z.ai-exclusive models (see catalog comment). */
   released?: string;
+  // Modality capabilities. Each is OPTIONAL: omitted = false (text-only). Set a
+  // field per-model only when a z.ai model gains that capability. Read these via
+  // `zaiCodingPlanModelCapabilities()`, which normalizes undefined → false;
+  // direct field access sees `undefined`, not `false`.
+  /** Accepts image input (vision). Omitted = false. */
+  supportsVision?: boolean;
+  /** Produces image output. Omitted = false. */
+  supportsImageGeneration?: boolean;
+  /** Accepts audio input. Omitted = false. */
+  supportsAudioInput?: boolean;
+  /** Produces audio output. Omitted = false. */
+  supportsAudioOutput?: boolean;
+}
+
+/**
+ * Resolve a z.ai coding-plan model's modality capabilities into the unified,
+ * provider-agnostic {@link ModelCapabilities} shape. Strips an optional `z-ai/`
+ * prefix and case-normalizes (same lookup contract as
+ * {@link getZaiCodingPlanContextLength}). Returns `null` for any model not in
+ * the catalog — callers treat that as "not a z.ai coding-plan model."
+ *
+ * z.ai coding-plan models are text-only today, so the catalog's modality flags
+ * are optional and read as `false` when omitted. A `kind='vision'` config on a
+ * z.ai model therefore fails closed (no confirmed vision support) until a z.ai
+ * vision model is explicitly flagged in the catalog.
+ */
+export function zaiCodingPlanModelCapabilities(model: string): ModelCapabilities | null {
+  const lower = model.toLowerCase();
+  const bare = lower.startsWith(ZAI_MODEL_PREFIX) ? lower.slice(ZAI_MODEL_PREFIX.length) : lower;
+  const entry = ZAI_MODEL_CATALOG[bare];
+  if (entry === undefined) {
+    return null;
+  }
+  return {
+    supportsVision: entry.supportsVision ?? false,
+    supportsImageGeneration: entry.supportsImageGeneration ?? false,
+    supportsAudioInput: entry.supportsAudioInput ?? false,
+    supportsAudioOutput: entry.supportsAudioOutput ?? false,
+    contextLength: entry.contextLength,
+    source: 'zai',
+  };
 }
 
 /**

--- a/packages/common-types/src/constants/index.ts
+++ b/packages/common-types/src/constants/index.ts
@@ -19,6 +19,7 @@ export {
   ZAI_MODEL_PREFIX,
   isZaiCodingPlanModel,
   getZaiCodingPlanContextLength,
+  zaiCodingPlanModelCapabilities,
   listZaiCodingPlanModels,
   buildModelInfoUrl,
 } from './ai.js';

--- a/packages/common-types/src/types/ai.ts
+++ b/packages/common-types/src/types/ai.ts
@@ -148,3 +148,33 @@ export interface ModelAutocompleteOption {
    */
   isRouter?: boolean;
 }
+
+/**
+ * Where a {@link ModelCapabilities} record was resolved from. Diagnostic only —
+ * lets callers distinguish an authoritative OpenRouter answer from a z.ai-catalog
+ * default (text-only) or a model we couldn't resolve at all.
+ */
+export type ModelCapabilitySource = 'openrouter' | 'zai' | 'unknown';
+
+/**
+ * Unified, provider-agnostic model-capability shape. Both the OpenRouter cache
+ * and the z.ai catalog map INTO this, so a capability check queries one shape
+ * regardless of which provider serves the model. This is the first concrete
+ * step toward decoupling capability resolution from OpenRouter (see backlog:
+ * provider abstraction) — new providers map their native format into this type
+ * rather than every caller learning each provider's quirks.
+ */
+export interface ModelCapabilities {
+  /** Accepts image input — the gate for `kind='vision'` configs. */
+  supportsVision: boolean;
+  /** Produces image output. */
+  supportsImageGeneration: boolean;
+  /** Accepts audio input. */
+  supportsAudioInput: boolean;
+  /** Produces audio output. */
+  supportsAudioOutput: boolean;
+  /** Max context length in tokens; null when the source doesn't report one. */
+  contextLength: number | null;
+  /** Which source resolved this record. */
+  source: ModelCapabilitySource;
+}

--- a/services/api-gateway/src/routes/admin/llm-config.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.ts
@@ -95,7 +95,15 @@ function createCreateConfigHandler(
     // z.ai-catalog models (incl. z.ai-only ones like glm-5.2) are validatable as
     // global configs. Users with a z.ai key promote at runtime; users without
     // one fall through to OpenRouter.
-    if (!(await validateLlmConfigModelFields({ res, modelCache, body, hasZaiCodingKey: true }))) {
+    if (
+      !(await validateLlmConfigModelFields({
+        res,
+        modelCache,
+        body,
+        hasZaiCodingKey: true,
+        kind: body.kind,
+      }))
+    ) {
       return;
     }
 
@@ -108,6 +116,7 @@ function createCreateConfigHandler(
       !(await ensureNoNameCollision(res, service, {
         name: body.name,
         scope: { type: 'GLOBAL' },
+        kind: body.kind,
         formatCollisionMessage: n => `A global config named "${n}" already exists`,
       }))
     ) {

--- a/services/api-gateway/src/routes/user/llm-config.ts
+++ b/services/api-gateway/src/routes/user/llm-config.ts
@@ -166,7 +166,15 @@ function createCreateHandler(
     const userId = resolveProvisionedUserId(req);
     const hasZaiCodingKey = await userHasActiveApiKey(prisma, userId, AIProvider.ZaiCoding);
 
-    if (!(await validateLlmConfigModelFields({ res, modelCache, body, hasZaiCodingKey }))) {
+    if (
+      !(await validateLlmConfigModelFields({
+        res,
+        modelCache,
+        body,
+        hasZaiCodingKey,
+        kind: body.kind,
+      }))
+    ) {
       return;
     }
 
@@ -179,6 +187,7 @@ function createCreateHandler(
       !(await ensureNoNameCollision(res, service, {
         name: body.name,
         scope: { type: 'USER', userId, discordId: discordUserId },
+        kind: body.kind,
         formatCollisionMessage: n => `You already have a config named "${n}"`,
       }))
     ) {

--- a/services/api-gateway/src/services/ModelCapabilityService.test.ts
+++ b/services/api-gateway/src/services/ModelCapabilityService.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for ModelCapabilityService
+ *
+ * Verifies the OpenRouter-authoritative → z.ai-catalog → null resolution
+ * priority, including the load-bearing cases: OpenRouter wins over the z.ai
+ * catalog for models on both, z.ai-only models resolve text-only, unknown
+ * models fail closed (null), and a missing cache still resolves z.ai models.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { ModelAutocompleteOption } from '@tzurot/common-types';
+import type { OpenRouterModelCache } from './OpenRouterModelCache.js';
+import { ModelCapabilityService } from './ModelCapabilityService.js';
+
+/** Build a ModelAutocompleteOption with sensible text-only defaults. */
+function modelOption(overrides: Partial<ModelAutocompleteOption> = {}): ModelAutocompleteOption {
+  return {
+    id: 'anthropic/claude-sonnet-4',
+    name: 'Claude Sonnet 4',
+    contextLength: 200_000,
+    supportsVision: false,
+    supportsImageGeneration: false,
+    supportsAudioInput: false,
+    supportsAudioOutput: false,
+    promptPricePerMillion: 3,
+    completionPricePerMillion: 15,
+    ...overrides,
+  };
+}
+
+/** A cache stub whose getModelById returns whatever the map holds (null otherwise). */
+function cacheReturning(byId: Record<string, ModelAutocompleteOption>): OpenRouterModelCache {
+  return {
+    getModelById: vi.fn(async (id: string) => byId[id] ?? null),
+  } as unknown as OpenRouterModelCache;
+}
+
+describe('ModelCapabilityService', () => {
+  it('uses OpenRouter capability tags when the model is on OpenRouter (vision-capable)', async () => {
+    const cache = cacheReturning({
+      'anthropic/claude-3.5-sonnet': modelOption({
+        id: 'anthropic/claude-3.5-sonnet',
+        supportsVision: true,
+        contextLength: 200_000,
+      }),
+    });
+    const caps = await new ModelCapabilityService(cache).resolve('anthropic/claude-3.5-sonnet');
+    expect(caps).toEqual({
+      supportsVision: true,
+      supportsImageGeneration: false,
+      supportsAudioInput: false,
+      supportsAudioOutput: false,
+      contextLength: 200_000,
+      source: 'openrouter',
+    });
+  });
+
+  it('reports a text-only OpenRouter model as non-vision', async () => {
+    const cache = cacheReturning({
+      'anthropic/claude-text': modelOption({ id: 'anthropic/claude-text', supportsVision: false }),
+    });
+    const caps = await new ModelCapabilityService(cache).resolve('anthropic/claude-text');
+    expect(caps?.supportsVision).toBe(false);
+    expect(caps?.source).toBe('openrouter');
+  });
+
+  it('OpenRouter is authoritative for z.ai models that ALSO live on OpenRouter', async () => {
+    // glm-5.1 is on OpenRouter. Even though it's z.ai-namespaced, the OpenRouter
+    // tags win — here OpenRouter (hypothetically) reports vision support, and the
+    // z.ai catalog (text-only) must NOT override it.
+    const cache = cacheReturning({
+      'z-ai/glm-5.1': modelOption({ id: 'z-ai/glm-5.1', supportsVision: true }),
+    });
+    const caps = await new ModelCapabilityService(cache).resolve('z-ai/glm-5.1');
+    expect(caps?.source).toBe('openrouter');
+    expect(caps?.supportsVision).toBe(true);
+  });
+
+  it('falls back to the z.ai catalog (text-only) for z.ai-only models absent from OpenRouter', async () => {
+    // glm-5.2 is z.ai's flagship and is NOT on OpenRouter — only the z.ai catalog
+    // resolves it, and z.ai coding-plan models are text-only.
+    const cache = cacheReturning({}); // getModelById → null for everything
+    const caps = await new ModelCapabilityService(cache).resolve('z-ai/glm-5.2');
+    expect(caps).toEqual({
+      supportsVision: false,
+      supportsImageGeneration: false,
+      supportsAudioInput: false,
+      supportsAudioOutput: false,
+      contextLength: 1_000_000,
+      source: 'zai',
+    });
+  });
+
+  it('returns null for a model unknown to both sources (fail closed)', async () => {
+    const cache = cacheReturning({});
+    const caps = await new ModelCapabilityService(cache).resolve('made-up/model-x');
+    expect(caps).toBeNull();
+  });
+
+  it('resolves z.ai catalog models even when the cache is unavailable', async () => {
+    const caps = await new ModelCapabilityService(undefined).resolve('z-ai/glm-5.2');
+    expect(caps?.source).toBe('zai');
+    expect(caps?.supportsVision).toBe(false);
+  });
+
+  it('returns null for an OpenRouter-only model when the cache is unavailable', async () => {
+    const caps = await new ModelCapabilityService(undefined).resolve('anthropic/claude-sonnet-4');
+    expect(caps).toBeNull();
+  });
+});

--- a/services/api-gateway/src/services/ModelCapabilityService.ts
+++ b/services/api-gateway/src/services/ModelCapabilityService.ts
@@ -1,0 +1,63 @@
+/**
+ * ModelCapabilityService
+ *
+ * Resolves a model's modality capabilities into the unified, provider-agnostic
+ * {@link ModelCapabilities} shape, regardless of which provider serves it. This
+ * is the first concrete step toward decoupling capability resolution from any
+ * single provider — today it unifies OpenRouter (authoritative) and the z.ai
+ * coding-plan catalog; future providers slot in as additional resolution
+ * sources without every caller learning each provider's native format.
+ *
+ * Capabilities are a property of the MODEL, not the requesting user — a model's
+ * vision support doesn't change with who's asking. Access concerns (e.g. "needs
+ * a z.ai-coding key to actually run this") live in the context/access
+ * validators, not here, so `resolve` takes only the model id.
+ */
+
+import { zaiCodingPlanModelCapabilities, type ModelCapabilities } from '@tzurot/common-types';
+import type { OpenRouterModelCache } from './OpenRouterModelCache.js';
+
+export class ModelCapabilityService {
+  /**
+   * @param modelCache - OpenRouter model cache. May be `undefined` (not wired
+   *   in local dev / tests) — resolution then falls back to the static z.ai
+   *   catalog, and returns `null` for any OpenRouter-only model.
+   */
+  constructor(private readonly modelCache: OpenRouterModelCache | undefined) {}
+
+  /**
+   * Resolve `modelId`'s capabilities. Resolution priority:
+   *
+   * 1. **OpenRouter (authoritative).** If the model is in the OpenRouter cache,
+   *    its capability tags win — even for `z-ai/`-namespaced models that also
+   *    live on OpenRouter (e.g. `z-ai/glm-5.1`). Per project direction,
+   *    OpenRouter is the source of truth for any model it carries.
+   * 2. **z.ai coding-plan catalog.** For `z-ai/`-prefixed models absent from
+   *    OpenRouter (e.g. `z-ai/glm-5.2`), fall back to the static z.ai catalog
+   *    (text-only today). `zaiCodingPlanModelCapabilities` handles the
+   *    prefix-strip / case-normalize / non-member-null itself.
+   * 3. **null.** Unknown to both sources — the caller treats this as "can't
+   *    confirm," which fails closed for a vision gate.
+   *
+   * Returns `null` (not an error) when the OpenRouter cache is unavailable AND
+   * the model isn't a z.ai-catalog member, mirroring `getModelById`'s
+   * graceful-degrade contract (it returns null both on cache-miss and
+   * cache-unavailable).
+   */
+  async resolve(modelId: string): Promise<ModelCapabilities | null> {
+    const openRouterModel = await this.modelCache?.getModelById(modelId);
+    if (openRouterModel !== null && openRouterModel !== undefined) {
+      return {
+        supportsVision: openRouterModel.supportsVision,
+        supportsImageGeneration: openRouterModel.supportsImageGeneration,
+        supportsAudioInput: openRouterModel.supportsAudioInput,
+        supportsAudioOutput: openRouterModel.supportsAudioOutput,
+        contextLength: openRouterModel.contextLength,
+        source: 'openrouter',
+      };
+    }
+
+    // Not on OpenRouter (or cache unavailable): try the z.ai catalog, else null.
+    return zaiCodingPlanModelCapabilities(modelId);
+  }
+}

--- a/services/api-gateway/src/utils/configRouteHelpers.test.ts
+++ b/services/api-gateway/src/utils/configRouteHelpers.test.ts
@@ -234,6 +234,7 @@ describe('ensureNoNameCollision', () => {
       'NewName',
       globalScope,
       undefined,
+      undefined,
       undefined
     );
     expect(mockSendError).not.toHaveBeenCalled();
@@ -277,6 +278,7 @@ describe('ensureNoNameCollision', () => {
       'RenameTarget',
       globalScope,
       'existing-id-789',
+      undefined,
       undefined
     );
   });
@@ -296,6 +298,7 @@ describe('ensureNoNameCollision', () => {
     expect(service.checkNameExists).toHaveBeenCalledWith(
       'MyConfig',
       userScope,
+      undefined,
       undefined,
       undefined
     );
@@ -334,7 +337,13 @@ describe('ensureNoNameCollision', () => {
       formatCollisionMessage: _n => `irrelevant`,
     });
 
-    expect(service.checkNameExists).toHaveBeenCalledWith('Renamed', userScope, 'cfg-1', true);
+    expect(service.checkNameExists).toHaveBeenCalledWith(
+      'Renamed',
+      userScope,
+      'cfg-1',
+      true,
+      undefined
+    );
   });
 
   it('does not pass postIsGlobal when omitted (service receives undefined 4th arg)', async () => {
@@ -352,7 +361,29 @@ describe('ensureNoNameCollision', () => {
       'Created',
       userScope,
       undefined,
+      undefined,
       undefined
+    );
+  });
+
+  it('forwards kind to the service so collision checks are kind-scoped', async () => {
+    const service = {
+      checkNameExists: vi.fn().mockResolvedValue({ exists: false }),
+    };
+
+    await ensureNoNameCollision(mockRes, service, {
+      name: 'VisionPreset',
+      scope: globalScope,
+      kind: 'vision',
+      formatCollisionMessage: _n => `irrelevant`,
+    });
+
+    expect(service.checkNameExists).toHaveBeenCalledWith(
+      'VisionPreset',
+      globalScope,
+      undefined,
+      undefined,
+      'vision'
     );
   });
 });

--- a/services/api-gateway/src/utils/configRouteHelpers.ts
+++ b/services/api-gateway/src/utils/configRouteHelpers.ts
@@ -15,7 +15,7 @@
 
 import type { Response } from 'express';
 import type { z } from 'zod';
-import type { PrismaClient, EntityPermissions } from '@tzurot/common-types';
+import type { PrismaClient, EntityPermissions, ConfigKind } from '@tzurot/common-types';
 import { sendError } from './responseHelpers.js';
 import { sendZodError } from './zodHelpers.js';
 import { ErrorResponses } from './errorResponses.js';
@@ -188,7 +188,8 @@ interface NameExistsChecker<TScope> {
     name: string,
     scope: TScope,
     excludeId?: string,
-    postIsGlobal?: boolean
+    postIsGlobal?: boolean,
+    kind?: ConfigKind
   ): Promise<{ exists: boolean }>;
 }
 
@@ -221,14 +222,19 @@ export async function ensureNoNameCollision<TScope>(
      *  state would be `isGlobal: true`, so the check widens to the
      *  cross-user global namespace. Admin and create paths omit this. */
     postIsGlobal?: boolean;
+    /** Config kind to scope the collision check to. Names are unique per
+     *  `(kind, …)` (the partial-unique indexes), so a vision config named "X"
+     *  must NOT collide with a text config named "X". Pass `body.kind` on
+     *  create; omit (defaults text in the service) for text-only callers. */
+    kind?: ConfigKind;
     /** Caller-provided message formatter. Receives `name` (so the caller
      *  doesn't have to capture it in closure) and returns the full
      *  user-facing message. */
     formatCollisionMessage: (name: string) => string;
   }
 ): Promise<boolean> {
-  const { name, scope, excludeId, postIsGlobal, formatCollisionMessage } = options;
-  const nameCheck = await service.checkNameExists(name, scope, excludeId, postIsGlobal);
+  const { name, scope, excludeId, postIsGlobal, kind, formatCollisionMessage } = options;
+  const nameCheck = await service.checkNameExists(name, scope, excludeId, postIsGlobal, kind);
   if (nameCheck.exists) {
     sendError(res, ErrorResponses.nameCollision(formatCollisionMessage(name)));
     return false;

--- a/services/api-gateway/src/utils/llmConfigValidation.test.ts
+++ b/services/api-gateway/src/utils/llmConfigValidation.test.ts
@@ -16,6 +16,17 @@ vi.mock('./modelValidation.js', () => ({
   validateModelAndContextWindow: (...args: unknown[]) => mockValidateModelAndContextWindow(...args),
 }));
 
+// Control the capability resolver so the vision gate can be exercised without a
+// real OpenRouter cache. Each instance delegates to the shared mockResolve.
+const mockResolve = vi.fn();
+vi.mock('../services/ModelCapabilityService.js', () => ({
+  ModelCapabilityService: class {
+    async resolve(modelId: string) {
+      return mockResolve(modelId);
+    }
+  },
+}));
+
 const mockSendError = vi.fn();
 vi.mock('./responseHelpers.js', () => ({
   sendError: (...args: unknown[]) => mockSendError(...args),
@@ -141,7 +152,11 @@ describe('validateLlmConfigModelFields', () => {
       expect(mockGetById).not.toHaveBeenCalled();
     });
 
-    it('validates with body.model directly when provided', async () => {
+    it('validates with body.model directly, but fetches the row to derive the immutable kind', async () => {
+      // The update path never carries `kind` (it's immutable), so when a model
+      // is being set the helper fetches the row to learn the kind for the
+      // capability gate. The model itself still comes from body.model, not the row.
+      mockGetById.mockResolvedValue({ model: 'old-model', kind: 'text' });
       mockValidateModelAndContextWindow.mockResolvedValue({});
 
       const result = await validateLlmConfigModelFields({
@@ -152,13 +167,15 @@ describe('validateLlmConfigModelFields', () => {
       });
 
       expect(result).toBe(true);
-      expect(mockGetById).not.toHaveBeenCalled();
+      expect(mockGetById).toHaveBeenCalledWith('cfg-1');
       expect(mockValidateModelAndContextWindow).toHaveBeenCalledWith(
         mockModelCache,
         'claude-3-opus',
         undefined,
         false
       );
+      // text config → no capability check
+      expect(mockResolve).not.toHaveBeenCalled();
     });
 
     it('fetches current model when only contextWindowTokens is being updated', async () => {
@@ -182,7 +199,10 @@ describe('validateLlmConfigModelFields', () => {
       );
     });
 
-    it('uses body.model when both model and contextWindowTokens are provided', async () => {
+    it('uses body.model for context validation when both model and contextWindowTokens are provided', async () => {
+      // Model fallback isn't needed (body.model present), but the row is still
+      // fetched to derive the immutable kind for the capability gate.
+      mockGetById.mockResolvedValue({ model: 'old-model', kind: 'text' });
       mockValidateModelAndContextWindow.mockResolvedValue({});
 
       const result = await validateLlmConfigModelFields({
@@ -193,8 +213,7 @@ describe('validateLlmConfigModelFields', () => {
       });
 
       expect(result).toBe(true);
-      // Should use body.model, not fetch current
-      expect(mockGetById).not.toHaveBeenCalled();
+      // Context validation uses body.model, not the stored model.
       expect(mockValidateModelAndContextWindow).toHaveBeenCalledWith(
         mockModelCache,
         'new-model',
@@ -204,6 +223,8 @@ describe('validateLlmConfigModelFields', () => {
     });
 
     it('returns false and sends error when validation fails on update', async () => {
+      // body.model present → the helper fetches the row to derive the kind.
+      mockGetById.mockResolvedValue({ model: 'gpt-4', kind: 'text' });
       mockValidateModelAndContextWindow.mockResolvedValue({
         error: 'Context window exceeds 50% of model limit',
       });
@@ -240,6 +261,128 @@ describe('validateLlmConfigModelFields', () => {
         8000,
         false
       );
+    });
+  });
+
+  describe('vision capability gate', () => {
+    beforeEach(() => {
+      // Context-window validation passes for all capability-gate cases; we're
+      // isolating the capability check that runs after it.
+      mockValidateModelAndContextWindow.mockResolvedValue({});
+    });
+
+    it('accepts a vision config whose model is vision-capable (create path)', async () => {
+      mockResolve.mockResolvedValue({ supportsVision: true, source: 'openrouter' });
+
+      const result = await validateLlmConfigModelFields({
+        res: mockRes,
+        modelCache: mockModelCache,
+        body: { model: 'anthropic/claude-3.5-sonnet' },
+        kind: 'vision',
+      });
+
+      expect(result).toBe(true);
+      expect(mockResolve).toHaveBeenCalledWith('anthropic/claude-3.5-sonnet');
+      expect(mockSendError).not.toHaveBeenCalled();
+    });
+
+    it('rejects a vision config whose model is text-only', async () => {
+      mockResolve.mockResolvedValue({ supportsVision: false, source: 'openrouter' });
+
+      const result = await validateLlmConfigModelFields({
+        res: mockRes,
+        modelCache: mockModelCache,
+        body: { model: 'some/text-only-model' },
+        kind: 'vision',
+      });
+
+      expect(result).toBe(false);
+      expect(mockSendError).toHaveBeenCalledWith(
+        mockRes,
+        expect.objectContaining({ message: expect.stringContaining("doesn't support image input") })
+      );
+    });
+
+    it('rejects a vision config on a z.ai-only (text-only) model', async () => {
+      // z.ai coding-plan models resolve to text-only capabilities → fail closed.
+      mockResolve.mockResolvedValue({ supportsVision: false, source: 'zai' });
+
+      const result = await validateLlmConfigModelFields({
+        res: mockRes,
+        modelCache: mockModelCache,
+        body: { model: 'z-ai/glm-5.2' },
+        kind: 'vision',
+        hasZaiCodingKey: true,
+      });
+
+      expect(result).toBe(false);
+      expect(mockSendError).toHaveBeenCalledWith(
+        mockRes,
+        expect.objectContaining({ message: expect.stringContaining("doesn't support image input") })
+      );
+    });
+
+    it('rejects a vision config on a model unknown to all sources (fail closed)', async () => {
+      mockResolve.mockResolvedValue(null);
+
+      const result = await validateLlmConfigModelFields({
+        res: mockRes,
+        modelCache: mockModelCache,
+        body: { model: 'made-up/model' },
+        kind: 'vision',
+      });
+
+      expect(result).toBe(false);
+      expect(mockSendError).toHaveBeenCalledWith(
+        mockRes,
+        expect.objectContaining({ message: expect.stringContaining("Couldn't confirm") })
+      );
+    });
+
+    it('does not capability-check a text config (vision models are also text-capable)', async () => {
+      const result = await validateLlmConfigModelFields({
+        res: mockRes,
+        modelCache: mockModelCache,
+        body: { model: 'anthropic/claude-3.5-sonnet' },
+        kind: 'text',
+      });
+
+      expect(result).toBe(true);
+      expect(mockResolve).not.toHaveBeenCalled();
+    });
+
+    it('capability-checks the NEW model on a vision-config update, with kind from the row', async () => {
+      // Update path: kind is immutable, derived from the stored row (vision);
+      // the model being validated is the new body.model.
+      mockGetById.mockResolvedValue({ model: 'old-vision-model', kind: 'vision' });
+      mockResolve.mockResolvedValue({ supportsVision: true, source: 'openrouter' });
+
+      const result = await validateLlmConfigModelFields({
+        res: mockRes,
+        modelCache: mockModelCache,
+        body: { model: 'new-vision-model' },
+        fallback: { service: mockService, configId: 'cfg-vision' },
+      });
+
+      expect(result).toBe(true);
+      expect(mockGetById).toHaveBeenCalledWith('cfg-vision');
+      expect(mockResolve).toHaveBeenCalledWith('new-vision-model');
+    });
+
+    it('skips the capability check on a context-only update (model unchanged)', async () => {
+      // body.model omitted → no model is being set → unchanged model isn't
+      // re-validated, even on a vision config.
+      mockGetById.mockResolvedValue({ model: 'existing-vision-model', kind: 'vision' });
+
+      const result = await validateLlmConfigModelFields({
+        res: mockRes,
+        modelCache: mockModelCache,
+        body: { contextWindowTokens: 16000 },
+        fallback: { service: mockService, configId: 'cfg-vision' },
+      });
+
+      expect(result).toBe(true);
+      expect(mockResolve).not.toHaveBeenCalled();
     });
   });
 });

--- a/services/api-gateway/src/utils/llmConfigValidation.ts
+++ b/services/api-gateway/src/utils/llmConfigValidation.ts
@@ -16,9 +16,11 @@
  */
 
 import type { Response } from 'express';
+import { DEFAULT_CONFIG_KIND, toConfigKind, type ConfigKind } from '@tzurot/common-types';
 import { sendError } from './responseHelpers.js';
 import { ErrorResponses } from './errorResponses.js';
 import { validateModelAndContextWindow } from './modelValidation.js';
+import { ModelCapabilityService } from '../services/ModelCapabilityService.js';
 import type { OpenRouterModelCache } from '../services/OpenRouterModelCache.js';
 import type { LlmConfigService } from '../services/LlmConfigService.js';
 
@@ -71,6 +73,82 @@ export interface ValidateLlmConfigModelFieldsOptions {
     service: LlmConfigService;
     configId: string;
   };
+  /**
+   * Config kind, gating the vision capability check. Pass it explicitly on the
+   * **create** path (from `body.kind`). On the **update** path leave it
+   * undefined — kind is immutable (never in the update body), so the helper
+   * derives it from the existing row via `fallback`. When neither is available
+   * it defaults to {@link DEFAULT_CONFIG_KIND} (text), which never rejects.
+   */
+  kind?: ConfigKind;
+}
+
+/**
+ * Resolve the effective model + kind for validation. On the update path the
+ * stored row is the source of truth for both: the model fallback (when the body
+ * omits it, so contextWindowTokens can still be validated against a known model)
+ * AND the immutable kind (never in the update body, so only knowable from the
+ * row). A single getById serves both, fetched only when something needs it:
+ *  - model fallback: the body omits `model`.
+ *  - kind for the capability gate: a model IS being set and kind is unknown
+ *    (the update path never passes kind). A context-only edit doesn't need the
+ *    kind, so it isn't derived.
+ */
+async function resolveEffectiveModelAndKind(
+  opts: ValidateLlmConfigModelFieldsOptions
+): Promise<{ effectiveModel: string | undefined; effectiveKind: ConfigKind }> {
+  const { body, fallback, kind } = opts;
+  let effectiveModel = body.model;
+  let effectiveKind: ConfigKind = kind ?? DEFAULT_CONFIG_KIND;
+  if (fallback !== undefined) {
+    const needModelFallback = effectiveModel === undefined;
+    const needKind = kind === undefined && body.model !== undefined;
+    if (needModelFallback || needKind) {
+      const current = await fallback.service.getById(fallback.configId);
+      if (needModelFallback) {
+        effectiveModel = current?.model;
+      }
+      if (needKind && current !== null) {
+        effectiveKind = toConfigKind(current.kind);
+      }
+    }
+  }
+  return { effectiveModel, effectiveKind };
+}
+
+/**
+ * Vision capability gate — fail closed. A vision config's model MUST be confirmed
+ * vision-capable; the prod failure the epic targets is a vision config silently
+ * pointing at a text-only model (→ no image description → the LLM improvises).
+ * On failure sends a 400 and returns false; returns true when the model is
+ * confirmed vision-capable.
+ */
+async function ensureVisionCapableModel(
+  res: Response,
+  modelCache: OpenRouterModelCache | undefined,
+  model: string
+): Promise<boolean> {
+  const capabilities = await new ModelCapabilityService(modelCache).resolve(model);
+  if (capabilities === null) {
+    sendError(
+      res,
+      ErrorResponses.validationError(
+        `Couldn't confirm '${model}' supports image input (vision) — it isn't in the model catalog. ` +
+          `Choose a vision-capable model for a vision preset.`
+      )
+    );
+    return false;
+  }
+  if (!capabilities.supportsVision) {
+    sendError(
+      res,
+      ErrorResponses.validationError(
+        `Model '${model}' doesn't support image input (vision). Choose a vision-capable model for a vision preset.`
+      )
+    );
+    return false;
+  }
+  return true;
 }
 
 /**
@@ -97,14 +175,7 @@ export async function validateLlmConfigModelFields(
     return true;
   }
 
-  // Resolve effective model. Update path with body.model absent falls back to
-  // the currently-stored model so contextWindowTokens can still be validated
-  // against a known model.
-  let effectiveModel = body.model;
-  if (effectiveModel === undefined && fallback !== undefined) {
-    const current = await fallback.service.getById(fallback.configId);
-    effectiveModel = current?.model;
-  }
+  const { effectiveModel, effectiveKind } = await resolveEffectiveModelAndKind(opts);
 
   const result = await validateModelAndContextWindow(
     modelCache,
@@ -116,6 +187,14 @@ export async function validateLlmConfigModelFields(
   if (result.error !== undefined) {
     sendError(res, ErrorResponses.validationError(result.error));
     return false;
+  }
+
+  // Vision capability gate. Only runs when a model is actually being SET — create
+  // always sets one; update only when `body.model` is present — so a context-only
+  // edit doesn't re-validate an unchanged model. Text configs never reach here;
+  // vision models are also text-capable.
+  if (effectiveKind === 'vision' && body.model !== undefined) {
+    return ensureVisionCapableModel(res, modelCache, body.model);
   }
 
   return true;


### PR DESCRIPTION
## Phase 2 / S1b — Model Configuration Overhaul

S1 (#1376) made the config backend kind-aware, but nothing stopped a `kind='vision'` config from pointing at a **text-only** model — the exact failure the epic targets (a personality's "vision model" silently can't see images → no description → the LLM improvises). S1b adds the capability gate.

### What's in this PR

**`@tzurot/common-types`**
- New provider-agnostic `ModelCapabilities` shape + `ModelCapabilitySource` — the unified intermediate type so capability checks query *one* shape regardless of provider (first concrete step toward decoupling from OpenRouter).
- z.ai catalog (`ZaiCodingPlanModelInfo` / `ZAI_MODEL_CATALOG`) gains **optional** modality flags (omitted = text-only; all 6 current models stay text-only) + a `zaiCodingPlanModelCapabilities()` mapper.

**`@tzurot/api-gateway`**
- New `ModelCapabilityService.resolve(modelId)` — **OpenRouter authoritative** → z.ai catalog → `null` priority. Capabilities are a property of the *model*, not the user, so it takes only the model id (the z.ai-key/access concern stays in the context validator).
- `validateLlmConfigModelFields` gains a kind-derived **vision capability gate** (fail closed: unconfirmable model → reject). Kind comes from `body.kind` on create and is derived from the **immutable stored row** on update; the gate fires only when a model is actually being set, so a context-only edit doesn't re-validate an unchanged model. (Extracted into helpers to keep cognitive complexity within limits.)
- Create-path name-collision check is now **kind-scoped** (`ensureNoNameCollision` forwards `kind` → `checkNameExists`), since names are unique per `(kind, …)` — keeps the now-capability-validated create path correct.

### Design decisions (flagged for review)
- **Vision = fail-closed, incl. cache-down.** If capabilities can't be resolved (unknown model, or cache unavailable for an OpenRouter model), vision is rejected — asymmetric with context-window validation (which skips gracefully). For this niche path, correctness > availability; the error is transient + clear.
- **OpenRouter authoritative** even for z.ai-namespaced models that also live on OpenRouter (e.g. `z-ai/glm-5.1`); z.ai-only models (e.g. `glm-5.2`) resolve from the z.ai catalog (text-only today).
- **`ModelCapabilityService` constructed inline** in the validator (stateless wrapper over the `modelCache` it already receives) rather than DI-threaded through 4 routes — still an independently-tested class.

### Scope notes
- **Dormant until S2**: nothing sends `kind='vision'` to a route yet, but the path is reachable via the raw API and fully unit-tested. Same "foundation now, value next slice" shape as S1.
- **Deferred to S2** (per the theme's "split if it balloons"): the read/by-id route kind-scoping (`list`/`getById` `?kind=` param, `set-default`/`free-default`/`delete`/`update` `requireKind` threading). It's dormant plumbing better shaped + end-to-end tested with the commands that drive it.
- The seeded vision defaults (`VisionConfigBootstrap`) bypass route validation, so they're unaffected. Confirming their models are OR-vision-capable is an S2 edit-path concern (they're explicitly chosen multimodal models).

### Verification
- `pnpm --filter @tzurot/common-types test` ✅ (2298) · `pnpm --filter @tzurot/api-gateway test` ✅ (2193) · `pnpm quality` ✅ (monorepo typecheck, lint, depcruise, knip, cpd, backlog).
- New tests: z.ai capability mapper; `ModelCapabilityService` priority matrix; `validateLlmConfigModelFields` capability matrix (vision+capable→ok, +text-only→reject, +z.ai→reject, +unknown→reject, text→skip, create-kind vs update-row-derivation); `ensureNoNameCollision` kind forwarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)