### PR TITLE
refactor: prune 7 dead functions + de-export 7 redundant guards (barrel audit pt.1)

### DIFF
--- a/packages/cache-invalidation/src/ApiKeyCacheInvalidationService.test.ts
+++ b/packages/cache-invalidation/src/ApiKeyCacheInvalidationService.test.ts
@@ -5,7 +5,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   ApiKeyCacheInvalidationService,
-  isValidApiKeyInvalidationEvent,
   type ApiKeyInvalidationEvent,
 } from './ApiKeyCacheInvalidationService.js';
 import { REDIS_CHANNELS } from '@tzurot/common-types/constants/queue';
@@ -35,25 +34,6 @@ describe('ApiKeyCacheInvalidationService', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
-  });
-
-  describe('isValidApiKeyInvalidationEvent', () => {
-    it('should validate user invalidation event', () => {
-      expect(isValidApiKeyInvalidationEvent({ type: 'user', discordId: '123456' })).toBe(true);
-    });
-
-    it('should validate all invalidation event', () => {
-      expect(isValidApiKeyInvalidationEvent({ type: 'all' })).toBe(true);
-    });
-
-    it('should reject invalid events', () => {
-      expect(isValidApiKeyInvalidationEvent(null)).toBe(false);
-      expect(isValidApiKeyInvalidationEvent(undefined)).toBe(false);
-      expect(isValidApiKeyInvalidationEvent('string')).toBe(false);
-      expect(isValidApiKeyInvalidationEvent({ type: 'unknown' })).toBe(false);
-      expect(isValidApiKeyInvalidationEvent({ type: 'user' })).toBe(false); // missing discordId
-      expect(isValidApiKeyInvalidationEvent({ type: 'all', extra: 'field' })).toBe(false);
-    });
   });
 
   describe('subscribe', () => {

--- a/packages/cache-invalidation/src/ApiKeyCacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/ApiKeyCacheInvalidationService.ts
@@ -30,8 +30,7 @@ export type ApiKeyInvalidationEvent = StandardInvalidationEvent;
 /**
  * Type guard to validate ApiKeyInvalidationEvent structure
  */
-export const isValidApiKeyInvalidationEvent =
-  createStandardEventValidator<ApiKeyInvalidationEvent>();
+const isValidApiKeyInvalidationEvent = createStandardEventValidator<ApiKeyInvalidationEvent>();
 
 /**
  * API Key Cache Invalidation Service

--- a/packages/cache-invalidation/src/ChannelActivationCacheInvalidationService.test.ts
+++ b/packages/cache-invalidation/src/ChannelActivationCacheInvalidationService.test.ts
@@ -5,7 +5,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   ChannelActivationCacheInvalidationService,
-  isValidChannelActivationInvalidationEvent,
   type ChannelActivationInvalidationEvent,
 } from './ChannelActivationCacheInvalidationService.js';
 import { REDIS_CHANNELS } from '@tzurot/common-types/constants/queue';
@@ -48,61 +47,6 @@ describe('ChannelActivationCacheInvalidationService', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
-  });
-
-  describe('isValidChannelActivationInvalidationEvent', () => {
-    it('should validate channel invalidation event', () => {
-      expect(
-        isValidChannelActivationInvalidationEvent({ type: 'channel', channelId: '123456' })
-      ).toBe(true);
-    });
-
-    it('should validate all invalidation event', () => {
-      expect(isValidChannelActivationInvalidationEvent({ type: 'all' })).toBe(true);
-    });
-
-    it('should reject null', () => {
-      expect(isValidChannelActivationInvalidationEvent(null)).toBe(false);
-    });
-
-    it('should reject undefined', () => {
-      expect(isValidChannelActivationInvalidationEvent(undefined)).toBe(false);
-    });
-
-    it('should reject non-objects', () => {
-      expect(isValidChannelActivationInvalidationEvent('string')).toBe(false);
-      expect(isValidChannelActivationInvalidationEvent(123)).toBe(false);
-    });
-
-    it('should reject invalid event types', () => {
-      expect(isValidChannelActivationInvalidationEvent({ type: 'unknown' })).toBe(false);
-    });
-
-    it('should reject channel event without channelId', () => {
-      expect(isValidChannelActivationInvalidationEvent({ type: 'channel' })).toBe(false);
-    });
-
-    it('should reject channel event with wrong channelId type', () => {
-      expect(isValidChannelActivationInvalidationEvent({ type: 'channel', channelId: 123 })).toBe(
-        false
-      );
-    });
-
-    it('should reject all event with extra properties', () => {
-      expect(isValidChannelActivationInvalidationEvent({ type: 'all', extra: 'field' })).toBe(
-        false
-      );
-    });
-
-    it('should reject channel event with extra properties', () => {
-      expect(
-        isValidChannelActivationInvalidationEvent({
-          type: 'channel',
-          channelId: '123',
-          extra: 'field',
-        })
-      ).toBe(false);
-    });
   });
 
   describe('subscribe', () => {

--- a/packages/cache-invalidation/src/ChannelActivationCacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/ChannelActivationCacheInvalidationService.ts
@@ -36,7 +36,7 @@ export type ChannelActivationInvalidationEvent =
 /**
  * Type guard to validate ChannelActivationInvalidationEvent structure
  */
-export const isValidChannelActivationInvalidationEvent =
+const isValidChannelActivationInvalidationEvent =
   createEventValidator<ChannelActivationInvalidationEvent>([
     { type: 'channel', fields: { channelId: 'string' } },
     { type: 'all' },

--- a/packages/cache-invalidation/src/ConfigCascadeCacheInvalidationService.test.ts
+++ b/packages/cache-invalidation/src/ConfigCascadeCacheInvalidationService.test.ts
@@ -3,10 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import {
-  ConfigCascadeCacheInvalidationService,
-  isValidConfigCascadeInvalidationEvent,
-} from './ConfigCascadeCacheInvalidationService.js';
+import { ConfigCascadeCacheInvalidationService } from './ConfigCascadeCacheInvalidationService.js';
 import { REDIS_CHANNELS } from '@tzurot/common-types/constants/queue';
 
 // Mock logger
@@ -59,75 +56,6 @@ describe('ConfigCascadeCacheInvalidationService', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
-  });
-
-  describe('isValidConfigCascadeInvalidationEvent', () => {
-    it('should validate "all" event', () => {
-      expect(isValidConfigCascadeInvalidationEvent({ type: 'all' })).toBe(true);
-    });
-
-    it('should validate "admin" event', () => {
-      expect(isValidConfigCascadeInvalidationEvent({ type: 'admin' })).toBe(true);
-    });
-
-    it('should validate "user" event with discordId', () => {
-      expect(isValidConfigCascadeInvalidationEvent({ type: 'user', discordId: '123' })).toBe(true);
-    });
-
-    it('should validate "personality" event with personalityId', () => {
-      expect(
-        isValidConfigCascadeInvalidationEvent({ type: 'personality', personalityId: 'p-123' })
-      ).toBe(true);
-    });
-
-    it('should reject null', () => {
-      expect(isValidConfigCascadeInvalidationEvent(null)).toBe(false);
-    });
-
-    it('should reject non-objects', () => {
-      expect(isValidConfigCascadeInvalidationEvent('string')).toBe(false);
-      expect(isValidConfigCascadeInvalidationEvent(123)).toBe(false);
-    });
-
-    it('should reject invalid event types', () => {
-      expect(isValidConfigCascadeInvalidationEvent({ type: 'invalid' })).toBe(false);
-    });
-
-    it('should reject "user" event without discordId', () => {
-      expect(isValidConfigCascadeInvalidationEvent({ type: 'user' })).toBe(false);
-    });
-
-    it('should validate "channel" event with channelId', () => {
-      expect(isValidConfigCascadeInvalidationEvent({ type: 'channel', channelId: 'ch-123' })).toBe(
-        true
-      );
-    });
-
-    it('should reject "channel" event without channelId', () => {
-      expect(isValidConfigCascadeInvalidationEvent({ type: 'channel' })).toBe(false);
-    });
-
-    it('should reject "channel" event with wrong channelId type', () => {
-      expect(isValidConfigCascadeInvalidationEvent({ type: 'channel', channelId: 123 })).toBe(
-        false
-      );
-    });
-
-    it('should reject "personality" event without personalityId', () => {
-      expect(isValidConfigCascadeInvalidationEvent({ type: 'personality' })).toBe(false);
-    });
-
-    it('should reject "all" event with extra properties', () => {
-      expect(isValidConfigCascadeInvalidationEvent({ type: 'all', extra: 'data' })).toBe(false);
-    });
-
-    it('should reject "admin" event with extra properties', () => {
-      expect(isValidConfigCascadeInvalidationEvent({ type: 'admin', extra: 'data' })).toBe(false);
-    });
-
-    it('should reject "user" event with wrong discordId type', () => {
-      expect(isValidConfigCascadeInvalidationEvent({ type: 'user', discordId: 123 })).toBe(false);
-    });
   });
 
   describe('publish', () => {

--- a/packages/cache-invalidation/src/ConfigCascadeCacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/ConfigCascadeCacheInvalidationService.ts
@@ -36,14 +36,13 @@ export type ConfigCascadeInvalidationEvent =
 /**
  * Type guard to validate ConfigCascadeInvalidationEvent structure
  */
-export const isValidConfigCascadeInvalidationEvent =
-  createEventValidator<ConfigCascadeInvalidationEvent>([
-    { type: 'user', fields: { discordId: 'string' } },
-    { type: 'personality', fields: { personalityId: 'string' } },
-    { type: 'channel', fields: { channelId: 'string' } },
-    { type: 'admin' },
-    { type: 'all' },
-  ]);
+const isValidConfigCascadeInvalidationEvent = createEventValidator<ConfigCascadeInvalidationEvent>([
+  { type: 'user', fields: { discordId: 'string' } },
+  { type: 'personality', fields: { personalityId: 'string' } },
+  { type: 'channel', fields: { channelId: 'string' } },
+  { type: 'admin' },
+  { type: 'all' },
+]);
 
 /**
  * Config Cascade Cache Invalidation Service

--- a/packages/cache-invalidation/src/LlmConfigCacheInvalidationService.test.ts
+++ b/packages/cache-invalidation/src/LlmConfigCacheInvalidationService.test.ts
@@ -3,10 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import {
-  LlmConfigCacheInvalidationService,
-  isValidLlmConfigInvalidationEvent,
-} from './LlmConfigCacheInvalidationService.js';
+import { LlmConfigCacheInvalidationService } from './LlmConfigCacheInvalidationService.js';
 import { REDIS_CHANNELS } from '@tzurot/common-types/constants/queue';
 
 // Mock logger
@@ -59,49 +56,6 @@ describe('LlmConfigCacheInvalidationService', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
-  });
-
-  describe('isValidLlmConfigInvalidationEvent', () => {
-    it('should validate "all" event type', () => {
-      expect(isValidLlmConfigInvalidationEvent({ type: 'all' })).toBe(true);
-    });
-
-    it('should validate "user" event type with discordId', () => {
-      expect(isValidLlmConfigInvalidationEvent({ type: 'user', discordId: '123' })).toBe(true);
-    });
-
-    it('should validate "config" event type with configId', () => {
-      expect(isValidLlmConfigInvalidationEvent({ type: 'config', configId: 'cfg-123' })).toBe(true);
-    });
-
-    it('should reject null', () => {
-      expect(isValidLlmConfigInvalidationEvent(null)).toBe(false);
-    });
-
-    it('should reject non-objects', () => {
-      expect(isValidLlmConfigInvalidationEvent('string')).toBe(false);
-      expect(isValidLlmConfigInvalidationEvent(123)).toBe(false);
-    });
-
-    it('should reject invalid event types', () => {
-      expect(isValidLlmConfigInvalidationEvent({ type: 'invalid' })).toBe(false);
-    });
-
-    it('should reject "user" event without discordId', () => {
-      expect(isValidLlmConfigInvalidationEvent({ type: 'user' })).toBe(false);
-    });
-
-    it('should reject "config" event without configId', () => {
-      expect(isValidLlmConfigInvalidationEvent({ type: 'config' })).toBe(false);
-    });
-
-    it('should reject "all" event with extra properties', () => {
-      expect(isValidLlmConfigInvalidationEvent({ type: 'all', extra: 'data' })).toBe(false);
-    });
-
-    it('should reject "user" event with wrong discordId type', () => {
-      expect(isValidLlmConfigInvalidationEvent({ type: 'user', discordId: 123 })).toBe(false);
-    });
   });
 
   describe('publish', () => {

--- a/packages/cache-invalidation/src/LlmConfigCacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/LlmConfigCacheInvalidationService.ts
@@ -32,7 +32,7 @@ type LlmConfigInvalidationEvent =
 /**
  * Type guard to validate LlmConfigInvalidationEvent structure
  */
-export const isValidLlmConfigInvalidationEvent = createEventValidator<LlmConfigInvalidationEvent>([
+const isValidLlmConfigInvalidationEvent = createEventValidator<LlmConfigInvalidationEvent>([
   { type: 'user', fields: { discordId: 'string' } },
   { type: 'config', fields: { configId: 'string' } },
   { type: 'all' },

--- a/packages/cache-invalidation/src/PersonaCacheInvalidationService.test.ts
+++ b/packages/cache-invalidation/src/PersonaCacheInvalidationService.test.ts
@@ -5,7 +5,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   PersonaCacheInvalidationService,
-  isValidPersonaInvalidationEvent,
   type PersonaInvalidationEvent,
 } from './PersonaCacheInvalidationService.js';
 import { REDIS_CHANNELS } from '@tzurot/common-types/constants/queue';
@@ -48,51 +47,6 @@ describe('PersonaCacheInvalidationService', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
-  });
-
-  describe('isValidPersonaInvalidationEvent', () => {
-    it('should validate user invalidation event', () => {
-      expect(isValidPersonaInvalidationEvent({ type: 'user', discordId: '123456' })).toBe(true);
-    });
-
-    it('should validate all invalidation event', () => {
-      expect(isValidPersonaInvalidationEvent({ type: 'all' })).toBe(true);
-    });
-
-    it('should reject null', () => {
-      expect(isValidPersonaInvalidationEvent(null)).toBe(false);
-    });
-
-    it('should reject undefined', () => {
-      expect(isValidPersonaInvalidationEvent(undefined)).toBe(false);
-    });
-
-    it('should reject non-objects', () => {
-      expect(isValidPersonaInvalidationEvent('string')).toBe(false);
-      expect(isValidPersonaInvalidationEvent(123)).toBe(false);
-    });
-
-    it('should reject invalid event types', () => {
-      expect(isValidPersonaInvalidationEvent({ type: 'unknown' })).toBe(false);
-    });
-
-    it('should reject user event without discordId', () => {
-      expect(isValidPersonaInvalidationEvent({ type: 'user' })).toBe(false);
-    });
-
-    it('should reject user event with wrong discordId type', () => {
-      expect(isValidPersonaInvalidationEvent({ type: 'user', discordId: 123 })).toBe(false);
-    });
-
-    it('should reject all event with extra properties', () => {
-      expect(isValidPersonaInvalidationEvent({ type: 'all', extra: 'field' })).toBe(false);
-    });
-
-    it('should reject user event with extra properties', () => {
-      expect(
-        isValidPersonaInvalidationEvent({ type: 'user', discordId: '123', extra: 'field' })
-      ).toBe(false);
-    });
   });
 
   describe('subscribe', () => {

--- a/packages/cache-invalidation/src/PersonaCacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/PersonaCacheInvalidationService.ts
@@ -30,8 +30,7 @@ export type PersonaInvalidationEvent = StandardInvalidationEvent;
 /**
  * Type guard to validate PersonaInvalidationEvent structure
  */
-export const isValidPersonaInvalidationEvent =
-  createStandardEventValidator<PersonaInvalidationEvent>();
+const isValidPersonaInvalidationEvent = createStandardEventValidator<PersonaInvalidationEvent>();
 
 /**
  * Persona Cache Invalidation Service

--- a/packages/cache-invalidation/src/SttResolverCacheInvalidationService.test.ts
+++ b/packages/cache-invalidation/src/SttResolverCacheInvalidationService.test.ts
@@ -7,10 +7,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import {
-  SttResolverCacheInvalidationService,
-  isValidSttResolverInvalidationEvent,
-} from './SttResolverCacheInvalidationService.js';
+import { SttResolverCacheInvalidationService } from './SttResolverCacheInvalidationService.js';
 import { REDIS_CHANNELS } from '@tzurot/common-types/constants/queue';
 import type { Redis } from 'ioredis';
 vi.mock('@tzurot/common-types/utils/logger', async importOriginal => {
@@ -25,34 +22,6 @@ vi.mock('@tzurot/common-types/utils/logger', async importOriginal => {
     }),
   };
 });
-describe('isValidSttResolverInvalidationEvent', () => {
-  it('accepts user event', () => {
-    expect(isValidSttResolverInvalidationEvent({ type: 'user', discordId: '123' })).toBe(true);
-  });
-
-  it('accepts all event', () => {
-    expect(isValidSttResolverInvalidationEvent({ type: 'all' })).toBe(true);
-  });
-
-  it('rejects user event missing discordId', () => {
-    expect(isValidSttResolverInvalidationEvent({ type: 'user' })).toBe(false);
-  });
-
-  it('rejects config event (STT has no per-config surface)', () => {
-    expect(isValidSttResolverInvalidationEvent({ type: 'config', configId: 'cfg' })).toBe(false);
-  });
-
-  it('rejects unknown event type', () => {
-    expect(isValidSttResolverInvalidationEvent({ type: 'mystery' })).toBe(false);
-  });
-
-  it('rejects null and primitives', () => {
-    expect(isValidSttResolverInvalidationEvent(null)).toBe(false);
-    expect(isValidSttResolverInvalidationEvent(undefined)).toBe(false);
-    expect(isValidSttResolverInvalidationEvent('not-an-object')).toBe(false);
-  });
-});
-
 describe('SttResolverCacheInvalidationService', () => {
   function makeService(): {
     service: SttResolverCacheInvalidationService;

--- a/packages/cache-invalidation/src/SttResolverCacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/SttResolverCacheInvalidationService.ts
@@ -26,11 +26,10 @@ import type { Redis } from 'ioredis';
 
 type SttResolverInvalidationEvent = { type: 'user'; discordId: string } | { type: 'all' };
 
-export const isValidSttResolverInvalidationEvent =
-  createEventValidator<SttResolverInvalidationEvent>([
-    { type: 'user', fields: { discordId: 'string' } },
-    { type: 'all' },
-  ]);
+const isValidSttResolverInvalidationEvent = createEventValidator<SttResolverInvalidationEvent>([
+  { type: 'user', fields: { discordId: 'string' } },
+  { type: 'all' },
+]);
 
 export class SttResolverCacheInvalidationService extends BaseCacheInvalidationService<SttResolverInvalidationEvent> {
   constructor(redis: Redis) {

--- a/packages/cache-invalidation/src/TtsConfigCacheInvalidationService.test.ts
+++ b/packages/cache-invalidation/src/TtsConfigCacheInvalidationService.test.ts
@@ -8,10 +8,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import {
-  TtsConfigCacheInvalidationService,
-  isValidTtsConfigInvalidationEvent,
-} from './TtsConfigCacheInvalidationService.js';
+import { TtsConfigCacheInvalidationService } from './TtsConfigCacheInvalidationService.js';
 import { REDIS_CHANNELS } from '@tzurot/common-types/constants/queue';
 import type { Redis } from 'ioredis';
 vi.mock('@tzurot/common-types/utils/logger', async importOriginal => {
@@ -26,38 +23,6 @@ vi.mock('@tzurot/common-types/utils/logger', async importOriginal => {
     }),
   };
 });
-describe('isValidTtsConfigInvalidationEvent', () => {
-  it('accepts user event', () => {
-    expect(isValidTtsConfigInvalidationEvent({ type: 'user', discordId: '123' })).toBe(true);
-  });
-
-  it('accepts config event', () => {
-    expect(isValidTtsConfigInvalidationEvent({ type: 'config', configId: 'cfg-uuid' })).toBe(true);
-  });
-
-  it('accepts all event', () => {
-    expect(isValidTtsConfigInvalidationEvent({ type: 'all' })).toBe(true);
-  });
-
-  it('rejects user event missing discordId', () => {
-    expect(isValidTtsConfigInvalidationEvent({ type: 'user' })).toBe(false);
-  });
-
-  it('rejects config event missing configId', () => {
-    expect(isValidTtsConfigInvalidationEvent({ type: 'config' })).toBe(false);
-  });
-
-  it('rejects unknown event type', () => {
-    expect(isValidTtsConfigInvalidationEvent({ type: 'mystery' })).toBe(false);
-  });
-
-  it('rejects null and primitives', () => {
-    expect(isValidTtsConfigInvalidationEvent(null)).toBe(false);
-    expect(isValidTtsConfigInvalidationEvent(undefined)).toBe(false);
-    expect(isValidTtsConfigInvalidationEvent('not-an-object')).toBe(false);
-  });
-});
-
 describe('TtsConfigCacheInvalidationService', () => {
   function makeService(): {
     service: TtsConfigCacheInvalidationService;

--- a/packages/cache-invalidation/src/TtsConfigCacheInvalidationService.ts
+++ b/packages/cache-invalidation/src/TtsConfigCacheInvalidationService.ts
@@ -28,7 +28,7 @@ type TtsConfigInvalidationEvent =
   { type: 'user'; discordId: string } | { type: 'config'; configId: string } | { type: 'all' };
 
 /** Type guard for incoming pub/sub events. */
-export const isValidTtsConfigInvalidationEvent = createEventValidator<TtsConfigInvalidationEvent>([
+const isValidTtsConfigInvalidationEvent = createEventValidator<TtsConfigInvalidationEvent>([
   { type: 'user', fields: { discordId: 'string' } },
   { type: 'config', fields: { configId: 'string' } },
   { type: 'all' },

--- a/packages/clients/src/clients/resultHelpers.test.ts
+++ b/packages/clients/src/clients/resultHelpers.test.ts
@@ -1,11 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  InfraError,
-  GatewayClientError,
-  nullOn404,
-  emptyOn404,
-  nullOnAnyError,
-} from './resultHelpers.js';
+import { InfraError, GatewayClientError, nullOn404 } from './resultHelpers.js';
 import type { GatewayResult } from './transport.js';
 
 // Builders for the two GatewayResult arms. The failure arm is kind-independent
@@ -105,45 +99,5 @@ describe('nullOn404', () => {
   it('throws GatewayClientError (not InfraError) on a non-404 4xx — no "try again"', () => {
     expect(() => nullOn404(forbidden())).toThrow(GatewayClientError);
     expect(() => nullOn404(forbidden())).not.toThrow(InfraError);
-  });
-});
-
-describe('emptyOn404', () => {
-  it('returns the array on success', () => {
-    expect(emptyOn404(ok([1, 2, 3]))).toEqual([1, 2, 3]);
-  });
-
-  it('returns [] ONLY on a genuine 404', () => {
-    expect(emptyOn404(notFound<number[]>())).toEqual([]);
-  });
-
-  it.each([
-    ['timeout', timeout<number[]>()],
-    ['network', network<number[]>()],
-    ['config', configError<number[]>()],
-    ['schema', schemaError<number[]>()],
-    ['5xx', serverError<number[]>()],
-  ])('throws InfraError on an infra failure (%s)', (_label, failure) => {
-    expect(() => emptyOn404(failure)).toThrow(InfraError);
-  });
-
-  it('throws GatewayClientError on a non-404 4xx', () => {
-    expect(() => emptyOn404(forbidden<number[]>())).toThrow(GatewayClientError);
-  });
-});
-
-describe('nullOnAnyError', () => {
-  it('returns the data on success', () => {
-    expect(nullOnAnyError(ok('value'))).toBe('value');
-  });
-
-  it.each([
-    ['404', notFound<string>()],
-    ['403', forbidden<string>()],
-    ['timeout', timeout<string>()],
-    ['network', network<string>()],
-    ['5xx', serverError<string>()],
-  ])('collapses every failure (%s) to null and never throws', (_label, failure) => {
-    expect(nullOnAnyError(failure)).toBeNull();
   });
 });

--- a/packages/clients/src/clients/resultHelpers.ts
+++ b/packages/clients/src/clients/resultHelpers.ts
@@ -10,23 +10,17 @@
  * really a transient blip. (Runtime-confirmed in prod: a `status: 0` transport
  * failure surfaced to a user as "Character not found".)
  *
- * Two collapse strategies, picked by the CALLER's needs:
+ * The collapse strategy (`nullOn404`) is for code that feeds a user-facing
+ * message: `null` means DEFINITIVELY absent (a real 404). An infra failure
+ * (5xx / timeout / network) THROWS `InfraError` → the command framework's "try
+ * again" message; a non-404 4xx (the request was rejected — retrying won't
+ * help) THROWS `GatewayClientError` → the generic error message.
  *
- *   - **Pattern B** (`nullOn404` / `emptyOn404`): for code that feeds a
- *     user-facing message. `null` / `[]` means DEFINITIVELY absent (a real 404).
- *     An infra failure (5xx / timeout / network) THROWS `InfraError` → the
- *     command framework's "try again" message; a non-404 4xx (the request was
- *     rejected — retrying won't help) THROWS `GatewayClientError` → the generic
- *     error message. The default for terminal command paths.
- *   - **Pattern A** (`nullOnAnyError`): for routing / mention-parsing paths that
- *     intentionally treat "unknown" as "no match" — a transient blip must not
- *     blind routing, so EVERY failure collapses to `null`. Use ONLY where a
- *     definitive negative is not surfaced to the user (and the caller does not
- *     negative-cache the `null`).
- *
- * Decision rule: result feeds a user message → Pattern B; result feeds further
- * logic / routing / aggregation → Pattern A, or thread the `GatewayResult`
- * through and branch on it explicitly.
+ * Decision rule: a genuine 404 collapses to `null`; every other failure throws,
+ * so a transient blip is never mistaken for a definitive "doesn't exist". A
+ * caller that needs to branch on the failure category rather than throw can
+ * thread the `GatewayResult` through and inspect it directly (see
+ * {@link isInfraFailure}).
  *
  * The `status > 0 ⟺ kind === 'http'` invariant (see `GatewayResult`) is what
  * makes `status === 404` an unambiguous "genuine miss": a `status: 0` infra
@@ -71,10 +65,9 @@ export class InfraError extends Error {
  * a caller wanting a resource-specific message (e.g. "you don't have access")
  * can catch this type.
  *
- * Distinct from {@link GatewayApiError}: that one is thrown by the transport
- * layer (the `callGatewayOrThrow` promise-based path); `GatewayClientError` is
- * thrown by these result-collapse helpers when a `GatewayResult` carries a
- * non-404 4xx.
+ * Distinct from {@link GatewayApiError}, which callers throw when they reject on
+ * a non-ok `GatewayResult`; `GatewayClientError` is thrown by these
+ * result-collapse helpers when a `GatewayResult` carries a non-404 4xx.
  */
 export class GatewayClientError extends Error {
   /** The 4xx status the gateway returned (e.g. 401/403/409). */
@@ -103,7 +96,7 @@ export function isInfraFailure(failure: GatewayFailure): boolean {
 }
 
 /**
- * Pattern B for single-resource reads. Returns the data on success, `null` ONLY
+ * Single-resource read collapse. Returns the data on success, `null` ONLY
  * on a genuine 404 — so `null` unambiguously means "the resource does not
  * exist". Other failures throw: {@link InfraError} for an infra failure (5xx /
  * timeout / network — "try again"), {@link GatewayClientError} for a non-404
@@ -120,32 +113,4 @@ export function nullOn404<T>(result: GatewayResult<T>): T | null {
     throw new InfraError(result);
   }
   throw new GatewayClientError(result);
-}
-
-/**
- * Pattern B for list reads. Returns the array on success, `[]` ONLY on a genuine
- * 404. Other failures throw: {@link InfraError} for an infra failure,
- * {@link GatewayClientError} for a non-404 4xx.
- */
-export function emptyOn404<T>(result: GatewayResult<T[]>): T[] {
-  if (result.ok) {
-    return result.data;
-  }
-  if (result.status === 404) {
-    return [];
-  }
-  if (isInfraFailure(result)) {
-    throw new InfraError(result);
-  }
-  throw new GatewayClientError(result);
-}
-
-/**
- * Pattern A for routing / mention-parsing. Collapses EVERY failure (including
- * infra) to `null` — "treat unknown as no match". Never throws. Use ONLY where a
- * transient failure must not surface a definitive negative to the user and the
- * caller does not negative-cache the `null`.
- */
-export function nullOnAnyError<T>(result: GatewayResult<T>): T | null {
-  return result.ok ? result.data : null;
 }

--- a/packages/clients/src/clients/transport.test.ts
+++ b/packages/clients/src/clients/transport.test.ts
@@ -8,8 +8,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { GATEWAY_TIMEOUTS } from '@tzurot/common-types/constants/discord';
-import { callGateway, callGatewayOrThrow } from './transport.js';
-import { GatewayApiError } from './errors.js';
+import { callGateway } from './transport.js';
 
 function jsonResponse(body: unknown, init?: ResponseInit): Response {
   return new Response(JSON.stringify(body), {
@@ -249,60 +248,5 @@ describe('callGateway', () => {
       }),
       'Request error'
     );
-  });
-});
-
-describe('callGatewayOrThrow', () => {
-  it('returns data on success', async () => {
-    fetchSpy.mockResolvedValueOnce(jsonResponse({ tz: 'UTC' }));
-    const data = await callGatewayOrThrow<{ tz: string }>(baseOpts);
-    expect(data).toEqual({ tz: 'UTC' });
-  });
-
-  it('throws GatewayApiError on non-2xx', async () => {
-    fetchSpy.mockResolvedValueOnce(
-      jsonResponse({ message: 'Forbidden', code: 'AUTH_REQUIRED' }, { status: 403 })
-    );
-    await expect(callGatewayOrThrow(baseOpts)).rejects.toMatchObject({
-      name: 'GatewayApiError',
-      message: 'Forbidden',
-      status: 403,
-      code: 'AUTH_REQUIRED',
-      kind: 'http',
-    });
-  });
-
-  it('throws GatewayApiError carrying kind:network on a network failure', async () => {
-    fetchSpy.mockRejectedValueOnce(new Error('ECONNREFUSED'));
-    // kind propagates to the throw path so try/catch callers get the same
-    // network-vs-timeout distinction the result path has.
-    const error = await callGatewayOrThrow(baseOpts).catch((e: unknown) => e);
-    expect(error).toBeInstanceOf(GatewayApiError);
-    expect(error).toMatchObject({ status: 0, kind: 'network' });
-  });
-
-  it('throws GatewayApiError carrying kind:timeout on a TimeoutError', async () => {
-    // The most user-relevant failure on a slow gateway — callGatewayOrThrow is a
-    // separate code path from callGateway, so assert the kind propagates here too.
-    const abortError = new Error('aborted');
-    abortError.name = 'TimeoutError';
-    fetchSpy.mockRejectedValueOnce(abortError);
-    const error = await callGatewayOrThrow(baseOpts).catch((e: unknown) => e);
-    expect(error).toBeInstanceOf(GatewayApiError);
-    expect(error).toMatchObject({ status: 0, kind: 'timeout' });
-  });
-
-  it('throws GatewayApiError carrying kind:schema + the Zod issues on contract drift', async () => {
-    // The raw Zod issues forward to the throw path too, so try/catch callers can
-    // inspect contract drift structurally instead of re-parsing the message.
-    const schema = z.object({ tz: z.string() });
-    fetchSpy.mockResolvedValueOnce(jsonResponse({ wrong: 'shape' }));
-    const error = await callGatewayOrThrow({ ...baseOpts, outputSchema: schema }).catch(
-      (e: unknown) => e
-    );
-    expect(error).toBeInstanceOf(GatewayApiError);
-    expect(error).toMatchObject({ status: 0, kind: 'schema' });
-    expect((error as GatewayApiError).issues).toEqual(expect.any(Array));
-    expect((error as GatewayApiError).issues?.length ?? 0).toBeGreaterThan(0);
   });
 });

--- a/packages/clients/src/clients/transport.ts
+++ b/packages/clients/src/clients/transport.ts
@@ -38,7 +38,7 @@ import { GATEWAY_TIMEOUTS } from '@tzurot/common-types/constants/discord';
 import { type ApiErrorSubcode } from '@tzurot/common-types/constants/error';
 import { CONTENT_TYPES } from '@tzurot/common-types/constants/media';
 import { isTimeoutError } from '@tzurot/common-types/utils/errors';
-import { GatewayApiError, type GatewayFailureKind, parseErrorResponse } from './errors.js';
+import { type GatewayFailureKind, parseErrorResponse } from './errors.js';
 
 /**
  * Result envelope mirroring the legacy `callGatewayApi` discriminated union.
@@ -96,8 +96,8 @@ export interface TransportOptions {
    * WARNING: when omitted, the response body is returned as `data` via an
    * unchecked `as T` cast — there is NO runtime contract enforcement. Generated
    * clients always pass `routeDef.output`, so this only bites direct callers of
-   * `callGateway` / `callGatewayOrThrow` that skip the schema. Omit only when
-   * the body is genuinely opaque (e.g. a passthrough proxy); otherwise pass one.
+   * `callGateway` that skip the schema. Omit only when the body is genuinely
+   * opaque (e.g. a passthrough proxy); otherwise pass one.
    */
   outputSchema?: z.ZodTypeAny;
   /** Optional logger callback for diagnostics. Avoids hard dep on pino. */
@@ -263,17 +263,4 @@ export async function callGateway<T>(options: TransportOptions): Promise<Gateway
     onWarn?.({ path, method, error: errorMessage, kind }, 'Request error');
     return { ok: false, kind, error: errorMessage, status: 0 };
   }
-}
-
-/**
- * Throwing variant: same contract as {@link callGateway}, but rejects
- * with `GatewayApiError` on non-ok responses. Useful for command handlers
- * that prefer try/catch over discriminated-union branching.
- */
-export async function callGatewayOrThrow<T>(options: TransportOptions): Promise<T> {
-  const result = await callGateway<T>(options);
-  if (!result.ok) {
-    throw new GatewayApiError(result.error, result.status, result.kind, result.code, result.issues);
-  }
-  return result.data;
 }

--- a/packages/clients/src/routes/types.test.ts
+++ b/packages/clients/src/routes/types.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, it, expect, expectTypeOf } from 'vitest';
 import { z } from 'zod';
-import { asActor, asSubject, resolveQueryShape, createPaginationSchema } from './types.js';
+import { asActor, asSubject, resolveQueryShape } from './types.js';
 import type { ActorDiscordId, SubjectDiscordId } from './types.js';
 
 describe('asActor', () => {
@@ -113,65 +113,5 @@ describe('resolveQueryShape', () => {
     const objectShape = resolveQueryShape(z.object({ a: z.string() }));
     expect(Object.keys(recordShape ?? {})).toEqual(['a']);
     expect(Object.keys(objectShape ?? {})).toEqual(['a']);
-  });
-});
-
-describe('createPaginationSchema', () => {
-  it('accepts a minimal valid input (all fields optional)', () => {
-    const schema = createPaginationSchema(['createdAt', 'updatedAt']);
-    expect(schema.safeParse({}).success).toBe(true);
-  });
-
-  it('accepts a fully-populated input', () => {
-    const schema = createPaginationSchema(['createdAt', 'updatedAt']);
-    const result = schema.safeParse({
-      limit: 20,
-      offset: 40,
-      sort: 'updatedAt',
-      order: 'desc',
-    });
-    expect(result.success).toBe(true);
-  });
-
-  it('rejects a sort value not in the declared sortFields tuple', () => {
-    const schema = createPaginationSchema(['createdAt']);
-    expect(schema.safeParse({ sort: 'notARealField' }).success).toBe(false);
-  });
-
-  it('rejects an order outside asc/desc', () => {
-    const schema = createPaginationSchema(['createdAt']);
-    expect(schema.safeParse({ order: 'random' }).success).toBe(false);
-  });
-
-  it('enforces limit bounds (1-100, integer)', () => {
-    const schema = createPaginationSchema(['createdAt']);
-    expect(schema.safeParse({ limit: 0 }).success).toBe(false);
-    expect(schema.safeParse({ limit: 101 }).success).toBe(false);
-    expect(schema.safeParse({ limit: 50.5 }).success).toBe(false);
-    expect(schema.safeParse({ limit: 50 }).success).toBe(true);
-  });
-
-  it('enforces offset >= 0', () => {
-    const schema = createPaginationSchema(['createdAt']);
-    expect(schema.safeParse({ offset: -1 }).success).toBe(false);
-    expect(schema.safeParse({ offset: 0 }).success).toBe(true);
-  });
-
-  it('produces a ZodObject that can be .extend()-ed with per-route fields', () => {
-    const base = createPaginationSchema(['createdAt', 'updatedAt']);
-    const extended = base.extend({ personalityId: z.string().uuid() });
-    expect(extended.safeParse({ personalityId: 'not-a-uuid' }).success).toBe(false);
-    expect(
-      extended.safeParse({ personalityId: '11111111-1111-4111-8111-111111111111' }).success
-    ).toBe(true);
-  });
-
-  it('preserves typed sortFields at the type level', () => {
-    const schema = createPaginationSchema(['createdAt', 'updatedAt']);
-    expect(schema).toBeDefined(); // runtime use so the factory result isn't dead
-    // Type-level assertion: sort is narrowed to the tuple, not generic string
-    expectTypeOf<z.infer<typeof schema>['sort']>().toEqualTypeOf<
-      'createdAt' | 'updatedAt' | undefined
-    >();
   });
 });

--- a/packages/clients/src/routes/types.ts
+++ b/packages/clients/src/routes/types.ts
@@ -174,8 +174,8 @@ export interface RouteDef<
    *   - `Record<string, ZodTypeAny>` — the "spread" form, one entry per
    *     query param. Use this for ad-hoc per-route queries.
    *   - `ZodObject<TQuery>` — the "schema" form. Use this when you want
-   *     to share a reusable query schema across routes (e.g., the
-   *     `createPaginationSchema(sortFields)` factory output). The codegen
+   *     to share a reusable query schema across routes (e.g., a shared
+   *     pagination schema built with `z.object()`). The codegen
    *     unwraps to `.shape` internally so the two forms are equivalent
    *     at the wire level; the schema form lets you `.extend()` it with
    *     per-route fields without copying the record entries.
@@ -342,42 +342,4 @@ export function resolveQueryShape(
     return query.shape;
   }
   return query;
-}
-
-// ============================================================================
-// Pagination factory (shared across paginated list endpoints)
-// ============================================================================
-
-/**
- * Build a reusable Zod object capturing the standard pagination params:
- * `limit`, `offset`, `sort`, `order`. Returned as a `ZodObject` so callers
- * can `.extend()` it with route-specific filters and `RouteDef.query`
- * accepts it directly.
- *
- * The `sortFields` tuple is preserved at the type level — generated clients
- * see `sort?: 'createdAt' | 'updatedAt'` rather than `sort?: string`,
- * catching drift between the route's declared sort fields and what callers
- * pass.
- *
- * @example
- * ```ts
- * const MemoryListQuery = createPaginationSchema(['createdAt', 'updatedAt']);
- * // RouteDef entry:
- * query: MemoryListQuery.extend({ personalityId: z.string().uuid() })
- * ```
- *
- * Defaults follow the project convention: `limit=20`, `offset=0`,
- * `sort=<first field>`, `order='desc'`. Callers wanting different defaults
- * can override on the returned schema's individual fields.
- */
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- Zod 4's enum-generic inference is too strict for a hand-written return signature; tuple sortFields would erode to `string` if explicitly typed. Inference preserves the narrow type via `const TSort`.
-export function createPaginationSchema<const TSort extends readonly [string, ...string[]]>(
-  sortFields: TSort
-) {
-  return z.object({
-    limit: z.number().int().min(1).max(100).optional(),
-    offset: z.number().int().min(0).optional(),
-    sort: z.enum(sortFields).optional(),
-    order: z.enum(['asc', 'desc'] as const).optional(),
-  });
 }

--- a/packages/common-types/src/schemas/api/shared.test.ts
+++ b/packages/common-types/src/schemas/api/shared.test.ts
@@ -4,54 +4,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { z } from 'zod';
-import { emptyToUndefined, emptyToNull, optionalString, nullableString } from './shared.js';
-
-describe('emptyToUndefined', () => {
-  // IMPORTANT: Use with `.optional()` INSIDE the preprocess, not outside
-  // This uses a union to accept either undefined or valid string
-  const schema = emptyToUndefined(z.union([z.undefined(), z.string().min(1)]));
-
-  it('should convert empty string to undefined', () => {
-    const result = schema.safeParse('');
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data).toBeUndefined();
-    }
-  });
-
-  it('should convert whitespace-only string to undefined', () => {
-    const result = schema.safeParse('   ');
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data).toBeUndefined();
-    }
-  });
-
-  it('should trim and keep valid strings', () => {
-    const result = schema.safeParse('  hello  ');
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data).toBe('hello');
-    }
-  });
-
-  it('should pass through non-string values', () => {
-    const numSchema = emptyToUndefined(z.number().optional());
-    const result = numSchema.safeParse(42);
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data).toBe(42);
-    }
-  });
-
-  it('should handle undefined input', () => {
-    const result = schema.safeParse(undefined);
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data).toBeUndefined();
-    }
-  });
-});
+import { emptyToNull, optionalString, nullableString } from './shared.js';
 
 describe('emptyToNull', () => {
   // IMPORTANT: Use with `.nullable()` INSIDE the preprocess, not outside

--- a/packages/common-types/src/schemas/api/shared.ts
+++ b/packages/common-types/src/schemas/api/shared.ts
@@ -14,32 +14,6 @@ const logger = createLogger('ZodSchemas');
 // ===========================================
 
 /**
- * Preprocess empty/whitespace strings to undefined.
- *
- * This is the STANDARD way to handle optional string fields from form inputs.
- * When users clear a field in a modal, the client often sends "" instead of
- * omitting the field. This transform lets `.optional()` work correctly.
- *
- * IMPORTANT: Use with `.optional()` on the INNER schema, not the outer result.
- *
- * @example
- * ```typescript
- * const schema = emptyToUndefined(z.string().min(1).optional());
- * schema.parse("");      // undefined
- * schema.parse("hello"); // "hello"
- * ```
- */
-export function emptyToUndefined<T extends z.ZodTypeAny>(schema: T): z.ZodType<z.infer<T>> {
-  return z.preprocess(val => {
-    if (typeof val === 'string') {
-      const trimmed = val.trim();
-      return trimmed.length === 0 ? undefined : trimmed;
-    }
-    return val;
-  }, schema);
-}
-
-/**
  * Preprocess empty/whitespace strings to null.
  *
  * Use for nullable fields where empty input should explicitly set null

--- a/packages/common-types/src/schemas/llmAdvancedParams.test.ts
+++ b/packages/common-types/src/schemas/llmAdvancedParams.test.ts
@@ -6,7 +6,6 @@ import {
   OutputParamsSchema,
   OpenRouterParamsSchema,
   AdvancedParamsSchema,
-  validateAdvancedParams,
   safeValidateAdvancedParams,
   hasReasoningEnabled,
   validateReasoningConstraints,
@@ -276,25 +275,6 @@ describe('LLM Advanced Params Schema', () => {
       });
       expect(result).toEqual({ temperature: 0.7 });
       expect(result).not.toHaveProperty('unknown_param');
-    });
-  });
-
-  describe('validateAdvancedParams', () => {
-    it('should return validated params', () => {
-      const params = { temperature: 0.5 };
-      expect(validateAdvancedParams(params)).toEqual(params);
-    });
-
-    it('should throw on invalid params', () => {
-      expect(() => validateAdvancedParams({ temperature: 5 })).toThrow();
-    });
-
-    it('should accept null (converts to empty object)', () => {
-      expect(validateAdvancedParams(null)).toEqual({});
-    });
-
-    it('should accept undefined (converts to empty object)', () => {
-      expect(validateAdvancedParams(undefined)).toEqual({});
     });
   });
 

--- a/packages/common-types/src/schemas/llmAdvancedParams.ts
+++ b/packages/common-types/src/schemas/llmAdvancedParams.ts
@@ -168,24 +168,6 @@ export type AdvancedParams = z.infer<typeof AdvancedParamsSchema>;
 // ============================================
 
 /**
- * Validate advancedParameters from database/user input.
- * Returns validated params or throws ZodError.
- *
- * Handles null/undefined from database JSONB by returning empty object.
- *
- * @param params - Raw params from database JSONB or user input
- * @returns Validated AdvancedParams
- * @throws ZodError if validation fails
- */
-export function validateAdvancedParams(params: unknown): AdvancedParams {
-  // Handle null/undefined from database JSONB
-  if (params === null || params === undefined) {
-    return {};
-  }
-  return AdvancedParamsSchema.parse(params);
-}
-
-/**
  * Safely validate advancedParameters, returning null on failure.
  * Logs validation errors at debug level.
  *

--- a/packages/identity/src/personality/PersonalityValidator.test.ts
+++ b/packages/identity/src/personality/PersonalityValidator.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { LlmConfigSchema, parseLlmConfig } from './PersonalityValidator.js';
+import { LlmConfigSchema } from './PersonalityValidator.js';
 import { Decimal } from '@prisma/client/runtime/client';
 
 describe('PersonalityValidator', () => {
@@ -121,60 +121,6 @@ describe('PersonalityValidator', () => {
 
       const result = LlmConfigSchema.safeParse(config);
       expect(result.success).toBe(false);
-    });
-  });
-
-  describe('parseLlmConfig', () => {
-    it('should parse valid config', () => {
-      const dbConfig = {
-        model: 'anthropic/claude-sonnet-4.5',
-        provider: 'openrouter',
-        temperature: new Decimal(0.7),
-        maxTokens: 4096,
-        topP: null,
-        topK: null,
-        frequencyPenalty: null,
-        presencePenalty: null,
-        memoryScoreThreshold: new Decimal(0.7),
-        memoryLimit: 10,
-        contextWindowTokens: 200000,
-      };
-
-      const result = parseLlmConfig(dbConfig);
-      expect(result).not.toBeNull();
-      expect(result?.model).toBe('anthropic/claude-sonnet-4.5');
-      expect(result?.temperature).toBe(0.7);
-      expect(result?.maxTokens).toBe(4096);
-    });
-
-    it('should handle config with invalid types gracefully', () => {
-      const invalidConfig = {
-        model: 'test-model',
-        provider: 'openrouter',
-        temperature: 'invalid', // Should be number, but coerceToNumber converts to undefined
-      };
-
-      const result = parseLlmConfig(invalidConfig);
-      // The coercion function converts invalid values to undefined, which is valid for optional fields
-      expect(result).not.toBeNull();
-      expect(result?.model).toBe('test-model');
-      expect(result?.temperature).toBeUndefined();
-    });
-
-    it('should return null for null config', () => {
-      const result = parseLlmConfig(null);
-      expect(result).toBeNull();
-    });
-
-    it('should handle config with out-of-range values', () => {
-      const invalidConfig = {
-        model: 'test-model',
-        provider: 'openrouter',
-        temperature: 5.0, // Out of range
-      };
-
-      const result = parseLlmConfig(invalidConfig);
-      expect(result).toBeNull();
     });
   });
 });

--- a/packages/identity/src/personality/PersonalityValidator.ts
+++ b/packages/identity/src/personality/PersonalityValidator.ts
@@ -72,34 +72,6 @@ export const LlmConfigSchema = z
   .nullish();
 
 /**
- * Inferred TypeScript type from the Zod schema
- */
-type LlmConfig = z.infer<typeof LlmConfigSchema>;
-
-/**
- * Safely parses an unknown database object into a clean LlmConfig object
- * @param dbConfig - Unknown config object from database
- * @returns Validated and transformed LlmConfig or null
- */
-export function parseLlmConfig(dbConfig: unknown): LlmConfig {
-  const result = LlmConfigSchema.safeParse(dbConfig);
-  if (result.success) {
-    return result.data;
-  }
-  // Log validation errors with field-level detail for debugging
-  const invalidFields = result.error.issues.map(issue => issue.path.join('.'));
-  logger.warn(
-    {
-      error: result.error.format(),
-      invalidFields,
-      receivedConfig: dbConfig,
-    },
-    'Failed to parse LLM config, using defaults'
-  );
-  return null;
-}
-
-/**
  * Raw LLM config shape from database (nested inside defaultConfigLink).
  *
  * Uses advancedParameters JSONB column instead of legacy individual columns.

--- a/packages/tooling/src/codegen/method-builder.test.ts
+++ b/packages/tooling/src/codegen/method-builder.test.ts
@@ -270,8 +270,8 @@ describe('buildMethod — user flavor', () => {
   });
 
   it('accepts a ZodObject query schema (not just Record<string, ZodTypeAny>)', () => {
-    // Shared/reusable query schemas (e.g., createPaginationSchema output) are
-    // ZodObjects, not plain Records. Codegen must unwrap via resolveQueryShape
+    // Shared/reusable query schemas (e.g., a pagination schema built with
+    // z.object) are ZodObjects, not plain Records. Codegen must unwrap via resolveQueryShape
     // so the generated client signature is identical for both forms.
     const querySchema = z.object({
       limit: z.number().int().optional(),


### PR DESCRIPTION
Part 1 of the sub-barrel dead-export cleanup epic — the bounded, no-tooling piece. Barrels still mask knip, so this is safe independent of the barrel-conversion work coming next.

## Deleted — 7 verified-dead functions
Each verified individually (the census counted JSDoc/comment mentions as references and excluded tests, so it over-flagged):
- **clients**: `emptyOn404`, `nullOnAnyError`, `callGatewayOrThrow` (used siblings `nullOn404`/`isInfraFailure` cover the need), `createPaginationSchema` (unused factory)
- **identity**: `parseLlmConfig` (unused DB-parse variant)
- **common-types**: `emptyToUndefined` (sibling `emptyToNull` is used), `validateAdvancedParams` (throwing variant; `safeValidateAdvancedParams` IS used)

Each removed the fn + JSDoc + colocated test + stale cross-file comment refs + orphaned imports/types.

## De-exported — 7 redundant guards
`cache-invalidation`'s 7 `isValid*InvalidationEvent` guards: used only in-file (passed to the base-class ctor), and their logic is line-covered by the shared factory tests, so the redundant per-domain `describe` blocks were removed with **no coverage loss**.

## NOT touched — verification overturned the census
- `hasReasoningEnabled` + `validateReasoningConstraints` — **intended-but-unwired** reasoning-token validation (`reasoning.max_tokens < max_tokens` is documented + tested but enforced nowhere). Filed as a real gap in `cold/follow-ups.md`, not deleted.
- 8 census-flagged "over-exports" that hold unique test coverage or real consumers (`asSubject`, `isValidInvalidationEvent`, `isValidDenylist…`, `buildShellPlaceholderPersonaName` [documented anti-drift export], `parseMessageMetadata`, `replacePlaceholders`, `deriveAvatarUrl`, `collectRefImageDescriptions`, `CONFIG_OVERRIDES_KEYS`).

## Verification
typecheck 25/25 · lint 25/25 · all affected package suites green (cache-invalidation 183, clients 162, common-types 2319, identity 159).

🤖 Generated with [Claude Code](https://claude.com/claude-code)