### PR TITLE
feat(api-gateway): stamp the vision fallback chain onto the job envelope (Phase 4 Slice B)

### DIFF
--- a/packages/common-types/src/types/schemas/personality.ts
+++ b/packages/common-types/src/types/schemas/personality.ts
@@ -46,6 +46,17 @@ export const loadedPersonalitySchema = z.object({
   model: z.string(),
   visionModel: z.string().optional(),
   /**
+   * Ordered vision-model fallback chain the worker retries down when the primary
+   * vision model FAILS at runtime (Phase 4 auto-fallback). Gateway-stamped from the
+   * DB-resolved defaults (`AdminSettings.globalDefaultVisionConfigId` →
+   * `freeDefaultVisionConfigId`) since the worker has no Prisma — all DB resolution
+   * stays gateway-side, the worker just walks the list. Absent/empty = no admin
+   * fallback tiers configured; the worker still has its local T2 (native main-model
+   * vision) and T5 (hardcoded floor) tiers. The worker composes + dedupes the full
+   * chain; this carries only the tiers it can't compute locally.
+   */
+  visionFallbackModels: z.array(z.string()).optional(),
+  /**
    * Provider routing key (e.g. 'openrouter', 'zai-coding'). Drives
    * provider-tier baseURL selection in ModelFactory and any auto-fallthrough
    * decisions in ProviderRouter. String-typed (not the AIProvider enum)

--- a/services/api-gateway/src/utils/BullMQJobChainContract.producer.test.ts
+++ b/services/api-gateway/src/utils/BullMQJobChainContract.producer.test.ts
@@ -60,6 +60,11 @@ const visionResolverStub: VisionConfigResolver = {
     source: 'personality',
     config: { model: 'resolved/vision-model' },
   }),
+  // Phase 4: stampResolvedConfig also reads the two default pointers for the
+  // visionFallbackModels chain. Return null (no admin fallbacks) so the snapshot
+  // carries only the resolved visionModel, not a fallback chain.
+  getGlobalDefaultConfig: vi.fn().mockResolvedValue(null),
+  getFreeDefaultVisionConfig: vi.fn().mockResolvedValue(null),
 } as unknown as VisionConfigResolver;
 
 const PERSONALITY: LoadedPersonality = {

--- a/services/api-gateway/src/utils/jobChainOrchestrator.test.ts
+++ b/services/api-gateway/src/utils/jobChainOrchestrator.test.ts
@@ -916,9 +916,26 @@ describe('jobChainOrchestrator (FlowProducer)', () => {
 
     // The vision cascade (VisionConfigResolver, kind='vision') stamps
     // personality.visionModel INDEPENDENTLY — its config.model IS the vision model.
-    const visionResolverReturning = (model: string): VisionConfigResolver =>
+    // `fallbacks` seeds the two DB-default readers the stamp also consults for the
+    // Phase-4 visionFallbackModels chain (default: neither set → readers return null).
+    const visionResolverReturning = (
+      model: string,
+      fallbacks: { global?: string; free?: string } = {}
+    ): VisionConfigResolver =>
       ({
         resolveConfig: vi.fn().mockResolvedValue({ config: { model }, source: 'personality' }),
+        getGlobalDefaultConfig: vi
+          .fn()
+          .mockResolvedValue(
+            fallbacks.global !== undefined
+              ? { model: fallbacks.global, source: 'personality' }
+              : null
+          ),
+        getFreeDefaultVisionConfig: vi
+          .fn()
+          .mockResolvedValue(
+            fallbacks.free !== undefined ? { model: fallbacks.free, source: 'personality' } : null
+          ),
       }) as unknown as VisionConfigResolver;
 
     it('stamps the resolved text model + vision model onto BOTH the LLM job and the image-description child', async () => {
@@ -979,6 +996,8 @@ describe('jobChainOrchestrator (FlowProducer)', () => {
           config: { model: 'qwen/qwen3.5-397b-a17b', source: 'hardcoded' },
           source: 'hardcoded',
         }),
+        getGlobalDefaultConfig: vi.fn().mockResolvedValue(null),
+        getFreeDefaultVisionConfig: vi.fn().mockResolvedValue(null),
       } as unknown as VisionConfigResolver;
 
       await createJobChain({
@@ -993,6 +1012,61 @@ describe('jobChainOrchestrator (FlowProducer)', () => {
       const flowCall = (flowProducer.add as any).mock.calls[0][0];
       // The 397B hardcoded fallback is NOT stamped → visionModel stays unset.
       expect(flowCall.data.personality.visionModel).toBeUndefined();
+    });
+
+    it('stamps the visionFallbackModels chain from the global + free vision defaults (Phase 4)', async () => {
+      await createJobChain({
+        requestId: 'req-vision-fallbacks',
+        personality: mockPersonality,
+        message: 'What is this?',
+        context: imageAttachmentContext(),
+        responseDestination: mockResponseDestination,
+        visionConfigResolver: visionResolverReturning('primary-vision', {
+          global: 'global-vision-default',
+          free: 'free-vision-default',
+        }),
+      });
+
+      const flowCall = (flowProducer.add as any).mock.calls[0][0];
+      expect(flowCall.data.personality.visionModel).toBe('primary-vision');
+      // The DB-resolved fallback tiers ride along for the worker's runtime retry loop,
+      // in global→free order — the worker composes its local native-main + hardcoded tiers.
+      expect(flowCall.data.personality.visionFallbackModels).toEqual([
+        'global-vision-default',
+        'free-vision-default',
+      ]);
+    });
+
+    it('dedupes the fallback chain when the global + free defaults are the same model', async () => {
+      await createJobChain({
+        requestId: 'req-vision-fallbacks-dedup',
+        personality: mockPersonality,
+        message: 'hi',
+        context: imageAttachmentContext(),
+        responseDestination: mockResponseDestination,
+        visionConfigResolver: visionResolverReturning('primary-vision', {
+          global: 'same-model',
+          free: 'same-model',
+        }),
+      });
+
+      const flowCall = (flowProducer.add as any).mock.calls[0][0];
+      expect(flowCall.data.personality.visionFallbackModels).toEqual(['same-model']);
+    });
+
+    it('omits visionFallbackModels entirely when no DB vision defaults are set', async () => {
+      await createJobChain({
+        requestId: 'req-vision-no-defaults',
+        personality: mockPersonality,
+        message: 'hi',
+        context: imageAttachmentContext(),
+        responseDestination: mockResponseDestination,
+        visionConfigResolver: visionResolverReturning('primary-vision'), // no global/free
+      });
+
+      const flowCall = (flowProducer.add as any).mock.calls[0][0];
+      // Absent, not an empty array — the worker still has its local T2/T5 tiers.
+      expect(flowCall.data.personality.visionFallbackModels).toBeUndefined();
     });
 
     it('does NOT overwrite provider (AuthStep auto-promote relies on the configured provider)', async () => {
@@ -1086,8 +1160,12 @@ describe('jobChainOrchestrator (FlowProducer)', () => {
         ...mockPersonality,
         visionModel: 'seed-vision',
       };
+      // resolveConfig is the sole thrower — the readers succeed so the test exercises
+      // the resolveConfig-throws path specifically (not an incidental missing-method throw).
       const visionConfigResolver = {
         resolveConfig: vi.fn().mockRejectedValue(new Error('db down')),
+        getGlobalDefaultConfig: vi.fn().mockResolvedValue(null),
+        getFreeDefaultVisionConfig: vi.fn().mockResolvedValue(null),
       } as unknown as VisionConfigResolver;
 
       const jobId = await createJobChain({

--- a/services/api-gateway/src/utils/jobChainOrchestrator.ts
+++ b/services/api-gateway/src/utils/jobChainOrchestrator.ts
@@ -20,7 +20,6 @@ import {
   type JobDependency,
   type JobContext,
   type ResponseDestination,
-  type ConfigSourceId,
   JobStatus,
   audioTranscriptionJobDataSchema,
   imageDescriptionJobDataSchema,
@@ -28,6 +27,7 @@ import {
 } from '@tzurot/common-types';
 import type { LlmConfigResolver, VisionConfigResolver } from '@tzurot/config-resolver';
 import { flowProducer } from '../queue.js';
+import { stampResolvedConfig } from './stampResolvedConfig.js';
 import type { FlowJob } from 'bullmq';
 
 const logger = createLogger('JobChainOrchestrator');
@@ -277,89 +277,6 @@ function processAttachmentsForJobs(
   dependencies.push(...imageResult.dependencies);
 
   return { children, dependencies };
-}
-
-/**
- * Resolve the user's effective TEXT model AND vision model ONCE and stamp both onto
- * the personality, so every job in the chain (the conversation job AND the
- * image-description child job) shares the same user-cascaded values. Without this,
- * the image-description job would consume the personality SEED values (the load-time
- * defaults) because it never runs ai-worker's `ConfigStep` cascade.
- *
- * The TEXT model (`personality.model`) and the VISION model (`personality.visionModel`,
- * the carrier `selectVisionModel` reads at priority 1) resolve through INDEPENDENT
- * cascades — `LlmConfigResolver` (kind='text') and `VisionConfigResolver` (kind='vision').
- * Vision stamps regardless of the text source, since it's its own config axis.
- *
- * `provider` is intentionally NOT stamped: `ResolvedLlmConfig` carries no provider
- * (all configs are OpenRouter; ai-worker's ProviderRouter auto-promotes by model-name
- * prefix), so the configured seed provider must survive for AuthStep's routing to fire.
- *
- * Fails open per axis: a resolver throw (or no resolver wired) leaves that axis on the
- * seed value — never block job creation on config resolution. An unstamped vision model
- * (undefined) makes `selectVisionModel` fall to priority-2/3; the guest downgrade of a
- * stamped paid vision model stays in AuthStep.
- */
-async function stampResolvedConfig(
-  personality: LoadedPersonality,
-  userId: string,
-  requestId: string,
-  llmConfigResolver?: LlmConfigResolver,
-  visionConfigResolver?: VisionConfigResolver
-): Promise<{ personality: LoadedPersonality; configSource: ConfigSourceId }> {
-  let stamped = personality;
-  // configSource tracks only the TEXT config axis (which tier of the text cascade
-  // stamped the model). The vision resolution source is intentionally NOT captured here.
-  let configSource: ConfigSourceId = 'personality';
-
-  // TEXT model: stamp personality.model from the user cascade.
-  if (llmConfigResolver !== undefined) {
-    try {
-      const resolved = await llmConfigResolver.resolveConfig(userId, personality.id, personality);
-      // Only the two user-override tiers stamp a model.
-      // - 'personality': the resolved model equals the seed already → leave unchanged.
-      // - 'free-default'/'hardcoded': LlmConfigResolver should never produce these
-      //   (TtsConfigResolver tiers). Warn so the contract violation stays observable.
-      if (resolved.source === 'free-default' || resolved.source === 'hardcoded') {
-        logger.warn(
-          { requestId, personalityId: personality.id, unexpectedSource: resolved.source },
-          'LlmConfigResolver returned a TTS-only config source — using personality seed'
-        );
-      } else if (resolved.source !== 'personality') {
-        // user-personality | user-default → stamp the resolved (already-merged) model.
-        stamped = { ...stamped, model: resolved.config.model };
-        configSource = resolved.source;
-      }
-    } catch (error) {
-      logger.warn(
-        { err: error, requestId, personalityId: personality.id },
-        'LLM config resolution failed at job-chain build — using personality seed'
-      );
-    }
-  }
-
-  // VISION model: stamp personality.visionModel from the INDEPENDENT vision cascade.
-  if (visionConfigResolver !== undefined) {
-    try {
-      const vision = await visionConfigResolver.resolveConfig(userId, personality.id, personality);
-      // Skip the hardcoded-fallback tier (source='hardcoded' → MODEL_DEFAULTS.VISION_FALLBACK,
-      // the slow model the resolver only returns before the vision globals are seeded).
-      // Stamping it would make selectVisionModel priority-1 fire and force the fallback even
-      // when the main model has native vision — the exact timeout this epic targets. Leaving
-      // it unstamped lets priority-2 (main-model-vision) win during the bootstrap window.
-      // Symmetric with the text leg, which skips the 'personality' (= seed) source.
-      if (vision.source !== 'hardcoded') {
-        stamped = { ...stamped, visionModel: vision.config.model };
-      }
-    } catch (error) {
-      logger.warn(
-        { err: error, requestId, personalityId: personality.id },
-        'Vision config resolution failed at job-chain build — leaving vision model unstamped'
-      );
-    }
-  }
-
-  return { personality: stamped, configSource };
 }
 
 /** Base params shared by every preprocessing job in a chain (per-job suffix/ref added at call site). */

--- a/services/api-gateway/src/utils/stampResolvedConfig.test.ts
+++ b/services/api-gateway/src/utils/stampResolvedConfig.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from 'vitest';
+import { stampResolvedConfig } from './stampResolvedConfig.js';
+import type { LoadedPersonality } from '@tzurot/common-types';
+import type { LlmConfigResolver, VisionConfigResolver } from '@tzurot/config-resolver';
+
+// stampResolvedConfig only reads id/model/visionModel and spreads the rest, so a minimal
+// cast is a faithful stand-in for a full LoadedPersonality here.
+const basePersonality = {
+  id: 'p-1',
+  model: 'seed-model',
+  // visionModel intentionally unset — an undefined seed vision model.
+} as unknown as LoadedPersonality;
+
+const llmResolver = (model: string, source: string): LlmConfigResolver =>
+  ({
+    resolveConfig: vi.fn().mockResolvedValue({ config: { model }, source }),
+  }) as unknown as LlmConfigResolver;
+
+const visionResolver = (
+  model: string,
+  source: string,
+  fallbacks: { global?: string; free?: string } = {}
+): VisionConfigResolver =>
+  ({
+    resolveConfig: vi.fn().mockResolvedValue({ config: { model }, source }),
+    getGlobalDefaultConfig: vi
+      .fn()
+      .mockResolvedValue(
+        fallbacks.global !== undefined ? { model: fallbacks.global, source: 'personality' } : null
+      ),
+    getFreeDefaultVisionConfig: vi
+      .fn()
+      .mockResolvedValue(
+        fallbacks.free !== undefined ? { model: fallbacks.free, source: 'personality' } : null
+      ),
+  }) as unknown as VisionConfigResolver;
+
+describe('stampResolvedConfig', () => {
+  describe('text axis', () => {
+    it('stamps the model + configSource from a user-override tier', async () => {
+      const { personality, configSource } = await stampResolvedConfig(
+        basePersonality,
+        'user-1',
+        'req-1',
+        llmResolver('resolved-model', 'user-default')
+      );
+      expect(personality.model).toBe('resolved-model');
+      expect(configSource).toBe('user-default');
+    });
+
+    it('leaves the seed model unchanged when the source is personality (already the seed)', async () => {
+      const { personality, configSource } = await stampResolvedConfig(
+        basePersonality,
+        'user-1',
+        'req-1',
+        llmResolver('ignored', 'personality')
+      );
+      expect(personality.model).toBe('seed-model');
+      expect(configSource).toBe('personality');
+    });
+
+    it('fails open to the seed model on a resolver throw', async () => {
+      const resolver = {
+        resolveConfig: vi.fn().mockRejectedValue(new Error('db down')),
+      } as unknown as LlmConfigResolver;
+      const { personality } = await stampResolvedConfig(basePersonality, 'u', 'r', resolver);
+      expect(personality.model).toBe('seed-model');
+    });
+  });
+
+  describe('vision axis', () => {
+    it('stamps the vision model + deduped fallback chain (global → free)', async () => {
+      const { personality } = await stampResolvedConfig(
+        basePersonality,
+        'u',
+        'r',
+        undefined,
+        visionResolver('primary-vision', 'personality', { global: 'g-default', free: 'f-default' })
+      );
+      expect(personality.visionModel).toBe('primary-vision');
+      expect(personality.visionFallbackModels).toEqual(['g-default', 'f-default']);
+    });
+
+    it('dedupes the fallback chain when global and free resolve to the same model', async () => {
+      const { personality } = await stampResolvedConfig(
+        basePersonality,
+        'u',
+        'r',
+        undefined,
+        visionResolver('primary', 'personality', { global: 'same', free: 'same' })
+      );
+      expect(personality.visionFallbackModels).toEqual(['same']);
+    });
+
+    it('omits the fallback chain when no DB vision defaults are set', async () => {
+      const { personality } = await stampResolvedConfig(
+        basePersonality,
+        'u',
+        'r',
+        undefined,
+        visionResolver('primary', 'personality')
+      );
+      expect(personality.visionFallbackModels).toBeUndefined();
+    });
+
+    it('does NOT stamp the hardcoded vision fallback (bootstrap window)', async () => {
+      const { personality } = await stampResolvedConfig(
+        basePersonality,
+        'u',
+        'r',
+        undefined,
+        visionResolver('qwen/hardcoded-fallback', 'hardcoded')
+      );
+      expect(personality.visionModel).toBeUndefined();
+    });
+
+    it('fails open on a vision-resolver throw (seed vision left unstamped)', async () => {
+      const resolver = {
+        resolveConfig: vi.fn().mockRejectedValue(new Error('db down')),
+        getGlobalDefaultConfig: vi.fn().mockResolvedValue(null),
+        getFreeDefaultVisionConfig: vi.fn().mockResolvedValue(null),
+      } as unknown as VisionConfigResolver;
+      const { personality } = await stampResolvedConfig(
+        basePersonality,
+        'u',
+        'r',
+        undefined,
+        resolver
+      );
+      expect(personality.visionModel).toBeUndefined();
+      expect(personality.visionFallbackModels).toBeUndefined();
+    });
+  });
+});

--- a/services/api-gateway/src/utils/stampResolvedConfig.ts
+++ b/services/api-gateway/src/utils/stampResolvedConfig.ts
@@ -1,0 +1,118 @@
+/**
+ * Config stamping for the job chain.
+ *
+ * Resolves the user's effective TEXT + VISION model ONCE (gateway-side, where the
+ * resolvers + DB live) and stamps them onto the personality so every job in the chain
+ * shares the same user-cascaded values. Split out of `jobChainOrchestrator` to keep that
+ * module under the line limit and to give the resolve-and-stamp logic its own test surface.
+ */
+
+import { createLogger, type LoadedPersonality, type ConfigSourceId } from '@tzurot/common-types';
+import type { LlmConfigResolver, VisionConfigResolver } from '@tzurot/config-resolver';
+
+const logger = createLogger('ConfigStamping');
+
+/**
+ * Resolve the user's effective TEXT model AND vision model ONCE and stamp both onto
+ * the personality, so every job in the chain (the conversation job AND the
+ * image-description child job) shares the same user-cascaded values. Without this,
+ * the image-description job would consume the personality SEED values (the load-time
+ * defaults) because it never runs ai-worker's `ConfigStep` cascade.
+ *
+ * The TEXT model (`personality.model`) and the VISION model (`personality.visionModel`,
+ * the carrier `selectVisionModel` reads at priority 1) resolve through INDEPENDENT
+ * cascades — `LlmConfigResolver` (kind='text') and `VisionConfigResolver` (kind='vision').
+ * Vision stamps regardless of the text source, since it's its own config axis.
+ *
+ * `provider` is intentionally NOT stamped: `ResolvedLlmConfig` carries no provider
+ * (all configs are OpenRouter; ai-worker's ProviderRouter auto-promotes by model-name
+ * prefix), so the configured seed provider must survive for AuthStep's routing to fire.
+ *
+ * Fails open per axis: a resolver throw (or no resolver wired) leaves that axis on the
+ * seed value — never block job creation on config resolution. An unstamped vision model
+ * (undefined) makes `selectVisionModel` fall to priority-2/3; the guest downgrade of a
+ * stamped paid vision model stays in AuthStep.
+ */
+export async function stampResolvedConfig(
+  personality: LoadedPersonality,
+  userId: string,
+  requestId: string,
+  llmConfigResolver?: LlmConfigResolver,
+  visionConfigResolver?: VisionConfigResolver
+): Promise<{ personality: LoadedPersonality; configSource: ConfigSourceId }> {
+  let stamped = personality;
+  // configSource tracks only the TEXT config axis (which tier of the text cascade
+  // stamped the model). The vision resolution source is intentionally NOT captured here.
+  let configSource: ConfigSourceId = 'personality';
+
+  // TEXT model: stamp personality.model from the user cascade.
+  if (llmConfigResolver !== undefined) {
+    try {
+      const resolved = await llmConfigResolver.resolveConfig(userId, personality.id, personality);
+      // Only the two user-override tiers stamp a model.
+      // - 'personality': the resolved model equals the seed already → leave unchanged.
+      // - 'free-default'/'hardcoded': LlmConfigResolver should never produce these
+      //   (TtsConfigResolver tiers). Warn so the contract violation stays observable.
+      if (resolved.source === 'free-default' || resolved.source === 'hardcoded') {
+        logger.warn(
+          { requestId, personalityId: personality.id, unexpectedSource: resolved.source },
+          'LlmConfigResolver returned a TTS-only config source — using personality seed'
+        );
+      } else if (resolved.source !== 'personality') {
+        // user-personality | user-default → stamp the resolved (already-merged) model.
+        stamped = { ...stamped, model: resolved.config.model };
+        configSource = resolved.source;
+      }
+    } catch (error) {
+      logger.warn(
+        { err: error, requestId, personalityId: personality.id },
+        'LLM config resolution failed at job-chain build — using personality seed'
+      );
+    }
+  }
+
+  // VISION model: stamp personality.visionModel from the INDEPENDENT vision cascade,
+  // plus the ordered DB-resolved fallback chain the worker retries down on a RUNTIME
+  // vision failure (Phase 4). The worker has no Prisma, so all DB resolution stays here.
+  if (visionConfigResolver !== undefined) {
+    try {
+      // resolveConfig picks the effective vision model; the two default readers supply the
+      // fallback tiers. Parallel — each is cache-backed after warmup (job-build, not per-token).
+      const [vision, globalDefault, freeDefault] = await Promise.all([
+        visionConfigResolver.resolveConfig(userId, personality.id, personality),
+        visionConfigResolver.getGlobalDefaultConfig(),
+        visionConfigResolver.getFreeDefaultVisionConfig(),
+      ]);
+      // Skip the hardcoded-fallback tier (source='hardcoded' → MODEL_DEFAULTS.VISION_FALLBACK,
+      // the slow model the resolver only returns before the vision globals are seeded).
+      // Stamping it would make selectVisionModel priority-1 fire and force the fallback even
+      // when the main model has native vision — the exact timeout this epic targets. Leaving
+      // it unstamped lets priority-2 (main-model-vision) win during the bootstrap window.
+      // Symmetric with the text leg, which skips the 'personality' (= seed) source.
+      if (vision.source !== 'hardcoded') {
+        stamped = { ...stamped, visionModel: vision.config.model };
+      }
+      // The DB-resolved fallback tiers (global → free), deduped + non-empty. The worker
+      // composes its local native-main + hardcoded tiers around this; only these DB tiers
+      // must cross the boundary. Stamped independently of visionModel — it's for the
+      // runtime-failure path, not the initial pick.
+      const fallbackModels = [
+        ...new Set(
+          [globalDefault?.model, freeDefault?.model].filter(
+            (m): m is string => m !== undefined && m.length > 0
+          )
+        ),
+      ];
+      if (fallbackModels.length > 0) {
+        stamped = { ...stamped, visionFallbackModels: fallbackModels };
+      }
+    } catch (error) {
+      logger.warn(
+        { err: error, requestId, personalityId: personality.id },
+        'Vision config resolution failed at job-chain build — leaving vision model unstamped'
+      );
+    }
+  }
+
+  return { personality: stamped, configSource };
+}


### PR DESCRIPTION
**Phase 4 — Vision Auto-Fallback, Slice B of 4** (additive/inert — nothing consumes the field yet; depends on Slice A #1426, already merged).

## What
The worker vision retry loop (Slice C) needs the DB-resolved fallback tiers, but the worker has no Prisma — so the gateway stamps them onto the job envelope.

- **`loadedPersonalitySchema`** gains `visionFallbackModels?: string[]` (sibling to `visionModel`, flows to the worker with the personality).
- **`stampResolvedConfig`** now also reads the two default pointers (`globalDefaultVisionConfigId` → `freeDefaultVisionConfigId`, via Slice A's reader) and stamps the ordered, deduped, non-empty chain. Runs the three resolver calls in parallel (all cache-backed). All DB resolution stays gateway-side — the worker will compose its local native-main + hardcoded tiers around this list.

## Refactor
Extracted `stampResolvedConfig` (resolve-and-stamp for both text + vision axes) out of `jobChainOrchestrator` into its own module + colocated test — the fallback-chain addition pushed the orchestrator over the 400-line limit, and it's a cohesive unit deserving its own test surface. Behavior-identical (logger renamed to `ConfigStamping`).

## Tests
- New `stampResolvedConfig.test.ts` (9 direct unit cases: text/vision stamp, fallback chain, dedup, omit-when-empty, hardcoded-skip, fail-open).
- Extended the orchestrator's stamp tests (chain, dedup, omit) + fixed two incomplete `VisionConfigResolver` stubs (they now need the default-reader methods, else the `Promise.all` throws → vision block fails open → `visionModel` unstamped, which broke a contract snapshot).
- `pnpm quality` green; api-gateway 2267 + common-types 2300 pass.

## Next
Slice C: the worker `describeImage` retry loop consumes `visionFallbackModels`, with the retry-vs-terminate policy + cost guards + `[VISION_UNAVAILABLE]` terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)