### PR TITLE
feat(api-gateway): vision-aware user override writes (S2b)

### DIFF
--- a/services/api-gateway/src/routes/user/model-override.test.ts
+++ b/services/api-gateway/src/routes/user/model-override.test.ts
@@ -76,10 +76,15 @@ import { getRouteHandler, findRoute } from '../../test/expressRouterUtils.js';
 import type { PrismaClient } from '@tzurot/common-types';
 
 // Helper to create mock request/response
-function createMockReqRes(body: Record<string, unknown> = {}, params: Record<string, string> = {}) {
+function createMockReqRes(
+  body: Record<string, unknown> = {},
+  params: Record<string, string> = {},
+  query: Record<string, unknown> = {}
+) {
   const req = {
     body,
     params,
+    query,
     userId: 'discord-user-123',
     provisionedUserId: 'user-uuid-123',
     provisionedDefaultPersonaId: 'persona-uuid-default',
@@ -720,7 +725,7 @@ describe('/user/model-override routes', () => {
       await handler(req, res);
 
       expect(mockPrisma.llmConfig.findFirst).toHaveBeenCalledWith({
-        where: { isFreeDefault: true },
+        where: { isFreeDefault: true, kind: 'text' },
         select: { id: true, name: true },
       });
       expect(res.json).toHaveBeenCalledWith(
@@ -795,6 +800,167 @@ describe('/user/model-override routes', () => {
 
       await handler(req, res);
 
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+  });
+
+  describe('vision kind branching', () => {
+    const VISION_CFG = '33333333-3333-4333-a333-333333333333';
+    const PERSONALITY = '11111111-1111-4111-a111-111111111111';
+
+    it('PUT /default writes defaultVisionConfigId when the config is kind=vision', async () => {
+      mockPrisma.llmConfig.findFirst.mockResolvedValue({
+        id: VISION_CFG,
+        name: 'Vision Cfg',
+        kind: 'vision',
+      });
+
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
+      const handler = getHandler(router, 'put', '/default');
+      const { req, res } = createMockReqRes({ configId: VISION_CFG });
+
+      await handler(req, res);
+
+      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-uuid-123' },
+        data: { defaultVisionConfigId: VISION_CFG },
+      });
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('PUT / writes visionConfigId on a per-personality override for a kind=vision config', async () => {
+      mockPrisma.personality.findFirst.mockResolvedValue({ id: PERSONALITY, name: 'Lilith' });
+      mockPrisma.llmConfig.findFirst.mockResolvedValue({
+        id: VISION_CFG,
+        name: 'Vision Cfg',
+        kind: 'vision',
+      });
+      mockPrisma.userPersonalityConfig.upsert.mockResolvedValue({
+        personalityId: PERSONALITY,
+        personality: { name: 'Lilith' },
+        llmConfigId: null,
+        llmConfig: null,
+        visionConfigId: VISION_CFG,
+        visionConfig: { name: 'Vision Cfg' },
+      });
+
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
+      const handler = getHandler(router, 'put', '/');
+      const { req, res } = createMockReqRes({ personalityId: PERSONALITY, configId: VISION_CFG });
+
+      await handler(req, res);
+
+      expect(mockPrisma.userPersonalityConfig.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({ visionConfigId: VISION_CFG }),
+          update: { visionConfigId: VISION_CFG },
+        })
+      );
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          override: expect.objectContaining({ configId: VISION_CFG, configName: 'Vision Cfg' }),
+        })
+      );
+    });
+
+    it('GET /default?kind=vision returns the vision default (text default ignored)', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({
+        defaultLlmConfigId: 'text-cfg',
+        defaultLlmConfig: { name: 'Text' },
+        defaultVisionConfigId: VISION_CFG,
+        defaultVisionConfig: { name: 'Vision Cfg' },
+      });
+
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
+      const handler = getHandler(router, 'get', '/default');
+      const { req, res } = createMockReqRes({}, {}, { kind: 'vision' });
+
+      await handler(req, res);
+
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          default: { configId: VISION_CFG, configName: 'Vision Cfg' },
+        })
+      );
+    });
+
+    it('DELETE /default?kind=vision clears only the vision default + scopes the free fallback', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({
+        defaultLlmConfigId: 'text-cfg',
+        defaultVisionConfigId: VISION_CFG,
+      });
+      mockPrisma.llmConfig.findFirst.mockResolvedValue({ id: 'vision-free', name: 'Vision Free' });
+
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
+      const handler = getHandler(router, 'delete', '/default');
+      const { req, res } = createMockReqRes({}, {}, { kind: 'vision' });
+
+      await handler(req, res);
+
+      // Exactly one update, targeting ONLY the vision FK — the text default is
+      // never touched (the "clears only" guarantee).
+      expect(mockPrisma.user.update).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-uuid-123' },
+        data: { defaultVisionConfigId: null },
+      });
+      // The free-default fallback lookup is scoped to the cleared kind.
+      expect(mockPrisma.llmConfig.findFirst).toHaveBeenCalledWith({
+        where: { isFreeDefault: true, kind: 'vision' },
+        select: { id: true, name: true },
+      });
+    });
+
+    it('GET /?kind=vision lists vision overrides', async () => {
+      mockPrisma.userPersonalityConfig.findMany.mockResolvedValue([
+        {
+          personalityId: PERSONALITY,
+          personality: { name: 'Lilith' },
+          llmConfigId: null,
+          llmConfig: null,
+          visionConfigId: VISION_CFG,
+          visionConfig: { name: 'Vision Cfg' },
+        },
+      ]);
+
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
+      const handler = getHandler(router, 'get', '/');
+      const { req, res } = createMockReqRes({}, {}, { kind: 'vision' });
+
+      await handler(req, res);
+
+      expect(mockPrisma.userPersonalityConfig.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ visionConfigId: { not: null } }),
+        })
+      );
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          overrides: [expect.objectContaining({ configId: VISION_CFG, configName: 'Vision Cfg' })],
+        })
+      );
+    });
+
+    it('DELETE /:personalityId?kind=vision clears only the vision override', async () => {
+      mockPrisma.userPersonalityConfig.findFirst.mockResolvedValue({
+        id: 'upc-1',
+        llmConfigId: 'text-cfg',
+        visionConfigId: VISION_CFG,
+        personality: { name: 'Lilith' },
+      });
+
+      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
+      const handler = getHandler(router, 'delete', '/:personalityId');
+      const { req, res } = createMockReqRes({}, { personalityId: PERSONALITY }, { kind: 'vision' });
+
+      await handler(req, res);
+
+      // Exactly one update, targeting ONLY the vision override FK.
+      expect(mockPrisma.userPersonalityConfig.update).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.userPersonalityConfig.update).toHaveBeenCalledWith({
+        where: { id: 'upc-1' },
+        data: { visionConfigId: null },
+      });
       expect(res.status).toHaveBeenCalledWith(200);
     });
   });

--- a/services/api-gateway/src/routes/user/model-override.ts
+++ b/services/api-gateway/src/routes/user/model-override.ts
@@ -16,6 +16,8 @@ import { StatusCodes } from 'http-status-codes';
 import {
   createLogger,
   generateUserPersonalityConfigUuid,
+  toConfigKind,
+  type ConfigKind,
   type PrismaClient,
   type ModelOverrideSummary,
   type UserDefaultConfig,
@@ -24,6 +26,7 @@ import {
 } from '@tzurot/common-types';
 import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
+import { parseConfigKindQuery } from '../../utils/configRouteHelpers.js';
 import { tryInvalidateCache } from '../../utils/configOverrideHelpers.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
@@ -37,20 +40,25 @@ const logger = createLogger('user-model-override');
 
 /**
  * Verify that the given LLM config exists and the user can access it (global or owned).
- * Returns the config if accessible, null otherwise.
+ * Returns the config (incl. its `kind`) if accessible, null otherwise. The set
+ * handlers branch on `kind` — a config's kind is intrinsic to its id, so the
+ * write targets the matching FK column (text vs vision).
  */
 async function verifyConfigAccess(
   prisma: PrismaClient,
   configId: string,
   userId: string
-): Promise<{ id: string; name: string } | null> {
-  return prisma.llmConfig.findFirst({
+): Promise<{ id: string; name: string; kind: ConfigKind } | null> {
+  const row = await prisma.llmConfig.findFirst({
     where: {
       id: configId,
       OR: [{ isGlobal: true }, { ownerId: userId }],
     },
-    select: { id: true, name: true },
+    select: { id: true, name: true, kind: true },
   });
+  // Narrow the raw DB string to ConfigKind at the boundary (toConfigKind floors
+  // an unexpected value to text + logs), so callers get an exhaustive-checkable kind.
+  return row === null ? null : { ...row, kind: toConfigKind(row.kind) };
 }
 
 /** GET /api/user/model-override — list all user model overrides */
@@ -60,16 +68,26 @@ export const handleListModelOverrides = (deps: RouteDeps): RequestHandler => {
     const discordUserId = req.userId;
     const userId = resolveProvisionedUserId(req);
 
+    const kind = parseConfigKindQuery(res, req.query);
+    if (kind === null) {
+      return;
+    }
+    const isVision = kind === 'vision';
+
+    // Filter by the requested kind's FK, but select BOTH FK pairs (fixed shape —
+    // a conditional select would yield a union return type), then pick below.
     const overrides = await prisma.userPersonalityConfig.findMany({
       where: {
         userId,
-        llmConfigId: { not: null },
+        ...(isVision ? { visionConfigId: { not: null } } : { llmConfigId: { not: null } }),
       },
       select: {
         personalityId: true,
         personality: { select: { name: true } },
         llmConfigId: true,
         llmConfig: { select: { name: true } },
+        visionConfigId: true,
+        visionConfig: { select: { name: true } },
       },
       take: 100,
     });
@@ -77,11 +95,11 @@ export const handleListModelOverrides = (deps: RouteDeps): RequestHandler => {
     const result: ModelOverrideSummary[] = overrides.map(o => ({
       personalityId: o.personalityId,
       personalityName: o.personality.name,
-      configId: o.llmConfigId,
-      configName: o.llmConfig?.name ?? null,
+      configId: isVision ? o.visionConfigId : o.llmConfigId,
+      configName: isVision ? (o.visionConfig?.name ?? null) : (o.llmConfig?.name ?? null),
     }));
 
-    logger.info({ discordUserId, count: result.length }, 'Listed overrides');
+    logger.info({ discordUserId, count: result.length, kind }, 'Listed overrides');
     sendCustomSuccess(res, { overrides: result }, StatusCodes.OK);
   });
 };
@@ -114,6 +132,12 @@ export const handleSetModelOverride = (deps: RouteDeps): RequestHandler => {
       return sendError(res, ErrorResponses.notFound('Config'));
     }
 
+    // The config's kind decides which FK column the override writes — a vision
+    // config sets `visionConfigId`, a text config `llmConfigId`. Both can coexist
+    // on the same (user, personality) row.
+    const isVision = llmConfig.kind === 'vision';
+    const fkData = isVision ? { visionConfigId: configId } : { llmConfigId: configId };
+
     const override = await prisma.userPersonalityConfig.upsert({
       where: {
         userId_personalityId: {
@@ -125,24 +149,26 @@ export const handleSetModelOverride = (deps: RouteDeps): RequestHandler => {
         id: generateUserPersonalityConfigUuid(userId, personalityId),
         userId,
         personalityId,
-        llmConfigId: configId,
+        ...fkData,
       },
-      update: {
-        llmConfigId: configId,
-      },
+      update: fkData,
       select: {
         personalityId: true,
         personality: { select: { name: true } },
         llmConfigId: true,
         llmConfig: { select: { name: true } },
+        visionConfigId: true,
+        visionConfig: { select: { name: true } },
       },
     });
 
     const result: ModelOverrideSummary = {
       personalityId: override.personalityId,
       personalityName: override.personality.name,
-      configId: override.llmConfigId,
-      configName: override.llmConfig?.name ?? null,
+      configId: isVision ? override.visionConfigId : override.llmConfigId,
+      configName: isVision
+        ? (override.visionConfig?.name ?? null)
+        : (override.llmConfig?.name ?? null),
     };
 
     logger.info(
@@ -152,6 +178,7 @@ export const handleSetModelOverride = (deps: RouteDeps): RequestHandler => {
         personalityName: personality.name,
         configId,
         configName: llmConfig.name,
+        kind: isVision ? 'vision' : 'text',
       },
       'Set override'
     );
@@ -167,20 +194,35 @@ export const handleGetDefaultModelConfig = (deps: RouteDeps): RequestHandler => 
     const discordUserId = req.userId;
     const userId = resolveProvisionedUserId(req);
 
+    const kind = parseConfigKindQuery(res, req.query);
+    if (kind === null) {
+      return;
+    }
+    const isVision = kind === 'vision';
+
+    // Select both FK pairs (fixed shape — a conditional select would yield a
+    // union return type), then pick the requested kind.
     const user = await prisma.user.findUnique({
       where: { id: userId },
       select: {
         defaultLlmConfigId: true,
         defaultLlmConfig: { select: { name: true } },
+        defaultVisionConfigId: true,
+        defaultVisionConfig: { select: { name: true } },
       },
     });
 
-    const result: UserDefaultConfig = {
-      configId: user?.defaultLlmConfigId ?? null,
-      configName: user?.defaultLlmConfig?.name ?? null,
-    };
+    const result: UserDefaultConfig = isVision
+      ? {
+          configId: user?.defaultVisionConfigId ?? null,
+          configName: user?.defaultVisionConfig?.name ?? null,
+        }
+      : {
+          configId: user?.defaultLlmConfigId ?? null,
+          configName: user?.defaultLlmConfig?.name ?? null,
+        };
 
-    logger.info({ discordUserId, configId: result.configId }, 'Got default config');
+    logger.info({ discordUserId, configId: result.configId, kind }, 'Got default config');
     sendCustomSuccess(res, { default: result }, StatusCodes.OK);
   });
 };
@@ -204,9 +246,12 @@ export const handleSetDefaultModelConfig = (deps: RouteDeps): RequestHandler => 
       return sendError(res, ErrorResponses.notFound('Config'));
     }
 
+    // A vision config sets the user's vision default (`defaultVisionConfigId`);
+    // a text config the text default. The two defaults coexist independently.
+    const isVision = llmConfig.kind === 'vision';
     await prisma.user.update({
       where: { id: userId },
-      data: { defaultLlmConfigId: configId },
+      data: isVision ? { defaultVisionConfigId: configId } : { defaultLlmConfigId: configId },
     });
 
     const result: UserDefaultConfig = {
@@ -214,7 +259,10 @@ export const handleSetDefaultModelConfig = (deps: RouteDeps): RequestHandler => 
       configName: llmConfig.name,
     };
 
-    logger.info({ discordUserId, configId, configName: llmConfig.name }, 'Set default config');
+    logger.info(
+      { discordUserId, configId, configName: llmConfig.name, kind: isVision ? 'vision' : 'text' },
+      'Set default config'
+    );
 
     await tryInvalidateCache(
       llmConfigCacheInvalidation?.invalidateUserLlmConfig.bind(
@@ -235,27 +283,33 @@ export const handleClearDefaultModelConfig = (deps: RouteDeps): RequestHandler =
     const discordUserId = req.userId;
     const userId = resolveProvisionedUserId(req);
 
+    const kind = parseConfigKindQuery(res, req.query);
+    if (kind === null) {
+      return;
+    }
+    const isVision = kind === 'vision';
+
     const user = await prisma.user.findUnique({
       where: { id: userId },
-      select: { defaultLlmConfigId: true },
+      select: { defaultLlmConfigId: true, defaultVisionConfigId: true },
     });
 
     if (user === null) {
       return sendError(res, ErrorResponses.notFound('User'));
     }
+    const currentDefault = isVision ? user.defaultVisionConfigId : user.defaultLlmConfigId;
 
-    // Look up the system free default the user will fall back to. Per-
-    // personality overrides (UserPersonalityConfig.llmConfigId) and
-    // personality-level defaults (PersonalityDefaultLlmConfig) are
+    // Look up the system free default of the SAME kind the user will fall back
+    // to. Per-personality overrides and personality-level defaults are
     // unaffected; the free default is just the user-global fallback.
     const newEffectiveDefault = await prisma.llmConfig.findFirst({
-      where: { isFreeDefault: true },
+      where: { isFreeDefault: true, kind },
       select: { id: true, name: true },
     });
 
-    if (user.defaultLlmConfigId === null) {
+    if (currentDefault === null) {
       logger.info(
-        { discordUserId, hadDefault: false },
+        { discordUserId, kind, hadDefault: false },
         'Clear called but no default was set (idempotent success)'
       );
       return sendCustomSuccess(
@@ -267,10 +321,10 @@ export const handleClearDefaultModelConfig = (deps: RouteDeps): RequestHandler =
 
     await prisma.user.update({
       where: { id: userId },
-      data: { defaultLlmConfigId: null },
+      data: isVision ? { defaultVisionConfigId: null } : { defaultLlmConfigId: null },
     });
 
-    logger.info({ discordUserId }, 'Cleared default config');
+    logger.info({ discordUserId, kind }, 'Cleared default config');
 
     await tryInvalidateCache(
       llmConfigCacheInvalidation?.invalidateUserLlmConfig.bind(
@@ -292,17 +346,31 @@ export const handleDeleteModelOverride = (deps: RouteDeps): RequestHandler => {
     const personalityId = getParam(req.params.personalityId);
     const userId = resolveProvisionedUserId(req);
 
+    const kind = parseConfigKindQuery(res, req.query);
+    if (kind === null) {
+      return;
+    }
+    const isVision = kind === 'vision';
+
     const override = await prisma.userPersonalityConfig.findFirst({
       where: {
         userId,
         personalityId,
       },
-      select: { id: true, llmConfigId: true, personality: { select: { name: true } } },
+      select: {
+        id: true,
+        llmConfigId: true,
+        visionConfigId: true,
+        personality: { select: { name: true } },
+      },
     });
+    // `findFirst` returns the row or null (never undefined), and the selected FK
+    // columns are `string | null` — so a null row OR a null FK means "not set".
+    const currentOverride = isVision ? override?.visionConfigId : override?.llmConfigId;
 
-    if (override?.llmConfigId === null || override?.llmConfigId === undefined) {
+    if (override === null || currentOverride === null) {
       logger.info(
-        { discordUserId, personalityId, hadOverride: false },
+        { discordUserId, personalityId, kind, hadOverride: false },
         'Reset called but no override was set (idempotent success)'
       );
       return sendCustomSuccess(res, { deleted: true, wasSet: false }, StatusCodes.OK);
@@ -310,11 +378,11 @@ export const handleDeleteModelOverride = (deps: RouteDeps): RequestHandler => {
 
     await prisma.userPersonalityConfig.update({
       where: { id: override.id },
-      data: { llmConfigId: null },
+      data: isVision ? { visionConfigId: null } : { llmConfigId: null },
     });
 
     logger.info(
-      { discordUserId, personalityId, personalityName: override.personality.name },
+      { discordUserId, personalityId, personalityName: override.personality.name, kind },
       'Removed override'
     );
 


### PR DESCRIPTION
## Phase 2 / S2b — Model Configuration Overhaul

S2a (#1378) let an **admin** set the global vision default. S2b lets a **user** point their own default / per-personality override at a vision config — the last backend piece before the commands (S2c).

The 6 handlers in `routes/user/model-override.ts` now branch on kind so the **vision FK columns** get written, which the `VisionConfigResolver` cascade already reads (`visionConfigId` → `defaultVisionConfigId` → … ).

### Design — branch on kind within the existing routes

- **Writes derive kind from the config row** (`verifyConfigAccess` now returns `kind`): set-default / set-override write `defaultVisionConfigId` / `visionConfigId` for a `kind=vision` config, else the text FK. Text + vision selections **coexist** on the same row.
- **Reads / clears take `?kind=`** (default text, via the existing `parseConfigKindQuery`): GET default/list select the matching FK/relation; clears null **only** the matching FK; the free-default fallback lookup is kind-scoped (`isFreeDefault: true, kind`).
- **Branch-on-kind, not parallel `/user/vision-override` routes** — the kind is intrinsic to the config (writes) or explicit in the param (reads/clears); duplicating the GET/PUT/DELETE × default/per-personality surface would be copy-paste. (The CPD ratchet's post-filter correctly treats the 6 similar branches as call-dominant skeletons — `cpd:check` green.)

### Scope
- **Next (S2c)**: the `kind` command option + autocomplete kind-filtering that drive S2a + S2b end-to-end.
- Personality-level default write-routes remain a separate pre-existing gap (`cold/follow-ups.md`).

### Verification
- `pnpm --filter @tzurot/api-gateway test` ✅ (2217) · `pnpm test:component` ✅ (446) · `pnpm quality` ✅.
- New tests (6): vision set-default → `defaultVisionConfigId`; vision per-personality override → `visionConfigId`; `GET /default?kind=vision` returns the vision default (text ignored); `DELETE /default?kind=vision` nulls only the vision FK + scopes the free fallback; `GET /?kind=vision` lists vision overrides; `DELETE /:personalityId?kind=vision` clears only the vision override. Existing text-path tests unchanged (kind defaults text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)