### PR TITLE
feat(api-gateway): thread config kind through llm-config routes (S2a)

### DIFF
--- a/services/api-gateway/src/routes/admin/llm-config.test.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.test.ts
@@ -146,6 +146,44 @@ describe('Admin LLM Config Routes', () => {
       expect(response.body.configs[1].ownerId).toBeUndefined();
       expect(response.body.configs[1].isOwned).toBe(true);
     });
+
+    it('scopes the list to ?kind=vision', async () => {
+      prisma.llmConfig.findMany.mockResolvedValue([]);
+
+      const response = await request(app).get('/admin/llm-config?kind=vision');
+
+      expect(response.status).toBe(200);
+      expect(prisma.llmConfig.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ kind: 'vision' }) })
+      );
+    });
+
+    it('rejects an invalid ?kind= with 400', async () => {
+      const response = await request(app).get('/admin/llm-config?kind=audio');
+
+      expect(response.status).toBe(400);
+      expect(prisma.llmConfig.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('invalid ?kind= on by-id write routes', () => {
+    it.each([
+      { method: 'put' as const, path: '/admin/llm-config/cfg-1' },
+      { method: 'put' as const, path: '/admin/llm-config/cfg-1/set-default' },
+      { method: 'put' as const, path: '/admin/llm-config/cfg-1/set-free-default' },
+      { method: 'delete' as const, path: '/admin/llm-config/cfg-1' },
+    ])(
+      'rejects $method $path with 400 (kind parsed before any DB work)',
+      async ({ method, path }) => {
+        const url = `${path}?kind=audio`;
+        const response =
+          method === 'put' ? await request(app).put(url) : await request(app).delete(url);
+
+        expect(response.status).toBe(400);
+        // The kind gate runs before the config fetch, so nothing is touched.
+        expect(prisma.llmConfig.findUnique).not.toHaveBeenCalled();
+      }
+    );
   });
 
   describe('GET /admin/llm-config/:id', () => {
@@ -174,6 +212,33 @@ describe('Admin LLM Config Routes', () => {
       expect(response.body.config.name).toBe('Default Config');
       expect(response.body.config.isGlobal).toBe(true);
       expect(response.body.config.params).toEqual({ temperature: 0.7 });
+    });
+
+    it('returns a kind=vision config WITHOUT ?kind= (GET by id is kind-agnostic)', async () => {
+      // Unlike the write routes, GET-by-id has no kind gate — the id uniquely
+      // identifies the config, so a vision row is returned on the bare route.
+      prisma.llmConfig.findUnique.mockResolvedValue({
+        id: 'vision-cfg',
+        name: 'Vision Cfg',
+        description: 'vision',
+        model: 'qwen/qwen3-vl-30b-a3b-instruct',
+        provider: 'openrouter',
+        isGlobal: true,
+        isDefault: false,
+        isFreeDefault: false,
+        kind: 'vision',
+        advancedParameters: {},
+        maxMessages: 50,
+        maxAge: null,
+        maxImages: 10,
+        memoryScoreThreshold: { toNumber: () => 0.5 },
+        memoryLimit: 20,
+      });
+
+      const response = await request(app).get('/admin/llm-config/vision-cfg');
+
+      expect(response.status).toBe(200);
+      expect(response.body.config.id).toBe('vision-cfg');
     });
 
     it('should return context settings (maxMessages, maxAge, maxImages)', async () => {
@@ -553,6 +618,39 @@ describe('Admin LLM Config Routes', () => {
       });
     });
 
+    it('edits a kind=vision config when ?kind=vision is passed', async () => {
+      // requireKind:vision lets the vision row through the otherwise text-default gate.
+      prisma.llmConfig.findUnique.mockResolvedValue({
+        id: 'vision-cfg',
+        name: 'Vision Cfg',
+        isGlobal: true,
+        kind: 'vision',
+        memoryScoreThreshold: { toNumber: () => 0.5 },
+        memoryLimit: 20,
+      });
+      prisma.llmConfig.update.mockResolvedValue({
+        id: 'vision-cfg',
+        name: 'Vision Cfg',
+        model: 'qwen/qwen3-vl-30b-a3b-instruct',
+        provider: 'openrouter',
+        isGlobal: true,
+        isDefault: false,
+        memoryScoreThreshold: { toNumber: () => 0.5 },
+        memoryLimit: 20,
+      });
+
+      const response = await request(app)
+        .put('/admin/llm-config/vision-cfg?kind=vision')
+        .send({ model: 'qwen/qwen3-vl-30b-a3b-instruct' });
+
+      expect(response.status).toBe(200);
+      expect(prisma.llmConfig.update).toHaveBeenCalledWith({
+        where: { id: 'vision-cfg' },
+        data: { model: 'qwen/qwen3-vl-30b-a3b-instruct' },
+        select: expect.any(Object),
+      });
+    });
+
     it('should accept memory settings in update (Phase 1 parity fix)', async () => {
       // This test verifies the Phase 1 fix - memory settings were previously missing from admin
       prisma.llmConfig.findUnique.mockResolvedValue({
@@ -733,9 +831,10 @@ describe('Admin LLM Config Routes', () => {
       expect(response.body.message).toMatch(/only global/i);
     });
 
-    it('rejects a kind=vision config (vision is seed/DB-only on the text surface)', async () => {
-      // The requireKind:'text' gate makes a vision UUID look not-found here, so an admin
-      // can't flip the vision default through the text-preset admin surface in Phase 1.
+    it('rejects a kind=vision config without ?kind=vision (requireKind defaults to text)', async () => {
+      // requireKind defaults to text, so a vision UUID looks not-found on the
+      // default text surface — an admin can't accidentally flip the vision
+      // default by hitting this route without explicitly asking for vision.
       prisma.llmConfig.findUnique.mockResolvedValue({
         id: 'vision-default',
         name: 'vision-default',
@@ -746,8 +845,33 @@ describe('Admin LLM Config Routes', () => {
       const response = await request(app).put('/admin/llm-config/vision-default/set-default');
 
       expect(response.status).toBe(404);
-      // The vision default must NOT have been touched through the text surface.
+      // The vision default must NOT have been touched on the default text surface.
       expect(prisma.llmConfig.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('sets a kind=vision config as the vision default when ?kind=vision is passed', async () => {
+      // ?kind=vision must let the vision row through requireKind AND scope the
+      // setAsDefault updateMany clear to kind='vision' (not 'text'), so the
+      // text default is never touched.
+      prisma.llmConfig.findUnique.mockResolvedValue({
+        id: 'vision-default',
+        name: 'vision-default',
+        isGlobal: true,
+        kind: 'vision',
+      });
+      prisma.llmConfig.updateMany.mockResolvedValue({ count: 1 });
+      prisma.llmConfig.update.mockResolvedValue({ id: 'vision-default', isDefault: true });
+
+      const response = await request(app).put(
+        '/admin/llm-config/vision-default/set-default?kind=vision'
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.configName).toBe('vision-default');
+      expect(prisma.llmConfig.updateMany).toHaveBeenCalledWith({
+        where: { isDefault: true, kind: 'vision' },
+        data: { isDefault: false },
+      });
     });
   });
 
@@ -777,6 +901,32 @@ describe('Admin LLM Config Routes', () => {
       // Verify it clears existing free default
       expect(prisma.llmConfig.updateMany).toHaveBeenCalledWith({
         where: { isFreeDefault: true, kind: 'text' },
+        data: { isFreeDefault: false },
+      });
+    });
+
+    it('sets a kind=vision free config as the vision free default when ?kind=vision is passed', async () => {
+      prisma.llmConfig.findUnique.mockResolvedValue({
+        id: 'vision-free',
+        name: 'Vision Free',
+        isGlobal: true,
+        kind: 'vision',
+        model: 'qwen/qwen3-vl-30b-a3b-instruct:free',
+        provider: 'openrouter',
+        memoryScoreThreshold: { toNumber: () => 0.5 },
+        memoryLimit: 20,
+      });
+      prisma.llmConfig.updateMany.mockResolvedValue({ count: 1 });
+      prisma.llmConfig.update.mockResolvedValue({ id: 'vision-free', isFreeDefault: true });
+
+      const response = await request(app).put(
+        '/admin/llm-config/vision-free/set-free-default?kind=vision'
+      );
+
+      expect(response.status).toBe(200);
+      // setAsFreeDefault is kind-scoped: clears only the existing VISION free default.
+      expect(prisma.llmConfig.updateMany).toHaveBeenCalledWith({
+        where: { isFreeDefault: true, kind: 'vision' },
         data: { isFreeDefault: false },
       });
     });

--- a/services/api-gateway/src/routes/admin/llm-config.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.ts
@@ -33,6 +33,7 @@ import { enrichWithModelContext } from '../../utils/modelValidation.js';
 import { validateLlmConfigModelFields } from '../../utils/llmConfigValidation.js';
 import {
   parseBodyOrSendError,
+  parseConfigKindQuery,
   findGlobalConfigOrSendError,
   findAdminUserOrSendError,
   ensureNoNameCollision,
@@ -51,12 +52,17 @@ const CONFIG_LABEL = 'configs';
 // --- Handler Factories ---
 
 function createListHandler(service: LlmConfigService) {
-  return async (_req: Request, res: Response) => {
-    const configs = (await service.list({ type: 'GLOBAL' })).map(raw =>
+  return async (req: Request, res: Response) => {
+    const kind = parseConfigKindQuery(res, req.query);
+    if (kind === null) {
+      return;
+    }
+
+    const configs = (await service.list({ type: 'GLOBAL' }, kind)).map(raw =>
       withAdminOwnership(service.formatConfigSummary(raw))
     );
 
-    logger.info({ count: configs.length }, 'Listed all configs');
+    logger.info({ count: configs.length, kind }, 'Listed all configs');
     sendCustomSuccess(res, { configs }, StatusCodes.OK);
   };
 }
@@ -65,6 +71,9 @@ function createGetHandler(service: LlmConfigService, modelCache?: OpenRouterMode
   return async (req: Request, res: Response) => {
     const configId = getRequiredParam(req.params.id, 'id');
 
+    // Kind-agnostic by id: a config's kind is intrinsic to its unique id, so a
+    // by-id fetch returns it regardless of kind (no `?kind=` gate). Only the
+    // list endpoint scopes by kind (no id, so the caller states which kind).
     const config = await service.getById(configId);
     if (config === null) {
       return sendError(res, ErrorResponses.notFound(CONFIG_RESOURCE));
@@ -140,6 +149,11 @@ function createEditConfigHandler(
   return async (req: Request, res: Response) => {
     const configId = getRequiredParam(req.params.id, 'id');
 
+    const kind = parseConfigKindQuery(res, req.query);
+    if (kind === null) {
+      return;
+    }
+
     const body = parseBodyOrSendError(res, LlmConfigUpdateSchema, req.body);
     if (body === null) {
       return;
@@ -168,7 +182,7 @@ function createEditConfigHandler(
         notFoundResource: CONFIG_RESOURCE,
         resourceLabel: CONFIG_LABEL,
         operation: 'edit',
-        requireKind: 'text',
+        requireKind: kind,
       }
     );
     if (existing === null) {
@@ -207,6 +221,11 @@ function createSetDefaultHandler(service: LlmConfigService, prisma: PrismaClient
   return async (req: Request, res: Response) => {
     const configId = getRequiredParam(req.params.id, 'id');
 
+    const kind = parseConfigKindQuery(res, req.query);
+    if (kind === null) {
+      return;
+    }
+
     const config = await findGlobalConfigOrSendError(
       res,
       () =>
@@ -218,7 +237,7 @@ function createSetDefaultHandler(service: LlmConfigService, prisma: PrismaClient
         notFoundResource: CONFIG_RESOURCE,
         resourceLabel: CONFIG_LABEL,
         operation: 'set as system default',
-        requireKind: 'text',
+        requireKind: kind,
       }
     );
     if (config === null) {
@@ -236,6 +255,11 @@ function createSetFreeDefaultHandler(service: LlmConfigService, prisma: PrismaCl
   return async (req: Request, res: Response) => {
     const configId = getRequiredParam(req.params.id, 'id');
 
+    const kind = parseConfigKindQuery(res, req.query);
+    if (kind === null) {
+      return;
+    }
+
     const config = await findGlobalConfigOrSendError(
       res,
       () =>
@@ -247,7 +271,7 @@ function createSetFreeDefaultHandler(service: LlmConfigService, prisma: PrismaCl
         notFoundResource: CONFIG_RESOURCE,
         resourceLabel: CONFIG_LABEL,
         operation: 'set as free tier default',
-        requireKind: 'text',
+        requireKind: kind,
       }
     );
     if (config === null) {
@@ -274,6 +298,11 @@ function createDeleteConfigHandler(service: LlmConfigService, prisma: PrismaClie
   return async (req: Request, res: Response) => {
     const configId = getRequiredParam(req.params.id, 'id');
 
+    const kind = parseConfigKindQuery(res, req.query);
+    if (kind === null) {
+      return;
+    }
+
     const config = await findGlobalConfigOrSendError(
       res,
       () =>
@@ -292,7 +321,7 @@ function createDeleteConfigHandler(service: LlmConfigService, prisma: PrismaClie
         notFoundResource: CONFIG_RESOURCE,
         resourceLabel: CONFIG_LABEL,
         operation: 'delete',
-        requireKind: 'text',
+        requireKind: kind,
       }
     );
     if (config === null) {

--- a/services/api-gateway/src/routes/user/llm-config.test.ts
+++ b/services/api-gateway/src/routes/user/llm-config.test.ts
@@ -161,10 +161,15 @@ import { getRouteHandler, findRoute } from '../../test/expressRouterUtils.js';
 import { computeLlmConfigPermissions, type PrismaClient } from '@tzurot/common-types';
 
 // Helper to create mock request/response
-function createMockReqRes(body: Record<string, unknown> = {}, params: Record<string, string> = {}) {
+function createMockReqRes(
+  body: Record<string, unknown> = {},
+  params: Record<string, string> = {},
+  query: Record<string, unknown> = {}
+) {
   const req = {
     body,
     params,
+    query,
     userId: 'discord-user-123',
     provisionedUserId: 'user-uuid-123',
     provisionedDefaultPersonaId: 'persona-uuid-default',
@@ -299,6 +304,40 @@ describe('/user/llm-config routes', () => {
           configs: [expect.objectContaining({ id: 'user-config-1', isOwned: true })],
         })
       );
+    });
+
+    it('scopes the list query to ?kind=vision', async () => {
+      mockPrisma.llmConfig.findMany.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
+      const handler = getHandler(router, 'get', '/');
+      const { req, res } = createMockReqRes({}, {}, { kind: 'vision' });
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      // User scope fires TWO queries (global + own). Assert BOTH carry the kind
+      // — `toHaveBeenCalledWith` alone would pass if only one did.
+      expect(mockPrisma.llmConfig.findMany).toHaveBeenCalledTimes(2);
+      expect(mockPrisma.llmConfig.findMany).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ where: expect.objectContaining({ kind: 'vision' }) })
+      );
+      expect(mockPrisma.llmConfig.findMany).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ where: expect.objectContaining({ kind: 'vision' }) })
+      );
+    });
+
+    it('rejects an invalid ?kind= with 400', async () => {
+      const router = createLlmConfigRoutes({ prisma: mockPrisma as unknown as PrismaClient });
+      const handler = getHandler(router, 'get', '/');
+      const { req, res } = createMockReqRes({}, {}, { kind: 'audio' });
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockPrisma.llmConfig.findMany).not.toHaveBeenCalled();
     });
   });
 
@@ -984,6 +1023,49 @@ describe('/user/llm-config routes', () => {
             params: { temperature: 0.9 },
           }),
         })
+      );
+    });
+
+    it('scopes the rename collision check to the config kind (vision)', async () => {
+      // Renaming a vision config to a name that only exists as a TEXT config must
+      // NOT collide — the collision check derives kind from the immutable row.
+      mockPrisma.llmConfig.findUnique.mockResolvedValue({
+        id: 'vision-cfg',
+        ownerId: 'user-uuid-123',
+        isGlobal: false,
+        name: 'Old Vision',
+        kind: 'vision',
+        memoryScoreThreshold: { toNumber: () => 0.5 },
+        memoryLimit: 20,
+      });
+      // No collision in the VISION namespace.
+      mockPrisma.llmConfig.findFirst.mockResolvedValue(null);
+      mockPrisma.llmConfig.update.mockResolvedValue({
+        id: 'vision-cfg',
+        name: 'Shared Name',
+        model: 'qwen/qwen3-vl-30b-a3b-instruct',
+        provider: 'openrouter',
+        isGlobal: false,
+        isDefault: false,
+        isFreeDefault: false,
+        ownerId: 'user-uuid-123',
+        memoryScoreThreshold: { toNumber: () => 0.5 },
+        memoryLimit: 20,
+      });
+
+      const router = createLlmConfigRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        llmConfigCacheInvalidation: mockCacheInvalidation,
+      });
+      const handler = getHandler(router, 'put', '/:id');
+      const { req, res } = createMockReqRes({ name: 'Shared Name' }, { id: 'vision-cfg' });
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      // The collision query must be scoped to kind='vision', not text.
+      expect(mockPrisma.llmConfig.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ kind: 'vision' }) })
       );
     });
 

--- a/services/api-gateway/src/routes/user/llm-config.ts
+++ b/services/api-gateway/src/routes/user/llm-config.ts
@@ -17,6 +17,7 @@ import {
   isBotOwner,
   type LlmConfigSummary,
   type PrismaClient,
+  toConfigKind,
   computeLlmConfigPermissions,
   AIProvider,
   // Shared schemas from common-types - single source of truth
@@ -32,6 +33,7 @@ import { isPrismaUniqueConstraintError } from '../../utils/prismaErrors.js';
 import { getRequiredParam } from '../../utils/requestParams.js';
 import {
   parseBodyOrSendError,
+  parseConfigKindQuery,
   findConfigOrSendNotFound,
   ensureNoNameCollision,
 } from '../../utils/configRouteHelpers.js';
@@ -72,12 +74,17 @@ function createListHandler(service: LlmConfigService) {
 
     // Admin sees all presets (same pattern as character browse)
     // Regular users see global + their own
+    const kind = parseConfigKindQuery(res, req.query);
+    if (kind === null) {
+      return;
+    }
+
     const isAdmin = isBotOwner(discordUserId);
     const scope: LlmConfigScope = isAdmin
       ? { type: 'GLOBAL' }
       : { type: 'USER', userId, discordId: discordUserId };
 
-    const rawConfigs = await service.list(scope);
+    const rawConfigs = await service.list(scope, kind);
 
     // Enrich with ownership and permissions (user-specific). `formatConfigSummary`
     // projects only public fields — `c.ownerId` is read here for the ownership
@@ -270,7 +277,11 @@ async function buildUpdatePatchOrSendCollision<
   service: LlmConfigService;
   req: ProvisionedRequest;
   body: TBody;
-  config: { name: string; isGlobal: boolean; ownerId: string };
+  /** Includes `kind` (the immutable discriminator) so the name-collision check
+   *  is scoped to the config's kind — a vision rename collides only against
+   *  vision names, never text. Derived from the row, not the request: kind is
+   *  intrinsic to the config and can't be changed by an update. */
+  config: { name: string; isGlobal: boolean; ownerId: string; kind: string };
   configId: string;
   isOwnedByRequester: boolean;
 }): Promise<TBody | null> {
@@ -298,6 +309,7 @@ async function buildUpdatePatchOrSendCollision<
       scope: { type: 'USER', userId: config.ownerId, discordId: discordUserId },
       excludeId: configId,
       postIsGlobal,
+      kind: toConfigKind(config.kind),
       formatCollisionMessage: n =>
         buildCollisionMessage({
           effectiveName: n,
@@ -343,6 +355,10 @@ function createUpdateHandler(
       return;
     }
 
+    // User by-id routes are kind-agnostic: the id unambiguously identifies the
+    // config of whatever kind, and kind is immutable. A `?kind=` query param
+    // here is intentionally ignored — the collision check below derives kind
+    // from the stored row, not the request.
     const config = await findConfigOrSendNotFound(
       res,
       () => service.getById(configId),

--- a/services/api-gateway/src/utils/configRouteHelpers.test.ts
+++ b/services/api-gateway/src/utils/configRouteHelpers.test.ts
@@ -29,6 +29,7 @@ vi.mock('./errorResponses.js', () => ({
 
 import {
   parseBodyOrSendError,
+  parseConfigKindQuery,
   findConfigOrSendNotFound,
   findGlobalConfigOrSendError,
   findAdminUserOrSendError,
@@ -40,6 +41,34 @@ import {
 const mockRes = {} as Response;
 
 beforeEach(() => vi.resetAllMocks());
+
+describe('parseConfigKindQuery', () => {
+  it('returns the parsed kind for a valid ?kind=vision', () => {
+    expect(parseConfigKindQuery(mockRes, { kind: 'vision' })).toBe('vision');
+    expect(mockSendZodError).not.toHaveBeenCalled();
+  });
+
+  it('returns text for a valid ?kind=text', () => {
+    expect(parseConfigKindQuery(mockRes, { kind: 'text' })).toBe('text');
+  });
+
+  it('defaults to text when the param is absent', () => {
+    expect(parseConfigKindQuery(mockRes, {})).toBe('text');
+    expect(mockSendZodError).not.toHaveBeenCalled();
+  });
+
+  it('defaults to text when the query object itself is undefined', () => {
+    // Express always populates req.query, but the helper must not 400 purely
+    // because the object is missing (e.g. in unit tests / edge cases).
+    expect(parseConfigKindQuery(mockRes, undefined)).toBe('text');
+    expect(mockSendZodError).not.toHaveBeenCalled();
+  });
+
+  it('sends a Zod error and returns null for an invalid kind', () => {
+    expect(parseConfigKindQuery(mockRes, { kind: 'audio' })).toBeNull();
+    expect(mockSendZodError).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe('parseBodyOrSendError', () => {
   const schema = z.object({ name: z.string(), count: z.number() });

--- a/services/api-gateway/src/utils/configRouteHelpers.ts
+++ b/services/api-gateway/src/utils/configRouteHelpers.ts
@@ -14,8 +14,14 @@
  */
 
 import type { Response } from 'express';
-import type { z } from 'zod';
-import type { PrismaClient, EntityPermissions, ConfigKind } from '@tzurot/common-types';
+import { z } from 'zod';
+import {
+  CONFIG_KINDS,
+  DEFAULT_CONFIG_KIND,
+  type PrismaClient,
+  type EntityPermissions,
+  type ConfigKind,
+} from '@tzurot/common-types';
 import { sendError } from './responseHelpers.js';
 import { sendZodError } from './zodHelpers.js';
 import { ErrorResponses } from './errorResponses.js';
@@ -45,6 +51,31 @@ export function parseBodyOrSendError<T>(
     return null;
   }
   return result.data;
+}
+
+/** Zod schema for the optional `?kind=` config-kind query param. */
+const ConfigKindQuerySchema = z.object({
+  kind: z.enum(CONFIG_KINDS).default(DEFAULT_CONFIG_KIND),
+});
+
+/**
+ * Parse the optional `?kind=` query param (`text` | `vision`), defaulting to
+ * `text`. Lets the read / by-id config routes scope to a kind so the SAME
+ * handler serves both — vision callers pass `?kind=vision`, everyone else gets
+ * the text default (so existing callers are unchanged). On an invalid value
+ * sends a Zod-shaped 400 and returns `null` (caller returns early); an absent
+ * param resolves to the default, never null.
+ */
+export function parseConfigKindQuery(res: Response, query: unknown): ConfigKind | null {
+  // `query ?? {}`: an absent query object means "no params" → the text default,
+  // not a 400. Express always populates `req.query` (at least `{}`), but guard
+  // the undefined case so the helper never rejects purely for a missing object.
+  const result = ConfigKindQuerySchema.safeParse(query ?? {});
+  if (!result.success) {
+    sendZodError(res, result.error);
+    return null;
+  }
+  return result.data.kind;
 }
 
 /**
@@ -94,12 +125,14 @@ export async function findGlobalConfigOrSendError<T extends { isGlobal: boolean;
     operation: GlobalGuardOperation;
     /**
      * When set, reject (as not-found) any row whose `kind` is present AND differs.
-     * Gates the text-preset admin surface from editing/deleting/(un)defaulting
-     * kind='vision' rows, which are seed/DB-only in Phase 1. The `kind !== undefined`
-     * leniency is a production no-op (the column is NOT NULL with a default) — it only
-     * spares callers/tests that don't select `kind`. Requires `kind` in the select.
+     * Gates the bare admin surface (no `?kind=`, which defaults to text) to text
+     * rows: a vision config 404s unless the caller explicitly passes
+     * `?kind=vision`, so the text surface can't accidentally edit / delete /
+     * (un)default a vision row. The `kind !== undefined` leniency is a production
+     * no-op (the column is NOT NULL with a default) — it only spares callers/tests
+     * that don't select `kind`. Requires `kind` in the select.
      */
-    requireKind?: string;
+    requireKind?: ConfigKind;
   }
 ): Promise<T | null> {
   const row = await fetchRow();

--- a/services/api-gateway/src/utils/llmConfigValidation.ts
+++ b/services/api-gateway/src/utils/llmConfigValidation.ts
@@ -111,6 +111,10 @@ async function resolveEffectiveModelAndKind(
       if (needKind && current !== null) {
         effectiveKind = toConfigKind(current.kind);
       }
+      // If `current` is null here (the config doesn't exist), effectiveKind stays
+      // the text default, so the vision gate is skipped — which is harmless: the
+      // update route's own fetch returns a clean 404 right after. We deliberately
+      // don't 404 here; existence is the route's concern, not the validator's.
     }
   }
   return { effectiveModel, effectiveKind };


### PR DESCRIPTION
## Phase 2 / S2a — Model Configuration Overhaul

S1/S1b made the config backend kind-aware. S2a threads the request's `kind` through the routes so vision configs can be **managed** via the existing surface — and an admin can set a **global vision default in one action** (the epic's core motivation).

### Design — kind is intrinsic to a config's unique id

- **LIST** (admin + user): scope by a `?kind=` query param (default `text`) via a new `parseConfigKindQuery` helper. The picker must not mix kinds; this is the *only* `?kind=` consumer.
- **Admin by-id writes** (edit / set-default / free-default / delete): the Phase-1 `requireKind:'text'` gate is **parameterized** to `requireKind: kind`. It still defaults text — a vision row 404s on the bare route, preserving the text-surface protection the gate was deliberately added for (and keeping its two guard tests green) — but `?kind=vision` now lets an admin manage vision configs, including setting the global vision default (`setAsDefault` was already kind-scoped).
- **User by-id** (get / update / delete): kept **kind-agnostic**. These never had a kind gate (they gate on permissions), and a by-id op is unambiguous (the id determines the kind). The update name-collision check derives kind from the **immutable stored row**, so a vision rename collides only against vision names.

This asymmetry is principled: thread `requireKind` where it already existed (admin's deliberate gate), don't bolt a gate onto routes that never had one (user). It also keeps `user/llm-config.ts` within the max-lines limit.

### Scope

- **Deferred to S2b**: the vision-aware override **write paths** (`defaultVisionConfigId` / `visionConfigId` in `model-override.ts`) — a distinct concern (config *selection* vs *CRUD*), shipped with the commands that drive them. Global vision default already works here via the admin set-default route.
- Also folds in the #1377 null-config comment in `resolveEffectiveModelAndKind`.
- The `getById` double-trip + `NameExistsChecker` options-object notes (#1377) and personality-level default write-routes remain backlogged for S2b / future.

### Verification
- `pnpm --filter @tzurot/api-gateway test` ✅ (2201) · `pnpm test:component` ✅ (446) · `pnpm quality` ✅.
- New tests: `parseConfigKindQuery` matrix; user list `?kind=vision` scoping + invalid-kind 400; admin set-default `?kind=vision` sets the global vision default (positive) alongside the existing bare-route 404 guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)