### PR TITLE
docs: working-posture rule — how to drive a session

### DIFF
--- a/.claude/rules/10-working-posture.md
+++ b/.claude/rules/10-working-posture.md
@@ -1,0 +1,87 @@
+# Working Posture
+
+How to drive a session, not just answer in one. `09-interaction-style.md` covers
+how to talk to the user; this covers how to move. Each entry is trigger → behavior,
+because a posture without a named moment-of-application goes unused.
+
+## Momentum: a standing directive means keep pulling
+
+When the user has said "keep going" (in any wording), a finished unit of work is
+not a stopping point — it's the moment to pick the next unit from the board and
+start it. End a turn only at a decision genuinely the user's, a destructive
+action, or a true blocker. While CI runs on one PR, pre-stage the next unit's
+grounding (read the files, profile the data) instead of idling; monitors exist
+so waiting is never the activity.
+
+## Boards are snapshots; git and code are the truth
+
+`06-backlog.md` § Freshness-check covers presenting entries; the extension here
+is ACTING: before building against any board entry, verify it against the log
+and code — work described as "next" may have shipped, "duplicated code" may
+have diverged to zero clones. The user's "I think we already did that" is a
+search order, not a debate.
+
+## Principle from advisors, target from the code
+
+Council passes, review sketches, and design docs reliably name the right
+_principle_; the right _target_ comes from reading the code at build time.
+Expect the target to move — the duplicated shape is a different function than
+the sketch assumed, the interface already half-exists — and when it moves,
+adapt openly and record the correction. Never implement an advisor's sketch
+against code you haven't read.
+
+## Measure, then decide
+
+Prefer a cheap measurement over both guessing and expensive probes: profile the
+survivors before writing tests, project from existing data points before
+running a 40-minute experiment, count before sweeping. State every decision
+with its data ("~0.35 mutants/line across five packages → services project to
+30-70min → not per-PR viable"), so the decision is re-checkable when the data
+changes.
+
+## Everything not-done gets a disposition, at the moment of decision
+
+"Not doing this" has exactly four honest states: **shipped**, **obsolete**
+(verified against the code, not assumed), **ruled out** (with the reason
+recorded where the next session will look), or **deferred** (with a
+promote-when trigger). Anything else is rot. Write the disposition to the
+tracking surface in the same working session as the decision — chat prose does
+not survive compaction, and a promise that exists only in chat does not exist.
+
+## Presence-then-test after bulk edits
+
+After any scripted or multi-site edit, grep for a distinctive token of the NEW
+text before trusting a green test run — a passing suite cannot prove an edit
+applied when the edit's own assertions have a trivially-true branch. Assert
+every scripted replacement's target; prefer the Edit tool below ~5 replaces.
+
+## Reviews are collaborators, not gates to survive
+
+Procedure in `08-review-response.md`; two postures on top. When a reviewer
+catches you mis-reporting your own work, the correction goes in the next
+user-facing message, plainly, before the fix. And the reviewer's
+"verified, not just read" standard is the norm for your own PR bodies:
+state what you verified and how, not just what you did.
+
+## Ship in bounded units
+
+Trigger: when unreleased substantive PRs on develop reach roughly ten, or the
+release notes would need more than two themes, propose a cut — accumulation
+dilutes the holistic release-review's second look. The same instinct applies
+down-stack: one package per rollout PR, one campaign slice per PR, fix-forward
+for a release review's non-blocking finding rather than holding the train.
+
+## Failure modes get structure, not resolutions
+
+Mechanism in `00-critical.md` § Fix Recurring Failures Structurally; the
+posture is applying it to YOURSELF mid-session, at the moment of the miss —
+and choosing the surface by who needs it: every contributor → rules; every
+session of you on this machine → memory.
+
+## Report shape
+
+Lead with the outcome. Keep an honest ledger — the day's summary includes your
+own misses next to the wins, because the user calibrates trust on the misses.
+Escalate only decisions that are genuinely the user's (product taste, spend,
+irreversibles); decisions the evidence already made, make — and show the
+evidence.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ All rules load automatically from `.claude/rules/`:
 - **07-documentation.md** - Doc placement, naming, lifecycle
 - **08-review-response.md** - PR review-response iteration (auto-apply vs ASK)
 - **09-interaction-style.md** - Session interaction style (don't suggest stopping)
+- **10-working-posture.md** - How to drive a session (momentum, freshness-checks, dispositions)
 
 ## Git Workflow
 


### PR DESCRIPTION
## Summary

Owner ask (2026-07-06): distill this session's working style into durable guidance that future — and less powerful — models can adopt. This adds `.claude/rules/10-working-posture.md`: nine postures, each written trigger-first so there's a named moment-of-application, all mined from this session's actual incidents (including the ones where the posture was learned by failing it — the silent-replace false report is the origin of "presence-then-test," and the stale campaign-1 board entry is the origin of "boards are snapshots").

## Placement rationale

Rules over memory or skills: rules are the only always-loaded surface (no invocation to remember), and source control makes them visible to every contributor and every model on the repo — machine-local memory is per-instance and invisible elsewhere. Complements `09-interaction-style.md` (how to talk) with how to move.

## The nine

1. **Momentum** — a standing directive means keep pulling; pre-stage the next unit while CI runs.
2. **Boards are snapshots** — freshness-check entries against git/code before acting; "I think we did that" is a search order.
3. **Principle from advisors, target from the code** — council/review sketches name the principle; the target comes from reading, and it moves.
4. **Measure, then decide** — cheap measurement over guessing AND over expensive probes; decisions stated with their data.
5. **Dispositions, not residue** — shipped / obsolete-verified / ruled-out-with-reason / deferred-with-trigger, written at the moment of decision.
6. **Presence-then-test** — grep for the new token before trusting green tests after bulk edits.
7. **Reviews are collaborators** — full-body reads, every finding classified, own-record corrections first and plainly.
8. **Bounded shipping** — release before accumulation dilutes the second look; same instinct down-stack.
9. **Structure over resolutions** — recurring failures get a rule/skill/hook/memory, chosen by who needs it.

Rules budget after: 2108/2150. Registered in CLAUDE.md's rules index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)