### PR TITLE
fix(ai-worker): treat finish_reason 'error' as a retryable failure

### DIFF
--- a/packages/common-types/src/constants/error.ts
+++ b/packages/common-types/src/constants/error.ts
@@ -101,6 +101,15 @@ export const ERROR_MESSAGES = {
   CENSORED_RESPONSE: 'LLM censored response (returned "ext") - this may succeed on retry',
   /** Response text that indicates censorship */
   CENSORED_RESPONSE_TEXT: 'ext',
+  /**
+   * Error message when the upstream provider failed mid-generation
+   * (finish_reason 'error' inside an HTTP 200). Deliberately STABLE — no
+   * provider detail is appended, because parseApiError classifies via regex
+   * over message text and upstream wording (e.g. "rate limit") could flip
+   * the classification to non-retryable. The detail rides the structured
+   * warn log + response_metadata.openrouter.providerError instead.
+   */
+  PROVIDER_ERROR_FINISH: 'LLM provider failed mid-generation (finish_reason: error)',
 } as const;
 
 /**

--- a/packages/common-types/src/constants/finishReasons.test.ts
+++ b/packages/common-types/src/constants/finishReasons.test.ts
@@ -14,11 +14,12 @@ describe('FINISH_REASONS', () => {
     expect(FINISH_REASONS.LENGTH).toBe('length');
     expect(FINISH_REASONS.STOP_SEQUENCE).toBe('stop_sequence');
     expect(FINISH_REASONS.CONTENT_FILTER).toBe('content_filter');
+    expect(FINISH_REASONS.ERROR).toBe('error');
     expect(FINISH_REASONS.UNKNOWN).toBe('unknown');
   });
 
-  it('should have 7 known finish reasons', () => {
-    expect(Object.keys(FINISH_REASONS)).toHaveLength(7);
+  it('should have 8 known finish reasons', () => {
+    expect(Object.keys(FINISH_REASONS)).toHaveLength(8);
   });
 
   it('should be assignable to FinishReason type', () => {
@@ -50,6 +51,10 @@ describe('isNaturalStop', () => {
 
   it('should return false for content_filter', () => {
     expect(isNaturalStop('content_filter')).toBe(false);
+  });
+
+  it('should return false for error (provider failure inside a 200)', () => {
+    expect(isNaturalStop('error')).toBe(false);
   });
 
   it('should return false for unknown', () => {

--- a/packages/common-types/src/constants/finishReasons.ts
+++ b/packages/common-types/src/constants/finishReasons.ts
@@ -24,6 +24,12 @@ export const FINISH_REASONS = {
   STOP_SEQUENCE: 'stop_sequence',
   /** Content filter blocked the response */
   CONTENT_FILTER: 'content_filter',
+  /**
+   * Upstream provider failed mid-generation. OpenRouter surfaces provider
+   * errors inside an HTTP 200 with this finish reason — any content on the
+   * response is partial garbage, not a deliverable completion.
+   */
+  ERROR: 'error',
   /** Default sentinel when finish reason is unavailable */
   UNKNOWN: 'unknown',
 } as const;

--- a/services/ai-worker/src/services/LLMInvoker.test.ts
+++ b/services/ai-worker/src/services/LLMInvoker.test.ts
@@ -4,9 +4,10 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { LLMInvoker } from './LLMInvoker.js';
+import { RetryError } from '../utils/retry.js';
 import { BaseMessage, HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { BaseChatModel } from '@langchain/core/language_models/chat_models';
-import { TIMEOUTS, ApiErrorType, ApiErrorCategory } from '@tzurot/common-types';
+import { TIMEOUTS, ApiErrorType, ApiErrorCategory, ERROR_MESSAGES } from '@tzurot/common-types';
 
 // Mock ModelFactory
 vi.mock('./ModelFactory.js', () => ({
@@ -1126,6 +1127,109 @@ describe('LLMInvoker', () => {
         });
 
         expect(result.content).toBe('Complete response');
+      });
+
+      it('throws retryable on finish_reason "error" — a provider failure inside a 200', async () => {
+        // The prod shape: OpenRouter returns 200 with finish_reason 'error'
+        // and partial (single-character) content when the upstream provider
+        // dies mid-generation. The content passes the emptiness guard, so
+        // without the error-finish guard it would be delivered and stored.
+        vi.useFakeTimers();
+
+        const mockModel = {
+          invoke: vi.fn().mockResolvedValue({
+            content: '.',
+            response_metadata: {
+              finish_reason: 'error',
+              usage: { prompt_tokens: 54810, completion_tokens: 1 },
+              // Post-extraction state: the OpenRouter extractor captured the
+              // provider's failure detail before deleting __raw_response —
+              // exercised here so the guard's warn-log detail path runs.
+              openrouter: {
+                providerError: { message: 'Upstream provider dropped the stream', code: 502 },
+              },
+            },
+          }),
+        } as any as BaseChatModel;
+
+        const messages: BaseMessage[] = [new HumanMessage('Hello')];
+
+        const promise = invoker.invokeWithRetry({
+          model: mockModel,
+          messages,
+          modelName: 'z-ai/glm-5.2',
+        });
+
+        // Attach rejection handler BEFORE advancing timers. Retry exhaustion
+        // wraps the underlying failure in RetryError — assert on lastError,
+        // where the stable provider-failure message lives.
+        const rejection = promise.catch((err: unknown) => err);
+        await vi.runAllTimersAsync();
+        const thrown = await rejection;
+
+        expect(thrown).toBeInstanceOf(RetryError);
+        expect(((thrown as RetryError).lastError as Error).message).toBe(
+          ERROR_MESSAGES.PROVIDER_ERROR_FINISH
+        );
+        // Full retry budget consumed — the throw classifies retryable, so a
+        // different upstream host gets a chance on each attempt.
+        expect(mockModel.invoke).toHaveBeenCalledTimes(3);
+
+        vi.useRealTimers();
+      });
+
+      it('recovers when a retry after an error finish succeeds', async () => {
+        vi.useFakeTimers();
+
+        const mockModel = {
+          invoke: vi
+            .fn()
+            .mockResolvedValueOnce({
+              content: '.',
+              response_metadata: { finish_reason: 'error' },
+            })
+            .mockResolvedValueOnce({
+              content: 'Full response from a healthier provider',
+              response_metadata: { finish_reason: 'stop' },
+            }),
+        } as any as BaseChatModel;
+
+        const messages: BaseMessage[] = [new HumanMessage('Hello')];
+
+        const promise = invoker.invokeWithRetry({
+          model: mockModel,
+          messages,
+          modelName: 'z-ai/glm-5.2',
+        });
+        await vi.runAllTimersAsync();
+        const result = await promise;
+
+        expect(result.content).toBe('Full response from a healthier provider');
+        expect(mockModel.invoke).toHaveBeenCalledTimes(2);
+
+        vi.useRealTimers();
+      });
+
+      it('does NOT throw on finish_reason "content_filter" (guard scoped to error only)', async () => {
+        // content_filter is a policy outcome, not a provider failure — a
+        // retry would not help, and its handling is a separate decision.
+        const mockModel = {
+          invoke: vi.fn().mockResolvedValue({
+            content: 'Partial but deliverable response',
+            response_metadata: { finish_reason: 'content_filter' },
+          }),
+        } as any as BaseChatModel;
+
+        const messages: BaseMessage[] = [new HumanMessage('Hello')];
+
+        const result = await invoker.invokeWithRetry({
+          model: mockModel,
+          messages,
+          modelName: 'test-model',
+        });
+
+        expect(result.content).toBe('Partial but deliverable response');
+        expect(mockModel.invoke).toHaveBeenCalledTimes(1);
       });
 
       it('should log info for unknown finish_reason values', async () => {

--- a/services/ai-worker/src/services/LLMInvoker.ts
+++ b/services/ai-worker/src/services/LLMInvoker.ts
@@ -495,7 +495,31 @@ export class LLMInvoker {
 
     // Log finish_reason for completion quality diagnostics
     // This helps identify models that fail to emit stop tokens (hallucinated turn bug)
-    this.logFinishReason(response, modelName);
+    const finishReason = this.logFinishReason(response, modelName);
+
+    // A provider failure inside an HTTP 200: OpenRouter surfaces upstream
+    // mid-generation errors as finish_reason 'error', typically with partial
+    // (often single-character) content that would pass the emptiness guard
+    // below, reach delivery, and be stored to LTM. Throw retryable instead —
+    // a retry re-enters OpenRouter's provider routing, which usually lands on
+    // a DIFFERENT upstream host than the one that just failed. Scoped
+    // strictly to 'error': other non-standard reasons (content_filter,
+    // length) carry their own semantics and stay observability-only. The
+    // thrown message is STABLE (see ERROR_MESSAGES.PROVIDER_ERROR_FINISH);
+    // the provider's own failure detail rides this warn log.
+    if (finishReason === FINISH_REASONS.ERROR) {
+      const providerErrorFailure = new Error(ERROR_MESSAGES.PROVIDER_ERROR_FINISH);
+      logger.warn(
+        {
+          err: providerErrorFailure,
+          modelName,
+          providerErrorDetail: this.extractProviderErrorDetail(response),
+          ...this.extractResponseDiagnostics(response),
+        },
+        'Provider reported an error finish_reason, treating as retryable error'
+      );
+      throw providerErrorFailure;
+    }
 
     // Guard against empty responses (treat as retryable error)
     // Handle both string content and multimodal array content
@@ -543,25 +567,26 @@ export class LLMInvoker {
   }
 
   /**
-   * Log finish_reason and token usage for completion-quality diagnostics.
+   * Log finish_reason and token usage for completion-quality diagnostics,
+   * returning the resolved reason so the caller can act on it (the
+   * error-finish guard in invokeSingleAttempt keys on the return value).
    *
    * This helps identify:
    * - Models that hit token limits (finish_reason: "length") - may truncate responses
    * - Models that completed naturally (finish_reason: "stop") - the ideal case
    */
-  private logFinishReason(response: BaseMessage, modelName: string): void {
+  private logFinishReason(response: BaseMessage, modelName: string): string {
     const metadata = (response as { response_metadata?: Record<string, unknown> })
       .response_metadata;
 
     if (!metadata) {
       logger.debug({ modelName }, 'No response_metadata available for finish_reason');
-      return;
+      return FINISH_REASONS.UNKNOWN;
     }
 
     const finishReason = resolveFinishReason(metadata);
     const usage = metadata.usage as
-      | { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number }
-      | undefined;
+      { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number } | undefined;
 
     const logContext: Record<string, unknown> = { modelName, finishReason };
     if (usage !== undefined) {
@@ -580,6 +605,32 @@ export class LLMInvoker {
     } else {
       logger.info(logContext, 'Model completion with non-standard finish_reason');
     }
+    return finishReason;
+  }
+
+  /**
+   * Provider-failure detail for an error finish_reason, read from the
+   * diagnostic metadata the OpenRouter extractor captured before deleting
+   * `__raw_response` (response_metadata.openrouter.providerError). Log-only:
+   * the thrown error's message stays stable for classification safety.
+   */
+  private extractProviderErrorDetail(response: BaseMessage): string | undefined {
+    const metadata = (response as { response_metadata?: Record<string, unknown> })
+      .response_metadata;
+    const openrouter = metadata?.openrouter as
+      { providerError?: { message?: string; code?: number | string } } | undefined;
+    const providerError = openrouter?.providerError;
+    if (providerError === undefined) {
+      return undefined;
+    }
+    const parts: string[] = [];
+    if (providerError.code !== undefined) {
+      parts.push(`code ${providerError.code}`);
+    }
+    if (providerError.message !== undefined) {
+      parts.push(providerError.message);
+    }
+    return parts.length > 0 ? parts.join(': ') : undefined;
   }
 
   /**
@@ -594,8 +645,7 @@ export class LLMInvoker {
       .additional_kwargs;
     const finishReason = resolveFinishReason(metadata);
     const usage = metadata?.usage as
-      | { prompt_tokens?: number; completion_tokens?: number }
-      | undefined;
+      { prompt_tokens?: number; completion_tokens?: number } | undefined;
 
     return {
       responseType: Array.isArray(response.content) ? 'array' : typeof response.content,

--- a/services/ai-worker/src/services/modelFactory/extractOpenRouterReasoning.test.ts
+++ b/services/ai-worker/src/services/modelFactory/extractOpenRouterReasoning.test.ts
@@ -421,4 +421,108 @@ describe('extractAndPopulateOpenRouterReasoning', () => {
       expect(() => extractAndPopulateOpenRouterReasoning(message)).not.toThrow();
     });
   });
+
+  describe('provider-error capture (finish_reason "error" support)', () => {
+    // OpenRouter surfaces upstream provider failures inside an HTTP 200 with
+    // finish_reason 'error' and an error object on the choice. The extractor
+    // must preserve that detail into response_metadata.openrouter BEFORE the
+    // memory-hygiene delete of __raw_response — it's the only place the
+    // invoker's error-finish guard and diagnostics can read it from.
+
+    function openrouterMeta(message: BaseMessage): {
+      providerError?: { message?: string; code?: number | string };
+    } {
+      return (message.response_metadata as Record<string, unknown>).openrouter as {
+        providerError?: { message?: string; code?: number | string };
+      };
+    }
+
+    it('captures a choice-level error object into openrouter.providerError', () => {
+      const message = buildMessage({
+        content: '.',
+        finishReason: 'error',
+        rawResponse: {
+          provider: 'Decart',
+          choices: [
+            {
+              error: { message: 'Upstream provider dropped the stream', code: 502 },
+              message: { role: 'assistant', content: '.' },
+            },
+          ],
+        },
+      });
+
+      extractAndPopulateOpenRouterReasoning(message);
+
+      expect(openrouterMeta(message).providerError).toEqual({
+        message: 'Upstream provider dropped the stream',
+        code: 502,
+      });
+      // Memory hygiene still applies — the raw response must not survive.
+      expect(message.additional_kwargs.__raw_response).toBeUndefined();
+    });
+
+    it('falls back to a top-level error object', () => {
+      const message = buildMessage({
+        content: '.',
+        finishReason: 'error',
+        rawResponse: {
+          error: { message: 'Provider returned error', code: 'PROVIDER_ERROR' },
+          choices: [{ message: { role: 'assistant', content: '.' } }],
+        },
+      });
+
+      extractAndPopulateOpenRouterReasoning(message);
+
+      expect(openrouterMeta(message).providerError).toEqual({
+        message: 'Provider returned error',
+        code: 'PROVIDER_ERROR',
+      });
+    });
+
+    it('omits providerError entirely on healthy responses', () => {
+      const message = buildMessage({
+        content: 'All good.',
+        finishReason: 'stop',
+        rawResponse: {
+          provider: 'Parasail',
+          choices: [{ message: { role: 'assistant', content: 'All good.' } }],
+        },
+      });
+
+      extractAndPopulateOpenRouterReasoning(message);
+
+      expect(openrouterMeta(message).providerError).toBeUndefined();
+    });
+
+    it('omits providerError when the error object carries no usable fields', () => {
+      const message = buildMessage({
+        content: '.',
+        finishReason: 'error',
+        rawResponse: {
+          error: { unexpected: 'shape' },
+          choices: [{ message: { role: 'assistant', content: '.' } }],
+        },
+      });
+
+      extractAndPopulateOpenRouterReasoning(message);
+
+      expect(openrouterMeta(message).providerError).toBeUndefined();
+    });
+
+    it('ignores malformed error shapes (string instead of object)', () => {
+      const message = buildMessage({
+        content: '.',
+        finishReason: 'error',
+        rawResponse: {
+          error: 'not-an-object',
+          choices: [{ message: { role: 'assistant', content: '.' } }],
+        },
+      });
+
+      extractAndPopulateOpenRouterReasoning(message);
+
+      expect(openrouterMeta(message).providerError).toBeUndefined();
+    });
+  });
 });

--- a/services/ai-worker/src/services/modelFactory/extractOpenRouterReasoning.ts
+++ b/services/ai-worker/src/services/modelFactory/extractOpenRouterReasoning.ts
@@ -48,6 +48,41 @@ export interface OpenRouterMessageMetadata {
   apiMessageKeys: string[];
   /** Length of `message.reasoning` from raw API response. Zero = model did not emit structured reasoning */
   apiReasoningLength: number;
+  /**
+   * Provider failure detail when the upstream errored mid-generation
+   * (finish_reason 'error'). OpenRouter attaches an error object on the
+   * choice (or top-level) alongside the 200 — captured here before
+   * `__raw_response` is deleted, so the invoker's error-finish guard and
+   * diagnostics can surface what the provider actually said.
+   */
+  providerError?: { message?: string; code?: number | string };
+}
+
+/**
+ * Pull the provider-failure error object off the raw response, if present.
+ * Choice-level takes precedence (that's where OpenRouter puts mid-generation
+ * provider failures); top-level is the fallback shape.
+ */
+function extractProviderErrorObject(
+  raw: Record<string, unknown>
+): OpenRouterMessageMetadata['providerError'] {
+  const choices = raw.choices;
+  const firstChoice = Array.isArray(choices)
+    ? (choices[0] as Record<string, unknown> | undefined)
+    : undefined;
+  const candidate = firstChoice?.error ?? raw.error;
+  if (typeof candidate !== 'object' || candidate === null) {
+    return undefined;
+  }
+  const err = candidate as Record<string, unknown>;
+  const result: NonNullable<OpenRouterMessageMetadata['providerError']> = {};
+  if (typeof err.message === 'string') {
+    result.message = err.message;
+  }
+  if (typeof err.code === 'string' || typeof err.code === 'number') {
+    result.code = err.code;
+  }
+  return result.message !== undefined || result.code !== undefined ? result : undefined;
 }
 
 /**
@@ -116,6 +151,10 @@ function buildOpenrouterMetadata(
   };
   if (typeof raw.provider === 'string') {
     result.provider = raw.provider;
+  }
+  const providerError = extractProviderErrorObject(raw);
+  if (providerError !== undefined) {
+    result.providerError = providerError;
   }
   return result;
 }


### PR DESCRIPTION
## Summary

Fixes the Production Issue filed tonight (request `f333a5db`, runtime-confirmed via /inspect + full log trace): OpenRouter surfaces upstream provider failures **inside an HTTP 200** with `finish_reason: "error"` and partial content. The invoker logged it as a curiosity and processed it as a normal completion — a 123-second Decart failure delivered a **1-character persona reply**, stored the garbage interaction **to LTM as a memory**, and never retried (the emptiness guard keys on `length === 0`; 1 char passes).

## Fix

- **`FINISH_REASONS.ERROR`** added to the vocabulary (previously `'error'` fell into the catch-all "non-standard" observability branch).
- **The invoker throws retryable** on an error finish, before the emptiness guard. The throw rides the existing retry ladder — and a retry re-enters OpenRouter's provider routing, which typically lands on a *different* upstream host than the one that just died, so retries have a real chance of succeeding rather than just failing honestly. Delivery and LTM storage of provider-failure garbage become structurally impossible.
- **Scope pinned to `'error'` only**: `content_filter`/`length` keep their existing semantics (explicit test locks this).

## Classification safety (the design decision worth reviewing)

The thrown message is **deliberately stable** — no provider detail appended — because `parseApiError` classifies via regex over message text, and upstream wording (e.g. a provider message containing "rate limit") could flip the classification to non-retryable, defeating the fix. This is the same pristine-message principle `attachFallbackFailure` documents. The provider's actual failure detail is preserved on a separate channel instead: the OpenRouter extractor now captures the raw response's choice-level/top-level `error` object into `response_metadata.openrouter.providerError` **before** its memory-hygiene delete of `__raw_response`, and the invoker surfaces it in the structured warn log + diagnostics (same plumbing that carries `Upstream: Decart` into /inspect).

## Tests

- Invoker: error finish throws and consumes the full retry budget (asserted via `RetryError.lastError` — the wrapper-vs-cause distinction from #1460); retry-after-error-finish recovers; `content_filter` pass-through pin.
- Extractor: choice-level + top-level error capture, absent on healthy responses, malformed-shape ignore, memory-hygiene delete still applies.
- Constants: `ERROR` value + count + `isNaturalStop(false)` pins.

`pnpm test` + `pnpm quality` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)