### PR TITLE
fix(bot-client): ack-first the persona override context handlers

### DIFF
--- a/services/bot-client/src/commands/persona/override/set.test.ts
+++ b/services/bot-client/src/commands/persona/override/set.test.ts
@@ -54,6 +54,8 @@ function makeStub(): PersonaClientStub {
 
 describe('handleOverrideSet', () => {
   const mockReply = vi.fn();
+  const mockDeferReply = vi.fn();
+  const mockEditReply = vi.fn();
   const mockShowModal = vi.fn();
   let stub: PersonaClientStub;
 
@@ -69,6 +71,20 @@ describe('handleOverrideSet', () => {
       user: { id: '123456789', username: 'testuser' },
       interaction: {
         user: { id: '123456789', username: 'testuser' },
+        // showModal is wrapped via showModalWithTimeoutCatch(context.interaction),
+        // so the mock lives on the raw interaction, not the context passthrough.
+        showModal: mockShowModal,
+        followUp: vi.fn(),
+        // editReply lives on the raw interaction — ModalCommandContext exposes
+        // deferReply but not editReply, so setExistingOverride edits via
+        // context.interaction.editReply.
+        editReply: mockEditReply,
+        // The catch branches on ack state; deferred reflects whether the
+        // setExisting path called deferReply.
+        get deferred() {
+          return mockDeferReply.mock.calls.length > 0;
+        },
+        replied: false,
         options: {
           getString: (name: string) => {
             if (name === 'character') return personalitySlug;
@@ -78,7 +94,7 @@ describe('handleOverrideSet', () => {
         },
       },
       reply: mockReply,
-      showModal: mockShowModal,
+      deferReply: mockDeferReply,
     } as unknown as Parameters<typeof handleOverrideSet>[0];
   }
 
@@ -95,9 +111,11 @@ describe('handleOverrideSet', () => {
     await handleOverrideSet(createMockContext('lilith', 'persona-123'));
 
     expect(stub.setPersonaOverride).toHaveBeenCalledWith('lilith', { personaId: 'persona-123' });
-    expect(mockReply).toHaveBeenCalledWith({
+    // Ack-first: deferReply before the gateway write; result lands via editReply.
+    expect(mockDeferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(mockReply).not.toHaveBeenCalled();
+    expect(mockEditReply).toHaveBeenCalledWith({
       content: expect.stringContaining('Persona override set'),
-      flags: MessageFlags.Ephemeral,
     });
   });
 
@@ -117,14 +135,56 @@ describe('handleOverrideSet', () => {
     expect(mockReply).not.toHaveBeenCalled();
   });
 
+  it('replies (not showModal) when the create-modal prep lookup fails', async () => {
+    // showCreateOverrideModal's !infoResult.ok branch: getPersonaOverride errors
+    // before the modal is built, so it replies with the mapped error and never
+    // shows a modal.
+    stub.getPersonaOverride.mockResolvedValue(makeErr(404, 'Personality not found'));
+
+    await handleOverrideSet(createMockContext('lilith', CREATE_NEW_PERSONA_VALUE));
+
+    expect(mockShowModal).not.toHaveBeenCalled();
+    expect(mockReply).toHaveBeenCalledWith({
+      content: expect.stringContaining('Character "lilith" not found'),
+      flags: MessageFlags.Ephemeral,
+    });
+  });
+
+  it('falls back to reply in the catch when the modal branch throws un-acked', async () => {
+    // getPersonaOverride rejecting makes showCreateOverrideModal throw before any
+    // ack, so handleOverrideSet's catch runs on a NOT-deferred interaction → reply
+    // (not editReply). Exercises the catch's else branch.
+    stub.getPersonaOverride.mockRejectedValue(new Error('Network error'));
+
+    await handleOverrideSet(createMockContext('lilith', CREATE_NEW_PERSONA_VALUE));
+
+    expect(mockDeferReply).not.toHaveBeenCalled();
+    expect(mockEditReply).not.toHaveBeenCalled();
+    expect(mockReply).toHaveBeenCalledWith({
+      content: expect.stringContaining('Failed to set persona override'),
+      flags: MessageFlags.Ephemeral,
+    });
+  });
+
+  it('surfaces the generic failure message when the gateway error is unmapped', async () => {
+    // setExistingOverride's !result.ok + mapOverrideError-returns-null branch: an
+    // unrecognized gateway error falls through to the generic editReply.
+    stub.setPersonaOverride.mockResolvedValue(makeErr(500, 'Internal server error'));
+
+    await handleOverrideSet(createMockContext('lilith', 'persona-123'));
+
+    expect(mockEditReply).toHaveBeenCalledWith({
+      content: expect.stringContaining('Failed to set persona override'),
+    });
+  });
+
   it('should error if personality not found', async () => {
     stub.setPersonaOverride.mockResolvedValue(makeErr(404, 'Personality not found'));
 
     await handleOverrideSet(createMockContext('nonexistent', 'persona-123'));
 
-    expect(mockReply).toHaveBeenCalledWith({
+    expect(mockEditReply).toHaveBeenCalledWith({
       content: expect.stringContaining('Character "nonexistent" not found'),
-      flags: MessageFlags.Ephemeral,
     });
   });
 
@@ -133,9 +193,8 @@ describe('handleOverrideSet', () => {
 
     await handleOverrideSet(createMockContext('lilith', 'persona-123'));
 
-    expect(mockReply).toHaveBeenCalledWith({
+    expect(mockEditReply).toHaveBeenCalledWith({
       content: expect.stringContaining("don't have an account yet"),
-      flags: MessageFlags.Ephemeral,
     });
   });
 
@@ -144,9 +203,8 @@ describe('handleOverrideSet', () => {
 
     await handleOverrideSet(createMockContext('lilith', 'other-persona'));
 
-    expect(mockReply).toHaveBeenCalledWith({
+    expect(mockEditReply).toHaveBeenCalledWith({
       content: expect.stringContaining('Persona not found'),
-      flags: MessageFlags.Ephemeral,
     });
   });
 
@@ -155,9 +213,9 @@ describe('handleOverrideSet', () => {
 
     await handleOverrideSet(createMockContext('lilith', 'persona-123'));
 
-    expect(mockReply).toHaveBeenCalledWith({
+    // setPersonaOverride threw after the deferReply, so the catch is post-defer → editReply.
+    expect(mockEditReply).toHaveBeenCalledWith({
       content: expect.stringContaining('Failed to set persona override'),
-      flags: MessageFlags.Ephemeral,
     });
   });
 

--- a/services/bot-client/src/commands/persona/override/set.ts
+++ b/services/bot-client/src/commands/persona/override/set.ts
@@ -29,6 +29,8 @@ import {
   isAutocompleteErrorSentinel,
 } from '../../../utils/apiCheck.js';
 import { clientsFor } from '../../../utils/gatewayClients.js';
+import { showModalWithTimeoutCatch } from '../../../utils/dashboard/showModalWithTimeoutCatch.js';
+import { ackWithTimeoutCatch } from '../../../utils/dashboard/ackWithTimeoutCatch.js';
 
 const logger = createLogger('persona-override-set');
 
@@ -61,10 +63,20 @@ async function showCreateOverrideModal(
 
   if (!infoResult.ok) {
     const errorMsg = mapOverrideError(infoResult.error, personalitySlug);
-    await context.reply({
-      content: errorMsg ?? '❌ Failed to prepare persona creation. Please try again later.',
-      flags: MessageFlags.Ephemeral,
-    });
+    const content = errorMsg ?? '❌ Failed to prepare persona creation. Please try again later.';
+    // getPersonaOverride already ate into the budget before this ack — same
+    // 10062 risk as the showModal success path below, so wrap it too.
+    await ackWithTimeoutCatch(
+      context.interaction,
+      () => context.reply({ content, flags: MessageFlags.Ephemeral }),
+      {
+        source: 'handleOverrideSet/showCreateOverrideModal',
+        userId: discordId,
+        entityId: personalitySlug,
+        sectionId: 'override-create-error',
+      },
+      content
+    );
     return;
   }
 
@@ -86,7 +98,21 @@ async function showCreateOverrideModal(
   });
   modal.addComponents(...inputFields);
 
-  await context.showModal(modal);
+  // The getPersonaOverride fetch above already ate into the 3-second budget, and
+  // this modal can't ack-first — its customId needs the fetched personality UUID.
+  // Wrap showModal so a budget-blown 10062 degrades to a followUp instead of a
+  // silent "Interaction Failed".
+  await showModalWithTimeoutCatch(
+    context.interaction,
+    modal,
+    {
+      source: 'handleOverrideSet/showCreateOverrideModal',
+      userId: discordId,
+      entityId: personality.id,
+      sectionId: 'override-create',
+    },
+    '⏳ That took too long — please run `/persona override set` again.'
+  );
   logger.info(
     { userId: discordId, personalityId: personality.id },
     'Showed create-for-override modal'
@@ -100,22 +126,26 @@ async function setExistingOverride(
   personalitySlug: string,
   personaId: string
 ): Promise<void> {
+  // Ack first (3-second rule): deferReply before the setPersonaOverride gateway
+  // write, so a slow write can't blow the budget before the ack. Ephemeral — a
+  // private confirmation. Every response below is editReply.
+  await context.deferReply({ ephemeral: true });
+
   const { userClient } = clientsFor(context.interaction);
   const result = await userClient.setPersonaOverride(personalitySlug, { personaId });
 
   if (!result.ok) {
     const errorMsg = mapOverrideError(result.error, personalitySlug);
     if (errorMsg !== null) {
-      await context.reply({ content: errorMsg, flags: MessageFlags.Ephemeral });
+      await context.interaction.editReply({ content: errorMsg });
       return;
     }
     logger.warn(
       { userId: discordId, personalitySlug, personaId, error: result.error },
       'Failed to set override'
     );
-    await context.reply({
+    await context.interaction.editReply({
       content: '❌ Failed to set persona override. Please try again later.',
-      flags: MessageFlags.Ephemeral,
     });
     return;
   }
@@ -129,9 +159,8 @@ async function setExistingOverride(
     'Set override persona'
   );
 
-  await context.reply({
+  await context.interaction.editReply({
     content: `✅ **Persona override set for ${personalityName}!**\n\n📋 Using: **${displayName}**\n\nThis persona will be used when talking to ${personalityName} instead of your default persona.`,
-    flags: MessageFlags.Ephemeral,
   });
 }
 
@@ -160,10 +189,15 @@ export async function handleOverrideSet(context: ModalCommandContext): Promise<v
     }
   } catch (error) {
     logger.error({ err: error, userId: discordId }, 'Failed to set override');
-    await context.reply({
-      content: '❌ Failed to set persona override. Please try again later.',
-      flags: MessageFlags.Ephemeral,
-    });
+    const content = '❌ Failed to set persona override. Please try again later.';
+    // setExistingOverride defers before its gateway write, so an error from that
+    // branch arrives here already-acked → editReply. The showCreateOverrideModal
+    // branch only throws before its showModal ack → reply.
+    if (context.interaction.deferred || context.interaction.replied) {
+      await context.interaction.editReply({ content });
+    } else {
+      await context.reply({ content, flags: MessageFlags.Ephemeral });
+    }
   }
 }
 

--- a/services/bot-client/src/utils/dashboard/ackWithTimeoutCatch.ts
+++ b/services/bot-client/src/utils/dashboard/ackWithTimeoutCatch.ts
@@ -24,6 +24,7 @@ import {
   DiscordAPIError,
   MessageFlags,
   type ButtonInteraction,
+  type ChatInputCommandInteraction,
   type ModalSubmitInteraction,
   type StringSelectMenuInteraction,
 } from 'discord.js';
@@ -42,7 +43,11 @@ export interface InteractionAckDiagContext {
   sectionId: string;
 }
 
-type AckableInteraction = ButtonInteraction | StringSelectMenuInteraction | ModalSubmitInteraction;
+type AckableInteraction =
+  | ButtonInteraction
+  | StringSelectMenuInteraction
+  | ModalSubmitInteraction
+  | ChatInputCommandInteraction;
 
 export async function ackWithTimeoutCatch(
   interaction: AckableInteraction,

--- a/services/bot-client/src/utils/dashboard/showModalWithTimeoutCatch.ts
+++ b/services/bot-client/src/utils/dashboard/showModalWithTimeoutCatch.ts
@@ -16,12 +16,13 @@
 import {
   type ModalBuilder,
   type ButtonInteraction,
+  type ChatInputCommandInteraction,
   type StringSelectMenuInteraction,
 } from 'discord.js';
 import { ackWithTimeoutCatch, type InteractionAckDiagContext } from './ackWithTimeoutCatch.js';
 
 export async function showModalWithTimeoutCatch(
-  interaction: StringSelectMenuInteraction | ButtonInteraction,
+  interaction: StringSelectMenuInteraction | ButtonInteraction | ChatInputCommandInteraction,
   modal: ModalBuilder,
   diagContext: InteractionAckDiagContext,
   retryMessage: string


### PR DESCRIPTION
## What

**PR 1 of the ack-first sweep tail (C4)** — the `ModalCommandContext` handlers the ESLint rule can't see (it targets raw interaction params). Both `/persona override set` handlers did gateway work before their ack:

- **`setExistingOverride`** — `setPersonaOverride` (gateway write) ran before a bare `reply`, so a slow write could blow the 3-second budget. Now `deferReply` first (`context.deferReply` — `ModalCommandContext` exposes it), then `editReply` via the raw `context.interaction` (the context type omits `editReply`; only `ManualCommandContext` has it). `handleOverrideSet`'s catch is now ack-state-aware (`editReply` when deferred, else `reply`).
- **`showCreateOverrideModal`** — `getPersonaOverride` runs before `showModal`, which **can't** ack-first (the modal's customId needs the fetched personality UUID). Wrapped in `showModalWithTimeoutCatch` so a budget-blown 10062 degrades to a `followUp` instead of a silent "Interaction Failed".

## Helper broadening

`ackWithTimeoutCatch` / `showModalWithTimeoutCatch` broadened their interaction union to include `ChatInputCommandInteraction` — additive (the 10062/followUp logic is interaction-agnostic; `sectionId` is just a diagnostic string), so the slash-command override flow can reuse them instead of duplicating the pattern.

## Verification

- 22 persona tests + full bot-client suite (5164) green; `pnpm quality` green.
- Rule-blind by design (context param) — this is exactly the gap C7 will close by extending the rule to `ModalCommandContext`.

## Sweep status

With C4 (this) + C5/C6 (#1415, merged), the ack-first sweep tail is done except **C7** (union-param rule extension + the confirmed real `getSessionDataOrReply` bug) — the higher-priority follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)