### PR TITLE
fix(bot-client): ack-first handleSettingsModal (defer before Redis read)

### DIFF
--- a/services/bot-client/src/utils/dashboard/settings/SettingsDashboardHandler.test.ts
+++ b/services/bot-client/src/utils/dashboard/settings/SettingsDashboardHandler.test.ts
@@ -1080,6 +1080,7 @@ describe('SettingsDashboardHandler', () => {
       reply: vi.fn(),
       deferUpdate: vi.fn(),
       editReply: vi.fn(),
+      followUp: vi.fn(),
     });
 
     it('should return early for invalid customId', async () => {
@@ -1118,7 +1119,9 @@ describe('SettingsDashboardHandler', () => {
 
       await handleSettingsModal(interaction as never, config, updateHandler);
 
-      expect(interaction.reply).toHaveBeenCalledWith(
+      // Ack-first: deferUpdate precedes getSession, so expiry surfaces via followUp.
+      expect(interaction.deferUpdate).toHaveBeenCalled();
+      expect(interaction.followUp).toHaveBeenCalledWith(
         expect.objectContaining({
           content: expect.stringContaining('expired'),
         })
@@ -1144,7 +1147,7 @@ describe('SettingsDashboardHandler', () => {
 
       await handleSettingsModal(interaction as never, config, updateHandler);
 
-      expect(interaction.reply).toHaveBeenCalledWith(
+      expect(interaction.followUp).toHaveBeenCalledWith(
         expect.objectContaining({
           content: expect.stringContaining('Unknown setting'),
         })
@@ -1262,7 +1265,7 @@ describe('SettingsDashboardHandler', () => {
 
         await handleSettingsModal(interaction as never, config, updateHandler);
 
-        expect(interaction.reply).toHaveBeenCalledWith(
+        expect(interaction.followUp).toHaveBeenCalledWith(
           expect.objectContaining({
             content: expect.stringContaining('Invalid number'),
           })
@@ -1290,7 +1293,7 @@ describe('SettingsDashboardHandler', () => {
 
         await handleSettingsModal(interaction as never, config, updateHandler);
 
-        expect(interaction.reply).toHaveBeenCalledWith(
+        expect(interaction.followUp).toHaveBeenCalledWith(
           expect.objectContaining({
             content: expect.stringContaining('between'),
           })
@@ -1318,7 +1321,7 @@ describe('SettingsDashboardHandler', () => {
 
         await handleSettingsModal(interaction as never, config, updateHandler);
 
-        expect(interaction.reply).toHaveBeenCalledWith(
+        expect(interaction.followUp).toHaveBeenCalledWith(
           expect.objectContaining({
             content: expect.stringContaining('between'),
           })
@@ -1483,7 +1486,7 @@ describe('SettingsDashboardHandler', () => {
 
         await handleSettingsModal(interaction as never, config, updateHandler);
 
-        expect(interaction.reply).toHaveBeenCalledWith(
+        expect(interaction.followUp).toHaveBeenCalledWith(
           expect.objectContaining({
             content: expect.stringContaining('Invalid duration'),
           })
@@ -1508,7 +1511,7 @@ describe('SettingsDashboardHandler', () => {
 
         await handleSettingsModal(interaction as never, config, updateHandler);
 
-        expect(interaction.reply).toHaveBeenCalledWith(
+        expect(interaction.followUp).toHaveBeenCalledWith(
           expect.objectContaining({
             content: expect.stringContaining('at least 1 minute'),
           })

--- a/services/bot-client/src/utils/dashboard/settings/SettingsDashboardHandler.ts
+++ b/services/bot-client/src/utils/dashboard/settings/SettingsDashboardHandler.ts
@@ -465,6 +465,7 @@ export async function handleSettingsModal(
 
   const settingId = parsed.extra;
   if (settingId === undefined) {
+    // Sync guard, no preceding async — reply is the ack-first response here.
     await interaction.reply({
       content: 'Invalid modal submission.',
       flags: MessageFlags.Ephemeral,
@@ -472,11 +473,16 @@ export async function handleSettingsModal(
     return;
   }
 
+  // Ack first (3-second rule): deferUpdate before the Redis getSession and the
+  // validation below. Every error path after this point uses followUp (the
+  // interaction is already acked); the success path editReplies the dashboard.
+  await interaction.deferUpdate();
+
   // Get session
   const session = await getSession(interaction.user.id, config.entityType, parsed.entityId);
 
   if (session === null) {
-    await interaction.reply({
+    await interaction.followUp({
       content: 'This dashboard has expired. Please run the command again.',
       flags: MessageFlags.Ephemeral,
     });
@@ -488,7 +494,7 @@ export async function handleSettingsModal(
   const setting = getSettingById(settingId);
 
   if (setting === undefined) {
-    await interaction.reply({
+    await interaction.followUp({
       content: 'Unknown setting.',
       flags: MessageFlags.Ephemeral,
     });
@@ -516,17 +522,14 @@ export async function handleSettingsModal(
   }
 
   if (error !== undefined) {
-    await interaction.reply({
+    await interaction.followUp({
       content: error,
       flags: MessageFlags.Ephemeral,
     });
     return;
   }
 
-  // Defer the update to acknowledge we're processing
-  await interaction.deferUpdate();
-
-  // Call the update handler
+  // Call the update handler (interaction was already deferUpdate'd above)
   const result = await updateHandler(interaction, session, settingId, parsedValue);
 
   if (!result.success) {


### PR DESCRIPTION
## What

**PR C1 of the ack-first sweep.** `handleSettingsModal` did `getSession` (Redis) + input validation **before** its `deferUpdate`, so on the normal modal-submit path the ack landed *after* the lookup — a real 3-second-budget violation, the same class fixed for the select-menu/button handlers in #1408.

It was missed there (and by the old lint rule) because an earlier `settingId`-guard `reply()` "claimed the first await" in the prior rule model. The redesigned `bare-ack-after-async` rule surfaces it (this is one of the real bugs the stricter rule found — see `docs/research/ack-first-lint-rule-redesign.md`).

## Fix

- Hoist `deferUpdate` ahead of `getSession`.
- The session-expired / unknown-setting / invalid-input guards → `followUp` (post-defer).
- The `settingId`-undefined guard **stays a `reply`** — it runs before the defer, on a sync check with no preceding async.
- Success path `editReply`s the dashboard (unchanged).

## Tests

- 7 modal error-path assertions flipped `reply`→`followUp`; modal mock gains `followUp`; added a `deferUpdate` ack-first assertion.
- Handler tests (73) + the 5 caller dashboards (102) + full bot-client suite (5164) green; `pnpm quality` green.

## Sweep status

Next: **C2** (the two persona modal handlers — `deferReply` pattern), then the `component-handler-ack-first` rule itself (#1409) + FP suppressions lands last on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)