### PR TITLE
ci: enforce workflow-file sync with main + fix stale integration-tier comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,12 @@ jobs:
       - name: Check audit tools have WHY.md
         run: pnpm ops guard:audit-tool-docs
 
+      # Workflow-file sync: a workflow change reaching develop before main
+      # silently disables claude-review on every PR (green ~15s no-op) until
+      # the next release. The guard skips itself on main-cut branches.
+      - name: Enforce workflow-file sync with main
+        run: pnpm ops guard:workflow-sync
+
       - name: Check claude/ command references resolve
         run: pnpm ops guard:claude-content-refs
 
@@ -343,7 +349,8 @@ jobs:
 
       # Real-dependency tiers: contract (*.contract.test.ts — the golden-fixture
       # envelope consumer + the BullMQ pair) + integration (*.integration.test.ts,
-      # currently none). The coverage topology's mechanism-presence check assumes
+      # e.g. the vision-fallback loop over real Redis). The coverage topology's
+      # mechanism-presence check assumes
       # these tiers execute + gate in CI; this step is that gate. `if: !cancelled()`
       # so a component-test failure doesn't hide the contract tier's own result.
       - name: Run integration + contract tiers


### PR DESCRIPTION
Main-cut PR per the workflow-file rule (a develop-first landing would silently disable claude-review on every PR until the next release). Pre-approved in session; merges right before the beta.145 release PR.

Two changes to `ci.yml`:
1. **`guard:workflow-sync` step in the lint job** — the command shipped on develop (#1452); this step makes drift a hard CI failure instead of a silent review-skip. Known nuance: on THIS PR's own CI run the step no-ops (main's tooling predates the command — cac exits 0 on unknown commands, verified); the release merge brings the command to main minutes later, and all developer-facing runs use develop-based checkouts that have it.
2. **Stale integration-tier comment** — `currently none` → the vision-fallback loop test (#1445) landed as the first `*.integration.test.ts`.

claude-review will skip on this PR (its ci.yml differs from main — the exact validation the guard exists to protect); the diff is 8 lines and was reviewed in-session.

After merge: `pnpm ops release:finalize` immediately, then the release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)