### PR TITLE
fix(deps): clean-first builds — kill the turbo cache-poisoning class

### DIFF
--- a/packages/cache-invalidation/package.json
+++ b/packages/cache-invalidation/package.json
@@ -8,7 +8,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "clean": "find src -name '*.js' -type f -delete && find src -name '*.js.map' -type f -delete",
-    "build": "tsc",
+    "build": "rm -rf dist tsconfig.tsbuildinfo && tsc",
     "pretest": "npm run clean",
     "test": "vitest",
     "test:watch": "vitest --watch",

--- a/packages/clients/package.json
+++ b/packages/clients/package.json
@@ -8,7 +8,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "clean": "find src -name '*.js' -type f -delete && find src -name '*.js.map' -type f -delete",
-    "build": "tsc",
+    "build": "rm -rf dist tsconfig.tsbuildinfo && tsc",
     "pretest": "npm run clean",
     "test": "vitest",
     "test:watch": "vitest --watch",

--- a/packages/common-types/package.json
+++ b/packages/common-types/package.json
@@ -8,7 +8,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "clean": "find src -name '*.js' -type f -delete && find src -name '*.js.map' -type f -delete",
-    "build": "tsc",
+    "build": "rm -rf dist tsconfig.tsbuildinfo && tsc",
     "pretest": "npm run clean",
     "test": "vitest",
     "test:watch": "vitest --watch",

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -8,7 +8,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "clean": "find src -name '*.js' -type f -delete && find src -name '*.js.map' -type f -delete",
-    "build": "tsc",
+    "build": "rm -rf dist tsconfig.tsbuildinfo && tsc",
     "pretest": "npm run clean",
     "test": "vitest",
     "test:watch": "vitest --watch",

--- a/packages/conversation-history/package.json
+++ b/packages/conversation-history/package.json
@@ -8,7 +8,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "clean": "find src -name '*.js' -type f -delete && find src -name '*.js.map' -type f -delete",
-    "build": "tsc",
+    "build": "rm -rf dist tsconfig.tsbuildinfo && tsc",
     "pretest": "npm run clean",
     "test": "vitest",
     "test:watch": "vitest --watch",

--- a/packages/embeddings/package.json
+++ b/packages/embeddings/package.json
@@ -8,7 +8,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "clean": "find src -name '*.js' -type f -delete && find src -name '*.js.map' -type f -delete",
-    "build": "tsc",
+    "build": "rm -rf dist tsconfig.tsbuildinfo && tsc",
     "pretest": "npm run clean",
     "test": "vitest",
     "test:watch": "vitest --watch",

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -8,7 +8,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "clean": "find src -name '*.js' -type f -delete && find src -name '*.js.map' -type f -delete",
-    "build": "tsc",
+    "build": "rm -rf dist tsconfig.tsbuildinfo && tsc",
     "pretest": "npm run clean",
     "test": "vitest",
     "test:watch": "vitest --watch",

--- a/packages/test-factories/package.json
+++ b/packages/test-factories/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "clean": "rm -rf dist",
-    "build": "tsc",
+    "build": "rm -rf dist tsconfig.tsbuildinfo && tsc",
     "test": "vitest",
     "lint": "eslint src --max-warnings=0",
     "lint:fix": "eslint src --fix",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsc",
+    "build": "rm -rf dist tsconfig.tsbuildinfo && tsc",
     "clean": "rm -rf dist",
     "lint": "eslint src --max-warnings=0",
     "lint:fix": "eslint src --fix",

--- a/packages/tooling/package.json
+++ b/packages/tooling/package.json
@@ -18,7 +18,7 @@
     "ops": "./dist/cli.js"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "rm -rf dist tsconfig.tsbuildinfo && tsc",
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
     "test": "vitest run",

--- a/services/ai-worker/package.json
+++ b/services/ai-worker/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "clean": "find src -name '*.js' -type f -delete && find src -name '*.js.map' -type f -delete",
     "dev": "tsx watch src/index.ts",
-    "build": "tsc",
+    "build": "rm -rf dist tsconfig.tsbuildinfo && tsc",
     "start": "node dist/index.js",
     "pretest": "npm run clean",
     "test": "vitest",

--- a/services/api-gateway/package.json
+++ b/services/api-gateway/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "clean": "find src -name '*.js' -type f -delete && find src -name '*.js.map' -type f -delete",
     "dev": "tsx watch src/index.ts",
-    "build": "tsc",
+    "build": "rm -rf dist tsconfig.tsbuildinfo && tsc",
     "start": "node dist/index.js",
     "pretest": "npm run clean",
     "test": "vitest",

--- a/services/bot-client/package.json
+++ b/services/bot-client/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "clean": "find src -name '*.js' -type f -delete && find src -name '*.js.map' -type f -delete",
     "dev": "tsx watch src/index.ts",
-    "build": "tsc",
+    "build": "rm -rf dist tsconfig.tsbuildinfo && tsc",
     "start": "node dist/index.js",
     "pretest": "npm run clean",
     "test": "vitest",


### PR DESCRIPTION
Structural fix for the cache-poisoning trap that bit three times today (two pre-push build failures with correct source, one full-cache-purge recovery).

## The mechanism (now fully decoded)

1. Root tsconfig sets `incremental: true`; every package builds with bare `tsc`; the `tsconfig.tsbuildinfo` lives at package root — **outside** turbo's `outputs: ["dist/**"]`.
2. A turbo cache restore replaces `dist/` but not the tsbuildinfo → the stale-claiming tsbuildinfo makes the next executed `tsc` a **no-op over wrong output**.
3. Turbo then caches that stale dist under the **current** source hash → the hash is poisoned; even source edits + rebuilds get clobbered on the next restore.

## The fix

`"build": "rm -rf dist tsconfig.tsbuildinfo && tsc"` in all 13 packages. An executed build that starts from nothing can never emit stale output, so no poisoned artifact can enter the cache — terminal by construction, rather than an escape procedure.

**Cost is nil in practice**: turbo already skips unchanged packages entirely via cache-hit, so tsc's incremental mode gained nothing inside the build task. The spec typecheck's separate `tsconfig.spec.tsbuildinfo` is untouched.

Verified by full `pnpm build` (13/13) from a deliberately-poisoned state (bogus tsbuildinfo touched first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)