### PR TITLE
docs: handoff-audit round 2 — encode today's doctrine

### DIFF
--- a/.claude/rules/02-code-standards.md
+++ b/.claude/rules/02-code-standards.md
@@ -322,6 +322,8 @@ Before extracting a new shared helper from a duplicated route pattern, prototype
 
 The rule's symmetry: when council reviewers (or your own instinct) warn "this looks like Wrong Abstraction," try the prototype. Don't pre-decide; let the signature size be the empirical answer.
 
+**The adapter-interface exception (council-ruled)**: a cohesive INTERFACE whose methods are authored together per implementor is ONE parameter, not N callbacks — even with 3+ methods. The test is cohesion: if removing one method makes the others meaningless (they produce/consume each other's outputs), it's an adapter seam; if the functions are independent degrees of freedom a caller could mix-and-match, it's callbacks and the ceiling applies. Precedents: `TtsProvider`, `EntitySectionAdapter` (findSection's sync bundle is what loadSectionData warms and resolveSectionContext composes — cohesive), vs. the rejected cascade-route "preamble helper" (schema + verify-access + pre-hook = independent knobs — ceiling). Constraint that keeps this honest: adapter IMPLEMENTATIONS live next to their implementor's code, never in the shared module.
+
 ### CPD measurement: raw vs filtered
 
 - **`pnpm cpd`** — runs jscpd. Output is informational. The raw clone count cannot reach zero in a well-abstracted TypeScript codebase because jscpd's token matcher treats standardized call sites of shared helpers as new clones across consumers.

--- a/.claude/rules/05-tooling.md
+++ b/.claude/rules/05-tooling.md
@@ -91,6 +91,16 @@ pnpm ops xray --imports              # Include import analysis (auto for md/json
 
 **Decision-point trigger**: xray is not just a periodic-audit tool — it is the required sweep before any negative existence claim ("we don't have X") per `00-critical.md` § Don't Present Speculation as Fact. `pnpm ops xray --format md | grep -iE 'termA|termB|termC'` searches every export in seconds and cannot be stale.
 
+### Mutation-Score Ratchet (Stryker)
+
+```bash
+pnpm --filter @tzurot/<pkg> test:mutation   # run Stryker for one tracked package (writes reports/mutation/<pkg>/)
+pnpm ops mutation:check --summary           # CI gate: per-package score >= baseline - graceMargin
+pnpm ops mutation:update-baseline           # sanctioned refresh (needs a fresh LOCAL report for EVERY tracked package)
+```
+
+Tracked packages live in `MUTATED_PACKAGES` (`packages/tooling/src/test/mutation-check.ts`). Adding one: copy config-resolver's `stryker.config.mjs` + `logger-calls` ignorer (NOT cache-invalidation's copy — its `observability-options` rule is package-specific), add a `test:mutation` script + the `@stryker-mutator/*` devDeps, add to `MUTATED_PACKAGES` (fingerprint drift forces the baseline refresh), add its CI step before `mutation:check`. When the check fails on a genuine score drop: close the test gaps it names — never hand-edit the baseline. Services are adjudicated NOT per-PR viable (30-70min projected runs); don't re-attempt without new data. `ignoreStatic` stays OFF (owner decision — module-top-level mutants held the rollout's best real finds).
+
 ### Test Audits
 
 ```bash

--- a/.github/baselines/lines-baseline.json
+++ b/.github/baselines/lines-baseline.json
@@ -1,11 +1,11 @@
 {
   "surfaces": {
     "rules": {
-      "lines": 2000,
+      "lines": 2120,
       "graceMargin": 150
     },
     "current": {
-      "lines": 33,
+      "lines": 37,
       "graceMargin": 60
     }
   },
@@ -13,7 +13,7 @@
     "toolVersion": "lines-check/1",
     "configHash": "84da1e207dac",
     "nodeVersion": "v24.11.1",
-    "generatedFromSha": "a2034e712f3bae289a56793ea74634cb1e4c74c4",
-    "generatedAt": "2026-07-03T19:27:14.760Z"
+    "generatedFromSha": "fabf69ee5b84334f2cba3986f6d5b45b084705a7",
+    "generatedAt": "2026-07-07T02:02:03.061Z"
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ Discord bot with AI personas. TypeScript monorepo on Railway.
 pnpm dev              # Start all services
 pnpm test             # Run unit tests
 pnpm test:component   # Run component tests (after command structure changes)
+pnpm test:integration # Run integration + contract tiers (*.contract.test.ts lives here, NOT in pnpm test)
 pnpm quality          # the full static gate — composition in package.json scripts.quality (synced to CI by guard:gate-parity)
 pnpm ops db:migrate --env dev  # Run migrations
 ```

--- a/packages/tooling/src/audits/check-claude-content-refs.test.ts
+++ b/packages/tooling/src/audits/check-claude-content-refs.test.ts
@@ -318,6 +318,8 @@ describe('findContentRefs (against real repo)', () => {
       'db:inspect',
       'db:migrate',
       'db:safe-migrate',
+      'mutation:check',
+      'mutation:update-baseline',
       'db:status',
       'deploy:dev',
       'deploy:setup-vars',


### PR DESCRIPTION
## Summary

Follow-up to the working-posture rule (#1525), per the owner's ask: a deep audit of rules/skills/CLAUDE.md ahead of the Fable→API-only cutover. Round 1 (2026-07-03, PR #1468) was friction-class-driven from six weeks of mined logs; **round 2's lens is today's session** — doctrinal amendments a strong model derived live that a weaker one needs written down, plus stale references from today's ~15 merged PRs.

## Findings → fixes

1. **The 2-callback ceiling lacked today's adapter-interface ruling** (`02-code-standards.md`). The council ruled twice today (CloneCacheKernel classifiers, EntitySectionAdapter) that a cohesive interface is ONE parameter, not N callbacks — with a concrete cohesion test (remove one method and the others become meaningless → seam; independent mix-and-match degrees of freedom → callbacks, ceiling applies). Both precedents + the rejected counter-example (the cascade preamble helper) + the entity-local-implementations constraint are now in the rule. Without this, the ceiling either forbids legitimate seams or gets rules-lawyered.
2. **The mutation ratchet had zero always-loaded documentation** (`05-tooling.md`). Commands, the update contract (fresh local report for EVERY tracked package), the add-a-package recipe with its one trap (copy config-resolver's clean ignorer, not cache-invalidation's package-specific copy), the services-not-viable adjudication, and the ignoreStatic owner decision. A weaker model facing a red `mutation-tests` job had no sanctioned path.
3. **`pnpm test:integration` added to CLAUDE.md's commands** — the contract tier is invisible from `pnpm test`, and nothing always-loaded said so.
4. **Line-budget baseline raised explicitly** (2000→2120 via `lines:update-baseline`, the sanctioned growth path) to accommodate this + #1525 landing in parallel (combined ~2218 < new 2270 ceiling).

## Audited-clean (no action)

Skills carry no stale single-package Stryker language; CLAUDE.md's structure/commands otherwise current; round-1's friction-class protocols intact. One deferred hygiene item rides the merge sequence: the `assert-python-replace-blocks` memory becomes redundant once #1525's presence-then-test posture merges — atomic promote-and-delete applies then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)