### PR TITLE
feat(tooling): harvest DEFERRABLE-constraint ALTERs into the PGLite schema

### DIFF
--- a/packages/test-utils/schema/pglite-schema.sql
+++ b/packages/test-utils/schema/pglite-schema.sql
@@ -924,3 +924,14 @@ CREATE UNIQUE INDEX "tts_configs_global_name_unique" ON "tts_configs"("name") WH
 CREATE UNIQUE INDEX "llm_configs_free_default_unique" ON "llm_configs"("kind") WHERE "is_free_default" = true;
 CREATE UNIQUE INDEX "llm_configs_global_name_unique" ON "llm_configs"("kind", "name") WHERE "is_global" = true;
 CREATE UNIQUE INDEX "llm_configs_default_unique" ON "llm_configs"("kind") WHERE "is_default" = true;
+
+-- DEFERRABLE-constraint ALTERs harvested from prisma/migrations/**/migration.sql
+-- (Prisma can't express DEFERRABLE in schema.prisma, so the hand-written
+-- ALTER CONSTRAINT statements are merged back in here. db-sync relies on
+-- SET CONSTRAINTS ALL DEFERRED for atomic circular-FK inserts.)
+ALTER TABLE "users" ALTER CONSTRAINT "users_default_persona_id_fkey" DEFERRABLE INITIALLY IMMEDIATE;
+ALTER TABLE "users" ALTER CONSTRAINT "users_default_llm_config_id_fkey" DEFERRABLE INITIALLY IMMEDIATE;
+ALTER TABLE "personas" ALTER CONSTRAINT "personas_owner_id_fkey" DEFERRABLE INITIALLY IMMEDIATE;
+ALTER TABLE "llm_configs" ALTER CONSTRAINT "llm_configs_owner_id_fkey" DEFERRABLE INITIALLY IMMEDIATE;
+ALTER TABLE "users" ALTER CONSTRAINT "users_default_tts_config_id_fkey" DEFERRABLE INITIALLY IMMEDIATE;
+ALTER TABLE "users" ALTER CONSTRAINT "users_default_vision_config_id_fkey" DEFERRABLE INITIALLY IMMEDIATE;

--- a/packages/tooling/src/test/generate-schema.test.ts
+++ b/packages/tooling/src/test/generate-schema.test.ts
@@ -548,7 +548,7 @@ describe('generateSchema', () => {
       await generateSchema();
 
       const output = consoleLogSpy.mock.calls.flat().join(' ');
-      expect(output).toContain('2 partial-UNIQUE indexes preserved');
+      expect(output).toContain('2 partial-UNIQUE indexes');
     });
 
     it('does not add the partial-UNIQUE banner when no partial-unique indexes exist', async () => {
@@ -561,6 +561,154 @@ describe('generateSchema', () => {
 
       const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
       expect(content).not.toContain('Partial-UNIQUE indexes harvested from');
+    });
+  });
+
+  describe('DEFERRABLE-constraint preservation', () => {
+    /**
+     * Build a mock-fs layout for a set of migrations. Mirrors the helpers in
+     * the CHECK/partial-unique suites — kept local so each suite is
+     * self-contained.
+     */
+    function mockMigrations(migrations: Record<string, string>): void {
+      fsMock.existsSync.mockImplementation((path: string) => {
+        if (path.endsWith('prisma/migrations')) return true;
+        for (const name of Object.keys(migrations)) {
+          if (path.endsWith(`${name}/migration.sql`)) return true;
+        }
+        return false;
+      });
+      fsMock.readdirSync.mockImplementation(() =>
+        Object.keys(migrations).map(name => ({
+          name,
+          isDirectory: () => true,
+        }))
+      );
+      fsMock.readFileSync.mockImplementation((path: string) => {
+        for (const [name, sql] of Object.entries(migrations)) {
+          if (path.endsWith(`${name}/migration.sql`)) return sql;
+        }
+        return '';
+      });
+    }
+
+    it('extracts a multi-line ALTER CONSTRAINT DEFERRABLE statement, normalizing whitespace', async () => {
+      // The real migration shape: wrapped after ALTER TABLE, with a comment.
+      mockMigrations({
+        '20260418010642_make_circular_fks_deferrable': `
+          -- Prisma cannot express DEFERRABLE in schema.prisma.
+          ALTER TABLE "users"
+            ALTER CONSTRAINT "users_default_persona_id_fkey" DEFERRABLE INITIALLY IMMEDIATE;
+        `,
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
+      expect(content).toContain(
+        'ALTER TABLE "users" ALTER CONSTRAINT "users_default_persona_id_fkey" DEFERRABLE INITIALLY IMMEDIATE;'
+      );
+      expect(content).toContain('DEFERRABLE-constraint ALTERs harvested from');
+    });
+
+    it('harvests ONLY the ALTER CONSTRAINT statements out of a full mixed-DDL migration', async () => {
+      // Mirror of 20260627040007_vision_config_kind: the DEFERRABLE clause
+      // lives among unrelated columns/indexes that the base diff already
+      // emits — re-harvesting those would produce duplicate DDL.
+      mockMigrations({
+        '20260627040007_vision_config_kind': `
+          ALTER TABLE "users" ADD COLUMN "default_vision_config_id" UUID;
+          CREATE INDEX "users_default_vision_config_id_idx" ON "users"("default_vision_config_id");
+          ALTER TABLE "users" ADD CONSTRAINT "users_default_vision_config_id_fkey"
+            FOREIGN KEY ("default_vision_config_id") REFERENCES "llm_configs"("id");
+          ALTER TABLE "users"
+            ALTER CONSTRAINT "users_default_vision_config_id_fkey" DEFERRABLE INITIALLY IMMEDIATE;
+        `,
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
+      const harvestedSection = content.slice(content.indexOf('DEFERRABLE-constraint ALTERs'));
+      expect(harvestedSection).toContain(
+        'ALTER CONSTRAINT "users_default_vision_config_id_fkey" DEFERRABLE INITIALLY IMMEDIATE;'
+      );
+      expect(harvestedSection).not.toContain('ADD COLUMN');
+      expect(harvestedSection).not.toContain('CREATE INDEX');
+      expect(harvestedSection).not.toContain('FOREIGN KEY');
+    });
+
+    it('does NOT extract a NOT DEFERRABLE revert, and removes the prior definition', async () => {
+      mockMigrations({
+        '20260101000000_make_deferrable':
+          'ALTER TABLE "t" ALTER CONSTRAINT "c1" DEFERRABLE INITIALLY IMMEDIATE;',
+        '20260102000000_revert': 'ALTER TABLE "t" ALTER CONSTRAINT "c1" NOT DEFERRABLE;',
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
+      expect(content).not.toContain('"c1"');
+      expect(content).not.toContain('DEFERRABLE-constraint ALTERs harvested from');
+    });
+
+    it('removes a DEFERRABLE clause when a later migration drops the constraint', async () => {
+      // Prisma emits DROP + re-ADD when an FK definition changes, and the
+      // re-ADD never carries DEFERRABLE — the harvest must mirror prod losing
+      // deferrability in that case.
+      mockMigrations({
+        '20260101000000_make_deferrable':
+          'ALTER TABLE "t" ALTER CONSTRAINT "c1" DEFERRABLE INITIALLY IMMEDIATE;',
+        '20260102000000_redefine_fk': `
+          ALTER TABLE "t" DROP CONSTRAINT "c1";
+          ALTER TABLE "t" ADD CONSTRAINT "c1" FOREIGN KEY ("x") REFERENCES "u"("id");
+        `,
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
+      expect(content).not.toContain('DEFERRABLE INITIALLY IMMEDIATE');
+    });
+
+    it('keeps the last definition when deferrability is re-added after a drop', async () => {
+      mockMigrations({
+        '20260101000000_make_deferrable':
+          'ALTER TABLE "t" ALTER CONSTRAINT "c1" DEFERRABLE INITIALLY IMMEDIATE;',
+        '20260102000000_redefine_and_realter': `
+          ALTER TABLE "t" DROP CONSTRAINT "c1";
+          ALTER TABLE "t" ADD CONSTRAINT "c1" FOREIGN KEY ("x") REFERENCES "u"("id");
+          ALTER TABLE "t" ALTER CONSTRAINT "c1" DEFERRABLE INITIALLY DEFERRED;
+        `,
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const [, content] = fsMock.writeFileSync.mock.calls[0] as [string, string];
+      expect(content).toContain(
+        'ALTER TABLE "t" ALTER CONSTRAINT "c1" DEFERRABLE INITIALLY DEFERRED;'
+      );
+      expect(content).not.toContain('INITIALLY IMMEDIATE');
+    });
+
+    it('reports the DEFERRABLE count in the success message', async () => {
+      mockMigrations({
+        '20260101000000_two': `
+          ALTER TABLE "t" ALTER CONSTRAINT "c1" DEFERRABLE INITIALLY IMMEDIATE;
+          ALTER TABLE "t" ALTER CONSTRAINT "c2" DEFERRABLE INITIALLY IMMEDIATE;
+        `,
+      });
+
+      const { generateSchema } = await import('./generate-schema.js');
+      await generateSchema();
+
+      const output = consoleLogSpy.mock.calls.flat().join(' ');
+      expect(output).toContain('2 DEFERRABLE constraints preserved');
     });
   });
 

--- a/packages/tooling/src/test/generate-schema.ts
+++ b/packages/tooling/src/test/generate-schema.ts
@@ -41,6 +41,17 @@ const PARTIAL_UNIQUE_INDEX_BANNER = [
   '-- being real Postgres-in-WASM, applies just like prod.)',
 ].join('\n');
 
+/**
+ * Header preceding appended DEFERRABLE-constraint ALTERs. Same shape as the
+ * banners above.
+ */
+const DEFERRABLE_CONSTRAINT_BANNER = [
+  '-- DEFERRABLE-constraint ALTERs harvested from prisma/migrations/**/migration.sql',
+  "-- (Prisma can't express DEFERRABLE in schema.prisma, so the hand-written",
+  '-- ALTER CONSTRAINT statements are merged back in here. db-sync relies on',
+  '-- SET CONSTRAINTS ALL DEFERRED for atomic circular-FK inserts.)',
+].join('\n');
+
 interface GenerateSchemaOptions {
   output?: string;
 }
@@ -60,8 +71,7 @@ interface GenerateSchemaOptions {
  * tokens (some migrations wrap after `ALTER TABLE`, others are single-line).
  * Case-insensitive to match either SQL convention. `"[^"]+"` requires at
  * least one character inside the quotes, so a successful match guarantees
- * group 1 is a non-empty string (see narrowing in
- * `extractCheckStatementsFromFile`).
+ * the name group is a non-empty string.
  */
 const CHECK_CONSTRAINT_REGEX = /^ALTER\s+TABLE\s+"[^"]+"\s+ADD\s+CONSTRAINT\s+"([^"]+)"\s+CHECK\b/i;
 // Matches both forms: `DROP CONSTRAINT "c"` and `DROP CONSTRAINT IF EXISTS "c"`.
@@ -70,114 +80,6 @@ const CHECK_CONSTRAINT_REGEX = /^ALTER\s+TABLE\s+"[^"]+"\s+ADD\s+CONSTRAINT\s+"(
 // equivalent for our extraction purposes.
 const DROP_CONSTRAINT_REGEX =
   /^ALTER\s+TABLE\s+"[^"]+"\s+DROP\s+CONSTRAINT\s+(?:IF\s+EXISTS\s+)?"([^"]+)"/i;
-
-type ExtractedCheck =
-  | { kind: 'add'; name: string; statement: string }
-  | { kind: 'drop'; name: string };
-
-/**
- * Parse one migration.sql file and emit its CHECK-constraint operations
- * (both ADD and DROP). Strips both line-comments and block-comments before
- * splitting on `;` — block comments matter because a block-comment body can
- * contain a raw `;` that would split the surrounding statement in half and
- * silently drop the CHECK that followed.
- *
- * DROP CONSTRAINT is emitted alongside ADD so the outer dedup loop can remove
- * a previously-added constraint when a later migration retires it without
- * re-adding (else PGLite would enforce a CHECK that prod Postgres no longer
- * has, producing confusing integration-test false positives).
- */
-function extractCheckStatementsFromFile(sqlPath: string): ExtractedCheck[] {
-  const raw = readFileSync(sqlPath, 'utf-8');
-  const uncommented = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/--[^\n]*/g, '');
-  const results: ExtractedCheck[] = [];
-
-  // Prisma migrations use ; as the unambiguous statement terminator even
-  // across line breaks. CHECK expressions can contain nested parens but never
-  // a raw ;. Splitting here is safer than a multi-line regex that has to
-  // balance parens.
-  for (const stmt of uncommented.split(';')) {
-    const trimmed = stmt.trim();
-    if (trimmed.length === 0) continue;
-
-    const addMatch = CHECK_CONSTRAINT_REGEX.exec(trimmed);
-    if (addMatch !== null) {
-      const name = addMatch[1];
-      // Unreachable per regex (`"[^"]+"` requires the capture), but TS sees
-      // match[1] as string | undefined.
-      if (name === undefined) continue;
-      results.push({
-        kind: 'add',
-        name,
-        statement: normalizeStatement(trimmed) + ';',
-      });
-      continue;
-    }
-
-    const dropMatch = DROP_CONSTRAINT_REGEX.exec(trimmed);
-    if (dropMatch !== null) {
-      const name = dropMatch[1];
-      // Unreachable per regex (`"[^"]+"` requires the capture); guard
-      // satisfies TS's `string | undefined` view of the match group.
-      if (name === undefined) continue;
-      results.push({ kind: 'drop', name });
-    }
-  }
-  return results;
-}
-
-/**
- * Extract all `ADD CONSTRAINT ... CHECK (...)` statements from every
- * `migration.sql` under `migrationsDir`. When the same constraint name
- * appears in multiple migrations (drop + re-add across two files), the
- * **last** migration's definition wins — this matches Postgres's own
- * semantics: after migration B drops and re-adds `c1`, prod enforces
- * migration B's CHECK expression, not migration A's. First-wins would
- * silently ship migration A's (stale) definition into PGLite while prod
- * runs migration B's, re-introducing the fidelity gap this extractor
- * was built to eliminate.
- */
-export function extractCheckConstraints(migrationsDir: string): string[] {
-  if (!existsSync(migrationsDir)) {
-    return [];
-  }
-
-  const migrationFolders = readdirSync(migrationsDir, { withFileTypes: true })
-    .filter(d => d.isDirectory())
-    .map(d => d.name)
-    // Prisma prefixes folders with `YYYYMMDDHHMMSS_`, so lexicographic sort
-    // matches chronological sort — essential for the last-wins dedup below.
-    .sort();
-
-  // Map.set overwrites existing entries while preserving insertion order.
-  // Iterating chronologically means later migrations replace earlier ones
-  // by name while the overall emission order stays deterministic.
-  const byName = new Map<string, string>();
-
-  for (const folder of migrationFolders) {
-    const sqlPath = join(migrationsDir, folder, 'migration.sql');
-    if (!existsSync(sqlPath)) continue;
-
-    for (const op of extractCheckStatementsFromFile(sqlPath)) {
-      if (op.kind === 'add') {
-        byName.set(op.name, op.statement);
-      } else {
-        // DROP without subsequent re-ADD must remove the prior definition.
-        // A drop-then-re-add pair across two migrations is handled correctly
-        // by the natural sequence: this delete fires, then the next iteration's
-        // ADD repopulates with the new statement.
-        byName.delete(op.name);
-      }
-    }
-  }
-
-  return Array.from(byName.values());
-}
-
-/** Collapse internal whitespace so each statement ends up on one line. */
-function normalizeStatement(stmt: string): string {
-  return stmt.replace(/\s+/g, ' ').trim();
-}
 
 /**
  * Matches a `CREATE UNIQUE INDEX "<name>" ON ... WHERE ...` statement and
@@ -201,8 +103,7 @@ function normalizeStatement(stmt: string): string {
  * The `[\s\S]*?` between the table reference and `WHERE` is lazy so it can
  * span the multi-line column list these statements usually wrap across,
  * without swallowing past the first `WHERE`. Case-insensitive to match either
- * SQL convention. `"[^"]+"` requires at least one character inside the quotes,
- * so a successful match guarantees group 1 is a non-empty string.
+ * SQL convention.
  */
 const PARTIAL_UNIQUE_INDEX_REGEX = /^CREATE\s+UNIQUE\s+INDEX\s+"([^"]+)"\s+ON\s[\s\S]*?\bWHERE\b/i;
 // Matches both `DROP INDEX "i"` and `DROP INDEX IF EXISTS "i"`. A hand-written
@@ -211,34 +112,79 @@ const PARTIAL_UNIQUE_INDEX_REGEX = /^CREATE\s+UNIQUE\s+INDEX\s+"([^"]+)"\s+ON\s[
 // loop needs to see the DROP to apply last-wins correctly.
 const DROP_INDEX_REGEX = /^DROP\s+INDEX\s+(?:IF\s+EXISTS\s+)?"([^"]+)"/i;
 
-type ExtractedIndex =
-  | { kind: 'add'; name: string; statement: string }
-  | { kind: 'drop'; name: string };
+/**
+ * Matches an `ALTER TABLE ... ALTER CONSTRAINT "<name>" DEFERRABLE ...`
+ * statement and captures the constraint name.
+ *
+ * Why this extractor exists: same gap again. Prisma cannot express
+ * DEFERRABLE in schema.prisma, so the circular-FK migrations hand-write
+ * `ALTER CONSTRAINT ... DEFERRABLE INITIALLY IMMEDIATE` — and `migrate diff`
+ * silently omits them. Without this harvest, PGLite FKs are NOT DEFERRABLE:
+ * `SET CONSTRAINTS ALL DEFERRED` becomes a silent no-op and db-sync's atomic
+ * circular inserts (users ↔ personas ↔ configs) fail in component tests while
+ * working in prod.
+ *
+ * The name group cannot match a `NOT DEFERRABLE` revert — `NOT` intervenes
+ * between the quoted name and `DEFERRABLE`, so the revert form falls through
+ * to DEFERRABLE_UNDO_REGEX below.
+ */
+const DEFERRABLE_CONSTRAINT_REGEX =
+  /^ALTER\s+TABLE\s+"[^"]+"\s+ALTER\s+CONSTRAINT\s+"([^"]+)"\s+DEFERRABLE\b/i;
+/**
+ * Undoes a harvested DEFERRABLE clause. Two forms retire deferrability:
+ * an explicit `ALTER CONSTRAINT "c" NOT DEFERRABLE` revert, or dropping the
+ * constraint outright (Prisma emits DROP + re-ADD when an FK definition
+ * changes, and the re-ADD never carries DEFERRABLE — so post-drop, prod is
+ * not deferrable unless a later migration re-alters it, and the harvest
+ * must mirror that).
+ */
+const DEFERRABLE_UNDO_REGEX =
+  /^ALTER\s+TABLE\s+"[^"]+"\s+(?:ALTER\s+CONSTRAINT\s+"([^"]+)"\s+NOT\s+DEFERRABLE\b|DROP\s+CONSTRAINT\s+(?:IF\s+EXISTS\s+)?"([^"]+)")/i;
+
+type ExtractedOp =
+  { kind: 'add'; name: string; statement: string } | { kind: 'drop'; name: string };
+
+/** Collapse internal whitespace so each statement ends up on one line. */
+function normalizeStatement(stmt: string): string {
+  return stmt.replace(/\s+/g, ' ').trim();
+}
+
+/** First defined capture group — undo regexes carry the name in one of two groups. */
+function capturedName(match: RegExpExecArray): string | undefined {
+  return match.slice(1).find(group => group !== undefined);
+}
 
 /**
- * Parse one migration.sql file and emit its partial-UNIQUE-index operations
- * (both ADD and DROP). Reuses the same comment-stripping + split-on-`;`
- * strategy as the CHECK extractor — block comments must be stripped because a
- * `;` inside one would split the surrounding statement.
+ * Parse one migration.sql file and emit the add/drop operations matched by
+ * the given regex pair. Strips both line-comments and block-comments before
+ * splitting on `;` — block comments matter because a block-comment body can
+ * contain a raw `;` that would split the surrounding statement in half and
+ * silently drop the statement that followed.
  *
- * DROP INDEX is emitted alongside CREATE so the outer dedup loop can drop a
- * previously-added partial index when a later migration (or a same-file
- * DROP-then-CREATE pair, as the per-kind rework uses) retires or redefines it.
+ * Prisma migrations use `;` as the unambiguous statement terminator even
+ * across line breaks. Harvested expressions can contain nested parens but
+ * never a raw `;`, so splitting here is safer than a multi-line regex that
+ * has to balance parens.
+ *
+ * Drops are emitted alongside adds so the last-wins dedup in
+ * `harvestLastWins` can remove a previously-added statement when a later
+ * migration retires it without re-adding (else PGLite would enforce DDL that
+ * prod Postgres no longer has, producing confusing test false positives).
  */
-function extractPartialUniqueStatementsFromFile(sqlPath: string): ExtractedIndex[] {
+function extractOpsFromFile(sqlPath: string, addRegex: RegExp, dropRegex: RegExp): ExtractedOp[] {
   const raw = readFileSync(sqlPath, 'utf-8');
   const uncommented = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/--[^\n]*/g, '');
-  const results: ExtractedIndex[] = [];
+  const results: ExtractedOp[] = [];
 
   for (const stmt of uncommented.split(';')) {
     const trimmed = stmt.trim();
     if (trimmed.length === 0) continue;
 
-    const addMatch = PARTIAL_UNIQUE_INDEX_REGEX.exec(trimmed);
+    const addMatch = addRegex.exec(trimmed);
     if (addMatch !== null) {
-      const name = addMatch[1];
-      // Unreachable per regex (`"[^"]+"` requires the capture), but TS sees
-      // match[1] as string | undefined.
+      const name = capturedName(addMatch);
+      // Unreachable per the regexes (`"[^"]+"` requires the capture), but TS
+      // sees the group as string | undefined.
       if (name === undefined) continue;
       results.push({
         kind: 'add',
@@ -248,11 +194,10 @@ function extractPartialUniqueStatementsFromFile(sqlPath: string): ExtractedIndex
       continue;
     }
 
-    const dropMatch = DROP_INDEX_REGEX.exec(trimmed);
+    const dropMatch = dropRegex.exec(trimmed);
     if (dropMatch !== null) {
-      const name = dropMatch[1];
-      // Unreachable per regex (`"[^"]+"` requires the capture); guard
-      // satisfies TS's `string | undefined` view of the match group.
+      const name = capturedName(dropMatch);
+      // Unreachable per the regexes; guard satisfies TS's view of the group.
       if (name === undefined) continue;
       results.push({ kind: 'drop', name });
     }
@@ -261,15 +206,17 @@ function extractPartialUniqueStatementsFromFile(sqlPath: string): ExtractedIndex
 }
 
 /**
- * Extract all partial `CREATE UNIQUE INDEX ... WHERE ...` statements from every
- * `migration.sql` under `migrationsDir`. When the same index name appears in
- * multiple migrations (drop + recreate across files, or a same-file
- * drop-then-create), the **last** definition wins — matching Postgres's own
- * post-apply state. First-wins would ship a stale predicate into PGLite while
- * prod runs the latest one, re-introducing the fidelity gap this extractor
- * eliminates.
+ * Extract all statements matching `addRegex` from every `migration.sql`
+ * under `migrationsDir`, applying last-wins dedup by captured name. When the
+ * same name appears in multiple migrations (drop + re-add across two files,
+ * or a same-file drop-then-add pair), the **last** definition wins — this
+ * matches Postgres's own semantics: after migration B drops and re-adds a
+ * constraint, prod enforces migration B's definition, not migration A's.
+ * First-wins would silently ship the stale definition into PGLite while prod
+ * runs the latest one, re-introducing the fidelity gap the harvest exists to
+ * eliminate. A drop without re-add removes the entry entirely.
  */
-export function extractPartialUniqueIndexes(migrationsDir: string): string[] {
+function harvestLastWins(migrationsDir: string, addRegex: RegExp, dropRegex: RegExp): string[] {
   if (!existsSync(migrationsDir)) {
     return [];
   }
@@ -281,29 +228,44 @@ export function extractPartialUniqueIndexes(migrationsDir: string): string[] {
     // matches chronological sort — essential for the last-wins dedup below.
     .sort();
 
-  // Map.set overwrites existing entries while preserving insertion order, so
-  // iterating chronologically lets later migrations replace earlier ones by
-  // name while the overall emission order stays deterministic.
+  // Map.set overwrites existing entries while preserving insertion order.
+  // Iterating chronologically means later migrations replace earlier ones
+  // by name while the overall emission order stays deterministic.
   const byName = new Map<string, string>();
 
   for (const folder of migrationFolders) {
     const sqlPath = join(migrationsDir, folder, 'migration.sql');
     if (!existsSync(sqlPath)) continue;
 
-    for (const op of extractPartialUniqueStatementsFromFile(sqlPath)) {
+    for (const op of extractOpsFromFile(sqlPath, addRegex, dropRegex)) {
       if (op.kind === 'add') {
         byName.set(op.name, op.statement);
       } else {
-        // DROP removes the prior definition. A same-file DROP-then-CREATE pair
-        // (the per-kind rework's shape) is handled correctly by source order:
-        // this delete fires first, then the following CREATE repopulates with
-        // the new predicate.
+        // Drop without subsequent re-add must remove the prior definition.
+        // A drop-then-re-add pair (across files or within one) is handled
+        // correctly by the natural sequence: this delete fires, then the
+        // following add repopulates with the new statement.
         byName.delete(op.name);
       }
     }
   }
 
   return Array.from(byName.values());
+}
+
+/** All `ADD CONSTRAINT ... CHECK (...)` statements, last-wins deduped. */
+export function extractCheckConstraints(migrationsDir: string): string[] {
+  return harvestLastWins(migrationsDir, CHECK_CONSTRAINT_REGEX, DROP_CONSTRAINT_REGEX);
+}
+
+/** All partial `CREATE UNIQUE INDEX ... WHERE ...` statements, last-wins deduped. */
+export function extractPartialUniqueIndexes(migrationsDir: string): string[] {
+  return harvestLastWins(migrationsDir, PARTIAL_UNIQUE_INDEX_REGEX, DROP_INDEX_REGEX);
+}
+
+/** All `ALTER CONSTRAINT ... DEFERRABLE ...` statements, last-wins deduped. */
+export function extractDeferrableConstraints(migrationsDir: string): string[] {
+  return harvestLastWins(migrationsDir, DEFERRABLE_CONSTRAINT_REGEX, DEFERRABLE_UNDO_REGEX);
 }
 
 /**
@@ -337,14 +299,15 @@ export async function generateSchema(options: GenerateSchemaOptions = {}): Promi
       }
     );
 
-    // Append CHECK constraints harvested from migration SQL. Prisma's schema-
-    // level diff doesn't represent CHECK constraints, so they must be merged
-    // in post-hoc or PGLite-backed tests silently accept values Postgres would
-    // reject.
+    // Append the DDL Prisma's schema-level diff can't represent, harvested
+    // from the hand-written migration SQL: CHECK constraints, partial-unique
+    // indexes, and DEFERRABLE-constraint ALTERs. Without the merge, PGLite-
+    // backed tests silently diverge from prod Postgres on each front.
     const checkStatements = extractCheckConstraints(migrationsDir);
-    // Same gap, partial-unique indexes: Prisma's diff omits `WHERE`-clause
-    // indexes entirely, so harvest them from the hand-written migrations too.
     const partialUniqueStatements = extractPartialUniqueIndexes(migrationsDir);
+    // Appended AFTER the base diff, which contains every ADD CONSTRAINT the
+    // ALTERs reference — so the harvested statements always find their target.
+    const deferrableStatements = extractDeferrableConstraints(migrationsDir);
 
     const harvestedSections: string[] = [];
     if (checkStatements.length > 0) {
@@ -354,6 +317,9 @@ export async function generateSchema(options: GenerateSchemaOptions = {}): Promi
       harvestedSections.push(
         `${PARTIAL_UNIQUE_INDEX_BANNER}\n${partialUniqueStatements.join('\n')}`
       );
+    }
+    if (deferrableStatements.length > 0) {
+      harvestedSections.push(`${DEFERRABLE_CONSTRAINT_BANNER}\n${deferrableStatements.join('\n')}`);
     }
 
     // Only reshape the base SQL when there's something to append — otherwise
@@ -374,7 +340,8 @@ export async function generateSchema(options: GenerateSchemaOptions = {}): Promi
     console.log(
       chalk.green(
         `Generated ${outputPath} (${lines} lines, ${checkStatements.length} CHECK constraints, ` +
-          `${partialUniqueStatements.length} partial-UNIQUE indexes preserved)`
+          `${partialUniqueStatements.length} partial-UNIQUE indexes, ` +
+          `${deferrableStatements.length} DEFERRABLE constraints preserved)`
       )
     );
     console.log(chalk.dim('Remember to commit the updated schema file.'));

--- a/services/api-gateway/src/services/DatabaseSyncService.component.test.ts
+++ b/services/api-gateway/src/services/DatabaseSyncService.component.test.ts
@@ -27,10 +27,13 @@
  *    pattern since deferred FKs only validate at COMMIT.
  *
  * Setup notes:
- * - `loadPGliteSchema()` returns SQL generated from `schema.prisma`, which
- *   cannot express DEFERRABLE. The DEFERRABLE ALTER statements (from the
- *   circular-FK, TTS, and vision migrations) are applied manually in
- *   `beforeAll` so the test environment matches production's constraint shape.
+ * - `loadPGliteSchema()` carries the DEFERRABLE ALTER statements directly:
+ *   the schema generator harvests `ALTER CONSTRAINT ... DEFERRABLE` from the
+ *   hand-written migrations (Prisma can't express DEFERRABLE in
+ *   schema.prisma), so the test environment matches production's constraint
+ *   shape with no manual migration replay here. If a future migration drops
+ *   deferrability, the harvest mirrors that and this suite's atomic
+ *   circular-insert tests go red.
  * - We spin up TWO PGLite instances — one acts as "dev", one as "prod".
  */
 
@@ -53,17 +56,6 @@ import { DatabaseSyncService } from './DatabaseSyncService.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-/**
- * Load the real DEFERRABLE migration SQL at test startup instead of
- * hand-maintaining a copy in this file (PR #826 R1 #2). If the migration
- * is ever edited, PGLite environment stays in sync with production's
- * constraint shape automatically — which is the exact invariant this
- * test suite is designed to protect.
- *
- * The PGLite schema generator (`prisma migrate diff --from-empty
- * --to-schema`) emits from `schema.prisma` and can't express DEFERRABLE,
- * so we apply this migration manually on top of `loadPGliteSchema()`.
- */
 /** Repo-root-relative path to `prisma/migrations/`. */
 function migrationsDir(): string {
   // Resolve relative to this test file. Service lives at
@@ -71,58 +63,6 @@ function migrationsDir(): string {
   // repo root is four `..` up (services/api-gateway/src/services/ → repo).
   const repoRoot = join(__dirname, '..', '..', '..', '..');
   return join(repoRoot, 'prisma', 'migrations');
-}
-
-function loadDeferrableFkMigration(): string {
-  const migrationPath = join(
-    migrationsDir(),
-    '20260418010642_make_circular_fks_deferrable',
-    'migration.sql'
-  );
-  return readFileSync(migrationPath, 'utf-8');
-}
-
-/**
- * Load the migration that made users.default_tts_config_id_fkey DEFERRABLE.
- * Same rationale as loadDeferrableFkMigration: PGLite schema generator can't
- * express DEFERRABLE, so this migration is applied manually in `beforeAll`.
- * Was added in a follow-up PR after the TTS feature shipped (the original
- * DEFERRABLE migration predates tts_configs).
- */
-function loadTtsDefaultFkDeferrableMigration(): string {
-  const migrationPath = join(
-    migrationsDir(),
-    '20260504065151_make_tts_default_fk_deferrable',
-    'migration.sql'
-  );
-  return readFileSync(migrationPath, 'utf-8');
-}
-
-/**
- * Extract the DEFERRABLE clause for users.default_vision_config_id_fkey from the
- * vision_config_kind migration.
- *
- * Unlike the pure-alter circular/TTS DEFERRABLE migrations (which can be replayed
- * wholesale), 20260627040007 is a FULL schema migration — replaying it on top of
- * loadPGliteSchema() would collide with the columns/indexes that schema already
- * created. So we extract ONLY its `ALTER CONSTRAINT … DEFERRABLE` statement.
- * Reading it from the migration FILE (not inlining the SQL) keeps the same
- * invariant the other helpers protect: if a future migration drops the DEFERRABLE
- * clause, the extraction throws and this test goes red.
- */
-function loadVisionDefaultFkDeferrableClause(): string {
-  const migrationPath = join(migrationsDir(), '20260627040007_vision_config_kind', 'migration.sql');
-  const sql = readFileSync(migrationPath, 'utf-8');
-  const match = sql.match(
-    /ALTER TABLE "users"\s+ALTER CONSTRAINT "users_default_vision_config_id_fkey" DEFERRABLE INITIALLY IMMEDIATE;/
-  );
-  if (match === null) {
-    throw new Error(
-      'DEFERRABLE clause for users_default_vision_config_id_fkey not found in ' +
-        '20260627040007_vision_config_kind — did the migration drop it?'
-    );
-  }
-  return match[0];
 }
 
 /**
@@ -217,32 +157,16 @@ describe('DatabaseSyncService Integration (Ouroboros pattern)', () => {
   let service: DatabaseSyncService;
 
   beforeAll(async () => {
+    // The schema already carries the DEFERRABLE-constraint ALTERs — the
+    // generator harvests them from the hand-written migrations, so no manual
+    // migration replay is needed to match production's constraint shape.
     const schema = loadPGliteSchema();
-    const deferrableFkMigration = loadDeferrableFkMigration();
-    const ttsDefaultFkDeferrableMigration = loadTtsDefaultFkDeferrableMigration();
-    const visionDefaultFkDeferrableClause = loadVisionDefaultFkDeferrableClause();
     const alignTtsGlobalsMigration = loadAlignTtsGlobalsMigration();
 
     devPglite = createTestPGlite();
     prodPglite = createTestPGlite();
     await devPglite.exec(schema);
     await prodPglite.exec(schema);
-    // Apply the DEFERRABLE migrations manually since the PGLite schema
-    // generator can't express DEFERRABLE. Matches what production's
-    // migrated schema actually has in place post-20260418010642 and
-    // post-20260504065151 (added when the TTS feature shipped — the
-    // users_default_tts_config_id_fkey FK has the same DEFERRABLE
-    // requirement as the original four for the same Ouroboros sync
-    // reason).
-    await devPglite.exec(deferrableFkMigration);
-    await prodPglite.exec(deferrableFkMigration);
-    await devPglite.exec(ttsDefaultFkDeferrableMigration);
-    await prodPglite.exec(ttsDefaultFkDeferrableMigration);
-    // Same for the vision-default FK (DEFERRABLE since 20260627040007). Only the
-    // ALTER clause is applied — the full vision migration can't be replayed on
-    // top of the generated schema (see loadVisionDefaultFkDeferrableClause).
-    await devPglite.exec(visionDefaultFkDeferrableClause);
-    await prodPglite.exec(visionDefaultFkDeferrableClause);
     // Recovery migration aligning TTS system-global rows to deterministic
     // UUIDs. Idempotent — these pglite instances have no TTS rows yet, so
     // the WHERE clauses match nothing on the first run. Loaded here for

--- a/services/api-gateway/src/services/sync/utils/alignTtsGlobalsRecovery.component.test.ts
+++ b/services/api-gateway/src/services/sync/utils/alignTtsGlobalsRecovery.component.test.ts
@@ -34,20 +34,6 @@ function migrationsDir(): string {
   return join(__dirname, '..', '..', '..', '..', '..', '..', 'prisma', 'migrations');
 }
 
-function loadDeferrableFkMigration(): string {
-  return readFileSync(
-    join(migrationsDir(), '20260418010642_make_circular_fks_deferrable', 'migration.sql'),
-    'utf-8'
-  );
-}
-
-function loadTtsDefaultFkDeferrableMigration(): string {
-  return readFileSync(
-    join(migrationsDir(), '20260504065151_make_tts_default_fk_deferrable', 'migration.sql'),
-    'utf-8'
-  );
-}
-
 function loadAlignTtsGlobalsMigration(): string {
   return readFileSync(
     join(migrationsDir(), '20260504140720_align_tts_globals_to_deterministic_ids', 'migration.sql'),
@@ -64,9 +50,9 @@ const ALIGNED_MISTRAL_ID = '8aa02cad-2c39-5b5b-9d37-482aacb7788d';
 
 async function setupPglite(): Promise<PGlite> {
   const pglite = createTestPGlite();
+  // The schema already carries the DEFERRABLE-constraint ALTERs — the
+  // generator harvests them from the hand-written migrations.
   await pglite.exec(loadPGliteSchema());
-  await pglite.exec(loadDeferrableFkMigration());
-  await pglite.exec(loadTtsDefaultFkDeferrableMigration());
   return pglite;
 }
 


### PR DESCRIPTION
## Summary

PGLite Fidelity theme, Phase 1. Prisma can't express DEFERRABLE in `schema.prisma`, so `migrate diff` silently dropped the hand-written `ALTER CONSTRAINT ... DEFERRABLE` statements — PGLite FKs were NOT DEFERRABLE, and two component test files papered over it by replaying the deferrable migrations manually (three loaders in `DatabaseSyncService.component.test.ts` + two more in `alignTtsGlobalsRecovery.component.test.ts`, found by exhaustive grep).

## Changes

- **Third harvester** in `generate-schema.ts` for `ALTER CONSTRAINT ... DEFERRABLE`, mirroring the CHECK + partial-unique extractors. Last-wins dedup treats **both** undo forms as retirements: an explicit `NOT DEFERRABLE` revert, and a `DROP CONSTRAINT` (Prisma's DROP + re-ADD on FK redefinition never carries DEFERRABLE, so prod loses deferrability — the harvest mirrors that).
- **Kernel unification**: with a third structurally-identical copy arriving, the per-file parse (comment-strip + split-on-`;`) and chronological last-wins scaffolding moved into one regex-parameterized kernel (`extractOpsFromFile` + `harvestLastWins`); the three public extractors are thin wrappers. Zero callbacks — regex pairs only. Behavior pinned by the pre-existing 30-test suite (all pass unmodified except the success-message wording assertion, updated for the new count clause).
- **`pglite-schema.sql` regenerated**: now carries all six ALTERs (4 circular FKs + TTS default + vision default).
- **Both component tests drop their bespoke replays.** The deferrability invariant survives: the sync suites' atomic circular-insert tests depend on `SET CONSTRAINTS ALL DEFERRED` actually deferring, so a future migration dropping a clause turns them red.

## Verification

- Generator suite: 36/36 (6 new DEFERRABLE cases incl. the mixed-DDL vision-migration shape, NOT-DEFERRABLE revert, drop-retirement, and drop-then-re-alter last-wins).
- Both cleaned component suites green against the harvested schema (11 tests), plus the full api-gateway component tier (245 passed / 10 documented skips).
- Full `pnpm test` + `pnpm quality` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)