### PR TITLE
fix(common-types): slug suffix preservation + config-name cap-message drift (#1484 round-6 nits)

### DIFF
--- a/packages/common-types/src/constants/ai.ts
+++ b/packages/common-types/src/constants/ai.ts
@@ -208,6 +208,14 @@ export const MODEL_DEFAULTS = {
  */
 export const CONFIG_KINDS = ['text', 'vision'] as const;
 export type ConfigKind = (typeof CONFIG_KINDS)[number];
+
+/**
+ * Max length for an LlmConfig/TtsConfig `name`. Single source for the `.max()` in
+ * both config schemas AND the promote-normalization util, so they can't drift.
+ * Lives here with the other config-domain constants (`CONFIG_KINDS` etc.).
+ */
+export const CONFIG_NAME_MAX_LENGTH = 100;
+
 /** Default kind for a newly-created config — matches the Prisma `kind` column default. */
 export const DEFAULT_CONFIG_KIND: ConfigKind = 'text';
 

--- a/packages/common-types/src/constants/index.ts
+++ b/packages/common-types/src/constants/index.ts
@@ -23,6 +23,7 @@ export {
   zaiCodingPlanModelCapabilities,
   listZaiCodingPlanModels,
   buildModelInfoUrl,
+  CONFIG_NAME_MAX_LENGTH,
 } from './ai.js';
 export type { ZaiCodingPlanModelInfo, ConfigKind } from './ai.js';
 
@@ -102,7 +103,6 @@ export {
   MessageRole,
   PLACEHOLDERS,
   MESSAGE_LIMITS,
-  CONFIG_NAME_MAX_LENGTH,
   MULTI_TAG,
   NO_TEXT_CONTENT_PLACEHOLDER,
   UNKNOWN_USER_DISCORD_ID,

--- a/packages/common-types/src/constants/message.ts
+++ b/packages/common-types/src/constants/message.ts
@@ -28,12 +28,6 @@ export const PLACEHOLDERS = {
  * Message context limits
  * These control how much context is included in AI requests
  */
-/**
- * Max length for an LlmConfig/TtsConfig `name`. Single source for the `.max()` in
- * both config schemas AND the promote-normalization util, so they can't drift.
- */
-export const CONFIG_NAME_MAX_LENGTH = 100;
-
 export const MESSAGE_LIMITS = {
   /**
    * Default value for maxMessages in LlmConfig

--- a/packages/common-types/src/schemas/api/llm-config.ts
+++ b/packages/common-types/src/schemas/api/llm-config.ts
@@ -89,7 +89,7 @@ export const LlmConfigCreateSchema = z.object({
   name: z
     .string()
     .min(1, 'name is required')
-    .max(CONFIG_NAME_MAX_LENGTH, 'name must be 100 characters or less'),
+    .max(CONFIG_NAME_MAX_LENGTH, `name must be ${CONFIG_NAME_MAX_LENGTH} characters or less`),
   model: z.string().min(1, 'model is required').max(200),
 
   // Config kind discriminator (text | vision | …). Optional; when omitted the

--- a/packages/common-types/src/schemas/api/personality.ts
+++ b/packages/common-types/src/schemas/api/personality.ts
@@ -187,7 +187,10 @@ export const PersonalityCharacterFieldsSchema = z.object({
 const slugSchema = z
   .string()
   .min(3, 'slug must be at least 3 characters')
-  .max(DISCORD_LIMITS.SLUG_MAX_LENGTH, 'slug must be 50 characters or less')
+  .max(
+    DISCORD_LIMITS.SLUG_MAX_LENGTH,
+    `slug must be ${DISCORD_LIMITS.SLUG_MAX_LENGTH} characters or less`
+  )
   .regex(
     /^[a-z][a-z0-9-]*$/,
     'slug must start with a letter and contain only lowercase letters, numbers, and hyphens'

--- a/packages/common-types/src/schemas/api/tts-config.ts
+++ b/packages/common-types/src/schemas/api/tts-config.ts
@@ -61,7 +61,7 @@ export const TtsConfigCreateSchema = z.object({
   name: z
     .string()
     .min(1, 'name is required')
-    .max(CONFIG_NAME_MAX_LENGTH, 'name must be 100 characters or less'),
+    .max(CONFIG_NAME_MAX_LENGTH, `name must be ${CONFIG_NAME_MAX_LENGTH} characters or less`),
   provider: TtsProviderIdSchema,
 
   // Optional fields

--- a/packages/common-types/src/utils/slugUtils.test.ts
+++ b/packages/common-types/src/utils/slugUtils.test.ts
@@ -91,6 +91,28 @@ describe('normalizeSlugForUser', () => {
       const result = normalizeSlugForUser('char-user-456', 'user-456', '!!!');
       expect(result).toBe('char-user-456');
     });
+
+    it('preserves the username suffix intact when an already-suffixed slug is over-length', () => {
+      // Reachable via shapes imports (no length cap before normalization): a long
+      // slug that already ends in this user's suffix must truncate the BASE only —
+      // eating into the `-username` provenance tail would break the guarantee the
+      // fresh-suffix path provides.
+      const longBase = 'a'.repeat(60);
+      const result = normalizeSlugForUser(`${longBase}-bob`, 'user-456', 'bob');
+
+      expect(result.length).toBeLessThanOrEqual(50);
+      expect(result.endsWith('-bob')).toBe(true);
+      // The truncated base carries the disambiguation hash before the suffix.
+      expect(result).toMatch(/-[0-9a-f]{6}-bob$/);
+    });
+
+    it('is stable when re-normalizing its own over-length output', () => {
+      // normalize(normalize(x)) === normalize(x): the truncated result is under the
+      // cap and already suffixed, so a second pass must return it unchanged.
+      const first = normalizeSlugForUser(`${'a'.repeat(60)}-bob`, 'user-456', 'bob');
+      const second = normalizeSlugForUser(first, 'user-456', 'bob');
+      expect(second).toBe(first);
+    });
   });
 
   describe('edge cases', () => {

--- a/packages/common-types/src/utils/slugUtils.ts
+++ b/packages/common-types/src/utils/slugUtils.ts
@@ -104,12 +104,27 @@ export function normalizeSlugForUser(
   const sanitizedUsername = sanitizeUsernameForSlug(discordUsername);
   const suffix = sanitizedUsername.length === 0 ? `-${discordUserId}` : `-${sanitizedUsername}`;
 
-  // Idempotent: if the slug is already suffixed for this user, leave it alone.
+  // Idempotent: if the slug is already suffixed for this user, don't re-append.
   // Without this, calling normalizeSlugForUser on a previously-normalized slug
   // would double-suffix (`lilith-bob` → `lilith-bob-bob`). Matters in update
   // paths where the input may already carry the suffix from a prior call.
+  //
+  // `endsWith` is a heuristic, not a provenance marker: a user who deliberately
+  // types a slug ending in their own suffix (bob typing `mybob-bob`) is treated
+  // as already-normalized. That false-positive is benign by construction —
+  // only the CALLING user's suffix matches (Discord usernames are unique, so a
+  // `-bob` tail always means bob authored it either way), collisions still hit
+  // the DB unique constraint, and skipping the append is what the user wanted
+  // (`mybob-bob`, not `mybob-bob-bob`). Tracking normalization out-of-band
+  // would add schema surface for a failure mode with no damage vector.
+  //
+  // Split the existing suffix off and re-fit base+suffix (rather than fitting the
+  // whole string with an empty suffix) so an over-length already-suffixed slug —
+  // reachable via shapes imports, which don't length-cap before normalizing —
+  // truncates only the BASE and keeps the `-username` provenance suffix intact,
+  // exactly like the fresh-suffix path below.
   if (slug.endsWith(suffix)) {
-    return fitSlugToMaxLength(slug, '', maxLength);
+    return fitSlugToMaxLength(slug.slice(0, -suffix.length), suffix, maxLength);
   }
 
   return fitSlugToMaxLength(slug, suffix, maxLength);

--- a/services/api-gateway/src/utils/normalizeConfigNameOnPromote.ts
+++ b/services/api-gateway/src/utils/normalizeConfigNameOnPromote.ts
@@ -25,7 +25,7 @@
 import type { Request } from 'express';
 import { normalizeSlugForUser } from '@tzurot/common-types/utils/slugUtils';
 // Shared cap so the config schemas + this promote-normalization can't drift (NOT the 50-char slug cap).
-import { CONFIG_NAME_MAX_LENGTH } from '@tzurot/common-types/constants/message';
+import { CONFIG_NAME_MAX_LENGTH } from '@tzurot/common-types/constants/ai';
 
 interface PromotionContext {
   /** Current state of the config (from `service.getById`). */


### PR DESCRIPTION
## Summary

The three non-blocking nits from #1484's round-6 review, batched:

1. **Suffix preservation on the idempotent path** — `normalizeSlugForUser`'s already-suffixed branch treated the *whole* string as truncatable base, so an over-length input (reachable via shapes imports, which don't length-cap before normalizing) could eat part of the real `-username` provenance suffix. Now it splits the suffix off and re-fits base+suffix exactly like the fresh-suffix path. New tests: suffix survives intact on over-length input; re-normalizing the truncated output is stable (`normalize(normalize(x)) === normalize(x)`).
2. **Cap-message drift** — the Zod messages were literals (`'100'`, `'50'`) independent of `CONFIG_NAME_MAX_LENGTH` / `SLUG_MAX_LENGTH`. Template-literaled (rendered text is unchanged today; it just can't lie after a future cap change).
3. **Constant placement** — `CONFIG_NAME_MAX_LENGTH` moves from `constants/message.ts` to `constants/ai.ts` next to `CONFIG_KINDS` (the config-domain constants home), per the reviewer's discoverability note. All consumers updated.

## Tests

`pnpm test` (25/25) + `pnpm quality` (24/24) green on this tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)