### PR TITLE
debug(bot-client): probe forward-content state at submitChatJob

### DIFF
--- a/services/bot-client/src/services/character/PersonalityChatManager.ts
+++ b/services/bot-client/src/services/character/PersonalityChatManager.ts
@@ -35,6 +35,7 @@ import {
 } from '../../utils/nsfwVerification.js';
 import type { DenylistCache } from '../DenylistCache.js';
 import type { MessageJobContext } from '../JobTracker.js';
+import { isForwardedMessage, extractForwardedContent } from '../../utils/forwardedMessageUtils.js';
 
 const logger = createLogger('PersonalityChatManager');
 
@@ -206,6 +207,31 @@ export class PersonalityChatManager {
   async submitChatJob(input: SubmitChatJobInput): Promise<SubmitChatJobResult> {
     const { message, personality, content, isAutoResponse } = input;
     const { channel } = message;
+
+    // [forward-probe] TEMPORARY diagnostic for the forwarded-message content-loss
+    // bug (forward → empty user message → "Hello" placeholder). Captures, at the
+    // single convergence point for all trigger modes, whether the forward was
+    // detected, whether Discord delivered snapshots, what extractForwardedContent
+    // WOULD yield, and what `content` the upstream actually passed — which pins
+    // detection-fail vs snapshot-absent vs upstream-dropped-the-extracted-text.
+    // Wrapped so the diagnostic can NEVER break the chat flow. Remove once fixed.
+    try {
+      logger.info(
+        {
+          messageId: message.id,
+          isAutoResponse: isAutoResponse ?? false,
+          forwarded: isForwardedMessage(message),
+          referenceType: message.reference?.type ?? null,
+          snapshotCount: message.messageSnapshots?.size ?? 0,
+          incomingContentLength: content.length,
+          extractedForwardLength: extractForwardedContent(message).length,
+          topLevelContentLength: message.content.length,
+        },
+        '[forward-probe] submitChatJob content/forward state'
+      );
+    } catch (probeErr) {
+      logger.warn({ err: probeErr }, '[forward-probe] failed to gather forward state');
+    }
 
     const denied = await this.runGates(message, personality);
     if (denied !== null) {


### PR DESCRIPTION
## Temporary diagnostic probe — forwarded-message content loss

Instrumentation to root-cause the prod bug where a native Discord forward in an activated channel produces an empty user message → the `"Hello"` placeholder → the character can't see the forwarded text (logged in `now.md` Production Issues; runtime-confirmed via the debug JSON for job `llm-dd5db39b`).

Logs at `PersonalityChatManager.submitChatJob` — the **single convergence point** for activated/reply/mention triggers — capturing:
- `forwarded` (`isForwardedMessage` result), `referenceType`, `snapshotCount`
- `incomingContentLength` (what the upstream passed), `extractedForwardLength` (what `extractForwardedContent` *would* yield), `topLevelContentLength`

This distinguishes the three candidate failure modes in **one dev repro**:
- `forwarded=false` → detection failed (the `reference.type`-not-populated fragility)
- `forwarded=true, snapshotCount=0` → Discord didn't deliver the snapshot
- `forwarded=true, extractedForwardLength>0, incomingContentLength=0` → the upstream content build dropped the extracted text (structural disconnect)

Wrapped in try/catch so the diagnostic **can never break the chat flow**. `debug`-type — to be removed in a paired `debug` removal commit once the root cause is pinned and fixed.

**Plan**: merge → dev auto-deploys → user reproduces a forward in a dev activated channel → I pull the `[forward-probe]` logs → targeted fix + regression test + remove probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)