### PR TITLE
docs(skills): dev deploys prove boot, not behavior

### DIFF
--- a/.claude/skills/tzurot-deployment/SKILL.md
+++ b/.claude/skills/tzurot-deployment/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-deployment
 description: 'Railway deployment procedures. Invoke with /tzurot-deployment for deploying, checking logs, and troubleshooting.'
-lastUpdated: '2026-06-27'
+lastUpdated: '2026-07-02'
 ---
 
 # Deployment Procedures
@@ -18,6 +18,19 @@ Both Railway environments auto-deploy from their respective branches. **No manua
 | `main`    | prod        | Auto-deploys on every push |
 
 For prod, the trigger is the release-PR merge from `develop` into `main` (procedure in `tzurot-git-workflow` skill). Schema changes do NOT auto-apply — see the migration step below.
+
+### What a dev deploy proves (and does NOT prove)
+
+**Dev has NO organic traffic.** Its only user is the project owner, and only during explicit testing sessions. A change that has "been on dev for a day" has, in the common case, executed exactly zero times beyond service boot.
+
+| A green dev deploy proves                                                            | It does NOT prove                                        |
+| ------------------------------------------------------------------------------------ | -------------------------------------------------------- |
+| The build compiles and ships                                                         | Any request-path behavior                                |
+| Services boot without crash-looping                                                  | Failure paths, fallbacks, retries                        |
+| Boot-time wiring runs (pool config applies, scheduled jobs register, env vars parse) | Scheduled jobs actually _execute_ correctly              |
+|                                                                                      | Anything involving real user input, load, or concurrency |
+
+**Never cite "soaked in dev" as release-safety evidence.** For this project, **prod is the soak environment** — the honest release-safety basis is: per-PR CI (all tiers) + adversarial review, the holistic release review, blast-radius analysis of the runtime-unverified paths, and logging good enough to diagnose the first real occurrence post-hoc. When a change's failure path genuinely needs pre-prod runtime verification, that means an _explicit_ dev testing session with the user driving Discord (see `/tzurot-testing`), not passive deploy time.
 
 ## Deployment Procedure
 

--- a/.claude/skills/tzurot-git-workflow/SKILL.md
+++ b/.claude/skills/tzurot-git-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-git-workflow
 description: 'Git workflow procedures. Invoke with /tzurot-git-workflow for commit, PR, and release procedures.'
-lastUpdated: '2026-06-27'
+lastUpdated: '2026-07-02'
 ---
 
 # Git Workflow Procedures
@@ -211,6 +211,8 @@ Skip if the release has no migration — `release:premigrate` detects this and e
 ⚠️ **NEVER use `--delete-branch` for release PRs.** `develop` is a long-lived branch.
 
 ⚠️ **Wait for every CI check to be green** per `.claude/rules/00-critical.md` "Never Merge PRs With Red CI". Release PRs are not exempt — claude-review is the second-look on the full release delta and infra failures (binary not found, missing secret) need `gh run rerun <run-id> --failed` before merge, not "merge through it."
+
+⚠️ **When assessing release safety, do NOT cite "soaked in dev".** Dev has no organic traffic — a dev deploy proves boot, not behavior (see `/tzurot-deployment` § "What a dev deploy proves"). The honest safety basis is per-PR CI + reviews, the holistic release review, and blast-radius analysis of runtime-unverified paths.
 
 ```bash
 # ✅ CORRECT - Merge without deleting develop (only after all checks green)


### PR DESCRIPTION
## Why

The "it's been soaking on dev" claim has crept into release-safety reasoning several times — most recently during the beta.144 go/no-go, where the user had to correct it: **dev has no organic traffic** (its only user is the owner, during explicit testing sessions), so a dev deploy is boot verification, not behavioral soak.

## What

- **`tzurot-deployment` skill**: new "What a dev deploy proves (and does NOT prove)" section right under the auto-deploy table — proves build/boot/boot-time-wiring; does NOT prove request paths, failure paths, scheduled-job execution, or anything under load. Names prod as this project's de-facto soak environment and points to explicit dev testing sessions (`/tzurot-testing`) for pre-prod runtime verification.
- **`tzurot-git-workflow` skill**: cross-reference warning at the release-merge step naming the honest safety basis (per-PR CI + reviews, holistic release review, blast-radius analysis).

Docs-only, but skills are load-bearing procedures → PR per `00-critical.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)