### PR TITLE
refactor(common-types): kill root barrel — PR 1 (tooling + leaf packages)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ railway_dev_logs.md
 
 # Stryker mutation-testing scratch
 .stryker-tmp/
+scripts/migrations/barrel-kill/symbol-map.json

--- a/packages/cache-invalidation/src/ApiKeyCacheInvalidationService.test.ts
+++ b/packages/cache-invalidation/src/ApiKeyCacheInvalidationService.test.ts
@@ -8,7 +8,7 @@ import {
   isValidApiKeyInvalidationEvent,
   type ApiKeyInvalidationEvent,
 } from './ApiKeyCacheInvalidationService.js';
-import { REDIS_CHANNELS } from '@tzurot/common-types';
+import { REDIS_CHANNELS } from '@tzurot/common-types/constants/queue';
 
 describe('ApiKeyCacheInvalidationService', () => {
   let mockRedis: ReturnType<typeof createMockRedis>;

--- a/packages/cache-invalidation/src/ApiKeyCacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/ApiKeyCacheInvalidationService.ts
@@ -14,7 +14,7 @@
  * - { type: 'all' } - Invalidate all API key caches (e.g., for key rotation)
  */
 
-import { REDIS_CHANNELS } from '@tzurot/common-types';
+import { REDIS_CHANNELS } from '@tzurot/common-types/constants/queue';
 import {
   BaseCacheInvalidationService,
   createStandardEventValidator,

--- a/packages/cache-invalidation/src/BaseCacheInvalidationService.test.ts
+++ b/packages/cache-invalidation/src/BaseCacheInvalidationService.test.ts
@@ -14,8 +14,8 @@ import {
 } from './BaseCacheInvalidationService.js';
 
 // Mock logger
-vi.mock('@tzurot/common-types', async importOriginal => {
-  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+vi.mock('@tzurot/common-types/utils/logger', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types/utils/logger')>();
   return {
     ...actual,
     createLogger: () => ({
@@ -26,7 +26,6 @@ vi.mock('@tzurot/common-types', async importOriginal => {
     }),
   };
 });
-
 describe('createStandardEventValidator', () => {
   const validator = createStandardEventValidator<StandardInvalidationEvent>();
 
@@ -493,9 +492,7 @@ describe('BaseCacheInvalidationService', () => {
   describe('custom event types', () => {
     // Test with a custom event type beyond standard user/all
     type CustomEvent =
-      | { type: 'user'; discordId: string }
-      | { type: 'guild'; guildId: string }
-      | { type: 'all' };
+      { type: 'user'; discordId: string } | { type: 'guild'; guildId: string } | { type: 'all' };
 
     const customValidator: EventValidator<CustomEvent> = (obj): obj is CustomEvent => {
       if (typeof obj !== 'object' || obj === null) return false;

--- a/packages/cache-invalidation/src/BaseCacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/BaseCacheInvalidationService.ts
@@ -21,7 +21,7 @@
  * ```
  */
 
-import { createLogger } from '@tzurot/common-types';
+import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { Logger } from 'pino';
 import type { Redis } from 'ioredis';
 

--- a/packages/cache-invalidation/src/CacheInvalidationService.test.ts
+++ b/packages/cache-invalidation/src/CacheInvalidationService.test.ts
@@ -8,7 +8,7 @@ import {
   CacheInvalidationService,
   type PersonalityCacheTarget,
 } from './CacheInvalidationService.js';
-import { REDIS_CHANNELS } from '@tzurot/common-types';
+import { REDIS_CHANNELS } from '@tzurot/common-types/constants/queue';
 import type { Redis } from 'ioredis';
 
 describe('CacheInvalidationService', () => {

--- a/packages/cache-invalidation/src/CacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/CacheInvalidationService.ts
@@ -13,7 +13,8 @@
  * - personality:invalidate:all - Invalidate all personality caches (global default changed)
  */
 
-import { createLogger, REDIS_CHANNELS } from '@tzurot/common-types';
+import { REDIS_CHANNELS } from '@tzurot/common-types/constants/queue';
+import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { Redis } from 'ioredis';
 
 const logger = createLogger('CacheInvalidationService');

--- a/packages/cache-invalidation/src/ChannelActivationCacheInvalidationService.test.ts
+++ b/packages/cache-invalidation/src/ChannelActivationCacheInvalidationService.test.ts
@@ -8,11 +8,11 @@ import {
   isValidChannelActivationInvalidationEvent,
   type ChannelActivationInvalidationEvent,
 } from './ChannelActivationCacheInvalidationService.js';
-import { REDIS_CHANNELS } from '@tzurot/common-types';
+import { REDIS_CHANNELS } from '@tzurot/common-types/constants/queue';
 
 // Mock logger
-vi.mock('@tzurot/common-types', async importOriginal => {
-  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+vi.mock('@tzurot/common-types/utils/logger', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types/utils/logger')>();
   return {
     ...actual,
     createLogger: () => ({
@@ -23,7 +23,6 @@ vi.mock('@tzurot/common-types', async importOriginal => {
     }),
   };
 });
-
 describe('ChannelActivationCacheInvalidationService', () => {
   let mockRedis: ReturnType<typeof createMockRedis>;
   let mockSubscriber: ReturnType<typeof createMockRedis>;

--- a/packages/cache-invalidation/src/ChannelActivationCacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/ChannelActivationCacheInvalidationService.ts
@@ -20,7 +20,7 @@
  * - { type: 'all' } - Invalidate all channel activation caches (for edge cases)
  */
 
-import { REDIS_CHANNELS } from '@tzurot/common-types';
+import { REDIS_CHANNELS } from '@tzurot/common-types/constants/queue';
 import {
   BaseCacheInvalidationService,
   createEventValidator,
@@ -31,8 +31,7 @@ import type { Redis } from 'ioredis';
  * Event types for channel activation cache invalidation
  */
 export type ChannelActivationInvalidationEvent =
-  | { type: 'channel'; channelId: string }
-  | { type: 'all' };
+  { type: 'channel'; channelId: string } | { type: 'all' };
 
 /**
  * Type guard to validate ChannelActivationInvalidationEvent structure

--- a/packages/cache-invalidation/src/ConfigCascadeCacheInvalidationService.test.ts
+++ b/packages/cache-invalidation/src/ConfigCascadeCacheInvalidationService.test.ts
@@ -7,11 +7,11 @@ import {
   ConfigCascadeCacheInvalidationService,
   isValidConfigCascadeInvalidationEvent,
 } from './ConfigCascadeCacheInvalidationService.js';
-import { REDIS_CHANNELS } from '@tzurot/common-types';
+import { REDIS_CHANNELS } from '@tzurot/common-types/constants/queue';
 
 // Mock logger
-vi.mock('@tzurot/common-types', async importOriginal => {
-  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+vi.mock('@tzurot/common-types/utils/logger', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types/utils/logger')>();
   return {
     ...actual,
     createLogger: () => ({
@@ -22,7 +22,6 @@ vi.mock('@tzurot/common-types', async importOriginal => {
     }),
   };
 });
-
 describe('ConfigCascadeCacheInvalidationService', () => {
   let mockRedis: {
     duplicate: ReturnType<typeof vi.fn>;

--- a/packages/cache-invalidation/src/ConfigCascadeCacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/ConfigCascadeCacheInvalidationService.ts
@@ -16,7 +16,7 @@
  * - { type: 'all' } - Full cache clear
  */
 
-import { REDIS_CHANNELS } from '@tzurot/common-types';
+import { REDIS_CHANNELS } from '@tzurot/common-types/constants/queue';
 import {
   BaseCacheInvalidationService,
   createEventValidator,

--- a/packages/cache-invalidation/src/DenylistCacheInvalidationService.test.ts
+++ b/packages/cache-invalidation/src/DenylistCacheInvalidationService.test.ts
@@ -8,11 +8,11 @@ import {
   isValidDenylistInvalidationEvent,
   type DenylistInvalidationEvent,
 } from './DenylistCacheInvalidationService.js';
-import { REDIS_CHANNELS } from '@tzurot/common-types';
+import { REDIS_CHANNELS } from '@tzurot/common-types/constants/queue';
 
 // Mock logger
-vi.mock('@tzurot/common-types', async importOriginal => {
-  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+vi.mock('@tzurot/common-types/utils/logger', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types/utils/logger')>();
   return {
     ...actual,
     createLogger: () => ({
@@ -23,7 +23,6 @@ vi.mock('@tzurot/common-types', async importOriginal => {
     }),
   };
 });
-
 describe('DenylistCacheInvalidationService', () => {
   let mockRedis: ReturnType<typeof createMockRedis>;
   let mockSubscriber: ReturnType<typeof createMockRedis>;

--- a/packages/cache-invalidation/src/DenylistCacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/DenylistCacheInvalidationService.ts
@@ -15,7 +15,7 @@
  * - { type: 'all' } - Full cache reload (for migrations or bulk changes)
  */
 
-import { REDIS_CHANNELS } from '@tzurot/common-types';
+import { REDIS_CHANNELS } from '@tzurot/common-types/constants/queue';
 import { BaseCacheInvalidationService } from './BaseCacheInvalidationService.js';
 import type { Redis } from 'ioredis';
 

--- a/packages/cache-invalidation/src/LlmConfigCacheInvalidationService.test.ts
+++ b/packages/cache-invalidation/src/LlmConfigCacheInvalidationService.test.ts
@@ -7,11 +7,11 @@ import {
   LlmConfigCacheInvalidationService,
   isValidLlmConfigInvalidationEvent,
 } from './LlmConfigCacheInvalidationService.js';
-import { REDIS_CHANNELS } from '@tzurot/common-types';
+import { REDIS_CHANNELS } from '@tzurot/common-types/constants/queue';
 
 // Mock logger
-vi.mock('@tzurot/common-types', async importOriginal => {
-  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+vi.mock('@tzurot/common-types/utils/logger', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types/utils/logger')>();
   return {
     ...actual,
     createLogger: () => ({
@@ -22,7 +22,6 @@ vi.mock('@tzurot/common-types', async importOriginal => {
     }),
   };
 });
-
 describe('LlmConfigCacheInvalidationService', () => {
   let mockRedis: {
     duplicate: ReturnType<typeof vi.fn>;

--- a/packages/cache-invalidation/src/LlmConfigCacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/LlmConfigCacheInvalidationService.ts
@@ -15,7 +15,7 @@
  * - { type: 'all' } - Invalidate all LLM config caches (e.g., for global config changes)
  */
 
-import { REDIS_CHANNELS } from '@tzurot/common-types';
+import { REDIS_CHANNELS } from '@tzurot/common-types/constants/queue';
 import {
   BaseCacheInvalidationService,
   createEventValidator,
@@ -27,9 +27,7 @@ import type { Redis } from 'ioredis';
  * Extends standard events with config-specific invalidation
  */
 type LlmConfigInvalidationEvent =
-  | { type: 'user'; discordId: string }
-  | { type: 'config'; configId: string }
-  | { type: 'all' };
+  { type: 'user'; discordId: string } | { type: 'config'; configId: string } | { type: 'all' };
 
 /**
  * Type guard to validate LlmConfigInvalidationEvent structure

--- a/packages/cache-invalidation/src/PersonaCacheInvalidationService.test.ts
+++ b/packages/cache-invalidation/src/PersonaCacheInvalidationService.test.ts
@@ -8,11 +8,11 @@ import {
   isValidPersonaInvalidationEvent,
   type PersonaInvalidationEvent,
 } from './PersonaCacheInvalidationService.js';
-import { REDIS_CHANNELS } from '@tzurot/common-types';
+import { REDIS_CHANNELS } from '@tzurot/common-types/constants/queue';
 
 // Mock logger
-vi.mock('@tzurot/common-types', async importOriginal => {
-  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+vi.mock('@tzurot/common-types/utils/logger', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types/utils/logger')>();
   return {
     ...actual,
     createLogger: () => ({
@@ -23,7 +23,6 @@ vi.mock('@tzurot/common-types', async importOriginal => {
     }),
   };
 });
-
 describe('PersonaCacheInvalidationService', () => {
   let mockRedis: ReturnType<typeof createMockRedis>;
   let mockSubscriber: ReturnType<typeof createMockRedis>;

--- a/packages/cache-invalidation/src/PersonaCacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/PersonaCacheInvalidationService.ts
@@ -14,7 +14,7 @@
  * - { type: 'all' } - Invalidate all persona caches (e.g., for migrations)
  */
 
-import { REDIS_CHANNELS } from '@tzurot/common-types';
+import { REDIS_CHANNELS } from '@tzurot/common-types/constants/queue';
 import {
   BaseCacheInvalidationService,
   createStandardEventValidator,

--- a/packages/cache-invalidation/src/SttResolverCacheInvalidationService.test.ts
+++ b/packages/cache-invalidation/src/SttResolverCacheInvalidationService.test.ts
@@ -11,11 +11,10 @@ import {
   SttResolverCacheInvalidationService,
   isValidSttResolverInvalidationEvent,
 } from './SttResolverCacheInvalidationService.js';
-import { REDIS_CHANNELS } from '@tzurot/common-types';
+import { REDIS_CHANNELS } from '@tzurot/common-types/constants/queue';
 import type { Redis } from 'ioredis';
-
-vi.mock('@tzurot/common-types', async importOriginal => {
-  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+vi.mock('@tzurot/common-types/utils/logger', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types/utils/logger')>();
   return {
     ...actual,
     createLogger: () => ({
@@ -26,7 +25,6 @@ vi.mock('@tzurot/common-types', async importOriginal => {
     }),
   };
 });
-
 describe('isValidSttResolverInvalidationEvent', () => {
   it('accepts user event', () => {
     expect(isValidSttResolverInvalidationEvent({ type: 'user', discordId: '123' })).toBe(true);

--- a/packages/cache-invalidation/src/SttResolverCacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/SttResolverCacheInvalidationService.ts
@@ -17,7 +17,7 @@
  * a config row — there's no per-config invalidation surface to model.
  */
 
-import { REDIS_CHANNELS } from '@tzurot/common-types';
+import { REDIS_CHANNELS } from '@tzurot/common-types/constants/queue';
 import {
   BaseCacheInvalidationService,
   createEventValidator,

--- a/packages/cache-invalidation/src/TtsConfigCacheInvalidationService.test.ts
+++ b/packages/cache-invalidation/src/TtsConfigCacheInvalidationService.test.ts
@@ -12,11 +12,10 @@ import {
   TtsConfigCacheInvalidationService,
   isValidTtsConfigInvalidationEvent,
 } from './TtsConfigCacheInvalidationService.js';
-import { REDIS_CHANNELS } from '@tzurot/common-types';
+import { REDIS_CHANNELS } from '@tzurot/common-types/constants/queue';
 import type { Redis } from 'ioredis';
-
-vi.mock('@tzurot/common-types', async importOriginal => {
-  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+vi.mock('@tzurot/common-types/utils/logger', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types/utils/logger')>();
   return {
     ...actual,
     createLogger: () => ({
@@ -27,7 +26,6 @@ vi.mock('@tzurot/common-types', async importOriginal => {
     }),
   };
 });
-
 describe('isValidTtsConfigInvalidationEvent', () => {
   it('accepts user event', () => {
     expect(isValidTtsConfigInvalidationEvent({ type: 'user', discordId: '123' })).toBe(true);

--- a/packages/cache-invalidation/src/TtsConfigCacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/TtsConfigCacheInvalidationService.ts
@@ -7,7 +7,7 @@
  *
  * Architecture:
  *   - Publisher: api-gateway (when global TtsConfigs are edited or user
- *     overrides change via the /settings tts UX, PR 3 of TTS Phase 1)
+ *     overrides change via the /settings tts UX)
  *   - Subscribers: ai-worker instances (to invalidate TtsConfigResolver cache)
  *
  * Events:
@@ -16,7 +16,7 @@
  *   - { type: 'all' } — invalidate everything (global config changes)
  */
 
-import { REDIS_CHANNELS } from '@tzurot/common-types';
+import { REDIS_CHANNELS } from '@tzurot/common-types/constants/queue';
 import {
   BaseCacheInvalidationService,
   createEventValidator,
@@ -25,9 +25,7 @@ import type { Redis } from 'ioredis';
 
 /** Event variants for TTS config cache invalidation. */
 type TtsConfigInvalidationEvent =
-  | { type: 'user'; discordId: string }
-  | { type: 'config'; configId: string }
-  | { type: 'all' };
+  { type: 'user'; discordId: string } | { type: 'config'; configId: string } | { type: 'all' };
 
 /** Type guard for incoming pub/sub events. */
 export const isValidTtsConfigInvalidationEvent = createEventValidator<TtsConfigInvalidationEvent>([

--- a/packages/clients/src/clients/_generated/user-client.ts
+++ b/packages/clients/src/clients/_generated/user-client.ts
@@ -17,7 +17,7 @@ import { z } from 'zod';
 import { callGateway, type GatewayResult } from '../transport.js';
 import { ROUTE_MANIFEST } from '../../routes/manifest.js';
 import { type ActorDiscordId, type SubjectDiscordId } from '../../routes/types.js';
-import type { GatewayUser } from '@tzurot/common-types';
+import type { GatewayUser } from '@tzurot/common-types/types/gateway-context';
 
 function buildQueryString(entries: Array<[string, string | undefined]>): string {
   const defined = entries.filter((e): e is [string, string] => e[1] !== undefined);

--- a/packages/clients/src/clients/errors.test.ts
+++ b/packages/clients/src/clients/errors.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { GatewayApiError, parseErrorResponse } from './errors.js';
-import { API_ERROR_SUBCODE } from '@tzurot/common-types';
+import { API_ERROR_SUBCODE } from '@tzurot/common-types/constants/error';
 
 describe('GatewayApiError', () => {
   it('preserves status + kind + code on construction', () => {

--- a/packages/clients/src/clients/errors.ts
+++ b/packages/clients/src/clients/errors.ts
@@ -9,8 +9,7 @@
  */
 
 import { z } from 'zod';
-
-import type { ApiErrorSubcode } from '@tzurot/common-types';
+import type { ApiErrorSubcode } from '@tzurot/common-types/constants/error';
 
 /**
  * Transport failure category. Defined here (the dependency target) rather than

--- a/packages/clients/src/clients/generated-encoding.test.ts
+++ b/packages/clients/src/clients/generated-encoding.test.ts
@@ -21,7 +21,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { asActor, asSubject, type ActorDiscordId } from '../routes/types.js';
-import type { GatewayUser } from '@tzurot/common-types';
+import type { GatewayUser } from '@tzurot/common-types/types/gateway-context';
 import { OwnerClient } from './_generated/owner-client.js';
 import { ServiceClient } from './_generated/service-client.js';
 import { UserClient } from './_generated/user-client.js';

--- a/packages/clients/src/clients/transport.test.ts
+++ b/packages/clients/src/clients/transport.test.ts
@@ -7,7 +7,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
-import { GATEWAY_TIMEOUTS } from '@tzurot/common-types';
+import { GATEWAY_TIMEOUTS } from '@tzurot/common-types/constants/discord';
 import { callGateway, callGatewayOrThrow } from './transport.js';
 import { GatewayApiError } from './errors.js';
 

--- a/packages/clients/src/clients/transport.ts
+++ b/packages/clients/src/clients/transport.ts
@@ -34,13 +34,10 @@
  */
 
 import type { z } from 'zod';
-
-import {
-  type ApiErrorSubcode,
-  CONTENT_TYPES,
-  GATEWAY_TIMEOUTS,
-  isTimeoutError,
-} from '@tzurot/common-types';
+import { GATEWAY_TIMEOUTS } from '@tzurot/common-types/constants/discord';
+import { type ApiErrorSubcode } from '@tzurot/common-types/constants/error';
+import { CONTENT_TYPES } from '@tzurot/common-types/constants/media';
+import { isTimeoutError } from '@tzurot/common-types/utils/errors';
 import { GatewayApiError, type GatewayFailureKind, parseErrorResponse } from './errors.js';
 
 /**

--- a/packages/clients/src/routes/admin.ts
+++ b/packages/clients/src/routes/admin.ts
@@ -24,44 +24,50 @@
  */
 
 import { z } from 'zod';
+import { CONFIG_KINDS } from '@tzurot/common-types/constants/ai';
+import { GATEWAY_TIMEOUTS } from '@tzurot/common-types/constants/discord';
+import { DbSyncSchema, InvalidateCacheSchema } from '@tzurot/common-types/schemas/api/admin';
 import {
-  CONFIG_KINDS,
-  AddDenylistResponseSchema,
   AdminCleanupResponseSchema,
-  AdminPersonalityResponseSchema,
-  AdminSettingsSchema,
-  AdminUsageStatsSchema,
-  ConfigOverridesSchema,
-  CreateLlmConfigResponseSchema,
-  CreateTtsConfigResponseSchema,
   DbSyncResponseSchema,
-  DbSyncSchema,
-  DeleteLlmConfigResponseSchema,
-  DeleteTtsConfigResponseSchema,
+  InvalidateCacheResponseSchema,
+} from '@tzurot/common-types/schemas/api/admin-operations';
+import { AdminSettingsSchema } from '@tzurot/common-types/schemas/api/adminSettings';
+import { ConfigOverridesSchema } from '@tzurot/common-types/schemas/api/configOverrides';
+import {
+  AddDenylistResponseSchema,
   DenylistAddSchema,
   denylistEntityTypeSchema,
   denylistScopeSchema,
-  GATEWAY_TIMEOUTS,
-  GetLlmConfigResponseSchema,
-  GetTtsConfigResponseSchema,
-  InvalidateCacheResponseSchema,
-  InvalidateCacheSchema,
   ListDenylistResponseSchema,
+  RemoveDenylistResponseSchema,
+} from '@tzurot/common-types/schemas/api/denylist';
+import {
+  CreateLlmConfigResponseSchema,
+  DeleteLlmConfigResponseSchema,
+  GetLlmConfigResponseSchema,
   ListLlmConfigsResponseSchema,
-  ListTtsConfigsResponseSchema,
   LlmConfigCreateSchema,
   LlmConfigUpdateSchema,
+  SetDefaultLlmConfigResponseSchema,
+  UpdateLlmConfigResponseSchema,
+} from '@tzurot/common-types/schemas/api/llm-config';
+import {
+  AdminPersonalityResponseSchema,
   PersonalityCreateSchema,
   PersonalityUpdateSchema,
-  RemoveDenylistResponseSchema,
-  SetDefaultLlmConfigResponseSchema,
+} from '@tzurot/common-types/schemas/api/personality';
+import {
+  CreateTtsConfigResponseSchema,
+  DeleteTtsConfigResponseSchema,
+  GetTtsConfigResponseSchema,
+  ListTtsConfigsResponseSchema,
   SetDefaultTtsConfigResponseSchema,
   TtsConfigCreateSchema,
   TtsConfigUpdateSchema,
-  UpdateLlmConfigResponseSchema,
   UpdateTtsConfigResponseSchema,
-} from '@tzurot/common-types';
-
+} from '@tzurot/common-types/schemas/api/tts-config';
+import { AdminUsageStatsSchema } from '@tzurot/common-types/schemas/api/usage';
 import type { RouteDef } from './types.js';
 
 // Shared path constants — extracted because GET/PUT/DELETE on the same

--- a/packages/clients/src/routes/internal.ts
+++ b/packages/clients/src/routes/internal.ts
@@ -14,24 +14,25 @@
  */
 
 import { z } from 'zod';
+import { TIMEOUTS } from '@tzurot/common-types/constants/timing';
+import { DiagnosticUpdateSchema } from '@tzurot/common-types/schemas/api/admin';
+import { AdminSettingsSchema } from '@tzurot/common-types/schemas/api/adminSettings';
 import {
-  AdminSettingsSchema,
   AiConfirmDeliveryResponseSchema,
   AiGenerateResponseSchema,
   AiJobStatusResponseSchema,
   AiTranscribeResponseSchema,
+} from '@tzurot/common-types/schemas/api/ai';
+import { GetChannelSettingsResponseSchema } from '@tzurot/common-types/schemas/api/channel';
+import { DenylistCacheResponseSchema } from '@tzurot/common-types/schemas/api/denylist';
+import { DiagnosticUpdateResponseSchema } from '@tzurot/common-types/schemas/api/diagnostic';
+import {
   ConversationSyncRequestSchema,
   ConversationSyncResponseSchema,
-  DenylistCacheResponseSchema,
-  DiagnosticUpdateResponseSchema,
-  DiagnosticUpdateSchema,
   DmSessionSetRequestSchema,
   DmSessionSetResponseSchema,
-  generateRequestSchema,
-  GetChannelSettingsResponseSchema,
   LoadPersonalityInternalResponseSchema,
   MessagePersonalityResponseSchema,
-  ModelsListResponseSchema,
   PersistAssistantMessageRequestSchema,
   PersistAssistantMessageResponseSchema,
   PersistUserMessageRequestSchema,
@@ -39,9 +40,11 @@ import {
   RecentUsersResponseSchema,
   RoutingContextRequestSchema,
   RoutingContextResponseSchema,
-  TIMEOUTS,
-  TranscribeRequestSchema,
-} from '@tzurot/common-types';
+} from '@tzurot/common-types/schemas/api/internal';
+import { ModelsListResponseSchema } from '@tzurot/common-types/schemas/api/models';
+import { TranscribeRequestSchema } from '@tzurot/common-types/schemas/api/transcribe';
+import { generateRequestSchema } from '@tzurot/common-types/types/schemas/generation';
+
 // generateRequestSchema lives under the `types/schemas/` module rather than
 // the `schemas/api/` barrel (it predates the API-schema reorganization). The
 // route-manifest treats them uniformly via the import below.

--- a/packages/clients/src/routes/manifest.test.ts
+++ b/packages/clients/src/routes/manifest.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { GATEWAY_TIMEOUTS } from '@tzurot/common-types';
+import { GATEWAY_TIMEOUTS } from '@tzurot/common-types/constants/discord';
 import { ROUTE_MANIFEST, adminRoutes, internalRoutes, userRoutes } from './manifest.js';
 import type { AnyRouteDef } from './types.js';
 

--- a/packages/clients/src/routes/user/config-overrides.ts
+++ b/packages/clients/src/routes/user/config-overrides.ts
@@ -20,18 +20,17 @@
  */
 
 import { z } from 'zod';
+import { GATEWAY_TIMEOUTS } from '@tzurot/common-types/constants/discord';
 import {
   ClearPersonalityConfigOverridesResponseSchema,
   ClearUserConfigDefaultsResponseSchema,
   ConfigOverridesSchema,
-  GATEWAY_TIMEOUTS,
   GetUserConfigDefaultsResponseSchema,
   ResolvedConfigOverridesSchema,
   ResolveUserConfigDefaultsResponseSchema,
   UpdateConfigDefaultsResponseSchema,
   UpdatePersonalityConfigOverridesResponseSchema,
-} from '@tzurot/common-types';
-
+} from '@tzurot/common-types/schemas/api/configOverrides';
 import type { RouteDef } from '../types.js';
 
 const BASE = '/config-overrides';

--- a/packages/clients/src/routes/user/configs.ts
+++ b/packages/clients/src/routes/user/configs.ts
@@ -11,48 +11,57 @@
  */
 
 import { z } from 'zod';
+import { CONFIG_KINDS } from '@tzurot/common-types/constants/ai';
+import { GATEWAY_TIMEOUTS } from '@tzurot/common-types/constants/discord';
 import {
-  CONFIG_KINDS,
-  ClearDefaultConfigResponseSchema,
-  ClearSttDefaultProviderResponseSchema,
-  ClearTtsDefaultConfigResponseSchema,
   CreateLlmConfigResponseSchema,
-  CreateTtsConfigResponseSchema,
   DeleteLlmConfigResponseSchema,
-  DeleteModelOverrideResponseSchema,
-  DeleteTtsConfigResponseSchema,
-  DeleteTtsOverrideResponseSchema,
-  GATEWAY_TIMEOUTS,
   GetLlmConfigResponseSchema,
-  GetTimezoneResponseSchema,
-  GetTtsConfigResponseSchema,
-  GetTtsDefaultConfigResponseSchema,
   ListLlmConfigsResponseSchema,
-  ListModelOverridesResponseSchema,
-  ListTtsConfigsResponseSchema,
-  ListTtsOverridesResponseSchema,
   LlmConfigCreateSchema,
   LlmConfigUpdateSchema,
   ResolveLlmConfigInputSchema,
   ResolveLlmConfigResponseSchema,
+  UpdateLlmConfigResponseSchema,
+} from '@tzurot/common-types/schemas/api/llm-config';
+import {
+  ClearDefaultConfigResponseSchema,
+  DeleteModelOverrideResponseSchema,
+  ListModelOverridesResponseSchema,
   SetDefaultConfigResponseSchema,
   SetDefaultConfigSchema,
   SetModelOverrideResponseSchema,
   SetModelOverrideSchema,
+} from '@tzurot/common-types/schemas/api/model-override';
+import {
+  ClearSttDefaultProviderResponseSchema,
   SetSttDefaultProviderResponseSchema,
   SetSttDefaultProviderSchema,
+} from '@tzurot/common-types/schemas/api/stt-override';
+import {
+  GetTimezoneResponseSchema,
   SetTimezoneInputSchema,
   SetTimezoneResponseSchema,
+} from '@tzurot/common-types/schemas/api/timezone';
+import {
+  CreateTtsConfigResponseSchema,
+  DeleteTtsConfigResponseSchema,
+  GetTtsConfigResponseSchema,
+  ListTtsConfigsResponseSchema,
+  TtsConfigCreateSchema,
+  TtsConfigUpdateSchema,
+  UpdateTtsConfigResponseSchema,
+} from '@tzurot/common-types/schemas/api/tts-config';
+import {
+  ClearTtsDefaultConfigResponseSchema,
+  DeleteTtsOverrideResponseSchema,
+  GetTtsDefaultConfigResponseSchema,
+  ListTtsOverridesResponseSchema,
   SetTtsDefaultConfigResponseSchema,
   SetTtsDefaultConfigSchema,
   SetTtsOverrideResponseSchema,
   SetTtsOverrideSchema,
-  TtsConfigCreateSchema,
-  TtsConfigUpdateSchema,
-  UpdateLlmConfigResponseSchema,
-  UpdateTtsConfigResponseSchema,
-} from '@tzurot/common-types';
-
+} from '@tzurot/common-types/schemas/api/tts-override';
 import type { RouteDef } from '../types.js';
 
 // Shared CRUD-detail path constants — GET/PUT/DELETE on the same :id share

--- a/packages/clients/src/routes/user/diagnostics.ts
+++ b/packages/clients/src/routes/user/diagnostics.ts
@@ -11,12 +11,12 @@
  */
 
 import { z } from 'zod';
+import { GATEWAY_TIMEOUTS } from '@tzurot/common-types/constants/discord';
 import {
   DiagnosticLogResponseSchema,
   DiagnosticLogsResponseSchema,
-  GATEWAY_TIMEOUTS,
   RecentDiagnosticLogsResponseSchema,
-} from '@tzurot/common-types';
+} from '@tzurot/common-types/schemas/api/diagnostic';
 import type { RouteDef } from '../types.js';
 
 export const userDiagnosticRoutes = {

--- a/packages/clients/src/routes/user/memory.ts
+++ b/packages/clients/src/routes/user/memory.ts
@@ -12,15 +12,8 @@ import {
   BatchDeleteResponseSchema,
   BatchDeleteSchema,
   DeleteMemoryResponseSchema,
-  DisableIncognitoRequestSchema,
-  DisableIncognitoResponseSchema,
-  EnableIncognitoRequestSchema,
-  EnableIncognitoResponseSchema,
   FocusModeSchema,
   FocusModeStatusResponseSchema,
-  GetIncognitoStatusResponseSchema,
-  IncognitoForgetRequestSchema,
-  IncognitoForgetResponseSchema,
   IssuePurgeTokenResponseSchema,
   IssuePurgeTokenSchema,
   MemoryListResponseSchema,
@@ -33,8 +26,18 @@ import {
   SetFocusResponseSchema,
   SetMemoryLockSchema,
   SingleMemoryResponseSchema,
-} from '@tzurot/common-types';
-
+} from '@tzurot/common-types/schemas/api/memory';
+import {
+  DisableIncognitoResponseSchema,
+  EnableIncognitoResponseSchema,
+  GetIncognitoStatusResponseSchema,
+  IncognitoForgetResponseSchema,
+} from '@tzurot/common-types/schemas/api/memoryIncognito';
+import {
+  DisableIncognitoRequestSchema,
+  EnableIncognitoRequestSchema,
+  IncognitoForgetRequestSchema,
+} from '@tzurot/common-types/types/incognito';
 import type { RouteDef } from '../types.js';
 
 const MEMORY_INCOGNITO_PATH = '/memory/incognito';

--- a/packages/clients/src/routes/user/ownership.ts
+++ b/packages/clients/src/routes/user/ownership.ts
@@ -9,31 +9,32 @@
  */
 
 import { z } from 'zod';
+import { GATEWAY_TIMEOUTS } from '@tzurot/common-types/constants/discord';
 import {
   ClearOverrideResponseSchema,
   CreateOverrideResponseSchema,
-  CreatePersonalityResponseSchema,
   CreatePersonaResponseSchema,
-  DeletePersonalityResponseSchema,
   DeletePersonaResponseSchema,
-  GATEWAY_TIMEOUTS,
-  GetPersonalityResponseSchema,
   GetPersonaResponseSchema,
-  ListPersonalitiesResponseSchema,
   ListPersonaOverridesResponseSchema,
   ListPersonasResponseSchema,
   OverrideInfoResponseSchema,
   PersonaCreateSchema,
-  PersonalityCreateSchema,
-  PersonalityUpdateSchema,
   PersonaUpdateSchema,
   SetDefaultPersonaResponseSchema,
   SetOverrideResponseSchema,
   SetPersonaOverrideSchema,
-  SetVisibilitySchema,
   UpdatePersonaResponseSchema,
-} from '@tzurot/common-types';
-
+} from '@tzurot/common-types/schemas/api/persona';
+import {
+  CreatePersonalityResponseSchema,
+  DeletePersonalityResponseSchema,
+  GetPersonalityResponseSchema,
+  ListPersonalitiesResponseSchema,
+  PersonalityCreateSchema,
+  PersonalityUpdateSchema,
+  SetVisibilitySchema,
+} from '@tzurot/common-types/schemas/api/personality';
 import type { RouteDef } from '../types.js';
 
 const PERSONALITY_DETAIL_PATH = '/personality/:slug';

--- a/packages/clients/src/routes/user/resources.ts
+++ b/packages/clients/src/routes/user/resources.ts
@@ -10,45 +10,54 @@
  */
 
 import { z } from 'zod';
+import { GATEWAY_TIMEOUTS } from '@tzurot/common-types/constants/discord';
+import { VALIDATION_TIMEOUTS } from '@tzurot/common-types/constants/timing';
 import {
   ActivateChannelRequestSchema,
   ActivateChannelResponseSchema,
-  ClearChannelConfigOverridesResponseSchema,
-  ClearHistoryResponseSchema,
-  ClearHistorySchema,
-  ClearVoicesResponseSchema,
   DeactivateChannelRequestSchema,
   DeactivateChannelResponseSchema,
-  DeleteVoiceResponseSchema,
-  GATEWAY_TIMEOUTS,
-  GetChannelConfigOverridesResponseSchema,
   GetChannelSettingsResponseSchema,
-  GetNsfwStatusResponseSchema,
-  GetVoiceResolutionResponseSchema,
+  ListChannelSettingsResponseSchema,
+  UpdateChannelGuildRequestSchema,
+  UpdateChannelGuildResponseSchema,
+} from '@tzurot/common-types/schemas/api/channel';
+import {
+  ClearChannelConfigOverridesResponseSchema,
+  GetChannelConfigOverridesResponseSchema,
+  UpdateChannelConfigOverridesRequestSchema,
+  UpdateChannelConfigOverridesResponseSchema,
+} from '@tzurot/common-types/schemas/api/configOverrides';
+import {
+  ClearHistoryResponseSchema,
+  ClearHistorySchema,
   HardDeleteHistoryResponseSchema,
   HardDeleteHistorySchema,
   HistoryStatsQuerySchema,
   HistoryStatsResponseSchema,
-  ListChannelSettingsResponseSchema,
+  UndoHistoryResponseSchema,
+  UndoHistorySchema,
+} from '@tzurot/common-types/schemas/api/history';
+import {
+  GetNsfwStatusResponseSchema,
+  VerifyNsfwResponseSchema,
+} from '@tzurot/common-types/schemas/api/nsfw';
+import { UsageStatsSchema } from '@tzurot/common-types/schemas/api/usage';
+import { GetVoiceResolutionResponseSchema } from '@tzurot/common-types/schemas/api/voice-resolution';
+import {
+  ClearVoicesResponseSchema,
+  DeleteVoiceResponseSchema,
   ListVoiceModelsResponseSchema,
   ListVoicesResponseSchema,
+} from '@tzurot/common-types/schemas/api/voices';
+import {
   ListWalletKeysResponseSchema,
   RemoveWalletKeyResponseSchema,
   SetWalletKeyResponseSchema,
   SetWalletKeySchema,
   TestWalletKeyResponseSchema,
   TestWalletKeySchema,
-  UndoHistoryResponseSchema,
-  UndoHistorySchema,
-  UpdateChannelConfigOverridesRequestSchema,
-  UpdateChannelConfigOverridesResponseSchema,
-  UpdateChannelGuildRequestSchema,
-  UpdateChannelGuildResponseSchema,
-  UsageStatsSchema,
-  VALIDATION_TIMEOUTS,
-  VerifyNsfwResponseSchema,
-} from '@tzurot/common-types';
-
+} from '@tzurot/common-types/schemas/api/wallet';
 import type { RouteDef } from '../types.js';
 
 const CHANNEL_CONFIG_OVERRIDES_PATH = '/channel/:channelId/config-overrides';

--- a/packages/clients/src/routes/user/shapes.ts
+++ b/packages/clients/src/routes/user/shapes.ts
@@ -10,9 +10,10 @@
  */
 
 import { z } from 'zod';
+import { GATEWAY_TIMEOUTS } from '@tzurot/common-types/constants/discord';
+import { VALIDATION_TIMEOUTS } from '@tzurot/common-types/constants/timing';
 import {
   DeleteShapesAuthResponseSchema,
-  GATEWAY_TIMEOUTS,
   ListShapesExportJobsResponseSchema,
   ListShapesImportJobsResponseSchema,
   ListShapesResponseSchema,
@@ -23,9 +24,7 @@ import {
   StartShapesImportResponseSchema,
   StoreShapesAuthInputSchema,
   StoreShapesAuthResponseSchema,
-  VALIDATION_TIMEOUTS,
-} from '@tzurot/common-types';
-
+} from '@tzurot/common-types/schemas/api/shapes';
 import type { RouteDef } from '../types.js';
 
 const BASE = '/shapes';

--- a/packages/clients/tsconfig.json
+++ b/packages/clients/tsconfig.json
@@ -3,9 +3,14 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-    "composite": true
+    "composite": true,
+    "types": ["node"]
   },
-  "references": [{ "path": "../common-types" }],
+  "references": [
+    {
+      "path": "../common-types"
+    }
+  ],
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
 }

--- a/packages/common-types/package.json
+++ b/packages/common-types/package.json
@@ -6,6 +6,52 @@
   "description": "Shared types and validation schemas for Tzurot",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./config/*": {
+      "types": "./dist/config/*.d.ts",
+      "default": "./dist/config/*.js"
+    },
+    "./constants/*": {
+      "types": "./dist/constants/*.d.ts",
+      "default": "./dist/constants/*.js"
+    },
+    "./schemas/*": {
+      "types": "./dist/schemas/*.d.ts",
+      "default": "./dist/schemas/*.js"
+    },
+    "./schemas/api/*": {
+      "types": "./dist/schemas/api/*.d.ts",
+      "default": "./dist/schemas/api/*.js"
+    },
+    "./services/*": {
+      "types": "./dist/services/*.d.ts",
+      "default": "./dist/services/*.js"
+    },
+    "./services/tts/*": {
+      "types": "./dist/services/tts/*.d.ts",
+      "default": "./dist/services/tts/*.js"
+    },
+    "./types/*": {
+      "types": "./dist/types/*.d.ts",
+      "default": "./dist/types/*.js"
+    },
+    "./types/schemas/*": {
+      "types": "./dist/types/schemas/*.d.ts",
+      "default": "./dist/types/schemas/*.js"
+    },
+    "./utils/*": {
+      "types": "./dist/utils/*.d.ts",
+      "default": "./dist/utils/*.js"
+    },
+    "./generated/commandOptions": {
+      "types": "./dist/generated/commandOptions.d.ts",
+      "default": "./dist/generated/commandOptions.js"
+    }
+  },
   "scripts": {
     "clean": "find src -name '*.js' -type f -delete && find src -name '*.js.map' -type f -delete",
     "build": "rm -rf dist tsconfig.tsbuildinfo && tsc",

--- a/packages/config-resolver/src/BaseConfigResolver.test.ts
+++ b/packages/config-resolver/src/BaseConfigResolver.test.ts
@@ -14,9 +14,8 @@ import {
   type ConfigOverrideEntry,
   type UserWithDefault,
 } from './BaseConfigResolver.js';
-
-vi.mock('@tzurot/common-types', async importOriginal => {
-  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+vi.mock('@tzurot/common-types/utils/logger', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types/utils/logger')>();
   return {
     ...actual,
     createLogger: () => ({
@@ -27,7 +26,6 @@ vi.mock('@tzurot/common-types', async importOriginal => {
     }),
   };
 });
-
 // ===== Minimal test fixtures =================================================
 
 /** Tiny "personality" shape: just a name field carrying the default config. */

--- a/packages/config-resolver/src/BaseConfigResolver.ts
+++ b/packages/config-resolver/src/BaseConfigResolver.ts
@@ -27,13 +27,13 @@
  * see `ConfigCascadeResolver` — different shape, different responsibility.
  */
 
+import { INTERVALS } from '@tzurot/common-types/constants/timing';
 import {
-  createLogger,
-  TTLCache,
-  INTERVALS,
   type ConfigResolutionSource,
   type BaseConfigResolutionResult,
-} from '@tzurot/common-types';
+} from '@tzurot/common-types/types/configResolution';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import { TTLCache } from '@tzurot/common-types/utils/TTLCache';
 import type { Logger } from 'pino';
 
 /** Override row metadata returned by tier-specific Prisma queries. */

--- a/packages/config-resolver/src/ConfigCascadeResolver.test.ts
+++ b/packages/config-resolver/src/ConfigCascadeResolver.test.ts
@@ -4,7 +4,8 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ConfigCascadeResolver } from './ConfigCascadeResolver.js';
-import { HARDCODED_CONFIG_DEFAULTS, ADMIN_SETTINGS_SINGLETON_ID } from '@tzurot/common-types';
+import { ADMIN_SETTINGS_SINGLETON_ID } from '@tzurot/common-types/schemas/api/adminSettings';
+import { HARDCODED_CONFIG_DEFAULTS } from '@tzurot/common-types/schemas/api/configOverrides';
 
 // Shared logger instance so tests can assert on (absence of) warnings — the
 // resolver's module-level logger is created once at import time, so the mock
@@ -15,9 +16,8 @@ const mockLogger = vi.hoisted(() => ({
   warn: vi.fn(),
   error: vi.fn(),
 }));
-
-vi.mock('@tzurot/common-types', async importOriginal => {
-  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+vi.mock('@tzurot/common-types/utils/logger', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types/utils/logger')>();
   return {
     ...actual,
     createLogger: () => mockLogger,

--- a/packages/config-resolver/src/ConfigCascadeResolver.ts
+++ b/packages/config-resolver/src/ConfigCascadeResolver.ts
@@ -18,18 +18,18 @@
  * cleanup interval, same constructor options).
  */
 
+import { INTERVALS } from '@tzurot/common-types/constants/timing';
+import { ADMIN_SETTINGS_SINGLETON_ID } from '@tzurot/common-types/schemas/api/adminSettings';
 import {
-  createLogger,
-  TTLCache,
-  INTERVALS,
   ConfigOverridesSchema,
   HARDCODED_CONFIG_DEFAULTS,
-  ADMIN_SETTINGS_SINGLETON_ID,
   type ConfigOverrides,
   type ConfigOverrideSource,
   type ResolvedConfigOverrides,
-  type PrismaClient,
-} from '@tzurot/common-types';
+} from '@tzurot/common-types/schemas/api/configOverrides';
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import { TTLCache } from '@tzurot/common-types/utils/TTLCache';
 
 const logger = createLogger('ConfigCascadeResolver');
 

--- a/packages/config-resolver/src/LlmConfigResolver.test.ts
+++ b/packages/config-resolver/src/LlmConfigResolver.test.ts
@@ -9,7 +9,8 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { LlmConfigResolver } from './LlmConfigResolver.js';
-import type { LoadedPersonality, PrismaClient } from '@tzurot/common-types';
+import type { PrismaClient } from '@tzurot/common-types/services/prisma';
+import type { LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
 
 // Shared logger instance so tests can assert on (absence of) error logs — the
 // resolver's logger is created once in the constructor, so the mock must hand
@@ -20,15 +21,13 @@ const mockLogger = vi.hoisted(() => ({
   warn: vi.fn(),
   error: vi.fn(),
 }));
-
-vi.mock('@tzurot/common-types', async importOriginal => {
-  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+vi.mock('@tzurot/common-types/utils/logger', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types/utils/logger')>();
   return {
     ...actual,
     createLogger: () => mockLogger,
   };
 });
-
 describe('LlmConfigResolver', () => {
   let resolver: LlmConfigResolver;
   let mockPrisma: {

--- a/packages/config-resolver/src/LlmConfigResolver.ts
+++ b/packages/config-resolver/src/LlmConfigResolver.ts
@@ -16,16 +16,16 @@
  * and the LLM-specific `getFreeDefaultConfig` lookup.
  */
 
+import { ADMIN_SETTINGS_SINGLETON_ID } from '@tzurot/common-types/schemas/api/adminSettings';
+import { LLM_CONFIG_OVERRIDE_KEYS } from '@tzurot/common-types/schemas/llmAdvancedParams';
 import {
-  ADMIN_SETTINGS_SINGLETON_ID,
-  LLM_CONFIG_OVERRIDE_KEYS,
   LLM_CONFIG_SELECT_WITH_NAME,
   mapLlmConfigFromDbWithName,
-  type LoadedPersonality,
   type MappedLlmConfigWithName,
-  type PrismaClient,
-  type ResolvedLlmConfig,
-} from '@tzurot/common-types';
+} from '@tzurot/common-types/services/LlmConfigMapper';
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
+import { type ResolvedLlmConfig } from '@tzurot/common-types/types/configResolution';
+import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
 import {
   BaseConfigResolver,
   type BaseConfigResolverOptions,

--- a/packages/config-resolver/src/SttResolver.test.ts
+++ b/packages/config-resolver/src/SttResolver.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SttResolver } from './SttResolver.js';
-import type { PrismaClient } from '@tzurot/common-types';
+import type { PrismaClient } from '@tzurot/common-types/services/prisma';
 
 // Shared logger instance so tests can assert on (absence of) warnings — the
 // resolver's logger is created once in the constructor.
@@ -10,15 +10,13 @@ const mockLogger = vi.hoisted(() => ({
   warn: vi.fn(),
   error: vi.fn(),
 }));
-
-vi.mock('@tzurot/common-types', async importOriginal => {
-  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+vi.mock('@tzurot/common-types/utils/logger', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types/utils/logger')>();
   return {
     ...actual,
     createLogger: () => mockLogger,
   };
 });
-
 // Minimal Prisma double — the resolver only consumes `prisma.user.findFirst`,
 // so a typed double is sufficient and avoids dragging the live Prisma client
 // into every test.

--- a/packages/config-resolver/src/SttResolver.ts
+++ b/packages/config-resolver/src/SttResolver.ts
@@ -18,16 +18,16 @@
  * choice)" in dashboards.
  */
 
+import { INTERVALS } from '@tzurot/common-types/constants/timing';
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import {
-  createLogger,
-  TTLCache,
-  INTERVALS,
   isSttProvider,
   isByokAudioProvider,
   type SttProvider,
   type SttResolutionSource,
-  type PrismaClient,
-} from '@tzurot/common-types';
+} from '@tzurot/common-types/types/sttProvider';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import { TTLCache } from '@tzurot/common-types/utils/TTLCache';
 import type { Logger } from 'pino';
 
 export interface SttResolutionResult {

--- a/packages/config-resolver/src/TtsConfigResolver.test.ts
+++ b/packages/config-resolver/src/TtsConfigResolver.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TtsConfigResolver } from './TtsConfigResolver.js';
-import type { PrismaClient } from '@tzurot/common-types';
+import type { PrismaClient } from '@tzurot/common-types/services/prisma';
 
 // Hoisted logger spies so tests can assert severity (the WARN→ERROR upgrade
 // for personality-default lookup failures is a behavioral contract worth pinning).
@@ -8,9 +8,8 @@ const { mockLoggerError, mockLoggerWarn } = vi.hoisted(() => ({
   mockLoggerError: vi.fn(),
   mockLoggerWarn: vi.fn(),
 }));
-
-vi.mock('@tzurot/common-types', async importOriginal => {
-  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+vi.mock('@tzurot/common-types/utils/logger', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types/utils/logger')>();
   return {
     ...actual,
     createLogger: () => ({

--- a/packages/config-resolver/src/TtsConfigResolver.ts
+++ b/packages/config-resolver/src/TtsConfigResolver.ts
@@ -23,15 +23,15 @@ import {
   type ConfigOverrideEntry,
   type UserWithDefault,
 } from './BaseConfigResolver.js';
+import { ADMIN_SETTINGS_SINGLETON_ID } from '@tzurot/common-types/schemas/api/adminSettings';
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
+import { type ResolvedTtsConfig } from '@tzurot/common-types/services/tts/TtsProvider';
 import {
-  ADMIN_SETTINGS_SINGLETON_ID,
   TTS_CONFIG_SELECT_WITH_NAME,
   mapTtsConfigFromDbWithName,
   type MappedTtsConfigWithName,
-  type PrismaClient,
-  type ResolvedTtsConfig,
-  type LoadedTtsPersonality,
-} from '@tzurot/common-types';
+} from '@tzurot/common-types/services/TtsConfigMapper';
+import { type LoadedTtsPersonality } from '@tzurot/common-types/types/configResolution';
 
 /** Sentinel cache key for the free-default lookup (no userId/personalityId axis). */
 const FREE_DEFAULT_CACHE_KEY = '__free_default__';

--- a/packages/config-resolver/src/VisionConfigResolver.test.ts
+++ b/packages/config-resolver/src/VisionConfigResolver.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { VisionConfigResolver } from './VisionConfigResolver.js';
-import { MODEL_DEFAULTS, type PrismaClient } from '@tzurot/common-types';
+import { MODEL_DEFAULTS } from '@tzurot/common-types/constants/ai';
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 
 // Hoisted logger spies so tests can assert the WARN→ERROR upgrade for a failed
 // personality-default lookup (a behavioral contract, mirroring TtsConfigResolver).
@@ -8,9 +9,8 @@ const { mockLoggerError, mockLoggerWarn } = vi.hoisted(() => ({
   mockLoggerError: vi.fn(),
   mockLoggerWarn: vi.fn(),
 }));
-
-vi.mock('@tzurot/common-types', async importOriginal => {
-  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+vi.mock('@tzurot/common-types/utils/logger', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types/utils/logger')>();
   return {
     ...actual,
     createLogger: () => ({

--- a/packages/config-resolver/src/VisionConfigResolver.ts
+++ b/packages/config-resolver/src/VisionConfigResolver.ts
@@ -32,18 +32,20 @@ import {
   type ConfigOverrideEntry,
   type UserWithDefault,
 } from './BaseConfigResolver.js';
+import { MODEL_DEFAULTS } from '@tzurot/common-types/constants/ai';
+import { INTERVALS } from '@tzurot/common-types/constants/timing';
+import { ADMIN_SETTINGS_SINGLETON_ID } from '@tzurot/common-types/schemas/api/adminSettings';
 import {
-  ADMIN_SETTINGS_SINGLETON_ID,
   LLM_CONFIG_SELECT_WITH_NAME,
   mapLlmConfigFromDbWithName,
-  MODEL_DEFAULTS,
-  TTLCache,
-  INTERVALS,
   type MappedLlmConfigWithName,
-  type PrismaClient,
+} from '@tzurot/common-types/services/LlmConfigMapper';
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
+import {
   type ResolvedVisionConfig,
   type LoadedVisionPersonality,
-} from '@tzurot/common-types';
+} from '@tzurot/common-types/types/configResolution';
+import { TTLCache } from '@tzurot/common-types/utils/TTLCache';
 
 /**
  * Hardcoded fallback when no DB vision config is available at any tier. The bootstrap

--- a/packages/conversation-history/src/ConversationHistoryService.component.test.ts
+++ b/packages/conversation-history/src/ConversationHistoryService.component.test.ts
@@ -15,7 +15,8 @@ import type { PGlite } from '@electric-sql/pglite';
 import { PrismaPGlite } from 'pglite-prisma-adapter';
 import { createTestPGlite, loadPGliteSchema, seedUserWithPersona } from '@tzurot/test-utils';
 import { ConversationHistoryService } from './ConversationHistoryService.js';
-import { PrismaClient, MessageRole } from '@tzurot/common-types';
+import { MessageRole } from '@tzurot/common-types/constants/message';
+import { PrismaClient } from '@tzurot/common-types/services/prisma';
 
 describe('ConversationHistoryService Component Test', () => {
   let prisma: PrismaClient;

--- a/packages/conversation-history/src/ConversationHistoryService.test.ts
+++ b/packages/conversation-history/src/ConversationHistoryService.test.ts
@@ -4,17 +4,20 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ConversationHistoryService } from './ConversationHistoryService.js';
-import { MessageRole, type PrismaClient } from '@tzurot/common-types';
+import { MessageRole } from '@tzurot/common-types/constants/message';
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 
 // countTextTokens now lives in @tzurot/common-types (consumed by the production
 // service via the barrel), so intercept it through a partial mock rather than a
 // namespace spy — the latter doesn't reliably catch a re-exported binding.
 const { mockCountTextTokens } = vi.hoisted(() => ({ mockCountTextTokens: vi.fn() }));
-vi.mock('@tzurot/common-types', async importOriginal => {
-  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
-  return { ...actual, countTextTokens: mockCountTextTokens };
+vi.mock('@tzurot/common-types/utils/tokenCounter', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types/utils/tokenCounter')>();
+  return {
+    ...actual,
+    countTextTokens: mockCountTextTokens,
+  };
 });
-
 // Create mock Prisma client
 const createMockPrismaClient = () => {
   const client = {

--- a/packages/conversation-history/src/ConversationHistoryService.ts
+++ b/packages/conversation-history/src/ConversationHistoryService.ts
@@ -8,17 +8,17 @@
  * - ConversationMessageMapper: Data transformation
  */
 
+import { MessageRole } from '@tzurot/common-types/constants/message';
+import { computeHistoryCutoff } from '@tzurot/common-types/services/historyCutoff';
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import {
-  createLogger,
-  MessageRole,
-  countTextTokens,
-  generateConversationHistoryUuid,
-  computeHistoryCutoff,
-  type PrismaClient,
-  type MessageMetadata,
   type ConversationMessage,
   type CrossChannelHistoryGroup,
-} from '@tzurot/common-types';
+} from '@tzurot/common-types/types/conversationMessage';
+import { type MessageMetadata } from '@tzurot/common-types/types/schemas/message';
+import { generateConversationHistoryUuid } from '@tzurot/common-types/utils/deterministicUuid';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import { countTextTokens } from '@tzurot/common-types/utils/tokenCounter';
 import {
   conversationHistorySelect,
   conversationRecencyOrderBy,

--- a/packages/conversation-history/src/ConversationMessageMapper.test.ts
+++ b/packages/conversation-history/src/ConversationMessageMapper.test.ts
@@ -6,11 +6,11 @@ import {
   conversationHistorySelect,
   type ConversationHistoryQueryResult,
 } from './ConversationMessageMapper.js';
-import { MessageRole } from '@tzurot/common-types';
+import { MessageRole } from '@tzurot/common-types/constants/message';
 
 // Suppress logger warnings in tests (createLogger now comes from the barrel)
-vi.mock('@tzurot/common-types', async importOriginal => {
-  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+vi.mock('@tzurot/common-types/utils/logger', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types/utils/logger')>();
   return {
     ...actual,
     createLogger: () => ({
@@ -21,7 +21,6 @@ vi.mock('@tzurot/common-types', async importOriginal => {
     }),
   };
 });
-
 describe('ConversationMessageMapper', () => {
   describe('conversationHistorySelect', () => {
     it('includes all required fields', () => {

--- a/packages/conversation-history/src/ConversationMessageMapper.ts
+++ b/packages/conversation-history/src/ConversationMessageMapper.ts
@@ -6,14 +6,14 @@
  * of select objects and mapping logic used in 3+ query methods.
  */
 
+import { MessageRole } from '@tzurot/common-types/constants/message';
+import { Prisma } from '@tzurot/common-types/services/prisma';
+import { type ConversationMessage } from '@tzurot/common-types/types/conversationMessage';
 import {
-  Prisma,
-  createLogger,
-  MessageRole,
   messageMetadataSchema,
   type MessageMetadata,
-  type ConversationMessage,
-} from '@tzurot/common-types';
+} from '@tzurot/common-types/types/schemas/message';
+import { createLogger } from '@tzurot/common-types/utils/logger';
 
 const logger = createLogger('ConversationMessageMapper');
 

--- a/packages/conversation-history/src/ConversationRetentionService.component.test.ts
+++ b/packages/conversation-history/src/ConversationRetentionService.component.test.ts
@@ -14,7 +14,8 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
-import { PrismaClient, SYNC_LIMITS } from '@tzurot/common-types';
+import { SYNC_LIMITS } from '@tzurot/common-types/constants/timing';
+import { PrismaClient } from '@tzurot/common-types/services/prisma';
 import type { PGlite } from '@electric-sql/pglite';
 import { PrismaPGlite } from 'pglite-prisma-adapter';
 import { ConversationRetentionService } from './ConversationRetentionService.js';
@@ -22,8 +23,8 @@ import { createTestPGlite, loadPGliteSchema, seedUserWithPersona } from '@tzurot
 
 // Suppress logger noise — the service's createLogger comes from common-types
 // (the old '../utils/logger.js' mock was a no-op: nothing imports that path).
-vi.mock('@tzurot/common-types', async importOriginal => {
-  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+vi.mock('@tzurot/common-types/utils/logger', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types/utils/logger')>();
   return {
     ...actual,
     createLogger: () => ({
@@ -34,7 +35,6 @@ vi.mock('@tzurot/common-types', async importOriginal => {
     }),
   };
 });
-
 describe('ConversationRetentionService', () => {
   let prisma: PrismaClient;
   let pglite: PGlite;

--- a/packages/conversation-history/src/ConversationRetentionService.test.ts
+++ b/packages/conversation-history/src/ConversationRetentionService.test.ts
@@ -7,8 +7,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ConversationRetentionService } from './ConversationRetentionService.js';
 
 // Suppress logger output in tests (the service's createLogger comes from common-types)
-vi.mock('@tzurot/common-types', async importOriginal => {
-  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
+vi.mock('@tzurot/common-types/utils/logger', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types/utils/logger')>();
   return {
     ...actual,
     createLogger: () => ({
@@ -19,7 +19,6 @@ vi.mock('@tzurot/common-types', async importOriginal => {
     }),
   };
 });
-
 // Helper to create a mock Prisma client with transaction support
 function createMockPrismaClient() {
   const mockClient = {

--- a/packages/conversation-history/src/ConversationRetentionService.ts
+++ b/packages/conversation-history/src/ConversationRetentionService.ts
@@ -9,13 +9,9 @@
  * Uses tombstones to prevent db-sync from restoring deleted messages.
  */
 
-import {
-  type PrismaClient,
-  Prisma,
-  createLogger,
-  CLEANUP_DEFAULTS,
-  SYNC_LIMITS,
-} from '@tzurot/common-types';
+import { CLEANUP_DEFAULTS, SYNC_LIMITS } from '@tzurot/common-types/constants/timing';
+import { type PrismaClient, Prisma } from '@tzurot/common-types/services/prisma';
+import { createLogger } from '@tzurot/common-types/utils/logger';
 
 const logger = createLogger('ConversationRetentionService');
 

--- a/packages/conversation-history/src/ConversationSyncService.component.test.ts
+++ b/packages/conversation-history/src/ConversationSyncService.component.test.ts
@@ -15,7 +15,8 @@ import { PrismaPGlite } from 'pglite-prisma-adapter';
 import { createTestPGlite, loadPGliteSchema, seedUserWithPersona } from '@tzurot/test-utils';
 import { ConversationSyncService } from './ConversationSyncService.js';
 import { ConversationHistoryService } from './ConversationHistoryService.js';
-import { PrismaClient, MessageRole } from '@tzurot/common-types';
+import { MessageRole } from '@tzurot/common-types/constants/message';
+import { PrismaClient } from '@tzurot/common-types/services/prisma';
 
 describe('ConversationSyncService Integration Test', () => {
   let prisma: PrismaClient;

--- a/packages/conversation-history/src/ConversationSyncService.test.ts
+++ b/packages/conversation-history/src/ConversationSyncService.test.ts
@@ -4,17 +4,19 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ConversationSyncService } from './ConversationSyncService.js';
-import { type PrismaClient } from '@tzurot/common-types';
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 
 // countTextTokens now lives in @tzurot/common-types (consumed by the production
 // service via the barrel), so intercept it through a partial mock rather than a
 // namespace spy — the latter doesn't reliably catch a re-exported binding.
 const { mockCountTextTokens } = vi.hoisted(() => ({ mockCountTextTokens: vi.fn() }));
-vi.mock('@tzurot/common-types', async importOriginal => {
-  const actual = await importOriginal<typeof import('@tzurot/common-types')>();
-  return { ...actual, countTextTokens: mockCountTextTokens };
+vi.mock('@tzurot/common-types/utils/tokenCounter', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types/utils/tokenCounter')>();
+  return {
+    ...actual,
+    countTextTokens: mockCountTextTokens,
+  };
 });
-
 // Create mock Prisma client
 const createMockPrismaClient = () => {
   const client = {

--- a/packages/conversation-history/src/ConversationSyncService.ts
+++ b/packages/conversation-history/src/ConversationSyncService.ts
@@ -9,16 +9,16 @@
  * Uses tombstones to prevent db-sync from restoring deleted messages.
  */
 
+import { SYNC_LIMITS } from '@tzurot/common-types/constants/timing';
 import {
-  createLogger,
-  countTextTokens,
-  SYNC_LIMITS,
   collateChunksForSync,
   contentsDiffer,
   getOldestObservedTimestamp,
-  type PrismaClient,
   type ObservedSyncMessage,
-} from '@tzurot/common-types';
+} from '@tzurot/common-types/services/conversationSyncDiff';
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import { countTextTokens } from '@tzurot/common-types/utils/tokenCounter';
 
 const logger = createLogger('ConversationSyncService');
 

--- a/packages/conversation-history/src/referenceImageDescriptions.test.ts
+++ b/packages/conversation-history/src/referenceImageDescriptions.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { collectRefImageDescriptions } from './referenceImageDescriptions.js';
-import type { StoredReferencedMessage } from '@tzurot/common-types';
+import type { StoredReferencedMessage } from '@tzurot/common-types/types/schemas/message';
 
 function makeRef(attachments?: StoredReferencedMessage['attachments']): StoredReferencedMessage {
   return {

--- a/packages/conversation-history/src/referenceImageDescriptions.ts
+++ b/packages/conversation-history/src/referenceImageDescriptions.ts
@@ -16,14 +16,14 @@
  * max-lines ceiling; the service exposes a thin delegating method.
  */
 
+import { MessageRole } from '@tzurot/common-types/constants/message';
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import {
-  createLogger,
-  MessageRole,
-  type PrismaClient,
   type MessageMetadata,
   type ResolvedImageDescription,
   type StoredReferencedMessage,
-} from '@tzurot/common-types';
+} from '@tzurot/common-types/types/schemas/message';
+import { createLogger } from '@tzurot/common-types/utils/logger';
 
 const logger = createLogger('ReferenceImageDescriptions');
 

--- a/packages/embeddings/src/LocalEmbeddingService.ts
+++ b/packages/embeddings/src/LocalEmbeddingService.ts
@@ -21,8 +21,7 @@ import { Worker } from 'node:worker_threads';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { createHash } from 'node:crypto';
-import { createLogger } from '@tzurot/common-types';
-
+import { createLogger } from '@tzurot/common-types/utils/logger';
 import type {
   IEmbeddingService,
   WorkerMessage,

--- a/packages/embeddings/src/embeddingWorker.test.ts
+++ b/packages/embeddings/src/embeddingWorker.test.ts
@@ -32,10 +32,9 @@ vi.mock('node:worker_threads', () => ({
 }));
 
 // Mock common-types to provide MODEL_DEFAULTS.EMBEDDING
-vi.mock('@tzurot/common-types', () => ({
+vi.mock('@tzurot/common-types/constants/ai', () => ({
   MODEL_DEFAULTS: { EMBEDDING: 'Xenova/bge-small-en-v1.5' },
 }));
-
 // Mock the HuggingFace pipeline
 const mockPipeline = vi.fn();
 vi.mock('@huggingface/transformers', () => ({

--- a/packages/embeddings/src/embeddingWorker.ts
+++ b/packages/embeddings/src/embeddingWorker.ts
@@ -12,8 +12,7 @@
 
 import { parentPort } from 'node:worker_threads';
 import { pipeline, env, type FeatureExtractionPipeline } from '@huggingface/transformers';
-
-import { MODEL_DEFAULTS } from '@tzurot/common-types';
+import { MODEL_DEFAULTS } from '@tzurot/common-types/constants/ai';
 import { LOCAL_EMBEDDING_DIMENSIONS } from './constants.js';
 import type { WorkerMessage, WorkerResponse } from './types.js';
 

--- a/packages/identity/src/RoutingContextResolver.test.ts
+++ b/packages/identity/src/RoutingContextResolver.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { resolveRoutingContext, type RoutingContextDeps } from './RoutingContextResolver.js';
-import type { PrismaClient, RoutingContextRequest } from '@tzurot/common-types';
+import type { RoutingContextRequest } from '@tzurot/common-types/schemas/api/internal';
+import type { PrismaClient } from '@tzurot/common-types/services/prisma';
 import type { UserService } from './UserService.js';
 import type { PersonaResolver } from './resolvers/PersonaResolver.js';
 

--- a/packages/identity/src/RoutingContextResolver.ts
+++ b/packages/identity/src/RoutingContextResolver.ts
@@ -16,11 +16,11 @@
  */
 
 import {
-  type PrismaClient,
-  createLogger,
   type RoutingContextRequest,
   type RoutingContextResponse,
-} from '@tzurot/common-types';
+} from '@tzurot/common-types/schemas/api/internal';
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
+import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { UserService } from './UserService.js';
 import type { PersonaResolver } from './resolvers/PersonaResolver.js';
 

--- a/packages/identity/src/UserService.component.test.ts
+++ b/packages/identity/src/UserService.component.test.ts
@@ -13,18 +13,23 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
-import { PrismaClient, generatePersonaUuid, isBotOwner } from '@tzurot/common-types';
+import { PrismaClient } from '@tzurot/common-types/services/prisma';
+import { generatePersonaUuid } from '@tzurot/common-types/utils/deterministicUuid';
+import { isBotOwner } from '@tzurot/common-types/utils/ownerMiddleware';
 import type { PGlite } from '@electric-sql/pglite';
 import { PrismaPGlite } from 'pglite-prisma-adapter';
 import { UserService } from './UserService.js';
 import { createTestPGlite, loadPGliteSchema } from '@tzurot/test-utils';
 
 // Mock isBotOwner - will be configured per test
-vi.mock('@tzurot/common-types', async importOriginal => ({
-  ...(await importOriginal<typeof import('@tzurot/common-types')>()),
-  isBotOwner: vi.fn().mockReturnValue(false),
-}));
-
+vi.mock('@tzurot/common-types/utils/ownerMiddleware', async importOriginal => {
+  const actual =
+    await importOriginal<typeof import('@tzurot/common-types/utils/ownerMiddleware')>();
+  return {
+    ...actual,
+    isBotOwner: vi.fn().mockReturnValue(false),
+  };
+});
 describe('UserService', () => {
   let prisma: PrismaClient;
   let pglite: PGlite;

--- a/packages/identity/src/UserService.test.ts
+++ b/packages/identity/src/UserService.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { UserService, buildShellPlaceholderPersonaName } from './UserService.js';
-import { resetConfig } from '@tzurot/common-types';
+import { resetConfig } from '@tzurot/common-types/config/config';
 
 // Use vi.hoisted() to create mocks that persist across test resets
 const { mockGenerateUserUuid, mockGeneratePersonaUuid } = vi.hoisted(() => ({
@@ -10,16 +10,25 @@ const { mockGenerateUserUuid, mockGeneratePersonaUuid } = vi.hoisted(() => ({
 
 // Mock dependencies — UserService now imports Prisma + the deterministic-UUID
 // helpers from the @tzurot/common-types barrel, so override them there.
-vi.mock('@tzurot/common-types', async importOriginal => ({
-  ...(await importOriginal<typeof import('@tzurot/common-types')>()),
-  Prisma: {
-    TransactionClient: class {},
-  },
-  DNS_NAMESPACE: '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
-  generateUserUuid: mockGenerateUserUuid,
-  generatePersonaUuid: mockGeneratePersonaUuid,
-}));
-
+vi.mock('@tzurot/common-types/services/prisma', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types/services/prisma')>();
+  return {
+    ...actual,
+    Prisma: {
+      TransactionClient: class {},
+    },
+  };
+});
+vi.mock('@tzurot/common-types/utils/deterministicUuid', async importOriginal => {
+  const actual =
+    await importOriginal<typeof import('@tzurot/common-types/utils/deterministicUuid')>();
+  return {
+    ...actual,
+    DNS_NAMESPACE: '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+    generateUserUuid: mockGenerateUserUuid,
+    generatePersonaUuid: mockGeneratePersonaUuid,
+  };
+});
 describe('UserService', () => {
   let userService: UserService;
   let mockPrisma: {

--- a/packages/identity/src/UserService.ts
+++ b/packages/identity/src/UserService.ts
@@ -4,7 +4,7 @@
  *
  * Key behaviors:
  * - Creates users with default personas atomically via a single-statement
- *   CTE (circular-FK bootstrap; see Phase 5b notes inline)
+ *   CTE (circular-FK bootstrap; see notes inline)
  * - Handles race conditions when multiple requests arrive for same user
  *   (P2002 recovery filtered to users.discord_id)
  * - Upgrades placeholder usernames (shell-created = discordId) to real
@@ -12,17 +12,16 @@
  *   placeholder persona in the same maintenance pass
  */
 
+import { UNKNOWN_USER_DISCORD_ID } from '@tzurot/common-types/constants/message';
+import { DEFAULT_PERSONA_DESCRIPTION } from '@tzurot/common-types/constants/persona';
+import { type PrismaClient, Prisma } from '@tzurot/common-types/services/prisma';
 import {
-  type PrismaClient,
-  Prisma,
-  createLogger,
-  TTLCache,
   generateUserUuid,
   generatePersonaUuid,
-  isBotOwner,
-  UNKNOWN_USER_DISCORD_ID,
-  DEFAULT_PERSONA_DESCRIPTION,
-} from '@tzurot/common-types';
+} from '@tzurot/common-types/utils/deterministicUuid';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import { isBotOwner } from '@tzurot/common-types/utils/ownerMiddleware';
+import { TTLCache } from '@tzurot/common-types/utils/TTLCache';
 
 /**
  * User record with fields needed for post-read maintenance checks (superuser
@@ -48,9 +47,8 @@ interface UserWithMaintenanceFields {
  * row AND its default Persona exist. Callers that only need `userId` should
  * destructure `{ userId }` rather than special-casing any field.
  *
- * This shape is the Phase 2 contract in the Identity & Provisioning Hardening
- * epic: by bundling `defaultPersonaId` non-null into the return type, we move
- * the "does this user have a persona?" invariant out of read-time repair
+ * By bundling `defaultPersonaId` non-null into the return type, this shape
+ * moves the "does this user have a persona?" invariant out of read-time repair
  * (runMaintenanceTasks) and into the type system.
  */
 export interface ProvisionedUser {
@@ -61,11 +59,11 @@ export interface ProvisionedUser {
 const logger = createLogger('UserService');
 
 /**
- * Build the placeholder persona name used during shell-user creation (Identity
- * Epic Phase 5b). Prefix `"User "` is intentional — the bare Discord snowflake
- * ID would violate the `personas_name_not_snowflake` CHECK constraint added
- * in Phase 5. This placeholder is replaced with the user's real Discord
- * username by `runMaintenanceTasks` on their first bot-client interaction.
+ * Build the placeholder persona name used during shell-user creation. Prefix
+ * `"User "` is intentional — the bare Discord snowflake ID would violate the
+ * `personas_name_not_snowflake` CHECK constraint. This placeholder is replaced
+ * with the user's real Discord username by `runMaintenanceTasks` on their first
+ * bot-client interaction.
  *
  * Exported so tests and any direct callers share the same formula without
  * duplicating the "User " prefix literal.
@@ -179,8 +177,8 @@ export class UserService {
     try {
       return await this.createUserWithDefaultPersona(discordId, username, displayName, bio);
     } catch (error) {
-      // Phase 5b: the full path's CTE now writes User + Persona in a single
-      // statement. Filter on `discord_id` explicitly so a P2002 from the
+      // The full path's CTE writes User + Persona in a single statement.
+      // Filter on `discord_id` explicitly so a P2002 from the
       // persona `(owner_id, name)` unique constraint cannot be mis-classified
       // as a "user already exists" race. In practice the persona UUID+name
       // pair is deterministic per ownerId so this shouldn't fire, but the
@@ -209,10 +207,11 @@ export class UserService {
    * (e.g., shell creation now writes User + Persona, each with its own
    * uniqueness) pass a target to match only the expected constraint.
    *
-   * Identity Epic Phase 5b added the target parameter as defense-in-depth for
-   * the new shell-creation transaction. Element-equality (not substring)
-   * matching means a future caller passing a short target like `'id'` can't
-   * silently false-positive against a longer column name like `'discord_id'`.
+   * The target parameter is defense-in-depth for the shell-creation transaction
+   * (User + Persona written in one tx, each with its own uniqueness).
+   * Element-equality (not substring) matching means a future caller passing a
+   * short target like `'id'` can't silently false-positive against a longer
+   * column name like `'discord_id'`.
    */
   private isPrismaUniqueConstraintError(error: unknown, target?: string): boolean {
     if (
@@ -275,7 +274,7 @@ export class UserService {
    * interaction. These are "read-repair" operations that fix pre-hardening
    * data on access.
    *
-   * Returns the effective `defaultPersonaId` — always non-null post-Phase-5b.
+   * Returns the effective `defaultPersonaId` — always non-null (DB-enforced).
    */
   private async runMaintenanceTasks(
     user: UserWithMaintenanceFields,
@@ -286,8 +285,8 @@ export class UserService {
     // Check if existing user should be promoted to superuser
     await this.promoteToSuperuserIfNeeded(user, discordId);
 
-    // Phase 5b: defaultPersonaId is structurally NOT NULL, so there is no
-    // backfill branch anymore. The legacy repair-on-read path that created
+    // defaultPersonaId is structurally NOT NULL, so there is no backfill
+    // branch anymore. The legacy repair-on-read path that created
     // personas for users missing a default persona has been removed along
     // with the null column.
     const defaultPersonaId = user.defaultPersonaId;
@@ -297,8 +296,8 @@ export class UserService {
     // This intentionally does NOT sync changed Discord usernames — we preserve
     // the username from first interaction to maintain historical consistency.
     //
-    // Identity Epic Phase 5b: also rename the placeholder persona from
-    // `"User {discordId}"` to the real username. The rename uses `updateMany`
+    // Also rename the placeholder persona from `"User {discordId}"` to the real
+    // username. The rename uses `updateMany`
     // with an idempotent WHERE predicate so concurrent maintenance calls for
     // the same user don't race — the second call matches zero rows and
     // no-ops. The unique `(ownerId, name)` constraint cannot fire here
@@ -384,8 +383,8 @@ export class UserService {
     const personaDisplayName = displayName ?? username;
     const personaContent = bio ?? '';
 
-    // Phase 5b: circular-FK bootstrap via single-statement CTE. See the
-    // matching comment in createShellUserWithRaceProtection for the reasoning.
+    // Circular-FK bootstrap via single-statement CTE. See the matching
+    // comment in createShellUserWithRaceProtection for the reasoning.
     await this.prisma.$executeRaw`
       WITH new_persona AS (
         INSERT INTO personas (id, name, preferred_name, description, content, owner_id, updated_at)

--- a/packages/identity/src/identityProvisioning.component.test.ts
+++ b/packages/identity/src/identityProvisioning.component.test.ts
@@ -27,7 +27,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import type { PGlite } from '@electric-sql/pglite';
 import { PrismaPGlite } from 'pglite-prisma-adapter';
 import { createTestPGlite, loadPGliteSchema } from '@tzurot/test-utils';
-import { PrismaClient } from '@tzurot/common-types';
+import { PrismaClient } from '@tzurot/common-types/services/prisma';
 import { UserService } from './UserService.js';
 import { PersonaResolver } from './resolvers/PersonaResolver.js';
 

--- a/packages/identity/src/personality/PersonalityDefaults.test.ts
+++ b/packages/identity/src/personality/PersonalityDefaults.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { replacePlaceholders, deriveAvatarUrl, mapToPersonality } from './PersonalityDefaults.js';
 import type { DatabasePersonality } from './PersonalityValidator.js';
-import type { MappedLlmConfig } from '@tzurot/common-types';
+import type { MappedLlmConfig } from '@tzurot/common-types/services/LlmConfigMapper';
 
 /**
  * Factory function to create a complete DatabasePersonality mock with sensible defaults.

--- a/packages/identity/src/personality/PersonalityDefaults.ts
+++ b/packages/identity/src/personality/PersonalityDefaults.ts
@@ -3,15 +3,13 @@
  * Default value merging and placeholder replacement logic for personalities
  */
 
+import { MODEL_DEFAULTS, AI_DEFAULTS } from '@tzurot/common-types/constants/ai';
+import { MESSAGE_LIMITS, PLACEHOLDERS } from '@tzurot/common-types/constants/message';
 import {
-  type LoadedPersonality,
-  MODEL_DEFAULTS,
-  AI_DEFAULTS,
-  MESSAGE_LIMITS,
-  PLACEHOLDERS,
   mapLlmConfigFromDb,
   type MappedLlmConfig,
-} from '@tzurot/common-types';
+} from '@tzurot/common-types/services/LlmConfigMapper';
+import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
 import type { DatabasePersonality } from './PersonalityValidator.js';
 
 /**

--- a/packages/identity/src/personality/PersonalityLoader.test.ts
+++ b/packages/identity/src/personality/PersonalityLoader.test.ts
@@ -14,15 +14,24 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { PersonalityLoader } from './PersonalityLoader.js';
-import type { PrismaClient } from '@tzurot/common-types';
-import * as commonTypes from '@tzurot/common-types';
-
-vi.mock('@tzurot/common-types', async importOriginal => ({
-  ...(await importOriginal<typeof import('@tzurot/common-types')>()),
-  isBotOwner: vi.fn().mockReturnValue(false),
-  getConfig: vi.fn().mockReturnValue({ BOT_OWNER_ID: undefined }),
-}));
-
+import type { PrismaClient } from '@tzurot/common-types/services/prisma';
+import { getConfig } from '@tzurot/common-types/config/config';
+import { isBotOwner } from '@tzurot/common-types/utils/ownerMiddleware';
+vi.mock('@tzurot/common-types/config/config', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types/config/config')>();
+  return {
+    ...actual,
+    getConfig: vi.fn().mockReturnValue({ BOT_OWNER_ID: undefined }),
+  };
+});
+vi.mock('@tzurot/common-types/utils/ownerMiddleware', async importOriginal => {
+  const actual =
+    await importOriginal<typeof import('@tzurot/common-types/utils/ownerMiddleware')>();
+  return {
+    ...actual,
+    isBotOwner: vi.fn().mockReturnValue(false),
+  };
+});
 describe('PersonalityLoader', () => {
   let mockPrisma: PrismaClient;
   let loader: PersonalityLoader;
@@ -329,7 +338,7 @@ describe('PersonalityLoader', () => {
         ] as any);
 
         // No BOT_OWNER_ID configured
-        vi.mocked(commonTypes.getConfig).mockReturnValue({ BOT_OWNER_ID: undefined } as any);
+        vi.mocked(getConfig).mockReturnValue({ BOT_OWNER_ID: undefined } as any);
 
         const result = await loader.loadFromDatabase('Lilith');
 
@@ -359,7 +368,7 @@ describe('PersonalityLoader', () => {
         ] as any);
 
         // Configure bot admin
-        vi.mocked(commonTypes.getConfig).mockReturnValue({
+        vi.mocked(getConfig).mockReturnValue({
           BOT_OWNER_ID: 'discord-admin-id',
         } as any);
         vi.mocked(mockPrisma.user.findUnique).mockResolvedValueOnce({
@@ -393,7 +402,7 @@ describe('PersonalityLoader', () => {
           publicOther,
         ] as any);
 
-        vi.mocked(commonTypes.getConfig).mockReturnValue({
+        vi.mocked(getConfig).mockReturnValue({
           BOT_OWNER_ID: 'discord-admin-id',
         } as any);
         vi.mocked(mockPrisma.user.findUnique).mockResolvedValueOnce({
@@ -426,7 +435,7 @@ describe('PersonalityLoader', () => {
         // DB returns oldest first
         vi.mocked(mockPrisma.personality.findMany).mockResolvedValueOnce([older, newer] as any);
 
-        vi.mocked(commonTypes.getConfig).mockReturnValue({ BOT_OWNER_ID: undefined } as any);
+        vi.mocked(getConfig).mockReturnValue({ BOT_OWNER_ID: undefined } as any);
 
         const result = await loader.loadFromDatabase('Lilith');
 
@@ -454,7 +463,7 @@ describe('PersonalityLoader', () => {
       });
 
       it('should cache bot admin UUID across multiple calls', async () => {
-        vi.mocked(commonTypes.getConfig).mockReturnValue({
+        vi.mocked(getConfig).mockReturnValue({
           BOT_OWNER_ID: 'discord-admin-id',
         } as any);
         // First call succeeds; second would throw if cache misses
@@ -532,7 +541,7 @@ describe('PersonalityLoader', () => {
           publicOther,
         ] as any);
 
-        vi.mocked(commonTypes.getConfig).mockReturnValue({
+        vi.mocked(getConfig).mockReturnValue({
           BOT_OWNER_ID: 'discord-admin-id',
         } as any);
         // DB error on admin lookup — should not propagate
@@ -548,7 +557,7 @@ describe('PersonalityLoader', () => {
       });
 
       it('should not cache null when admin has not registered yet', async () => {
-        vi.mocked(commonTypes.getConfig).mockReturnValue({
+        vi.mocked(getConfig).mockReturnValue({
           BOT_OWNER_ID: 'discord-admin-id',
         } as any);
 
@@ -588,7 +597,7 @@ describe('PersonalityLoader', () => {
       });
 
       it('should retry admin UUID lookup after transient failure', async () => {
-        vi.mocked(commonTypes.getConfig).mockReturnValue({
+        vi.mocked(getConfig).mockReturnValue({
           BOT_OWNER_ID: 'discord-admin-id',
         } as any);
 
@@ -780,7 +789,7 @@ describe('PersonalityLoader', () => {
 
       it('should bypass access filter when user is bot owner', async () => {
         // Mock isBotOwner to return true for this test
-        vi.mocked(commonTypes.isBotOwner).mockReturnValueOnce(true);
+        vi.mocked(isBotOwner).mockReturnValueOnce(true);
 
         const mockPersonality = createMockPersonality({
           id: 'private-id',

--- a/packages/identity/src/personality/PersonalityLoader.ts
+++ b/packages/identity/src/personality/PersonalityLoader.ts
@@ -3,18 +3,18 @@
  * Database query logic for loading personalities from PostgreSQL
  */
 
+import { getConfig } from '@tzurot/common-types/config/config';
+import { isValidUUID } from '@tzurot/common-types/constants/service';
+import { SYNC_LIMITS } from '@tzurot/common-types/constants/timing';
+import { ADMIN_SETTINGS_SINGLETON_ID } from '@tzurot/common-types/schemas/api/adminSettings';
 import {
-  type PrismaClient,
-  createLogger,
-  isBotOwner,
-  getConfig,
-  isValidUUID,
-  SYNC_LIMITS,
   LLM_CONFIG_SELECT,
   mapLlmConfigFromDb,
   type MappedLlmConfig,
-  ADMIN_SETTINGS_SINGLETON_ID,
-} from '@tzurot/common-types';
+} from '@tzurot/common-types/services/LlmConfigMapper';
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import { isBotOwner } from '@tzurot/common-types/utils/ownerMiddleware';
 import type { DatabasePersonality } from './PersonalityValidator.js';
 
 const logger = createLogger('PersonalityLoader');

--- a/packages/identity/src/personality/PersonalityService.component.test.ts
+++ b/packages/identity/src/personality/PersonalityService.component.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
-import { PrismaClient } from '@tzurot/common-types';
+import { PrismaClient } from '@tzurot/common-types/services/prisma';
 import type { PGlite } from '@electric-sql/pglite';
 import { PrismaPGlite } from 'pglite-prisma-adapter';
 import { PersonalityService } from './PersonalityService.js';

--- a/packages/identity/src/personality/PersonalityService.test.ts
+++ b/packages/identity/src/personality/PersonalityService.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { PersonalityService } from './PersonalityService.js';
-import type { PrismaClient } from '@tzurot/common-types';
+import type { PrismaClient } from '@tzurot/common-types/services/prisma';
 
 describe('PersonalityService - Cache Invalidation', () => {
   let mockPrisma: PrismaClient;

--- a/packages/identity/src/personality/PersonalityService.ts
+++ b/packages/identity/src/personality/PersonalityService.ts
@@ -9,13 +9,11 @@
  * - TTLCache: In-memory caching with TTL (via lru-cache)
  */
 
-import {
-  type PrismaClient,
-  createLogger,
-  TIMEOUTS,
-  type LoadedPersonality,
-  TTLCache,
-} from '@tzurot/common-types';
+import { TIMEOUTS } from '@tzurot/common-types/constants/timing';
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
+import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import { TTLCache } from '@tzurot/common-types/utils/TTLCache';
 import { PersonalityLoader } from './PersonalityLoader.js';
 import { mapToPersonality } from './PersonalityDefaults.js';
 

--- a/packages/identity/src/personality/PersonalityValidator.ts
+++ b/packages/identity/src/personality/PersonalityValidator.ts
@@ -4,7 +4,9 @@
  */
 
 import { z } from 'zod';
-import { Prisma, createLogger, type PersonalityCharacterFields } from '@tzurot/common-types';
+import { type PersonalityCharacterFields } from '@tzurot/common-types/schemas/api/personality';
+import { Prisma } from '@tzurot/common-types/services/prisma';
+import { createLogger } from '@tzurot/common-types/utils/logger';
 
 // Re-export Decimal type for convenience
 type Decimal = Prisma.Decimal;

--- a/packages/identity/src/resolvers/BaseConfigResolver.ts
+++ b/packages/identity/src/resolvers/BaseConfigResolver.ts
@@ -51,7 +51,10 @@
  * @see PersonaResolver - Switch strategy implementation
  */
 
-import { createLogger, INTERVALS, TTLCache, type PrismaClient } from '@tzurot/common-types';
+import { INTERVALS } from '@tzurot/common-types/constants/timing';
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import { TTLCache } from '@tzurot/common-types/utils/TTLCache';
 
 const logger = createLogger('BaseConfigResolver');
 

--- a/packages/identity/src/resolvers/PersonaResolver.test.ts
+++ b/packages/identity/src/resolvers/PersonaResolver.test.ts
@@ -35,12 +35,13 @@ const { mockLogger } = vi.hoisted(() => ({
     error: vi.fn(),
   },
 }));
-
-vi.mock('@tzurot/common-types', async importOriginal => ({
-  ...(await importOriginal<typeof import('@tzurot/common-types')>()),
-  createLogger: () => mockLogger,
-}));
-
+vi.mock('@tzurot/common-types/utils/logger', async importOriginal => {
+  const actual = await importOriginal<typeof import('@tzurot/common-types/utils/logger')>();
+  return {
+    ...actual,
+    createLogger: () => mockLogger,
+  };
+});
 describe('PersonaResolver', () => {
   let resolver: PersonaResolver;
 

--- a/packages/identity/src/resolvers/PersonaResolver.ts
+++ b/packages/identity/src/resolvers/PersonaResolver.ts
@@ -15,29 +15,25 @@
  * 3. Transient first-owned-persona fallback (warns, does NOT persist)
  * 4. System default (errors, user has no personas at all)
  *
- * Prior to the Identity Epic Phase 3 (2026-04-16), the Priority 3 branch
- * lazily persisted the first owned persona as the user's default. That lazy
- * mutation was dropped because: (a) it made a "read" path mutate state,
+ * The Priority 3 branch does NOT persist the fallback persona. An earlier
+ * design lazily wrote the first owned persona as the user's default here; that
+ * lazy mutation was dropped because: (a) it made a "read" path mutate state,
  * (b) errors were swallowed as "best-effort optimization" and became
  * invisible, (c) UserService already provisions `defaultPersonaId` atomically
- * at creation time (Phase 2), so the lazy-init code path is a transitional
- * compatibility shim rather than load-bearing logic.
+ * at creation time, so the lazy-init code path was a transitional compatibility
+ * shim rather than load-bearing logic.
  *
- * Post-Phase 5b, the Priority 3 branch should be unreachable in practice —
- * every user row has a non-null `defaultPersonaId` pointing to a real persona
- * (DB-enforced NOT NULL + Restrict FK). It remains as defense-in-depth for
- * any user row that somehow escapes the provisioning path (e.g., direct SQL
- * imports during sync). Transient resolution warns loudly so such orphans
- * are visible in logs.
+ * Priority 3 should be unreachable in practice — every user row has a non-null
+ * `defaultPersonaId` pointing to a real persona (DB-enforced NOT NULL + Restrict
+ * FK). It remains as defense-in-depth for any user row that somehow escapes the
+ * provisioning path (e.g., direct SQL imports during sync). Transient resolution
+ * warns loudly so such orphans are visible in logs.
  */
 
-import {
-  createLogger,
-  isValidUUID,
-  UUID_REGEX,
-  type PrismaClient,
-  type CorePersonaConfig,
-} from '@tzurot/common-types';
+import { isValidUUID, UUID_REGEX } from '@tzurot/common-types/constants/service';
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
+import { type CorePersonaConfig } from '@tzurot/common-types/types/personaResolution';
+import { createLogger } from '@tzurot/common-types/utils/logger';
 import {
   BaseConfigResolver,
   type BaseConfigResolverOptions,
@@ -242,9 +238,9 @@ export class PersonaResolver extends BaseConfigResolver<ResolvedPersona> {
     }
 
     // Execution reaches here only when Priority 2 didn't return — meaning
-    // `user.defaultPersona` is null. Post-Phase 5 this should be unreachable
-    // at the DB level: the FK is `onDelete: Restrict` (so a referenced persona
-    // can't be deleted) and Phase 5b made `defaultPersonaId` itself NOT NULL.
+    // `user.defaultPersona` is null. This should be unreachable at the DB
+    // level: the FK is `onDelete: Restrict` (so a referenced persona can't be
+    // deleted) and `defaultPersonaId` is itself NOT NULL.
     // We log loudly here as a tripwire — hitting this branch means either the
     // DB drifted from its schema guarantees or db-sync imported a row in an
     // inconsistent state. Either way we fall through to owned-persona
@@ -283,7 +279,8 @@ export class PersonaResolver extends BaseConfigResolver<ResolvedPersona> {
       };
     }
 
-    // No persona at all — genuine data-integrity violation post-Phase-2.
+    // No persona at all — genuine data-integrity violation (defaultPersonaId
+    // is NOT NULL, so a null here means the DB drifted from its schema).
     logger.error(
       { discordUserId, userId: user.id },
       'User has no personas — provisioning is incomplete. Check UserService.createUserWithDefaultPersona flow.'
@@ -442,8 +439,8 @@ export class PersonaResolver extends BaseConfigResolver<ResolvedPersona> {
   /**
    * Validate a personaId is a UUID, returning it unchanged or null.
    *
-   * **Post-Phase-4 contract**: callers must pass UUID personaIds. The
-   * legacy `discord:XXXX` placeholder format is stripped at the bot-client
+   * **Contract**: callers must pass UUID personaIds. The legacy
+   * `discord:XXXX` placeholder format is stripped at the bot-client
    * boundary by `ExtendedContextPersonaResolver.resolveExtendedContextPersonaIds`
    * before any data leaves the service, so ai-worker never sees it.
    *

--- a/packages/test-factories/src/llm-config.ts
+++ b/packages/test-factories/src/llm-config.ts
@@ -21,7 +21,7 @@ import {
   type ListLlmConfigsResponse,
   type CreateLlmConfigResponse,
   type DeleteLlmConfigResponse,
-} from '@tzurot/common-types';
+} from '@tzurot/common-types/schemas/api/llm-config';
 import { z } from 'zod';
 
 type LlmConfigSummary = z.infer<typeof LlmConfigSummarySchema>;
@@ -33,11 +33,10 @@ import { type DeepPartial } from './factoryUtils.js';
 // Shared Defaults
 // ============================================================================
 
-// Fixed RFC-4122-valid UUID used as the factory default. The response-schema
-// tightening added in the same PR as this factory rejects non-UUID ids at
-// `LlmConfigSummarySchema.parse()`, so `'config-123'` no longer works. A
-// hardcoded shape (version=4, variant=8) keeps the factory deterministic
-// without pulling in a generator dependency for test fixtures.
+// Fixed RFC-4122-valid UUID used as the factory default. The response schema
+// rejects non-UUID ids at `LlmConfigSummarySchema.parse()`, so `'config-123'`
+// no longer works. A hardcoded shape (version=4, variant=8) keeps the factory
+// deterministic without pulling in a generator dependency for test fixtures.
 const MOCK_DEFAULT_ID = '00000000-0000-4000-8000-000000000000';
 
 const defaultLlmConfigSummary: LlmConfigSummary = {

--- a/packages/test-factories/src/model-override.ts
+++ b/packages/test-factories/src/model-override.ts
@@ -17,7 +17,7 @@ import {
   type ClearDefaultConfigResponse,
   type DeleteModelOverrideResponse,
   type UserDefaultConfig,
-} from '@tzurot/common-types';
+} from '@tzurot/common-types/schemas/api/model-override';
 
 // Default UUIDs for consistent test data (RFC 4122 compliant v5 UUIDs)
 const DEFAULT_PERSONALITY_ID = '11111111-1111-5111-8111-111111111111';

--- a/packages/test-factories/src/persona.ts
+++ b/packages/test-factories/src/persona.ts
@@ -33,7 +33,7 @@ import {
   type CreateOverrideResponse,
   type PersonaDetails,
   type PersonaSummary,
-} from '@tzurot/common-types';
+} from '@tzurot/common-types/schemas/api/persona';
 
 // Default UUIDs for consistent test data (RFC 4122 compliant v5 UUIDs)
 const DEFAULT_PERSONALITY_ID = '11111111-1111-5111-8111-111111111111';

--- a/packages/test-factories/src/personality.ts
+++ b/packages/test-factories/src/personality.ts
@@ -13,7 +13,7 @@ import {
   type GetPersonalityResponse,
   type ListPersonalitiesResponse,
   type PersonalityFull,
-} from '@tzurot/common-types';
+} from '@tzurot/common-types/schemas/api/personality';
 
 // Default UUIDs for consistent test data (RFC 4122 compliant v5 UUIDs)
 const DEFAULT_PERSONALITY_ID = '33333333-3333-5333-8333-333333333333';

--- a/packages/test-factories/src/timezone.ts
+++ b/packages/test-factories/src/timezone.ts
@@ -17,8 +17,7 @@ import {
   SetTimezoneResponseSchema,
   type GetTimezoneResponse,
   type SetTimezoneResponse,
-} from '@tzurot/common-types';
-
+} from '@tzurot/common-types/schemas/api/timezone';
 import { type DeepPartial } from './factoryUtils.js';
 
 // ============================================================================

--- a/packages/test-factories/src/tts-override.ts
+++ b/packages/test-factories/src/tts-override.ts
@@ -7,7 +7,7 @@
 import {
   ClearTtsDefaultConfigResponseSchema,
   type ClearTtsDefaultConfigResponse,
-} from '@tzurot/common-types';
+} from '@tzurot/common-types/schemas/api/tts-override';
 
 // ============================================================================
 // Clear Default Config (DELETE /user/tts-override/default)

--- a/packages/test-factories/src/wallet.ts
+++ b/packages/test-factories/src/wallet.ts
@@ -13,8 +13,8 @@
  *   });
  */
 
+import { AIProvider } from '@tzurot/common-types/constants/ai';
 import {
-  AIProvider,
   ListWalletKeysResponseSchema,
   RemoveWalletKeyResponseSchema,
   TestWalletKeyResponseSchema,
@@ -22,8 +22,7 @@ import {
   type RemoveWalletKeyResponse,
   type TestWalletKeyResponse,
   type WalletKey,
-} from '@tzurot/common-types';
-
+} from '@tzurot/common-types/schemas/api/wallet';
 import { type DeepPartial, deepMerge } from './factoryUtils.js';
 
 // ============================================================================

--- a/packages/test-utils/src/seed.component.test.ts
+++ b/packages/test-utils/src/seed.component.test.ts
@@ -16,7 +16,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import type { PGlite } from '@electric-sql/pglite';
 import { PrismaPGlite } from 'pglite-prisma-adapter';
-import { PrismaClient } from '@tzurot/common-types';
+import { PrismaClient } from '@tzurot/common-types/services/prisma';
 import { createTestPGlite, loadPGliteSchema } from './setup-pglite.js';
 import { seedUserWithPersona } from './seed.js';
 

--- a/packages/test-utils/src/setup-pglite.ts
+++ b/packages/test-utils/src/setup-pglite.ts
@@ -59,7 +59,7 @@ const __dirname = dirname(__filename);
  * ```typescript
  * import { createTestPGlite, loadPGliteSchema } from '@tzurot/test-utils';
  * import { PrismaPGlite } from 'pglite-prisma-adapter';
- * import { PrismaClient } from '@tzurot/common-types';
+ * import { PrismaClient } from '@tzurot/common-types/services/prisma';
  *
  * const pglite = createTestPGlite();
  * await pglite.exec(loadPGliteSchema());
@@ -96,7 +96,7 @@ export function loadPGliteSchema(): string {
  * For tests that need Prisma/PGLite, set it up in the test file:
  * @example
  * ```typescript
- * import { PrismaClient } from '@tzurot/common-types';
+ * import { PrismaClient } from '@tzurot/common-types/services/prisma';
  * import { PrismaPGlite } from 'pglite-prisma-adapter';
  * import {
  *   setupTestEnvironment,

--- a/packages/test-utils/tsconfig.spec.json
+++ b/packages/test-utils/tsconfig.spec.json
@@ -16,7 +16,8 @@
     // vitest.component.config.ts so tsc can resolve the type for the spec typecheck
     // only — it does not add a package-graph edge.
     "paths": {
-      "@tzurot/common-types": ["../common-types/src/index.ts"]
+      "@tzurot/common-types": ["../common-types/src/index.ts"],
+      "@tzurot/common-types/*": ["../common-types/src/*.ts"]
     }
   },
   "include": ["src/**/*.ts"],

--- a/packages/tooling/src/cache/clear-credit-exhaustion.ts
+++ b/packages/tooling/src/cache/clear-credit-exhaustion.ts
@@ -12,8 +12,7 @@
 
 import { Redis } from 'ioredis';
 import chalk from 'chalk';
-import { CACHE_KEY_PREFIXES } from '@tzurot/common-types';
-
+import { CACHE_KEY_PREFIXES } from '@tzurot/common-types/constants/redis-keys';
 import { getRailwayRedisUrl } from '../inspect/bullmqConnection.js';
 import type { Environment } from '../utils/env-runner.js';
 
@@ -30,8 +29,7 @@ export interface ClearOptions {
  * human-readable reason; `kind: 'ok'` carries the Redis key to delete.
  */
 export type KeyResolution =
-  | { kind: 'ok'; key: string }
-  | { kind: 'error'; reason: 'mutually-exclusive' | 'missing-flag' };
+  { kind: 'ok'; key: string } | { kind: 'error'; reason: 'mutually-exclusive' | 'missing-flag' };
 
 /**
  * Pure key-resolution helper. Exposed for unit testing without a Redis client.

--- a/packages/tooling/src/codegen/client-builder.test.ts
+++ b/packages/tooling/src/codegen/client-builder.test.ts
@@ -165,7 +165,7 @@ describe('buildClientClass — UserClient', () => {
     });
     expect(src).toContain(`type ActorDiscordId`);
     expect(src).toContain(`GatewayUser`);
-    expect(src).toContain(`from '@tzurot/common-types'`);
+    expect(src).toContain(`from '@tzurot/common-types/types/gateway-context'`);
     expect(src).not.toContain(`SubjectDiscordId`);
   });
 

--- a/packages/tooling/src/codegen/client-builder.ts
+++ b/packages/tooling/src/codegen/client-builder.ts
@@ -54,8 +54,9 @@ function buildImports(flavor: ClientFlavor, routes: Record<string, RouteDef>): s
   // Intra-package symbols (transport, manifest, route types) import via
   // relative paths rather than the `@tzurot/clients` index to avoid a
   // self-import cycle: the package index re-exports the generated classes
-  // themselves. Cross-package symbols (GatewayUser) import from
-  // `@tzurot/common-types` — a one-way dependency, no cycle.
+  // themselves. Cross-package symbols (GatewayUser) import from the deep
+  // `@tzurot/common-types/types/gateway-context` subpath (the root barrel is
+  // being retired) — a one-way dependency, no cycle.
   const transportSymbols: string[] = ['callGateway', 'type GatewayResult'];
   const manifestSymbols: string[] = ['ROUTE_MANIFEST'];
   const typeSymbols: string[] = [];
@@ -75,7 +76,7 @@ function buildImports(flavor: ClientFlavor, routes: Record<string, RouteDef>): s
     lines.push(`import { ${typeSymbols.join(', ')} } from '../../routes/types.js';`);
   }
   if (flavor === 'user') {
-    lines.push(`import type { GatewayUser } from '@tzurot/common-types';`);
+    lines.push(`import type { GatewayUser } from '@tzurot/common-types/types/gateway-context';`);
   }
 
   lines.push('');

--- a/packages/tooling/src/db/check-migration-drift.test.ts
+++ b/packages/tooling/src/db/check-migration-drift.test.ts
@@ -1,16 +1,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
-import { createPrismaClient } from '@tzurot/common-types';
+import { createPrismaClient } from '@tzurot/common-types/services/prisma';
 
 const mockDispose = vi.fn().mockResolvedValue(undefined);
 
 // Mock common-types
-vi.mock('@tzurot/common-types', () => ({
-  createPrismaClient: vi.fn(),
+vi.mock('@tzurot/common-types/services/poolConfig', () => ({
   DB_POOL_DEFAULTS: { TRANSIENT_MAX: 5 },
 }));
-
+vi.mock('@tzurot/common-types/services/prisma', () => ({
+  createPrismaClient: vi.fn(),
+}));
 // Mock chalk
 vi.mock('chalk', () => ({
   default: {

--- a/packages/tooling/src/db/check-migration-drift.ts
+++ b/packages/tooling/src/db/check-migration-drift.ts
@@ -9,7 +9,8 @@ import fs from 'node:fs';
 import crypto from 'node:crypto';
 import path from 'node:path';
 import chalk from 'chalk';
-import { createPrismaClient, DB_POOL_DEFAULTS } from '@tzurot/common-types';
+import { DB_POOL_DEFAULTS } from '@tzurot/common-types/services/poolConfig';
+import { createPrismaClient } from '@tzurot/common-types/services/prisma';
 import {
   type Environment,
   validateEnvironment,

--- a/packages/tooling/src/db/create-safe-migration.test.ts
+++ b/packages/tooling/src/db/create-safe-migration.test.ts
@@ -5,16 +5,17 @@ import {
   computeFileChecksum,
   reconcileMigrationChecksum,
 } from './create-safe-migration.js';
-import { createPrismaClient } from '@tzurot/common-types';
+import { createPrismaClient } from '@tzurot/common-types/services/prisma';
 
 const mockDispose = vi.fn();
 
 // Mock common-types for reconcileMigrationChecksum tests
-vi.mock('@tzurot/common-types', () => ({
-  createPrismaClient: vi.fn(),
+vi.mock('@tzurot/common-types/services/poolConfig', () => ({
   DB_POOL_DEFAULTS: { TRANSIENT_MAX: 5 },
 }));
-
+vi.mock('@tzurot/common-types/services/prisma', () => ({
+  createPrismaClient: vi.fn(),
+}));
 /**
  * Tests for create-safe-migration
  *

--- a/packages/tooling/src/db/create-safe-migration.ts
+++ b/packages/tooling/src/db/create-safe-migration.ts
@@ -24,7 +24,8 @@ import { readFileSync, writeFileSync, readdirSync, statSync, mkdirSync } from 'n
 import { join, basename } from 'node:path';
 import { createInterface } from 'node:readline';
 import chalk from 'chalk';
-import { createPrismaClient, DB_POOL_DEFAULTS } from '@tzurot/common-types';
+import { DB_POOL_DEFAULTS } from '@tzurot/common-types/services/poolConfig';
+import { createPrismaClient } from '@tzurot/common-types/services/prisma';
 import {
   type Environment,
   validateEnvironment,

--- a/packages/tooling/src/db/fix-migration-drift.test.ts
+++ b/packages/tooling/src/db/fix-migration-drift.test.ts
@@ -1,15 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
-import { createPrismaClient } from '@tzurot/common-types';
+import { createPrismaClient } from '@tzurot/common-types/services/prisma';
 
 const mockDispose = vi.fn().mockResolvedValue(undefined);
 
 // Mock common-types
-vi.mock('@tzurot/common-types', () => ({
-  createPrismaClient: vi.fn(),
+vi.mock('@tzurot/common-types/services/poolConfig', () => ({
   DB_POOL_DEFAULTS: { TRANSIENT_MAX: 5 },
 }));
-
+vi.mock('@tzurot/common-types/services/prisma', () => ({
+  createPrismaClient: vi.fn(),
+}));
 // Mock chalk
 vi.mock('chalk', () => ({
   default: {

--- a/packages/tooling/src/db/fix-migration-drift.ts
+++ b/packages/tooling/src/db/fix-migration-drift.ts
@@ -9,7 +9,8 @@ import fs from 'node:fs';
 import crypto from 'node:crypto';
 import path from 'node:path';
 import chalk from 'chalk';
-import { createPrismaClient, DB_POOL_DEFAULTS } from '@tzurot/common-types';
+import { DB_POOL_DEFAULTS } from '@tzurot/common-types/services/poolConfig';
+import { createPrismaClient } from '@tzurot/common-types/services/prisma';
 import {
   type Environment,
   validateEnvironment,

--- a/packages/tooling/src/db/inspect-database.test.ts
+++ b/packages/tooling/src/db/inspect-database.test.ts
@@ -1,14 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { createPrismaClient } from '@tzurot/common-types';
+import { createPrismaClient } from '@tzurot/common-types/services/prisma';
 
 const mockDispose = vi.fn().mockResolvedValue(undefined);
 
 // Mock common-types before importing
-vi.mock('@tzurot/common-types', () => ({
-  createPrismaClient: vi.fn(),
+vi.mock('@tzurot/common-types/services/poolConfig', () => ({
   DB_POOL_DEFAULTS: { TRANSIENT_MAX: 5 },
 }));
-
+vi.mock('@tzurot/common-types/services/prisma', () => ({
+  createPrismaClient: vi.fn(),
+}));
 // Mock chalk to simplify output testing
 vi.mock('chalk', () => ({
   default: {

--- a/packages/tooling/src/db/inspect-database.ts
+++ b/packages/tooling/src/db/inspect-database.ts
@@ -9,7 +9,8 @@
  */
 
 import chalk from 'chalk';
-import { createPrismaClient, DB_POOL_DEFAULTS } from '@tzurot/common-types';
+import { DB_POOL_DEFAULTS } from '@tzurot/common-types/services/poolConfig';
+import { createPrismaClient } from '@tzurot/common-types/services/prisma';
 import {
   type Environment,
   validateEnvironment,

--- a/packages/tooling/src/db/migration-status.test.ts
+++ b/packages/tooling/src/db/migration-status.test.ts
@@ -1,15 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
-import { createPrismaClient } from '@tzurot/common-types';
+import { createPrismaClient } from '@tzurot/common-types/services/prisma';
 
 const mockDispose = vi.fn().mockResolvedValue(undefined);
 
 // Mock common-types
-vi.mock('@tzurot/common-types', () => ({
-  createPrismaClient: vi.fn(),
+vi.mock('@tzurot/common-types/services/poolConfig', () => ({
   DB_POOL_DEFAULTS: { TRANSIENT_MAX: 5 },
 }));
-
+vi.mock('@tzurot/common-types/services/prisma', () => ({
+  createPrismaClient: vi.fn(),
+}));
 // Mock chalk
 vi.mock('chalk', () => ({
   default: {

--- a/packages/tooling/src/db/migration-status.ts
+++ b/packages/tooling/src/db/migration-status.ts
@@ -10,7 +10,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import chalk from 'chalk';
-import { createPrismaClient, DB_POOL_DEFAULTS } from '@tzurot/common-types';
+import { DB_POOL_DEFAULTS } from '@tzurot/common-types/services/poolConfig';
+import { createPrismaClient } from '@tzurot/common-types/services/prisma';
 import {
   type Environment,
   validateEnvironment,

--- a/packages/tooling/src/inspect/bullmqConnection.ts
+++ b/packages/tooling/src/inspect/bullmqConnection.ts
@@ -5,7 +5,7 @@
  */
 
 import { Queue } from 'bullmq';
-import { parseRedisUrl, createBullMQRedisConfig } from '@tzurot/common-types';
+import { parseRedisUrl, createBullMQRedisConfig } from '@tzurot/common-types/utils/redis';
 import chalk from 'chalk';
 
 import type { Environment } from '../utils/env-runner.js';

--- a/packages/tooling/src/inspect/dlq.test.ts
+++ b/packages/tooling/src/inspect/dlq.test.ts
@@ -26,12 +26,10 @@ vi.mock('bullmq', () => ({
     close: vi.fn().mockResolvedValue(undefined),
   })),
 }));
-
-vi.mock('@tzurot/common-types', () => ({
+vi.mock('@tzurot/common-types/utils/redis', () => ({
   parseRedisUrl: vi.fn(() => ({ host: 'localhost', port: 6379 })),
   createBullMQRedisConfig: vi.fn(config => ({ ...config, maxRetriesPerRequest: null })),
 }));
-
 vi.mock('node:child_process', () => ({
   execFileSync: vi.fn().mockReturnValue(JSON.stringify({ REDIS_URL: 'redis://localhost:6379' })),
 }));

--- a/packages/tooling/src/inspect/queue.test.ts
+++ b/packages/tooling/src/inspect/queue.test.ts
@@ -35,12 +35,10 @@ vi.mock('bullmq', () => ({
     close: vi.fn().mockResolvedValue(undefined),
   })),
 }));
-
-vi.mock('@tzurot/common-types', () => ({
+vi.mock('@tzurot/common-types/utils/redis', () => ({
   parseRedisUrl: vi.fn(() => ({ host: 'localhost', port: 6379 })),
   createBullMQRedisConfig: vi.fn(config => ({ ...config, maxRetriesPerRequest: null })),
 }));
-
 vi.mock('node:child_process', () => ({
   execFileSync: vi.fn().mockReturnValue(JSON.stringify({ REDIS_URL: 'redis://localhost:6379' })),
 }));

--- a/packages/tooling/src/inspect/tts-configs.test.ts
+++ b/packages/tooling/src/inspect/tts-configs.test.ts
@@ -51,7 +51,10 @@ describe('buildInspectorScript', () => {
   it('imports the prisma factory from common-types', () => {
     const script = buildInspectorScript(200);
     expect(script).toContain(
-      "import { createPrismaClient, DB_POOL_DEFAULTS } from '@tzurot/common-types';"
+      "import { createPrismaClient } from '@tzurot/common-types/services/prisma';"
+    );
+    expect(script).toContain(
+      "import { DB_POOL_DEFAULTS } from '@tzurot/common-types/services/poolConfig';"
     );
   });
 

--- a/packages/tooling/src/inspect/tts-configs.ts
+++ b/packages/tooling/src/inspect/tts-configs.ts
@@ -77,7 +77,8 @@ export async function inspectTtsConfigs(options: InspectTtsConfigsOptions): Prom
  */
 export function buildInspectorScript(takeLimit: number): string {
   return `
-import { createPrismaClient, DB_POOL_DEFAULTS } from '@tzurot/common-types';
+import { createPrismaClient } from '@tzurot/common-types/services/prisma';
+import { DB_POOL_DEFAULTS } from '@tzurot/common-types/services/poolConfig';
 
 async function main() {
   const { prisma, dispose } = createPrismaClient({ max: DB_POOL_DEFAULTS.TRANSIENT_MAX });

--- a/packages/tooling/src/memory/backfill-ltm.test.ts
+++ b/packages/tooling/src/memory/backfill-ltm.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { hashContent, deterministicMemoryUuid } from '@tzurot/common-types';
+import { hashContent, deterministicMemoryUuid } from '@tzurot/common-types/constants/memory';
 import {
   pairMessages,
   deduplicatePairs,

--- a/packages/tooling/src/memory/backfill-ltm.ts
+++ b/packages/tooling/src/memory/backfill-ltm.ts
@@ -22,7 +22,8 @@ import {
 } from '../utils/env-runner.js';
 import { getPrismaForEnv } from './prisma-env.js';
 import { parseDateRange, printDryRunPreview } from './backfill-cli-helpers.js';
-import { deterministicMemoryUuid, Prisma, type PrismaClient } from '@tzurot/common-types';
+import { deterministicMemoryUuid } from '@tzurot/common-types/constants/memory';
+import { Prisma, type PrismaClient } from '@tzurot/common-types/services/prisma';
 
 export interface BackfillOptions {
   env: Environment;

--- a/packages/tooling/src/memory/cleanup-duplicates.ts
+++ b/packages/tooling/src/memory/cleanup-duplicates.ts
@@ -22,7 +22,7 @@ import {
   showEnvironmentBanner,
   confirmProductionOperation,
 } from '../utils/env-runner.js';
-import { type PrismaClient } from '@tzurot/common-types';
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { getPrismaForEnv } from './prisma-env.js';
 
 interface CleanupOptions {

--- a/packages/tooling/src/memory/prisma-env.test.ts
+++ b/packages/tooling/src/memory/prisma-env.test.ts
@@ -5,13 +5,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock external dependencies — both are used as constructors (`new X(...)`)
-vi.mock('@tzurot/common-types', () => ({
+vi.mock('@tzurot/common-types/services/poolConfig', () => ({
+  transientPoolOptions: () => ({ max: 5, connectionTimeoutMillis: 10_000 }),
+}));
+vi.mock('@tzurot/common-types/services/prisma', () => ({
   PrismaClient: class MockPrismaClient {
     $disconnect = vi.fn().mockResolvedValue(undefined);
   },
-  transientPoolOptions: () => ({ max: 5, connectionTimeoutMillis: 10_000 }),
 }));
-
 vi.mock('@prisma/adapter-pg', () => ({
   PrismaPg: class MockPrismaPg {},
 }));

--- a/packages/tooling/src/memory/prisma-env.ts
+++ b/packages/tooling/src/memory/prisma-env.ts
@@ -7,7 +7,8 @@
  */
 
 import { type Environment, getRailwayDatabaseUrl } from '../utils/env-runner.js';
-import { type PrismaClient, transientPoolOptions } from '@tzurot/common-types';
+import { transientPoolOptions } from '@tzurot/common-types/services/poolConfig';
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 
 export interface PrismaEnvConnection {
   prisma: PrismaClient;
@@ -20,7 +21,7 @@ export interface PrismaEnvConnection {
  * Dynamically imports Prisma to avoid loading it until needed.
  */
 export async function getPrismaForEnv(env: Environment): Promise<PrismaEnvConnection> {
-  const { PrismaClient: PrismaClientClass } = await import('@tzurot/common-types');
+  const { PrismaClient: PrismaClientClass } = await import('@tzurot/common-types/services/prisma');
   const { PrismaPg } = await import('@prisma/adapter-pg');
 
   let databaseUrl: string;

--- a/packages/tooling/src/topology/coverageTopology.test.ts
+++ b/packages/tooling/src/topology/coverageTopology.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { describe, it, expect } from 'vitest';
 import { ROUTE_MANIFEST } from '@tzurot/clients';
-import { JobType } from '@tzurot/common-types';
+import { JobType } from '@tzurot/common-types/constants/queue';
 import {
   generateCoverageTopology,
   surfaceGap,

--- a/packages/tooling/src/topology/coverageTopology.ts
+++ b/packages/tooling/src/topology/coverageTopology.ts
@@ -29,8 +29,7 @@ import { writeFileSync } from 'node:fs';
 import { resolve, dirname, join } from 'node:path';
 
 import { ROUTE_MANIFEST } from '@tzurot/clients';
-import { JobType } from '@tzurot/common-types';
-
+import { JobType } from '@tzurot/common-types/constants/queue';
 import { findFiles, fileExists, readFile } from '../test/audit-utils.js';
 import type { TestTier } from '../test/test-tiers.js';
 import { fileImportsSymbol } from './importAssertions.js';

--- a/packages/tooling/src/voice/audit-references.ts
+++ b/packages/tooling/src/voice/audit-references.ts
@@ -23,7 +23,8 @@ import { writeFile, unlink, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import chalk from 'chalk';
-import { createPrismaClient, DB_POOL_DEFAULTS } from '@tzurot/common-types';
+import { DB_POOL_DEFAULTS } from '@tzurot/common-types/services/poolConfig';
+import { createPrismaClient } from '@tzurot/common-types/services/prisma';
 import {
   type Environment,
   validateEnvironment,

--- a/packages/tooling/src/xray/types.ts
+++ b/packages/tooling/src/xray/types.ts
@@ -17,10 +17,7 @@ export interface PackageInfo {
 }
 
 export type SuppressionKind =
-  | 'eslint-disable'
-  | 'eslint-disable-next-line'
-  | 'ts-expect-error'
-  | 'ts-nocheck';
+  'eslint-disable' | 'eslint-disable-next-line' | 'ts-expect-error' | 'ts-nocheck';
 
 export interface SuppressionInfo {
   kind: SuppressionKind;

--- a/scripts/migrations/barrel-kill/build-symbol-map.ts
+++ b/scripts/migrations/barrel-kill/build-symbol-map.ts
@@ -1,0 +1,233 @@
+#!/usr/bin/env tsx
+/**
+ * Barrel-kill Phase 0: build the authoritative symbol → subpath map.
+ *
+ * The entire codemod rests on knowing, for every public name the
+ * `@tzurot/common-types` root barrel exports, which leaf module it actually
+ * lives in. Rather than hand-expand the barrel's `export *` / curated
+ * `export { … }` forms (and re-derive its collision/ambiguity rules), we use
+ * the compiler as the oracle: `SourceFile.getExportSymbols()` returns the
+ * fully-resolved public export set — star-expanded, curation-respecting,
+ * ambiguity-dropped. We chase each export alias to its real declaration and
+ * mirror that declaration's src-relative path into an import subpath
+ * (`utils/logger.ts` → `@tzurot/common-types/utils/logger`).
+ *
+ * Run with: npx tsx scripts/migrations/barrel-kill/build-symbol-map.ts [--json <path>]
+ *
+ * Fails loudly on:
+ *   - a public name resolving to two different leaves (true collision)
+ *   - an export whose declaration is not under src/ (third-party re-export leak)
+ *   - keyset asymmetry between getExportSymbols() and the built map
+ */
+
+import path from 'node:path';
+import { writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { Project, ts, type Symbol as MorphSymbol } from 'ts-morph';
+
+const COMMON_TYPES_ROOT = path.resolve(import.meta.dirname, '../../../packages/common-types');
+const SRC_DIR = path.join(COMMON_TYPES_ROOT, 'src');
+const INDEX_PATH = path.join(SRC_DIR, 'index.ts');
+const PACKAGE_NAME = '@tzurot/common-types';
+
+/** Leaf directories that must NEVER be exposed as a subpath. */
+const INTERNAL_PREFIXES = ['generated/prisma/'];
+
+function isInternalFile(filePath: string): boolean {
+  const rel = path.relative(SRC_DIR, filePath).replace(/\\/g, '/');
+  return INTERNAL_PREFIXES.some(p => rel.startsWith(p));
+}
+
+export interface SymbolMapEntry {
+  /** src-relative import subpath, e.g. `utils/logger` (no leading `./`, no `.ts`). */
+  subpath: string;
+  /** The declaration's own name (barrel has no aliasing, so == publicName). */
+  originalName: string;
+  /** Has a runtime value binding (function/class/const/enum/…). */
+  hasValue: boolean;
+  /** Has a type binding (interface/type-alias/class/enum/…). */
+  isType: boolean;
+}
+
+export type SymbolMap = Map<string, SymbolMapEntry>;
+
+function chaseAlias(symbol: MorphSymbol): MorphSymbol {
+  let current = symbol;
+  const seen = new Set<MorphSymbol>();
+  for (;;) {
+    if (seen.has(current)) return current;
+    seen.add(current);
+    const aliased = current.getAliasedSymbol();
+    if (aliased === undefined) return current;
+    current = aliased;
+  }
+}
+
+/**
+ * Resolve an exported symbol to its ORIGIN declaration file (fully chased).
+ * `getExportSymbols()` flattens the barrel's `export *`, so the origin is the
+ * real leaf for normal symbols (schemas → schemas/api/persona, createLogger →
+ * utils/logger) — great deep paths. The one case it gets "wrong" is a symbol
+ * whose origin is internal (`PrismaClient` originates in generated/prisma/) —
+ * those are handled by the direct-source fallback in `buildSymbolMap`.
+ */
+function resolveOriginFile(sym: MorphSymbol): { file: string | null; internal: boolean } {
+  const resolved = chaseAlias(sym);
+  const srcDecls = resolved
+    .getDeclarations()
+    .map(d => d.getSourceFile().getFilePath() as string)
+    .filter(fp => fp.startsWith(SRC_DIR) && !fp.endsWith('.d.ts') && fp !== INDEX_PATH);
+  if (srcDecls.length === 0) return { file: null, internal: false };
+  return { file: srcDecls[0], internal: isInternalFile(srcDecls[0]) };
+}
+
+/**
+ * Map each public name to the NON-internal leaf the barrel DIRECTLY re-exports
+ * it through, by reading the barrel's own `export … from './X'` declarations.
+ * Used only as the fallback for internal-origin symbols: `PrismaClient` is
+ * `export *`-contributed by `services/prisma.ts` (which curates it out of the
+ * generated client), so its direct source is the exposed `services/prisma`
+ * leaf even though its origin is internal.
+ */
+function buildDirectSourceMap(
+  index: ReturnType<Project['getSourceFileOrThrow']>
+): Map<string, string> {
+  const m = new Map<string, string>();
+  for (const exp of index.getExportDeclarations()) {
+    const modSrc = exp.getModuleSpecifierSourceFile();
+    if (modSrc === undefined) continue;
+    const modFile = modSrc.getFilePath() as string;
+    if (!modFile.startsWith(SRC_DIR) || isInternalFile(modFile)) continue;
+    const subpath = toSubpath(modFile);
+    const named = exp.getNamedExports();
+    if (named.length > 0) {
+      for (const spec of named) m.set(spec.getName(), subpath);
+    } else {
+      for (const s of modSrc.getExportSymbols()) m.set(s.getName(), subpath);
+    }
+  }
+  return m;
+}
+
+function toSubpath(filePath: string): string {
+  let rel = path.relative(SRC_DIR, filePath).replace(/\\/g, '/');
+  rel = rel.replace(/\.ts$/, '');
+  rel = rel.replace(/\/index$/, ''); // a leaf that IS an index barrel collapses to its dir
+  return rel;
+}
+
+export function buildSymbolMap(): {
+  map: SymbolMap;
+  subpaths: Set<string>;
+  flags: { internalLeaks: string[]; unresolved: string[] };
+} {
+  const project = new Project({
+    tsConfigFilePath: path.join(COMMON_TYPES_ROOT, 'tsconfig.json'),
+  });
+  const index = project.getSourceFileOrThrow(path.join(SRC_DIR, 'index.ts'));
+
+  const map: SymbolMap = new Map();
+  const subpaths = new Set<string>();
+  const internalLeaks: string[] = [];
+  const unresolved: string[] = [];
+  const collisions: string[] = [];
+
+  const exportSymbols = index.getExportSymbols();
+  const directSource = buildDirectSourceMap(index);
+
+  for (const sym of exportSymbols) {
+    const publicName = sym.getName();
+    const { file: originFile, internal } = resolveOriginFile(sym);
+
+    let subpath: string | undefined;
+    if (originFile !== null && !internal) {
+      subpath = toSubpath(originFile); // normal case: deep path to the real leaf
+    } else {
+      // Internal origin (generated/prisma) OR no src decl → fall back to the
+      // exposed leaf the barrel directly re-exports it through.
+      subpath = directSource.get(publicName);
+    }
+    if (subpath === undefined) {
+      if (internal) internalLeaks.push(`${publicName} → generated/prisma`);
+      else unresolved.push(publicName);
+      continue;
+    }
+    const resolved = chaseAlias(sym); // origin symbol carries the real value/type flags
+    const flags = resolved.getFlags();
+    const entry: SymbolMapEntry = {
+      subpath,
+      originalName: resolved.getName(),
+      hasValue: (flags & ts.SymbolFlags.Value) !== 0,
+      isType: (flags & ts.SymbolFlags.Type) !== 0,
+    };
+    const existing = map.get(publicName);
+    if (existing !== undefined && existing.subpath !== subpath) {
+      collisions.push(`${publicName}: ${existing.subpath} vs ${subpath}`);
+      continue;
+    }
+    map.set(publicName, entry);
+    subpaths.add(subpath);
+  }
+
+  // Keyset symmetry cross-check (minus the intentionally-dropped buckets).
+  const exportedNames = new Set(exportSymbols.map(s => s.getName()));
+  const droppedCount = internalLeaks.length + unresolved.length + collisions.length;
+  const asymmetry = exportedNames.size - (map.size + droppedCount);
+
+  if (collisions.length > 0) {
+    console.error('\n❌ HARD FAIL — true symbol collisions (name → two leaves):');
+    for (const c of collisions) console.error(`   ${c}`);
+    process.exit(1);
+  }
+  if (asymmetry !== 0) {
+    console.error(
+      `\n❌ HARD FAIL — keyset asymmetry: ${exportedNames.size} exported, ` +
+        `${map.size} mapped + ${droppedCount} dropped (diff ${asymmetry}).`
+    );
+    process.exit(1);
+  }
+
+  return { map, subpaths, flags: { internalLeaks, unresolved } };
+}
+
+function main(): void {
+  const { map, subpaths, flags } = buildSymbolMap();
+
+  console.log(`\n📦 Barrel symbol → subpath map`);
+  console.log(`   ${map.size} public symbols across ${subpaths.size} subpaths\n`);
+
+  // Per-subpath symbol counts, sorted.
+  const bySubpath = new Map<string, string[]>();
+  for (const [name, entry] of map) {
+    const list = bySubpath.get(entry.subpath) ?? [];
+    list.push(name);
+    bySubpath.set(entry.subpath, list);
+  }
+  for (const sp of [...subpaths].sort()) {
+    const names = (bySubpath.get(sp) ?? []).sort();
+    console.log(`   ${PACKAGE_NAME}/${sp}  (${names.length})`);
+    console.log(`      ${names.join(', ')}`);
+  }
+
+  if (flags.internalLeaks.length > 0) {
+    console.log(`\n🔒 Dropped (internal generated/prisma — correctly NOT exposed):`);
+    for (const l of flags.internalLeaks) console.log(`   ${l}`);
+  }
+  if (flags.unresolved.length > 0) {
+    console.log(`\n⚠️  Unresolved (no src declaration — investigate):`);
+    for (const u of flags.unresolved) console.log(`   ${u}`);
+  }
+
+  const jsonFlag = process.argv.indexOf('--json');
+  if (jsonFlag !== -1 && process.argv[jsonFlag + 1] !== undefined) {
+    const out = Object.fromEntries(map);
+    writeFileSync(process.argv[jsonFlag + 1], JSON.stringify(out, null, 2));
+    console.log(`\n💾 Wrote map JSON → ${process.argv[jsonFlag + 1]}`);
+  }
+}
+
+// Only dump the map when run directly (`tsx build-symbol-map.ts`), not on import.
+const invokedPath = process.argv[1];
+if (invokedPath !== undefined && path.resolve(invokedPath) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/migrations/barrel-kill/codemod.ts
+++ b/scripts/migrations/barrel-kill/codemod.ts
@@ -1,0 +1,246 @@
+#!/usr/bin/env tsx
+/**
+ * Barrel-kill codemod: rewrite consumer imports of the `@tzurot/common-types`
+ * ROOT barrel into deep subpath imports, driven by the authoritative
+ * symbol→subpath map (see build-symbol-map.ts).
+ *
+ * Production half (this file): rewrites
+ *   - `import { a, b } from '@tzurot/common-types'` → grouped deep imports
+ *   - `export { a } from '@tzurot/common-types'`     → grouped deep re-exports
+ *   - inline `import('@tzurot/common-types').X` type queries (with qualifier)
+ *
+ * Flags for manual review (never silently mangled):
+ *   - `import * as ns from '@tzurot/common-types'` namespace imports
+ *   - `export * from '@tzurot/common-types'` wildcard re-exports
+ *   - any imported/exported name absent from the map (curated-out / prisma-internal)
+ *
+ * The transform fires ONLY on the exact specifier `@tzurot/common-types`, so
+ * already-migrated deep imports are invisible → idempotent and resumable.
+ *
+ * Test-mock half (vi.mock / importActual splitting) lives in mock-codemod.ts and
+ * runs in the same pass for packages that have test mocks.
+ *
+ * Run: npx tsx scripts/migrations/barrel-kill/codemod.ts <pkgDir> [--dry-run]
+ */
+
+import path from 'node:path';
+import {
+  Project,
+  QuoteKind,
+  SyntaxKind,
+  type SourceFile,
+  type ImportSpecifierStructure,
+} from 'ts-morph';
+import { buildSymbolMap, type SymbolMap } from './build-symbol-map.js';
+
+const PACKAGE = '@tzurot/common-types';
+
+export interface CodemodReport {
+  filesChanged: number;
+  importsRewritten: number;
+  exportsRewritten: number;
+  inlineTypesRewritten: number;
+  namespaceImports: string[];
+  wildcardReExports: string[];
+  unresolved: string[];
+}
+
+function isBarrelSpecifier(spec: string): boolean {
+  return spec === PACKAGE;
+}
+
+/** Rewrite `import { … } from '@tzurot/common-types'` → grouped deep imports. */
+function rewriteImportDeclarations(sf: SourceFile, map: SymbolMap, report: CodemodReport): void {
+  const barrelImports = sf
+    .getImportDeclarations()
+    .filter(i => isBarrelSpecifier(i.getModuleSpecifierValue()));
+  // Process bottom-to-top so earlier statements keep their child index while we
+  // remove-then-insert (net +N-1 statements) at each site.
+  barrelImports.reverse();
+  for (const imp of barrelImports) {
+    const ns = imp.getNamespaceImport();
+    if (ns !== undefined) {
+      report.namespaceImports.push(`${sf.getFilePath()} :: import * as ${ns.getText()}`);
+      continue;
+    }
+    const named = imp.getNamedImports();
+    if (named.length === 0) continue; // bare side-effect import — nothing to route
+    const importIsTypeOnly = imp.isTypeOnly();
+
+    const groups = new Map<string, ImportSpecifierStructure[]>();
+    let unresolved = false;
+    for (const spec of named) {
+      const name = spec.getName();
+      const entry = map.get(name);
+      if (entry === undefined) {
+        report.unresolved.push(`${sf.getFilePath()} :: import ${name}`);
+        unresolved = true;
+        break;
+      }
+      const arr = groups.get(entry.subpath) ?? [];
+      arr.push({
+        name,
+        alias: spec.getAliasNode()?.getText(),
+        isTypeOnly: spec.isTypeOnly(),
+      });
+      groups.set(entry.subpath, arr);
+    }
+    if (unresolved) continue; // leave the original import in place, flagged
+
+    const structures = [...groups.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([subpath, specs]) => ({
+        isTypeOnly: importIsTypeOnly,
+        namedImports: specs,
+        moduleSpecifier: `${PACKAGE}/${subpath}`,
+      }));
+
+    const idx = imp.getChildIndex();
+    imp.remove();
+    sf.insertImportDeclarations(idx, structures);
+    report.importsRewritten += 1;
+  }
+}
+
+/** Rewrite `export { … } from '@tzurot/common-types'` → grouped deep re-exports. */
+function rewriteExportDeclarations(sf: SourceFile, map: SymbolMap, report: CodemodReport): void {
+  const barrelExports = sf
+    .getExportDeclarations()
+    .filter(
+      e =>
+        e.getModuleSpecifierValue() !== undefined &&
+        isBarrelSpecifier(e.getModuleSpecifierValue() as string)
+    );
+  barrelExports.reverse();
+  for (const exp of barrelExports) {
+    if (exp.getNamedExports().length === 0) {
+      // `export * from barrel` — cannot be split into deep paths.
+      report.wildcardReExports.push(`${sf.getFilePath()} :: export *`);
+      continue;
+    }
+    const exportIsTypeOnly = exp.isTypeOnly();
+    const groups = new Map<string, ImportSpecifierStructure[]>();
+    let unresolved = false;
+    for (const spec of exp.getNamedExports()) {
+      const name = spec.getName();
+      const entry = map.get(name);
+      if (entry === undefined) {
+        report.unresolved.push(`${sf.getFilePath()} :: export ${name}`);
+        unresolved = true;
+        break;
+      }
+      const arr = groups.get(entry.subpath) ?? [];
+      arr.push({ name, alias: spec.getAliasNode()?.getText(), isTypeOnly: spec.isTypeOnly() });
+      groups.set(entry.subpath, arr);
+    }
+    if (unresolved) continue;
+
+    const structures = [...groups.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([subpath, specs]) => ({
+        isTypeOnly: exportIsTypeOnly,
+        namedExports: specs,
+        moduleSpecifier: `${PACKAGE}/${subpath}`,
+      }));
+
+    const idx = exp.getChildIndex();
+    exp.remove();
+    sf.insertExportDeclarations(idx, structures);
+    report.exportsRewritten += 1;
+  }
+}
+
+/** Rewrite inline `import('@tzurot/common-types').X` type queries (qualifier only). */
+function rewriteInlineTypeImports(sf: SourceFile, map: SymbolMap, report: CodemodReport): void {
+  for (const node of sf.getDescendantsOfKind(SyntaxKind.ImportType)) {
+    const qualifier = node.getQualifier();
+    if (qualifier === undefined) continue; // bare `import('…')` — owned by the mock transform
+    const argLiteral = node.getArgument().asKind(SyntaxKind.LiteralType)?.getLiteral();
+    const argText = argLiteral?.asKind(SyntaxKind.StringLiteral)?.getLiteralValue();
+    if (argText === undefined || !isBarrelSpecifier(argText)) continue;
+    // First segment of the qualifier is the top-level symbol name.
+    const firstName =
+      qualifier.getFirstDescendantOfKind(SyntaxKind.Identifier)?.getText() ?? qualifier.getText();
+    const entry = map.get(firstName);
+    if (entry === undefined) {
+      report.unresolved.push(`${sf.getFilePath()} :: import('…').${firstName}`);
+      continue;
+    }
+    argLiteral?.asKind(SyntaxKind.StringLiteral)?.setLiteralValue(`${PACKAGE}/${entry.subpath}`);
+    report.inlineTypesRewritten += 1;
+  }
+}
+
+export function runCodemod(pkgDir: string, dryRun: boolean): CodemodReport {
+  const { map } = buildSymbolMap();
+  const project = new Project({
+    skipAddingFilesFromTsConfig: true,
+    compilerOptions: { allowJs: false },
+    manipulationSettings: { quoteKind: QuoteKind.Single },
+  });
+  // Skip codegen output (`_generated/`): those files are rewritten by their
+  // GENERATOR (e.g. client-builder.ts emits the deep import), not by hand — a
+  // codemod edit here would be clobbered on the next `codegen:routes` run.
+  project.addSourceFilesAtPaths([
+    path.join(pkgDir, 'src/**/*.ts'),
+    `!${path.join(pkgDir, 'src/**/*.d.ts')}`,
+    `!${path.join(pkgDir, 'src/**/_generated/**')}`,
+  ]);
+
+  const report: CodemodReport = {
+    filesChanged: 0,
+    importsRewritten: 0,
+    exportsRewritten: 0,
+    inlineTypesRewritten: 0,
+    namespaceImports: [],
+    wildcardReExports: [],
+    unresolved: [],
+  };
+
+  for (const sf of project.getSourceFiles()) {
+    const before = sf.getFullText();
+    rewriteImportDeclarations(sf, map, report);
+    rewriteExportDeclarations(sf, map, report);
+    rewriteInlineTypeImports(sf, map, report);
+    if (sf.getFullText() !== before) {
+      report.filesChanged += 1;
+      if (!dryRun) sf.saveSync();
+    }
+  }
+  return report;
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+  const pkgDir = args.find(a => !a.startsWith('--'));
+  if (pkgDir === undefined) {
+    console.error('Usage: codemod.ts <pkgDir> [--dry-run]');
+    process.exit(1);
+  }
+  const abs = path.resolve(pkgDir);
+  console.log(`\n🔧 Barrel-kill codemod (production half)${dryRun ? ' — DRY RUN' : ''}`);
+  console.log(`   target: ${abs}\n`);
+
+  const r = runCodemod(abs, dryRun);
+
+  console.log(`   files changed:        ${r.filesChanged}`);
+  console.log(`   imports rewritten:    ${r.importsRewritten}`);
+  console.log(`   export-froms:         ${r.exportsRewritten}`);
+  console.log(`   inline type imports:  ${r.inlineTypesRewritten}`);
+  if (r.namespaceImports.length > 0) {
+    console.log(`\n⚠️  Namespace imports (MANUAL — cannot auto-split):`);
+    for (const n of r.namespaceImports) console.log(`   ${n}`);
+  }
+  if (r.wildcardReExports.length > 0) {
+    console.log(`\n⚠️  Wildcard re-exports (MANUAL):`);
+    for (const n of r.wildcardReExports) console.log(`   ${n}`);
+  }
+  if (r.unresolved.length > 0) {
+    console.log(`\n❌ Unresolved names (NOT in barrel map — investigate):`);
+    for (const n of r.unresolved) console.log(`   ${n}`);
+  }
+  if (dryRun) console.log(`\n(dry run — no files written)`);
+}
+
+main();

--- a/scripts/migrations/barrel-kill/codemod.ts
+++ b/scripts/migrations/barrel-kill/codemod.ts
@@ -29,9 +29,12 @@ import {
   QuoteKind,
   SyntaxKind,
   type SourceFile,
+  type OptionalKind,
   type ImportSpecifierStructure,
+  type ExportSpecifierStructure,
 } from 'ts-morph';
 import { buildSymbolMap, type SymbolMap } from './build-symbol-map.js';
+import { rewriteViMocks } from './mock-codemod.js';
 
 const PACKAGE = '@tzurot/common-types';
 
@@ -40,9 +43,19 @@ export interface CodemodReport {
   importsRewritten: number;
   exportsRewritten: number;
   inlineTypesRewritten: number;
+  mocksRewritten: number;
+  mockGroupsEmitted: number;
   namespaceImports: string[];
   wildcardReExports: string[];
+  flagged: string[];
   unresolved: string[];
+  /**
+   * Bare `'@tzurot/common-types'` refs surviving after the AST transforms —
+   * dynamic `import()` calls, string-embedded imports, and barrel-centric test
+   * code the codemod can't rewrite. These keep working under dual-publish but
+   * MUST reach zero (minus an intentional allowlist) before PR 3 drops `"."`.
+   */
+  remainingBareRefs: string[];
 }
 
 function isBarrelSpecifier(spec: string): boolean {
@@ -67,7 +80,7 @@ function rewriteImportDeclarations(sf: SourceFile, map: SymbolMap, report: Codem
     if (named.length === 0) continue; // bare side-effect import — nothing to route
     const importIsTypeOnly = imp.isTypeOnly();
 
-    const groups = new Map<string, ImportSpecifierStructure[]>();
+    const groups = new Map<string, OptionalKind<ImportSpecifierStructure>[]>();
     let unresolved = false;
     for (const spec of named) {
       const name = spec.getName();
@@ -87,17 +100,23 @@ function rewriteImportDeclarations(sf: SourceFile, map: SymbolMap, report: Codem
     }
     if (unresolved) continue; // leave the original import in place, flagged
 
-    const structures = [...groups.entries()]
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([subpath, specs]) => ({
+    const sorted = [...groups.entries()].sort(([a], [b]) => a.localeCompare(b));
+    const first = sorted[0];
+    if (first === undefined) continue;
+    // Mutate the FIRST group INTO the existing import node in place, rather than
+    // remove()+insert. This keeps the node's leading trivia (file-header JSDoc,
+    // and any file-level pragma like `/* eslint-disable */`) attached exactly
+    // once — remove() strips leading comments, and re-attaching them by hand
+    // double-adds a surviving file-level pragma. Remaining groups insert after.
+    imp.set({ moduleSpecifier: `${PACKAGE}/${first[0]}`, namedImports: first[1] });
+    let insertAt = imp.getChildIndex() + 1;
+    for (const [subpath, specs] of sorted.slice(1)) {
+      sf.insertImportDeclaration(insertAt++, {
         isTypeOnly: importIsTypeOnly,
         namedImports: specs,
         moduleSpecifier: `${PACKAGE}/${subpath}`,
-      }));
-
-    const idx = imp.getChildIndex();
-    imp.remove();
-    sf.insertImportDeclarations(idx, structures);
+      });
+    }
     report.importsRewritten += 1;
   }
 }
@@ -119,7 +138,7 @@ function rewriteExportDeclarations(sf: SourceFile, map: SymbolMap, report: Codem
       continue;
     }
     const exportIsTypeOnly = exp.isTypeOnly();
-    const groups = new Map<string, ImportSpecifierStructure[]>();
+    const groups = new Map<string, OptionalKind<ExportSpecifierStructure>[]>();
     let unresolved = false;
     for (const spec of exp.getNamedExports()) {
       const name = spec.getName();
@@ -135,17 +154,20 @@ function rewriteExportDeclarations(sf: SourceFile, map: SymbolMap, report: Codem
     }
     if (unresolved) continue;
 
-    const structures = [...groups.entries()]
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([subpath, specs]) => ({
+    const sorted = [...groups.entries()].sort(([a], [b]) => a.localeCompare(b));
+    const first = sorted[0];
+    if (first === undefined) continue;
+    // Mutate the first group in place (preserves leading trivia — see the import
+    // rewrite above), insert the rest after.
+    exp.set({ moduleSpecifier: `${PACKAGE}/${first[0]}`, namedExports: first[1] });
+    let insertAt = exp.getChildIndex() + 1;
+    for (const [subpath, specs] of sorted.slice(1)) {
+      sf.insertExportDeclaration(insertAt++, {
         isTypeOnly: exportIsTypeOnly,
         namedExports: specs,
         moduleSpecifier: `${PACKAGE}/${subpath}`,
-      }));
-
-    const idx = exp.getChildIndex();
-    exp.remove();
-    sf.insertExportDeclarations(idx, structures);
+      });
+    }
     report.exportsRewritten += 1;
   }
 }
@@ -160,7 +182,7 @@ function rewriteInlineTypeImports(sf: SourceFile, map: SymbolMap, report: Codemo
     if (argText === undefined || !isBarrelSpecifier(argText)) continue;
     // First segment of the qualifier is the top-level symbol name.
     const firstName =
-      qualifier.getFirstDescendantOfKind(SyntaxKind.Identifier)?.getText() ?? qualifier.getText();
+      qualifier.getFirstDescendantByKind(SyntaxKind.Identifier)?.getText() ?? qualifier.getText();
     const entry = map.get(firstName);
     if (entry === undefined) {
       report.unresolved.push(`${sf.getFilePath()} :: import('…').${firstName}`);
@@ -168,6 +190,24 @@ function rewriteInlineTypeImports(sf: SourceFile, map: SymbolMap, report: Codemo
     }
     argLiteral?.asKind(SyntaxKind.StringLiteral)?.setLiteralValue(`${PACKAGE}/${entry.subpath}`);
     report.inlineTypesRewritten += 1;
+  }
+}
+
+/**
+ * Flag lines carrying a BARE `@tzurot/common-types` in MODULE-RESOLUTION syntax
+ * — a dynamic `import('…')` call or a `from '…'` specifier. After the AST pass
+ * rewrites real static imports to deep paths, a surviving bare `from '…'` means
+ * it's string-embedded (e.g. a generated subprocess script). Deliberately does
+ * NOT match prose mentions, package-name strings, or a tool's barrel-detection
+ * literals — only refs that actually resolve the module and would break when
+ * `"."` is dropped. The remaining hits still need human triage (some are
+ * intentional barrel-centric test fixtures → allowlist at PR 3).
+ */
+function scanRemainingBareRefs(filePath: string, text: string, report: CodemodReport): void {
+  const re = /import\s*\(\s*['"`]@tzurot\/common-types['"`]|from\s+['"`]@tzurot\/common-types['"`]/;
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (re.test(lines[i])) report.remainingBareRefs.push(`${filePath}:${i + 1}`);
   }
 }
 
@@ -192,20 +232,33 @@ export function runCodemod(pkgDir: string, dryRun: boolean): CodemodReport {
     importsRewritten: 0,
     exportsRewritten: 0,
     inlineTypesRewritten: 0,
+    mocksRewritten: 0,
+    mockGroupsEmitted: 0,
     namespaceImports: [],
     wildcardReExports: [],
+    flagged: [],
     unresolved: [],
+    remainingBareRefs: [],
   };
 
   for (const sf of project.getSourceFiles()) {
     const before = sf.getFullText();
+    // Mocks first: rewriteViMocks reads the ORIGINAL barrel-specifier vi.mock
+    // calls; the import rewrite doesn't touch them, but ordering keeps intent
+    // clear (test-mock half, then production imports on the same file).
+    rewriteViMocks(sf, map, report);
     rewriteImportDeclarations(sf, map, report);
     rewriteExportDeclarations(sf, map, report);
     rewriteInlineTypeImports(sf, map, report);
-    if (sf.getFullText() !== before) {
+    const after = sf.getFullText();
+    if (after !== before) {
       report.filesChanged += 1;
       if (!dryRun) sf.saveSync();
     }
+    // Text scan for bare barrel refs the AST can't reach. Runs on the FINAL
+    // text of every file (changed or not) so dynamic import() / string-embedded
+    // imports surface — the "grep sweep" the codemod would otherwise hide.
+    scanRemainingBareRefs(sf.getFilePath(), after, report);
   }
   return report;
 }
@@ -228,6 +281,13 @@ function main(): void {
   console.log(`   imports rewritten:    ${r.importsRewritten}`);
   console.log(`   export-froms:         ${r.exportsRewritten}`);
   console.log(`   inline type imports:  ${r.inlineTypesRewritten}`);
+  console.log(
+    `   vi.mocks rewritten:   ${r.mocksRewritten} (→ ${r.mockGroupsEmitted} subpath groups)`
+  );
+  if (r.flagged.length > 0) {
+    console.log(`\n⚠️  Flagged for MANUAL review (${r.flagged.length}):`);
+    for (const n of r.flagged) console.log(`   ${n}`);
+  }
   if (r.namespaceImports.length > 0) {
     console.log(`\n⚠️  Namespace imports (MANUAL — cannot auto-split):`);
     for (const n of r.namespaceImports) console.log(`   ${n}`);
@@ -239,6 +299,13 @@ function main(): void {
   if (r.unresolved.length > 0) {
     console.log(`\n❌ Unresolved names (NOT in barrel map — investigate):`);
     for (const n of r.unresolved) console.log(`   ${n}`);
+  }
+  if (r.remainingBareRefs.length > 0) {
+    console.log(
+      `\n🔎 Remaining BARE barrel refs (dynamic import()/string/barrel-centric — ` +
+        `AST can't rewrite; must clear or allowlist before PR 3 drops "."): ${r.remainingBareRefs.length}`
+    );
+    for (const n of r.remainingBareRefs) console.log(`   ${n.replace(`${process.cwd()}/`, '')}`);
   }
   if (dryRun) console.log(`\n(dry run — no files written)`);
 }

--- a/scripts/migrations/barrel-kill/mock-codemod.ts
+++ b/scripts/migrations/barrel-kill/mock-codemod.ts
@@ -1,0 +1,244 @@
+/**
+ * Barrel-kill codemod — test-mock half.
+ *
+ * `vi.mock(spec)` intercepts ONLY imports of the exact `spec`. Once production
+ * imports move to deep subpaths, a `vi.mock('@tzurot/common-types', factory)`
+ * intercepts nothing the subject imports — so each mock must be re-pointed at
+ * the subpath(s) of the symbols it OVERRIDES. Non-overridden symbols now resolve
+ * from their own (un-mocked) subpaths to the REAL module, so:
+ *   - identity passthroughs (`X: actual.X`) are DROPPED (they resolve real), and
+ *   - the `...actual` spread is mirrored per emitted group (each group spreads
+ *     its OWN subpath's real module).
+ *
+ * The repo's mocks come in exactly two shapes (measured): partial (spread
+ * `...actual` + a few overrides) and full-replacement (no spread). Anything that
+ * doesn't parse to one of those — or an override body that reaches ACROSS
+ * subpaths via `actual.foo` — is FLAGGED and left untouched for manual handling,
+ * never silently mangled.
+ */
+
+import {
+  SyntaxKind,
+  type SourceFile,
+  type Node,
+  type ObjectLiteralExpression,
+  type CallExpression,
+} from 'ts-morph';
+import type { SymbolMap } from './build-symbol-map.js';
+
+const PACKAGE = '@tzurot/common-types';
+
+export interface MockReport {
+  mocksRewritten: number;
+  mockGroupsEmitted: number;
+  flagged: string[]; // files/sites needing manual handling
+  unresolved: string[];
+}
+
+interface FactoryShape {
+  returnObj: ObjectLiteralExpression;
+  actualBinding: string | undefined; // name bound to importOriginal()/importActual()
+  hadSpread: boolean;
+  usesImportActual: boolean; // vi.importActual(...) vs importOriginal(...)
+  paramName: string | undefined; // the arrow param (importOriginal)
+}
+
+/** Locate `vi.mock('@tzurot/common-types', <factory>)` call expressions. */
+function findBarrelMockCalls(sf: SourceFile): CallExpression[] {
+  return sf.getDescendantsOfKind(SyntaxKind.CallExpression).filter(call => {
+    const expr = call.getExpression();
+    if (expr.getText() !== 'vi.mock') return false;
+    const arg0 = call.getArguments()[0];
+    return (
+      arg0 !== undefined && arg0.asKind(SyntaxKind.StringLiteral)?.getLiteralValue() === PACKAGE
+    );
+  });
+}
+
+/** Find the object literal a factory returns (arrow-expr body or block `return`). */
+function getReturnObject(factory: Node): ObjectLiteralExpression | undefined {
+  const arrow =
+    factory.asKind(SyntaxKind.ArrowFunction) ?? factory.asKind(SyntaxKind.FunctionExpression);
+  if (arrow === undefined) return undefined;
+  const body = arrow.getBody();
+  const paren = body.asKind(SyntaxKind.ParenthesizedExpression);
+  if (paren !== undefined) return paren.getExpression().asKind(SyntaxKind.ObjectLiteralExpression);
+  const block = body.asKind(SyntaxKind.Block);
+  if (block === undefined) return undefined;
+  const ret = block.getStatements().find(s => s.getKind() === SyntaxKind.ReturnStatement);
+  return ret
+    ?.asKind(SyntaxKind.ReturnStatement)
+    ?.getExpression()
+    ?.asKind(SyntaxKind.ObjectLiteralExpression);
+}
+
+/** Parse the factory into a normalized shape, or undefined if unrecognized. */
+function analyzeFactory(factory: Node): FactoryShape | undefined {
+  const returnObj = getReturnObject(factory);
+  if (returnObj === undefined) return undefined;
+
+  const arrow =
+    factory.asKind(SyntaxKind.ArrowFunction) ?? factory.asKind(SyntaxKind.FunctionExpression);
+  const paramName = arrow?.getParameters()[0]?.getName();
+
+  // Spread: any `...expr` in the returned object.
+  const spread = returnObj.getProperties().find(p => p.getKind() === SyntaxKind.SpreadAssignment);
+  const hadSpread = spread !== undefined;
+
+  // Find the `const <name> = await (importOriginal|vi.importActual)(...)` binding.
+  let actualBinding: string | undefined;
+  let usesImportActual = false;
+  const block = arrow?.getBody().asKind(SyntaxKind.Block);
+  if (block !== undefined) {
+    for (const stmt of block.getStatements()) {
+      const varDecl = stmt.asKind(SyntaxKind.VariableStatement)?.getDeclarations()[0];
+      const init = varDecl?.getInitializer();
+      const inner = init?.asKind(SyntaxKind.AwaitExpression)?.getExpression() ?? init;
+      const callText = inner?.asKind(SyntaxKind.CallExpression)?.getExpression().getText();
+      if (callText === undefined) continue;
+      if (
+        callText === paramName ||
+        callText.includes('importActual') ||
+        callText.includes('importOriginal')
+      ) {
+        actualBinding = varDecl?.getName();
+        usesImportActual = callText.includes('importActual');
+        break;
+      }
+    }
+  }
+  return { returnObj, actualBinding, hadSpread, usesImportActual, paramName };
+}
+
+interface OverrideProp {
+  text: string; // full property text, e.g. `createLogger: () => ({...})`
+  subpath: string;
+}
+
+/** Is `node` exactly `<actualBinding>.<name>` (identity passthrough)? */
+function isIdentityPassthrough(
+  valueNode: Node | undefined,
+  key: string,
+  actualBinding: string | undefined
+): boolean {
+  if (valueNode === undefined || actualBinding === undefined) return false;
+  const pae = valueNode.asKind(SyntaxKind.PropertyAccessExpression);
+  if (pae === undefined) return false;
+  return pae.getExpression().getText() === actualBinding && pae.getName() === key;
+}
+
+/** Does a value body reach `actualBinding.<foo>` where foo lives in ANOTHER subpath? */
+function hasCrossSubpathActualRef(
+  valueNode: Node | undefined,
+  actualBinding: string | undefined,
+  ownSubpath: string,
+  map: SymbolMap
+): boolean {
+  if (valueNode === undefined || actualBinding === undefined) return false;
+  for (const pae of valueNode.getDescendantsOfKind(SyntaxKind.PropertyAccessExpression)) {
+    if (pae.getExpression().getText() !== actualBinding) continue;
+    const foo = pae.getName();
+    const entry = map.get(foo);
+    if (entry !== undefined && entry.subpath !== ownSubpath) return true;
+  }
+  return false;
+}
+
+function buildGroupMock(
+  subpath: string,
+  props: OverrideProp[],
+  hadSpread: boolean,
+  usesImportActual: boolean
+): string {
+  const spec = `${PACKAGE}/${subpath}`;
+  const body = props.map(p => `    ${p.text},`).join('\n');
+  if (!hadSpread) {
+    return `vi.mock('${spec}', () => ({\n${body}\n}));`;
+  }
+  if (usesImportActual) {
+    return (
+      `vi.mock('${spec}', async () => {\n` +
+      `  const actual = await vi.importActual<typeof import('${spec}')>('${spec}');\n` +
+      `  return {\n    ...actual,\n${body}\n  };\n});`
+    );
+  }
+  return (
+    `vi.mock('${spec}', async importOriginal => {\n` +
+    `  const actual = await importOriginal<typeof import('${spec}')>();\n` +
+    `  return {\n    ...actual,\n${body}\n  };\n});`
+  );
+}
+
+export function rewriteViMocks(sf: SourceFile, map: SymbolMap, report: MockReport): void {
+  const calls = findBarrelMockCalls(sf);
+  // Bottom-to-top so statement indices stay valid across remove+insert.
+  calls.reverse();
+  for (const call of calls) {
+    const factory = call.getArguments()[1];
+    if (factory === undefined) {
+      report.flagged.push(`${sf.getFilePath()} :: vi.mock with no factory (auto-mock)`);
+      continue;
+    }
+    const shape = analyzeFactory(factory);
+    if (shape === undefined) {
+      report.flagged.push(`${sf.getFilePath()} :: unrecognized mock factory shape`);
+      continue;
+    }
+
+    const groups = new Map<string, OverrideProp[]>();
+    let flagFile = false;
+    for (const prop of shape.returnObj.getProperties()) {
+      if (prop.getKind() === SyntaxKind.SpreadAssignment) continue; // handled via hadSpread
+      const key =
+        prop.asKind(SyntaxKind.PropertyAssignment)?.getName() ??
+        prop.asKind(SyntaxKind.ShorthandPropertyAssignment)?.getName() ??
+        prop.asKind(SyntaxKind.MethodDeclaration)?.getName();
+      if (key === undefined) {
+        report.flagged.push(`${sf.getFilePath()} :: exotic mock property`);
+        flagFile = true;
+        break;
+      }
+      const valueNode = prop.asKind(SyntaxKind.PropertyAssignment)?.getInitializer();
+      if (isIdentityPassthrough(valueNode, key, shape.actualBinding)) continue; // drop
+      const entry = map.get(key);
+      if (entry === undefined) {
+        report.unresolved.push(`${sf.getFilePath()} :: mock override ${key}`);
+        flagFile = true;
+        break;
+      }
+      if (hasCrossSubpathActualRef(valueNode, shape.actualBinding, entry.subpath, map)) {
+        report.flagged.push(
+          `${sf.getFilePath()} :: override ${key} reaches actual.* across subpaths`
+        );
+        flagFile = true;
+        break;
+      }
+      const arr = groups.get(entry.subpath) ?? [];
+      arr.push({ text: prop.getText(), subpath: entry.subpath });
+      groups.set(entry.subpath, arr);
+    }
+    if (flagFile) continue; // leave the original mock in place, flagged
+    if (groups.size === 0) {
+      // Every property was an identity passthrough — the mock is a no-op now.
+      report.flagged.push(`${sf.getFilePath()} :: mock had only passthroughs (drop manually)`);
+      continue;
+    }
+
+    const statement = call.getFirstAncestorByKind(SyntaxKind.ExpressionStatement);
+    if (statement === undefined) {
+      report.flagged.push(`${sf.getFilePath()} :: vi.mock not a top-level statement`);
+      continue;
+    }
+    const newMocks = [...groups.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([subpath, props]) =>
+        buildGroupMock(subpath, props, shape.hadSpread, shape.usesImportActual)
+      );
+
+    const idx = statement.getChildIndex();
+    statement.remove();
+    sf.insertStatements(idx, newMocks);
+    report.mocksRewritten += 1;
+    report.mockGroupsEmitted += groups.size;
+  }
+}


### PR DESCRIPTION
## Barrel-kill, PR 1 of 3

Retires the 955-export `@tzurot/common-types` root barrel in favor of deep subpath imports — for TS-server performance and a non-opaque dependency surface (today every consumer can reach every symbol through one `index.ts`). This is the first of a grouped series; **the barrel stays alive** (dual-publish) until the final PR.

### Approach

- **Codemod tooling** (`scripts/migrations/barrel-kill/`, one-off, deleted at the end):
  - `build-symbol-map.ts` — resolves the barrel's **984 public symbols → 108 leaf subpaths** using the compiler's own `getExportSymbols()` as the oracle (curation-respecting; `PrismaClient`/`Prisma` routed to the exposed `services/prisma` leaf, not their internal `generated/prisma` origin). Hard-fails on collisions / keyset asymmetry.
  - `codemod.ts` — rewrites imports / export-froms / inline-type-imports to deep paths, **idempotently** (fires only on the exact root specifier, so it's resumable). Flags namespace imports for manual handling rather than mangling them.
  - `mock-codemod.ts` — splits `vi.mock('@tzurot/common-types', factory)` into one `vi.mock('<deep subpath>', …)` per overridden symbol's subpath, mirroring the `...actual` spread per group and dropping identity passthroughs.
- **Exports map** (dual-publish): per-subtree wildcards + explicit `generated/commandOptions`; root `"."` kept alive so un-migrated services still resolve. `generated/prisma` stays internal.

### Migrated in this PR (all `packages/*`)

`clients`, `embeddings`, `cache-invalidation`, `test-factories`, `test-utils`, `config-resolver`, `conversation-history`, `identity`, `tooling` — each unit-gate green (tooling 1301, cache-invalidation 244, identity 163, config-resolver 147, conversation-history 136, clients 189, …).

### Notable findings

- **Latent tsconfig free-ride:** the barrel was transitively dragging `@types/node` into `clients` (via `services/prisma → pg`). Deep imports don't, so `clients` — which uses `fetch`/`Response`/`URLSearchParams` but never declared `@types/node` — got `types: ["node"]`. Only `clients` needed it; other packages get node types via other surviving imports.
- **Codegen fixed at the source:** `client-builder.ts` now emits the deep `GatewayUser` import (so regeneration stays on deep paths); `_generated/` is excluded from the codemod.
- **test-utils** deliberately avoids depending on common-types (Turbo cycle); added a `@tzurot/common-types/*` wildcard to its spec `paths` (the runtime vitest alias already prefix-matches).

### Verification

`pnpm quality` green; per-package `typecheck` + `typecheck:spec` + `test` green; the pre-push affected build+test (whole repo, since everything depends on common-types) green under `LOW_RESOURCE_MODE=1`.

### Next

PR 2: the three heavy services (`ai-worker`, `api-gateway`, `bot-client`). PR 3: gut `src/index.ts`, drop `"."`, add the regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)