### PR TITLE
fix(api-gateway): break the unhandled-rejection shutdown loop + log the real reason

### DIFF
--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -404,35 +404,64 @@ function createShutdownHandler(
     dbNotificationListener,
   } = services;
 
+  // Re-entry guard: the unhandledRejection handler calls shutdown(), and a
+  // rejection thrown INSIDE shutdown (closing already-closed resources) is
+  // itself unhandled — without the guard that recurses forever: the process
+  // zombies with the HTTP server closed, looping the shutdown log sequence at
+  // thousands of lines/sec and never reaching process.exit. Observed as a
+  // multi-hour prod outage; the guard + the hard-exit timer below make any
+  // shutdown attempt terminal.
+  let shuttingDown = false;
+
   return async (): Promise<void> => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
     logger.info('Shutting down gracefully...');
 
-    server.close(() => {
-      logger.info('HTTP server closed');
-    });
+    // Hard-exit backstop: if any dispose step hangs or throws in a way that
+    // never reaches the exit calls below, still terminate (Railway restarts a
+    // dead process; it cannot restart a zombie that keeps its event loop alive).
+    const hardExit = setTimeout(() => {
+      logger.error('Shutdown did not complete within 10s — forcing exit');
+      process.exit(1);
+    }, 10_000);
+    hardExit.unref();
 
-    disposeDeduplicationCache();
-    logger.info('Request deduplication cache disposed');
+    try {
+      server.close(() => {
+        logger.info('HTTP server closed');
+      });
 
-    await dbNotificationListener.stop();
-    logger.info('Database notification listener stopped');
+      disposeDeduplicationCache();
+      logger.info('Request deduplication cache disposed');
 
-    await cacheInvalidationService.unsubscribe();
-    await cascadeInvalidation.unsubscribe();
-    cascadeResolver.stopCleanup();
-    cacheRedis.disconnect();
-    logger.info('Cache invalidation services closed');
+      await dbNotificationListener.stop();
+      logger.info('Database notification listener stopped');
 
-    await shutdownEmbeddingService();
-    logger.info('Embedding service shut down');
+      await cacheInvalidationService.unsubscribe();
+      await cascadeInvalidation.unsubscribe();
+      cascadeResolver.stopCleanup();
+      cacheRedis.disconnect();
+      logger.info('Cache invalidation services closed');
 
-    await closeQueue();
+      await shutdownEmbeddingService();
+      logger.info('Embedding service shut down');
 
-    // dispose() logs 'Prisma client disconnected' itself — no second line here.
-    await disposePrisma();
+      await closeQueue();
 
-    logger.info('Shutdown complete');
-    process.exit(0);
+      // dispose() logs 'Prisma client disconnected' itself — no second line here.
+      await disposePrisma();
+
+      logger.info('Shutdown complete');
+      process.exit(0);
+    } catch (error) {
+      // A failed dispose step must still end the process — exiting dirty is
+      // strictly better than living on as a half-shut-down zombie.
+      logger.error({ err: error }, 'Shutdown step failed — exiting');
+      process.exit(1);
+    }
   };
 }
 
@@ -553,7 +582,10 @@ async function main(): Promise<void> {
     void shutdown();
   });
   process.on('unhandledRejection', reason => {
-    logger.fatal({ reason }, 'Unhandled rejection:');
+    // MUST log under `err` — pino only serializes Errors via the `err`-key
+    // serializer; `{ reason }` stringified a real Error to `{}` and left a
+    // production incident with no root cause in the logs.
+    logger.fatal({ err: reason }, 'Unhandled rejection:');
     void shutdown();
   });
 


### PR DESCRIPTION
## The incident (prod, 2026-07-02 ~08:44–12:13 UTC)

An unhandled rejection triggered graceful shutdown → a rejection thrown *inside* shutdown (closing already-closed resources) was itself unhandled (the promise is `void`-discarded) → the handler re-fired → **infinite shutdown loop**. The process zombied with its HTTP server closed — a **~3.5-hour gateway outage** Railway couldn't heal (the looping handler kept the event loop alive, so the process never died), spewing the shutdown log sequence at ~4.5k lines/sec (57,006,075 messages dropped by Railway's rate cap). The original rejection's identity is lost: `logger.fatal({ reason })` serialized the Error to `{}` because pino only serializes Errors under the `err` key.

## Fixes

1. **Re-entry guard** — `shuttingDown` latch; a second `shutdown()` call returns immediately
2. **Terminal-by-construction** — try/catch around the dispose sequence (`exit(1)` on failure) + a 10s unref'd hard-exit timer (`exit(1)` on hang). A dead process gets restarted by Railway; a zombie does not.
3. **`{ err: reason }`** — the next incident logs its actual root cause

## Sibling audit

- bot-client: already correct (err-key logging, no shutdown-on-rejection, guarded signal handler)
- ai-worker: no handler → Node's default crash-and-exit, which is terminal and therefore Railway-healable

## Note

Intended to ride into release v3.0.0-beta.144 (#1439) — this is outage-class. Full gateway suite green (2251 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)