### PR TITLE
refactor(api-gateway): stop selecting/writing the dead isDefault/isFreeDefault columns

### DIFF
--- a/packages/common-types/src/schemas/api/llm-config.ts
+++ b/packages/common-types/src/schemas/api/llm-config.ts
@@ -180,8 +180,10 @@ export const LLM_CONFIG_LIST_SELECT = {
   // badge/filter by kind without a per-kind round-trip.
   kind: true,
   isGlobal: true,
-  isDefault: true,
-  isFreeDefault: true,
+  // isDefault/isFreeDefault are NOT selected: default-ness is an AdminSettings
+  // pointer relationship (S3), and LlmConfigService.list derives the summary
+  // flags from those pointers (applyDefaultFlags), not these columns. The
+  // columns are dead pending their DROP; nothing reads them off a config row.
   ownerId: true,
 } as const;
 

--- a/services/api-gateway/src/services/LlmConfigService.ts
+++ b/services/api-gateway/src/services/LlmConfigService.ts
@@ -70,9 +70,18 @@ interface RawConfigList {
   model: string;
   kind: string;
   isGlobal: boolean;
+  ownerId: string;
+}
+
+/**
+ * A list config with its default flags DERIVED from the AdminSettings pointers
+ * (S3) by {@link LlmConfigService.list}'s `applyDefaultFlags` — NOT read from the
+ * (dead, pending-DROP) `isDefault`/`isFreeDefault` columns. This is the shape
+ * `list()` returns and `formatConfigSummary` consumes.
+ */
+interface RawConfigListWithFlags extends RawConfigList {
   isDefault: boolean;
   isFreeDefault: boolean;
-  ownerId: string;
 }
 
 /**
@@ -181,7 +190,7 @@ export class LlmConfigService {
   async list(
     scope: LlmConfigScope,
     kind: ConfigKind | 'all' = DEFAULT_CONFIG_KIND
-  ): Promise<RawConfigList[]> {
+  ): Promise<RawConfigListWithFlags[]> {
     // Queries are scoped to the requested `kind` (default 'text'); the `'all'`
     // sentinel drops the filter so browse can list text + vision in one call
     // (each row carries `kind` in the summary). The autocomplete picker still
@@ -197,7 +206,7 @@ export class LlmConfigService {
     // pointer), so they're stale. Derive both flags — and the defaults-first
     // ordering — from the live pointers here. (isGlobal stays a real column.)
     const { globalDefaultIds, freeDefaultIds } = await this.getDefaultPointerSets();
-    const applyDefaultFlags = (raw: RawConfigList): RawConfigList => ({
+    const applyDefaultFlags = (raw: RawConfigList): RawConfigListWithFlags => ({
       ...raw,
       isDefault: globalDefaultIds.has(raw.id),
       isFreeDefault: freeDefaultIds.has(raw.id),
@@ -308,7 +317,9 @@ export class LlmConfigService {
           description: data.description ?? null,
           ownerId,
           isGlobal,
-          isDefault: false,
+          // isDefault/isFreeDefault omitted — the schema @default(false) fills
+          // them. Default-ness lives on the AdminSettings pointers (S3), never
+          // written here; these columns are dead pending their DROP.
           provider: data.provider ?? LLM_CONFIG_DEFAULTS.provider,
           model: data.model.trim(),
           // Stamp the requested kind (Zod defaults it to 'text'). Per-kind capability
@@ -671,7 +682,7 @@ export class LlmConfigService {
    * UUID, and the user-facing list would otherwise expose other users' owner
    * IDs). Mirrors `formatConfigDetail`'s explicit-projection discipline.
    */
-  formatConfigSummary(raw: RawConfigList): FormattedConfigSummary {
+  formatConfigSummary(raw: RawConfigListWithFlags): FormattedConfigSummary {
     return {
       id: raw.id,
       name: raw.name,


### PR DESCRIPTION
## What

**Column-drop-prep** — the *expand* half of an expand-contract for the dead `llm_configs.isDefault`/`isFreeDefault` columns.

## Why

Defaults became `AdminSettings` pointers in S3, and `list()` already derives the summary flags from those pointers via `applyDefaultFlags`. So the boolean columns are dead — this stops the last app-level reads/writes ahead of the eventual `DROP`.

## Changes
- `LLM_CONFIG_LIST_SELECT` no longer selects the two columns.
- `RawConfigList` drops them (it's now the raw-from-DB shape); a new **`RawConfigListWithFlags`** = `RawConfigList` + the **derived** flags is `applyDefaultFlags`'s output — what `list()` returns and `formatConfigSummary` consumes.
- The `create` write drops `isDefault: false` (schema `@default(false)` fills it — verified at `schema.prisma:189`).

## Not touched (deliberately)
The sync util (`llmConfigSingletons.ts`) still selects the columns itself and needs them for partial-unique-index conflict resolution **while the columns exist**. The `DROP COLUMN` + partial-index drop + sync-util removal ride the **next** release (the *contract* half). The dev↔prod defaults-sync worry was verified a non-issue — `admin_settings` is env-specific by design.

## Contract impact
**None.** `FormattedConfigSummary`/`LlmConfigSummary` still carry the (now purely pointer-derived) flags, so bot-client/clients are unchanged. Purely internal gateway cleanup.

## Verification
`pnpm quality` green; api-gateway unit (2248) + the LlmConfigService **component** test (33, real `list()` over PGLite with the columns removed from the query) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)