### PR TITLE
fix(ai-worker): model-agnostic canonical vision cache + filename-bearing failure placeholder

### DIFF
--- a/packages/common-types/src/constants/queue.ts
+++ b/packages/common-types/src/constants/queue.ts
@@ -57,8 +57,14 @@ export const REDIS_KEY_PREFIXES = {
   WEBHOOK_MESSAGE: 'webhook:',
   /** Prefix for voice transcript cache */
   VOICE_TRANSCRIPT: 'transcript:',
-  /** Prefix for vision description cache (keyed by image URL) */
-  VISION_DESCRIPTION: 'vision:',
+  /**
+   * Prefix for the model-AGNOSTIC "best available" vision description (two-tier
+   * cache). Every consumer reads this, so a free-tier user gets a description a
+   * paid model already produced. Writes are tier-promoted (a weaker model can't
+   * clobber a stronger model's description). Deliberately distinct from the
+   * retired legacy per-model `vision:` prefix, whose entries just aged out.
+   */
+  VISION_CANONICAL: 'vision:canon:',
   /** Key for OpenRouter models cache */
   OPENROUTER_MODELS: 'openrouter:models',
   /** Prefix for request deduplication cache */

--- a/services/ai-worker/src/services/RAGUtils.ts
+++ b/services/ai-worker/src/services/RAGUtils.ts
@@ -21,8 +21,8 @@ const logger = createLogger('RAGUtils');
 /**
  * Bare placeholder descriptions that should be filtered from content.
  * These are generic type labels produced when processing fails completely.
- * Vision failure descriptions like `[Image unavailable: bad_request]` are NOT
- * filtered — they provide useful context about what was in the message.
+ * Vision failure placeholders (`[Image … couldn't be processed …]`) are NOT
+ * filtered — they tell the model an image was there and how to respond.
  */
 const BARE_PLACEHOLDERS = new Set(['[image]', '[audio]', '[unsupported format]']);
 

--- a/services/ai-worker/src/services/VisionDescriptionCache.component.test.ts
+++ b/services/ai-worker/src/services/VisionDescriptionCache.component.test.ts
@@ -33,7 +33,7 @@ describe('VisionDescriptionCache Integration', () => {
       const description = 'A colorful sunset over the ocean with clouds';
 
       // Store description with attachmentId and url
-      await cache.store({ attachmentId, url: imageUrl }, description);
+      await cache.store({ model: 'test/paid-model', attachmentId, url: imageUrl }, description);
 
       // Retrieve description using attachmentId
       const retrieved = await cache.get({ attachmentId, url: imageUrl });
@@ -59,8 +59,8 @@ describe('VisionDescriptionCache Integration', () => {
       const description2 = 'A group of people at a party';
 
       // Store both
-      await cache.store({ attachmentId: id1, url: url1 }, description1);
-      await cache.store({ attachmentId: id2, url: url2 }, description2);
+      await cache.store({ model: 'test/paid-model', attachmentId: id1, url: url1 }, description1);
+      await cache.store({ model: 'test/paid-model', attachmentId: id2, url: url2 }, description2);
 
       // Retrieve and verify both
       const retrieved1 = await cache.get({ attachmentId: id1, url: url1 });
@@ -77,10 +77,10 @@ describe('VisionDescriptionCache Integration', () => {
       const description2 = 'Updated description with more detail';
 
       // Store first version
-      await cache.store({ attachmentId, url }, description1);
+      await cache.store({ model: 'test/paid-model', attachmentId, url }, description1);
 
       // Overwrite with second version
-      await cache.store({ attachmentId, url }, description2);
+      await cache.store({ model: 'test/paid-model', attachmentId, url }, description2);
 
       // Should return the updated version
       const retrieved = await cache.get({ attachmentId, url });
@@ -96,7 +96,7 @@ describe('VisionDescriptionCache Integration', () => {
       const ttl = 1; // 1 second
 
       // Store with short TTL
-      await cache.store({ attachmentId, url }, description, ttl);
+      await cache.store({ model: 'test/paid-model', attachmentId, url }, description, ttl);
 
       // Should be available immediately
       const immediate = await cache.get({ attachmentId, url });
@@ -117,7 +117,7 @@ describe('VisionDescriptionCache Integration', () => {
       const url = 'https://cdn.discordapp.com/attachments/999/111/empty.png';
       const emptyDescription = '';
 
-      await cache.store({ attachmentId, url }, emptyDescription);
+      await cache.store({ model: 'test/paid-model', attachmentId, url }, emptyDescription);
 
       // Empty string is treated as null (intentional behavior)
       // The cache checks `description.length > 0` before returning
@@ -130,7 +130,7 @@ describe('VisionDescriptionCache Integration', () => {
       const url = 'https://cdn.discordapp.com/attachments/222/333/detailed.png';
       const longDescription = 'This is a very detailed image showing '.repeat(100);
 
-      await cache.store({ attachmentId, url }, longDescription);
+      await cache.store({ model: 'test/paid-model', attachmentId, url }, longDescription);
 
       const retrieved = await cache.get({ attachmentId, url });
       expect(retrieved).toBe(longDescription);
@@ -142,7 +142,7 @@ describe('VisionDescriptionCache Integration', () => {
       const specialDescription =
         'Image shows: "quoted text", <html tags>, 日本語, 🎨 emojis, \n newlines';
 
-      await cache.store({ attachmentId, url }, specialDescription);
+      await cache.store({ model: 'test/paid-model', attachmentId, url }, specialDescription);
 
       const retrieved = await cache.get({ attachmentId, url });
       expect(retrieved).toBe(specialDescription);
@@ -154,10 +154,24 @@ describe('VisionDescriptionCache Integration', () => {
         'https://cdn.discordapp.com/attachments/123/456/image%20with%20spaces.png?ex=abc&is=def';
       const description = 'A normal image description';
 
-      await cache.store({ attachmentId, url }, description);
+      await cache.store({ model: 'test/paid-model', attachmentId, url }, description);
 
       const retrieved = await cache.get({ attachmentId, url });
       expect(retrieved).toBe(description);
+    });
+  });
+
+  describe('Tier promotion (real Redis)', () => {
+    it('keeps a paid description over a later free-model store, and serves it model-agnostically', async () => {
+      const attachmentId = '135791357913579135';
+      const url = 'https://cdn.discordapp.com/attachments/135/791/promoted.png';
+
+      await cache.store({ model: 'qwen/qwen3.7-plus', attachmentId, url }, 'paid description');
+      await cache.store({ model: 'openrouter/free', attachmentId, url }, 'weak free description');
+
+      // The free-tier write must NOT clobber the paid entry, and a read without
+      // any model (e.g. the stored-reference hydrator) must still hit it.
+      expect(await cache.get({ attachmentId, url })).toBe('paid description');
     });
   });
 
@@ -167,8 +181,14 @@ describe('VisionDescriptionCache Integration', () => {
       const otherId = '999000111222333444';
       const url = 'https://cdn.discordapp.com/attachments/123/456/image.png';
 
-      await cache.store({ attachmentId: baseId, url }, 'Base ID description');
-      await cache.store({ attachmentId: otherId, url }, 'Other ID description');
+      await cache.store(
+        { model: 'test/paid-model', attachmentId: baseId, url },
+        'Base ID description'
+      );
+      await cache.store(
+        { model: 'test/paid-model', attachmentId: otherId, url },
+        'Other ID description'
+      );
 
       // Should be different cache entries based on attachmentId
       const baseResult = await cache.get({ attachmentId: baseId, url });

--- a/services/ai-worker/src/services/VisionDescriptionCache.test.ts
+++ b/services/ai-worker/src/services/VisionDescriptionCache.test.ts
@@ -1,13 +1,13 @@
 /**
  * Unit Tests for VisionDescriptionCache
  *
- * Covers Redis L1 cache for vision descriptions and per-category negative cache.
- * (L2 PostgreSQL was removed in beta.110 — see VisionDescriptionCache.ts header.)
+ * Two-tier cache: a model-AGNOSTIC canonical success key (tier-promoted) + a
+ * per-model negative cache. (L2 PostgreSQL was removed in beta.110.)
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Redis } from 'ioredis';
-import { VisionDescriptionCache } from './VisionDescriptionCache.js';
+import { VisionDescriptionCache, shouldPromoteCanonical } from './VisionDescriptionCache.js';
 import { ApiErrorCategory } from '@tzurot/common-types/constants/error';
 import { REDIS_KEY_PREFIXES } from '@tzurot/common-types/constants/queue';
 import { INTERVALS } from '@tzurot/common-types/constants/timing';
@@ -19,20 +19,37 @@ vi.mock('@tzurot/common-types/utils/logger', async () => {
   );
   return {
     ...actual,
-    createLogger: () => ({
-      info: vi.fn(),
-      debug: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    }),
+    createLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   };
 });
 
+const CANON = REDIS_KEY_PREFIXES.VISION_CANONICAL;
+const FAIL = REDIS_KEY_PREFIXES.VISION_FAILURE;
+
+function canonicalEntry(description: string, tier: number, tsOffsetMs = 0): string {
+  return JSON.stringify({ description, model: 'm', tier, ts: Date.now() + tsOffsetMs });
+}
+
+describe('shouldPromoteCanonical (pure promotion decision)', () => {
+  const now = 1_000_000_000;
+  it('promotes when nothing is cached', () => {
+    expect(shouldPromoteCanonical(null, 1, now)).toBe(true);
+  });
+  it('promotes an equal-or-higher tier (paid over free, or same-tier refresh)', () => {
+    expect(shouldPromoteCanonical({ tier: 1, ts: now }, 2, now)).toBe(true);
+    expect(shouldPromoteCanonical({ tier: 2, ts: now }, 2, now)).toBe(true);
+  });
+  it('does NOT promote a lower tier over a higher one (no race to the bottom)', () => {
+    expect(shouldPromoteCanonical({ tier: 2, ts: now }, 1, now)).toBe(false);
+  });
+  it('promotes over a stale (>24h) entry regardless of tier', () => {
+    const staleTs = now - 25 * 60 * 60 * 1000;
+    expect(shouldPromoteCanonical({ tier: 2, ts: staleTs }, 1, now)).toBe(true);
+  });
+});
+
 describe('VisionDescriptionCache', () => {
-  let mockRedis: {
-    setex: ReturnType<typeof vi.fn>;
-    get: ReturnType<typeof vi.fn>;
-  };
+  let mockRedis: { setex: ReturnType<typeof vi.fn>; get: ReturnType<typeof vi.fn> };
   let cache: VisionDescriptionCache;
 
   beforeEach(() => {
@@ -44,206 +61,196 @@ describe('VisionDescriptionCache', () => {
     cache = new VisionDescriptionCache(mockRedis as unknown as Redis);
   });
 
-  describe('storeFailure (per-category cache policy)', () => {
-    it('should cache AUTHENTICATION failures with SHORT TTL (5min)', async () => {
-      await cache.storeFailure({
-        attachmentId: '123',
-        url: 'https://example.com/image.png',
-        category: ApiErrorCategory.AUTHENTICATION,
-      });
-
+  describe('store / get — canonical (model-agnostic) success cache', () => {
+    it('stores a canonical JSON entry under the model-agnostic key', async () => {
+      await cache.store({ attachmentId: '123', url: 'u', model: 'qwen/qwen3.7-plus' }, 'a cat');
       expect(mockRedis.setex).toHaveBeenCalledWith(
-        `${REDIS_KEY_PREFIXES.VISION_FAILURE}id:123`,
-        INTERVALS.VISION_FAILURE_TTL_SHORT,
-        expect.stringContaining(`"category":"${ApiErrorCategory.AUTHENTICATION}"`)
+        `${CANON}id:123`,
+        INTERVALS.VISION_DESCRIPTION_TTL,
+        expect.stringContaining('"description":"a cat"')
       );
     });
 
-    it('should cache QUOTA_EXCEEDED failures with SHORT TTL (5min)', async () => {
-      await cache.storeFailure({
-        attachmentId: '123',
-        url: 'https://example.com/image.png',
-        category: ApiErrorCategory.QUOTA_EXCEEDED,
-      });
-
-      const [, ttl] = mockRedis.setex.mock.calls[0];
-      expect(ttl).toBe(INTERVALS.VISION_FAILURE_TTL_SHORT);
+    it('serves a paid model’s description to a DIFFERENT (free) model — the free-tier fix', async () => {
+      // A paid model already cached the description (canonical, model-agnostic).
+      mockRedis.get.mockResolvedValueOnce(canonicalEntry('a cat on a keyboard', 2));
+      // A free-tier read hits the SAME canonical key and gets it — no re-describe.
+      const result = await cache.get({ attachmentId: '123', url: 'u', model: 'openrouter/free' });
+      expect(result).toBe('a cat on a keyboard');
     });
 
-    it('should cache CONTENT_POLICY failures with LONG TTL (60min)', async () => {
-      await cache.storeFailure({
-        attachmentId: '123',
-        url: 'https://example.com/image.png',
-        category: ApiErrorCategory.CONTENT_POLICY,
-      });
-
-      const [, ttl] = mockRedis.setex.mock.calls[0];
-      expect(ttl).toBe(INTERVALS.VISION_FAILURE_TTL_LONG);
+    it('returns null on miss', async () => {
+      mockRedis.get.mockResolvedValueOnce(null);
+      expect(await cache.get({ attachmentId: '123', url: 'u' })).toBeNull();
     });
 
-    it('should cache MEDIA_NOT_FOUND failures with LONG TTL', async () => {
-      await cache.storeFailure({
-        attachmentId: '123',
-        url: 'https://example.com/image.png',
-        category: ApiErrorCategory.MEDIA_NOT_FOUND,
-      });
-
-      const [, ttl] = mockRedis.setex.mock.calls[0];
-      expect(ttl).toBe(INTERVALS.VISION_FAILURE_TTL_LONG);
+    it('returns null (not a throw) on a corrupt canonical entry', async () => {
+      mockRedis.get.mockResolvedValueOnce('not json');
+      expect(await cache.get({ attachmentId: '123', url: 'u' })).toBeNull();
     });
 
-    it('should cache RATE_LIMIT (transient retryable) with default TTL (10min)', async () => {
-      await cache.storeFailure({
-        attachmentId: '123',
-        url: 'https://example.com/image.png',
-        category: ApiErrorCategory.RATE_LIMIT,
-      });
-
-      const [, ttl] = mockRedis.setex.mock.calls[0];
-      expect(ttl).toBe(INTERVALS.VISION_FAILURE_TTL);
+    it('returns null on a valid-JSON entry with the wrong shape (e.g. a legacy bare string)', async () => {
+      // Parses fine but has none of the CanonicalEntry fields — treated as absent.
+      mockRedis.get.mockResolvedValueOnce(JSON.stringify({ foo: 1 }));
+      expect(await cache.get({ attachmentId: '123', url: 'u' })).toBeNull();
     });
 
-    it('should embed cachedAt timestamp in the stored value', async () => {
+    it('uses the SAME canonical key for any model (model-agnostic)', async () => {
+      await cache.store({ attachmentId: '123', url: 'u', model: 'qwen/qwen3.7-plus' }, 'a');
+      await cache.store({ attachmentId: '123', url: 'u', model: 'openai/gpt-4o' }, 'b');
+      expect(mockRedis.setex.mock.calls[0][0]).toBe(`${CANON}id:123`);
+      expect(mockRedis.setex.mock.calls[1][0]).toBe(`${CANON}id:123`);
+    });
+  });
+
+  describe('store — tier promotion', () => {
+    it('does NOT overwrite a paid (tier 2) description with a free (tier 1) one', async () => {
+      mockRedis.get.mockResolvedValueOnce(canonicalEntry('paid desc', 2));
+      await cache.store(
+        { attachmentId: '123', url: 'u', model: 'openrouter/free' },
+        'weak free desc'
+      );
+      expect(mockRedis.setex).not.toHaveBeenCalled();
+    });
+
+    it('treats an empty-string model as the LOWEST tier (fail-safe, cannot clobber paid)', async () => {
+      // `model: ''` satisfies the `string` type but must not claim PAID
+      // (isFreeModel('') is false) — the runtime backstop maps it to FREE.
+      mockRedis.get.mockResolvedValueOnce(canonicalEntry('paid desc', 2));
+      await cache.store({ attachmentId: '123', url: 'u', model: '' }, 'unknown-origin desc');
+      expect(mockRedis.setex).not.toHaveBeenCalled();
+    });
+
+    it('promotes a paid (tier 2) description over an existing free (tier 1) one', async () => {
+      mockRedis.get.mockResolvedValueOnce(canonicalEntry('free desc', 1));
+      await cache.store({ attachmentId: '123', url: 'u', model: 'qwen/qwen3.7-plus' }, 'paid desc');
+      expect(mockRedis.setex).toHaveBeenCalledWith(
+        `${CANON}id:123`,
+        INTERVALS.VISION_DESCRIPTION_TTL,
+        expect.stringContaining('"description":"paid desc"')
+      );
+    });
+  });
+
+  describe('storeFailure (per-model, per-category cache policy)', () => {
+    it('caches AUTHENTICATION failures with SHORT TTL under the per-model failure key', async () => {
       await cache.storeFailure({
         attachmentId: '123',
-        url: 'https://example.com/image.png',
+        url: 'u',
+        model: 'openrouter/free',
         category: ApiErrorCategory.AUTHENTICATION,
       });
+      const [key, ttl, value] = mockRedis.setex.mock.calls[0];
+      expect(key).toBe(`${FAIL}openrouter_free:id:123`); // per-model — a paid model isn't blocked
+      expect(ttl).toBe(INTERVALS.VISION_FAILURE_TTL_SHORT);
+      expect(value).toContain(`"category":"${ApiErrorCategory.AUTHENTICATION}"`);
+    });
 
-      const [, , value] = mockRedis.setex.mock.calls[0];
-      const parsed = JSON.parse(value);
-      expect(parsed.cachedAt).toBeDefined();
+    it('caches CONTENT_POLICY + MEDIA_NOT_FOUND with LONG TTL, RATE_LIMIT with default', async () => {
+      const cases: [ApiErrorCategory, number][] = [
+        [ApiErrorCategory.CONTENT_POLICY, INTERVALS.VISION_FAILURE_TTL_LONG],
+        [ApiErrorCategory.MEDIA_NOT_FOUND, INTERVALS.VISION_FAILURE_TTL_LONG],
+        [ApiErrorCategory.RATE_LIMIT, INTERVALS.VISION_FAILURE_TTL],
+        [ApiErrorCategory.QUOTA_EXCEEDED, INTERVALS.VISION_FAILURE_TTL_SHORT],
+      ];
+      for (const [category, expectedTtl] of cases) {
+        mockRedis.setex.mockClear();
+        await cache.storeFailure({ attachmentId: '123', url: 'u', category });
+        expect(mockRedis.setex.mock.calls[0][1]).toBe(expectedTtl);
+      }
+    });
+
+    it('embeds an ISO cachedAt timestamp', async () => {
+      await cache.storeFailure({
+        attachmentId: '123',
+        url: 'u',
+        category: ApiErrorCategory.AUTHENTICATION,
+      });
+      const parsed = JSON.parse(mockRedis.setex.mock.calls[0][2]);
       expect(typeof parsed.cachedAt).toBe('string');
-      // Should parse as a valid ISO date
       expect(() => new Date(parsed.cachedAt).toISOString()).not.toThrow();
     });
 
-    it('should use URL-hash fallback key when attachmentId is missing', async () => {
+    it('falls back to a URL-hash key when attachmentId is missing', async () => {
       await cache.storeFailure({
-        url: 'https://example.com/image.png?ex=abc',
+        url: 'https://x/i.png?ex=abc',
         category: ApiErrorCategory.AUTHENTICATION,
       });
-
-      const [key] = mockRedis.setex.mock.calls[0];
-      expect(key).toMatch(new RegExp(`^${REDIS_KEY_PREFIXES.VISION_FAILURE}url:[a-f0-9]+$`));
+      expect(mockRedis.setex.mock.calls[0][0]).toMatch(new RegExp(`^${FAIL}url:[a-f0-9]+$`));
     });
 
-    it('should not throw on Redis errors', async () => {
+    it('does not throw on Redis errors', async () => {
       mockRedis.setex.mockRejectedValueOnce(new Error('Redis down'));
       await expect(
         cache.storeFailure({
           attachmentId: '123',
-          url: 'https://example.com/image.png',
+          url: 'u',
           category: ApiErrorCategory.AUTHENTICATION,
         })
       ).resolves.toBeUndefined();
     });
   });
 
+  describe('wiring/seam: real store→promote→get chain over a stateful Redis fake', () => {
+    // Replays the production bug scenario end-to-end with only Redis mocked:
+    // a paid model describes an image; a free-tier request for the SAME image
+    // must read that description; a later free-model store must not clobber it.
+    it('free tier reads the paid description; a weaker store cannot clobber it', async () => {
+      const kv = new Map<string, string>();
+      const statefulRedis = {
+        get: vi.fn((key: string) => Promise.resolve(kv.get(key) ?? null)),
+        setex: vi.fn((key: string, _ttl: number, value: string) => {
+          kv.set(key, value);
+          return Promise.resolve('OK');
+        }),
+      };
+      const seamCache = new VisionDescriptionCache(statefulRedis as unknown as Redis);
+      const image = {
+        attachmentId: '1522411708520333492',
+        url: 'https://cdn.discordapp.com/a.png',
+      };
+
+      // 1. Paid model describes and stores.
+      await seamCache.store({ ...image, model: 'qwen/qwen3.7-plus' }, 'a cat on a keyboard');
+      // 2. Free-tier request reads the SAME image — gets the paid description.
+      expect(await seamCache.get({ ...image, model: 'openrouter/free' })).toBe(
+        'a cat on a keyboard'
+      );
+      // 3. A weaker (free) store cannot clobber it...
+      await seamCache.store({ ...image, model: 'openrouter/free' }, 'weak free description');
+      expect(await seamCache.get(image)).toBe('a cat on a keyboard');
+      // 4. ...but an equal-tier (paid) store refreshes it.
+      await seamCache.store({ ...image, model: 'anthropic/claude-sonnet-4' }, 'better description');
+      expect(await seamCache.get(image)).toBe('better description');
+    });
+  });
+
   describe('getFailure', () => {
-    it('should return null when no entry cached', async () => {
+    it('returns null when no entry cached', async () => {
       mockRedis.get.mockResolvedValueOnce(null);
-      const result = await cache.getFailure({
-        attachmentId: '123',
-        url: 'https://example.com/image.png',
-      });
-      expect(result).toBeNull();
+      expect(await cache.getFailure({ attachmentId: '123', url: 'u' })).toBeNull();
     });
 
-    it('should return entry with category + cachedAt on hit', async () => {
+    it('returns the category + cachedAt on hit', async () => {
       const cachedAt = '2026-04-28T18:22:42.000Z';
       mockRedis.get.mockResolvedValueOnce(
         JSON.stringify({ category: ApiErrorCategory.AUTHENTICATION, cachedAt })
       );
-      const result = await cache.getFailure({
-        attachmentId: '123',
-        url: 'https://example.com/image.png',
-      });
-      expect(result).toEqual({ category: ApiErrorCategory.AUTHENTICATION, cachedAt });
-    });
-
-    it('should return null on Redis errors (fail open)', async () => {
-      mockRedis.get.mockRejectedValueOnce(new Error('Redis down'));
-      const result = await cache.getFailure({
-        attachmentId: '123',
-        url: 'https://example.com/image.png',
-      });
-      expect(result).toBeNull();
-    });
-
-    it('should use URL-hash fallback key when attachmentId is missing', async () => {
-      mockRedis.get.mockResolvedValueOnce(null);
-      await cache.getFailure({ url: 'https://example.com/image.png' });
-      const [key] = mockRedis.get.mock.calls[0];
-      expect(key).toMatch(new RegExp(`^${REDIS_KEY_PREFIXES.VISION_FAILURE}url:[a-f0-9]+$`));
-    });
-  });
-
-  describe('store / get (success cache)', () => {
-    it('should store description with default TTL', async () => {
-      await cache.store({ attachmentId: '123', url: 'https://example.com/image.png' }, 'a cat');
-      expect(mockRedis.setex).toHaveBeenCalledWith(
-        `${REDIS_KEY_PREFIXES.VISION_DESCRIPTION}id:123`,
-        INTERVALS.VISION_DESCRIPTION_TTL,
-        'a cat'
-      );
-    });
-
-    it('should return cached description on hit', async () => {
-      mockRedis.get.mockResolvedValueOnce('a cat');
-      const result = await cache.get({
-        attachmentId: '123',
-        url: 'https://example.com/image.png',
-      });
-      expect(result).toBe('a cat');
-    });
-
-    it('should return null on miss', async () => {
-      mockRedis.get.mockResolvedValueOnce(null);
-      const result = await cache.get({
-        attachmentId: '123',
-        url: 'https://example.com/image.png',
-      });
-      expect(result).toBeNull();
-    });
-  });
-
-  describe('model namespacing (cache key includes the resolved vision model)', () => {
-    it('produces different keys for different models on the same attachment', async () => {
-      await cache.store({ attachmentId: '123', url: 'u', model: 'qwen/qwen3.7-plus' }, 'desc-a');
-      await cache.store({ attachmentId: '123', url: 'u', model: 'openai/gpt-4o' }, 'desc-b');
-
-      const keyA = mockRedis.setex.mock.calls[0][0] as string;
-      const keyB = mockRedis.setex.mock.calls[1][0] as string;
-      // Different models → different keys, so a model swap re-attempts instead of
-      // replaying the old model's cached entry.
-      expect(keyA).not.toBe(keyB);
-      // ...but both still key off the same attachment id.
-      expect(keyA).toContain('id:123');
-      expect(keyB).toContain('id:123');
-    });
-
-    it('sanitizes the model segment so it cannot inject the key delimiter', async () => {
-      await cache.store({ attachmentId: '123', url: 'u', model: 'qwen/qwen3.7-plus' }, 'desc');
-      const key = mockRedis.setex.mock.calls[0][0] as string;
-      expect(key).toContain('qwen_qwen3.7-plus'); // '/' → '_'
-    });
-
-    it('falls back to the un-namespaced legacy key when no model is given', async () => {
-      await cache.store({ attachmentId: '123', url: 'u' }, 'desc');
-      const key = mockRedis.setex.mock.calls[0][0] as string;
-      expect(key).toBe(`${REDIS_KEY_PREFIXES.VISION_DESCRIPTION}id:123`);
-    });
-
-    it('also namespaces the failure-cache key by model', async () => {
-      await cache.storeFailure({
-        attachmentId: '123',
-        url: 'u',
-        model: 'qwen/qwen3.7-plus',
+      expect(await cache.getFailure({ attachmentId: '123', url: 'u' })).toEqual({
         category: ApiErrorCategory.AUTHENTICATION,
+        cachedAt,
       });
-      const key = mockRedis.setex.mock.calls[0][0] as string;
-      expect(key).toContain('qwen_qwen3.7-plus');
+    });
+
+    it('returns null on Redis errors (fail open)', async () => {
+      mockRedis.get.mockRejectedValueOnce(new Error('Redis down'));
+      expect(await cache.getFailure({ attachmentId: '123', url: 'u' })).toBeNull();
+    });
+
+    it('reads the per-model failure key', async () => {
+      mockRedis.get.mockResolvedValueOnce(null);
+      await cache.getFailure({ attachmentId: '123', url: 'u', model: 'openrouter/free' });
+      expect(mockRedis.get.mock.calls[0][0]).toBe(`${FAIL}openrouter_free:id:123`);
     });
   });
 });

--- a/services/ai-worker/src/services/VisionDescriptionCache.ts
+++ b/services/ai-worker/src/services/VisionDescriptionCache.ts
@@ -2,25 +2,26 @@
  * VisionDescriptionCache
  * Redis-backed L1 cache for image vision-API outputs and negative-cache cooldowns.
  *
- * Cache layout:
- * - Success descriptions: 1h Redis TTL (`VISION_DESCRIPTION_TTL`).
- * - Failure entries: per-category cooldown via `VISION_FAILURE_CACHE_POLICY`.
- *   AUTH/QUOTA failures get 5min cooldowns so transient OpenRouter glitches
- *   don't poison an attachment for its lifetime; attachment-bound failures
- *   (content-policy, dead URL, missing model) get 60min cooldowns.
+ * Two-tier layout (fixes the free-tier "can't reuse a paid model's description" bug):
+ * - **Canonical success** (`vision:canon:{attachmentId|urlHash}`) — model-AGNOSTIC
+ *   "best available" description. Every consumer reads this via `get()`, so a
+ *   free-tier user is served a description a stronger (paid) model already
+ *   produced. Writes go through a **tier-promotion** (`shouldPromoteCanonical`):
+ *   a weaker model's description can never overwrite a stronger one's
+ *   (`visionModelTier`), and a stale (>24h) or corrupt entry is replaced. 1h TTL.
+ * - **Per-model failure** (`vision:fail:{model}:{…}`) — the negative cache is kept
+ *   model-namespaced: it answers "has THIS model failed recently?" so a different
+ *   (e.g. paid) model isn't blocked by a free model's failure and can still
+ *   populate the canonical entry. Per-category cooldown via
+ *   `VISION_FAILURE_CACHE_POLICY` (5min transient … 60min attachment-bound).
  *
- * Cache key strategy:
- * 1. Namespace by the resolved vision model — so swapping the model (e.g. changing the
- *    global vision default) re-attempts immediately instead of replaying a poisoned /
- *    wrong-model entry for the OLD model
- * 2. Then prefer Discord attachment ID (stable snowflake) when available
- * 3. Fall back to URL hash (with query params stripped) for embed images
+ * Key derivation prefers the Discord attachment ID (stable snowflake) and falls
+ * back to a query-stripped URL hash for embed images (`deriveAttachmentCacheKey`).
  *
- * History note: a PostgreSQL L2 layer existed prior to v3.0.0-beta.110 to
- * survive Redis restarts. It was removed because (a) Discord attachments are
- * ephemeral, so the persistence value is small, and (b) lacking a TTL or
- * eviction path, transient failures became permanent for affected attachments.
- * See git history / release notes for the original vision negative-cache incident.
+ * History note: a PostgreSQL L2 layer existed prior to v3.0.0-beta.110 to survive
+ * Redis restarts; removed because Discord attachments are ephemeral and a missing
+ * TTL turned transient failures permanent. The legacy per-model success key
+ * (`vision:` un-prefixed) is no longer written; those entries simply age out.
  */
 
 import type { Redis } from 'ioredis';
@@ -34,7 +35,44 @@ import { INTERVALS } from '@tzurot/common-types/constants/timing';
 import { deriveAttachmentCacheKey } from '@tzurot/common-types/utils/attachmentCacheKey';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 
+import { visionModelTier, VISION_MODEL_TIER } from './multimodal/visionModelTier.js';
+
 const logger = createLogger('VisionDescriptionCache');
+
+/**
+ * Beyond this age an existing canonical entry no longer blocks lower-tier writes.
+ * Defensive only: entries carry a fresh `ts` per write and a 1h TTL, so a >24h
+ * entry implies clock skew or an anomalous write — better replaced than defended.
+ */
+const MAX_CANONICAL_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Pure promotion decision for the canonical key: should a new description
+ * (`newTier`, produced `nowMs`) overwrite the existing canonical `existing`?
+ *
+ * True when there is no entry, the entry is stale (older than MAX_CANONICAL_AGE),
+ * or the new model's tier is >= the stored tier — so a weaker model can never
+ * clobber a stronger model's description, but an equal/stronger one refreshes it.
+ *
+ * Extracted as a pure function so the promotion matrix is unit-testable without a
+ * Lua-capable Redis. The store's read→decide→setex is not atomic, so two
+ * concurrent stores for the SAME image race to last-writer-wins — rare (the
+ * per-request describe flow means one describe per image at a time) and
+ * low-impact (a lower-tier description survives at most one TTL cycle).
+ */
+export function shouldPromoteCanonical(
+  existing: { tier: number; ts: number } | null,
+  newTier: number,
+  nowMs: number
+): boolean {
+  if (existing === null) {
+    return true;
+  }
+  if (nowMs - existing.ts > MAX_CANONICAL_AGE_MS) {
+    return true;
+  }
+  return newTier >= existing.tier;
+}
 
 /** Options for cache key generation */
 interface VisionCacheKeyOptions {
@@ -43,16 +81,22 @@ interface VisionCacheKeyOptions {
   /** Image URL (fallback) */
   url: string;
   /**
-   * Resolved vision model that produced (or will produce) the entry. Namespaces the
-   * cache key so a model swap re-attempts immediately instead of replaying a
-   * poisoned/wrong-model entry for the old model. Optional: a missing model uses the
-   * un-namespaced (legacy) key.
+   * Resolved vision model that produced (or will produce) the entry. Used for the
+   * canonical tier (`visionModelTier`) and to namespace the per-model failure key.
    */
   model?: string;
 }
 
-/** Options for storing a description (success path) */
-type VisionStoreOptions = VisionCacheKeyOptions;
+/**
+ * Options for storing a description (success path). `model` is REQUIRED here —
+ * the canonical tier promotion derives dominance from it, and an absent model
+ * would otherwise default to the strongest tier (`isFreeModel('') === false`),
+ * letting an unknown-quality write clobber a genuine paid description. Making
+ * it required fails that misuse at compile time instead.
+ */
+interface VisionStoreOptions extends VisionCacheKeyOptions {
+  model: string;
+}
 
 /** Options for storing a vision failure */
 interface VisionFailureOptions extends VisionCacheKeyOptions {
@@ -72,11 +116,27 @@ export interface VisionFailureEntry {
   cachedAt?: string;
 }
 
+/** JSON shape of a canonical success entry. */
+interface CanonicalEntry {
+  description: string;
+  /**
+   * Model that produced it — observability/debugging ONLY (log fields). Never
+   * feeds a decision, which is why `readCanonicalEntry` deliberately does not
+   * validate it; promote it into the validated set if that ever changes.
+   */
+  model: string;
+  /** `visionModelTier` of the producing model — drives promotion dominance. */
+  tier: number;
+  /** epoch ms — drives the MAX_CANONICAL_AGE staleness check. */
+  ts: number;
+}
+
 export class VisionDescriptionCache {
   constructor(private redis: Redis) {}
 
   /**
-   * Store a vision description in Redis L1.
+   * Store a vision description in the model-agnostic canonical cache, tier-promoted
+   * so a weaker model can't overwrite a stronger model's description.
    */
   async store(
     options: VisionStoreOptions,
@@ -84,45 +144,85 @@ export class VisionDescriptionCache {
     ttlSeconds: number = INTERVALS.VISION_DESCRIPTION_TTL
   ): Promise<void> {
     try {
-      const key = this.getCacheKey(options);
-      await this.redis.setex(key, ttlSeconds, description);
+      const key = this.getCanonicalKey(options);
+      // Runtime backstop for the type-level guard: `model: ''` still satisfies
+      // `string`, and `visionModelTier('')` would report PAID (the strongest tier).
+      // An unknown-quality write must fail SAFE (lowest tier), not dominant.
+      const tier =
+        options.model.length > 0 ? visionModelTier(options.model) : VISION_MODEL_TIER.FREE;
+      const now = Date.now();
+
+      const existing = await this.readCanonicalEntry(key);
+      if (!shouldPromoteCanonical(existing, tier, now)) {
+        logger.debug(
+          {
+            attachmentId: options.attachmentId,
+            model: options.model,
+            tier,
+            existingTier: existing?.tier,
+          },
+          '[VisionDescriptionCache] Skipped canonical write — a stronger/current description is cached'
+        );
+        return;
+      }
+
+      const entry: CanonicalEntry = { description, model: options.model, tier, ts: now };
+      await this.redis.setex(key, ttlSeconds, JSON.stringify(entry));
       logger.debug(
         {
           attachmentId: options.attachmentId,
+          model: options.model,
+          tier,
           urlPrefix: options.url.substring(0, TEXT_LIMITS.URL_LOG_PREVIEW),
         },
-        '[VisionDescriptionCache] Stored description in L1'
+        '[VisionDescriptionCache] Stored/promoted canonical description'
       );
     } catch (error) {
       logger.error({ err: error }, '[VisionDescriptionCache] Failed to store description');
     }
   }
 
+  /** Read + parse the canonical entry; null on miss or corrupt JSON. */
+  private async readCanonicalEntry(key: string): Promise<CanonicalEntry | null> {
+    const raw = await this.redis.get(key);
+    if (raw === null || raw.length === 0) {
+      return null;
+    }
+    try {
+      const entry = JSON.parse(raw) as Partial<CanonicalEntry>;
+      if (
+        typeof entry.description === 'string' &&
+        typeof entry.tier === 'number' &&
+        typeof entry.ts === 'number'
+      ) {
+        return entry as CanonicalEntry;
+      }
+      return null;
+    } catch {
+      // Corrupt JSON is a genuinely unexpected state — make it greppable rather
+      // than silently treating it as a miss (consistent with the failure WARN).
+      logger.warn({ key }, '[VisionDescriptionCache] Corrupt canonical entry — treating as absent');
+      return null;
+    }
+  }
+
   /**
-   * Get cached vision description from Redis L1.
+   * Get the model-agnostic canonical description (the best any model has produced
+   * for this image). Returns the description string, or null on miss / corrupt entry.
    */
   async get(options: VisionCacheKeyOptions): Promise<string | null> {
     try {
-      const key = this.getCacheKey(options);
-      const description = await this.redis.get(key);
-
-      if (description !== null && description.length > 0) {
-        logger.info(
-          {
-            attachmentId: options.attachmentId,
-            urlPrefix: options.url.substring(0, TEXT_LIMITS.URL_LOG_PREVIEW),
-          },
-          '[VisionDescriptionCache] L1 cache HIT'
+      const entry = await this.readCanonicalEntry(this.getCanonicalKey(options));
+      if (entry !== null && entry.description.length > 0) {
+        logger.debug(
+          { attachmentId: options.attachmentId, model: entry.model, tier: entry.tier },
+          '[VisionDescriptionCache] Canonical HIT'
         );
-        return description;
+        return entry.description;
       }
-
       logger.debug(
-        {
-          attachmentId: options.attachmentId,
-          urlPrefix: options.url.substring(0, TEXT_LIMITS.URL_LOG_PREVIEW),
-        },
-        '[VisionDescriptionCache] Cache MISS'
+        { attachmentId: options.attachmentId },
+        '[VisionDescriptionCache] Canonical MISS'
       );
       return null;
     } catch (error) {
@@ -132,12 +232,13 @@ export class VisionDescriptionCache {
   }
 
   /**
-   * Store a vision failure in the negative cache.
+   * Store a vision failure in the per-model negative cache.
    *
-   * TTL is selected per-category via `VISION_FAILURE_CACHE_POLICY` so that
-   * possibly-transient failures (auth glitches, quota resets) get short
-   * cooldowns and recover quickly, while attachment-bound failures (content
-   * policy, dead URL, missing model) get longer cooldowns to avoid re-hammering.
+   * Kept model-namespaced: it answers "should THIS model retry?", so a free
+   * model's failure doesn't block a paid model from describing the same image
+   * and promoting a canonical success. TTL is per-category via
+   * `VISION_FAILURE_CACHE_POLICY` (short cooldowns for transient failures, longer
+   * for attachment-bound ones like a dead URL / content policy).
    */
   async storeFailure(options: VisionFailureOptions): Promise<void> {
     try {
@@ -148,9 +249,19 @@ export class VisionDescriptionCache {
 
       await this.redis.setex(key, ttlSeconds, value);
 
-      logger.info(
+      // WARN (not info): this is the single structured diagnostic for a vision failure
+      // entering cached state — one greppable line answering "which model failed on
+      // which attachment, why, and for how long" without reconstructing the request flow.
+      logger.warn(
         {
           attachmentId: options.attachmentId,
+          model: options.model,
+          // No model → no tier claim: `visionModelTier('')` would report PAID (the
+          // strongest tier) for an unknown model, and this WARN exists to be trusted.
+          tier:
+            options.model !== undefined && options.model.length > 0
+              ? visionModelTier(options.model)
+              : undefined,
           category: options.category,
           ttlSeconds,
           cachedAt,
@@ -163,7 +274,7 @@ export class VisionDescriptionCache {
   }
 
   /**
-   * Check if a vision failure is cached (negative cache check).
+   * Check if a vision failure is cached for this (model, attachment).
    * Returns the entry on hit, null on miss / OK to retry.
    */
   async getFailure(options: VisionCacheKeyOptions): Promise<VisionFailureEntry | null> {
@@ -179,6 +290,7 @@ export class VisionDescriptionCache {
       logger.info(
         {
           attachmentId: options.attachmentId,
+          model: options.model,
           category: entry.category,
           cachedAt: entry.cachedAt,
         },
@@ -192,22 +304,19 @@ export class VisionDescriptionCache {
   }
 
   /**
-   * Generate cache key from attachment ID (preferred) or query-stripped URL
-   * hash (fallback). Delegates to the shared `deriveAttachmentCacheKey` so the
-   * voice + vision caches share one normalization strategy.
+   * Model-AGNOSTIC canonical key: prefers the Discord attachment ID (stable
+   * snowflake), falls back to a query-stripped URL hash. No model in the key —
+   * that's the whole point (any model's description is reusable by any consumer).
    */
-  private getCacheKey(options: VisionCacheKeyOptions): string {
-    return deriveAttachmentCacheKey(
-      this.prefixWithModel(REDIS_KEY_PREFIXES.VISION_DESCRIPTION, options.model),
-      {
-        id: options.attachmentId,
-        url: options.url,
-      }
-    );
+  private getCanonicalKey(options: VisionCacheKeyOptions): string {
+    return deriveAttachmentCacheKey(REDIS_KEY_PREFIXES.VISION_CANONICAL, {
+      id: options.attachmentId,
+      url: options.url,
+    });
   }
 
   /**
-   * Generate failure cache key (separate namespace from success cache).
+   * Per-model failure key (separate namespace from the canonical success cache).
    */
   private getFailureKey(options: VisionCacheKeyOptions): string {
     return deriveAttachmentCacheKey(
@@ -220,16 +329,16 @@ export class VisionDescriptionCache {
   }
 
   /**
-   * Namespace a key prefix by the resolved vision model so entries are per-(attachment,
-   * model) — a model swap re-attempts rather than replaying the old model's entry. The
-   * model is sanitized (only `[A-Za-z0-9._-]` survive) so it can't introduce the `:`
-   * key delimiter. A missing model returns the bare prefix (legacy un-namespaced key).
+   * Namespace a key prefix by the resolved vision model so failure entries are
+   * per-(attachment, model). The model is sanitized (only `[A-Za-z0-9._-]` survive)
+   * so it can't introduce the `:` key delimiter. A missing model returns the bare prefix.
    */
   private prefixWithModel(prefix: string, model?: string): string {
     if (model === undefined || model.length === 0) {
       return prefix;
     }
     const safeModel = model.replace(/[^a-zA-Z0-9._-]/g, '_');
-    return `${prefix}:${safeModel}`;
+    // Keep the trailing-colon contract deriveAttachmentCacheKey expects of prefixes.
+    return `${prefix}${safeModel}:`;
   }
 }

--- a/services/ai-worker/src/services/VisionFallbackQuota.ts
+++ b/services/ai-worker/src/services/VisionFallbackQuota.ts
@@ -13,7 +13,8 @@
  * few heavy users could starve genuine guests. This cap bounds each user's daily
  * consumption of that shared resource. Once a user exceeds the cap, the tier's
  * auth resolution fail-fasts and the fallback loop advances / renders the
- * "[Image unavailable]" placeholder instead of serving another free-fallback call.
+ * `[Image … couldn't be processed …]` placeholder instead of serving another
+ * free-fallback call.
  *
  * **Counted per image (per system-key vision call)**: the fallback loop
  * (`describeImageWithFallback`) creates a fresh quota tracker per ATTACHMENT, so each

--- a/services/ai-worker/src/services/multimodal/VisionProcessor.test.ts
+++ b/services/ai-worker/src/services/multimodal/VisionProcessor.test.ts
@@ -8,7 +8,6 @@ import {
   describeImage,
   LONG_TTL_FAILURE_CATEGORIES,
   VISION_TERMINATE_CATEGORIES,
-  FAILURE_LABELS,
 } from './VisionProcessor.js';
 import type { AttachmentMetadata } from '@tzurot/common-types/types/schemas/discord';
 import type { LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
@@ -159,6 +158,14 @@ describe('VisionProcessor', () => {
       contentType: 'image/png',
       size: 1024,
     };
+
+    // Expected placeholder renders for mockAttachment — one per buildFailureFallback
+    // branch (permanent / transient / auth-user / auth-system). All must keep the
+    // `[Image` prefix (isValidVisionDescription's cache guard) and include the filename.
+    const PLACEHOLDER_PERMANENT = `[Image "test-image.png" was shared but couldn't be processed — you can acknowledge it if relevant, but can't see its contents]`;
+    const PLACEHOLDER_TRANSIENT = `[Image "test-image.png" was shared but couldn't be processed right now — it may succeed later; you can acknowledge it, but can't see its contents]`;
+    const PLACEHOLDER_AUTH_USER = `[Image "test-image.png" was shared but couldn't be processed — the vision API key was rejected; it can be fixed with /settings apikey set]`;
+    const PLACEHOLDER_AUTH_SYSTEM = `[Image "test-image.png" was shared but couldn't be processed right now — the vision service had a temporary problem; it may work again shortly]`;
 
     describe('image materialization (download → data URL)', () => {
       it('downloads a non-data: image and keys the cache on the ORIGINAL url', async () => {
@@ -635,9 +642,7 @@ describe('VisionProcessor', () => {
 
         const result = await describeImage(mockAttachment, personality);
 
-        expect(result).toBe(
-          '[Image unavailable: vision service temporarily unavailable, please retry shortly]'
-        );
+        expect(result).toBe(PLACEHOLDER_AUTH_SYSTEM);
         expect(mockModelInvoke).not.toHaveBeenCalled();
         expect(mockVisionCacheStore).not.toHaveBeenCalled();
       });
@@ -657,9 +662,7 @@ describe('VisionProcessor', () => {
           loggingContext: { apiKeySource: 'user' },
         });
 
-        expect(result).toBe(
-          '[Image unavailable: your API key was rejected — check /settings apikey set for the vision provider key]'
-        );
+        expect(result).toBe(PLACEHOLDER_AUTH_USER);
       });
 
       it('should return system-key-specific message when apiKeySource is "system"', async () => {
@@ -677,9 +680,7 @@ describe('VisionProcessor', () => {
           loggingContext: { apiKeySource: 'system' },
         });
 
-        expect(result).toBe(
-          '[Image unavailable: vision service temporarily unavailable, please retry shortly]'
-        );
+        expect(result).toBe(PLACEHOLDER_AUTH_SYSTEM);
       });
 
       it('should use friendly label for content_policy failures', async () => {
@@ -695,7 +696,7 @@ describe('VisionProcessor', () => {
 
         const result = await describeImage(mockAttachment, personality);
 
-        expect(result).toBe('[Image unavailable: content filtered]');
+        expect(result).toBe(PLACEHOLDER_PERMANENT);
       });
 
       it('should use friendly label for media_not_found failures', async () => {
@@ -711,7 +712,7 @@ describe('VisionProcessor', () => {
 
         const result = await describeImage(mockAttachment, personality);
 
-        expect(result).toBe('[Image unavailable: image unavailable]');
+        expect(result).toBe(PLACEHOLDER_PERMANENT);
       });
 
       it('should fall back to generic message for unrecognized categories', async () => {
@@ -730,7 +731,7 @@ describe('VisionProcessor', () => {
 
         const result = await describeImage(mockAttachment, personality);
 
-        expect(result).toBe('[Image temporarily unavailable]');
+        expect(result).toBe(PLACEHOLDER_TRANSIENT);
       });
 
       it('should return transient failure fallback when cooldown is active', async () => {
@@ -746,7 +747,7 @@ describe('VisionProcessor', () => {
 
         const result = await describeImage(mockAttachment, personality);
 
-        expect(result).toBe('[Image temporarily unavailable]');
+        expect(result).toBe(PLACEHOLDER_TRANSIENT);
         expect(mockModelInvoke).not.toHaveBeenCalled();
       });
 
@@ -767,7 +768,7 @@ describe('VisionProcessor', () => {
 
         const result = await describeImage(mockAttachment, personality);
 
-        expect(result).toBe('[Image temporarily unavailable]');
+        expect(result).toBe(PLACEHOLDER_TRANSIENT);
         expect(mockModelInvoke).not.toHaveBeenCalled();
       });
 
@@ -1007,7 +1008,7 @@ describe('VisionProcessor', () => {
         expect(mockVisionCacheGetFailure).toHaveBeenCalled();
         // No vision call — the cross-provider storm is prevented.
         expect(mockModelInvoke).not.toHaveBeenCalled();
-        expect(result).toBe('[Image unavailable: image unavailable]');
+        expect(result).toBe(PLACEHOLDER_PERMANENT);
       });
 
       it('should still check negative cache when skipNegativeCache is false', async () => {
@@ -1026,7 +1027,7 @@ describe('VisionProcessor', () => {
         });
 
         expect(mockVisionCacheGetFailure).toHaveBeenCalled();
-        expect(result).toBe('[Image temporarily unavailable]');
+        expect(result).toBe(PLACEHOLDER_TRANSIENT);
         expect(mockModelInvoke).not.toHaveBeenCalled();
       });
 
@@ -1044,7 +1045,7 @@ describe('VisionProcessor', () => {
         const result = await describeImage(mockAttachment, personality);
 
         expect(mockVisionCacheGetFailure).toHaveBeenCalled();
-        expect(result).toBe('[Image temporarily unavailable]');
+        expect(result).toBe(PLACEHOLDER_TRANSIENT);
         expect(mockModelInvoke).not.toHaveBeenCalled();
       });
 
@@ -1328,7 +1329,7 @@ describe('VisionProcessor', () => {
 
         // Should check negative cache (skipNegativeCache not set)
         expect(mockVisionCacheGetFailure).toHaveBeenCalled();
-        expect(result).toBe('[Image temporarily unavailable]');
+        expect(result).toBe(PLACEHOLDER_TRANSIENT);
       });
 
       it('should bypass both caches when both skip options are true', async () => {
@@ -1378,16 +1379,9 @@ describe('VisionProcessor', () => {
       }
     });
 
-    it('every LONG_TTL_FAILURE_CATEGORIES member must have a FAILURE_LABELS entry', () => {
-      // Without an entry here, `buildFailureFallback` falls through to the `?? category`
-      // safety net and surfaces raw enum strings (e.g. `[Image unavailable: new_thing]`)
-      // to users. The runtime fallback is defensive but the invariant catches the gap
-      // at PR time instead of waiting for a user to hit it.
-      for (const category of LONG_TTL_FAILURE_CATEGORIES) {
-        expect(FAILURE_LABELS[category]).toBeDefined();
-        expect(FAILURE_LABELS[category]?.length ?? 0).toBeGreaterThan(0);
-      }
-    });
+    // (The FAILURE_LABELS-coverage invariant test was removed with FAILURE_LABELS
+    // itself: buildFailureFallback no longer renders per-category labels — the
+    // placeholder distinguishes only permanent vs transient vs auth wording.)
   });
 
   describe('terminate-set / attachment-bound-set invariant', () => {

--- a/services/ai-worker/src/services/multimodal/VisionProcessor.ts
+++ b/services/ai-worker/src/services/multimodal/VisionProcessor.ts
@@ -68,27 +68,6 @@ export const VISION_TERMINATE_CATEGORIES: ReadonlySet<ApiErrorCategory> = new Se
 ]);
 
 /**
- * User-friendly labels for the ATTACHMENT-BOUND error categories that actually reach
- * `FAILURE_LABELS` via `buildFailureFallback`. Other categories (auth, quota, rate-limit,
- * server-error, timeout, network, etc.) return the generic "temporarily unavailable"
- * fallback before ever consulting this map, so listing them here would be dead code.
- *
- * **Invariant**: every member of `LONG_TTL_FAILURE_CATEGORIES` MUST have an entry
- * here. The two structures encode the same "this category gets a specific label" decision
- * and must stay in sync — adding a new attachment-bound category to the set without an
- * entry here would surface raw enum strings to users (e.g. `[Image unavailable: new_thing]`).
- * Enforced by an invariant test in `VisionProcessor.test.ts`.
- *
- * Exported for the invariant test only — call sites should use `buildFailureFallback`.
- */
-export const FAILURE_LABELS: Partial<Record<ApiErrorCategory, string>> = {
-  [ApiErrorCategory.CONTENT_POLICY]: 'content filtered',
-  [ApiErrorCategory.MODEL_NOT_FOUND]: 'model unavailable',
-  [ApiErrorCategory.MEDIA_NOT_FOUND]: 'image unavailable',
-  [ApiErrorCategory.CENSORED]: 'content filtered',
-};
-
-/**
  * Diagnostic context for failure logging — answers "whose request was this, on what key,
  * for what attachment" without forcing the caller to grep across multiple log lines.
  *
@@ -407,9 +386,9 @@ async function invokeVisionModelForDescribe(
 
 /**
  * Categories whose failures are bound to attachment properties (URL, content, model
- * availability) and unlikely to recover for the same attachment. The user-facing
- * fallback for these uses the specific `FAILURE_LABELS` wording; other categories
- * (auth, quota, rate-limit, etc.) get the generic "temporarily unavailable" wording.
+ * availability) and unlikely to recover for the same attachment. The prompt-facing
+ * placeholder for these uses the permanent "can't see its contents" wording; other
+ * categories (auth, quota, rate-limit, etc.) get the transient "may succeed later" wording.
  *
  * **Invariant**: every member of this set MUST also have its `l1TtlSeconds` set to
  * `INTERVALS.VISION_FAILURE_TTL_LONG` in `VISION_FAILURE_CACHE_POLICY`. The two
@@ -439,37 +418,42 @@ export const LONG_TTL_FAILURE_CATEGORIES: ReadonlySet<ApiErrorCategory> = new Se
 ]);
 
 /**
- * Build a user-facing fallback string for a cached vision failure.
+ * Build the placeholder injected into the prompt when an image couldn't be described.
  *
- * AUTH gets a source-aware variant: a system-key failure shouldn't blame the user
- * for "API key issue" wording (they'd think their Discord account is broken),
- * while a user-key failure points them at `/settings apikey set` to fix the underlying key.
- * Other categories use either `FAILURE_LABELS` (attachment-bound) or the generic
- * "temporarily unavailable" message.
+ * Written for the LLM reading the prompt, not as a status code: the previous
+ * `[Image unavailable: <reason-label>]` shape read like UI jargon and personas
+ * narrated it verbatim ("the image description is still showing as unavailable").
+ * The placeholder keeps the failure SIGNAL (the model should know an image was
+ * there) and the filename (often has semantic content worth acknowledging), and
+ * tells the model how to behave instead of reporting an internal state.
+ *
+ * Two load-bearing constraints on the wording:
+ * - It MUST start with `[Image` — `isValidVisionDescription` uses that prefix to
+ *   keep failure placeholders out of the positive description cache.
+ * - It must NOT contain any `ERROR_DESCRIPTION_PATTERNS` substring (e.g. "cannot
+ *   process") — those mark error-shaped text, and matching one would make cached
+ *   reads treat every placeholder as a poisoned entry.
+ *
+ * AUTH keeps a source-aware variant: a user-key failure points at
+ * `/settings apikey set`; a system-key (or unknown-source) failure uses the
+ * non-blaming transient wording — the user can't act on a key they don't own.
  */
 export function buildFailureFallback(
   category: ApiErrorCategory,
-  apiKeySource: 'user' | 'system' | undefined
+  apiKeySource: 'user' | 'system' | undefined,
+  filename?: string
 ): string {
+  const subject = filename !== undefined && filename.length > 0 ? `[Image "${filename}"` : '[Image';
   if (category === ApiErrorCategory.AUTHENTICATION) {
     if (apiKeySource === 'user') {
-      return '[Image unavailable: your API key was rejected — check /settings apikey set for the vision provider key]';
+      return `${subject} was shared but couldn't be processed — the vision API key was rejected; it can be fixed with /settings apikey set]`;
     }
-    // Unknown source defaults to the system-side wording (same as `apiKeySource === 'system'`):
-    // a user can't act on "API key issue" if they don't know whose key. Defaulting to the
-    // service-unavailable phrasing is the conservative choice — it doesn't blame the user
-    // when we can't be sure whose key failed, and the user has nothing to do anyway because
-    // any actionable wallet-level remediation only applies when source is definitely 'user'.
-    return '[Image unavailable: vision service temporarily unavailable, please retry shortly]';
+    return `${subject} was shared but couldn't be processed right now — the vision service had a temporary problem; it may work again shortly]`;
   }
   if (LONG_TTL_FAILURE_CATEGORIES.has(category)) {
-    // `?? category` is a defensive safety net: every member of
-    // LONG_TTL_FAILURE_CATEGORIES has an entry in FAILURE_LABELS, so the
-    // fallback shouldn't be reachable. Kept in case the two collections drift apart.
-    const label = FAILURE_LABELS[category] ?? category;
-    return `[Image unavailable: ${label}]`;
+    return `${subject} was shared but couldn't be processed — you can acknowledge it if relevant, but can't see its contents]`;
   }
-  return '[Image temporarily unavailable]';
+  return `${subject} was shared but couldn't be processed right now — it may succeed later; you can acknowledge it, but can't see its contents]`;
 }
 
 /**
@@ -645,17 +629,20 @@ export async function describeImage(
     'describeImage called - checking vision model configuration'
   );
 
-  // Resolve the vision model FIRST — the cache keys are namespaced by model (a model
-  // swap must re-attempt rather than replay the old model's entry), so it's needed
-  // before any cache read. Honor a caller-supplied model (from the gateway's
-  // VisionConfigResolver stamping / resolveVisionConfig) over internal selection — the
-  // resolver may have forced a free-tier downgrade selectVisionModel wouldn't reproduce.
+  // Resolve the vision model FIRST — the success cache is model-agnostic (canonical),
+  // but the NEGATIVE cache is per-model ("has this model failed on this image?") and
+  // the canonical store needs the model's tier, so it's needed before any cache write.
+  // Honor a caller-supplied model (from the gateway's VisionConfigResolver stamping /
+  // resolveVisionConfig) over internal selection — the resolver may have forced a
+  // free-tier downgrade selectVisionModel wouldn't reproduce.
   const usedModel =
     options.model !== undefined && options.model.length > 0
       ? options.model
       : await selectVisionModel(personality, isGuestMode);
 
-  // Check cache first to avoid duplicate vision API calls (keyed by attachment + model).
+  // Check the canonical cache first — model-agnostic, so a description ANY model
+  // produced (e.g. a paid model on an earlier turn) is reused here, including by
+  // free-tier requests that could never produce one themselves.
   const cacheKeyOptions = { attachmentId: attachment.id, url: attachment.url, model: usedModel };
   if (options?.skipCache !== true) {
     const cachedDescription = await visionDescriptionCache.get(cacheKeyOptions);
@@ -699,7 +686,7 @@ export async function describeImage(
     if (options?.throwOnFailure === true) {
       throw new VisionModelError(cachedCategory, 'vision negative-cache hit');
     }
-    return buildFailureFallback(cachedCategory, loggingContext.apiKeySource);
+    return buildFailureFallback(cachedCategory, loggingContext.apiKeySource, attachment.name);
   }
 
   const systemPrompt =

--- a/services/ai-worker/src/services/multimodal/describeImageWithFallback.test.ts
+++ b/services/ai-worker/src/services/multimodal/describeImageWithFallback.test.ts
@@ -10,7 +10,7 @@
  * - `describeImage` / `selectVisionModel` / `buildFailureFallback` from VisionProcessor
  *   (the REAL `VisionModelError` and `VISION_TERMINATE_CATEGORIES` are kept via importOriginal).
  * - `resolveVisionAuth` / `createVisionQuotaTracker` from visionAuthResolver
- *   (the REAL `VISION_AUTH_FAIL_FAST_DESCRIPTION` is kept).
+ *   (the REAL `visionAuthFailFastDescription` is kept).
  * - `getConfig` from common-types so `config.VISION_FALLBACK_MODEL` is deterministic
  *   (the REAL `MODEL_DEFAULTS` / `ApiErrorCategory` are kept).
  */
@@ -27,11 +27,7 @@ import {
   buildFailureFallback,
   VisionModelError,
 } from './VisionProcessor.js';
-import {
-  resolveVisionAuth,
-  createVisionQuotaTracker,
-  VISION_AUTH_FAIL_FAST_DESCRIPTION,
-} from './visionAuthResolver.js';
+import { resolveVisionAuth, createVisionQuotaTracker } from './visionAuthResolver.js';
 import type { ResolveVisionConfigOptions, VisionConfigResult } from './visionAuthResolver.js';
 
 const FALLBACK_PAID_MODEL = 'openrouter/paid-floor';
@@ -78,10 +74,9 @@ vi.mock('./VisionProcessor.js', async importOriginal => {
     ...actual,
     describeImage: vi.fn(),
     selectVisionModel: vi.fn(),
-    // Declaration-time real-string impl, NOT a bare vi.fn(): visionAuthResolver
-    // derives VISION_AUTH_FAIL_FAST_DESCRIPTION from this at MODULE LOAD (before
-    // any beforeEach), so a bare mock would bake `undefined` into the constant and
-    // turn the exhaustion assertions into undefined===undefined tautologies.
+    // Declaration-time real-string impl as a safety default; beforeEach re-sets it
+    // to the source-aware `[fallback:<category>/<source>]` render the assertions use.
+    // (visionAuthFailFastDescription calls this at CALL time — no module-load bake.)
     buildFailureFallback: vi.fn(
       (category: unknown, source?: unknown) =>
         `[Image unavailable: mock ${String(category)}/${String(source ?? 'none')}]`
@@ -90,7 +85,8 @@ vi.mock('./VisionProcessor.js', async importOriginal => {
 });
 
 // visionAuthResolver: mock resolveVisionAuth + createVisionQuotaTracker,
-// keep the REAL VISION_AUTH_FAIL_FAST_DESCRIPTION constant.
+// keep the REAL visionAuthFailFastDescription (it delegates to the mocked
+// buildFailureFallback above at call time).
 vi.mock('./visionAuthResolver.js', async importOriginal => {
   const actual = await importOriginal<typeof import('./visionAuthResolver.js')>();
   return {
@@ -164,9 +160,12 @@ beforeEach(() => {
   mockCreateVisionQuotaTracker.mockReturnValue({ tryConsume: vi.fn().mockResolvedValue(true) });
   // Default: resolve auth to the tier's own model (exercises dedup-by-resolved-model realistically).
   mockResolveVisionAuth.mockImplementation(async tierModel => resolvedFor(tierModel));
-  // Default buildFailureFallback: `[fallback:<category>]`.
+  // Default buildFailureFallback: `[fallback:<category>/<source>]` — source-aware so the
+  // fail-fast render (source 'user') stays distinguishable from an attempted-401 (source
+  // 'system') now that both derive from the same mocked function at call time.
   mockBuildFailureFallback.mockImplementation(
-    (category: ApiErrorCategory) => `[fallback:${category}]`
+    (category: ApiErrorCategory, source?: 'user' | 'system') =>
+      `[fallback:${category}/${source ?? 'none'}]`
   );
 });
 
@@ -299,7 +298,11 @@ describe('describeImageWithFallback', () => {
       makeAuthOptions({ personality })
     );
 
-    expect(mockBuildFailureFallback).toHaveBeenCalledWith(ApiErrorCategory.UNKNOWN, undefined);
+    expect(mockBuildFailureFallback).toHaveBeenCalledWith(
+      ApiErrorCategory.UNKNOWN,
+      undefined,
+      'img.png'
+    );
     expect(mockDescribeImage).not.toHaveBeenCalled();
     expect(typeof result).toBe('string');
   });
@@ -318,10 +321,11 @@ describe('describeImageWithFallback', () => {
     );
 
     // Returns buildFailureFallback(CONTENT_POLICY, ...) immediately.
-    expect(result).toBe(`[fallback:${ApiErrorCategory.CONTENT_POLICY}]`);
+    expect(result).toBe(`[fallback:${ApiErrorCategory.CONTENT_POLICY}/system]`);
     expect(mockBuildFailureFallback).toHaveBeenCalledWith(
       ApiErrorCategory.CONTENT_POLICY,
-      expect.anything()
+      expect.anything(),
+      'img.png' // the filename crosses the seam so the placeholder can name the image
     );
     // Only the primary tier was attempted — no later tiers.
     expect(mockDescribeImage).toHaveBeenCalledTimes(1);
@@ -340,7 +344,7 @@ describe('describeImageWithFallback', () => {
       { model: 'primary/model' }
     );
 
-    expect(result).toBe(`[fallback:${ApiErrorCategory.MEDIA_NOT_FOUND}]`);
+    expect(result).toBe(`[fallback:${ApiErrorCategory.MEDIA_NOT_FOUND}/system]`);
     expect(mockDescribeImage).toHaveBeenCalledTimes(1);
   });
 
@@ -358,13 +362,14 @@ describe('describeImageWithFallback', () => {
       { model: 'primary/model' }
     );
 
-    expect(result).toBe(`[fallback:${ApiErrorCategory.RATE_LIMIT}]`);
+    expect(result).toBe(`[fallback:${ApiErrorCategory.RATE_LIMIT}/system]`);
     // primary/model, tier-a, and the paid floor are three distinct resolved models.
     expect(mockDescribeImage).toHaveBeenCalledTimes(3);
     // Source is threaded from the last attempted tier (resolvedFor → 'system').
     expect(mockBuildFailureFallback).toHaveBeenLastCalledWith(
       ApiErrorCategory.RATE_LIMIT,
-      'system'
+      'system',
+      'img.png'
     );
   });
 
@@ -386,14 +391,15 @@ describe('describeImageWithFallback', () => {
     // A resolved-key 401 must respect the source (buildFailureFallback maps system-source AUTH
     // to a non-blaming "temporarily unavailable"), NOT the fixed "configure your key" string
     // — which would wrongly tell a guest to fix a key they don't own.
-    expect(result).not.toBe(VISION_AUTH_FAIL_FAST_DESCRIPTION);
+    expect(result).toBe(`[fallback:${ApiErrorCategory.AUTHENTICATION}/system]`);
     expect(mockBuildFailureFallback).toHaveBeenCalledWith(
       ApiErrorCategory.AUTHENTICATION,
-      'system'
+      'system',
+      'img.png'
     );
   });
 
-  it('returns VISION_AUTH_FAIL_FAST_DESCRIPTION when every tier resolves to failFast', async () => {
+  it('renders the fail-fast auth placeholder (with the filename) when every tier resolves to failFast', async () => {
     const personality = makePersonality({ visionFallbackModels: ['tier-a'] });
     // Never resolves auth — every tier fails fast on the provider.
     mockResolveVisionAuth.mockResolvedValue({ kind: 'failFast', provider: AIProvider.OpenRouter });
@@ -405,7 +411,13 @@ describe('describeImageWithFallback', () => {
       { model: 'primary/model' }
     );
 
-    expect(result).toBe(VISION_AUTH_FAIL_FAST_DESCRIPTION);
+    // visionAuthFailFastDescription(attachment.name) → AUTH + 'user' + the filename.
+    expect(result).toBe(`[fallback:${ApiErrorCategory.AUTHENTICATION}/user]`);
+    expect(mockBuildFailureFallback).toHaveBeenCalledWith(
+      ApiErrorCategory.AUTHENTICATION,
+      'user',
+      'img.png'
+    );
     // failFast means describeImage is never invoked for any tier.
     expect(mockDescribeImage).not.toHaveBeenCalled();
   });
@@ -434,8 +446,12 @@ describe('describeImageWithFallback', () => {
 
     // Rendered via buildFailureFallback(RATE_LIMIT, <the attempted tier's source>), NOT the
     // auth placeholder — the genuine RATE_LIMIT failure survives the later failFast tiers.
-    expect(result).not.toBe(VISION_AUTH_FAIL_FAST_DESCRIPTION);
-    expect(mockBuildFailureFallback).toHaveBeenCalledWith(ApiErrorCategory.RATE_LIMIT, 'system');
+    expect(result).toBe(`[fallback:${ApiErrorCategory.RATE_LIMIT}/system]`);
+    expect(mockBuildFailureFallback).toHaveBeenCalledWith(
+      ApiErrorCategory.RATE_LIMIT,
+      'system',
+      'img.png'
+    );
     // Only tier 1 was actually attempted (tiers 2/3 failFast).
     expect(mockDescribeImage).toHaveBeenCalledTimes(1);
   });
@@ -481,7 +497,7 @@ describe('describeImageWithFallback', () => {
     // Every attempt collapsed onto 'collapsed-free' → only one real describeImage call.
     expect(mockDescribeImage).toHaveBeenCalledTimes(1);
     // Chain exhausted on a retryable (rate-limit) category → generic fallback.
-    expect(result).toBe(`[fallback:${ApiErrorCategory.RATE_LIMIT}]`);
+    expect(result).toBe(`[fallback:${ApiErrorCategory.RATE_LIMIT}/system]`);
   });
 
   it('passes throwOnFailure + skipNegativeCache to describeImage', async () => {

--- a/services/ai-worker/src/services/multimodal/describeImageWithFallback.ts
+++ b/services/ai-worker/src/services/multimodal/describeImageWithFallback.ts
@@ -10,7 +10,7 @@
  * All DB resolution stays gateway-side (the tiers are stamped on the personality); this
  * loop only picks the next model + resolves its per-tier auth via `resolveVisionAuth`.
  * It NEVER throws `VisionModelError` — the loop is the boundary that turns a failure into
- * user-facing `[Image unavailable: …]` text.
+ * the prompt-facing `[Image … couldn't be processed …]` placeholder.
  */
 
 import { getConfig } from '@tzurot/common-types/config/config';
@@ -30,7 +30,7 @@ import {
 import {
   resolveVisionAuth,
   createVisionQuotaTracker,
-  VISION_AUTH_FAIL_FAST_DESCRIPTION,
+  visionAuthFailFastDescription,
   type ResolveVisionConfigOptions,
   type VisionConfig,
 } from './visionAuthResolver.js';
@@ -93,7 +93,10 @@ async function runVisionTier(
         { attachmentId: attachment.id, model: config.model, category: error.category },
         'Vision terminate category — image itself rejected, not retrying other tiers'
       );
-      return { kind: 'resolved', description: buildFailureFallback(error.category, config.source) };
+      return {
+        kind: 'resolved',
+        description: buildFailureFallback(error.category, config.source, attachment.name),
+      };
     }
     logger.info(
       { attachmentId: attachment.id, model: config.model, category: error.category },
@@ -141,8 +144,8 @@ export function composeVisionTiers(
 
 /**
  * Describe an image, retrying down the vision fallback chain on a retryable failure.
- * Returns a description string on success, or a `[Image unavailable: …]` placeholder when
- * a tier hits a terminate category or the whole chain is exhausted. **NEVER throws** — it is
+ * Returns a description string on success, or a `[Image … couldn't be processed …]`
+ * placeholder when a tier hits a terminate category or the whole chain is exhausted. **NEVER throws** — it is
  * the graceful-degradation boundary its callers rely on for per-image isolation, so any
  * unexpected error degrades to a generic placeholder rather than failing the whole batch.
  */
@@ -162,7 +165,7 @@ export async function describeImageWithFallback(
       { err: error, attachmentId: attachment.id },
       'Vision fallback loop threw unexpectedly — rendering generic fallback'
     );
-    return buildFailureFallback(ApiErrorCategory.UNKNOWN, undefined);
+    return buildFailureFallback(ApiErrorCategory.UNKNOWN, undefined, attachment.name);
   }
 }
 
@@ -219,7 +222,7 @@ async function walkFallbackChain(
   // user to fix a key they don't own (buildFailureFallback maps system-source AUTH to a
   // non-blaming "temporarily unavailable" message).
   if (lastAttempt === undefined) {
-    return VISION_AUTH_FAIL_FAST_DESCRIPTION;
+    return visionAuthFailFastDescription(attachment.name);
   }
-  return buildFailureFallback(lastAttempt.category, lastAttempt.source);
+  return buildFailureFallback(lastAttempt.category, lastAttempt.source, attachment.name);
 }

--- a/services/ai-worker/src/services/multimodal/visionAuthResolver.test.ts
+++ b/services/ai-worker/src/services/multimodal/visionAuthResolver.test.ts
@@ -19,9 +19,9 @@ import {
   resolveVisionConfig,
   resolveVisionAuth,
   createVisionQuotaTracker,
-  VISION_AUTH_FAIL_FAST_DESCRIPTION,
+  visionAuthFailFastDescription,
 } from './visionAuthResolver.js';
-import { selectVisionModel } from './VisionProcessor.js';
+import { selectVisionModel, buildFailureFallback } from './VisionProcessor.js';
 import type { ApiKeyResolver } from '../ApiKeyResolver.js';
 
 // Logger mock — visionAuthResolver imports createLogger from common-types
@@ -45,11 +45,12 @@ vi.mock('@tzurot/common-types/utils/logger', async () => {
 // without reaching into Redis (hasVisionSupport).
 vi.mock('./VisionProcessor.js', () => ({
   selectVisionModel: vi.fn(),
-  // Evaluated at MODULE LOAD (VISION_AUTH_FAIL_FAST_DESCRIPTION derives from it),
-  // so the mock must return a real string — a bare vi.fn() would bake `undefined`
-  // into the exported constant.
-  buildFailureFallback: (category: string, source?: string) =>
-    `[Image unavailable: mock ${String(category)}/${source ?? 'none'}]`,
+  // visionAuthFailFastDescription delegates to this at call time. vi.fn so the
+  // delegation test can assert the args that cross the seam (incl. the filename).
+  buildFailureFallback: vi.fn(
+    (category: string, source?: string) =>
+      `[Image unavailable: mock ${String(category)}/${source ?? 'none'}]`
+  ),
 }));
 
 // VisionDescriptionCache singleton mock — stubbed for module-load safety; we just
@@ -539,11 +540,17 @@ describe('createVisionQuotaTracker', () => {
     expect(mockTryConsume).toHaveBeenCalledTimes(1);
   });
 
-  it('derives VISION_AUTH_FAIL_FAST_DESCRIPTION as a real string at module load', () => {
-    // Guards the module-load derivation: if a mock (or future refactor) let the
-    // constant freeze to undefined, downstream toBe() assertions would silently
-    // become undefined===undefined tautologies.
-    expect(typeof VISION_AUTH_FAIL_FAST_DESCRIPTION).toBe('string');
-    expect(VISION_AUTH_FAIL_FAST_DESCRIPTION.length).toBeGreaterThan(0);
+  it('visionAuthFailFastDescription renders the AUTH+user placeholder with the filename', () => {
+    // Delegates to buildFailureFallback (mocked above as
+    // `[Image unavailable: mock <category>/<source>]`) with the AUTH+user branch;
+    // the filename is forwarded as the third arg for the per-request render.
+    const rendered = visionAuthFailFastDescription('photo.png');
+    expect(rendered).toBe('[Image unavailable: mock authentication/user]');
+    // The seam: category, source, AND the filename must all cross to the renderer.
+    expect(vi.mocked(buildFailureFallback)).toHaveBeenCalledWith(
+      'authentication',
+      'user',
+      'photo.png'
+    );
   });
 });

--- a/services/ai-worker/src/services/multimodal/visionAuthResolver.ts
+++ b/services/ai-worker/src/services/multimodal/visionAuthResolver.ts
@@ -22,7 +22,7 @@
  * can't auth the vision provider, not a specific provider's users.
  *
  * On `failFast`, the fallback loop (`describeImageWithFallback`) renders the
- * `VISION_AUTH_FAIL_FAST_DESCRIPTION` "configure your key" placeholder per attachment
+ * `visionAuthFailFastDescription` "configure your key" placeholder per attachment
  * once every fallback tier is exhausted.
  */
 
@@ -40,15 +40,18 @@ const logger = createLogger('VisionAuthResolver');
 /**
  * Fallback description shown to the LLM when no usable vision key exists across
  * every fallback tier. DERIVED from `buildFailureFallback`'s AUTH+user branch —
- * this constant is the "no tier ever resolved a key" rendering, which is the
- * same user-actionable situation, so the wording must stay identical. Deriving
+ * this is the "no tier ever resolved a key" rendering, which is the same
+ * user-actionable situation, so the wording must stay identical. Deriving
  * (rather than duplicating the literal) makes a future wording change land in
  * both places by construction.
+ *
+ * A function (not a module-level constant) so the per-request filename reaches
+ * the placeholder — every other failure path names the image file, and the
+ * fail-fast path shouldn't be the one exception.
  */
-export const VISION_AUTH_FAIL_FAST_DESCRIPTION = buildFailureFallback(
-  ApiErrorCategory.AUTHENTICATION,
-  'user'
-);
+export function visionAuthFailFastDescription(filename?: string): string {
+  return buildFailureFallback(ApiErrorCategory.AUTHENTICATION, 'user', filename);
+}
 
 /**
  * Resolved auth + model context for a vision call. Unifies the auth decision
@@ -78,7 +81,7 @@ export interface VisionConfig {
  * - `resolved` — caller proceeds with the vision call using `config`
  * - `failFast` — even the free-model system fallback is unavailable (no system
  *   OpenRouter key configured); the fallback loop treats this tier as unusable and
- *   advances (rendering `VISION_AUTH_FAIL_FAST_DESCRIPTION` once all tiers exhaust).
+ *   advances (rendering `visionAuthFailFastDescription` once all tiers exhaust).
  *   `provider` is the ORIGINAL vision provider the user actually lacked, so
  *   telemetry reflects what they were missing rather than the free-fallback provider.
  */

--- a/services/ai-worker/src/services/multimodal/visionModelTier.test.ts
+++ b/services/ai-worker/src/services/multimodal/visionModelTier.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+
+import { visionModelTier, VISION_MODEL_TIER } from './visionModelTier.js';
+
+describe('visionModelTier', () => {
+  it('ranks free models below paid ones', () => {
+    // Free: the openrouter free router + any `:free`-suffixed model.
+    expect(visionModelTier('openrouter/free')).toBe(VISION_MODEL_TIER.FREE);
+    expect(visionModelTier('cohere/north-mini-code:free')).toBe(VISION_MODEL_TIER.FREE);
+    expect(visionModelTier('google/gemma-4-31b-it:free')).toBe(VISION_MODEL_TIER.FREE);
+
+    // Paid: everything else.
+    expect(visionModelTier('qwen/qwen3.7-plus')).toBe(VISION_MODEL_TIER.PAID);
+    expect(visionModelTier('anthropic/claude-sonnet-4')).toBe(VISION_MODEL_TIER.PAID);
+
+    // The ordering the promotion logic relies on.
+    expect(visionModelTier('qwen/qwen3.7-plus')).toBeGreaterThan(
+      visionModelTier('openrouter/free')
+    );
+  });
+});

--- a/services/ai-worker/src/services/multimodal/visionModelTier.ts
+++ b/services/ai-worker/src/services/multimodal/visionModelTier.ts
@@ -1,0 +1,21 @@
+import { isFreeModel } from '@tzurot/common-types/constants/ai';
+
+/**
+ * Coarse quality tier for a resolved vision model, used by the vision-description
+ * cache's monotonic promotion: a higher-or-equal-tier success may overwrite the
+ * canonical entry, a lower-tier one may not — so a weak free model can never
+ * clobber a strong paid model's description.
+ *
+ * Deliberately coarse: free models (`openrouter/free`, `*:free`) are tier 1,
+ * everything else tier 2. The free-vs-paid split is exactly what drives the
+ * free-tier cache-miss bug this fixes; split into finer tiers later if a real
+ * quality ordering among paid models ever matters.
+ */
+export const VISION_MODEL_TIER = {
+  FREE: 1,
+  PAID: 2,
+} as const;
+
+export function visionModelTier(model: string): number {
+  return isFreeModel(model) ? VISION_MODEL_TIER.FREE : VISION_MODEL_TIER.PAID;
+}


### PR DESCRIPTION
## Summary

Fixes the reported free-tier prod bug: a persona on `cohere/north-mini-code:free` told the user *"The image description is still showing as unavailable"* for an image a paid model had already described and cached.

**Root cause**: the vision description cache was namespaced by resolved vision model (`vision:{model}:{attachmentId}`). A free-tier request could never reuse a paid model's description — it re-described with a weak free model, failed, and injected the internal `[Image unavailable: <reason>]` placeholder verbatim into the prompt, which the persona then narrated.

## Changes

- **Canonical success cache** (`vision:canon:{attachmentId|urlHash}`, model-agnostic): every consumer reads the best available description regardless of producing model. Writes go through a tier promotion (`shouldPromoteCanonical` + `visionModelTier`, free=1 / paid=2): a weaker model can never clobber a stronger model's entry, an equal/stronger one refreshes it. Promotion is a pure, unit-tested decision function (read→decide→setex; the rare concurrent-store race is documented and bounded to one TTL cycle).
- **Negative cache stays per-model** (`vision:fail:{model}:{…}`): one model's failure no longer blocks a *different* model from describing the same image and promoting a canonical success. Same per-category TTL policy as before.
- **`storedReferenceHydrator` fixed by construction**: its model-less `get()` — previously an always-miss dead path (it derived a key no writer ever used) — now reads the canonical key.
- **Placeholder rewritten for the LLM** (owner-directed): keeps the failure signal, names the image file (filenames often carry semantic content worth acknowledging), drops internal reason-code jargon, and distinguishes permanent vs transient vs auth wording. Keeps the load-bearing `[Image` prefix that `isValidVisionDescription` uses to keep placeholders out of the positive cache, and avoids every `ERROR_DESCRIPTION_PATTERNS` substring. `FAILURE_LABELS` deleted with its invariant test (no longer consumed).
- **Structured failure diagnostic**: `storeFailure` now logs one WARN (attachmentId, model, tier, category, TTL) — the greppable line the original investigation lacked.

### Design note (simplification vs the reviewed plan)
The council plan had per-model *provenance success* entries alongside canonical. Dropped: success always goes canonical (tier-promoted), and "has this model tried?" is only needed for failures — which the per-model negative cache already answers. Fewer keys, same properties.

## Tests

- Promotion matrix (pure function), canonical model-agnostic read/store, per-model failure keys, corrupt-entry fail-open.
- **Wiring/seam test** replaying the prod scenario over a stateful Redis fake: paid stores → free-tier read gets it → weak free store can't clobber → equal-tier refresh works.
- Placeholder tests updated to the new wording; seam assertions extended for the filename arg.
- Full suite: `pnpm test` (25/25 tasks) + `pnpm quality` (24/24) green.

## Rollout

No migration. Old `vision:{model}:` / un-prefixed entries are simply never read again and age out via TTL (≤1h success, ≤1h failure); the canonical namespace is fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)