### PR TITLE
fix(api-gateway): pool connect log + per-batch retention transactions

### DIFF
--- a/packages/common-types/src/services/prisma.test.ts
+++ b/packages/common-types/src/services/prisma.test.ts
@@ -86,6 +86,18 @@ describe('createPrismaClient', () => {
     );
   });
 
+  it('registers a connect handler that logs pool stats (the stall-diagnosis signal)', () => {
+    createPrismaClient();
+    // Invoke the captured 'connect' callback — the log line IS the deliverable
+    // (a connect event landing seconds into a slow request confirms the
+    // fresh-connect stall mechanism), so assert the handler executes and reads
+    // the pool counters without throwing, not just that it was registered.
+    const connectCall = mockPool.on.mock.calls.find(([event]) => event === 'connect');
+    expect(connectCall).toBeDefined();
+    const handler = connectCall?.[1] as () => void;
+    expect(() => handler()).not.toThrow();
+  });
+
   it('spreads poolOverrides into the Pool config (fast-pool timeouts + GUC options)', () => {
     createPrismaClient({
       max: 5,

--- a/packages/common-types/src/services/prisma.ts
+++ b/packages/common-types/src/services/prisma.ts
@@ -88,6 +88,19 @@ export function createPrismaClient(opts?: CreatePrismaClientOptions): PrismaClie
   pool.on('error', err => {
     logger.error({ err }, 'pg.Pool idle-client error');
   });
+  // Connect-event observability: a fresh physical connection is the suspect in the
+  // slow-then-succeeds stall family (a new handshake can ride a network blip into
+  // SYN-retransmit backoff, which keepAlive cannot prevent). One INFO line per
+  // connect means the next slow request self-identifies its mechanism from logs
+  // alone: a connect line landing seconds after the request started = fresh-connect
+  // stall CONFIRMED; no connect line = the stall is elsewhere. Low volume — the
+  // pool only dials after idle eviction or growth, not per query.
+  pool.on('connect', () => {
+    logger.info(
+      { total: pool.totalCount, idle: pool.idleCount, waiting: pool.waitingCount },
+      'pg.Pool established a new connection'
+    );
+  });
   const stopGauge = startPoolStatsGauge(pool, logger, resolvePoolStatsIntervalMs(), max);
 
   // The pool + stats gauge are now live; if client construction throws past

--- a/services/api-gateway/src/services/ConversationRetentionService.test.ts
+++ b/services/api-gateway/src/services/ConversationRetentionService.test.ts
@@ -82,8 +82,6 @@ describe('ConversationRetentionService', () => {
         where: { channelId: 'channel-123', personalityId: 'personality-456' },
         select: { id: true, channelId: true, personalityId: true, personaId: true },
         take: 1000, // SYNC_LIMITS.RETENTION_BATCH_SIZE
-        skip: 0,
-        cursor: undefined,
         orderBy: { id: 'asc' },
       });
       expect(mockPrismaClient.conversationHistoryTombstone.createMany).toHaveBeenCalledWith({
@@ -109,6 +107,44 @@ describe('ConversationRetentionService', () => {
       expect(count).toBe(0);
       expect(mockPrismaClient.conversationHistoryTombstone.createMany).not.toHaveBeenCalled();
       expect(mockPrismaClient.conversationHistory.deleteMany).not.toHaveBeenCalled();
+    });
+
+    it('processes multiple batches, each in its OWN transaction (lock-release seam)', async () => {
+      // The crux of the per-batch rework: a full-size batch means "keep going", and
+      // each iteration commits its own transaction so row locks release between
+      // batches (a sweep-wide transaction + the pool's lock_timeout would 55P03
+      // concurrent writers for the whole sweep).
+      const fullBatch = Array.from({ length: 1000 }, (_, i) => ({
+        id: `msg-${i}`,
+        channelId: 'channel-123',
+        personalityId: 'personality-456',
+        personaId: 'persona-1',
+      }));
+      const shortBatch = [
+        {
+          id: 'msg-last',
+          channelId: 'channel-123',
+          personalityId: 'personality-456',
+          personaId: 'persona-1',
+        },
+      ];
+      mockPrismaClient.conversationHistory.findMany
+        .mockResolvedValueOnce(fullBatch)
+        .mockResolvedValueOnce(shortBatch);
+      mockPrismaClient.conversationHistory.deleteMany
+        .mockResolvedValueOnce({ count: 1000 })
+        .mockResolvedValueOnce({ count: 1 });
+      mockPrismaClient.conversationHistoryTombstone.createMany.mockResolvedValue({ count: 0 });
+
+      const count = await service.clearHistory('channel-123', 'personality-456');
+
+      expect(count).toBe(1001);
+      // One transaction PER batch — the lock-release boundary this rework exists for.
+      expect(mockPrismaClient.$transaction).toHaveBeenCalledTimes(2);
+      expect(mockPrismaClient.conversationHistoryTombstone.createMany).toHaveBeenCalledTimes(2);
+      expect(mockPrismaClient.conversationHistory.deleteMany).toHaveBeenNthCalledWith(2, {
+        where: { id: { in: ['msg-last'] } },
+      });
     });
 
     it('should throw error on database failure', async () => {
@@ -144,8 +180,6 @@ describe('ConversationRetentionService', () => {
         },
         select: { id: true, channelId: true, personalityId: true, personaId: true },
         take: 1000,
-        skip: 0,
-        cursor: undefined,
         orderBy: { id: 'asc' },
       });
     });
@@ -225,8 +259,6 @@ describe('ConversationRetentionService', () => {
         where: { createdAt: { lt: expectedCutoff } },
         select: { id: true, channelId: true, personalityId: true, personaId: true },
         take: 1000,
-        skip: 0,
-        cursor: undefined,
         orderBy: { id: 'asc' },
       });
     });

--- a/services/api-gateway/src/services/ConversationRetentionService.ts
+++ b/services/api-gateway/src/services/ConversationRetentionService.ts
@@ -21,63 +21,65 @@ const logger = createLogger('ConversationRetentionService');
 
 /**
  * Delete messages matching the where clause and create tombstones to prevent db-sync restoration.
- * Uses cursor-based pagination to process in batches and prevent OOM on large datasets.
+ * Processes in batches to prevent OOM on large datasets.
+ *
+ * Atomicity is PER BATCH — each batch's tombstone-create + delete commits in its own
+ * transaction, releasing row locks between batches. A single sweep-wide transaction
+ * would hold every deleted row's lock until the final commit, and the main pool's
+ * `lock_timeout` (3s) would then fail any concurrent writer waiting on one of those
+ * rows for the whole sweep duration. Cross-batch atomicity is not needed: a partial
+ * sweep just leaves rows for the next run, and the tombstone-before-delete invariant
+ * (the thing that actually matters for db-sync) holds within each batch. No cursor
+ * needed — each committed batch removes its rows from the `where` result set, so a
+ * plain re-fetch naturally advances.
  */
 async function deleteMessagesWithTombstones(
-  tx: Prisma.TransactionClient,
+  prisma: PrismaClient,
   where: Prisma.ConversationHistoryWhereInput
 ): Promise<number> {
   let totalDeleted = 0;
-  let cursor: string | undefined;
 
   while (true) {
-    // Fetch a batch of messages to delete using cursor-based pagination
-    const batch = await tx.conversationHistory.findMany({
-      where,
-      select: {
-        id: true,
-        channelId: true,
-        personalityId: true,
-        personaId: true,
-      },
-      take: SYNC_LIMITS.RETENTION_BATCH_SIZE,
-      skip: cursor !== undefined ? 1 : 0,
-      cursor: cursor !== undefined ? { id: cursor } : undefined,
-      orderBy: { id: 'asc' },
+    const fetched = await prisma.$transaction(async tx => {
+      const batch = await tx.conversationHistory.findMany({
+        where,
+        select: {
+          id: true,
+          channelId: true,
+          personalityId: true,
+          personaId: true,
+        },
+        take: SYNC_LIMITS.RETENTION_BATCH_SIZE,
+        orderBy: { id: 'asc' },
+      });
+
+      if (batch.length === 0) {
+        return 0;
+      }
+
+      // Create tombstones for this batch BEFORE deleting — prevents db-sync
+      // from restoring the rows if it runs between batches.
+      await tx.conversationHistoryTombstone.createMany({
+        data: batch.map(msg => ({
+          id: msg.id,
+          channelId: msg.channelId,
+          personalityId: msg.personalityId,
+          personaId: msg.personaId,
+        })),
+        skipDuplicates: true, // In case tombstone already exists
+      });
+
+      const deleteResult = await tx.conversationHistory.deleteMany({
+        where: { id: { in: batch.map(msg => msg.id) } },
+      });
+      totalDeleted += deleteResult.count;
+      return batch.length;
     });
 
-    if (batch.length === 0) {
+    // A short batch means the where-set is drained.
+    if (fetched < SYNC_LIMITS.RETENTION_BATCH_SIZE) {
       break;
     }
-
-    const batchIds = batch.map(msg => msg.id);
-
-    // Create tombstones for this batch
-    // This prevents db-sync from restoring them
-    await tx.conversationHistoryTombstone.createMany({
-      data: batch.map(msg => ({
-        id: msg.id,
-        channelId: msg.channelId,
-        personalityId: msg.personalityId,
-        personaId: msg.personaId,
-      })),
-      skipDuplicates: true, // In case tombstone already exists
-    });
-
-    // Delete this batch of messages
-    const deleteResult = await tx.conversationHistory.deleteMany({
-      where: { id: { in: batchIds } },
-    });
-
-    totalDeleted += deleteResult.count;
-
-    // If we got less than batch size, we're done
-    if (batch.length < SYNC_LIMITS.RETENTION_BATCH_SIZE) {
-      break;
-    }
-
-    // Move cursor to last processed ID
-    cursor = batch[batch.length - 1].id;
   }
 
   return totalDeleted;
@@ -93,6 +95,12 @@ export class ConversationRetentionService {
    *
    * Creates tombstone records for deleted messages to prevent db-sync from
    * restoring them. Tombstones are small (just IDs) and can be periodically purged.
+   *
+   * NOT atomic end-to-end: deletion commits per batch (see
+   * deleteMessagesWithTombstones), so a mid-sweep failure leaves a partial
+   * delete — already-deleted rows stay tombstoned, and a retry picks up the
+   * remainder. Chosen over all-or-nothing so a large clear can't hold row
+   * locks across the whole sweep.
    *
    * @param channelId Channel ID
    * @param personalityId Personality ID
@@ -110,7 +118,7 @@ export class ConversationRetentionService {
         ...(personaId !== undefined && personaId.length > 0 && { personaId }),
       };
 
-      const count = await this.prisma.$transaction(tx => deleteMessagesWithTombstones(tx, where));
+      const count = await deleteMessagesWithTombstones(this.prisma, where);
 
       logger.info(
         {
@@ -141,9 +149,9 @@ export class ConversationRetentionService {
       const cutoffDate = new Date();
       cutoffDate.setDate(cutoffDate.getDate() - daysToKeep);
 
-      const count = await this.prisma.$transaction(tx =>
-        deleteMessagesWithTombstones(tx, { createdAt: { lt: cutoffDate } })
-      );
+      const count = await deleteMessagesWithTombstones(this.prisma, {
+        createdAt: { lt: cutoffDate },
+      });
 
       logger.info({ count, daysToKeep }, 'Cleaned up old messages with tombstones');
       return count;


### PR DESCRIPTION
## What

The two halves of the main-pool follow-through Quick Win (from #1433's review, user-flagged next-release):

1. **Connect-event observability** — `pool.on('connect')` INFO log (with pool totals) in `createPrismaClient`. The fresh-connect TCP stall is the *unconfirmed hypothesis* for the 20s personality-load; this line makes the next occurrence self-identify: a connect line landing seconds into a slow request confirms the mechanism, its absence refutes it. Low volume — the pool only dials after idle eviction or growth.

2. **Per-batch retention transactions** — the review's lock-chunking verification found a real issue: `deleteMessagesWithTombstones`'s `while(true)` batch loop ran inside ONE `$transaction`, holding every deleted row's lock until the final commit. With #1433's pool-wide `lock_timeout=3s`, a concurrent writer waiting on any of those rows would 55P03 for the sweep's whole duration. Now each batch commits its own transaction: the tombstone-before-delete invariant (what db-sync actually needs) holds within each batch, locks release between batches, and the cursor pagination collapses to plain re-fetch (each committed batch removes its rows from the `where`-set). This matters more once the automated-cleanup Quick Win makes sweeps regular.

## Tests

Retention tests updated for the new query shape (pagination params removed — assertion maintenance for an intentional behavior change, all 17 green). Common-types pool tests unaffected (9 green). `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)