### PR TITLE
fix(common-types): harden the main pool — keepAlive + idle eviction + safe lock_timeout

### DIFF
--- a/packages/common-types/src/services/poolConfig.test.ts
+++ b/packages/common-types/src/services/poolConfig.test.ts
@@ -6,9 +6,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   DB_POOL_DEFAULTS,
   FAST_POOL_DEFAULTS,
+  MAIN_POOL_DEFAULTS,
   resolvePoolMax,
   resolveConnectionTimeoutMs,
   resolvePoolStatsIntervalMs,
+  resolveMainLockTimeoutMs,
+  mainPoolConnectionOptions,
   resolveFastPoolMax,
   resolveFastLockTimeoutMs,
   resolveFastStatementTimeoutMs,
@@ -68,6 +71,36 @@ describe('transientPoolOptions', () => {
       max: DB_POOL_DEFAULTS.TRANSIENT_MAX,
       connectionTimeoutMillis: 2000,
     });
+  });
+});
+
+describe('mainPoolConnectionOptions', () => {
+  it('builds keepAlive + explicit idle eviction + the lock_timeout GUC with defaults', () => {
+    expect(mainPoolConnectionOptions({})).toEqual({
+      keepAlive: true,
+      keepAliveInitialDelayMillis: MAIN_POOL_DEFAULTS.KEEPALIVE_INITIAL_DELAY_MS,
+      idleTimeoutMillis: MAIN_POOL_DEFAULTS.IDLE_TIMEOUT_MS,
+      options: `-c lock_timeout=${MAIN_POOL_DEFAULTS.LOCK_TIMEOUT_MS}`,
+    });
+  });
+
+  it('deliberately sets NO statement_timeout (legit long ops stay exempt)', () => {
+    // The main pool serves pgvector search / Shapes import / retention batches;
+    // a pool-wide statement ceiling would clip them — that exemption is the
+    // reason the fast pool exists as a separate pool.
+    expect(mainPoolConnectionOptions({}).options).not.toContain('statement_timeout');
+  });
+
+  it('honors a DB_MAIN_LOCK_TIMEOUT_MS override and falls back on garbage', () => {
+    expect(mainPoolConnectionOptions({ DB_MAIN_LOCK_TIMEOUT_MS: '5000' }).options).toBe(
+      '-c lock_timeout=5000'
+    );
+    expect(resolveMainLockTimeoutMs({ DB_MAIN_LOCK_TIMEOUT_MS: 'nope' })).toBe(
+      MAIN_POOL_DEFAULTS.LOCK_TIMEOUT_MS
+    );
+    expect(resolveMainLockTimeoutMs({ DB_MAIN_LOCK_TIMEOUT_MS: '0' })).toBe(
+      MAIN_POOL_DEFAULTS.LOCK_TIMEOUT_MS
+    );
   });
 });
 

--- a/packages/common-types/src/services/poolConfig.ts
+++ b/packages/common-types/src/services/poolConfig.ts
@@ -79,6 +79,35 @@ export const FAST_POOL_DEFAULTS = {
   KEEPALIVE_INITIAL_DELAY_MS: 1_000,
 } as const;
 
+/**
+ * Main-pool hardening defaults. The fast pool (persist writes) got the full
+ * timeout ladder + keepAlive + retry in its own incident cycle; the MAIN pool —
+ * every other query in every service — had none of it, so its failures were
+ * silent: a query on a network-reaped socket hangs to the caller's HTTP abort,
+ * and a lock wait has no ceiling. Observed shape: a personality routing-load
+ * took ~20s (a fresh-connection TCP stall after an idle-quiet period), which
+ * bot-client's ~3s abort turned into a silently dropped @mention.
+ *
+ * Deliberately NO `statement_timeout` here: the main pool serves legitimately
+ * long operations (pgvector search, Shapes import/export, retention batches)
+ * that a pool-wide ceiling would clip — that exemption-by-architecture is the
+ * reason the fast pool exists as a separate pool at all. `lock_timeout` IS safe
+ * pool-wide: a healthy op waits micro-to-milliseconds for locks; 3s of lock
+ * waiting means contention that should fail loudly + self-label (SQLSTATE
+ * 55P03) rather than stack up invisibly.
+ */
+export const MAIN_POOL_DEFAULTS = {
+  /** Server GUC. Safe pool-wide: legit ops don't wait seconds on locks; a 55P03
+   *  names the cause instead of an unbounded invisible queue. */
+  LOCK_TIMEOUT_MS: 3_000,
+  /** Evict idle connections on our schedule (pg-pool's own default, made
+   *  explicit) — paired with keepAlive so a retained idle socket is genuinely
+   *  alive, not a middlebox-reaped husk waiting to hang the next query. */
+  IDLE_TIMEOUT_MS: 10_000,
+  /** TCP keepalive first-probe delay — the fast pool's proven value. */
+  KEEPALIVE_INITIAL_DELAY_MS: 1_000,
+} as const;
+
 /** Parse a non-negative integer env var, falling back when unset/invalid. */
 function parseIntEnv(value: string | undefined, fallback: number, minimum: number): number {
   const parsed = Number.parseInt(value ?? '', 10);
@@ -114,6 +143,36 @@ export function transientPoolOptions(env: NodeJS.ProcessEnv = process.env): {
   return {
     max: DB_POOL_DEFAULTS.TRANSIENT_MAX,
     connectionTimeoutMillis: resolveConnectionTimeoutMs(env),
+  };
+}
+
+/** Resolve the main-pool server-side `lock_timeout` in ms (≥ 1). */
+export function resolveMainLockTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
+  return parseIntEnv(env.DB_MAIN_LOCK_TIMEOUT_MS, MAIN_POOL_DEFAULTS.LOCK_TIMEOUT_MS, 1);
+}
+
+/**
+ * Main-pool hardening options, applied as the BASE pool config for every
+ * `createPrismaClient` pool (fast-pool `poolOverrides` spread after this, so
+ * its tighter ladder — including its own `options` string — fully wins there).
+ *
+ * Same pooler caveat as the fast pool: the `lock_timeout` GUC rides the
+ * Postgres `options` startup string, which a fronting pooler (PgBouncer
+ * txn-mode etc.) may strip. Unlike the fast pool there is NO boot-fail probe
+ * here — losing the label reverts to the status quo (no ceiling), not to a
+ * regression, so a stripped GUC is acceptable degradation.
+ */
+export function mainPoolConnectionOptions(env: NodeJS.ProcessEnv = process.env): {
+  keepAlive: true;
+  keepAliveInitialDelayMillis: number;
+  idleTimeoutMillis: number;
+  options: string;
+} {
+  return {
+    keepAlive: true,
+    keepAliveInitialDelayMillis: MAIN_POOL_DEFAULTS.KEEPALIVE_INITIAL_DELAY_MS,
+    idleTimeoutMillis: MAIN_POOL_DEFAULTS.IDLE_TIMEOUT_MS,
+    options: `-c lock_timeout=${resolveMainLockTimeoutMs(env)}`,
   };
 }
 

--- a/packages/common-types/src/services/prisma.test.ts
+++ b/packages/common-types/src/services/prisma.test.ts
@@ -42,6 +42,13 @@ vi.mock('./poolConfig.js', () => ({
   resolvePoolMax: mockResolvePoolMax,
   resolveConnectionTimeoutMs: vi.fn(() => 10_000),
   resolvePoolStatsIntervalMs: vi.fn(() => 0),
+  // Mirror the real shape: keepAlive + explicit idle eviction + the lock_timeout GUC.
+  mainPoolConnectionOptions: vi.fn(() => ({
+    keepAlive: true,
+    keepAliveInitialDelayMillis: 1000,
+    idleTimeoutMillis: 10_000,
+    options: '-c lock_timeout=3000',
+  })),
   startPoolStatsGauge: mockStartGauge,
 }));
 
@@ -67,6 +74,18 @@ describe('createPrismaClient', () => {
     expect(Pool).toHaveBeenCalledWith(expect.objectContaining({ max: 5 }));
   });
 
+  it('applies the main-pool hardening as the base config by default', () => {
+    createPrismaClient();
+    expect(Pool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        keepAlive: true,
+        keepAliveInitialDelayMillis: 1000,
+        idleTimeoutMillis: 10_000,
+        options: '-c lock_timeout=3000',
+      })
+    );
+  });
+
   it('spreads poolOverrides into the Pool config (fast-pool timeouts + GUC options)', () => {
     createPrismaClient({
       max: 5,
@@ -76,6 +95,8 @@ describe('createPrismaClient', () => {
         options: '-c statement_timeout=5000 -c lock_timeout=2000',
       },
     });
+    // The fast pool's own `options` string must fully REPLACE the main-pool base
+    // one — spread order is the seam that keeps its tighter ladder authoritative.
     expect(Pool).toHaveBeenCalledWith(
       expect.objectContaining({
         max: 5,

--- a/packages/common-types/src/services/prisma.ts
+++ b/packages/common-types/src/services/prisma.ts
@@ -18,6 +18,7 @@ import {
   resolvePoolMax,
   resolveConnectionTimeoutMs,
   resolvePoolStatsIntervalMs,
+  mainPoolConnectionOptions,
   startPoolStatsGauge,
 } from './poolConfig.js';
 
@@ -72,12 +73,16 @@ export function createPrismaClient(opts?: CreatePrismaClientOptions): PrismaClie
   // and starves under load. See poolConfig.ts for the full rationale.
   const max = opts?.max ?? resolvePoolMax();
   const connectionTimeoutMillis = resolveConnectionTimeoutMs();
-  // poolOverrides spread LAST so the fast pool can override connectionTimeoutMillis
-  // and add query_timeout/keepAlive/options without disturbing the main-pool path.
+  // Base config carries the main-pool hardening (keepAlive + explicit idle
+  // eviction + a safe pool-wide lock_timeout — see mainPoolConnectionOptions).
+  // poolOverrides spread LAST so the fast pool can override any of it: its
+  // tighter ladder, keepAlive knobs, and its own `options` GUC string fully
+  // replace the base values without disturbing every other pool.
   const pool = new Pool({
     connectionString: dbUrl,
     max,
     connectionTimeoutMillis,
+    ...mainPoolConnectionOptions(),
     ...opts?.poolOverrides,
   });
   pool.on('error', err => {


### PR DESCRIPTION
## Why

The recurring perf-fire family is the **connection/network layer**, not data volume — prod measurements (read-only, user-approved): DB **422 MB total**, no bloat, 7/100 connections. Nothing in this database can take 20 seconds. Yet a prod `@Ha-Shem` mention was silently dropped when the gateway's personality routing-load took ~20s after an idle-quiet period (slow-then-*succeeds* — the shape a dead socket or a slow query can't produce; the leading **hypothesis** is a fresh-connect TCP stall, not yet runtime-confirmed).

This promotes the deferred `cold/follow-ups.md` main-pool-hardening entry — its trigger ("a non-persist query observed hanging") has now fired. The fast pool (persist writes) already got this medicine in beta.138/.143; the main pool had none of it.

**Scope honesty**: this PR is **defense-in-depth for the connection-layer family**, not a targeted fix for the (hypothesized) fresh-connect SYN-stall mechanism — keepAlive protects *established* idle sockets from becoming reaped husks (the runtime-confirmed beta.143 failure mode); it does not speed up a brand-new handshake. A follow-up adds connect-event observability so the next stall self-identifies its mechanism, and can then tune idle retention if fresh-connect frequency is the confirmed driver.

## What

Every **`createPrismaClient`** pool now gets, as base config (fast-pool `poolOverrides` still spread last and fully win there):

- **`keepAlive: true`** (1s first probe) — retained idle sockets stay genuinely alive instead of becoming middlebox-reaped husks
- **explicit `idleTimeoutMillis: 10s`** — pg-pool's default made deliberate + documented
- **`lock_timeout=3s`** via the proven `options` GUC-string mechanism (env-tunable: `DB_MAIN_LOCK_TIMEOUT_MS`) — lock waits self-label (SQLSTATE 55P03) instead of stacking invisibly
- **deliberately NO `statement_timeout`** — per the original council ruling, legit long ops (pgvector search, Shapes import/export, retention batches) stay exempt by architecture

Not covered (intentionally): the two one-shot `PrismaPg`-direct constructions (`dbSync.ts`, tooling `prisma-env.ts`) — short-lived pools that are created and torn down within one operation never idle long enough to hit the reaped-socket mode.

No boot-fail probe for the main-pool GUC (unlike the fast pool): a pooler stripping it reverts to the status quo (no ceiling), not to a regression — acceptable degradation, noted in the JSDoc.

## Tests

- `mainPoolConnectionOptions` defaults / env override / garbage fallback, plus an explicit "NO statement_timeout" invariant test
- `createPrismaClient` seam tests: base config carries the hardening; fast-pool `poolOverrides` (incl. its own `options` string) fully replace it
- Full common-types suite green (2306 tests), `pnpm quality` green

## Follow-up (filed to `backlog/now.md`, next-release scope)

Connect-event observability (`pool.on('connect')` info log so the next stall self-identifies fresh-connect vs other) + verify long batch ops (import/retention) commit in chunks so the pool-wide `lock_timeout=3s` can't fail a concurrent waiter blocked by a legit long-held lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)