### PR TITLE
fix(api-gateway): aggregate usage Top Models by short model name

### DIFF
--- a/packages/common-types/src/utils/modelNames.test.ts
+++ b/packages/common-types/src/utils/modelNames.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { shortModelName } from './modelNames.js';
+
+describe('shortModelName', () => {
+  it('strips a single provider prefix', () => {
+    expect(shortModelName('z-ai/glm-5.2')).toBe('glm-5.2');
+  });
+
+  it('keeps only the last segment of a multi-segment id', () => {
+    expect(shortModelName('openrouter/z-ai/glm-5.2')).toBe('glm-5.2');
+  });
+
+  it('passes through an unprefixed name', () => {
+    expect(shortModelName('glm-5.2')).toBe('glm-5.2');
+  });
+
+  it('is idempotent', () => {
+    expect(shortModelName(shortModelName('z-ai/glm-5.2'))).toBe('glm-5.2');
+  });
+
+  it('falls back to the full id on a trailing slash', () => {
+    expect(shortModelName('weird/')).toBe('weird/');
+  });
+});

--- a/packages/common-types/src/utils/modelNames.ts
+++ b/packages/common-types/src/utils/modelNames.ts
@@ -1,0 +1,20 @@
+/**
+ * Model-name display helpers.
+ *
+ * Provider-qualified model ids (`z-ai/glm-5.2`, `openrouter/auto`) carry the
+ * provider as a path prefix. Display surfaces show only the short name, and
+ * usage aggregation groups by it (the same model reached via two providers is
+ * one model to the user — the per-provider split has its own section).
+ */
+
+/**
+ * The short display name of a model id: the segment after the last `/`.
+ * Ids without a prefix pass through unchanged. Idempotent.
+ */
+export function shortModelName(model: string): string {
+  if (!model.includes('/')) {
+    return model;
+  }
+  const short = model.split('/').pop();
+  return short !== undefined && short.length > 0 ? short : model;
+}

--- a/services/api-gateway/src/routes/admin/usage.test.ts
+++ b/services/api-gateway/src/routes/admin/usage.test.ts
@@ -191,6 +191,39 @@ describe('Admin Usage Routes', () => {
       });
     });
 
+    it('merges the same model reached via different providers into one row', async () => {
+      // The owner-reported duplicate: z-ai/glm-5.2 (zai-coding) and glm-5.2
+      // (openrouter) are the same model — one Top Models row, summed.
+      mockPrisma.usageLog.findMany.mockResolvedValue([
+        {
+          userId: 'user-1',
+          model: 'z-ai/glm-5.2',
+          provider: 'zai-coding',
+          tokensIn: 100,
+          tokensOut: 50,
+          requestType: 'chat',
+        },
+        {
+          userId: 'user-1',
+          model: 'glm-5.2',
+          provider: 'openrouter',
+          tokensIn: 200,
+          tokensOut: 100,
+          requestType: 'chat',
+        },
+      ]);
+      mockPrisma.user.findMany.mockResolvedValue([{ id: 'user-1', discordId: 'discord-123' }]);
+
+      const response = await request(app).get('/admin/usage');
+
+      expect(response.body.byModel['glm-5.2']).toEqual({
+        requests: 2,
+        tokensIn: 300,
+        tokensOut: 150,
+      });
+      expect(response.body.byModel['z-ai/glm-5.2']).toBeUndefined();
+    });
+
     it('should aggregate by request type', async () => {
       mockPrisma.usageLog.findMany.mockResolvedValue([
         {

--- a/services/api-gateway/src/routes/admin/usage.ts
+++ b/services/api-gateway/src/routes/admin/usage.ts
@@ -7,6 +7,7 @@ import { Router, type Response, type Request, type RequestHandler } from 'expres
 import { StatusCodes } from 'http-status-codes';
 import { Duration, DurationParseError } from '@tzurot/common-types/utils/Duration';
 import { createLogger } from '@tzurot/common-types/utils/logger';
+import { shortModelName } from '@tzurot/common-types/utils/modelNames';
 import { requireOwnerAuth } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { sendCustomSuccess } from '../../utils/responseHelpers.js';
@@ -128,11 +129,14 @@ export const handleGetAdminUsageStats = (deps: RouteDeps): RequestHandler => {
       stats.byProvider[log.provider].tokensIn += log.tokensIn;
       stats.byProvider[log.provider].tokensOut += log.tokensOut;
 
-      // By model
-      stats.byModel[log.model] ??= { requests: 0, tokensIn: 0, tokensOut: 0 };
-      stats.byModel[log.model].requests++;
-      stats.byModel[log.model].tokensIn += log.tokensIn;
-      stats.byModel[log.model].tokensOut += log.tokensOut;
+      // By model — keyed by the SHORT name so the same model reached via two
+      // providers (z-ai/glm-5.2 vs openrouter's glm-5.2) aggregates into one
+      // row; the per-provider split has its own section.
+      const modelKey = shortModelName(log.model);
+      stats.byModel[modelKey] ??= { requests: 0, tokensIn: 0, tokensOut: 0 };
+      stats.byModel[modelKey].requests++;
+      stats.byModel[modelKey].tokensIn += log.tokensIn;
+      stats.byModel[modelKey].tokensOut += log.tokensOut;
 
       // By request type
       stats.byRequestType[log.requestType] ??= { requests: 0, tokensIn: 0, tokensOut: 0 };

--- a/services/api-gateway/src/routes/user/usage.test.ts
+++ b/services/api-gateway/src/routes/user/usage.test.ts
@@ -287,6 +287,39 @@ describe('/user/usage routes', () => {
       );
     });
 
+    it('merges the same model reached via different providers into one row', async () => {
+      // The owner-reported duplicate: z-ai/glm-5.2 (zai-coding) and glm-5.2
+      // (openrouter) are the same model — one Top Models row, summed.
+      mockPrisma.usageLog.findMany.mockResolvedValue([
+        {
+          model: 'z-ai/glm-5.2',
+          provider: 'zai-coding',
+          tokensIn: 100,
+          tokensOut: 50,
+          requestType: 'chat',
+        },
+        {
+          model: 'glm-5.2',
+          provider: 'openrouter',
+          tokensIn: 200,
+          tokensOut: 100,
+          requestType: 'chat',
+        },
+      ]);
+
+      const { req, res } = createMockReqRes({});
+
+      await callHandler(mockPrisma, req, res);
+
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          byModel: {
+            'glm-5.2': { requests: 2, tokensIn: 300, tokensOut: 150 },
+          },
+        })
+      );
+    });
+
     it('should aggregate by request type', async () => {
       mockPrisma.usageLog.findMany.mockResolvedValue([
         {

--- a/services/api-gateway/src/routes/user/usage.ts
+++ b/services/api-gateway/src/routes/user/usage.ts
@@ -7,6 +7,7 @@ import { Router, type Response, type RequestHandler } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { type UsagePeriod, type UsageStats } from '@tzurot/common-types/schemas/api/usage';
 import { createLogger } from '@tzurot/common-types/utils/logger';
+import { shortModelName } from '@tzurot/common-types/utils/modelNames';
 import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import { resolveProvisionedUserId } from '../../utils/resolveProvisionedUserId.js';
@@ -115,11 +116,14 @@ export const handleGetUserUsage = (deps: RouteDeps): RequestHandler => {
       stats.byProvider[log.provider].tokensIn += log.tokensIn;
       stats.byProvider[log.provider].tokensOut += log.tokensOut;
 
-      // By model
-      stats.byModel[log.model] ??= { requests: 0, tokensIn: 0, tokensOut: 0 };
-      stats.byModel[log.model].requests++;
-      stats.byModel[log.model].tokensIn += log.tokensIn;
-      stats.byModel[log.model].tokensOut += log.tokensOut;
+      // By model — keyed by the SHORT name so the same model reached via two
+      // providers (z-ai/glm-5.2 vs openrouter's glm-5.2) aggregates into one
+      // row; the per-provider split has its own section.
+      const modelKey = shortModelName(log.model);
+      stats.byModel[modelKey] ??= { requests: 0, tokensIn: 0, tokensOut: 0 };
+      stats.byModel[modelKey].requests++;
+      stats.byModel[modelKey].tokensIn += log.tokensIn;
+      stats.byModel[modelKey].tokensOut += log.tokensOut;
 
       // By request type
       stats.byRequestType[log.requestType] ??= { requests: 0, tokensIn: 0, tokensOut: 0 };

--- a/services/bot-client/src/commands/preset/autocomplete.ts
+++ b/services/bot-client/src/commands/preset/autocomplete.ts
@@ -14,6 +14,7 @@ import {
 } from '@tzurot/common-types/utils/autocompleteFormat';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { TTLCache } from '@tzurot/common-types/utils/TTLCache';
+import { shortModelName } from '@tzurot/common-types/utils/modelNames';
 import { clientsFor } from '../../utils/gatewayClients.js';
 import {
   fetchTextModels,
@@ -206,7 +207,7 @@ async function handlePresetAutocomplete(
       // 👁 for vision-capable models (capability, not config kind)
       statusBadges: c.supportsVision ? [AUTOCOMPLETE_BADGES.VISION] : undefined,
       // Show model short name as metadata
-      metadata: c.model.split('/').pop(),
+      metadata: shortModelName(c.model),
     });
   });
 
@@ -339,7 +340,7 @@ async function handleGlobalConfigAutocomplete(
         value: c.id,
         scopeBadge: AUTOCOMPLETE_BADGES.GLOBAL,
         statusBadges: statusBadges.length > 0 ? statusBadges : undefined,
-        metadata: c.model.split('/').pop(),
+        metadata: shortModelName(c.model),
       });
     });
 

--- a/services/bot-client/src/commands/preset/browse.ts
+++ b/services/bot-client/src/commands/preset/browse.ts
@@ -21,6 +21,7 @@ import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
 import { presetBrowseOptions } from '@tzurot/common-types/generated/commandOptions';
 import { type LlmConfigSummary } from '@tzurot/common-types/schemas/api/llm-config';
 import { createLogger } from '@tzurot/common-types/utils/logger';
+import { shortModelName } from '@tzurot/common-types/utils/modelNames';
 import type { DeferredCommandContext } from '../../utils/commandContext/types.js';
 import type { UserClient } from '@tzurot/clients';
 import { clientsFor } from '../../utils/gatewayClients.js';
@@ -115,8 +116,7 @@ function buildPresetBadges(preset: LlmConfigSummary): string {
  * the user is in guest mode and the model isn't free.
  */
 function buildPresetDescription(preset: LlmConfigSummary, isGuestMode: boolean): string {
-  const shortModel = preset.model.includes('/') ? preset.model.split('/').pop() : preset.model;
-  let description = shortModel ?? preset.model;
+  let description = shortModelName(preset.model);
   if (isGuestMode && !isFreeModel(preset.model)) {
     description += ' (requires API key)';
   }
@@ -179,7 +179,7 @@ function filterPresets(
  */
 function formatPresetLine(c: LlmConfigSummary, isGuestMode: boolean, index: number): string {
   const badgeStr = presetBadgeArray(c).join('');
-  const shortModel = c.model.includes('/') ? c.model.split('/').pop() : c.model;
+  const shortModel = shortModelName(c.model);
   const safeName = escapeMarkdown(c.name);
 
   // In guest mode, dim paid presets

--- a/services/bot-client/src/commands/settings/preset/autocomplete.ts
+++ b/services/bot-client/src/commands/settings/preset/autocomplete.ts
@@ -12,6 +12,7 @@ import {
   type AutocompleteBadge,
 } from '@tzurot/common-types/utils/autocompleteFormat';
 import { createLogger } from '@tzurot/common-types/utils/logger';
+import { shortModelName } from '@tzurot/common-types/utils/modelNames';
 import { clientsFor } from '../../../utils/gatewayClients.js';
 import { handlePersonalityAutocomplete } from '../../../utils/autocomplete/index.js';
 
@@ -153,7 +154,7 @@ async function handlePresetAutocomplete(
       value: c.id,
       scopeBadge: c.isGlobal ? AUTOCOMPLETE_BADGES.GLOBAL : AUTOCOMPLETE_BADGES.OWNED,
       statusBadges: statusBadges.length > 0 ? statusBadges : undefined,
-      metadata: c.model.split('/').pop(),
+      metadata: shortModelName(c.model),
     });
   });
 

--- a/services/bot-client/src/utils/usageFormatter.ts
+++ b/services/bot-client/src/utils/usageFormatter.ts
@@ -5,6 +5,7 @@
 import { EmbedBuilder } from 'discord.js';
 import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
 import { type AdminUsageStats } from '@tzurot/common-types/schemas/api/usage';
+import { shortModelName } from '@tzurot/common-types/utils/modelNames';
 
 /**
  * Base usage stats structure (shared between user and admin)
@@ -105,7 +106,7 @@ function addModelBreakdown(
     .slice(0, maxItems)
     .map(model => {
       const m = byModel[model];
-      const shortModel = model.includes('/') ? model.split('/').pop() : model;
+      const shortModel = shortModelName(model);
       if (includeTokens) {
         return `**${shortModel}**: ${m.requests} req • ${formatTokens(m.tokensIn + m.tokensOut)} tokens`;
       }


### PR DESCRIPTION
Fixes the duplicate Top Models rows in `/usage` (owner-reported twice — screenshot showed `glm-5.2` at 1102 req AND 194 req): `byModel` keyed by the full provider-qualified id (`z-ai/glm-5.2` via zai-coding vs the same model via OpenRouter) while the formatter strips the prefix for display, so two distinct keys rendered as the identical short name.

**Fix shape (merge, per the filed follow-up's option a)**: both usage routes now aggregate `byModel` by the short model name — cross-provider usage for the same model sums into one row. The "By Provider" section already carries the per-provider split, so labeled duplicate rows would have been redundant with it.

**Rider (reuse-scout class)**: the strip idiom (`model.includes('/') ? model.split('/').pop() : model`) was copy-pasted across six display sites — usage formatter, preset browse ×2, preset autocomplete ×3. All consolidated onto one `shortModelName` helper in common-types (tested, idempotent, multi-segment-safe).

Discharges the `backlog/cold/follow-ups.md` Top-Models row (removed at merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)