### PR TITLE
fix: drop unused message_metadata GIN index (root cause of the persist timeout)

### DIFF
--- a/packages/test-utils/schema/pglite-schema.sql
+++ b/packages/test-utils/schema/pglite-schema.sql
@@ -619,9 +619,6 @@ CREATE INDEX "conversation_history_persona_id_personality_id_created_at_idx" ON 
 CREATE INDEX "conversation_history_discord_message_id_idx" ON "conversation_history"("discord_message_id");
 
 -- CreateIndex
-CREATE INDEX "conversation_history_message_metadata_idx" ON "conversation_history" USING GIN ("message_metadata");
-
--- CreateIndex
 CREATE INDEX "conversation_history_deleted_at_idx" ON "conversation_history"("deleted_at");
 
 -- CreateIndex

--- a/prisma/migrations/20260630223919_drop_unused_message_metadata_gin_index/migration.sql
+++ b/prisma/migrations/20260630223919_drop_unused_message_metadata_gin_index/migration.sql
@@ -1,0 +1,5 @@
+-- DropIndex
+DROP INDEX "conversation_history_message_metadata_idx";
+
+-- DropIndex
+-- REMOVED: DROP INDEX "idx_memories_embedding";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -484,7 +484,11 @@ model ConversationHistory {
   @@index([channelId, personalityId, createdAt(sort: Desc)])
   @@index([personaId, personalityId, createdAt(sort: Desc)])
   @@index([discordMessageId])
-  @@index([messageMetadata], map: "conversation_history_message_metadata_idx", type: Gin)
+  // No GIN index on messageMetadata: nothing queries it by JSONB containment
+  // (it's only ever SELECTed whole and property-accessed in app code), so the
+  // index was pure write-overhead — its pending-list flushes stalled inserts
+  // multi-second under load (the gateway query_timeout incident). Re-add only
+  // if a real containment query (@>, Prisma `path`/`has`) is introduced.
   @@index([deletedAt]) // For cleanup queries and filtering soft-deleted messages
   @@map("conversation_history")
 }


### PR DESCRIPTION
## What

Drops the `conversation_history_message_metadata_idx` GIN index — the **root cause** of the `500 Query read timeout` that #1410 made non-fatal. (#1410 = resilience; this = prevention.)

## Why it's safe to drop

`message_metadata` is **never queried by JSONB containment** — verified across all TS + raw SQL: it's only ever SELECTed whole and property-accessed in app code (`.referencedMessages`, `.voiceTranscripts`, …) and written. No `@>`, no Prisma `path`/`has`, no raw-SQL WHERE on it. The index was added **speculatively** ("for efficient JSONB queries (e.g., finding all messages with references)") in the column's original migration — a query that was never built. Pure write-overhead.

Its GIN **pending-list flushes** stalled inserts multi-second under load (high-confidence inference from the index config + concurrent same-table slowness + the pool config's own anticipatory comment), tripping pg's 6s client-side `query_timeout`.

**Contrast:** the `responseMessageIds` GIN index is **kept** — it backs a real `{ has: messageId }` containment query in `admin/diagnostic.ts`. Not every JSONB index is unused; this one specifically was.

## Migration

`DROP INDEX "conversation_history_message_metadata_idx";` — Prisma-representable (removed the `@@index` line; no drift-ignore needed). `db:safe-migrate` correctly sanitized out the protected `idx_memories_embedding` drop Prisma also tried to emit. PGLite schema regenerated.

Dropping an unused index is safe to apply anytime (no query planner uses it; no code references it).

## Deploy note

Apply to dev after merge (`pnpm ops db:migrate --env dev`); for prod, it's additive-safe (an unused-index drop) so `release:premigrate` handles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)