### PR TITLE
fix: guest paid-vision leak + vision failure signal (C2b-6 + C2b-3)

### DIFF
--- a/services/ai-worker/src/jobs/ImageDescriptionJob.test.ts
+++ b/services/ai-worker/src/jobs/ImageDescriptionJob.test.ts
@@ -479,6 +479,75 @@ describe('ImageDescriptionJob', () => {
       expect(result.metadata!.failedCount).toBe(1); // Track failures
     });
 
+    it('counts placeholder-shaped descriptions into failedCount (C2b-3: the wired path never throws)', async () => {
+      // The fallback loop renders failures as '[Image ...' placeholder content
+      // with success: true — without placeholder counting, failedCount pins at
+      // 0 and failure-rate monitoring goes silent. Placeholder-as-content
+      // stays; only the signal is restored.
+      const jobData: ImageDescriptionJobData = {
+        requestId: 'test-req-placeholder',
+        jobType: JobType.ImageDescription,
+        attachments: [
+          {
+            url: 'https://example.com/broken.png',
+            name: 'broken.png',
+            contentType: CONTENT_TYPES.IMAGE_PNG,
+            size: 1024,
+          },
+        ],
+        personality: mockPersonality,
+        context: { userId: 'user-123', channelId: 'channel-456' },
+        responseDestination: { type: 'discord', channelId: 'channel-456' },
+      };
+      const job = { id: 'image-test-placeholder', data: jobData } as Job<ImageDescriptionJobData>;
+      mockDescribeImage.mockResolvedValue(
+        '[Image "broken.png" unavailable: the vision model could not process it]'
+      );
+
+      const result = await processImageDescriptionJob(job);
+
+      expect(result.success).toBe(true); // user-facing behavior unchanged
+      expect(result.descriptions).toHaveLength(1); // placeholder still ships as content
+      expect(result.metadata!.failedCount).toBe(1); // ...but the signal fires
+    });
+
+    it('counts a placeholder from the RESOLVER-WIRED path into failedCount (C2b-3 motivating path)', async () => {
+      // The fallback loop renders failures as placeholder content — this is
+      // the exact production path whose signal was muted (the legacy-path
+      // variant of this test lives above).
+      const jobData: ImageDescriptionJobData = {
+        requestId: 'test-req-wired-placeholder',
+        jobType: JobType.ImageDescription,
+        attachments: [
+          {
+            url: 'https://example.com/broken2.png',
+            name: 'broken2.png',
+            contentType: CONTENT_TYPES.IMAGE_PNG,
+            size: 1024,
+          },
+        ],
+        personality: mockPersonality,
+        context: { userId: 'user-123', channelId: 'channel-456' },
+        responseDestination: { type: 'discord', channelId: 'channel-456' },
+      };
+      const job = {
+        id: 'image-test-wired-placeholder',
+        data: jobData,
+      } as Job<ImageDescriptionJobData>;
+      const mockApiKeyResolver = {
+        tryResolveUserKey: vi.fn(),
+        resolveApiKey: vi.fn(),
+      } as unknown as ApiKeyResolver;
+      mockDescribeImageWithFallback.mockResolvedValue(
+        '[Image "broken2.png" unavailable: all vision routes failed]'
+      );
+
+      const result = await processImageDescriptionJob(job, mockApiKeyResolver);
+
+      expect(result.success).toBe(true); // placeholder still ships as content
+      expect(result.metadata!.failedCount).toBe(1); // ...and the signal fires on THIS path
+    });
+
     it('routes to describeImageWithFallback with the guest userId in the visionAuth bundle', async () => {
       // Phase-4: with a resolver present, the job hands the auth INPUTS to the
       // fallback loop. The genuine-guest → free-model-on-system-key resolution now

--- a/services/ai-worker/src/jobs/ImageDescriptionJob.ts
+++ b/services/ai-worker/src/jobs/ImageDescriptionJob.ts
@@ -26,6 +26,8 @@ import {
   type ResolveVisionConfigOptions,
 } from '../services/multimodal/visionAuthResolver.js';
 
+import { VISION_PLACEHOLDER_PREFIX } from '../services/multimodal/visionDescriptionValidity.js';
+
 const logger = createLogger('ImageDescriptionJob');
 
 /**
@@ -308,7 +310,15 @@ export async function processImageDescriptionJob(
       )
       .map(r => ({ url: r.url, description: r.description }));
 
-    const failedCount = results.length - descriptions.length;
+    // Placeholder-shaped "descriptions" (the '[Image ...' render of a failure)
+    // ARE the wired path's failure mode — the loop never throws, so counting
+    // only missing descriptions pins failedCount at 0 and mutes failure-rate
+    // monitoring entirely. Placeholder-as-content stays (deliberate design);
+    // this restores the signal only.
+    const placeholderCount = descriptions.filter(d =>
+      d.description.trim().startsWith(VISION_PLACEHOLDER_PREFIX)
+    ).length;
+    const failedCount = results.length - descriptions.length + placeholderCount;
 
     if (descriptions.length === 0) {
       return buildAllFailedResult(requestId, results, attachments.length, sourceReferenceNumber);

--- a/services/ai-worker/src/services/multimodal/VisionProcessor.test.ts
+++ b/services/ai-worker/src/services/multimodal/VisionProcessor.test.ts
@@ -343,6 +343,54 @@ describe('VisionProcessor', () => {
         expect(mockCheckModelVisionSupport).not.toHaveBeenCalled();
       });
 
+      it('guest + explicit PAID visionModel free-forces on the PRIMARY tier (C2b-6)', async () => {
+        // The same cost-leak class the fallback-tier fix closed: a guest must
+        // not run a paid configured vision model on the system key.
+        const personality = createMockPersonality({
+          model: 'gpt-4',
+          visionModel: 'anthropic/claude-sonnet-4.5', // explicit PAID vision model
+        });
+
+        await describeImage(mockAttachment, personality, true /* isGuestMode */, undefined);
+
+        expect(mockCreateChatModel).toHaveBeenCalledWith(
+          expect.objectContaining({
+            modelName: MODEL_DEFAULTS.VISION_FALLBACK_FREE,
+          })
+        );
+      });
+
+      it('guest + vision-capable PAID main model free-forces on Priority 2 too', async () => {
+        mockCheckModelVisionSupport.mockResolvedValue(true); // main model HAS vision
+        const personality = createMockPersonality({
+          model: 'openai/gpt-4o', // paid, vision-capable, no explicit visionModel
+          visionModel: undefined,
+        });
+
+        await describeImage(mockAttachment, personality, true /* isGuestMode */, undefined);
+
+        expect(mockCreateChatModel).toHaveBeenCalledWith(
+          expect.objectContaining({
+            modelName: MODEL_DEFAULTS.VISION_FALLBACK_FREE,
+          })
+        );
+      });
+
+      it('non-guest keeps an explicit paid visionModel unchanged on the primary tier', async () => {
+        const personality = createMockPersonality({
+          model: 'gpt-4',
+          visionModel: 'anthropic/claude-sonnet-4.5',
+        });
+
+        await describeImage(mockAttachment, personality, false /* isGuestMode */, undefined);
+
+        expect(mockCreateChatModel).toHaveBeenCalledWith(
+          expect.objectContaining({
+            modelName: 'anthropic/claude-sonnet-4.5',
+          })
+        );
+      });
+
       it('falls back to selectVisionModel when options.model is an empty string', async () => {
         mockCheckModelVisionSupport.mockResolvedValue(false);
         const personality = createMockPersonality({

--- a/services/ai-worker/src/services/multimodal/VisionProcessor.ts
+++ b/services/ai-worker/src/services/multimodal/VisionProcessor.ts
@@ -11,7 +11,12 @@
 
 import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { getConfig } from '@tzurot/common-types/config/config';
-import { AI_DEFAULTS, MODEL_DEFAULTS, type AIProvider } from '@tzurot/common-types/constants/ai';
+import {
+  AI_DEFAULTS,
+  MODEL_DEFAULTS,
+  isFreeModel,
+  type AIProvider,
+} from '@tzurot/common-types/constants/ai';
 import { ERROR_MESSAGES, ApiErrorCategory } from '@tzurot/common-types/constants/error';
 import { TIMEOUTS } from '@tzurot/common-types/constants/timing';
 import { type AttachmentMetadata } from '@tzurot/common-types/types/schemas/discord';
@@ -24,6 +29,7 @@ import { checkModelVisionSupport, visionDescriptionCache } from '../../redis.js'
 import { isDataUrl } from '../../utils/attachmentFetch.js';
 import { downloadImageToDataUrl } from '../../utils/imageToDataUrl.js';
 import {
+  VISION_PLACEHOLDER_PREFIX,
   isValidVisionDescription,
   VISION_MIN_DESCRIPTION_LENGTH,
 } from './visionDescriptionValidity.js';
@@ -443,7 +449,10 @@ export function buildFailureFallback(
   apiKeySource: 'user' | 'system' | undefined,
   filename?: string
 ): string {
-  const subject = filename !== undefined && filename.length > 0 ? `[Image "${filename}"` : '[Image';
+  const subject =
+    filename !== undefined && filename.length > 0
+      ? `${VISION_PLACEHOLDER_PREFIX} "${filename}"`
+      : VISION_PLACEHOLDER_PREFIX;
   if (category === ApiErrorCategory.AUTHENTICATION) {
     if (apiKeySource === 'user') {
       return `${subject} was shared but couldn't be processed — the vision API key was rejected; it can be fixed with /settings apikey set]`;
@@ -517,19 +526,40 @@ export async function selectVisionModel(
   personality: LoadedPersonality,
   isGuestMode: boolean
 ): Promise<string> {
-  // Priority 1: Use personality's configured vision model if specified
+  // Priority 1: Use personality's configured vision model if specified.
+  // Guest mode free-forces a PAID configured model — the same cost-leak class
+  // the fallback tiers already guard: a guest hunting paid-vision personas
+  // must not burn the system key on the primary tier either.
   if (
     personality.visionModel !== undefined &&
     personality.visionModel !== null &&
     personality.visionModel.length > 0
   ) {
+    if (isGuestMode && !isFreeModel(personality.visionModel)) {
+      logger.info(
+        { configuredVisionModel: personality.visionModel },
+        'Guest mode: free-forcing paid configured vision model'
+      );
+      return MODEL_DEFAULTS.VISION_FALLBACK_FREE;
+    }
     logger.debug({ visionModel: personality.visionModel }, 'Using configured vision model');
     return personality.visionModel;
   }
 
-  // Priority 2: Use personality's main model if it has native vision support
+  // Priority 2: Use personality's main model if it has native vision support.
+  // Same guest free-force as Priority 1 — a vision-capable PAID main model
+  // (gpt-4o, gemini-pro, ...) is the more common config than an explicit
+  // visionModel override; guarding at this seam needs no caller-by-caller
+  // reachability proof and cannot affect non-guests.
   const mainModelHasVision = await hasVisionSupport(personality.model);
   if (mainModelHasVision) {
+    if (isGuestMode && !isFreeModel(personality.model)) {
+      logger.info(
+        { mainModel: personality.model },
+        'Guest mode: free-forcing paid vision-capable main model'
+      );
+      return MODEL_DEFAULTS.VISION_FALLBACK_FREE;
+    }
     logger.debug(
       { model: personality.model, source: 'main-model-vision' },
       'Using main LLM for vision (native vision support detected via cache/pattern)'

--- a/services/ai-worker/src/services/multimodal/visionDescriptionValidity.ts
+++ b/services/ai-worker/src/services/multimodal/visionDescriptionValidity.ts
@@ -16,6 +16,14 @@
 export const VISION_MIN_DESCRIPTION_LENGTH = 10;
 
 /**
+ * The canonical prefix of a failure-placeholder "description" ('[Image ...').
+ * Shared contract between the placeholder renderer (buildFailureFallback),
+ * the validity check below, and ImageDescriptionJob's failure counting —
+ * one constant instead of three independent literals.
+ */
+export const VISION_PLACEHOLDER_PREFIX = '[Image';
+
+/**
  * Patterns that indicate a vision model returned an error message as text
  * content rather than an actual image description.
  */
@@ -61,7 +69,7 @@ export function isValidVisionDescription(description: string): boolean {
   const trimmed = description.trim();
   return (
     trimmed.length >= VISION_MIN_DESCRIPTION_LENGTH &&
-    !trimmed.startsWith('[Image') &&
+    !trimmed.startsWith(VISION_PLACEHOLDER_PREFIX) &&
     !isLikelyErrorDescription(trimmed)
   );
 }


### PR DESCRIPTION
## Summary

The paired vision-path items from the external review brief (items 2+6), riding the same path per the brief's sequencing.

**[C2b-6] Guest paid-vision leak (primary tier)**: `selectVisionModel` Priority 1 returned an explicitly-configured **paid** `visionModel` without checking `isGuestMode` — the same cost-leak class the C2b-1 fix closed for the *fallback* tiers, still open on the primary tier. Adversarial shape per the brief: discoverable personality configs let a guest deliberately hunt paid-vision personas and burn the system key. Guests now free-force to `VISION_FALLBACK_FREE`; authenticated users keep their configured model verbatim. Both directions pinned by tests.

**Protected surface (per round-4 review trace)**: the guard lands in `selectVisionModel`, the seam shared by three callers — but the live leak was on the **RAG history/reference path** (`ragVisionAuth.ts`) and the **extended-context path** (`extendedContextVisionProcessor.ts`), which thread a genuinely-resolved `isGuestMode`. `ImageDescriptionJob`'s resolver-wired path hardcodes `isGuestMode: false` (deliberate Phase-4 shape) and was already guest-safe via `resolveBroadFreeFallback`. Priorities 1 AND 2 (explicit visionModel / vision-capable main model) are both guarded — guarding the shared seam needs no caller-by-caller reachability proof.

**Scope note**: an unrelated gateway shutdown-drain edit briefly leaked into this diff from a parallel branch (round-4 review caught it); it has been stripped — that change lives in #1535 with its own test.

**[C2b-3] Vision failure signal restored**: the wired `ImageDescriptionJob` path never throws — failures render as `[Image ...` placeholder *content* with `success: true`, so `metadata.failedCount` was structurally pinned at 0 and `buildAllFailedResult` unreachable; any failure-rate monitoring was decorative. Placeholder-shaped descriptions now count into `failedCount`. **Placeholder-as-content stays** (deliberate design) — only the signal is restored, and the test pins exactly that contract: `success: true`, placeholder ships to the user, `failedCount: 1`.

## Acceptance (both from the brief)

- Guest + explicit paid `visionModel` resolves to the free tier on the primary tier ✅ (test) / non-guest unchanged ✅ (test)
- A forced description failure increments `failedCount`; user-facing behavior unchanged ✅ (test)

## Verification

VisionProcessor 70/70, ImageDescriptionJob 17/17, full `pnpm test` 25/25, `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
