### PR TITLE
fix(bot-client): preset toggle keeps back-button; import/export round-trips isGlobal

### DIFF
--- a/services/bot-client/src/commands/preset/dashboardButtons.test.ts
+++ b/services/bot-client/src/commands/preset/dashboardButtons.test.ts
@@ -9,6 +9,7 @@ import {
   buildPresetDashboardOptions,
   handleCloseButton,
   handleRefreshButton,
+  handleToggleGlobalButton,
   handleDeleteButton,
   handleConfirmDeleteButton,
   handleCancelDeleteButton,
@@ -493,6 +494,34 @@ describe('Preset Dashboard Buttons', () => {
             browseContext: undefined,
           }),
         })
+      );
+    });
+  });
+
+  describe('handleToggleGlobalButton', () => {
+    it('preserves browseContext across the toggle re-render (Back-to-Browse survives)', async () => {
+      // Regression: the toggle rebuilt session data from the API response alone,
+      // dropping browseContext — showBack derives from it, so the re-rendered
+      // dashboard lost its Back-to-Browse button after Make Global/Private.
+      const mockInteraction = createMockButtonInteraction('preset::toggle-global::preset-123');
+      const browseContext = { source: 'browse' as const, page: 2, filter: 'mine' };
+
+      // *Once so the shared default implementations survive for later tests —
+      // a plain mockResolvedValue permanently replaces them and leaks.
+      mockRequireDeferredSession.mockResolvedValueOnce({
+        data: createMockFlattenedPreset({ isGlobal: false, browseContext }),
+      });
+      mockFetchPreset.mockResolvedValueOnce(createMockPresetResponse({ isGlobal: false }));
+      mockUpdatePreset.mockResolvedValueOnce(createMockPresetResponse({ isGlobal: true }));
+
+      await handleToggleGlobalButton(mockInteraction, 'preset-123');
+
+      // The seam assertion: the session update must carry browseContext through.
+      expect(mockSessionManager.update).toHaveBeenCalledWith(
+        expect.any(String),
+        'preset',
+        'preset-123',
+        expect.objectContaining({ browseContext })
       );
     });
   });

--- a/services/bot-client/src/commands/preset/dashboardButtons.ts
+++ b/services/bot-client/src/commands/preset/dashboardButtons.ts
@@ -173,7 +173,13 @@ export async function handleToggleGlobalButton(
     const newIsGlobal = !freshPreset.isGlobal;
     const updatedPreset = await updatePreset(entityId, { isGlobal: newIsGlobal }, userClient);
 
-    const flattenedData = flattenPresetData(updatedPreset);
+    // Preserve browseContext from the existing session (same pattern as the refresh
+    // handler above) — rebuilding from the API response alone drops it, and the
+    // re-render then loses the Back-to-Browse button (showBack derives from it).
+    const flattenedData: FlattenedPresetData = {
+      ...flattenPresetData(updatedPreset),
+      browseContext: session.data.browseContext,
+    };
     const sessionManager = getSessionManager();
 
     await sessionManager.update<FlattenedPresetData>(

--- a/services/bot-client/src/commands/preset/export.test.ts
+++ b/services/bot-client/src/commands/preset/export.test.ts
@@ -122,6 +122,25 @@ describe('Preset Export', () => {
       expect(editReplyArgs.files).toHaveLength(1);
     });
 
+    it('includes isGlobal in the exported JSON (visibility round-trip)', async () => {
+      stub.getUserLlmConfig.mockResolvedValue(
+        makeOk({ config: { ...mockPresetData, isGlobal: true } })
+      );
+
+      const mockContext = createMockContext();
+      await handleExport(mockContext);
+
+      const editReplyArgs = vi.mocked(mockContext.editReply).mock.calls[0][0] as {
+        files: AttachmentBuilder[];
+      };
+      // Parse the actual attachment payload — the flag must survive into the file
+      // so /preset import can round-trip visibility.
+      const json = JSON.parse(String(editReplyArgs.files[0].attachment)) as {
+        isGlobal?: boolean;
+      };
+      expect(json.isGlobal).toBe(true);
+    });
+
     it('should include advanced parameters in export', async () => {
       const presetWithAdvancedParams = {
         ...mockPresetData,

--- a/services/bot-client/src/commands/preset/export.ts
+++ b/services/bot-client/src/commands/preset/export.ts
@@ -14,10 +14,18 @@ const logger = createLogger('preset-export');
 
 /**
  * Fields to include in exported JSON
- * Excludes: id (generated on import), isGlobal (toggle in dashboard),
- * isOwned/permissions (computed server-side)
+ * Excludes: id (generated on import), isOwned/permissions (computed server-side).
+ * isGlobal IS exported so an export→import round-trip preserves visibility —
+ * import applies it post-create and reports the outcome in the result embed.
  */
-const EXPORT_FIELDS = ['name', 'description', 'provider', 'model', 'contextWindowTokens'] as const;
+const EXPORT_FIELDS = [
+  'name',
+  'description',
+  'provider',
+  'model',
+  'contextWindowTokens',
+  'isGlobal',
+] as const;
 
 /** Sampling parameter keys to extract from preset params */
 const SAMPLING_PARAMS = [

--- a/services/bot-client/src/commands/preset/import.test.ts
+++ b/services/bot-client/src/commands/preset/import.test.ts
@@ -53,10 +53,11 @@ const { handleImport, REQUIRED_IMPORT_FIELDS, PRESET_JSON_TEMPLATE } = await imp
 
 interface UserClientStub {
   createUserLlmConfig: ReturnType<typeof vi.fn>;
+  updateUserLlmConfig: ReturnType<typeof vi.fn>;
 }
 
 function createStub(): UserClientStub {
-  return { createUserLlmConfig: vi.fn() };
+  return { createUserLlmConfig: vi.fn(), updateUserLlmConfig: vi.fn() };
 }
 
 describe('Preset Import', () => {
@@ -135,6 +136,58 @@ describe('Preset Import', () => {
           ]),
         })
       );
+    });
+
+    it('applies isGlobal:true post-create via the update seam and reports Global', async () => {
+      vi.mocked(jsonFileUtils.validateAndParseJsonFile).mockResolvedValue({
+        data: createValidPresetData({ isGlobal: true }),
+      });
+      stub.createUserLlmConfig.mockResolvedValue(makeOk({ config: { id: 'new-preset-id' } }));
+      stub.updateUserLlmConfig.mockResolvedValue(
+        makeOk({ config: { id: 'new-preset-id', name: 'Test Preset', isGlobal: true, params: {} } })
+      );
+
+      const mockContext = createMockContext();
+      await handleImport(mockContext);
+
+      // The seam assertion: the flag must actually cross into the update call —
+      // create alone always lands private, so this call IS the round-trip.
+      expect(stub.updateUserLlmConfig).toHaveBeenCalledWith('new-preset-id', { isGlobal: true });
+      const embeds = vi.mocked(mockContext.editReply).mock.calls[0][0] as {
+        embeds: { data: { fields?: { name: string; value: string }[] } }[];
+      };
+      const visibility = embeds.embeds[0].data.fields?.find(f => f.name === 'Visibility');
+      expect(visibility?.value).toContain('Global');
+    });
+
+    it('keeps the import successful (private + warning) when applying isGlobal fails', async () => {
+      vi.mocked(jsonFileUtils.validateAndParseJsonFile).mockResolvedValue({
+        data: createValidPresetData({ isGlobal: true }),
+      });
+      stub.createUserLlmConfig.mockResolvedValue(makeOk({ config: { id: 'new-preset-id' } }));
+      stub.updateUserLlmConfig.mockResolvedValue(makeErr(403, 'Forbidden'));
+
+      const mockContext = createMockContext();
+      await handleImport(mockContext);
+
+      // Import must still succeed — the preset exists, just private.
+      const embeds = vi.mocked(mockContext.editReply).mock.calls[0][0] as {
+        embeds: { data: { title?: string; fields?: { name: string; value: string }[] } }[];
+      };
+      expect(embeds.embeds[0].data.title).toBe('Preset Imported Successfully');
+      const visibility = embeds.embeds[0].data.fields?.find(f => f.name === 'Visibility');
+      expect(visibility?.value).toContain('private');
+    });
+
+    it('does NOT touch the update seam when the file has no isGlobal', async () => {
+      vi.mocked(jsonFileUtils.validateAndParseJsonFile).mockResolvedValue({
+        data: createValidPresetData(),
+      });
+      stub.createUserLlmConfig.mockResolvedValue(makeOk({ config: { id: 'new-preset-id' } }));
+
+      await handleImport(createMockContext());
+
+      expect(stub.updateUserLlmConfig).not.toHaveBeenCalled();
     });
 
     it('should reject invalid JSON file', async () => {

--- a/services/bot-client/src/commands/preset/import.ts
+++ b/services/bot-client/src/commands/preset/import.ts
@@ -9,6 +9,7 @@ import type { DeferredCommandContext } from '../../utils/commandContext/types.js
 import type { UserClient } from '@tzurot/clients';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import { validateAndParseJsonFile } from '../../utils/jsonFileUtils.js';
+import { updatePreset } from './api.js';
 import {
   getImportedFieldsList,
   getMissingRequiredFields,
@@ -28,6 +29,8 @@ interface ImportedPresetData {
   provider?: string;
   model?: string;
   contextWindowTokens?: number;
+  /** Visibility round-trip: exports carry it; import applies it post-create. */
+  isGlobal?: boolean;
   advancedParameters?: {
     temperature?: number;
     top_p?: number;
@@ -62,6 +65,7 @@ export const PRESET_JSON_TEMPLATE = `{
   "provider": "anthropic",
   "model": "anthropic/claude-sonnet-4",
   "contextWindowTokens": 131072,
+  "isGlobal": false,
   "advancedParameters": {
     "temperature": 0.7,
     "top_p": 0.9,
@@ -86,6 +90,7 @@ const IMPORT_FIELD_DEFS: ImportFieldDef[] = [
   { key: 'provider', label: 'Provider' },
   { key: 'model', label: 'Model' },
   { key: 'contextWindowTokens', label: 'Context Window Tokens' },
+  { key: 'isGlobal', label: 'Visibility' },
   { key: 'advancedParameters', label: 'Advanced Parameters' },
 ];
 
@@ -156,6 +161,9 @@ function buildImportPayload(data: ImportedPresetData): Record<string, unknown> {
   if (data.advancedParameters !== undefined && Object.keys(data.advancedParameters).length > 0) {
     payload.advancedParameters = data.advancedParameters;
   }
+  if (typeof data.isGlobal === 'boolean') {
+    payload.isGlobal = data.isGlobal;
+  }
 
   return payload;
 }
@@ -170,7 +178,7 @@ function buildImportPayload(data: ImportedPresetData): Record<string, unknown> {
 async function createPresetFromImport(
   userClient: UserClient,
   payload: Record<string, unknown>
-): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
+): Promise<{ ok: true; id: string; globalApplied?: boolean } | { ok: false; error: string }> {
   // Create preset with all fields - API supports all fields in create endpoint
   const createResult = await userClient.createUserLlmConfig({
     name: payload.name,
@@ -185,14 +193,34 @@ async function createPresetFromImport(
     logger.error({ error: createResult.error }, 'Failed to create preset');
     return { ok: false, error: createResult.error };
   }
+  const id = createResult.data.config.id;
 
-  return { ok: true, id: createResult.data.config.id };
+  // Visibility round-trip: create lands private; apply isGlobal afterwards via the
+  // same update the dashboard toggle uses. A failure here must NOT fail the import —
+  // the preset exists; the caller surfaces "stayed private" in the result embed.
+  if (payload.isGlobal !== true) {
+    return { ok: true, id };
+  }
+  try {
+    await updatePreset(id, { isGlobal: true }, userClient);
+    return { ok: true, id, globalApplied: true };
+  } catch (error) {
+    logger.warn(
+      { err: error, presetId: id },
+      'Imported preset created but applying isGlobal failed — left private'
+    );
+    return { ok: true, id, globalApplied: false };
+  }
 }
 
 /**
  * Build success embed for import
  */
-function buildSuccessEmbed(payload: Record<string, unknown>, presetName: string): EmbedBuilder {
+function buildSuccessEmbed(
+  payload: Record<string, unknown>,
+  presetName: string,
+  globalApplied?: boolean
+): EmbedBuilder {
   const embed = new EmbedBuilder()
     .setColor(DISCORD_COLORS.SUCCESS)
     .setTitle('Preset Imported Successfully')
@@ -201,6 +229,19 @@ function buildSuccessEmbed(payload: Record<string, unknown>, presetName: string)
 
   const importedFields = getImportedFieldsList(payload, IMPORT_FIELD_DEFS);
   embed.addFields({ name: 'Imported Fields', value: importedFields.join(', '), inline: false });
+
+  // Visibility outcome — only shown when the file requested isGlobal:true. The apply
+  // is a separate post-create step, so its failure leaves a working PRIVATE preset;
+  // the user must see which of the two outcomes they got.
+  if (globalApplied !== undefined) {
+    embed.addFields({
+      name: 'Visibility',
+      value: globalApplied
+        ? '🌐 Global (visible to everyone)'
+        : '⚠️ Could not apply global visibility — imported as private. Toggle it in the dashboard.',
+      inline: false,
+    });
+  }
 
   return embed;
 }
@@ -249,7 +290,7 @@ export async function handleImport(context: DeferredCommandContext): Promise<voi
 
     // Step 5: Send success response
     const presetName = payload.name as string;
-    const embed = buildSuccessEmbed(payload, presetName);
+    const embed = buildSuccessEmbed(payload, presetName, createResult.globalApplied);
     await context.editReply({ embeds: [embed] });
 
     logger.info({ presetId: createResult.id, userId, presetName }, 'Preset imported successfully');


### PR DESCRIPTION
## What

The two `/preset` bugs from prod (both user-reported, both flagged next-release):

### 1. Make Global/Private dropped the Back-to-Browse button

The toggle handler rebuilt session data from the API response alone, losing `browseContext` — `showBack` derives from it, so the post-toggle re-render silently lost navigation (user screenshot: Refresh/Clone/Make Private/Close/Delete but no back button). The refresh handler already preserved it correctly; the toggle now uses the identical pattern. **The toggle handler had zero tests** — which is exactly how this shipped — so it now has a seam test asserting the session update carries `browseContext` through.

### 2. Visibility now round-trips through export/import (user decision: isGlobal, no alias)

Exports previously **excluded `isGlobal` by design** ("toggle in dashboard"), so every import landed private. Per the user's call: exports now include `isGlobal`, and import applies `isGlobal: true` post-create via the same update the dashboard toggle uses. The apply is deliberately **non-fatal** — a failure (e.g. permissions) leaves a working *private* preset, and the result embed states which outcome occurred (🌐 Global vs ⚠️ stayed private). Template + imported-fields list updated.

## Tests

- Toggle: browseContext-preservation seam test (new `handleToggleGlobalButton` describe)
- Import: 3 seam tests — flag crosses the update call (`toHaveBeenCalledWith(id, {isGlobal:true})`), failure path stays successful-but-private, no-flag files never touch the update seam
- Export: parses the actual attachment buffer and asserts `isGlobal` survives into the file
- Full bot-client suite green (5172 tests), `pnpm quality` green

Cluster-4 note: the *class* sweep (post-action button consistency across all dashboards + Close-button removal) stays tracked in the UX-audit entry — this PR fixes the concrete instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)