### PR TITLE
feat(tooling): add component-handler-ack-first ESLint rule (ack-first ratchet)

### DIFF
--- a/docs/research/ack-first-lint-rule-redesign.md
+++ b/docs/research/ack-first-lint-rule-redesign.md
@@ -1,0 +1,63 @@
+# Ack-first lint rule — redesign to `no-bare-ack-after-async`
+
+_Distilled from a 3-model council pass (GLM 5.2, Kimi K2.7-code, Qwen 3.7 Max) after a PR review surfaced a coverage gap in the first implementation._
+
+## The problem
+
+The first cut of `@tzurot/component-handler-ack-first` (PR #1409, parked as draft) enforces the Discord 3-second rule by detecting handlers that **own a direct `interaction.<ackMethod>()` call** and firing when async work precedes it. A PR review found a blind spot: handlers whose **only** ack goes through a wrapper helper (`ackWithTimeoutCatch` / `showModalWithTimeoutCatch`) are **never checked at all**.
+
+### Why the blind spot exists
+
+The rule's delegation exemption (an awaited call that passes the whole `interaction` to a callee) was added to kill false positives on delegating routers and ack-wrappers. But "exempt from being flagged as pre-ack work" silently also meant "never marks `ownsAck`." So a wrapper-ack handler has `ownsAck = false` for its whole body → the report condition (`ownsAck && firstMeaningfulAwait !== ack`) never trips → the handler is skipped. Killing the false positives opened a false negative.
+
+This matters because the wrapper-ack family is exactly the "must inspect data before choosing the ack shape" pattern (modals with prefilled fields): `detailModals.ts handleEditButton`, `deny/detailEdit.ts handleEdit`, `SettingsDashboardHandler.handleEditButton`. For this family **ack-first is impossible by construction** — you must fetch the data to know the modal's contents — so the timeout-catch wrapper IS the accepted mitigation, not ack-first ordering.
+
+## The reframe (council consensus)
+
+Stop trying to enforce "ack first" (impossible for the wrapper family). Enforce a single unified invariant that covers both families:
+
+> **A _bare_ initial-ack must not follow async work.**
+
+| Situation                                          | Verdict | Fix                          |
+| -------------------------------------------------- | ------- | ---------------------------- |
+| ack with **no** preceding async                    | PASS    | —                            |
+| async work → **wrapped** ack (`*WithTimeoutCatch`) | PASS    | — (accepted mitigation)      |
+| async work → **bare** `interaction.<ackMethod>()`  | FAIL    | hoist the ack **or** wrap it |
+
+The fix differs by family (direct-ack: hoist; wrapper-ack: wrap), but the **failure state is identical**, so one rule with one message is cleaner than two.
+
+This also resolves the reviewer's "make delegation set `ownsAck`" suggestion correctly: under the old "ack must be first" logic that would false-flag the wrapper family; under "bare ack must not follow async," a wrapped late ack legitimately passes.
+
+## Decisions
+
+1. **One unified rule**, renamed to reflect the real invariant (e.g. `no-bare-ack-after-async`). (Qwen + Kimi; GLM preferred two rules but the identical-failure-state argument + 2:1 majority win.)
+2. **Out of scope: "handler does async then never acks at all."** That's an _existence_ check, not _ordering/wrapping_; it needs reachability analysis and is FP-prone on branches/early-returns/delegations. If ever wanted, a separate optional `require-interaction-ack` rule — not this one.
+3. **Wrapper detection: `*WithTimeoutCatch` suffix convention** (primary — zero-config, self-documenting, lexical; both existing helpers already match), **plus a small config allowlist** as an escape hatch for any wrapper that can't follow the suffix. No type-aware linting (slow, fragile, overkill for a solo monorepo).
+
+## Implementation sketch (redo of PR #1409's rule)
+
+For each detected handler (router key or `(Button|SelectMenu|ModalSubmit)Interaction` param):
+
+1. Walk the body in source order, tracking whether an `await` of **real async work** has occurred (an await that is NOT itself an ack and NOT a wrapped-ack call).
+2. On encountering an **initial-ack** call:
+   - **Bare** (`interaction.<ackMethod>()`, ackMethods = deferUpdate/deferReply/reply/update/showModal — NOT followUp/editReply): if real async preceded it → **report**.
+   - **Wrapped** (callee identifier matches `/WithTimeoutCatch$/` or the allowlist, with `interaction` passed in): always PASS; stop checking (the handler is acked).
+3. No ack + no async, or async-only with no ack → PASS (out of scope per decision 2).
+
+Branch-sensitivity caveat (also raised in review): the current rule is single-pass source-order, so a `deferUpdate()` inside `if (!isModalAction)` is seen before the modal branch's `getSession`. The redesign should at minimum not _mis_-credit a branch-local ack to a sibling branch; full per-branch flow analysis is a stretch goal, not a v1 requirement.
+
+## Findings during implementation (the redesign is NOT behavior-neutral)
+
+The redesign was first assumed to be a behavior-neutral clarity refactor — empirical probes showed the OLD rule already caught `fetch → bare-ack` and passed `fetch → wrapper-ack`. **That assumption was wrong.** Once implemented and run across bot-client, the new model flagged ~20 sites where the old rule flagged 1.
+
+Root cause: the old rule's `firstMeaningfulAwait` was set ONCE, at the first non-delegation await. If that first await was itself an ack — e.g. an early sync-guard `reply()` — the slot was "claimed as an ack" and the rule stopped looking. Any LATER `realAsync → bare-ack` was masked. The old rule was silently **capping enforcement to the first await.** The new cumulative `sawRealAsync` model removes that cap, which is why "behavior-neutral" became a ~20-site sweep.
+
+Confirmed real bug the old rule (and PR #1408) missed: `handleSettingsModal` does `getSession` (Redis, line ~476) before its `deferUpdate` (line ~527) on the normal modal-submit path — masked because an earlier `settingId`-guard `reply()` claimed the first-await slot.
+
+### Detection-gap fix (removes a FP class)
+
+`passesInteractionToCallee` originally only recognized the interaction passed as a DIRECT identifier arg (`fn(interaction)`). The dashboard helpers pass it inside an options object (`fetchOrCreateSession({ entityId, interaction })`), so ack-capable delegations read as "real async" and false-flagged the following reply. Fixed by also scanning one-level `ObjectExpression` properties for the interaction identifier. (`interaction.user.id` — a member, not the identifier — still correctly reads as extracted DATA.)
+
+## Status
+
+**Decision (user): commit to the full stricter sweep.** The stricter rule is genuinely better (it found a real bug #1408 missed), so the plan is: fix the detection gap (done), triage the ~20 flags into real-bugs vs branch-leak FPs, remediate the real bugs with the #1408 ack-first pattern (`deferUpdate`/`deferReply` first; error paths → `followUp`; re-renders → `editReply`) across the affected files (grouped into PRs), and land the strict rule (#1409) only once the codebase is clean. Branch-leak FPs (e.g. `detailActionRouter`'s cross-switch-case `sawRealAsync` leak) get a justified `eslint-disable` at the relocated report line.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -407,6 +407,14 @@ export default tseslint.config(
       // Makes code harder to test because instances are created at import time
       '@tzurot/no-singleton-export': 'warn',
 
+      // Enforce Discord's 3-second rule structurally: a BARE ack (deferUpdate/
+      // deferReply/reply/update/showModal) in a component/modal interaction
+      // handler must not FOLLOW awaited async work — either ack first, or route a
+      // necessarily-late ack through a *WithTimeoutCatch wrapper. See
+      // `.claude/rules/04-discord.md`. 'error' because a violation is a real bug —
+      // the user gets no response.
+      '@tzurot/component-handler-ack-first': 'error',
+
       // ============================================================================
       // SONARJS RULES - Additional code quality checks
       // ============================================================================

--- a/packages/tooling/src/eslint/component-handler-ack-first.test.ts
+++ b/packages/tooling/src/eslint/component-handler-ack-first.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+import tseslint from 'typescript-eslint';
+import rule from './component-handler-ack-first.js';
+
+// The rule reads TS type annotations (param typed `ButtonInteraction`, etc.), so
+// the test linter must use the typescript-eslint parser. No type program is
+// needed — the rule inspects the AST annotation node, not resolved type info.
+const linter = new Linter({ configType: 'flat' });
+
+function lint(code: string): Linter.LintMessage[] {
+  return linter.verify(code, [
+    {
+      languageOptions: {
+        parser: tseslint.parser as unknown as Linter.Parser,
+        ecmaVersion: 2022,
+        sourceType: 'module',
+      },
+      plugins: {
+        test: {
+          rules: {
+            'ack-first': rule,
+          },
+        },
+      },
+      rules: {
+        'test/ack-first': 'error',
+      },
+    },
+  ]);
+}
+
+describe('rule metadata', () => {
+  it('is a problem rule with the ackAfterAsync message', () => {
+    expect(rule.meta?.type).toBe('problem');
+    expect(rule.meta?.messages?.ackAfterAsync).toBeDefined();
+  });
+});
+
+describe('valid — ack is the first await', () => {
+  it('router handleButton: deferUpdate before async work', () => {
+    expect(
+      lint(`defineCommand({
+        handleButton: async interaction => {
+          await interaction.deferUpdate();
+          const s = await findSession(interaction.message.id);
+        },
+      });`)
+    ).toHaveLength(0);
+  });
+
+  it('sync guard (no await) may precede the ack', () => {
+    expect(
+      lint(`defineCommand({
+        handleSelectMenu: async interaction => {
+          if (!isMine(interaction.customId)) return;
+          await interaction.deferUpdate();
+          await doWork();
+        },
+      });`)
+    ).toHaveLength(0);
+  });
+
+  it('typed downstream handler acks first', () => {
+    expect(
+      lint(`async function handleBrowsePagination(interaction: ButtonInteraction) {
+        await interaction.deferUpdate();
+        const s = await findSession(interaction.message.id);
+      }`)
+    ).toHaveLength(0);
+  });
+
+  it('double-ack guard counts as ack-first', () => {
+    expect(
+      lint(`async function handleBack(interaction: ButtonInteraction) {
+        if (!interaction.deferred && !interaction.replied) {
+          await interaction.deferUpdate();
+        }
+        await loadThing();
+      }`)
+    ).toHaveLength(0);
+  });
+
+  it('either branch acking first is fine', () => {
+    expect(
+      lint(`async function handleThing(interaction: ModalSubmitInteraction) {
+        if (wantsEphemeral) {
+          await interaction.deferReply({ ephemeral: true });
+        } else {
+          await interaction.deferUpdate();
+        }
+      }`)
+    ).toHaveLength(0);
+  });
+
+  it('awaits inside nested callbacks do not count as the handler first await', () => {
+    expect(
+      lint(`defineCommand({
+        handleButton: async interaction => {
+          await interaction.deferUpdate();
+          await Promise.all(rows.map(async r => await save(r)));
+        },
+      });`)
+    ).toHaveLength(0);
+  });
+
+  it('ignores autocomplete handlers (no ack — they respond directly)', () => {
+    expect(
+      lint(`async function handleAutocomplete(interaction: AutocompleteInteraction) {
+        const models = await fetchModels();
+        await interaction.respond(models);
+      }`)
+    ).toHaveLength(0);
+  });
+
+  it('ignores deferred-context subcommand handlers', () => {
+    expect(
+      lint(`async function handleSet(context: DeferredCommandContext) {
+        const cfg = await context.fetchConfig();
+        await context.editReply({ content: 'ok' });
+      }`)
+    ).toHaveLength(0);
+  });
+
+  it('ignores plain helpers that are not handlers', () => {
+    expect(
+      lint(`async function loadModels() {
+        return await fetch('https://x');
+      }`)
+    ).toHaveLength(0);
+  });
+
+  it('exempts a router that delegates without acking (the sub-handler acks)', () => {
+    expect(
+      lint(`defineCommand({
+        handleSelectMenu: async interaction => {
+          if (isServersSelect(interaction.customId)) {
+            await handleServersSelect(interaction);
+            return;
+          }
+          await handleOtherSelect(interaction);
+        },
+      });`)
+    ).toHaveLength(0);
+  });
+
+  it('exempts a sub-handler that relies on the caller ack (never acks itself)', () => {
+    expect(
+      lint(`async function handleModeToggle(interaction: ButtonInteraction) {
+        const data = await getSessionOrExpired(interaction, entryId);
+        if (data === null) return;
+        await saveMode(data);
+      }`)
+    ).toHaveLength(0);
+  });
+
+  it('exempts a router that delegates in matched branches and only acks in a fallback', () => {
+    expect(
+      lint(`async function handleButton(interaction: ButtonInteraction) {
+        if (isA(interaction.customId)) {
+          await handleA(interaction);
+          return;
+        }
+        if (isB(interaction.customId)) {
+          await handleB(interaction);
+          return;
+        }
+        await interaction.reply({ content: 'Unknown interaction.' });
+      }`)
+    ).toHaveLength(0);
+  });
+});
+
+describe('invalid — async work before the ack', () => {
+  it('router handleButton awaits a session lookup before deferUpdate', () => {
+    const messages = lint(`defineCommand({
+      handleButton: async interaction => {
+        const session = await findSession(interaction.message.id);
+        await interaction.deferUpdate();
+      },
+    });`);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].messageId).toBe('ackAfterAsync');
+  });
+
+  it('typed downstream handler awaits a lookup before the ack', () => {
+    expect(
+      lint(`async function handleBrowsePagination(interaction: ButtonInteraction) {
+        const session = await findSession(interaction.message.id);
+        await interaction.deferUpdate();
+      }`)
+    ).toHaveLength(1);
+  });
+
+  it('awaiting a non-interaction method first does not satisfy the rule', () => {
+    expect(
+      lint(`defineCommand({
+        handleSelectMenu: async interaction => {
+          await someService.update();
+          await interaction.deferUpdate();
+        },
+      });`)
+    ).toHaveLength(1);
+  });
+
+  it('a nested-callback await does not mask a real pre-ack lookup', () => {
+    expect(
+      lint(`defineCommand({
+        handleButton: async interaction => {
+          rows.forEach(async r => { await save(r); });
+          const session = await findSession(interaction.message.id);
+          await interaction.deferUpdate();
+        },
+      });`)
+    ).toHaveLength(1);
+  });
+
+  it('a BARE ack after a fetch is flagged even when the data shapes the ack (must wrap)', () => {
+    // The modal/inspect-then-ack family: must fetch first, so a BARE showModal
+    // after the fetch is the bug — it should go through a *WithTimeoutCatch wrapper.
+    expect(
+      lint(`async function handleEditButton(interaction: ButtonInteraction) {
+        const memory = await fetchMemory(memoryId);
+        await interaction.showModal(modal);
+      }`)
+    ).toHaveLength(1);
+  });
+});
+
+describe('wrapper-ack family — a necessarily-late ack via *WithTimeoutCatch is allowed', () => {
+  it('fetch then showModalWithTimeoutCatch(interaction) passes (wrapped late ack)', () => {
+    // Ack-first is impossible here (the modal is prefilled from the fetched row),
+    // so the timeout-catch wrapper IS the accepted mitigation — not a violation.
+    expect(
+      lint(`async function handleEditButton(interaction: ButtonInteraction) {
+        const memory = await fetchMemory(memoryId);
+        await showModalWithTimeoutCatch(interaction, modal, ctx, 'msg');
+      }`)
+    ).toHaveLength(0);
+  });
+
+  it('getSession then ackWithTimeoutCatch(interaction, () => reply) passes', () => {
+    expect(
+      lint(`async function handleEdit(interaction: ButtonInteraction) {
+        const session = await getSession(interaction.user.id);
+        await ackWithTimeoutCatch(interaction, () => interaction.reply({ content: 'x' }), {}, 'm');
+      }`)
+    ).toHaveLength(0);
+  });
+
+  it('a wrapped ack with no preceding async passes', () => {
+    expect(
+      lint(`async function handleEditButton(interaction: ButtonInteraction) {
+        await showModalWithTimeoutCatch(interaction, modal, ctx, 'msg');
+      }`)
+    ).toHaveLength(0);
+  });
+
+  it('real async then a delegation (interaction handed off) is not flagged', () => {
+    expect(
+      lint(`async function handleButton(interaction: ButtonInteraction) {
+        const meta = await loadMeta(thingId);
+        await routeToSubHandler(interaction, meta);
+      }`)
+    ).toHaveLength(0);
+  });
+
+  it('exempts a delegation that passes the interaction inside an options object', () => {
+    // fetchOrCreateSession({ ..., interaction }) is an ack-capable helper; the
+    // interaction rides in an options bag, not as a direct arg. It must still
+    // read as a handoff, not as real async work before the following reply.
+    expect(
+      lint(`async function handleSelect(interaction: StringSelectMenuInteraction) {
+        const result = await fetchOrCreateSession({ entityId, interaction });
+        if (!result.success) {
+          await interaction.reply({ content: 'not found' });
+        }
+      }`)
+    ).toHaveLength(0);
+  });
+
+  it('fails closed when the interaction param cannot be resolved (destructured param)', () => {
+    // interactionName is unresolvable from a destructured param, so a bare
+    // `.reply()` on some OTHER object must NOT be misread as THE interaction ack
+    // (fail closed rather than permissive — otherwise it could mask a real
+    // violation). We conservatively skip the handler instead of guessing.
+    expect(
+      lint(`defineCommand({
+        handleButton: async ({ message }) => {
+          const data = await load(message.id);
+          await message.reply(data);
+        },
+      });`)
+    ).toHaveLength(0);
+  });
+});
+
+describe('detection coverage — handleModal router key', () => {
+  it('flags a handleModal router entry that acks after async', () => {
+    // handleModal is a raw-interaction router key too; an untyped arrow entry
+    // that fetches before the ack must be caught, same as handleButton.
+    expect(
+      lint(`defineCommand({
+        handleModal: async interaction => {
+          const row = await fetchRow(interaction.customId);
+          await interaction.reply({ content: row.name });
+        },
+      });`)
+    ).toHaveLength(1);
+  });
+});

--- a/packages/tooling/src/eslint/component-handler-ack-first.ts
+++ b/packages/tooling/src/eslint/component-handler-ack-first.ts
@@ -1,0 +1,275 @@
+/**
+ * ESLint Rule: component-handler-ack-first
+ *
+ * Enforces Discord's 3-second interaction rule structurally. The invariant, stated
+ * precisely:
+ *
+ *   A handler must not perform a BARE acknowledgement (`interaction.deferUpdate()` /
+ *   `deferReply` / `reply` / `update` / `showModal`) AFTER it has already awaited
+ *   real async work (a Redis session lookup, a Prisma query, a gateway fetch).
+ *
+ * A bare ack that lands after slow work risks blowing the 3-second budget before
+ * the ack reaches Discord — the user gets a silent "This interaction failed". The
+ * `handleBrowsePagination` regression (awaited a session lookup, THEN `deferUpdate`)
+ * is the canonical bug; it recurred across three review rounds, so it's enforced at
+ * author-time. See `.claude/rules/04-discord.md` § "3-Second Rule".
+ *
+ * TWO WAYS TO SATISFY THE RULE — and why the wrapper path matters:
+ *
+ *   1. Ack FIRST. Put the bare ack before any awaited work:
+ *        handleButton: async interaction => {
+ *          await interaction.deferUpdate();          // ack first
+ *          const session = await findSession(...);   // then async work
+ *        }
+ *
+ *   2. WRAP a necessarily-late ack. Some handlers MUST inspect data before they can
+ *      choose the ack — e.g. a modal whose fields are prefilled from a fetched row.
+ *      Ack-first is impossible there. The accepted mitigation is a wrapper helper
+ *      (`ackWithTimeoutCatch` / `showModalWithTimeoutCatch`) that catches the 10062
+ *      "interaction expired" error if the budget blew and degrades to a followUp:
+ *        handleEditButton: async interaction => {
+ *          const memory = await fetchMemory(id);            // real work first (unavoidable)
+ *          await showModalWithTimeoutCatch(interaction, …); // wrapped ack — OK
+ *        }
+ *
+ * The rule treats any awaited call that is passed the WHOLE `interaction` as a
+ * legitimate ack/handoff and does NOT flag it (it's either a wrapper that catches
+ * the timeout, or a delegation to a sub-handler that acks). Only a BARE
+ * `interaction.<ackMethod>()` after real async work is flagged — that's the one
+ * shape that silently fails. So `fetch → bare showModal()` is flagged (use a wrapper
+ * or hoist the ack); `fetch → showModalWithTimeoutCatch(interaction)` passes.
+ *
+ * NOT enforced: "every handler must ack." Routers sync-check then DELEGATE
+ * (`await handleServersSelect(interaction)`); sub-handlers are often called post-ack
+ * and rely on the caller's ack. Those legitimately own no ack. Proving "this handler
+ * never acks at all" needs reachability analysis (FP-prone on branches/early
+ * returns) and is intentionally out of scope — a separate rule if ever wanted.
+ *
+ * Scope: targets ONLY handlers that receive a RAW interaction needing an ack —
+ * detected (a) by the `handleButton` / `handleSelectMenu` key (defineCommand router
+ * entries, whose arrow param is often un-annotated) and (b) by a first parameter
+ * typed as a Button/SelectMenu/ModalSubmit interaction (downstream handlers). Slash
+ * handlers (already-deferred `context`), autocomplete handlers (respond directly),
+ * and plain helpers are NOT targeted.
+ */
+
+import type { Rule } from 'eslint';
+import type { Node } from 'estree';
+
+/**
+ * Methods that perform the INITIAL acknowledgement of an interaction. Deliberately
+ * excludes `followUp` / `editReply` — those are POST-ack calls (they only run once
+ * the interaction is already acked), so they are never the bug this rule guards.
+ */
+const ACK_METHODS = new Set(['deferUpdate', 'deferReply', 'reply', 'update', 'showModal']);
+
+/**
+ * defineCommand keys whose value is a raw-interaction router entry. Includes
+ * `handleModal` (ModalSubmitInteraction) — the canonical wrapper-ack case this
+ * rule's docstring cites — so a `handleModal: async interaction => {…}` arrow
+ * entry gets the same coverage as its button/select siblings.
+ */
+const ROUTER_KEYS = new Set(['handleButton', 'handleSelectMenu', 'handleModal']);
+
+/**
+ * Param type names that REQUIRE an ack. Select-menu variants
+ * (String/User/Role/Channel/Mentionable/Any) all end in `SelectMenuInteraction`.
+ * Deliberately excludes `AutocompleteInteraction` (no ack — responds directly)
+ * and `ChatInputCommandInteraction` (this codebase defers those upstream and
+ * passes a deferred `context` to subcommand handlers).
+ */
+const ACK_REQUIRING_TYPE = /(?:Button|SelectMenu|ModalSubmit)Interaction$/;
+
+interface HandlerFrame {
+  /** Whether this function is a candidate interaction handler. */
+  isHandler: boolean;
+  /** The interaction parameter's identifier name (for matching `x.deferUpdate()`). */
+  interactionName: string | null;
+  /**
+   * Whether the handler has already awaited real async work (a non-ack call that
+   * is NOT passed the whole interaction — i.e. a data/IO op like a Redis lookup).
+   * Once true, a subsequent BARE ack is the bug. Monotonic: only flips false→true.
+   */
+  sawRealAsync: boolean;
+}
+
+type FunctionNode = Node & {
+  type: 'ArrowFunctionExpression' | 'FunctionExpression' | 'FunctionDeclaration';
+  params: Node[];
+  parent?: Node;
+};
+
+/** The first param's identifier name, or null if it isn't a plain identifier. */
+function firstParamName(fn: FunctionNode): string | null {
+  const first = fn.params[0];
+  return first?.type === 'Identifier' ? (first as Node & { name: string }).name : null;
+}
+
+/** True if the first param carries a type annotation matching an ack-requiring interaction. */
+function firstParamIsAckInteraction(fn: FunctionNode): boolean {
+  const first = fn.params[0] as
+    (Node & { typeAnnotation?: { typeAnnotation?: { typeName?: { name?: string } } } }) | undefined;
+  const typeName = first?.typeAnnotation?.typeAnnotation?.typeName?.name;
+  return typeof typeName === 'string' && ACK_REQUIRING_TYPE.test(typeName);
+}
+
+/** True if the function is the value of a `handleButton`/`handleSelectMenu` property. */
+function isRouterEntry(fn: FunctionNode): boolean {
+  const parent = fn.parent;
+  if (parent?.type !== 'Property') {
+    return false;
+  }
+  const key = (parent as Node & { key: Node & { name?: string }; value: Node }).key;
+  const value = (parent as Node & { value: Node }).value;
+  return value === fn && key.type === 'Identifier' && ROUTER_KEYS.has(key.name ?? '');
+}
+
+/**
+ * True if the awaited call is passed the WHOLE `interaction` as a direct argument
+ * — `await handleServersSelect(interaction)`, `await showModalWithTimeoutCatch(interaction, …)`,
+ * `await ackWithTimeoutCatch(interaction, () => …)`. Such a callee CAN acknowledge
+ * the interaction itself (a wrapper that catches the 3s timeout, or a delegation to
+ * a sub-handler), so the await is a legitimate ack/handoff — NOT real async work,
+ * and NOT a bare ack. The rule neither flags it nor counts it as preceding work.
+ *
+ * The discriminator is passing the interaction OBJECT vs. extracted DATA: a call
+ * passed only `interaction.user.id` / `interaction.message.id` (a member) cannot
+ * ack — it's a data/IO op (e.g. a Redis `getSession`), so it IS real async work and
+ * a following bare ack is flagged. This is the line between a wrapper/delegation and
+ * the real bug (an awaited lookup before a bare ack).
+ */
+function passesInteractionToCallee(
+  argument: Node | null | undefined,
+  interactionName: string | null
+): boolean {
+  if (argument?.type !== 'CallExpression' || interactionName === null) {
+    return false;
+  }
+  const call = argument as Node & { arguments: Node[] };
+  return call.arguments.some(arg => argReferencesInteraction(arg, interactionName));
+}
+
+/**
+ * True if a call argument hands the whole interaction to the callee — either
+ * directly (`fn(interaction)`) or as a property of an options object
+ * (`fetchOrCreateSession({ entityId, interaction })`, the dashboard helper shape).
+ * The options-object form is common enough that missing it false-flags every
+ * handler that delegates via an options bag — `interaction.user.id` (a member,
+ * not the identifier) still correctly reads as extracted DATA, not the object.
+ */
+function argReferencesInteraction(arg: Node, interactionName: string): boolean {
+  if (arg.type === 'Identifier') {
+    return (arg as Node & { name: string }).name === interactionName;
+  }
+  if (arg.type === 'ObjectExpression') {
+    const obj = arg as Node & { properties: Node[] };
+    return obj.properties.some(prop => {
+      if (prop.type !== 'Property') {
+        return false;
+      }
+      const value = (prop as Node & { value: Node }).value;
+      return (
+        value.type === 'Identifier' && (value as Node & { name: string }).name === interactionName
+      );
+    });
+  }
+  return false;
+}
+
+/** True if the awaited expression is a BARE ack call on the interaction (`interaction.deferUpdate()`). */
+function isBareAckCall(argument: Node | null | undefined, interactionName: string | null): boolean {
+  if (argument?.type !== 'CallExpression') {
+    return false;
+  }
+  const callee = (argument as Node & { callee: Node }).callee;
+  if (callee.type !== 'MemberExpression') {
+    return false;
+  }
+  const member = callee as Node & { object: Node; property: Node & { name?: string } };
+  const objectName =
+    member.object.type === 'Identifier' ? (member.object as Node & { name: string }).name : null;
+  // Fail CLOSED: only count this as an ack when we positively identified the
+  // interaction param. If interactionName is null (a destructured / zero-param
+  // handler we can't resolve), don't treat an arbitrary object's `.reply()` as
+  // THE ack — that would mask a real violation. `passesInteractionToCallee` is
+  // fail-closed for the same reason.
+  return (
+    interactionName !== null &&
+    objectName === interactionName &&
+    member.property.type === 'Identifier' &&
+    ACK_METHODS.has(member.property.name ?? '')
+  );
+}
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow a bare interaction acknowledgement after async work in a component/modal handler — ack first, or wrap a necessarily-late ack in a timeout-catch helper (Discord 3-second rule)',
+      recommended: true,
+    },
+    messages: {
+      ackAfterAsync:
+        "This handler does awaited work (often a Redis/DB/gateway call) BEFORE this bare interaction ack — that risks blowing Discord's 3-second budget before the ack lands, and the user gets a silent failure. Either move the ack (deferUpdate/deferReply/reply/update/showModal) ahead of the awaited work, or — if the data is needed to shape the ack (e.g. a modal's prefilled fields) — route it through a *WithTimeoutCatch wrapper so a blown budget degrades to a followUp. (followUp/editReply are post-ack and exempt; sync-only guards may precede the ack.)",
+    },
+    schema: [],
+  },
+
+  create(context) {
+    const stack: HandlerFrame[] = [];
+
+    function enterFunction(node: Node): void {
+      const fn = node as FunctionNode;
+      const isHandler = isRouterEntry(fn) || firstParamIsAckInteraction(fn);
+      stack.push({
+        isHandler,
+        interactionName: isHandler ? firstParamName(fn) : null,
+        sawRealAsync: false,
+      });
+    }
+
+    function exitFunction(): void {
+      stack.pop();
+    }
+
+    return {
+      ArrowFunctionExpression: enterFunction,
+      'ArrowFunctionExpression:exit': exitFunction,
+      FunctionExpression: enterFunction,
+      'FunctionExpression:exit': exitFunction,
+      FunctionDeclaration: enterFunction,
+      'FunctionDeclaration:exit': exitFunction,
+
+      AwaitExpression(node) {
+        // Only the NEAREST enclosing function's frame matters — an await inside a
+        // nested callback belongs to that callback, not the handler.
+        const frame = stack[stack.length - 1];
+        if (!frame?.isHandler) {
+          return;
+        }
+        const argument = (node as Node & { argument?: Node }).argument;
+
+        // A bare ack AFTER real async work is the bug.
+        if (isBareAckCall(argument, frame.interactionName)) {
+          if (frame.sawRealAsync) {
+            context.report({ node, messageId: 'ackAfterAsync' });
+          }
+          return;
+        }
+
+        // A call passed the whole interaction is a wrapper/delegation (legitimate
+        // ack point or handoff) — neither real async work nor a bare ack. Skip it.
+        if (passesInteractionToCallee(argument, frame.interactionName)) {
+          return;
+        }
+
+        // Otherwise it's real async work (a data/IO op). Mark it so a following
+        // bare ack is flagged.
+        frame.sawRealAsync = true;
+      },
+    };
+  },
+};
+
+export default rule;

--- a/packages/tooling/src/eslint/index.ts
+++ b/packages/tooling/src/eslint/index.ts
@@ -19,6 +19,7 @@
  */
 
 import noSingletonExport from './no-singleton-export.js';
+import componentHandlerAckFirst from './component-handler-ack-first.js';
 
 const plugin = {
   meta: {
@@ -27,6 +28,7 @@ const plugin = {
   },
   rules: {
     'no-singleton-export': noSingletonExport,
+    'component-handler-ack-first': componentHandlerAckFirst,
   },
 };
 

--- a/services/bot-client/src/commands/character/dashboardActions.ts
+++ b/services/bot-client/src/commands/character/dashboardActions.ts
@@ -107,6 +107,7 @@ export async function handleAction(
   if (actionId === 'avatar') {
     // Redirect to slash command — Discord modals can only contain text inputs,
     // not file upload fields, so avatar upload requires a separate command.
+    // eslint-disable-next-line @tzurot/component-handler-ack-first -- Branch-leak FP: static redirect, no async in this branch. The rule's source-order sawRealAsync leaked from the earlier `visibility` branch's fetchCharacter/toggleVisibility (which is ack-first via its own deferUpdate); this reply IS ack-first for the avatar branch.
     await interaction.reply({
       content:
         '🖼️ **Avatar Upload**\n\n' +
@@ -118,6 +119,7 @@ export async function handleAction(
   }
 
   if (actionId === 'voice') {
+    // eslint-disable-next-line @tzurot/component-handler-ack-first -- Branch-leak FP: static redirect, no async in this branch; sawRealAsync leaked from the earlier `visibility` branch. This reply IS ack-first for the voice branch.
     await interaction.reply({
       content:
         '🎤 **Voice Reference**\n\n' +
@@ -133,6 +135,7 @@ export async function handleAction(
     // TOCTOU note: We fetch-then-toggle, so a concurrent toggle could invert
     // the wrong value. Acceptable for a single-user dashboard — the user can
     // just click again if the state looks wrong.
+    // eslint-disable-next-line @tzurot/component-handler-ack-first -- Branch-leak FP: this deferUpdate IS ack-first for the voice-toggle branch (fetchCharacter/updateCharacter follow it); sawRealAsync leaked from the sibling `visibility` branch's async above.
     await interaction.deferUpdate();
 
     const { userClient } = clientsFor(interaction);

--- a/services/bot-client/src/commands/memory/detailActionRouter.ts
+++ b/services/bot-client/src/commands/memory/detailActionRouter.ts
@@ -122,6 +122,7 @@ export async function handleMemoryDetailAction(
       // stays inside the 3-second window. Guard against double-ack by
       // only deferring when the interaction is still untouched.
       if (!buttonInteraction.deferred && !buttonInteraction.replied) {
+        // eslint-disable-next-line @tzurot/component-handler-ack-first -- Branch-leak FP: this deferUpdate IS ack-first for the `back` case (double-ack-guarded; the caller may have pre-deferred). The rule's source-order sawRealAsync leaked from the `confirm-delete` branch's onRefresh above, which returns before this case ever runs.
         await buttonInteraction.deferUpdate();
       }
       await onRefresh();

--- a/services/bot-client/src/commands/memory/purge.ts
+++ b/services/bot-client/src/commands/memory/purge.ts
@@ -361,12 +361,14 @@ export async function handlePurgeModal(interaction: ModalSubmitInteraction): Pro
   // by the proceed button), but we narrow to satisfy the type checker.
   if (!interaction.isFromMessage()) {
     logger.warn({ customId: interaction.customId }, 'Purge modal submitted without parent message');
+    // eslint-disable-next-line @tzurot/component-handler-ack-first -- Branch-leak FP: on the phrase-matched path that reaches here, no real async precedes this ack (assertInvokerOwnership is exempt; the rest is sync). The rule's source-order sawRealAsync leaked from the phrase-MISMATCH branch's interaction.message.edit above, which returns before this point.
     await interaction.reply({
       content: '❌ Internal error: malformed modal context.',
       flags: MessageFlags.Ephemeral,
     });
     return;
   }
+  // eslint-disable-next-line @tzurot/component-handler-ack-first -- Branch-leak FP: this is the ack-first update() for the phrase-matched path (executePurgeHandshake runs after it). sawRealAsync leaked from the phrase-mismatch branch's message.edit above (which returns).
   await interaction.update({
     content: 'Purging memories…',
     embeds: [],


### PR DESCRIPTION
## What

The **ratchet** that closes the ack-first sweep: a custom ESLint rule (`@tzurot/component-handler-ack-first`) enforcing Discord's 3-second / ack-first discipline structurally. Lands **last**, on a now-clean tree.

## The invariant (redesigned)

A **bare** interaction acknowledgement (`deferUpdate`/`deferReply`/`reply`/`update`/`showModal`) must not follow awaited async work. Two ways to satisfy it:
- **ack first** — put the bare ack before any awaited work; or
- **wrap a necessarily-late ack** — if data must be fetched before choosing the ack (e.g. a modal prefilled from a row), route it through a `*WithTimeoutCatch` wrapper.

Any awaited call that passes the whole `interaction` (directly or in an options object) is treated as a wrapper/delegation and exempted. Full rationale + the design journey: `docs/research/ack-first-lint-rule-redesign.md`.

## Detection scope

Targets handlers receiving a **raw interaction** needing an ack, detected by: (a) the `handleButton` / `handleSelectMenu` / `handleModal` router keys (defineCommand entries, often un-annotated arrows), and (b) a first param typed `(Button|SelectMenu|ModalSubmit)Interaction`. Fail-closed: unresolvable params (destructured / union) are conservatively skipped, never mis-flagged.

## Why it lands last

The stricter rule found real ack-after-async bugs; those were fixed first so the rule goes green immediately: clean-3 batch + `SettingsDashboardHandler`; #1413 `handleSettingsModal`; #1414 persona modals.

## The 6 suppressions (all branch-leak FPs, justified)

Single-pass source-order (not per-branch), so `sawRealAsync` set in one branch can leak onto a sibling's ack. Each confirmed FP with an inline justification:
- `character/dashboardActions.ts` ×3 — `visibility` branch's fetch leaks onto static `avatar`/`voice` redirects + `voice-toggle` defer
- `memory/detailActionRouter.ts` ×1 — `confirm-delete`'s `onRefresh` leaks onto `back`'s `deferUpdate`
- `memory/purge.ts` ×2 — phrase-mismatch branch's `message.edit` leaks onto the matched-path acks

## Review response

- **Fail-closed `isBareAckCall`** — only counts an ack when the interaction is positively identified (was permissive on unresolvable params); regression test added.
- **`handleModal` added to router keys** — modal arrow entries now covered (was a gap); test added.
- **Union-typed params → split to a follow-up.** Enabling union detection surfaced 6 pre-existing sites needing individual triage (incl. a real C1-class bug in `getSessionDataOrReply`), which is a mini-campaign, not a rule tweak. Tracked as its own epic slice so this PR lands the ratchet for the common case now.

## Enforcement (verified)

- **CI lint job** builds the tooling dist (`ci.yml:75`) then runs lint (`:78`) → rule is `'error'`.
- **Pre-commit** `lint-staged` runs `eslint --fix --max-warnings=0` on staged `.ts`.
- Same plugin/dist/config as the existing `@tzurot/no-singleton-export` rule; unguarded import → fails loud, never a silent no-op.

25 rule unit tests + zero violations across bot-client; `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)