### PR TITLE
feat(api-gateway): warn when LLM reasoning budget leaves no room for the response

### DIFF
--- a/packages/common-types/src/schemas/api/ai.test.ts
+++ b/packages/common-types/src/schemas/api/ai.test.ts
@@ -47,7 +47,7 @@ describe('AiJobAckResponseSchema', () => {
 });
 
 describe('AiGenerateResponseSchema and AiTranscribeResponseSchema', () => {
-  it('share the ack envelope shape (both alias AiJobAckResponseSchema)', () => {
+  it('share the ack envelope shape (distinct schema values built from aiJobAckShape)', () => {
     const sample = { jobId: 'j', requestId: 'r', status: JobStatus.Queued };
     expect(AiGenerateResponseSchema.safeParse(sample).success).toBe(true);
     expect(AiTranscribeResponseSchema.safeParse(sample).success).toBe(true);

--- a/services/api-gateway/src/services/LlmConfigService.test.ts
+++ b/services/api-gateway/src/services/LlmConfigService.test.ts
@@ -11,6 +11,7 @@ import {
   CloneNameExhaustedError,
   type LlmConfigScope,
 } from './LlmConfigService.js';
+import { warnOnReasoningConstraintViolation } from './reasoningConstraintCheck.js';
 import { ADMIN_SETTINGS_SINGLETON_ID } from '@tzurot/common-types/schemas/api/adminSettings';
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import type { LlmConfigCacheInvalidationService } from '@tzurot/cache-invalidation';
@@ -30,6 +31,14 @@ vi.mock('@tzurot/common-types/utils/logger', async () => {
     }),
   };
 });
+
+// Mock the reasoning-constraint check so create/update seam tests can assert the
+// wiring (that the right `advancedParameters` is forwarded) without depending on
+// the module logger instance. The real check logic is tested in
+// reasoningConstraintCheck.test.ts.
+vi.mock('./reasoningConstraintCheck.js', () => ({
+  warnOnReasoningConstraintViolation: vi.fn(),
+}));
 
 // Helper to create mock Prisma client
 function createMockPrisma() {
@@ -299,6 +308,25 @@ describe('LlmConfigService', () => {
         })
       );
       expect(cacheService.invalidateAll).toHaveBeenCalled();
+    });
+
+    it('forwards advancedParameters to the reasoning-constraint check (seam)', async () => {
+      prisma.llmConfig.create.mockResolvedValue(sampleConfigDetail);
+      const advancedParameters = { max_tokens: 1024, reasoning: { max_tokens: 2000 } };
+
+      await service.create(
+        { type: 'GLOBAL' },
+        { name: 'T', model: 'm', advancedParameters },
+        'owner'
+      );
+
+      // Asserts create() forwards the SAVED params (not e.g. a dropped/swapped
+      // value) across the seam — the real warn logic is tested separately.
+      expect(warnOnReasoningConstraintViolation).toHaveBeenCalledWith(
+        expect.anything(),
+        { configId: 'config-123' },
+        advancedParameters
+      );
     });
 
     it('should create a user config for USER scope', async () => {
@@ -611,6 +639,19 @@ describe('LlmConfigService', () => {
         select: expect.any(Object),
       });
       expect(cacheService.invalidateAll).toHaveBeenCalled();
+    });
+
+    it('forwards advancedParameters to the reasoning-constraint check (seam)', async () => {
+      prisma.llmConfig.update.mockResolvedValue(sampleConfigDetail);
+      const advancedParameters = { max_tokens: 1024, reasoning: { max_tokens: 2000 } };
+
+      await service.update('config-123', { advancedParameters });
+
+      expect(warnOnReasoningConstraintViolation).toHaveBeenCalledWith(
+        expect.anything(),
+        { configId: 'config-123' },
+        advancedParameters
+      );
     });
 
     it('should update memory settings', async () => {

--- a/services/api-gateway/src/services/LlmConfigService.ts
+++ b/services/api-gateway/src/services/LlmConfigService.ts
@@ -31,6 +31,7 @@ import { type LlmConfigCacheInvalidationService } from '@tzurot/cache-invalidati
 import { isPrismaUniqueConstraintErrorOn } from '../utils/prismaErrors.js';
 import { CloneNameExhaustedError, AutoSuffixCollisionError } from './LlmConfigErrors.js';
 import { resolveNonCollidingName } from './llmConfigNameCollision.js';
+import { warnOnReasoningConstraintViolation } from './reasoningConstraintCheck.js';
 import { compareConfigsForList, derivePointerSets } from './llmConfigListHelpers.js';
 
 // Re-exported so route/test importers keep a stable `from './LlmConfigService.js'`
@@ -367,6 +368,8 @@ export class LlmConfigService {
       'Created LLM config'
     );
 
+    warnOnReasoningConstraintViolation(logger, { configId: config.id }, data.advancedParameters);
+
     // Invalidate list caches
     await this.invalidateCacheSafely('create', config.id);
 
@@ -428,6 +431,8 @@ export class LlmConfigService {
     });
 
     logger.info({ configId, updates: Object.keys(updateData) }, 'Updated LLM config');
+
+    warnOnReasoningConstraintViolation(logger, { configId }, data.advancedParameters);
 
     await this.invalidateCacheSafely('update', configId);
 

--- a/services/api-gateway/src/services/reasoningConstraintCheck.test.ts
+++ b/services/api-gateway/src/services/reasoningConstraintCheck.test.ts
@@ -56,12 +56,12 @@ describe('warnOnReasoningConstraintViolation', () => {
     const logger = { warn: vi.fn() };
     warnOnReasoningConstraintViolation(
       logger,
-      { configId: 'c1', name: 'my-config' },
+      { configId: 'c1' },
       { max_tokens: 1024, reasoning: { max_tokens: 2000 } }
     );
     expect(logger.warn).toHaveBeenCalledTimes(1);
     expect(logger.warn).toHaveBeenCalledWith(
-      { configId: 'c1', name: 'my-config', reasoningMaxTokens: 2000, maxTokens: 1024 },
+      { configId: 'c1', reasoningMaxTokens: 2000, maxTokens: 1024 },
       expect.stringContaining('reasoning.max_tokens >= max_tokens')
     );
   });

--- a/services/api-gateway/src/services/reasoningConstraintCheck.test.ts
+++ b/services/api-gateway/src/services/reasoningConstraintCheck.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  reasoningConstraintViolation,
+  warnOnReasoningConstraintViolation,
+} from './reasoningConstraintCheck.js';
+
+// reasoning.max_tokens is schema-bounded to [1024, 32000], so fixtures use
+// values in that range — a sub-1024 reasoning budget is rejected at parse
+// (safeValidateAdvancedParams → null) before the constraint is even checked.
+describe('reasoningConstraintViolation', () => {
+  it('flags reasoning.max_tokens >= max_tokens (no room for the response)', () => {
+    expect(
+      reasoningConstraintViolation({ max_tokens: 1024, reasoning: { max_tokens: 2000 } })
+    ).toEqual({ reasoningMaxTokens: 2000, maxTokens: 1024 });
+    // equal is still a violation (0 tokens left for the response)
+    expect(
+      reasoningConstraintViolation({ max_tokens: 2000, reasoning: { max_tokens: 2000 } })
+    ).toEqual({ reasoningMaxTokens: 2000, maxTokens: 2000 });
+  });
+
+  it('returns null when reasoning fits within max_tokens', () => {
+    expect(
+      reasoningConstraintViolation({ max_tokens: 5000, reasoning: { max_tokens: 2000 } })
+    ).toBeNull();
+  });
+
+  it('returns null when reasoning is not enabled', () => {
+    expect(
+      reasoningConstraintViolation({
+        max_tokens: 1024,
+        reasoning: { enabled: false, max_tokens: 2000 },
+      })
+    ).toBeNull();
+    expect(reasoningConstraintViolation({ max_tokens: 1024 })).toBeNull();
+  });
+
+  it('returns null when either budget is absent (nothing to compare)', () => {
+    // no top-level max_tokens
+    expect(reasoningConstraintViolation({ reasoning: { max_tokens: 2000 } })).toBeNull();
+    // reasoning enabled by effort only, no reasoning.max_tokens
+    expect(
+      reasoningConstraintViolation({ max_tokens: 1024, reasoning: { effort: 'high' } })
+    ).toBeNull();
+  });
+
+  it('returns null for unparseable input', () => {
+    expect(reasoningConstraintViolation('garbage')).toBeNull();
+    expect(reasoningConstraintViolation(undefined)).toBeNull();
+    expect(reasoningConstraintViolation({ max_tokens: 'not-a-number' })).toBeNull();
+  });
+});
+
+describe('warnOnReasoningConstraintViolation', () => {
+  it('warns (never throws) with the config context on a violation', () => {
+    const logger = { warn: vi.fn() };
+    warnOnReasoningConstraintViolation(
+      logger,
+      { configId: 'c1', name: 'my-config' },
+      { max_tokens: 1024, reasoning: { max_tokens: 2000 } }
+    );
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      { configId: 'c1', name: 'my-config', reasoningMaxTokens: 2000, maxTokens: 1024 },
+      expect.stringContaining('reasoning.max_tokens >= max_tokens')
+    );
+  });
+
+  it('stays silent when there is no violation', () => {
+    const logger = { warn: vi.fn() };
+    warnOnReasoningConstraintViolation(
+      logger,
+      { configId: 'c1' },
+      { max_tokens: 5000, reasoning: { max_tokens: 2000 } }
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});

--- a/services/api-gateway/src/services/reasoningConstraintCheck.ts
+++ b/services/api-gateway/src/services/reasoningConstraintCheck.ts
@@ -1,0 +1,62 @@
+/**
+ * Reasoning-budget sanity check for LLM config `advancedParameters`.
+ *
+ * `reasoning.max_tokens >= max_tokens` means the reasoning budget would consume
+ * the entire token allowance, leaving no room for the actual response. We WARN
+ * rather than reject on save: an existing config may already violate this
+ * (rejecting would block an unrelated edit to it), and OpenRouter may clamp the
+ * budget anyway — but a silent misconfiguration truncates output with no signal,
+ * so surfacing it in the logs is the useful middle ground.
+ */
+import {
+  safeValidateAdvancedParams,
+  hasReasoningEnabled,
+  validateReasoningConstraints,
+} from '@tzurot/common-types/schemas/llmAdvancedParams';
+
+/** Minimal structural logger — matches the pino logger's `warn(obj, msg)`. */
+interface WarnLogger {
+  warn: (obj: Record<string, unknown>, msg: string) => void;
+}
+
+/**
+ * If `advancedParameters` enable reasoning with a budget that leaves no room for
+ * the response (`reasoning.max_tokens >= max_tokens`), return the offending
+ * values for logging; otherwise `null`. Pure — the caller decides what to do.
+ */
+export function reasoningConstraintViolation(
+  advancedParameters: unknown
+): { reasoningMaxTokens: number; maxTokens: number } | null {
+  const params = safeValidateAdvancedParams(advancedParameters);
+  if (params === null) {
+    return null; // unparseable — the read path coerces to {}
+  }
+  if (!hasReasoningEnabled(params)) {
+    return null;
+  }
+  if (validateReasoningConstraints(params)) {
+    return null;
+  }
+  // Constraint violated ⇒ both values are defined (validateReasoningConstraints
+  // returns valid when either is undefined); the `?? 0` guards are unreachable.
+  return {
+    reasoningMaxTokens: params.reasoning?.max_tokens ?? 0,
+    maxTokens: params.max_tokens ?? 0,
+  };
+}
+
+/** Warn (never reject) when the reasoning budget leaves no room for the response. */
+export function warnOnReasoningConstraintViolation(
+  logger: WarnLogger,
+  context: { configId: string; name?: string },
+  advancedParameters: unknown
+): void {
+  const violation = reasoningConstraintViolation(advancedParameters);
+  if (violation === null) {
+    return;
+  }
+  logger.warn(
+    { ...context, ...violation },
+    'LLM config saved with reasoning.max_tokens >= max_tokens; reasoning may leave no room for the response'
+  );
+}

--- a/services/api-gateway/src/services/reasoningConstraintCheck.ts
+++ b/services/api-gateway/src/services/reasoningConstraintCheck.ts
@@ -48,7 +48,7 @@ export function reasoningConstraintViolation(
 /** Warn (never reject) when the reasoning budget leaves no room for the response. */
 export function warnOnReasoningConstraintViolation(
   logger: WarnLogger,
-  context: { configId: string; name?: string },
+  context: { configId: string },
   advancedParameters: unknown
 ): void {
   const violation = reasoningConstraintViolation(advancedParameters);


### PR DESCRIPTION
The last backlog follow-up from the barrel-audit epic — wiring a validation that had tests but no callers.

## What
`validateReasoningConstraints` + `hasReasoningEnabled` (common-types) implement the rule **`reasoning.max_tokens < max_tokens`** (reasoning must leave room for the actual response) and were fully unit-tested — but **nothing called them**, so the constraint was enforced nowhere.

Wire it in **WARN mode** (per the owner's call): on `LlmConfigService` create/update, if the saved `advancedParameters` enable reasoning with a budget that swallows the whole token allowance, **log a warning but still save.**

**Why warn, not reject:** an existing config may already violate this — a hard reject would block an unrelated edit to it — and OpenRouter may clamp the budget anyway. But a silent misconfiguration truncates output with no signal, so surfacing it in the logs is the useful middle ground.

## Shape
- New `reasoningConstraintCheck.ts`: pure `reasoningConstraintViolation()` + a `warnOnReasoningConstraintViolation()` wrapper. Extracted to its own module so `LlmConfigService.ts` stays under the 400-line `max-lines` ceiling (it was already at it).
- Wired into both create and update paths.
- Folds in #1482's review nit: fixes the stale "alias" wording in `ai.test.ts`.

## Verify
7 new tests (pure predicate across bounds + the warn wrapper asserts logger.warn args) · typecheck 0 · full `LlmConfigService` suite green · `reasoning.max_tokens` schema-bound `[1024, 32000]` accounted for in fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)