### PR TITLE
fix: carry proactive quota-swap metadata onto the failure footer

### DIFF
--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/GenerationStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/GenerationStep.test.ts
@@ -593,6 +593,66 @@ describe('GenerationStep', () => {
       );
     });
 
+    describe('quotaFallback metadata assembly (the announce-carrier seam)', () => {
+      const proactiveSwap = {
+        fromModel: 'configured/original',
+        toModel: 'fallback/model',
+        category: ApiErrorCategory.QUOTA_EXCEEDED,
+        mode: 'proactive',
+      } as const;
+
+      it('success path: a proactive swap from AuthStep rides result metadata', async () => {
+        vi.mocked(mockRAGService.generateResponse).mockResolvedValue({
+          content: 'ok',
+          modelUsed: 'fallback/model',
+        } as RAGResponse);
+
+        const result = await step.process({
+          job: createMockJob(),
+          startTime: Date.now(),
+          config: baseConfig,
+          auth: { ...baseAuth, quotaFallback: proactiveSwap },
+          preparedContext: basePreparedContext,
+        });
+
+        expect(result.result?.success).toBe(true);
+        expect(result.result?.metadata?.quotaFallback).toEqual(proactiveSwap);
+      });
+
+      it('failure path: a proactive swap still rides the ERROR metadata (never silent — the failed attempt ran the fallback model)', async () => {
+        vi.mocked(mockRAGService.generateResponse).mockRejectedValue(
+          new Error('fresh HTTP error on the fallback model')
+        );
+
+        const result = await step.process({
+          job: createMockJob(),
+          startTime: Date.now(),
+          config: baseConfig,
+          auth: { ...baseAuth, quotaFallback: proactiveSwap },
+          preparedContext: basePreparedContext,
+        });
+
+        expect(result.result?.success).toBe(false);
+        // The footer must be able to explain why modelUsed is the fallback.
+        expect(result.result?.metadata?.quotaFallback).toEqual(proactiveSwap);
+      });
+
+      it('failure path without any swap: quotaFallback stays absent', async () => {
+        vi.mocked(mockRAGService.generateResponse).mockRejectedValue(new Error('plain failure'));
+
+        const result = await step.process({
+          job: createMockJob(),
+          startTime: Date.now(),
+          config: baseConfig,
+          auth: baseAuth,
+          preparedContext: basePreparedContext,
+        });
+
+        expect(result.result?.success).toBe(false);
+        expect(result.result?.metadata?.quotaFallback).toBeUndefined();
+      });
+    });
+
     describe('RetryError unwrapping', () => {
       it('should unwrap RetryError to classify underlying API error', async () => {
         // Create an underlying authentication error

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/GenerationStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/GenerationStep.ts
@@ -492,6 +492,12 @@ export class GenerationStep implements IPipelineStep {
         configSource,
         provider,
         isGuestMode,
+        // The proactive swap (if any) took effect for this failed attempt —
+        // effectivePersonality is already the fallback model, and the error
+        // footer must explain why. A failed REACTIVE retarget is not carried
+        // (no reply came from its target); its story rides the
+        // fallback-failure summary the composer already folds in.
+        quotaFallback: auth.quotaFallback,
       });
     }
   }

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/generationFailureResult.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/generationFailureResult.ts
@@ -41,6 +41,15 @@ export interface GenerationFailureOptions {
   configSource: ReadyConfig['configSource'];
   provider: ReadyAuth['provider'];
   isGuestMode: boolean;
+  /**
+   * A quota retarget that TOOK EFFECT for the failed attempt (the proactive
+   * swap from AuthStep — `effectivePersonality`/`modelUsed` is already the
+   * fallback model, and without this field the error footer can't explain
+   * why). A FAILED reactive retarget is deliberately NOT carried here: no
+   * reply came from its target, so a "from → to" line would misdescribe —
+   * its story rides the fallback-failure text summary instead.
+   */
+  quotaFallback?: ReadyAuth['quotaFallback'];
 }
 
 /**
@@ -62,6 +71,7 @@ export function composeGenerationFailureResult(
     configSource,
     provider,
     isGuestMode,
+    quotaFallback,
   } = options;
   const { job, startTime } = context;
   const { requestId, personality } = job.data;
@@ -118,6 +128,9 @@ export function composeGenerationFailureResult(
         // The failed fallback attempt (if any) rides along so the error
         // footer renders the full route chain, not just the primary.
         fallbackProviderAttempted: getAttemptedFallbackProvider(error),
+        // A proactive quota swap that took effect before the failure — the
+        // footer must explain why modelUsed is the fallback (never silent).
+        quotaFallback,
         configSource,
         isGuestMode,
         showModelFooter: context.configOverrides?.showModelFooter,


### PR DESCRIPTION
## Summary

The beta.150 release review's one finding (owner call: merge the release, fix-forward): `composeGenerationFailureResult` dropped `quotaFallback`, so a proactive retarget followed by a fresh failure on the fallback model produced an error footer showing the fallback model with no swap explanation — the one branch that contradicted the feature's "never silent" invariant.

## Changes

- `GenerationFailureOptions.quotaFallback` — the proactive swap (which took effect for the failed attempt) now rides failure metadata; the footer can explain why `modelUsed` is the fallback.
- **Deliberate semantics**: a FAILED reactive retarget is NOT carried — no reply came from its target, so a `from → to` line would misdescribe; its story stays on the fallback-failure text summary the composer already folds in (documented on the field).
- The GenerationStep announce-carrier seam tests the review flagged as absent: success-with-swap, failure-with-swap, failure-without-swap.

## Verification

`pnpm --filter @tzurot/ai-worker` suites green (47 GenerationStep tests), full `pnpm test` 25/25, `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)