### PR TITLE
fix(bot-client): make trigger-message persist non-fatal in submitChatJob

### DIFF
--- a/services/bot-client/src/services/character/PersonalityChatManager.test.ts
+++ b/services/bot-client/src/services/character/PersonalityChatManager.test.ts
@@ -364,6 +364,24 @@ describe('PersonalityChatManager', () => {
       expect(call).toMatchObject({ attachments });
       expect(call.referencedMessages).toBeUndefined();
     });
+
+    it('continues to generate when the trigger-message persist fails (non-fatal)', async () => {
+      // A transient gateway/DB timeout persisting the trigger message must NOT
+      // block generation — the user still gets a response; only the history row
+      // is lost. Regression guard for the "something's slow, try again" dead-end.
+      mockPersistence.saveUserMessage.mockRejectedValueOnce(
+        new Error('User-message persist failed via gateway: 500 Query read timeout')
+      );
+
+      const result = await manager.submitChatJob({
+        message: createMockMessage(),
+        personality: createMockPersonality(),
+        content: 'Hi',
+      });
+
+      expect(result.kind).toBe('submitted');
+      expect(vi.mocked(generate)).toHaveBeenCalled();
+    });
   });
 
   describe('submitChatJob - NSFW edge cases', () => {

--- a/services/bot-client/src/services/character/PersonalityChatManager.ts
+++ b/services/bot-client/src/services/character/PersonalityChatManager.ts
@@ -249,13 +249,28 @@ export class PersonalityChatManager {
     // from `rawReferencedMessages` in the envelope. (The previous
     // `referencedMessages: context.referencedMessages` arg was a no-op — that
     // field is never populated on the thin envelope.)
-    await this.persistence.saveUserMessage({
-      message,
-      personality,
-      personaId,
-      messageContent,
-      attachments: context.attachments,
-    });
+    //
+    // Best-effort: a transient gateway/DB failure persisting the trigger message
+    // (conversation-history durability) must NOT block generation. The worker's
+    // context is already built above and shipped in the envelope, and
+    // triggerMessageId is only a Redis dedup key downstream — never a DB read of
+    // this row — so generation does not depend on the persist. Losing one history
+    // row on a rare transient timeout beats failing the whole response (the
+    // "something's slow, try again" dead-end the user otherwise hits).
+    try {
+      await this.persistence.saveUserMessage({
+        message,
+        personality,
+        personaId,
+        messageContent,
+        attachments: context.attachments,
+      });
+    } catch (err) {
+      logger.error(
+        { err, personalityId: personality.id, messageId: message.id },
+        'Trigger-message persist failed; continuing to generate (history row may be missing)'
+      );
+    }
 
     const userMessageTime = new Date();
 


### PR DESCRIPTION
## Production bug (user-reported, runtime-confirmed)

Users hit **"⏳ Couldn't get a response just now — something's slow on our end. Please try again in a moment."** with **no AI response**. Prod logs (2026-06-30 ~20:30 UTC, during a load spike) confirm the chain:

```
persistUserMessageViaGateway → 500 Query read timeout
  → ConversationPersistence.saveUserMessage → PersonalityChatManager.submitChatJob (threw)
  → MultiTagCoordinator.submitSlot → errored slot → all-slots-failed notice (anyInfraError=true)
```

`saveUserMessage` (trigger-message persist) threw **before** `generate()` ran, so the AI job was never submitted.

## Fix

Wrap the persist in try/catch — **log and continue to `generate()`**. The persist is conversation-history durability only:
- the worker's context is already built (`buildContext`, above the persist) and shipped in the envelope;
- `triggerMessageId` is only a **Redis dedup key** downstream (`markMessageProcessing`) — never a DB read of this row.

So generation does not depend on the persist. A rare transient timeout now loses **one history row** instead of **the entire response**. Ordering is preserved (the persist is still awaited before submission — not made async/fire-and-forget).

## Root cause (separate follow-up)

The `500 Query read timeout` itself is pg's **client-side 6s `query_timeout`** firing on a genuinely slow `conversation_history` INSERT — most likely **GIN pending-list flush contention** on the `message_metadata` GIN index (default settings, no `fastupdate=off`). Rare (1 occurrence in 12.3h), load-triggered. The root-cause fix (tune/drop the GIN index) is tracked separately; this PR is the resilience layer so a transient stall never dead-ends a response again.

## Tests

- New regression test: `saveUserMessage` rejects → `submitChatJob` still calls `generate()` and returns `kind: 'submitted'`.
- Full bot-client suite green (5164); `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)