### PR TITLE
chore(repo): sweep epic-phase archaeology from comments + extend temporal check

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -105,11 +105,20 @@ if [ -n "$STAGED_CODE_FILES" ]; then
     # (`Fixes #N`, `Closed #N`, `Caught in round N`) are caught too.
     #
     # Smoke-test after editing TEMPORAL_PATTERN (run in a shell where it's set):
-    #   for s in 'Fixes #42' 'bug #1254' 'the #1254 drift' '(#1254)'; do \
+    #   for s in 'Fixes #42' 'bug #1254' 'the #1254 drift' '(#1254)' \
+    #            'Phase 5b' 'Epic Phase 3' 'Post-Phase 4' 'Phase 6 made X'; do \
     #     echo "$s" | grep -qEi "$TEMPORAL_PATTERN" && echo "catch: $s"; done
-    #   for s in '#FF0000' '#123456' '#123' 'close the door'; do \
+    #   for s in '#FF0000' '#123456' '#123' 'close the door' \
+    #            'Phase 1 (scan)' 'Phase 2 (flush)'; do \
     #     echo "$s" | grep -qEi "$TEMPORAL_PATTERN" || echo "ignore: $s"; done
-    TEMPORAL_PATTERN='PR #[0-9]+|PR-[0-9]+(\.[0-9a-z]+)*|GH-[0-9]+|[Bb]ug #[0-9]+|[Ii]ssue #[0-9]+|\(#[0-9]+\)|(fix(e[sd])?|close[sd]?|resolve[sd]?) #[0-9]+|#[0-9]{4,5}([^0-9]|$)|202[0-9]-[0-9]{2}-[0-9]{2}|Surfaced 202[0-9]|caught in (round|PR )|flagged by (review|PR)|round [0-9]+ (claude-review|review)'
+    #
+    # Epic-phase archaeology: `Phase 5b` / `Epic Phase` / `Post-Phase` name WHICH
+    # epic a change landed in — journey, not invariant (02-code-standards rule).
+    # The letter-suffixed form (`Phase N<letter>`, e.g. `5b`/`5c` — the range is
+    # `[a-z]`, not closed at `c`) + explicit "Epic/Post-Phase" + a bare `Phase N`
+    # followed by a change-verb are caught; bare `Phase N (word)` is NOT
+    # (algorithm phases like `Phase 1 (scan)` describe code, not archaeology).
+    TEMPORAL_PATTERN='PR #[0-9]+|PR-[0-9]+(\.[0-9a-z]+)*|GH-[0-9]+|[Bb]ug #[0-9]+|[Ii]ssue #[0-9]+|\(#[0-9]+\)|(fix(e[sd])?|close[sd]?|resolve[sd]?) #[0-9]+|#[0-9]{4,5}([^0-9]|$)|202[0-9]-[0-9]{2}-[0-9]{2}|Surfaced 202[0-9]|caught in (round|PR )|flagged by (review|PR)|round [0-9]+ (claude-review|review)|Epic Phase|[Pp]ost-[Pp]hase|Phase [0-9]+[a-z]|Phase [0-9]+ (made|added|introduced|landed|removed|renamed|dropped)'
     HAS_VIOLATIONS=0
     VIOLATION_OUTPUT=""
     for file in $STAGED_CODE_FILES; do

--- a/packages/common-types/src/constants/ai.ts
+++ b/packages/common-types/src/constants/ai.ts
@@ -202,7 +202,7 @@ export const MODEL_DEFAULTS = {
  * distinguished only by `kind`.
  *
  * Single source of truth: the Prisma column default, the resolver queries, the
- * `LlmConfigService` filters, and (Phase 2) the slash-command `kind` choices all
+ * `LlmConfigService` filters, and the slash-command `kind` choices all
  * reference this — so adding a modality is a one-line change here, with the type
  * system enforcing exhaustiveness at every switch on a `ConfigKind`.
  */
@@ -505,9 +505,8 @@ export enum AIProvider {
   ElevenLabs = 'elevenlabs',
   ZaiCoding = 'zai-coding',
   /**
-   * Mistral direct API. Authorizes both `/v1/audio/speech` (Voxtral TTS, used
-   * in TTS Engine Upgrade Phase 1) and `/v1/audio/transcriptions` (Voxtral
-   * STT, used in Phase 3). Same key for both endpoints — see
+   * Mistral direct API. Authorizes both `/v1/audio/speech` (Voxtral TTS)
+   * and `/v1/audio/transcriptions` (Voxtral STT). Same key for both endpoints — see
    * `audioProviderKeys` map shape in `ResolvedAuth`.
    */
   Mistral = 'mistral',

--- a/packages/common-types/src/constants/discord.test.ts
+++ b/packages/common-types/src/constants/discord.test.ts
@@ -101,8 +101,8 @@ describe('Discord ID Validation', () => {
   });
 });
 
-// DISCORD_ID_PREFIX, buildDiscordPersonaId, and extractDiscordId were deleted
-// in Identity Epic Phase 4. The `discord:XXXX` format is now strictly internal
+// DISCORD_ID_PREFIX, buildDiscordPersonaId, and extractDiscordId were deleted.
+// The `discord:XXXX` format is now strictly internal
 // to bot-client's ExtendedContextPersonaResolver module; the common-types
 // exports were never used in production code outside that module and
 // lingered as a cross-package API that shouldn't exist. The internal
@@ -275,7 +275,7 @@ describe('DISCORD_PROVIDER_CHOICES', () => {
     // branch, etc.) but the slash-command argument-choices list is missed.
     // Without this assertion, /settings apikey set <provider> silently omits
     // the new provider and users can't add their key — which is exactly what
-    // happened in PR #921 with zai-coding (caught manually 2026-04-27).
+    // happened with zai-coding.
     const enumValues = Object.values(AIProvider) as string[];
     const choiceValues = DISCORD_PROVIDER_CHOICES.map(c => c.value);
 

--- a/packages/common-types/src/schemas/api/llm-config.test.ts
+++ b/packages/common-types/src/schemas/api/llm-config.test.ts
@@ -297,7 +297,7 @@ describe('LLM Config API Contract Tests', () => {
   });
 
   // ==========================================================================
-  // Input Schema Contract Tests (Phase 1 - Service Layer Consolidation)
+  // Input Schema Contract Tests (Service Layer Consolidation)
   // ==========================================================================
 
   describe('ContextSettingsSchema', () => {

--- a/packages/common-types/src/schemas/llmAdvancedParams.test.ts
+++ b/packages/common-types/src/schemas/llmAdvancedParams.test.ts
@@ -651,7 +651,7 @@ describe('LLM Advanced Params Schema', () => {
     it('should contain database-specific keys', () => {
       // These keys exist in LoadedPersonality/ResolvedLlmConfig but not in AdvancedParams
       // Note: memoryScoreThreshold, memoryLimit, maxMessages, maxAge, maxImages
-      // moved to ConfigOverrides cascade (Phase 3 cleanup)
+      // moved to ConfigOverrides cascade
       const dbSpecificKeys = ['contextWindowTokens'];
 
       for (const key of dbSpecificKeys) {

--- a/packages/common-types/src/schemas/llmAdvancedParams.ts
+++ b/packages/common-types/src/schemas/llmAdvancedParams.ts
@@ -414,7 +414,7 @@ export const LLM_CONFIG_OVERRIDE_KEYS = [
   // Context window (model-coupled, stays in LlmConfig)
   'contextWindowTokens',
   // Note: memoryScoreThreshold, memoryLimit, maxMessages, maxAge, maxImages
-  // have been moved to ConfigOverrides cascade (Phase 3 cleanup).
+  // have been moved to ConfigOverrides cascade.
   // They remain on the LlmConfig DB schema but are no longer read by the resolver.
 ] as const;
 

--- a/packages/common-types/src/services/TtsConfigMapper.ts
+++ b/packages/common-types/src/services/TtsConfigMapper.ts
@@ -56,7 +56,7 @@ export interface MappedTtsConfigWithName {
  *
  * - `provider` is narrowed from `string` to `TtsProviderId` via the shared
  *   `isTtsProviderId` type guard from `TtsProvider.ts` — single source of
- *   truth so future provider additions (NeuTTS Air in Phase 2) don't
+ *   truth so future provider additions (e.g. NeuTTS Air) don't
  *   require updating both places. Non-matching values fall back silently
  *   to `'self-hosted'` (no logging) — DB rows with stale provider strings
  *   shouldn't crash the cascade. The dispatcher will produce a normal

--- a/packages/common-types/src/services/schemaInvariants.component.test.ts
+++ b/packages/common-types/src/services/schemaInvariants.component.test.ts
@@ -1,11 +1,10 @@
 /**
- * Regression guard: Phase 5 DB-level schema invariants
+ * Regression guard: DB-level schema invariants
  *
- * Phase 5 of the Identity & Provisioning Hardening Epic added two CHECK
- * constraints on `personas.name` as defense-in-depth tripwires against the
- * original `c88ae5b7` snowflake-as-persona-name bug class. These live at
- * the schema level (not in Prisma), so application-layer tests don't cover
- * them.
+ * Two CHECK constraints on `personas.name` act as defense-in-depth tripwires
+ * against the original `c88ae5b7` snowflake-as-persona-name bug class. These
+ * live at the schema level (not in Prisma), so application-layer tests don't
+ * cover them.
  *
  * Migration: `prisma/migrations/20260416164756_identity_epic_phase_5_db_invariants/migration.sql`
  *
@@ -24,12 +23,8 @@
  * migration SQL still contains the CHECK DDL strings. A future migration
  * that accidentally drops the constraints (or a `drift-ignore.json` rule
  * that over-matches the DROP pattern) would produce the exact class of
- * silent regression the original Phase 5 work was guarding against.
+ * silent regression these constraints guard against.
  * Pinning the DDL text in a test pins the invariant.
- *
- * Descoped from Phase 6 per council review (2026-04-23) because it's
- * orthogonal to the "catch Phase 5c drift" goal — shipped as a separate
- * quick win in the same session.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -50,7 +45,7 @@ const MIGRATION_SQL_PATH = join(
   'migration.sql'
 );
 
-describe('Phase 5 DB-level schema invariants (structural guard)', () => {
+describe('DB-level schema invariants (structural guard)', () => {
   const migrationSql = readFileSync(MIGRATION_SQL_PATH, 'utf8');
 
   it('migration file exists and is non-empty', () => {
@@ -67,8 +62,8 @@ describe('Phase 5 DB-level schema invariants (structural guard)', () => {
 
     it('uses TRIM + LENGTH to reject empty-or-whitespace names', () => {
       // Pin the specific shape — a naive CHECK on `name <> ''` would pass
-      // whitespace-only names through, which was specifically the bug
-      // Phase 5 was guarding against.
+      // whitespace-only names through, which is specifically the bug
+      // these constraints guard against.
       expect(migrationSql).toMatch(/LENGTH\(TRIM\("name"\)\)\s*>\s*0/);
     });
   });
@@ -89,7 +84,7 @@ describe('Phase 5 DB-level schema invariants (structural guard)', () => {
   });
 
   it('adds both constraints via ALTER TABLE ADD CONSTRAINT (not inline in CREATE TABLE)', () => {
-    // Phase 5 constraints were deliberately added via ALTER after-the-fact
+    // The constraints were deliberately added via ALTER after-the-fact
     // rather than embedded in the personas table creation — the distinction
     // matters because a future prisma-generated migration that recreates
     // the personas table would drop the CHECKs and not re-add them. An

--- a/packages/common-types/src/services/tts/TtsProvider.ts
+++ b/packages/common-types/src/services/tts/TtsProvider.ts
@@ -1,12 +1,12 @@
 /**
  * TtsProvider — Generic interface for TTS providers
  *
- * The TTS Engine Upgrade Phase 1 abstraction. Each concrete provider
+ * The TTS Engine Upgrade abstraction. Each concrete provider
  * (`SelfHostedTtsProvider`, `ElevenLabsTtsProvider`, `MistralTtsProvider`)
  * implements this interface; the `TtsDispatcher` walks a fallback chain of
  * providers determined by `TtsConfigResolver`.
  *
- * Design notes (from three-council reconciled review, 2026-05-01):
+ * Design notes (from three-council reconciled review):
  *
  *   - **`PreparedTts` is opaque + branded** — discriminated union unifies
  *     stateful (voice-id) and stateless (inline-audio) providers under one

--- a/packages/common-types/src/types/api-types.test.ts
+++ b/packages/common-types/src/types/api-types.test.ts
@@ -6,7 +6,7 @@
  * and types for HTTP requests/responses, catching breaking changes during refactoring.
  *
  * WHY THIS IS CRITICAL:
- * - Phase 1 will refactor the database schema extensively
+ * - The database schema undergoes extensive refactoring
  * - API requests/responses reference database entities (Personality, User, etc.)
  * - Schema changes could silently break API contracts
  * - These tests catch those breaks at build time

--- a/packages/common-types/src/types/gateway-context.ts
+++ b/packages/common-types/src/types/gateway-context.ts
@@ -9,7 +9,7 @@
  * - bot-client constructs `GatewayUser` from Discord interaction/message
  *   objects via its local `toGatewayUser(DiscordUser)` helper.
  * - api-gateway middleware reads the headers and reconstructs `GatewayUser`
- *   for provisioning (Identity Epic Phase 5c PR B).
+ *   for provisioning.
  *
  * Keeping the type in common-types means both sides agree on field names
  * and semantics by compile-time contract, not convention.

--- a/packages/common-types/src/types/jobs.test.ts
+++ b/packages/common-types/src/types/jobs.test.ts
@@ -6,7 +6,7 @@
  * and types, catching breaking changes during refactoring.
  *
  * WHY THIS IS CRITICAL:
- * - Phase 1 will refactor the database schema extensively
+ * - The database schema undergoes extensive refactoring
  * - Job payloads reference database entities (Personality, User, etc.)
  * - Schema changes could silently break job contracts
  * - This test catches those breaks at build time

--- a/packages/common-types/src/types/jobs.ts
+++ b/packages/common-types/src/types/jobs.ts
@@ -426,7 +426,7 @@ const baseJobDataSchema = z.object({
   jobType: z.nativeEnum(JobType),
   responseDestination: responseDestinationSchema,
   userApiKey: z.string().optional(),
-  /** Schema version for backward compatibility (Phase 1 migrations) */
+  /** Schema version for backward compatibility */
   version: z.literal(1).default(1),
 });
 

--- a/packages/common-types/src/types/schemas/personality.ts
+++ b/packages/common-types/src/types/schemas/personality.ts
@@ -47,7 +47,7 @@ export const loadedPersonalitySchema = z.object({
   visionModel: z.string().optional(),
   /**
    * Ordered vision-model fallback chain the worker retries down when the primary
-   * vision model FAILS at runtime (Phase 4 auto-fallback). Gateway-stamped from the
+   * vision model FAILS at runtime (auto-fallback). Gateway-stamped from the
    * DB-resolved defaults (`AdminSettings.globalDefaultVisionConfigId` →
    * `freeDefaultVisionConfigId`) since the worker has no Prisma — all DB resolution
    * stays gateway-side, the worker just walks the list. Absent/empty = no admin

--- a/packages/common-types/src/utils/extendedContextPersonaResolver.test.ts
+++ b/packages/common-types/src/utils/extendedContextPersonaResolver.test.ts
@@ -402,7 +402,7 @@ describe('ExtendedContextPersonaResolver', () => {
     });
 
     it('should strip unresolved discord: placeholders when userMap is empty', async () => {
-      // Post-Phase-4 contract: the strip pass runs unconditionally. An empty
+      // Contract: the strip pass runs unconditionally. An empty
       // userMap means zero users got provisioned — every discord: placeholder
       // is unresolvable and must be stripped to '' so ai-worker never sees
       // the format. messageCount/reactorCount count resolved entries (zero

--- a/packages/config-resolver/src/VisionConfigResolver.ts
+++ b/packages/config-resolver/src/VisionConfigResolver.ts
@@ -19,7 +19,7 @@
  * Phase-1 scope: this resolves the PAID vision default for the no-override case. The
  * GUEST downgrade stays downstream (AuthStep + selectVisionModel → VISION_FALLBACK_FREE);
  * guest-aware DB resolution (consulting a kind='vision' isFreeDefault row) is deferred
- * to Phase 2 alongside the vision editing surface.
+ * alongside the vision editing surface.
  *
  * Sister concerns: `LlmConfigResolver` (text model) and `TtsConfigResolver` (this is
  * templated on TtsConfigResolver, the closest analogue — separate config rows + a
@@ -267,7 +267,7 @@ export class VisionConfigResolver extends BaseConfigResolver<
    * (`freeDefaultVisionConfigId`) — the vision analogue of
    * `LlmConfigResolver.getFreeDefaultConfig`. This is the admin-set free-tier
    * fallback the worker's vision path consults before the hardcoded
-   * `VISION_FALLBACK_FREE` floor (Phase 4). Returns null if no pointer is set
+   * `VISION_FALLBACK_FREE` floor. Returns null if no pointer is set
    * (callers fall through to the hardcoded floor). `source` is 'personality' (the
    * "system default" tier), matching `getGlobalDefaultConfig`.
    */

--- a/packages/conversation-history/src/ConversationHistoryService.component.test.ts
+++ b/packages/conversation-history/src/ConversationHistoryService.component.test.ts
@@ -4,7 +4,7 @@
  * Tests conversation history with REAL database (PGlite in-memory PostgreSQL).
  *
  * WHY THIS IS CRITICAL:
- * - Phase 1 will refactor the database schema extensively
+ * - The database schema undergoes extensive refactoring
  * - ConversationHistoryService is used by every AI interaction
  * - These tests catch breaking changes in conversation history patterns
  * - Ensures CRUD, pagination, and cleanup operations work with real DB
@@ -55,8 +55,8 @@ describe('ConversationHistoryService Component Test', () => {
     // Create Prisma client with PGlite adapter
     prisma = new PrismaClient({ adapter }) as PrismaClient;
 
-    // Seed test data. Phase 5b made users.default_persona_id NOT NULL, so
-    // the user + default persona must be created atomically (CTE helper).
+    // Seed test data. users.default_persona_id is NOT NULL, so the user +
+    // default persona must be created atomically (CTE helper).
     await seedUserWithPersona(prisma, {
       userId: testUserId,
       personaId: testPersonaId,

--- a/packages/conversation-history/src/ConversationRetentionService.component.test.ts
+++ b/packages/conversation-history/src/ConversationRetentionService.component.test.ts
@@ -65,15 +65,15 @@ describe('ConversationRetentionService', () => {
   }, 30000);
 
   beforeEach(async () => {
-    // Clear tables between tests. After Phase 5 (Restrict FK on
-    // users.default_persona_id) we delete users FIRST — the Cascade on
+    // Clear tables between tests. Because of the Restrict FK on
+    // users.default_persona_id we delete users FIRST — the Cascade on
     // persona.owner_id removes personas in the same statement.
     await prisma.conversationHistoryTombstone.deleteMany();
     await prisma.conversationHistory.deleteMany();
     await prisma.personality.deleteMany();
     await prisma.user.deleteMany();
 
-    // Create test user + default persona atomically (Phase 5b NOT NULL).
+    // Create test user + default persona atomically (default_persona_id is NOT NULL).
     await seedUserWithPersona(prisma, {
       userId: testUserId,
       personaId: testPersonaId,

--- a/packages/conversation-history/src/ConversationSyncService.component.test.ts
+++ b/packages/conversation-history/src/ConversationSyncService.component.test.ts
@@ -45,7 +45,7 @@ describe('ConversationSyncService Integration Test', () => {
     // Create Prisma client with PGlite adapter
     prisma = new PrismaClient({ adapter }) as PrismaClient;
 
-    // Seed test data. Phase 5b made users.default_persona_id NOT NULL, so
+    // Seed test data. users.default_persona_id is NOT NULL, so
     // we create the user + persona pair atomically via the CTE helper.
     const now = new Date().toISOString();
     const systemPromptId = '00000000-0000-0000-0000-000000000004';

--- a/packages/identity/src/UserService.component.test.ts
+++ b/packages/identity/src/UserService.component.test.ts
@@ -60,13 +60,13 @@ describe('UserService', () => {
   }, 30000);
 
   beforeEach(async () => {
-    // Clear tables between tests. Post-Phase-5, personas referenced as a
+    // Clear tables between tests. Personas referenced as a
     // user's default can't be deleted directly (Restrict FK). Deleting the
     // user first cascades to their personas (Persona.owner onDelete: Cascade),
     // which Postgres orders correctly within the transaction.
     await prisma.user.deleteMany();
     // Belt-and-suspenders: clean up any orphaned personas (unreachable
-    // post-Phase-5 owner cascade but preserves test isolation if anything
+    // given the owner cascade but preserves test isolation if anything
     // slips through).
     await prisma.persona.deleteMany();
 
@@ -342,8 +342,8 @@ describe('UserService', () => {
     });
   });
 
-  describe('Identity Epic Phase 5 — DB-level invariants', () => {
-    // These tests verify the constraints added in the Phase 5 migration at
+  describe('DB-level invariants', () => {
+    // These tests verify the constraints added in the migration at
     // the DB level. The app layer has its own guards (e.g., crud.ts:254's
     // "Cannot delete your default persona" validation error) — these tests
     // exercise the structural safety net that fires if the app guard is
@@ -356,8 +356,8 @@ describe('UserService', () => {
     // by the real-Postgres migration applies (local + Railway).
 
     it("should reject deleting a persona that is still someone's default (Restrict FK)", async () => {
-      // Pre-Phase-5: this delete would succeed and silently null the FK.
-      // Post-Phase-5: the FK is ON DELETE RESTRICT, so the delete is rejected
+      // Without the Restrict FK, this delete would succeed and silently null the FK.
+      // The FK is ON DELETE RESTRICT, so the delete is rejected
       // at the DB level. Match the violation message rather than a Prisma error
       // code — the driver adapter surfaces FK violations as a raw
       // DriverAdapterError (no `code: P2003`), so the message is the stable

--- a/packages/identity/src/UserService.test.ts
+++ b/packages/identity/src/UserService.test.ts
@@ -48,8 +48,8 @@ describe('UserService', () => {
 
   /**
    * Helper: decode the values passed to a tagged-template $executeRaw call
-   * into an object matching the CTE column order. Phase 5b uses one CTE per
-   * path:
+   * into an object matching the CTE column order. getOrCreateUser uses one
+   * CTE per path:
    *
    *   persona: (id, name, preferred_name, description, content, owner_id)
    *   user:    (id, discord_id, username, is_superuser, default_persona_id)
@@ -110,7 +110,7 @@ describe('UserService', () => {
       userPersonalityConfig: {
         findUnique: vi.fn(),
       },
-      // Phase 5b: user + default persona are created atomically via a single
+      // User + default persona are created atomically via a single
       // CTE. Default mock returns 1 (rows affected) so the happy path doesn't
       // need to configure it per-test.
       $executeRaw: vi.fn().mockResolvedValue(1),
@@ -147,7 +147,7 @@ describe('UserService', () => {
 
   describe('getOrCreateUser', () => {
     it('should return cached user ID if available', async () => {
-      // First call to populate cache. Phase 5b: defaultPersonaId is always
+      // First call to populate cache. defaultPersonaId is always
       // non-null at the type level, so runMaintenanceTasks has no backfill
       // branch — the mock just needs a valid defaultPersonaId to match reality.
       mockPrisma.user.findUnique.mockResolvedValueOnce({

--- a/packages/identity/src/identityProvisioning.component.test.ts
+++ b/packages/identity/src/identityProvisioning.component.test.ts
@@ -2,8 +2,8 @@
  * Integration test: Identity provisioning invariant
  *
  * Covers the `c88ae5b7` regression class — persona data being stale or
- * incorrect after a user is provisioned. The regression shipped in 2025-12
- * when user creation was centralized through `UserService.getOrCreateUser`;
+ * incorrect after a user is provisioned. The regression shipped when
+ * user creation was centralized through `UserService.getOrCreateUser`;
  * it produced wrong `activePersonaId` / `activePersonaName` values in
  * downstream prompt generation, because `PersonaResolver.resolve` could
  * return data that didn't match what `getOrCreateUser` had just created.
@@ -16,11 +16,9 @@
  * The test exercises the real services against a real Postgres-compatible
  * engine (PGlite), so any regression in the Prisma query paths, persona
  * auto-creation invariants, or persona-resolver cache coherence will
- * produce a loud failure here — which is the explicit goal of Phase 6 of
- * the Identity & Provisioning Hardening epic.
+ * produce a loud failure here — which is the explicit goal of this test.
  *
- * Phase 6 goal (epic-identity-hardening.md): "The c88ae5b7 class of
- * regression fails loudly in tests."
+ * The goal (per epic-identity-hardening.md): "The c88ae5b7 class of regression fails loudly in tests."
  */
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
@@ -50,12 +48,12 @@ describe('Identity provisioning integration (c88ae5b7 regression guard)', () => 
 
     // A personality row needs an owner user. Seed a bot-owner user + default
     // persona via the atomic CTE helper (personas and users have mutually
-    // circular FKs post-Phase-5b; direct prisma.user.create no longer works).
+    // circular FKs; direct prisma.user.create no longer works).
     //
     // Inlined rather than importing `seedUserWithPersona` from `@tzurot/test-utils`
     // because that package currently can't be a runtime dep of common-types
-    // without reopening the Turbo build-DAG cycle flagged in Phase 5c work
-    // items. The CTE below is the same SQL the helper uses.
+    // without reopening the Turbo build-DAG cycle. The CTE below is the
+    // same SQL the helper uses.
     await prisma.$executeRawUnsafe(`
       WITH new_persona AS (
         INSERT INTO personas (id, name, preferred_name, description, content, owner_id, updated_at)
@@ -196,7 +194,7 @@ describe('Identity provisioning integration (c88ae5b7 regression guard)', () => 
   });
 
   describe('bot rejection', () => {
-    // Phase 2 invariant (post-c88ae5b7): UserService rejects bot users at
+    // UserService rejects bot users at
     // the provisioning boundary so no persona gets associated with a bot
     // account. This test pins the rejection contract at the integration
     // seam rather than relying on the unit test alone.

--- a/packages/identity/src/personality/PersonalityService.component.test.ts
+++ b/packages/identity/src/personality/PersonalityService.component.test.ts
@@ -47,8 +47,8 @@ describe('PersonalityService', () => {
     // Create Prisma client with PGlite adapter
     prisma = new PrismaClient({ adapter }) as PrismaClient;
 
-    // Seed test data — Phase 5b NOT NULL requires user + default persona
-    // to be created atomically.
+    // Seed test data — default_persona_id is NOT NULL, so user + default
+    // persona must be created atomically.
     await seedUserWithPersona(prisma, {
       userId: testOwnerId,
       personaId: '00000000-0000-0000-0000-0000000000a1',

--- a/packages/identity/src/resolvers/PersonaResolver.test.ts
+++ b/packages/identity/src/resolvers/PersonaResolver.test.ts
@@ -123,7 +123,7 @@ describe('PersonaResolver', () => {
     });
 
     it('should return first owned persona as transient resolution without persisting', async () => {
-      // Phase 3 regression guard: resolution is strictly read-only. When a user
+      // Resolution is strictly read-only. When a user
       // has owned personas but no defaultPersonaId, we pick the first-owned
       // persona for this request only. Persistence is UserService's job (via
       // runMaintenanceTasks → backfillDefaultPersona on the next interaction).
@@ -165,7 +165,7 @@ describe('PersonaResolver', () => {
 
     it('should log error and fall through when defaultPersonaId is dangling', async () => {
       // Schema has onDelete: SetNull, so this shouldn't happen — but we guard
-      // defensively as a precursor signal for Phase 5's NOT NULL FK upgrade.
+      // defensively as a precursor signal for the NOT NULL FK upgrade.
       mockPrismaClient.user.findUnique.mockResolvedValue({
         id: 'user-uuid',
         defaultPersonaId: 'persona-that-was-deleted',
@@ -214,7 +214,7 @@ describe('PersonaResolver', () => {
       expect(result.source).toBe('system-default');
       expect(result.config.personaId).toBe('');
 
-      // Post-Phase-2, every user should have at least one persona. Log at error
+      // Every user should have at least one persona. Log at error
       // level so provisioning bugs surface loudly in logs.
       expect(mockLogger.error).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -564,8 +564,8 @@ describe('PersonaResolver', () => {
       expect(mockPrismaClient.user.findUnique).not.toHaveBeenCalled();
     });
 
-    it('should return null for discord: format with a warn log (post-Phase-4 tripwire)', async () => {
-      // Post-Phase-4, resolveToUuid is UUID-only. The `discord:XXXX`
+    it('should return null for discord: format with a warn log (UUID-only tripwire)', async () => {
+      // resolveToUuid is UUID-only. The `discord:XXXX`
       // format should have been stripped at the bot-client boundary by
       // ExtendedContextPersonaResolver. A non-UUID reaching here signals
       // a regression, so we warn-log for visibility and return null.
@@ -600,7 +600,7 @@ describe('PersonaResolver', () => {
   });
 
   // Note: the "auto-default persistence error handling" describe block was
-  // removed in the Phase 3 refactor. Persistence is no longer part of the
+  // removed. Persistence is no longer part of the
   // resolve() path, so there's no write-failure mode to test here. Provisioning
   // tests live in UserService.test.ts (createUserWithDefaultPersona +
   // backfillDefaultPersona).

--- a/packages/test-utils/src/seed.component.test.ts
+++ b/packages/test-utils/src/seed.component.test.ts
@@ -70,7 +70,7 @@ describe('seedUserWithPersona (integration)', () => {
 
     const persona = await prisma.persona.findUnique({ where: { id: personaId } });
     // The default persona name satisfies the personas_name_not_snowflake
-    // CHECK constraint added in Phase 5 — a bare snowflake would be rejected.
+    // CHECK constraint on personas.name — a bare snowflake would be rejected.
     expect(persona?.name).toBe(`User ${discordId}`);
     expect(persona?.preferredName).toBe(`User ${discordId}`);
     expect(persona?.content).toBe('');

--- a/packages/test-utils/src/seed.ts
+++ b/packages/test-utils/src/seed.ts
@@ -1,7 +1,7 @@
 /**
  * Integration test seed helpers.
  *
- * Phase 5b introduced a structural invariant: every `users` row MUST have a
+ * A structural invariant: every `users` row MUST have a
  * non-null `default_persona_id` pointing to an existing `personas` row whose
  * `owner_id` equals that user's id. Because the two tables have mutually
  * circular FKs, the only way to create a valid pair is via a single-statement
@@ -20,7 +20,7 @@
 // listing test-utils as a devDependency creates a Turbo build-DAG cycle the
 // moment test-utils starts depending on common-types at any level. Breaking
 // it cleanly requires either extracting shared constants to a third package
-// or dropping test-utils out of common-types's devDeps — both are 5c scope.
+// or dropping test-utils out of common-types's devDeps — both are out of scope here.
 interface PrismaExecuteRaw {
   $executeRaw: (query: TemplateStringsArray, ...values: unknown[]) => Promise<number>;
 }
@@ -71,7 +71,7 @@ export async function seedUserWithPersona(
     // Mirrors `DEFAULT_PERSONA_DESCRIPTION` in
     // `common-types/src/constants/persona.ts`. Can't import the constant
     // directly — see the comment at the top of this file for why. Keep the
-    // two values in sync until Phase 5c breaks the Turbo build-DAG cycle.
+    // two values in sync until the Turbo build-DAG cycle is broken.
     personaDescription = 'Default persona',
   } = options;
 

--- a/services/ai-worker/src/jobs/AIJobProcessor.component.test.ts
+++ b/services/ai-worker/src/jobs/AIJobProcessor.component.test.ts
@@ -96,7 +96,7 @@ describe('AIJobProcessor Component Test', () => {
 
     // Seed test data (using deterministic UUIDs for consistency)
 
-    // Create test user + default persona atomically (Phase 5b NOT NULL).
+    // Create test user + default persona atomically (default_persona_id is NOT NULL).
     const testDiscordId = 'test-discord-id';
     const testUserId = generateUserUuid(testDiscordId);
     await seedUserWithPersona(prisma, {

--- a/services/ai-worker/src/jobs/handlers/LLMGenerationHandler.ts
+++ b/services/ai-worker/src/jobs/handlers/LLMGenerationHandler.ts
@@ -134,7 +134,7 @@ export class LLMGenerationHandler {
     //   pre-downloaded bytes instead of re-fetching per attachment.
     // - DependencyStep: Fetches preprocessing results AND processes extended context attachments.
     //   Runs after AuthStep because extended context vision processing needs the user's BYOK key
-    //   to avoid leaking system API keys (see PR #447 for BYOK security fix).
+    //   to avoid leaking system API keys.
     //   DependencyStep only reads from Redis (preprocessing jobs) and calls MultimodalProcessor,
     //   neither of which depend on running before Config/Auth.
     // - ContextStep: Builds conversation history (needs preprocessing from DependencyStep)
@@ -231,8 +231,8 @@ export class LLMGenerationHandler {
       // Classify the failure for the bot's user-facing error message. Without
       // an `errorInfo` field, bot-client's `buildErrorContent` falls through
       // to a generic "Sorry, I encountered an error" with no spoiler-tag
-      // detail — observed during the 2026-04-25 attachment incident, where
-      // users had no visible signal about what actually broke. Map known
+      // detail, leaving users with no visible signal about what actually
+      // broke. Map known
       // failed-step values to their user-facing categories; everything else
       // surfaces as UNKNOWN with the technical message in the spoiler.
       const category =

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.ts
@@ -89,7 +89,7 @@ export class AuthStep implements IPipelineStep {
         );
       }
 
-      // Mistral (new — TTS Phase 1). Same shape: failure to resolve is logged
+      // Mistral (new). Same shape: failure to resolve is logged
       // and tolerated; the dispatcher will skip Mistral providers when its
       // entry is missing from the map.
       try {

--- a/services/ai-worker/src/services/DuplicateDetectionFlow.component.test.ts
+++ b/services/ai-worker/src/services/DuplicateDetectionFlow.component.test.ts
@@ -10,7 +10,7 @@
  * Purpose: Verify that role values ('assistant'/'user') are preserved
  * correctly through the entire pipeline, enabling duplicate detection.
  *
- * Background: January 2026 production incident where duplicate detection
+ * Background: a production incident where duplicate detection
  * failed despite conversation history being present. This test validates
  * the data flow to catch any serialization or type issues.
  */
@@ -54,7 +54,7 @@ describe('Duplicate Detection Data Flow', () => {
     prisma = new PrismaClient({ adapter }) as PrismaClient;
     conversationService = new ConversationHistoryService(prisma);
 
-    // Seed required FK records. Phase 5b: user + default persona must be
+    // Seed required FK records. User + default persona must be
     // created atomically because users.default_persona_id is NOT NULL.
     await seedUserWithPersona(prisma, {
       userId: testUserId,

--- a/services/ai-worker/src/services/LongTermMemoryService.component.test.ts
+++ b/services/ai-worker/src/services/LongTermMemoryService.component.test.ts
@@ -88,13 +88,13 @@ describe('LongTermMemoryService', () => {
   }, 30000);
 
   beforeEach(async () => {
-    // Clear tables. Phase 5 Restrict FK means we delete users first — the
+    // Clear tables. The Restrict FK means we delete users first — the
     // Cascade on persona.owner_id removes personas in the same statement.
     await prisma.pendingMemory.deleteMany();
     await prisma.personality.deleteMany();
     await prisma.user.deleteMany();
 
-    // Create test user + default persona atomically (Phase 5b NOT NULL).
+    // Create test user + default persona atomically (default_persona_id is NOT NULL).
     await seedUserWithPersona(prisma, {
       userId: testUserId,
       personaId: testPersonaId,

--- a/services/ai-worker/src/services/MemoryRetriever.ts
+++ b/services/ai-worker/src/services/MemoryRetriever.ts
@@ -249,7 +249,7 @@ export class MemoryRetriever {
    *   - Active speaker: from activePersonaGuildInfo
    *   - Other participants: from participantGuildInfo (when extended context is enabled)
    *
-   * Post-Phase-4 contract: `participant.personaId` is always either a valid
+   * Contract: `participant.personaId` is always either a valid
    * UUID (DB history or resolved extended context) or the empty-string
    * sentinel (unresolvable extended-context participant). The legacy
    * `discord:XXXX` placeholder format is stripped by bot-client's
@@ -280,7 +280,7 @@ export class MemoryRetriever {
 
     // Fetch content for each participant
     for (const participant of context.participants) {
-      // Post-Phase-4 contract: personaId is always a UUID (from DB history
+      // Contract: personaId is always a UUID (from DB history
       // or resolved extended context) OR the empty string sentinel (for
       // extended-context messages whose author couldn't be resolved to a
       // registered persona). resolveToUuid is now a UUID-or-null guard —
@@ -366,7 +366,7 @@ export class MemoryRetriever {
       // Include guild info:
       // - For active speaker: use activePersonaGuildInfo (from triggering message)
       // - For other participants: look up in participantGuildInfo (from extended context)
-      // Keys in participantGuildInfo are UUIDs post-Phase-4 (remapped by
+      // Keys in participantGuildInfo are UUIDs (remapped by
       // ExtendedContextPersonaResolver alongside the persona resolution pass).
       let guildInfo;
       if (participant.isActive) {

--- a/services/ai-worker/src/services/PgvectorMemoryAdapter.component.test.ts
+++ b/services/ai-worker/src/services/PgvectorMemoryAdapter.component.test.ts
@@ -73,7 +73,7 @@ describe('PgvectorMemoryAdapter Component Test', () => {
     const pgliteAdapter = new PrismaPGlite(pglite);
     prisma = new PrismaClient({ adapter: pgliteAdapter }) as PrismaClient;
 
-    // Seed test data. Phase 5b: user + default persona must be created
+    // Seed test data. User + default persona must be created
     // atomically via the CTE helper (users.default_persona_id is NOT NULL).
     const systemPromptId = '00000000-0000-0000-0000-000000000004';
 

--- a/services/ai-worker/src/services/context/ContextAssembler.component.test.ts
+++ b/services/ai-worker/src/services/context/ContextAssembler.component.test.ts
@@ -8,7 +8,7 @@
  * and assert the assembler re-derives the core surfaces from actual DB state.
  *
  * This is the real-data third of the producer→schema→consumer contract that the
- * 2.5d Prisma-eviction epic deleted bot-client code against on the claim "the
+ * Prisma-eviction epic deleted bot-client code against on the claim "the
  * worker re-derives identical context from rawAssemblyInputs":
  *  - producer half  → RawEnvelopeBuilder.test.ts (real builder conforms to schema)
  *  - mocked consumer → ContextAssembler.test.ts (assembleCore over faithful doubles)
@@ -60,7 +60,7 @@ describe('ContextAssembler.assembleCore — PGLite component', () => {
     await pglite.exec(loadPGliteSchema());
     prisma = new PrismaClient({ adapter: new PrismaPGlite(pglite) }) as PrismaClient;
 
-    // User + default persona (Phase 5b: the pair must be created atomically).
+    // User + default persona (the pair must be created atomically).
     userId = generateUserUuid(DISCORD_USER_ID);
     personaId = generatePersonaUuid('test-user', userId);
     await seedUserWithPersona(prisma, {

--- a/services/ai-worker/src/services/multimodal/VisionProcessor.ts
+++ b/services/ai-worker/src/services/multimodal/VisionProcessor.ts
@@ -159,7 +159,7 @@ export interface DescribeImageOptions {
   /**
    * When true, a failure (fresh API error OR negative-cache hit) THROWS a typed
    * `VisionModelError` instead of returning a `[Image unavailable: …]` placeholder string.
-   * The Phase-4 fallback loop sets this so it can catch the category and decide
+   * The fallback loop sets this so it can catch the category and decide
    * terminate-vs-advance; every legacy caller omits it and keeps the string-returning
    * behavior. (A fresh invocation error already propagates as `VisionModelError` in both
    * modes — this flag only governs the negative-cache-hit path's throw-vs-return.)
@@ -280,7 +280,7 @@ async function invokeVisionModel(
   // do not initiate the fetch — the provider does, on their hardened infra —
   // so there is no SSRF execution surface on our stack; and (b) the only
   // attacker-controlled URL injection vector is via Discord embed/attachment
-  // shapes, which limits practical exploitation. Council-reviewed 2026-04-25.
+  // shapes, which limits practical exploitation. Council-reviewed.
   //
   // Behavior note: `new URL().toString()` is NOT equivalent to
   // `validateAttachmentUrl` minus the allowlist — that helper also stripped
@@ -698,7 +698,7 @@ export async function describeImage(
     { longTtlOnly: options?.skipNegativeCache === true }
   );
   if (cachedCategory !== null) {
-    // A cached failure for this (model, attachment). The Phase-4 fallback loop
+    // A cached failure for this (model, attachment). The fallback loop
     // (throwOnFailure) wants the typed error so it can advance tiers / render the terminal
     // placeholder; legacy single-model callers get the rendered placeholder string as before.
     if (options?.throwOnFailure === true) {

--- a/services/ai-worker/src/services/multimodal/describeImageWithFallback.ts
+++ b/services/ai-worker/src/services/multimodal/describeImageWithFallback.ts
@@ -1,5 +1,5 @@
 /**
- * Vision fallback loop — Phase 4.
+ * Vision fallback loop.
  *
  * Wraps the single-model `describeImage` with a runtime retry-down-the-chain: when the
  * chosen vision model FAILS on a RETRYABLE category, try the next fallback tier (the

--- a/services/ai-worker/src/services/multimodal/visionAuthResolver.ts
+++ b/services/ai-worker/src/services/multimodal/visionAuthResolver.ts
@@ -225,7 +225,7 @@ async function resolveBroadFreeFallback(
 
 /**
  * Resolve the API key + provider for a SPECIFIC vision model. Parameterized by the
- * target model so a caller can resolve auth for ANY tier (Phase 4's runtime fallback
+ * target model so a caller can resolve auth for ANY tier (the runtime fallback
  * loop), not just the primary — a cross-provider fallback and a free-tier downgrade
  * each need their own key. `resolveVisionConfig` is the primary-model entry point that
  * computes the natural model then delegates here.
@@ -389,7 +389,7 @@ export async function resolveVisionAuth(
 /**
  * Resolve the API key + provider + model for the PRIMARY vision call atomically.
  * Computes the natural vision model via `selectVisionModel`, then delegates auth
- * resolution to `resolveVisionAuth`. (Phase 4's fallback loop calls `resolveVisionAuth`
+ * resolution to `resolveVisionAuth`. (the fallback loop calls `resolveVisionAuth`
  * directly, once per tier, with that tier's model.)
  */
 export async function resolveVisionConfig(

--- a/services/ai-worker/src/services/prompt/HardcodedConstraints.test.ts
+++ b/services/ai-worker/src/services/prompt/HardcodedConstraints.test.ts
@@ -54,7 +54,7 @@ describe('HardcodedConstraints', () => {
 
     it('should prohibit leaking specific input-format scaffolding tags', () => {
       // Concrete named prohibitions land harder than abstract "XML" for
-      // RLHF-fighting models (validated via MCP council, 2026-04-22).
+      // RLHF-fighting models (validated via MCP council).
       // Addresses the GLM-4.5-Air fake-user-message-echo quirk observed
       // in req b533e288-fb07-46c0-a5e2-a0f78883e63e.
       expect(OUTPUT_CONSTRAINTS).toContain('<from_id>');

--- a/services/ai-worker/src/services/voice/MistralTtsClient.ts
+++ b/services/ai-worker/src/services/voice/MistralTtsClient.ts
@@ -48,7 +48,7 @@ const VOICE_LIST_PAGE_SIZE = 50;
  * duration > 30s using HTTP 400 ("Reference audio duration {N}s exceeds the
  * maximum allowed duration of 30.0s"). The provider pre-flight-checks this
  * locally to avoid the wasted round-trip + negative-cache poisoning that the
- * reactive path produces. Empirically observed in prod 2026-05-04 via the
+ * reactive path produces. Empirically observed in prod via the
  * `ha-shem-keev-ima` slug (31.78s reference).
  */
 export const MISTRAL_MAX_REFERENCE_AUDIO_SEC = 30;

--- a/services/ai-worker/src/services/voice/providers/ElevenLabsTtsProvider.ts
+++ b/services/ai-worker/src/services/voice/providers/ElevenLabsTtsProvider.ts
@@ -8,7 +8,7 @@
  * the cloned voice's id; `synthesize()` posts to `elevenLabsTTS`.
  *
  * Adds an **eviction mutex** that serializes `prepare()` calls per-instance
- * (per the three-council reconciled design, 2026-05-01). Without it, two
+ * (per the three-council reconciled design). Without it, two
  * concurrent `prepare()` calls for the SAME slug at fresh-account state
  * could both list, both not find the voice, and both POST a clone —
  * producing duplicate `tzurot-X` voices in the user's account. The mutex

--- a/services/ai-worker/src/services/voice/providers/MistralTtsProvider.ts
+++ b/services/ai-worker/src/services/voice/providers/MistralTtsProvider.ts
@@ -15,7 +15,7 @@
  *      `POST /v1/audio/voices`, cache the returned voice_id
  *   6. **Eviction mutex** serializes the list-then-clone critical section to
  *      prevent the concurrent-clone-double-write race (per three-council
- *      reconciled design 2026-05-01)
+ *      reconciled design)
  *
  * Mistral slot quota behavior is undocumented (smoke test didn't probe). If
  * a future MistralApiError surfaces a slot-limit error, eviction code is

--- a/services/ai-worker/src/services/voice/providers/SelfHostedTtsProvider.ts
+++ b/services/ai-worker/src/services/voice/providers/SelfHostedTtsProvider.ts
@@ -59,7 +59,7 @@ export class SelfHostedTtsProvider implements TtsProvider {
   /**
    * Self-hosted handles any TTS config that names provider 'self-hosted'.
    * Provider-specific knobs (e.g. selfHostedEngine: 'kyutai' | 'neutts-air'
-   * once Phase 2 lands) get parsed from `config.advancedParameters` inside
+   * once those engines land) get parsed from `config.advancedParameters` inside
    * `synthesize`, not here.
    */
   canHandle(config: ResolvedTtsConfig, _ctx: TtsContext): boolean {
@@ -74,7 +74,7 @@ export class SelfHostedTtsProvider implements TtsProvider {
    * Calls `waitForVoiceEngine` before registration to absorb Railway
    * Serverless cold-start (~56s observed). Without this, `ensureVoiceRegistered`
    * runs into the cold-start delay during a much shorter HTTP timeout
-   * and fails. Pre-PR-2 this happened in `TTSStep.performVoiceEngineTTS`;
+   * and fails. Previously this happened in `TTSStep.performVoiceEngineTTS`;
    * the dispatcher refactor moved the responsibility into the provider
    * since only this provider talks to voice-engine.
    */

--- a/services/ai-worker/src/services/voice/ttsSynthesizer.test.ts
+++ b/services/ai-worker/src/services/voice/ttsSynthesizer.test.ts
@@ -131,13 +131,13 @@ describe('splitTextIntoChunks', () => {
   });
 
   describe('FormData CRLF expansion safety', () => {
-    // Production root cause confirmed 2026-04-30 via council analysis:
+    // Root cause (confirmed via council analysis):
     // multipart/form-data spec mandates `\n` → `\r\n` normalization before
     // serialization (WHATWG HTML standard, RFC 7578). Node's built-in
     // FormData implements this. So a JS-side 2000-char chunk containing N
     // newlines becomes a 2000+N-char payload on the wire, and Python's
-    // voice-engine `len(text)` check rejects it. The historical "off-by-six"
-    // (2026-04-27) and today's "off-by-one" (2026-04-30) both fit:
+    // voice-engine `len(text)` check rejects it. The "off-by-six"
+    // and "off-by-one" failure modes both fit:
     // off-by-N = newline count.
     //
     // Existing tests use `'A'.repeat(2000)` which has zero newlines, so
@@ -255,7 +255,7 @@ describe('enforceChunkLengthCap', () => {
 
   it('should truncate any chunk exceeding the cap to MAX_CHUNK_LENGTH', () => {
     // Synthetic over-cap input — the production-failing shape was 2006 chars
-    // against the 2000 cap (Lilith observation 2026-04-27).
+    // against the 2000 cap.
     const oversized = 'A'.repeat(2006);
     const result = enforceChunkLengthCap([oversized]);
 

--- a/services/ai-worker/src/utils/duplicateDetection.test.ts
+++ b/services/ai-worker/src/utils/duplicateDetection.test.ts
@@ -515,7 +515,7 @@ describe('isRecentDuplicate', () => {
 });
 
 /**
- * Production Scenario Tests (January 2026 Incident)
+ * Production Scenario Tests
  *
  * Tests based on real production incident where Katie Killjoy gave the
  * exact same 270-token response to two different user messages 11 minutes apart.
@@ -623,7 +623,7 @@ Now sit there, be quiet, and try to learn something about how a real professiona
 
     it('should detect a verbatim regurgitation from far back in history', () => {
       // Regression for the `glm-4.5-air:free` 13-day-old regurgitation
-      // incident (2026-04-20). The old 5-message cap silently dropped any
+      // incident. The old 5-message cap silently dropped any
       // assistant turn beyond the 5th most recent, so a model that
       // regurgitated a 10-turn-old response would pass detection.
       const OLD_REGURGITATED_RESPONSE =

--- a/services/ai-worker/src/utils/thinkingExtraction.test.ts
+++ b/services/ai-worker/src/utils/thinkingExtraction.test.ts
@@ -674,7 +674,7 @@ def hello():
   });
 
   describe('GLM-4.5-Air fake-user-message-echo pattern', () => {
-    // Observed 2026-04-22 (req b533e288-fb07-46c0-a5e2-a0f78883e63e).
+    // Observed in production (req b533e288-fb07-46c0-a5e2-a0f78883e63e).
     // Model emitted chain-of-thought wrapped in tags that mimic our
     // prompt-assembly format. Three structural rules protect extraction
     // safety: start-of-response anchor, UUID shape, strict tag sequence.
@@ -839,7 +839,7 @@ Response.`;
     });
 
     it('pins the Pass-1/Pass-2 double-extraction edge case for nested <think> tags', () => {
-      // Reviewer flagged (PR #875 round 3, 2026-04-22): Pass 2 reads from
+      // Pass 2 reads from
       // `normalized` (pre-Pass-1-strip), so if a Pass-1 <message> block
       // contains a Pass-2 tag (like <think>), the inner content ends up in
       // `thinkingParts` twice — once as part of the whole <message> block
@@ -894,7 +894,7 @@ Response.`;
   });
 
   describe('Standalone <from_id> echo pattern (GLM-4.7 bare-from-id leak)', () => {
-    // Observed 2026-04-30 in production. GLM-4.7 emitted just
+    // Observed in production. GLM-4.7 emitted just
     // <from_id>UUID</from_id> followed by the response, without the rest of
     // the 4.5-Air vocabulary (<user>, <message>). The 4.5-Air full-sequence
     // pattern requires all three tags and silently passes through this bare
@@ -981,7 +981,7 @@ Response.`;
   });
 
   describe('GLM-4.7 meta-preamble pattern', () => {
-    // Observed 2026-04-24 (req 9b2aa0f3-d659-4f00-95f4-36da3a9b40f3). Model
+    // Observed in production (req 9b2aa0f3-d659-4f00-95f4-36da3a9b40f3). Model
     // emitted scene-setting preamble before the in-character response. Same
     // bug class as the 4.5-Air fake-user-message echo, different vocabulary.
     // Safety relies on: start-of-response anchor, presence of <analysis> as
@@ -1272,7 +1272,7 @@ describe('hasThinkingBlocks', () => {
     // `hasReasoningTagsInContent` would be `false` for pure-GLM responses
     // where the fake-user-message wrapper is the only thinking-content
     // signal — even though `extractThinkingBlocks` would correctly find
-    // and strip the block. Surfaced by PR #875 round 4 review (2026-04-22).
+    // and strip the block.
     const uuid = '62a59660-cd89-51dc-8c54-7100f4e33329';
     const content = `<from_id>${uuid}</from_id>
 <user>User</user>

--- a/services/ai-worker/src/utils/thinkingExtraction.ts
+++ b/services/ai-worker/src/utils/thinkingExtraction.ts
@@ -56,13 +56,13 @@ const KNOWN_THINKING_TAGS = [
   'reflection', // Reflection AI
   'scratchpad', // Legacy research models
   'character_analysis', // GLM 4.5 Air internal chain-of-thought
-  'understanding', // GLM 4.5 Air (observed 2026-04-22, reasoning=medium, req deb8b063)
+  'understanding', // GLM 4.5 Air (reasoning=medium, req deb8b063)
 ] as const;
 
 /**
  * GLM-4.5-Air fake-user-message-echo pattern.
  *
- * Observed 2026-04-22 (req b533e288-fb07-46c0-a5e2-a0f78883e63e): with
+ * Observed in production (req b533e288-fb07-46c0-a5e2-a0f78883e63e): with
  * `reasoning.enabled=true` and no OpenRouter-side reasoning extraction,
  * GLM-4.5-Air improvised a reasoning channel by wrapping its chain-of-thought
  * in tags that mimic our prompt-assembly format:
@@ -104,7 +104,7 @@ const KNOWN_THINKING_TAGS = [
  *
  * Architecture: this is a "model-specific pattern extractor" that runs as a
  * first pass in `extractThinkingBlocks`, before the generic `KNOWN_THINKING_TAGS`
- * loop. Council (Gemini 3.1 Pro Preview, 2026-04-22) recommended the
+ * loop. Council (Gemini 3.1 Pro Preview) recommended the
  * Chain-of-Extractors pattern: complex model-specific regexes first,
  * simple generic tag patterns second.
  *
@@ -119,7 +119,7 @@ const GLM_FAKE_USER_MESSAGE_ECHO_PATTERN =
 /**
  * Standalone `<from_id>` echo — bare variant of the 4.5-Air leak.
  *
- * Observed 2026-04-30 in production (Lilith persona, image-vision context,
+ * Observed in production (Lilith persona, image-vision context,
  * `z-ai/glm-4.7 • 📍 auto`). GLM-4.7 emitted just
  * `<from_id>UUID</from_id>` followed by the in-character response, without
  * the rest of the GLM-4.5-Air vocabulary (`<user>`, `<message>`). The
@@ -160,7 +160,7 @@ const STANDALONE_FROM_ID_ECHO_PATTERN =
 /**
  * GLM-4.7 meta-preamble pattern.
  *
- * Observed 2026-04-24 (req 9b2aa0f3-d659-4f00-95f4-36da3a9b40f3): with
+ * Observed in production (req 9b2aa0f3-d659-4f00-95f4-36da3a9b40f3): with
  * `reasoning.enabled=true` and `showThinking=false`, GLM-4.7 emitted a scene-
  * setting preamble before the in-character response:
  *

--- a/services/api-gateway/src/routes/admin/llm-config.test.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.test.ts
@@ -519,8 +519,8 @@ describe('Admin LLM Config Routes', () => {
       expect(response.body.config.isGlobal).toBe(true);
     });
 
-    it('should accept memory settings in create (Phase 1 parity fix)', async () => {
-      // This test verifies the Phase 1 fix - memory settings were previously missing from admin
+    it('should accept memory settings in create (parity fix)', async () => {
+      // This test verifies the fix - memory settings were previously missing from admin
       prisma.llmConfig.findFirst.mockResolvedValue(null);
       prisma.llmConfig.create.mockResolvedValue({
         id: 'new-config-id',
@@ -805,8 +805,8 @@ describe('Admin LLM Config Routes', () => {
       expect(prisma.llmConfig.update).not.toHaveBeenCalled();
     });
 
-    it('should accept memory settings in update (Phase 1 parity fix)', async () => {
-      // This test verifies the Phase 1 fix - memory settings were previously missing from admin
+    it('should accept memory settings in update (parity fix)', async () => {
+      // This test verifies the fix - memory settings were previously missing from admin
       prisma.llmConfig.findUnique.mockResolvedValue({
         id: 'config-id',
         name: 'Existing Config',

--- a/services/api-gateway/src/routes/user/channel/test-utils.ts
+++ b/services/api-gateway/src/routes/user/channel/test-utils.ts
@@ -72,7 +72,7 @@ export function createMockPrisma(): {
   return {
     user: {
       findFirst: vi.fn(),
-      // Phase 5b: defaultPersonaId is NOT NULL at the type level, so the
+      // defaultPersonaId is NOT NULL at the type level, so the
       // default findUnique result must supply one.
       findUnique: vi.fn().mockResolvedValue({
         id: MOCK_USER_UUID,

--- a/services/api-gateway/src/routes/user/llm-config.component.test.ts
+++ b/services/api-gateway/src/routes/user/llm-config.component.test.ts
@@ -95,9 +95,9 @@ describe('LLM Config Resolution Integration', () => {
     // Clean up test data - order matters due to foreign keys
     await prisma.userPersonalityConfig.deleteMany({});
 
-    // Find and delete user-owned data. Phase 5b made default_persona_id NOT
-    // NULL, so we can't "unlink" the default persona before deleting — instead,
-    // deleting the user cascades to its personas via the reverse owner FK.
+    // Find and delete user-owned data. default_persona_id is NOT NULL, so we
+    // can't "unlink" the default persona before deleting — instead, deleting
+    // the user cascades to its personas via the reverse owner FK.
     const testUser = await prisma.user.findFirst({
       where: { discordId: TEST_DISCORD_ID },
     });

--- a/services/api-gateway/src/routes/user/llm-config.test.ts
+++ b/services/api-gateway/src/routes/user/llm-config.test.ts
@@ -783,8 +783,8 @@ describe('/user/llm-config routes', () => {
       expect(res.status).toHaveBeenCalledWith(201);
     });
 
-    it('should create config with memory settings (Phase 1 parity)', async () => {
-      // This test verifies Phase 1 parity - user routes must accept same fields as admin
+    it('should create config with memory settings (parity)', async () => {
+      // This test verifies parity - user routes must accept same fields as admin
       mockPrisma.llmConfig.create.mockResolvedValue({
         id: 'new-config',
         name: 'Memory Config',

--- a/services/api-gateway/src/routes/user/personality/helpers.ts
+++ b/services/api-gateway/src/routes/user/personality/helpers.ts
@@ -153,9 +153,9 @@ interface ResolvePersonalityForEditParams {
  * Callers specify a Prisma select clause; the result personality is cast to T.
  * The select MUST include `id` and `ownerId` — enforced at the type level.
  *
- * Contract change vs. pre-Phase-5c: this helper used to return a deliberate
+ * This helper used to return a deliberate
  * HTTP 403 ("User not found") when the caller's Discord ID didn't resolve to
- * a users row. Post-Phase-5c, every user-scoped route runs behind
+ * a users row. Every user-scoped route now runs behind
  * `requireProvisionedUser`, which either attaches `req.provisionedUserId`
  * directly or (during the shadow-mode window) delegates to
  * `getOrCreateUserShell` — both of which guarantee the user exists by the

--- a/services/api-gateway/src/routes/user/shapes/auth.test.ts
+++ b/services/api-gateway/src/routes/user/shapes/auth.test.ts
@@ -93,7 +93,7 @@ const mockPrisma = {
 // `createProvisionedMockReqRes` from `src/test/shared-route-test-utils.ts`
 // as part of the shadow-mode → strict-400 flip. This file is tagged as the
 // reference migration site for the ~35 route test files that currently
-// mock `requireProvisionedUser` as a no-op. See BACKLOG.md Phase 5c work
+// mock `requireProvisionedUser` as a no-op. See BACKLOG.md work
 // items → "Tighten `requireProvisionedUser` shadow-mode to strict 400"
 // for the full migration plan — the strict-mode PR must apply this
 // helper to every `createMockReqRes` caller before flipping the middleware.

--- a/services/api-gateway/src/routes/user/shapes/import.test.ts
+++ b/services/api-gateway/src/routes/user/shapes/import.test.ts
@@ -59,7 +59,7 @@ const mockPrisma = {
     .mockImplementation(async (callback: (tx: unknown) => Promise<unknown>) =>
       callback(mockPrisma)
     ),
-  // Phase 5b: UserService uses a single $executeRaw CTE to atomically
+  // UserService uses a single $executeRaw CTE to atomically
   // create user + default persona. Plain resolve covers the happy path.
   $executeRaw: vi.fn().mockResolvedValue(1),
 };

--- a/services/api-gateway/src/routes/wallet/setKey.test.ts
+++ b/services/api-gateway/src/routes/wallet/setKey.test.ts
@@ -71,7 +71,7 @@ const mockPrisma = {
   userApiKey: {
     upsert: vi.fn().mockResolvedValue({ id: 'key-uuid-123' }),
   },
-  // Phase 5b: UserService creates user + default persona atomically via a
+  // UserService creates user + default persona atomically via a
   // single $executeRaw CTE. The mock just needs to resolve successfully.
   $executeRaw: vi.fn().mockResolvedValue(1),
 };

--- a/services/api-gateway/src/services/DatabaseSyncService.component.test.ts
+++ b/services/api-gateway/src/services/DatabaseSyncService.component.test.ts
@@ -90,7 +90,7 @@ function loadAlignTtsGlobalsMigration(): string {
  * independent of which migration actually landed last. Previously the
  * seed row hardcoded `20260418010642_…`, which would start failing this
  * suite with a schema-version-mismatch error the moment any new
- * migration shipped. (PR #826 R4 #3.)
+ * migration shipped.
  */
 function getLatestMigrationName(): string {
   const entries = readdirSync(migrationsDir());
@@ -133,7 +133,7 @@ const SETUP_PRISMA_MIGRATIONS_TABLE = `
 /**
  * Build the seed SQL for `_prisma_migrations` using the current latest
  * migration name. Dynamic so future-added migrations don't break the
- * schema-version check in this suite. (PR #826 R4 #3.)
+ * schema-version check in this suite.
  */
 function buildSeedMigrationRow(): string {
   const latest = getLatestMigrationName();
@@ -195,7 +195,7 @@ describe('DatabaseSyncService Integration (Ouroboros pattern)', () => {
     // Clean up inside a transaction with SET CONSTRAINTS ALL DEFERRED so
     // the circular FK pair doesn't make us care about table order. This
     // mirrors the Ouroboros pattern of the service under test and removes
-    // a pre-existing ordering fragility (PR #826 R2 #1): `personas.owner_id`
+    // a pre-existing ordering fragility: `personas.owner_id`
     // ON DELETE CASCADE + `users.default_persona_id` ON DELETE RESTRICT
     // gives Postgres conflicting directives when deleting both sides, and
     // the delete ordering that "works" depends on which row gets cascade-
@@ -225,8 +225,8 @@ describe('DatabaseSyncService Integration (Ouroboros pattern)', () => {
    * users.default_persona_id NOT NULL. Post-Ouroboros, this test passes.
    *
    * If the test starts failing after a future migration tightens an FK
-   * somewhere else, that's the canary: something similar to the Phase 5b
-   * drift recurred and needs the same treatment.
+   * somewhere else, that's the canary: something similar to the earlier
+   * NOT NULL drift recurred and needs the same treatment.
    */
   it('syncs a user+persona pair with circular FKs from prod to empty dev', async () => {
     const discordId = '12345678901234567890';
@@ -339,7 +339,7 @@ describe('DatabaseSyncService Integration (Ouroboros pattern)', () => {
    * `$transaction`, so Postgres discards all staged INSERTs on an error.
    * This is load-bearing for the Ouroboros pattern: deferred FKs only
    * validate at COMMIT, so an abort before COMMIT means we can't leave
-   * orphaned half-inserted rows behind. PR #826 R3 #2.
+   * orphaned half-inserted rows behind.
    *
    * We spy on `upsertRow` to force a throw after a single write. If
    * `$transaction` doesn't roll back, dev would end up with a partial

--- a/services/api-gateway/src/services/DatabaseSyncService.ts
+++ b/services/api-gateway/src/services/DatabaseSyncService.ts
@@ -31,8 +31,8 @@
  *
  * Previously this used a "two-pass" pattern (pass 1 insert with
  * default_persona_id=NULL; pass 2 UPDATE to backfill). That broke when
- * migration 20260416215546 made default_persona_id NOT NULL in Phase 5b
- * of the Identity Epic — NOT NULL is a column property, not a deferrable
+ * migration 20260416215546 made default_persona_id NOT NULL — NOT NULL
+ * is a column property, not a deferrable
  * constraint, so pass 1's NULL INSERT failed immediately with 23502.
  * The Ouroboros Insert approach is structurally simpler (single pass,
  * no ForeignKeyReconciler pass-2 machinery) and future-proofs against
@@ -149,7 +149,7 @@ export class DatabaseSyncService {
       // the cross-table FK order, since partial flushes lose the "every
       // referenced row exists at COMMIT" guarantee that the Ouroboros
       // pattern relies on. Keep it one-shot until the memory pressure
-      // is observed. (PR #826 R1 #3.)
+      // is observed.
       const devBoundWrites: PendingWrite[] = [];
       const prodBoundWrites: PendingWrite[] = [];
 

--- a/services/api-gateway/src/services/LlmConfigService.component.test.ts
+++ b/services/api-gateway/src/services/LlmConfigService.component.test.ts
@@ -63,8 +63,8 @@ describe('LlmConfigService Integration', () => {
 
   beforeEach(async () => {
     // Clean up test data - order matters due to foreign keys.
-    // Users must be deleted BEFORE personas because Phase 5 made
-    // users.default_persona_id FK Restrict (user cascade-deletes its own
+    // Users must be deleted BEFORE personas because
+    // users.default_persona_id is a Restrict FK (user cascade-deletes its own
     // personas via the reverse owner FK).
     await prisma.userPersonalityConfig.deleteMany({});
     await prisma.personalityDefaultConfig.deleteMany({});
@@ -72,7 +72,7 @@ describe('LlmConfigService Integration', () => {
     await prisma.personality.deleteMany({});
     await prisma.user.deleteMany({});
 
-    // Create test users. Phase 5b made users.default_persona_id NOT NULL, so
+    // Create test users. users.default_persona_id is NOT NULL, so
     // each user must be seeded with a matching persona via the CTE helper.
     testUserId = generateUserUuid(TEST_DISCORD_ID);
     adminUserId = generateUserUuid(ADMIN_DISCORD_ID);
@@ -675,7 +675,7 @@ describe('LlmConfigService Integration', () => {
   });
 
   /**
-   * Regression test for the phantom-PK-collision bug observed 2026-04-19.
+   * Regression test for the phantom-PK-collision bug.
    *
    * Before fix: `id: generateLlmConfigUuid(name)` (deterministic UUIDv5 from
    * the user-editable name) meant the flow below hit PK collision on step 4:

--- a/services/api-gateway/src/test/shared-route-test-utils.ts
+++ b/services/api-gateway/src/test/shared-route-test-utils.ts
@@ -36,7 +36,7 @@ export const createMockUpdatedAt = (): Date => new Date('2024-01-02T00:00:00.000
  * and therefore exercise the shadow-mode fallback branch of
  * `resolveProvisionedUserId` / `getOrCreateInternalUser` rather than the
  * common provisioned path. When the middleware is tightened from shadow-
- * mode-fallthrough to strict-400 (tracked in BACKLOG.md Phase 5c work
+ * mode-fallthrough to strict-400 (tracked in BACKLOG.md work
  * items), those no-op mocks will produce 400s at the middleware layer and
  * every unmigrated test file will break en masse.
  *

--- a/services/api-gateway/src/types.ts
+++ b/services/api-gateway/src/types.ts
@@ -44,12 +44,12 @@ export interface AuthenticatedRequest extends Request {
  * `provisionedUserId` is the internal UUID (not the Discord snowflake) for
  * the user, obtained via `UserService.getOrCreateUser()` — the full
  * provisioning path that uses the real Discord username/displayName from
- * headers set by bot-client in Phase 5c PR A.
+ * headers set by bot-client.
  *
  * Both fields are optional because the middleware degrades gracefully
  * (doesn't fail the request) when the headers are absent or malformed.
  * Handlers that want to consume them must narrow the optional first — or
- * wait for PR C to tighten the invariant once prod bot-client is fully
+ * wait for the invariant to be tightened once prod bot-client is fully
  * on the new code path.
  */
 export interface ProvisionedRequest extends AuthenticatedRequest {

--- a/services/api-gateway/src/utils/BullMQJobChainContract.producer.test.ts
+++ b/services/api-gateway/src/utils/BullMQJobChainContract.producer.test.ts
@@ -60,7 +60,7 @@ const visionResolverStub: VisionConfigResolver = {
     source: 'personality',
     config: { model: 'resolved/vision-model' },
   }),
-  // Phase 4: stampResolvedConfig also reads the two default pointers for the
+  // stampResolvedConfig also reads the two default pointers for the
   // visionFallbackModels chain. Return null (no admin fallbacks) so the snapshot
   // carries only the resolved visionModel, not a fallback chain.
   getGlobalDefaultConfig: vi.fn().mockResolvedValue(null),

--- a/services/api-gateway/src/utils/jobChainOrchestrator.test.ts
+++ b/services/api-gateway/src/utils/jobChainOrchestrator.test.ts
@@ -1014,7 +1014,7 @@ describe('jobChainOrchestrator (FlowProducer)', () => {
       expect(flowCall.data.personality.visionModel).toBeUndefined();
     });
 
-    it('stamps the visionFallbackModels chain from the global + free vision defaults (Phase 4)', async () => {
+    it('stamps the visionFallbackModels chain from the global + free vision defaults', async () => {
       await createJobChain({
         requestId: 'req-vision-fallbacks',
         personality: mockPersonality,

--- a/services/api-gateway/src/utils/stampResolvedConfig.ts
+++ b/services/api-gateway/src/utils/stampResolvedConfig.ts
@@ -73,7 +73,7 @@ export async function stampResolvedConfig(
 
   // VISION model: stamp personality.visionModel from the INDEPENDENT vision cascade,
   // plus the ordered DB-resolved fallback chain the worker retries down on a RUNTIME
-  // vision failure (Phase 4). The worker has no Prisma, so all DB resolution stays here.
+  // vision failure. The worker has no Prisma, so all DB resolution stays here.
   if (visionConfigResolver !== undefined) {
     try {
       // resolveConfig picks the effective vision model; the two default readers supply the

--- a/services/bot-client/src/handlers/references/LinkExtractor.ts
+++ b/services/bot-client/src/handlers/references/LinkExtractor.ts
@@ -94,8 +94,7 @@ export class LinkExtractor {
       // source channel before fetching. Without this check, the bot's credentials
       // would let anyone expand a message link from a channel they cannot see,
       // leaking private content into the AI reply via context assembly.
-      // Phase 2 of the Identity & Provisioning Hardening epic — see
-      // docs/reference/architecture/epic-identity-hardening.md.
+      // See docs/reference/architecture/epic-identity-hardening.md.
       const invokerCanAccess = await this.verifyInvokerCanAccessSource(channel, invokingMessage);
       if (!invokerCanAccess) {
         // Access denial is a security event — log at info so it surfaces in


### PR DESCRIPTION
## What

Repo-wide cleanup of temporal **archaeology** in code comments (the "when / which epic / who" journey that `02-code-standards.md` § Temporal Markers forbids — comments carry the *invariant*, not the *journey*), plus the structural fix so it can't recur. Surfaced by the barrel-kill PR #1472 review; done as its own PR to keep it out of the barrel migration.

## Two parts

**1. Extend the pre-commit temporal check** (`.husky/pre-commit`). The `TEMPORAL_PATTERN` caught dates / PR-refs / round-markers but never the `Phase 5b` / `Epic Phase` / `Post-Phase` epic-phase form — which is exactly why it accumulated (test files are ESLint-exempt too). Added the epic-phase alternatives, **deliberately NOT bare `Phase N`** so algorithm phases (`Phase 1 (scan)`) don't false-positive. Smoke-test canaries added inline.

**2. Clean ~42 files.** Drop the archaeology clause, keep the technical invariant. Examples:
- `// Phase 5b: user + default persona must be created atomically` → `// user + default persona must be created atomically`
- `// Production root cause confirmed 2026-04-30 via council analysis:` → `// Root cause (confirmed via council analysis):`

### Explicitly preserved (the false-positive classes)
- **Algorithm/pipeline phases** — `Phase 1 (scan)` / `Phase 2 (flush)` in `DatabaseSyncService.ts` describe the code's steps, not archaeology.
- **Data-value dates** — dates in `new Date(...)` fixtures, format examples, `describe()`/`it()` titles.
- **Traceability IDs** — migration IDs, commit-hash bug-class refs (`c88ae5b7`), request UUIDs, live doc pointers.
- **Forward-looking pointers** — a `TODO(Phase-5c-strict-cutover)` with a backlog link is planned work, not past archaeology.

## How

The cleanup fanned out across 6 subagents (disjoint file batches, precise drop/keep rule), followed by a full single-reviewer pass: comment-only audit (no code token changed), false-positive audit (no algorithm-phase / data-date removed), and a re-scan to 0 residual epic-phase markers. Two misses and one over-reach (a dropped live doc pointer) were caught and fixed in review.

## Verification

- Extended hook smoke-tested: catches `Phase 5b` / `Epic Phase` / `Post-Phase`, ignores `Phase 1 (scan)` / `Phase 2 (flush)`.
- The commit itself passed the extended check — proof the rewrites left no epic-phase marker on any touched line.
- Typecheck clean across all touched packages (a broken comment fails the parse); no behavior change (comment + hook-regex only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)