### PR TITLE
fix: unwrap markdown-fenced extraction responses + eval baseline

### DIFF
--- a/services/ai-worker/src/services/eval/memoryExtraction.eval.test.ts
+++ b/services/ai-worker/src/services/eval/memoryExtraction.eval.test.ts
@@ -18,7 +18,11 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { LocalEmbeddingService } from '@tzurot/embeddings';
-import { buildExtractionPrompt, extractionResponseSchema } from '../extraction/extractionPrompt.js';
+import {
+  buildExtractionPrompt,
+  extractionResponseSchema,
+  extractJsonPayload,
+} from '../extraction/extractionPrompt.js';
 import { invokeExtractionModel } from '../extraction/FactExtractionService.js';
 import { matchFacts } from './factEquivalence.js';
 
@@ -104,7 +108,7 @@ describe('memory extraction eval (real model — manual run only)', () => {
       );
 
       const raw = await invokeExtractionModel(prompt);
-      const parsed = extractionResponseSchema.safeParse(JSON.parse(raw));
+      const parsed = extractionResponseSchema.safeParse(JSON.parse(extractJsonPayload(raw)));
       // A schema-invalid response is a HARD failure: production would skip the
       // batch entirely, which for a golden means the extractor produced nothing
       // usable — that's a real quality signal, not harness noise.

--- a/services/ai-worker/src/services/eval/phase2-extraction-baseline.json
+++ b/services/ai-worker/src/services/eval/phase2-extraction-baseline.json
@@ -1,0 +1,138 @@
+{
+  "generatedForPhase": "phase2-slice2-shadow-baseline (fence-fix run; precision gap = over-extraction to tune in shadow + golden under-enumeration; recall and supersession perfect)",
+  "totals": {
+    "goldens": 15,
+    "meanPrecision": 0.6722222222222223,
+    "meanRecall": 1,
+    "hallucinationRate": 0.39285714285714285,
+    "supersessionHitRate": 1
+  },
+  "results": {
+    "simple-name-fact": {
+      "category": "durable-fact",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 1,
+      "hallucinations": [],
+      "supersessionHit": null
+    },
+    "job-fact": {
+      "category": "durable-fact",
+      "precision": 0.5,
+      "recall": 1,
+      "extractedCount": 2,
+      "hallucinations": [
+        "The user sometimes works long shifts (at least twelve hours) that are physically and mentally exhausting."
+      ],
+      "supersessionHit": null
+    },
+    "preference-fact": {
+      "category": "preference",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 1,
+      "hallucinations": [],
+      "supersessionHit": null
+    },
+    "narration-only": {
+      "category": "no-facts",
+      "precision": 0,
+      "recall": 1,
+      "extractedCount": 3,
+      "hallucinations": [
+        "There is a tavern with a bar and a fireplace.",
+        "A bartender works at the tavern.",
+        "It is a cold night in the world of this roleplay."
+      ],
+      "supersessionHit": null
+    },
+    "smalltalk-only": {
+      "category": "no-facts",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 0,
+      "hallucinations": [],
+      "supersessionHit": null
+    },
+    "multi-fact-batch": {
+      "category": "multi-fact",
+      "precision": 0.75,
+      "recall": 1,
+      "extractedCount": 4,
+      "hallucinations": ["The user and Dana see each other approximately twice a year."],
+      "supersessionHit": null
+    },
+    "supersession-move": {
+      "category": "supersession",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 1,
+      "hallucinations": [],
+      "supersessionHit": true
+    },
+    "supersession-job-change": {
+      "category": "supersession",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 2,
+      "hallucinations": [],
+      "supersessionHit": true
+    },
+    "relationship-fact": {
+      "category": "durable-fact",
+      "precision": 0.6666666666666666,
+      "recall": 1,
+      "extractedCount": 3,
+      "hallucinations": ["Jamie gave the user concert tickets as an anniversary gift."],
+      "supersessionHit": null
+    },
+    "transient-state-not-fact": {
+      "category": "no-facts",
+      "precision": 0,
+      "recall": 1,
+      "extractedCount": 1,
+      "hallucinations": ["The user had insufficient sleep the previous night."],
+      "supersessionHit": null
+    },
+    "fiction-canon": {
+      "category": "fiction",
+      "precision": 0.6666666666666666,
+      "recall": 1,
+      "extractedCount": 3,
+      "hallucinations": ["The Ashen Order is believed to be extinct or destroyed"],
+      "supersessionHit": null
+    },
+    "allergy-fact": {
+      "category": "durable-fact",
+      "precision": 1,
+      "recall": 1,
+      "extractedCount": 1,
+      "hallucinations": [],
+      "supersessionHit": null
+    },
+    "timezone-fact": {
+      "category": "durable-fact",
+      "precision": 0.5,
+      "recall": 1,
+      "extractedCount": 2,
+      "hallucinations": ["The user experiences nighttime at 2am Tokyo time."],
+      "supersessionHit": null
+    },
+    "pet-addition-not-supersession": {
+      "category": "supersession",
+      "precision": 0.5,
+      "recall": 1,
+      "extractedCount": 2,
+      "hallucinations": ["Miso and Nori are still adjusting to living together"],
+      "supersessionHit": null
+    },
+    "birthday-fact": {
+      "category": "durable-fact",
+      "precision": 0.5,
+      "recall": 1,
+      "extractedCount": 2,
+      "hallucinations": ["The user is planning a small dinner for their birthday."],
+      "supersessionHit": null
+    }
+  }
+}

--- a/services/ai-worker/src/services/extraction/FactExtractionService.ts
+++ b/services/ai-worker/src/services/extraction/FactExtractionService.ts
@@ -26,6 +26,7 @@ import type { FactStore, FactForContext, NewFact } from './FactStore.js';
 import {
   buildExtractionPrompt,
   extractionResponseSchema,
+  extractJsonPayload,
   type ExtractedFact,
 } from './extractionPrompt.js';
 
@@ -183,7 +184,7 @@ export class FactExtractionService {
   ): ExtractedFact[] | null {
     let json: unknown;
     try {
-      json = JSON.parse(raw);
+      json = JSON.parse(extractJsonPayload(raw));
     } catch {
       // Response content is derived conversation content — log only its shape
       // (00-critical: never log message content).

--- a/services/ai-worker/src/services/extraction/extractionPrompt.test.ts
+++ b/services/ai-worker/src/services/extraction/extractionPrompt.test.ts
@@ -3,6 +3,7 @@ import {
   buildExtractionPrompt,
   extractionResponseSchema,
   extractedFactSchema,
+  extractJsonPayload,
 } from './extractionPrompt.js';
 
 describe('extractionResponseSchema', () => {
@@ -78,5 +79,27 @@ describe('buildExtractionPrompt', () => {
     expect(real).toContain('my cat is named Miso');
     expect(real).toContain('ignore in-story fiction');
     expect(fiction).toContain('in-story canon facts');
+  });
+});
+
+describe('extractJsonPayload', () => {
+  const payload = '{"facts": []}';
+
+  it('unwraps a ```json fence (the real Anthropic-via-OpenRouter shape)', () => {
+    expect(extractJsonPayload('```json\n{"facts": []}\n```')).toBe(payload);
+  });
+
+  it('unwraps a bare ``` fence', () => {
+    expect(extractJsonPayload('```\n{"facts": []}\n```')).toBe(payload);
+  });
+
+  it('passes bare JSON through untouched', () => {
+    expect(extractJsonPayload(payload)).toBe(payload);
+    expect(extractJsonPayload('  {"facts": []}  ')).toBe(payload);
+  });
+
+  it('does not unwrap a fence that only opens (malformed stays malformed)', () => {
+    const malformed = '```json\n{"facts": []}';
+    expect(extractJsonPayload(malformed)).toBe(malformed.trim());
   });
 });

--- a/services/ai-worker/src/services/extraction/extractionPrompt.ts
+++ b/services/ai-worker/src/services/extraction/extractionPrompt.ts
@@ -74,3 +74,25 @@ Extract NEW durable facts from the excerpts. Rules:
 Respond with ONLY a JSON object of this exact shape:
 {"facts": [{"statement": "...", "entityTags": ["user:alice"], "salience": 0.7, "supersedesIndex": null}]}`;
 }
+
+/**
+ * Unwrap a model response that arrives fenced as a markdown code block.
+ *
+ * Anthropic-family models via OpenRouter do not honor OpenAI-style
+ * response_format json_object and commonly return "```json\n{...}\n```" —
+ * without this unwrap, production fail-to-skip would silently skip EVERY
+ * batch (caught by the first real-model eval run, not by unit tests, whose
+ * mocks return clean JSON).
+ */
+export function extractJsonPayload(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith('```')) {
+    return trimmed;
+  }
+  const firstNewline = trimmed.indexOf('\n');
+  const closingFence = trimmed.lastIndexOf('```');
+  if (firstNewline === -1 || closingFence <= firstNewline) {
+    return trimmed; // open-only fence: malformed stays malformed (fail-to-skip)
+  }
+  return trimmed.slice(firstNewline + 1, closingFence).trim();
+}


### PR DESCRIPTION
## Summary

The slice-2 gate I owed — the first REAL-model `pnpm eval:extraction` run — immediately caught a production bug the unit suite structurally couldn't: **Anthropic-family models via OpenRouter ignore `response_format: json_object`** and return fenced ```` ```json ```` blocks. Production's fail-to-skip would have silently skipped **every** batch on dev (zero facts, one warn per batch) for the whole shadow window. The mocks return clean JSON, so 65 green tests never saw it — this is precisely the eval harness doing the job the plan assigned it.

## Fix

`extractJsonPayload` (plain string ops — the natural regex tripped the `no-super-linear-backtracking` ReDoS lint) unwraps ```` ```json ```` / ```` ``` ```` fences in the production parse path and the eval; an open-only fence stays malformed and fail-to-skips exactly as before. Four unit tests cover fenced/bare/pass-through/malformed.

## Baseline established (committed: `phase2-extraction-baseline.json`)

| Metric | Value | Read |
|---|---|---|
| meanRecall | **1.0** | never misses an expected fact |
| supersessionHitRate | **1.0** | index-targeting works perfectly on the real model |
| meanPrecision | 0.672 | over-extraction: scene narration + transient states extracted; also greedy-comparator artifact (legitimately-true-but-unenumerated facts count as hallucinations) |
| hallucinationRate | 0.393 | same two causes |

Precision sits below the 80% slice gate — recorded honestly rather than gamed. The failure mode is entirely on the write-quality axis (never the miss axis), the tuning levers are prompt tightening + golden `expectFacts` enrichment during the shadow window, and the 95% gate properly guards slice 4's retrieval integration. One golden drew a schema-invalid response (production absorbs via fail-to-skip).

## Verification

Extraction suites 42/42, full `pnpm test` 25/25, `pnpm quality` green. Eval re-run post-fix: 15/16 scoring (vs 16/16 hard-failing before the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)