### PR TITLE
fix(ai-worker): summarize the unwrapped provider error in the fallback story

### DIFF
--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/autoPromotionFallback.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/autoPromotionFallback.test.ts
@@ -9,6 +9,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { AIProvider } from '@tzurot/common-types';
+import { RetryError } from '../../../../utils/retry.js';
 import {
   runWithAutoPromotionFallback,
   getFallbackFailureSummary,
@@ -169,6 +170,37 @@ describe('runWithAutoPromotionFallback', () => {
     // The attempted route rides along too, so the error footer can render the
     // full chain ("via Z.AI Coding Plan → OpenRouter") instead of the primary.
     expect(getAttemptedFallbackProvider(originalError)).toBe('openrouter');
+  });
+
+  it('summarizes the UNWRAPPED provider error when the fallback failure is RetryError-wrapped', async () => {
+    // The retry machinery rethrows a RetryError whose own message is the
+    // generic wrapper — summarizing THAT buries the provider detail the user
+    // needs (observed in prod: a fallback 402 credit error surfaced as just
+    // "LLM invocation (z-ai/glm-5.2) failed with non-retryable error").
+    const originalError = new Error('Rate limit cached');
+    const providerError = new Error(
+      '402 This request requires more credits, or fewer max_tokens. You requested up to 65536 tokens'
+    );
+    const wrapped = new RetryError(
+      'LLM invocation (z-ai/glm-5.1) failed with non-retryable error',
+      1,
+      providerError
+    );
+    const attempt = vi.fn().mockRejectedValueOnce(originalError).mockRejectedValueOnce(wrapped);
+
+    await expect(
+      runWithAutoPromotionFallback(attempt, baseOpts, {
+        apiKey: 'sk-or',
+        provider: 'openrouter',
+        model: 'z-ai/glm-5.1',
+        isGuestMode: false,
+      })
+    ).rejects.toBe(originalError);
+
+    expect(getFallbackFailureSummary(originalError)).toBe(
+      '402 This request requires more credits, or fewer max_tokens. You requested up to 65536 tokens'
+    );
+    expect(getFallbackFailureSummary(originalError)).not.toContain('non-retryable');
   });
 
   it('caps an over-long fallback failure summary', async () => {

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/autoPromotionFallback.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/autoPromotionFallback.ts
@@ -26,6 +26,7 @@ import type {
 } from '../../../../services/ConversationalRAGTypes.js';
 import type { DiagnosticCollector } from '../../../../services/DiagnosticCollector.js';
 import type { GenerationContext } from '../types.js';
+import { RetryError } from '../../../../utils/retry.js';
 
 const logger = createLogger('AutoPromotionFallback');
 
@@ -150,8 +151,17 @@ export async function runWithAutoPromotionFallback(
       // GenerationStep appends it to the user-facing string AFTER classification.
       // The attempted route rides along so the error footer can render the full
       // chain ("via Z.AI Coding Plan → OpenRouter") instead of just the primary.
+      //
+      // Summarize the UNWRAPPED error: the retry machinery rethrows a
+      // RetryError whose own message is the generic wrapper ("LLM invocation
+      // (<model>) failed with non-retryable error"), which buries the provider
+      // detail the user actually needs (e.g. OpenRouter's 402 "requires more
+      // credits, or fewer max_tokens"). Same unwrap the primary error gets
+      // before classification in GenerationStep's composer.
       attachFallbackFailure(originalError, {
-        summary: summarizeError(fallbackError),
+        summary: summarizeError(
+          fallbackError instanceof RetryError ? fallbackError.lastError : fallbackError
+        ),
         provider: fallback.provider,
       });
       throw originalError;


### PR DESCRIPTION
## Summary

Prod incident (tonight, ref `mr4a692gj8k`): a both-routes-failed error correctly rendered the beta.144 enrichment, but the fallback half read `LLM invocation (z-ai/glm-5.2) failed with non-retryable error` — our retry wrapper's message — instead of the actual OpenRouter 402:

> This request requires more credits, or fewer max_tokens. You requested up to 65536 tokens, but can only afford 32646.

That detail is user-actionable (add credits *or lower maxTokens*); the wrapper text is not.

## Root cause + fix

`summarizeError(fallbackError)` read `.message` off the caught error, which is a `RetryError` wrapper rethrown by the retry machinery. The primary error already gets unwrapped (`error instanceof RetryError ? error.lastError : error`) before classification — the fallback summary path never did. The summary now unwraps to `lastError` before capping, so the provider's own sentence surfaces.

New test locks the exact incident shape: a RetryError-wrapped 402 must summarize to the provider message and must not contain the wrapper's "non-retryable" text.

## Incident notes (context, no code change)

- Primary failure was a z.ai headerless 429 (code 1305, capacity) — same late-June instability class.
- The full OpenRouter 402 body (including the `previous_errors` provider-attempt array) is now a captured sample for the sample-gated z.ai/402 error-shape theme; recording it there on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)