### PR TITLE
chore(bot-client): envelope forward-safety guard + trigger matrix

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -94,6 +94,28 @@ const COMPONENT_ROUTING_RULES = [
   },
 ];
 
+// Forward-safety: in the envelope-building path (contextBuilder/ +
+// MessageContextBuilder), the trigger `message`'s content-bearing fields are
+// EMPTY for a native Discord forward — the real content lives in
+// `message.messageSnapshots`, not the top-level fields. Reading
+// `message.content`/`.attachments`/`.embeds`/`.mentions` directly there is the
+// footgun behind the forwarded-text content-loss bug (the worker re-derived the
+// turn from an empty `rawMessageContent`). Route through the forward-aware
+// helpers in utils/forwardedMessageUtils.ts instead: getEffectiveContent (text),
+// extractForwardedAttachments / buildMessageContent (attachments+images),
+// hasVoiceAttachments (voice). The selector targets the Discord `message`
+// identifier specifically, so `msg.content` (a ConversationMessage) and
+// `snapshot.content` are unaffected. A legitimate non-forward read can suppress
+// with an eslint-disable + a concrete justification.
+const FORWARD_SAFE_MESSAGE_READ_RULES = [
+  {
+    selector:
+      "MemberExpression[object.name='message'][property.name=/^(content|attachments|embeds|mentions)$/]",
+    message:
+      "Don't read message.content/.attachments/.embeds/.mentions directly in the envelope-building path — they are EMPTY for forwarded triggers (content rides message.messageSnapshots). Use the forward-aware helpers in utils/forwardedMessageUtils.ts (getEffectiveContent, extractForwardedAttachments, hasVoiceAttachments) or buildMessageContent. Suppress with a justification only for a verified non-forward read.",
+  },
+];
+
 const IDENTITY_PROVISIONING_RULES = [
   {
     selector:
@@ -471,6 +493,30 @@ export default tseslint.config(
     ],
     rules: {
       'no-restricted-syntax': ['error', ...PINO_LOGGER_RULES],
+    },
+  },
+
+  // Forward-safety guard for the envelope-building path. Replicates the main
+  // block's bot-client `no-restricted-syntax` rules (flat config's last-match-
+  // wins would otherwise drop them for these files) and adds the
+  // FORWARD_SAFE_MESSAGE_READ_RULES ban on direct message.content/.attachments/
+  // .embeds/.mentions reads. Scoped to where the trigger context is assembled —
+  // the bug class is "a raw message-field read that's empty for a forward."
+  {
+    files: [
+      'services/bot-client/src/services/contextBuilder/**/*.ts',
+      'services/bot-client/src/services/MessageContextBuilder.ts',
+    ],
+    ignores: ['**/*.test.ts', '**/*.spec.ts'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        ...PINO_LOGGER_RULES,
+        ...IDENTITY_PROVISIONING_RULES,
+        ...SEND_TYPING_RULES,
+        ...COMPONENT_ROUTING_RULES,
+        ...FORWARD_SAFE_MESSAGE_READ_RULES,
+      ],
     },
   },
 

--- a/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.test.ts
+++ b/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.test.ts
@@ -239,23 +239,44 @@ describe('buildRawAssemblyInputs', () => {
     expect(raw?.rawRoutingTranscript).toBe('the spoken words');
   });
 
-  it('forwarded trigger: rawMessageContent carries the snapshot text, not the empty top-level content', () => {
-    // Regression (forward content-loss): a native Discord forward has empty
-    // message.content; its text lives in messageSnapshots. The worker re-derives
-    // the current turn SOLELY from rawMessageContent, so a bare message.content
-    // would drop the whole forward and the AI would see an empty turn ("Hello").
-    const raw = buildRawAssemblyInputs(
-      makeForwardedMessage('the forwarded text', { withReferenceType: true }),
-      undefined
-    );
-    expect(raw?.rawMessageContent).toBe('the forwarded text');
-  });
-
-  it('forwarded trigger detected via snapshot fallback (reference.type unpopulated) still carries the text', () => {
-    // Discord.js sometimes leaves reference.type unset; isForwardedMessage falls
-    // back to messageSnapshots.size > 0. The fix must survive that path too.
-    const raw = buildRawAssemblyInputs(makeForwardedMessage('snapshot-only forward'), undefined);
-    expect(raw?.rawMessageContent).toBe('snapshot-only forward');
+  // The worker's ContextAssembler re-derives the current turn SOLELY from
+  // rawMessageContent. This matrix is the regression guard for the forward
+  // content-loss bug: every trigger type must land its EFFECTIVE text here, or
+  // the AI sees an empty turn (the "Hello" placeholder). Parameterized so a new
+  // trigger type can't be added without a row — the gap that let the forward
+  // case ship unnoticed.
+  it.each([
+    {
+      trigger: 'normal text',
+      message: () => makeMessage([], 'hello there'),
+      expected: 'hello there',
+    },
+    {
+      trigger: 'forward (reference.type=Forward)',
+      message: () => makeForwardedMessage('forwarded body', { withReferenceType: true }),
+      expected: 'forwarded body',
+    },
+    {
+      trigger: 'forward (snapshot-size fallback, reference.type unset)',
+      message: () => makeForwardedMessage('snapshot-only body'),
+      expected: 'snapshot-only body',
+    },
+    {
+      trigger: 'forward with non-empty top-level content (snapshot text wins)',
+      message: () =>
+        makeForwardedMessage('snapshot wins', {
+          withReferenceType: true,
+          topLevelContent: 'wrapper note that must NOT win',
+        }),
+      expected: 'snapshot wins',
+    },
+    {
+      trigger: 'voice (empty content — worker re-transcribes, turn stays empty)',
+      message: () => makeMessage([], ''),
+      expected: '',
+    },
+  ])('rawMessageContent for $trigger → "$expected"', ({ message, expected }) => {
+    expect(buildRawAssemblyInputs(message(), undefined)?.rawMessageContent).toBe(expected);
   });
 
   it('leaves rawRoutingTranscript absent for non-voice triggers', () => {

--- a/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.ts
+++ b/services/bot-client/src/services/contextBuilder/RawEnvelopeBuilder.ts
@@ -142,6 +142,14 @@ export function buildRawAssemblyInputs(
     rawActiveGuildMemberInfo?: GuildMemberInfo;
   }
 ): RawAssemblyInputs {
+  // Wrapper-only mentions: message.mentions reflects the trigger message's OWN
+  // parsed mentions, which are empty for a forward — the snapshot's <@id> tokens
+  // aren't here. Resolving forward-snapshot user-mentions is a tracked follow-up
+  // (cold/follow-ups.md): non-trivial because MessageSnapshot strips mention
+  // metadata, so it needs regex + a per-id fetch. The forward's text still reaches
+  // the AI via rawMessageContent; only embedded <@id> name-substitution degrades.
+  // eslint-disable-next-line no-restricted-syntax -- wrapper-only mentions; forward-snapshot <@id> resolution is a tracked follow-up (cold/follow-ups.md)
+  const wrapperMentionedUsers = message.mentions.users;
   return {
     // getEffectiveContent yields message.content for normal triggers and the
     // forward snapshot text for forwarded ones; a bare message.content is empty
@@ -157,8 +165,8 @@ export function buildRawAssemblyInputs(
     rawMentionedChannels: refs?.rawMentionedChannels,
     rawMentionedRoles: refs?.rawMentionedRoles,
     rawMentionedUsers:
-      message.mentions.users.size > 0
-        ? [...message.mentions.users.values()].map(u => ({
+      wrapperMentionedUsers.size > 0
+        ? [...wrapperMentionedUsers.values()].map(u => ({
             discordId: u.id,
             username: u.username,
             displayName: u.globalName ?? u.username,

--- a/services/bot-client/src/services/contextBuilder/ReferenceExtractor.ts
+++ b/services/bot-client/src/services/contextBuilder/ReferenceExtractor.ts
@@ -16,7 +16,7 @@ import {
   type RawMentionedRole,
 } from '@tzurot/common-types';
 import { MessageReferenceExtractor } from '../../handlers/MessageReferenceExtractor.js';
-import { isVoiceAttachment } from '../../utils/voiceAttachment.js';
+import { hasVoiceAttachments } from '../../utils/forwardedMessageUtils.js';
 import type { MentionResolver } from '../MentionResolver.js';
 
 const logger = createLogger('MessageContextBuilder');
@@ -121,7 +121,9 @@ function logVoiceReplyDiagnostics(
   content: string,
   history: ConversationMessage[]
 ): void {
-  const hasVoiceAttachment = message.attachments.some(isVoiceAttachment);
+  // Forward-aware: a forwarded voice message keeps its audio in the snapshot,
+  // not message.attachments — hasVoiceAttachments walks both.
+  const hasVoiceAttachment = hasVoiceAttachments(message);
   if (!hasVoiceAttachment) {
     return;
   }


### PR DESCRIPTION
## Why

Follow-up to the forwarded-message content-loss fix (#1391). That bug — a native Discord forward's text lives in `message.messageSnapshots`, not the top-level fields, so the worker re-derived an empty turn → "Hello" placeholder — was one instance of a **class**: any direct `message.X` read in the envelope-building path is empty/wrong for a forward. The `forwardedMessageUtils` JSDoc warned about it, but documentation isn't enforcement, and there was no test asserting per-trigger that the turn survives. This PR adds the structural prevention + the missing regression guard.

Scope from the envelope regression audit: of ~15 `rawAssemblyInputs` fields, 13 were forward-correct; only the turn text (fixed in #1391) and user-mentions had the gap.

## Changes

### `fix`: forward-aware voice detection (`ReferenceExtractor`)
`logVoiceReplyDiagnostics` gated on `message.attachments.some(isVoiceAttachment)` — empty for a forwarded voice message. Swapped to the canonical forward-aware `hasVoiceAttachments(message)` (walks direct + snapshot audio). Minor, but a real same-class instance the guard surfaced.

### `chore`: the structural hardening
- **Lint guard** — `no-restricted-syntax` (`FORWARD_SAFE_MESSAGE_READ_RULES`) scoped to `contextBuilder/**` + `MessageContextBuilder.ts`, banning direct `message.{content,attachments,embeds,mentions}` member access. The selector targets the Discord `message` identifier specifically (so `msg.content` on a `ConversationMessage` and `snapshot.content` are unaffected). Replicates the main block's bot-client rules (flat-config last-match-wins would otherwise drop logger/typing/component enforcement) — mirrors the existing `api-gateway/routes/**` override pattern. **Verified it fires on the original bug shape.**
- **`rawMentionedUsers`** — the one known remaining read (`message.mentions.users`, the wrapper's mentions, empty for a forward) isolated to a single line with a justified `eslint-disable`; proper forward-snapshot `<@id>` resolution is tracked in `cold/follow-ups.md` (non-trivial: `MessageSnapshot` strips mention metadata).
- **Trigger-type matrix test** — parameterized `{normal / forward / snapshot-fallback / forward+top-level-content / voice}` asserting `rawMessageContent` (the worker's sole turn source) per trigger. A new trigger type can't be added without a row — closing the test gap that let the forward case ship. Also exercises the `topLevelContent` test-helper opt (the "snapshot wins over top-level content" row).

## Deferred (tracked, not bundled)
The dead `LinkExtractor.extractLinkReferences` (audit finding #2) is safe to delete — `ReferenceCrawler` calls `fetchMessageFromLink`, not it — but its ~35 tests may be the only coverage for the *live* `fetchMessageFromLink`/`verifyInvokerCanAccessSource`. Deleting them needs a coverage check, so it's its own small PR (stays in `cold/follow-ups.md`; dead code, zero runtime risk).

## Verification
- Guard fires on exactly the 2 pre-fix sites; clean after the fix + disable.
- `pnpm test` 25/25, `pnpm quality` clean (lint validated the eslint-config change across all packages).
- Trigger matrix green (5 rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)