### PR TITLE
fix(ai-worker): vision fallback tiers resolve their own auth (C2b cluster)

### DIFF
--- a/services/ai-worker/src/jobs/ImageDescriptionJob.ts
+++ b/services/ai-worker/src/jobs/ImageDescriptionJob.ts
@@ -22,7 +22,6 @@ import { withRetry } from '../utils/retry.js';
 import { shouldRetryError, getErrorLogContext } from '../utils/apiErrorParser.js';
 import type { ApiKeyResolver } from '../services/ApiKeyResolver.js';
 import {
-  resolveVisionConfig,
   type VisionConfigResult,
   type ResolveVisionConfigOptions,
 } from '../services/multimodal/visionAuthResolver.js';
@@ -46,53 +45,27 @@ interface ImageProcessResult {
 }
 
 /**
- * Resolve auth + model for vision processing via the unified `resolveVisionConfig`.
- *
- * `ImageDescriptionJob` runs as a standalone preprocessing job at upload time,
- * so it has no upstream main-model auth context — `mainProvider`/`mainApiKey`
- * are undefined (the same-provider fast path is skipped; per-provider resolution
- * always runs). `isGuestMode` is passed as `false`: the resolver discriminates
- * genuine-guest-vs-authenticated by probing the vision provider's user key, and
- * a genuine guest with no keys anywhere still resolves correctly to the system
- * key + free model via the broad free-fallback branch.
- *
- * Returns the unified `VisionConfigResult` directly. When `apiKeyResolver` is
- * undefined (legacy test-fixture path; production always wires it via the
- * worker bootstrap), we synthesize a `resolved` result that proceeds with no
- * user key — matching the pre-unification legacy behavior.
+ * Synthesize the legacy no-resolver auth result. Only the legacy test-fixture
+ * path reaches this — production always wires an `apiKeyResolver`, and that
+ * path hands the auth INPUTS to the fallback loop instead of pre-resolving
+ * (see `resolveImageJobAuth`).
  */
-async function resolveVisionApiKey(
-  apiKeyResolver: ApiKeyResolver | undefined,
-  userId: string,
-  personality: ImageDescriptionJobData['personality']
-): Promise<VisionConfigResult> {
-  if (!apiKeyResolver) {
-    // Legacy/no-resolver path: proceed with no user key. `describeImage`
-    // self-selects the model (model omitted) and `createChatModel` falls back
-    // to the env-default provider — same as the pre-unification behavior for
-    // this branch.
-    return {
-      kind: 'resolved',
-      config: {
-        apiKey: '',
-        provider: AIProvider.OpenRouter,
-        model: '',
-        source: 'system',
-        isGuestMode: false,
-      },
-    };
-  }
-
-  return resolveVisionConfig({
-    personality,
-    // No upstream main-model context at upload time — skip the same-provider
-    // fast path so per-provider resolution always runs.
-    mainProvider: undefined,
-    mainApiKey: undefined,
-    isGuestMode: false,
-    userId,
-    apiKeyResolver,
-  });
+function resolveVisionApiKey(): VisionConfigResult {
+  // Legacy/no-resolver path: proceed with no user key. `describeImage`
+  // self-selects the model (model omitted) and `createChatModel` falls back
+  // to the env-default provider — same as the pre-unification behavior for
+  // this branch. The resolver-wired path never reaches here (it hands the
+  // auth INPUTS to the fallback loop instead — see resolveImageJobAuth).
+  return {
+    kind: 'resolved',
+    config: {
+      apiKey: '',
+      provider: AIProvider.OpenRouter,
+      model: '',
+      source: 'system',
+      isGuestMode: false,
+    },
+  };
 }
 
 /** Per-image auth for `processImageDescriptionJob` — either the fallback-loop INPUTS or legacy pre-resolved fields. */
@@ -115,11 +88,11 @@ interface ImageJobAuth {
  * - No resolver (legacy test path): resolve once (always synthesizes a `resolved` config, never
  *   fail-fast) and expose the pre-resolved fields for the single-model describeImage.
  */
-async function resolveImageJobAuth(
+function resolveImageJobAuth(
   apiKeyResolver: ApiKeyResolver | undefined,
   userId: string,
   personality: ImageDescriptionJobData['personality']
-): Promise<ImageJobAuth> {
+): ImageJobAuth {
   const base: ImageJobAuth = {
     isGuestMode: false,
     userApiKey: undefined,
@@ -140,7 +113,7 @@ async function resolveImageJobAuth(
       },
     };
   }
-  const authResult = await resolveVisionApiKey(undefined, userId, personality);
+  const authResult = resolveVisionApiKey();
   if (authResult.kind !== 'resolved') {
     return base;
   }
@@ -295,7 +268,7 @@ export async function processImageDescriptionJob(
   );
 
   const { visionAuth, isGuestMode, userApiKey, visionProvider, visionModel, apiKeySource } =
-    await resolveImageJobAuth(apiKeyResolver, context.userId, personality);
+    resolveImageJobAuth(apiKeyResolver, context.userId, personality);
 
   const loggingContext = {
     userId: context.userId,

--- a/services/ai-worker/src/services/multimodal/describeImageWithFallback.test.ts
+++ b/services/ai-worker/src/services/multimodal/describeImageWithFallback.test.ts
@@ -70,7 +70,14 @@ vi.mock('./VisionProcessor.js', async importOriginal => {
     ...actual,
     describeImage: vi.fn(),
     selectVisionModel: vi.fn(),
-    buildFailureFallback: vi.fn(),
+    // Declaration-time real-string impl, NOT a bare vi.fn(): visionAuthResolver
+    // derives VISION_AUTH_FAIL_FAST_DESCRIPTION from this at MODULE LOAD (before
+    // any beforeEach), so a bare mock would bake `undefined` into the constant and
+    // turn the exhaustion assertions into undefined===undefined tautologies.
+    buildFailureFallback: vi.fn(
+      (category: unknown, source?: unknown) =>
+        `[Image unavailable: mock ${String(category)}/${String(source ?? 'none')}]`
+    ),
   };
 });
 
@@ -521,11 +528,49 @@ describe('describeImageWithFallback', () => {
 
     expect(result).toBe('ok');
     expect(mockSelectVisionModel).toHaveBeenCalledWith(personality, false);
-    // The resolved model echoes the selected primary.
+    // The resolved model echoes the selected primary — and the first tier is
+    // flagged primary (the only tier allowed the same-provider fast path).
     expect(mockResolveVisionAuth).toHaveBeenCalledWith(
       'selected/model',
       expect.anything(),
-      expect.anything()
+      expect.anything(),
+      true
+    );
+  });
+
+  it('flags ONLY the first tier as primary (fallback tiers skip the fast path)', async () => {
+    const personality = makePersonality({ visionFallbackModels: ['fallback/model'] });
+    // Tier 1 advances (retryable failure), tier 2 resolves.
+    mockResolveVisionAuth
+      .mockResolvedValueOnce(resolvedFor('primary/model'))
+      .mockResolvedValueOnce(resolvedFor('fallback/model'));
+    mockDescribeImage
+      .mockRejectedValueOnce(new VisionModelError(ApiErrorCategory.RATE_LIMIT, 'rl'))
+      .mockResolvedValueOnce('ok');
+
+    const result = await describeImageWithFallback(
+      attachment,
+      personality,
+      makeAuthOptions({ personality }),
+      { model: 'primary/model' }
+    );
+
+    expect(result).toBe('ok');
+    // Seam assertion: isPrimaryTier must be true for tier 1 and false afterwards —
+    // a fallback tier taking the fast path would retry the identical dead key.
+    expect(mockResolveVisionAuth).toHaveBeenNthCalledWith(
+      1,
+      'primary/model',
+      expect.anything(),
+      expect.anything(),
+      true
+    );
+    expect(mockResolveVisionAuth).toHaveBeenNthCalledWith(
+      2,
+      'fallback/model',
+      expect.anything(),
+      expect.anything(),
+      false
     );
   });
 });

--- a/services/ai-worker/src/services/multimodal/describeImageWithFallback.ts
+++ b/services/ai-worker/src/services/multimodal/describeImageWithFallback.ts
@@ -191,8 +191,11 @@ async function walkFallbackChain(
   // never contributes here; that keeps a downstream failFast from clobbering a real failure.
   let lastAttempt: { category: ApiErrorCategory; source: 'user' | 'system' } | undefined;
 
-  for (const tierModel of tiers) {
-    const auth = await resolveVisionAuth(tierModel, authOptions, quota);
+  for (const [tierIndex, tierModel] of tiers.entries()) {
+    // Only the FIRST tier may take the same-provider fast path (reuse the upstream
+    // main key) — a fallback tier re-handing back the identical key would retry the
+    // exact credential that just failed and defeat the loop's resilience purpose.
+    const auth = await resolveVisionAuth(tierModel, authOptions, quota, tierIndex === 0);
     if (auth.kind === 'failFast') {
       continue; // no usable key for this tier's provider (and no free fallback) — advance
     }

--- a/services/ai-worker/src/services/multimodal/visionAuthResolver.test.ts
+++ b/services/ai-worker/src/services/multimodal/visionAuthResolver.test.ts
@@ -18,6 +18,7 @@ import {
   resolveVisionConfig,
   resolveVisionAuth,
   createVisionQuotaTracker,
+  VISION_AUTH_FAIL_FAST_DESCRIPTION,
 } from './visionAuthResolver.js';
 import { selectVisionModel } from './VisionProcessor.js';
 import type { ApiKeyResolver } from '../ApiKeyResolver.js';
@@ -41,6 +42,11 @@ vi.mock('@tzurot/common-types', async importOriginal => {
 // without reaching into Redis (hasVisionSupport).
 vi.mock('./VisionProcessor.js', () => ({
   selectVisionModel: vi.fn(),
+  // Evaluated at MODULE LOAD (VISION_AUTH_FAIL_FAST_DESCRIPTION derives from it),
+  // so the mock must return a real string — a bare vi.fn() would bake `undefined`
+  // into the exported constant.
+  buildFailureFallback: (category: string, source?: string) =>
+    `[Image unavailable: mock ${String(category)}/${source ?? 'none'}]`,
 }));
 
 // VisionDescriptionCache singleton mock — stubbed for module-load safety; we just
@@ -415,7 +421,8 @@ describe('resolveVisionAuth (direct, model-parameterized)', () => {
         userId: 'user-1',
         apiKeyResolver: mockResolver,
       },
-      createVisionQuotaTracker('user-1')
+      createVisionQuotaTracker('user-1'),
+      false
     );
 
     expect(result.kind).toBe('resolved');
@@ -428,7 +435,7 @@ describe('resolveVisionAuth (direct, model-parameterized)', () => {
     expect(mockSelectVisionModel).not.toHaveBeenCalled();
   });
 
-  it('reuses the main key on the same-provider fast path with the target model', async () => {
+  it('reuses the main key on the same-provider fast path for the PRIMARY tier', async () => {
     const result = await resolveVisionAuth(
       'fallback/tier-model',
       {
@@ -439,7 +446,8 @@ describe('resolveVisionAuth (direct, model-parameterized)', () => {
         userId: 'user-1',
         apiKeyResolver: mockResolver,
       },
-      createVisionQuotaTracker('user-1')
+      createVisionQuotaTracker('user-1'),
+      true
     );
 
     expect(result).toEqual({
@@ -453,5 +461,86 @@ describe('resolveVisionAuth (direct, model-parameterized)', () => {
       },
     });
     expect(mockSelectVisionModel).not.toHaveBeenCalled();
+  });
+
+  it('skips the fast path on a FALLBACK tier even when providers match', async () => {
+    // The dead-key resilience seam: after a tier-1 failure, a same-provider tier-2
+    // must NOT re-hand back the identical upstream key — per-provider resolution
+    // picks up the user's wallet key instead.
+    mockTryResolveUserKey.mockResolvedValue('wallet-key');
+
+    const result = await resolveVisionAuth(
+      'fallback/tier-model',
+      {
+        personality,
+        mainProvider: AIProvider.OpenRouter,
+        mainApiKey: 'main-or-key',
+        isGuestMode: false,
+        userId: 'user-1',
+        apiKeyResolver: mockResolver,
+      },
+      createVisionQuotaTracker('user-1'),
+      false
+    );
+
+    expect(result.kind).toBe('resolved');
+    if (result.kind === 'resolved') {
+      // The wallet key, NOT the reused main key.
+      expect(result.config.apiKey).toBe('wallet-key');
+    }
+    expect(mockTryResolveUserKey).toHaveBeenCalledWith('user-1', AIProvider.OpenRouter);
+  });
+
+  it('forces the free model for a GUEST on a fallback tier (no system key on paid tiers)', async () => {
+    // A stamped fallback can be the admin's PAID global default; a guest walking
+    // onto it must not put the system key on a paid model.
+    mockResolveApiKey.mockResolvedValue({
+      apiKey: 'system-key',
+      source: 'system',
+      isGuestMode: true,
+    });
+
+    const result = await resolveVisionAuth(
+      'paid/global-default-vision',
+      {
+        personality,
+        mainProvider: undefined,
+        mainApiKey: undefined,
+        isGuestMode: true,
+        userId: 'user-1',
+        apiKeyResolver: mockResolver,
+      },
+      createVisionQuotaTracker('user-1'),
+      false
+    );
+
+    expect(result.kind).toBe('resolved');
+    if (result.kind === 'resolved') {
+      expect(result.config.model).toBe(MODEL_DEFAULTS.VISION_FALLBACK_FREE);
+      expect(result.config.apiKey).toBe('system-key');
+    }
+  });
+});
+
+describe('createVisionQuotaTracker', () => {
+  it('latches after ANY real check — an over-cap first answer stops later store hits', async () => {
+    // The seam: the underlying Redis-backed store must be hit at most ONCE per
+    // tracker, even when the first answer is over-cap (false) — the answer can't
+    // change within one tracker's lifetime, and re-hitting the store costs real
+    // INCR+EXPIRE round-trips for an already-denied user.
+    mockTryConsume.mockResolvedValueOnce(false);
+    const tracker = createVisionQuotaTracker('user-1');
+
+    expect(await tracker.tryConsume()).toBe(false);
+    expect(await tracker.tryConsume()).toBe(false);
+    expect(mockTryConsume).toHaveBeenCalledTimes(1);
+  });
+
+  it('derives VISION_AUTH_FAIL_FAST_DESCRIPTION as a real string at module load', () => {
+    // Guards the module-load derivation: if a mock (or future refactor) let the
+    // constant freeze to undefined, downstream toBe() assertions would silently
+    // become undefined===undefined tautologies.
+    expect(typeof VISION_AUTH_FAIL_FAST_DESCRIPTION).toBe('string');
+    expect(VISION_AUTH_FAIL_FAST_DESCRIPTION.length).toBeGreaterThan(0);
   });
 });

--- a/services/ai-worker/src/services/multimodal/visionAuthResolver.ts
+++ b/services/ai-worker/src/services/multimodal/visionAuthResolver.ts
@@ -29,29 +29,29 @@
 import {
   createLogger,
   AIProvider,
+  ApiErrorCategory,
   MODEL_DEFAULTS,
   type LoadedPersonality,
 } from '@tzurot/common-types';
 import { detectVisionProvider } from '../ProviderRouter.js';
-import { selectVisionModel } from './VisionProcessor.js';
+import { selectVisionModel, buildFailureFallback } from './VisionProcessor.js';
 import { visionFallbackQuota } from '../../redis.js';
 import type { ApiKeyResolver } from '../ApiKeyResolver.js';
 
 const logger = createLogger('VisionAuthResolver');
 
 /**
- * Source-aware fallback description shown to the LLM when no usable vision key
- * exists across every fallback tier. Exported as a constant rather than inlined
- * so the fallback loop (`describeImageWithFallback`, which renders it on
- * auth-exhaustion) and any future consumer share one source of truth. A string
- * update in one place would otherwise diverge silently.
- *
- * The wording is read by the LLM in the chat context, so it's phrased as a
- * description (not a UI error). The user sees the personality acknowledge
- * the missing image with the embedded "/settings apikey set" hint.
+ * Fallback description shown to the LLM when no usable vision key exists across
+ * every fallback tier. DERIVED from `buildFailureFallback`'s AUTH+user branch —
+ * this constant is the "no tier ever resolved a key" rendering, which is the
+ * same user-actionable situation, so the wording must stay identical. Deriving
+ * (rather than duplicating the literal) makes a future wording change land in
+ * both places by construction.
  */
-export const VISION_AUTH_FAIL_FAST_DESCRIPTION =
-  '[Image unavailable: your API key was rejected — check /settings apikey set for the vision provider key]';
+export const VISION_AUTH_FAIL_FAST_DESCRIPTION = buildFailureFallback(
+  ApiErrorCategory.AUTHENTICATION,
+  'user'
+);
 
 /**
  * Resolved auth + model context for a vision call. Unifies the auth decision
@@ -153,9 +153,10 @@ export function createVisionQuotaTracker(userId: string | undefined): VisionQuot
       } catch {
         ok = true; // fail-open — a quota-store blip must not block image description
       }
-      if (ok) {
-        consumedThisRequest = true;
-      }
+      // Latch on ANY real check, not just success: an over-cap answer can't change
+      // within one tracker's lifetime, so a later tier re-hitting Redis for an
+      // already-denied user is pure waste (extra INCR+EXPIRE round-trips).
+      consumedThisRequest = true;
       return ok;
     },
   };
@@ -230,8 +231,9 @@ async function resolveBroadFreeFallback(
  * computes the natural model then delegates here.
  *
  * Branch order:
- * 1. Same-provider fast path — reuse the upstream main-model key.
- * 2. Genuine guest (or unknown user) — system key for the vision provider.
+ * 1. Same-provider fast path (PRIMARY tier only) — reuse the upstream main-model key.
+ * 2. Genuine guest (or unknown user) — system key for the vision provider
+ *    (fallback tiers force the free model — see the guest branch).
  * 3. Authenticated user with a vision-provider key — use it.
  * 4. BROAD FREE FALLBACK — authenticated user lacking a vision-provider key
  *    downgrades to the free vision model on the system OpenRouter key (instead
@@ -240,11 +242,20 @@ async function resolveBroadFreeFallback(
  * 5. Fallback-of-fallback — if even the free-model system key is unavailable
  *    (no system OpenRouter key configured), `failFast` so the caller emits the
  *    "configure your key" placeholder against the ORIGINAL vision provider.
+ *
+ * `isPrimaryTier` — true only for the FIRST tier of a walk (and the primary-path
+ * entry point). Fallback tiers must not take the same-provider fast path: the
+ * fast path just re-hands back the identical upstream key, so after a tier-1
+ * failure a same-provider tier-2 would retry the exact same credential and the
+ * loop would provide zero resilience for the broken-key case it exists for.
+ * Forcing per-provider resolution on fallback tiers routes an authenticated
+ * user through their wallet key (or the broad free fallback) instead.
  */
 export async function resolveVisionAuth(
   targetModel: string,
   options: ResolveVisionConfigOptions,
-  quotaTracker: VisionQuotaTracker
+  quotaTracker: VisionQuotaTracker,
+  isPrimaryTier: boolean
 ): Promise<VisionConfigResult> {
   const { mainProvider, mainApiKey, isGuestMode, userId, apiKeyResolver } = options;
   // Self-derive the provider from the target model rather than accepting it as a separate
@@ -254,7 +265,7 @@ export async function resolveVisionAuth(
 
   // Same-provider fast path — reuse the upstream-resolved key without a second
   // resolver call. Avoids redundant DB reads for the common case where main and
-  // vision share a provider.
+  // vision share a provider. PRIMARY TIER ONLY — see the docstring.
   //
   // Gated on a non-empty `mainApiKey` because AuthStep's resolution-failure
   // catch branch returns `resolvedApiKey: undefined` regardless of whether the
@@ -263,7 +274,12 @@ export async function resolveVisionAuth(
   // reach `createChatModel` with no Authorization header and reproduce the exact
   // bug this resolver exists to prevent. Falling through to per-provider
   // resolution lets the user's actual keys (if any) be picked up instead.
-  if (visionProvider === mainProvider && mainApiKey !== undefined && mainApiKey.length > 0) {
+  if (
+    isPrimaryTier &&
+    visionProvider === mainProvider &&
+    mainApiKey !== undefined &&
+    mainApiKey.length > 0
+  ) {
     logger.debug(
       { userId, visionProvider, isGuestMode },
       'Vision config same-provider fast path — reusing main-model key'
@@ -305,19 +321,27 @@ export async function resolveVisionAuth(
   try {
     if (treatAsGuest) {
       // Genuine guest — system key is the only path that works for them.
-      // For the primary path `selectVisionModel` already returned the free model,
-      // so `targetModel` is correct here.
-      const result = await apiKeyResolver.resolveApiKey(userId, visionProvider);
+      // For the primary tier `selectVisionModel` already returned the free model,
+      // so `targetModel` is correct as-is. FALLBACK tiers carry the stamped DB
+      // models, which can be PAID (the admin's global vision default) — a guest
+      // walking onto one would put the system key on a paid model, bypassing the
+      // free-forcing that governs every other guest path. Force the free model
+      // there; the guest's floor tier is the free model anyway, so this only
+      // changes WHICH tier renders it (and the loop's resolved-model dedup then
+      // collapses the duplicates into one attempt).
+      const guestModel = isPrimaryTier ? targetModel : MODEL_DEFAULTS.VISION_FALLBACK_FREE;
+      const guestProvider = isPrimaryTier ? visionProvider : detectVisionProvider(guestModel);
+      const result = await apiKeyResolver.resolveApiKey(userId, guestProvider);
       logger.info(
-        { userId, visionProvider, mainProvider, source: result.source },
+        { userId, visionProvider: guestProvider, mainProvider, source: result.source },
         'Cross-provider vision config resolved (guest path)'
       );
       return {
         kind: 'resolved',
         config: {
           apiKey: result.apiKey,
-          provider: visionProvider,
-          model: targetModel,
+          provider: guestProvider,
+          model: guestModel,
           source: result.source,
           isGuestMode: result.isGuestMode,
         },
@@ -377,5 +401,6 @@ export async function resolveVisionConfig(
   // the OpenRouter fallback model — its provider is OpenRouter, not z.ai).
   const naturalModel = await selectVisionModel(options.personality, options.isGuestMode);
   // A fresh single-use tracker → identical to the old direct per-call quota consume.
-  return resolveVisionAuth(naturalModel, options, createVisionQuotaTracker(options.userId));
+  // The primary path IS the primary tier — the fast path is legitimate here.
+  return resolveVisionAuth(naturalModel, options, createVisionQuotaTracker(options.userId), true);
 }


### PR DESCRIPTION
## What

One cohesive PR closing **four deferred C2b review findings** (`cold/follow-ups.md` C2b-1/2/4/5 — the backlog-sweep cluster 1):

1. **C2b-1 (the real bug, user-flagged priority)**: the same-provider "reuse main key" fast path now fires on the **primary tier only** (`isPrimaryTier` threaded from the loop; `resolveVisionConfig` passes `true`). Previously every fallback tier sharing the main provider got handed back the identical upstream key — after a tier-1 auth failure, tier 2 retried the exact same dead credential, giving the loop zero resilience for the broken-key case it exists for. Fallback tiers now run per-provider resolution: wallet key → broad free fallback → system key + free model.

2. **C2b-1's cost-leak half**: guests on fallback tiers force the free model. A stamped fallback can be the admin's **paid** global vision default; a guest walking onto it put the system key on a paid model, bypassing the free-forcing that governs every other guest path. The guest's floor tier is the free model anyway — the loop's resolved-model dedup collapses duplicates into one attempt.

3. **C2b-2**: the quota tracker latches on ANY real check (success **or** over-cap) — the answer can't change within one tracker's lifetime, so later tiers re-hitting Redis (`INCR`+`EXPIRE`) for an already-denied user was pure waste, contradicting the "checked at most once per tracker" docstring.

4. **C2b-5 + C2b-4**: `VISION_AUTH_FAIL_FAST_DESCRIPTION` now **derives** from `buildFailureFallback(AUTHENTICATION, 'user')` instead of duplicating the literal (wording changes land in both places by construction); the dead `apiKeyResolver` branch in `ImageDescriptionJob.resolveVisionApiKey` is collapsed to the legacy synthesizer it actually is (now sync — its only caller always passed `undefined`).

## Tests

Seam assertions per the testing rule: per-tier `isPrimaryTier` flag (`toHaveBeenNthCalledWith` for tiers 1+2), fallback-tier fast-path bypass resolves the **wallet key** (not the reused main key), guest fallback-tier free-forcing. Full ai-worker suite green (3321 tests), `pnpm quality` green.

## Backlog

On merge, closes C2b-1/2/4/5 in `cold/follow-ups.md` (C2b-3 observability stays — separate, larger shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)