### PR TITLE
feat(api-gateway): enrich ModelOverrideSummary with supportsVision (S4b-gateway)

### DIFF
--- a/packages/common-types/src/schemas/api/model-override.test.ts
+++ b/packages/common-types/src/schemas/api/model-override.test.ts
@@ -25,6 +25,7 @@ function createValidOverrideSummary(overrides = {}) {
     configId: '550e8400-e29b-41d4-a716-446655440001',
     configName: 'Claude Sonnet',
     kind: 'text',
+    supportsVision: false,
     ...overrides,
   };
 }

--- a/packages/common-types/src/schemas/api/model-override.ts
+++ b/packages/common-types/src/schemas/api/model-override.ts
@@ -30,6 +30,14 @@ export const ModelOverrideSummarySchema = z.object({
    * one row per kind, so browse can badge + carry the kind through clear.
    */
   kind: z.enum(CONFIG_KINDS).nullable(),
+  /**
+   * Whether the override's config MODEL supports vision — sourced live from the
+   * model's capabilities (OpenRouter-authoritative → z.ai catalog), NOT from
+   * `kind`. This is the capability-driven signal the override-browse 👁 badge
+   * uses (mirrors `LlmConfigSummary.supportsVision`). `false` when capability is
+   * unknown (fail-closed). Populated by the override-list route, not the schema.
+   */
+  supportsVision: z.boolean(),
 });
 export type ModelOverrideSummary = z.infer<typeof ModelOverrideSummarySchema>;
 

--- a/packages/test-factories/src/model-override.ts
+++ b/packages/test-factories/src/model-override.ts
@@ -39,6 +39,7 @@ function createBaseModelOverrideSummary(
     configId: DEFAULT_CONFIG_ID,
     configName: 'TestConfig',
     kind: 'text',
+    supportsVision: false,
   };
   return deepMerge(base, overrides);
 }

--- a/services/api-gateway/src/routes/user/model-override.test.ts
+++ b/services/api-gateway/src/routes/user/model-override.test.ts
@@ -198,8 +198,43 @@ describe('/user/model-override routes', () => {
               configId: '22222222-2222-4222-a222-222222222222',
               configName: 'GPT-4 Config',
               kind: 'text',
+              supportsVision: false,
             },
           ],
+        })
+      );
+    });
+
+    it('enriches supportsVision: true when the list override model is vision-capable', async () => {
+      mockPrisma.userPersonalityConfig.findMany.mockResolvedValue([
+        {
+          personalityId: '11111111-1111-4111-a111-111111111111',
+          personality: { name: 'Lilith' },
+          llmConfigId: '22222222-2222-4222-a222-222222222222',
+          llmConfig: { name: 'GPT-4o', model: 'openai/gpt-4o' },
+        },
+      ]);
+
+      const modelCache = {
+        getModelById: vi.fn(async (id: string) =>
+          id === 'openai/gpt-4o' ? { supportsVision: true } : null
+        ),
+      } as unknown as import('../../services/OpenRouterModelCache.js').OpenRouterModelCache;
+
+      const router = createModelOverrideRoutes({
+        prisma: mockPrisma as unknown as PrismaClient,
+        modelCache,
+      });
+      const handler = getHandler(router, 'get', '/');
+      const { req, res } = createMockReqRes();
+
+      await handler(req, res);
+
+      // Proves the per-row model (from the list select) flows into the capability
+      // lookup — a supportsVision hardcoded to false, or a dropped select, fails here.
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          overrides: [expect.objectContaining({ configName: 'GPT-4o', supportsVision: true })],
         })
       );
     });
@@ -365,6 +400,7 @@ describe('/user/model-override routes', () => {
             configId: '22222222-2222-4222-a222-222222222222',
             configName: 'GPT-4',
             kind: 'text',
+            supportsVision: false,
           },
         })
       );
@@ -384,7 +420,7 @@ describe('/user/model-override routes', () => {
         personalityId: '11111111-1111-4111-a111-111111111111',
         personality: { name: 'Lilith' },
         visionConfigId: '22222222-2222-4222-a222-222222222222',
-        visionConfig: { name: 'GPT-4o' },
+        visionConfig: { name: 'GPT-4o', model: 'openai/gpt-4o' },
       });
 
       const modelCache = {
@@ -419,9 +455,12 @@ describe('/user/model-override routes', () => {
         })
       );
       expect(res.status).toHaveBeenCalledWith(200);
+      // supportsVision: true proves the enrichment reads the vision slot's model
+      // (openai/gpt-4o) capability via modelCache — not the kind label — and that
+      // the isVision→visionConfig.model branch is wired correctly.
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
-          override: expect.objectContaining({ kind: 'vision' }),
+          override: expect.objectContaining({ kind: 'vision', supportsVision: true }),
         })
       );
     });
@@ -1201,6 +1240,7 @@ describe('/user/model-override routes', () => {
               configId: 'text-cfg',
               configName: 'Text Cfg',
               kind: 'text',
+              supportsVision: false,
             },
             {
               personalityId: PERSONALITY,
@@ -1208,6 +1248,7 @@ describe('/user/model-override routes', () => {
               configId: VISION_CFG,
               configName: 'Vision Cfg',
               kind: 'vision',
+              supportsVision: false,
             },
           ],
         })

--- a/services/api-gateway/src/routes/user/model-override.ts
+++ b/services/api-gateway/src/routes/user/model-override.ts
@@ -30,6 +30,7 @@ import {
   parseConfigKindQueryAllowAll,
 } from '../../utils/configRouteHelpers.js';
 import { ensureVisionCapableModel } from '../../utils/llmConfigValidation.js';
+import { ModelCapabilityService } from '../../services/ModelCapabilityService.js';
 import { tryInvalidateCache } from '../../utils/configOverrideHelpers.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';
 import { sendError, sendCustomSuccess } from '../../utils/responseHelpers.js';
@@ -64,7 +65,8 @@ async function verifyConfigAccess(
 
 /** GET /api/user/model-override — list all user model overrides */
 export const handleListModelOverrides = (deps: RouteDeps): RequestHandler => {
-  const { prisma } = deps;
+  const { prisma, modelCache } = deps;
+  const capabilities = new ModelCapabilityService(modelCache);
   return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
     const discordUserId = req.userId;
     const userId = resolveProvisionedUserId(req);
@@ -93,9 +95,10 @@ export const handleListModelOverrides = (deps: RouteDeps): RequestHandler => {
         personalityId: true,
         personality: { select: { name: true } },
         llmConfigId: true,
-        llmConfig: { select: { name: true } },
+        // `model` feeds the capability-driven supportsVision badge (below).
+        llmConfig: { select: { name: true, model: true } },
         visionConfigId: true,
-        visionConfig: { select: { name: true } },
+        visionConfig: { select: { name: true, model: true } },
       },
       // Bounds personality CONFIG rows, not output rows: for `kind=all` a
       // personality with both FKs expands to two summaries below, so the
@@ -116,6 +119,7 @@ export const handleListModelOverrides = (deps: RouteDeps): RequestHandler => {
           configId: o.llmConfigId,
           configName: o.llmConfig?.name ?? null,
           kind: 'text',
+          supportsVision: await capabilities.supportsVision(o.llmConfig?.model ?? ''),
         });
       }
       if (emitVision && o.visionConfigId !== null) {
@@ -125,6 +129,7 @@ export const handleListModelOverrides = (deps: RouteDeps): RequestHandler => {
           configId: o.visionConfigId,
           configName: o.visionConfig?.name ?? null,
           kind: 'vision',
+          supportsVision: await capabilities.supportsVision(o.visionConfig?.model ?? ''),
         });
       }
     }
@@ -137,6 +142,7 @@ export const handleListModelOverrides = (deps: RouteDeps): RequestHandler => {
 /** PUT /api/user/model-override — set model override for a personality */
 export const handleSetModelOverride = (deps: RouteDeps): RequestHandler => {
   const { prisma, modelCache } = deps;
+  const capabilities = new ModelCapabilityService(modelCache);
   return asyncHandler(async (req: ProvisionedRequest, res: Response) => {
     const discordUserId = req.userId;
 
@@ -199,9 +205,10 @@ export const handleSetModelOverride = (deps: RouteDeps): RequestHandler => {
         personalityId: true,
         personality: { select: { name: true } },
         llmConfigId: true,
-        llmConfig: { select: { name: true } },
+        // `model` feeds the capability-driven supportsVision badge (below).
+        llmConfig: { select: { name: true, model: true } },
         visionConfigId: true,
-        visionConfig: { select: { name: true } },
+        visionConfig: { select: { name: true, model: true } },
       },
     });
 
@@ -213,6 +220,12 @@ export const handleSetModelOverride = (deps: RouteDeps): RequestHandler => {
         ? (override.visionConfig?.name ?? null)
         : (override.llmConfig?.name ?? null),
       kind: isVision ? 'vision' : 'text',
+      // Re-resolves the vision slot's capability that ensureVisionCapableModel
+      // already checked on the write-gate — harmless while resolution is a warm
+      // in-memory cache hit; revisit if it ever grows a network round-trip.
+      supportsVision: await capabilities.supportsVision(
+        (isVision ? override.visionConfig?.model : override.llmConfig?.model) ?? ''
+      ),
     };
 
     logger.info(


### PR DESCRIPTION
## What

**S4b-gateway slice.** Adds a capability-driven `supportsVision` to `ModelOverrideSummary`, sourced live from the override's config **model** via `ModelCapabilityService` (OpenRouter-authoritative → z.ai catalog, fail-closed) — **not** from `kind`. Mirrors `LlmConfigSummary.supportsVision` (S1).

## Why

Feeds S4b's override-browse **👁 badge**, which reads *capability* rather than the `kind` label — the capability-driven UX Phase 3 is built around.

## How
- The override route **already receives `modelCache`** (used by `ensureVisionCapableModel`), so no new plumbing — the LIST + SET handlers instantiate `ModelCapabilityService` and `await capabilities.supportsVision(model)` per emitted summary.
- The config selects gain `model` (were `{ name }` only).
- `false` when capability is unknown (fail-closed) or the router has no `modelCache`.

## Split rationale
Self-contained **gateway dependency** for S4b-bot-client (the badge consumer). Landing it first unblocks the bot-client UX slice.

## Verification
`pnpm quality` green (typecheck + `codegen:routes --check`); api-gateway model-override route suite (45) + common-types + test-factories + bot-client (5165) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)