### PR TITLE
feat: extend ack-first rule (union params, followUp-neutral) + remove dead getSessionDataOrReply (C7)

### DIFF
--- a/.claude/rules/04-discord.md
+++ b/.claude/rules/04-discord.md
@@ -8,6 +8,13 @@ never before. The 3-second budget is indivisible: a sub-millisecond Redis
 lookup today is a multi-second lookup under load, and the window doesn't
 distinguish between types of async work.
 
+**Enforced at lint time** by the `@tzurot/component-handler-ack-first` ESLint
+rule (`'error'`): a bare interaction ack (`deferUpdate`/`deferReply`/`reply`/
+`update`/`showModal`) must not follow awaited async work in a component/modal
+handler. Either ack first, or — when the data must be fetched before the ack
+(e.g. a modal prefilled from a row) — route the ack through a
+`*WithTimeoutCatch` wrapper so a blown budget degrades to a `followUp`.
+
 ### Slash commands: defer first, then process
 
 ```typescript

--- a/packages/tooling/src/eslint/component-handler-ack-first.test.ts
+++ b/packages/tooling/src/eslint/component-handler-ack-first.test.ts
@@ -309,3 +309,76 @@ describe('detection coverage — handleModal router key', () => {
     ).toHaveLength(1);
   });
 });
+
+describe('detection coverage — union params, optional chaining, post-ack responses', () => {
+  it('recognizes a union-typed handler param (ack-first path is valid)', () => {
+    // Shared button+select handler (e.g. shapes handleBrowsePage). The union
+    // param must be seen as a handler; the ack-first ordering here is valid.
+    expect(
+      lint(`async function handleBrowsePage(
+        interaction: ButtonInteraction | StringSelectMenuInteraction
+      ) {
+        await interaction.deferUpdate();
+        const list = await fetchShapesList();
+        await interaction.editReply(list);
+      }`)
+    ).toHaveLength(0);
+  });
+
+  it('flags a union-typed handler that acks after async', () => {
+    // The gap the union extension closes: a union param used to be silently
+    // skipped, so hoisting the fetch above the ack would go uncaught.
+    expect(
+      lint(`async function handleBrowsePage(
+        interaction: ButtonInteraction | StringSelectMenuInteraction
+      ) {
+        const list = await fetchShapesList();
+        await interaction.deferUpdate();
+      }`)
+    ).toHaveLength(1);
+  });
+
+  it('unwraps optional-chaining on the ack (interaction?.deferUpdate())', () => {
+    // A budget-safe ack-first handler using optional chaining must NOT be flagged
+    // (the ack parses as ChainExpression, which the visitor peels).
+    expect(
+      lint(`async function handleClick(interaction: ButtonInteraction) {
+        await interaction?.deferUpdate();
+        const session = await findSession(interaction.message.id);
+        await interaction.editReply(session);
+      }`)
+    ).toHaveLength(0);
+  });
+
+  it('does not flag the if(acked) followUp else reply ack-state helper shape', () => {
+    // followUp/editReply are post-ack responses, not fetches — the acked-branch
+    // response must NOT leak sawRealAsync onto the sibling else-branch reply.
+    expect(
+      lint(`async function replyError(
+        interaction: ButtonInteraction | StringSelectMenuInteraction
+      ) {
+        if (interaction.deferred || interaction.replied) {
+          await interaction.followUp({ content });
+        } else {
+          await interaction.reply({ content });
+        }
+      }`)
+    ).toHaveLength(0);
+  });
+
+  it('still flags a real fetch before the else-branch reply in that shape', () => {
+    // The followUp exemption must not blind the rule to a genuine fetch-before-ack.
+    expect(
+      lint(`async function replyError(
+        interaction: ButtonInteraction | StringSelectMenuInteraction
+      ) {
+        const data = await loadData(interaction.message.id);
+        if (interaction.replied) {
+          await interaction.followUp({ content: data });
+        } else {
+          await interaction.reply({ content: data });
+        }
+      }`)
+    ).toHaveLength(1);
+  });
+});

--- a/packages/tooling/src/eslint/component-handler-ack-first.ts
+++ b/packages/tooling/src/eslint/component-handler-ack-first.ts
@@ -64,6 +64,17 @@ import type { Node } from 'estree';
 const ACK_METHODS = new Set(['deferUpdate', 'deferReply', 'reply', 'update', 'showModal']);
 
 /**
+ * POST-ack response methods on the interaction. These run only AFTER an ack, so
+ * an `await interaction.followUp()` / `editReply()` is a response, NOT a data
+ * fetch — it must NOT count as "real async work" that would flag a following bare
+ * ack. Excluding them kills the branch-leak false positive from the standard
+ * ack-state-aware helper shape (`if (acked) followUp else reply`), where the
+ * acked-branch response would otherwise leak `sawRealAsync` onto the sibling
+ * else-branch `reply`.
+ */
+const RESPONSE_METHODS = new Set(['followUp', 'editReply', 'deleteReply']);
+
+/**
  * defineCommand keys whose value is a raw-interaction router entry. Includes
  * `handleModal` (ModalSubmitInteraction) — the canonical wrapper-ack case this
  * rule's docstring cites — so a `handleModal: async interaction => {…}` arrow
@@ -105,12 +116,36 @@ function firstParamName(fn: FunctionNode): string | null {
   return first?.type === 'Identifier' ? (first as Node & { name: string }).name : null;
 }
 
-/** True if the first param carries a type annotation matching an ack-requiring interaction. */
+/** The `typeName.name` of a TSTypeReference node, or null for any other shape. */
+function typeRefName(typeNode: unknown): string | null {
+  const name = (typeNode as { typeName?: { name?: string } } | undefined)?.typeName?.name;
+  return typeof name === 'string' ? name : null;
+}
+
+/**
+ * True if the first param carries a type annotation matching an ack-requiring
+ * interaction — directly (`interaction: ButtonInteraction`) or as a member of a
+ * union (`interaction: ButtonInteraction | StringSelectMenuInteraction`). A
+ * handler shared across ack-requiring interaction kinds still owns the ordering
+ * guarantee, so the union form must be recognized — its node is a `TSUnionType`
+ * (with `.types[]`, no `.typeName`), not a `TSTypeReference`.
+ */
 function firstParamIsAckInteraction(fn: FunctionNode): boolean {
   const first = fn.params[0] as
-    (Node & { typeAnnotation?: { typeAnnotation?: { typeName?: { name?: string } } } }) | undefined;
-  const typeName = first?.typeAnnotation?.typeAnnotation?.typeName?.name;
-  return typeof typeName === 'string' && ACK_REQUIRING_TYPE.test(typeName);
+    (Node & { typeAnnotation?: { typeAnnotation?: unknown } }) | undefined;
+  const typeNode = first?.typeAnnotation?.typeAnnotation as
+    { type?: string; types?: unknown[] } | undefined;
+  if (typeNode === undefined) {
+    return false;
+  }
+  if (typeNode.type === 'TSUnionType' && Array.isArray(typeNode.types)) {
+    return typeNode.types.some(member => {
+      const name = typeRefName(member);
+      return name !== null && ACK_REQUIRING_TYPE.test(name);
+    });
+  }
+  const name = typeRefName(typeNode);
+  return name !== null && ACK_REQUIRING_TYPE.test(name);
 }
 
 /** True if the function is the value of a `handleButton`/`handleSelectMenu` property. */
@@ -176,8 +211,18 @@ function argReferencesInteraction(arg: Node, interactionName: string): boolean {
   return false;
 }
 
-/** True if the awaited expression is a BARE ack call on the interaction (`interaction.deferUpdate()`). */
-function isBareAckCall(argument: Node | null | undefined, interactionName: string | null): boolean {
+/**
+ * True if the argument is a call of `interaction.<method>()` for a method in the
+ * given set. Fail CLOSED: only matches when interactionName is positively
+ * identified — a null name (destructured / unresolved param) never matches, so
+ * an arbitrary object's `.reply()` is not mistaken for THE interaction's ack.
+ * `passesInteractionToCallee` is fail-closed for the same reason.
+ */
+function isInteractionMethodCall(
+  argument: Node | null | undefined,
+  interactionName: string | null,
+  methods: ReadonlySet<string>
+): boolean {
   if (argument?.type !== 'CallExpression') {
     return false;
   }
@@ -188,17 +233,29 @@ function isBareAckCall(argument: Node | null | undefined, interactionName: strin
   const member = callee as Node & { object: Node; property: Node & { name?: string } };
   const objectName =
     member.object.type === 'Identifier' ? (member.object as Node & { name: string }).name : null;
-  // Fail CLOSED: only count this as an ack when we positively identified the
-  // interaction param. If interactionName is null (a destructured / zero-param
-  // handler we can't resolve), don't treat an arbitrary object's `.reply()` as
-  // THE ack — that would mask a real violation. `passesInteractionToCallee` is
-  // fail-closed for the same reason.
   return (
     interactionName !== null &&
     objectName === interactionName &&
     member.property.type === 'Identifier' &&
-    ACK_METHODS.has(member.property.name ?? '')
+    methods.has(member.property.name ?? '')
   );
+}
+
+/** True if the awaited expression is a BARE ack call on the interaction (`interaction.deferUpdate()`). */
+function isBareAckCall(argument: Node | null | undefined, interactionName: string | null): boolean {
+  return isInteractionMethodCall(argument, interactionName, ACK_METHODS);
+}
+
+/**
+ * True if the awaited expression is a POST-ack response on the interaction
+ * (`interaction.followUp()` / `editReply()` / `deleteReply()`) — a response, not
+ * a fetch. The visitor treats it as neutral (see RESPONSE_METHODS).
+ */
+function isPostAckResponseCall(
+  argument: Node | null | undefined,
+  interactionName: string | null
+): boolean {
+  return isInteractionMethodCall(argument, interactionName, RESPONSE_METHODS);
 }
 
 const rule: Rule.RuleModule = {
@@ -248,13 +305,27 @@ const rule: Rule.RuleModule = {
         if (!frame?.isHandler) {
           return;
         }
-        const argument = (node as Node & { argument?: Node }).argument;
+        // Unwrap optional-chaining: `interaction?.deferUpdate()` parses as
+        // AwaitExpression → ChainExpression → CallExpression, so peel the
+        // ChainExpression to inspect the underlying call (else it falls through
+        // to real-async and both mis-classifies the ack and over-flags).
+        const raw = (node as Node & { argument?: Node }).argument;
+        const argument =
+          raw?.type === 'ChainExpression' ? (raw as Node & { expression: Node }).expression : raw;
 
         // A bare ack AFTER real async work is the bug.
         if (isBareAckCall(argument, frame.interactionName)) {
           if (frame.sawRealAsync) {
             context.report({ node, messageId: 'ackAfterAsync' });
           }
+          return;
+        }
+
+        // A post-ack response (followUp/editReply/deleteReply) is a response, not
+        // a fetch — neither a bare ack nor real async work, so skip it. This is
+        // what keeps the `if (acked) followUp else reply` helper shape from
+        // leaking sawRealAsync onto the sibling else-branch's bare reply.
+        if (isPostAckResponseCall(argument, frame.interactionName)) {
           return;
         }
 

--- a/services/bot-client/src/utils/dashboard/index.ts
+++ b/services/bot-client/src/utils/dashboard/index.ts
@@ -91,7 +91,6 @@ export {
   fetchOrCreateSession,
   requireDeferredSession,
   getSessionOrExpired,
-  getSessionDataOrReply,
   getSessionDataOrFollowUp,
 } from './sessionHelpers.js';
 

--- a/services/bot-client/src/utils/dashboard/sessionHelpers.test.ts
+++ b/services/bot-client/src/utils/dashboard/sessionHelpers.test.ts
@@ -9,7 +9,6 @@ import {
   fetchOrCreateSession,
   requireDeferredSession,
   getSessionOrExpired,
-  getSessionDataOrReply,
   getSessionDataOrFollowUp,
 } from './sessionHelpers.js';
 import * as SessionManagerModule from './SessionManager.js';
@@ -216,44 +215,9 @@ describe('sessionHelpers', () => {
     });
   });
 
-  describe('getSessionDataOrReply', () => {
-    it('should return session data when it exists', async () => {
-      const sessionData = { name: 'Test' };
-      mockSessionManager.get.mockResolvedValue({ data: sessionData });
-      const interaction = {
-        user: { id: 'user-123' },
-        reply: vi.fn(),
-      } as unknown as ButtonInteraction;
-
-      const result = await getSessionDataOrReply(interaction, 'preset', 'preset-123');
-
-      expect(result).toEqual(sessionData);
-      expect(interaction.reply).not.toHaveBeenCalled();
-    });
-
-    it('should reply with error and return null when session is missing', async () => {
-      mockSessionManager.get.mockResolvedValue(null);
-      const interaction = {
-        user: { id: 'user-123' },
-        reply: vi.fn(),
-      } as unknown as ButtonInteraction;
-
-      const result = await getSessionDataOrReply(interaction, 'preset', 'preset-123');
-
-      expect(result).toBeNull();
-      expect(interaction.reply).toHaveBeenCalledWith({
-        content: '⏰ Session expired. Please run the command again.',
-        flags: MessageFlags.Ephemeral,
-      });
-    });
-  });
-
   describe('getSessionDataOrFollowUp', () => {
-    // Sibling of getSessionDataOrReply for already-deferred interactions.
-    // Mirrors the test pair above: the two helpers must behave identically
-    // on the happy path and only differ on the expired branch (reply vs
-    // followUp). Any drift between them would produce silent runtime errors
-    // (InteractionAlreadyReplied on the wrong call shape).
+    // For already-deferred interactions: the expired branch uses followUp
+    // (reply would throw on an acked interaction).
     it('should return session data when it exists', async () => {
       const sessionData = { name: 'Test' };
       mockSessionManager.get.mockResolvedValue({ data: sessionData });

--- a/services/bot-client/src/utils/dashboard/sessionHelpers.ts
+++ b/services/bot-client/src/utils/dashboard/sessionHelpers.ts
@@ -183,50 +183,14 @@ export async function getSessionOrExpired<T>(
 }
 
 /**
- * Get session data or reply with error.
- * Simpler version that just needs the data, not full session.
- * Uses interaction.reply() for non-deferred interactions.
+ * Get session data, or follow up with an expired-session error.
  *
- * For handlers that have already called `deferUpdate` / `deferReply` (and
- * therefore can't `reply` again without Discord throwing), use
- * {@link getSessionDataOrFollowUp} instead.
- *
- * @returns Session data or null if expired
- */
-export async function getSessionDataOrReply<T>(
-  interaction: ButtonInteraction | StringSelectMenuInteraction,
-  entityType: string,
-  entityId: string
-): Promise<T | null> {
-  const sessionManager = getSessionManager();
-  const session = await sessionManager.get<T>(interaction.user.id, entityType, entityId);
-
-  if (session === null) {
-    await interaction.reply({
-      content: DASHBOARD_MESSAGES.SESSION_EXPIRED,
-      flags: MessageFlags.Ephemeral,
-    });
-    return null;
-  }
-
-  return session.data;
-}
-
-/**
- * Get session data or follow up with error, for already-deferred interactions.
- *
- * Mirror of {@link getSessionDataOrReply} for handlers that called
- * `interaction.deferUpdate()` (or `deferReply()`) before the session lookup.
- * Uses `interaction.followUp` for the expired branch because `reply` would
- * throw on an already-acked interaction.
- *
- * **When to use this over `getSessionDataOrReply`**: when Discord's 3-second
- * interaction budget matters and you've deferred eagerly to protect it. The
- * Redis session lookup is sub-ms on the hot path but can spike under load,
- * and the old "reply or fail" pattern gave us no defer-first option because
- * the fallback branch would race the ack. See
- * `.claude/rules/04-discord.md` § "defer first, then process" for the
- * broader rule.
+ * For handlers that acked first (`interaction.deferUpdate()` / `deferReply()`)
+ * before the session lookup — the defer-first pattern the 3-second rule wants.
+ * Uses `interaction.followUp` for the expired branch because `reply` would throw
+ * on an already-acked interaction. The Redis session lookup is sub-ms on the hot
+ * path but can spike under load, so acking before it protects the budget. See
+ * `.claude/rules/04-discord.md` § "defer first, then process".
  *
  * @returns Session data or null if expired
  */


### PR DESCRIPTION
## What

**C7 — the final piece of the ack-first sweep.** Extends `component-handler-ack-first` to cover the rule-blind cases, and resolves the one real bug the extension surfaces.

### Rule extensions
- **Union-typed params** — `firstParamIsAckInteraction` now handles `TSUnionType`, so a handler shared across ack-requiring kinds (`ButtonInteraction | StringSelectMenuInteraction`, e.g. shapes `handleBrowsePage`) is covered instead of silently skipped.
- **Optional chaining** — the visitor peels a `ChainExpression`, so `interaction?.deferUpdate()` is classified correctly (was mis-read as real async, PR #1409 round-3 finding).
- **Post-ack responses neutral** — `followUp`/`editReply`/`deleteReply` no longer count as "real async." They're responses, not fetches. This kills the branch-leak FP from the standard `if (acked) followUp else reply` ack-state helper shape (the acked-branch response was leaking `sawRealAsync` onto the sibling else-branch `reply`). **So the 5 sites the union extension surfaced needed 0 suppressions** — 4 were this FP class, cleanly resolved.

### The one real site
`getSessionDataOrReply` — the union extension flagged it (Redis `get()` → bare `reply()` on a non-deferred interaction). It turned out to be **dead** (zero callers, only a barrel re-export) *and* the discouraged reply-after-fetch pattern the ratchet exists to prevent. **Deleted** rather than fix dead code — handlers should `deferUpdate`-first + use the sibling `getSessionDataOrFollowUp`. (Barrel export + tests + the sibling's docstring cleaned up.)

### Doc
`04-discord.md`'s 3-Second Rule section now links to the enforcing lint rule (PR #1409 round-3 finding).

## Verification
- 30 rule unit tests (union ×2, optional-chaining, followUp-neutral ×2 incl. a "still catches a real fetch" guard, handleModal); zero rule violations across bot-client; `pnpm quality` + 5165 bot-client + 1168 tooling tests green.

## Deferred
The **context-param** (`ModalCommandContext`) rule guard — zero current violations (verified in the 10062-sweep audit), and a meaningfully bigger extension. Kept as a lower-priority follow-up rather than bloating C7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)