### PR TITLE
fix(api-gateway): beta.142 release-review fixes (kind-scoped edit collision + singleton read)

### DIFF
--- a/services/api-gateway/src/routes/admin/llm-config.test.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.test.ts
@@ -674,6 +674,15 @@ describe('Admin LLM Config Routes', () => {
 
   describe('PUT /admin/llm-config/:id', () => {
     it('should return 400 when model validation fails on update', async () => {
+      // The config must exist (and pass the kind check) before model validation
+      // runs — validation is now after the row fetch, so mock findUnique.
+      prisma.llmConfig.findUnique.mockResolvedValue({
+        id: 'config-id',
+        name: 'Existing',
+        isGlobal: true,
+        memoryScoreThreshold: { toNumber: () => 0.5 },
+        memoryLimit: 20,
+      });
       mockValidateLlmConfigModelFields.mockImplementationOnce(
         async (opts: { res: { status: (n: number) => { json: (body: unknown) => unknown } } }) => {
           opts.res
@@ -758,6 +767,28 @@ describe('Admin LLM Config Routes', () => {
         data: { model: 'qwen/qwen3-vl-30b-a3b-instruct' },
         select: expect.any(Object),
       });
+    });
+
+    it('rejects a kind-mismatched edit (404) before the model/vision gate runs', async () => {
+      // The row is a TEXT config but the caller claims ?kind=vision. The row
+      // fetch + requireKind must reject (404) BEFORE model validation — otherwise
+      // the vision-capability gate would fire a misleading 400 and leak that the
+      // id exists. Guards the validate-after-fetch ordering.
+      prisma.llmConfig.findUnique.mockResolvedValue({
+        id: 'text-cfg',
+        name: 'Text Cfg',
+        isGlobal: true,
+        kind: 'text',
+        memoryScoreThreshold: { toNumber: () => 0.5 },
+        memoryLimit: 20,
+      });
+
+      const response = await request(app)
+        .put('/admin/llm-config/text-cfg?kind=vision')
+        .send({ model: 'openai/gpt-4o-mini' });
+
+      expect(response.status).toBe(404);
+      expect(prisma.llmConfig.update).not.toHaveBeenCalled();
     });
 
     it('should accept memory settings in update (Phase 1 parity fix)', async () => {
@@ -1278,6 +1309,43 @@ describe('Admin LLM Config Routes', () => {
       expect(response.status).toBe(400);
       expect(response.body.message).toMatch(/already exists/i);
       expect(prisma.llmConfig.update).not.toHaveBeenCalled();
+    });
+
+    it('scopes the rename collision check to the config kind (vision rename ignores a same-named text config)', async () => {
+      // The vision config being renamed.
+      prisma.llmConfig.findUnique.mockResolvedValue({
+        id: 'vision-id',
+        name: 'Old Vision',
+        isGlobal: true,
+        kind: 'vision',
+        memoryScoreThreshold: { toNumber: () => 0.5 },
+        memoryLimit: 20,
+      });
+      // A config named "Foo" exists ONLY in the text namespace. The collision
+      // check must query kind=vision (finds nothing) — before the fix it queried
+      // the text namespace and falsely blocked the rename.
+      prisma.llmConfig.findFirst.mockImplementation((args: { where?: { kind?: string } }) =>
+        Promise.resolve(args?.where?.kind === 'text' ? { id: 'text-foo' } : null)
+      );
+      prisma.llmConfig.update.mockResolvedValue({
+        id: 'vision-id',
+        name: 'Foo',
+        isGlobal: true,
+        kind: 'vision',
+        memoryScoreThreshold: { toNumber: () => 0.5 },
+        memoryLimit: 20,
+      });
+
+      const response = await request(app)
+        .put('/admin/llm-config/vision-id?kind=vision')
+        .send({ name: 'Foo' });
+
+      // Vision namespace has no "Foo" → rename allowed (not the false 400).
+      expect(response.status).toBe(200);
+      // The collision query was scoped to the vision namespace, not text.
+      expect(prisma.llmConfig.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ kind: 'vision' }) })
+      );
     });
 
     it('should allow keeping the same name (no duplicate check against self)', async () => {

--- a/services/api-gateway/src/routes/admin/llm-config.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.ts
@@ -171,18 +171,11 @@ function createEditConfigHandler(
       return;
     }
 
-    if (
-      !(await validateLlmConfigModelFields({
-        res,
-        modelCache,
-        body,
-        fallback: { service, configId: configId },
-        hasZaiCodingKey: true,
-      }))
-    ) {
-      return;
-    }
-
+    // Fetch + kind-verify the row FIRST, so the model/vision validation below
+    // runs against the row's real (requireKind-verified) kind rather than the
+    // caller-supplied query param. Otherwise `?kind=vision` on a text config
+    // would fire a misleading vision-capability 400 (and leak that the id exists)
+    // before requireKind rejects the kind mismatch.
     const existing = await findGlobalConfigOrSendError(
       res,
       () =>
@@ -202,11 +195,32 @@ function createEditConfigHandler(
     }
 
     if (
+      !(await validateLlmConfigModelFields({
+        res,
+        modelCache,
+        body,
+        fallback: { service, configId: configId },
+        hasZaiCodingKey: true,
+        // `kind` is verified against the row by requireKind above, so the
+        // vision-capability gate trusts it without a redundant getById fetch.
+        kind,
+      }))
+    ) {
+      return;
+    }
+
+    if (
       body.name !== undefined &&
       !(await ensureNoNameCollision(res, service, {
         name: body.name,
         scope: { type: 'GLOBAL' },
         excludeId: configId,
+        // Scope the collision check to the config's kind — global names are unique
+        // per (kind, name) (`llm_configs_global_name_unique`), so a vision rename
+        // must check the vision namespace, not text. Without this the helper
+        // defaults to text → false block across namespaces, or false pass → a
+        // Postgres unique-constraint 500.
+        kind,
         formatCollisionMessage: n => `A global config named "${n}" already exists`,
       }))
     ) {

--- a/services/api-gateway/src/services/LlmConfigService.test.ts
+++ b/services/api-gateway/src/services/LlmConfigService.test.ts
@@ -11,7 +11,7 @@ import {
   CloneNameExhaustedError,
   type LlmConfigScope,
 } from './LlmConfigService.js';
-import type { PrismaClient } from '@tzurot/common-types';
+import { type PrismaClient, ADMIN_SETTINGS_SINGLETON_ID } from '@tzurot/common-types';
 import type { LlmConfigCacheInvalidationService } from '@tzurot/cache-invalidation';
 
 // Mock logger
@@ -53,7 +53,7 @@ function createMockPrisma() {
   };
 
   const mockAdminSettings = {
-    upsert: vi.fn().mockResolvedValue({ id: 'admin-settings-singleton' }),
+    upsert: vi.fn().mockResolvedValue({ id: ADMIN_SETTINGS_SINGLETON_ID }),
     // list() derives isDefault/isFreeDefault from these pointers; default = none set.
     findFirst: vi.fn().mockResolvedValue(null),
   };
@@ -226,6 +226,11 @@ describe('LlmConfigService', () => {
       expect(result.find(c => c.id === 'the-default')?.isDefault).toBe(true);
       expect(result.find(c => c.id === 'the-free')?.isFreeDefault).toBe(true);
       expect(result.find(c => c.id === 'plain')?.isDefault).toBe(false);
+      // The singleton pointer read is id-filtered, not a bare findFirst — keeps
+      // the flags correct even if a stray admin_settings row ever appeared.
+      expect(prisma.adminSettings.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: ADMIN_SETTINGS_SINGLETON_ID } })
+      );
     });
 
     it('treats a config targeted by the VISION default pointer as isDefault ("any-default" semantics)', async () => {

--- a/services/api-gateway/src/services/LlmConfigService.ts
+++ b/services/api-gateway/src/services/LlmConfigService.ts
@@ -253,9 +253,12 @@ export class LlmConfigService {
     globalDefaultIds: Set<string>;
     freeDefaultIds: Set<string>;
   }> {
-    // findFirst (not findUnique-by-id) mirrors the delete-guard's singleton read
-    // in routes/admin/llm-config.ts — one consistent way to read the pointers.
+    // Read the AdminSettings singleton by its fixed id — same filter the
+    // delete-guard and VisionConfigResolver use. There's only ever one row, but
+    // the explicit id keeps this correct (right default flags + ordering) if a
+    // stray row ever appeared.
     const settings = await this.prisma.adminSettings.findFirst({
+      where: { id: ADMIN_SETTINGS_SINGLETON_ID },
       select: {
         globalDefaultLlmConfigId: true,
         globalDefaultVisionConfigId: true,

--- a/services/api-gateway/src/utils/llmConfigValidation.ts
+++ b/services/api-gateway/src/utils/llmConfigValidation.ts
@@ -74,25 +74,29 @@ export interface ValidateLlmConfigModelFieldsOptions {
     configId: string;
   };
   /**
-   * Config kind, gating the vision capability check. Pass it explicitly on the
-   * **create** path (from `body.kind`). On the **update** path leave it
-   * undefined — kind is immutable (never in the update body), so the helper
-   * derives it from the existing row via `fallback`. When neither is available
-   * it defaults to {@link DEFAULT_CONFIG_KIND} (text), which never rejects.
+   * Config kind, gating the vision capability check. Pass it explicitly whenever
+   * the caller already knows a verified kind — the **create** path (`body.kind`)
+   * and the **admin edit** path (the `requireKind`-checked value, after the row
+   * fetch) both do; this lets the helper skip a redundant `getById`. Leave it
+   * undefined when the kind isn't known to the caller (e.g. the user edit path) —
+   * the helper then derives it from the existing row via `fallback` (kind is
+   * immutable, never in the update body). When neither is available it defaults
+   * to {@link DEFAULT_CONFIG_KIND} (text), which never rejects.
    */
   kind?: ConfigKind;
 }
 
 /**
- * Resolve the effective model + kind for validation. On the update path the
- * stored row is the source of truth for both: the model fallback (when the body
- * omits it, so contextWindowTokens can still be validated against a known model)
- * AND the immutable kind (never in the update body, so only knowable from the
- * row). A single getById serves both, fetched only when something needs it:
+ * Resolve the effective model + kind for validation. The stored row is the
+ * fallback source for both: the model (when the body omits it, so
+ * contextWindowTokens can still be validated against a known model) AND the
+ * immutable kind (never in the update body). A single getById serves both,
+ * fetched only when something needs it:
  *  - model fallback: the body omits `model`.
- *  - kind for the capability gate: a model IS being set and kind is unknown
- *    (the update path never passes kind). A context-only edit doesn't need the
- *    kind, so it isn't derived.
+ *  - kind for the capability gate: a model IS being set and the caller didn't
+ *    pass `kind`. Callers with an already-verified kind (create from `body.kind`,
+ *    admin edit from the `requireKind`-checked value) pass it, so this fetch is
+ *    skipped; a context-only edit doesn't need the kind either.
  */
 async function resolveEffectiveModelAndKind(
   opts: ValidateLlmConfigModelFieldsOptions


### PR DESCRIPTION
The beta.142 holistic release review (#1398) surfaced three findings — all in this epic's own kind-namespacing code. Fixed here so they ride the release rather than ship as known bugs.

## 🔴 High — admin edit name-collision used the wrong namespace
`createEditConfigHandler` called `ensureNoNameCollision` **without** `kind`, so the helper defaulted to `text`. Renaming a **vision** config then checked the **text** namespace:
- **False block** — a vision rename to a name that exists only in text was wrongly rejected.
- **False pass → 500** — a vision rename to a name that exists in *vision* slipped the app check and hit the Postgres `(kind, name)` unique constraint as an opaque 500.

The create handler already passed `kind`; the edit handler missed it. Now passes the in-scope `kind`. **Test**: a vision rename ignores a same-named text config (200, collision query scoped to `kind: 'vision'`).

## 🟡 Medium — singleton read without an id filter
`getDefaultPointerSets` (`LlmConfigService`) read the `AdminSettings` singleton via `findFirst` with **no `where`** (and an inaccurate "mirrors the delete-guard" comment — the delete-guard *does* filter by id). Harmless today (one row) but would derive wrong default flags/ordering if a stray row appeared. Now `where: { id: ADMIN_SETTINGS_SINGLETON_ID }` (already imported). **Test**: the list path asserts the id-filtered read.

## 🔵 Low — two round-trips for the config kind on admin model-edit
`validateLlmConfigModelFields` was called without `kind`, forcing an extra `getById` to learn it for the vision gate — then the handler re-fetched the same row. Now passes the in-scope `kind`, skipping the redundant fetch (no behavior change; covered by the existing edit tests).

The ℹ️ informational finding (two default-pointer slots have no resolver consumer yet) is already tracked in `cold/follow-ups.md` (the pointer-cascade item).

## Verification
- `pnpm quality` green; gateway suites green (120 tests across the two touched files + helpers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)