### PR TITLE
feat(api-gateway): capability-gate the user/personality vision slots (P3-S2)

### DIFF
--- a/packages/clients/src/clients/_generated/user-client.ts
+++ b/packages/clients/src/clients/_generated/user-client.ts
@@ -486,8 +486,8 @@ export class UserClient {
   /**
    * @idempotent Replaying the exact same request lands the same final state — safe to retry on network failure.
    */
-  async setModelOverride(input: z.infer<typeof ROUTE_MANIFEST.setModelOverride.input>): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.setModelOverride.output>>> {
-    const fullPath = '/api/user/model-override';
+  async setModelOverride(input: z.infer<typeof ROUTE_MANIFEST.setModelOverride.input>, options: { kind?: string } = {}): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.setModelOverride.output>>> {
+    const fullPath = '/api/user/model-override' + buildQueryString([['kind', options.kind]]);
     return callGateway({
       baseUrl: this.baseUrl,
       serviceSecret: this.serviceSecret,
@@ -542,8 +542,8 @@ export class UserClient {
   /**
    * @idempotent Replaying the exact same request lands the same final state — safe to retry on network failure.
    */
-  async setDefaultModelConfig(input: z.infer<typeof ROUTE_MANIFEST.setDefaultModelConfig.input>): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.setDefaultModelConfig.output>>> {
-    const fullPath = '/api/user/model-override/default';
+  async setDefaultModelConfig(input: z.infer<typeof ROUTE_MANIFEST.setDefaultModelConfig.input>, options: { kind?: string } = {}): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.setDefaultModelConfig.output>>> {
+    const fullPath = '/api/user/model-override/default' + buildQueryString([['kind', options.kind]]);
     return callGateway({
       baseUrl: this.baseUrl,
       serviceSecret: this.serviceSecret,

--- a/packages/clients/src/routes/user/configs.ts
+++ b/packages/clients/src/routes/user/configs.ts
@@ -363,6 +363,9 @@ export const userConfigRoutes = {
     path: '/model-override',
     id: 'setModelOverride',
     input: SetModelOverrideSchema,
+    // The slot the override occupies (text|vision); defaults text. The gateway
+    // capability-gates the vision slot (its model must support image input).
+    query: { kind: z.enum(CONFIG_KINDS).optional() },
     output: SetModelOverrideResponseSchema,
     requiresProvisionedUser: true,
     meta: { idempotent: true },
@@ -401,6 +404,9 @@ export const userConfigRoutes = {
     path: MODEL_OVERRIDE_DEFAULT_PATH,
     id: 'setDefaultModelConfig',
     input: SetDefaultConfigSchema,
+    // The slot the default occupies (text|vision); defaults text. The gateway
+    // capability-gates the vision slot (its model must support image input).
+    query: { kind: z.enum(CONFIG_KINDS).optional() },
     output: SetDefaultConfigResponseSchema,
     requiresProvisionedUser: true,
     meta: { idempotent: true },

--- a/services/api-gateway/src/routes/user/model-override.test.ts
+++ b/services/api-gateway/src/routes/user/model-override.test.ts
@@ -365,6 +365,145 @@ describe('/user/model-override routes', () => {
         })
       );
     });
+
+    it('writes the vision slot when ?kind=vision and the model is vision-capable', async () => {
+      mockPrisma.personality.findFirst.mockResolvedValue({
+        id: '11111111-1111-4111-a111-111111111111',
+        name: 'Lilith',
+      });
+      mockPrisma.llmConfig.findFirst.mockResolvedValue({
+        id: '22222222-2222-4222-a222-222222222222',
+        name: 'GPT-4o',
+        model: 'openai/gpt-4o',
+      });
+      mockPrisma.userPersonalityConfig.upsert.mockResolvedValue({
+        personalityId: '11111111-1111-4111-a111-111111111111',
+        personality: { name: 'Lilith' },
+        visionConfigId: '22222222-2222-4222-a222-222222222222',
+        visionConfig: { name: 'GPT-4o' },
+      });
+
+      const modelCache = {
+        getModelById: vi.fn(async (id: string) =>
+          id === 'openai/gpt-4o' ? { supportsVision: true } : null
+        ),
+      } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
+
+      const router = createModelOverrideRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        modelCache,
+      });
+      const handler = getHandler(router, 'put', '/');
+      const { req, res } = createMockReqRes(
+        {
+          personalityId: '11111111-1111-4111-a111-111111111111',
+          configId: '22222222-2222-4222-a222-222222222222',
+        },
+        {},
+        { kind: 'vision' }
+      );
+
+      await handler(req, res);
+
+      // The vision slot FK is written, NOT the text slot.
+      expect(mockPrisma.userPersonalityConfig.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({
+            visionConfigId: '22222222-2222-4222-a222-222222222222',
+          }),
+          update: { visionConfigId: '22222222-2222-4222-a222-222222222222' },
+        })
+      );
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          override: expect.objectContaining({ kind: 'vision' }),
+        })
+      );
+    });
+
+    it('rejects the vision slot when the model is not vision-capable', async () => {
+      mockPrisma.personality.findFirst.mockResolvedValue({
+        id: '11111111-1111-4111-a111-111111111111',
+        name: 'Lilith',
+      });
+      mockPrisma.llmConfig.findFirst.mockResolvedValue({
+        id: '22222222-2222-4222-a222-222222222222',
+        name: 'GLM',
+        model: 'z-ai/glm-4.7',
+      });
+
+      const modelCache = {
+        getModelById: vi.fn(async (id: string) =>
+          id === 'z-ai/glm-4.7' ? { supportsVision: false } : null
+        ),
+      } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
+
+      const router = createModelOverrideRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        modelCache,
+      });
+      const handler = getHandler(router, 'put', '/');
+      const { req, res } = createMockReqRes(
+        {
+          personalityId: '11111111-1111-4111-a111-111111111111',
+          configId: '22222222-2222-4222-a222-222222222222',
+        },
+        {},
+        { kind: 'vision' }
+      );
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('vision'),
+        })
+      );
+      // No write happens when the capability gate rejects.
+      expect(mockPrisma.userPersonalityConfig.upsert).not.toHaveBeenCalled();
+    });
+
+    it('rejects the vision slot when the model is not in the catalog', async () => {
+      mockPrisma.personality.findFirst.mockResolvedValue({
+        id: '11111111-1111-4111-a111-111111111111',
+        name: 'Lilith',
+      });
+      mockPrisma.llmConfig.findFirst.mockResolvedValue({
+        id: '22222222-2222-4222-a222-222222222222',
+        name: 'Mystery',
+        model: 'mystery/model',
+      });
+
+      const modelCache = {
+        getModelById: vi.fn(async () => null), // unknown to OpenRouter + not a z.ai member
+      } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
+
+      const router = createModelOverrideRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        modelCache,
+      });
+      const handler = getHandler(router, 'put', '/');
+      const { req, res } = createMockReqRes(
+        {
+          personalityId: '11111111-1111-4111-a111-111111111111',
+          configId: '22222222-2222-4222-a222-222222222222',
+        },
+        {},
+        { kind: 'vision' }
+      );
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("Couldn't confirm"),
+        })
+      );
+      expect(mockPrisma.userPersonalityConfig.upsert).not.toHaveBeenCalled();
+    });
   });
 
   describe('DELETE /user/model-override/:personalityId', () => {
@@ -555,6 +694,107 @@ describe('/user/model-override routes', () => {
           },
         })
       );
+    });
+
+    it('writes the vision default when ?kind=vision and the model is vision-capable', async () => {
+      mockPrisma.llmConfig.findFirst.mockResolvedValue({
+        id: '22222222-2222-4222-a222-222222222222',
+        name: 'GPT-4o',
+        model: 'openai/gpt-4o',
+      });
+
+      const modelCache = {
+        getModelById: vi.fn(async (id: string) =>
+          id === 'openai/gpt-4o' ? { supportsVision: true } : null
+        ),
+      } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
+
+      const router = createModelOverrideRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        modelCache,
+      });
+      const handler = getHandler(router, 'put', '/default');
+      const { req, res } = createMockReqRes(
+        { configId: '22222222-2222-4222-a222-222222222222' },
+        {},
+        { kind: 'vision' }
+      );
+
+      await handler(req, res);
+
+      expect(mockPrisma.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-uuid-123' },
+        data: { defaultVisionConfigId: '22222222-2222-4222-a222-222222222222' },
+      });
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('rejects the vision default when the model is not vision-capable', async () => {
+      mockPrisma.llmConfig.findFirst.mockResolvedValue({
+        id: '22222222-2222-4222-a222-222222222222',
+        name: 'GLM',
+        model: 'z-ai/glm-4.7',
+      });
+
+      const modelCache = {
+        getModelById: vi.fn(async (id: string) =>
+          id === 'z-ai/glm-4.7' ? { supportsVision: false } : null
+        ),
+      } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
+
+      const router = createModelOverrideRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        modelCache,
+      });
+      const handler = getHandler(router, 'put', '/default');
+      const { req, res } = createMockReqRes(
+        { configId: '22222222-2222-4222-a222-222222222222' },
+        {},
+        { kind: 'vision' }
+      );
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('vision'),
+        })
+      );
+      expect(mockPrisma.user.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects the vision default when the model is not in the catalog', async () => {
+      mockPrisma.llmConfig.findFirst.mockResolvedValue({
+        id: '22222222-2222-4222-a222-222222222222',
+        name: 'Mystery',
+        model: 'mystery/model',
+      });
+
+      const modelCache = {
+        getModelById: vi.fn(async () => null), // unknown to OpenRouter + not a z.ai member
+      } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
+
+      const router = createModelOverrideRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        modelCache,
+      });
+      const handler = getHandler(router, 'put', '/default');
+      const { req, res } = createMockReqRes(
+        { configId: '22222222-2222-4222-a222-222222222222' },
+        {},
+        { kind: 'vision' }
+      );
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("Couldn't confirm"),
+        })
+      );
+      expect(mockPrisma.user.update).not.toHaveBeenCalled();
     });
   });
 
@@ -810,60 +1050,11 @@ describe('/user/model-override routes', () => {
     const VISION_CFG = '33333333-3333-4333-a333-333333333333';
     const PERSONALITY = '11111111-1111-4111-a111-111111111111';
 
-    it('PUT /default writes defaultVisionConfigId when the config is kind=vision', async () => {
-      mockPrisma.llmConfig.findFirst.mockResolvedValue({
-        id: VISION_CFG,
-        name: 'Vision Cfg',
-        kind: 'vision',
-      });
-
-      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
-      const handler = getHandler(router, 'put', '/default');
-      const { req, res } = createMockReqRes({ configId: VISION_CFG });
-
-      await handler(req, res);
-
-      expect(mockPrisma.user.update).toHaveBeenCalledWith({
-        where: { id: 'user-uuid-123' },
-        data: { defaultVisionConfigId: VISION_CFG },
-      });
-      expect(res.status).toHaveBeenCalledWith(200);
-    });
-
-    it('PUT / writes visionConfigId on a per-personality override for a kind=vision config', async () => {
-      mockPrisma.personality.findFirst.mockResolvedValue({ id: PERSONALITY, name: 'Lilith' });
-      mockPrisma.llmConfig.findFirst.mockResolvedValue({
-        id: VISION_CFG,
-        name: 'Vision Cfg',
-        kind: 'vision',
-      });
-      mockPrisma.userPersonalityConfig.upsert.mockResolvedValue({
-        personalityId: PERSONALITY,
-        personality: { name: 'Lilith' },
-        llmConfigId: null,
-        llmConfig: null,
-        visionConfigId: VISION_CFG,
-        visionConfig: { name: 'Vision Cfg' },
-      });
-
-      const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
-      const handler = getHandler(router, 'put', '/');
-      const { req, res } = createMockReqRes({ personalityId: PERSONALITY, configId: VISION_CFG });
-
-      await handler(req, res);
-
-      expect(mockPrisma.userPersonalityConfig.upsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          create: expect.objectContaining({ visionConfigId: VISION_CFG }),
-          update: { visionConfigId: VISION_CFG },
-        })
-      );
-      expect(res.json).toHaveBeenCalledWith(
-        expect.objectContaining({
-          override: expect.objectContaining({ configId: VISION_CFG, configName: 'Vision Cfg' }),
-        })
-      );
-    });
+    // NOTE: the PUT-set paths (vision slot via `?kind=vision` + capability gate)
+    // are covered above in the `PUT /user/model-override` and `PUT /default`
+    // describe blocks. The slot is now chosen by the request, not derived from
+    // `config.kind`, so those write tests live with the rest of the set-handler
+    // coverage. The read/clear `?kind=` scoping below is what this block exercises.
 
     it('GET /default?kind=vision returns the vision default (text default ignored)', async () => {
       mockPrisma.user.findUnique.mockResolvedValue({

--- a/services/api-gateway/src/routes/user/model-override.ts
+++ b/services/api-gateway/src/routes/user/model-override.ts
@@ -16,8 +16,6 @@ import { StatusCodes } from 'http-status-codes';
 import {
   createLogger,
   generateUserPersonalityConfigUuid,
-  toConfigKind,
-  type ConfigKind,
   type PrismaClient,
   type ModelOverrideSummary,
   type UserDefaultConfig,
@@ -30,6 +28,7 @@ import {
   parseConfigKindQuery,
   parseConfigKindQueryAllowAll,
 } from '../../utils/configRouteHelpers.js';
+import { ensureVisionCapableModel } from '../../utils/llmConfigValidation.js';
 import { tryInvalidateCache } from '../../utils/configOverrideHelpers.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
@@ -43,25 +42,23 @@ const logger = createLogger('user-model-override');
 
 /**
  * Verify that the given LLM config exists and the user can access it (global or owned).
- * Returns the config (incl. its `kind`) if accessible, null otherwise. The set
- * handlers branch on `kind` — a config's kind is intrinsic to its id, so the
- * write targets the matching FK column (text vs vision).
+ * Returns the config (incl. its `model`) if accessible, null otherwise. The slot a
+ * config occupies (chat vs vision) is the caller's request, NOT a property of the
+ * config — so the set handlers pick the FK column from `?kind=`. `model` is returned
+ * so the vision slot can be capability-gated (the model must support image input).
  */
 async function verifyConfigAccess(
   prisma: PrismaClient,
   configId: string,
   userId: string
-): Promise<{ id: string; name: string; kind: ConfigKind } | null> {
-  const row = await prisma.llmConfig.findFirst({
+): Promise<{ id: string; name: string; model: string } | null> {
+  return prisma.llmConfig.findFirst({
     where: {
       id: configId,
       OR: [{ isGlobal: true }, { ownerId: userId }],
     },
-    select: { id: true, name: true, kind: true },
+    select: { id: true, name: true, model: true },
   });
-  // Narrow the raw DB string to ConfigKind at the boundary (toConfigKind floors
-  // an unexpected value to text + logs), so callers get an exhaustive-checkable kind.
-  return row === null ? null : { ...row, kind: toConfigKind(row.kind) };
 }
 
 /** GET /api/user/model-override — list all user model overrides */
@@ -138,9 +135,16 @@ export const handleListModelOverrides = (deps: RouteDeps): RequestHandler => {
 
 /** PUT /api/user/model-override — set model override for a personality */
 export const handleSetModelOverride = (deps: RouteDeps): RequestHandler => {
-  const { prisma } = deps;
+  const { prisma, modelCache } = deps;
   return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
     const discordUserId = req.userId;
+
+    // The slot (chat vs vision) is the request's choice, not a config property;
+    // `?kind=` defaults to text. The vision slot is capability-gated below.
+    const kind = parseConfigKindQuery(res, req.query);
+    if (kind === null) {
+      return;
+    }
 
     const parseResult = SetModelOverrideSchema.safeParse(req.body);
     if (!parseResult.success) {
@@ -164,10 +168,16 @@ export const handleSetModelOverride = (deps: RouteDeps): RequestHandler => {
       return sendError(res, ErrorResponses.notFound('Config'));
     }
 
-    // The config's kind decides which FK column the override writes — a vision
-    // config sets `visionConfigId`, a text config `llmConfigId`. Both can coexist
-    // on the same (user, personality) row.
-    const isVision = llmConfig.kind === 'vision';
+    // The requested slot decides which FK column the override writes — vision sets
+    // `visionConfigId`, text `llmConfigId`. Both can coexist on the same (user,
+    // personality) row. The vision slot is capability-gated: its model must be
+    // confirmed vision-capable (unknown/unresolvable capability → 400, fail
+    // closed). With no model cache wired (local dev) an OpenRouter-only model
+    // can't be resolved and 400s here; prod always has the cache.
+    const isVision = kind === 'vision';
+    if (isVision && !(await ensureVisionCapableModel(res, modelCache, llmConfig.model))) {
+      return;
+    }
     const fkData = isVision ? { visionConfigId: configId } : { llmConfigId: configId };
 
     const override = await prisma.userPersonalityConfig.upsert({
@@ -262,9 +272,16 @@ export const handleGetDefaultModelConfig = (deps: RouteDeps): RequestHandler => 
 
 /** PUT /api/user/model-override/default — set user's global default LLM config */
 export const handleSetDefaultModelConfig = (deps: RouteDeps): RequestHandler => {
-  const { prisma, llmConfigCacheInvalidation } = deps;
+  const { prisma, modelCache, llmConfigCacheInvalidation } = deps;
   return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
     const discordUserId = req.userId;
+
+    // The slot (chat vs vision) is the request's choice, not a config property;
+    // `?kind=` defaults to text. The vision slot is capability-gated below.
+    const kind = parseConfigKindQuery(res, req.query);
+    if (kind === null) {
+      return;
+    }
 
     const parseResult = SetDefaultConfigSchema.safeParse(req.body);
     if (!parseResult.success) {
@@ -279,9 +296,16 @@ export const handleSetDefaultModelConfig = (deps: RouteDeps): RequestHandler => 
       return sendError(res, ErrorResponses.notFound('Config'));
     }
 
-    // A vision config sets the user's vision default (`defaultVisionConfigId`);
-    // a text config the text default. The two defaults coexist independently.
-    const isVision = llmConfig.kind === 'vision';
+    // The requested slot decides which default the write targets — vision sets
+    // `defaultVisionConfigId`, text `defaultLlmConfigId`; they coexist
+    // independently. The vision slot is capability-gated: its model must be
+    // confirmed vision-capable (unknown/unresolvable capability → 400, fail
+    // closed). With no model cache wired (local dev) an OpenRouter-only model
+    // can't be resolved and 400s here; prod always has the cache.
+    const isVision = kind === 'vision';
+    if (isVision && !(await ensureVisionCapableModel(res, modelCache, llmConfig.model))) {
+      return;
+    }
     await prisma.user.update({
       where: { id: userId },
       data: isVision ? { defaultVisionConfigId: configId } : { defaultLlmConfigId: configId },

--- a/services/api-gateway/src/utils/llmConfigValidation.ts
+++ b/services/api-gateway/src/utils/llmConfigValidation.ts
@@ -126,8 +126,13 @@ async function resolveEffectiveModelAndKind(
  * pointing at a text-only model (→ no image description → the LLM improvises).
  * On failure sends a 400 and returns false; returns true when the model is
  * confirmed vision-capable.
+ *
+ * Exported so the slot-setting routes (user/personality vision-slot overrides)
+ * gate on the SAME capability check the create/update path uses — a config's
+ * model must be confirmed vision-capable before it can occupy a vision slot,
+ * regardless of which endpoint does the slotting.
  */
-async function ensureVisionCapableModel(
+export async function ensureVisionCapableModel(
   res: Response,
   modelCache: OpenRouterModelCache | undefined,
   model: string


### PR DESCRIPTION
## Phase 3, Slice 2 — capability-driven config model

The slot a config occupies (chat vs vision) is the **request's** choice, not a property of the config. This slice reworks the user-default and per-personality override SET handlers to match that model.

### What changed
- **`routes/user/model-override.ts`** — the two SET handlers (`handleSetModelOverride`, `handleSetDefaultModelConfig`) now pick the FK column from `?kind=` (mirroring their read/clear siblings) instead of deriving it from the dormant `config.kind`. The **vision slot is capability-gated**: its model must be confirmed vision-capable (unknown capability → rejected, fail closed). `verifyConfigAccess` now returns `model` (for the gate) and no longer reads the dormant `kind`.
- **`utils/llmConfigValidation.ts`** — exports `ensureVisionCapableModel` so the slot-setting routes gate on the **same** capability check the create/update path already uses.
- **`packages/clients` route manifest** — adds the `kind` query option to `setModelOverride` / `setDefaultModelConfig`; user client regenerated so bot-client (Slice 4) can target the vision slot.

### Sequencing note
This is a **non-breaking** gateway slice: text-slot setting is unchanged (absent `?kind=` defaults to text). Per-user / per-character **vision** setting is fully wired end-to-end once **Slice 4** sends the slot from command context — the current bot-client doesn't yet send `?kind=vision`, so vision-set via these endpoints remains as it is today (the bug the epic targets) until S4. No currently-working flow regresses.

### Tests
- New: vision-slot success + capability-rejection for both SET handlers (4 tests).
- Removed: 2 obsolete tests that asserted the old slot-from-`config.kind` contract (superseded by the new request-driven tests).
- `pnpm test` + `pnpm quality` green locally.

Part of the [capability-driven config model epic](.claude/plans/floofy-rolling-crane.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)