### PR TITLE
refactor: single-source the quota-fallback category union

### DIFF
--- a/packages/common-types/src/constants/discord.ts
+++ b/packages/common-types/src/constants/discord.ts
@@ -4,6 +4,8 @@
  * Discord API limits, colors, and text truncation limits.
  */
 
+import type { QuotaFallbackCategoryValue } from './error.js';
+
 /**
  * Text truncation and preview limits
  */
@@ -318,7 +320,7 @@ export interface ModelFooterOptions {
    */
   quotaFallback?: {
     fromModel: string;
-    category: 'quota_exceeded' | 'credit_exhaustion' | 'rate_limit';
+    category: QuotaFallbackCategoryValue;
   };
 }
 

--- a/packages/common-types/src/constants/error.ts
+++ b/packages/common-types/src/constants/error.ts
@@ -185,6 +185,24 @@ export enum ApiErrorCategory {
 }
 
 /**
+ * The failure categories the tier-aware quota fallback can retarget on — the
+ * wire values carried in `quotaFallback` result metadata (a subset of
+ * `ApiErrorCategory` values). Single source of truth: the Zod enum in
+ * `generation.ts` and every hand-typed `category` field derive from this
+ * tuple, so adding a retargetable category is a one-line change here.
+ * (ai-worker's `QuotaFallbackCategory` enum-member union stays separate for
+ * its `ApiErrorCategory` narrowing; enum members are assignable to these
+ * literals, so producers type-check against this without casts.)
+ */
+export const QUOTA_FALLBACK_CATEGORIES = [
+  'quota_exceeded',
+  'credit_exhaustion',
+  'rate_limit',
+] as const;
+
+export type QuotaFallbackCategoryValue = (typeof QUOTA_FALLBACK_CATEGORIES)[number];
+
+/**
  * User-friendly error messages for each category
  * These are shown to users when no personality-specific error message is configured
  */

--- a/packages/common-types/src/constants/index.ts
+++ b/packages/common-types/src/constants/index.ts
@@ -76,6 +76,8 @@ export {
   MAX_ERROR_MESSAGE_LENGTH,
   ApiErrorType,
   ApiErrorCategory,
+  QUOTA_FALLBACK_CATEGORIES,
+  type QuotaFallbackCategoryValue,
   USER_ERROR_MESSAGES,
   VISION_FAILURE_CACHE_POLICY,
   generateErrorReferenceId,

--- a/packages/common-types/src/types/schemas/generation.test.ts
+++ b/packages/common-types/src/types/schemas/generation.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { QUOTA_FALLBACK_CATEGORIES } from '../../constants/error.js';
 import { TTS_PROVIDER_IDS } from '../../services/tts/TtsProvider.js';
 import { CONFIG_SOURCE_IDS, llmGenerationResultSchema } from './generation.js';
 
@@ -32,6 +33,20 @@ describe('llmGenerationResultSchema.metadata', () => {
         },
       });
       expect(parsed.success).toBe(true);
+    });
+
+    it('accepts every retargetable category (positive acceptance across the enum)', () => {
+      // Iterate the source-of-truth tuple so a future category automatically
+      // gets a positive-acceptance case (no 5th hand-typed copy of the list).
+      for (const category of QUOTA_FALLBACK_CATEGORIES) {
+        const parsed = llmGenerationResultSchema.safeParse({
+          ...baseValid,
+          metadata: {
+            quotaFallback: { fromModel: 'a', toModel: 'b', category, mode: 'proactive' },
+          },
+        });
+        expect(parsed.success, `category '${category}' should parse`).toBe(true);
+      }
     });
 
     it('rejects unknown categories and modes (closed enums)', () => {

--- a/packages/common-types/src/types/schemas/generation.ts
+++ b/packages/common-types/src/types/schemas/generation.ts
@@ -5,7 +5,11 @@
  */
 
 import { z } from 'zod';
-import { ApiErrorType, ApiErrorCategory } from '../../constants/index.js';
+import {
+  ApiErrorType,
+  ApiErrorCategory,
+  QUOTA_FALLBACK_CATEGORIES,
+} from '../../constants/index.js';
 import { TTS_PROVIDER_IDS } from '../../services/tts/TtsProvider.js';
 import { loadedPersonalitySchema, requestContextSchema } from './personality.js';
 
@@ -164,7 +168,7 @@ const generationPayloadSchema = z.object({
         .object({
           fromModel: z.string(),
           toModel: z.string(),
-          category: z.enum(['quota_exceeded', 'credit_exhaustion', 'rate_limit']),
+          category: z.enum(QUOTA_FALLBACK_CATEGORIES),
           mode: z.enum(['proactive', 'reactive']),
         })
         .optional(),

--- a/services/bot-client/src/services/DiscordResponseSender.ts
+++ b/services/bot-client/src/services/DiscordResponseSender.ts
@@ -18,6 +18,7 @@ import {
   BOT_FOOTER_TEXT,
   buildModelFooterText,
 } from '@tzurot/common-types/constants/discord';
+import { type QuotaFallbackCategoryValue } from '@tzurot/common-types/constants/error';
 import { type TypingChannel } from '@tzurot/common-types/types/discord-types';
 import { type LoadedPersonality } from '@tzurot/common-types/types/schemas/personality';
 import { splitMessage } from '@tzurot/common-types/utils/discord';
@@ -82,7 +83,7 @@ interface SendResponseOptions {
    */
   quotaFallback?: {
     fromModel: string;
-    category: 'quota_exceeded' | 'credit_exhaustion' | 'rate_limit';
+    category: QuotaFallbackCategoryValue;
   };
   /** Whether response was generated in guest mode (free model, no API key) */
   isGuestMode?: boolean;

--- a/services/bot-client/src/utils/resultMetadataPassthrough.ts
+++ b/services/bot-client/src/utils/resultMetadataPassthrough.ts
@@ -5,6 +5,7 @@
  * others (error paths forward a narrower, hand-picked subset).
  */
 
+import { type QuotaFallbackCategoryValue } from '@tzurot/common-types/constants/error';
 import { type LLMGenerationResult } from '@tzurot/common-types/types/schemas/generation';
 
 export interface ResultMetadataPassthrough {
@@ -13,7 +14,7 @@ export interface ResultMetadataPassthrough {
   fallbackProviderAttempted?: string;
   quotaFallback?: {
     fromModel: string;
-    category: 'quota_exceeded' | 'credit_exhaustion' | 'rate_limit';
+    category: QuotaFallbackCategoryValue;
   };
   isGuestMode?: boolean;
   focusModeEnabled?: boolean;


### PR DESCRIPTION
## Summary

Filed follow-up from the rate-limit rescue work: the quota-fallback `category` string union was hand-duplicated in **four** places — the `generation.ts` Zod schema, `discord.ts`'s footer options type, and bot-client's `DiscordResponseSender` + `resultMetadataPassthrough`. Adding `RATE_LIMIT` required touching all four; the next category would too.

Now there's one `QUOTA_FALLBACK_CATEGORIES` tuple in `constants/error.ts` (next to `ApiErrorCategory`, its semantic parent — mirrors the file's existing `CONFIG_SOURCE_IDS` pattern), with a derived `QuotaFallbackCategoryValue` type. The Zod enum and every `category` field import it. Grep confirms zero hand-typed unions remain.

**Deliberately untouched**: ai-worker's `QuotaFallbackCategory` (an `ApiErrorCategory` enum-member union) — it exists for enum *narrowing* inside the classifier, and enum members are assignable to their string literals, so producers type-check against the shared tuple without casts. Two types, one authority, no drift risk (the Zod schema at the wire boundary rejects any divergence at runtime).

Also adds the positive-acceptance case `generation.test.ts`'s own docstring asks for: every retargetable category parses (previously only `credit_exhaustion`/`quota_exceeded` had positive coverage; `rate_limit` had none).

## Verification

`pnpm test` 25/25, `pnpm quality` green (sequential). Placement in `constants/error.ts` (not `generation.ts`) avoids a `constants/discord.ts → types/schemas/generation.ts → constants/index.ts` import cycle.

## Backlog

Resolves the "Single-source the quotaFallback category union" row in `backlog/cold/follow-ups.md` — removed on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)