### PR TITLE
docs: indexes ship with their query — db-audit phase 1

### DIFF
--- a/.claude/rules/03-database.md
+++ b/.claude/rules/03-database.md
@@ -49,6 +49,12 @@ const results = await prisma.$queryRaw<SimilarMemory[]>`
 `;
 ```
 
+## Indexes Ship With Their Query
+
+**A new index must land in the same PR as a query that uses it** (or name the existing query it backs, verifiable by grep). A speculative index is not free: its write-path maintenance costs land immediately while its read benefit never arrives — a GIN index added "for future JSONB queries" that were never built stalled prod inserts past the 6s query timeout and dead-ended a user response. When reviewing a migration that adds an index, ask "which query?" — no query, no index.
+
+Corollary for removals: `idx_scan = 0` alone never justifies a drop. Verify no query exists (raw AND Prisma) — an index backing a real query on a still-small table shows 0 scans only because the planner seq-scans; it becomes load-bearing as the table grows. PK/unique indexes are constraints, never drop candidates.
+
 ## Migrations
 
 ### The One True Workflow

--- a/backlog/cold/themes/database-performance-audit.md
+++ b/backlog/cold/themes/database-performance-audit.md
@@ -26,8 +26,8 @@ A one-shot prod audit (`pg_stat_user_indexes` / `pg_stat_user_tables`, 2026-06-3
 - Seq-scan-heavy tables are mostly _tiny_ (`personas` 271 rows, `llm_configs` 34, `personalities` 178) — Postgres correctly prefers seq scans there; NOT a problem. Only `conversation_history` (~7500 rows, 34K seq-scans) is mildly worth a look for a missing index.
 - `pg_stat_database.stats_reset` was null; table-level counters are large (522K idx-scans on `users`), so the window is long enough to trust for secondary-index judgments — but confirm stats age before any drop.
 
-### Phase 1 — Prevention (cheapest, highest leverage) — NEXT
-- [ ] Add a rule to `.claude/rules/03-database.md`: **an index must ship in the same PR as a query that uses it.** `responseMessageIds` did this right; `message_metadata` didn't. (Load-bearing rule → small review-gated PR.)
+### Phase 1 — Prevention (cheapest, highest leverage) — ✅ SHIPPED 2026-07-06
+- [x] Rule added to `.claude/rules/03-database.md` § "Indexes Ship With Their Query": new index requires its query in the same PR (grep-verifiable); corollary encodes the 3-case drop judgment (no-query / real-query-small-table-KEEP / PK-constraint-never).
 
 ### Phase 2 — Recurring audit tooling
 - [ ] `pnpm ops db:index-audit` — pull `pg_stat_user_indexes` (idx_scan, size) + flag 0-scan _secondary_ indexes (exclude PK/unique), classified by the 3 cases above. Recurring green/red signal instead of a one-off. (Audit-class tool — see `docs/reference/audit-enforcement.md`.)


### PR DESCRIPTION
## Summary

**Database Performance Audit theme, Phase 1** (prevention — the cheap, high-leverage start). One load-bearing rule added to `.claude/rules/03-database.md`, review-gated per the rules-need-PRs policy.

## The rule

**"Indexes Ship With Their Query"**: a new index must land in the same PR as a query that uses it (or name the grep-verifiable existing query it backs). Born from the `message_metadata` GIN incident — a speculative index for never-built JSONB queries whose pending-list flushes stalled prod inserts past the 6s query timeout and dead-ended a user response (#1410/#1411).

The drop-side corollary encodes the three-case judgment from the 2026-06-30 prod snapshot, so `idx_scan = 0` alone never justifies a removal: no-query → droppable; real-query-but-small-table → KEEP (the planner switches to it at scale — the trap the snapshot surfaced on `llm_diagnostic_logs`); PK/unique → constraints, never drop candidates.

## Scope note

Phases 2–4 of the theme (the `db:index-audit` ops tool, per-index remediation walk, `pg_stat_statements` enablement) stay queued — this PR is deliberately just the always-loaded constraint.

Line budget: 03-database.md at 37/93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)