### PR TITLE
refactor: drop isDefault/isFreeDefault from the llm-config detail shape (S4a)

### DIFF
--- a/packages/common-types/src/schemas/api/llm-config.test.ts
+++ b/packages/common-types/src/schemas/api/llm-config.test.ts
@@ -130,8 +130,6 @@ describe('LLM Config API Contract Tests', () => {
       model: 'openai/gpt-4o-mini',
       kind: 'text',
       isGlobal: true,
-      isDefault: false,
-      isFreeDefault: false,
       isOwned: false,
       permissions: { canEdit: false, canDelete: false },
       contextWindowTokens: 8000,
@@ -140,6 +138,19 @@ describe('LLM Config API Contract Tests', () => {
 
     it('validates a full detail config', () => {
       expect(LlmConfigDetailSchema.safeParse(validDetail).success).toBe(true);
+    });
+
+    it('omits isDefault/isFreeDefault from the detail shape (pointer-relationship, not entity attr)', () => {
+      // Default-ness lives on the AdminSettings pointers (carried on the LIST
+      // summary for badges), never on the canonical detail. Pins the omit so a
+      // future accidental re-add is caught. See S4a.
+      const parsed = LlmConfigDetailSchema.parse({
+        ...validDetail,
+        isDefault: true,
+        isFreeDefault: true,
+      });
+      expect('isDefault' in parsed).toBe(false);
+      expect('isFreeDefault' in parsed).toBe(false);
     });
 
     it('allows optional modelContextLength / contextWindowCap', () => {

--- a/packages/common-types/src/schemas/api/llm-config.ts
+++ b/packages/common-types/src/schemas/api/llm-config.ts
@@ -278,6 +278,14 @@ export const LlmConfigDetailSchema = LlmConfigSummarySchema.omit({
   // the detail/dashboard path doesn't carry it yet (add when the dashboard
   // wants a vision badge). Omitted so detail handlers needn't compute it.
   supportsVision: true,
+  // `isDefault`/`isFreeDefault` are pointer-relationship flags (which config the
+  // AdminSettings global/free pointers target), NOT properties of the config
+  // entity. The list summary carries them (derived from the pointers) for the
+  // ⭐/🆓 browse badges; the canonical detail representation intentionally does
+  // not — nothing reads them off the detail, and deriving them would cost a
+  // pointer fetch per detail GET. See S4a.
+  isDefault: true,
+  isFreeDefault: true,
 }).extend({
   contextWindowTokens: z.number().int(),
   modelContextLength: z.number().int().optional(),

--- a/packages/test-factories/src/factories.test.ts
+++ b/packages/test-factories/src/factories.test.ts
@@ -285,7 +285,6 @@ describe('llm-config factories', () => {
 
       expect(response.config).toMatchObject({
         isGlobal: false,
-        isDefault: false,
         isOwned: true,
         permissions: { canEdit: true, canDelete: true },
       });

--- a/packages/test-factories/src/llm-config.ts
+++ b/packages/test-factories/src/llm-config.ts
@@ -158,7 +158,6 @@ export function mockCreateLlmConfigResponse(
   const response: CreateLlmConfigResponse = {
     config: mockLlmConfigDetail({
       isGlobal: false,
-      isDefault: false,
       isOwned: true,
       permissions: { canEdit: true, canDelete: true }, // User owns their created config
       ...overrides,

--- a/services/api-gateway/src/services/LlmConfigService.component.test.ts
+++ b/services/api-gateway/src/services/LlmConfigService.component.test.ts
@@ -662,8 +662,7 @@ describe('LlmConfigService Integration', () => {
         provider: 'openrouter',
         kind: 'text',
         isGlobal: true,
-        isDefault: false,
-        isFreeDefault: false,
+        // isDefault/isFreeDefault intentionally absent from the detail — see S4a.
         memoryScoreThreshold: 0.8,
         memoryLimit: 100,
         contextWindowTokens: 128000,

--- a/services/api-gateway/src/services/LlmConfigService.test.ts
+++ b/services/api-gateway/src/services/LlmConfigService.test.ts
@@ -893,8 +893,9 @@ describe('LlmConfigService', () => {
         provider: 'openrouter',
         kind: 'text',
         isGlobal: true,
-        isDefault: false,
-        isFreeDefault: false,
+        // isDefault/isFreeDefault are intentionally NOT on the detail response —
+        // default-ness is an AdminSettings pointer relationship, carried on the
+        // list summary (for badges), not the canonical config detail. See S4a.
         memoryScoreThreshold: 0.75,
         memoryLimit: 20,
         contextWindowTokens: 131072,

--- a/services/api-gateway/src/services/LlmConfigService.ts
+++ b/services/api-gateway/src/services/LlmConfigService.ts
@@ -117,8 +117,6 @@ interface FormattedConfigDetail {
   model: string;
   kind: ConfigKind;
   isGlobal: boolean;
-  isDefault: boolean;
-  isFreeDefault: boolean;
   memoryScoreThreshold: number;
   memoryLimit: number;
   contextWindowTokens: number;
@@ -650,8 +648,9 @@ export class LlmConfigService {
       model: raw.model,
       kind: toConfigKind(raw.kind),
       isGlobal: raw.isGlobal,
-      isDefault: raw.isDefault,
-      isFreeDefault: raw.isFreeDefault,
+      // isDefault/isFreeDefault are NOT on the detail response: defaults live on
+      // the AdminSettings pointers (S3), and no client reads them off the detail
+      // — the ⭐/🆓 badges derive from the pointer-based flags on the LIST summary.
       memoryScoreThreshold: raw.memoryScoreThreshold.toNumber(),
       memoryLimit: raw.memoryLimit,
       contextWindowTokens: raw.contextWindowTokens,


### PR DESCRIPTION
## What

**S4a (detail-cleanup slice).** Removes `isDefault`/`isFreeDefault` from the llm-config **detail** representation.

## Why

After S3, "is this the default?" is a property of the **AdminSettings pointer relationship** (which config the global/free pointers target), not an attribute of the config *entity*. So:
- The **list summary** carries the flags — derived from the pointers, for the ⭐/🆓 browse badges (a legitimate display-projection concern). *Unchanged.*
- The **canonical detail** representation intentionally does **not** — nothing reads them off the detail (verified: every `.isDefault` reader is the list/summary; `toPresetData`, the sole `LlmConfigDetail` consumer, doesn't touch them), and deriving them accurately would cost an AdminSettings pointer fetch per detail GET.

The list-keeps / detail-drops split is principled, not inconsistent: the list is a display projection; the detail is the entity.

## Changes
- `formatConfigDetail` + `FormattedConfigDetail` type: drop the two fields
- `LlmConfigDetailSchema`: omit them (summary schema keeps them)
- test-factory + 2 stale assertions updated

## Scope note
This eliminates the **first** raw-column reader toward the eventual `isDefault`/`isFreeDefault` `DROP COLUMN`. The rest of the column-drop enablement — the SELECTs, the `create` write, the sync util, and the `RawConfigList` type reconciliation — is a **separate column-drop-prep PR** (both ship this release; the destructive `DROP` rides the *next* release, expand-contract). `ModelOverrideSummary.supportsVision` folds into S4b, where its consumer lives.

## Verification
`pnpm quality` green (typecheck + `codegen:routes --check`); api-gateway (2247) + bot-client (5165) + test-factories (41) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)