### PR TITLE
refactor: extract CloneCacheKernel from the voice-provider pair

### DIFF
--- a/backlog/cold/themes/adjacent-cpd-follow-up-campaigns.md
+++ b/backlog/cold/themes/adjacent-cpd-follow-up-campaigns.md
@@ -4,7 +4,7 @@ _Focus: four distinct DRY-extraction campaigns that the api-gateway CRUD-config 
 
 The campaign-close audit at `docs/reference/CPD_CAMPAIGN_AUDIT.md` classifies the remaining post-filter clones into four buckets. Three of those buckets are out-of-scope-by-design (deferred to future campaigns); one is in-file local-helper work. Picking these up individually:
 
-1. **🟣 Service-layer parallel cleanup** (~24 lines / 2 clones)
+1. ~~**🟣 Service-layer parallel cleanup**~~ — **OBSOLETE 2026-07-06 (verified, not done)**: the kind-column retirement (#1499/#1501) restructured LlmConfigService enough that raw jscpd now finds ZERO clones between the pair; the parallel method names remain but the implementations diverged structurally (ModelSlot-parameterized defaults vs slotless TTS pointers, checkNameExists vs resolveNonCollidingName). The council question answered itself: the divergences ARE structural. No extraction. (original scope: ~24 lines / 2 clones)
    - `services/api-gateway/src/services/LlmConfigService.ts` ↔ `TtsConfigService.ts`
    - Sibling service implementations with shared structure (CRUD methods, scope-aware lookups, cache invalidation, error classes)
    - **Lowest blast radius** of the four. The helpers from PR #1039-1041 are at the ROUTE layer; this campaign would be the analogous extraction one level deeper. Some helpers may apply directly (`checkNameExists` is already parameterized).
@@ -22,7 +22,7 @@ The campaign-close audit at `docs/reference/CPD_CAMPAIGN_AUDIT.md` classifies th
    - **Largest remaining cluster** by lines, but most architecturally different from what was just done.
    - Council pass should focus on: which command groupings genuinely share helper-extractable shape? `character/*` siblings probably yes; `character/truncationWarning` ↔ `persona/truncationWarning` looks ripe.
 
-4. **🟣 ai-worker service-pattern campaign** (~34 lines / 2 clones for voice-provider siblings, plus internal in `KeyValidationService`, `ElevenLabsClient`)
+4. ✅ **🟣 ai-worker service-pattern campaign** — **SHIPPED 2026-07-06** (council pass: composed `CloneCacheKernel` over BaseTtsProvider inheritance — the failure classifiers have near-opposite polarity per provider and are load-bearing divergence; the three-cache state machine (positive/negative/inflight + finally-cleanup) is the identical-invariant kernel that must stay in sync. Exactly 2 callbacks (work + classifyFailure); Mistral's eviction mutex stays a provider lifecycle concern. Both provider suites passed UNCHANGED post-extraction; pair clones now 0. Internal `KeyValidationService`/`ElevenLabsClient` self-clones remain item-5 material.)
    - `services/ai-worker/src/services/voice/ElevenLabsVoiceService.ts` ↔ `voice/providers/MistralTtsProvider.ts`
    - Voice provider abstraction was deliberately additive during the TTS Phase 1+3 work — each provider implements `TtsProvider` independently. Cross-provider duplication has accumulated.
    - Council pass should focus on: is the `TtsProvider` interface incomplete? Should there be a `BaseTtsProvider` with shared concerns (cost telemetry, fallback wiring) and provider-specific subclasses for inference?
@@ -31,7 +31,7 @@ The campaign-close audit at `docs/reference/CPD_CAMPAIGN_AUDIT.md` classifies th
 
 5. **🔵 In-file local-helper extraction sweep** — 10 file pairs from the audit are SAME-file internal clones (`user/history.ts` self, `user/memorySingle.ts` self, `SettingsDashboardHandler` self, `ElevenLabsClient` self, etc., totaling ~339 lines). These are repeated guards/loops within single handlers that local-helper extraction would clean up. Per-file work, not a campaign — surface for opportunistic cleanup when next touching each file.
 
-**Sequencing**: Item 1 (service-layer) has the lowest blast radius and most immediate adjacency to what we just shipped — natural first pick. Item 2 (override-routes) is gated on a council design pass for the cascade-helper kernel shape. Item 3 (bot-client) is the largest but most architecturally distinct — would benefit from its own multi-PR shape. Item 4 (ai-worker voice providers) is the smallest and could be a single PR.
+**Sequencing**: Item 1 obsolete, item 4 shipped (2026-07-06). Item 2 (override-routes) is gated on a council design pass for the cascade-helper kernel shape. Item 3 (bot-client) is the largest but most architecturally distinct — would benefit from its own multi-PR shape. Item 4 (ai-worker voice providers) is the smallest and could be a single PR.
 
 **Promote when**: capacity for another DRY-extraction campaign exists, OR opportunistically when next touching the relevant code. Each item gets its own council pass before plan-mode per the project's "consult council before major refactors" rule.
 

--- a/services/ai-worker/src/services/voice/CloneCacheKernel.test.ts
+++ b/services/ai-worker/src/services/voice/CloneCacheKernel.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { CloneCacheKernel } from './CloneCacheKernel.js';
+
+describe('CloneCacheKernel', () => {
+  let kernel: CloneCacheKernel;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    kernel = new CloneCacheKernel({
+      positiveTtlMs: 30 * 60 * 1000,
+      negativeTtlMs: 5 * 60 * 1000,
+      maxSize: 10,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const neverCache = (): null => null;
+  const alwaysCache = (_error: unknown, reason: string): string => reason;
+
+  it('positive hit returns without invoking work', async () => {
+    const work = vi.fn().mockResolvedValue('voice-1');
+    await kernel.resolve({
+      cacheKey: 'k',
+      describe: 'clone "a"',
+      work,
+      classifyFailure: neverCache,
+    });
+
+    const again = vi.fn();
+    const result = await kernel.resolve({
+      cacheKey: 'k',
+      describe: 'clone "a"',
+      work: again,
+      classifyFailure: neverCache,
+    });
+
+    expect(result).toBe('voice-1');
+    expect(again).not.toHaveBeenCalled();
+  });
+
+  it('negative hit throws the describe-prefixed cached reason without invoking work', async () => {
+    const failing = vi.fn().mockRejectedValue(new Error('quota exceeded'));
+    await expect(
+      kernel.resolve({
+        cacheKey: 'k',
+        describe: 'clone "a"',
+        work: failing,
+        classifyFailure: alwaysCache,
+      })
+    ).rejects.toThrow('quota exceeded');
+
+    const again = vi.fn();
+    await expect(
+      kernel.resolve({
+        cacheKey: 'k',
+        describe: 'clone "a"',
+        work: again,
+        classifyFailure: neverCache,
+      })
+    ).rejects.toThrow('clone "a" recently failed: quota exceeded');
+    expect(again).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates concurrent resolves — work runs exactly once', async () => {
+    let release: (value: string) => void = () => undefined;
+    const work = vi.fn().mockImplementation(
+      () =>
+        new Promise<string>(resolve => {
+          release = resolve;
+        })
+    );
+
+    const first = kernel.resolve({
+      cacheKey: 'k',
+      describe: 'd',
+      work,
+      classifyFailure: neverCache,
+    });
+    const second = kernel.resolve({
+      cacheKey: 'k',
+      describe: 'd',
+      work,
+      classifyFailure: neverCache,
+    });
+    release('voice-9');
+
+    await expect(first).resolves.toBe('voice-9');
+    await expect(second).resolves.toBe('voice-9');
+    expect(work).toHaveBeenCalledTimes(1);
+  });
+
+  it('classifier returning null propagates the raw error and caches nothing', async () => {
+    const original = new Error('rate limited');
+    const work = vi.fn().mockRejectedValue(original);
+
+    await expect(
+      kernel.resolve({ cacheKey: 'k', describe: 'd', work, classifyFailure: neverCache })
+    ).rejects.toBe(original);
+
+    // No negative entry: the next attempt re-invokes work.
+    const retry = vi.fn().mockResolvedValue('voice-2');
+    await expect(
+      kernel.resolve({ cacheKey: 'k', describe: 'd', work: retry, classifyFailure: neverCache })
+    ).resolves.toBe('voice-2');
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it('classifier receives the error and the derived reason string', async () => {
+    const original = new Error('boom');
+    const classify = vi.fn().mockReturnValue(null);
+    const promise = kernel.resolve({
+      cacheKey: 'k',
+      describe: 'd',
+      work: vi.fn().mockRejectedValue(original),
+      classifyFailure: classify,
+    });
+    const assertion = expect(promise).rejects.toBe(original);
+    await assertion;
+
+    expect(classify).toHaveBeenCalledWith(original, 'boom');
+  });
+
+  it('clears inflight after rejection — the dedup map never wedges', async () => {
+    await expect(
+      kernel.resolve({
+        cacheKey: 'k',
+        describe: 'd',
+        work: vi.fn().mockRejectedValue(new Error('x')),
+        classifyFailure: neverCache,
+      })
+    ).rejects.toThrow('x');
+
+    expect(kernel.hasInflight('k')).toBe(false);
+  });
+
+  it('invalidate drops both records; deleteNegative drops only the failure', async () => {
+    await kernel.resolve({
+      cacheKey: 'good',
+      describe: 'd',
+      work: vi.fn().mockResolvedValue('voice-1'),
+      classifyFailure: neverCache,
+    });
+    await expect(
+      kernel.resolve({
+        cacheKey: 'bad',
+        describe: 'clone "bad"',
+        work: vi.fn().mockRejectedValue(new Error('nope')),
+        classifyFailure: alwaysCache,
+      })
+    ).rejects.toThrow('nope');
+
+    kernel.invalidate('good');
+    expect(kernel.getCached('good')).toBeNull();
+
+    kernel.deleteNegative('bad');
+    const retry = vi.fn().mockResolvedValue('voice-3');
+    await expect(
+      kernel.resolve({ cacheKey: 'bad', describe: 'd', work: retry, classifyFailure: neverCache })
+    ).resolves.toBe('voice-3');
+  });
+
+  it('has + getCached + clear expose the positive record for eviction support', async () => {
+    await kernel.resolve({
+      cacheKey: 'k',
+      describe: 'd',
+      work: vi.fn().mockResolvedValue('voice-7'),
+      classifyFailure: neverCache,
+    });
+    expect(kernel.has('k')).toBe(true);
+    expect(kernel.getCached('k')).toBe('voice-7');
+
+    kernel.clear();
+    expect(kernel.has('k')).toBe(false);
+  });
+
+  it('derives a reason string from a non-Error rejection', async () => {
+    const classify = vi.fn().mockReturnValue(null);
+    const promise = kernel.resolve({
+      cacheKey: 'k',
+      describe: 'd',
+      work: vi.fn().mockRejectedValue('raw string failure'),
+      classifyFailure: classify,
+    });
+    const assertion = expect(promise).rejects.toBe('raw string failure');
+    await assertion;
+
+    expect(classify).toHaveBeenCalledWith('raw string failure', 'raw string failure');
+  });
+});

--- a/services/ai-worker/src/services/voice/CloneCacheKernel.ts
+++ b/services/ai-worker/src/services/voice/CloneCacheKernel.ts
@@ -1,0 +1,141 @@
+/**
+ * CloneCacheKernel — the shared clone-on-demand cache state machine for
+ * voice providers.
+ *
+ * Every auto-cloning TTS provider needs the same three-cache interaction:
+ * a positive TTL cache of cloned voice ids, a negative TTL cache of recent
+ * failure reasons, and an inflight map deduplicating concurrent clone
+ * attempts. The interaction is a miniature state machine with real bug
+ * surface (a missed `.finally` permanently wedges dedup; negative-caching a
+ * transient error locks a user out for the TTL) — so the kernel lives in ONE
+ * place and providers keep only what genuinely diverges: the clone work
+ * itself and the failure-classification predicate (which encodes each
+ * provider's API semantics and stays with the provider by design — see the
+ * 2-callback ceiling rule in `.claude/rules/02-code-standards.md`).
+ *
+ * Lifecycle concerns stay out: Mistral's eviction mutex serializes WHEN
+ * `resolve` is called; the kernel neither knows nor cares.
+ */
+
+import { TTLCache } from '@tzurot/common-types/utils/TTLCache';
+
+export interface CloneCacheKernelOptions {
+  /** TTL for successful clone entries. */
+  positiveTtlMs: number;
+  /** TTL for negative (failure-reason) entries. */
+  negativeTtlMs: number;
+  /** Max entries per cache (LRU eviction). */
+  maxSize: number;
+}
+
+export interface CloneResolveArgs {
+  /** Cache key — typically `${slug}:${apiKeyDigest}`. */
+  cacheKey: string;
+  /**
+   * Human-readable subject for the negative-hit error message, e.g.
+   * `ElevenLabs voice clone for "my-slug"` — the kernel appends
+   * `recently failed: <reason>`. A plain string, deliberately not a
+   * callback (the 2-callback budget is spent on work + classifyFailure).
+   */
+  describe: string;
+  /** Provider-specific clone flow; resolves to the final voice id. */
+  work: () => Promise<string>;
+  /**
+   * Failure classifier — the provider owns the semantics entirely
+   * (including any structured logging as a side effect). Return the reason
+   * string to negative-cache, or null to let the error propagate uncached.
+   */
+  classifyFailure: (error: unknown, reason: string) => string | null;
+}
+
+export class CloneCacheKernel {
+  private readonly positive: TTLCache<string>;
+  private readonly negative: TTLCache<string>;
+  private readonly inflight = new Map<string, Promise<string>>();
+
+  constructor(options: CloneCacheKernelOptions) {
+    this.positive = new TTLCache<string>({
+      ttl: options.positiveTtlMs,
+      maxSize: options.maxSize,
+    });
+    this.negative = new TTLCache<string>({
+      ttl: options.negativeTtlMs,
+      maxSize: options.maxSize,
+    });
+  }
+
+  /** Positive-cached voice id, or null. */
+  getCached(cacheKey: string): string | null {
+    return this.positive.get(cacheKey);
+  }
+
+  /** Whether a positive entry exists (eviction victim-selection support). */
+  has(cacheKey: string): boolean {
+    return this.positive.has(cacheKey);
+  }
+
+  /** Whether a clone attempt is currently inflight for the key. */
+  hasInflight(cacheKey: string): boolean {
+    return this.inflight.has(cacheKey);
+  }
+
+  /** Clear a stale failure record (e.g. after evicting its victim). */
+  deleteNegative(cacheKey: string): void {
+    this.negative.delete(cacheKey);
+  }
+
+  /** Drop both records for a key — the voice is gone or must re-clone. */
+  invalidate(cacheKey: string): void {
+    this.positive.delete(cacheKey);
+    this.negative.delete(cacheKey);
+  }
+
+  /** Reset all state (tests, full-invalidation paths). */
+  clear(): void {
+    this.positive.clear();
+    this.negative.clear();
+    this.inflight.clear();
+  }
+
+  /**
+   * The kernel state machine: positive hit → negative hit (throws with the
+   * cached reason) → inflight dedup → run the work, classify any failure,
+   * always clear inflight.
+   */
+  async resolve(args: CloneResolveArgs): Promise<string> {
+    const { cacheKey, describe, work, classifyFailure } = args;
+
+    const cached = this.positive.get(cacheKey);
+    if (cached !== null) {
+      return cached;
+    }
+
+    const failReason = this.negative.get(cacheKey);
+    if (failReason !== null) {
+      throw new Error(`${describe} recently failed: ${failReason}`);
+    }
+
+    const existing = this.inflight.get(cacheKey);
+    if (existing !== undefined) {
+      return existing;
+    }
+
+    const promise = work()
+      .then(voiceId => {
+        this.positive.set(cacheKey, voiceId);
+        return voiceId;
+      })
+      .catch((error: unknown) => {
+        const reason = error instanceof Error ? error.message : String(error);
+        const toCache = classifyFailure(error, reason);
+        if (toCache !== null) {
+          this.negative.set(cacheKey, toCache);
+        }
+        throw error;
+      })
+      .finally(() => this.inflight.delete(cacheKey));
+
+    this.inflight.set(cacheKey, promise);
+    return promise;
+  }
+}

--- a/services/ai-worker/src/services/voice/ElevenLabsVoiceService.ts
+++ b/services/ai-worker/src/services/voice/ElevenLabsVoiceService.ts
@@ -17,7 +17,7 @@
 
 import { TTS_VOICE_NAME_PREFIX } from '@tzurot/common-types/constants/ai';
 import { createLogger } from '@tzurot/common-types/utils/logger';
-import { TTLCache } from '@tzurot/common-types/utils/TTLCache';
+import { CloneCacheKernel } from './CloneCacheKernel.js';
 import {
   elevenLabsCloneVoice,
   elevenLabsListVoices,
@@ -36,14 +36,9 @@ const NEGATIVE_CACHE_TTL_MS = 5 * 60 * 1000;
 /** Max cached entries */
 const CACHE_MAX_SIZE = 200;
 
-interface CachedVoice {
-  voiceId: string;
-}
-
 interface EvictAndCloneOptions {
   slug: string;
   apiKey: string;
-  cacheKey: string;
   voices: ElevenLabsVoiceInfo[];
   voiceName: string;
   audioBuffer: Buffer;
@@ -52,20 +47,11 @@ interface EvictAndCloneOptions {
 }
 
 export class ElevenLabsVoiceService {
-  private readonly cloneCache: TTLCache<CachedVoice>;
-  private readonly negativeCache: TTLCache<string>;
-  private readonly inflight = new Map<string, Promise<string>>();
-
-  constructor() {
-    this.cloneCache = new TTLCache<CachedVoice>({
-      ttl: CLONE_CACHE_TTL_MS,
-      maxSize: CACHE_MAX_SIZE,
-    });
-    this.negativeCache = new TTLCache<string>({
-      ttl: NEGATIVE_CACHE_TTL_MS,
-      maxSize: CACHE_MAX_SIZE,
-    });
-  }
+  private readonly cloneCache = new CloneCacheKernel({
+    positiveTtlMs: CLONE_CACHE_TTL_MS,
+    negativeTtlMs: NEGATIVE_CACHE_TTL_MS,
+    maxSize: CACHE_MAX_SIZE,
+  });
 
   /**
    * Ensure a voice is cloned for the given personality slug.
@@ -76,45 +62,23 @@ export class ElevenLabsVoiceService {
   async ensureVoiceCloned(slug: string, apiKey: string): Promise<string> {
     const cacheKey = this.buildCacheKey(slug, apiKey);
 
-    // Check positive cache
-    const cached = this.cloneCache.get(cacheKey);
-    if (cached !== null) {
-      return cached.voiceId;
-    }
-
-    // Check negative cache
-    const failReason = this.negativeCache.get(cacheKey);
-    if (failReason !== null) {
-      throw new Error(`ElevenLabs voice clone for "${slug}" recently failed: ${failReason}`);
-    }
-
-    // Deduplicate concurrent clone attempts
-    const existing = this.inflight.get(cacheKey);
-    if (existing !== undefined) {
-      return existing;
-    }
-
-    const promise = this.doEnsureCloned(slug, apiKey, cacheKey)
-      .catch(error => {
-        const reason = error instanceof Error ? error.message : String(error);
-
+    return this.cloneCache.resolve({
+      cacheKey,
+      describe: `ElevenLabs voice clone for "${slug}"`,
+      work: () => this.doEnsureCloned(slug, apiKey),
+      classifyFailure: (error, reason) => {
         // Rate limit (429) is transient — don't negatively cache
         if (error instanceof ElevenLabsApiError && error.isRateLimited) {
           logger.warn({ slug, reason }, 'ElevenLabs voice clone rate limited (not cached)');
-        } else {
-          this.negativeCache.set(cacheKey, reason);
-          logger.warn({ slug, reason }, 'ElevenLabs voice clone failed — cached for 5 min');
+          return null;
         }
-
-        throw error;
-      })
-      .finally(() => this.inflight.delete(cacheKey));
-
-    this.inflight.set(cacheKey, promise);
-    return promise;
+        logger.warn({ slug, reason }, 'ElevenLabs voice clone failed — cached for 5 min');
+        return reason;
+      },
+    });
   }
 
-  private async doEnsureCloned(slug: string, apiKey: string, cacheKey: string): Promise<string> {
+  private async doEnsureCloned(slug: string, apiKey: string): Promise<string> {
     const voiceName = `${TTS_VOICE_NAME_PREFIX}${slug}`;
 
     // 1. List voices → find existing → cache & return
@@ -124,7 +88,6 @@ export class ElevenLabsVoiceService {
       voices = await elevenLabsListVoices(apiKey);
       const existing = voices.find(v => v.name === voiceName);
       if (existing !== undefined) {
-        this.cloneCache.set(cacheKey, { voiceId: existing.voiceId });
         logger.info({ slug, voiceId: existing.voiceId }, 'Found existing ElevenLabs voice');
         return existing.voiceId;
       }
@@ -152,7 +115,6 @@ export class ElevenLabsVoiceService {
         description,
       });
 
-      this.cloneCache.set(cacheKey, { voiceId });
       logger.info({ slug, voiceId }, 'ElevenLabs voice cloned and cached');
       return voiceId;
     } catch (error) {
@@ -161,7 +123,6 @@ export class ElevenLabsVoiceService {
         return this.evictAndClone({
           slug,
           apiKey,
-          cacheKey,
           voices,
           voiceName,
           audioBuffer,
@@ -187,8 +148,7 @@ export class ElevenLabsVoiceService {
    * negatively cached for 5 min. Low probability and self-healing.
    */
   private async evictAndClone(opts: EvictAndCloneOptions): Promise<string> {
-    const { slug, apiKey, cacheKey, voices, voiceName, audioBuffer, contentType, description } =
-      opts;
+    const { slug, apiKey, voices, voiceName, audioBuffer, contentType, description } = opts;
     const keySuffix = this.getKeySuffix(apiKey);
 
     const candidates = voices.filter(v => {
@@ -201,7 +161,7 @@ export class ElevenLabsVoiceService {
       }
       const candidateSlug = v.name.slice(TTS_VOICE_NAME_PREFIX.length);
       const candidateKey = `${candidateSlug}:${keySuffix}`;
-      return !this.cloneCache.has(candidateKey) && !this.inflight.has(candidateKey);
+      return !this.cloneCache.has(candidateKey) && !this.cloneCache.hasInflight(candidateKey);
     });
 
     if (candidates.length === 0) {
@@ -239,7 +199,7 @@ export class ElevenLabsVoiceService {
     // Clear any stale negative cache for the evicted voice's slug so it can be
     // re-cloned immediately if requested (rather than waiting for 5-min expiry)
     const victimSlug = victim.name.slice(TTS_VOICE_NAME_PREFIX.length);
-    this.negativeCache.delete(`${victimSlug}:${keySuffix}`);
+    this.cloneCache.deleteNegative(`${victimSlug}:${keySuffix}`);
 
     // Retry clone
     const { voiceId } = await elevenLabsCloneVoice({
@@ -250,7 +210,6 @@ export class ElevenLabsVoiceService {
       description,
     });
 
-    this.cloneCache.set(cacheKey, { voiceId });
     logger.info({ slug, voiceId, evictedVoice: victim.name }, 'Voice cloned after eviction');
     return voiceId;
   }
@@ -280,15 +239,11 @@ export class ElevenLabsVoiceService {
    * to force re-cloning on the next ensureVoiceCloned() call.
    */
   invalidateVoice(slug: string, apiKey: string): void {
-    const cacheKey = this.buildCacheKey(slug, apiKey);
-    this.cloneCache.delete(cacheKey);
-    this.negativeCache.delete(cacheKey);
+    this.cloneCache.invalidate(this.buildCacheKey(slug, apiKey));
   }
 
   /** @internal Clear all caches (for testing only). */
   clearCache(): void {
     this.cloneCache.clear();
-    this.negativeCache.clear();
-    this.inflight.clear();
   }
 }

--- a/services/ai-worker/src/services/voice/providers/MistralTtsProvider.ts
+++ b/services/ai-worker/src/services/voice/providers/MistralTtsProvider.ts
@@ -33,7 +33,7 @@ import {
   type TtsProviderId,
 } from '@tzurot/common-types/services/tts/TtsProvider';
 import { createLogger } from '@tzurot/common-types/utils/logger';
-import { TTLCache } from '@tzurot/common-types/utils/TTLCache';
+import { CloneCacheKernel } from '../CloneCacheKernel.js';
 import {
   mistralCloneVoice,
   mistralListVoices,
@@ -71,10 +71,6 @@ const MISTRAL_CAPABILITIES: TtsCapabilities = {
   outputFormat: 'wav',
 };
 
-interface CachedVoice {
-  voiceId: string;
-}
-
 /**
  * The discriminated return shape of `mistralListVoices` — `{ voices, truncated }`.
  * Aliased so call-site code reads cleanly without repeating the inline
@@ -106,9 +102,11 @@ export class MistralTtsProvider implements TtsProvider {
   readonly displayName = 'Mistral Voxtral (BYOK)';
   readonly capabilities = MISTRAL_CAPABILITIES;
 
-  private readonly cloneCache: TTLCache<CachedVoice>;
-  private readonly negativeCache: TTLCache<string>;
-  private readonly inflight = new Map<string, Promise<string>>();
+  private readonly cloneCache = new CloneCacheKernel({
+    positiveTtlMs: CLONE_CACHE_TTL_MS,
+    negativeTtlMs: NEGATIVE_CACHE_TTL_MS,
+    maxSize: CACHE_MAX_SIZE,
+  });
 
   /**
    * Eviction mutex — serializes prepare() per-instance to prevent the
@@ -116,17 +114,6 @@ export class MistralTtsProvider implements TtsProvider {
    * section. Same pattern as ElevenLabsTtsProvider.
    */
   private evictionLock: Promise<unknown> = Promise.resolve();
-
-  constructor() {
-    this.cloneCache = new TTLCache<CachedVoice>({
-      ttl: CLONE_CACHE_TTL_MS,
-      maxSize: CACHE_MAX_SIZE,
-    });
-    this.negativeCache = new TTLCache<string>({
-      ttl: NEGATIVE_CACHE_TTL_MS,
-      maxSize: CACHE_MAX_SIZE,
-    });
-  }
 
   /** Cheap predicate — Mistral requires a BYOK key. No I/O. */
   isAvailable(ctx: TtsContext): boolean {
@@ -214,16 +201,12 @@ export class MistralTtsProvider implements TtsProvider {
 
   /** Invalidate cached voice for slug+key (e.g., on 404 from synthesize). */
   invalidateVoice(slug: string, apiKey: string): void {
-    const cacheKey = this.buildCacheKey(slug, apiKey);
-    this.cloneCache.delete(cacheKey);
-    this.negativeCache.delete(cacheKey);
+    this.cloneCache.invalidate(this.buildCacheKey(slug, apiKey));
   }
 
   /** @internal Test-only cache reset. */
   clearCache(): void {
     this.cloneCache.clear();
-    this.negativeCache.clear();
-    this.inflight.clear();
   }
 
   // ===== Internal lifecycle ===============================================
@@ -231,34 +214,15 @@ export class MistralTtsProvider implements TtsProvider {
   private async ensureVoiceCloned(slug: string, apiKey: string): Promise<string> {
     const cacheKey = this.buildCacheKey(slug, apiKey);
 
-    // Positive cache hit
-    const cached = this.cloneCache.get(cacheKey);
-    if (cached !== null) {
-      return cached.voiceId;
-    }
-
-    // Negative cache hit — surface the prior failure rather than retrying
-    const failReason = this.negativeCache.get(cacheKey);
-    if (failReason !== null) {
-      throw new Error(`Mistral voice clone for "${slug}" recently failed: ${failReason}`);
-    }
-
-    // Inflight dedup — defensive backstop only. The eviction mutex in
-    // `prepare()` already serializes concurrent calls, so by the time the
-    // second call's promise chain reaches here, the first has settled and
-    // populated the cache (or cleared inflight via `.finally`). The check
-    // is unreachable under the current call shape (`ensureVoiceCloned` is
-    // private + only called from the mutex-chained path), kept in case a
-    // future caller bypasses the mutex (e.g., direct test invocation).
-    const existing = this.inflight.get(cacheKey);
-    if (existing !== undefined) {
-      return existing;
-    }
-
-    const promise = this.doEnsureCloned(slug, apiKey, cacheKey)
-      .catch(error => {
-        const reason = error instanceof Error ? error.message : String(error);
-
+    // The kernel's inflight dedup is a defensive backstop only here: the
+    // eviction mutex in `prepare()` already serializes concurrent calls, so
+    // the check is unreachable under the current call shape — kept for any
+    // future caller that bypasses the mutex (e.g., direct test invocation).
+    return this.cloneCache.resolve({
+      cacheKey,
+      describe: `Mistral voice clone for "${slug}"`,
+      work: () => this.doEnsureCloned(slug, apiKey),
+      classifyFailure: (error, reason) => {
         // Branch ordering matters: MistralReferenceAudioTooLongError has
         // `isTransient = false`, so `isDeterministicFailure` would match it
         // too. Keep this explicit instanceof check first so the structured
@@ -278,43 +242,44 @@ export class MistralTtsProvider implements TtsProvider {
             },
             'Mistral reference audio exceeds 30s limit — skipping clone; dispatcher will attempt fallback if available'
           );
-        } else if (error instanceof MistralVoiceListUnavailableError) {
+          return null;
+        }
+        if (error instanceof MistralVoiceListUnavailableError) {
           // The clone path never ran — the list endpoint failed (truncation
           // or fetch retry-exhaustion). Log message reflects the actual
           // failure mode, distinct from "voice clone failed" which would
           // misattribute. Still cache (isTransient=true) so the next 5 min
           // of prepares short-circuit instead of repeating retry storms.
-          this.negativeCache.set(cacheKey, reason);
           logger.warn(
             { event: 'mistral.voiceListUnavailable', slug, listReason: error.reason, reason },
             'Mistral voice list unavailable — cached for 5 min, no clone attempted'
           );
-        } else if (error instanceof MistralApiError && error.isRateLimited) {
+          return reason;
+        }
+        if (error instanceof MistralApiError && error.isRateLimited) {
           // Rate-limited (429) is transient but too granular for a 5-min
           // blanket cache — Mistral's retry-after header is more precise.
           logger.warn({ slug, reason }, 'Mistral voice clone rate limited (not cached)');
-        } else if (isDeterministicFailure(error)) {
+          return null;
+        }
+        if (isDeterministicFailure(error)) {
           // Other deterministic failures (e.g., 4xx auth, malformed audio) —
           // caching adds nothing because the same input will keep failing.
-          // The absence of `negativeCache.set` is intentional: the `throw error`
-          // below still rejects the caller's promise, so the failure surfaces;
-          // we just don't poison the cache for the next attempt.
+          // Returning null is intentional: the kernel still rejects the
+          // caller's promise, so the failure surfaces; we just don't poison
+          // the cache for the next attempt.
           logger.warn({ slug, reason }, 'Mistral voice clone failed (deterministic — not cached)');
-        } else {
-          // Transient (5xx, response-shape, network blips) or unknown.
-          // Cache for 5 min to prevent retry storms.
-          this.negativeCache.set(cacheKey, reason);
-          logger.warn({ slug, reason }, 'Mistral voice clone failed — cached for 5 min');
+          return null;
         }
-        throw error;
-      })
-      .finally(() => this.inflight.delete(cacheKey));
-
-    this.inflight.set(cacheKey, promise);
-    return promise;
+        // Transient (5xx, response-shape, network blips) or unknown.
+        // Cache for 5 min to prevent retry storms.
+        logger.warn({ slug, reason }, 'Mistral voice clone failed — cached for 5 min');
+        return reason;
+      },
+    });
   }
 
-  private async doEnsureCloned(slug: string, apiKey: string, cacheKey: string): Promise<string> {
+  private async doEnsureCloned(slug: string, apiKey: string): Promise<string> {
     const voiceName = `${TTS_VOICE_NAME_PREFIX}${slug}`;
 
     // Step 1: list voices, find by name. `mistralListVoices` walks pages up
@@ -369,7 +334,6 @@ export class MistralTtsProvider implements TtsProvider {
     if (listResult !== undefined) {
       const existing = listResult.voices.find(v => v.name === voiceName);
       if (existing !== undefined) {
-        this.cloneCache.set(cacheKey, { voiceId: existing.id });
         logger.info({ slug, voiceId: existing.id }, 'Found existing Mistral voice');
         return existing.id;
       }
@@ -424,7 +388,6 @@ export class MistralTtsProvider implements TtsProvider {
       apiKey,
     });
 
-    this.cloneCache.set(cacheKey, { voiceId: cloned.id });
     logger.info({ slug, voiceId: cloned.id }, 'Mistral voice cloned and cached');
     return cloned.id;
   }


### PR DESCRIPTION
## Summary

**CPD campaign 4** (ai-worker voice providers) — council-adjudicated per the theme's gate, and **campaign 1 verified obsolete** en route.

## Council pass (recorded in the theme)

Three options weighed: composed kernel / `BaseTtsProvider` inheritance / leave inline. Verdict: **composition**, on one decisive distinction — the three-cache clone state machine (positive TTL cache, negative failure cache, inflight dedup, check-check-dedupe-work-classify-cleanup) is **identical invariants** that must stay in sync (a missed `.finally` wedges dedup forever; negative-caching a transient locks a user out for the TTL), while the failure **classifiers are load-bearing divergence** with near-opposite polarity (ElevenLabs whitelists 429 as uncached-transient; Mistral runs a four-branch classification with structured log events). Inheritance would template the wrong thing; inline leaves the invariants to manual mirroring.

## The kernel

`CloneCacheKernel.resolve({ cacheKey, describe, work, classifyFailure })` — **exactly two callbacks, at the 2-callback ceiling**, with `describe` a plain string for the negative-hit message. Eviction-support surface (`has`/`hasInflight`/`getCached`/`deleteNegative`/`invalidate`/`clear`) serves ElevenLabs's victim selection and both invalidation paths without exposing the caches. Mistral's eviction mutex stays a provider lifecycle concern — the kernel neither knows nor cares when `resolve` is called.

## Behavior preservation

- Both provider test suites pass **UNCHANGED** (20 ElevenLabs + 33 Mistral) — the strongest available pin that nothing user-observable moved.
- Negative-hit error messages preserved verbatim (`<Provider> voice clone for "slug" recently failed: reason`).
- All four Mistral classifier branches keep their structured events and exact ordering (the `MistralReferenceAudioTooLongError`-before-`isDeterministicFailure` ordering comment rides along).
- Providers lose three cache fields and five scattered positive-cache writes each — the kernel writes once on work resolution; every removed internal `set` was immediately followed by returning the same id.
- 9 new kernel tests incl. the concurrent-dedup, inflight-never-wedges, and non-Error-rejection pins. (Round 1 review dropped the caller-less `setCloned` from the surface.)

## Campaign 1: obsolete, verified

The theme's first pick (`LlmConfigService` ↔ `TtsConfigService`, ~24 lines in the 2026-05-16 audit) now has **zero raw jscpd clones** — the kind-column retirement (#1499/#1501) diverged the pair structurally (ModelSlot-parameterized defaults vs slotless pointers, `checkNameExists` vs `resolveNonCollidingName`). The campaign's own council question ("which divergences are structural?") answered itself. Recorded in the theme; no extraction.

## Numbers

jscpd pair clones 2 → 0; `cpd:filtered` 1648 → 1614 lines; `cpd:check` green. Full `pnpm test` 25/25, `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)