### PR TITLE
fix(ai-worker): raise TTS budget to 300s so a cold-start fallback isn't cut off

### DIFF
--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.test.ts
@@ -11,7 +11,7 @@
  *     plus `auth.audioProviderKeys` and the module-level provider registry)
  *   - Output normalization fast-path + failure-tolerance
  *   - Redis storage (only when synthesis succeeded)
- *   - Outer 240s timeout race (text-only delivery on timeout)
+ *   - Outer 300s timeout race (text-only delivery on timeout)
  *   - Error path on dispatcher failure → text still delivered
  *
  * Provider-internal behavior (cloning, retries, voice-engine warmup, etc.)
@@ -413,8 +413,8 @@ describe('TTSStep', () => {
       const ctx = createContext();
 
       const promise = step.process(ctx);
-      // Advance past the 240s budget
-      await vi.advanceTimersByTimeAsync(240_001);
+      // Advance past the 300s TTS budget (cold-start + long-synthesis worst case)
+      await vi.advanceTimersByTimeAsync(300_001);
       const result = await promise;
 
       expect(result.result?.metadata?.ttsAudioKey).toBeUndefined();

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/TTSStep.ts
@@ -14,7 +14,7 @@
  * which reads `ResolvedTtsConfig` (from `TtsConfigResolver`) plus
  * `audioProviderKeys` from `ResolvedAuth`. This step's job is the pipeline
  * glue: prerequisite checks, config resolution, dispatch with the outer
- * 240s budget, and Redis storage of the normalized output.
+ * 300s budget, and Redis storage of the normalized output.
  */
 
 import {
@@ -38,15 +38,24 @@ const logger = createLogger('TTSStep');
 
 /** Total TTS budget across prepare + synthesize + normalize.
  *
- * Sized to accommodate the worst case where the primary provider fails and
- * the dispatcher falls back to self-hosted, which has to cold-start:
- *   primary attempt (60s) + voice-engine cold start (~47s observed,
- *   75s budget) + registration (15s) + multi-chunk synthesis (~90s) + margin.
+ * Sized for the common worst case: the primary provider (BYOK) fails — e.g. a
+ * content-guardrail block — and the dispatcher falls back to self-hosted, which
+ * may have to cold-start from serverless sleep before it can synthesize:
+ *   primary attempt (~15s) + voice-engine cold start (up to the 120s warmup
+ *   budget, ~52s typical — see voiceEngineWarmup) + multi-chunk synthesis of a
+ *   long reply (~190s for ~3.5k chars) + margin.
+ *
+ * The cold start is charged against this same budget, so a long synthesis right
+ * after a cold start is the binding case (~260s) — hence 300s, not less. A
+ * pathological full-120s cold start + very-long synthesis can still exceed it
+ * (accepted edge case); the cleaner fix — start the synthesis timeout at
+ * warmup-completion so the cold start doesn't eat the synthesis budget — is
+ * tracked in `backlog/cold/follow-ups.md`.
  *
  * The race is around the entire dispatcher + normalize call so a stuck
  * normalizer (e.g., ffmpeg hang) can't deadlock the pipeline. Text is
  * always delivered regardless — this only affects whether audio attaches. */
-const TTS_MAX_TOTAL_MS = 240_000;
+const TTS_MAX_TOTAL_MS = 300_000;
 
 /** @internal Test-only — reset cached provider singletons between test files. */
 export function resetTTSStepState(): void {
@@ -175,7 +184,7 @@ export class TTSStep implements IPipelineStep {
   }
 
   /**
-   * Wrap the dispatch + normalize + store in the outer 240s budget. When the
+   * Wrap the dispatch + normalize + store in the outer 300s budget. When the
    * timeout wins the race, the underlying work continues in the background;
    * its result is discarded (ttsAudioKey never written) and the audio expires
    * via Redis TTL.


### PR DESCRIPTION
## Production issue — voice output silently dropped

**Runtime-confirmed** (prod ai-worker, 2026-06-29 15:47–15:51Z; char `lilith-tzel-shani`, user has a Mistral BYOK key). A voice-enabled reply came back **text-only** despite a working fallback chain:

1. Mistral TTS (BYOK) → **403 `guardrail_violation`** (content blocked, not a bad key) → `TtsDispatcher` correctly fell back to self-hosted.
2. Self-hosted voice-engine was **cold** (serverless idle-kill) → **~52s cold-start** (`VoiceEngineWarmup`, `warmupElapsedMs=52167`).
3. Long-reply synthesis (3,491 chars → 2 chunks) ran **~190s**.
4. `TTSStep`'s **240s** timeout fired at 15:51:09 → text-only. Synthesis actually completed at 15:51:29 (~20s late) → **audio discarded**.

## Root cause

`TTSStep.runWithTimeout` wraps the **entire** dispatch — including the cold-start warmup — in one `TTS_MAX_TOTAL_MS` race. So a cold-start (up to the 120s warmup budget) is charged against the same budget as synthesis: `~52s cold-start + ~190s synthesis ≈ 260s` just missed the old 240s. (A genuinely-dead engine still fails fast at the warmup poller's own ~120s budget, so the bigger budget doesn't delay that path.)

## Fix

Raise `TTS_MAX_TOTAL_MS` 240s → **300s** — covers a typical cold-start + a long synthesis with margin. Per owner direction (keeping the voice-engine serverless to control hosting cost, so always-warm is off the table; this is an edge case and synthesis usually isn't this long).

The **proper** fix — start the synthesis timeout at warmup-completion so the cold-start doesn't eat the synthesis budget (and deliver late-completed audio as a follow-up rather than discarding it) — is filed in `backlog/cold/follow-ups.md`, to promote if 300s is exceeded again. Verified no higher-level job/generation timeout caps below 300s (the trace shows the job lived past 260s; other timeouts are sub-components ≤60s).

## Tests

`TTSStep.test.ts` outer-timeout test updated to advance past 300s; `pnpm --filter @tzurot/ai-worker test` + `pnpm quality` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)