### PR TITLE
fix: make openrouter/free a first-class free model + the last-resort fallback

### DIFF
--- a/packages/common-types/src/constants/ai.test.ts
+++ b/packages/common-types/src/constants/ai.test.ts
@@ -31,6 +31,13 @@ describe('isFreeModel', () => {
     expect(isFreeModel(':free/some-model')).toBe(false);
   });
 
+  it('should recognize the OpenRouter free-model router (no :free suffix)', () => {
+    expect(isFreeModel('openrouter/free')).toBe(true);
+    // A model that merely ends in /free is NOT the router and not free.
+    expect(isFreeModel('some-provider/free')).toBe(false);
+    expect(isFreeModel('openrouter/auto')).toBe(false);
+  });
+
   it('should handle edge cases', () => {
     expect(isFreeModel('')).toBe(false);
     expect(isFreeModel(':free')).toBe(true);
@@ -40,7 +47,7 @@ describe('isFreeModel', () => {
 
 describe('GUEST_MODE', () => {
   it('should have a default free model configured', () => {
-    expect(GUEST_MODE.DEFAULT_MODEL).toBe('google/gemma-4-31b-it:free');
+    expect(GUEST_MODE.DEFAULT_MODEL).toBe('openrouter/free');
     expect(isFreeModel(GUEST_MODE.DEFAULT_MODEL)).toBe(true);
   });
 

--- a/packages/common-types/src/constants/ai.ts
+++ b/packages/common-types/src/constants/ai.ts
@@ -161,6 +161,14 @@ export const AI_ENDPOINTS = {
 const FREE_MULTIMODAL_MODEL = 'google/gemma-4-31b-it:free';
 
 /**
+ * OpenRouter's free-model router — a meta-model that routes to an available free
+ * model. It is free to use, but its ID does NOT carry the `:free` suffix, so
+ * `isFreeModel` must recognize it explicitly (otherwise it's wrongly excluded
+ * from free-tier defaults, guest-mode eligibility, and free-model badges).
+ */
+const FREE_ROUTER_MODEL = 'openrouter/free';
+
+/**
  * Centralized Model Configuration
  *
  * Single source of truth for all AI model defaults.
@@ -173,8 +181,12 @@ export const MODEL_DEFAULTS = {
   // Specialized models
   /** Vision fallback for BYOK users (paid) — natively multimodal */
   VISION_FALLBACK: 'qwen/qwen3.5-397b-a17b',
-  /** Vision fallback for free tier users (no BYOK) — 131k context, multimodal */
-  VISION_FALLBACK_FREE: FREE_MULTIMODAL_MODEL,
+  /**
+   * Vision fallback for free-tier users (no BYOK) — the dynamic free-model router
+   * (vision-capable per OpenRouter's catalog), so it survives individual free
+   * models being rate-limited or rotated out rather than pinning one model.
+   */
+  VISION_FALLBACK_FREE: FREE_ROUTER_MODEL,
   /**
    * Local embedding model (not configurable via env)
    * Uses @tzurot/embeddings package with 384-dimensional vectors.
@@ -509,10 +521,13 @@ export enum AIProvider {
  */
 export const GUEST_MODE = {
   /**
-   * Default free model for guest users
-   * Gemma 3 27B: 131k context window, multimodal, excellent for conversational AI
+   * Last-resort free model for guest users when no free-default config is set
+   * (AuthStep prefers a configured free default over this). The OpenRouter
+   * free-model router (dynamic) rather than a single pinned model, so it survives
+   * individual free models being rate-limited or rotated out — whatever free
+   * models are in rotation, the router resolves one.
    */
-  DEFAULT_MODEL: FREE_MULTIMODAL_MODEL,
+  DEFAULT_MODEL: FREE_ROUTER_MODEL,
 
   /**
    * Alternative free models (for failover or user choice)
@@ -537,12 +552,15 @@ export const GUEST_MODE = {
 } as const;
 
 /**
- * Check if a model ID is a free model
- * Free models on OpenRouter end with ':free'
+ * Check if a model ID is a free model.
+ *
+ * Two shapes count as free: OpenRouter models whose ID ends with ':free', and
+ * the OpenRouter free-model router ('openrouter/free'), which has no suffix but
+ * routes to a free model.
  *
  * @param modelId - The model ID to check (e.g., 'x-ai/grok-4.1-fast:free')
  * @returns true if the model is free
  */
 export function isFreeModel(modelId: string): boolean {
-  return modelId.endsWith(GUEST_MODE.FREE_MODEL_SUFFIX);
+  return modelId === FREE_ROUTER_MODEL || modelId.endsWith(GUEST_MODE.FREE_MODEL_SUFFIX);
 }

--- a/services/api-gateway/src/routes/admin/llm-config.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.ts
@@ -330,7 +330,7 @@ function createSetFreeDefaultHandler(
       return sendError(
         res,
         ErrorResponses.validationError(
-          'Only presets using free models (model ID ending in :free) can be set as free tier default'
+          'Only presets using free models (model ID ending in :free, or the openrouter/free router) can be set as free tier default'
         )
       );
     }

--- a/services/bot-client/src/commands/preset/autocomplete.ts
+++ b/services/bot-client/src/commands/preset/autocomplete.ts
@@ -309,7 +309,7 @@ async function handleGlobalConfigAutocomplete(
         if (!c.isGlobal) {
           return false;
         }
-        // If freeOnly, model must be a free model (ending in :free)
+        // If freeOnly, model must be a free model (a :free-suffixed model or the openrouter/free router)
         if (freeOnly && !isFreeModel(c.model)) {
           return false;
         }


### PR DESCRIPTION
## What

Two coupled changes around OpenRouter's free-model router (`openrouter/free`):

1. **`isFreeModel` recognizes it.** It only matched the `:free` suffix, so the router (free, but no `:free` suffix) was excluded everywhere `isFreeModel` gates free-tier behavior — the free-default **autocomplete dropped it** (the reported bug: couldn't select it), server-side free-default validation would reject it, guest-mode auth treated it as paid, and browse omitted the free badge.

2. **The hard-coded guest/vision fallbacks now point at the router** (`GUEST_MODE.DEFAULT_MODEL`, `MODEL_DEFAULTS.VISION_FALLBACK_FREE`) instead of a single pinned free model. The router is **vision-capable per OpenRouter's catalog** (API-sourced), so it's a safe last resort for both text and vision — and it survives individual free models being rate-limited or rotated out. Motivation: recent free-model rate-limit errors; the dynamic router resolves whatever free model is in rotation.

## Why coupled

(2) depends on (1): `AuthStep` does `if (isFreeModel(currentModel))` and uses `GUEST_MODE.DEFAULT_MODEL` as the guest fallback — if that constant is `openrouter/free`, `isFreeModel` must recognize it. And `AuthStep` still **prefers a configured free-default** over the constant, so setting the router as the free default (now possible via change 1) takes precedence; the constant is the last-resort floor.

## Tests

- `isFreeModel` recognizes `openrouter/free`; rejects near-misses (`some-provider/free`, `openrouter/auto`).
- `GUEST_MODE.DEFAULT_MODEL` assertion updated to the router; the constant-referencing consumer tests (AuthStep, visionAuthResolver) auto-follow.
- Full quality green; 129 ai-worker consumer tests + common-types tests pass.

> Verify on dev that `openrouter/free` resolves + responds end-to-end (incl. an image request for the vision path) before relying on it as the prod floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)