### PR TITLE
chore: operationalize session-mining friction fixes

### DIFF
--- a/.claude/rules/05-tooling.md
+++ b/.claude/rules/05-tooling.md
@@ -165,7 +165,7 @@ EOF
 **Types:** `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `perf`, `debug`
 **Scopes:** `ai-worker`, `api-gateway`, `bot-client`, `common-types`, `ci`, `deps`
 
-**Commitlint gotchas** (the hook catches these, but every trip costs a retry): the subject must start **lowercase** (`subject-case`), and the scope must be in the configured enum **or omitted entirely** — an unknown scope is rejected, no scope is fine.
+**Commitlint gotchas** (the hook catches these, but every trip costs a retry): the **full header must be ≤100 chars** (`header-max-length` — the most-tripped rule in practice; count before writing a long subject), the subject must start **lowercase** (`subject-case`), and the scope must be in the configured enum **or omitted entirely** — an unknown scope is rejected, no scope is fine.
 
 The list above is the project's primary set. `commitlint.config.cjs` also accepts the rest of the standard Conventional Commits types — `build`, `ci`, `revert`, `style` — and the `.husky/pre-push` branch-name allowlist permits all of them as branch prefixes too, so a valid commit type is always a valid branch prefix. Reach for the standard ones when they genuinely fit (`build:` for bundler/Docker changes, `revert:` for a clean revert); otherwise the primary set covers most work.
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pnpm exec eslint --fix \"$CLAUDE_FILE_PATH\" 2>&1 | head -50 || true"
+            "command": "pnpm exec eslint \"$CLAUDE_FILE_PATH\" 2>&1 | head -50 || true"
           }
         ]
       },

--- a/.claude/skills/tzurot-git-workflow/SKILL.md
+++ b/.claude/skills/tzurot-git-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tzurot-git-workflow
 description: 'Git workflow procedures. Invoke with /tzurot-git-workflow for commit, PR, and release procedures.'
-lastUpdated: '2026-07-03'
+lastUpdated: '2026-07-04'
 ---
 
 # Git Workflow Procedures
@@ -38,6 +38,18 @@ EOF
 **Types:** `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `perf`, `debug`
 (`debug` = temporary diagnostic instrumentation, added then removed; see `.claude/rules/05-tooling.md` § "The `debug` type" for when to use it vs. `chore`/`feat`.)
 **Scopes:** `ai-worker`, `api-gateway`, `bot-client`, `common-types`, `ci`, `deps`
+
+**Command-shape rules for commit/push** (each class cost multiple cycles in practice):
+
+- Chain with `&&`, never `;` — a hook-rejected commit must halt the chain; with `;` the dead commit flows into a push that no-ops as "Everything up-to-date" and the rejection reason scrolls away.
+- **Never filter commit/push output** through `grep`/`tail`/`head` — hook rejections (commitlint, pre-push gate) get swallowed and cost a blind re-diagnosis cycle. Read the full output; it's short when things work and essential when they don't.
+- **Pass `timeout: 600000`** on Bash calls that commit or push — lint-staged + the pre-push gate run the full local pipeline (minutes); default timeouts kill mid-hook and leave ambiguous state (commit landed, push didn't).
+- In compound commands that `cd` into a package, run the git step as `git -C <repo-root> …` (or with absolute paths) — repo-relative pathspecs break after the cd, failing AFTER the tests already passed.
+- Canonical push-verify (don't improvise greps — a pattern starting with `-` parses as an option flag). Use this `ls-remote` form when you need a scriptable boolean; the `-> branch` ref-update line / `git status -sb` check below is the quick visual form — same goal, pick by context:
+
+```bash
+test "$(git rev-parse HEAD)" = "$(git ls-remote origin "refs/heads/<branch>" | cut -f1)" && echo PUSH_LANDED
+```
 
 ### 3. Push
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,5 +85,6 @@ When compacting context, preserve:
 - **The work-stack pointer**: the interrupted task and its resume point when a side-quest (prod bug, review round) preempted the main line
 - **Manual-test / smoke-checklist state**: which items the user has executed and their results (also written to CURRENT.md per `/tzurot-testing` — the file is the source of truth)
 - Re-read `.claude/rules/` files after compaction
+- **Read-state does not survive compaction**: Edit/Write requires a fresh Read of any file post-compaction — and auto-loaded content (rules, CLAUDE.md, CURRENT.md, backlog injections) never counts as Read for editing purposes; Read the file first or the edit is rejected
 
 **Recovery mechanism**: exact pre-compaction context (verbatim quotes, tool output, decisions) is recoverable by grepping the session JSONL under `~/.claude/projects/<project-slug>/` (the slug derives from the checkout path — `ls ~/.claude/projects/` to find it) — use it before re-deriving or guessing at lost state.


### PR DESCRIPTION
## Summary

Post-beta.147 friction mining over the full session transcript (48MB JSONL, 118 tool errors → 15 verified classes). This PR operationalizes every recurring class that has a structural home in the repo, per the fix-recurring-failures-structurally doctrine. Full mining report in the session; counts below are from the transcript, not anecdote.

| Fix | Class it kills | Mined count |
|---|---|---|
| `05-tooling.md`: add **header-max-length ≤100** to the commitlint gotchas | commit-msg rejections — the top *actual* offender was the one gotcha not documented | 13 rejections (3 confirmed header-length) |
| `CLAUDE.md` compaction instructions: **read-state doesn't survive compaction; auto-loaded content ≠ Read** | edit-before-read rejections — the single largest mechanical cost | 33 |
| `tzurot-git-workflow` skill: **command-shape rules** (`&&` not `;`, never filter hook output, 600s timeouts, `git -C` in cd-compounds, canonical `ls-remote` push-verify) | four classes at once: hidden hook rejections (≥8), pathspec-after-cd (10), timeout kills mid-hook (6), dash-leading grep patterns breaking ugrep (3) | 27 |
| `settings.json`: PostToolUse eslint hook **drops `--fix`** (report-only) | modified-since-read rejections — the auto-fix rewrote every edited .ts, invalidating read-state for the next edit; lint-staged already fixes at commit, so the fix pass was redundant | 17 (~10 hook-caused) |

**⚠️ The settings.json change is the one judgment call**: lint feedback still surfaces after every edit (the hook still runs eslint and prints findings) — only the silent rewrite goes away. Auto-fixing still happens at commit via lint-staged. If you prefer keeping edit-time auto-fix, say so and I'll drop that hunk.

**Machine-local fixes applied outside this PR** (not review-gated): SSH keepalive for github.com in `~/.ssh/config` (push connections idled out during multi-minute pre-push gates — 5 drops in one afternoon), and a memory note for branch-switch dist staleness.

**Explicitly NOT fixed** (bounded by owner decision or external): claude-review silent completions (external dependency — rerun procedure is the ceiling), AskUserQuestion mobile answer loss (harness bug, one-off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)