### PR TITLE
chore: gate-lint @tzurot/tooling (pre-release gate)

### DIFF
--- a/packages/tooling/package.json
+++ b/packages/tooling/package.json
@@ -21,6 +21,7 @@
     "build": "rm -rf dist tsconfig.tsbuildinfo && tsc",
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
+    "lint": "eslint src --max-warnings=0",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage"

--- a/packages/tooling/src/context/session-context.ts
+++ b/packages/tooling/src/context/session-context.ts
@@ -119,9 +119,9 @@ function getPendingMigrations(cwd: string): string[] | null {
     // Prisma migrate status exits with non-zero when migrations are pending
     // We need to capture the output from stderr/stdout
     if (error && typeof error === 'object' && 'stdout' in error) {
-      result = String((error as { stdout: unknown }).stdout);
+      result = String(error.stdout);
     } else if (error && typeof error === 'object' && 'message' in error) {
-      result = String((error as { message: unknown }).message);
+      result = String(error.message);
     } else {
       return null;
     }

--- a/packages/tooling/src/eslint/no-singleton-export.ts
+++ b/packages/tooling/src/eslint/no-singleton-export.ts
@@ -55,8 +55,8 @@ function reportArraySingletons(context: Rule.RuleContext, elements: (Node | null
 // Helper: Report singleton in object properties
 function reportObjectSingletons(context: Rule.RuleContext, properties: (Property | Node)[]): void {
   for (const prop of properties) {
-    if (prop.type === 'Property' && isNewExpressionWithIdentifier((prop as Property).value)) {
-      const propValue = (prop as Property).value as Node & {
+    if (prop.type === 'Property' && isNewExpressionWithIdentifier(prop.value)) {
+      const propValue = prop.value as Node & {
         callee: { name: string };
       };
       context.report({
@@ -111,19 +111,21 @@ function handleExportDefault(
   }
 }
 
-// Helper: Handle export named declarations
-function handleExportNamed(
+interface ExportSpecifierNode {
+  type: string;
+  local: { type: string; name: string };
+}
+interface ExportDeclaratorNode {
+  init: Node | null;
+}
+
+// Handle: export { instance }
+function reportExportSpecifierSingletons(
   context: Rule.RuleContext,
-  node: Rule.Node,
+  specifiers: ExportSpecifierNode[],
   moduleInstances: TrackedInstance[]
 ): void {
-  const exportNode = node as unknown as {
-    specifiers?: { type: string; local: { type: string; name: string } }[];
-    declaration?: { type: string; declarations?: { init: Node | null }[] };
-  };
-
-  // Handle: export { instance }
-  for (const specifier of exportNode.specifiers ?? []) {
+  for (const specifier of specifiers) {
     if (specifier.type !== 'ExportSpecifier') continue;
     if (specifier.local.type !== 'Identifier') continue;
 
@@ -135,11 +137,14 @@ function handleExportNamed(
       });
     }
   }
+}
 
-  // Handle: export const x = new Foo() / [new Foo()] / { mgr: new Foo() }
-  if (exportNode.declaration?.type !== 'VariableDeclaration') return;
-
-  for (const declarator of exportNode.declaration.declarations ?? []) {
+// Handle: export const x = new Foo() / [new Foo()] / { mgr: new Foo() }
+function reportExportDeclaratorSingletons(
+  context: Rule.RuleContext,
+  declarators: ExportDeclaratorNode[]
+): void {
+  for (const declarator of declarators) {
     const init = declarator.init;
     if (!init) continue;
 
@@ -162,6 +167,23 @@ function handleExportNamed(
       reportObjectSingletons(context, init.properties);
     }
   }
+}
+
+// Helper: Handle export named declarations
+function handleExportNamed(
+  context: Rule.RuleContext,
+  node: Rule.Node,
+  moduleInstances: TrackedInstance[]
+): void {
+  const exportNode = node as unknown as {
+    specifiers?: ExportSpecifierNode[];
+    declaration?: { type: string; declarations?: ExportDeclaratorNode[] };
+  };
+
+  reportExportSpecifierSingletons(context, exportNode.specifiers ?? [], moduleInstances);
+
+  if (exportNode.declaration?.type !== 'VariableDeclaration') return;
+  reportExportDeclaratorSingletons(context, exportNode.declaration.declarations ?? []);
 }
 
 const rule: Rule.RuleModule = {

--- a/packages/tooling/src/xray/file-parser.test.ts
+++ b/packages/tooling/src/xray/file-parser.test.ts
@@ -344,6 +344,18 @@ const y: any = 2;
     expect(result[0].justification).toBe('testing invalid input');
   });
 
+  it('should keep the full trailing text as justification when @ts-expect-error has an internal --', () => {
+    // ts-expect-error has no rule concept, so a '--' that is NOT immediately after
+    // the directive does not split off a rule — the whole trailing text is the
+    // justification (pins the pre-refactor regex behavior).
+    const content = `// @ts-expect-error necessary for narrow inference -- see issue\nconst x = badCall();\n`;
+    const result = extractSuppressions(content);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe('ts-expect-error');
+    expect(result[0].justification).toBe('necessary for narrow inference -- see issue');
+  });
+
   it('should extract @ts-nocheck', () => {
     const content = `// @ts-nocheck\nconst x: any = 1;\n`;
     const result = extractSuppressions(content);

--- a/packages/tooling/src/xray/file-parser.ts
+++ b/packages/tooling/src/xray/file-parser.ts
@@ -242,7 +242,7 @@ function getNodeLineCount(node: {
 
 // Each pattern captures the raw tail after the directive as ONE group; the
 // rule name and ` -- ` justification are split apart in code (splitSuppressionTail).
-// A single greedy/lazy-to-a-literal-terminator capture is linear \u2014 the old nested
+// A single greedy/lazy-to-a-literal-terminator capture is linear -- the old nested
 // optional groups (`(?:\s+(rule))?(?:\s+--\s+(just))?`) let the rule quantifier and
 // the ` -- ` delimiter's `\s+` exchange characters, which regexp/no-super-linear-
 // backtracking flags as polynomial ReDoS.
@@ -292,15 +292,19 @@ function buildSuppressionInfo(
   rawTail: string
 ): SuppressionInfo {
   const info: SuppressionInfo = { kind, line: lineNumber };
-  const { rulePart, justification } = splitSuppressionTail(rawTail);
 
   if (kind === 'eslint-disable-next-line' || kind === 'eslint-disable') {
+    const { rulePart, justification } = splitSuppressionTail(rawTail);
     if (rulePart !== '') info.rule = rulePart;
     if (justification !== undefined) info.justification = justification;
   } else if (kind === 'ts-expect-error') {
-    // No rule name \u2014 the justification is either after ` -- ` or the bare trailing text.
-    const justText = justification ?? (rulePart !== '' ? rulePart : undefined);
-    if (justText !== undefined) info.justification = justText;
+    // No rule concept: the justification is the whole trailing text, or the text
+    // after a LEADING ' -- '. The old regex only recognised '--' immediately after
+    // the directive, so free text before an INTERNAL '--' stays part of the
+    // justification rather than being split off as a (nonexistent) rule.
+    const tail = rawTail.trim();
+    const justText = tail.startsWith('-- ') ? tail.slice('-- '.length).trim() : tail;
+    if (justText !== '') info.justification = justText;
   }
 
   return info;

--- a/packages/tooling/src/xray/file-parser.ts
+++ b/packages/tooling/src/xray/file-parser.ts
@@ -76,9 +76,9 @@ function extractDeclarations(sourceFile: SourceFile, includePrivate: boolean): D
     getStartLineNumber: () => number;
   };
   const simpleDecls: { items: NamedNode[]; kind: DeclarationKind }[] = [
-    { items: sourceFile.getInterfaces() as NamedNode[], kind: 'interface' },
-    { items: sourceFile.getTypeAliases() as NamedNode[], kind: 'type' },
-    { items: sourceFile.getEnums() as NamedNode[], kind: 'enum' },
+    { items: sourceFile.getInterfaces(), kind: 'interface' },
+    { items: sourceFile.getTypeAliases(), kind: 'type' },
+    { items: sourceFile.getEnums(), kind: 'enum' },
   ];
 
   for (const { items, kind } of simpleDecls) {
@@ -240,21 +240,27 @@ function getNodeLineCount(node: {
   return node.getEndLineNumber() - node.getStartLineNumber() + 1;
 }
 
+// Each pattern captures the raw tail after the directive as ONE group; the
+// rule name and ` -- ` justification are split apart in code (splitSuppressionTail).
+// A single greedy/lazy-to-a-literal-terminator capture is linear \u2014 the old nested
+// optional groups (`(?:\s+(rule))?(?:\s+--\s+(just))?`) let the rule quantifier and
+// the ` -- ` delimiter's `\s+` exchange characters, which regexp/no-super-linear-
+// backtracking flags as polynomial ReDoS.
 const SUPPRESSION_PATTERNS: {
   kind: SuppressionKind;
   regex: RegExp;
 }[] = [
   {
     kind: 'eslint-disable-next-line',
-    regex: /\/\/\s*eslint-disable-next-line(?:\s+([^\s-][^\n]*?))?(?:\s+--\s+(.+))?$/,
+    regex: /\/\/\s*eslint-disable-next-line(\s[^\n]*)?$/,
   },
   {
     kind: 'eslint-disable',
-    regex: /\/\*\s*eslint-disable(?:\s+([^\s*][^*]*?))?(?:\s+--\s+(.+?))?\s*\*\//,
+    regex: /\/\*\s*eslint-disable(\s[\s\S]*?)?\*\//,
   },
   {
     kind: 'ts-expect-error',
-    regex: /\/\/\s*@ts-expect-error(?:\s+--\s+(.+)|(\s+.+))?$/,
+    regex: /\/\/\s*@ts-expect-error(\s[^\n]*)?$/,
   },
   {
     kind: 'ts-nocheck',
@@ -263,39 +269,58 @@ const SUPPRESSION_PATTERNS: {
 ];
 
 /**
- * Extract lint suppression comments from raw file content.
+ * Split a suppression comment's raw tail into its rule part and justification on
+ * the ` -- ` delimiter (the project's lint-suppression convention). Splits on the
+ * FIRST delimiter so a justification may itself contain ` -- `.
  */
-// eslint-disable-next-line sonarjs/cognitive-complexity -- pattern-matching loop with simple branches
-export function extractSuppressions(content: string): SuppressionInfo[] {
-  const suppressions: SuppressionInfo[] = [];
-  const lines = content.split('\n');
+function splitSuppressionTail(raw: string): { rulePart: string; justification?: string } {
+  const DELIMITER = ' -- ';
+  const delimIndex = raw.indexOf(DELIMITER);
+  if (delimIndex === -1) {
+    return { rulePart: raw.trim() };
+  }
+  return {
+    rulePart: raw.slice(0, delimIndex).trim(),
+    justification: raw.slice(delimIndex + DELIMITER.length).trim() || undefined,
+  };
+}
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
+/** Build a SuppressionInfo from a matched directive's kind + raw tail. */
+function buildSuppressionInfo(
+  kind: SuppressionKind,
+  lineNumber: number,
+  rawTail: string
+): SuppressionInfo {
+  const info: SuppressionInfo = { kind, line: lineNumber };
+  const { rulePart, justification } = splitSuppressionTail(rawTail);
 
-    for (const { kind, regex } of SUPPRESSION_PATTERNS) {
-      const match = regex.exec(line);
-      if (match === null) continue;
-
-      const info: SuppressionInfo = { kind, line: i + 1 };
-
-      if (kind === 'eslint-disable-next-line' || kind === 'eslint-disable') {
-        if (match[1] !== undefined && match[1].trim() !== '') info.rule = match[1].trim();
-        if (match[2] !== undefined && match[2].trim() !== '') {
-          info.justification = match[2].trim();
-        }
-      } else if (kind === 'ts-expect-error') {
-        // match[1] is after " -- ", match[2] is trailing text without " -- "
-        const justText = match[1] ?? match[2];
-        if (justText !== undefined && justText.trim() !== '') {
-          info.justification = justText.trim();
-        }
-      }
-
-      suppressions.push(info);
-      break; // Only match first pattern per line
-    }
+  if (kind === 'eslint-disable-next-line' || kind === 'eslint-disable') {
+    if (rulePart !== '') info.rule = rulePart;
+    if (justification !== undefined) info.justification = justification;
+  } else if (kind === 'ts-expect-error') {
+    // No rule name \u2014 the justification is either after ` -- ` or the bare trailing text.
+    const justText = justification ?? (rulePart !== '' ? rulePart : undefined);
+    if (justText !== undefined) info.justification = justText;
   }
 
-  return suppressions;
+  return info;
+}
+
+/** Match the first suppression directive on a single line, if any. */
+function matchSuppressionLine(line: string, lineNumber: number): SuppressionInfo | null {
+  for (const { kind, regex } of SUPPRESSION_PATTERNS) {
+    const match = regex.exec(line);
+    if (match !== null) return buildSuppressionInfo(kind, lineNumber, match[1] ?? '');
+  }
+  return null;
+}
+
+/**
+ * Extract lint suppression comments from raw file content.
+ */
+export function extractSuppressions(content: string): SuppressionInfo[] {
+  return content.split('\n').flatMap((line, i) => {
+    const info = matchSuppressionLine(line, i + 1);
+    return info !== null ? [info] : [];
+  });
 }


### PR DESCRIPTION
Pre-release gate #2 of the barrel-kill fallout: `@tzurot/tooling` had **no `lint` script**, so `pnpm lint` (turbo) never linted it — 16 real eslint errors sat ungated (surfaced running eslint during #1476). This adds the gate and clears the backlog.

## Changes

- **Add `"lint": "eslint src --max-warnings=0"`** to tooling's package.json — turbo now runs it (24 → 25 lint tasks); tooling can no longer drift unlinted.
- **7 unnecessary type assertions** (auto-fixed) in `session-context.ts`, `no-singleton-export.ts`, `file-parser.ts`.
- **3 ReDoS-flagged regexes** in `xray/file-parser.ts` (the lint-suppression-comment parser): the nested optional groups `(?:\s+(rule))?(?:\s+--\s+(just))?` let the rule quantifier and the ` -- ` delimiter's `\s+` exchange characters (polynomial backtracking, `regexp/no-super-linear-backtracking`). Rewrote each to capture the raw tail as **one** group and split rule-vs-justification on ` -- ` in code (`splitSuppressionTail`) — provably linear. **Behavior preserved** (48 suppression-parser tests green).
- **2 cognitive-complexity findings**: extracted the per-line match loop (`matchSuppressionLine`/`buildSuppressionInfo`) and the two export-scan loops (`reportExportSpecifierSingletons`/`reportExportDeclaratorSingletons`) into helpers.

No runtime behavior change.

## Verification

`pnpm lint` 25/25 · tooling typecheck clean · full tooling suite green (1307 tests, incl. the 48 suppression-parser tests that pin the regex behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)