### PR TITLE
fix(bot-client): /settings preset set + set-default send the chosen slot (S4b-2a)

### DIFF
--- a/services/bot-client/src/commands/settings/preset/handlers.test.ts
+++ b/services/bot-client/src/commands/settings/preset/handlers.test.ts
@@ -112,10 +112,11 @@ describe('Preset Command Handlers', () => {
 
       await handleSet(createMockContext());
 
-      expect(stub.setModelOverride).toHaveBeenCalledWith({
-        personalityId: PERSONALITY_ID_1,
-        configId: CONFIG_ID_1,
-      });
+      // No slot option → defaults to the text (chat) slot.
+      expect(stub.setModelOverride).toHaveBeenCalledWith(
+        { personalityId: PERSONALITY_ID_1, configId: CONFIG_ID_1 },
+        { kind: 'text' }
+      );
       expect(mockEditReply).toHaveBeenCalledWith({
         embeds: [
           expect.objectContaining({

--- a/services/bot-client/src/commands/settings/preset/set-default.test.ts
+++ b/services/bot-client/src/commands/settings/preset/set-default.test.ts
@@ -50,12 +50,16 @@ describe('handleSetDefault', () => {
     mockEditReply.mockResolvedValue(undefined);
   });
 
-  function createMockContext(configId: string) {
+  function createMockContext(configId: string, kind?: string) {
     return {
       user: { id: 'user-123', username: 'testuser' },
       interaction: {
         options: {
-          getString: (_name: string, _required?: boolean) => configId,
+          getString: (name: string, _required?: boolean) => {
+            if (name === 'preset') return configId;
+            if (name === 'kind') return kind ?? null;
+            return null;
+          },
         },
       },
       editReply: mockEditReply,
@@ -82,9 +86,24 @@ describe('handleSetDefault', () => {
 
     await handleSetDefault(createMockContext('00000000-0000-4000-8000-000000000456'));
 
-    expect(stub.setDefaultModelConfig).toHaveBeenCalledWith({
-      configId: '00000000-0000-4000-8000-000000000456',
-    });
+    // No slot option → defaults to the text (chat) default.
+    expect(stub.setDefaultModelConfig).toHaveBeenCalledWith(
+      { configId: '00000000-0000-4000-8000-000000000456' },
+      { kind: 'text' }
+    );
+  });
+
+  it('sends the vision slot when kind:vision is chosen (the vision-default fix)', async () => {
+    mockNonGuestUserApis('00000000-0000-4000-8000-0000000000a1', 'Gemini Vision');
+
+    await handleSetDefault(createMockContext('00000000-0000-4000-8000-0000000000a1', 'vision'));
+
+    // The slot must reach the gateway — without it, a vision default silently
+    // lands in the text slot (the bug this fix closes).
+    expect(stub.setDefaultModelConfig).toHaveBeenCalledWith(
+      { configId: '00000000-0000-4000-8000-0000000000a1' },
+      { kind: 'vision' }
+    );
   });
 
   it('should display success embed on successful update', async () => {
@@ -189,9 +208,10 @@ describe('handleSetDefault', () => {
 
     await handleSetDefault(createMockContext('00000000-0000-4000-8000-000000000f00'));
 
-    expect(stub.setDefaultModelConfig).toHaveBeenCalledWith({
-      configId: '00000000-0000-4000-8000-000000000f00',
-    });
+    expect(stub.setDefaultModelConfig).toHaveBeenCalledWith(
+      { configId: '00000000-0000-4000-8000-000000000f00' },
+      { kind: 'text' }
+    );
     expect(mockEditReply).toHaveBeenCalledWith({
       embeds: [
         expect.objectContaining({

--- a/services/bot-client/src/commands/settings/preset/set-default.ts
+++ b/services/bot-client/src/commands/settings/preset/set-default.ts
@@ -9,6 +9,8 @@ import {
   createLogger,
   DISCORD_COLORS,
   settingsPresetSetDefaultOptions,
+  toConfigKind,
+  DEFAULT_CONFIG_KIND,
 } from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
 import { clientsFor } from '../../../utils/gatewayClients.js';
@@ -22,9 +24,11 @@ const logger = createLogger('settings-preset-set-default');
 export async function handleSetDefault(context: DeferredCommandContext): Promise<void> {
   const userId = context.user.id;
   const options = settingsPresetSetDefaultOptions(context.interaction);
-  // The `kind` option only scopes the preset autocomplete; the route infers
-  // kind from the chosen config row, so it isn't read or sent here.
   const configId = options.preset();
+  // The slot (text = chat default, or vision) decides which default FK the value
+  // writes; the gateway capability-gates the vision slot. Without sending it a
+  // vision default silently lands in the text slot — mirror clear-default.
+  const kind = toConfigKind(options.kind() ?? DEFAULT_CONFIG_KIND);
 
   if (await handleUnlockModelsUpsell(context, configId, userId)) {
     return;
@@ -38,10 +42,10 @@ export async function handleSetDefault(context: DeferredCommandContext): Promise
     }
     const { reason } = outcome;
 
-    const result = await userClient.setDefaultModelConfig({ configId });
+    const result = await userClient.setDefaultModelConfig({ configId }, { kind });
 
     if (!result.ok) {
-      logger.warn({ userId, status: result.status, configId }, 'Failed to set default');
+      logger.warn({ userId, status: result.status, configId, kind }, 'Failed to set default');
       await context.editReply({ content: `❌ Failed to set default: ${result.error}` });
       return;
     }
@@ -61,7 +65,7 @@ export async function handleSetDefault(context: DeferredCommandContext): Promise
     await context.editReply({ embeds: [embed] });
 
     logger.info(
-      { userId, configId, configName: data.default.configName, reason },
+      { userId, configId, configName: data.default.configName, kind, reason },
       'Set default config'
     );
   } catch (error) {

--- a/services/bot-client/src/commands/settings/preset/set.test.ts
+++ b/services/bot-client/src/commands/settings/preset/set.test.ts
@@ -44,7 +44,7 @@ describe('Me Preset Set Handler', () => {
     stub.setModelOverride.mockReset();
   });
 
-  function createMockContext(personalityId: string, presetId: string) {
+  function createMockContext(personalityId: string, presetId: string, kind?: string) {
     return {
       user: { id: 'user-123', username: 'testuser' },
       interaction: {
@@ -52,6 +52,7 @@ describe('Me Preset Set Handler', () => {
           getString: (name: string, _required?: boolean) => {
             if (name === 'character') return personalityId;
             if (name === 'preset') return presetId;
+            if (name === 'kind') return kind ?? null;
             return null;
           },
         },
@@ -98,10 +99,11 @@ describe('Me Preset Set Handler', () => {
 
       await handleSet(createMockContext('personality-1', 'config-1'));
 
-      expect(stub.setModelOverride).toHaveBeenCalledWith({
-        personalityId: 'personality-1',
-        configId: 'config-1',
-      });
+      // No slot option → defaults to the text (chat) slot.
+      expect(stub.setModelOverride).toHaveBeenCalledWith(
+        { personalityId: 'personality-1', configId: 'config-1' },
+        { kind: 'text' }
+      );
 
       const embedCall = mockEditReply.mock.calls[0][0] as { embeds: EmbedBuilder[] };
       const embed = embedCall.embeds[0];
@@ -113,6 +115,31 @@ describe('Me Preset Set Handler', () => {
 
       // Paid path: wallet check short-circuits, configs not fetched
       expect(stub.listUserLlmConfigs).not.toHaveBeenCalled();
+    });
+
+    it('sends the vision slot when kind:vision is chosen (the vision-set fix)', async () => {
+      stub.listWalletKeys.mockResolvedValue(
+        makeOk({ keys: [{ provider: 'openrouter', isActive: true }] })
+      );
+      stub.setModelOverride.mockResolvedValue(
+        makeOk({
+          override: {
+            personalityId: 'personality-1',
+            personalityName: 'Test Bot',
+            configId: 'vision-config',
+            configName: 'Gemini Vision',
+          },
+        })
+      );
+
+      await handleSet(createMockContext('personality-1', 'vision-config', 'vision'));
+
+      // The slot must reach the gateway — without it, a vision override silently
+      // lands in the text slot (the bug this fix closes).
+      expect(stub.setModelOverride).toHaveBeenCalledWith(
+        { personalityId: 'personality-1', configId: 'vision-config' },
+        { kind: 'vision' }
+      );
     });
 
     it('should block guest mode users from using premium models', async () => {
@@ -168,10 +195,10 @@ describe('Me Preset Set Handler', () => {
 
       await handleSet(createMockContext('personality-1', 'free-config'));
 
-      expect(stub.setModelOverride).toHaveBeenCalledWith({
-        personalityId: 'personality-1',
-        configId: 'free-config',
-      });
+      expect(stub.setModelOverride).toHaveBeenCalledWith(
+        { personalityId: 'personality-1', configId: 'free-config' },
+        { kind: 'text' }
+      );
     });
 
     it('should handle API error when setting override', async () => {

--- a/services/bot-client/src/commands/settings/preset/set.ts
+++ b/services/bot-client/src/commands/settings/preset/set.ts
@@ -4,7 +4,13 @@
  */
 
 import { EmbedBuilder } from 'discord.js';
-import { createLogger, DISCORD_COLORS, settingsPresetSetOptions } from '@tzurot/common-types';
+import {
+  createLogger,
+  DISCORD_COLORS,
+  settingsPresetSetOptions,
+  toConfigKind,
+  DEFAULT_CONFIG_KIND,
+} from '@tzurot/common-types';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
 import {
   AUTOCOMPLETE_UNAVAILABLE_MESSAGE,
@@ -22,9 +28,11 @@ export async function handleSet(context: DeferredCommandContext): Promise<void> 
   const userId = context.user.id;
   const options = settingsPresetSetOptions(context.interaction);
   const personalityId = options.character();
-  // The `kind` option only scopes the preset autocomplete; the route infers
-  // kind from the chosen config row, so it isn't read or sent here.
   const configId = options.preset();
+  // The slot (text = chat default, or vision) decides which FK the override
+  // writes; the gateway capability-gates the vision slot. Without sending it a
+  // vision override silently lands in the text slot — mirror clear, which sends it.
+  const kind = toConfigKind(options.kind() ?? DEFAULT_CONFIG_KIND);
 
   if (isAutocompleteErrorSentinel(personalityId)) {
     await context.editReply({ content: AUTOCOMPLETE_UNAVAILABLE_MESSAGE });
@@ -43,11 +51,11 @@ export async function handleSet(context: DeferredCommandContext): Promise<void> 
     }
     const { reason } = outcome;
 
-    const result = await userClient.setModelOverride({ personalityId, configId });
+    const result = await userClient.setModelOverride({ personalityId, configId }, { kind });
 
     if (!result.ok) {
       logger.warn(
-        { userId, status: result.status, personalityId, configId },
+        { userId, status: result.status, personalityId, configId, kind },
         'Failed to set override'
       );
       await context.editReply({ content: `❌ Failed to set preset: ${result.error}` });
@@ -74,6 +82,7 @@ export async function handleSet(context: DeferredCommandContext): Promise<void> 
         personalityName: data.override.personalityName,
         configId,
         configName: data.override.configName,
+        kind,
         reason,
       },
       'Set override'


### PR DESCRIPTION
## The bug

`/settings preset set` and `/settings preset set-default` each define a `kind` (text|vision) option but **never read or send it**. It's a leftover from the removed S2c row-inference, where the gateway used to derive the slot from the chosen config's `kind` column.

Post-Phase-3, the gateway picks the slot from `?kind=` (defaulting to text) and capability-gates the vision slot (`model-override.ts` `handleSetModelOverride` / `handleSetDefaultModelConfig` → `ensureVisionCapableModel`). So a vision override/default was **silently written to the text slot**:

- `clear` / `clear-default` already send `kind` → you can *remove* a vision override.
- `set` / `set-default` didn't → you could never *create* one.

That set/clear asymmetry is the functional gap S2 explicitly deferred to S4 ("bot-client sends the slot").

## The fix

Both setters now read `options.kind()` and forward `{ kind }` to `setModelOverride` / `setDefaultModelConfig`, mirroring clear/clear-default. The generated client methods already accept the `{ kind?: string }` options arg — only the call sites needed it.

**No command-structure change**: the `kind` option already exists (it already scopes the preset autocomplete). So picking `kind:Vision` now *both* scopes autocomplete to vision presets *and* writes the vision slot — finally consistent. No manifest/snapshot churn.

## Scope

This is the **behavioral** half, isolated so the bug ships clean and reviewable. The cosmetic/structural churn — `kind`→`slot` (Chat/Vision) rename, browse `kind`→`capability` + internal `PresetKindFilter` rename, `/preset create` dropping the option, autocomplete overhaul — follows in **S4b-2b** (which regenerates the manifest + component snapshots).

## Verification

- `set.test.ts` / `set-default.test.ts` / `handlers.test.ts`: existing call-shape assertions updated to the 2-arg form; **new `kind:vision` coverage** added to both setters (the path that was silently broken). 66/66 in `settings/preset/` green.
- `pnpm quality` green.
- Gateway capability-gate + per-slot FK write confirmed end-to-end (`model-override.ts:274-311`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)