### PR TITLE
docs(rules): process refit — operationalize friction-mining findings for the model handoff

### DIFF
--- a/.claude/hooks/pr-monitor-reminder.sh
+++ b/.claude/hooks/pr-monitor-reminder.sh
@@ -95,7 +95,7 @@ Per .claude/rules/05-tooling.md (PR Monitoring), arm a Monitor now:
 
   Monitor({
     description: "CI + reviews for PR #$PR_NUM",
-    command: 'gh pr checks $PR_NUM --watch --interval=30 > /dev/null 2>&1; echo "CI_COMPLETE"; gh pr checks $PR_NUM',
+    command: 'sleep 60; gh pr checks $PR_NUM --watch --interval=30 > /dev/null 2>&1; sleep 5; echo "CI_COMPLETE"; gh pr checks $PR_NUM',
     timeout_ms: 900000
   })
 
@@ -111,6 +111,7 @@ When it fires:
    silently misses inline line comments — the most common place human
    reviewers leave blocking feedback.)
 - Report CI state + reviewer findings in one message (blocking vs. non-blocking).
-- Do NOT fix without user approval.
+- Apply feedback per .claude/rules/08-review-response.md (trivial-shape
+  auto-apply via test-gated fixups; semantic-shape ASK; batch-present).
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 EOF

--- a/.claude/rules/00-critical.md
+++ b/.claude/rules/00-critical.md
@@ -132,6 +132,8 @@ gh pr merge 714 --rebase                  # develop survives
 
 **Uncommitted changes = HOURS OF WORK.** When user says "get changes" → COMMIT, not DISCARD.
 
+**`git stash pop` caveat**: stashes are a global LIFO stack, NOT per-branch. Popping blind applies another branch's stash and produces conflict markers in files you never touched. Always `git stash list` and inspect before any pop.
+
 ### Standing permission: feature-branch commits and pushes
 
 Routine `git add <files>` + `git commit` + `git push` + `gh pr create` to feature branches is **pre-authorized**. After implementation work passes its verification (tests + quality), proceed straight to: branch → stage specific files → commit → push → `gh pr create`. Don't ask "want me to commit?" or "should I open the PR now?" — the user reviews on the PR diff, not on a per-commit prompt.
@@ -170,27 +172,30 @@ git push origin develop
 
 No branch, no PR, no CI re-run. Pre-push hooks still fire because they run on any push.
 
-**Why this exception exists**: routine doc housekeeping (post-merge BACKLOG sweeps, CURRENT.md handoffs, runbook fixes) gets no useful signal from automated review, so the PR ceremony adds friction without catching mistakes. Code changes still go through PRs because the diff _is_ where the automated review fires. Established 2026-04-25 after PR #899 merge surfaced friction around stashing a 6-line BACKLOG tracker update for a future PR.
+**Why**: doc housekeeping gets no useful signal from automated review; code diffs are where the review fires.
 
 **This permission does NOT extend to:**
 
 - Anything in the "Destructive Commands - ASK FIRST" table above (force-push, reset --hard, restore, clean, kill processes, rm -rf)
-- `gh pr merge` (always needs explicit user approval — see "Never Merge PRs Without User Approval" below)
+- `gh pr merge` on the release PR (develop → main) — always needs explicit per-release approval; feature/fix merges follow "Merge Approval" below (standing authorization once truly ready)
 - Branch deletion (`git branch -D`, `--delete-branch` flag on `gh pr merge`) on long-lived branches (main/develop)
 - Skipping hooks (`--no-verify`, `--no-gpg-sign`)
 - Touching `.env` or files that may contain secrets
 
-**Why this rule exists**: applying "ask before any commit" too literally produced decision-fatigue noise — the user was rubber-stamping commits one-by-one when the meaningful review surface is the PR diff. A standing pre-authorization for the routine commit-push-PR cycle, paired with the unchanged "ask first" gates above, restores the right asymmetry: low cost for routine actions, high cost for irreversible ones. Established 2026-04-25.
+**Why**: per-commit asks produced rubber-stamping noise; the PR diff is the review surface. Low cost for routine actions, high cost for irreversible ones.
 
 ### Before Code Changes
 
 1. Read the ENTIRE file first
 2. Never modify files you haven't read
 3. Make ONLY the requested change
+4. **For approved designs that touch schema or user-visible behavior: restate the user-visible semantics in plain terms and get confirmation before building.** Plan-mode plans must include a "what the user will see/do differently" section. An epic phase was once built on a `kind` param the owner understood as capability-filtering when it actually stored config-kind — the most expensive miscommunication on record; restating semantics up front is how that class dies.
 
-### Never Merge PRs Without User Approval
+### Merge Approval
 
-CI passing != merge approval. User must explicitly request merge.
+**Standing authorization (user-granted 2026-06-26): feature/fix PRs may be merged without a per-PR ask once they are truly ready** — every CI check green + complete + read (next section), the claude-review body read with no unresolved substantive findings, and any human feedback addressed. "Truly ready" is strict; when in doubt, ask.
+
+**The release PR (develop → main) ALWAYS requires explicit per-release user approval.** CI passing ≠ release approval — no exceptions.
 
 ### Never Merge PRs Without Completed CI
 
@@ -218,7 +223,7 @@ If post-merge feedback surfaces from claude-review on a tiny fixup, it can alway
 
 **Bypassing CI is forbidden** even when the user has approved the merge in principle — approval is contingent on the merge happening through a green pipeline. If the user explicitly says "merge it anyway despite the red check," confirm once that they understand which check is red and what signal is being skipped before proceeding.
 
-**Observed**: 2026-04-24, release PR #892. `claude-review` failed with `Claude Code native binary not found at /home/runner/.local/bin/claude` (empty `ANTHROPIC_API_KEY` in env block). Treated as infra-only and merged through. User feedback: rerun the failed CI task rather than merge through it.
+**Observed**: release PR #892 — an infra-red claude-review was merged through; the correction is rerun-then-merge, never merge-through.
 
 ## Testing
 
@@ -251,7 +256,7 @@ This applies to:
 - **Coverage gaps** flagged in PR reviews — fix them, don't explain them away
 - **Documentation** that's stale or misleading in files you're touching
 
-The only exception: if fixing the issue would significantly expand the scope of the PR and risk introducing unrelated bugs. In that case, create a backlog item — but still fix it in a follow-up, not "someday."
+The only exception: fixing it would significantly expand the PR's scope and risk unrelated bugs. Deferring requires a stated strong reason (different mechanism, no production evidence, risky breadth) — "pre-existing," "harmless," and "could be a follow-up" are non-reasons. If deferred, write the backlog entry immediately and fix it in a follow-up, not "someday." Declined ideas get NO tombstone in docs or backlog — the decline rationale lives in the PR/commit that declined them.
 
 ### Verify Before Accepting External Feedback
 
@@ -276,6 +281,10 @@ When making claims about causation, origin, intent, or history, distinguish betw
 
 **An empty or sparse tool result is not evidence that the data is gone.** When a query returns nothing — or less than you expected — the cause is almost always the _query_, not missing data: a wrong filter field, an out-of-range flag value, the wrong scope, or finicky query syntax. Do NOT explain it away with infrastructure-decay claims ("the logs rolled off", "it aged out of retention", "it expired", "it got GC'd") unless you have direct evidence that's literally true. That's the satisfying answer, and it's almost always wrong — stating it as fact sends the user looking for data that's sitting right there. Default to "my query is wrong": enumerate why it could be returning nothing, and fix the query before blaming the store. (Railway-log specifics — the `--lines` cap, filtering by the field the log actually carries, the ended-deploy lookup — live in the `/tzurot-deployment` skill.)
 
+**Negative existence claims require an exhaustive search.** "We don't have X," "there's no way to do Y," and "that's not possible in this codebase" are claims about the ENTIRE codebase; a one-vocabulary grep cannot support them. Before stating one: search ≥3 vocabulary variants (your term, the domain's term, the library's term), sweep the generated declaration index (`pnpm ops xray --format md | grep -iE 'termA|termB|termC'` — regenerated from source, cannot be stale), and check for dormant scaffolding (`pnpm knip:dead`). If the sweep still finds nothing, state the claim WITH its evidence — "I searched A/B/C and found nothing" — which honestly invites correction. **The user's "I thought we had X" is a search order, not a debate prompt**: their vague memory has repeatedly beaten confident absence claims (webhook `applicationId`, the dormant `isProxyMessage` stub, the OpenRouter key that was "missing").
+
+**Completion claims require re-reading the scope definition.** Before declaring a theme, epic, or multi-part task "done"/"complete," re-open its scope artifact (theme file, plan, epic roadmap) and enumerate remaining items by name. "The last PR merged" is not "done" — the definition's own checklist being empty is. An overclaimed completion silently removes work from the finishing-first queue, which is strictly worse than leaving it visibly unfinished (the Stryker theme was declared done with one of many packages piloted).
+
 **Why this matters:** Users rely on assertions to decide what to do next. Speculation-as-fact produces wasted work when the real cause turns out to be different, and erodes trust when the pattern repeats. Prefer "the evidence shows X; the remaining candidates for why Y are A / B / C — here's how to narrow it" over "it was Z."
 
 ### Mandatory Global Discovery ("Grep Rule")
@@ -294,4 +303,8 @@ Claude's per-instance auto-memory at `~/.claude/projects/*/memory/` is a complem
 
 **When something is important enough to flag as feedback, it is usually important enough to make recurrence structurally harder.** If a failure mode belongs in memory, first ask whether it also belongs in a rule or skill. Don't let memory become a graveyard of "try harder" notes.
 
-Scope the structural fix to the **class** of failure, not just the exact symptom. And don't over-expand — a one-line rule addition or a paragraph in a skill is usually enough.
+**Promotion is atomic with deletion.** When a memory's content is promoted into a rule/skill/hook, delete the memory file, its MEMORY.md index line, and any inbound `[[links]]` in the same action — never leave the draft behind. Redundant memories reload every session and drift out of sync with the promoted rule.
+
+**A tool without a named decision-point trigger goes unused.** When building or adopting a tool, write down the moment it must be reached for ("before asserting X", "after every push") in the relevant rule/skill — a tool that exists only in a command-reference table gathers dust (xray: 95 mentions while being built, near-zero use in the month after).
+
+Scope the structural fix to the **class** of failure, not just the exact symptom. And don't over-expand — a one-line rule addition or a paragraph in a skill is usually enough. Rules state constraints plus at most a one-sentence why; multi-paragraph incident narratives don't belong here — the operationalized outcome IS the record (git preserves the story).

--- a/.claude/rules/00-critical.md
+++ b/.claude/rules/00-critical.md
@@ -193,7 +193,7 @@ No branch, no PR, no CI re-run. Pre-push hooks still fire because they run on an
 
 ### Merge Approval
 
-**Standing authorization (user-granted 2026-06-26): feature/fix PRs may be merged without a per-PR ask once they are truly ready** — every CI check green + complete + read (next section), the claude-review body read with no unresolved substantive findings, and any human feedback addressed. "Truly ready" is strict; when in doubt, ask.
+**Standing authorization (explicit user grant, reconfirmed at codification): feature/fix PRs may be merged without a per-PR ask once they are truly ready** — every CI check green + complete + read (next section), the claude-review body read with no unresolved substantive findings, and any human feedback addressed. "Truly ready" is strict; when in doubt, ask.
 
 **The release PR (develop → main) ALWAYS requires explicit per-release user approval.** CI passing ≠ release approval — no exceptions.
 

--- a/.claude/rules/05-tooling.md
+++ b/.claude/rules/05-tooling.md
@@ -88,6 +88,8 @@ pnpm ops xray --imports              # Include import analysis (auto for md/json
 
 **Use `--summary` for architectural overview.** Full mode lists every declaration.
 
+**Decision-point trigger**: xray is not just a periodic-audit tool — it is the required sweep before any negative existence claim ("we don't have X") per `00-critical.md` § Don't Present Speculation as Fact. `pnpm ops xray --format md | grep -iE 'termA|termB|termC'` searches every export in seconds and cannot be stale.
+
 ### Test Audits
 
 ```bash
@@ -160,6 +162,8 @@ EOF
 **Types:** `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `perf`, `debug`
 **Scopes:** `ai-worker`, `api-gateway`, `bot-client`, `common-types`, `ci`, `deps`
 
+**Commitlint gotchas** (the hook catches these, but every trip costs a retry): the subject must start **lowercase** (`subject-case`), and the scope must be in the configured enum **or omitted entirely** — an unknown scope is rejected, no scope is fine.
+
 The list above is the project's primary set. `commitlint.config.cjs` also accepts the rest of the standard Conventional Commits types — `build`, `ci`, `revert`, `style` — and the `.husky/pre-push` branch-name allowlist permits all of them as branch prefixes too, so a valid commit type is always a valid branch prefix. Reach for the standard ones when they genuinely fit (`build:` for bundler/Docker changes, `revert:` for a clean revert); otherwise the primary set covers most work.
 
 #### The `debug` type
@@ -170,11 +174,13 @@ The payoff is a built-in safety net: a `debug` commit is a high-signal "did I re
 
 Do **not** use `debug` for **permanent** observability (structured logs, metrics, traces that stay) — that is a real operational improvement and should be `feat`. The distinction is lifecycle: `debug` is scaffolding you intend to delete; `feat` observability is infrastructure you intend to keep.
 
-Adopted 2026-06-08 (unanimous council recommendation) after the forwarded-message debugging campaign repeatedly mislabelled diagnostic-logging PRs as `chore`. Enforced by `commitlint.config.cjs` (`type-enum`) and the `.husky/pre-push` branch-name allowlist (`debug/` branches permitted).
+Enforced by `commitlint.config.cjs` (`type-enum`) and the `.husky/pre-push` branch-name allowlist (`debug/` branches permitted).
 
 ### PR Monitoring (automatic — do not wait to be asked)
 
 **Whenever you create a PR or push commits to an open PR, arm a `Monitor` that waits for CI to finish and then reports on new reviewer comments.** Don't wait for the user to ask whether CI passed or whether a review landed.
+
+**First verify the push actually landed.** Backgrounded pushes reporting "exit 0" AND foreground pushes with `| tail`/`| grep`-filtered output can both hide a failed transfer. Confirm the `-> branch` ref-update line or `git status -sb` in-sync before arming the Monitor — a monitor watching a push that never landed reports a stale CI run as fresh.
 
 The `.claude/hooks/pr-monitor-reminder.sh` PostToolUse hook fires after every `git push` / `gh pr create` and injects a reminder with the pre-built Monitor invocation. If you see that banner, arm the Monitor before doing anything else — the hook is the enforcement mechanism behind this rule. If it ever stops firing (settings.json drift, hook script removed, etc.), fall back to manually arming the monitor yourself.
 
@@ -208,6 +214,10 @@ When the monitor fires, **all four** of the following must happen before the cyc
 
    Inline line comments are where human reviewers typically leave blocking feedback; if you only check `/issues/N/comments` you'll silently miss them. Track the most recently reported comment's timestamp in working memory so a subsequent push doesn't re-report already-surfaced feedback. **Include human reviewer comments** alongside `claude[bot]` / `github-advanced-security[bot]`.
 
+   **Never pipe review fetches through `| tail` / `| head`** — truncating the fetch is how body findings get silently dropped; pull the full output and read it.
+
+   **claude-review health**: the check turning green means the action _completed_ — it does NOT guarantee a review body was posted. If no new `claude[bot]` comment exists after a green run, re-run the workflow (`gh run rerun <run-id>`) before proceeding (observed twice: a placeholder post and a completed-but-posted-nothing run).
+
 3. In a single concise user-facing message, report: CI pass/fail summary **and** any new review findings (grouped as blocking vs. non-blocking). If there are no new reviews since the last push, say so explicitly — silence isn't a substitute for "no new comments."
 
    **Read every `###` section of each review body — do not rely on the trailing "Summary" / "Actionable items" section.** Reviewer output is tiered (verdict → strengths → major → minor → observations → summary), and the summary is a shortcut that commonly under-reports items the body flags. When a review is 100+ lines, treat length itself as a skimming red flag. Cross-check correlated signals: if codecov flags missing lines, grep the review body for a corresponding test-gap call-out. If multiple `claude[bot]` entries exist (e.g., one per push cycle), read every one — don't assume only the latest matters.
@@ -217,7 +227,7 @@ When the monitor fires, **all four** of the following must happen before the cyc
 Two failure modes to guard against — both matter:
 
 - **Step 1 without step 2**: all-green CI feels complete, so the comment-fetch step gets skipped. Steps 1 and 2 are both part of the Monitor-fire response contract; all-CI-green does not discharge the comment-fetch obligation.
-- **Step 2 without full-body read**: fetching comments but only extracting items from the trailing summary section. A review that ends "Summary: two actionable items" almost always has a body listing more. Observed 2026-04-21 on PRs #842/#843/#844 — multiple body-only items got missed, including a Medium test-coverage gap that codecov independently confirmed.
+- **Step 2 without full-body read**: fetching comments but only extracting items from the trailing summary section. A review that ends "Summary: two actionable items" almost always has a body listing more (observed: body-only items, including a codecov-confirmed coverage gap, missed on three consecutive PRs).
 
 If CI fails or CodeQL flags a new alert, surface it via `PushNotification` — that class of feedback changes what the user does next.
 

--- a/.claude/rules/05-tooling.md
+++ b/.claude/rules/05-tooling.md
@@ -187,7 +187,7 @@ The `.claude/hooks/pr-monitor-reminder.sh` PostToolUse hook fires after every `g
 The monitor command (PR number is `N`):
 
 ```
-gh pr checks N --watch --interval=30 > /dev/null 2>&1; echo "CI_COMPLETE"; gh pr checks N
+sleep 60; gh pr checks N --watch --interval=30 > /dev/null 2>&1; sleep 5; echo "CI_COMPLETE"; gh pr checks N
 ```
 
 Note the `;` between each command (not `&&`). `echo "CI_COMPLETE"` and the final `gh pr checks N` run unconditionally — the sentinel fires even if `--watch` exits non-zero (network blip, bad flag). That's intentional: the trailing `gh pr checks N` surfaces the true state regardless, and "watch exited" is always a useful signal. `CI_COMPLETE` means "watch exited," not "all checks passed."

--- a/.claude/rules/06-backlog.md
+++ b/.claude/rules/06-backlog.md
@@ -50,8 +50,9 @@ There is no "prune items older than N days" rule. Staleness is a signal to act, 
 
 1. Read `CURRENT.md` for context
 2. Read `backlog/now.md` — 🚨 Production Issues fix first; then continue 🎯 Current Focus
-3. If Current Focus is empty, pull from ⚡ Quick Wins (in `now.md`) or `backlog/active-epic.md`
-4. Do NOT load `backlog/cold/` — grep it only when a task points you there
+3. **Freshness-check before presenting**: a board entry is a snapshot, not a fact. Before presenting a Production Issue as live, verify it against reality (git log for fixes that already landed, the user's own runtime experience, recent release notes). When two entries share a symptom, check whether they're one underlying seam — the z.ai "routing bug" and the footer mis-attribution were tracked separately but were one bug.
+4. If Current Focus is empty, pull from ⚡ Quick Wins (in `now.md`) or `backlog/active-epic.md`
+5. Do NOT load `backlog/cold/` — grep it only when a task points you there
 
 ### Ending a Session
 
@@ -64,7 +65,9 @@ There is no "prune items older than N days" rule. Staleness is a signal to act, 
 
 Marking something "out of scope" is NOT permission to ignore it. Any known defect, inconsistency, or technical deficiency you decide not to fix in the current work **must** land in the appropriate `backlog/**/*.md` file with a concrete destination. Applies to plans, PRs, code reviews, and ad-hoc work.
 
-**Commit messages, PR bodies, plan notes, and code comments are NOT substitutes for backlog entries.** Mentioning "adminFetch sites are a distinct follow-up" in a commit message, or writing `// TODO: migrate this later` in a comment, does not count as tracking — nobody greps commit history or scattered comments looking for deferred work. If the follow-up matters enough to mention anywhere, it matters enough to be a concrete entry in the appropriate `backlog/**/*.md` file before the current work closes. Observed failure mode 2026-04-21 on PR #859 where "adminFetch follow-up" was flagged in a commit message but never written to backlog; reviewer caught the gap.
+**Commit messages, PR bodies, plan notes, and code comments are NOT substitutes for backlog entries.** Mentioning "adminFetch sites are a distinct follow-up" in a commit message, or writing `// TODO: migrate this later` in a comment, does not count as tracking — nobody greps commit history or scattered comments looking for deferred work. If the follow-up matters enough to mention anywhere, it matters enough to be a concrete entry in the appropriate `backlog/**/*.md` file before the current work closes.
+
+**The promise ledger — file at the moment of utterance.** Any in-flight "I'll do X later / after this PR / when the release is done" — in chat, a plan, or a PR description — must land in the task list or the appropriate backlog file THE MOMENT it is said, not at session end. A promise that exists only in chat prose does not exist: it dies at the next compaction, and the user ends up asking "you said you were going to do X" / "what's the plan for getting those done?" (both recurred repeatedly). The session-end gates below are the backstop, not the mechanism.
 
 ### Two types of "out of scope" — only one needs tracking
 
@@ -100,6 +103,8 @@ A session is ALSO not done until every item that shipped during the session is r
 - For each PR, grep `backlog/` (recursive — includes `cold/`) for the item title/topic — if a matching entry exists, **remove it**
 - For any backlog entry annotated "PROMOTED to Current Focus" or similar, re-verify the underlying fix actually shipped; if yes, remove
 - Also remove any entry whose "Start" hints point to code that no longer needs fixing (grep the file to confirm). This is the "genuinely obsolete" removal path — it's distinct from time-based pruning, which we do NOT do.
+
+**Strike through sub-items at absorption, not at PR close.** Umbrella entries (multi-item audits, grouped follow-ups) don't track sub-item resolution automatically: when a PR resolves ONE sub-item of an umbrella entry, strike it through in the same working session as the resolving PR — waiting for "later" is how umbrella entries silently rot into half-done.
 
 Both gates pair with the session-end workflow in the `/tzurot-docs` skill.
 

--- a/.claude/rules/07-documentation.md
+++ b/.claude/rules/07-documentation.md
@@ -50,6 +50,8 @@ Each layer points down. No upward references. No duplicated content.
 - **Abandoned plans** -- delete (git preserves history)
 - **Build process docs** -- delete after shipping (document the feature, not the process)
 - **Diverged planning docs** -- delete when implementation took a meaningfully different shape than what the doc describes; the code is the source of truth. Test: would a reader following this doc end up confused about what currently exists?
+- **Post-mortems** -- an entry is _incident (≤3 lines) → operationalization shipped (rule/hook/guard link)_. The point of a post-mortem is not the narrative but what got operationalized in its wake; narrative beyond that is deleted (git preserves it). An entry with no operationalization outcome is a red flag to fix, not a keepsake.
+- **Rules/skills carry constraints, not archaeology** -- a rule states the constraint plus at most a one-sentence why; multi-paragraph incident stories, adoption dates, and council-derivation notes don't belong in always-loaded surfaces. The operationalized outcome IS the record.
 
 ## Reference Root Files
 
@@ -63,6 +65,8 @@ These live directly in `docs/reference/` (not in a subdirectory):
 | `RAILWAY_CLI_REFERENCE.md`    | Railway CLI patterns                  |
 | `REASONING_MODEL_FORMATS.md`  | LLM reasoning output formats          |
 | `v2-patterns-reference.md`    | Legacy v2 patterns                    |
+| `audit-enforcement.md`        | Audit-tool registry criteria + layers |
+| `CPD_CAMPAIGN_AUDIT.md`       | CPD campaign close-out audit          |
 
 ## Related
 

--- a/.claude/rules/08-review-response.md
+++ b/.claude/rules/08-review-response.md
@@ -8,8 +8,6 @@ The prior rule was "report only, never fix without user approval." Rigorously sa
 
 **Key design principle**: `claude-review` is the same model family as the agent. It has no special epistemic authority. When the reviewer's severity label conflicts with the agent's own classification, that's **uncertainty**, not an override opportunity in either direction. The safe resolution is always ASK.
 
-Derived from a three-model council review (Gemini 3.1 Pro → Kimi K2.6 → GLM-5.1) on 2026-04-24 after a session where two PRs each hit 5–6 review rounds with extensive rubber-stamping overhead.
-
 ## The six rules
 
 ### 1. Classify the edit shape first
@@ -43,7 +41,7 @@ Compare the reviewer's severity label against the edit shape from rule 1:
 
 **Dismissed vs. Backlog candidates** — both are "no action this round," but they differ on whether a future trigger exists. **Key question: does the reviewer name a specific event, metric, or threshold that should reopen the question? If yes → Backlog candidate. If no → Dismissed.** A reviewer self-dismissal ("actually fine," "non-issue," "current is correct") has no trigger; the matter is closed. A **pure-aesthetic deferral** ("the naming could be cleaner someday," "might be worth polishing later," "if you're ever doing a follow-up pass" — vague preference with no named event) also has no actionable trigger; treat it as Dismissed. A reviewer deferral with a **named condition** ("worth keeping in mind if the retry count grows," "monitor over time," "if X happens, narrow Y") has an implicit trigger; without tracking, the trigger silently expires when memory fades.
 
-**When the reviewer's framing names a future event or condition that should reopen the question, the entry belongs in Backlog candidates, not Dismissed.** File the entry in the granularity-appropriate backlog file (per `06-backlog.md`: a one-line follow-up with a "promote when" trigger → `backlog/cold/follow-ups.md`; a larger parked idea → `backlog/cold/ideas.md`), capturing both the deferred concern and the promote-when criterion. (A trigger is a field on the item, not its own bucket — the old "route to Deferred" rule is gone.) Established 2026-04-29 after PR #941 round 1: a `claude-review` "worth keeping an eye on over the next few PR cycles" framing was incorrectly bucketed as Dismissed; the reviewer's later round 2 sharpened the framing to a concrete monitoring criterion + fallback action, surfacing the gap.
+**When the reviewer's framing names a future event or condition that should reopen the question, the entry belongs in Backlog candidates, not Dismissed.** File the entry in the granularity-appropriate backlog file (per `06-backlog.md`: a one-line follow-up with a "promote when" trigger → `backlog/cold/follow-ups.md`; a larger parked idea → `backlog/cold/ideas.md`), capturing both the deferred concern and the promote-when criterion. (A trigger is a field on the item, not its own bucket — the old "route to Deferred" rule is gone.)
 
 **Reviewer self-contradiction across rounds**: when round-N reviewer reverses its round-(N-1) stance on the same item (e.g., round 3 says "drop the `?? ''` as unreachable," round 4 says "add `?? ''` back for defensive typing"), the reviewer is not authoritative on its own prior disagreement. Dismiss and cite the earlier round's reasoning in the summary. Don't ping-pong. This is distinct from genuine new information surfacing — a round-N reviewer observation that _builds on_ round-(N-1) (adds context, corrects an error) is normal; a direct reversal on the same fact-pattern is noise.
 
@@ -62,7 +60,7 @@ Fixup commits autosquash naturally on the next `git rebase -i --autosquash`. Thi
 
 **Critical: `gh pr merge --rebase` does NOT autosquash fixup commits.** It runs `git rebase`, not `git rebase --autosquash`. Fixup commits will land on the base branch with their `fixup!` titles intact and clutter `git log` permanently (observed 2026-04-24 on PRs #889 and #890 — both required force-push cleanup of develop after merge).
 
-**Structural enforcement: the `fixup-check` job in `.github/workflows/ci.yml`** runs on every push to a feature branch and fails if any commit on the branch (since the merge base with develop) has a `fixup!` or `squash!` subject. CI stays red until you autosquash, which means the merge button is gated on it being green. This eliminates the "forgot to autosquash" failure mode at the tooling level — you can't accidentally merge a branch with fixup commits. Added 2026-04-24 after PR #890 merged with 4 visible `fixup!` commits despite this rule already prescribing the autosquash step.
+**Structural enforcement: the `fixup-check` job in `.github/workflows/ci.yml`** runs on every push to a feature branch and fails if any commit on the branch (since the merge base with develop) has a `fixup!` or `squash!` subject. CI stays red until you autosquash, which means the merge button is gated on it being green — you can't accidentally merge a branch with fixup commits.
 
 The correct pre-merge sequence is:
 
@@ -207,7 +205,7 @@ Before each round's consolidated message:
 
 ## Relationship to other rules
 
-- **`00-critical.md`** "Never merge PRs without user approval" remains in force. This rule governs iteration _before_ merge approval; it does not loosen the merge gate.
+- **`00-critical.md`** § "Merge Approval" governs the merge gate (standing authorization for feature/fix PRs once truly ready; the release PR always needs explicit approval). This rule governs iteration _before_ that gate; nothing here loosens it.
 - **`00-critical.md`** "NEVER modify tests to make them pass" remains in force. The test-suite gate in rule 3 fails closed — a trivial-shape edit that breaks tests is escalated, not covered up by modifying tests.
 - **`05-tooling.md`** PR-monitoring step 4 delegates to this file.
 - **`06-backlog.md`** out-of-scope tracking still applies — items explicitly flagged as follow-ups are added to the appropriate `backlog/**/*.md` file per rule 4's "Backlog candidates" section.

--- a/.claude/rules/09-interaction-style.md
+++ b/.claude/rules/09-interaction-style.md
@@ -4,40 +4,27 @@ Rules about how to interact with the user during sessions. These supplement, not
 
 ## Don't Suggest Stopping
 
-**Never proactively suggest the user stop for the day, take a break, or pause the session unless they explicitly signal fatigue or ask for one.** Phrasing like "you should not be doing X at 7 PM," "I'd lean toward stopping here, sleep on it," or "you've been at this for hours" reads as performative parenting and frustrates users who hired an AI helper precisely so they can keep working.
+**Never proactively suggest the user stop for the day, take a break, or pause the session unless they explicitly signal fatigue or ask for one.** Time-of-day, accumulated session length, and "you've been at this all day" are never reasons to recommend stopping — energy management belongs to the user, who hired an assistant precisely so they can keep working. They will say when they're tired.
 
-### Why this rule exists
+- Present options without ranking "stop" as a default or recommended path
+- Don't editorialize about session length or the clock ("you should not be doing X at 7:40 PM" is a violation)
+- No "sleep on it" / "you've earned a rest" codas on recommendations ("continuing tonight risks fatigue mistakes" projects fatigue onto the user — violation)
+- Next-step recommendations are technical (highest-leverage step), not pastoral
+- Flagging a _technical_ natural breakpoint ("this is a clean merge state if you want to lock it in first") is fine; recommending stopping as the preferred path is not
+- Edge case: if the user has explicitly flagged fatigue/illness/recovery, offering "this is a stopping point if you want one" _once_, as one option among several, is appropriate — never as the recommendation, never repeated
 
-The "go to sleep" / "you've earned a rest" pattern from Opus 4.7 was annoying and counter to the purpose of an AI assistant. The model had been invoking time-of-day, accumulated session length, or "you've been at this all day" as reasons to suggest stopping — even when the user gave no signal of wanting to stop. This rule is the remediation. The behavior was risk-averse to a fault: it shifts the burden of energy management onto the agent when it belongs to the user.
+## Answer the User's Questions First
 
-The behavior reads as "digital parent figure" framing: well-meaning but unwanted. The user hired an AI helper precisely so they don't have to negotiate session length with it. The user knows when they're tired. They will say so.
+When a user message contains a question, answer it BEFORE advancing your own agenda — the release flow, the next task, or a re-ask of your own pending question. Multi-part messages get every part addressed; enumerate the parts if that's what it takes. Skipping an embedded question forces the user to halt the work and re-ask ("can you answer my webhook question first?", "did you see my question?" — both real).
 
-This rule was promoted from auto-memory (`feedback_no_premature_stopping.md`) on 2026-04-26 after the memory-only version failed to prevent recurrence. Memory is per-instance and per-session-recall; rules load every session for every contributor.
+## User Directives Are Immutable Session State
 
-### How to apply
+Once the user has made a call — a release gate ("I want them fixed before the release is cut"), a scope decision, a design choice — do not re-propose the alternative in later turns. Re-litigating forces escalation ("I'm not budging on that"). Genuinely new information may justify surfacing the tradeoff once more, explicitly framed as new information; convenience or effort never does.
 
-- Present options without ranking "stop" as a default or recommended path among them
-- Don't editorialize about how long the session has been or what time it is
-- Don't add "you should rest" / "sleep on it" / "you've earned this" framing to recommendations
-- Trust the user to say when they want to pause; they will
-- Recommendations about what to work on next should be technical (highest-leverage next step) not pastoral (you've earned a rest)
-- It's still fine to flag a _technical_ natural breakpoint ("this is a clean state to merge if you want to") — what's NOT fine is recommending stopping as the preferred path
+## Most-Correct Is the Standing Default
 
-### Edge case
+When options differ in correctness vs. effort, do the most correct thing even when it's more work — the user's standing preference, stated unprompted many times ("I'd like us to do the most correct thing whenever possible, even if it's a bit more work"). Don't present speed-vs-correctness menus that force them to re-assert it. Offer a shortcut only when there's a concrete reason (throwaway code, hard deadline), explicitly labeled as the exception.
 
-If the user has explicitly mentioned fatigue, illness, or a recovery period (e.g., flagged in auto-memory like `user_recovery_period.md`), then gently noting "this is a stopping point if you want one" _once_, in a list of options, is appropriate. But still as an offered option, not a recommendation. Don't repeat across the session.
+## Read Dictated Messages Charitably
 
-### What violates this rule
-
-Examples from real session output that triggered the user-feedback that produced this rule:
-
-- "You've been at this all day. We've made progress; here are options:" → frames stopping as the default reading.
-- "You should not be diagnosing Discord.js internals at 7:40 PM after a marathon day." → uses time-of-day to push for stop.
-- "I'd lean toward option 2: cut the release because the work is real, leave the bug active in the backlog with concrete narrowed scope, sleep on it." → recommends stop with "sleep on it" coda.
-- "Continuing tonight risks fatigue mistakes." → projects fatigue onto the user.
-
-### What's fine
-
-- "Three options: (1) ..., (2) ..., (3) ...; my pick is option 3 because [technical reason]." → presents technical recommendation without time/fatigue framing.
-- "We've narrowed the bug to layer X. Next concrete step is Y. Want me to do Y now or hand off?" → asks user's preference without nudging toward stop.
-- "Before we continue: this is a clean merge state if you want to lock it in first." → flags a technical breakpoint without recommending stop.
+The user often dictates by voice, and the transcriber garbles words ("dock sweep" = doc sweep, "striker" = Stryker). Filler words and disfluency are normal dictation, not imprecision or frustration. Resolve odd phrases from context before asking. Half-formed thinking-out-loud designs ("maybe I'm overthinking it") are invitations to evaluate, not specs to execute verbatim.

--- a/.claude/skills/tzurot-council-mcp/SKILL.md
+++ b/.claude/skills/tzurot-council-mcp/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-council-mcp
 description: 'Multi-perspective AI consultation. Invoke with /tzurot-council-mcp for major refactors (>500 lines), structured debugging after failed attempts, or when a technical decision has multiple viable approaches.'
-lastUpdated: '2026-07-01'
+lastUpdated: '2026-07-03'
 ---
 
 # Council MCP Procedures
@@ -79,7 +79,7 @@ mcp__council__list_models({ provider: 'anthropic', search: 'claude' });
 mcp__council__recommend_model({ task: 'reasoning' });
 ```
 
-**Known drift incident (2026-04-09)**: `google/gemini-3-pro-preview` returned 404 mid-session — it had been superseded by `google/gemini-3.1-pro-preview`. Cached IDs from prior sessions are landmines.
+(Cached IDs from prior sessions are landmines — a preview model has 404'd mid-session after being superseded.)
 
 ### When a model 404s mid-session
 
@@ -94,7 +94,7 @@ End the failed session, call `list_models` to find a replacement with similar ca
 | Vision/Images    | Gemini 2.5 Flash, Gemini 2.5 Pro                                                                      | (verify availability with `list_models`)                                                    |
 | Long Documents   | Gemini (1M token context)                                                                             | (verify availability with `list_models`)                                                    |
 
-**Why avoid DeepSeek R1 for reasoning/design**: explicit user feedback (2026-04-09) — _"In the future, I would recommend not using R1 because again, it is dated. There are better models out there."_ R1 is acceptable for narrow factual queries but not for architectural decisions that ship to users. For open design decisions, run the current preferred trio in parallel — **GLM 5.2 · Kimi K2.7-code · Qwen 3.7 Max** — and verify each ID via `list_models` first (they drift; the council registry can lag a new release, e.g. GLM 5.2 wasn't listed 2026-06-17 → fall back to 5.1). If those are unavailable, fall back to Claude Sonnet / Opus, **not** R1.
+**Why avoid DeepSeek R1 for reasoning/design**: explicit user feedback — R1 is dated; design questions need SOTA. For open design decisions, run the current preferred trio in parallel — **GLM 5.2 · Kimi K2.7-code · Qwen 3.7 Max** — and verify each ID via `list_models` first (the registry can lag a new release; fall back to the prior version of the same family). If those are unavailable, fall back to Claude Sonnet / Opus, **not** R1.
 
 ### Per-call model specification
 
@@ -132,14 +132,31 @@ await mcp__council__end_conversation({
 });
 ```
 
+## Verify Premises Before Submitting
+
+**Garbage in, garbage out — a council run on a false premise wastes the whole
+pass.** Before submitting a design question, verify every factual claim in the
+prompt against the repo (read the actual routes/docstrings/config, don't
+paraphrase from memory). A council pass once ran on an oversimplified
+description built from a stale docstring and had to be fully re-run. If the
+user asks to "re-council with the full picture," that's this failure.
+
+## When the Council Splits
+
+Don't silently pick a side. Run a tiebreaker pass with a model from a different
+family than the split participants (e.g., Gemini Pro when the trio splits), give
+it both positions verbatim, and report the split + tiebreaker reasoning to the
+user. Cost is not a blocker for council usage — the user's standing position is
+that a better decision is worth the tokens.
+
 ## When Council and Claude Disagree
 
-**Resolution hierarchy:**
-
-1. Project guidelines (CLAUDE.md, rules)
-2. Existing codebase patterns
-3. Technical correctness
-4. User preference
+**Evaluate the tension on its merits — do NOT auto-resolve with "our rules always
+win."** The user's standing position: if the council proposes something genuinely
+better than an existing rule/pattern, they want to consider it. Present the
+conflict explicitly (what the rule says, what council proposes, your own
+assessment) and let the user decide. Rules win by default only when the council's
+case is weak or the rule encodes a hard safety constraint.
 
 ## Available Tools
 

--- a/.claude/skills/tzurot-deployment/SKILL.md
+++ b/.claude/skills/tzurot-deployment/SKILL.md
@@ -107,14 +107,23 @@ Raw CLI equivalents (single service, manual grep):
 # Tail specific service (CURRENT deployment only)
 railway logs --service bot-client -n 50
 
-# Search for errors
-railway logs --service api-gateway | grep "ERROR"
-
 # Trace request across services
 railway logs | grep "requestId:abc123"
+```
 
-# Find errors
-railway logs | grep '"level":"error"'
+**⚠️ NEVER grep prod logs by level.** Railway renders every pino line as
+`[INFO]` regardless of its actual level, and `"level":50`-style greps return
+false-clean while real `logger.error` failures exist (this wrongly read a
+broken deploy as "clean" once). Grep by **message text or `err=` content**
+instead:
+
+```bash
+# ✅ Find errors by content, not level
+railway logs --service api-gateway | grep -iE 'failed|error:|err='
+
+# ❌ Both of these give false-clean on Railway
+# railway logs | grep "ERROR"
+# railway logs | grep '"level":"error"'
 ```
 
 ### Pulling logs from PAST deployments
@@ -134,7 +143,7 @@ railway logs <DEPLOYMENT_ID> --service ai-worker --environment production --line
 
 The `--filter` flag uses Railway's query DSL (`@level:error`, quoted phrases like `"vision AND 404"`, etc.). For multi-token literal substring searches, single tokens often work better than quoted phrases — Railway's filter syntax doesn't always behave like grep.
 
-**When this matters**: investigations into bugs that surfaced just before a release deploy, or cross-deployment timeline traces. Surfaced 2026-04-25 during the LangChain reasoning-extraction investigation when the leaked request happened on the prior deployment.
+**When this matters**: investigations into bugs that surfaced just before a release deploy, or cross-deployment timeline traces.
 
 ### Empty log results = debug the query, not the retention
 
@@ -145,7 +154,7 @@ Railway retains logs; an empty or suspiciously short result almost always means 
 - **The `--filter` DSL is finicky.** Hyphenated tokens (`ref1-image`), quoted phrases (`"failed after"`), and special characters often match nothing. Prefer a single bare token, or pull `--lines 5000` into a file and `grep -iE` locally — local grep is predictable; the DSL is not.
 - **Ended/removed deploys are still queryable** by deployment ID (above). A `REMOVED` status does not mean the logs are gone.
 
-Surfaced 2026-06-19 chasing a prod vision `bad_request`: a `--lines 8000` query errored out to zero rows, and a `requestId` filter missed the error (logged under `attachmentId`) — both briefly mis-attributed to "logs rolled off." `--lines 5000` + local grep surfaced the full trace (a 403 on an `&amp;`-mangled embed URL) immediately.
+(Every one of these has produced a false "logs rolled off" conclusion at least once; `--lines 5000` + local grep resolved each immediately.)
 
 ## Environment Variables
 
@@ -199,6 +208,15 @@ pnpm ops run --env dev npx prisma studio
 # Note: 'railway restart' doesn't exist, use redeploy
 railway redeploy --service bot-client --yes
 ```
+
+## Cost Impact in Infra Recommendations
+
+Any recommendation that changes hosting posture — keep-warm toggles, serverless
+on/off, replica counts, timeout bumps that hold instances alive — MUST state its
+hosting-cost impact alongside the technical rationale. A keep-warm toggle was
+once recommended purely on latency grounds and overruled on cost ("will cost me
+a lot more money on hosting"); prefer the cost-neutral alternative (e.g., a
+timeout bump) unless the user opts into spend.
 
 ## Troubleshooting Checklist
 

--- a/.claude/skills/tzurot-git-workflow/SKILL.md
+++ b/.claude/skills/tzurot-git-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-git-workflow
 description: 'Git workflow procedures. Invoke with /tzurot-git-workflow for commit, PR, and release procedures.'
-lastUpdated: '2026-07-02'
+lastUpdated: '2026-07-03'
 ---
 
 # Git Workflow Procedures
@@ -45,6 +45,12 @@ EOF
 pnpm test && git push -u origin <branch>
 ```
 
+**Verify every push actually landed** before proceeding (and before arming the
+CI Monitor): confirm the `-> branch` ref-update line in the push output, or
+`git status -sb` showing in-sync. Backgrounded pushes reporting exit 0 AND
+foreground pushes with `| tail`/`| grep`-filtered output have both hidden
+failed transfers.
+
 ## PR Procedure
 
 ### Create PR
@@ -69,7 +75,7 @@ The `.claude/hooks/pr-monitor-reminder.sh` PostToolUse hook auto-fires on `git p
 ```
 Monitor({
   description: "CI + reviews for PR <N>",
-  command: 'gh pr checks <N> --watch --interval=30 > /dev/null 2>&1; echo "CI_COMPLETE"; gh pr checks <N>',
+  command: 'sleep 60; gh pr checks <N> --watch --interval=30 > /dev/null 2>&1; sleep 5; echo "CI_COMPLETE"; gh pr checks <N>',
   timeout_ms: 900000
 })
 ```
@@ -90,7 +96,7 @@ When the monitor fires, **all four** of the following must happen — do not sto
 
    **Each `claude[bot]` entry is a separate review cycle.** If multiple exist (pre-rebase + post-rebase, push + re-push), read every one — don't assume only the latest matters. Track `created_at` of the last-reported comment so future fetches dedup correctly across session boundaries.
 
-4. Don't fix anything without user approval — report only. User decides in-PR vs. backlog.
+4. Apply review feedback per `.claude/rules/08-review-response.md` — trivial-shape edits auto-apply (test-gated fixup commits), semantic-shape edits ASK; batch-present all items in one end-of-round message.
 
 The #1-without-#2 failure mode is worth guarding against: all-green CI feels complete, but new review comments can still carry blocking findings or non-blocking observations the user wants to triage.
 
@@ -98,7 +104,7 @@ The #2-without-full-body failure mode is the second trap: fetching comments but 
 
 If the monitor completes without a `CI_COMPLETE` line in its output, the 15-min timeout fired first — re-arm rather than assume CI passed. If CI fails or CodeQL flags something, use `PushNotification` — the user should hear about it before their next turn.
 
-**Merge gate is green-only.** Per `.claude/rules/00-critical.md` "Never Merge PRs With Red CI": every check must be green before `gh pr merge` runs, including release PRs. If a check fails for what looks like infrastructure reasons (binary not found, missing secret, action-setup error), `gh run rerun <run-id> --failed` and re-arm the Monitor — don't merge through the red. The release procedure below assumes a green pipeline.
+**Merge gate is green-only.** Per `.claude/rules/00-critical.md` "Never Merge PRs Without Completed CI": every check must be green before `gh pr merge` runs, including release PRs. If a check fails for what looks like infrastructure reasons (binary not found, missing secret, action-setup error), `gh run rerun <run-id> --failed` and re-arm the Monitor — don't merge through the red. The release procedure below assumes a green pipeline.
 
 ### After PR Merged
 
@@ -193,6 +199,16 @@ git log v<previous>..HEAD --no-merges --oneline
 
 ### 3. Create Release PR
 
+**Security preflight first**: check open Dependabot PRs and the GitHub security
+tab before cutting the release — the user has repeatedly been the one to notice
+new advisories mid-release, and a fixable vuln is cheaper to ride along than to
+hotfix after.
+
+```bash
+gh pr list --author "app/dependabot" --state open
+gh api repos/{owner}/{repo}/dependabot/alerts --jq '[.[] | select(.state=="open")] | length'
+```
+
 ```bash
 gh pr create --base main --head develop --title "Release v3.0.0-beta.XX: Description"
 ```
@@ -212,7 +228,7 @@ Skip if the release has no migration — `release:premigrate` detects this and e
 
 ⚠️ **NEVER use `--delete-branch` for release PRs.** `develop` is a long-lived branch.
 
-⚠️ **Wait for every CI check to be green** per `.claude/rules/00-critical.md` "Never Merge PRs With Red CI". Release PRs are not exempt — claude-review is the second-look on the full release delta and infra failures (binary not found, missing secret) need `gh run rerun <run-id> --failed` before merge, not "merge through it."
+⚠️ **Wait for every CI check to be green** per `.claude/rules/00-critical.md` "Never Merge PRs Without Completed CI". Release PRs are not exempt — claude-review is the second-look on the full release delta and infra failures (binary not found, missing secret) need `gh run rerun <run-id> --failed` before merge, not "merge through it."
 
 ⚠️ **When assessing release safety, do NOT cite "soaked in dev".** Dev has no organic traffic — a dev deploy proves boot, not behavior (see `/tzurot-deployment` § "What a dev deploy proves"). The honest safety basis is per-PR CI + reviews, the holistic release review, and blast-radius analysis of runtime-unverified paths.
 

--- a/.claude/skills/tzurot-testing/SKILL.md
+++ b/.claude/skills/tzurot-testing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-testing
 description: 'Testing procedures. Invoke with /tzurot-testing for test execution, coverage audits, and debugging test failures.'
-lastUpdated: '2026-06-26'
+lastUpdated: '2026-07-03'
 ---
 
 # Testing Procedures
@@ -180,6 +180,37 @@ Component tests (`*.component.test.ts`) run separately from unit tests and are *
 | Change component prefix routing  | Component tests verify button/select menu routing                           |
 
 **Update snapshots with:** `pnpm vitest run --config vitest.component.config.ts <file> --update`
+
+## Human-Verification Requests (manual testing by the user)
+
+The user is the ONLY manual-QA executor — usually on a phone, across session
+crashes and compactions. Every request for manual verification MUST be a
+complete, self-contained instruction with all five parts:
+
+1. **Exact repro path** — including the axis that keeps getting asked back:
+   regular message/reply vs **extended context**, which channel type, DM vs
+   guild, which command variant. If the axis matters, say which; if it doesn't,
+   say "either."
+2. **The invariant under test** — what property is being verified, so an
+   equivalent action counts ("any persona without an override," not "use
+   persona X"). The user shouldn't have to ask "does that not count?"
+3. **Masking state** — what cached/DB state could make the test falsely pass
+   (e.g., an already-described image pulls from the DB and never exercises the
+   new path). Name the reset step if one is needed.
+4. **Expected observable** — exactly what the user should see if it works, and
+   what failure looks like. Verify the expectation against the CODE
+   (`buildModelFooterText`, not a persona's in-character explanation) before
+   stating it.
+5. **How to report** — screenshot, paste, or a simple pass/fail.
+
+**Checklists are durable artifacts, not chat.** A release smoke-test checklist
+is written into `CURRENT.md` (with per-item status), so it survives compaction
+and the user can re-consult it from a phone. Track progress there as results
+come in ("from my quick tests how much of the checklist did that get us?" must
+be answerable from the file). Justify every case — a bloated matrix wastes the
+user's time; each case states what it uniquely proves. After the user reports,
+close the loop with runtime evidence (logs) when the user-visible outcome can't
+prove the new code path ran.
 
 ## Definition of Done
 

--- a/.claude/skills/tzurot-testing/SKILL.md
+++ b/.claude/skills/tzurot-testing/SKILL.md
@@ -92,6 +92,10 @@ is the unit tier ONLY. CI's `component-tests` job runs `test:component` +
 `test:integration`, so it catches what a unit-only local run silently skipped —
 don't let CI be the first thing that actually executes your contract test.
 
+Gotcha for mention/ID fixtures: tests need a **valid 17–19 digit Discord
+snowflake** — `isValidDiscordId` silently drops toy ids like `555` before
+resolution, making the assertion pass/fail for the wrong reason.
+
 ## Debugging Test Failures
 
 ### 1. Run Specific Test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ All rules load automatically from `.claude/rules/`:
 
 ```bash
 gh pr create --base develop --title "feat: description"
-gh pr merge <number> --rebase --delete-branch  # Feature PRs only, with user approval
+gh pr merge <number> --rebase --delete-branch  # Feature PRs only, when truly ready (00-critical § Merge Approval)
 gh pr merge <number> --rebase                  # Release PRs (develop → main) — NEVER delete develop
 ```
 
@@ -80,4 +80,10 @@ When compacting context, preserve:
 - List of all modified files in this session
 - Current task state and any blockers
 - Test commands that were run and their results
+- **Session settings the user changed** (reasoning effort level, permission mode) — post-compaction sessions have twice re-suggested settings that were already active
+- **Open promises and asks**: anything announced as "I'll do X later," any unanswered question posed to the user, any user question not yet answered
+- **The work-stack pointer**: the interrupted task and its resume point when a side-quest (prod bug, review round) preempted the main line
+- **Manual-test / smoke-checklist state**: which items the user has executed and their results (also written to CURRENT.md per `/tzurot-testing` — the file is the source of truth)
 - Re-read `.claude/rules/` files after compaction
+
+**Recovery mechanism**: exact pre-compaction context (verbatim quotes, tool output, decisions) is recoverable by grepping the session JSONL under `~/.claude/projects/<project-slug>/` (the slug derives from the checkout path — `ls ~/.claude/projects/` to find it) — use it before re-deriving or guessing at lost state.


### PR DESCRIPTION
## Context

Fable access ends 2026-07-07; before the handoff back to Opus, six weeks of session logs (~2,770 user messages mined from 700MB of transcripts), all 56 memory files, and the full docs tree were audited for friction that recurred without ever becoming structural. This PR is the rules/skills layer of the remediation (memory surgery and the docs purge follow separately).

## What's in here

**New constraints** (each traces to a mined recurrence, most with 3+ occurrences):
- **Negative-existence protocol** (00-critical): "we don't have X" requires ≥3 vocabulary variants + an `ops xray` declaration sweep + `knip:dead` check, or the claim downgrades to "I searched A/B/C and found nothing." The user's "I thought we had X" is a search order. (xray had 95 mentions while being built, then near-zero use — it's now named at its decision point.)
- **Completion-claim gate** (00-critical): "done" requires re-reading the scope artifact and enumerating remainders (the Stryker overclaim).
- **Design-semantics restatement** (00-critical): restate user-visible semantics before building approved schema/user-visible designs (the `kind`-param miscommunication).
- **Merge Approval reconciled** (00-critical): the standing feature/fix-PR merge authorization is now in the rule itself; release PRs remain explicit-approval-only.
- **Promise ledger** (06-backlog): "I'll do X later" files to the task list/backlog at utterance.
- **Board freshness** (06-backlog): verify Production Issues against reality before presenting them.
- **Interaction additions** (09): answer embedded questions first; directives are immutable; most-correct is the standing default; read dictation charitably.
- **Human-verification template** (tzurot-testing): 5 mandatory parts incl. the regular-vs-extended-context axis; smoke checklists live in CURRENT.md, not chat.
- **claude-review health + truncation ban + push-landed verification** (05-tooling / git-workflow).
- **Release security preflight** (git-workflow): dependabot + security tab before cutting.
- **Council hygiene** (council skill): premise verification, split tiebreaker, rule-conflicts evaluated on merits.
- **Railway log-level grep ban** (deployment skill): level greps false-clean on prod pino; grep by content. Cost impact now required in infra recommendations.

**Diet** (user mandate: rules carry constraints, not archaeology): multi-paragraph incident narratives trimmed to one-line "Observed:" markers across 00/05/08/09; new lifecycle rule in 07-documentation codifies it, plus the postmortem = outcome-not-narrative rule.

**Compaction hardening** (CLAUDE.md): preserve session settings, open promises/asks, the work-stack pointer, and checklist state; JSONL-grep named as the recovery mechanism.

## Verification

- `pnpm quality` green (includes `guard:claude-content-refs` over every edited rule/skill)
- Markdown-only diff; no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)