### PR TITLE
fix(bot-client): ack-first the persona create/override modal submits

### DIFF
--- a/services/bot-client/src/commands/persona/create.test.ts
+++ b/services/bot-client/src/commands/persona/create.test.ts
@@ -76,6 +76,8 @@ describe('handleCreatePersona', () => {
 
 describe('handleCreateModalSubmit', () => {
   const mockReply = vi.fn();
+  const mockDeferReply = vi.fn();
+  const mockEditReply = vi.fn();
   let stub: PersonaClientStub;
 
   beforeEach(() => {
@@ -91,6 +93,8 @@ describe('handleCreateModalSubmit', () => {
         getTextInputValue: (name: string) => fields[name] ?? '',
       },
       reply: mockReply,
+      deferReply: mockDeferReply,
+      editReply: mockEditReply,
     } as any;
   }
 
@@ -126,9 +130,12 @@ describe('handleCreateModalSubmit', () => {
       pronouns: 'she/her',
       content: 'I am professional',
     });
-    expect(mockReply).toHaveBeenCalledWith({
+    // Ack-first: deferReply runs before the createPersona gateway call; the
+    // result lands via editReply, never a bare reply.
+    expect(mockDeferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    expect(mockReply).not.toHaveBeenCalled();
+    expect(mockEditReply).toHaveBeenCalledWith({
       content: expect.stringContaining('Persona "Work Persona" created'),
-      flags: MessageFlags.Ephemeral,
     });
   });
 
@@ -144,9 +151,8 @@ describe('handleCreateModalSubmit', () => {
       })
     );
 
-    expect(mockReply).toHaveBeenCalledWith({
+    expect(mockEditReply).toHaveBeenCalledWith({
       content: expect.stringContaining('already have a persona named "Dup"'),
-      flags: MessageFlags.Ephemeral,
     });
   });
 
@@ -161,9 +167,8 @@ describe('handleCreateModalSubmit', () => {
       })
     );
 
-    expect(mockReply).toHaveBeenCalledWith({
+    expect(mockEditReply).toHaveBeenCalledWith({
       content: expect.stringContaining('Persona name is required'),
-      flags: MessageFlags.Ephemeral,
     });
     expect(stub.createPersona).not.toHaveBeenCalled();
   });
@@ -249,9 +254,8 @@ describe('handleCreateModalSubmit', () => {
       })
     );
 
-    expect(mockReply).toHaveBeenCalledWith({
+    expect(mockEditReply).toHaveBeenCalledWith({
       content: expect.stringContaining('Failed to create persona'),
-      flags: MessageFlags.Ephemeral,
     });
   });
 
@@ -268,9 +272,8 @@ describe('handleCreateModalSubmit', () => {
       })
     );
 
-    expect(mockReply).toHaveBeenCalledWith({
+    expect(mockEditReply).toHaveBeenCalledWith({
       content: expect.stringContaining('Failed to create persona'),
-      flags: MessageFlags.Ephemeral,
     });
   });
 });

--- a/services/bot-client/src/commands/persona/create.ts
+++ b/services/bot-client/src/commands/persona/create.ts
@@ -52,6 +52,13 @@ export async function handleCreatePersona(context: ModalCommandContext): Promise
 export async function handleCreateModalSubmit(interaction: ModalSubmitInteraction): Promise<void> {
   const discordId = interaction.user.id;
 
+  // Ack first (3-second rule): deferReply BEFORE the try — per the codebase
+  // convention — so a failure of the ack itself propagates to CommandHandler
+  // (which branches on replied/deferred) rather than into the catch below, which
+  // assumes the interaction is already acked. Ephemeral: the create result is a
+  // private confirmation. Everything inside the try is post-defer → editReply.
+  await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
   try {
     // Get values from modal
     const personaName = interaction.fields.getTextInputValue('personaName').trim();
@@ -65,10 +72,7 @@ export async function handleCreateModalSubmit(interaction: ModalSubmitInteractio
 
     // Persona name is required
     if (personaName.length === 0) {
-      await interaction.reply({
-        content: '❌ Persona name is required.',
-        flags: MessageFlags.Ephemeral,
-      });
+      await interaction.editReply({ content: '❌ Persona name is required.' });
       return;
     }
 
@@ -83,9 +87,8 @@ export async function handleCreateModalSubmit(interaction: ModalSubmitInteractio
 
     if (!result.ok) {
       if (result.code === API_ERROR_SUBCODE.NAME_COLLISION) {
-        await interaction.reply({
+        await interaction.editReply({
           content: `❌ You already have a persona named "${personaName}". Pick a different name, or edit the existing one with \`/persona edit\`.`,
-          flags: MessageFlags.Ephemeral,
         });
         return;
       }
@@ -93,9 +96,8 @@ export async function handleCreateModalSubmit(interaction: ModalSubmitInteractio
         { userId: discordId, error: result.error },
         'Failed to create persona via gateway'
       );
-      await interaction.reply({
+      await interaction.editReply({
         content: '❌ Failed to create persona. Please try again later.',
-        flags: MessageFlags.Ephemeral,
       });
       return;
     }
@@ -127,15 +129,13 @@ export async function handleCreateModalSubmit(interaction: ModalSubmitInteractio
     }
     response += '\n\nUse `/persona browse` to see all your personas.';
 
-    await interaction.reply({
-      content: response,
-      flags: MessageFlags.Ephemeral,
-    });
+    await interaction.editReply({ content: response });
   } catch (error) {
     logger.error({ err: error, userId: discordId }, 'Failed to create persona');
-    await interaction.reply({
+    // Post-defer: deferReply ran (and succeeded) before the try, so the
+    // interaction is acked by the time any error reaches here.
+    await interaction.editReply({
       content: '❌ Failed to create persona. Please try again later.',
-      flags: MessageFlags.Ephemeral,
     });
   }
 }

--- a/services/bot-client/src/commands/persona/override/set.test.ts
+++ b/services/bot-client/src/commands/persona/override/set.test.ts
@@ -186,6 +186,8 @@ describe('handleOverrideSet', () => {
 
 describe('handleOverrideCreateModalSubmit', () => {
   const mockReply = vi.fn();
+  const mockDeferReply = vi.fn();
+  const mockEditReply = vi.fn();
   let stub: PersonaClientStub;
 
   beforeEach(() => {
@@ -201,6 +203,8 @@ describe('handleOverrideCreateModalSubmit', () => {
         getTextInputValue: (name: string) => fields[name] ?? '',
       },
       reply: mockReply,
+      deferReply: mockDeferReply,
+      editReply: mockEditReply,
     } as unknown as Parameters<typeof handleOverrideCreateModalSubmit>[0];
   }
 
@@ -241,9 +245,12 @@ describe('handleOverrideCreateModalSubmit', () => {
       pronouns: 'she/her',
       content: 'Special content for Lilith',
     });
-    expect(mockReply).toHaveBeenCalledWith({
+    // Ack-first: deferReply runs before the createPersonaOverride gateway call;
+    // the result lands via editReply, never a bare reply.
+    expect(mockDeferReply).toHaveBeenCalledWith({ flags: MessageFlags.Ephemeral });
+    expect(mockReply).not.toHaveBeenCalled();
+    expect(mockEditReply).toHaveBeenCalledWith({
       content: expect.stringContaining('Persona "Lilith Persona" created'),
-      flags: MessageFlags.Ephemeral,
     });
   });
 
@@ -259,9 +266,8 @@ describe('handleOverrideCreateModalSubmit', () => {
       'personality-uuid'
     );
 
-    expect(mockReply).toHaveBeenCalledWith({
+    expect(mockEditReply).toHaveBeenCalledWith({
       content: expect.stringContaining('Persona name is required'),
-      flags: MessageFlags.Ephemeral,
     });
     expect(stub.createPersonaOverride).not.toHaveBeenCalled();
   });
@@ -280,9 +286,8 @@ describe('handleOverrideCreateModalSubmit', () => {
       'personality-uuid'
     );
 
-    expect(mockReply).toHaveBeenCalledWith({
+    expect(mockEditReply).toHaveBeenCalledWith({
       content: expect.stringContaining('User not found'),
-      flags: MessageFlags.Ephemeral,
     });
   });
 
@@ -302,9 +307,8 @@ describe('handleOverrideCreateModalSubmit', () => {
       'personality-uuid'
     );
 
-    expect(mockReply).toHaveBeenCalledWith({
+    expect(mockEditReply).toHaveBeenCalledWith({
       content: expect.stringContaining('already have a persona named "Dup"'),
-      flags: MessageFlags.Ephemeral,
     });
   });
 
@@ -322,9 +326,8 @@ describe('handleOverrideCreateModalSubmit', () => {
       'personality-uuid'
     );
 
-    expect(mockReply).toHaveBeenCalledWith({
+    expect(mockEditReply).toHaveBeenCalledWith({
       content: expect.stringContaining('Failed to create persona'),
-      flags: MessageFlags.Ephemeral,
     });
   });
 });

--- a/services/bot-client/src/commands/persona/override/set.ts
+++ b/services/bot-client/src/commands/persona/override/set.ts
@@ -177,6 +177,13 @@ export async function handleOverrideCreateModalSubmit(
 ): Promise<void> {
   const discordId = interaction.user.id;
 
+  // Ack first (3-second rule): deferReply BEFORE the try — per the codebase
+  // convention — so a failure of the ack itself propagates to CommandHandler
+  // (which branches on replied/deferred) rather than into the catch below, which
+  // assumes the interaction is already acked. Ephemeral: the result is a private
+  // confirmation. Everything inside the try is post-defer → editReply.
+  await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
   try {
     // Get values from modal
     const personaName = interaction.fields.getTextInputValue('personaName').trim();
@@ -190,10 +197,7 @@ export async function handleOverrideCreateModalSubmit(
 
     // Persona name is required
     if (personaName.length === 0) {
-      await interaction.reply({
-        content: '❌ Persona name is required.',
-        flags: MessageFlags.Ephemeral,
-      });
+      await interaction.editReply({ content: '❌ Persona name is required.' });
       return;
     }
 
@@ -208,18 +212,14 @@ export async function handleOverrideCreateModalSubmit(
 
     if (!result.ok) {
       if (result.code === API_ERROR_SUBCODE.NAME_COLLISION) {
-        await interaction.reply({
+        await interaction.editReply({
           content: `❌ You already have a persona named "${personaName}". Pick a different name, or edit the existing one with \`/persona edit\`.`,
-          flags: MessageFlags.Ephemeral,
         });
         return;
       }
 
       if (result.error.includes('User not found')) {
-        await interaction.reply({
-          content: '❌ User not found.',
-          flags: MessageFlags.Ephemeral,
-        });
+        await interaction.editReply({ content: '❌ User not found.' });
         return;
       }
 
@@ -227,9 +227,8 @@ export async function handleOverrideCreateModalSubmit(
         { userId: discordId, personalityId, error: result.error },
         'Failed to create override persona via gateway'
       );
-      await interaction.reply({
+      await interaction.editReply({
         content: '❌ Failed to create persona. Please try again later.',
-        flags: MessageFlags.Ephemeral,
       });
       return;
     }
@@ -242,21 +241,21 @@ export async function handleOverrideCreateModalSubmit(
       'Created new persona and set as override'
     );
 
-    await interaction.reply({
+    await interaction.editReply({
       content:
         `✅ **Persona "${personaName}" created and set as override for ${personalityName}!**\n\n` +
         `This persona will be used when talking to ${personalityName}.\n\n` +
         `Use \`/persona browse\` to see all your personas.`,
-      flags: MessageFlags.Ephemeral,
     });
   } catch (error) {
     logger.error(
       { err: error, userId: discordId, personalityId },
       'Failed to create override persona'
     );
-    await interaction.reply({
+    // Post-defer: deferReply ran (and succeeded) before the try, so the
+    // interaction is acked by the time any error reaches here.
+    await interaction.editReply({
       content: '❌ Failed to create persona. Please try again later.',
-      flags: MessageFlags.Ephemeral,
     });
   }
 }


### PR DESCRIPTION
## What

**PR C2 of the ack-first sweep.** `handleCreateModalSubmit` (`persona/create.ts`) and `handleOverrideCreateModalSubmit` (`persona/override/set.ts`) did the `createPersona` / `createPersonaOverride` **gateway POST before their first bare `reply`** — so under a slow gateway the ack could miss the 3-second window. Same ack-after-async class the redesigned rule surfaces.

## Fix

`deferReply({ ephemeral })` **first in the try** (before any modal-field extraction), then every response — including the `catch` — is `editReply`.

Putting the defer at the very top (not just before the gateway call) makes the `catch` unambiguously **post-defer**: the catch is reachable *before* the gateway call too (e.g. a field-extraction throw), so a defer-after-guard would leave the catch sometimes-deferred/sometimes-not and need branching. Defer-first removes that. UX gains a brief ephemeral "thinking…" on the slow path.

## Tests

- Both handlers' mocks gain `deferReply`/`editReply`; the response assertions flip `reply`→`editReply` and drop `flags` (ephemeral is set at defer time, not on `editReply`).
- 22 persona tests + full bot-client suite (5164) green; `pnpm quality` green.

## Sweep status

C1 (#1413, `handleSettingsModal`) + this (C2) are the real ack-after-async bugs. Remaining: the `component-handler-ack-first` rule itself (#1409) rebased on the clean tree + the branch-leak FP suppressions, landing last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)