### PR TITLE
fix: retry fast-pool persist once on a dead/stale connection + tighten the ladder

### DIFF
--- a/packages/common-types/src/services/poolConfig.test.ts
+++ b/packages/common-types/src/services/poolConfig.test.ts
@@ -102,7 +102,9 @@ describe('fastPoolConnectionOptions', () => {
     expect(cfg.poolOverrides).toMatchObject({
       connectionTimeoutMillis: FAST_POOL_DEFAULTS.CONNECTION_TIMEOUT_MS,
       query_timeout: FAST_POOL_DEFAULTS.QUERY_TIMEOUT_MS,
+      idleTimeoutMillis: FAST_POOL_DEFAULTS.IDLE_TIMEOUT_MS,
       keepAlive: true,
+      keepAliveInitialDelayMillis: FAST_POOL_DEFAULTS.KEEPALIVE_INITIAL_DELAY_MS,
     });
     expect(cfg.poolOverrides.options).toBe(
       `-c statement_timeout=${FAST_POOL_DEFAULTS.STATEMENT_TIMEOUT_MS} ` +
@@ -133,7 +135,7 @@ describe('fastPoolConnectionOptions', () => {
         DB_FAST_STATEMENT_TIMEOUT_MS: '3000',
       })
     ).toThrow(/ladder violated/);
-    // statement >= query_timeout (default query is 6000)
+    // statement >= query_timeout (default query is 3000)
     expect(() => fastPoolConnectionOptions({ DB_FAST_STATEMENT_TIMEOUT_MS: '9000' })).toThrow(
       /ladder violated/
     );

--- a/packages/common-types/src/services/poolConfig.ts
+++ b/packages/common-types/src/services/poolConfig.ts
@@ -49,20 +49,34 @@ export const FAST_POOL_DEFAULTS = {
   MAX: 5,
   /** Fail-fast on a saturated fast pool (vs the main pool's 10s). */
   CONNECTION_TIMEOUT_MS: 5_000,
-  /** Server GUC. Single-row INSERT acquires locks in low-ms; 2s absorbs normal
+  /** Server GUC. Single-row INSERT acquires locks in low-ms; 1s absorbs normal
    *  contention and fires FIRST → labels a lock wait (SQLSTATE 55P03). */
-  LOCK_TIMEOUT_MS: 2_000,
-  /** Server GUC. Healthy INSERT <100ms; even a GIN flush should be <1s. 5s
+  LOCK_TIMEOUT_MS: 1_000,
+  /** Server GUC. Healthy INSERT <100ms; even a GIN flush should be <1s. 2s
    *  catches pathological slow work → labels it (SQLSTATE 57014). */
-  STATEMENT_TIMEOUT_MS: 5_000,
+  STATEMENT_TIMEOUT_MS: 2_000,
   /** Server GUC. A leaked transaction can't pin a fast-pool connection. */
   IDLE_IN_TX_TIMEOUT_MS: 5_000,
   /** Client-side (node-postgres) abort — the backstop for a dead/stale socket
    *  the server never sees (so the GUCs can't fire). 1s above statement_timeout
-   *  so the server cancels first when it IS reachable. */
-  QUERY_TIMEOUT_MS: 6_000,
-  /** TCP keepalive first-probe delay; proactive dead-socket detection. */
-  KEEPALIVE_INITIAL_DELAY_MS: 10_000,
+   *  so the server cancels first when it IS reachable. When it fires, the dead
+   *  connection is destroyed (pg-pool `_release` removes on error) and the
+   *  persist route retries once on a fresh socket. Kept small (3s) so that
+   *  retry — the actual recovery — happens fast. */
+  QUERY_TIMEOUT_MS: 3_000,
+  /** Evict idle fast-pool connections before a middlebox silently reaps the
+   *  socket, so a stale connection is never handed out. Deliberately SHORTER
+   *  than pg-pool's built-in 10s default so eviction is more aggressive, not
+   *  less (a longer value would just give the reaper more time). The reconnect
+   *  cost is trivial on this small, low-volume pool. Defense-in-depth: can't be
+   *  tuned against an unknown reaper threshold, so the retry is the actual fix
+   *  and this just reduces how often the retry path is hit. */
+  IDLE_TIMEOUT_MS: 5_000,
+  /** TCP keepalive first-probe delay; proactive dead-socket detection. Low so
+   *  probing starts early — though the OS keepalive INTERVAL (~75s, not settable
+   *  via pg.Pool) means keepalive alone can't beat an aggressive reaper; the
+   *  retry is what actually recovers. */
+  KEEPALIVE_INITIAL_DELAY_MS: 1_000,
 } as const;
 
 /** Parse a non-negative integer env var, falling back when unset/invalid. */
@@ -132,6 +146,7 @@ export interface FastPoolConfig {
   poolOverrides: {
     connectionTimeoutMillis: number;
     query_timeout: number;
+    idleTimeoutMillis: number;
     keepAlive: true;
     keepAliveInitialDelayMillis: number;
     /** Postgres startup `options` string — the ONLY reliable way to set the
@@ -178,6 +193,7 @@ export function fastPoolConnectionOptions(env: NodeJS.ProcessEnv = process.env):
     poolOverrides: {
       connectionTimeoutMillis: FAST_POOL_DEFAULTS.CONNECTION_TIMEOUT_MS,
       query_timeout: queryTimeoutMs,
+      idleTimeoutMillis: FAST_POOL_DEFAULTS.IDLE_TIMEOUT_MS,
       keepAlive: true,
       keepAliveInitialDelayMillis: FAST_POOL_DEFAULTS.KEEPALIVE_INITIAL_DELAY_MS,
       options:

--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -40,6 +40,7 @@ import {
   VisionConfigResolver,
 } from '@tzurot/config-resolver';
 import { ConversationRetentionService } from './services/ConversationRetentionService.js';
+import { applyFastPoolDeadConnRetry } from './utils/dbTimeout.js';
 
 // Routes
 import { createAIRouter } from './routes/ai/index.js';
@@ -476,18 +477,23 @@ async function main(): Promise<void> {
   // long ops (pgvector search, Shapes import/export, retention) are exempt by
   // architecture. See poolConfig's fastPoolConnectionOptions.
   const fastCfg = fastPoolConnectionOptions();
-  const { prisma: fastPrisma, dispose: disposeFastPrisma } = createPrismaClient({
+  const { prisma: rawFastPrisma, dispose: disposeFastPrisma } = createPrismaClient({
     max: fastCfg.max,
     poolOverrides: fastCfg.poolOverrides,
   });
-  await fastPrisma.$connect();
+  await rawFastPrisma.$connect();
   // Boot probe: fail fast if the GUC `options` startup string didn't apply
   // (e.g. a connection pooler stripped it) — otherwise the tight timeouts are
-  // silently absent and we revert to the original silent-hang bug.
-  await verifyPoolTimeouts(fastPrisma, {
+  // silently absent and we revert to the original silent-hang bug. Probe the raw
+  // client (a boot check); the routes get the retry-wrapped client below.
+  await verifyPoolTimeouts(rawFastPrisma, {
     statementTimeoutMs: fastCfg.statementTimeoutMs,
     lockTimeoutMs: fastCfg.lockTimeoutMs,
   });
+  // Every fast-pool op retries once on a dead/stale socket (Railway silently
+  // reaps idle conns). Applied at the client boundary — one place, all fast-pool
+  // routes covered — instead of hand-wrapping each call site.
+  const fastPrisma = applyFastPoolDeadConnRetry(rawFastPrisma);
   logger.info('Fast-pool Prisma client established (conversation-event persists)');
 
   // Trust one reverse-proxy hop (Railway sits behind a single edge proxy).

--- a/services/api-gateway/src/utils/dbTimeout.test.ts
+++ b/services/api-gateway/src/utils/dbTimeout.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { classifyDbTimeout } from './dbTimeout.js';
+import { describe, it, expect, vi } from 'vitest';
+import { type PrismaClient } from '@tzurot/common-types';
+import { classifyDbTimeout, withDeadConnRetry, applyFastPoolDeadConnRetry } from './dbTimeout.js';
 
 describe('classifyDbTimeout', () => {
   it('labels a lock_timeout by SQLSTATE 55P03', () => {
@@ -84,5 +85,114 @@ describe('classifyDbTimeout', () => {
     expect(classifyDbTimeout(null).label).toBe('other');
     expect(classifyDbTimeout(undefined).label).toBe('other');
     expect(classifyDbTimeout('boom').label).toBe('other');
+  });
+});
+
+describe('withDeadConnRetry', () => {
+  it('returns the result without retrying on success', async () => {
+    const op = vi.fn().mockResolvedValue('ok');
+    const onRetry = vi.fn();
+    await expect(withDeadConnRetry(op, onRetry)).resolves.toBe('ok');
+    expect(op).toHaveBeenCalledTimes(1);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it('retries ONCE on a dead-conn error and succeeds on the fresh connection', async () => {
+    const op = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Query read timeout'))
+      .mockResolvedValueOnce('ok');
+    const onRetry = vi.fn();
+    await expect(withDeadConnRetry(op, onRetry)).resolves.toBe('ok');
+    expect(op).toHaveBeenCalledTimes(2);
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT retry a real statement-timeout (the query ran server-side)', async () => {
+    const err = { code: '57014' };
+    const op = vi.fn().mockRejectedValue(err);
+    const onRetry = vi.fn();
+    await expect(withDeadConnRetry(op, onRetry)).rejects.toBe(err);
+    expect(op).toHaveBeenCalledTimes(1);
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it('does NOT retry a lock-timeout or a constraint (P2002) error', async () => {
+    const lockErr = { code: '55P03' };
+    const opLock = vi.fn().mockRejectedValue(lockErr);
+    await expect(withDeadConnRetry(opLock)).rejects.toBe(lockErr);
+    expect(opLock).toHaveBeenCalledTimes(1);
+
+    const p2002 = { code: 'P2002', message: 'Unique constraint failed' };
+    const opP2002 = vi.fn().mockRejectedValue(p2002);
+    await expect(withDeadConnRetry(opP2002)).rejects.toBe(p2002);
+    expect(opP2002).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-throws if the retry ALSO hits a dead conn (surfaces the second failure)', async () => {
+    const first = new Error('Query read timeout');
+    const second = new Error('Connection terminated unexpectedly');
+    const op = vi.fn().mockRejectedValueOnce(first).mockRejectedValueOnce(second);
+    const onRetry = vi.fn();
+    await expect(withDeadConnRetry(op, onRetry)).rejects.toBe(second);
+    expect(op).toHaveBeenCalledTimes(2);
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it('works without an onRetry callback', async () => {
+    const op = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Query read timeout'))
+      .mockResolvedValueOnce('ok');
+    await expect(withDeadConnRetry(op)).resolves.toBe('ok');
+    expect(op).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('applyFastPoolDeadConnRetry', () => {
+  // Capture the `$allOperations` handler the extension installs, then drive it
+  // directly — this is the structural retry boundary every fast-pool op flows
+  // through, so testing the handler proves ALL fast-pool queries get the retry.
+  type AllOps = (ctx: {
+    query: (args: unknown) => Promise<unknown>;
+    args: unknown;
+    operation: string;
+    model?: string;
+  }) => Promise<unknown>;
+
+  function capture(): { allOps: AllOps | undefined } {
+    const box: { allOps: AllOps | undefined } = { allOps: undefined };
+    const fakeClient = {
+      $extends: (ext: { query: { $allOperations: AllOps } }) => {
+        box.allOps = ext.query.$allOperations;
+        return fakeClient;
+      },
+    };
+    applyFastPoolDeadConnRetry(fakeClient as unknown as PrismaClient);
+    return box;
+  }
+
+  it('installs an $allOperations handler that retries the dead-conn class once', async () => {
+    const { allOps } = capture();
+    expect(allOps).toBeDefined();
+
+    const query = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Query read timeout'))
+      .mockResolvedValueOnce('ok');
+    const result = await allOps!({ query, args: { where: {} }, operation: 'findUnique' });
+
+    expect(result).toBe('ok');
+    expect(query).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT retry a real statement-timeout through the extension', async () => {
+    const { allOps } = capture();
+    const query = vi.fn().mockRejectedValue({ code: '57014' });
+
+    await expect(allOps!({ query, args: {}, operation: 'create' })).rejects.toEqual({
+      code: '57014',
+    });
+    expect(query).toHaveBeenCalledTimes(1);
   });
 });

--- a/services/api-gateway/src/utils/dbTimeout.ts
+++ b/services/api-gateway/src/utils/dbTimeout.ts
@@ -17,11 +17,12 @@
  * `.cause`).
  */
 
+import { type PrismaClient, createLogger } from '@tzurot/common-types';
+
+const retryLogger = createLogger('fast-pool-retry');
+
 export type DbTimeoutLabel =
-  | 'lock-timeout'
-  | 'statement-timeout'
-  | 'query-timeout-or-dead-conn'
-  | 'other';
+  'lock-timeout' | 'statement-timeout' | 'query-timeout-or-dead-conn' | 'other';
 
 export interface DbTimeoutClassification {
   label: DbTimeoutLabel;
@@ -96,4 +97,70 @@ export function classifyDbTimeout(error: unknown): DbTimeoutClassification {
     return { label: 'query-timeout-or-dead-conn' };
   }
   return sqlstate !== undefined ? { label: 'other', sqlstate } : { label: 'other' };
+}
+
+/**
+ * Run a fast-pool persist, retrying ONCE if the first attempt fails with the
+ * dead/stale-socket class (`query-timeout-or-dead-conn`).
+ *
+ * Safe + deterministic because `pg-pool` DESTROYS a connection on any query
+ * error (its `_release` calls `_remove` when passed a truthy err), and
+ * `@prisma/adapter-pg`'s non-transactional path runs through `pool.query()` —
+ * so the dead socket is already evicted by the time we retry, and the second
+ * attempt acquires a FRESH connection. The write is idempotent two ways, so the
+ * retry is safe even if the classification is imperfect: (1) a dead-socket query
+ * never reached the server, so nothing was persisted on the failed attempt; and
+ * (2) in the ambiguous case where the socket died AFTER the INSERT committed, the
+ * retry's `create` (deterministic UUID) hits `P2002`, which the caller's outer
+ * catch already handles via its existence-compare fallback → a `matched` response.
+ *
+ * ONLY the dead-conn class is retried. A real `lock-timeout` / `statement-timeout`
+ * (the query actually ran server-side) or any other error (`other`, e.g. a
+ * constraint violation) re-throws immediately — retrying wouldn't help and could
+ * duplicate work.
+ */
+export async function withDeadConnRetry<T>(
+  op: () => Promise<T>,
+  onRetry?: (error: unknown) => void
+): Promise<T> {
+  try {
+    return await op();
+  } catch (error) {
+    if (classifyDbTimeout(error).label !== 'query-timeout-or-dead-conn') {
+      throw error;
+    }
+    onRetry?.(error);
+    return op();
+  }
+}
+
+/**
+ * Structural version of {@link withDeadConnRetry}: wrap a fast-pool `PrismaClient`
+ * so EVERY operation on it retries once on the dead/stale-socket class — applied
+ * at the client boundary instead of hand-wrapped per call site. This covers all
+ * fast-pool consumers (the conversation-persist existence-check reads AND the
+ * writes, plus any future fast-pool route) automatically, so the retry can't be
+ * forgotten when a new call site is added.
+ *
+ * Safe to apply blanket ONLY because the fast pool is dedicated to idempotent
+ * conversation-event persists by design (deterministic-UUID upsert-shaped writes
+ * + pure reads). Do NOT reuse this on the main pool, where non-idempotent writes
+ * would double-execute on retry.
+ */
+export function applyFastPoolDeadConnRetry(client: PrismaClient): PrismaClient {
+  return client.$extends({
+    query: {
+      $allOperations: ({ model, operation, args, query }) =>
+        withDeadConnRetry(
+          () => query(args),
+          error =>
+            retryLogger.warn(
+              { err: error, model, operation },
+              'Fast-pool query hit a dead/stale connection — retrying once on a fresh socket'
+            )
+        ),
+    },
+    // $extends returns a structurally-compatible but differently-typed client;
+    // the fast pool only ever runs the ops PrismaClient already exposes.
+  }) as unknown as PrismaClient;
 }


### PR DESCRIPTION
## What

Fixes the prod recurrence of the user-facing **"⏳ Couldn't get a response just now — something's slow on our end."**

## Diagnosis (verified)

Via the beta.138 SQLSTATE self-label, both prod incidents are **`query-timeout-or-dead-conn` @ 6005ms** — the *client* `query_timeout` fired, the *server* `statement_timeout` (verified-applied) never did → the query never executed server-side → a **dead/stale pooled connection** (Railway reaped an idle socket). **Not the GIN index.**

## Fix — structural (updated after review)

Rather than hand-wrap each fast-pool call site (opt-in, easy to forget, and it tripped `max-lines`), the retry is applied **once at the fast-pool client boundary**:

- **`applyFastPoolDeadConnRetry`** — a Prisma `$extends({ query: { $allOperations } })` on `fastPrisma` that retries **any** fast-pool operation once on the dead-conn class. This automatically covers the reviewer's flagged gap (the `compareExisting` existence-check **reads**, which run on every request) *and* the `addMessage` writes *and* any future fast-pool route — the retry can't be forgotten per call site.
- **Safe + deterministic** (verified from source): `pg-pool` DESTROYS a connection on any query error (`_release`→`_remove`), and `@prisma/adapter-pg` 7.8's non-tx path is `pool.query()`, so the retry gets a **fresh** socket. The fast pool is dedicated to idempotent persists by design. Only `query-timeout-or-dead-conn` retries; real lock/statement timeouts + constraint errors re-throw. **Not** applied to the main pool (non-idempotent writes).
- **Tightened ladder** to `lock 1s < statement 2s < query 3s` so the retry fires in ~3s. `idleTimeoutMillis` **5s** (shorter than pg-pool's 10s default — evict idle conns before the reaper) + `keepAliveInitialDelayMillis` 10s→1s.

The routes are back to plain `prisma` calls; `withDeadConnRetry` stays as the tested retry primitive the extension wraps operations with.

## Blast radius
The fast pool has exactly 2 consumers (the 2 persist routes); the extension covers them all. The main pool shares the root cause but manifests as ~20s hangs and isn't safely blanket-retryable — out of scope, tracked separately.

## Tests
`withDeadConnRetry` unit cases + `applyFastPoolDeadConnRetry` extension-handler cases (retry-on-dead-conn / no-retry-on-real-timeout). `pnpm quality` green; api-gateway suite (2256) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)