### PR TITLE
refactor(common-types): dedupe AI-job ack shape + finish blank-line sweep

### DIFF
--- a/packages/common-types/src/schemas/api/admin.ts
+++ b/packages/common-types/src/schemas/api/admin.ts
@@ -22,6 +22,7 @@ export const InvalidateCacheSchema = z
   .refine(data => data.all || (data.personalityId !== undefined && data.personalityId.length > 0), {
     message: 'Must provide either "personalityId" or "all: true"',
   });
+
 // ============================================================================
 // POST /admin/db-sync
 // ============================================================================

--- a/packages/common-types/src/schemas/api/ai.ts
+++ b/packages/common-types/src/schemas/api/ai.ts
@@ -27,50 +27,37 @@ import { z } from 'zod';
 import { JobStatus } from '../../constants/queue.js';
 
 /**
- * Shared envelope for AI-job responses: the queued / completed acknowledgment
- * shape used by both `/ai/generate` and `/ai/transcribe`.
+ * Shared field shape for the AI-job acknowledgment envelope — the queued /
+ * completed shape returned by `/ai/generate`, `/ai/transcribe`, and the shared
+ * ack. Defined once and spread into each named schema below: knip's
+ * duplicate-exports check rejects a pure alias (`X = Y`), but each `z.object(...)`
+ * call below is a distinct schema VALUE, so this stays DRY without aliasing —
+ * and the intention-revealing names remain the load-bearing piece for
+ * generated-client return types.
  *
- * `result` and `timestamp` are present only when `wait=true` was requested
- * on the transcribe route OR when the deduplication cache returns a
+ * `result` and `timestamp` are present only when `wait=true` was requested on
+ * the transcribe route OR when the deduplication cache returns a
  * previously-completed result; for the default async queueing path they're
- * absent.
+ * absent. `result` stays `z.unknown()` because the heavy payload (full LLM
+ * completion / transcription artifacts) is narrowed at the call site — see the
+ * file header for why it isn't validated here.
  */
-export const AiJobAckResponseSchema = z.object({
+const aiJobAckShape = {
   jobId: z.string(),
   requestId: z.string(),
   status: z.nativeEnum(JobStatus),
   result: z.unknown().optional(),
   timestamp: z.string().optional(),
-});
+};
 
-/**
- * Response shape for POST /ai/generate. Same envelope as the shared ack
- * but redeclared as its own z.object so the schema VALUE is distinct
- * (knip's duplicate-exports check rejects pure aliases). The intention-
- * revealing name is the load-bearing piece for generated-client return
- * types.
- */
-export const AiGenerateResponseSchema = z.object({
-  jobId: z.string(),
-  requestId: z.string(),
-  status: z.nativeEnum(JobStatus),
-  result: z.unknown().optional(),
-  timestamp: z.string().optional(),
-});
+/** Shared queued/completed ack envelope for AI-job responses. */
+export const AiJobAckResponseSchema = z.object(aiJobAckShape);
 
-/**
- * Response shape for POST /ai/transcribe. Same envelope as ack/generate
- * but redeclared for the same knip-duplicate-export reason. The `result`
- * field carries different content per route; typing it as `unknown` here
- * keeps the schema simple — route handlers narrow at the call site.
- */
-export const AiTranscribeResponseSchema = z.object({
-  jobId: z.string(),
-  requestId: z.string(),
-  status: z.nativeEnum(JobStatus),
-  result: z.unknown().optional(),
-  timestamp: z.string().optional(),
-});
+/** Response shape for POST /ai/generate. */
+export const AiGenerateResponseSchema = z.object(aiJobAckShape);
+
+/** Response shape for POST /ai/transcribe (`result` carries transcription content). */
+export const AiTranscribeResponseSchema = z.object(aiJobAckShape);
 
 /**
  * Response shape for GET /ai/job/:jobId — BullMQ job introspection.

--- a/packages/common-types/src/schemas/api/configOverrides.ts
+++ b/packages/common-types/src/schemas/api/configOverrides.ts
@@ -188,7 +188,9 @@ export const ResolvedConfigOverridesSchema = ConfigOverridesSchema.required().ex
  */
 type _ReservedKeysDoNotCollide =
   Extract<keyof ConfigOverrides, 'sources' | 'userOverrides'> extends never ? true : false;
+
 const _reservedKeysCheck: _ReservedKeysDoNotCollide = true;
+
 // Reference the check so `noUnusedLocals` keeps it. Compile-time guard only.
 void _reservedKeysCheck;
 
@@ -257,6 +259,7 @@ export const GetChannelConfigOverridesResponseSchema = z.object({
  * config layer (typed `settingId → apiField` map).
  */
 export const UpdateChannelConfigOverridesRequestSchema = z.record(z.string(), z.unknown());
+
 /** Response for PATCH /user/channel/:channelId/config-overrides — merged result echoed back. */
 export const UpdateChannelConfigOverridesResponseSchema = z.object({
   configOverrides: z.record(z.string(), z.unknown()),

--- a/packages/common-types/src/schemas/api/denylist.ts
+++ b/packages/common-types/src/schemas/api/denylist.ts
@@ -26,14 +26,17 @@ import { z } from 'zod';
 
 /** Who is being denied */
 export const denylistEntityTypeSchema = z.enum(['USER', 'GUILD']);
+
 export type DenylistEntityType = z.infer<typeof denylistEntityTypeSchema>;
 
 /** What level of denial */
 export const denylistScopeSchema = z.enum(['BOT', 'GUILD', 'CHANNEL', 'PERSONALITY']);
+
 export type DenylistScope = z.infer<typeof denylistScopeSchema>;
 
 /** Denial mode: BLOCK (full deny) or MUTE (don't respond but keep in context) */
 export const denylistModeSchema = z.enum(['BLOCK', 'MUTE']);
+
 export type DenylistMode = z.infer<typeof denylistModeSchema>;
 
 // ============================================================================

--- a/packages/common-types/src/schemas/api/memory.ts
+++ b/packages/common-types/src/schemas/api/memory.ts
@@ -28,6 +28,7 @@ export const PreviewTokenSchema = z
   .string()
   .regex(/^preview_[A-Za-z0-9_-]{16,64}$/, 'Invalid preview token format')
   .brand<'PreviewToken'>();
+
 /**
  * Branded type for purge confirmation. Same shape as `PreviewToken` but
  * a distinct brand so callers can't pass a delete-preview token to a
@@ -37,6 +38,7 @@ export const PurgeTokenSchema = z
   .string()
   .regex(/^purge_[A-Za-z0-9_-]{16,64}$/, 'Invalid purge token format')
   .brand<'PurgeToken'>();
+
 // ============================================================================
 // POST /user/memory/focus
 // ============================================================================

--- a/packages/common-types/src/schemas/api/shapes.ts
+++ b/packages/common-types/src/schemas/api/shapes.ts
@@ -48,6 +48,7 @@ export const ShapesAuthStatusResponseSchema = z.discriminatedUnion('hasCredentia
     expiresAt: z.string().nullable(),
   }),
 ]);
+
 // ============================================================================
 // /user/shapes/list
 // ============================================================================
@@ -110,6 +111,7 @@ export const ShapesImportJobSummarySchema = z
     importMetadata: z.unknown(),
   })
   .passthrough();
+
 export const ListShapesImportJobsResponseSchema = z.object({
   jobs: z.array(ShapesImportJobSummarySchema),
 });
@@ -164,6 +166,7 @@ export const ShapesExportJobSummarySchema = z
     downloadUrl: z.string().nullable(),
   })
   .passthrough();
+
 export const ListShapesExportJobsResponseSchema = z.object({
   jobs: z.array(ShapesExportJobSummarySchema),
 });

--- a/packages/common-types/src/schemas/api/usage.ts
+++ b/packages/common-types/src/schemas/api/usage.ts
@@ -19,6 +19,7 @@ export const UsageBreakdownSchema = z.object({
 
 /** Valid time periods for usage queries */
 export const UsagePeriodSchema = z.enum(['day', 'week', 'month', 'all']);
+
 export type UsagePeriod = z.infer<typeof UsagePeriodSchema>;
 
 /** Token usage statistics — per-user (returned by GET /user/usage). */

--- a/packages/common-types/src/schemas/api/voice-resolution.ts
+++ b/packages/common-types/src/schemas/api/voice-resolution.ts
@@ -32,6 +32,7 @@ export const TtsResolutionSourceSchema = z.enum([
   'free-default',
   'hardcoded',
 ]);
+
 export type TtsResolutionSource = z.infer<typeof TtsResolutionSourceSchema>;
 
 /** Resolved TTS view for one personality. */

--- a/packages/common-types/src/types/schemas/discord.ts
+++ b/packages/common-types/src/types/schemas/discord.ts
@@ -81,5 +81,7 @@ export const guildMemberInfoSchema = z.object({
 
 // Infer TypeScript types from schemas
 export type DiscordEnvironment = z.infer<typeof discordEnvironmentSchema>;
+
 export type AttachmentMetadata = z.infer<typeof attachmentMetadataSchema>;
+
 export type GuildMemberInfo = z.infer<typeof guildMemberInfoSchema>;

--- a/packages/common-types/src/types/schemas/generation.ts
+++ b/packages/common-types/src/types/schemas/generation.ts
@@ -15,6 +15,7 @@ import { loadedPersonalitySchema, requestContextSchema } from './personality.js'
  * tuple, so a new layer is a one-line change here.
  */
 export const CONFIG_SOURCE_IDS = ['personality', 'user-personality', 'user-default'] as const;
+
 export type ConfigSourceId = (typeof CONFIG_SOURCE_IDS)[number];
 
 /**
@@ -177,6 +178,8 @@ export const llmGenerationResultSchema = generationPayloadSchema.extend({
 
 // Infer TypeScript types from schemas
 export type GenerateRequest = z.infer<typeof generateRequestSchema>;
+
 /** Structured error info type for error classification consumers */
 export type ApiErrorInfo = z.infer<typeof errorInfoSchema>;
+
 export type LLMGenerationResult = z.infer<typeof llmGenerationResultSchema>;

--- a/packages/common-types/src/types/schemas/index.ts
+++ b/packages/common-types/src/types/schemas/index.ts
@@ -13,6 +13,7 @@ export {
   type GuildMemberInfo,
   guildMemberInfoSchema,
 } from './discord.js';
+
 export {
   apiConversationMessageSchema,
   type CrossChannelHistoryGroupEntry,
@@ -34,6 +35,7 @@ export {
   type StoredReferencedMessage,
   storedReferencedMessageSchema,
 } from './message.js';
+
 export {
   customFieldsSchema,
   isVoiceEnabled,
@@ -46,6 +48,7 @@ export {
   type RequestContext,
   requestContextSchema,
 } from './personality.js';
+
 export {
   type RawAssemblyInputs,
   rawAssemblyInputsSchema,
@@ -56,6 +59,7 @@ export {
   type RawMentionedRole,
   rawMentionedRoleSchema,
 } from './rawEnvelope.js';
+
 export {
   type ApiErrorInfo,
   CONFIG_SOURCE_IDS,

--- a/packages/common-types/src/types/schemas/message.ts
+++ b/packages/common-types/src/types/schemas/message.ts
@@ -47,6 +47,7 @@ export const apiConversationMessageSchema = z.object({
  * stored-history snapshot.
  */
 export const referenceAuthorRoleSchema = z.enum(['assistant', 'user', 'bot']);
+
 export type ReferenceAuthorRole = z.infer<typeof referenceAuthorRoleSchema>;
 
 /**
@@ -199,10 +200,17 @@ export const crossChannelHistoryGroupSchema = z.object({
 
 // Infer TypeScript types from schemas
 export type ReferencedMessage = z.infer<typeof referencedMessageSchema>;
+
 export type StoredReferencedMessage = z.infer<typeof storedReferencedMessageSchema>;
+
 export type ResolvedImageDescription = z.infer<typeof resolvedImageDescriptionSchema>;
+
 export type ReactionReactor = z.infer<typeof reactionReactorSchema>;
+
 export type MessageReaction = z.infer<typeof messageReactionSchema>;
+
 export type MessageMetadata = z.infer<typeof messageMetadataSchema>;
+
 export type CrossChannelMessage = z.infer<typeof crossChannelMessageSchema>;
+
 export type CrossChannelHistoryGroupEntry = z.infer<typeof crossChannelHistoryGroupSchema>;

--- a/packages/common-types/src/types/schemas/personality.ts
+++ b/packages/common-types/src/types/schemas/personality.ts
@@ -240,5 +240,7 @@ export function isVoiceEnabled(personality: LoadedPersonality): boolean {
 }
 
 export type MentionedPersona = z.infer<typeof mentionedPersonaSchema>;
+
 export type ReferencedChannel = z.infer<typeof referencedChannelSchema>;
+
 export type RequestContext = z.infer<typeof requestContextSchema>;

--- a/packages/common-types/src/types/schemas/rawEnvelope.ts
+++ b/packages/common-types/src/types/schemas/rawEnvelope.ts
@@ -167,6 +167,9 @@ export const rawAssemblyInputsSchema = z.object({
 });
 
 export type RawDiscordUser = z.infer<typeof rawDiscordUserSchema>;
+
 export type RawMentionedChannel = z.infer<typeof rawMentionedChannelSchema>;
+
 export type RawMentionedRole = z.infer<typeof rawMentionedRoleSchema>;
+
 export type RawAssemblyInputs = z.infer<typeof rawAssemblyInputsSchema>;


### PR DESCRIPTION
The DRY-sweep follow-up from the barrel-audit epic, plus the genuinely-complete blank-line restoration.

## What
- **Dedupe the AI-job ack shape.** `AiJobAckResponseSchema`, `AiGenerateResponseSchema`, and `AiTranscribeResponseSchema` had byte-identical 5-field shapes, each redeclared inline to dodge knip's pure-alias rejection. Extract the shape once (`aiJobAckShape`) and spread it into three distinct `z.object(...)` calls — distinct schema **values** (no alias), intention-revealing **names** preserved (load-bearing for generated-client return types), zero copy-paste.
- **Finish the blank-line sweep.** The #1479 passes only restored separation after `});` object-closes; claude-review flagged (twice) that other statement-end shapes were still abutting. This sweeps **all** top-level statement ends — `);`, `]);`, `.passthrough();`, `.brand<…>();`, `export const` — 36 spots across 13 files, prettier-normalized. `);`-style closes now separated too.

## Verify
typecheck 0 · `ai.test.ts` 10/10 · `guard:duplicate-exports` clean · purely type/formatting — no runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)