### PR TITLE
feat: NULL-vector memory self-healing sweep + dead-letter backlog visibility

### DIFF
--- a/.claude/rules/03-database.md
+++ b/.claude/rules/03-database.md
@@ -109,13 +109,14 @@ Prisma tries to DROP these indexes in migrations - ALWAYS review and remove:
 | `tts_configs_free_default_unique` | Partial unique | Prisma can't represent partial unique indexes |
 | `tts_configs_global_name_unique`  | Partial unique | Prisma can't represent partial unique indexes |
 | `idx_memories_is_locked`          | Partial B-tree | Prisma can't represent WHERE clauses          |
+| `idx_memories_null_embedding`     | Partial B-tree | Prisma can't represent WHERE clauses          |
 
 **Source of truth**: `prisma/drift-ignore.json` has a two-tier structure for index protection — pick the right tier when adding new entries:
 
 - **`ignorePatterns`** — list of regexes that strip unwanted SQL from Prisma's generated migration. Most entries are `DROP INDEX` patterns (the index should survive Prisma's drop), but the array also handles `CREATE INDEX` patterns where Prisma generates the wrong shape. For example, `memories_chunk_group_id_idx` has both a DROP entry **and** a CREATE entry — Prisma emits a non-partial CREATE that gets stripped, and the manually-written partial-index CREATE in the migration body is what actually applies. Use this for any generated SQL that should be suppressed; it's the minimum required for any partial/special index Prisma can't represent.
 - **`protectedIndexes`** — DROP suppression **plus** full `recreateSQL`. Add an entry here only if you also need a recovery path: someone accidentally drops the index and you want a one-line recreate. The IVFFlat vector index lives here because losing it would silently degrade query performance by 100x and you'd want the SQL ready to paste back in.
 
-The indexes above are split: `idx_memories_embedding` and `memories_chunk_group_id_idx` are in **both** arrays (DROP suppression + recreate SQL); `llm_configs_free_default_unique`, `llm_configs_global_name_unique`, `llm_configs_default_unique`, `tts_configs_free_default_unique`, `tts_configs_global_name_unique`, and `idx_memories_is_locked` are in **`ignorePatterns` only** (DROP suppression alone is enough — they have no expensive recreate cost). When adding a new partial/special index, default to `ignorePatterns`-only and only promote to `protectedIndexes` if recovery SQL would be valuable.
+The indexes above are split: `idx_memories_embedding` and `memories_chunk_group_id_idx` are in **both** arrays (DROP suppression + recreate SQL); `llm_configs_free_default_unique`, `llm_configs_global_name_unique`, `llm_configs_default_unique`, `tts_configs_free_default_unique`, `tts_configs_global_name_unique`, `idx_memories_is_locked`, and `idx_memories_null_embedding` are in **`ignorePatterns` only** (DROP suppression alone is enough — they have no expensive recreate cost). When adding a new partial/special index, default to `ignorePatterns`-only and only promote to `protectedIndexes` if recovery SQL would be valuable.
 
 ### Optional Columns Require Null-Semantics Documentation
 

--- a/prisma/drift-ignore.json
+++ b/prisma/drift-ignore.json
@@ -110,6 +110,11 @@
       "pattern": "DROP INDEX.*idx_memory_facts_embedding",
       "reason": "IVFFlat index on memory_facts.embedding managed outside Prisma (Unsupported vector type)",
       "action": "remove"
+    },
+    {
+      "pattern": "DROP INDEX.*idx_memories_null_embedding",
+      "reason": "Partial index with WHERE clause cannot be represented in Prisma schema (backs NullVectorReembedder sweep)",
+      "action": "remove"
     }
   ],
   "documentation": {

--- a/prisma/migrations/20260707150036_add_null_embedding_sweep_index/migration.sql
+++ b/prisma/migrations/20260707150036_add_null_embedding_sweep_index/migration.sql
@@ -1,0 +1,15 @@
+-- DropIndex
+-- REMOVED: DROP INDEX "idx_memories_embedding";
+
+-- DropIndex
+-- REMOVED: DROP INDEX "idx_memory_facts_embedding";
+
+-- Partial index backing the NullVectorReembedder hourly sweep:
+--   SELECT id, content FROM memories
+--   WHERE embedding IS NULL AND visibility = 'normal'
+--   ORDER BY created_at ASC LIMIT 50
+-- The generic visibility index is non-selective ('normal' is the dominant
+-- value); without this, the sweep scans all live rows every hour. The partial
+-- index stays tiny (only broken rows qualify) and makes the sweep O(backlog).
+CREATE INDEX "idx_memories_null_embedding" ON "memories" ("created_at")
+  WHERE embedding IS NULL AND visibility = 'normal';

--- a/services/ai-worker/src/index.ts
+++ b/services/ai-worker/src/index.ts
@@ -15,6 +15,7 @@ import { PgvectorMemoryAdapter } from './services/PgvectorMemoryAdapter.js';
 import { LocalEmbeddingService } from '@tzurot/embeddings';
 import { AIJobProcessor } from './jobs/AIJobProcessor.js';
 import { PendingMemoryProcessor } from './jobs/PendingMemoryProcessor.js';
+import { NullVectorReembedder } from './jobs/NullVectorReembedder.js';
 import { setupFactExtraction } from './jobs/factExtractionSetup.js';
 import { cleanupDiagnosticLogs } from './jobs/CleanupDiagnosticLogs.js';
 import { cleanupStuckImportJobs } from './jobs/cleanupStuckImportJobs.js';
@@ -46,6 +47,7 @@ const SCHEDULED_JOBS = {
   CLEANUP_STUCK_EXPORTS: 'cleanup-stuck-exports',
   CLEANUP_EXPIRED_EXPORTS: 'cleanup-expired-exports',
   CLEANUP_CONVERSATION_RETENTION: 'cleanup-conversation-retention',
+  REEMBED_NULL_VECTORS: 'reembed-null-vectors',
 } as const;
 
 // ============================================================================
@@ -199,11 +201,34 @@ function createMainWorker(jobProcessor: AIJobProcessor): Worker {
 }
 
 /**
+ * Repeatable-job schedule. Minute offsets are deliberate: they spread the
+ * hourly/15-min jobs across the hour so runs don't stack on shared resources.
+ * Conversation retention runs daily at 09:10 UTC — off-peak for the
+ * primarily-US user base, offset off the hourly jobs' minute marks.
+ */
+const REPEATABLE_JOB_SCHEDULE: readonly { name: string; pattern: string }[] = [
+  { name: SCHEDULED_JOBS.PROCESS_PENDING_MEMORIES, pattern: '*/10 * * * *' },
+  { name: SCHEDULED_JOBS.REEMBED_NULL_VECTORS, pattern: '13 * * * *' },
+  { name: SCHEDULED_JOBS.CLEANUP_DIAGNOSTIC_LOGS, pattern: '0 * * * *' },
+  { name: SCHEDULED_JOBS.CLEANUP_STUCK_IMPORTS, pattern: '*/15 * * * *' },
+  { name: SCHEDULED_JOBS.CLEANUP_STUCK_EXPORTS, pattern: '7,22,37,52 * * * *' },
+  { name: SCHEDULED_JOBS.CLEANUP_EXPIRED_EXPORTS, pattern: '30 * * * *' },
+  { name: SCHEDULED_JOBS.CLEANUP_CONVERSATION_RETENTION, pattern: '10 9 * * *' },
+];
+
+async function registerRepeatableJobs(scheduledQueue: Queue): Promise<void> {
+  for (const { name, pattern } of REPEATABLE_JOB_SCHEDULE) {
+    await scheduledQueue.add(name, {}, { repeat: { pattern }, jobId: name });
+  }
+}
+
+/**
  * Set up scheduled jobs queue and worker for periodic maintenance tasks
  */
 async function setupScheduledJobs(
   pendingMemoryProcessor: PendingMemoryProcessor,
-  prisma: PrismaClient
+  prisma: PrismaClient,
+  nullVectorReembedder: NullVectorReembedder
 ): Promise<ScheduledJobsResult> {
   const scheduledQueue = new Queue(SCHEDULED_QUEUE_NAME, { connection: config.redis });
 
@@ -212,7 +237,16 @@ async function setupScheduledJobs(
     async (job: Job) => {
       if (job.name === SCHEDULED_JOBS.PROCESS_PENDING_MEMORIES) {
         logger.debug('Running pending memory processor');
-        return pendingMemoryProcessor.processPendingMemories();
+        const stats = await pendingMemoryProcessor.processPendingMemories();
+        // Backlog snapshot rides every run's completed log — the dead-letter
+        // rows (attempts >= cap / the 999 invalid-metadata sentinel) are
+        // otherwise invisible after their single "Gave up" line.
+        const backlog = await pendingMemoryProcessor.getStats();
+        return { ...stats, backlog };
+      }
+      if (job.name === SCHEDULED_JOBS.REEMBED_NULL_VECTORS) {
+        logger.debug('Running NULL-vector re-embed sweep');
+        return nullVectorReembedder.sweep();
       }
       if (job.name === SCHEDULED_JOBS.CLEANUP_DIAGNOSTIC_LOGS) {
         logger.debug('Running diagnostic log cleanup');
@@ -260,54 +294,14 @@ async function setupScheduledJobs(
     logger.error({ err: error }, `Job ${job?.name} failed`);
   });
 
-  // Add repeatable job for pending memories (every 10 minutes)
-  await scheduledQueue.add(
-    SCHEDULED_JOBS.PROCESS_PENDING_MEMORIES,
-    {},
-    { repeat: { pattern: '*/10 * * * *' }, jobId: SCHEDULED_JOBS.PROCESS_PENDING_MEMORIES }
-  );
+  await registerRepeatableJobs(scheduledQueue);
 
-  // Add repeatable job for diagnostic log cleanup (hourly)
-  await scheduledQueue.add(
-    SCHEDULED_JOBS.CLEANUP_DIAGNOSTIC_LOGS,
-    {},
-    { repeat: { pattern: '0 * * * *' }, jobId: SCHEDULED_JOBS.CLEANUP_DIAGNOSTIC_LOGS }
-  );
-
-  // Add repeatable job for stuck import job cleanup (every 15 minutes)
-  await scheduledQueue.add(
-    SCHEDULED_JOBS.CLEANUP_STUCK_IMPORTS,
-    {},
-    { repeat: { pattern: '*/15 * * * *' }, jobId: SCHEDULED_JOBS.CLEANUP_STUCK_IMPORTS }
-  );
-
-  // Add repeatable job for stuck export job cleanup (every 15 minutes, offset by 7 min)
-  await scheduledQueue.add(
-    SCHEDULED_JOBS.CLEANUP_STUCK_EXPORTS,
-    {},
-    { repeat: { pattern: '7,22,37,52 * * * *' }, jobId: SCHEDULED_JOBS.CLEANUP_STUCK_EXPORTS }
-  );
-
-  // Add repeatable job for expired export cleanup (hourly, offset by 30 min)
-  await scheduledQueue.add(
-    SCHEDULED_JOBS.CLEANUP_EXPIRED_EXPORTS,
-    {},
-    { repeat: { pattern: '30 * * * *' }, jobId: SCHEDULED_JOBS.CLEANUP_EXPIRED_EXPORTS }
-  );
-
-  // Add repeatable job for conversation retention (daily at 09:10 UTC — off-peak
-  // for the primarily-US user base, offset off the hourly jobs' minute marks)
-  await scheduledQueue.add(
-    SCHEDULED_JOBS.CLEANUP_CONVERSATION_RETENTION,
-    {},
-    {
-      repeat: { pattern: '10 9 * * *' },
-      jobId: SCHEDULED_JOBS.CLEANUP_CONVERSATION_RETENTION,
-    }
-  );
-
+  // Derived from the schedule table so this line can't silently omit a job.
   logger.info(
-    'Scheduled jobs configured (pending memory: every 10 min, diagnostic cleanup: hourly, stuck imports/exports: every 15 min, expired exports: hourly, conversation retention: daily 09:10 UTC)'
+    {
+      schedule: Object.fromEntries(REPEATABLE_JOB_SCHEDULE.map(j => [j.name, j.pattern])),
+    },
+    'Scheduled jobs configured'
   );
 
   return { scheduledQueue, scheduledWorker };
@@ -402,9 +396,11 @@ async function main(): Promise<void> {
   }
 
   // Set up scheduled jobs
+  const nullVectorReembedder = new NullVectorReembedder(prisma, memoryManager);
   const { scheduledQueue, scheduledWorker } = await setupScheduledJobs(
     pendingMemoryProcessor,
-    prisma
+    prisma,
+    nullVectorReembedder
   );
 
   // Start health server if enabled

--- a/services/ai-worker/src/jobs/NullVectorReembedder.component.test.ts
+++ b/services/ai-worker/src/jobs/NullVectorReembedder.component.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Component test: the NULL-vector self-healing sweep over REAL PGLite+pgvector.
+ * Proves the full acceptance: a seeded NULL-vector row is re-embedded AND
+ * becomes RAG-visible again; soft-deleted rows are skipped; repeat runs no-op.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { type PGlite } from '@electric-sql/pglite';
+import { PrismaPGlite } from 'pglite-prisma-adapter';
+import { PrismaClient } from '@tzurot/common-types/services/prisma';
+import { createTestPGlite, loadPGliteSchema, seedUserWithPersona } from '@tzurot/test-utils';
+import { LocalEmbeddingService } from '@tzurot/embeddings';
+import { deterministicMemoryUuid } from '@tzurot/common-types/constants/memory';
+import { PgvectorMemoryAdapter } from '../services/PgvectorMemoryAdapter.js';
+import { NullVectorReembedder } from './NullVectorReembedder.js';
+
+const USER = '4f9b0f66-0000-4000-8000-00000000e001';
+const PERSONA = '4f9b0f66-0000-4000-8000-00000000e002';
+const PERSONALITY = '4f9b0f66-0000-4000-8000-00000000e003';
+const SYSTEM_PROMPT = '4f9b0f66-0000-4000-8000-00000000e004';
+
+describe('NullVectorReembedder (component, PGLite)', () => {
+  let pglite: PGlite;
+  let prisma: PrismaClient;
+  let embeddings: LocalEmbeddingService;
+  let adapter: PgvectorMemoryAdapter;
+  let sweeper: NullVectorReembedder;
+
+  beforeAll(async () => {
+    pglite = createTestPGlite();
+    await pglite.exec(loadPGliteSchema());
+    prisma = new PrismaClient({ adapter: new PrismaPGlite(pglite) }) as PrismaClient;
+
+    await seedUserWithPersona(prisma, {
+      userId: USER,
+      personaId: PERSONA,
+      discordId: '900000000000000077',
+      username: 'sweepuser',
+      personaName: 'Sweep Persona',
+      personaPreferredName: 'Sweepy',
+      personaContent: 'The self-healing persona',
+    });
+    await prisma.$executeRaw`
+      INSERT INTO system_prompts (id, name, content, updated_at)
+      VALUES (${SYSTEM_PROMPT}::uuid, 'Sweep Prompt', 'You are a sweep bot.', NOW())
+    `;
+    await prisma.$executeRaw`
+      INSERT INTO personalities (id, name, display_name, slug, system_prompt_id, character_info, personality_traits, owner_id, updated_at)
+      VALUES (${PERSONALITY}::uuid, 'SweepBot', 'Sweep Bot', 'sweepbot', ${SYSTEM_PROMPT}::uuid, 'Sweep character', 'Diligent', ${USER}::uuid, NOW())
+    `;
+
+    embeddings = new LocalEmbeddingService();
+    const ready = await embeddings.initialize();
+    if (!ready) {
+      throw new Error('Local embedding model failed to initialize');
+    }
+    adapter = new PgvectorMemoryAdapter(prisma, embeddings);
+    sweeper = new NullVectorReembedder(prisma, adapter);
+  }, 180_000);
+
+  afterAll(async () => {
+    await embeddings.shutdown();
+    await prisma.$disconnect();
+  });
+
+  beforeEach(async () => {
+    await prisma.$executeRaw`DELETE FROM memories`;
+  });
+
+  async function seedNullVectorMemory(text: string, visibility = 'normal'): Promise<string> {
+    const id = deterministicMemoryUuid(PERSONA, PERSONALITY, text);
+    await prisma.$executeRaw`
+      INSERT INTO memories (id, persona_id, personality_id, content, embedding, visibility, created_at, updated_at)
+      VALUES (${id}::uuid, ${PERSONA}::uuid, ${PERSONALITY}::uuid, ${text}, NULL, ${visibility}, NOW(), NOW())
+    `;
+    return id;
+  }
+
+  it('re-embeds a NULL-vector row and restores RAG visibility; skips soft-deleted; idempotent', async () => {
+    const orphanId = await seedNullVectorMemory(
+      'The user has a pet dragon named Ember that breathes purple fire'
+    );
+    const deletedId = await seedNullVectorMemory('A soft-deleted memory about sailing', 'deleted');
+
+    const stats = await sweeper.sweep();
+    expect(stats.scanned).toBe(1); // the soft-deleted row was never a candidate
+    expect(stats.reembedded).toBe(1);
+    expect(stats.failed).toBe(0);
+
+    // The healed row has a real vector; the soft-deleted row stays NULL.
+    const vectors = await prisma.$queryRaw<{ id: string; has_embedding: boolean }[]>`
+      SELECT id, (embedding IS NOT NULL) AS has_embedding FROM memories ORDER BY created_at
+    `;
+    expect(vectors.find(v => v.id === orphanId)?.has_embedding).toBe(true);
+    expect(vectors.find(v => v.id === deletedId)?.has_embedding).toBe(false);
+
+    // RAG-visible again: similarity search finds the healed memory.
+    const results = await adapter.queryMemories('pet dragon purple fire', {
+      personaId: PERSONA,
+      personalityId: PERSONALITY,
+      limit: 5,
+      scoreThreshold: 0.01,
+    });
+    expect(results.some(r => r.pageContent.includes('dragon named Ember'))).toBe(true);
+
+    // Idempotent: a second sweep finds nothing to do.
+    const second = await sweeper.sweep();
+    expect(second).toEqual({ scanned: 0, reembedded: 0, failed: 0 });
+  });
+});

--- a/services/ai-worker/src/jobs/NullVectorReembedder.test.ts
+++ b/services/ai-worker/src/jobs/NullVectorReembedder.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { PrismaClient } from '@tzurot/common-types/services/prisma';
+import type { PgvectorMemoryAdapter } from '../services/PgvectorMemoryAdapter.js';
+import { NullVectorReembedder } from './NullVectorReembedder.js';
+
+function makePrisma(rows: { id: string; content: string }[]): PrismaClient {
+  return { $queryRaw: vi.fn().mockResolvedValue(rows) } as unknown as PrismaClient;
+}
+
+function makeAdapter(
+  impl?: (id: string) => Promise<boolean>
+): PgvectorMemoryAdapter & { reembedMemory: ReturnType<typeof vi.fn> } {
+  return {
+    reembedMemory: vi.fn(impl ?? (() => Promise.resolve(true))),
+  } as unknown as PgvectorMemoryAdapter & { reembedMemory: ReturnType<typeof vi.fn> };
+}
+
+describe('NullVectorReembedder', () => {
+  it('re-embeds every NULL-vector row in the batch', async () => {
+    const rows = [
+      { id: 'mem-1', content: 'first orphaned memory' },
+      { id: 'mem-2', content: 'second orphaned memory' },
+    ];
+    const adapter = makeAdapter();
+    const sweeper = new NullVectorReembedder(makePrisma(rows), adapter);
+
+    const stats = await sweeper.sweep();
+
+    expect(stats).toEqual({ scanned: 2, reembedded: 2, failed: 0 });
+    // Seam: id + content cross to the adapter for each row.
+    expect(adapter.reembedMemory).toHaveBeenCalledWith('mem-1', 'first orphaned memory');
+    expect(adapter.reembedMemory).toHaveBeenCalledWith('mem-2', 'second orphaned memory');
+  });
+
+  it('is idempotent-by-shape: a concurrently-healed row (update returns false) is not a failure', async () => {
+    const adapter = makeAdapter(id => Promise.resolve(id !== 'mem-1'));
+    const sweeper = new NullVectorReembedder(
+      makePrisma([
+        { id: 'mem-1', content: 'healed concurrently' },
+        { id: 'mem-2', content: 'still orphaned' },
+      ]),
+      adapter
+    );
+
+    const stats = await sweeper.sweep();
+
+    expect(stats).toEqual({ scanned: 2, reembedded: 1, failed: 0 });
+  });
+
+  it('a failing row counts as failed and does not abort the batch', async () => {
+    const adapter = makeAdapter(id =>
+      id === 'mem-1' ? Promise.reject(new Error('embed down')) : Promise.resolve(true)
+    );
+    const sweeper = new NullVectorReembedder(
+      makePrisma([
+        { id: 'mem-1', content: 'a' },
+        { id: 'mem-2', content: 'b' },
+      ]),
+      adapter
+    );
+
+    const stats = await sweeper.sweep();
+
+    expect(stats).toEqual({ scanned: 2, reembedded: 1, failed: 1 });
+  });
+
+  it('no-ops cleanly with no rows or no memory manager', async () => {
+    const empty = new NullVectorReembedder(makePrisma([]), makeAdapter());
+    await expect(empty.sweep()).resolves.toEqual({ scanned: 0, reembedded: 0, failed: 0 });
+
+    const noManager = new NullVectorReembedder(makePrisma([{ id: 'x', content: 'y' }]));
+    await expect(noManager.sweep()).resolves.toEqual({ scanned: 0, reembedded: 0, failed: 0 });
+  });
+});

--- a/services/ai-worker/src/jobs/NullVectorReembedder.ts
+++ b/services/ai-worker/src/jobs/NullVectorReembedder.ts
@@ -1,0 +1,78 @@
+/**
+ * NULL-vector memory self-healing sweep (PendingMemoryProcessor sibling).
+ *
+ * A memory's embedding goes NULL when an edit lands during embedding-service
+ * downtime — correct at write time (invisible beats wrongly-matched), but
+ * nothing re-embedded it afterward: the memory silently stayed out of RAG
+ * until the user coincidentally edited it again. For a product whose core IS
+ * persona memory, that's the platform quietly forgetting while appearing to
+ * work.
+ *
+ * This sweep finds `embedding IS NULL AND visibility = 'normal'` rows and
+ * re-embeds them (bounded batch, oldest first). Idempotent: the adapter's
+ * UPDATE re-checks the NULL guard, so concurrent edits and repeat runs are
+ * safe. Runs on the scheduled-jobs queue; deliberately minimal so the
+ * memory-architecture Phase-5 consolidation work subsumes it cleanly.
+ */
+
+import { type PrismaClient } from '@tzurot/common-types/services/prisma';
+import { createLogger } from '@tzurot/common-types/utils/logger';
+import { type PgvectorMemoryAdapter } from '../services/PgvectorMemoryAdapter.js';
+
+const logger = createLogger('NullVectorReembedder');
+
+/** Bounded batch per run — a backlog heals over successive runs. */
+const SWEEP_BATCH_SIZE = 50;
+
+export interface SweepStats {
+  scanned: number;
+  reembedded: number;
+  failed: number;
+}
+
+export class NullVectorReembedder {
+  constructor(
+    private readonly prisma: PrismaClient,
+    private readonly memoryManager?: PgvectorMemoryAdapter
+  ) {}
+
+  /** One sweep pass. Never throws — a failed row logs and counts. */
+  async sweep(): Promise<SweepStats> {
+    if (this.memoryManager === undefined) {
+      return { scanned: 0, reembedded: 0, failed: 0 };
+    }
+
+    // Raw SQL: `embedding` is Unsupported("vector") in Prisma, so the typed
+    // client can't express `embedding IS NULL`.
+    const rows = await this.prisma.$queryRaw<{ id: string; content: string }[]>`
+      SELECT id, content FROM memories
+      WHERE embedding IS NULL AND visibility = 'normal'
+      ORDER BY created_at ASC
+      LIMIT ${SWEEP_BATCH_SIZE}
+    `;
+    if (rows.length === 0) {
+      return { scanned: 0, reembedded: 0, failed: 0 };
+    }
+
+    let reembedded = 0;
+    let failed = 0;
+    for (const row of rows) {
+      try {
+        const updated = await this.memoryManager.reembedMemory(row.id, row.content);
+        if (updated) {
+          reembedded += 1;
+        }
+        // !updated = the row healed or changed state concurrently — not a failure.
+      } catch (error) {
+        failed += 1;
+        logger.warn(
+          { err: error, memoryId: row.id },
+          'NULL-vector re-embed failed — row stays invisible until the next sweep'
+        );
+      }
+    }
+
+    logger.info({ scanned: rows.length, reembedded, failed }, 'NULL-vector sweep complete');
+    return { scanned: rows.length, reembedded, failed };
+  }
+}

--- a/services/ai-worker/src/services/PgvectorMemoryAdapter.ts
+++ b/services/ai-worker/src/services/PgvectorMemoryAdapter.ts
@@ -281,6 +281,29 @@ export class PgvectorMemoryAdapter {
     }
   }
 
+  /**
+   * Re-embed one memory in place — the NULL-vector self-healing path. Rows
+   * get a NULL embedding when an edit lands during embedding-service downtime
+   * (correct per the visibility invariant: invisible beats wrongly-matched);
+   * this restores them to RAG visibility. Guards with embedding IS NULL so a
+   * concurrent normal update can't be clobbered (idempotent by shape).
+   *
+   * @returns true when a row was updated, false when the row no longer
+   *   qualifies (already re-embedded, deleted, or made non-normal).
+   */
+  async reembedMemory(memoryId: string, text: string): Promise<boolean> {
+    const embedding = await this.generateEmbedding(text);
+    const updated = await this.prisma.$executeRaw`
+      UPDATE memories
+      SET embedding = ${`[${embedding.join(',')}]`}::vector(384),
+          updated_at = NOW()
+      WHERE id = ${memoryId}::uuid
+        AND embedding IS NULL
+        AND visibility = 'normal'
+    `;
+    return updated > 0;
+  }
+
   private async generateEmbedding(text: string): Promise<number[]> {
     if (!this.embeddingService.isServiceReady()) {
       throw new Error('Embedding service is not ready');


### PR DESCRIPTION
## Summary

**External review item 5** — promotion past its filed trigger confirmed by the owner. The trigger ("promote when a user reports a memory that exists but never surfaces") was structurally unobservable: a NULL-embedding memory is invisible in RAG, so the persona quietly knows less and no user can tell that's why.

## The mechanism

A memory's embedding goes NULL when an edit lands during embedding-service downtime — correct at write time (invisible beats wrongly-matched), but nothing ever re-embedded it. For a product whose core is persona memory, that's the platform quietly forgetting while appearing to work.

- **Hourly sweep** (`NullVectorReembedder`, scheduled-jobs queue, offset :13): finds `embedding IS NULL AND visibility='normal'` rows — bounded batch of 50, oldest first — and re-embeds via the adapter's new `reembedMemory`. Its UPDATE re-checks the NULL guard, so concurrent edits and repeat runs are idempotent by shape. Soft-deleted rows are never candidates (acceptance-pinned).
- **Rider — dead-letter visibility**: `PendingMemoryProcessor.getStats()` was logged once at startup then never again; permanently-exhausted rows (attempts ≥ cap / the 999 invalid-metadata sentinel) were invisible. Every scheduled run now returns a backlog snapshot in its completed log line — a durable ops surface in Railway logs.
- The seventh copy of the repeatable-job `add()` block pushed `setupScheduledJobs` past the 100-line cap; registrations are now a data-driven `REPEATABLE_JOB_SCHEDULE` table.

## Acceptance (from the brief)

Seeded NULL-vector row → sweep → re-embedded AND RAG-visible (real PGLite+pgvector similarity search finds it) ✅ · soft-deleted skipped ✅ · idempotent (second sweep no-ops) ✅ — all in one component test, plus a 4-case unit matrix (batch, concurrent-heal, per-row failure isolation, no-op guards).

Kept deliberately minimal so the memory-architecture Phase-5 consolidation subsumes it cleanly.

## Verification

Component tier 30/30 files (464 passed), full `pnpm test` 25/25, `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)