### PR TITLE
feat(tooling): incident-dig correlation flags for ops logs

### DIFF
--- a/.claude/skills/tzurot-deployment/SKILL.md
+++ b/.claude/skills/tzurot-deployment/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-deployment
 description: 'Railway deployment procedures. Invoke with /tzurot-deployment for deploying, checking logs, and troubleshooting.'
-lastUpdated: '2026-07-02'
+lastUpdated: '2026-07-03'
 ---
 
 # Deployment Procedures
@@ -81,6 +81,27 @@ git push origin develop
 ```
 
 ## Log Analysis
+
+**Incident digs: reach for `pnpm ops logs` correlation flags first.** They
+encode the reliable pull-and-grep-locally pattern (the server-side `--filter`
+DSL routinely misses hyphenated UUIDs) and sweep all three app services in
+one command:
+
+```bash
+# Cross-service trace of one request (5000-line window per service, local match)
+pnpm ops logs --env prod --request-id <uuid>
+
+# BullMQ job trace, floored to the last 2 hours (local pino-time filter)
+pnpm ops logs --env prod --job-id <id> --since 2h
+
+# Both flags AND together; --since accepts ISO-8601 or 45m/6h/2d
+pnpm ops logs --env prod --request-id <uuid> --job-id <id> --since 6h
+```
+
+Correlation mode reads the CURRENT deployment; for older windows use the
+deployment-ID lookup below.
+
+Raw CLI equivalents (single service, manual grep):
 
 ```bash
 # Tail specific service (CURRENT deployment only)

--- a/docs/reference/tooling/OPS_CLI_REFERENCE.md
+++ b/docs/reference/tooling/OPS_CLI_REFERENCE.md
@@ -106,15 +106,24 @@ Runtime state inspection for debugging:
 
 Fetch and analyze Railway service logs:
 
-| Command                               | Description                      |
-| ------------------------------------- | -------------------------------- |
-| `pnpm ops logs --env dev`             | Fetch logs from all dev services |
-| `pnpm ops logs --env prod`            | Fetch logs from production       |
-| `pnpm ops logs --service api-gateway` | Logs from specific service       |
-| `pnpm ops logs --filter error`        | Filter by log level              |
-| `pnpm ops logs --filter "keyword"`    | Filter by text content           |
-| `pnpm ops logs --lines 200`           | Fetch more lines (default: 100)  |
-| `pnpm ops logs --follow`              | Stream logs in real-time         |
+| Command                                 | Description                                                       |
+| --------------------------------------- | ----------------------------------------------------------------- |
+| `pnpm ops logs --env dev`               | Fetch logs from all dev services                                  |
+| `pnpm ops logs --env prod`              | Fetch logs from production                                        |
+| `pnpm ops logs --service api-gateway`   | Logs from specific service                                        |
+| `pnpm ops logs --filter "@level:error"` | Server-side Railway query DSL                                     |
+| `pnpm ops logs --lines 200`             | Fetch more lines (default: 100; clamped at the CLI's ~5000 cap)   |
+| `pnpm ops logs --request-id <uuid>`     | Incident dig: local-match a request ID, sweeping all app services |
+| `pnpm ops logs --job-id <id>`           | Incident dig: local-match a BullMQ job ID (ANDs with request-id)  |
+| `pnpm ops logs --since 2h`              | Time floor (ISO-8601 or `45m`/`6h`/`2d`); local pino-time filter  |
+| `pnpm ops logs --follow`                | Stream logs in real-time (not combinable with dig flags)          |
+
+**Correlation dig flags** (`--request-id`/`--job-id`/`--since`) deliberately match
+**locally** over a fetched window instead of using the server `--filter` DSL —
+that engine routinely misses hyphenated tokens (UUIDs). With no `--service`,
+the dig sweeps bot-client + api-gateway + ai-worker in labeled sections. It
+reads the CURRENT deployment; for older windows use
+`railway deployment list` + `railway logs <deployment-id>`.
 
 **Output includes:**
 
@@ -122,7 +131,7 @@ Fetch and analyze Railway service logs:
 - Service and environment context
 - Tips for common queries
 
-**Use case:** Debug production issues, check for errors across services, monitor logs in real-time.
+**Use case:** Debug production issues, trace one request/job across services, monitor logs in real-time.
 
 ## Release Commands
 

--- a/packages/tooling/src/commands/commands.test.ts
+++ b/packages/tooling/src/commands/commands.test.ts
@@ -30,6 +30,10 @@ vi.mock('../deployment/update-gateway-url.js', () => ({
   updateGatewayUrl: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock('../deployment/logs.js', () => ({
+  fetchLogs: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock('../test/audit-unified.js', () => ({
   auditUnified: vi.fn().mockReturnValue(true),
 }));
@@ -148,6 +152,24 @@ describe('command handlers', () => {
 
       await vi.waitFor(() => {
         expect(updateGatewayUrl).toHaveBeenCalled();
+      });
+    });
+
+    it('delivers an all-digit --job-id to fetchLogs as a STRING (CAC auto-casts to number)', async () => {
+      // CAC/mri parses `--job-id 42317` to the number 42317; without the
+      // String() coercion in deploy.ts, logs.ts's `typeof === 'string'` term
+      // filter silently drops it — the dig runs unfiltered while looking
+      // successful. This test crosses the real cli.parse() boundary the
+      // logs.test.ts unit tests bypass.
+      const { registerDeployCommands } = await import('./deploy.js');
+      const { fetchLogs } = await import('../deployment/logs.js');
+      const cli = cac('test');
+      registerDeployCommands(cli);
+
+      cli.parse(['node', 'test', 'logs', '--env', 'prod', '--job-id', '42317'], { run: true });
+
+      await vi.waitFor(() => {
+        expect(fetchLogs).toHaveBeenCalledWith(expect.objectContaining({ jobId: '42317' }));
       });
     });
   });

--- a/packages/tooling/src/commands/deploy.ts
+++ b/packages/tooling/src/commands/deploy.ts
@@ -43,19 +43,31 @@ export function registerDeployCommands(cli: CAC): void {
     .command('logs', 'Fetch logs from Railway services')
     .option('--env <env>', 'Environment (dev or prod)', { default: 'dev' })
     .option('--service <service>', 'Service name (bot-client, api-gateway, ai-worker)')
-    .option('--lines <n>', 'Number of lines to fetch', { default: 100 })
-    .option('--filter <text>', 'Filter logs by text or level (error, warn, info, debug)')
+    .option('--lines <n>', 'Number of lines to fetch (capped at ~5000 by the Railway CLI)')
+    .option('--filter <text>', 'Server-side Railway query DSL (@level:error, "a AND b")')
+    .option('--request-id <id>', 'Incident dig: local-match a request ID across app services')
+    .option(
+      '--job-id <id>',
+      'Incident dig: local-match a BullMQ job ID across app services (short numeric IDs may substring-match unrelated numbers; prefer --request-id when both are known)'
+    )
+    .option(
+      '--since <when>',
+      'Time floor: ISO-8601 or relative (45m, 6h, 2d); enters dig mode (5000-line window, sweeps app services unless --service)'
+    )
     .option('--follow', 'Follow logs in real-time')
     .example('ops logs --env dev')
     .example('ops logs --env dev --service api-gateway')
-    .example('ops logs --env dev --filter error')
-    .example('ops logs --env dev --follow')
+    .example('ops logs --env prod --request-id f333a5db-1234-5678-9abc-def012345678')
+    .example('ops logs --env prod --job-id 42317 --since 2h')
     .action(
       async (options: {
         env: string;
         service?: string;
-        lines: number;
+        lines?: number;
         filter?: string;
+        requestId?: string;
+        jobId?: string;
+        since?: string;
         follow?: boolean;
       }) => {
         if (options.env !== 'dev' && options.env !== 'prod') {
@@ -67,8 +79,13 @@ export function registerDeployCommands(cli: CAC): void {
         await fetchLogs({
           env: options.env,
           service: options.service,
-          lines: options.lines,
+          lines: options.lines === undefined ? undefined : Number(options.lines),
           filter: options.filter,
+          // CAC auto-casts all-digit values to Number; an unstringed ID would
+          // silently fail logs.ts's `typeof === 'string'` term filter.
+          requestId: options.requestId === undefined ? undefined : String(options.requestId),
+          jobId: options.jobId === undefined ? undefined : String(options.jobId),
+          since: options.since === undefined ? undefined : String(options.since),
           follow: options.follow,
         });
       }

--- a/packages/tooling/src/deployment/logs.test.ts
+++ b/packages/tooling/src/deployment/logs.test.ts
@@ -24,7 +24,7 @@ vi.mock('../utils/env-runner.js', () => ({
 }));
 
 import { execFileSync } from 'node:child_process';
-import { fetchLogs } from './logs.js';
+import { fetchLogs, parseSinceMs } from './logs.js';
 
 describe('fetchLogs', () => {
   let consoleLogSpy: MockInstance;
@@ -66,6 +66,15 @@ describe('fetchLogs', () => {
       const output = consoleLogSpy.mock.calls.flat().join(' ');
       expect(output).toContain('RAILWAY LOGS');
       expect(output).toContain('DEVELOPMENT');
+    });
+
+    it('defaults to 100 lines in plain (non-dig) mode', async () => {
+      // The dig default is 5000; a ternary flip that applied it to plain
+      // fetches too would silently make every casual tail 50x heavier.
+      await fetchLogs({ env: 'dev' });
+
+      const args = vi.mocked(execFileSync).mock.calls[0][1] as string[];
+      expect(args[args.indexOf('-n') + 1]).toBe('100');
     });
 
     it('should fetch logs with correct Railway arguments', async () => {
@@ -208,5 +217,188 @@ describe('fetchLogs', () => {
       expect(output).toContain('Tips');
       expect(output).toContain('ops logs');
     });
+  });
+
+  describe('correlation dig mode (--request-id / --job-id)', () => {
+    const REQ = 'f333a5db-aaaa-bbbb-cccc-0123456789ab';
+
+    it('local-matches the request ID instead of using the server DSL', async () => {
+      vi.mocked(execFileSync).mockReturnValue(
+        `{"time":1751500000000,"requestId":"${REQ}","msg":"job queued"}\n` +
+          `{"time":1751500001000,"requestId":"other-req","msg":"unrelated"}\n`
+      );
+
+      await fetchLogs({ env: 'prod', service: 'api-gateway', requestId: REQ });
+
+      // The fetch args must NOT carry --filter (DSL is unreliable for UUIDs)
+      const args = vi.mocked(execFileSync).mock.calls[0][1] as string[];
+      expect(args).not.toContain('--filter');
+      // Dig default window, not the last screenful
+      expect(args).toContain('-n');
+      expect(args[args.indexOf('-n') + 1]).toBe('5000');
+
+      const output = consoleLogSpy.mock.calls.flat().join('\n');
+      expect(output).toContain('job queued');
+      expect(output).not.toContain('unrelated');
+    });
+
+    it('sweeps all three app services when no --service is given', async () => {
+      vi.mocked(execFileSync).mockReturnValue('');
+
+      await fetchLogs({ env: 'prod', requestId: REQ });
+
+      const serviceArgs = vi
+        .mocked(execFileSync)
+        .mock.calls.map(call => {
+          const args = call[1] as string[];
+          return args[args.indexOf('--service') + 1];
+        })
+        .sort();
+      expect(serviceArgs).toEqual(['ai-worker', 'api-gateway', 'bot-client']);
+    });
+
+    it('requires ALL terms when both request-id and job-id are given', async () => {
+      vi.mocked(execFileSync).mockReturnValue(
+        `{"requestId":"${REQ}","jobId":"42317","msg":"both"}\n` +
+          `{"requestId":"${REQ}","jobId":"99999","msg":"request only"}\n`
+      );
+
+      await fetchLogs({ env: 'prod', service: 'ai-worker', requestId: REQ, jobId: '42317' });
+
+      const output = consoleLogSpy.mock.calls.flat().join('\n');
+      expect(output).toContain('both');
+      expect(output).not.toContain('request only');
+    });
+
+    it('rejects combining dig flags with --follow', async () => {
+      await fetchLogs({ env: 'prod', requestId: REQ, follow: true });
+
+      expect(process.exitCode).toBe(1);
+      const errors = consoleErrorSpy.mock.calls.flat().join(' ');
+      expect(errors).toContain('cannot combine with --follow');
+      expect(vi.mocked(execFileSync)).not.toHaveBeenCalled();
+    });
+
+    it('clamps --lines above the Railway CLI cap instead of erroring to zero rows', async () => {
+      vi.mocked(execFileSync).mockReturnValue('');
+
+      await fetchLogs({ env: 'prod', service: 'ai-worker', requestId: REQ, lines: 8000 });
+
+      const args = vi.mocked(execFileSync).mock.calls[0][1] as string[];
+      expect(args[args.indexOf('-n') + 1]).toBe('5000');
+      const output = consoleLogSpy.mock.calls.flat().join(' ');
+      expect(output).toContain('clamping to 5000');
+    });
+  });
+
+  describe('--since time floor', () => {
+    const FROZEN_NOW = 1_751_500_000_000;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(FROZEN_NOW);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('drops lines older than the floor (and lines without a pino time)', async () => {
+      vi.mocked(execFileSync).mockReturnValue(
+        `{"time":${FROZEN_NOW - 60_000},"msg":"recent line"}\n` +
+          `{"time":${FROZEN_NOW - 7_200_000},"msg":"stale line"}\n` +
+          `no-json boot noise\n`
+      );
+
+      await fetchLogs({ env: 'prod', service: 'ai-worker', since: '30m' });
+
+      const output = consoleLogSpy.mock.calls.flat().join('\n');
+      expect(output).toContain('recent line');
+      expect(output).not.toContain('stale line');
+      expect(output).not.toContain('boot noise');
+    });
+
+    it('rejects an unparseable --since value', async () => {
+      await fetchLogs({ env: 'prod', since: 'yesterday-ish' });
+
+      expect(process.exitCode).toBe(1);
+      const errors = consoleErrorSpy.mock.calls.flat().join(' ');
+      expect(errors).toContain('Cannot parse --since');
+    });
+  });
+
+  describe('dig-mode composition and failure paths', () => {
+    const REQ = 'f333a5db-aaaa-bbbb-cccc-0123456789ab';
+
+    it('passes an explicit --filter through to the server AND still matches locally', async () => {
+      vi.mocked(execFileSync).mockReturnValue(
+        `{"level":50,"requestId":"${REQ}","msg":"target error"}\n` +
+          `{"level":50,"requestId":"someone-else","msg":"other error"}\n`
+      );
+
+      await fetchLogs({
+        env: 'prod',
+        service: 'ai-worker',
+        requestId: REQ,
+        filter: '@level:error',
+      });
+
+      const args = vi.mocked(execFileSync).mock.calls[0][1] as string[];
+      expect(args[args.indexOf('--filter') + 1]).toBe('@level:error');
+      const output = consoleLogSpy.mock.calls.flat().join('\n');
+      expect(output).toContain('target error');
+      expect(output).not.toContain('other error');
+    });
+
+    it('continues the sweep when one service errors', async () => {
+      vi.mocked(execFileSync).mockImplementation((_cmd, args) => {
+        const serviceArgs = args as string[];
+        if (serviceArgs.includes('bot-client')) {
+          throw new Error('service not found');
+        }
+        return `{"requestId":"${REQ}","msg":"worker hit"}\n`;
+      });
+
+      await fetchLogs({ env: 'prod', requestId: REQ });
+
+      // All three services attempted despite the first failing
+      expect(vi.mocked(execFileSync)).toHaveBeenCalledTimes(3);
+      expect(process.exitCode).toBe(1);
+      const output = consoleLogSpy.mock.calls.flat().join('\n');
+      expect(output).toContain('worker hit');
+    });
+
+    it('rejects a non-numeric --lines instead of forwarding -n NaN', async () => {
+      await fetchLogs({ env: 'prod', service: 'ai-worker', lines: Number('abc') });
+
+      expect(process.exitCode).toBe(1);
+      const errors = consoleErrorSpy.mock.calls.flat().join(' ');
+      expect(errors).toContain('--lines must be a positive number');
+      expect(vi.mocked(execFileSync)).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('parseSinceMs', () => {
+  const NOW = 1_751_500_000_000;
+
+  it.each([
+    ['45m', NOW - 45 * 60_000],
+    ['6h', NOW - 6 * 3_600_000],
+    ['2d', NOW - 2 * 86_400_000],
+    ['45M', NOW - 45 * 60_000],
+    ['6H', NOW - 6 * 3_600_000],
+  ])('parses relative %s (case-insensitive)', (input, expected) => {
+    expect(parseSinceMs(input, NOW)).toBe(expected);
+  });
+
+  it('parses ISO-8601 timestamps', () => {
+    expect(parseSinceMs('2026-07-03T02:00:00.000Z', NOW)).toBe(
+      Date.parse('2026-07-03T02:00:00.000Z')
+    );
+  });
+
+  it('throws on garbage', () => {
+    expect(() => parseSinceMs('soonish', NOW)).toThrow('Cannot parse --since');
   });
 });

--- a/packages/tooling/src/deployment/logs.ts
+++ b/packages/tooling/src/deployment/logs.ts
@@ -3,6 +3,19 @@
  *
  * Fetches and displays logs from Railway services.
  * Supports filtering by service, time range, and log level.
+ *
+ * Correlation flags (`--request-id`, `--job-id`) deliberately do NOT
+ * translate to Railway's server-side `--filter` DSL: hyphenated tokens
+ * (UUIDs are all hyphens) and quoted phrases frequently match nothing in
+ * that engine. They implement the reliable incident-dig pattern instead —
+ * pull a window (capped at the CLI's ~5000-line limit) and substring-match
+ * locally, sweeping all app services when none is specified so the
+ * cross-service trace lands in one command.
+ *
+ * Exit-code contract: a sweep where ANY service window fails to fetch exits
+ * non-zero even if other services returned matches — incomplete data should
+ * never read as a clean dig. Automation wanting best-effort semantics should
+ * check for output rather than exit code.
  */
 
 import { execFileSync } from 'node:child_process';
@@ -15,10 +28,30 @@ interface LogsOptions {
   lines?: number;
   filter?: string;
   follow?: boolean;
+  /** Correlation term: match lines containing this request ID (local substring). */
+  requestId?: string;
+  /** Correlation term: match lines containing this job ID (local substring). */
+  jobId?: string;
+  /** Time floor: ISO-8601 timestamp or relative (`30m`, `2h`, `1d`). Local filter on pino `time`. */
+  since?: string;
 }
 
 // Known services in the Tzurot project
 const KNOWN_SERVICES = ['bot-client', 'api-gateway', 'ai-worker', 'pgvector', 'redis'] as const;
+
+/** Services swept by correlation mode — the ones that carry request/job IDs. */
+const APP_SERVICES = ['bot-client', 'api-gateway', 'ai-worker'] as const;
+
+/**
+ * Railway CLI hard limit: `-n` values above ~5000 don't degrade gracefully —
+ * they error out and return ZERO rows, which reads as "no matching logs".
+ * Clamp instead; to reach further back, narrow by deployment ID
+ * (`railway deployment list` → `railway logs <id>`).
+ */
+const MAX_LINES = 5000;
+
+/** Default window in correlation mode — a dig wants depth, not the last screenful. */
+const CORRELATION_DEFAULT_LINES = MAX_LINES;
 
 /**
  * Validate and get the service name
@@ -91,9 +124,63 @@ function displayFooter(): void {
   console.log(chalk.dim('💡 Tips (--filter uses Railway query DSL):'));
   console.log(chalk.dim('   pnpm ops logs --env dev --service api-gateway'));
   console.log(chalk.dim('   pnpm ops logs --env dev --filter "@level:error"'));
-  console.log(chalk.dim('   pnpm ops logs --env dev --filter "vision AND 404"'));
-  console.log(chalk.dim('   pnpm ops logs --env dev --follow'));
+  console.log(chalk.dim('   pnpm ops logs --env prod --request-id <uuid>   # cross-service dig'));
+  console.log(chalk.dim('   pnpm ops logs --env prod --job-id <id> --since 2h'));
+  console.log(chalk.dim('   Correlation reads the CURRENT deployment; for older windows use'));
+  console.log(chalk.dim('   `railway deployment list` + `railway logs <deployment-id>`.'));
   console.log(chalk.cyan.bold('═══════════════════════════════════════════════════════'));
+}
+
+/**
+ * Parse `--since` into an epoch-ms floor. Accepts ISO-8601 (anything
+ * `Date.parse` takes) or a relative suffix form: `45m`, `6h`, `2d`.
+ * Exported for direct unit testing.
+ */
+export function parseSinceMs(since: string, nowMs: number): number {
+  const relative = /^(\d+)([mhd])$/i.exec(since.trim());
+  if (relative !== null) {
+    const amount = Number(relative[1]);
+    const unit = relative[2].toLowerCase() as 'm' | 'h' | 'd';
+    const unitMs = { m: 60_000, h: 3_600_000, d: 86_400_000 }[unit];
+    return nowMs - amount * unitMs;
+  }
+  const parsed = Date.parse(since);
+  if (Number.isNaN(parsed)) {
+    throw new Error(
+      `Cannot parse --since "${since}" — use ISO-8601 (2026-07-03T02:00:00Z) or relative (45m, 6h, 2d)`
+    );
+  }
+  return parsed;
+}
+
+/** Extract the pino epoch-ms `time` field from a JSON log line, if present. */
+function lineTimeMs(line: string): number | undefined {
+  const match = /"time":\s*(\d{10,})/.exec(line);
+  return match === null ? undefined : Number(match[1]);
+}
+
+/**
+ * Local line filtering: every correlation term must appear (case-insensitive
+ * substring — predictable, unlike the server DSL), and when a time floor is
+ * set, only lines whose pino `time` is at/after it survive (lines without a
+ * parseable time are dropped in since-mode; they're boot noise, not events).
+ */
+export function applyLocalFilters(logs: string, terms: string[], sinceMs?: number): string[] {
+  const lowered = terms.map(t => t.toLowerCase());
+  return logs.split('\n').filter(line => {
+    if (line.trim().length === 0) {
+      return false;
+    }
+    const lineLower = line.toLowerCase();
+    if (!lowered.every(term => lineLower.includes(term))) {
+      return false;
+    }
+    if (sinceMs !== undefined) {
+      const time = lineTimeMs(line);
+      return time !== undefined && time >= sinceMs;
+    }
+    return true;
+  });
 }
 
 /**
@@ -166,10 +253,129 @@ function handleLogsError(error: unknown, validatedService: string | undefined): 
 }
 
 /**
+ * Build the `railway logs` argument vector for one fetch.
+ * `--filter` passes through as a Railway 4.11.2 server-side query (attribute
+ * filters like `@level:error`, boolean operators like `"vision AND 404"`).
+ */
+function buildRailwayArgs(opts: {
+  railwayEnv: string;
+  service?: string;
+  lines: number;
+  filter?: string;
+  follow?: boolean;
+}): string[] {
+  const args = ['logs', '--environment', opts.railwayEnv];
+  if (opts.service !== undefined && opts.service.length > 0) {
+    args.push('--service', opts.service);
+  }
+  args.push('-n', String(opts.lines));
+  if (opts.filter !== undefined) {
+    args.push('--filter', opts.filter);
+  }
+  if (opts.follow === true) {
+    args.push('--follow');
+  }
+  return args;
+}
+
+/**
+ * Correlation/since dig: window-fetch per service, filter locally, print
+ * labeled sections. Sweeps all app services when none was specified.
+ */
+function runLocalFilterDig(opts: {
+  railwayEnv: string;
+  service?: string;
+  lines: number;
+  filter?: string;
+  terms: string[];
+  sinceMs?: number;
+}): void {
+  const services: string[] = opts.service !== undefined ? [opts.service] : [...APP_SERVICES];
+
+  let totalMatched = 0;
+  for (const svc of services) {
+    const args = buildRailwayArgs({
+      railwayEnv: opts.railwayEnv,
+      service: svc,
+      lines: opts.lines,
+      filter: opts.filter,
+    });
+    let raw: string;
+    try {
+      raw = execFileSync('railway', args, {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        maxBuffer: 10 * 1024 * 1024,
+      });
+    } catch (error) {
+      handleLogsError(error, svc);
+      continue;
+    }
+
+    const matched = applyLocalFilters(raw, opts.terms, opts.sinceMs);
+    totalMatched += matched.length;
+    if (services.length > 1) {
+      console.log(chalk.cyan.bold(`\n── ${svc} ──`));
+    }
+    if (matched.length === 0) {
+      console.log(chalk.dim('   (no matching lines in this window)'));
+    } else {
+      console.log(colorizeLogs(matched.join('\n')));
+    }
+  }
+
+  console.log('');
+  console.log(
+    chalk.dim(
+      `${totalMatched} matching line(s) across ${services.length} service window(s) of ${opts.lines} lines each.`
+    )
+  );
+}
+
+/**
+ * Validate + resolve the window bounds (`--since` floor, `--lines` count).
+ * Prints the error and returns null on invalid input; the caller exits.
+ */
+function resolveWindowBounds(
+  options: LogsOptions,
+  digMode: boolean
+): { sinceMs?: number; lines: number } | null {
+  let sinceMs: number | undefined;
+  if (options.since !== undefined) {
+    try {
+      sinceMs = parseSinceMs(options.since, Date.now());
+    } catch (error) {
+      console.error(chalk.red(`❌ ${error instanceof Error ? error.message : String(error)}`));
+      process.exitCode = 1;
+      return null;
+    }
+  }
+
+  const requestedLines = options.lines ?? (digMode ? CORRELATION_DEFAULT_LINES : 100);
+  if (!Number.isFinite(requestedLines) || requestedLines <= 0) {
+    // NaN silently comparing false against the cap would forward `-n NaN`
+    // to the railway CLI — a confusing downstream failure instead of this.
+    console.error(chalk.red(`❌ --lines must be a positive number, got "${options.lines}"`));
+    process.exitCode = 1;
+    return null;
+  }
+  if (requestedLines > MAX_LINES) {
+    console.log(
+      chalk.yellow(
+        `⚠️  --lines ${requestedLines} exceeds the Railway CLI cap (~${MAX_LINES}); ` +
+          `clamping to ${MAX_LINES}. For older windows, use \`railway logs <deployment-id>\`.`
+      )
+    );
+    return { sinceMs, lines: MAX_LINES };
+  }
+  return { sinceMs, lines: requestedLines };
+}
+
+/**
  * Fetch logs from Railway service
  */
 export async function fetchLogs(options: LogsOptions): Promise<void> {
-  const { env, service, lines = 100, filter, follow = false } = options;
+  const { env, service, filter, follow = false, requestId, jobId, since } = options;
 
   if (!checkRailwayCli()) {
     console.error(chalk.red('❌ Railway CLI not authenticated'));
@@ -178,31 +384,46 @@ export async function fetchLogs(options: LogsOptions): Promise<void> {
     return;
   }
 
+  const terms = [requestId, jobId].filter(
+    (t): t is string => typeof t === 'string' && t.length > 0
+  );
+  const digMode = terms.length > 0 || since !== undefined;
+
+  if (digMode && follow) {
+    console.error(chalk.red('❌ --request-id/--job-id/--since cannot combine with --follow'));
+    console.error(chalk.dim('   They filter a fetched window; --follow is a live stream.'));
+    process.exitCode = 1;
+    return;
+  }
+
+  const bounds = resolveWindowBounds(options, digMode);
+  if (bounds === null) {
+    return;
+  }
+  const { sinceMs, lines } = bounds;
+
   const railwayEnv = getRailwayEnvName(env);
   const validatedService = validateService(service);
 
-  displayHeader(railwayEnv, validatedService, lines, filter);
-
-  // Build Railway logs command arguments.
-  // --filter is passed through as a Railway 4.11.2 server-side query (attribute
-  // filters like `@level:error`, boolean operators like `"vision AND 404"`).
-  const args = ['logs', '--environment', railwayEnv];
-  if (validatedService) {
-    args.push('--service', validatedService);
-  }
-  args.push('-n', String(lines));
-  if (filter !== undefined) {
-    args.push('--filter', filter);
-  }
-  if (follow) {
-    args.push('--follow');
-  }
+  // Header shows BOTH filter layers when they compose: the server-side DSL
+  // narrows the fetched window, then the correlation terms match locally.
+  const filterDisplay = [
+    filter,
+    terms.length > 0 ? `local terms: ${terms.join(' AND ')}` : undefined,
+  ]
+    .filter((part): part is string => part !== undefined && part.length > 0)
+    .join(' | ');
+  displayHeader(railwayEnv, validatedService, lines, filterDisplay);
 
   try {
-    if (follow) {
-      await streamLogsWithFollow(args);
+    if (digMode) {
+      runLocalFilterDig({ railwayEnv, service: validatedService, lines, filter, terms, sinceMs });
+    } else if (follow) {
+      await streamLogsWithFollow(
+        buildRailwayArgs({ railwayEnv, service: validatedService, lines, filter, follow })
+      );
     } else {
-      fetchLogsSync(args);
+      fetchLogsSync(buildRailwayArgs({ railwayEnv, service: validatedService, lines, filter }));
     }
   } catch (error) {
     handleLogsError(error, validatedService);


### PR DESCRIPTION
## Summary

**Closes the [railway-log-search-dx theme](../blob/develop/backlog/cold/themes/railway-log-search-dx-for-incident-digs.md)** — second closure of the finishing push. Items 1 (requestId threading) and 2 (query-syntax docs + server-side `--filter` passthrough) shipped earlier; this is item 3, the ergonomic flags.

## Design deviation from the original spec — deliberate

The theme drafted the flags as translations to Railway's DSL (`@requestId:X`). That would build on the *unreliable* mechanism: the deployment skill documents (from the 2026-06-19 vision-404 dig) that hyphenated tokens — UUIDs are all hyphens — and quoted phrases routinely match nothing server-side, and that the reliable pattern is pull-a-window-and-grep-locally. The flags encode the reliable pattern:

- `--request-id <uuid>` / `--job-id <id>`: fetch a 5000-line window per service, **local** case-insensitive substring match (AND when both given), sweeping bot-client + api-gateway + ai-worker with labeled sections when no `--service` is specified — the cross-service trace this theme was founded on, in one command.
- `--lines` above ~5000 now **clamps with a warning** instead of hitting the CLI failure mode where the request errors out and returns zero rows (which reads as "no matching logs" — the exact trap the skill warns about).
- `--since <when>`: local floor on the pino `time` field; ISO-8601 or relative (`45m`/`6h`/`2d`). Lines without a parseable time (boot noise) drop in since-mode.
- Dig flags reject `--follow` (window filter vs. live stream); footer notes the current-deployment scope and points at the deployment-ID lookup for older windows.

`parseSinceMs`/`applyLocalFilters` exported pure for direct testing; the skill's Log Analysis section now leads with the ergonomic flags.

## Tests

11 new: local-match without `--filter` + 5000-line dig default, three-service sweep, AND semantics, `--follow` rejection, clamp warning, since-floor line filtering (recent kept / stale + timeless dropped), unparseable-since rejection, and `parseSinceMs` unit cases (relative × 3, ISO, garbage). `pnpm test` + `pnpm quality` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)