### PR TITLE
fix: trim provider error text before quoting in the error spoiler

### DIFF
--- a/packages/common-types/src/constants/error.test.ts
+++ b/packages/common-types/src/constants/error.test.ts
@@ -170,6 +170,21 @@ describe('isTransientError', () => {
 });
 
 describe('formatErrorSpoiler', () => {
+  it('omits a whitespace-only technical message entirely (no-detail form)', () => {
+    const result = formatErrorSpoiler(ApiErrorCategory.TIMEOUT, 'ref001', '   \n\n  ');
+    expect(result).toBe('||*(error: timeout; ref: ref001)*||');
+  });
+
+  it('trims trailing/leading whitespace from the technical message (provider errors end with newlines)', () => {
+    const result = formatErrorSpoiler(
+      ApiErrorCategory.RATE_LIMIT,
+      'mref12345',
+      '429 Provider returned error\n\nTroubleshooting URL: https://example.com/docs\n'
+    );
+    expect(result).not.toContain('\n"'); // the closing quote hugs the text
+    expect(result.endsWith('; ref: mref12345)*||')).toBe(true);
+  });
+
   it('should format category and reference ID in spoiler tags', () => {
     const result = formatErrorSpoiler(ApiErrorCategory.QUOTA_EXCEEDED, 'abc123');
     expect(result).toBe('||*(error: quota exceeded; ref: abc123)*||');

--- a/packages/common-types/src/constants/error.ts
+++ b/packages/common-types/src/constants/error.ts
@@ -460,10 +460,13 @@ export function formatErrorSpoiler(
   const categoryLabel = category.replace(/_/g, ' ');
   // technicalMessage frequently carries provider URLs (e.g., the LangChain
   // troubleshooting link); wrap them so the spoiler doesn't trigger
-  // Discord embeds.
+  // Discord embeds. Provider messages also often end with a trailing newline,
+  // which would put the closing quote on its own line in the rendered
+  // spoiler — trim before quoting.
+  const trimmedTech = technicalMessage?.trim();
   const techPart =
-    technicalMessage !== undefined && technicalMessage.length > 0
-      ? ` — "${wrapUrlsForNoEmbed(technicalMessage)}"`
+    trimmedTech !== undefined && trimmedTech.length > 0
+      ? ` — "${wrapUrlsForNoEmbed(trimmedTech)}"`
       : '';
   return `||*(error: ${categoryLabel}${techPart}; ref: ${referenceId})*||`;
 }


### PR DESCRIPTION
## Summary

Owner-reported cosmetic bug: provider error messages often end with a trailing newline (LangChain's rate-limit errors append a troubleshooting-URL block with one), so the error spoiler rendered its closing quote on its own line:

```
||*(error: rate limit — "429 Provider returned error

Troubleshooting URL: <https://...>
"; ref: mrardj7yqvc)*||
```

`formatErrorSpoiler` now trims the technical message before quoting. A whitespace-only message collapses to the no-detail form instead of quoting emptiness. Test pins that the closing quote hugs the text.

## Verification

common-types error tests 87/87, full `pnpm test` 25/25, `pnpm quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)