### PR TITLE
feat(bot-client): override-browse 👁 badge reads supportsVision, not kind (S4b)

### DIFF
--- a/services/bot-client/src/commands/settings/preset/browse.test.ts
+++ b/services/bot-client/src/commands/settings/preset/browse.test.ts
@@ -42,6 +42,7 @@ type OverrideRow = {
   personalityName: string;
   configName: string | null;
   kind?: 'text' | 'vision';
+  supportsVision?: boolean;
 };
 
 /**
@@ -71,7 +72,13 @@ describe('handlePresetBrowse', () => {
   it('lists overrides of both kinds and renders them (vision badged)', async () => {
     mockAllOverrides([
       { personalityId: 'p1', personalityName: 'Lilith', configName: 'Fast', kind: 'text' },
-      { personalityId: 'p2', personalityName: 'Aria', configName: 'GPT-4o', kind: 'vision' },
+      {
+        personalityId: 'p2',
+        personalityName: 'Aria',
+        configName: 'GPT-4o',
+        kind: 'vision',
+        supportsVision: true,
+      },
     ]);
     const editReply = vi.fn();
     const context = {

--- a/services/bot-client/src/utils/overrideBrowse.test.ts
+++ b/services/bot-client/src/utils/overrideBrowse.test.ts
@@ -54,9 +54,10 @@ function override(
   id: string,
   name: string,
   configName: string | null = 'Cfg',
-  kind?: ConfigKind
+  kind?: ConfigKind,
+  supportsVision?: boolean
 ): OverrideSummary {
-  return { personalityId: id, personalityName: name, configName, kind };
+  return { personalityId: id, personalityName: name, configName, kind, supportsVision };
 }
 
 beforeEach(() => {
@@ -142,14 +143,14 @@ describe('buildOverrideBrowseView', () => {
     expect(menu.options[0].label).toContain('Lilith');
   });
 
-  it('badges vision overrides and encodes kind in the select value', () => {
+  it('badges by model capability (supportsVision) and encodes kind in the select value', () => {
     const overrides = [
-      override('p1', 'Lilith', 'Text Cfg', 'text'),
-      override('p1', 'Lilith', 'Vision Cfg', 'vision'),
+      override('p1', 'Lilith', 'Text Cfg', 'text', false),
+      override('p1', 'Lilith', 'Vision Cfg', 'vision', true),
     ];
     const { embeds, components } = buildOverrideBrowseView(makeConfig(), overrides);
 
-    // The vision line carries the 👁️ badge; the text line does not.
+    // The vision-capable row carries the 👁️ badge; the non-vision row does not.
     const description = embeds[0].toJSON().description ?? '';
     expect(description).toContain('👁️');
 
@@ -160,6 +161,19 @@ describe('buildOverrideBrowseView', () => {
     // Same personality, two kinds → kind-encoded values disambiguate them.
     expect(menu.options.map(o => o.value)).toEqual(['p1::text', 'p1::vision']);
     expect(menu.options[1].label).toContain('👁️');
+    expect(menu.options[0].label).not.toContain('👁️');
+  });
+
+  it('badges from capability, not slot: a chat-slot override on a vision-capable model gets 👁️', () => {
+    // The badge reflects the MODEL's capability, not which slot the override
+    // occupies — a chat-slot (kind:text) override whose model supports vision is
+    // still badged. This is the whole point of the capability-driven switch.
+    const overrides = [override('p1', 'Lilith', 'Vision-capable chat model', 'text', true)];
+    const { embeds, components } = buildOverrideBrowseView(makeConfig(), overrides);
+
+    expect(embeds[0].toJSON().description ?? '').toContain('👁️');
+    const row = components[0].toJSON() as { components: { options: { label: string }[] }[] };
+    expect(row.components[0].options[0].label).toContain('👁️');
   });
 
   it('renders Unknown for a null config name', () => {

--- a/services/bot-client/src/utils/overrideBrowse.ts
+++ b/services/bot-client/src/utils/overrideBrowse.ts
@@ -64,12 +64,19 @@ export interface OverrideSummary {
   configName: string | null;
   /**
    * Config kind of this override (text | vision). Optional: domains without a
-   * kind axis (e.g. TTS overrides) omit it and the browser behaves exactly as
-   * before. When present, vision rows are badged and the kind is carried through
-   * select → clear so the right FK is cleared (a character can have BOTH a text
-   * and a vision override — so `(personalityId, kind)` is the unique key).
+   * kind axis (e.g. TTS overrides) omit it. It is the ROUTING identity carried
+   * through select → clear so the right FK is cleared (a character can have BOTH
+   * a text and a vision override — so `(personalityId, kind)` is the unique key).
+   * The 👁 badge is NOT derived from this — it reads `supportsVision`, so the
+   * badge reflects the model's actual capability, not the slot label.
    */
   kind?: ConfigKind;
+  /**
+   * Whether the override's config MODEL supports vision — capability-driven, from
+   * the gateway's `ModelOverrideSummary.supportsVision`. Drives the 👁 badge.
+   * Optional: domains without a capability axis (TTS) omit it → no badge.
+   */
+  supportsVision?: boolean;
 }
 
 /**
@@ -190,7 +197,7 @@ export function buildOverrideBrowseView(
   }
 
   const lines = overrides.map(o => {
-    const visionBadge = o.kind === 'vision' ? '👁️ ' : '';
+    const visionBadge = o.supportsVision === true ? '👁️ ' : '';
     return `${visionBadge}**${escapeMarkdown(o.personalityName)}** → ${escapeMarkdown(o.configName ?? 'Unknown')}`;
   });
   embed.setDescription(lines.join('\n'));
@@ -212,10 +219,11 @@ export function buildOverrideBrowseView(
     placeholder: config.selectPlaceholder,
     startIndex: 0,
     formatItem: o => ({
-      // kind-aware domains badge vision + encode kind in the value so
-      // `(personalityId, kind)` stays the unique key (a character can have both
-      // a text and a vision override); kind-less domains keep the bare id.
-      label: o.kind === 'vision' ? `👁️ ${o.personalityName}` : o.personalityName,
+      // The 👁 badge reads model capability (`supportsVision`); the value encodes
+      // `kind` so `(personalityId, kind)` stays the unique clear-key (a character
+      // can have both a text and a vision override). kind-less domains (TTS) get
+      // no badge and keep the bare id.
+      label: o.supportsVision === true ? `👁️ ${o.personalityName}` : o.personalityName,
       value:
         o.kind === undefined
           ? o.personalityId


### PR DESCRIPTION
## What

The per-character override browser (`/settings preset browse`, `/voice tts browse`) was the **last renderer** deriving the 👁 vision badge from the override's **slot** (`kind === 'vision'`) rather than the model's actual **capability**. Now that the gateway carries `ModelOverrideSummary.supportsVision` (#1419), the badge reads it.

## Why

Capability ≠ slot. A **chat-slot** override on a vision-capable model should show 👁 (the model *can* see); a vision-slot label shouldn't be the badge source. This completes the capability-driven UX the rest of Phase 3 was built around — the override browser now matches how `preset browse` / autocomplete already badge.

## The one nuance

`kind` in `overrideBrowse.ts` is **dual-purpose**: the 👁 badge *and* the `(personalityId, kind)` routing identity carried through select → clear (a character can have both a text and a vision override, so the clear path needs the slot). This PR moves **only the badge** to `supportsVision`; `kind` stays as the routing key. `supportsVision` is optional on `OverrideSummary` so kind-less domains (TTS) omit it → no badge, unchanged.

## Scope note

This is the **only** remaining S4b-bot-client work — the plan's other items (slot vocabulary, the setter slot-send fix, capability-filtered pickers) already shipped in earlier PRs (`ec0704b30`, `dff503f76` "S4b-2b", etc.). **No slash-option changes → no manifest/snapshot regen.**

## Tests
- overrideBrowse badge test now drives off `supportsVision`; **added** a decoupling test (chat-slot + vision-capable model → 👁, proving badge ≠ slot).
- Full bot-client suite (5166) + `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)