### PR TITLE
docs: doc-audit sweep — quality-desc drift, rules 08/09, council models, README commands

### DIFF
--- a/.claude/rules/05-tooling.md
+++ b/.claude/rules/05-tooling.md
@@ -7,7 +7,7 @@
 pnpm dev              # Start all services
 pnpm test             # Run unit tests
 pnpm test:component   # Run component tests (snapshots, cross-service)
-pnpm quality          # lint + codegen-drift + knip + cpd + cpd:check + depcruise + typecheck + typecheck:spec + backlog:lint
+pnpm quality          # lint + codegen-drift + topology:check + knip + cpd + cpd:check + test:audit + depcruise + typecheck + typecheck:spec + backlog:lint + guard:test-taxonomy
 pnpm lint             # Lint all packages
 pnpm lint:errors      # Show only errors
 

--- a/.claude/skills/tzurot-council-mcp/SKILL.md
+++ b/.claude/skills/tzurot-council-mcp/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-council-mcp
 description: 'Multi-perspective AI consultation. Invoke with /tzurot-council-mcp for major refactors (>500 lines), structured debugging after failed attempts, or when a technical decision has multiple viable approaches.'
-lastUpdated: '2026-04-11'
+lastUpdated: '2026-07-01'
 ---
 
 # Council MCP Procedures
@@ -87,14 +87,14 @@ End the failed session, call `list_models` to find a replacement with similar ca
 
 ### Recommended models by task
 
-| Task Type        | Recommended Models                              | Notes                                                               |
-| ---------------- | ----------------------------------------------- | ------------------------------------------------------------------- |
-| Reasoning/Design | **Gemini 3.1 Pro Preview** → Claude Sonnet/Opus | **Avoid DeepSeek R1** — it's dated; reasoning/design needs SOTA     |
-| Coding/Review    | Claude Sonnet 4, Claude Opus 4                  | Tool-use variants of Gemini also work for structured refactor tasks |
-| Vision/Images    | Gemini 2.5 Flash, Gemini 2.5 Pro                | (verify availability with `list_models`)                            |
-| Long Documents   | Gemini (1M token context)                       | (verify availability with `list_models`)                            |
+| Task Type        | Recommended Models                                                                                    | Notes                                                                                       |
+| ---------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Reasoning/Design | **GLM 5.2 · Kimi K2.7-code · Qwen 3.7 Max** (run all three in parallel) → Claude Sonnet/Opus fallback | **Avoid DeepSeek R1** — dated; design needs SOTA. Verify IDs via `list_models` (they drift) |
+| Coding/Review    | Claude Sonnet 4, Claude Opus 4                                                                        | Tool-use variants of Gemini also work for structured refactor tasks                         |
+| Vision/Images    | Gemini 2.5 Flash, Gemini 2.5 Pro                                                                      | (verify availability with `list_models`)                                                    |
+| Long Documents   | Gemini (1M token context)                                                                             | (verify availability with `list_models`)                                                    |
 
-**Why avoid DeepSeek R1 for reasoning/design**: explicit user feedback (2026-04-09) — _"In the future, I would recommend not using R1 because again, it is dated. There are better models out there."_ R1 is acceptable for narrow factual queries but not for architectural decisions that ship to users. Default to Gemini 3.1 Pro Preview (or current SOTA equivalent — verify with `list_models`). If Gemini is unavailable, fall back to Claude Sonnet 4 / Opus 4, **not** R1.
+**Why avoid DeepSeek R1 for reasoning/design**: explicit user feedback (2026-04-09) — _"In the future, I would recommend not using R1 because again, it is dated. There are better models out there."_ R1 is acceptable for narrow factual queries but not for architectural decisions that ship to users. For open design decisions, run the current preferred trio in parallel — **GLM 5.2 · Kimi K2.7-code · Qwen 3.7 Max** — and verify each ID via `list_models` first (they drift; the council registry can lag a new release, e.g. GLM 5.2 wasn't listed 2026-06-17 → fall back to 5.1). If those are unavailable, fall back to Claude Sonnet / Opus, **not** R1.
 
 ### Per-call model specification
 

--- a/.claude/skills/tzurot-doc-audit/SKILL.md
+++ b/.claude/skills/tzurot-doc-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-doc-audit
 description: 'Documentation and auto-memory freshness audit. Invoke with /tzurot-doc-audit to review docs and Claude auto-memory for staleness, items in the wrong layer, and missing-tool drift.'
-lastUpdated: '2026-06-17'
+lastUpdated: '2026-07-01'
 ---
 
 # Documentation Audit Procedure
@@ -105,16 +105,18 @@ Auto-memory audit runs as part of the recurring `/tzurot-doc-audit` cycle — th
 
 ### 2. Rules Files (`.claude/rules/`)
 
-| File                   | Check                                                                                                                                                                              |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `00-critical.md`       | Security rules still reflect current patterns? Post-mortem table current?                                                                                                          |
-| `01-architecture.md`   | Service boundaries match dependency-cruiser rules? Anti-patterns table current?                                                                                                    |
-| `02-code-standards.md` | ESLint limits match `eslint.config.js`? Testing patterns current?                                                                                                                  |
-| `03-database.md`       | Cache implementations table accurate? Protected indexes list current?                                                                                                              |
-| `04-discord.md`        | Shared utilities table lists all browse/dashboard helpers?                                                                                                                         |
-| `05-tooling.md`        | All `pnpm ops` commands listed? `pnpm quality` description accurate?                                                                                                               |
-| `06-backlog.md`        | HOT/COLD topology table matches actual `backlog/` layout (`now.md` + `active-epic.md` hot; `cold/` themes/ideas/follow-ups/epic-log)? Granularity-ladder + staleness rules intact? |
-| `07-documentation.md`  | Placement table covers all `docs/reference/` subdirs? Lifecycle rules current?                                                                                                     |
+| File                      | Check                                                                                                                                                                              |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `00-critical.md`          | Security rules still reflect current patterns? Post-mortem table current?                                                                                                          |
+| `01-architecture.md`      | Service boundaries match dependency-cruiser rules? Anti-patterns table current?                                                                                                    |
+| `02-code-standards.md`    | ESLint limits match `eslint.config.js`? Testing patterns current?                                                                                                                  |
+| `03-database.md`          | Cache implementations table accurate? Protected indexes list current?                                                                                                              |
+| `04-discord.md`           | Shared utilities table lists all browse/dashboard helpers?                                                                                                                         |
+| `05-tooling.md`           | All `pnpm ops` commands listed? `pnpm quality` description accurate?                                                                                                               |
+| `06-backlog.md`           | HOT/COLD topology table matches actual `backlog/` layout (`now.md` + `active-epic.md` hot; `cold/` themes/ideas/follow-ups/epic-log)? Granularity-ladder + staleness rules intact? |
+| `07-documentation.md`     | Placement table covers all `docs/reference/` subdirs? Lifecycle rules current?                                                                                                     |
+| `08-review-response.md`   | Edit-shape whitelist current? Round-cap + fixup-commit procedure matches the CI `fixup-check` job?                                                                                 |
+| `09-interaction-style.md` | Interaction guidance still reflects current feedback (no premature-stopping, etc.)?                                                                                                |
 
 **How to verify 05-tooling.md:**
 
@@ -162,9 +164,21 @@ ls .claude/skills/*/SKILL.md
 
 ### 6. Research Notes
 
+**Format check** (a well-formatted doc can still be obsolete — do the relevance check below too):
+
 - [ ] Files in `docs/research/` are TL;DR format (2-5KB, not raw transcripts)
 - [ ] No raw AI chat dumps (distill or delete)
 - [ ] Research links to actionable items in `backlog/**/*.md` or proposals
+- [ ] `docs/research/README.md` index lists exactly the files present (no phantom rows, no missing files, descriptions not stale)
+
+**Relevance / lifecycle check (guards against doc sprawl — format-clean ≠ still-needed).** For EACH research doc, decide **KEEP / TRIM / DELETE**. A research doc is meant to persist as the "why we chose X" rationale record, so the bar for deletion is: its unique rationale is captured nowhere it's needed. Delete/trim when:
+
+- [ ] **Stale point-in-time snapshot** — the doc froze a moment ("free models as of Jan 2026", "current API pricing") that no longer holds and now _misleads_. → DELETE.
+- [ ] **Superseded / absorbed** — its "Actionable Items" pointer is dead (the backlog item shipped, was absorbed, or renamed), AND its rationale is now captured in shipped code + a `docs/reference/` doc. → DELETE.
+- [ ] **Bloated with redundant passes** — multiple dated passes where later ones restate earlier prose (as opposed to adding distinct decision layers / empirical data). → TRIM to the load-bearing findings.
+- [ ] **Still a live write-target or seeds unshipped backlog** — a backlog follow-up says "document findings here", or it holds impl detail/rationale for open themes the terse backlog rows lack. → KEEP.
+
+**How to run it**: for each file, grep the repo for its filename (find inbound references), grep `backlog/` + `docs/proposals/` for whether its subject shipped/was-absorbed/is-still-open, and check `docs/reference/` for a doc that already captures the same rationale. Verify before deleting — never orphan a rationale that isn't recorded elsewhere. Deletions are `git rm` (git history is the backstop); confirm with the maintainer if unsure.
 
 ### 8. Incidents
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Discord bot with AI personas. TypeScript monorepo on Railway.
 pnpm dev              # Start all services
 pnpm test             # Run unit tests
 pnpm test:component   # Run component tests (after command structure changes)
-pnpm quality          # lint + codegen-drift + knip + cpd + cpd:check + depcruise + typecheck + typecheck:spec + backlog:lint
+pnpm quality          # lint + codegen-drift + topology:check + knip + cpd + cpd:check + test:audit + depcruise + typecheck + typecheck:spec + backlog:lint + guard:test-taxonomy
 pnpm ops db:migrate --env dev  # Run migrations
 ```
 
@@ -44,6 +44,8 @@ All rules load automatically from `.claude/rules/`:
 - **05-tooling.md** - CLI reference, commit & release standards
 - **06-backlog.md** - Backlog structure and session workflow
 - **07-documentation.md** - Doc placement, naming, lifecycle
+- **08-review-response.md** - PR review-response iteration (auto-apply vs ASK)
+- **09-interaction-style.md** - Session interaction style (don't suggest stopping)
 
 ## Git Workflow
 

--- a/README.md
+++ b/README.md
@@ -159,9 +159,10 @@ Tzurot is fully managed via Discord slash commands. For the complete reference (
 - **`/persona`** — User personas, defaults, per-character overrides
 - **`/voice`** — TTS/STT provider config, cloned-voice library, per-character resolved-state dashboard (`/voice view`)
 - **`/preset`** + **`/channel`** — Custom LLM presets, channel auto-response activation
+- **`/models`** — Browse and inspect available AI models (capabilities, context window, pricing)
 - **`/memory`** + **`/history`** — Long-term memory browse/search/prune, conversation history management, privacy modes (focus, incognito)
 - **`/settings`** — Timezone, BYOK API keys, per-character preset overrides, global default settings dashboard
-- **`/inspect`** — Diagnostic log browser (full LLM request flight recorder)
+- **`/inspect`** + **`/help`** — Diagnostic log browser (full LLM request flight recorder); list all available commands
 - **`/shapes`** — Legacy Shapes.inc character migration
 - **`/admin`** + **`/deny`** — Owner-only monitoring, maintenance, denial management
 


### PR DESCRIPTION
Doc-audit sweep (the post-release freshness pass). Split from the direct-to-develop `docs/**` fixes (already on develop: GIN-drop in `PRISMA_DRIFT_ISSUES.md`, deleted the shipped `tts-engine-upgrade-phase-1-plan.md`, backlogged 2 findings). This PR carries the **review-gated** files (`.claude/rules/`, skill, root `CLAUDE.md`/`README.md`).

## Changes

- **`05-tooling.md` + `CLAUDE.md`** — the `pnpm quality` description had drifted from the actual root script: missing `topology:check`, `test:audit`, `guard:test-taxonomy`. Now matches.
- **`CLAUDE.md` Key Rules** — add `08-review-response.md` + `09-interaction-style.md` (both exist but weren't listed).
- **`README.md`** — add `/models` and `/help` to the slash-command list (both are real top-level commands, were omitted).
- **`tzurot-council-mcp` skill** — refresh the Reasoning/Design recommendation from the stale `Gemini 3.1 Pro Preview` default to the current preferred trio (**GLM 5.2 · Kimi K2.7-code · Qwen 3.7 Max**, per the user's documented council prefs), keeping the "verify via `list_models`" + "avoid R1" caveats; bump `lastUpdated` 2026-04-11 → 2026-07-01.

## Audit coverage (4 parallel agents + Section 0)
Rules↔code, README/CLAUDE, reference-docs/links, skills/index all swept. Everything else audited **clean** (ESLint limits, dependency-cruiser boundaries, protected-index table, post-mortem table, docs/README index, all proposal lifecycles except the shipped TTS one). Two decisions backlogged (package-list curate-vs-list-all; index-table completeness). Section 0 (auto-memory) surfaced 4 rule-superseded memories held for the user's delete approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)