### PR TITLE
fix(ai-worker): demote per-image vision plumbing logs from info to debug

### DIFF
--- a/services/ai-worker/src/services/RAGUtils.ts
+++ b/services/ai-worker/src/services/RAGUtils.ts
@@ -243,7 +243,7 @@ export function injectImageDescriptions(
   }
 
   if (injectedCount > 0) {
-    logger.info(
+    logger.debug(
       { injectedCount },
       'Injected image descriptions into history entries for inline display'
     );
@@ -394,7 +394,7 @@ export async function enrichConversationHistory(
     if (linkedImages.length > 0) {
       try {
         await processImagesFn(linkedImages);
-        logger.info(
+        logger.debug(
           { imageCount: linkedImages.length },
           'Warmed vision cache for linked-message images'
         );

--- a/services/ai-worker/src/services/VisionDescriptionCache.ts
+++ b/services/ai-worker/src/services/VisionDescriptionCache.ts
@@ -287,7 +287,7 @@ export class VisionDescriptionCache {
       }
 
       const entry = JSON.parse(value) as VisionFailureEntry;
-      logger.info(
+      logger.debug(
         {
           attachmentId: options.attachmentId,
           model: options.model,

--- a/services/ai-worker/src/services/multimodal/VisionProcessor.ts
+++ b/services/ai-worker/src/services/multimodal/VisionProcessor.ts
@@ -523,14 +523,14 @@ export async function selectVisionModel(
     personality.visionModel !== null &&
     personality.visionModel.length > 0
   ) {
-    logger.info({ visionModel: personality.visionModel }, 'Using configured vision model');
+    logger.debug({ visionModel: personality.visionModel }, 'Using configured vision model');
     return personality.visionModel;
   }
 
   // Priority 2: Use personality's main model if it has native vision support
   const mainModelHasVision = await hasVisionSupport(personality.model);
   if (mainModelHasVision) {
-    logger.info(
+    logger.debug(
       { model: personality.model, source: 'main-model-vision' },
       'Using main LLM for vision (native vision support detected via cache/pattern)'
     );
@@ -540,7 +540,7 @@ export async function selectVisionModel(
   // Priority 3: Use fallback vision model
   // Guest users (no BYOK API key) use VISION_FALLBACK_FREE, BYOK users use VISION_FALLBACK (paid)
   const fallback = isGuestMode ? MODEL_DEFAULTS.VISION_FALLBACK_FREE : config.VISION_FALLBACK_MODEL;
-  logger.info(
+  logger.debug(
     { mainModel: personality.model, fallbackModel: fallback, isGuestMode, source: 'fallback' },
     'Using fallback vision model - main LLM lacks vision support'
   );
@@ -619,7 +619,7 @@ export async function describeImage(
   options: DescribeImageOptions = {}
 ): Promise<string> {
   const loggingContext: VisionLoggingContext = options.loggingContext ?? {};
-  logger.info(
+  logger.debug(
     {
       personalityName: personality.name,
       mainModel: personality.model,
@@ -651,7 +651,7 @@ export async function describeImage(
       // (e.g., "I cannot access the image URL") that looks valid but isn't useful.
       // Re-processing gives the vision model a chance to succeed with a fresh attempt.
       if (isValidVisionDescription(cachedDescription)) {
-        logger.info(
+        logger.debug(
           { attachmentName: attachment.name, attachmentId: attachment.id },
           'Using cached vision description - avoiding duplicate API call'
         );

--- a/services/ai-worker/src/services/multimodal/visionAuthResolver.ts
+++ b/services/ai-worker/src/services/multimodal/visionAuthResolver.ts
@@ -203,7 +203,7 @@ async function resolveBroadFreeFallback(
   if (sys.source === 'system' && !(await quotaTracker.tryConsume())) {
     return { kind: 'failFast', provider: originalVisionProvider };
   }
-  logger.info(
+  logger.debug(
     { userId, originalVisionProvider, freeProvider, freeModel, source: sys.source },
     'Authenticated user lacks vision-provider key — downgrading to free vision model on system key'
   );
@@ -332,7 +332,7 @@ export async function resolveVisionAuth(
       const guestModel = isPrimaryTier ? targetModel : MODEL_DEFAULTS.VISION_FALLBACK_FREE;
       const guestProvider = isPrimaryTier ? visionProvider : detectVisionProvider(guestModel);
       const result = await apiKeyResolver.resolveApiKey(userId, guestProvider);
-      logger.info(
+      logger.debug(
         { userId, visionProvider: guestProvider, mainProvider, source: result.source },
         'Cross-provider vision config resolved (guest path)'
       );
@@ -351,7 +351,7 @@ export async function resolveVisionAuth(
     // Authenticated user — try their key for the vision provider first.
     const userKey = await apiKeyResolver.tryResolveUserKey(userId, visionProvider);
     if (userKey !== null) {
-      logger.info(
+      logger.debug(
         { userId, visionProvider, mainProvider, source: 'user' },
         'Cross-provider vision config resolved (authenticated user key)'
       );


### PR DESCRIPTION
## Summary

Companion to #1485 (the release's observability item). The vision path logged ~5 INFO lines per image per turn — entry trace, model-selection branch, config resolution, cache hits, history injection. During an image-heavy multi-persona burst this is exactly the volume that made the free-tier bug's 20:12 runtime trace unreachable (3000 log lines ≈ 1.5 min of wall time).

**Demoted to debug (11 sites):** `describeImage` entry trace, the three `selectVisionModel` branch logs, cached-description reuse, the free-model downgrade + two cross-provider resolution lines, the cache-level negative-cache HIT (its honoring site in `checkNegativeCache` keeps INFO with `apiKeySource` context), and the two per-turn history-injection/cache-warm lines.

**Kept at INFO/WARN (the money events):** actual model invocations (real API calls), cooldown skips (explain degraded responses), fail-fast (no key anywhere), per-request hydration summary, completed attachment processing, and #1485's structured failure WARN.

Net effect: a quiet turn with cached images emits ~0 vision INFO lines instead of ~5 per image; failures stay loud.

## Tests

No test asserts the demoted levels (verified by grep). Full multimodal + cache + RAGUtils suites green (226 tests); typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)