### PR TITLE
fix(bot-client): 10062-harden + dedup settings dashboard session guards

### DIFF
--- a/services/bot-client/src/utils/dashboard/settings/SettingsDashboardHandler.ts
+++ b/services/bot-client/src/utils/dashboard/settings/SettingsDashboardHandler.ts
@@ -98,6 +98,32 @@ export async function createSettingsDashboard(
 }
 
 /**
+ * Fetch the dashboard session and run the shared expired + ownership guards.
+ * Returns the session, or null after notifying the user. `notify` abstracts the
+ * send shape that differs between callers (a select menu always `followUp`s
+ * post-defer; the button handler routes the un-acked edit path through a
+ * 10062-safe wrapped reply). Callers ack (deferUpdate) before calling — except
+ * the edit path, whose `notify` owns its own ack.
+ */
+async function resolveValidatedSession(
+  interaction: ButtonInteraction | StringSelectMenuInteraction,
+  entityType: string,
+  entityId: string,
+  notify: (content: string) => Promise<unknown>
+): Promise<SettingsDashboardSession | null> {
+  const session = await getSession(interaction.user.id, entityType, entityId);
+  if (session === null) {
+    await notify('This dashboard has expired. Please run the command again.');
+    return null;
+  }
+  if (session.userId !== interaction.user.id) {
+    await notify('This dashboard belongs to another user.');
+    return null;
+  }
+  return session;
+}
+
+/**
  * Handle a select menu interaction for settings navigation
  */
 export async function handleSettingsSelectMenu(
@@ -116,23 +142,13 @@ export async function handleSettingsSelectMenu(
   // below become followUp (errors) / editReply (the drill-down).
   await interaction.deferUpdate();
 
-  // Get session
-  const session = await getSession(interaction.user.id, config.entityType, parsed.entityId);
-
+  const session = await resolveValidatedSession(
+    interaction,
+    config.entityType,
+    parsed.entityId,
+    content => interaction.followUp({ content, flags: MessageFlags.Ephemeral })
+  );
   if (session === null) {
-    await interaction.followUp({
-      content: 'This dashboard has expired. Please run the command again.',
-      flags: MessageFlags.Ephemeral,
-    });
-    return;
-  }
-
-  // Verify ownership
-  if (session.userId !== interaction.user.id) {
-    await interaction.followUp({
-      content: 'This dashboard belongs to another user.',
-      flags: MessageFlags.Ephemeral,
-    });
     return;
   }
 
@@ -192,22 +208,22 @@ export async function handleSettingsButton(
   if (!isModalAction) {
     await interaction.deferUpdate();
   }
+  // The edit action can't defer (showModal is its ack), so its guard replies are
+  // un-acked — route them through replyEditGuard so a budget-blown 10062 degrades
+  // to a followUp instead of a silent failure. Every other action deferred above,
+  // so followUp (post-defer) is correct and safe.
   const notify = (content: string): Promise<unknown> =>
     isModalAction
-      ? interaction.reply({ content, flags: MessageFlags.Ephemeral })
+      ? replyEditGuard(interaction, parsed.entityId, content, parsed.extra ?? parsed.action)
       : interaction.followUp({ content, flags: MessageFlags.Ephemeral });
 
-  // Get session
-  const session = await getSession(interaction.user.id, config.entityType, parsed.entityId);
-
+  const session = await resolveValidatedSession(
+    interaction,
+    config.entityType,
+    parsed.entityId,
+    notify
+  );
   if (session === null) {
-    await notify('This dashboard has expired. Please run the command again.');
-    return;
-  }
-
-  // Verify ownership
-  if (session.userId !== interaction.user.id) {
-    await notify('This dashboard belongs to another user.');
     return;
   }
 
@@ -378,7 +394,7 @@ async function handleSetButton(
  */
 function replyEditGuard(
   interaction: ButtonInteraction,
-  session: SettingsDashboardSession,
+  entityId: string,
   content: string,
   sectionId: string
 ): Promise<void> {
@@ -388,7 +404,7 @@ function replyEditGuard(
     {
       source: 'handleSettingsButton/edit',
       userId: interaction.user.id,
-      entityId: session.entityId,
+      entityId,
       sectionId,
     },
     content
@@ -411,7 +427,7 @@ async function handleEditButton(
     logger.warn('Edit button missing setting ID');
     await replyEditGuard(
       interaction,
-      session,
+      session.entityId,
       'Invalid button data. Please run the command again.',
       'edit'
     );
@@ -420,7 +436,7 @@ async function handleEditButton(
 
   const setting = getSettingById(settingId);
   if (setting === undefined) {
-    await replyEditGuard(interaction, session, 'Unknown setting.', settingId);
+    await replyEditGuard(interaction, session.entityId, 'Unknown setting.', settingId);
     return;
   }
 


### PR DESCRIPTION
## What

**PR 2 of the ack-first sweep tail** (C5 + C6, consolidated — both touch `SettingsDashboardHandler.ts`'s ack/session path).

### C5 — 10062 symmetry on the edit path

The edit action can't `deferUpdate` (`showModal` is its ack), so its session-expired / wrong-owner / unknown-action guard replies fire **un-acked** after `getSession` has already eaten into the 3-second budget. They were **bare** replies — a budget-blown 10062 surfaced as a silent "Interaction Failed". Now routed through the existing `replyEditGuard` (`ackWithTimeoutCatch`) so they degrade to a `followUp`, matching the deeper `handleEditButton` guards that were already wrapped. Closes the asymmetry backlog item (#192).

### C6 — dedup the session guards

`handleSettingsButton` and `handleSettingsSelectMenu` each duplicated `getSession → expired → ownership` with **identical messages**, differing only in send shape (`followUp` vs the edit-aware `notify`). Extracted `resolveValidatedSession(interaction, entityType, entityId, notify)` — the **single** `notify` callback absorbs the divergence, comfortably **under the 2-callback ceiling**, so it's a real dedup, not a forced abstraction. `replyEditGuard` now takes `entityId` directly (not the full session) so it's callable at the `notify` site, before `getSession`.

## Verification

- 73 `SettingsDashboardHandler` tests + full bot-client suite (5164) green; `pnpm quality` green.
- **Ratchet check:** the now-live `@tzurot/component-handler-ack-first` rule passes on the changed file — nice self-validation that the ack ordering stays correct.

## Sweep status

C4 (persona `ModalCommandContext` handlers) follows as PR 1 — it needs a small additive broadening of the ack-timeout helper to accept slash interactions, so it's kept separate. C7 (union-param rule extension + the real `getSessionDataOrReply` bug) is the higher-priority follow-up after these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)