### PR TITLE
fix: premigrate exempts destructive DDL on same-file-created tables

### DIFF
--- a/packages/tooling/src/release/premigrate.test.ts
+++ b/packages/tooling/src/release/premigrate.test.ts
@@ -92,6 +92,70 @@ describe('premigrate', () => {
     expect(runMigration).toHaveBeenCalledWith({ env: 'prod', force: true, dryRun: false });
   });
 
+  it('exempts destructive statements on tables CREATEd earlier in the same file', async () => {
+    // The vector-column false-positive class: CREATE TABLE + ALTER COLUMN TYPE
+    // on the brand-new table in one migration cannot break live code.
+    mockGitDiff([ADDITIVE_MIGRATION]);
+    vi.mocked(readFileSync).mockReturnValue(
+      'CREATE TABLE "memory_facts" ("id" UUID NOT NULL, "embedding" vector);\n' +
+        'ALTER TABLE "memory_facts" ALTER COLUMN "embedding" SET DATA TYPE vector(384);\n' +
+        'ALTER TABLE "public"."memory_facts" DROP COLUMN "scratch";'
+    );
+
+    await premigrate({ env: 'prod', force: true });
+
+    expect(runMigration).toHaveBeenCalledWith({ env: 'prod', force: true, dryRun: false });
+  });
+
+  it('still refuses DROP-then-reCREATE of the same table (order-aware exemption)', async () => {
+    // Recreating a table destroys prod data; the CREATE after the DROP must
+    // not retroactively bless it.
+    mockGitDiff([DESTRUCTIVE_MIGRATION]);
+    vi.mocked(readFileSync).mockReturnValue(
+      'DROP TABLE "memories";\nCREATE TABLE "memories" ("id" UUID NOT NULL);'
+    );
+
+    await expect(premigrate({ env: 'prod' })).rejects.toThrow('process.exit:1');
+    expect(runMigration).not.toHaveBeenCalled();
+  });
+
+  it('still refuses a comma-list DROP TABLE that includes a pre-existing table', async () => {
+    // `DROP TABLE new, existing;` — exempting on the first-listed (created)
+    // table alone would silently bless dropping the live one.
+    mockGitDiff([DESTRUCTIVE_MIGRATION]);
+    vi.mocked(readFileSync).mockReturnValue(
+      'CREATE TABLE "scratch_cache" ("id" UUID NOT NULL);\n' +
+        'DROP TABLE "scratch_cache", "user_settings";'
+    );
+
+    await expect(premigrate({ env: 'prod' })).rejects.toThrow('process.exit:1');
+    expect(runMigration).not.toHaveBeenCalled();
+  });
+
+  it('exempts a comma-list DROP TABLE when every listed table was created in the file', async () => {
+    mockGitDiff([ADDITIVE_MIGRATION]);
+    vi.mocked(readFileSync).mockReturnValue(
+      'CREATE TABLE "tmp_a" ("id" UUID NOT NULL);\n' +
+        'CREATE TABLE "tmp_b" ("id" UUID NOT NULL);\n' +
+        'DROP TABLE "tmp_a", "tmp_b";'
+    );
+
+    await premigrate({ env: 'prod', force: true });
+
+    expect(runMigration).toHaveBeenCalledWith({ env: 'prod', force: true, dryRun: false });
+  });
+
+  it('still refuses ALTER COLUMN TYPE on a table not created in the file', async () => {
+    mockGitDiff([DESTRUCTIVE_MIGRATION]);
+    vi.mocked(readFileSync).mockReturnValue(
+      'CREATE TABLE "other" ("id" UUID NOT NULL);\n' +
+        'ALTER TABLE "memories" ALTER COLUMN "content" SET DATA TYPE JSONB;'
+    );
+
+    await expect(premigrate({ env: 'prod' })).rejects.toThrow('process.exit:1');
+    expect(runMigration).not.toHaveBeenCalled();
+  });
+
   it('refuses when a release mixes additive and destructive migrations', async () => {
     mockGitDiff([ADDITIVE_MIGRATION, DESTRUCTIVE_MIGRATION]);
     // additive file → no destructive markers; destructive file → DROP COLUMN

--- a/packages/tooling/src/release/premigrate.ts
+++ b/packages/tooling/src/release/premigrate.ts
@@ -85,6 +85,71 @@ function newMigrationSqlFiles(): string[] {
     .filter(line => line.endsWith('.sql'));
 }
 
+/** A possibly-quoted, possibly-schema-qualified table reference in DDL. */
+const TABLE_REF = String.raw`(?:"[^"]+"|\w+)(?:\.(?:"[^"]+"|\w+))?`;
+
+const CREATE_TABLE_RE = new RegExp(
+  String.raw`\bCREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(${TABLE_REF})`,
+  'i'
+);
+
+// Captures the FULL comma-separated table list: `DROP TABLE a, b;` is one
+// statement targeting several tables (ALTER TABLE only ever targets one).
+const TARGET_TABLES_RE = new RegExp(
+  String.raw`\b(?:ALTER|DROP)\s+TABLE\s+(?:IF\s+EXISTS\s+)?(?:ONLY\s+)?(${TABLE_REF}(?:\s*,\s*${TABLE_REF})*)`,
+  'i'
+);
+
+/** Strip quotes + schema qualifier so `"public"."memory_facts"` ≡ `memory_facts`. */
+function normalizeTableRef(ref: string): string {
+  const parts = ref.split('.').map(p => p.replace(/"/g, '').toLowerCase());
+  return parts[parts.length - 1];
+}
+
+/**
+ * Every table the statement targets, or null when none is identifiable
+ * (no-target → the caller keeps the hit; over-warning is the safe direction).
+ */
+function statementTargetTables(statement: string): string[] | null {
+  const match = TARGET_TABLES_RE.exec(statement);
+  if (match === null) {
+    return null;
+  }
+  return match[1].split(',').map(ref => normalizeTableRef(ref.trim()));
+}
+
+/**
+ * Scan one migration file's SQL statement-by-statement for destructive shapes.
+ *
+ * A destructive statement targeting a table CREATEd **earlier in the same
+ * file** is exempt: prod doesn't have that table until this migration runs,
+ * so nothing live can break (e.g. CREATE TABLE + ALTER COLUMN TYPE on the new
+ * table in one file — a false positive that previously forced
+ * --allow-destructive). Order matters deliberately: DROP-then-reCREATE of the
+ * same name destroys prod data, and stays flagged because the CREATE comes
+ * after the DROP.
+ */
+function scanSqlForDestructive(sql: string): string[] {
+  const labels: string[] = [];
+  const createdEarlier = new Set<string>();
+  for (const statement of sql.split(';')) {
+    const created = CREATE_TABLE_RE.exec(statement);
+    for (const { label, re } of DESTRUCTIVE_PATTERNS) {
+      if (!re.test(statement)) continue;
+      // Exempt ONLY when every targeted table was created earlier in this
+      // file — `DROP TABLE new_one, live_one;` must keep its hit for the
+      // table that exists in prod.
+      const targets = statementTargetTables(statement);
+      if (targets?.every(t => createdEarlier.has(t)) === true) continue;
+      if (!labels.includes(label)) labels.push(label);
+    }
+    // Register AFTER scanning the statement itself, so a hypothetical
+    // single-statement create+destroy can't self-exempt.
+    if (created !== null) createdEarlier.add(normalizeTableRef(created[1]));
+  }
+  return labels;
+}
+
 /** Scan the given migration files for destructive SQL shapes. */
 function scanDestructive(repoRoot: string, files: string[]): { file: string; label: string }[] {
   const hits: { file: string; label: string }[] = [];
@@ -102,8 +167,8 @@ function scanDestructive(repoRoot: string, files: string[]): { file: string; lab
       );
       continue;
     }
-    for (const { label, re } of DESTRUCTIVE_PATTERNS) {
-      if (re.test(sql)) hits.push({ file, label });
+    for (const label of scanSqlForDestructive(sql)) {
+      hits.push({ file, label });
     }
   }
   return hits;


### PR DESCRIPTION
## Summary

Filed follow-up from the beta.152 release: the `memory_facts` migration's `ALTER COLUMN ... SET DATA TYPE vector(384)` — on a table CREATEd three statements earlier in the same file — tripped `release:premigrate`'s destructive gate, forcing `--allow-destructive` + a manual confirmation for a change that could not possibly break live code (prod doesn't have the table until the migration runs).

The destructive scan is now **per-statement** and exempts destructive statements whose target table was CREATEd **earlier in the same file**. Handles quoted and schema-qualified refs (`"public"."memory_facts"` ≡ `memory_facts`).

**Order-aware deliberately**: `DROP TABLE x; CREATE TABLE x;` (the recreate pattern) destroys prod data and **stays flagged** — a CREATE after the DROP can't retroactively bless it. The created-set is also registered after each statement is scanned, so a statement can't self-exempt.

Failure direction preserved: when target extraction can't identify a table (or the statement has no table target), the hit stands — over-warning remains the safe default.

## Tests

Three new cases: the vector-column false-positive repro (CREATE + ALTER TYPE + DROP COLUMN on the new table → additive), the DROP-then-reCREATE trap (still refuses), and ALTER TYPE on a pre-existing table with an unrelated same-file CREATE (still refuses). Full `pnpm test` 25/25, `pnpm quality` green.

## Backlog

Resolves the "release:premigrate destructive-shape detector: ignore ALTERs on same-migration-created tables" row in `backlog/cold/follow-ups.md` — removed on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)