### PR TITLE
fix(bot-client): ack-first in 3 dashboard handlers (defer before Redis/gateway)

### DIFF
--- a/services/bot-client/src/commands/deny/detailEdit.test.ts
+++ b/services/bot-client/src/commands/deny/detailEdit.test.ts
@@ -288,27 +288,7 @@ describe('handleEditModal', () => {
     expect(stub.addDenylistEntry).not.toHaveBeenCalled();
   });
 
-  it('falls back to followUp when the session-expired reply hits 10062 (modal submit path)', async () => {
-    mockSessionManager.get.mockResolvedValue(null);
-    const interaction = createMockModalInteraction('deny::modal::entry-uuid-1234::edit', {});
-    const timeoutError = new DiscordAPIError(
-      { code: 10062, message: 'Unknown interaction' },
-      10062,
-      404,
-      'POST',
-      '/interactions/x/y/callback',
-      {}
-    );
-    vi.mocked(interaction.reply).mockRejectedValue(timeoutError);
-
-    await expect(handleEditModal(interaction, 'entry-uuid-1234')).resolves.toBeUndefined();
-
-    expect(interaction.followUp).toHaveBeenCalledWith(
-      expect.objectContaining({ content: expect.stringContaining('Session expired') })
-    );
-  });
-
-  it('should handle session expiry', async () => {
+  it('defers then followUps on session expiry (ack-first)', async () => {
     mockSessionManager.get.mockResolvedValue(null);
     const interaction = createMockModalInteraction('deny::modal::entry-uuid-1234::edit', {
       scope: 'BOT',
@@ -318,9 +298,16 @@ describe('handleEditModal', () => {
 
     await handleEditModal(interaction, 'entry-uuid-1234');
 
-    expect(interaction.reply).toHaveBeenCalledWith(
+    // Ack-first: deferUpdate precedes the Redis session read; expiry uses followUp
+    // (reply would throw on the already-acked interaction). The old read-then-reply
+    // path — with its 10062 reply→followUp fallback — is gone for the modal-submit
+    // handler; that fallback now only guards the modal-OPEN handler, which can't
+    // defer before showModal.
+    expect(interaction.deferUpdate).toHaveBeenCalled();
+    expect(interaction.followUp).toHaveBeenCalledWith(
       expect.objectContaining({ content: expect.stringContaining('Session expired') })
     );
+    expect(interaction.reply).not.toHaveBeenCalled();
   });
 
   it('should handle API error on edit', async () => {

--- a/services/bot-client/src/commands/deny/detailEdit.ts
+++ b/services/bot-client/src/commands/deny/detailEdit.ts
@@ -172,6 +172,12 @@ export async function handleEditModal(
   interaction: ModalSubmitInteraction,
   entryId: string
 ): Promise<void> {
+  // Ack first (3-second rule): deferUpdate before the Redis session read. On
+  // expiry, followUp — reply would throw on the already-acked interaction. (The
+  // modal-OPEN handler keeps showModalWithTimeoutCatch: showModal cannot be
+  // preceded by a defer, so that path's getSession-before-ack is unavoidable.)
+  await interaction.deferUpdate();
+
   const sessionManager = getSessionManager();
   const session = await sessionManager.get<DenyDetailSession>(
     interaction.user.id,
@@ -180,11 +186,12 @@ export async function handleEditModal(
   );
 
   if (session === null) {
-    await replySessionExpired(interaction, 'handleEditModal', entryId);
+    await interaction.followUp({
+      content: DASHBOARD_MESSAGES.SESSION_EXPIRED,
+      flags: MessageFlags.Ephemeral,
+    });
     return;
   }
-
-  await interaction.deferUpdate();
 
   const data = session.data;
   const newScopeRaw = interaction.fields.getTextInputValue('scope').trim().toUpperCase();

--- a/services/bot-client/src/commands/persona/dashboard.test.ts
+++ b/services/bot-client/src/commands/persona/dashboard.test.ts
@@ -69,12 +69,14 @@ const mockRenderPostActionScreen = vi.fn();
 const mockHandleSharedBackButton = vi.fn();
 
 // Mock getSessionDataOrReply to delegate to mockSessionGet
+// Models getSessionDataOrFollowUp (the deferred variant handleDeleteButton now
+// uses): followUp on expiry, since the caller has already deferred.
 const mockGetSessionDataOrReply = vi
   .fn()
   .mockImplementation(async (interaction, entityType, entityId) => {
     const session = await mockSessionGet(interaction.user.id, entityType, entityId);
     if (session === null) {
-      await interaction.reply({
+      await interaction.followUp({
         content: DASHBOARD_MESSAGES.SESSION_EXPIRED,
         flags: MessageFlags.Ephemeral,
       });
@@ -174,6 +176,7 @@ vi.mock('../../utils/dashboard/index.js', async () => {
     requireDeferredSession: (...args: unknown[]) => mockRequireDeferredSession(...args),
     getSessionOrExpired: (...args: unknown[]) => mockGetSessionOrExpired(...args),
     getSessionDataOrReply: (...args: unknown[]) => mockGetSessionDataOrReply(...args),
+    getSessionDataOrFollowUp: (...args: unknown[]) => mockGetSessionDataOrReply(...args),
     parseDashboardCustomId: vi.fn((customId: string) => {
       // Simple parser for tests
       const parts = customId.split('::');
@@ -588,6 +591,7 @@ describe('handleButton', () => {
   const mockDeferUpdate = vi.fn();
   const mockEditReply = vi.fn();
   const mockReply = vi.fn();
+  const mockFollowUp = vi.fn();
   let stub: PersonaClientStub;
 
   beforeEach(() => {
@@ -610,10 +614,12 @@ describe('handleButton', () => {
       }
       return session;
     });
+    // Models getSessionDataOrFollowUp (handleDeleteButton defers first, so the
+    // helper followUps on expiry — reply would throw on the acked interaction).
     mockGetSessionDataOrReply.mockImplementation(async (interaction, entityType, entityId) => {
       const session = await mockSessionGet(interaction.user.id, entityType, entityId);
       if (session === null) {
-        await interaction.reply({
+        await interaction.followUp({
           content: DASHBOARD_MESSAGES.SESSION_EXPIRED,
           flags: MessageFlags.Ephemeral,
         });
@@ -633,6 +639,7 @@ describe('handleButton', () => {
       deferUpdate: mockDeferUpdate,
       editReply: mockEditReply,
       reply: mockReply,
+      followUp: mockFollowUp,
     } as unknown as Parameters<typeof handleButton>[0];
   }
 
@@ -668,7 +675,9 @@ describe('handleButton', () => {
         entityName: 'Test Persona',
       })
     );
-    expect(mockUpdate).toHaveBeenCalled();
+    // Ack-first: the confirm dialog now renders via editReply (post-deferUpdate).
+    expect(mockDeferUpdate).toHaveBeenCalled();
+    expect(mockEditReply).toHaveBeenCalled();
   });
 
   it('should block delete of default persona', async () => {
@@ -686,11 +695,14 @@ describe('handleButton', () => {
 
     await handleButton(createMockButtonInteraction(`persona::delete::${TEST_PERSONA_ID}`));
 
-    expect(mockReply).toHaveBeenCalledWith({
+    // Ack-first: deferUpdate runs before the gateway isDefaultPersona() check; the
+    // block notice is a followUp (reply would throw post-defer), and no confirm
+    // dialog is rendered.
+    expect(mockFollowUp).toHaveBeenCalledWith({
       content: expect.stringContaining('Cannot delete your default'),
       flags: MessageFlags.Ephemeral,
     });
-    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockEditReply).not.toHaveBeenCalled();
   });
 
   it('should show error on delete when session expired', async () => {
@@ -698,7 +710,9 @@ describe('handleButton', () => {
 
     await handleButton(createMockButtonInteraction(`persona::delete::${TEST_PERSONA_ID}`));
 
-    expect(mockReply).toHaveBeenCalledWith({
+    // Ack-first: deferUpdate, then the deferred session helper followUps on expiry.
+    expect(mockDeferUpdate).toHaveBeenCalled();
+    expect(mockFollowUp).toHaveBeenCalledWith({
       content: expect.stringContaining('Session expired'),
       flags: MessageFlags.Ephemeral,
     });

--- a/services/bot-client/src/commands/persona/dashboard.ts
+++ b/services/bot-client/src/commands/persona/dashboard.ts
@@ -22,7 +22,7 @@ import {
   formatSuccessBanner,
   getSessionManager,
   requireDeferredSession,
-  getSessionDataOrReply,
+  getSessionDataOrFollowUp,
   parseDashboardCustomId,
   isDashboardInteraction,
   renderPostActionScreen,
@@ -250,8 +250,17 @@ const handleRefreshButton = createRefreshHandler({
  * Handle delete button - show confirmation dialog.
  */
 async function handleDeleteButton(interaction: ButtonInteraction, entityId: string): Promise<void> {
-  // Get session data or show expired message
-  const data = await getSessionDataOrReply<FlattenedPersonaData>(interaction, 'persona', entityId);
+  // Ack first (3-second rule): deferUpdate before the Redis session read AND the
+  // gateway isDefaultPersona() call. Use the deferred session helper (followUp on
+  // expiry) + followUp/editReply for the responses, since reply/update would
+  // throw on the already-acked interaction.
+  await interaction.deferUpdate();
+
+  const data = await getSessionDataOrFollowUp<FlattenedPersonaData>(
+    interaction,
+    'persona',
+    entityId
+  );
   if (data === null) {
     return;
   }
@@ -259,7 +268,7 @@ async function handleDeleteButton(interaction: ButtonInteraction, entityId: stri
   const { userClient } = clientsFor(interaction);
   const isDefault = await isDefaultPersona(entityId, userClient);
   if (isDefault) {
-    await interaction.reply({
+    await interaction.followUp({
       content:
         '❌ Cannot delete your default persona.\n\n' +
         'Use `/persona default <other-persona>` to set a different default first.',
@@ -268,7 +277,7 @@ async function handleDeleteButton(interaction: ButtonInteraction, entityId: stri
     return;
   }
 
-  // Show confirmation dialog using shared utility
+  // Show confirmation dialog using shared utility (editReply — already deferred).
   const { embed, components } = buildDeleteConfirmation({
     entityType: 'Persona',
     entityName: data.name,
@@ -277,7 +286,7 @@ async function handleDeleteButton(interaction: ButtonInteraction, entityId: stri
     additionalWarning: 'Any character-specific overrides using this persona will be cleared.',
   });
 
-  await interaction.update({ embeds: [embed], components });
+  await interaction.editReply({ embeds: [embed], components });
 }
 
 /**

--- a/services/bot-client/src/utils/dashboard/closeHandler.test.ts
+++ b/services/bot-client/src/utils/dashboard/closeHandler.test.ts
@@ -16,25 +16,29 @@ vi.mock('./SessionManager.js', () => ({
 }));
 
 describe('handleDashboardClose', () => {
-  const mockUpdate = vi.fn();
+  const mockDeferUpdate = vi.fn();
+  const mockEditReply = vi.fn();
 
   const createMockInteraction = (): ButtonInteraction =>
     ({
       user: { id: 'user-123' },
-      update: mockUpdate,
+      deferUpdate: mockDeferUpdate,
+      editReply: mockEditReply,
     }) as unknown as ButtonInteraction;
 
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('should delete session and show closed message', async () => {
+  it('should ack first, delete session, then show the closed message', async () => {
     const interaction = createMockInteraction();
 
     await handleDashboardClose(interaction, 'persona', 'persona-123');
 
+    // Ack-first (3-second rule): deferUpdate precedes the Redis delete.
+    expect(mockDeferUpdate).toHaveBeenCalled();
     expect(mockDelete).toHaveBeenCalledWith('user-123', 'persona', 'persona-123');
-    expect(mockUpdate).toHaveBeenCalledWith({
+    expect(mockEditReply).toHaveBeenCalledWith({
       content: DASHBOARD_MESSAGES.DASHBOARD_CLOSED,
       embeds: [],
       components: [],
@@ -48,7 +52,7 @@ describe('handleDashboardClose', () => {
     await handleDashboardClose(interaction, 'preset', 'preset-456', customMessage);
 
     expect(mockDelete).toHaveBeenCalledWith('user-123', 'preset', 'preset-456');
-    expect(mockUpdate).toHaveBeenCalledWith({
+    expect(mockEditReply).toHaveBeenCalledWith({
       content: customMessage,
       embeds: [],
       components: [],
@@ -65,12 +69,14 @@ describe('handleDashboardClose', () => {
 });
 
 describe('createCloseHandler', () => {
-  const mockUpdate = vi.fn();
+  const mockDeferUpdate = vi.fn();
+  const mockEditReply = vi.fn();
 
   const createMockInteraction = (): ButtonInteraction =>
     ({
       user: { id: 'user-456' },
-      update: mockUpdate,
+      deferUpdate: mockDeferUpdate,
+      editReply: mockEditReply,
     }) as unknown as ButtonInteraction;
 
   beforeEach(() => {
@@ -83,8 +89,9 @@ describe('createCloseHandler', () => {
 
     await handleClose(interaction, 'preset-789');
 
+    expect(mockDeferUpdate).toHaveBeenCalled();
     expect(mockDelete).toHaveBeenCalledWith('user-456', 'preset', 'preset-789');
-    expect(mockUpdate).toHaveBeenCalledWith({
+    expect(mockEditReply).toHaveBeenCalledWith({
       content: DASHBOARD_MESSAGES.DASHBOARD_CLOSED,
       embeds: [],
       components: [],

--- a/services/bot-client/src/utils/dashboard/closeHandler.ts
+++ b/services/bot-client/src/utils/dashboard/closeHandler.ts
@@ -29,10 +29,15 @@ export async function handleDashboardClose(
   entityId: string,
   customMessage?: string
 ): Promise<void> {
+  // Ack first (3-second rule): deferUpdate before the Redis session delete, then
+  // editReply the closed-state message. deferUpdate→editReply reaches the same end
+  // state as a bare update() while keeping the Redis round-trip off the 3s budget.
+  await interaction.deferUpdate();
+
   const sessionManager = getSessionManager();
   await sessionManager.delete(interaction.user.id, entityType, entityId);
 
-  await interaction.update({
+  await interaction.editReply({
     content: customMessage ?? DASHBOARD_MESSAGES.DASHBOARD_CLOSED,
     embeds: [],
     components: [],


### PR DESCRIPTION
**PR A1 of the ack-first remediation** (the `component-handler-ack-first` ESLint rule found these). Plan: fix the real violations first across two PRs, then the rule lands clean as the ratchet. This is the **3 localized defer-first fixes**; the `SettingsDashboardHandler` coordinated refactor is PR A2.

## The bug class
Each handler `await`ed a **Redis session op or a gateway HTTP call before acknowledging** the interaction — the documented 3-second-rule antipattern (`04-discord.md`). They're confirmed first-ackers (they call `reply`/`update`, which would throw post-ack if they were downstream).

## Fixes (migrate to the defer-first pattern the codebase already supports)
| Handler | Before | After |
|---|---|---|
| `closeHandler.handleDashboardClose` (shared) | `sessionManager.delete` → `update` | `deferUpdate` → delete → `editReply` |
| `persona/dashboard.handleDeleteButton` | `getSessionDataOrReply` (Redis) → `isDefaultPersona` (gateway) → `reply`/`update` | `deferUpdate` → `getSessionDataOrFollowUp` → checks → `followUp`/`editReply` |
| `deny/detailEdit.handleEditModal` | `sessionManager.get` → `reply`-on-expiry → `deferUpdate` | `deferUpdate` → get → `followUp`-on-expiry |

`getSessionDataOrFollowUp` is the existing deferred-variant helper (its JSDoc points to it for exactly "when the 3-second budget matters and you've deferred eagerly").

**Untouched on purpose:** the modal-*open* handlers keep `showModalWithTimeoutCatch` — `showModal` can't be preceded by a `defer`, so their `getSession`-before-`showModal` is unavoidable and already mitigated.

## Tests
Updated to the `deferUpdate` + `editReply`/`followUp` shape. The deny modal-submit's old `reply`→10062-`followUp` fallback test is dropped (that path no longer exists; the fallback only guarded the can't-defer modal-open handler, still tested). `pnpm test` + `pnpm test:component` + `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)