### PR TITLE
refactor: drop llm_configs.kind + collapse preset namespace (Phase B)

### DIFF
--- a/packages/clients/src/clients/_generated/owner-client.ts
+++ b/packages/clients/src/clients/_generated/owner-client.ts
@@ -172,8 +172,8 @@ export class OwnerClient {
   /**
    * @safeRead Server-side has no observable mutation — safe to cache client-side.
    */
-  async listGlobalLlmConfigs(options: { kind?: string } = {}): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.listGlobalLlmConfigs.output>>> {
-    const fullPath = '/api/admin/llm-config' + buildQueryString([['kind', options.kind]]);
+  async listGlobalLlmConfigs(): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.listGlobalLlmConfigs.output>>> {
+    const fullPath = '/api/admin/llm-config';
     return callGateway({
       baseUrl: this.baseUrl,
       serviceSecret: this.serviceSecret,
@@ -242,8 +242,8 @@ export class OwnerClient {
   /**
    * @idempotent Replaying the exact same request lands the same final state — safe to retry on network failure.
    */
-  async setGlobalLlmConfigDefault(id: string, options: { kind?: string } = {}): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.setGlobalLlmConfigDefault.output>>> {
-    const fullPath = `/api/admin/llm-config/${encodeURIComponent(id)}/set-default` + buildQueryString([['kind', options.kind]]);
+  async setGlobalLlmConfigDefault(id: string, options: { slot?: string } = {}): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.setGlobalLlmConfigDefault.output>>> {
+    const fullPath = `/api/admin/llm-config/${encodeURIComponent(id)}/set-default` + buildQueryString([['slot', options.slot]]);
     return callGateway({
       baseUrl: this.baseUrl,
       serviceSecret: this.serviceSecret,
@@ -259,8 +259,8 @@ export class OwnerClient {
   /**
    * @idempotent Replaying the exact same request lands the same final state — safe to retry on network failure.
    */
-  async setGlobalLlmConfigFreeDefault(id: string, options: { kind?: string } = {}): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.setGlobalLlmConfigFreeDefault.output>>> {
-    const fullPath = `/api/admin/llm-config/${encodeURIComponent(id)}/set-free-default` + buildQueryString([['kind', options.kind]]);
+  async setGlobalLlmConfigFreeDefault(id: string, options: { slot?: string } = {}): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.setGlobalLlmConfigFreeDefault.output>>> {
+    const fullPath = `/api/admin/llm-config/${encodeURIComponent(id)}/set-free-default` + buildQueryString([['slot', options.slot]]);
     return callGateway({
       baseUrl: this.baseUrl,
       serviceSecret: this.serviceSecret,

--- a/packages/clients/src/clients/_generated/user-client.ts
+++ b/packages/clients/src/clients/_generated/user-client.ts
@@ -96,8 +96,8 @@ export class UserClient {
   /**
    * @safeRead Server-side has no observable mutation — safe to cache client-side.
    */
-  async listUserLlmConfigs(options: { kind?: string } = {}): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.listUserLlmConfigs.output>>> {
-    const fullPath = '/api/user/llm-config' + buildQueryString([['kind', options.kind]]);
+  async listUserLlmConfigs(): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.listUserLlmConfigs.output>>> {
+    const fullPath = '/api/user/llm-config';
     return callGateway({
       baseUrl: this.baseUrl,
       serviceSecret: this.serviceSecret,
@@ -488,8 +488,8 @@ export class UserClient {
   /**
    * @safeRead Server-side has no observable mutation — safe to cache client-side.
    */
-  async listModelOverrides(options: { kind?: string } = {}): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.listModelOverrides.output>>> {
-    const fullPath = '/api/user/model-override' + buildQueryString([['kind', options.kind]]);
+  async listModelOverrides(options: { slot?: string } = {}): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.listModelOverrides.output>>> {
+    const fullPath = '/api/user/model-override' + buildQueryString([['slot', options.slot]]);
     return callGateway({
       baseUrl: this.baseUrl,
       serviceSecret: this.serviceSecret,
@@ -509,8 +509,8 @@ export class UserClient {
   /**
    * @idempotent Replaying the exact same request lands the same final state — safe to retry on network failure.
    */
-  async setModelOverride(input: z.infer<typeof ROUTE_MANIFEST.setModelOverride.input>, options: { kind?: string } = {}): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.setModelOverride.output>>> {
-    const fullPath = '/api/user/model-override' + buildQueryString([['kind', options.kind]]);
+  async setModelOverride(input: z.infer<typeof ROUTE_MANIFEST.setModelOverride.input>, options: { slot?: string } = {}): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.setModelOverride.output>>> {
+    const fullPath = '/api/user/model-override' + buildQueryString([['slot', options.slot]]);
     return callGateway({
       baseUrl: this.baseUrl,
       serviceSecret: this.serviceSecret,
@@ -527,8 +527,8 @@ export class UserClient {
     });
   }
 
-  async deleteModelOverride(personalityId: string, options: { kind?: string } = {}): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.deleteModelOverride.output>>> {
-    const fullPath = `/api/user/model-override/${encodeURIComponent(personalityId)}` + buildQueryString([['kind', options.kind]]);
+  async deleteModelOverride(personalityId: string, options: { slot?: string } = {}): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.deleteModelOverride.output>>> {
+    const fullPath = `/api/user/model-override/${encodeURIComponent(personalityId)}` + buildQueryString([['slot', options.slot]]);
     return callGateway({
       baseUrl: this.baseUrl,
       serviceSecret: this.serviceSecret,
@@ -568,8 +568,8 @@ export class UserClient {
   /**
    * @idempotent Replaying the exact same request lands the same final state — safe to retry on network failure.
    */
-  async setDefaultModelConfig(input: z.infer<typeof ROUTE_MANIFEST.setDefaultModelConfig.input>, options: { kind?: string } = {}): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.setDefaultModelConfig.output>>> {
-    const fullPath = '/api/user/model-override/default' + buildQueryString([['kind', options.kind]]);
+  async setDefaultModelConfig(input: z.infer<typeof ROUTE_MANIFEST.setDefaultModelConfig.input>, options: { slot?: string } = {}): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.setDefaultModelConfig.output>>> {
+    const fullPath = '/api/user/model-override/default' + buildQueryString([['slot', options.slot]]);
     return callGateway({
       baseUrl: this.baseUrl,
       serviceSecret: this.serviceSecret,
@@ -586,8 +586,8 @@ export class UserClient {
     });
   }
 
-  async clearDefaultModelConfig(options: { kind?: string } = {}): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.clearDefaultModelConfig.output>>> {
-    const fullPath = '/api/user/model-override/default' + buildQueryString([['kind', options.kind]]);
+  async clearDefaultModelConfig(options: { slot?: string } = {}): Promise<GatewayResult<z.infer<typeof ROUTE_MANIFEST.clearDefaultModelConfig.output>>> {
+    const fullPath = '/api/user/model-override/default' + buildQueryString([['slot', options.slot]]);
     return callGateway({
       baseUrl: this.baseUrl,
       serviceSecret: this.serviceSecret,

--- a/packages/clients/src/routes/admin.ts
+++ b/packages/clients/src/routes/admin.ts
@@ -24,7 +24,7 @@
  */
 
 import { z } from 'zod';
-import { CONFIG_KINDS } from '@tzurot/common-types/constants/ai';
+import { MODEL_SLOTS } from '@tzurot/common-types/constants/ai';
 import { GATEWAY_TIMEOUTS } from '@tzurot/common-types/constants/discord';
 import { DbSyncSchema, InvalidateCacheSchema } from '@tzurot/common-types/schemas/api/admin';
 import {
@@ -233,10 +233,6 @@ export const adminRoutes = {
     method: 'get',
     path: '/llm-config',
     id: 'listGlobalLlmConfigs',
-    // Scope the listing to a config kind (text|vision), or `all` to return both
-    // (the owner picker fetches both in one capability-agnostic call); defaults
-    // text. The gateway LIST handler parses this with parseConfigKindQueryAllowAll.
-    query: { kind: z.enum([...CONFIG_KINDS, 'all']).optional() },
     output: ListLlmConfigsResponseSchema,
     meta: { safeRead: true },
     // Dual-context: bot-owner autocomplete (3s Discord deadline) and
@@ -289,9 +285,9 @@ export const adminRoutes = {
     path: '/llm-config/:id/set-default',
     id: 'setGlobalLlmConfigDefault',
     params: { id: z.string() },
-    // The admin set-default routes gate by kind (requireKind); pass it so a
-    // vision config can be promoted to the vision default.
-    query: { kind: z.enum(CONFIG_KINDS).optional() },
+    // Which default slot the config is promoted into; the gateway
+    // capability-gates the vision slot.
+    query: { slot: z.enum(MODEL_SLOTS).optional() },
     output: SetDefaultLlmConfigResponseSchema,
     meta: { idempotent: true },
   },
@@ -303,9 +299,9 @@ export const adminRoutes = {
     path: '/llm-config/:id/set-free-default',
     id: 'setGlobalLlmConfigFreeDefault',
     params: { id: z.string() },
-    // The admin set-default routes gate by kind (requireKind); pass it so a
-    // vision config can be promoted to the vision default.
-    query: { kind: z.enum(CONFIG_KINDS).optional() },
+    // Which free-default slot the config is promoted into; the gateway
+    // capability-gates the vision slot.
+    query: { slot: z.enum(MODEL_SLOTS).optional() },
     output: SetDefaultLlmConfigResponseSchema,
     meta: { idempotent: true },
   },

--- a/packages/clients/src/routes/user/configs.ts
+++ b/packages/clients/src/routes/user/configs.ts
@@ -11,7 +11,7 @@
  */
 
 import { z } from 'zod';
-import { CONFIG_KINDS } from '@tzurot/common-types/constants/ai';
+import { MODEL_SLOTS } from '@tzurot/common-types/constants/ai';
 import { GATEWAY_TIMEOUTS } from '@tzurot/common-types/constants/discord';
 import {
   CreateLlmConfigResponseSchema,
@@ -110,11 +110,6 @@ export const userConfigRoutes = {
     method: 'get',
     path: '/llm-config',
     id: 'listUserLlmConfigs',
-    // Scope the listing to a config kind (text|vision), or `all` to return both
-    // (browse fetches both in one call); defaults text. The gateway LIST handler
-    // parses this with parseConfigKindQueryAllowAll, so `all` is a valid inbound
-    // value the manifest must permit.
-    query: { kind: z.enum([...CONFIG_KINDS, 'all']).optional() },
     output: ListLlmConfigsResponseSchema,
     requiresProvisionedUser: true,
     meta: { safeRead: true },
@@ -359,11 +354,11 @@ export const userConfigRoutes = {
     method: 'get',
     path: '/model-override',
     id: 'listModelOverrides',
-    // Scope the listing to a config kind (text|vision), or `all` to return both
-    // (browse fetches both in one call); defaults text. The gateway LIST handler
-    // parses this with parseConfigKindQueryAllowAll, so `all` is a valid inbound
-    // value the manifest must permit.
-    query: { kind: z.enum([...CONFIG_KINDS, 'all']).optional() },
+    // Scope the listing to a slot (text|vision), or `all` to return both
+    // (browse fetches both in one call — one row per occupied slot); defaults
+    // text. The gateway parses this with parseModelSlotQueryAllowAll, so `all`
+    // is a valid inbound value the manifest must permit.
+    query: { slot: z.enum([...MODEL_SLOTS, 'all']).optional() },
     output: ListModelOverridesResponseSchema,
     requiresProvisionedUser: true,
     meta: { safeRead: true },
@@ -378,7 +373,7 @@ export const userConfigRoutes = {
     input: SetModelOverrideSchema,
     // The slot the override occupies (text|vision); defaults text. The gateway
     // capability-gates the vision slot (its model must support image input).
-    query: { kind: z.enum(CONFIG_KINDS).optional() },
+    query: { slot: z.enum(MODEL_SLOTS).optional() },
     output: SetModelOverrideResponseSchema,
     requiresProvisionedUser: true,
     meta: { idempotent: true },
@@ -392,7 +387,7 @@ export const userConfigRoutes = {
     params: { personalityId: z.string() },
     // Scope the clear to a slot: `all` (the no-slot default) clears BOTH slots,
     // an explicit text|vision clears just that one.
-    query: { kind: z.enum([...CONFIG_KINDS, 'all']).optional() },
+    query: { slot: z.enum([...MODEL_SLOTS, 'all']).optional() },
     output: DeleteModelOverrideResponseSchema,
     requiresProvisionedUser: true,
   },
@@ -419,7 +414,7 @@ export const userConfigRoutes = {
     input: SetDefaultConfigSchema,
     // The slot the default occupies (text|vision); defaults text. The gateway
     // capability-gates the vision slot (its model must support image input).
-    query: { kind: z.enum(CONFIG_KINDS).optional() },
+    query: { slot: z.enum(MODEL_SLOTS).optional() },
     output: SetDefaultConfigResponseSchema,
     requiresProvisionedUser: true,
     meta: { idempotent: true },
@@ -432,7 +427,7 @@ export const userConfigRoutes = {
     id: 'clearDefaultModelConfig',
     // Scope the clear to a slot: `all` (the no-slot default) clears BOTH slots,
     // an explicit text|vision clears just that one.
-    query: { kind: z.enum([...CONFIG_KINDS, 'all']).optional() },
+    query: { slot: z.enum([...MODEL_SLOTS, 'all']).optional() },
     output: ClearDefaultConfigResponseSchema,
     requiresProvisionedUser: true,
   },

--- a/packages/common-types/src/constants/ai.test.ts
+++ b/packages/common-types/src/constants/ai.test.ts
@@ -11,6 +11,9 @@ import {
   getZaiCodingPlanContextLength,
   zaiCodingPlanModelCapabilities,
   listZaiCodingPlanModels,
+  toModelSlot,
+  MODEL_SLOTS,
+  DEFAULT_MODEL_SLOT,
 } from './ai.js';
 
 describe('isFreeModel', () => {
@@ -42,6 +45,20 @@ describe('isFreeModel', () => {
     expect(isFreeModel('')).toBe(false);
     expect(isFreeModel(':free')).toBe(true);
     expect(isFreeModel('model:FREE')).toBe(false); // case sensitive
+  });
+});
+
+describe('toModelSlot', () => {
+  it('narrows each known slot value through unchanged', () => {
+    for (const slot of MODEL_SLOTS) {
+      expect(toModelSlot(slot)).toBe(slot);
+    }
+  });
+
+  it('floors an unrecognized value to the default (text) slot', () => {
+    expect(toModelSlot('audio')).toBe(DEFAULT_MODEL_SLOT);
+    expect(toModelSlot('')).toBe(DEFAULT_MODEL_SLOT);
+    expect(toModelSlot('TEXT')).toBe(DEFAULT_MODEL_SLOT); // case-sensitive
   });
 });
 

--- a/packages/common-types/src/constants/ai.ts
+++ b/packages/common-types/src/constants/ai.ts
@@ -196,28 +196,39 @@ export const MODEL_DEFAULTS = {
 } as const;
 
 /**
- * Config-kind discriminator for the shared `llm_configs` table. A config row is a
- * text-model preset or a vision-model preset (future: image / video). Vision (and
- * future-modality) configs REUSE the same table + cascade + CRUD as text,
- * distinguished only by `kind`.
+ * Model-slot selector: which of a target's two model assignments an operation
+ * addresses. Personalities, user defaults, and the admin global/free defaults each
+ * carry a text-model slot and a vision-model slot (separate FK columns / pointer
+ * columns); the slot is always the CALLER's choice on the request, never a property
+ * of the config row — any preset can occupy either slot, gated only by model
+ * capability at assignment time (`ensureVisionCapableModel`).
  *
- * Single source of truth: the Prisma column default, the resolver queries, the
- * `LlmConfigService` filters, and the slash-command `kind` choices all
- * reference this — so adding a modality is a one-line change here, with the type
- * system enforcing exhaustiveness at every switch on a `ConfigKind`.
+ * Single source of truth for the wire `?slot=` query param, the slash-command
+ * `slot` choices, and every switch on a `ModelSlot`.
  */
-export const CONFIG_KINDS = ['text', 'vision'] as const;
-export type ConfigKind = (typeof CONFIG_KINDS)[number];
+export const MODEL_SLOTS = ['text', 'vision'] as const;
+export type ModelSlot = (typeof MODEL_SLOTS)[number];
 
 /**
  * Max length for an LlmConfig/TtsConfig `name`. Single source for the `.max()` in
  * both config schemas AND the promote-normalization util, so they can't drift.
- * Lives here with the other config-domain constants (`CONFIG_KINDS` etc.).
+ * Lives here with the other config-domain constants (`MODEL_SLOTS` etc.).
  */
 export const CONFIG_NAME_MAX_LENGTH = 100;
 
-/** Default kind for a newly-created config — matches the Prisma `kind` column default. */
-export const DEFAULT_CONFIG_KIND: ConfigKind = 'text';
+/** Default slot when an operation doesn't specify one — the text (chat) slot. */
+export const DEFAULT_MODEL_SLOT: ModelSlot = 'text';
+
+/**
+ * Narrow a string (e.g. a slash-command option value) to a {@link ModelSlot}.
+ * Option choices are compile-time constrained to the slot values, so this normally
+ * just narrows the type; an unrecognized value floors to the default (text) slot.
+ */
+export function toModelSlot(value: string): ModelSlot {
+  return (MODEL_SLOTS as readonly string[]).includes(value)
+    ? (value as ModelSlot)
+    : DEFAULT_MODEL_SLOT;
+}
 
 /**
  * Shared description for the `slot` slash-command option (Chat | Vision) across the
@@ -225,7 +236,7 @@ export const DEFAULT_CONFIG_KIND: ConfigKind = 'text';
  * silently diverge between `/preset` and `/settings preset`. The option NAME +
  * required flag stay inline at each call site because the command-types codegen
  * reads them as string literals (it does not read the description). The encoded
- * choice values stay `text`/`vision` (the gateway's `?kind=` wire contract); only
+ * choice values stay `text`/`vision` (the gateway's `?slot=` wire contract); only
  * the user-facing labels are Chat/Vision.
  */
 export const CONFIG_SLOT_OPTION_DESCRIPTION = 'Which slot to target: Chat (default) or Vision';

--- a/packages/common-types/src/constants/index.ts
+++ b/packages/common-types/src/constants/index.ts
@@ -9,8 +9,9 @@ export {
   AI_DEFAULTS,
   AI_ENDPOINTS,
   MODEL_DEFAULTS,
-  CONFIG_KINDS,
-  DEFAULT_CONFIG_KIND,
+  MODEL_SLOTS,
+  DEFAULT_MODEL_SLOT,
+  toModelSlot,
   CONFIG_SLOT_OPTION_DESCRIPTION,
   TTS_VOICE_NAME_PREFIX,
   AIProvider,
@@ -25,7 +26,7 @@ export {
   buildModelInfoUrl,
   CONFIG_NAME_MAX_LENGTH,
 } from './ai.js';
-export type { ZaiCodingPlanModelInfo, ConfigKind } from './ai.js';
+export type { ZaiCodingPlanModelInfo, ModelSlot } from './ai.js';
 
 // Timing constants
 export {

--- a/packages/common-types/src/schemas/api/llm-config.test.ts
+++ b/packages/common-types/src/schemas/api/llm-config.test.ts
@@ -33,7 +33,7 @@ describe('LLM Config API Contract Tests', () => {
       model: 'openai/gpt-4o-mini',
       provider: 'openrouter',
       supportsVision: false,
-      kind: 'text',
+
       isGlobal: true,
       isDefault: true,
       isFreeDefault: false,
@@ -128,7 +128,7 @@ describe('LLM Config API Contract Tests', () => {
       description: null,
       provider: 'openrouter',
       model: 'openai/gpt-4o-mini',
-      kind: 'text',
+
       isGlobal: true,
       isOwned: false,
       permissions: { canEdit: false, canDelete: false },
@@ -203,7 +203,7 @@ describe('LLM Config API Contract Tests', () => {
             model: 'openai/gpt-4o-mini',
             provider: 'openrouter',
             supportsVision: false,
-            kind: 'text',
+
             isGlobal: true,
             isDefault: true,
             isFreeDefault: false,
@@ -217,7 +217,7 @@ describe('LLM Config API Contract Tests', () => {
             model: 'anthropic/claude-sonnet-4',
             provider: 'openrouter',
             supportsVision: true,
-            kind: 'vision',
+
             isGlobal: false,
             isDefault: false,
             isFreeDefault: false,
@@ -248,7 +248,7 @@ describe('LLM Config API Contract Tests', () => {
           description: 'A custom preset',
           model: 'anthropic/claude-sonnet-4',
           provider: 'openrouter',
-          kind: 'text',
+
           isGlobal: false,
           isDefault: false,
           isFreeDefault: false,
@@ -393,21 +393,6 @@ describe('LLM Config API Contract Tests', () => {
       expect(result.success).toBe(true);
     });
 
-    it('kind is optional (omitted → undefined) and accepts a valid kind', () => {
-      const omitted = LlmConfigCreateSchema.safeParse(validCreateInput);
-      expect(omitted.success).toBe(true);
-      expect(omitted.success && omitted.data.kind).toBeUndefined();
-
-      const vision = LlmConfigCreateSchema.safeParse({ ...validCreateInput, kind: 'vision' });
-      expect(vision.success).toBe(true);
-      expect(vision.success && vision.data.kind).toBe('vision');
-    });
-
-    it('rejects an unknown kind', () => {
-      const result = LlmConfigCreateSchema.safeParse({ ...validCreateInput, kind: 'audio' });
-      expect(result.success).toBe(false);
-    });
-
     it('should validate complete create input with all optional fields', () => {
       const completeInput = {
         ...validCreateInput,
@@ -531,13 +516,6 @@ describe('LLM Config API Contract Tests', () => {
       expect(result.success).toBe(true);
     });
 
-    it('does not carry kind — it is immutable (any supplied kind is stripped)', () => {
-      const result = LlmConfigUpdateSchema.safeParse({ name: 'X', kind: 'vision' });
-      expect(result.success).toBe(true);
-      // Zod strips unknown keys, so `kind` never reaches the update payload.
-      expect(result.success && 'kind' in result.data).toBe(false);
-    });
-
     it('should validate partial update with single field', () => {
       const updates = [
         { name: 'New Name' },
@@ -651,7 +629,7 @@ describe('LLM Config API Contract Tests', () => {
       description: null,
       provider: 'openrouter',
       model: 'openai/gpt-4o-mini',
-      kind: 'text',
+
       isGlobal: true,
       isDefault: false,
       isFreeDefault: false,
@@ -683,7 +661,7 @@ describe('LLM Config API Contract Tests', () => {
         description: null,
         provider: 'openrouter',
         model: 'openai/gpt-4o-mini',
-        kind: 'text',
+
         isGlobal: true,
         isDefault: false,
         isFreeDefault: false,

--- a/packages/common-types/src/schemas/api/llm-config.ts
+++ b/packages/common-types/src/schemas/api/llm-config.ts
@@ -16,12 +16,7 @@
 import { z } from 'zod';
 import { EntityPermissionsSchema, optionalString, nullableString } from './shared.js';
 import { AdvancedParamsSchema } from '../llmAdvancedParams.js';
-import {
-  MESSAGE_LIMITS,
-  AI_DEFAULTS,
-  CONFIG_KINDS,
-  CONFIG_NAME_MAX_LENGTH,
-} from '../../constants/index.js';
+import { MESSAGE_LIMITS, AI_DEFAULTS, CONFIG_NAME_MAX_LENGTH } from '../../constants/index.js';
 
 // ============================================================================
 // Context Settings Schema (shared validation for context history limits)
@@ -92,13 +87,6 @@ export const LlmConfigCreateSchema = z.object({
     .max(CONFIG_NAME_MAX_LENGTH, `name must be ${CONFIG_NAME_MAX_LENGTH} characters or less`),
   model: z.string().min(1, 'model is required').max(200),
 
-  // Config kind discriminator (text | vision | …). Optional; when omitted the
-  // service defaults it to 'text', so a caller that doesn't set it gets a text
-  // preset. A 'vision' create is validated for vision capability before it's
-  // accepted. NOT present on the update schema — `kind` is immutable (changing
-  // it would orphan the per-kind default flags); convert by delete + recreate.
-  kind: z.enum(CONFIG_KINDS).optional(),
-
   // Optional string fields
   description: z.string().max(500).optional().nullable(),
   provider: z.string().max(50).optional(),
@@ -162,10 +150,6 @@ export const LlmConfigUpdateSchema = z.object({
 
   /** Toggle global visibility - users can share their presets */
   isGlobal: z.boolean().optional(),
-
-  // NOTE: `kind` is intentionally absent — it's immutable after creation
-  // (changing it would orphan the per-kind default flags + mis-route resolvers).
-  // Convert a config to another kind by delete + recreate.
 });
 
 export type LlmConfigUpdateInput = z.infer<typeof LlmConfigUpdateSchema>;
@@ -184,9 +168,6 @@ export const LLM_CONFIG_LIST_SELECT = {
   description: true,
   provider: true,
   model: true,
-  // Surfaced in the list summary so browse can fetch all kinds in one call and
-  // badge/filter by kind without a per-kind round-trip.
-  kind: true,
   isGlobal: true,
   // isDefault/isFreeDefault are NOT selected: default-ness is an AdminSettings
   // pointer relationship (S3), and LlmConfigService.list derives the summary
@@ -201,8 +182,6 @@ export const LLM_CONFIG_LIST_SELECT = {
  */
 export const LLM_CONFIG_DETAIL_SELECT = {
   ...LLM_CONFIG_LIST_SELECT,
-  // `kind` comes through the LIST_SELECT spread (it's now surfaced in the list
-  // summary too). Detail queries still rely on it for the getById kind-gate.
   advancedParameters: true,
   // Memory settings
   memoryScoreThreshold: true,
@@ -260,13 +239,11 @@ export const LlmConfigSummarySchema = z.object({
   /**
    * Whether the model accepts image input, sourced live from the model's
    * capabilities (OpenRouter-authoritative → z.ai catalog), NOT from the config.
-   * This is the capability-driven signal the browse UI badges/filters on — it
-   * supersedes reading `kind` for vision eligibility. `false` when capability is
-   * unknown (fail-closed). Populated by the list route, not `formatConfigSummary`.
+   * This is the capability-driven signal the browse UI badges/filters on.
+   * `false` when capability is unknown (fail-closed). Populated by the list
+   * route, not `formatConfigSummary`.
    */
   supportsVision: z.boolean(),
-  /** Config kind discriminator (text | vision). Always present in list responses. */
-  kind: z.enum(CONFIG_KINDS),
   isGlobal: z.boolean(),
   isDefault: z.boolean(),
   isFreeDefault: z.boolean(),

--- a/packages/common-types/src/schemas/api/model-override.test.ts
+++ b/packages/common-types/src/schemas/api/model-override.test.ts
@@ -24,7 +24,7 @@ function createValidOverrideSummary(overrides = {}) {
     personalityName: 'Lilith',
     configId: '550e8400-e29b-41d4-a716-446655440001',
     configName: 'Claude Sonnet',
-    kind: 'text',
+    slot: 'text',
     supportsVision: false,
     ...overrides,
   };

--- a/packages/common-types/src/schemas/api/model-override.ts
+++ b/packages/common-types/src/schemas/api/model-override.ts
@@ -10,7 +10,7 @@
  */
 
 import { z } from 'zod';
-import { CONFIG_KINDS } from '../../constants/ai.js';
+import { MODEL_SLOTS } from '../../constants/ai.js';
 
 // ============================================================================
 // Shared Sub-schemas
@@ -25,17 +25,17 @@ export const ModelOverrideSummarySchema = z.object({
   configId: z.string().nullable(),
   configName: z.string().nullable(),
   /**
-   * Config kind of the override (text | vision). Nullable to match `configId`:
-   * null when there's no override; set when one exists. The all-kinds list emits
-   * one row per kind, so browse can badge + carry the kind through clear.
+   * Which model slot the override occupies (text | vision). Nullable to match
+   * `configId`: null when there's no override; set when one exists. The all-slots
+   * list emits one row per slot, so browse can badge + carry the slot through clear.
    */
-  kind: z.enum(CONFIG_KINDS).nullable(),
+  slot: z.enum(MODEL_SLOTS).nullable(),
   /**
    * Whether the override's config MODEL supports vision — sourced live from the
-   * model's capabilities (OpenRouter-authoritative → z.ai catalog), NOT from
-   * `kind`. This is the capability-driven signal the override-browse 👁 badge
-   * uses (mirrors `LlmConfigSummary.supportsVision`). `false` when capability is
-   * unknown (fail-closed). Populated by the override-list route, not the schema.
+   * model's capabilities (OpenRouter-authoritative → z.ai catalog). This is the
+   * capability-driven signal the override-browse 👁 badge uses (mirrors
+   * `LlmConfigSummary.supportsVision`). `false` when capability is unknown
+   * (fail-closed). Populated by the override-list route, not the schema.
    */
   supportsVision: z.boolean(),
 });

--- a/packages/common-types/src/services/LlmConfigMapper.test.ts
+++ b/packages/common-types/src/services/LlmConfigMapper.test.ts
@@ -13,7 +13,6 @@ describe('LlmConfigMapper', () => {
   describe('LLM_CONFIG_SELECT', () => {
     it('should include all required fields', () => {
       expect(LLM_CONFIG_SELECT.model).toBe(true);
-      expect(LLM_CONFIG_SELECT.kind).toBe(true);
       expect(LLM_CONFIG_SELECT.advancedParameters).toBe(true);
       expect(LLM_CONFIG_SELECT.memoryScoreThreshold).toBe(true);
       expect(LLM_CONFIG_SELECT.memoryLimit).toBe(true);
@@ -39,7 +38,6 @@ describe('LlmConfigMapper', () => {
     const createRaw = (overrides: Partial<RawLlmConfigFromDb> = {}): RawLlmConfigFromDb => ({
       model: 'openai/gpt-4',
       provider: 'openrouter',
-      kind: 'text',
       advancedParameters: null,
       memoryScoreThreshold: null,
       memoryLimit: null,
@@ -55,7 +53,6 @@ describe('LlmConfigMapper', () => {
       const result = mapLlmConfigFromDb(raw);
 
       expect(result.model).toBe('openai/gpt-4');
-      expect(result.kind).toBe('text');
       expect(result.contextWindowTokens).toBe(128000);
     });
 
@@ -205,7 +202,6 @@ describe('LlmConfigMapper', () => {
         name: 'My Custom Config',
         model: 'openai/gpt-4',
         provider: 'openrouter',
-        kind: 'text',
         advancedParameters: { temperature: 0.7 },
         memoryScoreThreshold: null,
         memoryLimit: 100,
@@ -228,7 +224,6 @@ describe('LlmConfigMapper', () => {
       const raw: RawLlmConfigFromDb = {
         model: 'anthropic/claude-3-sonnet',
         provider: 'openrouter',
-        kind: 'vision',
         advancedParameters: {
           temperature: 0.9,
           top_p: 0.95,
@@ -245,7 +240,6 @@ describe('LlmConfigMapper', () => {
       const result = mapLlmConfigFromDb(raw);
 
       expect(result.model).toBe('anthropic/claude-3-sonnet');
-      expect(result.kind).toBe('vision');
       expect(result.temperature).toBe(0.9);
       expect(result.topP).toBe(0.95);
       expect(result.maxTokens).toBe(4096);
@@ -258,7 +252,6 @@ describe('LlmConfigMapper', () => {
       const raw: RawLlmConfigFromDb = {
         model: 'deepseek/deepseek-r1',
         provider: 'openrouter',
-        kind: 'text',
         advancedParameters: {
           temperature: 1.0, // Required for reasoning models
           max_tokens: 32000,
@@ -293,7 +286,6 @@ describe('LlmConfigMapper', () => {
         name: 'Creative Mode',
         model: 'openai/gpt-4o',
         provider: 'openrouter',
-        kind: 'text',
         advancedParameters: {
           temperature: 1.5,
           frequency_penalty: 0.8,
@@ -314,35 +306,6 @@ describe('LlmConfigMapper', () => {
       // Other params should be undefined for proper cascade merging
       expect(result.topP).toBeUndefined();
       expect(result.maxTokens).toBeUndefined();
-    });
-  });
-
-  describe('kind discriminator', () => {
-    const rawWithKind = (kind: string): RawLlmConfigFromDb => ({
-      model: 'openai/gpt-4',
-      provider: 'openrouter',
-      kind,
-      advancedParameters: null,
-      memoryScoreThreshold: null,
-      memoryLimit: null,
-      contextWindowTokens: 128000,
-      maxMessages: 50,
-      maxAge: null,
-      maxImages: 10,
-    });
-
-    it("maps a 'vision' kind through unchanged", () => {
-      expect(mapLlmConfigFromDb(rawWithKind('vision')).kind).toBe('vision');
-    });
-
-    it("maps a 'text' kind through unchanged", () => {
-      expect(mapLlmConfigFromDb(rawWithKind('text')).kind).toBe('text');
-    });
-
-    it('defaults an unrecognized kind to text (defensive narrowing)', () => {
-      // The DB column is constrained, but an unknown value must not propagate an
-      // invalid discriminator through the resolver cascade — toConfigKind floors it.
-      expect(mapLlmConfigFromDb(rawWithKind('image-not-yet-supported')).kind).toBe('text');
     });
   });
 });

--- a/packages/common-types/src/services/LlmConfigMapper.ts
+++ b/packages/common-types/src/services/LlmConfigMapper.ts
@@ -19,7 +19,6 @@ import {
   advancedParamsToConfigFormat,
   type ConvertedLlmParams,
 } from '../schemas/llmAdvancedParams.js';
-import { CONFIG_KINDS, DEFAULT_CONFIG_KIND, type ConfigKind } from '../constants/ai.js';
 import { createLogger } from '../utils/logger.js';
 
 const logger = createLogger('LlmConfigMapper');
@@ -36,7 +35,6 @@ const logger = createLogger('LlmConfigMapper');
  *
  * Fields included:
  * - model: Model identifier
- * - kind: 'text' | 'vision' discriminator (vision configs are their own presets)
  * - advancedParameters: JSONB with ALL sampling/reasoning/output params
  * - memoryScoreThreshold, memoryLimit: Memory-related settings (not in JSONB)
  * - contextWindowTokens: Context window size (not in JSONB)
@@ -44,7 +42,6 @@ const logger = createLogger('LlmConfigMapper');
  */
 export const LLM_CONFIG_SELECT = {
   model: true,
-  kind: true, // 'text' | 'vision' discriminator (vision rows are their own presets)
   provider: true, // String column — drives provider-tier routing (e.g. 'openrouter', 'zai-coding')
   advancedParameters: true, // JSONB (snake_case)
   memoryScoreThreshold: true, // Decimal column (not in JSONB)
@@ -77,7 +74,6 @@ export const LLM_CONFIG_SELECT_WITH_NAME = {
  */
 export interface RawLlmConfigFromDb {
   model: string;
-  kind: string; // 'text' | 'vision'
   provider: string; // 'openrouter' | 'zai-coding' | future enum values
   advancedParameters: unknown; // JSONB - validated via Zod
   memoryScoreThreshold: unknown; // Prisma Decimal - converted via toNumber()
@@ -104,7 +100,6 @@ export interface RawLlmConfigFromDbWithName extends RawLlmConfigFromDb {
  */
 export interface MappedLlmConfig extends ConvertedLlmParams {
   model: string;
-  kind: ConfigKind; // validated from the raw DB string via toConfigKind()
   /**
    * Provider routing key. String-typed (not the AIProvider enum) because the
    * DB stores it as a string column and may carry future values not yet in the
@@ -180,27 +175,6 @@ function toNumber(value: unknown): number | null {
  * @param raw - Raw result from Prisma query using LLM_CONFIG_SELECT
  * @returns Mapped config ready for use in application code
  */
-/**
- * Narrow a raw DB `kind` string to a {@link ConfigKind}. The column is constrained
- * (default 'text', only our own code writes it), so this normally just narrows the
- * type; an unrecognized value defensively falls back to the default kind rather than
- * propagating an unknown discriminator through the resolver cascade.
- */
-export function toConfigKind(value: string): ConfigKind {
-  if ((CONFIG_KINDS as readonly string[]).includes(value)) {
-    return value as ConfigKind;
-  }
-  // Should never fire (the column is constrained + defaulted) — but if a malformed
-  // kind reaches here via schema drift or a partial deploy, the silent floor to 'text'
-  // would make a vision row resolve as text and quietly fall to the vision fallback.
-  // Warn so the drift is observable rather than invisible.
-  logger.warn(
-    { actual: value, validKinds: CONFIG_KINDS },
-    'Unknown LlmConfig.kind — flooring to default (text)'
-  );
-  return DEFAULT_CONFIG_KIND;
-}
-
 export function mapLlmConfigFromDb(raw: RawLlmConfigFromDb): MappedLlmConfig {
   // Validate and convert advancedParameters JSONB
   const params = safeValidateAdvancedParams(raw.advancedParameters);
@@ -208,7 +182,6 @@ export function mapLlmConfigFromDb(raw: RawLlmConfigFromDb): MappedLlmConfig {
 
   return {
     model: raw.model,
-    kind: toConfigKind(raw.kind),
     provider: raw.provider,
     // Spread ALL converted params (sampling, reasoning, output, OpenRouter)
     ...converted,

--- a/packages/common-types/src/utils/deterministicUuid.ts
+++ b/packages/common-types/src/utils/deterministicUuid.ts
@@ -127,7 +127,7 @@ export function generateSystemGlobalTtsConfigUuid(name: string): string {
  * Deterministic UUID for a system-global LlmConfig row.
  *
  * Mirrors {@link generateSystemGlobalTtsConfigUuid}. Used by `VisionConfigBootstrap`
- * to seed the vision system globals (`kind='vision'` LlmConfig rows) with stable IDs,
+ * to seed the vision system globals (LlmConfig rows) with stable IDs,
  * so dev and prod assign the same UUID for the same well-known name. Without this,
  * `/admin db-sync` fails with `llm_configs_owner_id_name_key` collisions because each
  * env would generate its own random UUID for the same logical row.

--- a/packages/config-resolver/src/LlmConfigResolver.ts
+++ b/packages/config-resolver/src/LlmConfigResolver.ts
@@ -179,7 +179,7 @@ export class LlmConfigResolver extends BaseConfigResolver<
 
     try {
       // Read the admin-set free-tier chat default via the AdminSettings pointer
-      // (singleton). Replaces the old isFreeDefault+kind='text' flag query; a null
+      // (singleton). Replaces the old per-kind flag query; a null
       // pointer means no free default — caller uses the hardcoded fallback.
       const settings = await this.prisma.adminSettings.findUnique({
         where: { id: ADMIN_SETTINGS_SINGLETON_ID },

--- a/packages/config-resolver/src/VisionConfigResolver.test.ts
+++ b/packages/config-resolver/src/VisionConfigResolver.test.ts
@@ -48,7 +48,6 @@ function createMockPrisma(): MockPrisma {
 function visionRow(over: { model?: string; name?: string } = {}): Record<string, unknown> {
   return {
     model: over.model ?? 'qwen/qwen3-vl-235b-a22b-instruct',
-    kind: 'vision',
     provider: 'openrouter',
     advancedParameters: null,
     memoryScoreThreshold: null,

--- a/packages/config-resolver/src/VisionConfigResolver.ts
+++ b/packages/config-resolver/src/VisionConfigResolver.ts
@@ -1,16 +1,16 @@
 /**
  * Vision Config Resolver Service
  *
- * Resolves the effective VISION model for a user+personality combination. Vision
- * configs are their own first-class presets — `kind='vision'` rows in the SAME
- * `llm_configs` table as text presets (their `model` field IS the vision model) —
+ * Resolves the effective VISION model for a user+personality combination. Any
+ * preset in `llm_configs` can occupy a vision slot (its `model` field IS the
+ * vision model; the slot assignment is capability-gated at write time) —
  * so this resolver reuses the LLM mapper and walks a parallel cascade.
  *
  * Resolution hierarchy (first match wins):
  *   1. User per-personality override (UserPersonalityConfig.visionConfigId)
  *   2. User global default (User.defaultVisionConfigId)
  *   3. Personality vision default (PersonalityVisionDefaultConfig — separate join table)
- *   4. Global vision default (kind='vision' AND isGlobal AND isDefault — the paid default)
+ *   4. Global vision default (AdminSettings.globalDefaultVisionConfigId — the paid default)
  *   5. Hardcoded fallback (MODEL_DEFAULTS.VISION_FALLBACK)
  *
  * The cascade waterfall (tiers 1-2) and cache lifecycle live in `BaseConfigResolver`.
@@ -18,7 +18,7 @@
  *
  * Phase-1 scope: this resolves the PAID vision default for the no-override case. The
  * GUEST downgrade stays downstream (AuthStep + selectVisionModel → VISION_FALLBACK_FREE);
- * guest-aware DB resolution (consulting a kind='vision' isFreeDefault row) is deferred
+ * guest-aware DB resolution (consulting the free-default vision pointer) is deferred
  * alongside the vision editing surface.
  *
  * Sister concerns: `LlmConfigResolver` (text model) and `TtsConfigResolver` (this is
@@ -164,7 +164,7 @@ export class VisionConfigResolver extends BaseConfigResolver<
       );
     }
 
-    // Tier 4: global vision default (kind='vision' AND isGlobal AND isDefault).
+    // Tier 4: global vision default (the AdminSettings pointer).
     const globalDefault = await this.getGlobalDefaultConfig();
     if (globalDefault !== null) {
       return globalDefault;
@@ -205,9 +205,9 @@ export class VisionConfigResolver extends BaseConfigResolver<
   }
 
   /**
-   * Get the global vision default (kind='vision' AND isGlobal AND isDefault). Cached
+   * Get the global vision default (the AdminSettings pointer). Cached
    * under the base's free-default sentinel slot — it's the no-axis system default for
-   * the vision kind. Returns null if no such row exists (callers fall to hardcoded).
+   * the vision slot. Returns null if no such row exists (callers fall to hardcoded).
    */
   async getGlobalDefaultConfig(): Promise<ResolvedVisionConfig | null> {
     const cached = this.cache.get(GLOBAL_DEFAULT_CACHE_KEY);
@@ -225,7 +225,7 @@ export class VisionConfigResolver extends BaseConfigResolver<
       // (singleton). The vision slot is capability-gated at write time, so any
       // pointed config is vision-eligible; a null pointer means no admin default —
       // fall through to the hardcoded floor. Replaces the old
-      // kind='vision'+isGlobal+isDefault flag query.
+      // per-kind flag query.
       const settings = await this.prisma.adminSettings.findUnique({
         where: { id: ADMIN_SETTINGS_SINGLETON_ID },
         select: { globalDefaultVisionConfig: { select: LLM_CONFIG_SELECT_WITH_NAME } },

--- a/packages/identity/src/personality/PersonalityDefaults.test.ts
+++ b/packages/identity/src/personality/PersonalityDefaults.test.ts
@@ -175,7 +175,6 @@ describe('PersonalityDefaults', () => {
           llmConfig: {
             model: 'anthropic/claude-sonnet-4.5',
             provider: 'openrouter',
-            kind: 'text',
             advancedParameters: {
               temperature: 0.7,
               max_tokens: 4096,
@@ -215,7 +214,6 @@ describe('PersonalityDefaults', () => {
       const globalConfig: MappedLlmConfig = {
         model: 'global-model',
         provider: 'openrouter',
-        kind: 'text',
         temperature: 0.8,
         maxTokens: 2048,
         memoryScoreThreshold: 0.6,
@@ -277,7 +275,6 @@ describe('PersonalityDefaults', () => {
           llmConfig: {
             model: 'deepseek/deepseek-r1',
             provider: 'openrouter',
-            kind: 'text',
             advancedParameters: {
               temperature: 0.7,
               top_p: 0.95,
@@ -323,7 +320,6 @@ describe('PersonalityDefaults', () => {
       const globalConfig: MappedLlmConfig = {
         model: 'global-model',
         provider: 'openrouter',
-        kind: 'text',
         temperature: 0.8,
         maxTokens: 2048,
         memoryScoreThreshold: 0.6,
@@ -359,7 +355,6 @@ describe('PersonalityDefaults', () => {
           llmConfig: {
             model: 'z-ai/glm-4.5-air:free',
             provider: 'openrouter',
-            kind: 'text',
             advancedParameters: {
               temperature: 1,
               top_p: 0.95,
@@ -395,7 +390,6 @@ describe('PersonalityDefaults', () => {
           llmConfig: {
             model: 'anthropic/claude-sonnet-4.5',
             provider: 'openrouter',
-            kind: 'text',
             advancedParameters: {
               temperature: 0.7,
               max_tokens: 16384, // Explicitly set
@@ -456,7 +450,6 @@ describe('PersonalityDefaults', () => {
           llmConfig: {
             model: 'test-model',
             provider: 'openrouter',
-            kind: 'text',
             advancedParameters: {
               temperature: 0.7,
               max_tokens: 4096,
@@ -490,7 +483,6 @@ describe('PersonalityDefaults', () => {
       const globalConfig: MappedLlmConfig = {
         model: 'global-model',
         provider: 'openrouter',
-        kind: 'text',
         temperature: 0.7,
         maxTokens: 2048,
         memoryScoreThreshold: 0.5,
@@ -534,7 +526,6 @@ describe('PersonalityDefaults', () => {
           llmConfig: {
             model: 'anthropic/claude-3-opus',
             provider: 'openrouter',
-            kind: 'text',
             advancedParameters: {
               temperature: 0.9,
               max_tokens: 4096,
@@ -553,7 +544,6 @@ describe('PersonalityDefaults', () => {
       const globalConfig: MappedLlmConfig = {
         model: 'openai/gpt-4',
         provider: 'openrouter',
-        kind: 'text',
         temperature: 0.5,
         maxTokens: 2048,
         memoryScoreThreshold: 0.5,

--- a/packages/identity/src/personality/PersonalityLoader.ts
+++ b/packages/identity/src/personality/PersonalityLoader.ts
@@ -376,7 +376,7 @@ export class PersonalityLoader {
       const mappedConfig = mapLlmConfigFromDb(globalDefault);
 
       logger.info(
-        { model: mappedConfig.model, kind: mappedConfig.kind },
+        { model: mappedConfig.model },
         '[PersonalityLoader] Loaded global default LLM config'
       );
 

--- a/packages/identity/src/personality/PersonalityValidator.ts
+++ b/packages/identity/src/personality/PersonalityValidator.ts
@@ -79,7 +79,6 @@ export const LlmConfigSchema = z
  */
 export interface DatabaseLlmConfig {
   model: string;
-  kind: string;
   provider: string; // 'openrouter' | 'zai-coding' | future enum values
   advancedParameters: unknown; // JSONB - validated via Zod in mapper
   memoryScoreThreshold: Decimal | null;

--- a/packages/test-factories/src/llm-config.ts
+++ b/packages/test-factories/src/llm-config.ts
@@ -46,7 +46,6 @@ const defaultLlmConfigSummary: LlmConfigSummary = {
   provider: 'openrouter',
   model: 'openai/gpt-4o-mini',
   supportsVision: false,
-  kind: 'text',
   isGlobal: true,
   isDefault: true,
   isFreeDefault: false,

--- a/packages/test-factories/src/model-override.ts
+++ b/packages/test-factories/src/model-override.ts
@@ -38,7 +38,7 @@ function createBaseModelOverrideSummary(
     personalityName: 'TestPersonality',
     configId: DEFAULT_CONFIG_ID,
     configName: 'TestConfig',
-    kind: 'text',
+    slot: 'text',
     supportsVision: false,
   };
   return deepMerge(base, overrides);

--- a/packages/test-utils/schema/pglite-schema.sql
+++ b/packages/test-utils/schema/pglite-schema.sql
@@ -108,7 +108,6 @@ CREATE TABLE "llm_configs" (
     "id" UUID NOT NULL,
     "name" CITEXT NOT NULL,
     "description" TEXT,
-    "kind" VARCHAR(10) NOT NULL DEFAULT 'text',
     "owner_id" UUID NOT NULL,
     "is_global" BOOLEAN NOT NULL DEFAULT false,
     "provider" VARCHAR(20) NOT NULL DEFAULT 'openrouter',
@@ -532,9 +531,6 @@ CREATE INDEX "llm_configs_owner_id_idx" ON "llm_configs"("owner_id");
 CREATE INDEX "llm_configs_is_global_idx" ON "llm_configs"("is_global");
 
 -- CreateIndex
-CREATE INDEX "llm_configs_kind_idx" ON "llm_configs"("kind");
-
--- CreateIndex
 CREATE UNIQUE INDEX "llm_configs_owner_id_name_key" ON "llm_configs"("owner_id", "name");
 
 -- CreateIndex
@@ -925,7 +921,7 @@ ALTER TABLE "users" ADD CONSTRAINT "valid_default_stt_provider_id" CHECK ("defau
 -- being real Postgres-in-WASM, applies just like prod.)
 CREATE UNIQUE INDEX "tts_configs_free_default_unique" ON "tts_configs"("is_free_default") WHERE "is_free_default" = true;
 CREATE UNIQUE INDEX "tts_configs_global_name_unique" ON "tts_configs"("name") WHERE "is_global" = true;
-CREATE UNIQUE INDEX "llm_configs_global_name_unique" ON "llm_configs"("kind", "name") WHERE "is_global" = true;
+CREATE UNIQUE INDEX "llm_configs_global_name_unique" ON "llm_configs" ("name") WHERE ("is_global" = true);
 
 -- DEFERRABLE-constraint ALTERs harvested from prisma/migrations/**/migration.sql
 -- (Prisma can't express DEFERRABLE in schema.prisma, so the hand-written

--- a/prisma/migrations/20260706002509_drop_llm_config_kind_column/migration.sql
+++ b/prisma/migrations/20260706002509_drop_llm_config_kind_column/migration.sql
@@ -1,0 +1,30 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `kind` on the `llm_configs` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "llm_configs_kind_idx";
+
+-- DropIndex
+-- REMOVED: DROP INDEX "idx_memories_embedding";
+
+-- DropIndex (explicit, ahead of the column drop)
+-- The (kind, name) partial-unique global-name index would be cascade-dropped by
+-- DROP COLUMN "kind" below, but the PGLite schema generator replays migration
+-- history and cannot see column-drop cascades — the drop must be spelled out.
+DROP INDEX IF EXISTS "llm_configs_global_name_unique";
+
+-- AlterTable
+ALTER TABLE "llm_configs" DROP COLUMN "kind";
+
+-- CreateIndex
+-- Rebuild the global-name uniqueness as a single namespace (its original shape,
+-- before the vision-kind migration split it per-kind). Partial unique index —
+-- not representable in schema.prisma; protected by drift-ignore.json. Doubles as
+-- the fail-loud guard: if any cross-kind global name collision exists in the
+-- target database, this CREATE fails and the migration aborts before deploy.
+CREATE UNIQUE INDEX "llm_configs_global_name_unique"
+  ON "llm_configs" ("name")
+  WHERE ("is_global" = true);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -188,10 +188,6 @@ model LlmConfig {
   id                                String                           @id @db.Uuid
   name                              String                           @db.Citext
   description                       String?
-  /// Discriminates text-model presets (kind='text') from vision-model presets
-  /// (kind='vision'). A vision config's `model` field IS the vision model — there is no
-  /// nested vision field. Per-kind defaults are enforced by partial unique indexes.
-  kind                              String                           @default("text") @db.VarChar(10)
   ownerId                           String                           @map("owner_id") @db.Uuid
   isGlobal                          Boolean                          @default(false) @map("is_global")
   provider                          String                           @default("openrouter") @db.VarChar(20)
@@ -227,7 +223,6 @@ model LlmConfig {
   @@unique([ownerId, name], map: "llm_configs_owner_id_name_key")
   @@index([ownerId])
   @@index([isGlobal])
-  @@index([kind])
   @@map("llm_configs")
 }
 

--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -201,7 +201,7 @@ async function initializeServices(prisma: PrismaClient): Promise<ServicesContext
   // moment a user's LLM config changes, closing the cache-TTL window where a job
   // could otherwise be stamped with the pre-change model.
   const llmConfigResolver = new LlmConfigResolver(prisma);
-  // Vision configs ARE LlmConfig rows (kind='vision'), so they share the SAME
+  // Vision slots point at LlmConfig rows in the same table, so they share the SAME
   // cache-invalidation pub/sub as text configs — a preset/config edit must clear the
   // vision resolver's cache (incl. its global-default slot) too.
   const visionConfigResolver = new VisionConfigResolver(prisma);

--- a/services/api-gateway/src/routes/admin/llm-config.test.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.test.ts
@@ -191,38 +191,6 @@ describe('Admin LLM Config Routes', () => {
       expect(response.body.configs[1].isOwned).toBe(true);
     });
 
-    it('scopes the list to ?kind=vision', async () => {
-      prisma.llmConfig.findMany.mockResolvedValue([]);
-
-      const response = await request(app).get('/admin/llm-config?kind=vision');
-
-      expect(response.status).toBe(200);
-      expect(prisma.llmConfig.findMany).toHaveBeenCalledWith(
-        expect.objectContaining({ where: expect.objectContaining({ kind: 'vision' }) })
-      );
-    });
-
-    it('accepts ?kind=all and lists both slots (capability-agnostic owner picker)', async () => {
-      prisma.llmConfig.findMany.mockResolvedValue([]);
-
-      const response = await request(app).get('/admin/llm-config?kind=all');
-
-      // `all` is now a valid LIST sentinel (parseConfigKindQueryAllowAll) — the
-      // owner picker fetches both slots in one call. No 400; the admin GLOBAL
-      // scope drops the kind filter entirely (where: {}).
-      expect(response.status).toBe(200);
-      expect(prisma.llmConfig.findMany).toHaveBeenCalledWith(
-        expect.objectContaining({ where: {} })
-      );
-    });
-
-    it('rejects an invalid ?kind= with 400', async () => {
-      const response = await request(app).get('/admin/llm-config?kind=audio');
-
-      expect(response.status).toBe(400);
-      expect(prisma.llmConfig.findMany).not.toHaveBeenCalled();
-    });
-
     it('enriches each list row with supportsVision from the model capabilities', async () => {
       // gpt-4o resolves vision-capable via OpenRouter; glm-4.7 misses OpenRouter
       // and resolves text-only from the z.ai catalog → supportsVision false.
@@ -261,7 +229,6 @@ describe('Admin LLM Config Routes', () => {
           name: 'Vision',
           model: 'openai/gpt-4o',
           provider: 'openrouter',
-          kind: 'text',
           isGlobal: true,
           isDefault: false,
           isFreeDefault: false,
@@ -272,7 +239,6 @@ describe('Admin LLM Config Routes', () => {
           name: 'Text',
           model: 'z-ai/glm-4.7',
           provider: 'openrouter',
-          kind: 'text',
           isGlobal: true,
           isDefault: false,
           isFreeDefault: false,
@@ -292,19 +258,17 @@ describe('Admin LLM Config Routes', () => {
     });
   });
 
-  describe('invalid ?kind= on by-id write routes', () => {
-    // DELETE no longer parses ?kind= (the capability-driven delete guard reads the
-    // AdminSettings pointers, not a kind-scoped flag), so only the kind-parsing write
-    // routes are covered here.
+  describe('invalid ?slot= on by-id write routes', () => {
+    // Only set-default / set-free-default parse ?slot= — edit and delete take
+    // no slot query, so they aren't covered here.
     it.each([
-      { path: '/admin/llm-config/cfg-1' },
       { path: '/admin/llm-config/cfg-1/set-default' },
       { path: '/admin/llm-config/cfg-1/set-free-default' },
-    ])('rejects put $path with 400 (kind parsed before any DB work)', async ({ path }) => {
-      const response = await request(app).put(`${path}?kind=audio`);
+    ])('rejects put $path with 400 (slot parsed before any DB work)', async ({ path }) => {
+      const response = await request(app).put(`${path}?slot=audio`);
 
       expect(response.status).toBe(400);
-      // The kind gate runs before the config fetch, so nothing is touched.
+      // The slot gate runs before the config fetch, so nothing is touched.
       expect(prisma.llmConfig.findUnique).not.toHaveBeenCalled();
     });
   });
@@ -335,33 +299,6 @@ describe('Admin LLM Config Routes', () => {
       expect(response.body.config.name).toBe('Default Config');
       expect(response.body.config.isGlobal).toBe(true);
       expect(response.body.config.params).toEqual({ temperature: 0.7 });
-    });
-
-    it('returns a kind=vision config WITHOUT ?kind= (GET by id is kind-agnostic)', async () => {
-      // Unlike the write routes, GET-by-id has no kind gate — the id uniquely
-      // identifies the config, so a vision row is returned on the bare route.
-      prisma.llmConfig.findUnique.mockResolvedValue({
-        id: 'vision-cfg',
-        name: 'Vision Cfg',
-        description: 'vision',
-        model: 'qwen/qwen3-vl-30b-a3b-instruct',
-        provider: 'openrouter',
-        isGlobal: true,
-        isDefault: false,
-        isFreeDefault: false,
-        kind: 'vision',
-        advancedParameters: {},
-        maxMessages: 50,
-        maxAge: null,
-        maxImages: 10,
-        memoryScoreThreshold: { toNumber: () => 0.5 },
-        memoryLimit: 20,
-      });
-
-      const response = await request(app).get('/admin/llm-config/vision-cfg');
-
-      expect(response.status).toBe(200);
-      expect(response.body.config.id).toBe('vision-cfg');
     });
 
     it('should return context settings (maxMessages, maxAge, maxImages)', async () => {
@@ -688,8 +625,8 @@ describe('Admin LLM Config Routes', () => {
 
   describe('PUT /admin/llm-config/:id', () => {
     it('should return 400 when model validation fails on update', async () => {
-      // The config must exist (and pass the kind check) before model validation
-      // runs — validation is now after the row fetch, so mock findUnique.
+      // The config must exist before model validation runs — validation is
+      // after the row fetch, so mock findUnique.
       prisma.llmConfig.findUnique.mockResolvedValue({
         id: 'config-id',
         name: 'Existing',
@@ -748,61 +685,6 @@ describe('Admin LLM Config Routes', () => {
         data: { name: 'New Name', model: 'google/gemini-2.0-flash' },
         select: expect.any(Object),
       });
-    });
-
-    it('edits a kind=vision config when ?kind=vision is passed', async () => {
-      // requireKind:vision lets the vision row through the otherwise text-default gate.
-      prisma.llmConfig.findUnique.mockResolvedValue({
-        id: 'vision-cfg',
-        name: 'Vision Cfg',
-        isGlobal: true,
-        kind: 'vision',
-        memoryScoreThreshold: { toNumber: () => 0.5 },
-        memoryLimit: 20,
-      });
-      prisma.llmConfig.update.mockResolvedValue({
-        id: 'vision-cfg',
-        name: 'Vision Cfg',
-        model: 'qwen/qwen3-vl-30b-a3b-instruct',
-        provider: 'openrouter',
-        isGlobal: true,
-        isDefault: false,
-        memoryScoreThreshold: { toNumber: () => 0.5 },
-        memoryLimit: 20,
-      });
-
-      const response = await request(app)
-        .put('/admin/llm-config/vision-cfg?kind=vision')
-        .send({ model: 'qwen/qwen3-vl-30b-a3b-instruct' });
-
-      expect(response.status).toBe(200);
-      expect(prisma.llmConfig.update).toHaveBeenCalledWith({
-        where: { id: 'vision-cfg' },
-        data: { model: 'qwen/qwen3-vl-30b-a3b-instruct' },
-        select: expect.any(Object),
-      });
-    });
-
-    it('rejects a kind-mismatched edit (404) before the model/vision gate runs', async () => {
-      // The row is a TEXT config but the caller claims ?kind=vision. The row
-      // fetch + requireKind must reject (404) BEFORE model validation — otherwise
-      // the vision-capability gate would fire a misleading 400 and leak that the
-      // id exists. Guards the validate-after-fetch ordering.
-      prisma.llmConfig.findUnique.mockResolvedValue({
-        id: 'text-cfg',
-        name: 'Text Cfg',
-        isGlobal: true,
-        kind: 'text',
-        memoryScoreThreshold: { toNumber: () => 0.5 },
-        memoryLimit: 20,
-      });
-
-      const response = await request(app)
-        .put('/admin/llm-config/text-cfg?kind=vision')
-        .send({ model: 'openai/gpt-4o-mini' });
-
-      expect(response.status).toBe(404);
-      expect(prisma.llmConfig.update).not.toHaveBeenCalled();
     });
 
     it('should accept memory settings in update (parity fix)', async () => {
@@ -975,10 +857,9 @@ describe('Admin LLM Config Routes', () => {
       expect(response.body.message).toMatch(/only global/i);
     });
 
-    it('writes the global vision-slot pointer when ?kind=vision and the model is vision-capable', async () => {
-      // The config's own kind is irrelevant now — any vision-capable config can fill
-      // the vision slot. The pointer write targets globalDefaultVisionConfigId, leaving
-      // the chat slot untouched.
+    it('writes the global vision-slot pointer when ?slot=vision and the model is vision-capable', async () => {
+      // Any vision-capable config can fill the vision slot. The pointer write
+      // targets globalDefaultVisionConfigId, leaving the chat slot untouched.
       prisma.llmConfig.findUnique.mockResolvedValue({
         id: 'vision-default',
         name: 'vision-default',
@@ -987,7 +868,7 @@ describe('Admin LLM Config Routes', () => {
       });
 
       const response = await request(buildAppWithVisionCache()).put(
-        '/admin/llm-config/vision-default/set-default?kind=vision'
+        '/admin/llm-config/vision-default/set-default?slot=vision'
       );
 
       expect(response.status).toBe(200);
@@ -997,7 +878,7 @@ describe('Admin LLM Config Routes', () => {
       );
     });
 
-    it('rejects ?kind=vision when the model is not vision-capable', async () => {
+    it('rejects ?slot=vision when the model is not vision-capable', async () => {
       prisma.llmConfig.findUnique.mockResolvedValue({
         id: 'text-only',
         name: 'text-only',
@@ -1006,14 +887,14 @@ describe('Admin LLM Config Routes', () => {
       });
 
       const response = await request(buildAppWithVisionCache()).put(
-        '/admin/llm-config/text-only/set-default?kind=vision'
+        '/admin/llm-config/text-only/set-default?slot=vision'
       );
 
       expect(response.status).toBe(400);
       expect(prisma.adminSettings.upsert).not.toHaveBeenCalled();
     });
 
-    it('rejects ?kind=vision when the model is unknown to the catalog (fail closed)', async () => {
+    it('rejects ?slot=vision when the model is unknown to the catalog (fail closed)', async () => {
       prisma.llmConfig.findUnique.mockResolvedValue({
         id: 'mystery',
         name: 'Mystery',
@@ -1022,7 +903,7 @@ describe('Admin LLM Config Routes', () => {
       });
 
       const response = await request(buildAppWithVisionCache()).put(
-        '/admin/llm-config/mystery/set-default?kind=vision'
+        '/admin/llm-config/mystery/set-default?slot=vision'
       );
 
       expect(response.status).toBe(400);
@@ -1051,7 +932,7 @@ describe('Admin LLM Config Routes', () => {
       );
     });
 
-    it('writes the free vision-slot pointer when ?kind=vision and the model is a free vision model', async () => {
+    it('writes the free vision-slot pointer when ?slot=vision and the model is a free vision model', async () => {
       prisma.llmConfig.findUnique.mockResolvedValue({
         id: 'vision-free',
         name: 'Vision Free',
@@ -1061,7 +942,7 @@ describe('Admin LLM Config Routes', () => {
       });
 
       const response = await request(buildAppWithVisionCache()).put(
-        '/admin/llm-config/vision-free/set-free-default?kind=vision'
+        '/admin/llm-config/vision-free/set-free-default?slot=vision'
       );
 
       expect(response.status).toBe(200);
@@ -1070,7 +951,7 @@ describe('Admin LLM Config Routes', () => {
       );
     });
 
-    it('rejects ?kind=vision when the free model is not vision-capable', async () => {
+    it('rejects ?slot=vision when the free model is not vision-capable', async () => {
       // Passes the :free check but fails the vision capability gate.
       prisma.llmConfig.findUnique.mockResolvedValue({
         id: 'glm-free',
@@ -1080,7 +961,7 @@ describe('Admin LLM Config Routes', () => {
       });
 
       const response = await request(buildAppWithVisionCache()).put(
-        '/admin/llm-config/glm-free/set-free-default?kind=vision'
+        '/admin/llm-config/glm-free/set-free-default?slot=vision'
       );
 
       expect(response.status).toBe(400);
@@ -1349,43 +1230,6 @@ describe('Admin LLM Config Routes', () => {
       expect(prisma.llmConfig.update).not.toHaveBeenCalled();
     });
 
-    it('scopes the rename collision check to the config kind (vision rename ignores a same-named text config)', async () => {
-      // The vision config being renamed.
-      prisma.llmConfig.findUnique.mockResolvedValue({
-        id: 'vision-id',
-        name: 'Old Vision',
-        isGlobal: true,
-        kind: 'vision',
-        memoryScoreThreshold: { toNumber: () => 0.5 },
-        memoryLimit: 20,
-      });
-      // A config named "Foo" exists ONLY in the text namespace. The collision
-      // check must query kind=vision (finds nothing) — before the fix it queried
-      // the text namespace and falsely blocked the rename.
-      prisma.llmConfig.findFirst.mockImplementation((args: { where?: { kind?: string } }) =>
-        Promise.resolve(args?.where?.kind === 'text' ? { id: 'text-foo' } : null)
-      );
-      prisma.llmConfig.update.mockResolvedValue({
-        id: 'vision-id',
-        name: 'Foo',
-        isGlobal: true,
-        kind: 'vision',
-        memoryScoreThreshold: { toNumber: () => 0.5 },
-        memoryLimit: 20,
-      });
-
-      const response = await request(app)
-        .put('/admin/llm-config/vision-id?kind=vision')
-        .send({ name: 'Foo' });
-
-      // Vision namespace has no "Foo" → rename allowed (not the false 400).
-      expect(response.status).toBe(200);
-      // The collision query was scoped to the vision namespace, not text.
-      expect(prisma.llmConfig.findFirst).toHaveBeenCalledWith(
-        expect.objectContaining({ where: expect.objectContaining({ kind: 'vision' }) })
-      );
-    });
-
     it('should allow keeping the same name (no duplicate check against self)', async () => {
       prisma.llmConfig.findUnique.mockResolvedValue({
         id: 'config-id',
@@ -1418,7 +1262,6 @@ describe('Admin LLM Config Routes', () => {
       expect(prisma.llmConfig.findFirst).toHaveBeenCalledWith({
         where: {
           isGlobal: true,
-          kind: 'text',
           name: 'Same Name',
           id: { not: 'config-id' },
         },
@@ -1495,7 +1338,6 @@ describe('Admin LLM Config Routes', () => {
         id: 'config-id',
         name: 'Free Config',
         isGlobal: true,
-        kind: 'text',
         model: 'meta-llama/llama-3.3-70b-instruct:free',
         provider: 'openrouter',
         memoryScoreThreshold: { toNumber: () => 0.5 },

--- a/services/api-gateway/src/routes/admin/llm-config.ts
+++ b/services/api-gateway/src/routes/admin/llm-config.ts
@@ -38,8 +38,7 @@ import {
 } from '../../utils/llmConfigValidation.js';
 import {
   parseBodyOrSendError,
-  parseConfigKindQuery,
-  parseConfigKindQueryAllowAll,
+  parseModelSlotQuery,
   findGlobalConfigOrSendError,
   findAdminUserOrSendError,
   ensureNoNameCollision,
@@ -60,26 +59,17 @@ const CONFIG_LABEL = 'configs';
 function createListHandler(service: LlmConfigService, modelCache?: OpenRouterModelCache) {
   // Stateless wrapper over the cache ref — built once per handler, not per request.
   const capabilities = new ModelCapabilityService(modelCache);
-  return async (req: Request, res: Response) => {
-    // AllowAll so the owner picker can fetch both slots in one call (capability-
-    // agnostic, mirroring the user list route); `service.list` handles the `all`
-    // sentinel. Sets (set-default / set-free-default) stay strict — you target a
-    // single slot, never `all`.
-    const kind = parseConfigKindQueryAllowAll(res, req.query);
-    if (kind === null) {
-      return;
-    }
-
+  return async (_req: Request, res: Response) => {
     const configs = await Promise.all(
-      (await service.list({ type: 'GLOBAL' }, kind)).map(async raw => ({
+      (await service.list({ type: 'GLOBAL' })).map(async raw => ({
         ...withAdminOwnership(service.formatConfigSummary(raw)),
-        // Capability-driven vision eligibility, sourced live from the model
-        // (not the config's `kind`). Cheap: a cached array lookup per row.
+        // Capability-driven vision eligibility, sourced live from the model.
+        // Cheap: a cached array lookup per row.
         supportsVision: await capabilities.supportsVision(raw.model),
       }))
     );
 
-    logger.info({ count: configs.length, kind }, 'Listed all configs');
+    logger.info({ count: configs.length }, 'Listed all configs');
     sendCustomSuccess(res, { configs }, StatusCodes.OK);
   };
 }
@@ -88,9 +78,6 @@ function createGetHandler(service: LlmConfigService, modelCache?: OpenRouterMode
   return async (req: Request, res: Response) => {
     const configId = getRequiredParam(req.params.id, 'id');
 
-    // Kind-agnostic by id: a config's kind is intrinsic to its unique id, so a
-    // by-id fetch returns it regardless of kind (no `?kind=` gate). Only the
-    // list endpoint scopes by kind (no id, so the caller states which kind).
     const config = await service.getById(configId);
     if (config === null) {
       return sendError(res, ErrorResponses.notFound(CONFIG_RESOURCE));
@@ -127,7 +114,6 @@ function createCreateConfigHandler(
         modelCache,
         body,
         hasZaiCodingKey: true,
-        kind: body.kind,
       }))
     ) {
       return;
@@ -142,7 +128,6 @@ function createCreateConfigHandler(
       !(await ensureNoNameCollision(res, service, {
         name: body.name,
         scope: { type: 'GLOBAL' },
-        kind: body.kind,
         formatCollisionMessage: n => `A global config named "${n}" already exists`,
       }))
     ) {
@@ -166,33 +151,24 @@ function createEditConfigHandler(
   return async (req: Request, res: Response) => {
     const configId = getRequiredParam(req.params.id, 'id');
 
-    const kind = parseConfigKindQuery(res, req.query);
-    if (kind === null) {
-      return;
-    }
-
     const body = parseBodyOrSendError(res, LlmConfigUpdateSchema, req.body);
     if (body === null) {
       return;
     }
 
-    // Fetch + kind-verify the row FIRST, so the model/vision validation below
-    // runs against the row's real (requireKind-verified) kind rather than the
-    // caller-supplied query param. Otherwise `?kind=vision` on a text config
-    // would fire a misleading vision-capability 400 (and leak that the id exists)
-    // before requireKind rejects the kind mismatch.
+    // Fetch the row first: the isGlobal guard must reject before any
+    // model/collision work leaks whether the id exists.
     const existing = await findGlobalConfigOrSendError(
       res,
       () =>
         prisma.llmConfig.findUnique({
           where: { id: configId },
-          select: { id: true, name: true, isGlobal: true, kind: true },
+          select: { id: true, name: true, isGlobal: true },
         }),
       {
         notFoundResource: CONFIG_RESOURCE,
         resourceLabel: CONFIG_LABEL,
         operation: 'edit',
-        requireKind: kind,
       }
     );
     if (existing === null) {
@@ -206,9 +182,6 @@ function createEditConfigHandler(
         body,
         fallback: { service, configId: configId },
         hasZaiCodingKey: true,
-        // `kind` is verified against the row by requireKind above, so the
-        // vision-capability gate trusts it without a redundant getById fetch.
-        kind,
       }))
     ) {
       return;
@@ -220,12 +193,6 @@ function createEditConfigHandler(
         name: body.name,
         scope: { type: 'GLOBAL' },
         excludeId: configId,
-        // Scope the collision check to the config's kind — global names are unique
-        // per (kind, name) (`llm_configs_global_name_unique`), so a vision rename
-        // must check the vision namespace, not text. Without this the helper
-        // defaults to text → false block across namespaces, or false pass → a
-        // Postgres unique-constraint 500.
-        kind,
         formatCollisionMessage: n => `A global config named "${n}" already exists`,
       }))
     ) {
@@ -256,10 +223,9 @@ function createSetDefaultHandler(
   return async (req: Request, res: Response) => {
     const configId = getRequiredParam(req.params.id, 'id');
 
-    // The slot the config fills (chat vs vision) is the request's choice, not the
-    // config's kind — any global config can fill any slot, so there's no kind-match
-    // gate. The vision slot is capability-gated below instead.
-    const slot = parseConfigKindQuery(res, req.query);
+    // The slot the config fills (chat vs vision) is the request's choice — any
+    // global config can fill any slot. The vision slot is capability-gated below.
+    const slot = parseModelSlotQuery(res, req.query);
     if (slot === null) {
       return;
     }
@@ -301,9 +267,8 @@ function createSetFreeDefaultHandler(
   return async (req: Request, res: Response) => {
     const configId = getRequiredParam(req.params.id, 'id');
 
-    // Slot = request's choice (chat vs vision); no kind-match gate. Vision is
-    // capability-gated below.
-    const slot = parseConfigKindQuery(res, req.query);
+    // Slot = request's choice (chat vs vision). Vision is capability-gated below.
+    const slot = parseModelSlotQuery(res, req.query);
     if (slot === null) {
       return;
     }

--- a/services/api-gateway/src/routes/user/llm-config.test.ts
+++ b/services/api-gateway/src/routes/user/llm-config.test.ts
@@ -330,40 +330,6 @@ describe('/user/llm-config routes', () => {
       );
     });
 
-    it('scopes the list query to ?kind=vision', async () => {
-      mockPrisma.llmConfig.findMany.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
-
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'get', '/');
-      const { req, res } = createMockReqRes({}, {}, { kind: 'vision' });
-
-      await handler(req, res);
-
-      expect(res.status).toHaveBeenCalledWith(200);
-      // User scope fires TWO queries (global + own). Assert BOTH carry the kind
-      // — `toHaveBeenCalledWith` alone would pass if only one did.
-      expect(mockPrisma.llmConfig.findMany).toHaveBeenCalledTimes(2);
-      expect(mockPrisma.llmConfig.findMany).toHaveBeenNthCalledWith(
-        1,
-        expect.objectContaining({ where: expect.objectContaining({ kind: 'vision' }) })
-      );
-      expect(mockPrisma.llmConfig.findMany).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({ where: expect.objectContaining({ kind: 'vision' }) })
-      );
-    });
-
-    it('rejects an invalid ?kind= with 400', async () => {
-      const router = createLlmConfigRoutes(mockDeps);
-      const handler = getHandler(router, 'get', '/');
-      const { req, res } = createMockReqRes({}, {}, { kind: 'audio' });
-
-      await handler(req, res);
-
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(mockPrisma.llmConfig.findMany).not.toHaveBeenCalled();
-    });
-
     it('enriches each list row with supportsVision from the model capabilities', async () => {
       const visionConfig = {
         id: 'vc-1',
@@ -371,7 +337,6 @@ describe('/user/llm-config routes', () => {
         description: null,
         model: 'openai/gpt-4o',
         provider: 'openrouter',
-        kind: 'text',
         isGlobal: true,
         isDefault: false,
         isFreeDefault: false,
@@ -383,7 +348,6 @@ describe('/user/llm-config routes', () => {
         description: null,
         model: 'z-ai/glm-4.7', // not on OpenRouter → z.ai catalog (text-only)
         provider: 'openrouter',
-        kind: 'text',
         isGlobal: true,
         isDefault: false,
         isFreeDefault: false,
@@ -1112,49 +1076,6 @@ describe('/user/llm-config routes', () => {
             params: { temperature: 0.9 },
           }),
         })
-      );
-    });
-
-    it('scopes the rename collision check to the config kind (vision)', async () => {
-      // Renaming a vision config to a name that only exists as a TEXT config must
-      // NOT collide — the collision check derives kind from the immutable row.
-      mockPrisma.llmConfig.findUnique.mockResolvedValue({
-        id: 'vision-cfg',
-        ownerId: 'user-uuid-123',
-        isGlobal: false,
-        name: 'Old Vision',
-        kind: 'vision',
-        memoryScoreThreshold: { toNumber: () => 0.5 },
-        memoryLimit: 20,
-      });
-      // No collision in the VISION namespace.
-      mockPrisma.llmConfig.findFirst.mockResolvedValue(null);
-      mockPrisma.llmConfig.update.mockResolvedValue({
-        id: 'vision-cfg',
-        name: 'Shared Name',
-        model: 'qwen/qwen3-vl-30b-a3b-instruct',
-        provider: 'openrouter',
-        isGlobal: false,
-        isDefault: false,
-        isFreeDefault: false,
-        ownerId: 'user-uuid-123',
-        memoryScoreThreshold: { toNumber: () => 0.5 },
-        memoryLimit: 20,
-      });
-
-      const router = createLlmConfigRoutes({
-        ...mockDeps,
-        llmConfigCacheInvalidation: mockCacheInvalidation,
-      });
-      const handler = getHandler(router, 'put', '/:id');
-      const { req, res } = createMockReqRes({ name: 'Shared Name' }, { id: 'vision-cfg' });
-
-      await handler(req, res);
-
-      expect(res.status).toHaveBeenCalledWith(200);
-      // The collision query must be scoped to kind='vision', not text.
-      expect(mockPrisma.llmConfig.findFirst).toHaveBeenCalledWith(
-        expect.objectContaining({ where: expect.objectContaining({ kind: 'vision' }) })
       );
     });
 

--- a/services/api-gateway/src/routes/user/llm-config.ts
+++ b/services/api-gateway/src/routes/user/llm-config.ts
@@ -18,7 +18,6 @@ import {
   LlmConfigCreateSchema,
   LlmConfigUpdateSchema,
 } from '@tzurot/common-types/schemas/api/llm-config';
-import { toConfigKind } from '@tzurot/common-types/services/LlmConfigMapper';
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import { isBotOwner } from '@tzurot/common-types/utils/ownerMiddleware';
@@ -32,7 +31,6 @@ import { isPrismaUniqueConstraintError } from '../../utils/prismaErrors.js';
 import { getRequiredParam } from '../../utils/requestParams.js';
 import {
   parseBodyOrSendError,
-  parseConfigKindQueryAllowAll,
   findConfigOrSendNotFound,
   ensureNoNameCollision,
 } from '../../utils/configRouteHelpers.js';
@@ -74,20 +72,14 @@ function createListHandler(service: LlmConfigService, modelCache?: OpenRouterMod
     const discordUserId = req.userId;
     const userId = resolveProvisionedUserId(req);
 
-    // Admin sees all presets (same pattern as character browse)
-    // Regular users see global + their own. Browse passes `?kind=all` to list
-    // both kinds in one call; autocomplete passes an explicit text|vision.
-    const kind = parseConfigKindQueryAllowAll(res, req.query);
-    if (kind === null) {
-      return;
-    }
-
+    // Admin sees all presets (same pattern as character browse);
+    // regular users see global + their own.
     const isAdmin = isBotOwner(discordUserId);
     const scope: LlmConfigScope = isAdmin
       ? { type: 'GLOBAL' }
       : { type: 'USER', userId, discordId: discordUserId };
 
-    const rawConfigs = await service.list(scope, kind);
+    const rawConfigs = await service.list(scope);
 
     // Enrich with ownership and permissions (user-specific). `formatConfigSummary`
     // projects only public fields — `c.ownerId` is read here for the ownership
@@ -97,8 +89,8 @@ function createListHandler(service: LlmConfigService, modelCache?: OpenRouterMod
       rawConfigs.map(async c => ({
         ...service.formatConfigSummary(c),
         isOwned: c.ownerId === userId,
-        // Capability-driven vision eligibility, sourced live from the model
-        // (not the config's `kind`). Cheap: a cached array lookup per row.
+        // Capability-driven vision eligibility, sourced live from the model.
+        // Cheap: a cached array lookup per row.
         supportsVision: await capabilities.supportsVision(c.model),
         permissions: computeLlmConfigPermissions(
           { ownerId: c.ownerId, isGlobal: c.isGlobal },
@@ -187,7 +179,6 @@ function createCreateHandler(
         modelCache,
         body,
         hasZaiCodingKey,
-        kind: body.kind,
       }))
     ) {
       return;
@@ -202,7 +193,6 @@ function createCreateHandler(
       !(await ensureNoNameCollision(res, service, {
         name: body.name,
         scope: { type: 'USER', userId, discordId: discordUserId },
-        kind: body.kind,
         formatCollisionMessage: n => `You already have a config named "${n}"`,
       }))
     ) {
@@ -285,11 +275,7 @@ async function buildUpdatePatchOrSendCollision<
   service: LlmConfigService;
   req: ProvisionedRequest;
   body: TBody;
-  /** Includes `kind` (the immutable discriminator) so the name-collision check
-   *  is scoped to the config's kind — a vision rename collides only against
-   *  vision names, never text. Derived from the row, not the request: kind is
-   *  intrinsic to the config and can't be changed by an update. */
-  config: { name: string; isGlobal: boolean; ownerId: string; kind: string };
+  config: { name: string; isGlobal: boolean; ownerId: string };
   configId: string;
   isOwnedByRequester: boolean;
 }): Promise<TBody | null> {
@@ -317,7 +303,6 @@ async function buildUpdatePatchOrSendCollision<
       scope: { type: 'USER', userId: config.ownerId, discordId: discordUserId },
       excludeId: configId,
       postIsGlobal,
-      kind: toConfigKind(config.kind),
       formatCollisionMessage: n =>
         buildCollisionMessage({
           effectiveName: n,
@@ -363,10 +348,6 @@ function createUpdateHandler(
       return;
     }
 
-    // User by-id routes are kind-agnostic: the id unambiguously identifies the
-    // config of whatever kind, and kind is immutable. A `?kind=` query param
-    // here is intentionally ignored — the collision check below derives kind
-    // from the stored row, not the request.
     const config = await findConfigOrSendNotFound(
       res,
       () => service.getById(configId),

--- a/services/api-gateway/src/routes/user/model-override.test.ts
+++ b/services/api-gateway/src/routes/user/model-override.test.ts
@@ -200,7 +200,7 @@ describe('/user/model-override routes', () => {
               personalityName: 'Lilith',
               configId: '22222222-2222-4222-a222-222222222222',
               configName: 'GPT-4 Config',
-              kind: 'text',
+              slot: 'text',
               supportsVision: false,
             },
           ],
@@ -402,14 +402,14 @@ describe('/user/model-override routes', () => {
             personalityName: 'Lilith',
             configId: '22222222-2222-4222-a222-222222222222',
             configName: 'GPT-4',
-            kind: 'text',
+            slot: 'text',
             supportsVision: false,
           },
         })
       );
     });
 
-    it('writes the vision slot when ?kind=vision and the model is vision-capable', async () => {
+    it('writes the vision slot when ?slot=vision and the model is vision-capable', async () => {
       mockPrisma.personality.findFirst.mockResolvedValue({
         id: '11111111-1111-4111-a111-111111111111',
         name: 'Lilith',
@@ -443,7 +443,7 @@ describe('/user/model-override routes', () => {
           configId: '22222222-2222-4222-a222-222222222222',
         },
         {},
-        { kind: 'vision' }
+        { slot: 'vision' }
       );
 
       await handler(req, res);
@@ -459,11 +459,11 @@ describe('/user/model-override routes', () => {
       );
       expect(res.status).toHaveBeenCalledWith(200);
       // supportsVision: true proves the enrichment reads the vision slot's model
-      // (openai/gpt-4o) capability via modelCache — not the kind label — and that
+      // (openai/gpt-4o) capability via modelCache — not the slot label — and that
       // the isVision→visionConfig.model branch is wired correctly.
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
-          override: expect.objectContaining({ kind: 'vision', supportsVision: true }),
+          override: expect.objectContaining({ slot: 'vision', supportsVision: true }),
         })
       );
     });
@@ -496,7 +496,7 @@ describe('/user/model-override routes', () => {
           configId: '22222222-2222-4222-a222-222222222222',
         },
         {},
-        { kind: 'vision' }
+        { slot: 'vision' }
       );
 
       await handler(req, res);
@@ -537,7 +537,7 @@ describe('/user/model-override routes', () => {
           configId: '22222222-2222-4222-a222-222222222222',
         },
         {},
-        { kind: 'vision' }
+        { slot: 'vision' }
       );
 
       await handler(req, res);
@@ -742,7 +742,7 @@ describe('/user/model-override routes', () => {
       );
     });
 
-    it('writes the vision default when ?kind=vision and the model is vision-capable', async () => {
+    it('writes the vision default when ?slot=vision and the model is vision-capable', async () => {
       mockPrisma.llmConfig.findFirst.mockResolvedValue({
         id: '22222222-2222-4222-a222-222222222222',
         name: 'GPT-4o',
@@ -763,7 +763,7 @@ describe('/user/model-override routes', () => {
       const { req, res } = createMockReqRes(
         { configId: '22222222-2222-4222-a222-222222222222' },
         {},
-        { kind: 'vision' }
+        { slot: 'vision' }
       );
 
       await handler(req, res);
@@ -796,7 +796,7 @@ describe('/user/model-override routes', () => {
       const { req, res } = createMockReqRes(
         { configId: '22222222-2222-4222-a222-222222222222' },
         {},
-        { kind: 'vision' }
+        { slot: 'vision' }
       );
 
       await handler(req, res);
@@ -829,7 +829,7 @@ describe('/user/model-override routes', () => {
       const { req, res } = createMockReqRes(
         { configId: '22222222-2222-4222-a222-222222222222' },
         {},
-        { kind: 'vision' }
+        { slot: 'vision' }
       );
 
       await handler(req, res);
@@ -937,7 +937,7 @@ describe('/user/model-override routes', () => {
         expect.objectContaining({
           deleted: true,
           wasSet: false,
-          // No slot arg → kind defaults to text; no admin free default mocked → null.
+          // No slot arg → slot defaults to text; no admin free default mocked → null.
           newEffectiveDefaults: { text: null },
         })
       );
@@ -1106,17 +1106,17 @@ describe('/user/model-override routes', () => {
     });
   });
 
-  describe('vision kind branching', () => {
+  describe('vision slot branching', () => {
     const VISION_CFG = '33333333-3333-4333-a333-333333333333';
     const PERSONALITY = '11111111-1111-4111-a111-111111111111';
 
-    // NOTE: the PUT-set paths (vision slot via `?kind=vision` + capability gate)
+    // NOTE: the PUT-set paths (vision slot via `?slot=vision` + capability gate)
     // are covered above in the `PUT /user/model-override` and `PUT /default`
-    // describe blocks. The slot is now chosen by the request, not derived from
-    // `config.kind`, so those write tests live with the rest of the set-handler
-    // coverage. The read/clear `?kind=` scoping below is what this block exercises.
+    // describe blocks. The slot is chosen by the request, so those write tests
+    // live with the rest of the set-handler coverage. The read/clear `?slot=`
+    // scoping below is what this block exercises.
 
-    it('GET /default?kind=vision returns the vision default (text default ignored)', async () => {
+    it('GET /default?slot=vision returns the vision default (text default ignored)', async () => {
       mockPrisma.user.findUnique.mockResolvedValue({
         defaultLlmConfigId: 'text-cfg',
         defaultLlmConfig: { name: 'Text' },
@@ -1126,7 +1126,7 @@ describe('/user/model-override routes', () => {
 
       const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/default');
-      const { req, res } = createMockReqRes({}, {}, { kind: 'vision' });
+      const { req, res } = createMockReqRes({}, {}, { slot: 'vision' });
 
       await handler(req, res);
 
@@ -1137,7 +1137,7 @@ describe('/user/model-override routes', () => {
       );
     });
 
-    it('DELETE /default?kind=vision clears only the vision default + scopes the free fallback', async () => {
+    it('DELETE /default?slot=vision clears only the vision default + scopes the free fallback', async () => {
       mockPrisma.user.findUnique.mockResolvedValue({
         defaultLlmConfigId: 'text-cfg',
         defaultVisionConfigId: VISION_CFG,
@@ -1150,7 +1150,7 @@ describe('/user/model-override routes', () => {
 
       const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/default');
-      const { req, res } = createMockReqRes({}, {}, { kind: 'vision' });
+      const { req, res } = createMockReqRes({}, {}, { slot: 'vision' });
 
       await handler(req, res);
 
@@ -1161,7 +1161,7 @@ describe('/user/model-override routes', () => {
         where: { id: 'user-uuid-123' },
         data: { defaultVisionConfigId: null },
       });
-      // The fallback resolves the VISION free-default POINTER (cleared kind=vision).
+      // The fallback resolves the VISION free-default POINTER (cleared slot=vision).
       // Exactly once — the text slot is NOT resolved (the "clears only vision" contract).
       expect(mockPrisma.llmConfig.findUnique).toHaveBeenCalledTimes(1);
       expect(mockPrisma.llmConfig.findUnique).toHaveBeenCalledWith({
@@ -1177,7 +1177,7 @@ describe('/user/model-override routes', () => {
       );
     });
 
-    it('GET /?kind=vision lists vision overrides', async () => {
+    it('GET /?slot=vision lists vision overrides', async () => {
       mockPrisma.userPersonalityConfig.findMany.mockResolvedValue([
         {
           personalityId: PERSONALITY,
@@ -1191,7 +1191,7 @@ describe('/user/model-override routes', () => {
 
       const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/');
-      const { req, res } = createMockReqRes({}, {}, { kind: 'vision' });
+      const { req, res } = createMockReqRes({}, {}, { slot: 'vision' });
 
       await handler(req, res);
 
@@ -1207,7 +1207,7 @@ describe('/user/model-override routes', () => {
       );
     });
 
-    it('GET /?kind=all emits one kind-tagged row per non-null FK (both on one personality)', async () => {
+    it('GET /?slot=all emits one slot-tagged row per non-null FK (both on one personality)', async () => {
       mockPrisma.userPersonalityConfig.findMany.mockResolvedValue([
         {
           personalityId: PERSONALITY,
@@ -1221,11 +1221,11 @@ describe('/user/model-override routes', () => {
 
       const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'get', '/');
-      const { req, res } = createMockReqRes({}, {}, { kind: 'all' });
+      const { req, res } = createMockReqRes({}, {}, { slot: 'all' });
 
       await handler(req, res);
 
-      // All-kinds query matches a row with EITHER FK set (not a single-kind filter).
+      // All-slots query matches a row with EITHER FK set (not a single-slot filter).
       expect(mockPrisma.userPersonalityConfig.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
@@ -1233,7 +1233,7 @@ describe('/user/model-override routes', () => {
           }),
         })
       );
-      // One personality with both FKs → two rows, each tagged with its kind.
+      // One personality with both FKs → two rows, each tagged with its slot.
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
           overrides: [
@@ -1242,7 +1242,7 @@ describe('/user/model-override routes', () => {
               personalityName: 'Lilith',
               configId: 'text-cfg',
               configName: 'Text Cfg',
-              kind: 'text',
+              slot: 'text',
               supportsVision: false,
             },
             {
@@ -1250,7 +1250,7 @@ describe('/user/model-override routes', () => {
               personalityName: 'Lilith',
               configId: VISION_CFG,
               configName: 'Vision Cfg',
-              kind: 'vision',
+              slot: 'vision',
               supportsVision: false,
             },
           ],
@@ -1258,7 +1258,7 @@ describe('/user/model-override routes', () => {
       );
     });
 
-    it('DELETE /:personalityId?kind=vision clears only the vision override', async () => {
+    it('DELETE /:personalityId?slot=vision clears only the vision override', async () => {
       mockPrisma.userPersonalityConfig.findFirst.mockResolvedValue({
         id: 'upc-1',
         llmConfigId: 'text-cfg',
@@ -1268,7 +1268,7 @@ describe('/user/model-override routes', () => {
 
       const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:personalityId');
-      const { req, res } = createMockReqRes({}, { personalityId: PERSONALITY }, { kind: 'vision' });
+      const { req, res } = createMockReqRes({}, { personalityId: PERSONALITY }, { slot: 'vision' });
 
       await handler(req, res);
 
@@ -1281,7 +1281,7 @@ describe('/user/model-override routes', () => {
       expect(res.status).toHaveBeenCalledWith(200);
     });
 
-    it('DELETE /default?kind=all clears BOTH defaults in one update', async () => {
+    it('DELETE /default?slot=all clears BOTH defaults in one update', async () => {
       mockPrisma.user.findUnique.mockResolvedValue({
         defaultLlmConfigId: 'text-cfg',
         defaultVisionConfigId: VISION_CFG,
@@ -1298,7 +1298,7 @@ describe('/user/model-override routes', () => {
 
       const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/default');
-      const { req, res } = createMockReqRes({}, {}, { kind: 'all' });
+      const { req, res } = createMockReqRes({}, {}, { slot: 'all' });
 
       await handler(req, res);
 
@@ -1320,7 +1320,7 @@ describe('/user/model-override routes', () => {
       expect(res.status).toHaveBeenCalledWith(200);
     });
 
-    it('DELETE /:personalityId?kind=all clears BOTH override slots in one update', async () => {
+    it('DELETE /:personalityId?slot=all clears BOTH override slots in one update', async () => {
       mockPrisma.userPersonalityConfig.findFirst.mockResolvedValue({
         id: 'upc-1',
         llmConfigId: 'text-cfg',
@@ -1330,7 +1330,7 @@ describe('/user/model-override routes', () => {
 
       const router = createModelOverrideRoutes({ prisma: mockPrisma as unknown as PrismaClient });
       const handler = getHandler(router, 'delete', '/:personalityId');
-      const { req, res } = createMockReqRes({}, { personalityId: PERSONALITY }, { kind: 'all' });
+      const { req, res } = createMockReqRes({}, { personalityId: PERSONALITY }, { slot: 'all' });
 
       await handler(req, res);
 

--- a/services/api-gateway/src/routes/user/model-override.ts
+++ b/services/api-gateway/src/routes/user/model-override.ts
@@ -26,8 +26,8 @@ import { createLogger } from '@tzurot/common-types/utils/logger';
 import { requireUserAuth, requireProvisionedUser } from '../../services/AuthMiddleware.js';
 import { asyncHandler } from '../../utils/asyncHandler.js';
 import {
-  parseConfigKindQuery,
-  parseConfigKindQueryAllowAll,
+  parseModelSlotQuery,
+  parseModelSlotQueryAllowAll,
 } from '../../utils/configRouteHelpers.js';
 import { ensureVisionCapableModel } from '../../utils/llmConfigValidation.js';
 import { ModelCapabilityService } from '../../services/ModelCapabilityService.js';
@@ -46,7 +46,7 @@ const logger = createLogger('user-model-override');
  * Verify that the given LLM config exists and the user can access it (global or owned).
  * Returns the config (incl. its `model`) if accessible, null otherwise. The slot a
  * config occupies (chat vs vision) is the caller's request, NOT a property of the
- * config — so the set handlers pick the FK column from `?kind=`. `model` is returned
+ * config — so the set handlers pick the FK column from `?slot=`. `model` is returned
  * so the vision slot can be capability-gated (the model must support image input).
  */
 async function verifyConfigAccess(
@@ -71,21 +71,21 @@ export const handleListModelOverrides = (deps: RouteDeps): RequestHandler => {
     const discordUserId = req.userId;
     const userId = resolveProvisionedUserId(req);
 
-    // Browse passes `?kind=all` to list BOTH kinds in one call (one summary row
+    // Browse passes `?slot=all` to list BOTH slots in one call (one summary row
     // per non-null FK); the dashboard passes an explicit text|vision.
-    const kind = parseConfigKindQueryAllowAll(res, req.query);
-    if (kind === null) {
+    const slot = parseModelSlotQueryAllowAll(res, req.query);
+    if (slot === null) {
       return;
     }
-    const allKinds = kind === 'all';
-    const isVision = kind === 'vision';
+    const allSlots = slot === 'all';
+    const isVision = slot === 'vision';
 
     // Select BOTH FK pairs (fixed shape — a conditional select would yield a
-    // union return type), then emit the matching kind(s) below.
+    // union return type), then emit the matching slot(s) below.
     const overrides = await prisma.userPersonalityConfig.findMany({
       where: {
         userId,
-        ...(allKinds
+        ...(allSlots
           ? { OR: [{ llmConfigId: { not: null } }, { visionConfigId: { not: null } }] }
           : isVision
             ? { visionConfigId: { not: null } }
@@ -100,16 +100,16 @@ export const handleListModelOverrides = (deps: RouteDeps): RequestHandler => {
         visionConfigId: true,
         visionConfig: { select: { name: true, model: true } },
       },
-      // Bounds personality CONFIG rows, not output rows: for `kind=all` a
+      // Bounds personality CONFIG rows, not output rows: for `slot=all` a
       // personality with both FKs expands to two summaries below, so the
       // response can be up to 2× this (≤200). Fine for the browse page size.
       take: 100,
     });
 
     // A character can have BOTH a text and a vision override; for `all`, emit a
-    // row per non-null FK (kind-tagged) so browse can badge + clear each.
-    const emitText = allKinds || !isVision; // kind === 'text' or kind === 'all'
-    const emitVision = allKinds || isVision; // kind === 'vision' or kind === 'all'
+    // row per non-null FK (slot-tagged) so browse can badge + clear each.
+    const emitText = allSlots || !isVision; // slot === 'text' or slot === 'all'
+    const emitVision = allSlots || isVision; // slot === 'vision' or slot === 'all'
     const result: ModelOverrideSummary[] = [];
     for (const o of overrides) {
       if (emitText && o.llmConfigId !== null) {
@@ -118,7 +118,7 @@ export const handleListModelOverrides = (deps: RouteDeps): RequestHandler => {
           personalityName: o.personality.name,
           configId: o.llmConfigId,
           configName: o.llmConfig?.name ?? null,
-          kind: 'text',
+          slot: 'text',
           supportsVision: await capabilities.supportsVision(o.llmConfig?.model ?? ''),
         });
       }
@@ -128,13 +128,13 @@ export const handleListModelOverrides = (deps: RouteDeps): RequestHandler => {
           personalityName: o.personality.name,
           configId: o.visionConfigId,
           configName: o.visionConfig?.name ?? null,
-          kind: 'vision',
+          slot: 'vision',
           supportsVision: await capabilities.supportsVision(o.visionConfig?.model ?? ''),
         });
       }
     }
 
-    logger.info({ discordUserId, count: result.length, kind }, 'Listed overrides');
+    logger.info({ discordUserId, count: result.length, slot }, 'Listed overrides');
     sendCustomSuccess(res, { overrides: result }, StatusCodes.OK);
   });
 };
@@ -147,9 +147,9 @@ export const handleSetModelOverride = (deps: RouteDeps): RequestHandler => {
     const discordUserId = req.userId;
 
     // The slot (chat vs vision) is the request's choice, not a config property;
-    // `?kind=` defaults to text. The vision slot is capability-gated below.
-    const kind = parseConfigKindQuery(res, req.query);
-    if (kind === null) {
+    // `?slot=` defaults to text. The vision slot is capability-gated below.
+    const slot = parseModelSlotQuery(res, req.query);
+    if (slot === null) {
       return;
     }
 
@@ -181,7 +181,7 @@ export const handleSetModelOverride = (deps: RouteDeps): RequestHandler => {
     // confirmed vision-capable (unknown/unresolvable capability → 400, fail
     // closed). With no model cache wired (local dev) an OpenRouter-only model
     // can't be resolved and 400s here; prod always has the cache.
-    const isVision = kind === 'vision';
+    const isVision = slot === 'vision';
     if (isVision && !(await ensureVisionCapableModel(res, modelCache, llmConfig.model))) {
       return;
     }
@@ -219,7 +219,7 @@ export const handleSetModelOverride = (deps: RouteDeps): RequestHandler => {
       configName: isVision
         ? (override.visionConfig?.name ?? null)
         : (override.llmConfig?.name ?? null),
-      kind: isVision ? 'vision' : 'text',
+      slot: isVision ? 'vision' : 'text',
       // Re-resolves the vision slot's capability that ensureVisionCapableModel
       // already checked on the write-gate — harmless while resolution is a warm
       // in-memory cache hit; revisit if it ever grows a network round-trip.
@@ -235,7 +235,7 @@ export const handleSetModelOverride = (deps: RouteDeps): RequestHandler => {
         personalityName: personality.name,
         configId,
         configName: llmConfig.name,
-        kind: isVision ? 'vision' : 'text',
+        slot: isVision ? 'vision' : 'text',
       },
       'Set override'
     );
@@ -251,14 +251,14 @@ export const handleGetDefaultModelConfig = (deps: RouteDeps): RequestHandler => 
     const discordUserId = req.userId;
     const userId = resolveProvisionedUserId(req);
 
-    const kind = parseConfigKindQuery(res, req.query);
-    if (kind === null) {
+    const slot = parseModelSlotQuery(res, req.query);
+    if (slot === null) {
       return;
     }
-    const isVision = kind === 'vision';
+    const isVision = slot === 'vision';
 
     // Select both FK pairs (fixed shape — a conditional select would yield a
-    // union return type), then pick the requested kind.
+    // union return type), then pick the requested slot.
     const user = await prisma.user.findUnique({
       where: { id: userId },
       select: {
@@ -279,7 +279,7 @@ export const handleGetDefaultModelConfig = (deps: RouteDeps): RequestHandler => 
           configName: user?.defaultLlmConfig?.name ?? null,
         };
 
-    logger.info({ discordUserId, configId: result.configId, kind }, 'Got default config');
+    logger.info({ discordUserId, configId: result.configId, slot }, 'Got default config');
     sendCustomSuccess(res, { default: result }, StatusCodes.OK);
   });
 };
@@ -291,9 +291,9 @@ export const handleSetDefaultModelConfig = (deps: RouteDeps): RequestHandler => 
     const discordUserId = req.userId;
 
     // The slot (chat vs vision) is the request's choice, not a config property;
-    // `?kind=` defaults to text. The vision slot is capability-gated below.
-    const kind = parseConfigKindQuery(res, req.query);
-    if (kind === null) {
+    // `?slot=` defaults to text. The vision slot is capability-gated below.
+    const slot = parseModelSlotQuery(res, req.query);
+    if (slot === null) {
       return;
     }
 
@@ -316,7 +316,7 @@ export const handleSetDefaultModelConfig = (deps: RouteDeps): RequestHandler => 
     // confirmed vision-capable (unknown/unresolvable capability → 400, fail
     // closed). With no model cache wired (local dev) an OpenRouter-only model
     // can't be resolved and 400s here; prod always has the cache.
-    const isVision = kind === 'vision';
+    const isVision = slot === 'vision';
     if (isVision && !(await ensureVisionCapableModel(res, modelCache, llmConfig.model))) {
       return;
     }
@@ -331,7 +331,7 @@ export const handleSetDefaultModelConfig = (deps: RouteDeps): RequestHandler => 
     };
 
     logger.info(
-      { discordUserId, configId, configName: llmConfig.name, kind: isVision ? 'vision' : 'text' },
+      { discordUserId, configId, configName: llmConfig.name, slot: isVision ? 'vision' : 'text' },
       'Set default config'
     );
 
@@ -356,12 +356,12 @@ export const handleClearDefaultModelConfig = (deps: RouteDeps): RequestHandler =
 
     // `all` (the bot-client default when no slot is chosen) clears BOTH slots;
     // an explicit text|vision clears just that one.
-    const kind = parseConfigKindQueryAllowAll(res, req.query);
-    if (kind === null) {
+    const slot = parseModelSlotQueryAllowAll(res, req.query);
+    if (slot === null) {
       return;
     }
-    const clearText = kind === 'text' || kind === 'all';
-    const clearVision = kind === 'vision' || kind === 'all';
+    const clearText = slot === 'text' || slot === 'all';
+    const clearVision = slot === 'vision' || slot === 'all';
 
     const user = await prisma.user.findUnique({
       where: { id: userId },
@@ -408,7 +408,7 @@ export const handleClearDefaultModelConfig = (deps: RouteDeps): RequestHandler =
 
     if (!wasSet) {
       logger.info(
-        { discordUserId, kind, hadDefault: false },
+        { discordUserId, slot, hadDefault: false },
         'Clear called but no default was set (idempotent success)'
       );
       return sendCustomSuccess(
@@ -426,7 +426,7 @@ export const handleClearDefaultModelConfig = (deps: RouteDeps): RequestHandler =
       },
     });
 
-    logger.info({ discordUserId, kind }, 'Cleared default config');
+    logger.info({ discordUserId, slot }, 'Cleared default config');
 
     await tryInvalidateCache(
       llmConfigCacheInvalidation?.invalidateUserLlmConfig.bind(
@@ -450,12 +450,12 @@ export const handleDeleteModelOverride = (deps: RouteDeps): RequestHandler => {
 
     // `all` (the bot-client default when no slot is chosen) clears BOTH slots;
     // an explicit text|vision clears just that one.
-    const kind = parseConfigKindQueryAllowAll(res, req.query);
-    if (kind === null) {
+    const slot = parseModelSlotQueryAllowAll(res, req.query);
+    if (slot === null) {
       return;
     }
-    const clearText = kind === 'text' || kind === 'all';
-    const clearVision = kind === 'vision' || kind === 'all';
+    const clearText = slot === 'text' || slot === 'all';
+    const clearVision = slot === 'vision' || slot === 'all';
 
     const override = await prisma.userPersonalityConfig.findFirst({
       where: {
@@ -477,7 +477,7 @@ export const handleDeleteModelOverride = (deps: RouteDeps): RequestHandler => {
 
     if (override === null || !wasSet) {
       logger.info(
-        { discordUserId, personalityId, kind, hadOverride: false },
+        { discordUserId, personalityId, slot, hadOverride: false },
         'Reset called but no override was set (idempotent success)'
       );
       return sendCustomSuccess(res, { deleted: true, wasSet: false }, StatusCodes.OK);
@@ -492,7 +492,7 @@ export const handleDeleteModelOverride = (deps: RouteDeps): RequestHandler => {
     });
 
     logger.info(
-      { discordUserId, personalityId, personalityName: override.personality.name, kind },
+      { discordUserId, personalityId, personalityName: override.personality.name, slot },
       'Removed override'
     );
 

--- a/services/api-gateway/src/services/LlmConfigService.component.test.ts
+++ b/services/api-gateway/src/services/LlmConfigService.component.test.ts
@@ -656,7 +656,6 @@ describe('LlmConfigService Integration', () => {
         description: 'Test description',
         model: 'test-model',
         provider: 'openrouter',
-        kind: 'text',
         isGlobal: true,
         // isDefault/isFreeDefault intentionally absent from the detail — see S4a.
         memoryScoreThreshold: 0.8,
@@ -888,15 +887,15 @@ describe('LlmConfigService Integration', () => {
     });
   });
 
-  describe('per-kind partial-unique constraints (DB-level, via PGLite)', () => {
-    // Guards the hand-written partial-unique indexes Prisma can't represent (harvested
-    // into the PGLite schema by generate-schema.ts): text and vision each get their OWN
-    // default / free-default / global-name namespace. This is the core "vision is a
-    // first-class, independently-defaulted config axis" guarantee — verified against the
-    // real Postgres engine (PGLite), since the unit tier mocks the DB and can't see it.
-    // Generic over the overrides so their keys (id, name, kind, …) survive in the
-    // return type — a non-generic `Record<string, unknown>` param would erase them and
-    // leave the merged object missing the required `id`/`name` at the type level.
+  describe('global-name partial-unique constraint (DB-level, via PGLite)', () => {
+    // Guards the hand-written partial-unique index Prisma can't represent (harvested
+    // into the PGLite schema by generate-schema.ts): `llm_configs_global_name_unique`
+    // is UNIQUE (name) WHERE is_global — ONE shared namespace for every global preset.
+    // Verified against the real Postgres engine (PGLite), since the unit tier mocks
+    // the DB and can't see it. Generic over the overrides so their keys (id, name, …)
+    // survive in the return type — a non-generic `Record<string, unknown>` param would
+    // erase them and leave the merged object missing the required `id`/`name` at the
+    // type level.
     const baseConfig = <T extends Record<string, unknown>>(overrides: T) => ({
       model: 'test/model',
       provider: 'openrouter',
@@ -907,41 +906,14 @@ describe('LlmConfigService Integration', () => {
       ...overrides,
     });
 
-    it('scopes the global-name unique by kind (same name, different kind coexist)', async () => {
-      // Different owners on purpose: the owner-scoped `owner_id+name` unique would fire
-      // first for same-owner rows. `llm_configs_global_name_unique` is what guards
-      // CROSS-owner global name clashes, and it's scoped by kind — so the same global
-      // name under different kinds must coexist.
-      await prisma.llmConfig.create({
-        data: baseConfig({
-          id: newLlmConfigId(),
-          name: 'shared-name',
-          kind: 'text',
-          isGlobal: true,
-          ownerId: adminUserId,
-        }),
-      });
-      await expect(
-        prisma.llmConfig.create({
-          data: baseConfig({
-            id: newLlmConfigId(),
-            name: 'shared-name',
-            kind: 'vision',
-            isGlobal: true,
-            ownerId: testUserId,
-          }),
-        })
-      ).resolves.toBeDefined();
-    });
-
-    it('rejects two cross-owner global configs of the same kind+name (llm_configs_global_name_unique)', async () => {
-      // Different owners bypass `owner_id+name`, isolating the global-name partial unique:
-      // two GLOBAL configs of the same kind+name must be rejected regardless of owner.
+    it('rejects two cross-owner global configs of the same name (llm_configs_global_name_unique)', async () => {
+      // Different owners bypass `owner_id+name`, isolating the global-name partial
+      // unique: two GLOBAL configs of the same name must be rejected regardless of
+      // owner — the single namespace the kind-column retirement collapsed to.
       await prisma.llmConfig.create({
         data: baseConfig({
           id: newLlmConfigId(),
           name: 'dup',
-          kind: 'text',
           isGlobal: true,
           ownerId: adminUserId,
         }),
@@ -951,12 +923,34 @@ describe('LlmConfigService Integration', () => {
           data: baseConfig({
             id: newLlmConfigId(),
             name: 'dup',
-            kind: 'text',
             isGlobal: true,
             ownerId: testUserId,
           }),
         })
       ).rejects.toThrow();
+    });
+
+    it('permits the same name on a NON-global config (the unique is partial)', async () => {
+      // The WHERE (is_global) clause is what makes the index partial: a user's own
+      // private preset may share a name with someone's global one.
+      await prisma.llmConfig.create({
+        data: baseConfig({
+          id: newLlmConfigId(),
+          name: 'partial-name',
+          isGlobal: true,
+          ownerId: adminUserId,
+        }),
+      });
+      await expect(
+        prisma.llmConfig.create({
+          data: baseConfig({
+            id: newLlmConfigId(),
+            name: 'partial-name',
+            isGlobal: false,
+            ownerId: testUserId,
+          }),
+        })
+      ).resolves.toBeDefined();
     });
   });
 });

--- a/services/api-gateway/src/services/LlmConfigService.test.ts
+++ b/services/api-gateway/src/services/LlmConfigService.test.ts
@@ -102,7 +102,6 @@ const sampleConfigDetail = {
   description: 'A test config',
   model: 'anthropic/claude-sonnet-4',
   provider: 'openrouter',
-  kind: 'text',
   isGlobal: true,
   isDefault: false,
   isFreeDefault: false,
@@ -151,24 +150,6 @@ describe('LlmConfigService', () => {
 
       expect(result).toBeNull();
     });
-
-    it('returns the config when expectedKind matches the row kind', async () => {
-      prisma.llmConfig.findUnique.mockResolvedValue(sampleConfigDetail); // kind: 'text'
-
-      const result = await service.getById('config-123', 'text');
-
-      expect(result).toEqual(sampleConfigDetail);
-    });
-
-    it('returns null when expectedKind does NOT match the row kind (cross-kind gate)', async () => {
-      prisma.llmConfig.findUnique.mockResolvedValue(sampleConfigDetail); // kind: 'text'
-
-      // Asking for a vision config by an id that resolves to a text row → null,
-      // so a vision-scoped route never returns a text row (and vice versa).
-      const result = await service.getById('config-123', 'vision');
-
-      expect(result).toBeNull();
-    });
   });
 
   describe('list', () => {
@@ -207,12 +188,12 @@ describe('LlmConfigService', () => {
       // First call: global configs
       expect(prisma.llmConfig.findMany).toHaveBeenNthCalledWith(
         1,
-        expect.objectContaining({ where: { isGlobal: true, kind: 'text' } })
+        expect.objectContaining({ where: { isGlobal: true } })
       );
       // Second call: user's own configs
       expect(prisma.llmConfig.findMany).toHaveBeenNthCalledWith(
         2,
-        expect.objectContaining({ where: { ownerId: 'user-123', isGlobal: false, kind: 'text' } })
+        expect.objectContaining({ where: { ownerId: 'user-123', isGlobal: false } })
       );
     });
 
@@ -258,33 +239,6 @@ describe('LlmConfigService', () => {
       const result = await service.list({ type: 'GLOBAL' });
 
       expect(result[0].isDefault).toBe(true);
-    });
-
-    it('scopes the query to the requested kind (defaults to text; vision when asked)', async () => {
-      prisma.llmConfig.findMany.mockResolvedValue([]);
-
-      await service.list({ type: 'GLOBAL' }); // default kind
-      expect(prisma.llmConfig.findMany).toHaveBeenLastCalledWith(
-        expect.objectContaining({ where: { kind: 'text' } })
-      );
-
-      await service.list({ type: 'GLOBAL' }, 'vision');
-      expect(prisma.llmConfig.findMany).toHaveBeenLastCalledWith(
-        expect.objectContaining({ where: { kind: 'vision' } })
-      );
-    });
-
-    it("omits the kind filter entirely for the 'all' sentinel (both kinds)", async () => {
-      prisma.llmConfig.findMany.mockResolvedValue([]);
-
-      await service.list({ type: 'GLOBAL' }, 'all');
-
-      // The 'all' sentinel drops the `kind` predicate from the where clause
-      // (vs. the text/vision cases above which pin it) → both kinds returned.
-      const lastCall = prisma.llmConfig.findMany.mock.calls.at(-1)?.[0] as {
-        where: Record<string, unknown>;
-      };
-      expect(lastCall.where).not.toHaveProperty('kind');
     });
   });
 
@@ -348,20 +302,6 @@ describe('LlmConfigService', () => {
             ownerId: 'user-123',
           }),
         })
-      );
-    });
-
-    it('stamps kind: defaults to text, honors an explicit vision kind', async () => {
-      prisma.llmConfig.create.mockResolvedValue(sampleConfigDetail);
-
-      await service.create({ type: 'GLOBAL' }, { name: 'T', model: 'm' }, 'owner');
-      expect(prisma.llmConfig.create).toHaveBeenLastCalledWith(
-        expect.objectContaining({ data: expect.objectContaining({ kind: 'text' }) })
-      );
-
-      await service.create({ type: 'GLOBAL' }, { name: 'V', model: 'm', kind: 'vision' }, 'owner');
-      expect(prisma.llmConfig.create).toHaveBeenLastCalledWith(
-        expect.objectContaining({ data: expect.objectContaining({ kind: 'vision' }) })
       );
     });
 
@@ -720,7 +660,7 @@ describe('LlmConfigService', () => {
 
   describe('setAsDefault', () => {
     // The slot (chat vs vision) is the caller's choice — it writes the matching
-    // pointer on the AdminSettings singleton, NOT a per-kind flag. The route layer
+    // pointer on the AdminSettings singleton, NOT a flag on the config row. The route layer
     // verifies the config exists + capability-gates the vision slot before this runs.
     it('writes the global chat-slot pointer for slot=text', async () => {
       await service.setAsDefault('config-123', 'text');
@@ -775,7 +715,7 @@ describe('LlmConfigService', () => {
 
       expect(result).toEqual({ exists: false });
       expect(prisma.llmConfig.findFirst).toHaveBeenCalledWith({
-        where: { name: 'Test Name', isGlobal: true, kind: 'text' },
+        where: { name: 'Test Name', isGlobal: true },
         select: { id: true },
       });
     });
@@ -788,7 +728,7 @@ describe('LlmConfigService', () => {
 
       expect(result).toEqual({ exists: true, conflictId: 'existing-config' });
       expect(prisma.llmConfig.findFirst).toHaveBeenCalledWith({
-        where: { name: 'Test Name', ownerId: 'user-123', kind: 'text' },
+        where: { name: 'Test Name', ownerId: 'user-123' },
         select: { id: true },
       });
     });
@@ -802,7 +742,6 @@ describe('LlmConfigService', () => {
         where: {
           name: 'Test Name',
           isGlobal: true,
-          kind: 'text',
           id: { not: 'current-config-id' },
         },
         select: { id: true },
@@ -822,10 +761,10 @@ describe('LlmConfigService', () => {
 
       expect(result).toEqual({ exists: true, conflictId: 'someone-elses-global' });
       expect(prisma.llmConfig.findFirst).toHaveBeenCalledTimes(2);
-      // Second call queries the global namespace (kind='text' mirrors the
-      // per-kind partial-unique index it pre-empts)
+      // Second call queries the global namespace (mirrors the partial-unique
+      // index it pre-empts: UNIQUE (name) WHERE is_global)
       expect(prisma.llmConfig.findFirst).toHaveBeenNthCalledWith(2, {
-        where: { name: 'MyVoice-bob', isGlobal: true, kind: 'text' },
+        where: { name: 'MyVoice-bob', isGlobal: true },
         select: { id: true },
       });
     });
@@ -852,7 +791,7 @@ describe('LlmConfigService', () => {
 
       expect(prisma.llmConfig.findFirst).toHaveBeenCalledTimes(1);
       expect(prisma.llmConfig.findFirst).toHaveBeenCalledWith({
-        where: { name: 'Test Name', ownerId: 'user-123', kind: 'text' },
+        where: { name: 'Test Name', ownerId: 'user-123' },
         select: { id: true },
       });
     });
@@ -935,7 +874,6 @@ describe('LlmConfigService', () => {
         description: 'A test config',
         model: 'anthropic/claude-sonnet-4',
         provider: 'openrouter',
-        kind: 'text',
         isGlobal: true,
         // isDefault/isFreeDefault are intentionally NOT on the detail response —
         // default-ness is an AdminSettings pointer relationship, carried on the

--- a/services/api-gateway/src/services/LlmConfigService.ts
+++ b/services/api-gateway/src/services/LlmConfigService.ts
@@ -12,7 +12,7 @@
  * This eliminates duplication between /admin/llm-config and /user/llm-config routes.
  */
 
-import { type ConfigKind, DEFAULT_CONFIG_KIND } from '@tzurot/common-types/constants/ai';
+import { type ModelSlot } from '@tzurot/common-types/constants/ai';
 import { ADMIN_SETTINGS_SINGLETON_ID } from '@tzurot/common-types/schemas/api/adminSettings';
 import {
   type LlmConfigCreateInput,
@@ -22,7 +22,6 @@ import {
   LLM_CONFIG_DEFAULTS,
 } from '@tzurot/common-types/schemas/api/llm-config';
 import { safeValidateAdvancedParams } from '@tzurot/common-types/schemas/llmAdvancedParams';
-import { toConfigKind } from '@tzurot/common-types/services/LlmConfigMapper';
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { newLlmConfigId } from '@tzurot/common-types/utils/deterministicUuid';
 import { createLogger } from '@tzurot/common-types/utils/logger';
@@ -68,7 +67,6 @@ interface RawConfigList {
   description: string | null;
   provider: string;
   model: string;
-  kind: string;
   isGlobal: boolean;
   ownerId: string;
 }
@@ -89,8 +87,6 @@ interface RawConfigListWithFlags extends RawConfigList {
  * Raw config from Prisma query (detail select).
  */
 interface RawConfigDetail extends RawConfigList {
-  /** Discriminator ('text' | 'vision' | …) — projected by LLM_CONFIG_DETAIL_SELECT for the getById kind-gate; not surfaced in the response. */
-  kind: string;
   advancedParameters: unknown;
   memoryScoreThreshold: { toNumber: () => number };
   memoryLimit: number;
@@ -110,7 +106,6 @@ interface FormattedConfigSummary {
   description: string | null;
   provider: string;
   model: string;
-  kind: ConfigKind;
   isGlobal: boolean;
   isDefault: boolean;
   isFreeDefault: boolean;
@@ -125,7 +120,6 @@ interface FormattedConfigDetail {
   description: string | null;
   provider: string;
   model: string;
-  kind: ConfigKind;
   isGlobal: boolean;
   memoryScoreThreshold: number;
   memoryLimit: number;
@@ -161,25 +155,13 @@ export class LlmConfigService {
   // --------------------------------------------------------------------------
 
   /**
-   * Get a single config by ID.
-   * Returns null if not found, or if `expectedKind` is given and the row is a
-   * different kind (so a text-scoped route never returns a vision row, and vice
-   * versa). Post-fetch check rather than a `findFirst({ id, kind })` query — it
-   * keeps the single-row `findUnique` (and its test mocks) intact while still
-   * closing the cross-kind read gap. `expectedKind` omitted = no kind filter.
+   * Get a single config by ID. Returns null if not found.
    */
-  async getById(configId: string, expectedKind?: ConfigKind): Promise<RawConfigDetail | null> {
-    const config = await this.prisma.llmConfig.findUnique({
+  async getById(configId: string): Promise<RawConfigDetail | null> {
+    return this.prisma.llmConfig.findUnique({
       where: { id: configId },
       select: LLM_CONFIG_DETAIL_SELECT,
     });
-    if (config === null) {
-      return null;
-    }
-    if (expectedKind !== undefined && toConfigKind(config.kind) !== expectedKind) {
-      return null;
-    }
-    return config;
   }
 
   /**
@@ -188,20 +170,11 @@ export class LlmConfigService {
    * - GLOBAL scope: All configs (for admin view)
    * - USER scope: Global configs + user's own configs
    */
-  async list(
-    scope: LlmConfigScope,
-    kind: ConfigKind | 'all' = DEFAULT_CONFIG_KIND
-  ): Promise<RawConfigListWithFlags[]> {
-    // Queries are scoped to the requested `kind` (default 'text'); the `'all'`
-    // sentinel drops the filter so browse can list text + vision in one call
-    // (each row carries `kind` in the summary). The autocomplete picker still
-    // passes an explicit kind so it never mixes kinds.
-    //
+  async list(scope: LlmConfigScope): Promise<RawConfigListWithFlags[]> {
     // Bound note: each findMany is `take: 100`. For USER scope that's two
-    // parallel queries (global + owned), so the merged result can reach 200 —
-    // and `'all'` widens each to both kinds. browse paginates, so a larger set
-    // is fine; a future non-paginating caller should pass an explicit kind.
-    const kindWhere = kind === 'all' ? {} : { kind };
+    // parallel queries (global + owned), so the merged result can reach 200.
+    // browse paginates, so a larger set is fine.
+    //
     // isDefault/isFreeDefault moved to the AdminSettings pointers in S3; the
     // boolean columns are no longer maintained (set-default writes only the
     // pointer), so they're stale. Derive both flags — and the defaults-first
@@ -214,11 +187,10 @@ export class LlmConfigService {
     });
 
     if (scope.type === 'GLOBAL') {
-      // Admin: list all configs of this kind. Base-order by name in the DB; the
+      // Admin: list all configs. Base-order by name in the DB; the
       // defaults-first sort is applied in-app from the derived flags (the DB
       // orderBy can't express pointer membership).
       const configs = await this.prisma.llmConfig.findMany({
-        where: kindWhere,
         select: LLM_CONFIG_LIST_SELECT,
         orderBy: { name: 'asc' },
         take: 100,
@@ -226,16 +198,16 @@ export class LlmConfigService {
       return configs.map(applyDefaultFlags).sort(compareConfigsForList);
     }
 
-    // User scope: Global configs + user's own configs (of this kind)
+    // User scope: Global configs + user's own configs
     const [globalConfigs, userConfigs] = await Promise.all([
       this.prisma.llmConfig.findMany({
-        where: { isGlobal: true, ...kindWhere },
+        where: { isGlobal: true },
         select: LLM_CONFIG_LIST_SELECT,
         orderBy: { name: 'asc' },
         take: 100,
       }),
       this.prisma.llmConfig.findMany({
-        where: { ownerId: scope.userId, isGlobal: false, ...kindWhere },
+        where: { ownerId: scope.userId, isGlobal: false },
         select: LLM_CONFIG_LIST_SELECT,
         orderBy: { name: 'asc' },
         take: 100,
@@ -303,10 +275,9 @@ export class LlmConfigService {
     const isGlobal = scope.type === 'GLOBAL';
     const requestedName = data.name.trim();
 
-    const kind = data.kind ?? DEFAULT_CONFIG_KIND;
     const effectiveName =
       data.autoSuffixOnCollision === true
-        ? await resolveNonCollidingName(this.prisma, requestedName, ownerId, kind)
+        ? await resolveNonCollidingName(this.prisma, requestedName, ownerId)
         : requestedName;
 
     let config;
@@ -322,9 +293,6 @@ export class LlmConfigService {
           // lives entirely on the AdminSettings pointers (S3).
           provider: data.provider ?? LLM_CONFIG_DEFAULTS.provider,
           model: data.model.trim(),
-          // Stamp the requested kind (Zod defaults it to 'text'). Per-kind capability
-          // validation runs in the route handler before create is called.
-          kind,
           advancedParameters: data.advancedParameters ?? undefined,
           // Memory settings — memoryScoreThreshold and memoryLimit are
           // NOT NULL with `@default(0.5)` / `@default(20)` in the schema.
@@ -460,7 +428,7 @@ export class LlmConfigService {
    * Set a config as the global (paid) default for a slot.
    *
    * Writes the per-slot pointer on the AdminSettings singleton — the slot (chat
-   * vs vision) is the caller's choice, NOT the config's `kind`. A config can be
+   * vs vision) is always the caller's choice. A config can be
    * the chat default and the vision default simultaneously (separate pointers).
    * The config's existence and (for the vision slot) capability are validated at
    * the route layer before this is called — an invalid id reaching the upsert
@@ -477,7 +445,7 @@ export class LlmConfigService {
    * @param configId - ID of config to point the slot at
    * @param slot - which default slot to set ('text' = chat, or 'vision')
    */
-  async setAsDefault(configId: string, slot: ConfigKind): Promise<void> {
+  async setAsDefault(configId: string, slot: ModelSlot): Promise<void> {
     const data =
       slot === 'vision'
         ? { globalDefaultVisionConfigId: configId }
@@ -503,7 +471,7 @@ export class LlmConfigService {
    * @param configId - ID of config to point the slot at
    * @param slot - which free-default slot to set ('text' = chat, or 'vision')
    */
-  async setAsFreeDefault(configId: string, slot: ConfigKind): Promise<void> {
+  async setAsFreeDefault(configId: string, slot: ModelSlot): Promise<void> {
     const data =
       slot === 'vision'
         ? { freeDefaultVisionConfigId: configId }
@@ -547,16 +515,16 @@ export class LlmConfigService {
     name: string,
     scope: LlmConfigScope,
     excludeId?: string,
-    postIsGlobal = false,
-    kind: ConfigKind = DEFAULT_CONFIG_KIND
+    postIsGlobal = false
   ): Promise<NameCheckResult> {
     const trimmedName = name.trim();
     const excludeClause = excludeId !== undefined ? { id: { not: excludeId } } : {};
 
     if (scope.type === 'GLOBAL') {
-      // Admin: Check among global configs of this kind only
+      // Admin: check the single global namespace (names are unique per
+      // owner and — via the partial-unique index — across all globals).
       const existing = await this.prisma.llmConfig.findFirst({
-        where: { name: trimmedName, isGlobal: true, kind, ...excludeClause },
+        where: { name: trimmedName, isGlobal: true, ...excludeClause },
         select: { id: true },
       });
       return existing === null ? { exists: false } : { exists: true, conflictId: existing.id };
@@ -567,9 +535,6 @@ export class LlmConfigService {
     const ownClause: Record<string, unknown> = {
       name: trimmedName,
       ownerId: scope.userId,
-      // Scoped to the requested kind — keeps the app check aligned with the
-      // per-kind unique index (names are unique per (kind, owner)/(kind, global)).
-      kind,
       ...excludeClause,
     };
     const ownPromise = this.prisma.llmConfig.findFirst({
@@ -583,10 +548,9 @@ export class LlmConfigService {
     }
 
     const globalPromise = this.prisma.llmConfig.findFirst({
-      // Scoped to kind to mirror the partial-unique index this check pre-empts
-      // (`llm_configs_global_name_unique` is UNIQUE (kind, name) WHERE is_global);
-      // without it a promotion would falsely collide with a same-named other-kind global.
-      where: { name: trimmedName, isGlobal: true, kind, ...excludeClause },
+      // Mirrors the partial-unique index this check pre-empts
+      // (`llm_configs_global_name_unique` is UNIQUE (name) WHERE is_global).
+      where: { name: trimmedName, isGlobal: true, ...excludeClause },
       select: { id: true },
     });
     const [own, global] = await Promise.all([ownPromise, globalPromise]);
@@ -646,7 +610,6 @@ export class LlmConfigService {
       description: raw.description,
       provider: raw.provider,
       model: raw.model,
-      kind: toConfigKind(raw.kind),
       isGlobal: raw.isGlobal,
       // isDefault/isFreeDefault are NOT on the detail response: defaults live on
       // the AdminSettings pointers (S3), and no client reads them off the detail
@@ -678,7 +641,6 @@ export class LlmConfigService {
       description: raw.description,
       provider: raw.provider,
       model: raw.model,
-      kind: toConfigKind(raw.kind),
       isGlobal: raw.isGlobal,
       isDefault: raw.isDefault,
       isFreeDefault: raw.isFreeDefault,

--- a/services/api-gateway/src/services/llmConfigNameCollision.test.ts
+++ b/services/api-gateway/src/services/llmConfigNameCollision.test.ts
@@ -16,29 +16,25 @@ function mockPrisma(takenNames: string[]) {
 describe('resolveNonCollidingName', () => {
   it('returns the base name when nothing collides', async () => {
     const prisma = mockPrisma([]);
-    expect(await resolveNonCollidingName(prisma, 'Preset', 'owner-1', 'text')).toBe('Preset');
+    expect(await resolveNonCollidingName(prisma, 'Preset', 'owner-1')).toBe('Preset');
   });
 
   it('bumps a (Copy) suffix when the base name is taken', async () => {
     const prisma = mockPrisma(['Preset']);
-    expect(await resolveNonCollidingName(prisma, 'Preset', 'owner-1', 'text')).toBe(
-      'Preset (Copy)'
-    );
+    expect(await resolveNonCollidingName(prisma, 'Preset', 'owner-1')).toBe('Preset (Copy)');
   });
 
   it('matches case-insensitively (lowercased legacy rows still collide)', async () => {
     const prisma = mockPrisma(['preset']); // lowercase legacy row
-    expect(await resolveNonCollidingName(prisma, 'Preset', 'owner-1', 'text')).toBe(
-      'Preset (Copy)'
-    );
+    expect(await resolveNonCollidingName(prisma, 'Preset', 'owner-1')).toBe('Preset (Copy)');
   });
 
-  it('scopes the lookup to the given owner and kind', async () => {
+  it('scopes the lookup to the given owner', async () => {
     const prisma = mockPrisma([]);
-    await resolveNonCollidingName(prisma, 'Preset', 'owner-1', 'vision');
+    await resolveNonCollidingName(prisma, 'Preset', 'owner-1');
     expect(prisma.llmConfig.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({ ownerId: 'owner-1', kind: 'vision' }),
+        where: expect.objectContaining({ ownerId: 'owner-1' }),
       })
     );
   });
@@ -52,7 +48,7 @@ describe('resolveNonCollidingName', () => {
       candidate = generateClonedName(candidate);
     }
     const prisma = mockPrisma(taken);
-    await expect(resolveNonCollidingName(prisma, 'Preset', 'owner-1', 'text')).rejects.toThrow(
+    await expect(resolveNonCollidingName(prisma, 'Preset', 'owner-1')).rejects.toThrow(
       CloneNameExhaustedError
     );
   });

--- a/services/api-gateway/src/services/llmConfigNameCollision.ts
+++ b/services/api-gateway/src/services/llmConfigNameCollision.ts
@@ -2,11 +2,10 @@
  * Clone-name collision resolution for LLM config presets.
  *
  * Extracted from LlmConfigService (keeps that file under the max-lines limit).
- * Self-contained: a name-walk over the owner's existing configs of a given kind,
+ * Self-contained: a name-walk over the owner's existing configs,
  * with no service state beyond the injected Prisma client.
  */
 
-import { type ConfigKind } from '@tzurot/common-types/constants/ai';
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { generateClonedName, stripCopySuffix } from '@tzurot/common-types/utils/presetCloneName';
 import { CloneNameExhaustedError } from './LlmConfigErrors.js';
@@ -20,7 +19,7 @@ export const MAX_CLONE_NAME_ATTEMPTS = 20;
 
 /**
  * Find a name that doesn't collide with any existing config owned by the same
- * user (of the given `kind`), starting from `baseName` and bumping `(Copy N)`
+ * user, starting from `baseName` and bumping `(Copy N)`
  * suffixes via `generateClonedName` until a free slot is found.
  *
  * Uses a single SELECT to enumerate all variants (base, `base (Copy)`,
@@ -34,8 +33,7 @@ export const MAX_CLONE_NAME_ATTEMPTS = 20;
 export async function resolveNonCollidingName(
   prisma: PrismaClient,
   baseName: string,
-  ownerId: string,
-  kind: ConfigKind
+  ownerId: string
 ): Promise<string> {
   const stripped = stripCopySuffix(baseName);
 
@@ -66,7 +64,6 @@ export async function resolveNonCollidingName(
   const existing = await prisma.llmConfig.findMany({
     where: {
       ownerId,
-      kind,
       OR: [
         { name: stripped },
         { name: { startsWith: `${stripped} (Copy)`, mode: 'insensitive' } },

--- a/services/api-gateway/src/services/sync/config/syncTables.ts
+++ b/services/api-gateway/src/services/sync/config/syncTables.ts
@@ -109,7 +109,7 @@ export const SYNC_CONFIG: Record<SyncTableName, TableSyncConfig> = {
     //     DEFERRABLE since migration 20260418010642 (the original circular-FK fix).
     //   - default_tts_config_id (nullable): DEFERRABLE since migration
     //     20260504065151 (added when the TTS feature shipped).
-    //   - default_vision_config_id (nullable, → llm_configs vision-kind row):
+    //   - default_vision_config_id (nullable, → llm_configs row):
     //     DEFERRABLE since migration 20260627040007 (the vision_config_kind migration).
     // Nullability is orthogonal to DEFERRABLE: deferral controls *when* the FK
     // reference is validated (at COMMIT, after the referenced row is synced),

--- a/services/api-gateway/src/utils/configRouteHelpers.test.ts
+++ b/services/api-gateway/src/utils/configRouteHelpers.test.ts
@@ -29,8 +29,8 @@ vi.mock('./errorResponses.js', () => ({
 
 import {
   parseBodyOrSendError,
-  parseConfigKindQuery,
-  parseConfigKindQueryAllowAll,
+  parseModelSlotQuery,
+  parseModelSlotQueryAllowAll,
   findConfigOrSendNotFound,
   findGlobalConfigOrSendError,
   findAdminUserOrSendError,
@@ -43,56 +43,56 @@ const mockRes = {} as Response;
 
 beforeEach(() => vi.resetAllMocks());
 
-describe('parseConfigKindQuery', () => {
-  it('returns the parsed kind for a valid ?kind=vision', () => {
-    expect(parseConfigKindQuery(mockRes, { kind: 'vision' })).toBe('vision');
+describe('parseModelSlotQuery', () => {
+  it('returns the parsed slot for a valid ?slot=vision', () => {
+    expect(parseModelSlotQuery(mockRes, { slot: 'vision' })).toBe('vision');
     expect(mockSendZodError).not.toHaveBeenCalled();
   });
 
-  it('returns text for a valid ?kind=text', () => {
-    expect(parseConfigKindQuery(mockRes, { kind: 'text' })).toBe('text');
+  it('returns text for a valid ?slot=text', () => {
+    expect(parseModelSlotQuery(mockRes, { slot: 'text' })).toBe('text');
   });
 
   it('defaults to text when the param is absent', () => {
-    expect(parseConfigKindQuery(mockRes, {})).toBe('text');
+    expect(parseModelSlotQuery(mockRes, {})).toBe('text');
     expect(mockSendZodError).not.toHaveBeenCalled();
   });
 
   it('defaults to text when the query object itself is undefined', () => {
     // Express always populates req.query, but the helper must not 400 purely
     // because the object is missing (e.g. in unit tests / edge cases).
-    expect(parseConfigKindQuery(mockRes, undefined)).toBe('text');
+    expect(parseModelSlotQuery(mockRes, undefined)).toBe('text');
     expect(mockSendZodError).not.toHaveBeenCalled();
   });
 
-  it('sends a Zod error and returns null for an invalid kind', () => {
-    expect(parseConfigKindQuery(mockRes, { kind: 'audio' })).toBeNull();
+  it('sends a Zod error and returns null for an invalid slot', () => {
+    expect(parseModelSlotQuery(mockRes, { slot: 'audio' })).toBeNull();
     expect(mockSendZodError).toHaveBeenCalledTimes(1);
   });
 });
 
-describe('parseConfigKindQueryAllowAll', () => {
-  it('returns the parsed kind for a valid ?kind=vision', () => {
-    expect(parseConfigKindQueryAllowAll(mockRes, { kind: 'vision' })).toBe('vision');
+describe('parseModelSlotQueryAllowAll', () => {
+  it('returns the parsed slot for a valid ?slot=vision', () => {
+    expect(parseModelSlotQueryAllowAll(mockRes, { slot: 'vision' })).toBe('vision');
     expect(mockSendZodError).not.toHaveBeenCalled();
   });
 
-  it('returns text for a valid ?kind=text', () => {
-    expect(parseConfigKindQueryAllowAll(mockRes, { kind: 'text' })).toBe('text');
+  it('returns text for a valid ?slot=text', () => {
+    expect(parseModelSlotQueryAllowAll(mockRes, { slot: 'text' })).toBe('text');
   });
 
-  it('accepts the all-kinds sentinel ?kind=all (list-only widening)', () => {
-    expect(parseConfigKindQueryAllowAll(mockRes, { kind: 'all' })).toBe('all');
+  it('accepts the both-slots sentinel ?slot=all (list-only widening)', () => {
+    expect(parseModelSlotQueryAllowAll(mockRes, { slot: 'all' })).toBe('all');
     expect(mockSendZodError).not.toHaveBeenCalled();
   });
 
   it('defaults to text when the param is absent', () => {
-    expect(parseConfigKindQueryAllowAll(mockRes, {})).toBe('text');
+    expect(parseModelSlotQueryAllowAll(mockRes, {})).toBe('text');
     expect(mockSendZodError).not.toHaveBeenCalled();
   });
 
-  it('sends a Zod error and returns null for an invalid kind', () => {
-    expect(parseConfigKindQueryAllowAll(mockRes, { kind: 'audio' })).toBeNull();
+  it('sends a Zod error and returns null for an invalid slot', () => {
+    expect(parseModelSlotQueryAllowAll(mockRes, { slot: 'audio' })).toBeNull();
     expect(mockSendZodError).toHaveBeenCalledTimes(1);
   });
 });
@@ -290,7 +290,6 @@ describe('ensureNoNameCollision', () => {
       'NewName',
       globalScope,
       undefined,
-      undefined,
       undefined
     );
     expect(mockSendError).not.toHaveBeenCalled();
@@ -334,7 +333,6 @@ describe('ensureNoNameCollision', () => {
       'RenameTarget',
       globalScope,
       'existing-id-789',
-      undefined,
       undefined
     );
   });
@@ -354,7 +352,6 @@ describe('ensureNoNameCollision', () => {
     expect(service.checkNameExists).toHaveBeenCalledWith(
       'MyConfig',
       userScope,
-      undefined,
       undefined,
       undefined
     );
@@ -393,13 +390,7 @@ describe('ensureNoNameCollision', () => {
       formatCollisionMessage: _n => `irrelevant`,
     });
 
-    expect(service.checkNameExists).toHaveBeenCalledWith(
-      'Renamed',
-      userScope,
-      'cfg-1',
-      true,
-      undefined
-    );
+    expect(service.checkNameExists).toHaveBeenCalledWith('Renamed', userScope, 'cfg-1', true);
   });
 
   it('does not pass postIsGlobal when omitted (service receives undefined 4th arg)', async () => {
@@ -417,29 +408,7 @@ describe('ensureNoNameCollision', () => {
       'Created',
       userScope,
       undefined,
-      undefined,
       undefined
-    );
-  });
-
-  it('forwards kind to the service so collision checks are kind-scoped', async () => {
-    const service = {
-      checkNameExists: vi.fn().mockResolvedValue({ exists: false }),
-    };
-
-    await ensureNoNameCollision(mockRes, service, {
-      name: 'VisionPreset',
-      scope: globalScope,
-      kind: 'vision',
-      formatCollisionMessage: _n => `irrelevant`,
-    });
-
-    expect(service.checkNameExists).toHaveBeenCalledWith(
-      'VisionPreset',
-      globalScope,
-      undefined,
-      undefined,
-      'vision'
     );
   });
 });

--- a/services/api-gateway/src/utils/configRouteHelpers.ts
+++ b/services/api-gateway/src/utils/configRouteHelpers.ts
@@ -15,11 +15,7 @@
 
 import type { Response } from 'express';
 import { z } from 'zod';
-import {
-  CONFIG_KINDS,
-  DEFAULT_CONFIG_KIND,
-  type ConfigKind,
-} from '@tzurot/common-types/constants/ai';
+import { MODEL_SLOTS, DEFAULT_MODEL_SLOT, type ModelSlot } from '@tzurot/common-types/constants/ai';
 import { type PrismaClient } from '@tzurot/common-types/services/prisma';
 import { type EntityPermissions } from '@tzurot/common-types/utils/permissions';
 import { sendError } from './responseHelpers.js';
@@ -53,53 +49,53 @@ export function parseBodyOrSendError<T>(
   return result.data;
 }
 
-/** Zod schema for the optional `?kind=` config-kind query param. */
-const ConfigKindQuerySchema = z.object({
-  kind: z.enum(CONFIG_KINDS).default(DEFAULT_CONFIG_KIND),
+/** Zod schema for the optional `?slot=` model-slot query param. */
+const ModelSlotQuerySchema = z.object({
+  slot: z.enum(MODEL_SLOTS).default(DEFAULT_MODEL_SLOT),
 });
 
 /**
- * Parse the optional `?kind=` query param (`text` | `vision`), defaulting to
- * `text`. Lets the read / by-id config routes scope to a kind so the SAME
- * handler serves both — vision callers pass `?kind=vision`, everyone else gets
- * the text default (so existing callers are unchanged). On an invalid value
+ * Parse the optional `?slot=` query param (`text` | `vision`), defaulting to
+ * `text`. Used by the slot-addressed routes (model overrides, admin default
+ * pointers) so the SAME handler serves both slots — vision callers pass
+ * `?slot=vision`, everyone else gets the text default. On an invalid value
  * sends a Zod-shaped 400 and returns `null` (caller returns early); an absent
  * param resolves to the default, never null.
  */
-export function parseConfigKindQuery(res: Response, query: unknown): ConfigKind | null {
+export function parseModelSlotQuery(res: Response, query: unknown): ModelSlot | null {
   // `query ?? {}`: an absent query object means "no params" → the text default,
   // not a 400. Express always populates `req.query` (at least `{}`), but guard
   // the undefined case so the helper never rejects purely for a missing object.
-  const result = ConfigKindQuerySchema.safeParse(query ?? {});
+  const result = ModelSlotQuerySchema.safeParse(query ?? {});
   if (!result.success) {
     sendZodError(res, result.error);
     return null;
   }
-  return result.data.kind;
+  return result.data.slot;
 }
 
-/** LIST-route `?kind=` schema that also accepts the `all` sentinel (both kinds). */
-const ConfigKindOrAllQuerySchema = z.object({
-  kind: z.enum([...CONFIG_KINDS, 'all'] as const).default(DEFAULT_CONFIG_KIND),
+/** `?slot=` schema that also accepts the `all` sentinel (both slots). */
+const ModelSlotOrAllQuerySchema = z.object({
+  slot: z.enum([...MODEL_SLOTS, 'all'] as const).default(DEFAULT_MODEL_SLOT),
 });
 
 /**
- * Parse the optional `?kind=` query for LIST routes, additionally accepting the
- * `'all'` sentinel meaning "return BOTH kinds" (used by browse to fetch text +
- * vision in one call). Defaults to text so existing callers are unchanged. Only
- * list/browse handlers use this; the strict {@link parseConfigKindQuery} stays
- * for by-id / set / clear so those can never receive `'all'`.
+ * Parse the optional `?slot=` query, additionally accepting the `'all'`
+ * sentinel meaning "BOTH slots" (used by the override list — one row per
+ * occupied slot — and the clear-default path that clears both pointers).
+ * Defaults to text. Setters use the strict {@link parseModelSlotQuery} so a
+ * write can never target `'all'`.
  */
-export function parseConfigKindQueryAllowAll(
+export function parseModelSlotQueryAllowAll(
   res: Response,
   query: unknown
-): ConfigKind | 'all' | null {
-  const result = ConfigKindOrAllQuerySchema.safeParse(query ?? {});
+): ModelSlot | 'all' | null {
+  const result = ModelSlotOrAllQuerySchema.safeParse(query ?? {});
   if (!result.success) {
     sendZodError(res, result.error);
     return null;
   }
-  return result.data.kind;
+  return result.data.slot;
 }
 
 /**
@@ -134,7 +130,7 @@ export type GlobalGuardOperation =
  * a global config. On not-found → 404; on non-global → 400 with operation-scoped
  * wording. Returns the row on success, null on failure (error already sent).
  */
-export async function findGlobalConfigOrSendError<T extends { isGlobal: boolean; kind?: string }>(
+export async function findGlobalConfigOrSendError<T extends { isGlobal: boolean }>(
   res: Response,
   fetchRow: () => Promise<T | null>,
   options: {
@@ -144,16 +140,6 @@ export async function findGlobalConfigOrSendError<T extends { isGlobal: boolean;
     resourceLabel: string;
     /** Operation being attempted — determines guard wording. */
     operation: GlobalGuardOperation;
-    /**
-     * When set, reject (as not-found) any row whose `kind` is present AND differs.
-     * Gates the bare admin surface (no `?kind=`, which defaults to text) to text
-     * rows: a vision config 404s unless the caller explicitly passes
-     * `?kind=vision`, so the text surface can't accidentally edit / delete /
-     * (un)default a vision row. The `kind !== undefined` leniency is a production
-     * no-op (the column is NOT NULL with a default) — it only spares callers/tests
-     * that don't select `kind`. Requires `kind` in the select.
-     */
-    requireKind?: ConfigKind;
   }
 ): Promise<T | null> {
   const row = await fetchRow();
@@ -168,15 +154,6 @@ export async function findGlobalConfigOrSendError<T extends { isGlobal: boolean;
         formatGlobalGuardMessage(options.operation, options.resourceLabel)
       )
     );
-    return null;
-  }
-  if (
-    options.requireKind !== undefined &&
-    row.kind !== undefined &&
-    row.kind !== options.requireKind
-  ) {
-    // A wrong-kind row is "not found" on this surface — don't reveal it exists elsewhere.
-    sendError(res, ErrorResponses.notFound(options.notFoundResource));
     return null;
   }
   return row;
@@ -242,8 +219,7 @@ interface NameExistsChecker<TScope> {
     name: string,
     scope: TScope,
     excludeId?: string,
-    postIsGlobal?: boolean,
-    kind?: ConfigKind
+    postIsGlobal?: boolean
   ): Promise<{ exists: boolean }>;
 }
 
@@ -276,19 +252,14 @@ export async function ensureNoNameCollision<TScope>(
      *  state would be `isGlobal: true`, so the check widens to the
      *  cross-user global namespace. Admin and create paths omit this. */
     postIsGlobal?: boolean;
-    /** Config kind to scope the collision check to. Names are unique per
-     *  `(kind, …)` (the partial-unique indexes), so a vision config named "X"
-     *  must NOT collide with a text config named "X". Pass `body.kind` on
-     *  create; omit (defaults text in the service) for text-only callers. */
-    kind?: ConfigKind;
     /** Caller-provided message formatter. Receives `name` (so the caller
      *  doesn't have to capture it in closure) and returns the full
      *  user-facing message. */
     formatCollisionMessage: (name: string) => string;
   }
 ): Promise<boolean> {
-  const { name, scope, excludeId, postIsGlobal, kind, formatCollisionMessage } = options;
-  const nameCheck = await service.checkNameExists(name, scope, excludeId, postIsGlobal, kind);
+  const { name, scope, excludeId, postIsGlobal, formatCollisionMessage } = options;
+  const nameCheck = await service.checkNameExists(name, scope, excludeId, postIsGlobal);
   if (nameCheck.exists) {
     sendError(res, ErrorResponses.nameCollision(formatCollisionMessage(name)));
     return false;

--- a/services/api-gateway/src/utils/llmConfigValidation.test.ts
+++ b/services/api-gateway/src/utils/llmConfigValidation.test.ts
@@ -16,17 +16,6 @@ vi.mock('./modelValidation.js', () => ({
   validateModelAndContextWindow: (...args: unknown[]) => mockValidateModelAndContextWindow(...args),
 }));
 
-// Control the capability resolver so the vision gate can be exercised without a
-// real OpenRouter cache. Each instance delegates to the shared mockResolve.
-const mockResolve = vi.fn();
-vi.mock('../services/ModelCapabilityService.js', () => ({
-  ModelCapabilityService: class {
-    async resolve(modelId: string) {
-      return mockResolve(modelId);
-    }
-  },
-}));
-
 const mockSendError = vi.fn();
 vi.mock('./responseHelpers.js', () => ({
   sendError: (...args: unknown[]) => mockSendError(...args),
@@ -152,11 +141,9 @@ describe('validateLlmConfigModelFields', () => {
       expect(mockGetById).not.toHaveBeenCalled();
     });
 
-    it('validates with body.model directly, but fetches the row to derive the immutable kind', async () => {
-      // The update path never carries `kind` (it's immutable), so when a model
-      // is being set the helper fetches the row to learn the kind for the
-      // capability gate. The model itself still comes from body.model, not the row.
-      mockGetById.mockResolvedValue({ model: 'old-model', kind: 'text' });
+    it('validates with body.model directly without fetching the row', async () => {
+      // The fetch exists only as a model fallback — when the update body
+      // carries a model, there's nothing to derive from the stored row.
       mockValidateModelAndContextWindow.mockResolvedValue({});
 
       const result = await validateLlmConfigModelFields({
@@ -167,15 +154,13 @@ describe('validateLlmConfigModelFields', () => {
       });
 
       expect(result).toBe(true);
-      expect(mockGetById).toHaveBeenCalledWith('cfg-1');
+      expect(mockGetById).not.toHaveBeenCalled();
       expect(mockValidateModelAndContextWindow).toHaveBeenCalledWith(
         mockModelCache,
         'claude-3-opus',
         undefined,
         false
       );
-      // text config → no capability check
-      expect(mockResolve).not.toHaveBeenCalled();
     });
 
     it('fetches current model when only contextWindowTokens is being updated', async () => {
@@ -200,9 +185,6 @@ describe('validateLlmConfigModelFields', () => {
     });
 
     it('uses body.model for context validation when both model and contextWindowTokens are provided', async () => {
-      // Model fallback isn't needed (body.model present), but the row is still
-      // fetched to derive the immutable kind for the capability gate.
-      mockGetById.mockResolvedValue({ model: 'old-model', kind: 'text' });
       mockValidateModelAndContextWindow.mockResolvedValue({});
 
       const result = await validateLlmConfigModelFields({
@@ -223,8 +205,6 @@ describe('validateLlmConfigModelFields', () => {
     });
 
     it('returns false and sends error when validation fails on update', async () => {
-      // body.model present → the helper fetches the row to derive the kind.
-      mockGetById.mockResolvedValue({ model: 'gpt-4', kind: 'text' });
       mockValidateModelAndContextWindow.mockResolvedValue({
         error: 'Context window exceeds 50% of model limit',
       });
@@ -261,128 +241,6 @@ describe('validateLlmConfigModelFields', () => {
         8000,
         false
       );
-    });
-  });
-
-  describe('vision capability gate', () => {
-    beforeEach(() => {
-      // Context-window validation passes for all capability-gate cases; we're
-      // isolating the capability check that runs after it.
-      mockValidateModelAndContextWindow.mockResolvedValue({});
-    });
-
-    it('accepts a vision config whose model is vision-capable (create path)', async () => {
-      mockResolve.mockResolvedValue({ supportsVision: true, source: 'openrouter' });
-
-      const result = await validateLlmConfigModelFields({
-        res: mockRes,
-        modelCache: mockModelCache,
-        body: { model: 'anthropic/claude-3.5-sonnet' },
-        kind: 'vision',
-      });
-
-      expect(result).toBe(true);
-      expect(mockResolve).toHaveBeenCalledWith('anthropic/claude-3.5-sonnet');
-      expect(mockSendError).not.toHaveBeenCalled();
-    });
-
-    it('rejects a vision config whose model is text-only', async () => {
-      mockResolve.mockResolvedValue({ supportsVision: false, source: 'openrouter' });
-
-      const result = await validateLlmConfigModelFields({
-        res: mockRes,
-        modelCache: mockModelCache,
-        body: { model: 'some/text-only-model' },
-        kind: 'vision',
-      });
-
-      expect(result).toBe(false);
-      expect(mockSendError).toHaveBeenCalledWith(
-        mockRes,
-        expect.objectContaining({ message: expect.stringContaining("doesn't support image input") })
-      );
-    });
-
-    it('rejects a vision config on a z.ai-only (text-only) model', async () => {
-      // z.ai coding-plan models resolve to text-only capabilities → fail closed.
-      mockResolve.mockResolvedValue({ supportsVision: false, source: 'zai' });
-
-      const result = await validateLlmConfigModelFields({
-        res: mockRes,
-        modelCache: mockModelCache,
-        body: { model: 'z-ai/glm-5.2' },
-        kind: 'vision',
-        hasZaiCodingKey: true,
-      });
-
-      expect(result).toBe(false);
-      expect(mockSendError).toHaveBeenCalledWith(
-        mockRes,
-        expect.objectContaining({ message: expect.stringContaining("doesn't support image input") })
-      );
-    });
-
-    it('rejects a vision config on a model unknown to all sources (fail closed)', async () => {
-      mockResolve.mockResolvedValue(null);
-
-      const result = await validateLlmConfigModelFields({
-        res: mockRes,
-        modelCache: mockModelCache,
-        body: { model: 'made-up/model' },
-        kind: 'vision',
-      });
-
-      expect(result).toBe(false);
-      expect(mockSendError).toHaveBeenCalledWith(
-        mockRes,
-        expect.objectContaining({ message: expect.stringContaining("Couldn't confirm") })
-      );
-    });
-
-    it('does not capability-check a text config (vision models are also text-capable)', async () => {
-      const result = await validateLlmConfigModelFields({
-        res: mockRes,
-        modelCache: mockModelCache,
-        body: { model: 'anthropic/claude-3.5-sonnet' },
-        kind: 'text',
-      });
-
-      expect(result).toBe(true);
-      expect(mockResolve).not.toHaveBeenCalled();
-    });
-
-    it('capability-checks the NEW model on a vision-config update, with kind from the row', async () => {
-      // Update path: kind is immutable, derived from the stored row (vision);
-      // the model being validated is the new body.model.
-      mockGetById.mockResolvedValue({ model: 'old-vision-model', kind: 'vision' });
-      mockResolve.mockResolvedValue({ supportsVision: true, source: 'openrouter' });
-
-      const result = await validateLlmConfigModelFields({
-        res: mockRes,
-        modelCache: mockModelCache,
-        body: { model: 'new-vision-model' },
-        fallback: { service: mockService, configId: 'cfg-vision' },
-      });
-
-      expect(result).toBe(true);
-      expect(mockGetById).toHaveBeenCalledWith('cfg-vision');
-      expect(mockResolve).toHaveBeenCalledWith('new-vision-model');
-    });
-
-    it('skips the capability check on a context-only update (model unchanged)', async () => {
-      // body.model omitted → no model is being set → unchanged model isn't
-      // re-validated, even on a vision config.
-      mockGetById.mockResolvedValue({ model: 'existing-vision-model', kind: 'vision' });
-
-      const result = await validateLlmConfigModelFields({
-        res: mockRes,
-        modelCache: mockModelCache,
-        body: { contextWindowTokens: 16000 },
-        fallback: { service: mockService, configId: 'cfg-vision' },
-      });
-
-      expect(result).toBe(true);
-      expect(mockResolve).not.toHaveBeenCalled();
     });
   });
 });

--- a/services/api-gateway/src/utils/llmConfigValidation.ts
+++ b/services/api-gateway/src/utils/llmConfigValidation.ts
@@ -16,8 +16,6 @@
  */
 
 import type { Response } from 'express';
-import { DEFAULT_CONFIG_KIND, type ConfigKind } from '@tzurot/common-types/constants/ai';
-import { toConfigKind } from '@tzurot/common-types/services/LlmConfigMapper';
 import { sendError } from './responseHelpers.js';
 import { ErrorResponses } from './errorResponses.js';
 import { validateModelAndContextWindow } from './modelValidation.js';
@@ -74,66 +72,37 @@ export interface ValidateLlmConfigModelFieldsOptions {
     service: LlmConfigService;
     configId: string;
   };
-  /**
-   * Config kind, gating the vision capability check. Pass it explicitly whenever
-   * the caller already knows a verified kind — the **create** path (`body.kind`)
-   * and the **admin edit** path (the `requireKind`-checked value, after the row
-   * fetch) both do; this lets the helper skip a redundant `getById`. Leave it
-   * undefined when the kind isn't known to the caller (e.g. the user edit path) —
-   * the helper then derives it from the existing row via `fallback` (kind is
-   * immutable, never in the update body). When neither is available it defaults
-   * to {@link DEFAULT_CONFIG_KIND} (text), which never rejects.
-   */
-  kind?: ConfigKind;
 }
 
 /**
- * Resolve the effective model + kind for validation. The stored row is the
- * fallback source for both: the model (when the body omits it, so
- * contextWindowTokens can still be validated against a known model) AND the
- * immutable kind (never in the update body). A single getById serves both,
- * fetched only when something needs it:
- *  - model fallback: the body omits `model`.
- *  - kind for the capability gate: a model IS being set and the caller didn't
- *    pass `kind`. Callers with an already-verified kind (create from `body.kind`,
- *    admin edit from the `requireKind`-checked value) pass it, so this fetch is
- *    skipped; a context-only edit doesn't need the kind either.
+ * Resolve the effective model for validation: the body's model when present,
+ * otherwise the stored row's (so contextWindowTokens can still be validated
+ * against a known model on a context-only edit). The fetch only happens when
+ * the fallback is actually needed.
  */
-async function resolveEffectiveModelAndKind(
+async function resolveEffectiveModel(
   opts: ValidateLlmConfigModelFieldsOptions
-): Promise<{ effectiveModel: string | undefined; effectiveKind: ConfigKind }> {
-  const { body, fallback, kind } = opts;
-  let effectiveModel = body.model;
-  let effectiveKind: ConfigKind = kind ?? DEFAULT_CONFIG_KIND;
-  if (fallback !== undefined) {
-    const needModelFallback = effectiveModel === undefined;
-    const needKind = kind === undefined && body.model !== undefined;
-    if (needModelFallback || needKind) {
-      const current = await fallback.service.getById(fallback.configId);
-      if (needModelFallback) {
-        effectiveModel = current?.model;
-      }
-      if (needKind && current !== null) {
-        effectiveKind = toConfigKind(current.kind);
-      }
-      // If `current` is null here (the config doesn't exist), effectiveKind stays
-      // the text default, so the vision gate is skipped — which is harmless: the
-      // update route's own fetch returns a clean 404 right after. We deliberately
-      // don't 404 here; existence is the route's concern, not the validator's.
-    }
+): Promise<string | undefined> {
+  const { body, fallback } = opts;
+  if (body.model !== undefined || fallback === undefined) {
+    return body.model;
   }
-  return { effectiveModel, effectiveKind };
+  // If the row doesn't exist, this resolves undefined and validation is skipped —
+  // which is harmless: the update route's own fetch returns a clean 404 right
+  // after. We deliberately don't 404 here; existence is the route's concern.
+  const current = await fallback.service.getById(fallback.configId);
+  return current?.model;
 }
 
 /**
- * Vision capability gate — fail closed. A vision config's model MUST be confirmed
- * vision-capable; the prod failure the epic targets is a vision config silently
+ * Vision capability gate — fail closed. A vision-slot model MUST be confirmed
+ * vision-capable; the prod failure the epic targeted was a vision slot silently
  * pointing at a text-only model (→ no image description → the LLM improvises).
  * On failure sends a 400 and returns false; returns true when the model is
  * confirmed vision-capable.
  *
- * Exported so the slot-setting routes (user/personality vision-slot overrides)
- * gate on the SAME capability check the create/update path uses — a config's
+ * THE gate for vision-ness: every slot-setting route (user/personality vision-slot
+ * overrides, admin default pointers) runs this same capability check — a config's
  * model must be confirmed vision-capable before it can occupy a vision slot,
  * regardless of which endpoint does the slotting.
  */
@@ -195,7 +164,7 @@ export async function validateLlmConfigModelFields(
     return true;
   }
 
-  const { effectiveModel, effectiveKind } = await resolveEffectiveModelAndKind(opts);
+  const effectiveModel = await resolveEffectiveModel(opts);
 
   const result = await validateModelAndContextWindow(
     modelCache,
@@ -207,14 +176,6 @@ export async function validateLlmConfigModelFields(
   if (result.error !== undefined) {
     sendError(res, ErrorResponses.validationError(result.error));
     return false;
-  }
-
-  // Vision capability gate. Only runs when a model is actually being SET — create
-  // always sets one; update only when `body.model` is present — so a context-only
-  // edit doesn't re-validate an unchanged model. Text configs never reach here;
-  // vision models are also text-capable.
-  if (effectiveKind === 'vision' && body.model !== undefined) {
-    return ensureVisionCapableModel(res, modelCache, body.model);
   }
 
   return true;

--- a/services/api-gateway/src/utils/stampResolvedConfig.ts
+++ b/services/api-gateway/src/utils/stampResolvedConfig.ts
@@ -23,7 +23,7 @@ const logger = createLogger('ConfigStamping');
  *
  * The TEXT model (`personality.model`) and the VISION model (`personality.visionModel`,
  * the carrier `selectVisionModel` reads at priority 1) resolve through INDEPENDENT
- * cascades — `LlmConfigResolver` (kind='text') and `VisionConfigResolver` (kind='vision').
+ * cascades — `LlmConfigResolver` (text slot) and `VisionConfigResolver` (vision slot).
  * Vision stamps regardless of the text source, since it's its own config axis.
  *
  * `provider` is intentionally NOT stamped: `ResolvedLlmConfig` carries no provider

--- a/services/bot-client/src/commands/preset/api.ts
+++ b/services/bot-client/src/commands/preset/api.ts
@@ -6,7 +6,6 @@
  * operations go through `ownerClient`.
  */
 
-import { type ConfigKind } from '@tzurot/common-types/constants/ai';
 import {
   type LlmConfigDetail,
   type LlmConfigUpdateInput,
@@ -123,8 +122,6 @@ export async function createPreset(
     model: string;
     provider?: string;
     description?: string;
-    /** Preset kind (text|vision); the server defaults to text when omitted. */
-    kind?: ConfigKind;
     /**
      * When true, server bumps the `(Copy N)` suffix on name collision
      * instead of returning NAME_COLLISION. Used by the clone flow so a

--- a/services/bot-client/src/commands/preset/autocomplete.test.ts
+++ b/services/bot-client/src/commands/preset/autocomplete.test.ts
@@ -68,7 +68,7 @@ describe('handleAutocomplete', () => {
         getFocused: vi.fn(),
         getSubcommand: vi.fn().mockReturnValue('delete'),
         getSubcommandGroup: vi.fn().mockReturnValue(null),
-        // The `kind` option is optional; null → handler defaults to 'text'.
+        // A `slot` option may exist on the command; the picker never scopes by it.
         getString: vi.fn().mockReturnValue(null),
       },
       respond: vi.fn().mockResolvedValue(undefined),
@@ -110,8 +110,8 @@ describe('handleAutocomplete', () => {
 
       await handleAutocomplete(mockInteraction);
 
-      // Capability-agnostic: fetch ALL kinds (slot-independent picker).
-      expect(stub.listUserLlmConfigs).toHaveBeenCalledWith({ kind: 'all' });
+      // Capability-agnostic: fetch the full unscoped list (slot-independent picker).
+      expect(stub.listUserLlmConfigs).toHaveBeenCalledWith();
       // Should only return owned presets
       expect(mockInteraction.respond).toHaveBeenCalledWith([
         { name: 'My Preset · claude-sonnet-4', value: '00000000-0000-4000-8000-0000000000c1' },
@@ -142,8 +142,8 @@ describe('handleAutocomplete', () => {
 
       await handleAutocomplete(mockInteraction);
 
-      // Always fetches all kinds (no slot-scoping); the vision row is 👁-badged.
-      expect(stub.listUserLlmConfigs).toHaveBeenCalledWith({ kind: 'all' });
+      // Always fetches the full unscoped list (no slot-scoping); the vision row is 👁-badged.
+      expect(stub.listUserLlmConfigs).toHaveBeenCalledWith();
       const respondCall = vi.mocked(mockInteraction.respond).mock.calls[0][0] as {
         name: string;
         value: string;
@@ -428,20 +428,20 @@ describe('handleAutocomplete', () => {
       expect(respondCall).toEqual([expect.objectContaining({ value: 'g-free' })]);
     });
 
-    it('fetches the global list capability-agnostically (kind=all), ignoring the slot option', async () => {
+    it('fetches the full unscoped global list, ignoring the slot option', async () => {
       vi.mocked(mockInteraction.options.getFocused).mockReturnValue({
         name: 'preset',
         value: '',
       } as unknown as string);
       vi.mocked(mockInteraction.options.getSubcommand).mockReturnValue('set-default');
-      // Even with a vision slot chosen, the picker fetches BOTH kinds and badges
-      // by capability — so the suggestion list doesn't reorder when the slot changes.
+      // Even with a vision slot chosen, the picker fetches the full unscoped list
+      // and badges by capability — so it doesn't reorder when the slot changes.
       vi.mocked(mockInteraction.options.getString).mockReturnValue('vision');
       ownerStub.listGlobalLlmConfigs.mockResolvedValue(cacheableFixture);
 
       await handleAutocomplete(mockInteraction);
 
-      expect(ownerStub.listGlobalLlmConfigs).toHaveBeenCalledWith({ kind: 'all' });
+      expect(ownerStub.listGlobalLlmConfigs).toHaveBeenCalledWith();
     });
 
     it('caches the global config set — a second keystroke hits the cache', async () => {

--- a/services/bot-client/src/commands/preset/autocomplete.ts
+++ b/services/bot-client/src/commands/preset/autocomplete.ts
@@ -180,7 +180,7 @@ async function handlePresetAutocomplete(
   // Capability-agnostic: fetch ALL presets, 👁-badged by capability below. The
   // slot is chosen on the command option, so the picker stays slot-independent.
   const { userClient } = clientsFor(interaction);
-  const result = await userClient.listUserLlmConfigs({ kind: 'all' });
+  const result = await userClient.listUserLlmConfigs();
 
   if (!result.ok) {
     logger.warn({ userId, error: result.error }, 'Failed to fetch presets');
@@ -204,7 +204,7 @@ async function handlePresetAutocomplete(
       value: c.id,
       // Show scope badge for edit command only (global vs owned)
       scopeBadge: subcommand === 'edit' ? getPresetScopeBadge(c.isGlobal) : undefined,
-      // 👁 for vision-capable models (capability, not config kind)
+      // 👁 for vision-capable models (capability-driven)
       statusBadges: c.supportsVision ? [AUTOCOMPLETE_BADGES.VISION] : undefined,
       // Show model short name as metadata
       metadata: shortModelName(c.model),
@@ -243,7 +243,7 @@ async function handleVisionModelAutocomplete(
 }
 
 /** Single cache key — the picker is capability-agnostic, so the full global
- *  config set (both slots) is cached under one key, not one entry per kind. */
+ *  config set (both slots) is cached under one key, not one entry per slot. */
 const GLOBAL_CONFIG_CACHE_KEY = 'global-configs:all';
 
 /**
@@ -251,7 +251,7 @@ const GLOBAL_CONFIG_CACHE_KEY = 'global-configs:all';
  * the call site. Capability-agnostic, mirroring the user picker: the slot is
  * chosen on the command's `slot` option, so the suggestion list stays
  * slot-independent and doesn't reorder when the owner switches slots. The
- * gateway LIST route accepts the `all` sentinel via parseConfigKindQueryAllowAll.
+ * suggestion list is the full unscoped set.
  */
 async function fetchGlobalConfigs(
   interaction: AutocompleteInteraction
@@ -265,7 +265,7 @@ async function fetchGlobalConfigs(
   }
 
   const { ownerClient } = clientsFor(interaction);
-  const result = await ownerClient.listGlobalLlmConfigs({ kind: 'all' });
+  const result = await ownerClient.listGlobalLlmConfigs();
 
   if (!result.ok) {
     return null;

--- a/services/bot-client/src/commands/preset/browse.test.ts
+++ b/services/bot-client/src/commands/preset/browse.test.ts
@@ -85,18 +85,15 @@ function configurePresets(
   hasWallet = true,
   visionPresets: Parameters<typeof mockListLlmConfigsResponse>[0] = []
 ): void {
-  // Browse now issues ONE all-kinds call and filters by capability client-side,
+  // Browse issues ONE unscoped call and filters by capability client-side,
   // so the mock just returns the full set. The 👁 badge + capability filter key
-  // off `supportsVision` — text rows are text-only, vision rows vision-capable;
-  // the `kind` tag is retained only for callers that still group by it.
+  // off `supportsVision` — text rows are text-only, vision rows vision-capable.
   const textRows = (presets ?? []).map(p => ({
     ...p,
-    kind: 'text' as const,
     supportsVision: false,
   }));
   const visionRows = visionPresets.map(p => ({
     ...p,
-    kind: 'vision' as const,
     supportsVision: true,
   }));
   stub.listUserLlmConfigs.mockResolvedValue(

--- a/services/bot-client/src/commands/preset/browse.ts
+++ b/services/bot-client/src/commands/preset/browse.ts
@@ -5,7 +5,7 @@
  * Replaces the old /preset list with enhanced functionality:
  * - Optional query parameter for searching by name/model
  * - Optional scope filter (all, global, mine, free)
- * - Optional kind filter (all, text, vision) — orthogonal to scope
+ * - Optional capability filter (all, text, vision) — orthogonal to scope
  * - Pagination support for larger lists
  */
 
@@ -125,7 +125,7 @@ function buildPresetDescription(preset: LlmConfigSummary, isGuestMode: boolean):
 
 /**
  * Apply the scope + capability axes + search query — all client-side. Browse
- * fetches every config (`kind: 'all'`); capability ('vision'/'text') is a
+ * fetches every config; capability ('vision'/'text') is a
  * model-`supportsVision` check applied here, not a fetch-scope parameter.
  */
 function filterPresets(
@@ -301,13 +301,13 @@ function buildBrowsePage(
 }
 
 /**
- * Fetches all of the user's presets (`kind: 'all'`) in a single call; the
+ * Fetches all of the user's presets in a single call; the
  * capability axis (text/vision) is applied client-side from each row's
- * `supportsVision`, since configs no longer carry a `kind` to fetch-scope by.
+ * `supportsVision` — capability is a model property, not a fetch-scope parameter.
  * Returns null on fetch failure.
  */
 async function fetchPresets(userClient: UserClient): Promise<LlmConfigSummary[] | null> {
-  const result = await userClient.listUserLlmConfigs({ kind: 'all' });
+  const result = await userClient.listUserLlmConfigs();
   if (!result.ok) {
     logger.warn({ status: result.status }, 'Failed to fetch presets');
     return null;

--- a/services/bot-client/src/commands/preset/browseFilter.ts
+++ b/services/bot-client/src/commands/preset/browseFilter.ts
@@ -9,20 +9,20 @@
  * the encoding; everything else passes the composite around verbatim.
  */
 
-import { CONFIG_KINDS } from '@tzurot/common-types/constants/ai';
+import { MODEL_SLOTS } from '@tzurot/common-types/constants/ai';
 
 // Single source of truth for each axis: the runtime arrays drive the types
 // (`typeof[number]`) AND the customId factory's validation, so the two can't
 // drift. Adding a scope/capability value here updates both with no second edit.
 const PRESET_SCOPE_FILTERS = ['all', 'global', 'mine', 'free'] as const;
-// The capability values reuse CONFIG_KINDS ('text'/'vision') as the encoded
+// The capability values reuse MODEL_SLOTS ('text'/'vision') as the encoded
 // tokens so the customId format is unchanged from when this axis was a config
-// `kind` — but they're now interpreted as a model-capability filter, not a kind.
-const PRESET_CAPABILITY_FILTERS = ['all', ...CONFIG_KINDS] as const;
+// `kind` — but they're now interpreted as a model-capability filter.
+const PRESET_CAPABILITY_FILTERS = ['all', ...MODEL_SLOTS] as const;
 
 /** Scope axis of the browse filter (independent of capability). */
 export type PresetScopeFilter = (typeof PRESET_SCOPE_FILTERS)[number];
-/** Capability axis — `'all'` means no capability filter (derived from CONFIG_KINDS). */
+/** Capability axis — `'all'` means no capability filter (derived from MODEL_SLOTS). */
 export type PresetCapabilityFilter = (typeof PRESET_CAPABILITY_FILTERS)[number];
 
 /**

--- a/services/bot-client/src/commands/preset/create.ts
+++ b/services/bot-client/src/commands/preset/create.ts
@@ -45,7 +45,7 @@ const logger = createLogger('preset-create');
  * because this subcommand uses deferralMode: 'modal'.
  */
 export async function handleCreate(context: ModalCommandContext): Promise<void> {
-  // No kind/slot: a preset's vision-capability is derived from its model
+  // No slot option: a preset's vision-capability is derived from its model
   // (`supportsVision`), not chosen at creation. The vision SLOT is picked later
   // when the preset is assigned (set/set-default/global).
   const modal = new ModalBuilder()

--- a/services/bot-client/src/commands/preset/global/free-default.test.ts
+++ b/services/bot-client/src/commands/preset/global/free-default.test.ts
@@ -40,7 +40,7 @@ describe('Preset Global Set Free Default Handler', () => {
   const mockEditReply = vi.fn();
   let stub: OwnerClientStub;
 
-  const createMockContext = (configId: string, kind?: string) =>
+  const createMockContext = (configId: string, slot?: string) =>
     ({
       user: { id: 'owner-123' },
       interaction: {
@@ -49,7 +49,7 @@ describe('Preset Global Set Free Default Handler', () => {
           // The `slot` option is optional (getString('slot', false)); everything
           // else (the `preset` option) resolves to the configId under test.
           getString: vi.fn((name: string, _required?: boolean) =>
-            name === 'slot' ? (kind ?? null) : configId
+            name === 'slot' ? (slot ?? null) : configId
           ),
         },
       },
@@ -75,9 +75,9 @@ describe('Preset Global Set Free Default Handler', () => {
 
       await handleGlobalSetFreeDefault(context);
 
-      // No kind option → defaults to text (the admin route gates by kind).
+      // No slot option → defaults to text (the admin route gates by slot).
       expect(stub.setGlobalLlmConfigFreeDefault).toHaveBeenCalledWith('config-456', {
-        kind: 'text',
+        slot: 'text',
       });
 
       expect(mockEditReply).toHaveBeenCalledWith({
@@ -92,7 +92,7 @@ describe('Preset Global Set Free Default Handler', () => {
       expect(embedData.description).toContain('Guest users');
     });
 
-    it('should pass kind=vision through to the promote call', async () => {
+    it('should pass slot=vision through to the promote call', async () => {
       const context = createMockContext('vision-config', 'vision');
       stub.setGlobalLlmConfigFreeDefault.mockResolvedValue(
         makeOk({ success: true, configName: 'Gemini Vision Free' })
@@ -101,7 +101,7 @@ describe('Preset Global Set Free Default Handler', () => {
       await handleGlobalSetFreeDefault(context);
 
       expect(stub.setGlobalLlmConfigFreeDefault).toHaveBeenCalledWith('vision-config', {
-        kind: 'vision',
+        slot: 'vision',
       });
     });
 

--- a/services/bot-client/src/commands/preset/global/free-default.ts
+++ b/services/bot-client/src/commands/preset/global/free-default.ts
@@ -4,9 +4,8 @@
  * Sets a global config as the free tier default for guest users (owner only)
  */
 
-import { DEFAULT_CONFIG_KIND } from '@tzurot/common-types/constants/ai';
+import { DEFAULT_MODEL_SLOT, toModelSlot } from '@tzurot/common-types/constants/ai';
 import { presetGlobalFreeDefaultOptions } from '@tzurot/common-types/generated/commandOptions';
-import { toConfigKind } from '@tzurot/common-types/services/LlmConfigMapper';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
 import { handleGlobalPresetUpdate } from './globalPresetHelpers.js';
 
@@ -16,10 +15,10 @@ import { handleGlobalPresetUpdate } from './globalPresetHelpers.js';
 export async function handleGlobalSetFreeDefault(context: DeferredCommandContext): Promise<void> {
   const options = presetGlobalFreeDefaultOptions(context.interaction);
   const configId = options.preset();
-  const kind = toConfigKind(options.slot() ?? DEFAULT_CONFIG_KIND);
+  const slot = toModelSlot(options.slot() ?? DEFAULT_MODEL_SLOT);
 
   await handleGlobalPresetUpdate(context, configId, {
-    promote: (ownerClient, id) => ownerClient.setGlobalLlmConfigFreeDefault(id, { kind }),
+    promote: (ownerClient, id) => ownerClient.setGlobalLlmConfigFreeDefault(id, { slot }),
     embedTitle: 'Free Tier Default Preset Updated',
     embedDescription: (configName: string) =>
       `**${configName}** is now the free tier default preset.\n\n` +

--- a/services/bot-client/src/commands/preset/global/set-default.test.ts
+++ b/services/bot-client/src/commands/preset/global/set-default.test.ts
@@ -40,7 +40,7 @@ describe('Preset Global Set Default Handler', () => {
   const mockEditReply = vi.fn();
   let stub: OwnerClientStub;
 
-  const createMockContext = (configId: string, kind?: string) =>
+  const createMockContext = (configId: string, slot?: string) =>
     ({
       user: { id: 'owner-123' },
       interaction: {
@@ -49,7 +49,7 @@ describe('Preset Global Set Default Handler', () => {
           // The `slot` option is optional (getString('slot', false)); everything
           // else (the `preset` option) resolves to the configId under test.
           getString: vi.fn((name: string, _required?: boolean) =>
-            name === 'slot' ? (kind ?? null) : configId
+            name === 'slot' ? (slot ?? null) : configId
           ),
         },
       },
@@ -75,8 +75,8 @@ describe('Preset Global Set Default Handler', () => {
 
       await handleGlobalSetDefault(context);
 
-      // No kind option → defaults to text (the admin route gates by kind).
-      expect(stub.setGlobalLlmConfigDefault).toHaveBeenCalledWith('config-123', { kind: 'text' });
+      // No slot option → defaults to text (the admin route gates by slot).
+      expect(stub.setGlobalLlmConfigDefault).toHaveBeenCalledWith('config-123', { slot: 'text' });
 
       expect(mockEditReply).toHaveBeenCalledWith({
         embeds: expect.arrayContaining([expect.any(EmbedBuilder)]),
@@ -90,7 +90,7 @@ describe('Preset Global Set Default Handler', () => {
       expect(embedData.description).toContain('system default');
     });
 
-    it('should pass kind=vision through to the promote call', async () => {
+    it('should pass slot=vision through to the promote call', async () => {
       const context = createMockContext('vision-config', 'vision');
       stub.setGlobalLlmConfigDefault.mockResolvedValue(
         makeOk({ success: true, configName: 'GPT-4 Vision' })
@@ -99,7 +99,7 @@ describe('Preset Global Set Default Handler', () => {
       await handleGlobalSetDefault(context);
 
       expect(stub.setGlobalLlmConfigDefault).toHaveBeenCalledWith('vision-config', {
-        kind: 'vision',
+        slot: 'vision',
       });
     });
 

--- a/services/bot-client/src/commands/preset/global/set-default.ts
+++ b/services/bot-client/src/commands/preset/global/set-default.ts
@@ -4,9 +4,8 @@
  * Sets a global config as the system default (owner only)
  */
 
-import { DEFAULT_CONFIG_KIND } from '@tzurot/common-types/constants/ai';
+import { DEFAULT_MODEL_SLOT, toModelSlot } from '@tzurot/common-types/constants/ai';
 import { presetGlobalDefaultOptions } from '@tzurot/common-types/generated/commandOptions';
-import { toConfigKind } from '@tzurot/common-types/services/LlmConfigMapper';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
 import { handleGlobalPresetUpdate } from './globalPresetHelpers.js';
 
@@ -16,12 +15,12 @@ import { handleGlobalPresetUpdate } from './globalPresetHelpers.js';
 export async function handleGlobalSetDefault(context: DeferredCommandContext): Promise<void> {
   const options = presetGlobalDefaultOptions(context.interaction);
   const configId = options.preset();
-  // Admin set-default gates by slot (requireKind); pass it so a vision preset
+  // Admin set-default targets a slot; pass it so a vision preset
   // promotes to the vision default. Defaults Chat → existing usage unchanged.
-  const kind = toConfigKind(options.slot() ?? DEFAULT_CONFIG_KIND);
+  const slot = toModelSlot(options.slot() ?? DEFAULT_MODEL_SLOT);
 
   await handleGlobalPresetUpdate(context, configId, {
-    promote: (ownerClient, id) => ownerClient.setGlobalLlmConfigDefault(id, { kind }),
+    promote: (ownerClient, id) => ownerClient.setGlobalLlmConfigDefault(id, { slot }),
     embedTitle: 'System Default Preset Updated',
     embedDescription: (configName: string) =>
       `**${configName}** is now the system default preset.\n\n` +

--- a/services/bot-client/src/commands/preset/index.ts
+++ b/services/bot-client/src/commands/preset/index.ts
@@ -198,7 +198,7 @@ export default defineCommand({
         )
     )
     .addSubcommand(subcommand =>
-      // No kind/slot option: a preset's vision-capability is derived from its
+      // No slot option: a preset's vision-capability is derived from its
       // model (`supportsVision`), not chosen at creation. The vision SLOT is
       // picked later when the preset is assigned (set/set-default/global).
       subcommand.setName('create').setDescription('Create a new model preset')

--- a/services/bot-client/src/commands/settings/preset/autocomplete.test.ts
+++ b/services/bot-client/src/commands/settings/preset/autocomplete.test.ts
@@ -92,7 +92,7 @@ describe('handleAutocomplete', () => {
       options: {
         getFocused: vi.fn(),
         getSubcommand: vi.fn().mockReturnValue('set'),
-        // The `kind` option is optional; null → handler defaults to 'text'.
+        // A `slot` option may exist on the command; the picker never scopes by it.
         getString: vi.fn().mockReturnValue(null),
       },
       respond: vi.fn().mockResolvedValue(undefined),
@@ -301,8 +301,8 @@ describe('handleAutocomplete', () => {
 
       await handleAutocomplete(mockInteraction);
 
-      // Capability-agnostic: fetch ALL kinds (slot-independent picker).
-      expect(stub.listUserLlmConfigs).toHaveBeenCalledWith({ kind: 'all' });
+      // Capability-agnostic: fetch the full unscoped list (slot-independent picker).
+      expect(stub.listUserLlmConfigs).toHaveBeenCalledWith();
       expect(mockInteraction.respond).toHaveBeenCalledWith([
         {
           name: '🌐⭐ Claude Config · claude-sonnet-4',
@@ -335,8 +335,8 @@ describe('handleAutocomplete', () => {
 
       await handleAutocomplete(mockInteraction);
 
-      // Always fetches all kinds (no slot-scoping); the vision row is 👁-badged.
-      expect(stub.listUserLlmConfigs).toHaveBeenCalledWith({ kind: 'all' });
+      // Always fetches the full unscoped list (no slot-scoping); the vision row is 👁-badged.
+      expect(stub.listUserLlmConfigs).toHaveBeenCalledWith();
       const choices = vi.mocked(mockInteraction.respond).mock.calls[0][0] as {
         name: string;
         value: string;

--- a/services/bot-client/src/commands/settings/preset/autocomplete.ts
+++ b/services/bot-client/src/commands/settings/preset/autocomplete.ts
@@ -76,7 +76,7 @@ async function handlePresetAutocomplete(
   // so the suggestion list doesn't reorder when the user flips Chat ↔ Vision.
   const { userClient } = clientsFor(interaction);
   const [configResult, walletResult] = await Promise.all([
-    userClient.listUserLlmConfigs({ kind: 'all' }),
+    userClient.listUserLlmConfigs(),
     userClient.listWalletKeys(),
   ]);
 

--- a/services/bot-client/src/commands/settings/preset/browse.test.ts
+++ b/services/bot-client/src/commands/settings/preset/browse.test.ts
@@ -3,7 +3,7 @@
  *
  * The interaction logic lives in `utils/overrideBrowse.ts` (tested there);
  * this verifies the preset config is wired to the right client calls and
- * customId prefix — including the single all-kinds fetch + kind-carrying clear
+ * customId prefix — including the single all-slots fetch + slot-carrying clear
  * (a character can have both a text and a vision override).
  */
 
@@ -43,14 +43,14 @@ type OverrideRow = {
   personalityId: string;
   personalityName: string;
   configName: string | null;
-  kind?: 'text' | 'vision';
+  slot?: 'text' | 'vision';
   supportsVision?: boolean;
 };
 
 /**
- * The preset config issues ONE all-kinds `listModelOverrides` call; the gateway
- * emits a row per non-null FK, each tagged with its `kind`. The mock returns the
- * given rows (each carrying its own kind) regardless of the call args.
+ * The preset config issues ONE all-slots `listModelOverrides` call; the gateway
+ * emits a row per non-null FK, each tagged with its `slot`. The mock returns the
+ * given rows (each carrying its own slot) regardless of the call args.
  */
 function mockAllOverrides(rows: OverrideRow[]): void {
   stub.listModelOverrides.mockResolvedValue(makeOk(mockListModelOverridesResponse(rows)));
@@ -71,14 +71,14 @@ describe('isPresetOverrideInteraction', () => {
 });
 
 describe('handlePresetBrowse', () => {
-  it('lists overrides of both kinds and renders them (vision badged)', async () => {
+  it('lists overrides of both slots and renders them (vision badged)', async () => {
     mockAllOverrides([
-      { personalityId: 'p1', personalityName: 'Lilith', configName: 'Fast', kind: 'text' },
+      { personalityId: 'p1', personalityName: 'Lilith', configName: 'Fast', slot: 'text' },
       {
         personalityId: 'p2',
         personalityName: 'Aria',
         configName: 'GPT-4o',
-        kind: 'vision',
+        slot: 'vision',
         supportsVision: true,
       },
     ]);
@@ -91,9 +91,9 @@ describe('handlePresetBrowse', () => {
 
     await handlePresetBrowse(context);
 
-    // Both kinds come back from ONE all-kinds call.
+    // Both slots come back from ONE all-slots call.
     expect(stub.listModelOverrides).toHaveBeenCalledTimes(1);
-    expect(stub.listModelOverrides).toHaveBeenCalledWith({ kind: 'all' });
+    expect(stub.listModelOverrides).toHaveBeenCalledWith({ slot: 'all' });
     const arg = editReply.mock.calls[0][0] as { embeds: EmbedBuilder[] };
     const description = arg.embeds[0].toJSON().description ?? '';
     expect(description).toContain('Lilith');
@@ -101,7 +101,7 @@ describe('handlePresetBrowse', () => {
     expect(description).toContain('👁️'); // the vision override is badged
   });
 
-  it('renders the load-failure message when the all-kinds list call fails', async () => {
+  it('renders the load-failure message when the all-slots list call fails', async () => {
     // The list closure returns null on a failed gateway call → the shared
     // browser surfaces the load-failure notice (covers the closure error path).
     stub.listModelOverrides.mockResolvedValue(makeErr(500, 'Server error'));
@@ -114,16 +114,16 @@ describe('handlePresetBrowse', () => {
 
     await handlePresetBrowse(context);
 
-    expect(stub.listModelOverrides).toHaveBeenCalledWith({ kind: 'all' });
+    expect(stub.listModelOverrides).toHaveBeenCalledWith({ slot: 'all' });
     const arg = editReply.mock.calls[0][0] as { content?: string };
     expect(arg.content).toContain('Failed to load overrides');
   });
 });
 
 describe('handlePresetBrowseSelect', () => {
-  it('routes a kind-encoded selection to the shared select handler (shows confirm)', async () => {
+  it('routes a slot-encoded selection to the shared select handler (shows confirm)', async () => {
     mockAllOverrides([
-      { personalityId: 'p1', personalityName: 'Lilith', configName: 'Fast', kind: 'text' },
+      { personalityId: 'p1', personalityName: 'Lilith', configName: 'Fast', slot: 'text' },
     ]);
     const editReply = vi.fn();
     const interaction = {
@@ -142,7 +142,7 @@ describe('handlePresetBrowseSelect', () => {
 });
 
 describe('handlePresetBrowseButton', () => {
-  it('clears the model override of the carried kind on confirm', async () => {
+  it('clears the model override of the carried slot on confirm', async () => {
     stub.deleteModelOverride.mockResolvedValue(makeOk({ deleted: true }));
     mockAllOverrides([]);
     const interaction = {
@@ -154,6 +154,6 @@ describe('handlePresetBrowseButton', () => {
 
     await handlePresetBrowseButton(interaction);
 
-    expect(stub.deleteModelOverride).toHaveBeenCalledWith('p1', { kind: 'vision' });
+    expect(stub.deleteModelOverride).toHaveBeenCalledWith('p1', { slot: 'vision' });
   });
 });

--- a/services/bot-client/src/commands/settings/preset/browse.ts
+++ b/services/bot-client/src/commands/settings/preset/browse.ts
@@ -33,20 +33,20 @@ const presetOverrideConfig: OverrideBrowseConfig = {
   clearCommandHint: '/settings preset clear',
   selectPlaceholder: 'Select an override to clear…',
   logger,
-  // One all-kinds call: the gateway emits a row per non-null FK, each tagged with
-  // its kind, so a character with both a text + a vision override surfaces as two
-  // rows that badge and clear independently. (`kind` is nullable on the summary to
-  // mirror `configId`, but all-kinds rows always carry it — coerce null → undefined.)
+  // One all-slots call: the gateway emits a row per non-null FK, each tagged with
+  // its slot, so a character with both a text + a vision override surfaces as two
+  // rows that badge and clear independently. (`slot` is nullable on the summary to
+  // mirror `configId`, but all-slots rows always carry it — coerce null → undefined.)
   list: async userClient => {
-    const result = await userClient.listModelOverrides({ kind: 'all' });
+    const result = await userClient.listModelOverrides({ slot: 'all' });
     if (!result.ok) {
       logger.warn({ status: result.status }, 'Failed to list preset overrides');
       return null;
     }
-    return result.data.overrides.map(o => ({ ...o, kind: o.kind ?? undefined }));
+    return result.data.overrides.map(o => ({ ...o, slot: o.slot ?? undefined }));
   },
-  delete: (userClient, personalityId, kind) =>
-    userClient.deleteModelOverride(personalityId, { kind }),
+  delete: (userClient, personalityId, slot) =>
+    userClient.deleteModelOverride(personalityId, { slot }),
 };
 
 const presetOverrideIds = createOverrideBrowseCustomIds(PRESET_OVERRIDE_PREFIX);

--- a/services/bot-client/src/commands/settings/preset/clear-default.test.ts
+++ b/services/bot-client/src/commands/settings/preset/clear-default.test.ts
@@ -44,13 +44,13 @@ describe('handleClearDefault', () => {
     mockEditReply.mockResolvedValue(undefined);
   });
 
-  function createMockContext(kind?: string) {
+  function createMockContext(slot?: string) {
     return {
       user: { id: '123456789', username: 'testuser' },
       interaction: {
-        // The `kind` option is optional (null → handler defaults to text).
+        // The `slot` option is optional (null → handler clears both slots).
         options: {
-          getString: (_name: string, _required?: boolean) => kind ?? null,
+          getString: (_name: string, _required?: boolean) => slot ?? null,
         },
       } as never,
       editReply: mockEditReply,
@@ -62,15 +62,15 @@ describe('handleClearDefault', () => {
 
     await handleClearDefault(createMockContext());
 
-    expect(stub.clearDefaultModelConfig).toHaveBeenCalledWith({ kind: 'all' });
+    expect(stub.clearDefaultModelConfig).toHaveBeenCalledWith({ slot: 'all' });
   });
 
-  it('should clear the vision default when kind=vision', async () => {
+  it('should clear the vision default when slot=vision', async () => {
     stub.clearDefaultModelConfig.mockResolvedValue(makeOk(mockClearDefaultConfigResponse()));
 
     await handleClearDefault(createMockContext('vision'));
 
-    expect(stub.clearDefaultModelConfig).toHaveBeenCalledWith({ kind: 'vision' });
+    expect(stub.clearDefaultModelConfig).toHaveBeenCalledWith({ slot: 'vision' });
     // The vision path completes through to the success embed, same as text.
     expect(mockEditReply).toHaveBeenCalledWith({
       embeds: [

--- a/services/bot-client/src/commands/settings/preset/clear-default.ts
+++ b/services/bot-client/src/commands/settings/preset/clear-default.ts
@@ -5,9 +5,9 @@
  */
 
 import { EmbedBuilder } from 'discord.js';
+import { toModelSlot } from '@tzurot/common-types/constants/ai';
 import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
 import { settingsPresetClearDefaultOptions } from '@tzurot/common-types/generated/commandOptions';
-import { toConfigKind } from '@tzurot/common-types/services/LlmConfigMapper';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
 import { clientsFor } from '../../../utils/gatewayClients.js';
@@ -22,12 +22,12 @@ export async function handleClearDefault(context: DeferredCommandContext): Promi
   // No slot → clear BOTH defaults (`all`); an explicit slot clears just that one.
   // The vision default is a separate FK from the text default, so a no-slot clear
   // has to target both or it silently leaves the other in place.
-  const slot = settingsPresetClearDefaultOptions(context.interaction).slot();
-  const kind = slot !== null ? toConfigKind(slot) : 'all';
+  const slotOption = settingsPresetClearDefaultOptions(context.interaction).slot();
+  const slot = slotOption !== null ? toModelSlot(slotOption) : 'all';
 
   try {
     const { userClient } = clientsFor(context.interaction);
-    const result = await userClient.clearDefaultModelConfig({ kind });
+    const result = await userClient.clearDefaultModelConfig({ slot });
 
     if (!result.ok) {
       logger.warn({ userId, status: result.status }, 'Failed to clear default');
@@ -42,16 +42,16 @@ export async function handleClearDefault(context: DeferredCommandContext): Promi
     // free default exists for it. Per-character overrides are unaffected and
     // surface in the closing sentence.
     const SLOT_LABELS = { text: 'Chat', vision: 'Vision' } as const;
-    const fallbackLines = (['text', 'vision'] as const).flatMap(slot => {
-      const fallback = result.data.newEffectiveDefaults[slot];
+    const fallbackLines = (['text', 'vision'] as const).flatMap(slotKey => {
+      const fallback = result.data.newEffectiveDefaults[slotKey];
       // Slot absent from the map → it wasn't cleared, so emit no line for it.
       if (fallback === undefined) {
         return [];
       }
       return [
         fallback !== null
-          ? `**${SLOT_LABELS[slot]}** → falling back to system default: \`${fallback.name}\`.`
-          : `**${SLOT_LABELS[slot]}** → no system default is configured; the bot will use its built-in fallback.`,
+          ? `**${SLOT_LABELS[slotKey]}** → falling back to system default: \`${fallback.name}\`.`
+          : `**${SLOT_LABELS[slotKey]}** → no system default is configured; the bot will use its built-in fallback.`,
       ];
     });
 
@@ -75,7 +75,7 @@ export async function handleClearDefault(context: DeferredCommandContext): Promi
     logger.info(
       {
         userId,
-        kind,
+        slot,
         newDefaults: {
           text: result.data.newEffectiveDefaults.text?.name ?? null,
           vision: result.data.newEffectiveDefaults.vision?.name ?? null,

--- a/services/bot-client/src/commands/settings/preset/clear.test.ts
+++ b/services/bot-client/src/commands/settings/preset/clear.test.ts
@@ -68,15 +68,15 @@ describe('Preset Clear Handler', () => {
     );
   });
 
-  function createMockContext(personalityId: string, kind?: string) {
+  function createMockContext(personalityId: string, slot?: string) {
     return {
       user: { id: 'user-123', username: 'testuser' },
       interaction: {
         options: {
-          // The `slot` option is optional (null → handler defaults to text);
+          // The `slot` option is optional (null → handler clears both slots);
           // every other option (`character`) resolves to the personalityId.
           getString: (name: string, _required?: boolean) =>
-            name === 'slot' ? (kind ?? null) : personalityId,
+            name === 'slot' ? (slot ?? null) : personalityId,
         },
       },
       editReply: mockEditReply,
@@ -91,7 +91,7 @@ describe('Preset Clear Handler', () => {
 
       // No slot → clear both slots (the gateway's `all` sentinel), so a vision
       // override isn't silently left behind.
-      expect(stub.deleteModelOverride).toHaveBeenCalledWith('personality-123', { kind: 'all' });
+      expect(stub.deleteModelOverride).toHaveBeenCalledWith('personality-123', { slot: 'all' });
 
       expect(mockCreateSuccessEmbed).toHaveBeenCalledWith(
         '🔄 Preset Override Removed',
@@ -103,12 +103,12 @@ describe('Preset Clear Handler', () => {
       });
     });
 
-    it('clears the vision override when kind=vision', async () => {
+    it('clears the vision override when slot=vision', async () => {
       stub.deleteModelOverride.mockResolvedValue(makeOk({ deleted: true }));
 
       await handleClear(createMockContext('personality-123', 'vision'));
 
-      expect(stub.deleteModelOverride).toHaveBeenCalledWith('personality-123', { kind: 'vision' });
+      expect(stub.deleteModelOverride).toHaveBeenCalledWith('personality-123', { slot: 'vision' });
       // The vision path completes through to the success embed, same as text.
       expect(mockCreateSuccessEmbed).toHaveBeenCalledWith(
         '🔄 Preset Override Removed',

--- a/services/bot-client/src/commands/settings/preset/clear.ts
+++ b/services/bot-client/src/commands/settings/preset/clear.ts
@@ -3,8 +3,8 @@
  * Handles /settings preset clear subcommand
  */
 
+import { toModelSlot } from '@tzurot/common-types/constants/ai';
 import { settingsPresetClearOptions } from '@tzurot/common-types/generated/commandOptions';
-import { toConfigKind } from '@tzurot/common-types/services/LlmConfigMapper';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
 import {
@@ -26,8 +26,8 @@ export async function handleClear(context: DeferredCommandContext): Promise<void
   // No slot → clear BOTH slots (`all`); an explicit slot clears just that one.
   // A vision override is a separate FK from the text override, so a no-slot
   // clear has to target both or it silently leaves the other in place.
-  const slot = options.slot();
-  const kind = slot !== null ? toConfigKind(slot) : 'all';
+  const slotOption = options.slot();
+  const slot = slotOption !== null ? toModelSlot(slotOption) : 'all';
 
   if (isAutocompleteErrorSentinel(personalityId)) {
     await context.editReply({ content: AUTOCOMPLETE_UNAVAILABLE_MESSAGE });
@@ -36,7 +36,7 @@ export async function handleClear(context: DeferredCommandContext): Promise<void
 
   try {
     const { userClient } = clientsFor(context.interaction);
-    const result = await userClient.deleteModelOverride(personalityId, { kind });
+    const result = await userClient.deleteModelOverride(personalityId, { slot });
 
     if (!result.ok) {
       logger.warn({ userId, status: result.status, personalityId }, 'Failed to clear override');
@@ -59,7 +59,7 @@ export async function handleClear(context: DeferredCommandContext): Promise<void
 
     await context.editReply({ embeds: [embed] });
 
-    logger.info({ userId, personalityId, kind, wasSet }, 'Cleared override');
+    logger.info({ userId, personalityId, slot, wasSet }, 'Cleared override');
   } catch (error) {
     logger.error({ err: error, userId, command: 'Preset Clear' }, 'Error');
     await context.editReply({ content: '❌ An error occurred. Please try again later.' });

--- a/services/bot-client/src/commands/settings/preset/handlers.test.ts
+++ b/services/bot-client/src/commands/settings/preset/handlers.test.ts
@@ -122,7 +122,7 @@ describe('Preset Command Handlers', () => {
       // No slot option → defaults to the text (chat) slot.
       expect(stub.setModelOverride).toHaveBeenCalledWith(
         { personalityId: PERSONALITY_ID_1, configId: CONFIG_ID_1 },
-        { kind: 'text' }
+        { slot: 'text' }
       );
       expect(mockEditReply).toHaveBeenCalledWith({
         embeds: [
@@ -135,7 +135,7 @@ describe('Preset Command Handlers', () => {
       });
     });
 
-    it('routes the chosen slot to the gateway when kind:vision is selected', async () => {
+    it('routes the chosen slot to the gateway when slot:vision is selected', async () => {
       // Mirrors set.test.ts's vision-slot case at the shared-handler level: the
       // slot option must reach setModelOverride, or a vision override silently
       // lands in the text slot.
@@ -166,7 +166,7 @@ describe('Preset Command Handlers', () => {
 
       expect(stub.setModelOverride).toHaveBeenCalledWith(
         { personalityId: PERSONALITY_ID_1, configId: CONFIG_ID_1 },
-        { kind: 'vision' }
+        { slot: 'vision' }
       );
     });
 
@@ -206,7 +206,7 @@ describe('Preset Command Handlers', () => {
       await handleClear(createMockContext());
 
       // No slot → clears both slots (the gateway's `all` sentinel).
-      expect(stub.deleteModelOverride).toHaveBeenCalledWith(PERSONALITY_ID_1, { kind: 'all' });
+      expect(stub.deleteModelOverride).toHaveBeenCalledWith(PERSONALITY_ID_1, { slot: 'all' });
       expect(mockCreateSuccessEmbed).toHaveBeenCalledWith(
         '🔄 Preset Override Removed',
         'The character will now use its default preset.'

--- a/services/bot-client/src/commands/settings/preset/set-default.test.ts
+++ b/services/bot-client/src/commands/settings/preset/set-default.test.ts
@@ -91,11 +91,11 @@ describe('handleSetDefault', () => {
     // No slot option → defaults to the text (chat) default.
     expect(stub.setDefaultModelConfig).toHaveBeenCalledWith(
       { configId: '00000000-0000-4000-8000-000000000456' },
-      { kind: 'text' }
+      { slot: 'text' }
     );
   });
 
-  it('sends the vision slot when kind:vision is chosen (the vision-default fix)', async () => {
+  it('sends the vision slot when slot:vision is chosen (the vision-default fix)', async () => {
     mockNonGuestUserApis('00000000-0000-4000-8000-0000000000a1', 'Gemini Vision');
 
     await handleSetDefault(createMockContext('00000000-0000-4000-8000-0000000000a1', 'vision'));
@@ -104,7 +104,7 @@ describe('handleSetDefault', () => {
     // lands in the text slot (the bug this fix closes).
     expect(stub.setDefaultModelConfig).toHaveBeenCalledWith(
       { configId: '00000000-0000-4000-8000-0000000000a1' },
-      { kind: 'vision' }
+      { slot: 'vision' }
     );
     // The confirmation names the vision slot.
     expect(mockEditReply).toHaveBeenCalledWith({
@@ -224,7 +224,7 @@ describe('handleSetDefault', () => {
 
     expect(stub.setDefaultModelConfig).toHaveBeenCalledWith(
       { configId: '00000000-0000-4000-8000-000000000f00' },
-      { kind: 'text' }
+      { slot: 'text' }
     );
     expect(mockEditReply).toHaveBeenCalledWith({
       embeds: [

--- a/services/bot-client/src/commands/settings/preset/set-default.ts
+++ b/services/bot-client/src/commands/settings/preset/set-default.ts
@@ -5,10 +5,9 @@
  */
 
 import { EmbedBuilder } from 'discord.js';
-import { DEFAULT_CONFIG_KIND } from '@tzurot/common-types/constants/ai';
+import { DEFAULT_MODEL_SLOT, toModelSlot } from '@tzurot/common-types/constants/ai';
 import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
 import { settingsPresetSetDefaultOptions } from '@tzurot/common-types/generated/commandOptions';
-import { toConfigKind } from '@tzurot/common-types/services/LlmConfigMapper';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
 import { clientsFor } from '../../../utils/gatewayClients.js';
@@ -26,7 +25,7 @@ export async function handleSetDefault(context: DeferredCommandContext): Promise
   // The slot (text = chat default, or vision) decides which default FK the value
   // writes; the gateway capability-gates the vision slot. Without sending it a
   // vision default silently lands in the text slot — mirror clear-default.
-  const kind = toConfigKind(options.slot() ?? DEFAULT_CONFIG_KIND);
+  const slot = toModelSlot(options.slot() ?? DEFAULT_MODEL_SLOT);
 
   if (await handleUnlockModelsUpsell(context, configId, userId)) {
     return;
@@ -40,10 +39,10 @@ export async function handleSetDefault(context: DeferredCommandContext): Promise
     }
     const { reason } = outcome;
 
-    const result = await userClient.setDefaultModelConfig({ configId }, { kind });
+    const result = await userClient.setDefaultModelConfig({ configId }, { slot });
 
     if (!result.ok) {
-      logger.warn({ userId, status: result.status, configId, kind }, 'Failed to set default');
+      logger.warn({ userId, status: result.status, configId, slot }, 'Failed to set default');
       await context.editReply({ content: `❌ Failed to set default: ${result.error}` });
       return;
     }
@@ -54,7 +53,7 @@ export async function handleSetDefault(context: DeferredCommandContext): Promise
       .setTitle('✅ Default Preset Set')
       .setColor(DISCORD_COLORS.SUCCESS)
       .setDescription(
-        `Your default ${kind === 'vision' ? 'vision (image)' : 'chat'} preset is now ` +
+        `Your default ${slot === 'vision' ? 'vision (image)' : 'chat'} preset is now ` +
           `**${data.default.configName}**.\n\n` +
           'This will be used for all characters unless you have a specific override.'
       )
@@ -64,7 +63,7 @@ export async function handleSetDefault(context: DeferredCommandContext): Promise
     await context.editReply({ embeds: [embed] });
 
     logger.info(
-      { userId, configId, configName: data.default.configName, kind, reason },
+      { userId, configId, configName: data.default.configName, slot, reason },
       'Set default config'
     );
   } catch (error) {

--- a/services/bot-client/src/commands/settings/preset/set.test.ts
+++ b/services/bot-client/src/commands/settings/preset/set.test.ts
@@ -104,7 +104,7 @@ describe('Me Preset Set Handler', () => {
       // No slot option → defaults to the text (chat) slot.
       expect(stub.setModelOverride).toHaveBeenCalledWith(
         { personalityId: 'personality-1', configId: 'config-1' },
-        { kind: 'text' }
+        { slot: 'text' }
       );
 
       const embedCall = mockEditReply.mock.calls[0][0] as { embeds: EmbedBuilder[] };
@@ -121,7 +121,7 @@ describe('Me Preset Set Handler', () => {
       expect(stub.listUserLlmConfigs).not.toHaveBeenCalled();
     });
 
-    it('sends the vision slot when kind:vision is chosen (the vision-set fix)', async () => {
+    it('sends the vision slot when slot:vision is chosen (the vision-set fix)', async () => {
       stub.listWalletKeys.mockResolvedValue(
         makeOk({ keys: [{ provider: 'openrouter', isActive: true }] })
       );
@@ -142,7 +142,7 @@ describe('Me Preset Set Handler', () => {
       // lands in the text slot (the bug this fix closes).
       expect(stub.setModelOverride).toHaveBeenCalledWith(
         { personalityId: 'personality-1', configId: 'vision-config' },
-        { kind: 'vision' }
+        { slot: 'vision' }
       );
 
       // The confirmation names the vision slot.
@@ -207,7 +207,7 @@ describe('Me Preset Set Handler', () => {
 
       expect(stub.setModelOverride).toHaveBeenCalledWith(
         { personalityId: 'personality-1', configId: 'free-config' },
-        { kind: 'text' }
+        { slot: 'text' }
       );
     });
 

--- a/services/bot-client/src/commands/settings/preset/set.ts
+++ b/services/bot-client/src/commands/settings/preset/set.ts
@@ -4,10 +4,9 @@
  */
 
 import { EmbedBuilder } from 'discord.js';
-import { DEFAULT_CONFIG_KIND } from '@tzurot/common-types/constants/ai';
+import { DEFAULT_MODEL_SLOT, toModelSlot } from '@tzurot/common-types/constants/ai';
 import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
 import { settingsPresetSetOptions } from '@tzurot/common-types/generated/commandOptions';
-import { toConfigKind } from '@tzurot/common-types/services/LlmConfigMapper';
 import { createLogger } from '@tzurot/common-types/utils/logger';
 import type { DeferredCommandContext } from '../../../utils/commandContext/types.js';
 import {
@@ -30,7 +29,7 @@ export async function handleSet(context: DeferredCommandContext): Promise<void> 
   // The slot (text = chat default, or vision) decides which FK the override
   // writes; the gateway capability-gates the vision slot. Without sending it a
   // vision override silently lands in the text slot — mirror clear, which sends it.
-  const kind = toConfigKind(options.slot() ?? DEFAULT_CONFIG_KIND);
+  const slot = toModelSlot(options.slot() ?? DEFAULT_MODEL_SLOT);
 
   if (isAutocompleteErrorSentinel(personalityId)) {
     await context.editReply({ content: AUTOCOMPLETE_UNAVAILABLE_MESSAGE });
@@ -49,11 +48,11 @@ export async function handleSet(context: DeferredCommandContext): Promise<void> 
     }
     const { reason } = outcome;
 
-    const result = await userClient.setModelOverride({ personalityId, configId }, { kind });
+    const result = await userClient.setModelOverride({ personalityId, configId }, { slot });
 
     if (!result.ok) {
       logger.warn(
-        { userId, status: result.status, personalityId, configId, kind },
+        { userId, status: result.status, personalityId, configId, slot },
         'Failed to set override'
       );
       await context.editReply({ content: `❌ Failed to set preset: ${result.error}` });
@@ -67,7 +66,7 @@ export async function handleSet(context: DeferredCommandContext): Promise<void> 
       .setColor(DISCORD_COLORS.SUCCESS)
       .setDescription(
         `**${data.override.personalityName}** will now use the **${data.override.configName}** preset for ${
-          kind === 'vision' ? 'vision (image)' : 'chat'
+          slot === 'vision' ? 'vision (image)' : 'chat'
         } messages.`
       )
       .setFooter({ text: 'Use /settings preset clear to remove this override' })
@@ -82,7 +81,7 @@ export async function handleSet(context: DeferredCommandContext): Promise<void> 
         personalityName: data.override.personalityName,
         configId,
         configName: data.override.configName,
-        kind,
+        slot,
         reason,
       },
       'Set override'

--- a/services/bot-client/src/utils/overrideBrowse.test.ts
+++ b/services/bot-client/src/utils/overrideBrowse.test.ts
@@ -4,13 +4,13 @@
  * Covers the customId helpers, the view builder, and the three interaction
  * handlers (slash / select / button). The two consumers (preset + TTS) are
  * thin wrappers, so this is where the behaviour is exercised — including the
- * optional `kind` axis (preset overrides span text + vision; TTS has none).
+ * optional `slot` axis (preset overrides span text + vision; TTS has none).
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { type EmbedBuilder } from 'discord.js';
 import type { UserClient } from '@tzurot/clients';
-import type { ConfigKind } from '@tzurot/common-types/constants/ai';
+import type { ModelSlot } from '@tzurot/common-types/constants/ai';
 import { makeOk, makeErr } from '../test/gatewayClientStubs.js';
 import {
   type OverrideBrowseConfig,
@@ -23,8 +23,8 @@ import {
 } from './overrideBrowse.js';
 
 const stub = {
-  // list now returns `OverrideSummary[] | null` (null = fetch failed); the
-  // domain config owns the fetch strategy (preset issues two kind-scoped calls).
+  // list returns `OverrideSummary[] | null` (null = fetch failed); the
+  // domain config owns the fetch strategy.
   list: vi.fn(),
   delete: vi.fn(),
 };
@@ -46,7 +46,7 @@ function makeConfig(): OverrideBrowseConfig {
     selectPlaceholder: 'Pick one…',
     logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never,
     list: () => stub.list() as ReturnType<OverrideBrowseConfig['list']>,
-    delete: (_uc, id, kind) => stub.delete(id, kind) as ReturnType<OverrideBrowseConfig['delete']>,
+    delete: (_uc, id, slot) => stub.delete(id, slot) as ReturnType<OverrideBrowseConfig['delete']>,
   };
 }
 
@@ -54,10 +54,10 @@ function override(
   id: string,
   name: string,
   configName: string | null = 'Cfg',
-  kind?: ConfigKind,
+  slot?: ModelSlot,
   supportsVision?: boolean
 ): OverrideSummary {
-  return { personalityId: id, personalityName: name, configName, kind, supportsVision };
+  return { personalityId: id, personalityName: name, configName, slot, supportsVision };
 }
 
 beforeEach(() => {
@@ -75,7 +75,7 @@ describe('createOverrideBrowseCustomIds', () => {
     expect(ids.clear('p1')).toBe('test-override::clear::p1');
   });
 
-  it('appends kind as a 4th segment when present', () => {
+  it('appends slot as a 4th segment when present', () => {
     expect(ids.clear('p1', 'vision')).toBe('test-override::clear::p1::vision');
     expect(ids.clear('p1', 'text')).toBe('test-override::clear::p1::text');
   });
@@ -92,17 +92,17 @@ describe('createOverrideBrowseCustomIds', () => {
     expect(ids.parse('test-override::clear::p1')).toEqual({ action: 'clear', personalityId: 'p1' });
   });
 
-  it('parses the kind segment on a clear id', () => {
+  it('parses the slot segment on a clear id', () => {
     expect(ids.parse('test-override::clear::p1::vision')).toEqual({
       action: 'clear',
       personalityId: 'p1',
-      kind: 'vision',
+      slot: 'vision',
     });
-    // A non-kind 4th segment is ignored (kind left undefined).
+    // A non-slot 4th segment is ignored (slot left undefined).
     expect(ids.parse('test-override::clear::p1::bogus')).toEqual({
       action: 'clear',
       personalityId: 'p1',
-      kind: undefined,
+      slot: undefined,
     });
   });
 
@@ -138,12 +138,12 @@ describe('buildOverrideBrowseView', () => {
     };
     const menu = row.components[0];
     expect(menu.custom_id).toBe('test-override::select');
-    // No kind → bare personalityId values (kind-less domains unchanged).
+    // No slot → bare personalityId values (slot-less domains unchanged).
     expect(menu.options.map(o => o.value)).toEqual(['p1', 'p2']);
     expect(menu.options[0].label).toContain('Lilith');
   });
 
-  it('badges by model capability (supportsVision) and encodes kind in the select value', () => {
+  it('badges by model capability (supportsVision) and encodes slot in the select value', () => {
     const overrides = [
       override('p1', 'Lilith', 'Text Cfg', 'text', false),
       override('p1', 'Lilith', 'Vision Cfg', 'vision', true),
@@ -158,7 +158,7 @@ describe('buildOverrideBrowseView', () => {
       components: { options: { label: string; value: string }[] }[];
     };
     const menu = row.components[0];
-    // Same personality, two kinds → kind-encoded values disambiguate them.
+    // Same personality, two slots → slot-encoded values disambiguate them.
     expect(menu.options.map(o => o.value)).toEqual(['p1::text', 'p1::vision']);
     expect(menu.options[1].label).toContain('👁️');
     expect(menu.options[0].label).not.toContain('👁️');
@@ -166,7 +166,7 @@ describe('buildOverrideBrowseView', () => {
 
   it('badges from capability, not slot: a chat-slot override on a vision-capable model gets 👁️', () => {
     // The badge reflects the MODEL's capability, not which slot the override
-    // occupies — a chat-slot (kind:text) override whose model supports vision is
+    // occupies — a chat-slot (slot:text) override whose model supports vision is
     // still badged. This is the whole point of the capability-driven switch.
     const overrides = [override('p1', 'Lilith', 'Vision-capable chat model', 'text', true)];
     const { embeds, components } = buildOverrideBrowseView(makeConfig(), overrides);
@@ -254,7 +254,7 @@ describe('handleOverrideBrowseSelect', () => {
     expect(buttonIds).toEqual(['test-override::cancel', 'test-override::clear::p1']);
   });
 
-  it('disambiguates a kind-encoded select value and carries kind into the clear id', async () => {
+  it('disambiguates a slot-encoded select value and carries slot into the clear id', async () => {
     stub.list.mockResolvedValue([
       override('p1', 'Lilith', 'Text Cfg', 'text'),
       override('p1', 'Lilith', 'Vision Cfg', 'vision'),
@@ -317,13 +317,13 @@ describe('handleOverrideBrowseButton', () => {
     await handleOverrideBrowseButton(makeConfig(), buttonInteraction('test-override::clear::p1'));
 
     expect(deferUpdate).toHaveBeenCalled();
-    // No kind in the customId → kind passed through as undefined.
+    // No slot in the customId → slot passed through as undefined.
     expect(stub.delete).toHaveBeenCalledWith('p1', undefined);
     const arg = editReply.mock.calls[0][0] as { embeds: EmbedBuilder[] };
     expect(arg.embeds[0].toJSON().description).toContain('No overrides set');
   });
 
-  it('passes the kind through to delete when the clear id carries it', async () => {
+  it('passes the slot through to delete when the clear id carries it', async () => {
     stub.delete.mockResolvedValue(makeOk({ deleted: true }));
     stub.list.mockResolvedValue([]);
 

--- a/services/bot-client/src/utils/overrideBrowse.ts
+++ b/services/bot-client/src/utils/overrideBrowse.ts
@@ -28,7 +28,7 @@ import {
   type ButtonInteraction,
   type StringSelectMenuInteraction,
 } from 'discord.js';
-import { CONFIG_KINDS, type ConfigKind } from '@tzurot/common-types/constants/ai';
+import { MODEL_SLOTS, type ModelSlot } from '@tzurot/common-types/constants/ai';
 import { DISCORD_COLORS } from '@tzurot/common-types/constants/discord';
 import { type createLogger } from '@tzurot/common-types/utils/logger';
 import type { GatewayResult, UserClient } from '@tzurot/clients';
@@ -40,14 +40,14 @@ import { buildBrowseSelectMenu } from './browse/index.js';
 type Logger = ReturnType<typeof createLogger>;
 
 /**
- * Narrow a raw customId/select-value segment to a {@link ConfigKind}, or
- * `undefined` when the segment is absent or not a known kind. Checked against
- * `CONFIG_KINDS` rather than literal comparisons so a future third kind is
+ * Narrow a raw customId/select-value segment to a {@link ModelSlot}, or
+ * `undefined` when the segment is absent or not a known slot. Checked against
+ * `MODEL_SLOTS` rather than literal comparisons so a future third slot is
  * picked up automatically.
  */
-function narrowConfigKind(value: string | undefined): ConfigKind | undefined {
-  return value !== undefined && (CONFIG_KINDS as readonly string[]).includes(value)
-    ? (value as ConfigKind)
+function narrowModelSlot(value: string | undefined): ModelSlot | undefined {
+  return value !== undefined && (MODEL_SLOTS as readonly string[]).includes(value)
+    ? (value as ModelSlot)
     : undefined;
 }
 
@@ -60,14 +60,14 @@ export interface OverrideSummary {
   personalityName: string;
   configName: string | null;
   /**
-   * Config kind of this override (text | vision). Optional: domains without a
-   * kind axis (e.g. TTS overrides) omit it. It is the ROUTING identity carried
+   * Which model slot this override occupies (text | vision). Optional: domains without a
+   * slot axis (e.g. TTS overrides) omit it. It is the ROUTING identity carried
    * through select → clear so the right FK is cleared (a character can have BOTH
-   * a text and a vision override — so `(personalityId, kind)` is the unique key).
+   * a text and a vision override — so `(personalityId, slot)` is the unique key).
    * The 👁 badge is NOT derived from this — it reads `supportsVision`, so the
    * badge reflects the model's actual capability, not the slot label.
    */
-  kind?: ConfigKind;
+  slot?: ModelSlot;
   /**
    * Whether the override's config MODEL supports vision — capability-driven, from
    * the gateway's `ModelOverrideSummary.supportsVision`. Drives the 👁 badge.
@@ -102,19 +102,19 @@ export interface OverrideBrowseConfig {
   /** Domain logger (e.g. `settings-preset-browse`). */
   logger: Logger;
   /**
-   * Fetch the user's overrides. Returns the rows (optionally kind-tagged), or
+   * Fetch the user's overrides. Returns the rows (optionally slot-tagged), or
    * `null` if the fetch failed — domains that span multiple kinds (preset) issue
-   * one call per kind and merge here, so a single `GatewayResult` no longer fits.
+   * one call per slot and merge here, so a single `GatewayResult` no longer fits.
    */
   list: (userClient: UserClient) => Promise<OverrideSummary[] | null>;
   /**
-   * Clear one override by personality id (+ kind, for kind-aware domains — the
-   * gateway clears the matching FK; omitted ⇒ the route's default kind).
+   * Clear one override by personality id (+ slot, for slot-aware domains — the
+   * gateway clears the matching FK; omitted ⇒ the route's default slot).
    */
   delete: (
     userClient: UserClient,
     personalityId: string,
-    kind?: ConfigKind
+    slot?: ModelSlot
   ) => Promise<GatewayResult<unknown>>;
 }
 
@@ -143,23 +143,23 @@ function errorReply(content: string): { content: string; embeds: []; components:
 export function createOverrideBrowseCustomIds(prefix: string): {
   select: string;
   cancel: string;
-  clear: (personalityId: string, kind?: ConfigKind) => string;
+  clear: (personalityId: string, slot?: ModelSlot) => string;
   isOwn: (customId: string) => boolean;
   parse: (
     customId: string
-  ) => { action: 'select' | 'clear' | 'cancel'; personalityId?: string; kind?: ConfigKind } | null;
+  ) => { action: 'select' | 'clear' | 'cancel'; personalityId?: string; slot?: ModelSlot } | null;
 } {
   const select = `${prefix}${CUSTOM_ID_DELIMITER}select`;
   const cancel = `${prefix}${CUSTOM_ID_DELIMITER}cancel`;
   return {
     select,
     cancel,
-    // kind is appended as a 4th segment only for kind-aware domains; omitted for
+    // slot is appended as a 4th segment only for slot-aware domains; omitted for
     // the rest (TTS) so their customIds are byte-identical to before.
-    clear: (personalityId: string, kind?: ConfigKind) =>
-      kind === undefined
+    clear: (personalityId: string, slot?: ModelSlot) =>
+      slot === undefined
         ? `${prefix}${CUSTOM_ID_DELIMITER}clear${CUSTOM_ID_DELIMITER}${personalityId}`
-        : `${prefix}${CUSTOM_ID_DELIMITER}clear${CUSTOM_ID_DELIMITER}${personalityId}${CUSTOM_ID_DELIMITER}${kind}`,
+        : `${prefix}${CUSTOM_ID_DELIMITER}clear${CUSTOM_ID_DELIMITER}${personalityId}${CUSTOM_ID_DELIMITER}${slot}`,
     isOwn: (customId: string) => customId.startsWith(`${prefix}${CUSTOM_ID_DELIMITER}`),
     parse: customId => {
       if (!customId.startsWith(`${prefix}${CUSTOM_ID_DELIMITER}`)) {
@@ -171,7 +171,7 @@ export function createOverrideBrowseCustomIds(prefix: string): {
         return { action };
       }
       if (action === 'clear' && parts[2] !== undefined && parts[2] !== '') {
-        return { action: 'clear', personalityId: parts[2], kind: narrowConfigKind(parts[3]) };
+        return { action: 'clear', personalityId: parts[2], slot: narrowModelSlot(parts[3]) };
       }
       return null;
     },
@@ -217,14 +217,14 @@ export function buildOverrideBrowseView(
     startIndex: 0,
     formatItem: o => ({
       // The 👁 badge reads model capability (`supportsVision`); the value encodes
-      // `kind` so `(personalityId, kind)` stays the unique clear-key (a character
-      // can have both a text and a vision override). kind-less domains (TTS) get
+      // `slot` so `(personalityId, slot)` stays the unique clear-key (a character
+      // can have both a text and a vision override). slot-less domains (TTS) get
       // no badge and keep the bare id.
       label: o.supportsVision === true ? `👁️ ${o.personalityName}` : o.personalityName,
       value:
-        o.kind === undefined
+        o.slot === undefined
           ? o.personalityId
-          : `${o.personalityId}${CUSTOM_ID_DELIMITER}${o.kind}`,
+          : `${o.personalityId}${CUSTOM_ID_DELIMITER}${o.slot}`,
       description: `→ ${o.configName ?? 'Unknown'}`,
     }),
   });
@@ -263,12 +263,12 @@ export async function handleOverrideBrowseSelect(
 ): Promise<void> {
   await interaction.deferUpdate();
 
-  // The select value is `personalityId` or `personalityId::kind` (kind-aware
-  // domains) — split so `(personalityId, kind)` identifies the exact override.
+  // The select value is `personalityId` or `personalityId::slot` (slot-aware
+  // domains) — split so `(personalityId, slot)` identifies the exact override.
   // Safe because personalityId is always a UUID (never contains `::`), so the
-  // split is unambiguous — the first segment is the id, the second (if any) kind.
-  const [personalityId, kindStr] = interaction.values[0].split(CUSTOM_ID_DELIMITER);
-  const kind = narrowConfigKind(kindStr);
+  // split is unambiguous — the first segment is the id, the second (if any) slot.
+  const [personalityId, slotStr] = interaction.values[0].split(CUSTOM_ID_DELIMITER);
+  const slot = narrowModelSlot(slotStr);
   const userId = interaction.user.id;
   try {
     const { userClient } = clientsFor(interaction);
@@ -279,7 +279,7 @@ export async function handleOverrideBrowseSelect(
       return;
     }
 
-    const override = overrides.find(o => o.personalityId === personalityId && o.kind === kind);
+    const override = overrides.find(o => o.personalityId === personalityId && o.slot === slot);
     if (override === undefined) {
       // Already cleared elsewhere — just refresh the list.
       const view = buildOverrideBrowseView(config, overrides);
@@ -302,7 +302,7 @@ export async function handleOverrideBrowseSelect(
         .setLabel('Cancel')
         .setStyle(ButtonStyle.Secondary),
       new ButtonBuilder()
-        .setCustomId(ids.clear(override.personalityId, override.kind))
+        .setCustomId(ids.clear(override.personalityId, override.slot))
         .setLabel('Clear')
         .setStyle(ButtonStyle.Danger)
         .setEmoji('🗑️')
@@ -335,7 +335,7 @@ export async function handleOverrideBrowseButton(
     const { userClient } = clientsFor(interaction);
 
     if (parsed.action === 'clear' && parsed.personalityId !== undefined) {
-      const deleteResult = await config.delete(userClient, parsed.personalityId, parsed.kind);
+      const deleteResult = await config.delete(userClient, parsed.personalityId, parsed.slot);
       if (!deleteResult.ok) {
         config.logger.warn({ userId, status: deleteResult.status }, 'Failed to clear override');
         await interaction.editReply(
@@ -344,7 +344,7 @@ export async function handleOverrideBrowseButton(
         return;
       }
       config.logger.info(
-        { userId, personalityId: parsed.personalityId, kind: parsed.kind },
+        { userId, personalityId: parsed.personalityId, slot: parsed.slot },
         'Cleared override'
       );
     }


### PR DESCRIPTION
## Summary

The final slice of the LLM legacy-column retirement theme: retires the dormant `kind` column end-to-end and collapses global preset names to a single namespace (owner-approved 2026-07-05).

**Pre-build verification** (this is the design pass the theme's scope correction demanded):
- Every reader of the column was traced: interactive pickers already pass unscoped lists; `getById(expectedKind)` had zero callers; the create-side kind option is unreachable from Discord; the runtime cascade reads the AdminSettings vision pointer, never the column.
- Dev data queried live: zero non-text rows, zero cross-kind global name collisions — even the vision-default pointer targets a text-kind row.
- Vision-ness was already capability-gated at slot assignment (`ensureVisionCapableModel`); that gate is untouched and remains THE gate.

## Changes

- **Destructive migration** `drop_llm_config_kind_column`: drops the column + `llm_configs_kind_idx`, rebuilds `llm_configs_global_name_unique` as `UNIQUE (name) WHERE is_global` (its original pre-vision shape). Explicit DROP INDEX statements for the PGLite harvester; the CREATE doubles as a fail-loud collision guard at premigrate time.
- **Namespace collapse**: name-collision checks (service + clone-suffix walker) lose their kind scoping; owner scope was already single-namespace at the DB level.
- **Slot vocabulary rename**: `ConfigKind` → `ModelSlot`, `toConfigKind` → `toModelSlot` (now in `constants/ai`), wire `?kind=` → `?slot=` on override/default endpoints, `ModelOverrideSummary.kind` → `slot`. Post-drop, grep-for-kind returns zero llm-config hits.
- **Dead machinery removed**: `list()` kind filter (the two default-'text' callers — guest-mode validation and `/models` 📌 pins — become strictly more correct), `getById` expectedKind gate, admin `requireKind` edit guard, create/edit-side kind-gated vision validation.
- **Riders**: stale `kind='vision'`/`isDefault` archaeology comments cleaned (config-resolver, identity, constants); component test now guards the single-namespace partial index against real Postgres, including the partial WHERE clause.

## User-visible semantics

Essentially nothing changes in Discord — pickers, browse, slots, and defaults already ignored kind. Global preset names are now unique across the whole global set; guest-mode validation and `/models` pins see every preset.

## Release gate

Migration is destructive → ships via `pnpm ops release:premigrate --allow-destructive` alongside the queued Phase A + memory-scoping migrations. Prod data check (same audit script as dev) queued as a pre-premigrate step; even skipped, the unique-index CREATE fails loudly before anything deploys.

## Testing

- `pnpm test` (25/25 tasks), `pnpm test:component` (456 passed — includes new DB-level partial-index guards), `pnpm quality` green.
- Dev DB migrated locally; PGLite schema regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)