### PR TITLE
test: close the retention test gaps ('all'-target seam + mid-sweep partial-commit)

### DIFF
--- a/packages/conversation-history/src/ConversationRetentionService.component.test.ts
+++ b/packages/conversation-history/src/ConversationRetentionService.component.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
-import { PrismaClient } from '@tzurot/common-types';
+import { PrismaClient, SYNC_LIMITS } from '@tzurot/common-types';
 import type { PGlite } from '@electric-sql/pglite';
 import { PrismaPGlite } from 'pglite-prisma-adapter';
 import { ConversationRetentionService } from './ConversationRetentionService.js';
@@ -344,6 +344,94 @@ describe('ConversationRetentionService', () => {
       // Verify all tombstones created
       const tombstones = await prisma.conversationHistoryTombstone.count();
       expect(tombstones).toBe(messageCount);
+    });
+  });
+
+  describe('mid-sweep failure (per-batch atomicity contract)', () => {
+    /**
+     * Wraps a real PrismaClient so the Nth `$transaction` call rejects.
+     * All other members (including model delegates) pass through untouched,
+     * so committed batches hit the real PGlite database.
+     */
+    function failNthTransaction(client: PrismaClient, failOn: number): PrismaClient {
+      let calls = 0;
+      return new Proxy(client, {
+        get(target, prop, receiver): unknown {
+          if (prop === '$transaction') {
+            return (...args: unknown[]): Promise<unknown> => {
+              calls += 1;
+              if (calls === failOn) {
+                return Promise.reject(new Error('simulated mid-sweep failure'));
+              }
+              return (target.$transaction as (...a: unknown[]) => Promise<unknown>).apply(
+                target,
+                args
+              );
+            };
+          }
+          return Reflect.get(target, prop, receiver);
+        },
+      }) as PrismaClient;
+    }
+
+    it('a batch-2 failure preserves batch 1 (deletes committed WITH tombstones) and leaves the rest untouched', async () => {
+      // The contract under test: atomicity is PER BATCH. A sweep that dies on
+      // batch 2 must leave batch 1 fully committed — its rows deleted AND
+      // tombstoned (the tombstone-before-delete invariant is what stops
+      // db-sync from resurrecting them) — while the unswept remainder is
+      // untouched and a later retry can drain it. Unit tests can't verify
+      // this: it's transaction-commit behavior, which needs a real database.
+      const BATCH = SYNC_LIMITS.RETENTION_BATCH_SIZE;
+      const REMAINDER = 100;
+      const oldDate = new Date();
+      oldDate.setDate(oldDate.getDate() - 40);
+
+      // Bulk-seed BATCH + REMAINDER rows older than the 30-day cutoff.
+      // (createMany, not the per-row helper — 1100 sequential creates is slow.)
+      await prisma.conversationHistory.createMany({
+        data: Array.from({ length: BATCH + REMAINDER }, (_, i) => ({
+          id: `00000000-0000-0000-0002-${String(i).padStart(12, '0')}`,
+          channelId: testChannelId,
+          personalityId: testPersonalityId,
+          personaId: testPersonaId,
+          role: 'user',
+          content: `Old message ${i}`,
+          createdAt: oldDate,
+        })),
+      });
+
+      const failingService = new ConversationRetentionService(failNthTransaction(prisma, 2));
+
+      // The sweep dies on batch 2; the service rethrows.
+      await expect(failingService.cleanupOldHistory(30)).rejects.toThrow(
+        'simulated mid-sweep failure'
+      );
+
+      // Batch 1 (BATCH rows, ascending id order) committed: rows gone,
+      // tombstones present. The REMAINDER rows survive untouched.
+      const remaining = await prisma.conversationHistory.count();
+      const tombstones = await prisma.conversationHistoryTombstone.count();
+      expect(remaining).toBe(REMAINDER);
+      expect(tombstones).toBe(BATCH);
+
+      // The tombstone-before-delete invariant: every deleted row has a
+      // tombstone. Since batch order is `id: 'asc'`, the tombstoned ids are
+      // exactly the first BATCH seeded ids — spot-check both boundaries.
+      const firstDeleted = `00000000-0000-0000-0002-${String(0).padStart(12, '0')}`;
+      const lastDeleted = `00000000-0000-0000-0002-${String(BATCH - 1).padStart(12, '0')}`;
+      const firstSurvivor = `00000000-0000-0000-0002-${String(BATCH).padStart(12, '0')}`;
+      expect(
+        await prisma.conversationHistoryTombstone.count({
+          where: { id: { in: [firstDeleted, lastDeleted] } },
+        })
+      ).toBe(2);
+      expect(await prisma.conversationHistory.count({ where: { id: firstSurvivor } })).toBe(1);
+
+      // A retry with a healthy client drains the remainder — the partial
+      // sweep is recoverable by construction.
+      const retried = await service.cleanupOldHistory(30);
+      expect(retried).toBe(REMAINDER);
+      expect(await prisma.conversationHistory.count()).toBe(0);
     });
   });
 });

--- a/services/api-gateway/src/routes/admin/cleanup.test.ts
+++ b/services/api-gateway/src/routes/admin/cleanup.test.ts
@@ -137,6 +137,23 @@ describe('Admin Cleanup Routes', () => {
       expect(mockService.cleanupSoftDeletedMessages).toHaveBeenCalledWith();
     });
 
+    it("folds soft-deleted hard-deletes into historyDeleted on target 'all' too", async () => {
+      // 'all' shares the `target === 'history' || target === 'all'` branch with
+      // the test above, but nothing structural guarantees that — a refactor
+      // splitting the branch could silently drop the fold from 'all' while the
+      // 'history' seam test stays green. Pin both entry points.
+      mockService.cleanupOldHistory.mockResolvedValue(7);
+      mockService.cleanupSoftDeletedMessages.mockResolvedValue(2);
+      mockService.cleanupOldTombstones.mockResolvedValue(3);
+
+      const response = await request(app).post('/admin/cleanup').send({ target: 'all' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.historyDeleted).toBe(9);
+      expect(response.body.tombstonesDeleted).toBe(3);
+      expect(mockService.cleanupSoftDeletedMessages).toHaveBeenCalledWith();
+    });
+
     it('should return validation error for daysToKeep less than 1', async () => {
       const response = await request(app).post('/admin/cleanup').send({ daysToKeep: 0 });
 


### PR DESCRIPTION
Test-only PR — beta.145 opener #1, closing the two gaps flagged during the beta.144 release cycle.

## 1. `'all'`-target seam assertion (cleanup route)

The `'all'` target shares the `target === 'history' || target === 'all'` branch with `'history'`, but only `'history'` had the `cleanupSoftDeletedMessages` fold assertion (#1437 round-3 reviewer note). A branch-splitting refactor could silently drop the fold from `'all'` while the existing seam test stayed green. Both entry points now pinned.

## 2. Mid-sweep partial-commit contract (PGLite component test)

The per-batch atomicity contract was documented in `deleteMessagesWithTombstones`'s comments but unverifiable in unit tests — it's transaction-commit behavior needing a real database. The new component test:

- Bulk-seeds `RETENTION_BATCH_SIZE + 100` expired rows
- Wraps the PGLite prisma in a pass-through Proxy that rejects the **2nd** `$transaction`
- Asserts: batch 1 fully committed (1000 rows deleted **with** their tombstones — the invariant that stops db-sync resurrection), the 100-row remainder untouched, the error propagated, and a healthy-client retry drains the remainder to zero

Verified with the tier configs that actually run them: 13/13 unit (`vitest run`), 11/11 component (`vitest.component.config.ts`), spec typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)