### PR TITLE
feat(tooling): guard:no-export-star (prevent barrel re-masking) + pathNot anchor

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -72,10 +72,12 @@ module.exports = {
       // modules (constants/discord.js, types/schemas/discord.js, utils/discord.js)
       // — ai-worker legitimately consumes those shared Discord types, which is
       // the rule's entire point. The `discord\.js` path pattern collides with
-      // those filenames; `pathNot: 'common-types'` keeps the ban on the library
-      // while allowing the shared types. (The root barrel hid this collision —
-      // ai-worker's imports resolved through index.js; deep imports exposed it.)
-      to: { path: 'discord\\.js', pathNot: 'packages/common-types/' },
+      // those filenames; `pathNot: '^packages/common-types/'` keeps the ban on
+      // the library while allowing the shared types. Anchored (like the sibling
+      // `^packages/...` rules) so a future `common-types-v2` isn't exempted.
+      // (The root barrel hid this collision — ai-worker's imports resolved
+      // through index.js; deep imports exposed it.)
+      to: { path: 'discord\\.js', pathNot: '^packages/common-types/' },
     },
   ],
   options: {

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -75,7 +75,7 @@ module.exports = {
       // those filenames; `pathNot: 'common-types'` keeps the ban on the library
       // while allowing the shared types. (The root barrel hid this collision —
       // ai-worker's imports resolved through index.js; deep imports exposed it.)
-      to: { path: 'discord\\.js', pathNot: 'common-types' },
+      to: { path: 'discord\\.js', pathNot: 'packages/common-types/' },
     },
   ],
   options: {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,9 @@ jobs:
       - name: Check for duplicate export names
         run: pnpm ops guard:duplicate-exports
 
+      - name: Check for export* barrels (re-mask knip)
+        run: pnpm ops guard:no-export-star
+
       - name: Check Dockerfile runner-stage dist copies
         run: pnpm ops guard:dockerfile-dist
 

--- a/docs/reference/tooling/OPS_CLI_REFERENCE.md
+++ b/docs/reference/tooling/OPS_CLI_REFERENCE.md
@@ -255,6 +255,9 @@ Structural enforcement checks that hard-fail CI on findings:
 | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
 | `pnpm ops guard:boundaries`                | Service-boundary imports (bot-client never imports Prisma directly, etc.) (audit-class, `--summary` not yet wired)           |
 | `pnpm ops guard:duplicate-exports`         | Same name exported from multiple files within a package (CI gate, intentionally not audit-class — no `--summary`)            |
+| `pnpm ops guard:no-export-star`            | Fail if any production `src/**` uses `export *` (re-masks knip's dead-export tracing) (CI gate, not audit-class)             |
+| `pnpm ops guard:dockerfile-dist`           | Service Dockerfile runner stages copy every runtime workspace dep's dist (CI gate, not audit-class)                          |
+| `pnpm ops guard:workflow-sync`             | Fail when the claude workflow files differ from origin/main (a develop-first change silently disables claude-review)         |
 | `pnpm ops guard:proposal-links`            | Every `docs/proposals/backlog/*.md` has an inbound link                                                                      |
 | `pnpm ops guard:proposal-links --summary`  | Emit JSONL summary line (for aggregator)                                                                                     |
 | `pnpm ops guard:audit-tool-docs`           | Every registered audit tool has a non-stub WHY.md (bidirectional check)                                                      |

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "backlog:lint": "tsx packages/tooling/src/cli.ts backlog",
     "ops:health": "tsx packages/tooling/src/cli.ts health",
     "test:tiers": "tsx packages/tooling/src/cli.ts test:tiers",
-    "quality": "pnpm lint && pnpm ops codegen:routes --check && pnpm ops codegen:command-types --check && pnpm ops topology:check && pnpm knip && pnpm knip:dead && pnpm cpd && pnpm ops cpd:check && pnpm ops test:audit && pnpm depcruise && pnpm typecheck && pnpm typecheck:spec && pnpm backlog:lint && pnpm ops guard:test-taxonomy && pnpm ops guard:workflow-sync && pnpm ops guard:proposal-links && pnpm ops guard:audit-tool-docs && pnpm ops guard:claude-content-refs && pnpm ops guard:duplicate-exports && pnpm ops guard:dockerfile-dist && pnpm ops commands:audit && pnpm ops xray --suppressions --check && pnpm ops lines:check && pnpm ops guard:gate-parity",
+    "quality": "pnpm lint && pnpm ops codegen:routes --check && pnpm ops codegen:command-types --check && pnpm ops topology:check && pnpm knip && pnpm knip:dead && pnpm cpd && pnpm ops cpd:check && pnpm ops test:audit && pnpm depcruise && pnpm typecheck && pnpm typecheck:spec && pnpm backlog:lint && pnpm ops guard:test-taxonomy && pnpm ops guard:workflow-sync && pnpm ops guard:proposal-links && pnpm ops guard:audit-tool-docs && pnpm ops guard:claude-content-refs && pnpm ops guard:duplicate-exports && pnpm ops guard:no-export-star && pnpm ops guard:dockerfile-dist && pnpm ops commands:audit && pnpm ops xray --suppressions --check && pnpm ops lines:check && pnpm ops guard:gate-parity",
     "focus:lint": "pnpm ops dev:lint",
     "focus:test": "pnpm ops dev:test",
     "focus:build": "pnpm ops dev:focus build",

--- a/packages/tooling/src/commands/guard.ts
+++ b/packages/tooling/src/commands/guard.ts
@@ -39,6 +39,17 @@ export function registerGuardCommands(cli: CAC): void {
 
   cli
     .command(
+      'guard:no-export-star',
+      'Fail if any production source uses `export *` (re-masks knip)'
+    )
+    .example('ops guard:no-export-star')
+    .action(async () => {
+      const { checkNoExportStar } = await import('../dev/check-no-export-star.js');
+      checkNoExportStar();
+    });
+
+  cli
+    .command(
       'guard:dockerfile-dist',
       'Check service Dockerfile runner stages copy every runtime workspace dep dist'
     )

--- a/packages/tooling/src/dev/check-no-export-star.test.ts
+++ b/packages/tooling/src/dev/check-no-export-star.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { isScannedSourceFile, findStarExports } from './check-no-export-star.js';
+
+describe('isScannedSourceFile', () => {
+  it('includes plain .ts production files', () => {
+    expect(isScannedSourceFile('/repo/packages/a/src/foo.ts')).toBe(true);
+  });
+
+  it('excludes test, spec, and declaration files', () => {
+    expect(isScannedSourceFile('/repo/packages/a/src/foo.test.ts')).toBe(false);
+    expect(isScannedSourceFile('/repo/packages/a/src/foo.spec.ts')).toBe(false);
+    expect(isScannedSourceFile('/repo/packages/a/src/foo.d.ts')).toBe(false);
+  });
+
+  it('exempts generated code and test infrastructure', () => {
+    expect(isScannedSourceFile('/repo/packages/a/src/generated/x.ts')).toBe(false);
+    expect(isScannedSourceFile('/repo/packages/a/src/clients/_generated/y.ts')).toBe(false);
+    expect(isScannedSourceFile('/repo/services/a/src/services/__mocks__/z.ts')).toBe(false);
+    expect(isScannedSourceFile('/repo/services/a/src/test/mocks/index.ts')).toBe(false);
+    expect(isScannedSourceFile('/repo/services/a/src/test/fixtures/f.ts')).toBe(false);
+  });
+});
+
+describe('findStarExports', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'guard-star-'));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function write(rel: string, content: string): void {
+    const full = join(tmp, rel);
+    mkdirSync(dirname(full), { recursive: true });
+    writeFileSync(full, content);
+  }
+
+  it('flags `export *` in production source, ignoring explicit re-exports + exempt paths', () => {
+    write(
+      'packages/a/src/index.ts',
+      "export * from './foo.js';\nexport { Bar } from './bar.js';\n"
+    );
+    write('packages/a/src/foo.ts', 'export const x = 1;\n');
+    write('packages/a/src/generated/gen.ts', "export * from './blah.js';\n"); // exempt (generated)
+    write('packages/a/src/index.test.ts', "export * from './foo.js';\n"); // exempt (test)
+    write('services/b/src/deep/re.ts', "  export * from '../thing.js';\n"); // flagged (indented)
+
+    const found = findStarExports(tmp);
+    const rels = found.map(v => v.filePath.slice(tmp.length + 1)).sort();
+
+    expect(rels).toEqual(['packages/a/src/index.ts', 'services/b/src/deep/re.ts']);
+    const idx = found.find(v => v.filePath.endsWith('index.ts'));
+    expect(idx?.line).toBe(1);
+    expect(idx?.text).toBe("export * from './foo.js';");
+  });
+
+  it('returns [] when nothing uses `export *`', () => {
+    write('packages/a/src/index.ts', "export { Bar } from './bar.js';\n");
+    expect(findStarExports(tmp)).toEqual([]);
+  });
+});

--- a/packages/tooling/src/dev/check-no-export-star.test.ts
+++ b/packages/tooling/src/dev/check-no-export-star.test.ts
@@ -64,4 +64,15 @@ describe('findStarExports', () => {
     write('packages/a/src/index.ts', "export { Bar } from './bar.js';\n");
     expect(findStarExports(tmp)).toEqual([]);
   });
+
+  it('ignores `export * as ns from` — a named binding knip can trace, not a masking wildcard', () => {
+    write('packages/a/src/index.ts', "export * as helpers from './helpers.js';\n");
+    expect(findStarExports(tmp)).toEqual([]);
+  });
+
+  it('ignores `export *` outside src/ (config/scripts files knip does not trace)', () => {
+    write('packages/a/vitest.config.ts', "export * from './base.js';\n");
+    write('packages/a/scripts/gen.ts', "export * from './templates.js';\n");
+    expect(findStarExports(tmp)).toEqual([]);
+  });
 });

--- a/packages/tooling/src/dev/check-no-export-star.test.ts
+++ b/packages/tooling/src/dev/check-no-export-star.test.ts
@@ -65,8 +65,16 @@ describe('findStarExports', () => {
     expect(findStarExports(tmp)).toEqual([]);
   });
 
-  it('ignores `export * as ns from` — a named binding knip can trace, not a masking wildcard', () => {
+  it('flags `export type * from` (TS 5.0+ wildcard type re-export masks knip too)', () => {
+    write('packages/a/src/types.ts', "export type * from './types-impl.js';\n");
+    expect(findStarExports(tmp).map(v => v.filePath.slice(tmp.length + 1))).toEqual([
+      'packages/a/src/types.ts',
+    ]);
+  });
+
+  it('ignores the `as ns` forms — named bindings knip can trace, not masking wildcards', () => {
     write('packages/a/src/index.ts', "export * as helpers from './helpers.js';\n");
+    write('packages/a/src/types.ts', "export type * as T from './types-impl.js';\n");
     expect(findStarExports(tmp)).toEqual([]);
   });
 

--- a/packages/tooling/src/dev/check-no-export-star.ts
+++ b/packages/tooling/src/dev/check-no-export-star.ts
@@ -22,6 +22,10 @@ const ROOTS = ['packages', 'services'] as const;
 const SKIP_DIRS = new Set(['node_modules', 'dist', '.turbo', 'coverage']);
 /** Files under these path segments aren't part of the dead-export surface. */
 const EXEMPT_PATH = /\/(generated|_generated|__mocks__)\/|\/test\/(mocks|fixtures)\//;
+// Matches a wildcard re-export `export * from '…'` — the shape that masks knip
+// (every re-exported name becomes untraceable). `export * as ns from '…'` is
+// deliberately NOT matched: it binds a single named `ns` export, which knip
+// traces like any named export, so it doesn't mask anything.
 const STAR_EXPORT = /^\s*export\s+\*\s+from\s+['"]/;
 
 export interface StarExportViolation {
@@ -65,19 +69,33 @@ function walk(dir: string, out: string[]): void {
   }
 }
 
-/** Find every `export * from '…'` in production source across the monorepo. */
+/**
+ * Find every `export * from '…'` under each package's `src/` across the
+ * monorepo. Scoped to `<pkg>/src` (not the whole package dir) to match knip's
+ * own `src/**` audit surface — an `export *` outside src/ (a config or scripts
+ * file) isn't traced by knip, so it can't mask anything knip would have caught.
+ */
 export function findStarExports(rootDir: string): StarExportViolation[] {
   const violations: StarExportViolation[] = [];
   for (const root of ROOTS) {
-    const files: string[] = [];
-    walk(join(rootDir, root), files);
-    for (const file of files) {
-      const lines = readFileSync(file, 'utf-8').split('\n');
-      lines.forEach((line, i) => {
-        if (STAR_EXPORT.test(line)) {
-          violations.push({ filePath: file, line: i + 1, text: line.trim() });
-        }
-      });
+    const rootPath = join(rootDir, root);
+    let packages: string[];
+    try {
+      packages = readdirSync(rootPath);
+    } catch {
+      continue; // root doesn't exist
+    }
+    for (const pkg of packages) {
+      const files: string[] = [];
+      walk(join(rootPath, pkg, 'src'), files);
+      for (const file of files) {
+        const lines = readFileSync(file, 'utf-8').split('\n');
+        lines.forEach((line, i) => {
+          if (STAR_EXPORT.test(line)) {
+            violations.push({ filePath: file, line: i + 1, text: line.trim() });
+          }
+        });
+      }
     }
   }
   return violations;

--- a/packages/tooling/src/dev/check-no-export-star.ts
+++ b/packages/tooling/src/dev/check-no-export-star.ts
@@ -1,0 +1,107 @@
+/**
+ * Guard: no `export *` barrels in production source.
+ *
+ * `export * from '…'` re-exports MASK knip's dead-export detection — knip can't
+ * trace which star-re-exported symbols are consumed, so it treats them all as
+ * used, and unused exports silently accumulate behind the barrel. The barrel-kill
+ * epic converted every barrel to explicit `export { A, type B } from '…'` (which
+ * knip CAN trace); this guard keeps it that way. A single new `export *` in
+ * production source re-masks the whole dead-export gate for that subtree.
+ *
+ * Exempt: generated code (`generated/`, `_generated/`) and test infrastructure
+ * (`__mocks__/`, `test/mocks/`, `test/fixtures/`) — those aren't part of the
+ * dead-export surface knip audits.
+ *
+ * This is a binary sync-check (like guard:duplicate-exports), NOT an audit-class
+ * tool: no threshold, no WHY.md, no --summary.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const ROOTS = ['packages', 'services'] as const;
+const SKIP_DIRS = new Set(['node_modules', 'dist', '.turbo', 'coverage']);
+/** Files under these path segments aren't part of the dead-export surface. */
+const EXEMPT_PATH = /\/(generated|_generated|__mocks__)\/|\/test\/(mocks|fixtures)\//;
+const STAR_EXPORT = /^\s*export\s+\*\s+from\s+['"]/;
+
+export interface StarExportViolation {
+  filePath: string;
+  line: number;
+  text: string;
+}
+
+/** A scanned production source file: `.ts`, not a test/declaration file, not exempt. */
+export function isScannedSourceFile(filePath: string): boolean {
+  return (
+    filePath.endsWith('.ts') &&
+    !filePath.endsWith('.test.ts') &&
+    !filePath.endsWith('.spec.ts') &&
+    !filePath.endsWith('.d.ts') &&
+    !EXEMPT_PATH.test(filePath)
+  );
+}
+
+function walk(dir: string, out: string[]): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return; // directory doesn't exist / not readable
+  }
+  for (const entry of entries) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    let stat: ReturnType<typeof statSync>;
+    try {
+      stat = statSync(full);
+    } catch {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      walk(full, out);
+    } else if (isScannedSourceFile(full)) {
+      out.push(full);
+    }
+  }
+}
+
+/** Find every `export * from '…'` in production source across the monorepo. */
+export function findStarExports(rootDir: string): StarExportViolation[] {
+  const violations: StarExportViolation[] = [];
+  for (const root of ROOTS) {
+    const files: string[] = [];
+    walk(join(rootDir, root), files);
+    for (const file of files) {
+      const lines = readFileSync(file, 'utf-8').split('\n');
+      lines.forEach((line, i) => {
+        if (STAR_EXPORT.test(line)) {
+          violations.push({ filePath: file, line: i + 1, text: line.trim() });
+        }
+      });
+    }
+  }
+  return violations;
+}
+
+export function checkNoExportStar(): void {
+  const rootDir = process.cwd();
+  const violations = findStarExports(rootDir);
+
+  if (violations.length === 0) {
+    console.log('✓ No `export *` barrels in production source.');
+    return;
+  }
+
+  console.error(
+    `❌ ${violations.length} \`export *\` re-export${violations.length === 1 ? '' : 's'} found — ` +
+      "these re-mask knip's dead-export detection."
+  );
+  for (const v of violations) {
+    console.error(`  ${relative(rootDir, v.filePath)}:${v.line}  ${v.text}`);
+  }
+  console.error(
+    "\nUse explicit `export { A, type B } from './x.js'` so knip can trace the " +
+      're-exports (barrel-kill epic). Generated code + test mocks/fixtures are exempt.'
+  );
+  process.exitCode = 1;
+}

--- a/packages/tooling/src/dev/check-no-export-star.ts
+++ b/packages/tooling/src/dev/check-no-export-star.ts
@@ -22,11 +22,12 @@ const ROOTS = ['packages', 'services'] as const;
 const SKIP_DIRS = new Set(['node_modules', 'dist', '.turbo', 'coverage']);
 /** Files under these path segments aren't part of the dead-export surface. */
 const EXEMPT_PATH = /\/(generated|_generated|__mocks__)\/|\/test\/(mocks|fixtures)\//;
-// Matches a wildcard re-export `export * from '…'` — the shape that masks knip
-// (every re-exported name becomes untraceable). `export * as ns from '…'` is
-// deliberately NOT matched: it binds a single named `ns` export, which knip
-// traces like any named export, so it doesn't mask anything.
-const STAR_EXPORT = /^\s*export\s+\*\s+from\s+['"]/;
+// Matches a wildcard re-export `export * from '…'` OR `export type * from '…'`
+// (TS 5.0+) — both mask knip (every re-exported name becomes untraceable). The
+// `as ns` forms (`export * as ns`, `export type * as ns`) are deliberately NOT
+// matched: they bind a single named export, which knip traces like any named
+// export, so they don't mask anything.
+const STAR_EXPORT = /^\s*export\s+(?:type\s+)?\*\s+from\s+['"]/;
 
 export interface StarExportViolation {
   filePath: string;

--- a/services/ai-worker/src/jobs/handlers/pipeline/index.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/index.ts
@@ -2,7 +2,16 @@
  * Pipeline exports
  */
 
-export * from './types.js';
+export {
+  type ConversationHistoryEntry,
+  type GenerationContext,
+  type IPipelineStep,
+  type Participant,
+  type PreparedContext,
+  type PreprocessingResults,
+  type ResolvedAuth,
+  type ResolvedConfig,
+} from './types.js';
 export { ValidationStep } from './steps/ValidationStep.js';
 export { NormalizationStep } from './steps/NormalizationStep.js';
 export { DependencyStep } from './steps/DependencyStep.js';


### PR DESCRIPTION
The council's "stop the flow" win from the barrel-audit pass — the highest-value part per the census (draining the existing stock is low-yield; stopping the *flow* of new masking is the real long-term protection).

## What
knip can't trace `export *` re-exports, so it treats every star-re-exported symbol as used — unused exports accumulate silently behind the barrel. The epic converted all 9 barrels + the last stray (ai-worker `pipeline/index.ts`) to explicit `export { … }`. This guard keeps it that way: **one new `export *` in production src re-masks the dead-export gate for that subtree.**

- **`guard:no-export-star`** — binary sync-check (like `guard:duplicate-exports`): scans `packages/*/src` + `services/*/src` for `export * from`, fails on any hit. Exempts `generated/`, `_generated/`, `__mocks__/`, `test/mocks/`, `test/fixtures/`. Wired into **both** `pnpm quality` and the CI lint job (gate-parity green).
- Convert the last stray `export *` (ai-worker `pipeline/index.ts`).
- Fold in a filed follow-up: anchor the `ai-worker-no-discord` depcruise `pathNot` from the substring `'common-types'` to `'packages/common-types/'` so a future `common-types-v2` can't be wrongly exempted.

## Verify
guard test 5/5 · `guard:gate-parity` in sync · depcruise still 0 · typecheck + lint clean. Confirmed the guard catches an injected `export *` (exit 1) and passes on the clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)