### PR TITLE
fix(ai-worker): dedup reply-stub markers no longer truncate away the text

### DIFF
--- a/packages/common-types/src/utils/referenceEnrichment.test.ts
+++ b/packages/common-types/src/utils/referenceEnrichment.test.ts
@@ -5,6 +5,7 @@ import type { ReferencedMessage } from '../types/schemas/message.js';
 import {
   appendVoiceTranscripts,
   buildDedupedReferenceStub,
+  capDedupText,
   isBotAuthoredReference,
   isDuplicateReference,
   stripBotVoiceAttachments,
@@ -117,6 +118,22 @@ function fullReference(content: string, botAuthored = false): ReferencedMessage 
     isForwarded: true,
   };
 }
+
+describe('capDedupText', () => {
+  it('returns text at or under the limit unchanged (no ellipsis)', () => {
+    const short = 'X'.repeat(TEXT_LIMITS.DEDUP_STUB_CONTENT);
+    expect(capDedupText(short)).toBe(short);
+    expect(capDedupText('hi')).toBe('hi');
+    expect(capDedupText('')).toBe('');
+  });
+
+  it('caps over-limit text to DEDUP_STUB_CONTENT chars + ellipsis', () => {
+    const long = 'X'.repeat(TEXT_LIMITS.DEDUP_STUB_CONTENT + 100);
+    const capped = capDedupText(long);
+    expect(capped).toBe('X'.repeat(TEXT_LIMITS.DEDUP_STUB_CONTENT) + '...');
+    expect(capped).not.toContain('X'.repeat(TEXT_LIMITS.DEDUP_STUB_CONTENT + 1));
+  });
+});
 
 describe('buildDedupedReferenceStub', () => {
   it('strips embeds/location/flags and folds the attachment marker into content', () => {

--- a/packages/common-types/src/utils/referenceEnrichment.ts
+++ b/packages/common-types/src/utils/referenceEnrichment.ts
@@ -127,6 +127,19 @@ export function stripBotVoiceAttachments(reference: ReferencedMessage): Referenc
 }
 
 /**
+ * The SINGLE truncation point for dedup-stub previews. Caps a TEXT preview to
+ * `DEDUP_STUB_CONTENT` (+ `…`). Applied to text ONLY — never to text-with-markers — so
+ * attachment markers (folded in separately, after this) can't eat the budget and squeeze
+ * the text to a misleading fragment. `formatDedupedQuote` renders the result as-is: every
+ * caller must cap here first (both `buildDedupedReferenceStub` and the stored-history path
+ * in `xmlMetadataFormatters.formatQuotedSection`).
+ */
+export function capDedupText(text: string): string {
+  const limit = TEXT_LIMITS.DEDUP_STUB_CONTENT;
+  return text.length > limit ? text.substring(0, limit) + '...' : text;
+}
+
+/**
  * Collapse a full reference into the minimal deduplicated stub: truncated
  * content (with attachment markers), no embeds/location. The stub keeps the
  * reference number — numbering is assigned before the dedup decision, so stubs
@@ -138,10 +151,12 @@ export function stripBotVoiceAttachments(reference: ReferencedMessage): Referenc
  * its rendered image description) is in the history the stub points at. The
  * marker's filename lets the model correlate the stub with that history entry.
  *
- * Contract: with attachments present the returned `content` can exceed
- * `DEDUP_STUB_CONTENT` (markers are prepended AFTER the text is truncated), so a
- * caller that treats it as final output must re-apply the limit. The prompt path
- * already does, via `formatDedupedQuote`.
+ * With attachments present the returned `content` can exceed `DEDUP_STUB_CONTENT`
+ * (markers are prepended AFTER the text is truncated) — that's intentional and FINAL:
+ * `formatDedupedQuote` renders it as-is. It must NOT re-apply the limit to the combined
+ * markers+text, or long image-filename markers eat the whole budget and squeeze the text
+ * hint to a misleading fragment (`I...` for `I got myself off…`). The text is capped here
+ * (this is the single truncation point); the markers are short metadata kept whole.
  */
 export function buildDedupedReferenceStub(reference: ReferencedMessage): ReferencedMessage {
   // Bot-authored stubs carry NO preview. A snippet of the model's own prior text
@@ -150,16 +165,12 @@ export function buildDedupedReferenceStub(reference: ReferencedMessage): Referen
   // reply-targets keep a short preview — genuine content the model may need.
   let content = '';
   if (!isBotAuthoredReference(reference)) {
-    const limit = TEXT_LIMITS.DEDUP_STUB_CONTENT;
-    const truncatedContent =
-      reference.content.length > limit
-        ? reference.content.substring(0, limit) + '...'
-        : reference.content;
-    // Markers go FIRST so they survive downstream re-truncation: formatDedupedQuote
-    // applies DEDUP_STUB_CONTENT to the COMBINED (markers + text) string and trims
-    // from the end, so the effective text budget there is DEDUP_STUB_CONTENT minus
-    // the marker length. Squeezing the text hint is acceptable — the full message
-    // (the thing the stub points at) is in history regardless; the marker is not.
+    const truncatedContent = capDedupText(reference.content);
+    // Markers go FIRST (before the truncated text). The text already has its FULL
+    // DEDUP_STUB_CONTENT budget above; markers are appended without eating it, because
+    // formatDedupedQuote renders this as-is (no second truncation). The full message the
+    // stub points at is in history regardless; the marker filenames are the correlation
+    // hint that must survive.
     const attachmentMarkers = (reference.attachments ?? [])
       .map(att => `[${att.contentType}: ${att.name ?? 'attachment'}]`)
       .join('\n');

--- a/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.test.ts
+++ b/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.test.ts
@@ -22,6 +22,9 @@ vi.mock('@tzurot/common-types', () => ({
   escapeXmlContent: (s: string) =>
     s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'),
   formatPromptTimestamp: (ts: string) => `formatted:${ts}`,
+  // Real capDedupText behavior (cap to DEDUP_STUB_CONTENT=100 + ellipsis). This is now the
+  // single truncation point for the stored deduped path; formatDedupedQuote renders as-is.
+  capDedupText: (text: string) => (text.length > 100 ? text.substring(0, 100) + '...' : text),
 }));
 
 // Mock QuoteFormatter - pass through to real implementation for structural tests
@@ -55,17 +58,18 @@ const { mockFormatQuoteElement, mockFormatDedupedQuote } = vi.hoisted(() => {
     return parts.join('\n');
   });
 
+  // Mirror the REAL formatDedupedQuote: render content AS-IS (no truncation). The cap now
+  // happens upstream in formatQuotedSection via the real capDedupText, so the
+  // "truncates long content" test below verifies THAT cap, not a mock-side truncation.
   const fdq = vi
     .fn()
     .mockImplementation(
       (opts: { from: string; role?: string; timeFormatted?: string; content: string }) => {
-        const truncated =
-          opts.content.length > 100 ? opts.content.substring(0, 100) + '...' : opts.content;
         return fqe({
           from: opts.from,
           role: opts.role,
           timeFormatted: opts.timeFormatted,
-          content: `[Referenced message — full text in <chat_log>]\n\n${truncated}`,
+          content: `[Referenced message — full text in <chat_log>]\n\n${opts.content}`,
         });
       }
     );

--- a/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.ts
+++ b/services/ai-worker/src/jobs/utils/xmlMetadataFormatters.ts
@@ -10,6 +10,7 @@ import {
   escapeXml,
   escapeXmlContent,
   formatPromptTimestamp,
+  capDedupText,
   type StoredReferencedMessage,
 } from '@tzurot/common-types';
 import { formatQuoteElement, formatDedupedQuote } from '../../services/prompt/QuoteFormatter.js';
@@ -128,7 +129,10 @@ export function formatQuotedSection(
         ref.timestamp !== undefined && ref.timestamp.length > 0
           ? formatPromptTimestamp(ref.timestamp)
           : undefined,
-      content: ref.content,
+      // Cap the stored text preview HERE (the single truncation point) — formatDedupedQuote
+      // renders as-is. Stored refs carry attachments separately (attachmentLines), so content
+      // is text-only and safe to cap directly.
+      content: capDedupText(ref.content),
     });
   });
 

--- a/services/ai-worker/src/services/prompt/QuoteFormatter.test.ts
+++ b/services/ai-worker/src/services/prompt/QuoteFormatter.test.ts
@@ -414,5 +414,20 @@ describe('QuoteFormatter', () => {
       expect(result).toContain('<content>[Referenced message — full text in <chat_log>]</content>');
       expect(result).toContain('role="assistant"');
     });
+
+    it('does NOT let long attachment markers truncate away the text preview', () => {
+      // Regression: a reply-target with two long image-filename markers + short text. The
+      // content is already text-capped upstream (buildDedupedReferenceStub); formatDedupedQuote
+      // must render it WHOLE — re-truncating the combined markers+text left a misleading "I..."
+      // that the model read as an unfinished sentence.
+      const content =
+        '[image/jpeg: SPOILER_PXL_20260701_221008932.jpg]\n' +
+        '[image/jpeg: SPOILER_PXL_20260701_222104453.jpg]\n\n' +
+        'I got myself off with this fucker';
+      const result = formatDedupedQuote({ from: 'Lila', role: 'user', content });
+      // The real text survives intact — no misleading 1-char "I..." fragment.
+      expect(result).toContain('I got myself off with this fucker');
+      expect(result).not.toContain('I...</content>');
+    });
   });
 });

--- a/services/ai-worker/src/services/prompt/QuoteFormatter.ts
+++ b/services/ai-worker/src/services/prompt/QuoteFormatter.ts
@@ -11,12 +11,7 @@
  * to provide context about the quote source.
  */
 
-import {
-  escapeXml,
-  escapeXmlContent,
-  TEXT_LIMITS,
-  type ReferenceAuthorRole,
-} from '@tzurot/common-types';
+import { escapeXml, escapeXmlContent, type ReferenceAuthorRole } from '@tzurot/common-types';
 
 /**
  * Options for formatting a single <quote> element.
@@ -195,23 +190,27 @@ export interface DedupedQuoteOptions {
   timestamp?: { absolute: string; relative: string };
   /** Pre-formatted timestamp as attribute */
   timeFormatted?: string;
-  /** Original message content (will be truncated). Empty → marker-only stub. */
+  /** Original message content, already text-capped upstream (`buildDedupedReferenceStub`).
+   *  Rendered as-is — NOT re-truncated here. Empty → marker-only stub. */
   content: string;
 }
 
 /**
- * Format a deduplicated reference as a lightweight <quote> stub.
- * Truncates content and prepends the reply-target note.
+ * Format a deduplicated reference as a lightweight <quote> stub. Renders the (already
+ * text-capped, via `capDedupText` at the caller) content as-is and prepends the reply-target
+ * note — does NOT truncate, so markers can't cannibalize the text preview.
  */
 export function formatDedupedQuote(opts: DedupedQuoteOptions): string {
-  const limit = TEXT_LIMITS.DEDUP_STUB_CONTENT;
-  const truncated =
-    opts.content.length > limit ? opts.content.substring(0, limit) + '...' : opts.content;
-
+  // Do NOT truncate here. `opts.content` is already TEXT-capped upstream by
+  // `buildDedupedReferenceStub` (it truncates the text to DEDUP_STUB_CONTENT, THEN prepends
+  // the attachment markers). Re-applying the limit to the COMBINED markers+text let long
+  // image-filename markers eat the whole budget, leaving a misleading 1-char text fragment
+  // (e.g. `I...` for `I got myself off…`) that the model reads as an unfinished sentence.
+  // The text is already bounded; the markers are short metadata that must survive intact.
   // Empty content (e.g. a bot's own reply-target) → marker only, no trailing blank.
   const content =
-    truncated.length > 0
-      ? `${DEDUP_REPLY_TARGET_PREFIX}\n\n${truncated}`
+    opts.content.length > 0
+      ? `${DEDUP_REPLY_TARGET_PREFIX}\n\n${opts.content}`
       : DEDUP_REPLY_TARGET_PREFIX;
 
   return formatQuoteElement({


### PR DESCRIPTION
## Symptom

Replying to a message that carries **2+ images**, the persona gets confused by the contextual reference — it renders the replied-to text as a bare `"I..."` and reads that truncation artifact as an unfinished sentence (*"The 'I...' is doing a lot of work"*), instead of the real message (`"I got myself off with this fucker"`), which was sitting in `<chat_log>` the whole time. Surfaced on a forwarded-message-being-replied-to (the forward's images render as filename markers).

## Root cause — double truncation

The reply-reference dedup stub is truncated **twice** against the same 100-char `DEDUP_STUB_CONTENT` budget:

1. `buildDedupedReferenceStub` (common-types) caps the **text** to 100, then prepends the image-filename markers.
2. `formatDedupedQuote` (ai-worker) then re-truncated the **combined markers+text** to 100 — and two 48-char image filenames (99 chars) ate the entire budget, leaving exactly one char (`"I"`) of the real text → `"I..."`.

The `referenceEnrichment.ts` comment explicitly bet the squeeze was "acceptable — the full message is in history." That bet breaks catastrophically once the attachment markers alone exceed the budget (any 2-image reply-target), turning the text into a misleading fragment.

## Fix

`formatDedupedQuote` renders the already-text-capped content **as-is** — no second truncation. The text keeps its full budget; the short markers survive intact. Regression test (`QuoteFormatter.test.ts`) covers the marker-heavy reply-target; the stale "must re-apply the limit" contract comments updated.

## Diagnosed from

The user's attached request debug JSON + system-prompt XML: `attachmentDescriptions: []`, `referencedMessagesContent` had the full text, but the assembled `<contextual_references>` quote showed `I...` — while `<chat_log>` line held the full `I got myself off with this fucker`. Confirmed the double-truncation by char-counting the markers against the 100 limit.

## Note (separate, filed follow-up territory)

The forwarded images weren't vision-described here (`attachmentDescriptions` empty) — the persona's image "description" was drawn from memory/history, not this forward. That's the RAG-family / forwarded-image-vision gap already tracked in `cold/follow-ups.md`, not part of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)