### PR TITLE
fix(bot-client): anchor /character echo ordering to the echo's real Discord time

### DIFF
--- a/services/bot-client/src/commands/character/chat.test.ts
+++ b/services/bot-client/src/commands/character/chat.test.ts
@@ -113,11 +113,15 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 describe('Character Chat Handler (push delivery)', () => {
   const mockConfig = { GATEWAY_URL: 'http://localhost:3000' } as EnvConfig;
 
+  // A distinctive createdAt so tests can assert the echo's REAL Discord time (not a
+  // pre-send new Date()) anchors both the user row and the assistant's userMessageTime.
+  const ECHO_CREATED_AT = new Date('2026-07-01T23:10:54.101Z');
   const createMockMessage = (id: string = 'user-msg-123') => ({
     id,
     client: { user: { id: 'bot-user-123' } },
     channel: { id: 'channel-123' },
     author: { id: 'user-123' },
+    createdAt: ECHO_CREATED_AT,
   });
 
   const createMockCollection = (entries: Array<[string, ReturnType<typeof createMockMessage>]>) => {
@@ -302,6 +306,30 @@ describe('Character Chat Handler (push delivery)', () => {
           characterSlug: 'test-char',
           isWeighInMode: false,
         })
+      );
+    });
+
+    it('anchors BOTH the user row and the assistant time to the echo’s real createdAt', async () => {
+      // Regression: userMessageTime was sampled with new Date() BEFORE the echo posted, so
+      // the user row + assistant landed ~80ms ahead of the echo's real snowflake and the
+      // extended-context merge could invert the pair. The user row's persisted timestamp AND
+      // the tracked userMessageTime must both equal the echo message's createdAt.
+      const channel = createMockChannel(ChannelType.GuildText);
+      const ctx = createMockContext('test-char', 'Hello!', channel);
+      mockPersonalityService.loadPersonality.mockResolvedValue(createMockPersonality());
+      mockGatewayClient.generate.mockResolvedValue({ jobId: 'job-1', requestId: 'req-1' });
+
+      await handleChat(ctx, mockConfig);
+
+      // User row persisted at the echo's createdAt (not a pre-send new Date()).
+      expect(mockConversationPersistence.saveUserMessageFromFields).toHaveBeenCalledWith(
+        expect.objectContaining({ timestamp: ECHO_CREATED_AT })
+      );
+      // Assistant ordering (userMessageTime) anchored to the same echo createdAt → +1ms lands
+      // just after the user row, consistent with the real Discord timeline.
+      expect(mockJobTracker.trackJob).toHaveBeenCalledWith(
+        'job-1',
+        expect.objectContaining({ userMessageTime: ECHO_CREATED_AT })
       );
     });
 

--- a/services/bot-client/src/commands/character/chat.ts
+++ b/services/bot-client/src/commands/character/chat.ts
@@ -209,8 +209,6 @@ interface SendUserMessageParams {
   personality: LoadedPersonality;
   personaId: string;
   guildId: string | null;
-  /** Timestamp for ensuring user < assistant ordering */
-  timestamp: Date;
 }
 
 /**
@@ -218,14 +216,19 @@ interface SendUserMessageParams {
  * Returns the Message object for context building and trigger tracking.
  */
 async function sendAndPersistUserMessage(params: SendUserMessageParams): Promise<Message> {
-  const { channel, displayName, message, personality, personaId, guildId, timestamp } = params;
+  const { channel, displayName, message, personality, personaId, guildId } = params;
 
   const userMsg = await channel.send(`**${displayName}:** ${message}`);
 
   // Fire-and-forget persistence: Trade-off between responsiveness and guaranteed persistence.
   // If save fails (DB issues), the Discord message is still sent but won't be in history.
   // This matches the @mention pattern and prioritizes UX over perfect data consistency.
-  // Pass explicit timestamp to ensure user message < assistant message ordering.
+  //
+  // Persist at the ECHO's own Discord createdAt so the stored row's timestamp equals its
+  // snowflake time. The caller anchors the assistant row to echo.createdAt + 1ms, so the pair
+  // stays ordered (user < assistant) AND consistent with the real Discord timeline — a
+  // pre-send timestamp would land the pair ahead of the echo's snowflake and let the
+  // extended-context merge (which sees the echo at its real snowflake time) invert them.
   void getConversationPersistence()
     .saveUserMessageFromFields({
       channelId: channel.id,
@@ -234,7 +237,7 @@ async function sendAndPersistUserMessage(params: SendUserMessageParams): Promise
       personality,
       personaId,
       messageContent: message,
-      timestamp,
+      timestamp: userMsg.createdAt,
     })
     .catch(err => {
       logger.warn({ err, messageId: userMsg.id }, 'Failed to save user message');
@@ -490,10 +493,9 @@ async function runCharacterTurn(
     // 5. Replace the deferred "thinking..." indicator before sending messages.
     await finalizeDeferredReply(context, personality, isRandomPick);
 
-    // Capture timestamp for conversation ordering (user message < assistant message)
-    const userMessageTime = new Date();
-
-    // 6. Get a Discord Message object to use for context building with extended context
+    // 6. Get a Discord Message object to use for context building with extended context.
+    //    For a non-weigh-in turn this posts the echo, whose real Discord timestamp anchors
+    //    conversation ordering (see userMessageTime below).
     const anchorResult = await getAnchorMessage(
       channel,
       isWeighInMode,
@@ -506,7 +508,6 @@ async function runCharacterTurn(
             personality,
             personaId: userContext.personaId,
             guildId: context.guild?.id ?? null,
-            timestamp: userMessageTime,
           }
     );
 
@@ -515,6 +516,15 @@ async function runCharacterTurn(
       return;
     }
     const anchorMessage = anchorResult.message;
+
+    // Anchor conversation ordering to the echo's REAL Discord post time — NOT a pre-send
+    // new Date(). The user row is persisted at the echo's createdAt (inside getAnchorMessage);
+    // the assistant row derives echo.createdAt + 1ms. Sampling the time BEFORE the echo posted
+    // stamped both rows ~80ms ahead of the echo's real snowflake, which the extended-context
+    // merge — it sorts DB rows against bot-observed snapshot rows by their real snowflake time —
+    // could then invert (assistant before user). Weigh-in posts no echo (synthetic anchor), so
+    // it falls back to now(); there's no user row to order against there.
+    const userMessageTime = isWeighInMode ? new Date() : anchorMessage.createdAt;
 
     // 7. Build full context with command invoker's identity (not anchor message author)
     const messageContent = isWeighInMode ? WEIGH_IN_MESSAGE : message;


### PR DESCRIPTION
## Symptom

`/character random` (and `/character chat`) with a message renders the user's text via a bot echo. In the AI's `<chat_log>`, the user message ends up **after** the AI's reply — the persona reads its own answer before the question (e.g. Katie's disoriented *"gestures vaguely at the chat log …whatever THIS is"*). The visual Discord order is correct; only the *stored* history order is inverted.

## Root cause (confirmed against prod)

The echo path persists a user row + an assistant row (`userMessageTime + 1ms`) to anchor ordering. But `userMessageTime` was sampled with `new Date()` **before** the echo posted, so both rows landed ~80ms *ahead* of the echo's real Discord snowflake:

```
user  createdAt 23:10:54.019   (echo snowflake 23:10:54.101)
asst  createdAt 23:10:54.020   (userMessageTime + 1ms)
```

Inside the DB that's fine (user < assistant by 1ms). But `historyMerger` sorts DB rows against **bot-observed snapshot rows** purely by `createdAt.getTime()`, and the snapshot copy of the echo carries its **real snowflake** (54.101). When the user is represented by 54.101 and the assistant by its anchored 54.020, the assistant sorts first → the inversion. A normally-typed message never hits this because the user's `createdAt` *is* its real snowflake.

## Fix

Persist the user row at the **echo's own `createdAt`** and anchor `userMessageTime` to it, so the stored time equals the snowflake and the `+1ms` assistant lands just after — consistent whether the merge reads the DB row or the snapshot. Weigh-in (`chime-in` / no-message) posts no echo and keeps the `now()` fallback. The fix is at the shared `runCharacterTurn` / `sendAndPersistUserMessage` layer, so **chat + random both inherit it**.

A seam test (`chat.test.ts`) asserts both the user-row persist and the tracked `userMessageTime` receive the echo's `createdAt` — the mocked seam this bug lived in.

## Diagnosis note

Found by querying prod `conversation_history` (read-only, user-approved) after the code path *looked* correct — the persistence write is fine; the read-path merge exposed the latent pre-echo-timestamp inconsistency. Classic code-reading-isn't-runtime case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)