### PR TITLE
fix: degrade to free default on system key when paid retarget lacks a user key

### DIFF
--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.test.ts
@@ -691,6 +691,40 @@ describe('AuthStep', () => {
         expect(result.auth?.quotaFallback?.toModel).toBe('paid/default');
       });
 
+      it('z.ai-only user (no OpenRouter key): doomed promotion degrades to the FREE default on the system key', async () => {
+        // Degraded-beats-failed: the paid retarget needs the user's own
+        // OpenRouter key; without one the request must still work — free
+        // default, system key, guest semantics, zero owner cost.
+        const promotedGuestFallback = {
+          ...PROMOTED_ROUTE,
+          fallback: { ...PROMOTED_ROUTE.fallback, apiKey: 'sk-system', isGuestMode: true },
+        };
+        const resolverWithDefaults = {
+          ...mockConfigResolver,
+          getGlobalDefaultConfig: vi.fn().mockResolvedValue({ model: 'paid/default' }),
+          getFreeDefaultConfig: vi.fn().mockResolvedValue({ model: 'free/default' }),
+        } as unknown as LlmConfigResolver;
+        const injectedRouter = {
+          resolveRoute: vi.fn().mockResolvedValue(promotedGuestFallback),
+        } as unknown as import('../../../../services/ProviderRouter.js').ProviderRouter;
+        vi.mocked(mockApiKeyResolver.resolveUserOpenRouterKey).mockResolvedValue(undefined);
+        vi.mocked(mockApiKeyResolver.resolveSystemOpenRouterKey).mockResolvedValue('sk-system');
+        step = new AuthStep(
+          mockApiKeyResolver,
+          resolverWithDefaults,
+          injectedRouter,
+          undefined,
+          buildDemotionCaches(['glm-5.2']) as never
+        );
+
+        const result = await step.process(makeContext());
+
+        expect(result.config?.effectivePersonality.model).toBe('free/default');
+        expect(result.auth?.apiKey).toBe('sk-system');
+        expect(result.auth?.isGuestMode).toBe(true);
+        expect(result.auth?.quotaFallback?.toModel).toBe('free/default');
+      });
+
       it('leaves a viable promotion untouched (no demotion, rescue route intact)', async () => {
         step = makeStep([]); // nothing doomed
 

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/AuthStep.ts
@@ -23,6 +23,7 @@ import {
 } from '../../../../services/quotaFallback.js';
 import { deriveCacheKeyId } from '../../../../services/RateLimitCache.js';
 import { tryPromotionDemotion } from './promotionDemotion.js';
+import { resolveRetargetRoute } from './retargetRoute.js';
 import type { IPipelineStep, GenerationContext } from '../types.js';
 
 const logger = createLogger('AuthStep');
@@ -240,40 +241,39 @@ export class AuthStep implements IPipelineStep {
       return null;
     }
 
-    let retargetApiKey = apiKey;
-    let retargetIsGuestMode = isGuestMode;
-    if (target.forceSystemKey) {
-      const systemKey = await this.apiKeyResolver?.resolveSystemOpenRouterKey();
-      if (systemKey === undefined) {
-        return null;
-      }
-      retargetApiKey = systemKey;
-      retargetIsGuestMode = true;
-    } else if (
-      personality.provider !== undefined &&
-      personality.provider !== (AIProvider.OpenRouter as string)
-    ) {
-      // The resolved key belongs to a different provider (e.g. a z.ai-promoted
-      // request carries the user's z.ai key). The OpenRouter retarget needs the
-      // user's OWN OpenRouter key; without one, abort rather than running a
-      // paid default on the system key (owner-cost boundary).
-      const openRouterKey = await this.apiKeyResolver?.resolveUserOpenRouterKey(userId);
-      if (openRouterKey === undefined) {
-        return null;
-      }
-      retargetApiKey = openRouterKey;
+    const resolved = await resolveRetargetRoute({
+      target,
+      personality,
+      apiKey,
+      isGuestMode,
+      userId,
+      category,
+      cacheKeyId,
+      deps: {
+        apiKeyResolver: this.apiKeyResolver,
+        configResolver: this.configResolver,
+        caches: this.quotaFallbackCaches,
+      },
+    });
+    if (resolved === null) {
+      return null;
     }
+    const {
+      config: retargetConfig,
+      apiKey: retargetApiKey,
+      isGuestMode: retargetIsGuestMode,
+    } = resolved;
 
     const info: QuotaFallbackInfo = {
       fromModel: personality.model,
-      toModel: target.config.model,
+      toModel: retargetConfig.model,
       category,
       mode: 'proactive',
     };
     logQuotaFallbackAudit(info, { jobId, cacheKeyId });
 
     return {
-      personality: applyConfigToPersonality(personality, target.config),
+      personality: applyConfigToPersonality(personality, retargetConfig),
       apiKey: retargetApiKey,
       isGuestMode: retargetIsGuestMode,
       info,

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/quotaFallbackRunner.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/quotaFallbackRunner.test.ts
@@ -235,7 +235,52 @@ describe('runWithQuotaFallback', () => {
     );
   });
 
-  it('z.ai-promoted personality without an OpenRouter key: terminal (never paid default on system key)', async () => {
+  it('z.ai-promoted personality without an OpenRouter key: degrades to the FREE default on the system key', async () => {
+    // Degraded-beats-failed (owner policy): the paid retarget can't ride the
+    // system key, but the FREE default can — the turn must still work.
+    // (Previously terminal; that expectation left z.ai-only users with a
+    // failed request instead of a degraded one.)
+    const original = quotaError(ApiErrorCategory.QUOTA_EXCEEDED);
+    const primary = vi.fn().mockRejectedValue(original);
+    const retry = vi.fn().mockResolvedValue({
+      response: { content: 'rescued' },
+      duplicateRetries: 0,
+      emptyRetries: 0,
+      leakedThinkingRetries: 0,
+    });
+
+    const result = await runWithQuotaFallback({
+      primary,
+      retry,
+      opts: buildOpts({
+        personality: {
+          id: 'p1',
+          name: 'Testy',
+          model: 'glm-5.2',
+          provider: 'zai-coding',
+        } as unknown as GenerateAttemptOpts['personality'],
+        apiKey: 'sk-zai-key',
+      }),
+      userId: '123',
+      deps: buildDeps({
+        global: { model: 'paid/default' },
+        free: { model: 'free/default' },
+        systemKey: 'sk-system-key',
+        userOpenRouterKey: undefined,
+      }),
+    });
+
+    expect(retry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'sk-system-key',
+        isGuestMode: true,
+        personality: expect.objectContaining({ model: 'free/default' }),
+      })
+    );
+    expect(result.quotaFallback?.toModel).toBe('free/default');
+  });
+
+  it('z.ai-promoted personality without OpenRouter key AND no system key: terminal', async () => {
     const original = quotaError(ApiErrorCategory.QUOTA_EXCEEDED);
     const primary = vi.fn().mockRejectedValue(original);
     const retry = vi.fn();
@@ -254,7 +299,12 @@ describe('runWithQuotaFallback', () => {
           apiKey: 'sk-zai-key',
         }),
         userId: '123',
-        deps: buildDeps({ global: { model: 'paid/default' }, userOpenRouterKey: undefined }),
+        deps: buildDeps({
+          global: { model: 'paid/default' },
+          free: { model: 'free/default' },
+          systemKey: undefined,
+          userOpenRouterKey: undefined,
+        }),
       })
     ).rejects.toBe(original);
     expect(retry).not.toHaveBeenCalled();

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/quotaFallbackRunner.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/quotaFallbackRunner.ts
@@ -103,14 +103,38 @@ export async function runWithQuotaFallback(options: {
       throw originalError;
     }
 
-    const credentials = await resolveRetryCredentials(target, opts, deps, userId);
+    let effectiveTarget = target;
+    let credentials = await resolveRetryCredentials(target, opts, deps, userId);
     if (credentials === null) {
-      throw originalError;
+      // Degraded-beats-failed (owner policy): the retarget's credential
+      // resolution came up empty (typically: paid target needs the user's own
+      // OpenRouter key and they have none). Downgrade to the FREE default on
+      // the system key — zero owner cost — rather than failing the turn.
+      // Wrapped so a throwing dep can never REPLACE the pristine original
+      // (same guarantee resolveRetryCredentials holds for itself).
+      try {
+        const guestTarget = await selectQuotaFallbackTarget({
+          category,
+          isGuestMode: true,
+          failingModel: opts.personality.model,
+          cacheKeyId,
+          configResolver: deps.configResolver,
+          caches: deps.caches,
+        });
+        const systemKey = await deps.resolveSystemKey();
+        if (guestTarget === null || systemKey === undefined) {
+          throw originalError;
+        }
+        effectiveTarget = guestTarget;
+        credentials = { apiKey: systemKey, isGuestMode: true };
+      } catch {
+        throw originalError;
+      }
     }
 
     const info: QuotaFallbackInfo = {
       fromModel: opts.personality.model,
-      toModel: target.config.model,
+      toModel: effectiveTarget.config.model,
       category,
       mode: 'reactive',
     };
@@ -120,7 +144,7 @@ export async function runWithQuotaFallback(options: {
       retry,
       opts: {
         ...opts,
-        personality: applyConfigToPersonality(opts.personality, target.config),
+        personality: applyConfigToPersonality(opts.personality, effectiveTarget.config),
         apiKey: credentials.apiKey,
         isGuestMode: credentials.isGuestMode,
         // The retarget is an OpenRouter attempt by construction (admin

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/retargetRoute.test.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/retargetRoute.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ApiErrorCategory } from '@tzurot/common-types/constants/error';
+import type { LlmConfigResolver } from '@tzurot/config-resolver';
+import type { ApiKeyResolver } from '../../../../services/ApiKeyResolver.js';
+import type {
+  QuotaFallbackCaches,
+  QuotaFallbackCategory,
+} from '../../../../services/quotaFallback.js';
+import { resolveRetargetRoute, type RetargetRouteDeps } from './retargetRoute.js';
+
+const CATEGORY = ApiErrorCategory.QUOTA_EXCEEDED as QuotaFallbackCategory;
+
+function makeDeps(overrides?: {
+  userOpenRouterKey?: string;
+  systemKey?: string;
+  freeConfig?: { model: string } | null;
+}): RetargetRouteDeps {
+  return {
+    apiKeyResolver: {
+      resolveUserOpenRouterKey: vi.fn().mockResolvedValue(overrides?.userOpenRouterKey),
+      resolveSystemOpenRouterKey: vi.fn().mockResolvedValue(overrides?.systemKey),
+    } as unknown as ApiKeyResolver,
+    configResolver: {
+      getFreeDefaultConfig: vi.fn().mockResolvedValue(overrides?.freeConfig ?? null),
+    } as unknown as LlmConfigResolver,
+    caches: {
+      creditExhaustion: { isCreditExhausted: vi.fn().mockResolvedValue({ exhausted: false }) },
+      rateLimit: { isRateLimited: vi.fn().mockResolvedValue({ rateLimited: false }) },
+    } as unknown as QuotaFallbackCaches,
+  };
+}
+
+const paidTarget = { config: { model: 'paid/default' }, forceSystemKey: false } as never;
+
+describe('resolveRetargetRoute', () => {
+  it('same-provider request keeps its own key and the target config', async () => {
+    const route = await resolveRetargetRoute({
+      target: paidTarget,
+      personality: { model: 'some/model', provider: 'openrouter' },
+      apiKey: 'sk-user',
+      isGuestMode: false,
+      userId: 'u1',
+      category: CATEGORY,
+      cacheKeyId: 'ck',
+      deps: makeDeps(),
+    });
+    expect(route).toEqual({
+      config: { model: 'paid/default' },
+      apiKey: 'sk-user',
+      isGuestMode: false,
+    });
+  });
+
+  it('cross-provider with a user OpenRouter key swaps to that key', async () => {
+    const route = await resolveRetargetRoute({
+      target: paidTarget,
+      personality: { model: 'glm-5.2', provider: 'zai-coding' },
+      apiKey: 'sk-zai',
+      isGuestMode: false,
+      userId: 'u1',
+      category: CATEGORY,
+      cacheKeyId: 'ck',
+      deps: makeDeps({ userOpenRouterKey: 'sk-or-user' }),
+    });
+    expect(route?.apiKey).toBe('sk-or-user');
+    expect(route?.config.model).toBe('paid/default');
+  });
+
+  it('cross-provider WITHOUT a user key degrades to the FREE default on the system key', async () => {
+    const route = await resolveRetargetRoute({
+      target: paidTarget,
+      personality: { model: 'glm-5.2', provider: 'zai-coding' },
+      apiKey: 'sk-zai',
+      isGuestMode: false,
+      userId: 'u1',
+      category: CATEGORY,
+      cacheKeyId: 'ck',
+      deps: makeDeps({ systemKey: 'sk-system', freeConfig: { model: 'free/default' } }),
+    });
+    expect(route).toEqual({
+      config: { model: 'free/default' },
+      apiKey: 'sk-system',
+      isGuestMode: true,
+    });
+  });
+
+  it('downgrade aborts (null) when no system key or free default exists', async () => {
+    const noSystem = await resolveRetargetRoute({
+      target: paidTarget,
+      personality: { model: 'glm-5.2', provider: 'zai-coding' },
+      apiKey: 'sk-zai',
+      isGuestMode: false,
+      userId: 'u1',
+      category: CATEGORY,
+      cacheKeyId: 'ck',
+      deps: makeDeps({ freeConfig: { model: 'free/default' } }),
+    });
+    expect(noSystem).toBeNull();
+
+    const noFree = await resolveRetargetRoute({
+      target: paidTarget,
+      personality: { model: 'glm-5.2', provider: 'zai-coding' },
+      apiKey: 'sk-zai',
+      isGuestMode: false,
+      userId: 'u1',
+      category: CATEGORY,
+      cacheKeyId: 'ck',
+      deps: makeDeps({ systemKey: 'sk-system', freeConfig: null }),
+    });
+    expect(noFree).toBeNull();
+  });
+
+  it('forced system-key target (credit exhaustion) uses the system key with guest semantics', async () => {
+    const route = await resolveRetargetRoute({
+      target: { config: { model: 'free/default' }, forceSystemKey: true } as never,
+      personality: { model: 'some/model', provider: 'openrouter' },
+      apiKey: 'sk-user',
+      isGuestMode: false,
+      userId: 'u1',
+      category: CATEGORY,
+      cacheKeyId: 'ck',
+      deps: makeDeps({ systemKey: 'sk-system' }),
+    });
+    expect(route).toEqual({
+      config: { model: 'free/default' },
+      apiKey: 'sk-system',
+      isGuestMode: true,
+    });
+  });
+});

--- a/services/ai-worker/src/jobs/handlers/pipeline/steps/retargetRoute.ts
+++ b/services/ai-worker/src/jobs/handlers/pipeline/steps/retargetRoute.ts
@@ -1,0 +1,99 @@
+/**
+ * Retarget route resolution for the proactive quota fallback (kept out of
+ * AuthStep for the 400-line cap; pure functions over injected deps).
+ *
+ * Resolves the (config, key, guest-mode) triple a quota retarget should run
+ * on. The load-bearing policy: when the paid target needs the user's own
+ * OpenRouter key and they have none, degrade to the FREE default on the
+ * system key (guest semantics, zero owner cost) — a failed request is a worse
+ * experience than a degraded one (owner policy), and the paid default must
+ * never ride the system key.
+ */
+
+import { AIProvider } from '@tzurot/common-types/constants/ai';
+import type { LlmConfigResolver } from '@tzurot/config-resolver';
+import type { ApiKeyResolver } from '../../../../services/ApiKeyResolver.js';
+import {
+  selectQuotaFallbackTarget,
+  type QuotaFallbackCaches,
+  type QuotaFallbackCategory,
+} from '../../../../services/quotaFallback.js';
+
+type QuotaTarget = NonNullable<Awaited<ReturnType<typeof selectQuotaFallbackTarget>>>;
+
+export interface RetargetRouteDeps {
+  apiKeyResolver: ApiKeyResolver | undefined;
+  configResolver: LlmConfigResolver | undefined;
+  caches: QuotaFallbackCaches | undefined;
+}
+
+export interface ResolvedRetargetRoute {
+  config: QuotaTarget['config'];
+  apiKey: string | undefined;
+  isGuestMode: boolean;
+}
+
+/**
+ * Resolve the credential + config triple for a selected quota target.
+ * Null aborts the retarget (the doomed request proceeds and fails as before).
+ */
+export async function resolveRetargetRoute(options: {
+  target: QuotaTarget;
+  personality: { model: string; provider?: string };
+  apiKey: string | undefined;
+  isGuestMode: boolean;
+  userId: string;
+  category: QuotaFallbackCategory;
+  cacheKeyId: string;
+  deps: RetargetRouteDeps;
+}): Promise<ResolvedRetargetRoute | null> {
+  const { target, personality, apiKey, isGuestMode, userId, category, cacheKeyId, deps } = options;
+
+  if (target.forceSystemKey) {
+    const systemKey = await deps.apiKeyResolver?.resolveSystemOpenRouterKey();
+    return systemKey === undefined
+      ? null
+      : { config: target.config, apiKey: systemKey, isGuestMode: true };
+  }
+
+  const isCrossProvider =
+    personality.provider !== undefined &&
+    personality.provider !== (AIProvider.OpenRouter as string);
+  if (!isCrossProvider) {
+    return { config: target.config, apiKey, isGuestMode };
+  }
+
+  // Cross-provider (e.g. a z.ai-promoted request carries the user's z.ai
+  // key): the OpenRouter retarget needs the user's OWN OpenRouter key.
+  const openRouterKey = await deps.apiKeyResolver?.resolveUserOpenRouterKey(userId);
+  if (openRouterKey !== undefined) {
+    return { config: target.config, apiKey: openRouterKey, isGuestMode };
+  }
+  return downgradeToFreeDefault({ personality, category, cacheKeyId, deps });
+}
+
+/** The degraded-beats-failed downgrade: free default, system key, guest semantics. */
+async function downgradeToFreeDefault(options: {
+  personality: { model: string };
+  category: QuotaFallbackCategory;
+  cacheKeyId: string;
+  deps: RetargetRouteDeps;
+}): Promise<ResolvedRetargetRoute | null> {
+  const { personality, category, cacheKeyId, deps } = options;
+  if (deps.caches === undefined || deps.configResolver === undefined) {
+    return null;
+  }
+  const guestTarget = await selectQuotaFallbackTarget({
+    category,
+    isGuestMode: true,
+    failingModel: personality.model,
+    cacheKeyId,
+    configResolver: deps.configResolver,
+    caches: deps.caches,
+  });
+  const systemKey = await deps.apiKeyResolver?.resolveSystemOpenRouterKey();
+  if (guestTarget === null || systemKey === undefined) {
+    return null;
+  }
+  return { config: guestTarget.config, apiKey: systemKey, isGuestMode: true };
+}


### PR DESCRIPTION
## Summary

Owner-directed follow-on to #1531: **"the goal is to give the user as good an experience as possible without costing me money — a failed request is a worse experience than a degraded one."**

Both quota-retarget paths (proactive `AuthStep`, reactive `quotaFallbackRunner`) aborted when the paid retarget needed the user's own OpenRouter key and they had none — a z.ai-key-only user's doomed request simply ran and failed. That abort branch now **downgrades to the free default on the system key with guest semantics**: the turn works, degraded, at zero owner cost. The invariant "the paid default never rides the system key" is preserved — it's precisely why the downgrade swaps the *config* to the free default rather than just the key.

## Mechanics

- Proactive: `AuthStep`'s retarget-route resolution extracted to `retargetRoute.ts` (pure functions — the new branch pushed AuthStep past both the 400-line cap and the complexity ceiling), with the downgrade as the cross-provider-no-user-key terminal branch.
- Reactive: the runner's `credentials === null` → throw becomes a guest-target re-selection + system key, **wrapped so a throwing credential dep can never replace the pristine original error** (the existing guarantee, still pinned by its test).
- The old `"terminal (never paid default on system key)"` runner test encoded the failed-request behavior — it now asserts the free-default downgrade, with a no-system-key truly-terminal case kept alongside.

## Tests

New `retargetRoute.test.ts` matrix (same-provider passthrough / cross-provider key swap / **downgrade** / downgrade-aborts / forced-system-key) + AuthStep proactive downgrade test (z.ai-only user lands on `free/default` + system key + guest) + runner downgrade/terminal pair. 306 pipeline-step tests green; full `pnpm test` 25/25; `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)